### PR TITLE
feat: add redacted Factory session briefing

### DIFF
--- a/aragora/cli/commands/factory_sessions.py
+++ b/aragora/cli/commands/factory_sessions.py
@@ -1,0 +1,146 @@
+"""CLI handlers for ``aragora factory sessions brief``.
+
+The command surfaces Factory/Droid local session metadata as redacted operator
+briefs. It intentionally does not read raw Factory transcripts, prompts, logs,
+or history files.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+DEFAULT_SINCE = "4h"
+DEFAULT_LIMIT = 50
+
+
+def _parse_since(value: str):
+    from aragora.codex.duration import parse_duration
+
+    return parse_duration(value)
+
+
+def _print_json(payload: Any) -> None:
+    json.dump(payload, sys.stdout, indent=2, sort_keys=True, default=str)
+    sys.stdout.write("\n")
+
+
+def _format_table(rows: list[dict[str, Any]], columns: list[tuple[str, str]]) -> str:
+    if not rows:
+        return "(no rows)"
+    widths = {key: len(label) for key, label in columns}
+    for row in rows:
+        for key, _ in columns:
+            widths[key] = max(widths[key], len(str(row.get(key, ""))))
+    header = "  ".join(label.ljust(widths[key]) for key, label in columns)
+    separator = "  ".join("-" * widths[key] for key, _ in columns)
+    body = "\n".join(
+        "  ".join(str(row.get(key, "")).ljust(widths[key]) for key, _ in columns) for row in rows
+    )
+    return f"{header}\n{separator}\n{body}"
+
+
+def _compact_brief(row: dict[str, Any]) -> dict[str, Any]:
+    raw_router = row.get("router")
+    router: dict[str, Any] = raw_router if isinstance(raw_router, dict) else {}
+    return {
+        "provider": row.get("provider"),
+        "session_id": row.get("session_id"),
+        "age": row.get("age"),
+        "branch": row.get("branch"),
+        "pr_number": row.get("pr_number"),
+        "route": router.get("category"),
+        "conflict_risk": row.get("conflict_risk"),
+        "prompt_needed": row.get("prompt_needed"),
+        "prompt_needed_reason": row.get("prompt_needed_reason"),
+        "direct_steering_available": row.get("direct_steering_available"),
+        "recommended_next_prompt": router.get("recommended_next_prompt"),
+    }
+
+
+def _format_brief_table(briefs: list[dict[str, Any]]) -> str:
+    rows = []
+    for brief in briefs:
+        raw_router = brief.get("router")
+        router: dict[str, Any] = raw_router if isinstance(raw_router, dict) else {}
+        raw_lane = brief.get("matched_lane")
+        lane: dict[str, Any] = raw_lane if isinstance(raw_lane, dict) else {}
+        rows.append(
+            {
+                "id": str(brief.get("session_id") or "")[:18],
+                "age": brief.get("age") or "",
+                "route": router.get("category") or "",
+                "pr": f"#{brief['pr_number']}" if brief.get("pr_number") else "",
+                "branch": str(brief.get("branch") or "")[:28],
+                "lane": str(lane.get("lane_id") or "")[:24],
+                "conflict": brief.get("conflict_risk") or "",
+            }
+        )
+    return _format_table(
+        rows,
+        columns=[
+            ("id", "ID"),
+            ("age", "AGE"),
+            ("route", "ROUTE"),
+            ("pr", "PR"),
+            ("branch", "BRANCH"),
+            ("lane", "LANE"),
+            ("conflict", "CONFLICT"),
+        ],
+    )
+
+
+def cmd_factory_sessions_brief(args: argparse.Namespace) -> int:
+    from aragora.factory.session_inspector import build_factory_session_briefs, redact_display
+
+    if args.limit < 0:
+        print("error: --limit must be >= 0", file=sys.stderr)
+        return 2
+    try:
+        since = _parse_since(args.since)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    repo_root = getattr(args, "repo_root", None)
+    if repo_root == "":
+        repo_root = None
+    factory_home = getattr(args, "factory_home", None)
+    briefs = [
+        brief.to_dict()
+        for brief in build_factory_session_briefs(
+            factory_home=factory_home,
+            repo_root=repo_root,
+            since=since,
+            limit=args.limit,
+            session=getattr(args, "session", None),
+        )
+    ]
+    compact = bool(getattr(args, "compact", False))
+    output_briefs = [_compact_brief(row) for row in briefs] if compact else briefs
+    payload = {
+        "schema": "aragora-factory-sessions-brief/1.0",
+        "generated_at": datetime.now(UTC).isoformat(),
+        "factory_home": redact_display(Path(factory_home).expanduser())
+        if factory_home
+        else redact_display(Path("~/.factory").expanduser()),
+        "repo_root": redact_display(Path(repo_root).expanduser()) if repo_root else None,
+        "since": args.since,
+        "since_seconds": int(since.total_seconds()),
+        "limit": int(args.limit),
+        "session": redact_display(getattr(args, "session", None)),
+        "compact": compact,
+        "count": len(output_briefs),
+        "briefs": output_briefs,
+    }
+    if args.json:
+        _print_json(payload)
+        return 0
+
+    print(_format_brief_table(output_briefs))
+    print(f"\n{len(output_briefs)} Factory/Droid brief(s) updated since {since}.")
+    return 0

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -199,6 +199,7 @@ Examples:
     _add_signing_parser(subparsers)
     _add_inbox_wedge_parser(subparsers)
     _add_codex_parser(subparsers)
+    _add_factory_parser(subparsers)
     _add_triage_parser(subparsers)
     _add_ralph_parser(subparsers)
     _add_assess_parser(subparsers)
@@ -3422,6 +3423,80 @@ def _add_codex_parser(subparsers) -> None:
     )
     digest_cmd.set_defaults(
         func=_lazy("aragora.cli.commands.codex_insights", "cmd_codex_insights_digest")
+    )
+
+
+def _add_factory_parser(subparsers) -> None:
+    """Add the 'factory' read-only inspector commands for Factory/Droid metadata."""
+
+    def parent_help(p: argparse.ArgumentParser):
+        def _cmd_parent_help(_args):
+            p.print_help()
+            return 2
+
+        return _cmd_parent_help
+
+    factory = subparsers.add_parser(
+        "factory",
+        help="Read-only inspector for Factory/Droid local session metadata",
+        description=(
+            "Surface Factory/Droid sessions from ~/.factory/ as redacted, read-only "
+            "metadata. Raw transcripts, prompts, logs, and history are not read."
+        ),
+    )
+    factory.set_defaults(func=parent_help(factory))
+    factory_sub = factory.add_subparsers(dest="factory_cmd")
+
+    sessions = factory_sub.add_parser(
+        "sessions",
+        help="Inspect Factory/Droid session metadata",
+        description="Brief Factory/Droid sessions from local metadata (read-only).",
+    )
+    sessions.set_defaults(func=parent_help(sessions))
+    sessions_sub = sessions.add_subparsers(dest="factory_sessions_cmd")
+
+    brief_cmd = sessions_sub.add_parser(
+        "brief",
+        help="Brief recent Factory/Droid sessions and route conservative next prompts",
+        description=(
+            "Build redacted Factory/Droid session briefings from local metadata. "
+            "Raw transcript text, prompt logs, history, and session logs are not emitted."
+        ),
+    )
+    brief_cmd.add_argument(
+        "--factory-home",
+        default=None,
+        help="Factory home directory (default: ~/.factory).",
+    )
+    brief_cmd.add_argument(
+        "--since",
+        default="4h",
+        help="Time window (e.g. 30m, 4h, 1d, 90s). Default: 4h.",
+    )
+    brief_cmd.add_argument(
+        "--limit",
+        type=int,
+        default=50,
+        help="Maximum number of sessions to brief (default: 50, 0 = no limit).",
+    )
+    brief_cmd.add_argument(
+        "--session",
+        default=None,
+        help="Restrict to one Factory/Droid session id or id prefix.",
+    )
+    brief_cmd.add_argument(
+        "--compact",
+        action="store_true",
+        help="Emit compact prompt-router rows instead of full briefing objects.",
+    )
+    brief_cmd.add_argument(
+        "--repo-root",
+        default=".",
+        help="Repo root used for queue/lane context (default: current directory; '' disables).",
+    )
+    brief_cmd.add_argument("--json", action="store_true", help="Emit JSON output.")
+    brief_cmd.set_defaults(
+        func=_lazy("aragora.cli.commands.factory_sessions", "cmd_factory_sessions_brief")
     )
 
 

--- a/aragora/factory/__init__.py
+++ b/aragora/factory/__init__.py
@@ -1,0 +1,5 @@
+"""Read-only Factory/Droid local metadata helpers."""
+
+from __future__ import annotations
+
+__all__ = ["session_inspector"]

--- a/aragora/factory/session_inspector.py
+++ b/aragora/factory/session_inspector.py
@@ -1,0 +1,591 @@
+"""Read-only, redacted Factory/Droid session metadata inspector.
+
+The inspector intentionally uses only metadata files: ``sessions-index.json``,
+tmux ``*.meta.json`` records, lane registry rows, and git metadata for existing
+worktrees. It does not read Factory history, raw transcript files, prompt logs,
+or agent logs by default.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shlex
+import subprocess
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from aragora.debate.security_barrier import SecurityBarrier
+
+_EXTRA_REDACTION_PATTERNS = (
+    r"gh[pousr]_[A-Za-z0-9_]{20,}",
+    r"github_pat_[A-Za-z0-9_]{22,}",
+    r"AKIA[0-9A-Z]{16}",
+    r"sk-or-v1-[A-Za-z0-9]+",
+)
+
+_PR_RE = re.compile(r"(?:\bPR\s*)?#(\d{2,7})\b", re.IGNORECASE)
+_BRANCH_RE = re.compile(
+    r"\b(?:origin/main|main|(?:codex|droid|claude|vision-incubator|worktree|feat|fix|"
+    r"chore|docs|review)/[A-Za-z0-9._/-]+)\b"
+)
+_ACTIVE_STATUSES = {"active", "running", "pending", "queued", "claimed", "conflict"}
+
+DEFAULT_FACTORY_HOME = Path("~/.factory")
+DEFAULT_LIMIT = 50
+
+
+@dataclass(frozen=True, slots=True)
+class PromptRoute:
+    category: str
+    reason: str
+    recommended_next_prompt: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "category": self.category,
+            "reason": self.reason,
+            "recommended_next_prompt": self.recommended_next_prompt,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class FactorySessionBrief:
+    provider: str
+    session_id: str
+    cwd: str | None
+    worktree: str | None
+    branch: str | None
+    head: str | None
+    updated_at: datetime | None
+    age_seconds: int | None
+    age: str | None
+    pr_number: int | None
+    matched_lane: dict[str, Any] | None
+    conflict_risk: str
+    prompt_needed: bool | str
+    prompt_needed_reason: str
+    router: PromptRoute
+    source_types: tuple[str, ...]
+    direct_steering_available: bool
+    steering_command: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "provider": self.provider,
+            "session_id": self.session_id,
+            "cwd": self.cwd,
+            "worktree": self.worktree,
+            "branch": self.branch,
+            "head": self.head,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+            "age_seconds": self.age_seconds,
+            "age": self.age,
+            "pr_number": self.pr_number,
+            "matched_lane": self.matched_lane,
+            "conflict_risk": self.conflict_risk,
+            "prompt_needed": self.prompt_needed,
+            "prompt_needed_reason": self.prompt_needed_reason,
+            "router": self.router.to_dict(),
+            "source_types": list(self.source_types),
+            "direct_steering_available": self.direct_steering_available,
+            "steering_command": self.steering_command,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class _FactorySessionRecord:
+    session_id: str
+    cwd: str | None
+    branch: str | None
+    head: str | None
+    pr_number: int | None
+    updated_at: datetime | None
+    search_text: str
+    source_types: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _TmuxTarget:
+    name: str
+    cwd: str | None
+
+
+def _build_barrier() -> SecurityBarrier:
+    barrier = SecurityBarrier()
+    for pattern in _EXTRA_REDACTION_PATTERNS:
+        barrier.add_pattern(pattern)
+    return barrier
+
+
+def redact_display(value: str | Path | None) -> str | None:
+    if value is None:
+        return None
+    return _build_barrier().redact(str(value))
+
+
+def _redact_lane(record: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: value
+        for key, value in {
+            "lane_id": redact_display(record.get("lane_id")),
+            "owner_session": redact_display(record.get("owner_session")),
+            "status": redact_display(record.get("status")),
+            "pr_number": record.get("pr_number"),
+            "branch": redact_display(record.get("branch")),
+            "worktree": redact_display(record.get("worktree")),
+            "updated_at": redact_display(record.get("updated_at")),
+        }.items()
+        if value not in (None, "")
+    }
+
+
+def _to_datetime(value: Any) -> datetime | None:
+    if value in (None, ""):
+        return None
+    if isinstance(value, (int, float)):
+        number = float(value)
+        if number > 32503680000:
+            number = number / 1000.0
+        return datetime.fromtimestamp(number, tz=UTC)
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        if text.isdigit():
+            return _to_datetime(int(text))
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=UTC)
+        return parsed.astimezone(UTC)
+    except ValueError:
+        return None
+
+
+def humanize_ago(value: datetime | None, *, now: datetime | None = None) -> str | None:
+    if value is None:
+        return None
+    now = now or datetime.now(UTC)
+    seconds = max(0, int((now - value).total_seconds()))
+    if seconds < 60:
+        return f"{seconds}s ago"
+    minutes = seconds // 60
+    if minutes < 60:
+        return f"{minutes}m ago"
+    hours = minutes // 60
+    if hours < 48:
+        return f"{hours}h ago"
+    days = hours // 24
+    return f"{days}d ago"
+
+
+def _extract_pr_number(*values: Any) -> int | None:
+    for value in values:
+        if value in (None, ""):
+            continue
+        if isinstance(value, int):
+            return value
+        if isinstance(value, str) and value.isdigit():
+            return int(value)
+        matches = _PR_RE.findall(str(value))
+        if matches:
+            return int(matches[0])
+    return None
+
+
+def _extract_branch(*values: Any) -> str | None:
+    for value in values:
+        if not isinstance(value, str):
+            continue
+        matches = _BRANCH_RE.findall(value)
+        if matches:
+            return redact_display(matches[0])
+    return None
+
+
+def _load_json_file(path: Path) -> Any | None:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+def _index_entries(factory_home: Path) -> list[dict[str, Any]]:
+    payload = _load_json_file(factory_home / "sessions-index.json")
+    if isinstance(payload, dict):
+        entries = payload.get("entries") or payload.get("sessions") or []
+    elif isinstance(payload, list):
+        entries = payload
+    else:
+        entries = []
+    return [entry for entry in entries if isinstance(entry, dict)]
+
+
+def _git_metadata(cwd: str | None) -> tuple[str | None, str | None]:
+    if not cwd:
+        return None, None
+    path = Path(cwd).expanduser()
+    if not path.exists() or not path.is_dir():
+        return None, None
+    try:
+        branch_result = subprocess.run(
+            ["git", "branch", "--show-current"],
+            cwd=str(path),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        head_result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(path),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None, None
+    branch = branch_result.stdout.strip() if branch_result.returncode == 0 else None
+    head = head_result.stdout.strip() if head_result.returncode == 0 else None
+    if head and not re.fullmatch(r"[0-9a-f]{40}", head):
+        head = None
+    return redact_display(branch), head
+
+
+def _enrich_selected_records_with_git(
+    records: Sequence[_FactorySessionRecord],
+) -> list[_FactorySessionRecord]:
+    enriched: list[_FactorySessionRecord] = []
+    for record in records:
+        if (record.branch and record.head) or not record.cwd:
+            enriched.append(record)
+            continue
+        git_branch, git_head = _git_metadata(record.cwd)
+        enriched.append(
+            replace(
+                record,
+                branch=record.branch or git_branch,
+                head=record.head or git_head,
+            )
+        )
+    return enriched
+
+
+def _session_records(factory_home: Path, *, limit: int) -> list[_FactorySessionRecord]:
+    records: list[_FactorySessionRecord] = []
+    for entry in _index_entries(factory_home):
+        session_id = str(
+            entry.get("sessionId")
+            or entry.get("session_id")
+            or entry.get("id")
+            or entry.get("name")
+            or ""
+        ).strip()
+        if not session_id:
+            continue
+        cwd_raw = entry.get("cwd") or entry.get("worktree")
+        cwd = str(cwd_raw) if cwd_raw else None
+        title = str(entry.get("title") or "")
+        raw_tags = entry.get("tags")
+        tags: list[Any] = raw_tags if isinstance(raw_tags, list) else []
+        search_text = " ".join(
+            str(value)
+            for value in (
+                session_id,
+                cwd or "",
+                title,
+                entry.get("branch") or "",
+                " ".join(str(tag) for tag in tags),
+            )
+            if value
+        )
+        branch = redact_display(entry.get("branch")) or _extract_branch(search_text)
+        pr_number = _extract_pr_number(
+            entry.get("pr_number"),
+            entry.get("prNumber"),
+            entry.get("pr"),
+            search_text,
+        )
+        head_value = entry.get("head") or entry.get("sha") or entry.get("git_sha")
+        head = str(head_value) if isinstance(head_value, str) else None
+        if head and not re.fullmatch(r"[0-9a-f]{40}", head):
+            head = None
+        updated_at = _to_datetime(
+            entry.get("mtime") or entry.get("updated_at") or entry.get("updatedAt")
+        )
+        records.append(
+            _FactorySessionRecord(
+                session_id=redact_display(session_id) or session_id,
+                cwd=redact_display(cwd),
+                branch=branch,
+                head=head,
+                pr_number=pr_number,
+                updated_at=updated_at,
+                search_text=search_text,
+                source_types=("factory_sessions_index",),
+            )
+        )
+    records.sort(
+        key=lambda record: record.updated_at or datetime.fromtimestamp(0, tz=UTC), reverse=True
+    )
+    selected = records[:limit] if limit > 0 else records
+    return _enrich_selected_records_with_git(selected)
+
+
+def _active_lane_records(repo_root: Path | None) -> list[dict[str, Any]]:
+    if repo_root is None:
+        return []
+    registry = repo_root / ".aragora" / "agent-bridge" / "lanes.json"
+    payload = _load_json_file(registry)
+    if isinstance(payload, dict):
+        rows = payload.get("lanes") or payload.get("records") or []
+    elif isinstance(payload, list):
+        rows = payload
+    else:
+        rows = []
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        status = str(row.get("status") or "").lower()
+        if status not in _ACTIVE_STATUSES:
+            continue
+        out.append(row)
+    return out
+
+
+def _tmux_targets(repo_root: Path | None) -> list[_TmuxTarget]:
+    if repo_root is None:
+        return []
+    tmux_dir = repo_root / ".aragora" / "tmux-sessions"
+    if not tmux_dir.exists():
+        tmux_dir = Path("~/.aragora/tmux-sessions").expanduser()
+    targets: list[_TmuxTarget] = []
+    for meta_path in sorted(tmux_dir.glob("*.meta.json")):
+        payload = _load_json_file(meta_path)
+        if not isinstance(payload, dict):
+            continue
+        agent = str(payload.get("agent") or "").lower()
+        if agent not in {"droid", "factory"}:
+            continue
+        name = str(payload.get("name") or "").strip()
+        if not name:
+            continue
+        cwd = str(payload.get("worktree") or payload.get("cwd") or "") or None
+        targets.append(_TmuxTarget(name=name, cwd=redact_display(cwd)))
+    return targets
+
+
+def _same_owner(record: _FactorySessionRecord, lane: dict[str, Any]) -> bool:
+    owner = str(lane.get("owner_session") or "")
+    return bool(owner and (owner == record.session_id or owner.startswith(record.session_id)))
+
+
+def _lane_matches(record: _FactorySessionRecord, lane: dict[str, Any]) -> bool:
+    if _same_owner(record, lane):
+        return True
+    if record.pr_number is not None and lane.get("pr_number") == record.pr_number:
+        return True
+    if record.branch and lane.get("branch") == record.branch:
+        return True
+    if record.cwd and lane.get("worktree") == record.cwd:
+        return True
+    return False
+
+
+def _matched_lane(
+    record: _FactorySessionRecord, lanes: Sequence[dict[str, Any]]
+) -> dict[str, Any] | None:
+    owner_match = next((lane for lane in lanes if _same_owner(record, lane)), None)
+    if owner_match is not None:
+        return owner_match
+    return next((lane for lane in lanes if _lane_matches(record, lane)), None)
+
+
+def _tmux_target(
+    record: _FactorySessionRecord,
+    targets: Sequence[_TmuxTarget],
+    lane: dict[str, Any] | None,
+) -> _TmuxTarget | None:
+    lane_owner = str(lane.get("owner_session") or "") if lane else ""
+    for target in targets:
+        if target.name == record.session_id:
+            return target
+        if lane_owner and target.name == lane_owner:
+            return target
+    return None
+
+
+def _steering_prompt(record: _FactorySessionRecord, lane: dict[str, Any] | None) -> str:
+    if lane and not _same_owner(record, lane):
+        owner = redact_display(lane.get("owner_session")) or "the active owner"
+        lane_id = redact_display(lane.get("lane_id")) or "the active lane"
+        return (
+            f"Do not edit, push, comment, mark-ready, merge, or label. "
+            f"Another active owner appears to own this work: {owner} / {lane_id}. "
+            "Report your local head and stop unless the operator explicitly reassigns ownership."
+        )
+    if lane:
+        return (
+            "Continue only if your local worktree/head still matches this active lane. "
+            "Re-check live PR truth and report a bounded next action."
+        )
+    return (
+        "Factory/Droid session is visible only through redacted metadata. "
+        "Paste the relevant Factory excerpt for exact conversational advice, or assign a bounded lane."
+    )
+
+
+def _route(record: _FactorySessionRecord, lane: dict[str, Any] | None) -> PromptRoute:
+    if lane and not _same_owner(record, lane):
+        return PromptRoute(
+            category="pause",
+            reason="another active lane owns the same PR, branch, or worktree",
+            recommended_next_prompt=_steering_prompt(record, lane),
+        )
+    if lane:
+        return PromptRoute(
+            category="watch",
+            reason="session appears to own an active lane",
+            recommended_next_prompt=_steering_prompt(record, lane),
+        )
+    if record.pr_number is not None:
+        return PromptRoute(
+            category="review",
+            reason="session metadata mentions a PR but no active lane owns it",
+            recommended_next_prompt=(
+                f"Start from live repo truth. Duplicate-owner detection first. "
+                f"Review or watch PR #{record.pr_number} only; do not mutate unless you claim a lane."
+            ),
+        )
+    return PromptRoute(
+        category="paste-needed",
+        reason="metadata is insufficient to infer the latest conversational state",
+        recommended_next_prompt=_steering_prompt(record, None),
+    )
+
+
+def _brief_from_record(
+    record: _FactorySessionRecord,
+    *,
+    lanes: Sequence[dict[str, Any]],
+    targets: Sequence[_TmuxTarget],
+    now: datetime,
+) -> FactorySessionBrief:
+    lane = _matched_lane(record, lanes)
+    route = _route(record, lane)
+    same_owner = bool(lane and _same_owner(record, lane))
+    conflict_risk = "active-owner-overlap" if lane and not same_owner else "none"
+    target = _tmux_target(record, targets, lane)
+    direct_steering_available = target is not None
+    steering_command = None
+    if target is not None:
+        steering_command = (
+            "python3 scripts/agent_bridge.py send "
+            f"{shlex.quote(target.name)} {shlex.quote(route.recommended_next_prompt)}"
+        )
+    age_seconds = (
+        max(0, int((now - record.updated_at).total_seconds())) if record.updated_at else None
+    )
+    return FactorySessionBrief(
+        provider="factory",
+        session_id=record.session_id,
+        cwd=record.cwd,
+        worktree=record.cwd,
+        branch=record.branch,
+        head=record.head,
+        updated_at=record.updated_at,
+        age_seconds=age_seconds,
+        age=humanize_ago(record.updated_at, now=now),
+        pr_number=record.pr_number or (lane.get("pr_number") if lane else None),
+        matched_lane=_redact_lane(lane) if lane else None,
+        conflict_risk=conflict_risk,
+        prompt_needed=False if same_owner else True,
+        prompt_needed_reason="active_lane_owned" if same_owner else route.reason,
+        router=route,
+        source_types=tuple(
+            dict.fromkeys((*record.source_types, *(("agent_bridge_lanes",) if lanes else ())))
+        ),
+        direct_steering_available=direct_steering_available,
+        steering_command=steering_command,
+    )
+
+
+def paste_needed_brief(session_id: str) -> FactorySessionBrief:
+    route = PromptRoute(
+        category="paste-needed",
+        reason="session id/prefix is not visible in Factory local metadata",
+        recommended_next_prompt=(
+            "Paste the relevant Factory excerpt, or provide a Factory session id/worktree "
+            "that appears in sessions-index.json."
+        ),
+    )
+    return FactorySessionBrief(
+        provider="factory",
+        session_id=redact_display(session_id) or session_id,
+        cwd=None,
+        worktree=None,
+        branch=None,
+        head=None,
+        updated_at=None,
+        age_seconds=None,
+        age=None,
+        pr_number=None,
+        matched_lane=None,
+        conflict_risk="unknown",
+        prompt_needed="unknown",
+        prompt_needed_reason="raw_signal_insufficient",
+        router=route,
+        source_types=(),
+        direct_steering_available=False,
+        steering_command=None,
+    )
+
+
+def _filter_since(
+    records: Iterable[_FactorySessionRecord], since: timedelta
+) -> list[_FactorySessionRecord]:
+    cutoff = datetime.now(UTC) - since
+    return [
+        record for record in records if record.updated_at is None or record.updated_at >= cutoff
+    ]
+
+
+def _filter_session(
+    records: Sequence[_FactorySessionRecord], session: str | None
+) -> list[_FactorySessionRecord]:
+    if not session:
+        return list(records)
+    return [
+        record
+        for record in records
+        if record.session_id == session or record.session_id.startswith(session)
+    ]
+
+
+def build_factory_session_briefs(
+    *,
+    factory_home: str | Path | None = None,
+    repo_root: str | Path | None = None,
+    since: timedelta = timedelta(hours=4),
+    limit: int = DEFAULT_LIMIT,
+    session: str | None = None,
+) -> list[FactorySessionBrief]:
+    home = (
+        Path(factory_home).expanduser()
+        if factory_home is not None
+        else DEFAULT_FACTORY_HOME.expanduser()
+    )
+    repo = Path(repo_root).expanduser() if repo_root is not None else None
+    records = _filter_since(_session_records(home, limit=limit), since)
+    records = _filter_session(records, session)
+    if session and not records:
+        return [paste_needed_brief(session)]
+    lanes = _active_lane_records(repo)
+    targets = _tmux_targets(repo)
+    now = datetime.now(UTC)
+    return [_brief_from_record(record, lanes=lanes, targets=targets, now=now) for record in records]

--- a/aragora/factory/session_inspector.py
+++ b/aragora/factory/session_inspector.py
@@ -32,6 +32,7 @@ _BRANCH_RE = re.compile(
     r"\b(?:origin/main|main|(?:codex|droid|claude|vision-incubator|worktree|feat|fix|"
     r"chore|docs|review)/[A-Za-z0-9._/-]+)\b"
 )
+_SAFE_TMUX_TARGET_RE = re.compile(r"^[A-Za-z0-9_.:@-]{1,128}$")
 _ACTIVE_STATUSES = {"active", "running", "pending", "queued", "claimed", "conflict"}
 
 DEFAULT_FACTORY_HOME = Path("~/.factory")
@@ -125,6 +126,18 @@ def redact_display(value: str | Path | None) -> str | None:
     if value is None:
         return None
     return _build_barrier().redact(str(value))
+
+
+def _safe_tmux_target_name(value: str | None) -> str | None:
+    name = str(value or "").strip()
+    if not name:
+        return None
+    redacted = redact_display(name)
+    if not redacted or redacted != name:
+        return None
+    if not _SAFE_TMUX_TARGET_RE.fullmatch(name):
+        return None
+    return name
 
 
 def _redact_lane(record: dict[str, Any]) -> dict[str, Any]:
@@ -372,7 +385,7 @@ def _tmux_targets(repo_root: Path | None) -> list[_TmuxTarget]:
         agent = str(payload.get("agent") or "").lower()
         if agent not in {"droid", "factory"}:
             continue
-        name = str(payload.get("name") or "").strip()
+        name = _safe_tmux_target_name(str(payload.get("name") or ""))
         if not name:
             continue
         cwd = str(payload.get("worktree") or payload.get("cwd") or "") or None

--- a/aragora/module_tiers.yaml
+++ b/aragora/module_tiers.yaml
@@ -26,9 +26,9 @@ thresholds:
 summary:
   core: 21
   integrated: 89
-  experimental: 27
+  experimental: 28
   deprecated: 2
-  total: 139
+  total: 140
 
 modules:
   # --- core (21) ---
@@ -45,15 +45,15 @@ modules:
     test_file_count: 118
   - name: cli
     tier: core
-    py_files: 104
+    py_files: 107
     importer_count: 6
-    test_file_count: 119
+    test_file_count: 122
     override_reason: "aragora CLI — primary developer surface"
   - name: config
     tier: core
     py_files: 15
     importer_count: 329
-    test_file_count: 78
+    test_file_count: 79
     override_reason: "Pydantic settings + allowlist — load bearing"
   - name: connectors
     tier: core
@@ -75,7 +75,7 @@ modules:
   - name: debate
     tier: core
     py_files: 263
-    importer_count: 161
+    importer_count: 162
     test_file_count: 596
     override_reason: "Arena + DebateProtocol + consensus — mainline flow"
   - name: events
@@ -128,8 +128,8 @@ modules:
   - name: reasoning
     tier: core
     py_files: 19
-    importer_count: 120
-    test_file_count: 108
+    importer_count: 121
+    test_file_count: 109
   - name: resilience
     tier: core
     py_files: 13
@@ -257,8 +257,8 @@ modules:
   - name: epistemic
     tier: integrated
     py_files: 21
-    importer_count: 4
-    test_file_count: 21
+    importer_count: 6
+    test_file_count: 22
   - name: essay
     tier: integrated
     py_files: 6
@@ -387,9 +387,9 @@ modules:
     test_file_count: 35
   - name: metrics
     tier: integrated
-    py_files: 6
+    py_files: 7
     importer_count: 1
-    test_file_count: 8
+    test_file_count: 9
   - name: migrations
     tier: integrated
     py_files: 21
@@ -468,8 +468,8 @@ modules:
   - name: reputation
     tier: integrated
     py_files: 11
-    importer_count: 2
-    test_file_count: 14
+    importer_count: 3
+    test_file_count: 15
   - name: review
     tier: integrated
     py_files: 14
@@ -503,7 +503,7 @@ modules:
   - name: security
     tier: integrated
     py_files: 23
-    importer_count: 61
+    importer_count: 62
     test_file_count: 40
   - name: services
     tier: integrated
@@ -534,7 +534,7 @@ modules:
     tier: integrated
     py_files: 102
     importer_count: 32
-    test_file_count: 160
+    test_file_count: 161
   - name: templates
     tier: integrated
     py_files: 1
@@ -552,9 +552,9 @@ modules:
     test_file_count: 12
   - name: triage
     tier: integrated
-    py_files: 5
+    py_files: 8
     importer_count: 5
-    test_file_count: 8
+    test_file_count: 9
   - name: types
     tier: integrated
     py_files: 2
@@ -596,7 +596,7 @@ modules:
     importer_count: 16
     test_file_count: 11
 
-  # --- experimental (27) ---
+  # --- experimental (28) ---
   - name: approvals
     tier: experimental
     py_files: 5
@@ -609,9 +609,9 @@ modules:
     test_file_count: 3
   - name: codex
     tier: experimental
-    py_files: 6
-    importer_count: 1
-    test_file_count: 1
+    py_files: 7
+    importer_count: 3
+    test_file_count: 2
   - name: embeddings
     tier: experimental
     py_files: 1
@@ -622,6 +622,11 @@ modules:
     py_files: 2
     importer_count: 4
     test_file_count: 3
+  - name: factory
+    tier: experimental
+    py_files: 2
+    importer_count: 1
+    test_file_count: 1
   - name: fixtures
     tier: experimental
     py_files: 1

--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -11,8 +11,8 @@ description: Generated Aragora CLI command catalog from live parser
 
 This reference documents the command surface as implemented in code. It includes all top-level commands and known aliases.
 
-- Canonical top-level commands: **100**
-- Total top-level invocations (including aliases): **101**
+- Canonical top-level commands: **101**
+- Total top-level invocations (including aliases): **102**
 
 ## Installation
 
@@ -81,6 +81,7 @@ For full runtime configuration, see [ENVIRONMENT](../getting-started/environment
 | `essay` | - | Refine raw ideas into a polished essay or score an existing draft | `refine`, `score` |
 | `explain` | - | Explain a debate decision (evidence chains, vote pivots, counterfactuals) | - |
 | `export` | - | Export debate artifacts | - |
+| `factory` | - | Read-only inspector for Factory/Droid local session metadata | `sessions` |
 | `gauntlet` | - | Adversarial stress-test a specification, architecture, or policy | - |
 | `genealogy` | - | DIC-24: inspect epistemic genealogy ledger for proof-carrying code units | `show` |
 | `handlers` | - | List registered HTTP handlers and routes | `list`, `routes` |

--- a/docs-site/docs/contributing/b0-benchmark-truth-status.md
+++ b/docs-site/docs/contributing/b0-benchmark-truth-status.md
@@ -5,7 +5,7 @@ description: B0 Benchmark Truth Status
 
 # B0 Benchmark Truth Status
 
-Last updated: 2026-05-17T14:36:51Z
+Last updated: 2026-05-19T04:09:29Z
 
 This is the repo-tracked recurring `TW-02` publication surface for the fixed benchmark corpus.
 
@@ -71,8 +71,8 @@ This is the repo-tracked recurring `TW-02` publication surface for the fixed ben
 
 ## Previous Published Artifact
 
-- Previous artifact path: `docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/rev-4/scorecard-20260515T163115Z.json`
-- Previous generated_at: `2026-05-15T16:31:15Z`
+- Previous artifact path: `docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/rev-4/scorecard-20260517T143651Z.json`
+- Previous generated_at: `2026-05-17T14:36:51Z`
 
 ## Deltas
 

--- a/docs-site/docs/contributing/capability-matrix.md
+++ b/docs-site/docs/contributing/capability-matrix.md
@@ -8,7 +8,7 @@
 | Surface | Inventory | Capability Coverage |
 |---------|-----------|---------------------|
 | **HTTP API** | 1772 paths / 2100 operations | 81.1% |
-| **CLI** | 101 commands | 43.2% |
+| **CLI** | 102 commands | 43.2% |
 | **SDK (Python)** | 191 namespaces | 70.3% |
 | **SDK (TypeScript)** | 190 namespaces | 70.3% |
 | **UI** | tracked in capability surfaces | 86.5% |

--- a/docs-site/docs/contributing/tw03-rescue-productization-status.md
+++ b/docs-site/docs/contributing/tw03-rescue-productization-status.md
@@ -5,9 +5,9 @@ description: TW-03 Rescue Productization Status
 
 # TW-03 Rescue Productization Status
 
-Last updated: 2026-04-17T12:57:28Z
+Last updated: 2026-05-19T03:58:02Z
 
-This repo-tracked recurring `TW-03` status captures repeated rescue-class harvest, conversion, and ledger-consistency validation.
+This is the repo-tracked recurring `TW-03` publication surface for repeated rescue-class harvest and conversion.
 
 ## Summary
 

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -8,7 +8,7 @@
 | Surface | Inventory | Capability Coverage |
 |---------|-----------|---------------------|
 | **HTTP API** | 1772 paths / 2100 operations | 81.1% |
-| **CLI** | 101 commands | 43.2% |
+| **CLI** | 102 commands | 43.2% |
 | **SDK (Python)** | 191 namespaces | 70.3% |
 | **SDK (TypeScript)** | 190 namespaces | 70.3% |
 | **UI** | tracked in capability surfaces | 86.5% |

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -12,13 +12,13 @@
 
 | Metric | Value | Source | Command |
 |---|---|---|---|
-| Python files under aragora/ | `4140` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1941752` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
-| Top-level modules under aragora/ | `139` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5196` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `218496` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| Python files under aragora/ | `4143` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
+| Python lines of code under aragora/ | `1942582` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Top-level modules under aragora/ | `140` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
+| Test files (test_*.py under tests/) | `5203` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `218567` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
 | @pytest.mark.parametrize decorators | `689` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
-| CLI top-level command modules | `69` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
+| CLI top-level command modules | `70` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2870` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
 | OpenAPI operations (HTTP verbs) | `3297` | `docs/api/openapi.json` | `python -c "import json; spec=json.load(open('docs/api/openapi.json')); print(sum(1 for p in spec['paths'].values() for m in p if m.lower() in {'get','post','put','delete','patch','head','options'}))"` |
 | @require_permission decorator calls | `1365` | `aragora/` | `git grep -E '@require_permission\(' -- aragora \| wc -l` |
@@ -28,7 +28,7 @@
 | Allowlisted agent types | `34` | `aragora/config/settings.py` | `grep -A 50 'ALLOWED_AGENT_TYPES' aragora/config/settings.py \| grep -oE "'[a-z-]+'" \| sort -u \| wc -l` |
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `46` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |
-| Markdown files under docs/ | `892` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
+| Markdown files under docs/ | `921` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
 | GitHub Actions workflows | `85` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
 | Mypy baseline errors (grandfathered) | `3317` | `.mypy-baseline` | `wc -l .mypy-baseline` |
 

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -6,8 +6,8 @@
 
 This reference documents the command surface as implemented in code. It includes all top-level commands and known aliases.
 
-- Canonical top-level commands: **100**
-- Total top-level invocations (including aliases): **101**
+- Canonical top-level commands: **101**
+- Total top-level invocations (including aliases): **102**
 
 ## Installation
 
@@ -76,6 +76,7 @@ For full runtime configuration, see [ENVIRONMENT](ENVIRONMENT.md).
 | `essay` | - | Refine raw ideas into a polished essay or score an existing draft | `refine`, `score` |
 | `explain` | - | Explain a debate decision (evidence chains, vote pivots, counterfactuals) | - |
 | `export` | - | Export debate artifacts | - |
+| `factory` | - | Read-only inspector for Factory/Droid local session metadata | `sessions` |
 | `gauntlet` | - | Adversarial stress-test a specification, architecture, or policy | - |
 | `genealogy` | - | DIC-24: inspect epistemic genealogy ledger for proof-carrying code units | `show` |
 | `handlers` | - | List registered HTTP handlers and routes | `list`, `routes` |

--- a/tests/factory/test_cli_factory_sessions.py
+++ b/tests/factory/test_cli_factory_sessions.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+from aragora.cli.commands import factory_sessions as cli
+from aragora.cli.parser import build_parser
+
+
+def _args(**kwargs: object) -> argparse.Namespace:
+    base: dict[str, object] = {
+        "factory_home": None,
+        "repo_root": None,
+        "json": False,
+        "compact": False,
+    }
+    base.update(kwargs)
+    return argparse.Namespace(**base)
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_factory_sessions_parser_registers_brief_command() -> None:
+    args = build_parser().parse_args(["factory", "sessions", "brief", "--json"])
+
+    assert args.factory_cmd == "sessions"
+    assert args.factory_sessions_cmd == "brief"
+    assert args.json is True
+
+
+def test_cli_brief_json_schema_and_redaction(tmp_path: Path, capsys) -> None:  # type: ignore[no-untyped-def]
+    factory_home = tmp_path / "factory"
+    repo = tmp_path / "repo"
+    _write_json(
+        factory_home / "sessions-index.json",
+        [
+            {
+                "id": "droid-CLI",
+                "cwd": str(tmp_path / "worktree"),
+                "branch": "droid/cli-branch",
+                "pr_number": 7354,
+                "updated_at": int(time.time()),
+                "title": "Factory raw title with ghp_FAKELEAK12345678901234",
+            }
+        ],
+    )
+    _write_json(repo / ".aragora" / "agent-bridge" / "lanes.json", [])
+
+    rc = cli.cmd_factory_sessions_brief(
+        _args(
+            factory_home=str(factory_home),
+            repo_root=str(repo),
+            since="4h",
+            limit=50,
+            session=None,
+            json=True,
+            compact=False,
+        )
+    )
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+
+    assert rc == 0
+    assert payload["schema"] == "aragora-factory-sessions-brief/1.0"
+    assert payload["count"] == 1
+    assert payload["briefs"][0]["session_id"] == "droid-CLI"
+    assert "Factory raw title" not in out
+    assert "ghp_FAKELEAK12345678901234" not in out
+
+
+def test_cli_compact_omits_raw_paths_and_transcript_like_fields(tmp_path: Path, capsys) -> None:  # type: ignore[no-untyped-def]
+    factory_home = tmp_path / "factory"
+    repo = tmp_path / "repo"
+    _write_json(
+        factory_home / "sessions-index.json",
+        [
+            {
+                "id": "droid-COMPACT",
+                "cwd": str(tmp_path / "worktree"),
+                "updated_at": int(time.time()),
+            }
+        ],
+    )
+    _write_json(repo / ".aragora" / "agent-bridge" / "lanes.json", [])
+
+    rc = cli.cmd_factory_sessions_brief(
+        _args(
+            factory_home=str(factory_home),
+            repo_root=str(repo),
+            since="4h",
+            limit=50,
+            session=None,
+            json=True,
+            compact=True,
+        )
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert payload["compact"] is True
+    row = payload["briefs"][0]
+    assert set(row) == {
+        "provider",
+        "session_id",
+        "age",
+        "branch",
+        "pr_number",
+        "route",
+        "conflict_risk",
+        "prompt_needed",
+        "prompt_needed_reason",
+        "direct_steering_available",
+        "recommended_next_prompt",
+    }
+
+
+def test_cli_unknown_session_returns_paste_needed(tmp_path: Path, capsys) -> None:  # type: ignore[no-untyped-def]
+    factory_home = tmp_path / "factory"
+    repo = tmp_path / "repo"
+    _write_json(factory_home / "sessions-index.json", [])
+    _write_json(repo / ".aragora" / "agent-bridge" / "lanes.json", [])
+
+    rc = cli.cmd_factory_sessions_brief(
+        _args(
+            factory_home=str(factory_home),
+            repo_root=str(repo),
+            since="4h",
+            limit=50,
+            session="missing-session",
+            json=True,
+            compact=False,
+        )
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert payload["count"] == 1
+    assert payload["briefs"][0]["session_id"] == "missing-session"
+    assert payload["briefs"][0]["router"]["category"] == "paste-needed"

--- a/tests/factory/test_session_inspector.py
+++ b/tests/factory/test_session_inspector.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import json
+import time
+from datetime import timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from aragora.factory import session_inspector as inspector
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _repo_with_lanes(tmp_path: Path, lanes: list[dict[str, object]]) -> Path:
+    repo = tmp_path / "repo"
+    registry = repo / ".aragora" / "agent-bridge" / "lanes.json"
+    _write_json(registry, lanes)
+    return repo
+
+
+def _factory_home_with_index(tmp_path: Path, sessions: list[dict[str, object]]) -> Path:
+    home = tmp_path / "factory"
+    _write_json(home / "sessions-index.json", sessions)
+    return home
+
+
+def test_brief_redacts_index_metadata_and_matches_active_lane(tmp_path: Path) -> None:
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    factory_home = _factory_home_with_index(
+        tmp_path,
+        [
+            {
+                "id": "droid-ABC123",
+                "cwd": str(worktree),
+                "branch": "droid/P16-stage2",
+                "head": "a" * 40,
+                "pr_number": 7292,
+                "updated_at": int(time.time()),
+                "title": "repair #7292 with sk-proj-FAKE-FACTORY-SECRET",
+            }
+        ],
+    )
+    repo = _repo_with_lanes(
+        tmp_path,
+        [
+            {
+                "lane_id": "P16-stage2",
+                "owner_session": "droid-ABC123",
+                "status": "active",
+                "pr_number": 7292,
+                "branch": "droid/P16-stage2",
+                "worktree": str(worktree),
+                "updated_at": "2026-05-19T12:00:00Z",
+            }
+        ],
+    )
+
+    briefs = inspector.build_factory_session_briefs(
+        factory_home=factory_home,
+        repo_root=repo,
+        since=timedelta(hours=4),
+    )
+    payload = [brief.to_dict() for brief in briefs]
+    serialized = json.dumps(payload)
+
+    assert len(payload) == 1
+    row = payload[0]
+    assert row["provider"] == "factory"
+    assert row["session_id"] == "droid-ABC123"
+    assert row["pr_number"] == 7292
+    assert row["branch"] == "droid/P16-stage2"
+    assert row["head"] == "a" * 40
+    assert row["matched_lane"]["lane_id"] == "P16-stage2"
+    assert row["prompt_needed"] is False
+    assert row["prompt_needed_reason"] == "active_lane_owned"
+    assert "sk-proj-FAKE-FACTORY-SECRET" not in serialized
+    assert "repair #7292" not in serialized
+
+
+def test_default_inspector_does_not_read_history_or_raw_session_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    factory_home = _factory_home_with_index(
+        tmp_path,
+        [
+            {
+                "id": "droid-RAW",
+                "cwd": str(tmp_path / "worktree"),
+                "updated_at": int(time.time()),
+            }
+        ],
+    )
+    forbidden_paths = {
+        factory_home / "history.json",
+        factory_home / "sessions" / "droid-RAW" / "transcript.jsonl",
+        factory_home / "logs" / "droid-log-single.log",
+    }
+    for path in forbidden_paths:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("RAW_FACTORY_SECRET_SHOULD_NOT_BE_READ", encoding="utf-8")
+    original_read_text: Any = Path.read_text
+
+    def guarded_read_text(self: Path, *args: Any, **kwargs: Any) -> str:
+        if self in forbidden_paths:
+            raise AssertionError(f"raw Factory file was read: {self}")
+        return str(original_read_text(self, *args, **kwargs))
+
+    monkeypatch.setattr(Path, "read_text", guarded_read_text)
+
+    briefs = inspector.build_factory_session_briefs(
+        factory_home=factory_home,
+        repo_root=_repo_with_lanes(tmp_path, []),
+        since=timedelta(hours=4),
+    )
+    serialized = json.dumps([brief.to_dict() for brief in briefs])
+
+    assert len(briefs) == 1
+    assert "RAW_FACTORY_SECRET_SHOULD_NOT_BE_READ" not in serialized
+
+
+def test_duplicate_active_pr_owner_reports_conflict_and_steering(tmp_path: Path) -> None:
+    factory_home = _factory_home_with_index(
+        tmp_path,
+        [
+            {
+                "id": "droid-DUPLICATE",
+                "cwd": str(tmp_path / "duplicate"),
+                "branch": "droid/duplicate",
+                "pr_number": 7292,
+                "updated_at": int(time.time()),
+            }
+        ],
+    )
+    repo = _repo_with_lanes(
+        tmp_path,
+        [
+            {
+                "lane_id": "Q01-owner",
+                "owner_session": "codex-owner",
+                "status": "active",
+                "pr_number": 7292,
+                "branch": "droid/current-owner",
+                "updated_at": "2026-05-19T12:00:00Z",
+            }
+        ],
+    )
+
+    brief = inspector.build_factory_session_briefs(
+        factory_home=factory_home,
+        repo_root=repo,
+        since=timedelta(hours=4),
+    )[0]
+    payload = brief.to_dict()
+
+    assert payload["conflict_risk"] == "active-owner-overlap"
+    assert payload["direct_steering_available"] is False
+    assert payload["matched_lane"]["owner_session"] == "codex-owner"
+    assert "codex-owner" in payload["router"]["recommended_next_prompt"]
+    assert "Do not edit" in payload["router"]["recommended_next_prompt"]
+
+
+def test_direct_steering_does_not_use_shared_cwd_without_session_or_lane_match(
+    tmp_path: Path,
+) -> None:
+    shared_cwd = tmp_path / "repo"
+    shared_cwd.mkdir()
+    factory_home = _factory_home_with_index(
+        tmp_path,
+        [
+            {
+                "id": "factory-uuid-session",
+                "cwd": str(shared_cwd),
+                "updated_at": int(time.time()),
+            }
+        ],
+    )
+    repo = _repo_with_lanes(tmp_path, [])
+    _write_json(
+        repo / ".aragora" / "tmux-sessions" / "factory-review.meta.json",
+        {
+            "name": "factory-review",
+            "agent": "droid",
+            "cwd": str(shared_cwd),
+            "tmux_window_target": "aragora:factory-review",
+        },
+    )
+
+    brief = inspector.build_factory_session_briefs(
+        factory_home=factory_home,
+        repo_root=repo,
+        since=timedelta(hours=4),
+    )[0]
+
+    assert brief.direct_steering_available is False
+    assert brief.steering_command is None
+
+
+def test_unknown_session_returns_paste_needed(tmp_path: Path) -> None:
+    factory_home = _factory_home_with_index(tmp_path, [])
+
+    brief = inspector.paste_needed_brief("missing-session")
+    payload = brief.to_dict()
+
+    assert payload["session_id"] == "missing-session"
+    assert payload["router"]["category"] == "paste-needed"
+    assert "Paste the relevant Factory excerpt" in payload["router"]["recommended_next_prompt"]
+    assert (
+        inspector.build_factory_session_briefs(
+            factory_home=factory_home,
+            repo_root=_repo_with_lanes(tmp_path, []),
+            since=timedelta(hours=4),
+            session="missing-session",
+        )[0].router.category
+        == "paste-needed"
+    )

--- a/tests/factory/test_session_inspector.py
+++ b/tests/factory/test_session_inspector.py
@@ -201,6 +201,81 @@ def test_direct_steering_does_not_use_shared_cwd_without_session_or_lane_match(
     assert brief.steering_command is None
 
 
+def test_direct_steering_ignores_secret_like_tmux_target_names(tmp_path: Path) -> None:
+    factory_home = _factory_home_with_index(
+        tmp_path,
+        [
+            {
+                "id": "factory-visible",
+                "pr_number": 7359,
+                "updated_at": int(time.time()),
+            }
+        ],
+    )
+    secret_target = "factory-ghp_FAKELEAK12345678901234"
+    repo = _repo_with_lanes(
+        tmp_path,
+        [
+            {
+                "lane_id": "P80-owner",
+                "owner_session": secret_target,
+                "status": "active",
+                "pr_number": 7359,
+                "updated_at": "2026-05-19T12:00:00Z",
+            }
+        ],
+    )
+    _write_json(
+        repo / ".aragora" / "tmux-sessions" / "factory-secret.meta.json",
+        {
+            "name": secret_target,
+            "agent": "factory",
+        },
+    )
+
+    brief = inspector.build_factory_session_briefs(
+        factory_home=factory_home,
+        repo_root=repo,
+        since=timedelta(hours=4),
+    )[0]
+    payload = brief.to_dict()
+    serialized = json.dumps(payload)
+
+    assert payload["matched_lane"]["owner_session"] == "factory-[REDACTED]"
+    assert payload["direct_steering_available"] is False
+    assert payload["steering_command"] is None
+    assert secret_target not in serialized
+
+
+def test_direct_steering_ignores_path_like_tmux_target_names(tmp_path: Path) -> None:
+    factory_home = _factory_home_with_index(
+        tmp_path,
+        [
+            {
+                "id": "factory-path-target",
+                "updated_at": int(time.time()),
+            }
+        ],
+    )
+    repo = _repo_with_lanes(tmp_path, [])
+    _write_json(
+        repo / ".aragora" / "tmux-sessions" / "factory-path.meta.json",
+        {
+            "name": "factory/path-target",
+            "agent": "droid",
+        },
+    )
+
+    brief = inspector.build_factory_session_briefs(
+        factory_home=factory_home,
+        repo_root=repo,
+        since=timedelta(hours=4),
+    )[0]
+
+    assert brief.direct_steering_available is False
+    assert brief.steering_command is None
+
+
 def test_unknown_session_returns_paste_needed(tmp_path: Path) -> None:
     factory_home = _factory_home_with_index(tmp_path, [])
 


### PR DESCRIPTION
## Summary
- add read-only Factory/Droid session metadata briefs under `aragora factory sessions brief`
- map Factory sessions to lane/PR/worktree metadata without reading raw transcripts, prompt logs, history, or session logs
- emit conservative routing and steering packets, with direct steering only for exact session/lane target matches

## Validation
- `python3 -m pytest tests/factory/test_session_inspector.py tests/factory/test_cli_factory_sessions.py tests/scripts/test_agent_bridge.py tests/scripts/test_list_active_agent_sessions.py -q`
- `python3 -m ruff check aragora/factory/session_inspector.py aragora/cli/commands/factory_sessions.py aragora/cli/parser.py tests/factory/test_session_inspector.py tests/factory/test_cli_factory_sessions.py`
- `python3 -m ruff format --check aragora/factory/session_inspector.py aragora/cli/commands/factory_sessions.py aragora/cli/parser.py tests/factory/test_session_inspector.py tests/factory/test_cli_factory_sessions.py`
- `python3 -m mypy aragora/factory/session_inspector.py aragora/cli/commands/factory_sessions.py tests/factory/test_session_inspector.py tests/factory/test_cli_factory_sessions.py --ignore-missing-imports --no-incremental`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- `python3 -m aragora.cli.main factory sessions brief --since 4h --compact --json`