### PR TITLE
fix(compliance): detect structured PHI identifiers in compliance check (#7394)

### DIFF
--- a/aragora/compliance/framework.py
+++ b/aragora/compliance/framework.py
@@ -20,6 +20,8 @@ from enum import Enum
 from typing import Any
 from re import Pattern
 
+from aragora.compliance.phi_detectors import PHI_DETECTORS
+
 
 class ComplianceSeverity(Enum):
     """Severity levels for compliance issues."""
@@ -107,6 +109,10 @@ class ComplianceRule:
     severity: ComplianceSeverity
     pattern: str | None = None  # Regex pattern to match
     keywords: list[str] = field(default_factory=list)  # Keywords to detect
+    # Named validated-format detectors (e.g. "ssn", "npi") from PHI_DETECTORS.
+    # Used for structured identifiers whose precise format makes deterministic
+    # detection (with check-digit/range validation) the correct tool.
+    validators: list[str] = field(default_factory=list)
     recommendation: str = ""
     category: str = ""
     references: list[str] = field(default_factory=list)
@@ -166,6 +172,29 @@ class ComplianceRule:
                     )
                 )
                 break  # Only report once per keyword set
+
+        # Check validated structured-identifier detectors
+        for validator_name in self.validators:
+            detector = PHI_DETECTORS.get(validator_name)
+            if detector is None:
+                continue
+            for found in detector(content):
+                line_num = content[: found.start].count("\n") + 1
+                issues.append(
+                    ComplianceIssue(
+                        framework=self.framework,
+                        rule_id=self.id,
+                        severity=self.severity,
+                        description=self.description,
+                        recommendation=self.recommendation,
+                        matched_text=found.text,
+                        line_number=line_num,
+                        metadata={
+                            "category": self.category,
+                            "validator": validator_name,
+                        },
+                    )
+                )
 
         return issues
 
@@ -229,6 +258,80 @@ HIPAA_FRAMEWORK = ComplianceFramework(
                 "social security",
             ],
             recommendation="Ensure PHI is encrypted at rest and in transit. Apply minimum necessary standard.",
+            category="privacy",
+        ),
+        # Structured identifier detectors (validated formats, not keywords).
+        # These detect the actual PHI values in content -- SSNs, NPIs, ICD-10
+        # codes, MRNs, dates of birth, emails, phone numbers -- which the
+        # keyword/regex rules above cannot find.
+        ComplianceRule(
+            id="hipaa-phi-ssn",
+            framework="hipaa",
+            name="SSN in Content",
+            description="Social Security Number detected (direct PHI identifier)",
+            severity=ComplianceSeverity.CRITICAL,
+            validators=["ssn"],
+            recommendation="Remove or tokenize SSNs. Encrypt and restrict access under the minimum necessary standard.",
+            category="privacy",
+        ),
+        ComplianceRule(
+            id="hipaa-phi-npi",
+            framework="hipaa",
+            name="NPI in Content",
+            description="National Provider Identifier detected (provider PHI identifier)",
+            severity=ComplianceSeverity.HIGH,
+            validators=["npi"],
+            recommendation="Restrict and audit access to provider identifiers. Encrypt at rest and in transit.",
+            category="privacy",
+        ),
+        ComplianceRule(
+            id="hipaa-phi-icd10",
+            framework="hipaa",
+            name="ICD-10 Diagnosis Code",
+            description="ICD-10 diagnosis code detected (health condition PHI)",
+            severity=ComplianceSeverity.HIGH,
+            validators=["icd10"],
+            recommendation="Treat diagnosis codes as PHI. Encrypt and apply the minimum necessary standard.",
+            category="privacy",
+        ),
+        ComplianceRule(
+            id="hipaa-phi-mrn",
+            framework="hipaa",
+            name="Medical Record Number",
+            description="Medical Record Number detected (direct PHI identifier)",
+            severity=ComplianceSeverity.CRITICAL,
+            validators=["mrn"],
+            recommendation="Remove or tokenize MRNs. Encrypt and restrict access under the minimum necessary standard.",
+            category="privacy",
+        ),
+        ComplianceRule(
+            id="hipaa-phi-dob",
+            framework="hipaa",
+            name="Date of Birth",
+            description="Date of birth detected (PHI identifier under the Safe Harbor method)",
+            severity=ComplianceSeverity.HIGH,
+            validators=["dob"],
+            recommendation="De-identify dates per HIPAA Safe Harbor (retain year only) where feasible.",
+            category="privacy",
+        ),
+        ComplianceRule(
+            id="hipaa-phi-email",
+            framework="hipaa",
+            name="Email Address",
+            description="Email address detected (PHI identifier under the Safe Harbor method)",
+            severity=ComplianceSeverity.HIGH,
+            validators=["email"],
+            recommendation="Treat contact details as PHI. Encrypt and restrict access.",
+            category="privacy",
+        ),
+        ComplianceRule(
+            id="hipaa-phi-phone",
+            framework="hipaa",
+            name="Phone Number",
+            description="Telephone number detected (PHI identifier under the Safe Harbor method)",
+            severity=ComplianceSeverity.HIGH,
+            validators=["phone"],
+            recommendation="Treat contact details as PHI. Encrypt and restrict access.",
             category="privacy",
         ),
         ComplianceRule(

--- a/aragora/compliance/framework.py
+++ b/aragora/compliance/framework.py
@@ -109,13 +109,20 @@ class ComplianceRule:
     severity: ComplianceSeverity
     pattern: str | None = None  # Regex pattern to match
     keywords: list[str] = field(default_factory=list)  # Keywords to detect
-    # Named validated-format detectors (e.g. "ssn", "npi") from PHI_DETECTORS.
-    # Used for structured identifiers whose precise format makes deterministic
-    # detection (with check-digit/range validation) the correct tool.
-    validators: list[str] = field(default_factory=list)
     recommendation: str = ""
     category: str = ""
     references: list[str] = field(default_factory=list)
+    # Named validated-format detectors (e.g. "ssn", "npi") from PHI_DETECTORS.
+    # Used for structured identifiers whose precise format makes deterministic
+    # detection (with check-digit/range validation) the correct tool.
+    #
+    # Appended at the END of the field list (after ``references``) so the
+    # generated ``__init__`` positional order matches pre-PHI callers that
+    # construct rules positionally (``ComplianceRule(..., pattern, keywords,
+    # recommendation, category, references)``). Adding it earlier would shift
+    # ``recommendation``/``category``/``references`` into the wrong slots and
+    # cause ``check()`` to iterate a recommendation string char-by-char.
+    validators: list[str] = field(default_factory=list)
 
     # Compiled regex (lazy)
     _compiled_pattern: Pattern | None = None

--- a/aragora/compliance/phi_detectors.py
+++ b/aragora/compliance/phi_detectors.py
@@ -82,8 +82,10 @@ def detect_ssn(content: str) -> list[DetectorMatch]:
 # NPI (National Provider Identifier)
 # ---------------------------------------------------------------------------
 
-# 10-digit number, optionally labeled with "NPI".
+# 10-digit number, labeled with "NPI" to avoid false positives on arbitrary
+# account IDs, timestamps, or phone-like values that happen to pass Luhn.
 _NPI_RE = re.compile(r"\b(\d{10})\b")
+_NPI_CONTEXT_RE = re.compile(r"\bNPI\b", re.IGNORECASE)
 
 
 def detect_npi(content: str) -> list[DetectorMatch]:
@@ -94,6 +96,9 @@ def detect_npi(content: str) -> list[DetectorMatch]:
     """
     matches: list[DetectorMatch] = []
     for m in _NPI_RE.finditer(content):
+        context = content[max(0, m.start() - 24) : m.start()]
+        if not _NPI_CONTEXT_RE.search(context):
+            continue
         candidate = m.group(1)
         if _luhn_is_valid("80840" + candidate):
             matches.append(DetectorMatch(text=m.group(0), start=m.start()))
@@ -107,12 +112,17 @@ def detect_npi(content: str) -> list[DetectorMatch]:
 # ICD-10-CM: letter, 2 digits, optional decimal + up to 4 alnum chars.
 # Exclude I (capital i) ambiguity by requiring the trailing structure.
 _ICD10_RE = re.compile(r"\b([A-TV-Z][0-9][0-9A-Z](?:\.[0-9A-Z]{1,4})?)\b")
+_ICD10_CONTEXT_RE = re.compile(r"\b(?:ICD-?10|diagnos(?:is|ed)|dx|condition|code)\b", re.IGNORECASE)
 
 
 def detect_icd10(content: str) -> list[DetectorMatch]:
     """Detect ICD-10-CM diagnosis codes by format."""
     matches: list[DetectorMatch] = []
     for m in _ICD10_RE.finditer(content):
+        if "." not in m.group(0):
+            context = content[max(0, m.start() - 40) : m.start()]
+            if not _ICD10_CONTEXT_RE.search(context):
+                continue
         matches.append(DetectorMatch(text=m.group(0), start=m.start()))
     return matches
 
@@ -143,6 +153,7 @@ def detect_mrn(content: str) -> list[DetectorMatch]:
 
 # ISO (YYYY-MM-DD) or US (MM/DD/YYYY) numeric dates, optionally DOB-labeled.
 _DATE_RE = re.compile(r"\b(?:(\d{4})-(\d{2})-(\d{2})|(\d{1,2})/(\d{1,2})/(\d{4}))\b")
+_DOB_CONTEXT_RE = re.compile(r"\b(?:DOB|date\s+of\s+birth|birth\s+date|born)\b", re.IGNORECASE)
 
 
 def _valid_date_parts(year: int, month: int, day: int) -> bool:
@@ -153,6 +164,9 @@ def detect_dob(content: str) -> list[DetectorMatch]:
     """Detect dates of birth (ISO or US numeric formats) with range checks."""
     matches: list[DetectorMatch] = []
     for m in _DATE_RE.finditer(content):
+        context = content[max(0, m.start() - 40) : m.start()]
+        if not _DOB_CONTEXT_RE.search(context):
+            continue
         if m.group(1):  # ISO
             year, month, day = int(m.group(1)), int(m.group(2)), int(m.group(3))
         else:  # US
@@ -180,7 +194,7 @@ def detect_email(content: str) -> list[DetectorMatch]:
 
 # US/NANP phone numbers with common separators, optional +1 / parens.
 _PHONE_RE = re.compile(
-    r"(?<![\d-])(?:\+?1[-.\s]?)?(?:\(\d{3}\)|\d{3})[-.\s]\d{3}[-.\s]\d{4}(?![\d-])"
+    r"(?<![\d-])(?:\+?1[-.\s]?)?(?:(?:\(\d{3}\)[-.\s]?)|(?:\d{3}[-.\s]))\d{3}[-.\s]\d{4}(?![\d-])"
 )
 
 

--- a/aragora/compliance/phi_detectors.py
+++ b/aragora/compliance/phi_detectors.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+from datetime import date
 from typing import Callable
 
 
@@ -96,8 +97,9 @@ def detect_npi(content: str) -> list[DetectorMatch]:
     """
     matches: list[DetectorMatch] = []
     for m in _NPI_RE.finditer(content):
-        context = content[max(0, m.start() - 24) : m.start()]
-        if not _NPI_CONTEXT_RE.search(context):
+        before = content[max(0, m.start() - 24) : m.start()]
+        after = content[m.end() : min(len(content), m.end() + 24)]
+        if not (_NPI_CONTEXT_RE.search(before) or _NPI_CONTEXT_RE.search(after)):
             continue
         candidate = m.group(1)
         if _luhn_is_valid("80840" + candidate):
@@ -110,8 +112,8 @@ def detect_npi(content: str) -> list[DetectorMatch]:
 # ---------------------------------------------------------------------------
 
 # ICD-10-CM: letter, 2 digits, optional decimal + up to 4 alnum chars.
-# Exclude I (capital i) ambiguity by requiring the trailing structure.
-_ICD10_RE = re.compile(r"\b([A-TV-Z][0-9][0-9A-Z](?:\.[0-9A-Z]{1,4})?)\b")
+# Context is required below because this format overlaps with technical tokens.
+_ICD10_RE = re.compile(r"\b([A-Z][0-9][0-9A-Z](?:\.[0-9A-Z]{1,4})?)\b")
 _ICD10_CONTEXT_RE = re.compile(r"\b(?:ICD-?10|diagnos(?:is|ed)|dx|condition|code)\b", re.IGNORECASE)
 
 
@@ -119,10 +121,9 @@ def detect_icd10(content: str) -> list[DetectorMatch]:
     """Detect ICD-10-CM diagnosis codes by format."""
     matches: list[DetectorMatch] = []
     for m in _ICD10_RE.finditer(content):
-        if "." not in m.group(0):
-            context = content[max(0, m.start() - 40) : m.start()]
-            if not _ICD10_CONTEXT_RE.search(context):
-                continue
+        context = content[max(0, m.start() - 40) : m.start()]
+        if not _ICD10_CONTEXT_RE.search(context):
+            continue
         matches.append(DetectorMatch(text=m.group(0), start=m.start()))
     return matches
 
@@ -157,7 +158,13 @@ _DOB_CONTEXT_RE = re.compile(r"\b(?:DOB|date\s+of\s+birth|birth\s+date|born)\b",
 
 
 def _valid_date_parts(year: int, month: int, day: int) -> bool:
-    return 1900 <= year <= 2100 and 1 <= month <= 12 and 1 <= day <= 31
+    if not 1900 <= year <= 2100:
+        return False
+    try:
+        date(year, month, day)
+    except ValueError:
+        return False
+    return True
 
 
 def detect_dob(content: str) -> list[DetectorMatch]:

--- a/aragora/compliance/phi_detectors.py
+++ b/aragora/compliance/phi_detectors.py
@@ -1,0 +1,215 @@
+"""Validated structured-identifier detectors for PHI/PII.
+
+These are deterministic, *format-validated* detectors for well-defined
+structured identifiers (SSN, NPI, ICD-10, MRN, date of birth, email, phone).
+They are NOT semantic classifiers -- each identifier has a precise, published
+format, so format detection (with check-digit / range validation where one
+exists) is the industry-standard correct tool here (cf. Microsoft Presidio).
+
+Each detector is a callable ``(content: str) -> list[DetectorMatch]`` returning
+the matched substring plus its start offset, so the framework can attach a line
+number and build a :class:`~aragora.compliance.framework.ComplianceIssue`.
+
+The framework wires these in through the new ``validators`` field on
+``ComplianceRule`` so they share the existing finding model and severity/scoring
+path rather than forming a parallel system.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Callable
+
+
+@dataclass(frozen=True)
+class DetectorMatch:
+    """A single structured-identifier match within content."""
+
+    text: str
+    start: int
+
+
+# A named detector: takes content, returns the matches it found.
+Detector = Callable[[str], list[DetectorMatch]]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _luhn_is_valid(digits: str) -> bool:
+    """Return True if ``digits`` passes the Luhn (mod-10) check."""
+    total = 0
+    reverse = digits[::-1]
+    for idx, char in enumerate(reverse):
+        digit = ord(char) - ord("0")
+        if idx % 2 == 1:
+            digit *= 2
+            if digit > 9:
+                digit -= 9
+        total += digit
+    return total % 10 == 0
+
+
+# ---------------------------------------------------------------------------
+# SSN
+# ---------------------------------------------------------------------------
+
+# US SSN: AAA-GG-SSSS (dashes or spaces). Word-boundary anchored.
+_SSN_RE = re.compile(r"\b(\d{3})[- ](\d{2})[- ](\d{4})\b")
+
+
+def detect_ssn(content: str) -> list[DetectorMatch]:
+    """Detect US Social Security Numbers with structural validation.
+
+    Rejects allocations that the SSA never issues: area 000/666/900-999,
+    group 00, serial 0000.
+    """
+    matches: list[DetectorMatch] = []
+    for m in _SSN_RE.finditer(content):
+        area, group, serial = m.group(1), m.group(2), m.group(3)
+        if area in ("000", "666") or area[0] == "9":
+            continue
+        if group == "00" or serial == "0000":
+            continue
+        matches.append(DetectorMatch(text=m.group(0), start=m.start()))
+    return matches
+
+
+# ---------------------------------------------------------------------------
+# NPI (National Provider Identifier)
+# ---------------------------------------------------------------------------
+
+# 10-digit number, optionally labeled with "NPI".
+_NPI_RE = re.compile(r"\b(\d{10})\b")
+
+
+def detect_npi(content: str) -> list[DetectorMatch]:
+    """Detect NPI numbers (10 digits, Luhn-valid with 80840 prefix).
+
+    Per CMS, NPI check-digit validation prepends the constant ``80840`` before
+    running the Luhn algorithm on all 15 digits.
+    """
+    matches: list[DetectorMatch] = []
+    for m in _NPI_RE.finditer(content):
+        candidate = m.group(1)
+        if _luhn_is_valid("80840" + candidate):
+            matches.append(DetectorMatch(text=m.group(0), start=m.start()))
+    return matches
+
+
+# ---------------------------------------------------------------------------
+# ICD-10 diagnosis codes
+# ---------------------------------------------------------------------------
+
+# ICD-10-CM: letter, 2 digits, optional decimal + up to 4 alnum chars.
+# Exclude I (capital i) ambiguity by requiring the trailing structure.
+_ICD10_RE = re.compile(r"\b([A-TV-Z][0-9][0-9A-Z](?:\.[0-9A-Z]{1,4})?)\b")
+
+
+def detect_icd10(content: str) -> list[DetectorMatch]:
+    """Detect ICD-10-CM diagnosis codes by format."""
+    matches: list[DetectorMatch] = []
+    for m in _ICD10_RE.finditer(content):
+        matches.append(DetectorMatch(text=m.group(0), start=m.start()))
+    return matches
+
+
+# ---------------------------------------------------------------------------
+# MRN (Medical Record Number)
+# ---------------------------------------------------------------------------
+
+# MRNs have no universal format, so detection is label-anchored to avoid
+# false positives on arbitrary numbers.
+_MRN_RE = re.compile(
+    r"\b(?:MRN|medical\s+record\s+(?:number|no\.?|#))\b\s*[:#]?\s*([A-Z0-9-]{5,12})",
+    re.IGNORECASE,
+)
+
+
+def detect_mrn(content: str) -> list[DetectorMatch]:
+    """Detect labeled Medical Record Numbers."""
+    matches: list[DetectorMatch] = []
+    for m in _MRN_RE.finditer(content):
+        matches.append(DetectorMatch(text=m.group(0), start=m.start()))
+    return matches
+
+
+# ---------------------------------------------------------------------------
+# Date of birth
+# ---------------------------------------------------------------------------
+
+# ISO (YYYY-MM-DD) or US (MM/DD/YYYY) numeric dates, optionally DOB-labeled.
+_DATE_RE = re.compile(r"\b(?:(\d{4})-(\d{2})-(\d{2})|(\d{1,2})/(\d{1,2})/(\d{4}))\b")
+
+
+def _valid_date_parts(year: int, month: int, day: int) -> bool:
+    return 1900 <= year <= 2100 and 1 <= month <= 12 and 1 <= day <= 31
+
+
+def detect_dob(content: str) -> list[DetectorMatch]:
+    """Detect dates of birth (ISO or US numeric formats) with range checks."""
+    matches: list[DetectorMatch] = []
+    for m in _DATE_RE.finditer(content):
+        if m.group(1):  # ISO
+            year, month, day = int(m.group(1)), int(m.group(2)), int(m.group(3))
+        else:  # US
+            month, day, year = int(m.group(4)), int(m.group(5)), int(m.group(6))
+        if _valid_date_parts(year, month, day):
+            matches.append(DetectorMatch(text=m.group(0), start=m.start()))
+    return matches
+
+
+# ---------------------------------------------------------------------------
+# Email
+# ---------------------------------------------------------------------------
+
+_EMAIL_RE = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
+
+
+def detect_email(content: str) -> list[DetectorMatch]:
+    """Detect email addresses."""
+    return [DetectorMatch(text=m.group(0), start=m.start()) for m in _EMAIL_RE.finditer(content)]
+
+
+# ---------------------------------------------------------------------------
+# Phone
+# ---------------------------------------------------------------------------
+
+# US/NANP phone numbers with common separators, optional +1 / parens.
+_PHONE_RE = re.compile(
+    r"(?<![\d-])(?:\+?1[-.\s]?)?(?:\(\d{3}\)|\d{3})[-.\s]\d{3}[-.\s]\d{4}(?![\d-])"
+)
+
+
+def detect_phone(content: str) -> list[DetectorMatch]:
+    """Detect telephone numbers in common North American formats."""
+    return [DetectorMatch(text=m.group(0), start=m.start()) for m in _PHONE_RE.finditer(content)]
+
+
+# Registry of named detectors, referenced by ComplianceRule.validators.
+PHI_DETECTORS: dict[str, Detector] = {
+    "ssn": detect_ssn,
+    "npi": detect_npi,
+    "icd10": detect_icd10,
+    "mrn": detect_mrn,
+    "dob": detect_dob,
+    "email": detect_email,
+    "phone": detect_phone,
+}
+
+
+__all__ = [
+    "DetectorMatch",
+    "Detector",
+    "PHI_DETECTORS",
+    "detect_ssn",
+    "detect_npi",
+    "detect_icd10",
+    "detect_mrn",
+    "detect_dob",
+    "detect_email",
+    "detect_phone",
+]

--- a/aragora/compliance/phi_detectors.py
+++ b/aragora/compliance/phi_detectors.py
@@ -139,8 +139,17 @@ def detect_icd10(content: str) -> list[DetectorMatch]:
 
 # MRNs have no universal format, so detection is label-anchored to avoid
 # false positives on arbitrary numbers.
+#
+# The trailing boundary after the label alternation is a negative lookahead for
+# a word character (``(?![A-Za-z0-9])``) rather than ``\b``. ``\b`` fails when a
+# label variant ends in a non-word char (``#`` in "Medical Record #" or ``.`` in
+# "Medical Record no.") followed by whitespace, because there is no word/non-word
+# transition there -- which silently dropped those common labels. The lookahead
+# accepts the end of any variant (letter, ``.``, or ``#``) as long as the label
+# token is not glued to additional word chars. All quantifiers remain bounded so
+# the pattern stays linear (no ReDoS).
 _MRN_RE = re.compile(
-    r"\b(?:MRN|medical\s+record\s+(?:number|no\.?|#))\b\s*[:#]?\s*([A-Z0-9-]{5,12})",
+    r"\b(?:MRN|medical\s+record\s+(?:number|no\.?|#))(?![A-Za-z0-9])\s*[:#]?\s*([A-Z0-9-]{5,12})",
     re.IGNORECASE,
 )
 

--- a/aragora/compliance/phi_detectors.py
+++ b/aragora/compliance/phi_detectors.py
@@ -58,8 +58,9 @@ def _luhn_is_valid(digits: str) -> bool:
 # SSN
 # ---------------------------------------------------------------------------
 
-# US SSN: AAA-GG-SSSS (dashes or spaces). Word-boundary anchored.
-_SSN_RE = re.compile(r"\b(\d{3})[- ](\d{2})[- ](\d{4})\b")
+# US SSN: AAA-GG-SSSS, optionally unseparated when explicitly labeled.
+_SSN_RE = re.compile(r"\b(\d{3})([- ]?)(\d{2})([- ]?)(\d{4})\b")
+_SSN_CONTEXT_RE = re.compile(r"\b(?:SSN|social\s+security)\b", re.IGNORECASE)
 
 
 def detect_ssn(content: str) -> list[DetectorMatch]:
@@ -70,7 +71,11 @@ def detect_ssn(content: str) -> list[DetectorMatch]:
     """
     matches: list[DetectorMatch] = []
     for m in _SSN_RE.finditer(content):
-        area, group, serial = m.group(1), m.group(2), m.group(3)
+        if not (m.group(2) or m.group(4)):
+            context = content[max(0, m.start() - 24) : m.start()]
+            if not _SSN_CONTEXT_RE.search(context):
+                continue
+        area, group, serial = m.group(1), m.group(3), m.group(5)
         if area in ("000", "666") or area[0] == "9":
             continue
         if group == "00" or serial == "0000":
@@ -114,14 +119,14 @@ def detect_npi(content: str) -> list[DetectorMatch]:
 # ICD-10-CM: letter, 2 digits, optional decimal + up to 4 alnum chars.
 # Context is required below because this format overlaps with technical tokens.
 _ICD10_RE = re.compile(r"\b([A-Z][0-9][0-9A-Z](?:\.[0-9A-Z]{1,4})?)\b")
-_ICD10_CONTEXT_RE = re.compile(r"\b(?:ICD-?10|diagnos(?:is|ed)|dx|condition|code)\b", re.IGNORECASE)
+_ICD10_CONTEXT_RE = re.compile(r"\b(?:ICD-?10|diagnos(?:is|ed)|dx|condition)\b", re.IGNORECASE)
 
 
 def detect_icd10(content: str) -> list[DetectorMatch]:
     """Detect ICD-10-CM diagnosis codes by format."""
     matches: list[DetectorMatch] = []
     for m in _ICD10_RE.finditer(content):
-        context = content[max(0, m.start() - 40) : m.start()]
+        context = content[max(0, m.start() - 40) : min(len(content), m.end() + 40)]
         if not _ICD10_CONTEXT_RE.search(context):
             continue
         matches.append(DetectorMatch(text=m.group(0), start=m.start()))
@@ -144,7 +149,7 @@ def detect_mrn(content: str) -> list[DetectorMatch]:
     """Detect labeled Medical Record Numbers."""
     matches: list[DetectorMatch] = []
     for m in _MRN_RE.finditer(content):
-        matches.append(DetectorMatch(text=m.group(0), start=m.start()))
+        matches.append(DetectorMatch(text=m.group(1), start=m.start(1)))
     return matches
 
 
@@ -171,7 +176,7 @@ def detect_dob(content: str) -> list[DetectorMatch]:
     """Detect dates of birth (ISO or US numeric formats) with range checks."""
     matches: list[DetectorMatch] = []
     for m in _DATE_RE.finditer(content):
-        context = content[max(0, m.start() - 40) : m.start()]
+        context = content[max(0, m.start() - 40) : min(len(content), m.end() + 40)]
         if not _DOB_CONTEXT_RE.search(context):
             continue
         if m.group(1):  # ISO

--- a/aragora/compliance/phi_detectors.py
+++ b/aragora/compliance/phi_detectors.py
@@ -146,10 +146,19 @@ def detect_icd10(content: str) -> list[DetectorMatch]:
 # "Medical Record no.") followed by whitespace, because there is no word/non-word
 # transition there -- which silently dropped those common labels. The lookahead
 # accepts the end of any variant (letter, ``.``, or ``#``) as long as the label
-# token is not glued to additional word chars. All quantifiers remain bounded so
-# the pattern stays linear (no ReDoS).
+# token is not glued to additional word chars.
+#
+# The captured identifier must contain at least one digit
+# (``(?=[A-Z0-9-]{0,11}\d)``). Without this constraint the ``5..12``-char token
+# greedily swallowed any ordinary word that happened to follow the label text
+# (e.g. "MRN status", "medical record number REDACTED"), producing false
+# positives. Real MRNs are numeric or alphanumeric, never plain English words,
+# so requiring a digit removes those matches while preserving genuine MRNs. All
+# quantifiers remain bounded (the digit lookahead spans at most 12 chars) so the
+# pattern stays linear (no ReDoS).
 _MRN_RE = re.compile(
-    r"\b(?:MRN|medical\s+record\s+(?:number|no\.?|#))(?![A-Za-z0-9])\s*[:#]?\s*([A-Z0-9-]{5,12})",
+    r"\b(?:MRN|medical\s+record\s+(?:number|no\.?|#))(?![A-Za-z0-9])\s*[:#]?\s*"
+    r"(?=[A-Z0-9-]{0,11}\d)([A-Z0-9-]{5,12})",
     re.IGNORECASE,
 )
 

--- a/aragora/compliance/phi_detectors.py
+++ b/aragora/compliance/phi_detectors.py
@@ -192,12 +192,38 @@ def detect_dob(content: str) -> list[DetectorMatch]:
 # Email
 # ---------------------------------------------------------------------------
 
-_EMAIL_RE = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
+# Both the local part and the domain are matched as sequences of dot-separated
+# labels whose label class deliberately *excludes* ``.``. Because no character
+# class overlaps the literal ``.`` separator, a given dot in the input can only
+# be consumed one way -- there is no ambiguous split for the engine to backtrack
+# through. Every quantifier is additionally *bounded* to RFC-aligned limits
+# (local/domain labels up to 64/63 chars, at most a handful of dot-segments,
+# TLD 2-24 letters), so the per-position matching cost is a constant. Together
+# these make matching linear in the length of the input and immune to the
+# catastrophic backtracking (ReDoS) of an unbounded ``[A-Za-z0-9.-]+`` middle
+# class on adversarial input such as ``x@`` + ``a.`` * N or ``x`` + ``.x`` * N.
+_EMAIL_RE = re.compile(
+    r"\b[A-Za-z0-9_%+-]{1,64}(?:\.[A-Za-z0-9_%+-]{1,64}){0,8}"
+    r"@[A-Za-z0-9-]{1,63}(?:\.[A-Za-z0-9-]{1,63}){0,8}\.[A-Za-z]{2,24}\b"
+)
+
+# Defense-in-depth: a single contiguous run of email-ish characters longer than
+# this cannot be a real address (RFC limits a whole address to ~320 chars). The
+# detector skips over such runs rather than feeding them to the engine, which
+# bounds worst-case work even if the pattern above were ever weakened.
+_MAX_EMAIL_TOKEN_LEN = 512
+_EMAIL_TOKEN_RE = re.compile(r"[A-Za-z0-9._%+@-]{1," + str(_MAX_EMAIL_TOKEN_LEN) + r"}")
 
 
 def detect_email(content: str) -> list[DetectorMatch]:
     """Detect email addresses."""
-    return [DetectorMatch(text=m.group(0), start=m.start()) for m in _EMAIL_RE.finditer(content)]
+    matches: list[DetectorMatch] = []
+    # Scan in bounded email-ish tokens so no single regex application ever sees
+    # an unbounded adversarial run (defense-in-depth for the linear pattern).
+    for token in _EMAIL_TOKEN_RE.finditer(content):
+        for m in _EMAIL_RE.finditer(token.group(0)):
+            matches.append(DetectorMatch(text=m.group(0), start=token.start() + m.start()))
+    return matches
 
 
 # ---------------------------------------------------------------------------

--- a/tests/compliance/test_framework.py
+++ b/tests/compliance/test_framework.py
@@ -195,6 +195,39 @@ class TestComplianceRule:
         assert len(rule.keywords) == 3
         assert "sensitive" in rule.keywords
 
+    def test_positional_construction_preserves_field_assignment(self):
+        """Regression: positional args must keep their pre-PHI meaning.
+
+        ``validators`` was originally inserted *before* ``recommendation``/
+        ``category``/``references``, which shifted the generated ``__init__``
+        positional order. A pre-PHI caller passing ``recommendation`` /
+        ``category`` / ``references`` positionally (after ``pattern`` and
+        ``keywords``) would have had the recommendation string land in
+        ``validators`` -- then ``check()`` would iterate it char-by-char as
+        detector names. ``validators`` now lives at the end of the field list,
+        restoring the legacy positional ABI.
+        """
+        rule = ComplianceRule(
+            "POS-001",  # id
+            "custom",  # framework
+            "Positional Rule",  # name
+            "Built with positional args",  # description
+            ComplianceSeverity.HIGH,  # severity
+            r"secret\s*=",  # pattern
+            ["token"],  # keywords
+            "Redact secrets before logging",  # recommendation
+            "security",  # category
+            ["INTERNAL-1"],  # references
+        )
+        assert rule.recommendation == "Redact secrets before logging"
+        assert rule.category == "security"
+        assert rule.references == ["INTERNAL-1"]
+        # validators defaults to an empty list, NOT the recommendation string.
+        assert rule.validators == []
+        # check() must not treat the recommendation string as detector names.
+        issues = rule.check("password secret = 'x'")
+        assert all(i.recommendation == "Redact secrets before logging" for i in issues)
+
     def test_rule_get_pattern_compiles_regex(self):
         """Test that get_pattern compiles the regex."""
         rule = ComplianceRule(

--- a/tests/compliance/test_phi_identifiers.py
+++ b/tests/compliance/test_phi_identifiers.py
@@ -177,6 +177,20 @@ class TestMRNDetector:
         mrn_issues = [i for i in result.issues if i.rule_id == "hipaa-phi-mrn"]
         assert mrn_issues[0].matched_text == "ABCD-12345"
 
+    def test_medical_record_hash_label(self):
+        """Regression: "Medical Record # 12345" was missed because the trailing
+        ``\\b`` after the label could not match between ``#`` and whitespace."""
+        manager = ComplianceFrameworkManager()
+        result = manager.check("Medical Record # 12345", frameworks=["hipaa"])
+        assert any(i.rule_id == "hipaa-phi-mrn" for i in result.issues)
+
+    def test_medical_record_no_dot_label(self):
+        """Regression: "Medical Record no. 12345" was missed because the trailing
+        ``\\b`` after the label could not match between ``.`` and whitespace."""
+        manager = ComplianceFrameworkManager()
+        result = manager.check("Medical Record no. 12345", frameworks=["hipaa"])
+        assert any(i.rule_id == "hipaa-phi-mrn" for i in result.issues)
+
 
 class TestNoFalsePositivesOnCleanContent:
     def test_clean_text_has_no_phi_findings(self):

--- a/tests/compliance/test_phi_identifiers.py
+++ b/tests/compliance/test_phi_identifiers.py
@@ -101,6 +101,11 @@ class TestNPIDetector:
         result = manager.check("Provider NPI 1234567890", frameworks=["hipaa"])
         assert not any(i.rule_id == "hipaa-phi-npi" for i in result.issues)
 
+    def test_luhn_passing_number_without_npi_context_is_not_npi(self):
+        manager = ComplianceFrameworkManager()
+        result = manager.check("Customer account 1234567893 was updated", frameworks=["hipaa"])
+        assert not any(i.rule_id == "hipaa-phi-npi" for i in result.issues)
+
 
 class TestICD10Detector:
     def test_valid_icd10_code(self):
@@ -113,6 +118,11 @@ class TestICD10Detector:
         manager = ComplianceFrameworkManager()
         result = manager.check("Code I10 hypertension", frameworks=["hipaa"])
         assert any(i.rule_id == "hipaa-phi-icd10" for i in result.issues)
+
+    def test_rejects_unlabeled_short_technical_tokens(self):
+        manager = ComplianceFrameworkManager()
+        result = manager.check("Built on 2024-01-15; see B12 in module A10.", frameworks=["hipaa"])
+        assert not any(i.rule_id == "hipaa-phi-icd10" for i in result.issues)
 
 
 class TestMRNDetector:
@@ -144,3 +154,16 @@ class TestNoFalsePositivesOnCleanContent:
             "hipaa-phi-phone",
         }
         assert not (phi_rule_ids & _rule_ids(result))
+
+    def test_clean_operational_dates_are_not_dates_of_birth(self):
+        manager = ComplianceFrameworkManager()
+        result = manager.check(
+            "Deployed on 2026-05-31 and reviewed 01/15/2025.",
+            frameworks=["hipaa"],
+        )
+        assert not any(i.rule_id == "hipaa-phi-dob" for i in result.issues)
+
+    def test_common_parenthesized_phone_without_space_is_detected(self):
+        manager = ComplianceFrameworkManager()
+        result = manager.check("Call patient at (555)123-4567", frameworks=["hipaa"])
+        assert any(i.rule_id == "hipaa-phi-phone" for i in result.issues)

--- a/tests/compliance/test_phi_identifiers.py
+++ b/tests/compliance/test_phi_identifiers.py
@@ -191,6 +191,29 @@ class TestMRNDetector:
         result = manager.check("Medical Record no. 12345", frameworks=["hipaa"])
         assert any(i.rule_id == "hipaa-phi-mrn" for i in result.issues)
 
+    @pytest.mark.parametrize(
+        "content",
+        [
+            "MRN status PENDING for the patient",
+            "medical record number REDACTED in the chart",
+            "Medical Record no. attached to file",
+            "MRN: UNKNOWN",
+            "medical record # PENDING",
+            "medical record number SUMMARY",
+        ],
+    )
+    def test_label_followed_by_plain_word_is_not_mrn(self, content):
+        """Regression: requiring a digit in the captured identifier prevents the
+        detector from flagging an ordinary word that follows the label text.
+
+        The cycle-2 change that widened the trailing label boundary to support
+        ``#``/``no.`` variants also let the ``5..12``-char token greedily capture
+        any following word as an "MRN". A genuine MRN is numeric/alphanumeric, so
+        the identifier group now demands at least one digit."""
+        manager = ComplianceFrameworkManager()
+        result = manager.check(content, frameworks=["hipaa"])
+        assert not any(i.rule_id == "hipaa-phi-mrn" for i in result.issues)
+
 
 class TestNoFalsePositivesOnCleanContent:
     def test_clean_text_has_no_phi_findings(self):

--- a/tests/compliance/test_phi_identifiers.py
+++ b/tests/compliance/test_phi_identifiers.py
@@ -71,6 +71,16 @@ class TestSSNDetector:
         result = manager.check("SSN: 078-05-1120", frameworks=["hipaa"])
         assert any(i.rule_id == "hipaa-phi-ssn" for i in result.issues)
 
+    def test_labeled_compact_ssn(self):
+        manager = ComplianceFrameworkManager()
+        result = manager.check("SSN: 078051120", frameworks=["hipaa"])
+        assert any(i.rule_id == "hipaa-phi-ssn" for i in result.issues)
+
+    def test_unlabeled_compact_ssn_is_not_detected(self):
+        manager = ComplianceFrameworkManager()
+        result = manager.check("Ticket 078051120 was processed", frameworks=["hipaa"])
+        assert not any(i.rule_id == "hipaa-phi-ssn" for i in result.issues)
+
     def test_rejects_invalid_area_000(self):
         manager = ComplianceFrameworkManager()
         result = manager.check("Code 000-12-3456 here", frameworks=["hipaa"])
@@ -121,7 +131,7 @@ class TestICD10Detector:
 
     def test_icd10_without_decimal(self):
         manager = ComplianceFrameworkManager()
-        result = manager.check("Code I10 hypertension", frameworks=["hipaa"])
+        result = manager.check("Diagnosis I10 hypertension", frameworks=["hipaa"])
         assert any(i.rule_id == "hipaa-phi-icd10" for i in result.issues)
 
     def test_rejects_unlabeled_short_technical_tokens(self):
@@ -134,9 +144,19 @@ class TestICD10Detector:
         result = manager.check("module A10.2 and version B12.3 shipped", frameworks=["hipaa"])
         assert not any(i.rule_id == "hipaa-phi-icd10" for i in result.issues)
 
+    def test_rejects_technical_status_code_context(self):
+        manager = ComplianceFrameworkManager()
+        result = manager.check("status code I10 returned by module R51", frameworks=["hipaa"])
+        assert not any(i.rule_id == "hipaa-phi-icd10" for i in result.issues)
+
     def test_u_prefixed_icd10_code_with_context(self):
         manager = ComplianceFrameworkManager()
         result = manager.check("Diagnosis U07.1 confirmed", frameworks=["hipaa"])
+        assert any(i.rule_id == "hipaa-phi-icd10" for i in result.issues)
+
+    def test_trailing_diagnosis_context_detects_icd10(self):
+        manager = ComplianceFrameworkManager()
+        result = manager.check("U07.1 was the diagnosis", frameworks=["hipaa"])
         assert any(i.rule_id == "hipaa-phi-icd10" for i in result.issues)
 
 
@@ -150,6 +170,12 @@ class TestMRNDetector:
         manager = ComplianceFrameworkManager()
         result = manager.check("Medical Record Number 7654321", frameworks=["hipaa"])
         assert any(i.rule_id == "hipaa-phi-mrn" for i in result.issues)
+
+    def test_mrn_matched_text_is_identifier_value(self):
+        manager = ComplianceFrameworkManager()
+        result = manager.check("MRN: ABCD-12345", frameworks=["hipaa"])
+        mrn_issues = [i for i in result.issues if i.rule_id == "hipaa-phi-mrn"]
+        assert mrn_issues[0].matched_text == "ABCD-12345"
 
 
 class TestNoFalsePositivesOnCleanContent:
@@ -183,7 +209,17 @@ class TestNoFalsePositivesOnCleanContent:
         result = manager.check("Patient DOB 1980-02-31", frameworks=["hipaa"])
         assert not any(i.rule_id == "hipaa-phi-dob" for i in result.issues)
 
+    def test_trailing_birth_context_detects_dob(self):
+        manager = ComplianceFrameworkManager()
+        result = manager.check("1980-03-15 is the patient's date of birth", frameworks=["hipaa"])
+        assert any(i.rule_id == "hipaa-phi-dob" for i in result.issues)
+
     def test_common_parenthesized_phone_without_space_is_detected(self):
         manager = ComplianceFrameworkManager()
         result = manager.check("Call patient at (555)123-4567", frameworks=["hipaa"])
+        assert any(i.rule_id == "hipaa-phi-phone" for i in result.issues)
+
+    def test_plus_one_phone_is_detected(self):
+        manager = ComplianceFrameworkManager()
+        result = manager.check("Call patient at +1 555-123-4567", frameworks=["hipaa"])
         assert any(i.rule_id == "hipaa-phi-phone" for i in result.issues)

--- a/tests/compliance/test_phi_identifiers.py
+++ b/tests/compliance/test_phi_identifiers.py
@@ -106,6 +106,11 @@ class TestNPIDetector:
         result = manager.check("Customer account 1234567893 was updated", frameworks=["hipaa"])
         assert not any(i.rule_id == "hipaa-phi-npi" for i in result.issues)
 
+    def test_trailing_npi_label_is_detected(self):
+        manager = ComplianceFrameworkManager()
+        result = manager.check("Provider 1234567893 (NPI)", frameworks=["hipaa"])
+        assert any(i.rule_id == "hipaa-phi-npi" for i in result.issues)
+
 
 class TestICD10Detector:
     def test_valid_icd10_code(self):
@@ -123,6 +128,16 @@ class TestICD10Detector:
         manager = ComplianceFrameworkManager()
         result = manager.check("Built on 2024-01-15; see B12 in module A10.", frameworks=["hipaa"])
         assert not any(i.rule_id == "hipaa-phi-icd10" for i in result.issues)
+
+    def test_rejects_unlabeled_decimal_technical_tokens(self):
+        manager = ComplianceFrameworkManager()
+        result = manager.check("module A10.2 and version B12.3 shipped", frameworks=["hipaa"])
+        assert not any(i.rule_id == "hipaa-phi-icd10" for i in result.issues)
+
+    def test_u_prefixed_icd10_code_with_context(self):
+        manager = ComplianceFrameworkManager()
+        result = manager.check("Diagnosis U07.1 confirmed", frameworks=["hipaa"])
+        assert any(i.rule_id == "hipaa-phi-icd10" for i in result.issues)
 
 
 class TestMRNDetector:
@@ -161,6 +176,11 @@ class TestNoFalsePositivesOnCleanContent:
             "Deployed on 2026-05-31 and reviewed 01/15/2025.",
             frameworks=["hipaa"],
         )
+        assert not any(i.rule_id == "hipaa-phi-dob" for i in result.issues)
+
+    def test_invalid_calendar_dates_are_not_dates_of_birth(self):
+        manager = ComplianceFrameworkManager()
+        result = manager.check("Patient DOB 1980-02-31", frameworks=["hipaa"])
         assert not any(i.rule_id == "hipaa-phi-dob" for i in result.issues)
 
     def test_common_parenthesized_phone_without_space_is_detected(self):

--- a/tests/compliance/test_phi_identifiers.py
+++ b/tests/compliance/test_phi_identifiers.py
@@ -1,0 +1,146 @@
+"""Tests for structured PHI identifier detection in the compliance framework.
+
+Covers the deterministic, validated format detectors integrated into the HIPAA
+framework: SSN, NPI (Luhn-checked), ICD-10, MRN, DOB, email, and phone numbers.
+
+These detectors close GitHub issue #7394, where ``aragora compliance check
+--frameworks hipaa`` against synthetic PHI only flagged the literal keyword
+"ssn"/"diagnosis" and missed the actual structured identifiers in the content.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.compliance.framework import (
+    ComplianceFrameworkManager,
+    ComplianceSeverity,
+)
+
+# Synthetic PHI string from issue #7394.
+SYNTHETIC_PHI = (
+    "Patient John Doe, SSN 123-45-6789, DOB 1980-03-15, was treated for diabetes "
+    "at Springfield General Hospital. Contact: john.doe@example.com, "
+    "phone 555-123-4567"
+)
+
+
+def _rule_ids(result) -> set[str]:
+    return {issue.rule_id for issue in result.issues}
+
+
+class TestStructuredPHIDetection:
+    """Structured identifiers are detected as HIPAA findings."""
+
+    @pytest.fixture
+    def result(self):
+        manager = ComplianceFrameworkManager()
+        return manager.check(SYNTHETIC_PHI, frameworks=["hipaa"])
+
+    def test_detects_ssn_value(self, result):
+        """The actual SSN value (not just the word 'ssn') is detected."""
+        ssn_issues = [i for i in result.issues if i.rule_id == "hipaa-phi-ssn"]
+        assert ssn_issues, f"SSN not detected. Rules: {_rule_ids(result)}"
+        assert "123-45-6789" in ssn_issues[0].matched_text
+        assert ssn_issues[0].severity == ComplianceSeverity.CRITICAL
+
+    def test_detects_date_of_birth(self, result):
+        dob_issues = [i for i in result.issues if i.rule_id == "hipaa-phi-dob"]
+        assert dob_issues, f"DOB not detected. Rules: {_rule_ids(result)}"
+        assert "1980-03-15" in dob_issues[0].matched_text
+
+    def test_detects_email(self, result):
+        email_issues = [i for i in result.issues if i.rule_id == "hipaa-phi-email"]
+        assert email_issues, f"Email not detected. Rules: {_rule_ids(result)}"
+        assert "john.doe@example.com" in email_issues[0].matched_text
+
+    def test_detects_phone(self, result):
+        phone_issues = [i for i in result.issues if i.rule_id == "hipaa-phi-phone"]
+        assert phone_issues, f"Phone not detected. Rules: {_rule_ids(result)}"
+        assert "555-123-4567" in phone_issues[0].matched_text
+
+    def test_result_is_non_compliant_with_multiple_findings(self, result):
+        """Repro should now surface several findings, not just one keyword."""
+        assert not result.compliant
+        assert len(result.issues) >= 4
+
+
+class TestSSNDetector:
+    def test_dashed_ssn(self):
+        manager = ComplianceFrameworkManager()
+        result = manager.check("SSN: 078-05-1120", frameworks=["hipaa"])
+        assert any(i.rule_id == "hipaa-phi-ssn" for i in result.issues)
+
+    def test_rejects_invalid_area_000(self):
+        manager = ComplianceFrameworkManager()
+        result = manager.check("Code 000-12-3456 here", frameworks=["hipaa"])
+        assert not any(i.rule_id == "hipaa-phi-ssn" for i in result.issues)
+
+    def test_rejects_invalid_group_00(self):
+        manager = ComplianceFrameworkManager()
+        result = manager.check("Value 123-00-6789", frameworks=["hipaa"])
+        assert not any(i.rule_id == "hipaa-phi-ssn" for i in result.issues)
+
+    def test_rejects_900_series(self):
+        manager = ComplianceFrameworkManager()
+        result = manager.check("Number 900-12-3456", frameworks=["hipaa"])
+        assert not any(i.rule_id == "hipaa-phi-ssn" for i in result.issues)
+
+
+class TestNPIDetector:
+    """NPI must pass the Luhn check (with the 80840 prefix)."""
+
+    def test_valid_npi(self):
+        # 1234567893 is a well-known valid example NPI (Luhn-valid).
+        manager = ComplianceFrameworkManager()
+        result = manager.check("Provider NPI 1234567893", frameworks=["hipaa"])
+        assert any(i.rule_id == "hipaa-phi-npi" for i in result.issues)
+
+    def test_invalid_npi_fails_luhn(self):
+        manager = ComplianceFrameworkManager()
+        result = manager.check("Provider NPI 1234567890", frameworks=["hipaa"])
+        assert not any(i.rule_id == "hipaa-phi-npi" for i in result.issues)
+
+
+class TestICD10Detector:
+    def test_valid_icd10_code(self):
+        # E11.9 = Type 2 diabetes mellitus without complications.
+        manager = ComplianceFrameworkManager()
+        result = manager.check("Diagnosed with E11.9", frameworks=["hipaa"])
+        assert any(i.rule_id == "hipaa-phi-icd10" for i in result.issues)
+
+    def test_icd10_without_decimal(self):
+        manager = ComplianceFrameworkManager()
+        result = manager.check("Code I10 hypertension", frameworks=["hipaa"])
+        assert any(i.rule_id == "hipaa-phi-icd10" for i in result.issues)
+
+
+class TestMRNDetector:
+    def test_labeled_mrn(self):
+        manager = ComplianceFrameworkManager()
+        result = manager.check("MRN: 00123456", frameworks=["hipaa"])
+        assert any(i.rule_id == "hipaa-phi-mrn" for i in result.issues)
+
+    def test_medical_record_number_label(self):
+        manager = ComplianceFrameworkManager()
+        result = manager.check("Medical Record Number 7654321", frameworks=["hipaa"])
+        assert any(i.rule_id == "hipaa-phi-mrn" for i in result.issues)
+
+
+class TestNoFalsePositivesOnCleanContent:
+    def test_clean_text_has_no_phi_findings(self):
+        manager = ComplianceFrameworkManager()
+        result = manager.check(
+            "The deployment pipeline uses TLS 1.2 and rotates keys monthly.",
+            frameworks=["hipaa"],
+        )
+        phi_rule_ids = {
+            "hipaa-phi-ssn",
+            "hipaa-phi-npi",
+            "hipaa-phi-icd10",
+            "hipaa-phi-mrn",
+            "hipaa-phi-dob",
+            "hipaa-phi-email",
+            "hipaa-phi-phone",
+        }
+        assert not (phi_rule_ids & _rule_ids(result))

--- a/tests/compliance/test_phi_identifiers.py
+++ b/tests/compliance/test_phi_identifiers.py
@@ -223,3 +223,94 @@ class TestNoFalsePositivesOnCleanContent:
         manager = ComplianceFrameworkManager()
         result = manager.check("Call patient at +1 555-123-4567", frameworks=["hipaa"])
         assert any(i.rule_id == "hipaa-phi-phone" for i in result.issues)
+
+
+class TestEmailDetectorReDoS:
+    """Regression tests for the email detector ReDoS (CWE-1333).
+
+    The original pattern ``[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}``
+    had an unbounded middle class that overlapped the literal ``.`` separator,
+    causing catastrophic (quadratic) backtracking. Crafted input such as
+    ``x@`` + ``a.`` * N or ``x`` + ``.x`` * N pinned a CPU for many seconds at
+    only tens of KB -- an authenticated DoS reachable via
+    ``POST /api/v1/compliance/check`` and ``compliance check --file``.
+
+    The hardened pattern uses non-overlapping, RFC-bounded labels so matching
+    is linear; these tests assert the adversarial inputs complete near-instantly
+    while normal emails are still detected and benign strings are not.
+    """
+
+    # Comfortably above linear cost, far below the multi-second pathological
+    # blowup of the original pattern (which took >5s at 64 KB).
+    _BUDGET_SECONDS = 1.0
+
+    @pytest.mark.parametrize(
+        "make_payload",
+        [
+            pytest.param(lambda n: "x@" + "a." * n + "!", id="domain-label-dots"),
+            pytest.param(lambda n: "x" + ".x" * n + "@!", id="local-part-dots"),
+            pytest.param(lambda n: ("a." * n) + "@" + ("b." * n) + "!", id="both-sides-dots"),
+        ],
+    )
+    def test_adversarial_email_input_is_linear(self, make_payload):
+        import time
+
+        from aragora.compliance.phi_detectors import detect_email
+
+        # ~64 KB crafted string: instant with the linear pattern, multi-second
+        # (and super-linear) with the original backtracking pattern.
+        payload = make_payload(16_000)
+        assert len(payload) >= 32_000  # ensure the input is genuinely large
+
+        start = time.perf_counter()
+        detect_email(payload)
+        elapsed = time.perf_counter() - start
+
+        assert elapsed < self._BUDGET_SECONDS, (
+            f"detect_email took {elapsed:.3f}s on a {len(payload)}-char adversarial "
+            f"input; expected < {self._BUDGET_SECONDS}s (ReDoS regression)"
+        )
+
+    def test_normal_emails_still_detected(self):
+        from aragora.compliance.phi_detectors import detect_email
+
+        cases = {
+            "Contact jane.doe@example.com please": "jane.doe@example.com",
+            "user+tag@sub.domain.co.uk": "user+tag@sub.domain.co.uk",
+            "a_b%c@host-name.io": "a_b%c@host-name.io",
+            "x@y.z.example.org": "x@y.z.example.org",
+            "first.middle.last@dept.company.co": "first.middle.last@dept.company.co",
+        }
+        for content, expected in cases.items():
+            found = [m.text for m in detect_email(content)]
+            assert expected in found, f"{expected!r} not detected in {content!r}: {found}"
+
+    def test_email_match_offsets_are_correct(self):
+        from aragora.compliance.phi_detectors import detect_email
+
+        content = "hello jane.doe@example.com and user+tag@sub.domain.co.uk!"
+        for match in detect_email(content):
+            assert content[match.start : match.start + len(match.text)] == match.text
+
+    def test_benign_near_email_strings_not_matched_pathologically(self):
+        from aragora.compliance.phi_detectors import detect_email
+
+        for content in ["x@", "a@b.", "foo@bar..com", "@nope.com", "user@localhost"]:
+            assert detect_email(content) == [], f"unexpected email match in {content!r}"
+
+    def test_adversarial_input_via_compliance_check_is_linear(self):
+        import time
+
+        # Exercise the full reachable path: ComplianceFrameworkManager.check is
+        # what POST /api/v1/compliance/check and `compliance check --file` call.
+        payload = "x@" + "a." * 16_000 + "!"
+        manager = ComplianceFrameworkManager()
+
+        start = time.perf_counter()
+        manager.check(payload, frameworks=["hipaa"])
+        elapsed = time.perf_counter() - start
+
+        assert elapsed < self._BUDGET_SECONDS, (
+            f"compliance check took {elapsed:.3f}s on adversarial email input; "
+            f"expected < {self._BUDGET_SECONDS}s (ReDoS regression)"
+        )


### PR DESCRIPTION
## Summary

`aragora compliance check --frameworks hipaa` only ran keyword/regex rules, so against synthetic PHI it flagged just the literal word `ssn` (and `diagnosis`) and **missed the actual structured identifiers** — the SSN value, ICD-10 codes, NPI, MRN, date of birth, email, and phone.

This adds deterministic, **format-validated** detectors for these well-defined structured identifiers and integrates them into the **existing** framework detection path via a new `validators` field on `ComplianceRule`. Findings flow through the same `ComplianceIssue` / severity / scoring model — no parallel system.

### Why detectors (not an LLM) here
The project rule is "use real intelligence, not regex" for *semantic classification/routing/disambiguation*. Structured identifiers (SSN, NPI, ICD-10, MRN, DOB, email, phone) are precise published **formats**, not semantic judgments, so validated format detectors with check-digit/range validation are the industry-standard correct tool (cf. Microsoft Presidio). The contextual-PHI keyword rules already in the HIPAA framework are untouched and continue to run alongside.

### Validation included
- **SSN**: rejects SSA-invalid allocations (area `000`/`666`/`900-999`, group `00`, serial `0000`).
- **NPI**: 10-digit + Luhn check with the CMS `80840` prefix.
- **ICD-10**: ICD-10-CM format (`A00`–`Z99` with optional decimal extension).
- **MRN**: label-anchored (`MRN`/`Medical Record Number`) to avoid false positives.
- **DOB**: ISO and US numeric dates with range checks.
- **Email / Phone**: standard formats.

## Before

```
$ aragora compliance check --frameworks hipaa,gdpr "Patient John Doe, SSN 123-45-6789, DOB 1980-03-15, was treated for diabetes at Springfield General Hospital. Contact: john.doe@example.com, phone 555-123-4567"

  Status: NON-COMPLIANT
  Score:  70%
  Issues found: 1
  Critical issues: 1

  [CRITICAL] hipaa/hipaa-phi-exposure
    Potential exposure of Protected Health Information (PHI) (keyword: ssn)
    Matched: ssn
```

## After

```
$ aragora compliance check --frameworks hipaa,gdpr "Patient John Doe, SSN 123-45-6789, DOB 1980-03-15, was treated for diabetes at Springfield General Hospital. Contact: john.doe@example.com, phone 555-123-4567"

  Status: NON-COMPLIANT
  Score:  0%
  Issues found: 5
  Critical issues: 2
  High issues: 3

  [CRITICAL] hipaa/hipaa-phi-exposure   Matched: ssn
  [CRITICAL] hipaa/hipaa-phi-ssn        Matched: 123-45-6789
  [HIGH]     hipaa/hipaa-phi-dob        Matched: 1980-03-15
  [HIGH]     hipaa/hipaa-phi-email      Matched: john.doe@example.com
  [HIGH]     hipaa/hipaa-phi-phone      Matched: 555-123-4567
```

ICD-10 / NPI / MRN are detected when present, e.g.:

```
$ aragora compliance check --frameworks hipaa "Provider NPI 1234567893 diagnosed patient with E11.9. MRN: 00123456"
  [HIGH]     hipaa/hipaa-phi-npi
  [HIGH]     hipaa/hipaa-phi-icd10
  [CRITICAL] hipaa/hipaa-phi-mrn
```

## Tests
New `tests/compliance/test_phi_identifiers.py` (16 tests): per-identifier detection, the issue-#7394 synthetic string, SSN/NPI validation negatives, and a clean-content no-false-positive guard. Full compliance suite green (672 passing).

Closes #7394

🤖 Generated with [Claude Code](https://claude.com/claude-code)
