### PR TITLE
fix(cli): repair `aragora knowledge query` crash on every invocation

### DIFF
--- a/aragora/cli/knowledge.py
+++ b/aragora/cli/knowledge.py
@@ -191,7 +191,7 @@ def cmd_query(args: Namespace) -> int:
         options = QueryOptions(
             use_agents=args.debate,
             use_debate=args.debate,
-            max_facts=args.limit,
+            max_chunks=args.limit,
         )
 
         result = await engine.query(
@@ -204,12 +204,15 @@ def cmd_query(args: Namespace) -> int:
 
     result = asyncio.run(run_query())
 
+    facts = result.facts
+    chunks_searched = result.metadata.get("chunks_searched", 0)
+
     if args.json:
         output = {
             "answer": result.answer,
             "confidence": result.confidence,
-            "facts_used": len(result.facts_used),
-            "chunks_used": len(result.chunks_used),
+            "facts_used": len(facts),
+            "chunks_used": chunks_searched,
         }
         print(json.dumps(output, indent=2))
     else:
@@ -218,14 +221,14 @@ def cmd_query(args: Namespace) -> int:
         print("=" * 60)
         print(result.answer)
         print(f"\nConfidence: {result.confidence:.1%}")
-        print(f"Facts used: {len(result.facts_used)}")
-        print(f"Chunks used: {len(result.chunks_used)}")
+        print(f"Facts used: {len(facts)}")
+        print(f"Chunks used: {chunks_searched}")
 
-        if result.facts_used:
+        if facts:
             print("\n" + "-" * 60)
             print("SUPPORTING FACTS")
             print("-" * 60)
-            for fact in result.facts_used[:5]:
+            for fact in facts[:5]:
                 print(f"  - {fact.statement}")
 
     return 0

--- a/tests/cli/test_knowledge.py
+++ b/tests/cli/test_knowledge.py
@@ -38,12 +38,18 @@ if TYPE_CHECKING:
 
 @dataclass
 class MockQueryResult:
-    """Mock query result."""
+    """Mock query result.
+
+    Mirrors the real ``aragora.knowledge.types.QueryResult`` contract:
+    supporting facts live on ``facts`` (not ``facts_used``) and chunk counts
+    are reported via ``metadata["chunks_searched"]`` (there is no
+    ``chunks_used`` attribute).
+    """
 
     answer: str = "Test answer"
     confidence: float = 0.85
-    facts_used: list = field(default_factory=list)
-    chunks_used: list = field(default_factory=list)
+    facts: list = field(default_factory=list)
+    metadata: dict = field(default_factory=lambda: {"chunks_searched": 0})
 
 
 @dataclass
@@ -311,7 +317,7 @@ class TestCmdQuery:
     def test_query_with_facts(self, mock_run, query_args, capsys):
         """Test query that returns supporting facts."""
         mock_result = MockQueryResult(
-            facts_used=[MockFact(), MockFact(id="fact-2", statement="Second fact")]
+            facts=[MockFact(), MockFact(id="fact-2", statement="Second fact")]
         )
         mock_run.return_value = mock_result
 
@@ -346,6 +352,83 @@ class TestCmdQuery:
         assert result == 1
         captured = capsys.readouterr()
         assert "Error: Knowledge module not available" in captured.out
+
+    # -- Regression tests for the QueryOptions/QueryResult contract --------
+    #
+    # The tests above replace QueryOptions/QueryResult with MagicMock, which
+    # silently accepts any kwarg/attribute and therefore masked two real
+    # crashes in cmd_query:
+    #   1. QueryOptions(max_facts=...) -> TypeError (no such field)
+    #   2. result.facts_used / result.chunks_used -> AttributeError
+    # These tests exercise cmd_query against the REAL in-memory engine
+    # (offline, no API key) so the actual dataclass contracts are checked.
+
+    def test_query_options_has_no_max_facts_field(self):
+        """The real QueryOptions must not accept a max_facts kwarg.
+
+        cmd_query passes --limit through to QueryOptions; the only chunk/fact
+        sizing field on the dataclass is max_chunks. Constructing with
+        max_facts is the original defect and must remain a TypeError so we
+        never regress to it.
+        """
+        import dataclasses
+
+        from aragora.knowledge import QueryOptions
+
+        field_names = {f.name for f in dataclasses.fields(QueryOptions)}
+        assert "max_facts" not in field_names
+        assert "max_chunks" in field_names
+
+        # max_chunks is the correct mapping for --limit and must be accepted.
+        opts = QueryOptions(max_chunks=7)
+        assert opts.max_chunks == 7
+
+        with pytest.raises(TypeError):
+            QueryOptions(max_facts=7)  # type: ignore[call-arg]
+
+    def test_query_result_uses_facts_not_facts_used(self):
+        """QueryResult exposes `facts` and metadata, not facts_used/chunks_used."""
+        import dataclasses
+
+        from aragora.knowledge.types import QueryResult
+
+        field_names = {f.name for f in dataclasses.fields(QueryResult)}
+        assert "facts" in field_names
+        assert "facts_used" not in field_names
+        assert "chunks_used" not in field_names
+
+    def test_query_real_engine_text_output(self, query_args, capsys):
+        """cmd_query runs end-to-end on the real in-memory engine (text)."""
+        result = cmd_query(query_args)
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "ANSWER" in captured.out
+        assert "Facts used:" in captured.out
+        assert "Chunks used:" in captured.out
+
+    def test_query_real_engine_json_output(self, query_args, capsys):
+        """cmd_query runs end-to-end on the real in-memory engine (JSON)."""
+        query_args.json = True
+
+        result = cmd_query(query_args)
+
+        assert result == 0
+        captured = capsys.readouterr()
+        output = json.loads(captured.out)
+        assert set(output) == {"answer", "confidence", "facts_used", "chunks_used"}
+        assert isinstance(output["facts_used"], int)
+        assert isinstance(output["chunks_used"], int)
+
+    def test_query_real_engine_debate_flag(self, query_args, capsys):
+        """cmd_query with --debate does not crash during options construction."""
+        query_args.debate = True
+
+        result = cmd_query(query_args)
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "ANSWER" in captured.out
 
 
 # ===========================================================================


### PR DESCRIPTION
## Defect

`aragora knowledge query "<question>"` — the documented first `knowledge` subcommand — crashed with an **uncaught Python traceback and exit 1 on every invocation** (plain, `--json`, and `--debate` forms identically). The crash is independent of provider API keys: it happens during options construction / result consumption, before any LLM call, so it fired even against the offline in-memory engine.

## Root cause

`cmd_query` in `aragora/cli/knowledge.py` used two names that do not exist on the real contracts:

1. **`QueryOptions(max_facts=args.limit)`** → `TypeError: QueryOptions.__init__() got an unexpected keyword argument 'max_facts'`. `QueryOptions` (`aragora/knowledge/query_engine.py`) has no `max_facts` field; the field that sizes chunk/fact retrieval is `max_chunks`.
2. **`result.facts_used` / `result.chunks_used`** → `AttributeError`. `QueryResult` (`aragora/knowledge/types.py`) exposes `facts` and reports chunk counts via `metadata["chunks_searched"]`; there is no `facts_used`/`chunks_used` attribute.

(The second bug was masked behind the first until the `max_facts` crash was fixed.)

## Fix

- Map `--limit` ("Max facts to include") to `QueryOptions(max_chunks=args.limit)`.
- Read supporting facts from `result.facts` and chunk count from `result.metadata.get("chunks_searched", 0)` for both the text and `--json` output paths.

### Before
```
$ aragora knowledge query "What are the payment terms?"
...
TypeError: QueryOptions.__init__() got an unexpected keyword argument 'max_facts'
(exit 1)
```

### After
```
$ aragora knowledge query "What are the payment terms?"
============================================================
ANSWER
============================================================
No relevant content found
Confidence: 0.0%
Facts used: 0
Chunks used: 0
(exit 0)
```

## Tests

The existing `cmd_query` tests replaced `QueryOptions`/`QueryResult` with `MagicMock`, which accepts any kwarg/attribute and therefore **masked** both crashes. Added:

- End-to-end regression tests that run `cmd_query` against the **real in-memory engine** (offline, no API key) for text, `--json`, and `--debate` forms — these fail on the buggy code (`TypeError`) and pass on the fix.
- Dataclass-contract guards asserting `QueryOptions` has `max_chunks` (and rejects `max_facts`) and that `QueryResult` exposes `facts` (not `facts_used`/`chunks_used`).
- Corrected `MockQueryResult` to mirror the real `QueryResult` contract.

`tests/cli/test_knowledge.py`: 49 passed. `tests/test_cli_knowledge.py`: 6 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
