### PR TITLE
fix(cli): catch SSRFBlockedError in `aragora status` health probe

### DIFF
--- a/aragora/cli/commands/status.py
+++ b/aragora/cli/commands/status.py
@@ -157,15 +157,28 @@ def cmd_status(args: argparse.Namespace) -> None:
     print("\n\U0001f310 Server Status:")
     server_url = args.server if hasattr(args, "server") else DEFAULT_API_URL
     try:
-        from aragora.security.safe_http import safe_get
-
-        resp = safe_get(f"{server_url}/api/health", timeout=2)
-        if resp.status_code == 200:
-            print(f"  \u2713 Server running at {server_url}")
-        else:
-            print(f"  \u26a0 Server returned status {resp.status_code}")
-    except (ImportError, OSError, TimeoutError, ConnectionError, RuntimeError):
+        from aragora.security.safe_http import SSRFValidationError, safe_get
+    except ImportError:
         print(f"  \u2717 Server not reachable at {server_url}")
+    else:
+        try:
+            resp = safe_get(f"{server_url}/api/health", timeout=2)
+            if resp.status_code == 200:
+                print(f"  \u2713 Server running at {server_url}")
+            else:
+                print(f"  \u26a0 Server returned status {resp.status_code}")
+        except (
+            OSError,
+            TimeoutError,
+            ConnectionError,
+            RuntimeError,
+            SSRFValidationError,
+        ):
+            # SSRFValidationError (incl. SSRFBlockedError) fires on the default
+            # localhost URL, which safe_get rejects as an SSRF target. Treat it
+            # the same as any other unreachable-server failure rather than
+            # crashing with an uncaught traceback.
+            print(f"  \u2717 Server not reachable at {server_url}")
 
     # Check database
     print("\n\U0001f4be Databases:")

--- a/tests/cli/test_status_validate_env.py
+++ b/tests/cli/test_status_validate_env.py
@@ -46,6 +46,32 @@ def _validate_args(**overrides: Any) -> argparse.Namespace:
     return argparse.Namespace(**values)
 
 
+def test_status_handles_ssrf_blocked_localhost(monkeypatch, capsys) -> None:
+    """`aragora status` must not crash when the health probe raises SSRFBlockedError.
+
+    The default server URL is http://localhost:8080, and safe_get() rejects
+    localhost with SSRFBlockedError (a subclass of SSRFValidationError -> Exception,
+    NOT of OSError/ConnectionError/RuntimeError). The command should render a
+    friendly 'not reachable' line and still print the remaining sections.
+    """
+    from aragora.security.safe_http import SSRFBlockedError
+
+    def fake_safe_get(*_args: Any, **_kwargs: Any) -> Any:
+        raise SSRFBlockedError("Localhost hostname detected", url="http://localhost:8080")
+
+    monkeypatch.setattr("aragora.security.safe_http.safe_get", fake_safe_get)
+
+    args = argparse.Namespace(server="http://localhost:8080")
+
+    # Must not raise (previously aborted with an uncaught traceback).
+    status_mod.cmd_status(args)
+
+    out = capsys.readouterr().out
+    assert "Server not reachable at http://localhost:8080" in out
+    # Sections after the server health probe must still render.
+    assert "Databases:" in out
+
+
 def test_validate_env_parser_accepts_smoke_agents() -> None:
     parser = cli_parser.build_parser()
 


### PR DESCRIPTION
Closes the `status` lane defect: `aragora status` crashes with an uncaught `SSRFBlockedError` traceback on the default (localhost) server URL.

## Root cause

`aragora/cli/commands/status.py` probes server health via `safe_get(f"{server_url}/api/health")`. With the default `ARAGORA_API_URL=http://localhost:8080`, `safe_get` rejects localhost as an SSRF target and raises `SSRFBlockedError`.

Its MRO is `SSRFBlockedError -> SSRFValidationError -> Exception` — it is **not** a subclass of any type in the existing `except (ImportError, OSError, TimeoutError, ConnectionError, RuntimeError)` tuple. So the exception escaped uncaught.

## Before

```
$ python3 -m aragora.cli.main status
...
🌐 Server Status:
Traceback (most recent call last):
  ...
aragora.security.safe_http.SSRFBlockedError: Localhost hostname detected
```
Output aborted right after the `Server Status:` header (Databases / Nomic Loop sections never rendered), process exited **1**. This is the bare default invocation hit by every local-dev user.

## After

```
🌐 Server Status:
  ✗ Server not reachable at http://localhost:8080

💾 Databases:
  ✗ Memory store: not found
  ...
```
All sections render, process exits **0**.

## Fix

Catch `SSRFValidationError` (parent of `SSRFBlockedError`) alongside the existing transport errors and render the same friendly "Server not reachable" line. The `safe_http` import is hoisted into its own `try/except ImportError` so the `except` tuple never references an unbound name when the import itself fails.

## Test

Added `test_status_handles_ssrf_blocked_localhost` in `tests/cli/test_status_validate_env.py`: patches `safe_get` to raise `SSRFBlockedError`, asserts `cmd_status` does not raise, prints the friendly line, and still renders the Databases section. Verified failing before the fix, green after. Full module: 7 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)