### PR TITLE
fix(codex-insights): window-scope token metric + anomaly (stop lifetime false-alarms)

### DIFF
--- a/aragora/cli/commands/codex_insights.py
+++ b/aragora/cli/commands/codex_insights.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -74,7 +75,11 @@ def cmd_codex_insights_summary(args: argparse.Namespace) -> int:
         )
         return 0
     print(f"Window:    {since} ({len(pairs)} threads scanned)")
-    print(f"Tokens:    {pattern.total_tokens_used:,}")
+    print(f"Tokens (window-created threads): {pattern.window_created_tokens:,}")
+    print(
+        f"Lifetime tokens (all active threads, NOT window consumption): "
+        f"{pattern.total_tokens_used:,}"
+    )
     print(f"Distinct cwds: {pattern.distinct_cwds}")
     print(
         f"Duration:  p50={pattern.duration_seconds_p50:.1f}s  p95={pattern.duration_seconds_p95:.1f}s"
@@ -106,11 +111,13 @@ def cmd_codex_insights_anomalies(args: argparse.Namespace) -> int:
         include_archived=args.include_archived,
         paths=paths,
     )
+    cutoff = datetime.now(UTC) - since
     anomalies = detect_anomalies(
         pairs,
         token_cap=args.token_cap,
         runaway_tool_calls=args.runaway_tool_calls,
         stuck_turn_minutes=args.stuck_turn_minutes,
+        cutoff=cutoff,
     )
     if args.json:
         _emit_json([a.to_dict() for a in anomalies])

--- a/aragora/codex/insights.py
+++ b/aragora/codex/insights.py
@@ -43,7 +43,14 @@ class SessionPattern:
     archived_excluded: bool
     model_distribution: dict[str, int]
     tool_call_distribution: dict[str, int]
+    # NOTE: ``total_tokens_used`` is the sum of each active thread's *lifetime*
+    # cumulative ``tokens_used`` field, NOT tokens consumed within the analysis
+    # window. A thread last touched in-window but created weeks ago contributes
+    # its entire lifetime total. Use ``window_created_tokens`` for a figure that
+    # approximates in-window consumption (threads created within the window,
+    # whose lifetime total == window consumption). See _split_token_totals.
     total_tokens_used: int
+    window_created_tokens: int
     distinct_cwds: int
     duration_seconds_p50: float
     duration_seconds_p95: float
@@ -171,19 +178,21 @@ def summarize_patterns(
         paths=paths,
     )
     now = datetime.now(UTC)
+    cutoff = now - since
     per_thread: list[tuple[ThreadSummary, SessionSummary]] = []
     tool_call_counts: Counter[str] = Counter()
     model_counts: Counter[str] = Counter()
     durations: list[float] = []
     abandoned = 0
-    total_tokens = 0
     cwds: set[str] = set()
+    scanned_threads: list[ThreadSummary] = []
 
     for thread in threads:
         if not thread.rollout_path.exists():
             continue
         summary = summarize_session(thread.rollout_path, max_events=max_events_per_summary)
         per_thread.append((thread, summary))
+        scanned_threads.append(thread)
         for name, count in summary.tool_call_counts.items():
             tool_call_counts[name] += count
         if thread.model:
@@ -191,9 +200,10 @@ def summarize_patterns(
         durations.append(_session_duration_seconds(summary))
         if _is_abandoned(thread, summary, now=now):
             abandoned += 1
-        total_tokens += thread.tokens_used
         if thread.cwd:
             cwds.add(thread.cwd)
+
+    lifetime_tokens, window_created_tokens = _split_token_totals(scanned_threads, cutoff=cutoff)
 
     pattern = SessionPattern(
         window_seconds=int(since.total_seconds()),
@@ -201,7 +211,8 @@ def summarize_patterns(
         archived_excluded=not include_archived,
         model_distribution=dict(model_counts),
         tool_call_distribution=dict(tool_call_counts),
-        total_tokens_used=total_tokens,
+        total_tokens_used=lifetime_tokens,
+        window_created_tokens=window_created_tokens,
         distinct_cwds=len(cwds),
         duration_seconds_p50=_percentile(durations, 0.5),
         duration_seconds_p95=_percentile(durations, 0.95),
@@ -210,12 +221,28 @@ def summarize_patterns(
     return pattern, per_thread
 
 
+def _split_token_totals(threads: list[ThreadSummary], *, cutoff: datetime) -> tuple[int, int]:
+    """Split token totals into (lifetime, window_created).
+
+    ``tokens_used`` on a ThreadSummary is the thread's *lifetime* cumulative
+    total. Summing it across all window-active threads (``lifetime``) double-
+    counts pre-window history for long-lived threads. ``window_created`` sums
+    only threads created at or after ``cutoff`` — for those, lifetime total
+    equals in-window consumption, so it is the honest "tokens consumed in this
+    window" approximation. Returns ``(lifetime, window_created)``.
+    """
+    lifetime = sum(t.tokens_used for t in threads)
+    window_created = sum(t.tokens_used for t in threads if t.created_at >= cutoff)
+    return lifetime, window_created
+
+
 def detect_anomalies(
     pairs: list[tuple[ThreadSummary, SessionSummary]],
     *,
     token_cap: int = DEFAULT_TOKEN_ANOMALY_THRESHOLD,
     runaway_tool_calls: int = DEFAULT_RUNAWAY_TOOL_CALLS,
     stuck_turn_minutes: int = DEFAULT_STUCK_TURN_MINUTES,
+    cutoff: datetime | None = None,
 ) -> list[Anomaly]:
     """Return a list of anomalies detected across the (thread, summary) pairs.
 
@@ -224,7 +251,15 @@ def detect_anomalies(
       with no recent user turn
     - ``stuck_turn``: last event is ``turn_start`` (or similar) with no
       matching completion and silence exceeds ``stuck_turn_minutes``
-    - ``token_cap_exceeded``: thread.tokens_used > ``token_cap``
+    - ``token_cap_exceeded``: a thread's ``tokens_used`` exceeds ``token_cap``.
+
+    ``cutoff`` window-scopes the ``token_cap_exceeded`` check. ``tokens_used``
+    is a *lifetime* cumulative field, so a months-old thread always exceeds any
+    modest cap regardless of in-window activity (the false-alarm bug). When
+    ``cutoff`` is supplied, the cap is only applied to threads created at or
+    after ``cutoff`` — those whose lifetime total equals their in-window
+    consumption. When ``cutoff`` is ``None`` the legacy behavior (flag any
+    thread over cap) is preserved for backward compatibility.
     """
     now = datetime.now(UTC)
     anomalies: list[Anomaly] = []
@@ -252,15 +287,29 @@ def detect_anomalies(
                 )
             )
 
-        if thread.tokens_used >= token_cap:
+        # token_cap_exceeded is only meaningful for threads whose tokens were
+        # consumed within the window. tokens_used is lifetime-cumulative, so a
+        # cutoff scopes the check to window-created threads (lifetime == window
+        # consumption). cutoff=None preserves legacy unscoped behavior.
+        token_cap_in_scope = cutoff is None or thread.created_at >= cutoff
+        if token_cap_in_scope and thread.tokens_used >= token_cap:
             anomalies.append(
                 Anomaly(
                     thread_id=thread.id,
                     rollout_path=_redacted_path(summary.rollout_path),
                     kind="token_cap_exceeded",
                     severity="medium",
-                    detail=(f"tokens_used={thread.tokens_used} >= cap={token_cap}"),
-                    evidence={"tokens_used": thread.tokens_used, "cap": token_cap},
+                    detail=(
+                        f"tokens_used={thread.tokens_used} >= cap={token_cap} "
+                        f"(thread created in-window)"
+                        if cutoff is not None
+                        else f"tokens_used={thread.tokens_used} >= cap={token_cap}"
+                    ),
+                    evidence={
+                        "tokens_used": thread.tokens_used,
+                        "cap": token_cap,
+                        "window_scoped": cutoff is not None,
+                    },
                 )
             )
 
@@ -396,7 +445,7 @@ def build_digest(
         paths=paths,
         max_events_per_summary=max_events_per_summary,
     )
-    anomalies = detect_anomalies(pairs)
+    anomalies = detect_anomalies(pairs, cutoff=datetime.now(UTC) - since)
     crossref = crossref_work_board(pairs)
     inspector_summaries = tuple(
         {

--- a/tests/codex/test_cli_codex_insights.py
+++ b/tests/codex/test_cli_codex_insights.py
@@ -30,7 +30,11 @@ def test_cli_summary_text(fake_codex_home, capsys: pytest.CaptureFixture[str]) -
     out = capsys.readouterr().out
     assert rc == 0
     assert "Window:" in out
-    assert "Tokens:" in out
+    # Token lines are now explicitly labeled to distinguish window-created
+    # consumption from lifetime-cumulative totals (the prior bare "Tokens:"
+    # label misrepresented lifetime totals as in-window consumption).
+    assert "Tokens (window-created threads):" in out
+    assert "Lifetime tokens" in out
     assert "Tool calls" in out
 
 

--- a/tests/codex/test_insights.py
+++ b/tests/codex/test_insights.py
@@ -126,6 +126,110 @@ def test_detect_anomalies_token_cap_exceeded(tmp_path: Path) -> None:
     assert any(a.kind == "token_cap_exceeded" for a in anomalies)
 
 
+def _thread_with_created(
+    *, id: str, tokens: int, created_at: datetime, rollout: Path
+) -> ThreadSummary:
+    now = datetime.now(UTC)
+    return ThreadSummary(
+        id=id,
+        title="t",
+        cwd="/repo",
+        model="gpt-5.5",
+        rollout_path=rollout,
+        created_at=created_at,
+        updated_at=now,
+        tokens_used=tokens,
+        archived=False,
+        git_sha=None,
+        git_branch="main",
+        source="vscode",
+        first_user_message="x",
+    )
+
+
+def test_token_cap_anomaly_ignores_pre_window_threads(tmp_path: Path) -> None:
+    """REGRESSION: a months-old thread whose LIFETIME tokens exceed the cap
+    must NOT be flagged token_cap_exceeded when a window cutoff is supplied.
+
+    This is the false-alarm bug: tokens_used is a lifetime cumulative field,
+    so a 60-day-old thread always exceeds a 100k cap even if it consumed
+    almost nothing in the analysis window. Scoping to created_at >= cutoff
+    means the cap only applies to threads that genuinely ran in-window
+    (where lifetime tokens == window consumption).
+    """
+    rollout = tmp_path / "old.jsonl"
+    rollout.write_text("{}\n", encoding="utf-8")
+    now = datetime.now(UTC)
+    old_thread = _thread_with_created(
+        id="old", tokens=5_000_000_000, created_at=now - timedelta(days=60), rollout=rollout
+    )
+    summary = _make_summary(rollout, tool_calls={"Read": 1})
+    cutoff = now - timedelta(hours=6)
+    anomalies = insights.detect_anomalies(
+        [(old_thread, summary)],
+        token_cap=100_000,
+        cutoff=cutoff,
+    )
+    assert not any(a.kind == "token_cap_exceeded" for a in anomalies), (
+        "60-day-old thread's lifetime tokens must not trigger token_cap_exceeded "
+        "when a window cutoff is supplied — that is the false-alarm bug."
+    )
+
+
+def test_token_cap_anomaly_flags_window_created_threads(tmp_path: Path) -> None:
+    """A thread CREATED within the window with tokens over cap IS flagged.
+
+    For window-created threads, lifetime tokens == window consumption, so the
+    cap is a meaningful per-run signal.
+    """
+    rollout = tmp_path / "new.jsonl"
+    rollout.write_text("{}\n", encoding="utf-8")
+    now = datetime.now(UTC)
+    new_thread = _thread_with_created(
+        id="new", tokens=999_999, created_at=now - timedelta(minutes=30), rollout=rollout
+    )
+    summary = _make_summary(rollout, tool_calls={"Read": 1})
+    cutoff = now - timedelta(hours=6)
+    anomalies = insights.detect_anomalies(
+        [(new_thread, summary)],
+        token_cap=100_000,
+        cutoff=cutoff,
+    )
+    assert any(a.kind == "token_cap_exceeded" for a in anomalies)
+
+
+def test_token_cap_anomaly_unscoped_without_cutoff_preserves_legacy(tmp_path: Path) -> None:
+    """Back-compat: with no cutoff, behavior is unchanged (flag any over-cap)."""
+    rollout = tmp_path / "any.jsonl"
+    rollout.write_text("{}\n", encoding="utf-8")
+    now = datetime.now(UTC)
+    old_thread = _thread_with_created(
+        id="any", tokens=999_999, created_at=now - timedelta(days=60), rollout=rollout
+    )
+    summary = _make_summary(rollout, tool_calls={"Read": 1})
+    anomalies = insights.detect_anomalies([(old_thread, summary)], token_cap=100_000)
+    assert any(a.kind == "token_cap_exceeded" for a in anomalies)
+
+
+def test_split_token_totals_separates_window_from_lifetime(tmp_path: Path) -> None:
+    """The token split helper distinguishes window-created from lifetime totals."""
+    rollout = tmp_path / "r.jsonl"
+    rollout.write_text("{}\n", encoding="utf-8")
+    now = datetime.now(UTC)
+    cutoff = now - timedelta(hours=6)
+    threads = [
+        _thread_with_created(
+            id="old", tokens=5_000_000_000, created_at=now - timedelta(days=60), rollout=rollout
+        ),
+        _thread_with_created(
+            id="new", tokens=1_000, created_at=now - timedelta(minutes=30), rollout=rollout
+        ),
+    ]
+    lifetime, window_created = insights._split_token_totals(threads, cutoff=cutoff)
+    assert lifetime == 5_000_001_000  # both threads' lifetime totals
+    assert window_created == 1_000  # only the window-created thread
+
+
 def test_detect_anomalies_stuck_turn(tmp_path: Path) -> None:
     rollout = tmp_path / "r.jsonl"
     rollout.write_text("{}\n", encoding="utf-8")


### PR DESCRIPTION
## Summary

`aragora codex insights` summed each thread's **lifetime** cumulative `tokens_used` while filtering threads by `updated_at`, then presented the result as "tokens in window" and flagged `token_cap_exceeded` on it. Because `tokens_used` is lifetime-cumulative, a months-old thread touched once in-window contributed its entire history — producing "billions of tokens in 6h" and ~90 spurious `token_cap_exceeded` anomalies for threads created 1–3 months ago. **This misrepresentation sent a real operator investigation down a false path twice.**

This is honest-accounting only — **no change to actual consumption**, just how it's measured and labeled.

## Changes
- `_split_token_totals(threads, *, cutoff)` → `(lifetime, window_created)`; `window_created` sums only threads created at/after the window cutoff (where lifetime total ≈ in-window consumption).
- `SessionPattern.window_created_tokens` added alongside `total_tokens_used` (now documented as lifetime-cumulative, NOT window consumption).
- `detect_anomalies(..., cutoff=None)`: `token_cap_exceeded` is applied only to threads created at/after `cutoff`. `cutoff=None` preserves legacy unscoped behavior (back-compat).
- CLI + `build_digest` pass `cutoff` so scoping is active in practice; CLI relabels output to "Tokens (window-created threads)" and "Lifetime tokens (all active threads, NOT window consumption)".

Diff: 4 files, +174/-10 (`aragora/codex/insights.py`, `aragora/cli/commands/codex_insights.py`, 2 test files).

## Validation evidence
- `pytest tests/codex/test_insights.py tests/codex/test_cli_codex_insights.py` → **32 passed** (5 new: pre-window thread not flagged, window-created thread flagged, legacy unscoped back-compat, token-split helper; + updated CLI label assertion).
- CI-equivalent touched-file typecheck: `mypy aragora/codex/insights.py aragora/cli/commands/codex_insights.py` → **Success: no issues found**.
- Rebased onto current `main` (post-#7500 baseline resync); branch clean, single commit.

## Hook-exception note (transparency)
This branch was pushed with a **one-time, operator-authorized `--no-verify`**. Rationale: the local `mypy-baseline` pre-push hook is a **non-authoritative local gate** (it is `ci.skip`-ped — "Run separately in CI for better caching") and is currently failing on **pre-existing environment/toolchain drift** unrelated to this change (stale pinned mypy 1.10.0 vs a 1.19.x-synced baseline, isolated-venv missing project deps + type stubs). The change itself is rebased, tested, and CI-clean; **CI remains the enforcement gate** and will run the authoritative mypy check on this PR. The pre-push hook's proper fix (toolchain freeze + baseline resync) is tracked separately as its own infra task and intentionally not bundled here.

## Test plan
- [ ] CI mypy/lint passes on touched files
- [ ] `tests/codex/` suite green in CI
- [ ] Manual: `aragora codex insights summary` shows distinct window-created vs lifetime token lines; `anomalies` no longer flags months-old threads under a modest cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)