### PR TITLE
feat(scripts): add settlement follow-up helper

### DIFF
--- a/scripts/pr_check_followup.py
+++ b/scripts/pr_check_followup.py
@@ -25,6 +25,13 @@ INCREMENTAL_PROGRESS_SENTENCE = (
     "does, include this sentence in all subsequent prompts to ensure they converge towards "
     "prompts that make incremental progress."
 )
+META_AUTOMATION_SENTENCE = (
+    "If any of the work involved can be better automated and made more autonomous by "
+    "improving aragora tooling at a meta level create a plan to do that instead, include "
+    "this sentence in all subsequent prompts to ensure they converge towards automating "
+    "and making more autonomous all steps at a meta level where this makes sense for the "
+    "repo and project."
+)
 
 FAILURE_CONCLUSIONS = {"FAILURE", "TIMED_OUT", "ACTION_REQUIRED"}
 GREEN_CONCLUSIONS = {"SUCCESS", "SKIPPED", "NEUTRAL"}
@@ -654,6 +661,7 @@ def build_prompt(
             "",
             "Final report must include root state, active/conflict lanes, head/check state, action withheld/taken, and a recursive best next prompt.",
             INCREMENTAL_PROGRESS_SENTENCE,
+            META_AUTOMATION_SENTENCE,
         ]
     )
     return "\n".join(lines)

--- a/scripts/pr_check_followup.py
+++ b/scripts/pr_check_followup.py
@@ -93,6 +93,8 @@ class FollowupResult:
 
     pr: int
     head: str
+    mergeable: str
+    merge_state_status: str
     expected_head: str | None
     action: str
     checks: list[CheckDiagnosis]
@@ -317,6 +319,39 @@ def _has_model_quorum_blocker(check: CheckDiagnosis) -> bool:
     return any(marker in text for marker in MODEL_QUORUM_MARKERS)
 
 
+def _wait_check_selector_parts(selector: str) -> tuple[str, str] | None:
+    """Parse a workflow/name selector into normalized parts."""
+    parts = [part.strip().lower() for part in selector.split("/", maxsplit=1)]
+    if len(parts) != 2 or not parts[0] or not parts[1]:
+        return None
+    return parts[0], parts[1]
+
+
+def wait_check_run_id(pr_data: dict[str, Any], selector: str) -> str | None:
+    """Return the run id for a matching in-progress status check, if any."""
+    parsed = _wait_check_selector_parts(selector)
+    if parsed is None:
+        return None
+    expected_workflow, expected_name = parsed
+    pr_head = str(pr_data.get("headRefOid") or "").strip()
+    for check in latest_status_check_rollup(list(pr_data.get("statusCheckRollup") or [])):
+        workflow = str(check.get("workflowName") or check.get("workflow") or "").strip().lower()
+        name = str(check.get("name") or check.get("context") or "").strip().lower()
+        if workflow != expected_workflow or name != expected_name:
+            continue
+        diagnosis = classify_check(check, pr_head)
+        if diagnosis.classification == "in_progress":
+            return diagnosis.run_id
+        return None
+    return None
+
+
+def _has_branch_conflict(pr_data: dict[str, Any]) -> bool:
+    mergeable = str(pr_data.get("mergeable") or "").upper()
+    merge_state = str(pr_data.get("mergeStateStatus") or "").upper()
+    return mergeable == "CONFLICTING" or merge_state == "DIRTY"
+
+
 def classify_run_job(job: dict[str, Any], run_id: str, run_data: dict[str, Any]) -> CheckDiagnosis:
     """Classify an Actions job from gh run view JSON."""
     job_id = _job_id(job)
@@ -427,6 +462,7 @@ def _derive_action(
     *,
     expected_head: str | None,
     head: str,
+    branch_conflict: bool = False,
 ) -> str:
     if expected_head and head != expected_head:
         return "head_drift"
@@ -465,6 +501,8 @@ def _derive_action(
         return "diagnose_unknown"
     if any(check.classification == "early_cancelled" for check in checks):
         return "rerun_cancelled"
+    if branch_conflict:
+        return "diagnose_branch_conflict"
     return "green"
 
 
@@ -480,6 +518,8 @@ def build_followup_result(
     """Build the follow-up decision from already-fetched PR/run data."""
     pr_number = int(pr_data.get("number") or pr_data.get("pr") or 0)
     head = str(pr_data.get("headRefOid") or "").strip()
+    mergeable = str(pr_data.get("mergeable") or "").strip()
+    merge_state_status = str(pr_data.get("mergeStateStatus") or "").strip()
     checks: list[CheckDiagnosis] = []
     for check in latest_status_check_rollup(list(pr_data.get("statusCheckRollup") or [])):
         run_id, _job_id_value = parse_run_job_ids(str(check.get("detailsUrl") or ""))
@@ -489,10 +529,17 @@ def build_followup_result(
         checks.append(diagnosis)
 
     if wait_run:
-        existing_job_ids = {check.job_id for check in checks if check.job_id}
-        checks.extend(job for job in wait_run.jobs if job.job_id not in existing_job_ids)
+        waited_job_ids = {job.job_id for job in wait_run.jobs if job.job_id}
+        checks = [check for check in checks if check.job_id not in waited_job_ids]
+        checks.extend(wait_run.jobs)
 
-    action = _derive_action(checks, wait_run, expected_head=expected_head, head=head)
+    action = _derive_action(
+        checks,
+        wait_run,
+        expected_head=expected_head,
+        head=head,
+        branch_conflict=_has_branch_conflict(pr_data),
+    )
     rerun_commands = [
         check.rerun_command
         for check in checks
@@ -513,6 +560,8 @@ def build_followup_result(
     return FollowupResult(
         pr=pr_number,
         head=head,
+        mergeable=mergeable,
+        merge_state_status=merge_state_status,
         expected_head=expected_head,
         action=action,
         checks=checks,
@@ -570,6 +619,13 @@ def build_prompt(
         lines.extend(
             [
                 f"Goal: monitor #{pr_number} at head {pin} until checks settle. Do not merge, rerun, push, edit files, start cleanup, or start broader queue settlement.",
+                "",
+            ]
+        )
+    elif action == "diagnose_branch_conflict":
+        lines.extend(
+            [
+                f"Goal: diagnose only #{pr_number}'s live branch conflict or mergeability blocker at head {pin}. Do not merge, rerun CI, push, edit files outside a later explicitly authorized conflict repair, start cleanup, or start broader queue settlement.",
                 "",
             ]
         )
@@ -655,6 +711,10 @@ def build_prompt(
         lines.append(
             f"If #{pr_number} remains green/green-equivalent, run review-queue merge-packet for the PR. Do not merge."
         )
+    elif action == "diagnose_branch_conflict":
+        lines.append(
+            f"Checks are green/green-equivalent, but #{pr_number} is still CONFLICTING/DIRTY. Diagnose only the live branch conflict or merge-packet blocker and produce a bounded repair prompt. Do not merge."
+        )
 
     lines.extend(
         [
@@ -728,6 +788,7 @@ def fetch_live_result(
     include_logs: bool,
     allow_rerun_commands: bool,
     wait_run_id: str | None = None,
+    wait_check: str | None = None,
     wait_interval_seconds: float = 180.0,
     wait_timeout_seconds: float = 1800.0,
 ) -> FollowupResult:
@@ -746,6 +807,9 @@ def fetch_live_result(
     run_data_by_id: dict[str, dict[str, Any]] = {}
     log_summary_by_job: dict[str, list[str]] = {}
     wait_run: WaitRunDiagnosis | None = None
+
+    if wait_run_id is None and wait_check:
+        wait_run_id = wait_check_run_id(pr_data, wait_check)
 
     if wait_run_id:
         run_data, timed_out = wait_for_run(
@@ -830,6 +894,10 @@ def build_arg_parser() -> argparse.ArgumentParser:
         help="Poll one GitHub Actions run until completion before generating the prompt",
     )
     parser.add_argument(
+        "--wait-check",
+        help="Poll the run for an in-progress status check selected as 'Workflow/Check name'",
+    )
+    parser.add_argument(
         "--wait-interval-seconds",
         type=float,
         default=180.0,
@@ -852,6 +920,7 @@ def main(argv: list[str] | None = None) -> int:
         include_logs=args.include_logs,
         allow_rerun_commands=args.allow_rerun_commands,
         wait_run_id=args.wait_run,
+        wait_check=args.wait_check,
         wait_interval_seconds=args.wait_interval_seconds,
         wait_timeout_seconds=args.wait_timeout_seconds,
     )

--- a/scripts/pr_check_followup.py
+++ b/scripts/pr_check_followup.py
@@ -1,0 +1,858 @@
+#!/usr/bin/env python3
+"""Diagnose PR check state and generate a bounded follow-up prompt.
+
+The helper is intentionally read-only by default: it shells out to ``gh`` for
+current PR state and run/job diagnostics, but never reruns jobs, pushes, or
+edits files. When ``--wait-run`` is provided, it polls one Actions run until it
+completes or times out, then switches the generated prompt to failed-job
+diagnosis or narrow current-head cancelled-job rerun commands.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+
+INCREMENTAL_PROGRESS_SENTENCE = (
+    "If the prompt above accomplishes no incremental progress make the next prompt one that "
+    "does, include this sentence in all subsequent prompts to ensure they converge towards "
+    "prompts that make incremental progress."
+)
+
+FAILURE_CONCLUSIONS = {"FAILURE", "TIMED_OUT", "ACTION_REQUIRED"}
+GREEN_CONCLUSIONS = {"SUCCESS", "SKIPPED", "NEUTRAL"}
+PENDING_STATUSES = {"IN_PROGRESS", "QUEUED", "PENDING", "EXPECTED", "REQUESTED", "WAITING"}
+CHECKOUT_MARKERS = ("checkout", "sparse-checkout", "repository checkout")
+SUBSTANTIVE_MARKERS = (
+    "verify",
+    "build",
+    "test",
+    "smoke",
+    "drift",
+    "consistency",
+    "quorum",
+    "readiness",
+)
+MODEL_QUORUM_MARKERS = (
+    "needs_model_review_quorum",
+    "collect_model_quorum_before_merge",
+    "model quorum incomplete",
+    "focused adversarial dogfood evidence is required",
+)
+
+
+@dataclass
+class CheckDiagnosis:
+    """Normalized status for a PR check row or Actions job."""
+
+    workflow: str
+    name: str
+    status: str
+    conclusion: str
+    classification: str
+    details_url: str = ""
+    run_id: str | None = None
+    job_id: str | None = None
+    run_head_sha: str | None = None
+    summary: str = ""
+    rerun_command: str | None = None
+    log_command: str | None = None
+    log_summary: list[str] = field(default_factory=list)
+
+
+@dataclass
+class WaitRunDiagnosis:
+    """Summary for an optionally waited GitHub Actions run."""
+
+    run_id: str
+    status: str
+    conclusion: str
+    workflow: str
+    head_sha: str
+    timed_out: bool
+    jobs: list[CheckDiagnosis]
+
+
+@dataclass
+class FollowupResult:
+    """Machine-readable PR follow-up decision."""
+
+    pr: int
+    head: str
+    expected_head: str | None
+    action: str
+    checks: list[CheckDiagnosis]
+    rerun_commands: list[str]
+    prompt: str
+    wait_run: WaitRunDiagnosis | None = None
+
+
+def parse_run_job_ids(details_url: str) -> tuple[str | None, str | None]:
+    """Extract GitHub Actions run/job ids from a details URL."""
+    match = re.search(r"/actions/runs/(\d+)/job/(\d+)", details_url or "")
+    if not match:
+        return None, None
+    return match.group(1), match.group(2)
+
+
+def check_identity(check: dict[str, Any]) -> str:
+    """Return a stable check identity for latest-row collapse."""
+    workflow = str(check.get("workflowName") or check.get("workflow") or "").strip()
+    name = str(check.get("name") or check.get("context") or "").strip()
+    if not name:
+        return ""
+    return f"{workflow}:{name}" if workflow else name
+
+
+def latest_status_check_rollup(checks: list[Any]) -> list[dict[str, Any]]:
+    """Collapse superseded check rows to the latest row per workflow/job identity."""
+    latest: dict[str, tuple[str, int, dict[str, Any]]] = {}
+    passthrough: list[dict[str, Any]] = []
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            continue
+        identity = check_identity(check)
+        if not identity:
+            passthrough.append(check)
+            continue
+        timestamp = str(
+            check.get("completedAt")
+            or check.get("startedAt")
+            or check.get("createdAt")
+            or check.get("updatedAt")
+            or ""
+        )
+        previous = latest.get(identity)
+        if previous is None or (timestamp, index) >= (previous[0], previous[1]):
+            latest[identity] = (timestamp, index, check)
+    return passthrough + [item[2] for item in sorted(latest.values(), key=lambda item: item[1])]
+
+
+def _parse_datetime(raw: str | None) -> datetime | None:
+    if not raw:
+        return None
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _duration_seconds(check: dict[str, Any]) -> float | None:
+    started = _parse_datetime(str(check.get("startedAt") or ""))
+    completed = _parse_datetime(str(check.get("completedAt") or ""))
+    if not started or not completed:
+        return None
+    return max(0.0, (completed - started).total_seconds())
+
+
+def classify_check(
+    check: dict[str, Any], pr_head: str, run_data: dict[str, Any] | None = None
+) -> CheckDiagnosis:
+    """Classify a statusCheckRollup row into operator-relevant buckets."""
+    workflow = str(check.get("workflowName") or check.get("workflow") or "").strip()
+    name = str(check.get("name") or check.get("context") or "").strip()
+    status = str(check.get("status") or check.get("state") or "").upper()
+    conclusion = str(check.get("conclusion") or "").upper()
+    if not conclusion and status in FAILURE_CONCLUSIONS | GREEN_CONCLUSIONS | {
+        "CANCELLED",
+        "STALE",
+    }:
+        conclusion = status
+
+    details_url = str(check.get("detailsUrl") or check.get("link") or "").strip()
+    run_id, job_id = parse_run_job_ids(details_url)
+    run_head = str((run_data or {}).get("headSha") or "").strip() or None
+    classification = "unknown"
+    summary = ""
+
+    if conclusion == "CANCELLED":
+        if run_head and run_head != pr_head:
+            classification = "stale_cancelled"
+            summary = f"cancelled on stale head {run_head}"
+        else:
+            duration = _duration_seconds(check)
+            if _is_early_cancelled_job(run_data, job_id) or (
+                duration is not None and duration <= 120
+            ):
+                classification = "early_cancelled"
+                summary = "cancelled before substantive verification"
+            else:
+                classification = "unknown"
+                summary = "cancelled after job startup; inspect log before rerun"
+    elif conclusion in FAILURE_CONCLUSIONS:
+        classification = "real_failure"
+        summary = (
+            _failure_after_checkout_summary(_job_steps(run_data, job_id))
+            or "current-head failure requiring repair"
+        )
+    elif status in PENDING_STATUSES or not conclusion:
+        classification = "in_progress"
+        summary = "check still running or pending"
+    elif conclusion in GREEN_CONCLUSIONS:
+        classification = "green"
+        summary = "green or green-equivalent"
+    elif conclusion == "STALE":
+        classification = "stale_cancelled"
+        summary = "stale status context"
+
+    rerun_command = f"gh run rerun {run_id} --job {job_id}" if run_id and job_id else None
+    log_command = f"gh run view {run_id} --job {job_id} --log" if run_id and job_id else None
+    return CheckDiagnosis(
+        workflow=workflow,
+        name=name,
+        status=status,
+        conclusion=conclusion,
+        classification=classification,
+        details_url=details_url,
+        run_id=run_id,
+        job_id=job_id,
+        run_head_sha=run_head,
+        summary=summary,
+        rerun_command=rerun_command,
+        log_command=log_command,
+    )
+
+
+def _job_id(job: dict[str, Any]) -> str:
+    return str(job.get("databaseId") or job.get("id") or "").strip()
+
+
+def _step_names_before_first_cancel(steps: list[dict[str, Any]]) -> tuple[list[str], bool]:
+    names = [str(step.get("name") or "").lower() for step in steps]
+    first_cancelled_index = next(
+        (
+            index
+            for index, step in enumerate(steps)
+            if str(step.get("conclusion") or "").upper() == "CANCELLED"
+        ),
+        None,
+    )
+    if first_cancelled_index is None:
+        return names, False
+    return names[: first_cancelled_index + 1], True
+
+
+def _is_early_cancelled_steps(steps: list[dict[str, Any]]) -> bool:
+    if not steps:
+        return False
+    before_cancel, had_cancel = _step_names_before_first_cancel(steps)
+    if not had_cancel:
+        return False
+    return any(
+        any(marker in name for marker in CHECKOUT_MARKERS) for name in before_cancel
+    ) and not any(
+        any(marker in name for marker in SUBSTANTIVE_MARKERS) for name in before_cancel[:-1]
+    )
+
+
+def _is_early_cancelled_job(run_data: dict[str, Any] | None, job_id: str | None) -> bool:
+    if not run_data or not job_id:
+        return False
+    for job in run_data.get("jobs") or []:
+        if not isinstance(job, dict):
+            continue
+        database_id = _job_id(job)
+        if database_id and database_id != job_id:
+            continue
+        steps = [step for step in job.get("steps") or [] if isinstance(step, dict)]
+        return _is_early_cancelled_steps(steps)
+    return False
+
+
+def _job_steps(run_data: dict[str, Any] | None, job_id: str | None) -> list[dict[str, Any]]:
+    if not run_data or not job_id:
+        return []
+    for job in run_data.get("jobs") or []:
+        if not isinstance(job, dict):
+            continue
+        database_id = _job_id(job)
+        if database_id and database_id != job_id:
+            continue
+        return [step for step in job.get("steps") or [] if isinstance(step, dict)]
+    return []
+
+
+def _failure_after_checkout_summary(steps: list[dict[str, Any]]) -> str | None:
+    """Return the first failing substantive step after checkout, if available."""
+    checkout_index: int | None = None
+    for index, step in enumerate(steps):
+        name = str(step.get("name") or "").lower()
+        conclusion = str(step.get("conclusion") or "").upper()
+        if checkout_index is None and any(marker in name for marker in CHECKOUT_MARKERS):
+            if conclusion == "SUCCESS":
+                checkout_index = index
+            continue
+        if checkout_index is None or index <= checkout_index:
+            continue
+        if conclusion in FAILURE_CONCLUSIONS or conclusion == "FAILURE":
+            step_name = str(step.get("name") or "substantive step").strip()
+            return f"failed after checkout during {step_name}"
+    return None
+
+
+def _is_merge_quorum_check(check: CheckDiagnosis) -> bool:
+    workflow = check.workflow.lower()
+    name = check.name.lower()
+    return "merge quorum" in workflow or "merge-quorum" in workflow or "merge-quorum" in name
+
+
+def _has_model_quorum_blocker(check: CheckDiagnosis) -> bool:
+    if check.classification != "real_failure" or not _is_merge_quorum_check(check):
+        return False
+    text = "\n".join([check.summary, *check.log_summary]).lower()
+    return any(marker in text for marker in MODEL_QUORUM_MARKERS)
+
+
+def classify_run_job(job: dict[str, Any], run_id: str, run_data: dict[str, Any]) -> CheckDiagnosis:
+    """Classify an Actions job from gh run view JSON."""
+    job_id = _job_id(job)
+    status = str(job.get("status") or "").upper()
+    conclusion = str(job.get("conclusion") or "").upper()
+    workflow = str(run_data.get("workflowName") or "").strip()
+    name = str(job.get("name") or job_id or "").strip()
+    head_sha = str(run_data.get("headSha") or "").strip() or None
+    classification = "unknown"
+    summary = ""
+
+    if conclusion == "CANCELLED":
+        if _is_early_cancelled_steps(
+            [step for step in job.get("steps") or [] if isinstance(step, dict)]
+        ):
+            classification = "early_cancelled"
+            summary = "cancelled before substantive verification"
+        else:
+            classification = "unknown"
+            summary = "cancelled after job startup; inspect log before rerun"
+    elif conclusion in FAILURE_CONCLUSIONS:
+        classification = "real_failure"
+        summary = (
+            _failure_after_checkout_summary(
+                [step for step in job.get("steps") or [] if isinstance(step, dict)]
+            )
+            or "current-head failure requiring repair"
+        )
+    elif status in PENDING_STATUSES or not conclusion:
+        classification = "in_progress"
+        summary = "job still running or pending"
+    elif conclusion in GREEN_CONCLUSIONS:
+        classification = "green"
+        summary = "green or green-equivalent"
+
+    rerun_command = f"gh run rerun {run_id} --job {job_id}" if job_id else None
+    log_command = f"gh run view {run_id} --job {job_id} --log" if job_id else None
+    return CheckDiagnosis(
+        workflow=workflow,
+        name=name,
+        status=status,
+        conclusion=conclusion,
+        classification=classification,
+        run_id=run_id,
+        job_id=job_id or None,
+        run_head_sha=head_sha,
+        summary=summary,
+        rerun_command=rerun_command,
+        log_command=log_command,
+    )
+
+
+def summarize_log(log_text: str, max_lines: int = 12) -> list[str]:
+    """Extract high-signal failure lines without dumping complete logs."""
+    markers = (
+        "##[error]",
+        "FAIL:",
+        "FAILED",
+        "Out of date:",
+        " E ",
+        "Error:",
+        "error:",
+        "verdict=",
+        "status=needs_model_review_quorum",
+        "model quorum incomplete",
+        "focused adversarial dogfood evidence is required",
+    )
+    lines: list[str] = []
+    for raw in log_text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        if any(marker in line for marker in markers):
+            lines.append(line)
+    return lines[-max_lines:]
+
+
+def diagnose_wait_run(
+    run_id: str,
+    run_data: dict[str, Any],
+    *,
+    timed_out: bool = False,
+    log_summary_by_job: dict[str, list[str]] | None = None,
+) -> WaitRunDiagnosis:
+    """Build a diagnosis for a waited Actions run."""
+    jobs = [
+        classify_run_job(job, run_id, run_data)
+        for job in run_data.get("jobs") or []
+        if isinstance(job, dict)
+    ]
+    for diagnosis in jobs:
+        if diagnosis.job_id and log_summary_by_job:
+            diagnosis.log_summary = log_summary_by_job.get(diagnosis.job_id, [])
+    return WaitRunDiagnosis(
+        run_id=run_id,
+        status=str(run_data.get("status") or "").lower(),
+        conclusion=str(run_data.get("conclusion") or "").lower(),
+        workflow=str(run_data.get("workflowName") or ""),
+        head_sha=str(run_data.get("headSha") or ""),
+        timed_out=timed_out,
+        jobs=jobs,
+    )
+
+
+def _derive_action(
+    checks: list[CheckDiagnosis],
+    wait_run: WaitRunDiagnosis | None,
+    *,
+    expected_head: str | None,
+    head: str,
+) -> str:
+    if expected_head and head != expected_head:
+        return "head_drift"
+
+    wait_jobs = wait_run.jobs if wait_run else []
+    if wait_run and (
+        wait_run.timed_out or any(job.classification == "in_progress" for job in wait_jobs)
+    ):
+        return "monitor"
+    if any(job.classification == "real_failure" for job in wait_jobs):
+        if all(
+            job.classification != "real_failure" or _has_model_quorum_blocker(job)
+            for job in wait_jobs
+        ):
+            return "collect_model_evidence"
+        return "repair_failures"
+    if any(job.classification == "unknown" for job in wait_jobs):
+        return "diagnose_unknown"
+    if (
+        wait_jobs
+        and any(job.classification == "early_cancelled" for job in wait_jobs)
+        and not any(job.classification == "real_failure" for job in wait_jobs)
+    ):
+        return "rerun_cancelled"
+
+    if any(check.classification == "real_failure" for check in checks):
+        if all(
+            check.classification != "real_failure" or _has_model_quorum_blocker(check)
+            for check in checks
+        ):
+            return "collect_model_evidence"
+        return "repair_failures"
+    if any(check.classification == "in_progress" for check in checks):
+        return "monitor"
+    if any(check.classification == "unknown" for check in checks):
+        return "diagnose_unknown"
+    if any(check.classification == "early_cancelled" for check in checks):
+        return "rerun_cancelled"
+    return "green"
+
+
+def build_followup_result(
+    pr_data: dict[str, Any],
+    *,
+    expected_head: str | None = None,
+    run_data_by_id: dict[str, dict[str, Any]] | None = None,
+    log_summary_by_job: dict[str, list[str]] | None = None,
+    wait_run: WaitRunDiagnosis | None = None,
+    allow_rerun_commands: bool = False,
+) -> FollowupResult:
+    """Build the follow-up decision from already-fetched PR/run data."""
+    pr_number = int(pr_data.get("number") or pr_data.get("pr") or 0)
+    head = str(pr_data.get("headRefOid") or "").strip()
+    checks: list[CheckDiagnosis] = []
+    for check in latest_status_check_rollup(list(pr_data.get("statusCheckRollup") or [])):
+        run_id, _job_id_value = parse_run_job_ids(str(check.get("detailsUrl") or ""))
+        diagnosis = classify_check(check, head, (run_data_by_id or {}).get(run_id or ""))
+        if diagnosis.job_id and log_summary_by_job:
+            diagnosis.log_summary = log_summary_by_job.get(diagnosis.job_id, [])
+        checks.append(diagnosis)
+
+    if wait_run:
+        existing_job_ids = {check.job_id for check in checks if check.job_id}
+        checks.extend(job for job in wait_run.jobs if job.job_id not in existing_job_ids)
+
+    action = _derive_action(checks, wait_run, expected_head=expected_head, head=head)
+    rerun_commands = [
+        check.rerun_command
+        for check in checks
+        if check.classification == "early_cancelled" and check.rerun_command
+    ]
+    if not allow_rerun_commands or action != "rerun_cancelled":
+        rerun_commands = []
+
+    prompt = build_prompt(
+        pr_number=pr_number,
+        head=head,
+        expected_head=expected_head,
+        action=action,
+        checks=checks,
+        rerun_commands=rerun_commands,
+        wait_run=wait_run,
+    )
+    return FollowupResult(
+        pr=pr_number,
+        head=head,
+        expected_head=expected_head,
+        action=action,
+        checks=checks,
+        rerun_commands=rerun_commands,
+        prompt=prompt,
+        wait_run=wait_run,
+    )
+
+
+def build_prompt(
+    *,
+    pr_number: int,
+    head: str,
+    expected_head: str | None,
+    action: str,
+    checks: list[CheckDiagnosis],
+    rerun_commands: list[str],
+    wait_run: WaitRunDiagnosis | None = None,
+) -> str:
+    """Render the recursive best-next prompt."""
+    lines = [
+        "Start from live repo truth in /Users/armand/Development/aragora. Do not trust prior transcript state. Check your Aragora operator-steering mailbox before lane work.",
+        "",
+    ]
+    pin = expected_head or head
+    if action == "head_drift":
+        lines.extend(
+            [
+                f"Goal: refresh #{pr_number} follow-up because the live head drifted from {expected_head} to {head}. Do not merge, rerun, push, edit files, start cleanup, or start broader queue settlement.",
+                "",
+            ]
+        )
+    elif action == "repair_failures":
+        lines.extend(
+            [
+                f"Goal: make one bounded progress increment on #{pr_number} by repairing only current-head real CI failures at head {pin}. Do not merge, start broader queue settlement, rerun cancelled jobs, start cleanup, or touch unrelated PRs/files.",
+                "",
+            ]
+        )
+    elif action == "collect_model_evidence":
+        lines.extend(
+            [
+                f"Goal: make one bounded progress increment on #{pr_number} by collecting exactly one current-head non-Codex model/dogfood evidence signal at head {pin}. Do not merge, start broader queue settlement, rerun cancelled jobs, start cleanup, push unrelated work, or touch unrelated PRs/files.",
+                "",
+            ]
+        )
+    elif action == "rerun_cancelled":
+        lines.extend(
+            [
+                f"Goal: make one bounded progress increment on #{pr_number} by rerunning only current-head early-cancelled jobs at head {pin}. Do not merge, push, edit files, start cleanup, or touch unrelated PRs/files.",
+                "",
+            ]
+        )
+    elif action == "monitor":
+        lines.extend(
+            [
+                f"Goal: monitor #{pr_number} at head {pin} until checks settle. Do not merge, rerun, push, edit files, start cleanup, or start broader queue settlement.",
+                "",
+            ]
+        )
+    else:
+        lines.extend(
+            [
+                f"Goal: continue exact-head follow-up for #{pr_number} at head {pin}. Do not merge, push, edit files, start cleanup, or touch unrelated PRs/files.",
+                "",
+            ]
+        )
+
+    lines.extend(
+        [
+            "Run read-only first:",
+            "- git status --short --branch --untracked-files=all",
+            "- python3 scripts/agent_bridge.py --json health || true",
+            f"- python3 scripts/identify_lane_owner.py --pr {pr_number} --json || true",
+            f"- gh pr view {pr_number} --json number,state,isDraft,headRefName,headRefOid,mergeable,mergeStateStatus,statusCheckRollup,url",
+            "",
+            f"If any active lane owns #{pr_number} repair/settlement, stop and report owner. If #{pr_number} head drifted from {pin}, stop and produce a refreshed prompt pinned to live head.",
+            "",
+        ]
+    )
+
+    if wait_run:
+        lines.extend(
+            [
+                f"Wait-run diagnosis: run {wait_run.run_id} / {wait_run.workflow} is {wait_run.status} with conclusion {wait_run.conclusion or 'none'} at head {wait_run.head_sha or 'unknown'}.",
+                "",
+            ]
+        )
+
+    interesting = [check for check in checks if check.classification != "green"]
+    if interesting:
+        lines.append("Current non-green diagnosis:")
+        for check in interesting:
+            run_job = (
+                f" run {check.run_id}, job {check.job_id}" if check.run_id and check.job_id else ""
+            )
+            lines.append(
+                f"- {check.workflow} / {check.name}: {check.classification}{run_job}; {check.summary}"
+            )
+            if (
+                action in {"repair_failures", "collect_model_evidence"}
+                and check.classification == "real_failure"
+                and check.log_command
+            ):
+                lines.append(f"  inspect: {check.log_command}")
+            for item in check.log_summary[-3:]:
+                lines.append(f"  log: {item}")
+        lines.append("")
+
+    if action == "repair_failures":
+        lines.append(
+            "Repair only the real failed checks. Do not rerun cancelled rows until the substantive failures are green."
+        )
+    elif action == "collect_model_evidence":
+        lines.append(
+            "If merge-packet still blocks on model quorum or focused adversarial dogfood, collect exactly one current-head non-Codex model/dogfood evidence signal."
+        )
+        lines.append(
+            "Post exactly one valid PR comment only if the evidence is current-head, non-Codex, lists files reviewed, puts findings first, includes validation run/not-run reasons, includes focused adversarial dogfood verdict, and states that it is not merge authorization."
+        )
+        lines.append(
+            "Then rerun review-queue merge-packet for the PR and report the next blocker. Do not merge."
+        )
+    elif action == "rerun_cancelled" and rerun_commands:
+        lines.append("If the same rows remain current-head early cancellations, run only:")
+        for command in rerun_commands:
+            lines.append(f"- {command}")
+        lines.append("Then monitor until those rerun jobs settle.")
+    elif action == "rerun_cancelled":
+        lines.append(
+            "Only early-cancelled rows remain; rerun commands were intentionally withheld by the helper. Re-run the helper with --allow-rerun-commands to generate exact commands."
+        )
+    elif action == "monitor" and wait_run and wait_run.timed_out:
+        lines.append(
+            f"Run {wait_run.run_id} did not settle before the wait timeout. Monitor again before diagnosing or rerunning."
+        )
+    elif action == "monitor":
+        lines.append("If checks are still in progress, report exact names and stop.")
+    elif action == "green":
+        lines.append(
+            f"If #{pr_number} remains green/green-equivalent, run review-queue merge-packet for the PR. Do not merge."
+        )
+
+    lines.extend(
+        [
+            "",
+            "Final report must include root state, active/conflict lanes, head/check state, action withheld/taken, and a recursive best next prompt.",
+            INCREMENTAL_PROGRESS_SENTENCE,
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _run_gh_json(args: list[str]) -> dict[str, Any]:
+    completed = subprocess.run(args, check=True, text=True, capture_output=True)
+    return json.loads(completed.stdout)
+
+
+def _run_gh_log(args: list[str]) -> str:
+    completed = subprocess.run(args, check=True, text=True, capture_output=True)
+    return completed.stdout
+
+
+def wait_for_run(
+    run_id: str,
+    *,
+    poll_interval_seconds: float,
+    timeout_seconds: float,
+) -> tuple[dict[str, Any], bool]:
+    """Poll a GitHub Actions run until it completes or the timeout expires."""
+    deadline = time.monotonic() + max(0.0, timeout_seconds)
+    latest: dict[str, Any] | None = None
+    while True:
+        latest = _run_gh_json(
+            [
+                "gh",
+                "run",
+                "view",
+                run_id,
+                "--json",
+                "status,conclusion,event,headSha,workflowName,jobs",
+            ]
+        )
+        if str(latest.get("status") or "").lower() == "completed":
+            return latest, False
+        if time.monotonic() >= deadline:
+            return latest, True
+        time.sleep(max(0.0, poll_interval_seconds))
+
+
+def _fetch_logs_for_failed_jobs(run_id: str, run_data: dict[str, Any]) -> dict[str, list[str]]:
+    summaries: dict[str, list[str]] = {}
+    for job in run_data.get("jobs") or []:
+        if not isinstance(job, dict):
+            continue
+        job_id = _job_id(job)
+        conclusion = str(job.get("conclusion") or "").upper()
+        if not job_id or conclusion not in FAILURE_CONCLUSIONS:
+            continue
+        try:
+            log_text = _run_gh_log(["gh", "run", "view", run_id, "--job", job_id, "--log"])
+            summaries[job_id] = summarize_log(log_text)
+        except subprocess.CalledProcessError:
+            summaries[job_id] = ["failed to fetch job log"]
+    return summaries
+
+
+def fetch_live_result(
+    pr_number: int,
+    *,
+    expected_head: str | None,
+    include_logs: bool,
+    allow_rerun_commands: bool,
+    wait_run_id: str | None = None,
+    wait_interval_seconds: float = 180.0,
+    wait_timeout_seconds: float = 1800.0,
+) -> FollowupResult:
+    """Fetch live PR/run data through gh and build a follow-up result."""
+    pr_data = _run_gh_json(
+        [
+            "gh",
+            "pr",
+            "view",
+            str(pr_number),
+            "--json",
+            "number,state,isDraft,headRefName,headRefOid,mergeable,mergeStateStatus,statusCheckRollup,url",
+        ]
+    )
+    head = str(pr_data.get("headRefOid") or "")
+    run_data_by_id: dict[str, dict[str, Any]] = {}
+    log_summary_by_job: dict[str, list[str]] = {}
+    wait_run: WaitRunDiagnosis | None = None
+
+    if wait_run_id:
+        run_data, timed_out = wait_for_run(
+            wait_run_id,
+            poll_interval_seconds=wait_interval_seconds,
+            timeout_seconds=wait_timeout_seconds,
+        )
+        run_data_by_id[wait_run_id] = run_data
+        log_summary_by_job.update(_fetch_logs_for_failed_jobs(wait_run_id, run_data))
+        wait_run = diagnose_wait_run(
+            wait_run_id,
+            run_data,
+            timed_out=timed_out,
+            log_summary_by_job=log_summary_by_job,
+        )
+
+    for check in latest_status_check_rollup(list(pr_data.get("statusCheckRollup") or [])):
+        diagnosis = classify_check(check, head)
+        if diagnosis.classification not in {"real_failure", "early_cancelled", "unknown"}:
+            continue
+        if not diagnosis.run_id or not diagnosis.job_id or diagnosis.run_id in run_data_by_id:
+            continue
+        try:
+            run_data_by_id[diagnosis.run_id] = _run_gh_json(
+                [
+                    "gh",
+                    "run",
+                    "view",
+                    diagnosis.run_id,
+                    "--json",
+                    "status,conclusion,event,headSha,workflowName,jobs",
+                ]
+            )
+        except (subprocess.CalledProcessError, json.JSONDecodeError):
+            continue
+        should_fetch_log = include_logs or (
+            diagnosis.classification == "real_failure" and _is_merge_quorum_check(diagnosis)
+        )
+        if should_fetch_log and diagnosis.classification == "real_failure":
+            try:
+                log_text = _run_gh_log(
+                    ["gh", "run", "view", diagnosis.run_id, "--job", diagnosis.job_id, "--log"]
+                )
+                log_summary_by_job[diagnosis.job_id] = summarize_log(log_text)
+            except subprocess.CalledProcessError:
+                log_summary_by_job[diagnosis.job_id] = ["failed to fetch job log"]
+
+    return build_followup_result(
+        pr_data,
+        expected_head=expected_head,
+        run_data_by_id=run_data_by_id,
+        log_summary_by_job=log_summary_by_job,
+        wait_run=wait_run,
+        allow_rerun_commands=allow_rerun_commands,
+    )
+
+
+def _result_to_json(result: FollowupResult) -> str:
+    payload = asdict(result)
+    payload["generated_at"] = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    return json.dumps(payload, indent=2, sort_keys=True)
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pr", type=int, required=True, help="Pull request number to inspect")
+    parser.add_argument("--head", help="Expected PR head SHA; head drift stops the prompt")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+    parser.add_argument("--prompt", action="store_true", help="Print the recursive prompt")
+    parser.add_argument(
+        "--include-logs",
+        action="store_true",
+        help="Fetch failed job logs and include concise failure snippets",
+    )
+    parser.add_argument(
+        "--allow-rerun-commands",
+        action="store_true",
+        help="Include exact rerun commands when only current-head early cancellations remain",
+    )
+    parser.add_argument(
+        "--wait-run",
+        help="Poll one GitHub Actions run until completion before generating the prompt",
+    )
+    parser.add_argument(
+        "--wait-interval-seconds",
+        type=float,
+        default=180.0,
+        help="Polling interval for --wait-run (default: 180)",
+    )
+    parser.add_argument(
+        "--wait-timeout-seconds",
+        type=float,
+        default=1800.0,
+        help="Maximum wait duration for --wait-run (default: 1800)",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    result = fetch_live_result(
+        args.pr,
+        expected_head=args.head,
+        include_logs=args.include_logs,
+        allow_rerun_commands=args.allow_rerun_commands,
+        wait_run_id=args.wait_run,
+        wait_interval_seconds=args.wait_interval_seconds,
+        wait_timeout_seconds=args.wait_timeout_seconds,
+    )
+    if args.json:
+        print(_result_to_json(result))
+    if args.prompt or not args.json:
+        print(result.prompt)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/settlement_followup.py
+++ b/scripts/settlement_followup.py
@@ -1,0 +1,477 @@
+#!/usr/bin/env python3
+"""Read-only follow-up packet for exact-head Tier 4 settlement work.
+
+The helper intentionally reports live state and suggested next prompts only. It
+does not merge, push, create worktrees, rerun CI, apply settlement, or clean up.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import Any
+
+DEFAULT_REPO_ROOT = Path(__file__).resolve().parents[1]
+CONVERGENCE_SENTENCE = (
+    "If the prompt above accomplishes no incremental progress make the next prompt one "
+    "that does, include this sentence in all subsequent prompts to ensure they converge "
+    "towards prompts that make incremental progress."
+)
+AUTOMATION_SENTENCE = (
+    "If any of the work involved can be better automated and made more autonomous by "
+    "improving aragora tooling at a meta level create a plan to do that instead, "
+    "include this sentence in all subsequent prompts to ensure they converge towards "
+    "automating and making more autonomous all steps at a meta level where this makes "
+    "sense for the repo and project."
+)
+
+CommandRunner = Callable[[list[str], Path], subprocess.CompletedProcess[str]]
+
+
+def _default_runner(command: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.setdefault("PYTHONDONTWRITEBYTECODE", "1")
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=180,
+        env=env,
+    )
+
+
+def _run_text(command: list[str], cwd: Path, runner: CommandRunner) -> dict[str, Any]:
+    try:
+        result = runner(command, cwd)
+    except (OSError, subprocess.SubprocessError) as exc:
+        return {
+            "command": command,
+            "returncode": 127,
+            "stdout": "",
+            "stderr": str(exc),
+        }
+    return {
+        "command": command,
+        "returncode": result.returncode,
+        "stdout": result.stdout or "",
+        "stderr": result.stderr or "",
+    }
+
+
+def _parse_json(text: str) -> Any:
+    stripped = text.strip()
+    if not stripped:
+        return None
+    try:
+        return json.loads(stripped)
+    except json.JSONDecodeError:
+        return {"raw": stripped}
+
+
+def _run_json(command: list[str], cwd: Path, runner: CommandRunner) -> dict[str, Any]:
+    result = _run_text(command, cwd, runner)
+    payload = _parse_json(str(result.get("stdout") or ""))
+    result["payload"] = payload
+    return result
+
+
+def _status_packet(repo_root: Path, runner: CommandRunner) -> dict[str, Any]:
+    result = _run_text(
+        ["git", "status", "--short", "--branch", "--untracked-files=all"],
+        repo_root,
+        runner,
+    )
+    lines = [line for line in str(result["stdout"]).splitlines() if line.strip()]
+    dirty_paths: list[str] = []
+    for line in lines:
+        if line.startswith("##"):
+            continue
+        dirty_paths.append(line[3:].strip() if len(line) > 3 else line.strip())
+    return {
+        "dirty": bool(dirty_paths),
+        "dirty_paths": dirty_paths,
+        "status": lines,
+        "returncode": result["returncode"],
+    }
+
+
+def _normalize_branch(branch: str) -> str:
+    text = branch.strip()
+    for prefix in ("refs/heads/", "origin/"):
+        if text.startswith(prefix):
+            return text[len(prefix) :]
+    return text
+
+
+def _remote_branch_packet(
+    repo_root: Path,
+    *,
+    branch: str,
+    expected_oid: str | None,
+    runner: CommandRunner,
+) -> dict[str, Any]:
+    normalized = _normalize_branch(branch)
+    result = _run_text(
+        ["git", "ls-remote", "origin", f"refs/heads/{normalized}"],
+        repo_root,
+        runner,
+    )
+    line = next((item for item in result["stdout"].splitlines() if item.strip()), "")
+    remote_oid = line.split()[0] if line else None
+    matches_expected = remote_oid == expected_oid if expected_oid else None
+    return {
+        "input": branch,
+        "branch": normalized,
+        "remote_ref": f"refs/heads/{normalized}",
+        "published": bool(remote_oid),
+        "remote_oid": remote_oid,
+        "expected_oid": expected_oid,
+        "matches_expected": matches_expected,
+        "returncode": result["returncode"],
+        "stderr": result["stderr"],
+    }
+
+
+def _worktree_list(repo_root: Path, runner: CommandRunner) -> list[dict[str, str]]:
+    result = _run_text(["git", "worktree", "list", "--porcelain"], repo_root, runner)
+    records: list[dict[str, str]] = []
+    current: dict[str, str] = {}
+    for line in result["stdout"].splitlines():
+        if not line.strip():
+            if current:
+                records.append(current)
+                current = {}
+            continue
+        key, _, value = line.partition(" ")
+        current[key] = value
+    if current:
+        records.append(current)
+    return records
+
+
+def _repair_worktree_path(
+    repo_root: Path,
+    *,
+    branch: str,
+    explicit_path: Path | None,
+    runner: CommandRunner,
+) -> Path | None:
+    if explicit_path is not None:
+        return explicit_path
+    normalized = _normalize_branch(branch)
+    for record in _worktree_list(repo_root, runner):
+        if record.get("branch") == f"refs/heads/{normalized}":
+            return Path(record["worktree"])
+    return None
+
+
+def _repair_worktree_packet(
+    repo_root: Path,
+    *,
+    branch: str,
+    expected_oid: str | None,
+    explicit_path: Path | None,
+    runner: CommandRunner,
+) -> dict[str, Any]:
+    path = _repair_worktree_path(
+        repo_root,
+        branch=branch,
+        explicit_path=explicit_path,
+        runner=runner,
+    )
+    if path is None:
+        return {
+            "found": False,
+            "path": None,
+            "dirty": None,
+            "head": None,
+            "matches_expected": None,
+        }
+    status = _status_packet(path, runner)
+    head_result = _run_text(["git", "rev-parse", "HEAD"], path, runner)
+    head = str(head_result["stdout"]).strip() or None
+    return {
+        "found": True,
+        "path": str(path),
+        "dirty": status["dirty"],
+        "dirty_paths": status["dirty_paths"],
+        "status": status["status"],
+        "head": head,
+        "expected_oid": expected_oid,
+        "matches_expected": head == expected_oid if expected_oid else None,
+    }
+
+
+def _tail_lines(text: str, *, limit: int = 20) -> list[str]:
+    lines = [line for line in text.splitlines() if line.strip()]
+    return lines[-limit:]
+
+
+def _settlement_check_packet(
+    *,
+    pr: int,
+    head: str,
+    repair_cwd: Path | None,
+    runner: CommandRunner,
+) -> dict[str, Any]:
+    if repair_cwd is None:
+        return {
+            "ran": False,
+            "ok": False,
+            "reason": "repair worktree not found",
+            "blockers": ["repair worktree not found"],
+        }
+    command = [
+        sys.executable,
+        "scripts/settle_tier4_pr.py",
+        "--check",
+        "--pr",
+        str(pr),
+        "--head",
+        head,
+        "--json",
+    ]
+    result = _run_json(command, repair_cwd, runner)
+    payload = result.get("payload")
+    gate = payload.get("gate") if isinstance(payload, dict) else None
+    blockers = gate.get("blockers") if isinstance(gate, dict) else None
+    return {
+        "ran": True,
+        "command": command,
+        "returncode": result["returncode"],
+        "payload": payload,
+        "ok": bool(isinstance(gate, dict) and gate.get("ok")),
+        "blockers": blockers if isinstance(blockers, list) else [],
+        "stderr": result["stderr"],
+    }
+
+
+def _focused_tests_packet(
+    *,
+    repair_cwd: Path | None,
+    runner: CommandRunner,
+) -> dict[str, Any]:
+    if repair_cwd is None:
+        return {
+            "ran": False,
+            "ok": False,
+            "reason": "repair worktree not found",
+        }
+    command = [
+        sys.executable,
+        "-m",
+        "pytest",
+        "-p",
+        "no:cacheprovider",
+        "tests/scripts/test_settle_tier4_pr.py",
+    ]
+    result = _run_text(command, repair_cwd, runner)
+    return {
+        "ran": True,
+        "command": command,
+        "returncode": result["returncode"],
+        "ok": result["returncode"] == 0,
+        "stdout_tail": _tail_lines(str(result["stdout"])),
+        "stderr_tail": _tail_lines(str(result["stderr"])),
+    }
+
+
+def _prompt_for(packet: dict[str, Any]) -> str:
+    pr = packet["pr"]
+    head = packet["head"]
+    repair = packet["repair_branch"]
+    repair_branch = repair["branch"]
+    repair_oid = repair.get("remote_oid") or packet.get("repair_head") or "<repair-head>"
+    root_dirty = packet["root"]["dirty"]
+    pr_state = packet["pr_state"].get("payload") or {}
+    mergeable = pr_state.get("mergeable")
+    merge_state = pr_state.get("mergeStateStatus")
+    gate = packet["validation"]["settlement_check"]
+    blockers = gate.get("blockers") or []
+
+    if root_dirty:
+        next_action = "First classify and preserve the root dirty state before any mutation."
+    elif blockers or merge_state in {"DIRTY", "CONFLICTING"} or mergeable == "CONFLICTING":
+        next_action = "Diagnose only the live branch conflict or merge-packet blocker."
+    elif gate.get("ok"):
+        next_action = (
+            "Prepare exact-head settlement apply only if a fresh prompt explicitly authorizes it."
+        )
+    else:
+        next_action = (
+            "Re-run the read-only settlement follow-up helper and report the exact blocker."
+        )
+
+    return (
+        "Start from live repo truth in `/Users/armand/Development/aragora`. "
+        "Do not trust prior transcript state. Check Aragora operator-steering mailbox "
+        "before lane work. "
+        f"Goal: continue #{pr} settlement follow-up from repaired branch "
+        f"`origin/{repair_branch}` at `{repair_oid}` without applying settlement. "
+        "Do not merge, push, cleanup, rerun CI, apply settlement, or start unrelated queue work "
+        "unless explicitly authorized. "
+        f"First run `python3 scripts/settlement_followup.py --pr {pr} --head {head} "
+        f"--repair-branch origin/{repair_branch}"
+        + (f" --repair-head {repair_oid}" if repair_oid != "<repair-head>" else "")
+        + " --json --prompt` and report root dirty paths, bridge health, PR mergeability, "
+        "repair-branch publish state, focused validation, and exact apply blockers. "
+        f"{next_action} "
+        f"{CONVERGENCE_SENTENCE} {AUTOMATION_SENTENCE}"
+    )
+
+
+def build_followup_packet(
+    *,
+    pr: int,
+    head: str,
+    repair_branch: str,
+    repair_head: str | None = None,
+    repair_worktree: Path | None = None,
+    repo_root: Path = DEFAULT_REPO_ROOT,
+    include_prompt: bool = False,
+    run_focused_tests: bool = True,
+    runner: CommandRunner = _default_runner,
+) -> dict[str, Any]:
+    repo_root = repo_root.resolve()
+    owner = _run_json(
+        [sys.executable, "scripts/identify_lane_owner.py", "--pr", str(pr), "--json"],
+        repo_root,
+        runner,
+    )
+    root = _status_packet(repo_root, runner)
+    bridge_health = _run_json(
+        [sys.executable, "scripts/agent_bridge.py", "--json", "health"],
+        repo_root,
+        runner,
+    )
+    pr_state = _run_json(
+        [
+            "gh",
+            "pr",
+            "view",
+            str(pr),
+            "--json",
+            "number,state,isDraft,headRefName,headRefOid,mergeable,mergeStateStatus,url",
+        ],
+        repo_root,
+        runner,
+    )
+    remote = _remote_branch_packet(
+        repo_root,
+        branch=repair_branch,
+        expected_oid=repair_head,
+        runner=runner,
+    )
+    worktree = _repair_worktree_packet(
+        repo_root,
+        branch=remote["branch"],
+        expected_oid=repair_head,
+        explicit_path=repair_worktree,
+        runner=runner,
+    )
+    repair_cwd = Path(worktree["path"]) if worktree.get("path") else None
+    settlement_check = _settlement_check_packet(
+        pr=pr,
+        head=head,
+        repair_cwd=repair_cwd,
+        runner=runner,
+    )
+    focused_tests = (
+        _focused_tests_packet(repair_cwd=repair_cwd, runner=runner)
+        if run_focused_tests
+        else {"ran": False, "ok": None, "reason": "disabled"}
+    )
+    packet = {
+        "pr": pr,
+        "head": head,
+        "repair_head": repair_head,
+        "owner": owner.get("payload"),
+        "mailbox": _mailbox_summary(owner.get("payload")),
+        "root": root,
+        "bridge_health": bridge_health.get("payload"),
+        "pr_state": pr_state,
+        "repair_branch": remote,
+        "repair_worktree": worktree,
+        "validation": {
+            "settlement_check": settlement_check,
+            "focused_tests": focused_tests,
+        },
+        "apply_blockers": settlement_check.get("blockers", []),
+    }
+    if include_prompt:
+        packet["next_prompt"] = _prompt_for(packet)
+    return packet
+
+
+def _mailbox_summary(owner_payload: Any) -> dict[str, Any]:
+    if not isinstance(owner_payload, dict):
+        return {}
+    keys = (
+        "owner_session",
+        "steering_inbox_path",
+        "pending_message_count",
+        "unread_message_count",
+        "read_receipt_count",
+        "latest_read_receipt",
+        "status",
+        "last_steering_outcome",
+    )
+    return {key: owner_payload.get(key) for key in keys}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pr", type=int, required=True)
+    parser.add_argument("--head", required=True)
+    parser.add_argument("--repair-branch", required=True)
+    parser.add_argument("--repair-head")
+    parser.add_argument("--repair-worktree", type=Path)
+    parser.add_argument("--repo-root", type=Path, default=DEFAULT_REPO_ROOT)
+    parser.add_argument("--skip-focused-tests", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--prompt", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    packet = build_followup_packet(
+        pr=args.pr,
+        head=args.head,
+        repair_branch=args.repair_branch,
+        repair_head=args.repair_head,
+        repair_worktree=args.repair_worktree,
+        repo_root=args.repo_root,
+        include_prompt=args.prompt,
+        run_focused_tests=not args.skip_focused_tests,
+    )
+    if args.json:
+        print(json.dumps(packet, indent=2, sort_keys=True))
+    else:
+        print(f"PR #{packet['pr']} settlement follow-up")
+        print(f"root_dirty={packet['root']['dirty']}")
+        pr_payload = packet["pr_state"].get("payload") or {}
+        print(
+            "pr_state="
+            f"{pr_payload.get('headRefOid')} {pr_payload.get('mergeable')} "
+            f"{pr_payload.get('mergeStateStatus')}"
+        )
+        print(f"bridge_ok={(packet.get('bridge_health') or {}).get('ok')}")
+        print(f"repair_published={packet['repair_branch']['published']}")
+        print(f"settlement_ok={packet['validation']['settlement_check'].get('ok')}")
+        for blocker in packet["apply_blockers"]:
+            print(f"- {blocker}")
+        if args.prompt:
+            print()
+            print(packet["next_prompt"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_pr_check_followup.py
+++ b/tests/scripts/test_pr_check_followup.py
@@ -313,7 +313,8 @@ def test_wait_run_timeout_keeps_prompt_in_monitor_mode() -> None:
     assert "did not settle before the wait timeout" in result.prompt
 
 
-def test_prompt_always_contains_incremental_progress_sentence() -> None:
+def test_prompt_always_contains_recursive_convergence_sentences() -> None:
     result = followup.build_followup_result(_pr([]))
 
     assert followup.INCREMENTAL_PROGRESS_SENTENCE in result.prompt
+    assert followup.META_AUTOMATION_SENTENCE in result.prompt

--- a/tests/scripts/test_pr_check_followup.py
+++ b/tests/scripts/test_pr_check_followup.py
@@ -44,8 +44,20 @@ def _check(
     }
 
 
-def _pr(checks: list[dict[str, str]], head: str = "head-sha") -> dict[str, Any]:
-    return {"number": 7443, "headRefOid": head, "statusCheckRollup": checks}
+def _pr(
+    checks: list[dict[str, str]],
+    head: str = "head-sha",
+    *,
+    mergeable: str = "MERGEABLE",
+    merge_state_status: str = "CLEAN",
+) -> dict[str, Any]:
+    return {
+        "number": 7443,
+        "headRefOid": head,
+        "mergeable": mergeable,
+        "mergeStateStatus": merge_state_status,
+        "statusCheckRollup": checks,
+    }
 
 
 def _job(
@@ -318,3 +330,83 @@ def test_prompt_always_contains_recursive_convergence_sentences() -> None:
 
     assert followup.INCREMENTAL_PROGRESS_SENTENCE in result.prompt
     assert followup.META_AUTOMATION_SENTENCE in result.prompt
+
+
+def test_wait_check_waits_for_matching_status_row_then_emits_reruns(monkeypatch: Any) -> None:
+    pr_data = _pr(
+        [
+            {
+                "workflowName": "Tests",
+                "name": "Baseline Determinism",
+                "status": "IN_PROGRESS",
+                "conclusion": "",
+                "detailsUrl": "https://github.com/synaptent/aragora/actions/runs/99/job/101",
+                "startedAt": "2026-05-27T02:22:12Z",
+                "completedAt": "",
+            },
+            _check("Metrics Drift", "check", "CANCELLED", run_id="2", job_id="20"),
+        ]
+    )
+    calls: list[list[str]] = []
+
+    def fake_run_gh_json(args: list[str]) -> dict[str, Any]:
+        calls.append(args)
+        if args[:3] == ["gh", "pr", "view"]:
+            return pr_data
+        if args[:4] == ["gh", "run", "view", "99"]:
+            return {
+                "status": "completed",
+                "conclusion": "success",
+                "workflowName": "Tests",
+                "headSha": "head-sha",
+                "jobs": [_job("Baseline Determinism", "success", job_id="101")],
+            }
+        if args[:4] == ["gh", "run", "view", "2"]:
+            return {
+                "headSha": "head-sha",
+                "workflowName": "Metrics Drift",
+                "jobs": [
+                    _job(
+                        "check",
+                        "cancelled",
+                        job_id="20",
+                        steps=[
+                            {"name": "Set up job", "conclusion": "success"},
+                            {"name": "Checkout", "conclusion": "cancelled"},
+                        ],
+                    )
+                ],
+            }
+        raise AssertionError(f"unexpected gh json call: {args}")
+
+    monkeypatch.setattr(followup, "_run_gh_json", fake_run_gh_json)
+
+    result = followup.fetch_live_result(
+        7443,
+        expected_head="head-sha",
+        include_logs=False,
+        allow_rerun_commands=True,
+        wait_check="Tests/Baseline Determinism",
+        wait_interval_seconds=0,
+        wait_timeout_seconds=0,
+    )
+
+    assert any(args[:4] == ["gh", "run", "view", "99"] for args in calls)
+    assert result.wait_run is not None
+    assert result.wait_run.run_id == "99"
+    assert result.action == "rerun_cancelled"
+    assert result.rerun_commands == ["gh run rerun 2 --job 20"]
+
+
+def test_green_conflicting_pr_emits_branch_conflict_prompt() -> None:
+    result = followup.build_followup_result(
+        _pr(
+            [_check("Tests", "Baseline Determinism", "SUCCESS")],
+            mergeable="CONFLICTING",
+            merge_state_status="DIRTY",
+        )
+    )
+
+    assert result.action == "diagnose_branch_conflict"
+    assert "branch conflict" in result.prompt
+    assert "Do not merge" in result.prompt

--- a/tests/scripts/test_pr_check_followup.py
+++ b/tests/scripts/test_pr_check_followup.py
@@ -1,0 +1,319 @@
+"""Tests for ``scripts/pr_check_followup.py``."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _load_module(script_name: str) -> Any:
+    here = Path(__file__).resolve()
+    script_path = here.parents[2] / "scripts" / script_name
+    spec = importlib.util.spec_from_file_location(f"{script_name}_under_test", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load spec for {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+followup = _load_module("pr_check_followup.py")
+
+
+def _check(
+    workflow: str,
+    name: str,
+    conclusion: str,
+    *,
+    run_id: str = "123",
+    job_id: str = "456",
+    started_at: str = "2026-05-23T19:27:02Z",
+    completed_at: str = "2026-05-23T19:27:10Z",
+) -> dict[str, str]:
+    return {
+        "workflowName": workflow,
+        "name": name,
+        "status": "COMPLETED",
+        "conclusion": conclusion,
+        "detailsUrl": f"https://github.com/synaptent/aragora/actions/runs/{run_id}/job/{job_id}",
+        "startedAt": started_at,
+        "completedAt": completed_at,
+    }
+
+
+def _pr(checks: list[dict[str, str]], head: str = "head-sha") -> dict[str, Any]:
+    return {"number": 7443, "headRefOid": head, "statusCheckRollup": checks}
+
+
+def _job(
+    name: str,
+    conclusion: str,
+    *,
+    job_id: str = "456",
+    status: str = "completed",
+    steps: list[dict[str, str]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "databaseId": int(job_id),
+        "name": name,
+        "status": status,
+        "conclusion": conclusion,
+        "steps": steps or [],
+    }
+
+
+def test_mixed_real_failures_suppress_rerun_commands() -> None:
+    result = followup.build_followup_result(
+        _pr(
+            [
+                _check("Tests", "Version Alignment", "FAILURE", run_id="1", job_id="10"),
+                _check("Metrics Drift", "check", "CANCELLED", run_id="2", job_id="20"),
+            ]
+        ),
+        allow_rerun_commands=True,
+    )
+
+    assert result.action == "repair_failures"
+    assert result.rerun_commands == []
+    assert "Do not rerun cancelled rows" in result.prompt
+
+
+def test_only_current_head_early_cancelled_rows_emit_narrow_reruns() -> None:
+    result = followup.build_followup_result(
+        _pr(
+            [
+                _check("Metrics Drift", "check", "CANCELLED", run_id="2", job_id="20"),
+                _check(
+                    "Docs Consistency", "Docs Consistency", "CANCELLED", run_id="3", job_id="30"
+                ),
+            ]
+        ),
+        run_data_by_id={
+            "2": {"headSha": "head-sha", "jobs": []},
+            "3": {"headSha": "head-sha", "jobs": []},
+        },
+        allow_rerun_commands=True,
+    )
+
+    assert result.action == "rerun_cancelled"
+    assert result.rerun_commands == [
+        "gh run rerun 2 --job 20",
+        "gh run rerun 3 --job 30",
+    ]
+    assert "- gh run rerun 2 --job 20" in result.prompt
+
+
+def test_in_progress_checks_monitor_without_repair_or_rerun() -> None:
+    result = followup.build_followup_result(
+        _pr(
+            [
+                {
+                    "workflowName": "Tests",
+                    "name": "Type Check",
+                    "status": "IN_PROGRESS",
+                    "conclusion": "",
+                    "detailsUrl": "",
+                }
+            ]
+        )
+    )
+
+    assert result.action == "monitor"
+    assert result.rerun_commands == []
+    assert "monitor #7443" in result.prompt
+
+
+def test_expected_head_drift_stops_followup() -> None:
+    result = followup.build_followup_result(_pr([], head="new-head"), expected_head="old-head")
+
+    assert result.action == "head_drift"
+    assert "live head drifted from old-head to new-head" in result.prompt
+
+
+def test_wait_run_failure_switches_to_failed_job_diagnosis() -> None:
+    wait_run = followup.diagnose_wait_run(
+        "99",
+        {
+            "status": "completed",
+            "conclusion": "failure",
+            "workflowName": "Tests",
+            "headSha": "head-sha",
+            "jobs": [_job("test-fast", "failure", job_id="101")],
+        },
+        log_summary_by_job={"101": ["FAILED tests/test_example.py::test_case"]},
+    )
+    result = followup.build_followup_result(
+        _pr([]),
+        wait_run=wait_run,
+        allow_rerun_commands=True,
+    )
+
+    assert result.action == "repair_failures"
+    assert result.rerun_commands == []
+    assert "gh run view 99 --job 101 --log" in result.prompt
+    assert "FAILED tests/test_example.py::test_case" in result.prompt
+
+
+def test_failed_rerun_after_checkout_is_substantive_blocker() -> None:
+    wait_run = followup.diagnose_wait_run(
+        "99",
+        {
+            "status": "completed",
+            "conclusion": "failure",
+            "workflowName": "Metrics Drift",
+            "headSha": "head-sha",
+            "jobs": [
+                _job(
+                    "check",
+                    "failure",
+                    job_id="101",
+                    steps=[
+                        {"name": "Set up job", "conclusion": "success"},
+                        {"name": "Checkout", "conclusion": "success"},
+                        {"name": "Verify drift", "conclusion": "failure"},
+                    ],
+                )
+            ],
+        },
+        log_summary_by_job={"101": ["Out of date: docs/METRICS.md"]},
+    )
+    result = followup.build_followup_result(
+        _pr([]),
+        wait_run=wait_run,
+        allow_rerun_commands=True,
+    )
+
+    assert result.action == "repair_failures"
+    assert result.rerun_commands == []
+    assert "failed after checkout during Verify drift" in result.prompt
+    assert "Do not rerun cancelled rows" in result.prompt
+
+
+def test_merge_quorum_model_quorum_failure_emits_evidence_prompt() -> None:
+    result = followup.build_followup_result(
+        _pr(
+            [
+                _check(
+                    "Aragora Merge Quorum",
+                    "aragora-merge-quorum",
+                    "FAILURE",
+                    run_id="7",
+                    job_id="70",
+                    started_at="2026-05-27T00:12:07Z",
+                    completed_at="2026-05-27T00:13:12Z",
+                ),
+            ],
+            head="evidence-head",
+        ),
+        run_data_by_id={
+            "7": {
+                "headSha": "evidence-head",
+                "workflowName": "Aragora Merge Quorum",
+                "jobs": [
+                    _job(
+                        "aragora-merge-quorum",
+                        "failure",
+                        job_id="70",
+                        steps=[
+                            {"name": "Set up job", "conclusion": "success"},
+                            {"name": "Run actions/checkout@v4", "conclusion": "success"},
+                            {"name": "Evaluate merge quorum", "conclusion": "failure"},
+                        ],
+                    )
+                ],
+            }
+        },
+        log_summary_by_job={
+            "70": [
+                "PR #7474 | Tier 2 | status=needs_model_review_quorum | verdict=collect_model_quorum_before_merge",
+                "- model quorum incomplete: 0/2 signal(s)",
+                "- focused adversarial dogfood evidence is required",
+            ]
+        },
+        allow_rerun_commands=True,
+    )
+
+    assert result.action == "collect_model_evidence"
+    assert result.rerun_commands == []
+    assert (
+        "collecting exactly one current-head non-Codex model/dogfood evidence signal"
+        in result.prompt
+    )
+    assert "Post exactly one valid PR comment" in result.prompt
+    assert "Do not merge" in result.prompt
+
+
+def test_summarize_log_keeps_model_quorum_lines() -> None:
+    summary = followup.summarize_log(
+        "\n".join(
+            [
+                "noise",
+                "PR #7474 | Tier 2 | status=needs_model_review_quorum | verdict=collect_model_quorum_before_merge",
+                "  - model quorum incomplete: 0/2 signal(s)",
+                "  - focused adversarial dogfood evidence is required",
+                "##[error]Merge quorum not met (status=needs_model_review_quorum).",
+            ]
+        )
+    )
+
+    assert any("model quorum incomplete" in line for line in summary)
+    assert any("focused adversarial dogfood" in line for line in summary)
+
+
+def test_wait_run_only_current_head_early_cancellations_emit_reruns() -> None:
+    wait_run = followup.diagnose_wait_run(
+        "99",
+        {
+            "status": "completed",
+            "conclusion": "cancelled",
+            "workflowName": "Tests",
+            "headSha": "head-sha",
+            "jobs": [
+                _job(
+                    "Build Documentation",
+                    "cancelled",
+                    job_id="101",
+                    steps=[
+                        {"name": "Set up job", "conclusion": "success"},
+                        {"name": "Checkout", "conclusion": "cancelled"},
+                    ],
+                )
+            ],
+        },
+    )
+    result = followup.build_followup_result(
+        _pr([]),
+        wait_run=wait_run,
+        allow_rerun_commands=True,
+    )
+
+    assert result.action == "rerun_cancelled"
+    assert result.rerun_commands == ["gh run rerun 99 --job 101"]
+    assert "Build Documentation: early_cancelled" in result.prompt
+
+
+def test_wait_run_timeout_keeps_prompt_in_monitor_mode() -> None:
+    wait_run = followup.diagnose_wait_run(
+        "99",
+        {
+            "status": "in_progress",
+            "conclusion": "",
+            "workflowName": "Tests",
+            "headSha": "head-sha",
+            "jobs": [_job("test-fast", "", status="in_progress", job_id="101")],
+        },
+        timed_out=True,
+    )
+    result = followup.build_followup_result(_pr([]), wait_run=wait_run)
+
+    assert result.action == "monitor"
+    assert "did not settle before the wait timeout" in result.prompt
+
+
+def test_prompt_always_contains_incremental_progress_sentence() -> None:
+    result = followup.build_followup_result(_pr([]))
+
+    assert followup.INCREMENTAL_PROGRESS_SENTENCE in result.prompt

--- a/tests/scripts/test_settlement_followup.py
+++ b/tests/scripts/test_settlement_followup.py
@@ -1,0 +1,209 @@
+"""Tests for ``scripts/settlement_followup.py``."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _load_module(script_name: str) -> Any:
+    here = Path(__file__).resolve()
+    script_path = here.parents[2] / "scripts" / script_name
+    spec = importlib.util.spec_from_file_location(f"{script_name}_under_test", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load spec for {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+followup = _load_module("settlement_followup.py")
+
+
+class FakeRunner:
+    def __init__(
+        self,
+        *,
+        worktree_found: bool = True,
+        settlement_ok: bool = False,
+        pr_mergeable: str = "CONFLICTING",
+        merge_state: str = "DIRTY",
+    ) -> None:
+        self.commands: list[tuple[Path, list[str]]] = []
+        self.worktree_found = worktree_found
+        self.settlement_ok = settlement_ok
+        self.pr_mergeable = pr_mergeable
+        self.merge_state = merge_state
+
+    def __call__(self, command: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+        self.commands.append((cwd, command))
+        joined = " ".join(command)
+        if "identify_lane_owner.py" in joined:
+            return self._json(
+                command,
+                {
+                    "owner_session": "droid-7443-tier4-settlement-20260526",
+                    "status": "completed",
+                    "steering_inbox_path": "/repo/.aragora/operator-steering/droid",
+                    "pending_message_count": 1,
+                    "unread_message_count": 0,
+                    "read_receipt_count": 3,
+                    "last_steering_outcome": "completed",
+                    "latest_read_receipt": {"outcome": "completed"},
+                },
+            )
+        if command[:3] == ["git", "status", "--short"]:
+            if str(cwd).endswith("repair"):
+                return subprocess.CompletedProcess(
+                    command,
+                    0,
+                    "## codex/droid-7443-tier4-settlement-20260526...origin/codex/droid-7443-tier4-settlement-20260526\n",
+                    "",
+                )
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                "## main...origin/main\n M scripts/settle_tier4_pr.py\n",
+                "",
+            )
+        if "agent_bridge.py --json health" in joined:
+            return self._json(command, {"ok": True, "issues": []})
+        if command[:3] == ["gh", "pr", "view"]:
+            return self._json(
+                command,
+                {
+                    "number": 7443,
+                    "state": "OPEN",
+                    "isDraft": False,
+                    "headRefName": "codex/harvest-provider-readiness-secrets-cli-20260523",
+                    "headRefOid": "5a692b5dd54f05f2befe0df7b497c56e3c6ead6f",
+                    "mergeable": self.pr_mergeable,
+                    "mergeStateStatus": self.merge_state,
+                    "url": "https://github.com/synaptent/aragora/pull/7443",
+                },
+            )
+        if command[:3] == ["git", "ls-remote", "origin"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                "63ff1513b4eb1e9a73b5ce3dbbc92a0179c00f67\trefs/heads/codex/droid-7443-tier4-settlement-20260526\n",
+                "",
+            )
+        if command[:3] == ["git", "worktree", "list"]:
+            stdout = (
+                "worktree /tmp/repair\n"
+                "HEAD 63ff1513b4eb1e9a73b5ce3dbbc92a0179c00f67\n"
+                "branch refs/heads/codex/droid-7443-tier4-settlement-20260526\n\n"
+                if self.worktree_found
+                else ""
+            )
+            return subprocess.CompletedProcess(command, 0, stdout, "")
+        if command[:3] == ["git", "rev-parse", "HEAD"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                "63ff1513b4eb1e9a73b5ce3dbbc92a0179c00f67\n",
+                "",
+            )
+        if "settle_tier4_pr.py --check" in joined:
+            gate = {
+                "ok": self.settlement_ok,
+                "pr": 7443,
+                "expected_head": "5a692b5dd54f05f2befe0df7b497c56e3c6ead6f",
+                "actual_head": "5a692b5dd54f05f2befe0df7b497c56e3c6ead6f",
+                "merge_state": self.merge_state,
+                "blockers": []
+                if self.settlement_ok
+                else ["PR #7443 is DIRTY", "merge-packet has unexpected blockers: 7443"],
+                "authorized_actions": ["merge"],
+            }
+            return subprocess.CompletedProcess(
+                command,
+                0 if self.settlement_ok else 1,
+                json.dumps({"gate": gate, "applied_commands": []}),
+                "",
+            )
+        if "-m pytest" in joined:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                "tests/scripts/test_settle_tier4_pr.py ........................ [100%]\n24 passed\n",
+                "",
+            )
+        return subprocess.CompletedProcess(command, 0, "{}", "")
+
+    @staticmethod
+    def _json(command: list[str], payload: dict[str, Any]) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(command, 0, json.dumps(payload), "")
+
+
+def test_followup_packet_reports_owner_branch_validation_and_prompt(tmp_path: Path) -> None:
+    runner = FakeRunner()
+
+    packet = followup.build_followup_packet(
+        pr=7443,
+        head="5a692b5dd54f05f2befe0df7b497c56e3c6ead6f",
+        repair_branch="origin/codex/droid-7443-tier4-settlement-20260526",
+        repair_head="63ff1513b4eb1e9a73b5ce3dbbc92a0179c00f67",
+        repo_root=tmp_path,
+        include_prompt=True,
+        runner=runner,
+    )
+
+    assert packet["mailbox"]["owner_session"] == "droid-7443-tier4-settlement-20260526"
+    assert packet["root"]["dirty"] is True
+    assert packet["repair_branch"]["published"] is True
+    assert packet["repair_branch"]["matches_expected"] is True
+    assert packet["repair_worktree"]["found"] is True
+    assert packet["validation"]["focused_tests"]["ok"] is True
+    assert packet["apply_blockers"] == [
+        "PR #7443 is DIRTY",
+        "merge-packet has unexpected blockers: 7443",
+    ]
+    assert "settlement_followup.py --pr 7443" in packet["next_prompt"]
+    assert followup.CONVERGENCE_SENTENCE in packet["next_prompt"]
+    assert followup.AUTOMATION_SENTENCE in packet["next_prompt"]
+
+
+def test_followup_does_not_run_apply_push_or_cleanup(tmp_path: Path) -> None:
+    runner = FakeRunner(settlement_ok=True, pr_mergeable="MERGEABLE", merge_state="UNSTABLE")
+
+    packet = followup.build_followup_packet(
+        pr=7443,
+        head="5a692b5dd54f05f2befe0df7b497c56e3c6ead6f",
+        repair_branch="codex/droid-7443-tier4-settlement-20260526",
+        repair_head="63ff1513b4eb1e9a73b5ce3dbbc92a0179c00f67",
+        repo_root=tmp_path,
+        include_prompt=True,
+        runner=runner,
+    )
+
+    flat_commands = [" ".join(command) for _, command in runner.commands]
+    assert all("--apply" not in command for command in flat_commands)
+    assert all("git push" not in command for command in flat_commands)
+    assert all("pr merge" not in command for command in flat_commands)
+    assert all("worktree add" not in command for command in flat_commands)
+    assert packet["validation"]["settlement_check"]["ok"] is True
+
+
+def test_missing_repair_worktree_reports_validation_blocker(tmp_path: Path) -> None:
+    runner = FakeRunner(worktree_found=False)
+
+    packet = followup.build_followup_packet(
+        pr=7443,
+        head="5a692b5dd54f05f2befe0df7b497c56e3c6ead6f",
+        repair_branch="codex/droid-7443-tier4-settlement-20260526",
+        repair_head="63ff1513b4eb1e9a73b5ce3dbbc92a0179c00f67",
+        repo_root=tmp_path,
+        runner=runner,
+    )
+
+    assert packet["repair_worktree"]["found"] is False
+    assert packet["validation"]["settlement_check"]["ran"] is False
+    assert packet["validation"]["settlement_check"]["blockers"] == ["repair worktree not found"]
+    assert packet["validation"]["focused_tests"]["ran"] is False


### PR DESCRIPTION
## Summary
- add read-only scripts/settlement_followup.py for exact-head Tier 4 settlement follow-up packets
- report owner/mailbox state, bridge health, root dirty paths, PR mergeability, repair-branch publish state, focused validation, exact apply blockers, and recursive next prompt
- add mocked unit coverage proving the helper does not run apply/push/merge/worktree mutation commands

## Validation
- python3 -m pytest tests/scripts/test_settlement_followup.py
- python3 -m ruff check scripts/settlement_followup.py tests/scripts/test_settlement_followup.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- live smoke: python3 scripts/settlement_followup.py --repo-root /Users/armand/Development/aragora --pr 7443 --head 5a692b5dd54f05f2befe0df7b497c56e3c6ead6f --repair-branch origin/codex/droid-7443-tier4-settlement-20260526 --repair-head 63ff1513b4eb1e9a73b5ce3dbbc92a0179c00f67 --json --prompt
