### PR TITLE
[DIC-27] Arbitration rows in DIC-18 truth map

### DIFF
--- a/aragora/epistemic/truth_map.py
+++ b/aragora/epistemic/truth_map.py
@@ -1,9 +1,10 @@
 """Organizational Truth Map report (DIC-18 / #6028).
 
 Read-only operator report aggregating ExecutableClaim verification results
-(DIC-14) and optional CruxFinderResult summaries (DIC-15).
-Default OFF — callers must explicitly invoke ``build_truth_map`` or
-``build_truth_map_from_manifests``.  No queue mutation, no side effects.
+(DIC-14), optional CruxFinderResult summaries (DIC-15), and operator
+arbitration records (DIC-27).  Default OFF — callers must explicitly invoke
+``build_truth_map`` or ``build_truth_map_from_manifests``.  No queue
+mutation, no side effects.
 """
 
 from __future__ import annotations
@@ -17,6 +18,7 @@ from aragora.epistemic.claim_verifier import ClaimResult, ClaimStatus
 
 if TYPE_CHECKING:
     from aragora.debate.crux_mode import CruxFinderResult
+    from aragora.epistemic.arbitration import CruxArbitration
 
 
 @dataclass
@@ -48,12 +50,37 @@ class CruxSummaryRow:
 
 
 @dataclass
+class ArbitrationRow:
+    """One operator arbitration record in the truth map (DIC-27).
+
+    Populated only when ``ARAGORA_CRUX_ARBITRATION_ENABLED=1``.
+    ``age_hours`` is the wall-clock age of the arbitration at report
+    generation time, rounded to 2 decimal places.
+    """
+
+    arbitration_id: str
+    crux_id: str
+    statement: str
+    side: str
+    operator: str
+    created_at: str
+    expires_at: str
+    age_hours: float
+    is_expired: bool
+    is_reversed: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
 class OrgTruthMapReport:
     """Read-only aggregated truth map for an Aragora deployment."""
 
     generated_at: str
     claims: list[ClaimRow] = field(default_factory=list)
     crux_summaries: list[CruxSummaryRow] = field(default_factory=list)
+    arbitrations: list[ArbitrationRow] = field(default_factory=list)
     total_claims: int = 0
     passing_claims: int = 0
     failing_claims: int = 0
@@ -61,12 +88,16 @@ class OrgTruthMapReport:
     unsupported_claims: int = 0
     error_claims: int = 0
     open_crux_count: int = 0
+    active_arbitrations: int = 0
+    expired_arbitrations: int = 0
+    reversed_arbitrations: int = 0
 
     def to_dict(self) -> dict[str, Any]:
         return {
             "generated_at": self.generated_at,
             "claims": [c.to_dict() for c in self.claims],
             "crux_summaries": [cs.to_dict() for cs in self.crux_summaries],
+            "arbitrations": [a.to_dict() for a in self.arbitrations],
             "summary": {
                 "total_claims": self.total_claims,
                 "passing": self.passing_claims,
@@ -75,6 +106,9 @@ class OrgTruthMapReport:
                 "unsupported": self.unsupported_claims,
                 "error": self.error_claims,
                 "open_crux_count": self.open_crux_count,
+                "active_arbitrations": self.active_arbitrations,
+                "expired_arbitrations": self.expired_arbitrations,
+                "reversed_arbitrations": self.reversed_arbitrations,
             },
         }
 
@@ -86,8 +120,9 @@ def build_truth_map(
     crux_results: list[CruxFinderResult] | None = None,
     top_k_cruxes: int = 3,
     open_crux_score_threshold: float = 0.3,
+    arbitrations: list[CruxArbitration] | None = None,
 ) -> OrgTruthMapReport:
-    """Build an OrgTruthMapReport from pre-computed claim and crux inputs."""
+    """Build an OrgTruthMapReport from pre-computed claim, crux, and arbitration inputs."""
     meta = claim_metadata or {}
     rows: list[ClaimRow] = []
     for cr in claim_results:
@@ -131,10 +166,47 @@ def build_truth_map(
             )
         )
 
+    arb_rows: list[ArbitrationRow] = []
+    active = expired = reversed_ = 0
+    if arbitrations is not None:
+        from aragora.epistemic.arbitration import crux_arbitration_enabled
+
+        if crux_arbitration_enabled():
+            now = datetime.datetime.now(datetime.timezone.utc)
+            for arb in arbitrations:
+                try:
+                    created = datetime.datetime.fromisoformat(arb.created_at)
+                    if created.tzinfo is None:
+                        created = created.replace(tzinfo=datetime.timezone.utc)
+                except ValueError:
+                    created = now
+                age_h = round((now - created).total_seconds() / 3600.0, 2)
+                arb_rows.append(
+                    ArbitrationRow(
+                        arbitration_id=arb.arbitration_id,
+                        crux_id=arb.crux.crux_id,
+                        statement=arb.crux.statement,
+                        side=arb.side,
+                        operator=arb.operator,
+                        created_at=arb.created_at,
+                        expires_at=arb.expires_at,
+                        age_hours=age_h,
+                        is_expired=arb.is_expired,
+                        is_reversed=arb.is_reversed,
+                    )
+                )
+                if arb.is_reversed:
+                    reversed_ += 1
+                elif arb.is_expired:
+                    expired += 1
+                else:
+                    active += 1
+
     return OrgTruthMapReport(
         generated_at=datetime.datetime.utcnow().isoformat() + "Z",
         claims=rows,
         crux_summaries=crux_rows,
+        arbitrations=arb_rows,
         total_claims=len(rows),
         passing_claims=counts[ClaimStatus.PASS],
         failing_claims=counts[ClaimStatus.FAIL],
@@ -142,6 +214,9 @@ def build_truth_map(
         unsupported_claims=counts[ClaimStatus.UNSUPPORTED],
         error_claims=counts[ClaimStatus.ERROR],
         open_crux_count=open_crux_total,
+        active_arbitrations=active,
+        expired_arbitrations=expired,
+        reversed_arbitrations=reversed_,
     )
 
 
@@ -153,6 +228,7 @@ def build_truth_map_from_manifests(
     top_k_cruxes: int = 3,
     open_crux_score_threshold: float = 0.3,
     dry_run: bool = True,
+    arbitrations: list[CruxArbitration] | None = None,
 ) -> OrgTruthMapReport:
     """Load DIC-13 YAML manifests, verify claims, and build a truth map."""
     import yaml  # project-level dep; local import keeps module testable without it
@@ -175,4 +251,5 @@ def build_truth_map_from_manifests(
         crux_results=crux_results,
         top_k_cruxes=top_k_cruxes,
         open_crux_score_threshold=open_crux_score_threshold,
+        arbitrations=arbitrations,
     )

--- a/tests/epistemic/test_truth_map_arbitration.py
+++ b/tests/epistemic/test_truth_map_arbitration.py
@@ -1,0 +1,215 @@
+"""DIC-27 arbitration rows in the DIC-18 truth map.
+
+Tests for ArbitrationRow and the arbitrations= parameter of build_truth_map.
+Flag-gated via ARAGORA_CRUX_ARBITRATION_ENABLED; default off.
+Advances issue #6221.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import os
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+
+from aragora.epistemic.arbitration import (
+    PERSISTENT_CRUX_MIN_CONSECUTIVE,
+    PERSISTENT_CRUX_MIN_SCORE,
+    CruxArbitration,
+    PersistentCrux,
+    build_arbitration,
+    build_reversal,
+)
+from aragora.epistemic.claim_verifier import ClaimResult, ClaimStatus
+from aragora.epistemic.truth_map import ArbitrationRow, OrgTruthMapReport, build_truth_map
+
+
+# ─────────────────────────── helpers ────────────────────────────────────────
+
+
+def _make_crux(crux_id: str = "crux-1") -> PersistentCrux:
+    return PersistentCrux(
+        crux_id=crux_id,
+        statement="Should we expand B2?",
+        question_family_id="qf-b2",
+        consecutive_debate_count=PERSISTENT_CRUX_MIN_CONSECUTIVE,
+        load_bearing_score=PERSISTENT_CRUX_MIN_SCORE,
+        cruxset_receipt_ids=("r1",),
+    )
+
+
+def _make_arb(crux_id: str = "crux-1", expiry_days: int = 90) -> CruxArbitration:
+    return build_arbitration(
+        crux=_make_crux(crux_id),
+        operator="alice",
+        side="accept",
+        rationale="Evidence favours expansion.",
+        expiry_days=expiry_days,
+    )
+
+
+def _make_expired_arb(crux_id: str = "crux-expired") -> CruxArbitration:
+    arb = _make_arb(crux_id)
+    past = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+    return dataclasses.replace(arb, expires_at=past)
+
+
+def _make_reversed_arb(crux_id: str = "crux-rev") -> CruxArbitration:
+    arb = _make_arb(crux_id)
+    updated, _ = build_reversal(arb, reversed_by="bob", reason="New evidence.")
+    return updated
+
+
+# ─────────────────────────── ArbitrationRow ──────────────────────────────────
+
+
+class TestArbitrationRow:
+    def test_to_dict_round_trips_all_fields(self) -> None:
+        now = datetime.now(timezone.utc)
+        row = ArbitrationRow(
+            arbitration_id="a1",
+            crux_id="c1",
+            statement="Q?",
+            side="accept",
+            operator="alice",
+            created_at=now.isoformat(),
+            expires_at=(now + timedelta(days=90)).isoformat(),
+            age_hours=2.5,
+            is_expired=False,
+            is_reversed=False,
+        )
+        d = row.to_dict()
+        assert d["arbitration_id"] == "a1"
+        assert d["crux_id"] == "c1"
+        assert d["side"] == "accept"
+        assert d["is_expired"] is False
+        assert d["age_hours"] == pytest.approx(2.5)
+
+
+# ─────────────────────────── flag gating ─────────────────────────────────────
+
+
+class TestArbitrationFlagGating:
+    def test_empty_arbitrations_list_gives_zero_counts(self) -> None:
+        r = build_truth_map(claim_results=[])
+        assert r.arbitrations == []
+        assert r.active_arbitrations == 0
+        assert r.expired_arbitrations == 0
+        assert r.reversed_arbitrations == 0
+
+    def test_arbitrations_ignored_when_flag_off(self) -> None:
+        arb = _make_arb()
+        with patch.dict(os.environ, {"ARAGORA_CRUX_ARBITRATION_ENABLED": "0"}):
+            r = build_truth_map(claim_results=[], arbitrations=[arb])
+        assert r.arbitrations == []
+        assert r.active_arbitrations == 0
+
+    def test_arbitrations_populated_when_flag_on(self) -> None:
+        arb = _make_arb()
+        with patch.dict(os.environ, {"ARAGORA_CRUX_ARBITRATION_ENABLED": "1"}):
+            r = build_truth_map(claim_results=[], arbitrations=[arb])
+        assert len(r.arbitrations) == 1
+        assert r.active_arbitrations == 1
+
+
+# ─────────────────────────── row field accuracy ───────────────────────────────
+
+
+class TestArbitrationRowFields:
+    def test_row_fields_match_arbitration(self) -> None:
+        arb = _make_arb("crux-xyz")
+        with patch.dict(os.environ, {"ARAGORA_CRUX_ARBITRATION_ENABLED": "1"}):
+            r = build_truth_map(claim_results=[], arbitrations=[arb])
+        row = r.arbitrations[0]
+        assert row.crux_id == "crux-xyz"
+        assert row.statement == "Should we expand B2?"
+        assert row.side == "accept"
+        assert row.operator == "alice"
+        assert row.is_expired is False
+        assert row.is_reversed is False
+        assert row.age_hours >= 0.0
+
+    def test_age_hours_is_non_negative(self) -> None:
+        arb = _make_arb()
+        with patch.dict(os.environ, {"ARAGORA_CRUX_ARBITRATION_ENABLED": "1"}):
+            r = build_truth_map(claim_results=[], arbitrations=[arb])
+        assert r.arbitrations[0].age_hours >= 0.0
+
+
+# ─────────────────────────── expired / reversed ───────────────────────────────
+
+
+class TestArbitrationCounting:
+    def test_expired_counted_separately(self) -> None:
+        arb = _make_expired_arb()
+        with patch.dict(os.environ, {"ARAGORA_CRUX_ARBITRATION_ENABLED": "1"}):
+            r = build_truth_map(claim_results=[], arbitrations=[arb])
+        assert r.expired_arbitrations == 1
+        assert r.active_arbitrations == 0
+        assert r.arbitrations[0].is_expired is True
+
+    def test_reversed_counted_separately(self) -> None:
+        arb = _make_reversed_arb()
+        with patch.dict(os.environ, {"ARAGORA_CRUX_ARBITRATION_ENABLED": "1"}):
+            r = build_truth_map(claim_results=[], arbitrations=[arb])
+        assert r.reversed_arbitrations == 1
+        assert r.active_arbitrations == 0
+        assert r.arbitrations[0].is_reversed is True
+
+    def test_mixed_arbitrations_all_counted(self) -> None:
+        active = _make_arb("c-active")
+        expired = _make_expired_arb("c-expired")
+        rev = _make_reversed_arb("c-rev")
+        with patch.dict(os.environ, {"ARAGORA_CRUX_ARBITRATION_ENABLED": "1"}):
+            r = build_truth_map(claim_results=[], arbitrations=[active, expired, rev])
+        assert len(r.arbitrations) == 3
+        assert r.active_arbitrations == 1
+        assert r.expired_arbitrations == 1
+        assert r.reversed_arbitrations == 1
+
+
+# ─────────────────────────── to_dict ─────────────────────────────────────────
+
+
+class TestToDict:
+    def test_to_dict_includes_arbitration_keys(self) -> None:
+        arb = _make_arb()
+        with patch.dict(os.environ, {"ARAGORA_CRUX_ARBITRATION_ENABLED": "1"}):
+            d = build_truth_map(claim_results=[], arbitrations=[arb]).to_dict()
+        assert "arbitrations" in d
+        assert len(d["arbitrations"]) == 1
+        assert d["summary"]["active_arbitrations"] == 1
+        assert d["summary"]["expired_arbitrations"] == 0
+        assert d["summary"]["reversed_arbitrations"] == 0
+
+    def test_to_dict_summary_has_arbitration_counts_when_flag_off(self) -> None:
+        arb = _make_arb()
+        with patch.dict(os.environ, {"ARAGORA_CRUX_ARBITRATION_ENABLED": "0"}):
+            d = build_truth_map(claim_results=[], arbitrations=[arb]).to_dict()
+        assert d["arbitrations"] == []
+        assert d["summary"]["active_arbitrations"] == 0
+
+
+# ─────────────────────────── orthogonality ───────────────────────────────────
+
+
+class TestOrthogonality:
+    def test_claim_counts_unaffected_by_arbitrations(self) -> None:
+        cr = ClaimResult(claim_id="c1", status=ClaimStatus.PASS, message="", detail={})
+        arb = _make_arb()
+        with patch.dict(os.environ, {"ARAGORA_CRUX_ARBITRATION_ENABLED": "1"}):
+            r = build_truth_map(claim_results=[cr], arbitrations=[arb])
+        assert r.total_claims == 1
+        assert r.passing_claims == 1
+        assert r.active_arbitrations == 1
+
+    def test_no_arbitrations_param_preserves_existing_summary_keys(self) -> None:
+        d = build_truth_map(claim_results=[]).to_dict()
+        expected = {
+            "total_claims", "passing", "failing", "stale",
+            "unsupported", "error", "open_crux_count",
+            "active_arbitrations", "expired_arbitrations", "reversed_arbitrations",
+        }
+        assert expected <= d["summary"].keys()

--- a/tests/epistemic/test_truth_map_arbitration.py
+++ b/tests/epistemic/test_truth_map_arbitration.py
@@ -208,8 +208,15 @@ class TestOrthogonality:
     def test_no_arbitrations_param_preserves_existing_summary_keys(self) -> None:
         d = build_truth_map(claim_results=[]).to_dict()
         expected = {
-            "total_claims", "passing", "failing", "stale",
-            "unsupported", "error", "open_crux_count",
-            "active_arbitrations", "expired_arbitrations", "reversed_arbitrations",
+            "total_claims",
+            "passing",
+            "failing",
+            "stale",
+            "unsupported",
+            "error",
+            "open_crux_count",
+            "active_arbitrations",
+            "expired_arbitrations",
+            "reversed_arbitrations",
         }
         assert expected <= d["summary"].keys()


### PR DESCRIPTION
## Slice

Adds `ArbitrationRow` to the DIC-18 organizational truth map report, completing the integration explicitly deferred in `aragora/epistemic/arbitration.py` (docstring: *"Out of scope for this slice (future work): DIC-18 truth-map integration for arbitration age display"*). `build_truth_map` now accepts an `arbitrations=` parameter that, when `ARAGORA_CRUX_ARBITRATION_ENABLED=1`, populates per-arbitration rows with age, expiry, and reversal status, plus three new summary counters (`active_arbitrations`, `expired_arbitrations`, `reversed_arbitrations`).

## Gating

- Default: **OFF** — flag: `ARAGORA_CRUX_ARBITRATION_ENABLED` (reuses the existing arbitration module flag)
- Live queue effect: **none** — `build_truth_map` is a pure read-only report builder
- Advances issue: #6221 (DIC-27 Operator Crux Arbitration)

## Tests

New file: `tests/epistemic/test_truth_map_arbitration.py`

| Class | What it verifies |
|---|---|
| `TestArbitrationRow` | `to_dict` round-trips all fields |
| `TestArbitrationFlagGating` | rows absent when flag off; present when on |
| `TestArbitrationRowFields` | crux_id, statement, side, operator, age_hours populated correctly |
| `TestArbitrationCounting` | expired / reversed / active counted into separate buckets |
| `TestToDict` | `to_dict()` includes `arbitrations` list and three summary counters |
| `TestOrthogonality` | existing claim counts unaffected; existing summary keys still present |

## Validation

- `pytest tests/epistemic/test_truth_map_arbitration.py tests/epistemic/test_truth_map.py` — 21 tests, 0 failures
- `ruff check aragora/epistemic/truth_map.py tests/epistemic/test_truth_map_arbitration.py` — clean
- `mypy aragora/epistemic/truth_map.py` — clean (`from __future__ import annotations` defers `CruxArbitration` evaluation; lazy runtime import inside function body avoids circular-import risk)

## Out of scope

- Belief-network priors-update path from arbitration records (depends on DIC-15/16 being production-green — still deferred).
- CLI `aragora truth-map` surface exposing arbitration age inline (future DIC-18 CLI slice).
- Writing the truth-map report to disk (caller decides — same as today).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiWyLEjPUZTwcFNPxe3JyG)_