### PR TITLE
fix(scripts): protect unknown backlog divergence

### DIFF
--- a/scripts/audit_codex_branch_backlog.py
+++ b/scripts/audit_codex_branch_backlog.py
@@ -1225,6 +1225,7 @@ def audit(
         + counts["protected_handoff_receipt"]
         + counts["protected_handoff_outbox"]
         + counts["protected_open_pr_lookup_unknown"]
+        + counts["protected_divergence_lookup_unknown"]
     )
     salvage = (
         counts["salvage_recent_unique"]

--- a/scripts/audit_codex_branch_backlog.py
+++ b/scripts/audit_codex_branch_backlog.py
@@ -56,6 +56,7 @@ COMPACT_RECORD_EXAMPLE_FIELDS = (
     "subject",
     "ahead_count",
     "behind_count",
+    "divergence_lookup_failed",
     "patch_equivalence_skipped",
     "open_pr",
     "worktree_paths",
@@ -75,8 +76,9 @@ class BranchRecord:
     head_sha: str
     committed_at: str
     subject: str
-    ahead_count: int
-    behind_count: int
+    ahead_count: int | None
+    behind_count: int | None
+    divergence_lookup_failed: bool
     merged_to_base: bool
     patch_equivalent_to_base: bool
     patch_equivalence_skipped: bool
@@ -707,20 +709,23 @@ def open_pr_heads(root: Path, repo: str, prefix: str) -> dict[str, int] | None:
     return heads
 
 
-def count_ahead(root: Path, base: str, branch: str) -> int:
-    ahead_count, _behind_count = branch_divergence(root, base, branch)
+def count_ahead(root: Path, base: str, branch: str) -> int | None:
+    divergence = branch_divergence(root, base, branch)
+    if divergence is None:
+        return None
+    ahead_count, _behind_count = divergence
     return ahead_count
 
 
-def branch_divergence(root: Path, base: str, branch: str) -> tuple[int, int]:
+def branch_divergence(root: Path, base: str, branch: str) -> tuple[int, int] | None:
     proc = run_git(["rev-list", "--left-right", "--count", f"{base}...{branch}"], root)
     if proc.returncode != 0:
-        return (0, 0)
+        return None
     try:
         behind_count, ahead_count = (int(part) for part in proc.stdout.split())
         return (ahead_count, behind_count)
     except ValueError:
-        return (0, 0)
+        return None
 
 
 def branch_divergence_map(
@@ -1034,20 +1039,37 @@ def audit(
             divergence = divergence_by_branch.get(branch)
             if divergence is None:
                 divergence = branch_divergence(root, base, branch)
-            ahead_count, behind_count = divergence
+            if divergence is None:
+                ahead_count = None
+                behind_count = None
+                divergence_lookup_failed = True
+            else:
+                ahead_count, behind_count = divergence
+                divergence_lookup_failed = False
         else:
+            divergence_lookup_failed = False
             try:
                 behind_count = int(row.get("behind_count", "0"))
             except ValueError:
                 divergence = divergence_by_branch.get(branch)
                 if divergence is None:
                     divergence = branch_divergence(root, base, branch)
-                _ahead_count, behind_count = divergence
+                if divergence is None:
+                    ahead_count = None
+                    behind_count = None
+                    divergence_lookup_failed = True
+                else:
+                    ahead_count, behind_count = divergence
         merged_to_base = branch in merged_branches
         patch_equivalent = False
         patch_equivalence_skipped = False
         patch_id = None
-        if ahead_count > 0 and not merged_to_base and not protected_before_patch_check:
+        if (
+            ahead_count is not None
+            and ahead_count > 0
+            and not merged_to_base
+            and not protected_before_patch_check
+        ):
             if _patch_budget_exhausted(patch_deadline):
                 patch_equivalence_budget_exhausted = True
                 patch_equivalence_skipped_branches += 1
@@ -1110,24 +1132,29 @@ def audit(
                     deadline=patch_deadline,
                 )
             handoff_outbox = patch_id in handoff_outbox_patch_ids
-        category = classify(
-            open_pr=open_pr,
-            active_paths=active_paths,
-            dirty_paths=dirty_paths,
-            ahead_count=ahead_count,
-            behind_count=behind_count,
-            merged_to_base=merged_to_base,
-            patch_equivalent_to_base=patch_equivalent,
-            handoff_receipt_exists=handoff_receipted,
-            handoff_outbox_exists=handoff_outbox,
-            committed_at=committed_at,
-            recent_cutoff=recent_cutoff,
-            remote_branch_exists=remote_exists,
-        )
-        if open_pr_lookup_failed and (
-            category.startswith("cleanup_") or category in SALVAGE_CATEGORIES
-        ):
-            category = "protected_open_pr_lookup_unknown"
+        if divergence_lookup_failed:
+            category = "protected_divergence_lookup_unknown"
+        else:
+            assert ahead_count is not None
+            assert behind_count is not None
+            category = classify(
+                open_pr=open_pr,
+                active_paths=active_paths,
+                dirty_paths=dirty_paths,
+                ahead_count=ahead_count,
+                behind_count=behind_count,
+                merged_to_base=merged_to_base,
+                patch_equivalent_to_base=patch_equivalent,
+                handoff_receipt_exists=handoff_receipted,
+                handoff_outbox_exists=handoff_outbox,
+                committed_at=committed_at,
+                recent_cutoff=recent_cutoff,
+                remote_branch_exists=remote_exists,
+            )
+            if open_pr_lookup_failed and (
+                category.startswith("cleanup_") or category in SALVAGE_CATEGORIES
+            ):
+                category = "protected_open_pr_lookup_unknown"
         if (
             not include_patch_equivalence
             and not patch_equivalent
@@ -1145,6 +1172,8 @@ def audit(
                     timeout=_patch_timeout(patch_deadline, 60),
                 )
             if patch_equivalent:
+                assert ahead_count is not None
+                assert behind_count is not None
                 category = classify(
                     open_pr=open_pr,
                     active_paths=active_paths,
@@ -1172,6 +1201,7 @@ def audit(
                 subject=row["subject"],
                 ahead_count=ahead_count,
                 behind_count=behind_count,
+                divergence_lookup_failed=divergence_lookup_failed,
                 merged_to_base=merged_to_base,
                 patch_equivalent_to_base=patch_equivalent,
                 patch_equivalence_skipped=patch_equivalence_skipped,

--- a/tests/scripts/test_audit_codex_branch_backlog.py
+++ b/tests/scripts/test_audit_codex_branch_backlog.py
@@ -77,6 +77,24 @@ def test_branch_divergence_parses_rev_list_left_right_counts(
     assert mod.branch_divergence(tmp_path, "origin/main", "codex/example") == (7, 3)
 
 
+def test_branch_divergence_returns_none_on_rev_list_failure(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    def fake_run_git(
+        args: list[str], cwd: Path, *, timeout: int = 60
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=128,
+            stdout="",
+            stderr="fatal: ambiguous argument",
+        )
+
+    monkeypatch.setattr(mod, "run_git", fake_run_git)
+
+    assert mod.branch_divergence(tmp_path, "origin/main", "codex/example") is None
+
+
 def test_branch_divergence_map_parses_batch_ahead_behind_output(
     tmp_path: Path, monkeypatch: Any
 ) -> None:
@@ -435,6 +453,52 @@ def test_audit_uses_batched_divergence_before_fallback(tmp_path: Path, monkeypat
 
     assert payload["records"][0]["ahead_count"] == 5
     assert payload["records"][0]["behind_count"] == 2
+
+
+def test_audit_protects_branch_when_divergence_lookup_fails(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    row = _branch_row(ahead_count="", behind_count="")
+    _stub_git_inventory(monkeypatch, row)
+    monkeypatch.setattr(mod, "branch_divergence_map", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(mod, "branch_divergence", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda _root: GitHubCLIHealth(
+            ready=False,
+            auth_ok=False,
+            api_ok=False,
+            mode="connectivity_failed",
+            error="offline",
+            repo=str(tmp_path),
+        ),
+    )
+
+    def fail_patch_check(*_args: Any, **_kwargs: Any) -> bool:
+        raise AssertionError("unknown divergence must not run patch-equivalence checks")
+
+    monkeypatch.setattr(mod, "has_empty_branch_diff", fail_patch_check)
+    monkeypatch.setattr(mod, "is_patch_equivalent", fail_patch_check)
+
+    payload = mod.audit(
+        root=tmp_path,
+        base="origin/main",
+        repo="synaptent/aragora",
+        prefix="codex/",
+        recent_hours=72,
+        max_branches=None,
+        include_patch_equivalence=False,
+        publisher_backlog_limit=12,
+    )
+
+    record = payload["records"][0]
+    assert record["category"] == "protected_divergence_lookup_unknown"
+    assert record["ahead_count"] is None
+    assert record["behind_count"] is None
+    assert record["divergence_lookup_failed"] is True
+    assert payload["summary"]["safe_cleanup_candidates"] == 0
+    assert payload["summary"]["by_category"] == {"protected_divergence_lookup_unknown": 1}
 
 
 def test_audit_uses_open_pr_lookup_when_github_health_is_ready(

--- a/tests/scripts/test_audit_codex_branch_backlog.py
+++ b/tests/scripts/test_audit_codex_branch_backlog.py
@@ -498,6 +498,7 @@ def test_audit_protects_branch_when_divergence_lookup_fails(
     assert record["behind_count"] is None
     assert record["divergence_lookup_failed"] is True
     assert payload["summary"]["safe_cleanup_candidates"] == 0
+    assert payload["summary"]["protected"] == 1
     assert payload["summary"]["by_category"] == {"protected_divergence_lookup_unknown": 1}
 
 


### PR DESCRIPTION
## Summary
- Make branch divergence lookup failures explicit instead of treating them as 0 ahead / 0 behind.
- Classify unresolved divergence as `protected_divergence_lookup_unknown` so harvest/cleanup tooling fails closed.
- Add focused regression coverage for direct rev-list failure and audit-level protection without patch-equivalence cleanup checks.

## Mailbox / Coordination
- Checked Q49 mailbox before edits: no pending messages.
- No active lane owned this branch or audit surface at claim time.
- This PR does not remove worktrees, delete branches, merge PRs, or mutate cleanup state.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/scripts/test_audit_codex_branch_backlog.py -q -p no:cacheprovider` -> 54 passed
- `python3 -m ruff check scripts/audit_codex_branch_backlog.py tests/scripts/test_audit_codex_branch_backlog.py` -> passed
- `python3 -m ruff format --check scripts/audit_codex_branch_backlog.py tests/scripts/test_audit_codex_branch_backlog.py` -> passed
- `python3 -m mypy scripts/audit_codex_branch_backlog.py --ignore-missing-imports --no-incremental` -> passed
- `python3 scripts/audit_codex_branch_backlog.py --summary-only --json --skip-patch-equivalence --examples 1` -> completed; publishable_branch_backlog=0
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> passed

Do not settle in this lane; review as a focused harvest/cleanup safety hardening PR.