### PR TITLE
fix(scripts): avoid Auto Off Droid launches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,10 @@ For Codex-driven automations in this repo, default to maximum safe autonomy. Fin
   verify the issue, make the smallest credible fix, validate it, commit it, push it, open the PR, and leave the inbox or memory handoff in the same run when the task is otherwise ready.
 - Do not stop at the first blocked path:
   inspect `--help`, adapt to the actual helper interface, and try the next practical route before declaring a blocker.
+- Do not launch Factory/Droid in interactive Auto Off for normal Aragora work:
+  prompted Droid/Factory lanes should use `scripts/tmux_session_launcher.sh` or
+  `scripts/agent_bridge.py launch`, which route through `droid exec --auto high`.
+  Use `ARAGORA_ALLOW_DROID_AUTO_OFF=1` only for explicit manual debugging.
 - Use layered fallbacks:
   move between shell git/gh, MCP connectors, local repo inspection, and browser flows when one surface is degraded.
 - Recover cleanly from partial failure:

--- a/scripts/tmux_launcher_metadata.py
+++ b/scripts/tmux_launcher_metadata.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Small metadata helpers for tmux transport scripts."""
+
+from __future__ import annotations
+
+import datetime
+import json
+import sys
+from pathlib import Path
+
+
+def _write_prompt_audit(argv: list[str]) -> int:
+    (
+        audit_log,
+        name,
+        prompt_id,
+        timestamp,
+        chars,
+        lines,
+        source_tag,
+        source_kind,
+        prompt_file,
+        method,
+        target,
+        preview,
+    ) = argv
+    record = {
+        "prompt_id": prompt_id,
+        "timestamp": timestamp,
+        "name": name,
+        "target": target,
+        "chars": int(chars),
+        "lines": int(lines),
+        "source": source_tag or None,
+        "source_kind": source_kind,
+        "prompt_file": prompt_file or None,
+        "dispatch_method": method,
+        "preview": preview,
+    }
+    with open(audit_log, "a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record) + "\n")
+    return 0
+
+
+def _write_session_meta(argv: list[str]) -> int:
+    (
+        name,
+        agent,
+        log_file,
+        repo_root,
+        workdir,
+        prompt_file,
+        meta_file,
+        has_prompt,
+        window_target,
+        tmux_session,
+        pane_index,
+        launch_cmd,
+        registry_repo_root,
+    ) = argv
+    started_at = (
+        datetime.datetime.now(datetime.timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+    meta = {
+        "name": name,
+        "agent": agent,
+        "started": started_at,
+        "log_file": log_file,
+        "repo_root": repo_root,
+        "cwd": workdir,
+        "worktree": workdir,
+        "tmux_session": tmux_session,
+        "tmux_window_target": window_target,
+        "tmux_pane_index": pane_index,
+        "prompt_file": prompt_file or None,
+        "has_prompt": bool(has_prompt),
+    }
+    Path(meta_file).write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+
+    try:
+        registry_path = Path(registry_repo_root) / ".aragora" / "session_mux" / "registry.json"
+        if registry_path.exists():
+            payload = json.loads(registry_path.read_text(encoding="utf-8"))
+            if not isinstance(payload, dict):
+                payload = {}
+        else:
+            payload = {}
+        payload.setdefault("schema_version", 1)
+        sessions = payload.setdefault("sessions", {})
+        if not isinstance(sessions, dict):
+            sessions = {}
+            payload["sessions"] = sessions
+        sessions[name] = {
+            "name": name,
+            "tmux_session": tmux_session,
+            "tmux_window": window_target,
+            "tmux_pane": pane_index or "0",
+            "launcher_command": launch_cmd,
+            "started_at": started_at,
+            "last_prompt_at": None,
+            "last_prompt_id": None,
+            "worktree_path": None,
+            "branch": None,
+            "log_path": log_file,
+            "launcher_log_path": None,
+            "meta_path": meta_file,
+        }
+        registry_path.parent.mkdir(parents=True, exist_ok=True)
+        registry_path.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    except Exception as exc:  # pragma: no cover
+        print(f"warning: failed to register launcher session: {exc}", file=sys.stderr)
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print("usage: tmux_launcher_metadata.py <prompt-audit|session-meta> ...", file=sys.stderr)
+        return 2
+    command = argv[1]
+    rest = argv[2:]
+    if command == "prompt-audit":
+        if len(rest) != 12:
+            print(f"prompt-audit expected 12 args, got {len(rest)}", file=sys.stderr)
+            return 2
+        return _write_prompt_audit(rest)
+    if command == "session-meta":
+        if len(rest) != 13:
+            print(f"session-meta expected 13 args, got {len(rest)}", file=sys.stderr)
+            return 2
+        return _write_session_meta(rest)
+    print(f"unknown command: {command}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/tmux_send_prompt.sh
+++ b/scripts/tmux_send_prompt.sh
@@ -33,6 +33,7 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 TMUX_SESSION="aragora"
 LOG_DIR="${HOME}/.aragora/tmux-sessions"
 NAME=""
@@ -193,25 +194,19 @@ fi
 # --- Append to prompt audit log (one JSON record per line — jsonl) ---
 mkdir -p "${LOG_DIR}"
 PREVIEW="$(printf '%s' "${PROMPT}" | head -c 200 | tr '\n' ' ')"
-python3 - "${PROMPT_AUDIT_LOG}" "${NAME}" "${PROMPT_ID}" "${TIMESTAMP}" "${CHAR_COUNT}" "${LINE_COUNT}" "${SOURCE_TAG}" "${PROMPT_SOURCE_KIND}" "${PROMPT_FILE}" "${DISPATCH_METHOD}" "${TARGET}" "${PREVIEW}" <<'PYEOF'
-import json, sys
-audit_log, name, prompt_id, timestamp, chars, lines, source_tag, source_kind, prompt_file, method, target, preview = sys.argv[1:13]
-record = {
-    "prompt_id": prompt_id,
-    "timestamp": timestamp,
-    "name": name,
-    "target": target,
-    "chars": int(chars),
-    "lines": int(lines),
-    "source": source_tag or None,
-    "source_kind": source_kind,
-    "prompt_file": prompt_file or None,
-    "dispatch_method": method,
-    "preview": preview,
-}
-with open(audit_log, "a", encoding="utf-8") as f:
-    f.write(json.dumps(record) + "\n")
-PYEOF
+python3 "${SCRIPT_DIR}/tmux_launcher_metadata.py" prompt-audit \
+    "${PROMPT_AUDIT_LOG}" \
+    "${NAME}" \
+    "${PROMPT_ID}" \
+    "${TIMESTAMP}" \
+    "${CHAR_COUNT}" \
+    "${LINE_COUNT}" \
+    "${SOURCE_TAG}" \
+    "${PROMPT_SOURCE_KIND}" \
+    "${PROMPT_FILE}" \
+    "${DISPATCH_METHOD}" \
+    "${TARGET}" \
+    "${PREVIEW}"
 
 # --- Emit receipt ---
 if [[ "${JSON_OUTPUT}" -eq 1 ]]; then

--- a/scripts/tmux_session_launcher.sh
+++ b/scripts/tmux_session_launcher.sh
@@ -62,25 +62,19 @@ send_prompt_to_target() {
     if [[ -n "${PROMPT_FILE:-}" ]]; then
         source_kind="file"
     fi
-    python3 - "${audit_log}" "${NAME}" "${prompt_id}" "${timestamp}" "${#prompt}" "${line_count}" "launcher" "${source_kind}" "${PROMPT_FILE:-}" "${method}" "${target}" "${preview}" <<'PYEOF'
-import json, sys
-audit_log, name, prompt_id, timestamp, chars, lines, source_tag, source_kind, prompt_file, method, target, preview = sys.argv[1:13]
-record = {
-    "prompt_id": prompt_id,
-    "timestamp": timestamp,
-    "name": name,
-    "target": target,
-    "chars": int(chars),
-    "lines": int(lines),
-    "source": source_tag or None,
-    "source_kind": source_kind,
-    "prompt_file": prompt_file or None,
-    "dispatch_method": method,
-    "preview": preview,
-}
-with open(audit_log, "a", encoding="utf-8") as f:
-    f.write(json.dumps(record) + "\n")
-PYEOF
+    python3 "${SCRIPT_DIR}/tmux_launcher_metadata.py" prompt-audit \
+        "${audit_log}" \
+        "${NAME}" \
+        "${prompt_id}" \
+        "${timestamp}" \
+        "${#prompt}" \
+        "${line_count}" \
+        "launcher" \
+        "${source_kind}" \
+        "${PROMPT_FILE:-}" \
+        "${method}" \
+        "${target}" \
+        "${preview}"
 
     echo "Prompt sent to '${NAME}' (${#prompt} chars, prompt_id=${prompt_id})"
 }
@@ -222,6 +216,20 @@ fi
 LOG_FILE="${LOG_DIR}/${NAME}.log"
 META_FILE="${LOG_DIR}/${NAME}.meta.json"
 REGISTRY_REPO_ROOT="${ARAGORA_TMUX_REGISTRY_REPO_ROOT:-${REPO_ROOT}}"
+HAS_PROMPT=""
+
+if [[ -n "${PROMPT_FILE}" ]]; then
+    if [[ ! -f "${PROMPT_FILE}" ]]; then
+        echo "Prompt file does not exist: ${PROMPT_FILE}" >&2
+        exit 1
+    fi
+    PROMPT_FILE="$(cd "$(dirname "${PROMPT_FILE}")" && pwd)/$(basename "${PROMPT_FILE}")"
+    PROMPT="$(cat "${PROMPT_FILE}")"
+fi
+
+if [[ -n "${PROMPT}" ]]; then
+    HAS_PROMPT="yes"
+fi
 
 # Ensure tmux session exists
 if ! tmux has-session -t "${TMUX_SESSION}" 2>/dev/null; then
@@ -246,18 +254,33 @@ elif [[ "${AGENT}" == "claude" ]]; then
         LAUNCH_CMD="cd '${WORKDIR}' && ./scripts/claude-wt"
     fi
 elif [[ "${AGENT}" == "droid" || "${AGENT}" == "factory" ]]; then
-    # Droid interactive sessions do their own permission gating. Mission/exec
-    # mode is intentionally not used here so the pane remains interactive for
-    # later agent_bridge.py send/read cycles.
-    LAUNCH_CMD="cd '${WORKDIR}' && droid --cwd '${WORKDIR}'"
+    DROID_AUTO_LEVEL="${ARAGORA_DROID_AUTO_LEVEL:-high}"
+    case "${DROID_AUTO_LEVEL}" in
+        low|medium|high) ;;
+        *)
+            echo "Invalid ARAGORA_DROID_AUTO_LEVEL='${DROID_AUTO_LEVEL}'. Use low, medium, or high." >&2
+            exit 1
+            ;;
+    esac
+    if [[ -n "${PROMPT}" ]]; then
+        DROID_EXEC_PROMPT_FILE="${PROMPT_FILE}"
+        if [[ -z "${DROID_EXEC_PROMPT_FILE}" ]]; then
+            DROID_EXEC_PROMPT_FILE="${LOG_DIR}/${NAME}.prompt.md"
+            printf '%s\n' "${PROMPT}" > "${DROID_EXEC_PROMPT_FILE}"
+            PROMPT_FILE="${DROID_EXEC_PROMPT_FILE}"
+        fi
+        LAUNCH_CMD="cd '${WORKDIR}' && droid exec --auto '${DROID_AUTO_LEVEL}' --cwd '${WORKDIR}' -f '${DROID_EXEC_PROMPT_FILE}'"
+        PROMPT=""
+    else
+        if [[ "${ARAGORA_ALLOW_DROID_AUTO_OFF:-0}" != "1" ]]; then
+            echo "Refusing to launch ${AGENT} without a prompt: interactive Droid starts Auto Off. Set ARAGORA_ALLOW_DROID_AUTO_OFF=1 only for explicit manual debugging." >&2
+            exit 1
+        fi
+        LAUNCH_CMD="cd '${WORKDIR}' && droid --cwd '${WORKDIR}'"
+    fi
 else
     echo "Unknown agent: ${AGENT}. Use 'codex', 'claude', 'droid', or 'factory'." >&2
     exit 1
-fi
-
-# If a prompt file is specified, we'll feed it after launch
-if [[ -n "${PROMPT_FILE}" && -f "${PROMPT_FILE}" ]]; then
-    PROMPT="$(cat "${PROMPT_FILE}")"
 fi
 
 # Create new tmux window with logging
@@ -269,54 +292,20 @@ tmux pipe-pane -t "${WINDOW_TARGET}" -o "cat >> '${LOG_FILE}'"
 tmux send-keys -t "${WINDOW_TARGET}" "${LAUNCH_CMD}" Enter
 
 # Write metadata (avoid embedding prompt content in Python literal)
-python3 - "${NAME}" "${AGENT}" "${LOG_FILE}" "${REPO_ROOT}" "${WORKDIR}" "${PROMPT_FILE}" "${META_FILE}" "${PROMPT:+yes}" "${WINDOW_TARGET}" "${TMUX_SESSION}" "${PANE_INDEX}" "${LAUNCH_CMD}" "${REGISTRY_REPO_ROOT}" <<'PYEOF'
-import datetime
-import importlib.util
-import json
-from pathlib import Path
-import sys
-
-name, agent, log_file, repo_root, workdir, prompt_file, meta_file, has_prompt, window_target, tmux_session, pane_index, launch_cmd, registry_repo_root = sys.argv[1:14]
-started_at = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
-meta = {
-    "name": name,
-    "agent": agent,
-    "started": started_at,
-    "log_file": log_file,
-    "repo_root": repo_root,
-    "cwd": workdir,
-    "worktree": workdir,
-    "tmux_session": tmux_session,
-    "tmux_window_target": window_target,
-    "tmux_pane_index": pane_index,
-    "prompt_file": prompt_file or None,
-    "has_prompt": bool(has_prompt),
-}
-Path(meta_file).write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
-
-try:
-    module_path = Path(repo_root) / "aragora" / "swarm" / "session_mux.py"
-    spec = importlib.util.spec_from_file_location("aragora_swarm_session_mux", module_path)
-    if spec is None or spec.loader is None:
-        raise RuntimeError(f"unable to load session_mux module from {module_path}")
-    session_mux = importlib.util.module_from_spec(spec)
-    sys.modules[spec.name] = session_mux
-    spec.loader.exec_module(session_mux)
-
-    record = session_mux.SessionRecord(
-        name=name,
-        tmux_session=tmux_session,
-        tmux_window=window_target,
-        tmux_pane=pane_index or "0",
-        launcher_command=launch_cmd,
-        started_at=started_at,
-        log_path=log_file,
-        meta_path=meta_file,
-    )
-    session_mux.SessionMuxRegistry(Path(registry_repo_root)).upsert(record)
-except Exception as exc:  # pragma: no cover - launcher should still succeed if registry sync fails
-    print(f"warning: failed to register launcher session: {exc}", file=sys.stderr)
-PYEOF
+python3 "${SCRIPT_DIR}/tmux_launcher_metadata.py" session-meta \
+    "${NAME}" \
+    "${AGENT}" \
+    "${LOG_FILE}" \
+    "${REPO_ROOT}" \
+    "${WORKDIR}" \
+    "${PROMPT_FILE}" \
+    "${META_FILE}" \
+    "${HAS_PROMPT}" \
+    "${WINDOW_TARGET}" \
+    "${TMUX_SESSION}" \
+    "${PANE_INDEX}" \
+    "${LAUNCH_CMD}" \
+    "${REGISTRY_REPO_ROOT}"
 
 echo "Launched '${NAME}' (${AGENT}) in tmux session '${TMUX_SESSION}'"
 echo "  Cwd: ${WORKDIR}"

--- a/tests/scripts/test_tmux_transport_scripts.py
+++ b/tests/scripts/test_tmux_transport_scripts.py
@@ -253,16 +253,50 @@ def test_tmux_session_launcher_supports_droid_agent(tmp_path: Path) -> None:
         check=True,
     )
 
-    assert "Readiness markers detected for factory-review." in result.stdout
+    assert "Launched 'factory-review' (droid)" in result.stdout
     calls = _load_tmux_calls(env)
     assert any(
-        call[:2] == ["send-keys", "-t"] and call[2] == "@17" and "droid --cwd" in call[3]
+        call[:2] == ["send-keys", "-t"]
+        and call[2] == "@17"
+        and "droid exec --auto 'high'" in call[3]
+        and " -f '" in call[3]
         for call in calls
     )
-    assert any(
-        call[:2] == ["send-keys", "-t"] and call[2] == "@17" and "review only" in call
-        for call in calls
+    assert not any("review only" in item for call in calls for item in call)
+    prompt_file = log_dir / "factory-review.prompt.md"
+    assert prompt_file.read_text(encoding="utf-8") == "review only\n"
+    meta = json.loads((log_dir / "factory-review.meta.json").read_text(encoding="utf-8"))
+    assert meta["has_prompt"] is True
+    assert meta["prompt_file"] == str(prompt_file)
+
+
+def test_tmux_session_launcher_rejects_unprompted_droid_auto_off_by_default(
+    tmp_path: Path,
+) -> None:
+    _write_fake_tmux(tmp_path)
+    env = _fake_tmux_env(tmp_path)
+    env["ARAGORA_TMUX_REGISTRY_REPO_ROOT"] = str(tmp_path)
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(REPO_ROOT / "scripts" / "tmux_session_launcher.sh"),
+            "--name",
+            "factory-review",
+            "--agent",
+            "droid",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
     )
+
+    assert result.returncode != 0
+    assert "interactive Droid starts Auto Off" in result.stderr
+    calls = _load_tmux_calls(env)
+    assert any(call[:3] == ["has-session", "-t", "aragora"] for call in calls)
+    assert not any(call[:2] == ["send-keys", "-t"] for call in calls)
 
 
 def test_tmux_session_launcher_does_not_send_prompt_before_readiness_by_default(


### PR DESCRIPTION
## Summary
- Route prompted Droid/Factory tmux launches through `droid exec --auto high -f <promptfile>` instead of interactive Auto Off mode.
- Refuse unprompted Droid/Factory launches by default, with `ARAGORA_ALLOW_DROID_AUTO_OFF=1` reserved for explicit manual debugging.
- Move shared prompt-audit/session metadata writes into `scripts/tmux_launcher_metadata.py` so the transport tests avoid inline Python heredoc hangs.
- Document the repo-wide Auto Off rule in `AGENTS.md`.

## Validation
- `timeout 60 python3 -m pytest -q tests/scripts/test_tmux_transport_scripts.py -p no:rerunfailures -p no:cacheprovider`
- `bash -n scripts/tmux_session_launcher.sh scripts/tmux_send_prompt.sh`
- `python3 -m py_compile scripts/tmux_launcher_metadata.py`
- `python3 -m ruff check scripts/tmux_launcher_metadata.py tests/scripts/test_tmux_transport_scripts.py`
- `python3 -m ruff format --check scripts/tmux_launcher_metadata.py tests/scripts/test_tmux_transport_scripts.py`
- `git diff --check -- AGENTS.md scripts/tmux_session_launcher.sh scripts/tmux_send_prompt.sh scripts/tmux_launcher_metadata.py tests/scripts/test_tmux_transport_scripts.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Non-touches
No #7377/#7378/#7379 changes, no cleanup worktrees, branch deletion, labels, issues, launchd, automation.toml, raw transcripts, or ADC PR edits.
