### PR TITLE
test(swarm): cover rescue event public exports

### DIFF
--- a/tests/swarm/test_rescue_events.py
+++ b/tests/swarm/test_rescue_events.py
@@ -181,3 +181,16 @@ class TestRescueEventType:
         """RescueEventType members should be usable as plain strings."""
         assert isinstance(RescueEventType.OTHER, str)
         assert RescueEventType.OTHER == "other"
+
+
+class TestPublicExports:
+    def test_rescue_events_exports_public_api(self) -> None:
+        from aragora.swarm import rescue_events
+
+        assert set(rescue_events.__all__) == {
+            "DEFAULT_RESCUE_LEDGER_PATH",
+            "RescueEvent",
+            "RescueEventLedger",
+            "RescueEventType",
+            "record_rescue",
+        }


### PR DESCRIPTION
## Summary

Adds focused regression coverage for the public `__all__` exports required by B0 corpus issue #5427. Current `origin/main` already exposes the requested rescue event and rescue planner public APIs; this PR makes that proof durable and PR-linked so the issue can graduate through the normal B0 evidence path instead of a manual close.

Closes #5427.

## Validation

- `python3 -m pytest tests/swarm/test_rescue_events.py tests/swarm/test_rescue_planner.py -q` -> 35 passed
- `python3 -c "from aragora.swarm.rescue_events import __all__; print(__all__)"`
- `python3 -c "from aragora.swarm.rescue_planner import __all__; print(__all__)"`
- `ruff check aragora/swarm/rescue_events.py aragora/swarm/rescue_planner.py tests/swarm/test_rescue_events.py tests/swarm/test_rescue_planner.py`
- `ruff format --check tests/swarm/test_rescue_events.py`
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## B0 impact

This is one bounded B0 corpus issue/linkage step toward the stronger claim. After settlement and merge, #5427 should become a PR-linked success rather than an open in-progress corpus item.

No broad drain, labels, branch protection changes, outbox, harvest, admin path, or unrelated PR work.