### PR TITLE
fix(scripts): bind stage2 subprocesses to repo root

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -16,7 +16,7 @@
 | Python lines of code under aragora/ | `1943843` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `140` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
 | Test files (test_*.py under tests/) | `5208` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `218707` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| Test functions (class + module level) | `218731` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
 | @pytest.mark.parametrize decorators | `698` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `70` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2870` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
@@ -28,7 +28,7 @@
 | Allowlisted agent types | `34` | `aragora/config/settings.py` | `grep -A 50 'ALLOWED_AGENT_TYPES' aragora/config/settings.py \| grep -oE "'[a-z-]+'" \| sort -u \| wc -l` |
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `46` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |
-| Markdown files under docs/ | `927` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
+| Markdown files under docs/ | `929` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
 | GitHub Actions workflows | `85` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
 | Mypy baseline errors (grandfathered) | `3317` | `.mypy-baseline` | `wc -l .mypy-baseline` |
 

--- a/scripts/auto_merge_bucket_a.py
+++ b/scripts/auto_merge_bucket_a.py
@@ -136,7 +136,7 @@ ReviewQueueSourceValidator = Callable[[], str | None]
 
 
 def _default_runner(args: list[str]) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(args, text=True, capture_output=True, check=False)
+    return subprocess.run(args, text=True, capture_output=True, check=False, cwd=REPO_ROOT)
 
 
 def trusted_authors(env: Mapping[str, str] | None = None) -> frozenset[str]:

--- a/tests/scripts/test_auto_merge_bucket_a.py
+++ b/tests/scripts/test_auto_merge_bucket_a.py
@@ -231,6 +231,71 @@ class _MergePacketRegistry:
 
 
 class TestGhMerge:
+    def test_default_subprocesses_run_from_repo_root(self, tmp_path: Path, monkeypatch):
+        calls: list[tuple[list[str], Path | None]] = []
+
+        def fake_run(
+            args: list[str],
+            *,
+            text: bool,
+            capture_output: bool,
+            check: bool,
+            cwd: Path | None = None,
+        ) -> subprocess.CompletedProcess[str]:
+            calls.append((args, cwd))
+            if args == ["python3", str(amba.TRIAGE_SCRIPT), "--json"]:
+                stdout = json.dumps(make_triage_payload(bucket_a_entry(9001)))
+            elif args[:3] == ["gh", "pr", "view"]:
+                stdout = json.dumps(make_metadata(9001))
+            elif args[:3] == ["python3", "-m", "aragora.cli.main"]:
+                stdout = json.dumps(make_merge_packet(9001, head_sha="a" * 40))
+            else:
+                stdout = ""
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout=stdout, stderr="")
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(amba.subprocess, "run", fake_run)
+
+        amba.run_triage()
+        amba.fetch_pr_commit_metadata(9001)
+        amba.fetch_merge_packet(9001)
+        amba.gh_pr_merge_squash(9001, "a" * 40)
+
+        assert [call[0] for call in calls] == [
+            ["python3", str(amba.TRIAGE_SCRIPT), "--json"],
+            [
+                "gh",
+                "pr",
+                "view",
+                "9001",
+                "--json",
+                (
+                    "number,title,author,isDraft,mergeable,mergeStateStatus,"
+                    "labels,files,commits,statusCheckRollup,headRefOid,reviewDecision"
+                ),
+            ],
+            [
+                "python3",
+                "-m",
+                "aragora.cli.main",
+                "review-queue",
+                "merge-packet",
+                "--pr",
+                "9001",
+                "--json",
+            ],
+            [
+                "gh",
+                "pr",
+                "merge",
+                "9001",
+                "--squash",
+                "--match-head-commit",
+                "a" * 40,
+            ],
+        ]
+        assert all(cwd == amba.REPO_ROOT for _, cwd in calls)
+
     def test_merge_uses_exact_head_and_preserves_branch_by_default(self):
         calls: list[list[str]] = []
 


### PR DESCRIPTION
## Summary
- bind the default Stage 2 auto-merge subprocess runner to `REPO_ROOT`
- add a focused regression proving caller cwd cannot redirect triage, PR metadata fetch, merge-packet fetch, or `gh pr merge`
- refresh `docs/METRICS.md` with the generated count changes from the added test

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/scripts/test_auto_merge_bucket_a.py -q -p no:cacheprovider` — 86 passed
- `python3 -m ruff check scripts/auto_merge_bucket_a.py tests/scripts/test_auto_merge_bucket_a.py` — passed
- `python3 -m ruff format --check scripts/auto_merge_bucket_a.py tests/scripts/test_auto_merge_bucket_a.py` — passed
- `python3 -m mypy scripts/auto_merge_bucket_a.py tests/scripts/test_auto_merge_bucket_a.py --ignore-missing-imports --no-incremental` — passed
- `python3 scripts/regenerate_metrics.py --check` — passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` — passed

## Dogfood
- `python3 scripts/auto_merge_bucket_a.py --json --only-pr 7292` still exits before Stage 2 logic because broad `triage_open_prs.py --json` hits GitHub GraphQL HTTP 504. That is the known separate `--only-pr` fallback issue and is intentionally not changed in this PR.
