### PR TITLE
fix(review-pr): block codex fallback for noncodex reviewers

### DIFF
--- a/aragora/cli/commands/review_pr.py
+++ b/aragora/cli/commands/review_pr.py
@@ -31,6 +31,18 @@ _STATUS_REVIEW_EVENT_BY_STATUS = {
     "blocked_nonreviewable": "COMMENT",
 }
 _OPTIONAL_AGENT_PLACEHOLDERS = {"", "none", "null"}
+_REVIEWER_FAMILY_MARKERS = (
+    ("codex", ("codex", "openai", "gpt")),
+    ("claude", ("claude", "anthropic")),
+    ("grok", ("grok", "xai")),
+    ("gemini", ("gemini", "google")),
+    ("openrouter", ("openrouter",)),
+    ("mistral", ("mistral", "codestral")),
+    ("deepseek", ("deepseek",)),
+    ("qwen", ("qwen",)),
+    ("kimi", ("kimi", "moonshot")),
+    ("factory", ("factory", "droid")),
+)
 
 
 @dataclass(slots=True)
@@ -386,6 +398,11 @@ async def _run_review_pass(
         status = "blocked_nonreviewable"
     findings = _normalize_findings(parsed.get("findings", []))
     summary = str(parsed.get("summary", "")).strip()
+    route_blocker = _codex_fallback_blocker(reviewer, dict(routing.get("candidate") or {}))
+    if route_blocker:
+        status = "blocked_nonreviewable"
+        summary = route_blocker["body"]
+        findings = [route_blocker]
     if status == "changes_requested" and not findings:
         findings = [{"title": "Blocking changes requested", "body": raw_response, "priority": "P1"}]
     if status == "blocked_nonreviewable" and not findings:
@@ -405,6 +422,45 @@ async def _run_review_pass(
         attempts=[dict(item) for item in routing.get("attempts", []) if isinstance(item, dict)],
         raw_response=raw_response,
     )
+
+
+def _reviewer_family(value: object) -> str:
+    lower = str(value or "").strip().lower()
+    if not lower:
+        return ""
+    for family, markers in _REVIEWER_FAMILY_MARKERS:
+        if any(marker in lower for marker in markers):
+            return family
+    return lower
+
+
+def _candidate_family(candidate: dict[str, Any]) -> str:
+    provider = str(candidate.get("provider", "") or "").strip()
+    if provider:
+        return _reviewer_family(provider)
+    label = str(candidate.get("label", "") or "").strip()
+    return _reviewer_family(label)
+
+
+def _codex_fallback_blocker(
+    requested_reviewer: str,
+    candidate: dict[str, Any],
+) -> dict[str, str] | None:
+    requested_family = _reviewer_family(requested_reviewer)
+    if not requested_family or requested_family == "codex":
+        return None
+    if _candidate_family(candidate) != "codex":
+        return None
+    candidate_label = str(candidate.get("label", "") or "").strip() or "codex"
+    return {
+        "title": "Requested reviewer routed to Codex",
+        "body": (
+            f"Requested reviewer `{requested_reviewer}` requires non-Codex evidence, but "
+            f"review-pr selected Codex candidate `{candidate_label}`. Re-run with a real "
+            "non-Codex reviewer or do not count this result as non-Codex quorum evidence."
+        ),
+        "priority": "P1",
+    }
 
 
 async def _run_fix_pass(

--- a/tests/cli/commands/test_review_pr.py
+++ b/tests/cli/commands/test_review_pr.py
@@ -71,6 +71,56 @@ def test_normalize_optional_agent_rejects_placeholder_none() -> None:
 
 
 @pytest.mark.asyncio
+async def test_run_review_pass_blocks_codex_fallback_for_requested_noncodex(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    sample_target: review_pr.PullRequestTarget,
+) -> None:
+    async def _fake_generate_review_response(*_: object, **__: object) -> dict[str, object]:
+        return {
+            "candidate": {"provider": "codex", "label": "codex"},
+            "response": json.dumps(
+                {
+                    "status": "passed",
+                    "summary": "No issues found.",
+                    "findings": [],
+                }
+            ),
+            "attempts": [
+                {
+                    "candidate": "codex",
+                    "stage": "generate",
+                    "detail": "ok",
+                }
+            ],
+        }
+
+    monkeypatch.setattr(review_pr, "generate_review_response", _fake_generate_review_response)
+
+    result = await review_pr._run_review_pass(
+        target=sample_target,
+        diff_text="diff --git a/foo b/foo\n+ok\n",
+        reviewer="grok",
+        worker_model="codex",
+        repo_root=tmp_path,
+    )
+
+    assert result.status == "blocked_nonreviewable"
+    assert result.candidate == {"provider": "codex", "label": "codex"}
+    assert result.findings == [
+        {
+            "title": "Requested reviewer routed to Codex",
+            "body": (
+                "Requested reviewer `grok` requires non-Codex evidence, but review-pr "
+                "selected Codex candidate `codex`. Re-run with a real non-Codex reviewer "
+                "or do not count this result as non-Codex quorum evidence."
+            ),
+            "priority": "P1",
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_run_review_pr_loop_review_only_writes_artifact(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- block review-pr runs when a requested non-Codex reviewer resolves to a Codex candidate
- emit a P1 non-reviewable finding so JSON and published advisory bodies cannot be mistaken for non-Codex quorum evidence
- add regression coverage for the Grok-requested/Codex-selected fallback path

## Validation
- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/cli/commands/test_review_pr.py -q -p no:cacheprovider
- python3 -m ruff check aragora/cli/commands/review_pr.py tests/cli/commands/test_review_pr.py
- python3 -m ruff format --check aragora/cli/commands/review_pr.py tests/cli/commands/test_review_pr.py
- python3 -m mypy aragora/cli/commands/review_pr.py tests/cli/commands/test_review_pr.py --ignore-missing-imports --no-incremental
- git diff --check origin/main...HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD

Do not settle in this lane; this is the requested meta-tooling follow-up for review-pr provider mismatch safety.