### PR TITLE
fix(settlement): block app-pinned status spoofing

### DIFF
--- a/scripts/settle_one_pr.py
+++ b/scripts/settle_one_pr.py
@@ -271,6 +271,80 @@ def required_check_report(checks: Any) -> dict[str, Any]:
     return {"status": status, "blockers": blockers, "suggestions": suggestions}
 
 
+def _rollup_name(item: dict[str, Any]) -> str:
+    return str(item.get("name") or item.get("context") or "")
+
+
+def _rollup_success(item: dict[str, Any]) -> bool:
+    state = str(item.get("state") or item.get("status") or item.get("conclusion") or "").upper()
+    return state == "SUCCESS"
+
+
+def required_check_source_report(
+    protection: Any,
+    pr_view: Any,
+) -> dict[str, Any]:
+    """Fail closed when an app-pinned required check is only a manual status.
+
+    GitHub branch protection may pin a required check context to a specific App.
+    In that case a manually posted commit status with the same context can look
+    green in `gh pr checks`, but GitHub will reject mergePullRequest because the
+    expected App did not set the check. The steward should surface that before
+    an executor tries to merge.
+    """
+    if not isinstance(protection, dict):
+        return {
+            "status": "unknown",
+            "blockers": ["branch protection required_status_checks JSON unavailable"],
+        }
+    if not isinstance(pr_view, dict):
+        return {
+            "status": "unknown",
+            "blockers": ["PR statusCheckRollup JSON unavailable"],
+        }
+
+    rollup = pr_view.get("statusCheckRollup") or []
+    if not isinstance(rollup, list):
+        return {
+            "status": "unknown",
+            "blockers": ["PR statusCheckRollup is not a list"],
+        }
+
+    blockers: list[str] = []
+    for required in protection.get("checks") or []:
+        if not isinstance(required, dict):
+            continue
+        context = str(required.get("context") or "")
+        app_id = required.get("app_id")
+        if not context or app_id is None:
+            continue
+
+        matching = [
+            item for item in rollup if isinstance(item, dict) and _rollup_name(item) == context
+        ]
+        has_successful_check_run = any(
+            item.get("__typename") == "CheckRun" and _rollup_success(item) for item in matching
+        )
+        if has_successful_check_run:
+            continue
+
+        has_successful_status = any(
+            item.get("__typename") == "StatusContext" and _rollup_success(item) for item in matching
+        )
+        if has_successful_status:
+            blockers.append(
+                f"{context} is app-pinned to app_id {app_id}, but only a manual "
+                "StatusContext is green"
+            )
+        else:
+            blockers.append(
+                f"{context} is app-pinned to app_id {app_id}, but no successful CheckRun is present"
+            )
+
+    status = "pass" if not blockers else "blocked"
+    return {"status": status, "blockers": blockers}
+
+
 def validation_report(
     entry: dict[str, Any], *, cwd: Path, run_validation: bool
 ) -> list[dict[str, Any]]:
@@ -427,6 +501,16 @@ def build_report(
         report["pr_view_check"] = view_cmd
         blockers.extend(head_blockers(selected, pr_view))
 
+        protection, protection_cmd = _run_json(
+            [
+                "gh",
+                "api",
+                "repos/{owner}/{repo}/branches/main/protection/required_status_checks",
+            ],
+            cwd=cwd,
+        )
+        report["required_check_source_command"] = protection_cmd
+
         required_checks, required_cmd = _run_json(
             [
                 "gh",
@@ -444,6 +528,10 @@ def build_report(
         report["checks"]["required"] = check_report
         blockers.extend(check_report["blockers"])
         report["suggested_commands"].extend(check_report["suggestions"])
+
+        source_report = required_check_source_report(protection, pr_view)
+        report["checks"]["required_sources"] = source_report
+        blockers.extend(source_report["blockers"])
 
     should_validate = validate and not blockers
     report["validation"] = validation_report(selected, cwd=cwd, run_validation=should_validate)

--- a/scripts/settle_one_pr.py
+++ b/scripts/settle_one_pr.py
@@ -4,7 +4,9 @@
 The script is intentionally read-only. It does not approve, comment, mark
 ready, rerun workflows, or merge. It gathers the repeated settlement gates into
 one report so a follow-up executor can make bounded progress without broad queue
-drain.
+drain. Live mode fails closed when `gh` cannot read branch-protection required
+check source metadata; app-pinned required checks must be satisfied by the
+expected GitHub App, not by manual status spoofing.
 """
 
 from __future__ import annotations
@@ -278,12 +280,44 @@ def _rollup_name(item: dict[str, Any]) -> str:
 
 def _rollup_success(item: dict[str, Any]) -> bool:
     state = str(item.get("state") or item.get("status") or item.get("conclusion") or "").upper()
-    return state == "SUCCESS"
+    return state in {"SUCCESS", "SKIPPED", "NEUTRAL"}
+
+
+def _check_run_app_id(item: dict[str, Any]) -> int | None:
+    """Extract the source GitHub App database id from common CheckRun shapes."""
+    direct = _coerce_int(item.get("app_id") or item.get("appId") or item.get("appDatabaseId"))
+    if direct is not None:
+        return direct
+
+    app = item.get("app")
+    if isinstance(app, dict):
+        app_id = _coerce_int(app.get("id") or app.get("databaseId"))
+        if app_id is not None:
+            return app_id
+
+    check_suite = item.get("checkSuite")
+    if isinstance(check_suite, dict):
+        suite_app = check_suite.get("app")
+        if isinstance(suite_app, dict):
+            return _coerce_int(suite_app.get("id") or suite_app.get("databaseId"))
+
+    return None
+
+
+def _check_runs_from_payload(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, dict):
+        check_runs = payload.get("check_runs") or payload.get("nodes") or []
+    else:
+        check_runs = payload
+    if not isinstance(check_runs, list):
+        return []
+    return [item for item in check_runs if isinstance(item, dict)]
 
 
 def required_check_source_report(
     protection: Any,
     pr_view: Any,
+    check_runs_payload: Any = None,
 ) -> dict[str, Any]:
     """Fail closed when an app-pinned required check is only a manual status.
 
@@ -316,6 +350,7 @@ def required_check_source_report(
             "suggestions": ["rerun gh pr view with statusCheckRollup before settlement"],
         }
 
+    check_runs = _check_runs_from_payload(check_runs_payload)
     blockers: list[str] = []
     suggestions: list[str] = []
     for required in protection.get("checks") or []:
@@ -325,30 +360,62 @@ def required_check_source_report(
         app_id = required.get("app_id")
         if not context or app_id in (None, -1):
             continue
+        expected_app_id = _coerce_int(app_id)
+        if expected_app_id is None:
+            blockers.append(f"{context} has unparseable pinned app_id {app_id!r}")
+            suggestions.append("inspect branch protection required_status_checks.checks")
+            continue
 
         matching = [
             item for item in rollup if isinstance(item, dict) and _rollup_name(item) == context
         ]
-        has_successful_check_run = any(
-            item.get("__typename") == "CheckRun" and _rollup_success(item) for item in matching
-        )
-        if has_successful_check_run:
+        matching_check_runs = [
+            item
+            for item in [*matching, *check_runs]
+            if _rollup_name(item) == context
+            and (item.get("__typename") == "CheckRun" or "app" in item or "checkSuite" in item)
+        ]
+        successful_check_runs = [item for item in matching_check_runs if _rollup_success(item)]
+        successful_expected_app_runs = [
+            item for item in successful_check_runs if _check_run_app_id(item) == expected_app_id
+        ]
+        if successful_expected_app_runs:
             continue
 
         has_successful_status = any(
             item.get("__typename") == "StatusContext" and _rollup_success(item) for item in matching
         )
+        observed_app_ids = sorted(
+            {
+                observed
+                for item in successful_check_runs
+                if (observed := _check_run_app_id(item)) is not None
+            }
+        )
+        has_unverified_successful_check_run = bool(successful_check_runs) and not observed_app_ids
         if has_successful_status:
             blockers.append(
-                f"{context} is app-pinned to app_id {app_id}, but only a manual "
+                f"{context} is app-pinned to app_id {expected_app_id}, but only a manual "
                 "StatusContext is green"
             )
             suggestions.append(
                 f"rerun the app-sourced {context} check; do not satisfy it with a manual status"
             )
+        elif observed_app_ids:
+            blockers.append(
+                f"{context} is app-pinned to app_id {expected_app_id}, but successful "
+                f"CheckRun app_id(s) were {observed_app_ids}"
+            )
+            suggestions.append(f"rerun the app-sourced {context} check")
+        elif has_unverified_successful_check_run:
+            blockers.append(
+                f"{context} is app-pinned to app_id {expected_app_id}, but CheckRun "
+                "source app could not be verified"
+            )
+            suggestions.append("fetch commit check-runs with app metadata before settlement")
         else:
             blockers.append(
-                f"{context} is app-pinned to app_id {app_id}, but no successful CheckRun is present"
+                f"{context} is app-pinned to app_id {expected_app_id}, but no successful CheckRun is present"
             )
             suggestions.append(f"rerun the app-sourced {context} check")
 
@@ -530,6 +597,19 @@ def build_report(
         )
         report["required_check_source_command"] = protection_cmd
 
+        head_ref = report["head_sha"]
+        if isinstance(pr_view, dict):
+            head_ref = str(pr_view.get("headRefOid") or head_ref)
+        check_runs_payload, check_runs_cmd = _run_json(
+            [
+                "gh",
+                "api",
+                f"repos/{{owner}}/{{repo}}/commits/{head_ref}/check-runs?per_page=100",
+            ],
+            cwd=cwd,
+        )
+        report["check_run_source_command"] = check_runs_cmd
+
         required_checks, required_cmd = _run_json(
             [
                 "gh",
@@ -548,7 +628,7 @@ def build_report(
         blockers.extend(check_report["blockers"])
         report["suggested_commands"].extend(check_report["suggestions"])
 
-        source_report = required_check_source_report(protection, pr_view)
+        source_report = required_check_source_report(protection, pr_view, check_runs_payload)
         report["checks"]["required_sources"] = source_report
         blockers.extend(source_report["blockers"])
         report["suggested_commands"].extend(source_report.get("suggestions") or [])
@@ -559,7 +639,11 @@ def build_report(
         if item.get("status") == "blocked":
             blockers.append(f"validation failed: {item.get('command')}")
 
-    if selected.get("admin_squash_allowed") and selected.get("status") == "satisfied":
+    if (
+        not blockers
+        and selected.get("admin_squash_allowed")
+        and selected.get("status") == "satisfied"
+    ):
         report["status"] = "packet_authorized_dry_run"
         report["suggested_commands"].append(
             f"gh pr merge {pr_number} --squash --match-head-commit {report['head_sha']}"

--- a/scripts/settle_one_pr.py
+++ b/scripts/settle_one_pr.py
@@ -18,6 +18,7 @@ import sys
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 CONVERGENCE_SENTENCE = (
     "If the prompt above accomplishes no incremental progress make the next prompt one "
@@ -296,11 +297,15 @@ def required_check_source_report(
         return {
             "status": "unknown",
             "blockers": ["branch protection required_status_checks JSON unavailable"],
+            "suggestions": [
+                "ensure gh can read branch protection required_status_checks before settlement"
+            ],
         }
     if not isinstance(pr_view, dict):
         return {
             "status": "unknown",
             "blockers": ["PR statusCheckRollup JSON unavailable"],
+            "suggestions": ["rerun gh pr view with statusCheckRollup before settlement"],
         }
 
     rollup = pr_view.get("statusCheckRollup") or []
@@ -308,15 +313,17 @@ def required_check_source_report(
         return {
             "status": "unknown",
             "blockers": ["PR statusCheckRollup is not a list"],
+            "suggestions": ["rerun gh pr view with statusCheckRollup before settlement"],
         }
 
     blockers: list[str] = []
+    suggestions: list[str] = []
     for required in protection.get("checks") or []:
         if not isinstance(required, dict):
             continue
         context = str(required.get("context") or "")
         app_id = required.get("app_id")
-        if not context or app_id is None:
+        if not context or app_id in (None, -1):
             continue
 
         matching = [
@@ -336,13 +343,17 @@ def required_check_source_report(
                 f"{context} is app-pinned to app_id {app_id}, but only a manual "
                 "StatusContext is green"
             )
+            suggestions.append(
+                f"rerun the app-sourced {context} check; do not satisfy it with a manual status"
+            )
         else:
             blockers.append(
                 f"{context} is app-pinned to app_id {app_id}, but no successful CheckRun is present"
             )
+            suggestions.append(f"rerun the app-sourced {context} check")
 
     status = "pass" if not blockers else "blocked"
-    return {"status": status, "blockers": blockers}
+    return {"status": status, "blockers": blockers, "suggestions": suggestions}
 
 
 def validation_report(
@@ -494,18 +505,26 @@ def build_report(
                 "view",
                 str(pr_number),
                 "--json",
-                "number,state,isDraft,headRefOid,headRefName,mergeable,mergeStateStatus,statusCheckRollup",
+                (
+                    "number,state,isDraft,headRefOid,headRefName,baseRefName,mergeable,"
+                    "mergeStateStatus,statusCheckRollup"
+                ),
             ],
             cwd=cwd,
         )
         report["pr_view_check"] = view_cmd
         blockers.extend(head_blockers(selected, pr_view))
 
+        base_ref = "main"
+        if isinstance(pr_view, dict):
+            base_ref = str(pr_view.get("baseRefName") or base_ref)
+        protected_branch = quote(base_ref, safe="")
+
         protection, protection_cmd = _run_json(
             [
                 "gh",
                 "api",
-                "repos/{owner}/{repo}/branches/main/protection/required_status_checks",
+                f"repos/{{owner}}/{{repo}}/branches/{protected_branch}/protection/required_status_checks",
             ],
             cwd=cwd,
         )
@@ -532,6 +551,7 @@ def build_report(
         source_report = required_check_source_report(protection, pr_view)
         report["checks"]["required_sources"] = source_report
         blockers.extend(source_report["blockers"])
+        report["suggested_commands"].extend(source_report.get("suggestions") or [])
 
     should_validate = validate and not blockers
     report["validation"] = validation_report(selected, cwd=cwd, run_validation=should_validate)

--- a/scripts/settle_one_pr.py
+++ b/scripts/settle_one_pr.py
@@ -279,7 +279,10 @@ def _rollup_name(item: dict[str, Any]) -> str:
 
 
 def _rollup_success(item: dict[str, Any]) -> bool:
-    state = str(item.get("state") or item.get("status") or item.get("conclusion") or "").upper()
+    conclusion = str(item.get("conclusion") or "").upper()
+    if conclusion:
+        return conclusion in {"SUCCESS", "SKIPPED", "NEUTRAL"}
+    state = str(item.get("state") or item.get("status") or "").upper()
     return state in {"SUCCESS", "SKIPPED", "NEUTRAL"}
 
 
@@ -605,6 +608,11 @@ def build_report(
                 "gh",
                 "api",
                 f"repos/{{owner}}/{{repo}}/commits/{head_ref}/check-runs?per_page=100",
+                "--jq",
+                (
+                    "{check_runs: [.check_runs[] | "
+                    "{name, status, conclusion, app: {id: .app.id, slug: .app.slug}}]}"
+                ),
             ],
             cwd=cwd,
         )

--- a/tests/scripts/test_settle_one_pr.py
+++ b/tests/scripts/test_settle_one_pr.py
@@ -10,6 +10,7 @@ from scripts.settle_one_pr import (
     owner_blockers,
     recursive_prompt,
     required_check_report,
+    required_check_source_report,
     select_candidate,
 )
 
@@ -173,6 +174,67 @@ def test_cancelled_merge_quorum_suggests_rerun() -> None:
     assert report["status"] == "blocked"
     assert report["blockers"] == ["aragora-merge-quorum is cancelled"]
     assert report["suggestions"] == ["gh run rerun 123456789 --failed"]
+
+
+def test_app_pinned_required_check_blocks_manual_status_spoof() -> None:
+    report = required_check_source_report(
+        {"checks": [{"context": "aragora-merge-quorum", "app_id": 15368}]},
+        {
+            "statusCheckRollup": [
+                {
+                    "__typename": "StatusContext",
+                    "context": "aragora-merge-quorum",
+                    "state": "SUCCESS",
+                }
+            ]
+        },
+    )
+
+    assert report["status"] == "blocked"
+    assert report["blockers"] == [
+        "aragora-merge-quorum is app-pinned to app_id 15368, but only a manual "
+        "StatusContext is green"
+    ]
+
+
+def test_app_pinned_required_check_accepts_successful_check_run() -> None:
+    report = required_check_source_report(
+        {"checks": [{"context": "aragora-merge-quorum", "app_id": 15368}]},
+        {
+            "statusCheckRollup": [
+                {
+                    "__typename": "StatusContext",
+                    "context": "aragora-merge-quorum",
+                    "state": "SUCCESS",
+                },
+                {
+                    "__typename": "CheckRun",
+                    "name": "aragora-merge-quorum",
+                    "conclusion": "SUCCESS",
+                    "workflowName": "Aragora Merge Quorum",
+                },
+            ]
+        },
+    )
+
+    assert report == {"status": "pass", "blockers": []}
+
+
+def test_unpinned_required_check_allows_status_context() -> None:
+    report = required_check_source_report(
+        {"checks": [{"context": "legacy-status", "app_id": None}]},
+        {
+            "statusCheckRollup": [
+                {
+                    "__typename": "StatusContext",
+                    "context": "legacy-status",
+                    "state": "SUCCESS",
+                }
+            ]
+        },
+    )
+
+    assert report == {"status": "pass", "blockers": []}
 
 
 def test_recursive_prompt_always_contains_convergence_sentence() -> None:

--- a/tests/scripts/test_settle_one_pr.py
+++ b/tests/scripts/test_settle_one_pr.py
@@ -216,7 +216,89 @@ def test_app_pinned_required_check_accepts_successful_check_run() -> None:
                     "name": "aragora-merge-quorum",
                     "conclusion": "SUCCESS",
                     "workflowName": "Aragora Merge Quorum",
+                    "checkSuite": {"app": {"databaseId": 15368}},
                 },
+            ]
+        },
+    )
+
+    assert report == {"status": "pass", "blockers": [], "suggestions": []}
+
+
+def test_app_pinned_required_check_blocks_wrong_app_check_run() -> None:
+    report = required_check_source_report(
+        {"checks": [{"context": "aragora-merge-quorum", "app_id": 15368}]},
+        {
+            "statusCheckRollup": [
+                {
+                    "__typename": "CheckRun",
+                    "name": "aragora-merge-quorum",
+                    "conclusion": "SUCCESS",
+                    "checkSuite": {"app": {"databaseId": 42}},
+                }
+            ]
+        },
+    )
+
+    assert report["status"] == "blocked"
+    assert report["blockers"] == [
+        "aragora-merge-quorum is app-pinned to app_id 15368, but successful "
+        "CheckRun app_id(s) were [42]"
+    ]
+    assert report["suggestions"] == ["rerun the app-sourced aragora-merge-quorum check"]
+
+
+def test_app_pinned_required_check_blocks_unverified_check_run_source() -> None:
+    report = required_check_source_report(
+        {"checks": [{"context": "aragora-merge-quorum", "app_id": 15368}]},
+        {
+            "statusCheckRollup": [
+                {
+                    "__typename": "CheckRun",
+                    "name": "aragora-merge-quorum",
+                    "conclusion": "SUCCESS",
+                }
+            ]
+        },
+    )
+
+    assert report["status"] == "blocked"
+    assert report["blockers"] == [
+        "aragora-merge-quorum is app-pinned to app_id 15368, but CheckRun "
+        "source app could not be verified"
+    ]
+    assert report["suggestions"] == ["fetch commit check-runs with app metadata before settlement"]
+
+
+def test_app_pinned_required_check_accepts_rest_check_run_source() -> None:
+    report = required_check_source_report(
+        {"checks": [{"context": "aragora-merge-quorum", "app_id": 15368}]},
+        {"statusCheckRollup": []},
+        {
+            "check_runs": [
+                {
+                    "name": "aragora-merge-quorum",
+                    "conclusion": "success",
+                    "app": {"id": 15368, "slug": "github-actions"},
+                }
+            ]
+        },
+    )
+
+    assert report == {"status": "pass", "blockers": [], "suggestions": []}
+
+
+def test_app_pinned_required_check_treats_neutral_check_run_as_passing() -> None:
+    report = required_check_source_report(
+        {"checks": [{"context": "aragora-merge-quorum", "app_id": 15368}]},
+        {
+            "statusCheckRollup": [
+                {
+                    "__typename": "CheckRun",
+                    "name": "aragora-merge-quorum",
+                    "conclusion": "NEUTRAL",
+                    "checkSuite": {"app": {"databaseId": 15368}},
+                }
             ]
         },
     )
@@ -299,10 +381,23 @@ def test_build_report_reads_required_checks_from_pr_base_branch(monkeypatch) -> 
                 },
                 {"command": "view", "returncode": 0},
             )
-        if args[:2] == ["gh", "api"]:
+        if args[:2] == ["gh", "api"] and args[2].endswith("/required_status_checks"):
             return (
                 {"checks": [{"context": "aragora-merge-quorum", "app_id": 15368}]},
                 {"command": "protection", "returncode": 0},
+            )
+        if args[:2] == ["gh", "api"] and args[2].endswith("/check-runs?per_page=100"):
+            return (
+                {
+                    "check_runs": [
+                        {
+                            "name": "aragora-merge-quorum",
+                            "conclusion": "success",
+                            "app": {"id": 15368},
+                        }
+                    ]
+                },
+                {"command": "check-runs", "returncode": 0},
             )
         if args[:3] == ["gh", "pr", "checks"]:
             return (
@@ -339,6 +434,67 @@ def test_build_report_reads_required_checks_from_pr_base_branch(monkeypatch) -> 
         == "repos/{owner}/{repo}/branches/release%2F2026.05/protection/required_status_checks"
         for cmd in commands
     )
+
+
+def test_build_report_fails_closed_when_required_check_sources_unreadable(monkeypatch) -> None:
+    def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
+        del cwd, timeout
+        if args[:3] == ["python3", "scripts/identify_lane_owner.py", "--pr"]:
+            return {"status": "completed"}, {"command": "owner", "returncode": 0}
+        if args[:3] == ["python3", "scripts/read_operator_steering.py", "--pr"]:
+            return {"message_count": 0}, {"command": "mailbox", "returncode": 0}
+        if args[:3] == ["gh", "pr", "view"]:
+            return (
+                {
+                    "headRefOid": "0000000000000000000000000000000000001009",
+                    "baseRefName": "main",
+                    "isDraft": False,
+                    "mergeable": "MERGEABLE",
+                    "mergeStateStatus": "CLEAN",
+                    "statusCheckRollup": [
+                        {
+                            "__typename": "CheckRun",
+                            "name": "aragora-merge-quorum",
+                            "conclusion": "SUCCESS",
+                        }
+                    ],
+                },
+                {"command": "view", "returncode": 0},
+            )
+        if args[:2] == ["gh", "api"] and args[2].endswith("/required_status_checks"):
+            return None, {"command": "protection", "returncode": 403}
+        if args[:2] == ["gh", "api"] and args[2].endswith("/check-runs?per_page=100"):
+            return {"check_runs": []}, {"command": "check-runs", "returncode": 0}
+        if args[:3] == ["gh", "pr", "checks"]:
+            return (
+                [{"name": "aragora-merge-quorum", "state": "SUCCESS"}],
+                {"command": "checks", "returncode": 0},
+            )
+        raise AssertionError(args)
+
+    monkeypatch.setattr(settle_one_pr, "_run_json", fake_run_json)
+
+    report = build_report(
+        _packet(
+            _entry(
+                1009,
+                status="satisfied",
+                verdict="admin_squash_allowed",
+                admin_squash_allowed=True,
+                reasons=["bounded internal code surface"],
+            ),
+            admin_order=[1009],
+        ),
+        cwd=Path.cwd(),
+        state_root=Path.cwd(),
+        explicit_pr=1009,
+        exclude_prs=set(),
+        live=True,
+        validate=False,
+    )
+
+    assert report["status"] == "blocked"
+    assert "branch protection required_status_checks JSON unavailable" in report["blockers"]
 
 
 def test_recursive_prompt_always_contains_convergence_sentence() -> None:

--- a/tests/scripts/test_settle_one_pr.py
+++ b/tests/scripts/test_settle_one_pr.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import scripts.settle_one_pr as settle_one_pr
 from scripts.settle_one_pr import (
     CONVERGENCE_SENTENCE,
     build_report,
@@ -195,6 +196,9 @@ def test_app_pinned_required_check_blocks_manual_status_spoof() -> None:
         "aragora-merge-quorum is app-pinned to app_id 15368, but only a manual "
         "StatusContext is green"
     ]
+    assert report["suggestions"] == [
+        "rerun the app-sourced aragora-merge-quorum check; do not satisfy it with a manual status"
+    ]
 
 
 def test_app_pinned_required_check_accepts_successful_check_run() -> None:
@@ -217,10 +221,10 @@ def test_app_pinned_required_check_accepts_successful_check_run() -> None:
         },
     )
 
-    assert report == {"status": "pass", "blockers": []}
+    assert report == {"status": "pass", "blockers": [], "suggestions": []}
 
 
-def test_unpinned_required_check_allows_status_context() -> None:
+def test_unpinned_null_required_check_allows_status_context() -> None:
     report = required_check_source_report(
         {"checks": [{"context": "legacy-status", "app_id": None}]},
         {
@@ -234,7 +238,107 @@ def test_unpinned_required_check_allows_status_context() -> None:
         },
     )
 
-    assert report == {"status": "pass", "blockers": []}
+    assert report == {"status": "pass", "blockers": [], "suggestions": []}
+
+
+def test_unpinned_any_source_required_check_allows_status_context() -> None:
+    report = required_check_source_report(
+        {"checks": [{"context": "legacy-status", "app_id": -1}]},
+        {
+            "statusCheckRollup": [
+                {
+                    "__typename": "StatusContext",
+                    "context": "legacy-status",
+                    "state": "SUCCESS",
+                }
+            ]
+        },
+    )
+
+    assert report == {"status": "pass", "blockers": [], "suggestions": []}
+
+
+def test_required_check_source_report_fails_closed_without_protection_json() -> None:
+    report = required_check_source_report(
+        None,
+        {"statusCheckRollup": []},
+    )
+
+    assert report["status"] == "unknown"
+    assert report["blockers"] == ["branch protection required_status_checks JSON unavailable"]
+    assert report["suggestions"] == [
+        "ensure gh can read branch protection required_status_checks before settlement"
+    ]
+
+
+def test_build_report_reads_required_checks_from_pr_base_branch(monkeypatch) -> None:
+    commands: list[list[str]] = []
+
+    def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
+        del cwd, timeout
+        commands.append(args)
+        if args[:3] == ["python3", "scripts/identify_lane_owner.py", "--pr"]:
+            return {"status": "completed"}, {"command": "owner", "returncode": 0}
+        if args[:3] == ["python3", "scripts/read_operator_steering.py", "--pr"]:
+            return {"message_count": 0}, {"command": "mailbox", "returncode": 0}
+        if args[:3] == ["gh", "pr", "view"]:
+            return (
+                {
+                    "headRefOid": "0000000000000000000000000000000000001008",
+                    "baseRefName": "release/2026.05",
+                    "isDraft": False,
+                    "mergeable": "MERGEABLE",
+                    "mergeStateStatus": "CLEAN",
+                    "statusCheckRollup": [
+                        {
+                            "__typename": "CheckRun",
+                            "name": "aragora-merge-quorum",
+                            "conclusion": "SUCCESS",
+                        }
+                    ],
+                },
+                {"command": "view", "returncode": 0},
+            )
+        if args[:2] == ["gh", "api"]:
+            return (
+                {"checks": [{"context": "aragora-merge-quorum", "app_id": 15368}]},
+                {"command": "protection", "returncode": 0},
+            )
+        if args[:3] == ["gh", "pr", "checks"]:
+            return (
+                [{"name": "aragora-merge-quorum", "state": "SUCCESS"}],
+                {"command": "checks", "returncode": 0},
+            )
+        raise AssertionError(args)
+
+    monkeypatch.setattr(settle_one_pr, "_run_json", fake_run_json)
+
+    report = build_report(
+        _packet(
+            _entry(
+                1008,
+                status="satisfied",
+                verdict="admin_squash_allowed",
+                admin_squash_allowed=True,
+                reasons=["bounded internal code surface"],
+            ),
+            admin_order=[1008],
+        ),
+        cwd=Path.cwd(),
+        state_root=Path.cwd(),
+        explicit_pr=1008,
+        exclude_prs=set(),
+        live=True,
+        validate=False,
+    )
+
+    assert report["status"] == "packet_authorized_dry_run"
+    assert any(
+        cmd[:2] == ["gh", "api"]
+        and cmd[2]
+        == "repos/{owner}/{repo}/branches/release%2F2026.05/protection/required_status_checks"
+        for cmd in commands
+    )
 
 
 def test_recursive_prompt_always_contains_convergence_sentence() -> None:

--- a/tests/scripts/test_settle_one_pr.py
+++ b/tests/scripts/test_settle_one_pr.py
@@ -278,6 +278,7 @@ def test_app_pinned_required_check_accepts_rest_check_run_source() -> None:
             "check_runs": [
                 {
                     "name": "aragora-merge-quorum",
+                    "status": "completed",
                     "conclusion": "success",
                     "app": {"id": 15368, "slug": "github-actions"},
                 }


### PR DESCRIPTION
## Summary
- teach settle_one_pr.py to read branch protection required_status_checks.checks
- fail closed when an app-pinned required check is only satisfied by a manual StatusContext
- keep unpinned legacy status contexts allowed

## Validation
- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/scripts/test_settle_one_pr.py -q -p no:cacheprovider
- python3 -m ruff check scripts/settle_one_pr.py tests/scripts/test_settle_one_pr.py
- python3 -m ruff format --check scripts/settle_one_pr.py tests/scripts/test_settle_one_pr.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD