### PR TITLE
fix(scripts): update Codex autonomous launcher flags

### DIFF
--- a/scripts/codex_session.sh
+++ b/scripts/codex_session.sh
@@ -5,6 +5,7 @@
 #   ./scripts/codex_session.sh
 #   ./scripts/codex_session.sh --agent codex-qa
 #   ./scripts/codex_session.sh --agent codex-qa --full-auto
+#   ./scripts/codex_session.sh --agent codex-qa --yolo
 #   ./scripts/codex_session.sh --orchestrator crewai
 #   ./scripts/codex_session.sh --agent codex-qa --base main -- python -m pytest tests/debate -q
 #   ./scripts/codex_session.sh --managed-dir .worktrees/codex-auto-qa --no-maintain --no-reconcile
@@ -38,6 +39,7 @@ WRITE_SCOPES=()
 CLAIMED_PATHS=()
 TEST_COMMANDS=()
 CODEX_ARGS=()
+AUTONOMOUS_CODEX=false
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -101,8 +103,8 @@ while [[ $# -gt 0 ]]; do
             ALLOW_LEASE_OVERLAP=true
             shift
             ;;
-        --full-auto)
-            CODEX_ARGS+=(--full-auto)
+        --full-auto|--yolo)
+            AUTONOMOUS_CODEX=true
             shift
             ;;
         --dangerously-bypass-approvals-and-sandbox)
@@ -122,6 +124,14 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+if ${AUTONOMOUS_CODEX}; then
+    if ! codex exec --dangerously-bypass-approvals-and-sandbox --help >/dev/null 2>&1; then
+        echo "Codex autonomous mode requires 'codex exec --dangerously-bypass-approvals-and-sandbox', but this Codex CLI does not support it." >&2
+        exit 2
+    fi
+    CODEX_ARGS+=(--dangerously-bypass-approvals-and-sandbox)
+fi
 
 ENSURE_ARGS=(ensure --agent "${AGENT}" --base "${BASE_BRANCH}" --print-path)
 if [[ -n "${SESSION_ID_OVERRIDE}" ]]; then

--- a/scripts/tmux_session_launcher.sh
+++ b/scripts/tmux_session_launcher.sh
@@ -11,7 +11,8 @@
 #   ./scripts/tmux_session_launcher.sh --kill codex-conductor
 #
 # Flags:
-#   --autonomous   Grant full permissions (Claude: --dangerously-skip-permissions, Codex: --full-auto)
+#   --autonomous   Grant full permissions (Claude: --dangerously-skip-permissions,
+#                  Codex: codex exec --dangerously-bypass-approvals-and-sandbox)
 #                  Required for agents to run Bash, edit files, etc. in tmux lanes.
 #
 # Each session gets:
@@ -246,12 +247,52 @@ fi
 # Build the launch command
 # When --autonomous is set:
 #   - Claude gets ARAGORA_ADMIN_APPROVED=1 → --dangerously-skip-permissions (can run Bash)
-#   - Codex gets --full-auto approval mode
+#   - Prompted Codex uses non-interactive `codex exec --dangerously-bypass-approvals-and-sandbox`
+#   - Unprompted Codex stays interactive and gets the local `--yolo` compatibility alias
 #   - Droid/Factory prompted work always uses `droid exec --auto high`; use
 #     ARAGORA_DROID_AUTO_LEVEL=low|medium|high to lower the level explicitly.
 if [[ "${AGENT}" == "codex" ]]; then
     if [[ "${AUTONOMOUS}" == "1" ]]; then
-        LAUNCH_CMD="cd '${WORKDIR}' && ./scripts/codex_session.sh --agent '${NAME}' --base main --full-auto"
+        if [[ -n "${PROMPT}" ]]; then
+            CODEX_EXEC_PROMPT_FILE="${PROMPT_FILE}"
+            if [[ -z "${CODEX_EXEC_PROMPT_FILE}" ]]; then
+                CODEX_EXEC_PROMPT_FILE="${LOG_DIR}/${NAME}.prompt.md"
+                printf '%s\n' "${PROMPT}" > "${CODEX_EXEC_PROMPT_FILE}"
+            fi
+            CODEX_EXEC_PROMPT_FILE="$(cd "$(dirname "${CODEX_EXEC_PROMPT_FILE}")" && pwd)/$(basename "${CODEX_EXEC_PROMPT_FILE}")"
+            CODEX_EXEC_LAUNCH_FILE="${LOG_DIR}/${NAME}.launch.sh"
+            python3 - "${CODEX_EXEC_LAUNCH_FILE}" "${WORKDIR}" "${NAME}" "${CODEX_EXEC_PROMPT_FILE}" <<'PY'
+import os
+import shlex
+import sys
+from pathlib import Path
+
+launch_file, workdir, name, prompt_file = sys.argv[1:5]
+body = "\n".join(
+    [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        f"cd {shlex.quote(workdir)}",
+        (
+            "./scripts/codex_session.sh "
+            f"--agent {shlex.quote(name)} --base main --yolo -- "
+            "codex exec --dangerously-bypass-approvals-and-sandbox "
+            f"- < {shlex.quote(prompt_file)}"
+        ),
+        "",
+    ]
+)
+path = Path(launch_file)
+path.write_text(body, encoding="utf-8")
+os.chmod(path, 0o700)
+PY
+            LAUNCH_CMD="bash '${CODEX_EXEC_LAUNCH_FILE}'"
+            # `codex exec` consumes the prompt directly; do not also paste it
+            # into an interactive pane.
+            PROMPT=""
+        else
+            LAUNCH_CMD="cd '${WORKDIR}' && ./scripts/codex_session.sh --agent '${NAME}' --base main --yolo"
+        fi
     else
         LAUNCH_CMD="cd '${WORKDIR}' && ./scripts/codex_session.sh --agent '${NAME}' --base main"
     fi

--- a/tests/scripts/test_codex_session_script.py
+++ b/tests/scripts/test_codex_session_script.py
@@ -1,10 +1,13 @@
 from pathlib import Path
 
 
-def test_codex_session_forwards_full_auto_to_codex() -> None:
+def test_codex_session_translates_autonomous_aliases_to_supported_codex_flags() -> None:
     script = Path("scripts/codex_session.sh").read_text(encoding="utf-8")
 
-    assert "--full-auto)" in script
-    assert "CODEX_ARGS+=(--full-auto)" in script
+    assert "--full-auto|--yolo)" in script
+    assert "AUTONOMOUS_CODEX=true" in script
+    assert "CODEX_ARGS+=(--dangerously-bypass-approvals-and-sandbox)" in script
+    assert "--ask-for-approval" not in script
+    assert "CODEX_ARGS+=(--full-auto)" not in script
     assert 'codex "${CODEX_ARGS[@]}"' in script
     assert 'SESSION_ARGS_JSON="$(python3 - "${CODEX_ARGS[@]}"' in script

--- a/tests/scripts/test_tmux_transport_scripts.py
+++ b/tests/scripts/test_tmux_transport_scripts.py
@@ -155,6 +155,54 @@ def test_tmux_session_launcher_waits_for_readiness_marker_before_prompt_send(
     assert registry_payload["sessions"]["testpane"]["tmux_window"] == "@17"
 
 
+def test_tmux_session_launcher_autonomous_codex_prompt_uses_exec(
+    tmp_path: Path,
+) -> None:
+    _write_fake_tmux(tmp_path)
+    env = _fake_tmux_env(tmp_path)
+    env["ARAGORA_TMUX_INIT_WAIT_SECONDS"] = "1"
+    env["ARAGORA_TMUX_REGISTRY_REPO_ROOT"] = str(tmp_path)
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(REPO_ROOT / "scripts" / "tmux_session_launcher.sh"),
+            "--name",
+            "codex-auto",
+            "--agent",
+            "codex",
+            "--autonomous",
+            "--prompt",
+            "report git status only",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert "Waiting up to" not in result.stdout
+    calls = _load_tmux_calls(env)
+    assert any(
+        call[:2] == ["send-keys", "-t"]
+        and call[2] == "@17"
+        and "bash '" in call[3]
+        and "codex-auto.launch.sh" in call[3]
+        and "--full-auto" not in call[3]
+        for call in calls
+    )
+    launch_script = Path(env["HOME"]) / ".aragora" / "tmux-sessions" / "codex-auto.launch.sh"
+    launch_body = launch_script.read_text(encoding="utf-8")
+    assert "codex exec --dangerously-bypass-approvals-and-sandbox - <" in launch_body
+    assert "--ask-for-approval" not in launch_body
+    assert "--full-auto" not in launch_body
+    assert not any("report git status only" in json.dumps(call) for call in calls)
+    assert (Path(env["HOME"]) / ".aragora" / "tmux-sessions" / "codex-auto.prompt.md").read_text(
+        encoding="utf-8"
+    ) == "report git status only\n"
+
+
 def test_tmux_session_launcher_accepts_new_codex_readiness_markers(tmp_path: Path) -> None:
     _write_fake_tmux(tmp_path)
     env = _fake_tmux_env(tmp_path)


### PR DESCRIPTION
## Summary\n- translate legacy Codex launcher autonomy aliases (`--full-auto`, `--yolo`) to the supported dangerous bypass flag instead of forwarding invalid flags\n- route prompted autonomous Codex tmux launches through a generated wrapper that runs `codex exec --dangerously-bypass-approvals-and-sandbox -`\n- keep promptless Codex tmux launches interactive while allowing the local `--yolo` compatibility alias\n\n## Validation\n- `bash -n scripts/codex_session.sh scripts/tmux_session_launcher.sh`\n- `python3 -m pytest tests/scripts/test_codex_session_script.py tests/scripts/test_tmux_transport_scripts.py -q`\n- `codex exec --dangerously-bypass-approvals-and-sandbox --help`\n- bridge smoke: `scripts/agent_bridge.py launch --agent codex --autonomous` with a read-only git-status prompt reached Codex exec, reported approval=never/sandbox=danger-full-access, and exited 0\n- `bash scripts/automation_pr_preflight.sh origin/main HEAD`