### PR TITLE
fix(automation): add compact publisher freshness output

### DIFF
--- a/scripts/publisher_freshness_check.py
+++ b/scripts/publisher_freshness_check.py
@@ -370,11 +370,45 @@ def _build_parser() -> argparse.ArgumentParser:
         "--json", action="store_true", help="Emit JSON to stdout instead of the 1-line summary"
     )
     parser.add_argument(
+        "--summary-only",
+        action="store_true",
+        help=(
+            "Print compact JSON for automation startup logs. Only applies with "
+            "--json; the full text summary is already compact."
+        ),
+    )
+    parser.add_argument(
         "--exit-nonzero-on-degraded",
         action="store_true",
         help="Exit 1 when verdict is degraded (useful in CI/launchd post-flight)",
     )
     return parser
+
+
+def summary_only_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return compact publisher freshness state for startup probes."""
+
+    keep_keys = (
+        "generated_at",
+        "verdict",
+        "summary",
+        "blockers",
+        "launchd_loaded",
+        "launchd_detail",
+        "launchd_last_exit_code",
+        "cache_present",
+        "cache_age_human",
+        "cache_stale",
+        "cache_stale_threshold_seconds",
+        "outbox_real_count",
+        "outbox_cache_count",
+        "outbox_drift",
+        "drift_detail",
+    )
+    compact = {key: payload[key] for key in keep_keys if key in payload}
+    compact["details_omitted"] = True
+    compact["paths_omitted"] = any(key in payload for key in ("cache_path", "outbox_dir"))
+    return compact
 
 
 def _resolve_explicit_path(repo_root: Path, value: str | None) -> Path | None:
@@ -404,7 +438,8 @@ def main(argv: list[str] | None = None) -> int:
             "generated_at": datetime.now(tz=timezone.utc).isoformat().replace("+00:00", "Z"),
             **asdict(report),
         }
-        print(json.dumps(payload, indent=2, sort_keys=True))
+        output_payload = summary_only_payload(payload) if args.summary_only else payload
+        print(json.dumps(output_payload, indent=2, sort_keys=True))
     else:
         print(report.summary)
         if report.blockers and not args.json:

--- a/tests/scripts/test_publisher_freshness_check.py
+++ b/tests/scripts/test_publisher_freshness_check.py
@@ -232,6 +232,38 @@ def test_main_json_output_includes_full_report(
     assert parsed["launchd_loaded"] is True
 
 
+def test_main_summary_only_json_omits_paths(
+    monkeypatch: pytest.MonkeyPatch, stub_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _write_cache(stub_repo, outbox_count=2)
+    _write_outbox_files(stub_repo, 2)
+    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (True, "loaded", None))
+
+    rc = mod.main(
+        [
+            "--repo",
+            str(stub_repo),
+            "--outbox-dir",
+            str(stub_repo / ".aragora" / "automation-outbox"),
+            "--receipt-dir",
+            str(stub_repo / ".aragora" / "automation-receipts"),
+            "--json",
+            "--summary-only",
+        ]
+    )
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    parsed = json.loads(out)
+    assert parsed["verdict"] == "ready"
+    assert parsed["outbox_real_count"] == 2
+    assert parsed["details_omitted"] is True
+    assert parsed["paths_omitted"] is True
+    assert "cache_path" not in parsed
+    assert "outbox_dir" not in parsed
+    assert "cache_age_seconds" not in parsed
+
+
 def test_check_publisher_freshness_wrapper_executes_primary_script(stub_repo: Path) -> None:
     result = subprocess.run(
         [sys.executable, str(WRAPPER_SCRIPT_PATH), "--repo", str(stub_repo), "--json"],


### PR DESCRIPTION
## Summary
- Adds compact JSON output for publisher freshness checks.
- Preserves full default output while allowing automation memory/status paths to omit bulky details.

## Validation
- `git diff --check origin/main...e0dd5e2563d1e398ec96a4d6e59a675df45e8565`
- `bash scripts/automation_pr_preflight.sh origin/main e0dd5e2563d1e398ec96a4d6e59a675df45e8565`
- Handoff evidence: `tests/scripts/test_publisher_freshness_check.py` passed at exact head.

Harvested from Codex automation outbox handoff `open-pr-codex-publisher-freshness-summary-only-r2-20260522-e0dd5e25.json`.