### PR TITLE
chore(tier4): diagnose settlement comments

### DIFF
--- a/scripts/settle_tier4_pr.py
+++ b/scripts/settle_tier4_pr.py
@@ -506,11 +506,12 @@ def evaluate_tier4_gate(
         if unexpected:
             blockers.append(f"merge-packet has unexpected blockers: {', '.join(unexpected)}")
 
+    required_checks_green = _required_checks_are_green(required_checks)
     authorization_precondition_blockers: list[str] = []
     if actual_head == expected_head:
         if not required_checks:
             authorization_precondition_blockers.append(REQUIRED_CHECKS_BLOCKER)
-        elif not _required_checks_are_green(required_checks):
+        elif not required_checks_green:
             pass
         elif not _human_settlement_status_is_success(pr_view):
             authorization_precondition_blockers.append(HUMAN_SETTLEMENT_STATUS_BLOCKER)
@@ -530,7 +531,11 @@ def evaluate_tier4_gate(
         evaluate_member_permissions=not blockers,
     )
     authorized_actions: set[str] = set()
-    if actual_head == expected_head and not authorization_precondition_blockers:
+    if (
+        actual_head == expected_head
+        and required_checks_green
+        and not authorization_precondition_blockers
+    ):
         authorized_actions = _operator_authorized_actions(
             pr_view,
             pr=pr,

--- a/scripts/settle_tier4_pr.py
+++ b/scripts/settle_tier4_pr.py
@@ -131,12 +131,28 @@ def _is_trusted_operator_author(
     *,
     trusted_operator_logins: frozenset[str],
     permission_checker: PermissionChecker,
+    evaluate_member_permissions: bool = True,
 ) -> bool:
     return not _operator_author_rejection_reason(
         item,
         trusted_operator_logins=trusted_operator_logins,
         permission_checker=permission_checker,
+        evaluate_member_permissions=evaluate_member_permissions,
     )
+
+
+def _trusted_member_requires_permission_check(
+    item: dict[str, Any],
+    *,
+    trusted_operator_logins: frozenset[str],
+) -> bool:
+    association = str(item.get("authorAssociation") or "").upper()
+    if association not in TRUSTED_OPERATOR_MEMBER_ASSOCIATIONS:
+        return False
+    login = _author_login(item)
+    if not login:
+        return False
+    return not trusted_operator_logins or login in trusted_operator_logins
 
 
 def _operator_author_rejection_reason(
@@ -144,6 +160,7 @@ def _operator_author_rejection_reason(
     *,
     trusted_operator_logins: frozenset[str],
     permission_checker: PermissionChecker,
+    evaluate_member_permissions: bool = True,
 ) -> str:
     association = str(item.get("authorAssociation") or "").upper()
     if association in TRUSTED_OPERATOR_AUTHOR_ASSOCIATIONS:
@@ -155,6 +172,8 @@ def _operator_author_rejection_reason(
         return f"{association} login <missing> is not available"
     if trusted_operator_logins and login not in trusted_operator_logins:
         return f"{association} login {login} is not in trusted operator allowlist"
+    if not evaluate_member_permissions:
+        return ""
     if not permission_checker(login):
         return f"trusted member {login or '<missing>'} lacks admin permission"
     return ""
@@ -180,6 +199,7 @@ def _authorization_diagnostic(
     require_branch_protection_token: bool,
     trusted_operator_logins: frozenset[str],
     permission_checker: PermissionChecker,
+    evaluate_member_permissions: bool = True,
 ) -> dict[str, Any]:
     body = str(item.get("body") or "")
     association = str(item.get("authorAssociation") or "").upper()
@@ -188,7 +208,13 @@ def _authorization_diagnostic(
         item,
         trusted_operator_logins=trusted_operator_logins,
         permission_checker=permission_checker,
+        evaluate_member_permissions=evaluate_member_permissions,
     )
+    admin_permission_required = _trusted_member_requires_permission_check(
+        item,
+        trusted_operator_logins=trusted_operator_logins,
+    )
+    admin_permission_evaluated = admin_permission_required and evaluate_member_permissions
     trusted_author_association = not author_rejection
     fresh_after_head_commit = _authorization_is_fresh(item, head_committed_at=head_committed_at)
     exact_head_present = head in body
@@ -201,6 +227,10 @@ def _authorization_diagnostic(
         rejection_reasons.append("authorization marker is missing")
     if author_rejection:
         rejection_reasons.append(author_rejection)
+    if admin_permission_required and not evaluate_member_permissions:
+        rejection_reasons.append(
+            "trusted member admin permission was not evaluated because earlier gate blockers are present"
+        )
     if not fresh_after_head_commit:
         rejection_reasons.append("authorization is older than head commit")
     if not exact_head_present:
@@ -218,6 +248,8 @@ def _authorization_diagnostic(
         "url": item.get("url"),
         "marker_present": marker_present,
         "trusted_author_association": trusted_author_association,
+        "admin_permission_required": admin_permission_required,
+        "admin_permission_evaluated": admin_permission_evaluated,
         "fresh_after_head_commit": fresh_after_head_commit,
         "exact_head_present": exact_head_present,
         "merge_action_present": merge_action_present,
@@ -238,12 +270,16 @@ def authorization_diagnostics(
     cwd: Path | None = None,
     trusted_operator_logins: Sequence[str] | None = None,
     permission_checker: PermissionChecker | None = None,
+    evaluate_member_permissions: bool = True,
 ) -> dict[str, Any]:
     head_committed_at = _head_committed_at(pr_view)
     allowed_logins = _trusted_operator_logins(trusted_operator_logins)
     checker = permission_checker or (lambda login: _login_has_admin_permission(login, repo, cwd))
     return {
         "required_author_associations": sorted(TRUSTED_OPERATOR_AUTHOR_ASSOCIATIONS),
+        "admin_permission_evaluation": "enabled"
+        if evaluate_member_permissions
+        else "skipped_early_gate_blockers",
         "head_committed_at": head_committed_at,
         "settlement_comment_template": _settlement_comment_template(pr=pr, head=head),
         "authorization_diagnostics": [
@@ -254,6 +290,7 @@ def authorization_diagnostics(
                 require_branch_protection_token=require_branch_protection_token,
                 trusted_operator_logins=allowed_logins,
                 permission_checker=checker,
+                evaluate_member_permissions=evaluate_member_permissions,
             )
             for item in _text_items(pr_view)
         ],
@@ -474,6 +511,7 @@ def evaluate_tier4_gate(
         cwd=cwd,
         trusted_operator_logins=trusted_operator_logins,
         permission_checker=permission_checker,
+        evaluate_member_permissions=not blockers,
     )
     authorized_actions: set[str] = set()
     if actual_head == expected_head:

--- a/scripts/settle_tier4_pr.py
+++ b/scripts/settle_tier4_pr.py
@@ -26,6 +26,10 @@ TRUSTED_OPERATOR_MEMBER_ASSOCIATIONS = {"MEMBER"}
 TRUSTED_OPERATOR_LOGINS_ENV = "ARAGORA_TIER4_TRUSTED_OPERATORS"
 PermissionChecker = Callable[[str], bool]
 HUMAN_SETTLEMENT_CONTEXT = "aragora/human-settlement"
+HUMAN_SETTLEMENT_STATUS_BLOCKER = f"missing or unsuccessful {HUMAN_SETTLEMENT_CONTEXT} status"
+OPERATOR_COMMENT_BLOCKER = "missing repo-visible Tier 4 operator settlement comment"
+REQUIRED_CHECKS_BLOCKER = "required checks are missing"
+TIER4_EVIDENCE_BLOCKER = "missing Tier 4 model/dogfood settlement evidence"
 SUCCESS_STATES = {"SUCCESS", "PASS", "PASSED", "SKIPPED", "NEUTRAL"}
 MIN_TIER4_COUNTED_REVIEWER_IDS = 2
 ALLOWED_TIER4_NOT_READY = {
@@ -502,6 +506,18 @@ def evaluate_tier4_gate(
         if unexpected:
             blockers.append(f"merge-packet has unexpected blockers: {', '.join(unexpected)}")
 
+    authorization_precondition_blockers: list[str] = []
+    if actual_head == expected_head:
+        if not required_checks:
+            authorization_precondition_blockers.append(REQUIRED_CHECKS_BLOCKER)
+        elif not _required_checks_are_green(required_checks):
+            pass
+        elif not _human_settlement_status_is_success(pr_view):
+            authorization_precondition_blockers.append(HUMAN_SETTLEMENT_STATUS_BLOCKER)
+        elif not _packet_has_counted_tier4_evidence(merge_packet, pr=pr):
+            authorization_precondition_blockers.append(TIER4_EVIDENCE_BLOCKER)
+    blockers.extend(authorization_precondition_blockers)
+
     diagnostic_report = authorization_diagnostics(
         pr_view,
         pr=pr,
@@ -514,7 +530,7 @@ def evaluate_tier4_gate(
         evaluate_member_permissions=not blockers,
     )
     authorized_actions: set[str] = set()
-    if actual_head == expected_head:
+    if actual_head == expected_head and not authorization_precondition_blockers:
         authorized_actions = _operator_authorized_actions(
             pr_view,
             pr=pr,
@@ -529,7 +545,7 @@ def evaluate_tier4_gate(
             diagnostic_report=diagnostic_report,
         )
         if not authorized_actions:
-            blockers.append("missing repo-visible Tier 4 operator settlement comment")
+            blockers.append(OPERATOR_COMMENT_BLOCKER)
 
     return {
         "ok": not blockers,

--- a/scripts/settle_tier4_pr.py
+++ b/scripts/settle_tier4_pr.py
@@ -50,9 +50,11 @@ def _text_items(pr_view: dict[str, Any]) -> list[dict[str, Any]]:
                 if isinstance(body, str):
                     items.append(
                         {
+                            "kind": "review" if key == "reviews" else "comment",
                             "body": body,
                             "authorAssociation": entry.get("authorAssociation"),
                             "author": entry.get("author"),
+                            "url": entry.get("url"),
                             "createdAt": entry.get("createdAt") or entry.get("submittedAt"),
                         }
                     )
@@ -130,17 +132,132 @@ def _is_trusted_operator_author(
     trusted_operator_logins: frozenset[str],
     permission_checker: PermissionChecker,
 ) -> bool:
+    return not _operator_author_rejection_reason(
+        item,
+        trusted_operator_logins=trusted_operator_logins,
+        permission_checker=permission_checker,
+    )
+
+
+def _operator_author_rejection_reason(
+    item: dict[str, Any],
+    *,
+    trusted_operator_logins: frozenset[str],
+    permission_checker: PermissionChecker,
+) -> str:
     association = str(item.get("authorAssociation") or "").upper()
     if association in TRUSTED_OPERATOR_AUTHOR_ASSOCIATIONS:
-        return True
+        return ""
     if association not in TRUSTED_OPERATOR_MEMBER_ASSOCIATIONS:
-        return False
+        return f"authorAssociation {association or '<missing>'} is not trusted"
     login = _author_login(item)
     if not login:
-        return False
+        return f"{association} login <missing> is not available"
     if trusted_operator_logins and login not in trusted_operator_logins:
-        return False
-    return permission_checker(login)
+        return f"{association} login {login} is not in trusted operator allowlist"
+    if not permission_checker(login):
+        return f"trusted member {login or '<missing>'} lacks admin permission"
+    return ""
+
+
+def _settlement_comment_template(*, pr: int, head: str) -> str:
+    return (
+        "Tier-4 Human Settlement Authorization\n\n"
+        f"PR: #{pr}\n"
+        f"Exact head: {head}\n"
+        "Authorized action: admin_squash_merge and branch_protection_reconcile, "
+        f"only if #{pr} is non-draft and live exact-head checks/merge-packet "
+        "remain otherwise green.\n\n"
+        "Human-risk settlement: I accept the Tier 4 risk for this PR."
+    )
+
+
+def _authorization_diagnostic(
+    item: dict[str, Any],
+    *,
+    head: str,
+    head_committed_at: str,
+    require_branch_protection_token: bool,
+    trusted_operator_logins: frozenset[str],
+    permission_checker: PermissionChecker,
+) -> dict[str, Any]:
+    body = str(item.get("body") or "")
+    association = str(item.get("authorAssociation") or "").upper()
+    marker_present = AUTHORIZED_MARKER in body
+    author_rejection = _operator_author_rejection_reason(
+        item,
+        trusted_operator_logins=trusted_operator_logins,
+        permission_checker=permission_checker,
+    )
+    trusted_author_association = not author_rejection
+    fresh_after_head_commit = _authorization_is_fresh(item, head_committed_at=head_committed_at)
+    exact_head_present = head in body
+    authorized_actions = _comment_authorized_actions(body)
+    merge_action_present = "merge" in authorized_actions
+    branch_protection_action_present = "branch_protection" in authorized_actions
+
+    rejection_reasons: list[str] = []
+    if not marker_present:
+        rejection_reasons.append("authorization marker is missing")
+    if author_rejection:
+        rejection_reasons.append(author_rejection)
+    if not fresh_after_head_commit:
+        rejection_reasons.append("authorization is older than head commit")
+    if not exact_head_present:
+        rejection_reasons.append("exact head is missing")
+    if not merge_action_present:
+        rejection_reasons.append("admin_squash_merge action is missing")
+    if require_branch_protection_token and not branch_protection_action_present:
+        rejection_reasons.append("branch_protection_reconcile action is missing")
+
+    return {
+        "kind": item.get("kind") or "text",
+        "author": _author_login(item),
+        "authorAssociation": association,
+        "createdAt": item.get("createdAt"),
+        "url": item.get("url"),
+        "marker_present": marker_present,
+        "trusted_author_association": trusted_author_association,
+        "fresh_after_head_commit": fresh_after_head_commit,
+        "exact_head_present": exact_head_present,
+        "merge_action_present": merge_action_present,
+        "branch_protection_action_present": branch_protection_action_present,
+        "authorized_actions": sorted(authorized_actions),
+        "accepted": not rejection_reasons,
+        "rejection_reasons": rejection_reasons,
+    }
+
+
+def authorization_diagnostics(
+    pr_view: dict[str, Any],
+    *,
+    pr: int,
+    head: str,
+    require_branch_protection_token: bool = False,
+    repo: str = DEFAULT_REPO,
+    cwd: Path | None = None,
+    trusted_operator_logins: Sequence[str] | None = None,
+    permission_checker: PermissionChecker | None = None,
+) -> dict[str, Any]:
+    head_committed_at = _head_committed_at(pr_view)
+    allowed_logins = _trusted_operator_logins(trusted_operator_logins)
+    checker = permission_checker or (lambda login: _login_has_admin_permission(login, repo, cwd))
+    return {
+        "required_author_associations": sorted(TRUSTED_OPERATOR_AUTHOR_ASSOCIATIONS),
+        "head_committed_at": head_committed_at,
+        "settlement_comment_template": _settlement_comment_template(pr=pr, head=head),
+        "authorization_diagnostics": [
+            _authorization_diagnostic(
+                item,
+                head=head,
+                head_committed_at=head_committed_at,
+                require_branch_protection_token=require_branch_protection_token,
+                trusted_operator_logins=allowed_logins,
+                permission_checker=checker,
+            )
+            for item in _text_items(pr_view)
+        ],
+    }
 
 
 def _state_is_success(value: Any) -> bool:
@@ -225,6 +342,7 @@ def _operator_authorized_actions(
     cwd: Path | None = None,
     trusted_operator_logins: Sequence[str] | None = None,
     permission_checker: PermissionChecker | None = None,
+    diagnostic_report: dict[str, Any] | None = None,
 ) -> set[str]:
     if not _required_checks_are_green(required_checks):
         return set()
@@ -233,27 +351,25 @@ def _operator_authorized_actions(
     if not _packet_has_counted_tier4_evidence(merge_packet, pr=pr):
         return set()
 
-    head_committed_at = _head_committed_at(pr_view)
-    allowed_logins = _trusted_operator_logins(trusted_operator_logins)
-    checker = permission_checker or (lambda login: _login_has_admin_permission(login, repo, cwd))
-    for item in _text_items(pr_view):
-        body = str(item.get("body") or "")
-        if AUTHORIZED_MARKER not in body:
+    report = diagnostic_report
+    if report is None:
+        report = authorization_diagnostics(
+            pr_view,
+            pr=pr,
+            head=head,
+            require_branch_protection_token=require_branch_protection_token,
+            repo=repo,
+            cwd=cwd,
+            trusted_operator_logins=trusted_operator_logins,
+            permission_checker=permission_checker,
+        )
+    for diagnostic in report.get("authorization_diagnostics", []):
+        if not isinstance(diagnostic, dict) or not diagnostic.get("accepted"):
             continue
-        if not _is_trusted_operator_author(
-            item,
-            trusted_operator_logins=allowed_logins,
-            permission_checker=checker,
-        ):
-            continue
-        if not _authorization_is_fresh(item, head_committed_at=head_committed_at):
-            continue
-        if head not in body:
-            continue
-        if _comment_authorizes_requested_action(
-            body, require_branch_protection_token=require_branch_protection_token
-        ):
-            return _comment_authorized_actions(body)
+        actions = diagnostic.get("authorized_actions")
+        if not isinstance(actions, list):
+            return set()
+        return {str(action) for action in actions if str(action)}
     return set()
 
 
@@ -269,6 +385,7 @@ def has_operator_authorization(
     cwd: Path | None = None,
     trusted_operator_logins: Sequence[str] | None = None,
     permission_checker: PermissionChecker | None = None,
+    diagnostic_report: dict[str, Any] | None = None,
 ) -> bool:
     return bool(
         _operator_authorized_actions(
@@ -282,6 +399,7 @@ def has_operator_authorization(
             cwd=cwd,
             trusted_operator_logins=trusted_operator_logins,
             permission_checker=permission_checker,
+            diagnostic_report=diagnostic_report,
         )
     )
 
@@ -346,6 +464,17 @@ def evaluate_tier4_gate(
         unexpected = sorted({str(item) for item in not_ready} - allowed_not_ready)
         if unexpected:
             blockers.append(f"merge-packet has unexpected blockers: {', '.join(unexpected)}")
+
+    diagnostic_report = authorization_diagnostics(
+        pr_view,
+        pr=pr,
+        head=expected_head,
+        require_branch_protection_token=require_branch_protection_token,
+        repo=repo,
+        cwd=cwd,
+        trusted_operator_logins=trusted_operator_logins,
+        permission_checker=permission_checker,
+    )
     authorized_actions: set[str] = set()
     if actual_head == expected_head:
         authorized_actions = _operator_authorized_actions(
@@ -359,6 +488,7 @@ def evaluate_tier4_gate(
             cwd=cwd,
             trusted_operator_logins=trusted_operator_logins,
             permission_checker=permission_checker,
+            diagnostic_report=diagnostic_report,
         )
         if not authorized_actions:
             blockers.append("missing repo-visible Tier 4 operator settlement comment")
@@ -371,6 +501,7 @@ def evaluate_tier4_gate(
         "merge_state": merge_state,
         "blockers": blockers,
         "authorized_actions": sorted(authorized_actions),
+        **diagnostic_report,
     }
 
 

--- a/scripts/settle_tier4_pr.py
+++ b/scripts/settle_tier4_pr.py
@@ -535,6 +535,7 @@ def evaluate_tier4_gate(
         actual_head == expected_head
         and required_checks_green
         and not authorization_precondition_blockers
+        and not blockers
     ):
         authorized_actions = _operator_authorized_actions(
             pr_view,

--- a/tests/scripts/test_settle_tier4_pr.py
+++ b/tests/scripts/test_settle_tier4_pr.py
@@ -532,6 +532,7 @@ def test_failed_required_check_blocks_settlement() -> None:
 
     assert result["ok"] is False
     assert "required check lint is FAILURE" in result["blockers"]
+    assert "missing repo-visible Tier 4 operator settlement comment" not in result["blockers"]
 
 
 def test_failed_required_check_skips_member_permission_check(monkeypatch: Any) -> None:
@@ -601,6 +602,7 @@ def test_present_failed_merge_quorum_required_check_blocks_settlement() -> None:
 
     assert result["ok"] is False
     assert "required check aragora-merge-quorum is FAILURE" in result["blockers"]
+    assert "missing repo-visible Tier 4 operator settlement comment" not in result["blockers"]
 
 
 def test_unexpected_merge_packet_blocker_blocks_settlement() -> None:

--- a/tests/scripts/test_settle_tier4_pr.py
+++ b/tests/scripts/test_settle_tier4_pr.py
@@ -621,6 +621,48 @@ def test_unexpected_merge_packet_blocker_blocks_settlement() -> None:
     assert "merge-packet has unexpected blockers: model_quorum" in result["blockers"]
 
 
+def test_unexpected_packet_blocker_does_not_report_missing_trusted_member_comment(
+    monkeypatch: Any,
+) -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    packet = _tier4_packet()
+    packet["not_ready"] = ["human_risk_settlement", "model_quorum"]
+    monkeypatch.setenv("ARAGORA_TIER4_TRUSTED_OPERATORS", "trusted-member")
+
+    def permission_checker(login: str) -> bool:
+        raise AssertionError(f"permission check should be lazy, got {login}")
+
+    result = settler.evaluate_tier4_gate(
+        pr=7423,
+        expected_head=head,
+        pr_view=_pr_view(
+            head,
+            comments=[
+                _authorized_comment(
+                    head,
+                    association="MEMBER",
+                    author="trusted-member",
+                )
+            ],
+        ),
+        merge_packet=packet,
+        required_checks=_valid_checks(),
+        permission_checker=permission_checker,
+    )
+
+    diagnostic = result["authorization_diagnostics"][0]
+    assert result["ok"] is False
+    assert "merge-packet has unexpected blockers: model_quorum" in result["blockers"]
+    assert "missing repo-visible Tier 4 operator settlement comment" not in result["blockers"]
+    assert result["admin_permission_evaluation"] == "skipped_early_gate_blockers"
+    assert diagnostic["admin_permission_required"] is True
+    assert diagnostic["admin_permission_evaluated"] is False
+    assert (
+        "trusted member admin permission was not evaluated because earlier gate blockers are present"
+        in diagnostic["rejection_reasons"]
+    )
+
+
 def test_authorization_diagnostics_explain_member_rejection() -> None:
     head = "57c740022e3c432718462efa12ca79f1df4f674d"
     result = settler.evaluate_tier4_gate(

--- a/tests/scripts/test_settle_tier4_pr.py
+++ b/tests/scripts/test_settle_tier4_pr.py
@@ -110,19 +110,13 @@ def _valid_checks() -> list[dict[str, str]]:
 
 
 def test_missing_operator_comment_blocks_settlement() -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
     result = settler.evaluate_tier4_gate(
         pr=7423,
-        expected_head="57c740022e3c432718462efa12ca79f1df4f674d",
-        pr_view={
-            "headRefOid": "57c740022e3c432718462efa12ca79f1df4f674d",
-            "state": "OPEN",
-            "isDraft": False,
-            "mergeStateStatus": "BLOCKED",
-            "headCommittedDate": HEAD_COMMITTED_AT,
-            "comments": [{"body": "looks good"}],
-            "reviews": [],
-        },
-        merge_packet={"admin_squash_allowed": False, "not_ready": ["human_risk_settlement"]},
+        expected_head=head,
+        pr_view=_pr_view(head, comments=[{"body": "looks good"}]),
+        merge_packet=_tier4_packet(),
+        required_checks=_valid_checks(),
     )
 
     assert result["ok"] is False
@@ -172,14 +166,14 @@ def test_member_operator_comment_with_status_and_evidence_allows_check_result() 
     assert result["blockers"] == []
 
 
-def test_member_operator_comment_without_human_status_does_not_authorize() -> None:
+def test_operator_comment_without_human_status_does_not_authorize() -> None:
     head = "57c740022e3c432718462efa12ca79f1df4f674d"
     result = settler.evaluate_tier4_gate(
         pr=7423,
         expected_head=head,
         pr_view=_pr_view(
             head,
-            comments=[_authorized_comment(head, association="MEMBER")],
+            comments=[_authorized_comment(head)],
             human_settlement_state=None,
         ),
         merge_packet=_tier4_packet(),
@@ -187,7 +181,8 @@ def test_member_operator_comment_without_human_status_does_not_authorize() -> No
     )
 
     assert result["ok"] is False
-    assert "missing repo-visible Tier 4 operator settlement comment" in result["blockers"]
+    assert "missing or unsuccessful aragora/human-settlement status" in result["blockers"]
+    assert "missing repo-visible Tier 4 operator settlement comment" not in result["blockers"]
 
 
 def test_operator_comment_without_counted_evidence_does_not_authorize() -> None:
@@ -201,7 +196,23 @@ def test_operator_comment_without_counted_evidence_does_not_authorize() -> None:
     )
 
     assert result["ok"] is False
-    assert "missing repo-visible Tier 4 operator settlement comment" in result["blockers"]
+    assert "missing Tier 4 model/dogfood settlement evidence" in result["blockers"]
+    assert "missing repo-visible Tier 4 operator settlement comment" not in result["blockers"]
+
+
+def test_missing_required_checks_report_distinct_blocker() -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    result = settler.evaluate_tier4_gate(
+        pr=7423,
+        expected_head=head,
+        pr_view=_pr_view(head, comments=[_authorized_comment(head)]),
+        merge_packet=_tier4_packet(),
+        required_checks=[],
+    )
+
+    assert result["ok"] is False
+    assert "required checks are missing" in result["blockers"]
+    assert "missing repo-visible Tier 4 operator settlement comment" not in result["blockers"]
 
 
 def test_branch_protection_mode_requires_branch_protection_token() -> None:
@@ -276,16 +287,11 @@ def test_untrusted_member_comment_does_not_authorize() -> None:
     result = settler.evaluate_tier4_gate(
         pr=7423,
         expected_head=head,
-        pr_view={
-            "headRefOid": head,
-            "state": "OPEN",
-            "isDraft": False,
-            "mergeStateStatus": "BLOCKED",
-            "headCommittedDate": HEAD_COMMITTED_AT,
-            "comments": [_authorized_comment(head, association="MEMBER", author="random-member")],
-            "reviews": [],
-        },
-        merge_packet={"admin_squash_allowed": False, "not_ready": ["human_risk_settlement"]},
+        pr_view=_pr_view(
+            head,
+            comments=[_authorized_comment(head, association="MEMBER", author="random-member")],
+        ),
+        merge_packet=_tier4_packet(),
         required_checks=_valid_checks(),
     )
 
@@ -343,16 +349,11 @@ def test_trusted_member_comment_requires_admin_permission(monkeypatch: Any) -> N
     result = settler.evaluate_tier4_gate(
         pr=7423,
         expected_head=head,
-        pr_view={
-            "headRefOid": head,
-            "state": "OPEN",
-            "isDraft": False,
-            "mergeStateStatus": "BLOCKED",
-            "headCommittedDate": HEAD_COMMITTED_AT,
-            "comments": [_authorized_comment(head, association="MEMBER", author="trusted-member")],
-            "reviews": [],
-        },
-        merge_packet={"admin_squash_allowed": False, "not_ready": ["human_risk_settlement"]},
+        pr_view=_pr_view(
+            head,
+            comments=[_authorized_comment(head, association="MEMBER", author="trusted-member")],
+        ),
+        merge_packet=_tier4_packet(),
         required_checks=_valid_checks(),
         permission_checker=lambda login: False,
     )
@@ -430,16 +431,8 @@ def test_authorization_comment_for_different_head_does_not_authorize() -> None:
     result = settler.evaluate_tier4_gate(
         pr=7423,
         expected_head=head,
-        pr_view={
-            "headRefOid": head,
-            "state": "OPEN",
-            "isDraft": False,
-            "mergeStateStatus": "BLOCKED",
-            "headCommittedDate": HEAD_COMMITTED_AT,
-            "comments": [_authorized_comment("different-head")],
-            "reviews": [],
-        },
-        merge_packet={"admin_squash_allowed": False, "not_ready": ["human_risk_settlement"]},
+        pr_view=_pr_view(head, comments=[_authorized_comment("different-head")]),
+        merge_packet=_tier4_packet(),
         required_checks=_valid_checks(),
     )
 

--- a/tests/scripts/test_settle_tier4_pr.py
+++ b/tests/scripts/test_settle_tier4_pr.py
@@ -484,6 +484,46 @@ def test_head_mismatch_blocks_before_authorization() -> None:
     assert "head mismatch: expected expected, got actual" in result["blockers"]
 
 
+def test_head_mismatch_skips_member_permission_check(monkeypatch: Any) -> None:
+    monkeypatch.setenv("ARAGORA_TIER4_TRUSTED_OPERATORS", "trusted-member")
+
+    def permission_checker(login: str) -> bool:
+        raise AssertionError(f"permission check should be lazy, got {login}")
+
+    result = settler.evaluate_tier4_gate(
+        pr=7423,
+        expected_head="expected",
+        pr_view={
+            "headRefOid": "actual",
+            "state": "OPEN",
+            "isDraft": False,
+            "mergeStateStatus": "BLOCKED",
+            "headCommittedDate": HEAD_COMMITTED_AT,
+            "comments": [
+                _authorized_comment(
+                    "expected",
+                    association="MEMBER",
+                    author="trusted-member",
+                )
+            ],
+            "reviews": [],
+            "statusCheckRollup": [{"context": "aragora/human-settlement", "state": "SUCCESS"}],
+        },
+        merge_packet=_tier4_packet(),
+        required_checks=_valid_checks(),
+        permission_checker=permission_checker,
+    )
+
+    diagnostic = result["authorization_diagnostics"][0]
+    assert result["admin_permission_evaluation"] == "skipped_early_gate_blockers"
+    assert diagnostic["admin_permission_required"] is True
+    assert diagnostic["admin_permission_evaluated"] is False
+    assert (
+        "trusted member admin permission was not evaluated because earlier gate blockers are present"
+        in diagnostic["rejection_reasons"]
+    )
+
+
 def test_failed_required_check_blocks_settlement() -> None:
     head = "57c740022e3c432718462efa12ca79f1df4f674d"
     result = settler.evaluate_tier4_gate(
@@ -499,6 +539,44 @@ def test_failed_required_check_blocks_settlement() -> None:
 
     assert result["ok"] is False
     assert "required check lint is FAILURE" in result["blockers"]
+
+
+def test_failed_required_check_skips_member_permission_check(monkeypatch: Any) -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    monkeypatch.setenv("ARAGORA_TIER4_TRUSTED_OPERATORS", "trusted-member")
+
+    def permission_checker(login: str) -> bool:
+        raise AssertionError(f"permission check should be lazy, got {login}")
+
+    result = settler.evaluate_tier4_gate(
+        pr=7423,
+        expected_head=head,
+        pr_view=_pr_view(
+            head,
+            comments=[
+                _authorized_comment(
+                    head,
+                    association="MEMBER",
+                    author="trusted-member",
+                )
+            ],
+        ),
+        merge_packet=_tier4_packet(),
+        required_checks=[
+            {"name": "lint", "state": "FAILURE"},
+            {"name": "aragora-merge-quorum", "state": "SUCCESS"},
+        ],
+        permission_checker=permission_checker,
+    )
+
+    diagnostic = result["authorization_diagnostics"][0]
+    assert result["admin_permission_evaluation"] == "skipped_early_gate_blockers"
+    assert diagnostic["admin_permission_required"] is True
+    assert diagnostic["admin_permission_evaluated"] is False
+    assert (
+        "trusted member admin permission was not evaluated because earlier gate blockers are present"
+        in diagnostic["rejection_reasons"]
+    )
 
 
 def test_missing_merge_quorum_check_is_allowed_before_apply_reconciles_protection() -> None:

--- a/tests/scripts/test_settle_tier4_pr.py
+++ b/tests/scripts/test_settle_tier4_pr.py
@@ -556,6 +556,7 @@ def test_authorization_diagnostics_explain_member_rejection() -> None:
         pr_view=_pr_view(head, comments=[_authorized_comment(head, association="MEMBER")]),
         merge_packet=_tier4_packet(),
         required_checks=_valid_checks(),
+        trusted_operator_logins=["trusted-member"],
     )
 
     assert result["ok"] is False

--- a/tests/scripts/test_settle_tier4_pr.py
+++ b/tests/scripts/test_settle_tier4_pr.py
@@ -42,6 +42,7 @@ def _authorized_comment(
         "authorAssociation": association,
         "author": {"login": author},
         "createdAt": AUTH_CREATED_AT,
+        "url": "https://github.example/pr/7423#issuecomment-1",
         "body": (
             "Tier-4 Human Settlement Authorization\n"
             f"Authorized Head SHA: {head}\n"
@@ -311,6 +312,31 @@ def test_configured_trusted_member_comment_authorizes(monkeypatch: Any) -> None:
     assert result["blockers"] == []
 
 
+def test_configured_trusted_member_permission_check_runs_once(monkeypatch: Any) -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    checked_logins: list[str] = []
+    monkeypatch.setenv("ARAGORA_TIER4_TRUSTED_OPERATORS", "trusted-member")
+
+    def permission_checker(login: str) -> bool:
+        checked_logins.append(login)
+        return login == "trusted-member"
+
+    result = settler.evaluate_tier4_gate(
+        pr=7423,
+        expected_head=head,
+        pr_view=_pr_view(
+            head,
+            comments=[_authorized_comment(head, association="MEMBER", author="trusted-member")],
+        ),
+        merge_packet=_tier4_packet(),
+        required_checks=_valid_checks(),
+        permission_checker=permission_checker,
+    )
+
+    assert result["ok"] is True
+    assert checked_logins == ["trusted-member"]
+
+
 def test_trusted_member_comment_requires_admin_permission(monkeypatch: Any) -> None:
     head = "57c740022e3c432718462efa12ca79f1df4f674d"
     monkeypatch.setenv("ARAGORA_TIER4_TRUSTED_OPERATORS", "trusted-member")
@@ -431,6 +457,7 @@ def test_stale_authorization_comment_does_not_authorize() -> None:
         pr_view=_pr_view(head, comments=[stale]),
         merge_packet=_tier4_packet(),
         required_checks=_valid_checks(),
+        trusted_operator_logins=["trusted-member"],
     )
 
     assert result["ok"] is False
@@ -519,6 +546,143 @@ def test_unexpected_merge_packet_blocker_blocks_settlement() -> None:
 
     assert result["ok"] is False
     assert "merge-packet has unexpected blockers: model_quorum" in result["blockers"]
+
+
+def test_authorization_diagnostics_explain_member_rejection() -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    result = settler.evaluate_tier4_gate(
+        pr=7423,
+        expected_head=head,
+        pr_view=_pr_view(head, comments=[_authorized_comment(head, association="MEMBER")]),
+        merge_packet=_tier4_packet(),
+        required_checks=_valid_checks(),
+    )
+
+    assert result["ok"] is False
+    assert result["required_author_associations"] == ["OWNER"]
+    assert "Tier-4 Human Settlement Authorization" in result["settlement_comment_template"]
+    assert "PR: #7423" in result["settlement_comment_template"]
+    assert f"Exact head: {head}" in result["settlement_comment_template"]
+    assert (
+        "admin_squash_merge and branch_protection_reconcile"
+        in result["settlement_comment_template"]
+    )
+    diagnostics = result["authorization_diagnostics"]
+    assert len(diagnostics) == 1
+    diagnostic = diagnostics[0]
+    assert diagnostic["kind"] == "comment"
+    assert diagnostic["author"] == "owner-user"
+    assert diagnostic["authorAssociation"] == "MEMBER"
+    assert diagnostic["url"] == "https://github.example/pr/7423#issuecomment-1"
+    assert diagnostic["marker_present"] is True
+    assert diagnostic["trusted_author_association"] is False
+    assert diagnostic["fresh_after_head_commit"] is True
+    assert diagnostic["exact_head_present"] is True
+    assert diagnostic["merge_action_present"] is True
+    assert diagnostic["branch_protection_action_present"] is True
+    assert diagnostic["accepted"] is False
+    assert diagnostic["rejection_reasons"] == [
+        "MEMBER login owner-user is not in trusted operator allowlist"
+    ]
+
+
+def test_authorization_diagnostics_accept_owner_comment() -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    result = settler.evaluate_tier4_gate(
+        pr=7423,
+        expected_head=head,
+        pr_view=_pr_view(head, comments=[_authorized_comment(head)]),
+        merge_packet=_tier4_packet(),
+        required_checks=_valid_checks(),
+    )
+
+    assert result["ok"] is True
+    assert result["authorization_diagnostics"][0]["accepted"] is True
+    assert result["authorization_diagnostics"][0]["rejection_reasons"] == []
+
+
+def test_authorization_diagnostics_report_stale_comment() -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    stale = _authorized_comment(head)
+    stale["createdAt"] = "2026-05-21T23:59:00Z"
+    result = settler.evaluate_tier4_gate(
+        pr=7423,
+        expected_head=head,
+        pr_view=_pr_view(head, comments=[stale]),
+        merge_packet=_tier4_packet(),
+        required_checks=_valid_checks(),
+    )
+
+    assert result["authorization_diagnostics"][0]["fresh_after_head_commit"] is False
+    assert result["authorization_diagnostics"][0]["rejection_reasons"] == [
+        "authorization is older than head commit"
+    ]
+
+
+def test_authorization_diagnostics_report_missing_head_and_tokens() -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    bad = _authorized_comment("different-head")
+    bad["body"] = (
+        "Tier-4 Human Settlement Authorization\n"
+        "PR: #7423\n"
+        "Exact head: different-head\n"
+        "Authorized action: admin_squash_merge only\n"
+    )
+    result = settler.evaluate_tier4_gate(
+        pr=7423,
+        expected_head=head,
+        pr_view=_pr_view(head, comments=[bad]),
+        merge_packet=_tier4_packet(),
+        required_checks=_valid_checks(),
+        require_branch_protection_token=True,
+    )
+
+    diagnostic = result["authorization_diagnostics"][0]
+    assert diagnostic["exact_head_present"] is False
+    assert diagnostic["merge_action_present"] is True
+    assert diagnostic["branch_protection_action_present"] is False
+    assert diagnostic["rejection_reasons"] == [
+        "exact head is missing",
+        "branch_protection_reconcile action is missing",
+    ]
+
+
+def test_check_json_includes_authorization_diagnostics(
+    monkeypatch: Any, tmp_path: Path, capsys: Any
+) -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    monkeypatch.setattr(
+        settler,
+        "_load_live_inputs",
+        lambda pr, cwd: (
+            _pr_view(head, comments=[_authorized_comment(head, association="MEMBER")]),
+            _tier4_packet(),
+            _valid_checks(),
+        ),
+    )
+
+    rc = settler.main(
+        [
+            "--check",
+            "--pr",
+            "7423",
+            "--head",
+            head,
+            "--trusted-operator-login",
+            "trusted-member",
+            "--cwd",
+            str(tmp_path),
+            "--json",
+        ]
+    )
+
+    assert rc == 1
+    payload = settler.json.loads(capsys.readouterr().out)
+    gate = payload["gate"]
+    assert gate["required_author_associations"] == ["OWNER"]
+    assert gate["authorization_diagnostics"][0]["rejection_reasons"] == [
+        "MEMBER login owner-user is not in trusted operator allowlist"
+    ]
 
 
 def test_apply_uses_valid_command_sequence(monkeypatch: Any, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add read-only Tier 4 authorization diagnostics to settle_tier4_pr --check JSON output
- include per-comment/review pass flags, rejection reasons, required author associations, head timestamp, and a settlement comment template
- keep apply behavior unchanged

## Validation
- pytest tests/scripts/test_settle_tier4_pr.py -q
- ruff check scripts/settle_tier4_pr.py tests/scripts/test_settle_tier4_pr.py
- ruff format --check scripts/settle_tier4_pr.py tests/scripts/test_settle_tier4_pr.py
- git diff --check origin/main...HEAD
- python3 scripts/settle_tier4_pr.py --check --pr 7447 --head 042e9934afdfa83ee1ebf74cb572e37d9305a301 --json
- bash scripts/automation_pr_preflight.sh origin/main HEAD