### PR TITLE
fix(steering): guard target diagnostics without selector

### DIFF
--- a/scripts/send_operator_steering.py
+++ b/scripts/send_operator_steering.py
@@ -304,7 +304,7 @@ def build_target_diagnostic(
 ) -> dict[str, Any]:
     """Summarize owner-target routing without writing steering messages."""
 
-    if pr is None and branch is None and worktree is None:
+    if pr is None and not branch and not worktree:
         raise ValueError("provide at least one owner selector")
 
     resolved_via = "pr" if pr is not None else "branch" if branch else "worktree"
@@ -682,13 +682,17 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 0
 
     if args.diagnose_target and to_session is None:
-        diagnostic = build_target_diagnostic(
-            registry_path=args.lane_registry_path,
-            pr=args.to_owner_pr,
-            branch=args.to_owner_branch,
-            worktree=args.to_owner_worktree,
-            steering_inbox_root=args.steering_inbox_root,
-        )
+        try:
+            diagnostic = build_target_diagnostic(
+                registry_path=args.lane_registry_path,
+                pr=args.to_owner_pr,
+                branch=args.to_owner_branch,
+                worktree=args.to_owner_worktree,
+                steering_inbox_root=args.steering_inbox_root,
+            )
+        except ValueError as exc:
+            print(f"ERROR: failed to resolve active owner: {exc}", file=sys.stderr)
+            return 2
         out = {
             "_dry_run": True,
             "_would_write": False,
@@ -711,13 +715,17 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
         except ValueError as exc:
             if no_write:
-                diagnostic = build_target_diagnostic(
-                    registry_path=args.lane_registry_path,
-                    pr=args.to_owner_pr,
-                    branch=args.to_owner_branch,
-                    worktree=args.to_owner_worktree,
-                    steering_inbox_root=args.steering_inbox_root,
-                )
+                try:
+                    diagnostic = build_target_diagnostic(
+                        registry_path=args.lane_registry_path,
+                        pr=args.to_owner_pr,
+                        branch=args.to_owner_branch,
+                        worktree=args.to_owner_worktree,
+                        steering_inbox_root=args.steering_inbox_root,
+                    )
+                except ValueError:
+                    print(f"ERROR: failed to resolve active owner: {exc}", file=sys.stderr)
+                    return 2
                 diagnostic["resolution_error"] = str(exc)
                 out = {
                     "_dry_run": True,

--- a/tests/scripts/test_send_operator_steering.py
+++ b/tests/scripts/test_send_operator_steering.py
@@ -638,6 +638,25 @@ class TestActiveOwnerRouting:
         assert parsed["_target"]["steering_inbox_path"] == str(tmp_path / "inbox" / "codex-q23")
         assert list((tmp_path / "inbox").rglob("*.json")) == []
 
+    def test_print_target_without_selector_returns_parse_error(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rc = sos.main(["--print-target", "--json"])
+
+        captured = capsys.readouterr()
+        assert rc == 2
+        assert "one of the arguments" in captured.err
+
+    def test_print_target_empty_branch_returns_clean_error(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rc = sos.main(["--to-owner-branch", "", "--print-target", "--json"])
+
+        captured = capsys.readouterr()
+        assert rc == 2
+        assert "ERROR: failed to resolve active owner:" in captured.err
+        assert "Traceback" not in captured.err
+
     def test_to_owner_pr_rejects_completed_only_owner(self, tmp_path: Path) -> None:
         registry = self._write_lanes(
             tmp_path,
@@ -744,6 +763,27 @@ class TestActiveOwnerRouting:
         assert diagnostic["active_owner"]["owner_session"] == "codex-q23"
         assert diagnostic["historical_related_sessions"] == []
         assert list((tmp_path / "inbox").rglob("*.json")) == []
+
+    def test_diagnose_target_without_selector_returns_parse_error(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rc = sos.main(["--diagnose-target", "--json"])
+
+        captured = capsys.readouterr()
+        assert rc == 2
+        assert "one of the arguments" in captured.err
+
+    def test_diagnose_target_empty_branch_returns_clean_error(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rc = sos.main(["--to-owner-branch", "", "--diagnose-target", "--json"])
+
+        captured = capsys.readouterr()
+        assert rc == 2
+        assert "ERROR: failed to resolve active owner: provide at least one owner selector" in (
+            captured.err
+        )
+        assert "Traceback" not in captured.err
 
     def test_dry_run_no_active_owner_returns_structured_no_target(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
## Summary
- Preserve the #7483 follow-up guard after #7483 merged before the fix could push.
- Make no-write target diagnostics fail cleanly when selectors are omitted or empty.
- Keep valid PR/branch diagnostic lookups as no-write structured output.

## Validation
- python3 -m pytest tests/scripts/test_send_operator_steering.py -q
- python3 -m ruff check scripts/send_operator_steering.py tests/scripts/test_send_operator_steering.py
- python3 -m ruff format --check scripts/send_operator_steering.py tests/scripts/test_send_operator_steering.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- live no-write diagnostics for #7483 and codex/steering-target-diagnostics-20260527

## Notes
- Follow-up to merged #7483; no labels, outbox, branch protection, or queue state changed.