### PR TITLE
fix(automation): clarify compact publisher truncation

### DIFF
--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -181,7 +181,13 @@ def summary_only_payload(payload: dict[str, Any]) -> dict[str, Any]:
     compact = dict(payload)
     decisions = compact.pop("decisions", None)
     if isinstance(decisions, Sequence) and not isinstance(decisions, (str, bytes, bytearray)):
-        compact["decision_count"] = len(decisions)
+        decision_count = len(decisions)
+        compact["decision_count"] = decision_count
+        handoff_count = compact.get("handoff_count")
+        if isinstance(handoff_count, int):
+            omitted_count = max(handoff_count - decision_count, 0)
+            compact["decision_omitted_count"] = omitted_count
+            compact["decisions_truncated"] = omitted_count > 0
         compact["decisions_omitted"] = True
     compact["details_omitted"] = True
     return compact

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -1964,6 +1964,14 @@ def test_main_summary_only_omits_decisions_when_github_unavailable(
             labels={},
             expires_at=None,
         ),
+        Handoff(
+            source_file=str(tmp_path / "third.md"),
+            task_title="Third offline handoff",
+            priority="MEDIUM",
+            body="body",
+            labels={},
+            expires_at=None,
+        ),
     ]
     monkeypatch.setattr(mod, "_repo_root", lambda path: tmp_path)
     monkeypatch.setattr(mod, "load_handoffs", lambda codex_home, automation_ids=None: handoffs)
@@ -1994,7 +2002,10 @@ def test_main_summary_only_omits_decisions_when_github_unavailable(
     assert exit_code == 1
     payload = json.loads(capsys.readouterr().out)
     assert "decisions" not in payload
+    assert payload["handoff_count"] == 3
     assert payload["decision_count"] == 2
+    assert payload["decision_omitted_count"] == 1
+    assert payload["decisions_truncated"] is True
     assert payload["decisions_omitted"] is True
     assert payload["details_omitted"] is True
     assert payload["decision_summary"] == {


### PR DESCRIPTION
## Summary
- Adds explicit compact-output metadata for truncated publisher handoff decisions.
- Helps automation summaries distinguish a small queue from a deliberately omitted decision preview.

## Validation
- `git diff --check origin/main...f32af8c725606c4e30bd9bb81d868ace260b60d2`
- `bash scripts/automation_pr_preflight.sh origin/main f32af8c725606c4e30bd9bb81d868ace260b60d2`
- Handoff evidence: `tests/scripts/test_publish_automation_handoffs.py` passed at exact head.

Harvested from Codex automation outbox handoff `open-pr-codex-publish-handoff-summary-truncation-20260522-f32af8c7.json`.