### PR TITLE
fix(compliance): reject unknown framework IDs instead of false COMPLIANT

### DIFF
--- a/aragora/cli/commands/compliance.py
+++ b/aragora/cli/commands/compliance.py
@@ -407,7 +407,11 @@ def _cmd_report(args: argparse.Namespace) -> None:
     framework_ids = [f.strip() for f in frameworks_str.split(",")] if frameworks_str else None
 
     manager = ComplianceFrameworkManager()
-    result = manager.check(content, frameworks=framework_ids)
+    try:
+        result = manager.check(content, frameworks=framework_ids)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
 
     output_format = getattr(args, "output_format", "text")
 
@@ -469,7 +473,11 @@ def _cmd_check(args: argparse.Namespace) -> None:
     min_severity = severity_map.get(min_severity_str, ComplianceSeverity.LOW)
 
     manager = ComplianceFrameworkManager()
-    result = manager.check(content, frameworks=framework_ids, min_severity=min_severity)
+    try:
+        result = manager.check(content, frameworks=framework_ids, min_severity=min_severity)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
 
     if as_json:
         print(json.dumps(result.to_dict(), indent=2, default=str))

--- a/aragora/compliance/framework.py
+++ b/aragora/compliance/framework.py
@@ -938,7 +938,19 @@ class ComplianceFrameworkManager:
         if frameworks is None:
             frameworks_to_check = list(self._frameworks.values())
         else:
-            frameworks_to_check = [self._frameworks[f] for f in frameworks if f in self._frameworks]
+            # Fail loud on unknown/typo'd framework IDs rather than silently
+            # dropping them. Silently ignoring unknown IDs can yield a false
+            # "COMPLIANT / 100%" result for content that was never actually
+            # evaluated against any framework (e.g. a typo like "gdrp" for
+            # "gdpr"), which is a dangerous false negative for a compliance tool.
+            unknown = [f for f in frameworks if f not in self._frameworks]
+            if unknown:
+                available = ", ".join(sorted(self._frameworks))
+                raise ValueError(
+                    "Unknown compliance framework(s): "
+                    f"{', '.join(unknown)}. Available frameworks: {available}"
+                )
+            frameworks_to_check = [self._frameworks[f] for f in frameworks]
 
         if not frameworks_to_check:
             return ComplianceCheckResult(

--- a/tests/cli/test_compliance_framework.py
+++ b/tests/cli/test_compliance_framework.py
@@ -286,6 +286,46 @@ class TestComplianceCheck:
             with pytest.raises(SystemExit):
                 _cmd_check(args)
 
+    def test_check_unknown_framework_exits_with_error(self, capsys):
+        """Typo'd framework IDs must exit non-zero, not report a false COMPLIANT.
+
+        Regression: 'gdrp,hippa' (typos for 'gdpr,hipaa') previously reported
+        Status COMPLIANT / Score 100% / no frameworks checked / exit 0, hiding a
+        critical SSN/PHI exposure behind a green all-clear.
+        """
+        args = argparse.Namespace(
+            compliance_command="check",
+            content=["store ssn 123-45-6789 unencrypted password=secret"],
+            content_file=None,
+            frameworks="gdrp,hippa",
+            min_severity="low",
+            json=False,
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            _cmd_check(args)
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "Unknown compliance framework" in captured.err
+        assert "gdrp" in captured.err
+        # Must NOT have printed a passing result
+        assert "COMPLIANT" not in captured.out
+
+    def test_check_partial_unknown_framework_exits_with_error(self, capsys):
+        """A valid framework mixed with a typo'd one must still error."""
+        args = argparse.Namespace(
+            compliance_command="check",
+            content=["ssn 123-45-6789"],
+            content_file=None,
+            frameworks="hipaa,gdrp",
+            min_severity="low",
+            json=False,
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            _cmd_check(args)
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "gdrp" in captured.err
+
     def test_check_from_file(self, capsys, tmp_path):
         """Check command reads content from file."""
         test_file = tmp_path / "test.py"
@@ -349,6 +389,26 @@ class TestComplianceReport:
         data = json.loads(output)
         assert "compliant" in data
         assert "score" in data
+
+    def test_report_unknown_framework_exits_with_error(self, capsys, tmp_path):
+        """Report command also rejects typo'd framework IDs with exit 1."""
+        test_file = tmp_path / "plan.txt"
+        test_file.write_text("store ssn 123-45-6789 unencrypted")
+
+        args = argparse.Namespace(
+            compliance_command="report",
+            content_file=str(test_file),
+            frameworks="hippa",
+            output_format="text",
+            output=None,
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            _cmd_report(args)
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "Unknown compliance framework" in captured.err
+        assert "hippa" in captured.err
+        assert "COMPLIANT" not in captured.out
 
     def test_report_write_to_file(self, tmp_path):
         """Report command writes output to file."""

--- a/tests/compliance/test_framework.py
+++ b/tests/compliance/test_framework.py
@@ -741,20 +741,43 @@ class TestComplianceFrameworkManager:
         result = manager.check(content, frameworks=["hipaa"])
         assert result.frameworks_checked == ["hipaa"]
 
-    def test_manager_check_with_unknown_frameworks_ignores_them(self):
-        """Test that unknown framework IDs are ignored."""
-        manager = ComplianceFrameworkManager()
-        result = manager.check("test content", frameworks=["hipaa", "nonexistent"])
-        assert "hipaa" in result.frameworks_checked
-        assert "nonexistent" not in result.frameworks_checked
+    def test_manager_check_with_partially_unknown_frameworks_raises(self):
+        """Unknown framework IDs mixed with valid ones must raise, not be ignored.
 
-    def test_manager_check_with_empty_frameworks_returns_compliant(self):
-        """Test check with no valid frameworks returns compliant."""
+        Silently dropping an unknown/typo'd framework ID could lead a caller to
+        believe a framework was evaluated when it never was.
+        """
         manager = ComplianceFrameworkManager()
-        result = manager.check("test content", frameworks=["nonexistent"])
-        assert result.compliant is True
-        assert result.score == 1.0
-        assert len(result.issues) == 0
+        with pytest.raises(ValueError) as exc_info:
+            manager.check("test content", frameworks=["hipaa", "nonexistent"])
+        assert "nonexistent" in str(exc_info.value)
+
+    def test_manager_check_with_all_unknown_frameworks_raises_not_compliant(self):
+        """A request that names only unknown frameworks must raise.
+
+        Regression test: previously this returned a false COMPLIANT/100% result
+        for content that was never evaluated against any framework, hiding even
+        critical issues (e.g. exposed SSN/PHI) behind a green all-clear.
+        """
+        manager = ComplianceFrameworkManager()
+        # Content with a critical SSN/PHI exposure that should never be reported
+        # as compliant simply because the framework IDs were typo'd.
+        content = "store ssn 123-45-6789 unencrypted password=secret"
+        with pytest.raises(ValueError) as exc_info:
+            manager.check(content, frameworks=["gdrp", "hippa"])
+        msg = str(exc_info.value)
+        assert "gdrp" in msg
+        assert "hippa" in msg
+
+    def test_manager_check_unknown_framework_error_lists_available(self):
+        """The error should help the user by listing valid framework IDs."""
+        manager = ComplianceFrameworkManager()
+        with pytest.raises(ValueError) as exc_info:
+            manager.check("test content", frameworks=["bogus"])
+        msg = str(exc_info.value).lower()
+        # Mentions at least a couple of real frameworks as guidance
+        assert "gdpr" in msg
+        assert "hipaa" in msg
 
     def test_manager_check_min_severity_filter(self):
         """Test minimum severity filtering."""


### PR DESCRIPTION
## Defect (high severity)

`compliance check` / `compliance report --frameworks` silently ignored unknown/typo'd framework IDs and reported a false **COMPLIANT / 100%** result for content that was never evaluated against any framework.

Repro:
```
python3 -m aragora.cli.main compliance check 'store ssn 123-45-6789 unencrypted password=secret' --frameworks 'gdrp,hippa'
```

**Before:** `Status: COMPLIANT`, `Score: 100%`, `Frameworks checked:` (empty), `No issues found.`, exit `0` — a green all-clear that scanned nothing, hiding a critical SSN/PHI exposure.

**After:** `Error: Unknown compliance framework(s): gdrp, hippa. Available frameworks: fda_21_cfr, fedramp, gdpr, hipaa, iso_27001, owasp, pci_dss, sox`, exit `1`. The same content with the correct IDs (`gdpr,hipaa`) still correctly reports **NON-COMPLIANT / 70%** with a CRITICAL `hipaa/hipaa-phi-exposure` issue.

## Root cause

`ComplianceFrameworkManager.check()` (`aragora/compliance/framework.py`) filtered requested IDs with `if f in self._frameworks`, silently dropping unknowns. When the resulting set was empty it returned `ComplianceCheckResult(compliant=True, score=1.0, frameworks_checked=[])`. The CLI (`aragora/cli/commands/compliance.py`) passed raw comma-split strings through without validation.

## Fix

- **`framework.py`**: raise `ValueError` listing the unknown ID(s) and the available frameworks whenever *any* requested framework ID is unknown — fail loud instead of producing a false pass. All existing callers (CLI, FastAPI `/compliance/check` route, policy handler) already catch `ValueError` and degrade safely (server returns a clean error response, never a false-green).
- **`compliance.py` CLI**: catch `ValueError` in `_cmd_check` and `_cmd_report`, print a clean `Error: ...` to stderr and `sys.exit(1)`, matching the command's existing error-handling pattern.

## Tests (TDD)

- `tests/compliance/test_framework.py`: unknown and partially-unknown IDs now raise; error message lists valid frameworks. Replaced the two prior tests that encoded the buggy "ignore unknown / return compliant" behavior.
- `tests/cli/test_compliance_framework.py`: `check` and `report` with typo'd frameworks exit `1` with a clear stderr message and never print `COMPLIANT`.

Verification: `165 passed` (framework + CLI), `180 passed` (policy/route), `685 passed` (server `-k compliance`) — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
