### PR TITLE
fix(automation): flag stale outbox branch heads

### DIFF
--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -678,6 +678,41 @@ def _remote_tracking_head(repo_root: Path, branch: str | None) -> str | None:
     return value if re.fullmatch(r"[0-9a-fA-F]{7,40}", value) else None
 
 
+def _branch_tip(repo_root: Path, branch: str | None) -> str | None:
+    if not branch:
+        return None
+
+    refs = [branch] if branch.startswith("origin/") else [f"origin/{branch}", branch]
+    for ref in dict.fromkeys(refs):
+        proc = _run(["git", "rev-parse", "--verify", ref], cwd=repo_root)
+        if proc.returncode != 0:
+            continue
+        value = proc.stdout.strip()
+        if re.fullmatch(r"[0-9a-fA-F]{7,40}", value):
+            return value
+    return None
+
+
+def _stale_outbox_head(repo_root: Path, handoff: Handoff) -> str | None:
+    if handoff.source_kind != "outbox" or not handoff.branch or not handoff.desired_head:
+        return None
+    branch_tip = _branch_tip(repo_root, handoff.branch)
+    if not branch_tip or _head_matches(handoff.desired_head, branch_tip):
+        return None
+    return branch_tip
+
+
+def _local_handoff_blocker(repo_root: Path, handoff: Handoff) -> PublishDecision | None:
+    if _stale_outbox_head(repo_root, handoff):
+        return PublishDecision(
+            task_title=handoff.task_title,
+            source_file=handoff.source_file,
+            eligible=False,
+            reason="stale_outbox_head",
+        )
+    return None
+
+
 def _receipt_satisfies_outbox(
     repo_root: Path,
     payload: dict[str, Any],
@@ -1169,6 +1204,10 @@ def decide_handoffs(
     open_issue_count = _open_boss_ready_count(repo_root, repo, labels)
     decisions: list[PublishDecision] = []
     for handoff in handoffs:
+        local_blocker = _local_handoff_blocker(repo_root, handoff)
+        if local_blocker is not None:
+            decisions.append(local_blocker)
+            continue
         target_pr = _target_open_pr(repo_root, repo, handoff)
         if target_pr:
             decisions.append(
@@ -1408,7 +1447,8 @@ def main(argv: list[str] | None = None) -> int:
     if not github_health.ready:
         decision_handoffs = handoffs[: max(args.limit, 0)]
         decisions = [
-            PublishDecision(
+            _local_handoff_blocker(repo_root, handoff)
+            or PublishDecision(
                 task_title=handoff.task_title,
                 source_file=handoff.source_file,
                 eligible=False,

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -118,6 +118,37 @@ def _repo_with_patch_equivalent_codex_branch(tmp_path: Path) -> tuple[Path, str]
     return repo, head
 
 
+def _repo_with_stale_outbox_head(tmp_path: Path) -> tuple[Path, str, str]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    def git(*args: str) -> str:
+        proc = subprocess.run(
+            ["git", *args],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return proc.stdout.strip()
+
+    git("init")
+    git("checkout", "-b", "main")
+    git("config", "user.email", "codex@example.com")
+    git("config", "user.name", "Codex")
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    git("add", "README.md")
+    git("commit", "-m", "base")
+    git("checkout", "-b", "codex/example")
+    (repo / "README.md").write_text("base\nold\n", encoding="utf-8")
+    git("commit", "-am", "old")
+    old_head = git("rev-parse", "HEAD")
+    (repo / "README.md").write_text("base\nold\nnew\n", encoding="utf-8")
+    git("commit", "-am", "new")
+    new_head = git("rev-parse", "HEAD")
+    return repo, old_head, new_head
+
+
 def test_load_handoffs_parses_structured_memory(tmp_path: Path) -> None:
     _memory(tmp_path, "founder-review", _handoff())
 
@@ -1187,6 +1218,8 @@ def test_decide_handoffs_routes_branch_handoff_to_open_pr_before_issue_cap(
             )
         if args[:3] == ["gh", "pr", "list"]:
             return subprocess.CompletedProcess(args, 0, "[]", "")
+        if args[:3] == ["git", "rev-parse", "--verify"]:
+            return subprocess.CompletedProcess(args, 1, "", "unknown ref")
         raise AssertionError(f"unexpected args: {args}")
 
     monkeypatch.setattr(mod, "_run", fake_run)
@@ -1252,6 +1285,8 @@ def test_decide_handoffs_keeps_branch_update_actionable_when_pr_head_is_stale(
             return subprocess.CompletedProcess(args, 0, "[]", "")
         if args[:3] == ["gh", "pr", "list"]:
             return subprocess.CompletedProcess(args, 0, "[]", "")
+        if args[:3] == ["git", "rev-parse", "--verify"]:
+            return subprocess.CompletedProcess(args, 1, "", "unknown ref")
         raise AssertionError(f"unexpected args: {args}")
 
     monkeypatch.setattr(mod, "_run", fake_run)
@@ -1272,6 +1307,51 @@ def test_decide_handoffs_keeps_branch_update_actionable_when_pr_head_is_stale(
             reason="eligible",
         )
     ]
+
+
+def test_decide_handoffs_blocks_stale_outbox_head_before_pr_lookup(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    repo, old_head, new_head = _repo_with_stale_outbox_head(tmp_path)
+    handoff = Handoff(
+        source_file=str(tmp_path / "outbox.json"),
+        task_title="Open draft PR for stale evidence",
+        priority="MEDIUM",
+        body="body",
+        labels={},
+        expires_at=None,
+        source_kind="outbox",
+        branch="codex/example",
+        desired_head=old_head,
+    )
+    real_run = mod._run
+
+    def fake_run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+        if args[:3] == ["gh", "issue", "list"] and "--label" in args:
+            return subprocess.CompletedProcess(args, 0, "[]", "")
+        if args and args[0] == "gh":
+            raise AssertionError(f"unexpected GitHub lookup for stale handoff: {args}")
+        return real_run(args, cwd=cwd)
+
+    monkeypatch.setattr(mod, "_run", fake_run)
+
+    decisions = mod.decide_handoffs(
+        [handoff],
+        repo_root=repo,
+        repo="synaptent/aragora",
+        labels=["boss-ready"],
+        max_open_issues=12,
+    )
+
+    assert decisions == [
+        PublishDecision(
+            task_title=handoff.task_title,
+            source_file=handoff.source_file,
+            eligible=False,
+            reason="stale_outbox_head",
+        )
+    ]
+    assert mod._branch_tip(repo, "codex/example") == new_head
 
 
 def test_decide_handoffs_prefers_branch_pr_over_duplicate_issue(
@@ -1862,6 +1942,66 @@ def test_main_reports_github_health_when_unavailable(
             "github_unavailable": 1,
         },
     }
+
+
+def test_main_reports_stale_outbox_head_when_github_unavailable(
+    monkeypatch: Any, tmp_path: Path, capsys: Any
+) -> None:
+    repo, old_head, _new_head = _repo_with_stale_outbox_head(tmp_path)
+    outbox = repo / ".aragora" / "automation-outbox"
+    receipts = repo / ".aragora" / "automation-receipts"
+    outbox.mkdir(parents=True)
+    receipts.mkdir(parents=True)
+    (outbox / "open-pr-codex-example-oldhead.json").write_text(
+        json.dumps(
+            _outbox_payload(
+                repo="synaptent/aragora",
+                requested_action={
+                    "type": "open_or_update_pr",
+                    "branch": "codex/example",
+                    "base": "main",
+                    "desired_head_sha": old_head,
+                },
+                local_evidence={
+                    "branch": "codex/example",
+                    "base": "main",
+                    "head_sha": old_head,
+                },
+            )
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda repo_root: GitHubCLIHealth(
+            ready=False,
+            auth_ok=False,
+            api_ok=False,
+            mode="connectivity_failed",
+            error="error connecting to api.github.com",
+            repo=str(repo_root),
+        ),
+    )
+
+    exit_code = mod.main(
+        [
+            "--repo",
+            str(repo),
+            "--codex-home",
+            str(tmp_path / "codex-home"),
+            "--outbox-dir",
+            str(outbox),
+            "--receipt-dir",
+            str(receipts),
+            "--json",
+        ]
+    )
+
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["outbox_handoff_count"] == 1
+    assert payload["decisions"][0]["reason"] == "stale_outbox_head"
 
 
 def test_main_limits_github_unavailable_decision_preview(


### PR DESCRIPTION
## Summary
- rebase P86 publisher stale-outbox handoff work after #7365 merged
- keep stale outbox desired-head detection when GitHub is unavailable
- preserve decision summaries for unavailable GitHub previews

## Validation
- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/scripts/test_publish_automation_handoffs.py -q -p no:cacheprovider
- python3 -m ruff check scripts/publish_automation_handoffs.py tests/scripts/test_publish_automation_handoffs.py
- python3 -m ruff format --check scripts/publish_automation_handoffs.py tests/scripts/test_publish_automation_handoffs.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- pre-push hooks passed during git push

No dependency PRs, drafts, cleanup, launchd, automation.toml, protected PRs, or root generated metrics were touched.