### PR TITLE
fix(review-pr): guard stale follow-up routing

### DIFF
--- a/aragora/cli/commands/review_pr.py
+++ b/aragora/cli/commands/review_pr.py
@@ -292,6 +292,14 @@ async def run_review_pr_loop(
             "url": None,
             "error": stale_reason,
         }
+    elif _has_codex_route_blocker(review_runs):
+        payload["github_review"] = {
+            "posted": False,
+            "event": None,
+            "mode": "advisory" if advisory_only else "status",
+            "url": None,
+            "error": "Requested non-Codex reviewer routed to Codex before review generation.",
+        }
     elif publish_review:
         payload["github_review"] = await _publish_review_outcome(
             target=target,
@@ -390,7 +398,23 @@ async def _run_review_pass(
         worker_model=worker_model,
         preferred_review_model=reviewer,
         repo_root=repo_root,
+        candidate_blocker=_review_candidate_blocker(reviewer),
     )
+    candidate = dict(routing.get("candidate") or {})
+    attempts = [dict(item) for item in routing.get("attempts", []) if isinstance(item, dict)]
+    blocked = routing.get("blocked")
+    if isinstance(blocked, dict):
+        finding = _normalize_route_blocker(blocked)
+        return ReviewPass(
+            reviewer=reviewer,
+            reviewed_at=_now_iso(),
+            status="blocked_nonreviewable",
+            summary=finding["body"],
+            findings=[finding],
+            candidate=candidate,
+            attempts=attempts,
+            raw_response="",
+        )
     raw_response = str(routing.get("response", "")).strip()
     parsed = _extract_first_json_object(raw_response)
     status = str(parsed.get("status", "")).strip().lower()
@@ -398,7 +422,7 @@ async def _run_review_pass(
         status = "blocked_nonreviewable"
     findings = _normalize_findings(parsed.get("findings", []))
     summary = str(parsed.get("summary", "")).strip()
-    route_blocker = _codex_fallback_blocker(reviewer, dict(routing.get("candidate") or {}))
+    route_blocker = _codex_fallback_blocker(reviewer, candidate)
     if route_blocker:
         status = "blocked_nonreviewable"
         summary = route_blocker["body"]
@@ -418,8 +442,8 @@ async def _run_review_pass(
         status=status,
         summary=summary,
         findings=findings,
-        candidate=dict(routing.get("candidate") or {}),
-        attempts=[dict(item) for item in routing.get("attempts", []) if isinstance(item, dict)],
+        candidate=candidate,
+        attempts=attempts,
         raw_response=raw_response,
     )
 
@@ -461,6 +485,44 @@ def _codex_fallback_blocker(
         ),
         "priority": "P1",
     }
+
+
+def _review_candidate_blocker(requested_reviewer: str):
+    def _block(candidate: object) -> dict[str, str] | None:
+        to_dict = getattr(candidate, "to_dict", None)
+        if callable(to_dict):
+            payload = to_dict()
+        elif isinstance(candidate, dict):
+            payload = candidate
+        else:
+            payload = {}
+        return _codex_fallback_blocker(requested_reviewer, dict(payload))
+
+    return _block
+
+
+def _normalize_route_blocker(blocked: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "title": str(blocked.get("title") or "Requested reviewer routed to Codex"),
+        "body": str(blocked.get("body") or "Requested non-Codex reviewer routed to Codex."),
+        "priority": str(blocked.get("priority") or "P1"),
+    }
+
+
+def _has_codex_route_blocker(review_runs: list[dict[str, Any]]) -> bool:
+    if not review_runs:
+        return False
+    latest_review = review_runs[-1]
+    if str(latest_review.get("status") or "").strip().lower() != "blocked_nonreviewable":
+        return False
+    findings = latest_review.get("findings")
+    if not isinstance(findings, list):
+        return False
+    return any(
+        isinstance(item, dict)
+        and str(item.get("title") or "").strip() == "Requested reviewer routed to Codex"
+        for item in findings
+    )
 
 
 async def _run_fix_pass(

--- a/aragora/swarm/review_routing.py
+++ b/aragora/swarm/review_routing.py
@@ -7,6 +7,7 @@ import shutil
 import socket
 import ssl
 import subprocess
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -44,6 +45,9 @@ class ReviewCandidate:
         if self.profile:
             payload["profile"] = self.profile
         return payload
+
+
+CandidateBlocker = Callable[[ReviewCandidate], dict[str, Any] | None]
 
 
 class ReviewRoutingError(RuntimeError):
@@ -123,6 +127,7 @@ async def generate_review_response(
     worker_model: str,
     preferred_review_model: str,
     repo_root: Path,
+    candidate_blocker: CandidateBlocker | None = None,
 ) -> dict[str, Any]:
     attempts: list[dict[str, Any]] = []
     for candidate in resolve_review_candidates(
@@ -139,6 +144,23 @@ async def generate_review_response(
                 }
             )
             continue
+        blocked = candidate_blocker(candidate) if candidate_blocker else None
+        if blocked:
+            attempts.append(
+                {
+                    "candidate": candidate.label,
+                    "stage": "route_guard",
+                    "kind": "blocked_nonreviewable",
+                    "detail": str(blocked.get("title", "candidate blocked")).strip()
+                    or "candidate blocked",
+                }
+            )
+            return {
+                "candidate": candidate.to_dict(),
+                "response": "",
+                "attempts": attempts,
+                "blocked": dict(blocked),
+            }
         try:
             response = await _run_review_candidate(candidate, prompt, repo_root=repo_root)
         except CLISubprocessError as exc:

--- a/scripts/pr_check_followup.py
+++ b/scripts/pr_check_followup.py
@@ -352,7 +352,13 @@ def _has_branch_conflict(pr_data: dict[str, Any]) -> bool:
     return mergeable == "CONFLICTING" or merge_state == "DIRTY"
 
 
-def classify_run_job(job: dict[str, Any], run_id: str, run_data: dict[str, Any]) -> CheckDiagnosis:
+def classify_run_job(
+    job: dict[str, Any],
+    run_id: str,
+    run_data: dict[str, Any],
+    *,
+    pr_head: str | None = None,
+) -> CheckDiagnosis:
     """Classify an Actions job from gh run view JSON."""
     job_id = _job_id(job)
     status = str(job.get("status") or "").upper()
@@ -363,7 +369,10 @@ def classify_run_job(job: dict[str, Any], run_id: str, run_data: dict[str, Any])
     classification = "unknown"
     summary = ""
 
-    if conclusion == "CANCELLED":
+    if pr_head and head_sha and head_sha != pr_head:
+        classification = "stale_cancelled"
+        summary = f"run belongs to stale head {head_sha}; current PR head is {pr_head}"
+    elif conclusion == "CANCELLED":
         if _is_early_cancelled_steps(
             [step for step in job.get("steps") or [] if isinstance(step, dict)]
         ):
@@ -433,12 +442,13 @@ def diagnose_wait_run(
     run_id: str,
     run_data: dict[str, Any],
     *,
+    pr_head: str | None = None,
     timed_out: bool = False,
     log_summary_by_job: dict[str, list[str]] | None = None,
 ) -> WaitRunDiagnosis:
     """Build a diagnosis for a waited Actions run."""
     jobs = [
-        classify_run_job(job, run_id, run_data)
+        classify_run_job(job, run_id, run_data, pr_head=pr_head)
         for job in run_data.get("jobs") or []
         if isinstance(job, dict)
     ]
@@ -466,6 +476,8 @@ def _derive_action(
 ) -> str:
     if expected_head and head != expected_head:
         return "head_drift"
+    if wait_run and wait_run.head_sha and head and wait_run.head_sha != head:
+        return "stale_wait_run"
 
     wait_jobs = wait_run.jobs if wait_run else []
     if wait_run and (
@@ -528,7 +540,7 @@ def build_followup_result(
             diagnosis.log_summary = log_summary_by_job.get(diagnosis.job_id, [])
         checks.append(diagnosis)
 
-    if wait_run:
+    if wait_run and not (wait_run.head_sha and head and wait_run.head_sha != head):
         waited_job_ids = {job.job_id for job in wait_run.jobs if job.job_id}
         checks = [check for check in checks if check.job_id not in waited_job_ids]
         checks.extend(wait_run.jobs)
@@ -591,6 +603,14 @@ def build_prompt(
         lines.extend(
             [
                 f"Goal: refresh #{pr_number} follow-up because the live head drifted from {expected_head} to {head}. Do not merge, rerun, push, edit files, start cleanup, or start broader queue settlement.",
+                "",
+            ]
+        )
+    elif action == "stale_wait_run":
+        run_head = wait_run.head_sha if wait_run else "unknown"
+        lines.extend(
+            [
+                f"Goal: refresh #{pr_number} follow-up because the waited Actions run belongs to stale head {run_head}, while the live PR head is {head}. Do not merge, rerun, push, edit files, start cleanup, or start broader queue settlement.",
                 "",
             ]
         )
@@ -700,6 +720,10 @@ def build_prompt(
     elif action == "rerun_cancelled":
         lines.append(
             "Only early-cancelled rows remain; rerun commands were intentionally withheld by the helper. Re-run the helper with --allow-rerun-commands to generate exact commands."
+        )
+    elif action == "stale_wait_run":
+        lines.append(
+            "Ignore the stale waited run for current-head decisions. Re-run the helper against a current-head run/check or omit --wait-run and use live statusCheckRollup."
         )
     elif action == "monitor" and wait_run and wait_run.timed_out:
         lines.append(
@@ -822,6 +846,7 @@ def fetch_live_result(
         wait_run = diagnose_wait_run(
             wait_run_id,
             run_data,
+            pr_head=head,
             timed_out=timed_out,
             log_summary_by_job=log_summary_by_job,
         )

--- a/scripts/settlement_followup.py
+++ b/scripts/settlement_followup.py
@@ -252,6 +252,20 @@ def _settlement_check_packet(
     }
 
 
+def _head_drift_blocker(*, pr: int, requested_head: str, pr_state: Any) -> str | None:
+    if not isinstance(pr_state, dict):
+        return "live PR state unavailable; cannot verify requested head"
+    live_head = str(pr_state.get("headRefOid") or "").strip()
+    if not live_head:
+        return "live PR head unavailable; cannot verify requested head"
+    if live_head != requested_head:
+        return (
+            f"PR #{pr} head drifted from requested {requested_head} to live {live_head}; "
+            "do not prepare settlement apply for a stale head"
+        )
+    return None
+
+
 def _focused_tests_packet(
     *,
     repair_cwd: Path | None,
@@ -293,10 +307,15 @@ def _prompt_for(packet: dict[str, Any]) -> str:
     mergeable = pr_state.get("mergeable")
     merge_state = pr_state.get("mergeStateStatus")
     gate = packet["validation"]["settlement_check"]
-    blockers = gate.get("blockers") or []
+    blockers = packet.get("apply_blockers") or gate.get("blockers") or []
 
     if root_dirty:
         next_action = "First classify and preserve the root dirty state before any mutation."
+    elif any("head drifted" in str(blocker) for blocker in blockers):
+        next_action = (
+            "Stop before settlement apply because the requested head no longer matches the "
+            "live PR head."
+        )
     elif blockers or merge_state in {"DIRTY", "CONFLICTING"} or mergeable == "CONFLICTING":
         next_action = "Diagnose only the live branch conflict or merge-packet blocker."
     elif gate.get("ok"):
@@ -362,6 +381,12 @@ def build_followup_packet(
         repo_root,
         runner,
     )
+    pr_payload = pr_state.get("payload")
+    head_drift_blocker = _head_drift_blocker(
+        pr=pr,
+        requested_head=head,
+        pr_state=pr_payload,
+    )
     remote = _remote_branch_packet(
         repo_root,
         branch=repair_branch,
@@ -387,9 +412,15 @@ def build_followup_packet(
         if run_focused_tests
         else {"ran": False, "ok": None, "reason": "disabled"}
     )
+    settlement_blockers = list(settlement_check.get("blockers", []))
+    apply_blockers = (
+        [head_drift_blocker, *settlement_blockers] if head_drift_blocker else settlement_blockers
+    )
     packet = {
         "pr": pr,
         "head": head,
+        "live_head": pr_payload.get("headRefOid") if isinstance(pr_payload, dict) else None,
+        "requested_head_matches_live": head_drift_blocker is None,
         "repair_head": repair_head,
         "owner": owner.get("payload"),
         "mailbox": _mailbox_summary(owner.get("payload")),
@@ -402,7 +433,7 @@ def build_followup_packet(
             "settlement_check": settlement_check,
             "focused_tests": focused_tests,
         },
-        "apply_blockers": settlement_check.get("blockers", []),
+        "apply_blockers": apply_blockers,
     }
     if include_prompt:
         packet["next_prompt"] = _prompt_for(packet)

--- a/tests/cli/commands/test_review_pr.py
+++ b/tests/cli/commands/test_review_pr.py
@@ -71,28 +71,34 @@ def test_normalize_optional_agent_rejects_placeholder_none() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("requested_reviewer", ["grok", "claude", "gemini"])
 async def test_run_review_pass_blocks_codex_fallback_for_requested_noncodex(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     sample_target: review_pr.PullRequestTarget,
+    requested_reviewer: str,
 ) -> None:
-    async def _fake_generate_review_response(*_: object, **__: object) -> dict[str, object]:
+    async def _fake_generate_review_response(
+        *_: object,
+        candidate_blocker: object,
+        **__: object,
+    ) -> dict[str, object]:
+        candidate = {"provider": "codex", "label": "codex"}
+        assert callable(candidate_blocker)
+        blocked = candidate_blocker(candidate)
+        assert blocked
         return {
-            "candidate": {"provider": "codex", "label": "codex"},
-            "response": json.dumps(
-                {
-                    "status": "passed",
-                    "summary": "No issues found.",
-                    "findings": [],
-                }
-            ),
+            "candidate": candidate,
+            "response": "",
             "attempts": [
                 {
                     "candidate": "codex",
-                    "stage": "generate",
-                    "detail": "ok",
+                    "stage": "route_guard",
+                    "kind": "blocked_nonreviewable",
+                    "detail": "Requested reviewer routed to Codex",
                 }
             ],
+            "blocked": blocked,
         }
 
     monkeypatch.setattr(review_pr, "generate_review_response", _fake_generate_review_response)
@@ -100,7 +106,7 @@ async def test_run_review_pass_blocks_codex_fallback_for_requested_noncodex(
     result = await review_pr._run_review_pass(
         target=sample_target,
         diff_text="diff --git a/foo b/foo\n+ok\n",
-        reviewer="grok",
+        reviewer=requested_reviewer,
         worker_model="codex",
         repo_root=tmp_path,
     )
@@ -111,13 +117,75 @@ async def test_run_review_pass_blocks_codex_fallback_for_requested_noncodex(
         {
             "title": "Requested reviewer routed to Codex",
             "body": (
-                "Requested reviewer `grok` requires non-Codex evidence, but review-pr "
+                f"Requested reviewer `{requested_reviewer}` requires non-Codex evidence, but review-pr "
                 "selected Codex candidate `codex`. Re-run with a real non-Codex reviewer "
                 "or do not count this result as non-Codex quorum evidence."
             ),
             "priority": "P1",
         }
     ]
+    assert result.raw_response == ""
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("requested_reviewer", ["grok", "claude", "gemini"])
+async def test_run_review_pr_loop_does_not_publish_codex_routed_noncodex_review(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    sample_target: review_pr.PullRequestTarget,
+    requested_reviewer: str,
+) -> None:
+    monkeypatch.setattr(review_pr, "_fetch_pr_target", lambda *_, **__: sample_target)
+    monkeypatch.setattr(review_pr, "_fetch_pr_diff", lambda *_: "diff --git a/foo b/foo\n+ok\n")
+
+    async def _fake_review(**_: object) -> review_pr.ReviewPass:
+        return review_pr.ReviewPass(
+            reviewer=requested_reviewer,
+            reviewed_at="2026-03-21T10:00:00+00:00",
+            status="blocked_nonreviewable",
+            summary="Requested non-Codex reviewer routed to Codex.",
+            findings=[
+                {
+                    "title": "Requested reviewer routed to Codex",
+                    "body": "Requested non-Codex reviewer routed to Codex.",
+                    "priority": "P1",
+                }
+            ],
+            candidate={"provider": "codex", "label": "codex"},
+            attempts=[
+                {
+                    "candidate": "codex",
+                    "stage": "route_guard",
+                    "kind": "blocked_nonreviewable",
+                    "detail": "Requested reviewer routed to Codex",
+                }
+            ],
+            raw_response="",
+        )
+
+    async def _should_not_publish(**_: object) -> dict[str, object]:
+        raise AssertionError("_publish_review_outcome should not publish Codex-routed evidence")
+
+    monkeypatch.setattr(review_pr, "_run_review_pass", _fake_review)
+    monkeypatch.setattr(review_pr, "_publish_review_outcome", _should_not_publish)
+
+    result = await review_pr.run_review_pr_loop(
+        pr_ref="1137",
+        repo_root=tmp_path,
+        reviewer=requested_reviewer,
+        artifact_root=tmp_path / "artifacts",
+        publish_review=True,
+    )
+
+    assert result["final_status"] == "blocked_nonreviewable"
+    assert result["github_review"] == {
+        "posted": False,
+        "event": None,
+        "mode": "advisory",
+        "url": None,
+        "error": "Requested non-Codex reviewer routed to Codex before review generation.",
+    }
+    assert result["review_runs"][0]["candidate"] == {"provider": "codex", "label": "codex"}
 
 
 @pytest.mark.asyncio

--- a/tests/scripts/test_pr_check_followup.py
+++ b/tests/scripts/test_pr_check_followup.py
@@ -204,6 +204,40 @@ def test_failed_rerun_after_checkout_is_substantive_blocker() -> None:
     assert "Do not rerun cancelled rows" in result.prompt
 
 
+def test_wait_run_stale_head_does_not_drive_current_head_rerun() -> None:
+    wait_run = followup.diagnose_wait_run(
+        "99",
+        {
+            "status": "completed",
+            "conclusion": "cancelled",
+            "workflowName": "Tests",
+            "headSha": "old-head",
+            "jobs": [
+                _job(
+                    "Build Documentation",
+                    "cancelled",
+                    job_id="101",
+                    steps=[
+                        {"name": "Set up job", "conclusion": "success"},
+                        {"name": "Checkout", "conclusion": "cancelled"},
+                    ],
+                )
+            ],
+        },
+        pr_head="new-head",
+    )
+    result = followup.build_followup_result(
+        _pr([], head="new-head"),
+        wait_run=wait_run,
+        allow_rerun_commands=True,
+    )
+
+    assert result.action == "stale_wait_run"
+    assert result.rerun_commands == []
+    assert "waited Actions run belongs to stale head old-head" in result.prompt
+    assert "gh run rerun 99 --job 101" not in result.prompt
+
+
 def test_merge_quorum_model_quorum_failure_emits_evidence_prompt() -> None:
     result = followup.build_followup_result(
         _pr(

--- a/tests/scripts/test_settlement_followup.py
+++ b/tests/scripts/test_settlement_followup.py
@@ -33,12 +33,16 @@ class FakeRunner:
         settlement_ok: bool = False,
         pr_mergeable: str = "CONFLICTING",
         merge_state: str = "DIRTY",
+        pr_head: str = "5a692b5dd54f05f2befe0df7b497c56e3c6ead6f",
+        root_dirty: bool = True,
     ) -> None:
         self.commands: list[tuple[Path, list[str]]] = []
         self.worktree_found = worktree_found
         self.settlement_ok = settlement_ok
         self.pr_mergeable = pr_mergeable
         self.merge_state = merge_state
+        self.pr_head = pr_head
+        self.root_dirty = root_dirty
 
     def __call__(self, command: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
         self.commands.append((cwd, command))
@@ -65,6 +69,8 @@ class FakeRunner:
                     "## codex/droid-7443-tier4-settlement-20260526...origin/codex/droid-7443-tier4-settlement-20260526\n",
                     "",
                 )
+            if not self.root_dirty:
+                return subprocess.CompletedProcess(command, 0, "## main...origin/main\n", "")
             return subprocess.CompletedProcess(
                 command,
                 0,
@@ -81,7 +87,7 @@ class FakeRunner:
                     "state": "OPEN",
                     "isDraft": False,
                     "headRefName": "codex/harvest-provider-readiness-secrets-cli-20260523",
-                    "headRefOid": "5a692b5dd54f05f2befe0df7b497c56e3c6ead6f",
+                    "headRefOid": self.pr_head,
                     "mergeable": self.pr_mergeable,
                     "mergeStateStatus": self.merge_state,
                     "url": "https://github.com/synaptent/aragora/pull/7443",
@@ -207,3 +213,33 @@ def test_missing_repair_worktree_reports_validation_blocker(tmp_path: Path) -> N
     assert packet["validation"]["settlement_check"]["ran"] is False
     assert packet["validation"]["settlement_check"]["blockers"] == ["repair worktree not found"]
     assert packet["validation"]["focused_tests"]["ran"] is False
+
+
+def test_live_head_drift_blocks_settlement_apply_prompt(tmp_path: Path) -> None:
+    runner = FakeRunner(
+        settlement_ok=True,
+        pr_mergeable="MERGEABLE",
+        merge_state="UNSTABLE",
+        pr_head="new-head",
+        root_dirty=False,
+    )
+
+    packet = followup.build_followup_packet(
+        pr=7443,
+        head="old-head",
+        repair_branch="codex/droid-7443-tier4-settlement-20260526",
+        repair_head="63ff1513b4eb1e9a73b5ce3dbbc92a0179c00f67",
+        repo_root=tmp_path,
+        include_prompt=True,
+        runner=runner,
+    )
+
+    assert packet["requested_head_matches_live"] is False
+    assert packet["live_head"] == "new-head"
+    assert packet["apply_blockers"][0] == (
+        "PR #7443 head drifted from requested old-head to live new-head; "
+        "do not prepare settlement apply for a stale head"
+    )
+    assert packet["validation"]["settlement_check"]["ok"] is True
+    assert "Stop before settlement apply" in packet["next_prompt"]
+    assert "Prepare exact-head settlement apply" not in packet["next_prompt"]

--- a/tests/swarm/test_review_routing.py
+++ b/tests/swarm/test_review_routing.py
@@ -78,6 +78,48 @@ async def test_generate_review_response_fails_over_to_next_candidate() -> None:
 
 
 @pytest.mark.asyncio
+async def test_generate_review_response_candidate_blocker_stops_before_generation() -> None:
+    run_candidate = AsyncMock(side_effect=AssertionError("candidate generation should not run"))
+    blocker = {
+        "title": "Requested reviewer routed to Codex",
+        "body": "requested non-Codex reviewer selected Codex",
+        "priority": "P1",
+    }
+
+    with (
+        patch(
+            "aragora.swarm.review_routing.resolve_review_candidates",
+            return_value=[ReviewCandidate(provider="codex", label="codex")],
+        ),
+        patch(
+            "aragora.swarm.review_routing.preflight_review_candidate",
+            return_value={"ok": True, "detail": "codex available"},
+        ),
+        patch("aragora.swarm.review_routing._run_review_candidate", new=run_candidate),
+    ):
+        result = await generate_review_response(
+            "review this",
+            worker_model="claude",
+            preferred_review_model="grok",
+            repo_root=Path("/tmp/repo"),
+            candidate_blocker=lambda candidate: blocker if candidate.provider == "codex" else None,
+        )
+
+    assert result["candidate"]["label"] == "codex"
+    assert result["response"] == ""
+    assert result["blocked"] == blocker
+    assert result["attempts"] == [
+        {
+            "candidate": "codex",
+            "stage": "route_guard",
+            "kind": "blocked_nonreviewable",
+            "detail": "Requested reviewer routed to Codex",
+        }
+    ]
+    run_candidate.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_generate_review_response_records_unexpected_exception_detail() -> None:
     with (
         patch(


### PR DESCRIPTION
## Summary
- block stale `--wait-run` Actions runs from driving current-head follow-up decisions
- block settlement follow-up prompts when requested `--head` differs from live PR head
- fail `review-pr --reviewer <non-codex>` before generation/publish when routing selects Codex

## Test Plan
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/scripts/test_pr_check_followup.py tests/scripts/test_settlement_followup.py tests/cli/commands/test_review_pr.py tests/swarm/test_review_routing.py -q -p no:cacheprovider`
- `python3 -m ruff check scripts/pr_check_followup.py scripts/settlement_followup.py tests/scripts/test_pr_check_followup.py tests/scripts/test_settlement_followup.py aragora/cli/commands/review_pr.py aragora/swarm/review_routing.py tests/cli/commands/test_review_pr.py tests/swarm/test_review_routing.py`
- `python3 -m ruff format --check scripts/pr_check_followup.py scripts/settlement_followup.py tests/scripts/test_pr_check_followup.py tests/scripts/test_settlement_followup.py aragora/cli/commands/review_pr.py aragora/swarm/review_routing.py tests/cli/commands/test_review_pr.py tests/swarm/test_review_routing.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

Draft follow-up only. Do not merge without separate operator authorization.