### PR TITLE
feat: add Codex Desktop steering queue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,10 @@ For Codex-driven automations in this repo, default to maximum safe autonomy. Fin
   inspect `--help`, adapt to the actual helper interface, and try the next practical route before declaring a blocker.
 - Use layered fallbacks:
   move between shell git/gh, MCP connectors, local repo inspection, and browser flows when one surface is degraded.
+- Do not launch Factory/Droid in interactive Auto Off mode for normal Aragora work.
+  Prompted Droid/Factory lanes should go through `scripts/tmux_session_launcher.sh`
+  or `scripts/agent_bridge.py launch`, which route them through `droid exec --auto high`.
+  Only use `ARAGORA_ALLOW_DROID_AUTO_OFF=1` for an explicit manual-debugging exception.
 - Recover cleanly from partial failure:
   if publish or inbox delivery fails, still leave a clean committed branch or an exact handoff with the compare URL, blocker, and next action.
 - Treat founder guidance as strong but verify it:

--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -183,6 +183,11 @@ class LaneRecord:
     codex_thread_id: str = ""
     codex_rollout_path: str = ""
     session_title: str = ""
+    contact_method: str = ""
+    contact_payload: dict[str, Any] | None = None
+    last_mailbox_check_at: str = ""
+    last_delivery_at: str = ""
+    last_ack_at: str = ""
 
     def to_dict(self) -> dict[str, Any]:
         return {k: v for k, v in asdict(self).items() if v not in ("", None)}
@@ -206,6 +211,13 @@ class LaneRecord:
             codex_thread_id=str(payload.get("codex_thread_id", "")),
             codex_rollout_path=str(payload.get("codex_rollout_path", "")),
             session_title=str(payload.get("session_title", "")),
+            contact_method=str(payload.get("contact_method", "")),
+            contact_payload=payload.get("contact_payload")
+            if isinstance(payload.get("contact_payload"), dict)
+            else None,
+            last_mailbox_check_at=str(payload.get("last_mailbox_check_at", "")),
+            last_delivery_at=str(payload.get("last_delivery_at", "")),
+            last_ack_at=str(payload.get("last_ack_at", "")),
         )
 
 
@@ -1639,18 +1651,87 @@ def _collect_pending_steering_messages(
         # consumed messages per the Phase D convention.
         return [p for p in dir_path.glob("*.json") if p.is_file()]
 
+    def _read_receipt_summary(dir_path: Path, files: list[Path]) -> dict[str, Any]:
+        receipt_dir = dir_path / "_read_receipts"
+        if not receipt_dir.is_dir():
+            return {
+                "read_receipt_count": 0,
+                "unread_message_count": len(files),
+                "latest_read_receipt": None,
+            }
+
+        receipts: list[dict[str, Any]] = []
+        read_keys: set[tuple[str, str]] = set()
+        for receipt_path in receipt_dir.glob("*.json"):
+            if not receipt_path.is_file():
+                continue
+            try:
+                data = json.loads(receipt_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if not isinstance(data, dict):
+                continue
+            data["_receipt_filename"] = receipt_path.name
+            receipts.append(data)
+            read_keys.add(
+                (
+                    str(data.get("message_filename") or ""),
+                    str(data.get("message_sha256") or ""),
+                )
+            )
+
+        unread = 0
+        for message_path in files:
+            try:
+                message = json.loads(message_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                message = {}
+            if not isinstance(message, dict):
+                message = {}
+            key = (message_path.name, str(message.get("message_sha256") or ""))
+            if key not in read_keys:
+                unread += 1
+
+        receipts.sort(key=lambda r: str(r.get("read_at_utc") or ""), reverse=True)
+        latest = None
+        if receipts:
+            raw = receipts[0]
+            latest = {
+                "receipt_filename": raw.get("_receipt_filename"),
+                "read_at_utc": raw.get("read_at_utc"),
+                "read_by_session": raw.get("read_by_session"),
+                "message_filename": raw.get("message_filename"),
+                "message_sha256": raw.get("message_sha256"),
+                "outcome": raw.get("outcome"),
+                "subject": raw.get("subject"),
+            }
+        return {
+            "read_receipt_count": len(receipts),
+            "unread_message_count": unread,
+            "latest_read_receipt": latest,
+        }
+
     if session_name:
-        files = _inbox_files(steering_root / session_name)
+        inbox_dir = steering_root / session_name
+        files = _inbox_files(inbox_dir)
         summaries = sorted(
             (_summary_from(p) for p in files),
             key=lambda s: s["sent_at_utc"],
             reverse=True,
         )
-        return {"count": len(files), "latest_three": summaries[:3]}
+        return {
+            "count": len(files),
+            "latest_three": summaries[:3],
+            **_read_receipt_summary(inbox_dir, files),
+        }
 
     # Roll-up across all recipient dirs.
     by_recipient: dict[str, int] = {}
+    read_receipts_by_recipient: dict[str, int] = {}
     all_summaries: list[dict[str, Any]] = []
+    total_read_receipts = 0
+    total_unread = 0
+    latest_receipts: list[dict[str, Any]] = []
     for child in sorted(steering_root.iterdir()):
         if not child.is_dir() or child.name.startswith("."):
             continue
@@ -1658,11 +1739,24 @@ def _collect_pending_steering_messages(
         if files:
             by_recipient[child.name] = len(files)
             all_summaries.extend(_summary_from(p) for p in files)
+        receipt_summary = _read_receipt_summary(child, files)
+        total_read_receipts += int(receipt_summary["read_receipt_count"])
+        total_unread += int(receipt_summary["unread_message_count"])
+        if receipt_summary["read_receipt_count"]:
+            read_receipts_by_recipient[child.name] = int(receipt_summary["read_receipt_count"])
+        latest = receipt_summary["latest_read_receipt"]
+        if isinstance(latest, dict):
+            latest_receipts.append(latest)
     all_summaries.sort(key=lambda s: s["sent_at_utc"], reverse=True)
+    latest_receipts.sort(key=lambda r: str(r.get("read_at_utc") or ""), reverse=True)
     return {
         "count": sum(by_recipient.values()),
         "by_recipient": by_recipient,
         "latest_three": all_summaries[:3],
+        "read_receipt_count": total_read_receipts,
+        "unread_message_count": total_unread,
+        "read_receipts_by_recipient": read_receipts_by_recipient,
+        "latest_read_receipt": latest_receipts[0] if latest_receipts else None,
     }
 
 

--- a/scripts/check_operator_steering.py
+++ b/scripts/check_operator_steering.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Compatibility entrypoint for reading operator-steering mailboxes.
+
+The implementation lives in ``read_operator_steering.py``.  This wrapper
+provides the user-facing verb used by session startup hooks and operator
+prompts.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import read_operator_steering
+
+
+if __name__ == "__main__":
+    sys.exit(read_operator_steering.main())

--- a/scripts/claim_active_agent_lane.py
+++ b/scripts/claim_active_agent_lane.py
@@ -31,7 +31,9 @@ bootstraps and from any agent):
   ``branch``, ``worktree``, ``pr_number``, ``conflict_session``,
   ``conflict_reason``, and optional Desktop identity metadata
   (``desktop_label``, ``codex_thread_id``, ``codex_rollout_path``,
-  ``session_title``).
+  ``session_title``), plus optional steering contact metadata
+  (``contact_method``, ``contact_payload``, ``last_mailbox_check_at``,
+  ``last_delivery_at``, ``last_ack_at``).
 - A claim with the same ``lane_id`` from the same ``owner_session``
   overwrites the existing row (idempotent refresh). A claim with the
   same ``lane_id`` from a *different* ``owner_session`` is rejected
@@ -115,6 +117,11 @@ LANE_RECORD_KEYS = (
     "codex_thread_id",
     "codex_rollout_path",
     "session_title",
+    "contact_method",
+    "contact_payload",
+    "last_mailbox_check_at",
+    "last_delivery_at",
+    "last_ack_at",
 )
 
 
@@ -187,6 +194,8 @@ def _normalize_row(row: dict[str, Any]) -> dict[str, Any]:
     for key in LANE_RECORD_KEYS:
         value = row.get(key)
         if value is None or value == "":
+            continue
+        if key == "contact_payload" and not isinstance(value, dict):
             continue
         out[key] = value
     return out
@@ -328,6 +337,11 @@ def claim_lane(
     codex_thread_id: str = "",
     codex_rollout_path: str = "",
     session_title: str = "",
+    contact_method: str = "",
+    contact_payload: dict[str, Any] | None = None,
+    last_mailbox_check_at: str = "",
+    last_delivery_at: str = "",
+    last_ack_at: str = "",
     force: bool = False,
     allow_resource_conflicts: bool = False,
     updated_at: str | None = None,
@@ -361,6 +375,11 @@ def claim_lane(
             "codex_thread_id": codex_thread_id,
             "codex_rollout_path": codex_rollout_path,
             "session_title": session_title,
+            "contact_method": contact_method,
+            "contact_payload": contact_payload,
+            "last_mailbox_check_at": last_mailbox_check_at,
+            "last_delivery_at": last_delivery_at,
+            "last_ack_at": last_ack_at,
         }
         normalized = _normalize_row(new_row)
 
@@ -440,6 +459,23 @@ def build_parser() -> argparse.ArgumentParser:
         help="Optional visible or inferred session title for operator display.",
     )
     parser.add_argument(
+        "--contact-method",
+        default="",
+        help=(
+            "Optional steering transport, e.g. tmux:aragora:1, "
+            "codex-exec-resume:<thread_id>, codex-app-server:<socket>, "
+            "or mailbox-only."
+        ),
+    )
+    parser.add_argument(
+        "--contact-payload",
+        default="",
+        help="Optional JSON object with backend-specific steering metadata.",
+    )
+    parser.add_argument("--last-mailbox-check-at", default="")
+    parser.add_argument("--last-delivery-at", default="")
+    parser.add_argument("--last-ack-at", default="")
+    parser.add_argument(
         "--force",
         action="store_true",
         help="Overwrite an existing claim or identity conflict owned by a different session.",
@@ -501,6 +537,12 @@ def main(argv: list[str] | None = None) -> int:
         explicit=args.registry_path,
     )
     try:
+        contact_payload = None
+        if args.contact_payload:
+            parsed_payload = json.loads(args.contact_payload)
+            if not isinstance(parsed_payload, dict):
+                raise ValueError("--contact-payload must be a JSON object")
+            contact_payload = parsed_payload
         if args.release_stale:
             row = release_stale_claims(
                 registry_path=registry_path,
@@ -526,6 +568,11 @@ def main(argv: list[str] | None = None) -> int:
                 codex_thread_id=args.codex_thread_id,
                 codex_rollout_path=args.codex_rollout_path,
                 session_title=args.session_title,
+                contact_method=args.contact_method,
+                contact_payload=contact_payload,
+                last_mailbox_check_at=args.last_mailbox_check_at,
+                last_delivery_at=args.last_delivery_at,
+                last_ack_at=args.last_ack_at,
                 force=args.force,
                 allow_resource_conflicts=args.allow_resource_conflicts,
                 updated_at=args.updated_at,

--- a/scripts/codex_dispatch_queue.py
+++ b/scripts/codex_dispatch_queue.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Local Codex/agent steering dispatch queue.
+
+Jobs are JSON files under ``.aragora/codex-dispatch-queue/pending``.  The
+runner resolves the target with ``wake_agent.py`` and moves each job to
+``delivered`` or ``blocked`` with an auditable receipt.  Dry-run processing is
+the default and never sends prompts or writes mailbox messages.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+import secrets
+import sys
+import tempfile
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import wake_agent
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+QUEUE_ROOT_DEFAULT = REPO_ROOT / ".aragora" / "codex-dispatch-queue"
+JOB_SCHEMA_VERSION = "aragora-codex-dispatch-job/1.0"
+RECEIPT_SCHEMA_VERSION = "aragora-codex-dispatch-receipt/1.0"
+
+
+class QueueError(Exception):
+    """Raised when a queue operation cannot proceed safely."""
+
+    def __init__(self, message: str, *, exit_code: int = 1) -> None:
+        super().__init__(message)
+        self.exit_code = exit_code
+
+
+def _now_utc_iso() -> str:
+    return dt.datetime.now(dt.UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _filename_timestamp(value: str) -> str:
+    return value.replace(":", "-").replace(".", "-")
+
+
+def _sha256(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        os.replace(tmp_path, path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def _queue_dirs(root: Path) -> dict[str, Path]:
+    return {name: root / name for name in ("pending", "running", "delivered", "blocked")}
+
+
+def _read_prompt(*, prompt: str | None, prompt_file: Path | None) -> str:
+    if bool(prompt) == bool(prompt_file):
+        raise QueueError("provide exactly one of --prompt or --prompt-file", exit_code=2)
+    if prompt_file is not None:
+        if not prompt_file.is_file():
+            raise QueueError(f"prompt file not found: {prompt_file}", exit_code=2)
+        body = prompt_file.read_text(encoding="utf-8")
+    else:
+        body = prompt or ""
+    if not body.strip():
+        raise QueueError("prompt must not be empty", exit_code=2)
+    return body
+
+
+def enqueue(args: argparse.Namespace) -> dict[str, Any]:
+    prompt = _read_prompt(prompt=args.prompt, prompt_file=args.prompt_file)
+    selectors = {
+        "to": args.to,
+        "lane_id": args.lane_id,
+        "pr": args.pr,
+        "branch": args.branch,
+        "worktree": args.worktree,
+    }
+    if sum(value is not None and value != "" for value in selectors.values()) != 1:
+        raise QueueError("provide exactly one target selector", exit_code=2)
+    created_at = _now_utc_iso()
+    job_id = f"{_filename_timestamp(created_at)}-{secrets.token_hex(4)}"
+    job = {
+        "schema_version": JOB_SCHEMA_VERSION,
+        "id": job_id,
+        "created_at_utc": created_at,
+        "priority": args.priority,
+        "selectors": selectors,
+        "expected_head": args.expected_head,
+        "prompt": prompt,
+        "prompt_sha256": _sha256(prompt),
+        "status": "pending",
+    }
+    pending = _queue_dirs(args.queue_root)["pending"]
+    path = pending / f"{job_id}.json"
+    _atomic_write_json(path, job)
+    return {"ok": True, "job": job, "path": str(path)}
+
+
+def _load_job(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise QueueError(f"cannot read job {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise QueueError(f"job {path} is not a JSON object")
+    if payload.get("schema_version") != JOB_SCHEMA_VERSION:
+        raise QueueError(f"job {path} has unsupported schema_version")
+    return payload
+
+
+def _wake_argv_for_job(
+    job: dict[str, Any],
+    *,
+    apply: bool,
+    registry_path: Path,
+    steering_inbox_root: Path,
+    receipt_root: Path,
+) -> list[str]:
+    selectors = job.get("selectors") if isinstance(job.get("selectors"), dict) else {}
+    argv: list[str] = []
+    if selectors.get("to"):
+        argv.extend(["--to", str(selectors["to"])])
+    elif selectors.get("lane_id"):
+        argv.extend(["--lane-id", str(selectors["lane_id"])])
+    elif selectors.get("pr") is not None:
+        argv.extend(["--pr", str(selectors["pr"])])
+    elif selectors.get("branch"):
+        argv.extend(["--branch", str(selectors["branch"])])
+    elif selectors.get("worktree"):
+        argv.extend(["--worktree", str(selectors["worktree"])])
+    else:
+        raise QueueError("queued job has no usable selector")
+    argv.extend(["--prompt", str(job.get("prompt") or "")])
+    argv.extend(["--priority", str(job.get("priority") or "normal")])
+    argv.extend(["--registry-path", str(registry_path)])
+    argv.extend(["--steering-inbox-root", str(steering_inbox_root)])
+    argv.extend(["--receipt-root", str(receipt_root)])
+    argv.extend(["--json"])
+    if apply:
+        argv.append("--apply")
+    return argv
+
+
+def _write_run_receipt(
+    *,
+    job: dict[str, Any],
+    queue_root: Path,
+    wake_result: dict[str, Any] | None,
+    status: str,
+    error: str | None = None,
+) -> Path:
+    completed_at = _now_utc_iso()
+    receipt = {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "job_id": job.get("id"),
+        "status": status,
+        "completed_at_utc": completed_at,
+        "prompt_sha256": job.get("prompt_sha256"),
+        "wake_result": wake_result,
+        "error": error,
+    }
+    path = queue_root / status / f"{job.get('id', 'unknown')}.receipt.json"
+    _atomic_write_json(path, receipt)
+    return path
+
+
+def run_queue(args: argparse.Namespace) -> dict[str, Any]:
+    dirs = _queue_dirs(args.queue_root)
+    for path in dirs.values():
+        path.mkdir(parents=True, exist_ok=True)
+    pending = sorted(dirs["pending"].glob("*.json"))
+    processed: list[dict[str, Any]] = []
+    for pending_path in pending[: args.limit]:
+        job = _load_job(pending_path)
+        running_path = dirs["running"] / pending_path.name
+        os.replace(pending_path, running_path)
+        wake_result: dict[str, Any] | None = None
+        status = "blocked"
+        error = None
+        try:
+            wake_args = wake_agent.build_parser().parse_args(
+                _wake_argv_for_job(
+                    job,
+                    apply=args.apply,
+                    registry_path=args.registry_path,
+                    steering_inbox_root=args.steering_inbox_root,
+                    receipt_root=args.receipt_root,
+                )
+            )
+            wake_result = wake_agent.run(wake_args)
+            if args.apply and wake_result.get("ok"):
+                status = "delivered"
+            else:
+                status = "blocked"
+                if not args.apply:
+                    error = "dry-run; no prompt delivered"
+                elif not wake_result.get("ok"):
+                    error = str(wake_result.get("error") or "wake_agent blocked")
+        except Exception as exc:  # noqa: BLE001 - queue receipts should capture all blockers.
+            error = str(exc)
+        receipt_path = _write_run_receipt(
+            job=job,
+            queue_root=args.queue_root,
+            wake_result=wake_result,
+            status=status,
+            error=error,
+        )
+        final_job = dirs[status] / pending_path.name
+        os.replace(running_path, final_job)
+        processed.append(
+            {
+                "job_id": job.get("id"),
+                "status": status,
+                "job_path": str(final_job),
+                "receipt_path": str(receipt_path),
+                "wake_result": wake_result,
+                "error": error,
+            }
+        )
+    return {"ok": True, "dry_run": not args.apply, "processed": processed}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    enqueue_p = sub.add_parser("enqueue")
+    target = enqueue_p.add_mutually_exclusive_group(required=True)
+    target.add_argument("--to")
+    target.add_argument("--lane", "--lane-id", dest="lane_id")
+    target.add_argument("--pr", type=int)
+    target.add_argument("--branch")
+    target.add_argument("--worktree")
+    body = enqueue_p.add_mutually_exclusive_group(required=True)
+    body.add_argument("--prompt")
+    body.add_argument("--prompt-file", type=Path)
+    enqueue_p.add_argument(
+        "--priority", choices=("low", "normal", "high", "blocking"), default="normal"
+    )
+    enqueue_p.add_argument("--expected-head", default=None)
+    enqueue_p.add_argument("--queue-root", type=Path, default=QUEUE_ROOT_DEFAULT)
+    enqueue_p.add_argument("--json", action="store_true")
+
+    run_p = sub.add_parser("run")
+    run_p.add_argument("--queue-root", type=Path, default=QUEUE_ROOT_DEFAULT)
+    run_p.add_argument("--registry-path", type=Path, default=wake_agent.LANE_REGISTRY_DEFAULT)
+    run_p.add_argument(
+        "--steering-inbox-root", type=Path, default=wake_agent.STEERING_INBOX_ROOT_DEFAULT
+    )
+    run_p.add_argument(
+        "--receipt-root", type=Path, default=wake_agent.DISPATCH_RECEIPT_ROOT_DEFAULT
+    )
+    run_p.add_argument("--limit", type=int, default=1)
+    run_p.add_argument("--apply", action="store_true", help="Deliver queued prompts.")
+    run_p.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        result = enqueue(args) if args.command == "enqueue" else run_queue(args)
+    except QueueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return exc.exit_code
+    if getattr(args, "json", False):
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        if args.command == "enqueue":
+            print(f"queued {result['job']['id']} at {result['path']}")
+        else:
+            print(f"processed {len(result['processed'])} job(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/codex_dispatch_queue.py
+++ b/scripts/codex_dispatch_queue.py
@@ -135,7 +135,8 @@ def _wake_argv_for_job(
     steering_inbox_root: Path,
     receipt_root: Path,
 ) -> list[str]:
-    selectors = job.get("selectors") if isinstance(job.get("selectors"), dict) else {}
+    raw_selectors = job.get("selectors")
+    selectors: dict[str, Any] = raw_selectors if isinstance(raw_selectors, dict) else {}
     argv: list[str] = []
     if selectors.get("to"):
         argv.extend(["--to", str(selectors["to"])])
@@ -206,15 +207,16 @@ def run_queue(args: argparse.Namespace) -> dict[str, Any]:
                     receipt_root=args.receipt_root,
                 )
             )
-            wake_result = wake_agent.run(wake_args)
-            if args.apply and wake_result.get("ok"):
+            result = wake_agent.run(wake_args)
+            wake_result = result
+            if args.apply and result.get("ok"):
                 status = "delivered"
             else:
                 status = "blocked"
                 if not args.apply:
                     error = "dry-run; no prompt delivered"
-                elif not wake_result.get("ok"):
-                    error = str(wake_result.get("error") or "wake_agent blocked")
+                elif not result.get("ok"):
+                    error = str(result.get("error") or "wake_agent blocked")
         except Exception as exc:  # noqa: BLE001 - queue receipts should capture all blockers.
             error = str(exc)
         receipt_path = _write_run_receipt(

--- a/scripts/codex_session.sh
+++ b/scripts/codex_session.sh
@@ -319,6 +319,15 @@ fi
     echo "command=${SESSION_COMMAND}"
 } >> "${LOG_FILE}"
 
+if [[ -f "${REPO_ROOT}/scripts/check_operator_steering.py" ]]; then
+    python3 "${REPO_ROOT}/scripts/check_operator_steering.py" \
+        --to "${SESSION_ID}" \
+        --read-by-session "${SESSION_ID}" \
+        --no-receipt \
+        --quiet-empty \
+        2>/dev/null | tee -a "${LOG_FILE}" || true
+fi
+
 cleanup_lock() {
     local exit_code=$?
     local ended_at

--- a/scripts/identify_lane_owner.py
+++ b/scripts/identify_lane_owner.py
@@ -108,12 +108,22 @@ class LaneOwnerInfo:
     codex_rollout_path: str | None
     desktop_label: str | None
     session_title: str | None
+    contact_method: str | None
+    contact_payload: dict[str, Any] | None
+    last_mailbox_check_at: str | None
+    last_delivery_at: str | None
+    last_ack_at: str | None
     live_process: dict[str, Any]
     codex_thread: dict[str, Any]
     claude_session: dict[str, Any]
     factory_droid: dict[str, Any]
     steering_inbox_path: str
     pending_message_count: int
+    read_receipt_count: int
+    unread_message_count: int
+    latest_read_receipt: dict[str, Any] | None
+    mailbox_dispatchable: bool
+    live_prompt_dispatchable: bool
     dispatchable: bool
     dispatch_blocker: str | None
     steering_command: str | None
@@ -660,16 +670,86 @@ def lookup_factory_droid(
 # ---------------------------------------------------------------------------
 
 
+def _load_json_dict(path: Path) -> dict[str, Any] | None:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _read_receipt_summary(inbox: Path, message_files: list[Path]) -> dict[str, Any]:
+    receipt_dir = inbox / "_read_receipts"
+    if not receipt_dir.is_dir():
+        return {
+            "read_receipt_count": 0,
+            "unread_message_count": len(message_files),
+            "latest_read_receipt": None,
+        }
+
+    receipts: list[dict[str, Any]] = []
+    read_keys: set[tuple[str, str]] = set()
+    for path in receipt_dir.glob("*.json"):
+        if not path.is_file():
+            continue
+        data = _load_json_dict(path)
+        if data is None:
+            continue
+        data["_receipt_filename"] = path.name
+        receipts.append(data)
+        read_keys.add(
+            (
+                str(data.get("message_filename") or ""),
+                str(data.get("message_sha256") or ""),
+            )
+        )
+
+    unread = 0
+    for path in message_files:
+        data = _load_json_dict(path) or {}
+        key = (path.name, str(data.get("message_sha256") or ""))
+        if key not in read_keys:
+            unread += 1
+
+    receipts.sort(key=lambda r: str(r.get("read_at_utc") or ""), reverse=True)
+    latest = None
+    if receipts:
+        raw = receipts[0]
+        latest = {
+            "receipt_filename": raw.get("_receipt_filename"),
+            "read_at_utc": raw.get("read_at_utc"),
+            "read_by_session": raw.get("read_by_session"),
+            "message_filename": raw.get("message_filename"),
+            "message_sha256": raw.get("message_sha256"),
+            "outcome": raw.get("outcome"),
+            "subject": raw.get("subject"),
+        }
+    return {
+        "read_receipt_count": len(receipts),
+        "unread_message_count": unread,
+        "latest_read_receipt": latest,
+    }
+
+
 def steering_inbox_for(
     owner_session: str, *, root: Path = STEERING_INBOX_ROOT_DEFAULT
-) -> tuple[Path, int]:
-    """Return ``(inbox_path, pending_count)``; missing dir → ``(path, 0)``."""
+) -> tuple[Path, int, dict[str, Any]]:
+    """Return inbox path, pending count, and read-receipt summary."""
 
     inbox = root / owner_session
     if not inbox.is_dir():
-        return inbox, 0
-    count = sum(1 for _ in inbox.glob("*.json"))
-    return inbox, count
+        return (
+            inbox,
+            0,
+            {
+                "read_receipt_count": 0,
+                "unread_message_count": 0,
+                "latest_read_receipt": None,
+            },
+        )
+    files = [path for path in inbox.glob("*.json") if path.is_file()]
+    count = len(files)
+    return inbox, count, _read_receipt_summary(inbox, files)
 
 
 def _dispatch_blocker_for(lane: dict[str, Any], owner_session: str) -> str | None:
@@ -683,6 +763,27 @@ def _dispatch_blocker_for(lane: dict[str, Any], owner_session: str) -> str | Non
     if status in COMPLETED_STATUSES:
         return f"lane status is {status}; claim an active lane before steering"
     return f"lane status is {status or 'unknown'}; claim an active lane before steering"
+
+
+def _contact_payload_for(lane: dict[str, Any]) -> dict[str, Any] | None:
+    payload = lane.get("contact_payload")
+    return payload if isinstance(payload, dict) else None
+
+
+def _live_prompt_dispatchable_for(lane: dict[str, Any], owner_session: str) -> bool:
+    if _dispatch_blocker_for(lane, owner_session) is not None:
+        return False
+    method = str(lane.get("contact_method") or "").strip()
+    if method.startswith("tmux:"):
+        return bool(method.removeprefix("tmux:").strip())
+    if method.startswith("codex-exec-resume:"):
+        return bool(method.removeprefix("codex-exec-resume:").strip())
+    if method.startswith("codex-app-server:"):
+        payload = _contact_payload_for(lane) or {}
+        return bool(
+            payload.get("socket") and (payload.get("thread_id") or lane.get("codex_thread_id"))
+        )
+    return bool(lane.get("codex_thread_id"))
 
 
 def _steering_command_for(lane: dict[str, Any], owner_session: str) -> str | None:
@@ -756,7 +857,7 @@ def build_owner_info(
     codex = lookup_codex_thread(lane, sessions_root=sessions_root, now=fuzzy_now)
     claude = lookup_claude_session(lane, projects_root=projects_root)
     factory = lookup_factory_droid(lane, bg_path=bg_path)
-    inbox_path, pending = steering_inbox_for(owner, root=steering_inbox_root)
+    inbox_path, pending, receipt_summary = steering_inbox_for(owner, root=steering_inbox_root)
     dispatch_blocker = _dispatch_blocker_for(lane, owner)
 
     raw_pr = lane.get("pr_number")
@@ -779,12 +880,22 @@ def build_owner_info(
         codex_rollout_path=lane.get("codex_rollout_path"),
         desktop_label=lane.get("desktop_label"),
         session_title=lane.get("session_title"),
+        contact_method=lane.get("contact_method"),
+        contact_payload=_contact_payload_for(lane),
+        last_mailbox_check_at=lane.get("last_mailbox_check_at"),
+        last_delivery_at=lane.get("last_delivery_at"),
+        last_ack_at=lane.get("last_ack_at"),
         live_process=live,
         codex_thread=codex,
         claude_session=claude,
         factory_droid=factory,
         steering_inbox_path=str(inbox_path),
         pending_message_count=pending,
+        read_receipt_count=int(receipt_summary["read_receipt_count"]),
+        unread_message_count=int(receipt_summary["unread_message_count"]),
+        latest_read_receipt=receipt_summary["latest_read_receipt"],
+        mailbox_dispatchable=dispatch_blocker is None,
+        live_prompt_dispatchable=_live_prompt_dispatchable_for(lane, owner),
         dispatchable=dispatch_blocker is None,
         dispatch_blocker=dispatch_blocker,
         steering_command=_steering_command_for(lane, owner),
@@ -823,6 +934,11 @@ def _print_human(info: LaneOwnerInfo) -> None:
     print(f"  codex_rollout_path: {info.codex_rollout_path or '(not supplied)'}")
     print(f"  desktop_label:      {info.desktop_label or '(not supplied)'}")
     print(f"  session_title:      {info.session_title or '(not supplied)'}")
+    print(f"  contact_method:     {info.contact_method or '(not supplied)'}")
+    print(f"  contact_payload:    {info.contact_payload or '-'}")
+    print(f"  last_mailbox_check: {info.last_mailbox_check_at or '-'}")
+    print(f"  last_delivery_at:   {info.last_delivery_at or '-'}")
+    print(f"  last_ack_at:        {info.last_ack_at or '-'}")
     print()
     print("best-effort live lookups:")
     print(f"  live_process:   {_glyph(info.live_process.get('found', False))}  {info.live_process}")
@@ -836,6 +952,11 @@ def _print_human(info: LaneOwnerInfo) -> None:
     print()
     print(f"steering_inbox_path:   {info.steering_inbox_path}")
     print(f"pending_message_count: {info.pending_message_count}")
+    print(f"read_receipt_count:    {info.read_receipt_count}")
+    print(f"unread_message_count:  {info.unread_message_count}")
+    print(f"latest_read_receipt:   {info.latest_read_receipt or '-'}")
+    print(f"mailbox_dispatchable:  {info.mailbox_dispatchable}")
+    print(f"live_prompt_dispatchable: {info.live_prompt_dispatchable}")
     print(f"dispatchable:          {info.dispatchable}")
     print(f"dispatch_blocker:      {info.dispatch_blocker or '-'}")
     print(f"steering_command:      {info.steering_command or '-'}")

--- a/scripts/read_operator_steering.py
+++ b/scripts/read_operator_steering.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Read operator-steering messages and write append-only read receipts.
+
+This is a sidecar receipt protocol, not an ack protocol: top-level
+``*.json`` messages remain in place and still count as pending until a
+future explicit ack/move flow exists.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+import secrets
+import sys
+import tempfile
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import identify_lane_owner as owner_lookup
+import send_operator_steering as steering_writer
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+STEERING_INBOX_ROOT_DEFAULT = REPO_ROOT / ".aragora" / "operator-steering"
+LANE_REGISTRY_DEFAULT = REPO_ROOT / ".aragora" / "agent-bridge" / "lanes.json"
+READ_RECEIPT_SCHEMA_VERSION = "aragora-operator-steering-read-receipt/1.0"
+OUTCOME_CHOICES = ("read", "obeyed", "held", "stale", "superseded", "blocked")
+
+
+def _now_utc_iso() -> str:
+    return (
+        datetime.datetime.now(datetime.timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def _filename_timestamp(iso: str) -> str:
+    return iso.replace(":", "-").replace(".", "-")
+
+
+def _resolve_owner_session(
+    *,
+    to_session: str | None,
+    lane_id: str | None,
+    pr: int | None,
+    branch: str | None,
+    registry_path: Path,
+    steering_inbox_root: Path,
+) -> tuple[str, str, dict[str, Any] | None]:
+    if to_session:
+        steering_writer.validate_to_session(to_session, steering_inbox_root=steering_inbox_root)
+        return to_session, "direct", None
+
+    records = owner_lookup.load_lane_records(registry_path)
+    lane = owner_lookup.find_lane(records, lane_id=lane_id, pr=pr, branch=branch)
+    if lane is None:
+        raise ValueError("no lane matched the requested selector")
+    owner_session = str(lane.get("owner_session") or "")
+    if not owner_session:
+        raise ValueError("matched lane has no owner_session")
+    steering_writer.validate_to_session(owner_session, steering_inbox_root=steering_inbox_root)
+    if lane_id:
+        resolved_via = "lane-id"
+    elif pr is not None:
+        resolved_via = "pr"
+    else:
+        resolved_via = "branch"
+    return owner_session, resolved_via, lane
+
+
+def _message_files(owner_session: str, *, steering_inbox_root: Path) -> list[Path]:
+    inbox = steering_writer.validate_to_session(
+        owner_session, steering_inbox_root=steering_inbox_root
+    )
+    if not inbox.is_dir():
+        return []
+    return sorted((p for p in inbox.glob("*.json") if p.is_file()), key=lambda p: p.name)
+
+
+def _load_message(path: Path) -> tuple[dict[str, Any], bool]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}, False
+    if not isinstance(data, dict):
+        return {}, False
+    _, _, sha_ok = steering_writer.verify_message_sha256(data)
+    return data, sha_ok
+
+
+def _message_summary(path: Path) -> dict[str, Any]:
+    data, sha_ok = _load_message(path)
+    return {
+        "filename": path.name,
+        "path": str(path),
+        "schema_version": data.get("schema_version"),
+        "to_session": data.get("to_session"),
+        "from": data.get("from"),
+        "sent_at_utc": data.get("sent_at_utc"),
+        "lane_id_hint": data.get("lane_id_hint"),
+        "pr_hint": data.get("pr_hint"),
+        "priority": data.get("priority"),
+        "subject": data.get("subject"),
+        "message_sha256": data.get("message_sha256"),
+        "sha256_valid": sha_ok,
+    }
+
+
+def build_read_receipt(
+    *,
+    owner_session: str,
+    read_by_session: str,
+    message_path: Path,
+    outcome: str = "read",
+    outcome_note: str | None = None,
+    read_at_utc: str | None = None,
+) -> dict[str, Any]:
+    data, _sha_ok = _load_message(message_path)
+    receipt: dict[str, Any] = {
+        "schema_version": READ_RECEIPT_SCHEMA_VERSION,
+        "owner_session": owner_session,
+        "read_by_session": read_by_session,
+        "read_at_utc": read_at_utc or _now_utc_iso(),
+        "message_filename": message_path.name,
+        "message_sha256": data.get("message_sha256"),
+        "message_sent_at_utc": data.get("sent_at_utc"),
+        "priority": data.get("priority"),
+        "lane_id_hint": data.get("lane_id_hint"),
+        "pr_hint": data.get("pr_hint"),
+        "subject": data.get("subject"),
+        "outcome": outcome,
+    }
+    if outcome_note:
+        receipt["outcome_note"] = outcome_note
+    return receipt
+
+
+def write_read_receipt(
+    receipt: dict[str, Any],
+    *,
+    steering_inbox_root: Path = STEERING_INBOX_ROOT_DEFAULT,
+) -> Path:
+    owner_session = str(receipt.get("owner_session") or "")
+    inbox = steering_writer.validate_to_session(
+        owner_session, steering_inbox_root=steering_inbox_root
+    )
+    receipt_dir = inbox / "_read_receipts"
+    receipt_dir.mkdir(parents=True, exist_ok=True)
+    ts = _filename_timestamp(str(receipt.get("read_at_utc") or _now_utc_iso()))
+    final_path = receipt_dir / f"{ts}-{secrets.token_hex(4)}.json"
+    body = json.dumps(receipt, indent=2, sort_keys=True)
+
+    fd, tmp_path = tempfile.mkstemp(prefix=".tmp-", suffix=".json", dir=str(receipt_dir))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(body)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, final_path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+    return final_path
+
+
+def _default_read_by_session(owner_session: str) -> str:
+    return (
+        os.environ.get("ARAGORA_SESSION_ID") or os.environ.get("CODEX_SESSION_ID") or owner_session
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="read_operator_steering.py",
+        description="Read one operator-steering mailbox and optionally write read receipts.",
+    )
+    target = parser.add_mutually_exclusive_group(required=True)
+    target.add_argument("--to", metavar="OWNER_SESSION", help="Read this owner_session mailbox.")
+    target.add_argument("--lane-id", help="Resolve owner_session from lane id.")
+    target.add_argument("--pr", type=int, help="Resolve owner_session from PR number.")
+    target.add_argument("--branch", help="Resolve owner_session from branch name.")
+    parser.add_argument(
+        "--read-by-session",
+        default=None,
+        help="Session id recorded as receipt.read_by_session. Defaults to env/session target.",
+    )
+    parser.add_argument("--outcome", choices=OUTCOME_CHOICES, default="read")
+    parser.add_argument("--outcome-note", default=None)
+    parser.add_argument("--no-receipt", action="store_true", help="Read/list without writing.")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable output.")
+    parser.add_argument(
+        "--quiet-empty",
+        action="store_true",
+        help="Print nothing and exit 0 when the selected mailbox has no messages.",
+    )
+    parser.add_argument(
+        "--steering-inbox-root",
+        type=Path,
+        default=STEERING_INBOX_ROOT_DEFAULT,
+        help="Override .aragora/operator-steering root.",
+    )
+    parser.add_argument(
+        "--registry-path",
+        type=Path,
+        default=LANE_REGISTRY_DEFAULT,
+        help="Override .aragora/agent-bridge/lanes.json.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        owner_session, resolved_via, lane = _resolve_owner_session(
+            to_session=args.to,
+            lane_id=args.lane_id,
+            pr=args.pr,
+            branch=args.branch,
+            registry_path=args.registry_path,
+            steering_inbox_root=args.steering_inbox_root,
+        )
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    files = _message_files(owner_session, steering_inbox_root=args.steering_inbox_root)
+    read_by = args.read_by_session or _default_read_by_session(owner_session)
+    receipt_paths: list[Path] = []
+    if not args.no_receipt:
+        for path in files:
+            receipt = build_read_receipt(
+                owner_session=owner_session,
+                read_by_session=read_by,
+                message_path=path,
+                outcome=args.outcome,
+                outcome_note=args.outcome_note,
+            )
+            receipt_paths.append(
+                write_read_receipt(receipt, steering_inbox_root=args.steering_inbox_root)
+            )
+
+    out = {
+        "owner_session": owner_session,
+        "resolved_via": resolved_via,
+        "lane_id": lane.get("lane_id") if isinstance(lane, dict) else None,
+        "pr_number": lane.get("pr_number") if isinstance(lane, dict) else args.pr,
+        "branch": lane.get("branch") if isinstance(lane, dict) else args.branch,
+        "steering_inbox_path": str(args.steering_inbox_root / owner_session),
+        "message_count": len(files),
+        "receipt_count": len(receipt_paths),
+        "read_by_session": read_by,
+        "messages": [_message_summary(path) for path in files],
+        "read_receipt_paths": [str(path) for path in receipt_paths],
+        "no_receipt": bool(args.no_receipt),
+    }
+    if args.quiet_empty and not files:
+        return 0
+    if args.json:
+        print(json.dumps(out, indent=2, sort_keys=True))
+    else:
+        print(f"owner_session: {owner_session}")
+        print(f"steering_inbox_path: {out['steering_inbox_path']}")
+        print(f"message_count: {len(files)}")
+        print(f"receipt_count: {len(receipt_paths)}")
+        for msg in out["messages"]:
+            print(
+                f"- {msg['filename']} priority={msg['priority']} "
+                f"sent_at_utc={msg['sent_at_utc']} sha256_valid={msg['sha256_valid']} "
+                f"subject={msg['subject']}"
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tmux_send_prompt.sh
+++ b/scripts/tmux_send_prompt.sh
@@ -131,8 +131,10 @@ fi
 # --- Dry-run: print what would be sent, do not touch anything ---
 if [[ "${DRY_RUN}" -eq 1 ]]; then
     if [[ "${JSON_OUTPUT}" -eq 1 ]]; then
-        python3 - "${NAME}" "${TARGET}" "${PROMPT_ID}" "${TIMESTAMP}" "${CHAR_COUNT}" "${LINE_COUNT}" "${SOURCE_TAG}" "${PROMPT_SOURCE_KIND}" "${PROMPT_FILE}" <<'PYEOF'
-import json, sys
+        python3 -c '
+import json
+import sys
+
 name, target, prompt_id, timestamp, chars, lines, source_tag, source_kind, prompt_file = sys.argv[1:10]
 print(json.dumps({
     "dispatch": "dry-run",
@@ -146,7 +148,7 @@ print(json.dumps({
     "source_kind": source_kind,
     "prompt_file": prompt_file or None,
 }, indent=2))
-PYEOF
+' "${NAME}" "${TARGET}" "${PROMPT_ID}" "${TIMESTAMP}" "${CHAR_COUNT}" "${LINE_COUNT}" "${SOURCE_TAG}" "${PROMPT_SOURCE_KIND}" "${PROMPT_FILE}"
     else
         echo "=== DRY RUN — nothing sent, no audit log written ==="
         echo "name:        ${NAME}"
@@ -193,8 +195,10 @@ fi
 # --- Append to prompt audit log (one JSON record per line — jsonl) ---
 mkdir -p "${LOG_DIR}"
 PREVIEW="$(printf '%s' "${PROMPT}" | head -c 200 | tr '\n' ' ')"
-python3 - "${PROMPT_AUDIT_LOG}" "${NAME}" "${PROMPT_ID}" "${TIMESTAMP}" "${CHAR_COUNT}" "${LINE_COUNT}" "${SOURCE_TAG}" "${PROMPT_SOURCE_KIND}" "${PROMPT_FILE}" "${DISPATCH_METHOD}" "${TARGET}" "${PREVIEW}" <<'PYEOF'
-import json, sys
+python3 -c '
+import json
+import sys
+
 audit_log, name, prompt_id, timestamp, chars, lines, source_tag, source_kind, prompt_file, method, target, preview = sys.argv[1:13]
 record = {
     "prompt_id": prompt_id,
@@ -211,12 +215,14 @@ record = {
 }
 with open(audit_log, "a", encoding="utf-8") as f:
     f.write(json.dumps(record) + "\n")
-PYEOF
+' "${PROMPT_AUDIT_LOG}" "${NAME}" "${PROMPT_ID}" "${TIMESTAMP}" "${CHAR_COUNT}" "${LINE_COUNT}" "${SOURCE_TAG}" "${PROMPT_SOURCE_KIND}" "${PROMPT_FILE}" "${DISPATCH_METHOD}" "${TARGET}" "${PREVIEW}"
 
 # --- Emit receipt ---
 if [[ "${JSON_OUTPUT}" -eq 1 ]]; then
-    python3 - "${NAME}" "${TARGET}" "${PROMPT_ID}" "${TIMESTAMP}" "${CHAR_COUNT}" "${LINE_COUNT}" "${SOURCE_TAG}" "${PROMPT_SOURCE_KIND}" "${PROMPT_FILE}" "${DISPATCH_METHOD}" "${PROMPT_AUDIT_LOG}" <<'PYEOF'
-import json, sys
+    python3 -c '
+import json
+import sys
+
 name, target, prompt_id, timestamp, chars, lines, source_tag, source_kind, prompt_file, method, audit_log = sys.argv[1:12]
 print(json.dumps({
     "dispatch": "ok",
@@ -232,7 +238,7 @@ print(json.dumps({
     "dispatch_method": method,
     "audit_log": audit_log,
 }, indent=2))
-PYEOF
+' "${NAME}" "${TARGET}" "${PROMPT_ID}" "${TIMESTAMP}" "${CHAR_COUNT}" "${LINE_COUNT}" "${SOURCE_TAG}" "${PROMPT_SOURCE_KIND}" "${PROMPT_FILE}" "${DISPATCH_METHOD}" "${PROMPT_AUDIT_LOG}"
 else
     echo "Prompt sent to '${NAME}' (${CHAR_COUNT} chars, ${LINE_COUNT} lines, prompt_id=${PROMPT_ID})"
 fi

--- a/scripts/tmux_session_launcher.sh
+++ b/scripts/tmux_session_launcher.sh
@@ -62,8 +62,10 @@ send_prompt_to_target() {
     if [[ -n "${PROMPT_FILE:-}" ]]; then
         source_kind="file"
     fi
-    python3 - "${audit_log}" "${NAME}" "${prompt_id}" "${timestamp}" "${#prompt}" "${line_count}" "launcher" "${source_kind}" "${PROMPT_FILE:-}" "${method}" "${target}" "${preview}" <<'PYEOF'
-import json, sys
+    python3 -c '
+import json
+import sys
+
 audit_log, name, prompt_id, timestamp, chars, lines, source_tag, source_kind, prompt_file, method, target, preview = sys.argv[1:13]
 record = {
     "prompt_id": prompt_id,
@@ -80,7 +82,7 @@ record = {
 }
 with open(audit_log, "a", encoding="utf-8") as f:
     f.write(json.dumps(record) + "\n")
-PYEOF
+' "${audit_log}" "${NAME}" "${prompt_id}" "${timestamp}" "${#prompt}" "${line_count}" "launcher" "${source_kind}" "${PROMPT_FILE:-}" "${method}" "${target}" "${preview}"
 
     echo "Prompt sent to '${NAME}' (${#prompt} chars, prompt_id=${prompt_id})"
 }
@@ -94,7 +96,7 @@ wait_for_agent_ready() {
 
     case "${agent}" in
         codex)
-            pattern='Use /skills to list available skills|Improve documentation in @filename|Find and fix a bug in @filename|Explain this codebase|Use /rename to rename your threads'
+            pattern='Use /skills to list available skills|Improve documentation in @filename|Find and fix a bug in @filename|Explain this codebase'
             ;;
         claude)
             pattern='Claude Code|ctrl\+g to edit in VS Code|don'"'"'t ask on'
@@ -229,10 +231,24 @@ if ! tmux has-session -t "${TMUX_SESSION}" 2>/dev/null; then
     echo "Created tmux session: ${TMUX_SESSION}"
 fi
 
+# If a prompt file is specified, load it before building the launch command.
+# Droid/Factory prompted launches use `droid exec -f ...` because interactive
+# Droid starts in Auto Off mode and cannot be made autonomous via CLI flags.
+if [[ -n "${PROMPT_FILE}" ]]; then
+    if [[ ! -f "${PROMPT_FILE}" ]]; then
+        echo "Prompt file does not exist: ${PROMPT_FILE}" >&2
+        exit 1
+    fi
+    PROMPT_FILE="$(cd "$(dirname "${PROMPT_FILE}")" && pwd)/$(basename "${PROMPT_FILE}")"
+    PROMPT="$(cat "${PROMPT_FILE}")"
+fi
+
 # Build the launch command
 # When --autonomous is set:
 #   - Claude gets ARAGORA_ADMIN_APPROVED=1 → --dangerously-skip-permissions (can run Bash)
 #   - Codex gets --full-auto approval mode
+#   - Droid/Factory prompted work always uses `droid exec --auto high`; use
+#     ARAGORA_DROID_AUTO_LEVEL=low|medium|high to lower the level explicitly.
 if [[ "${AGENT}" == "codex" ]]; then
     if [[ "${AUTONOMOUS}" == "1" ]]; then
         LAUNCH_CMD="cd '${WORKDIR}' && ./scripts/codex_session.sh --agent '${NAME}' --base main --full-auto"
@@ -246,18 +262,35 @@ elif [[ "${AGENT}" == "claude" ]]; then
         LAUNCH_CMD="cd '${WORKDIR}' && ./scripts/claude-wt"
     fi
 elif [[ "${AGENT}" == "droid" || "${AGENT}" == "factory" ]]; then
-    # Droid interactive sessions do their own permission gating. Mission/exec
-    # mode is intentionally not used here so the pane remains interactive for
-    # later agent_bridge.py send/read cycles.
-    LAUNCH_CMD="cd '${WORKDIR}' && droid --cwd '${WORKDIR}'"
+    DROID_AUTO_LEVEL="${ARAGORA_DROID_AUTO_LEVEL:-high}"
+    case "${DROID_AUTO_LEVEL}" in
+        low|medium|high) ;;
+        *)
+            echo "Invalid ARAGORA_DROID_AUTO_LEVEL='${DROID_AUTO_LEVEL}'. Use low, medium, or high." >&2
+            exit 1
+            ;;
+    esac
+    if [[ -n "${PROMPT}" ]]; then
+        DROID_EXEC_PROMPT_FILE="${PROMPT_FILE}"
+        if [[ -z "${DROID_EXEC_PROMPT_FILE}" ]]; then
+            DROID_EXEC_PROMPT_FILE="${LOG_DIR}/${NAME}.prompt.md"
+            printf '%s\n' "${PROMPT}" > "${DROID_EXEC_PROMPT_FILE}"
+        fi
+        DROID_EXEC_PROMPT_FILE="$(cd "$(dirname "${DROID_EXEC_PROMPT_FILE}")" && pwd)/$(basename "${DROID_EXEC_PROMPT_FILE}")"
+        LAUNCH_CMD="cd '${WORKDIR}' && droid exec --auto '${DROID_AUTO_LEVEL}' --cwd '${WORKDIR}' -f '${DROID_EXEC_PROMPT_FILE}'"
+        # `droid exec -f` consumes the prompt directly; do not also paste it
+        # into an interactive pane.
+        PROMPT=""
+    else
+        if [[ "${ARAGORA_ALLOW_DROID_AUTO_OFF:-0}" != "1" ]]; then
+            echo "Refusing to launch ${AGENT} without a prompt: interactive Droid starts Auto Off. Use --prompt/--prompt-file so this launcher can run droid exec --auto ${DROID_AUTO_LEVEL}, or set ARAGORA_ALLOW_DROID_AUTO_OFF=1 for an explicit manual override." >&2
+            exit 1
+        fi
+        LAUNCH_CMD="cd '${WORKDIR}' && droid --cwd '${WORKDIR}'"
+    fi
 else
     echo "Unknown agent: ${AGENT}. Use 'codex', 'claude', 'droid', or 'factory'." >&2
     exit 1
-fi
-
-# If a prompt file is specified, we'll feed it after launch
-if [[ -n "${PROMPT_FILE}" && -f "${PROMPT_FILE}" ]]; then
-    PROMPT="$(cat "${PROMPT_FILE}")"
 fi
 
 # Create new tmux window with logging
@@ -268,10 +301,11 @@ tmux pipe-pane -t "${WINDOW_TARGET}" -o "cat >> '${LOG_FILE}'"
 # Send the launch command
 tmux send-keys -t "${WINDOW_TARGET}" "${LAUNCH_CMD}" Enter
 
-# Write metadata (avoid embedding prompt content in Python literal)
-python3 - "${NAME}" "${AGENT}" "${LOG_FILE}" "${REPO_ROOT}" "${WORKDIR}" "${PROMPT_FILE}" "${META_FILE}" "${PROMPT:+yes}" "${WINDOW_TARGET}" "${TMUX_SESSION}" "${PANE_INDEX}" "${LAUNCH_CMD}" "${REGISTRY_REPO_ROOT}" <<'PYEOF'
+# Write metadata (avoid embedding prompt content in Python literal). Use
+# `python3 -c` instead of a heredoc; some macOS bash/tmux test paths can block
+# while writing heredoc content before the Python reader starts.
+python3 -c '
 import datetime
-import importlib.util
 import json
 from pathlib import Path
 import sys
@@ -295,28 +329,38 @@ meta = {
 Path(meta_file).write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
 
 try:
-    module_path = Path(repo_root) / "aragora" / "swarm" / "session_mux.py"
-    spec = importlib.util.spec_from_file_location("aragora_swarm_session_mux", module_path)
-    if spec is None or spec.loader is None:
-        raise RuntimeError(f"unable to load session_mux module from {module_path}")
-    session_mux = importlib.util.module_from_spec(spec)
-    sys.modules[spec.name] = session_mux
-    spec.loader.exec_module(session_mux)
-
-    record = session_mux.SessionRecord(
-        name=name,
-        tmux_session=tmux_session,
-        tmux_window=window_target,
-        tmux_pane=pane_index or "0",
-        launcher_command=launch_cmd,
-        started_at=started_at,
-        log_path=log_file,
-        meta_path=meta_file,
-    )
-    session_mux.SessionMuxRegistry(Path(registry_repo_root)).upsert(record)
-except Exception as exc:  # pragma: no cover - launcher should still succeed if registry sync fails
-    print(f"warning: failed to register launcher session: {exc}", file=sys.stderr)
-PYEOF
+    registry_path = Path(registry_repo_root) / ".aragora" / "session_mux" / "registry.json"
+    if registry_path.exists():
+        payload = json.loads(registry_path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            payload = {}
+    else:
+        payload = {}
+    payload.setdefault("schema_version", 1)
+    sessions = payload.setdefault("sessions", {})
+    if not isinstance(sessions, dict):
+        sessions = {}
+        payload["sessions"] = sessions
+    sessions[name] = {
+        "name": name,
+        "tmux_session": tmux_session,
+        "tmux_window": window_target,
+        "tmux_pane": pane_index or "0",
+        "launcher_command": launch_cmd,
+        "started_at": started_at,
+        "last_prompt_at": None,
+        "last_prompt_id": None,
+        "worktree_path": None,
+        "branch": None,
+        "log_path": log_file,
+        "launcher_log_path": None,
+        "meta_path": meta_file,
+    }
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+except Exception as exc:
+    print("warning: failed to register launcher session: " + str(exc), file=sys.stderr)
+' "${NAME}" "${AGENT}" "${LOG_FILE}" "${REPO_ROOT}" "${WORKDIR}" "${PROMPT_FILE}" "${META_FILE}" "${PROMPT:+yes}" "${WINDOW_TARGET}" "${TMUX_SESSION}" "${PANE_INDEX}" "${LAUNCH_CMD}" "${REGISTRY_REPO_ROOT}"
 
 echo "Launched '${NAME}' (${AGENT}) in tmux session '${TMUX_SESSION}'"
 echo "  Cwd: ${WORKDIR}"

--- a/scripts/wake_agent.py
+++ b/scripts/wake_agent.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""Resolve an agent owner and deliver or queue a steering prompt.
+
+Default mode is dry-run.  ``--apply`` is required before the command sends to
+tmux, resumes a Codex thread, or writes a mailbox message.  Every attempted
+dispatch writes an auditable receipt unless ``--no-receipt`` is supplied.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import identify_lane_owner as owner_lookup
+import send_operator_steering as steering_writer
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+LANE_REGISTRY_DEFAULT = REPO_ROOT / ".aragora" / "agent-bridge" / "lanes.json"
+STEERING_INBOX_ROOT_DEFAULT = REPO_ROOT / ".aragora" / "operator-steering"
+DISPATCH_RECEIPT_ROOT_DEFAULT = REPO_ROOT / ".aragora" / "dispatch-receipts"
+RECEIPT_SCHEMA_VERSION = "aragora-wake-agent-receipt/1.0"
+
+
+class WakeError(Exception):
+    """Raised when a prompt cannot be resolved or delivered safely."""
+
+    def __init__(self, message: str, *, exit_code: int = 1) -> None:
+        super().__init__(message)
+        self.exit_code = exit_code
+
+
+def _now_utc_iso() -> str:
+    return dt.datetime.now(dt.UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _filename_timestamp(iso: str) -> str:
+    return iso.replace(":", "-").replace(".", "-")
+
+
+def _prompt_sha256(prompt: str) -> str:
+    return hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        os.replace(tmp_path, path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def _read_prompt(*, prompt: str | None, prompt_file: Path | None) -> str:
+    if bool(prompt) == bool(prompt_file):
+        raise WakeError("provide exactly one of --prompt or --prompt-file", exit_code=2)
+    if prompt_file is not None:
+        if not prompt_file.is_file():
+            raise WakeError(f"prompt file not found: {prompt_file}", exit_code=2)
+        body = prompt_file.read_text(encoding="utf-8")
+    else:
+        body = prompt or ""
+    if not body.strip():
+        raise WakeError("prompt must not be empty", exit_code=2)
+    return body
+
+
+def _resolve_lane(
+    *,
+    to_session: str | None,
+    lane_id: str | None,
+    pr: int | None,
+    branch: str | None,
+    worktree: str | None,
+    registry_path: Path,
+    steering_inbox_root: Path,
+) -> tuple[str, dict[str, Any] | None, str]:
+    if to_session:
+        steering_writer.validate_to_session(to_session, steering_inbox_root=steering_inbox_root)
+        return to_session, None, "direct"
+
+    records = owner_lookup.load_lane_records(registry_path)
+    lane = owner_lookup.find_lane(
+        records,
+        lane_id=lane_id,
+        pr=pr,
+        branch=branch,
+        worktree=worktree,
+    )
+    if lane is None:
+        raise WakeError("no lane matched the requested selector", exit_code=2)
+    owner_session = str(lane.get("owner_session") or "")
+    if not owner_session:
+        raise WakeError("matched lane has no owner_session", exit_code=2)
+    steering_writer.validate_to_session(owner_session, steering_inbox_root=steering_inbox_root)
+    if str(lane.get("status") or "").strip().lower() not in owner_lookup.ACTIVE_STATUSES:
+        raise WakeError(
+            f"matched lane status is {lane.get('status')!r}; refusing live dispatch",
+            exit_code=3,
+        )
+    if lane_id:
+        return owner_session, lane, "lane-id"
+    if pr is not None:
+        return owner_session, lane, "pr"
+    if branch:
+        return owner_session, lane, "branch"
+    return owner_session, lane, "worktree"
+
+
+def _contact_payload(lane: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(lane, dict):
+        return {}
+    payload = lane.get("contact_payload")
+    return payload if isinstance(payload, dict) else {}
+
+
+def choose_transport(
+    *,
+    lane: dict[str, Any] | None,
+    fallback: str,
+) -> tuple[str, dict[str, Any]]:
+    """Return ``(transport, details)``.
+
+    ``transport`` is one of ``tmux``, ``codex-exec-resume``, ``mailbox``, or
+    ``blocked``.  Codex app-server is intentionally not enabled until a lane
+    registers a reachable socket and the repository ships a tested protocol
+    adapter; mailbox fallback is safer than blind Desktop tab injection.
+    """
+
+    method = str((lane or {}).get("contact_method") or "").strip()
+    payload = _contact_payload(lane)
+    thread_id = str((lane or {}).get("codex_thread_id") or "").strip()
+
+    if method.startswith("tmux:"):
+        target = method.removeprefix("tmux:").strip()
+        if target:
+            return "tmux", {"target": target, "contact_method": method}
+        return "blocked", {"reason": "tmux contact_method has no target"}
+
+    if method.startswith("codex-exec-resume:"):
+        method_thread = method.removeprefix("codex-exec-resume:").strip()
+        if method_thread:
+            return "codex-exec-resume", {
+                "thread_id": method_thread,
+                "contact_method": method,
+            }
+        return "blocked", {"reason": "codex-exec-resume contact_method has no thread id"}
+
+    if method.startswith("codex-app-server:"):
+        if fallback == "fail":
+            return "blocked", {
+                "reason": "codex-app-server transport requires a shipped protocol adapter"
+            }
+        return "mailbox", {
+            "fallback_reason": "codex-app-server transport not yet enabled",
+            "socket": payload.get("socket"),
+            "thread_id": payload.get("thread_id") or thread_id,
+        }
+
+    if method == "mailbox-only":
+        return "mailbox", {"contact_method": method}
+
+    if thread_id:
+        return "codex-exec-resume", {"thread_id": thread_id, "source": "codex_thread_id"}
+
+    if method and fallback == "fail":
+        return "blocked", {"reason": f"unsupported contact_method {method!r}"}
+    return "mailbox", {"fallback_reason": "no live contact method registered"}
+
+
+def _send_tmux(target: str, prompt: str) -> None:
+    if "\n" in prompt:
+        subprocess.run(
+            ["tmux", "load-buffer", "-"], input=prompt, text=True, check=True, timeout=10
+        )
+        subprocess.run(["tmux", "paste-buffer", "-d", "-t", target], check=True, timeout=10)
+        subprocess.run(["tmux", "send-keys", "-t", target, "Enter"], check=True, timeout=10)
+    else:
+        subprocess.run(["tmux", "send-keys", "-t", target, prompt, "Enter"], check=True, timeout=10)
+
+
+def _send_codex_exec_resume(thread_id: str, prompt: str, cwd: Path) -> None:
+    subprocess.run(
+        ["codex", "exec", "resume", thread_id, "-"],
+        input=prompt,
+        text=True,
+        cwd=str(cwd),
+        check=True,
+        timeout=3600,
+    )
+
+
+def _write_mailbox(
+    *,
+    owner_session: str,
+    prompt: str,
+    lane: dict[str, Any] | None,
+    priority: str,
+    steering_inbox_root: Path,
+) -> Path:
+    raw_pr = (lane or {}).get("pr_number")
+    try:
+        pr_hint = int(raw_pr) if raw_pr is not None else None
+    except (TypeError, ValueError):
+        pr_hint = None
+    message = steering_writer.build_message(
+        to_session=owner_session,
+        body=prompt,
+        priority=priority,
+        lane_id_hint=str((lane or {}).get("lane_id") or "") or None,
+        pr_hint=pr_hint,
+    )
+    return steering_writer.write_message(message, steering_inbox_root=steering_inbox_root)
+
+
+def _write_receipt(
+    *,
+    receipt_root: Path,
+    payload: dict[str, Any],
+) -> Path:
+    ts = _filename_timestamp(str(payload.get("completed_at_utc") or _now_utc_iso()))
+    lane_part = str(payload.get("lane_id") or payload.get("owner_session") or "direct")
+    safe_lane = "".join(ch if ch.isalnum() or ch in "-_." else "-" for ch in lane_part)[:80]
+    path = receipt_root / f"{ts}-{safe_lane}-{str(payload['prompt_sha256'])[:8]}.json"
+    _atomic_write_json(path, payload)
+    return path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    target = parser.add_mutually_exclusive_group(required=True)
+    target.add_argument("--to", help="Direct owner_session recipient.")
+    target.add_argument("--lane", "--lane-id", dest="lane_id", help="Lane id selector.")
+    target.add_argument("--pr", type=int, help="PR number selector.")
+    target.add_argument("--branch", help="Branch selector.")
+    target.add_argument("--worktree", help="Worktree selector.")
+    body = parser.add_mutually_exclusive_group(required=True)
+    body.add_argument("--prompt", help="Prompt body.")
+    body.add_argument("--prompt-file", type=Path, help="Prompt file.")
+    parser.add_argument("--priority", choices=steering_writer.PRIORITY_CHOICES, default="normal")
+    parser.add_argument("--fallback", choices=("mailbox-only", "fail"), default="mailbox-only")
+    parser.add_argument("--apply", action="store_true", help="Actually deliver instead of dry-run.")
+    parser.add_argument("--no-receipt", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--registry-path", type=Path, default=LANE_REGISTRY_DEFAULT)
+    parser.add_argument("--steering-inbox-root", type=Path, default=STEERING_INBOX_ROOT_DEFAULT)
+    parser.add_argument("--receipt-root", type=Path, default=DISPATCH_RECEIPT_ROOT_DEFAULT)
+    parser.add_argument("--cwd", type=Path, default=REPO_ROOT)
+    return parser
+
+
+def run(args: argparse.Namespace) -> dict[str, Any]:
+    prompt = _read_prompt(prompt=args.prompt, prompt_file=args.prompt_file)
+    owner_session, lane, resolved_via = _resolve_lane(
+        to_session=args.to,
+        lane_id=args.lane_id,
+        pr=args.pr,
+        branch=args.branch,
+        worktree=args.worktree,
+        registry_path=args.registry_path,
+        steering_inbox_root=args.steering_inbox_root,
+    )
+    transport, details = choose_transport(lane=lane, fallback=args.fallback)
+    prompt_hash = _prompt_sha256(prompt)
+    now = _now_utc_iso()
+    result: dict[str, Any] = {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "ok": False,
+        "dry_run": not args.apply,
+        "owner_session": owner_session,
+        "resolved_via": resolved_via,
+        "lane_id": (lane or {}).get("lane_id"),
+        "pr_number": (lane or {}).get("pr_number"),
+        "branch": (lane or {}).get("branch"),
+        "worktree": (lane or {}).get("worktree"),
+        "transport": transport,
+        "transport_details": details,
+        "mailbox_dispatchable": transport in {"mailbox", "tmux", "codex-exec-resume"},
+        "live_prompt_dispatchable": transport in {"tmux", "codex-exec-resume"},
+        "prompt_sha256": prompt_hash,
+        "created_at_utc": now,
+        "completed_at_utc": now,
+        "receipt_path": None,
+    }
+
+    try:
+        if transport == "blocked":
+            raise WakeError(str(details.get("reason") or "transport blocked"), exit_code=3)
+        if not args.apply:
+            result["ok"] = True
+            result["status"] = "dry-run"
+            return result
+        if transport == "tmux":
+            _send_tmux(str(details["target"]), prompt)
+            result["status"] = "sent"
+        elif transport == "codex-exec-resume":
+            _send_codex_exec_resume(str(details["thread_id"]), prompt, args.cwd)
+            result["status"] = "sent"
+        elif transport == "mailbox":
+            path = _write_mailbox(
+                owner_session=owner_session,
+                prompt=prompt,
+                lane=lane,
+                priority=args.priority,
+                steering_inbox_root=args.steering_inbox_root,
+            )
+            result["status"] = "mailbox-written"
+            result["mailbox_message_path"] = str(path)
+        result["ok"] = True
+        return result
+    except (OSError, subprocess.SubprocessError, WakeError) as exc:
+        result["ok"] = False
+        result["status"] = "blocked"
+        result["error"] = str(exc)
+        return result
+    finally:
+        result["completed_at_utc"] = _now_utc_iso()
+        if not args.no_receipt:
+            receipt_path = _write_receipt(receipt_root=args.receipt_root, payload=result)
+            result["receipt_path"] = str(receipt_path)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        result = run(args)
+    except WakeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return exc.exit_code
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(
+            f"{result['status']}: owner={result['owner_session']} "
+            f"transport={result['transport']} dry_run={result['dry_run']}"
+        )
+        if result.get("error"):
+            print(f"error: {result['error']}", file=sys.stderr)
+        if result.get("receipt_path"):
+            print(f"receipt: {result['receipt_path']}")
+    return 0 if result.get("ok") else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_agent_bridge_steering.py
+++ b/tests/scripts/test_agent_bridge_steering.py
@@ -88,11 +88,25 @@ def _write_message(
 class TestCollectPendingSteeringMessages:
     def test_empty_mailbox_scoped(self, tmp_path: Path) -> None:
         result = ab._collect_pending_steering_messages("fixture-a", steering_root=tmp_path)
-        assert result == {"count": 0, "latest_three": []}
+        assert result == {
+            "count": 0,
+            "latest_three": [],
+            "read_receipt_count": 0,
+            "unread_message_count": 0,
+            "latest_read_receipt": None,
+        }
 
     def test_empty_mailbox_rollup(self, tmp_path: Path) -> None:
         result = ab._collect_pending_steering_messages(None, steering_root=tmp_path)
-        assert result == {"count": 0, "by_recipient": {}, "latest_three": []}
+        assert result == {
+            "count": 0,
+            "by_recipient": {},
+            "latest_three": [],
+            "read_receipt_count": 0,
+            "unread_message_count": 0,
+            "read_receipts_by_recipient": {},
+            "latest_read_receipt": None,
+        }
 
     def test_missing_dir_returns_zero(self, tmp_path: Path) -> None:
         # Steering root does not exist at all.
@@ -124,6 +138,51 @@ class TestCollectPendingSteeringMessages:
         assert first["priority"] == "high"
         assert first["lane_id_hint"] == "P30-fixture"
         assert first["pr_hint"] == 9000
+        assert result["read_receipt_count"] == 0
+        assert result["unread_message_count"] == 1
+        assert result["latest_read_receipt"] is None
+
+    def test_read_receipts_reduce_unread_but_preserve_pending_count(self, tmp_path: Path) -> None:
+        _write_message(
+            tmp_path,
+            "fixture-receipts",
+            body="already read",
+            sent_at_utc="2026-05-18T01:00:00.000Z",
+            filename="msg-a.json",
+        )
+        _write_message(
+            tmp_path,
+            "fixture-receipts",
+            body="still unread",
+            sent_at_utc="2026-05-18T02:00:00.000Z",
+            filename="msg-b.json",
+        )
+        receipt_dir = tmp_path / "fixture-receipts" / "_read_receipts"
+        receipt_dir.mkdir(parents=True)
+        msg_a = json.loads((tmp_path / "fixture-receipts" / "msg-a.json").read_text())
+        (receipt_dir / "receipt-a.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": "aragora-operator-steering-read-receipt/1.0",
+                    "owner_session": "fixture-receipts",
+                    "read_by_session": "reader",
+                    "read_at_utc": "2026-05-18T03:00:00.000Z",
+                    "message_filename": "msg-a.json",
+                    "message_sha256": msg_a["message_sha256"],
+                    "outcome": "obeyed",
+                    "subject": "already read",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = ab._collect_pending_steering_messages("fixture-receipts", steering_root=tmp_path)
+
+        assert result["count"] == 2
+        assert result["read_receipt_count"] == 1
+        assert result["unread_message_count"] == 1
+        assert result["latest_read_receipt"]["message_filename"] == "msg-a.json"
+        assert result["latest_read_receipt"]["outcome"] == "obeyed"
 
     def test_five_messages_returns_top_three_newest(self, tmp_path: Path) -> None:
         # Write 5 with strictly-increasing sent_at_utc.
@@ -149,6 +208,9 @@ class TestCollectPendingSteeringMessages:
         result = ab._collect_pending_steering_messages(None, steering_root=tmp_path)
         assert result["count"] == 4
         assert result["by_recipient"] == {"alpha": 2, "beta": 1, "gamma": 1}
+        assert result["read_receipt_count"] == 0
+        assert result["unread_message_count"] == 4
+        assert result["read_receipts_by_recipient"] == {}
         # latest_three sorted newest first across all recipients
         subjects = [m["subject"] for m in result["latest_three"]]
         assert subjects == ["g-only", "b-only", "a-second"]

--- a/tests/scripts/test_claim_active_agent_lane.py
+++ b/tests/scripts/test_claim_active_agent_lane.py
@@ -466,6 +466,27 @@ def test_desktop_identity_metadata_round_trips(tmp_registry: Path) -> None:
     assert payload[0]["session_title"] == "Review #7286"
 
 
+def test_contact_metadata_round_trips(tmp_registry: Path) -> None:
+    claim_module.claim_lane(
+        registry_path=tmp_registry,
+        lane_id="codex-steer",
+        owner_session="codex-owner",
+        contact_method="codex-exec-resume:019e-thread",
+        contact_payload={"thread_id": "019e-thread", "socket": "/tmp/codex.sock"},
+        last_mailbox_check_at="2026-05-20T01:00:00Z",
+        last_delivery_at="2026-05-20T01:01:00Z",
+        last_ack_at="2026-05-20T01:02:00Z",
+    )
+
+    payload = json.loads(tmp_registry.read_text(encoding="utf-8"))
+    row = payload[0]
+    assert row["contact_method"] == "codex-exec-resume:019e-thread"
+    assert row["contact_payload"]["thread_id"] == "019e-thread"
+    assert row["last_mailbox_check_at"] == "2026-05-20T01:00:00Z"
+    assert row["last_delivery_at"] == "2026-05-20T01:01:00Z"
+    assert row["last_ack_at"] == "2026-05-20T01:02:00Z"
+
+
 def test_cli_help_exits_zero() -> None:
     result = subprocess.run(
         [sys.executable, str(SCRIPT_PATH), "--help"],
@@ -496,6 +517,10 @@ def test_cli_writes_registry_via_subprocess(tmp_path: Path) -> None:
             "/Users/armand/.codex/sessions/cli.jsonl",
             "--session-title",
             "CLI lane claim",
+            "--contact-method",
+            "tmux:aragora:1",
+            "--contact-payload",
+            '{"target": "aragora:1"}',
             "--status",
             "active",
             "--registry-path",
@@ -517,6 +542,8 @@ def test_cli_writes_registry_via_subprocess(tmp_path: Path) -> None:
     assert file_payload[0]["codex_thread_id"] == "019e-cli-thread"
     assert file_payload[0]["codex_rollout_path"].endswith("cli.jsonl")
     assert file_payload[0]["session_title"] == "CLI lane claim"
+    assert file_payload[0]["contact_method"] == "tmux:aragora:1"
+    assert file_payload[0]["contact_payload"]["target"] == "aragora:1"
 
 
 def test_cli_conflict_returns_exit_code_2(tmp_path: Path) -> None:

--- a/tests/scripts/test_codex_dispatch_queue.py
+++ b/tests/scripts/test_codex_dispatch_queue.py
@@ -1,0 +1,86 @@
+"""Tests for the local Codex dispatch queue runner."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _load_module(script_name: str) -> Any:
+    here = Path(__file__).resolve()
+    script_path = here.parents[2] / "scripts" / script_name
+    spec = importlib.util.spec_from_file_location(f"{script_name}_under_test", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load spec for {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+queue = _load_module("codex_dispatch_queue.py")
+
+
+def test_enqueue_writes_pending_job(tmp_path: Path) -> None:
+    args = queue.build_parser().parse_args(
+        [
+            "enqueue",
+            "--to",
+            "codex-owner",
+            "--prompt",
+            "queued prompt",
+            "--queue-root",
+            str(tmp_path / "queue"),
+            "--json",
+        ]
+    )
+
+    result = queue.enqueue(args)
+
+    assert result["ok"] is True
+    path = Path(result["path"])
+    assert path.exists()
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == queue.JOB_SCHEMA_VERSION
+    assert payload["selectors"]["to"] == "codex-owner"
+    assert payload["prompt_sha256"]
+
+
+def test_dry_run_runner_blocks_without_writing_mailbox(tmp_path: Path) -> None:
+    enqueue_args = queue.build_parser().parse_args(
+        [
+            "enqueue",
+            "--to",
+            "codex-owner",
+            "--prompt",
+            "queued prompt",
+            "--queue-root",
+            str(tmp_path / "queue"),
+        ]
+    )
+    queue.enqueue(enqueue_args)
+    run_args = queue.build_parser().parse_args(
+        [
+            "run",
+            "--queue-root",
+            str(tmp_path / "queue"),
+            "--steering-inbox-root",
+            str(tmp_path / "steering"),
+            "--receipt-root",
+            str(tmp_path / "dispatch-receipts"),
+            "--json",
+        ]
+    )
+
+    result = queue.run_queue(run_args)
+
+    assert result["ok"] is True
+    assert result["dry_run"] is True
+    assert result["processed"][0]["status"] == "blocked"
+    assert result["processed"][0]["error"] == "dry-run; no prompt delivered"
+    assert not (tmp_path / "steering").exists()
+    assert list((tmp_path / "queue" / "blocked").glob("*.json"))
+    assert list((tmp_path / "queue" / "blocked").glob("*.receipt.json"))

--- a/tests/scripts/test_identify_lane_owner.py
+++ b/tests/scripts/test_identify_lane_owner.py
@@ -596,9 +596,14 @@ class TestLookupFactoryDroid:
 
 class TestSteeringInbox:
     def test_missing_inbox_dir_returns_zero_count(self, tmp_path: Path) -> None:
-        path, count = ilo.steering_inbox_for("nobody-1", root=tmp_path / "steering")
+        path, count, receipt_summary = ilo.steering_inbox_for(
+            "nobody-1", root=tmp_path / "steering"
+        )
         assert count == 0
         assert path == tmp_path / "steering" / "nobody-1"
+        assert receipt_summary["read_receipt_count"] == 0
+        assert receipt_summary["unread_message_count"] == 0
+        assert receipt_summary["latest_read_receipt"] is None
 
     def test_counts_only_dot_json_files(self, tmp_path: Path) -> None:
         inbox = tmp_path / "steering" / "claude-X"
@@ -606,9 +611,65 @@ class TestSteeringInbox:
         (inbox / "msg-a.json").write_text("{}", encoding="utf-8")
         (inbox / "msg-b.json").write_text("{}", encoding="utf-8")
         (inbox / "README.md").write_text("docs only", encoding="utf-8")
-        path, count = ilo.steering_inbox_for("claude-X", root=tmp_path / "steering")
+        path, count, receipt_summary = ilo.steering_inbox_for(
+            "claude-X", root=tmp_path / "steering"
+        )
         assert count == 2
         assert path == inbox
+        assert receipt_summary["read_receipt_count"] == 0
+        assert receipt_summary["unread_message_count"] == 2
+        assert receipt_summary["latest_read_receipt"] is None
+
+    def test_summarizes_read_receipts_without_changing_pending_count(self, tmp_path: Path) -> None:
+        inbox = tmp_path / "steering" / "claude-X"
+        receipts = inbox / "_read_receipts"
+        receipts.mkdir(parents=True)
+        (inbox / "msg-a.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": "aragora-operator-steering/1.0",
+                    "message_sha256": "aaa",
+                    "sent_at_utc": "2026-05-18T01:00:00.000Z",
+                }
+            ),
+            encoding="utf-8",
+        )
+        (inbox / "msg-b.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": "aragora-operator-steering/1.0",
+                    "message_sha256": "bbb",
+                    "sent_at_utc": "2026-05-18T02:00:00.000Z",
+                }
+            ),
+            encoding="utf-8",
+        )
+        (receipts / "receipt-a.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": "aragora-operator-steering-read-receipt/1.0",
+                    "owner_session": "claude-X",
+                    "read_by_session": "reader",
+                    "read_at_utc": "2026-05-18T03:00:00.000Z",
+                    "message_filename": "msg-a.json",
+                    "message_sha256": "aaa",
+                    "outcome": "stale",
+                    "subject": "msg-a",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        path, count, receipt_summary = ilo.steering_inbox_for(
+            "claude-X", root=tmp_path / "steering"
+        )
+
+        assert path == inbox
+        assert count == 2
+        assert receipt_summary["read_receipt_count"] == 1
+        assert receipt_summary["unread_message_count"] == 1
+        assert receipt_summary["latest_read_receipt"]["message_filename"] == "msg-a.json"
+        assert receipt_summary["latest_read_receipt"]["outcome"] == "stale"
 
 
 # ---------------------------------------------------------------------------
@@ -637,11 +698,47 @@ class TestBuildOwnerInfo:
         assert info.codex_thread_id == "019e3942-e27e-7e72-b8d6-b61d981fd532"
         assert info.desktop_label == "Test Codex Desktop Tab"
         assert info.session_title == "Rich identity claim"
+        assert info.live_prompt_dispatchable is True
+        assert info.mailbox_dispatchable is True
         assert info.pending_message_count == 0
+        assert info.read_receipt_count == 0
+        assert info.unread_message_count == 0
+        assert info.latest_read_receipt is None
         # Live lookups all return found=False because tmp dirs are empty.
         assert info.live_process["found"] is False
         assert info.claude_session["found"] is False
         assert info.factory_droid["found"] is False
+
+    def test_contact_metadata_surfaces_and_controls_dispatch_split(self, tmp_path: Path) -> None:
+        bg = tmp_path / "factory_bg.json"
+        bg.write_text("[]", encoding="utf-8")
+        lane = {
+            "lane_id": "tmux-lane",
+            "owner_session": "codex-tmux",
+            "status": "active",
+            "contact_method": "tmux:aragora:2",
+            "contact_payload": {"target": "aragora:2"},
+            "last_mailbox_check_at": "2026-05-20T01:00:00Z",
+            "last_delivery_at": "2026-05-20T01:01:00Z",
+            "last_ack_at": "2026-05-20T01:02:00Z",
+        }
+
+        info = ilo.build_owner_info(
+            lane,
+            snapshot_provider=lambda: fake_snapshot_records([]),
+            sessions_root=tmp_path / "codex_sessions",
+            projects_root=tmp_path / "claude_projects",
+            bg_path=bg,
+            steering_inbox_root=tmp_path / "steering",
+        )
+
+        assert info.contact_method == "tmux:aragora:2"
+        assert info.contact_payload == {"target": "aragora:2"}
+        assert info.last_mailbox_check_at == "2026-05-20T01:00:00Z"
+        assert info.last_delivery_at == "2026-05-20T01:01:00Z"
+        assert info.last_ack_at == "2026-05-20T01:02:00Z"
+        assert info.mailbox_dispatchable is True
+        assert info.live_prompt_dispatchable is True
 
 
 # ---------------------------------------------------------------------------
@@ -707,6 +804,9 @@ class TestMainCLI:
         assert data["pr_number"] == 7292
         assert data["live_process"]["found"] is False  # no snapshot integration in CLI default path
         assert data["pending_message_count"] == 0
+        assert data["read_receipt_count"] == 0
+        assert data["unread_message_count"] == 0
+        assert data["latest_read_receipt"] is None
         assert data["dispatchable"] is True
         assert data["dispatch_blocker"] is None
         assert data["harness_confidence"] == "mailbox_only"

--- a/tests/scripts/test_read_operator_steering.py
+++ b/tests/scripts/test_read_operator_steering.py
@@ -1,0 +1,175 @@
+"""Tests for ``scripts/read_operator_steering.py``.
+
+Fixture-driven; all steering mailbox reads/writes happen under ``tmp_path``.
+The reader must leave original messages in place and write append-only read
+receipts into a sidecar directory.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _load_module(script_name: str) -> Any:
+    here = Path(__file__).resolve()
+    script_path = here.parents[2] / "scripts" / script_name
+    spec = importlib.util.spec_from_file_location(f"{script_name}_under_test", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load spec for {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+sos = _load_module("send_operator_steering.py")
+ros = _load_module("read_operator_steering.py")
+
+
+def _write_message(root: Path, recipient: str, body: str = "body") -> Path:
+    message = sos.build_message(
+        to_session=recipient,
+        body=body,
+        priority="blocking",
+        lane_id_hint="P-read-fixture",
+        pr_hint=7373,
+        sent_at_utc="2026-05-19T22:00:00.000Z",
+    )
+    return sos.write_message(message, steering_inbox_root=root)
+
+
+def _receipt_files(root: Path, recipient: str) -> list[Path]:
+    receipt_dir = root / recipient / "_read_receipts"
+    return sorted(receipt_dir.glob("*.json")) if receipt_dir.is_dir() else []
+
+
+def test_reads_only_selected_owner_and_writes_bound_receipt(tmp_path: Path, capsys: Any) -> None:
+    steering_root = tmp_path / "steering"
+    selected = _write_message(steering_root, "codex-selected", "selected body")
+    other = _write_message(steering_root, "codex-other", "other body")
+
+    rc = ros.main(
+        [
+            "--to",
+            "codex-selected",
+            "--read-by-session",
+            "reader-session",
+            "--outcome",
+            "obeyed",
+            "--outcome-note",
+            "validated and followed",
+            "--steering-inbox-root",
+            str(steering_root),
+            "--json",
+        ]
+    )
+
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["owner_session"] == "codex-selected"
+    assert out["message_count"] == 1
+    assert out["receipt_count"] == 1
+    assert out["messages"][0]["filename"] == selected.name
+    assert out["messages"][0]["sha256_valid"] is True
+    assert selected.exists()
+    assert other.exists()
+
+    receipts = _receipt_files(steering_root, "codex-selected")
+    assert len(receipts) == 1
+    receipt = json.loads(receipts[0].read_text(encoding="utf-8"))
+    selected_payload = json.loads(selected.read_text(encoding="utf-8"))
+    assert receipt["schema_version"] == "aragora-operator-steering-read-receipt/1.0"
+    assert receipt["owner_session"] == "codex-selected"
+    assert receipt["read_by_session"] == "reader-session"
+    assert receipt["message_filename"] == selected.name
+    assert receipt["message_sha256"] == selected_payload["message_sha256"]
+    assert receipt["message_sent_at_utc"] == "2026-05-19T22:00:00.000Z"
+    assert receipt["priority"] == "blocking"
+    assert receipt["lane_id_hint"] == "P-read-fixture"
+    assert receipt["pr_hint"] == 7373
+    assert receipt["subject"] == "selected body"
+    assert receipt["outcome"] == "obeyed"
+    assert receipt["outcome_note"] == "validated and followed"
+    assert _receipt_files(steering_root, "codex-other") == []
+
+
+def test_no_receipt_lists_messages_without_writing(tmp_path: Path, capsys: Any) -> None:
+    steering_root = tmp_path / "steering"
+    msg = _write_message(steering_root, "codex-dry", "dry body")
+
+    rc = ros.main(
+        [
+            "--to",
+            "codex-dry",
+            "--no-receipt",
+            "--steering-inbox-root",
+            str(steering_root),
+            "--json",
+        ]
+    )
+
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["message_count"] == 1
+    assert out["receipt_count"] == 0
+    assert out["messages"][0]["filename"] == msg.name
+    assert _receipt_files(steering_root, "codex-dry") == []
+    assert msg.exists()
+
+
+def test_rejects_unsafe_session_before_reading(tmp_path: Path, capsys: Any) -> None:
+    rc = ros.main(
+        [
+            "--to",
+            "../escape",
+            "--steering-inbox-root",
+            str(tmp_path / "steering"),
+            "--json",
+        ]
+    )
+
+    assert rc == 2
+    assert "path separators" in capsys.readouterr().err
+    assert list(tmp_path.rglob("*.json")) == []
+
+
+def test_resolves_owner_by_lane_id(tmp_path: Path, capsys: Any) -> None:
+    steering_root = tmp_path / "steering"
+    registry = tmp_path / "lanes.json"
+    registry.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "P-read-fixture",
+                    "owner_session": "codex-lane-owner",
+                    "status": "active",
+                    "branch": "codex/read-fixture",
+                    "pr_number": 7373,
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    _write_message(steering_root, "codex-lane-owner", "lane body")
+
+    rc = ros.main(
+        [
+            "--lane-id",
+            "P-read-fixture",
+            "--registry-path",
+            str(registry),
+            "--steering-inbox-root",
+            str(steering_root),
+            "--json",
+        ]
+    )
+
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["owner_session"] == "codex-lane-owner"
+    assert out["resolved_via"] == "lane-id"
+    assert out["message_count"] == 1

--- a/tests/scripts/test_tmux_transport_scripts.py
+++ b/tests/scripts/test_tmux_transport_scripts.py
@@ -198,7 +198,7 @@ def test_tmux_session_launcher_does_not_treat_codex_banner_as_ready(tmp_path: Pa
     log_dir = Path(env["HOME"]) / ".aragora" / "tmux-sessions"
     log_dir.mkdir(parents=True)
     (log_dir / "testpane.log").write_text(
-        "boot\nOpenAI Codex (v0.125.0)\n",
+        "boot\nOpenAI Codex (v0.125.0)\nUse /rename to rename your threads\n",
         encoding="utf-8",
     )
 
@@ -223,6 +223,9 @@ def test_tmux_session_launcher_does_not_treat_codex_banner_as_ready(tmp_path: Pa
     assert "Timed out waiting for readiness markers for testpane; prompt not sent." in result.stdout
     calls = _load_tmux_calls(env)
     assert ["load-buffer", "-"] not in calls
+    assert not any(
+        call[:2] == ["send-keys", "-t"] and "hello from launcher" in call for call in calls
+    )
 
 
 def test_tmux_session_launcher_supports_droid_agent(tmp_path: Path) -> None:
@@ -253,16 +256,83 @@ def test_tmux_session_launcher_supports_droid_agent(tmp_path: Path) -> None:
         check=True,
     )
 
-    assert "Readiness markers detected for factory-review." in result.stdout
     calls = _load_tmux_calls(env)
     assert any(
-        call[:2] == ["send-keys", "-t"] and call[2] == "@17" and "droid --cwd" in call[3]
+        call[:2] == ["send-keys", "-t"]
+        and call[2] == "@17"
+        and "droid exec --auto 'high'" in call[3]
+        and "-f" in call[3]
         for call in calls
     )
+    assert not any("review only" in json.dumps(call) for call in calls)
+
+
+def test_tmux_session_launcher_supports_droid_prompt_file(tmp_path: Path) -> None:
+    _write_fake_tmux(tmp_path)
+    env = _fake_tmux_env(tmp_path)
+    env["ARAGORA_TMUX_INIT_WAIT_SECONDS"] = "1"
+    env["ARAGORA_TMUX_REGISTRY_REPO_ROOT"] = str(tmp_path)
+    prompt_file = tmp_path / "review.md"
+    prompt_file.write_text("review from file", encoding="utf-8")
+
+    log_dir = Path(env["HOME"]) / ".aragora" / "tmux-sessions"
+    log_dir.mkdir(parents=True)
+    (log_dir / "factory-review.log").write_text("boot\nDroid\n", encoding="utf-8")
+
+    subprocess.run(
+        [
+            "bash",
+            str(REPO_ROOT / "scripts" / "tmux_session_launcher.sh"),
+            "--name",
+            "factory-review",
+            "--agent",
+            "factory",
+            "--prompt-file",
+            str(prompt_file),
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    calls = _load_tmux_calls(env)
     assert any(
-        call[:2] == ["send-keys", "-t"] and call[2] == "@17" and "review only" in call
+        call[:2] == ["send-keys", "-t"]
+        and call[2] == "@17"
+        and "droid exec --auto 'high'" in call[3]
+        and f"-f '{prompt_file}'" in call[3]
         for call in calls
     )
+    assert not any("review from file" in json.dumps(call) for call in calls)
+
+
+def test_tmux_session_launcher_rejects_unprompted_droid_auto_off_by_default(
+    tmp_path: Path,
+) -> None:
+    _write_fake_tmux(tmp_path)
+    env = _fake_tmux_env(tmp_path)
+    env["ARAGORA_TMUX_REGISTRY_REPO_ROOT"] = str(tmp_path)
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(REPO_ROOT / "scripts" / "tmux_session_launcher.sh"),
+            "--name",
+            "factory-review",
+            "--agent",
+            "droid",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "interactive Droid starts Auto Off" in result.stderr
 
 
 def test_tmux_session_launcher_does_not_send_prompt_before_readiness_by_default(

--- a/tests/scripts/test_wake_agent.py
+++ b/tests/scripts/test_wake_agent.py
@@ -1,0 +1,118 @@
+"""Tests for ``scripts/wake_agent.py`` safe steering transport selection."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _load_module(script_name: str) -> Any:
+    here = Path(__file__).resolve()
+    script_path = here.parents[2] / "scripts" / script_name
+    spec = importlib.util.spec_from_file_location(f"{script_name}_under_test", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load spec for {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+wake = _load_module("wake_agent.py")
+
+
+def _parse(args: list[str]) -> Any:
+    return wake.build_parser().parse_args(args)
+
+
+def test_choose_transport_prefers_explicit_tmux() -> None:
+    transport, details = wake.choose_transport(
+        lane={"contact_method": "tmux:aragora:3"},
+        fallback="mailbox-only",
+    )
+
+    assert transport == "tmux"
+    assert details["target"] == "aragora:3"
+
+
+def test_choose_transport_uses_codex_thread_id_without_ui_injection() -> None:
+    transport, details = wake.choose_transport(
+        lane={"codex_thread_id": "019e-thread"},
+        fallback="mailbox-only",
+    )
+
+    assert transport == "codex-exec-resume"
+    assert details["thread_id"] == "019e-thread"
+
+
+def test_codex_app_server_contact_falls_back_to_mailbox_until_adapter_exists() -> None:
+    transport, details = wake.choose_transport(
+        lane={
+            "contact_method": "codex-app-server:/tmp/codex.sock",
+            "contact_payload": {"socket": "/tmp/codex.sock", "thread_id": "t1"},
+        },
+        fallback="mailbox-only",
+    )
+
+    assert transport == "mailbox"
+    assert "not yet enabled" in details["fallback_reason"]
+
+
+def test_dry_run_does_not_write_mailbox_but_writes_receipt(tmp_path: Path) -> None:
+    args = _parse(
+        [
+            "--to",
+            "codex-owner",
+            "--prompt",
+            "check your mailbox",
+            "--steering-inbox-root",
+            str(tmp_path / "steering"),
+            "--receipt-root",
+            str(tmp_path / "receipts"),
+            "--json",
+        ]
+    )
+
+    result = wake.run(args)
+
+    assert result["ok"] is True
+    assert result["dry_run"] is True
+    assert result["status"] == "dry-run"
+    assert not (tmp_path / "steering").exists()
+    receipt_path = Path(result["receipt_path"])
+    assert receipt_path.exists()
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert receipt["prompt_sha256"] == result["prompt_sha256"]
+
+
+def test_apply_mailbox_writes_message_and_receipt(tmp_path: Path) -> None:
+    args = _parse(
+        [
+            "--to",
+            "codex-owner",
+            "--prompt",
+            "real mailbox delivery",
+            "--apply",
+            "--priority",
+            "blocking",
+            "--steering-inbox-root",
+            str(tmp_path / "steering"),
+            "--receipt-root",
+            str(tmp_path / "receipts"),
+            "--json",
+        ]
+    )
+
+    result = wake.run(args)
+
+    assert result["ok"] is True
+    assert result["status"] == "mailbox-written"
+    message_files = list((tmp_path / "steering" / "codex-owner").glob("*.json"))
+    assert len(message_files) == 1
+    message = json.loads(message_files[0].read_text(encoding="utf-8"))
+    assert message["body"] == "real mailbox delivery"
+    assert message["priority"] == "blocking"
+    assert Path(result["receipt_path"]).exists()


### PR DESCRIPTION
## Summary
- add operator-steering mailbox reader/checker with append-only read receipts
- add lane contact metadata and split mailbox vs live prompt dispatchability in owner lookup
- add wake_agent.py and codex_dispatch_queue.py for audited local prompt dispatch with safe mailbox fallback
- wire Codex managed session startup to surface steering mailbox messages by default

## Validation
- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/scripts/test_read_operator_steering.py tests/scripts/test_agent_bridge_steering.py tests/scripts/test_identify_lane_owner.py tests/scripts/test_claim_active_agent_lane.py tests/scripts/test_wake_agent.py tests/scripts/test_codex_dispatch_queue.py -q -p no:cacheprovider
- python3 -m ruff check scripts/check_operator_steering.py scripts/read_operator_steering.py scripts/wake_agent.py scripts/codex_dispatch_queue.py scripts/claim_active_agent_lane.py scripts/agent_bridge.py scripts/identify_lane_owner.py tests/scripts/test_read_operator_steering.py tests/scripts/test_agent_bridge_steering.py tests/scripts/test_identify_lane_owner.py tests/scripts/test_claim_active_agent_lane.py tests/scripts/test_wake_agent.py tests/scripts/test_codex_dispatch_queue.py
- python3 -m ruff format --check scripts/check_operator_steering.py scripts/read_operator_steering.py scripts/wake_agent.py scripts/codex_dispatch_queue.py scripts/claim_active_agent_lane.py scripts/agent_bridge.py scripts/identify_lane_owner.py tests/scripts/test_read_operator_steering.py tests/scripts/test_agent_bridge_steering.py tests/scripts/test_identify_lane_owner.py tests/scripts/test_claim_active_agent_lane.py tests/scripts/test_wake_agent.py tests/scripts/test_codex_dispatch_queue.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- pre-push hook passed: mypy-baseline, gitleaks