### PR TITLE
[DIC-26] coherence-scan CLI: operator surface for belief coherence monitor

### DIFF
--- a/aragora/cli/commands/dic26_coherence.py
+++ b/aragora/cli/commands/dic26_coherence.py
@@ -1,0 +1,108 @@
+"""CLI command: ``aragora coherence-scan``.
+
+DIC-26 operator surface for the belief coherence monitor (issue #6220).
+
+Reads a JSON file where each element is a BeliefEntry dict:
+    {"belief_id": "...", "subject": "...", "confidence": 0.8,
+     "status": "pass", "evidence_paths": ["docs/status/foo.md"]}
+
+Flag: ``ARAGORA_COHERENCE_MONITOR_ENABLED`` (default OFF).
+Live queue effect: none — read-only operator report.
+Advances: issue #6220 (DIC-26).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+from aragora.epistemic.coherence import (
+    BeliefEntry,
+    coherence_monitor_enabled,
+    scan_coherence,
+)
+
+logger = logging.getLogger(__name__)
+
+_FLAG = "ARAGORA_COHERENCE_MONITOR_ENABLED"
+_DEFAULT_GAP: float = 0.5
+_DEFAULT_MIN_CONFIDENCE: float = 0.3
+
+
+def _load_entries(path: Path) -> list[BeliefEntry]:
+    """Parse *path* as JSON into a list of :class:`BeliefEntry`.
+
+    Accepts a JSON array or a single JSON object. Malformed entries are
+    logged at WARNING and skipped so one bad row does not abort the scan.
+    """
+    raw: Any = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(raw, dict):
+        raw = [raw]
+    entries: list[BeliefEntry] = []
+    for idx, obj in enumerate(raw, 1):
+        try:
+            entries.append(
+                BeliefEntry(
+                    belief_id=str(obj["belief_id"]),
+                    subject=str(obj["subject"]),
+                    confidence=float(obj["confidence"]),
+                    status=str(obj.get("status", "unknown")),
+                    evidence_paths=tuple(
+                        str(p) for p in obj.get("evidence_paths") or []
+                    ),
+                )
+            )
+        except (KeyError, ValueError, TypeError) as exc:
+            logger.warning("belief entry %d skipped: %s", idx, exc)
+    return entries
+
+
+def cmd_coherence_scan(args: argparse.Namespace) -> int:
+    """Handle the ``aragora coherence-scan`` subcommand."""
+    if not coherence_monitor_enabled():
+        print(
+            f"error: {_FLAG} is not set; set it to '1' to enable coherence-scan",
+            file=sys.stderr,
+        )
+        return 1
+
+    input_path = Path(args.input).expanduser()
+    if not input_path.exists():
+        print(f"error: input file not found: {input_path}", file=sys.stderr)
+        return 1
+
+    try:
+        entries = _load_entries(input_path)
+    except (json.JSONDecodeError, OSError) as exc:
+        print(f"error: failed to load {input_path}: {exc}", file=sys.stderr)
+        return 1
+
+    report = scan_coherence(
+        entries,
+        contradiction_gap=float(getattr(args, "contradiction_gap", _DEFAULT_GAP)),
+        min_confidence=float(getattr(args, "min_confidence", _DEFAULT_MIN_CONFIDENCE)),
+        enabled=True,
+    )
+
+    as_json: bool = getattr(args, "json", False)
+    if as_json:
+        print(json.dumps(report.to_dict(), indent=2))
+        return 0
+
+    print(f"Coherence scan: {input_path}")
+    print(f"  scanned            : {report.scanned}")
+    print(f"  coherent           : {report.coherent}")
+    print(f"  contradictions     : {report.contradiction_count}")
+    print(f"  evidence conflicts : {report.evidence_conflict_count}")
+    print(f"  confidence rot     : {report.confidence_rot_count}")
+    if report.issues:
+        print()
+        for issue in report.issues:
+            ids = ", ".join(issue.belief_ids)
+            print(f"  [{issue.severity}] {issue.kind.value}: {ids}")
+            print(f"    {issue.detail}")
+    return 0

--- a/aragora/cli/commands/dic26_coherence.py
+++ b/aragora/cli/commands/dic26_coherence.py
@@ -51,9 +51,7 @@ def _load_entries(path: Path) -> list[BeliefEntry]:
                     subject=str(obj["subject"]),
                     confidence=float(obj["confidence"]),
                     status=str(obj.get("status", "unknown")),
-                    evidence_paths=tuple(
-                        str(p) for p in obj.get("evidence_paths") or []
-                    ),
+                    evidence_paths=tuple(str(p) for p in obj.get("evidence_paths") or []),
                 )
             )
         except (KeyError, ValueError, TypeError) as exc:

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -217,6 +217,7 @@ Examples:
     _add_cruxset_parser(subparsers)
     _add_crux_followup_parser(subparsers)
     _add_genealogy_parser(subparsers)  # DIC-24 / #6218
+    _add_coherence_scan_parser(subparsers)  # DIC-26 / #6220
 
     # DIC-27: operator crux arbitration surface
     _add_crux_arbitrate_parser(subparsers)
@@ -607,6 +608,48 @@ def _add_genealogy_parser(subparsers) -> None:
     )
     show.add_argument("--json", action="store_true", help="Emit JSON instead of text")
     show.set_defaults(func=_lazy("aragora.cli.commands.dic24_genealogy", "cmd_genealogy_show"))
+
+
+def _add_coherence_scan_parser(subparsers) -> None:
+    """Add the 'coherence-scan' subcommand (DIC-26 / #6220).
+
+    Flag-gated: ARAGORA_COHERENCE_MONITOR_ENABLED must be set.
+    Live queue effect: none (read-only operator report).
+    """
+    p = subparsers.add_parser(
+        "coherence-scan",
+        help="DIC-26: scan a belief ledger for contradictions, evidence conflicts, and confidence rot",
+        description=(
+            "Read-only operator surface for the belief coherence monitor. "
+            "Requires ARAGORA_COHERENCE_MONITOR_ENABLED=1."
+        ),
+    )
+    p.add_argument(
+        "--input",
+        required=True,
+        metavar="JSON",
+        help="Path to a JSON file containing a list of BeliefEntry dicts",
+    )
+    p.add_argument(
+        "--contradiction-gap",
+        dest="contradiction_gap",
+        type=float,
+        default=0.5,
+        metavar="FLOAT",
+        help="Confidence gap threshold for contradiction detection (default: 0.5)",
+    )
+    p.add_argument(
+        "--min-confidence",
+        dest="min_confidence",
+        type=float,
+        default=0.3,
+        metavar="FLOAT",
+        help="Minimum confidence threshold for rot detection (default: 0.3)",
+    )
+    p.add_argument("--json", action="store_true", help="Emit JSON instead of text")
+    p.set_defaults(
+        func=_lazy("aragora.cli.commands.dic26_coherence", "cmd_coherence_scan")
+    )
 
 
 def _add_crux_arbitrate_parser(subparsers) -> None:

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -647,9 +647,7 @@ def _add_coherence_scan_parser(subparsers) -> None:
         help="Minimum confidence threshold for rot detection (default: 0.3)",
     )
     p.add_argument("--json", action="store_true", help="Emit JSON instead of text")
-    p.set_defaults(
-        func=_lazy("aragora.cli.commands.dic26_coherence", "cmd_coherence_scan")
-    )
+    p.set_defaults(func=_lazy("aragora.cli.commands.dic26_coherence", "cmd_coherence_scan"))
 
 
 def _add_crux_arbitrate_parser(subparsers) -> None:

--- a/tests/cli/test_dic26_coherence.py
+++ b/tests/cli/test_dic26_coherence.py
@@ -1,0 +1,118 @@
+"""DIC-26 coherence-scan CLI tests.
+
+Flag: ARAGORA_COHERENCE_MONITOR_ENABLED (default OFF)
+Live queue effect: none
+Advances: issue #6220 (DIC-26)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from aragora.cli.commands.dic26_coherence import _load_entries, cmd_coherence_scan
+
+
+def _args(
+    input_path: str,
+    *,
+    json_output: bool = False,
+    gap: float = 0.5,
+    min_conf: float = 0.3,
+) -> argparse.Namespace:
+    ns = argparse.Namespace()
+    ns.input = input_path
+    ns.json = json_output
+    ns.contradiction_gap = gap
+    ns.min_confidence = min_conf
+    return ns
+
+
+def _write(tmp_path: Path, data: object) -> Path:
+    p = tmp_path / "beliefs.json"
+    p.write_text(json.dumps(data), encoding="utf-8")
+    return p
+
+
+def test_disabled_by_default_exits_1(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("ARAGORA_COHERENCE_MONITOR_ENABLED", raising=False)
+    assert cmd_coherence_scan(_args(str(_write(tmp_path, [])))) == 1
+
+
+def test_missing_input_file_exits_1(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("ARAGORA_COHERENCE_MONITOR_ENABLED", "1")
+    assert cmd_coherence_scan(_args(str(tmp_path / "nonexistent.json"))) == 1
+
+
+def test_empty_ledger_exits_0_and_reports_coherent(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("ARAGORA_COHERENCE_MONITOR_ENABLED", "1")
+    assert cmd_coherence_scan(_args(str(_write(tmp_path, [])))) == 0
+    assert "coherent" in capsys.readouterr().out
+
+
+def test_json_output_is_valid_for_coherent_ledger(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("ARAGORA_COHERENCE_MONITOR_ENABLED", "1")
+    entries = [{"belief_id": "b1", "subject": "claim.rate_limit", "confidence": 0.9, "status": "pass"}]
+    assert cmd_coherence_scan(_args(str(_write(tmp_path, entries)), json_output=True)) == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["scanned"] == 1 and data["coherent"] is True and data["issue_count"] == 0
+
+
+def test_contradiction_flagged_in_json(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("ARAGORA_COHERENCE_MONITOR_ENABLED", "1")
+    entries = [
+        {"belief_id": "b_high", "subject": "claim.x", "confidence": 0.95, "status": "pass"},
+        {"belief_id": "b_low",  "subject": "claim.x", "confidence": 0.05, "status": "fail"},
+    ]
+    assert cmd_coherence_scan(_args(str(_write(tmp_path, entries)), json_output=True)) == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["contradiction_count"] == 1 and data["coherent"] is False
+
+
+def test_confidence_rot_flagged_in_json(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("ARAGORA_COHERENCE_MONITOR_ENABLED", "1")
+    entries = [{"belief_id": "b_rotten", "subject": "claim.stale", "confidence": 0.1, "status": "stale"}]
+    assert cmd_coherence_scan(_args(str(_write(tmp_path, entries)), json_output=True, min_conf=0.3)) == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["confidence_rot_count"] == 1
+
+
+def test_load_entries_skips_bad_confidence_type(tmp_path: Path) -> None:
+    raw = [
+        {"belief_id": "good", "subject": "s", "confidence": 0.8},
+        {"belief_id": "bad_conf", "subject": "s", "confidence": "not-a-float"},
+    ]
+    p = tmp_path / "b.json"
+    p.write_text(json.dumps(raw), encoding="utf-8")
+    entries = _load_entries(p)
+    assert len(entries) == 1 and entries[0].belief_id == "good"
+
+
+def test_load_entries_skips_missing_belief_id(tmp_path: Path) -> None:
+    raw = [
+        {"belief_id": "ok", "subject": "s", "confidence": 0.7},
+        {"subject": "no_id", "confidence": 0.5},
+    ]
+    p = tmp_path / "b.json"
+    p.write_text(json.dumps(raw), encoding="utf-8")
+    entries = _load_entries(p)
+    assert len(entries) == 1 and entries[0].belief_id == "ok"
+
+
+def test_load_entries_accepts_single_object(tmp_path: Path) -> None:
+    raw = {"belief_id": "singleton", "subject": "s", "confidence": 0.6}
+    p = tmp_path / "b.json"
+    p.write_text(json.dumps(raw), encoding="utf-8")
+    entries = _load_entries(p)
+    assert len(entries) == 1 and entries[0].belief_id == "singleton"

--- a/tests/cli/test_dic26_coherence.py
+++ b/tests/cli/test_dic26_coherence.py
@@ -59,7 +59,9 @@ def test_json_output_is_valid_for_coherent_ledger(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     monkeypatch.setenv("ARAGORA_COHERENCE_MONITOR_ENABLED", "1")
-    entries = [{"belief_id": "b1", "subject": "claim.rate_limit", "confidence": 0.9, "status": "pass"}]
+    entries = [
+        {"belief_id": "b1", "subject": "claim.rate_limit", "confidence": 0.9, "status": "pass"}
+    ]
     assert cmd_coherence_scan(_args(str(_write(tmp_path, entries)), json_output=True)) == 0
     data = json.loads(capsys.readouterr().out)
     assert data["scanned"] == 1 and data["coherent"] is True and data["issue_count"] == 0
@@ -71,7 +73,7 @@ def test_contradiction_flagged_in_json(
     monkeypatch.setenv("ARAGORA_COHERENCE_MONITOR_ENABLED", "1")
     entries = [
         {"belief_id": "b_high", "subject": "claim.x", "confidence": 0.95, "status": "pass"},
-        {"belief_id": "b_low",  "subject": "claim.x", "confidence": 0.05, "status": "fail"},
+        {"belief_id": "b_low", "subject": "claim.x", "confidence": 0.05, "status": "fail"},
     ]
     assert cmd_coherence_scan(_args(str(_write(tmp_path, entries)), json_output=True)) == 0
     data = json.loads(capsys.readouterr().out)
@@ -82,8 +84,13 @@ def test_confidence_rot_flagged_in_json(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     monkeypatch.setenv("ARAGORA_COHERENCE_MONITOR_ENABLED", "1")
-    entries = [{"belief_id": "b_rotten", "subject": "claim.stale", "confidence": 0.1, "status": "stale"}]
-    assert cmd_coherence_scan(_args(str(_write(tmp_path, entries)), json_output=True, min_conf=0.3)) == 0
+    entries = [
+        {"belief_id": "b_rotten", "subject": "claim.stale", "confidence": 0.1, "status": "stale"}
+    ]
+    assert (
+        cmd_coherence_scan(_args(str(_write(tmp_path, entries)), json_output=True, min_conf=0.3))
+        == 0
+    )
     data = json.loads(capsys.readouterr().out)
     assert data["confidence_rot_count"] == 1
 


### PR DESCRIPTION
## Slice

Adds `aragora coherence-scan --input <json>` — a thin CLI verb that wraps the existing `scan_coherence` function in `aragora.epistemic.coherence`. Operators can point it at a JSON file of `BeliefEntry` dicts and get a structured report of contradictions, evidence conflicts, and confidence rot across their belief ledger, without touching any live queue path.

## Gating

- Default: **OFF** (flag: `ARAGORA_COHERENCE_MONITOR_ENABLED=1`)
- Live queue effect: **none** — read-only report; no issue creation, no dispatch change, no queue write
- Advances issue: #6220 (DIC-26)

## Tests

- `test_disabled_by_default_exits_1` — command returns rc=1 when flag is unset
- `test_missing_input_file_exits_1` — returns rc=1 when `--input` path does not exist
- `test_empty_ledger_exits_0_and_reports_coherent` — empty ledger exits 0, output contains "coherent"
- `test_json_output_is_valid_for_coherent_ledger` — `--json` emits parseable JSON with `scanned=1`, `coherent=true`, `issue_count=0`
- `test_contradiction_flagged_in_json` — two entries on same subject with high/low confidence produce `contradiction_count=1`, `coherent=false`
- `test_confidence_rot_flagged_in_json` — entry with confidence below threshold produces `confidence_rot_count=1`
- `test_load_entries_skips_bad_confidence_type` — malformed `confidence` string skipped; good entry survives
- `test_load_entries_skips_missing_belief_id` — entry missing `belief_id` skipped; good entry survives
- `test_load_entries_accepts_single_object` — bare JSON object (not array) is treated as a single entry

## Validation

- `pytest tests/cli/test_dic26_coherence.py` — **9 passed**
- `ruff check aragora/cli/commands/dic26_coherence.py aragora/cli/parser.py tests/cli/test_dic26_coherence.py` — **clean**
- `mypy aragora/cli/commands/dic26_coherence.py tests/cli/test_dic26_coherence.py --ignore-missing-imports` — **clean**
- Net diff: **269 LOC** (3 files: +108 command, +43 parser, +118 tests)

## Out of scope

- DIC-17 bridge integration (failed coherence issues → bounded follow-up issue proposals) — deferred; `followup.py` and `propose_followup_for_failed_claim` exist but are not wired here
- `BeliefNetwork` adapter for live arena beliefs — deferred; `from_belief_node` exists in `coherence.py` but requires an active `BeliefNetwork` instance
- Scheduling / periodic coherence sweeps — deferred to a future DIC-28/gardening slice

---
_Generated by [Claude Code](https://claude.ai/code/session_019hvGv4TY78M9wMpvBJZD3z)_