### PR TITLE
fix(automation): treat cleanup receipts as terminal

### DIFF
--- a/scripts/cache_codex_automation_github_status.py
+++ b/scripts/cache_codex_automation_github_status.py
@@ -42,7 +42,23 @@ DEFAULT_MAX_OPEN_PRS = 12
 DEFAULT_OUTBOX_DIR = Path(".aragora/automation-outbox")
 DEFAULT_RECEIPT_DIR = Path(".aragora/automation-receipts")
 DEFAULT_OUTPUT = Path(".aragora/automation-github-status/latest.json")
-TERMINAL_RECEIPT_STATUSES = {"published", "already_satisfied", "completed", "skipped"}
+TERMINAL_RECEIPT_STATUSES = {
+    "already_satisfied",
+    "checkout_removed",
+    "checkout_removed_branch_preserved",
+    "checkout_retired",
+    "completed",
+    "local_branch_retired",
+    "published",
+    "retired",
+    "retired_local_merged",
+    "retired_local_superseded",
+    "skipped",
+}
+TERMINAL_RECEIPT_STATUS_PREFIXES = (
+    "patch_equivalent_to_",
+    "superseded_by_",
+)
 DUPLICATE_OUTBOX_EXAMPLE_LIMIT = 20
 LOCAL_QUEUE_DETAIL_KEYS = (
     "nonterminal_receipts",
@@ -365,12 +381,18 @@ def _terminal_receipts_by_key(
         if payload is None:
             continue
         status = str(payload.get("status") or "").strip().lower()
-        if status not in TERMINAL_RECEIPT_STATUSES:
+        if not _is_terminal_receipt_status(status):
             continue
         key = str(payload.get("idempotency_key") or path.stem).strip()
         if key:
             by_key[key].append((path, payload))
     return by_key
+
+
+def _is_terminal_receipt_status(status: str) -> bool:
+    return status in TERMINAL_RECEIPT_STATUSES or status.startswith(
+        TERMINAL_RECEIPT_STATUS_PREFIXES
+    )
 
 
 def _load_json_mapping(path: Path) -> dict[str, Any] | None:
@@ -419,7 +441,7 @@ def _local_queue_state(
     terminal_receipts_by_key = _terminal_receipts_by_key(receipt_files)
     terminal_receipt_keys = set(terminal_receipts_by_key)
     nonterminal_receipts = [
-        item for item in receipt_states if item["status"] not in TERMINAL_RECEIPT_STATUSES
+        item for item in receipt_states if not _is_terminal_receipt_status(item["status"])
     ]
     outbox_items = [
         (item, _queue_file_key(item), _queue_file_branch(item)) for item in outbox_files

--- a/tests/scripts/test_cache_codex_automation_github_status.py
+++ b/tests/scripts/test_cache_codex_automation_github_status.py
@@ -83,6 +83,45 @@ def test_local_queue_state_matches_receipts_by_idempotency_key(tmp_path: Path) -
     assert payload["unreceipted_outbox_count"] == 0
 
 
+def test_local_queue_state_treats_cleanup_receipts_as_terminal(tmp_path: Path) -> None:
+    receipts = tmp_path / ".aragora" / "automation-receipts"
+    receipts.mkdir(parents=True)
+    terminal_cleanup_statuses = [
+        "checkout_removed_branch_preserved",
+        "checkout_removed",
+        "checkout_retired",
+        "local_branch_retired",
+        "patch_equivalent_to_active_handoff",
+        "patch_equivalent_to_newer_handoff",
+        "retired",
+        "retired_local_merged",
+        "retired_local_superseded",
+        "superseded_by_pr_7447",
+        "superseded_by_refreshed_handoff",
+    ]
+    for index, status in enumerate(terminal_cleanup_statuses):
+        (receipts / f"receipt-{index}.json").write_text(
+            json.dumps(
+                {
+                    "idempotency_key": f"cleanup-{index}",
+                    "status": status,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    payload = mod._local_queue_state(
+        repo_root=tmp_path,
+        outbox_dir=None,
+        receipt_dir=None,
+    )
+
+    assert payload["receipt_count"] == len(terminal_cleanup_statuses)
+    assert payload["terminal_receipt_count"] == len(terminal_cleanup_statuses)
+    assert payload["nonterminal_receipt_count"] == 0
+    assert payload["nonterminal_receipts"] == []
+
+
 def test_local_queue_state_treats_stale_target_pr_receipt_as_unreceipted(
     monkeypatch: Any,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- Classifies local cleanup receipts as terminal in automation queue status/cache output.
- Keeps nonterminal receipt counts focused on actionable publication blockers.
- Publishes the validated handoff `open-pr-codex-terminal-cleanup-receipt-statuses-primary-20260524-6b006b66` without broadening scope.

## Validation
- Current-main integration validation: `git merge --no-ff --no-commit codex/terminal-cleanup-receipt-statuses-primary-20260524` in a disposable `origin/main` worktree, then `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/scripts/test_cache_codex_automation_github_status.py -q -p no:rerunfailures -p no:cacheprovider` -> 18 passed
- `python3 -m ruff check scripts/cache_codex_automation_github_status.py tests/scripts/test_cache_codex_automation_github_status.py` -> passed
- `python3 -m ruff format --check scripts/cache_codex_automation_github_status.py tests/scripts/test_cache_codex_automation_github_status.py` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main codex/terminal-cleanup-receipt-statuses-primary-20260524` -> ok
- `git merge-tree --write-tree origin/main codex/terminal-cleanup-receipt-statuses-primary-20260524` -> clean tree

## Notes
- Draft PR from an existing automation handoff branch.
- No merge/settlement authorization is implied.
