### PR TITLE
fix(settlement): allow generated docs-site policy surfaces

### DIFF
--- a/scripts/settle_one_pr.py
+++ b/scripts/settle_one_pr.py
@@ -182,7 +182,15 @@ def _has_prefixed_component(component: str, stem: str) -> bool:
 
 
 def _is_docs_or_tests_path(segments: list[str]) -> bool:
-    return bool(segments) and segments[0] in {"doc", "docs", "test", "tests"}
+    if not segments:
+        return False
+    if segments[0] in {"doc", "docs", "test", "tests"}:
+        return True
+    return (
+        len(segments) >= 2
+        and segments[0] in {"docs-site", "documentation-site", "site", "website"}
+        and segments[1] in {"doc", "docs", "documentation"}
+    )
 
 
 def _is_dependabot_pr(entry: dict[str, Any], metadata: dict[str, Any]) -> bool:

--- a/tests/scripts/test_settle_one_pr.py
+++ b/tests/scripts/test_settle_one_pr.py
@@ -294,6 +294,34 @@ def test_policy_exclusion_reasons_does_not_flag_plain_unsafe_words_in_docs() -> 
     assert reasons == []
 
 
+def test_policy_exclusion_reasons_allows_docs_site_generated_secrets_deploy_docs() -> None:
+    docs = _entry(
+        7485,
+        tier=0,
+        reasons=["docs/tests/status-only", "model quorum incomplete: 0/1"],
+    )
+
+    reasons = policy_exclusion_reasons(
+        docs,
+        policy_metadata={
+            7485: {
+                "title": "docs: refresh generated deployment status",
+                "headRefName": "codex/docs-site-status-refresh",
+                "files": [
+                    {"path": "docs-site/docs/contributing/b0-benchmark-truth-status.md"},
+                    {"path": "docs-site/docs/deployment/secrets-management.md"},
+                    {"path": "docs-site/docs/getting-started/environment.md"},
+                    {"path": "docs-site/docs/operations/overview.md"},
+                    {"path": "docs/FOCUS.md"},
+                    {"path": "docs/status/B0_BENCHMARK_TRUTH_STATUS.md"},
+                ],
+            }
+        },
+    )
+
+    assert reasons == []
+
+
 def test_policy_exclusion_reasons_scopes_adc_to_title_and_branch() -> None:
     entry = _entry(
         7461,


### PR DESCRIPTION
## Summary
- Extends settlement docs-only classification to generated docs-site policy surfaces.
- Treats `docs-site/docs`, `documentation-site/docs`, `site/docs`, and `website/docs` as docs-only surfaces while preserving unsafe-surface detection for non-doc paths.
- Publishes the validated handoff `open-pr-codex-docs-only-policy-exclusion-primary-r2-20260528-977ad8a2` without broadening scope.

## Validation
- Current-main integration validation: `git merge --no-ff --no-commit codex/docs-only-policy-exclusion-primary-r2-20260528` in a disposable `origin/main` worktree, then `python3 -m pytest tests/scripts/test_settle_one_pr.py -q` -> 49 passed
- `bash scripts/automation_pr_preflight.sh origin/main codex/docs-only-policy-exclusion-primary-r2-20260528` -> ok
- `git merge-tree --write-tree origin/main codex/docs-only-policy-exclusion-primary-r2-20260528` -> clean tree

## Notes
- Draft PR from an existing automation handoff branch.
- No merge/settlement authorization is implied.
