### PR TITLE
fix(publisher): accept dry-run alias

### DIFF
--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -1308,11 +1308,19 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Print machine-readable output",
     )
-    parser.add_argument(
+    mode_group = parser.add_mutually_exclusive_group()
+    mode_group.add_argument(
         "--apply",
         action="store_true",
         help="Push eligible branches and open PRs; default is dry-run planning only",
     )
+    mode_group.add_argument(
+        "--dry-run",
+        dest="apply",
+        action="store_false",
+        help="Plan only without pushing branches or opening PRs; this is the default",
+    )
+    parser.set_defaults(apply=False)
     parser.add_argument(
         "--preflight-script",
         default=DEFAULT_PREFLIGHT_SCRIPT,

--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -427,7 +427,10 @@ def _free_disk_gib(path: Path) -> float:
 
 
 def _codex_rss_gib() -> float | None:
-    proc = _run(["ps", "-axo", "rss=,comm="], cwd=REPO_ROOT)
+    try:
+        proc = _run(["ps", "-axo", "rss=,comm="], cwd=REPO_ROOT)
+    except OSError:
+        return None
     if proc.returncode != 0:
         return None
     rss_kib = 0

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -271,6 +271,17 @@ def test_automation_guardrails_block_when_spend_caps_are_exhausted(
     assert report.blockers == ["daily_spend_usd=51.25 at or above cap 50.00"]
 
 
+def test_codex_rss_probe_treats_blocked_process_census_as_unavailable(
+    monkeypatch: Any,
+) -> None:
+    def blocked_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        raise PermissionError("ps blocked by sandbox")
+
+    monkeypatch.setattr(mod, "_run", blocked_run)
+
+    assert mod._codex_rss_gib() is None
+
+
 def test_outbox_superseded_branches_reads_local_supersession_metadata(
     tmp_path: Path,
 ) -> None:

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -153,6 +153,12 @@ def test_parser_accepts_receipt_dir_for_shared_cli_compatibility(tmp_path: Path)
     assert args.receipt_dir == receipt_dir
 
 
+def test_parser_accepts_dry_run_alias_for_default_planning_mode() -> None:
+    args = _build_parser().parse_args(["--dry-run"])
+
+    assert args.apply is False
+
+
 def test_select_publishable_branches_skips_open_pr_and_old_or_merged_branches() -> None:
     decisions = select_publishable_branches(
         [


### PR DESCRIPTION
## Summary
- Adds the explicit publisher `--dry-run` CLI alias expected by automation startup probes.
- Hardens the blocked process-census path so branch publishing decisions can still be inspected when process census is unavailable.
- Publishes the validated handoff `open-pr-codex-publisher-dry-run-alias-20260523-75044613` without broadening scope.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/scripts/test_publish_codex_automation_branches.py -q -p no:rerunfailures -p no:cacheprovider` -> 41 passed
- `bash scripts/automation_pr_preflight.sh origin/main codex/harvest-publisher-dry-run-alias-r5-20260529` -> ok
- `git merge-tree --write-tree origin/main codex/harvest-publisher-dry-run-alias-r5-20260529` -> clean tree

## Notes
- Draft PR from an existing automation handoff branch.
- No merge/settlement authorization is implied.
