### PR TITLE
docs(governance): ADC continuation wave readiness packet

### DIFF
--- a/docs/governance/ADC_AUTONOMOUS_CONTINUATION_WAVE_2026-05-19.md
+++ b/docs/governance/ADC_AUTONOMOUS_CONTINUATION_WAVE_2026-05-19.md
@@ -1,0 +1,81 @@
+# ADC Autonomous Continuation Wave — 2026-05-19
+
+**Status:** execution spec, strict-gated
+**Worktree:** `codex/droid-20260519-151711-92e43188`
+**Primary gate:** do not dispatch ADC v0.7 until the operator explicitly authorizes it after reviewing the v0.1-v0.4 merge-readiness packet.
+
+## Objective
+
+Preserve the Aragora Delegation Contract (ADC) planning artifacts, make the v0.8 cross-family adapter plan reviewable, produce a current merge-readiness packet for the v0.1-v0.4 base stack, and prepare-but-park v0.8 worker prompts. This wave intentionally favors operator legibility over additional autonomous fan-out.
+
+## Hard boundaries
+
+- No v0.7 dispatch in this turn.
+- No P75 / P76 / settlement-UI dispatch from the context sweep.
+- No PR merges, mark-ready, labels, force-push, protected-file edits, worker killing, foreign worktree cleanup, or branch cleanup.
+- No edits to `CLAUDE.md`, `aragora/__init__.py`, `.env`, `.envrc`, `scripts/nomic_loop.py`, `docs/AGENT_OPERATING_CONTRACT.md`, `docs/governance/OPERATOR_DELEGATION_POLICY.md`, or `automation.toml`.
+- Any worker prompt created by this wave is parked only.
+
+## Execution flow
+
+```mermaid
+flowchart TD
+    A[Truth refresh] --> B[Wave spec]
+    B --> C[v0.8 plan]
+    C --> D[Merge packet]
+    D --> E[Context sweep]
+    E --> F[Parked prompts]
+    F --> G[Validate]
+    G --> H[Draft PR]
+```
+
+## ADC base-stack gate
+
+Canonical audit order from `ADC_v0.1-v0.4_STACK_AUDIT.md`:
+
+1. `#7357` — ADC v0.1 schema + predicate oracle
+2. `#7361` — ADC v0.4 HMAC signing
+3. `{#7358, #7360}` — ADC v0.2 lane-registry hookup and v0.3 progress ledger
+
+Current gate result is captured in `ADC_v0.1-v0.4_MERGE_READINESS_2026-05-19.md`.
+
+Key outcome: `#7357` is merged, but `#7361` is currently `CONFLICTING` / `DIRTY`. Therefore the original audit order has drifted and v0.7 remains parked until the operator either resolves/rebases v0.4 or explicitly authorizes a named integration branch.
+
+## Context sweep
+
+Read-only sweep result:
+
+```text
+P75 agent_overlap_report.py: in-flight — #7354 open draft, DIRTY/CONFLICTING, branch droid/P75-agent-overlap-report-20260519.
+P76 blocked_auth_failure: in-flight — #7352 open draft, DIRTY, branch codex/droid-20260519-042102-21e078d9; older #7265 merged, #7271 closed.
+Settlement UI: in-flight — #7268 open draft, CLEAN, branch codex/settlement-packet-ui-20260517; older #7266 closed.
+Older queue-settlement packet: in-flight — #7263 open draft, BLOCKED, branch worktree-open-queue-settlement-2026-05-17; #7279 operator-decisions ingestion is merged.
+```
+
+No follow-up dispatch is authorized from this sweep. It exists only to reduce duplicate work and keep the next fan-out decision legible.
+
+## Parked v0.8 prompt pack
+
+Dispatcher-local prompts were prepared under `.aragora/v16-dispatch/`:
+
+- `ADC-v0.8-envelope-and-validator.md`
+- `ADC-v0.8-droid-adapter.md`
+- `ADC-v0.8-claude-codex-stubs.md`
+
+They are explicitly parked until v0.7 ships or the operator waives that prerequisite.
+
+## Operator decision needed
+
+To unblock v0.7, choose one:
+
+1. Resolve and land the base stack in a refreshed order after rebasing `#7361`; or
+2. Authorize a named integration branch containing v0.1-v0.4 and dispatch v0.7 against that branch.
+
+Until that decision is made, the correct autonomous action is documentation, readiness reporting, and prompt preparation only.
+
+## Validation requirements for this wave
+
+- `git diff --check`
+- Review `git diff` / `git diff --cached` for secrets or sensitive local paths.
+- Run `bash scripts/automation_pr_preflight.sh origin/main HEAD` before pushing the docs-only PR.
+- Open one draft PR with no labels.

--- a/docs/governance/ADC_AUTONOMOUS_CONTINUATION_WAVE_2026-05-19.md
+++ b/docs/governance/ADC_AUTONOMOUS_CONTINUATION_WAVE_2026-05-19.md
@@ -39,7 +39,7 @@ Canonical audit order from `ADC_v0.1-v0.4_STACK_AUDIT.md`:
 
 Current gate result is captured in `ADC_v0.1-v0.4_MERGE_READINESS_2026-05-19.md`.
 
-Key outcome: `#7357` is merged, but `#7361` is currently `CONFLICTING` / `DIRTY`. Therefore the original audit order has drifted and v0.7 remains parked until the operator either resolves/rebases v0.4 or explicitly authorizes a named integration branch.
+Key outcome: `#7357` is merged, `#7361` has been repaired/rebased at head `9093ddbc48ac4dd2ccaa3364b527b660c089a41e`, and `#7361`, `#7358`, and `#7360` are all `MERGEABLE` / `BLOCKED` on review with no failing checks. The original audit order is mechanically restored, but v0.7 remains parked until the operator merges the base stack or explicitly authorizes a named integration branch.
 
 ## Context sweep
 
@@ -66,12 +66,23 @@ They are explicitly parked until v0.7 ships or the operator waives that prerequi
 
 ## Operator decision needed
 
-To unblock v0.7, choose one:
+To unblock v0.7:
 
-1. Resolve and land the base stack in a refreshed order after rebasing `#7361`; or
-2. Authorize a named integration branch containing v0.1-v0.4 and dispatch v0.7 against that branch.
+1. Merge/review the base stack in order `#7361 → {#7358, #7360}`; then
+2. Authorize v0.7 dispatch from current `main` using `.aragora/v16-dispatch/dispatch-adc-v0.7.sh`.
 
 Until that decision is made, the correct autonomous action is documentation, readiness reporting, and prompt preparation only.
+
+## Adjacent Lane Sweep — 2026-05-19T16:20Z
+
+```text
+P75 agent_overlap_report.py: in-flight — #7354 open draft, DIRTY/CONFLICTING, branch droid/P75-agent-overlap-report-20260519; older #7270 closed unmerged, #7267 merged adjacent overlap-detector work.
+P76 blocked_auth_failure: in-flight — #7352 open draft, DIRTY, branch codex/droid-20260519-042102-21e078d9; older #7265 merged, #7271 closed.
+Settlement UI: in-flight — #7268 open draft, CLEAN, branch codex/settlement-packet-ui-20260517; older #7266 closed unmerged.
+Older queue-settlement work: stale — #7263 open draft/BLOCKED, #7278 open draft/CLEAN but stacked on closed #7277, and #7279 operator-decisions ingestion merged.
+```
+
+No adjacent-lane dispatch is authorized from this sweep.
 
 ## Validation requirements for this wave
 

--- a/docs/governance/ADC_v0.1-v0.4_MERGE_READINESS_2026-05-19.md
+++ b/docs/governance/ADC_v0.1-v0.4_MERGE_READINESS_2026-05-19.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-05-19
 **Purpose:** operator-visible gate before any ADC v0.7 dispatch
-**Verdict:** **BLOCKED — do not dispatch v0.7 yet**
+**Verdict:** **READY_FOR_OPERATOR_REVIEW — base stack mergeable; awaiting operator merge**
 
 ## Summary
 
@@ -12,16 +12,16 @@ The previous stack audit recommended merge order:
 #7357 → #7361 → {#7358, #7360}
 ```
 
-That order has drifted. `#7357` is now merged, but `#7361` is currently `CONFLICTING` / `DIRTY` against `main`, so the second step in the audit order is no longer directly mergeable. v0.7 must remain parked until the operator either resolves/rebases v0.4 or explicitly authorizes a named integration branch.
+The audit order is mechanically restored after `#7361`'s rebase (head `9093ddbc48ac4dd2ccaa3364b527b660c089a41e`). `#7357` is merged; `#7361`, `#7358`, and `#7360` are all `MERGEABLE` / `BLOCKED` on review and may be merged in the audit order.
 
 ## PR readiness table
 
 | PR | Version | State | Draft | Head SHA | Mergeable | Merge state | CI rollup | Blockers | Recommendation |
 |---|---|---:|---:|---|---|---|---|---|---|
 | [#7357](https://github.com/synaptent/aragora/pull/7357) | v0.1 schema + predicate oracle | MERGED | no | `94f0b688129b0b121b091ddc9f4c93fe257a046d` | UNKNOWN | UNKNOWN | 88 total: 62 success, 25 skipped, 1 cancelled | already merged | `ready-for-base` / no action |
-| [#7361](https://github.com/synaptent/aragora/pull/7361) | v0.4 HMAC signing | OPEN | yes | `e39a558c6639ca906a543064ccabeb2587f9dc49` | CONFLICTING | DIRTY | 70 total: 17 success, 53 skipped, 0 failure, 0 pending | draft, review-required, conflicts with current `main` | `needs-rebase` |
-| [#7358](https://github.com/synaptent/aragora/pull/7358) | v0.2 lane-registry hookup | OPEN | yes | `d926a9749f23b8ac097a2ec8573df7e63a11f738` | MERGEABLE | BLOCKED | 6 total: 4 success, 2 skipped, 0 failure, 0 pending | draft + review-required | `needs-review` / later merge after v0.4 is resolved |
-| [#7360](https://github.com/synaptent/aragora/pull/7360) | v0.3 progress ledger | OPEN | yes | `7b0cf9ea426fe2cc78b3e7298f1db7618931a8db` | MERGEABLE | BLOCKED | 70 total: 17 success, 53 skipped, 0 failure, 0 pending | draft + review-required | `needs-review` / later merge after v0.4 is resolved |
+| [#7361](https://github.com/synaptent/aragora/pull/7361) | v0.4 HMAC signing | OPEN | yes | `9093ddbc48ac4dd2ccaa3364b527b660c089a41e` | MERGEABLE | BLOCKED | 68 total: 16 success, 52 skipped, 0 failure, 0 cancelled | draft, review-required | `needs-review` |
+| [#7358](https://github.com/synaptent/aragora/pull/7358) | v0.2 lane-registry hookup | OPEN | yes | `d926a9749f23b8ac097a2ec8573df7e63a11f738` | MERGEABLE | BLOCKED | 6 total: 4 success, 2 skipped, 0 failure, 0 pending | draft + review-required | `needs-review` |
+| [#7360](https://github.com/synaptent/aragora/pull/7360) | v0.3 progress ledger | OPEN | yes | `7b0cf9ea426fe2cc78b3e7298f1db7618931a8db` | MERGEABLE | BLOCKED | 70 total: 17 success, 53 skipped, 0 failure, 0 pending | draft + review-required | `needs-review` |
 
 ## File-overlap observations
 
@@ -47,18 +47,12 @@ All three open ADC PRs still touch parts of the v0.1 trust-kernel surface:
 
 ## Gate conclusion
 
-The audit order remains conceptually correct, but it is no longer mechanically ready because `#7361` must be rebased or otherwise repaired after `#7357` landed.
+The audit order is mechanically ready again: `#7357` is merged, `#7361` has been rebased onto current `main`, and `#7358` / `#7360` are independently mergeable.
 
-Do **not** dispatch ADC v0.7 until one of these happens:
-
-1. `#7361` is rebased/repaired and the base stack lands in a refreshed order; or
-2. the operator explicitly authorizes an integration branch containing v0.1-v0.4 as the v0.7 base.
+ADC v0.7 may be dispatched once the operator merges the base stack (`#7361`, then `#7358` and `#7360`). The merge decision is operator-only; no agent should auto-merge.
 
 ## Operator decision needed
 
-Choose one:
-
-- **Repair-and-merge path:** rebase/repair `#7361`, then settle `#7358` and `#7360`.
-- **Integration-branch path:** authorize a named branch that composes `#7361`, `#7358`, and `#7360` on top of current `main`, then dispatch v0.7 against that branch.
+Merge the base stack in order `#7361 → {#7358, #7360}`, then authorize v0.7 dispatch by running the prepared invocation at `.aragora/v16-dispatch/dispatch-adc-v0.7.sh`.
 
 No merges, labels, ready-state flips, or v0.7 dispatches were performed by this packet.

--- a/docs/governance/ADC_v0.1-v0.4_MERGE_READINESS_2026-05-19.md
+++ b/docs/governance/ADC_v0.1-v0.4_MERGE_READINESS_2026-05-19.md
@@ -1,0 +1,64 @@
+# ADC v0.1 → v0.4 Merge Readiness Packet
+
+**Date:** 2026-05-19
+**Purpose:** operator-visible gate before any ADC v0.7 dispatch
+**Verdict:** **BLOCKED — do not dispatch v0.7 yet**
+
+## Summary
+
+The previous stack audit recommended merge order:
+
+```text
+#7357 → #7361 → {#7358, #7360}
+```
+
+That order has drifted. `#7357` is now merged, but `#7361` is currently `CONFLICTING` / `DIRTY` against `main`, so the second step in the audit order is no longer directly mergeable. v0.7 must remain parked until the operator either resolves/rebases v0.4 or explicitly authorizes a named integration branch.
+
+## PR readiness table
+
+| PR | Version | State | Draft | Head SHA | Mergeable | Merge state | CI rollup | Blockers | Recommendation |
+|---|---|---:|---:|---|---|---|---|---|---|
+| [#7357](https://github.com/synaptent/aragora/pull/7357) | v0.1 schema + predicate oracle | MERGED | no | `94f0b688129b0b121b091ddc9f4c93fe257a046d` | UNKNOWN | UNKNOWN | 88 total: 62 success, 25 skipped, 1 cancelled | already merged | `ready-for-base` / no action |
+| [#7361](https://github.com/synaptent/aragora/pull/7361) | v0.4 HMAC signing | OPEN | yes | `e39a558c6639ca906a543064ccabeb2587f9dc49` | CONFLICTING | DIRTY | 70 total: 17 success, 53 skipped, 0 failure, 0 pending | draft, review-required, conflicts with current `main` | `needs-rebase` |
+| [#7358](https://github.com/synaptent/aragora/pull/7358) | v0.2 lane-registry hookup | OPEN | yes | `d926a9749f23b8ac097a2ec8573df7e63a11f738` | MERGEABLE | BLOCKED | 6 total: 4 success, 2 skipped, 0 failure, 0 pending | draft + review-required | `needs-review` / later merge after v0.4 is resolved |
+| [#7360](https://github.com/synaptent/aragora/pull/7360) | v0.3 progress ledger | OPEN | yes | `7b0cf9ea426fe2cc78b3e7298f1db7618931a8db` | MERGEABLE | BLOCKED | 70 total: 17 success, 53 skipped, 0 failure, 0 pending | draft + review-required | `needs-review` / later merge after v0.4 is resolved |
+
+## File-overlap observations
+
+All three open ADC PRs still touch parts of the v0.1 trust-kernel surface:
+
+- `aragora/policy/__init__.py`
+- `aragora/policy/delegation_contract.py`
+- `aragora/policy/predicate_oracle.py`
+- `docs/governance/DELEGATION_CONTRACT_V0_1_SPEC.md`
+- `tests/policy/test_delegation_contract.py`
+- `tests/policy/test_predicate_oracle.py`
+
+`#7361` additionally adds signing-specific surfaces:
+
+- `aragora/policy/contract_signing.py`
+- `scripts/sign_delegation_contract.py`
+- `tests/policy/test_contract_signing.py`
+- `tests/scripts/test_sign_delegation_contract.py`
+
+`#7358` adds the lane-registry integration in `scripts/claim_active_agent_lane.py`.
+
+`#7360` adds the progress evaluator in `scripts/evaluate_goal_progress.py`.
+
+## Gate conclusion
+
+The audit order remains conceptually correct, but it is no longer mechanically ready because `#7361` must be rebased or otherwise repaired after `#7357` landed.
+
+Do **not** dispatch ADC v0.7 until one of these happens:
+
+1. `#7361` is rebased/repaired and the base stack lands in a refreshed order; or
+2. the operator explicitly authorizes an integration branch containing v0.1-v0.4 as the v0.7 base.
+
+## Operator decision needed
+
+Choose one:
+
+- **Repair-and-merge path:** rebase/repair `#7361`, then settle `#7358` and `#7360`.
+- **Integration-branch path:** authorize a named branch that composes `#7361`, `#7358`, and `#7360` on top of current `main`, then dispatch v0.7 against that branch.
+
+No merges, labels, ready-state flips, or v0.7 dispatches were performed by this packet.

--- a/docs/governance/ADC_v0.5_SPEC_DRAFT.md
+++ b/docs/governance/ADC_v0.5_SPEC_DRAFT.md
@@ -1,0 +1,177 @@
+# ADC v0.5 Spec Draft — Continuous Adversarial Verification
+
+**Status:** draft for operator review
+**Depends on:** ADC v0.1-v0.4 base stack, ADC v0.7 lifecycle, ADC v0.8 cross-family adapter
+**Do not implement until:** v0.7 and v0.8 have shipped or the operator explicitly waives that prerequisite.
+
+## Purpose
+
+ADC v0.1-v0.4 define what a delegation contract is, how it is attached to lane claims, how progress is evaluated, and how contracts/receipts are signed. ADC v0.5 adds a continuous adversarial verification loop: every significant agent action is checked by a cheap adversarial reviewer before it executes.
+
+The goal is to catch goal drift, waste, permission laundering, and obviously unsafe actions without relying on coarse periodic spot checks.
+
+## Problem
+
+Periodic spot checks are gameable:
+
+- workers can infer timing patterns;
+- risky actions can be shifted away from check windows;
+- reviewers see too much history and not enough exact action context;
+- a late reviewer can identify a problem after the action has already mutated state.
+
+The safer shape is a lightweight check at every action boundary, with escalation only when the cheap check raises a concrete concern.
+
+## Design principle
+
+The adversarial verifier is not a second autonomous operator. It is a narrow reviewer with one job:
+
+> Find reasons the proposed action should not execute under the current delegation contract and goal spec.
+
+It returns either:
+
+- `PROCEED`: action aligns with contract, goal, and current lifecycle state; or
+- `HALT`: concrete concern, suggested narrower action, and escalation target.
+
+## Action boundary
+
+ADC v0.5 should initially gate these action classes:
+
+| Class | Examples | v0.5 behavior |
+|---|---|---|
+| shared-state write | lane claim, branch push, PR open | adversarial check required |
+| delegation | spawn subagent, issue child contract | adversarial check required |
+| destructive | force-push, delete, kill process | adversarial check + human-only policy; default deny |
+| bounded write | edit own worktree | optional in v0.5, default off unless contract requests |
+| read | file read, PR metadata read | no adversarial check by default |
+
+## Inputs
+
+Each check receives a compact, structured payload:
+
+```json
+{
+  "schema_version": "aragora-adversarial-action-check/0.5",
+  "contract_id": "adc-...",
+  "goal_id": "goal-...",
+  "actor_session": "droid-...",
+  "lane_id": "ADC-v0.7-three-tier-reversibility",
+  "action_class": "shared_state",
+  "action_summary": "push branch to draft PR",
+  "target_surface": "branch:codex/example",
+  "expected_progress_delta": ["AC2"],
+  "rollback_plan": "branch push can be superseded by follow-up commit",
+  "recent_lifecycle_state": "active"
+}
+```
+
+The worker does not decide the payload format ad hoc; the launcher/policy layer builds it from the contract, lane registry, and proposed tool action.
+
+## Output
+
+```json
+{
+  "schema_version": "aragora-adversarial-action-verdict/0.5",
+  "verdict": "PROCEED",
+  "concern": null,
+  "suggested_action": null,
+  "confidence": 0.82,
+  "reviewer": "cheap-adversarial-model",
+  "reviewed_at_utc": "2026-05-19T00:00:00Z"
+}
+```
+
+For a halt:
+
+```json
+{
+  "verdict": "HALT",
+  "concern": "Proposed branch push targets a branch outside allowed_surfaces.",
+  "suggested_action": "Open a draft PR from the contract-bound branch only.",
+  "confidence": 0.91
+}
+```
+
+## Reviewer prompt shape
+
+The verifier prompt should be short and adversarial:
+
+```text
+You are an adversarial action verifier. Your job is to find concrete reasons
+this proposed action should NOT execute under the attached delegation contract,
+goal spec, lifecycle state, and authority bounds.
+
+Return PROCEED only if the action is within scope, advances a listed acceptance
+criterion, and does not widen authority. Return HALT with one concrete concern
+otherwise.
+```
+
+## Escalation path
+
+ADC v0.5 does not ask a human for every concern. It uses a staged path:
+
+1. cheap adversarial verifier returns `PROCEED` → action may continue;
+2. cheap verifier returns `HALT` → contested action pauses;
+3. if the worker disagrees, run a bounded heterogeneous debate panel;
+4. debate returns `continue`, `narrow_scope`, `ask_human`, or `halt`;
+5. destructive actions still require explicit human approval regardless of debate result.
+
+```mermaid
+flowchart TD
+    A[Proposed action] --> B[Cheap check]
+    B -->|PROCEED| C[Execute]
+    B -->|HALT| D[Pause action]
+    D --> E[Debate panel]
+    E -->|continue| C
+    E -->|narrow| F[Narrow action]
+    E -->|ask human| G[Operator]
+    E -->|halt| H[Lifecycle halt]
+```
+
+## Aragora wiring
+
+Existing surfaces to compose:
+
+- `aragora/policy/delegation_contract.py`: contract, budget, surfaces, allowed/denied action lists.
+- `aragora/policy/predicate_oracle.py`: artifact-grounded progress predicates.
+- ADC v0.7 `contract_lifecycle.py`: pause/halt/revoke actuator.
+- ADC v0.8 launcher adapter: action boundary and contract propagation.
+- `aragora/debate/`: heterogeneous panel escalation.
+- lane registry: session/lane/contract binding.
+- receipt trio: final audit trail.
+
+## Anti-gaming properties
+
+- The worker sees that checks exist but not hidden reviewer prompts or aggregation details.
+- Checks are action-scoped, not periodic.
+- Reviewer only sees the action context needed to judge scope and intent.
+- Reviewer output is recorded in receipts when it blocks or narrows work.
+
+## Acceptance criteria
+
+An implementation PR should prove:
+
+1. A shared-state action outside allowed surfaces returns `HALT`.
+2. A lane claim inside allowed surfaces returns `PROCEED`.
+3. A destructive action returns `HALT` unless explicitly human-approved in the contract metadata.
+4. A `HALT` verdict can call v0.7 pause/halt hooks without killing a process.
+5. The action-check receipt includes contract id, goal id, lane id, action class, and verdict.
+6. The checker can be disabled for pure read actions.
+7. All tests are deterministic; model calls are mocked.
+
+## Out of scope
+
+- Trust multiplier updates; that is ADC v0.6.
+- Cross-family launch enforcement; that is ADC v0.8.
+- Always-on per-keystroke checks.
+- Giving the verifier authority to mutate state directly.
+- Replacing existing harness/tool safety layers.
+
+## Implementation guidance
+
+Start with a pure-Python policy module and mocked reviewer:
+
+- `aragora/policy/adversarial_check.py`
+- `scripts/evaluate_adversarial_action.py`
+- tests under `tests/policy/` and `tests/scripts/`
+
+Only after deterministic tests pass should a real model-backed reviewer be wired behind a feature flag.

--- a/docs/governance/ADC_v0.6_SPEC_DRAFT.md
+++ b/docs/governance/ADC_v0.6_SPEC_DRAFT.md
@@ -1,0 +1,160 @@
+# ADC v0.6 Spec Draft — ELO Trust Multiplier
+
+**Status:** draft for operator review
+**Depends on:** ADC v0.1-v0.5 evidence surfaces
+**Do not implement until:** v0.5 action-check receipts exist or the operator explicitly authorizes a narrower static-budget slice.
+
+## Purpose
+
+ADC v0.6 makes autonomy budgets trust-adjusted. A static budget is too permissive for unknown agents and too restrictive for agents with a long record of clean, verified work. v0.6 introduces a multiplier that scales contract budgets by agent reliability and action class.
+
+```text
+effective_budget = base_budget × trust_multiplier(agent_id, action_class)
+```
+
+## Problem
+
+ADC v0.1-v0.4 encode scope and budget, but all agents with the same contract receive the same budget. That ignores observed history:
+
+- new or unproven agents should get narrow budgets on risky actions;
+- agents with clean receipts and merged work should earn more autonomy;
+- agents that trigger halts/revocations should lose budget quickly;
+- read-only work should not be penalized the same way as destructive/shared-state work.
+
+## Prior art already in Aragora
+
+Aragora already has agent skill tracking:
+
+- `aragora/ranking/elo.py` tracks comparative agent performance.
+- receipt conventions record lane outcomes.
+- ADC v0.3 progress ledgers record goal progress.
+- ADC v0.5 action-check receipts will record contested/blocked actions.
+
+v0.6 should compose with these rather than creating a parallel reputation system.
+
+## Trust multiplier model
+
+Trust is per `(agent_id, action_class)`, not just global.
+
+| Action class | New agent default | Floor | Ceiling | Notes |
+|---|---:|---:|---:|---|
+| read | 1.0x | 0.5x | 3.0x | Low blast radius; allow discovery. |
+| bounded_write | 0.75x | 0.25x | 2.0x | Own worktree edits / draft docs. |
+| shared_state | 0.5x | 0.1x | 1.5x | Lane claims, branch pushes, draft PRs. |
+| delegation | 0.25x | 0.0x | 1.0x | Spawn child worker / issue child contract. |
+| destructive | 0.1x | 0.0x | 0.25x | Still human-only unless explicitly granted. |
+
+The default values are policy recommendations, not hard-coded constants. Implementation should make them configurable.
+
+## Inputs
+
+Trust updates should be based on verified events:
+
+| Event | Effect |
+|---|---|
+| contract completed and acceptance criteria satisfied | increase multiplier for relevant action classes |
+| draft PR opened with green checks | small increase for bounded/shared-state actions |
+| merged PR without revert after observation window | larger increase |
+| ADC v0.5 `HALT` verdict | decrease for action class that triggered halt |
+| lifecycle `halt` event | decrease across bounded/shared/delegation classes |
+| lifecycle `revoke` event | strong decrease; delegation may go to zero |
+| failed checks after branch push | decrease shared-state multiplier |
+| repeated no-progress ledger ticks | decrease bounded-write multiplier |
+
+All updates must cite a receipt, PR, check run, or progress-ledger tick.
+
+## Data model
+
+Draft record:
+
+```json
+{
+  "schema_version": "aragora-adc-trust-multiplier/0.6",
+  "agent_id": "droid-...",
+  "action_class": "shared_state",
+  "multiplier": 0.75,
+  "updated_at_utc": "2026-05-19T00:00:00Z",
+  "source_event": {
+    "kind": "pr_checks_green",
+    "pr": 7367,
+    "receipt_sha256": "..."
+  },
+  "previous_multiplier": 0.5,
+  "reason": "draft PR opened with green checks"
+}
+```
+
+Storage should be append-only JSONL first, with a later move to a persistent store if needed.
+
+## Budget application
+
+The contract still defines the hard base budget. Trust only scales downward/upward within policy caps.
+
+```python
+effective = min(
+    contract_budget_for_action * trust_multiplier,
+    operator_max_budget_for_action,
+)
+```
+
+If the contract explicitly sets `trust_multiplier_override`, that override must be operator-signed and recorded in the receipt.
+
+## Anti-gaming
+
+- The agent should not update its own multiplier.
+- Multipliers update from external receipts/checks, not self-reported progress.
+- The worker may know its current budget, but not the exact pending update formula for the current action.
+- Collusion checks are out of scope for v0.6 but should be called out in receipts when the same agent family verifies itself.
+
+## Aragora wiring
+
+Potential implementation surfaces:
+
+- `aragora/ranking/elo.py`: source of baseline reliability where available.
+- `aragora/policy/delegation_contract.py`: apply trust-adjusted effective budget.
+- ADC v0.3 progress ledger: no-progress / regression signals.
+- ADC v0.5 adversarial checks: contested action signals.
+- ADC v0.7 lifecycle: halt/revoke signals.
+- ADC v0.8 launcher adapter: effective budget propagation into child process environment.
+
+## State transitions
+
+```mermaid
+stateDiagram
+    [*] --> Unknown
+    Unknown --> Limited: first contract
+    Limited --> Trusted: verified successes
+    Trusted --> Limited: halt or failed checks
+    Limited --> Suspended: revoke or repeated halts
+    Suspended --> Limited: operator reset
+```
+
+## Acceptance criteria
+
+An implementation PR should prove:
+
+1. New agents receive lower multipliers for delegation/destructive classes than read-only classes.
+2. A green-check receipt increases the bounded/shared multiplier within caps.
+3. A halt/revoke event decreases the relevant multiplier.
+4. Multipliers cannot raise effective budget above operator cap.
+5. Trust updates require a cited external event.
+6. Agent self-reported progress alone cannot update trust.
+7. The trust multiplier used for a contract is recorded in the contract/dispatch receipt.
+
+## Out of scope
+
+- Federated trust across Aragora instances.
+- Collusion detection between model families.
+- Real-time marketplace pricing.
+- Penalizing an agent for unrelated infrastructure failures unless the evidence ties to its action.
+- Replacing human approval for destructive actions.
+
+## Implementation guidance
+
+Start with:
+
+- `aragora/policy/trust_multiplier.py`
+- `scripts/update_trust_multiplier.py`
+- tests with synthetic receipts and lifecycle events
+
+Do not wire to real model calls or live PR mutation in v0.6. Keep all update sources deterministic and receipt-backed.

--- a/docs/governance/ADC_v0.8_CROSS_FAMILY_ADAPTER_PLAN.md
+++ b/docs/governance/ADC_v0.8_CROSS_FAMILY_ADAPTER_PLAN.md
@@ -1,0 +1,203 @@
+# ADC v0.8 Cross-Family Adapter Plan
+
+**Date:** 2026-05-19
+**Status:** planning artifact
+**Depends on:** ADC v0.1 (#7357), v0.2 (#7358), v0.3 (#7360), v0.4 (#7361), and v0.7 (three-tier reversibility)
+
+## Purpose
+
+ADC v0.1-v0.4 made delegation contracts typed, attachable to lane claims, progress-measurable, and signable. The remaining gap is cross-family enforcement: a Claude, Factory Droid, Codex CLI, or Codex Desktop worker can still be launched without reading the parent contract that authorized it.
+
+v0.8 turns the contract into a launcher-level boundary. A dispatcher passes `--parent-contract <path>` when spawning a worker. The launcher validates the contract envelope, intersects it with the harness's native permissions, and gives the child worker only the narrowed effective authority.
+
+## Non-goals
+
+- Do not replace existing harness safety layers.
+- Do not grant a child worker any permission not already allowed by the harness.
+- Do not implement per-tool enforcement in the first v0.8 slice; start with launch-time validation, environment propagation, lane-registry binding, and receipt linkage.
+- Do not force every family to adopt a complete ADC runtime at once. v0.8 starts with a droid-first adapter and stubs for Claude/Codex surfaces.
+- Do not launch or control live workers from this plan document.
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+    participant H as Human
+    participant D as Disp
+    participant C as Contract
+    participant L as Launch
+    participant W as Worker
+    participant R as Registry
+    participant P as Policy
+    participant O as Oracle
+
+    H->>D: approve goal + budget
+    D->>C: write contract envelope
+    D->>L: launch --parent-contract
+    L->>P: intersect native + contract caps
+    L->>W: pass env + contract file
+    W->>R: claim lane with contract_id
+    W->>P: check before mutation
+    W->>O: evaluate progress predicates
+    W->>R: receipt + release
+```
+
+Legend: `Disp` = dispatcher, `Registry` = lane registry, `Oracle` = deterministic predicate oracle.
+
+## Contract-on-disk envelope
+
+The cross-family lingua franca is a canonical JSON envelope written into the dispatcher's worktree and copied into the child worktree.
+
+```json
+{
+  "schema_version": "aragora-contract-envelope/0.8",
+  "envelope_id": "adc-env-...",
+  "created_at_utc": "2026-05-19T00:00:00Z",
+  "issuer_family": "claude|droid|codex|factory|operator",
+  "target_family": "droid|claude|codex",
+  "parent_contract_id": "adc-...",
+  "contract": {},
+  "goal": {},
+  "signature": "hex-or-null",
+  "launcher_metadata": {
+    "repo": "synaptent/aragora",
+    "base_ref": "origin/main",
+    "lane_id": "ADC-v0.8-cross-family-adapter",
+    "dispatch_tool": "launch_lane.sh"
+  }
+}
+```
+
+Rules:
+
+1. `contract` is the v0.1 `DelegationContract` payload.
+2. `goal` is the v0.1 `GoalSpec` payload or a `goal_id` reference if the full goal spec is already stored locally.
+3. `signature` uses v0.4 signing when available; unsigned envelopes are permitted only for explicit dry-run/dev modes.
+4. The launcher must copy the envelope into the child worktree as `ADC_PARENT_CONTRACT.json` and set `ARAGORA_PARENT_CONTRACT=<absolute-path>`.
+5. Receipts must include `envelope_id`, `contract_id`, `goal_id`, and `parent_contract_id`.
+
+## Permission intersection
+
+The adapter never widens authority. Effective permissions are the intersection of three sets:
+
+```text
+effective_allowed = native_allowed ∩ contract.allowed_actions ∩ adapter_capabilities
+effective_denied  = native_denied ∪ contract.denied_actions ∪ adapter_denied
+effective_budget  = min(native_budget, contract_budget, adapter_budget)
+```
+
+If an action is both allowed and denied, denied wins.
+
+### Action classes
+
+| Class | Examples | v0.8 handling |
+|---|---|---|
+| read | file read, grep, PR metadata read | allowed when within contract scope |
+| bounded_write | edits in child worktree, draft PR | allowed only when contract permits matching file/branch surfaces |
+| shared_state | lane registry claim, branch push | requires contract id binding in the lane row / receipt |
+| destructive | force-push, delete worktree, kill process | denied unless explicit human-only path exists; v0.8 should not automate it |
+| delegation | spawn subagent | allowed only when `max_depth > 0` and child contract narrows parent |
+
+## Adapter targets
+
+### 1. Droid adapter (primary)
+
+This is the first real implementation target because Factory Droid workers are already launched through wrapper scripts.
+
+Implementation shape:
+
+1. Add a tracked wrapper or extend the existing tracked launcher surface with `--parent-contract <path>`.
+2. Validate the envelope before spawning `droid exec`.
+3. Copy the envelope to the worker worktree as `ADC_PARENT_CONTRACT.json`.
+4. Export:
+   - `ARAGORA_PARENT_CONTRACT`
+   - `ARAGORA_DELEGATION_CONTRACT_ID`
+   - `ARAGORA_GOAL_ID`
+   - `ARAGORA_CONTRACT_ENVELOPE_ID`
+5. Inject a short preamble into the worker prompt requiring:
+   - lane claim with `delegation_contract_id`;
+   - receipt fields binding to the envelope;
+   - no action outside the effective permission set.
+
+### 2. Claude adapter (stub)
+
+Claude Code does not expose the same generic launch surface in this repo. v0.8 should define a stub contract-reader that a Claude session can run at startup:
+
+```bash
+python3 scripts/validate_parent_contract.py --parent-contract "$ARAGORA_PARENT_CONTRACT"
+```
+
+The stub should validate and print the effective scope but does not claim to enforce tool calls inside Claude Code. That honesty boundary is important.
+
+### 3. Codex adapter (stub)
+
+Codex CLI / Desktop surfaces should start as read-only validation and receipt binding:
+
+- validate envelope before a Codex worker starts;
+- record `contract_id` / `goal_id` in lane claim metadata;
+- include the fields in receipts;
+- defer deeper Codex runtime control to a later family-specific integration.
+
+## Lifecycle integration
+
+v0.8 should depend on v0.7 for pause / halt / revoke state. Launchers should check contract state at startup:
+
+| State | Launch behavior |
+|---|---|
+| active | proceed |
+| paused | refuse launch with clear message |
+| halted | refuse launch; terminal |
+| revoked | refuse launch; verification fails |
+
+For already-running workers, v0.8 only requires a heartbeat-level poll. Hard process control is out of scope for the first slice.
+
+## Build sequence
+
+1. Land or integrate v0.1-v0.4 per `ADC_v0.1-v0.4_STACK_AUDIT.md`.
+2. Land v0.7 lifecycle state machine.
+3. Add `scripts/validate_parent_contract.py`.
+4. Add contract-envelope dataclass/helpers under `aragora/policy/contract_envelope.py`.
+5. Add droid launcher support for `--parent-contract`.
+6. Add lane-claim / receipt binding checks.
+7. Add Claude/Codex validation stubs.
+8. Dogfood by launching the next droid mission with a parent contract and verifying the worker claims the lane with the contract id.
+
+## Acceptance criteria
+
+- A valid signed envelope can be validated and copied into a child worktree.
+- An invalid, revoked, halted, or paused envelope refuses launch before any worker starts.
+- The droid launch path exports contract environment variables.
+- The child lane claim contains `delegation_contract_id`.
+- The worker receipt contains `envelope_id`, `contract_id`, and `goal_id`.
+- Tests cover permission intersection, denied-wins behavior, budget min behavior, paused/halted/revoked launch refusal, and unsigned-dev-mode handling.
+- The first dogfood worker launched after v0.8 is contract-bound.
+
+## Threat model
+
+| Threat | v0.8 mitigation |
+|---|---|
+| Permission laundering across harnesses | parent contract is copied and validated at launch |
+| Harness grants broader native permissions than parent intended | intersection rule narrows authority |
+| Child claims a lane without contract binding | lane-registry check rejects or flags it |
+| Revoked contract is reused | v0.7 lifecycle check refuses launch |
+| Worker fabricates progress | v0.3 predicate oracle remains deterministic and non-LLM |
+| Adapter overclaims enforcement | Claude/Codex adapters are explicitly stubs until hard enforcement exists |
+
+## Open operator decisions
+
+1. Should unsigned envelopes be allowed for local dry-run only, or forbidden entirely once v0.4 is merged?
+2. Should the first droid adapter extend the existing dispatcher script, or add a new tracked `scripts/launch_contract_bound_droid.py` wrapper?
+3. Should a paused contract block launch only, or also ask active workers to release their lane immediately?
+4. Should contract-bound dispatch be required for all ADC lanes after v0.8, or initially opt-in?
+
+## Recommended next implementation slice
+
+Implement the droid adapter first, not the entire cross-family matrix. The smallest useful PR is:
+
+- `aragora/policy/contract_envelope.py`
+- `scripts/validate_parent_contract.py`
+- tracked droid launcher wrapper with `--parent-contract`
+- tests for envelope validation and permission intersection
+- one dogfood receipt showing a contract-bound droid launch in dry-run or draft mode
+
+That slice makes v0.8 real without claiming full hard enforcement for Claude/Codex yet.


### PR DESCRIPTION
## Summary

Docs-only ADC continuation checkpoint:

- Adds the autonomous continuation wave spec with the strict no-v0.7-dispatch gate.
- Adds the ADC v0.8 cross-family adapter plan.
- Adds the ADC v0.1-v0.4 merge-readiness packet.

## Gate result

Do not dispatch ADC v0.7 yet. #7357 is merged, but #7361 is currently DIRTY/CONFLICTING, so the prior audit merge order has drifted. Operator decision needed: repair/rebase #7361 and settle #7358/#7360, or explicitly authorize a named integration branch.

## Validation

- git diff --check
- secret-pattern scan over new docs
- bash scripts/automation_pr_preflight.sh origin/main HEAD

## Boundaries

No workers dispatched. No merges, labels, mark-ready, force-push, process killing, or protected-file edits.