### PR TITLE
guard shared root checkout hygiene

### DIFF
--- a/docs/runbooks/RUNBOOK_ROOT_GUARD_HYGIENE.md
+++ b/docs/runbooks/RUNBOOK_ROOT_GUARD_HYGIENE.md
@@ -1,0 +1,43 @@
+# Root Guard Hygiene Runbook
+
+Phase 1 is prevention-only. The guard scripts fail closed and explain why root
+is unsafe for git-mutating work. They do not restore, reset, clean, stash, switch
+branches, edit local automation configuration, or reconcile worktrees.
+
+## Operator Automation Stanza
+
+Apply this stanza to local automation prompts or local `~/.codex/automations/*`
+configuration outside the repository:
+
+> Before any git-mutating action run python3 scripts/assert_not_root_checkout.py and stand down on non-zero. Never git switch/checkout -b/commit/worktree add inside /Users/armand/Development/aragora; always create and cd into a disposable worktree first. At start, run python3 scripts/assert_root_clean_on_main.py; if it fails, do read-only work from a clean worktree and do not mutate the shared root.
+
+This repository change intentionally does not edit local `~/.codex/automations/*`
+files. Operators apply the stanza locally after the PR lands.
+
+## Guards
+
+Use `python3 scripts/assert_not_root_checkout.py` immediately before any
+git-mutating action. It exits:
+
+- `0` when the current git toplevel is a linked or disposable worktree.
+- `3` when the current git toplevel is the canonical shared root checkout.
+- `2` for usage or system errors.
+
+Use `python3 scripts/assert_root_clean_on_main.py` at automation startup. It
+exits:
+
+- `0` only when the canonical shared root is on `main`, has no staged,
+  unstaged, or untracked paths, is not in merge/rebase/cherry-pick state, and
+  local `HEAD == origin/main`.
+- `3` when any root hygiene condition fails.
+- `2` for usage or system errors.
+
+Both scripts support `--json` for machine-readable reports. The canonical root
+defaults to the primary worktree from `git worktree list --porcelain`; override
+with `--canonical-root PATH` or `ARAGORA_CANONICAL_ROOT`.
+
+## Non-Goals
+
+Phase 1 does not implement preserve-first root restoration. A later phase can
+design restoration with active-process checks, index-lock checks, unique commit
+preservation, and explicit operator authorization.

--- a/scripts/assert_not_root_checkout.py
+++ b/scripts/assert_not_root_checkout.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Fail closed when a git-mutating automation is running from shared root.
+
+This guard is intentionally diagnostic only. It never switches branches, stashes,
+cleans, resets, or edits local automation configuration.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from root_guarded_queue import _run  # noqa: E402
+
+
+BLOCKED = "blocked_shared_root"
+OK = "ok_linked_worktree"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Refuse git-mutating work from the canonical shared root checkout.",
+    )
+    parser.add_argument(
+        "--cwd",
+        type=Path,
+        default=None,
+        help="Directory to classify; defaults to the current working directory.",
+    )
+    parser.add_argument(
+        "--canonical-root",
+        type=Path,
+        default=None,
+        help=(
+            "Override the shared root checkout path. Defaults to "
+            "ARAGORA_CANONICAL_ROOT or the primary worktree from git worktree list."
+        ),
+    )
+    parser.add_argument("--json", action="store_true", help="Emit a JSON report.")
+    return parser
+
+
+def _git_toplevel(cwd: Path) -> Path:
+    result = _run(["git", "rev-parse", "--show-toplevel"], cwd=cwd)
+    if result.returncode != 0 or not result.stdout:
+        raise RuntimeError(result.stderr or f"{cwd} is not inside a git worktree")
+    return Path(result.stdout).resolve()
+
+
+def _primary_worktree(cwd: Path) -> Path:
+    result = _run(["git", "worktree", "list", "--porcelain"], cwd=cwd)
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr or "git worktree list failed")
+    for line in result.stdout.splitlines():
+        if line.startswith("worktree "):
+            return Path(line.removeprefix("worktree ")).resolve()
+    raise RuntimeError("git worktree list did not report a primary worktree")
+
+
+def _canonical_root(cwd: Path, override: Path | None) -> Path:
+    if override is not None:
+        return override.resolve()
+    env_root = os.environ.get("ARAGORA_CANONICAL_ROOT")
+    if env_root:
+        return Path(env_root).resolve()
+    return _primary_worktree(cwd)
+
+
+def check_not_root_checkout(args: argparse.Namespace) -> dict[str, Any]:
+    cwd = (args.cwd or Path.cwd()).resolve()
+    repo_root = _git_toplevel(cwd)
+    canonical_root = _canonical_root(repo_root, args.canonical_root)
+    is_shared_root = repo_root == canonical_root
+    reasons = ["current git toplevel is the shared root checkout"] if is_shared_root else []
+    return {
+        "version": "assert_not_root_checkout.v1",
+        "ok": not is_shared_root,
+        "status": BLOCKED if is_shared_root else OK,
+        "cwd": str(cwd),
+        "repo_root": str(repo_root),
+        "canonical_root": str(canonical_root),
+        "reasons": reasons,
+    }
+
+
+def _print_text(report: dict[str, Any]) -> None:
+    if report["ok"]:
+        print(f"OK: {report['repo_root']} is not the shared root checkout")
+        return
+    print(f"BLOCKED: {report['repo_root']} is the shared root checkout")
+    for reason in report["reasons"]:
+        print(f"- {reason}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        report = check_not_root_checkout(args)
+    except Exception as exc:  # pragma: no cover - exercised by CLI/system failures
+        report = {
+            "version": "assert_not_root_checkout.v1",
+            "ok": False,
+            "status": "error",
+            "cwd": str((args.cwd or Path.cwd()).resolve()),
+            "canonical_root": str(args.canonical_root.resolve()) if args.canonical_root else None,
+            "reasons": [str(exc)],
+        }
+        if args.json:
+            print(json.dumps(report, indent=2, sort_keys=True))
+        else:
+            print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        _print_text(report)
+    return 0 if report["ok"] else 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/assert_root_clean_on_main.py
+++ b/scripts/assert_root_clean_on_main.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Fail closed unless the shared root is clean on local origin/main.
+
+This guard reads local git state only. It does not fetch, reset, restore, clean,
+stash, switch branches, or mutate local automation configuration.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from root_guarded_queue import _run, _snapshot  # noqa: E402
+
+
+OK = "ok_clean_on_main"
+BLOCKED = "blocked_root_not_clean_on_main"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Refuse root use unless shared root is clean on local origin/main.",
+    )
+    parser.add_argument(
+        "--canonical-root",
+        type=Path,
+        default=None,
+        help=(
+            "Shared root checkout path. Defaults to ARAGORA_CANONICAL_ROOT or the "
+            "primary worktree from git worktree list."
+        ),
+    )
+    parser.add_argument("--base", default="main", help="Expected branch name.")
+    parser.add_argument("--remote", default="origin", help="Remote name for comparison.")
+    parser.add_argument("--json", action="store_true", help="Emit a JSON report.")
+    return parser
+
+
+def _primary_worktree(cwd: Path) -> Path:
+    result = _run(["git", "worktree", "list", "--porcelain"], cwd=cwd)
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr or "git worktree list failed")
+    for line in result.stdout.splitlines():
+        if line.startswith("worktree "):
+            return Path(line.removeprefix("worktree ")).resolve()
+    raise RuntimeError("git worktree list did not report a primary worktree")
+
+
+def _canonical_root(override: Path | None) -> Path:
+    if override is not None:
+        return override.resolve()
+    env_root = os.environ.get("ARAGORA_CANONICAL_ROOT")
+    if env_root:
+        return Path(env_root).resolve()
+    return _primary_worktree(Path.cwd())
+
+
+def _ref_exists(cwd: Path, ref: str) -> bool:
+    result = _run(["git", "rev-parse", "--verify", "--quiet", ref], cwd=cwd)
+    return result.returncode == 0 and bool(result.stdout)
+
+
+def _git_path_exists(cwd: Path, name: str) -> bool:
+    result = _run(["git", "rev-parse", "--git-path", name], cwd=cwd)
+    if result.returncode != 0 or not result.stdout:
+        return False
+    git_path = Path(result.stdout)
+    if not git_path.is_absolute():
+        git_path = cwd / git_path
+    return git_path.exists()
+
+
+def _operation_state_reasons(cwd: Path) -> list[str]:
+    reasons: list[str] = []
+    for name in ("MERGE_HEAD", "REBASE_HEAD", "CHERRY_PICK_HEAD", "REVERT_HEAD"):
+        if _git_path_exists(cwd, name):
+            reasons.append(f"merge/rebase/cherry-pick state present: {name}")
+    for name in ("rebase-merge", "rebase-apply"):
+        if _git_path_exists(cwd, name):
+            reasons.append(f"merge/rebase/cherry-pick state present: {name}")
+    return reasons
+
+
+def _rev_parse(cwd: Path, ref: str) -> str | None:
+    result = _run(["git", "rev-parse", ref], cwd=cwd)
+    if result.returncode != 0 or not result.stdout:
+        return None
+    return result.stdout
+
+
+def _ahead_behind(cwd: Path, left_ref: str, right_ref: str) -> tuple[int, int] | None:
+    result = _run(
+        ["git", "rev-list", "--left-right", "--count", f"{left_ref}...{right_ref}"],
+        cwd=cwd,
+    )
+    if result.returncode != 0 or not result.stdout:
+        return None
+    left, right = result.stdout.split()
+    return int(left), int(right)
+
+
+def check_root_clean_on_main(args: argparse.Namespace) -> dict[str, Any]:
+    canonical_root = _canonical_root(args.canonical_root)
+    snapshot = _snapshot(canonical_root)
+    base_ref = f"{args.remote}/{args.base}"
+    reasons: list[str] = []
+
+    if snapshot.branch != args.base:
+        reasons.append(f"branch is {snapshot.branch}, expected {args.base}")
+    if snapshot.dirty_paths:
+        reasons.append(f"dirty root: {', '.join(snapshot.dirty_paths)}")
+    reasons.extend(_operation_state_reasons(canonical_root))
+
+    base_head: str | None = None
+    if not _ref_exists(canonical_root, base_ref):
+        reasons.append(f"missing ref {base_ref}")
+    else:
+        base_head = _rev_parse(canonical_root, base_ref)
+        if snapshot.head != base_head:
+            counts = _ahead_behind(canonical_root, "HEAD", base_ref)
+            if counts is None:
+                reasons.append(f"HEAD differs from {base_ref}")
+            else:
+                ahead, behind = counts
+                reasons.append(f"HEAD differs from {base_ref}: ahead={ahead} behind={behind}")
+
+    ok = not reasons
+    return {
+        "version": "assert_root_clean_on_main.v1",
+        "ok": ok,
+        "status": OK if ok else BLOCKED,
+        "canonical_root": str(canonical_root),
+        "branch": snapshot.branch,
+        "head": snapshot.head,
+        "base_ref": base_ref,
+        "base_head": base_head,
+        "dirty_paths": snapshot.dirty_paths,
+        "status_lines": snapshot.status_lines,
+        "reasons": reasons,
+    }
+
+
+def _print_text(report: dict[str, Any]) -> None:
+    if report["ok"]:
+        print(
+            f"OK: {report['canonical_root']} is clean on {report['branch']} == {report['base_ref']}"
+        )
+        return
+    print(f"BLOCKED: {report['canonical_root']} is not clean on {report['base_ref']}")
+    for reason in report["reasons"]:
+        print(f"- {reason}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        report = check_root_clean_on_main(args)
+    except Exception as exc:  # pragma: no cover - exercised by CLI/system failures
+        report = {
+            "version": "assert_root_clean_on_main.v1",
+            "ok": False,
+            "status": "error",
+            "canonical_root": str(args.canonical_root.resolve()) if args.canonical_root else None,
+            "reasons": [str(exc)],
+        }
+        if args.json:
+            print(json.dumps(report, indent=2, sort_keys=True))
+        else:
+            print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        _print_text(report)
+    return 0 if report["ok"] else 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_assert_not_root_checkout.py
+++ b/tests/scripts/test_assert_not_root_checkout.py
@@ -1,0 +1,100 @@
+"""Tests for ``scripts/assert_not_root_checkout.py``."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _load_module(script_name: str) -> Any:
+    here = Path(__file__).resolve()
+    script_path = here.parents[2] / "scripts" / script_name
+    spec = importlib.util.spec_from_file_location(f"{script_name}_under_test", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load spec for {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+guard = _load_module("assert_not_root_checkout.py")
+
+
+def _run(args: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, cwd=cwd, text=True, capture_output=True, check=False)
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run(["git", "init", "-b", "main"], cwd=repo)
+    _run(["git", "config", "user.name", "Test User"], cwd=repo)
+    _run(["git", "config", "user.email", "test@example.com"], cwd=repo)
+    (repo / "README.md").write_text("hello\n", encoding="utf-8")
+    _run(["git", "add", "README.md"], cwd=repo)
+    _run(["git", "commit", "-m", "init"], cwd=repo)
+    return repo
+
+
+def test_primary_root_checkout_blocks(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+
+    report = guard.check_not_root_checkout(
+        guard.build_parser().parse_args(["--cwd", str(repo), "--canonical-root", str(repo)])
+    )
+
+    assert report["ok"] is False
+    assert report["status"] == "blocked_shared_root"
+    assert report["canonical_root"] == str(repo.resolve())
+    assert report["cwd"] == str(repo.resolve())
+    assert report["reasons"] == ["current git toplevel is the shared root checkout"]
+
+
+def test_linked_worktree_checkout_passes(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    linked = tmp_path / "linked"
+    result = _run(["git", "worktree", "add", str(linked), "-b", "feature"], cwd=repo)
+    assert result.returncode == 0, result.stderr
+
+    report = guard.check_not_root_checkout(
+        guard.build_parser().parse_args(["--cwd", str(linked), "--canonical-root", str(repo)])
+    )
+
+    assert report["ok"] is True
+    assert report["status"] == "ok_linked_worktree"
+    assert report["canonical_root"] == str(repo.resolve())
+    assert report["cwd"] == str(linked.resolve())
+    assert report["reasons"] == []
+
+
+def test_canonical_root_override_is_honored(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    other_root = tmp_path / "other-root"
+    other_root.mkdir()
+
+    report = guard.check_not_root_checkout(
+        guard.build_parser().parse_args(["--cwd", str(repo), "--canonical-root", str(other_root)])
+    )
+
+    assert report["ok"] is True
+    assert report["status"] == "ok_linked_worktree"
+    assert report["canonical_root"] == str(other_root.resolve())
+    assert report["cwd"] == str(repo.resolve())
+
+
+def test_json_output_contains_stable_fields(tmp_path: Path, capsys: Any) -> None:
+    repo = _init_repo(tmp_path)
+
+    exit_code = guard.main(["--cwd", str(repo), "--canonical-root", str(repo), "--json"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 3
+    assert '"ok": false' in captured.out
+    assert '"status": "blocked_shared_root"' in captured.out
+    assert '"canonical_root":' in captured.out
+    assert '"cwd":' in captured.out
+    assert '"reasons":' in captured.out

--- a/tests/scripts/test_assert_root_clean_on_main.py
+++ b/tests/scripts/test_assert_root_clean_on_main.py
@@ -1,0 +1,157 @@
+"""Tests for ``scripts/assert_root_clean_on_main.py``."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _load_module(script_name: str) -> Any:
+    here = Path(__file__).resolve()
+    script_path = here.parents[2] / "scripts" / script_name
+    spec = importlib.util.spec_from_file_location(f"{script_name}_under_test", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load spec for {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+guard = _load_module("assert_root_clean_on_main.py")
+
+
+def _run(args: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, cwd=cwd, text=True, capture_output=True, check=False)
+
+
+def _init_repo_with_origin(tmp_path: Path) -> tuple[Path, Path]:
+    origin = tmp_path / "origin.git"
+    repo = tmp_path / "repo"
+    _run(["git", "init", "--bare", "-b", "main", str(origin)], cwd=tmp_path)
+    repo.mkdir()
+    _run(["git", "init", "-b", "main"], cwd=repo)
+    _run(["git", "config", "user.name", "Test User"], cwd=repo)
+    _run(["git", "config", "user.email", "test@example.com"], cwd=repo)
+    (repo / "README.md").write_text("hello\n", encoding="utf-8")
+    _run(["git", "add", "README.md"], cwd=repo)
+    _run(["git", "commit", "-m", "init"], cwd=repo)
+    _run(["git", "remote", "add", "origin", str(origin)], cwd=repo)
+    push = _run(["git", "push", "-u", "origin", "main"], cwd=repo)
+    assert push.returncode == 0, push.stderr
+    return repo, origin
+
+
+def _commit(repo: Path, filename: str, content: str, message: str) -> None:
+    (repo / filename).write_text(content, encoding="utf-8")
+    _run(["git", "add", filename], cwd=repo)
+    result = _run(["git", "commit", "-m", message], cwd=repo)
+    assert result.returncode == 0, result.stderr
+
+
+def test_clean_main_equal_to_origin_passes(tmp_path: Path) -> None:
+    repo, _origin = _init_repo_with_origin(tmp_path)
+
+    report = guard.check_root_clean_on_main(
+        guard.build_parser().parse_args(["--canonical-root", str(repo)])
+    )
+
+    assert report["ok"] is True
+    assert report["status"] == "ok_clean_on_main"
+    assert report["canonical_root"] == str(repo.resolve())
+    assert report["branch"] == "main"
+    assert report["base_ref"] == "origin/main"
+    assert report["reasons"] == []
+
+
+def test_dirty_untracked_root_fails(tmp_path: Path) -> None:
+    repo, _origin = _init_repo_with_origin(tmp_path)
+    (repo / "dirty.txt").write_text("dirty\n", encoding="utf-8")
+
+    report = guard.check_root_clean_on_main(
+        guard.build_parser().parse_args(["--canonical-root", str(repo)])
+    )
+
+    assert report["ok"] is False
+    assert report["status"] == "blocked_root_not_clean_on_main"
+    assert "dirty root: dirty.txt" in report["reasons"]
+
+
+def test_feature_branch_fails(tmp_path: Path) -> None:
+    repo, _origin = _init_repo_with_origin(tmp_path)
+    _run(["git", "switch", "-c", "feature"], cwd=repo)
+
+    report = guard.check_root_clean_on_main(
+        guard.build_parser().parse_args(["--canonical-root", str(repo)])
+    )
+
+    assert report["ok"] is False
+    assert "branch is feature, expected main" in report["reasons"]
+
+
+def test_missing_origin_main_fails(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run(["git", "init", "-b", "main"], cwd=repo)
+    _run(["git", "config", "user.name", "Test User"], cwd=repo)
+    _run(["git", "config", "user.email", "test@example.com"], cwd=repo)
+    (repo / "README.md").write_text("hello\n", encoding="utf-8")
+    _run(["git", "add", "README.md"], cwd=repo)
+    _run(["git", "commit", "-m", "init"], cwd=repo)
+
+    report = guard.check_root_clean_on_main(
+        guard.build_parser().parse_args(["--canonical-root", str(repo)])
+    )
+
+    assert report["ok"] is False
+    assert "missing ref origin/main" in report["reasons"]
+
+
+def test_root_ahead_of_origin_main_fails(tmp_path: Path) -> None:
+    repo, _origin = _init_repo_with_origin(tmp_path)
+    _commit(repo, "local.txt", "local\n", "local change")
+
+    report = guard.check_root_clean_on_main(
+        guard.build_parser().parse_args(["--canonical-root", str(repo)])
+    )
+
+    assert report["ok"] is False
+    assert "HEAD differs from origin/main: ahead=1 behind=0" in report["reasons"]
+
+
+def test_root_behind_origin_main_fails(tmp_path: Path) -> None:
+    repo, origin = _init_repo_with_origin(tmp_path)
+    clone = tmp_path / "clone"
+    _run(["git", "clone", str(origin), str(clone)], cwd=tmp_path)
+    _run(["git", "config", "user.name", "Test User"], cwd=clone)
+    _run(["git", "config", "user.email", "test@example.com"], cwd=clone)
+    _commit(clone, "remote.txt", "remote\n", "remote change")
+    push = _run(["git", "push", "origin", "main"], cwd=clone)
+    assert push.returncode == 0, push.stderr
+    _run(["git", "fetch", "origin", "main"], cwd=repo)
+
+    report = guard.check_root_clean_on_main(
+        guard.build_parser().parse_args(["--canonical-root", str(repo)])
+    )
+
+    assert report["ok"] is False
+    assert "HEAD differs from origin/main: ahead=0 behind=1" in report["reasons"]
+
+
+def test_merge_state_fails(tmp_path: Path) -> None:
+    repo, _origin = _init_repo_with_origin(tmp_path)
+    merge_head_path = _run(["git", "rev-parse", "--git-path", "MERGE_HEAD"], cwd=repo).stdout
+    merge_head = Path(merge_head_path.strip())
+    if not merge_head.is_absolute():
+        merge_head = repo / merge_head
+    merge_head.write_text("deadbeef\n", encoding="utf-8")
+
+    report = guard.check_root_clean_on_main(
+        guard.build_parser().parse_args(["--canonical-root", str(repo)])
+    )
+
+    assert report["ok"] is False
+    assert "merge/rebase/cherry-pick state present: MERGE_HEAD" in report["reasons"]


### PR DESCRIPTION
## Summary
- add `scripts/assert_not_root_checkout.py` to fail closed before git-mutating work runs from the shared root checkout
- add `scripts/assert_root_clean_on_main.py` to require the canonical root to be clean on local `origin/main` at automation startup
- document the Phase 1 root-guard hygiene operator stanza in `docs/runbooks/RUNBOOK_ROOT_GUARD_HYGIENE.md`

This is prevention/diagnostic only: no restore, reset, clean, stash, branch switch, cleanup, or local automation config mutation is implemented.

Local `~/.codex/automations/*` changes are operator-applied from the runbook stanza; this PR intentionally does not edit those local configs.

## Validation
- `python3 -m pytest tests/scripts/test_assert_not_root_checkout.py tests/scripts/test_assert_root_clean_on_main.py tests/scripts/test_root_guarded_queue.py -q`
- `python3 -m ruff check scripts/assert_not_root_checkout.py scripts/assert_root_clean_on_main.py tests/scripts/test_assert_not_root_checkout.py tests/scripts/test_assert_root_clean_on_main.py`
- `python3 -m ruff format --check scripts/assert_not_root_checkout.py scripts/assert_root_clean_on_main.py tests/scripts/test_assert_not_root_checkout.py tests/scripts/test_assert_root_clean_on_main.py`
- `python3 -m mypy scripts/assert_not_root_checkout.py scripts/assert_root_clean_on_main.py`
- `git diff --check origin/main...HEAD`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
