### PR TITLE
fix(review-queue): fallback to required check-runs

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -1430,6 +1430,15 @@ def _summarize_required_pr_checks(checks: list[dict[str, Any]]) -> tuple[str, bo
     return ("no required checks", False, False)
 
 
+def _effective_required_pr_check_count(checks: list[dict[str, Any]]) -> int:
+    """Count required PR checks after excluding the current merge-quorum self-check."""
+    return sum(
+        1
+        for check in checks
+        if isinstance(check, dict) and not _is_current_merge_quorum_self_check(check)
+    )
+
+
 def _check_rollup_unavailable(pr: dict[str, Any]) -> bool:
     """Return true when an open PR has no GitHub PR-facing check rollup."""
     pr_state = str(pr.get("state") or "").strip().upper()
@@ -1541,6 +1550,8 @@ def _direct_check_run_is_non_green(run: dict[str, Any]) -> bool:
     if conclusion in {"SUCCESS", "SKIPPED", "NEUTRAL"}:
         return False
     if conclusion:
+        return True
+    if status in {"", "COMPLETED"}:
         return True
     return status in {"QUEUED", "IN_PROGRESS", "PENDING", "EXPECTED"}
 
@@ -1903,9 +1914,11 @@ def _build_packet(
             required_summary, required_has_failures, required_has_pending = (
                 _summarize_required_pr_checks(required_pr_checks)
             )
+            effective_required_count = _effective_required_pr_check_count(required_pr_checks)
             check_surfaces["required_pr_checks"] = {
                 "available": True,
                 "total": len(required_pr_checks),
+                "effective_total": effective_required_count,
                 "summary": required_summary,
                 "failing_or_cancelled": [
                     str(check.get("name") or "").strip()
@@ -1919,7 +1932,11 @@ def _build_packet(
                     and not _is_current_merge_quorum_self_check(check)
                 ][:CHECK_SURFACE_DIAGNOSTIC_LIMIT],
             }
-            if not required_has_failures and not required_has_pending:
+            if (
+                effective_required_count > 0
+                and not required_has_failures
+                and not required_has_pending
+            ):
                 required_pr_check_gate_satisfied = True
                 checks_summary = f"{required_summary} (required PR checks)"
                 has_pending = False

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -33,7 +33,7 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 from aragora.review.invalidation import (
     BaselineMeasurement,
@@ -135,6 +135,7 @@ PARKED_LABELS: tuple[str, ...] = ("stale", "do-not-merge", "wip", "blocked")
 MERGE_QUORUM_CHECK_NAME = "aragora-merge-quorum"
 MERGE_QUORUM_WORKFLOW_NAME = "Aragora Merge Quorum"
 MERGE_QUORUM_JOB_ID = "merge-quorum"
+CHECK_SURFACE_DIAGNOSTIC_LIMIT = 12
 
 LANE_ORDER: dict[str, int] = {
     "ready_now": 0,
@@ -203,6 +204,7 @@ class ReviewPacket:
     machine_recommendation_reason: str
     packet_sha: str
     generated_at: str
+    check_surfaces: dict[str, Any] = field(default_factory=dict)
     protocol: dict[str, Any] = field(default_factory=dict)
     model_review_quorum: dict[str, Any] = field(default_factory=dict)
     advisory_only: bool = True
@@ -1375,6 +1377,157 @@ def _check_rollup_unavailable(pr: dict[str, Any]) -> bool:
     return rollup is None or rollup == []
 
 
+def _repo_slug_from_pr_payload(pr: dict[str, Any], repo_override: str | None) -> str:
+    """Resolve owner/repo from an explicit override or the PR URL."""
+    override = str(repo_override or "").strip()
+    if override:
+        parsed = urlparse(override)
+        if parsed.netloc:
+            parts = [part for part in parsed.path.split("/") if part]
+            if len(parts) >= 2:
+                return f"{parts[0]}/{parts[1]}"
+        if "/" in override and not override.startswith("-"):
+            return override.removeprefix("repos/").strip("/")
+
+    url = str(pr.get("url") or "").strip()
+    parsed = urlparse(url)
+    parts = [part for part in parsed.path.split("/") if part]
+    if len(parts) >= 2:
+        return f"{parts[0]}/{parts[1]}"
+    return ""
+
+
+def _fetch_required_check_contexts(repo_slug: str, base_ref: str) -> list[str]:
+    """Best-effort branch-protection required contexts for diagnostics only."""
+    if not repo_slug or not base_ref:
+        return []
+    try:
+        payload = _gh_json(
+            [
+                "api",
+                f"repos/{repo_slug}/branches/{quote(base_ref, safe='')}"
+                "/protection/required_status_checks",
+            ]
+        )
+    except _GhError:
+        return []
+    if not isinstance(payload, dict):
+        return []
+    contexts = payload.get("contexts") or []
+    return [str(item).strip() for item in contexts if str(item).strip()]
+
+
+def _fetch_direct_commit_check_runs(repo_slug: str, head_sha: str) -> list[dict[str, Any]]:
+    """Best-effort direct commit check-runs for diagnostics only."""
+    if not repo_slug or not head_sha:
+        return []
+    try:
+        payload = _gh_json(
+            [
+                "api",
+                f"repos/{repo_slug}/commits/{head_sha}/check-runs?per_page=100",
+            ]
+        )
+    except _GhError:
+        return []
+    if not isinstance(payload, dict):
+        return []
+    runs = payload.get("check_runs") or []
+    return [run for run in runs if isinstance(run, dict)]
+
+
+def _direct_check_run_name(run: dict[str, Any]) -> str:
+    return str(run.get("name") or run.get("context") or "").strip()
+
+
+def _direct_check_run_is_success(run: dict[str, Any]) -> bool:
+    return str(run.get("conclusion") or "").strip().upper() == "SUCCESS"
+
+
+def _direct_check_run_is_non_green(run: dict[str, Any]) -> bool:
+    status = str(run.get("status") or "").strip().upper()
+    conclusion = str(run.get("conclusion") or "").strip().upper()
+    if conclusion in {"SUCCESS", "SKIPPED", "NEUTRAL"}:
+        return False
+    if conclusion:
+        return True
+    return status in {"QUEUED", "IN_PROGRESS", "PENDING", "EXPECTED"}
+
+
+def _build_check_surface_diagnostics(
+    pr: dict[str, Any],
+    *,
+    repo_override: str | None,
+    checks_summary: str,
+    checks_unavailable: bool,
+) -> dict[str, Any]:
+    """Explain PR-facing check rollup separately from direct commit check-runs.
+
+    Direct commit check-runs are diagnostic only. They intentionally do not make
+    a PR settlement-ready when GitHub's PR-facing rollup is empty.
+    """
+    rollup = pr.get("statusCheckRollup")
+    rollup_count = len(rollup) if isinstance(rollup, list) else None
+    diagnostics: dict[str, Any] = {
+        "pr_rollup": {
+            "available": not checks_unavailable,
+            "count": rollup_count,
+            "summary": checks_summary,
+        }
+    }
+    if not checks_unavailable:
+        return diagnostics
+
+    head_sha = str(pr.get("headRefOid") or "").strip()
+    repo_slug = _repo_slug_from_pr_payload(pr, repo_override)
+    base_ref = str(pr.get("baseRefName") or "main").strip()
+    required_contexts = _fetch_required_check_contexts(repo_slug, base_ref)
+    direct_runs = _fetch_direct_commit_check_runs(repo_slug, head_sha)
+    direct_names = {_direct_check_run_name(run) for run in direct_runs}
+    successful_names = {
+        _direct_check_run_name(run) for run in direct_runs if _direct_check_run_is_success(run)
+    }
+    non_green = [
+        _direct_check_run_name(run)
+        for run in direct_runs
+        if _direct_check_run_name(run) and _direct_check_run_is_non_green(run)
+    ]
+    direct_summary = {
+        "available": bool(direct_runs),
+        "total": len(direct_runs),
+        "required_contexts": required_contexts,
+        "successful_required_contexts": [
+            context for context in required_contexts if context in successful_names
+        ],
+        "missing_required_contexts": [
+            context for context in required_contexts if context not in direct_names
+        ],
+        "non_green_sample": non_green[:CHECK_SURFACE_DIAGNOSTIC_LIMIT],
+        "non_green_count": len(non_green),
+    }
+    diagnostics["direct_commit_check_runs"] = direct_summary
+    if direct_runs:
+        diagnostics["diagnosis"] = (
+            "GitHub PR statusCheckRollup is empty while direct commit check-runs "
+            "exist at the head; merge-packet fails closed because direct checks "
+            "do not replace the PR-facing rollup."
+        )
+        diagnostics["remediation_prompt"] = (
+            "Authorize only a PR-state/check-only nudge to refresh GitHub's PR "
+            "check rollup, or keep the PR blocked and open a bounded CI/tooling "
+            "repair lane. Do not merge from direct commit check-runs alone."
+        )
+    else:
+        diagnostics["diagnosis"] = (
+            "GitHub PR statusCheckRollup is empty and no direct commit check-runs were found."
+        )
+        diagnostics["remediation_prompt"] = (
+            "Wait for checks or authorize a minimal check-only action; do not "
+            "settle or merge while the PR-facing rollup is unavailable."
+        )
+    return diagnostics
+
+
 def _latest_status_check_rollup(checks: list) -> list[dict[str, Any]]:
     """Collapse superseded check-rollup entries to their latest identity.
 
@@ -1484,6 +1637,7 @@ def _build_packet(
             "baseRefOid",
             "state",
             "mergedAt",
+            "baseRefName",
             "isDraft",
             "mergeable",
             "reviewDecision",
@@ -1572,6 +1726,12 @@ def _build_packet(
         risk_flags.append("check rollup unavailable")
     if has_failures:
         risk_flags.append(f"checks failing ({checks_summary})")
+    check_surfaces = _build_check_surface_diagnostics(
+        pr,
+        repo_override=repo_override,
+        checks_summary=checks_summary,
+        checks_unavailable=checks_unavailable,
+    )
 
     if settlement_recorded:
         recommendation = "settled_noop"
@@ -1673,6 +1833,7 @@ def _build_packet(
         machine_recommendation_reason=recommendation_reason,
         packet_sha="",
         generated_at=datetime.now(UTC).isoformat(),
+        check_surfaces=check_surfaces,
         protocol=protocol_dict,
         model_review_quorum=_build_model_review_quorum(
             pr=pr,
@@ -1684,6 +1845,7 @@ def _build_packet(
             checks_unavailable=checks_unavailable,
             settlement_recorded=settlement_recorded,
             human_risk_settlement_recorded=human_risk_settlement_recorded,
+            check_surfaces=check_surfaces,
         ),
     )
     packet.packet_sha = _packet_sha(packet)
@@ -1748,6 +1910,8 @@ def _build_merge_authorization_packet(
             "counted_reviewer_ids": quorum["counted_reviewer_ids"],
             "reasons": quorum["reasons"],
         }
+        if packet.check_surfaces:
+            entry["check_surfaces"] = packet.check_surfaces
         entries.append(entry)
 
     return {
@@ -1791,6 +1955,7 @@ def _build_model_review_quorum(
     checks_unavailable: bool = False,
     settlement_recorded: bool = False,
     human_risk_settlement_recorded: bool = False,
+    check_surfaces: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     tier, tier_name, tier_reason = _classify_model_review_tier(files, pr=pr)
     requirement = _tier_requirement(tier)
@@ -1833,6 +1998,13 @@ def _build_model_review_quorum(
         reasons.append("checks are failing; repair before settlement")
     if checks_unavailable and not settlement_recorded:
         reasons.append("checks are unavailable; wait for GitHub check rollup before settlement")
+        if isinstance(check_surfaces, dict) and (
+            check_surfaces.get("direct_commit_check_runs") or {}
+        ).get("total", 0):
+            reasons.append(
+                "direct commit check-runs are visible, but PR statusCheckRollup is empty; "
+                "refresh the PR-facing check rollup before settlement"
+            )
     elif has_pending and not settlement_recorded:
         reasons.append("checks are pending; wait before settlement")
     if not settlement_recorded:
@@ -2980,6 +3152,26 @@ def _render_packet(packet: ReviewPacket) -> None:
         f"across {packet.changed_files} files"
     )
     print(f"checks:          {packet.checks_summary}")
+    if packet.check_surfaces:
+        rollup = packet.check_surfaces.get("pr_rollup") or {}
+        direct = packet.check_surfaces.get("direct_commit_check_runs") or {}
+        print(
+            "check surfaces:  "
+            f"pr_rollup_available={str(bool(rollup.get('available'))).lower()} "
+            f"pr_rollup_count={rollup.get('count')}"
+        )
+        if direct:
+            print(
+                "                 "
+                f"direct_commit_check_runs={direct.get('total', 0)} "
+                f"successful_required={len(direct.get('successful_required_contexts') or [])}"
+            )
+        diagnosis = str(packet.check_surfaces.get("diagnosis") or "").strip()
+        if diagnosis:
+            print(f"                 diagnosis: {diagnosis}")
+        remediation = str(packet.check_surfaces.get("remediation_prompt") or "").strip()
+        if remediation:
+            print(f"                 remediation: {remediation}")
     print()
     if packet.touched_subsystems:
         print("touched subsystems:")
@@ -3174,6 +3366,25 @@ def _render_merge_authorization_packet(packet: dict[str, Any]) -> None:
         print(f"  {entry.get('title', '')}")
         print(f"  head: {entry.get('head_sha', '')}")
         print(f"  checks: {entry.get('checks_summary', '')}")
+        surfaces = entry.get("check_surfaces") or {}
+        if isinstance(surfaces, dict) and surfaces:
+            rollup = surfaces.get("pr_rollup") or {}
+            direct = surfaces.get("direct_commit_check_runs") or {}
+            print(
+                "  check surfaces: "
+                f"pr_rollup_available={str(bool(rollup.get('available'))).lower()} "
+                f"pr_rollup_count={rollup.get('count')}"
+            )
+            if direct:
+                print(
+                    "  direct checks: "
+                    f"total={direct.get('total', 0)}, "
+                    f"successful_required={len(direct.get('successful_required_contexts') or [])}, "
+                    f"non_green={direct.get('non_green_count', 0)}"
+                )
+            remediation = str(surfaces.get("remediation_prompt") or "").strip()
+            if remediation:
+                print(f"  remediation: {remediation}")
         print(
             "  evidence: "
             f"{len(entry.get('reviewer_signals') or [])} reviewer signal(s), "

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -2003,8 +2003,8 @@ def _build_packet(
         risk_flags.append("check rollup unavailable")
     if has_failures:
         risk_flags.append(f"checks failing ({checks_summary})")
-    required_pr_checks = check_surfaces.get("required_pr_checks") or {}
-    if required_pr_check_gate_satisfied and required_pr_checks:
+    required_pr_check_surface = check_surfaces.get("required_pr_checks") or {}
+    if required_pr_check_gate_satisfied and required_pr_check_surface:
         risk_flags.append(
             "non-required PR checks are non-green; "
             "effective gate uses branch-protection required checks"

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -1421,10 +1421,21 @@ def _fetch_required_status_check_protection(
         return {"available": False, "contexts": [], "strict": None}
     if not isinstance(payload, dict):
         return {"available": False, "contexts": [], "strict": None}
-    contexts = payload.get("contexts") or []
+    contexts: list[str] = []
+    for item in payload.get("contexts") or []:
+        context = str(item).strip()
+        if context:
+            contexts.append(context)
+    for item in payload.get("checks") or []:
+        if not isinstance(item, dict):
+            continue
+        context = str(item.get("context") or "").strip()
+        if context:
+            contexts.append(context)
+    deduped_contexts = list(dict.fromkeys(contexts))
     return {
         "available": True,
-        "contexts": [str(item).strip() for item in contexts if str(item).strip()],
+        "contexts": deduped_contexts,
         "strict": bool(payload.get("strict")),
     }
 
@@ -1453,7 +1464,11 @@ def _direct_check_run_name(run: dict[str, Any]) -> str:
 
 
 def _direct_check_run_is_success(run: dict[str, Any]) -> bool:
-    return str(run.get("conclusion") or "").strip().upper() == "SUCCESS"
+    return str(run.get("conclusion") or "").strip().upper() in {
+        "SUCCESS",
+        "SKIPPED",
+        "NEUTRAL",
+    }
 
 
 def _direct_check_run_is_non_green(run: dict[str, Any]) -> bool:
@@ -1484,7 +1499,11 @@ def _latest_direct_check_runs_by_name(
             or ""
         )
         previous = latest.get(name)
-        if previous is None or (timestamp, index) >= (previous[0], previous[1]):
+        if (
+            previous is None
+            or timestamp > previous[0]
+            or (timestamp == previous[0] and index < previous[1])
+        ):
             latest[name] = (timestamp, index, run)
     return {name: item[2] for name, item in latest.items()}
 
@@ -1516,7 +1535,7 @@ def _build_check_surface_diagnostics(
 
     head_sha = str(pr.get("headRefOid") or "").strip()
     repo_slug = _repo_slug_from_pr_payload(pr, repo_override)
-    base_ref = str(pr.get("baseRefName") or "main").strip()
+    base_ref = str(pr.get("baseRefName") or "").strip()
     required_status_checks = _fetch_required_status_check_protection(repo_slug, base_ref)
     required_contexts = required_status_checks["contexts"]
     strict_required = bool(required_status_checks["strict"])
@@ -1835,6 +1854,12 @@ def _build_packet(
         risk_flags.append("check rollup unavailable")
     if has_failures:
         risk_flags.append(f"checks failing ({checks_summary})")
+    direct_summary = check_surfaces.get("direct_commit_check_runs") or {}
+    if direct_check_fallback_satisfied and direct_summary.get("non_green_count", 0):
+        risk_flags.append(
+            "non-required direct check-runs are non-green; "
+            "fallback gates only branch-protection required contexts"
+        )
 
     if settlement_recorded:
         recommendation = "settled_noop"

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -1399,8 +1399,16 @@ def _repo_slug_from_pr_payload(pr: dict[str, Any], repo_override: str | None) ->
 
 def _fetch_required_check_contexts(repo_slug: str, base_ref: str) -> list[str]:
     """Best-effort branch-protection required contexts for diagnostics only."""
+    return _fetch_required_status_check_protection(repo_slug, base_ref)["contexts"]
+
+
+def _fetch_required_status_check_protection(
+    repo_slug: str,
+    base_ref: str,
+) -> dict[str, Any]:
+    """Best-effort branch-protection required status-check settings."""
     if not repo_slug or not base_ref:
-        return []
+        return {"available": False, "contexts": [], "strict": None}
     try:
         payload = _gh_json(
             [
@@ -1410,11 +1418,15 @@ def _fetch_required_check_contexts(repo_slug: str, base_ref: str) -> list[str]:
             ]
         )
     except _GhError:
-        return []
+        return {"available": False, "contexts": [], "strict": None}
     if not isinstance(payload, dict):
-        return []
+        return {"available": False, "contexts": [], "strict": None}
     contexts = payload.get("contexts") or []
-    return [str(item).strip() for item in contexts if str(item).strip()]
+    return {
+        "available": True,
+        "contexts": [str(item).strip() for item in contexts if str(item).strip()],
+        "strict": bool(payload.get("strict")),
+    }
 
 
 def _fetch_direct_commit_check_runs(repo_slug: str, head_sha: str) -> list[dict[str, Any]]:
@@ -1505,7 +1517,9 @@ def _build_check_surface_diagnostics(
     head_sha = str(pr.get("headRefOid") or "").strip()
     repo_slug = _repo_slug_from_pr_payload(pr, repo_override)
     base_ref = str(pr.get("baseRefName") or "main").strip()
-    required_contexts = _fetch_required_check_contexts(repo_slug, base_ref)
+    required_status_checks = _fetch_required_status_check_protection(repo_slug, base_ref)
+    required_contexts = required_status_checks["contexts"]
+    strict_required = bool(required_status_checks["strict"])
     direct_runs = _fetch_direct_commit_check_runs(repo_slug, head_sha)
     latest_direct_runs = _latest_direct_check_runs_by_name(direct_runs)
     direct_names = set(latest_direct_runs)
@@ -1526,12 +1540,18 @@ def _build_check_surface_diagnostics(
         for context in required_contexts
         if context in direct_names and context not in successful_names
     ]
-    required_contexts_satisfied = bool(required_contexts) and not (
-        missing_required_contexts or non_success_required_contexts
+    required_contexts_satisfied = (
+        bool(required_contexts)
+        and not strict_required
+        and not (missing_required_contexts or non_success_required_contexts)
     )
     direct_summary = {
         "available": bool(direct_runs),
         "total": len(direct_runs),
+        "branch_protection_required_status_checks_available": bool(
+            required_status_checks["available"]
+        ),
+        "branch_protection_strict": strict_required,
         "required_contexts": required_contexts,
         "successful_required_contexts": successful_required_contexts,
         "missing_required_contexts": missing_required_contexts,
@@ -1552,16 +1572,29 @@ def _build_check_surface_diagnostics(
             "exact-head branch-protection required check-runs."
         )
     elif direct_runs:
-        diagnostics["diagnosis"] = (
-            "GitHub PR statusCheckRollup is empty while direct commit check-runs "
-            "exist at the head; merge-packet fails closed because direct checks "
-            "do not satisfy all branch-protection required contexts."
-        )
-        diagnostics["remediation_prompt"] = (
-            "Authorize only a PR-state/check-only nudge to refresh GitHub's PR "
-            "check rollup, or keep the PR blocked and open a bounded CI/tooling "
-            "repair lane. Do not merge from direct commit check-runs alone."
-        )
+        if strict_required:
+            diagnostics["diagnosis"] = (
+                "GitHub PR statusCheckRollup is empty while exact-head direct commit "
+                "check-runs exist, but branch protection requires strict base freshness; "
+                "merge-packet fails closed because direct commit check-runs alone do "
+                "not prove the PR is up to date with base."
+            )
+            diagnostics["remediation_prompt"] = (
+                "Refresh the PR-facing check rollup after the branch is current with "
+                "base, or keep the PR blocked. Do not settle from direct commit "
+                "check-runs alone when branch protection is strict."
+            )
+        else:
+            diagnostics["diagnosis"] = (
+                "GitHub PR statusCheckRollup is empty while direct commit check-runs "
+                "exist at the head; merge-packet fails closed because direct checks "
+                "do not satisfy all branch-protection required contexts."
+            )
+            diagnostics["remediation_prompt"] = (
+                "Authorize only a PR-state/check-only nudge to refresh GitHub's PR "
+                "check rollup, or keep the PR blocked and open a bounded CI/tooling "
+                "repair lane. Do not merge from direct commit check-runs alone."
+            )
     else:
         diagnostics["diagnosis"] = (
             "GitHub PR statusCheckRollup is empty and no direct commit check-runs were found."

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -1454,6 +1454,29 @@ def _direct_check_run_is_non_green(run: dict[str, Any]) -> bool:
     return status in {"QUEUED", "IN_PROGRESS", "PENDING", "EXPECTED"}
 
 
+def _latest_direct_check_runs_by_name(
+    runs: list[dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    latest: dict[str, tuple[str, int, dict[str, Any]]] = {}
+    for index, run in enumerate(runs):
+        name = _direct_check_run_name(run)
+        if not name:
+            continue
+        timestamp = str(
+            run.get("completed_at")
+            or run.get("started_at")
+            or run.get("created_at")
+            or run.get("completedAt")
+            or run.get("startedAt")
+            or run.get("createdAt")
+            or ""
+        )
+        previous = latest.get(name)
+        if previous is None or (timestamp, index) >= (previous[0], previous[1]):
+            latest[name] = (timestamp, index, run)
+    return {name: item[2] for name, item in latest.items()}
+
+
 def _build_check_surface_diagnostics(
     pr: dict[str, Any],
     *,
@@ -1463,8 +1486,9 @@ def _build_check_surface_diagnostics(
 ) -> dict[str, Any]:
     """Explain PR-facing check rollup separately from direct commit check-runs.
 
-    Direct commit check-runs are diagnostic only. They intentionally do not make
-    a PR settlement-ready when GitHub's PR-facing rollup is empty.
+    Direct commit check-runs are a fail-closed fallback only when branch
+    protection required contexts are known and all are successful at the exact
+    PR head.
     """
     rollup = pr.get("statusCheckRollup")
     rollup_count = len(rollup) if isinstance(rollup, list) else None
@@ -1483,34 +1507,55 @@ def _build_check_surface_diagnostics(
     base_ref = str(pr.get("baseRefName") or "main").strip()
     required_contexts = _fetch_required_check_contexts(repo_slug, base_ref)
     direct_runs = _fetch_direct_commit_check_runs(repo_slug, head_sha)
-    direct_names = {_direct_check_run_name(run) for run in direct_runs}
+    latest_direct_runs = _latest_direct_check_runs_by_name(direct_runs)
+    direct_names = set(latest_direct_runs)
     successful_names = {
-        _direct_check_run_name(run) for run in direct_runs if _direct_check_run_is_success(run)
+        name for name, run in latest_direct_runs.items() if _direct_check_run_is_success(run)
     }
     non_green = [
-        _direct_check_run_name(run)
-        for run in direct_runs
-        if _direct_check_run_name(run) and _direct_check_run_is_non_green(run)
+        name for name, run in latest_direct_runs.items() if _direct_check_run_is_non_green(run)
     ]
+    missing_required_contexts = [
+        context for context in required_contexts if context not in direct_names
+    ]
+    successful_required_contexts = [
+        context for context in required_contexts if context in successful_names
+    ]
+    non_success_required_contexts = [
+        context
+        for context in required_contexts
+        if context in direct_names and context not in successful_names
+    ]
+    required_contexts_satisfied = bool(required_contexts) and not (
+        missing_required_contexts or non_success_required_contexts
+    )
     direct_summary = {
         "available": bool(direct_runs),
         "total": len(direct_runs),
         "required_contexts": required_contexts,
-        "successful_required_contexts": [
-            context for context in required_contexts if context in successful_names
-        ],
-        "missing_required_contexts": [
-            context for context in required_contexts if context not in direct_names
-        ],
+        "successful_required_contexts": successful_required_contexts,
+        "missing_required_contexts": missing_required_contexts,
+        "non_success_required_contexts": non_success_required_contexts,
+        "required_contexts_satisfied": required_contexts_satisfied,
         "non_green_sample": non_green[:CHECK_SURFACE_DIAGNOSTIC_LIMIT],
         "non_green_count": len(non_green),
     }
     diagnostics["direct_commit_check_runs"] = direct_summary
-    if direct_runs:
+    if required_contexts_satisfied:
+        diagnostics["diagnosis"] = (
+            "GitHub PR statusCheckRollup is empty, but exact-head direct commit "
+            "check-runs show every branch-protection required context successful; "
+            "merge-packet uses the direct required check-run fallback."
+        )
+        diagnostics["remediation_prompt"] = (
+            "No check-rollup nudge is required for settlement; continue gating on "
+            "exact-head branch-protection required check-runs."
+        )
+    elif direct_runs:
         diagnostics["diagnosis"] = (
             "GitHub PR statusCheckRollup is empty while direct commit check-runs "
             "exist at the head; merge-packet fails closed because direct checks "
-            "do not replace the PR-facing rollup."
+            "do not satisfy all branch-protection required contexts."
         )
         diagnostics["remediation_prompt"] = (
             "Authorize only a PR-state/check-only nudge to refresh GitHub's PR "
@@ -1526,6 +1571,13 @@ def _build_check_surface_diagnostics(
             "settle or merge while the PR-facing rollup is unavailable."
         )
     return diagnostics
+
+
+def _direct_required_check_fallback_satisfied(check_surfaces: dict[str, Any]) -> bool:
+    direct = check_surfaces.get("direct_commit_check_runs")
+    if not isinstance(direct, dict):
+        return False
+    return bool(direct.get("required_contexts_satisfied"))
 
 
 def _latest_status_check_rollup(checks: list) -> list[dict[str, Any]]:
@@ -1679,6 +1731,30 @@ def _build_packet(
     if checks_unavailable:
         checks_summary = "no checks reported"
         has_pending = True
+    check_surfaces = _build_check_surface_diagnostics(
+        pr,
+        repo_override=repo_override,
+        checks_summary=checks_summary,
+        checks_unavailable=checks_unavailable,
+    )
+    direct_check_fallback_satisfied = (
+        checks_unavailable and _direct_required_check_fallback_satisfied(check_surfaces)
+    )
+    if direct_check_fallback_satisfied:
+        direct_summary = check_surfaces["direct_commit_check_runs"]
+        successful_required = direct_summary.get("successful_required_contexts") or []
+        required_contexts = direct_summary.get("required_contexts") or []
+        checks_summary = (
+            f"{len(successful_required)}/{len(required_contexts)} required green "
+            "(direct check-runs fallback)"
+        )
+        has_pending = False
+        has_failures = False
+        checks_unavailable = False
+        check_surfaces["effective_gate"] = {
+            "source": "direct_commit_check_runs",
+            "summary": checks_summary,
+        }
     additions = int(pr.get("additions", 0) or 0)
     deletions = int(pr.get("deletions", 0) or 0)
     is_draft = bool(pr.get("isDraft", False))
@@ -1726,12 +1802,6 @@ def _build_packet(
         risk_flags.append("check rollup unavailable")
     if has_failures:
         risk_flags.append(f"checks failing ({checks_summary})")
-    check_surfaces = _build_check_surface_diagnostics(
-        pr,
-        repo_override=repo_override,
-        checks_summary=checks_summary,
-        checks_unavailable=checks_unavailable,
-    )
 
     if settlement_recorded:
         recommendation = "settled_noop"

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -1889,7 +1889,13 @@ def _build_packet(
         recommendation_reason = "checks still pending — wait for completion"
     else:
         recommendation = "approve_candidate"
-        recommendation_reason = "all green, bounded diff, no high-risk paths"
+        if direct_check_fallback_satisfied and direct_summary.get("non_green_count", 0):
+            recommendation_reason = (
+                "branch-protection required contexts green via direct check-run fallback; "
+                "non-required direct check-runs are non-green"
+            )
+        else:
+            recommendation_reason = "all green, bounded diff, no high-risk paths"
 
     author = ""
     author_payload = pr.get("author")

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -1397,11 +1397,6 @@ def _repo_slug_from_pr_payload(pr: dict[str, Any], repo_override: str | None) ->
     return ""
 
 
-def _fetch_required_check_contexts(repo_slug: str, base_ref: str) -> list[str]:
-    """Best-effort branch-protection required contexts for diagnostics only."""
-    return _fetch_required_status_check_protection(repo_slug, base_ref)["contexts"]
-
-
 def _fetch_required_status_check_protection(
     repo_slug: str,
     base_ref: str,
@@ -1421,21 +1416,26 @@ def _fetch_required_status_check_protection(
         return {"available": False, "contexts": [], "strict": None}
     if not isinstance(payload, dict):
         return {"available": False, "contexts": [], "strict": None}
-    contexts: list[str] = []
+    required_by_context: dict[str, dict[str, Any]] = {}
     for item in payload.get("contexts") or []:
         context = str(item).strip()
         if context:
-            contexts.append(context)
+            required_by_context.setdefault(context, {"context": context, "app_id": None})
     for item in payload.get("checks") or []:
         if not isinstance(item, dict):
             continue
         context = str(item.get("context") or "").strip()
         if context:
-            contexts.append(context)
-    deduped_contexts = list(dict.fromkeys(contexts))
+            app_id = item.get("app_id")
+            required_by_context[context] = {
+                "context": context,
+                "app_id": app_id if app_id is not None else None,
+            }
+    required_checks = list(required_by_context.values())
     return {
         "available": True,
-        "contexts": deduped_contexts,
+        "contexts": [item["context"] for item in required_checks],
+        "checks": required_checks,
         "strict": bool(payload.get("strict")),
     }
 
@@ -1508,6 +1508,48 @@ def _latest_direct_check_runs_by_name(
     return {name: item[2] for name, item in latest.items()}
 
 
+def _direct_check_run_app_id(run: dict[str, Any]) -> Any:
+    app = run.get("app")
+    if isinstance(app, dict):
+        return app.get("id")
+    return None
+
+
+def _direct_check_run_matches_required(run: dict[str, Any], required: dict[str, Any]) -> bool:
+    if _direct_check_run_name(run) != required.get("context"):
+        return False
+    required_app_id = required.get("app_id")
+    if required_app_id is None:
+        return True
+    return _direct_check_run_app_id(run) == required_app_id
+
+
+def _latest_direct_check_run_for_required(
+    runs: list[dict[str, Any]],
+    required: dict[str, Any],
+) -> dict[str, Any] | None:
+    latest: tuple[str, int, dict[str, Any]] | None = None
+    for index, run in enumerate(runs):
+        if not _direct_check_run_matches_required(run, required):
+            continue
+        timestamp = str(
+            run.get("completed_at")
+            or run.get("started_at")
+            or run.get("created_at")
+            or run.get("completedAt")
+            or run.get("startedAt")
+            or run.get("createdAt")
+            or ""
+        )
+        if (
+            latest is None
+            or timestamp > latest[0]
+            or (timestamp == latest[0] and index < latest[1])
+        ):
+            latest = (timestamp, index, run)
+    return latest[2] if latest else None
+
+
 def _build_check_surface_diagnostics(
     pr: dict[str, Any],
     *,
@@ -1538,27 +1580,27 @@ def _build_check_surface_diagnostics(
     base_ref = str(pr.get("baseRefName") or "").strip()
     required_status_checks = _fetch_required_status_check_protection(repo_slug, base_ref)
     required_contexts = required_status_checks["contexts"]
+    required_check_specs = required_status_checks.get("checks") or []
     strict_required = bool(required_status_checks["strict"])
     direct_runs = _fetch_direct_commit_check_runs(repo_slug, head_sha)
     latest_direct_runs = _latest_direct_check_runs_by_name(direct_runs)
-    direct_names = set(latest_direct_runs)
-    successful_names = {
-        name for name, run in latest_direct_runs.items() if _direct_check_run_is_success(run)
-    }
     non_green = [
         name for name, run in latest_direct_runs.items() if _direct_check_run_is_non_green(run)
     ]
-    missing_required_contexts = [
-        context for context in required_contexts if context not in direct_names
-    ]
-    successful_required_contexts = [
-        context for context in required_contexts if context in successful_names
-    ]
-    non_success_required_contexts = [
-        context
-        for context in required_contexts
-        if context in direct_names and context not in successful_names
-    ]
+    missing_required_contexts: list[str] = []
+    successful_required_contexts: list[str] = []
+    non_success_required_contexts: list[str] = []
+    for required in required_check_specs:
+        context = str(required.get("context") or "").strip()
+        if not context:
+            continue
+        run = _latest_direct_check_run_for_required(direct_runs, required)
+        if run is None:
+            missing_required_contexts.append(context)
+        elif _direct_check_run_is_success(run):
+            successful_required_contexts.append(context)
+        else:
+            non_success_required_contexts.append(context)
     required_contexts_satisfied = (
         bool(required_contexts)
         and not strict_required
@@ -1572,6 +1614,7 @@ def _build_check_surface_diagnostics(
         ),
         "branch_protection_strict": strict_required,
         "required_contexts": required_contexts,
+        "required_checks": required_check_specs,
         "successful_required_contexts": successful_required_contexts,
         "missing_required_contexts": missing_required_contexts,
         "non_success_required_contexts": non_success_required_contexts,

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -1366,6 +1366,70 @@ def _summarize_checks(checks: list) -> tuple[str, bool, bool]:
     return ("no checks", False, False)
 
 
+def _fetch_required_pr_checks(pr_number: int, repo_override: str | None) -> list[dict[str, Any]]:
+    """Fetch GitHub's branch-protection-required PR checks."""
+    args = [
+        "pr",
+        "checks",
+        str(pr_number),
+        "--required",
+        "--json",
+        "name,state,bucket,workflow,link,startedAt,completedAt",
+    ]
+    if repo_override:
+        args.extend(["--repo", repo_override])
+    try:
+        payload = _gh_json(args)
+    except _GhError:
+        return []
+    if not isinstance(payload, list):
+        return []
+    return [item for item in payload if isinstance(item, dict)]
+
+
+def _required_pr_check_bucket(check: dict[str, Any]) -> str:
+    bucket = str(check.get("bucket") or "").strip().lower()
+    if bucket:
+        return bucket
+    state = str(check.get("state") or "").strip().upper()
+    if state in {"SUCCESS", "SUCCESSFUL", "COMPLETED"}:
+        return "pass"
+    if state in {"SKIPPED", "NEUTRAL"}:
+        return "skipping"
+    if state in {"FAILURE", "FAILED", "ERROR", "TIMED_OUT", "ACTION_REQUIRED"}:
+        return "fail"
+    if state in {"CANCELLED", "CANCELED"}:
+        return "cancel"
+    if state in {"PENDING", "QUEUED", "IN_PROGRESS", "EXPECTED", ""}:
+        return "pending"
+    return state.lower()
+
+
+def _summarize_required_pr_checks(checks: list[dict[str, Any]]) -> tuple[str, bool, bool]:
+    """Return ``(summary, has_failures, has_pending)`` for required PR checks."""
+    success = failure = pending = 0
+    for check in checks:
+        if _is_current_merge_quorum_self_check(check):
+            continue
+        bucket = _required_pr_check_bucket(check)
+        if bucket in {"pass", "skipping"}:
+            success += 1
+        elif bucket in {"fail", "cancel"}:
+            failure += 1
+        elif bucket == "pending":
+            pending += 1
+        else:
+            pending += 1
+    total = success + failure + pending
+    if failure > 0:
+        return (f"{failure} failing / {total} required", True, pending > 0)
+    if pending > 0:
+        return (f"{pending} pending / {total} required", False, True)
+    if success > 0:
+        return (f"{success}/{total} required green", False, False)
+    return ("no required checks", False, False)
+
+
 def _check_rollup_unavailable(pr: dict[str, Any]) -> bool:
     """Return true when an open PR has no GitHub PR-facing check rollup."""
     pr_state = str(pr.get("state") or "").strip().upper()
@@ -1832,6 +1896,48 @@ def _build_packet(
         checks_summary=checks_summary,
         checks_unavailable=checks_unavailable,
     )
+    required_pr_check_gate_satisfied = False
+    if not checks_unavailable and (has_failures or has_pending):
+        required_pr_checks = _fetch_required_pr_checks(number, repo_override)
+        if required_pr_checks:
+            required_summary, required_has_failures, required_has_pending = (
+                _summarize_required_pr_checks(required_pr_checks)
+            )
+            check_surfaces["required_pr_checks"] = {
+                "available": True,
+                "total": len(required_pr_checks),
+                "summary": required_summary,
+                "failing_or_cancelled": [
+                    str(check.get("name") or "").strip()
+                    for check in required_pr_checks
+                    if _required_pr_check_bucket(check) in {"fail", "cancel"}
+                ][:CHECK_SURFACE_DIAGNOSTIC_LIMIT],
+                "pending": [
+                    str(check.get("name") or "").strip()
+                    for check in required_pr_checks
+                    if _required_pr_check_bucket(check) == "pending"
+                    and not _is_current_merge_quorum_self_check(check)
+                ][:CHECK_SURFACE_DIAGNOSTIC_LIMIT],
+            }
+            if not required_has_failures and not required_has_pending:
+                required_pr_check_gate_satisfied = True
+                checks_summary = f"{required_summary} (required PR checks)"
+                has_pending = False
+                has_failures = False
+                checks_unavailable = False
+                check_surfaces["effective_gate"] = {
+                    "source": "required_pr_checks",
+                    "summary": checks_summary,
+                }
+                check_surfaces["diagnosis"] = (
+                    "The PR check rollup includes non-required non-green checks, "
+                    "but GitHub reports every branch-protection required check green; "
+                    "merge-packet uses the required PR checks gate."
+                )
+                check_surfaces["remediation_prompt"] = (
+                    "Continue gating on branch-protection required checks; keep "
+                    "non-required shadow/advisory check failures visible but non-blocking."
+                )
     direct_check_fallback_satisfied = (
         checks_unavailable and _direct_required_check_fallback_satisfied(check_surfaces)
     )
@@ -1897,6 +2003,12 @@ def _build_packet(
         risk_flags.append("check rollup unavailable")
     if has_failures:
         risk_flags.append(f"checks failing ({checks_summary})")
+    required_pr_checks = check_surfaces.get("required_pr_checks") or {}
+    if required_pr_check_gate_satisfied and required_pr_checks:
+        risk_flags.append(
+            "non-required PR checks are non-green; "
+            "effective gate uses branch-protection required checks"
+        )
     direct_summary = check_surfaces.get("direct_commit_check_runs") or {}
     if direct_check_fallback_satisfied and direct_summary.get("non_green_count", 0):
         risk_flags.append(
@@ -1932,7 +2044,11 @@ def _build_packet(
         recommendation_reason = "checks still pending — wait for completion"
     else:
         recommendation = "approve_candidate"
-        if direct_check_fallback_satisfied and direct_summary.get("non_green_count", 0):
+        if required_pr_check_gate_satisfied:
+            recommendation_reason = (
+                "branch-protection required checks green; non-required PR checks are non-green"
+            )
+        elif direct_check_fallback_satisfied and direct_summary.get("non_green_count", 0):
             recommendation_reason = (
                 "branch-protection required contexts green via direct check-run fallback; "
                 "non-required direct check-runs are non-green"
@@ -3332,11 +3448,18 @@ def _render_packet(packet: ReviewPacket) -> None:
     if packet.check_surfaces:
         rollup = packet.check_surfaces.get("pr_rollup") or {}
         direct = packet.check_surfaces.get("direct_commit_check_runs") or {}
+        required = packet.check_surfaces.get("required_pr_checks") or {}
         print(
             "check surfaces:  "
             f"pr_rollup_available={str(bool(rollup.get('available'))).lower()} "
             f"pr_rollup_count={rollup.get('count')}"
         )
+        if required:
+            print(
+                "                 "
+                f"required_pr_checks={required.get('total', 0)} "
+                f"summary={required.get('summary')}"
+            )
         if direct:
             print(
                 "                 "

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -1787,6 +1787,46 @@ class TestBuildQueueAndPacket:
             "checks are unavailable" in reason for reason in packet.model_review_quorum["reasons"]
         )
 
+    def test_missing_check_rollup_fails_closed_when_branch_protection_is_strict(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pr_payload = _make_pr(number=7465, files=["docs/status/open.md"])
+        pr_payload["statusCheckRollup"] = []
+        pr_payload["comments"] = [
+            _dogfood_comment("## Claude focused dogfood\npass"),
+            {
+                "author": {"login": "an0mium"},
+                "body": "## Grok independent model review\nVerdict: approve.",
+            },
+        ]
+
+        def fake_gh_json(args: list[str]) -> dict[str, Any]:
+            if args[:2] == ["pr", "view"]:
+                return pr_payload
+            if args[:1] == ["api"] and "required_status_checks" in args[1]:
+                return {"contexts": ["lint", "typecheck"], "strict": True}
+            if args[:1] == ["api"] and "check-runs" in args[1]:
+                return {
+                    "check_runs": [
+                        {"name": "lint", "status": "completed", "conclusion": "success"},
+                        {"name": "typecheck", "status": "completed", "conclusion": "success"},
+                    ]
+                }
+            raise AssertionError(f"unexpected gh call: {args}")
+
+        monkeypatch.setattr("aragora.cli.commands.review_queue._gh_json", fake_gh_json)
+
+        packet = _build_packet("7465", repo_override=None)
+        direct = packet.check_surfaces["direct_commit_check_runs"]
+
+        assert packet.checks_summary == "no checks reported"
+        assert direct["branch_protection_strict"] is True
+        assert direct["successful_required_contexts"] == ["lint", "typecheck"]
+        assert direct["required_contexts_satisfied"] is False
+        assert packet.model_review_quorum["admin_squash_allowed"] is False
+        assert packet.model_review_quorum["status"] == "repair_or_wait"
+        assert "strict base freshness" in packet.check_surfaces["diagnosis"]
+
     def test_missing_check_rollup_fails_closed_when_required_context_missing(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -1805,6 +1805,69 @@ class TestBuildQueueAndPacket:
         assert "diagnosis:" in rendered_packet
         assert "remediation:" in rendered_packet
 
+    def test_non_required_rollup_failures_use_required_pr_checks_gate(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pr_payload = _make_pr(
+            number=7465,
+            files=["docs/status/open.md"],
+            checks=[
+                {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
+                {"name": "typecheck", "status": "COMPLETED", "conclusion": "SUCCESS"},
+                {
+                    "name": "Mac TypeScript SDK Shadow",
+                    "status": "QUEUED",
+                    "conclusion": "",
+                },
+                {"name": "Docs Consistency", "status": "COMPLETED", "conclusion": "FAILURE"},
+            ],
+        )
+        pr_payload["comments"] = [
+            _dogfood_comment("## Claude focused dogfood\npass"),
+            {
+                "author": {"login": "an0mium"},
+                "body": "## Grok independent model review\nVerdict: approve.",
+            },
+        ]
+
+        def fake_gh_json(args: list[str]) -> Any:
+            if args[:2] == ["pr", "view"]:
+                return pr_payload
+            if args[:2] == ["pr", "checks"]:
+                return [
+                    {
+                        "name": "lint",
+                        "state": "SUCCESS",
+                        "bucket": "pass",
+                        "workflow": "Lint",
+                    },
+                    {
+                        "name": "typecheck",
+                        "state": "SUCCESS",
+                        "bucket": "pass",
+                        "workflow": "Lint",
+                    },
+                ]
+            raise AssertionError(f"unexpected gh call: {args}")
+
+        monkeypatch.setattr("aragora.cli.commands.review_queue._gh_json", fake_gh_json)
+
+        packet = _build_packet("7465", repo_override=None)
+
+        assert packet.checks_summary == "2/2 required green (required PR checks)"
+        assert packet.check_surfaces["effective_gate"] == {
+            "source": "required_pr_checks",
+            "summary": "2/2 required green (required PR checks)",
+        }
+        assert (
+            "non-required PR checks are non-green; "
+            "effective gate uses branch-protection required checks"
+        ) in packet.risk_flags
+        assert "non-required PR checks are non-green" in packet.machine_recommendation_reason
+        assert packet.machine_recommendation == "approve_candidate"
+        assert packet.model_review_quorum["admin_squash_allowed"] is True
+        assert packet.model_review_quorum["status"] == "satisfied"
+
     def test_missing_check_rollup_uses_modern_checks_field_and_skipped_neutral(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -81,6 +81,7 @@ def _make_pr(
         "mergedAt": merged_at,
         "headRefName": f"branch-{number}",
         "headRefOid": f"sha{number:08d}",
+        "baseRefName": "main",
         "baseRefOid": "basesha0001",
         "isDraft": is_draft,
         "mergeable": mergeable,
@@ -1767,11 +1768,16 @@ class TestBuildQueueAndPacket:
         assert packet.checks_summary == "2/2 required green (direct check-runs fallback)"
         assert "check rollup unavailable" not in packet.risk_flags
         assert direct["total"] == 3
+        assert direct["branch_protection_strict"] is False
         assert direct["successful_required_contexts"] == ["lint", "typecheck"]
         assert direct["missing_required_contexts"] == []
         assert direct["non_success_required_contexts"] == []
         assert direct["required_contexts_satisfied"] is True
         assert direct["non_green_sample"] == ["Python SDK Tests (3.11)"]
+        assert (
+            "non-required direct check-runs are non-green; "
+            "fallback gates only branch-protection required contexts"
+        ) in packet.risk_flags
         assert packet.check_surfaces["effective_gate"] == {
             "source": "direct_commit_check_runs",
             "summary": "2/2 required green (direct check-runs fallback)",
@@ -1786,6 +1792,53 @@ class TestBuildQueueAndPacket:
         assert not any(
             "checks are unavailable" in reason for reason in packet.model_review_quorum["reasons"]
         )
+
+    def test_missing_check_rollup_uses_modern_checks_field_and_skipped_neutral(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pr_payload = _make_pr(number=7465, files=["docs/status/open.md"])
+        pr_payload["statusCheckRollup"] = []
+        pr_payload["comments"] = [
+            _dogfood_comment("## Claude focused dogfood\npass"),
+            {
+                "author": {"login": "an0mium"},
+                "body": "## Grok independent model review\nVerdict: approve.",
+            },
+        ]
+
+        def fake_gh_json(args: list[str]) -> dict[str, Any]:
+            if args[:2] == ["pr", "view"]:
+                return pr_payload
+            if args[:1] == ["api"] and "required_status_checks" in args[1]:
+                return {
+                    "contexts": [],
+                    "checks": [{"context": "lint"}, {"context": "typecheck"}],
+                    "strict": False,
+                }
+            if args[:1] == ["api"] and "check-runs" in args[1]:
+                return {
+                    "check_runs": [
+                        {"name": "lint", "status": "completed", "conclusion": "skipped"},
+                        {
+                            "name": "typecheck",
+                            "status": "completed",
+                            "conclusion": "neutral",
+                        },
+                    ]
+                }
+            raise AssertionError(f"unexpected gh call: {args}")
+
+        monkeypatch.setattr("aragora.cli.commands.review_queue._gh_json", fake_gh_json)
+
+        packet = _build_packet("7465", repo_override=None)
+        direct = packet.check_surfaces["direct_commit_check_runs"]
+
+        assert packet.checks_summary == "2/2 required green (direct check-runs fallback)"
+        assert direct["required_contexts"] == ["lint", "typecheck"]
+        assert direct["successful_required_contexts"] == ["lint", "typecheck"]
+        assert direct["non_success_required_contexts"] == []
+        assert direct["required_contexts_satisfied"] is True
+        assert packet.model_review_quorum["admin_squash_allowed"] is True
 
     def test_missing_check_rollup_fails_closed_when_branch_protection_is_strict(
         self, monkeypatch: pytest.MonkeyPatch
@@ -1826,6 +1879,44 @@ class TestBuildQueueAndPacket:
         assert packet.model_review_quorum["admin_squash_allowed"] is False
         assert packet.model_review_quorum["status"] == "repair_or_wait"
         assert "strict base freshness" in packet.check_surfaces["diagnosis"]
+
+    def test_missing_check_rollup_fails_closed_when_base_ref_is_unknown(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pr_payload = _make_pr(number=7465, files=["docs/status/open.md"])
+        pr_payload.pop("baseRefName", None)
+        pr_payload["statusCheckRollup"] = []
+        pr_payload["comments"] = [
+            _dogfood_comment("## Claude focused dogfood\npass"),
+            {
+                "author": {"login": "an0mium"},
+                "body": "## Grok independent model review\nVerdict: approve.",
+            },
+        ]
+
+        def fake_gh_json(args: list[str]) -> dict[str, Any]:
+            if args[:2] == ["pr", "view"]:
+                return pr_payload
+            if args[:1] == ["api"] and "required_status_checks" in args[1]:
+                raise AssertionError("must not query a fabricated default base ref")
+            if args[:1] == ["api"] and "check-runs" in args[1]:
+                return {
+                    "check_runs": [
+                        {"name": "lint", "status": "completed", "conclusion": "success"},
+                    ]
+                }
+            raise AssertionError(f"unexpected gh call: {args}")
+
+        monkeypatch.setattr("aragora.cli.commands.review_queue._gh_json", fake_gh_json)
+
+        packet = _build_packet("7465", repo_override=None)
+        direct = packet.check_surfaces["direct_commit_check_runs"]
+
+        assert direct["branch_protection_required_status_checks_available"] is False
+        assert direct["required_contexts"] == []
+        assert direct["required_contexts_satisfied"] is False
+        assert packet.model_review_quorum["admin_squash_allowed"] is False
+        assert packet.model_review_quorum["status"] == "repair_or_wait"
 
     def test_missing_check_rollup_fails_closed_when_required_context_missing(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -1824,17 +1824,26 @@ class TestBuildQueueAndPacket:
             if args[:1] == ["api"] and "required_status_checks" in args[1]:
                 return {
                     "contexts": [],
-                    "checks": [{"context": "lint"}, {"context": "typecheck"}],
+                    "checks": [
+                        {"context": "lint", "app_id": 15368},
+                        {"context": "typecheck", "app_id": 15368},
+                    ],
                     "strict": False,
                 }
             if args[:1] == ["api"] and "check-runs" in args[1]:
                 return {
                     "check_runs": [
-                        {"name": "lint", "status": "completed", "conclusion": "skipped"},
+                        {
+                            "name": "lint",
+                            "status": "completed",
+                            "conclusion": "skipped",
+                            "app": {"id": 15368},
+                        },
                         {
                             "name": "typecheck",
                             "status": "completed",
                             "conclusion": "neutral",
+                            "app": {"id": 15368},
                         },
                     ]
                 }
@@ -1847,10 +1856,61 @@ class TestBuildQueueAndPacket:
 
         assert packet.checks_summary == "2/2 required green (direct check-runs fallback)"
         assert direct["required_contexts"] == ["lint", "typecheck"]
+        assert direct["required_checks"] == [
+            {"context": "lint", "app_id": 15368},
+            {"context": "typecheck", "app_id": 15368},
+        ]
         assert direct["successful_required_contexts"] == ["lint", "typecheck"]
         assert direct["non_success_required_contexts"] == []
         assert direct["required_contexts_satisfied"] is True
         assert packet.model_review_quorum["admin_squash_allowed"] is True
+
+    def test_missing_check_rollup_fails_closed_when_required_app_binding_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pr_payload = _make_pr(number=7465, files=["docs/status/open.md"])
+        pr_payload["statusCheckRollup"] = []
+        pr_payload["comments"] = [
+            _dogfood_comment("## Claude focused dogfood\npass"),
+            {
+                "author": {"login": "an0mium"},
+                "body": "## Grok independent model review\nVerdict: approve.",
+            },
+        ]
+
+        def fake_gh_json(args: list[str]) -> dict[str, Any]:
+            if args[:2] == ["pr", "view"]:
+                return pr_payload
+            if args[:1] == ["api"] and "required_status_checks" in args[1]:
+                return {
+                    "contexts": [],
+                    "checks": [{"context": "lint", "app_id": 15368}],
+                    "strict": False,
+                }
+            if args[:1] == ["api"] and "check-runs" in args[1]:
+                return {
+                    "check_runs": [
+                        {
+                            "name": "lint",
+                            "status": "completed",
+                            "conclusion": "success",
+                            "app": {"id": 99999},
+                        },
+                    ]
+                }
+            raise AssertionError(f"unexpected gh call: {args}")
+
+        monkeypatch.setattr("aragora.cli.commands.review_queue._gh_json", fake_gh_json)
+
+        packet = _build_packet("7465", repo_override=None)
+        direct = packet.check_surfaces["direct_commit_check_runs"]
+
+        assert direct["required_contexts"] == ["lint"]
+        assert direct["required_checks"] == [{"context": "lint", "app_id": 15368}]
+        assert direct["missing_required_contexts"] == ["lint"]
+        assert direct["required_contexts_satisfied"] is False
+        assert packet.model_review_quorum["admin_squash_allowed"] is False
+        assert packet.model_review_quorum["status"] == "repair_or_wait"
 
     def test_missing_check_rollup_fails_closed_when_branch_protection_is_strict(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -1710,10 +1710,69 @@ class TestBuildQueueAndPacket:
         assert packet.checks_summary == "no checks reported"
         assert packet.machine_recommendation == "needs_human_attention"
         assert "check rollup unavailable" in packet.risk_flags
+        assert packet.check_surfaces["pr_rollup"] == {
+            "available": False,
+            "count": None,
+            "summary": "no checks reported",
+        }
         assert packet.model_review_quorum["admin_squash_allowed"] is False
         assert packet.model_review_quorum["status"] == "repair_or_wait"
         assert (
             "checks are unavailable; wait for GitHub check rollup before settlement"
+            in packet.model_review_quorum["reasons"]
+        )
+
+    def test_missing_check_rollup_reports_direct_commit_check_surface(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pr_payload = _make_pr(number=7465, files=["docs/status/open.md"])
+        pr_payload["statusCheckRollup"] = []
+        pr_payload["comments"] = [
+            _dogfood_comment("## Claude focused dogfood\npass"),
+            {
+                "author": {"login": "an0mium"},
+                "body": "## Grok independent model review\nVerdict: approve.",
+            },
+        ]
+
+        def fake_gh_json(args: list[str]) -> dict[str, Any]:
+            if args[:2] == ["pr", "view"]:
+                return pr_payload
+            if args[:1] == ["api"] and "required_status_checks" in args[1]:
+                return {"contexts": ["lint", "typecheck"]}
+            if args[:1] == ["api"] and "check-runs" in args[1]:
+                return {
+                    "check_runs": [
+                        {"name": "lint", "status": "completed", "conclusion": "success"},
+                        {"name": "typecheck", "status": "completed", "conclusion": "success"},
+                        {
+                            "name": "Python SDK Tests (3.11)",
+                            "status": "completed",
+                            "conclusion": "failure",
+                        },
+                    ]
+                }
+            raise AssertionError(f"unexpected gh call: {args}")
+
+        monkeypatch.setattr("aragora.cli.commands.review_queue._gh_json", fake_gh_json)
+
+        packet = _build_packet("7465", repo_override=None)
+        direct = packet.check_surfaces["direct_commit_check_runs"]
+
+        assert packet.check_surfaces["pr_rollup"] == {
+            "available": False,
+            "count": 0,
+            "summary": "no checks reported",
+        }
+        assert direct["total"] == 3
+        assert direct["successful_required_contexts"] == ["lint", "typecheck"]
+        assert direct["missing_required_contexts"] == []
+        assert direct["non_green_sample"] == ["Python SDK Tests (3.11)"]
+        assert "PR statusCheckRollup is empty" in packet.check_surfaces["diagnosis"]
+        assert "PR-state/check-only nudge" in packet.check_surfaces["remediation_prompt"]
+        assert (
+            "direct commit check-runs are visible, but PR statusCheckRollup is empty; "
+            "refresh the PR-facing check rollup before settlement"
             in packet.model_review_quorum["reasons"]
         )
 
@@ -2249,6 +2308,7 @@ class TestJsonOutput:
             "high_risk_paths_touched",
             "validation",
             "checks_summary",
+            "check_surfaces",
             "risk_flags",
             "machine_recommendation",
             "machine_recommendation_reason",

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -1868,6 +1868,55 @@ class TestBuildQueueAndPacket:
         assert packet.model_review_quorum["admin_squash_allowed"] is True
         assert packet.model_review_quorum["status"] == "satisfied"
 
+    def test_required_pr_checks_gate_fails_closed_when_only_self_check_visible(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pr_payload = _make_pr(
+            number=7465,
+            files=["docs/status/open.md"],
+            checks=[
+                {"name": "Docs Consistency", "status": "COMPLETED", "conclusion": "FAILURE"},
+            ],
+        )
+        pr_payload["comments"] = [
+            _dogfood_comment("## Claude focused dogfood\npass"),
+            {
+                "author": {"login": "an0mium"},
+                "body": "## Grok independent model review\nVerdict: approve.",
+            },
+        ]
+        monkeypatch.setenv("GITHUB_WORKFLOW", "Aragora Merge Quorum")
+        monkeypatch.setenv("GITHUB_JOB", "merge-quorum")
+        monkeypatch.setenv("GITHUB_RUN_ID", "123456")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "synaptent/aragora")
+        monkeypatch.setenv("GITHUB_SERVER_URL", "https://github.com")
+
+        def fake_gh_json(args: list[str]) -> Any:
+            if args[:2] == ["pr", "view"]:
+                return pr_payload
+            if args[:2] == ["pr", "checks"]:
+                return [
+                    {
+                        "name": "aragora-merge-quorum",
+                        "state": "PENDING",
+                        "bucket": "pending",
+                        "workflow": "Aragora Merge Quorum",
+                        "link": "https://github.com/synaptent/aragora/actions/runs/123456/job/1",
+                    },
+                ]
+            raise AssertionError(f"unexpected gh call: {args}")
+
+        monkeypatch.setattr("aragora.cli.commands.review_queue._gh_json", fake_gh_json)
+
+        packet = _build_packet("7465", repo_override=None)
+        required = packet.check_surfaces["required_pr_checks"]
+
+        assert required["effective_total"] == 0
+        assert required["summary"] == "no required checks"
+        assert "effective_gate" not in packet.check_surfaces
+        assert packet.model_review_quorum["admin_squash_allowed"] is False
+        assert packet.model_review_quorum["status"] == "repair_or_wait"
+
     def test_missing_check_rollup_uses_modern_checks_field_and_skipped_neutral(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -31,6 +31,7 @@ from aragora.cli.commands.review_queue import (
     _is_high_risk_path,
     _parse_pr_number,
     _record_external_settlement,
+    _render_packet,
     _requested_action,
     _settle_packet,
     _subsystem_for,
@@ -1787,11 +1788,22 @@ class TestBuildQueueAndPacket:
             in packet.check_surfaces["diagnosis"]
         )
         assert packet.machine_recommendation == "approve_candidate"
+        assert (
+            "non-required direct check-runs are non-green" in packet.machine_recommendation_reason
+        )
         assert packet.model_review_quorum["admin_squash_allowed"] is True
         assert packet.model_review_quorum["status"] == "satisfied"
         assert not any(
             "checks are unavailable" in reason for reason in packet.model_review_quorum["reasons"]
         )
+        rendered = io.StringIO()
+        with redirect_stdout(rendered):
+            _render_packet(packet)
+        rendered_packet = rendered.getvalue()
+        assert "check surfaces:" in rendered_packet
+        assert "direct_commit_check_runs=3" in rendered_packet
+        assert "diagnosis:" in rendered_packet
+        assert "remediation:" in rendered_packet
 
     def test_missing_check_rollup_uses_modern_checks_field_and_skipped_neutral(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -1764,17 +1764,147 @@ class TestBuildQueueAndPacket:
             "count": 0,
             "summary": "no checks reported",
         }
+        assert packet.checks_summary == "2/2 required green (direct check-runs fallback)"
+        assert "check rollup unavailable" not in packet.risk_flags
         assert direct["total"] == 3
         assert direct["successful_required_contexts"] == ["lint", "typecheck"]
         assert direct["missing_required_contexts"] == []
+        assert direct["non_success_required_contexts"] == []
+        assert direct["required_contexts_satisfied"] is True
         assert direct["non_green_sample"] == ["Python SDK Tests (3.11)"]
-        assert "PR statusCheckRollup is empty" in packet.check_surfaces["diagnosis"]
-        assert "PR-state/check-only nudge" in packet.check_surfaces["remediation_prompt"]
+        assert packet.check_surfaces["effective_gate"] == {
+            "source": "direct_commit_check_runs",
+            "summary": "2/2 required green (direct check-runs fallback)",
+        }
         assert (
-            "direct commit check-runs are visible, but PR statusCheckRollup is empty; "
-            "refresh the PR-facing check rollup before settlement"
+            "every branch-protection required context successful"
+            in packet.check_surfaces["diagnosis"]
+        )
+        assert packet.machine_recommendation == "approve_candidate"
+        assert packet.model_review_quorum["admin_squash_allowed"] is True
+        assert packet.model_review_quorum["status"] == "satisfied"
+        assert not any(
+            "checks are unavailable" in reason for reason in packet.model_review_quorum["reasons"]
+        )
+
+    def test_missing_check_rollup_fails_closed_when_required_context_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pr_payload = _make_pr(number=7465, files=["docs/status/open.md"])
+        pr_payload["statusCheckRollup"] = []
+        pr_payload["comments"] = [
+            _dogfood_comment("## Claude focused dogfood\npass"),
+            {
+                "author": {"login": "an0mium"},
+                "body": "## Grok independent model review\nVerdict: approve.",
+            },
+        ]
+
+        def fake_gh_json(args: list[str]) -> dict[str, Any]:
+            if args[:2] == ["pr", "view"]:
+                return pr_payload
+            if args[:1] == ["api"] and "required_status_checks" in args[1]:
+                return {"contexts": ["lint", "typecheck"]}
+            if args[:1] == ["api"] and "check-runs" in args[1]:
+                return {
+                    "check_runs": [
+                        {"name": "lint", "status": "completed", "conclusion": "success"},
+                    ]
+                }
+            raise AssertionError(f"unexpected gh call: {args}")
+
+        monkeypatch.setattr("aragora.cli.commands.review_queue._gh_json", fake_gh_json)
+
+        packet = _build_packet("7465", repo_override=None)
+        direct = packet.check_surfaces["direct_commit_check_runs"]
+
+        assert packet.checks_summary == "no checks reported"
+        assert direct["missing_required_contexts"] == ["typecheck"]
+        assert direct["required_contexts_satisfied"] is False
+        assert packet.model_review_quorum["admin_squash_allowed"] is False
+        assert packet.model_review_quorum["status"] == "repair_or_wait"
+        assert (
+            "checks are unavailable; wait for GitHub check rollup before settlement"
             in packet.model_review_quorum["reasons"]
         )
+
+    def test_missing_check_rollup_fails_closed_when_required_context_not_successful(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pr_payload = _make_pr(number=7465, files=["docs/status/open.md"])
+        pr_payload["statusCheckRollup"] = []
+        pr_payload["comments"] = [
+            _dogfood_comment("## Claude focused dogfood\npass"),
+            {
+                "author": {"login": "an0mium"},
+                "body": "## Grok independent model review\nVerdict: approve.",
+            },
+        ]
+
+        def fake_gh_json(args: list[str]) -> dict[str, Any]:
+            if args[:2] == ["pr", "view"]:
+                return pr_payload
+            if args[:1] == ["api"] and "required_status_checks" in args[1]:
+                return {"contexts": ["lint", "typecheck"]}
+            if args[:1] == ["api"] and "check-runs" in args[1]:
+                return {
+                    "check_runs": [
+                        {"name": "lint", "status": "completed", "conclusion": "success"},
+                        {
+                            "name": "typecheck",
+                            "status": "completed",
+                            "conclusion": "failure",
+                        },
+                    ]
+                }
+            raise AssertionError(f"unexpected gh call: {args}")
+
+        monkeypatch.setattr("aragora.cli.commands.review_queue._gh_json", fake_gh_json)
+
+        packet = _build_packet("7465", repo_override=None)
+        direct = packet.check_surfaces["direct_commit_check_runs"]
+
+        assert packet.checks_summary == "no checks reported"
+        assert direct["non_success_required_contexts"] == ["typecheck"]
+        assert direct["required_contexts_satisfied"] is False
+        assert packet.model_review_quorum["admin_squash_allowed"] is False
+        assert packet.model_review_quorum["status"] == "repair_or_wait"
+
+    def test_missing_check_rollup_fails_closed_without_required_contexts(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pr_payload = _make_pr(number=7465, files=["docs/status/open.md"])
+        pr_payload["statusCheckRollup"] = []
+        pr_payload["comments"] = [
+            _dogfood_comment("## Claude focused dogfood\npass"),
+            {
+                "author": {"login": "an0mium"},
+                "body": "## Grok independent model review\nVerdict: approve.",
+            },
+        ]
+
+        def fake_gh_json(args: list[str]) -> dict[str, Any]:
+            if args[:2] == ["pr", "view"]:
+                return pr_payload
+            if args[:1] == ["api"] and "required_status_checks" in args[1]:
+                return {"contexts": []}
+            if args[:1] == ["api"] and "check-runs" in args[1]:
+                return {
+                    "check_runs": [
+                        {"name": "lint", "status": "completed", "conclusion": "success"},
+                    ]
+                }
+            raise AssertionError(f"unexpected gh call: {args}")
+
+        monkeypatch.setattr("aragora.cli.commands.review_queue._gh_json", fake_gh_json)
+
+        packet = _build_packet("7465", repo_override=None)
+        direct = packet.check_surfaces["direct_commit_check_runs"]
+
+        assert direct["required_contexts"] == []
+        assert direct["required_contexts_satisfied"] is False
+        assert packet.model_review_quorum["admin_squash_allowed"] is False
+        assert packet.model_review_quorum["status"] == "repair_or_wait"
 
     def test_cancelled_merge_quorum_blocks_admin_squash_authorization(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary
- Adds a direct required check-run fallback when GitHub PR `statusCheckRollup` is empty.
- Keeps merge-packet/check reconciliation fail-closed while recovering required checks from exact-head check-runs.
- Publishes the existing validated automation handoff `open-pr-codex-pr-rollup-required-check-fallback-primary-20260530-c7522c56` without changing its scope.

## Validation
- `python3 -m pytest tests/cli/commands/test_review_queue.py -q` -> 166 passed
- `bash scripts/automation_pr_preflight.sh origin/main codex/pr-rollup-required-check-fallback-primary-20260530` -> ok
- `git merge-tree --write-tree origin/main codex/pr-rollup-required-check-fallback-primary-20260530` -> clean tree

## Notes
- Draft PR from a previously validated local automation branch.
- No merge/settlement authorization is implied.
