### PR TITLE
fix(review-queue): block merged PR settlement packets

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -1348,6 +1348,8 @@ def _build_packet(
             "url",
             "headRefOid",
             "baseRefOid",
+            "state",
+            "mergedAt",
             "isDraft",
             "mergeable",
             "reviewDecision",
@@ -1382,6 +1384,7 @@ def _build_packet(
         if isinstance(lab, dict) and lab.get("name")
     ]
     parked_label_hits = [lab for lab in labels if lab in PARKED_LABELS]
+    settlement_state_block = _settlement_state_block_reason(pr)
     touched = sorted({_subsystem_for(p) for p in files})
     high_risk = [p for p in files if _is_high_risk_path(p)]
     checks_summary, has_failures, has_pending = _summarize_checks(pr.get("statusCheckRollup") or [])
@@ -1393,6 +1396,8 @@ def _build_packet(
     validation = _extract_validation_commands(str(pr.get("body", "") or ""))
 
     risk_flags: list[str] = []
+    if settlement_state_block:
+        risk_flags.append(settlement_state_block)
     if is_draft:
         risk_flags.append("draft PR")
     if parked_label_hits:
@@ -1408,7 +1413,10 @@ def _build_packet(
     if has_failures:
         risk_flags.append(f"checks failing ({checks_summary})")
 
-    if has_failures or mergeable == "CONFLICTING":
+    if settlement_state_block:
+        recommendation = "needs_human_attention"
+        recommendation_reason = settlement_state_block
+    elif has_failures or mergeable == "CONFLICTING":
         recommendation = "repair_first"
         recommendation_reason = "checks failing or merge conflict — fix before review"
     elif is_draft:
@@ -1629,6 +1637,7 @@ def _build_model_review_quorum(
         view for view in (protocol.get("dissenting_views") or []) if isinstance(view, dict)
     ]
     blocking_workflow_state = _has_blocking_workflow_state(pr)
+    settlement_state_block = _settlement_state_block_reason(pr)
     unresolved_dissent = bool(dissenting_views)
     counted_reviewer_ids = _counted_model_reviewer_ids(reviewer_signals, dogfood_evidence)
     signal_count = len(counted_reviewer_ids)
@@ -1640,6 +1649,8 @@ def _build_model_review_quorum(
     )
 
     reasons = [tier_reason]
+    if settlement_state_block:
+        reasons.append(settlement_state_block)
     if has_failures:
         reasons.append("checks are failing; repair before settlement")
     if has_pending:
@@ -1661,6 +1672,7 @@ def _build_model_review_quorum(
         or has_pending
         or machine_recommendation == "repair_first"
         or blocking_workflow_state
+        or settlement_state_block
     ):
         status = "repair_or_wait"
         verdict = "not_ready_for_settlement"
@@ -1775,6 +1787,8 @@ def _tier_requirement(tier: int) -> dict[str, Any]:
 
 
 def _has_blocking_workflow_state(pr: dict[str, Any]) -> bool:
+    if _settlement_state_block_reason(pr):
+        return True
     if bool(pr.get("isDraft", False)):
         return True
     mergeable = str(pr.get("mergeable", "")).strip().upper()
@@ -1786,6 +1800,20 @@ def _has_blocking_workflow_state(pr: dict[str, Any]) -> bool:
         if isinstance(label, dict) and label.get("name")
     ]
     return any(label in PARKED_LABELS for label in labels)
+
+
+def _settlement_state_block_reason(pr: dict[str, Any]) -> str:
+    state = str(pr.get("state") or "").strip().upper()
+    merged_at = str(pr.get("mergedAt") or "").strip()
+    if merged_at:
+        if state == "OPEN":
+            return (
+                "PR state is OPEN but mergedAt is set; settlement applies only to open unmerged PRs"
+            )
+        return f"PR is {state or 'MERGED'}; settlement applies only to open PRs"
+    if state and state != "OPEN":
+        return f"PR is {state}; settlement applies only to open PRs"
+    return ""
 
 
 def _reviewer_signals_from_protocol(protocol: dict[str, Any]) -> list[dict[str, Any]]:

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -1455,6 +1455,132 @@ class TestBuildQueueAndPacket:
         assert packet.machine_recommendation == "approve_candidate"
         assert packet.checks_summary == "2/2 green"
 
+    def test_merged_pr_fails_closed_before_admin_authorization(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pr_payload = _make_pr(number=7470, files=["docs/status/focus.md"])
+        pr_payload["state"] = "MERGED"
+        pr_payload["mergedAt"] = "2026-05-27T00:19:36Z"
+        pr_payload["comments"] = [
+            {
+                "author": {"login": "an0mium"},
+                "body": "## Grok independent model review\nVerdict: approve.",
+            },
+        ]
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._gh_json",
+            lambda args: pr_payload,
+        )
+        packet = _build_packet("7470", repo_override=None)
+        quorum = packet.model_review_quorum
+
+        assert packet.machine_recommendation == "needs_human_attention"
+        assert "PR is MERGED; settlement applies only to open PRs" in packet.risk_flags
+        assert quorum["admin_squash_allowed"] is False
+        assert quorum["status"] == "repair_or_wait"
+        assert "PR is MERGED; settlement applies only to open PRs" in quorum["reasons"]
+
+    def test_closed_pr_fails_closed_before_admin_authorization(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pr_payload = _make_pr(number=7471, files=["docs/status/closed.md"])
+        pr_payload["state"] = "CLOSED"
+        pr_payload["comments"] = [
+            {
+                "author": {"login": "an0mium"},
+                "body": "## Grok independent model review\nVerdict: approve.",
+            },
+        ]
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._gh_json",
+            lambda args: pr_payload,
+        )
+        packet = _build_packet("7471", repo_override=None)
+
+        assert packet.model_review_quorum["admin_squash_allowed"] is False
+        assert packet.model_review_quorum["status"] == "repair_or_wait"
+        assert (
+            "PR is CLOSED; settlement applies only to open PRs"
+            in packet.model_review_quorum["reasons"]
+        )
+
+    def test_open_authorized_pr_still_allows_admin_squash(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pr_payload = _make_pr(number=7472, files=["docs/status/open.md"])
+        pr_payload["state"] = "OPEN"
+        pr_payload["comments"] = [
+            {
+                "author": {"login": "an0mium"},
+                "body": "## Grok independent model review\nVerdict: approve.",
+            },
+        ]
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._gh_json",
+            lambda args: pr_payload,
+        )
+        packet = _build_packet("7472", repo_override=None)
+
+        assert packet.machine_recommendation == "approve_candidate"
+        assert packet.model_review_quorum["admin_squash_allowed"] is True
+        assert packet.model_review_quorum["status"] == "satisfied"
+
+    def test_inconsistent_open_state_with_merged_at_fails_closed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pr_payload = _make_pr(number=7473, files=["docs/status/stale.md"])
+        pr_payload["state"] = "OPEN"
+        pr_payload["mergedAt"] = "2026-05-27T00:19:36Z"
+        pr_payload["comments"] = [
+            {
+                "author": {"login": "an0mium"},
+                "body": "## Grok independent model review\nVerdict: approve.",
+            },
+        ]
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._gh_json",
+            lambda args: pr_payload,
+        )
+        packet = _build_packet("7473", repo_override=None)
+
+        assert packet.model_review_quorum["admin_squash_allowed"] is False
+        assert packet.model_review_quorum["status"] == "repair_or_wait"
+        assert (
+            "PR state is OPEN but mergedAt is set; settlement applies only to open unmerged PRs"
+        ) in packet.model_review_quorum["reasons"]
+
+    def test_merge_packet_omits_merged_pr_from_admin_squash_order(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pr_payload = _make_pr(number=7470, files=["docs/status/focus.md"])
+        pr_payload["state"] = "MERGED"
+        pr_payload["mergedAt"] = "2026-05-27T00:19:36Z"
+        pr_payload["comments"] = [
+            {
+                "author": {"login": "an0mium"},
+                "body": "## Grok independent model review\nVerdict: approve.",
+            },
+        ]
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._build_queue",
+            lambda limit: [_classify_pr(_make_pr(number=7470))],
+        )
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._gh_json",
+            lambda args: pr_payload,
+        )
+
+        packet = _build_merge_authorization_packet(
+            pr_refs=["7470"],
+            limit=10,
+            repo_override=None,
+        )
+
+        assert packet["entries"][0]["status"] == "repair_or_wait"
+        assert packet["entries"][0]["admin_squash_allowed"] is False
+        assert packet["admin_squash_order"] == []
+        assert packet["not_ready"] == [7470]
+
     def test_build_packet_preserves_completed_merge_quorum_failure(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary
- make merge-packet request live PR state/mergedAt and fail closed for merged or closed PRs
- preserve open PR settlement behavior
- add focused regressions for merged, closed, inconsistent state/mergedAt, open authorized, and admin_squash_order exclusion

## Live Repro
- Before this branch, `python3 -m aragora.cli.main review-queue merge-packet --pr 7470 --json` emitted `admin_squash_allowed=true` for merged PR #7470.
- On this branch, the same command returns `repair_or_wait`, `admin_squash_allowed=false`, and `admin_squash_order=[]` with reason `PR is MERGED; settlement applies only to open PRs`.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/cli/commands/test_review_queue.py -q -p no:cacheprovider`
- `python3 -m ruff check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py`
- `python3 -m ruff format --check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py`
- `python3 -m mypy aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py --ignore-missing-imports --no-incremental`
- `git diff --check origin/main...HEAD`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

Draft only. Do not settle in this lane without normal merge-packet authorization.