### PR TITLE
[codex] Add post-merge lane audit integration

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -28,6 +28,7 @@ import sqlite3
 import subprocess
 import sys
 import time
+from collections.abc import Callable
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -51,8 +52,14 @@ from aragora.swarm.pr_review_protocol import (
 )
 from aragora.triage.auto_handle_calibration import AutoHandleCalibrationStore
 from aragora.worktree.fleet import resolve_repo_root
+from scripts.post_merge_lane_audit import (
+    post_merge_lane_audit_failed,
+    post_merge_lane_audit_failure_reason,
+    run_post_merge_lane_audit,
+)
 
 UTC = timezone.utc
+PostMergeLaneAuditProvider = Callable[[int, bool], dict[str, Any]]
 
 # Lane classification thresholds and risk-path catalog.
 LARGE_DIFF_THRESHOLD = 500  # additions + deletions, beyond which "needs_human_attention"
@@ -255,9 +262,13 @@ class SettlementReceipt:
     outcome_rollback: bool | None = None
     outcome_reopened_pr: bool | None = None
     outcome_observed_at: str | None = None
+    post_merge_lane_audit: dict[str, Any] | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
+        payload = asdict(self)
+        if payload.get("post_merge_lane_audit") is None:
+            payload.pop("post_merge_lane_audit", None)
+        return payload
 
 
 @dataclass(slots=True)
@@ -268,9 +279,14 @@ class RecordedSettlementResult:
     receipt_sha256: str
     idempotent: bool
     written: bool
+    post_merge_lane_audit: dict[str, Any] | None = None
+    post_merge_lane_audit_failed: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         payload = self.receipt.to_dict()
+        if self.post_merge_lane_audit is not None:
+            payload["post_merge_lane_audit"] = self.post_merge_lane_audit
+            payload["post_merge_lane_audit_failed"] = self.post_merge_lane_audit_failed
         payload.update(
             {
                 "receipt_sha256": self.receipt_sha256,
@@ -412,6 +428,15 @@ def add_review_queue_parser(subparsers: argparse._SubParsersAction) -> None:
         help=(
             "Override the review-queue store root used for settlement "
             "receipts. Defaults to <repo>/.aragora/review-queue."
+        ),
+    )
+    record_p.add_argument(
+        "--apply-post-merge-lane-audit",
+        action="store_true",
+        help=(
+            "For admin_squash_merge records, apply merged-PR lane supersession "
+            "after verifying GitHub reports MERGED and using the live merge "
+            "commit as the exact guard. Default is dry-run/report only."
         ),
     )
     record_p.add_argument("--json", action="store_true", help="Output local receipt as JSON")
@@ -886,6 +911,7 @@ def _cmd_record_settlement(args: argparse.Namespace) -> int:
             repo_root=repo_root,
             repo_override=getattr(args, "repo", None),
             review_queue_root=getattr(args, "review_queue_root", None),
+            apply_post_merge_lane_audit=bool(getattr(args, "apply_post_merge_lane_audit", False)),
         )
     except _GhError as exc:
         print(f"error: {exc}", file=sys.stderr)
@@ -894,7 +920,7 @@ def _cmd_record_settlement(args: argparse.Namespace) -> int:
         print(json.dumps(result.to_dict(), indent=2))
     else:
         _render_recorded_settlement_result(result)
-    return 0
+    return 1 if result.post_merge_lane_audit_failed else 0
 
 
 def _cmd_evidence_lint(args: argparse.Namespace) -> int:
@@ -2570,6 +2596,8 @@ def _record_external_settlement(
     repo_root: Path,
     repo_override: str | None,
     review_queue_root: str | Path | None,
+    apply_post_merge_lane_audit: bool = False,
+    post_merge_lane_audit_provider: PostMergeLaneAuditProvider | None = None,
 ) -> RecordedSettlementResult:
     pr_number = _parse_pr_number(pr_ref)
     expected_head_sha = str(head_sha or "").strip()
@@ -2594,6 +2622,28 @@ def _record_external_settlement(
             "admin_squash_merge records require the PR to be MERGED on GitHub; "
             f"current state is {github_state or 'unknown'}"
         )
+    post_merge_lane_audit: dict[str, Any] | None = None
+    if action == "admin_squash_merge":
+        audit_provider = post_merge_lane_audit_provider
+        if audit_provider is None:
+            audit_provider = lambda pr, audit_apply=False: run_post_merge_lane_audit(
+                pr,
+                repo_root=repo_root,
+                apply=audit_apply,
+            )
+        try:
+            post_merge_lane_audit = audit_provider(pr_number, apply_post_merge_lane_audit)
+        except Exception as exc:
+            post_merge_lane_audit = {
+                "audit_ok": False,
+                "audit_applied": False,
+                "audit_apply_requested": apply_post_merge_lane_audit,
+                "audit_error": str(exc),
+            }
+    audit_failed = post_merge_lane_audit_failed(
+        post_merge_lane_audit,
+        apply_requested=apply_post_merge_lane_audit,
+    )
 
     pr_url = str(pr_payload.get("url", "") or "").strip()
     base_sha = str(pr_payload.get("baseRefOid", "") or "").strip()
@@ -2631,6 +2681,7 @@ def _record_external_settlement(
         queue_bucket="external_settlement",
         machine_recommendation="operator_recorded_external_settlement",
         github_event=github_event,
+        post_merge_lane_audit=post_merge_lane_audit,
     )
     root = _resolve_review_queue_root_override(repo_root, review_queue_root)
     receipt_path = _settlement_receipt_path_for_root(
@@ -2654,6 +2705,8 @@ def _record_external_settlement(
             receipt_sha256=_receipt_file_sha256(receipt_path),
             idempotent=True,
             written=False,
+            post_merge_lane_audit=post_merge_lane_audit,
+            post_merge_lane_audit_failed=audit_failed,
         )
 
     _write_json(receipt_path, new_payload)
@@ -2662,6 +2715,8 @@ def _record_external_settlement(
         receipt_sha256=_receipt_file_sha256(receipt_path),
         idempotent=False,
         written=True,
+        post_merge_lane_audit=post_merge_lane_audit,
+        post_merge_lane_audit_failed=audit_failed,
     )
 
 
@@ -2870,6 +2925,17 @@ def _render_settlement_receipt(receipt: SettlementReceipt) -> None:
 
 def _render_recorded_settlement_result(result: RecordedSettlementResult) -> None:
     _render_settlement_receipt(result.receipt)
+    if result.post_merge_lane_audit is not None:
+        audit = result.post_merge_lane_audit
+        print("  post-merge lane audit:")
+        print(f"    finding count: {audit.get('finding_count', 'unknown')}")
+        print(f"    resolved count: {audit.get('resolved_count', 'unknown')}")
+        if audit.get("blocked_reason"):
+            print(f"    blocked:       {audit['blocked_reason']}")
+        if result.post_merge_lane_audit_failed:
+            print(f"    failed:        {post_merge_lane_audit_failure_reason(audit)}")
+        if audit.get("operator_apply_command"):
+            print(f"    apply command: {audit['operator_apply_command']}")
     print(f"  receipt sha:  {result.receipt_sha256}")
     print(f"  idempotent:   {str(result.idempotent).lower()}")
     print(f"  written:      {str(result.written).lower()}")

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -1946,6 +1946,14 @@ def _add_review_queue_parser(subparsers) -> None:
         help="Override the review-queue root used for settlement receipts.",
     )
     record_parser.add_argument(
+        "--apply-post-merge-lane-audit",
+        action="store_true",
+        help=(
+            "For admin_squash_merge records, apply merged-PR lane supersession "
+            "using the live merge commit guard. Default is dry-run/report only."
+        ),
+    )
+    record_parser.add_argument(
         "--json",
         dest="json_output",
         action="store_true",

--- a/scripts/auto_merge_bucket_a.py
+++ b/scripts/auto_merge_bucket_a.py
@@ -51,6 +51,14 @@ TRIAGE_SCRIPT = REPO_ROOT / "scripts" / "triage_open_prs.py"
 RECEIPT_DIR = REPO_ROOT / "docs" / "status"
 POLICY_DOC = REPO_ROOT / "docs" / "governance" / "OPERATOR_DELEGATION_POLICY.md"
 
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+from scripts.post_merge_lane_audit import (  # noqa: E402
+    post_merge_lane_audit_failed,
+    post_merge_lane_audit_failure_reason,
+    run_post_merge_lane_audit,
+)
+
 BUCKET_A = "A"
 
 DEFAULT_SETTLING_MINUTES = 30
@@ -124,6 +132,7 @@ class MergeDecision:
     reason: str
     head_sha: str | None = None
     applied: bool = False
+    post_merge_lane_audit: dict[str, Any] | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -133,6 +142,7 @@ class MergeDecision:
 
 Runner = Callable[[list[str]], "subprocess.CompletedProcess[str]"]
 ReviewQueueSourceValidator = Callable[[], str | None]
+PostMergeLaneAuditProvider = Callable[[int, bool], dict[str, Any]]
 
 
 def _default_runner(args: list[str]) -> subprocess.CompletedProcess[str]:
@@ -625,6 +635,8 @@ def decide(
     merge_packet_provider: Callable[[int], dict[str, Any]] | None = None,
     review_queue_source_validator: ReviewQueueSourceValidator | None = None,
     merger: Callable[[int, str, bool, bool], subprocess.CompletedProcess[str]] | None = None,
+    post_merge_lane_audit_provider: PostMergeLaneAuditProvider | None = None,
+    apply_post_merge_lane_audit: bool = False,
     delete_branch_on_merge: bool = False,
     now: datetime.datetime | None = None,
 ) -> tuple[list[MergeDecision], int]:
@@ -644,6 +656,12 @@ def decide(
             _review_queue_source_tripwire if using_default_merge_packet_provider else (lambda: None)
         )
     merger = merger or gh_pr_merge_squash
+    if post_merge_lane_audit_provider is None:
+        post_merge_lane_audit_provider = lambda pr, audit_apply=False: run_post_merge_lane_audit(
+            pr,
+            repo_root=REPO_ROOT,
+            apply=audit_apply,
+        )
 
     decisions: list[MergeDecision] = []
     tripwire_exit = 0
@@ -825,14 +843,37 @@ def decide(
                 )
                 tripwire_exit = 1
                 continue
+            try:
+                post_merge_lane_audit = post_merge_lane_audit_provider(
+                    pr_number,
+                    apply_post_merge_lane_audit,
+                )
+            except Exception as exc:
+                post_merge_lane_audit = {
+                    "audit_ok": False,
+                    "audit_applied": False,
+                    "audit_apply_requested": apply_post_merge_lane_audit,
+                    "audit_error": str(exc),
+                }
+            reason = "bucket A + tripwire clear + settling window met"
+            if post_merge_lane_audit_failed(
+                post_merge_lane_audit,
+                apply_requested=apply_post_merge_lane_audit,
+            ):
+                tripwire_exit = 1
+                reason = (
+                    f"{reason}; post-merge lane audit failed: "
+                    f"{post_merge_lane_audit_failure_reason(post_merge_lane_audit)}"
+                )
             decisions.append(
                 MergeDecision(
                     pr_number=pr_number,
                     title=title,
                     decision="merge",
-                    reason="bucket A + tripwire clear + settling window met",
+                    reason=reason,
                     head_sha=head_sha or None,
                     applied=True,
+                    post_merge_lane_audit=post_merge_lane_audit,
                 )
             )
         else:
@@ -902,6 +943,21 @@ def render_receipt(
             f"| #{d.pr_number} | `{d.decision}` | {'yes' if d.applied else 'no'} | "
             f"`{head}` | {d.reason} |"
         )
+    audit_decisions = [d for d in decisions if d.post_merge_lane_audit is not None]
+    if audit_decisions:
+        lines.append("")
+        lines.append("## Post-merge lane audit")
+        lines.append("")
+        lines.append("| PR | Findings | Resolved | Blocked reason | Operator apply command |")
+        lines.append("|---|---:|---:|---|---|")
+        for d in audit_decisions:
+            audit = d.post_merge_lane_audit or {}
+            command = str(audit.get("operator_apply_command") or "—").replace("|", "\\|")
+            lines.append(
+                f"| #{d.pr_number} | {audit.get('finding_count', '—')} | "
+                f"{audit.get('resolved_count', '—')} | "
+                f"{audit.get('blocked_reason') or '—'} | `{command}` |"
+            )
     lines.append("")
     return "\n".join(lines)
 
@@ -1058,11 +1114,23 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Delete merged PR branches. Default keeps branches for auditability.",
     )
+    parser.add_argument(
+        "--apply-post-merge-lane-audit",
+        action="store_true",
+        help=(
+            "After a successful protected merge, apply the merged-PR lane audit "
+            "with operator authorization and the live merge commit guard. "
+            "Default is dry-run/report only."
+        ),
+    )
 
     args = parser.parse_args(argv)
 
     if args.settling_minutes < 0:
         print("error: --settling-minutes must be non-negative", file=sys.stderr)
+        return 2
+    if args.apply_post_merge_lane_audit and not args.apply:
+        print("error: --apply-post-merge-lane-audit requires --apply", file=sys.stderr)
         return 2
 
     try:
@@ -1093,6 +1161,7 @@ def main(argv: list[str] | None = None) -> int:
         settling_minutes=args.settling_minutes,
         only_pr=args.only_pr,
         delete_branch_on_merge=args.delete_branch_on_merge,
+        apply_post_merge_lane_audit=args.apply_post_merge_lane_audit,
     )
 
     if args.apply:

--- a/scripts/post_merge_lane_audit.py
+++ b/scripts/post_merge_lane_audit.py
@@ -1,0 +1,261 @@
+"""Shared post-merge lane-audit helper.
+
+This wraps ``scripts/resolve_lane_conflicts.py --merged-pr-lane-audit`` so
+settlement paths can report stale active lane rows after a PR lands, while
+keeping the default behavior dry-run and non-destructive.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+Runner = Callable[[list[str]], subprocess.CompletedProcess[str]]
+
+
+def _run_command(
+    args: list[str],
+    *,
+    cwd: Path,
+    runner: Runner | None,
+) -> subprocess.CompletedProcess[str]:
+    if runner is not None:
+        return runner(args)
+    return subprocess.run(args, cwd=cwd, text=True, capture_output=True, check=False)
+
+
+def _parse_json(stdout: str) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return payload
+
+
+def _command_error(
+    *,
+    command: list[str],
+    proc: subprocess.CompletedProcess[str] | None,
+    message: str,
+    apply_requested: bool,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "audit_ok": False,
+        "audit_applied": False,
+        "audit_apply_requested": apply_requested,
+        "audit_command": command,
+        "audit_error": message,
+    }
+    if proc is not None:
+        result["audit_returncode"] = proc.returncode
+        result["audit_stdout"] = proc.stdout
+        result["audit_stderr"] = proc.stderr
+    return result
+
+
+def _resolver_command(
+    *,
+    repo_root: Path,
+    pr_number: int,
+    gh_bin: str,
+    apply: bool,
+    expected_merge_commit: str | None = None,
+) -> list[str]:
+    command = [
+        sys.executable,
+        str(repo_root / "scripts" / "resolve_lane_conflicts.py"),
+        "--merged-pr-lane-audit",
+        "--pr",
+        str(pr_number),
+        "--gh-bin",
+        gh_bin,
+        "--json",
+    ]
+    if apply:
+        command.extend(
+            [
+                "--expected-merge-commit",
+                str(expected_merge_commit or ""),
+                "--operator-authorized",
+                "--apply",
+            ]
+        )
+    return command
+
+
+def _merge_helper_metadata(
+    payload: dict[str, Any],
+    *,
+    audit_ok: bool,
+    audit_applied: bool,
+    apply_requested: bool,
+    command: list[str],
+    proc: subprocess.CompletedProcess[str],
+    error: str | None = None,
+) -> dict[str, Any]:
+    result = dict(payload)
+    result.update(
+        {
+            "audit_ok": audit_ok,
+            "audit_applied": audit_applied,
+            "audit_apply_requested": apply_requested,
+            "audit_command": command,
+            "audit_returncode": proc.returncode,
+        }
+    )
+    if error:
+        result["audit_error"] = error
+    return result
+
+
+def run_post_merge_lane_audit(
+    pr_number: int,
+    *,
+    repo_root: Path | None = None,
+    apply: bool = False,
+    gh_bin: str = "gh",
+    runner: Runner | None = None,
+) -> dict[str, Any]:
+    """Run the merged-PR lane audit and optionally apply guarded cleanup.
+
+    Dry-run mode returns the resolver JSON plus helper metadata and never
+    mutates lane state. Apply mode first runs the same dry-run, then reruns the
+    resolver with ``--apply --operator-authorized --expected-merge-commit`` only
+    when GitHub reports the PR is merged and exposes the live merge commit.
+    """
+
+    root = repo_root or REPO_ROOT
+    run = runner
+    dry_command = _resolver_command(repo_root=root, pr_number=pr_number, gh_bin=gh_bin, apply=False)
+    try:
+        dry_proc = _run_command(dry_command, cwd=root, runner=run)
+    except OSError as exc:
+        return _command_error(
+            command=dry_command,
+            proc=None,
+            message=str(exc),
+            apply_requested=apply,
+        )
+    dry_payload = _parse_json(dry_proc.stdout)
+    if dry_payload is None:
+        return _command_error(
+            command=dry_command,
+            proc=dry_proc,
+            message="merged-PR lane audit returned invalid JSON",
+            apply_requested=apply,
+        )
+    if dry_proc.returncode != 0:
+        message = str(dry_payload.get("blocked_reason") or dry_proc.stderr or "audit failed")
+        return _merge_helper_metadata(
+            dry_payload,
+            audit_ok=False,
+            audit_applied=False,
+            apply_requested=apply,
+            command=dry_command,
+            proc=dry_proc,
+            error=message,
+        )
+
+    dry_result = _merge_helper_metadata(
+        dry_payload,
+        audit_ok=True,
+        audit_applied=False,
+        apply_requested=apply,
+        command=dry_command,
+        proc=dry_proc,
+    )
+    if not apply:
+        return dry_result
+
+    github_state = dry_payload.get("github_state")
+    if not isinstance(github_state, dict):
+        dry_result["audit_ok"] = False
+        dry_result["audit_error"] = "github_state_missing"
+        return dry_result
+    if github_state.get("available") is not True or github_state.get("state") != "MERGED":
+        dry_result["audit_ok"] = False
+        dry_result["audit_error"] = str(dry_payload.get("blocked_reason") or "pr_not_merged")
+        return dry_result
+    merge_commit = str(github_state.get("mergeCommit") or "").strip()
+    if not merge_commit:
+        dry_result["audit_ok"] = False
+        dry_result["audit_error"] = "merge_commit_missing"
+        return dry_result
+    if int(dry_payload.get("finding_count") or 0) == 0:
+        dry_result["audit_apply_skipped_reason"] = "no_active_lanes_for_merged_pr"
+        return dry_result
+
+    apply_command = _resolver_command(
+        repo_root=root,
+        pr_number=pr_number,
+        gh_bin=gh_bin,
+        apply=True,
+        expected_merge_commit=merge_commit,
+    )
+    try:
+        apply_proc = _run_command(apply_command, cwd=root, runner=run)
+    except OSError as exc:
+        return _command_error(
+            command=apply_command,
+            proc=None,
+            message=str(exc),
+            apply_requested=True,
+        )
+    apply_payload = _parse_json(apply_proc.stdout)
+    if apply_payload is None:
+        return _command_error(
+            command=apply_command,
+            proc=apply_proc,
+            message="merged-PR lane audit apply returned invalid JSON",
+            apply_requested=True,
+        )
+    error = None
+    audit_ok = apply_proc.returncode == 0 and not apply_payload.get("blocked_reason")
+    if not audit_ok:
+        error = str(
+            apply_payload.get("blocked_reason") or apply_proc.stderr or "audit apply failed"
+        )
+    return _merge_helper_metadata(
+        apply_payload,
+        audit_ok=audit_ok,
+        audit_applied=audit_ok,
+        apply_requested=True,
+        command=apply_command,
+        proc=apply_proc,
+        error=error,
+    )
+
+
+def post_merge_lane_audit_failed(
+    result: Mapping[str, Any] | None,
+    *,
+    apply_requested: bool,
+) -> bool:
+    """Return whether an audit result should make the caller fail.
+
+    Dry-run audit failures are surfaced in output but intentionally do not
+    reclassify a successful merge. Explicit apply failures are command-failing
+    because the operator requested lane mutation and it did not complete.
+    """
+
+    if not apply_requested or result is None:
+        return False
+    return result.get("audit_ok") is False
+
+
+def post_merge_lane_audit_failure_reason(result: Mapping[str, Any] | None) -> str:
+    if result is None:
+        return "post-merge lane audit unavailable"
+    return str(
+        result.get("audit_error")
+        or result.get("blocked_reason")
+        or result.get("audit_stderr")
+        or "post-merge lane audit failed"
+    )

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -1798,6 +1798,7 @@ class TestCommandDispatch:
                 "admin_squash_merge",
                 "--reason",
                 "operator authorized exact-head merge",
+                "--apply-post-merge-lane-audit",
                 "--json",
             ]
         )
@@ -1806,6 +1807,7 @@ class TestCommandDispatch:
         assert ns_record.head_sha == "headsha123"
         assert ns_record.action == "admin_squash_merge"
         assert ns_record.reason == "operator authorized exact-head merge"
+        assert ns_record.apply_post_merge_lane_audit is True
 
     def test_cmd_review_queue_with_no_subcommand_returns_2(self) -> None:
         ns = argparse.Namespace(review_queue_command=None)
@@ -1827,6 +1829,7 @@ class TestCommandDispatch:
                 "admin_squash_merge",
                 "--reason",
                 "operator authorized exact-head merge",
+                "--apply-post-merge-lane-audit",
                 "--json",
             ]
         )
@@ -1837,6 +1840,7 @@ class TestCommandDispatch:
         assert ns.head_sha == "headsha123"
         assert ns.action == "admin_squash_merge"
         assert ns.reason == "operator authorized exact-head merge"
+        assert ns.apply_post_merge_lane_audit is True
         assert ns.json_output is True
 
     def test_top_level_parser_registers_evidence_lint(self) -> None:
@@ -2126,6 +2130,96 @@ class TestSettlementHelpers:
         assert saved["head_sha"] == "headsha123"
         assert saved["packet_sha"].startswith("sha256:")
 
+    def test_record_external_admin_merge_includes_post_merge_lane_audit(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        def _fake_gh_json(args: list[str]) -> dict[str, Any]:
+            if args[:2] == ["pr", "view"]:
+                return {
+                    "number": 6294,
+                    "url": "https://github.com/synaptent/aragora/pull/6294",
+                    "headRefOid": "headsha123",
+                    "baseRefOid": "basesha123",
+                    "state": "MERGED",
+                    "mergedAt": "2026-05-10T08:00:00Z",
+                }
+            if args == ["api", "user"]:
+                return {"login": "an0mium"}
+            raise AssertionError(args)
+
+        monkeypatch.setattr("aragora.cli.commands.review_queue._gh_json", _fake_gh_json)
+        audit_calls: list[tuple[int, bool]] = []
+
+        def audit_provider(pr_number: int, apply: bool = False) -> dict[str, Any]:
+            audit_calls.append((pr_number, apply))
+            return {
+                "finding_count": 1,
+                "resolved_count": 0,
+                "blocked_reason": None,
+                "owner_steering_text": "",
+                "owner_release_commands": [],
+                "operator_apply_command": "python3 scripts/resolve_lane_conflicts.py --apply ...",
+                "receipt_paths": [],
+                "github_state": {"state": "MERGED", "mergeCommit": "merge-sha"},
+                "audit_ok": True,
+                "audit_applied": False,
+            }
+
+        result = _record_external_settlement(
+            pr_ref="6294",
+            head_sha="headsha123",
+            action="admin_squash_merge",
+            reason="operator authorized exact-head merge",
+            repo_root=tmp_path,
+            repo_override=None,
+            review_queue_root=None,
+            post_merge_lane_audit_provider=audit_provider,
+        )
+
+        assert audit_calls == [(6294, False)]
+        assert result.post_merge_lane_audit is not None
+        assert result.to_dict()["post_merge_lane_audit"]["operator_apply_command"].startswith(
+            "python3 scripts/resolve_lane_conflicts.py"
+        )
+        saved = json.loads(Path(result.receipt.receipt_path).read_text())
+        assert saved["post_merge_lane_audit"]["finding_count"] == 1
+
+    def test_record_external_non_merge_settlement_does_not_run_post_merge_lane_audit(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        def _fake_gh_json(args: list[str]) -> dict[str, Any]:
+            if args[:2] == ["pr", "view"]:
+                return {
+                    "number": 6294,
+                    "url": "https://github.com/synaptent/aragora/pull/6294",
+                    "headRefOid": "headsha123",
+                    "baseRefOid": "basesha123",
+                    "state": "OPEN",
+                    "mergedAt": "",
+                }
+            if args == ["api", "user"]:
+                return {"login": "an0mium"}
+            raise AssertionError(args)
+
+        monkeypatch.setattr("aragora.cli.commands.review_queue._gh_json", _fake_gh_json)
+
+        def audit_provider(pr_number: int, apply: bool = False) -> dict[str, Any]:
+            raise AssertionError("post-merge audit should only run for admin_squash_merge")
+
+        result = _record_external_settlement(
+            pr_ref="6294",
+            head_sha="headsha123",
+            action="comment",
+            reason="operator recorded a comment",
+            repo_root=tmp_path,
+            repo_override=None,
+            review_queue_root=None,
+            post_merge_lane_audit_provider=audit_provider,
+        )
+
+        assert result.post_merge_lane_audit is None
+        assert "post_merge_lane_audit" not in result.to_dict()
+
     def test_record_external_settlement_is_idempotent(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
@@ -2293,6 +2387,79 @@ class TestSettlementHelpers:
 
         assert rc == 1
         assert "gh unavailable" in err_buf.getvalue()
+
+    def test_record_settlement_command_records_audit_apply_failure_then_returns_1(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue.resolve_repo_root",
+            lambda cwd: tmp_path,
+        )
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._require_clean_worktree",
+            lambda repo_root: None,
+        )
+
+        def _fake_gh_json(args: list[str]) -> dict[str, Any]:
+            if args[:2] == ["pr", "view"]:
+                return {
+                    "number": 6294,
+                    "url": "https://github.com/synaptent/aragora/pull/6294",
+                    "headRefOid": "headsha123",
+                    "baseRefOid": "basesha123",
+                    "state": "MERGED",
+                    "mergedAt": "2026-05-10T08:00:00Z",
+                }
+            if args == ["api", "user"]:
+                return {"login": "an0mium"}
+            raise AssertionError(args)
+
+        def _audit_failure(
+            pr_number: int,
+            *,
+            repo_root: Path | None = None,
+            apply: bool = False,
+        ) -> dict[str, Any]:
+            assert pr_number == 6294
+            assert apply is True
+            return {
+                "finding_count": 1,
+                "resolved_count": 0,
+                "blocked_reason": "merge_commit_mismatch",
+                "operator_apply_command": "python3 scripts/resolve_lane_conflicts.py --apply ...",
+                "receipt_paths": [],
+                "github_state": {"state": "MERGED", "mergeCommit": "merge-sha"},
+                "audit_ok": False,
+                "audit_applied": False,
+                "audit_error": "merge_commit_mismatch",
+            }
+
+        monkeypatch.setattr("aragora.cli.commands.review_queue._gh_json", _fake_gh_json)
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue.run_post_merge_lane_audit",
+            _audit_failure,
+        )
+        ns = argparse.Namespace(
+            review_queue_command="record-settlement",
+            pr="6294",
+            repo=None,
+            head_sha="headsha123",
+            action="admin_squash_merge",
+            reason="operator authorized exact-head merge",
+            review_queue_root=None,
+            apply_post_merge_lane_audit=True,
+            json=True,
+        )
+
+        out_buf = io.StringIO()
+        with redirect_stdout(out_buf):
+            rc = cmd_review_queue(ns)
+
+        payload = json.loads(out_buf.getvalue())
+        assert rc == 1
+        assert payload["post_merge_lane_audit_failed"] is True
+        assert payload["post_merge_lane_audit"]["blocked_reason"] == "merge_commit_mismatch"
+        assert Path(payload["receipt_path"]).is_file()
 
     def test_build_command_renders_table(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(

--- a/tests/scripts/test_auto_merge_bucket_a.py
+++ b/tests/scripts/test_auto_merge_bucket_a.py
@@ -336,6 +336,106 @@ class TestDecide:
         skipped_non_a = sorted(d.pr_number for d in decisions if d.decision == "skip-non-bucket-a")
         assert skipped_non_a == [9002, 9003, 9004]
 
+    def test_apply_success_runs_post_merge_lane_audit_dry_run_by_default(self):
+        payload = make_triage_payload(bucket_a_entry(9001))
+        meta = _MetadataRegistry({9001: make_metadata(9001)})
+        recorder = _MergeRecorder()
+        audit_calls: list[tuple[int, bool]] = []
+
+        def audit_provider(pr_number: int, apply: bool = False) -> dict[str, Any]:
+            audit_calls.append((pr_number, apply))
+            return {
+                "finding_count": 1,
+                "resolved_count": 0,
+                "operator_apply_command": "python3 scripts/resolve_lane_conflicts.py --apply ...",
+                "github_state": {"state": "MERGED", "mergeCommit": "merge-sha"},
+                "audit_ok": True,
+                "audit_applied": False,
+            }
+
+        decisions, exit_code = amba.decide(
+            payload,
+            apply=True,
+            settling_minutes=30,
+            metadata_provider=meta,
+            merger=recorder,
+            post_merge_lane_audit_provider=audit_provider,
+            now=NOW,
+        )
+
+        assert exit_code == 0
+        assert audit_calls == [(9001, False)]
+        assert decisions[0].applied is True
+        assert (
+            decisions[0]
+            .post_merge_lane_audit["operator_apply_command"]
+            .startswith("python3 scripts/resolve_lane_conflicts.py")
+        )
+
+    def test_apply_post_merge_lane_audit_flag_applies_guarded_audit(self):
+        payload = make_triage_payload(bucket_a_entry(9001))
+        meta = _MetadataRegistry({9001: make_metadata(9001)})
+        recorder = _MergeRecorder()
+        audit_calls: list[tuple[int, bool]] = []
+
+        def audit_provider(pr_number: int, apply: bool = False) -> dict[str, Any]:
+            audit_calls.append((pr_number, apply))
+            return {
+                "finding_count": 1,
+                "resolved_count": 1,
+                "receipt_paths": ["/tmp/receipt.json"],
+                "github_state": {"state": "MERGED", "mergeCommit": "merge-sha"},
+                "audit_ok": True,
+                "audit_applied": True,
+            }
+
+        decisions, exit_code = amba.decide(
+            payload,
+            apply=True,
+            settling_minutes=30,
+            metadata_provider=meta,
+            merger=recorder,
+            post_merge_lane_audit_provider=audit_provider,
+            apply_post_merge_lane_audit=True,
+            now=NOW,
+        )
+
+        assert exit_code == 0
+        assert audit_calls == [(9001, True)]
+        assert decisions[0].post_merge_lane_audit["receipt_paths"] == ["/tmp/receipt.json"]
+
+    def test_apply_post_merge_lane_audit_failure_is_reported_after_merge(self):
+        payload = make_triage_payload(bucket_a_entry(9001))
+        meta = _MetadataRegistry({9001: make_metadata(9001)})
+        recorder = _MergeRecorder()
+
+        def audit_provider(pr_number: int, apply: bool = False) -> dict[str, Any]:
+            return {
+                "finding_count": 1,
+                "resolved_count": 0,
+                "blocked_reason": "operator_authorization_required",
+                "github_state": {"state": "MERGED", "mergeCommit": "merge-sha"},
+                "audit_ok": False,
+                "audit_error": "operator_authorization_required",
+            }
+
+        decisions, exit_code = amba.decide(
+            payload,
+            apply=True,
+            settling_minutes=30,
+            metadata_provider=meta,
+            merger=recorder,
+            post_merge_lane_audit_provider=audit_provider,
+            apply_post_merge_lane_audit=True,
+            now=NOW,
+        )
+
+        assert recorder.calls == [9001]
+        assert decisions[0].applied is True
+        assert decisions[0].post_merge_lane_audit["audit_ok"] is False
+        assert "post-merge lane audit failed" in decisions[0].reason
+        assert exit_code == 1
+
     def test_apply_attempts_at_most_one_merge_per_snapshot(self):
         payload = make_triage_payload(bucket_a_entry(9001), bucket_a_entry(9002))
         meta = _MetadataRegistry({9001: make_metadata(9001), 9002: make_metadata(9002)})

--- a/tests/scripts/test_post_merge_lane_audit.py
+++ b/tests/scripts/test_post_merge_lane_audit.py
@@ -1,0 +1,104 @@
+"""Tests for the shared post-merge lane-audit helper."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Any
+
+from scripts.post_merge_lane_audit import run_post_merge_lane_audit
+
+
+def _proc(
+    args: list[str], payload: dict[str, Any], returncode: int = 0
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=args,
+        returncode=returncode,
+        stdout=json.dumps(payload),
+        stderr="",
+    )
+
+
+def _dry_payload(
+    *,
+    state: str = "MERGED",
+    merge_commit: str = "merge-sha",
+    finding_count: int = 1,
+    blocked_reason: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "finding_count": finding_count,
+        "resolved_count": 0,
+        "blocked_reason": blocked_reason,
+        "owner_steering_text": "",
+        "owner_release_commands": [],
+        "operator_apply_command": "python3 scripts/resolve_lane_conflicts.py --apply ...",
+        "receipt_paths": [],
+        "github_state": {
+            "available": True,
+            "state": state,
+            "mergeCommit": merge_commit,
+        },
+    }
+
+
+def test_post_merge_lane_audit_dry_run_preserves_resolver_result() -> None:
+    commands: list[list[str]] = []
+
+    def runner(args: list[str]) -> subprocess.CompletedProcess[str]:
+        commands.append(args)
+        return _proc(args, _dry_payload())
+
+    result = run_post_merge_lane_audit(7435, runner=runner)
+
+    assert len(commands) == 1
+    assert "--apply" not in commands[0]
+    assert result["audit_ok"] is True
+    assert result["audit_applied"] is False
+    assert result["operator_apply_command"].startswith("python3 scripts/resolve_lane_conflicts.py")
+
+
+def test_post_merge_lane_audit_apply_uses_live_merge_commit_guard() -> None:
+    commands: list[list[str]] = []
+
+    def runner(args: list[str]) -> subprocess.CompletedProcess[str]:
+        commands.append(args)
+        if len(commands) == 1:
+            return _proc(args, _dry_payload(merge_commit="live-merge-sha"))
+        return _proc(
+            args,
+            {
+                **_dry_payload(merge_commit="live-merge-sha"),
+                "resolved_count": 1,
+                "receipt_paths": ["/tmp/lane-receipt.json"],
+                "blocked_reason": None,
+            },
+        )
+
+    result = run_post_merge_lane_audit(7435, apply=True, runner=runner)
+
+    assert len(commands) == 2
+    assert "--apply" in commands[1]
+    assert "--operator-authorized" in commands[1]
+    assert commands[1][commands[1].index("--expected-merge-commit") + 1] == "live-merge-sha"
+    assert result["audit_ok"] is True
+    assert result["audit_applied"] is True
+    assert result["receipt_paths"] == ["/tmp/lane-receipt.json"]
+
+
+def test_post_merge_lane_audit_apply_refuses_unmerged_pr_without_mutation() -> None:
+    commands: list[list[str]] = []
+
+    def runner(args: list[str]) -> subprocess.CompletedProcess[str]:
+        commands.append(args)
+        return _proc(
+            args, _dry_payload(state="OPEN", merge_commit="", blocked_reason="pr_not_merged")
+        )
+
+    result = run_post_merge_lane_audit(7435, apply=True, runner=runner)
+
+    assert len(commands) == 1
+    assert result["audit_ok"] is False
+    assert result["audit_applied"] is False
+    assert result["audit_error"] == "pr_not_merged"


### PR DESCRIPTION
## Summary
- Add a shared post-merge lane audit helper around `resolve_lane_conflicts.py --merged-pr-lane-audit`.
- Run/report the audit after successful Bucket A protected merges and admin-squash settlement records.
- Add explicit `--apply-post-merge-lane-audit` controls that apply only with a live merge-commit guard.

## Test Plan
- `python3 -m pytest tests/scripts/test_auto_merge_bucket_a.py tests/scripts/test_post_merge_lane_audit.py tests/cli/commands/test_review_queue.py tests/scripts/test_resolve_lane_conflicts.py -q`
- `python3 -m ruff check scripts/auto_merge_bucket_a.py scripts/post_merge_lane_audit.py aragora/cli/commands/review_queue.py aragora/cli/parser.py tests/scripts/test_auto_merge_bucket_a.py tests/scripts/test_post_merge_lane_audit.py tests/cli/commands/test_review_queue.py`
- `python3 scripts/auto_merge_bucket_a.py --help`
- `python3 -m aragora.cli.main review-queue record-settlement --help`

## Notes
- Default behavior is dry-run/report-only. Lane state mutation requires the explicit apply flag and the resolver live merge commit guard.
- This PR does not merge or mutate #7481.