### PR TITLE
fix(automation): restore compact outbox reconcile output

### DIFF
--- a/scripts/reconcile_automation_outbox.py
+++ b/scripts/reconcile_automation_outbox.py
@@ -496,6 +496,11 @@ def main(argv: list[str] | None = None) -> int:
         help="Print a machine-readable reconciliation result instead of human text",
     )
     parser.add_argument(
+        "--summary-only",
+        action="store_true",
+        help="With --json, omit per-handoff action details and print only compact counts.",
+    )
+    parser.add_argument(
         "--write-report",
         action="store_true",
         help=(
@@ -856,35 +861,34 @@ def main(argv: list[str] | None = None) -> int:
     if not args.apply:
         emit("\n  DRY-RUN — re-run with --apply to actually archive files.")
     if args.json:
-        print(
-            json.dumps(
-                {
-                    "actions": actions,
-                    "applied": args.apply,
-                    "archive_dir": str(archive_dir),
-                    "archived": archived,
-                    "base": args.base,
-                    "counts": counts,
-                    "dry_run": not args.apply,
-                    "kept": kept,
-                    "outbox_count": len(outbox_files),
-                    "outbox_dir": str(outbox_dir),
-                    "receipt_dir": str(receipt_dir),
-                    "repo": str(root),
-                    "repo_name": args.repo_name,
-                    "report": str(report_path) if report_path is not None else None,
-                    "state_root": str(state_root),
-                    "target": {
-                        "idempotency_keys": sorted(target_keys),
-                        "outbox_files": sorted(str(path) for path in target_files),
-                    },
-                    "terminal_receipt_count": len(receipt_keys),
-                    "total_outbox_count": len(all_outbox_files),
-                },
-                indent=2,
-                sort_keys=True,
-            )
-        )
+        payload = {
+            "actions": actions,
+            "applied": args.apply,
+            "archive_dir": str(archive_dir),
+            "archived": archived,
+            "base": args.base,
+            "counts": counts,
+            "dry_run": not args.apply,
+            "kept": kept,
+            "outbox_count": len(outbox_files),
+            "outbox_dir": str(outbox_dir),
+            "receipt_dir": str(receipt_dir),
+            "repo": str(root),
+            "repo_name": args.repo_name,
+            "report": str(report_path) if report_path is not None else None,
+            "state_root": str(state_root),
+            "target": {
+                "idempotency_keys": sorted(target_keys),
+                "outbox_files": sorted(str(path) for path in target_files),
+            },
+            "terminal_receipt_count": len(receipt_keys),
+            "total_outbox_count": len(all_outbox_files),
+        }
+        if args.summary_only:
+            payload["action_count"] = len(actions)
+            payload["actions_omitted"] = True
+            payload.pop("actions", None)
+        print(json.dumps(payload, indent=2, sort_keys=True))
     return 0
 
 

--- a/tests/scripts/test_reconcile_automation_outbox.py
+++ b/tests/scripts/test_reconcile_automation_outbox.py
@@ -143,6 +143,31 @@ def test_json_output_reports_reconciliation_without_human_preamble(
     assert payload["actions"][0]["branch"] == "codex/json-output"
 
 
+def test_json_summary_only_omits_action_details(
+    tmp_path: Path,
+    capsys: Any,
+) -> None:
+    outbox_dir = tmp_path / ".aragora" / "automation-outbox"
+    receipt_dir = tmp_path / ".aragora" / "automation-receipts"
+    key = "open-pr-codex-summary-only-abc123"
+    _write_outbox_handoff(outbox_dir, branch="codex/summary-only", key=key)
+    receipt_dir.mkdir(parents=True)
+    (receipt_dir / f"{key}.json").write_text(
+        json.dumps({"idempotency_key": key, "status": "published"}),
+        encoding="utf-8",
+    )
+
+    rc = mod.main(["--repo", str(tmp_path), "--json", "--summary-only"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["archived"] == 1
+    assert payload["kept"] == 0
+    assert payload["action_count"] == 1
+    assert payload["actions_omitted"] is True
+    assert "actions" not in payload
+
+
 def test_state_root_can_point_at_direct_dot_aragora(
     tmp_path: Path,
     capsys: Any,


### PR DESCRIPTION
## Summary
- Adds `--summary-only` compact JSON output to `reconcile_automation_outbox.py` on current main.
- Preserves the newer targeted reconciliation and issue-only receipt protections already landed on main.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/scripts/test_reconcile_automation_outbox.py -q -p no:rerunfailures -p no:cacheprovider`
- `python3 -m ruff check scripts/reconcile_automation_outbox.py tests/scripts/test_reconcile_automation_outbox.py`
- `python3 -m ruff format --check scripts/reconcile_automation_outbox.py tests/scripts/test_reconcile_automation_outbox.py`
- `git diff --check origin/main...HEAD && bash scripts/automation_pr_preflight.sh origin/main HEAD`
- `python3 scripts/reconcile_automation_outbox.py --repo /Users/armand/Development/aragora --state-root /Users/armand/Development/aragora/.aragora --dry-run --json --summary-only`

Harvested from Codex automation outbox handoff `open-pr-codex-reconcile-outbox-summary-only-primary-r2-20260521-589d1367.json`, refreshed instead of publishing the stale conflicting head.