### PR TITLE
fix(cli): align `aragora memory` commands to real server endpoints

### DIFF
--- a/aragora/cli/commands/memory_ops.py
+++ b/aragora/cli/commands/memory_ops.py
@@ -108,7 +108,7 @@ async def _cmd_query(args: argparse.Namespace) -> None:
         params["tier"] = tier
 
     try:
-        result = await _api_get("/api/v1/memory/continuum/search", params)
+        result = await _api_get("/api/v1/memory/search", params)
 
         if as_json:
             print(json.dumps(result, indent=2))
@@ -157,7 +157,7 @@ async def _cmd_store(args: argparse.Namespace) -> None:
     }
 
     try:
-        result = await _api_post("/api/v1/memory", data)
+        result = await _api_post("/api/v1/memory/store", data)
 
         if as_json:
             print(json.dumps(result, indent=2))
@@ -184,7 +184,7 @@ async def _cmd_stats(args: argparse.Namespace) -> None:
     as_json = getattr(args, "json", False)
 
     try:
-        result = await _api_get("/api/v1/memory/continuum/tier-stats")
+        result = await _api_get("/api/v1/memory/tier-stats")
 
         if as_json:
             print(json.dumps(result, indent=2))
@@ -240,13 +240,11 @@ async def _cmd_promote(args: argparse.Namespace) -> None:
         return
 
     data: dict[str, Any] = {
-        "action": "promote",
-        "entry_id": entry_id,
         "target_tier": target_tier,
     }
 
     try:
-        result = await _api_post("/api/v1/memory", data)
+        result = await _api_post(f"/api/v1/memory/{entry_id}/promote", data)
 
         if as_json:
             print(json.dumps(result, indent=2))

--- a/aragora/server/handlers/memory/memory.py
+++ b/aragora/server/handlers/memory/memory.py
@@ -54,16 +54,15 @@ MEMORY_READ_PERMISSION = "memory:read"
 MEMORY_WRITE_PERMISSION = "memory:write"
 MEMORY_MANAGE_PERMISSION = "memory:manage"
 
-# Pre-declare optional import names for type safety
-MemoryTier: Any = None
-CritiqueStore: Any = None
-
-# Optional import for memory functionality
+# Optional import for memory functionality.
+# Fallbacks are assigned in the ``except`` branch so static type checkers do
+# not see a redundant re-definition of the imported name.
 try:
     from aragora.memory.continuum import MemoryTier
 
     CONTINUUM_AVAILABLE = True
 except ImportError:
+    MemoryTier = None  # type: ignore[assignment,misc]
     CONTINUUM_AVAILABLE = False
 
 # Optional import for critique store - use canonical helper
@@ -75,7 +74,7 @@ CRITIQUE_STORE_AVAILABLE = is_critique_store_available()
 try:
     from aragora.memory.store import CritiqueStore
 except ImportError:
-    CritiqueStore = None
+    CritiqueStore = None  # type: ignore[assignment,misc]
 
 
 class MemoryHandler(
@@ -104,6 +103,7 @@ class MemoryHandler(
         "/api/v1/memory/pressure",
         "/api/v1/memory/tiers",
         "/api/v1/memory/search",
+        "/api/v1/memory/store",
         "/api/v1/memory/search-index",
         "/api/v1/memory/search-timeline",
         "/api/v1/memory/entries",
@@ -275,7 +275,130 @@ class MemoryHandler(
                 return error_response("Rate limit exceeded. Please try again later.", 429)
             return self._unified_search(query_params, handler)
 
+        if path == "/api/v1/memory/store":
+            # Rate limit: 10/min for mutation operations
+            if not _mutation_limiter.is_allowed(client_ip):
+                return error_response("Rate limit exceeded. Please try again later.", 429)
+            return self._store_memory(handler)
+
+        # Promote an entry to a new tier: POST /api/v1/memory/{id}/promote
+        if path.endswith("/promote") and path.startswith("/api/v1/memory/"):
+            # Rate limit: 10/min for mutation operations
+            if not _mutation_limiter.is_allowed(client_ip):
+                return error_response("Rate limit exceeded. Please try again later.", 429)
+            # split("/") => ["", "api", "v1", "memory", "{id}", "promote"]
+            memory_id, err = self.extract_path_param(path, 4, "memory_id")
+            if err or memory_id is None:
+                return err or error_response("Empty memory_id", 400)
+            return self._promote_memory(memory_id, handler)
+
         return None
+
+    def _resolve_tier(self, tier_name: str) -> Any:
+        """Resolve a tier name string to a MemoryTier enum, or None if invalid."""
+        if not CONTINUUM_AVAILABLE or MemoryTier is None:
+            return None
+        try:
+            return MemoryTier[tier_name.strip().upper()]
+        except (KeyError, AttributeError):
+            return None
+
+    def _store_memory(self, handler: Any) -> HandlerResult:
+        """Store a new memory entry: POST /api/v1/memory/store.
+
+        Expects JSON body: {"content": str, "tier": str, "importance"?: float}.
+        Returns {"id": str, "tier": str}.
+        """
+        if not CONTINUUM_AVAILABLE:
+            return error_response("Continuum memory system not available", 503)
+
+        continuum = self.ctx.get("continuum_memory")
+        if not continuum:
+            return error_response("Continuum memory not initialized", 503)
+
+        body = self.read_json_body(handler) or {}
+        content = body.get("content")
+        if not isinstance(content, str) or not content.strip():
+            return error_response("Missing required field: content", 400)
+
+        tier_name = body.get("tier", "fast")
+        tier = self._resolve_tier(str(tier_name))
+        if tier is None:
+            return error_response(f"Invalid tier: {tier_name}", 400)
+
+        importance = body.get("importance", 0.5)
+        try:
+            importance = float(importance)
+        except (TypeError, ValueError):
+            importance = 0.5
+        importance = max(0.0, min(1.0, importance))
+
+        import uuid
+
+        memory_id = str(uuid.uuid4())
+        try:
+            entry = continuum.add(
+                id=memory_id,
+                content=content,
+                tier=tier,
+                importance=importance,
+            )
+        except (RuntimeError, ValueError, TypeError, OSError, KeyError, AttributeError) as e:
+            logger.warning("Memory store failed: %s", e)
+            return error_response("Failed to store memory entry", 500)
+
+        stored_id = getattr(entry, "id", None) or memory_id
+        return json_response({"id": stored_id, "tier": tier.name.lower()})
+
+    def _promote_memory(self, memory_id: str, handler: Any) -> HandlerResult:
+        """Promote a memory entry to a new tier: POST /api/v1/memory/{id}/promote.
+
+        Expects JSON body: {"target_tier": str}.
+        Returns {"success": bool, "previous_tier": str | None}.
+        """
+        if not CONTINUUM_AVAILABLE:
+            return error_response("Continuum memory system not available", 503)
+
+        continuum = self.ctx.get("continuum_memory")
+        if not continuum:
+            return error_response("Continuum memory not initialized", 503)
+
+        body = self.read_json_body(handler) or {}
+        target_tier_name = body.get("target_tier")
+        if not target_tier_name:
+            return error_response("Missing required field: target_tier", 400)
+
+        target_tier = self._resolve_tier(str(target_tier_name))
+        if target_tier is None:
+            return error_response(f"Invalid tier: {target_tier_name}", 400)
+
+        # Capture the current tier before promotion for the response.
+        previous_tier: str | None = None
+        try:
+            existing = continuum.get(memory_id)
+        except (RuntimeError, ValueError, TypeError, OSError, AttributeError):
+            existing = None
+        if existing is not None:
+            existing_tier = getattr(existing, "tier", None)
+            if existing_tier is not None and hasattr(existing_tier, "name"):
+                previous_tier = existing_tier.name.lower()
+
+        try:
+            promoted = continuum.promote_entry(memory_id, target_tier)
+        except (RuntimeError, ValueError, TypeError, OSError, KeyError, AttributeError) as e:
+            logger.warning("Memory promote failed: %s", e)
+            return error_response("Failed to promote memory entry", 500)
+
+        if not promoted:
+            return json_response(
+                {
+                    "success": False,
+                    "previous_tier": previous_tier,
+                    "error": "Memory entry not found",
+                }
+            )
+
+        return json_response({"success": True, "previous_tier": previous_tier})
 
     @handle_errors("memory deletion")
     def handle_delete(
@@ -319,7 +442,7 @@ class MemoryHandler(
     def _parse_bool_param(params: dict, name: str, default: bool = False) -> bool:
         """Parse a boolean parameter from query params."""
         raw = get_bounded_string_param(params, name, "", max_length=10)
-        if raw == "":
+        if not raw:
             return default
         return raw.strip().lower() in ("1", "true", "yes", "y", "on")
 
@@ -429,13 +552,15 @@ class MemoryHandler(
     def _get_unified_handler(self) -> Any:
         """Get or create UnifiedMemoryHandler."""
         if not hasattr(self, "_unified_handler"):
+            unified: Any = None
             try:
                 from .unified_handler import UnifiedMemoryHandler
 
                 gateway = getattr(self, "_memory_gateway", None)
-                self._unified_handler = UnifiedMemoryHandler(gateway=gateway)
+                unified = UnifiedMemoryHandler(gateway=gateway)
             except ImportError:
-                self._unified_handler = None
+                unified = None
+            self._unified_handler = unified
         return self._unified_handler
 
     def _unified_search(self, query_params: dict[str, Any], handler: Any) -> HandlerResult:

--- a/tests/cli/test_memory_ops.py
+++ b/tests/cli/test_memory_ops.py
@@ -341,3 +341,96 @@ class TestCmdPromote:
             await _cmd_promote(args)
         captured = capsys.readouterr()
         assert "404" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Endpoint contract tests (regression guard for wrong-endpoint defects)
+#
+# These tests pin the exact server endpoints the CLI must call. The CLI
+# previously targeted non-existent routes (`/api/v1/memory/continuum/search`,
+# `/api/v1/memory/continuum/tier-stats`, and bare `POST /api/v1/memory`) that
+# the server's MemoryHandler does not implement, yielding user-facing 404/500
+# errors. The real routes are:
+#   - GET  /api/v1/memory/search       (query)
+#   - GET  /api/v1/memory/tier-stats   (stats)
+#   - POST /api/v1/memory/store        (store)
+#   - POST /api/v1/memory/{id}/promote (promote)
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryOpsEndpoints:
+    """Pin the exact API endpoints invoked by each subcommand."""
+
+    @pytest.mark.asyncio
+    async def test_query_targets_search_route(self):
+        args = argparse.Namespace(text="needle", tier="slow", limit=7, json=True)
+        mock_get = AsyncMock(return_value={"results": [], "total": 0})
+        with patch("aragora.cli.commands.memory_ops._api_get", mock_get):
+            await _cmd_query(args)
+        endpoint = mock_get.await_args.args[0]
+        params = mock_get.await_args.args[1]
+        assert endpoint == "/api/v1/memory/search"
+        assert "continuum" not in endpoint
+        # query params align with the server search contract (q/tier/limit)
+        assert params["q"] == "needle"
+        assert params["tier"] == "slow"
+        assert params["limit"] == 7
+
+    @pytest.mark.asyncio
+    async def test_stats_targets_tier_stats_route(self):
+        args = argparse.Namespace(json=True)
+        mock_get = AsyncMock(return_value={"tiers": {}, "total_entries": 0})
+        with patch("aragora.cli.commands.memory_ops._api_get", mock_get):
+            await _cmd_stats(args)
+        endpoint = mock_get.await_args.args[0]
+        assert endpoint == "/api/v1/memory/tier-stats"
+        assert "continuum" not in endpoint
+
+    @pytest.mark.asyncio
+    async def test_store_targets_store_route_with_payload(self):
+        args = argparse.Namespace(text="remember this", tier="medium", json=True)
+        mock_post = AsyncMock(return_value={"id": "m1", "tier": "medium"})
+        with patch("aragora.cli.commands.memory_ops._api_post", mock_post):
+            await _cmd_store(args)
+        endpoint = mock_post.await_args.args[0]
+        payload = mock_post.await_args.args[1]
+        assert endpoint == "/api/v1/memory/store"
+        assert payload["content"] == "remember this"
+        assert payload["tier"] == "medium"
+
+    @pytest.mark.asyncio
+    async def test_promote_targets_promote_route_with_payload(self):
+        args = argparse.Namespace(id="abc123", to="slow", json=True)
+        mock_post = AsyncMock(return_value={"success": True, "previous_tier": "fast"})
+        with patch("aragora.cli.commands.memory_ops._api_post", mock_post):
+            await _cmd_promote(args)
+        endpoint = mock_post.await_args.args[0]
+        payload = mock_post.await_args.args[1]
+        assert endpoint == "/api/v1/memory/abc123/promote"
+        assert payload["target_tier"] == "slow"
+
+
+class TestMemoryHandlerServerContract:
+    """The server MemoryHandler must actually claim the routes the CLI calls."""
+
+    def _handler(self):
+        from aragora.server.handlers.memory.memory import MemoryHandler
+
+        return MemoryHandler()
+
+    def test_store_route_is_claimed(self):
+        h = self._handler()
+        assert h.can_handle("/api/v1/memory/store") is True
+
+    def test_promote_route_is_claimed(self):
+        h = self._handler()
+        assert h.can_handle("/api/v1/memory/abc123/promote") is True
+
+    def test_handle_post_routes_store_and_promote(self):
+        import inspect
+
+        from aragora.server.handlers.memory.memory import MemoryHandler
+
+        src = inspect.getsource(MemoryHandler.handle_post)
+        assert "/api/v1/memory/store" in src
+        assert "/promote" in src

--- a/tests/server/handlers/memory/test_memory_handler.py
+++ b/tests/server/handlers/memory/test_memory_handler.py
@@ -550,3 +550,104 @@ class TestCoordinatorEdgeCases:
 
         body = json.loads(result.body) if isinstance(result.body, (str, bytes)) else result.body
         assert body.get("configured") is False
+
+
+# ===========================================================================
+# Store / Promote POST endpoints (regression for CLI memory-lane defects)
+#
+# The CLI `aragora memory store` / `aragora memory promote` commands target
+# `POST /api/v1/memory/store` and `POST /api/v1/memory/{id}/promote`. These
+# functional tests exercise the server handler end-to-end against a real
+# ContinuumMemory backend so producer (CLI) and consumer (server) stay aligned.
+# ===========================================================================
+
+
+class _StoreMockHTTPHandler:
+    """Minimal HTTP handler shim exposing a JSON body for handle_post."""
+
+    def __init__(self, body: dict | None = None, client_ip: str = "127.0.0.1"):
+        self.command = "POST"
+        self.client_address = (client_ip, 12345)
+        self.headers: dict[str, str] = {"User-Agent": "test-agent"}
+        self.rfile = MagicMock()
+        body_bytes = json.dumps(body or {}).encode()
+        self.rfile.read.return_value = body_bytes
+        self.headers["Content-Length"] = str(len(body_bytes))
+
+
+@pytest.fixture
+def real_continuum(tmp_path):
+    """Construct a real ContinuumMemory backed by a temp SQLite DB."""
+    from aragora.memory.continuum import ContinuumMemory
+
+    return ContinuumMemory(db_path=str(tmp_path / "continuum_memory.db"))
+
+
+@pytest.fixture
+def store_handler(real_continuum):
+    from aragora.server.handlers.base import clear_cache
+    from aragora.server.handlers.memory.memory import MemoryHandler
+
+    clear_cache()
+    return MemoryHandler(server_context={"continuum_memory": real_continuum})
+
+
+def _body(result):
+    return json.loads(result.body) if isinstance(result.body, (str, bytes)) else result.body
+
+
+class TestMemoryStorePromote:
+    """Functional tests for POST store/promote."""
+
+    def test_store_claims_route(self, store_handler):
+        assert store_handler.can_handle("/api/v1/memory/store") is True
+
+    def test_promote_claims_route(self, store_handler):
+        assert store_handler.can_handle("/api/v1/memory/m1/promote") is True
+
+    def test_store_creates_entry(self, store_handler):
+        http = _StoreMockHTTPHandler({"content": "hello world", "tier": "fast"})
+        result = store_handler.handle_post("/api/v1/memory/store", {}, http)
+        assert result is not None
+        assert result.status_code == 200
+        body = _body(result)
+        assert body["tier"] == "fast"
+        assert body["id"]
+
+    def test_store_missing_content_is_400(self, store_handler):
+        http = _StoreMockHTTPHandler({"tier": "fast"})
+        result = store_handler.handle_post("/api/v1/memory/store", {}, http)
+        assert result.status_code == 400
+
+    def test_store_invalid_tier_is_400(self, store_handler):
+        http = _StoreMockHTTPHandler({"content": "x", "tier": "bogus"})
+        result = store_handler.handle_post("/api/v1/memory/store", {}, http)
+        assert result.status_code == 400
+
+    def test_store_then_promote_roundtrip(self, store_handler):
+        # Store in fast tier
+        store_http = _StoreMockHTTPHandler({"content": "promote me", "tier": "fast"})
+        store_result = store_handler.handle_post("/api/v1/memory/store", {}, store_http)
+        entry_id = _body(store_result)["id"]
+
+        # Promote to slow tier
+        promote_http = _StoreMockHTTPHandler({"target_tier": "slow"})
+        promote_result = store_handler.handle_post(
+            f"/api/v1/memory/{entry_id}/promote", {}, promote_http
+        )
+        assert promote_result.status_code == 200
+        body = _body(promote_result)
+        assert body["success"] is True
+        assert body["previous_tier"] == "fast"
+
+    def test_promote_missing_entry_returns_not_found(self, store_handler):
+        http = _StoreMockHTTPHandler({"target_tier": "slow"})
+        result = store_handler.handle_post("/api/v1/memory/does-not-exist/promote", {}, http)
+        assert result.status_code == 200
+        body = _body(result)
+        assert body["success"] is False
+
+    def test_promote_missing_target_tier_is_400(self, store_handler):
+        http = _StoreMockHTTPHandler({})
+        result = store_handler.handle_post("/api/v1/memory/m1/promote", {}, http)
+        assert result.status_code == 400


### PR DESCRIPTION
## Summary

The `aragora memory` CLI subcommands (`query`, `stats`, `store`, `promote`) targeted server endpoints that **no route or handler implements**, so every one of them is non-functional against a real server.

## Root cause

`aragora/cli/commands/memory_ops.py` issued requests to endpoints the server does not serve:

| Command | CLI called (before) | Server result |
|---|---|---|
| `query`   | `GET /api/v1/memory/continuum/search`     | `can_handle` prefix-claims it, but `handle()` has no branch → returns `None` → dispatcher emits **HTTP 500** `{handler_no_result}` |
| `stats`   | `GET /api/v1/memory/continuum/tier-stats` | same matched-but-no-result chain → **HTTP 500** |
| `store`   | `POST /api/v1/memory` (bare)              | `can_handle` requires the trailing slash, so the bare path is **unclaimed** → unified server **404** |
| `promote` | `POST /api/v1/memory` (bare)              | unclaimed → **404**; also no `handle_post` branch read the payload |

`MemoryHandler.can_handle()` prefix-matches everything under `/api/v1/memory/`, so the bad GET paths were claimed but unhandled (→ 500), while the bare POST path lacked the trailing slash and was unclaimed (→ 404). The CLI's `response.raise_for_status()` surfaced both as `Error: API request failed (4xx/5xx)`.

The real routes already served by `MemoryHandler` are `/api/v1/memory/search` and `/api/v1/memory/tier-stats`. There was **no** store/promote endpoint at all (the `*/promote` and `*/move` entries in `ROUTES` were declared but never implemented in `handle_post`).

## Fix

**CLI** (`aragora/cli/commands/memory_ops.py`) — call the real routes:
- `query`   → `GET  /api/v1/memory/search`
- `stats`   → `GET  /api/v1/memory/tier-stats`
- `store`   → `POST /api/v1/memory/store` with `{content, tier}`
- `promote` → `POST /api/v1/memory/{id}/promote` with `{target_tier}`

**Server** (`aragora/server/handlers/memory/memory.py`) — implement the missing POST handlers for the routes the CLI now calls (the `*/promote` route was already declared; `/store` added to `ROUTES`):
- `_store_memory` → `continuum.add()`, returns `{id, tier}`
- `_promote_memory` → `continuum.promote_entry()`, returns `{success, previous_tier}`
- Reuses existing conventions: `read_json_body`, `error_response`/`json_response`, `extract_path_param`, and the 10/min mutation rate limiter; validates tier/content and returns 400/503 consistently with sibling handlers.

Also tidied two pre-existing mypy `no-redef`/`union-attr` issues in `memory.py` that the changed-file typecheck gate surfaced (optional-import fallbacks moved into the `except` branch; `_unified_handler` init narrowed).

## Before / after

```
# before (real server)
$ aragora memory query "foo"     -> Error: API request failed (500)
$ aragora memory stats           -> Error: API request failed (500)
$ aragora memory store "x"       -> Error: API request failed (404)
$ aragora memory promote id --to slow -> Error: API request failed (404)

# after
$ aragora memory query "foo"     -> Found N memory entries ...
$ aragora memory stats           -> MEMORY TIER STATISTICS ...
$ aragora memory store "x"       -> Memory entry stored successfully (ID / Tier)
$ aragora memory promote id --to slow -> Entry promoted successfully (From / To)
```

## Tests (TDD — written failing first)

- `tests/cli/test_memory_ops.py::TestMemoryOpsEndpoints` — pins the exact endpoint URL + payload each subcommand sends. (The prior mocked tests stubbed `_api_get`/`_api_post` and never asserted the URL, which is exactly how the defect slipped through.)
- `tests/cli/test_memory_ops.py::TestMemoryHandlerServerContract` — server claims `/store` and `/{id}/promote`.
- `tests/server/handlers/memory/test_memory_handler.py::TestMemoryStorePromote` — functional store → promote roundtrip against a **real** `ContinuumMemory`, plus 400/not-found paths.

Verification: full memory CLI + handler suites green — `1088 passed`. Changed-file mypy clean.

Closes the three memory-lane defects at `memory_ops.py:111` (query), `:187` (stats), `:160` (store/promote).

🤖 Generated with [Claude Code](https://claude.com/claude-code)