### PR TITLE
feat(scripts): route steering to active PR owners

### DIFF
--- a/scripts/identify_lane_owner.py
+++ b/scripts/identify_lane_owner.py
@@ -69,6 +69,7 @@ FACTORY_BG_PROCESSES_DEFAULT = Path.home() / ".factory" / "background-processes.
 
 # Fuzzy codex rollout search window (seconds).
 CODEX_FUZZY_MAX_AGE_SECONDS = 4 * 60 * 60
+ACTIVE_STATUSES = {"active", "running", "pending", "queued", "claimed"}
 
 # Subprocess timeout for ``agent_bridge operator-snapshot``.
 SNAPSHOT_TIMEOUT_SECONDS = 30
@@ -137,29 +138,43 @@ def find_lane(
     branch: str | None = None,
     worktree: str | None = None,
 ) -> dict[str, Any] | None:
-    """Return the first matching lane record by lane_id > pr > branch > worktree."""
+    """Return the best matching lane record by lane_id > pr > branch > worktree.
+
+    Multiple historical rows can target the same PR/branch/worktree. Prefer an
+    active row, then the most recently updated historical row, so owner lookup
+    does not silently route an operator to a stale completed lane.
+    """
+
+    def best_match(matches: list[dict[str, Any]]) -> dict[str, Any] | None:
+        if not matches:
+            return None
+        active = [
+            r for r in matches if str(r.get("status") or "").strip().lower() in ACTIVE_STATUSES
+        ]
+        pool = active or matches
+        return sorted(pool, key=lambda r: str(r.get("updated_at") or ""), reverse=True)[0]
 
     if lane_id:
-        for r in records:
-            if r.get("lane_id") == lane_id:
-                return r
+        return best_match([r for r in records if r.get("lane_id") == lane_id])
     if pr is not None:
+        matches = []
         for r in records:
             try:
                 if int(r.get("pr_number") or 0) == int(pr):
-                    return r
+                    matches.append(r)
             except (TypeError, ValueError):
                 continue
+        return best_match(matches)
     if branch:
-        for r in records:
-            if r.get("branch") == branch:
-                return r
+        return best_match([r for r in records if r.get("branch") == branch])
     if worktree:
         wt_norm = os.path.normpath(worktree)
+        matches = []
         for r in records:
             rwt = r.get("worktree")
             if rwt and os.path.normpath(rwt) == wt_norm:
-                return r
+                matches.append(r)
+        return best_match(matches)
     return None
 
 

--- a/scripts/identify_lane_owner.py
+++ b/scripts/identify_lane_owner.py
@@ -53,6 +53,7 @@ import subprocess
 import sys
 import time
 from collections.abc import Callable, Sequence
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -70,6 +71,8 @@ FACTORY_BG_PROCESSES_DEFAULT = Path.home() / ".factory" / "background-processes.
 # Fuzzy codex rollout search window (seconds).
 CODEX_FUZZY_MAX_AGE_SECONDS = 4 * 60 * 60
 ACTIVE_STATUSES = {"active", "running", "pending", "queued", "claimed"}
+CONFLICT_STATUSES = {"conflict", "conflicting"}
+COMPLETED_STATUSES = {"completed", "released"}
 
 # Subprocess timeout for ``agent_bridge operator-snapshot``.
 SNAPSHOT_TIMEOUT_SECONDS = 30
@@ -130,6 +133,53 @@ def load_lane_records(registry_path: Path = LANE_REGISTRY_DEFAULT) -> list[dict[
     return [r for r in data if isinstance(r, dict)] if isinstance(data, list) else []
 
 
+def _status_rank(raw_status: Any) -> int:
+    """Rank lane statuses for non-unique selectors; lower is preferred."""
+
+    status = str(raw_status or "").strip().lower()
+    if status in ACTIVE_STATUSES:
+        return 0
+    if status in CONFLICT_STATUSES:
+        return 1
+    if status in COMPLETED_STATUSES:
+        return 2
+    return 3
+
+
+def _updated_at_timestamp(raw_updated_at: Any) -> float:
+    """Parse ``updated_at`` for ordering; invalid or missing values sort oldest."""
+
+    text = str(raw_updated_at or "").strip()
+    if not text:
+        return 0.0
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return 0.0
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.timestamp()
+
+
+def _best_lane_match(matches: Sequence[dict[str, Any]]) -> dict[str, Any] | None:
+    """Return the best row for non-unique selectors like PR, branch, or worktree."""
+
+    if not matches:
+        return None
+    indexed = enumerate(matches)
+    _, best = min(
+        indexed,
+        key=lambda item: (
+            _status_rank(item[1].get("status")),
+            -_updated_at_timestamp(item[1].get("updated_at")),
+            item[0],
+        ),
+    )
+    return best
+
+
 def find_lane(
     records: Sequence[dict[str, Any]],
     *,
@@ -141,21 +191,13 @@ def find_lane(
     """Return the best matching lane record by lane_id > pr > branch > worktree.
 
     Multiple historical rows can target the same PR/branch/worktree. Prefer an
-    active row, then the most recently updated historical row, so owner lookup
-    does not silently route an operator to a stale completed lane.
+    active row, then a conflict row, then the most recently updated completed or
+    released row, so owner lookup does not silently route an operator to a stale
+    completed lane. Exact lane-id lookup preserves registry order.
     """
 
-    def best_match(matches: list[dict[str, Any]]) -> dict[str, Any] | None:
-        if not matches:
-            return None
-        active = [
-            r for r in matches if str(r.get("status") or "").strip().lower() in ACTIVE_STATUSES
-        ]
-        pool = active or matches
-        return sorted(pool, key=lambda r: str(r.get("updated_at") or ""), reverse=True)[0]
-
     if lane_id:
-        return best_match([r for r in records if r.get("lane_id") == lane_id])
+        return next((r for r in records if r.get("lane_id") == lane_id), None)
     if pr is not None:
         matches = []
         for r in records:
@@ -164,9 +206,9 @@ def find_lane(
                     matches.append(r)
             except (TypeError, ValueError):
                 continue
-        return best_match(matches)
+        return _best_lane_match(matches)
     if branch:
-        return best_match([r for r in records if r.get("branch") == branch])
+        return _best_lane_match([r for r in records if r.get("branch") == branch])
     if worktree:
         wt_norm = os.path.normpath(worktree)
         matches = []
@@ -174,7 +216,7 @@ def find_lane(
             rwt = r.get("worktree")
             if rwt and os.path.normpath(rwt) == wt_norm:
                 matches.append(r)
-        return best_match(matches)
+        return _best_lane_match(matches)
     return None
 
 

--- a/scripts/send_operator_steering.py
+++ b/scripts/send_operator_steering.py
@@ -47,11 +47,14 @@ from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 STEERING_INBOX_ROOT_DEFAULT = REPO_ROOT / ".aragora" / "operator-steering"
+LANE_REGISTRY_DEFAULT = REPO_ROOT / ".aragora" / "agent-bridge" / "lanes.json"
+USER_LANE_REGISTRY_DEFAULT = Path.home() / ".aragora" / "agent-bridge" / "lanes.json"
 
 SCHEMA_VERSION = "aragora-operator-steering/1.0"
 SUBJECT_MAX_CHARS = 80
 PRIORITY_CHOICES = ("low", "normal", "high", "blocking")
 SHORT_UUID_BYTES = 4  # 8 hex chars; collision risk negligible per-second
+ACTIVE_STATUSES = {"active", "running", "pending", "queued", "claimed"}
 
 
 # ---------------------------------------------------------------------------
@@ -147,6 +150,110 @@ def validate_to_session(to_session: str, *, steering_inbox_root: Path) -> Path:
     return inbox
 
 
+def _load_lane_records(registry_path: Path) -> list[dict[str, Any]]:
+    try:
+        data = json.loads(registry_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    return [record for record in data if isinstance(record, dict)] if isinstance(data, list) else []
+
+
+def _load_default_lane_records(registry_path: Path) -> list[dict[str, Any]]:
+    if registry_path != LANE_REGISTRY_DEFAULT:
+        return _load_lane_records(registry_path)
+    records: list[dict[str, Any]] = []
+    seen: set[Path] = set()
+    for path in (USER_LANE_REGISTRY_DEFAULT, LANE_REGISTRY_DEFAULT):
+        try:
+            resolved = path.resolve()
+        except OSError:
+            resolved = path
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        records.extend(_load_lane_records(path))
+    return records
+
+
+def _is_active_lane(record: dict[str, Any]) -> bool:
+    return str(record.get("status") or "").strip().lower() in ACTIVE_STATUSES
+
+
+def _identity_matches(
+    record: dict[str, Any],
+    *,
+    pr: int | None = None,
+    branch: str | None = None,
+    worktree: str | None = None,
+) -> bool:
+    if pr is not None:
+        try:
+            if int(record.get("pr_number") or 0) == int(pr):
+                return True
+        except (TypeError, ValueError):
+            pass
+    if branch and record.get("branch") == branch:
+        return True
+    if worktree:
+        record_worktree = record.get("worktree")
+        if record_worktree and os.path.normpath(str(record_worktree)) == os.path.normpath(worktree):
+            return True
+    return False
+
+
+def _updated_at_sort_key(record: dict[str, Any]) -> str:
+    return str(record.get("updated_at") or "")
+
+
+def resolve_active_owner(
+    *,
+    registry_path: Path | None = None,
+    pr: int | None = None,
+    branch: str | None = None,
+    worktree: str | None = None,
+) -> dict[str, Any]:
+    """Resolve a single active owner by PR/branch/worktree, failing closed.
+
+    This is intentionally stricter than ``identify_lane_owner.py``: steering
+    should only route to an active owner. Released/completed rows are useful
+    history, but they are not a live dispatch target.
+    """
+
+    if pr is None and branch is None and worktree is None:
+        raise ValueError("provide at least one owner selector")
+    records = _load_default_lane_records(registry_path or LANE_REGISTRY_DEFAULT)
+    matches = [
+        record
+        for record in records
+        if _is_active_lane(record)
+        and _identity_matches(record, pr=pr, branch=branch, worktree=worktree)
+    ]
+    if not matches:
+        raise ValueError("no active owner matched the requested PR/branch/worktree")
+
+    owners = {str(record.get("owner_session") or "") for record in matches}
+    lanes = {str(record.get("lane_id") or "") for record in matches}
+    if len(owners) != 1 or len(lanes) != 1:
+        compact = [
+            {
+                "lane_id": record.get("lane_id"),
+                "owner_session": record.get("owner_session"),
+                "pr_number": record.get("pr_number"),
+                "branch": record.get("branch"),
+                "worktree": record.get("worktree"),
+                "status": record.get("status"),
+            }
+            for record in sorted(matches, key=_updated_at_sort_key, reverse=True)
+        ]
+        raise ValueError(f"multiple active owners matched; resolve conflict first: {compact}")
+
+    chosen = sorted(matches, key=_updated_at_sort_key, reverse=True)[0]
+    owner = str(chosen.get("owner_session") or "")
+    if not owner:
+        raise ValueError("matched active lane has no owner_session")
+    return chosen
+
+
 def _mailbox_filename(sent_at_utc: str) -> str:
     return f"{_filename_timestamp(sent_at_utc)}-{secrets.token_hex(SHORT_UUID_BYTES)}.json"
 
@@ -208,11 +315,27 @@ def _build_parser() -> argparse.ArgumentParser:
             "atomic mailbox under .aragora/operator-steering/<to_session>/."
         ),
     )
-    parser.add_argument(
+    target_group = parser.add_mutually_exclusive_group(required=True)
+    target_group.add_argument(
         "--to",
-        required=True,
         metavar="OWNER_SESSION",
         help="Target owner_session identifier (e.g., codex-p19-repair-7292).",
+    )
+    target_group.add_argument(
+        "--to-owner-pr",
+        type=int,
+        metavar="N",
+        help="Resolve the active owner_session for PR N from lanes.json before writing.",
+    )
+    target_group.add_argument(
+        "--to-owner-branch",
+        metavar="BRANCH",
+        help="Resolve the active owner_session for BRANCH from lanes.json before writing.",
+    )
+    target_group.add_argument(
+        "--to-owner-worktree",
+        metavar="PATH",
+        help="Resolve the active owner_session for worktree PATH from lanes.json before writing.",
     )
     parser.add_argument(
         "--lane-id",
@@ -263,6 +386,12 @@ def _build_parser() -> argparse.ArgumentParser:
         default=STEERING_INBOX_ROOT_DEFAULT,
         help="Override the steering inbox root (used by tests).",
     )
+    parser.add_argument(
+        "--lane-registry-path",
+        type=Path,
+        default=LANE_REGISTRY_DEFAULT,
+        help="Override path to lanes.json for --to-owner-* resolution (used by tests).",
+    )
     return parser
 
 
@@ -292,8 +421,39 @@ def main(argv: Sequence[str] | None = None) -> int:
         print("ERROR: message body is empty", file=sys.stderr)
         return 2
 
+    route: dict[str, Any] | None = None
+    to_session = args.to
+    if to_session is None:
+        try:
+            owner_record = resolve_active_owner(
+                registry_path=args.lane_registry_path,
+                pr=args.to_owner_pr,
+                branch=args.to_owner_branch,
+                worktree=args.to_owner_worktree,
+            )
+        except ValueError as exc:
+            print(f"ERROR: failed to resolve active owner: {exc}", file=sys.stderr)
+            return 2
+        to_session = str(owner_record.get("owner_session") or "")
+        route = {
+            "resolved_via": (
+                "pr"
+                if args.to_owner_pr is not None
+                else "branch"
+                if args.to_owner_branch
+                else "worktree"
+            ),
+            "lane_id": owner_record.get("lane_id"),
+            "owner_session": to_session,
+            "pr_number": owner_record.get("pr_number"),
+            "branch": owner_record.get("branch"),
+            "worktree": owner_record.get("worktree"),
+            "status": owner_record.get("status"),
+            "updated_at": owner_record.get("updated_at"),
+        }
+
     message = build_message(
-        to_session=args.to,
+        to_session=to_session,
         body=body_text,
         from_label=args.from_label,
         lane_id_hint=args.lane_id,
@@ -310,6 +470,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.json:
         out = dict(message)
         out["_written_path"] = str(written_path)
+        if route is not None:
+            out["_route"] = route
         print(json.dumps(out, indent=2, sort_keys=True))
     else:
         print(

--- a/tests/scripts/test_identify_lane_owner.py
+++ b/tests/scripts/test_identify_lane_owner.py
@@ -115,6 +115,25 @@ class TestLoadAndFind:
         assert r is not None
         assert r["owner_session"] == "codex-p19-repair-7292"
 
+    def test_find_by_exact_lane_id_preserves_registry_order(self) -> None:
+        lanes = [
+            {
+                "lane_id": "duplicate-lane-id",
+                "owner_session": "codex-original",
+                "status": "released",
+                "updated_at": "2026-05-18T04:00:00Z",
+            },
+            {
+                "lane_id": "duplicate-lane-id",
+                "owner_session": "codex-newer-active",
+                "status": "active",
+                "updated_at": "2026-05-18T05:00:00Z",
+            },
+        ]
+        r = ilo.find_lane(lanes, lane_id="duplicate-lane-id")
+        assert r is not None
+        assert r["owner_session"] == "codex-original"
+
     def test_find_by_pr_number(self) -> None:
         r = ilo.find_lane(SAMPLE_LANES, pr=7292)
         assert r is not None
@@ -162,12 +181,102 @@ class TestLoadAndFind:
         assert r is not None
         assert r["lane_id"] == "newer-released"
 
+    def test_find_by_pr_prefers_conflict_over_newer_released_history(self) -> None:
+        lanes = [
+            {
+                "lane_id": "newer-released",
+                "owner_session": "codex-released",
+                "status": "released",
+                "pr_number": 7292,
+                "updated_at": "2026-05-18T05:00:00Z",
+            },
+            {
+                "lane_id": "older-conflict",
+                "owner_session": "codex-conflict",
+                "status": "conflict",
+                "pr_number": 7292,
+                "updated_at": "2026-05-18T04:00:00Z",
+            },
+        ]
+        r = ilo.find_lane(lanes, pr=7292)
+        assert r is not None
+        assert r["lane_id"] == "older-conflict"
+
+    def test_find_by_pr_treats_bad_or_missing_updated_at_as_oldest(self) -> None:
+        lanes = [
+            {
+                "lane_id": "bad-time",
+                "owner_session": "codex-bad",
+                "status": "released",
+                "pr_number": 7292,
+                "updated_at": "not-a-timestamp",
+            },
+            {
+                "lane_id": "missing-time",
+                "owner_session": "codex-missing",
+                "status": "released",
+                "pr_number": 7292,
+            },
+            {
+                "lane_id": "valid-time",
+                "owner_session": "codex-valid",
+                "status": "completed",
+                "pr_number": 7292,
+                "updated_at": "2026-05-18T04:00:00Z",
+            },
+        ]
+        r = ilo.find_lane(lanes, pr=7292)
+        assert r is not None
+        assert r["lane_id"] == "valid-time"
+
     def test_find_by_branch(self) -> None:
         r = ilo.find_lane(
             SAMPLE_LANES, branch="droid/P20-model-pins-frontier-aligned-20260518-041438"
         )
         assert r is not None
         assert r["lane_id"] == "P20-model-pins-frontier-aligned"
+
+    def test_find_by_branch_uses_duplicate_lane_ranking(self) -> None:
+        lanes = [
+            {
+                "lane_id": "newer-released",
+                "owner_session": "codex-released",
+                "status": "released",
+                "branch": "codex/shared-branch",
+                "updated_at": "2026-05-18T05:00:00Z",
+            },
+            {
+                "lane_id": "older-conflict",
+                "owner_session": "codex-conflict",
+                "status": "conflict",
+                "branch": "codex/shared-branch",
+                "updated_at": "2026-05-18T04:00:00Z",
+            },
+        ]
+        r = ilo.find_lane(lanes, branch="codex/shared-branch")
+        assert r is not None
+        assert r["lane_id"] == "older-conflict"
+
+    def test_find_by_worktree_uses_duplicate_lane_ranking(self) -> None:
+        lanes = [
+            {
+                "lane_id": "older-released",
+                "owner_session": "codex-released",
+                "status": "released",
+                "worktree": "/private/tmp/shared-worktree",
+                "updated_at": "2026-05-18T05:00:00Z",
+            },
+            {
+                "lane_id": "current-active",
+                "owner_session": "codex-active",
+                "status": "active",
+                "worktree": "/private/tmp/shared-worktree",
+                "updated_at": "2026-05-18T04:00:00Z",
+            },
+        ]
+        r = ilo.find_lane(lanes, worktree="/private/tmp/shared-worktree/")
+        assert r is not None
+        assert r["lane_id"] == "current-active"
 
     def test_find_by_worktree_path_normalised(self) -> None:
         # Trailing-slash variant must match the registry's path.

--- a/tests/scripts/test_identify_lane_owner.py
+++ b/tests/scripts/test_identify_lane_owner.py
@@ -120,6 +120,48 @@ class TestLoadAndFind:
         assert r is not None
         assert r["lane_id"] == "P19-repair-7292-stage2-blockers"
 
+    def test_find_by_pr_prefers_active_over_stale_history(self) -> None:
+        lanes = [
+            {
+                "lane_id": "old-completed",
+                "owner_session": "codex-old",
+                "status": "completed",
+                "pr_number": 7292,
+                "updated_at": "2026-05-18T05:00:00Z",
+            },
+            {
+                "lane_id": "current-active",
+                "owner_session": "codex-current",
+                "status": "active",
+                "pr_number": 7292,
+                "updated_at": "2026-05-18T04:00:00Z",
+            },
+        ]
+        r = ilo.find_lane(lanes, pr=7292)
+        assert r is not None
+        assert r["lane_id"] == "current-active"
+
+    def test_find_by_pr_uses_newest_historical_when_unowned(self) -> None:
+        lanes = [
+            {
+                "lane_id": "older-completed",
+                "owner_session": "codex-old",
+                "status": "completed",
+                "pr_number": 7292,
+                "updated_at": "2026-05-18T04:00:00Z",
+            },
+            {
+                "lane_id": "newer-released",
+                "owner_session": "codex-new",
+                "status": "released",
+                "pr_number": 7292,
+                "updated_at": "2026-05-18T05:00:00Z",
+            },
+        ]
+        r = ilo.find_lane(lanes, pr=7292)
+        assert r is not None
+        assert r["lane_id"] == "newer-released"
+
     def test_find_by_branch(self) -> None:
         r = ilo.find_lane(
             SAMPLE_LANES, branch="droid/P20-model-pins-frontier-aligned-20260518-041438"

--- a/tests/scripts/test_send_operator_steering.py
+++ b/tests/scripts/test_send_operator_steering.py
@@ -446,6 +446,188 @@ class TestJsonOutput:
 
 
 # ---------------------------------------------------------------------------
+# Active-owner routing
+# ---------------------------------------------------------------------------
+
+
+class TestActiveOwnerRouting:
+    def _write_lanes(self, tmp_path: Path, lanes: list[dict[str, Any]]) -> Path:
+        registry = tmp_path / "lanes.json"
+        registry.parent.mkdir(parents=True, exist_ok=True)
+        registry.write_text(json.dumps(lanes), encoding="utf-8")
+        return registry
+
+    def test_to_owner_pr_routes_to_single_active_owner(self, tmp_path: Path) -> None:
+        registry = self._write_lanes(
+            tmp_path,
+            [
+                {
+                    "lane_id": "old-7292",
+                    "owner_session": "codex-old",
+                    "status": "completed",
+                    "pr_number": 7292,
+                    "updated_at": "2026-05-18T01:00:00Z",
+                },
+                {
+                    "lane_id": "q23-repair-7292",
+                    "owner_session": "codex-q23",
+                    "status": "active",
+                    "pr_number": 7292,
+                    "branch": "droid/P16-stage2",
+                    "updated_at": "2026-05-19T16:05:53Z",
+                },
+            ],
+        )
+
+        rc = sos.main(
+            [
+                "--to-owner-pr",
+                "7292",
+                "--body",
+                "continue only if you own Q23",
+                "--json",
+                "--lane-registry-path",
+                str(registry),
+                "--steering-inbox-root",
+                str(tmp_path / "inbox"),
+            ]
+        )
+
+        assert rc == 0
+        msgs = _list_messages(tmp_path / "inbox", "codex-q23")
+        assert len(msgs) == 1
+        payload = json.loads(msgs[0].read_text(encoding="utf-8"))
+        assert payload["to_session"] == "codex-q23"
+
+    def test_default_owner_resolution_reads_user_and_repo_registries(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        repo_registry = self._write_lanes(tmp_path / "repo", [])
+        user_registry = self._write_lanes(
+            tmp_path / "user",
+            [
+                {
+                    "lane_id": "q23-repair-7292",
+                    "owner_session": "codex-q23",
+                    "status": "active",
+                    "pr_number": 7292,
+                    "updated_at": "2026-05-19T16:05:53Z",
+                }
+            ],
+        )
+        monkeypatch.setattr(sos, "LANE_REGISTRY_DEFAULT", repo_registry)
+        monkeypatch.setattr(sos, "USER_LANE_REGISTRY_DEFAULT", user_registry)
+
+        resolved = sos.resolve_active_owner(pr=7292)
+
+        assert resolved["lane_id"] == "q23-repair-7292"
+        assert resolved["owner_session"] == "codex-q23"
+
+    def test_to_owner_pr_json_includes_route(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        registry = self._write_lanes(
+            tmp_path,
+            [
+                {
+                    "lane_id": "q23-repair-7292",
+                    "owner_session": "codex-q23",
+                    "status": "active",
+                    "pr_number": 7292,
+                    "updated_at": "2026-05-19T16:05:53Z",
+                }
+            ],
+        )
+
+        rc = sos.main(
+            [
+                "--to-owner-pr",
+                "7292",
+                "--body",
+                "route metadata please",
+                "--json",
+                "--lane-registry-path",
+                str(registry),
+                "--steering-inbox-root",
+                str(tmp_path / "inbox"),
+            ]
+        )
+
+        assert rc == 0
+        parsed = json.loads(capsys.readouterr().out)
+        assert parsed["_route"]["resolved_via"] == "pr"
+        assert parsed["_route"]["lane_id"] == "q23-repair-7292"
+        assert parsed["_route"]["owner_session"] == "codex-q23"
+
+    def test_to_owner_pr_rejects_completed_only_owner(self, tmp_path: Path) -> None:
+        registry = self._write_lanes(
+            tmp_path,
+            [
+                {
+                    "lane_id": "q23-repair-7292",
+                    "owner_session": "codex-q23",
+                    "status": "completed",
+                    "pr_number": 7292,
+                    "updated_at": "2026-05-19T16:16:29Z",
+                }
+            ],
+        )
+
+        rc = sos.main(
+            [
+                "--to-owner-pr",
+                "7292",
+                "--body",
+                "must not route to completed lane",
+                "--lane-registry-path",
+                str(registry),
+                "--steering-inbox-root",
+                str(tmp_path / "inbox"),
+            ]
+        )
+
+        assert rc == 2
+        assert list((tmp_path / "inbox").rglob("*.json")) == []
+
+    def test_to_owner_pr_rejects_duplicate_active_owners(self, tmp_path: Path) -> None:
+        registry = self._write_lanes(
+            tmp_path,
+            [
+                {
+                    "lane_id": "lane-a",
+                    "owner_session": "codex-a",
+                    "status": "active",
+                    "pr_number": 7292,
+                    "updated_at": "2026-05-19T16:00:00Z",
+                },
+                {
+                    "lane_id": "lane-b",
+                    "owner_session": "codex-b",
+                    "status": "active",
+                    "pr_number": 7292,
+                    "updated_at": "2026-05-19T16:01:00Z",
+                },
+            ],
+        )
+
+        rc = sos.main(
+            [
+                "--to-owner-pr",
+                "7292",
+                "--body",
+                "must not route to ambiguous owners",
+                "--lane-registry-path",
+                str(registry),
+                "--steering-inbox-root",
+                str(tmp_path / "inbox"),
+            ]
+        )
+
+        assert rc == 2
+        assert list((tmp_path / "inbox").rglob("*.json")) == []
+
+
+# ---------------------------------------------------------------------------
 # Build / verify helpers exposed for downstream callers
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- add active-owner resolution to send_operator_steering.py via --to-owner-pr/--to-owner-branch/--to-owner-worktree
- fail closed when a PR has no active owner or multiple active owners
- make identify_lane_owner prefer active/conflict rows over stale completed history for non-unique selectors

## Validation
- python3 -m pytest tests/scripts/test_send_operator_steering.py tests/scripts/test_identify_lane_owner.py -q
- python3 -m ruff check scripts/send_operator_steering.py scripts/identify_lane_owner.py tests/scripts/test_send_operator_steering.py tests/scripts/test_identify_lane_owner.py
- python3 -m ruff format --check scripts/send_operator_steering.py scripts/identify_lane_owner.py tests/scripts/test_send_operator_steering.py tests/scripts/test_identify_lane_owner.py
- python3 -m mypy scripts/send_operator_steering.py scripts/identify_lane_owner.py tests/scripts/test_send_operator_steering.py tests/scripts/test_identify_lane_owner.py --ignore-missing-imports --no-incremental
- bash scripts/automation_pr_preflight.sh origin/main HEAD

## Dogfood
- python3 scripts/send_operator_steering.py --to-owner-pr 7292 ... failed closed because #7292 has no active owner
