### PR TITLE
fix(preflight): reject nested rescue publish artifacts

### DIFF
--- a/scripts/automation_pr_preflight.sh
+++ b/scripts/automation_pr_preflight.sh
@@ -159,7 +159,7 @@ if [[ -n "${forbidden_files}" ]]; then
     exit 1
 fi
 
-rescue_publish_regex='(^|/)(rescue_productization|rescue-productization)/(latest\.json|rescue-productization-[0-9]{8}T[0-9]{6}Z\.json)$'
+rescue_publish_regex='(^|/)rescue-productization-[0-9]{8}T[0-9]{6}Z\.json$|(^|/)(rescue_productization|rescue-productization)(/.*)?/(latest\.json|rescue-productization-[0-9]{8}T[0-9]{6}Z\.json)$'
 rescue_publish_files="$(printf '%s\n' "${changed_files}" | grep -E "${rescue_publish_regex}" || true)"
 if [[ -n "${rescue_publish_files}" ]]; then
     if [[ "${JSON_MODE}" == "true" ]]; then

--- a/scripts/automation_pr_preflight.sh
+++ b/scripts/automation_pr_preflight.sh
@@ -49,7 +49,7 @@ emit_json() {
     export PREFLIGHT_DOCS_ONLY="${docs_only}"
     export PREFLIGHT_FORBIDDEN_FILES="${forbidden_files}"
     export PREFLIGHT_RESCUE_PUBLISH_FILES="${rescue_publish_files}"
-    python3 - <<'PY'
+    python3 -c '
 import json
 import os
 import shlex
@@ -88,7 +88,7 @@ error = os.environ.get("PREFLIGHT_ERROR", "")
 if error:
     payload["error"] = error
 print(json.dumps(payload, sort_keys=True))
-PY
+'
 }
 
 fail_preflight() {

--- a/tests/scripts/test_automation_pr_preflight.py
+++ b/tests/scripts/test_automation_pr_preflight.py
@@ -220,6 +220,35 @@ def test_automation_pr_preflight_rejects_rescue_publish_latest_pointer(
     assert "published/rescue-productization/latest.json" in proc.stderr
 
 
+def test_automation_pr_preflight_rejects_nested_rescue_publish_pointers(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _run(["git", "switch", "-c", "codex/bad-nested-rescue-publish"], cwd=repo)
+    timestamped = repo / "published" / "rescue-productization-20260516T162243Z.json"
+    latest = repo / "published" / "rescue_productization" / "snapshots" / "latest.json"
+    latest.parent.mkdir(parents=True)
+    timestamped.write_text("{}\n", encoding="utf-8")
+    latest.write_text("{}\n", encoding="utf-8")
+    _run(
+        [
+            "git",
+            "add",
+            "published/rescue-productization-20260516T162243Z.json",
+            "published/rescue_productization/snapshots/latest.json",
+        ],
+        cwd=repo,
+    )
+    _run(["git", "commit", "-m", "bad: commit nested rescue publish artifacts"], cwd=repo)
+
+    proc = _run(["bash", str(SCRIPT), "origin/main", "HEAD"], cwd=repo)
+
+    assert proc.returncode == 1
+    assert "rescue productization publish artifacts" in proc.stderr
+    assert "published/rescue-productization-20260516T162243Z.json" in proc.stderr
+    assert "published/rescue_productization/snapshots/latest.json" in proc.stderr
+
+
 def test_automation_pr_preflight_accepts_unrelated_latest_json(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- reject nested rescue productization publish artifacts in automation preflight
- preserve unrelated latest.json paths
- fix JSON-mode preflight output to avoid stdin/heredoc hangs observed during validation

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_automation_pr_preflight.py -p no:rerunfailures -p no:cacheprovider` -> 13 passed
- `bash -n scripts/automation_pr_preflight.sh` -> passed
- `python3 -m ruff check tests/scripts/test_automation_pr_preflight.py` -> passed
- `python3 -m ruff format --check tests/scripts/test_automation_pr_preflight.py` -> passed
- `python3 -m mypy tests/scripts/test_automation_pr_preflight.py` -> passed
- `git diff --check origin/main...HEAD` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> passed
- `timeout 10 bash scripts/automation_pr_preflight.sh --json origin/main HEAD` -> passed

## Non-touches
No #7292/Q20, P72/#7362, P73/#7363, P74/#7365, cleanup worktrees, branch deletion, labels, issues, launchd, automation.toml, or raw transcripts.
