### PR TITLE
[DIC-14] Add epistemic-check CLI verb for claim verification runner

### DIFF
--- a/aragora/cli/commands/epistemic_check.py
+++ b/aragora/cli/commands/epistemic_check.py
@@ -1,0 +1,100 @@
+"""CLI command: ``aragora epistemic-check``.
+
+Loads claim manifests from ``docs/status/claims/`` (or a path you supply)
+and runs the DIC-14 ClaimVerifier against them, emitting a JSON or
+human-readable status report.  No network, no queue mutation, no issue
+creation.
+
+Flag-gated: set ``ARAGORA_EPISTEMIC_CLAIMS_ENABLED=1`` to enable command
+execution.  When the flag is not set the command exits 0 and prints a
+brief reminder — so CI jobs and operator scripts can call it unconditionally
+without breaking.
+
+Advances: issue #6024 (DIC-14 — claim verification runner CLI surface).
+Live queue effect: none.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+_FLAG = "ARAGORA_EPISTEMIC_CLAIMS_ENABLED"
+_DEFAULT_CLAIMS_DIR = Path("docs/status/claims")
+
+
+def _enabled() -> bool:
+    return str(os.environ.get(_FLAG) or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _render_text(results: list) -> str:
+    """Return a compact human-readable status table."""
+    from aragora.epistemic.claim_verifier import ClaimStatus
+
+    if not results:
+        return "No claims found."
+
+    width_id = max(len(r.claim_id) for r in results)
+    lines: list[str] = [f"{'CLAIM_ID':<{width_id}}  STATUS       SEVERITY"]
+    lines.append("-" * (width_id + 28))
+    for r in results:
+        lines.append(f"{r.claim_id:<{width_id}}  {r.status.value:<12} {r.severity}")
+
+    counts = {s.value: sum(1 for r in results if r.status == s) for s in ClaimStatus}
+    lines.append("")
+    parts = [f"{v} {k}" for k, v in counts.items() if v]
+    lines.append("Summary: " + ", ".join(parts))
+    return "\n".join(lines)
+
+
+def cmd_epistemic_check(args: argparse.Namespace) -> int:
+    """Entry point for ``aragora epistemic-check``."""
+    if not _enabled():
+        print(
+            f"epistemic-check: skipped (set {_FLAG}=1 to enable)",
+            file=sys.stderr,
+        )
+        return 0
+
+    from aragora.epistemic.claim_verifier import ClaimStatus, ClaimVerifier
+
+    target = Path(args.path).expanduser() if args.path else _DEFAULT_CLAIMS_DIR
+    repo_root = Path(args.repo_root).expanduser() if args.repo_root else Path.cwd()
+
+    verifier = ClaimVerifier(repo_root=repo_root, dry_run=args.dry_run)
+
+    if target.is_file():
+        manifest_files = [target]
+    elif target.is_dir():
+        manifest_files = sorted(target.glob("*.yaml"))
+    else:
+        print(f"error: path does not exist: {target}", file=sys.stderr)
+        return 1
+
+    if not manifest_files:
+        print(f"No *.yaml manifests found under {target}", file=sys.stderr)
+        return 0
+
+    all_results = []
+    for mf in manifest_files:
+        try:
+            all_results.extend(verifier.verify_manifest(mf))
+        except Exception as exc:  # noqa: BLE001
+            print(f"error loading {mf}: {exc}", file=sys.stderr)
+            return 1
+
+    if args.json:
+        # Call on the instance so tests can inject a replacement class.
+        print(verifier.report_json(all_results))
+    else:
+        print(_render_text(all_results))
+
+    # Exit 1 only if a *blocking* claim failed or errored.
+    blocking_failures = [
+        r for r in all_results
+        if r.status in (ClaimStatus.FAIL, ClaimStatus.ERROR)
+        and r.severity == "blocking"
+    ]
+    return 1 if blocking_failures else 0

--- a/aragora/cli/commands/epistemic_check.py
+++ b/aragora/cli/commands/epistemic_check.py
@@ -93,8 +93,8 @@ def cmd_epistemic_check(args: argparse.Namespace) -> int:
 
     # Exit 1 only if a *blocking* claim failed or errored.
     blocking_failures = [
-        r for r in all_results
-        if r.status in (ClaimStatus.FAIL, ClaimStatus.ERROR)
-        and r.severity == "blocking"
+        r
+        for r in all_results
+        if r.status in (ClaimStatus.FAIL, ClaimStatus.ERROR) and r.severity == "blocking"
     ]
     return 1 if blocking_failures else 0

--- a/aragora/cli/commands/epistemic_check.py
+++ b/aragora/cli/commands/epistemic_check.py
@@ -2,8 +2,14 @@
 
 Loads claim manifests from ``docs/status/claims/`` (or a path you supply)
 and runs the DIC-14 ClaimVerifier against them, emitting a JSON or
-human-readable status report.  No network, no queue mutation, no issue
-creation.
+human-readable status report.  No queue mutation, no issue creation.
+
+Read-only by default: manifest-provided ``command``-kind verifications are
+**not** executed unless the operator opts in with ``--execute``.  Without
+``--execute`` the verifier runs in dry-run mode and reports command-kind
+claims as UNSUPPORTED, so pointing the CLI at an untrusted manifest cannot
+run arbitrary subprocesses.  ``--execute`` runs those commands with the
+caller's shell privileges and should only be used for trusted manifests.
 
 Flag-gated: set ``ARAGORA_EPISTEMIC_CLAIMS_ENABLED=1`` to enable command
 execution.  When the flag is not set the command exits 0 and prints a
@@ -63,7 +69,14 @@ def cmd_epistemic_check(args: argparse.Namespace) -> int:
     target = Path(args.path).expanduser() if args.path else _DEFAULT_CLAIMS_DIR
     repo_root = Path(args.repo_root).expanduser() if args.repo_root else Path.cwd()
 
-    verifier = ClaimVerifier(repo_root=repo_root, dry_run=args.dry_run)
+    # Read-only by default: only run manifest-provided commands when the
+    # operator explicitly opts in with --execute. --dry-run is accepted for
+    # explicitness/back-compat but is already the default. This keeps the
+    # documented "read-only" invariant true even for untrusted manifests.
+    execute = bool(getattr(args, "execute", False))
+    dry_run = True if not execute else bool(getattr(args, "dry_run", False))
+
+    verifier = ClaimVerifier(repo_root=repo_root, dry_run=dry_run)
 
     if target.is_file():
         manifest_files = [target]

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -221,6 +221,7 @@ Examples:
     _add_coherence_scan_parser(subparsers)  # DIC-26 / #6220
     _add_truth_map_parser(subparsers)  # DIC-18 / #6028
     _add_decay_monitor_parser(subparsers)  # DIC-20 / #6031
+    _add_epistemic_check_parser(subparsers)  # DIC-14 / #6024
 
     # DIC-27: operator crux arbitration surface
     _add_crux_arbitrate_parser(subparsers)
@@ -875,6 +876,51 @@ def _add_crux_garden_parser(subparsers) -> None:
     )
     p.add_argument("--json", action="store_true", help="Emit report as JSON.")
     p.set_defaults(func=_lazy("aragora.cli.commands.dic28_crux_garden", "cmd_crux_garden"))
+
+
+def _add_epistemic_check_parser(subparsers) -> None:
+    """Add the 'epistemic-check' subcommand for DIC-14 claim verification."""
+    p = subparsers.add_parser(
+        "epistemic-check",
+        help="DIC-14: verify executable claim manifests and emit a status report",
+        description=(
+            "Load *.yaml claim manifests from docs/status/claims/ (or a path you\n"
+            "supply) and verify each claim via the DIC-14 ClaimVerifier.  Outputs\n"
+            "a human-readable table or JSON.  No queue mutation, no issue creation.\n\n"
+            "Requires ARAGORA_EPISTEMIC_CLAIMS_ENABLED=1 to execute; otherwise exits\n"
+            "0 with an informational message."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "path",
+        nargs="?",
+        default=None,
+        metavar="PATH",
+        help=(
+            "YAML manifest file or directory of manifests. "
+            "Defaults to docs/status/claims/"
+        ),
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        default=False,
+        help="Emit machine-readable JSON (schema_version, results, summary)",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="Skip command execution; return UNSUPPORTED for command-kind claims",
+    )
+    p.add_argument(
+        "--repo-root",
+        default=None,
+        metavar="DIR",
+        help="Repository root for resolving relative evidence paths (defaults to cwd)",
+    )
+    p.set_defaults(func=_lazy("aragora.cli.commands.epistemic_check", "cmd_epistemic_check"))
 
 
 def _add_ask_parser(subparsers) -> None:

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -897,10 +897,7 @@ def _add_epistemic_check_parser(subparsers) -> None:
         nargs="?",
         default=None,
         metavar="PATH",
-        help=(
-            "YAML manifest file or directory of manifests. "
-            "Defaults to docs/status/claims/"
-        ),
+        help=("YAML manifest file or directory of manifests. Defaults to docs/status/claims/"),
     )
     p.add_argument(
         "--json",

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -887,6 +887,9 @@ def _add_epistemic_check_parser(subparsers) -> None:
             "Load *.yaml claim manifests from docs/status/claims/ (or a path you\n"
             "supply) and verify each claim via the DIC-14 ClaimVerifier.  Outputs\n"
             "a human-readable table or JSON.  No queue mutation, no issue creation.\n\n"
+            "Read-only by default: manifest-provided verification commands are NOT\n"
+            "executed unless you pass --execute (command-kind claims are reported\n"
+            "UNSUPPORTED). Only pass --execute for manifests you trust.\n\n"
             "Requires ARAGORA_EPISTEMIC_CLAIMS_ENABLED=1 to execute; otherwise exits\n"
             "0 with an informational message."
         ),
@@ -909,7 +912,22 @@ def _add_epistemic_check_parser(subparsers) -> None:
         "--dry-run",
         action="store_true",
         default=False,
-        help="Skip command execution; return UNSUPPORTED for command-kind claims",
+        help=(
+            "Skip command execution; return UNSUPPORTED for command-kind claims. "
+            "This is already the DEFAULT behavior — the flag is accepted for "
+            "explicitness and backward compatibility."
+        ),
+    )
+    p.add_argument(
+        "--execute",
+        action="store_true",
+        default=False,
+        help=(
+            "Opt in to running manifest-provided verification commands as "
+            "subprocesses. Off by default: command-kind claims are skipped "
+            "(reported UNSUPPORTED) unless this flag is set. Only pass --execute "
+            "for manifests you trust, since commands run with your shell privileges."
+        ),
     )
     p.add_argument(
         "--repo-root",

--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -11,8 +11,8 @@ description: Generated Aragora CLI command catalog from live parser
 
 This reference documents the command surface as implemented in code. It includes all top-level commands and known aliases.
 
-- Canonical top-level commands: **106**
-- Total top-level invocations (including aliases): **107**
+- Canonical top-level commands: **108**
+- Total top-level invocations (including aliases): **109**
 
 ## Installation
 
@@ -73,6 +73,7 @@ For full runtime configuration, see [ENVIRONMENT](../getting-started/environment
 | `crux-followup` | - | Generate DIC-17 follow-up proposals from a CruxSet (flag-gated filing) | - |
 | `crux-garden` | - | DIC-28: proactive re-examination of cruxes for staleness and contradictions | - |
 | `cruxset` | - | AGT-01: inspect CruxSet payloads emitted by the debate path | `show` |
+| `decay-monitor` | - | DIC-20: report epistemic decay for proof-carrying code units | - |
 | `decide` | - | Run full decision pipeline: debate → plan → execute | - |
 | `demo` | - | Run a self-contained adversarial debate demo (no API keys needed) | - |
 | `deploy` | - | Deployment validation and configuration | `secrets`, `start`, `status`, `stop`, `validate` |
@@ -80,6 +81,7 @@ For full runtime configuration, see [ENVIRONMENT](../getting-started/environment
 | `document-audit` | - | Audit documents using multi-agent analysis | `report`, `scan`, `status`, `upload` |
 | `documents` | - | Document management (upload, list, show) | `list`, `show`, `upload` |
 | `elo` | - | View ELO ratings, leaderboards, and match history | - |
+| `epistemic-check` | - | DIC-14: verify executable claim manifests and emit a status report | - |
 | `essay` | - | Refine raw ideas into a polished essay or score an existing draft | `refine`, `score` |
 | `explain` | - | Explain a debate decision (evidence chains, vote pivots, counterfactuals) | - |
 | `export` | - | Export debate artifacts | - |

--- a/docs-site/docs/contributing/capability-matrix.md
+++ b/docs-site/docs/contributing/capability-matrix.md
@@ -8,7 +8,7 @@
 | Surface | Inventory | Capability Coverage |
 |---------|-----------|---------------------|
 | **HTTP API** | 1772 paths / 2100 operations | 81.1% |
-| **CLI** | 107 commands | 43.2% |
+| **CLI** | 109 commands | 43.2% |
 | **SDK (Python)** | 191 namespaces | 70.3% |
 | **SDK (TypeScript)** | 190 namespaces | 70.3% |
 | **UI** | tracked in capability surfaces | 86.5% |

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -8,7 +8,7 @@
 | Surface | Inventory | Capability Coverage |
 |---------|-----------|---------------------|
 | **HTTP API** | 1772 paths / 2100 operations | 81.1% |
-| **CLI** | 107 commands | 43.2% |
+| **CLI** | 109 commands | 43.2% |
 | **SDK (Python)** | 191 namespaces | 70.3% |
 | **SDK (TypeScript)** | 190 namespaces | 70.3% |
 | **UI** | tracked in capability surfaces | 86.5% |

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -12,13 +12,13 @@
 
 | Metric | Value | Source | Command |
 |---|---|---|---|
-| Python files under aragora/ | `4155` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1949692` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python files under aragora/ | `4157` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
+| Python lines of code under aragora/ | `1950127` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `141` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5253` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `219564` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
-| @pytest.mark.parametrize decorators | `715` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
-| CLI top-level command modules | `75` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
+| Test files (test_*.py under tests/) | `5259` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `219622` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| @pytest.mark.parametrize decorators | `717` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
+| CLI top-level command modules | `77` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2870` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
 | OpenAPI operations (HTTP verbs) | `3297` | `docs/api/openapi.json` | `python -c "import json; spec=json.load(open('docs/api/openapi.json')); print(sum(1 for p in spec['paths'].values() for m in p if m.lower() in {'get','post','put','delete','patch','head','options'}))"` |
 | @require_permission decorator calls | `1365` | `aragora/` | `git grep -E '@require_permission\(' -- aragora \| wc -l` |
@@ -28,8 +28,8 @@
 | Allowlisted agent types | `35` | `aragora/config/settings.py` | `grep -A 50 'ALLOWED_AGENT_TYPES' aragora/config/settings.py \| grep -oE "'[a-z-]+'" \| sort -u \| wc -l` |
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `46` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |
-| Markdown files under docs/ | `969` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
-| GitHub Actions workflows | `86` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
+| Markdown files under docs/ | `970` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
+| GitHub Actions workflows | `87` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
 | Mypy baseline errors (grandfathered) | `3115` | `.mypy-baseline` | `wc -l .mypy-baseline` |
 
 ## Notes on counting methodology

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -6,8 +6,8 @@
 
 This reference documents the command surface as implemented in code. It includes all top-level commands and known aliases.
 
-- Canonical top-level commands: **106**
-- Total top-level invocations (including aliases): **107**
+- Canonical top-level commands: **108**
+- Total top-level invocations (including aliases): **109**
 
 ## Installation
 
@@ -68,6 +68,7 @@ For full runtime configuration, see [ENVIRONMENT](ENVIRONMENT.md).
 | `crux-followup` | - | Generate DIC-17 follow-up proposals from a CruxSet (flag-gated filing) | - |
 | `crux-garden` | - | DIC-28: proactive re-examination of cruxes for staleness and contradictions | - |
 | `cruxset` | - | AGT-01: inspect CruxSet payloads emitted by the debate path | `show` |
+| `decay-monitor` | - | DIC-20: report epistemic decay for proof-carrying code units | - |
 | `decide` | - | Run full decision pipeline: debate → plan → execute | - |
 | `demo` | - | Run a self-contained adversarial debate demo (no API keys needed) | - |
 | `deploy` | - | Deployment validation and configuration | `secrets`, `start`, `status`, `stop`, `validate` |
@@ -75,6 +76,7 @@ For full runtime configuration, see [ENVIRONMENT](ENVIRONMENT.md).
 | `document-audit` | - | Audit documents using multi-agent analysis | `report`, `scan`, `status`, `upload` |
 | `documents` | - | Document management (upload, list, show) | `list`, `show`, `upload` |
 | `elo` | - | View ELO ratings, leaderboards, and match history | - |
+| `epistemic-check` | - | DIC-14: verify executable claim manifests and emit a status report | - |
 | `essay` | - | Refine raw ideas into a polished essay or score an existing draft | `refine`, `score` |
 | `explain` | - | Explain a debate decision (evidence chains, vote pivots, counterfactuals) | - |
 | `export` | - | Export debate artifacts | - |

--- a/tests/cli/test_epistemic_check.py
+++ b/tests/cli/test_epistemic_check.py
@@ -36,8 +36,14 @@ def _ns(path=None, *, json_output=False, dry_run=False, repo_root=None):
 
 
 def _result(claim_id="c", status=ClaimStatus.PASS, severity="info"):
-    return ClaimResult(claim_id=claim_id, status=status, message="ok",
-                       severity=severity, allowed_action="report_only", elapsed_ms=1.0)
+    return ClaimResult(
+        claim_id=claim_id,
+        status=status,
+        message="ok",
+        severity=severity,
+        allowed_action="report_only",
+        elapsed_ms=1.0,
+    )
 
 
 def _mock(results):
@@ -100,8 +106,13 @@ def test_json_result_status_and_id(tmp_path, capsys):
     _run(tmp_path, [_result("my.claim", ClaimStatus.STALE)])
     payload = json.loads(capsys.readouterr().out)
     assert payload["results"][0] == {
-        "claim_id": "my.claim", "status": "stale", "message": "ok",
-        "severity": "info", "allowed_action": "report_only", "elapsed_ms": 1.0, "detail": {},
+        "claim_id": "my.claim",
+        "status": "stale",
+        "message": "ok",
+        "severity": "info",
+        "allowed_action": "report_only",
+        "elapsed_ms": 1.0,
+        "detail": {},
     }
 
 

--- a/tests/cli/test_epistemic_check.py
+++ b/tests/cli/test_epistemic_check.py
@@ -1,0 +1,156 @@
+"""Tests for the ``aragora epistemic-check`` CLI command (DIC-14 / #6024).
+
+Runs without network access, subprocess calls, pydantic, or real YAML
+parsing.  ClaimVerifier is injected as a mock — YAML parsing is covered by
+``tests/epistemic/test_claim_verifier.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+for _stub in ["yaml", "pydantic", "pydantic.fields", "pydantic_settings", "pydantic_settings.main"]:
+    if _stub not in sys.modules:
+        sys.modules[_stub] = MagicMock()
+
+from aragora.cli.commands.epistemic_check import _enabled, cmd_epistemic_check  # noqa: E402
+from aragora.epistemic.claim_verifier import ClaimResult, ClaimStatus, ClaimVerifier  # noqa: E402
+
+_PATCH = "aragora.epistemic.claim_verifier.ClaimVerifier"
+_real_report_json = ClaimVerifier.report_json  # captured before any patching
+
+
+def _ns(path=None, *, json_output=False, dry_run=False, repo_root=None):
+    ns = argparse.Namespace()
+    ns.path = path
+    ns.json = json_output
+    ns.dry_run = dry_run
+    ns.repo_root = repo_root
+    return ns
+
+
+def _result(claim_id="c", status=ClaimStatus.PASS, severity="info"):
+    return ClaimResult(claim_id=claim_id, status=status, message="ok",
+                       severity=severity, allowed_action="report_only", elapsed_ms=1.0)
+
+
+def _mock(results):
+    v = MagicMock()
+    v.verify_manifest.return_value = results
+    v.report_json = _real_report_json
+    return v
+
+
+def _run(tmp_path, results, *, json_output=True):
+    p = tmp_path / "m.yaml"
+    p.write_text("placeholder")
+    with (
+        patch.dict("os.environ", {"ARAGORA_EPISTEMIC_CLAIMS_ENABLED": "1"}),
+        patch(_PATCH, return_value=_mock(results)),
+    ):
+        return cmd_epistemic_check(_ns(str(p), json_output=json_output))
+
+
+# ---------------------------------------------------------------------------
+# Flag-gating
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_exits_zero_with_stderr(tmp_path, capsys):
+    with patch.dict("os.environ", {}, clear=True):
+        rc = cmd_epistemic_check(_ns(str(tmp_path)))
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "ARAGORA_EPISTEMIC_CLAIMS_ENABLED" in captured.err
+
+
+def test_enabled_values():
+    for v in ("1", "true", "yes", "on", "TRUE"):
+        with patch.dict("os.environ", {"ARAGORA_EPISTEMIC_CLAIMS_ENABLED": v}):
+            assert _enabled() is True
+
+
+def test_disabled_values():
+    for v in ("0", "false", "no", "off", ""):
+        with patch.dict("os.environ", {"ARAGORA_EPISTEMIC_CLAIMS_ENABLED": v}):
+            assert _enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# JSON output shape
+# ---------------------------------------------------------------------------
+
+
+def test_json_schema_keys(tmp_path, capsys):
+    rc = _run(tmp_path, [_result()])
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["schema_version"] == 1
+    assert "results" in payload and "summary" in payload
+    assert rc == 0
+
+
+def test_json_result_status_and_id(tmp_path, capsys):
+    _run(tmp_path, [_result("my.claim", ClaimStatus.STALE)])
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["results"][0] == {
+        "claim_id": "my.claim", "status": "stale", "message": "ok",
+        "severity": "info", "allowed_action": "report_only", "elapsed_ms": 1.0, "detail": {},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Exit codes
+# ---------------------------------------------------------------------------
+
+
+def test_blocking_fail_exits_one(tmp_path):
+    assert _run(tmp_path, [_result("x", ClaimStatus.FAIL, "blocking")]) == 1
+
+
+def test_blocking_error_exits_one(tmp_path):
+    assert _run(tmp_path, [_result("x", ClaimStatus.ERROR, "blocking")]) == 1
+
+
+def test_non_blocking_fail_exits_zero(tmp_path):
+    assert _run(tmp_path, [_result("x", ClaimStatus.FAIL, "warning")]) == 0
+
+
+def test_missing_path_exits_one(tmp_path, capsys):
+    with patch.dict("os.environ", {"ARAGORA_EPISTEMIC_CLAIMS_ENABLED": "1"}):
+        rc = cmd_epistemic_check(_ns(str(tmp_path / "absent.yaml")))
+    assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# Directory scanning and dry_run forwarding
+# ---------------------------------------------------------------------------
+
+
+def test_empty_dir_exits_zero(tmp_path):
+    with patch.dict("os.environ", {"ARAGORA_EPISTEMIC_CLAIMS_ENABLED": "1"}):
+        assert cmd_epistemic_check(_ns(str(tmp_path))) == 0
+
+
+def test_dry_run_forwarded(tmp_path):
+    p = tmp_path / "m.yaml"
+    p.write_text("placeholder")
+    captured_kwargs: dict = {}
+
+    def _ctor(**kw):
+        captured_kwargs.update(kw)
+        return _mock([_result()])
+
+    with (
+        patch.dict("os.environ", {"ARAGORA_EPISTEMIC_CLAIMS_ENABLED": "1"}),
+        patch(_PATCH, _ctor),
+    ):
+        cmd_epistemic_check(_ns(str(p), dry_run=True, json_output=True))
+
+    assert captured_kwargs.get("dry_run") is True

--- a/tests/cli/test_epistemic_check.py
+++ b/tests/cli/test_epistemic_check.py
@@ -26,11 +26,12 @@ _PATCH = "aragora.epistemic.claim_verifier.ClaimVerifier"
 _real_report_json = ClaimVerifier.report_json  # captured before any patching
 
 
-def _ns(path=None, *, json_output=False, dry_run=False, repo_root=None):
+def _ns(path=None, *, json_output=False, dry_run=False, execute=False, repo_root=None):
     ns = argparse.Namespace()
     ns.path = path
     ns.json = json_output
     ns.dry_run = dry_run
+    ns.execute = execute
     ns.repo_root = repo_root
     return ns
 
@@ -149,9 +150,11 @@ def test_empty_dir_exits_zero(tmp_path):
         assert cmd_epistemic_check(_ns(str(tmp_path))) == 0
 
 
-def test_dry_run_forwarded(tmp_path):
+def _capture_verifier_kwargs(tmp_path, ns):
+    """Run the command with ClaimVerifier mocked and return its ctor kwargs."""
     p = tmp_path / "m.yaml"
     p.write_text("placeholder")
+    ns.path = str(p)
     captured_kwargs: dict = {}
 
     def _ctor(**kw):
@@ -162,6 +165,78 @@ def test_dry_run_forwarded(tmp_path):
         patch.dict("os.environ", {"ARAGORA_EPISTEMIC_CLAIMS_ENABLED": "1"}),
         patch(_PATCH, _ctor),
     ):
-        cmd_epistemic_check(_ns(str(p), dry_run=True, json_output=True))
+        cmd_epistemic_check(ns)
+    return captured_kwargs
 
-    assert captured_kwargs.get("dry_run") is True
+
+def test_dry_run_forwarded(tmp_path):
+    kwargs = _capture_verifier_kwargs(tmp_path, _ns(dry_run=True, json_output=True))
+    assert kwargs.get("dry_run") is True
+
+
+def test_default_invocation_is_read_only(tmp_path):
+    """Read-only by default: without --execute the verifier runs dry-run, so
+    manifest-provided commands are never executed even for untrusted paths."""
+    kwargs = _capture_verifier_kwargs(tmp_path, _ns(json_output=True))
+    assert kwargs.get("dry_run") is True
+
+
+def test_execute_flag_enables_command_execution(tmp_path):
+    """--execute opts in to running commands (dry_run forwarded as False)."""
+    kwargs = _capture_verifier_kwargs(tmp_path, _ns(execute=True, json_output=True))
+    assert kwargs.get("dry_run") is False
+
+
+def test_dry_run_overrides_execute(tmp_path):
+    """If both flags are passed, --dry-run wins (fail safe, no execution)."""
+    kwargs = _capture_verifier_kwargs(tmp_path, _ns(execute=True, dry_run=True, json_output=True))
+    assert kwargs.get("dry_run") is True
+
+
+def test_default_does_not_run_command_kind_claims(tmp_path):
+    """End-to-end: a manifest whose command would mutate state is NOT run by
+    default. We use a real ClaimVerifier with an injected command runner and
+    confirm the runner is never invoked unless --execute is set."""
+    import yaml as _yaml
+
+    if isinstance(_yaml, MagicMock) or isinstance(getattr(_yaml, "safe_load", None), MagicMock):
+        pytest.skip("real PyYAML required to parse the manifest in this end-to-end test")
+
+    from aragora.epistemic.claim_verifier import ClaimVerifier
+
+    manifest = tmp_path / "danger.yaml"
+    manifest.write_text(
+        "claims:\n"
+        "  - claim_id: danger.command\n"
+        "    verification:\n"
+        "      kind: command\n"
+        "      command: echo pwned\n"
+    )
+
+    runner_calls: list = []
+
+    def _spy_runner(args):
+        runner_calls.append(args)
+        return 0, "", ""
+
+    real_ctor = ClaimVerifier
+
+    def _ctor(**kw):
+        kw.pop("command_runner", None)
+        return real_ctor(command_runner=_spy_runner, **kw)
+
+    # Default (no --execute): runner must never be called.
+    with (
+        patch.dict("os.environ", {"ARAGORA_EPISTEMIC_CLAIMS_ENABLED": "1"}),
+        patch(_PATCH, _ctor),
+    ):
+        cmd_epistemic_check(_ns(str(manifest), json_output=True))
+    assert runner_calls == []
+
+    # With --execute: the command runs.
+    with (
+        patch.dict("os.environ", {"ARAGORA_EPISTEMIC_CLAIMS_ENABLED": "1"}),
+        patch(_PATCH, _ctor),
+    ):
+        cmd_epistemic_check(_ns(str(manifest), execute=True, json_output=True))
+    assert runner_calls == [["echo", "pwned"]]


### PR DESCRIPTION
## Slice
Adds `aragora epistemic-check` — a new subcommand that loads `*.yaml` claim manifests from `docs/status/claims/` (or a path you supply), runs the DIC-14 `ClaimVerifier` against each claim, and emits a human-readable status table or a machine-readable JSON report. No queue mutation, no network calls, no issue creation.

The `ClaimVerifier` Python module (DIC-14) already existed on `main`. This slice surfaces it as a usable CLI verb so operators can actually run it.

## Gating
- Default: **OFF** (flag: `ARAGORA_EPISTEMIC_CLAIMS_ENABLED=1` required)
- Live queue effect: **none** — read-only; no `boss-ready` labels; no queue writes
- Advances issue: #6024 (DIC-14 — claim verification runner)

## Tests
- `test_disabled_exits_zero_with_stderr` — flag off → exit 0, message to stderr
- `test_enabled_values` / `test_disabled_values` — all truthy/falsy flag spellings
- `test_json_schema_keys` — output has `schema_version`, `results`, `summary`
- `test_json_result_status_and_id` — result fields serialise correctly
- `test_blocking_fail_exits_one` / `test_blocking_error_exits_one` — blocking severity → exit 1
- `test_non_blocking_fail_exits_zero` — warning severity fail → exit 0
- `test_missing_path_exits_one` — absent path → exit 1, error to stderr
- `test_empty_dir_exits_zero` — no manifests → exit 0 with message
- `test_dry_run_forwarded` — `--dry-run` flag forwarded to `ClaimVerifier(dry_run=True)`

## Validation
- `pytest tests/cli/test_epistemic_check.py --noconftest` — **11 passed**
- `ruff check aragora/cli/commands/epistemic_check.py tests/cli/test_epistemic_check.py aragora/cli/parser.py` — **clean**
- Net diff: **302 lines** across 3 files (2 new, 1 modified)

## Out of scope
- Wiring `epistemic-check` into CI or making it a recurring job (DIC-14 runner integration — deferred)
- Receipt/KM persistence of check results (DIC-16)
- Creating follow-up issues from failed claims (DIC-17)
- Full YAML parsing tests — those live in `tests/epistemic/test_claim_verifier.py`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hov19zVjT2aUSyuy2vjrQA)_