### PR TITLE
fix(settlement): require admin-verified tier4 operator allowlist

### DIFF
--- a/scripts/settle_tier4_pr.py
+++ b/scripts/settle_tier4_pr.py
@@ -12,9 +12,10 @@ import json
 import os
 import subprocess
 import sys
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 DEFAULT_REPO = "synaptent/aragora"
 AUTHORIZED_MARKER = "Tier-4 Human Settlement Authorization"
@@ -22,8 +23,8 @@ AUTHORIZED_MERGE_TOKENS = ("admin_squash_merge", "admin squash")
 AUTHORIZED_PROTECTION_TOKENS = ("branch_protection_reconcile", "branch protection reconcile")
 TRUSTED_OPERATOR_AUTHOR_ASSOCIATIONS = {"OWNER"}
 TRUSTED_OPERATOR_MEMBER_ASSOCIATIONS = {"MEMBER"}
-DEFAULT_TRUSTED_OPERATOR_LOGINS = frozenset({"an0mium"})
 TRUSTED_OPERATOR_LOGINS_ENV = "ARAGORA_TIER4_TRUSTED_OPERATORS"
+PermissionChecker = Callable[[str], bool]
 ALLOWED_TIER4_NOT_READY = {
     "human_risk_settlement",
     "tier4_human_risk_settlement",
@@ -83,13 +84,14 @@ def _authorization_is_fresh(item: dict[str, Any], *, head_committed_at: str) -> 
     return _parse_timestamp(created_at) >= _parse_timestamp(head_committed_at)
 
 
-def _trusted_operator_logins() -> frozenset[str]:
+def _trusted_operator_logins(extra_logins: Sequence[str] | None = None) -> frozenset[str]:
     configured = {
         login.strip().lower()
         for login in os.environ.get(TRUSTED_OPERATOR_LOGINS_ENV, "").split(",")
         if login.strip()
     }
-    return DEFAULT_TRUSTED_OPERATOR_LOGINS | configured
+    explicit = {login.strip().lower() for login in extra_logins or () if login.strip()}
+    return configured | explicit
 
 
 def _author_login(item: dict[str, Any]) -> str:
@@ -101,23 +103,61 @@ def _author_login(item: dict[str, Any]) -> str:
     return ""
 
 
-def _is_trusted_operator_author(item: dict[str, Any]) -> bool:
+def _collaborator_permission_is_admin(payload: dict[str, Any]) -> bool:
+    return (
+        str(payload.get("permission") or "").lower() == "admin"
+        or str(payload.get("role_name") or "").lower() == "admin"
+    )
+
+
+def _login_has_admin_permission(login: str, repo: str, cwd: Path | None) -> bool:
+    if not login:
+        return False
+    endpoint = f"repos/{repo}/collaborators/{quote(login, safe='')}/permission"
+    try:
+        payload = _run_json(["gh", "api", endpoint], cwd=cwd)
+    except RuntimeError:
+        return False
+    return _collaborator_permission_is_admin(payload)
+
+
+def _is_trusted_operator_author(
+    item: dict[str, Any],
+    *,
+    trusted_operator_logins: frozenset[str],
+    permission_checker: PermissionChecker,
+) -> bool:
     association = str(item.get("authorAssociation") or "").upper()
     if association in TRUSTED_OPERATOR_AUTHOR_ASSOCIATIONS:
         return True
     if association not in TRUSTED_OPERATOR_MEMBER_ASSOCIATIONS:
         return False
-    return _author_login(item) in _trusted_operator_logins()
+    login = _author_login(item)
+    return login in trusted_operator_logins and permission_checker(login)
 
 
-def has_operator_authorization(pr_view: dict[str, Any], *, head: str) -> bool:
+def has_operator_authorization(
+    pr_view: dict[str, Any],
+    *,
+    head: str,
+    repo: str = DEFAULT_REPO,
+    cwd: Path | None = None,
+    trusted_operator_logins: Sequence[str] | None = None,
+    permission_checker: PermissionChecker | None = None,
+) -> bool:
     head_committed_at = _head_committed_at(pr_view)
+    allowed_logins = _trusted_operator_logins(trusted_operator_logins)
+    checker = permission_checker or (lambda login: _login_has_admin_permission(login, repo, cwd))
     for item in _text_items(pr_view):
         body = str(item.get("body") or "")
         lowered = body.lower()
         if AUTHORIZED_MARKER not in body:
             continue
-        if not _is_trusted_operator_author(item):
+        if not _is_trusted_operator_author(
+            item,
+            trusted_operator_logins=allowed_logins,
+            permission_checker=checker,
+        ):
             continue
         if not _authorization_is_fresh(item, head_committed_at=head_committed_at):
             continue
@@ -161,6 +201,10 @@ def evaluate_tier4_gate(
     pr_view: dict[str, Any],
     merge_packet: dict[str, Any],
     required_checks: list[dict[str, Any]] | None = None,
+    repo: str = DEFAULT_REPO,
+    cwd: Path | None = None,
+    trusted_operator_logins: Sequence[str] | None = None,
+    permission_checker: PermissionChecker | None = None,
 ) -> dict[str, Any]:
     blockers: list[str] = []
     actual_head = str(pr_view.get("headRefOid") or "")
@@ -186,7 +230,14 @@ def evaluate_tier4_gate(
         unexpected = sorted({str(item) for item in not_ready} - allowed_not_ready)
         if unexpected:
             blockers.append(f"merge-packet has unexpected blockers: {', '.join(unexpected)}")
-    if actual_head == expected_head and not has_operator_authorization(pr_view, head=expected_head):
+    if actual_head == expected_head and not has_operator_authorization(
+        pr_view,
+        head=expected_head,
+        repo=repo,
+        cwd=cwd,
+        trusted_operator_logins=trusted_operator_logins,
+        permission_checker=permission_checker,
+    ):
         blockers.append("missing repo-visible Tier 4 operator settlement comment")
 
     return {
@@ -429,6 +480,16 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--head", required=True)
     parser.add_argument("--repo", default=DEFAULT_REPO)
     parser.add_argument("--cwd", type=Path, default=Path.cwd())
+    parser.add_argument(
+        "--trusted-operator-login",
+        action="append",
+        default=[],
+        help=(
+            "Allow a repo-visible MEMBER authorization comment from this login "
+            "when live GitHub collaborator permission is admin. Repeatable; "
+            f"also reads comma-separated {TRUSTED_OPERATOR_LOGINS_ENV}."
+        ),
+    )
     parser.add_argument("--json", action="store_true")
     return parser
 
@@ -443,6 +504,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             pr_view=pr_view,
             merge_packet=merge_packet,
             required_checks=required_checks,
+            repo=args.repo,
+            cwd=args.cwd,
+            trusted_operator_logins=args.trusted_operator_login,
         )
         applied_commands: list[list[str]] = []
         if args.apply:

--- a/scripts/settle_tier4_pr.py
+++ b/scripts/settle_tier4_pr.py
@@ -91,7 +91,7 @@ def _trusted_operator_logins(extra_logins: Sequence[str] | None = None) -> froze
         if login.strip()
     }
     explicit = {login.strip().lower() for login in extra_logins or () if login.strip()}
-    return configured | explicit
+    return frozenset(configured | explicit)
 
 
 def _author_login(item: dict[str, Any]) -> str:

--- a/scripts/settle_tier4_pr.py
+++ b/scripts/settle_tier4_pr.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 from collections.abc import Sequence
@@ -20,6 +21,9 @@ AUTHORIZED_MARKER = "Tier-4 Human Settlement Authorization"
 AUTHORIZED_MERGE_TOKENS = ("admin_squash_merge", "admin squash")
 AUTHORIZED_PROTECTION_TOKENS = ("branch_protection_reconcile", "branch protection reconcile")
 TRUSTED_OPERATOR_AUTHOR_ASSOCIATIONS = {"OWNER"}
+TRUSTED_OPERATOR_MEMBER_ASSOCIATIONS = {"MEMBER"}
+DEFAULT_TRUSTED_OPERATOR_LOGINS = frozenset({"an0mium"})
+TRUSTED_OPERATOR_LOGINS_ENV = "ARAGORA_TIER4_TRUSTED_OPERATORS"
 ALLOWED_TIER4_NOT_READY = {
     "human_risk_settlement",
     "tier4_human_risk_settlement",
@@ -79,6 +83,33 @@ def _authorization_is_fresh(item: dict[str, Any], *, head_committed_at: str) -> 
     return _parse_timestamp(created_at) >= _parse_timestamp(head_committed_at)
 
 
+def _trusted_operator_logins() -> frozenset[str]:
+    configured = {
+        login.strip().lower()
+        for login in os.environ.get(TRUSTED_OPERATOR_LOGINS_ENV, "").split(",")
+        if login.strip()
+    }
+    return DEFAULT_TRUSTED_OPERATOR_LOGINS | configured
+
+
+def _author_login(item: dict[str, Any]) -> str:
+    author = item.get("author")
+    if isinstance(author, dict):
+        return str(author.get("login") or "").strip().lower()
+    if isinstance(author, str):
+        return author.strip().lower()
+    return ""
+
+
+def _is_trusted_operator_author(item: dict[str, Any]) -> bool:
+    association = str(item.get("authorAssociation") or "").upper()
+    if association in TRUSTED_OPERATOR_AUTHOR_ASSOCIATIONS:
+        return True
+    if association not in TRUSTED_OPERATOR_MEMBER_ASSOCIATIONS:
+        return False
+    return _author_login(item) in _trusted_operator_logins()
+
+
 def has_operator_authorization(pr_view: dict[str, Any], *, head: str) -> bool:
     head_committed_at = _head_committed_at(pr_view)
     for item in _text_items(pr_view):
@@ -86,8 +117,7 @@ def has_operator_authorization(pr_view: dict[str, Any], *, head: str) -> bool:
         lowered = body.lower()
         if AUTHORIZED_MARKER not in body:
             continue
-        association = str(item.get("authorAssociation") or "").upper()
-        if association not in TRUSTED_OPERATOR_AUTHOR_ASSOCIATIONS:
+        if not _is_trusted_operator_author(item):
             continue
         if not _authorization_is_fresh(item, head_committed_at=head_committed_at):
             continue

--- a/tests/scripts/test_settle_tier4_pr.py
+++ b/tests/scripts/test_settle_tier4_pr.py
@@ -187,13 +187,38 @@ def test_configured_trusted_member_comment_authorizes(monkeypatch: Any) -> None:
         },
         merge_packet={"admin_squash_allowed": False, "not_ready": ["human_risk_settlement"]},
         required_checks=_valid_checks(),
+        permission_checker=lambda login: login == "trusted-member",
     )
 
     assert result["ok"] is True
     assert result["blockers"] == []
 
 
-def test_default_trusted_operator_member_comment_authorizes() -> None:
+def test_trusted_member_comment_requires_admin_permission(monkeypatch: Any) -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    monkeypatch.setenv("ARAGORA_TIER4_TRUSTED_OPERATORS", "trusted-member")
+    result = settler.evaluate_tier4_gate(
+        pr=7423,
+        expected_head=head,
+        pr_view={
+            "headRefOid": head,
+            "state": "OPEN",
+            "isDraft": False,
+            "mergeStateStatus": "BLOCKED",
+            "headCommittedDate": HEAD_COMMITTED_AT,
+            "comments": [_authorized_comment(head, association="MEMBER", author="trusted-member")],
+            "reviews": [],
+        },
+        merge_packet={"admin_squash_allowed": False, "not_ready": ["human_risk_settlement"]},
+        required_checks=_valid_checks(),
+        permission_checker=lambda login: False,
+    )
+
+    assert result["ok"] is False
+    assert "missing repo-visible Tier 4 operator settlement comment" in result["blockers"]
+
+
+def test_an0mium_member_comment_requires_explicit_allowlist() -> None:
     head = "57c740022e3c432718462efa12ca79f1df4f674d"
     result = settler.evaluate_tier4_gate(
         pr=7423,
@@ -209,10 +234,64 @@ def test_default_trusted_operator_member_comment_authorizes() -> None:
         },
         merge_packet={"admin_squash_allowed": False, "not_ready": ["human_risk_settlement"]},
         required_checks=_valid_checks(),
+        permission_checker=lambda login: True,
     )
 
-    assert result["ok"] is True
-    assert result["blockers"] == []
+    assert result["ok"] is False
+    assert "missing repo-visible Tier 4 operator settlement comment" in result["blockers"]
+
+
+def test_cli_trusted_operator_login_authorizes_member_comment(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    monkeypatch.setattr(
+        settler,
+        "_load_live_inputs",
+        lambda pr, cwd: (
+            {
+                "headRefOid": head,
+                "state": "OPEN",
+                "isDraft": False,
+                "mergeStateStatus": "BLOCKED",
+                "headCommittedDate": HEAD_COMMITTED_AT,
+                "comments": [
+                    _authorized_comment(head, association="MEMBER", author="trusted-member")
+                ],
+                "reviews": [],
+            },
+            {"not_ready": ["human_risk_settlement"]},
+            _valid_checks(),
+        ),
+    )
+    monkeypatch.setattr(
+        settler,
+        "_login_has_admin_permission",
+        lambda login, repo, cwd: login == "trusted-member",
+    )
+
+    rc = settler.main(
+        [
+            "--check",
+            "--pr",
+            "7423",
+            "--head",
+            head,
+            "--trusted-operator-login",
+            "trusted-member",
+            "--cwd",
+            str(tmp_path),
+        ]
+    )
+
+    assert rc == 0
+
+
+def test_collaborator_permission_payload_only_treats_admin_as_admin() -> None:
+    assert settler._collaborator_permission_is_admin({"permission": "admin"}) is True
+    assert settler._collaborator_permission_is_admin({"role_name": "admin"}) is True
+    for permission in ("maintain", "write", "triage", "read"):
+        assert settler._collaborator_permission_is_admin({"permission": permission}) is False
 
 
 def test_authorization_comment_for_different_head_does_not_authorize() -> None:

--- a/tests/scripts/test_settle_tier4_pr.py
+++ b/tests/scripts/test_settle_tier4_pr.py
@@ -26,9 +26,15 @@ HEAD_COMMITTED_AT = "2026-05-22T00:00:00Z"
 AUTH_CREATED_AT = "2026-05-22T00:05:00Z"
 
 
-def _authorized_comment(head: str, *, association: str = "OWNER") -> dict[str, str]:
+def _authorized_comment(
+    head: str,
+    *,
+    association: str = "OWNER",
+    author: str = "owner-user",
+) -> dict[str, Any]:
     return {
         "authorAssociation": association,
+        "author": {"login": author},
         "createdAt": AUTH_CREATED_AT,
         "body": (
             "Tier-4 Human Settlement Authorization\n"
@@ -132,6 +138,95 @@ def test_untrusted_author_comment_does_not_authorize() -> None:
             "mergeStateStatus": "BLOCKED",
             "headCommittedDate": HEAD_COMMITTED_AT,
             "comments": [_authorized_comment(head, association="CONTRIBUTOR")],
+            "reviews": [],
+        },
+        merge_packet={"admin_squash_allowed": False, "not_ready": ["human_risk_settlement"]},
+        required_checks=_valid_checks(),
+    )
+
+    assert result["ok"] is False
+    assert "missing repo-visible Tier 4 operator settlement comment" in result["blockers"]
+
+
+def test_untrusted_member_comment_does_not_authorize() -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    result = settler.evaluate_tier4_gate(
+        pr=7423,
+        expected_head=head,
+        pr_view={
+            "headRefOid": head,
+            "state": "OPEN",
+            "isDraft": False,
+            "mergeStateStatus": "BLOCKED",
+            "headCommittedDate": HEAD_COMMITTED_AT,
+            "comments": [_authorized_comment(head, association="MEMBER", author="random-member")],
+            "reviews": [],
+        },
+        merge_packet={"admin_squash_allowed": False, "not_ready": ["human_risk_settlement"]},
+        required_checks=_valid_checks(),
+    )
+
+    assert result["ok"] is False
+    assert "missing repo-visible Tier 4 operator settlement comment" in result["blockers"]
+
+
+def test_configured_trusted_member_comment_authorizes(monkeypatch: Any) -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    monkeypatch.setenv("ARAGORA_TIER4_TRUSTED_OPERATORS", "trusted-member")
+    result = settler.evaluate_tier4_gate(
+        pr=7423,
+        expected_head=head,
+        pr_view={
+            "headRefOid": head,
+            "state": "OPEN",
+            "isDraft": False,
+            "mergeStateStatus": "BLOCKED",
+            "headCommittedDate": HEAD_COMMITTED_AT,
+            "comments": [_authorized_comment(head, association="MEMBER", author="trusted-member")],
+            "reviews": [],
+        },
+        merge_packet={"admin_squash_allowed": False, "not_ready": ["human_risk_settlement"]},
+        required_checks=_valid_checks(),
+    )
+
+    assert result["ok"] is True
+    assert result["blockers"] == []
+
+
+def test_default_trusted_operator_member_comment_authorizes() -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    result = settler.evaluate_tier4_gate(
+        pr=7423,
+        expected_head=head,
+        pr_view={
+            "headRefOid": head,
+            "state": "OPEN",
+            "isDraft": False,
+            "mergeStateStatus": "BLOCKED",
+            "headCommittedDate": HEAD_COMMITTED_AT,
+            "comments": [_authorized_comment(head, association="MEMBER", author="an0mium")],
+            "reviews": [],
+        },
+        merge_packet={"admin_squash_allowed": False, "not_ready": ["human_risk_settlement"]},
+        required_checks=_valid_checks(),
+    )
+
+    assert result["ok"] is True
+    assert result["blockers"] == []
+
+
+def test_authorization_comment_for_different_head_does_not_authorize() -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    result = settler.evaluate_tier4_gate(
+        pr=7423,
+        expected_head=head,
+        pr_view={
+            "headRefOid": head,
+            "state": "OPEN",
+            "isDraft": False,
+            "mergeStateStatus": "BLOCKED",
+            "headCommittedDate": HEAD_COMMITTED_AT,
+            "comments": [_authorized_comment("different-head")],
             "reviews": [],
         },
         merge_packet={"admin_squash_allowed": False, "not_ready": ["human_risk_settlement"]},


### PR DESCRIPTION
## Summary
- update `scripts/settle_tier4_pr.py` so repo-visible Tier 4 settlement comments from `MEMBER` authors can count only when the login is explicitly allowlisted and live GitHub collaborator permission is admin
- preserve existing `OWNER` behavior
- keep arbitrary `MEMBER`, stale, and head-mismatched comments fail-closed
- add CLI support: `--trusted-operator-login <login>`; env fallback remains `ARAGORA_TIER4_TRUSTED_OPERATORS`

## #7439 follow-up
From this repaired branch, the existing #7439 authorization comment by `an0mium` is recognized when invoked with `--trusted-operator-login an0mium`; the only remaining blocker is `required check aragora-merge-quorum is CANCELLED`.

Next exact-head check after this lands:
```bash
python3 scripts/settle_tier4_pr.py --check --json --pr 7439 --head 02865ae6c82944a6d12afd50736402bd91e2a018 --trusted-operator-login an0mium
```

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/scripts/test_settle_tier4_pr.py -q -p no:cacheprovider` -> 18 passed
- `python3 -m ruff check scripts/settle_tier4_pr.py tests/scripts/test_settle_tier4_pr.py` -> passed
- `python3 -m ruff format --check scripts/settle_tier4_pr.py tests/scripts/test_settle_tier4_pr.py` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> passed
- `python3 scripts/settle_tier4_pr.py --check --json --pr 7439 --head 02865ae6c82944a6d12afd50736402bd91e2a018 --trusted-operator-login an0mium` -> only blocker: `required check aragora-merge-quorum is CANCELLED`

No merge authorization.