### PR TITLE
ADC v0.4 — HMAC-SHA256 signing for Delegation Contracts [lane: ADC-v0.4-hmac-signing]

### DIFF
--- a/aragora/policy/__init__.py
+++ b/aragora/policy/__init__.py
@@ -64,6 +64,19 @@ from aragora.policy.delegation_contract import (
     make_root_contract,
     narrow_for_child,
 )
+from aragora.policy.contract_signing import (
+    SIGNING_SCHEMA_VERSION,
+    SigningError,
+    VerificationError,
+    VerificationResult,
+    canonical_contract_payload,
+    is_contract_signed,
+    sign_contract,
+    sign_receipt,
+    signing_key_available,
+    verify_contract,
+    verify_receipt,
+)
 from aragora.policy.predicate_oracle import (
     EVALUATORS,
     PredicateParseError,
@@ -95,6 +108,18 @@ __all__ = [
     "GOAL_SPEC_SCHEMA_VERSION",
     "narrow_for_child",
     "make_root_contract",
+    # Delegation Contract v0.4 signing
+    "SIGNING_SCHEMA_VERSION",
+    "SigningError",
+    "VerificationError",
+    "VerificationResult",
+    "canonical_contract_payload",
+    "is_contract_signed",
+    "sign_contract",
+    "sign_receipt",
+    "signing_key_available",
+    "verify_contract",
+    "verify_receipt",
     # Predicate oracle
     "PredicateResult",
     "PredicateParseError",

--- a/aragora/policy/contract_signing.py
+++ b/aragora/policy/contract_signing.py
@@ -1,0 +1,392 @@
+"""HMAC-SHA256 signing for Aragora Delegation Contracts (v0.4).
+
+Companion to ``aragora.policy.delegation_contract`` — turns a v0.1 contract
+(which carries a nullable ``signature`` field) into a signed artifact whose
+authority chain is cryptographically unforgeable, not just typed.
+
+Design choices
+--------------
+- **HMAC-SHA256** over a canonical JSON serialization. ed25519 (asymmetric
+  signing with a public-key directory) is a v1.0 hardening item; for v0.4
+  HMAC is sufficient because the verifier is always a process that already
+  shares the shared secret. The same primitive backs
+  ``aragora.security.context_signing`` and is well-trodden in the codebase.
+- **Canonical JSON**: ``sort_keys=True`` + ``separators=(",",":")`` +
+  the ``signature`` field omitted. This guarantees the same contract
+  serializes byte-identically across Python versions, dict insertion
+  orders, and whether the caller round-tripped through JSON before
+  signing.
+- **Key resolution**: explicit ``key`` kwarg wins; otherwise we fall back
+  to ``ARAGORA_CONTEXT_SIGNING_KEY`` via
+  ``aragora.security.context_signing.get_signing_key()`` so v0.4 inherits
+  the same env contract as G1 manifest signing. Missing key + no explicit
+  key + signing mode raises ``SigningError``.
+- **Schema-additive**: the contract dataclass is unchanged. We bump only
+  a *signing* schema version (``SIGNING_SCHEMA_VERSION``) so v0.1
+  contracts remain parsable; the v0.1 ``validate()`` rule is relaxed
+  separately in ``delegation_contract.py`` to allow either ``None``
+  (unsigned mode) or a populated signature that verifies.
+
+Out of scope for v0.4
+---------------------
+- ed25519 / public-key signing (v1.0)
+- key rotation / public-key infrastructure (v1.0)
+- lane-registry enforcement at claim time (v0.5, depends on lane-registry
+  hookup v0.2 first)
+- re-signing previously-emitted receipts retroactively
+
+Pure stdlib. No new pip deps.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from aragora.security.context_signing import get_signing_key
+
+from .delegation_contract import (
+    AllowedSurfaces,
+    ContractBudget,
+    DelegationContract,
+)
+
+SIGNING_SCHEMA_VERSION = "aragora-contract-signing/0.4"
+
+# Field carrying the signature on both contracts and receipts. Centralized
+# so canonicalization and verification stay in lock-step.
+_SIGNATURE_FIELD = "signature"
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class SigningError(RuntimeError):
+    """Raised when signing cannot proceed (e.g. no key available)."""
+
+
+class VerificationError(RuntimeError):
+    """Raised on unrecoverable verification problems (malformed input)."""
+
+
+# ---------------------------------------------------------------------------
+# Verification result
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class VerificationResult:
+    """Outcome of a contract or receipt signature check.
+
+    Attributes:
+        ok: True iff a signature was present AND verified against ``key``.
+        signed: True iff the artifact carried a non-empty ``signature``
+            field. ``signed=False`` is not an error — it just means the
+            artifact is in "unsigned mode".
+        reason: Human-readable summary.
+    """
+
+    ok: bool
+    signed: bool
+    reason: str
+
+
+# ---------------------------------------------------------------------------
+# Canonicalization
+# ---------------------------------------------------------------------------
+
+
+def _contract_to_plain(contract: DelegationContract) -> dict[str, Any]:
+    """Serialize a ``DelegationContract`` into a dict of JSON-native types.
+
+    frozensets become sorted lists; nested dataclasses are unrolled. The
+    ``signature`` field is INCLUDED at this layer — the canonicalizer is
+    responsible for omitting it when computing the signing payload.
+    """
+    surfaces: AllowedSurfaces = contract.allowed_surfaces
+    budget: ContractBudget = contract.budget
+    return {
+        "contract_id": contract.contract_id,
+        "schema_version": contract.schema_version,
+        "root_intent_id": contract.root_intent_id,
+        "parent_contract_id": contract.parent_contract_id,
+        "delegator": contract.delegator,
+        "delegatee": contract.delegatee,
+        "max_depth": contract.max_depth,
+        "goal_id": contract.goal_id,
+        "allowed_actions": sorted(contract.allowed_actions),
+        "denied_actions": sorted(contract.denied_actions),
+        "allowed_surfaces": {
+            "pr_numbers": sorted(surfaces.pr_numbers),
+            "branch_globs": sorted(surfaces.branch_globs),
+            "worktree_globs": sorted(surfaces.worktree_globs),
+            "file_globs": sorted(surfaces.file_globs),
+            "deny_file_globs": sorted(surfaces.deny_file_globs),
+        },
+        "destructive_action_policy": contract.destructive_action_policy,
+        "budget": {
+            "risk_budget": {
+                "total": budget.risk_budget.total,
+                "spent": budget.risk_budget.spent,
+            },
+            "max_wall_clock_minutes": budget.max_wall_clock_minutes,
+            "max_subagents_spawned": budget.max_subagents_spawned,
+            "max_prs_opened": budget.max_prs_opened,
+            "max_commits_to_main": budget.max_commits_to_main,
+            "max_api_dollars": budget.max_api_dollars,
+            "max_lane_claims": budget.max_lane_claims,
+        },
+        "issued_at": contract.issued_at,
+        "expires_at": contract.expires_at,
+        "revocation_check_uri": contract.revocation_check_uri,
+        "progress_predicates": list(contract.progress_predicates),
+        "stale_threshold_minutes": contract.stale_threshold_minutes,
+        _SIGNATURE_FIELD: contract.signature,
+    }
+
+
+def _canonical_bytes(payload: Mapping[str, Any]) -> bytes:
+    """Deterministic JSON encoding with ``signature`` omitted.
+
+    Same rules as RFC 8785 (JSON Canonicalization Scheme) at the level
+    we need:
+    - sorted keys at every depth
+    - no extra whitespace
+    - UTF-8 bytes
+    - the ``signature`` field is removed before hashing so a signed
+      contract and its pre-signing form hash identically.
+    """
+
+    def _strip(obj: Any) -> Any:
+        if isinstance(obj, dict):
+            return {k: _strip(v) for k, v in obj.items() if k != _SIGNATURE_FIELD}
+        if isinstance(obj, list):
+            return [_strip(item) for item in obj]
+        return obj
+
+    stripped = _strip(dict(payload))
+    return json.dumps(stripped, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode(
+        "utf-8"
+    )
+
+
+def canonical_contract_payload(contract: DelegationContract) -> bytes:
+    """Return the deterministic JSON byte string for ``contract``.
+
+    The bytes are identical regardless of:
+    - whether ``contract.signature`` is ``None`` or populated (the field
+      is omitted before hashing)
+    - dict insertion order (sorted keys at every depth)
+    - frozenset iteration order (we sort first)
+    - whitespace formatting
+
+    This is the input to HMAC-SHA256.
+    """
+    return _canonical_bytes(_contract_to_plain(contract))
+
+
+# ---------------------------------------------------------------------------
+# Key resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_key(
+    key: bytes | None,
+    *,
+    required: bool,
+) -> bytes | None:
+    """Resolve an HMAC key. Explicit > env > None.
+
+    When ``required`` is True and no key is available, raises
+    ``SigningError``.
+    """
+    if key is not None:
+        if not key:
+            raise SigningError("explicit signing key is empty")
+        return key
+    env_key = get_signing_key()
+    if env_key:
+        return env_key
+    if required:
+        raise SigningError(
+            "no signing key available: pass ``key=`` explicitly or set the "
+            "ARAGORA_CONTEXT_SIGNING_KEY env var (base64-encoded)"
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Contract signing / verification
+# ---------------------------------------------------------------------------
+
+
+def _hmac_hex(payload: bytes, key: bytes) -> str:
+    return hmac.new(key, payload, hashlib.sha256).hexdigest()
+
+
+def sign_contract(
+    contract: DelegationContract,
+    *,
+    key: bytes | None = None,
+) -> DelegationContract:
+    """Return a NEW ``DelegationContract`` with ``signature`` populated.
+
+    The signature is HMAC-SHA256 over ``canonical_contract_payload(contract)``.
+    Because the canonical payload omits the ``signature`` field, signing an
+    already-signed contract is idempotent in the sense that the resulting
+    signature value matches the original (assuming the key is the same).
+
+    Raises:
+        SigningError: when no key is available.
+    """
+    resolved = _resolve_key(key, required=True)
+    if resolved is None:  # pragma: no cover — _resolve_key would have raised
+        raise SigningError("internal: key resolution returned None despite required=True")
+    payload = canonical_contract_payload(contract)
+    signature = _hmac_hex(payload, resolved)
+    # Use dataclasses.replace to avoid duplicating field plumbing.
+    from dataclasses import replace
+
+    return replace(contract, signature=signature)
+
+
+def verify_contract(
+    contract: DelegationContract,
+    *,
+    key: bytes | None = None,
+) -> VerificationResult:
+    """Verify the signature on ``contract``.
+
+    Returns a ``VerificationResult``. ``ok`` is True only when a signature
+    was present and successfully verified. ``signed=False`` for contracts
+    with ``signature=None`` is not an error.
+
+    Verification never raises on tampered input — only on missing key
+    when one is required by the artifact itself.
+    """
+    if not contract.signature:
+        return VerificationResult(
+            ok=False,
+            signed=False,
+            reason="contract is unsigned (signature field is None or empty)",
+        )
+    resolved = _resolve_key(key, required=False)
+    if resolved is None:
+        return VerificationResult(
+            ok=False,
+            signed=True,
+            reason=(
+                "contract is signed but no verification key is available; "
+                "pass key= or set ARAGORA_CONTEXT_SIGNING_KEY"
+            ),
+        )
+    payload = canonical_contract_payload(contract)
+    expected = _hmac_hex(payload, resolved)
+    if hmac.compare_digest(expected, contract.signature):
+        return VerificationResult(ok=True, signed=True, reason="signature verified")
+    return VerificationResult(
+        ok=False,
+        signed=True,
+        reason="signature does not match canonical payload (tampered or wrong key)",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Receipt signing / verification
+# ---------------------------------------------------------------------------
+
+
+def sign_receipt(
+    receipt: Mapping[str, Any],
+    *,
+    key: bytes | None = None,
+) -> dict[str, Any]:
+    """Return a NEW receipt dict with a ``signature`` field added.
+
+    Idempotent: signing an already-signed receipt with the same key
+    produces the same signature because the canonical payload omits the
+    ``signature`` field before hashing.
+
+    Receipts are arbitrary JSON-serializable mappings. The signature is
+    HMAC-SHA256 over the canonical-JSON-without-signature bytes.
+    """
+    resolved = _resolve_key(key, required=True)
+    if resolved is None:  # pragma: no cover
+        raise SigningError("internal: key resolution returned None despite required=True")
+    payload_bytes = _canonical_bytes(dict(receipt))
+    signature = _hmac_hex(payload_bytes, resolved)
+    signed: dict[str, Any] = dict(receipt)
+    signed[_SIGNATURE_FIELD] = signature
+    return signed
+
+
+def verify_receipt(
+    receipt: Mapping[str, Any],
+    *,
+    key: bytes | None = None,
+) -> VerificationResult:
+    """Verify a signed receipt dict. Mirrors ``verify_contract`` semantics."""
+    sig = receipt.get(_SIGNATURE_FIELD)
+    if not sig or not isinstance(sig, str):
+        return VerificationResult(
+            ok=False,
+            signed=False,
+            reason="receipt is unsigned (no `signature` field)",
+        )
+    resolved = _resolve_key(key, required=False)
+    if resolved is None:
+        return VerificationResult(
+            ok=False,
+            signed=True,
+            reason=(
+                "receipt is signed but no verification key is available; "
+                "pass key= or set ARAGORA_CONTEXT_SIGNING_KEY"
+            ),
+        )
+    payload_bytes = _canonical_bytes(dict(receipt))
+    expected = _hmac_hex(payload_bytes, resolved)
+    if hmac.compare_digest(expected, sig):
+        return VerificationResult(ok=True, signed=True, reason="signature verified")
+    return VerificationResult(
+        ok=False,
+        signed=True,
+        reason="signature does not match canonical payload (tampered or wrong key)",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers exposed for the CLI tool / external callers
+# ---------------------------------------------------------------------------
+
+
+def is_contract_signed(contract: DelegationContract) -> bool:
+    """Convenience: True iff the contract carries a non-empty signature."""
+    return bool(contract.signature)
+
+
+def signing_key_available(key: bytes | None = None) -> bool:
+    """True iff a signing key is resolvable from explicit arg or env."""
+    if key:
+        return True
+    return bool(os.environ.get("ARAGORA_CONTEXT_SIGNING_KEY"))
+
+
+__all__ = [
+    "SIGNING_SCHEMA_VERSION",
+    "SigningError",
+    "VerificationError",
+    "VerificationResult",
+    "canonical_contract_payload",
+    "is_contract_signed",
+    "sign_contract",
+    "sign_receipt",
+    "signing_key_available",
+    "verify_contract",
+    "verify_receipt",
+]

--- a/aragora/policy/delegation_contract.py
+++ b/aragora/policy/delegation_contract.py
@@ -6,8 +6,11 @@ ContractBudget, AllowedSurfaces) plus a monotonic-narrowing validator at
 parent → child issue time.
 
 No autonomous worker behavior changes in v0.1. The lane registry hookup
-is Stage 2 (separate PR). The signing layer is v0.4. See
-``docs/governance/DELEGATION_CONTRACT_V0_1_SPEC.md`` for the full
+is Stage 2 (separate PR). The signing layer ships in v0.4 (see
+``aragora.policy.contract_signing``) and relaxes the v0.1 ``signature``
+must-be-None rule: a populated signature is now accepted, and verified
+against ``ARAGORA_CONTEXT_SIGNING_KEY`` when the env var is set.
+See ``docs/governance/DELEGATION_CONTRACT_V0_1_SPEC.md`` for the full
 roadmap.
 
 Design influences (per spec doc):
@@ -340,9 +343,59 @@ class DelegationContract:
             raise ContractValidationError(
                 f"stale_threshold_minutes must be >= 1; got {self.stale_threshold_minutes}"
             )
-        # Signature must be None in v0.1
+        # Signature: v0.4 relaxes the v0.1 "must be None" rule. The
+        # signature may now be either:
+        #   - None / empty   → unsigned mode (still permitted; the lane
+        #     registry hookup in v0.5 will be responsible for refusing
+        #     to honor unsigned contracts in production paths)
+        #   - non-empty str  → must be a hex digest. If the
+        #     ARAGORA_CONTEXT_SIGNING_KEY env var is set, we also verify
+        #     the HMAC against the canonical contract payload. If the
+        #     env var is unset, the type/shape check is enough — the
+        #     verification responsibility shifts to the caller.
+        # See ``aragora.policy.contract_signing`` for the signing primitives.
         if self.signature is not None:
-            raise ContractValidationError("signature must be None in v0.1; signing ships in v0.4")
+            if not isinstance(self.signature, str) or not self.signature:
+                raise ContractValidationError(
+                    "signature must be either None or a non-empty hex string"
+                )
+            # Hex shape (HMAC-SHA256 → 64 hex chars). We don't hard-fail
+            # on length to keep room for future signature schemes, but
+            # we do reject non-hex content because that's almost
+            # certainly a bug or a tamper attempt.
+            try:
+                int(self.signature, 16)
+            except ValueError as exc:
+                raise ContractValidationError(
+                    f"signature is not a hex string: {self.signature!r}"
+                ) from exc
+            # If an env-backed key is present, verify the signature
+            # cryptographically. Import locally to avoid a hard import
+            # cycle with the signing module.
+            import os
+
+            if os.environ.get("ARAGORA_CONTEXT_SIGNING_KEY"):
+                from .contract_signing import verify_contract
+
+                result = verify_contract(self)
+                if not result.ok:
+                    raise ContractValidationError(
+                        f"contract carries a signature that fails verification: {result.reason}"
+                    )
+
+    # -----------------------------------------------------------------------
+    # Signature helpers
+    # -----------------------------------------------------------------------
+
+    @property
+    def is_signed(self) -> bool:
+        """True iff this contract carries a non-empty signature.
+
+        Note: this is a shape check only — ``is_signed`` does NOT verify
+        the signature cryptographically. For that, use
+        ``aragora.policy.contract_signing.verify_contract``.
+        """
+        return bool(self.signature)
 
     # -----------------------------------------------------------------------
     # Time helpers

--- a/scripts/sign_delegation_contract.py
+++ b/scripts/sign_delegation_contract.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Sign or verify a Delegation Contract JSON file.
+
+Companion CLI for ``aragora.policy.contract_signing`` (v0.4). Reads a
+contract JSON file produced by the contract issuance pipeline, signs it
+with HMAC-SHA256, and writes the signed contract back out.
+
+Usage
+-----
+
+Sign an unsigned contract::
+
+    python3 scripts/sign_delegation_contract.py \\
+        --in unsigned.json --out signed.json
+
+Verify a signed contract (read-only)::
+
+    python3 scripts/sign_delegation_contract.py \\
+        --in signed.json --verify-only
+
+Sign with an explicit base64-encoded key (instead of env var)::
+
+    python3 scripts/sign_delegation_contract.py \\
+        --in unsigned.json --out signed.json --key-b64 BASE64=
+
+Exit codes
+----------
+- 0    success (signed or verified)
+- 1    generic error (file missing, malformed JSON, etc.)
+- 2    no signing key available and --require-signed was passed
+       (or verification key missing in --verify-only mode)
+- 3    signature is present but does NOT verify (tamper / wrong key)
+- 4    --verify-only and contract is unsigned
+
+Pure stdlib. No new pip deps. Lane: ADC-v0.4-hmac-signing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# Allow running directly from a checkout without installing the package.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from aragora.policy.contract_signing import (  # noqa: E402
+    SigningError,
+    canonical_contract_payload,
+    sign_contract,
+    signing_key_available,
+    verify_contract,
+)
+from aragora.policy.delegation_contract import (  # noqa: E402
+    AllowedSurfaces,
+    ContractBudget,
+    ContractValidationError,
+    DelegationContract,
+)
+from aragora.policy.risk import RiskBudget  # noqa: E402
+
+
+def _load_contract(path: Path) -> DelegationContract:
+    """Load a contract JSON file into a ``DelegationContract`` dataclass.
+
+    The on-disk JSON shape is the one produced by
+    ``aragora.policy.contract_signing._contract_to_plain`` (sorted-list
+    encoding of frozensets, nested objects for surfaces/budget).
+    """
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    surfaces_raw: dict[str, Any] = raw.get("allowed_surfaces", {})
+    budget_raw: dict[str, Any] = raw.get("budget", {})
+    risk_raw: dict[str, Any] = budget_raw.get("risk_budget", {})
+
+    surfaces = AllowedSurfaces(
+        pr_numbers=frozenset(surfaces_raw.get("pr_numbers", []) or []),
+        branch_globs=frozenset(surfaces_raw.get("branch_globs", []) or []),
+        worktree_globs=frozenset(surfaces_raw.get("worktree_globs", []) or []),
+        file_globs=frozenset(surfaces_raw.get("file_globs", []) or []),
+        deny_file_globs=frozenset(surfaces_raw.get("deny_file_globs", []) or []),
+    )
+    budget = ContractBudget(
+        risk_budget=RiskBudget(
+            total=risk_raw.get("total", 100),
+            spent=risk_raw.get("spent", 0),
+        ),
+        max_wall_clock_minutes=budget_raw.get("max_wall_clock_minutes", 60),
+        max_subagents_spawned=budget_raw.get("max_subagents_spawned", 0),
+        max_prs_opened=budget_raw.get("max_prs_opened", 1),
+        max_commits_to_main=budget_raw.get("max_commits_to_main", 0),
+        max_api_dollars=budget_raw.get("max_api_dollars", 1.0),
+        max_lane_claims=budget_raw.get("max_lane_claims", 1),
+    )
+    return DelegationContract(
+        contract_id=raw["contract_id"],
+        schema_version=raw["schema_version"],
+        root_intent_id=raw["root_intent_id"],
+        parent_contract_id=raw.get("parent_contract_id"),
+        delegator=raw["delegator"],
+        delegatee=raw["delegatee"],
+        max_depth=raw["max_depth"],
+        goal_id=raw["goal_id"],
+        allowed_actions=frozenset(raw.get("allowed_actions", [])),
+        denied_actions=frozenset(raw.get("denied_actions", [])),
+        allowed_surfaces=surfaces,
+        destructive_action_policy=raw.get("destructive_action_policy", "deny"),
+        budget=budget,
+        issued_at=raw["issued_at"],
+        expires_at=raw["expires_at"],
+        revocation_check_uri=raw.get("revocation_check_uri"),
+        progress_predicates=list(raw.get("progress_predicates", [])),
+        stale_threshold_minutes=raw.get("stale_threshold_minutes", 30),
+        signature=raw.get("signature"),
+    )
+
+
+def _dump_contract(contract: DelegationContract, path: Path) -> None:
+    """Write the contract JSON to ``path`` in canonical-ish form.
+
+    We use indent=2 for the on-disk artifact (humans need to diff it);
+    the signing payload itself uses canonical compact JSON via
+    ``canonical_contract_payload``.
+    """
+    # Reuse the canonicalizer to derive the dict shape, then re-decode
+    # so we can re-emit with indentation.
+    payload_bytes = canonical_contract_payload(contract)
+    obj = json.loads(payload_bytes.decode("utf-8"))
+    if contract.signature:
+        obj["signature"] = contract.signature
+    path.write_text(json.dumps(obj, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _resolve_explicit_key(args: argparse.Namespace) -> bytes | None:
+    if args.key_b64:
+        try:
+            return base64.b64decode(args.key_b64)
+        except Exception as exc:  # noqa: BLE001
+            print(f"ERROR: --key-b64 is not valid base64: {exc}", file=sys.stderr)
+            sys.exit(1)
+    return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="sign_delegation_contract.py",
+        description=("Sign or verify an Aragora Delegation Contract JSON file (v0.4 HMAC-SHA256)."),
+    )
+    parser.add_argument(
+        "--in",
+        dest="in_path",
+        required=True,
+        type=Path,
+        help="path to contract JSON file to sign or verify",
+    )
+    parser.add_argument(
+        "--out",
+        dest="out_path",
+        type=Path,
+        default=None,
+        help="path to write the signed contract (required unless --verify-only)",
+    )
+    parser.add_argument(
+        "--verify-only",
+        action="store_true",
+        help="do not sign; just verify the signature on the input file",
+    )
+    parser.add_argument(
+        "--require-signed",
+        action="store_true",
+        help=(
+            "fail (exit 2) when no signing key is available, rather than "
+            "writing an unsigned contract"
+        ),
+    )
+    parser.add_argument(
+        "--key-b64",
+        dest="key_b64",
+        default=None,
+        help=(
+            "base64-encoded HMAC key, overriding ARAGORA_CONTEXT_SIGNING_KEY. "
+            "Useful for tests; production paths should rely on the env var."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    in_path: Path = args.in_path
+    if not in_path.exists():
+        print(f"ERROR: input file does not exist: {in_path}", file=sys.stderr)
+        return 1
+
+    try:
+        contract = _load_contract(in_path)
+    except (KeyError, json.JSONDecodeError) as exc:
+        print(f"ERROR: failed to parse contract JSON at {in_path}: {exc}", file=sys.stderr)
+        return 1
+    except ContractValidationError as exc:
+        print(f"ERROR: contract validation failed at {in_path}: {exc}", file=sys.stderr)
+        return 1
+
+    explicit_key = _resolve_explicit_key(args)
+
+    if args.verify_only:
+        result = verify_contract(contract, key=explicit_key)
+        if not result.signed:
+            print(f"UNSIGNED: {result.reason}", file=sys.stderr)
+            return 4
+        if not result.ok:
+            print(f"VERIFY-FAILED: {result.reason}", file=sys.stderr)
+            return 3
+        print(f"OK: {result.reason}")
+        return 0
+
+    # Signing mode
+    if args.out_path is None:
+        print("ERROR: --out is required when not using --verify-only", file=sys.stderr)
+        return 1
+
+    if not signing_key_available(explicit_key):
+        if args.require_signed:
+            print(
+                "ERROR: --require-signed was passed but no signing key is "
+                "available (set ARAGORA_CONTEXT_SIGNING_KEY or pass --key-b64)",
+                file=sys.stderr,
+            )
+            return 2
+        # No key + not required → just copy through (still valid v0.4
+        # unsigned mode). We re-emit via _dump_contract so the on-disk
+        # JSON gets canonical key ordering.
+        _dump_contract(contract, args.out_path)
+        print(f"WROTE (unsigned): {args.out_path}")
+        return 0
+
+    try:
+        signed = sign_contract(contract, key=explicit_key)
+    except SigningError as exc:
+        print(f"ERROR: signing failed: {exc}", file=sys.stderr)
+        return 2
+
+    _dump_contract(signed, args.out_path)
+    print(f"WROTE (signed): {args.out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/policy/test_contract_signing.py
+++ b/tests/policy/test_contract_signing.py
@@ -1,0 +1,311 @@
+"""Tests for ``aragora.policy.contract_signing`` — Delegation Contract v0.4.
+
+Covers:
+- canonical_contract_payload is deterministic, omits the signature field,
+  and is stable across frozenset / dict ordering
+- sign_contract → verify_contract round-trip
+- tamper detection (mutated field → verification fails)
+- unsigned-mode verification (signed=False, ok=False, no error)
+- key resolution (explicit > env > missing-raises)
+- sign_receipt → verify_receipt round-trip
+- cross-key incompatibility (key A signs, key B fails)
+- parent → child narrowing preserves signature semantics
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from aragora.policy import (
+    ContractBudget,
+    ContractValidationError,
+    DelegationContract,
+    RiskBudget,
+    SigningError,
+    canonical_contract_payload,
+    is_contract_signed,
+    make_root_contract,
+    narrow_for_child,
+    sign_contract,
+    sign_receipt,
+    signing_key_available,
+    verify_contract,
+    verify_receipt,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _now_iso(offset_minutes: int = 0) -> str:
+    return (datetime.now(UTC) + timedelta(minutes=offset_minutes)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _make_parent() -> DelegationContract:
+    return make_root_contract(
+        contract_id="root-1",
+        root_intent_id="intent-1",
+        delegator="an0mium",
+        delegatee="claude-A",
+        goal_id="G-foo",
+        allowed_actions=("read:*", "write:branch:claude/*", "spawn:subagent"),
+        max_depth=3,
+        duration_minutes=120,
+        stale_threshold_minutes=30,
+        destructive_action_policy="deny",
+    )
+
+
+KEY_A = b"\x01" * 32
+KEY_B = b"\x02" * 32
+
+
+@pytest.fixture(autouse=True)
+def _clean_signing_env(monkeypatch):
+    """Ensure tests start with no env-backed signing key."""
+    monkeypatch.delenv("ARAGORA_CONTEXT_SIGNING_KEY", raising=False)
+    yield
+
+
+# ---------------------------------------------------------------------------
+# 1-3. Canonicalization properties
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_payload_is_deterministic() -> None:
+    """Same contract → same canonical bytes across two calls."""
+    contract = _make_parent()
+    assert canonical_contract_payload(contract) == canonical_contract_payload(contract)
+
+
+def test_canonical_payload_omits_signature_field() -> None:
+    """The signing payload must not include the `signature` key."""
+    contract = _make_parent()
+    payload = canonical_contract_payload(contract)
+    decoded = json.loads(payload.decode("utf-8"))
+    assert "signature" not in decoded
+    # And a signed contract produces the same payload as its unsigned form.
+    signed = sign_contract(contract, key=KEY_A)
+    assert canonical_contract_payload(signed) == payload
+
+
+def test_canonical_payload_stable_under_field_order_changes() -> None:
+    """Frozenset / dict order must not change the canonical bytes.
+
+    We rebuild the same logical contract twice with different iteration-order
+    seeds and confirm the canonical bytes match.
+    """
+    c1 = _make_parent()
+    # Rebuild with the same logical content but reversed iteration order for
+    # the allowed_actions set. frozenset already has unspecified order, but
+    # canonical_contract_payload must sort it before serializing.
+    c2 = replace(
+        c1,
+        allowed_actions=frozenset(sorted(c1.allowed_actions, reverse=True)),
+        denied_actions=frozenset(sorted(c1.denied_actions, reverse=True)),
+    )
+    assert canonical_contract_payload(c1) == canonical_contract_payload(c2)
+
+
+# ---------------------------------------------------------------------------
+# 4-5. Sign / verify round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_sign_then_verify_round_trip() -> None:
+    contract = _make_parent()
+    signed = sign_contract(contract, key=KEY_A)
+    assert signed.signature is not None
+    assert is_contract_signed(signed)
+    result = verify_contract(signed, key=KEY_A)
+    assert result.ok is True
+    assert result.signed is True
+
+
+def test_verify_detects_tamper() -> None:
+    """Mutating any signed field must invalidate the signature."""
+    contract = _make_parent()
+    signed = sign_contract(contract, key=KEY_A)
+    # Tamper: change the delegatee.
+    tampered = replace(signed, delegatee="evil-agent")
+    result = verify_contract(tampered, key=KEY_A)
+    assert result.ok is False
+    assert result.signed is True
+    assert "tampered" in result.reason or "match" in result.reason
+
+
+# ---------------------------------------------------------------------------
+# 6. Unsigned-mode behavior
+# ---------------------------------------------------------------------------
+
+
+def test_verify_unsigned_returns_signed_false_without_raising() -> None:
+    contract = _make_parent()
+    assert contract.signature is None
+    result = verify_contract(contract, key=KEY_A)
+    assert result.ok is False
+    assert result.signed is False
+    # Reason must explain it's an unsigned-mode result, not a verify failure.
+    assert "unsigned" in result.reason.lower()
+
+
+# ---------------------------------------------------------------------------
+# 7. Key resolution
+# ---------------------------------------------------------------------------
+
+
+def test_signing_requires_key_explicit_or_env(monkeypatch) -> None:
+    """Without an explicit key AND without env var, signing must raise."""
+    contract = _make_parent()
+    monkeypatch.delenv("ARAGORA_CONTEXT_SIGNING_KEY", raising=False)
+    with pytest.raises(SigningError, match="no signing key"):
+        sign_contract(contract)
+
+    # Setting the env var resolves the key (base64-encoded).
+    monkeypatch.setenv("ARAGORA_CONTEXT_SIGNING_KEY", base64.b64encode(KEY_A).decode())
+    signed = sign_contract(contract)
+    assert signed.signature is not None
+    assert verify_contract(signed).ok is True
+    assert signing_key_available() is True
+
+
+# ---------------------------------------------------------------------------
+# 8. Receipt round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_sign_receipt_then_verify_round_trip() -> None:
+    receipt = {
+        "lane_id": "ADC-v0.4-hmac-signing",
+        "session_id": "droid-FAKE",
+        "outcome": "shipped",
+        "pr_number": 9999,
+        "nested": {"a": 1, "b": [3, 1, 2]},
+    }
+    signed = sign_receipt(receipt, key=KEY_A)
+    assert "signature" in signed
+    assert signed["signature"] is not None
+    # Original receipt unchanged (sign_receipt is non-mutating).
+    assert "signature" not in receipt
+
+    result = verify_receipt(signed, key=KEY_A)
+    assert result.ok is True
+    assert result.signed is True
+
+    # Tamper detection: change a field.
+    tampered = dict(signed)
+    tampered["outcome"] = "fraudulent-shipped"
+    assert verify_receipt(tampered, key=KEY_A).ok is False
+
+
+def test_sign_receipt_idempotent_with_same_key() -> None:
+    """Signing a receipt twice with the same key produces the same digest."""
+    receipt = {"lane_id": "X", "n": 1}
+    s1 = sign_receipt(receipt, key=KEY_A)
+    s2 = sign_receipt(s1, key=KEY_A)
+    assert s1["signature"] == s2["signature"]
+
+
+# ---------------------------------------------------------------------------
+# 9. Cross-key incompatibility
+# ---------------------------------------------------------------------------
+
+
+def test_contract_signed_with_key_a_fails_under_key_b() -> None:
+    contract = _make_parent()
+    signed_a = sign_contract(contract, key=KEY_A)
+    result = verify_contract(signed_a, key=KEY_B)
+    assert result.ok is False
+    assert result.signed is True
+
+
+def test_receipt_signed_with_key_a_fails_under_key_b() -> None:
+    receipt = {"k": "v"}
+    signed_a = sign_receipt(receipt, key=KEY_A)
+    assert verify_receipt(signed_a, key=KEY_B).ok is False
+
+
+# ---------------------------------------------------------------------------
+# 10. Parent → child narrowing preserves signature semantics
+# ---------------------------------------------------------------------------
+
+
+def test_child_carries_own_signature_not_parent_transcription() -> None:
+    """``narrow_for_child`` mints a child with its own (None at issue time)
+    signature; the parent's signature is referenced via parent_contract_id
+    in the authority chain, not copied into the child's signature field.
+    """
+    parent = _make_parent()
+    signed_parent = sign_contract(parent, key=KEY_A)
+    child = narrow_for_child(
+        signed_parent,
+        child_contract_id="child-1",
+        child_delegatee="claude-B",
+        child_allowed_actions=frozenset({"read:*"}),
+        child_budget=ContractBudget(risk_budget=RiskBudget()),
+        child_stale_threshold_minutes=15,
+        child_expires_at=_now_iso(60),
+    )
+    # Child starts unsigned and references the signed parent by id.
+    assert child.signature is None
+    assert child.is_signed is False
+    assert child.parent_contract_id == signed_parent.contract_id
+    # Parent's signature is intact; not consumed by the narrowing step.
+    assert signed_parent.signature is not None
+    assert verify_contract(signed_parent, key=KEY_A).ok is True
+
+    # Signing the child independently works and remains independent of parent.
+    signed_child = sign_contract(child, key=KEY_A)
+    assert signed_child.signature != signed_parent.signature
+    assert verify_contract(signed_child, key=KEY_A).ok is True
+
+
+# ---------------------------------------------------------------------------
+# Bonus: validation of populated signatures
+# ---------------------------------------------------------------------------
+
+
+def test_contract_validate_accepts_hex_signature_without_env_key(monkeypatch) -> None:
+    """With no env-backed key, validate() accepts a well-shaped signature
+    (hex string) without cryptographic verification."""
+    monkeypatch.delenv("ARAGORA_CONTEXT_SIGNING_KEY", raising=False)
+    parent = _make_parent()
+    signed = sign_contract(parent, key=KEY_A)
+    # Should not raise even though the env key is absent.
+    signed.validate()
+
+
+def test_contract_validate_rejects_non_hex_signature() -> None:
+    parent = _make_parent()
+    forged = replace(parent, signature="not-hex-content!!")
+    with pytest.raises(ContractValidationError, match="hex"):
+        forged.validate()
+
+
+def test_contract_validate_with_env_key_verifies_signature(monkeypatch) -> None:
+    """When the env key is set, validate() cryptographically verifies."""
+    monkeypatch.setenv("ARAGORA_CONTEXT_SIGNING_KEY", base64.b64encode(KEY_A).decode())
+    contract = _make_parent()
+    signed = sign_contract(contract)  # picks up env key
+    signed.validate()
+    # Now flip a field; signature no longer matches → validate raises.
+    tampered = replace(signed, delegatee="evil")
+    with pytest.raises(ContractValidationError, match="fails verification"):
+        tampered.validate()
+
+
+def test_canonical_payload_is_pure_json_bytes() -> None:
+    """Canonical payload must be valid UTF-8 JSON (no surprises)."""
+    contract = _make_parent()
+    payload = canonical_contract_payload(contract)
+    decoded = json.loads(payload.decode("utf-8"))
+    assert isinstance(decoded, dict)
+    # Allowed_actions / surfaces become sorted lists (canonical encoding).
+    assert decoded["allowed_actions"] == sorted(contract.allowed_actions)
+    assert decoded["allowed_surfaces"]["pr_numbers"] == []

--- a/tests/policy/test_delegation_contract.py
+++ b/tests/policy/test_delegation_contract.py
@@ -82,12 +82,31 @@ def test_root_contract_rejects_destructive_policy_allow() -> None:
         _make_simple_parent(destructive_action_policy="allow")
 
 
-def test_root_contract_rejects_v01_signature() -> None:
+def test_root_contract_accepts_hex_signature_in_v04() -> None:
+    """v0.4 relaxed the v0.1 'signature must be None' rule.
+
+    A well-shaped hex signature must validate (cryptographic verification
+    happens only when ARAGORA_CONTEXT_SIGNING_KEY is set; see
+    ``tests/policy/test_contract_signing.py`` for the env-key path).
+    """
     parent = _make_simple_parent()
-    forged = DelegationContract(
+    # `deadbeef` is valid hex → validate() must accept it. The signature
+    # is not cryptographically checked here because no env-backed key
+    # is set, which is the documented v0.4 behavior.
+    signed_like = DelegationContract(
         **{**parent.__dict__, "signature": "deadbeef"},
     )
-    with pytest.raises(ContractValidationError, match="signature must be None in v0.1"):
+    signed_like.validate()
+    assert signed_like.is_signed is True
+
+
+def test_root_contract_rejects_non_hex_signature() -> None:
+    """A signature that isn't hex (e.g. raw garbage) must be rejected."""
+    parent = _make_simple_parent()
+    forged = DelegationContract(
+        **{**parent.__dict__, "signature": "not-hex!!"},
+    )
+    with pytest.raises(ContractValidationError, match="hex"):
         forged.validate()
 
 

--- a/tests/scripts/test_sign_delegation_contract.py
+++ b/tests/scripts/test_sign_delegation_contract.py
@@ -1,0 +1,198 @@
+"""Subprocess-style tests for ``scripts/sign_delegation_contract.py``.
+
+The CLI is a thin shim around ``aragora.policy.contract_signing``; these
+tests exercise the script via the same Python interpreter to keep the
+suite hermetic and fast.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "sign_delegation_contract.py"
+
+
+def _sample_contract_json(tmp_path: Path) -> Path:
+    """Write a minimal valid unsigned contract to ``tmp_path/contract.json``."""
+    # Pull the canonical encoding from the live module so we don't drift.
+    from aragora.policy import make_root_contract
+    from aragora.policy.contract_signing import canonical_contract_payload
+
+    contract = make_root_contract(
+        contract_id="cli-test-1",
+        root_intent_id="intent-cli-1",
+        delegator="operator",
+        delegatee="droid-cli",
+        goal_id="G-cli",
+        allowed_actions=("read:*",),
+        duration_minutes=60,
+    )
+    payload = canonical_contract_payload(contract)
+    raw_obj = json.loads(payload.decode("utf-8"))
+    raw_obj["signature"] = None  # make the unsigned mode explicit on disk
+    path = tmp_path / "contract.json"
+    path.write_text(json.dumps(raw_obj, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def _run(
+    args: list[str],
+    *,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    cmd = [sys.executable, str(SCRIPT), *args]
+    merged_env = os.environ.copy()
+    # Default to a hermetic env that does NOT carry the user's signing key.
+    merged_env.pop("ARAGORA_CONTEXT_SIGNING_KEY", None)
+    if env:
+        merged_env.update(env)
+    return subprocess.run(
+        cmd,
+        cwd=str(REPO_ROOT),
+        text=True,
+        capture_output=True,
+        check=False,
+        env=merged_env,
+    )
+
+
+def _fixture_hmac_material() -> str:
+    """Synthetic test-only HMAC fixture: 32 deterministic bytes,
+    base64-encoded. Not a real secret — just exercises the signer."""
+    return base64.b64encode(b"\x11" * 32).decode()
+
+
+# ---------------------------------------------------------------------------
+# 1. Sign a valid unsigned contract.
+# ---------------------------------------------------------------------------
+
+
+def test_signs_unsigned_contract_with_env_key(tmp_path: Path) -> None:
+    contract_path = _sample_contract_json(tmp_path)
+    out_path = tmp_path / "signed.json"
+
+    result = _run(
+        ["--in", str(contract_path), "--out", str(out_path)],
+        env={"ARAGORA_CONTEXT_SIGNING_KEY": _fixture_hmac_material()},
+    )
+    assert result.returncode == 0, result.stderr
+    assert out_path.exists()
+
+    signed = json.loads(out_path.read_text(encoding="utf-8"))
+    assert isinstance(signed.get("signature"), str)
+    assert len(signed["signature"]) == 64  # SHA-256 hex digest
+
+
+# ---------------------------------------------------------------------------
+# 2. Verify a signed contract.
+# ---------------------------------------------------------------------------
+
+
+def test_verify_only_succeeds_on_signed_contract(tmp_path: Path) -> None:
+    contract_path = _sample_contract_json(tmp_path)
+    out_path = tmp_path / "signed.json"
+
+    # Sign first.
+    sign_res = _run(
+        ["--in", str(contract_path), "--out", str(out_path)],
+        env={"ARAGORA_CONTEXT_SIGNING_KEY": _fixture_hmac_material()},
+    )
+    assert sign_res.returncode == 0, sign_res.stderr
+
+    # Verify.
+    verify_res = _run(
+        ["--in", str(out_path), "--verify-only"],
+        env={"ARAGORA_CONTEXT_SIGNING_KEY": _fixture_hmac_material()},
+    )
+    assert verify_res.returncode == 0, verify_res.stderr
+    assert "OK" in verify_res.stdout
+
+
+# ---------------------------------------------------------------------------
+# 3. --require-signed without a key fails clearly.
+# ---------------------------------------------------------------------------
+
+
+def test_require_signed_without_key_fails(tmp_path: Path) -> None:
+    contract_path = _sample_contract_json(tmp_path)
+    out_path = tmp_path / "should-not-exist.json"
+
+    result = _run(
+        ["--in", str(contract_path), "--out", str(out_path), "--require-signed"],
+    )
+    assert result.returncode == 2, result.stderr
+    assert "no signing key" in result.stderr.lower()
+    assert not out_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# 4. --verify-only against tampered contract exits non-zero.
+# ---------------------------------------------------------------------------
+
+
+def test_verify_only_detects_tamper(tmp_path: Path) -> None:
+    contract_path = _sample_contract_json(tmp_path)
+    out_path = tmp_path / "signed.json"
+
+    sign_res = _run(
+        ["--in", str(contract_path), "--out", str(out_path)],
+        env={"ARAGORA_CONTEXT_SIGNING_KEY": _fixture_hmac_material()},
+    )
+    assert sign_res.returncode == 0, sign_res.stderr
+
+    # Tamper: mutate delegatee while keeping the signature intact.
+    signed_obj = json.loads(out_path.read_text(encoding="utf-8"))
+    signed_obj["delegatee"] = "evil-agent"
+    tampered_path = tmp_path / "tampered.json"
+    tampered_path.write_text(json.dumps(signed_obj, indent=2, sort_keys=True), encoding="utf-8")
+
+    verify_res = _run(
+        ["--in", str(tampered_path), "--verify-only"],
+        env={"ARAGORA_CONTEXT_SIGNING_KEY": _fixture_hmac_material()},
+    )
+    assert verify_res.returncode == 3, (verify_res.returncode, verify_res.stderr)
+    assert "VERIFY-FAILED" in verify_res.stderr
+
+
+# ---------------------------------------------------------------------------
+# 5. --verify-only against unsigned contract exits 4.
+# ---------------------------------------------------------------------------
+
+
+def test_verify_only_on_unsigned_returns_exit_4(tmp_path: Path) -> None:
+    contract_path = _sample_contract_json(tmp_path)
+    verify_res = _run(
+        ["--in", str(contract_path), "--verify-only"],
+        env={"ARAGORA_CONTEXT_SIGNING_KEY": _fixture_hmac_material()},
+    )
+    assert verify_res.returncode == 4
+    assert "UNSIGNED" in verify_res.stderr
+
+
+# ---------------------------------------------------------------------------
+# 6. Sign via --key-b64 instead of env var.
+# ---------------------------------------------------------------------------
+
+
+def test_sign_with_explicit_key_b64(tmp_path: Path) -> None:
+    contract_path = _sample_contract_json(tmp_path)
+    out_path = tmp_path / "signed.json"
+    result = _run(
+        [
+            "--in",
+            str(contract_path),
+            "--out",
+            str(out_path),
+            "--key-b64",
+            _fixture_hmac_material(),
+        ],
+    )
+    assert result.returncode == 0, result.stderr
+    signed = json.loads(out_path.read_text(encoding="utf-8"))
+    assert signed.get("signature")


### PR DESCRIPTION
## ADC v0.4 — HMAC-SHA256 signing for Delegation Contracts + receipts

Phase 4 of the Aragora Delegation Contract: makes the contract actually carry a cryptographic signature so the authority chain is unforgeable, not just typed.

### Depends-on

- Depends-on: #7357 (ADC-v0.1 schema + predicate oracle)

Branch is based on the v0.1 PR head so the chain is explicit. Once v0.1 lands on main, this rebases cleanly to a self-contained diff.

### What ships

**`aragora/policy/contract_signing.py`** (new):
- `canonical_contract_payload(contract) -> bytes` — deterministic JSON (sorted keys at every depth, compact separators, `signature` field omitted) so the same contract serializes byte-identically across Python versions, dict insertion orders, frozenset iteration orders, and pre/post-signing.
- `sign_contract(contract, *, key=None) -> DelegationContract` — returns a new contract with HMAC-SHA256 signature populated.
- `verify_contract(contract, *, key=None) -> VerificationResult` — `(ok, signed, reason)` dataclass; never raises on tampered input.
- `sign_receipt(receipt, *, key=None) -> dict` / `verify_receipt(receipt, *, key=None) -> VerificationResult` — idempotent receipt signing.
- Key resolution: explicit `key` arg > `ARAGORA_CONTEXT_SIGNING_KEY` env var (reuses `aragora.security.context_signing.get_signing_key()`) > raises `SigningError`.
- `SIGNING_SCHEMA_VERSION = "aragora-contract-signing/0.4"`.

**`aragora/policy/delegation_contract.py`** (relaxed):
- v0.1's "signature must be None" rule is relaxed: a populated signature is now accepted (must be hex). When `ARAGORA_CONTEXT_SIGNING_KEY` is set, `validate()` additionally verifies the HMAC against the canonical payload, so tampered fields are caught at construction time.
- New `DelegationContract.is_signed` property (shape check only).

**`scripts/sign_delegation_contract.py`** (new CLI):
```
python3 scripts/sign_delegation_contract.py --in unsigned.json --out signed.json
python3 scripts/sign_delegation_contract.py --in signed.json --verify-only
```
Exit codes: `0` success, `1` parse error, `2` no key / `--require-signed` violated, `3` tamper, `4` `--verify-only` on unsigned input.

### Tests

- `tests/policy/test_contract_signing.py` — 16 tests covering canonicalization determinism, signature-field omission, ordering stability, sign→verify round-trip, tamper detection, unsigned-mode behavior, key resolution (explicit vs env vs missing), receipt round-trip + idempotency, cross-key incompatibility (KEY_A signs, KEY_B fails), parent→child signature semantics (child carries its own signature, parent's is referenced via `parent_contract_id`), env-key validation in `validate()`.
- `tests/scripts/test_sign_delegation_contract.py` — 6 subprocess tests for the CLI: sign, verify, `--require-signed` missing key, `--verify-only` tamper, `--verify-only` unsigned, `--key-b64`.
- `tests/policy/test_delegation_contract.py` — replaces the v0.1 "rejects signature" test with v0.4 semantics: accepts hex, rejects non-hex.

All 87 tests in the four policy/scripts suites pass locally.

### Discipline

- Re-uses `aragora.security.context_signing` for env-key resolution (same contract as G1 manifest signing).
- Pure stdlib. No new pip deps.
- Schema-additive on the contract side; the v0.1 dataclass shape is unchanged.
- No protected files touched.
- ruff / ruff-format / mypy / `bash scripts/automation_pr_preflight.sh origin/main HEAD` all clean.
- Signing flow works without network or AI calls.

### Out of scope (v1.0 hardening)

- ed25519 / public-key signing
- key rotation / PKI
- lane-registry enforcement at claim time (v0.5; depends on lane-registry hookup v0.2 first)
- re-signing previously-emitted receipts retroactively
