### PR TITLE
fix(review-queue): block merged PR merge packets

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -443,6 +443,14 @@ def add_review_queue_parser(subparsers: argparse._SubParsersAction) -> None:
         help="GitHub repo slug override (owner/name). Defaults to current repo context.",
     )
     merge_packet_p.add_argument(
+        "--review-queue-root",
+        default=None,
+        help=(
+            "Override the review-queue store root used for settlement receipt lookups. "
+            "Defaults to <repo>/.aragora/review-queue."
+        ),
+    )
+    merge_packet_p.add_argument(
         "--execute-reviewers",
         action="store_true",
         help="Attempt live heterogeneous reviewer execution for each packet.",
@@ -868,6 +876,7 @@ def _cmd_merge_packet(args: argparse.Namespace) -> int:
             pr_refs=list(getattr(args, "pr", []) or []),
             limit=int(getattr(args, "limit", 30) or 30),
             repo_override=getattr(args, "repo", None),
+            review_queue_root=getattr(args, "review_queue_root", None),
             execute_reviewers=bool(getattr(args, "execute_reviewers", False)),
         )
     except _GhError as exc:
@@ -1338,6 +1347,7 @@ def _build_packet(
     pr_ref: str,
     *,
     repo_override: str | None,
+    review_queue_root: str | Path | None = None,
     execute_reviewers: bool = False,
 ) -> ReviewPacket:
     number = _parse_pr_number(pr_ref)
@@ -1391,12 +1401,21 @@ def _build_packet(
     deletions = int(pr.get("deletions", 0) or 0)
     is_draft = bool(pr.get("isDraft", False))
     settlement_state_block = _settlement_state_block_reason(pr)
+    settlement_recorded = str(
+        pr.get("state") or ""
+    ).strip().upper() == "MERGED" and _has_recorded_admin_squash_settlement(
+        pr_number=number,
+        head_sha=str(pr.get("headRefOid", "")).strip(),
+        review_queue_root=review_queue_root,
+    )
     mergeable = str(pr.get("mergeable", "")).strip().upper()
     queue_item = _classify_pr(pr)
     validation = _extract_validation_commands(str(pr.get("body", "") or ""))
 
     risk_flags: list[str] = []
-    if settlement_state_block:
+    if settlement_recorded:
+        risk_flags.append("exact-head admin_squash_merge settlement receipt recorded")
+    elif settlement_state_block:
         risk_flags.append(settlement_state_block)
     if is_draft:
         risk_flags.append("draft PR")
@@ -1413,7 +1432,10 @@ def _build_packet(
     if has_failures:
         risk_flags.append(f"checks failing ({checks_summary})")
 
-    if settlement_state_block:
+    if settlement_recorded:
+        recommendation = "settled_noop"
+        recommendation_reason = "PR is already merged with an exact-head settlement receipt"
+    elif settlement_state_block:
         recommendation = "needs_human_attention"
         recommendation_reason = settlement_state_block
     elif has_failures or mergeable == "CONFLICTING":
@@ -1515,6 +1537,7 @@ def _build_packet(
             machine_recommendation=recommendation,
             has_pending=has_pending,
             has_failures=has_failures,
+            settlement_recorded=settlement_recorded,
         ),
     )
     packet.packet_sha = _packet_sha(packet)
@@ -1526,6 +1549,7 @@ def _build_merge_authorization_packet(
     pr_refs: list[str],
     limit: int,
     repo_override: str | None,
+    review_queue_root: str | Path | None = None,
     execute_reviewers: bool = False,
 ) -> dict[str, Any]:
     if pr_refs:
@@ -1536,10 +1560,13 @@ def _build_merge_authorization_packet(
         refs = [str(item.number) for item in queue]
         queue_size = len(queue)
 
-    packets = [
-        _build_packet(ref, repo_override=repo_override, execute_reviewers=execute_reviewers)
-        for ref in refs
-    ]
+    packet_kwargs: dict[str, Any] = {
+        "repo_override": repo_override,
+        "execute_reviewers": execute_reviewers,
+    }
+    if review_queue_root is not None:
+        packet_kwargs["review_queue_root"] = review_queue_root
+    packets = [_build_packet(ref, **packet_kwargs) for ref in refs]
     queue_pressure_active = queue_size > MODEL_REVIEW_QUEUE_CAP
     entries = []
     for packet in packets:
@@ -1602,7 +1629,7 @@ def _build_merge_authorization_packet(
         "not_ready": [
             entry["pr_number"]
             for entry in entries
-            if entry["status"] not in {"satisfied", "human_risk_settlement_required"}
+            if entry["status"] not in {"satisfied", "human_risk_settlement_required", "settled"}
         ],
     }
 
@@ -1615,6 +1642,7 @@ def _build_model_review_quorum(
     machine_recommendation: str,
     has_pending: bool,
     has_failures: bool,
+    settlement_recorded: bool = False,
 ) -> dict[str, Any]:
     tier, tier_name, tier_reason = _classify_model_review_tier(files, pr=pr)
     requirement = _tier_requirement(tier)
@@ -1649,14 +1677,17 @@ def _build_model_review_quorum(
     )
 
     reasons = [tier_reason]
-    if has_failures:
+    if settlement_recorded:
+        reasons.append("exact-head admin_squash_merge settlement receipt recorded")
+    if has_failures and not settlement_recorded:
         reasons.append("checks are failing; repair before settlement")
-    if has_pending:
+    if has_pending and not settlement_recorded:
         reasons.append("checks are pending; wait before settlement")
-    reasons.extend(blocking_workflow_reasons)
-    if unresolved_dissent:
+    if not settlement_recorded:
+        reasons.extend(blocking_workflow_reasons)
+    if unresolved_dissent and not settlement_recorded:
         reasons.append("unresolved model dissent is present")
-    if not quorum_satisfied:
+    if not quorum_satisfied and not settlement_recorded:
         reasons.append(
             "model quorum incomplete: "
             f"{signal_count}/{requirement['required_model_signals']} signal(s)"
@@ -1666,7 +1697,11 @@ def _build_model_review_quorum(
 
     admin_squash_allowed = False
     requires_human_risk_settlement = bool(requirement["requires_human_risk_settlement"])
-    if (
+    if settlement_recorded:
+        status = "settled"
+        verdict = "already_merged_settlement_recorded"
+        requires_human_risk_settlement = False
+    elif (
         has_failures
         or has_pending
         or machine_recommendation == "repair_first"
@@ -1821,6 +1856,36 @@ def _settlement_state_block_reason(pr: dict[str, Any]) -> str:
     if state and state != "OPEN":
         return f"PR is {state}; settlement applies only to open PRs"
     return ""
+
+
+def _has_recorded_admin_squash_settlement(
+    *,
+    pr_number: int,
+    head_sha: str,
+    review_queue_root: str | Path | None,
+) -> bool:
+    if not head_sha:
+        return False
+    repo_root = resolve_repo_root(Path.cwd())
+    root = _resolve_review_queue_root_override(repo_root, review_queue_root)
+    receipts_dir = root / "receipts"
+    if not receipts_dir.is_dir():
+        return False
+    for path in receipts_dir.glob(f"pr-{pr_number}-*.json"):
+        try:
+            payload = _read_receipt_payload(path)
+        except _GhError:
+            continue
+        if int(payload.get("pr_number") or 0) != pr_number:
+            continue
+        if str(payload.get("head_sha") or "").strip() != head_sha:
+            continue
+        if str(payload.get("action") or "").strip() != "admin_squash_merge":
+            continue
+        if str(payload.get("github_event") or "").strip() != "ADMIN_SQUASH_MERGE":
+            continue
+        return True
+    return False
 
 
 def _reviewer_signals_from_protocol(protocol: dict[str, Any]) -> list[dict[str, Any]]:

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -1349,6 +1349,7 @@ def _build_packet(
             "headRefOid",
             "baseRefOid",
             "state",
+            "mergedAt",
             "isDraft",
             "mergeable",
             "reviewDecision",
@@ -1389,14 +1390,14 @@ def _build_packet(
     additions = int(pr.get("additions", 0) or 0)
     deletions = int(pr.get("deletions", 0) or 0)
     is_draft = bool(pr.get("isDraft", False))
-    github_state = _github_pr_state(pr)
+    settlement_state_block = _settlement_state_block_reason(pr)
     mergeable = str(pr.get("mergeable", "")).strip().upper()
     queue_item = _classify_pr(pr)
     validation = _extract_validation_commands(str(pr.get("body", "") or ""))
 
     risk_flags: list[str] = []
-    if github_state and github_state != "OPEN":
-        risk_flags.append(f"PR is already {github_state}")
+    if settlement_state_block:
+        risk_flags.append(settlement_state_block)
     if is_draft:
         risk_flags.append("draft PR")
     if parked_label_hits:
@@ -1412,11 +1413,12 @@ def _build_packet(
     if has_failures:
         risk_flags.append(f"checks failing ({checks_summary})")
 
-    if has_failures or mergeable == "CONFLICTING" or (github_state and github_state != "OPEN"):
+    if settlement_state_block:
+        recommendation = "needs_human_attention"
+        recommendation_reason = settlement_state_block
+    elif has_failures or mergeable == "CONFLICTING":
         recommendation = "repair_first"
-        recommendation_reason = (
-            "checks failing, merge conflict, or PR is not open — fix before review"
-        )
+        recommendation_reason = "checks failing or merge conflict — fix before review"
     elif is_draft:
         recommendation = "needs_human_attention"
         recommendation_reason = "draft PR — keep parked until it is ready for review"
@@ -1788,9 +1790,9 @@ def _has_blocking_workflow_state(pr: dict[str, Any]) -> bool:
 
 def _blocking_workflow_state_reasons(pr: dict[str, Any]) -> list[str]:
     reasons: list[str] = []
-    github_state = _github_pr_state(pr)
-    if github_state and github_state != "OPEN":
-        reasons.append(f"PR is already {github_state}")
+    settlement_state_block = _settlement_state_block_reason(pr)
+    if settlement_state_block:
+        reasons.append(settlement_state_block)
     if bool(pr.get("isDraft", False)):
         reasons.append("draft PR")
     mergeable = str(pr.get("mergeable", "")).strip().upper()
@@ -1807,8 +1809,18 @@ def _blocking_workflow_state_reasons(pr: dict[str, Any]) -> list[str]:
     return reasons
 
 
-def _github_pr_state(pr: dict[str, Any]) -> str:
-    return str(pr.get("state", "") or "").strip().upper()
+def _settlement_state_block_reason(pr: dict[str, Any]) -> str:
+    state = str(pr.get("state") or "").strip().upper()
+    merged_at = str(pr.get("mergedAt") or "").strip()
+    if merged_at:
+        if state == "OPEN":
+            return (
+                "PR state is OPEN but mergedAt is set; settlement applies only to open unmerged PRs"
+            )
+        return f"PR is {state or 'MERGED'}; settlement applies only to open PRs"
+    if state and state != "OPEN":
+        return f"PR is {state}; settlement applies only to open PRs"
+    return ""
 
 
 def _reviewer_signals_from_protocol(protocol: dict[str, Any]) -> list[dict[str, Any]]:

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -1348,6 +1348,7 @@ def _build_packet(
             "url",
             "headRefOid",
             "baseRefOid",
+            "state",
             "isDraft",
             "mergeable",
             "reviewDecision",
@@ -1388,11 +1389,14 @@ def _build_packet(
     additions = int(pr.get("additions", 0) or 0)
     deletions = int(pr.get("deletions", 0) or 0)
     is_draft = bool(pr.get("isDraft", False))
+    github_state = _github_pr_state(pr)
     mergeable = str(pr.get("mergeable", "")).strip().upper()
     queue_item = _classify_pr(pr)
     validation = _extract_validation_commands(str(pr.get("body", "") or ""))
 
     risk_flags: list[str] = []
+    if github_state and github_state != "OPEN":
+        risk_flags.append(f"PR is already {github_state}")
     if is_draft:
         risk_flags.append("draft PR")
     if parked_label_hits:
@@ -1408,9 +1412,11 @@ def _build_packet(
     if has_failures:
         risk_flags.append(f"checks failing ({checks_summary})")
 
-    if has_failures or mergeable == "CONFLICTING":
+    if has_failures or mergeable == "CONFLICTING" or (github_state and github_state != "OPEN"):
         recommendation = "repair_first"
-        recommendation_reason = "checks failing or merge conflict — fix before review"
+        recommendation_reason = (
+            "checks failing, merge conflict, or PR is not open — fix before review"
+        )
     elif is_draft:
         recommendation = "needs_human_attention"
         recommendation_reason = "draft PR — keep parked until it is ready for review"
@@ -1628,7 +1634,8 @@ def _build_model_review_quorum(
     dissenting_views = [
         view for view in (protocol.get("dissenting_views") or []) if isinstance(view, dict)
     ]
-    blocking_workflow_state = _has_blocking_workflow_state(pr)
+    blocking_workflow_reasons = _blocking_workflow_state_reasons(pr)
+    blocking_workflow_state = bool(blocking_workflow_reasons)
     unresolved_dissent = bool(dissenting_views)
     counted_reviewer_ids = _counted_model_reviewer_ids(reviewer_signals, dogfood_evidence)
     signal_count = len(counted_reviewer_ids)
@@ -1644,6 +1651,7 @@ def _build_model_review_quorum(
         reasons.append("checks are failing; repair before settlement")
     if has_pending:
         reasons.append("checks are pending; wait before settlement")
+    reasons.extend(blocking_workflow_reasons)
     if unresolved_dissent:
         reasons.append("unresolved model dissent is present")
     if not quorum_satisfied:
@@ -1775,17 +1783,32 @@ def _tier_requirement(tier: int) -> dict[str, Any]:
 
 
 def _has_blocking_workflow_state(pr: dict[str, Any]) -> bool:
+    return bool(_blocking_workflow_state_reasons(pr))
+
+
+def _blocking_workflow_state_reasons(pr: dict[str, Any]) -> list[str]:
+    reasons: list[str] = []
+    github_state = _github_pr_state(pr)
+    if github_state and github_state != "OPEN":
+        reasons.append(f"PR is already {github_state}")
     if bool(pr.get("isDraft", False)):
-        return True
+        reasons.append("draft PR")
     mergeable = str(pr.get("mergeable", "")).strip().upper()
     if mergeable == "CONFLICTING":
-        return True
+        reasons.append("merge conflict")
     labels = [
         str(label.get("name", "")).strip()
         for label in (pr.get("labels") or [])
         if isinstance(label, dict) and label.get("name")
     ]
-    return any(label in PARKED_LABELS for label in labels)
+    parked_label_hits = [label for label in labels if label in PARKED_LABELS]
+    if parked_label_hits:
+        reasons.append(f"parked label ({','.join(parked_label_hits)})")
+    return reasons
+
+
+def _github_pr_state(pr: dict[str, Any]) -> str:
+    return str(pr.get("state", "") or "").strip().upper()
 
 
 def _reviewer_signals_from_protocol(protocol: dict[str, Any]) -> list[dict[str, Any]]:

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -1984,6 +1984,11 @@ def _add_review_queue_parser(subparsers) -> None:
         help="GitHub repo slug override (owner/name). Defaults to current repo context.",
     )
     merge_packet_parser.add_argument(
+        "--review-queue-root",
+        default=None,
+        help="Override the review-queue store root used for settlement receipt lookups.",
+    )
+    merge_packet_parser.add_argument(
         "--execute-reviewers",
         action="store_true",
         help="Attempt live heterogeneous reviewer execution for each packet.",

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -59,6 +59,7 @@ def _make_pr(
     number: int = 1,
     title: str = "test PR",
     state: str = "OPEN",
+    merged_at: str = "",
     is_draft: bool = False,
     mergeable: str = "MERGEABLE",
     review_decision: str = "",
@@ -77,6 +78,7 @@ def _make_pr(
         "title": title,
         "url": f"https://github.com/synaptent/aragora/pull/{number}",
         "state": state,
+        "mergedAt": merged_at,
         "headRefName": f"branch-{number}",
         "headRefOid": f"sha{number:08d}",
         "baseRefOid": "basesha0001",
@@ -1178,7 +1180,11 @@ class TestModelReviewQuorum:
         assert quorum["admin_squash_allowed"] is False
 
     def test_merged_state_blocks_settlement_even_with_quorum(self) -> None:
-        pr = _make_pr(files=["docs/README.md"], state="MERGED")
+        pr = _make_pr(
+            files=["docs/README.md"],
+            state="MERGED",
+            merged_at="2026-05-27T00:19:36Z",
+        )
         pr["comments"] = [_dogfood_comment("## Claude focused dogfood\npass")]
         quorum = _build_model_review_quorum(
             pr=pr,
@@ -1191,7 +1197,7 @@ class TestModelReviewQuorum:
         assert quorum["status"] == "repair_or_wait"
         assert quorum["verdict"] == "not_ready_for_settlement"
         assert quorum["admin_squash_allowed"] is False
-        assert "PR is already MERGED" in quorum["reasons"]
+        assert "PR is MERGED; settlement applies only to open PRs" in quorum["reasons"]
 
     def test_tier_three_never_admin_squashes_without_human_risk_settlement(self) -> None:
         pr = _make_pr(files=["aragora/reputation/store.py"])
@@ -1472,6 +1478,138 @@ class TestBuildQueueAndPacket:
         packet = _build_packet("6280", repo_override=None)
         assert packet.machine_recommendation == "approve_candidate"
         assert packet.checks_summary == "2/2 green"
+
+    def test_merged_pr_fails_closed_before_admin_authorization(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pr_payload = _make_pr(
+            number=7470,
+            files=["docs/status/focus.md"],
+            state="MERGED",
+            merged_at="2026-05-27T00:19:36Z",
+        )
+        pr_payload["comments"] = [
+            {
+                "author": {"login": "an0mium"},
+                "body": "## Grok independent model review\nVerdict: approve.",
+            },
+        ]
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._gh_json",
+            lambda args: pr_payload,
+        )
+        packet = _build_packet("7470", repo_override=None)
+        quorum = packet.model_review_quorum
+
+        assert packet.machine_recommendation == "needs_human_attention"
+        assert "PR is MERGED; settlement applies only to open PRs" in packet.risk_flags
+        assert quorum["admin_squash_allowed"] is False
+        assert quorum["status"] == "repair_or_wait"
+        assert "PR is MERGED; settlement applies only to open PRs" in quorum["reasons"]
+
+    def test_closed_pr_fails_closed_before_admin_authorization(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pr_payload = _make_pr(number=7471, files=["docs/status/closed.md"], state="CLOSED")
+        pr_payload["comments"] = [
+            {
+                "author": {"login": "an0mium"},
+                "body": "## Grok independent model review\nVerdict: approve.",
+            },
+        ]
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._gh_json",
+            lambda args: pr_payload,
+        )
+        packet = _build_packet("7471", repo_override=None)
+
+        assert packet.model_review_quorum["admin_squash_allowed"] is False
+        assert packet.model_review_quorum["status"] == "repair_or_wait"
+        assert (
+            "PR is CLOSED; settlement applies only to open PRs"
+            in packet.model_review_quorum["reasons"]
+        )
+
+    def test_open_authorized_pr_still_allows_admin_squash(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pr_payload = _make_pr(number=7472, files=["docs/status/open.md"])
+        pr_payload["comments"] = [
+            {
+                "author": {"login": "an0mium"},
+                "body": "## Grok independent model review\nVerdict: approve.",
+            },
+        ]
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._gh_json",
+            lambda args: pr_payload,
+        )
+        packet = _build_packet("7472", repo_override=None)
+
+        assert packet.machine_recommendation == "approve_candidate"
+        assert packet.model_review_quorum["admin_squash_allowed"] is True
+        assert packet.model_review_quorum["status"] == "satisfied"
+
+    def test_inconsistent_open_state_with_merged_at_fails_closed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pr_payload = _make_pr(
+            number=7473,
+            files=["docs/status/stale.md"],
+            merged_at="2026-05-27T00:19:36Z",
+        )
+        pr_payload["comments"] = [
+            {
+                "author": {"login": "an0mium"},
+                "body": "## Grok independent model review\nVerdict: approve.",
+            },
+        ]
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._gh_json",
+            lambda args: pr_payload,
+        )
+        packet = _build_packet("7473", repo_override=None)
+
+        assert packet.model_review_quorum["admin_squash_allowed"] is False
+        assert packet.model_review_quorum["status"] == "repair_or_wait"
+        assert (
+            "PR state is OPEN but mergedAt is set; settlement applies only to open unmerged PRs"
+        ) in packet.model_review_quorum["reasons"]
+
+    def test_merge_packet_omits_merged_pr_from_admin_squash_order(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pr_payload = _make_pr(
+            number=7470,
+            files=["docs/status/focus.md"],
+            state="MERGED",
+            merged_at="2026-05-27T00:19:36Z",
+        )
+        pr_payload["comments"] = [
+            {
+                "author": {"login": "an0mium"},
+                "body": "## Grok independent model review\nVerdict: approve.",
+            },
+        ]
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._build_queue",
+            lambda limit: [_classify_pr(_make_pr(number=7470))],
+        )
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._gh_json",
+            lambda args: pr_payload,
+        )
+
+        packet = _build_merge_authorization_packet(
+            pr_refs=["7470"],
+            limit=10,
+            repo_override=None,
+        )
+
+        assert packet["entries"][0]["status"] == "repair_or_wait"
+        assert packet["entries"][0]["admin_squash_allowed"] is False
+        assert packet["admin_squash_order"] == []
+        assert packet["not_ready"] == [7470]
 
     def test_build_packet_preserves_completed_merge_quorum_failure(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -58,6 +58,7 @@ def _make_pr(
     *,
     number: int = 1,
     title: str = "test PR",
+    state: str = "OPEN",
     is_draft: bool = False,
     mergeable: str = "MERGEABLE",
     review_decision: str = "",
@@ -75,6 +76,7 @@ def _make_pr(
         "number": number,
         "title": title,
         "url": f"https://github.com/synaptent/aragora/pull/{number}",
+        "state": state,
         "headRefName": f"branch-{number}",
         "headRefOid": f"sha{number:08d}",
         "baseRefOid": "basesha0001",
@@ -1174,6 +1176,22 @@ class TestModelReviewQuorum:
         )
         assert quorum["status"] == "repair_or_wait"
         assert quorum["admin_squash_allowed"] is False
+
+    def test_merged_state_blocks_settlement_even_with_quorum(self) -> None:
+        pr = _make_pr(files=["docs/README.md"], state="MERGED")
+        pr["comments"] = [_dogfood_comment("## Claude focused dogfood\npass")]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=["docs/README.md"],
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+        )
+        assert quorum["status"] == "repair_or_wait"
+        assert quorum["verdict"] == "not_ready_for_settlement"
+        assert quorum["admin_squash_allowed"] is False
+        assert "PR is already MERGED" in quorum["reasons"]
 
     def test_tier_three_never_admin_squashes_without_human_risk_settlement(self) -> None:
         pr = _make_pr(files=["aragora/reputation/store.py"])

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -138,6 +138,30 @@ def _make_reviewer_output(
     )
 
 
+def _write_admin_squash_receipt(
+    review_queue_root: Path,
+    *,
+    pr_number: int,
+    head_sha: str,
+) -> Path:
+    receipts_dir = review_queue_root / "receipts"
+    receipts_dir.mkdir(parents=True, exist_ok=True)
+    path = receipts_dir / f"pr-{pr_number}-recorded-{head_sha[:12]}-admin_squash_merge.json"
+    path.write_text(
+        json.dumps(
+            {
+                "pr_number": pr_number,
+                "head_sha": head_sha,
+                "action": "admin_squash_merge",
+                "github_event": "ADMIN_SQUASH_MERGE",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
 def _dogfood_comment(
     body: str = "## Cross-author adversarial dogfood (Claude)\n6/6 pass",
 ) -> dict[str, Any]:
@@ -1611,6 +1635,82 @@ class TestBuildQueueAndPacket:
         assert packet["admin_squash_order"] == []
         assert packet["not_ready"] == [7470]
 
+    def test_merged_pr_with_exact_settlement_receipt_is_settled_noop(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        pr_payload = _make_pr(
+            number=7447,
+            files=["aragora/cli/commands/review_queue.py"],
+            state="MERGED",
+            merged_at="2026-05-27T02:57:31Z",
+        )
+        review_queue_root = tmp_path / "review-queue"
+        _write_admin_squash_receipt(
+            review_queue_root,
+            pr_number=7447,
+            head_sha=str(pr_payload["headRefOid"]),
+        )
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._build_queue",
+            lambda limit: [_classify_pr(_make_pr(number=7447))],
+        )
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._gh_json",
+            lambda args: pr_payload,
+        )
+
+        packet = _build_merge_authorization_packet(
+            pr_refs=["7447"],
+            limit=10,
+            repo_override=None,
+            review_queue_root=review_queue_root,
+        )
+
+        entry = packet["entries"][0]
+        assert entry["status"] == "settled"
+        assert entry["verdict"] == "already_merged_settlement_recorded"
+        assert entry["admin_squash_allowed"] is False
+        assert entry["requires_human_risk_settlement"] is False
+        assert entry["reasons"] == [
+            "workflow/deploy/destructive surface touched",
+            "exact-head admin_squash_merge settlement receipt recorded",
+        ]
+        assert packet["admin_squash_order"] == []
+        assert packet["human_risk_settlement_required"] == []
+        assert packet["not_ready"] == []
+
+    def test_merged_pr_with_stale_settlement_receipt_stays_fail_closed(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        pr_payload = _make_pr(
+            number=7447,
+            files=["docs/status/focus.md"],
+            state="MERGED",
+            merged_at="2026-05-27T02:57:31Z",
+        )
+        review_queue_root = tmp_path / "review-queue"
+        _write_admin_squash_receipt(
+            review_queue_root,
+            pr_number=7447,
+            head_sha="stale-head-sha",
+        )
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._gh_json",
+            lambda args: pr_payload,
+        )
+
+        packet = _build_packet(
+            "7447",
+            repo_override=None,
+            review_queue_root=review_queue_root,
+        )
+
+        quorum = packet.model_review_quorum
+        assert quorum["status"] == "repair_or_wait"
+        assert quorum["verdict"] == "not_ready_for_settlement"
+        assert quorum["admin_squash_allowed"] is False
+        assert "PR is MERGED; settlement applies only to open PRs" in quorum["reasons"]
+
     def test_build_packet_preserves_completed_merge_quorum_failure(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -1901,6 +2001,18 @@ class TestCommandDispatch:
         ns_merge_packet = root.parse_args(["review-queue", "merge-packet", "--pr", "6280"])
         assert ns_merge_packet.review_queue_command == "merge-packet"
         assert ns_merge_packet.pr == ["6280"]
+        ns_merge_packet_root = root.parse_args(
+            [
+                "review-queue",
+                "merge-packet",
+                "--pr",
+                "6280",
+                "--review-queue-root",
+                "/tmp/review-queue",
+            ]
+        )
+        assert ns_merge_packet_root.review_queue_command == "merge-packet"
+        assert ns_merge_packet_root.review_queue_root == "/tmp/review-queue"
         # run invocation parses
         ns_run = root.parse_args(["review-queue", "run", "--limit", "3", "--ready-only"])
         assert ns_run.review_queue_command == "run"

--- a/tests/cli/test_parser_lazy_review_pr.py
+++ b/tests/cli/test_parser_lazy_review_pr.py
@@ -9,7 +9,7 @@ from aragora.cli.parser import build_parser
 
 
 def test_build_parser_keeps_review_pr_runtime_lazy(monkeypatch):
-    sys.modules.pop("aragora.cli.commands.review_pr", None)
+    monkeypatch.delitem(sys.modules, "aragora.cli.commands.review_pr", raising=False)
     imported: list[str] = []
     real_import = builtins.__import__
 
@@ -46,7 +46,7 @@ def test_build_parser_keeps_triage_status_free_of_heavy_review_imports(monkeypat
         "aragora.worktree",
         "aragora.worktree.fleet",
     ):
-        sys.modules.pop(module_name, None)
+        monkeypatch.delitem(sys.modules, module_name, raising=False)
 
     imported: list[str] = []
     real_import = builtins.__import__
@@ -71,7 +71,7 @@ def test_build_parser_keeps_triage_status_free_of_heavy_review_imports(monkeypat
 
 
 def test_build_parser_keeps_review_queue_runtime_lazy(monkeypatch):
-    sys.modules.pop("aragora.cli.commands.review_queue", None)
+    monkeypatch.delitem(sys.modules, "aragora.cli.commands.review_queue", raising=False)
     imported: list[str] = []
     real_import = builtins.__import__
 
@@ -106,7 +106,7 @@ def test_build_parser_keeps_review_queue_runtime_lazy(monkeypatch):
 
 
 def test_build_parser_registers_review_queue_baseline_lazily(monkeypatch):
-    sys.modules.pop("aragora.cli.commands.review_queue", None)
+    monkeypatch.delitem(sys.modules, "aragora.cli.commands.review_queue", raising=False)
     imported: list[str] = []
     real_import = builtins.__import__
 
@@ -155,7 +155,7 @@ def test_build_parser_registers_review_queue_baseline_lazily(monkeypatch):
 
 
 def test_build_parser_registers_review_queue_merge_packet_lazily(monkeypatch):
-    sys.modules.pop("aragora.cli.commands.review_queue", None)
+    monkeypatch.delitem(sys.modules, "aragora.cli.commands.review_queue", raising=False)
     imported: list[str] = []
     real_import = builtins.__import__
 

--- a/tests/cli/test_parser_lazy_review_pr.py
+++ b/tests/cli/test_parser_lazy_review_pr.py
@@ -173,6 +173,8 @@ def test_build_parser_registers_review_queue_merge_packet_lazily(monkeypatch):
             "merge-packet",
             "--pr",
             "6779",
+            "--review-queue-root",
+            "/tmp/review-queue",
             "--execute-reviewers",
             "--json",
         ]
@@ -182,6 +184,7 @@ def test_build_parser_registers_review_queue_merge_packet_lazily(monkeypatch):
     assert args.command == "review-queue"
     assert args.review_queue_command == "merge-packet"
     assert args.pr == ["6779"]
+    assert args.review_queue_root == "/tmp/review-queue"
     assert args.execute_reviewers is True
     assert args.json_output is True
     assert args.func.__name__ == "cmd_review_queue"


### PR DESCRIPTION
## Summary
- include GitHub PR `state` in per-PR merge-packet input
- block explicit non-OPEN PR states from admin-squash authorization
- surface `PR is already MERGED` as a packet reason instead of treating a settled PR as merge-ready

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/cli/commands/test_review_queue.py -q -p no:cacheprovider` -> 134 passed
- `python3 -m ruff check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py` -> passed
- `python3 -m ruff format --check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py` -> passed
- `python3 scripts/regenerate_metrics.py --check` -> passed
- `python3 scripts/regenerate_module_tiers.py --check` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> passed
- live repro: `python3 -m aragora.cli.main review-queue merge-packet --pr 7468 --json` now reports `admin_squash_allowed=false`, `status=repair_or_wait`, and reason `PR is already MERGED`

Draft until current-head model evidence and queue gates are collected.
