### PR TITLE
fix(bridge): ignore resolved conflict lanes in snapshots

### DIFF
--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -508,6 +508,37 @@ def _sync_lane_records(records: list[LaneRecord], sessions: list[Session]) -> li
     return records
 
 
+def _conflict_lane_resolved_by_completed_owner(
+    record: LaneRecord, records: list[LaneRecord]
+) -> bool:
+    if record.status not in CONFLICT_LANE_STATUSES or not record.conflict_session:
+        return False
+    conflict_updated_at = _parse_timestamp(record.updated_at)
+    if conflict_updated_at is None:
+        return False
+    for candidate in records:
+        if candidate.owner_session != record.conflict_session:
+            continue
+        if candidate.status not in COMPLETED_LANE_STATUSES:
+            continue
+        candidate_updated_at = _parse_timestamp(candidate.updated_at)
+        if candidate_updated_at is not None and candidate_updated_at >= conflict_updated_at:
+            return True
+    return False
+
+
+def _filter_current_lane_records(records: list[LaneRecord]) -> list[LaneRecord]:
+    return [
+        record
+        for record in records
+        if record.status in ACTIVE_LANE_STATUSES
+        or (
+            record.status in CONFLICT_LANE_STATUSES
+            and not _conflict_lane_resolved_by_completed_owner(record, records)
+        )
+    ]
+
+
 def _head_for_worktree(path: str | Path | None) -> str | None:
     if not path:
         return None
@@ -1777,6 +1808,8 @@ def cmd_operator_snapshot(args: argparse.Namespace) -> int:
         _enrich_prs(discovered_sessions)
         _write_session_snapshot(discovered_sessions)
     records = _sync_lane_records(_load_lane_registry(), sessions)
+    if not include_historical:
+        records = _filter_current_lane_records(records)
 
     issues = _collect_health_issues(sessions, records)
     lane_conflicts = _active_lane_identity_conflicts(records)

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -587,6 +587,56 @@ def test_operator_snapshot_does_not_conflict_same_owner_refreshes(
     assert payload["health"]["ok"] is True
 
 
+def test_operator_snapshot_current_scope_ignores_resolved_conflict_lane(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import agent_bridge as mod
+
+    _patch_bridge_paths(mod, tmp_path, monkeypatch)
+    mod.AGENT_BRIDGE_DIR.mkdir(parents=True, exist_ok=True)
+    mod.LANE_REGISTRY_FILE.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "p104-stands-down",
+                    "owner_session": "codex-p104",
+                    "status": "conflict",
+                    "conflict_session": "codex-r03",
+                    "conflict_reason": "r03 owns follow-through",
+                    "updated_at": "2026-05-21T18:13:49Z",
+                },
+                {
+                    "lane_id": "r03-follow-through",
+                    "owner_session": "codex-r03",
+                    "status": "completed",
+                    "updated_at": "2026-05-21T18:37:57Z",
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mod, "discover", lambda **_kwargs: [])
+    monkeypatch.setattr(
+        mod,
+        "_collect_agent_process_census",
+        lambda *, include_records=True, record_limit=None, ps_lines=None: {
+            "ok": True,
+            "total": 0,
+            "by_role": {},
+        },
+    )
+
+    rc = mod.cmd_operator_snapshot(argparse.Namespace(json=True, summary_only=True))
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["summary"]["conflict_lanes"] == 0
+    assert payload["health"] == {"ok": True, "issues": []}
+    assert payload["lane_conflicts"] == []
+
+
 def test_cmd_owner_json_reports_active_pr_owner(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- Filters resolved conflict lanes out of operator snapshots.
- Keeps current active-lane health from being polluted by stale resolved collision records.

## Validation
- `git diff --check origin/main...1ff5b6bce828111e9df0539a0720b8f98f62f258`
- `bash scripts/automation_pr_preflight.sh origin/main 1ff5b6bce828111e9df0539a0720b8f98f62f258`
- Handoff evidence: focused `tests/scripts/test_agent_bridge.py` regression passed at exact head.

Harvested from Codex automation outbox handoff `open-pr-codex-operator-snapshot-resolved-conflict-health-20260521-ef850702.json`.