### PR TITLE
feat(scripts): audit merged PR lane rows

### DIFF
--- a/scripts/resolve_lane_conflicts.py
+++ b/scripts/resolve_lane_conflicts.py
@@ -13,6 +13,7 @@ import datetime as dt
 import json
 import os
 import secrets
+import subprocess
 import sys
 import tempfile
 from collections.abc import Iterator
@@ -31,6 +32,7 @@ DEFAULT_REPO_ROOT = Path(__file__).resolve().parents[1]
 REGISTRY_RELATIVE_PATH = Path(".aragora") / "agent-bridge" / "lanes.json"
 RECEIPT_RELATIVE_DIR = Path(".aragora") / "agent-bridge" / "conflict-resolution-receipts"
 RECEIPT_SCHEMA_VERSION = "aragora-lane-conflict-resolution/1.0"
+MERGED_PR_RECEIPT_SCHEMA_VERSION = "aragora-merged-pr-lane-audit/1.0"
 ACTIVE_STATUSES = {
     "active",
     "running",
@@ -167,6 +169,351 @@ def _write_receipt(
     return path
 
 
+def _coerce_int(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _merge_commit_oid(payload: dict[str, Any]) -> str:
+    merge_commit = payload.get("mergeCommit")
+    if isinstance(merge_commit, dict):
+        return str(merge_commit.get("oid") or "").strip()
+    return ""
+
+
+def _fetch_pr_state(*, pr: int, gh_bin: str) -> dict[str, Any]:
+    cmd = [
+        gh_bin,
+        "pr",
+        "view",
+        str(pr),
+        "--json",
+        "number,state,headRefOid,mergedAt,mergeCommit,url",
+    ]
+    try:
+        proc = subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return {
+            "available": False,
+            "state": None,
+            "error": str(exc),
+            "command": cmd,
+        }
+    if proc.returncode != 0:
+        return {
+            "available": False,
+            "state": None,
+            "error": proc.stderr.strip() or proc.stdout.strip(),
+            "returncode": proc.returncode,
+            "command": cmd,
+        }
+    try:
+        payload = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        return {
+            "available": False,
+            "state": None,
+            "error": f"invalid gh json: {exc}",
+            "command": cmd,
+        }
+    if not isinstance(payload, dict):
+        return {
+            "available": False,
+            "state": None,
+            "error": "gh pr view returned non-object JSON",
+            "command": cmd,
+        }
+    return {
+        "available": True,
+        "number": _coerce_int(payload.get("number")),
+        "state": str(payload.get("state") or "").upper(),
+        "headRefOid": str(payload.get("headRefOid") or ""),
+        "mergedAt": payload.get("mergedAt"),
+        "mergeCommit": _merge_commit_oid(payload),
+        "url": str(payload.get("url") or ""),
+        "command": cmd,
+    }
+
+
+def _active_pr_lane_findings(rows: list[dict[str, Any]], *, pr: int) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    for row in rows:
+        if _coerce_int(row.get("pr_number")) != pr:
+            continue
+        status = str(row.get("status") or "")
+        if status not in ACTIVE_STATUSES:
+            continue
+        findings.append(
+            {
+                "lane_id": row.get("lane_id"),
+                "owner_session": row.get("owner_session"),
+                "status": status,
+                "branch": row.get("branch"),
+                "worktree": row.get("worktree"),
+                "next_action": row.get("next_action"),
+                "updated_at": row.get("updated_at"),
+                "last_heartbeat_at": row.get("last_heartbeat_at"),
+                "last_steering_outcome": row.get("last_steering_outcome"),
+                "pr_number": pr,
+            }
+        )
+    return findings
+
+
+def _quote_shell_arg(value: Any) -> str:
+    text = str(value or "")
+    return "'" + text.replace("'", "'\"'\"'") + "'"
+
+
+def _steering_body(*, pr: int, github_state: dict[str, Any]) -> str:
+    merge_commit = github_state.get("mergeCommit") or ""
+    head = github_state.get("headRefOid") or ""
+    merged_at = github_state.get("mergedAt") or ""
+    return (
+        f"PR #{pr} is already merged at {merge_commit} from head {head} "
+        f"(merged_at={merged_at}). Please mark this lane completed, released, "
+        "or superseded via claim_active_agent_lane.py; do not continue PR "
+        "mutation work on this already-merged target."
+    )
+
+
+def _owner_steering_commands(
+    *,
+    findings: list[dict[str, Any]],
+    pr: int,
+    github_state: dict[str, Any],
+) -> list[str]:
+    body = _quote_shell_arg(_steering_body(pr=pr, github_state=github_state))
+    commands: list[str] = []
+    for finding in findings:
+        owner = finding.get("owner_session")
+        lane_id = finding.get("lane_id")
+        if not owner:
+            continue
+        cmd = (
+            f"python3 scripts/send_operator_steering.py --to {owner} "
+            f"--pr {pr} --priority blocking --body {body}"
+        )
+        if lane_id:
+            cmd += f" --lane-id {lane_id}"
+        commands.append(cmd)
+    return commands
+
+
+def _owner_release_commands(
+    *,
+    findings: list[dict[str, Any]],
+    pr: int,
+    github_state: dict[str, Any],
+) -> list[str]:
+    merge_commit = github_state.get("mergeCommit") or ""
+    next_action = _quote_shell_arg(
+        f"superseded after PR #{pr} merged at {merge_commit}; no further PR mutation"
+    )
+    commands: list[str] = []
+    for finding in findings:
+        lane_id = finding.get("lane_id")
+        owner = finding.get("owner_session")
+        if not lane_id or not owner:
+            continue
+        commands.append(
+            "python3 scripts/claim_active_agent_lane.py "
+            f"--lane-id {lane_id} --owner-session {owner} "
+            f"--status superseded --pr-number {pr} "
+            f"--next-action {next_action} --json"
+        )
+    return commands
+
+
+def _operator_apply_command(
+    *,
+    pr: int,
+    registry_path: Path,
+    receipt_dir: Path,
+    expected_merge_commit: str,
+) -> str:
+    commit_arg = expected_merge_commit or "<merge-commit-sha>"
+    return (
+        "python3 scripts/resolve_lane_conflicts.py --merged-pr-lane-audit "
+        f"--pr {pr} --expected-merge-commit {commit_arg} --operator-authorized "
+        f"--registry-path {registry_path} --receipt-dir {receipt_dir} --apply --json"
+    )
+
+
+def _base_merged_pr_audit_result(
+    *,
+    registry_path: Path,
+    receipt_dir: Path,
+    pr: int,
+    apply: bool,
+    operator_authorized: bool,
+    expected_merge_commit: str | None,
+    github_state: dict[str, Any],
+    findings: list[dict[str, Any]],
+    blocked_reason: str | None,
+) -> dict[str, Any]:
+    merge_commit = str(github_state.get("mergeCommit") or "")
+    expected = str(expected_merge_commit or "")
+    apply_eligible = (
+        apply
+        and operator_authorized
+        and bool(expected)
+        and bool(findings)
+        and github_state.get("available") is True
+        and github_state.get("state") == "MERGED"
+        and merge_commit == expected
+    )
+    return {
+        "mode": "merged_pr_lane_audit",
+        "registry_path": str(registry_path),
+        "receipt_dir": str(receipt_dir),
+        "dry_run": not apply,
+        "pr_number": pr,
+        "github_state": github_state,
+        "finding_count": len(findings),
+        "findings": findings,
+        "owner_steering_text": "\n".join(
+            _owner_steering_commands(findings=findings, pr=pr, github_state=github_state)
+        ),
+        "owner_release_commands": _owner_release_commands(
+            findings=findings,
+            pr=pr,
+            github_state=github_state,
+        ),
+        "operator_apply_command": _operator_apply_command(
+            pr=pr,
+            registry_path=registry_path,
+            receipt_dir=receipt_dir,
+            expected_merge_commit=merge_commit or expected,
+        ),
+        "requires_operator_authorization": True,
+        "operator_authorized": operator_authorized,
+        "expected_merge_commit": expected,
+        "apply_eligible": apply_eligible,
+        "blocked_reason": blocked_reason,
+        "resolved_count": 0,
+        "receipt_paths": [],
+    }
+
+
+def _merged_pr_audit_blocked_reason(
+    *,
+    apply: bool,
+    operator_authorized: bool,
+    expected_merge_commit: str | None,
+    github_state: dict[str, Any],
+    findings: list[dict[str, Any]],
+) -> str | None:
+    if github_state.get("available") is not True:
+        return "github_state_unavailable"
+    if github_state.get("state") != "MERGED":
+        return "pr_not_merged"
+    if not findings:
+        return "no_active_lanes_for_merged_pr"
+    if not apply:
+        return None
+    if not operator_authorized:
+        return "operator_authorization_required"
+    expected = str(expected_merge_commit or "")
+    if not expected:
+        return "expected_merge_commit_required"
+    if str(github_state.get("mergeCommit") or "") != expected:
+        return "merge_commit_mismatch"
+    return None
+
+
+def audit_merged_pr_lanes(
+    *,
+    registry_path: Path,
+    receipt_dir: Path,
+    pr: int,
+    gh_bin: str = "gh",
+    apply: bool = False,
+    operator_authorized: bool = False,
+    expected_merge_commit: str | None = None,
+    resolved_at: str | None = None,
+) -> dict[str, Any]:
+    """Audit active/blocked lane rows for an already-merged PR.
+
+    Dry-run mode never mutates. Apply mode requires explicit operator
+    authorization and an exact merge-commit guard before superseding active
+    lifecycle rows.
+    """
+
+    resolved_at = resolved_at or _utc_now_iso()
+    github_state = _fetch_pr_state(pr=pr, gh_bin=gh_bin)
+    with _registry_write_lock(registry_path):
+        rows = _read_rows(registry_path)
+        findings: list[dict[str, Any]] = []
+        if github_state.get("available") is True and github_state.get("state") == "MERGED":
+            findings = _active_pr_lane_findings(rows, pr=pr)
+        blocked_reason = _merged_pr_audit_blocked_reason(
+            apply=apply,
+            operator_authorized=operator_authorized,
+            expected_merge_commit=expected_merge_commit,
+            github_state=github_state,
+            findings=findings,
+        )
+        result = _base_merged_pr_audit_result(
+            registry_path=registry_path,
+            receipt_dir=receipt_dir,
+            pr=pr,
+            apply=apply,
+            operator_authorized=operator_authorized,
+            expected_merge_commit=expected_merge_commit,
+            github_state=github_state,
+            findings=findings,
+            blocked_reason=blocked_reason,
+        )
+        if not result["apply_eligible"]:
+            return result
+
+        target_keys = {
+            (str(finding.get("lane_id") or ""), str(finding.get("owner_session") or ""))
+            for finding in findings
+        }
+        receipt_paths: list[str] = []
+        out_rows: list[dict[str, Any]] = []
+        for row in rows:
+            row = dict(row)
+            row_key = (str(row.get("lane_id") or ""), str(row.get("owner_session") or ""))
+            row_pr = _coerce_int(row.get("pr_number"))
+            old_status = str(row.get("status") or "")
+            if row_key in target_keys and row_pr == pr and old_status in ACTIVE_STATUSES:
+                row["status"] = "superseded"
+                row["updated_at"] = resolved_at
+                row["last_steering_outcome"] = "superseded"
+                receipt = {
+                    "schema_version": MERGED_PR_RECEIPT_SCHEMA_VERSION,
+                    "lane_id": row.get("lane_id"),
+                    "owner_session": row.get("owner_session"),
+                    "pr_number": pr,
+                    "head_sha": github_state.get("headRefOid"),
+                    "merge_commit": github_state.get("mergeCommit"),
+                    "merged_at": github_state.get("mergedAt"),
+                    "old_status": old_status,
+                    "new_status": "superseded",
+                    "resolved_at_utc": resolved_at,
+                    "resolution": "merged_pr_has_active_lane_row",
+                }
+                receipt_paths.append(str(_write_receipt(receipt_dir=receipt_dir, receipt=receipt)))
+            out_rows.append(row)
+        _atomic_write(registry_path, out_rows)
+        result["resolved_count"] = len(receipt_paths)
+        result["receipt_paths"] = receipt_paths
+        result["blocked_reason"] = None
+        return result
+
+
 def resolve_conflicts(
     *,
     registry_path: Path,
@@ -236,6 +583,27 @@ def build_parser() -> argparse.ArgumentParser:
     action.add_argument("--dry-run", action="store_true", default=True)
     action.add_argument("--apply", action="store_true")
     parser.add_argument(
+        "--merged-pr-lane-audit",
+        action="store_true",
+        help="Audit active/blocked lane rows for an already-merged PR.",
+    )
+    parser.add_argument("--pr", type=int, help="PR number for --merged-pr-lane-audit.")
+    parser.add_argument(
+        "--gh-bin",
+        default="gh",
+        help="GitHub CLI executable for read-only PR state lookup.",
+    )
+    parser.add_argument(
+        "--expected-merge-commit",
+        default="",
+        help="Exact merge commit required for authorized merged-PR apply mode.",
+    )
+    parser.add_argument(
+        "--operator-authorized",
+        action="store_true",
+        help="Required with --apply in merged-PR lane audit mode.",
+    )
+    parser.add_argument(
         "--registry-path",
         type=Path,
         default=DEFAULT_REPO_ROOT / REGISTRY_RELATIVE_PATH,
@@ -251,6 +619,44 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    if args.merged_pr_lane_audit:
+        if args.pr is None:
+            result = {
+                "mode": "merged_pr_lane_audit",
+                "blocked_reason": "pr_required",
+                "resolved_count": 0,
+                "receipt_paths": [],
+            }
+            if args.json:
+                print(json.dumps(result, indent=2, sort_keys=True))
+            else:
+                print("blocked: --pr is required for --merged-pr-lane-audit")
+            return 2
+        result = audit_merged_pr_lanes(
+            registry_path=args.registry_path,
+            receipt_dir=args.receipt_dir,
+            pr=args.pr,
+            gh_bin=args.gh_bin,
+            apply=bool(args.apply),
+            operator_authorized=bool(args.operator_authorized),
+            expected_merge_commit=args.expected_merge_commit,
+        )
+        if args.json:
+            print(json.dumps(result, indent=2, sort_keys=True))
+        else:
+            if result.get("blocked_reason"):
+                print(f"blocked={result['blocked_reason']}")
+            print(f"finding_count={result['finding_count']}")
+            if result.get("owner_steering_text"):
+                print(result["owner_steering_text"])
+            for command in result.get("owner_release_commands") or []:
+                print(command)
+            if result.get("operator_apply_command"):
+                print(result["operator_apply_command"])
+        if args.apply and result.get("resolved_count", 0) == 0:
+            return 2
+        return 0
+
     result = resolve_conflicts(
         registry_path=args.registry_path,
         receipt_dir=args.receipt_dir,

--- a/scripts/resolve_lane_conflicts.py
+++ b/scripts/resolve_lane_conflicts.py
@@ -649,8 +649,10 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(f"finding_count={result['finding_count']}")
             if result.get("owner_steering_text"):
                 print(result["owner_steering_text"])
-            for command in result.get("owner_release_commands") or []:
-                print(command)
+            owner_release_commands = result.get("owner_release_commands")
+            if isinstance(owner_release_commands, list):
+                for command in owner_release_commands:
+                    print(command)
             if result.get("operator_apply_command"):
                 print(result["operator_apply_command"])
         if args.apply and result.get("resolved_count", 0) == 0:
@@ -667,11 +669,15 @@ def main(argv: Sequence[str] | None = None) -> int:
     else:
         verb = "resolved" if args.apply else "candidate"
         print(f"{verb}_count={result['resolved_count' if args.apply else 'candidate_count']}")
-        for candidate in result["candidates"]:
-            print(
-                f"- lane_id={candidate['lane_id']} conflict_session="
-                f"{candidate['conflict_session']} -> superseded"
-            )
+        candidates = result.get("candidates")
+        if isinstance(candidates, list):
+            for candidate in candidates:
+                if not isinstance(candidate, dict):
+                    continue
+                print(
+                    f"- lane_id={candidate['lane_id']} conflict_session="
+                    f"{candidate['conflict_session']} -> superseded"
+                )
     return 0
 
 

--- a/tests/scripts/test_resolve_lane_conflicts.py
+++ b/tests/scripts/test_resolve_lane_conflicts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -24,6 +25,27 @@ def _load_module(script_name: str) -> Any:
 
 resolver = _load_module("resolve_lane_conflicts.py")
 SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "resolve_lane_conflicts.py"
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _fake_gh(tmp_path: Path, payload: dict[str, Any], *, exit_code: int = 0) -> Path:
+    gh = tmp_path / "fake-gh"
+    gh.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, sys\n"
+        f"payload = {json.dumps(payload)!r}\n"
+        f"exit_code = {exit_code!r}\n"
+        "if exit_code:\n"
+        "    print('gh unavailable', file=sys.stderr)\n"
+        "    raise SystemExit(exit_code)\n"
+        "print(payload)\n",
+        encoding="utf-8",
+    )
+    gh.chmod(0o755)
+    return gh
 
 
 def test_detects_completed_owner_conflict_without_mutating(tmp_path: Path) -> None:
@@ -188,3 +210,326 @@ def test_concurrent_apply_preserves_registry_json(tmp_path: Path) -> None:
     payload = json.loads(registry.read_text(encoding="utf-8"))
     by_lane = {row["lane_id"]: row for row in payload}
     assert all(by_lane[f"conflict-{idx:02d}"]["status"] == "superseded" for idx in range(8))
+
+
+def test_merged_pr_audit_reports_active_rows_without_mutating(tmp_path: Path) -> None:
+    registry = tmp_path / "lanes.json"
+    receipt_dir = tmp_path / "receipts"
+    _write_json(
+        registry,
+        [
+            {
+                "lane_id": "codex-7435-tier0-settlement",
+                "owner_session": "codex-a",
+                "status": "blocked",
+                "branch": "worktree-queue-drain-final",
+                "worktree": "/repo",
+                "pr_number": 7435,
+            },
+            {
+                "lane_id": "codex-7435-repair-settle",
+                "owner_session": "codex-b",
+                "status": "active",
+                "branch": "worktree-queue-drain-final",
+                "worktree": "/repo/.claude/worktrees/queue-drain-final",
+                "pr_number": 7435,
+            },
+            {
+                "lane_id": "done",
+                "owner_session": "codex-done",
+                "status": "completed",
+                "pr_number": 7435,
+            },
+            {
+                "lane_id": "missing-pr",
+                "owner_session": "codex-missing-pr",
+                "status": "active",
+            },
+        ],
+    )
+    gh = _fake_gh(
+        tmp_path,
+        {
+            "number": 7435,
+            "state": "MERGED",
+            "headRefOid": "96ea60500851ac459aa542a0d31afc06d92c288a",
+            "mergedAt": "2026-05-23T19:16:23Z",
+            "mergeCommit": {"oid": "4e8b21e98a0ddbcb383d9c92e6c20b343e49d151"},
+            "url": "https://github.com/synaptent/aragora/pull/7435",
+        },
+    )
+
+    result = resolver.audit_merged_pr_lanes(
+        registry_path=registry,
+        receipt_dir=receipt_dir,
+        pr=7435,
+        gh_bin=str(gh),
+        apply=False,
+    )
+
+    assert result["github_state"]["state"] == "MERGED"
+    assert result["finding_count"] == 2
+    assert result["requires_operator_authorization"] is True
+    assert result["apply_eligible"] is False
+    assert result["receipt_paths"] == []
+    assert "send_operator_steering.py --to codex-a" in result["owner_steering_text"]
+    assert (
+        "claim_active_agent_lane.py --lane-id codex-7435-tier0-settlement"
+        in result["owner_release_commands"][0]
+    )
+    rows = json.loads(registry.read_text(encoding="utf-8"))
+    assert [row["status"] for row in rows] == ["blocked", "active", "completed", "active"]
+
+
+def test_merged_pr_audit_ignores_open_and_unmerged_prs(tmp_path: Path) -> None:
+    registry = tmp_path / "lanes.json"
+    _write_json(
+        registry,
+        [
+            {
+                "lane_id": "codex-open",
+                "owner_session": "codex-open",
+                "status": "active",
+                "pr_number": 7441,
+            },
+            {
+                "lane_id": "no-pr",
+                "owner_session": "codex-no-pr",
+                "status": "active",
+            },
+        ],
+    )
+    gh = _fake_gh(
+        tmp_path,
+        {
+            "number": 7441,
+            "state": "OPEN",
+            "headRefOid": "abc",
+            "mergedAt": None,
+            "mergeCommit": None,
+            "url": "https://github.com/synaptent/aragora/pull/7441",
+        },
+    )
+
+    result = resolver.audit_merged_pr_lanes(
+        registry_path=registry,
+        receipt_dir=tmp_path / "receipts",
+        pr=7441,
+        gh_bin=str(gh),
+        apply=False,
+    )
+
+    assert result["finding_count"] == 0
+    assert result["github_state"]["state"] == "OPEN"
+    assert result["apply_eligible"] is False
+    assert result["blocked_reason"] == "pr_not_merged"
+
+    gh_closed = _fake_gh(
+        tmp_path,
+        {
+            "number": 7441,
+            "state": "CLOSED",
+            "headRefOid": "abc",
+            "mergedAt": None,
+            "mergeCommit": None,
+            "url": "https://github.com/synaptent/aragora/pull/7441",
+        },
+    )
+
+    closed_result = resolver.audit_merged_pr_lanes(
+        registry_path=registry,
+        receipt_dir=tmp_path / "receipts",
+        pr=7441,
+        gh_bin=str(gh_closed),
+        apply=False,
+    )
+
+    assert closed_result["finding_count"] == 0
+    assert closed_result["github_state"]["state"] == "CLOSED"
+    assert closed_result["blocked_reason"] == "pr_not_merged"
+
+
+def test_merged_pr_audit_reports_github_state_unavailable(tmp_path: Path) -> None:
+    registry = tmp_path / "lanes.json"
+    _write_json(
+        registry,
+        [
+            {
+                "lane_id": "codex-merged",
+                "owner_session": "codex-owner",
+                "status": "active",
+                "pr_number": 7435,
+            }
+        ],
+    )
+    gh = _fake_gh(tmp_path, {}, exit_code=1)
+
+    result = resolver.audit_merged_pr_lanes(
+        registry_path=registry,
+        receipt_dir=tmp_path / "receipts",
+        pr=7435,
+        gh_bin=str(gh),
+        apply=False,
+    )
+
+    assert result["finding_count"] == 0
+    assert result["github_state"]["available"] is False
+    assert result["blocked_reason"] == "github_state_unavailable"
+
+
+def test_merged_pr_audit_apply_requires_operator_authorization(tmp_path: Path) -> None:
+    registry = tmp_path / "lanes.json"
+    _write_json(
+        registry,
+        [
+            {
+                "lane_id": "codex-merged",
+                "owner_session": "codex-owner",
+                "status": "active",
+                "pr_number": 7435,
+            }
+        ],
+    )
+    gh = _fake_gh(
+        tmp_path,
+        {
+            "number": 7435,
+            "state": "MERGED",
+            "headRefOid": "head",
+            "mergedAt": "2026-05-23T19:16:23Z",
+            "mergeCommit": {"oid": "merge"},
+            "url": "https://github.com/synaptent/aragora/pull/7435",
+        },
+    )
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--merged-pr-lane-audit",
+            "--pr",
+            "7435",
+            "--apply",
+            "--gh-bin",
+            str(gh),
+            "--registry-path",
+            str(registry),
+            "--receipt-dir",
+            str(tmp_path / "receipts"),
+            "--json",
+        ],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert proc.returncode == 2
+    result = json.loads(proc.stdout)
+    assert result["blocked_reason"] == "operator_authorization_required"
+    assert json.loads(registry.read_text(encoding="utf-8"))[0]["status"] == "active"
+
+
+def test_merged_pr_audit_apply_supersedes_only_target_pr_rows(tmp_path: Path) -> None:
+    registry = tmp_path / "lanes.json"
+    receipt_dir = tmp_path / "receipts"
+    _write_json(
+        registry,
+        [
+            {
+                "lane_id": "codex-7435-a",
+                "owner_session": "codex-a",
+                "status": "blocked",
+                "next_action": "old",
+                "pr_number": 7435,
+            },
+            {
+                "lane_id": "codex-7435-b",
+                "owner_session": "codex-b",
+                "status": "active",
+                "pr_number": 7435,
+            },
+            {
+                "lane_id": "codex-7441",
+                "owner_session": "codex-c",
+                "status": "active",
+                "pr_number": 7441,
+            },
+        ],
+    )
+    gh = _fake_gh(
+        tmp_path,
+        {
+            "number": 7435,
+            "state": "MERGED",
+            "headRefOid": "96ea60500851ac459aa542a0d31afc06d92c288a",
+            "mergedAt": "2026-05-23T19:16:23Z",
+            "mergeCommit": {"oid": "4e8b21e98a0ddbcb383d9c92e6c20b343e49d151"},
+            "url": "https://github.com/synaptent/aragora/pull/7435",
+        },
+    )
+
+    result = resolver.audit_merged_pr_lanes(
+        registry_path=registry,
+        receipt_dir=receipt_dir,
+        pr=7435,
+        gh_bin=str(gh),
+        apply=True,
+        operator_authorized=True,
+        expected_merge_commit="4e8b21e98a0ddbcb383d9c92e6c20b343e49d151",
+        resolved_at="2026-05-23T19:20:00Z",
+    )
+
+    rows = {row["lane_id"]: row for row in json.loads(registry.read_text(encoding="utf-8"))}
+    assert result["resolved_count"] == 2
+    assert rows["codex-7435-a"]["status"] == "superseded"
+    assert rows["codex-7435-a"]["next_action"] == "old"
+    assert rows["codex-7435-a"]["last_steering_outcome"] == "superseded"
+    assert rows["codex-7441"]["status"] == "active"
+    receipts = sorted(receipt_dir.glob("*.json"))
+    assert len(receipts) == 2
+    receipt = json.loads(receipts[0].read_text(encoding="utf-8"))
+    assert receipt["schema_version"] == "aragora-merged-pr-lane-audit/1.0"
+    assert receipt["pr_number"] == 7435
+    assert receipt["merge_commit"] == "4e8b21e98a0ddbcb383d9c92e6c20b343e49d151"
+    assert receipt["old_status"] in {"active", "blocked"}
+
+
+def test_merged_pr_audit_apply_rejects_merge_commit_mismatch(tmp_path: Path) -> None:
+    registry = tmp_path / "lanes.json"
+    _write_json(
+        registry,
+        [
+            {
+                "lane_id": "codex-merged",
+                "owner_session": "codex-owner",
+                "status": "active",
+                "pr_number": 7435,
+            }
+        ],
+    )
+    gh = _fake_gh(
+        tmp_path,
+        {
+            "number": 7435,
+            "state": "MERGED",
+            "headRefOid": "head",
+            "mergedAt": "2026-05-23T19:16:23Z",
+            "mergeCommit": {"oid": "actual"},
+            "url": "https://github.com/synaptent/aragora/pull/7435",
+        },
+    )
+
+    result = resolver.audit_merged_pr_lanes(
+        registry_path=registry,
+        receipt_dir=tmp_path / "receipts",
+        pr=7435,
+        gh_bin=str(gh),
+        apply=True,
+        operator_authorized=True,
+        expected_merge_commit="expected",
+    )
+
+    assert result["resolved_count"] == 0
+    assert result["blocked_reason"] == "merge_commit_mismatch"
+    assert json.loads(registry.read_text(encoding="utf-8"))[0]["status"] == "active"


### PR DESCRIPTION
## Summary
- add a merged-PR lane audit mode to scripts/resolve_lane_conflicts.py
- report active/blocked lane rows that still point at already-merged PRs
- require explicit operator authorization and exact merge-commit guard before applying superseded lane updates

## Validation
- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/scripts/test_resolve_lane_conflicts.py -q -p no:cacheprovider
- python3 -m ruff check scripts/resolve_lane_conflicts.py tests/scripts/test_resolve_lane_conflicts.py
- python3 -m ruff format --check scripts/resolve_lane_conflicts.py tests/scripts/test_resolve_lane_conflicts.py
- python3 -m mypy scripts/resolve_lane_conflicts.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- pre-push hooks passed, including baseline-filtered mypy and gitleaks

Draft because this was created to preserve and unblock the root checkout; it still needs normal review/queue handling before settlement.