### PR TITLE
[codex] Add settlement-aware PR check watcher guard

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -12,12 +12,12 @@
 
 | Metric | Value | Source | Command |
 |---|---|---|---|
-| Python files under aragora/ | `4148` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1944630` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python files under aragora/ | `4149` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
+| Python lines of code under aragora/ | `1945471` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `141` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5229` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `218984` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
-| @pytest.mark.parametrize decorators | `701` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
+| Test files (test_*.py under tests/) | `5235` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `219167` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| @pytest.mark.parametrize decorators | `705` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `71` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2870` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
 | OpenAPI operations (HTTP verbs) | `3297` | `docs/api/openapi.json` | `python -c "import json; spec=json.load(open('docs/api/openapi.json')); print(sum(1 for p in spec['paths'].values() for m in p if m.lower() in {'get','post','put','delete','patch','head','options'}))"` |
@@ -28,7 +28,7 @@
 | Allowlisted agent types | `34` | `aragora/config/settings.py` | `grep -A 50 'ALLOWED_AGENT_TYPES' aragora/config/settings.py \| grep -oE "'[a-z-]+'" \| sort -u \| wc -l` |
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `46` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |
-| Markdown files under docs/ | `960` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
+| Markdown files under docs/ | `964` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
 | GitHub Actions workflows | `86` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
 | Mypy baseline errors (grandfathered) | `3317` | `.mypy-baseline` | `wc -l .mypy-baseline` |
 

--- a/scripts/pr_check_followup.py
+++ b/scripts/pr_check_followup.py
@@ -13,7 +13,9 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import shlex
 import subprocess
+import sys
 import time
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
@@ -36,6 +38,10 @@ META_AUTOMATION_SENTENCE = (
 FAILURE_CONCLUSIONS = {"FAILURE", "TIMED_OUT", "ACTION_REQUIRED"}
 GREEN_CONCLUSIONS = {"SUCCESS", "SKIPPED", "NEUTRAL"}
 PENDING_STATUSES = {"IN_PROGRESS", "QUEUED", "PENDING", "EXPECTED", "REQUESTED", "WAITING"}
+GREEN_BUCKETS = {"pass", "skipping"}
+PENDING_BUCKETS = {"pending"}
+FAILURE_BUCKETS = {"fail"}
+CANCEL_BUCKETS = {"cancel"}
 CHECKOUT_MARKERS = ("checkout", "sparse-checkout", "repository checkout")
 SUBSTANTIVE_MARKERS = (
     "verify",
@@ -75,6 +81,58 @@ class CheckDiagnosis:
 
 
 @dataclass
+class CheckRow:
+    """Normalized ``gh pr checks`` row."""
+
+    workflow: str
+    name: str
+    state: str
+    bucket: str
+    link: str = ""
+    run_id: str | None = None
+    job_id: str | None = None
+
+
+@dataclass
+class MergePacketSummary:
+    """Small merge-packet view needed by the check watcher."""
+
+    available: bool
+    admin_squash_allowed: bool
+    not_ready: list[Any]
+    head_sha: str | None = None
+    status: str = ""
+    verdict: str = ""
+
+
+@dataclass
+class SettlementGuard:
+    """Fail-closed settlement-readiness decision from direct checks and packet."""
+
+    direct_required_checks_green: bool
+    merge_packet_authorizes: bool
+    required_non_green: list[CheckRow]
+    full_rollup_pending: list[CheckRow]
+    full_rollup_non_green: list[CheckRow]
+    stale_merge_quorum: CheckRow | None
+    safe_stale_merge_quorum_rerun: bool
+    blocker: str
+
+
+@dataclass
+class RerunAttempt:
+    """Result of the explicitly requested stale-quorum rerun."""
+
+    requested: bool
+    executed: bool
+    command: str | None = None
+    returncode: int | None = None
+    stdout: str = ""
+    stderr: str = ""
+    reason: str = ""
+
+
+@dataclass
 class WaitRunDiagnosis:
     """Summary for an optionally waited GitHub Actions run."""
 
@@ -101,6 +159,11 @@ class FollowupResult:
     rerun_commands: list[str]
     prompt: str
     wait_run: WaitRunDiagnosis | None = None
+    required_checks: list[CheckRow] = field(default_factory=list)
+    full_rollup_checks: list[CheckRow] = field(default_factory=list)
+    merge_packet_summary: MergePacketSummary | None = None
+    settlement_guard: SettlementGuard | None = None
+    rerun_attempt: RerunAttempt | None = None
 
 
 def parse_run_job_ids(details_url: str) -> tuple[str | None, str | None]:
@@ -109,6 +172,97 @@ def parse_run_job_ids(details_url: str) -> tuple[str | None, str | None]:
     if not match:
         return None, None
     return match.group(1), match.group(2)
+
+
+def check_row_from_gh(row: dict[str, Any]) -> CheckRow:
+    """Normalize one ``gh pr checks --json`` row."""
+    link = str(row.get("link") or row.get("detailsUrl") or "").strip()
+    run_id, job_id = parse_run_job_ids(link)
+    return CheckRow(
+        workflow=str(row.get("workflow") or row.get("workflowName") or "").strip(),
+        name=str(row.get("name") or row.get("context") or "").strip(),
+        state=str(row.get("state") or row.get("status") or row.get("conclusion") or "").strip(),
+        bucket=str(row.get("bucket") or "").strip().lower(),
+        link=link,
+        run_id=run_id,
+        job_id=job_id,
+    )
+
+
+def _check_row_identity(row: CheckRow) -> str:
+    workflow = row.workflow.strip().lower()
+    name = row.name.strip().lower()
+    return f"{workflow}:{name}" if workflow else name
+
+
+def _is_row_green(row: CheckRow) -> bool:
+    state = row.state.strip().upper()
+    return row.bucket in GREEN_BUCKETS or state in GREEN_CONCLUSIONS
+
+
+def _is_row_pending(row: CheckRow) -> bool:
+    return row.bucket in PENDING_BUCKETS or row.state.strip().upper() in PENDING_STATUSES
+
+
+def _is_row_failure(row: CheckRow) -> bool:
+    state = row.state.strip().upper()
+    return row.bucket in FAILURE_BUCKETS or state in FAILURE_CONCLUSIONS
+
+
+def _is_row_cancelled(row: CheckRow) -> bool:
+    return row.bucket in CANCEL_BUCKETS or row.state.strip().upper() == "CANCELLED"
+
+
+def _is_merge_quorum_row(row: CheckRow) -> bool:
+    identity = _check_row_identity(row)
+    return "merge quorum" in identity or "merge-quorum" in identity
+
+
+def _rerun_command_for_row(row: CheckRow) -> str | None:
+    if not row.run_id:
+        return None
+    if row.job_id:
+        return f"gh run rerun {row.run_id} --job {row.job_id}"
+    return f"gh run rerun {row.run_id}"
+
+
+def _merge_packet_entry(packet: dict[str, Any], pr_number: int) -> dict[str, Any]:
+    entries = packet.get("entries")
+    if isinstance(entries, list):
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            if int(entry.get("pr_number") or entry.get("number") or 0) == pr_number:
+                return entry
+        if len(entries) == 1 and isinstance(entries[0], dict):
+            return entries[0]
+    return packet if int(packet.get("pr_number") or packet.get("number") or 0) == pr_number else {}
+
+
+def summarize_merge_packet(packet: dict[str, Any] | None, pr_number: int) -> MergePacketSummary:
+    """Extract the small packet view needed for guarded settlement prompts."""
+    if not packet:
+        return MergePacketSummary(
+            available=False,
+            admin_squash_allowed=False,
+            not_ready=[],
+            verdict="missing_merge_packet",
+        )
+    entry = _merge_packet_entry(packet, pr_number)
+    raw_not_ready = packet.get("not_ready")
+    not_ready: list[Any] = raw_not_ready if isinstance(raw_not_ready, list) else []
+    entry_allowed = bool(entry.get("admin_squash_allowed"))
+    top_allowed = bool(packet.get("admin_squash_allowed"))
+    admin_order = packet.get("admin_squash_order")
+    order_allows = isinstance(admin_order, list) and pr_number in admin_order
+    return MergePacketSummary(
+        available=True,
+        admin_squash_allowed=(entry_allowed or top_allowed or order_allows) and not not_ready,
+        not_ready=not_ready,
+        head_sha=str(entry.get("head_sha") or entry.get("headRefOid") or "") or None,
+        status=str(entry.get("status") or ""),
+        verdict=str(entry.get("verdict") or ""),
+    )
 
 
 def check_identity(check: dict[str, Any]) -> str:
@@ -518,6 +672,93 @@ def _derive_action(
     return "green"
 
 
+def build_settlement_guard(
+    *,
+    required_checks: list[CheckRow],
+    full_rollup_checks: list[CheckRow],
+    merge_packet_summary: MergePacketSummary,
+) -> SettlementGuard:
+    """Build the fail-closed settlement guard from direct checks and packet."""
+    required_non_green = [row for row in required_checks if not _is_row_green(row)]
+    full_rollup_pending = [row for row in full_rollup_checks if _is_row_pending(row)]
+    full_rollup_non_green = [
+        row for row in full_rollup_checks if not _is_row_green(row) and not _is_row_pending(row)
+    ]
+    quorum_candidates = [
+        row for row in required_non_green if _is_merge_quorum_row(row) and _is_row_cancelled(row)
+    ]
+    stale_merge_quorum = quorum_candidates[0] if len(quorum_candidates) == 1 else None
+    only_required_blocker_is_quorum = (
+        stale_merge_quorum is not None and len(required_non_green) == 1
+    )
+    full_non_green_without_quorum = [
+        row
+        for row in full_rollup_non_green
+        if not (_is_merge_quorum_row(row) and _is_row_cancelled(row))
+    ]
+    safe_stale_merge_quorum_rerun = (
+        merge_packet_summary.admin_squash_allowed
+        and only_required_blocker_is_quorum
+        and not full_rollup_pending
+        and not full_non_green_without_quorum
+    )
+
+    blocker = ""
+    if any(_is_row_pending(row) for row in required_non_green):
+        blocker = "required_checks_pending"
+    elif only_required_blocker_is_quorum and full_rollup_pending:
+        blocker = "full_rollup_pending"
+    elif required_non_green and safe_stale_merge_quorum_rerun:
+        blocker = "stale_merge_quorum"
+    elif required_non_green:
+        blocker = "required_checks_failed"
+    elif full_rollup_pending:
+        blocker = "full_rollup_pending"
+    elif full_non_green_without_quorum:
+        blocker = "full_rollup_failed"
+    elif not merge_packet_summary.admin_squash_allowed:
+        blocker = "merge_packet_blocked"
+    else:
+        blocker = "ready_for_operator_authorization"
+
+    return SettlementGuard(
+        direct_required_checks_green=not required_non_green,
+        merge_packet_authorizes=merge_packet_summary.admin_squash_allowed,
+        required_non_green=required_non_green,
+        full_rollup_pending=full_rollup_pending,
+        full_rollup_non_green=full_rollup_non_green,
+        stale_merge_quorum=stale_merge_quorum,
+        safe_stale_merge_quorum_rerun=safe_stale_merge_quorum_rerun,
+        blocker=blocker,
+    )
+
+
+def _derive_settlement_action(
+    *,
+    base_action: str,
+    branch_conflict: bool,
+    guard: SettlementGuard,
+) -> str:
+    """Overlay settlement-specific safety precedence on the base check action."""
+    if guard.blocker == "required_checks_pending":
+        return "monitor_required_checks"
+    if guard.blocker == "required_checks_failed":
+        return "repair_failures"
+    if guard.blocker == "full_rollup_pending":
+        return "monitor_full_rollup"
+    if guard.blocker == "full_rollup_failed":
+        return "repair_failures"
+    if guard.blocker == "stale_merge_quorum":
+        return "rerun_stale_merge_quorum"
+    if branch_conflict:
+        return "diagnose_branch_conflict"
+    if guard.blocker == "ready_for_operator_authorization":
+        return "ready_for_operator_authorization"
+    if guard.blocker == "merge_packet_blocked":
+        return "packet_blocked"
+    return base_action
+
+
 def build_followup_result(
     pr_data: dict[str, Any],
     *,
@@ -526,6 +767,10 @@ def build_followup_result(
     log_summary_by_job: dict[str, list[str]] | None = None,
     wait_run: WaitRunDiagnosis | None = None,
     allow_rerun_commands: bool = False,
+    required_checks: list[dict[str, Any]] | None = None,
+    full_rollup_checks: list[dict[str, Any]] | None = None,
+    merge_packet: dict[str, Any] | None = None,
+    settlement_guard: bool = False,
 ) -> FollowupResult:
     """Build the follow-up decision from already-fetched PR/run data."""
     pr_number = int(pr_data.get("number") or pr_data.get("pr") or 0)
@@ -545,19 +790,44 @@ def build_followup_result(
         checks = [check for check in checks if check.job_id not in waited_job_ids]
         checks.extend(wait_run.jobs)
 
+    branch_conflict = _has_branch_conflict(pr_data)
     action = _derive_action(
         checks,
         wait_run,
         expected_head=expected_head,
         head=head,
-        branch_conflict=_has_branch_conflict(pr_data),
+        branch_conflict=branch_conflict,
     )
+    required_rows = [check_row_from_gh(row) for row in required_checks or []]
+    full_rollup_rows = [check_row_from_gh(row) for row in full_rollup_checks or []]
+    merge_summary = summarize_merge_packet(merge_packet, pr_number) if settlement_guard else None
+    settlement = (
+        build_settlement_guard(
+            required_checks=required_rows,
+            full_rollup_checks=full_rollup_rows,
+            merge_packet_summary=merge_summary,
+        )
+        if settlement_guard and merge_summary is not None
+        else None
+    )
+    if settlement and action not in {"head_drift", "stale_wait_run"}:
+        action = _derive_settlement_action(
+            base_action=action,
+            branch_conflict=branch_conflict,
+            guard=settlement,
+        )
     rerun_commands = [
         check.rerun_command
         for check in checks
         if check.classification == "early_cancelled" and check.rerun_command
     ]
+    if settlement and action == "rerun_stale_merge_quorum" and settlement.stale_merge_quorum:
+        rerun_command = _rerun_command_for_row(settlement.stale_merge_quorum)
+        rerun_commands = [rerun_command] if rerun_command else []
     if not allow_rerun_commands or action != "rerun_cancelled":
+        if action != "rerun_stale_merge_quorum":
+            rerun_commands = []
+    if action == "rerun_stale_merge_quorum" and not allow_rerun_commands:
         rerun_commands = []
 
     prompt = build_prompt(
@@ -568,6 +838,10 @@ def build_followup_result(
         checks=checks,
         rerun_commands=rerun_commands,
         wait_run=wait_run,
+        required_checks=required_rows,
+        full_rollup_checks=full_rollup_rows,
+        merge_packet_summary=merge_summary,
+        settlement_guard=settlement,
     )
     return FollowupResult(
         pr=pr_number,
@@ -580,6 +854,10 @@ def build_followup_result(
         rerun_commands=rerun_commands,
         prompt=prompt,
         wait_run=wait_run,
+        required_checks=required_rows,
+        full_rollup_checks=full_rollup_rows,
+        merge_packet_summary=merge_summary,
+        settlement_guard=settlement,
     )
 
 
@@ -592,6 +870,10 @@ def build_prompt(
     checks: list[CheckDiagnosis],
     rerun_commands: list[str],
     wait_run: WaitRunDiagnosis | None = None,
+    required_checks: list[CheckRow] | None = None,
+    full_rollup_checks: list[CheckRow] | None = None,
+    merge_packet_summary: MergePacketSummary | None = None,
+    settlement_guard: SettlementGuard | None = None,
 ) -> str:
     """Render the recursive best-next prompt."""
     lines = [
@@ -639,6 +921,41 @@ def build_prompt(
         lines.extend(
             [
                 f"Goal: monitor #{pr_number} at head {pin} until checks settle. Do not merge, rerun, push, edit files, start cleanup, or start broader queue settlement.",
+                "",
+            ]
+        )
+    elif action == "monitor_required_checks":
+        lines.extend(
+            [
+                f"Goal: monitor #{pr_number} at head {pin} until direct required checks settle. Do not merge, rerun, push, edit files, start cleanup, or start broader queue settlement.",
+                "",
+            ]
+        )
+    elif action == "monitor_full_rollup":
+        lines.extend(
+            [
+                f"Goal: monitor #{pr_number} at head {pin} until full-rollup checks settle. Do not merge, rerun, push, edit files, start cleanup, or start broader queue settlement.",
+                "",
+            ]
+        )
+    elif action == "rerun_stale_merge_quorum":
+        lines.extend(
+            [
+                f"Goal: rerun only the current-head stale/cancelled aragora-merge-quorum job for #{pr_number} at head {pin}, then watch required checks settle. Do not merge, push, edit files, start cleanup, or touch unrelated PRs/files.",
+                "",
+            ]
+        )
+    elif action == "ready_for_operator_authorization":
+        lines.extend(
+            [
+                f"Goal: request explicit exact-head operator authorization for #{pr_number} at head {pin}. Do not merge in this run unless a later prompt gives exact-head authorization.",
+                "",
+            ]
+        )
+    elif action == "packet_blocked":
+        lines.extend(
+            [
+                f"Goal: classify #{pr_number}'s merge-packet blocker at head {pin} after direct checks passed. Do not merge, rerun, push, edit files, start cleanup, or start broader queue settlement.",
                 "",
             ]
         )
@@ -698,6 +1015,27 @@ def build_prompt(
                 lines.append(f"  log: {item}")
         lines.append("")
 
+    if settlement_guard:
+        lines.append("Settlement guard state:")
+        if settlement_guard.required_non_green:
+            lines.append("Direct required checks are still pending/failing:")
+            for row in settlement_guard.required_non_green:
+                lines.append(f"- {row.workflow} / {row.name}: {row.bucket or row.state}")
+        else:
+            lines.append("- Direct required checks: green/green-equivalent")
+        if settlement_guard.full_rollup_pending:
+            lines.append("Full-rollup pending checks:")
+            for row in settlement_guard.full_rollup_pending:
+                lines.append(f"- {row.workflow} / {row.name}: {row.bucket or row.state}")
+        if merge_packet_summary:
+            packet_status = (
+                "authorizes"
+                if merge_packet_summary.admin_squash_allowed
+                else f"blocked ({merge_packet_summary.verdict or 'unknown'})"
+            )
+            lines.append(f"- Merge-packet: {packet_status}")
+        lines.append("")
+
     if action == "repair_failures":
         lines.append(
             "Repair only the real failed checks. Do not rerun cancelled rows until the substantive failures are green."
@@ -731,6 +1069,45 @@ def build_prompt(
         )
     elif action == "monitor":
         lines.append("If checks are still in progress, report exact names and stop.")
+    elif action == "monitor_required_checks":
+        lines.append(
+            "If direct required checks are still pending/failing, report the exact names and stop. Do not use merge-packet authorization while direct checks disagree."
+        )
+    elif action == "monitor_full_rollup":
+        lines.append(
+            "If full-rollup checks are still pending, wait only for those checks to settle before diagnosing or rerunning aragora-merge-quorum."
+        )
+    elif action == "rerun_stale_merge_quorum" and rerun_commands:
+        lines.append("Run only this stale/cancelled quorum rerun command:")
+        for command in rerun_commands:
+            lines.append(f"- {command}")
+        lines.append(
+            "Then watch required checks and rerun review-queue merge-packet. Do not merge."
+        )
+    elif action == "rerun_stale_merge_quorum":
+        lines.append(
+            "Only stale/cancelled aragora-merge-quorum remains, but the rerun command was withheld. Re-run the helper with --allow-rerun-commands or --rerun-stale-merge-quorum-once when explicitly authorized."
+        )
+    elif action == "ready_for_operator_authorization":
+        lines.extend(
+            [
+                "Exact operator authorization prompt:",
+                f"I explicitly authorize exact-head admin squash merge for PR #{pr_number} at head {pin} if live gates still pass.",
+                "",
+                "Run root status, active-session conflicts, identify_lane_owner for the PR and branch, gh pr view/checks, and merge-packet.",
+                "",
+                f"Proceed only if #{pr_number} is unowned, open, non-draft, exact-head stable, required checks are green, merge-packet says admin_squash_allowed=true with not_ready=[], and unresolved_dissent=false.",
+                "",
+                "If clean, merge exactly:",
+                f"gh pr merge {pr_number} --squash --admin --match-head-commit {pin}",
+                "",
+                "Then record settlement and rerun merge-packet. Do not touch unrelated surfaces.",
+            ]
+        )
+    elif action == "packet_blocked":
+        lines.append(
+            "Direct checks are green, but merge-packet does not authorize settlement. Report the exact packet blocker and do not merge."
+        )
     elif action == "green":
         lines.append(
             f"If #{pr_number} remains green/green-equivalent, run review-queue merge-packet for the PR. Do not merge."
@@ -754,6 +1131,23 @@ def build_prompt(
 def _run_gh_json(args: list[str]) -> dict[str, Any]:
     completed = subprocess.run(args, check=True, text=True, capture_output=True)
     return json.loads(completed.stdout)
+
+
+def _run_json_allow_pending(args: list[str]) -> Any:
+    """Run a JSON command, accepting ``gh pr checks`` exit code 8 for pending checks."""
+    completed = subprocess.run(args, check=False, text=True, capture_output=True)
+    if completed.returncode not in {0, 8}:
+        raise subprocess.CalledProcessError(
+            completed.returncode,
+            args,
+            output=completed.stdout,
+            stderr=completed.stderr,
+        )
+    return json.loads(completed.stdout or "[]")
+
+
+def _run_command(command: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(shlex.split(command), check=False, text=True, capture_output=True)
 
 
 def _run_gh_log(args: list[str]) -> str:
@@ -788,6 +1182,41 @@ def wait_for_run(
         time.sleep(max(0.0, poll_interval_seconds))
 
 
+def fetch_pr_checks_rows(pr_number: int, *, required: bool) -> list[dict[str, Any]]:
+    """Fetch PR checks through ``gh pr checks`` while preserving pending rows."""
+    args = [
+        "gh",
+        "pr",
+        "checks",
+        str(pr_number),
+        "--watch=false",
+        "--json",
+        "name,state,bucket,workflow,link",
+    ]
+    if required:
+        args.insert(4, "--required")
+    rows = _run_json_allow_pending(args)
+    return [row for row in rows if isinstance(row, dict)] if isinstance(rows, list) else []
+
+
+def wait_for_full_rollup_checks(
+    pr_number: int,
+    *,
+    poll_interval_seconds: float,
+    timeout_seconds: float,
+) -> tuple[list[dict[str, Any]], bool]:
+    """Poll full PR checks until no rows are pending or timeout expires."""
+    deadline = time.monotonic() + max(0.0, timeout_seconds)
+    latest: list[dict[str, Any]] = []
+    while True:
+        latest = fetch_pr_checks_rows(pr_number, required=False)
+        if not any(_is_row_pending(check_row_from_gh(row)) for row in latest):
+            return latest, False
+        if time.monotonic() >= deadline:
+            return latest, True
+        time.sleep(max(0.0, poll_interval_seconds))
+
+
 def _fetch_logs_for_failed_jobs(run_id: str, run_data: dict[str, Any]) -> dict[str, list[str]]:
     summaries: dict[str, list[str]] = {}
     for job in run_data.get("jobs") or []:
@@ -813,6 +1242,9 @@ def fetch_live_result(
     allow_rerun_commands: bool,
     wait_run_id: str | None = None,
     wait_check: str | None = None,
+    settlement_guard: bool = False,
+    wait_full_rollup: bool = False,
+    rerun_stale_merge_quorum_once: bool = False,
     wait_interval_seconds: float = 180.0,
     wait_timeout_seconds: float = 1800.0,
 ) -> FollowupResult:
@@ -831,6 +1263,10 @@ def fetch_live_result(
     run_data_by_id: dict[str, dict[str, Any]] = {}
     log_summary_by_job: dict[str, list[str]] = {}
     wait_run: WaitRunDiagnosis | None = None
+    required_checks: list[dict[str, Any]] = []
+    full_rollup_checks: list[dict[str, Any]] = []
+    merge_packet: dict[str, Any] | None = None
+    rerun_attempt: RerunAttempt | None = None
 
     if wait_run_id is None and wait_check:
         wait_run_id = wait_check_run_id(pr_data, wait_check)
@@ -882,14 +1318,66 @@ def fetch_live_result(
             except subprocess.CalledProcessError:
                 log_summary_by_job[diagnosis.job_id] = ["failed to fetch job log"]
 
-    return build_followup_result(
+    if settlement_guard:
+        required_checks = fetch_pr_checks_rows(pr_number, required=True)
+        if wait_full_rollup:
+            full_rollup_checks, _timed_out = wait_for_full_rollup_checks(
+                pr_number,
+                poll_interval_seconds=wait_interval_seconds,
+                timeout_seconds=wait_timeout_seconds,
+            )
+        else:
+            full_rollup_checks = fetch_pr_checks_rows(pr_number, required=False)
+        merge_packet = _run_gh_json(
+            [
+                sys.executable,
+                "-m",
+                "aragora.cli.main",
+                "review-queue",
+                "merge-packet",
+                "--pr",
+                str(pr_number),
+                "--json",
+            ]
+        )
+
+    result = build_followup_result(
         pr_data,
         expected_head=expected_head,
         run_data_by_id=run_data_by_id,
         log_summary_by_job=log_summary_by_job,
         wait_run=wait_run,
-        allow_rerun_commands=allow_rerun_commands,
+        allow_rerun_commands=allow_rerun_commands or rerun_stale_merge_quorum_once,
+        required_checks=required_checks,
+        full_rollup_checks=full_rollup_checks,
+        merge_packet=merge_packet,
+        settlement_guard=settlement_guard,
     )
+    if rerun_stale_merge_quorum_once:
+        command = (
+            result.rerun_commands[0]
+            if result.action == "rerun_stale_merge_quorum" and result.rerun_commands
+            else None
+        )
+        if command:
+            completed = _run_command(command)
+            rerun_attempt = RerunAttempt(
+                requested=True,
+                executed=True,
+                command=command,
+                returncode=completed.returncode,
+                stdout=completed.stdout,
+                stderr=completed.stderr,
+                reason="executed stale/cancelled aragora-merge-quorum rerun",
+            )
+        else:
+            rerun_attempt = RerunAttempt(
+                requested=True,
+                executed=False,
+                reason=f"rerun not safe for action {result.action}",
+            )
+        result.rerun_attempt = rerun_attempt
+    return result
 
 
 def _result_to_json(result: FollowupResult) -> str:
@@ -923,6 +1411,21 @@ def build_arg_parser() -> argparse.ArgumentParser:
         help="Poll the run for an in-progress status check selected as 'Workflow/Check name'",
     )
     parser.add_argument(
+        "--settlement-guard",
+        action="store_true",
+        help="Fetch direct required checks and merge-packet before surfacing settlement prompts",
+    )
+    parser.add_argument(
+        "--wait-full-rollup",
+        action="store_true",
+        help="Poll full PR check rollup until no rows remain pending before deciding",
+    )
+    parser.add_argument(
+        "--rerun-stale-merge-quorum-once",
+        action="store_true",
+        help="Mutating opt-in: rerun exactly one safe stale/cancelled aragora-merge-quorum job",
+    )
+    parser.add_argument(
         "--wait-interval-seconds",
         type=float,
         default=180.0,
@@ -946,6 +1449,9 @@ def main(argv: list[str] | None = None) -> int:
         allow_rerun_commands=args.allow_rerun_commands,
         wait_run_id=args.wait_run,
         wait_check=args.wait_check,
+        settlement_guard=args.settlement_guard,
+        wait_full_rollup=args.wait_full_rollup,
+        rerun_stale_merge_quorum_once=args.rerun_stale_merge_quorum_once,
         wait_interval_seconds=args.wait_interval_seconds,
         wait_timeout_seconds=args.wait_timeout_seconds,
     )

--- a/tests/scripts/test_pr_check_followup.py
+++ b/tests/scripts/test_pr_check_followup.py
@@ -444,3 +444,214 @@ def test_green_conflicting_pr_emits_branch_conflict_prompt() -> None:
     assert result.action == "diagnose_branch_conflict"
     assert "branch conflict" in result.prompt
     assert "Do not merge" in result.prompt
+
+
+def _required_check(
+    name: str,
+    bucket: str,
+    *,
+    workflow: str = "Tests",
+    state: str | None = None,
+    run_id: str = "123",
+    job_id: str = "456",
+) -> dict[str, str]:
+    return {
+        "name": name,
+        "bucket": bucket,
+        "state": state or bucket.upper(),
+        "workflow": workflow,
+        "link": f"https://github.com/synaptent/aragora/actions/runs/{run_id}/job/{job_id}",
+    }
+
+
+def _merge_packet(
+    *,
+    allowed: bool = True,
+    not_ready: list[int] | None = None,
+    head: str = "head-sha",
+) -> dict[str, Any]:
+    return {
+        "entries": [
+            {
+                "pr_number": 7443,
+                "head_sha": head,
+                "admin_squash_allowed": allowed,
+                "status": "satisfied" if allowed else "repair_or_wait",
+                "verdict": "admin_squash_allowed" if allowed else "not_ready_for_settlement",
+            }
+        ],
+        "admin_squash_order": [7443] if allowed else [],
+        "not_ready": not_ready or [],
+    }
+
+
+def test_settlement_guard_required_pending_blocks_packet_authorization() -> None:
+    result = followup.build_followup_result(
+        _pr([_check("Tests", "Type Check", "SUCCESS")]),
+        required_checks=[
+            _required_check("aragora-merge-quorum", "pending", workflow="Aragora Merge Quorum"),
+        ],
+        merge_packet=_merge_packet(allowed=True),
+        settlement_guard=True,
+    )
+
+    assert result.action == "monitor_required_checks"
+    assert result.rerun_commands == []
+    assert result.settlement_guard is not None
+    assert result.settlement_guard.direct_required_checks_green is False
+    assert "required checks are still pending/failing" in result.prompt
+    assert "admin squash merge" not in result.prompt
+
+
+def test_settlement_guard_full_rollup_pending_blocks_stale_quorum_rerun() -> None:
+    result = followup.build_followup_result(
+        _pr([_check("Aragora Merge Quorum", "aragora-merge-quorum", "CANCELLED")]),
+        required_checks=[
+            _required_check(
+                "aragora-merge-quorum",
+                "cancel",
+                workflow="Aragora Merge Quorum",
+                state="CANCELLED",
+                run_id="77",
+                job_id="88",
+            ),
+        ],
+        full_rollup_checks=[
+            _required_check(
+                "aragora-merge-quorum",
+                "cancel",
+                workflow="Aragora Merge Quorum",
+                state="CANCELLED",
+                run_id="77",
+                job_id="88",
+            ),
+            _required_check("Baseline Determinism", "pending", workflow="Tests"),
+        ],
+        merge_packet=_merge_packet(allowed=True),
+        settlement_guard=True,
+        allow_rerun_commands=True,
+    )
+
+    assert result.action == "monitor_full_rollup"
+    assert result.rerun_commands == []
+    assert "Baseline Determinism" in result.prompt
+    assert "gh run rerun" not in result.prompt
+
+
+def test_settlement_guard_safe_stale_quorum_emits_rerun_only_when_allowed() -> None:
+    result = followup.build_followup_result(
+        _pr([_check("Aragora Merge Quorum", "aragora-merge-quorum", "CANCELLED")]),
+        required_checks=[
+            _required_check(
+                "aragora-merge-quorum",
+                "cancel",
+                workflow="Aragora Merge Quorum",
+                state="CANCELLED",
+                run_id="77",
+                job_id="88",
+            ),
+        ],
+        full_rollup_checks=[
+            _required_check(
+                "aragora-merge-quorum",
+                "cancel",
+                workflow="Aragora Merge Quorum",
+                state="CANCELLED",
+                run_id="77",
+                job_id="88",
+            ),
+            _required_check("Type Check", "pass", workflow="Tests"),
+        ],
+        merge_packet=_merge_packet(allowed=True),
+        settlement_guard=True,
+        allow_rerun_commands=False,
+    )
+    allowed = followup.build_followup_result(
+        _pr([_check("Aragora Merge Quorum", "aragora-merge-quorum", "CANCELLED")]),
+        required_checks=[
+            _required_check(
+                "aragora-merge-quorum",
+                "cancel",
+                workflow="Aragora Merge Quorum",
+                state="CANCELLED",
+                run_id="77",
+                job_id="88",
+            ),
+        ],
+        full_rollup_checks=[
+            _required_check(
+                "aragora-merge-quorum",
+                "cancel",
+                workflow="Aragora Merge Quorum",
+                state="CANCELLED",
+                run_id="77",
+                job_id="88",
+            ),
+            _required_check("Type Check", "pass", workflow="Tests"),
+        ],
+        merge_packet=_merge_packet(allowed=True),
+        settlement_guard=True,
+        allow_rerun_commands=True,
+    )
+
+    assert result.action == "rerun_stale_merge_quorum"
+    assert result.rerun_commands == []
+    assert allowed.action == "rerun_stale_merge_quorum"
+    assert allowed.rerun_commands == ["gh run rerun 77 --job 88"]
+
+
+def test_settlement_guard_real_non_quorum_failure_repairs_not_reruns() -> None:
+    result = followup.build_followup_result(
+        _pr([_check("Tests", "Type Check", "FAILURE")]),
+        required_checks=[_required_check("Type Check", "fail", workflow="Tests")],
+        full_rollup_checks=[_required_check("Type Check", "fail", workflow="Tests")],
+        merge_packet=_merge_packet(allowed=True),
+        settlement_guard=True,
+        allow_rerun_commands=True,
+    )
+
+    assert result.action == "repair_failures"
+    assert result.rerun_commands == []
+    assert "Repair only the real failed checks" in result.prompt
+
+
+def test_settlement_guard_green_checks_and_packet_authorized_prompts_operator_auth() -> None:
+    result = followup.build_followup_result(
+        _pr([_check("Tests", "Type Check", "SUCCESS")]),
+        required_checks=[_required_check("Type Check", "pass", workflow="Tests")],
+        full_rollup_checks=[_required_check("Type Check", "pass", workflow="Tests")],
+        merge_packet=_merge_packet(allowed=True),
+        settlement_guard=True,
+    )
+
+    assert result.action == "ready_for_operator_authorization"
+    assert result.settlement_guard is not None
+    assert result.settlement_guard.merge_packet_authorizes is True
+    assert "I explicitly authorize exact-head admin squash merge for PR #7443" in result.prompt
+    assert "gh pr merge 7443 --squash --admin --match-head-commit head-sha" in result.prompt
+
+
+def test_pr_checks_exit_code_8_still_parses_pending_stdout(monkeypatch: Any) -> None:
+    completed = followup.subprocess.CompletedProcess(
+        args=["gh", "pr", "checks"],
+        returncode=8,
+        stdout='[{"name":"Type Check","bucket":"pending","state":"IN_PROGRESS","workflow":"Tests","link":""}]',
+        stderr="checks pending",
+    )
+
+    def fake_run(*args: Any, **kwargs: Any) -> Any:
+        return completed
+
+    monkeypatch.setattr(followup.subprocess, "run", fake_run)
+
+    rows = followup._run_json_allow_pending(["gh", "pr", "checks", "7443"])
+
+    assert rows == [
+        {
+            "name": "Type Check",
+            "bucket": "pending",
+            "state": "IN_PROGRESS",
+            "workflow": "Tests",
+            "link": "",
+        }
+    ]


### PR DESCRIPTION
## Summary
- add a settlement guard path to `scripts/pr_check_followup.py` that combines direct required checks, full rollup state, and merge-packet readiness before surfacing settlement prompts
- identify exactly one safe stale/cancelled `aragora-merge-quorum` rerun only when direct checks and merge-packet make that safe
- cover the new settlement-aware guard and rerun behavior in `tests/scripts/test_pr_check_followup.py`

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/scripts/test_pr_check_followup.py -q -p no:rerunfailures -p no:cacheprovider`
- `python3 -m ruff check scripts/pr_check_followup.py tests/scripts/test_pr_check_followup.py`
- `python3 -m ruff format --check scripts/pr_check_followup.py tests/scripts/test_pr_check_followup.py`
- `git diff --check -- scripts/pr_check_followup.py tests/scripts/test_pr_check_followup.py`
- `python3 scripts/pr_check_followup.py --help`

## Notes
- Normal pre-push hooks passed except `mypy-baseline`, which was skipped on push after it reported `new: 0` errors but requested unrelated baseline/metrics sync because this branch resolves existing violations.
