### PR TITLE
fix(automation): avoid guard amend help heredoc hang

### DIFF
--- a/scripts/guard_amend_pushed.sh
+++ b/scripts/guard_amend_pushed.sh
@@ -23,22 +23,21 @@ REMOTE="origin"
 BRANCH=""
 
 usage() {
-    cat <<'EOF'
-Usage: scripts/guard_amend_pushed.sh [--remote NAME] [--branch NAME]
-
-Refuses `git commit --amend` when the current HEAD is already published
-on the remote tracking branch. Implements v13 rule R19.
-
-Options:
-  --remote NAME   remote name (default: origin)
-  --branch NAME   branch name (default: current branch from HEAD)
-  -h, --help      show this help and exit
-
-Exit codes:
-  0  amend is safe (HEAD ahead of remote, or remote branch absent)
-  1  AMEND-BLOCKED (HEAD == remote tip)
-  2  usage / invocation error
-EOF
+    printf '%s\n' \
+        "Usage: scripts/guard_amend_pushed.sh [--remote NAME] [--branch NAME]" \
+        "" \
+        'Refuses `git commit --amend` when the current HEAD is already published' \
+        "on the remote tracking branch. Implements v13 rule R19." \
+        "" \
+        "Options:" \
+        "  --remote NAME   remote name (default: origin)" \
+        "  --branch NAME   branch name (default: current branch from HEAD)" \
+        "  -h, --help      show this help and exit" \
+        "" \
+        "Exit codes:" \
+        "  0  amend is safe (HEAD ahead of remote, or remote branch absent)" \
+        "  1  AMEND-BLOCKED (HEAD == remote tip)" \
+        "  2  usage / invocation error"
 }
 
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
## Summary
- Fixes `scripts/guard_amend_pushed.sh --help` so it exits immediately instead of hanging in heredoc/help output handling.
- Preserves the R19 amend-guard usage text while avoiding the automation startup probe timeout.
- Publishes the validated handoff `open-pr-codex-guard-amend-help-printf-20260529-f8afe375` without broadening scope.

## Validation
- `bash scripts/guard_amend_pushed.sh --help` -> exits 0 and prints usage
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/scripts/test_guard_amend_pushed.py -q -p no:rerunfailures -p no:cacheprovider --timeout=20` -> 5 passed
- `bash -n scripts/guard_amend_pushed.sh` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main codex/guard-amend-help-printf-primary-r2-20260529` -> ok
- `git merge-tree --write-tree origin/main codex/guard-amend-help-printf-primary-r2-20260529` -> clean tree

## Notes
- Draft PR from an existing automation handoff branch.
- No merge/settlement authorization is implied.
