### PR TITLE
fix(automation): add compact handoff publisher output

### DIFF
--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -175,6 +175,18 @@ def summarize_decisions(decisions: Sequence[PublishDecision]) -> dict[str, Any]:
     }
 
 
+def summary_only_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return compact publisher status for recurring automation logs."""
+
+    compact = dict(payload)
+    decisions = compact.pop("decisions", None)
+    if isinstance(decisions, Sequence) and not isinstance(decisions, (str, bytes, bytearray)):
+        compact["decision_count"] = len(decisions)
+        compact["decisions_omitted"] = True
+    compact["details_omitted"] = True
+    return compact
+
+
 def _gh_write_op(args: list[str]) -> bool:
     return len(args) >= 2 and (args[0], args[1]) in {
         ("issue", "create"),
@@ -1401,6 +1413,11 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Preview eligible handoffs without writing; this is the default mode",
     )
     parser.add_argument("--json", action="store_true", help="Print machine-readable output")
+    parser.add_argument(
+        "--summary-only",
+        action="store_true",
+        help="With --json, omit per-handoff decisions and print compact counts only.",
+    )
     return parser
 
 
@@ -1472,7 +1489,8 @@ def main(argv: list[str] | None = None) -> int:
             "decision_summary": summarize_decisions(decisions),
         }
         if args.json:
-            print(json.dumps(payload, indent=2))
+            output_payload = summary_only_payload(payload) if args.summary_only else payload
+            print(json.dumps(output_payload, indent=2))
         else:
             if handoffs:
                 print(f"github_unavailable: {github_health.mode} {github_health.error}".strip())
@@ -1523,7 +1541,8 @@ def main(argv: list[str] | None = None) -> int:
         "decision_summary": summarize_decisions(results),
     }
     if args.json:
-        print(json.dumps(payload, indent=2))
+        output_payload = summary_only_payload(payload) if args.summary_only else payload
+        print(json.dumps(output_payload, indent=2))
     else:
         for item in results:
             marker = (

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -1944,6 +1944,69 @@ def test_main_reports_github_health_when_unavailable(
     }
 
 
+def test_main_summary_only_omits_decisions_when_github_unavailable(
+    monkeypatch: Any, tmp_path: Path, capsys
+) -> None:
+    handoffs = [
+        Handoff(
+            source_file=str(tmp_path / "first.md"),
+            task_title="First offline handoff",
+            priority="MEDIUM",
+            body="body",
+            labels={},
+            expires_at=None,
+        ),
+        Handoff(
+            source_file=str(tmp_path / "second.md"),
+            task_title="Second offline handoff",
+            priority="MEDIUM",
+            body="body",
+            labels={},
+            expires_at=None,
+        ),
+    ]
+    monkeypatch.setattr(mod, "_repo_root", lambda path: tmp_path)
+    monkeypatch.setattr(mod, "load_handoffs", lambda codex_home, automation_ids=None: handoffs)
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda repo_root: GitHubCLIHealth(
+            ready=False,
+            auth_ok=True,
+            api_ok=False,
+            mode="connectivity_failed",
+            error="error connecting to api.github.com",
+            repo=str(tmp_path),
+        ),
+    )
+
+    exit_code = mod.main(
+        [
+            "--repo",
+            str(tmp_path),
+            "--codex-home",
+            str(tmp_path),
+            "--json",
+            "--summary-only",
+        ]
+    )
+
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert "decisions" not in payload
+    assert payload["decision_count"] == 2
+    assert payload["decisions_omitted"] is True
+    assert payload["details_omitted"] is True
+    assert payload["decision_summary"] == {
+        "total": 2,
+        "eligible_count": 0,
+        "ineligible_count": 2,
+        "reason_counts": {
+            "github_unavailable": 2,
+        },
+    }
+
+
 def test_main_reports_stale_outbox_head_when_github_unavailable(
     monkeypatch: Any, tmp_path: Path, capsys: Any
 ) -> None:


### PR DESCRIPTION
## Summary
- Adds compact summary-only output for the automation handoff publisher.
- Updates focused publisher tests for the new output shape.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_publish_automation_handoffs.py -p no:rerunfailures -p no:cacheprovider` — 56 passed
- `python3 -m ruff check scripts/publish_automation_handoffs.py tests/scripts/test_publish_automation_handoffs.py`
- `python3 -m ruff format --check scripts/publish_automation_handoffs.py tests/scripts/test_publish_automation_handoffs.py`
- `python3 -m mypy scripts/publish_automation_handoffs.py`
- `git diff --check origin/main...HEAD`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Non-touches
- No labels, merges, branch deletion, cleanup worktree deletion by raw rm, launchd edits, `automation.toml` edits, raw transcript edits, #7292, #7385, ADC PRs, #7297/Q42, Q43/#7300, or P100 work touched.
