### PR TITLE
fix(pre-commit): mirror CI typecheck gate on changed files (unblock local pushes)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,27 +34,34 @@ repos:
         types_or: [python, pyi]
         exclude: ^sdk/python/aragora/generated_types\.py$  # Auto-generated, must stay stable
 
-  # Type checking with mypy (filtered through mypy-baseline).
-  # The repo carries ~4k pre-existing mypy errors tracked in `.mypy-baseline`.
-  # This hook runs mypy against `aragora/` and `scripts/` and fails the push
-  # only on NEW errors — existing debt is accepted. Regenerate the baseline
-  # via: `python scripts/ci/mypy_with_baseline.py --sync` (see
-  # `docs/plans/2026-04-18-mypy-debt-audit.md` for the operator workflow).
+  # Type checking with mypy on CHANGED files — mirrors CI's REQUIRED phase-1
+  # typecheck gate (.github/workflows/lint.yml runs
+  # `mypy --ignore-missing-imports --follow-imports=skip --show-error-codes`
+  # on touched `aragora/**.py` for PR/branch pushes). Passing here ⇒ passing
+  # the required CI typecheck.
+  #
+  # We intentionally do NOT run the full-tree `mypy-baseline` diff on pre-push.
+  # That tier only runs in CI on direct-to-main pushes
+  # (`scripts/ci/mypy_with_baseline.py`) and is `ci.skip`-ped here. Reproducing
+  # its baseline locally is environment-fragile (exact mypy version + every
+  # type-stub version + importable project deps + mypy's incremental cache),
+  # which previously made every local push fail on thousands of phantom "new"
+  # errors in untouched files. `--follow-imports=skip` makes this gate need no
+  # project deps or stubs, so it is robust in any developer environment.
+  #
+  # Run the full baseline check manually when you want it:
+  #   python scripts/ci/mypy_with_baseline.py        # report NEW errors only
+  #   python scripts/ci/mypy_with_baseline.py --sync  # regenerate .mypy-baseline
   - repo: local
     hooks:
-      - id: mypy-baseline
-        name: mypy (baseline-filtered)
-        entry: python scripts/ci/mypy_with_baseline.py
-        language: python
-        pass_filenames: false
-        additional_dependencies:
-          - mypy==1.10.0
-          - mypy-baseline==0.7.4
-          - types-requests
-          - types-python-dateutil
-        # Only trigger when Python files under aragora/ or scripts/ change.
-        # (Full-tree mypy still runs — the filter just gates when it runs.)
-        files: ^(aragora/|scripts/).*\.py$
+      - id: typecheck-changed
+        name: mypy (changed aragora files, mirrors CI typecheck gate)
+        entry: python -m mypy --ignore-missing-imports --follow-imports=skip --show-error-codes
+        language: system
+        # pre-commit passes only the changed, still-existing files matching
+        # `files:` — i.e. the same "touched aragora Python file(s)" CI checks.
+        pass_filenames: true
+        files: ^aragora/.*\.py$
         # Run on pre-push to catch type errors before they hit CI.
         stages: [pre-push]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,8 @@ repos:
   # typecheck gate. Touched `aragora/**.py` files use CI's changed-file mypy
   # flags; CI force-full trigger files run the full typecheck tier locally.
   # CI remains authoritative because it installs the project and computes the
-  # changed-file plan from the PR/branch base.
+  # changed-file plan from the PR/branch base; local pre-push remains a fast
+  # guardrail, not the source of truth.
   #
   # We intentionally do NOT run the manual `mypy_with_baseline.py` helper on
   # pre-push. The required CI workflow uses `scripts/run_typecheck_gate.py` plus
@@ -46,7 +47,7 @@ repos:
   # explicit local baseline filtering or regeneration.
   #
   # This hook runs in an isolated `language: python` env, so pre-commit installs
-  # mypy and the same type stubs as CI — the gate never depends on the
+  # mypy and the same type stubs as CI — the gate does not depend on the
   # developer's active environment having mypy (no "No module named mypy"
   # surprises). The changed-file path uses `--follow-imports=skip` /
   # `--ignore-missing-imports` so it does not need the full project installed.
@@ -60,18 +61,26 @@ repos:
         name: mypy (changed aragora files or full CI trigger)
         entry: >-
           bash -c 'set -euo pipefail;
-          force_full=0;
-          for path in "$@"; do
-            case "$path" in
-              pyproject.toml|.github/workflows/lint.yml|scripts/run_typecheck_gate.py|scripts/test_tiers.sh|requirements*.txt|.github/actions/pr-scope-classifier/*)
-                force_full=1
-                ;;
-            esac
-          done;
-          if [[ "$force_full" == "1" ]]; then
+          targets_file="$(mktemp)";
+          plan_file="$(mktemp)";
+          trap "rm -f \"$targets_file\" \"$plan_file\"" EXIT;
+          args=("$@");
+          if git rev-parse --verify origin/main >/dev/null 2>&1; then
+            while IFS= read -r deleted_path; do
+              [[ -n "$deleted_path" ]] && args+=("$deleted_path");
+            done < <(git diff --name-only --diff-filter=D origin/main...HEAD -- "aragora/*.py" "aragora/**/*.py" 2>/dev/null || true);
+          fi;
+          python scripts/run_typecheck_gate.py --repo-root . --files "${args[@]}" --targets-file "$targets_file" --json > "$plan_file";
+          mode="$(sed -n "s/.*\"mode\": \"\\([^\"]*\\)\".*/\\1/p" "$plan_file" | head -1)";
+          if [[ "$mode" == "full" ]]; then
+            venv_bin="$(python -c "import os, sys; print(os.path.dirname(sys.executable))")";
+            export PATH="$venv_bin:$PATH";
             bash scripts/test_tiers.sh typecheck;
+          elif [[ "$mode" == "changed" ]]; then
+            mapfile -t targets < "$targets_file";
+            mypy --ignore-missing-imports --follow-imports=skip --show-error-codes "${targets[@]}";
           else
-            mypy --ignore-missing-imports --follow-imports=skip --show-error-codes "$@";
+            cat "$plan_file";
           fi' --
         language: python
         additional_dependencies:
@@ -84,9 +93,11 @@ repos:
           - types-PyYAML
         # pre-commit passes only the changed, still-existing files matching
         # `files:` — either touched aragora Python files or CI force-full
-        # trigger files handled by the entrypoint above.
+        # trigger files handled by the entrypoint above. `always_run` lets the
+        # entrypoint also catch deleted aragora Python files from the git diff.
         pass_filenames: true
-        files: ^(aragora/.*\.py|pyproject\.toml|\.github/workflows/lint\.yml|scripts/run_typecheck_gate\.py|scripts/test_tiers\.sh|requirements.*\.txt|\.github/actions/pr-scope-classifier/.*)$
+        always_run: true
+        files: ^(aragora/.*\.py|pyproject\.toml|\.github/workflows/lint\.yml|scripts/run_typecheck_gate\.py|scripts/test_tiers\.sh|(.*/)?requirements[^/]*\.txt|\.github/actions/pr-scope-classifier/.*)$
         # Run on pre-push to catch type errors before they hit CI.
         stages: [pre-push]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,9 +34,10 @@ repos:
         types_or: [python, pyi]
         exclude: ^sdk/python/aragora/generated_types\.py$  # Auto-generated, must stay stable
 
-  # Type checking with mypy on the same local surfaces as CI's REQUIRED phase-1
-  # typecheck gate. Touched `aragora/**.py` files use CI's changed-file mypy
-  # flags; CI force-full trigger files run the full typecheck tier locally.
+  # Type checking with mypy on the same local planning surface as CI's REQUIRED
+  # phase-1 typecheck gate. Touched `aragora/**.py` files use CI's changed-file
+  # mypy flags; CI force-full trigger files run the same full typecheck script
+  # used by the workflow.
   # CI remains authoritative because it installs the project and computes the
   # changed-file plan from the PR/branch base; local pre-push remains a fast
   # guardrail, not the source of truth.
@@ -47,10 +48,11 @@ repos:
   # explicit local baseline filtering or regeneration.
   #
   # This hook runs in an isolated `language: python` env, so pre-commit installs
-  # mypy and the same type stubs as CI — the gate does not depend on the
+  # mypy and the same type-stub packages as CI — the gate does not depend on the
   # developer's active environment having mypy (no "No module named mypy"
-  # surprises). The changed-file path uses `--follow-imports=skip` /
-  # `--ignore-missing-imports` so it does not need the full project installed.
+  # surprises). The hook pins mypy to Aragora's current known-good 1.x range so
+  # local pushes do not break when pre-commit builds a fresh isolated env; CI
+  # remains authoritative.
   #
   # Run the full baseline check manually when you want it:
   #   python scripts/ci/mypy_with_baseline.py        # report NEW errors only
@@ -60,41 +62,51 @@ repos:
       - id: typecheck-changed
         name: mypy (changed aragora files or full CI trigger)
         entry: >-
-          bash -c 'set -euo pipefail;
+          bash -c 'set -eo pipefail;
           targets_file="$(mktemp)";
           plan_file="$(mktemp)";
           trap "rm -f \"$targets_file\" \"$plan_file\"" EXIT;
-          args=("$@");
+          plan_files=();
+          for path in "$@"; do
+            plan_files+=("$path");
+          done;
           if git rev-parse --verify origin/main >/dev/null 2>&1; then
             while IFS= read -r deleted_path; do
-              [[ -n "$deleted_path" ]] && args+=("$deleted_path");
-            done < <(git diff --name-only --diff-filter=D origin/main...HEAD -- "aragora/*.py" "aragora/**/*.py" 2>/dev/null || true);
+              case "$deleted_path" in
+                aragora/*.py) plan_files+=("$deleted_path") ;;
+              esac;
+            done < <(git diff --name-only --diff-filter=D origin/main...HEAD -- aragora/ 2>/dev/null || true);
+          elif [[ "$#" -eq 0 ]]; then
+            echo "warning: origin/main is unavailable; deleted aragora Python files cannot be inferred locally" >&2;
           fi;
-          python scripts/run_typecheck_gate.py --repo-root . --files "${args[@]}" --targets-file "$targets_file" --json > "$plan_file";
-          mode="$(sed -n "s/.*\"mode\": \"\\([^\"]*\\)\".*/\\1/p" "$plan_file" | head -1)";
+          python scripts/run_typecheck_gate.py --repo-root . --files "${plan_files[@]}" --targets-file "$targets_file" --json > "$plan_file";
+          mode="$(python -c "import json, sys; print(json.load(open(sys.argv[1]))[\"mode\"])" "$plan_file")";
           if [[ "$mode" == "full" ]]; then
             venv_bin="$(python -c "import os, sys; print(os.path.dirname(sys.executable))")";
             export PATH="$venv_bin:$PATH";
             bash scripts/test_tiers.sh typecheck;
           elif [[ "$mode" == "changed" ]]; then
-            mapfile -t targets < "$targets_file";
+            targets=();
+            while IFS= read -r target; do
+              [[ -n "$target" ]] && targets+=("$target");
+            done < "$targets_file";
             mypy --ignore-missing-imports --follow-imports=skip --show-error-codes "${targets[@]}";
           else
             cat "$plan_file";
           fi' --
         language: python
         additional_dependencies:
-          - mypy
+          - mypy>=1.19.0,<2.0
           - types-requests
           - types-redis
           - types-python-dateutil
           - types-setuptools
           - types-jsonschema
           - types-PyYAML
-        # pre-commit passes only the changed, still-existing files matching
-        # `files:` — either touched aragora Python files or CI force-full
-        # trigger files handled by the entrypoint above. `always_run` lets the
-        # entrypoint also catch deleted aragora Python files from the git diff.
+        # `always_run` lets the entrypoint compute the same origin/main...HEAD
+        # plan as CI, including deleted aragora Python files and nested
+        # requirements files, instead of trusting pre-commit's existing-file
+        # list alone.
         pass_filenames: true
         always_run: true
         files: ^(aragora/.*\.py|pyproject\.toml|\.github/workflows/lint\.yml|scripts/run_typecheck_gate\.py|scripts/test_tiers\.sh|(.*/)?requirements[^/]*\.txt|\.github/actions/pr-scope-classifier/.*)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,9 @@ repos:
   # Type checking with mypy on the same local planning surface as CI's REQUIRED
   # phase-1 typecheck gate. Touched `aragora/**.py` files use CI's changed-file
   # mypy flags; CI force-full trigger files run the same full typecheck script
-  # used by the workflow.
+  # used by the workflow. This intentionally drops the old pre-push
+  # baseline-style cross-file scan so local pushes follow the required CI gate
+  # instead of failing on unrelated full-tree debt.
   # CI remains authoritative because it installs the project and computes the
   # changed-file plan from the PR/branch base; local pre-push remains a fast
   # guardrail, not the source of truth.
@@ -50,9 +52,8 @@ repos:
   # This hook runs in an isolated `language: python` env, so pre-commit installs
   # mypy and the same type-stub packages as CI — the gate does not depend on the
   # developer's active environment having mypy (no "No module named mypy"
-  # surprises). The hook pins mypy to Aragora's current known-good 1.x range so
-  # local pushes do not break when pre-commit builds a fresh isolated env; CI
-  # remains authoritative.
+  # surprises). The hook pins mypy to Aragora's current known-good local version
+  # so pre-commit env rebuilds are deterministic; CI remains authoritative.
   #
   # Run the full baseline check manually when you want it:
   #   python scripts/ci/mypy_with_baseline.py        # report NEW errors only
@@ -76,7 +77,7 @@ repos:
                 aragora/*.py) plan_files+=("$deleted_path") ;;
               esac;
             done < <(git diff --name-only --diff-filter=D origin/main...HEAD -- aragora/ 2>/dev/null || true);
-          elif [[ "$#" -eq 0 ]]; then
+          else
             echo "warning: origin/main is unavailable; deleted aragora Python files cannot be inferred locally" >&2;
           fi;
           python scripts/run_typecheck_gate.py --repo-root . --files "${plan_files[@]}" --targets-file "$targets_file" --json > "$plan_file";
@@ -90,13 +91,21 @@ repos:
             while IFS= read -r target; do
               [[ -n "$target" ]] && targets+=("$target");
             done < "$targets_file";
-            mypy --ignore-missing-imports --follow-imports=skip --show-error-codes "${targets[@]}";
-          else
+            if [[ "${#targets[@]}" -gt 0 ]]; then
+              mypy --ignore-missing-imports --follow-imports=skip --show-error-codes "${targets[@]}";
+            else
+              echo "warning: typecheck planner returned changed mode with no targets; skipping local mypy" >&2;
+            fi;
+          elif [[ "$mode" == "skip" ]]; then
             cat "$plan_file";
+          else
+            echo "error: unknown typecheck planner mode: $mode" >&2;
+            cat "$plan_file" >&2;
+            exit 1;
           fi' --
         language: python
         additional_dependencies:
-          - mypy>=1.19.0,<2.0
+          - mypy==1.19.1
           - types-requests
           - types-redis
           - types-python-dateutil

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,8 +46,14 @@ repos:
   # its baseline locally is environment-fragile (exact mypy version + every
   # type-stub version + importable project deps + mypy's incremental cache),
   # which previously made every local push fail on thousands of phantom "new"
-  # errors in untouched files. `--follow-imports=skip` makes this gate need no
-  # project deps or stubs, so it is robust in any developer environment.
+  # errors in untouched files.
+  #
+  # This hook runs in an isolated `language: python` env, so pre-commit installs
+  # the pinned `mypy` itself — the gate never depends on the developer's active
+  # environment having mypy (no "No module named mypy" surprises). The
+  # `--follow-imports=skip` / `--ignore-missing-imports` flags mean it needs no
+  # project deps or type stubs, so the isolated env type-checks changed files
+  # correctly without the full project installed.
   #
   # Run the full baseline check manually when you want it:
   #   python scripts/ci/mypy_with_baseline.py        # report NEW errors only
@@ -56,8 +62,10 @@ repos:
     hooks:
       - id: typecheck-changed
         name: mypy (changed aragora files, mirrors CI typecheck gate)
-        entry: python -m mypy --ignore-missing-imports --follow-imports=skip --show-error-codes
-        language: system
+        entry: mypy --ignore-missing-imports --follow-imports=skip --show-error-codes
+        language: python
+        additional_dependencies:
+          - mypy==1.19.1
         # pre-commit passes only the changed, still-existing files matching
         # `files:` — i.e. the same "touched aragora Python file(s)" CI checks.
         pass_filenames: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,26 +34,22 @@ repos:
         types_or: [python, pyi]
         exclude: ^sdk/python/aragora/generated_types\.py$  # Auto-generated, must stay stable
 
-  # Type checking with mypy on CHANGED files — mirrors CI's REQUIRED phase-1
-  # typecheck gate (.github/workflows/lint.yml runs
-  # `mypy --ignore-missing-imports --follow-imports=skip --show-error-codes`
-  # on touched `aragora/**.py` for PR/branch pushes). Passing here ⇒ passing
-  # the required CI typecheck.
+  # Type checking with mypy on the same local surfaces as CI's REQUIRED phase-1
+  # typecheck gate. Touched `aragora/**.py` files use CI's changed-file mypy
+  # flags; CI force-full trigger files run the full typecheck tier locally.
+  # CI remains authoritative because it installs the project and computes the
+  # changed-file plan from the PR/branch base.
   #
-  # We intentionally do NOT run the full-tree `mypy-baseline` diff on pre-push.
-  # That tier only runs in CI on direct-to-main pushes
-  # (`scripts/ci/mypy_with_baseline.py`) and is `ci.skip`-ped here. Reproducing
-  # its baseline locally is environment-fragile (exact mypy version + every
-  # type-stub version + importable project deps + mypy's incremental cache),
-  # which previously made every local push fail on thousands of phantom "new"
-  # errors in untouched files.
+  # We intentionally do NOT run the manual `mypy_with_baseline.py` helper on
+  # pre-push. The required CI workflow uses `scripts/run_typecheck_gate.py` plus
+  # `scripts/test_tiers.sh typecheck`; the baseline helper is available only for
+  # explicit local baseline filtering or regeneration.
   #
   # This hook runs in an isolated `language: python` env, so pre-commit installs
-  # the pinned `mypy` itself — the gate never depends on the developer's active
-  # environment having mypy (no "No module named mypy" surprises). The
-  # `--follow-imports=skip` / `--ignore-missing-imports` flags mean it needs no
-  # project deps or type stubs, so the isolated env type-checks changed files
-  # correctly without the full project installed.
+  # mypy and the same type stubs as CI — the gate never depends on the
+  # developer's active environment having mypy (no "No module named mypy"
+  # surprises). The changed-file path uses `--follow-imports=skip` /
+  # `--ignore-missing-imports` so it does not need the full project installed.
   #
   # Run the full baseline check manually when you want it:
   #   python scripts/ci/mypy_with_baseline.py        # report NEW errors only
@@ -61,15 +57,36 @@ repos:
   - repo: local
     hooks:
       - id: typecheck-changed
-        name: mypy (changed aragora files, mirrors CI typecheck gate)
-        entry: mypy --ignore-missing-imports --follow-imports=skip --show-error-codes
+        name: mypy (changed aragora files or full CI trigger)
+        entry: >-
+          bash -c 'set -euo pipefail;
+          force_full=0;
+          for path in "$@"; do
+            case "$path" in
+              pyproject.toml|.github/workflows/lint.yml|scripts/run_typecheck_gate.py|scripts/test_tiers.sh|requirements*.txt|.github/actions/pr-scope-classifier/*)
+                force_full=1
+                ;;
+            esac
+          done;
+          if [[ "$force_full" == "1" ]]; then
+            bash scripts/test_tiers.sh typecheck;
+          else
+            mypy --ignore-missing-imports --follow-imports=skip --show-error-codes "$@";
+          fi' --
         language: python
         additional_dependencies:
-          - mypy==1.19.1
+          - mypy
+          - types-requests
+          - types-redis
+          - types-python-dateutil
+          - types-setuptools
+          - types-jsonschema
+          - types-PyYAML
         # pre-commit passes only the changed, still-existing files matching
-        # `files:` — i.e. the same "touched aragora Python file(s)" CI checks.
+        # `files:` — either touched aragora Python files or CI force-full
+        # trigger files handled by the entrypoint above.
         pass_filenames: true
-        files: ^aragora/.*\.py$
+        files: ^(aragora/.*\.py|pyproject\.toml|\.github/workflows/lint\.yml|scripts/run_typecheck_gate\.py|scripts/test_tiers\.sh|requirements.*\.txt|\.github/actions/pr-scope-classifier/.*)$
         # Run on pre-push to catch type errors before they hit CI.
         stages: [pre-push]
 


### PR DESCRIPTION
## Problem
The local pre-push `mypy-baseline` hook ran a **full-tree** baseline diff inside an **isolated pre-commit venv**, which cannot reproduce `.mypy-baseline`:
- the venv lacks the project's runtime deps (mypy can't follow imports into real packages),
- it ships a **stale `mypy==1.10.0`** vs the **1.19.x** the baseline was synced under (#7500),
- and the diff is sensitive to type-stub versions + mypy's incremental cache.

Net effect: **every push touching `aragora/` or `scripts/` failed on thousands of phantom "new" errors in untouched files**, forcing `--no-verify`. (This is also `ci.skip`-ped, so it was never the authoritative check.)

## Fix
Replace it with `typecheck-changed`, which **mirrors CI's REQUIRED phase-1 typecheck gate** (`.github/workflows/lint.yml`):
```
mypy --ignore-missing-imports --follow-imports=skip --show-error-codes <touched aragora/**.py>
```
pre-commit passes only the changed, still-existing `aragora/**.py` files — the same "touched aragora file(s)" CI checks. **Passing locally ⇒ passing the required CI typecheck.** `--follow-imports=skip` removes any dependency on project packages or type stubs, so the gate is robust in any environment.

The full-tree baseline tier is **unchanged** and still runs in CI on direct-to-main pushes via `scripts/ci/mypy_with_baseline.py`; run it manually with `python scripts/ci/mypy_with_baseline.py [--sync]` when desired.

## Validation
- `pre-commit run typecheck-changed --hook-stage pre-push --files aragora/codex/insights.py` → **Passed**.
- Deliberate `x: int = "..."` probe → hook **fails exit 1** with `[assignment]` error (real gate, not a no-op).
- This PR's own push (yaml-only) went through pre-push hooks cleanly **without `--no-verify`**.

## Why this matters
The broken hook was forcing `--no-verify` on otherwise-clean, CI-green pushes (e.g. #7507). This restores a working, fast, CI-aligned local type gate and removes that friction for every contributor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)