### PR TITLE
fix(ask): isolate explicit provider credentials

### DIFF
--- a/aragora/agents/api_agents/common.py
+++ b/aragora/agents/api_agents/common.py
@@ -310,8 +310,14 @@ def is_openrouter_fallback_available() -> bool:
     if not get_default_fallback_enabled():
         return False
 
-    # Only consider fallback available if the OpenRouter key is set
-    return bool(get_api_key("OPENROUTER_API_KEY", required=False))
+    # Only consider fallback available if the OpenRouter key is set.  Strict
+    # secret mode may make this optional probe unavailable; that should disable
+    # fallback, not block a selected primary provider.
+    try:
+        return bool(get_api_key("OPENROUTER_API_KEY", required=False))
+    except Exception as exc:  # noqa: BLE001 - optional fallback must be fail-closed
+        logger.debug("OpenRouter fallback unavailable: %s", exc)
+        return False
 
 
 def get_primary_api_key(*env_vars: str, allow_openrouter_fallback: bool = False) -> str | None:
@@ -320,8 +326,13 @@ def get_primary_api_key(*env_vars: str, allow_openrouter_fallback: bool = False)
     When fallback is allowed and OpenRouter is configured, this returns None
     instead of raising to allow agent instantiation with fallback-only mode.
     """
-    if allow_openrouter_fallback and is_openrouter_fallback_available():
-        return get_api_key(*env_vars, required=False)
+    if allow_openrouter_fallback:
+        primary_key = get_api_key(*env_vars, required=False)
+        if primary_key:
+            return primary_key
+        if is_openrouter_fallback_available():
+            return None
+        return get_api_key(*env_vars, required=True)
     return get_api_key(*env_vars, required=True)
 
 

--- a/aragora/agents/api_agents/grok.py
+++ b/aragora/agents/api_agents/grok.py
@@ -14,6 +14,7 @@ from aragora.agents.registry import AgentRegistry
     default_model="grok-4-latest",
     agent_type="API",
     env_vars="XAI_API_KEY or GROK_API_KEY",
+    accepts_api_key=True,
 )
 class GrokAgent(OpenAICompatibleMixin, APIAgent):
     """Agent that uses xAI's Grok API (OpenAI-compatible).

--- a/aragora/agents/base.py
+++ b/aragora/agents/base.py
@@ -286,7 +286,6 @@ AgentType = Literal[
     "anthropic-api",
     "openai-api",
     "grok",
-    "mistral-api",
     # API-based (via OpenRouter)
     "deepseek",
     "deepseek-r1",

--- a/aragora/agents/base.py
+++ b/aragora/agents/base.py
@@ -286,6 +286,7 @@ AgentType = Literal[
     "anthropic-api",
     "openai-api",
     "grok",
+    "mistral-api",
     # API-based (via OpenRouter)
     "deepseek",
     "deepseek-r1",

--- a/aragora/cli/commands/debate.py
+++ b/aragora/cli/commands/debate.py
@@ -174,6 +174,23 @@ def parse_agents(agents_str: str) -> list[AgentSpec]:
     return AgentSpec.coerce_list(agents_str, warn=False)
 
 
+def _resolved_cli_provider_key(provider: str) -> str | None:
+    """Return the CLI-resolved key for an explicit provider, if configured.
+
+    The CLI key store is the same surface used by ``validate-env`` live
+    provider checks. Passing this key into direct API agents keeps explicit
+    ``aragora ask --agents <provider>`` runs from re-discovering credentials
+    through unrelated fallback probes.
+    """
+    try:
+        from aragora.cli.api_keys import get_provider_key
+
+        value, _source = get_provider_key(provider)
+    except (RuntimeError, ValueError):
+        return None
+    return value.strip() if value and value.strip() else None
+
+
 def _coalesce_grouped_arena_configs(arena_kwargs: dict[str, Any]) -> None:
     """Backfill grouped Arena config objects from legacy per-flag kwargs."""
     existing_memory_cfg = arena_kwargs.get("memory_config")
@@ -1244,11 +1261,13 @@ async def run_debate(
                 role = "critic"
 
         try:
+            api_key = _resolved_cli_provider_key(spec.provider)
             agent = create_agent(
                 model_type=cast(AgentType, spec.provider),
                 name=spec.name or f"{spec.provider}_{role}",
                 role=role,
                 model=spec.model,  # Pass model from spec
+                api_key=api_key,
             )
         except (ValueError, ImportError, RuntimeError) as e:
             failed_agents.append(f"{spec.provider} ({e})")

--- a/aragora/config/legacy.py
+++ b/aragora/config/legacy.py
@@ -205,7 +205,28 @@ def get_api_key(*env_vars: str, required: bool = True) -> str | None:
         >>> api_key = get_api_key("GEMINI_API_KEY", "GOOGLE_API_KEY")
         >>> optional_key = get_api_key("BACKUP_KEY", required=False)
     """
-    # Try AWS Secrets Manager first (if enabled)
+    # Optional provider probes are used for fallback availability checks. They
+    # should treat strict-mode env-blocked secrets as absent without emitting the
+    # "critical secret found in environment" warning from value retrieval.
+    if not required:
+        try:
+            from aragora.config.secrets import get_secret, get_secret_presence
+
+            for var in env_vars:
+                presence = get_secret_presence(var)
+                if presence.source == "aws":
+                    value = get_secret(var)
+                    if value and value.strip():
+                        return value.strip()
+                elif presence.source == "env":
+                    value = os.getenv(var)
+                    if value and value.strip():
+                        return value.strip()
+            return None
+        except ImportError:
+            pass  # secrets module not available, fall through to env vars
+
+    # Try AWS Secrets Manager first (if enabled).
     try:
         from aragora.config.secrets import get_secret
 

--- a/aragora/config/settings.py
+++ b/aragora/config/settings.py
@@ -1310,6 +1310,7 @@ ALLOWED_AGENT_TYPES: frozenset[str] = frozenset(
         "anthropic-api",
         "openai-api",
         "grok",
+        "mistral-api",
         # API-based (via OpenRouter)
         "deepseek",
         "deepseek-r1",

--- a/aragora/debate/orchestrator_delegates.py
+++ b/aragora/debate/orchestrator_delegates.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any
 
 from aragora.core import Agent, Critique, DebateResult, Message, Vote
 from aragora.debate.config.defaults import DEBATE_DEFAULTS
+from aragora.exceptions import ExternalServiceError
 from aragora.knowledge.mound.retrieval import build_debate_knowledge_query
 
 if TYPE_CHECKING:
@@ -358,7 +359,13 @@ class ArenaDelegatesMixin:
                 limit=5,
                 auth_context=getattr(self, "auth_context", None),
             )
-        except (AttributeError, RuntimeError, TypeError, ValueError) as exc:
+        except (
+            AttributeError,
+            ExternalServiceError,
+            RuntimeError,
+            TypeError,
+            ValueError,
+        ) as exc:
             logger.debug("[knowledge_mound] Round refresh failed: %s", exc)
             return 0
 

--- a/aragora/debate/phases/synthesis_generator.py
+++ b/aragora/debate/phases/synthesis_generator.py
@@ -109,6 +109,11 @@ class SynthesisGenerator:
             synthesis = self._combine_proposals_as_synthesis(ctx)
             synthesis_source = "combined"
 
+        if not synthesis and not self._anthropic_synthesis_available():
+            logger.debug("synthesis_llm_skipped reason=anthropic_api_key_unavailable")
+            synthesis = self._combine_proposals_as_synthesis(ctx)
+            synthesis_source = "combined"
+
         if synthesis:
             # Store synthesis in result
             ctx.result.synthesis = synthesis
@@ -218,6 +223,17 @@ class SynthesisGenerator:
         self._generate_export_links(ctx)
 
         return True
+
+    @staticmethod
+    def _anthropic_synthesis_available() -> bool:
+        """Return whether optional Anthropic-backed synthesis can run."""
+        try:
+            from aragora.config import get_api_key
+
+            return bool(get_api_key("ANTHROPIC_API_KEY", required=False))
+        except Exception as exc:  # noqa: BLE001 - optional synthesis probe
+            logger.debug("synthesis_key_probe_failed error=%s", exc)
+            return False
 
     def _is_likely_truncated(self, synthesis: str) -> bool:
         """Heuristic check for truncated/incomplete synthesis output."""

--- a/aragora/debate/phases/synthesis_generator.py
+++ b/aragora/debate/phases/synthesis_generator.py
@@ -84,20 +84,20 @@ class SynthesisGenerator:
         # If no proposals, emit a minimal synthesis to avoid silent endings
         if not ctx.proposals:
             logger.warning("synthesis_fallback reason=no_proposals")
-            synthesis = (
+            fallback_synthesis = (
                 "## Debate Summary\n\n"
                 "No proposals were generated. One or more agents may have failed to respond."
             )
-            ctx.result.synthesis = synthesis
+            ctx.result.synthesis = fallback_synthesis
             # Synthesis is the definitive final answer — always overwrite.
-            ctx.result.final_answer = synthesis
-            self._emit_synthesis_events(ctx, synthesis, "fallback")
+            ctx.result.final_answer = fallback_synthesis
+            self._emit_synthesis_events(ctx, fallback_synthesis, "fallback")
             self._generate_export_links(ctx)
             return True
 
         logger.info("synthesis_generation_start")
 
-        synthesis = None
+        synthesis: str | None = None
         synthesis_source = "opus"
 
         # In offline/demo mode (or when explicitly disabled), avoid attempting
@@ -145,14 +145,14 @@ class SynthesisGenerator:
             # Generate synthesis with timeout (60s to fit within phase budget)
             # Pass user_prompt WITHOUT context_messages to avoid essay-pattern priming
             with streaming_task_context("synthesis-agent:opus_synthesis"):
-                synthesis = await asyncio.wait_for(
+                opus_synthesis = await asyncio.wait_for(
                     synthesizer.generate(user_prompt),
                     timeout=60.0,
                 )
             synthesis = await self._ensure_complete_synthesis(
                 ctx=ctx,
                 synthesizer=synthesizer,
-                synthesis=synthesis,
+                synthesis=opus_synthesis,
                 source="opus",
             )
             logger.info("synthesis_generated_opus chars=%s", len(synthesis))
@@ -179,14 +179,14 @@ class SynthesisGenerator:
                 system_prompt, user_prompt = self._build_synthesis_prompt_parts(ctx)
                 synthesizer.system_prompt = system_prompt
                 with streaming_task_context("synthesis-agent-fallback:sonnet_synthesis"):
-                    synthesis = await asyncio.wait_for(
+                    sonnet_synthesis = await asyncio.wait_for(
                         synthesizer.generate(user_prompt),
                         timeout=30.0,
                     )
                 synthesis = await self._ensure_complete_synthesis(
                     ctx=ctx,
                     synthesizer=synthesizer,
-                    synthesis=synthesis,
+                    synthesis=sonnet_synthesis,
                     source="sonnet",
                 )
                 logger.info("synthesis_generated_sonnet chars=%s", len(synthesis))

--- a/aragora/evaluation/llm_judge.py
+++ b/aragora/evaluation/llm_judge.py
@@ -599,6 +599,9 @@ class LLMJudge:
 
         # Get evaluation from LLM
         try:
+            if not self._judge_provider_available():
+                result.summary = "Evaluation skipped: ANTHROPIC_API_KEY not configured"
+                return result
             evaluation_text = await self._call_judge(prompt)
             dimension_scores = self._parse_evaluation(evaluation_text)
             result.dimension_scores = dimension_scores
@@ -628,6 +631,17 @@ class LLMJudge:
             await self._add_secondary_evaluation(result, query, response, context, reference)
 
         return result
+
+    @staticmethod
+    def _judge_provider_available() -> bool:
+        """Return whether the optional Anthropic-backed judge can run."""
+        try:
+            from aragora.config import get_api_key
+
+            return bool(get_api_key("ANTHROPIC_API_KEY", required=False))
+        except Exception as exc:  # noqa: BLE001 - optional judge probe
+            logger.debug("LLMJudge provider probe failed: %s", exc)
+            return False
 
     async def compare(
         self,
@@ -666,6 +680,9 @@ class LLMJudge:
         )
 
         try:
+            if not self._judge_provider_available():
+                result.explanation = "Comparison skipped: ANTHROPIC_API_KEY not configured"
+                return result
             comparison_text = await self._call_judge(prompt)
             parsed = self._parse_comparison(comparison_text)
 

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -12,12 +12,12 @@
 
 | Metric | Value | Source | Command |
 |---|---|---|---|
-| Python files under aragora/ | `4148` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1944630` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python files under aragora/ | `4149` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
+| Python lines of code under aragora/ | `1945375` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `141` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5229` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `218984` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
-| @pytest.mark.parametrize decorators | `701` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
+| Test files (test_*.py under tests/) | `5235` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `219102` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| @pytest.mark.parametrize decorators | `703` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `71` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2870` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
 | OpenAPI operations (HTTP verbs) | `3297` | `docs/api/openapi.json` | `python -c "import json; spec=json.load(open('docs/api/openapi.json')); print(sum(1 for p in spec['paths'].values() for m in p if m.lower() in {'get','post','put','delete','patch','head','options'}))"` |
@@ -25,10 +25,10 @@
 | Unique permission strings | `424` | `aragora/` | `git grep -h -o -E "@require_permission\(['\"][^'\"]+['\"]\)" -- aragora \| sed -E "s/.*['\"]([^'\"]+)['\"].*/\1/" \| sort -u \| wc -l` |
 | Python SDK modules | `198` | `sdk/python/` | `git ls-files sdk/python/aragora_sdk \| grep -E '\.py$' \| grep -v '/__' \| awk -F/ 'NF<=5' \| wc -l` |
 | TypeScript SDK modules | `215` | `sdk/typescript/` | `git ls-files sdk/typescript/src \| grep -E '\.ts$' \| awk -F/ 'NF<=5' \| wc -l` |
-| Allowlisted agent types | `34` | `aragora/config/settings.py` | `grep -A 50 'ALLOWED_AGENT_TYPES' aragora/config/settings.py \| grep -oE "'[a-z-]+'" \| sort -u \| wc -l` |
+| Allowlisted agent types | `35` | `aragora/config/settings.py` | `grep -A 50 'ALLOWED_AGENT_TYPES' aragora/config/settings.py \| grep -oE "'[a-z-]+'" \| sort -u \| wc -l` |
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `46` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |
-| Markdown files under docs/ | `960` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
+| Markdown files under docs/ | `964` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
 | GitHub Actions workflows | `86` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
 | Mypy baseline errors (grandfathered) | `3317` | `.mypy-baseline` | `wc -l .mypy-baseline` |
 

--- a/tests/cli/test_mode_flag.py
+++ b/tests/cli/test_mode_flag.py
@@ -72,7 +72,7 @@ class TestModeInRunDebate:
 
         created_agents = []
 
-        def mock_create_agent(model_type, name, role, model=None):
+        def mock_create_agent(model_type, name, role, model=None, **kwargs):
             agent = MagicMock()
             agent.name = name
             agent.role = role
@@ -132,7 +132,7 @@ class TestModeInRunDebate:
         created_agents = []
         original_prompt = "Default agent prompt"
 
-        def mock_create_agent(model_type, name, role, model=None):
+        def mock_create_agent(model_type, name, role, model=None, **kwargs):
             agent = MagicMock()
             agent.name = name
             agent.role = role

--- a/tests/debate/phases/test_synthesis_generator.py
+++ b/tests/debate/phases/test_synthesis_generator.py
@@ -457,6 +457,7 @@ class TestGenerateMandatorySynthesis:
 
         with (
             patch("aragora.utils.env.is_offline_mode", return_value=False),
+            patch.object(gen, "_anthropic_synthesis_available", return_value=True),
             patch("aragora.agents.api_agents.anthropic.AnthropicAPIAgent") as mock_agent_class,
         ):
             mock_agent = AsyncMock()
@@ -488,6 +489,7 @@ class TestGenerateMandatorySynthesis:
 
         with (
             patch("aragora.utils.env.is_offline_mode", return_value=False),
+            patch.object(gen, "_anthropic_synthesis_available", return_value=True),
             patch("aragora.agents.api_agents.anthropic.AnthropicAPIAgent") as mock_agent_class,
         ):
             mock_agent = MagicMock()

--- a/tests/test_fresh_provider_ask_isolation.py
+++ b/tests/test_fresh_provider_ask_isolation.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aragora.config.secrets import SecretNotFoundError, SecretPresence
+
+
+def test_optional_get_api_key_treats_strict_secret_miss_as_absent(monkeypatch: pytest.MonkeyPatch):
+    """Optional provider probes must not fail a selected-provider path."""
+    from aragora.config.legacy import get_api_key
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "env-openrouter-key")
+
+    def strict_secret_presence(name: str) -> SecretPresence:
+        return SecretPresence(
+            name=name,
+            source="blocked_by_strict_mode",
+            critical=True,
+            managed=True,
+        )
+
+    monkeypatch.setattr("aragora.config.secrets.get_secret_presence", strict_secret_presence)
+    monkeypatch.setattr(
+        "aragora.config.secrets.get_secret",
+        lambda name: (_ for _ in ()).throw(AssertionError("value probe should be skipped")),
+    )
+
+    assert get_api_key("OPENROUTER_API_KEY", required=False) is None
+
+
+def test_primary_key_is_used_before_openrouter_fallback_probe():
+    """Direct providers should not fail on OpenRouter fallback when primary key exists."""
+    from aragora.agents.api_agents import common
+
+    def fake_get_api_key(*env_vars: str, required: bool = True) -> str | None:
+        if env_vars == ("XAI_API_KEY", "GROK_API_KEY") and required is False:
+            return "xai-primary-key"
+        if env_vars == ("OPENROUTER_API_KEY",):
+            raise AssertionError("OpenRouter fallback should not be probed before primary")
+        raise AssertionError(f"unexpected api key lookup: {env_vars!r}, required={required!r}")
+
+    with patch.object(common, "get_api_key", side_effect=fake_get_api_key):
+        assert (
+            common.get_primary_api_key(
+                "XAI_API_KEY",
+                "GROK_API_KEY",
+                allow_openrouter_fallback=True,
+            )
+            == "xai-primary-key"
+        )
+
+
+def test_mistral_api_is_allowed_in_ask_agent_specs():
+    """Provider readiness and ask parsing must agree on the direct Mistral provider name."""
+    from aragora.agents.registry import AgentRegistry
+    from aragora.agents.spec import AgentSpec
+
+    parsed = AgentSpec.parse("mistral-api:proposer", _warn=False)
+
+    assert parsed.provider == "mistral-api"
+    assert parsed.role == "proposer"
+    assert AgentRegistry.validate_allowed("mistral-api")
+
+
+@pytest.mark.asyncio
+async def test_run_debate_passes_resolved_provider_key_to_direct_agent():
+    """Local ask should reuse the same provider key surface validate-env checks."""
+    from aragora.cli.main import run_debate
+
+    created_agents: list[dict] = []
+
+    def track_create(*args, **kwargs):
+        created_agents.append(kwargs)
+        agent = MagicMock()
+        agent.name = kwargs.get("name", "grok_proposer")
+        return agent
+
+    with patch("aragora.cli.commands.debate.create_agent", side_effect=track_create):
+        with patch("aragora.cli.commands.debate.Arena") as mock_arena:
+            mock_result = MagicMock()
+            mock_arena.return_value.run = AsyncMock(return_value=mock_result)
+            with patch(
+                "aragora.cli.api_keys.get_provider_key",
+                return_value=("xai-provider-key", "environment (XAI_API_KEY)"),
+            ):
+                await run_debate(
+                    task="Test",
+                    agents_str="grok",
+                    rounds=1,
+                    learn=False,
+                    offline=True,
+                )
+
+    assert created_agents[0]["api_key"] == "xai-provider-key"
+
+
+def test_grok_registry_accepts_explicit_api_key():
+    """The direct Grok API agent must accept the key passed by local ask."""
+    from aragora.agents.registry import AgentRegistry, register_all_agents
+
+    register_all_agents()
+
+    assert AgentRegistry._registry["grok"].accepts_api_key is True
+
+
+def test_semantic_store_auto_detect_falls_back_on_optional_secret_miss(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    """Knowledge setup should not block a selected ask provider on missing embedding keys."""
+    import aragora.config as config
+    from aragora.knowledge.mound.semantic_store import EmbeddingProvider, SemanticStore
+
+    def optional_secret_miss(*env_vars: str, required: bool = True) -> str | None:
+        assert required is False
+        raise SecretNotFoundError(env_vars[0])
+
+    monkeypatch.setattr(config, "get_api_key", optional_secret_miss)
+
+    with patch("socket.socket") as mock_socket:
+        mock_sock = MagicMock()
+        mock_sock.connect_ex.return_value = 1
+        mock_socket.return_value.__enter__ = MagicMock(return_value=mock_sock)
+        mock_socket.return_value.__exit__ = MagicMock(return_value=None)
+
+        store = SemanticStore(str(tmp_path / "semantic.db"))
+
+    assert isinstance(store.embedding_provider, EmbeddingProvider)
+    assert store.embedding_dimension == 256
+
+
+@pytest.mark.asyncio
+async def test_synthesis_uses_combined_output_when_optional_anthropic_missing():
+    """Single-provider asks should not probe Anthropic for mandatory synthesis."""
+    from aragora.debate.phases.synthesis_generator import SynthesisGenerator
+
+    ctx = SimpleNamespace(
+        env=SimpleNamespace(task="Return a short answer"),
+        proposals={"grok_proposer": "provider reached"},
+        result=SimpleNamespace(
+            confidence=0.5,
+            debate_id="debate-test",
+            final_answer="provider reached",
+            synthesis=None,
+            winner=None,
+        ),
+    )
+    generator = SynthesisGenerator(protocol=SimpleNamespace(enable_llm_synthesis=True, rounds=1))
+
+    with patch.object(generator, "_anthropic_synthesis_available", return_value=False):
+        ok = await generator.generate_mandatory_synthesis(ctx)
+
+    assert ok is True
+    assert "provider reached" in ctx.result.synthesis
+    assert "provider reached" in ctx.result.final_answer
+
+
+@pytest.mark.asyncio
+async def test_llm_judge_skips_when_optional_anthropic_missing(monkeypatch: pytest.MonkeyPatch):
+    """Optional post-debate judging must not become an unrelated provider failure."""
+    from aragora.evaluation.llm_judge import LLMJudge
+
+    monkeypatch.setattr("aragora.config.get_api_key", lambda *args, **kwargs: None)
+
+    with patch.object(LLMJudge, "_call_judge", new_callable=AsyncMock) as call_judge:
+        result = await LLMJudge().evaluate(query="q", response="r")
+
+    call_judge.assert_not_awaited()
+    assert result.summary == "Evaluation skipped: ANTHROPIC_API_KEY not configured"

--- a/tests/test_fresh_provider_ask_isolation.py
+++ b/tests/test_fresh_provider_ask_isolation.py
@@ -158,6 +158,38 @@ async def test_synthesis_uses_combined_output_when_optional_anthropic_missing():
 
 
 @pytest.mark.asyncio
+async def test_round_knowledge_refresh_treats_external_embedding_failure_as_optional():
+    """Expired unrelated embedding providers must not fail an explicit-provider ask."""
+    from aragora.debate.orchestrator_delegates import ArenaDelegatesMixin
+    from aragora.exceptions import ExternalServiceError
+
+    class Harness(ArenaDelegatesMixin):
+        def __init__(self) -> None:
+            self.enable_knowledge_retrieval = True
+            self.env = SimpleNamespace(task="Provider isolation validation")
+            self._km_manager = SimpleNamespace(
+                fetch_context=AsyncMock(
+                    side_effect=ExternalServiceError(
+                        service="Gemini Embedding",
+                        reason="API key expired",
+                        status_code=400,
+                    )
+                )
+            )
+
+    harness = Harness()
+
+    refreshed = await harness._refresh_knowledge_context_for_round(
+        "explicit Grok provider returned a response",
+        SimpleNamespace(),
+        1,
+    )
+
+    assert refreshed == 0
+    harness._km_manager.fetch_context.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_llm_judge_skips_when_optional_anthropic_missing(monkeypatch: pytest.MonkeyPatch):
     """Optional post-debate judging must not become an unrelated provider failure."""
     from aragora.evaluation.llm_judge import LLMJudge


### PR DESCRIPTION
## Summary
- passes CLI-resolved provider keys into explicit local ask agents so validated providers do not rediscover credentials through unrelated fallback paths
- treats optional strict-mode fallback probes as unavailable instead of blocking or warning
- allows direct `mistral-api` ask parsing, and skips Anthropic-backed synthesis/judge when Anthropic is unavailable

## Validation
- `pytest tests/test_fresh_provider_ask_isolation.py tests/test_api_agents.py::TestAgentTypeAttribute::test_grok_agent_has_correct_type tests/test_api_agents.py::TestAgentTypeAttribute::test_mistral_agent_has_correct_type tests/test_cli_main.py::TestEdgeCases::test_parse_agents_single_colon -q`
- `python3 -m ruff check aragora/config/legacy.py aragora/agents/api_agents/common.py aragora/config/settings.py aragora/agents/api_agents/grok.py aragora/cli/commands/debate.py aragora/debate/phases/synthesis_generator.py aragora/evaluation/llm_judge.py tests/test_fresh_provider_ask_isolation.py`
- `python3 -m ruff format --check aragora/config/legacy.py aragora/agents/api_agents/common.py aragora/config/settings.py aragora/agents/api_agents/grok.py aragora/cli/commands/debate.py aragora/debate/phases/synthesis_generator.py aragora/evaluation/llm_judge.py tests/test_fresh_provider_ask_isolation.py`
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- `python3 -m aragora.cli.main validate-env --json` (expected nonzero: Gemini invalid; xAI/Grok and Mistral valid)
- `python3 -m aragora.cli.main doctor --validate` (expected nonzero: Gemini invalid; xAI/Grok and Mistral valid)
- real Grok-only `aragora ask --decision-integrity` produced receipt `/Users/armand/.aragora/receipts/b513ba0a-8367-499b-8072-d018209a3729_1f94cd6fe04cc261.json`
- `python3 -m aragora.cli.main receipt verify /Users/armand/.aragora/receipts/b513ba0a-8367-499b-8072-d018209a3729_1f94cd6fe04cc261.json --verbose`: VALID (3/3)

## Scope
No broad drain, labels, branch protection, outbox, harvest, or unrelated PR work.
