### PR TITLE
fix(scripts): type post-merge audit provider

### DIFF
--- a/scripts/auto_merge_bucket_a.py
+++ b/scripts/auto_merge_bucket_a.py
@@ -657,11 +657,18 @@ def decide(
         )
     merger = merger or gh_pr_merge_squash
     if post_merge_lane_audit_provider is None:
-        post_merge_lane_audit_provider = lambda pr, audit_apply=False: run_post_merge_lane_audit(
-            pr,
-            repo_root=REPO_ROOT,
-            apply=audit_apply,
-        )
+
+        def default_post_merge_lane_audit_provider(
+            pr: int,
+            audit_apply: bool = False,
+        ) -> dict[str, Any]:
+            return run_post_merge_lane_audit(
+                pr,
+                repo_root=REPO_ROOT,
+                apply=audit_apply,
+            )
+
+        post_merge_lane_audit_provider = default_post_merge_lane_audit_provider
 
     decisions: list[MergeDecision] = []
     tripwire_exit = 0


### PR DESCRIPTION
## Summary

Removes a pre-existing mypy-baseline drift blocker in `scripts/auto_merge_bucket_a.py` by replacing an untyped default lambda with a typed local function.

Why this matters: normal pre-push blocked unrelated product branches with `scripts/auto_merge_bucket_a.py:660: error: Cannot infer type of lambda [misc]`, even when those branches did not touch this file. This keeps the mypy gate useful while removing false friction from product-proof PRs.

## Validation

- `python scripts/ci/mypy_with_baseline.py scripts/auto_merge_bucket_a.py --config-file=pyproject.toml --ignore-missing-imports` -> no new errors.
- `pytest tests/scripts/test_auto_merge_bucket_a.py -q` -> 88 passed.
- `python3 -m ruff check scripts/auto_merge_bucket_a.py` -> passed.
- `python3 -m ruff format --check scripts/auto_merge_bucket_a.py` -> passed.
- `git diff --check` -> passed.
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> passed.
- Normal `git push` pre-push hooks passed, including `mypy (baseline-filtered)`.
