### PR TITLE
fix(cli): make `costs report` and `costs agents` call CostTracker correctly

### DIFF
--- a/aragora/cli/commands/billing_ops.py
+++ b/aragora/cli/commands/billing_ops.py
@@ -14,6 +14,7 @@ import argparse
 import asyncio
 import json
 import logging
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import httpx
@@ -254,62 +255,94 @@ def _cmd_dashboard(args: argparse.Namespace) -> None:
         print(f"  Monthly proj:   ${monthly:.2f}")
 
 
+def _period_bounds(days: int) -> tuple[datetime, datetime]:
+    """Translate a ``--days`` window into (period_start, period_end)."""
+    period_end = datetime.now(timezone.utc)
+    period_start = period_end - timedelta(days=max(1, days))
+    return period_start, period_end
+
+
 def _cmd_report(args: argparse.Namespace) -> None:
     """Generate a cost report (local, no server required)."""
     as_json = getattr(args, "json", False)
     days = getattr(args, "days", 30)
+    workspace_id = getattr(args, "workspace", None)
     tracker = _get_cost_tracker()
     if tracker is None:
         print("\nError: CostTracker not available. Install billing dependencies.")
         return
 
+    period_start, period_end = _period_bounds(days)
     try:
-        report = tracker.generate_report(days=days)
-    except (AttributeError, TypeError):
+        report_obj = asyncio.run(
+            tracker.generate_report(
+                workspace_id=workspace_id,
+                period_start=period_start,
+                period_end=period_end,
+            )
+        )
+    except AttributeError:
         print("\nError: CostTracker.generate_report() not available.")
         return
+
+    # CostReport is a dataclass; normalize to a plain dict for display/JSON.
+    report = report_obj.to_dict() if hasattr(report_obj, "to_dict") else dict(report_obj)
 
     if as_json:
         print(json.dumps(report, indent=2, default=str))
         return
 
+    total_cost = float(report.get("total_cost_usd", 0) or 0)
+    total_tokens = int(report.get("total_tokens_in", 0) or 0) + int(
+        report.get("total_tokens_out", 0) or 0
+    )
+    total_calls = int(report.get("total_api_calls", 0) or 0)
+
     print("\n" + "=" * 60)
     print(f"COST REPORT (Last {days} days)")
     print("=" * 60 + "\n")
 
-    print(f"  Period:         {report.get('period', f'{days} days')}")
-    print(f"  Total cost:     ${report.get('total_cost', 0):.4f}")
-    print(f"  Total tokens:   {report.get('total_tokens', 0):,}")
-    print(f"  Total debates:  {report.get('total_debates', 0)}")
+    print(f"  Period:         {report.get('period_start', '')} -> {report.get('period_end', '')}")
+    print(f"  Total cost:     ${total_cost:.4f}")
+    print(f"  Total tokens:   {total_tokens:,}")
+    print(f"  Total API calls:{total_calls:>8,}")
 
-    by_provider = report.get("by_provider", {})
+    by_provider = report.get("cost_by_provider", {})
     if by_provider:
         print("\n  By provider:")
         for provider, data in sorted(by_provider.items()):
-            cost = data.get("cost", 0) if isinstance(data, dict) else data
-            print(f"    {provider:20} ${cost:.4f}")
+            cost = data.get("cost", 0) if isinstance(data, dict) else float(data or 0)
+            print(f"    {provider:20} ${float(cost):.4f}")
 
-    by_day = report.get("by_day", [])
-    if by_day:
-        print("\n  Daily breakdown:")
-        for entry in by_day[-7:]:
-            day = entry.get("date", "")
-            cost = entry.get("cost", 0)
-            print(f"    {day:12} ${cost:.4f}")
+    top_agents = report.get("top_agents_by_cost", [])
+    if top_agents:
+        print("\n  Top agents by cost:")
+        for entry in top_agents[:7]:
+            name = entry.get("agent", "unknown")
+            cost = float(entry.get("cost_usd", 0) or 0)
+            print(f"    {name:25} ${cost:.4f}")
 
 
 def _cmd_agents(args: argparse.Namespace) -> None:
     """Show per-agent cost breakdown (local, no server required)."""
     as_json = getattr(args, "json", False)
     days = getattr(args, "days", 30)
+    workspace_id = getattr(args, "workspace", None) or "default"
     tracker = _get_cost_tracker()
     if tracker is None:
         print("\nError: CostTracker not available. Install billing dependencies.")
         return
 
+    period_start, period_end = _period_bounds(days)
     try:
-        agent_costs = tracker.get_agent_costs(days=days)
-    except (AttributeError, TypeError):
+        agent_costs = asyncio.run(
+            tracker.get_agent_costs(
+                workspace_id,
+                period_start=period_start,
+                period_end=period_end,
+            )
+        )
+    except AttributeError:
         print("\nError: CostTracker.get_agent_costs() not available.")
         return
 
@@ -325,14 +358,16 @@ def _cmd_agents(args: argparse.Namespace) -> None:
         print("  No agent cost data available.")
         return
 
-    print(f"  {'Agent':<25} {'Cost':>10} {'Tokens':>12} {'Debates':>8}")
-    print(f"  {'-' * 25} {'-' * 10} {'-' * 12} {'-' * 8}")
-    for entry in agent_costs:
-        name = entry.get("agent", "unknown")
-        cost = entry.get("cost", 0)
-        tokens = entry.get("tokens", 0)
-        debates = entry.get("debates", 0)
-        print(f"  {name:<25} ${cost:>9.4f} {tokens:>12,} {debates:>8}")
+    print(f"  {'Agent':<25} {'Cost':>12} {'Share':>8}")
+    print(f"  {'-' * 25} {'-' * 12} {'-' * 8}")
+    for name, data in sorted(
+        agent_costs.items(),
+        key=lambda kv: float(kv[1].get("cost_usd", 0) or 0),
+        reverse=True,
+    ):
+        cost = float(data.get("cost_usd", 0) or 0)
+        pct = float(data.get("percentage", 0) or 0)
+        print(f"  {name:<25} ${cost:>11.4f} {pct:>6.1f}%")
 
 
 def _print_api_error(e: httpx.HTTPStatusError) -> None:
@@ -382,11 +417,17 @@ def add_billing_ops_parser(subparsers: Any) -> None:
     report_p.add_argument(
         "--days", "-d", type=int, default=30, help="Report period in days (default: 30)"
     )
+    report_p.add_argument(
+        "--workspace", "-w", default=None, help="Filter by workspace ID (optional)"
+    )
     report_p.add_argument("--json", action="store_true", help="Output as JSON")
 
     # agents (local)
     agents_p = bp_sub.add_parser("agents", help="Per-agent cost breakdown (local)")
     agents_p.add_argument("--days", "-d", type=int, default=30, help="Period in days (default: 30)")
+    agents_p.add_argument(
+        "--workspace", "-w", default=None, help="Workspace ID to break down (default: 'default')"
+    )
     agents_p.add_argument("--json", action="store_true", help="Output as JSON")
 
 

--- a/tests/cli/test_cli_commands.py
+++ b/tests/cli/test_cli_commands.py
@@ -10,7 +10,7 @@ Covers argument parsing and command dispatch for:
 
 import argparse
 import json
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import httpx
 import pytest
@@ -48,6 +48,8 @@ from aragora.cli.commands.billing_ops import (
     _cmd_usage,
     _cmd_budget,
     _cmd_forecast,
+    _cmd_report,
+    _cmd_agents,
     add_billing_ops_parser,
     cmd_billing_ops,
 )
@@ -494,3 +496,122 @@ class TestBillingCommands:
         ):
             await _cmd_usage(args)
         assert "Could not connect" in capsys.readouterr().out
+
+
+class TestBillingLocalCostCommands:
+    """Regression tests for `costs report` / `costs agents`.
+
+    Both commands previously always printed a misleading
+    'CostTracker.<method>() not available.' error because they called the
+    async CostTracker methods with an unsupported ``days=`` kwarg and never
+    awaited the returned coroutine. These tests pin the corrected behavior:
+    the real (async) tracker methods are invoked with period bounds and the
+    results are rendered.
+    """
+
+    def _report_parser(self):
+        return _build_parser(add_billing_ops_parser, "costs")
+
+    def test_report_workspace_flag_parses(self):
+        args = self._report_parser().parse_args(
+            ["costs", "report", "--days", "7", "--workspace", "ws1"]
+        )
+        assert args.days == 7
+        assert args.workspace == "ws1"
+
+    def test_agents_workspace_flag_parses(self):
+        args = self._report_parser().parse_args(["costs", "agents", "--workspace", "ws2"])
+        assert args.workspace == "ws2"
+
+    def test_report_renders_async_costreport(self, capsys):
+        """generate_report is async + returns a CostReport; it must be awaited
+        and normalized via .to_dict(), not reported as 'not available'."""
+        report_obj = Mock()
+        report_obj.to_dict.return_value = {
+            "period_start": "2026-05-01",
+            "period_end": "2026-05-31",
+            "total_cost_usd": "1.2345",
+            "total_tokens_in": 1000,
+            "total_tokens_out": 500,
+            "total_api_calls": 3,
+            "cost_by_provider": {"anthropic": "1.2345"},
+            "top_agents_by_cost": [{"agent": "claude", "cost_usd": "1.2345"}],
+        }
+        tracker = Mock()
+        tracker.generate_report = AsyncMock(return_value=report_obj)
+
+        args = argparse.Namespace(json=False, days=30, workspace=None)
+        with patch("aragora.cli.commands.billing_ops._get_cost_tracker", return_value=tracker):
+            _cmd_report(args)
+
+        out = capsys.readouterr().out
+        assert "not available" not in out
+        assert "COST REPORT" in out
+        assert "1.2345" in out
+        assert "claude" in out
+        # The async method must actually have been called (and awaited).
+        tracker.generate_report.assert_awaited_once()
+        _, kwargs = tracker.generate_report.call_args
+        assert "days" not in kwargs  # the buggy kwarg must be gone
+        assert kwargs["period_start"] is not None
+        assert kwargs["period_end"] is not None
+
+    def test_agents_renders_async_agent_costs(self, capsys):
+        """get_agent_costs is async, requires a workspace_id, and returns a
+        mapping of agent -> {cost_usd, percentage}."""
+        tracker = Mock()
+        tracker.get_agent_costs = AsyncMock(
+            return_value={
+                "claude": {"cost_usd": "0.9000", "percentage": 75.0},
+                "gpt": {"cost_usd": "0.3000", "percentage": 25.0},
+            }
+        )
+
+        args = argparse.Namespace(json=False, days=30, workspace="ws1")
+        with patch("aragora.cli.commands.billing_ops._get_cost_tracker", return_value=tracker):
+            _cmd_agents(args)
+
+        out = capsys.readouterr().out
+        assert "not available" not in out
+        assert "AGENT COSTS" in out
+        assert "claude" in out
+        assert "0.9000" in out
+        tracker.get_agent_costs.assert_awaited_once()
+        # workspace_id passed positionally; days kwarg must be gone
+        call = tracker.get_agent_costs.call_args
+        assert call.args[0] == "ws1"
+        assert "days" not in call.kwargs
+
+    def test_agents_json_output(self, capsys):
+        tracker = Mock()
+        tracker.get_agent_costs = AsyncMock(
+            return_value={"claude": {"cost_usd": "0.9", "percentage": 100.0}}
+        )
+        args = argparse.Namespace(json=True, days=30, workspace=None)
+        with patch("aragora.cli.commands.billing_ops._get_cost_tracker", return_value=tracker):
+            _cmd_agents(args)
+        parsed = json.loads(capsys.readouterr().out)
+        assert parsed["claude"]["cost_usd"] == "0.9"
+        # default workspace used when none supplied
+        assert tracker.get_agent_costs.call_args.args[0] == "default"
+
+    def test_report_empty_tracker_still_succeeds(self, capsys):
+        """Empty data must render a real (zero) report, never the misleading
+        'not available' error."""
+        report_obj = Mock()
+        report_obj.to_dict.return_value = {
+            "period_start": "2026-05-01",
+            "period_end": "2026-05-31",
+            "total_cost_usd": "0",
+            "total_tokens_in": 0,
+            "total_tokens_out": 0,
+            "total_api_calls": 0,
+        }
+        tracker = Mock()
+        tracker.generate_report = AsyncMock(return_value=report_obj)
+        args = argparse.Namespace(json=False, days=30, workspace=None)
+        with patch("aragora.cli.commands.billing_ops._get_cost_tracker", return_value=tracker):
+            _cmd_report(args)
+        out = capsys.readouterr().out
+        assert "not available" not in out
+        assert "COST REPORT" in out


### PR DESCRIPTION
## Summary

`aragora costs report` and `aragora costs agents` always failed with a misleading
`Error: CostTracker.<method>() not available.` (exit 0), even though `aragora costs dashboard`
works against the **same** `CostTracker`. This fixes both commands at the root cause.

Lane: **costs** (high severity).

## Root cause

`aragora/cli/commands/billing_ops.py` had two layered bugs in `_cmd_report` and `_cmd_agents`:

1. **Wrong signature.** The code called `tracker.generate_report(days=days)` and
   `tracker.get_agent_costs(days=days)`, but the real methods are:
   - `generate_report(workspace_id, org_id, period_start, period_end, granularity)`
   - `get_agent_costs(workspace_id, period_start, period_end)`

   Neither accepts a `days` kwarg, so each raised `TypeError`.

2. **Missing async handling.** Both methods are `async def` but were called synchronously
   (no `await` / `asyncio.run`), so even with correct args they'd return an un-awaited coroutine.

The `TypeError` was swallowed by `except (AttributeError, TypeError)` and re-reported as the
false "not available" message.

## Fix

- Translate `--days` into `period_start`/`period_end` via a small `_period_bounds` helper.
- Await the async methods through `asyncio.run` (matching the existing `cmd_billing_ops` dispatch style).
- Normalize the returned `CostReport` dataclass via `.to_dict()` and render the real
  per-provider / top-agent breakdown; render the `agent -> {cost_usd, percentage}` mapping
  returned by `get_agent_costs`.
- Add `--workspace/-w` to both subcommands (`get_agent_costs` requires a `workspace_id`;
  defaults to `"default"`).
- Narrow the residual guard to `AttributeError` only, so genuine call errors are no longer
  masked as "not available".

## Before / after

```
# before
$ aragora costs report   -> "Error: CostTracker.generate_report() not available."  (exit 0)
$ aragora costs agents    -> "Error: CostTracker.get_agent_costs() not available."  (exit 0)

# after
$ aragora costs report
============================================================
COST REPORT (Last 30 days)
============================================================
  Period:         2026-05-01... -> 2026-05-31...
  Total cost:     $0.0000
  ...
$ aragora costs agents
============================================================
AGENT COSTS (Last 30 days)
============================================================
  No agent cost data available.
```

(Empty figures reflect an empty local tracker — the same data source `costs dashboard` uses.)

## Tests

Added `TestBillingLocalCostCommands` (6 tests) in `tests/cli/test_cli_commands.py`:
- async invocation is actually awaited (`assert_awaited_once`)
- the buggy `days=` kwarg is gone
- `CostReport.to_dict()` rendering, agent-cost mapping rendering, JSON output
- workspace flag parsing + `"default"` fallback

All 6 fail against the original impl and pass after the fix. Full `tests/cli/test_cli_commands.py`
module: 54 passed. `ruff check` clean.

Closes the `costs` lane defect (`billing_ops.py:267,311`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
