### PR TITLE
fix(publisher): cache local queue on remote query failure

### DIFF
--- a/scripts/cache_codex_automation_github_status.py
+++ b/scripts/cache_codex_automation_github_status.py
@@ -510,6 +510,16 @@ def _merge_state_counts(open_prs: list[dict[str, Any]]) -> dict[str, int]:
     return counts
 
 
+def _github_queue_unavailable(*, reason: str, error: str | None = None) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "available": False,
+        "reason": reason,
+    }
+    if error:
+        payload["error"] = error
+    return payload
+
+
 def build_status(
     *,
     repo_root: Path,
@@ -538,15 +548,20 @@ def build_status(
     }
 
     if not health.ready:
-        payload["github_queue"] = {
-            "available": False,
-            "reason": health.mode,
-        }
+        payload["github_queue"] = _github_queue_unavailable(reason=health.mode)
         return payload
 
-    open_prs = _open_codex_prs(repo_root, github_repo)
+    try:
+        open_prs = _open_codex_prs(repo_root, github_repo)
+        open_issue_count = _open_boss_ready_count(repo_root, github_repo, list(labels))
+    except RuntimeError as exc:
+        payload["github_queue"] = _github_queue_unavailable(
+            reason="remote_query_failed",
+            error=str(exc),
+        )
+        return payload
+
     unhealthy_open_pr_count = sum(1 for item in open_prs if _open_codex_pr_is_unhealthy(item))
-    open_issue_count = _open_boss_ready_count(repo_root, github_repo, list(labels))
     payload["github_queue"] = {
         "available": True,
         "open_codex_pr_count": len(open_prs),

--- a/tests/scripts/test_cache_codex_automation_github_status.py
+++ b/tests/scripts/test_cache_codex_automation_github_status.py
@@ -53,6 +53,52 @@ def test_build_status_uses_local_queue_when_github_unavailable(
     assert payload["local_queue"]["unreceipted_outbox_count"] == 1
 
 
+def test_build_status_keeps_local_queue_when_remote_query_fails(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    outbox = tmp_path / ".aragora" / "automation-outbox"
+    receipts = tmp_path / ".aragora" / "automation-receipts"
+    outbox.mkdir(parents=True)
+    receipts.mkdir(parents=True)
+    (outbox / "open-pr-example.json").write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda repo_root: GitHubCLIHealth(
+            ready=True,
+            auth_ok=True,
+            api_ok=True,
+            mode="ready",
+            error="",
+            repo=str(repo_root),
+        ),
+    )
+    monkeypatch.setattr(
+        mod,
+        "_open_codex_prs",
+        lambda repo_root, repo: (_ for _ in ()).throw(RuntimeError("HTTP 504")),
+    )
+
+    payload = mod.build_status(
+        repo_root=tmp_path,
+        github_repo="synaptent/aragora",
+        labels=["boss-ready"],
+        max_open_prs=12,
+        max_open_issues=16,
+    )
+
+    assert payload["github_health"]["ready"] is True
+    assert payload["github_queue"] == {
+        "available": False,
+        "reason": "remote_query_failed",
+        "error": "HTTP 504",
+    }
+    assert payload["local_queue"]["outbox_count"] == 1
+    assert payload["local_queue"]["unreceipted_outbox_count"] == 1
+
+
 def test_local_queue_state_matches_receipts_by_idempotency_key(tmp_path: Path) -> None:
     outbox = tmp_path / ".aragora" / "automation-outbox"
     receipts = tmp_path / ".aragora" / "automation-receipts"


### PR DESCRIPTION
## Summary
- Keep cache_codex_automation_github_status from aborting when GitHub health is ready but the remote queue query fails later.
- Emit a degraded github_queue payload with reason=remote_query_failed while still writing fresh local queue counts.
- Add regression coverage for the HTTP 504-style partial failure path.

## Validation
- python3 -m pytest tests/scripts/test_cache_codex_automation_github_status.py -q
- python3 -m ruff check scripts/cache_codex_automation_github_status.py tests/scripts/test_cache_codex_automation_github_status.py
- python3 -m ruff format --check scripts/cache_codex_automation_github_status.py tests/scripts/test_cache_codex_automation_github_status.py
- git diff --check
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- Real cache refresh against current repo now writes local_queue outbox=103 despite GitHub GraphQL HTTP 504, and publisher_freshness_check reports ready with drift outbox=103 cache=103.