### PR TITLE
[DIC-28] crux-garden CLI: flag-gated gardening pass operator surface

### DIFF
--- a/aragora/cli/commands/dic28_crux_garden.py
+++ b/aragora/cli/commands/dic28_crux_garden.py
@@ -93,7 +93,9 @@ def _format_text(report: GardeningReport) -> str:
         f"  resolved: {len(report.resolved_results)}  outstanding: {len(report.outstanding_results)}",
         "Summary: " + "  ".join(f"{k}={v}" for k, v in sorted(report.summary.items())),
     ]
-    findings = [r for r in report.resolved_results + report.outstanding_results if r.status != "healthy"]
+    findings = [
+        r for r in report.resolved_results + report.outstanding_results if r.status != "healthy"
+    ]
     if findings:
         lines.append("Findings:")
         for r in findings:

--- a/aragora/cli/commands/dic28_crux_garden.py
+++ b/aragora/cli/commands/dic28_crux_garden.py
@@ -73,7 +73,7 @@ def _load_receipts(path: Path) -> list[CruxReceipt] | str:
         try:
             raw = json.loads(text)
             return [_parse_receipt(item) for item in (raw if isinstance(raw, list) else [])]
-        except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+        except (AttributeError, json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
             return f"invalid JSON: {exc}"
     receipts: list[CruxReceipt] = []
     for lineno, line in enumerate(text.splitlines(), 1):
@@ -82,7 +82,7 @@ def _load_receipts(path: Path) -> list[CruxReceipt] | str:
             continue
         try:
             receipts.append(_parse_receipt(json.loads(line)))
-        except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+        except (AttributeError, json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
             return f"line {lineno}: {exc}"
     return receipts
 

--- a/aragora/cli/commands/dic28_crux_garden.py
+++ b/aragora/cli/commands/dic28_crux_garden.py
@@ -1,0 +1,115 @@
+"""CLI command: aragora crux-garden.
+
+DIC-28 operator surface for the proactive crux gardening pass (issue #6222).
+
+Reads a JSONL or JSON-array file of CruxReceipt dicts, runs a full
+gardening pass, and prints the GardeningReport as JSON or a text summary.
+No debate is started; no issue is created; no queue is touched.
+
+Flag: ARAGORA_CRUX_GARDENING_ENABLED (default OFF).
+Live queue effect: none — read-only analysis.
+Advances: issue #6222 (DIC-28).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from aragora.epistemic.crux_receipt import CruxEntry, CruxReceipt
+from aragora.epistemic.gardening import GardeningConfig, GardeningReport, run_gardening_pass
+
+_FLAG = "ARAGORA_CRUX_GARDENING_ENABLED"
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def _flag_enabled() -> bool:
+    return str(os.environ.get(_FLAG) or "").strip().lower() in _TRUTHY
+
+
+def _parse_receipt(d: dict[str, Any]) -> CruxReceipt:
+    """Deserialise one CruxReceipt from a plain dict (JSON/JSONL)."""
+    cruxes = [
+        CruxEntry(
+            crux_id=str(c.get("crux_id", "")),
+            statement=str(c.get("statement", "")),
+            load_bearing_score=float(c.get("load_bearing_score", 0.0)),
+            uncertainty_score=float(c.get("uncertainty_score", 0.0)),
+            contesting_agents=list(c.get("contesting_agents") or []),
+            affected_claims=list(c.get("affected_claims") or []),
+            resolution_impact=float(c.get("resolution_impact", 0.0)),
+        )
+        for c in (d.get("cruxes") or [])
+    ]
+    return CruxReceipt(
+        receipt_id=str(d.get("receipt_id", "")),
+        debate_id=str(d.get("debate_id", "")),
+        question=str(d.get("question", "")),
+        cruxes=cruxes,
+        convergence_barrier=float(d.get("convergence_barrier", 0.0)),
+        counterfactuals=list(d.get("counterfactuals") or []),
+        agents=list(d.get("agents") or []),
+        rounds=int(d.get("rounds", 0)),
+        metadata=dict(d.get("metadata") or {}),
+        checksum=str(d.get("checksum", "")),
+    )
+
+
+def _load_receipts(path: Path) -> list[CruxReceipt] | str:
+    """Load CruxReceipts from a JSON array or JSONL file.
+
+    Returns a list on success or an error string on failure.
+    """
+    if not path.exists():
+        return f"input file not found: {path}"
+    text = path.read_text(encoding="utf-8").strip()
+    if not text:
+        return []
+    if text.startswith("["):
+        try:
+            raw = json.loads(text)
+            return [_parse_receipt(item) for item in (raw if isinstance(raw, list) else [])]
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+            return f"invalid JSON: {exc}"
+    receipts: list[CruxReceipt] = []
+    for lineno, line in enumerate(text.splitlines(), 1):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            receipts.append(_parse_receipt(json.loads(line)))
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+            return f"line {lineno}: {exc}"
+    return receipts
+
+
+def _format_text(report: GardeningReport) -> str:
+    lines = [
+        f"Gardening report  {report.generated_at}",
+        f"  resolved: {len(report.resolved_results)}  outstanding: {len(report.outstanding_results)}",
+        "Summary: " + "  ".join(f"{k}={v}" for k, v in sorted(report.summary.items())),
+    ]
+    findings = [r for r in report.resolved_results + report.outstanding_results if r.status != "healthy"]
+    if findings:
+        lines.append("Findings:")
+        for r in findings:
+            suffix = " [needs-followup]" if r.needs_followup else ""
+            lines.append(f"  [{r.status}] {r.crux_id}: {r.detail}{suffix}")
+    return "\n".join(lines)
+
+
+def cmd_crux_garden(args: argparse.Namespace) -> int:
+    if not _flag_enabled():
+        print(f"error: {_FLAG} is not set; crux gardening is disabled", file=sys.stderr)
+        return 1
+    result = _load_receipts(Path(args.input))
+    if isinstance(result, str):
+        print(f"error: {result}", file=sys.stderr)
+        return 1
+    report = run_gardening_pass(result, [], config=GardeningConfig(enabled=True))
+    print(report.to_json() if args.json else _format_text(report))
+    return 0

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -221,6 +221,9 @@ Examples:
     # DIC-27: operator crux arbitration surface
     _add_crux_arbitrate_parser(subparsers)
 
+    # DIC-28: proactive crux gardening operator surface
+    _add_crux_garden_parser(subparsers)
+
     return parser
 
 
@@ -676,6 +679,29 @@ def _add_crux_arbitrate_parser(subparsers) -> None:
         help="Emit output as JSON instead of human-readable text",
     )
     p.set_defaults(func=_lazy("aragora.cli.commands.crux_arbitrate", "cmd_crux_arbitrate"))
+
+
+def _add_crux_garden_parser(subparsers) -> None:
+    """DIC-28: proactive crux gardening operator surface (issue #6222).
+
+    Flag-gated: ARAGORA_CRUX_GARDENING_ENABLED. Live queue effect: none.
+    """
+    p = subparsers.add_parser(
+        "crux-garden",
+        help="DIC-28: proactive re-examination of cruxes for staleness and contradictions",
+        description=(
+            "Load a JSONL or JSON-array of CruxReceipt dicts and run a gardening pass. "
+            "Report-only; no debates started, no issues created. "
+            "Requires ARAGORA_CRUX_GARDENING_ENABLED=1."
+        ),
+    )
+    p.add_argument(
+        "--input",
+        required=True,
+        help="Path to a JSONL or JSON-array file of CruxReceipt dicts.",
+    )
+    p.add_argument("--json", action="store_true", help="Emit report as JSON.")
+    p.set_defaults(func=_lazy("aragora.cli.commands.dic28_crux_garden", "cmd_crux_garden"))
 
 
 def _add_ask_parser(subparsers) -> None:

--- a/tests/cli/test_dic28_crux_garden.py
+++ b/tests/cli/test_dic28_crux_garden.py
@@ -153,3 +153,34 @@ def test_parse_receipt_crux_fields(tmp_path: Path) -> None:
     assert crux.crux_id == "crux.soak.equivalence"
     assert crux.load_bearing_score == pytest.approx(0.82)
     assert "claim.b0.fresh" in crux.affected_claims
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "[1]",  # array with non-object scalar
+        "[null]",  # array with null entry
+        '["string"]',  # array with string entry
+    ],
+)
+def test_non_object_receipt_exits_1(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture,
+    content: str,
+) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    f = tmp_path / "r.json"
+    f.write_text(content)
+    assert cmd_crux_garden(_ns(input_path=str(f))) == 1
+    assert "error" in capsys.readouterr().err.lower()
+
+
+def test_jsonl_non_object_line_exits_1(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    f = tmp_path / "r.jsonl"
+    f.write_text("1\n")
+    assert cmd_crux_garden(_ns(input_path=str(f))) == 1
+    assert "line 1" in capsys.readouterr().err

--- a/tests/cli/test_dic28_crux_garden.py
+++ b/tests/cli/test_dic28_crux_garden.py
@@ -1,0 +1,159 @@
+"""Tests for aragora crux-garden CLI (DIC-28 / #6222).
+
+No network, no subprocess, no queue mutation.
+All receipt inputs are synthetic dicts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from aragora.cli.commands.dic28_crux_garden import (
+    _flag_enabled,
+    _load_receipts,
+    _parse_receipt,
+    cmd_crux_garden,
+)
+
+_FLAG = "ARAGORA_CRUX_GARDENING_ENABLED"
+
+_RECEIPT: dict = {
+    "receipt_id": "rcpt_abc123",
+    "debate_id": "debate_xyz",
+    "question": "Should we expand the B2 guard now?",
+    "cruxes": [
+        {
+            "crux_id": "crux.soak.equivalence",
+            "statement": "One soak may equal three.",
+            "load_bearing_score": 0.82,
+            "uncertainty_score": 0.40,
+            "contesting_agents": ["claude", "codex"],
+            "affected_claims": ["claim.b0.fresh"],
+            "resolution_impact": 0.9,
+        }
+    ],
+    "convergence_barrier": 0.73,
+    "counterfactuals": [],
+    "agents": ["claude", "codex"],
+    "rounds": 3,
+    "metadata": {"mode": "crux_finder"},
+    "checksum": "deadbeef" * 8,
+}
+
+
+def _ns(*, input_path: str, json_out: bool = False) -> argparse.Namespace:
+    return argparse.Namespace(input=input_path, json=json_out)
+
+
+# ---------------------------------------------------------------------------
+# Flag guard
+# ---------------------------------------------------------------------------
+
+
+def test_flag_off_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(_FLAG, raising=False)
+    assert _flag_enabled() is False
+
+
+def test_disabled_exits_1(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.delenv(_FLAG, raising=False)
+    f = tmp_path / "r.json"
+    f.write_text("[]")
+    assert cmd_crux_garden(_ns(input_path=str(f))) == 1
+    assert _FLAG in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# Input handling
+# ---------------------------------------------------------------------------
+
+
+def test_missing_input_exits_1(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    assert cmd_crux_garden(_ns(input_path=str(tmp_path / "nope.json"))) == 1
+    assert "not found" in capsys.readouterr().err
+
+
+def test_invalid_json_exits_1(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    f = tmp_path / "bad.json"
+    f.write_text("[{invalid}")
+    assert cmd_crux_garden(_ns(input_path=str(f))) == 1
+    assert "error" in capsys.readouterr().err.lower()
+
+
+def test_jsonl_bad_line_exits_1(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    f = tmp_path / "r.jsonl"
+    f.write_text(json.dumps(_RECEIPT) + "\n{bad}\n")
+    assert cmd_crux_garden(_ns(input_path=str(f))) == 1
+    assert "line 2" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# Successful runs
+# ---------------------------------------------------------------------------
+
+
+def test_json_array_input_exits_0(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    f = tmp_path / "r.json"
+    f.write_text(json.dumps([_RECEIPT]))
+    assert cmd_crux_garden(_ns(input_path=str(f))) == 0
+
+
+def test_jsonl_input_exits_0(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    f = tmp_path / "r.jsonl"
+    f.write_text(json.dumps(_RECEIPT) + "\n")
+    assert cmd_crux_garden(_ns(input_path=str(f))) == 0
+
+
+def test_json_output_parseable_with_schema_version(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    f = tmp_path / "r.json"
+    f.write_text(json.dumps([_RECEIPT]))
+    assert cmd_crux_garden(_ns(input_path=str(f), json_out=True)) == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["schema_version"] == 1
+    assert "summary" in report
+    assert "generated_at" in report
+
+
+def test_summary_has_gardening_status_keys(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    f = tmp_path / "r.json"
+    f.write_text(json.dumps([_RECEIPT]))
+    cmd_crux_garden(_ns(input_path=str(f), json_out=True))
+    report = json.loads(capsys.readouterr().out)
+    for key in ("healthy", "stale_evidence", "new_contradiction", "insufficient_evidence"):
+        assert key in report["summary"], f"missing summary key: {key}"
+
+
+def test_parse_receipt_crux_fields(tmp_path: Path) -> None:
+    receipt = _parse_receipt(_RECEIPT)
+    assert len(receipt.cruxes) == 1
+    crux = receipt.cruxes[0]
+    assert crux.crux_id == "crux.soak.equivalence"
+    assert crux.load_bearing_score == pytest.approx(0.82)
+    assert "claim.b0.fresh" in crux.affected_claims

--- a/tests/cli/test_dic28_crux_garden.py
+++ b/tests/cli/test_dic28_crux_garden.py
@@ -107,18 +107,14 @@ def test_jsonl_bad_line_exits_1(
 # ---------------------------------------------------------------------------
 
 
-def test_json_array_input_exits_0(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_json_array_input_exits_0(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv(_FLAG, "1")
     f = tmp_path / "r.json"
     f.write_text(json.dumps([_RECEIPT]))
     assert cmd_crux_garden(_ns(input_path=str(f))) == 0
 
 
-def test_jsonl_input_exits_0(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_jsonl_input_exits_0(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv(_FLAG, "1")
     f = tmp_path / "r.jsonl"
     f.write_text(json.dumps(_RECEIPT) + "\n")


### PR DESCRIPTION
## Slice

Adds `aragora crux-garden --input <path> [--json]` — a thin CLI verb that wraps the existing `run_gardening_pass` function in `aragora.epistemic.gardening`. Operators point it at a JSONL or JSON-array file of CruxReceipt dicts and get a structured report of stale evidence, new contradictions, and fragility shifts across their crux ledger — without touching any live queue path.

## Gating

- Default: **OFF** (flag: `ARAGORA_CRUX_GARDENING_ENABLED=1`)
- Live queue effect: **none** — read-only report; no debate started, no issue created, no queue write
- Advances issue: #6222 (DIC-28)

## Tests

- `test_flag_off_by_default` — `_flag_enabled()` returns False when env var is unset
- `test_disabled_exits_1` — command returns rc=1 and prints the flag name when unset
- `test_missing_input_exits_1` — returns rc=1 when `--input` path does not exist
- `test_invalid_json_exits_1` — returns rc=1 on malformed JSON input
- `test_jsonl_bad_line_exits_1` — returns rc=1 and reports `line 2` on a bad JSONL line
- `test_json_array_input_exits_0` — JSON-array input with one receipt exits 0
- `test_jsonl_input_exits_0` — JSONL input with one receipt exits 0
- `test_json_output_parseable_with_schema_version` — `--json` emits valid JSON with `schema_version=1`, `summary`, `generated_at`
- `test_summary_has_gardening_status_keys` — report summary contains `healthy`, `stale_evidence`, `new_contradiction`, `insufficient_evidence`
- `test_parse_receipt_crux_fields` — `_parse_receipt` deserialises `crux_id`, `load_bearing_score`, `affected_claims` correctly

## Validation

- `pytest tests/cli/test_dic28_crux_garden.py` — **10 passed**
- `ruff check aragora/cli/commands/dic28_crux_garden.py tests/cli/test_dic28_crux_garden.py` — **clean**
- `mypy aragora/cli/commands/dic28_crux_garden.py tests/cli/test_dic28_crux_garden.py --ignore-missing-imports` — **clean**
- Net diff: **300 LOC** (3 files: +115 command, +26 parser, +159 tests)

## Out of scope

- DIC-17 bridge integration (`followup.py` and `propose_followup_for_failed_claim` exist but are not wired here — deferred to a future slice that specifically exercises the `followup_eligible` config flag)
- Coherence issue input (DIC-26 `CoherenceIssue` injection) — the CLI currently passes no `coherence_issues`; a future slice can add `--coherence <path>` to feed DIC-26 output in
- Fragility baseline input (DIC-25 `fragility_scores`) — similarly deferred; outstanding cruxes pass through with `insufficient_evidence` status when no baseline is supplied

## Gate status

Per `docs/status/NEXT_STEPS_CANONICAL.md`, `DIC-13..22` are in the **Delay** track — issues may stay open for planning but must not enter the live boss-ready queue. The proof-first Foreman gate has **not** opened. This PR is planning truth only.

---
_Generated by [Claude Code](https://claude.ai/code/session_019s1cwZKHEundwpK3S4QfKt)_