### PR TITLE
fix(settlement): accept guarded tier4 merge-only settlement

### DIFF
--- a/scripts/settle_tier4_pr.py
+++ b/scripts/settle_tier4_pr.py
@@ -25,6 +25,9 @@ TRUSTED_OPERATOR_AUTHOR_ASSOCIATIONS = {"OWNER"}
 TRUSTED_OPERATOR_MEMBER_ASSOCIATIONS = {"MEMBER"}
 TRUSTED_OPERATOR_LOGINS_ENV = "ARAGORA_TIER4_TRUSTED_OPERATORS"
 PermissionChecker = Callable[[str], bool]
+HUMAN_SETTLEMENT_CONTEXT = "aragora/human-settlement"
+SUCCESS_STATES = {"SUCCESS", "PASS", "PASSED", "SKIPPED", "NEUTRAL"}
+MIN_TIER4_COUNTED_REVIEWER_IDS = 2
 ALLOWED_TIER4_NOT_READY = {
     "human_risk_settlement",
     "tier4_human_risk_settlement",
@@ -136,21 +139,93 @@ def _is_trusted_operator_author(
     return login in trusted_operator_logins and permission_checker(login)
 
 
+def _state_is_success(value: Any) -> bool:
+    return str(value or "").upper() in SUCCESS_STATES
+
+
+def _required_checks_are_green(required_checks: list[dict[str, Any]] | None) -> bool:
+    if not required_checks:
+        return False
+    for check in required_checks:
+        state = check.get("state") or check.get("conclusion")
+        if not _state_is_success(state):
+            return False
+    return True
+
+
+def _human_settlement_status_is_success(pr_view: dict[str, Any]) -> bool:
+    rollup = pr_view.get("statusCheckRollup")
+    if not isinstance(rollup, list):
+        return False
+    for item in rollup:
+        if not isinstance(item, dict):
+            continue
+        context = str(item.get("context") or item.get("name") or "")
+        if context != HUMAN_SETTLEMENT_CONTEXT:
+            continue
+        state = item.get("state") or item.get("conclusion")
+        return _state_is_success(state)
+    return False
+
+
+def _packet_has_counted_tier4_evidence(merge_packet: dict[str, Any], *, pr: int) -> bool:
+    entry = _entry_for_pr(merge_packet, pr=pr)
+    if not entry:
+        return False
+    if bool(entry.get("unresolved_dissent")):
+        return False
+    counted = entry.get("counted_reviewer_ids")
+    counted_ids = (
+        {str(item).strip() for item in counted if isinstance(item, str) and str(item).strip()}
+        if isinstance(counted, list)
+        else set()
+    )
+    if len(counted_ids) < MIN_TIER4_COUNTED_REVIEWER_IDS:
+        return False
+    dogfood = entry.get("dogfood_evidence")
+    if not isinstance(dogfood, list) or not dogfood:
+        return False
+    return True
+
+
+def _comment_authorizes_requested_action(
+    body: str, *, require_branch_protection_token: bool
+) -> bool:
+    lowered = body.lower()
+    if not any(token in lowered for token in AUTHORIZED_MERGE_TOKENS):
+        return False
+    if require_branch_protection_token and not any(
+        token in lowered for token in AUTHORIZED_PROTECTION_TOKENS
+    ):
+        return False
+    return True
+
+
 def has_operator_authorization(
     pr_view: dict[str, Any],
     *,
+    pr: int,
     head: str,
+    merge_packet: dict[str, Any],
+    required_checks: list[dict[str, Any]] | None = None,
+    require_branch_protection_token: bool = False,
     repo: str = DEFAULT_REPO,
     cwd: Path | None = None,
     trusted_operator_logins: Sequence[str] | None = None,
     permission_checker: PermissionChecker | None = None,
 ) -> bool:
+    if not _required_checks_are_green(required_checks):
+        return False
+    if not _human_settlement_status_is_success(pr_view):
+        return False
+    if not _packet_has_counted_tier4_evidence(merge_packet, pr=pr):
+        return False
+
     head_committed_at = _head_committed_at(pr_view)
     allowed_logins = _trusted_operator_logins(trusted_operator_logins)
     checker = permission_checker or (lambda login: _login_has_admin_permission(login, repo, cwd))
     for item in _text_items(pr_view):
         body = str(item.get("body") or "")
-        lowered = body.lower()
         if AUTHORIZED_MARKER not in body:
             continue
         if not _is_trusted_operator_author(
@@ -163,9 +238,8 @@ def has_operator_authorization(
             continue
         if head not in body:
             continue
-        if all(
-            any(token in lowered for token in token_group)
-            for token_group in (AUTHORIZED_MERGE_TOKENS, AUTHORIZED_PROTECTION_TOKENS)
+        if _comment_authorizes_requested_action(
+            body, require_branch_protection_token=require_branch_protection_token
         ):
             return True
     return False
@@ -201,6 +275,7 @@ def evaluate_tier4_gate(
     pr_view: dict[str, Any],
     merge_packet: dict[str, Any],
     required_checks: list[dict[str, Any]] | None = None,
+    require_branch_protection_token: bool = False,
     repo: str = DEFAULT_REPO,
     cwd: Path | None = None,
     trusted_operator_logins: Sequence[str] | None = None,
@@ -220,7 +295,7 @@ def evaluate_tier4_gate(
     for check in required_checks or []:
         name = str(check.get("name") or check.get("workflow") or "required check")
         state = str(check.get("state") or check.get("conclusion") or "UNKNOWN").upper()
-        if state not in {"SUCCESS", "PASS", "PASSED", "SKIPPED", "NEUTRAL"}:
+        if not _state_is_success(state):
             blockers.append(f"required check {name} is {state}")
     not_ready = merge_packet.get("not_ready")
     if isinstance(not_ready, list):
@@ -232,7 +307,11 @@ def evaluate_tier4_gate(
             blockers.append(f"merge-packet has unexpected blockers: {', '.join(unexpected)}")
     if actual_head == expected_head and not has_operator_authorization(
         pr_view,
+        pr=pr,
         head=expected_head,
+        merge_packet=merge_packet,
+        required_checks=required_checks,
+        require_branch_protection_token=require_branch_protection_token,
         repo=repo,
         cwd=cwd,
         trusted_operator_logins=trusted_operator_logins,
@@ -283,7 +362,7 @@ def _load_live_inputs(
             "view",
             str(pr),
             "--json",
-            "headRefOid,state,isDraft,mergeStateStatus,comments,reviews,commits,url",
+            "headRefOid,state,isDraft,mergeStateStatus,comments,reviews,commits,statusCheckRollup,url",
         ],
         cwd=cwd,
     )
@@ -504,6 +583,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             pr_view=pr_view,
             merge_packet=merge_packet,
             required_checks=required_checks,
+            require_branch_protection_token=bool(args.apply),
             repo=args.repo,
             cwd=args.cwd,
             trusted_operator_logins=args.trusted_operator_login,

--- a/tests/scripts/test_settle_tier4_pr.py
+++ b/tests/scripts/test_settle_tier4_pr.py
@@ -31,7 +31,13 @@ def _authorized_comment(
     *,
     association: str = "OWNER",
     author: str = "owner-user",
+    include_branch_protection: bool = True,
 ) -> dict[str, Any]:
+    branch_line = (
+        "Authorized Action: branch_protection_reconcile on main\n"
+        if include_branch_protection
+        else ""
+    )
     return {
         "authorAssociation": association,
         "author": {"login": author},
@@ -40,8 +46,58 @@ def _authorized_comment(
             "Tier-4 Human Settlement Authorization\n"
             f"Authorized Head SHA: {head}\n"
             "Authorized Action: admin_squash_merge on PR #7423\n"
-            "Authorized Action: branch_protection_reconcile on main\n"
+            f"{branch_line}"
         ),
+    }
+
+
+def _pr_view(
+    head: str,
+    *,
+    comments: list[dict[str, Any]],
+    human_settlement_state: str | None = "SUCCESS",
+) -> dict[str, Any]:
+    status_rollup = (
+        [{"context": "aragora/human-settlement", "state": human_settlement_state}]
+        if human_settlement_state is not None
+        else []
+    )
+    return {
+        "headRefOid": head,
+        "state": "OPEN",
+        "isDraft": False,
+        "mergeStateStatus": "BLOCKED",
+        "headCommittedDate": HEAD_COMMITTED_AT,
+        "comments": comments,
+        "reviews": [],
+        "statusCheckRollup": status_rollup,
+    }
+
+
+def _tier4_packet(
+    pr: int = 7423,
+    *,
+    counted_reviewer_ids: list[str] | None = None,
+    dogfood_evidence: list[dict[str, str]] | None = None,
+    unresolved_dissent: bool = False,
+) -> dict[str, Any]:
+    return {
+        "not_ready": [pr],
+        "human_risk_settlement_required": [pr],
+        "entries": [
+            {
+                "pr_number": pr,
+                "status": "human_preapproval_required",
+                "requires_human_risk_settlement": True,
+                "unresolved_dissent": unresolved_dissent,
+                "counted_reviewer_ids": (
+                    ["codex", "grok"] if counted_reviewer_ids is None else counted_reviewer_ids
+                ),
+                "dogfood_evidence": (
+                    [{"reviewer_id": "codex"}] if dogfood_evidence is None else dogfood_evidence
+                ),
+            }
+        ],
     }
 
 
@@ -77,17 +133,103 @@ def test_exact_head_operator_comment_allows_check_result() -> None:
     result = settler.evaluate_tier4_gate(
         pr=7423,
         expected_head=head,
-        pr_view={
-            "headRefOid": head,
-            "state": "OPEN",
-            "isDraft": False,
-            "mergeStateStatus": "BLOCKED",
-            "headCommittedDate": HEAD_COMMITTED_AT,
-            "comments": [_authorized_comment(head)],
-            "reviews": [],
-        },
-        merge_packet={"admin_squash_allowed": False, "not_ready": ["human_risk_settlement"]},
+        pr_view=_pr_view(
+            head,
+            comments=[_authorized_comment(head, include_branch_protection=False)],
+        ),
+        merge_packet=_tier4_packet(),
         required_checks=_valid_checks(),
+    )
+
+    assert result["ok"] is True
+    assert result["blockers"] == []
+
+
+def test_member_operator_comment_with_status_and_evidence_allows_check_result() -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    result = settler.evaluate_tier4_gate(
+        pr=7423,
+        expected_head=head,
+        pr_view=_pr_view(
+            head,
+            comments=[
+                _authorized_comment(
+                    head,
+                    association="MEMBER",
+                    author="trusted-member",
+                    include_branch_protection=False,
+                )
+            ],
+        ),
+        merge_packet=_tier4_packet(),
+        required_checks=_valid_checks(),
+        trusted_operator_logins=["trusted-member"],
+        permission_checker=lambda login: login == "trusted-member",
+    )
+
+    assert result["ok"] is True
+    assert result["blockers"] == []
+
+
+def test_member_operator_comment_without_human_status_does_not_authorize() -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    result = settler.evaluate_tier4_gate(
+        pr=7423,
+        expected_head=head,
+        pr_view=_pr_view(
+            head,
+            comments=[_authorized_comment(head, association="MEMBER")],
+            human_settlement_state=None,
+        ),
+        merge_packet=_tier4_packet(),
+        required_checks=_valid_checks(),
+    )
+
+    assert result["ok"] is False
+    assert "missing repo-visible Tier 4 operator settlement comment" in result["blockers"]
+
+
+def test_operator_comment_without_counted_evidence_does_not_authorize() -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    result = settler.evaluate_tier4_gate(
+        pr=7423,
+        expected_head=head,
+        pr_view=_pr_view(head, comments=[_authorized_comment(head)]),
+        merge_packet=_tier4_packet(counted_reviewer_ids=["codex"]),
+        required_checks=_valid_checks(),
+    )
+
+    assert result["ok"] is False
+    assert "missing repo-visible Tier 4 operator settlement comment" in result["blockers"]
+
+
+def test_branch_protection_mode_requires_branch_protection_token() -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    result = settler.evaluate_tier4_gate(
+        pr=7423,
+        expected_head=head,
+        pr_view=_pr_view(
+            head,
+            comments=[_authorized_comment(head, include_branch_protection=False)],
+        ),
+        merge_packet=_tier4_packet(),
+        required_checks=_valid_checks(),
+        require_branch_protection_token=True,
+    )
+
+    assert result["ok"] is False
+    assert "missing repo-visible Tier 4 operator settlement comment" in result["blockers"]
+
+
+def test_branch_protection_mode_accepts_branch_protection_token() -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    result = settler.evaluate_tier4_gate(
+        pr=7423,
+        expected_head=head,
+        pr_view=_pr_view(head, comments=[_authorized_comment(head)]),
+        merge_packet=_tier4_packet(),
+        required_checks=_valid_checks(),
+        require_branch_protection_token=True,
     )
 
     assert result["ok"] is True
@@ -99,26 +241,11 @@ def test_numeric_not_ready_is_allowed_when_packet_marks_tier4_human_settlement()
     result = settler.evaluate_tier4_gate(
         pr=7423,
         expected_head=head,
-        pr_view={
-            "headRefOid": head,
-            "state": "OPEN",
-            "isDraft": False,
-            "mergeStateStatus": "BLOCKED",
-            "headCommittedDate": HEAD_COMMITTED_AT,
-            "comments": [_authorized_comment(head)],
-            "reviews": [],
-        },
-        merge_packet={
-            "not_ready": [7423],
-            "human_risk_settlement_required": [7423],
-            "entries": [
-                {
-                    "pr_number": 7423,
-                    "status": "human_preapproval_required",
-                    "requires_human_risk_settlement": True,
-                }
-            ],
-        },
+        pr_view=_pr_view(
+            head,
+            comments=[_authorized_comment(head, include_branch_protection=False)],
+        ),
+        merge_packet=_tier4_packet(),
         required_checks=[{"name": "lint", "state": "SUCCESS"}],
     )
 
@@ -131,16 +258,11 @@ def test_untrusted_author_comment_does_not_authorize() -> None:
     result = settler.evaluate_tier4_gate(
         pr=7423,
         expected_head=head,
-        pr_view={
-            "headRefOid": head,
-            "state": "OPEN",
-            "isDraft": False,
-            "mergeStateStatus": "BLOCKED",
-            "headCommittedDate": HEAD_COMMITTED_AT,
-            "comments": [_authorized_comment(head, association="CONTRIBUTOR")],
-            "reviews": [],
-        },
-        merge_packet={"admin_squash_allowed": False, "not_ready": ["human_risk_settlement"]},
+        pr_view=_pr_view(
+            head,
+            comments=[_authorized_comment(head, association="CONTRIBUTOR")],
+        ),
+        merge_packet=_tier4_packet(),
         required_checks=_valid_checks(),
     )
 
@@ -176,16 +298,11 @@ def test_configured_trusted_member_comment_authorizes(monkeypatch: Any) -> None:
     result = settler.evaluate_tier4_gate(
         pr=7423,
         expected_head=head,
-        pr_view={
-            "headRefOid": head,
-            "state": "OPEN",
-            "isDraft": False,
-            "mergeStateStatus": "BLOCKED",
-            "headCommittedDate": HEAD_COMMITTED_AT,
-            "comments": [_authorized_comment(head, association="MEMBER", author="trusted-member")],
-            "reviews": [],
-        },
-        merge_packet={"admin_squash_allowed": False, "not_ready": ["human_risk_settlement"]},
+        pr_view=_pr_view(
+            head,
+            comments=[_authorized_comment(head, association="MEMBER", author="trusted-member")],
+        ),
+        merge_packet=_tier4_packet(),
         required_checks=_valid_checks(),
         permission_checker=lambda login: login == "trusted-member",
     )
@@ -249,18 +366,11 @@ def test_cli_trusted_operator_login_authorizes_member_comment(
         settler,
         "_load_live_inputs",
         lambda pr, cwd: (
-            {
-                "headRefOid": head,
-                "state": "OPEN",
-                "isDraft": False,
-                "mergeStateStatus": "BLOCKED",
-                "headCommittedDate": HEAD_COMMITTED_AT,
-                "comments": [
-                    _authorized_comment(head, association="MEMBER", author="trusted-member")
-                ],
-                "reviews": [],
-            },
-            {"not_ready": ["human_risk_settlement"]},
+            _pr_view(
+                head,
+                comments=[_authorized_comment(head, association="MEMBER", author="trusted-member")],
+            ),
+            _tier4_packet(),
             _valid_checks(),
         ),
     )
@@ -323,16 +433,8 @@ def test_stale_authorization_comment_does_not_authorize() -> None:
     result = settler.evaluate_tier4_gate(
         pr=7423,
         expected_head=head,
-        pr_view={
-            "headRefOid": head,
-            "state": "OPEN",
-            "isDraft": False,
-            "mergeStateStatus": "BLOCKED",
-            "headCommittedDate": HEAD_COMMITTED_AT,
-            "comments": [stale],
-            "reviews": [],
-        },
-        merge_packet={"admin_squash_allowed": False, "not_ready": ["human_risk_settlement"]},
+        pr_view=_pr_view(head, comments=[stale]),
+        merge_packet=_tier4_packet(),
         required_checks=_valid_checks(),
     )
 
@@ -365,16 +467,8 @@ def test_failed_required_check_blocks_settlement() -> None:
     result = settler.evaluate_tier4_gate(
         pr=7423,
         expected_head=head,
-        pr_view={
-            "headRefOid": head,
-            "state": "OPEN",
-            "isDraft": False,
-            "mergeStateStatus": "BLOCKED",
-            "headCommittedDate": HEAD_COMMITTED_AT,
-            "comments": [_authorized_comment(head)],
-            "reviews": [],
-        },
-        merge_packet={"admin_squash_allowed": False, "not_ready": ["human_risk_settlement"]},
+        pr_view=_pr_view(head, comments=[_authorized_comment(head)]),
+        merge_packet=_tier4_packet(),
         required_checks=[
             {"name": "lint", "state": "FAILURE"},
             {"name": "aragora-merge-quorum", "state": "SUCCESS"},
@@ -390,16 +484,8 @@ def test_missing_merge_quorum_check_is_allowed_before_apply_reconciles_protectio
     result = settler.evaluate_tier4_gate(
         pr=7423,
         expected_head=head,
-        pr_view={
-            "headRefOid": head,
-            "state": "OPEN",
-            "isDraft": False,
-            "mergeStateStatus": "BLOCKED",
-            "headCommittedDate": HEAD_COMMITTED_AT,
-            "comments": [_authorized_comment(head)],
-            "reviews": [],
-        },
-        merge_packet={"admin_squash_allowed": False, "not_ready": ["human_risk_settlement"]},
+        pr_view=_pr_view(head, comments=[_authorized_comment(head)]),
+        merge_packet=_tier4_packet(),
         required_checks=[{"name": "lint", "state": "SUCCESS"}],
     )
 
@@ -412,16 +498,8 @@ def test_present_failed_merge_quorum_required_check_blocks_settlement() -> None:
     result = settler.evaluate_tier4_gate(
         pr=7423,
         expected_head=head,
-        pr_view={
-            "headRefOid": head,
-            "state": "OPEN",
-            "isDraft": False,
-            "mergeStateStatus": "BLOCKED",
-            "headCommittedDate": HEAD_COMMITTED_AT,
-            "comments": [_authorized_comment(head)],
-            "reviews": [],
-        },
-        merge_packet={"admin_squash_allowed": False, "not_ready": ["human_risk_settlement"]},
+        pr_view=_pr_view(head, comments=[_authorized_comment(head)]),
+        merge_packet=_tier4_packet(),
         required_checks=[
             {"name": "lint", "state": "SUCCESS"},
             {"name": "aragora-merge-quorum", "state": "FAILURE"},
@@ -434,19 +512,13 @@ def test_present_failed_merge_quorum_required_check_blocks_settlement() -> None:
 
 def test_unexpected_merge_packet_blocker_blocks_settlement() -> None:
     head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    packet = _tier4_packet()
+    packet["not_ready"] = ["human_risk_settlement", "model_quorum"]
     result = settler.evaluate_tier4_gate(
         pr=7423,
         expected_head=head,
-        pr_view={
-            "headRefOid": head,
-            "state": "OPEN",
-            "isDraft": False,
-            "mergeStateStatus": "BLOCKED",
-            "headCommittedDate": HEAD_COMMITTED_AT,
-            "comments": [_authorized_comment(head)],
-            "reviews": [],
-        },
-        merge_packet={"not_ready": ["human_risk_settlement", "model_quorum"]},
+        pr_view=_pr_view(head, comments=[_authorized_comment(head)]),
+        merge_packet=packet,
         required_checks=_valid_checks(),
     )
 
@@ -462,16 +534,8 @@ def test_apply_uses_valid_command_sequence(monkeypatch: Any, tmp_path: Path) -> 
         settler,
         "_load_live_inputs",
         lambda pr, cwd: (
-            {
-                "headRefOid": head,
-                "state": "OPEN",
-                "isDraft": False,
-                "mergeStateStatus": "BLOCKED",
-                "headCommittedDate": HEAD_COMMITTED_AT,
-                "comments": [_authorized_comment(head)],
-                "reviews": [],
-            },
-            {"not_ready": ["human_risk_settlement"]},
+            _pr_view(head, comments=[_authorized_comment(head)]),
+            _tier4_packet(),
             _valid_checks(),
         ),
     )


### PR DESCRIPTION
## Summary
- keep #7454 trusted-member allowlist/admin-permission guard while adding merge-only Tier 4 settlement checks
- require human-settlement success, green required checks, counted evidence, no unresolved dissent, and exact-head authorization
- require branch_protection_reconcile only when branch-protection mutation is authorized

## Validation
- pytest tests/scripts/test_settle_tier4_pr.py -q
- python3 -m ruff check scripts/settle_tier4_pr.py tests/scripts/test_settle_tier4_pr.py
- python3 -m ruff format --check scripts/settle_tier4_pr.py tests/scripts/test_settle_tier4_pr.py
- git diff --check
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- python3 scripts/settle_tier4_pr.py --check --pr 7443 --head 5a692b5dd54f05f2befe0df7b497c56e3c6ead6f --trusted-operator-login an0mium --json

No #7443 merge or branch protection mutation performed.