### PR TITLE
fix(review-queue): warn on review-pr object quorum evidence

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -1360,6 +1360,7 @@ def _build_packet(
             "files",
             "body",
             "comments",
+            "reviews",
             "commits",
         ]
     )
@@ -1631,6 +1632,12 @@ def _build_model_review_quorum(
     blocking_workflow_state = _has_blocking_workflow_state(pr)
     unresolved_dissent = bool(dissenting_views)
     counted_reviewer_ids = _counted_model_reviewer_ids(reviewer_signals, dogfood_evidence)
+    review_object_warnings = _review_object_quorum_warnings(
+        pr.get("reviews") or [],
+        counted_reviewer_ids=counted_reviewer_ids,
+        head_sha=head_sha,
+        head_committed_at=head_committed_at,
+    )
     signal_count = len(counted_reviewer_ids)
     has_required_dogfood = not requirement["requires_adversarial_dogfood"] or any(
         _known_model_reviewer_id(item) for item in dogfood_evidence
@@ -1653,6 +1660,7 @@ def _build_model_review_quorum(
         )
         if not has_required_dogfood:
             reasons.append("focused adversarial dogfood evidence is required")
+        reasons.extend(review_object_warnings)
 
     admin_squash_allowed = False
     requires_human_risk_settlement = bool(requirement["requires_human_risk_settlement"])
@@ -1971,6 +1979,78 @@ def _model_review_signals_from_comments(
             }
         )
     return signals[:5]
+
+
+def _review_object_quorum_warnings(
+    reviews: list[Any],
+    *,
+    counted_reviewer_ids: list[str],
+    head_sha: str = "",
+    head_committed_at: str = "",
+) -> list[str]:
+    """Warn when ``review-pr`` evidence is present in non-countable form.
+
+    Merge quorum intentionally counts model evidence from PR comments because
+    comments are easier to audit, quote, and mirror across queue tooling. A
+    GitHub review object alone should therefore not satisfy quorum, but it
+    should produce an operator-visible warning instead of silently looking like
+    missing evidence.
+    """
+    counted = set(counted_reviewer_ids)
+    warnings: list[str] = []
+    warned: set[str] = set()
+    for review in reviews:
+        if not isinstance(review, dict):
+            continue
+        if not _is_review_grounded_on_head(review, head_sha, head_committed_at):
+            continue
+        body = str(review.get("body", "") or "")
+        reviewer_id = _known_model_reviewer_id(
+            {"reviewer_id": _review_pr_reviewer_from_body(body), "provider": ""}
+        )
+        if not reviewer_id:
+            reviewer_id = _normalize_model_reviewer_id(_infer_model_reviewer_from_text(body))
+        if not reviewer_id or reviewer_id in counted or reviewer_id in warned:
+            continue
+        warnings.append(
+            "GitHub review object from "
+            f"{reviewer_id} is advisory-only for merge-packet model quorum; "
+            "mirror the review-pr output into a current-head PR comment before settlement"
+        )
+        warned.add(reviewer_id)
+    return warnings
+
+
+def _review_pr_reviewer_from_body(body: str) -> str:
+    for line in str(body).splitlines():
+        stripped = line.strip()
+        if not stripped.lower().startswith("- reviewer:"):
+            continue
+        value = stripped.split(":", 1)[1].strip().strip("`")
+        return value.strip()
+    return ""
+
+
+def _is_review_grounded_on_head(
+    review: dict[str, Any],
+    head_sha: str,
+    head_committed_at: str,
+) -> bool:
+    if not head_sha:
+        return True
+    commit = review.get("commit")
+    if isinstance(commit, dict) and str(commit.get("oid", "") or "").strip() == head_sha:
+        return True
+    body = str(review.get("body", "") or "")
+    head_short = head_sha[:7]
+    if head_short and head_short in body:
+        return True
+    if not head_committed_at:
+        return False
+    submitted = str(review.get("submittedAt", "") or "")
+    if not submitted:
+        return False
+    return submitted >= head_committed_at
 
 
 def _infer_model_reviewer_from_text(text: str) -> str:

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -2039,10 +2039,14 @@ def _is_review_grounded_on_head(
     if not head_sha:
         return True
     commit = review.get("commit")
-    if isinstance(commit, dict) and str(commit.get("oid", "") or "").strip() == head_sha:
-        return True
     body = str(review.get("body", "") or "")
     head_short = head_sha[:7]
+    if isinstance(commit, dict):
+        commit_oid = str(commit.get("oid", "") or "").strip()
+        if commit_oid:
+            if commit_oid == head_sha:
+                return True
+            return bool(head_short and head_short in body)
     if head_short and head_short in body:
         return True
     if not head_committed_at:

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -1237,6 +1237,50 @@ class TestModelReviewQuorum:
         assert len(quorum["reviewer_signals"]) == 0
         assert len(quorum["dogfood_evidence"]) == 1
 
+    def test_current_head_review_pr_object_warns_that_comment_form_is_required(
+        self,
+    ) -> None:
+        head_sha = "abcdef1234567890abcdef1234567890abcdef12"
+        pr = _make_pr(files=["aragora/cli/commands/swarm.py"])
+        pr["headRefOid"] = head_sha
+        pr["commits"] = [
+            {"oid": head_sha, "committedDate": "2026-04-28T20:00:00Z"},
+        ]
+        pr["comments"] = [
+            {
+                **_dogfood_comment("## Codex focused dogfood\n10/10 pass"),
+                "createdAt": "2026-04-28T20:05:00Z",
+            },
+        ]
+        pr["reviews"] = [
+            {
+                "author": {"login": "an0mium"},
+                "body": (
+                    "## Aragora review-pr: advisory pass\n\n"
+                    "- Reviewer: `claude`\n"
+                    f"- Head SHA: `{head_sha}`\n"
+                    "- Final status: `passed`\n"
+                ),
+                "commit": {"oid": head_sha},
+                "state": "COMMENTED",
+                "submittedAt": "2026-04-28T20:10:00Z",
+            }
+        ]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=["aragora/cli/commands/swarm.py"],
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+        )
+        assert quorum["counted_reviewer_ids"] == ["codex"]
+        assert quorum["status"] == "needs_model_review_quorum"
+        assert any(
+            "GitHub review object" in reason and "PR comment" in reason
+            for reason in quorum["reasons"]
+        )
+
     # --- Finding 6: merge-authority self-modification elevation ------------
 
     def test_review_queue_self_modification_classified_tier_four(self) -> None:

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -1281,6 +1281,45 @@ class TestModelReviewQuorum:
             for reason in quorum["reasons"]
         )
 
+    def test_off_head_review_pr_object_does_not_warn_as_current_evidence(
+        self,
+    ) -> None:
+        head_sha = "abcdef1234567890abcdef1234567890abcdef12"
+        pr = _make_pr(files=["aragora/cli/commands/swarm.py"])
+        pr["headRefOid"] = head_sha
+        pr["commits"] = [
+            {"oid": head_sha, "committedDate": "2026-04-28T20:00:00Z"},
+        ]
+        pr["comments"] = [
+            {
+                **_dogfood_comment("## Codex focused dogfood\n10/10 pass"),
+                "createdAt": "2026-04-28T20:05:00Z",
+            },
+        ]
+        pr["reviews"] = [
+            {
+                "author": {"login": "an0mium"},
+                "body": (
+                    "## Aragora review-pr: advisory pass\n\n"
+                    "- Reviewer: `claude`\n"
+                    "- Final status: `passed`\n"
+                ),
+                "commit": {"oid": "0000000000000000000000000000000000000000"},
+                "state": "COMMENTED",
+                "submittedAt": "2026-04-28T20:10:00Z",
+            }
+        ]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=["aragora/cli/commands/swarm.py"],
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+        )
+        assert quorum["counted_reviewer_ids"] == ["codex"]
+        assert not any("GitHub review object" in reason for reason in quorum["reasons"])
+
     # --- Finding 6: merge-authority self-modification elevation ------------
 
     def test_review_queue_self_modification_classified_tier_four(self) -> None:


### PR DESCRIPTION
## Summary
- include GitHub review objects in merge-packet PR fetches so advisory review-pr output can be detected
- keep review objects non-counting for model quorum, but emit an explicit reason when a current-head model review object needs to be mirrored into a PR comment
- add a regression for current-head review-pr evidence that would otherwise look like missing quorum

## Validation
- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/cli/commands/test_review_queue.py::TestModelReviewQuorum -q -p no:cacheprovider
- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/cli/commands/test_review_queue.py -q -p no:cacheprovider
- python3 -m ruff check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py
- python3 -m ruff format --check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py
- python3 -m mypy aragora/cli/commands/review_queue.py --ignore-missing-imports --no-incremental
- bash scripts/automation_pr_preflight.sh origin/main HEAD

## Notes
This is a Tier 4 merge-authority tooling change. It should not be settled without the normal exact-head review, merge-packet, and human-risk gates.