### PR TITLE
ci: extend debate test shard timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -582,7 +582,11 @@ jobs:
             timeout: 30
           - name: debate
             path: tests/debate
-            timeout: 30
+            # The debate shard currently exceeds the generic 30-minute cap on
+            # GitHub-hosted runners: #6579 reached 54% before cancellation.
+            # Keep the suite required, but give it a realistic envelope while
+            # longer-term sharding work splits tests/debate into smaller lanes.
+            timeout: 60
           - name: reasoning
             path: tests/rlm tests/reasoning
             timeout: 30


### PR DESCRIPTION
## Summary
Harvested from existing branch `codex/debate-test-shard-timeout` — single-commit, small-scope change identified by P102 harvest classifier (claude-51C05A58 session).

**Commit:** 0b55862f9e ci: extend debate test shard timeout
**Stats:** 1 file changed, 5 insertions(+), 1 deletion(-)
**Files:** .github/workflows/test.yml

## Why this PR exists
The branch had unique commits versus `origin/main` and no associated open PR. Per the substrate-freeze posture, this PR preserves existing useful work in a discoverable way without introducing new logic.

## Author identity caveat
Opened via `gh` on the operator's machine; author shows as @an0mium (PR author == repo owner). A non-author reviewer is required for approval per branch protection. Mark-ready and approval are deferred to operator/another agent identity.

## Test plan
- [x] Branch verified to exist on origin
- [x] No conflicting open PR
- [x] No active worktree bound to this branch (classifier output)
- [ ] Render-check (`gh pr view --web`)
- [ ] Non-author review

[lane: P102-claude-harvest-recovery]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
