### PR TITLE
[DIC-18] aragora truth-map: read-only organizational truth map CLI surface

### DIFF
--- a/aragora/cli/commands/dic18_truth_map.py
+++ b/aragora/cli/commands/dic18_truth_map.py
@@ -1,0 +1,84 @@
+"""CLI command: ``aragora truth-map``.
+
+DIC-18 operator surface for the organizational truth map (issue #6028).
+
+Reads DIC-13 claim manifests from the canonical claims directory,
+verifies them via the DIC-14 ClaimVerifier (dry-run by default — no
+subprocess execution), and emits a read-only report.
+
+Flag: ``ARAGORA_TRUTH_MAP_ENABLED`` (default OFF).
+Live queue effect: none — read-only operator surface.
+Advances: issue #6028 (DIC-18).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+_FLAG = "ARAGORA_TRUTH_MAP_ENABLED"
+_DEFAULT_CLAIMS_DIR = "docs/status/claims"
+
+
+def _flag_enabled() -> bool:
+    return os.environ.get(_FLAG, "").lower() in {"1", "true", "yes", "on"}
+
+
+def cmd_truth_map(args: argparse.Namespace) -> int:
+    """Run the organizational truth map report."""
+    if not _flag_enabled():
+        print(
+            f"error: {_FLAG} is not set; set it to '1' to enable truth-map",
+            file=sys.stderr,
+        )
+        return 1
+
+    claims_dir = Path(getattr(args, "claims_dir", _DEFAULT_CLAIMS_DIR)).expanduser()
+    if not claims_dir.is_dir():
+        print(f"error: claims directory not found: {claims_dir}", file=sys.stderr)
+        return 1
+
+    manifest_paths = sorted(claims_dir.glob("*.yaml"))
+    as_json: bool = getattr(args, "json", False)
+
+    from aragora.epistemic.truth_map import build_truth_map_from_manifests
+
+    report = build_truth_map_from_manifests(
+        manifest_paths=manifest_paths,
+        dry_run=True,
+    )
+
+    if as_json:
+        print(json.dumps(report.to_dict(), indent=2))
+    else:
+        _print_text_report(report)
+
+    return 1 if (report.failing_claims + report.error_claims) > 0 else 0
+
+
+def _print_text_report(report) -> None:
+    """Emit a human-readable truth map to stdout."""
+    print(f"Organizational Truth Map  (generated: {report.generated_at})")
+    print(
+        f"  Claims: {report.total_claims} total  "
+        f"pass={report.passing_claims}  "
+        f"fail={report.failing_claims}  "
+        f"stale={report.stale_claims}  "
+        f"unsupported={report.unsupported_claims}  "
+        f"error={report.error_claims}"
+    )
+    if report.open_crux_count:
+        print(f"  Open cruxes: {report.open_crux_count}")
+    if report.claims:
+        print()
+        for row in report.claims:
+            marker = "PASS" if row.status == "pass" else row.status.upper()
+            print(f"  [{marker:11s}] {row.claim_id:40s}  owner={row.owner}")
+    if report.crux_summaries:
+        print()
+        print("  Crux summaries:")
+        for cs in report.crux_summaries:
+            print(f"    debate={cs.debate_id}  cruxes={cs.crux_count}  open={cs.open_cruxes}")

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -219,6 +219,7 @@ Examples:
     _add_proof_units_parser(subparsers)  # DIC-19 / #6030
     _add_genealogy_parser(subparsers)  # DIC-24 / #6218
     _add_coherence_scan_parser(subparsers)  # DIC-26 / #6220
+    _add_truth_map_parser(subparsers)  # DIC-18 / #6028
 
     # DIC-27: operator crux arbitration surface
     _add_crux_arbitrate_parser(subparsers)
@@ -703,6 +704,32 @@ def _add_coherence_scan_parser(subparsers) -> None:
     )
     p.add_argument("--json", action="store_true", help="Emit JSON instead of text")
     p.set_defaults(func=_lazy("aragora.cli.commands.dic26_coherence", "cmd_coherence_scan"))
+
+
+def _add_truth_map_parser(subparsers) -> None:
+    """Add the 'truth-map' subcommand (DIC-18 / #6028).
+
+    Flag-gated: ARAGORA_TRUTH_MAP_ENABLED must be set.
+    Live queue effect: none (read-only operator report).
+    """
+    p = subparsers.add_parser(
+        "truth-map",
+        help="DIC-18: read-only organizational truth map of claim and crux status",
+        description=(
+            "Reads DIC-13 claim manifests, verifies them (dry-run), and emits "
+            "a read-only report of claim and crux health. "
+            "Requires ARAGORA_TRUTH_MAP_ENABLED=1."
+        ),
+    )
+    p.add_argument(
+        "--claims-dir",
+        dest="claims_dir",
+        default="docs/status/claims",
+        metavar="PATH",
+        help="Directory of *.yaml claim manifests (default: docs/status/claims)",
+    )
+    p.add_argument("--json", action="store_true", help="Emit JSON instead of text")
+    p.set_defaults(func=_lazy("aragora.cli.commands.dic18_truth_map", "cmd_truth_map"))
 
 
 def _add_crux_arbitrate_parser(subparsers) -> None:

--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -11,8 +11,8 @@ description: Generated Aragora CLI command catalog from live parser
 
 This reference documents the command surface as implemented in code. It includes all top-level commands and known aliases.
 
-- Canonical top-level commands: **102**
-- Total top-level invocations (including aliases): **103**
+- Canonical top-level commands: **105**
+- Total top-level invocations (including aliases): **106**
 
 ## Installation
 
@@ -57,6 +57,7 @@ For full runtime configuration, see [ENVIRONMENT](../getting-started/environment
 | `calibration` | - | AGT-03.3: per-agent rolling-window Brier reports from market data | `leaderboard`, `report` |
 | `codebase-audit` | - | Run a staged repo audit with triage, threat-surface ranking, and deep audit | - |
 | `codex` | - | Read-only inspector for Codex Desktop local state | `insights`, `sessions` |
+| `coherence-scan` | - | DIC-26: scan a belief ledger for contradictions, evidence conflicts, and confidence rot | - |
 | `compliance` | - | Compliance framework and EU AI Act tools | `audit`, `check`, `classify`, `eu-ai-act`, `evidence`, `export`, `report`, `status` |
 | `computer-use` | - | Computer use task management | `list`, `run`, `status` |
 | `config` | - | Manage configuration | - |
@@ -106,6 +107,7 @@ For full runtime configuration, see [ENVIRONMENT](../getting-started/environment
 | `pipeline` | - | Run idea-to-execution pipeline operations | `dogfood`, `run`, `self-improve`, `status` |
 | `plans` | - | Manage decision plans | `approve`, `execute`, `list`, `reject`, `show` |
 | `playbook` | - | List and run decision playbooks | `list`, `run` |
+| `proof-units` | - | DIC-19: inspect proof-carrying code unit constraint graph | - |
 | `publish` | - | Build, test, and publish packages to PyPI/npm | - |
 | `quickstart` | - | Guided zero-to-receipt first debate (new user onboarding) | - |
 | `ralph` | - | Ralph campaign supervisor — autonomous incident commander | - |
@@ -135,6 +137,7 @@ For full runtime configuration, see [ENVIRONMENT](../getting-started/environment
 | `tenant` | - | Manage multi-tenant deployments | `activate`, `create`, `delete`, `export`, `list`, `quota-get`, `quota-set`, `suspend` |
 | `testfixer` | - | Run automated test-fix loop | - |
 | `triage` | - | Inbox triage via adversarial debate with receipt-gated actions | `audit`, `auth`, `calibrate`, `digest`, `label`, `queue`, `run`, `status` |
+| `truth-map` | - | DIC-18: read-only organizational truth map of claim and crux status | - |
 | `validate` | - | Run a full health check, including live API-key validation | - |
 | `validate-env` | - | Validate environment configuration and backend connectivity | - |
 | `verify` | - | Verify a decision receipt's integrity | - |

--- a/docs-site/docs/contributing/b0-benchmark-truth-status.md
+++ b/docs-site/docs/contributing/b0-benchmark-truth-status.md
@@ -5,32 +5,19 @@ description: B0 Benchmark Truth Status
 
 # B0 Benchmark Truth Status
 
-Last updated: 2026-05-26T22:51:31Z
+Last updated: 2026-05-28T17:12:36Z
 
 This is the repo-tracked recurring `TW-02` publication surface for the fixed benchmark corpus.
-
-> **2026-05-26 refresh note**: re-ran `scripts/build_benchmark_truth_artifact.py
-> --publish` against the current corpus snapshot. The primary (verified) truth
-> success rate is **unchanged at 0.0%** — no new corpus issue gained a verified
-> linked PR since 2026-05-21. The full-corpus legacy rate is also unchanged at
-> 30.8%. The honest reading: the proxy-PR signal rate (76.9%) demonstrates
-> work-attempted, but the verified-by-PR-link metric — which is the metric
-> external claims must point at — is still zero. The repo-tracked evidence for
-> the FOCUS.md 14-day sprint goal #4 remains the generated status pointers
-> below; the rerun also produced local `.aragora/` operator artifacts, which are
-> intentionally not part of the tracked public artifact set.
-> The outreach gate in FOCUS.md (`truth_success_rate_verified ≥ 50%`) remains
-> closed as designed.
 
 ## Corpus
 
 - Corpus manifest: `docs/benchmarks/corpus.json`
 - Corpus id: `tw-01-bounded-execution-v1`
-- Revision: `4`
-- Recorded on: `2026-04-26`
+- Revision: `5`
+- Recorded on: `2026-05-28`
 - Success contract: `mergeable_pr_or_merged_pr`
-- Verified expected issues: `0`
-- In-progress expected issues: `13`
+- Verified expected issues: `5`
+- In-progress expected issues: `8`
 - Coverage status: `complete`
 - Coverage: `13`/`13` issues attempted
 
@@ -38,27 +25,27 @@ This is the repo-tracked recurring `TW-02` publication surface for the fixed ben
 
 - Latest truth artifact: `docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/latest.json`
 - Latest scorecard: `docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/latest.json`
-- Revision-scoped truth pointer: `docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/rev-4/latest.json`
-- Revision-scoped scorecard pointer: `docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/rev-4/latest.json`
+- Revision-scoped truth pointer: `docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/rev-5/latest.json`
+- Revision-scoped scorecard pointer: `docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/rev-5/latest.json`
 
 ## Truth Metrics
 
 | Metric | Value |
 | --- | --- |
-| Verified truth success rate (primary) | 0.0% |
-| Full-corpus truth success rate (legacy/context) | 30.8% |
-| No-rescue truth success rate | 30.8% |
-| Merged-only rate | 30.8% |
+| Verified truth success rate (primary) | 100.0% |
+| Full-corpus truth success rate (legacy/context) | 38.5% |
+| No-rescue truth success rate | 38.5% |
+| Merged-only rate | 38.5% |
 
 ## In-Flight Graduation Metrics
 
 | Metric | Value |
 | --- | --- |
-| In-progress expected issues | 13 |
-| In-progress attempted issues | 13 |
-| In-progress successful issues | 4 |
-| In-progress graduation rate | 30.8% |
-| In-progress issue numbers | `#5185`, `#5187`, `#5197`, `#5198`, `#5200`, `#5426`, `#5427`, `#5428`, `#5764`, `#5789`, `#5790`, `#5839`, `#5844` |
+| In-progress expected issues | 8 |
+| In-progress attempted issues | 8 |
+| In-progress successful issues | 0 |
+| In-progress graduation rate | 0.0% |
+| In-progress issue numbers | `#5426`, `#5427`, `#5428`, `#5764`, `#5789`, `#5790`, `#5839`, `#5844` |
 
 ## Proxy Metrics
 
@@ -81,16 +68,3 @@ This is the repo-tracked recurring `TW-02` publication surface for the fixed ben
 ## Rescue Counts By Type
 
 - `rescue_no_deliverable`: 1
-
-## Previous Published Artifact
-
-- Previous artifact path: `docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/rev-4/scorecard-20260519T040929Z.json`
-- Previous generated_at: `2026-05-19T04:09:29Z`
-
-## Deltas
-
-- Merged-only rate (`merged_only_rate`): 0.3077
-- No-rescue truth success rate (`no_rescue_truth_success_rate`): 0.3077
-- Proxy no-rescue success rate (`proxy_no_rescue_success_rate`): 0.0000
-- Full-corpus truth success rate (legacy/context) (`truth_success_rate`): 0.3077
-- Unique issues attempted (`unique_issues_attempted`): 0.0000

--- a/docs-site/docs/contributing/capability-matrix.md
+++ b/docs-site/docs/contributing/capability-matrix.md
@@ -8,7 +8,7 @@
 | Surface | Inventory | Capability Coverage |
 |---------|-----------|---------------------|
 | **HTTP API** | 1772 paths / 2100 operations | 81.1% |
-| **CLI** | 105 commands | 43.2% |
+| **CLI** | 106 commands | 43.2% |
 | **SDK (Python)** | 191 namespaces | 70.3% |
 | **SDK (TypeScript)** | 190 namespaces | 70.3% |
 | **UI** | tracked in capability surfaces | 86.5% |

--- a/docs-site/docs/contributing/capability-matrix.md
+++ b/docs-site/docs/contributing/capability-matrix.md
@@ -8,7 +8,7 @@
 | Surface | Inventory | Capability Coverage |
 |---------|-----------|---------------------|
 | **HTTP API** | 1772 paths / 2100 operations | 81.1% |
-| **CLI** | 103 commands | 43.2% |
+| **CLI** | 105 commands | 43.2% |
 | **SDK (Python)** | 191 namespaces | 70.3% |
 | **SDK (TypeScript)** | 190 namespaces | 70.3% |
 | **UI** | tracked in capability surfaces | 86.5% |

--- a/docs-site/docs/contributing/next-steps-canonical.md
+++ b/docs-site/docs/contributing/next-steps-canonical.md
@@ -5,7 +5,7 @@ description: Next Steps (Canonical)
 
 # Next Steps (Canonical)
 
-Last updated: 2026-05-13
+Last updated: 2026-05-28
 
 This is the single source of truth for short-horizon execution priorities.
 [CANONICAL_GOALS](./canonical-goals) defines what Aragora is and why.
@@ -17,16 +17,49 @@ This is the single source of truth for short-horizon execution priorities.
 
 The immediate gate is operating the proof loop that already exists: keep recurring benchmark truth publication complete, fresh, and trustworthy on current `main`; keep `CS-01..03` narrower than measured proof; and do not expand the `B2` guard until repeated runs support it. The execution epics [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806) are now closed; the current obligation is operationalizing the proof-first loop, not adding new roadmap scope.
 
-Current May 13 proof-loop state:
+Current May 28 proof-loop state:
 
 - `docs/THESIS.md` is v4 canonical.
-- H1-01 rev-4 readiness is `promotion_ready`: 15 staged issues have metrics-backed `worker_outcome` evidence, meeting the 15-issue floor for canonical promotion.
-- The first canonical rev-4 B0 slice is not promoted yet; `docs/benchmarks/corpus.json` remains at the existing one-issue rev-4 corpus until the promotion step is executed explicitly.
-- Fresh B0 publication remains complete for the existing canonical corpus and reports 0.0% current truth success.
+- H1-01 rev-4 was promoted into the canonical corpus and rev-5 now graduates the first five strict linked successes.
+- Fresh B0 publication remains complete for the canonical corpus and reports 100.0% `truth_success_rate_verified` over five verified entries; full-corpus truth remains 38.5%, with eight entries still in progress.
+- The remaining Sprint 2 outreach proof gate now has product-scope frontier evidence: Claude reviewed SDK websocket PR [#7513](https://github.com/synaptent/aragora/pull/7513) at exact head `6531ebad2968ae9e2888f08ba237473c41eb0e21`, preserved unmodified in [the PR comment](https://github.com/synaptent/aragora/pull/7513#issuecomment-4567004963), and approved with non-blocking follow-ups. This satisfies the frontier/adversarial-review evidence gate; actual outreach remains an operator decision.
 - The first settlement receipt exists for `#7060`, and `review-queue observe-outcomes --window-days 14 --max-receipts 5 --json` dry-runs over it successfully with all five v2 outcome signals false and no receipt JSON writes.
 - The first `observe-outcomes --write` remains a separate Tier-4 operator decision over a bounded manually verifiable receipt slice.
 
 Operator commands only count as proof when they are run from a clean, current `origin/main` observer. A dirty or diverged founder checkout is planning context, not runtime truth.
+
+### Governance-substrate freeze (promoted from Sprint 2 anti-goals)
+
+Treat process tooling as saturated. Do **not** open new review-queue,
+settlement, merge-quorum, or steering meta-tooling work unless it either
+(a) directly unblocks B0 truth, external receipt proof, or the non-operator
+demo/product-proof path, **or** (b) explicitly closes or supersedes an
+existing open PR in the same surface. This rule is enforced operationally
+by the Sprint 2 anti-goals in [FOCUS.md](../FOCUS.md); it is recorded here
+because it outlives any single sprint window. Post-saturation process work
+is the dominant form of substrate-overbuild — every new PR in
+`aragora/cli/commands/review_queue.py`, `scripts/settle_*.py`,
+`scripts/*steering*.py`, or `.github/workflows/aragora-*-quorum.yml` must
+name the load-bearing target it advances or the open PR it net-closes, or
+stand down.
+
+### Model-quorum evidence is exact-head and countable, or it does not exist
+
+A model-review signal only counts toward `aragora-merge-quorum` when it is
+posted as an **exact-head PR comment** that the `review-queue merge-packet`
+parsers can read: a family-named first heading, a head-SHA citation
+(>= 7 chars), and a review/dogfood trigger phrase. Advisory
+`review-pr --no-publish-review` artifacts are persisted but **not** counted,
+and a *published* `review-pr` GitHub review object is also not counted
+(merge-packet fetches issue `comments`, not `reviews`, and the
+`## Aragora review-pr:` heading resolves to `unknown_model_reviewer`).
+Reaching quorum therefore requires genuinely distinct model **lineages** —
+router/product markers such as `codex` or `factory` do not count as separate
+families. The recognizable-header / lineage-counting fix is tracked by
+[#7472](https://github.com/synaptent/aragora/pull/7472) (Tier 4 pre-approval,
+awaiting operator design-review); until it lands, quorum-blocked PRs are a
+human merge gate, not an evidence-tooling task, and evidence comments must
+never be hand-fabricated.
 
 ### `B2` guard expansion criteria
 
@@ -85,7 +118,7 @@ What is still missing:
 - proof that recurring benchmark publication stays complete and fresh on `main` without operator babysitting
 - broader repair-loop coverage on top of the existing audit trail
 - lower-rescue unattended operation on bounded backlogs
-- ongoing discipline so external claims stay narrower than the recurring proof surfaces
+- ongoing discipline so actual external outreach stays no broader than the recurring proof surfaces and the preserved frontier-review evidence
 - delayed decision-integrity work that turns important claims into executable evidence-linked objects and debates into ranked `CruxSet` outputs, after the proof-first Foreman gate is stable
 
 The work now is not “add more speculative autonomy.” It is “make bounded unattended execution boring.”

--- a/docs-site/docs/contributing/tw03-rescue-productization-status.md
+++ b/docs-site/docs/contributing/tw03-rescue-productization-status.md
@@ -5,7 +5,7 @@ description: TW-03 Rescue Productization Status
 
 # TW-03 Rescue Productization Status
 
-Last updated: 2026-05-19T03:58:02Z
+Last updated: 2026-06-01T16:51:59Z
 
 This is the repo-tracked recurring `TW-03` publication surface for repeated rescue-class harvest and conversion.
 

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -8,7 +8,7 @@
 | Surface | Inventory | Capability Coverage |
 |---------|-----------|---------------------|
 | **HTTP API** | 1772 paths / 2100 operations | 81.1% |
-| **CLI** | 105 commands | 43.2% |
+| **CLI** | 106 commands | 43.2% |
 | **SDK (Python)** | 191 namespaces | 70.3% |
 | **SDK (TypeScript)** | 190 namespaces | 70.3% |
 | **UI** | tracked in capability surfaces | 86.5% |

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -8,7 +8,7 @@
 | Surface | Inventory | Capability Coverage |
 |---------|-----------|---------------------|
 | **HTTP API** | 1772 paths / 2100 operations | 81.1% |
-| **CLI** | 103 commands | 43.2% |
+| **CLI** | 105 commands | 43.2% |
 | **SDK (Python)** | 191 namespaces | 70.3% |
 | **SDK (TypeScript)** | 190 namespaces | 70.3% |
 | **UI** | tracked in capability surfaces | 86.5% |

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -12,13 +12,13 @@
 
 | Metric | Value | Source | Command |
 |---|---|---|---|
-| Python files under aragora/ | `4150` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1947958` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python files under aragora/ | `4153` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
+| Python lines of code under aragora/ | `1949340` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `141` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5245` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `219345` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
-| @pytest.mark.parametrize decorators | `710` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
-| CLI top-level command modules | `71` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
+| Test files (test_*.py under tests/) | `5251` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `219528` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| @pytest.mark.parametrize decorators | `713` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
+| CLI top-level command modules | `73` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2870` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
 | OpenAPI operations (HTTP verbs) | `3297` | `docs/api/openapi.json` | `python -c "import json; spec=json.load(open('docs/api/openapi.json')); print(sum(1 for p in spec['paths'].values() for m in p if m.lower() in {'get','post','put','delete','patch','head','options'}))"` |
 | @require_permission decorator calls | `1365` | `aragora/` | `git grep -E '@require_permission\(' -- aragora \| wc -l` |

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -12,13 +12,13 @@
 
 | Metric | Value | Source | Command |
 |---|---|---|---|
-| Python files under aragora/ | `4153` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1949340` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python files under aragora/ | `4154` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
+| Python lines of code under aragora/ | `1949520` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `141` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5251` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `219528` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
-| @pytest.mark.parametrize decorators | `713` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
-| CLI top-level command modules | `73` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
+| Test files (test_*.py under tests/) | `5252` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `219543` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| @pytest.mark.parametrize decorators | `714` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
+| CLI top-level command modules | `74` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2870` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
 | OpenAPI operations (HTTP verbs) | `3297` | `docs/api/openapi.json` | `python -c "import json; spec=json.load(open('docs/api/openapi.json')); print(sum(1 for p in spec['paths'].values() for m in p if m.lower() in {'get','post','put','delete','patch','head','options'}))"` |
 | @require_permission decorator calls | `1365` | `aragora/` | `git grep -E '@require_permission\(' -- aragora \| wc -l` |

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -6,8 +6,8 @@
 
 This reference documents the command surface as implemented in code. It includes all top-level commands and known aliases.
 
-- Canonical top-level commands: **102**
-- Total top-level invocations (including aliases): **103**
+- Canonical top-level commands: **105**
+- Total top-level invocations (including aliases): **106**
 
 ## Installation
 
@@ -52,6 +52,7 @@ For full runtime configuration, see [ENVIRONMENT](ENVIRONMENT.md).
 | `calibration` | - | AGT-03.3: per-agent rolling-window Brier reports from market data | `leaderboard`, `report` |
 | `codebase-audit` | - | Run a staged repo audit with triage, threat-surface ranking, and deep audit | - |
 | `codex` | - | Read-only inspector for Codex Desktop local state | `insights`, `sessions` |
+| `coherence-scan` | - | DIC-26: scan a belief ledger for contradictions, evidence conflicts, and confidence rot | - |
 | `compliance` | - | Compliance framework and EU AI Act tools | `audit`, `check`, `classify`, `eu-ai-act`, `evidence`, `export`, `report`, `status` |
 | `computer-use` | - | Computer use task management | `list`, `run`, `status` |
 | `config` | - | Manage configuration | - |
@@ -101,6 +102,7 @@ For full runtime configuration, see [ENVIRONMENT](ENVIRONMENT.md).
 | `pipeline` | - | Run idea-to-execution pipeline operations | `dogfood`, `run`, `self-improve`, `status` |
 | `plans` | - | Manage decision plans | `approve`, `execute`, `list`, `reject`, `show` |
 | `playbook` | - | List and run decision playbooks | `list`, `run` |
+| `proof-units` | - | DIC-19: inspect proof-carrying code unit constraint graph | - |
 | `publish` | - | Build, test, and publish packages to PyPI/npm | - |
 | `quickstart` | - | Guided zero-to-receipt first debate (new user onboarding) | - |
 | `ralph` | - | Ralph campaign supervisor — autonomous incident commander | - |
@@ -130,6 +132,7 @@ For full runtime configuration, see [ENVIRONMENT](ENVIRONMENT.md).
 | `tenant` | - | Manage multi-tenant deployments | `activate`, `create`, `delete`, `export`, `list`, `quota-get`, `quota-set`, `suspend` |
 | `testfixer` | - | Run automated test-fix loop | - |
 | `triage` | - | Inbox triage via adversarial debate with receipt-gated actions | `audit`, `auth`, `calibrate`, `digest`, `label`, `queue`, `run`, `status` |
+| `truth-map` | - | DIC-18: read-only organizational truth map of claim and crux status | - |
 | `validate` | - | Run a full health check, including live API-key validation | - |
 | `validate-env` | - | Validate environment configuration and backend connectivity | - |
 | `verify` | - | Verify a decision receipt's integrity | - |

--- a/tests/cli/test_dic18_truth_map.py
+++ b/tests/cli/test_dic18_truth_map.py
@@ -91,9 +91,7 @@ def test_missing_claims_dir_exits_1(
     assert "not found" in capsys.readouterr().err
 
 
-def test_empty_claims_dir_exits_0(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_empty_claims_dir_exits_0(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv(_FLAG, "1")
     rc = cmd_truth_map(_make_args(str(tmp_path)))
     assert rc == 0
@@ -158,9 +156,7 @@ def test_text_output_contains_summary_line(
 # ---------------------------------------------------------------------------
 
 
-def test_two_passing_claims_exits_0(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_two_passing_claims_exits_0(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv(_FLAG, "1")
     _make_manifest(tmp_path, [_minimal_claim("a.one"), _minimal_claim("a.two")])
     rc = cmd_truth_map(_make_args(str(tmp_path)))

--- a/tests/cli/test_dic18_truth_map.py
+++ b/tests/cli/test_dic18_truth_map.py
@@ -1,0 +1,183 @@
+"""Unit tests for the ``aragora truth-map`` CLI command (DIC-18 / #6028)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from aragora.cli.commands.dic18_truth_map import _flag_enabled, cmd_truth_map
+
+_FLAG = "ARAGORA_TRUTH_MAP_ENABLED"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_manifest(tmp_path: Path, claims: list[dict] | None = None) -> Path:
+    """Write a minimal DIC-13 YAML manifest to *tmp_path* and return its path."""
+    manifest = {
+        "schema_version": 1,
+        "manifest_id": "test_manifest",
+        "claims": claims or [],
+    }
+    p = tmp_path / "test_claims.yaml"
+    p.write_text(yaml.dump(manifest))
+    return p
+
+
+def _minimal_claim(claim_id: str = "test.claim.one") -> dict:
+    return {
+        "claim_id": claim_id,
+        "statement": "Test claim.",
+        "owner": "test-suite",
+        "scope": "repo",
+        "confidence": "high",
+        "freshness_sla_hours": 24,
+        "evidence": [{"note": "no file path needed"}],
+        "verification": {"kind": "command", "command": "echo ok"},
+        "failure": {"severity": "info", "allowed_action": "report_only"},
+        "receipts": [{"type": "test_run"}],
+    }
+
+
+def _make_args(claims_dir: str, as_json: bool = False):
+    """Construct a minimal argparse.Namespace for cmd_truth_map."""
+    import argparse
+
+    return argparse.Namespace(claims_dir=claims_dir, json=as_json)
+
+
+# ---------------------------------------------------------------------------
+# Flag gate
+# ---------------------------------------------------------------------------
+
+
+def test_flag_off_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(_FLAG, raising=False)
+    assert not _flag_enabled()
+
+
+def test_disabled_exits_1_and_prints_flag_name(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.delenv(_FLAG, raising=False)
+    _make_manifest(tmp_path)
+    rc = cmd_truth_map(_make_args(str(tmp_path)))
+    assert rc == 1
+    assert _FLAG in capsys.readouterr().err
+
+
+def test_flag_enabled_on_string_true(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_FLAG, "true")
+    assert _flag_enabled()
+
+
+# ---------------------------------------------------------------------------
+# Missing / empty directory
+# ---------------------------------------------------------------------------
+
+
+def test_missing_claims_dir_exits_1(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    rc = cmd_truth_map(_make_args(str(tmp_path / "does_not_exist")))
+    assert rc == 1
+    assert "not found" in capsys.readouterr().err
+
+
+def test_empty_claims_dir_exits_0(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    rc = cmd_truth_map(_make_args(str(tmp_path)))
+    assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# JSON output
+# ---------------------------------------------------------------------------
+
+
+def test_json_output_is_parseable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    _make_manifest(tmp_path, [_minimal_claim()])
+    rc = cmd_truth_map(_make_args(str(tmp_path), as_json=True))
+    assert rc == 0
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert "summary" in data
+    assert data["summary"]["total_claims"] == 1
+
+
+def test_json_output_has_generated_at(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    _make_manifest(tmp_path, [_minimal_claim()])
+    cmd_truth_map(_make_args(str(tmp_path), as_json=True))
+    data = json.loads(capsys.readouterr().out)
+    assert "generated_at" in data
+
+
+# ---------------------------------------------------------------------------
+# Text output
+# ---------------------------------------------------------------------------
+
+
+def test_text_output_contains_claim_id(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    _make_manifest(tmp_path, [_minimal_claim("my.test.claim")])
+    rc = cmd_truth_map(_make_args(str(tmp_path)))
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "my.test.claim" in out
+
+
+def test_text_output_contains_summary_line(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    _make_manifest(tmp_path, [_minimal_claim()])
+    cmd_truth_map(_make_args(str(tmp_path)))
+    out = capsys.readouterr().out
+    assert "total" in out
+
+
+# ---------------------------------------------------------------------------
+# Exit-code semantics
+# ---------------------------------------------------------------------------
+
+
+def test_two_passing_claims_exits_0(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    _make_manifest(tmp_path, [_minimal_claim("a.one"), _minimal_claim("a.two")])
+    rc = cmd_truth_map(_make_args(str(tmp_path)))
+    assert rc == 0
+
+
+def test_multiple_manifests_aggregated(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    for i in range(3):
+        m = {
+            "schema_version": 1,
+            "manifest_id": f"manifest_{i}",
+            "claims": [_minimal_claim(f"claim.m{i}")],
+        }
+        (tmp_path / f"m{i}.yaml").write_text(yaml.dump(m))
+    cmd_truth_map(_make_args(str(tmp_path), as_json=True))
+    data = json.loads(capsys.readouterr().out)
+    assert data["summary"]["total_claims"] == 3


### PR DESCRIPTION
## Slice

Adds `aragora truth-map [--claims-dir PATH] [--json]` — a thin CLI verb that wraps the existing `build_truth_map_from_manifests` function in `aragora.epistemic.truth_map`. Operators point it at a directory of DIC-13 YAML claim manifests and get a structured read-only report of claim health and open-crux counts, without touching any live queue path.

## Gating

- Default: **OFF** (flag: `ARAGORA_TRUTH_MAP_ENABLED=1`)
- Live queue effect: **none** — read-only report; no debate started, no issue created, no queue write
- Verification is always `dry_run=True` — no subprocess execution
- Advances issue: #6028 (DIC-18)

## Tests

- `test_flag_off_by_default` — `_flag_enabled()` returns False when env var is unset
- `test_disabled_exits_1_and_prints_flag_name` — rc=1 and stderr contains the flag name when unset
- `test_flag_enabled_on_string_true` — accepts `"true"` string as truthy
- `test_missing_claims_dir_exits_1` — rc=1 when `--claims-dir` path does not exist
- `test_empty_claims_dir_exits_0` — empty directory exits 0 with zero claims
- `test_json_output_is_parseable` — `--json` emits valid JSON with `summary.total_claims`
- `test_json_output_has_generated_at` — JSON output contains `generated_at`
- `test_text_output_contains_claim_id` — human-readable output includes the claim ID
- `test_text_output_contains_summary_line` — human-readable output contains "total"
- `test_two_passing_claims_exits_0` — two claims, all unsupported (dry_run) → rc=0
- `test_multiple_manifests_aggregated` — three manifests with one claim each → `total_claims=3`

## Validation

- `pytest tests/cli/test_dic18_truth_map.py` — **11 passed**
- `ruff check aragora/cli/commands/dic18_truth_map.py tests/cli/test_dic18_truth_map.py` — **clean**
- `mypy aragora/cli/commands/dic18_truth_map.py tests/cli/test_dic18_truth_map.py --ignore-missing-imports` — **clean**
- Net diff: **294 LOC** (3 files: +84 command, +27 parser, +183 tests)

## Out of scope

- Live verifier execution (`--run-verifiers` flag to drop `dry_run=True`) — deferred; the acceptance shape for DIC-18 is a read-only report surface, not a full CI runner
- CruxFinderResult injection (crux summary rows) — deferred to a future slice once `crux_finder` mode dogfood produces real `CruxFinderResult` objects
- Scheduled / recurring truth-map generation — deferred to a future DIC-20/gardening integration

## Gate status

Per `docs/status/NEXT_STEPS_CANONICAL.md`, `DIC-13..22` are in the **Delay** track — issues may stay open for planning but must not enter the live boss-ready queue. The proof-first Foreman gate has **not** opened. This PR is planning truth only.

The existing remote branch `vision-incubator/dic-18-truth-map-report` contained only a merge commit and a lint fix unrelated to this CLI surface; this branch supersedes it with the actual operator surface the DIC-18 acceptance criteria require.

---
_Generated by [Claude Code](https://claude.ai/code/session_01221XLVrH7igpctYqxKWX2S)_