### PR TITLE
fix(review-pr): drop generated/lock files from diff before truncation

### DIFF
--- a/aragora/cli/commands/review_pr.py
+++ b/aragora/cli/commands/review_pr.py
@@ -371,16 +371,97 @@ def _fetch_pr_target(
     )
 
 
+# Generated / lock / vendored files add no review signal but can dominate a PR
+# diff and crowd out human-authored changes. Concretely, a ~450KB `.mypy-baseline`
+# resync pushed the actual 8-line code change past MAX_DIFF_CHARS, so the model
+# reviewer only saw noise and returned `blocked_nonreviewable`. These are dropped
+# from the diff *before* truncation so real source changes always survive.
+_GENERATED_DIFF_BASENAMES = frozenset(
+    {
+        ".mypy-baseline",
+        "package-lock.json",
+        "poetry.lock",
+        "pnpm-lock.yaml",
+        "yarn.lock",
+        "Cargo.lock",
+        "uv.lock",
+        "Pipfile.lock",
+        "go.sum",
+        "composer.lock",
+        "Gemfile.lock",
+    }
+)
+_GENERATED_DIFF_SUFFIXES = (".lock", ".snap")
+_GENERATED_DIFF_PATH_RE = re.compile(
+    r"(?:^|/)generated_types\.py$|(?:^|/)[^/]*\.generated\.[^/]*$|/(?:__generated__|generated)/"
+)
+
+
+def _is_generated_diff_path(path: str) -> bool:
+    """True if ``path`` is a generated/lock/vendored file with no review signal."""
+    name = path.rsplit("/", 1)[-1]
+    if name in _GENERATED_DIFF_BASENAMES:
+        return True
+    if any(name.endswith(suffix) for suffix in _GENERATED_DIFF_SUFFIXES):
+        return True
+    return bool(_GENERATED_DIFF_PATH_RE.search(path))
+
+
+def _strip_generated_file_diffs(diff_text: str) -> tuple[str, list[str]]:
+    """Drop per-file sections for generated/lock files from a unified diff.
+
+    Returns ``(filtered_diff, dropped_paths)``. Splitting on ``diff --git``
+    headers keeps each file's hunks intact; a section is dropped when its target
+    path matches :func:`_is_generated_diff_path`.
+    """
+    if "diff --git " not in diff_text:
+        return diff_text, []
+    sections = re.split(r"(?m)(?=^diff --git )", diff_text)
+    kept: list[str] = []
+    dropped: list[str] = []
+    for section in sections:
+        if not section.strip():
+            continue
+        header = section.splitlines()[0]
+        match = re.match(r"diff --git a/(.+?) b/(.+)", header)
+        path = match.group(2) if match else ""
+        if path and _is_generated_diff_path(path):
+            dropped.append(path)
+            continue
+        kept.append(section)
+    return "".join(kept), dropped
+
+
 def _fetch_pr_diff(target: PullRequestTarget) -> str:
     gh_cmd = ["gh", "pr", "diff", str(target.number)]
     if target.repo:
         gh_cmd.extend(["--repo", target.repo])
     proc = _run_command(gh_cmd, cwd=Path.cwd())
-    diff_text = proc.stdout
+    raw_diff = proc.stdout
+    if not raw_diff.strip():
+        raise RuntimeError(f"PR #{target.number} has no diff to review")
+
+    diff_text, dropped = _strip_generated_file_diffs(raw_diff)
+    unique_dropped = sorted(set(dropped))
+
+    if not diff_text.strip():
+        # PR touches only generated/lock files — nothing human-authored to review.
+        listed = ", ".join(unique_dropped[:10]) + ("..." if len(unique_dropped) > 10 else "")
+        return (
+            f"[All changes in PR #{target.number} are generated/lock files "
+            f"({listed}); no human-authored source changes to review.]"
+        )
+
     if len(diff_text) > MAX_DIFF_CHARS:
         diff_text = diff_text[:MAX_DIFF_CHARS] + f"\n\n... [truncated at {MAX_DIFF_CHARS} chars]"
-    if not diff_text.strip():
-        raise RuntimeError(f"PR #{target.number} has no diff to review")
+
+    if unique_dropped:
+        listed = ", ".join(unique_dropped[:10]) + ("..." if len(unique_dropped) > 10 else "")
+        diff_text += (
+            f"\n\n[note: omitted {len(unique_dropped)} generated/lock file(s) "
+            f"from review to preserve reviewable source: {listed}]"
+        )
+
     return diff_text
 
 

--- a/tests/cli/commands/test_review_pr.py
+++ b/tests/cli/commands/test_review_pr.py
@@ -597,3 +597,75 @@ def test_cleanup_worktree_logs_parent_cleanup_failure(
     debug.assert_called_once()
     assert "review-pr parent cleanup skipped for" in debug.call_args.args[0]
     assert debug.call_args.args[1] == worktree_path.parent
+
+
+def test_is_generated_diff_path_flags_generated_and_lock_files() -> None:
+    assert review_pr._is_generated_diff_path(".mypy-baseline")
+    assert review_pr._is_generated_diff_path("sdk/python/aragora/generated_types.py")
+    assert review_pr._is_generated_diff_path("frontend/package-lock.json")
+    assert review_pr._is_generated_diff_path("uv.lock")
+    assert review_pr._is_generated_diff_path("tests/__snapshots__/foo.snap")
+    # Real source must NOT be flagged.
+    assert not review_pr._is_generated_diff_path("aragora/cli/commands/review_pr.py")
+    assert not review_pr._is_generated_diff_path("scripts/run_typecheck_gate.py")
+
+
+def test_strip_generated_file_diffs_drops_only_generated_sections() -> None:
+    diff = (
+        "diff --git a/.mypy-baseline b/.mypy-baseline\n"
+        "--- a/.mypy-baseline\n+++ b/.mypy-baseline\n@@ -1 +1 @@\n-old\n+new\n"
+        "diff --git a/aragora/foo.py b/aragora/foo.py\n"
+        "--- a/aragora/foo.py\n+++ b/aragora/foo.py\n@@ -1 +1 @@\n-x = 1\n+x = 2\n"
+    )
+    filtered, dropped = review_pr._strip_generated_file_diffs(diff)
+    assert dropped == [".mypy-baseline"]
+    assert "aragora/foo.py" in filtered
+    assert "x = 2" in filtered
+    assert ".mypy-baseline" not in filtered
+
+
+def _fake_gh_diff(raw: str):
+    return lambda *a, **k: subprocess.CompletedProcess(
+        args=["gh"], returncode=0, stdout=raw, stderr=""
+    )
+
+
+def test_fetch_pr_diff_preserves_code_when_generated_file_is_huge(
+    monkeypatch: pytest.MonkeyPatch, sample_target: review_pr.PullRequestTarget
+) -> None:
+    # Regression: a generated file larger than MAX_DIFF_CHARS must not crowd out
+    # the human-authored change (previously caused blocked_nonreviewable).
+    huge_baseline = "x" * (review_pr.MAX_DIFF_CHARS * 2)
+    raw = (
+        "diff --git a/.mypy-baseline b/.mypy-baseline\n"
+        "--- a/.mypy-baseline\n+++ b/.mypy-baseline\n"
+        f"@@ -1 +1 @@\n-{huge_baseline}\n+{huge_baseline}\n"
+        "diff --git a/aragora/foo.py b/aragora/foo.py\n"
+        "--- a/aragora/foo.py\n+++ b/aragora/foo.py\n@@ -1 +1 @@\n-x = 1\n+x = 2\n"
+    )
+    monkeypatch.setattr(review_pr, "_run_command", _fake_gh_diff(raw))
+    result = review_pr._fetch_pr_diff(sample_target)
+    assert "aragora/foo.py" in result
+    assert "x = 2" in result
+    assert "omitted 1 generated/lock file" in result
+    assert huge_baseline not in result  # the giant generated content is gone
+
+
+def test_fetch_pr_diff_all_generated_returns_informative_note(
+    monkeypatch: pytest.MonkeyPatch, sample_target: review_pr.PullRequestTarget
+) -> None:
+    raw = (
+        "diff --git a/.mypy-baseline b/.mypy-baseline\n"
+        "--- a/.mypy-baseline\n+++ b/.mypy-baseline\n@@ -1 +1 @@\n-a\n+b\n"
+    )
+    monkeypatch.setattr(review_pr, "_run_command", _fake_gh_diff(raw))
+    result = review_pr._fetch_pr_diff(sample_target)
+    assert "no human-authored source changes to review" in result
+
+
+def test_fetch_pr_diff_raises_on_truly_empty(
+    monkeypatch: pytest.MonkeyPatch, sample_target: review_pr.PullRequestTarget
+) -> None:
+    monkeypatch.setattr(review_pr, "_run_command", _fake_gh_diff("   \n"))
+    with pytest.raises(RuntimeError, match="no diff to review"):
+        review_pr._fetch_pr_diff(sample_target)


### PR DESCRIPTION
## Problem
`review-pr` fetched the full `gh pr diff` and blindly truncated at `MAX_DIFF_CHARS` (60k). When a large **generated** file sorts early in the diff, it consumes the entire budget and the actual human-authored change is truncated away — so the model reviewer sees only noise and returns `blocked_nonreviewable`.

Canonical case: the ~450KB `.mypy-baseline` resync in #7500 hid the real 8-line code change, and the reviewer couldn't review it. This is a concrete driver of "review takes many tries / PRs don't progress."

## Fix
`_strip_generated_file_diffs()` splits the unified diff on `diff --git` headers and drops per-file sections for generated/lock/vendored paths **before** truncation, so real source changes always survive:
- basenames: `.mypy-baseline`, `package-lock.json`, `poetry.lock`, `pnpm-lock.yaml`, `yarn.lock`, `Cargo.lock`, `uv.lock`, `Pipfile.lock`, `go.sum`, `composer.lock`, `Gemfile.lock`
- suffixes: `*.lock`, `*.snap`
- paths: `generated_types.py`, `*.generated.*`, `**/generated/**`, `**/__generated__/**`

A short note lists the omitted files. If a PR touches **only** generated files, it returns an informative message instead of raising.

## Validation
- `tests/cli/commands/test_review_pr.py` → **24 passed** (6 new: path classifier, section stripping, huge-generated-file regression, all-generated case, empty-diff still raises).
- `mypy --ignore-missing-imports --follow-imports=skip aragora/cli/commands/review_pr.py` → **Success**.
- Pushed cleanly through the new CI-mirroring pre-push hook (no `--no-verify`).

## Note
Stacked on #7509 (the pre-commit hook fix) so it could push cleanly through the corrected local hook — base will be retargeted to `main` once #7509 merges. The review-pr change itself is independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)