### PR TITLE
fix(review-queue): record pre-merge admin squash settlement

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -392,8 +392,9 @@ def add_review_queue_parser(subparsers: argparse._SubParsersAction) -> None:
         "record-settlement",
         help="Record an already-authorized PR settlement without mutating GitHub",
         description=(
-            "Write a local review-queue settlement receipt after an external\n"
-            "operator decision, such as an exact-head admin squash merge. This\n"
+            "Write a local review-queue settlement receipt for an external\n"
+            "operator decision, such as an exact-head admin squash merge\n"
+            "authorization before merge or a recorded post-merge outcome. This\n"
             "is local-only: it verifies the live PR head/state, writes under\n"
             ".aragora/review-queue/receipts (or --review-queue-root), and does\n"
             "not approve, comment, merge, or otherwise mutate GitHub."
@@ -409,13 +410,13 @@ def add_review_queue_parser(subparsers: argparse._SubParsersAction) -> None:
     record_p.add_argument(
         "--head-sha",
         required=True,
-        help="Exact PR head SHA that was externally settled.",
+        help="Exact PR head SHA that was externally settled or authorized.",
     )
     record_p.add_argument(
         "--action",
         required=True,
         choices=("approve", "request_changes", "comment", "admin_squash_merge"),
-        help="Externally observed settlement action to record.",
+        help="Operator settlement action or post-merge outcome to record.",
     )
     record_p.add_argument(
         "--reason",
@@ -2778,9 +2779,9 @@ def _record_external_settlement(
         )
     github_state = str(pr_payload.get("state", "") or "").strip().upper()
     merged_at = str(pr_payload.get("mergedAt", "") or "").strip()
-    if action == "admin_squash_merge" and github_state != "MERGED":
+    if action == "admin_squash_merge" and github_state not in {"OPEN", "MERGED"}:
         raise _GhError(
-            "admin_squash_merge records require the PR to be MERGED on GitHub; "
+            "admin_squash_merge records require an OPEN or MERGED PR on GitHub; "
             f"current state is {github_state or 'unknown'}"
         )
     post_merge_lane_audit: dict[str, Any] | None = None

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -1927,13 +1927,13 @@ def _add_review_queue_parser(subparsers) -> None:
     record_parser.add_argument(
         "--head-sha",
         required=True,
-        help="Exact PR head SHA that was externally settled.",
+        help="Exact PR head SHA that was externally settled or authorized.",
     )
     record_parser.add_argument(
         "--action",
         required=True,
         choices=("approve", "request_changes", "comment", "admin_squash_merge"),
-        help="Externally observed settlement action to record.",
+        help="Operator settlement action or post-merge outcome to record.",
     )
     record_parser.add_argument(
         "--reason",

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -2869,7 +2869,43 @@ class TestSettlementHelpers:
                 review_queue_root=None,
             )
 
-    def test_record_external_settlement_rejects_unmerged_admin_merge(
+    def test_record_external_settlement_writes_open_admin_merge_authorization(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        def _fake_gh_json(args: list[str]) -> dict[str, Any]:
+            if args[:2] == ["pr", "view"]:
+                return {
+                    "number": 6294,
+                    "url": "https://github.com/synaptent/aragora/pull/6294",
+                    "headRefOid": "headsha123",
+                    "baseRefOid": "basesha123",
+                    "state": "OPEN",
+                    "mergedAt": "",
+                }
+            if args == ["api", "user"]:
+                return {"login": "an0mium"}
+            raise AssertionError(args)
+
+        monkeypatch.setattr("aragora.cli.commands.review_queue._gh_json", _fake_gh_json)
+
+        result = _record_external_settlement(
+            pr_ref="6294",
+            head_sha="headsha123",
+            action="admin_squash_merge",
+            reason="operator authorized exact-head merge",
+            repo_root=tmp_path,
+            repo_override=None,
+            review_queue_root=None,
+        )
+
+        assert result.written is True
+        assert result.receipt.action == "admin_squash_merge"
+        assert result.receipt.github_event == "ADMIN_SQUASH_MERGE"
+        assert result.receipt.reviewed_at
+        assert result.receipt.head_sha == "headsha123"
+        assert Path(result.receipt.receipt_path).exists()
+
+    def test_record_external_settlement_rejects_closed_unmerged_admin_merge(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         monkeypatch.setattr(
@@ -2879,12 +2915,12 @@ class TestSettlementHelpers:
                 "url": "https://github.com/synaptent/aragora/pull/6294",
                 "headRefOid": "headsha123",
                 "baseRefOid": "basesha123",
-                "state": "OPEN",
+                "state": "CLOSED",
                 "mergedAt": "",
             },
         )
 
-        with pytest.raises(_GhError, match="require the PR to be MERGED"):
+        with pytest.raises(_GhError, match="require an OPEN or MERGED PR"):
             _record_external_settlement(
                 pr_ref="6294",
                 head_sha="headsha123",


### PR DESCRIPTION
## Summary
- Records pre-merge admin squash settlement packet handling in review-queue surfaces.
- Wires the parser and focused tests for the salvaged Tier 4 pre-merge settlement path.
- Publishes the validated handoff `open-pr-codex-salvage-record-settlement-premerge-tier4-20260528-e1451c32` without broadening scope.

## Validation
- Current-main integration validation: `git merge --no-ff --no-commit codex/salvage-record-settlement-premerge-tier4-20260528` in a disposable `origin/main` worktree, then `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/cli/commands/test_review_queue.py -q -p no:rerunfailures -p no:cacheprovider` -> 163 passed
- `python3 -m ruff check aragora/cli/commands/review_queue.py aragora/cli/parser.py tests/cli/commands/test_review_queue.py` -> passed
- `python3 -m ruff format --check aragora/cli/commands/review_queue.py aragora/cli/parser.py tests/cli/commands/test_review_queue.py` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main codex/salvage-record-settlement-premerge-tier4-20260528` -> ok
- `git merge-tree --write-tree origin/main codex/salvage-record-settlement-premerge-tier4-20260528` -> clean tree

## Notes
- Draft PR from an existing automation handoff branch.
- No merge/settlement authorization is implied.
