### PR TITLE
fix(review-queue): block cancelled merge-quorum checks

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -1312,6 +1312,8 @@ def _summarize_checks(checks: list) -> tuple[str, bool, bool]:
             conclusion = "FAILURE"
         if conclusion == "SUCCESS":
             success += 1
+        elif conclusion == "CANCELLED" and _is_merge_quorum_check(check):
+            failure += 1
         elif conclusion in ("FAILURE", "TIMED_OUT", "ACTION_REQUIRED"):
             failure += 1
         elif conclusion in ("CANCELLED", "SKIPPED", "NEUTRAL", "STALE"):
@@ -1370,11 +1372,15 @@ def _status_check_identity(check: dict[str, Any]) -> str:
     return f"status-context:{name}"
 
 
-def _is_current_merge_quorum_self_check(check: dict[str, Any]) -> bool:
-    """Ignore only this merge-quorum workflow run while building its packet."""
+def _is_merge_quorum_check(check: dict[str, Any]) -> bool:
     workflow = str(check.get("workflowName") or check.get("workflow") or "").strip()
     name = str(check.get("name") or check.get("context") or "").strip()
-    if workflow != MERGE_QUORUM_WORKFLOW_NAME or name != MERGE_QUORUM_CHECK_NAME:
+    return workflow == MERGE_QUORUM_WORKFLOW_NAME and name == MERGE_QUORUM_CHECK_NAME
+
+
+def _is_current_merge_quorum_self_check(check: dict[str, Any]) -> bool:
+    """Ignore only this merge-quorum workflow run while building its packet."""
+    if not _is_merge_quorum_check(check):
         return False
 
     status = str(check.get("status") or check.get("state") or "").upper()

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -643,6 +643,30 @@ class TestSummarizeChecks:
         assert has_fail
         assert not has_pending
 
+    def test_cancelled_merge_quorum_check_blocks_settlement_summary(self) -> None:
+        checks = [
+            {
+                "name": "aragora-merge-quorum",
+                "workflowName": "Aragora Merge Quorum",
+                "status": "COMPLETED",
+                "conclusion": "CANCELLED",
+                "completedAt": "2026-05-27T17:13:53Z",
+            },
+            {
+                "name": "lint",
+                "workflowName": "Tests",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+                "completedAt": "2026-05-27T17:14:53Z",
+            },
+        ]
+
+        summary, has_fail, has_pending = _summarize_checks(checks)
+
+        assert summary == "1 failing / 2 total"
+        assert has_fail
+        assert not has_pending
+
 
 # --- _classify_pr lane logic -----------------------------------------------
 
@@ -1573,6 +1597,48 @@ class TestBuildQueueAndPacket:
         assert packet.machine_recommendation == "approve_candidate"
         assert packet.model_review_quorum["admin_squash_allowed"] is True
         assert packet.model_review_quorum["status"] == "satisfied"
+
+    def test_cancelled_merge_quorum_blocks_admin_squash_authorization(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pr_payload = _make_pr(
+            number=7456,
+            files=["docs/status/open.md"],
+            checks=[
+                {
+                    "name": "aragora-merge-quorum",
+                    "workflowName": "Aragora Merge Quorum",
+                    "status": "COMPLETED",
+                    "conclusion": "CANCELLED",
+                    "completedAt": "2026-05-27T17:13:53Z",
+                },
+                {
+                    "name": "lint",
+                    "workflowName": "Tests",
+                    "status": "COMPLETED",
+                    "conclusion": "SUCCESS",
+                    "completedAt": "2026-05-27T17:14:53Z",
+                },
+            ],
+        )
+        pr_payload["comments"] = [
+            {
+                "author": {"login": "an0mium"},
+                "body": "## Grok independent model review\nVerdict: approve.",
+            },
+        ]
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._gh_json",
+            lambda args: pr_payload,
+        )
+        packet = _build_packet("7456", repo_override=None)
+        quorum = packet.model_review_quorum
+
+        assert packet.checks_summary == "1 failing / 2 total"
+        assert packet.machine_recommendation == "repair_first"
+        assert quorum["admin_squash_allowed"] is False
+        assert quorum["status"] == "repair_or_wait"
+        assert "checks are failing; repair before settlement" in quorum["reasons"]
 
     def test_inconsistent_open_state_with_merged_at_fails_closed(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary
- Treat completed CANCELLED `Aragora Merge Quorum / aragora-merge-quorum` check runs as blocking failures in merge-packet summaries.
- Preserve the existing current-run self-check pending exclusion and the existing behavior for ordinary skipped/cancelled non-meaningful checks.
- Add regression coverage proving the cancelled merge-quorum check cannot produce `admin_squash_allowed=true`.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/cli/commands/test_review_queue.py -q -p no:cacheprovider`
- `python3 -m ruff check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py`
- `python3 -m ruff format --check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py`
- `python3 -m mypy aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py --ignore-missing-imports --no-incremental`
- `git diff --check origin/main...HEAD`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Notes
- Exposed by PR #7456, where a direct required `aragora-merge-quorum` cancellation coexisted with merge-packet `checks_summary` green and admin-squash authorization.
- Draft only; do not mark ready or settle in this lane without normal exact-head merge-packet authorization.