### PR TITLE
[AGT-06] `aragora metrics viah --persist`: wire SD-4 snapshot CLI flag

### DIFF
--- a/aragora/cli/commands/agt_metrics.py
+++ b/aragora/cli/commands/agt_metrics.py
@@ -12,15 +12,20 @@ import json
 import sys
 from pathlib import Path
 
-from aragora.metrics.viah import VIAH_TREND_FLAG, compute_viah, viah_trend_enabled
+from aragora.metrics.viah import (
+    VIAH_TREND_FLAG,
+    compute_viah,
+    persist_viah_snapshot,
+    viah_trend_enabled,
+)
 from aragora.swarm.shift_ledger import DEFAULT_LEDGER_PATH, ShiftLedger
 
 
 def cmd_metrics_viah(args: argparse.Namespace) -> int:
     """Compute and print the VIAH report over a window.
 
-    Returns 0 on success; non-zero only on argparse-level usage error
-    (which argparse handles itself before reaching here).
+    Returns 0 on success; 1 when ``--persist`` is requested but
+    ``ARAGORA_VIAH_TREND_ENABLED`` is not set.
     """
     ledger_path: Path | None
     raw_path = getattr(args, "ledger_path", None)
@@ -42,6 +47,15 @@ def cmd_metrics_viah(args: argparse.Namespace) -> int:
         predictions_above_brier_threshold=predictions,
         failed_claims_promoted_without_repair=failed_claims,
     )
+
+    if getattr(args, "persist", False):
+        if not viah_trend_enabled():
+            print(
+                f"error: --persist requires {VIAH_TREND_FLAG}=1 to be set",
+                file=sys.stderr,
+            )
+            return 1
+        persist_viah_snapshot(ledger=ledger, report=report)
 
     if getattr(args, "json", False):
         print(json.dumps(report.to_dict(), sort_keys=True, indent=2))

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -271,6 +271,15 @@ def _add_metrics_parser(subparsers) -> None:
         help="Sidecar count of failed claims promoted without bounded repair (AGT-05)",
     )
     viah.add_argument("--json", action="store_true", help="Emit the report as JSON")
+    viah.add_argument(
+        "--persist",
+        action="store_true",
+        default=False,
+        help=(
+            "Persist a viah_snapshot entry to the ShiftLedger after computing. "
+            "Requires ARAGORA_VIAH_TREND_ENABLED=1; default off (AGT-06 SD-4 / #6067)."
+        ),
+    )
     viah.set_defaults(func=_lazy("aragora.cli.commands.agt_metrics", "cmd_metrics_viah"))
 
     status = metrics_sub.add_parser(

--- a/aragora/cli/parser_viah_persist_patch.py
+++ b/aragora/cli/parser_viah_persist_patch.py
@@ -1,0 +1,4 @@
+# This file is intentionally empty — the --persist argument is wired
+# directly in aragora/cli/parser.py _add_metrics_parser().
+# It exists only as a marker so the diff is reviewable separately from
+# the parser.py edit. It will be removed when the branch is merged.

--- a/aragora/cli/parser_viah_persist_patch.py
+++ b/aragora/cli/parser_viah_persist_patch.py
@@ -1,4 +1,0 @@
-# This file is intentionally empty — the --persist argument is wired
-# directly in aragora/cli/parser.py _add_metrics_parser().
-# It exists only as a marker so the diff is reviewable separately from
-# the parser.py edit. It will be removed when the branch is merged.

--- a/tests/cli/test_viah_persist_flag.py
+++ b/tests/cli/test_viah_persist_flag.py
@@ -1,0 +1,139 @@
+"""Tests for the AGT-06 ``aragora metrics viah --persist`` CLI flag (SD-4 / #6067).
+
+Verifies that:
+- ``--persist`` without ``ARAGORA_VIAH_TREND_ENABLED`` returns 1 with an error message
+- default (no ``--persist``) leaves the ledger unchanged
+- ``--persist`` with the flag set writes one ``viah_snapshot`` entry
+- the snapshot payload round-trips the key signal counts from the report
+
+All tests are self-contained: they use a ``tmp_path`` ledger, inject the
+environment flag via ``monkeypatch``, and invoke ``cmd_metrics_viah`` directly
+(no subprocess, no network, no queue mutation).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from aragora.cli.commands.agt_metrics import cmd_metrics_viah
+from aragora.metrics.viah import VIAH_TREND_FLAG, read_viah_snapshots
+from aragora.swarm.shift_ledger import ShiftLedger
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_args(
+    ledger_path: str,
+    *,
+    persist: bool = False,
+    window_hours: float = 24.0,
+    as_json: bool = False,
+) -> argparse.Namespace:
+    return argparse.Namespace(
+        ledger_path=ledger_path,
+        window_hours=window_hours,
+        cruxes_correctly_detected=0,
+        predictions_above_brier_threshold=0,
+        failed_claims_promoted_without_repair=0,
+        json=as_json,
+        persist=persist,
+    )
+
+
+def _seed_shift(path: Path) -> None:
+    """Write minimal shift_start / pr_merged / shift_stop entries within the last 2 hours."""
+    now = datetime.now(UTC)
+    entries = [
+        {
+            "entry_type": "shift_start",
+            "timestamp": (now - timedelta(hours=2)).isoformat(),
+            "payload": {"shift_id": "s1"},
+        },
+        {
+            "entry_type": "pr_merged",
+            "timestamp": (now - timedelta(hours=1)).isoformat(),
+            "payload": {},
+        },
+        {
+            "entry_type": "shift_stop",
+            "timestamp": now.isoformat(),
+            "payload": {"shift_id": "s1"},
+        },
+    ]
+    with path.open("w", encoding="utf-8") as fh:
+        for entry in entries:
+            fh.write(json.dumps(entry, sort_keys=True) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestViahPersistFlag:
+    def test_persist_without_trend_flag_returns_error(self, tmp_path, monkeypatch, capsys) -> None:
+        """--persist without ARAGORA_VIAH_TREND_ENABLED should return 1 and print to stderr."""
+        monkeypatch.delenv(VIAH_TREND_FLAG, raising=False)
+        ledger_path = tmp_path / "ledger.jsonl"
+        ledger_path.write_text("", encoding="utf-8")
+
+        rc = cmd_metrics_viah(_make_args(str(ledger_path), persist=True))
+
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert VIAH_TREND_FLAG in err
+        assert "--persist" in err
+
+    def test_no_persist_flag_leaves_ledger_unchanged(self, tmp_path, monkeypatch, capsys) -> None:
+        """Omitting --persist must not write any snapshot, even with trend flag on."""
+        monkeypatch.setenv(VIAH_TREND_FLAG, "1")
+        ledger_path = tmp_path / "ledger.jsonl"
+        ledger_path.write_text("", encoding="utf-8")
+
+        rc = cmd_metrics_viah(_make_args(str(ledger_path), persist=False))
+
+        assert rc == 0
+        ledger = ShiftLedger(path=ledger_path)
+        assert read_viah_snapshots(ledger=ledger) == []
+
+    def test_persist_writes_one_snapshot_entry(self, tmp_path, monkeypatch, capsys) -> None:
+        """--persist with flag set should write exactly one viah_snapshot entry."""
+        monkeypatch.setenv(VIAH_TREND_FLAG, "1")
+        ledger_path = tmp_path / "ledger.jsonl"
+        _seed_shift(ledger_path)
+
+        rc = cmd_metrics_viah(_make_args(str(ledger_path), persist=True))
+
+        assert rc == 0
+        ledger = ShiftLedger(path=ledger_path)
+        snaps = read_viah_snapshots(ledger=ledger)
+        assert len(snaps) == 1
+        snap = snaps[0]
+        assert snap["merged_autonomous_prs"] == 1
+        assert "agent_hours" in snap
+        assert "window_start" in snap
+        assert "window_end" in snap
+
+    def test_persist_snapshot_signal_counts_match_input(self, tmp_path, monkeypatch) -> None:
+        """Persisted snapshot payload carries the same signal counts as the computed report."""
+        monkeypatch.setenv(VIAH_TREND_FLAG, "1")
+        ledger_path = tmp_path / "ledger.jsonl"
+        _seed_shift(ledger_path)
+
+        cmd_metrics_viah(_make_args(str(ledger_path), persist=True))
+
+        ledger = ShiftLedger(path=ledger_path)
+        snap = read_viah_snapshots(ledger=ledger)[-1]
+        assert snap["rescues_required"] == 0
+        assert snap["cruxes_correctly_detected"] == 0
+        assert snap["predictions_above_brier_threshold"] == 0
+        assert snap["failed_claims_promoted_without_repair"] == 0
+        assert snap["merged_autonomous_prs"] >= 1


### PR DESCRIPTION
## Slice

Wires the existing `persist_viah_snapshot` function (already on `main` in `aragora/metrics/viah.py`) to the `aragora metrics viah` CLI so operators can write a `viah_snapshot` ShiftLedger entry in a single command. This closes the SD-4 gap noted in `aragora/metrics/viah_status.py` (the "Historical trend persistence requires AGT-06 SD-4" caveat).

## Gating

- Default: **OFF** — `--persist` is opt-in at the CLI call site; `persist_viah_snapshot` itself requires `ARAGORA_VIAH_TREND_ENABLED=1` and raises `RuntimeError` when unset (the CLI surfaces this as `rc=1` + error message).
- Live queue effect: **none** — read-only report path unchanged; snapshot writes only when `--persist` is explicitly passed.
- Advances issue: [#6067](https://github.com/synaptent/aragora/issues/6067) (AGT-06 SD-4)

## Changes

| File | What changed |
|------|-------------|
| `aragora/cli/commands/agt_metrics.py` | Import `persist_viah_snapshot`; add persist branch in `cmd_metrics_viah` — fails closed (rc=1) when `ARAGORA_VIAH_TREND_ENABLED` is unset, otherwise calls `persist_viah_snapshot` before printing. |
| `aragora/cli/parser.py` | Add `--persist` / default-off `store_true` argument to the `viah` subparser. |
| `tests/cli/test_viah_persist_flag.py` | New test file — 4 focused tests (see below). |

## Tests

- `test_persist_without_trend_flag_returns_error` — `--persist` with `ARAGORA_VIAH_TREND_ENABLED` unset returns `rc=1`; stderr contains the flag name.
- `test_no_persist_flag_leaves_ledger_unchanged` — default (`persist=False`) with flag on: ledger has zero `viah_snapshot` entries after the call.
- `test_persist_writes_one_snapshot_entry` — `--persist` with flag on and a seeded ledger: exactly one `viah_snapshot` entry is written, contains `merged_autonomous_prs`, `agent_hours`, `window_start`.
- `test_persist_snapshot_signal_counts_match_input` — snapshot payload carries the same zero sidecar signal counts passed to the command.

## Validation

- `python3 -c "import ast; ast.parse(open('aragora/cli/commands/agt_metrics.py').read())"` — clean
- `python3 -c "import ast; ast.parse(open('tests/cli/test_viah_persist_flag.py').read())"` — clean
- Net diff: **165 LOC** (3 files: +139 test, +20 agt_metrics.py, +9 parser.py)

## Out of scope

- Sidecar signal wiring (crux-correctness, Brier threshold counts) — deferred to AGT-05 settlement landing per the existing `compute_viah` design.
- Auto-scheduling of weekly VIAH snapshots — deferred to a future AGT-06 slice once the operator has validated manual `--persist` runs.
- `aragora metrics status` does not use persisted snapshots yet — it still computes trend on-the-fly from ledger entries (the `viah_status.py` caveat note remains accurate).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KaMfDtD8MoUZBz8PyAKAr4)_