### PR TITLE
chore(publisher): report skipped outbox files

### DIFF
--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -1461,6 +1461,8 @@ def main(argv: list[str] | None = None) -> int:
         if args.no_outbox
         else load_outbox_handoffs(repo_root, outbox_dir=outbox_dir, receipt_dir=receipt_dir)
     )
+    outbox_file_count = 0 if args.no_outbox else len(_outbox_files(outbox_dir))
+    outbox_skipped_count = max(outbox_file_count - len(outbox_handoffs), 0)
     handoffs = sorted(
         memory_handoffs + outbox_handoffs,
         key=lambda item: (_source_mtime(item.source_file), item.priority),
@@ -1488,7 +1490,9 @@ def main(argv: list[str] | None = None) -> int:
             "outbox_dir": str(outbox_dir),
             "receipt_dir": str(receipt_dir),
             "memory_handoff_count": len(memory_handoffs),
+            "outbox_file_count": outbox_file_count,
             "outbox_handoff_count": len(outbox_handoffs),
+            "outbox_skipped_count": outbox_skipped_count,
             "handoff_count": len(handoffs),
             "github_health": github_health.to_dict(),
             "decisions": [asdict(item) for item in decisions],
@@ -1540,7 +1544,9 @@ def main(argv: list[str] | None = None) -> int:
         "outbox_dir": str(outbox_dir),
         "receipt_dir": str(receipt_dir),
         "memory_handoff_count": len(memory_handoffs),
+        "outbox_file_count": outbox_file_count,
         "outbox_handoff_count": len(outbox_handoffs),
+        "outbox_skipped_count": outbox_skipped_count,
         "handoff_count": len(handoffs),
         "github_health": github_health.to_dict(),
         "decisions": [asdict(item) for item in results],

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -2018,6 +2018,68 @@ def test_main_summary_only_omits_decisions_when_github_unavailable(
     }
 
 
+def test_main_summary_only_reports_outbox_files_skipped_before_publish(
+    monkeypatch: Any, tmp_path: Path, capsys
+) -> None:
+    outbox = tmp_path / ".aragora" / "automation-outbox"
+    receipts = tmp_path / ".aragora" / "automation-receipts"
+    outbox.mkdir(parents=True)
+    receipts.mkdir(parents=True)
+    (outbox / "active.json").write_text(
+        json.dumps(
+            _outbox_payload(
+                idempotency_key="open-pr-active",
+                expires_at=None,
+            )
+        ),
+        encoding="utf-8",
+    )
+    (outbox / "expired.json").write_text(
+        json.dumps(
+            _outbox_payload(
+                idempotency_key="open-pr-expired",
+                expires_at="2026-04-24T15:00:00+00:00",
+            )
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mod, "_repo_root", lambda path: tmp_path)
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda repo_root: GitHubCLIHealth(
+            ready=False,
+            auth_ok=True,
+            api_ok=False,
+            mode="connectivity_failed",
+            error="error connecting to api.github.com",
+            repo=str(tmp_path),
+        ),
+    )
+
+    exit_code = mod.main(
+        [
+            "--repo",
+            str(tmp_path),
+            "--codex-home",
+            str(tmp_path),
+            "--outbox-dir",
+            str(outbox),
+            "--receipt-dir",
+            str(receipts),
+            "--json",
+            "--summary-only",
+        ]
+    )
+
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["outbox_file_count"] == 2
+    assert payload["outbox_handoff_count"] == 1
+    assert payload["outbox_skipped_count"] == 1
+    assert payload["handoff_count"] == 1
+
+
 def test_main_reports_stale_outbox_head_when_github_unavailable(
     monkeypatch: Any, tmp_path: Path, capsys: Any
 ) -> None:


### PR DESCRIPTION
## Summary
- surface raw outbox file count and skipped-file count in publisher summary output
- add regression coverage for files skipped before publication decisions

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/scripts/test_publish_automation_handoffs.py::test_main_summary_only_reports_outbox_files_skipped_before_publish
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/scripts/test_publish_automation_handoffs.py
- python3 -m ruff check scripts/publish_automation_handoffs.py tests/scripts/test_publish_automation_handoffs.py
- python3 -m ruff format --check scripts/publish_automation_handoffs.py tests/scripts/test_publish_automation_handoffs.py
- python3 scripts/publish_automation_handoffs.py --repo /private/tmp/aragora-publisher-outbox-skipped-counts-harvest-20260531T1037Z --state-root /Users/armand/Development/aragora --dry-run --json --summary-only --limit 5 (exited 1 on expected github_unavailable; summary included outbox_file_count=104, outbox_handoff_count=102, outbox_skipped_count=2)
- git diff --check origin/main...HEAD && git rev-list --left-right --count origin/main...HEAD && git cherry -v origin/main HEAD && git merge-tree --write-tree origin/main HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD