### PR TITLE
governance: enforce model-review quorum as required check; reconcile branch protection (RECOVERED — Tier 4)

### DIFF
--- a/.github/workflows/aragora-merge-quorum.yml
+++ b/.github/workflows/aragora-merge-quorum.yml
@@ -1,0 +1,194 @@
+name: Aragora Merge Quorum
+
+# Enforcing model-review-quorum gate.
+#
+# Unlike the advisory "Aragora Code Review" workflow (aragora-review-gate.yml),
+# this check CAN fail a PR and is intended to be a REQUIRED status check on
+# `main`. It is the GitHub-visible expression of the review authority defined in
+# docs/REVIEW_AUTHORITY_PRINCIPLES.md: a heterogeneous model quorum is the
+# technical reviewer; the human operator is the accountable risk settler for
+# Tier 3-4.
+#
+# It does NOT post a bot APPROVE review. It reports an honest pass/fail status.
+#
+# This file lives under .github/workflows/, so per REVIEW_AUTHORITY_PRINCIPLES.md
+# every change to it is a Tier 4 "merge-authority self-modification" and requires
+# explicit human preapproval before implementation and before merge.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to evaluate (debug; does not update PR check status)"
+        required: true
+        type: string
+
+concurrency:
+  group: aragora-merge-quorum-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+  statuses: read
+
+jobs:
+  merge-quorum:
+    name: aragora-merge-quorum
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        id: setup-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+        continue-on-error: true
+
+      - name: Fallback to system Python
+        if: steps.setup-python.outcome == 'failure'
+        shell: bash
+        run: |
+          for cmd in python3.11 python3; do
+            if command -v "$cmd" &>/dev/null; then
+              sudo ln -sf "$(command -v "$cmd")" /usr/local/bin/python
+              sudo ln -sf "$(command -v "$cmd")" /usr/local/bin/python3
+              break
+            fi
+          done
+          python --version
+
+      - name: Install Aragora
+        run: |
+          python -m pip install --upgrade pip
+          bash scripts/ci_install_project.sh --extras dev
+          python -m pip install -e . "pydantic>=2,<3" pydantic-settings aiohttp defusedxml numpy
+
+      - name: Evaluate merge quorum
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+          IS_DRAFT: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft || 'false' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "$IS_DRAFT" == "true" ]]; then
+            echo "Draft PR — merge-quorum gate deferred until ready_for_review."
+            exit 0
+          fi
+
+          # Build the read-only merge authorization packet for this PR.
+          # merge-packet does not approve, comment, merge, or write receipts.
+          set +e
+          python -m aragora.cli.main review-queue merge-packet \
+            --pr "$PR_NUMBER" --repo "$GH_REPO" --json \
+            > /tmp/merge_packet.json 2> /tmp/merge_packet.err
+          packet_exit=$?
+          set -e
+
+          if [[ "$packet_exit" -ne 0 ]]; then
+            echo "::error::merge-packet command failed (exit ${packet_exit}) — failing closed."
+            cat /tmp/merge_packet.err || true
+            exit 1
+          fi
+
+          # Decide pass/fail. Fail closed on anything unexpected.
+          python3 - <<'PY'
+          import json
+          import os
+          import subprocess
+          import sys
+
+          pr_number = str(os.environ["PR_NUMBER"]).strip()
+          repo = os.environ["GH_REPO"]
+
+          try:
+              with open("/tmp/merge_packet.json", encoding="utf-8") as fh:
+                  packet = json.load(fh)
+          except Exception as exc:  # noqa: BLE001
+              print(f"::error::merge packet is not valid JSON: {exc}")
+              sys.exit(1)
+
+          entries = packet.get("entries") or []
+          entry = next(
+              (e for e in entries if str(e.get("pr_number")) == pr_number), None
+          )
+          if entry is None:
+              print(f"::error::merge packet has no entry for PR #{pr_number} — failing closed.")
+              sys.exit(1)
+
+          tier = entry.get("tier")
+          status = entry.get("status")
+          verdict = entry.get("verdict")
+          head_sha = str(entry.get("head_sha") or "").strip()
+          reasons = entry.get("reasons") or []
+
+          print(f"PR #{pr_number} | Tier {tier} | status={status} | verdict={verdict}")
+          for reason in reasons:
+              print(f"  - {reason}")
+
+          def fail(message: str) -> None:
+              print(f"::error::{message}")
+              sys.exit(1)
+
+          def human_settlement_present() -> bool:
+              # Tier 3-4 require a head-SHA-bound human settlement signal: a commit
+              # status with context 'aragora/human-settlement' = success, set by the
+              # operator AFTER recording the local settlement receipt. A new push
+              # changes the head SHA and drops the signal — settlement is bound to
+              # the exact reviewed state. See docs/governance/MERGE_GATE_RECONCILIATION.md.
+              if not head_sha:
+                  return False
+              result = subprocess.run(
+                  [
+                      "gh", "api", f"repos/{repo}/commits/{head_sha}/statuses",
+                      "--jq",
+                      '.[] | select(.context=="aragora/human-settlement") | .state',
+                  ],
+                  capture_output=True,
+                  text=True,
+                  check=False,
+              )
+              if result.returncode != 0:
+                  print(f"::warning::could not read commit statuses: {result.stderr.strip()}")
+                  return False
+              states = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+              # The statuses API returns most-recent first.
+              return bool(states) and states[0] == "success"
+
+          # Tier 0-2: model quorum alone authorizes the merge.
+          if status == "satisfied":
+              print("Model quorum satisfied; Tier 0-2 settlement authorized.")
+              sys.exit(0)
+
+          # Genuinely not ready: checks failing/pending, or not enough model signals.
+          if status in ("repair_or_wait", "needs_model_review_quorum"):
+              fail(f"Merge quorum not met (status={status}). Resolve the reasons above before merge.")
+
+          # Dissent always needs a human, regardless of tier.
+          if status == "unresolved_dissent" or entry.get("unresolved_dissent"):
+              fail("Unresolved model dissent — requires human attention before merge.")
+
+          # Tier 3-4: model quorum prepared the packet; a recorded human
+          # settlement signal must also be present for the exact head SHA.
+          if status in ("human_risk_settlement_required", "human_preapproval_required"):
+              if human_settlement_present():
+                  print(f"Tier {tier}: human settlement signal present for {head_sha[:12]}.")
+                  sys.exit(0)
+              fail(
+                  f"Tier {tier}: model quorum prepared the risk packet, but no human "
+                  f"settlement signal is recorded for head {head_sha[:12]}. The operator "
+                  "must record settlement and set the 'aragora/human-settlement' commit "
+                  "status. See docs/governance/MERGE_GATE_RECONCILIATION.md."
+              )
+
+          fail(f"Unrecognized merge-quorum status '{status}' — failing closed.")
+          PY

--- a/docs/REVIEW_AUTHORITY_PRINCIPLES.md
+++ b/docs/REVIEW_AUTHORITY_PRINCIPLES.md
@@ -35,4 +35,16 @@ Machine reviews remain advisory in GitHub terms: they do not become bot `APPROVE
 
 A change to `aragora/cli/commands/review_queue.py` is treated as Tier 4 because the model-quorum logic that gates the change *is* the code being changed. Without the elevation, a bug or weakening introduced in the diff would be evaluated by the version of the gate it is trying to land — the artifact under review would be its own arbiter. Tier 4 keeps the human in the chain of trust for these PRs specifically.
 
+## Enforcement on GitHub
+
+Two workflows express this policy on GitHub, and they are deliberately separate.
+
+`aragora-review-gate.yml` ("Aragora Code Review") is advisory. It runs the heterogeneous model review, posts findings as a PR comment, and never fails a PR. `scripts/check_aragora_review_gate_policy.py` guards it against drift and keeps it advisory on purpose.
+
+`aragora-merge-quorum.yml` ("aragora-merge-quorum") is enforcing. It is the required status check on `main`. It builds the read-only merge-authorization packet (`review-queue merge-packet`) for the PR's exact head SHA and fails the check unless the packet authorizes the merge. For Tier 0-2 it passes when the model-quorum verdict is `admin_squash_allowed` with no unresolved dissent. For Tier 3-4 it passes only when, in addition to the model quorum, a head-SHA-bound human settlement signal is recorded — the `aragora/human-settlement` commit status, set by the operator after the local settlement receipt is written — and it fails closed until then.
+
+Branch protection on `main` therefore requires status checks (CI plus `aragora-merge-quorum`) and does not require a human approving review. This is intentional. A human `APPROVE` review by the author, or by any second GitHub identity the author controls, is a symbolic approval with no independent competence behind it: it satisfies the mechanism while defeating the four factors above. The model quorum supplies the technical review; the operator's recorded risk settlement supplies accountability and stake. Neither is a bot `APPROVE`, and neither pretends a second person reviewed the diff.
+
+A second GitHub account operated by the same person as the PR author MUST NOT be used to satisfy any review requirement. It fails the independence factor this document is built on, and in the audit trail it is indistinguishable from a genuine independent review — which makes it worse than no approval at all. Review authority on this repo comes from the model quorum and the operator's recorded settlement, never from a second login.
+
 These principles fit the repo's existing pillars rather than adding new ones. Receipts bind decisions to the exact reviewed state. Evidence-first review requires concrete validation and current-head truth before a merge decision is meaningful. Bounded scope keeps approvals legible enough that an approver can understand what is being accepted. The goal is not symbolic human presence. The goal is a reviewer with enough competence, independence, accountability, and stake to make the approval mean something.

--- a/docs/briefs/automation-merge-contract.md
+++ b/docs/briefs/automation-merge-contract.md
@@ -76,7 +76,7 @@ For Tier 3+, the model quorum prepares the risk packet. The human/operator accep
 
 ## Required vs Advisory Checks
 
-The merge decision should use GitHub branch protection as the authoritative hard gate. As of this contract, that means the required status checks configured on `main`, one approving review, and a scoped diff with validation evidence in the PR body.
+The merge decision should use GitHub branch protection as the authoritative hard gate. As of this contract, that means the required status checks configured on `main` — CI plus the enforcing `aragora-merge-quorum` check — and a scoped diff with validation evidence in the PR body. Branch protection does not require a human approving review: the heterogeneous model-review quorum is the technical reviewer, and the operator's recorded risk settlement carries human accountability for Tier 3-4. See `docs/governance/MERGE_GATE_RECONCILIATION.md`.
 
 Advisory workflows are still useful evidence, but they should not create a hidden second merge policy. Treat advisory checks as follows:
 
@@ -86,7 +86,7 @@ Advisory workflows are still useful evidence, but they should not create a hidde
 - Failed advisory checks are blockers only when the failure is in-scope for the PR diff or reveals a mainline regression that would be worsened by the PR.
 - Summary-only jobs such as analytics, admission signals, and AI review comments should prefer warnings and PR comments over failing statuses.
 
-Use a fast lane for docs-only, tests-only, and narrow CI reliability PRs: if the required checks pass, the diff is scoped, and one reviewer approves, the PR is mergeable even if unrelated advisory lanes are pending or skipped. Use the full lane for product, security, deploy, data migration, and cross-cutting architecture changes: relevant advisory lanes should be green or explicitly waived in the PR body before admin merge.
+Use a fast lane for docs-only, tests-only, and narrow CI reliability PRs: if the required checks pass (including `aragora-merge-quorum`) and the diff is scoped, the PR is mergeable even if unrelated advisory lanes are pending or skipped. Use the full lane for product, security, deploy, data migration, and cross-cutting architecture changes: relevant advisory lanes should be green or explicitly waived in the PR body before admin merge.
 
 ## Queue Hygiene
 

--- a/docs/governance/MERGE_GATE_RECONCILIATION.md
+++ b/docs/governance/MERGE_GATE_RECONCILIATION.md
@@ -1,0 +1,177 @@
+# Merge Gate Reconciliation
+
+**Status:** active
+**Last updated:** 2026-05-21
+**Purpose:** Align GitHub branch protection on `main` with the review authority
+already defined in `docs/REVIEW_AUTHORITY_PRINCIPLES.md` and
+`docs/briefs/automation-merge-contract.md`.
+
+## Why this exists
+
+The operator (`@an0mium`) authors essentially every PR, and `.github/CODEOWNERS`
+routes every path to `@an0mium`. While branch protection required a human
+approving review, no PR could ever satisfy that requirement honestly: an author
+cannot approve their own PR, and using a second GitHub identity controlled by the
+same person is a symbolic approval with no independent competence behind it —
+explicitly disallowed by `REVIEW_AUTHORITY_PRINCIPLES.md`.
+
+The repo already has the real reviewer: the heterogeneous model-review quorum,
+plus the operator acting as accountable risk settler for Tier 3-4. The fix is to
+make that quorum the enforced GitHub gate and to stop branch protection from
+requiring a human `APPROVE` that cannot be produced honestly.
+
+## The two workflows
+
+| Workflow | Role | Can fail a PR? |
+| --- | --- | --- |
+| `aragora-review-gate.yml` ("Aragora Code Review") | Advisory — runs the model review, posts findings as a comment | No (kept advisory by `scripts/check_aragora_review_gate_policy.py`) |
+| `aragora-merge-quorum.yml` ("aragora-merge-quorum") | Enforcing — required status check; builds the `merge-packet` and gates the merge | Yes |
+
+`aragora-merge-quorum` is the GitHub-visible second reviewer. It is a status
+check, not a bot `APPROVE` review.
+
+## Target state for `main` branch protection
+
+Required status checks (must pass before merge):
+
+- the existing CI required checks — keep whatever is configured today
+- `aragora-merge-quorum` — the new enforcing check
+
+Require a pull request before merging: **keep ON.** Every change to `main` must
+still go through a PR so the status checks apply. Do not remove this.
+
+Required approvals: **0.** Remove the approving-review count and the "Require
+review from Code Owners" requirement. The model quorum is the technical
+reviewer; the operator's recorded risk settlement carries human accountability
+for Tier 3-4.
+
+Enforce on administrators: **ON.** Without this the enforcing check is theatre —
+an admin (or admin-token automation) could merge past a red quorum check. For a
+genuine "the gate itself is broken" emergency, toggle this off briefly; branch
+protection changes are logged in the repo audit trail.
+
+`.github/CODEOWNERS` may stay in the repo — it still requests reviewers and
+documents ownership. It just must not be a *required* merge gate.
+
+## Applying it (operator, repo admin)
+
+The safest path is the GitHub UI, because it shows the full resulting state.
+**Settings → Branches → Branch protection rules → `main`:**
+
+1. Keep **Require a pull request before merging** checked.
+2. Under it, set **Require approvals** to `0` (or uncheck it) and uncheck
+   **Require review from Code Owners**.
+3. Under **Require status checks to pass before merging**, add
+   `aragora-merge-quorum` to the required list, alongside the existing CI
+   checks. (This name only appears in the picker after the workflow has run
+   once — see Rollout order below.)
+4. Check **Do not allow bypassing the above settings** / **Include
+   administrators**.
+5. Save.
+
+Equivalent `gh` commands for reference (run as a repo admin — then verify the
+result in the UI). Apply them in the order shown: drop the review requirement
+**before** enabling `enforce_admins`, so there is no window where administrators
+are enforced while an unsatisfiable review requirement is still active.
+
+```bash
+# Set required approvals to 0 and drop CODEOWNERS gating,
+# WITHOUT removing the "PR required" rule itself.
+gh api --method PATCH \
+  repos/synaptent/aragora/branches/main/protection/required_pull_request_reviews \
+  -F required_approving_review_count=0 \
+  -F require_code_owner_reviews=false
+
+# Enforce branch protection on administrators.
+gh api --method POST \
+  repos/synaptent/aragora/branches/main/protection/enforce_admins
+
+# Inspect current required status checks before changing them.
+gh api repos/synaptent/aragora/branches/main/protection/required_status_checks
+```
+
+Add `aragora-merge-quorum` to the required status checks via the UI (step 3) —
+it is safer than editing the status-check set through the API.
+
+## Recording Tier 3-4 human settlement
+
+Tier 0-2 PRs merge on the model quorum alone. Tier 3-4 PRs additionally require
+a head-SHA-bound human settlement signal. The enforcing check fails closed until
+that signal exists.
+
+```bash
+PR=<number>
+HEAD_SHA=$(gh pr view "$PR" --repo synaptent/aragora --json headRefOid --jq .headRefOid)
+
+# 1. Write the local, head-bound settlement receipt.
+python -m aragora.cli.main review-queue record-settlement "$PR" \
+  --head-sha "$HEAD_SHA" \
+  --action admin_squash_merge \
+  --reason "Operator risk settlement: <one-line authorization>"
+
+# 2. Publish the GitHub-visible settlement signal on the exact head SHA.
+gh api --method POST "repos/synaptent/aragora/statuses/$HEAD_SHA" \
+  -f state=success \
+  -f context=aragora/human-settlement \
+  -f "description=Operator risk settlement recorded for PR #$PR"
+
+# 3. Re-run the merge-quorum check so it observes the signal.
+#    (Or: PR page -> Checks -> aragora-merge-quorum -> Re-run.)
+BRANCH=$(gh pr view "$PR" --repo synaptent/aragora --json headRefName --jq .headRefName)
+RUN_ID=$(gh run list --repo synaptent/aragora \
+  --workflow=aragora-merge-quorum.yml --branch "$BRANCH" \
+  --limit 1 --json databaseId --jq '.[0].databaseId')
+gh run rerun --repo synaptent/aragora "$RUN_ID"
+```
+
+If a new commit is pushed, the head SHA changes and the settlement signal no
+longer applies — re-record settlement against the new head. This is
+intentional: settlement is bound to the exact reviewed state.
+
+The `aragora/human-settlement` status MUST be set by the operator, not by
+pipeline automation. It represents the operator's accountable acceptance of
+risk. Setting it from an automated agent re-creates exactly the
+symbolic-approval problem this reconciliation removes. The local settlement
+receipt (step 1) remains the stronger, `merge_arbiter`-enforced record; the
+commit status is only its GitHub-visible projection.
+
+## Rollout order
+
+1. Merge the enforcing workflow `.github/workflows/aragora-merge-quorum.yml`.
+   This is a Tier 4 change (workflow policy and merge-authority
+   self-modification) and needs explicit operator preapproval before
+   implementation and before merge.
+2. Let the workflow run once on an open non-draft PR so GitHub registers the
+   `aragora-merge-quorum` check name.
+3. Apply the branch-protection changes above.
+4. `auto_merge_bucket_a.py` is safe to leave as-is. It passes `gh pr merge
+   --admin` only when `mergeStateStatus == BLOCKED`, which today is caused
+   solely by the review requirement. Once that requirement is removed, Bucket A
+   PRs (green checks) become `CLEAN` and the script merges them with a normal
+   `gh pr merge --squash` — no `--admin`. Its `defense_in_depth_tripwire`
+   already requires CI green independently, so `--admin` never bypassed checks,
+   only the review gate. `enforce_admins: ON` therefore does not break it.
+   Re-verify the boss-loop / `merge_arbiter` path separately if it has its own
+   merge call.
+5. Retire the second-identity approval path: stop using any non-author GitHub
+   login to satisfy review, and remove the isolated `gh` config created for it.
+
+## What this retires
+
+The earlier approach of authorizing merges with a second GitHub identity
+(`scarmani`, or any operator-controlled non-author login) is retired. It
+contradicted `REVIEW_AUTHORITY_PRINCIPLES.md` ("does not authorize bot-only
+GitHub approvals"; the independence factor) and produced an audit trail that
+implied an independent human review that did not happen. The model quorum plus
+recorded operator settlement replaces it with an honest, inspectable trail.
+
+## Health note
+
+An enforcing check is only meaningful if it can fail and sometimes does. Track
+the `aragora-merge-quorum` block rate. If it has never blocked a PR, the tier
+classification or the quorum thresholds are mis-tuned and the gate is not doing
+real work. The model quorum is also only a *partial* independent reviewer —
+`REVIEW_AUTHORITY_PRINCIPLES.md` notes these reviewers are not yet calibrated to
+replace human risk settlement for escalated classes — so the integrity of the
+whole gate depends on Tier 3-4 classification staying honest and the operator
+staying genuinely engaged on those tiers.


### PR DESCRIPTION
## ⚠️ Tier 4 change — requires explicit operator preapproval before merge

This PR touches workflow policy and merge-authority self-modification (`.github/workflows/aragora-merge-quorum.yml` + governance docs). Per `docs/REVIEW_AUTHORITY_PRINCIPLES.md` and the workflow's own docstring, **explicit human preapproval is required before implementation and before merge**. Draft status is deliberate; do not flip to ready until preapproval is recorded.

## Recovery context

An earlier agent session staged these 4 files but blocked on `.git/...lock` deletion due to a filesystem sandbox limitation in its environment. The working tree was then cleaned by automation, leaving:
- Orphan `.git/worktrees/merge-gate-reconciliation/` metadata (now cleaned up)
- 4 file blobs intact in git's object store
- A stale `chore/merge-gate-reconciliation` branch with no governance commits (will be deleted after this PR is settled)

This PR recovers the exact 4 blobs by `git cat-file -p`, writes them to a fresh worktree off origin/main, and commits with the original `COMMIT_EDITMSG` message. Diff matches the prior agent's report exactly: workflow +194, governance doc +177, REVIEW_AUTHORITY +12, automation-contract +4/−2.

Blob hashes (verifiable via `git cat-file -s`):
- `.github/workflows/aragora-merge-quorum.yml`      : `678d20607010c3d8a0a1b09c61c4849ff828fd6a` (7791 B)
- `docs/REVIEW_AUTHORITY_PRINCIPLES.md`             : `da329ba415a0d7020d93ba12a174b9add1eaba69` (6962 B)
- `docs/briefs/automation-merge-contract.md`        : `92d1a7cffd0cfaff79b975e12989a89a6d8d421a` (13008 B)
- `docs/governance/MERGE_GATE_RECONCILIATION.md`    : `ccf8d3d7cf193a8d28086bc9c90cbc5a500057d7` (8588 B)

## Summary of changes

- **NEW** `.github/workflows/aragora-merge-quorum.yml` — enforcing required status check on `main`. Builds the read-only review-queue merge-packet and gates merges on the model quorum (Tier 0-2) plus a head-SHA-bound human settlement signal (Tier 3-4), failing closed otherwise. Does NOT post a bot APPROVE — reports honest pass/fail.
- **NEW** `docs/governance/MERGE_GATE_RECONCILIATION.md` — branch-protection target state, apply steps, rollout order.
- **UPDATE** `docs/REVIEW_AUTHORITY_PRINCIPLES.md` (+12 lines, no deletions) — documents the enforcing-vs-advisory workflow split + explicitly prohibits second-account approvals.
- **UPDATE** `docs/briefs/automation-merge-contract.md` (+4/−2) — pins `aragora-merge-quorum` as a required check.

The advisory `aragora-review-gate.yml` is intentionally untouched.

## Validation

```bash
# YAML parses cleanly
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/aragora-merge-quorum.yml'))"
# → "Parsed OK; name= Aragora Merge Quorum; jobs: ['merge-quorum']"

# actionlint clean
actionlint .github/workflows/aragora-merge-quorum.yml
# → no output (clean)

# Preflight ok (workflow change flagged for validation, satisfied above)
bash scripts/automation_pr_preflight.sh origin/main HEAD
# → preflight: ok
```

No `aragora-merge-quorum` workflow runs against this PR yet (chicken-and-egg: it doesn't exist on main). Once merged, it will start gating subsequent PRs.

## Identity gate

PR opened by `an0mium`. Per `REVIEW_AUTHORITY_PRINCIPLES.md` (the very doc this PR formalizes), bot/same-author approvals are not valid. A separate independent human approval is required before merge.

## Test plan
- [ ] Operator preapproval recorded (Tier 4)
- [ ] Manual render-check of `MERGE_GATE_RECONCILIATION.md`
- [ ] Manual render-check of `REVIEW_AUTHORITY_PRINCIPLES.md` diff
- [ ] Dry-run the workflow against a recent PR via `workflow_dispatch` after merge

## Non-touches
- `aragora-review-gate.yml` (advisory; intentionally untouched)
- Branch protection rules (require operator-side change after this lands per `MERGE_GATE_RECONCILIATION.md`)
- Held PRs (#7173, #7215, #7240, #7243, #7245, #7249, #7252, #4990, #7209)
- ADC PRs #7358/#7360/#7361/#7367/#7376
- #7292, #7385, #7297 (merged), Dependabot branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)