### PR TITLE
fix(automation): clarify outbox backlog counts

### DIFF
--- a/scripts/audit_codex_branch_backlog.py
+++ b/scripts/audit_codex_branch_backlog.py
@@ -1212,6 +1212,15 @@ def audit(
     publishable_branch_backlog = (
         counts["salvage_recent_unique"] + counts["salvage_stale_remote_unique"]
     )
+    direct_handoff_outbox_branches = sum(
+        1 for record in records if record.name in handoff_outbox_branches
+    )
+    patch_equivalent_handoff_outbox_branches = sum(
+        1
+        for record in records
+        if record.category == "protected_handoff_outbox"
+        and record.name not in handoff_outbox_branches
+    )
     skipped_counts = Counter(
         record.category for record in records if record.patch_equivalence_skipped
     )
@@ -1241,6 +1250,9 @@ def audit(
             "stale_local_only_salvage_candidates": counts["salvage_stale_local_unique"],
             "handoff_receipted_branches": counts["protected_handoff_receipt"],
             "handoff_outbox_branches": counts["protected_handoff_outbox"],
+            "unresolved_handoff_outbox_branch_refs": len(handoff_outbox_branches),
+            "direct_handoff_outbox_branches": direct_handoff_outbox_branches,
+            "patch_equivalent_handoff_outbox_branches": (patch_equivalent_handoff_outbox_branches),
             "writer_should_pause_for_branch_backlog": (
                 publishable_branch_backlog >= publisher_backlog_limit
             ),
@@ -1303,6 +1315,16 @@ def print_markdown(payload: dict[str, Any], *, examples: int) -> None:
     print(f"- Diverged salvage candidates: `{summary['diverged_salvage_candidates']}`")
     print(f"- Handoff-receipted branches: `{summary['handoff_receipted_branches']}`")
     print(f"- Handoff-outbox branches: `{summary['handoff_outbox_branches']}`")
+    if "unresolved_handoff_outbox_branch_refs" in summary:
+        print(
+            "- Unresolved handoff-outbox branch refs: "
+            f"`{summary['unresolved_handoff_outbox_branch_refs']}`"
+        )
+        print(f"- Direct handoff-outbox branches: `{summary['direct_handoff_outbox_branches']}`")
+        print(
+            "- Patch-equivalent handoff-outbox branches: "
+            f"`{summary['patch_equivalent_handoff_outbox_branches']}`"
+        )
     print(
         f"- Patch-equivalence budget exhausted: `{payload['patch_equivalence_budget_exhausted']}`"
     )

--- a/tests/scripts/test_audit_codex_branch_backlog.py
+++ b/tests/scripts/test_audit_codex_branch_backlog.py
@@ -1468,6 +1468,9 @@ def test_audit_protects_patch_equivalent_unresolved_handoff_branches(
     by_category = payload["summary"]["by_category"]
     assert by_category["protected_handoff_outbox"] == 2
     assert by_category["salvage_recent_unique"] == 1
+    assert payload["summary"]["unresolved_handoff_outbox_branch_refs"] == 1
+    assert payload["summary"]["direct_handoff_outbox_branches"] == 1
+    assert payload["summary"]["patch_equivalent_handoff_outbox_branches"] == 1
     assert payload["summary"]["publishable_branch_backlog"] == 1
     assert payload["summary"]["writer_should_pause_for_branch_backlog"] is False
     stale_copy = next(
@@ -1646,12 +1649,76 @@ def test_audit_treats_superseded_branch_as_unresolved_handoff(
     )
 
     assert payload["summary"]["handoff_outbox_branches"] == 1
+    assert payload["summary"]["unresolved_handoff_outbox_branch_refs"] == 2
+    assert payload["summary"]["direct_handoff_outbox_branches"] == 1
+    assert payload["summary"]["patch_equivalent_handoff_outbox_branches"] == 0
     assert payload["summary"]["publishable_branch_backlog"] == 1
     original = next(
         record for record in payload["records"] if record["name"] == "codex/stale-original"
     )
     assert original["handoff_outbox_exists"] is True
     assert original["category"] == "protected_handoff_outbox"
+
+
+def test_audit_counts_direct_outbox_refs_even_when_active_worktree_wins_category(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    now = datetime.now(timezone.utc)
+    row = _branch_row("codex/direct-outbox", committed_at=now)
+    worktree = tmp_path / "active-worktree"
+    worktree.mkdir()
+    outbox = tmp_path / ".aragora" / "automation-outbox"
+    outbox.mkdir(parents=True)
+    (outbox / "direct.json").write_text(
+        json.dumps(
+            {
+                "task": "Publish direct branch",
+                "requires_github": True,
+                "requested_action": "open_pr",
+                "repo": "synaptent/aragora",
+                "local_evidence": {"branch": "codex/direct-outbox", "head": "abc123"},
+                "idempotency_key": "open-pr-codex-direct-outbox-abc123",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mod, "local_branches", lambda _root, _prefix, _base: [row])
+    monkeypatch.setattr(mod, "remote_branch_names", lambda _root, _prefix: set())
+    monkeypatch.setattr(mod, "merged_branch_names", lambda _root, _base, _prefix: set())
+    monkeypatch.setattr(mod, "worktree_map", lambda _root: {"codex/direct-outbox": [worktree]})
+    monkeypatch.setattr(mod, "dirty_worktree", lambda _path: False)
+    monkeypatch.setattr(mod, "active_worktree", lambda _path: True)
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda _root: GitHubCLIHealth(
+            ready=False,
+            auth_ok=False,
+            api_ok=False,
+            mode="connectivity_failed",
+            error="offline",
+            repo=str(tmp_path),
+        ),
+    )
+
+    payload = mod.audit(
+        root=tmp_path,
+        base="origin/main",
+        repo="synaptent/aragora",
+        prefix="codex/",
+        recent_hours=72,
+        max_branches=None,
+        include_patch_equivalence=True,
+        publisher_backlog_limit=2,
+    )
+
+    record = payload["records"][0]
+    assert record["category"] == "protected_active_worktree"
+    assert record["handoff_outbox_exists"] is True
+    assert payload["summary"]["handoff_outbox_branches"] == 0
+    assert payload["summary"]["unresolved_handoff_outbox_branch_refs"] == 1
+    assert payload["summary"]["direct_handoff_outbox_branches"] == 1
+    assert payload["summary"]["patch_equivalent_handoff_outbox_branches"] == 0
 
 
 def test_audit_treats_superseded_branch_as_terminal_receipt(


### PR DESCRIPTION
## Summary
- Clarifies backlog accounting for automation outbox-protected branches.
- Updates focused tests for `audit_codex_branch_backlog.py`.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_audit_codex_branch_backlog.py -p no:rerunfailures -p no:cacheprovider` — 53 passed
- `python3 -m ruff check scripts/audit_codex_branch_backlog.py tests/scripts/test_audit_codex_branch_backlog.py`
- `python3 -m ruff format --check scripts/audit_codex_branch_backlog.py tests/scripts/test_audit_codex_branch_backlog.py`
- `python3 -m mypy scripts/audit_codex_branch_backlog.py`
- `git diff --check origin/main...HEAD`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Non-touches
- No labels, merges, branch deletion, cleanup worktree deletion by raw rm, launchd edits, `automation.toml` edits, raw transcript edits, #7292, #7385, ADC PRs, #7297/Q42, or P91/P100 work touched.
