### PR TITLE
[AGT-05] Three-axis stale-claim policy (decay_penalty / renewal_required / abstain)

### DIFF
--- a/aragora/reputation/stale_policy.py
+++ b/aragora/reputation/stale_policy.py
@@ -17,13 +17,31 @@ This is shadow-only:
   machine-greppable.
 - No production code path calls into this module yet.
 
-A future PR can wire this into ``settle_claim``, the calibration
-leaderboard, and the rev-4 staging scorecard. Until then, this seed
-exists only so the policy surface is reviewable in isolation.
+**Three-axis extension (AGT-05 sub-deliverable — plan:**
+``docs/plans/2026-04-29-agt-05-stale-claim-policy.md``):
+
+When a ``STALE`` verdict is produced by the settlement path the simple
+``is_stale`` predicate does not tell the caller *what to do about it*.
+Treating every stale claim identically as a calibration miss creates a
+false-decay-penalty pathology over time (see plan for full analysis).
+
+:func:`evaluate_stale_axis` introduces a three-band decision based on
+``evidence_age_at_resolution_days`` vs ``half_life_used_days``:
+
+- ``DECAY_PENALTY`` — age < 0.5 × half_life → premature staleness,
+  treat as calibration miss (existing −2 delta)
+- ``RENEWAL_REQUIRED`` — 0.5 ≤ age/half_life < 1.5 → mid-band, issue
+  renewal; delta abstains at 0
+- ``ABSTAIN`` — age ≥ 1.5 × half_life → structural staleness; delta
+  abstains at 0, no penalty
+
+No production code path calls into this yet; wiring into ``settle_claim``
+is a follow-up PR.
 """
 
 from __future__ import annotations
 
+import enum
 import hashlib
 import json
 from dataclasses import dataclass
@@ -165,6 +183,110 @@ def is_stale(
     )
 
 
+# ---------------------------------------------------------------------------
+# Three-axis stale policy (AGT-05 sub-deliverable)
+# ---------------------------------------------------------------------------
+
+# Band boundaries expressed as multiples of half_life_used_days (see plan).
+_DECAY_PENALTY_UPPER = 0.5  # age < 0.5 × half_life → decay penalty
+_ABSTAIN_LOWER = 1.5        # age ≥ 1.5 × half_life → abstain
+
+
+class StaleAxis(str, enum.Enum):
+    """Resolution axis for a STALE claim under the three-band policy.
+
+    Attributes:
+        DECAY_PENALTY: Premature staleness — treat as calibration miss
+            (same −2 delta as an outright failure).
+        RENEWAL_REQUIRED: Mid-band staleness — abstain from delta but
+            record a ``claim_renewal_id`` for downstream re-evidencing.
+        ABSTAIN: Structural staleness — evidence so old that penalising
+            the agent would be unfair; no delta, no renewal obligation.
+    """
+
+    DECAY_PENALTY = "decay_penalty"
+    RENEWAL_REQUIRED = "renewal_required"
+    ABSTAIN = "abstain"
+
+
+@dataclass(frozen=True)
+class StaleAxisDecision:
+    """Outcome of :func:`evaluate_stale_axis`.
+
+    Attributes:
+        axis: One of the three :class:`StaleAxis` values.
+        evidence_age_days: Age of the evidence at resolution time.
+        half_life_used_days: The half-life value used in this evaluation.
+        calibration_delta: Recommended delta (−2 for DECAY_PENALTY, 0
+            for RENEWAL_REQUIRED and ABSTAIN).  Advisory only — callers
+            decide whether to apply it.
+        ratio: ``evidence_age_days / half_life_used_days`` for audit
+            logging; None when ``half_life_used_days`` is zero.
+    """
+
+    axis: StaleAxis
+    evidence_age_days: float
+    half_life_used_days: float
+    calibration_delta: int
+    ratio: float | None
+
+
+def evaluate_stale_axis(
+    evidence_age_days: float,
+    half_life_used_days: float,
+) -> StaleAxisDecision:
+    """Classify a STALE verdict into one of three policy bands.
+
+    Args:
+        evidence_age_days: Age of the underlying evidence at the moment
+            of resolution, expressed in days.  Must be non-negative.
+        half_life_used_days: The half-life the settlement path used when
+            producing the STALE verdict.  Must be positive.
+
+    Returns:
+        A :class:`StaleAxisDecision`.  The decision is advisory; callers
+        are responsible for applying (or ignoring) ``calibration_delta``.
+
+    Raises:
+        ValueError: If ``evidence_age_days`` is negative or
+            ``half_life_used_days`` is non-positive.
+    """
+    if evidence_age_days < 0:
+        raise ValueError(
+            f"evidence_age_days must be non-negative; got {evidence_age_days}"
+        )
+    if half_life_used_days <= 0:
+        raise ValueError(
+            f"half_life_used_days must be positive; got {half_life_used_days}"
+        )
+
+    ratio = evidence_age_days / half_life_used_days
+
+    if ratio < _DECAY_PENALTY_UPPER:
+        return StaleAxisDecision(
+            axis=StaleAxis.DECAY_PENALTY,
+            evidence_age_days=evidence_age_days,
+            half_life_used_days=half_life_used_days,
+            calibration_delta=-2,
+            ratio=ratio,
+        )
+    if ratio < _ABSTAIN_LOWER:
+        return StaleAxisDecision(
+            axis=StaleAxis.RENEWAL_REQUIRED,
+            evidence_age_days=evidence_age_days,
+            half_life_used_days=half_life_used_days,
+            calibration_delta=0,
+            ratio=ratio,
+        )
+    return StaleAxisDecision(
+        axis=StaleAxis.ABSTAIN,
+        evidence_age_days=evidence_age_days,
+        half_life_used_days=half_life_used_days,
+        calibration_delta=0,
+        ratio=ratio,
+    )
+
+
 __all__ = [
     "DEFAULT_FRESH_DAYS",
     "DEFAULT_STALE_DAYS",
@@ -172,4 +294,8 @@ __all__ = [
     "StalePolicy",
     "StaleDecision",
     "is_stale",
+    # Three-axis extension
+    "StaleAxis",
+    "StaleAxisDecision",
+    "evaluate_stale_axis",
 ]

--- a/aragora/reputation/stale_policy.py
+++ b/aragora/reputation/stale_policy.py
@@ -189,7 +189,7 @@ def is_stale(
 
 # Band boundaries expressed as multiples of half_life_used_days (see plan).
 _DECAY_PENALTY_UPPER = 0.5  # age < 0.5 × half_life → decay penalty
-_ABSTAIN_LOWER = 1.5        # age ≥ 1.5 × half_life → abstain
+_ABSTAIN_LOWER = 1.5  # age ≥ 1.5 × half_life → abstain
 
 
 class StaleAxis(str, enum.Enum):
@@ -252,13 +252,9 @@ def evaluate_stale_axis(
             ``half_life_used_days`` is non-positive.
     """
     if evidence_age_days < 0:
-        raise ValueError(
-            f"evidence_age_days must be non-negative; got {evidence_age_days}"
-        )
+        raise ValueError(f"evidence_age_days must be non-negative; got {evidence_age_days}")
     if half_life_used_days <= 0:
-        raise ValueError(
-            f"half_life_used_days must be positive; got {half_life_used_days}"
-        )
+        raise ValueError(f"half_life_used_days must be positive; got {half_life_used_days}")
 
     ratio = evidence_age_days / half_life_used_days
 

--- a/tests/reputation/test_stale_axis_policy.py
+++ b/tests/reputation/test_stale_axis_policy.py
@@ -1,0 +1,157 @@
+"""Tests for the AGT-05 three-axis stale-claim policy.
+
+Covers evaluate_stale_axis() across all three bands (DECAY_PENALTY,
+RENEWAL_REQUIRED, ABSTAIN), boundary conditions, and invalid inputs.
+
+Shadow-only: no production wiring, no live queue effect.
+Advances: AGT-05 (#6066), docs/plans/2026-04-29-agt-05-stale-claim-policy.md
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.reputation.stale_policy import (
+    StaleAxis,
+    StaleAxisDecision,
+    evaluate_stale_axis,
+)
+
+
+def _call(age: float, half_life: float = 30.0) -> StaleAxisDecision:
+    return evaluate_stale_axis(age, half_life)
+
+
+# ---------------------------------------------------------------------------
+# DECAY_PENALTY band  (age < 0.5 × half_life)
+# ---------------------------------------------------------------------------
+
+
+class TestDecayPenaltyBand:
+    def test_zero_age_is_decay_penalty(self) -> None:
+        assert _call(age=0.0).axis is StaleAxis.DECAY_PENALTY
+
+    def test_calibration_delta_is_minus_two(self) -> None:
+        assert _call(age=5.0).calibration_delta == -2
+
+    def test_just_below_boundary_is_decay_penalty(self) -> None:
+        assert _call(age=14.999).axis is StaleAxis.DECAY_PENALTY
+
+    def test_ratio_stored_correctly(self) -> None:
+        assert _call(age=6.0).ratio == pytest.approx(6.0 / 30.0)
+
+    def test_fields_round_trip(self) -> None:
+        d = _call(age=7.5)
+        assert d.evidence_age_days == 7.5
+        assert d.half_life_used_days == 30.0
+
+
+# ---------------------------------------------------------------------------
+# RENEWAL_REQUIRED band  (0.5 × half_life ≤ age < 1.5 × half_life)
+# ---------------------------------------------------------------------------
+
+
+class TestRenewalRequiredBand:
+    def test_at_lower_boundary(self) -> None:
+        assert _call(age=15.0).axis is StaleAxis.RENEWAL_REQUIRED
+
+    def test_midband(self) -> None:
+        assert _call(age=25.0).axis is StaleAxis.RENEWAL_REQUIRED
+
+    def test_just_below_upper_boundary(self) -> None:
+        assert _call(age=44.999).axis is StaleAxis.RENEWAL_REQUIRED
+
+    def test_calibration_delta_is_zero(self) -> None:
+        assert _call(age=20.0).calibration_delta == 0
+
+    def test_ratio_at_lower_boundary(self) -> None:
+        assert _call(age=15.0).ratio == pytest.approx(0.5)
+
+    def test_non_default_half_life(self) -> None:
+        assert _call(age=7.0, half_life=7.0).axis is StaleAxis.RENEWAL_REQUIRED
+
+
+# ---------------------------------------------------------------------------
+# ABSTAIN band  (age ≥ 1.5 × half_life)
+# ---------------------------------------------------------------------------
+
+
+class TestAbstainBand:
+    def test_at_lower_boundary(self) -> None:
+        assert _call(age=45.0).axis is StaleAxis.ABSTAIN
+
+    def test_well_above_boundary(self) -> None:
+        assert _call(age=180.0).axis is StaleAxis.ABSTAIN
+
+    def test_calibration_delta_is_zero(self) -> None:
+        assert _call(age=90.0).calibration_delta == 0
+
+    def test_ratio_at_boundary(self) -> None:
+        assert _call(age=45.0).ratio == pytest.approx(1.5)
+
+    def test_short_half_life_abstain(self) -> None:
+        assert _call(age=4.0, half_life=2.0).axis is StaleAxis.ABSTAIN
+
+
+# ---------------------------------------------------------------------------
+# Boundary contiguity — bands are contiguous and non-overlapping
+# ---------------------------------------------------------------------------
+
+
+class TestBandContiguity:
+    @pytest.mark.parametrize("half_life", [7.0, 14.0, 30.0, 90.0])
+    def test_lower_boundary_is_renewal_not_decay(self, half_life: float) -> None:
+        assert _call(0.5 * half_life, half_life).axis is StaleAxis.RENEWAL_REQUIRED
+
+    @pytest.mark.parametrize("half_life", [7.0, 14.0, 30.0, 90.0])
+    def test_upper_boundary_is_abstain_not_renewal(self, half_life: float) -> None:
+        assert _call(1.5 * half_life, half_life).axis is StaleAxis.ABSTAIN
+
+    def test_three_adjacent_samples(self) -> None:
+        hl = 20.0
+        assert _call(9.0, hl).axis is StaleAxis.DECAY_PENALTY
+        assert _call(10.0, hl).axis is StaleAxis.RENEWAL_REQUIRED
+        assert _call(30.0, hl).axis is StaleAxis.ABSTAIN
+
+
+# ---------------------------------------------------------------------------
+# Full field verification
+# ---------------------------------------------------------------------------
+
+
+class TestDecisionFields:
+    def test_decay_penalty_all_fields(self) -> None:
+        d = evaluate_stale_axis(evidence_age_days=5.0, half_life_used_days=30.0)
+        assert d.axis is StaleAxis.DECAY_PENALTY
+        assert d.evidence_age_days == 5.0
+        assert d.half_life_used_days == 30.0
+        assert d.calibration_delta == -2
+        assert d.ratio == pytest.approx(5.0 / 30.0)
+
+    def test_abstain_all_fields(self) -> None:
+        d = evaluate_stale_axis(evidence_age_days=60.0, half_life_used_days=30.0)
+        assert d.axis is StaleAxis.ABSTAIN
+        assert d.calibration_delta == 0
+        assert d.ratio == pytest.approx(2.0)
+
+
+# ---------------------------------------------------------------------------
+# Invalid inputs
+# ---------------------------------------------------------------------------
+
+
+class TestInvalidInputs:
+    def test_negative_age_raises(self) -> None:
+        with pytest.raises(ValueError, match="evidence_age_days"):
+            evaluate_stale_axis(-1.0, 30.0)
+
+    def test_zero_half_life_raises(self) -> None:
+        with pytest.raises(ValueError, match="half_life_used_days"):
+            evaluate_stale_axis(10.0, 0.0)
+
+    def test_negative_half_life_raises(self) -> None:
+        with pytest.raises(ValueError, match="half_life_used_days"):
+            evaluate_stale_axis(10.0, -5.0)
+
+    def test_zero_age_is_valid(self) -> None:
+        assert evaluate_stale_axis(0.0, 30.0).axis is StaleAxis.DECAY_PENALTY


### PR DESCRIPTION
## Slice

Extends `aragora/reputation/stale_policy.py` with a three-band axis evaluation (`evaluate_stale_axis`) that classifies a STALE settlement verdict by _why_ the claim is stale — distinguishing premature staleness (calibration miss) from mid-band decay (evidence renewal needed) from structural staleness (abstain). The existing `is_stale()` two-tier predicate is untouched; this adds new symbols only.

Plan: `docs/plans/2026-04-29-agt-05-stale-claim-policy.md`

## Gating

- Default: OFF — shadow-only; no production code path calls `evaluate_stale_axis` yet
- Live queue effect: none — pure in-memory function, no dispatch or settle_claim wiring
- Advances issue: #6066 (AGT-05: skin-in-the-game reputation flow)

## Tests

- `TestDecayPenaltyBand` — zero age, delta=-2, just-below-boundary, ratio, fields
- `TestRenewalRequiredBand` — at-boundary, midband, just-below-upper, delta=0, ratio, non-default half-life
- `TestAbstainBand` — at-boundary, well-above, delta=0, ratio, short half-life
- `TestBandContiguity` — parametrized over 4 half-life values; confirms lower boundary is RENEWAL not DECAY, upper boundary is ABSTAIN not RENEWAL; three-sample adjacency test
- `TestDecisionFields` — all fields on DECAY_PENALTY and ABSTAIN outputs
- `TestInvalidInputs` — negative age, zero half_life, negative half_life, zero age valid

## Validation

- `pytest tests/reputation/test_stale_axis_policy.py` — 31 passed
- `pytest tests/reputation/test_stale_policy.py` — 17 passed (no regression)
- `ruff check aragora/reputation/stale_policy.py tests/reputation/test_stale_axis_policy.py` — clean
- Net diff: 283 LOC (132 added to stale_policy.py, 157-line new test file, 3 lines replaced in `__all__`)

## Out of scope

- Wiring `evaluate_stale_axis` into `settle_claim` is the explicit follow-on slice (plan §pseudocode)
- Calibration leaderboard and rev-4 staging scorecard integration deferred to that same follow-on
- On-chain anchoring via `ReputationRegistry` is a separate track


---
_Generated by [Claude Code](https://claude.ai/code/session_01EQURFjPJp9CzPvxN8jiE74)_