### PR TITLE
fix(automation): reconcile merged target PR receipts

### DIFF
--- a/scripts/reconcile_automation_outbox.py
+++ b/scripts/reconcile_automation_outbox.py
@@ -26,6 +26,7 @@ import argparse
 import ast
 import json
 import shutil
+import subprocess
 import sys
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
@@ -250,6 +251,76 @@ def _receipt_has_pr_reference(receipt: Mapping[str, Any]) -> bool:
     return False
 
 
+def _pr_number_from_value(value: Any) -> int | None:
+    text = str(value or "").strip().rstrip("/")
+    if not text:
+        return None
+    if text.isdigit():
+        return int(text)
+    marker = "/pull/"
+    if marker not in text:
+        return None
+    candidate = text.rsplit(marker, 1)[1].split("/", 1)[0]
+    return int(candidate) if candidate.isdigit() else None
+
+
+def _target_pr_number_from_receipt(receipt: Mapping[str, Any]) -> int | None:
+    for key in ("target_pr", "pr_number", "pull_request_number"):
+        number = _pr_number_from_value(receipt.get(key))
+        if number is not None:
+            return number
+    for key in (
+        "created_pr_url",
+        "existing_pr_url",
+        "pr_url",
+        "pull_request_url",
+        "created_pull_request_url",
+        "existing_pull_request_url",
+    ):
+        number = _pr_number_from_value(receipt.get(key))
+        if number is not None:
+            return number
+    return None
+
+
+def _target_pr_state(
+    root: Path,
+    repo_name: str,
+    receipt: Mapping[str, Any],
+) -> Mapping[str, Any] | None:
+    number = _target_pr_number_from_receipt(receipt)
+    if number is None:
+        return None
+    repo = str(receipt.get("repo") or repo_name).strip() or repo_name
+    try:
+        proc = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "view",
+                str(number),
+                "--repo",
+                repo,
+                "--json",
+                "number,state,headRefOid",
+            ],
+            cwd=root,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=20,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if proc.returncode != 0:
+        return None
+    try:
+        payload = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, Mapping) else None
+
+
 def _receipt_has_issue_reference(receipt: Mapping[str, Any]) -> bool:
     for key in (
         "created_issue_url",
@@ -300,6 +371,7 @@ def _git_ref_head(root: Path, ref: str) -> str:
 
 def _receipt_handoff_keep_reason(
     root: Path,
+    repo_name: str,
     payload: dict[str, Any],
     receipt: Mapping[str, Any],
     branch: str,
@@ -314,6 +386,17 @@ def _receipt_handoff_keep_reason(
     desired_head = _desired_head_from_payload(payload)
     if not desired_head:
         return None
+
+    target_pr_state = _target_pr_state(root, repo_name, receipt)
+    if str((target_pr_state or {}).get("state") or "").strip().upper() == "MERGED":
+        target_pr_head = str((target_pr_state or {}).get("headRefOid") or "").strip()
+        target_pr_number = str((target_pr_state or {}).get("number") or "").strip()
+        if _heads_match(desired_head, target_pr_head):
+            return None
+        return (
+            f"target_open_pr receipt points to merged PR #{target_pr_number} at "
+            f"{target_pr_head[:12] or 'unknown'}, not desired head {desired_head[:12]}"
+        )
 
     remote_ref = f"refs/remotes/origin/{branch}"
     remote_head = _git_ref_head(root, remote_ref)
@@ -665,7 +748,9 @@ def main(argv: list[str] | None = None) -> int:
                     }
                 )
                 continue
-            keep_reason = _receipt_handoff_keep_reason(root, payload, receipt, branch)
+            keep_reason = _receipt_handoff_keep_reason(
+                root, args.repo_name, payload, receipt, branch
+            )
             if keep_reason is not None:
                 counts["blocked_receipt_pr_head_mismatch"] += 1
                 counts["still_protecting_active_work"] += 1

--- a/tests/scripts/test_reconcile_automation_outbox.py
+++ b/tests/scripts/test_reconcile_automation_outbox.py
@@ -647,6 +647,7 @@ def test_reconcile_keeps_target_pr_receipt_when_desired_head_not_published(
         raise AssertionError(f"unexpected git call: {args}")
 
     monkeypatch.setattr(mod, "run_git", fake_run_git)
+    monkeypatch.setattr(mod, "_target_pr_state", lambda *_args: None)
     monkeypatch.setattr(
         mod,
         "open_pr_heads",
@@ -662,6 +663,144 @@ def test_reconcile_keeps_target_pr_receipt_when_desired_head_not_published(
     assert payload["counts"]["satisfied_by_existing_receipt"] == 0
     assert payload["counts"]["still_protecting_active_work"] == 1
     assert payload["actions"][0]["decision"] == "keep"
+    assert "not desired head" in payload["actions"][0]["reason"]
+    assert handoff.exists()
+    assert not (tmp_path / ".aragora" / "automation-outbox-archive").exists()
+
+
+def test_reconcile_archives_target_pr_receipt_when_pr_merged_at_desired_head(
+    tmp_path: Path,
+    monkeypatch: Any,
+    capsys: Any,
+) -> None:
+    outbox_dir = tmp_path / ".aragora" / "automation-outbox"
+    receipt_dir = tmp_path / ".aragora" / "automation-receipts"
+    key = "open-pr-codex-target-pr-merged"
+    desired_head = "abcdef1234567890abcdef1234567890abcdef12"
+    handoff = _write_outbox_handoff(
+        outbox_dir,
+        branch="codex/target-pr-merged",
+        key=key,
+        local_evidence={
+            "branch": "codex/target-pr-merged",
+            "desired_head_sha": desired_head,
+        },
+    )
+    receipt_dir.mkdir(parents=True)
+    (receipt_dir / f"{key}.json").write_text(
+        json.dumps(
+            {
+                "idempotency_key": key,
+                "status": "already_satisfied",
+                "reason": "target_open_pr",
+                "existing_pr_url": "https://github.com/synaptent/aragora/pull/7105",
+                "repo": "synaptent/aragora",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        mod,
+        "_target_pr_state",
+        lambda *_args: {
+            "number": 7105,
+            "state": "MERGED",
+            "headRefOid": desired_head,
+        },
+    )
+    monkeypatch.setattr(
+        mod,
+        "run_git",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("git ref checks should not run for merged target PR receipts")
+        ),
+    )
+    monkeypatch.setattr(
+        mod,
+        "open_pr_heads",
+        lambda *_args: (_ for _ in ()).throw(
+            AssertionError("open PR fetch should not run for matched target PR receipts")
+        ),
+    )
+
+    assert mod.main(["--repo", str(tmp_path), "--json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["counts"]["satisfied_by_existing_receipt"] == 1
+    assert payload["counts"]["blocked_receipt_pr_head_mismatch"] == 0
+    assert payload["counts"]["still_protecting_active_work"] == 0
+    assert payload["actions"][0]["decision"] == "archive"
+    assert payload["actions"][0]["reason"] == "matching receipt exists"
+    assert handoff.exists()
+    assert not (tmp_path / ".aragora" / "automation-outbox-archive").exists()
+
+
+def test_reconcile_keeps_target_pr_receipt_when_merged_pr_head_differs(
+    tmp_path: Path,
+    monkeypatch: Any,
+    capsys: Any,
+) -> None:
+    outbox_dir = tmp_path / ".aragora" / "automation-outbox"
+    receipt_dir = tmp_path / ".aragora" / "automation-receipts"
+    key = "open-pr-codex-target-pr-merged-mismatch"
+    desired_head = "abcdef1234567890abcdef1234567890abcdef12"
+    merged_head = "1111111234567890abcdef1234567890abcdef12"
+    handoff = _write_outbox_handoff(
+        outbox_dir,
+        branch="codex/target-pr-merged-mismatch",
+        key=key,
+        local_evidence={
+            "branch": "codex/target-pr-merged-mismatch",
+            "desired_head_sha": desired_head,
+        },
+    )
+    receipt_dir.mkdir(parents=True)
+    (receipt_dir / f"{key}.json").write_text(
+        json.dumps(
+            {
+                "idempotency_key": key,
+                "status": "already_satisfied",
+                "reason": "target_open_pr",
+                "existing_pr_url": "https://github.com/synaptent/aragora/pull/7105",
+                "repo": "synaptent/aragora",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        mod,
+        "_target_pr_state",
+        lambda *_args: {
+            "number": 7105,
+            "state": "MERGED",
+            "headRefOid": merged_head,
+        },
+    )
+    monkeypatch.setattr(
+        mod,
+        "run_git",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("git ref checks should not run for mismatched merged PR receipts")
+        ),
+    )
+    monkeypatch.setattr(
+        mod,
+        "open_pr_heads",
+        lambda *_args: (_ for _ in ()).throw(
+            AssertionError("open PR fetch should not run for mismatched merged PR receipts")
+        ),
+    )
+
+    assert mod.main(["--repo", str(tmp_path), "--json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["counts"]["blocked_receipt_pr_head_mismatch"] == 1
+    assert payload["counts"]["satisfied_by_existing_receipt"] == 0
+    assert payload["counts"]["still_protecting_active_work"] == 1
+    assert payload["actions"][0]["decision"] == "keep"
+    assert "merged PR #7105" in payload["actions"][0]["reason"]
     assert "not desired head" in payload["actions"][0]["reason"]
     assert handoff.exists()
     assert not (tmp_path / ".aragora" / "automation-outbox-archive").exists()


### PR DESCRIPTION
## Summary
- teach `reconcile_automation_outbox.py` to inspect `target_open_pr` receipts that point at merged PRs
- archive the handoff only when the merged PR head matches the handoff's desired head
- keep the previous conservative behavior when the PR state is unavailable, unmerged, or merged at a different head

## Live dry-run evidence
After #7429-#7432 landed, the live outbox still kept #7429 and #7431 because their receipts pointed at merged PRs whose remote branches were unavailable. #7430 is already archived, and #7432 is still recognized by landed-on-main evidence.

Patched dry-run against `/Users/armand/Development/aragora/.aragora`:

```json
{
  "outbox_count": 6,
  "archived": 3,
  "kept": 3,
  "satisfied_by_existing_receipt": 2,
  "satisfied_by_landed_on_main": 1,
  "blocked_receipt_pr_head_mismatch": 0,
  "still_protecting_active_work": 3
}
```

Archive candidates in that dry-run:
- #7429 handoff: matching target PR receipt, PR merged at `e0dd5e2563d1e398ec96a4d6e59a675df45e8565`
- #7431 handoff: matching target PR receipt, PR merged at `1ff5b6bce828111e9df0539a0720b8f98f62f258`
- #7432 handoff: branch work landed on main

Kept handoffs remain protected: doctor secrets, EU AI artifacts, and security-gate product audit.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/scripts/test_reconcile_automation_outbox.py -q -p no:rerunfailures -p no:cacheprovider`
- `python3 -m ruff check scripts/reconcile_automation_outbox.py tests/scripts/test_reconcile_automation_outbox.py`
- `python3 -m ruff format --check scripts/reconcile_automation_outbox.py tests/scripts/test_reconcile_automation_outbox.py`
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- `python3 scripts/reconcile_automation_outbox.py --repo /Users/armand/Development/aragora --state-root /Users/armand/Development/aragora/.aragora --dry-run --json --summary-only`
