### PR TITLE
fix(queue): tolerate denied root process census

### DIFF
--- a/scripts/root_guarded_queue.py
+++ b/scripts/root_guarded_queue.py
@@ -124,7 +124,18 @@ def _owner_attribution(cwd: Path, *, branch: str, pr: int | None) -> dict[str, A
 
 
 def _process_attribution(patterns: list[str]) -> dict[str, Any]:
-    result = _run(["ps", "-axo", "pid,ppid,etime,state,time,%cpu,command"], cwd=Path.cwd())
+    command = ["ps", "-axo", "pid,ppid,etime,state,time,%cpu,command"]
+    try:
+        result = _run(command, cwd=Path.cwd())
+    except OSError as exc:
+        return {
+            "available": False,
+            "reason": f"{type(exc).__name__}: {exc}",
+            "patterns": patterns,
+            "matches": [],
+            "command": command,
+            "returncode": None,
+        }
     matches: list[str] = []
     current_pid = os.getpid()
     parent_pid = os.getppid()
@@ -139,6 +150,7 @@ def _process_attribution(patterns: list[str]) -> dict[str, Any]:
         if any(pattern in stripped for pattern in patterns):
             matches.append(stripped)
     return {
+        "available": True,
         "patterns": patterns,
         "matches": matches,
         "command": result.command,

--- a/tests/scripts/test_root_guarded_queue.py
+++ b/tests/scripts/test_root_guarded_queue.py
@@ -137,3 +137,19 @@ def test_process_attribution_records_matching_process(monkeypatch: Any) -> None:
     assert attribution["matches"] == [
         "123 1 00:01 S 0:00 0.0 python review-queue merge-packet --pr 7466"
     ]
+
+
+def test_process_attribution_reports_denied_process_census(monkeypatch: Any) -> None:
+    def fake_run(args: list[str], *, cwd: Path, timeout: int = 120) -> Any:
+        if args[:2] == ["ps", "-axo"]:
+            raise PermissionError(1, "Operation not permitted", "ps")
+        return guard.CommandResult(command=args, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(guard, "_run", fake_run)
+
+    attribution = guard._process_attribution(["review-queue merge-packet"])
+
+    assert attribution["available"] is False
+    assert attribution["matches"] == []
+    assert attribution["returncode"] is None
+    assert "Operation not permitted" in attribution["reason"]


### PR DESCRIPTION
## Summary
- Handles denied `ps` process-census calls in root guarded queue inspection without crashing.
- Returns structured unavailable attribution with the PermissionError reason instead of propagating the exception.
- Publishes the validated handoff `open-pr-codex-root-guarded-queue-ps-denied-20260529-5278b175` without broadening scope.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/scripts/test_root_guarded_queue.py -q -p no:rerunfailures -p no:cacheprovider` -> 6 passed
- `bash scripts/automation_pr_preflight.sh origin/main codex/root-guarded-queue-ps-denied-primary-r3-20260529` -> ok
- `git merge-tree --write-tree origin/main codex/root-guarded-queue-ps-denied-primary-r3-20260529` -> clean tree

## Notes
- Draft PR from an existing automation handoff branch.
- No merge/settlement authorization is implied.
