### PR TITLE
fix(ci): fail review gate on missing artifact

### DIFF
--- a/.github/workflows/aragora-review-gate.yml
+++ b/.github/workflows/aragora-review-gate.yml
@@ -178,13 +178,12 @@ jobs:
 
           review_json="$review_output_dir/review.json"
           if [[ ! -f "$review_json" ]]; then
-            echo "::warning::Aragora advisory review did not produce $review_json"
+            echo "::error::Aragora advisory review did not produce $review_json"
             if [[ -s /tmp/review.stderr ]]; then
               cat /tmp/review.stderr
             fi
-            echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "review_failed=true" >> "$GITHUB_OUTPUT"
-            exit 0
+            exit 1
           fi
 
           echo "skip=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
Harvested from existing branch `codex/review-gate-missing-artifact-fail-closed` — single-commit, small-scope change identified by P102 harvest classifier (claude-51C05A58 session).

**Commit:** 1fd2c9e2c7 fix(ci): fail review gate on missing artifact
**Stats:** 1 file changed, 2 insertions(+), 3 deletions(-)
**Files:** .github/workflows/aragora-review-gate.yml

## Why this PR exists
The branch had unique commits versus `origin/main` and no associated open PR. Per the substrate-freeze posture, this PR preserves existing useful work in a discoverable way without introducing new logic.

## Author identity caveat
Opened via `gh` on the operator's machine; author shows as @an0mium (PR author == repo owner). A non-author reviewer is required for approval per branch protection. Mark-ready and approval are deferred to operator/another agent identity.

## Test plan
- [x] Branch verified to exist on origin
- [x] No conflicting open PR
- [x] No active worktree bound to this branch (classifier output)
- [ ] Render-check (`gh pr view --web`)
- [ ] Non-author review

[lane: P102-claude-harvest-recovery]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
