### PR TITLE
fix(review-queue): ignore superseded stale check runs

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -123,6 +123,8 @@ TIER_4_PREFIXES: tuple[str, ...] = (
     "aragora/cli/parser.py",
 )
 PARKED_LABELS: tuple[str, ...] = ("stale", "do-not-merge", "wip", "blocked")
+MERGE_QUORUM_CHECK_NAME = "aragora-merge-quorum"
+MERGE_QUORUM_WORKFLOW_NAME = "Aragora Merge Quorum"
 
 LANE_ORDER: dict[str, int] = {
     "ready_now": 0,
@@ -1202,6 +1204,8 @@ def _summarize_checks(checks: list) -> tuple[str, bool, bool]:
     for check in _latest_status_check_rollup(checks):
         if not isinstance(check, dict):
             continue
+        if _is_merge_quorum_self_check(check):
+            continue
         status = str(check.get("status") or check.get("state") or "").upper()
         conclusion = str(check.get("conclusion") or "").upper()
         # Status-context rollups use ``state`` without a separate conclusion.
@@ -1277,6 +1281,15 @@ def _status_check_identity(check: dict[str, Any]) -> str:
     if workflow:
         return f"check-run:{workflow}:{name}"
     return f"status-context:{name}"
+
+
+def _is_merge_quorum_self_check(check: dict[str, Any]) -> bool:
+    """Ignore the merge-quorum workflow's own status while building its packet."""
+    name = str(check.get("name") or check.get("context") or "").strip()
+    if name != MERGE_QUORUM_CHECK_NAME:
+        return False
+    workflow = str(check.get("workflowName") or check.get("workflow") or "").strip()
+    return workflow in {"", MERGE_QUORUM_WORKFLOW_NAME}
 
 
 def _filter_lanes(

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -1199,7 +1199,7 @@ def _classify_pr(pr: dict[str, Any]) -> QueueItem:
 def _summarize_checks(checks: list) -> tuple[str, bool, bool]:
     """Return ``(summary, has_failures, has_pending)`` for a statusCheckRollup."""
     success = failure = pending = 0
-    for check in checks:
+    for check in _latest_status_check_rollup(checks):
         if not isinstance(check, dict):
             continue
         status = str(check.get("status") or check.get("state") or "").upper()
@@ -1237,6 +1237,46 @@ def _summarize_checks(checks: list) -> tuple[str, bool, bool]:
     if success > 0:
         return (f"{success}/{total} green", False, False)
     return ("no checks", False, False)
+
+
+def _latest_status_check_rollup(checks: list) -> list[dict[str, Any]]:
+    """Collapse superseded check-rollup entries to their latest identity.
+
+    GitHub's PR ``statusCheckRollup`` can retain older Actions check runs for
+    the same workflow/job at the current head.  Merge-packet should gate on the
+    latest visible state for a check identity, matching ``gh pr checks``.
+    """
+    latest: dict[str, tuple[str, int, dict[str, Any]]] = {}
+    passthrough: list[dict[str, Any]] = []
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            continue
+        key = _status_check_identity(check)
+        if not key:
+            passthrough.append(check)
+            continue
+        timestamp = str(
+            check.get("completedAt")
+            or check.get("startedAt")
+            or check.get("createdAt")
+            or check.get("updatedAt")
+            or ""
+        )
+        previous = latest.get(key)
+        if previous is None or (timestamp, index) >= (previous[0], previous[1]):
+            latest[key] = (timestamp, index, check)
+    ordered = sorted(latest.values(), key=lambda item: item[1])
+    return passthrough + [item[2] for item in ordered]
+
+
+def _status_check_identity(check: dict[str, Any]) -> str:
+    workflow = str(check.get("workflowName") or check.get("workflow") or "").strip()
+    name = str(check.get("name") or check.get("context") or "").strip()
+    if not name:
+        return ""
+    if workflow:
+        return f"check-run:{workflow}:{name}"
+    return f"status-context:{name}"
 
 
 def _filter_lanes(

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -241,6 +241,61 @@ class TestSummarizeChecks:
         summary, _, _ = _summarize_checks(checks)
         assert "1/1 green" in summary
 
+    def test_superseded_historical_failure_ignored_by_latest_check_identity(self) -> None:
+        checks = [
+            {
+                "name": "build",
+                "workflowName": "Build Documentation (PR Check)",
+                "status": "COMPLETED",
+                "conclusion": "FAILURE",
+                "completedAt": "2026-04-19T00:39:02Z",
+            },
+            {
+                "name": "build",
+                "workflowName": "Build Documentation (PR Check)",
+                "status": "COMPLETED",
+                "conclusion": "SKIPPED",
+                "completedAt": "2026-05-21T15:28:50Z",
+            },
+            {
+                "name": "lint",
+                "workflowName": "Lint",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+                "completedAt": "2026-05-21T15:29:19Z",
+            },
+        ]
+
+        summary, has_fail, has_pending = _summarize_checks(checks)
+
+        assert summary == "1/1 green"
+        assert not has_fail
+        assert not has_pending
+
+    def test_latest_failure_for_same_check_identity_still_blocks(self) -> None:
+        checks = [
+            {
+                "name": "build",
+                "workflowName": "Build Documentation (PR Check)",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+                "completedAt": "2026-05-21T15:28:50Z",
+            },
+            {
+                "name": "build",
+                "workflowName": "Build Documentation (PR Check)",
+                "status": "COMPLETED",
+                "conclusion": "FAILURE",
+                "completedAt": "2026-05-21T15:30:50Z",
+            },
+        ]
+
+        summary, has_fail, has_pending = _summarize_checks(checks)
+
+        assert summary == "1 failing / 1 total"
+        assert has_fail
+        assert not has_pending
+
 
 # --- _classify_pr lane logic -----------------------------------------------
 

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -296,6 +296,71 @@ class TestSummarizeChecks:
         assert has_fail
         assert not has_pending
 
+    def test_merge_quorum_self_check_pending_is_ignored(self) -> None:
+        checks = [
+            {
+                "name": "aragora-merge-quorum",
+                "workflowName": "Aragora Merge Quorum",
+                "status": "IN_PROGRESS",
+                "conclusion": "",
+                "startedAt": "2026-05-22T14:08:46Z",
+            },
+            {
+                "name": "lint",
+                "workflowName": "Lint",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+                "completedAt": "2026-05-22T13:01:00Z",
+            },
+        ]
+
+        summary, has_fail, has_pending = _summarize_checks(checks)
+
+        assert summary == "1/1 green"
+        assert not has_fail
+        assert not has_pending
+
+    def test_merge_quorum_self_check_failure_is_ignored(self) -> None:
+        checks = [
+            {
+                "name": "aragora-merge-quorum",
+                "workflowName": "Aragora Merge Quorum",
+                "status": "COMPLETED",
+                "conclusion": "FAILURE",
+                "completedAt": "2026-05-22T14:09:40Z",
+            },
+            {
+                "name": "Generate & Validate",
+                "workflowName": "OpenAPI Spec",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+                "completedAt": "2026-05-22T12:46:43Z",
+            },
+        ]
+
+        summary, has_fail, has_pending = _summarize_checks(checks)
+
+        assert summary == "1/1 green"
+        assert not has_fail
+        assert not has_pending
+
+    def test_similarly_named_check_in_other_workflow_still_blocks(self) -> None:
+        checks = [
+            {
+                "name": "aragora-merge-quorum",
+                "workflowName": "Release Readiness Gate",
+                "status": "COMPLETED",
+                "conclusion": "FAILURE",
+                "completedAt": "2026-05-22T14:09:40Z",
+            },
+        ]
+
+        summary, has_fail, has_pending = _summarize_checks(checks)
+
+        assert summary == "1 failing / 1 total"
+        assert has_fail
+        assert not has_pending
+
 
 # --- _classify_pr lane logic -----------------------------------------------
 


### PR DESCRIPTION
## Summary
- collapse superseded `statusCheckRollup` entries by check identity before merge-packet summarizes failures
- keep the latest workflow/name or status-context result so stale historical failures do not override current same-head success/skipped states
- add focused tests for the #7409 stale Build Documentation case and for preserving a genuinely latest failing check

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/cli/commands/test_review_queue.py::TestSummarizeChecks -q -p no:cacheprovider`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/cli/commands/test_review_queue.py -q -p no:cacheprovider`
- `python3 -m ruff check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py`
- `python3 -m ruff format --check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py`
- pre-push hooks passed, including `mypy (baseline-filtered)` and gitleaks

## #7409 verification
After this local fix, `python3 -m aragora.cli.main review-queue merge-packet --pr 7409 --json` reports `checks_summary: "15/15 green"` instead of `1 failing / 58 total`. #7409 remains draft and was not marked ready or merged.
