### PR TITLE
fix(gauntlet): non-zero exit when no agents can be created

### DIFF
--- a/aragora/cli/gauntlet.py
+++ b/aragora/cli/gauntlet.py
@@ -171,7 +171,12 @@ def cmd_gauntlet(args: argparse.Namespace) -> None:
         print(f"  - The file exists: ls -la {input_path.parent}")
         print("\nUsage:")
         print("  aragora gauntlet path/to/spec.md --input-type spec")
-        return
+        # Fatal: cannot run the gauntlet without an input file. Exit non-zero
+        # so callers/CI gates (e.g. `aragora gauntlet ... && deploy`) can tell
+        # "gauntlet never ran" apart from "gauntlet passed". Code 1 is distinct
+        # from the verdict-based exits (rejected=1 is a *ran* outcome, but a
+        # fatal pre-run failure is unambiguously not a pass either way).
+        sys.exit(1)
 
     input_content = input_path.read_text()
 
@@ -333,7 +338,10 @@ def cmd_gauntlet(args: argparse.Namespace) -> None:
         print("  1. Set the required API key: export ANTHROPIC_API_KEY='your-key'")
         print("  2. Run 'aragora agents' to see available agents")
         print("  3. Run 'aragora doctor' to diagnose configuration issues")
-        return
+        # Fatal: the gauntlet cannot run at all without agents. Exit non-zero
+        # so callers/CI gates can distinguish "gauntlet never ran" from
+        # "gauntlet passed" (a bare return here yielded exit 0 — a false pass).
+        sys.exit(1)
 
     print(f"Agents: {', '.join(a.name for a in agents)}")
 

--- a/tests/cli/test_gauntlet.py
+++ b/tests/cli/test_gauntlet.py
@@ -336,7 +336,8 @@ class TestCmdGauntlet:
 
         with patch.dict("sys.modules", {"aragora.gauntlet": mock_gauntlet}):
             with patch.dict("sys.modules", {"aragora.agents.base": MagicMock()}):
-                cmd_gauntlet(args)
+                with pytest.raises(SystemExit):
+                    cmd_gauntlet(args)
 
         captured = capsys.readouterr()
         assert "Input file not found" in captured.out
@@ -355,10 +356,56 @@ class TestCmdGauntlet:
         with patch.dict("sys.modules", {"aragora.gauntlet": mock_gauntlet}):
             with patch.dict("sys.modules", {"aragora.agents.base": mock_agents}):
                 with patch("aragora.agents.spec.AgentSpec", mock_spec):
-                    cmd_gauntlet(gauntlet_args)
+                    with pytest.raises(SystemExit):
+                        cmd_gauntlet(gauntlet_args)
 
         captured = capsys.readouterr()
         assert "No agents could be created" in captured.out
+
+    def test_no_agents_created_exits_nonzero(self, gauntlet_args, capsys):
+        """No agents is a FATAL condition: must exit non-zero, not 0.
+
+        Regression guard: a bare ``return`` here yields exit code 0, making
+        "gauntlet never ran" indistinguishable from "gauntlet passed" in a
+        gating context like ``aragora gauntlet ... && deploy``.
+        """
+        mock_gauntlet = MagicMock()
+        mock_gauntlet.InputType = MagicMock()
+
+        mock_agents = MagicMock()
+        mock_agents.create_agent.side_effect = RuntimeError("No API key")
+
+        mock_spec = MagicMock()
+        mock_spec.coerce_list.return_value = [MockAgentSpec()]
+
+        with patch.dict("sys.modules", {"aragora.gauntlet": mock_gauntlet}):
+            with patch.dict("sys.modules", {"aragora.agents.base": mock_agents}):
+                with patch("aragora.agents.spec.AgentSpec", mock_spec):
+                    with pytest.raises(SystemExit) as exc_info:
+                        cmd_gauntlet(gauntlet_args)
+
+        assert exc_info.value.code != 0
+        captured = capsys.readouterr()
+        assert "No agents could be created" in captured.out
+
+    def test_input_file_not_found_exits_nonzero(self, capsys):
+        """Missing input file is FATAL: must exit non-zero, not 0."""
+        args = argparse.Namespace()
+        args.input = "/nonexistent/file.md"
+        args.input_type = "spec"
+        args.agents = "anthropic-api"
+
+        mock_gauntlet = MagicMock()
+        mock_gauntlet.InputType = MagicMock()
+
+        with patch.dict("sys.modules", {"aragora.gauntlet": mock_gauntlet}):
+            with patch.dict("sys.modules", {"aragora.agents.base": MagicMock()}):
+                with pytest.raises(SystemExit) as exc_info:
+                    cmd_gauntlet(args)
+
+        assert exc_info.value.code != 0
+        captured = capsys.readouterr()
+        assert "Input file not found" in captured.out
 
     def test_gauntlet_run_success(self, gauntlet_args, capsys):
         """Test successful gauntlet run."""

--- a/tests/test_cli_gauntlet.py
+++ b/tests/test_cli_gauntlet.py
@@ -175,7 +175,9 @@ class TestCmdGauntletInputHandling:
             agents="anthropic-api",
             profile="default",
         )
-        cmd_gauntlet(args)
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_gauntlet(args)
+        assert exc_info.value.code != 0
         captured = capsys.readouterr()
         assert "Error: Input file not found" in captured.out
 
@@ -187,7 +189,8 @@ class TestCmdGauntletInputHandling:
             agents="anthropic-api",
             profile="default",
         )
-        cmd_gauntlet(args)
+        with pytest.raises(SystemExit):
+            cmd_gauntlet(args)
         captured = capsys.readouterr()
         assert "Please check" in captured.out
         assert "file path is correct" in captured.out
@@ -213,7 +216,8 @@ class TestCmdGauntletInputHandling:
         )
 
         with patch("aragora.agents.base.create_agent", side_effect=Exception("No agent")):
-            cmd_gauntlet(args)
+            with pytest.raises(SystemExit):
+                cmd_gauntlet(args)
 
         captured = capsys.readouterr()
         assert "Input:" in captured.out
@@ -240,7 +244,8 @@ class TestCmdGauntletInputHandling:
         )
 
         with patch("aragora.agents.base.create_agent", side_effect=Exception("No agent")):
-            cmd_gauntlet(args)
+            with pytest.raises(SystemExit):
+                cmd_gauntlet(args)
 
         captured = capsys.readouterr()
         assert "Type: architecture" in captured.out
@@ -272,8 +277,10 @@ class TestCmdGauntletAgentCreation:
     def test_all_agents_fail_prints_detailed_error(self, mock_args, capsys):
         """All agents failing prints detailed error."""
         with patch("aragora.agents.base.create_agent", side_effect=Exception("API key missing")):
-            cmd_gauntlet(mock_args)
+            with pytest.raises(SystemExit) as exc_info:
+                cmd_gauntlet(mock_args)
 
+        assert exc_info.value.code != 0
         captured = capsys.readouterr()
         assert "Error: No agents could be created" in captured.out
         assert "Failed agents:" in captured.out
@@ -283,7 +290,8 @@ class TestCmdGauntletAgentCreation:
         """API agent failure shows environment variable hint."""
         mock_args.agents = "anthropic-api"
         with patch("aragora.agents.base.create_agent", side_effect=Exception("No key")):
-            cmd_gauntlet(mock_args)
+            with pytest.raises(SystemExit):
+                cmd_gauntlet(mock_args)
 
         captured = capsys.readouterr()
         assert "ANTHROPIC_API_KEY" in captured.out
@@ -292,7 +300,8 @@ class TestCmdGauntletAgentCreation:
         """OpenAI agent failure shows environment variable hint."""
         mock_args.agents = "openai-api"
         with patch("aragora.agents.base.create_agent", side_effect=Exception("No key")):
-            cmd_gauntlet(mock_args)
+            with pytest.raises(SystemExit):
+                cmd_gauntlet(mock_args)
 
         captured = capsys.readouterr()
         assert "OPENAI_API_KEY" in captured.out
@@ -301,16 +310,19 @@ class TestCmdGauntletAgentCreation:
         """Gemini agent failure shows environment variable hint."""
         mock_args.agents = "gemini"
         with patch("aragora.agents.base.create_agent", side_effect=Exception("No key")):
-            cmd_gauntlet(mock_args)
+            with pytest.raises(SystemExit):
+                cmd_gauntlet(mock_args)
 
         captured = capsys.readouterr()
         assert "GEMINI_API_KEY" in captured.out
 
-    def test_no_agents_returns_early(self, mock_args, capsys):
-        """Zero successful agents returns early."""
+    def test_no_agents_exits_nonzero_before_run(self, mock_args, capsys):
+        """Zero successful agents is fatal: exit non-zero before running."""
         with patch("aragora.agents.base.create_agent", side_effect=Exception("Failed")):
-            cmd_gauntlet(mock_args)
+            with pytest.raises(SystemExit) as exc_info:
+                cmd_gauntlet(mock_args)
 
+        assert exc_info.value.code != 0
         captured = capsys.readouterr()
         assert "No agents could be created" in captured.out
         # Should not see "Running stress-test"


### PR DESCRIPTION
## Problem

`aragora gauntlet` printed `Error: No agents could be created.` — a **fatal** condition (the gauntlet cannot run at all) — but then exited with **code 0**. This makes "gauntlet never ran" indistinguishable from "gauntlet passed" in any gating context such as:

```bash
aragora gauntlet spec.md --input-type spec && deploy   # deploys even though the gauntlet never ran
```

This branch fires for **any** agent-creation failure, not just missing API keys.

## Root cause

In `cmd_gauntlet` (`aragora/cli/gauntlet.py`), the no-agents branch printed the error + remediation hints then did a bare `return`, yielding exit 0. The normal outcomes already map verdicts to exit codes (`rejected`->1, `needs_review`->2) via direct `sys.exit()` calls. The fatal pre-run paths did not mirror that, so a fatal failure looked like success.

## Fix

Two fatal-but-exit-0 paths now `sys.exit(1)`, consistent with the file's existing exit-code convention:

1. **No agents could be created** (any agent-creation failure).
2. **Input file not found** (cannot run the gauntlet on a nonexistent file) — same bare-`return` bug found while scanning the command.

`sys.exit(1)` is the file's convention for non-zero termination and unambiguously signals "not a pass" to scripts/CI gates. The helpful error messages + remediation hints are preserved.

## Before / after

**Before** (no API keys set):
```
Error: No agents could be created.
...
exit=0
```

**After**:
```
Error: No agents could be created.
...
exit=1
```

Input-file-not-found path likewise went `exit=0` -> `exit=1`.

## Tests

- Added regression tests asserting **non-zero** exit for both fatal paths (`tests/cli/test_gauntlet.py`).
- Updated pre-existing tests in `tests/test_cli_gauntlet.py` and `tests/cli/test_gauntlet.py` that asserted only the error *message* (and implicitly the buggy exit-0) to expect `SystemExit`.
- `tests/cli/test_gauntlet.py` + `tests/test_cli_gauntlet.py`: **53 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)