### PR TITLE
fix(automation): summarize handoff publisher decisions

### DIFF
--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -17,9 +17,10 @@ import os
 import re
 import subprocess
 import sys
+from collections import Counter
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta, timezone
-from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -161,6 +162,17 @@ class PublishDecision:
     existing_issue_url: str | None = None
     existing_pr_url: str | None = None
     created_issue_url: str | None = None
+
+
+def summarize_decisions(decisions: Sequence[PublishDecision]) -> dict[str, Any]:
+    reason_counts = Counter(item.reason for item in decisions)
+    eligible_count = sum(1 for item in decisions if item.eligible)
+    return {
+        "total": len(decisions),
+        "eligible_count": eligible_count,
+        "ineligible_count": len(decisions) - eligible_count,
+        "reason_counts": dict(sorted(reason_counts.items())),
+    }
 
 
 def _gh_write_op(args: list[str]) -> bool:
@@ -1395,6 +1407,15 @@ def main(argv: list[str] | None = None) -> int:
     github_health = check_github_cli_health(repo_root)
     if not github_health.ready:
         decision_handoffs = handoffs[: max(args.limit, 0)]
+        decisions = [
+            PublishDecision(
+                task_title=handoff.task_title,
+                source_file=handoff.source_file,
+                eligible=False,
+                reason="github_unavailable",
+            )
+            for handoff in decision_handoffs
+        ]
         payload = {
             "repo": str(repo_root),
             "codex_home": str(codex_home),
@@ -1407,17 +1428,8 @@ def main(argv: list[str] | None = None) -> int:
             "outbox_handoff_count": len(outbox_handoffs),
             "handoff_count": len(handoffs),
             "github_health": github_health.to_dict(),
-            "decisions": [
-                asdict(
-                    PublishDecision(
-                        task_title=handoff.task_title,
-                        source_file=handoff.source_file,
-                        eligible=False,
-                        reason="github_unavailable",
-                    )
-                )
-                for handoff in decision_handoffs
-            ],
+            "decisions": [asdict(item) for item in decisions],
+            "decision_summary": summarize_decisions(decisions),
         }
         if args.json:
             print(json.dumps(payload, indent=2))
@@ -1468,6 +1480,7 @@ def main(argv: list[str] | None = None) -> int:
         "handoff_count": len(handoffs),
         "github_health": github_health.to_dict(),
         "decisions": [asdict(item) for item in results],
+        "decision_summary": summarize_decisions(results),
     }
     if args.json:
         print(json.dumps(payload, indent=2))

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -1380,6 +1380,39 @@ def test_decide_handoffs_respects_open_issue_cap(monkeypatch: Any, tmp_path: Pat
     assert decisions[0].reason == "open_issue_cap"
 
 
+def test_summarize_decisions_counts_eligibility_and_reasons(tmp_path: Path) -> None:
+    decisions = [
+        PublishDecision(
+            task_title="Publish ready handoff",
+            source_file=str(tmp_path / "ready.json"),
+            eligible=True,
+            reason="eligible",
+        ),
+        PublishDecision(
+            task_title="Existing issue handoff",
+            source_file=str(tmp_path / "existing.json"),
+            eligible=False,
+            reason="existing_issue",
+        ),
+        PublishDecision(
+            task_title="Second existing issue handoff",
+            source_file=str(tmp_path / "existing-2.json"),
+            eligible=False,
+            reason="existing_issue",
+        ),
+    ]
+
+    assert mod.summarize_decisions(decisions) == {
+        "total": 3,
+        "eligible_count": 1,
+        "ineligible_count": 2,
+        "reason_counts": {
+            "eligible": 1,
+            "existing_issue": 2,
+        },
+    }
+
+
 def test_referenced_pr_numbers_deduplicates_multiple_mentions(tmp_path: Path) -> None:
     handoff = Handoff(
         source_file=str(tmp_path / "memory.md"),
@@ -1629,7 +1662,16 @@ def test_main_preview_does_not_write_outbox_receipt(
 
     assert exit_code == 0
     assert not receipts.exists()
-    assert '"reason": "existing_issue"' in capsys.readouterr().out
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["decisions"][0]["reason"] == "existing_issue"
+    assert payload["decision_summary"] == {
+        "total": 1,
+        "eligible_count": 0,
+        "ineligible_count": 1,
+        "reason_counts": {
+            "existing_issue": 1,
+        },
+    }
 
 
 def test_main_accepts_explicit_dry_run_alias(monkeypatch: Any, tmp_path: Path, capsys) -> None:
@@ -1809,9 +1851,17 @@ def test_main_reports_github_health_when_unavailable(
     exit_code = mod.main(["--repo", str(tmp_path), "--codex-home", str(tmp_path), "--json"])
 
     assert exit_code == 1
-    out = capsys.readouterr().out
-    assert '"mode": "connectivity_failed"' in out
-    assert '"reason": "github_unavailable"' in out
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["github_health"]["mode"] == "connectivity_failed"
+    assert payload["decisions"][0]["reason"] == "github_unavailable"
+    assert payload["decision_summary"] == {
+        "total": 1,
+        "eligible_count": 0,
+        "ineligible_count": 1,
+        "reason_counts": {
+            "github_unavailable": 1,
+        },
+    }
 
 
 def test_main_limits_github_unavailable_decision_preview(
@@ -1860,6 +1910,14 @@ def test_main_limits_github_unavailable_decision_preview(
     assert len(payload["decisions"]) == 1
     assert payload["decisions"][0]["task_title"] == "First offline handoff"
     assert payload["decisions"][0]["reason"] == "github_unavailable"
+    assert payload["decision_summary"] == {
+        "total": 1,
+        "eligible_count": 0,
+        "ineligible_count": 1,
+        "reason_counts": {
+            "github_unavailable": 1,
+        },
+    }
 
 
 def test_create_issue_truncates_oversized_body(monkeypatch: Any, tmp_path: Path) -> None:


### PR DESCRIPTION
Publishes the prepared protected automation handoff branch.

Summary:
- Adds `decision_summary` output to `publish_automation_handoffs.py`.
- Lets automation monitors see aggregate eligible/ineligible/reason counts without parsing every individual decision row.
- Includes focused tests for decision summary counts and JSON output.

Validation:
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_publish_automation_handoffs.py -p no:rerunfailures -p no:cacheprovider`
- `python3 -m ruff check scripts/publish_automation_handoffs.py tests/scripts/test_publish_automation_handoffs.py`
- `python3 -m ruff format --check scripts/publish_automation_handoffs.py tests/scripts/test_publish_automation_handoffs.py`
- `python3 -m mypy scripts/publish_automation_handoffs.py`
- `git diff --check origin/main...HEAD`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
