### PR TITLE
fix(automation): bound audit github health probes

### DIFF
--- a/scripts/audit_codex_branch_backlog.py
+++ b/scripts/audit_codex_branch_backlog.py
@@ -40,6 +40,7 @@ DEFAULT_RECEIPT_DIR = Path(".aragora/automation-receipts")
 TERMINAL_RECEIPT_STATUSES = {"published", "already_satisfied", "completed", "skipped"}
 COMMIT_PREFIX_RE = re.compile(r"^[0-9a-f]{7,40}$", re.IGNORECASE)
 BRANCH_IDEMPOTENCY_PREFIXES = ("open-pr-", "already-satisfied-")
+DEFAULT_GITHUB_HEALTH_TIMEOUT_SECONDS = 5
 SALVAGE_CATEGORIES = {
     "salvage_recent_unique",
     "salvage_stale_remote_unique",
@@ -953,6 +954,7 @@ def audit(
     include_patch_equivalence: bool,
     patch_equivalence_time_budget_seconds: float | None = None,
     publisher_backlog_limit: int,
+    github_health_timeout_seconds: int = DEFAULT_GITHUB_HEALTH_TIMEOUT_SECONDS,
     outbox_dir: Path | None = None,
     receipt_dir: Path | None = None,
 ) -> dict[str, Any]:
@@ -971,7 +973,11 @@ def audit(
     remotes = remote_branch_names(root, prefix)
     merged_branches = merged_branch_names(root, base, prefix)
     worktrees = worktree_map(root)
-    github_health = check_github_cli_health(root)
+    github_health = check_github_cli_health(
+        root,
+        timeout_seconds=github_health_timeout_seconds,
+        prefer_app=False,
+    )
     open_pr_lookup_failed = False
     if github_health.ready:
         open_pr_result = open_pr_heads(root, repo, prefix)
@@ -1469,6 +1475,15 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--github-health-timeout-seconds",
+        type=int,
+        default=DEFAULT_GITHUB_HEALTH_TIMEOUT_SECONDS,
+        help=(
+            "Timeout for each GitHub CLI health probe before skipping open PR lookup "
+            f"(default: {DEFAULT_GITHUB_HEALTH_TIMEOUT_SECONDS})."
+        ),
+    )
+    parser.add_argument(
         "--state-root",
         type=Path,
         default=None,
@@ -1535,6 +1550,7 @@ def main(argv: list[str] | None = None) -> int:
         include_patch_equivalence=args.include_patch_equivalence,
         patch_equivalence_time_budget_seconds=patch_budget,
         publisher_backlog_limit=args.publisher_backlog_limit,
+        github_health_timeout_seconds=args.github_health_timeout_seconds,
         outbox_dir=outbox_dir,
         receipt_dir=receipt_dir,
     )

--- a/scripts/github_cli_health.py
+++ b/scripts/github_cli_health.py
@@ -12,17 +12,6 @@ from dataclasses import asdict, dataclass
 from collections.abc import Mapping
 from pathlib import Path
 
-try:
-    from aragora.swarm.github_app_auth import github_cli_env
-except Exception:  # pragma: no cover - fallback for partially bootstrapped script contexts
-
-    def github_cli_env(
-        base_env: Mapping[str, str] | None = None,
-        *,
-        prefer_app: bool = True,
-    ) -> dict[str, str]:
-        return dict(os.environ if base_env is None else base_env)
-
 
 DEFAULT_TIMEOUT_SECONDS = 20
 CONNECTIVITY_ERROR_TOKENS = (
@@ -73,8 +62,29 @@ def _command_error(proc: subprocess.CompletedProcess[str], fallback: str) -> str
     return proc.stderr.strip() or proc.stdout.strip() or fallback
 
 
-def _run(args: list[str], *, cwd: Path, timeout_seconds: int) -> subprocess.CompletedProcess[str]:
-    env = github_cli_env(os.environ) if args and args[0] == "gh" else None
+def github_cli_env(
+    base_env: Mapping[str, str] | None = None,
+    *,
+    prefer_app: bool = True,
+) -> dict[str, str]:
+    env = dict(os.environ if base_env is None else base_env)
+    if not prefer_app:
+        return env
+    try:
+        from aragora.swarm.github_app_auth import github_cli_env as app_github_cli_env
+    except Exception:  # pragma: no cover - fallback for partially bootstrapped script contexts
+        return env
+    return app_github_cli_env(env, prefer_app=True)
+
+
+def _run(
+    args: list[str],
+    *,
+    cwd: Path,
+    timeout_seconds: int,
+    prefer_app: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    env = github_cli_env(os.environ, prefer_app=prefer_app) if args and args[0] == "gh" else None
     try:
         return subprocess.run(
             args,
@@ -96,6 +106,7 @@ def check_github_cli_health(
     repo_root: Path,
     *,
     timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+    prefer_app: bool = True,
 ) -> GitHubCLIHealth:
     repo_root = repo_root.resolve()
     repo_label = str(repo_root)
@@ -109,7 +120,12 @@ def check_github_cli_health(
             repo=repo_label,
         )
 
-    api_proc = _run(["gh", "api", "rate_limit"], cwd=repo_root, timeout_seconds=timeout_seconds)
+    api_proc = _run(
+        ["gh", "api", "rate_limit"],
+        cwd=repo_root,
+        timeout_seconds=timeout_seconds,
+        prefer_app=prefer_app,
+    )
     if api_proc.returncode == 0:
         return GitHubCLIHealth(
             ready=True,
@@ -121,7 +137,12 @@ def check_github_cli_health(
         )
 
     api_error = _command_error(api_proc, "gh api rate_limit failed")
-    auth_proc = _run(["gh", "auth", "status"], cwd=repo_root, timeout_seconds=timeout_seconds)
+    auth_proc = _run(
+        ["gh", "auth", "status"],
+        cwd=repo_root,
+        timeout_seconds=timeout_seconds,
+        prefer_app=prefer_app,
+    )
     if auth_proc.returncode != 0:
         auth_error = _command_error(auth_proc, "gh auth status failed")
         api_connectivity = is_github_connectivity_error(api_error)

--- a/tests/scripts/test_audit_codex_branch_backlog.py
+++ b/tests/scripts/test_audit_codex_branch_backlog.py
@@ -342,7 +342,7 @@ def test_audit_skips_open_pr_lookup_when_github_health_degraded(
     monkeypatch.setattr(
         mod,
         "check_github_cli_health",
-        lambda _root: GitHubCLIHealth(
+        lambda _root, **_kwargs: GitHubCLIHealth(
             ready=False,
             auth_ok=False,
             api_ok=False,
@@ -374,12 +374,47 @@ def test_audit_skips_open_pr_lookup_when_github_health_degraded(
     assert payload["records"][0]["category"] == "salvage_recent_unique"
 
 
+def test_audit_passes_bounded_timeout_to_github_health(tmp_path: Path, monkeypatch: Any) -> None:
+    _stub_git_inventory(monkeypatch, _branch_row())
+    observed_timeouts: list[int] = []
+
+    def fake_health(_root: Path, *, timeout_seconds: int, prefer_app: bool) -> GitHubCLIHealth:
+        observed_timeouts.append(timeout_seconds)
+        assert prefer_app is False
+        return GitHubCLIHealth(
+            ready=False,
+            auth_ok=False,
+            api_ok=False,
+            mode="connectivity_failed",
+            error="offline",
+            repo=str(tmp_path),
+        )
+
+    monkeypatch.setattr(mod, "check_github_cli_health", fake_health)
+
+    payload = mod.audit(
+        root=tmp_path,
+        base="origin/main",
+        repo="synaptent/aragora",
+        prefix="codex/",
+        recent_hours=72,
+        max_branches=None,
+        include_patch_equivalence=False,
+        publisher_backlog_limit=12,
+        github_health_timeout_seconds=3,
+    )
+
+    assert observed_timeouts == [3]
+    assert payload["github_health"]["mode"] == "connectivity_failed"
+    assert payload["open_pr_lookup_skipped"] is True
+
+
 def test_audit_reports_worktree_and_base_revisions(tmp_path: Path, monkeypatch: Any) -> None:
     _stub_git_inventory(monkeypatch, _branch_row())
     monkeypatch.setattr(
         mod,
         "check_github_cli_health",
-        lambda _root: GitHubCLIHealth(
+        lambda _root, **_kwargs: GitHubCLIHealth(
             ready=False,
             auth_ok=False,
             api_ok=False,
@@ -430,7 +465,7 @@ def test_audit_uses_batched_divergence_before_fallback(tmp_path: Path, monkeypat
     monkeypatch.setattr(
         mod,
         "check_github_cli_health",
-        lambda _root: GitHubCLIHealth(
+        lambda _root, **_kwargs: GitHubCLIHealth(
             ready=False,
             auth_ok=False,
             api_ok=False,
@@ -465,7 +500,7 @@ def test_audit_protects_branch_when_divergence_lookup_fails(
     monkeypatch.setattr(
         mod,
         "check_github_cli_health",
-        lambda _root: GitHubCLIHealth(
+        lambda _root, **_kwargs: GitHubCLIHealth(
             ready=False,
             auth_ok=False,
             api_ok=False,
@@ -510,7 +545,7 @@ def test_audit_uses_open_pr_lookup_when_github_health_is_ready(
     monkeypatch.setattr(
         mod,
         "check_github_cli_health",
-        lambda _root: GitHubCLIHealth(
+        lambda _root, **_kwargs: GitHubCLIHealth(
             ready=True,
             auth_ok=True,
             api_ok=True,
@@ -553,7 +588,7 @@ def test_audit_fails_closed_when_open_pr_lookup_times_out(tmp_path: Path, monkey
     monkeypatch.setattr(
         mod,
         "check_github_cli_health",
-        lambda _root: GitHubCLIHealth(
+        lambda _root, **_kwargs: GitHubCLIHealth(
             ready=True,
             auth_ok=True,
             api_ok=True,
@@ -595,7 +630,7 @@ def test_audit_ignores_missing_worktree_paths(tmp_path: Path, monkeypatch: Any) 
     monkeypatch.setattr(
         mod,
         "check_github_cli_health",
-        lambda _root: GitHubCLIHealth(
+        lambda _root, **_kwargs: GitHubCLIHealth(
             ready=False,
             auth_ok=False,
             api_ok=False,
@@ -666,7 +701,7 @@ def test_audit_skips_patch_equivalence_for_dirty_worktrees(
     monkeypatch.setattr(
         mod,
         "check_github_cli_health",
-        lambda _root: GitHubCLIHealth(
+        lambda _root, **_kwargs: GitHubCLIHealth(
             ready=False,
             auth_ok=False,
             api_ok=False,
@@ -709,7 +744,7 @@ def test_audit_publishable_backlog_excludes_stale_local_only_branches(
     monkeypatch.setattr(
         mod,
         "check_github_cli_health",
-        lambda _root: GitHubCLIHealth(
+        lambda _root, **_kwargs: GitHubCLIHealth(
             ready=True,
             auth_ok=True,
             api_ok=True,
@@ -763,7 +798,7 @@ def test_audit_excludes_diverged_branches_from_publishable_backlog(
     monkeypatch.setattr(
         mod,
         "check_github_cli_health",
-        lambda _root: GitHubCLIHealth(
+        lambda _root, **_kwargs: GitHubCLIHealth(
             ready=False,
             auth_ok=False,
             api_ok=False,
@@ -838,7 +873,7 @@ def test_audit_excludes_terminal_outbox_receipts_from_publishable_backlog(
     monkeypatch.setattr(
         mod,
         "check_github_cli_health",
-        lambda _root: GitHubCLIHealth(
+        lambda _root, **_kwargs: GitHubCLIHealth(
             ready=False,
             auth_ok=False,
             api_ok=False,
@@ -899,7 +934,7 @@ def test_audit_excludes_terminal_receipt_branch_without_outbox_payload(
     monkeypatch.setattr(
         mod,
         "check_github_cli_health",
-        lambda _root: GitHubCLIHealth(
+        lambda _root, **_kwargs: GitHubCLIHealth(
             ready=False,
             auth_ok=False,
             api_ok=False,
@@ -961,7 +996,7 @@ def test_audit_excludes_completed_and_skipped_terminal_receipts(
     monkeypatch.setattr(
         mod,
         "check_github_cli_health",
-        lambda _root: GitHubCLIHealth(
+        lambda _root, **_kwargs: GitHubCLIHealth(
             ready=False,
             auth_ok=False,
             api_ok=False,
@@ -1024,7 +1059,7 @@ def test_audit_matches_terminal_receipt_by_idempotency_key_when_outbox_missing(
     monkeypatch.setattr(
         mod,
         "check_github_cli_health",
-        lambda _root: GitHubCLIHealth(
+        lambda _root, **_kwargs: GitHubCLIHealth(
             ready=False,
             auth_ok=False,
             api_ok=False,
@@ -1090,7 +1125,7 @@ def test_audit_ignores_terminal_receipt_with_mismatched_explicit_head(
     monkeypatch.setattr(
         mod,
         "check_github_cli_health",
-        lambda _root: GitHubCLIHealth(
+        lambda _root, **_kwargs: GitHubCLIHealth(
             ready=False,
             auth_ok=False,
             api_ok=False,
@@ -1169,7 +1204,7 @@ def test_audit_reads_archived_outbox_payload_for_terminal_receipt(
     monkeypatch.setattr(
         mod,
         "check_github_cli_health",
-        lambda _root: GitHubCLIHealth(
+        lambda _root, **_kwargs: GitHubCLIHealth(
             ready=False,
             auth_ok=False,
             api_ok=False,
@@ -1229,7 +1264,7 @@ def test_audit_excludes_unresolved_outbox_handoffs_from_publishable_backlog(
     monkeypatch.setattr(
         mod,
         "check_github_cli_health",
-        lambda _root: GitHubCLIHealth(
+        lambda _root, **_kwargs: GitHubCLIHealth(
             ready=False,
             auth_ok=False,
             api_ok=False,
@@ -1299,7 +1334,7 @@ def test_audit_protects_list_local_evidence_branch_handoffs(
     monkeypatch.setattr(
         mod,
         "check_github_cli_health",
-        lambda _root: GitHubCLIHealth(
+        lambda _root, **_kwargs: GitHubCLIHealth(
             ready=False,
             auth_ok=False,
             api_ok=False,
@@ -1363,7 +1398,7 @@ def test_audit_protects_structured_action_branch_handoffs(tmp_path: Path, monkey
     monkeypatch.setattr(
         mod,
         "check_github_cli_health",
-        lambda _root: GitHubCLIHealth(
+        lambda _root, **_kwargs: GitHubCLIHealth(
             ready=False,
             auth_ok=False,
             api_ok=False,
@@ -1431,7 +1466,7 @@ def test_audit_protects_json_string_action_branch_handoffs(
     monkeypatch.setattr(
         mod,
         "check_github_cli_health",
-        lambda _root: GitHubCLIHealth(
+        lambda _root, **_kwargs: GitHubCLIHealth(
             ready=False,
             auth_ok=False,
             api_ok=False,
@@ -1509,7 +1544,7 @@ def test_audit_protects_patch_equivalent_unresolved_handoff_branches(
     monkeypatch.setattr(
         mod,
         "check_github_cli_health",
-        lambda _root: GitHubCLIHealth(
+        lambda _root, **_kwargs: GitHubCLIHealth(
             ready=False,
             auth_ok=False,
             api_ok=False,
@@ -1573,7 +1608,7 @@ def test_audit_checks_branch_equivalence_before_handoff_patch_ids(
     monkeypatch.setattr(
         mod,
         "check_github_cli_health",
-        lambda _root: GitHubCLIHealth(
+        lambda _root, **_kwargs: GitHubCLIHealth(
             ready=False,
             auth_ok=False,
             api_ok=False,
@@ -1629,7 +1664,7 @@ def test_audit_does_not_spend_patch_ids_for_exact_outbox_branch(
     monkeypatch.setattr(
         mod,
         "check_github_cli_health",
-        lambda _root: GitHubCLIHealth(
+        lambda _root, **_kwargs: GitHubCLIHealth(
             ready=False,
             auth_ok=False,
             api_ok=False,
@@ -1692,7 +1727,7 @@ def test_audit_treats_superseded_branch_as_unresolved_handoff(
     monkeypatch.setattr(
         mod,
         "check_github_cli_health",
-        lambda _root: GitHubCLIHealth(
+        lambda _root, **_kwargs: GitHubCLIHealth(
             ready=False,
             auth_ok=False,
             api_ok=False,
@@ -1756,7 +1791,7 @@ def test_audit_counts_direct_outbox_refs_even_when_active_worktree_wins_category
     monkeypatch.setattr(
         mod,
         "check_github_cli_health",
-        lambda _root: GitHubCLIHealth(
+        lambda _root, **_kwargs: GitHubCLIHealth(
             ready=False,
             auth_ok=False,
             api_ok=False,
@@ -1821,7 +1856,7 @@ def test_audit_treats_superseded_branch_as_terminal_receipt(
     monkeypatch.setattr(
         mod,
         "check_github_cli_health",
-        lambda _root: GitHubCLIHealth(
+        lambda _root, **_kwargs: GitHubCLIHealth(
             ready=False,
             auth_ok=False,
             api_ok=False,
@@ -1881,7 +1916,7 @@ def test_audit_reads_top_level_branch_for_terminal_outbox_receipts(
     monkeypatch.setattr(
         mod,
         "check_github_cli_health",
-        lambda _root: GitHubCLIHealth(
+        lambda _root, **_kwargs: GitHubCLIHealth(
             ready=False,
             auth_ok=False,
             api_ok=False,
@@ -1942,7 +1977,7 @@ def test_audit_excludes_unresolved_top_level_outbox_handoffs_from_publishable_ba
     monkeypatch.setattr(
         mod,
         "check_github_cli_health",
-        lambda _root: GitHubCLIHealth(
+        lambda _root, **_kwargs: GitHubCLIHealth(
             ready=False,
             auth_ok=False,
             api_ok=False,
@@ -2019,7 +2054,7 @@ def test_audit_uses_automation_state_root_for_default_handoff_dirs(
     monkeypatch.setattr(
         mod,
         "check_github_cli_health",
-        lambda _root: GitHubCLIHealth(
+        lambda _root, **_kwargs: GitHubCLIHealth(
             ready=False,
             auth_ok=False,
             api_ok=False,
@@ -2110,7 +2145,7 @@ def test_audit_skips_patch_equivalence_after_time_budget(tmp_path: Path, monkeyp
     monkeypatch.setattr(
         mod,
         "check_github_cli_health",
-        lambda _root: GitHubCLIHealth(
+        lambda _root, **_kwargs: GitHubCLIHealth(
             ready=False,
             auth_ok=False,
             api_ok=False,
@@ -2174,7 +2209,7 @@ def test_audit_skips_patch_checks_for_exact_handoff_protected_branches(
     monkeypatch.setattr(
         mod,
         "check_github_cli_health",
-        lambda _root: GitHubCLIHealth(
+        lambda _root, **_kwargs: GitHubCLIHealth(
             ready=False,
             auth_ok=False,
             api_ok=False,
@@ -2241,7 +2276,7 @@ def test_audit_skip_patch_equivalence_still_cleans_empty_branch_diff(
     monkeypatch.setattr(
         mod,
         "check_github_cli_health",
-        lambda _root: GitHubCLIHealth(
+        lambda _root, **_kwargs: GitHubCLIHealth(
             ready=False,
             auth_ok=False,
             api_ok=False,
@@ -2317,7 +2352,7 @@ def test_audit_skip_patch_equivalence_verifies_salvage_candidates(
     monkeypatch.setattr(
         mod,
         "check_github_cli_health",
-        lambda _root: GitHubCLIHealth(
+        lambda _root, **_kwargs: GitHubCLIHealth(
             ready=False,
             auth_ok=False,
             api_ok=False,

--- a/tests/scripts/test_github_cli_health.py
+++ b/tests/scripts/test_github_cli_health.py
@@ -7,7 +7,11 @@ import scripts.github_cli_health as mod
 
 
 def test_run_uses_github_cli_env_for_gh(monkeypatch) -> None:
-    monkeypatch.setattr(mod, "github_cli_env", lambda env: {"GH_TOKEN": "app-token"})
+    monkeypatch.setattr(
+        mod,
+        "github_cli_env",
+        lambda env, prefer_app=True: {"GH_TOKEN": "app-token"},
+    )
 
     captured: dict[str, object] = {}
 
@@ -24,11 +28,39 @@ def test_run_uses_github_cli_env_for_gh(monkeypatch) -> None:
     assert captured["env"] == {"GH_TOKEN": "app-token"}
 
 
+def test_run_can_skip_app_env_for_diagnostic_health(monkeypatch) -> None:
+    prefer_app_values: list[bool] = []
+
+    def fake_github_cli_env(env, prefer_app=True):
+        prefer_app_values.append(prefer_app)
+        return {"BASE_ENV": "1"}
+
+    captured: dict[str, object] = {}
+
+    def fake_subprocess_run(*args, **kwargs):
+        captured["env"] = kwargs.get("env")
+        return subprocess.CompletedProcess(
+            args=kwargs.get("args", args[0]), returncode=0, stdout="", stderr=""
+        )
+
+    monkeypatch.setattr(mod, "github_cli_env", fake_github_cli_env)
+    monkeypatch.setattr(mod.subprocess, "run", fake_subprocess_run)
+
+    mod._run(["gh", "api", "rate_limit"], cwd=Path("."), timeout_seconds=5, prefer_app=False)
+
+    assert prefer_app_values == [False]
+    assert captured["env"] == {"BASE_ENV": "1"}
+
+
 def test_check_github_cli_health_ready(monkeypatch) -> None:
     monkeypatch.setattr(mod.shutil, "which", lambda name: "/usr/bin/gh")
 
     def fake_run(
-        args: list[str], *, cwd: Path, timeout_seconds: int
+        args: list[str],
+        *,
+        cwd: Path,
+        timeout_seconds: int,
+        prefer_app: bool = True,
     ) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(args=args, returncode=0, stdout="ok", stderr="")
 
@@ -50,7 +82,11 @@ def test_check_github_cli_health_ready_with_app_env_auth_even_if_auth_status_is_
     calls: list[list[str]] = []
 
     def fake_run(
-        args: list[str], *, cwd: Path, timeout_seconds: int
+        args: list[str],
+        *,
+        cwd: Path,
+        timeout_seconds: int,
+        prefer_app: bool = True,
     ) -> subprocess.CompletedProcess[str]:
         calls.append(args)
         if args[:3] == ["gh", "api", "rate_limit"]:
@@ -77,7 +113,11 @@ def test_check_github_cli_health_detects_connectivity_failure(monkeypatch) -> No
     monkeypatch.setattr(mod.shutil, "which", lambda name: "/usr/bin/gh")
 
     def fake_run(
-        args: list[str], *, cwd: Path, timeout_seconds: int
+        args: list[str],
+        *,
+        cwd: Path,
+        timeout_seconds: int,
+        prefer_app: bool = True,
     ) -> subprocess.CompletedProcess[str]:
         if args[:3] == ["gh", "api", "rate_limit"]:
             return subprocess.CompletedProcess(
@@ -132,7 +172,11 @@ def test_check_github_cli_health_classifies_api_timeout_as_connectivity(
     monkeypatch.setattr(mod.shutil, "which", lambda name: "/usr/bin/gh")
 
     def fake_run(
-        args: list[str], *, cwd: Path, timeout_seconds: int
+        args: list[str],
+        *,
+        cwd: Path,
+        timeout_seconds: int,
+        prefer_app: bool = True,
     ) -> subprocess.CompletedProcess[str]:
         if args[:3] == ["gh", "api", "rate_limit"]:
             return subprocess.CompletedProcess(
@@ -161,7 +205,11 @@ def test_check_github_cli_health_prefers_connectivity_error_when_auth_status_is_
     monkeypatch.setattr(mod.shutil, "which", lambda name: "/usr/bin/gh")
 
     def fake_run(
-        args: list[str], *, cwd: Path, timeout_seconds: int
+        args: list[str],
+        *,
+        cwd: Path,
+        timeout_seconds: int,
+        prefer_app: bool = True,
     ) -> subprocess.CompletedProcess[str]:
         if args[:3] == ["gh", "api", "rate_limit"]:
             return subprocess.CompletedProcess(
@@ -196,7 +244,11 @@ def test_check_github_cli_health_classifies_auth_timeout_as_connectivity(
     monkeypatch.setattr(mod.shutil, "which", lambda name: "/usr/bin/gh")
 
     def fake_run(
-        args: list[str], *, cwd: Path, timeout_seconds: int
+        args: list[str],
+        *,
+        cwd: Path,
+        timeout_seconds: int,
+        prefer_app: bool = True,
     ) -> subprocess.CompletedProcess[str]:
         if args[:3] == ["gh", "api", "rate_limit"]:
             return subprocess.CompletedProcess(
@@ -229,7 +281,11 @@ def test_check_github_cli_health_detects_auth_failure(monkeypatch) -> None:
     monkeypatch.setattr(mod.shutil, "which", lambda name: "/usr/bin/gh")
 
     def fake_run(
-        args: list[str], *, cwd: Path, timeout_seconds: int
+        args: list[str],
+        *,
+        cwd: Path,
+        timeout_seconds: int,
+        prefer_app: bool = True,
     ) -> subprocess.CompletedProcess[str]:
         if args[:3] == ["gh", "api", "rate_limit"]:
             return subprocess.CompletedProcess(


### PR DESCRIPTION
## Summary
- Bound GitHub health probes in branch backlog audit paths.
- Keep audit classification productive during degraded-network runs.
- Skip GitHub App env minting for diagnostic audit health checks.

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest --confcutdir=tests/scripts tests/scripts/test_github_cli_health.py tests/scripts/test_audit_codex_branch_backlog.py -q -> 68 passed
- ruff check scripts/github_cli_health.py scripts/audit_codex_branch_backlog.py tests/scripts/test_github_cli_health.py tests/scripts/test_audit_codex_branch_backlog.py
- ruff format --check scripts/github_cli_health.py scripts/audit_codex_branch_backlog.py tests/scripts/test_github_cli_health.py tests/scripts/test_audit_codex_branch_backlog.py
- git diff --check origin/main...HEAD
- bash scripts/automation_pr_preflight.sh origin/main codex/audit-backlog-github-health-timeout-primary-20260530

## Publication note
Published from idempotent automation-outbox handoff open-pr-codex-audit-backlog-github-health-timeout-primary-20260530-ee869594 after prior attempts were blocked by GitHub connectivity/auth.