### PR TITLE
fix(review-queue): ignore active merge-quorum self check

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import sqlite3
 import subprocess
 import sys
@@ -31,6 +32,7 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 from aragora.review.invalidation import (
     BaselineMeasurement,
@@ -125,6 +127,7 @@ TIER_4_PREFIXES: tuple[str, ...] = (
 PARKED_LABELS: tuple[str, ...] = ("stale", "do-not-merge", "wip", "blocked")
 MERGE_QUORUM_CHECK_NAME = "aragora-merge-quorum"
 MERGE_QUORUM_WORKFLOW_NAME = "Aragora Merge Quorum"
+MERGE_QUORUM_JOB_ID = "merge-quorum"
 
 LANE_ORDER: dict[str, int] = {
     "ready_now": 0,
@@ -1198,23 +1201,13 @@ def _classify_pr(pr: dict[str, Any]) -> QueueItem:
     )
 
 
-def _is_merge_quorum_self_check(check: dict[str, Any]) -> bool:
-    """Return True for the required check that executes this merge-packet gate."""
-    name_fields = (
-        str(check.get("name") or "").strip().lower(),
-        str(check.get("context") or "").strip().lower(),
-    )
-    workflow_name = str(check.get("workflowName") or "").strip().lower()
-    return "aragora-merge-quorum" in name_fields or workflow_name == "aragora merge quorum"
-
-
 def _summarize_checks(checks: list) -> tuple[str, bool, bool]:
     """Return ``(summary, has_failures, has_pending)`` for a statusCheckRollup."""
     success = failure = pending = 0
     for check in _latest_status_check_rollup(checks):
         if not isinstance(check, dict):
             continue
-        if _is_merge_quorum_self_check(check):
+        if _is_current_merge_quorum_self_check(check):
             continue
         status = str(check.get("status") or check.get("state") or "").upper()
         conclusion = str(check.get("conclusion") or "").upper()
@@ -1293,13 +1286,39 @@ def _status_check_identity(check: dict[str, Any]) -> str:
     return f"status-context:{name}"
 
 
-def _is_merge_quorum_self_check(check: dict[str, Any]) -> bool:
-    """Ignore the merge-quorum workflow's own status while building its packet."""
-    name = str(check.get("name") or check.get("context") or "").strip()
-    if name != MERGE_QUORUM_CHECK_NAME:
-        return False
+def _is_current_merge_quorum_self_check(check: dict[str, Any]) -> bool:
+    """Ignore only this merge-quorum workflow run while building its packet."""
     workflow = str(check.get("workflowName") or check.get("workflow") or "").strip()
-    return workflow in {"", MERGE_QUORUM_WORKFLOW_NAME}
+    name = str(check.get("name") or check.get("context") or "").strip()
+    if workflow != MERGE_QUORUM_WORKFLOW_NAME or name != MERGE_QUORUM_CHECK_NAME:
+        return False
+
+    status = str(check.get("status") or check.get("state") or "").upper()
+    conclusion = str(check.get("conclusion") or "").upper()
+    if conclusion or status not in {"IN_PROGRESS", "QUEUED", "PENDING", "EXPECTED"}:
+        return False
+
+    if os.environ.get("GITHUB_WORKFLOW") != MERGE_QUORUM_WORKFLOW_NAME:
+        return False
+    if os.environ.get("GITHUB_JOB") != MERGE_QUORUM_JOB_ID:
+        return False
+
+    run_id = str(os.environ.get("GITHUB_RUN_ID") or "").strip()
+    repo = str(os.environ.get("GITHUB_REPOSITORY") or "").strip()
+    if not run_id or not repo:
+        return False
+
+    server_url = str(os.environ.get("GITHUB_SERVER_URL") or "https://github.com")
+    details_url = str(check.get("detailsUrl") or check.get("link") or "").strip()
+    parsed_server = urlparse(server_url)
+    parsed_details = urlparse(details_url)
+    expected_path_prefix = f"/{repo}/actions/runs/{run_id}/"
+    return (
+        parsed_details.scheme in {"http", "https"}
+        and bool(parsed_server.netloc)
+        and parsed_details.netloc == parsed_server.netloc
+        and parsed_details.path.startswith(expected_path_prefix)
+    )
 
 
 def _filter_lanes(

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -464,6 +464,140 @@ class TestSummarizeChecks:
         assert has_fail
         assert not has_pending
 
+    def test_merge_quorum_self_check_requires_matching_repo_url(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GITHUB_WORKFLOW", "Aragora Merge Quorum")
+        monkeypatch.setenv("GITHUB_JOB", "merge-quorum")
+        monkeypatch.setenv("GITHUB_RUN_ID", "26311249200")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "synaptent/aragora")
+        monkeypatch.setenv("GITHUB_SERVER_URL", "https://github.com")
+        checks = [
+            {
+                "name": "aragora-merge-quorum",
+                "workflowName": "Aragora Merge Quorum",
+                "status": "IN_PROGRESS",
+                "conclusion": "",
+                "detailsUrl": (
+                    "https://github.com/fork/aragora/actions/runs/26311249200/job/77460233891"
+                ),
+            },
+            {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
+        ]
+
+        summary, has_fail, has_pending = _summarize_checks(checks)
+
+        assert summary == "1 pending / 2 total"
+        assert not has_fail
+        assert has_pending
+
+    def test_merge_quorum_self_check_requires_path_match_not_query(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GITHUB_WORKFLOW", "Aragora Merge Quorum")
+        monkeypatch.setenv("GITHUB_JOB", "merge-quorum")
+        monkeypatch.setenv("GITHUB_RUN_ID", "26311249200")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "synaptent/aragora")
+        checks = [
+            {
+                "name": "aragora-merge-quorum",
+                "workflowName": "Aragora Merge Quorum",
+                "status": "IN_PROGRESS",
+                "conclusion": "",
+                "detailsUrl": (
+                    "https://github.com/synaptent/aragora/pull/7436?"
+                    "next=/synaptent/aragora/actions/runs/26311249200/job/77460233891"
+                ),
+            },
+            {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
+        ]
+
+        summary, has_fail, has_pending = _summarize_checks(checks)
+
+        assert summary == "1 pending / 2 total"
+        assert not has_fail
+        assert has_pending
+
+    def test_merge_quorum_self_check_requires_path_match_not_fragment(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GITHUB_WORKFLOW", "Aragora Merge Quorum")
+        monkeypatch.setenv("GITHUB_JOB", "merge-quorum")
+        monkeypatch.setenv("GITHUB_RUN_ID", "26311249200")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "synaptent/aragora")
+        checks = [
+            {
+                "name": "aragora-merge-quorum",
+                "workflowName": "Aragora Merge Quorum",
+                "status": "IN_PROGRESS",
+                "conclusion": "",
+                "detailsUrl": (
+                    "https://github.com/synaptent/aragora/pull/7436#"
+                    "/synaptent/aragora/actions/runs/26311249200/job/77460233891"
+                ),
+            },
+            {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
+        ]
+
+        summary, has_fail, has_pending = _summarize_checks(checks)
+
+        assert summary == "1 pending / 2 total"
+        assert not has_fail
+        assert has_pending
+
+    def test_merge_quorum_self_check_requires_server_host(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GITHUB_WORKFLOW", "Aragora Merge Quorum")
+        monkeypatch.setenv("GITHUB_JOB", "merge-quorum")
+        monkeypatch.setenv("GITHUB_RUN_ID", "26311249200")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "synaptent/aragora")
+        monkeypatch.setenv("GITHUB_SERVER_URL", "https://github.enterprise.example")
+        checks = [
+            {
+                "name": "aragora-merge-quorum",
+                "workflowName": "Aragora Merge Quorum",
+                "status": "IN_PROGRESS",
+                "conclusion": "",
+                "detailsUrl": (
+                    "https://github.com/synaptent/aragora/actions/runs/26311249200/job/77460233891"
+                ),
+            },
+            {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
+        ]
+
+        summary, has_fail, has_pending = _summarize_checks(checks)
+
+        assert summary == "1 pending / 2 total"
+        assert not has_fail
+        assert has_pending
+
+    def test_merge_quorum_self_check_requires_repository_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GITHUB_WORKFLOW", "Aragora Merge Quorum")
+        monkeypatch.setenv("GITHUB_JOB", "merge-quorum")
+        monkeypatch.setenv("GITHUB_RUN_ID", "26311249200")
+        monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+        checks = [
+            {
+                "name": "aragora-merge-quorum",
+                "workflowName": "Aragora Merge Quorum",
+                "status": "IN_PROGRESS",
+                "conclusion": "",
+                "detailsUrl": (
+                    "https://github.com/synaptent/aragora/actions/runs/26311249200/job/77460233891"
+                ),
+            },
+            {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
+        ]
+
+        summary, has_fail, has_pending = _summarize_checks(checks)
+
+        assert summary == "1 pending / 2 total"
+        assert not has_fail
+        assert has_pending
+
     def test_similarly_named_check_in_other_workflow_still_blocks(self) -> None:
         checks = [
             {

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -230,23 +230,23 @@ class TestSummarizeChecks:
         assert not has_pending
         assert "1/1 green" in summary
 
-    def test_merge_quorum_self_pending_excluded_from_summary(self) -> None:
-        checks = [
-            {"name": "aragora-merge-quorum", "status": "IN_PROGRESS", "conclusion": ""},
-            {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
-        ]
-        summary, has_fail, has_pending = _summarize_checks(checks)
-        assert summary == "1/1 green"
-        assert not has_fail
-        assert not has_pending
-
-    def test_merge_quorum_self_failure_excluded_from_summary(self) -> None:
+    def test_current_merge_quorum_self_check_pending_is_ignored(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GITHUB_WORKFLOW", "Aragora Merge Quorum")
+        monkeypatch.setenv("GITHUB_JOB", "merge-quorum")
+        monkeypatch.setenv("GITHUB_RUN_ID", "26288586838")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "synaptent/aragora")
+        monkeypatch.setenv("GITHUB_SERVER_URL", "https://github.com")
         checks = [
             {
                 "name": "aragora-merge-quorum",
                 "workflowName": "Aragora Merge Quorum",
-                "status": "COMPLETED",
-                "conclusion": "FAILURE",
+                "status": "IN_PROGRESS",
+                "conclusion": "",
+                "detailsUrl": (
+                    "https://github.com/synaptent/aragora/actions/runs/26288586838/job/77396719826"
+                ),
             },
             {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
         ]
@@ -255,9 +255,67 @@ class TestSummarizeChecks:
         assert not has_fail
         assert not has_pending
 
-    def test_unrelated_failure_still_blocks_with_merge_quorum_present(self) -> None:
+    def test_merge_quorum_pending_outside_current_run_still_blocks(self) -> None:
         checks = [
-            {"name": "aragora-merge-quorum", "status": "IN_PROGRESS", "conclusion": ""},
+            {
+                "name": "aragora-merge-quorum",
+                "workflowName": "Aragora Merge Quorum",
+                "status": "IN_PROGRESS",
+                "conclusion": "",
+                "detailsUrl": (
+                    "https://github.com/synaptent/aragora/actions/runs/26288586838/job/77396719826"
+                ),
+            },
+            {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
+        ]
+        summary, has_fail, has_pending = _summarize_checks(checks)
+        assert summary == "1 pending / 2 total"
+        assert not has_fail
+        assert has_pending
+
+    def test_completed_merge_quorum_failure_still_blocks(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GITHUB_WORKFLOW", "Aragora Merge Quorum")
+        monkeypatch.setenv("GITHUB_JOB", "merge-quorum")
+        monkeypatch.setenv("GITHUB_RUN_ID", "26288586838")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "synaptent/aragora")
+        monkeypatch.setenv("GITHUB_SERVER_URL", "https://github.com")
+        checks = [
+            {
+                "name": "aragora-merge-quorum",
+                "workflowName": "Aragora Merge Quorum",
+                "status": "COMPLETED",
+                "conclusion": "FAILURE",
+                "detailsUrl": (
+                    "https://github.com/synaptent/aragora/actions/runs/26288586838/job/77396719826"
+                ),
+            },
+            {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
+        ]
+        summary, has_fail, has_pending = _summarize_checks(checks)
+        assert summary == "1 failing / 2 total"
+        assert has_fail
+        assert not has_pending
+
+    def test_unrelated_failure_still_blocks_with_merge_quorum_present(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GITHUB_WORKFLOW", "Aragora Merge Quorum")
+        monkeypatch.setenv("GITHUB_JOB", "merge-quorum")
+        monkeypatch.setenv("GITHUB_RUN_ID", "26288586838")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "synaptent/aragora")
+        monkeypatch.setenv("GITHUB_SERVER_URL", "https://github.com")
+        checks = [
+            {
+                "name": "aragora-merge-quorum",
+                "workflowName": "Aragora Merge Quorum",
+                "status": "IN_PROGRESS",
+                "conclusion": "",
+                "detailsUrl": (
+                    "https://github.com/synaptent/aragora/actions/runs/26288586838/job/77396719826"
+                ),
+            },
             {"name": "typecheck", "status": "COMPLETED", "conclusion": "FAILURE"},
             {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
         ]
@@ -266,12 +324,23 @@ class TestSummarizeChecks:
         assert has_fail
         assert not has_pending
 
-    def test_unrelated_pending_still_blocks_with_merge_quorum_present(self) -> None:
+    def test_unrelated_pending_still_blocks_with_merge_quorum_present(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GITHUB_WORKFLOW", "Aragora Merge Quorum")
+        monkeypatch.setenv("GITHUB_JOB", "merge-quorum")
+        monkeypatch.setenv("GITHUB_RUN_ID", "26288586838")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "synaptent/aragora")
+        monkeypatch.setenv("GITHUB_SERVER_URL", "https://github.com")
         checks = [
             {
                 "name": "aragora-merge-quorum",
-                "status": "COMPLETED",
-                "conclusion": "FAILURE",
+                "workflowName": "Aragora Merge Quorum",
+                "status": "IN_PROGRESS",
+                "conclusion": "",
+                "detailsUrl": (
+                    "https://github.com/synaptent/aragora/actions/runs/26288586838/job/77396719826"
+                ),
             },
             {"name": "typecheck", "status": "IN_PROGRESS", "conclusion": ""},
             {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
@@ -347,7 +416,7 @@ class TestSummarizeChecks:
         assert has_fail
         assert not has_pending
 
-    def test_merge_quorum_self_check_pending_is_ignored(self) -> None:
+    def test_merge_quorum_self_check_pending_outside_current_run_blocks(self) -> None:
         checks = [
             {
                 "name": "aragora-merge-quorum",
@@ -367,11 +436,11 @@ class TestSummarizeChecks:
 
         summary, has_fail, has_pending = _summarize_checks(checks)
 
-        assert summary == "1/1 green"
+        assert summary == "1 pending / 2 total"
         assert not has_fail
-        assert not has_pending
+        assert has_pending
 
-    def test_merge_quorum_self_check_failure_is_ignored(self) -> None:
+    def test_merge_quorum_self_check_failure_is_preserved(self) -> None:
         checks = [
             {
                 "name": "aragora-merge-quorum",
@@ -391,8 +460,8 @@ class TestSummarizeChecks:
 
         summary, has_fail, has_pending = _summarize_checks(checks)
 
-        assert summary == "1/1 green"
-        assert not has_fail
+        assert summary == "1 failing / 2 total"
+        assert has_fail
         assert not has_pending
 
     def test_similarly_named_check_in_other_workflow_still_blocks(self) -> None:
@@ -1252,7 +1321,7 @@ class TestBuildQueueAndPacket:
         assert packet.machine_recommendation == "approve_candidate"
         assert packet.checks_summary == "2/2 green"
 
-    def test_build_packet_ignores_merge_quorum_self_failure(
+    def test_build_packet_preserves_completed_merge_quorum_failure(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         pr_payload = _make_pr(
@@ -1273,12 +1342,11 @@ class TestBuildQueueAndPacket:
             lambda args: pr_payload,
         )
         packet = _build_packet("6281", repo_override=None)
-        assert packet.machine_recommendation == "approve_candidate"
-        assert packet.checks_summary == "1/1 green"
-        assert not any("checks failing" in flag for flag in packet.risk_flags)
+        assert packet.machine_recommendation == "repair_first"
+        assert packet.checks_summary == "1 failing / 2 total"
+        assert "checks failing (1 failing / 2 total)" in packet.risk_flags
         assert (
-            "checks are failing; repair before settlement"
-            not in packet.model_review_quorum["reasons"]
+            "checks are failing; repair before settlement" in packet.model_review_quorum["reasons"]
         )
 
     def test_build_packet_preserves_non_self_check_failure(
@@ -1303,8 +1371,8 @@ class TestBuildQueueAndPacket:
         )
         packet = _build_packet("6282", repo_override=None)
         assert packet.machine_recommendation == "repair_first"
-        assert packet.checks_summary == "1 failing / 2 total"
-        assert "checks failing (1 failing / 2 total)" in packet.risk_flags
+        assert packet.checks_summary == "2 failing / 3 total"
+        assert "checks failing (2 failing / 3 total)" in packet.risk_flags
         assert (
             "checks are failing; repair before settlement" in packet.model_review_quorum["reasons"]
         )


### PR DESCRIPTION
## Summary
- Ignore only the currently-running Aragora Merge Quorum check when the merge-quorum job evaluates its own PR/head readiness.
- Keep prior completed merge-quorum failures, ordinary pending checks, and ordinary failures fail-closed.
- Add regression coverage for the self-check pending case and the blocking cases.

## Validation
- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/cli/commands/test_review_queue.py -q -p no:cacheprovider
- python3 -m ruff check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py
- python3 -m ruff format --check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py
- python3 -m mypy aragora/cli/commands/review_queue.py --ignore-missing-imports --no-incremental
- bash scripts/automation_pr_preflight.sh origin/main HEAD

This PR does not touch #7295 code, labels, lane registry state, cleanup, launchd, automation.toml, or raw transcripts.