### PR TITLE
fix(automation): target safe outbox reconciliation

### DIFF
--- a/scripts/reconcile_automation_outbox.py
+++ b/scripts/reconcile_automation_outbox.py
@@ -213,6 +213,75 @@ def _desired_head_from_payload(payload: dict[str, Any]) -> str:
     return ""
 
 
+def _requested_action_type(payload: Mapping[str, Any]) -> str:
+    requested_action = payload.get("requested_action")
+    requested_action_mapping = _mapping_from_action(requested_action)
+    if requested_action_mapping is not None:
+        return str(requested_action_mapping.get("type") or "").strip().lower()
+    if isinstance(requested_action, str):
+        return requested_action.strip().lower()
+    return ""
+
+
+def _is_pr_publication_request(payload: Mapping[str, Any]) -> bool:
+    return _requested_action_type(payload) in {
+        "open_pr",
+        "open_pull_request",
+        "open_or_update_pr",
+        "open_or_update_pull_request",
+        "push_branch_and_open_pr",
+        "push_branch_and_open_pull_request",
+        "push_branch_and_open_or_update_pr",
+        "push_branch_and_open_or_update_pull_request",
+    }
+
+
+def _receipt_has_pr_reference(receipt: Mapping[str, Any]) -> bool:
+    for key in (
+        "created_pr_url",
+        "existing_pr_url",
+        "pr_url",
+        "pull_request_url",
+        "created_pull_request_url",
+        "existing_pull_request_url",
+    ):
+        if str(receipt.get(key) or "").strip():
+            return True
+    return False
+
+
+def _receipt_has_issue_reference(receipt: Mapping[str, Any]) -> bool:
+    for key in (
+        "created_issue_url",
+        "existing_issue_url",
+        "issue_url",
+    ):
+        if str(receipt.get(key) or "").strip():
+            return True
+    return False
+
+
+def _issue_only_pr_receipt_keep_reason(
+    payload: Mapping[str, Any],
+    receipt: Mapping[str, Any],
+) -> str | None:
+    """Return why an issue-only receipt cannot satisfy a PR-intended handoff."""
+
+    if not _is_pr_publication_request(payload):
+        return None
+
+    status = str(receipt.get("status") or "").strip().lower()
+    if status not in {"already_satisfied", "published"} or _receipt_has_pr_reference(receipt):
+        return None
+
+    reason = str(receipt.get("reason") or "").strip().lower()
+    if reason in {"published", "existing_issue", "created_issue"} or _receipt_has_issue_reference(
+        receipt
+    ):
+        return "PR-intended handoff has issue-only receipt; keep until a PR receipt exists"
+    return None
+
+
 def _heads_match(expected: str, actual: str) -> bool:
     expected_value = expected.strip().lower()
     actual_value = actual.strip().lower()
@@ -551,6 +620,7 @@ def main(argv: list[str] | None = None) -> int:
     counts = {
         "satisfied_by_existing_receipt": 0,
         "blocked_receipt_pr_head_mismatch": 0,
+        "blocked_receipt_issue_only": 0,
         "satisfied_by_superseded_handoff": 0,
         "satisfied_by_landed_on_main": 0,
         "satisfied_by_open_pr_merged": 0,  # placeholder; we only know open PRs
@@ -576,6 +646,20 @@ def main(argv: list[str] | None = None) -> int:
 
         receipt = receipt_payloads_by_key.get(idem)
         if receipt is not None:
+            issue_only_keep_reason = _issue_only_pr_receipt_keep_reason(payload, receipt)
+            if issue_only_keep_reason is not None:
+                counts["blocked_receipt_issue_only"] += 1
+                counts["still_protecting_active_work"] += 1
+                actions.append(
+                    {
+                        "path": str(path),
+                        "branch": branch,
+                        "decision": "keep",
+                        "reason": issue_only_keep_reason,
+                        "synthetic_receipt": False,
+                    }
+                )
+                continue
             keep_reason = _receipt_handoff_keep_reason(root, payload, receipt, branch)
             if keep_reason is not None:
                 counts["blocked_receipt_pr_head_mismatch"] += 1

--- a/scripts/reconcile_automation_outbox.py
+++ b/scripts/reconcile_automation_outbox.py
@@ -60,6 +60,13 @@ def _list_json(path: Path) -> list[Path]:
     return sorted(p for p in path.iterdir() if p.is_file() and p.suffix == ".json")
 
 
+def _resolve_outbox_file_filter(outbox_dir: Path, value: Path) -> Path:
+    expanded = value.expanduser()
+    if expanded.is_absolute():
+        return expanded.resolve()
+    return (outbox_dir / expanded).resolve()
+
+
 def _state_default_path(state_root: Path, default_relative: Path) -> Path:
     expanded = state_root.expanduser()
     if default_relative.parts[:1] == (".aragora",) and expanded.name == ".aragora":
@@ -384,6 +391,25 @@ def main(argv: list[str] | None = None) -> int:
             "the selected automation outbox."
         ),
     )
+    parser.add_argument(
+        "--idempotency-key",
+        action="append",
+        default=[],
+        help=(
+            "Only reconcile the outbox handoff with this idempotency key. "
+            "Repeat to target multiple handoffs."
+        ),
+    )
+    parser.add_argument(
+        "--outbox-file",
+        action="append",
+        type=Path,
+        default=[],
+        help=(
+            "Only reconcile this outbox JSON file. Relative paths resolve inside "
+            "the selected outbox directory; repeat to target multiple handoffs."
+        ),
+    )
     mode = parser.add_mutually_exclusive_group()
     mode.add_argument(
         "--apply",
@@ -453,15 +479,58 @@ def main(argv: list[str] | None = None) -> int:
     emit(f"  {len(receipt_keys)} terminal receipt keys")
 
     emit("loading outbox files...")
-    outbox_files = _list_json(outbox_dir)
-    emit(f"  {len(outbox_files)} outbox files\n")
+    all_outbox_files = _list_json(outbox_dir)
+    emit(f"  {len(all_outbox_files)} outbox files\n")
 
     parsed_outbox_payloads: dict[Path, dict[str, Any]] = {}
-    for path in outbox_files:
+    for path in all_outbox_files:
         payload = _load_json(path)
         if isinstance(payload, dict):
             parsed_outbox_payloads[path] = payload
     superseded_targets = _superseded_targets(list(parsed_outbox_payloads.items()))
+
+    target_keys = {str(key).strip() for key in args.idempotency_key if str(key).strip()}
+    target_files = {_resolve_outbox_file_filter(outbox_dir, path) for path in args.outbox_file}
+    if target_keys or target_files:
+        outbox_files = []
+        matched_keys: set[str] = set()
+        matched_files: set[Path] = set()
+        for path in all_outbox_files:
+            resolved_path = path.resolve()
+            payload = parsed_outbox_payloads.get(path)
+            idempotency_key = str((payload or {}).get("idempotency_key") or path.stem).strip()
+            if idempotency_key in target_keys or resolved_path in target_files:
+                outbox_files.append(path)
+                if idempotency_key in target_keys:
+                    matched_keys.add(idempotency_key)
+                if resolved_path in target_files:
+                    matched_files.add(resolved_path)
+
+        missing_keys = sorted(target_keys - matched_keys)
+        missing_files = sorted(str(path) for path in target_files - matched_files)
+        if missing_keys or missing_files:
+            payload = {
+                "applied": False,
+                "dry_run": not args.apply,
+                "error": "target outbox handoff not found",
+                "missing_idempotency_keys": missing_keys,
+                "missing_outbox_files": missing_files,
+                "outbox_count": 0,
+                "outbox_dir": str(outbox_dir),
+                "repo": str(root),
+                "state_root": str(state_root),
+                "total_outbox_count": len(all_outbox_files),
+            }
+            if args.json:
+                print(json.dumps(payload, indent=2, sort_keys=True))
+            else:
+                for key in missing_keys:
+                    emit(f"ERROR: no outbox handoff found for idempotency key {key}")
+                for path in missing_files:
+                    emit(f"ERROR: no outbox handoff found at {path}")
+            return 2
+    else:
+        outbox_files = all_outbox_files
 
     open_prs_cache: dict[str, int] | None = None
     open_pr_state_available = False
@@ -713,7 +782,12 @@ def main(argv: list[str] | None = None) -> int:
                     "repo_name": args.repo_name,
                     "report": str(report_path) if report_path is not None else None,
                     "state_root": str(state_root),
+                    "target": {
+                        "idempotency_keys": sorted(target_keys),
+                        "outbox_files": sorted(str(path) for path in target_files),
+                    },
                     "terminal_receipt_count": len(receipt_keys),
+                    "total_outbox_count": len(all_outbox_files),
                 },
                 indent=2,
                 sort_keys=True,

--- a/scripts/reconcile_automation_outbox.py
+++ b/scripts/reconcile_automation_outbox.py
@@ -595,8 +595,8 @@ def main(argv: list[str] | None = None) -> int:
             else:
                 for key in missing_keys:
                     emit(f"ERROR: no outbox handoff found for idempotency key {key}")
-                for path in missing_files:
-                    emit(f"ERROR: no outbox handoff found at {path}")
+                for missing_file in missing_files:
+                    emit(f"ERROR: no outbox handoff found at {missing_file}")
             return 2
     else:
         outbox_files = all_outbox_files

--- a/tests/scripts/test_reconcile_automation_outbox.py
+++ b/tests/scripts/test_reconcile_automation_outbox.py
@@ -212,6 +212,115 @@ def test_apply_uses_explicit_shared_state_dirs(
     assert (archive_dir / handoff.name).exists()
 
 
+def test_idempotency_key_filter_limits_reconciliation_scope(
+    tmp_path: Path,
+    capsys: Any,
+) -> None:
+    outbox_dir = tmp_path / ".aragora" / "automation-outbox"
+    receipt_dir = tmp_path / ".aragora" / "automation-receipts"
+    selected_key = "open-pr-codex-selected-abc123"
+    skipped_key = "open-pr-codex-skipped-def456"
+    _write_outbox_handoff(outbox_dir, branch="codex/selected", key=selected_key)
+    _write_outbox_handoff(outbox_dir, branch="codex/skipped", key=skipped_key)
+    receipt_dir.mkdir(parents=True)
+    for key in (selected_key, skipped_key):
+        (receipt_dir / f"{key}.json").write_text(
+            json.dumps({"idempotency_key": key, "status": "published"}),
+            encoding="utf-8",
+        )
+
+    rc = mod.main(
+        [
+            "--repo",
+            str(tmp_path),
+            "--idempotency-key",
+            selected_key,
+            "--json",
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["outbox_count"] == 1
+    assert payload["total_outbox_count"] == 2
+    assert payload["archived"] == 1
+    assert payload["actions"][0]["branch"] == "codex/selected"
+    assert payload["target"]["idempotency_keys"] == [selected_key]
+
+
+def test_apply_outbox_file_filter_archives_only_selected_handoff(
+    tmp_path: Path,
+    capsys: Any,
+) -> None:
+    outbox_dir = tmp_path / ".aragora" / "automation-outbox"
+    receipt_dir = tmp_path / ".aragora" / "automation-receipts"
+    selected_key = "open-pr-codex-file-selected-abc123"
+    skipped_key = "open-pr-codex-file-skipped-def456"
+    selected = _write_outbox_handoff(
+        outbox_dir,
+        branch="codex/file-selected",
+        key=selected_key,
+    )
+    skipped = _write_outbox_handoff(
+        outbox_dir,
+        branch="codex/file-skipped",
+        key=skipped_key,
+    )
+    receipt_dir.mkdir(parents=True)
+    for key in (selected_key, skipped_key):
+        (receipt_dir / f"{key}.json").write_text(
+            json.dumps({"idempotency_key": key, "status": "published"}),
+            encoding="utf-8",
+        )
+
+    rc = mod.main(
+        [
+            "--repo",
+            str(tmp_path),
+            "--outbox-file",
+            selected.name,
+            "--apply",
+            "--json",
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    archived = tmp_path / ".aragora" / "automation-outbox-archive" / selected.name
+    assert rc == 0
+    assert payload["outbox_count"] == 1
+    assert payload["total_outbox_count"] == 2
+    assert payload["archived"] == 1
+    assert selected.exists() is False
+    assert archived.exists()
+    assert skipped.exists()
+
+
+def test_missing_target_filter_fails_closed(
+    tmp_path: Path,
+    capsys: Any,
+) -> None:
+    outbox_dir = tmp_path / ".aragora" / "automation-outbox"
+    key = "open-pr-codex-present-abc123"
+    _write_outbox_handoff(outbox_dir, branch="codex/present", key=key)
+
+    rc = mod.main(
+        [
+            "--repo",
+            str(tmp_path),
+            "--idempotency-key",
+            "open-pr-codex-missing-def456",
+            "--json",
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 2
+    assert payload["error"] == "target outbox handoff not found"
+    assert payload["missing_idempotency_keys"] == ["open-pr-codex-missing-def456"]
+    assert payload["total_outbox_count"] == 1
+    assert (outbox_dir / f"{key}.json").exists()
+
+
 def test_explicit_outbox_dir_defaults_archive_beside_outbox(
     tmp_path: Path,
     capsys: Any,

--- a/tests/scripts/test_reconcile_automation_outbox.py
+++ b/tests/scripts/test_reconcile_automation_outbox.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
+import pytest
+
 import scripts.reconcile_automation_outbox as mod
 
 
@@ -518,6 +520,61 @@ def test_reconcile_existing_receipt_uses_structured_requested_action_branch(
     assert payload["counts"]["satisfied_by_existing_receipt"] == 1
     assert payload["counts"]["skipped_unparseable"] == 0
     assert payload["actions"][0]["branch"] == "codex/structured-action"
+
+
+@pytest.mark.parametrize(
+    ("status", "reason", "issue_key"),
+    [
+        ("already_satisfied", "existing_issue", "existing_issue_url"),
+        ("published", "published", "created_issue_url"),
+    ],
+)
+def test_reconcile_keeps_pr_handoff_with_issue_only_receipt(
+    tmp_path: Path,
+    capsys: Any,
+    status: str,
+    reason: str,
+    issue_key: str,
+) -> None:
+    outbox_dir = tmp_path / ".aragora" / "automation-outbox"
+    receipt_dir = tmp_path / ".aragora" / "automation-receipts"
+    key = "open-pr-codex-issue-only-receipt-abc123"
+    handoff = _write_outbox_handoff(
+        outbox_dir,
+        branch="codex/issue-only-receipt",
+        key=key,
+    )
+    payload = json.loads(handoff.read_text(encoding="utf-8"))
+    payload["requested_action"] = {
+        "type": "open_or_update_pr",
+        "base": "main",
+        "branch": "codex/issue-only-receipt",
+        "desired_head_sha": "abcdef1234567890abcdef1234567890abcdef12",
+    }
+    handoff.write_text(json.dumps(payload), encoding="utf-8")
+    receipt_dir.mkdir(parents=True)
+    (receipt_dir / f"{key}.json").write_text(
+        json.dumps(
+            {
+                "idempotency_key": key,
+                "status": status,
+                "reason": reason,
+                issue_key: "https://github.com/synaptent/aragora/issues/7320",
+                "existing_pr_url": None,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert mod.main(["--repo", str(tmp_path), "--json"]) == 0
+
+    result = json.loads(capsys.readouterr().out)
+    assert result["counts"]["blocked_receipt_issue_only"] == 1
+    assert result["counts"]["satisfied_by_existing_receipt"] == 0
+    assert result["counts"]["still_protecting_active_work"] == 1
+    assert result["actions"][0]["decision"] == "keep"
+    assert "issue-only receipt" in result["actions"][0]["reason"]
+    assert handoff.exists()
 
 
 def test_reconcile_keeps_target_pr_receipt_when_desired_head_not_published(


### PR DESCRIPTION
Publishes the protected automation outbox reconciliation branch.

Summary:
- Adds targeted outbox-file/idempotency-key filters to `scripts/reconcile_automation_outbox.py`.
- Preserves PR-intended handoffs that only have issue receipts, avoiding unsafe archival before a PR receipt exists.
- Includes focused tests for targeted filtering and issue-only PR receipt protection.

Validation:
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_reconcile_automation_outbox.py -p no:rerunfailures -p no:cacheprovider`
- `python3 -m ruff check scripts/reconcile_automation_outbox.py tests/scripts/test_reconcile_automation_outbox.py`
- `python3 -m ruff format --check scripts/reconcile_automation_outbox.py tests/scripts/test_reconcile_automation_outbox.py`
- `python3 -m mypy scripts/reconcile_automation_outbox.py`
- `git diff --check origin/main...HEAD && git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- `python3 scripts/reconcile_automation_outbox.py --repo /Users/armand/Development/aragora --base origin/main --dry-run --json`
