### PR TITLE
fix(automation): avoid tmux prompt heredoc hangs

### DIFF
--- a/scripts/tmux_prompt_audit.py
+++ b/scripts/tmux_prompt_audit.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Append a prompt dispatch audit record for tmux session launchers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--audit-log", required=True)
+    parser.add_argument("--name", required=True)
+    parser.add_argument("--prompt-id", required=True)
+    parser.add_argument("--timestamp", required=True)
+    parser.add_argument("--chars", required=True, type=int)
+    parser.add_argument("--lines", required=True, type=int)
+    parser.add_argument("--source", default="")
+    parser.add_argument("--source-kind", required=True)
+    parser.add_argument("--prompt-file", default="")
+    parser.add_argument("--dispatch-method", required=True)
+    parser.add_argument("--target", required=True)
+    parser.add_argument("--preview", default="")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    record = {
+        "prompt_id": args.prompt_id,
+        "timestamp": args.timestamp,
+        "name": args.name,
+        "target": args.target,
+        "chars": args.chars,
+        "lines": args.lines,
+        "source": args.source or None,
+        "source_kind": args.source_kind,
+        "prompt_file": args.prompt_file or None,
+        "dispatch_method": args.dispatch_method,
+        "preview": args.preview,
+    }
+    audit_log = Path(args.audit_log)
+    audit_log.parent.mkdir(parents=True, exist_ok=True)
+    with audit_log.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tmux_prompt_receipt.py
+++ b/scripts/tmux_prompt_receipt.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Print a JSON receipt for tmux prompt dispatch."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dispatch", required=True, choices=("dry-run", "ok"))
+    parser.add_argument("--name", required=True)
+    parser.add_argument("--target", required=True)
+    parser.add_argument("--prompt-id", required=True)
+    parser.add_argument("--timestamp", required=True)
+    parser.add_argument("--chars", required=True, type=int)
+    parser.add_argument("--lines", required=True, type=int)
+    parser.add_argument("--source", default="")
+    parser.add_argument("--source-kind", required=True)
+    parser.add_argument("--prompt-file", default="")
+    parser.add_argument("--dispatch-method", default="")
+    parser.add_argument("--audit-log", default="")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    payload = {
+        "dispatch": args.dispatch,
+        "name": args.name,
+        "target": args.target,
+        "prompt_id": args.prompt_id,
+        "timestamp": args.timestamp,
+        "chars": args.chars,
+        "lines": args.lines,
+        "source": args.source or None,
+        "source_kind": args.source_kind,
+        "prompt_file": args.prompt_file or None,
+    }
+    if args.dispatch_method:
+        payload["dispatch_method"] = args.dispatch_method
+    if args.audit_log:
+        payload["audit_log"] = args.audit_log
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tmux_send_prompt.sh
+++ b/scripts/tmux_send_prompt.sh
@@ -131,22 +131,17 @@ fi
 # --- Dry-run: print what would be sent, do not touch anything ---
 if [[ "${DRY_RUN}" -eq 1 ]]; then
     if [[ "${JSON_OUTPUT}" -eq 1 ]]; then
-        python3 - "${NAME}" "${TARGET}" "${PROMPT_ID}" "${TIMESTAMP}" "${CHAR_COUNT}" "${LINE_COUNT}" "${SOURCE_TAG}" "${PROMPT_SOURCE_KIND}" "${PROMPT_FILE}" <<'PYEOF'
-import json, sys
-name, target, prompt_id, timestamp, chars, lines, source_tag, source_kind, prompt_file = sys.argv[1:10]
-print(json.dumps({
-    "dispatch": "dry-run",
-    "name": name,
-    "target": target,
-    "prompt_id": prompt_id,
-    "timestamp": timestamp,
-    "chars": int(chars),
-    "lines": int(lines),
-    "source": source_tag or None,
-    "source_kind": source_kind,
-    "prompt_file": prompt_file or None,
-}, indent=2))
-PYEOF
+        python3 "$(dirname "$0")/tmux_prompt_receipt.py" \
+            --dispatch "dry-run" \
+            --name "${NAME}" \
+            --target "${TARGET}" \
+            --prompt-id "${PROMPT_ID}" \
+            --timestamp "${TIMESTAMP}" \
+            --chars "${CHAR_COUNT}" \
+            --lines "${LINE_COUNT}" \
+            --source "${SOURCE_TAG}" \
+            --source-kind "${PROMPT_SOURCE_KIND}" \
+            --prompt-file "${PROMPT_FILE}"
     else
         echo "=== DRY RUN — nothing sent, no audit log written ==="
         echo "name:        ${NAME}"
@@ -193,46 +188,35 @@ fi
 # --- Append to prompt audit log (one JSON record per line — jsonl) ---
 mkdir -p "${LOG_DIR}"
 PREVIEW="$(printf '%s' "${PROMPT}" | head -c 200 | tr '\n' ' ')"
-python3 - "${PROMPT_AUDIT_LOG}" "${NAME}" "${PROMPT_ID}" "${TIMESTAMP}" "${CHAR_COUNT}" "${LINE_COUNT}" "${SOURCE_TAG}" "${PROMPT_SOURCE_KIND}" "${PROMPT_FILE}" "${DISPATCH_METHOD}" "${TARGET}" "${PREVIEW}" <<'PYEOF'
-import json, sys
-audit_log, name, prompt_id, timestamp, chars, lines, source_tag, source_kind, prompt_file, method, target, preview = sys.argv[1:13]
-record = {
-    "prompt_id": prompt_id,
-    "timestamp": timestamp,
-    "name": name,
-    "target": target,
-    "chars": int(chars),
-    "lines": int(lines),
-    "source": source_tag or None,
-    "source_kind": source_kind,
-    "prompt_file": prompt_file or None,
-    "dispatch_method": method,
-    "preview": preview,
-}
-with open(audit_log, "a", encoding="utf-8") as f:
-    f.write(json.dumps(record) + "\n")
-PYEOF
+python3 "$(dirname "$0")/tmux_prompt_audit.py" \
+    --audit-log "${PROMPT_AUDIT_LOG}" \
+    --name "${NAME}" \
+    --prompt-id "${PROMPT_ID}" \
+    --timestamp "${TIMESTAMP}" \
+    --chars "${CHAR_COUNT}" \
+    --lines "${LINE_COUNT}" \
+    --source "${SOURCE_TAG}" \
+    --source-kind "${PROMPT_SOURCE_KIND}" \
+    --prompt-file "${PROMPT_FILE}" \
+    --dispatch-method "${DISPATCH_METHOD}" \
+    --target "${TARGET}" \
+    --preview "${PREVIEW}"
 
 # --- Emit receipt ---
 if [[ "${JSON_OUTPUT}" -eq 1 ]]; then
-    python3 - "${NAME}" "${TARGET}" "${PROMPT_ID}" "${TIMESTAMP}" "${CHAR_COUNT}" "${LINE_COUNT}" "${SOURCE_TAG}" "${PROMPT_SOURCE_KIND}" "${PROMPT_FILE}" "${DISPATCH_METHOD}" "${PROMPT_AUDIT_LOG}" <<'PYEOF'
-import json, sys
-name, target, prompt_id, timestamp, chars, lines, source_tag, source_kind, prompt_file, method, audit_log = sys.argv[1:12]
-print(json.dumps({
-    "dispatch": "ok",
-    "name": name,
-    "target": target,
-    "prompt_id": prompt_id,
-    "timestamp": timestamp,
-    "chars": int(chars),
-    "lines": int(lines),
-    "source": source_tag or None,
-    "source_kind": source_kind,
-    "prompt_file": prompt_file or None,
-    "dispatch_method": method,
-    "audit_log": audit_log,
-}, indent=2))
-PYEOF
+    python3 "$(dirname "$0")/tmux_prompt_receipt.py" \
+        --dispatch "ok" \
+        --name "${NAME}" \
+        --target "${TARGET}" \
+        --prompt-id "${PROMPT_ID}" \
+        --timestamp "${TIMESTAMP}" \
+        --chars "${CHAR_COUNT}" \
+        --lines "${LINE_COUNT}" \
+        --source "${SOURCE_TAG}" \
+        --source-kind "${PROMPT_SOURCE_KIND}" \
+        --prompt-file "${PROMPT_FILE}" \
+        --dispatch-method "${DISPATCH_METHOD}" \
+        --audit-log "${PROMPT_AUDIT_LOG}"
 else
     echo "Prompt sent to '${NAME}' (${CHAR_COUNT} chars, ${LINE_COUNT} lines, prompt_id=${PROMPT_ID})"
 fi

--- a/scripts/tmux_session_launcher.sh
+++ b/scripts/tmux_session_launcher.sh
@@ -62,25 +62,19 @@ send_prompt_to_target() {
     if [[ -n "${PROMPT_FILE:-}" ]]; then
         source_kind="file"
     fi
-    python3 - "${audit_log}" "${NAME}" "${prompt_id}" "${timestamp}" "${#prompt}" "${line_count}" "launcher" "${source_kind}" "${PROMPT_FILE:-}" "${method}" "${target}" "${preview}" <<'PYEOF'
-import json, sys
-audit_log, name, prompt_id, timestamp, chars, lines, source_tag, source_kind, prompt_file, method, target, preview = sys.argv[1:13]
-record = {
-    "prompt_id": prompt_id,
-    "timestamp": timestamp,
-    "name": name,
-    "target": target,
-    "chars": int(chars),
-    "lines": int(lines),
-    "source": source_tag or None,
-    "source_kind": source_kind,
-    "prompt_file": prompt_file or None,
-    "dispatch_method": method,
-    "preview": preview,
-}
-with open(audit_log, "a", encoding="utf-8") as f:
-    f.write(json.dumps(record) + "\n")
-PYEOF
+    python3 "${SCRIPT_DIR}/tmux_prompt_audit.py" \
+        --audit-log "${audit_log}" \
+        --name "${NAME}" \
+        --prompt-id "${prompt_id}" \
+        --timestamp "${timestamp}" \
+        --chars "${#prompt}" \
+        --lines "${line_count}" \
+        --source "launcher" \
+        --source-kind "${source_kind}" \
+        --prompt-file "${PROMPT_FILE:-}" \
+        --dispatch-method "${method}" \
+        --target "${target}" \
+        --preview "${preview}"
 
     echo "Prompt sent to '${NAME}' (${#prompt} chars, prompt_id=${prompt_id})"
 }
@@ -268,55 +262,22 @@ tmux pipe-pane -t "${WINDOW_TARGET}" -o "cat >> '${LOG_FILE}'"
 # Send the launch command
 tmux send-keys -t "${WINDOW_TARGET}" "${LAUNCH_CMD}" Enter
 
-# Write metadata (avoid embedding prompt content in Python literal)
-python3 - "${NAME}" "${AGENT}" "${LOG_FILE}" "${REPO_ROOT}" "${WORKDIR}" "${PROMPT_FILE}" "${META_FILE}" "${PROMPT:+yes}" "${WINDOW_TARGET}" "${TMUX_SESSION}" "${PANE_INDEX}" "${LAUNCH_CMD}" "${REGISTRY_REPO_ROOT}" <<'PYEOF'
-import datetime
-import importlib.util
-import json
-from pathlib import Path
-import sys
-
-name, agent, log_file, repo_root, workdir, prompt_file, meta_file, has_prompt, window_target, tmux_session, pane_index, launch_cmd, registry_repo_root = sys.argv[1:14]
-started_at = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
-meta = {
-    "name": name,
-    "agent": agent,
-    "started": started_at,
-    "log_file": log_file,
-    "repo_root": repo_root,
-    "cwd": workdir,
-    "worktree": workdir,
-    "tmux_session": tmux_session,
-    "tmux_window_target": window_target,
-    "tmux_pane_index": pane_index,
-    "prompt_file": prompt_file or None,
-    "has_prompt": bool(has_prompt),
-}
-Path(meta_file).write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
-
-try:
-    module_path = Path(repo_root) / "aragora" / "swarm" / "session_mux.py"
-    spec = importlib.util.spec_from_file_location("aragora_swarm_session_mux", module_path)
-    if spec is None or spec.loader is None:
-        raise RuntimeError(f"unable to load session_mux module from {module_path}")
-    session_mux = importlib.util.module_from_spec(spec)
-    sys.modules[spec.name] = session_mux
-    spec.loader.exec_module(session_mux)
-
-    record = session_mux.SessionRecord(
-        name=name,
-        tmux_session=tmux_session,
-        tmux_window=window_target,
-        tmux_pane=pane_index or "0",
-        launcher_command=launch_cmd,
-        started_at=started_at,
-        log_path=log_file,
-        meta_path=meta_file,
-    )
-    session_mux.SessionMuxRegistry(Path(registry_repo_root)).upsert(record)
-except Exception as exc:  # pragma: no cover - launcher should still succeed if registry sync fails
-    print(f"warning: failed to register launcher session: {exc}", file=sys.stderr)
-PYEOF
+# Write metadata without consuming launcher stdin. Several automation tests run
+# this script from subprocess pipes, where inline `python3 - <<...` can block.
+python3 "${SCRIPT_DIR}/tmux_session_metadata.py" \
+    --name "${NAME}" \
+    --agent "${AGENT}" \
+    --log-file "${LOG_FILE}" \
+    --repo-root "${REPO_ROOT}" \
+    --workdir "${WORKDIR}" \
+    --prompt-file "${PROMPT_FILE}" \
+    --meta-file "${META_FILE}" \
+    --has-prompt "${PROMPT:+yes}" \
+    --window-target "${WINDOW_TARGET}" \
+    --tmux-session "${TMUX_SESSION}" \
+    --pane-index "${PANE_INDEX}" \
+    --launch-command "${LAUNCH_CMD}" \
+    --registry-repo-root "${REGISTRY_REPO_ROOT}"
 
 echo "Launched '${NAME}' (${AGENT}) in tmux session '${TMUX_SESSION}'"
 echo "  Cwd: ${WORKDIR}"

--- a/scripts/tmux_session_metadata.py
+++ b/scripts/tmux_session_metadata.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Write tmux launcher metadata and update the session mux registry."""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+
+def _started_at() -> str:
+    return (
+        datetime.datetime.now(datetime.timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _load_session_mux(repo_root: Path):
+    module_path = repo_root / "aragora" / "swarm" / "session_mux.py"
+    spec = importlib.util.spec_from_file_location("aragora_swarm_session_mux", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"unable to load session_mux module from {module_path}")
+    session_mux = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = session_mux
+    spec.loader.exec_module(session_mux)
+    return session_mux
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--name", required=True)
+    parser.add_argument("--agent", required=True)
+    parser.add_argument("--log-file", required=True)
+    parser.add_argument("--repo-root", required=True)
+    parser.add_argument("--workdir", required=True)
+    parser.add_argument("--prompt-file", default="")
+    parser.add_argument("--meta-file", required=True)
+    parser.add_argument("--has-prompt", default="")
+    parser.add_argument("--window-target", required=True)
+    parser.add_argument("--tmux-session", required=True)
+    parser.add_argument("--pane-index", default="0")
+    parser.add_argument("--launch-command", required=True)
+    parser.add_argument("--registry-repo-root", required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    repo_root = Path(args.repo_root)
+    started_at = _started_at()
+    meta = {
+        "name": args.name,
+        "agent": args.agent,
+        "started": started_at,
+        "log_file": args.log_file,
+        "repo_root": args.repo_root,
+        "cwd": args.workdir,
+        "worktree": args.workdir,
+        "tmux_session": args.tmux_session,
+        "tmux_window_target": args.window_target,
+        "tmux_pane_index": args.pane_index,
+        "prompt_file": args.prompt_file or None,
+        "has_prompt": bool(args.has_prompt),
+    }
+    Path(args.meta_file).write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+
+    try:
+        session_mux = _load_session_mux(repo_root)
+        record = session_mux.SessionRecord(
+            name=args.name,
+            tmux_session=args.tmux_session,
+            tmux_window=args.window_target,
+            tmux_pane=args.pane_index or "0",
+            launcher_command=args.launch_command,
+            started_at=started_at,
+            log_path=args.log_file,
+            meta_path=args.meta_file,
+        )
+        session_mux.SessionMuxRegistry(Path(args.registry_repo_root)).upsert(record)
+    except (
+        Exception
+    ) as exc:  # pragma: no cover - launcher should still succeed if registry sync fails
+        print(f"warning: failed to register launcher session: {exc}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Harvested from existing branch `codex/tmux-launcher-metadata-helper-current-base` — single-commit, identified by P102 harvest classifier (claude-51C05A58 session).

**Commit:** 8a61318ac5 fix(automation): avoid tmux prompt heredoc hangs
**Stats:** 5 files changed, 260 insertions(+), 121 deletions(-)
**Files:** scripts/tmux_prompt_audit.py, scripts/tmux_prompt_receipt.py, scripts/tmux_send_prompt.sh, scripts/tmux_session_launcher.sh, scripts/tmux_session_metadata.py

## Author identity caveat
Opened via `gh` on the operator's machine; author shows as @an0mium. A non-author reviewer is required for approval per branch protection.

[lane: P102-claude-harvest-recovery]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
