### PR TITLE
docs(status): proof-first governance freeze + quorum-evidence countability

### DIFF
--- a/docs/status/NEXT_STEPS_CANONICAL.md
+++ b/docs/status/NEXT_STEPS_CANONICAL.md
@@ -1,6 +1,6 @@
 # Next Steps (Canonical)
 
-Last updated: 2026-05-13
+Last updated: 2026-05-28
 
 This is the single source of truth for short-horizon execution priorities.
 [CANONICAL_GOALS](../CANONICAL_GOALS.md) defines what Aragora is and why.
@@ -22,6 +22,39 @@ Current May 13 proof-loop state:
 - The first `observe-outcomes --write` remains a separate Tier-4 operator decision over a bounded manually verifiable receipt slice.
 
 Operator commands only count as proof when they are run from a clean, current `origin/main` observer. A dirty or diverged founder checkout is planning context, not runtime truth.
+
+### Governance-substrate freeze (promoted from Sprint 2 anti-goals)
+
+Treat process tooling as saturated. Do **not** open new review-queue,
+settlement, merge-quorum, or steering meta-tooling work unless it either
+(a) directly unblocks B0 truth, external receipt proof, or the non-operator
+demo/product-proof path, **or** (b) explicitly closes or supersedes an
+existing open PR in the same surface. This rule is enforced operationally
+by the Sprint 2 anti-goals in [FOCUS.md](../FOCUS.md); it is recorded here
+because it outlives any single sprint window. Post-saturation process work
+is the dominant form of substrate-overbuild — every new PR in
+`aragora/cli/commands/review_queue.py`, `scripts/settle_*.py`,
+`scripts/*steering*.py`, or `.github/workflows/aragora-*-quorum.yml` must
+name the load-bearing target it advances or the open PR it net-closes, or
+stand down.
+
+### Model-quorum evidence is exact-head and countable, or it does not exist
+
+A model-review signal only counts toward `aragora-merge-quorum` when it is
+posted as an **exact-head PR comment** that the `review-queue merge-packet`
+parsers can read: a family-named first heading, a head-SHA citation
+(>= 7 chars), and a review/dogfood trigger phrase. Advisory
+`review-pr --no-publish-review` artifacts are persisted but **not** counted,
+and a *published* `review-pr` GitHub review object is also not counted
+(merge-packet fetches issue `comments`, not `reviews`, and the
+`## Aragora review-pr:` heading resolves to `unknown_model_reviewer`).
+Reaching quorum therefore requires genuinely distinct model **lineages** —
+router/product markers such as `codex` or `factory` do not count as separate
+families. The recognizable-header / lineage-counting fix is tracked by
+[#7472](https://github.com/synaptent/aragora/pull/7472) (Tier 4 pre-approval,
+awaiting operator design-review); until it lands, quorum-blocked PRs are a
+human merge gate, not an evidence-tooling task, and evidence comments must
+never be hand-fabricated.
 
 ### `B2` guard expansion criteria
 


### PR DESCRIPTION
## Summary

Bounded docs-only update to the canonical next-steps doc. Two things, both promoted/recorded from work that already exists elsewhere in the repo — **no new substrate**:

1. **Governance-substrate freeze.** Promotes the Sprint 2 anti-goal from `docs/FOCUS.md` into `docs/status/NEXT_STEPS_CANONICAL.md` so it outlives the sprint window: no new review-queue / settlement / merge-quorum / steering meta-tooling unless it (a) directly unblocks B0 truth, external receipt proof, or the non-operator demo path, **or** (b) closes/supersedes an existing open PR in the same surface.
2. **Quorum-evidence countability learning** (surfaced while settling the #7509/#7507 stack): model-quorum signals only count as exact-head PR *comments* (family-named heading + head-SHA citation + review/dogfood trigger). Advisory `--no-publish` reviews and *published* `review-pr` GitHub review objects are **not** counted (merge-packet fetches issue `comments`, not `reviews`; the `## Aragora review-pr:` heading resolves to `unknown_model_reviewer`). Reaching quorum needs distinct model *lineages* — router/product markers like `codex`/`factory` don't count as separate families. The recognizable-header / lineage-counting fix is tracked by #7472.

## Why this is in-scope and not sprawl

- Updates an existing canonical doc (last touched 2026-05-13, stale); creates no new doc, no new issue, no new tooling.
- Cross-references existing artifacts (`FOCUS.md` Sprint 2 anti-goals, #7472) rather than duplicating them.
- The countability mismatch itself is **already tracked** by #7472 — this PR only makes the operating consequence canonical.

## Status

Draft — left for operator review. Not marked ready; no merge authorization requested for this docs change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)