### PR TITLE
fix(cli): keep `aragora spec --format json` stdout pipeable

### DIFF
--- a/aragora/cli/commands/spec.py
+++ b/aragora/cli/commands/spec.py
@@ -380,20 +380,28 @@ def cmd_spec(args: argparse.Namespace) -> None:
     use_orchestrator = getattr(args, "orchestrator", False)
     to_mission = getattr(args, "to_mission", None)
 
-    print("\n" + "=" * 60)
-    print("  ARAGORA SPEC")
-    print("  Prompt-to-specification pipeline")
-    print("=" * 60)
-    print(f"\n  Prompt:  {prompt}")
-    print(f"  Depth:   {depth}")
-    print(f"  Profile: {profile}")
+    # When emitting machine-readable JSON, keep stdout reserved for the JSON
+    # document alone so it stays pipeable (e.g. `aragora spec ... --format json | jq`).
+    # All human-facing banner / progress / footer text is routed to stderr.
+    human_stream = sys.stderr if output_format == "json" else sys.stdout
+
+    def _echo(message: str = "") -> None:
+        print(message, file=human_stream)
+
+    _echo("\n" + "=" * 60)
+    _echo("  ARAGORA SPEC")
+    _echo("  Prompt-to-specification pipeline")
+    _echo("=" * 60)
+    _echo(f"\n  Prompt:  {prompt}")
+    _echo(f"  Depth:   {depth}")
+    _echo(f"  Profile: {profile}")
 
     if dry_run:
-        print("\n  [dry-run] Would run: decompose -> interrogate -> research -> specify")
-        print("  Use without --dry-run to execute.")
+        _echo("\n  [dry-run] Would run: decompose -> interrogate -> research -> specify")
+        _echo("  Use without --dry-run to execute.")
         return
 
-    print("\n[*] Running prompt-to-spec pipeline...\n")
+    _echo("\n[*] Running prompt-to-spec pipeline...\n")
 
     start_time = time.monotonic()
     try:
@@ -414,19 +422,20 @@ def cmd_spec(args: argparse.Namespace) -> None:
         logger.warning("spec_command_circuit_open", extra={"agent_name": agent_name})
         result = _build_spec_fallback(prompt, reason=reason)
     except (RuntimeError, ValueError, TypeError, ImportError) as e:
-        print(f"\n[!] Spec pipeline failed: {e}")
+        print(f"\n[!] Spec pipeline failed: {e}", file=sys.stderr)
         sys.exit(1)
 
     elapsed = time.monotonic() - start_time
-    print(f"  Elapsed: {elapsed:.1f}s")
+    _echo(f"  Elapsed: {elapsed:.1f}s")
 
+    # The rendered spec body always goes to stdout so JSON output stays pipeable.
     _print_spec_result(result, output_format)
 
     # Save spec artifact
     output_path = getattr(args, "output", None)
     if output_path:
         path = _save_spec_result(result, output_path, output_format)
-        print(f"\nSpec saved to: {path}")
+        _echo(f"\nSpec saved to: {path}")
 
     if to_mission:
         mission_path = _write_mission_from_spec_result(
@@ -434,9 +443,9 @@ def cmd_spec(args: argparse.Namespace) -> None:
             result=result,
             output_path=to_mission,
         )
-        print(f"\nConductor mission saved to: {mission_path}")
-        print(f"Run: python3 scripts/goal_conductor.py run-once --mission {mission_path} --json")
+        _echo(f"\nConductor mission saved to: {mission_path}")
+        _echo(f"Run: python3 scripts/goal_conductor.py run-once --mission {mission_path} --json")
 
-    print("\nNext steps:")
-    print("  aragora decide 'task' --spec <file>  # Execute from spec")
-    print("  aragora ask 'task'                    # Debate the approach")
+    _echo("\nNext steps:")
+    _echo("  aragora decide 'task' --spec <file>  # Execute from spec")
+    _echo("  aragora ask 'task'                    # Debate the approach")

--- a/tests/cli/test_spec_command.py
+++ b/tests/cli/test_spec_command.py
@@ -267,12 +267,17 @@ class TestCmdSpec:
         ) as run_spec:
             cmd_spec(args)
 
-        out = capsys.readouterr().out
-        assert "ARAGORA SPEC" in out
-        assert "Elapsed:" in out
-        assert '"total_duration_ms": 84.0' in out
-        assert '"stage": "specify"' in out
-        assert "Spec saved to:" in out
+        captured = capsys.readouterr()
+        out = captured.out
+        err = captured.err
+        # With --format json, stdout must be a single valid JSON document so it
+        # stays pipeable; all human banner/progress/footer text goes to stderr.
+        assert json.loads(out) == result
+        assert "ARAGORA SPEC" not in out
+        assert "Elapsed:" not in out
+        assert "ARAGORA SPEC" in err
+        assert "Elapsed:" in err
+        assert "Spec saved to:" in err
         run_spec.assert_awaited_once_with(
             "Make onboarding better",
             depth="quick",
@@ -283,6 +288,52 @@ class TestCmdSpec:
             use_orchestrator=False,
         )
         assert json.loads(output_path.read_text()) == result
+
+    def test_cmd_spec_json_format_emits_pure_json_on_stdout(self, capsys):
+        """Regression: `--format json` stdout must be a single parseable JSON
+        document (pipeable to jq); banner/progress/footer go to stderr."""
+        result = {
+            "intent": {"intent_type": "feature", "scope_estimate": "medium"},
+            "specification": {
+                "problem_statement": "Need a rate limiter.",
+                "proposed_solution": "Token bucket per client.",
+                "success_criteria": [{"description": "Caps request rate."}],
+                "confidence": 0.7,
+            },
+            "research": None,
+            "timing": {},
+        }
+        args = argparse.Namespace(
+            prompt="Design a rate limiter",
+            depth="quick",
+            profile="founder",
+            skip_research=False,
+            skip_interrogation=False,
+            format="json",
+            dry_run=False,
+            output=None,
+            orchestrator=False,
+            to_mission=None,
+        )
+
+        with patch(
+            "aragora.cli.commands.spec._run_spec_pipeline",
+            new_callable=AsyncMock,
+            return_value=result,
+        ):
+            cmd_spec(args)
+
+        captured = capsys.readouterr()
+        # The whole of stdout must parse as JSON and equal the result body.
+        assert json.loads(captured.out) == result
+        # No human banner/progress/footer leaks onto stdout.
+        assert "ARAGORA SPEC" not in captured.out
+        assert "[*] Running" not in captured.out
+        assert "Elapsed:" not in captured.out
+        assert "Next steps:" not in captured.out
+        # Human text is preserved on stderr.
+        assert "ARAGORA SPEC" in captured.err
+        assert "Next steps:" in captured.err
 
     def test_cmd_spec_writes_conductor_mission_without_dispatch(self, tmp_path, capsys):
         mission_path = tmp_path / "mission.yaml"


### PR DESCRIPTION
## Defect (high severity, spec-json lane)

`aragora spec 'Design a rate limiter' --format json | jq .` fails with
`Expecting value: line 2 column 1 (char 1)`. With `--format json`, stdout is
never a valid JSON document.

## Root cause

`cmd_spec()` in `aragora/cli/commands/spec.py` (lines ~383-443) printed the
`ARAGORA SPEC` banner, prompt/depth/profile header, `[*] Running...` progress,
`Elapsed:` timing, `Spec saved to:`/mission lines, and the `Next steps:` footer
to **stdout unconditionally**, regardless of `output_format`. The JSON body
(from `_print_spec_result`) was wrapped in that human text, so `json.loads(stdout)`
always failed.

## Fix

When `output_format == "json"`, route all human banner/progress/footer text to
**stderr** via an `_echo` helper, leaving stdout reserved for the single JSON
document. Text mode is unchanged (everything stays on stdout). The pipeline-failure
message also moves to stderr to match the non-zero-exit convention.

### Before / After (`--format json` stdout)
- **before:** `banner + Elapsed + {JSON body} + Next steps` → not parseable
- **after:** `{JSON body}` only → `| jq` works; banner/footer go to stderr

## Tests

- Added `test_cmd_spec_json_format_emits_pure_json_on_stdout`: asserts the whole of
  stdout parses as one JSON document equal to the result, and that
  banner/`[*] Running`/`Elapsed:`/`Next steps:` appear only on stderr.
- Updated the existing json-format test (which previously asserted the buggy
  on-stdout behavior) to the same contract.

Both fail on the pre-fix impl with the exact reported `JSONDecodeError` and pass
with the fix. Full module: `9 passed`.

Reproduced offline by stubbing `_run_spec_pipeline` with the in-code fallback
spec — no live LLM / API key required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)