### PR TITLE
fix(scripts): preserve tmux exec prompt metadata

### DIFF
--- a/scripts/tmux_session_launcher.sh
+++ b/scripts/tmux_session_launcher.sh
@@ -225,6 +225,7 @@ fi
 LOG_FILE="${LOG_DIR}/${NAME}.log"
 META_FILE="${LOG_DIR}/${NAME}.meta.json"
 REGISTRY_REPO_ROOT="${ARAGORA_TMUX_REGISTRY_REPO_ROOT:-${REPO_ROOT}}"
+HAS_PROMPT=""
 
 # Ensure tmux session exists
 if ! tmux has-session -t "${TMUX_SESSION}" 2>/dev/null; then
@@ -244,6 +245,10 @@ if [[ -n "${PROMPT_FILE}" ]]; then
     PROMPT="$(cat "${PROMPT_FILE}")"
 fi
 
+if [[ -n "${PROMPT}" ]]; then
+    HAS_PROMPT="yes"
+fi
+
 # Build the launch command
 # When --autonomous is set:
 #   - Claude gets ARAGORA_ADMIN_APPROVED=1 → --dangerously-skip-permissions (can run Bash)
@@ -260,8 +265,9 @@ if [[ "${AGENT}" == "codex" ]]; then
                 printf '%s\n' "${PROMPT}" > "${CODEX_EXEC_PROMPT_FILE}"
             fi
             CODEX_EXEC_PROMPT_FILE="$(cd "$(dirname "${CODEX_EXEC_PROMPT_FILE}")" && pwd)/$(basename "${CODEX_EXEC_PROMPT_FILE}")"
+            PROMPT_FILE="${CODEX_EXEC_PROMPT_FILE}"
             CODEX_EXEC_LAUNCH_FILE="${LOG_DIR}/${NAME}.launch.sh"
-            python3 - "${CODEX_EXEC_LAUNCH_FILE}" "${WORKDIR}" "${NAME}" "${CODEX_EXEC_PROMPT_FILE}" <<'PY'
+            python3 -c '
 import os
 import shlex
 import sys
@@ -285,7 +291,7 @@ body = "\n".join(
 path = Path(launch_file)
 path.write_text(body, encoding="utf-8")
 os.chmod(path, 0o700)
-PY
+' "${CODEX_EXEC_LAUNCH_FILE}" "${WORKDIR}" "${NAME}" "${CODEX_EXEC_PROMPT_FILE}"
             LAUNCH_CMD="bash '${CODEX_EXEC_LAUNCH_FILE}'"
             # `codex exec` consumes the prompt directly; do not also paste it
             # into an interactive pane.
@@ -318,6 +324,7 @@ elif [[ "${AGENT}" == "droid" || "${AGENT}" == "factory" ]]; then
             printf '%s\n' "${PROMPT}" > "${DROID_EXEC_PROMPT_FILE}"
         fi
         DROID_EXEC_PROMPT_FILE="$(cd "$(dirname "${DROID_EXEC_PROMPT_FILE}")" && pwd)/$(basename "${DROID_EXEC_PROMPT_FILE}")"
+        PROMPT_FILE="${DROID_EXEC_PROMPT_FILE}"
         LAUNCH_CMD="cd '${WORKDIR}' && droid exec --auto '${DROID_AUTO_LEVEL}' --cwd '${WORKDIR}' -f '${DROID_EXEC_PROMPT_FILE}'"
         # `droid exec -f` consumes the prompt directly; do not also paste it
         # into an interactive pane.
@@ -401,7 +408,7 @@ try:
     registry_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 except Exception as exc:
     print("warning: failed to register launcher session: " + str(exc), file=sys.stderr)
-' "${NAME}" "${AGENT}" "${LOG_FILE}" "${REPO_ROOT}" "${WORKDIR}" "${PROMPT_FILE}" "${META_FILE}" "${PROMPT:+yes}" "${WINDOW_TARGET}" "${TMUX_SESSION}" "${PANE_INDEX}" "${LAUNCH_CMD}" "${REGISTRY_REPO_ROOT}"
+' "${NAME}" "${AGENT}" "${LOG_FILE}" "${REPO_ROOT}" "${WORKDIR}" "${PROMPT_FILE}" "${META_FILE}" "${HAS_PROMPT}" "${WINDOW_TARGET}" "${TMUX_SESSION}" "${PANE_INDEX}" "${LAUNCH_CMD}" "${REGISTRY_REPO_ROOT}"
 
 echo "Launched '${NAME}' (${AGENT}) in tmux session '${TMUX_SESSION}'"
 echo "  Cwd: ${WORKDIR}"

--- a/tests/scripts/test_tmux_transport_scripts.py
+++ b/tests/scripts/test_tmux_transport_scripts.py
@@ -201,6 +201,13 @@ def test_tmux_session_launcher_autonomous_codex_prompt_uses_exec(
     assert (Path(env["HOME"]) / ".aragora" / "tmux-sessions" / "codex-auto.prompt.md").read_text(
         encoding="utf-8"
     ) == "report git status only\n"
+    meta = json.loads(
+        (Path(env["HOME"]) / ".aragora" / "tmux-sessions" / "codex-auto.meta.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert meta["has_prompt"] is True
+    assert meta["prompt_file"].endswith("codex-auto.prompt.md")
 
 
 def test_tmux_session_launcher_accepts_new_codex_readiness_markers(tmp_path: Path) -> None:
@@ -313,6 +320,14 @@ def test_tmux_session_launcher_supports_droid_agent(tmp_path: Path) -> None:
         for call in calls
     )
     assert not any("review only" in json.dumps(call) for call in calls)
+    meta = json.loads(
+        (Path(env["HOME"]) / ".aragora" / "tmux-sessions" / "factory-review.meta.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert meta["has_prompt"] is True
+    assert meta["prompt_file"].endswith("factory-review.prompt.md")
+    assert Path(meta["prompt_file"]).read_text(encoding="utf-8") == "review only\n"
 
 
 def test_tmux_session_launcher_supports_droid_prompt_file(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- preserve prompt-file metadata for autonomous Codex/Droid tmux launches that consume prompts noninteractively
- keep prompted exec launches from losing the prompt path after the prompt is handed to the runner
- add focused launcher transport coverage

## Outbox handoff
- key: open-pr-codex-harvest-tmux-launcher-prompt-metadata-20260522-b92615ba
- branch: codex/harvest-tmux-launcher-prompt-metadata-20260522
- head: b92615baf0f48ce409ab48d06dfb43ef0e2af81f

## Validation
- git diff --check origin/main...HEAD
- git merge-tree --write-tree origin/main HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- python3 -m pytest tests/scripts/test_tmux_transport_scripts.py
