### PR TITLE
fix(sdk): guard websocket reconnect without event loop

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -13,11 +13,11 @@
 | Metric | Value | Source | Command |
 |---|---|---|---|
 | Python files under aragora/ | `4149` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1945694` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python lines of code under aragora/ | `1945866` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `141` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
 | Test files (test_*.py under tests/) | `5238` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `219188` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
-| @pytest.mark.parametrize decorators | `705` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
+| Test functions (class + module level) | `219200` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| @pytest.mark.parametrize decorators | `708` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `71` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2870` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
 | OpenAPI operations (HTTP verbs) | `3297` | `docs/api/openapi.json` | `python -c "import json; spec=json.load(open('docs/api/openapi.json')); print(sum(1 for p in spec['paths'].values() for m in p if m.lower() in {'get','post','put','delete','patch','head','options'}))"` |
@@ -28,9 +28,9 @@
 | Allowlisted agent types | `35` | `aragora/config/settings.py` | `grep -A 50 'ALLOWED_AGENT_TYPES' aragora/config/settings.py \| grep -oE "'[a-z-]+'" \| sort -u \| wc -l` |
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `46` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |
-| Markdown files under docs/ | `966` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
+| Markdown files under docs/ | `964` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
 | GitHub Actions workflows | `86` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
-| Mypy baseline errors (grandfathered) | `3317` | `.mypy-baseline` | `wc -l .mypy-baseline` |
+| Mypy baseline errors (grandfathered) | `3115` | `.mypy-baseline` | `wc -l .mypy-baseline` |
 
 ## Notes on counting methodology
 

--- a/sdk/python/aragora_sdk/websocket.py
+++ b/sdk/python/aragora_sdk/websocket.py
@@ -381,6 +381,13 @@ class AragoraWebSocket:
 
     def _schedule_reconnect(self) -> None:
         """Schedule a reconnection with exponential back-off."""
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            logger.debug("Skipping reconnect scheduling because no event loop is running")
+            self._state = _STATE_DISCONNECTED
+            return
+
         self._state = _STATE_RECONNECTING
         delay = self.options.reconnect_delay * (2**self._reconnect_attempts)
         self._reconnect_attempts += 1
@@ -392,7 +399,7 @@ class AragoraWebSocket:
             except Exception:
                 pass  # connect() will emit errors and trigger disconnect
 
-        self._reconnect_task = asyncio.ensure_future(_do_reconnect())
+        self._reconnect_task = loop.create_task(_do_reconnect())
 
     def _cleanup(self) -> None:
         """Cancel background tasks."""

--- a/sdk/python/tests/test_streaming.py
+++ b/sdk/python/tests/test_streaming.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -539,6 +540,27 @@ class TestAragoraWebSocketReconnection:
         event_data = handler.call_args[0][0]
         assert event_data["code"] == 1006
         assert event_data["reason"] == "Connection lost"
+
+    def test_handle_disconnect_without_event_loop_emits_disconnected(self) -> None:
+        """_handle_disconnect does not require a main-thread event loop."""
+        ws = AragoraWebSocket("https://api.aragora.ai")
+        handler = MagicMock()
+        ws.on("disconnected", handler)
+
+        try:
+            previous_loop = asyncio.get_event_loop()
+        except RuntimeError:
+            previous_loop = None
+
+        asyncio.set_event_loop(None)
+        try:
+            ws._handle_disconnect(1006, "Connection lost")
+        finally:
+            asyncio.set_event_loop(previous_loop)
+
+        handler.assert_called_once()
+        assert ws.state == "disconnected"
+        assert ws._reconnect_task is None
 
     def test_handle_disconnect_schedules_reconnect(self) -> None:
         """_handle_disconnect schedules reconnection if auto_reconnect enabled."""


### PR DESCRIPTION
## Summary
- Guard SDK WebSocket reconnect scheduling when no event loop is running in the current thread.
- Keep disconnected-event emission non-throwing in synchronous disconnect paths.
- Add a regression test for disconnect handling with no main-thread event loop.

## Validation
- uv run --python 3.11 --with pytest --with pytest-asyncio --with httpx --with pydantic --with websockets python -m pytest sdk/python/tests/test_streaming.py::TestAragoraWebSocketReconnection::test_handle_disconnect_without_event_loop_emits_disconnected -q
- uv run --python 3.11 --with pytest --with pytest-asyncio --with httpx --with pydantic --with websockets python -m pytest sdk/python/tests/test_streaming.py -q
- uv run --python 3.11 --with pytest --with pytest-asyncio --with httpx --with pydantic --with websockets python -m pytest sdk/python/tests -q
- python3 -m pytest sdk/python/tests/test_streaming.py -q
- python3 -m ruff check sdk/python/aragora_sdk/websocket.py sdk/python/tests/test_streaming.py

## Notes
This is a bounded repair lane for the SDK failure observed while diagnosing #7465. It does not mutate #7465, does not rerun #7465 checks, and does not merge/admin-merge anything.