### PR TITLE
feat(review-queue): lint evidence comments before posting

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -1903,24 +1903,19 @@ def _lint_evidence_comment(
     source: str,
 ) -> dict[str, Any]:
     """Dry-run whether one proposed comment would satisfy quorum parsers."""
-    effective_head_committed_at = head_committed_at or "9999-12-31T23:59:59Z"
+    grounded, grounding_method = _proposed_evidence_head_grounding(body, head_sha)
     comment = {
         "author": {"login": author},
         "body": body,
         "createdAt": "",
     }
-    dogfood_evidence = _dogfood_evidence_from_comments(
-        [comment],
-        head_sha=head_sha,
-        head_committed_at=effective_head_committed_at,
-    )
-    reviewer_signals = _model_review_signals_from_comments(
-        [comment],
-        head_sha=head_sha,
-        head_committed_at=effective_head_committed_at,
-    )
+    if grounded:
+        dogfood_evidence = _dogfood_evidence_from_comments([comment])
+        reviewer_signals = _model_review_signals_from_comments([comment])
+    else:
+        dogfood_evidence = []
+        reviewer_signals = []
     counted_reviewer_ids = _counted_model_reviewer_ids(reviewer_signals, dogfood_evidence)
-    grounded = _is_comment_grounded_on_head(comment, head_sha, effective_head_committed_at)
     inferred_reviewer = _infer_model_reviewer_from_text(body)
     lower = body.lower()
 
@@ -1963,12 +1958,28 @@ def _lint_evidence_comment(
         "comment_summary": _first_nonempty_line(body)[:240],
         "inferred_reviewer": inferred_reviewer,
         "current_head_grounded": grounded,
+        "current_head_grounding_method": grounding_method,
         "dogfood_evidence": dogfood_evidence,
         "reviewer_signals": reviewer_signals,
         "counted_reviewer_ids": counted_reviewer_ids,
         "would_count": bool(counted_reviewer_ids),
         "problems": problems,
     }
+
+
+def _proposed_evidence_head_grounding(body: str, head_sha: str) -> tuple[bool, str]:
+    """Require proposed comments to cite the target head SHA prefix.
+
+    Unlike persisted GitHub comments, evidence-lint inputs have no trustworthy
+    ``createdAt``.  Lint mode therefore does not use timestamp recency as a
+    substitute for current-head grounding.
+    """
+    normalized_head = str(head_sha or "").strip().lower()
+    if len(normalized_head) < 7:
+        return False, "missing_head_sha_argument"
+    if normalized_head[:7] in str(body or "").lower():
+        return True, "head_sha_citation"
+    return False, "missing_head_sha_citation"
 
 
 def _head_committed_at_from_pr(pr: dict[str, Any]) -> str:

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -449,6 +449,39 @@ def add_review_queue_parser(subparsers: argparse._SubParsersAction) -> None:
     )
     merge_packet_p.add_argument("--json", action="store_true", help="Output as JSON")
 
+    evidence_lint_p = sub.add_parser(
+        "evidence-lint",
+        help="Dry-run whether a proposed evidence comment will count for model quorum",
+        description=(
+            "Lint a proposed PR comment against the same current-head evidence "
+            "parsers used by review-queue merge-packet. This is read-only: it "
+            "does not fetch GitHub, post comments, write receipts, or mutate state."
+        ),
+    )
+    evidence_lint_p.add_argument("--pr", required=True, help="PR number the evidence targets")
+    evidence_lint_p.add_argument(
+        "--head-sha",
+        required=True,
+        help="Exact PR head SHA the proposed comment must cite.",
+    )
+    evidence_lint_p.add_argument(
+        "--head-committed-at",
+        default="",
+        help=(
+            "Optional current head committedDate. When supplied, comments must either "
+            "cite --head-sha or have a createdAt at/after this timestamp."
+        ),
+    )
+    body_group = evidence_lint_p.add_mutually_exclusive_group(required=True)
+    body_group.add_argument("--body", help="Proposed evidence comment body to lint")
+    body_group.add_argument("--body-file", help="Read proposed evidence comment body from file")
+    evidence_lint_p.add_argument(
+        "--author",
+        default="local",
+        help="GitHub author login to simulate for the proposed comment (default: local)",
+    )
+    evidence_lint_p.add_argument("--json", action="store_true", help="Output as JSON")
+
     baseline_p = sub.add_parser(
         "baseline",
         help="Measure empirical invalidation baseline from on-disk stores (#6375)",
@@ -635,6 +668,8 @@ def cmd_review_queue(args: argparse.Namespace) -> int:
         return _cmd_record_settlement(args)
     if command == "merge-packet":
         return _cmd_merge_packet(args)
+    if command == "evidence-lint":
+        return _cmd_evidence_lint(args)
     if command == "baseline":
         return _cmd_baseline(args)
     if command == "observe-outcomes":
@@ -647,7 +682,8 @@ def cmd_review_queue(args: argparse.Namespace) -> int:
         return _cmd_health_alert(args)
     print(
         "Usage: aragora review-queue "
-        "{build,packet,run,act,record-settlement,merge-packet,baseline,observe-outcomes,"
+        "{build,packet,run,act,record-settlement,merge-packet,evidence-lint,baseline,"
+        "observe-outcomes,"
         "health,health-alert} [...]\n"
         "Run 'aragora review-queue run --help' for the human settlement loop.",
         file=sys.stderr,
@@ -859,6 +895,45 @@ def _cmd_record_settlement(args: argparse.Namespace) -> int:
     else:
         _render_recorded_settlement_result(result)
     return 0
+
+
+def _cmd_evidence_lint(args: argparse.Namespace) -> int:
+    json_output = bool(getattr(args, "json", False) or getattr(args, "json_output", False))
+    body_file = getattr(args, "body_file", None)
+    try:
+        if body_file:
+            body = Path(str(body_file)).read_text(encoding="utf-8")
+        else:
+            body = str(getattr(args, "body", "") or "")
+    except OSError as exc:
+        if json_output:
+            print(
+                json.dumps(
+                    {
+                        "mode": "evidence_lint",
+                        "would_count": False,
+                        "problems": [f"body_file_unreadable: {exc}"],
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            print(f"error: could not read --body-file: {exc}", file=sys.stderr)
+        return 1
+
+    result = _lint_evidence_comment(
+        pr=str(getattr(args, "pr", "") or ""),
+        head_sha=str(getattr(args, "head_sha", "") or ""),
+        head_committed_at=str(getattr(args, "head_committed_at", "") or ""),
+        body=body,
+        author=str(getattr(args, "author", "") or ""),
+        source="body_file" if body_file else "inline",
+    )
+    if json_output:
+        print(json.dumps(result, indent=2))
+    else:
+        _render_evidence_lint(result)
+    return 0 if result["would_count"] else 1
 
 
 def _cmd_merge_packet(args: argparse.Namespace) -> int:
@@ -1818,6 +1893,84 @@ def _counted_model_reviewer_ids(
     return sorted(reviewer_ids)
 
 
+def _lint_evidence_comment(
+    *,
+    pr: str,
+    head_sha: str,
+    head_committed_at: str,
+    body: str,
+    author: str,
+    source: str,
+) -> dict[str, Any]:
+    """Dry-run whether one proposed comment would satisfy quorum parsers."""
+    effective_head_committed_at = head_committed_at or "9999-12-31T23:59:59Z"
+    comment = {
+        "author": {"login": author},
+        "body": body,
+        "createdAt": "",
+    }
+    dogfood_evidence = _dogfood_evidence_from_comments(
+        [comment],
+        head_sha=head_sha,
+        head_committed_at=effective_head_committed_at,
+    )
+    reviewer_signals = _model_review_signals_from_comments(
+        [comment],
+        head_sha=head_sha,
+        head_committed_at=effective_head_committed_at,
+    )
+    counted_reviewer_ids = _counted_model_reviewer_ids(reviewer_signals, dogfood_evidence)
+    grounded = _is_comment_grounded_on_head(comment, head_sha, effective_head_committed_at)
+    inferred_reviewer = _infer_model_reviewer_from_text(body)
+    lower = body.lower()
+
+    problems: list[str] = []
+    if not body.strip():
+        problems.append("empty_body")
+    if not grounded:
+        problems.append("missing_current_head_grounding")
+    if str(author or "").strip() == "github-actions":
+        problems.append("github_actions_author_not_counted")
+    if inferred_reviewer == "unknown_model_reviewer":
+        problems.append("missing_known_model_reviewer_heading")
+    if not any(
+        token in lower
+        for token in (
+            "dogfood",
+            "adversarial",
+            "cross-author",
+            "recheck",
+            "codex review",
+            "claude review",
+            "grok independent",
+            "gemini independent",
+            "independent semantic review",
+            "independent model review",
+            "model-family semantic signal",
+        )
+    ):
+        problems.append("missing_dogfood_or_review_trigger")
+    if not counted_reviewer_ids:
+        problems.append("no_counted_model_reviewer")
+
+    return {
+        "mode": "evidence_lint",
+        "pr_number": str(pr),
+        "head_sha": head_sha,
+        "head_committed_at": head_committed_at,
+        "source": source,
+        "author": author,
+        "comment_summary": _first_nonempty_line(body)[:240],
+        "inferred_reviewer": inferred_reviewer,
+        "current_head_grounded": grounded,
+        "dogfood_evidence": dogfood_evidence,
+        "reviewer_signals": reviewer_signals,
+        "counted_reviewer_ids": counted_reviewer_ids,
+        "would_count": bool(counted_reviewer_ids),
+        "problems": problems,
+    }
+
+
 def _head_committed_at_from_pr(pr: dict[str, Any]) -> str:
     """Return the ``committedDate`` of the PR head commit, or ``""``.
 
@@ -2758,6 +2911,20 @@ def _render_merge_authorization_packet(packet: dict[str, Any]) -> None:
         for reason in entry.get("reasons") or []:
             print(f"  - {reason}")
         print()
+
+
+def _render_evidence_lint(result: dict[str, Any]) -> None:
+    print("# Evidence lint")
+    print(f"PR: #{result.get('pr_number', '')}")
+    print(f"head: {result.get('head_sha', '')}")
+    print(f"would count: {str(result.get('would_count', False)).lower()}")
+    counted = result.get("counted_reviewer_ids") or []
+    print(f"counted reviewers: {', '.join(counted) or '(none)'}")
+    problems = result.get("problems") or []
+    if problems:
+        print("problems:")
+        for problem in problems:
+            print(f"  - {problem}")
 
 
 def _render_baseline_report(

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -1888,6 +1888,43 @@ def _add_review_queue_parser(subparsers) -> None:
     )
     record_parser.set_defaults(func=_lazy("aragora.cli.commands.review_queue", "cmd_review_queue"))
 
+    evidence_lint_parser = queue_subparsers.add_parser(
+        "evidence-lint",
+        help="Dry-run whether a proposed evidence comment will count for model quorum",
+        description=(
+            "Lint a proposed PR comment against the same current-head evidence "
+            "parsers used by review-queue merge-packet. This is read-only."
+        ),
+    )
+    evidence_lint_parser.add_argument("--pr", required=True, help="PR number the evidence targets")
+    evidence_lint_parser.add_argument(
+        "--head-sha",
+        required=True,
+        help="Exact PR head SHA the proposed comment must cite.",
+    )
+    evidence_lint_parser.add_argument(
+        "--head-committed-at",
+        default="",
+        help="Optional current head committedDate for stricter current-head grounding.",
+    )
+    body_group = evidence_lint_parser.add_mutually_exclusive_group(required=True)
+    body_group.add_argument("--body", help="Proposed evidence comment body to lint")
+    body_group.add_argument("--body-file", help="Read proposed evidence comment body from file")
+    evidence_lint_parser.add_argument(
+        "--author",
+        default="local",
+        help="GitHub author login to simulate for the proposed comment.",
+    )
+    evidence_lint_parser.add_argument(
+        "--json",
+        dest="json_output",
+        action="store_true",
+        help="Output as JSON",
+    )
+    evidence_lint_parser.set_defaults(
+        func=_lazy("aragora.cli.commands.review_queue", "cmd_review_queue")
+    )
+
     baseline_parser = queue_subparsers.add_parser(
         "baseline",
         help="Measure empirical invalidation baseline from on-disk stores (#6375)",

--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -115,7 +115,7 @@ For full runtime configuration, see [ENVIRONMENT](../getting-started/environment
 | `replay` | - | Replay stored debates | - |
 | `review` | - | Run AI code review on a diff or PR | - |
 | `review-pr` | - | Review a live GitHub PR head and optionally run a fixer loop | - |
-| `review-queue` | - | PR review queue + advisory packets + human settlement | `act`, `baseline`, `build`, `health`, `health-alert`, `merge-packet`, `observe-outcomes`, `packet`, `record-settlement`, `run` |
+| `review-queue` | - | PR review queue + advisory packets + human settlement | `act`, `baseline`, `build`, `evidence-lint`, `health`, `health-alert`, `merge-packet`, `observe-outcomes`, `packet`, `record-settlement`, `run` |
 | `rlm` | - | RLM (Recursive Language Models) operations | `clear-cache`, `compress`, `query`, `stats` |
 | `security` | - | Security operations (encryption, key rotation) | `health`, `list-tokens`, `migrate`, `rotate-key`, `rotate-token`, `status`, `verify-token` |
 | `self-improve` | - | Run self-improvement pipeline with worktree isolation and validation | - |

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -110,7 +110,7 @@ For full runtime configuration, see [ENVIRONMENT](ENVIRONMENT.md).
 | `replay` | - | Replay stored debates | - |
 | `review` | - | Run AI code review on a diff or PR | - |
 | `review-pr` | - | Review a live GitHub PR head and optionally run a fixer loop | - |
-| `review-queue` | - | PR review queue + advisory packets + human settlement | `act`, `baseline`, `build`, `health`, `health-alert`, `merge-packet`, `observe-outcomes`, `packet`, `record-settlement`, `run` |
+| `review-queue` | - | PR review queue + advisory packets + human settlement | `act`, `baseline`, `build`, `evidence-lint`, `health`, `health-alert`, `merge-packet`, `observe-outcomes`, `packet`, `record-settlement`, `run` |
 | `rlm` | - | RLM (Recursive Language Models) operations | `clear-cache`, `compress`, `query`, `stats` |
 | `security` | - | Security operations (encryption, key rotation) | `health`, `list-tokens`, `migrate`, `rotate-key`, `rotate-token`, `status`, `verify-token` |
 | `self-improve` | - | Run self-improvement pipeline with worktree isolation and validation | - |

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -1745,6 +1745,25 @@ class TestCommandDispatch:
         ns_merge_packet = root.parse_args(["review-queue", "merge-packet", "--pr", "6280"])
         assert ns_merge_packet.review_queue_command == "merge-packet"
         assert ns_merge_packet.pr == ["6280"]
+        # evidence-lint invocation parses
+        ns_evidence_lint = root.parse_args(
+            [
+                "review-queue",
+                "evidence-lint",
+                "--pr",
+                "6280",
+                "--head-sha",
+                "headsha123",
+                "--body",
+                "## Codex focused dogfood\nCurrent head: headsha123",
+                "--json",
+            ]
+        )
+        assert ns_evidence_lint.review_queue_command == "evidence-lint"
+        assert ns_evidence_lint.pr == "6280"
+        assert ns_evidence_lint.head_sha == "headsha123"
+        assert ns_evidence_lint.body_file is None
+        assert ns_evidence_lint.json is True
         # run invocation parses
         ns_run = root.parse_args(["review-queue", "run", "--limit", "3", "--ready-only"])
         assert ns_run.review_queue_command == "run"
@@ -1819,6 +1838,131 @@ class TestCommandDispatch:
         assert ns.action == "admin_squash_merge"
         assert ns.reason == "operator authorized exact-head merge"
         assert ns.json_output is True
+
+    def test_top_level_parser_registers_evidence_lint(self) -> None:
+        from aragora.cli.parser import build_parser
+
+        parser = build_parser()
+        ns = parser.parse_args(
+            [
+                "review-queue",
+                "evidence-lint",
+                "--pr",
+                "7445",
+                "--head-sha",
+                "cd87c5a1b2db34f04167906553502db3ede9525e",
+                "--body",
+                "## Claude review\nCurrent head: cd87c5a1b2db34f04167906553502db3ede9525e",
+                "--json",
+            ]
+        )
+
+        assert ns.command == "review-queue"
+        assert ns.review_queue_command == "evidence-lint"
+        assert ns.pr == "7445"
+        assert ns.head_sha == "cd87c5a1b2db34f04167906553502db3ede9525e"
+        assert ns.body_file is None
+        assert ns.json_output is True
+
+    def test_evidence_lint_counts_current_head_dogfood(self) -> None:
+        ns = argparse.Namespace(
+            review_queue_command="evidence-lint",
+            pr="7445",
+            head_sha="cd87c5a1b2db34f04167906553502db3ede9525e",
+            head_committed_at="2026-05-23T19:00:00Z",
+            body=(
+                "## Codex focused dogfood\n\n"
+                "Current head: cd87c5a1b2db34f04167906553502db3ede9525e\n"
+                "Validation passed for the exact touched surface."
+            ),
+            body_file=None,
+            author="an0mium",
+            json=True,
+        )
+
+        out = io.StringIO()
+        with redirect_stdout(out):
+            rc = cmd_review_queue(ns)
+
+        payload = json.loads(out.getvalue())
+        assert rc == 0
+        assert payload["mode"] == "evidence_lint"
+        assert payload["would_count"] is True
+        assert payload["counted_reviewer_ids"] == ["codex"]
+        assert payload["dogfood_evidence"][0]["reviewer_id"] == "codex"
+        assert payload["problems"] == []
+
+    def test_evidence_lint_rejects_ungrounded_comment(self) -> None:
+        ns = argparse.Namespace(
+            review_queue_command="evidence-lint",
+            pr="7445",
+            head_sha="cd87c5a1b2db34f04167906553502db3ede9525e",
+            head_committed_at="2026-05-23T19:00:00Z",
+            body="## Claude review\n\nLooks good, but no exact head citation.",
+            body_file=None,
+            author="an0mium",
+            json=True,
+        )
+
+        out = io.StringIO()
+        with redirect_stdout(out):
+            rc = cmd_review_queue(ns)
+
+        payload = json.loads(out.getvalue())
+        assert rc == 1
+        assert payload["would_count"] is False
+        assert "missing_current_head_grounding" in payload["problems"]
+        assert "no_counted_model_reviewer" in payload["problems"]
+
+    def test_evidence_lint_requires_head_sha_when_timestamp_omitted(self) -> None:
+        ns = argparse.Namespace(
+            review_queue_command="evidence-lint",
+            pr="7445",
+            head_sha="cd87c5a1b2db34f04167906553502db3ede9525e",
+            head_committed_at="",
+            body="## Codex focused dogfood\n\nValidation passed, but no SHA citation.",
+            body_file=None,
+            author="an0mium",
+            json=True,
+        )
+
+        out = io.StringIO()
+        with redirect_stdout(out):
+            rc = cmd_review_queue(ns)
+
+        payload = json.loads(out.getvalue())
+        assert rc == 1
+        assert payload["would_count"] is False
+        assert "missing_current_head_grounding" in payload["problems"]
+
+    def test_evidence_lint_reads_body_file(self, tmp_path: Path) -> None:
+        body_file = tmp_path / "comment.md"
+        body_file.write_text(
+            "## Claude review\n\n"
+            "Current head: cd87c5a1b2db34f04167906553502db3ede9525e\n"
+            "I reviewed the exact-head evidence-lint diff.",
+            encoding="utf-8",
+        )
+        ns = argparse.Namespace(
+            review_queue_command="evidence-lint",
+            pr="7445",
+            head_sha="cd87c5a1b2db34f04167906553502db3ede9525e",
+            head_committed_at="2026-05-23T19:00:00Z",
+            body=None,
+            body_file=str(body_file),
+            author="an0mium",
+            json=True,
+        )
+
+        out = io.StringIO()
+        with redirect_stdout(out):
+            rc = cmd_review_queue(ns)
+
+        payload = json.loads(out.getvalue())
+        assert rc == 0
+        assert payload["would_count"] is True
+        assert payload["counted_reviewer_ids"] == ["claude"]
+        assert payload["reviewer_signals"][0]["reviewer_id"] == "claude"
 
 
 class TestSettlementHelpers:

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -1890,6 +1890,7 @@ class TestCommandDispatch:
         assert payload["would_count"] is True
         assert payload["counted_reviewer_ids"] == ["codex"]
         assert payload["dogfood_evidence"][0]["reviewer_id"] == "codex"
+        assert payload["current_head_grounding_method"] == "head_sha_citation"
         assert payload["problems"] == []
 
     def test_evidence_lint_rejects_ungrounded_comment(self) -> None:
@@ -1911,6 +1912,7 @@ class TestCommandDispatch:
         payload = json.loads(out.getvalue())
         assert rc == 1
         assert payload["would_count"] is False
+        assert payload["current_head_grounding_method"] == "missing_head_sha_citation"
         assert "missing_current_head_grounding" in payload["problems"]
         assert "no_counted_model_reviewer" in payload["problems"]
 
@@ -1933,6 +1935,7 @@ class TestCommandDispatch:
         payload = json.loads(out.getvalue())
         assert rc == 1
         assert payload["would_count"] is False
+        assert payload["current_head_grounding_method"] == "missing_head_sha_citation"
         assert "missing_current_head_grounding" in payload["problems"]
 
     def test_evidence_lint_reads_body_file(self, tmp_path: Path) -> None:
@@ -1962,6 +1965,7 @@ class TestCommandDispatch:
         assert rc == 0
         assert payload["would_count"] is True
         assert payload["counted_reviewer_ids"] == ["claude"]
+        assert payload["current_head_grounding_method"] == "head_sha_citation"
         assert payload["reviewer_signals"][0]["reviewer_id"] == "claude"
 
 


### PR DESCRIPTION
## Summary
- add a read-only `review-queue evidence-lint` command that dry-runs proposed evidence comments against the merge-packet quorum parsers
- require exact-head grounding by SHA for linted comments, including when no head timestamp is supplied
- cover parser, body-file, current-head, and rejection cases in review-queue tests

## Validation
- `pytest tests/cli/commands/test_review_queue.py -q`
- `ruff check aragora/cli/commands/review_queue.py aragora/cli/parser.py tests/cli/commands/test_review_queue.py`
- `ruff format --check aragora/cli/commands/review_queue.py aragora/cli/parser.py tests/cli/commands/test_review_queue.py`
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- `python3 -m aragora.cli.main review-queue evidence-lint --pr 7445 --head-sha cd87c5a1b2db34f04167906553502db3ede9525e --body-file <tmp> --json`