### PR TITLE
Fix pre-merge Tier 4 settlement recording

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -376,8 +376,9 @@ def add_review_queue_parser(subparsers: argparse._SubParsersAction) -> None:
         "record-settlement",
         help="Record an already-authorized PR settlement without mutating GitHub",
         description=(
-            "Write a local review-queue settlement receipt after an external\n"
-            "operator decision, such as an exact-head admin squash merge. This\n"
+            "Write a local review-queue settlement receipt for an external\n"
+            "operator decision, such as an exact-head admin squash merge\n"
+            "authorization before merge or a recorded post-merge outcome. This\n"
             "is local-only: it verifies the live PR head/state, writes under\n"
             ".aragora/review-queue/receipts (or --review-queue-root), and does\n"
             "not approve, comment, merge, or otherwise mutate GitHub."
@@ -393,13 +394,13 @@ def add_review_queue_parser(subparsers: argparse._SubParsersAction) -> None:
     record_p.add_argument(
         "--head-sha",
         required=True,
-        help="Exact PR head SHA that was externally settled.",
+        help="Exact PR head SHA that was externally settled or authorized.",
     )
     record_p.add_argument(
         "--action",
         required=True,
         choices=("approve", "request_changes", "comment", "admin_squash_merge"),
-        help="Externally observed settlement action to record.",
+        help="Operator settlement action or post-merge outcome to record.",
     )
     record_p.add_argument(
         "--reason",
@@ -2425,9 +2426,9 @@ def _record_external_settlement(
         )
     github_state = str(pr_payload.get("state", "") or "").strip().upper()
     merged_at = str(pr_payload.get("mergedAt", "") or "").strip()
-    if action == "admin_squash_merge" and github_state != "MERGED":
+    if action == "admin_squash_merge" and github_state not in {"OPEN", "MERGED"}:
         raise _GhError(
-            "admin_squash_merge records require the PR to be MERGED on GitHub; "
+            "admin_squash_merge records require an OPEN or MERGED PR on GitHub; "
             f"current state is {github_state or 'unknown'}"
         )
 

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -1878,13 +1878,13 @@ def _add_review_queue_parser(subparsers) -> None:
     record_parser.add_argument(
         "--head-sha",
         required=True,
-        help="Exact PR head SHA that was externally settled.",
+        help="Exact PR head SHA that was externally settled or authorized.",
     )
     record_parser.add_argument(
         "--action",
         required=True,
         choices=("approve", "request_changes", "comment", "admin_squash_merge"),
-        help="Externally observed settlement action to record.",
+        help="Operator settlement action or post-merge outcome to record.",
     )
     record_parser.add_argument(
         "--reason",

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -2086,7 +2086,43 @@ class TestSettlementHelpers:
                 review_queue_root=None,
             )
 
-    def test_record_external_settlement_rejects_unmerged_admin_merge(
+    def test_record_external_settlement_writes_open_admin_merge_authorization(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        def _fake_gh_json(args: list[str]) -> dict[str, Any]:
+            if args[:2] == ["pr", "view"]:
+                return {
+                    "number": 6294,
+                    "url": "https://github.com/synaptent/aragora/pull/6294",
+                    "headRefOid": "headsha123",
+                    "baseRefOid": "basesha123",
+                    "state": "OPEN",
+                    "mergedAt": "",
+                }
+            if args == ["api", "user"]:
+                return {"login": "an0mium"}
+            raise AssertionError(args)
+
+        monkeypatch.setattr("aragora.cli.commands.review_queue._gh_json", _fake_gh_json)
+
+        result = _record_external_settlement(
+            pr_ref="6294",
+            head_sha="headsha123",
+            action="admin_squash_merge",
+            reason="operator authorized exact-head merge",
+            repo_root=tmp_path,
+            repo_override=None,
+            review_queue_root=None,
+        )
+
+        assert result.written is True
+        assert result.receipt.action == "admin_squash_merge"
+        assert result.receipt.github_event == "ADMIN_SQUASH_MERGE"
+        assert result.receipt.reviewed_at
+        assert result.receipt.head_sha == "headsha123"
+        assert Path(result.receipt.receipt_path).exists()
+
+    def test_record_external_settlement_rejects_closed_unmerged_admin_merge(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         monkeypatch.setattr(
@@ -2096,12 +2132,12 @@ class TestSettlementHelpers:
                 "url": "https://github.com/synaptent/aragora/pull/6294",
                 "headRefOid": "headsha123",
                 "baseRefOid": "basesha123",
-                "state": "OPEN",
+                "state": "CLOSED",
                 "mergedAt": "",
             },
         )
 
-        with pytest.raises(_GhError, match="require the PR to be MERGED"):
+        with pytest.raises(_GhError, match="require an OPEN or MERGED PR"):
             _record_external_settlement(
                 pr_ref="6294",
                 head_sha="headsha123",


### PR DESCRIPTION
## Summary
- allow `review-queue record-settlement --action admin_squash_merge` to record exact-head operator authorization while a PR is still open
- continue rejecting closed/unmerged PRs for admin squash settlement records
- update CLI help to describe operator authorization and post-merge outcome recording

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/cli/commands/test_review_queue.py -q -p no:cacheprovider`
- `python3 -m ruff check aragora/cli/commands/review_queue.py aragora/cli/parser.py tests/cli/commands/test_review_queue.py`
- `python3 -m ruff format --check aragora/cli/commands/review_queue.py aragora/cli/parser.py tests/cli/commands/test_review_queue.py`
- `git diff --check origin/main...HEAD`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Notes
This fixes the #7443 tooling gap where the documented Tier 3/4 settlement flow expects a pre-merge local settlement receipt, but the CLI previously refused `admin_squash_merge` unless the PR was already merged.