### PR TITLE
feat: add operator steering read receipts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,14 @@ For Codex-driven automations in this repo, default to maximum safe autonomy. Fin
 
 - Use the shared automation merge contract in `docs/briefs/automation-merge-contract.md`.
   Before publishing local Codex app automation or Aragora boss-loop worker branches, run `bash scripts/automation_pr_preflight.sh origin/main HEAD` from the branch worktree, or run it against the explicit worker branch.
+- Before continuing lane work, check the owner-session operator-steering mailbox
+  with `python3 scripts/read_operator_steering.py --lane-id <LANE_ID>` or the
+  equivalent `--pr`, `--branch`, or `--to OWNER_SESSION` selector. The reader
+  leaves top-level message files in place and writes append-only read receipts
+  under `.aragora/operator-steering/<owner_session>/_read_receipts/`. This is
+  visibility only, not an ack protocol: messages remain pending until a future
+  ack/move protocol exists. Other sessions can verify read state through
+  `scripts/identify_lane_owner.py` or `scripts/agent_bridge.py operator-snapshot`.
 - Prefer execution over advice:
   verify the issue, make the smallest credible fix, validate it, commit it, push it, open the PR, and leave the inbox or memory handoff in the same run when the task is otherwise ready.
 - Do not stop at the first blocked path:

--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -1602,23 +1602,35 @@ def _collect_pending_steering_messages(
         steering_root = REPO_ROOT / ".aragora" / "operator-steering"
     if not steering_root.is_dir():
         if session_name:
-            return {"count": 0, "latest_three": []}
-        return {"count": 0, "by_recipient": {}, "latest_three": []}
+            return {
+                "count": 0,
+                "latest_three": [],
+                "read_receipt_count": 0,
+                "unread_message_count": 0,
+                "latest_read_receipt": None,
+            }
+        return {
+            "count": 0,
+            "by_recipient": {},
+            "latest_three": [],
+            "read_receipt_count": 0,
+            "unread_message_count": 0,
+            "read_receipts_by_recipient": {},
+            "latest_read_receipt": None,
+        }
 
-    def _summary_from(path: Path) -> dict[str, Any]:
+    def _load_json_dict(path: Path) -> dict[str, Any] | None:
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
+            return None
+        return data if isinstance(data, dict) else None
+
+    def _summary_from(path: Path) -> dict[str, Any]:
+        data = _load_json_dict(path)
+        if data is None:
             return {
                 "subject": "(unreadable)",
-                "sent_at_utc": "",
-                "priority": "",
-                "lane_id_hint": None,
-                "pr_hint": None,
-            }
-        if not isinstance(data, dict):
-            return {
-                "subject": "(invalid)",
                 "sent_at_utc": "",
                 "priority": "",
                 "lane_id_hint": None,
@@ -1639,30 +1651,98 @@ def _collect_pending_steering_messages(
         # consumed messages per the Phase D convention.
         return [p for p in dir_path.glob("*.json") if p.is_file()]
 
+    def _read_receipt_summary(dir_path: Path, files: list[Path]) -> dict[str, Any]:
+        receipt_dir = dir_path / "_read_receipts"
+        if not receipt_dir.is_dir():
+            return {
+                "read_receipt_count": 0,
+                "unread_message_count": len(files),
+                "latest_read_receipt": None,
+            }
+
+        receipts: list[dict[str, Any]] = []
+        read_bindings: set[tuple[str, str]] = set()
+        for receipt_path in receipt_dir.glob("*.json"):
+            receipt = _load_json_dict(receipt_path)
+            if receipt is None:
+                continue
+            with_filename = dict(receipt)
+            with_filename["receipt_filename"] = receipt_path.name
+            receipts.append(with_filename)
+            msg_filename = str(receipt.get("message_filename") or "")
+            msg_sha = str(receipt.get("message_sha256") or "")
+            if msg_filename and msg_sha:
+                read_bindings.add((msg_filename, msg_sha))
+
+        unread_count = 0
+        for message_path in files:
+            message = _load_json_dict(message_path)
+            msg_sha = "" if message is None else str(message.get("message_sha256") or "")
+            if not msg_sha or (message_path.name, msg_sha) not in read_bindings:
+                unread_count += 1
+
+        latest: dict[str, Any] | None = None
+        if receipts:
+            latest_raw = max(receipts, key=lambda r: str(r.get("read_at_utc") or ""))
+            latest = {
+                "receipt_filename": latest_raw.get("receipt_filename"),
+                "read_at_utc": latest_raw.get("read_at_utc"),
+                "read_by_session": latest_raw.get("read_by_session"),
+                "message_filename": latest_raw.get("message_filename"),
+                "message_sha256": latest_raw.get("message_sha256"),
+                "outcome": latest_raw.get("outcome"),
+                "subject": latest_raw.get("subject"),
+            }
+        return {
+            "read_receipt_count": len(receipts),
+            "unread_message_count": unread_count,
+            "latest_read_receipt": latest,
+        }
+
     if session_name:
-        files = _inbox_files(steering_root / session_name)
+        inbox = steering_root / session_name
+        files = _inbox_files(inbox)
         summaries = sorted(
             (_summary_from(p) for p in files),
             key=lambda s: s["sent_at_utc"],
             reverse=True,
         )
-        return {"count": len(files), "latest_three": summaries[:3]}
+        receipt_summary = _read_receipt_summary(inbox, files)
+        return {"count": len(files), "latest_three": summaries[:3], **receipt_summary}
 
     # Roll-up across all recipient dirs.
     by_recipient: dict[str, int] = {}
+    read_receipts_by_recipient: dict[str, int] = {}
     all_summaries: list[dict[str, Any]] = []
+    all_receipts: list[dict[str, Any]] = []
+    total_read_receipts = 0
+    total_unread = 0
     for child in sorted(steering_root.iterdir()):
         if not child.is_dir() or child.name.startswith("."):
             continue
         files = _inbox_files(child)
+        receipt_summary = _read_receipt_summary(child, files)
+        total_read_receipts += int(receipt_summary["read_receipt_count"])
+        total_unread += int(receipt_summary["unread_message_count"])
+        if receipt_summary["read_receipt_count"]:
+            read_receipts_by_recipient[child.name] = int(receipt_summary["read_receipt_count"])
+        if receipt_summary["latest_read_receipt"] is not None:
+            all_receipts.append(receipt_summary["latest_read_receipt"])
         if files:
             by_recipient[child.name] = len(files)
             all_summaries.extend(_summary_from(p) for p in files)
     all_summaries.sort(key=lambda s: s["sent_at_utc"], reverse=True)
+    latest_read_receipt = None
+    if all_receipts:
+        latest_read_receipt = max(all_receipts, key=lambda r: str(r.get("read_at_utc") or ""))
     return {
         "count": sum(by_recipient.values()),
         "by_recipient": by_recipient,
         "latest_three": all_summaries[:3],
+        "read_receipt_count": total_read_receipts,
+        "unread_message_count": total_unread,
+        "read_receipts_by_recipient": read_receipts_by_recipient,
+        "latest_read_receipt": latest_read_receipt,
     }
 
 

--- a/scripts/identify_lane_owner.py
+++ b/scripts/identify_lane_owner.py
@@ -114,6 +114,9 @@ class LaneOwnerInfo:
     factory_droid: dict[str, Any]
     steering_inbox_path: str
     pending_message_count: int
+    read_receipt_count: int
+    unread_message_count: int
+    latest_read_receipt: dict[str, Any] | None
     dispatchable: bool
     dispatch_blocker: str | None
     steering_command: str | None
@@ -662,14 +665,71 @@ def lookup_factory_droid(
 
 def steering_inbox_for(
     owner_session: str, *, root: Path = STEERING_INBOX_ROOT_DEFAULT
-) -> tuple[Path, int]:
-    """Return ``(inbox_path, pending_count)``; missing dir → ``(path, 0)``."""
+) -> tuple[Path, int, dict[str, Any]]:
+    """Return inbox path, top-level message count, and read-receipt summary."""
 
     inbox = root / owner_session
     if not inbox.is_dir():
-        return inbox, 0
-    count = sum(1 for _ in inbox.glob("*.json"))
-    return inbox, count
+        return inbox, 0, _read_receipt_summary(inbox, [])
+    message_files = [p for p in inbox.glob("*.json") if p.is_file()]
+    return inbox, len(message_files), _read_receipt_summary(inbox, message_files)
+
+
+def _load_json_dict(path: Path) -> dict[str, Any] | None:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _read_receipt_summary(inbox: Path, message_files: Sequence[Path]) -> dict[str, Any]:
+    receipt_dir = inbox / "_read_receipts"
+    if not receipt_dir.is_dir():
+        return {
+            "read_receipt_count": 0,
+            "unread_message_count": len(message_files),
+            "latest_read_receipt": None,
+        }
+
+    receipts: list[dict[str, Any]] = []
+    read_bindings: set[tuple[str, str]] = set()
+    for path in receipt_dir.glob("*.json"):
+        receipt = _load_json_dict(path)
+        if receipt is None:
+            continue
+        receipt_with_filename = dict(receipt)
+        receipt_with_filename["receipt_filename"] = path.name
+        receipts.append(receipt_with_filename)
+        msg_filename = str(receipt.get("message_filename") or "")
+        msg_sha = str(receipt.get("message_sha256") or "")
+        if msg_filename and msg_sha:
+            read_bindings.add((msg_filename, msg_sha))
+
+    unread_count = 0
+    for message_path in message_files:
+        message = _load_json_dict(message_path)
+        msg_sha = "" if message is None else str(message.get("message_sha256") or "")
+        if not msg_sha or (message_path.name, msg_sha) not in read_bindings:
+            unread_count += 1
+
+    latest: dict[str, Any] | None = None
+    if receipts:
+        latest_raw = max(receipts, key=lambda r: str(r.get("read_at_utc") or ""))
+        latest = {
+            "receipt_filename": latest_raw.get("receipt_filename"),
+            "read_at_utc": latest_raw.get("read_at_utc"),
+            "read_by_session": latest_raw.get("read_by_session"),
+            "message_filename": latest_raw.get("message_filename"),
+            "message_sha256": latest_raw.get("message_sha256"),
+            "outcome": latest_raw.get("outcome"),
+            "subject": latest_raw.get("subject"),
+        }
+    return {
+        "read_receipt_count": len(receipts),
+        "unread_message_count": unread_count,
+        "latest_read_receipt": latest,
+    }
 
 
 def _dispatch_blocker_for(lane: dict[str, Any], owner_session: str) -> str | None:
@@ -756,7 +816,7 @@ def build_owner_info(
     codex = lookup_codex_thread(lane, sessions_root=sessions_root, now=fuzzy_now)
     claude = lookup_claude_session(lane, projects_root=projects_root)
     factory = lookup_factory_droid(lane, bg_path=bg_path)
-    inbox_path, pending = steering_inbox_for(owner, root=steering_inbox_root)
+    inbox_path, pending, receipt_summary = steering_inbox_for(owner, root=steering_inbox_root)
     dispatch_blocker = _dispatch_blocker_for(lane, owner)
 
     raw_pr = lane.get("pr_number")
@@ -785,6 +845,9 @@ def build_owner_info(
         factory_droid=factory,
         steering_inbox_path=str(inbox_path),
         pending_message_count=pending,
+        read_receipt_count=int(receipt_summary["read_receipt_count"]),
+        unread_message_count=int(receipt_summary["unread_message_count"]),
+        latest_read_receipt=receipt_summary["latest_read_receipt"],
         dispatchable=dispatch_blocker is None,
         dispatch_blocker=dispatch_blocker,
         steering_command=_steering_command_for(lane, owner),
@@ -836,6 +899,9 @@ def _print_human(info: LaneOwnerInfo) -> None:
     print()
     print(f"steering_inbox_path:   {info.steering_inbox_path}")
     print(f"pending_message_count: {info.pending_message_count}")
+    print(f"read_receipt_count:    {info.read_receipt_count}")
+    print(f"unread_message_count:  {info.unread_message_count}")
+    print(f"latest_read_receipt:   {info.latest_read_receipt or '-'}")
     print(f"dispatchable:          {info.dispatchable}")
     print(f"dispatch_blocker:      {info.dispatch_blocker or '-'}")
     print(f"steering_command:      {info.steering_command or '-'}")

--- a/scripts/read_operator_steering.py
+++ b/scripts/read_operator_steering.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Read operator-steering messages and write append-only read receipts.
+
+This is a sidecar receipt protocol, not an ack protocol: top-level
+``*.json`` messages remain in place and still count as pending until a
+future explicit ack/move flow exists.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+import secrets
+import sys
+import tempfile
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import identify_lane_owner as owner_lookup
+import send_operator_steering as steering_writer
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+STEERING_INBOX_ROOT_DEFAULT = REPO_ROOT / ".aragora" / "operator-steering"
+LANE_REGISTRY_DEFAULT = REPO_ROOT / ".aragora" / "agent-bridge" / "lanes.json"
+READ_RECEIPT_SCHEMA_VERSION = "aragora-operator-steering-read-receipt/1.0"
+OUTCOME_CHOICES = ("read", "obeyed", "held", "stale", "superseded", "blocked")
+
+
+def _now_utc_iso() -> str:
+    return (
+        datetime.datetime.now(datetime.timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def _filename_timestamp(iso: str) -> str:
+    return iso.replace(":", "-").replace(".", "-")
+
+
+def _resolve_owner_session(
+    *,
+    to_session: str | None,
+    lane_id: str | None,
+    pr: int | None,
+    branch: str | None,
+    registry_path: Path,
+    steering_inbox_root: Path,
+) -> tuple[str, str, dict[str, Any] | None]:
+    if to_session:
+        steering_writer.validate_to_session(to_session, steering_inbox_root=steering_inbox_root)
+        return to_session, "direct", None
+
+    records = owner_lookup.load_lane_records(registry_path)
+    lane = owner_lookup.find_lane(records, lane_id=lane_id, pr=pr, branch=branch)
+    if lane is None:
+        raise ValueError("no lane matched the requested selector")
+    owner_session = str(lane.get("owner_session") or "")
+    if not owner_session:
+        raise ValueError("matched lane has no owner_session")
+    steering_writer.validate_to_session(owner_session, steering_inbox_root=steering_inbox_root)
+    if lane_id:
+        resolved_via = "lane-id"
+    elif pr is not None:
+        resolved_via = "pr"
+    else:
+        resolved_via = "branch"
+    return owner_session, resolved_via, lane
+
+
+def _message_files(owner_session: str, *, steering_inbox_root: Path) -> list[Path]:
+    inbox = steering_writer.validate_to_session(
+        owner_session, steering_inbox_root=steering_inbox_root
+    )
+    if not inbox.is_dir():
+        return []
+    return sorted((p for p in inbox.glob("*.json") if p.is_file()), key=lambda p: p.name)
+
+
+def _load_message(path: Path) -> tuple[dict[str, Any], bool]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}, False
+    if not isinstance(data, dict):
+        return {}, False
+    _, _, sha_ok = steering_writer.verify_message_sha256(data)
+    return data, sha_ok
+
+
+def _message_summary(path: Path) -> dict[str, Any]:
+    data, sha_ok = _load_message(path)
+    return {
+        "filename": path.name,
+        "path": str(path),
+        "schema_version": data.get("schema_version"),
+        "to_session": data.get("to_session"),
+        "from": data.get("from"),
+        "sent_at_utc": data.get("sent_at_utc"),
+        "lane_id_hint": data.get("lane_id_hint"),
+        "pr_hint": data.get("pr_hint"),
+        "priority": data.get("priority"),
+        "subject": data.get("subject"),
+        "message_sha256": data.get("message_sha256"),
+        "sha256_valid": sha_ok,
+    }
+
+
+def build_read_receipt(
+    *,
+    owner_session: str,
+    read_by_session: str,
+    message_path: Path,
+    outcome: str = "read",
+    outcome_note: str | None = None,
+    read_at_utc: str | None = None,
+) -> dict[str, Any]:
+    data, _sha_ok = _load_message(message_path)
+    receipt: dict[str, Any] = {
+        "schema_version": READ_RECEIPT_SCHEMA_VERSION,
+        "owner_session": owner_session,
+        "read_by_session": read_by_session,
+        "read_at_utc": read_at_utc or _now_utc_iso(),
+        "message_filename": message_path.name,
+        "message_sha256": data.get("message_sha256"),
+        "message_sent_at_utc": data.get("sent_at_utc"),
+        "priority": data.get("priority"),
+        "lane_id_hint": data.get("lane_id_hint"),
+        "pr_hint": data.get("pr_hint"),
+        "subject": data.get("subject"),
+        "outcome": outcome,
+    }
+    if outcome_note:
+        receipt["outcome_note"] = outcome_note
+    return receipt
+
+
+def write_read_receipt(
+    receipt: dict[str, Any],
+    *,
+    steering_inbox_root: Path = STEERING_INBOX_ROOT_DEFAULT,
+) -> Path:
+    owner_session = str(receipt.get("owner_session") or "")
+    inbox = steering_writer.validate_to_session(
+        owner_session, steering_inbox_root=steering_inbox_root
+    )
+    receipt_dir = inbox / "_read_receipts"
+    receipt_dir.mkdir(parents=True, exist_ok=True)
+    ts = _filename_timestamp(str(receipt.get("read_at_utc") or _now_utc_iso()))
+    final_path = receipt_dir / f"{ts}-{secrets.token_hex(4)}.json"
+    body = json.dumps(receipt, indent=2, sort_keys=True)
+
+    fd, tmp_path = tempfile.mkstemp(prefix=".tmp-", suffix=".json", dir=str(receipt_dir))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(body)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, final_path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+    return final_path
+
+
+def _default_read_by_session(owner_session: str) -> str:
+    return (
+        os.environ.get("ARAGORA_SESSION_ID") or os.environ.get("CODEX_SESSION_ID") or owner_session
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="read_operator_steering.py",
+        description="Read one operator-steering mailbox and optionally write read receipts.",
+    )
+    target = parser.add_mutually_exclusive_group(required=True)
+    target.add_argument("--to", metavar="OWNER_SESSION", help="Read this owner_session mailbox.")
+    target.add_argument("--lane-id", help="Resolve owner_session from lane id.")
+    target.add_argument("--pr", type=int, help="Resolve owner_session from PR number.")
+    target.add_argument("--branch", help="Resolve owner_session from branch name.")
+    parser.add_argument(
+        "--read-by-session",
+        default=None,
+        help="Session id recorded as receipt.read_by_session. Defaults to env/session target.",
+    )
+    parser.add_argument("--outcome", choices=OUTCOME_CHOICES, default="read")
+    parser.add_argument("--outcome-note", default=None)
+    parser.add_argument("--no-receipt", action="store_true", help="Read/list without writing.")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable output.")
+    parser.add_argument(
+        "--steering-inbox-root",
+        type=Path,
+        default=STEERING_INBOX_ROOT_DEFAULT,
+        help="Override .aragora/operator-steering root.",
+    )
+    parser.add_argument(
+        "--registry-path",
+        type=Path,
+        default=LANE_REGISTRY_DEFAULT,
+        help="Override .aragora/agent-bridge/lanes.json.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        owner_session, resolved_via, lane = _resolve_owner_session(
+            to_session=args.to,
+            lane_id=args.lane_id,
+            pr=args.pr,
+            branch=args.branch,
+            registry_path=args.registry_path,
+            steering_inbox_root=args.steering_inbox_root,
+        )
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    files = _message_files(owner_session, steering_inbox_root=args.steering_inbox_root)
+    read_by = args.read_by_session or _default_read_by_session(owner_session)
+    receipt_paths: list[Path] = []
+    if not args.no_receipt:
+        for path in files:
+            receipt = build_read_receipt(
+                owner_session=owner_session,
+                read_by_session=read_by,
+                message_path=path,
+                outcome=args.outcome,
+                outcome_note=args.outcome_note,
+            )
+            receipt_paths.append(
+                write_read_receipt(receipt, steering_inbox_root=args.steering_inbox_root)
+            )
+
+    out = {
+        "owner_session": owner_session,
+        "resolved_via": resolved_via,
+        "lane_id": lane.get("lane_id") if isinstance(lane, dict) else None,
+        "pr_number": lane.get("pr_number") if isinstance(lane, dict) else args.pr,
+        "branch": lane.get("branch") if isinstance(lane, dict) else args.branch,
+        "steering_inbox_path": str(args.steering_inbox_root / owner_session),
+        "message_count": len(files),
+        "receipt_count": len(receipt_paths),
+        "read_by_session": read_by,
+        "messages": [_message_summary(path) for path in files],
+        "read_receipt_paths": [str(path) for path in receipt_paths],
+        "no_receipt": bool(args.no_receipt),
+    }
+    if args.json:
+        print(json.dumps(out, indent=2, sort_keys=True))
+    else:
+        print(f"owner_session: {owner_session}")
+        print(f"steering_inbox_path: {out['steering_inbox_path']}")
+        print(f"message_count: {len(files)}")
+        print(f"receipt_count: {len(receipt_paths)}")
+        for msg in out["messages"]:
+            print(
+                f"- {msg['filename']} priority={msg['priority']} "
+                f"sent_at_utc={msg['sent_at_utc']} sha256_valid={msg['sha256_valid']} "
+                f"subject={msg['subject']}"
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_agent_bridge_steering.py
+++ b/tests/scripts/test_agent_bridge_steering.py
@@ -88,22 +88,50 @@ def _write_message(
 class TestCollectPendingSteeringMessages:
     def test_empty_mailbox_scoped(self, tmp_path: Path) -> None:
         result = ab._collect_pending_steering_messages("fixture-a", steering_root=tmp_path)
-        assert result == {"count": 0, "latest_three": []}
+        assert result == {
+            "count": 0,
+            "latest_three": [],
+            "read_receipt_count": 0,
+            "unread_message_count": 0,
+            "latest_read_receipt": None,
+        }
 
     def test_empty_mailbox_rollup(self, tmp_path: Path) -> None:
         result = ab._collect_pending_steering_messages(None, steering_root=tmp_path)
-        assert result == {"count": 0, "by_recipient": {}, "latest_three": []}
+        assert result == {
+            "count": 0,
+            "by_recipient": {},
+            "latest_three": [],
+            "read_receipt_count": 0,
+            "unread_message_count": 0,
+            "read_receipts_by_recipient": {},
+            "latest_read_receipt": None,
+        }
 
     def test_missing_dir_returns_zero(self, tmp_path: Path) -> None:
         # Steering root does not exist at all.
         result = ab._collect_pending_steering_messages(
             "fixture", steering_root=tmp_path / "no-root"
         )
-        assert result == {"count": 0, "latest_three": []}
+        assert result == {
+            "count": 0,
+            "latest_three": [],
+            "read_receipt_count": 0,
+            "unread_message_count": 0,
+            "latest_read_receipt": None,
+        }
         result_rollup = ab._collect_pending_steering_messages(
             None, steering_root=tmp_path / "no-root"
         )
-        assert result_rollup == {"count": 0, "by_recipient": {}, "latest_three": []}
+        assert result_rollup == {
+            "count": 0,
+            "by_recipient": {},
+            "latest_three": [],
+            "read_receipt_count": 0,
+            "unread_message_count": 0,
+            "read_receipts_by_recipient": {},
+            "latest_read_receipt": None,
+        }
 
     def test_single_message_scoped_surfaces_metadata(self, tmp_path: Path) -> None:
         _write_message(
@@ -117,6 +145,9 @@ class TestCollectPendingSteeringMessages:
         )
         result = ab._collect_pending_steering_messages("fixture-single", steering_root=tmp_path)
         assert result["count"] == 1
+        assert result["read_receipt_count"] == 0
+        assert result["unread_message_count"] == 1
+        assert result["latest_read_receipt"] is None
         assert len(result["latest_three"]) == 1
         first = result["latest_three"][0]
         assert first["subject"] == "hello world"
@@ -149,9 +180,60 @@ class TestCollectPendingSteeringMessages:
         result = ab._collect_pending_steering_messages(None, steering_root=tmp_path)
         assert result["count"] == 4
         assert result["by_recipient"] == {"alpha": 2, "beta": 1, "gamma": 1}
+        assert result["read_receipt_count"] == 0
+        assert result["unread_message_count"] == 4
+        assert result["read_receipts_by_recipient"] == {}
+        assert result["latest_read_receipt"] is None
         # latest_three sorted newest first across all recipients
         subjects = [m["subject"] for m in result["latest_three"]]
         assert subjects == ["g-only", "b-only", "a-second"]
+
+    def test_read_receipts_reduce_unread_but_preserve_pending_count(self, tmp_path: Path) -> None:
+        msg_a = _write_message(
+            tmp_path,
+            "receipt-fixture",
+            body="message-a",
+            sent_at_utc="2026-05-18T01:00:00.000Z",
+            filename="msg-a.json",
+        )
+        _write_message(
+            tmp_path,
+            "receipt-fixture",
+            body="message-b",
+            sent_at_utc="2026-05-18T02:00:00.000Z",
+            filename="msg-b.json",
+        )
+        msg_a_data = json.loads(msg_a.read_text(encoding="utf-8"))
+        receipt_dir = tmp_path / "receipt-fixture" / "_read_receipts"
+        receipt_dir.mkdir(parents=True)
+        (receipt_dir / "read-a.json").write_text(
+            json.dumps(
+                {
+                    "read_at_utc": "2026-05-19T22:00:00.000Z",
+                    "read_by_session": "codex-reader",
+                    "message_filename": "msg-a.json",
+                    "message_sha256": msg_a_data["message_sha256"],
+                    "outcome": "obeyed",
+                    "subject": "message-a",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = ab._collect_pending_steering_messages("receipt-fixture", steering_root=tmp_path)
+
+        assert result["count"] == 2
+        assert result["read_receipt_count"] == 1
+        assert result["unread_message_count"] == 1
+        assert result["latest_read_receipt"] == {
+            "receipt_filename": "read-a.json",
+            "read_at_utc": "2026-05-19T22:00:00.000Z",
+            "read_by_session": "codex-reader",
+            "message_filename": "msg-a.json",
+            "message_sha256": msg_a_data["message_sha256"],
+            "outcome": "obeyed",
+            "subject": "message-a",
+        }
 
     def test_acked_subdir_excluded(self, tmp_path: Path) -> None:
         """Phase D ack convention: messages moved to _acked/ should NOT count."""

--- a/tests/scripts/test_identify_lane_owner.py
+++ b/tests/scripts/test_identify_lane_owner.py
@@ -596,9 +596,16 @@ class TestLookupFactoryDroid:
 
 class TestSteeringInbox:
     def test_missing_inbox_dir_returns_zero_count(self, tmp_path: Path) -> None:
-        path, count = ilo.steering_inbox_for("nobody-1", root=tmp_path / "steering")
+        path, count, receipt_summary = ilo.steering_inbox_for(
+            "nobody-1", root=tmp_path / "steering"
+        )
         assert count == 0
         assert path == tmp_path / "steering" / "nobody-1"
+        assert receipt_summary == {
+            "read_receipt_count": 0,
+            "unread_message_count": 0,
+            "latest_read_receipt": None,
+        }
 
     def test_counts_only_dot_json_files(self, tmp_path: Path) -> None:
         inbox = tmp_path / "steering" / "claude-X"
@@ -606,9 +613,58 @@ class TestSteeringInbox:
         (inbox / "msg-a.json").write_text("{}", encoding="utf-8")
         (inbox / "msg-b.json").write_text("{}", encoding="utf-8")
         (inbox / "README.md").write_text("docs only", encoding="utf-8")
-        path, count = ilo.steering_inbox_for("claude-X", root=tmp_path / "steering")
+        path, count, receipt_summary = ilo.steering_inbox_for(
+            "claude-X", root=tmp_path / "steering"
+        )
         assert count == 2
         assert path == inbox
+        assert receipt_summary == {
+            "read_receipt_count": 0,
+            "unread_message_count": 2,
+            "latest_read_receipt": None,
+        }
+
+    def test_summarizes_read_receipts_without_changing_pending_count(self, tmp_path: Path) -> None:
+        inbox = tmp_path / "steering" / "codex-X"
+        receipt_dir = inbox / "_read_receipts"
+        receipt_dir.mkdir(parents=True)
+        (inbox / "msg-a.json").write_text(
+            json.dumps({"message_sha256": "aaa"}),
+            encoding="utf-8",
+        )
+        (inbox / "msg-b.json").write_text(
+            json.dumps({"message_sha256": "bbb"}),
+            encoding="utf-8",
+        )
+        (receipt_dir / "receipt-a.json").write_text(
+            json.dumps(
+                {
+                    "read_at_utc": "2026-05-19T22:00:00.000Z",
+                    "read_by_session": "codex-reader",
+                    "message_filename": "msg-a.json",
+                    "message_sha256": "aaa",
+                    "outcome": "held",
+                    "subject": "subject-a",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        path, count, receipt_summary = ilo.steering_inbox_for("codex-X", root=tmp_path / "steering")
+
+        assert path == inbox
+        assert count == 2
+        assert receipt_summary["read_receipt_count"] == 1
+        assert receipt_summary["unread_message_count"] == 1
+        assert receipt_summary["latest_read_receipt"] == {
+            "receipt_filename": "receipt-a.json",
+            "read_at_utc": "2026-05-19T22:00:00.000Z",
+            "read_by_session": "codex-reader",
+            "message_filename": "msg-a.json",
+            "message_sha256": "aaa",
+            "outcome": "held",
+            "subject": "subject-a",
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -638,6 +694,9 @@ class TestBuildOwnerInfo:
         assert info.desktop_label == "Test Codex Desktop Tab"
         assert info.session_title == "Rich identity claim"
         assert info.pending_message_count == 0
+        assert info.read_receipt_count == 0
+        assert info.unread_message_count == 0
+        assert info.latest_read_receipt is None
         # Live lookups all return found=False because tmp dirs are empty.
         assert info.live_process["found"] is False
         assert info.claude_session["found"] is False
@@ -707,6 +766,9 @@ class TestMainCLI:
         assert data["pr_number"] == 7292
         assert data["live_process"]["found"] is False  # no snapshot integration in CLI default path
         assert data["pending_message_count"] == 0
+        assert data["read_receipt_count"] == 0
+        assert data["unread_message_count"] == 0
+        assert data["latest_read_receipt"] is None
         assert data["dispatchable"] is True
         assert data["dispatch_blocker"] is None
         assert data["harness_confidence"] == "mailbox_only"

--- a/tests/scripts/test_read_operator_steering.py
+++ b/tests/scripts/test_read_operator_steering.py
@@ -1,0 +1,160 @@
+"""Fixture tests for ``scripts/read_operator_steering.py``."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _load_script(name: str) -> Any:
+    script_path = Path(__file__).resolve().parents[2] / "scripts" / f"{name}.py"
+    scripts_dir = str(script_path.parent)
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+    spec = importlib.util.spec_from_file_location(f"{name}_under_test", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load spec for {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+sos = _load_script("send_operator_steering")
+ros = _load_script("read_operator_steering")
+
+
+def _write_message(root: Path, recipient: str, body: str) -> Path:
+    message = sos.build_message(
+        to_session=recipient,
+        body=body,
+        from_label="operator-test",
+        lane_id_hint="Q-test",
+        pr_hint=7373,
+        priority="blocking",
+        sent_at_utc="2026-05-19T22:00:00.000Z",
+    )
+    return sos.write_message(message, steering_inbox_root=root)
+
+
+def test_reads_only_selected_owner_and_writes_bound_receipt(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    target_message = _write_message(tmp_path, "codex-target", "continue the target lane")
+    other_message = _write_message(tmp_path, "codex-other", "do not read this")
+
+    rc = ros.main(
+        [
+            "--to",
+            "codex-target",
+            "--read-by-session",
+            "codex-reader",
+            "--outcome",
+            "obeyed",
+            "--json",
+            "--steering-inbox-root",
+            str(tmp_path),
+        ]
+    )
+
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["owner_session"] == "codex-target"
+    assert data["message_count"] == 1
+    assert data["receipt_count"] == 1
+    assert data["messages"][0]["filename"] == target_message.name
+    assert data["messages"][0]["sha256_valid"] is True
+
+    receipts = sorted((tmp_path / "codex-target" / "_read_receipts").glob("*.json"))
+    assert len(receipts) == 1
+    receipt = json.loads(receipts[0].read_text(encoding="utf-8"))
+    original = json.loads(target_message.read_text(encoding="utf-8"))
+    assert receipt["schema_version"] == "aragora-operator-steering-read-receipt/1.0"
+    assert receipt["owner_session"] == "codex-target"
+    assert receipt["read_by_session"] == "codex-reader"
+    assert receipt["message_filename"] == target_message.name
+    assert receipt["message_sha256"] == original["message_sha256"]
+    assert receipt["priority"] == "blocking"
+    assert receipt["lane_id_hint"] == "Q-test"
+    assert receipt["pr_hint"] == 7373
+    assert receipt["outcome"] == "obeyed"
+    assert target_message.exists()
+    assert other_message.exists()
+    assert not (tmp_path / "codex-other" / "_read_receipts").exists()
+
+
+def test_no_receipt_lists_messages_without_writing(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _write_message(tmp_path, "codex-target", "read-only inspection")
+
+    rc = ros.main(
+        [
+            "--to",
+            "codex-target",
+            "--no-receipt",
+            "--json",
+            "--steering-inbox-root",
+            str(tmp_path),
+        ]
+    )
+
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["message_count"] == 1
+    assert data["receipt_count"] == 0
+    assert data["no_receipt"] is True
+    assert not (tmp_path / "codex-target" / "_read_receipts").exists()
+
+
+def test_rejects_unsafe_session_before_reading(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    rc = ros.main(["--to", "../escape", "--json", "--steering-inbox-root", str(tmp_path)])
+
+    assert rc == 2
+    assert "path separators" in capsys.readouterr().err
+
+
+def test_resolves_owner_by_lane_id(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    _write_message(tmp_path, "codex-lane-owner", "lane-routed message")
+    registry = tmp_path / "lanes.json"
+    registry.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "Q-lane",
+                    "owner_session": "codex-lane-owner",
+                    "status": "active",
+                    "branch": "codex/test",
+                    "pr_number": 7373,
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    rc = ros.main(
+        [
+            "--lane-id",
+            "Q-lane",
+            "--json",
+            "--registry-path",
+            str(registry),
+            "--steering-inbox-root",
+            str(tmp_path),
+        ]
+    )
+
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["owner_session"] == "codex-lane-owner"
+    assert data["resolved_via"] == "lane-id"
+    assert data["lane_id"] == "Q-lane"
+    assert data["pr_number"] == 7373
+    assert data["receipt_count"] == 1


### PR DESCRIPTION
## Summary
- add scripts/read_operator_steering.py as the official mailbox reader with append-only read receipts
- expose read_receipt_count, unread_message_count, and latest_read_receipt in identify_lane_owner.py and agent_bridge.py operator-snapshot
- document mailbox-read behavior in AGENTS.md and cover it with fixture tests

## Validation
- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/scripts/test_send_operator_steering.py tests/scripts/test_identify_lane_owner.py tests/scripts/test_agent_bridge_steering.py tests/scripts/test_read_operator_steering.py -q -p no:cacheprovider
- python3 -m ruff check scripts/read_operator_steering.py scripts/identify_lane_owner.py scripts/agent_bridge.py tests/scripts/test_read_operator_steering.py tests/scripts/test_identify_lane_owner.py tests/scripts/test_agent_bridge_steering.py
- python3 -m ruff format --check scripts/read_operator_steering.py scripts/identify_lane_owner.py scripts/agent_bridge.py tests/scripts/test_read_operator_steering.py tests/scripts/test_identify_lane_owner.py tests/scripts/test_agent_bridge_steering.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD

Note: implemented from /private/tmp/aragora-read-receipts-clean to avoid unrelated dirty root changes.