### PR TITLE
fix(review-queue): warn on review-pr object quorum evidence

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -1929,6 +1929,7 @@ def _build_packet(
             "files",
             "body",
             "comments",
+            "reviews",
             "commits",
         ]
     )
@@ -2355,6 +2356,12 @@ def _build_model_review_quorum(
     blocking_workflow_state = bool(blocking_workflow_reasons)
     unresolved_dissent = bool(dissenting_views)
     counted_reviewer_ids = _counted_model_reviewer_ids(reviewer_signals, dogfood_evidence)
+    review_object_warnings = _review_object_quorum_warnings(
+        pr.get("reviews") or [],
+        counted_reviewer_ids=counted_reviewer_ids,
+        head_sha=head_sha,
+        head_committed_at=head_committed_at,
+    )
     signal_count = len(counted_reviewer_ids)
     has_required_dogfood = not requirement["requires_adversarial_dogfood"] or any(
         _known_model_reviewer_id(item) for item in dogfood_evidence
@@ -2392,6 +2399,7 @@ def _build_model_review_quorum(
         )
         if not has_required_dogfood:
             reasons.append("focused adversarial dogfood evidence is required")
+        reasons.extend(review_object_warnings)
 
     admin_squash_allowed = False
     requires_human_risk_settlement = bool(requirement["requires_human_risk_settlement"])
@@ -3056,6 +3064,78 @@ def _model_review_signals_from_comments(
             }
         )
     return signals[:5]
+
+
+def _review_object_quorum_warnings(
+    reviews: list[Any],
+    *,
+    counted_reviewer_ids: list[str],
+    head_sha: str = "",
+    head_committed_at: str = "",
+) -> list[str]:
+    """Warn when ``review-pr`` evidence is present in non-countable form.
+
+    Merge quorum intentionally counts model evidence from PR comments because
+    comments are easier to audit, quote, and mirror across queue tooling. A
+    GitHub review object alone should therefore not satisfy quorum, but it
+    should produce an operator-visible warning instead of silently looking like
+    missing evidence.
+    """
+    counted = set(counted_reviewer_ids)
+    warnings: list[str] = []
+    warned: set[str] = set()
+    for review in reviews:
+        if not isinstance(review, dict):
+            continue
+        if not _is_review_grounded_on_head(review, head_sha, head_committed_at):
+            continue
+        body = str(review.get("body", "") or "")
+        reviewer_id = _known_model_reviewer_id(
+            {"reviewer_id": _review_pr_reviewer_from_body(body), "provider": ""}
+        )
+        if not reviewer_id:
+            reviewer_id = _normalize_model_reviewer_id(_infer_model_reviewer_from_text(body))
+        if not reviewer_id or reviewer_id in counted or reviewer_id in warned:
+            continue
+        warnings.append(
+            "GitHub review object from "
+            f"{reviewer_id} is advisory-only for merge-packet model quorum; "
+            "mirror the review-pr output into a current-head PR comment before settlement"
+        )
+        warned.add(reviewer_id)
+    return warnings
+
+
+def _review_pr_reviewer_from_body(body: str) -> str:
+    for line in str(body).splitlines():
+        stripped = line.strip()
+        if not stripped.lower().startswith("- reviewer:"):
+            continue
+        value = stripped.split(":", 1)[1].strip().strip("`")
+        return value.strip()
+    return ""
+
+
+def _is_review_grounded_on_head(
+    review: dict[str, Any],
+    head_sha: str,
+    head_committed_at: str,
+) -> bool:
+    if not head_sha:
+        return True
+    commit = review.get("commit")
+    if isinstance(commit, dict) and str(commit.get("oid", "") or "").strip() == head_sha:
+        return True
+    body = str(review.get("body", "") or "")
+    head_short = head_sha[:7]
+    if head_short and head_short in body:
+        return True
+    if not head_committed_at:
+        return False
+    submitted = str(review.get("submittedAt", "") or "")
+    if not submitted:
+        return False
+    return submitted >= head_committed_at
 
 
 def _infer_model_reviewer_from_text(text: str) -> str:

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3124,10 +3124,14 @@ def _is_review_grounded_on_head(
     if not head_sha:
         return True
     commit = review.get("commit")
-    if isinstance(commit, dict) and str(commit.get("oid", "") or "").strip() == head_sha:
-        return True
     body = str(review.get("body", "") or "")
     head_short = head_sha[:7]
+    if isinstance(commit, dict):
+        commit_oid = str(commit.get("oid", "") or "").strip()
+        if commit_oid:
+            if commit_oid == head_sha:
+                return True
+            return bool(head_short and head_short in body)
     if head_short and head_short in body:
         return True
     if not head_committed_at:

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3090,30 +3090,91 @@ def _review_object_quorum_warnings(
         if not _is_review_grounded_on_head(review, head_sha, head_committed_at):
             continue
         body = str(review.get("body", "") or "")
-        reviewer_id = _known_model_reviewer_id(
-            {"reviewer_id": _review_pr_reviewer_from_body(body), "provider": ""}
-        )
-        if not reviewer_id:
-            reviewer_id = _normalize_model_reviewer_id(_infer_model_reviewer_from_text(body))
-        if not reviewer_id or reviewer_id in counted or reviewer_id in warned:
+        identity = _resolve_review_object_model_identity(body)
+        reviewer_id = _known_model_reviewer_id(identity.as_packet_fields())
+        if reviewer_id:
+            if reviewer_id in counted or reviewer_id in warned:
+                continue
+            warnings.append(
+                "GitHub review object from "
+                f"{reviewer_id} is advisory-only for merge-packet model quorum; "
+                "mirror the review-pr output into a current-head PR comment before settlement"
+            )
+            warned.add(reviewer_id)
             continue
-        warnings.append(
-            "GitHub review object from "
-            f"{reviewer_id} is advisory-only for merge-packet model quorum; "
-            "mirror the review-pr output into a current-head PR comment before settlement"
-        )
-        warned.add(reviewer_id)
+        surface = identity.surface_reviewer_id
+        if surface == "unknown_model_reviewer" or surface in warned:
+            continue
+        if any(problem in IDENTITY_COUNT_BLOCKERS for problem in identity.identity_problems):
+            warnings.append(
+                "GitHub review object from "
+                f"{surface} lacks lineage-bound model family metadata; mirror the "
+                "review-pr output into a current-head PR comment with Model family "
+                "metadata before settlement"
+            )
+            warned.add(surface)
     return warnings
 
 
-def _review_pr_reviewer_from_body(body: str) -> str:
+def _resolve_review_object_model_identity(body: str) -> ModelReviewIdentity:
+    identity = _resolve_model_review_identity(body)
+    if _known_model_reviewer_id(identity.as_packet_fields()):
+        return identity
+
+    metadata = _review_pr_metadata_from_body(body)
+    reviewer = metadata.get("reviewer", "")
+    if not reviewer:
+        return identity
+
+    surface = _infer_surface_reviewer_from_candidate(reviewer)
+    explicit_family_raw = metadata.get("model family", "")
+    explicit_family = _normalize_model_family(explicit_family_raw)
+    model_id = metadata.get("model id", "")
+    problems: list[str] = []
+
+    if surface == "unknown_model_reviewer":
+        problems.append("unknown_surface_reviewer")
+    if explicit_family_raw and not explicit_family:
+        problems.append("unknown_model_family")
+
+    model_family = explicit_family
+    identity_source = "review_pr_model_family_metadata" if explicit_family_raw else "none"
+    if surface in ROUTER_SURFACE_REVIEWERS:
+        if not explicit_family_raw:
+            problems.append("missing_model_family_disclosure")
+    elif surface != "unknown_model_reviewer":
+        direct_family = _normalize_model_family(surface)
+        if explicit_family and direct_family and explicit_family != direct_family:
+            problems.append("heading_model_family_conflict")
+        if not explicit_family_raw and direct_family:
+            model_family = direct_family
+            identity_source = "review_pr_direct_reviewer"
+        elif explicit_family and direct_family == explicit_family:
+            identity_source = "review_pr_model_family_metadata"
+
+    return ModelReviewIdentity(
+        surface_reviewer_id=surface,
+        model_family=model_family,
+        model_id=model_id,
+        identity_source=identity_source,
+        identity_problems=tuple(dict.fromkeys(problems)),
+    )
+
+
+def _review_pr_metadata_from_body(body: str) -> dict[str, str]:
+    metadata: dict[str, str] = {}
     for line in str(body).splitlines():
         stripped = line.strip()
-        if not stripped.lower().startswith("- reviewer:"):
+        if stripped.startswith("-"):
+            stripped = stripped[1:].strip()
+        label, sep, value = stripped.partition(":")
+        if not sep:
             continue
-        value = stripped.split(":", 1)[1].strip().strip("`")
-        return value.strip()
-    return ""
+        normalized_label = label.strip().strip("*").lower()
+        if normalized_label not in {"reviewer", "model family", "model id"}:
+            continue
+        metadata[normalized_label] = value.strip().strip("*").strip().strip("`")
+    return metadata
 
 
 def _is_review_grounded_on_head(

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -1436,6 +1436,50 @@ class TestModelReviewQuorum:
         assert len(quorum["reviewer_signals"]) == 0
         assert len(quorum["dogfood_evidence"]) == 1
 
+    def test_current_head_review_pr_object_warns_that_comment_form_is_required(
+        self,
+    ) -> None:
+        head_sha = "abcdef1234567890abcdef1234567890abcdef12"
+        pr = _make_pr(files=["aragora/cli/commands/swarm.py"])
+        pr["headRefOid"] = head_sha
+        pr["commits"] = [
+            {"oid": head_sha, "committedDate": "2026-04-28T20:00:00Z"},
+        ]
+        pr["comments"] = [
+            {
+                **_dogfood_comment("## Codex focused dogfood\n10/10 pass"),
+                "createdAt": "2026-04-28T20:05:00Z",
+            },
+        ]
+        pr["reviews"] = [
+            {
+                "author": {"login": "an0mium"},
+                "body": (
+                    "## Aragora review-pr: advisory pass\n\n"
+                    "- Reviewer: `claude`\n"
+                    f"- Head SHA: `{head_sha}`\n"
+                    "- Final status: `passed`\n"
+                ),
+                "commit": {"oid": head_sha},
+                "state": "COMMENTED",
+                "submittedAt": "2026-04-28T20:10:00Z",
+            }
+        ]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=["aragora/cli/commands/swarm.py"],
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+        )
+        assert quorum["counted_reviewer_ids"] == ["codex"]
+        assert quorum["status"] == "needs_model_review_quorum"
+        assert any(
+            "GitHub review object" in reason and "PR comment" in reason
+            for reason in quorum["reasons"]
+        )
+
     # --- Finding 6: merge-authority self-modification elevation ------------
 
     def test_review_queue_self_modification_classified_tier_four(self) -> None:

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -1447,7 +1447,7 @@ class TestModelReviewQuorum:
         ]
         pr["comments"] = [
             {
-                **_dogfood_comment("## Codex focused dogfood\n10/10 pass"),
+                **_dogfood_comment("## Claude focused dogfood\n10/10 pass"),
                 "createdAt": "2026-04-28T20:05:00Z",
             },
         ]
@@ -1456,7 +1456,9 @@ class TestModelReviewQuorum:
                 "author": {"login": "an0mium"},
                 "body": (
                     "## Aragora review-pr: advisory pass\n\n"
-                    "- Reviewer: `claude`\n"
+                    "- Reviewer: `codex`\n"
+                    "- Model family: `openai`\n"
+                    "- Model id: `gpt-5-codex`\n"
                     f"- Head SHA: `{head_sha}`\n"
                     "- Final status: `passed`\n"
                 ),
@@ -1473,10 +1475,54 @@ class TestModelReviewQuorum:
             has_pending=False,
             has_failures=False,
         )
-        assert quorum["counted_reviewer_ids"] == ["codex"]
+        assert quorum["counted_reviewer_ids"] == ["claude"]
         assert quorum["status"] == "needs_model_review_quorum"
         assert any(
-            "GitHub review object" in reason and "PR comment" in reason
+            "GitHub review object from openai" in reason and "PR comment" in reason
+            for reason in quorum["reasons"]
+        )
+        assert not any("GitHub review object from codex" in reason for reason in quorum["reasons"])
+
+    def test_review_pr_object_with_router_reviewer_requires_model_family_metadata(
+        self,
+    ) -> None:
+        head_sha = "abcdef1234567890abcdef1234567890abcdef12"
+        pr = _make_pr(files=["aragora/cli/commands/swarm.py"])
+        pr["headRefOid"] = head_sha
+        pr["commits"] = [
+            {"oid": head_sha, "committedDate": "2026-04-28T20:00:00Z"},
+        ]
+        pr["comments"] = [
+            {
+                **_dogfood_comment("## Claude focused dogfood\n10/10 pass"),
+                "createdAt": "2026-04-28T20:05:00Z",
+            },
+        ]
+        pr["reviews"] = [
+            {
+                "author": {"login": "an0mium"},
+                "body": (
+                    "## Aragora review-pr: advisory pass\n\n"
+                    "- Reviewer: `codex`\n"
+                    f"- Head SHA: `{head_sha}`\n"
+                    "- Final status: `passed`\n"
+                ),
+                "commit": {"oid": head_sha},
+                "state": "COMMENTED",
+                "submittedAt": "2026-04-28T20:10:00Z",
+            }
+        ]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=["aragora/cli/commands/swarm.py"],
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+        )
+        assert quorum["counted_reviewer_ids"] == ["claude"]
+        assert any(
+            "GitHub review object from codex lacks lineage-bound model family metadata" in reason
             for reason in quorum["reasons"]
         )
 
@@ -1491,7 +1537,7 @@ class TestModelReviewQuorum:
         ]
         pr["comments"] = [
             {
-                **_dogfood_comment("## Codex focused dogfood\n10/10 pass"),
+                **_dogfood_comment("## Claude focused dogfood\n10/10 pass"),
                 "createdAt": "2026-04-28T20:05:00Z",
             },
         ]
@@ -1500,7 +1546,9 @@ class TestModelReviewQuorum:
                 "author": {"login": "an0mium"},
                 "body": (
                     "## Aragora review-pr: advisory pass\n\n"
-                    "- Reviewer: `claude`\n"
+                    "- Reviewer: `codex`\n"
+                    "- Model family: `openai`\n"
+                    "- Model id: `gpt-5-codex`\n"
                     "- Final status: `passed`\n"
                 ),
                 "commit": {"oid": "0000000000000000000000000000000000000000"},
@@ -1516,7 +1564,7 @@ class TestModelReviewQuorum:
             has_pending=False,
             has_failures=False,
         )
-        assert quorum["counted_reviewer_ids"] == ["codex"]
+        assert quorum["counted_reviewer_ids"] == ["claude"]
         assert not any("GitHub review object" in reason for reason in quorum["reasons"])
 
     # --- Finding 6: merge-authority self-modification elevation ------------

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -1480,6 +1480,45 @@ class TestModelReviewQuorum:
             for reason in quorum["reasons"]
         )
 
+    def test_off_head_review_pr_object_does_not_warn_as_current_evidence(
+        self,
+    ) -> None:
+        head_sha = "abcdef1234567890abcdef1234567890abcdef12"
+        pr = _make_pr(files=["aragora/cli/commands/swarm.py"])
+        pr["headRefOid"] = head_sha
+        pr["commits"] = [
+            {"oid": head_sha, "committedDate": "2026-04-28T20:00:00Z"},
+        ]
+        pr["comments"] = [
+            {
+                **_dogfood_comment("## Codex focused dogfood\n10/10 pass"),
+                "createdAt": "2026-04-28T20:05:00Z",
+            },
+        ]
+        pr["reviews"] = [
+            {
+                "author": {"login": "an0mium"},
+                "body": (
+                    "## Aragora review-pr: advisory pass\n\n"
+                    "- Reviewer: `claude`\n"
+                    "- Final status: `passed`\n"
+                ),
+                "commit": {"oid": "0000000000000000000000000000000000000000"},
+                "state": "COMMENTED",
+                "submittedAt": "2026-04-28T20:10:00Z",
+            }
+        ]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=["aragora/cli/commands/swarm.py"],
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+        )
+        assert quorum["counted_reviewer_ids"] == ["codex"]
+        assert not any("GitHub review object" in reason for reason in quorum["reasons"])
+
     # --- Finding 6: merge-authority self-modification elevation ------------
 
     def test_review_queue_self_modification_classified_tier_four(self) -> None:


### PR DESCRIPTION
## Summary
- Warn when review-pr evidence exists only as GitHub PR review objects that merge-packet cannot count.
- Preserve exact-head exclusion for off-head review objects.
- Add focused review_queue tests for the warning path.

## Validation
- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/cli/commands/test_review_queue.py -q -p no:rerunfailures -p no:cacheprovider -> 164 passed
- python3 -m ruff check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py
- python3 -m ruff format --check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py
- git diff --check origin/main...HEAD && git diff --check
- bash scripts/automation_pr_preflight.sh origin/main HEAD

## Publication note
Published from the existing idempotent automation-outbox handoff open-pr-codex-review-pr-comment-quorum-warning-primary-r2-20260524-ec96eb94 after the previous blocker was GitHub connectivity/auth, not local validation.