### PR TITLE
docs(governance): harvest ADC follow-on packet

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -15,9 +15,9 @@
 | Python files under aragora/ | `4149` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
 | Python lines of code under aragora/ | `1945922` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `141` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5241` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `219228` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
-| @pytest.mark.parametrize decorators | `708` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
+| Test files (test_*.py under tests/) | `5242` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `219236` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| @pytest.mark.parametrize decorators | `712` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `71` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2870` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
 | OpenAPI operations (HTTP verbs) | `3297` | `docs/api/openapi.json` | `python -c "import json; spec=json.load(open('docs/api/openapi.json')); print(sum(1 for p in spec['paths'].values() for m in p if m.lower() in {'get','post','put','delete','patch','head','options'}))"` |
@@ -28,7 +28,7 @@
 | Allowlisted agent types | `35` | `aragora/config/settings.py` | `grep -A 50 'ALLOWED_AGENT_TYPES' aragora/config/settings.py \| grep -oE "'[a-z-]+'" \| sort -u \| wc -l` |
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `46` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |
-| Markdown files under docs/ | `968` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
+| Markdown files under docs/ | `975` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
 | GitHub Actions workflows | `86` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
 | Mypy baseline errors (grandfathered) | `3115` | `.mypy-baseline` | `wc -l .mypy-baseline` |
 

--- a/docs/governance/ADC_BASE_STACK_INTEGRATION_REVIEW_2026-05-19.md
+++ b/docs/governance/ADC_BASE_STACK_INTEGRATION_REVIEW_2026-05-19.md
@@ -1,0 +1,194 @@
+# ADC Base Stack Integration Review — 2026-05-19
+
+**Status:** operator review aid
+**Scope:** ADC `#7361`, `#7358`, `#7360`, and packet PR `#7367`
+**Branch:** `codex/adc-follow-on-deepening-20260519`
+**No operator gate crossed:** no merges, labels, mark-ready, branch edits, or dispatches.
+
+## Current PR truth
+
+Read-only verification found the base stack stable:
+
+| PR | Role | State | Draft | Head | Mergeability | Review | Check rollup |
+|---|---|---:|---:|---|---|---|---|
+| `#7358` | v0.2 lane-registry attachment | OPEN | yes | `d926a9749f23b8ac097a2ec8573df7e63a11f738` | MERGEABLE / BLOCKED | REVIEW_REQUIRED | 4 success, 2 skipped, 0 fail |
+| `#7360` | v0.3 progress ledger evaluator | OPEN | yes | `7b0cf9ea426fe2cc78b3e7298f1db7618931a8db` | MERGEABLE / BLOCKED | REVIEW_REQUIRED | 17 success, 53 skipped, 0 fail |
+| `#7361` | v0.4 HMAC signing | OPEN | yes | `9093ddbc48ac4dd2ccaa3364b527b660c089a41e` | MERGEABLE / BLOCKED | REVIEW_REQUIRED | 16 success, 52 skipped, 0 fail |
+| `#7367` | continuation/readiness packet | OPEN | yes | `a1e9949a1975d61a489c7960e8618858862d827a` | MERGEABLE / BLOCKED | REVIEW_REQUIRED | 15 success, 20 skipped, 0 fail |
+
+Verdict: stable. `#7361` and `#7367` heads match the prior READY_FOR_OPERATOR_REVIEW packet.
+
+## Semantic stack
+
+```mermaid
+flowchart TD
+    A[v0.1 schema] --> B[v0.4 signing]
+    A --> C[v0.2 lane]
+    A --> D[v0.3 progress]
+    B --> E[v0.7 lifecycle]
+    C --> E
+    D --> E
+    E --> F[v0.8 adapter]
+```
+
+Legend: v0.1 is already on `main`; v0.4 signs contracts/receipts; v0.2 binds contracts into lane claims; v0.3 evaluates goal progress; v0.7 will add pause/halt/revoke; v0.8 will propagate contracts across worker families.
+
+## File-overlap map
+
+Current `main` already contains the v0.1 trust kernel. Some PR UI diffs include v0.1 files because the branches were cut before v0.1 landed; compare against current `origin/main` before deciding conflicts.
+
+| File | `#7358` v0.2 | `#7360` v0.3 | `#7361` v0.4 | Integration note |
+|---|---|---|---|---|
+| `aragora/policy/__init__.py` | no net change vs current `main` | no net change vs current `main` | adds signing exports | Hotspot if stale branches replay old v0.1 hunks after v0.4 lands. |
+| `aragora/policy/delegation_contract.py` | no net change vs current `main` | no net change vs current `main` | relaxes v0.1 `signature is None` rule and adds `DelegationContract.is_signed` | v0.4 must preserve v0.1 validation while enabling signed payloads. |
+| `aragora/policy/predicate_oracle.py` | no net change vs current `main` | no net change vs current `main` | no net change vs current `main` | No expected conflict. |
+| `scripts/claim_active_agent_lane.py` | adds contract fields and parent/root checks | no net change vs current `main` | no net change vs current `main` | Unique v0.2 surface; watch `_KNOWN_FIELDS`, `claim_lane`, parser, and main. |
+| `scripts/evaluate_goal_progress.py` | — | new script | — | Unique v0.3 surface. |
+| `scripts/sign_delegation_contract.py` | — | — | new script | Unique v0.4 surface. |
+| `tests/policy/test_delegation_contract.py` | no net change vs current `main` | no net change vs current `main` | replaces v0.1 signature rejection with v0.4 signature tests | Expected semantic shift after v0.4. |
+| `tests/policy/test_contract_signing.py` | — | — | new signing tests | Unique v0.4 surface. |
+| `tests/scripts/test_claim_active_agent_lane.py` | adds contract-field tests | no net change vs current `main` | no net change vs current `main` | Unique v0.2 surface. |
+| `tests/scripts/test_evaluate_goal_progress.py` | — | new evaluator tests | — | Unique v0.3 surface. |
+| `tests/scripts/test_sign_delegation_contract.py` | — | — | new signing CLI tests | Unique v0.4 surface. |
+
+## Merge-order risk analysis
+
+The operator-facing gate remains:
+
+```text
+#7361 → {#7358, #7360}
+```
+
+That order makes semantic sense because signed contracts/receipts become available before downstream lifecycle and adapter work. It has one mechanical caveat: after `#7361` lands, GitHub must re-evaluate `#7358` and `#7360` against the new base. They are mergeable against current `main` now, but a post-v0.4 base may force a rebase if their stale v0.1 file hunks are still present.
+
+Recommended operator posture:
+
+1. merge/review `#7361`;
+2. immediately re-check `#7358` and `#7360` mergeability and checks;
+3. if either becomes `DIRTY`/`CONFLICTING`, ask that branch owner to rebase without changing scope;
+4. merge/review `#7358` and `#7360` once they are again `MERGEABLE` and green.
+
+Do not let an agent auto-merge or auto-rebase the base-stack branches unless the operator explicitly delegates that branch.
+
+## Known semantic risks
+
+### v0.4 signing environment sensitivity
+
+`#7361` appears to make validation sensitive to signing-key availability. If `ARAGORA_CONTEXT_SIGNING_KEY` is set in a local or CI environment, validation paths may verify signatures that unsigned tests did not previously exercise.
+
+Mitigation:
+
+- run signing tests with `env -u ARAGORA_CONTEXT_SIGNING_KEY` first;
+- add a second keyed smoke if the signing PR provides deterministic fixture keys;
+- ensure v0.7/v0.8 prompts require explicit signed/unsigned dry-run policy.
+
+### v0.2 force semantics
+
+`#7358` reportedly adds parent/root contract fields to the lane registry. Review notes indicate possible mismatch between help text and behavior: `--force` may override a missing parent but not a mismatched `root_intent_id`.
+
+Mitigation:
+
+- verify tests cover missing parent, mismatched root intent, and `--force`;
+- if behavior is intentionally stricter than help text, update the help text before merge.
+
+### v0.3 progress ledger application
+
+`#7360` should remain read-only unless `--apply` is passed. The evaluator must not silently mutate `.aragora/progress-ledger/*.jsonl` during dry-run or validation.
+
+Mitigation:
+
+- run dry-run tests first;
+- inspect generated ledger path behavior;
+- confirm no untracked ledger artifacts are created during post-merge tests unless explicitly requested.
+
+## Post-merge validation commands
+
+Run from a clean `main` checkout after each merge.
+
+### After `#7361`
+
+```bash
+python -m py_compile aragora/policy/contract_signing.py scripts/sign_delegation_contract.py
+env -u ARAGORA_CONTEXT_SIGNING_KEY python -m pytest \
+  tests/policy/test_contract_signing.py \
+  tests/policy/test_delegation_contract.py \
+  tests/scripts/test_sign_delegation_contract.py \
+  -q
+```
+
+Then re-check downstream PRs:
+
+```bash
+gh pr view 7358 --json headRefOid,mergeable,mergeStateStatus,reviewDecision
+gh pr view 7360 --json headRefOid,mergeable,mergeStateStatus,reviewDecision
+gh pr checks 7358
+gh pr checks 7360
+```
+
+### After `#7358`
+
+```bash
+python -m py_compile scripts/claim_active_agent_lane.py
+python -m pytest \
+  tests/scripts/test_claim_active_agent_lane.py \
+  tests/policy/test_delegation_contract.py \
+  tests/policy/test_predicate_oracle.py \
+  -q
+```
+
+### After `#7360`
+
+```bash
+python -m py_compile scripts/evaluate_goal_progress.py
+python -m pytest \
+  tests/scripts/test_evaluate_goal_progress.py \
+  tests/policy/test_predicate_oracle.py \
+  tests/policy/test_delegation_contract.py \
+  -q
+```
+
+### Final stack smoke
+
+```bash
+python -m pytest \
+  tests/policy/test_delegation_contract.py \
+  tests/policy/test_predicate_oracle.py \
+  tests/policy/test_contract_signing.py \
+  tests/scripts/test_claim_active_agent_lane.py \
+  tests/scripts/test_evaluate_goal_progress.py \
+  tests/scripts/test_sign_delegation_contract.py \
+  -q
+```
+
+## Rollback / revert guidance
+
+If all three base PRs land and a stack-level issue appears, revert in reverse semantic order:
+
+```text
+#7360 or #7358 if isolated → #7361 last if signing caused the failure
+```
+
+Detailed guidance:
+
+- Reverting `#7358` removes lane-contract fields and CLI flags. Do not delete existing lane-registry rows or JSON artifacts without explicit operator approval.
+- Reverting `#7360` removes the progress evaluator. Do not delete any `.aragora/progress-ledger/*.jsonl` artifacts unless the operator explicitly names them.
+- Reverting `#7361` restores unsigned-only validation. Signed contract/receipt artifacts created after v0.4 may fail validation after revert unless downstream readers tolerate stripped signatures.
+
+## Operator checklist
+
+- [ ] Read `#7361` diff and confirm signing-key handling is acceptable.
+- [ ] Merge/review `#7361`.
+- [ ] Re-check `#7358` and `#7360` mergeability/checks.
+- [ ] Ask branch owners to rebase if either downstream PR becomes dirty.
+- [ ] Merge/review `#7358` and `#7360` once clean.
+- [ ] Run the final stack smoke.
+- [ ] Only after all base PRs are on `main`, consider v0.7 dispatch.
+
+## Stop conditions
+
+Stop and do not dispatch v0.7 if any of these occur:
+
+- `#7361`, `#7358`, or `#7360` develops failing checks;
+- a downstream PR becomes `CONFLICTING`/`DIRTY` after `#7361`;
+- signing validation depends on unavailable or non-deterministic secrets in CI;
+- the operator has not explicitly authorized v0.7 after the base stack lands.

--- a/docs/governance/ADC_OPERATOR_POSTMERGE_RUNBOOK_2026-05-19.md
+++ b/docs/governance/ADC_OPERATOR_POSTMERGE_RUNBOOK_2026-05-19.md
@@ -1,0 +1,173 @@
+# ADC Operator Post-Merge Runbook — 2026-05-19
+
+**Status:** operator runbook
+**Scope:** what to do after `#7361`, `#7358`, and `#7360` land
+**No automation executed:** this document is a checklist, not a dispatch.
+
+## Decision gate
+
+Current gate remains:
+
+```text
+merge/review #7361 → re-check #7358/#7360 → merge/review #7358 and #7360 → authorize v0.7
+```
+
+Do not run v0.7 dispatch helpers before the base stack is present on `main`.
+
+## Pre-merge read-only checks
+
+```bash
+for pr in 7361 7358 7360 7367; do
+  gh pr view "$pr" --json number,state,isDraft,headRefOid,mergeable,mergeStateStatus,reviewDecision,title,url
+  gh pr checks "$pr"
+done
+```
+
+Expected before merge:
+
+- `#7361` head `9093ddbc48ac4dd2ccaa3364b527b660c089a41e`
+- `#7358` head `d926a9749f23b8ac097a2ec8573df7e63a11f738`
+- `#7360` head `7b0cf9ea426fe2cc78b3e7298f1db7618931a8db`
+- no failing checks
+- review/merge blocks only
+
+## Merge step 1 — v0.4 signing
+
+Merge/review `#7361`.
+
+After it lands:
+
+```bash
+git fetch origin main
+git checkout main
+git pull --ff-only origin main
+
+python -m py_compile aragora/policy/contract_signing.py scripts/sign_delegation_contract.py
+env -u ARAGORA_CONTEXT_SIGNING_KEY python -m pytest \
+  tests/policy/test_contract_signing.py \
+  tests/policy/test_delegation_contract.py \
+  tests/scripts/test_sign_delegation_contract.py \
+  -q
+```
+
+If these fail, stop before merging v0.2/v0.3 and ask the v0.4 owner to repair.
+
+## Re-check downstream PRs
+
+```bash
+for pr in 7358 7360; do
+  gh pr view "$pr" --json number,state,isDraft,headRefOid,mergeable,mergeStateStatus,reviewDecision,title,url
+  gh pr checks "$pr"
+done
+```
+
+If either is no longer `MERGEABLE` or has failing checks:
+
+1. do not merge it;
+2. ask its owner to rebase/repair only that branch;
+3. re-run the post-repair checks.
+
+## Merge step 2 — v0.2 lane registry
+
+Merge/review `#7358` once it is clean.
+
+Post-merge:
+
+```bash
+git fetch origin main
+git checkout main
+git pull --ff-only origin main
+
+python -m py_compile scripts/claim_active_agent_lane.py
+python -m pytest \
+  tests/scripts/test_claim_active_agent_lane.py \
+  tests/policy/test_delegation_contract.py \
+  tests/policy/test_predicate_oracle.py \
+  -q
+```
+
+If the test suite creates lane registry artifacts, inspect them before cleanup and do not delete untracked files unless they are exact temp/test artifacts and the operator approves.
+
+## Merge step 3 — v0.3 progress ledger
+
+Merge/review `#7360` once it is clean.
+
+Post-merge:
+
+```bash
+git fetch origin main
+git checkout main
+git pull --ff-only origin main
+
+python -m py_compile scripts/evaluate_goal_progress.py
+python -m pytest \
+  tests/scripts/test_evaluate_goal_progress.py \
+  tests/policy/test_predicate_oracle.py \
+  tests/policy/test_delegation_contract.py \
+  -q
+```
+
+Confirm dry-run mode does not write `.aragora/progress-ledger/*.jsonl` unless `--apply` is explicitly passed.
+
+## Final base-stack smoke
+
+```bash
+python -m pytest \
+  tests/policy/test_delegation_contract.py \
+  tests/policy/test_predicate_oracle.py \
+  tests/policy/test_contract_signing.py \
+  tests/scripts/test_claim_active_agent_lane.py \
+  tests/scripts/test_evaluate_goal_progress.py \
+  tests/scripts/test_sign_delegation_contract.py \
+  -q
+```
+
+Optional import smoke:
+
+```bash
+python - <<'PY'
+from aragora.policy import DelegationContract, GoalSpec, evaluate_predicate
+from aragora.policy import sign_contract, verify_contract, sign_receipt, verify_receipt
+print("ADC base stack imports ok")
+PY
+```
+
+## v0.7 dispatch preflight
+
+Only after the final base-stack smoke passes:
+
+1. locate or recreate `.aragora/v16-dispatch/dispatch-adc-v0.7.sh`;
+2. run `bash -n .aragora/v16-dispatch/dispatch-adc-v0.7.sh`;
+3. ensure local prompt exists:
+
+```bash
+test -f "$HOME/.factory/specs/2026-05-19-adc-v0.7-three-tier-reversibility-droid-prompt.md"
+```
+
+4. inspect the helper output;
+5. run it only if the operator is intentionally authorizing v0.7.
+
+The helper should refuse unless all three base PRs are `MERGED`.
+
+## Rollback routing
+
+If a post-merge issue is isolated:
+
+| Failing surface | First rollback candidate |
+|---|---|
+| signing/import/signature validation | `#7361` |
+| lane claim fields/registry metadata | `#7358` |
+| progress ticks/ledger application | `#7360` |
+| docs only | `#7367` or follow-on docs PR |
+
+If all three landed and the issue is systemic, revert newest causal merge first, then work backward. Do not delete generated lane/progress JSONL artifacts without explicit operator approval.
+
+## Stop conditions
+
+Stop and request operator direction if:
+
+- a post-merge validation command fails;
+- a downstream PR becomes `DIRTY`/`CONFLICTING`;
+- signing behavior depends on a secret only present on one machine;
+- the v0.7 helper is missing and cannot be reconstructed from the preservation doc;
+- any automation proposes a merge, label, mark-ready, force-push, or dispatch without explicit operator approval.

--- a/docs/governance/ADC_PARKED_ARTIFACTS_PRESERVATION_2026-05-19.md
+++ b/docs/governance/ADC_PARKED_ARTIFACTS_PRESERVATION_2026-05-19.md
@@ -1,0 +1,181 @@
+# ADC Parked Artifact Preservation — 2026-05-19
+
+**Status:** preservation packet only
+**Source worktree:** `/Users/armand/Development/aragora/.worktrees/codex-auto/droid-20260519-151711-92e43188`
+**Target branch:** `codex/adc-follow-on-deepening-20260519`
+**Operator gate:** no v0.7/v0.8 dispatch until `#7361 → {#7358, #7360}` lands on `main`
+
+## Purpose
+
+Claude could not physically inspect Factory's gitignored v0.7/v0.8 artifacts from its checkout. This packet records where those artifacts were found, their hashes, their validation status, and enough safe reconstruction detail that the operator can recover them later without relying on hidden workspace memory.
+
+No ignored executable artifact is committed by this packet. This document is a non-executable preservation/reconstruction note.
+
+## Located artifacts
+
+| Artifact | Located | SHA-256 | Validation |
+|---|---:|---|---|
+| `.aragora/v16-dispatch/dispatch-adc-v0.7.sh` | yes | `03751114711df883bb7650b2b6533a42aa6a570c10d63d9fc5b140fc7a96a48e` | `bash -n` passed |
+| `.aragora/v16-dispatch/ADC-v0.8-envelope-and-validator.md` | yes | `15e2821cf13655b80f13204c156e348e3d30acb7d40b28556c3c0080f4e680e5` | read-only inspected |
+| `.aragora/v16-dispatch/ADC-v0.8-droid-adapter.md` | yes | `b2930117f7c7f5f8970e649299b9ed98d0c776536f7f2f5f2c06766ac41cba15` | read-only inspected |
+| `.aragora/v16-dispatch/ADC-v0.8-claude-codex-stubs.md` | yes | `e5f34ef1a582b0af724a285f66e50052cd6b199f4f784e8f17b8d32b0e857ea1` | read-only inspected |
+
+## v0.7 dispatch helper behavior
+
+The helper is intentionally interactive and fail-closed:
+
+1. resolves `REPO_ROOT` from `.aragora/v16-dispatch`;
+2. points at local hardened prompt `$HOME/.factory/specs/2026-05-19-adc-v0.7-three-tier-reversibility-droid-prompt.md`;
+3. refuses unless PRs `#7361`, `#7358`, and `#7360` are `MERGED`;
+4. refuses if the prompt is missing;
+5. refuses if `.aragora/v13-dispatch/launch_lane.sh` is missing or non-executable;
+6. prints the exact launch command;
+7. requires the operator to type `DISPATCH`;
+8. only then runs `bash .aragora/v13-dispatch/launch_lane.sh ADC-v0.7-three-tier-reversibility <prompt>`.
+
+Reconstruction script:
+
+```bash
+mkdir -p .aragora/v16-dispatch
+cat > .aragora/v16-dispatch/dispatch-adc-v0.7.sh <<'EOF'
+#!/usr/bin/env bash
+# Operator instruction: run this only AFTER #7361, #7358, and #7360 are merged to main.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PROMPT="$HOME/.factory/specs/2026-05-19-adc-v0.7-three-tier-reversibility-droid-prompt.md"
+LANE_ID="ADC-v0.7-three-tier-reversibility"
+
+cd "$REPO_ROOT"
+
+echo "ADC v0.7 dispatch preview"
+echo "repo: $REPO_ROOT"
+echo "lane: $LANE_ID"
+echo "prompt: $PROMPT"
+echo
+echo "Checking base stack is merged..."
+
+for pr in 7361 7358 7360; do
+  state="$(gh pr view "$pr" --json state --jq .state)"
+  if [[ "$state" != "MERGED" ]]; then
+    echo "REFUSING: PR #$pr is $state, expected MERGED." >&2
+    exit 1
+  fi
+done
+
+if [[ ! -f "$PROMPT" ]]; then
+  echo "REFUSING: prompt missing: $PROMPT" >&2
+  exit 1
+fi
+
+if [[ ! -x ".aragora/v13-dispatch/launch_lane.sh" ]]; then
+  echo "REFUSING: launcher missing or not executable: .aragora/v13-dispatch/launch_lane.sh" >&2
+  exit 1
+fi
+
+echo "Base stack merged. This will launch one droid worker via:"
+echo "  bash .aragora/v13-dispatch/launch_lane.sh $LANE_ID $PROMPT"
+echo
+read -r -p "Type DISPATCH to launch ADC v0.7: " answer
+if [[ "$answer" != "DISPATCH" ]]; then
+  echo "Aborted."
+  exit 0
+fi
+
+bash .aragora/v13-dispatch/launch_lane.sh "$LANE_ID" "$PROMPT"
+EOF
+chmod +x .aragora/v16-dispatch/dispatch-adc-v0.7.sh
+bash -n .aragora/v16-dispatch/dispatch-adc-v0.7.sh
+```
+
+## v0.8 prompt pack summary
+
+All three parked v0.8 prompts carry the same hard gate:
+
+> Do not dispatch until ADC v0.7 has shipped or the operator explicitly waives that prerequisite.
+
+### Envelope + validator
+
+Lane: `ADC-v0.8-envelope-and-validator`
+
+Safe deliverables captured:
+
+- `aragora/policy/contract_envelope.py` with `ContractEnvelope`, canonical JSON load/dump, schema validation, signing verification via ADC v0.4, and lifecycle refusal via ADC v0.7.
+- `scripts/validate_parent_contract.py` with `--parent-contract PATH`, `--json`, and clear non-zero exits for invalid, paused, halted, revoked, or unsigned-disallowed contracts.
+- Tests for valid signed envelopes, unsigned dry-run envelopes, malformed schema, permission intersection, and paused/halted/revoked refusal.
+
+Important drift note already fixed in the parked prompt:
+
+> `docs/governance/ADC_v0.8_CROSS_FAMILY_ADAPTER_PLAN.md` is carried by PR #7367 and is not on `main` until #7367 lands. If this prompt is dispatched before #7367 merges, copy the plan document into the integration branch/worktree first or keep this prompt self-contained.
+
+### Droid adapter
+
+Lane: `ADC-v0.8-droid-adapter`
+
+Safe deliverables captured:
+
+- `scripts/launch_contract_bound_droid.py`;
+- flags `--lane-id`, `--prompt`, `--parent-contract`, `--dry-run`;
+- fail-closed parent envelope validation before launch;
+- effective permission intersection;
+- copied `ADC_PARENT_CONTRACT.json` in child worktree;
+- exported `ARAGORA_PARENT_CONTRACT`, `ARAGORA_DELEGATION_CONTRACT_ID`, `ARAGORA_GOAL_ID`, `ARAGORA_CONTRACT_ENVELOPE_ID`;
+- worker-instruction prelude requiring lane claim and receipt binding.
+
+### Claude/Codex stubs
+
+Lane: `ADC-v0.8-claude-codex-stubs`
+
+Safe deliverables captured:
+
+- validation examples for Claude Code startup, Codex CLI worker startup, and Codex Desktop/rollout metadata binding where available;
+- explicit limitation text: these stubs validate and record scope but do not intercept every tool call unless the underlying harness provides that boundary;
+- tests for validation behavior and receipt-field extraction.
+
+## Verified symbol references
+
+Current `main` provides:
+
+- `DelegationContract`
+- `GoalSpec`
+- `AcceptanceCriterion`
+- `AllowedSurfaces`
+- `ContractBudget`
+- `ContractValidationError`
+- `narrow_for_child`
+- `make_root_contract`
+- predicate-oracle helpers including `parse_predicate` and `evaluate_predicate`
+
+Rebased `#7361` provides:
+
+- `SIGNING_SCHEMA_VERSION`
+- `SigningError`
+- `VerificationError`
+- `VerificationResult`
+- `canonical_contract_payload`
+- `sign_contract`
+- `verify_contract`
+- `sign_receipt`
+- `verify_receipt`
+- `is_contract_signed`
+- `signing_key_available`
+
+Planned v0.7 symbols used by v0.8 prompts:
+
+- `get_contract_state`
+- `ContractState`
+
+These v0.7 symbols do not exist on `main` yet and must not be referenced by executable code until the lifecycle PR lands or the implementation guards imports behind explicit dependency checks.
+
+## Recovery checklist
+
+1. Confirm `#7361`, `#7358`, and `#7360` are merged to `main`.
+2. Recreate `.aragora/v16-dispatch/dispatch-adc-v0.7.sh` from the reconstruction block above if the prior worktree has been removed.
+3. Confirm the hardened local v0.7 prompt exists at `$HOME/.factory/specs/2026-05-19-adc-v0.7-three-tier-reversibility-droid-prompt.md`.
+4. Run `bash -n .aragora/v16-dispatch/dispatch-adc-v0.7.sh`.
+5. Review the staged command printed by the helper.
+6. Type `DISPATCH` only when the operator intentionally authorizes v0.7.
+
+## Boundaries observed
+
+This preservation pass did not execute the dispatch helper, did not create a child worker, did not modify ignored artifacts, did not mutate GitHub, and did not edit protected files.

--- a/docs/governance/ADC_PARKED_IMPLEMENTATION_PROMPTS_2026-05-19.md
+++ b/docs/governance/ADC_PARKED_IMPLEMENTATION_PROMPTS_2026-05-19.md
@@ -1,0 +1,258 @@
+# PARKED — ADC Implementation Prompt Pack — 2026-05-19
+
+**Status:** parked prompts only
+**Do not dispatch from this document without operator approval.**
+**Global boundaries:** no merges, no labels, no mark-ready, no protected-file edits, no destructive cleanup, no force-push, no branch mutation outside the assigned implementation branch.
+
+## PARKED prompt — ADC v0.7 lifecycle
+
+```text
+You are implementing ADC v0.7 Three-Tier Reversibility for Aragora.
+
+Prerequisite gate:
+- Refuse to proceed unless #7361, #7358, and #7360 are merged to main, or the operator explicitly names an integration branch containing v0.1-v0.4.
+- Do not dispatch subagents unless the operator explicitly authorizes them.
+
+Goal:
+Implement lifecycle pause/halt/revoke for Delegation Contracts without process killing.
+
+Deliverables:
+1. aragora/policy/contract_lifecycle.py
+   - LifecycleEvent
+   - LifecycleDecision
+   - ContractState
+   - append-only JSONL load/reduce helpers
+   - pause/resume/halt/revoke event builders
+   - fail-closed lifecycle evaluator
+2. scripts/update_contract_lifecycle.py
+   - --contract PATH
+   - --event pause|resume|halt|revoke
+   - --reason TEXT
+   - --actor TEXT
+   - --ledger PATH
+   - --dry-run
+   - --json
+3. scripts/check_contract_lifecycle.py
+   - --contract PATH
+   - --action-class read|bounded_write|shared_state|delegation|destructive
+   - --ledger PATH
+   - documented exit codes
+4. Tests:
+   - tests/policy/test_contract_lifecycle.py
+   - tests/scripts/test_update_contract_lifecycle.py
+   - tests/scripts/test_check_contract_lifecycle.py
+
+Required behavior:
+- active permits actions only if the contract permits them.
+- paused denies writes/spawns but allows audit reads.
+- halted and revoked are terminal for writes/spawns.
+- revoked outranks halt, pause, and resume.
+- unreadable lifecycle ledger fails closed for writes/spawns.
+- v0.4 signing is used for lifecycle receipts when present.
+- missing v0.4 signing support refuses signed-required mode.
+
+Validation:
+- python -m pytest tests/policy/test_contract_lifecycle.py tests/scripts/test_update_contract_lifecycle.py tests/scripts/test_check_contract_lifecycle.py -q
+- git diff --check
+- project preflight before push.
+
+Open a draft PR only. Do not merge or mark ready.
+```
+
+## PARKED prompt — ADC v0.8 envelope + validator
+
+```text
+You are implementing ADC v0.8 envelope + validator for Aragora.
+
+Prerequisite gate:
+- Refuse to proceed unless ADC v0.7 lifecycle has shipped, or the operator explicitly waives that prerequisite.
+- Refuse signed-required mode unless #7361 signing symbols are present on the base branch.
+- If ADC_v0.8_CROSS_FAMILY_ADAPTER_PLAN.md is not present, carry it into the integration branch or keep the prompt self-contained.
+
+Goal:
+Implement the contract-on-disk envelope and parent-contract validation surface.
+
+Deliverables:
+1. aragora/policy/contract_envelope.py
+   - ContractEnvelope dataclass
+   - canonical JSON load/dump
+   - schema validation
+   - contract + goal extraction
+   - effective-scope intersection
+   - v0.4 signature verification when required
+   - v0.7 lifecycle validation when required
+2. scripts/validate_parent_contract.py
+   - --parent-contract PATH
+   - --action-class read|bounded_write|shared_state|delegation|destructive
+   - --require-signed
+   - --allow-unsigned-dry-run
+   - --require-lifecycle
+   - --json
+3. Tests:
+   - tests/policy/test_contract_envelope.py
+   - tests/scripts/test_validate_parent_contract.py
+
+Fail closed for:
+- malformed envelope
+- scope widening
+- expired contract
+- missing parent contract
+- unsigned contract in signed-required mode
+- paused/halted/revoked lifecycle state for worker launch
+- missing lifecycle support in lifecycle-required mode
+
+Validation:
+- python -m pytest tests/policy/test_contract_envelope.py tests/scripts/test_validate_parent_contract.py -q
+- git diff --check
+- project preflight before push.
+
+Open a draft PR only. Do not launch workers.
+```
+
+## PARKED prompt — ADC v0.8 Droid adapter
+
+```text
+You are implementing the ADC v0.8 contract-bound Factory Droid adapter.
+
+Prerequisite gate:
+- Refuse to proceed unless ADC v0.8 envelope + validator exists on the base branch.
+- Refuse real launches unless the operator explicitly authorizes them. Initial PR should support dry-run only.
+
+Goal:
+Make Droid launches accept --parent-contract and propagate validated contract scope into the child worktree.
+
+Deliverables:
+1. scripts/launch_contract_bound_droid.py
+   - --lane-id
+   - --prompt
+   - --parent-contract
+   - --dry-run
+   - --json
+2. Behavior:
+   - call validate_parent_contract before launch
+   - compute effective permissions by intersection
+   - copy envelope into child worktree as ADC_PARENT_CONTRACT.json
+   - export ARAGORA_PARENT_CONTRACT
+   - export ARAGORA_DELEGATION_CONTRACT_ID
+   - export ARAGORA_GOAL_ID
+   - export ARAGORA_CONTRACT_ENVELOPE_ID
+   - prepend worker instructions requiring lane claim and receipt binding
+3. Tests:
+   - tests/scripts/test_launch_contract_bound_droid.py
+   - relevant Droid harness tests
+
+Validation:
+- dry-run tests must prove exact launch plan without spawning a worker.
+- bash/python compile checks for scripts.
+- project preflight before push.
+
+Open a draft PR only. Do not dispatch a real Droid worker.
+```
+
+## PARKED prompt — ADC v0.8 Claude/Codex stubs
+
+```text
+You are implementing honest ADC v0.8 validation stubs for Claude Code and Codex surfaces.
+
+Prerequisite gate:
+- Refuse to proceed unless ADC v0.8 envelope + validator exists on the base branch.
+- Do not claim hard runtime tool-call interception unless the harness actually enforces it.
+
+Goal:
+Validate and record parent contracts at Claude/Codex startup surfaces without overclaiming enforcement.
+
+Deliverables:
+1. Startup integration examples for:
+   - Claude Code
+   - Codex CLI worker startup
+   - Codex Desktop / rollout metadata binding where available
+2. Docs or code comments that explicitly state:
+   - validates envelope
+   - prints effective scope
+   - records contract fields for receipts/lane claims
+   - does not intercept every tool call in Claude/Codex harnesses
+3. Tests:
+   - validation behavior
+   - receipt-field extraction
+   - limitation text present
+
+Validation:
+- python -m pytest relevant harness/stub tests -q
+- project preflight before push.
+
+Open a draft PR only.
+```
+
+## PARKED prompt — ADC v0.5 adversarial checks
+
+```text
+You are implementing ADC v0.5 Continuous Adversarial Verification.
+
+Prerequisite gate:
+- Prefer to wait until v0.7 and v0.8 exist.
+- If the operator authorizes an earlier slice, implement deterministic mock-first policy only.
+
+Goal:
+Create an action-boundary adversarial check that can halt or narrow unsafe proposed actions before they mutate state.
+
+Deliverables:
+1. aragora/policy/adversarial_check.py
+   - ActionCheckRequest
+   - ActionCheckVerdict
+   - ActionCheckReceipt
+   - StaticActionPolicy
+   - MockAdversarialReviewer
+2. scripts/evaluate_adversarial_action.py
+   - accepts JSON request
+   - emits JSON verdict
+   - no real model calls by default
+3. Tests:
+   - out-of-scope shared-state action returns HALT
+   - in-scope lane claim returns PROCEED
+   - destructive action without human approval returns HALT
+   - paused/halted/revoked lifecycle returns HALT
+   - pure read bypasses model reviewer
+   - receipt is append-only and deterministic
+
+Hard rule:
+No real model calls in the first implementation PR. Model-backed reviewers must be feature-flagged and disabled in CI.
+
+Open a draft PR only.
+```
+
+## PARKED prompt — ADC v0.6 trust multiplier
+
+```text
+You are implementing ADC v0.6 ELO Trust Multiplier.
+
+Prerequisite gate:
+- Prefer to wait until v0.5 action-check receipts exist.
+- If the operator authorizes an earlier slice, implement static trust-budget calculation only with synthetic receipts.
+
+Goal:
+Compute effective budget = min(contract_budget * trust_multiplier, operator_cap) per agent and action class, using receipt-backed trust deltas.
+
+Deliverables:
+1. aragora/policy/trust_multiplier.py
+   - TrustMultiplierRecord
+   - TrustUpdateEvent
+   - default policy table
+   - clamp/floor/ceiling math
+   - append-only JSONL reducer
+2. scripts/update_trust_multiplier.py
+   - consumes synthetic or v0.5 receipts
+   - emits append-only trust update
+   - --dry-run and --json
+3. Tests:
+   - defaults by action class
+   - green-check receipt increases within ceiling
+   - halt/revoke decreases
+   - self-reported progress alone does not update
+   - operator cap wins over trust expansion
+   - corrupt ledger fails closed for increases
+
+Hard rule:
+Trust multipliers never authorize an action denied by the contract, lifecycle state, destructive-action policy, or operator cap.
+
+Open a draft PR only.
+```

--- a/docs/governance/ADC_v0.5-v0.6_HARDENING_ADDENDUM.md
+++ b/docs/governance/ADC_v0.5-v0.6_HARDENING_ADDENDUM.md
@@ -1,0 +1,257 @@
+# ADC v0.5/v0.6 Hardening Addendum — 2026-05-19
+
+**Status:** addendum to PR #7367 drafts
+**Inputs reviewed:** `ADC_v0.5_SPEC_DRAFT.md` and `ADC_v0.6_SPEC_DRAFT.md` from PR #7367
+**Scope:** docs-only clarification; no implementation or model wiring.
+
+## Summary
+
+The v0.5/v0.6 drafts are directionally sound. This addendum tightens four details before implementation prompts are issued:
+
+1. v0.5 should define reviewer tiers without hard-coding vendor/model names.
+2. v0.5 must be deterministic and mock-first before real model reviewers are allowed.
+3. v0.6 needs explicit multiplier update math with floors, caps, and event weights.
+4. v0.6 trust deltas should flow from v0.5 action-check receipts, not self-reported progress.
+
+## v0.5 reviewer-tier policy
+
+Keep reviewer tiers configurable by capability class instead of naming specific commercial models in the spec.
+
+| Tier | Intended backend | Trigger | Output | Default authority |
+|---|---|---|---|---|
+| `T0_static` | pure policy code | every gated action | `PROCEED` / `HALT` with deterministic reason | may block |
+| `T1_cheap` | low-cost model or local classifier | shared-state, delegation, optional bounded writes | structured adversarial verdict | may pause contested action |
+| `T2_panel` | heterogeneous debate panel | worker disputes `T1_cheap` halt or confidence is low | `continue`, `narrow_scope`, `ask_human`, `halt` | may recommend, not override human gate |
+| `T3_operator` | human/operator | destructive actions, ambiguous safety, policy conflicts | explicit approval/denial | final authority |
+
+Implementation should expose model/provider selection through configuration:
+
+```json
+{
+  "schema_version": "aragora-adversarial-reviewer-policy/0.5",
+  "tiers": {
+    "T1_cheap": {
+      "backend": "configurable",
+      "max_cost_usd": 0.01,
+      "timeout_seconds": 20,
+      "fallback": "HALT"
+    },
+    "T2_panel": {
+      "backend": "configurable_heterogeneous_panel",
+      "min_families": 2,
+      "timeout_seconds": 120,
+      "fallback": "ask_human"
+    }
+  }
+}
+```
+
+The spec can mention examples in operator notes, but code and tests should never assume a specific model name.
+
+## v0.5 mock-first path
+
+The first implementation PR should not call real models. It should build:
+
+- `ActionCheckRequest`
+- `ActionCheckVerdict`
+- `StaticActionPolicy`
+- `MockAdversarialReviewer`
+- `ActionCheckReceipt`
+
+Minimum deterministic decision rules:
+
+| Condition | Verdict |
+|---|---|
+| action target outside allowed surfaces | `HALT` |
+| action class `destructive` without explicit human approval token | `HALT` |
+| action class `delegation` and `max_depth == 0` | `HALT` |
+| action class `delegation` and budget cannot fit child | `HALT` |
+| lifecycle state `paused`, `halted`, or `revoked` for write/spawn | `HALT` |
+| pure read action with no sensitive target | `PROCEED` |
+| bounded write inside worktree/file globs | `PROCEED` |
+
+Only after these deterministic tests pass should a feature-flagged real reviewer be added:
+
+```text
+ARAGORA_ADC_ADVERSARIAL_REVIEWER=mock|disabled|model
+```
+
+Default for tests and CI: `mock`.
+
+## v0.5 receipt minimum
+
+Every action check that gates an action should produce a receipt:
+
+```json
+{
+  "schema_version": "aragora-adversarial-action-receipt/0.5",
+  "request_id": "acr-...",
+  "contract_id": "adc-...",
+  "goal_id": "goal-...",
+  "actor_session": "droid-...",
+  "action_class": "shared_state",
+  "target_surface": "branch:codex/example",
+  "verdict": "HALT",
+  "reason": "target branch outside allowed_surfaces",
+  "tier": "T0_static",
+  "confidence": 1.0,
+  "reviewed_at_utc": "2026-05-19T00:00:00Z",
+  "source_refs": {
+    "contract_sha256": "...",
+    "lifecycle_event_sha256": "..."
+  },
+  "signature": null
+}
+```
+
+Receipts should be append-only and safe to feed into v0.6.
+
+## v0.6 trust update math
+
+Represent trust per `(agent_id, action_class)`.
+
+Definitions:
+
+```text
+base = current_multiplier(agent_id, action_class)
+delta = event_weight * severity_weight * evidence_confidence
+raw = base + delta
+next = clamp(raw, floor(action_class), ceiling(action_class))
+```
+
+Suggested event weights:
+
+| Event | Weight |
+|---|---:|
+| signed completion receipt with all ACs satisfied | `+0.10` |
+| draft PR opened with green checks | `+0.03` |
+| merged PR without revert after observation window | `+0.15` |
+| v0.5 `PROCEED` for shared-state action later validated by green checks | `+0.02` |
+| v0.5 `HALT` that worker accepted/narrowed | `-0.05` |
+| v0.5 `HALT` followed by attempted override without operator approval | `-0.20` |
+| failed checks after branch push | `-0.10` |
+| lifecycle `halt` | `-0.20` |
+| lifecycle `revoke` | `-0.50` |
+
+Suggested severity weights:
+
+| Action class | Severity |
+|---|---:|
+| `read` | `0.25` |
+| `bounded_write` | `0.75` |
+| `shared_state` | `1.00` |
+| `delegation` | `1.50` |
+| `destructive` | `2.00` |
+
+Positive deltas should be slower than negative deltas for risky classes. This asymmetry prevents one successful PR from immediately restoring delegation authority after a revoke/halt.
+
+## v0.6 floors and ceilings
+
+Carry forward the draft table, but make it configuration rather than code constants:
+
+| Action class | New-agent default | Floor | Ceiling |
+|---|---:|---:|---:|
+| `read` | `1.00` | `0.50` | `3.00` |
+| `bounded_write` | `0.75` | `0.25` | `2.00` |
+| `shared_state` | `0.50` | `0.10` | `1.50` |
+| `delegation` | `0.25` | `0.00` | `1.00` |
+| `destructive` | `0.10` | `0.00` | `0.25` |
+
+Effective budget stays capped by operator policy:
+
+```python
+effective_budget = min(
+    contract_budget * trust_multiplier,
+    operator_cap_for_action_class,
+)
+```
+
+Trust can reduce or modestly expand a contract budget, but cannot exceed the operator cap and cannot authorize a denied action.
+
+## v0.5 → v0.6 data flow
+
+```mermaid
+flowchart LR
+    A[Action request] --> B[v0.5 check]
+    B --> C[Check receipt]
+    C --> D[v0.6 update]
+    D --> E[Trust record]
+    E --> F[Effective budget]
+```
+
+The v0.6 updater should accept v0.5 receipts only when:
+
+- receipt schema is recognized;
+- contract id and goal id are present;
+- action class is present;
+- verdict is `PROCEED` or `HALT`;
+- source evidence is external or deterministic;
+- receipt is signed when signed mode is required.
+
+Self-reported worker progress may be included as context, but it must not directly change the trust multiplier.
+
+## v0.6 append-only trust ledger
+
+Suggested path:
+
+```text
+.aragora/delegation-contracts/trust-multiplier.jsonl
+```
+
+Suggested record:
+
+```json
+{
+  "schema_version": "aragora-adc-trust-update/0.6",
+  "agent_id": "droid-...",
+  "action_class": "shared_state",
+  "previous_multiplier": 0.5,
+  "delta": 0.03,
+  "next_multiplier": 0.53,
+  "floor": 0.1,
+  "ceiling": 1.5,
+  "source_event": {
+    "kind": "v0.5_action_check",
+    "receipt_sha256": "...",
+    "verdict": "PROCEED"
+  },
+  "updated_at_utc": "2026-05-19T00:00:00Z",
+  "reason": "shared-state action proceeded and checks later passed",
+  "signature": null
+}
+```
+
+## Anti-gaming requirements
+
+- The worker cannot update its own multiplier.
+- Trust updates require external receipts or deterministic checks.
+- Negative updates from `HALT`/`revoke` should apply before positive completion updates in the same time window.
+- Same-family self-review must be recorded in the receipt and should reduce evidence confidence.
+- Unknown receipt schemas are ignored, not guessed.
+- Missing ledger or corrupt ledger should fail closed for multiplier increases and fall back to floor/default for budget computation.
+
+## Implementation prompt guardrails
+
+Future v0.5/v0.6 implementation prompts should include:
+
+```text
+Do not call real models in the first implementation PR. Build deterministic
+mock-first surfaces, append-only receipts, and tests. Real reviewers and live
+trust updates must remain behind explicit feature flags and operator approval.
+```
+
+```text
+Do not let trust multipliers authorize actions forbidden by the Delegation
+Contract, lifecycle state, destructive-action policy, or operator cap.
+```
+
+## Acceptance additions
+
+Add these to the PR #7367 draft acceptance criteria before implementation:
+
+1. v0.5 has deterministic `T0_static` tests before mock/model reviewers.
+2. v0.5 real-model reviewer is feature-flagged and disabled in CI.
+3. v0.6 update math clamps to configured floor/ceiling.
+4. v0.6 negative deltas are applied before positive deltas in the same reduction window.
+5. v0.6 ignores self-reported progress unless backed by external evidence.
+6. v0.6 records the multiplier and source receipt in every dispatch receipt.

--- a/docs/governance/ADC_v0.7-v0.8_TEST_MATRIX_2026-05-19.md
+++ b/docs/governance/ADC_v0.7-v0.8_TEST_MATRIX_2026-05-19.md
@@ -1,0 +1,217 @@
+# ADC v0.7/v0.8 Test Matrix — 2026-05-19
+
+**Status:** fallback queue artifact
+**Scope:** planned tests after ADC base stack lands
+**No code changes included:** this matrix is an implementation planning aid.
+
+## Current coverage on `main`
+
+Current `main` has ADC v0.1 coverage:
+
+| Area | Existing file | Covered |
+|---|---|---|
+| contract schema/narrowing | `tests/policy/test_delegation_contract.py` | root validation, depth, child narrowing, budgets, destructive deny, expiry, surface containment, v0.1 unsigned-only rule |
+| predicate oracle | `tests/policy/test_predicate_oracle.py` | parser basics, filesystem predicates, PR/issue/branch/commit/test predicates with subprocess mocked |
+| lane registry | `tests/scripts/test_claim_active_agent_lane.py` | lane claim/refresh/conflict behavior, resource collision detection, stale release, CLI roundtrip |
+| agent bridge/launcher | `tests/scripts/test_agent_bridge.py`, `tests/scripts/test_agent_bridge_broker.py`, `tests/swarm/agent_bridge/*`, `tests/swarm/test_worker_launcher.py` | generic launch/harness behavior, not yet ADC-aware |
+
+Coverage gaps:
+
+- `GoalSpec.validate()` edge cases need direct tests.
+- `AllowedSurfaces.pr_numbers` and `worktree_globs` are lightly covered.
+- `ContractBudget` negative fields need complete coverage.
+- predicate parser needs quoted-comma and malformed-quote edge tests.
+- no lifecycle ledger/reducer tests exist.
+- no contract envelope/adapter tests exist.
+- no launcher fail-closed tests exist for missing/expired/unsigned/revoked parent contracts.
+
+## v0.7 lifecycle matrix
+
+Suggested file: `tests/policy/test_contract_lifecycle.py`
+
+| ID | Scenario | Expected |
+|---|---|---|
+| L1 | no events for valid contract | state `active` |
+| L2 | `pause` event | bounded/shared/delegation actions denied; audit reads allowed |
+| L3 | `resume` after `pause` | state `active`; actions evaluated by contract scope |
+| L4 | `halt` from `active` | terminal `halted`; writes/spawns denied |
+| L5 | `halt` from `paused` | terminal `halted`; resume denied |
+| L6 | `revoke` from `active` | terminal `revoked`; writes/spawns denied |
+| L7 | `revoke` after `halt` | state `revoked`; revoke outranks halt |
+| L8 | stale later `resume` after `revoke` | still `revoked` |
+| L9 | corrupt lifecycle ledger | write/spawn checks fail closed |
+| L10 | missing lifecycle ledger in required mode | write/spawn checks fail closed |
+| L11 | missing lifecycle ledger in optional dry-run mode | explicit warning, no silent `active` |
+| L12 | descendant contract found through parent chain | parent revoke blocks descendant |
+| L13 | lifecycle event with invalid schema | ignored for state increase, recorded as error |
+| L14 | signed receipt verification failure | fail closed in signed-required mode |
+
+Suggested file: `tests/scripts/test_update_contract_lifecycle.py`
+
+| ID | Scenario | Expected |
+|---|---|---|
+| U1 | dry-run pause | JSON event printed; ledger unchanged |
+| U2 | append pause | ledger receives one JSONL event |
+| U3 | resume from paused | event appended and state active |
+| U4 | resume from halted | non-zero exit |
+| U5 | revoke from any non-revoked state | event appended |
+| U6 | append is atomic | no partial file after simulated failure |
+| U7 | invalid contract file | exit 3 |
+
+Suggested file: `tests/scripts/test_check_contract_lifecycle.py`
+
+| ID | Scenario | Expected exit |
+|---|---|---:|
+| C1 | active + read | 0 |
+| C2 | active + delegation, depth/budget valid | 0 |
+| C3 | paused + read | 0 |
+| C4 | paused + bounded_write | 2 |
+| C5 | halted + read | 0 with audit-only warning |
+| C6 | halted + delegation | 2 |
+| C7 | revoked + shared_state | 2 |
+| C8 | invalid contract | 3 |
+| C9 | unreadable ledger | 4 |
+| C10 | missing v0.4 in signed-required mode | 5 |
+
+## v0.8 envelope matrix
+
+Suggested file: `tests/policy/test_contract_envelope.py`
+
+| ID | Scenario | Expected |
+|---|---|---|
+| E1 | valid signed envelope | validates |
+| E2 | unsigned envelope in dry-run mode | validates with warning |
+| E3 | unsigned envelope in signed-required mode | fails |
+| E4 | malformed JSON | fails with schema error |
+| E5 | unexpected schema version | fails |
+| E6 | child allowed action widens parent | fails |
+| E7 | child branch glob widens parent | fails |
+| E8 | child budget exceeds parent | fails |
+| E9 | expired contract | fails |
+| E10 | revoked contract | fails |
+| E11 | paused contract for worker launch | fails |
+| E12 | paused contract for audit read | validates as audit-only |
+| E13 | missing lifecycle support in required mode | fails |
+| E14 | missing v0.4 signing support in required mode | fails |
+| E15 | envelope id and contract id are stable in receipt refs | validates |
+
+Suggested file: `tests/scripts/test_validate_parent_contract.py`
+
+| ID | CLI | Expected |
+|---|---|---|
+| V1 | `--parent-contract valid.json --json` | exit 0 with effective scope |
+| V2 | missing file | non-zero |
+| V3 | invalid schema | non-zero |
+| V4 | `--require-signed` with unsigned envelope | non-zero |
+| V5 | `--allow-unsigned-dry-run` with unsigned envelope | exit 0 with warning |
+| V6 | `--action-class delegation` with paused lifecycle | non-zero |
+| V7 | `--action-class read` with halted lifecycle | exit 0 audit-only |
+| V8 | corrupt lifecycle ledger | non-zero fail-closed |
+
+## v0.8 adapter matrix
+
+Suggested file: `tests/scripts/test_launch_contract_bound_droid.py`
+
+| ID | Scenario | Expected |
+|---|---|---|
+| D1 | dry-run valid parent | prints launch plan, no worker spawned |
+| D2 | invalid parent | refuses before launch |
+| D3 | paused parent | refuses before launch |
+| D4 | revoked parent | refuses before launch |
+| D5 | effective env vars | plan includes `ARAGORA_PARENT_CONTRACT`, `ARAGORA_DELEGATION_CONTRACT_ID`, `ARAGORA_GOAL_ID`, `ARAGORA_CONTRACT_ENVELOPE_ID` |
+| D6 | child worktree copy | plan includes `ADC_PARENT_CONTRACT.json` copy target |
+| D7 | missing prompt | refuses |
+| D8 | missing launcher | refuses |
+
+Suggested existing harness files to extend:
+
+- `tests/swarm/agent_bridge/test_harnesses_claude.py`
+- `tests/swarm/agent_bridge/test_harnesses_codex.py`
+- `tests/swarm/agent_bridge/test_harnesses_droid.py`
+- `tests/swarm/test_worker_launcher.py`
+
+| ID | Scenario | Expected |
+|---|---|---|
+| H1 | Claude startup stub receives parent contract | validates and records limitation |
+| H2 | Codex startup stub receives parent contract | validates and records limitation |
+| H3 | Droid startup wrapper receives parent contract | hard launch gate |
+| H4 | Codex Desktop metadata binding | parent contract id recorded where available |
+| H5 | stub limitation text | no claim of full tool interception |
+| H6 | worker receipt binding | contract id + envelope id carried into receipt |
+
+## v0.5/v0.6 bridge tests
+
+Suggested file: `tests/policy/test_adversarial_check.py`
+
+| ID | Scenario | Expected |
+|---|---|---|
+| A1 | out-of-scope branch push | `HALT` |
+| A2 | in-scope lane claim | `PROCEED` |
+| A3 | destructive action without approval | `HALT` |
+| A4 | pure read | `PROCEED` without model reviewer |
+| A5 | paused lifecycle | `HALT` |
+| A6 | mocked reviewer halt | receipt written |
+
+Suggested file: `tests/policy/test_trust_multiplier.py`
+
+| ID | Scenario | Expected |
+|---|---|---|
+| T1 | new agent defaults by action class | table values |
+| T2 | green-check event | positive delta within ceiling |
+| T3 | halt event | negative delta |
+| T4 | revoke event | strong negative delta |
+| T5 | self-reported progress only | no update |
+| T6 | operator cap lower than multiplier result | cap wins |
+| T7 | corrupt trust ledger | fail closed for increases |
+
+## Validation command bundles
+
+### Current-main smoke
+
+```bash
+python -m pytest tests/policy/test_delegation_contract.py tests/policy/test_predicate_oracle.py -q
+```
+
+### After v0.7 implementation
+
+```bash
+python -m pytest \
+  tests/policy/test_contract_lifecycle.py \
+  tests/scripts/test_update_contract_lifecycle.py \
+  tests/scripts/test_check_contract_lifecycle.py \
+  tests/scripts/test_claim_active_agent_lane.py \
+  tests/scripts/test_evaluate_goal_progress.py \
+  -q
+```
+
+### After v0.8 implementation
+
+```bash
+python -m pytest \
+  tests/policy/test_contract_envelope.py \
+  tests/scripts/test_validate_parent_contract.py \
+  tests/scripts/test_launch_contract_bound_droid.py \
+  tests/swarm/agent_bridge/test_harnesses_claude.py \
+  tests/swarm/agent_bridge/test_harnesses_codex.py \
+  tests/swarm/agent_bridge/test_harnesses_droid.py \
+  tests/swarm/test_worker_launcher.py \
+  -q
+```
+
+### After v0.5/v0.6 implementation
+
+```bash
+python -m pytest \
+  tests/policy/test_adversarial_check.py \
+  tests/policy/test_trust_multiplier.py \
+  tests/scripts/test_evaluate_adversarial_action.py \
+  tests/scripts/test_update_trust_multiplier.py \
+  -q
+```
+
+## Operator notes
+
+- Keep first implementation PRs deterministic and mock-first.
+- Do not let v0.8 claim full Claude/Codex tool interception until the harness can enforce it.
+- Do not allow v0.6 trust multipliers to override contract denies, lifecycle denies, or destructive-action human gates.
+- Treat generated `.aragora/*/*.jsonl` ledgers as operator-owned artifacts; tests should use temporary directories by default.

--- a/docs/governance/ADC_v0.7_IMPLEMENTATION_BLUEPRINT.md
+++ b/docs/governance/ADC_v0.7_IMPLEMENTATION_BLUEPRINT.md
@@ -1,0 +1,326 @@
+# ADC v0.7 Implementation Blueprint — Three-Tier Reversibility
+
+**Status:** blueprint only
+**Do not implement until:** ADC base stack `#7361 → {#7358, #7360}` lands on `main`, or the operator explicitly authorizes an integration branch
+**No dispatch performed:** this document only describes the future implementation.
+
+## Purpose
+
+ADC v0.7 adds a lifecycle actuator to the Delegation Contract stack. Earlier ADC layers define and evaluate authority:
+
+- v0.1: schema, validator, monotonic narrowing, predicate oracle;
+- v0.2: lane-registry attachment;
+- v0.3: progress ledger;
+- v0.4: HMAC signatures for contracts and receipts.
+
+v0.7 should make authority reversible without relying on process killing:
+
+1. **pause** new work while preserving resumability;
+2. **halt** a lane/contract when progress or safety gates fail;
+3. **revoke** authority permanently across descendants.
+
+## Design constraints
+
+- Deterministic stdlib-first implementation.
+- No LLM in the lifecycle trust kernel.
+- No process killing as the primary safety mechanism.
+- All state changes are append-only receipt events.
+- Lifecycle checks must fail closed when contract state cannot be read.
+- Destructive actions remain human-only.
+- v0.7 must refuse dispatch if v0.1-v0.4 prerequisites are missing.
+
+## State machine
+
+```mermaid
+stateDiagram
+    [*] --> active
+    active --> paused: pause
+    paused --> active: resume
+    active --> halted: halt
+    paused --> halted: halt
+    active --> revoked: revoke
+    paused --> revoked: revoke
+    halted --> revoked: revoke
+    halted --> halted: terminal
+    revoked --> revoked: terminal
+```
+
+### State semantics
+
+| State | New read | New bounded write | New shared-state write | Spawn child | Resume? | Terminal? |
+|---|---:|---:|---:|---:|---:|---:|
+| `active` | allow | allow if contract permits | allow if contract permits | allow if depth/budget permits | n/a | no |
+| `paused` | allow | deny by default | deny | deny | yes | no |
+| `halted` | allow for audit only | deny | deny | deny | no | yes |
+| `revoked` | allow for audit only | deny | deny | deny | no | yes |
+
+`halted` means "stop this contract's work because progress/safety failed." `revoked` means "authority is withdrawn and descendants must fail closed."
+
+## Proposed modules
+
+### `aragora/policy/contract_lifecycle.py`
+
+Core dataclasses:
+
+```python
+LIFECYCLE_SCHEMA_VERSION = "aragora-contract-lifecycle/0.7"
+
+ContractState = Literal["active", "paused", "halted", "revoked"]
+LifecycleEventKind = Literal["issue", "pause", "resume", "halt", "revoke", "tick"]
+
+@dataclass(frozen=True)
+class LifecycleEvent:
+    schema_version: str
+    contract_id: str
+    goal_id: str
+    event: LifecycleEventKind
+    resulting_state: ContractState
+    reason: str
+    actor: str
+    occurred_at: str
+    parent_contract_id: str | None = None
+    root_intent_id: str | None = None
+    evidence: dict[str, str] = field(default_factory=dict)
+    signature: str | None = None
+
+@dataclass(frozen=True)
+class LifecycleDecision:
+    contract_id: str
+    state: ContractState
+    may_execute: bool
+    may_spawn_child: bool
+    reason: str
+```
+
+Core functions:
+
+- `load_lifecycle_events(path: Path) -> list[LifecycleEvent]`
+- `append_lifecycle_event(path: Path, event: LifecycleEvent) -> None`
+- `get_contract_state(contract_id: str, event_paths: Iterable[Path]) -> ContractState`
+- `evaluate_lifecycle(contract: DelegationContract, action_class: str, event_paths: Iterable[Path]) -> LifecycleDecision`
+- `pause_contract(...) -> LifecycleEvent`
+- `resume_contract(...) -> LifecycleEvent`
+- `halt_contract(...) -> LifecycleEvent`
+- `revoke_contract(...) -> LifecycleEvent`
+- `descendant_contract_ids(root_or_parent: str, registry_paths: Iterable[Path]) -> set[str]`
+
+Implementation should keep state reduction deterministic:
+
+```text
+revoked wins over halted wins over paused wins over active
+latest valid event wins inside the same precedence tier
+invalid or unreadable lifecycle ledger => fail closed for writes/spawns
+```
+
+### Ledger path
+
+Default repo-local path:
+
+```text
+.aragora/delegation-contracts/lifecycle.jsonl
+```
+
+This path should be configurable for tests. Production code should not create or delete arbitrary files outside the repo or user Aragora state root.
+
+## Proposed scripts
+
+### `scripts/update_contract_lifecycle.py`
+
+CLI:
+
+```bash
+python scripts/update_contract_lifecycle.py \
+  --contract path/to/contract.json \
+  --event pause \
+  --reason "operator hold before base-stack merge" \
+  --actor operator \
+  --ledger .aragora/delegation-contracts/lifecycle.jsonl \
+  --json
+```
+
+Flags:
+
+- `--contract PATH`
+- `--event pause|resume|halt|revoke`
+- `--reason TEXT`
+- `--actor TEXT`
+- `--ledger PATH`
+- `--parent-ledger PATH` optional, repeatable
+- `--json`
+- `--dry-run`
+
+Rules:
+
+- `resume` is allowed only from `paused`;
+- `halted` cannot resume;
+- `revoked` cannot resume or halt;
+- `revoke` may apply from any non-revoked state;
+- mutation writes are append-only JSONL;
+- dry-run prints the event that would be appended.
+
+### `scripts/check_contract_lifecycle.py`
+
+CLI:
+
+```bash
+python scripts/check_contract_lifecycle.py \
+  --contract path/to/contract.json \
+  --action-class delegation \
+  --ledger .aragora/delegation-contracts/lifecycle.jsonl \
+  --json
+```
+
+Exit codes:
+
+| Exit | Meaning |
+|---:|---|
+| 0 | action may proceed |
+| 2 | action refused by lifecycle state |
+| 3 | invalid contract |
+| 4 | unreadable or invalid lifecycle ledger |
+| 5 | dependency missing |
+
+This script becomes the v0.8 `validate_parent_contract.py` dependency for lifecycle gating.
+
+## Receipt fields
+
+Every lifecycle receipt should include:
+
+| Field | Purpose |
+|---|---|
+| `schema_version` | lifecycle receipt version |
+| `contract_id` | primary contract |
+| `goal_id` | goal binding |
+| `root_intent_id` | authority-chain root |
+| `parent_contract_id` | parent if any |
+| `event` | pause/resume/halt/revoke/tick |
+| `previous_state` | state before event |
+| `resulting_state` | state after event |
+| `reason` | operator or deterministic evaluator reason |
+| `actor` | operator/session/tool |
+| `occurred_at` | UTC timestamp |
+| `evidence` | predicate/progress/check references |
+| `signature` | v0.4 receipt signature when available |
+
+If v0.4 signing is unavailable, v0.7 should write unsigned dry-run receipts only when the operator explicitly selects unsigned mode. Default dispatch mode should require signing once `#7361` lands.
+
+## Integration points
+
+### v0.1 schema and predicate oracle
+
+`DelegationContract` remains the authority object. v0.7 should not add lifecycle mutable fields directly to the frozen contract dataclass. Lifecycle state is external, append-only, and reducible from events.
+
+Predicate-oracle integration can add deterministic predicates later:
+
+- `contract_active(path_or_id)`
+- `contract_not_revoked(path_or_id)`
+- `contract_state(path_or_id, state)`
+
+Do not add these predicates until lifecycle storage format is stable.
+
+### v0.2 lane registry
+
+Lane claims should store:
+
+- `delegation_contract_id`
+- `parent_contract_id`
+- `root_intent_id`
+- optional `lifecycle_state`
+- optional `lifecycle_checked_at`
+
+v0.7 should not depend on the lane registry as the sole source of truth. It may mirror lifecycle state there for operator snapshots, but the lifecycle ledger remains canonical.
+
+### v0.3 progress ledger
+
+Progress evaluation should emit a lifecycle recommendation, not directly kill or revoke:
+
+- repeated no-progress ticks → `pause` or `halt` recommendation;
+- anti-signal predicate satisfied → `halt` recommendation;
+- acceptance criteria complete → `halt` with reason `completed`, or `pause` if awaiting review.
+
+The operator or contract policy determines whether recommendations auto-append lifecycle events.
+
+### v0.4 signing
+
+Lifecycle events should be signed as receipts once v0.4 is present:
+
+- `sign_receipt(event_payload, key)`
+- `verify_receipt(event_payload, signature, key)`
+
+v0.7 must refuse signed-required mode when v0.4 symbols are absent.
+
+## Dependency checks
+
+Before any v0.7 dispatch/implementation worker starts, the launcher should verify:
+
+```python
+required_main_symbols = [
+    "aragora.policy.DelegationContract",
+    "aragora.policy.GoalSpec",
+    "aragora.policy.evaluate_predicate",
+]
+
+required_after_7361 = [
+    "aragora.policy.sign_contract",
+    "aragora.policy.verify_contract",
+    "aragora.policy.sign_receipt",
+    "aragora.policy.verify_receipt",
+]
+```
+
+Fail-closed behavior:
+
+| Missing | Behavior |
+|---|---|
+| v0.1 contract symbols | refuse immediately |
+| v0.2 lane fields | allow policy-module tests, refuse launcher integration |
+| v0.3 progress evaluator | allow lifecycle module, refuse progress-trigger integration |
+| v0.4 signing symbols | allow unsigned test mode only; refuse signed-required dispatch |
+
+## Test plan
+
+Suggested files:
+
+- `tests/policy/test_contract_lifecycle.py`
+- `tests/scripts/test_update_contract_lifecycle.py`
+- `tests/scripts/test_check_contract_lifecycle.py`
+- `tests/scripts/test_claim_active_agent_lane.py`
+- `tests/scripts/test_evaluate_goal_progress.py`
+
+Core tests:
+
+1. new contract reduces to `active` with no events;
+2. `pause` blocks writes and child issuance but permits audit reads;
+3. `resume` from `paused` returns to `active`;
+4. `resume` from `halted` fails;
+5. `revoke` terminally blocks all writes/spawns;
+6. `halt` terminally blocks all writes/spawns but preserves audit reads;
+7. `revoked` outranks later stale `resume`;
+8. unreadable ledger fails closed for write/spawn checks;
+9. lifecycle event JSONL append is atomic and sorted by occurrence during reduction;
+10. descendant revocation finds child contracts through lane-registry metadata;
+11. v0.4 signing symbols are used when present and skipped only under explicit unsigned mode;
+12. scripts return documented exit codes.
+
+## Implementation sequence
+
+1. Add pure dataclasses and reducer in `contract_lifecycle.py`.
+2. Add deterministic tests with temporary JSONL ledgers.
+3. Add `check_contract_lifecycle.py` read-only CLI.
+4. Add `update_contract_lifecycle.py` append-only CLI.
+5. Wire optional lane-registry mirroring after v0.2 fields exist on `main`.
+6. Wire optional progress-trigger recommendations after v0.3 exists on `main`.
+7. Wire signing after v0.4 exists on `main`.
+8. Only after all deterministic tests pass, prepare v0.8 adapter integration.
+
+## Operator-ready acceptance criteria
+
+A v0.7 implementation PR should not be considered ready until:
+
+- it is based on a branch containing v0.1-v0.4;
+- lifecycle reducer tests pass without network or model calls;
+- CLI scripts have deterministic exit codes;
+- signed-required mode fails closed when v0.4 symbols are absent;
+- paused/halted/revoked states block child issuance;
+- lifecycle receipts are append-only and cite evidence;
+- final documentation states that process killing is not the primary enforcement mechanism.

--- a/docs/governance/ADC_v0.8_PROMPT_PACK_READINESS.md
+++ b/docs/governance/ADC_v0.8_PROMPT_PACK_READINESS.md
@@ -1,0 +1,229 @@
+# ADC v0.8 Prompt Pack Readiness — 2026-05-19
+
+**Status:** readiness packet only
+**Prompt source:** parked `.aragora/v16-dispatch/ADC-v0.8-*.md` files from the prior Factory worktree
+**Dispatch gate:** do not dispatch v0.8 until v0.7 ships, or the operator explicitly waives that prerequisite.
+
+## Purpose
+
+ADC v0.8 is the cross-family adapter layer: the contract should travel with a worker launch regardless of whether the worker is Factory Droid, Claude Code, or Codex. The parked prompts are useful but gitignored. This tracked readiness document preserves the dispatch preconditions, verified symbols, expected deliverables, and enforcement limitations without committing executable launch artifacts.
+
+## Readiness verdict
+
+Not ready to dispatch.
+
+Required before v0.8 work starts:
+
+1. ADC v0.1 on `main` — complete.
+2. ADC v0.4 `#7361` on `main` — pending operator review/merge.
+3. ADC v0.2 `#7358` and v0.3 `#7360` on `main` — pending operator review/merge.
+4. ADC v0.7 lifecycle state machine on `main` or explicit operator waiver.
+5. If PR #7367 is not merged, carry `docs/governance/ADC_v0.8_CROSS_FAMILY_ADAPTER_PLAN.md` into the v0.8 integration branch before dispatch.
+
+## Verified current-main symbols
+
+The parked prompts correctly reference these current `main` symbols:
+
+| Symbol | Source | Use in v0.8 |
+|---|---|---|
+| `DelegationContract` | `aragora.policy` | parent authority object |
+| `GoalSpec` | `aragora.policy` | goal/acceptance binding |
+| `AcceptanceCriterion` | `aragora.policy` | deterministic acceptance criteria |
+| `AllowedSurfaces` | `aragora.policy` | branch/file/worktree/PR scope |
+| `ContractBudget` | `aragora.policy` | gas/budget scope |
+| `ContractValidationError` | `aragora.policy` | fail-closed validation |
+| `narrow_for_child` | `aragora.policy` | child contract narrowing |
+| `make_root_contract` | `aragora.policy` | tests/fixtures |
+| `parse_predicate` | `aragora.policy` | goal predicate parsing |
+| `evaluate_predicate` | `aragora.policy` | deterministic predicate checks |
+
+## Verified v0.4 symbols from `#7361`
+
+These symbols are verified on rebased `#7361` head `9093ddbc48ac4dd2ccaa3364b527b660c089a41e`, but are not on `main` until `#7361` merges:
+
+| Symbol | Intended use |
+|---|---|
+| `SIGNING_SCHEMA_VERSION` | signing schema guard |
+| `SigningError` | sign failure handling |
+| `VerificationError` | verification failure handling |
+| `VerificationResult` | structured verification result |
+| `canonical_contract_payload` | stable signing payload |
+| `sign_contract` | contract signing |
+| `verify_contract` | contract verification |
+| `sign_receipt` | receipt signing |
+| `verify_receipt` | receipt verification |
+| `is_contract_signed` | signed/unsigned mode gate |
+| `signing_key_available` | fail-closed dependency check |
+
+## Planned v0.7 symbols
+
+These are planned by the v0.7 blueprint and should be imported only after v0.7 lands:
+
+- `get_contract_state`
+- `ContractState`
+- lifecycle reducers/checkers that return active/paused/halted/revoked decisions
+
+Executable v0.8 code must either:
+
+1. depend on v0.7 and import these symbols directly; or
+2. run in unsigned/lifecycle-disabled dry-run mode and clearly label lifecycle checks as unavailable.
+
+It must not silently treat missing lifecycle support as `active`.
+
+## Prompt lanes
+
+### `ADC-v0.8-envelope-and-validator`
+
+Goal:
+
+> Implement the contract-on-disk envelope and validation surface.
+
+Expected deliverables:
+
+- `aragora/policy/contract_envelope.py`
+- `ContractEnvelope` dataclass
+- canonical JSON load/dump
+- schema validation
+- signature verification via v0.4
+- lifecycle state check via v0.7
+- `scripts/validate_parent_contract.py`
+- deterministic tests for signed, unsigned dry-run, malformed, scope-widening, paused, halted, and revoked cases
+
+Fail-closed rules:
+
+- invalid envelope → non-zero exit;
+- missing parent contract → non-zero exit;
+- missing v0.4 when signed mode is required → non-zero exit;
+- missing v0.7 when lifecycle mode is required → non-zero exit;
+- paused/halted/revoked → non-zero exit for worker launch.
+
+### `ADC-v0.8-droid-adapter`
+
+Goal:
+
+> Make Factory Droid worker launches contract-bound by accepting `--parent-contract <path>` and propagating validated scope into the child worktree.
+
+Expected deliverables:
+
+- `scripts/launch_contract_bound_droid.py`
+- flags `--lane-id`, `--prompt`, `--parent-contract`, `--dry-run`
+- parent envelope validation before launch
+- child permission intersection
+- copied `ADC_PARENT_CONTRACT.json`
+- exported:
+  - `ARAGORA_PARENT_CONTRACT`
+  - `ARAGORA_DELEGATION_CONTRACT_ID`
+  - `ARAGORA_GOAL_ID`
+  - `ARAGORA_CONTRACT_ENVELOPE_ID`
+- worker instruction prelude requiring lane claim and receipt binding
+
+The first implementation PR should support `--dry-run` and prove the launch plan without actually spawning a worker in tests.
+
+### `ADC-v0.8-claude-codex-stubs`
+
+Goal:
+
+> Provide honest validation stubs for Claude Code and Codex without overclaiming runtime enforcement.
+
+Expected deliverables:
+
+- examples for Claude Code startup;
+- examples for Codex CLI worker startup;
+- examples for Codex Desktop/rollout metadata binding where available;
+- docs section explicitly stating limitations;
+- tests for validation and receipt-field extraction.
+
+Hard limitation text to preserve:
+
+> Claude/Codex stubs may validate and report lifecycle state, but must not claim to intercept every tool call unless the harness supports that enforcement boundary.
+
+## Contract envelope shape
+
+Suggested v0.8 envelope:
+
+```json
+{
+  "schema_version": "aragora-contract-envelope/0.8",
+  "envelope_id": "env-...",
+  "contract": {},
+  "goal_spec": {},
+  "parent_envelope_id": null,
+  "issued_for": {
+    "agent_family": "droid",
+    "owner_session": "droid-...",
+    "lane_id": "ADC-v0.8-droid-adapter"
+  },
+  "effective_scope": {
+    "allowed_actions": ["read:*"],
+    "allowed_surfaces": {},
+    "budget": {}
+  },
+  "lifecycle": {
+    "required": true,
+    "state": "active",
+    "checked_at_utc": "2026-05-19T00:00:00Z"
+  },
+  "signing": {
+    "required": true,
+    "contract_signed": true,
+    "verified_at_utc": "2026-05-19T00:00:00Z"
+  }
+}
+```
+
+The envelope stores the effective scope that was validated at launch time. The source contract remains canonical, and downstream receipts should cite both contract id and envelope id.
+
+## Adapter enforcement matrix
+
+| Family | Hard launch gate? | Tool-call interception? | Honest v0.8 claim |
+|---|---:|---:|---|
+| Factory Droid | yes, through wrapper | partial/launcher-mediated | can refuse launch and pass scope/env into worker |
+| Claude Code | startup validation only unless harness changes | not guaranteed | can validate envelope, print scope, and bind receipts |
+| Codex CLI | startup validation only unless harness changes | not guaranteed | can validate envelope, print scope, and bind receipts |
+| Codex Desktop | metadata binding where available | not guaranteed | can record parent contract in rollout/session metadata |
+
+## Tests to require before dispatch
+
+Suggested files:
+
+- `tests/policy/test_contract_envelope.py`
+- `tests/scripts/test_validate_parent_contract.py`
+- `tests/scripts/test_launch_contract_bound_droid.py`
+- `tests/swarm/agent_bridge/test_harnesses_claude.py`
+- `tests/swarm/agent_bridge/test_harnesses_codex.py`
+- `tests/swarm/agent_bridge/test_harnesses_droid.py`
+
+Core cases:
+
+1. valid signed envelope passes;
+2. unsigned envelope passes only in explicit dry-run/unsigned mode;
+3. malformed JSON fails;
+4. schema mismatch fails;
+5. signature verification failure fails;
+6. child scope widening fails;
+7. paused contract fails worker launch;
+8. halted contract fails worker launch;
+9. revoked contract fails worker launch;
+10. missing lifecycle support fails when lifecycle is required;
+11. droid dry-run prints exact launch plan;
+12. Claude/Codex stubs record limitation text and do not claim full tool interception.
+
+## Dispatch checklist
+
+- [ ] Base stack `#7361`, `#7358`, `#7360` has landed on `main`.
+- [ ] v0.7 lifecycle is on `main`, or operator explicitly waives lifecycle prerequisite.
+- [ ] `ADC_v0.8_CROSS_FAMILY_ADAPTER_PLAN.md` is present in the target branch.
+- [ ] v0.8 prompt pack is refreshed against current symbols.
+- [ ] `validate_parent_contract.py` prompt is dispatched before adapter prompts.
+- [ ] Droid adapter prompt runs before Claude/Codex stubs if hard enforcement is desired first.
+- [ ] All PRs remain draft until operator review.
+
+## Stop conditions
+
+Do not dispatch v0.8 if:
+
+- any base-stack PR is still open;
+- v0.7 has not shipped and no explicit waiver exists;
+- v0.4 signing symbols drift from the verified names above;
+- the prompt would require protected-file edits;
+- the implementation would claim enforcement that the harness cannot provide.


### PR DESCRIPTION
## Summary
- Publish the harvested ADC follow-on governance packet from the existing idempotent handoff.
- Adds ADC base-stack review, parked-artifact preservation, implementation prompts, v0.7/v0.8 planning, and metrics refresh docs.
- Docs-only packet; no runtime behavior change.

## Validation
- bash scripts/automation_pr_preflight.sh origin/main codex/harvest-adc-follow-on-deepening-r4-20260529
- git diff --check origin/main...codex/harvest-adc-follow-on-deepening-r4-20260529
- Prior handoff validation: tests/scripts/test_regenerate_metrics.py -> 22 passed; scripts/regenerate_metrics.py --check reported no drift beyond threshold; ruff check/format passed for regenerate_metrics tests.

## Publication note
Published from idempotent automation-outbox handoff open-pr-codex-harvest-adc-follow-on-deepening-r4-20260529-3228456c after prior attempts were blocked by GitHub connectivity/auth.