### PR TITLE
feat(skills): elves-aragora overnight-run skill (crash-resumable, gate-bound)

### DIFF
--- a/.agents/skills/elves-aragora/SKILL.md
+++ b/.agents/skills/elves-aragora/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: elves-aragora
+description: Crash-resumable, plan-driven overnight execution bound to aragora's proof-first gates. Use when the user says "run overnight", "I'm going offline", "implement this plan", "keep going without me", "don't stop", "I'll be back in the morning", or otherwise asks for long unattended autonomous work in this repo. Unlike a generic overnight runner, every batch lands through aragora's real gates — model-quorum evidence, decision receipts, draft-PR only, never admin merge — and the run survives a crash or context compaction via an on-disk execution log.
+license: MIT
+metadata:
+  author: Aragora Contributors
+  version: "0.1.0"
+  derived-from: aigorahub/elves (MIT) — survival-guide / execution-log scaffolding pattern
+  argument-hint: Path to a plan file (docs/plans/*.md), or plan text directly.
+---
+
+# Elves-Aragora — governed overnight runs
+
+You are the night shift. The user is the day manager who handed you a written plan
+before going offline. Execute it batch by batch — with testing, model-quorum review,
+receipts, and documentation — until the plan is done or you hit a genuine blocker.
+
+**You never admin-merge. You never bypass a gate. The user (or the quorum) merges.**
+**The run must survive a crash:** every batch's state lives in an on-disk execution
+log so a fresh session can resume from live truth, not transcript memory.
+
+This skill does **not** reinvent aragora's autonomy loop — that already exists
+(`AGENTS.md`, `docs/AGENT_OPERATING_CONTRACT.md`, `scripts/codex_worktree_autopilot.py`,
+the merge-quorum gate, decision receipts). It adds the missing piece: a **resumable,
+plan-driven wrapper** so those gates run unattended overnight and recover from interruption.
+
+## Install / location
+
+This skill lives at `.agents/skills/elves-aragora/` (the Codex per-repo skills path —
+read by the Codex CLI, IDE extension, and desktop app). Claude Code reads
+`~/.claude/skills/`; because this repo `.gitignore`s `.claude/`, Claude Code users copy
+or symlink this directory into `~/.claude/skills/elves-aragora/`. Restart the agent to re-index.
+
+## Three documents (the scaffolding)
+
+Borrowed from elves (credit: `aigorahub/elves`, MIT), adapted to aragora gates:
+
+1. **Plan** — `docs/plans/<name>.md`. The user authors this: goal, milestones broken
+   into sprint-sized batches, each batch independently shippable and testable.
+2. **Survival Guide** — `docs/plans/<name>.survival.md`. Per-project gates and invariants
+   the night shift must obey. For aragora the gate is NOT `npm test` — see "Batch gate" below.
+3. **Execution Log** — `docs/plans/<name>.log.md`. Append-only. After every batch step,
+   write: batch id, branch, head SHA, what changed, gate results, PR number, current
+   blocker. **This is the crash/compaction recovery anchor** — a resumed session reads
+   this first, re-derives live truth, and continues.
+
+Bootstrap missing docs from `~/.claude/skills/elves/references/` (plan-template.md,
+survival-guide-template.md, execution-log-template.md) then rewrite the gate sections per below.
+
+## Loop (per batch)
+
+0. **Recover state first.** Read the execution log. Run the gate-discovery commands
+   (below). Trust live truth over the transcript — a crash may have happened mid-batch.
+1. **Isolate.** Work in a fresh git worktree (never the shared root if dirty/owned).
+2. **Implement** the next batch with TDD. Keep batches small and independently shippable.
+3. **Batch gate (aragora-specific — this replaces a plain test run):**
+   - Required CI checks green (`gh pr checks <pr> --required`).
+   - Genuine model-quorum evidence at exact head: run `review-pr <pr> --reviewer claude`
+     and `--reviewer codex`; if a review returns `changes_requested`, **repair first** —
+     the findings are usually real. Post head-grounded countable evidence
+     (`review-queue evidence-lint` → `would_count` → `gh pr comment`).
+   - `settle_one_pr.py --pr <pr>` blockers reduce to `['PR is draft']` only.
+4. **Open a DRAFT PR** (`Closes #...`). Never mark ready unless the merge-packet and
+   settle agree the only blocker is draft status, and tier ≤ 2 with no human-risk settlement.
+5. **Log it** (append to the execution log) and notify (`scripts/notify.sh` if configured).
+6. **Stop conditions** (hand back to the human): publisher not ready, active-owner conflict,
+   Tier 3+/security/policy settlement, workflow/branch-protection change, normal merge rejected,
+   or no unowned high-value batch remains.
+
+## Batch gate — exact commands
+
+Gate discovery (run at start of every batch and after any resume):
+```
+git status --short --branch
+python3 scripts/publisher_freshness_check.py
+python3 scripts/agent_bridge.py --json health || true
+python3 -m aragora.cli.main work robot --json
+python3 scripts/identify_lane_owner.py --pr <PR> --json   # skip owned lanes
+python3 -m aragora.cli.main review-queue merge-packet --pr <PR> --json
+python3 scripts/settle_one_pr.py --pr <PR> --json
+```
+
+Hard constraints (from `docs/AGENT_OPERATING_CONTRACT.md`):
+- Never admin-merge; never edit branch protection, workflows, labels, publisher/outbox,
+  launchd, or protected files (`CLAUDE.md`, `aragora/__init__.py`, `.env`, `scripts/nomic_loop.py`).
+- Tier 0 = 1 model signal; Tier 2 = 2 distinct-model signals + adversarial dogfood;
+  Tier 3 (semantic/security) = + human risk settlement → STOP.
+- Exact-head evidence expires on head drift. Re-review after any repair push.
+
+## Crash / compaction recovery
+
+If you wake with no memory of an in-flight run:
+1. Find the plan + `.log.md` under `docs/plans/`.
+2. Read the log's last entry → branch, head SHA, last gate result, open PR.
+3. Re-run gate discovery to confirm live state (the PR may have merged or drifted while you were gone).
+4. Resume at the first incomplete batch step. Do not re-do completed, logged work.
+
+## Notes
+- Reference implementation of the underlying gate mechanics: the proven no-admin
+  proof-first land loop, and `docs/prompts/MASTER_FANOUT_PROMPT.md` (idempotent Phase-0 discovery).
+- The generic upstream skill is installed at `~/.claude/skills/elves/` for its templates; this
+  aragora-native skill is the one to invoke for repo work because its gates are real, not placeholders.

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,44 @@
+# Third-Party Licenses
+
+Aragora is MIT-licensed (see `LICENSE`). Components or patterns derived from
+third-party projects are credited here.
+
+## elves (aigorahub/elves)
+
+- **Project:** https://github.com/aigorahub/elves
+- **License:** MIT
+- **Author:** John Ennis / aigorahub
+- **Used in:** `.agents/skills/elves-aragora/`
+
+The `elves-aragora` skill adapts the *scaffolding pattern* introduced by elves —
+the three-document structure (Plan / Survival Guide / Execution Log) and the
+crash/compaction-survival discipline for long unattended runs. No elves source
+code is vendored; the aragora skill reimplements the pattern and binds every
+validation gate to aragora's own governance (model-quorum evidence, decision
+receipts, draft-PR-only, the Operating Contract). The upstream elves skill and
+its templates are installed separately at `~/.claude/skills/elves/`.
+
+The upstream project is distributed under the MIT License. A copy of the MIT
+License text governing the adapted pattern is reproduced below for completeness.
+
+```
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```


### PR DESCRIPTION
Adds **`.agents/skills/elves-aragora/`** — a plan-driven overnight-execution Agent Skill (Codex per-repo path; Claude Code users copy to `~/.claude/skills/`) that binds every batch's validation gate to aragora's **real** governance instead of a generic test run:

- model-quorum evidence at exact head (`review-pr` claude + codex), repair-on-`changes_requested`
- decision-receipt / merge-packet / `settle_one` gating
- **draft-PR only, never admin-merge**
- **crash/compaction-resumable** via an on-disk execution log (Plan / Survival Guide / Execution Log)

### Why (not a duplicate loop)
aragora already has a *stronger* autonomy loop than the generic `elves` skill (merge-quorum, receipts, operating contract, worktree autopilot). This skill adds only the missing piece — a **resumable, plan-driven wrapper** so those gates run unattended and recover from interruption (this work itself was interrupted by a crash). It reuses the existing proof-first land loop rather than reimplementing autonomy.

### Provenance / license
Adapts the three-document scaffolding *pattern* from [`aigorahub/elves`](https://github.com/aigorahub/elves) (MIT). **No upstream code vendored.** `THIRD_PARTY_LICENSES.md` credits the upstream project + MIT text. Both projects MIT.

### Notes
- `.claude/` is gitignored in this repo, so the committed home is the Codex `.agents/skills/` path.
- Docs-only addition; no runtime/import surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)