### PR TITLE
fix(settlement): allow merge-only tier4 operator settlements

### DIFF
--- a/scripts/settle_tier4_pr.py
+++ b/scripts/settle_tier4_pr.py
@@ -136,7 +136,11 @@ def _is_trusted_operator_author(
     if association not in TRUSTED_OPERATOR_MEMBER_ASSOCIATIONS:
         return False
     login = _author_login(item)
-    return login in trusted_operator_logins and permission_checker(login)
+    if not login:
+        return False
+    if trusted_operator_logins and login not in trusted_operator_logins:
+        return False
+    return permission_checker(login)
 
 
 def _state_is_success(value: Any) -> bool:
@@ -191,17 +195,25 @@ def _packet_has_counted_tier4_evidence(merge_packet: dict[str, Any], *, pr: int)
 def _comment_authorizes_requested_action(
     body: str, *, require_branch_protection_token: bool
 ) -> bool:
-    lowered = body.lower()
-    if not any(token in lowered for token in AUTHORIZED_MERGE_TOKENS):
+    actions = _comment_authorized_actions(body)
+    if "merge" not in actions:
         return False
-    if require_branch_protection_token and not any(
-        token in lowered for token in AUTHORIZED_PROTECTION_TOKENS
-    ):
+    if require_branch_protection_token and "branch_protection" not in actions:
         return False
     return True
 
 
-def has_operator_authorization(
+def _comment_authorized_actions(body: str) -> set[str]:
+    lowered = body.lower()
+    actions: set[str] = set()
+    if any(token in lowered for token in AUTHORIZED_MERGE_TOKENS):
+        actions.add("merge")
+    if any(token in lowered for token in AUTHORIZED_PROTECTION_TOKENS):
+        actions.add("branch_protection")
+    return actions
+
+
+def _operator_authorized_actions(
     pr_view: dict[str, Any],
     *,
     pr: int,
@@ -213,13 +225,13 @@ def has_operator_authorization(
     cwd: Path | None = None,
     trusted_operator_logins: Sequence[str] | None = None,
     permission_checker: PermissionChecker | None = None,
-) -> bool:
+) -> set[str]:
     if not _required_checks_are_green(required_checks):
-        return False
+        return set()
     if not _human_settlement_status_is_success(pr_view):
-        return False
+        return set()
     if not _packet_has_counted_tier4_evidence(merge_packet, pr=pr):
-        return False
+        return set()
 
     head_committed_at = _head_committed_at(pr_view)
     allowed_logins = _trusted_operator_logins(trusted_operator_logins)
@@ -241,8 +253,37 @@ def has_operator_authorization(
         if _comment_authorizes_requested_action(
             body, require_branch_protection_token=require_branch_protection_token
         ):
-            return True
-    return False
+            return _comment_authorized_actions(body)
+    return set()
+
+
+def has_operator_authorization(
+    pr_view: dict[str, Any],
+    *,
+    pr: int,
+    head: str,
+    merge_packet: dict[str, Any],
+    required_checks: list[dict[str, Any]] | None = None,
+    require_branch_protection_token: bool = False,
+    repo: str = DEFAULT_REPO,
+    cwd: Path | None = None,
+    trusted_operator_logins: Sequence[str] | None = None,
+    permission_checker: PermissionChecker | None = None,
+) -> bool:
+    return bool(
+        _operator_authorized_actions(
+            pr_view,
+            pr=pr,
+            head=head,
+            merge_packet=merge_packet,
+            required_checks=required_checks,
+            require_branch_protection_token=require_branch_protection_token,
+            repo=repo,
+            cwd=cwd,
+            trusted_operator_logins=trusted_operator_logins,
+            permission_checker=permission_checker,
+        )
+    )
 
 
 def _entry_for_pr(merge_packet: dict[str, Any], *, pr: int) -> dict[str, Any] | None:
@@ -305,19 +346,22 @@ def evaluate_tier4_gate(
         unexpected = sorted({str(item) for item in not_ready} - allowed_not_ready)
         if unexpected:
             blockers.append(f"merge-packet has unexpected blockers: {', '.join(unexpected)}")
-    if actual_head == expected_head and not has_operator_authorization(
-        pr_view,
-        pr=pr,
-        head=expected_head,
-        merge_packet=merge_packet,
-        required_checks=required_checks,
-        require_branch_protection_token=require_branch_protection_token,
-        repo=repo,
-        cwd=cwd,
-        trusted_operator_logins=trusted_operator_logins,
-        permission_checker=permission_checker,
-    ):
-        blockers.append("missing repo-visible Tier 4 operator settlement comment")
+    authorized_actions: set[str] = set()
+    if actual_head == expected_head:
+        authorized_actions = _operator_authorized_actions(
+            pr_view,
+            pr=pr,
+            head=expected_head,
+            merge_packet=merge_packet,
+            required_checks=required_checks,
+            require_branch_protection_token=require_branch_protection_token,
+            repo=repo,
+            cwd=cwd,
+            trusted_operator_logins=trusted_operator_logins,
+            permission_checker=permission_checker,
+        )
+        if not authorized_actions:
+            blockers.append("missing repo-visible Tier 4 operator settlement comment")
 
     return {
         "ok": not blockers,
@@ -326,6 +370,7 @@ def evaluate_tier4_gate(
         "actual_head": actual_head,
         "merge_state": merge_state,
         "blockers": blockers,
+        "authorized_actions": sorted(authorized_actions),
     }
 
 
@@ -490,9 +535,18 @@ def _restore_branch_protection(*, repo: str, cwd: Path, snapshot: dict[str, Any]
     return errors
 
 
-def _apply_settlement(*, pr: int, head: str, repo: str, cwd: Path) -> list[list[str]]:
+def _apply_settlement(
+    *,
+    pr: int,
+    head: str,
+    repo: str,
+    cwd: Path,
+    reconcile_branch_protection: bool = False,
+) -> list[list[str]]:
     commands: list[list[str]] = []
-    snapshot = _branch_protection_snapshot(repo=repo, cwd=cwd)
+    snapshot = (
+        _branch_protection_snapshot(repo=repo, cwd=cwd) if reconcile_branch_protection else {}
+    )
     merge_command = [
         "gh",
         "pr",
@@ -506,6 +560,9 @@ def _apply_settlement(*, pr: int, head: str, repo: str, cwd: Path) -> list[list[
     try:
         _run_command(merge_command, cwd=cwd)
         commands.append(merge_command)
+
+        if not reconcile_branch_protection:
+            return commands
 
         reviews_command = [
             "gh",
@@ -564,9 +621,10 @@ def build_parser() -> argparse.ArgumentParser:
         action="append",
         default=[],
         help=(
-            "Allow a repo-visible MEMBER authorization comment from this login "
-            "when live GitHub collaborator permission is admin. Repeatable; "
-            f"also reads comma-separated {TRUSTED_OPERATOR_LOGINS_ENV}."
+            "Restrict repo-visible MEMBER authorization comments to this admin "
+            "login. Repeatable; also reads comma-separated "
+            f"{TRUSTED_OPERATOR_LOGINS_ENV}. If omitted, any live admin MEMBER "
+            f"may authorize when {HUMAN_SETTLEMENT_CONTEXT} is success."
         ),
     )
     parser.add_argument("--json", action="store_true")
@@ -583,7 +641,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             pr_view=pr_view,
             merge_packet=merge_packet,
             required_checks=required_checks,
-            require_branch_protection_token=bool(args.apply),
+            require_branch_protection_token=False,
             repo=args.repo,
             cwd=args.cwd,
             trusted_operator_logins=args.trusted_operator_login,
@@ -597,6 +655,8 @@ def main(argv: Sequence[str] | None = None) -> int:
                 head=args.head,
                 repo=args.repo,
                 cwd=args.cwd,
+                reconcile_branch_protection="branch_protection"
+                in set(gate.get("authorized_actions") or []),
             )
         out = {"gate": gate, "applied_commands": applied_commands}
     except RuntimeError as exc:

--- a/tests/scripts/test_settle_tier4_pr.py
+++ b/tests/scripts/test_settle_tier4_pr.py
@@ -335,27 +335,22 @@ def test_trusted_member_comment_requires_admin_permission(monkeypatch: Any) -> N
     assert "missing repo-visible Tier 4 operator settlement comment" in result["blockers"]
 
 
-def test_an0mium_member_comment_requires_explicit_allowlist() -> None:
+def test_admin_member_comment_does_not_require_explicit_allowlist() -> None:
     head = "57c740022e3c432718462efa12ca79f1df4f674d"
     result = settler.evaluate_tier4_gate(
         pr=7423,
         expected_head=head,
-        pr_view={
-            "headRefOid": head,
-            "state": "OPEN",
-            "isDraft": False,
-            "mergeStateStatus": "BLOCKED",
-            "headCommittedDate": HEAD_COMMITTED_AT,
-            "comments": [_authorized_comment(head, association="MEMBER", author="an0mium")],
-            "reviews": [],
-        },
-        merge_packet={"admin_squash_allowed": False, "not_ready": ["human_risk_settlement"]},
+        pr_view=_pr_view(
+            head,
+            comments=[_authorized_comment(head, association="MEMBER", author="an0mium")],
+        ),
+        merge_packet=_tier4_packet(),
         required_checks=_valid_checks(),
-        permission_checker=lambda login: True,
+        permission_checker=lambda login: login == "an0mium",
     )
 
-    assert result["ok"] is False
-    assert "missing repo-visible Tier 4 operator settlement comment" in result["blockers"]
+    assert result["ok"] is True
+    assert result["blockers"] == []
 
 
 def test_cli_trusted_operator_login_authorizes_member_comment(
@@ -570,3 +565,52 @@ def test_apply_uses_valid_command_sequence(monkeypatch: Any, tmp_path: Path) -> 
     ]
     assert "required_approving_review_count" in str(commands[1][1])
     assert commands[-1][0][-1].endswith("/protection/enforce_admins")
+
+
+def test_apply_merge_only_authorization_skips_branch_protection(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    commands: list[tuple[list[str], str | None]] = []
+
+    monkeypatch.setattr(
+        settler,
+        "_load_live_inputs",
+        lambda pr, cwd: (
+            _pr_view(
+                head,
+                comments=[_authorized_comment(head, include_branch_protection=False)],
+            ),
+            _tier4_packet(),
+            _valid_checks(),
+        ),
+    )
+    monkeypatch.setattr(
+        settler,
+        "_run_command",
+        lambda command, cwd, input_text=None: commands.append((command, input_text)),
+    )
+    monkeypatch.setattr(
+        settler,
+        "_branch_protection_snapshot",
+        lambda repo, cwd: {"unexpected": "snapshot"},
+    )
+
+    rc = settler.main(["--apply", "--pr", "7423", "--head", head, "--cwd", str(tmp_path)])
+
+    assert rc == 0
+    assert commands == [
+        (
+            [
+                "gh",
+                "pr",
+                "merge",
+                "7423",
+                "--squash",
+                "--admin",
+                "--match-head-commit",
+                head,
+            ],
+            None,
+        )
+    ]


### PR DESCRIPTION
## Summary
- allow admin-verified MEMBER Tier 4 operator settlement without requiring a preconfigured login allowlist when `aragora/human-settlement` is success
- separate merge authorization from branch-protection reconciliation so merge-only settlement comments do not mutate branch protection
- report `authorized_actions` from the Tier 4 checker and cover merge-only apply behavior in tests

## Validation
- `pytest tests/scripts/test_settle_tier4_pr.py tests/scripts/test_settle_one_pr.py -q` -> 44 passed
- `ruff check scripts/settle_tier4_pr.py tests/scripts/test_settle_tier4_pr.py`
- `ruff format --check scripts/settle_tier4_pr.py tests/scripts/test_settle_tier4_pr.py`
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> preflight: ok
- `python3 scripts/settle_tier4_pr.py --check --pr 7443 --head 5a692b5dd54f05f2befe0df7b497c56e3c6ead6f --json` -> ok: true, authorized_actions: [merge]

No #7443 merge or branch-protection mutation was performed.