### PR TITLE
fix(automation): qualify unavailable PR state in outbox reconcile

### DIFF
--- a/scripts/reconcile_automation_outbox.py
+++ b/scripts/reconcile_automation_outbox.py
@@ -637,7 +637,7 @@ def main(argv: list[str] | None = None) -> int:
                 shutil.move(str(path), str(archive_dir / path.name))
             continue
 
-        open_prs, _open_pr_state_available = load_open_pr_state()
+        open_prs, open_pr_state_available = load_open_pr_state()
         if branch in open_prs:
             counts["still_protecting_active_work"] += 1
             actions.append(
@@ -651,13 +651,21 @@ def main(argv: list[str] | None = None) -> int:
             )
             continue
 
+        reason = (
+            "branch has unique commits not on main, no open PR — actively protecting"
+            if open_pr_state_available
+            else (
+                "branch has unique commits not on main, open PR state is unavailable "
+                "— actively protecting"
+            )
+        )
         counts["still_protecting_active_work"] += 1
         actions.append(
             {
                 "path": str(path),
                 "branch": branch,
                 "decision": "keep",
-                "reason": "branch has unique commits not on main, no open PR — actively protecting",
+                "reason": reason,
                 "synthetic_receipt": False,
             }
         )

--- a/tests/scripts/test_reconcile_automation_outbox.py
+++ b/tests/scripts/test_reconcile_automation_outbox.py
@@ -543,6 +543,48 @@ def test_missing_branch_archives_when_open_pr_state_is_available(
     assert payload["actions"][0]["reason"] == "branch no longer exists"
 
 
+def test_unique_branch_keep_reason_notes_unavailable_open_pr_state(
+    tmp_path: Path,
+    monkeypatch: Any,
+    capsys: Any,
+) -> None:
+    outbox_dir = tmp_path / ".aragora" / "automation-outbox"
+    key = "open-pr-codex-unique-abc123"
+    _write_outbox_handoff(outbox_dir, branch="codex/unique", key=key)
+
+    def fake_run_git(
+        args: list[str],
+        _root: Path,
+        *,
+        timeout: int = 60,
+    ) -> subprocess.CompletedProcess[str]:
+        if args == ["rev-parse", "--verify", "codex/unique"]:
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout="abc123\n")
+        if args[:2] == ["merge-base", "--is-ancestor"]:
+            return subprocess.CompletedProcess(args=args, returncode=1, stdout="")
+        if args[0] == "cherry":
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout="+ abc123\n")
+        raise AssertionError(f"unexpected git call: {args}")
+
+    monkeypatch.setattr(mod, "run_git", fake_run_git)
+    monkeypatch.setattr(mod, "check_github_cli_health", lambda _root: _unhealthy_github())
+    monkeypatch.setattr(
+        mod,
+        "open_pr_heads",
+        lambda *_args: (_ for _ in ()).throw(
+            AssertionError("open PR fetch should be skipped when GitHub is unhealthy")
+        ),
+    )
+
+    assert mod.main(["--repo", str(tmp_path), "--json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["counts"]["still_protecting_active_work"] == 1
+    assert payload["actions"][0]["decision"] == "keep"
+    assert "open PR state is unavailable" in payload["actions"][0]["reason"]
+    assert "no open PR" not in payload["actions"][0]["reason"]
+
+
 def test_landed_branch_archives_without_github_lookup(
     tmp_path: Path,
     monkeypatch: Any,


### PR DESCRIPTION
## Summary
- distinguish unavailable GitHub PR state from an empty open-PR result in outbox reconciliation
- preserve explicit evidence for unknown PR state in the dry-run output
- add regression coverage for unavailable open-PR lookups

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_reconcile_automation_outbox.py -p no:rerunfailures -p no:cacheprovider`
- `python3 -m ruff check scripts/reconcile_automation_outbox.py tests/scripts/test_reconcile_automation_outbox.py`
- `python3 -m ruff format --check scripts/reconcile_automation_outbox.py tests/scripts/test_reconcile_automation_outbox.py`
- `python3 -m mypy scripts/reconcile_automation_outbox.py`
- `git diff --check origin/main...HEAD`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## P94 Non-Touches
No labels, merges, mark-ready, branch deletion, cleanup worktree deletion by raw rm, launchd edits, automation.toml edits, raw transcript edits, manual issue closure, ADC PR edits, #7292/#7385/#7297 edits, or Dependabot branch edits.
