### PR TITLE
fix(review-queue): scope explicit merge packets

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -1698,9 +1698,11 @@ def _build_merge_authorization_packet(
     review_queue_root: str | Path | None = None,
     execute_reviewers: bool = False,
 ) -> dict[str, Any]:
+    scoped_pr_refs = False
     if pr_refs:
         refs = list(dict.fromkeys(str(ref).strip() for ref in pr_refs if str(ref).strip()))
-        queue_size = len(_build_queue(limit=max(limit, len(refs), MODEL_REVIEW_QUEUE_CAP + 1)))
+        queue_size = len(refs)
+        scoped_pr_refs = True
     else:
         queue = _build_queue(limit=limit)
         refs = [str(item.number) for item in queue]
@@ -1721,6 +1723,7 @@ def _build_merge_authorization_packet(
             "current_open_prs": queue_size,
             "cap": MODEL_REVIEW_QUEUE_CAP,
             "active": queue_pressure_active,
+            "scope": "explicit_pr_refs" if scoped_pr_refs else "open_pr_queue",
             "allowed_work_when_active": [
                 "review",
                 "dogfood",
@@ -1757,6 +1760,7 @@ def _build_merge_authorization_packet(
             "current_open_prs": queue_size,
             "cap": MODEL_REVIEW_QUEUE_CAP,
             "active": queue_pressure_active,
+            "scope": "explicit_pr_refs" if scoped_pr_refs else "open_pr_queue",
         },
         "authorization_sentence": (
             "I accept the model quorum evidence for Tier 0-2 PRs in this packet "

--- a/scripts/settle_one_pr.py
+++ b/scripts/settle_one_pr.py
@@ -984,7 +984,11 @@ def build_report(
         repo_blocker, repo_command, cwd_repo = repo_cwd_blocker(cwd, repo)
         if repo_blocker:
             preselection_blockers.append(repo_blocker)
-        policy_metadata, metadata_command = load_open_pr_metadata(cwd, repo=repo)
+        if explicit_pr is not None:
+            metadata, metadata_command = load_pr_policy_metadata(cwd, explicit_pr, repo=repo)
+            policy_metadata = {explicit_pr: metadata} if metadata else {}
+        else:
+            policy_metadata, metadata_command = load_open_pr_metadata(cwd, repo=repo)
         policy_metadata_commands.append(metadata_command)
         active_owned_command: dict[str, Any] | None = None
         snapshot_preblocked = _has_operator_snapshot_load_blocker(preselection_blockers)

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -1537,6 +1537,66 @@ class TestValidationExtraction:
 
 
 class TestBuildQueueAndPacket:
+    def test_merge_packet_explicit_pr_refs_do_not_hydrate_open_queue(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def fail_build_queue(*_args: Any, **_kwargs: Any) -> list[QueueItem]:
+            raise AssertionError("explicit --pr merge-packet must not call _build_queue")
+
+        def fake_build_packet(ref: str, **_kwargs: Any) -> ReviewPacket:
+            return ReviewPacket(
+                pr_number=int(ref),
+                title=f"PR {ref}",
+                url=f"https://github.com/synaptent/aragora/pull/{ref}",
+                head_sha="abc123",
+                base_sha="def456",
+                author="codex",
+                is_draft=False,
+                additions=1,
+                deletions=1,
+                changed_files=1,
+                queue_bucket="ready_now",
+                touched_subsystems=["scripts"],
+                high_risk_paths_touched=[],
+                validation=[],
+                checks_summary="4/4 green",
+                risk_flags=[],
+                machine_recommendation="approve_candidate",
+                machine_recommendation_reason="bounded test packet",
+                packet_sha="sha256:test",
+                generated_at="2026-05-30T00:00:00+00:00",
+                model_review_quorum={
+                    "tier": 0,
+                    "tier_name": "Tier 0",
+                    "status": "satisfied",
+                    "verdict": "admin_squash_allowed",
+                    "admin_squash_allowed": True,
+                    "requires_human_risk_settlement": False,
+                    "unresolved_dissent": False,
+                    "reviewer_signals": [],
+                    "dogfood_evidence": [],
+                    "counted_reviewer_ids": ["codex"],
+                    "reasons": ["docs/tests/status-only change"],
+                },
+            )
+
+        monkeypatch.setattr("aragora.cli.commands.review_queue._build_queue", fail_build_queue)
+        monkeypatch.setattr("aragora.cli.commands.review_queue._build_packet", fake_build_packet)
+
+        packet = _build_merge_authorization_packet(
+            pr_refs=["7528"],
+            limit=30,
+            repo_override=None,
+        )
+
+        assert packet["queue_pressure"] == {
+            "current_open_prs": 1,
+            "cap": MODEL_REVIEW_QUEUE_CAP,
+            "active": False,
+            "scope": "explicit_pr_refs",
+        }
+        assert packet["admin_squash_order"] == [7528]
+
     def test_build_queue_classifies_and_sorts(self, monkeypatch: pytest.MonkeyPatch) -> None:
         prs = [
             _make_pr(number=10, is_draft=True),  # parked
@@ -3213,7 +3273,7 @@ class TestSettlementHelpers:
         )
         ns = argparse.Namespace(
             review_queue_command="merge-packet",
-            pr=["1"],
+            pr=[],
             repo=None,
             limit=10,
             execute_reviewers=False,
@@ -3225,7 +3285,8 @@ class TestSettlementHelpers:
         assert rc == 0
         payload = json.loads(buf.getvalue())
         assert payload["queue_pressure"]["active"] is True
-        assert payload["admin_squash_order"] == [1]
+        assert payload["queue_pressure"]["scope"] == "open_pr_queue"
+        assert payload["admin_squash_order"] == list(range(1, MODEL_REVIEW_QUEUE_CAP + 2))
         assert payload["entries"][0]["verdict"] == "admin_squash_allowed"
 
     def test_act_command_requires_reason_for_request_changes(self) -> None:

--- a/tests/scripts/test_settle_one_pr.py
+++ b/tests/scripts/test_settle_one_pr.py
@@ -675,6 +675,55 @@ def test_build_report_threads_repo_to_policy_metadata(monkeypatch) -> None:
     assert view_command[-2:] == ["--repo", "example/repo"]
 
 
+def test_build_report_explicit_pr_loads_policy_metadata_without_broad_list(monkeypatch) -> None:
+    commands: list[list[str]] = []
+
+    def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
+        del cwd, timeout
+        commands.append(args)
+        if args[:3] == ["gh", "pr", "list"]:
+            raise AssertionError("explicit --pr settlement must not call gh pr list")
+        if args[:3] == ["gh", "pr", "view"] and args[3] == "7451":
+            return (
+                {
+                    "number": 7451,
+                    "title": "fix: candidate",
+                    "headRefName": "codex/candidate",
+                    "mergeable": "MERGEABLE",
+                    "mergeStateStatus": "CLEAN",
+                    "files": [{"path": "aragora/server/routes.py"}],
+                },
+                {"command": "policy-view", "returncode": 0},
+            )
+        if args[:3] == ["python3", "scripts/agent_bridge.py", "operator-snapshot"]:
+            return {"lanes": []}, {"command": "snapshot", "returncode": 0}
+        raise AssertionError(args)
+
+    monkeypatch.setattr(settle_one_pr, "_run_json", fake_run_json)
+
+    report = build_report(
+        _packet(
+            _entry(
+                7451,
+                tier=3,
+                requires_human_risk_settlement=True,
+                reasons=["semantic, persistence, security, API, or SDK surface touched"],
+            )
+        ),
+        cwd=Path.cwd(),
+        state_root=Path.cwd(),
+        explicit_pr=7451,
+        exclude_prs=set(),
+        live=True,
+        validate=False,
+    )
+
+    assert report["selected_pr"] == 7451
+    assert report["status"] == "blocked"
+    assert commands[0][:3] == ["gh", "pr", "view"]
+    assert all(command[:3] != ["gh", "pr", "list"] for command in commands)
+
+
 def test_build_report_fails_closed_when_operator_snapshot_fails(monkeypatch) -> None:
     def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
         del cwd, timeout


### PR DESCRIPTION
## Summary
- avoid hydrating the full open PR queue when review-queue merge-packet is called with explicit --pr refs
- make explicit-pr queue_pressure report scope=explicit_pr_refs instead of open_pr_queue
- make settle_one_pr.py --pr load policy metadata with gh pr view for that PR, not gh pr list

## Validation
- python3 -m pytest tests/cli/commands/test_review_queue.py tests/scripts/test_settle_one_pr.py -q
- python3 -m aragora.cli.main review-queue merge-packet --pr 7528 --json
- python3 scripts/settle_one_pr.py --pr 7528 --json
- python3 -m ruff format --check aragora/cli/commands/review_queue.py scripts/settle_one_pr.py tests/cli/commands/test_review_queue.py tests/scripts/test_settle_one_pr.py
- python3 -m ruff check aragora/cli/commands/review_queue.py scripts/settle_one_pr.py tests/cli/commands/test_review_queue.py tests/scripts/test_settle_one_pr.py
- git diff --check
- bash scripts/automation_pr_preflight.sh origin/main HEAD

## Notes
This is a steward-tooling repair split from #7528. It does not change #7528 model defaults and does not mark any PR ready or merge.