### PR TITLE
fix(scripts): report conflict lane owners

### DIFF
--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -66,6 +66,8 @@ if agent_bridge_sessions is not None:
     except (OSError, RuntimeError, ValueError):
         CANONICAL_REPO_ROOT = REPO_ROOT
 ACTIVE_LANE_STATUSES = {"active", "running", "pending", "queued", "claimed"}
+CONFLICT_LANE_STATUSES = {"conflict"}
+COMPLETED_LANE_STATUSES = {"completed", "released"}
 CURRENT_SESSION_LIFECYCLES = {"live", "active_broker"}
 HISTORICAL_SESSION_LIFECYCLES = {"historical", "dead", "stale", "orphaned"}
 DEFAULT_STALE_TTL_HOURS = 24
@@ -534,8 +536,6 @@ def _record_matches_owner_query(
     branch: str | None,
     worktree: str | None,
 ) -> bool:
-    if record.status not in ACTIVE_LANE_STATUSES:
-        return False
     if pr_number is not None and record.pr_number == pr_number:
         return True
     if branch and record.branch == branch:
@@ -587,12 +587,55 @@ def _owned_owner_payload(record: LaneRecord) -> dict[str, Any]:
     }
 
 
+def _historical_owner_payload(record: LaneRecord) -> dict[str, Any]:
+    return {
+        "owner_status": "unowned",
+        "active_owner": False,
+        "lane_id": record.lane_id,
+        "owner_session": record.owner_session,
+        "pr_number": record.pr_number,
+        "branch": record.branch or None,
+        "worktree": record.worktree or None,
+        "head": _head_for_worktree(record.worktree),
+        "status": record.status,
+        "updated_at": record.updated_at or None,
+        "recommended_operator_action": (
+            f"latest matching lane is {record.status}; claim the lane before mutation"
+        ),
+    }
+
+
+def _conflict_status_owner_payload(record: LaneRecord) -> dict[str, Any]:
+    reason = record.conflict_reason or "resolve the recorded lane conflict"
+    return {
+        "owner_status": "conflict",
+        "active_owner": False,
+        "lane_id": record.lane_id,
+        "owner_session": record.owner_session,
+        "pr_number": record.pr_number,
+        "branch": record.branch or None,
+        "worktree": record.worktree or None,
+        "head": _head_for_worktree(record.worktree),
+        "status": record.status,
+        "updated_at": record.updated_at or None,
+        "conflict_session": record.conflict_session or None,
+        "conflict_reason": record.conflict_reason or None,
+        "recommended_operator_action": f"resolve lane conflict before mutation: {reason}",
+    }
+
+
 def _conflicted_owner_payload(records: list[LaneRecord]) -> dict[str, Any]:
     lane_ids = sorted({record.lane_id for record in records if record.lane_id})
     owner_sessions = sorted({record.owner_session for record in records if record.owner_session})
     branches = sorted({record.branch for record in records if record.branch})
     worktrees = sorted({record.worktree for record in records if record.worktree})
     pr_numbers = sorted({record.pr_number for record in records if record.pr_number is not None})
+    conflict_sessions = sorted(
+        {record.conflict_session for record in records if record.conflict_session}
+    )
+    conflict_reasons = sorted(
+        {record.conflict_reason for record in records if record.conflict_reason}
+    )
     updated_values = sorted(
         (record.updated_at for record in records if record.updated_at), reverse=True
     )
@@ -607,10 +650,28 @@ def _conflicted_owner_payload(records: list[LaneRecord]) -> dict[str, Any]:
         "head": None,
         "status": "conflict",
         "updated_at": updated_values[0] if updated_values else None,
+        "conflict_session": ",".join(conflict_sessions) or None,
+        "conflict_reason": " | ".join(conflict_reasons) or None,
         "recommended_operator_action": (
             "pause duplicate mutation; resolve active owner conflict before mutation"
         ),
     }
+
+
+def _lane_updated_timestamp(record: LaneRecord) -> float:
+    parsed = _parse_timestamp(record.updated_at)
+    if parsed is None:
+        return 0.0
+    return parsed.timestamp()
+
+
+def _newest_lane_record(records: list[LaneRecord]) -> LaneRecord:
+    indexed = list(enumerate(records))
+    _index, record = min(
+        indexed,
+        key=lambda item: (-_lane_updated_timestamp(item[1]), item[0]),
+    )
+    return record
 
 
 def _active_owner_payload(
@@ -629,11 +690,23 @@ def _active_owner_payload(
     ]
     if not matches:
         return _unowned_owner_payload(pr_number=pr_number, branch=branch, worktree=worktree)
-    owners = {record.owner_session for record in matches if record.owner_session}
-    if len(owners) > 1:
-        return _conflicted_owner_payload(matches)
-    matches.sort(key=lambda record: record.updated_at or "", reverse=True)
-    return _owned_owner_payload(matches[0])
+
+    active_matches = [record for record in matches if record.status in ACTIVE_LANE_STATUSES]
+    if active_matches:
+        owners = {record.owner_session for record in active_matches if record.owner_session}
+        if len(owners) > 1:
+            return _conflicted_owner_payload(active_matches)
+        return _owned_owner_payload(_newest_lane_record(active_matches))
+
+    conflict_matches = [record for record in matches if record.status in CONFLICT_LANE_STATUSES]
+    if conflict_matches:
+        return _conflict_status_owner_payload(_newest_lane_record(conflict_matches))
+
+    completed_matches = [record for record in matches if record.status in COMPLETED_LANE_STATUSES]
+    if completed_matches:
+        return _historical_owner_payload(_newest_lane_record(completed_matches))
+
+    return _unowned_owner_payload(pr_number=pr_number, branch=branch, worktree=worktree)
 
 
 def _load_broker_run_summaries() -> list[dict[str, Any]]:

--- a/scripts/identify_lane_owner.py
+++ b/scripts/identify_lane_owner.py
@@ -114,6 +114,10 @@ class LaneOwnerInfo:
     factory_droid: dict[str, Any]
     steering_inbox_path: str
     pending_message_count: int
+    dispatchable: bool
+    dispatch_blocker: str | None
+    steering_command: str | None
+    harness_confidence: str
 
 
 # ---------------------------------------------------------------------------
@@ -668,6 +672,70 @@ def steering_inbox_for(
     return inbox, count
 
 
+def _dispatch_blocker_for(lane: dict[str, Any], owner_session: str) -> str | None:
+    status = str(lane.get("status") or "").strip().lower()
+    if not owner_session:
+        return "lane has no owner_session"
+    if status in ACTIVE_STATUSES:
+        return None
+    if status in CONFLICT_STATUSES:
+        return "lane status is conflict; resolve the conflict before steering"
+    if status in COMPLETED_STATUSES:
+        return f"lane status is {status}; claim an active lane before steering"
+    return f"lane status is {status or 'unknown'}; claim an active lane before steering"
+
+
+def _steering_command_for(lane: dict[str, Any], owner_session: str) -> str | None:
+    if _dispatch_blocker_for(lane, owner_session) is not None:
+        return None
+    parts = [
+        "python3",
+        "scripts/send_operator_steering.py",
+        "--to",
+        owner_session,
+    ]
+    lane_id = str(lane.get("lane_id") or "")
+    if lane_id:
+        parts.extend(["--lane-id", lane_id])
+    raw_pr = lane.get("pr_number")
+    if raw_pr is not None:
+        parts.extend(["--pr", str(raw_pr)])
+    parts.extend(["--priority", "blocking", "--body", "'<message>'"])
+    return " ".join(parts)
+
+
+def _harness_confidence_for(
+    lane: dict[str, Any],
+    *,
+    live: dict[str, Any],
+    codex: dict[str, Any],
+    claude: dict[str, Any],
+    factory: dict[str, Any],
+) -> str:
+    if any(
+        lane.get(field)
+        for field in (
+            "codex_thread_id",
+            "codex_rollout_path",
+            "desktop_label",
+            "session_title",
+        )
+    ):
+        return "recorded_identity"
+    if live.get("found"):
+        return "live_process"
+    if codex.get("found"):
+        matched_via = str(codex.get("matched_via") or "")
+        if "ambiguous" in matched_via or "fuzzy" in matched_via:
+            return "mailbox_only_fuzzy_thread"
+        return "codex_thread_best_effort"
+    if claude.get("found"):
+        return "claude_session_best_effort"
+    if factory.get("found"):
+        return "factory_droid_best_effort"
+    return "mailbox_only"
+
+
 # ---------------------------------------------------------------------------
 # Composition
 # ---------------------------------------------------------------------------
@@ -689,6 +757,7 @@ def build_owner_info(
     claude = lookup_claude_session(lane, projects_root=projects_root)
     factory = lookup_factory_droid(lane, bg_path=bg_path)
     inbox_path, pending = steering_inbox_for(owner, root=steering_inbox_root)
+    dispatch_blocker = _dispatch_blocker_for(lane, owner)
 
     raw_pr = lane.get("pr_number")
     try:
@@ -716,6 +785,16 @@ def build_owner_info(
         factory_droid=factory,
         steering_inbox_path=str(inbox_path),
         pending_message_count=pending,
+        dispatchable=dispatch_blocker is None,
+        dispatch_blocker=dispatch_blocker,
+        steering_command=_steering_command_for(lane, owner),
+        harness_confidence=_harness_confidence_for(
+            lane,
+            live=live,
+            codex=codex,
+            claude=claude,
+            factory=factory,
+        ),
     )
 
 
@@ -757,6 +836,10 @@ def _print_human(info: LaneOwnerInfo) -> None:
     print()
     print(f"steering_inbox_path:   {info.steering_inbox_path}")
     print(f"pending_message_count: {info.pending_message_count}")
+    print(f"dispatchable:          {info.dispatchable}")
+    print(f"dispatch_blocker:      {info.dispatch_blocker or '-'}")
+    print(f"steering_command:      {info.steering_command or '-'}")
+    print(f"harness_confidence:    {info.harness_confidence}")
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/scripts/send_operator_steering.py
+++ b/scripts/send_operator_steering.py
@@ -205,6 +205,50 @@ def _updated_at_sort_key(record: dict[str, Any]) -> str:
     return str(record.get("updated_at") or "")
 
 
+def route_payload_for_record(
+    owner_record: dict[str, Any],
+    *,
+    resolved_via: str,
+    steering_inbox_root: Path,
+) -> dict[str, Any]:
+    """Return target metadata for a resolved active-owner route without writing."""
+
+    owner_session = str(owner_record.get("owner_session") or "")
+    inbox_path = validate_to_session(owner_session, steering_inbox_root=steering_inbox_root)
+    return {
+        "resolved_via": resolved_via,
+        "lane_id": owner_record.get("lane_id"),
+        "owner_session": owner_session,
+        "pr_number": owner_record.get("pr_number"),
+        "branch": owner_record.get("branch"),
+        "worktree": owner_record.get("worktree"),
+        "status": owner_record.get("status"),
+        "updated_at": owner_record.get("updated_at"),
+        "steering_inbox_path": str(inbox_path),
+        "dispatchable": True,
+        "dispatch_blocker": None,
+    }
+
+
+def direct_route_payload(to_session: str, *, steering_inbox_root: Path) -> dict[str, Any]:
+    """Return target metadata for direct ``--to`` dispatch without writing."""
+
+    inbox_path = validate_to_session(to_session, steering_inbox_root=steering_inbox_root)
+    return {
+        "resolved_via": "direct",
+        "lane_id": None,
+        "owner_session": to_session,
+        "pr_number": None,
+        "branch": None,
+        "worktree": None,
+        "status": None,
+        "updated_at": None,
+        "steering_inbox_path": str(inbox_path),
+        "dispatchable": True,
+        "dispatch_blocker": None,
+    }
+
+
 def resolve_active_owner(
     *,
     registry_path: Path | None = None,
@@ -362,7 +406,7 @@ def _build_parser() -> argparse.ArgumentParser:
         default="normal",
         help="Message priority (default: normal).",
     )
-    body_group = parser.add_mutually_exclusive_group(required=True)
+    body_group = parser.add_mutually_exclusive_group(required=False)
     body_group.add_argument(
         "--body",
         default=None,
@@ -379,6 +423,16 @@ def _build_parser() -> argparse.ArgumentParser:
         "--json",
         action="store_true",
         help="Emit the written record + final path as JSON to stdout.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Resolve and validate the target, but do not write a steering message.",
+    )
+    parser.add_argument(
+        "--print-target",
+        action="store_true",
+        help="Print the resolved steering target without requiring a message body or writing.",
     )
     parser.add_argument(
         "--steering-inbox-root",
@@ -402,11 +456,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         # argparse exits 2 on bad args; preserve that contract.
         return int(exc.code) if isinstance(exc.code, int) else 2
 
+    no_write = bool(args.dry_run or args.print_target)
+
     # Validate / resolve body.
     body_text: str
     if args.body is not None:
         body_text = args.body
-    else:
+    elif args.body_file is not None:
         body_path: Path = args.body_file
         if not body_path.exists():
             print(f"ERROR: --body-file not found: {body_path}", file=sys.stderr)
@@ -416,8 +472,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         except (OSError, UnicodeDecodeError) as exc:
             print(f"ERROR: cannot read --body-file: {exc}", file=sys.stderr)
             return 2
+    else:
+        body_text = ""
 
-    if not body_text.strip():
+    if not body_text.strip() and not args.print_target:
         print("ERROR: message body is empty", file=sys.stderr)
         return 2
 
@@ -435,22 +493,39 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(f"ERROR: failed to resolve active owner: {exc}", file=sys.stderr)
             return 2
         to_session = str(owner_record.get("owner_session") or "")
-        route = {
-            "resolved_via": (
-                "pr"
-                if args.to_owner_pr is not None
-                else "branch"
-                if args.to_owner_branch
-                else "worktree"
-            ),
-            "lane_id": owner_record.get("lane_id"),
-            "owner_session": to_session,
-            "pr_number": owner_record.get("pr_number"),
-            "branch": owner_record.get("branch"),
-            "worktree": owner_record.get("worktree"),
-            "status": owner_record.get("status"),
-            "updated_at": owner_record.get("updated_at"),
+        resolved_via = (
+            "pr"
+            if args.to_owner_pr is not None
+            else "branch"
+            if args.to_owner_branch
+            else "worktree"
+        )
+        route = route_payload_for_record(
+            owner_record,
+            resolved_via=resolved_via,
+            steering_inbox_root=args.steering_inbox_root,
+        )
+    else:
+        try:
+            route = direct_route_payload(to_session, steering_inbox_root=args.steering_inbox_root)
+        except ValueError as exc:
+            print(f"ERROR: failed to validate target: {exc}", file=sys.stderr)
+            return 2
+
+    if args.print_target and not body_text.strip():
+        out = {
+            "_dry_run": True,
+            "_would_write": False,
+            "_target": route,
         }
+        if args.json:
+            print(json.dumps(out, indent=2, sort_keys=True))
+        else:
+            print(
+                f"target {route['owner_session']} -> {route['steering_inbox_path']} "
+                "(no message body supplied; no write)"
+            )
+        return 0
 
     message = build_message(
         to_session=to_session,
@@ -461,18 +536,27 @@ def main(argv: Sequence[str] | None = None) -> int:
         priority=args.priority,
     )
 
-    try:
-        written_path = write_message(message, steering_inbox_root=args.steering_inbox_root)
-    except (OSError, ValueError) as exc:
-        print(f"ERROR: failed to write message: {exc}", file=sys.stderr)
-        return 2
+    written_path: Path | None = None
+    if not no_write:
+        try:
+            written_path = write_message(message, steering_inbox_root=args.steering_inbox_root)
+        except (OSError, ValueError) as exc:
+            print(f"ERROR: failed to write message: {exc}", file=sys.stderr)
+            return 2
 
     if args.json:
         out = dict(message)
-        out["_written_path"] = str(written_path)
+        out["_dry_run"] = no_write
+        out["_would_write"] = no_write
+        out["_written_path"] = str(written_path) if written_path is not None else None
         if route is not None:
             out["_route"] = route
         print(json.dumps(out, indent=2, sort_keys=True))
+    elif no_write:
+        print(
+            f"would write to {route['steering_inbox_path']}  "
+            f"(to={route['owner_session']}, priority={message['priority']})"
+        )
     else:
         print(
             f"wrote {written_path}  "

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -831,6 +831,152 @@ def test_cmd_owner_json_reports_duplicate_pr_conflict(
     )
 
 
+def test_cmd_owner_json_reports_conflict_status_lane_instead_of_unowned(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import agent_bridge as mod
+
+    _patch_bridge_paths(mod, tmp_path, monkeypatch)
+    mod.AGENT_BRIDGE_DIR.mkdir(parents=True, exist_ok=True)
+    mod.LANE_REGISTRY_FILE.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "newer-released",
+                    "owner_session": "codex-released",
+                    "status": "released",
+                    "updated_at": "2026-05-18T17:10:00Z",
+                    "branch": "droid/P16-stage2",
+                    "pr_number": 7292,
+                },
+                {
+                    "lane_id": "q26-conflict",
+                    "owner_session": "codex-q26",
+                    "status": "conflict",
+                    "updated_at": "2026-05-18T17:00:00Z",
+                    "branch": "droid/P16-stage2",
+                    "pr_number": 7292,
+                    "conflict_session": "gemini-review",
+                    "conflict_reason": "fresh-head validation blocker",
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mod, "discover", lambda **_kwargs: [])
+
+    rc = mod.cmd_owner(argparse.Namespace(json=True, pr=7292, branch=None, worktree=None))
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["owner_status"] == "conflict"
+    assert payload["active_owner"] is False
+    assert payload["lane_id"] == "q26-conflict"
+    assert payload["owner_session"] == "codex-q26"
+    assert payload["pr_number"] == 7292
+    assert payload["branch"] == "droid/P16-stage2"
+    assert payload["status"] == "conflict"
+    assert payload["conflict_session"] == "gemini-review"
+    assert payload["conflict_reason"] == "fresh-head validation blocker"
+    assert payload["recommended_operator_action"] == (
+        "resolve lane conflict before mutation: fresh-head validation blocker"
+    )
+
+
+def test_cmd_owner_json_prefers_active_lane_over_conflict_status_lane(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import agent_bridge as mod
+
+    _patch_bridge_paths(mod, tmp_path, monkeypatch)
+    mod.AGENT_BRIDGE_DIR.mkdir(parents=True, exist_ok=True)
+    mod.LANE_REGISTRY_FILE.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "q26-conflict",
+                    "owner_session": "codex-q26",
+                    "status": "conflict",
+                    "updated_at": "2026-05-18T17:10:00Z",
+                    "branch": "droid/P16-stage2",
+                    "pr_number": 7292,
+                    "conflict_reason": "stale blocker",
+                },
+                {
+                    "lane_id": "q27-active",
+                    "owner_session": "codex-q27",
+                    "status": "active",
+                    "updated_at": "2026-05-18T17:00:00Z",
+                    "branch": "droid/P16-stage2",
+                    "pr_number": 7292,
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mod, "discover", lambda **_kwargs: [])
+
+    rc = mod.cmd_owner(argparse.Namespace(json=True, pr=7292, branch=None, worktree=None))
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["owner_status"] == "owned"
+    assert payload["lane_id"] == "q27-active"
+    assert payload["owner_session"] == "codex-q27"
+
+
+def test_cmd_owner_json_reports_newest_historical_match_when_unowned(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import agent_bridge as mod
+
+    _patch_bridge_paths(mod, tmp_path, monkeypatch)
+    mod.AGENT_BRIDGE_DIR.mkdir(parents=True, exist_ok=True)
+    mod.LANE_REGISTRY_FILE.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "older-completed",
+                    "owner_session": "codex-old",
+                    "status": "completed",
+                    "updated_at": "2026-05-18T17:00:00Z",
+                    "branch": "droid/P16-stage2",
+                    "pr_number": 7292,
+                },
+                {
+                    "lane_id": "newer-released",
+                    "owner_session": "codex-new",
+                    "status": "released",
+                    "updated_at": "2026-05-18T17:10:00Z",
+                    "branch": "droid/P16-stage2",
+                    "pr_number": 7292,
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mod, "discover", lambda **_kwargs: [])
+
+    rc = mod.cmd_owner(argparse.Namespace(json=True, pr=7292, branch=None, worktree=None))
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["owner_status"] == "unowned"
+    assert payload["active_owner"] is False
+    assert payload["lane_id"] == "newer-released"
+    assert payload["owner_session"] == "codex-new"
+    assert payload["status"] == "released"
+    assert payload["recommended_operator_action"] == (
+        "latest matching lane is released; claim the lane before mutation"
+    )
+
+
 def test_collect_agent_process_census_redacts_commands_and_counts_roles() -> None:
     import agent_bridge as mod
 

--- a/tests/scripts/test_identify_lane_owner.py
+++ b/tests/scripts/test_identify_lane_owner.py
@@ -707,6 +707,41 @@ class TestMainCLI:
         assert data["pr_number"] == 7292
         assert data["live_process"]["found"] is False  # no snapshot integration in CLI default path
         assert data["pending_message_count"] == 0
+        assert data["dispatchable"] is True
+        assert data["dispatch_blocker"] is None
+        assert data["harness_confidence"] == "mailbox_only"
+        assert "send_operator_steering.py --to codex-p19-repair-7292" in data["steering_command"]
+
+    def test_completed_lane_reports_mailbox_only_but_not_dispatchable(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        registry = write_lane_registry(
+            tmp_path,
+            [
+                {
+                    "lane_id": "q25-finished",
+                    "owner_session": "codex-finished",
+                    "source": "codex",
+                    "status": "released",
+                    "branch": "codex/finished",
+                    "worktree": "/tmp/finished",
+                    "pr_number": 7370,
+                    "updated_at": "2026-05-19T17:49:14Z",
+                }
+            ],
+        )
+
+        rc = ilo.main(["--pr", "7370", "--json", *self._cli_args(registry, tmp_path)])
+
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["owner_session"] == "codex-finished"
+        assert data["dispatchable"] is False
+        assert data["dispatch_blocker"] == (
+            "lane status is released; claim an active lane before steering"
+        )
+        assert data["steering_command"] is None
+        assert data["harness_confidence"] == "mailbox_only"
 
     def test_happy_path_human(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         registry = write_lane_registry(tmp_path)

--- a/tests/scripts/test_send_operator_steering.py
+++ b/tests/scripts/test_send_operator_steering.py
@@ -558,6 +558,85 @@ class TestActiveOwnerRouting:
         assert parsed["_route"]["resolved_via"] == "pr"
         assert parsed["_route"]["lane_id"] == "q23-repair-7292"
         assert parsed["_route"]["owner_session"] == "codex-q23"
+        assert parsed["_route"]["dispatchable"] is True
+        assert parsed["_route"]["steering_inbox_path"] == str(tmp_path / "inbox" / "codex-q23")
+
+    def test_dry_run_to_owner_pr_does_not_write(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        registry = self._write_lanes(
+            tmp_path,
+            [
+                {
+                    "lane_id": "q23-repair-7292",
+                    "owner_session": "codex-q23",
+                    "status": "active",
+                    "pr_number": 7292,
+                    "updated_at": "2026-05-19T16:05:53Z",
+                }
+            ],
+        )
+
+        rc = sos.main(
+            [
+                "--to-owner-pr",
+                "7292",
+                "--body",
+                "route metadata please",
+                "--json",
+                "--dry-run",
+                "--lane-registry-path",
+                str(registry),
+                "--steering-inbox-root",
+                str(tmp_path / "inbox"),
+            ]
+        )
+
+        assert rc == 0
+        parsed = json.loads(capsys.readouterr().out)
+        assert parsed["_dry_run"] is True
+        assert parsed["_would_write"] is True
+        assert parsed["_written_path"] is None
+        assert parsed["_route"]["owner_session"] == "codex-q23"
+        assert list((tmp_path / "inbox").rglob("*.json")) == []
+
+    def test_print_target_to_owner_pr_does_not_require_body_or_write(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        registry = self._write_lanes(
+            tmp_path,
+            [
+                {
+                    "lane_id": "q23-repair-7292",
+                    "owner_session": "codex-q23",
+                    "status": "active",
+                    "pr_number": 7292,
+                    "updated_at": "2026-05-19T16:05:53Z",
+                }
+            ],
+        )
+
+        rc = sos.main(
+            [
+                "--to-owner-pr",
+                "7292",
+                "--print-target",
+                "--json",
+                "--lane-registry-path",
+                str(registry),
+                "--steering-inbox-root",
+                str(tmp_path / "inbox"),
+            ]
+        )
+
+        assert rc == 0
+        parsed = json.loads(capsys.readouterr().out)
+        assert parsed["_dry_run"] is True
+        assert parsed["_would_write"] is False
+        assert parsed["_target"]["resolved_via"] == "pr"
+        assert parsed["_target"]["owner_session"] == "codex-q23"
+        assert parsed["_target"]["steering_inbox_path"] == str(tmp_path / "inbox" / "codex-q23")
+        assert list((tmp_path / "inbox").rglob("*.json")) == []
 
     def test_to_owner_pr_rejects_completed_only_owner(self, tmp_path: Path) -> None:
         registry = self._write_lanes(


### PR DESCRIPTION
## Summary
- Aligns `agent_bridge.py owner` with `identify_lane_owner.py` ranking for PR/branch/worktree selectors: active lanes first, then conflict lanes, then newest completed/released history.
- Reports conflict-status lanes with `owner_status=conflict`, conflict reason, and a resolve-before-mutation action instead of falling through to unowned.
- Adds dispatchability metadata to `identify_lane_owner.py`: `dispatchable`, `dispatch_blocker`, `steering_command`, and `harness_confidence`.
- Adds no-write target discovery to `send_operator_steering.py` via `--dry-run` and `--print-target`.
- Preserves strict real dispatch semantics: mailbox writes still require exactly one active owner and remain confined to `.aragora/operator-steering/<owner_session>/`.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/scripts/test_identify_lane_owner.py tests/scripts/test_send_operator_steering.py tests/scripts/test_agent_bridge.py -q -p no:cacheprovider` -> 125 passed.
- `python3 -m ruff check scripts/identify_lane_owner.py scripts/send_operator_steering.py scripts/agent_bridge.py tests/scripts/test_identify_lane_owner.py tests/scripts/test_send_operator_steering.py tests/scripts/test_agent_bridge.py` -> passed.
- `python3 -m ruff format --check scripts/identify_lane_owner.py scripts/send_operator_steering.py scripts/agent_bridge.py tests/scripts/test_identify_lane_owner.py tests/scripts/test_send_operator_steering.py tests/scripts/test_agent_bridge.py` -> passed.
- `python3 -m mypy scripts/identify_lane_owner.py scripts/send_operator_steering.py scripts/agent_bridge.py --ignore-missing-imports --no-incremental` -> passed.
- `git diff --check` -> passed.
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> passed.

## Dogfood
- `python3 scripts/identify_lane_owner.py --pr 7370 --json` reports Q25 as completed, non-dispatchable, with `dispatch_blocker="lane status is completed; claim an active lane before steering"` and `harness_confidence="mailbox_only_fuzzy_thread"`.
- Temp-registry `send_operator_steering.py --to-owner-pr 9999 --print-target --json` resolved target metadata and wrote zero files.
- Temp-registry `send_operator_steering.py --to-owner-pr 9999 --body ... --dry-run --json` produced message metadata and wrote zero files.

No real `.aragora/operator-steering` inbox writes, lane-registry edits, publisher state edits, launchd, `automation.toml`, H2, or observe-outcomes changes were made.
