### PR TITLE
fix(review-queue): count quorum by model lineage

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -2217,7 +2217,7 @@ def _lint_evidence_comment(
         problems.append("empty_body")
     if not grounded:
         problems.append("missing_current_head_grounding")
-    if str(author or "").strip() == "github-actions":
+    if _is_github_actions_author(author):
         problems.append("github_actions_author_not_counted")
     if inferred_reviewer == "unknown_model_reviewer":
         problems.append("missing_known_model_reviewer_heading")
@@ -2324,6 +2324,10 @@ def _known_model_reviewer_id(item: dict[str, Any]) -> str:
     provider = str(item.get("provider", "") or "")
     reviewer_id = str(item.get("reviewer_id", "") or "")
     return _normalize_model_reviewer_id(provider) or _normalize_model_reviewer_id(reviewer_id)
+
+
+def _is_github_actions_author(author: str) -> bool:
+    return str(author or "").strip().lower() in {"github-actions", "github-actions[bot]"}
 
 
 def _normalize_model_reviewer_id(value: str) -> str:
@@ -2505,7 +2509,7 @@ def _dogfood_evidence_from_comments(
         author = ""
         if isinstance(author_payload, dict):
             author = str(author_payload.get("login", "") or "")
-        if author == "github-actions":
+        if _is_github_actions_author(author):
             continue
         evidence.append(
             {
@@ -2553,7 +2557,7 @@ def _model_review_signals_from_comments(
         github_author = ""
         if isinstance(author_payload, dict):
             github_author = str(author_payload.get("login", "") or "")
-        if github_author == "github-actions":
+        if _is_github_actions_author(github_author):
             continue
         signals.append(
             {

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -65,6 +65,63 @@ PostMergeLaneAuditProvider = Callable[[int, bool], dict[str, Any]]
 LARGE_DIFF_THRESHOLD = 500  # additions + deletions, beyond which "needs_human_attention"
 MODEL_REVIEW_QUEUE_CAP = 6
 MODEL_REVIEW_QUORUM_VERSION = "model_review_quorum.v1"
+CANONICAL_MODEL_FAMILIES: tuple[str, ...] = (
+    "claude",
+    "openai",
+    "gemini",
+    "grok",
+    "mistral",
+    "deepseek",
+    "qwen",
+    "kimi",
+    "yi",
+    "glm",
+    "minimax",
+    "hermes",
+)
+DIRECT_MODEL_FAMILY_MARKERS: dict[str, tuple[str, ...]] = {
+    "claude": ("claude", "anthropic"),
+    "openai": ("openai",),
+    "gemini": ("gemini", "google"),
+    "grok": ("grok", "xai"),
+    "mistral": ("mistral", "codestral"),
+    "deepseek": ("deepseek",),
+    "qwen": ("qwen",),
+    "kimi": ("kimi", "moonshot"),
+    "yi": ("yi", "yi-large"),
+    "glm": ("glm", "zhipu", "z-ai"),
+    "minimax": ("minimax",),
+    "hermes": ("hermes", "nous hermes"),
+}
+ROUTER_SURFACE_REVIEWERS: frozenset[str] = frozenset(("factory", "codex", "tesla", "harvey"))
+IDENTITY_COUNT_BLOCKERS: frozenset[str] = frozenset(
+    (
+        "missing_model_family_disclosure",
+        "unknown_model_family",
+        "heading_model_family_conflict",
+        "unknown_surface_reviewer",
+    )
+)
+
+
+@dataclass(frozen=True)
+class ModelReviewIdentity:
+    surface_reviewer_id: str
+    model_family: str
+    model_id: str
+    identity_source: str
+    identity_problems: tuple[str, ...] = ()
+
+    def as_packet_fields(self) -> dict[str, Any]:
+        return {
+            "surface_reviewer_id": self.surface_reviewer_id,
+            "model_family": self.model_family,
+            "model_id": self.model_id,
+            "identity_source": self.identity_source,
+            "identity_problems": list(self.identity_problems),
+        }
+
+
 HIGH_RISK_PATHS: tuple[str, ...] = (
     "CLAUDE.md",
     "aragora/__init__.py",
@@ -1746,6 +1803,9 @@ def _build_merge_authorization_packet(
             "reviewer_signals": quorum["reviewer_signals"],
             "dogfood_evidence": quorum["dogfood_evidence"],
             "counted_reviewer_ids": quorum["counted_reviewer_ids"],
+            "counted_model_families": quorum.get(
+                "counted_model_families", quorum["counted_reviewer_ids"]
+            ),
             "reasons": quorum["reasons"],
         }
         entries.append(entry)
@@ -1903,6 +1963,7 @@ def _build_model_review_quorum(
         "reviewer_signals": reviewer_signals,
         "dogfood_evidence": dogfood_evidence,
         "counted_reviewer_ids": counted_reviewer_ids,
+        "counted_model_families": counted_reviewer_ids,
         "dissenting_views": dissenting_views,
         "unresolved_dissent": unresolved_dissent,
         "reasons": reasons,
@@ -2089,11 +2150,24 @@ def _reviewer_signals_from_protocol(protocol: dict[str, Any]) -> list[dict[str, 
     signals = []
     for index, reviewer_id in enumerate(reviewer_ids):
         provider = providers[index] if index < len(providers) else ""
+        model_family = _normalize_model_reviewer_id(str(provider)) or _normalize_model_reviewer_id(
+            str(reviewer_id)
+        )
+        identity_problems: list[str] = []
+        if not model_family:
+            identity_problems.append("unknown_model_family")
         signals.append(
             {
                 "reviewer_id": str(reviewer_id),
                 "provider": str(provider),
                 "source": protocol.get("status", ""),
+                "surface_reviewer_id": _infer_surface_reviewer_from_candidate(
+                    str(provider) or str(reviewer_id)
+                ),
+                "model_family": model_family,
+                "model_id": "",
+                "identity_source": "protocol_provider",
+                "identity_problems": identity_problems,
             }
         )
     return signals
@@ -2101,7 +2175,7 @@ def _reviewer_signals_from_protocol(protocol: dict[str, Any]) -> list[dict[str, 
 
 def _counted_model_reviewer_ids(
     reviewer_signals: list[dict[str, Any]],
-    dogfood_evidence: list[dict[str, str]],
+    dogfood_evidence: list[dict[str, Any]],
 ) -> list[str]:
     reviewer_ids: set[str] = set()
     for item in [*reviewer_signals, *dogfood_evidence]:
@@ -2134,7 +2208,8 @@ def _lint_evidence_comment(
         dogfood_evidence = []
         reviewer_signals = []
     counted_reviewer_ids = _counted_model_reviewer_ids(reviewer_signals, dogfood_evidence)
-    inferred_reviewer = _infer_model_reviewer_from_text(body)
+    identity = _resolve_model_review_identity(body)
+    inferred_reviewer = identity.surface_reviewer_id
     lower = body.lower()
 
     problems: list[str] = []
@@ -2146,6 +2221,9 @@ def _lint_evidence_comment(
         problems.append("github_actions_author_not_counted")
     if inferred_reviewer == "unknown_model_reviewer":
         problems.append("missing_known_model_reviewer_heading")
+    for problem in identity.identity_problems:
+        if problem in IDENTITY_COUNT_BLOCKERS:
+            problems.append(problem)
     if not any(
         token in lower
         for token in (
@@ -2164,6 +2242,7 @@ def _lint_evidence_comment(
     ):
         problems.append("missing_dogfood_or_review_trigger")
     if not counted_reviewer_ids:
+        problems.append("no_counted_model_family")
         problems.append("no_counted_model_reviewer")
 
     return {
@@ -2175,11 +2254,17 @@ def _lint_evidence_comment(
         "author": author,
         "comment_summary": _first_nonempty_line(body)[:240],
         "inferred_reviewer": inferred_reviewer,
+        "surface_reviewer_id": identity.surface_reviewer_id,
+        "model_family": identity.model_family,
+        "model_id": identity.model_id,
+        "identity_source": identity.identity_source,
+        "identity_problems": list(identity.identity_problems),
         "current_head_grounded": grounded,
         "current_head_grounding_method": grounding_method,
         "dogfood_evidence": dogfood_evidence,
         "reviewer_signals": reviewer_signals,
         "counted_reviewer_ids": counted_reviewer_ids,
+        "counted_model_families": counted_reviewer_ids,
         "would_count": bool(counted_reviewer_ids),
         "problems": problems,
     }
@@ -2230,6 +2315,12 @@ def _head_committed_at_from_pr(pr: dict[str, Any]) -> str:
 
 
 def _known_model_reviewer_id(item: dict[str, Any]) -> str:
+    problems = [str(problem) for problem in (item.get("identity_problems") or [])]
+    if any(problem in IDENTITY_COUNT_BLOCKERS for problem in problems):
+        return ""
+    model_family = _normalize_model_family(str(item.get("model_family", "") or ""))
+    if model_family:
+        return model_family
     provider = str(item.get("provider", "") or "")
     reviewer_id = str(item.get("reviewer_id", "") or "")
     return _normalize_model_reviewer_id(provider) or _normalize_model_reviewer_id(reviewer_id)
@@ -2241,7 +2332,6 @@ def _normalize_model_reviewer_id(value: str) -> str:
         return ""
     known_markers = (
         ("claude", ("claude", "anthropic")),
-        ("codex", ("codex",)),
         ("openai", ("openai", "gpt")),
         ("grok", ("grok", "xai")),
         ("gemini", ("gemini", "google")),
@@ -2249,9 +2339,10 @@ def _normalize_model_reviewer_id(value: str) -> str:
         ("deepseek", ("deepseek",)),
         ("qwen", ("qwen",)),
         ("kimi", ("kimi", "moonshot")),
-        ("tesla", ("tesla",)),
-        ("harvey", ("harvey",)),
-        ("factory", ("factory",)),
+        ("yi", ("yi",)),
+        ("glm", ("glm", "zhipu", "z-ai")),
+        ("minimax", ("minimax",)),
+        ("hermes", ("hermes", "nous hermes")),
     )
     for normalized, markers in known_markers:
         if any(marker in lower for marker in markers):
@@ -2259,24 +2350,143 @@ def _normalize_model_reviewer_id(value: str) -> str:
     return ""
 
 
+def _normalize_model_family(value: str) -> str:
+    lower = str(value or "").strip().lower()
+    if not lower:
+        return ""
+    if lower in CANONICAL_MODEL_FAMILIES:
+        return lower
+    aliases = {
+        "anthropic": "claude",
+        "google": "gemini",
+        "xai": "grok",
+        "codestral": "mistral",
+        "moonshot": "kimi",
+        "zhipu": "glm",
+        "z-ai": "glm",
+        "nous-hermes": "hermes",
+        "nous hermes": "hermes",
+    }
+    return aliases.get(lower, "")
+
+
+def _first_heading_candidate(text: str) -> tuple[str, int | None]:
+    for index, line in enumerate(str(text).splitlines()):
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            candidate = stripped.lstrip("#").strip()
+            if candidate:
+                return candidate, index
+    return str(text)[:200], None
+
+
+def _infer_surface_reviewer_from_candidate(candidate: str) -> str:
+    lower = str(candidate or "").lower()
+    for name in ("claude", "codex", "tesla", "harvey", "factory", "grok", "gemini"):
+        if name in lower:
+            return name
+    for family, markers in DIRECT_MODEL_FAMILY_MARKERS.items():
+        if any(marker in lower for marker in markers):
+            return family
+    return "unknown_model_reviewer"
+
+
+def _structured_identity_metadata(text: str, heading_index: int | None) -> dict[str, str]:
+    if heading_index is None:
+        return {}
+    lines = str(text).splitlines()
+    metadata: dict[str, str] = {}
+    in_fence = False
+    fence_marker = ""
+    for line in lines[heading_index + 1 : heading_index + 26]:
+        stripped = line.strip()
+        if stripped.startswith(("```", "~~~")):
+            marker = stripped[:3]
+            if not in_fence:
+                in_fence = True
+                fence_marker = marker
+            elif marker == fence_marker:
+                in_fence = False
+                fence_marker = ""
+            continue
+        if in_fence:
+            continue
+        if stripped.startswith("#"):
+            break
+        label, sep, value = stripped.partition(":")
+        if not sep:
+            continue
+        normalized_label = label.strip().strip("*").lower()
+        normalized_value = value.strip().strip("*").strip()
+        if normalized_label in {
+            "reviewer harness",
+            "model family",
+            "model id",
+            "receipt artifact",
+        }:
+            metadata[normalized_label] = normalized_value
+    return metadata
+
+
+def _resolve_model_review_identity(text: str) -> ModelReviewIdentity:
+    candidate, heading_index = _first_heading_candidate(text)
+    surface = _infer_surface_reviewer_from_candidate(candidate)
+    metadata = _structured_identity_metadata(text, heading_index)
+    explicit_family_raw = metadata.get("model family", "")
+    explicit_family = _normalize_model_family(explicit_family_raw)
+    model_id = metadata.get("model id", "")
+    receipt_artifact = metadata.get("receipt artifact", "")
+    problems: list[str] = []
+
+    if surface == "unknown_model_reviewer":
+        problems.append("unknown_surface_reviewer")
+
+    if explicit_family_raw and not explicit_family:
+        problems.append("unknown_model_family")
+
+    model_family = explicit_family
+    identity_source = "model_family_metadata" if explicit_family_raw else "none"
+
+    if surface in ROUTER_SURFACE_REVIEWERS:
+        if not explicit_family_raw:
+            problems.append("missing_model_family_disclosure")
+    elif surface != "unknown_model_reviewer":
+        direct_family = _normalize_model_family(surface)
+        if explicit_family and direct_family and explicit_family != direct_family:
+            problems.append("heading_model_family_conflict")
+        if not explicit_family_raw and direct_family:
+            model_family = direct_family
+            identity_source = "direct_heading"
+        elif explicit_family and direct_family == explicit_family:
+            identity_source = "model_family_metadata"
+
+    if not receipt_artifact:
+        problems.append("missing_receipt_artifact")
+
+    return ModelReviewIdentity(
+        surface_reviewer_id=surface,
+        model_family=model_family,
+        model_id=model_id,
+        identity_source=identity_source,
+        identity_problems=tuple(dict.fromkeys(problems)),
+    )
+
+
 def _dogfood_evidence_from_comments(
     comments: list[Any],
     *,
     head_sha: str = "",
     head_committed_at: str = "",
-) -> list[dict[str, str]]:
+) -> list[dict[str, Any]]:
     """Extract focused-adversarial dogfood signals from PR comments.
 
     Mirrors the source-side filtering of
-    :func:`_model_review_signals_from_comments` for symmetry: an entry is
-    only emitted when (a) the comment is SHA-grounded on the current head,
-    (b) a known model reviewer can be inferred from the comment's
-    structured header, and (c) the comment was not posted by GitHub
-    Actions. Unknowns are still neutralised at counting time by
-    :func:`_known_model_reviewer_id`, but excluding them at the source
-    keeps the evidence list interpretable for downstream consumers.
+    :func:`_model_review_signals_from_comments` for symmetry. Router
+    comments whose first heading names a known surface but whose metadata
+    is missing or conflicted remain visible in the evidence list with
+    ``identity_problems``; counting remains fail-closed.
     """
-    evidence: list[dict[str, str]] = []
+    evidence: list[dict[str, Any]] = []
     for comment in comments:
         if not isinstance(comment, dict):
             continue
@@ -2288,8 +2498,8 @@ def _dogfood_evidence_from_comments(
             token in lower for token in ("dogfood", "adversarial", "cross-author", "recheck")
         ):
             continue
-        reviewer = _infer_model_reviewer_from_text(body)
-        if reviewer == "unknown_model_reviewer":
+        identity = _resolve_model_review_identity(body)
+        if identity.surface_reviewer_id == "unknown_model_reviewer":
             continue
         author_payload = comment.get("author")
         author = ""
@@ -2299,10 +2509,11 @@ def _dogfood_evidence_from_comments(
             continue
         evidence.append(
             {
-                "reviewer_id": reviewer,
+                "reviewer_id": identity.model_family or identity.surface_reviewer_id,
                 "github_author": author,
                 "source": "pr_comment",
                 "summary": _first_nonempty_line(body)[:240],
+                **identity.as_packet_fields(),
             }
         )
     return evidence[:5]
@@ -2313,8 +2524,8 @@ def _model_review_signals_from_comments(
     *,
     head_sha: str = "",
     head_committed_at: str = "",
-) -> list[dict[str, str]]:
-    signals: list[dict[str, str]] = []
+) -> list[dict[str, Any]]:
+    signals: list[dict[str, Any]] = []
     for comment in comments:
         if not isinstance(comment, dict):
             continue
@@ -2335,8 +2546,8 @@ def _model_review_signals_from_comments(
             )
         ):
             continue
-        reviewer = _infer_model_reviewer_from_text(body)
-        if reviewer == "unknown_model_reviewer":
+        identity = _resolve_model_review_identity(body)
+        if identity.surface_reviewer_id == "unknown_model_reviewer":
             continue
         author_payload = comment.get("author")
         github_author = ""
@@ -2346,10 +2557,12 @@ def _model_review_signals_from_comments(
             continue
         signals.append(
             {
-                "reviewer_id": reviewer,
-                "provider": reviewer,
+                "reviewer_id": identity.model_family or identity.surface_reviewer_id,
+                "provider": identity.model_family,
                 "source": "pr_comment",
                 "summary": _first_nonempty_line(body)[:240],
+                "github_author": github_author,
+                **identity.as_packet_fields(),
             }
         )
     return signals[:5]
@@ -2366,20 +2579,8 @@ def _infer_model_reviewer_from_text(text: str) -> str:
     ``claude-mem`` in a file path.  Reviewers conventionally announce
     their identity in the comment's first heading.
     """
-    candidate = ""
-    for line in str(text).splitlines():
-        stripped = line.strip()
-        if stripped.startswith("#"):
-            candidate = stripped.lstrip("#").strip()
-            if candidate:
-                break
-    if not candidate:
-        candidate = str(text)[:200]
-    lower = candidate.lower()
-    for name in ("claude", "codex", "tesla", "harvey", "factory", "grok", "gemini"):
-        if name in lower:
-            return name
-    return "unknown_model_reviewer"
+    candidate, _ = _first_heading_candidate(text)
+    return _infer_surface_reviewer_from_candidate(candidate)
 
 
 def _is_comment_grounded_on_head(

--- a/docs/specs/MODEL_LINEAGE_DISCLOSURE.md
+++ b/docs/specs/MODEL_LINEAGE_DISCLOSURE.md
@@ -1,279 +1,98 @@
-# Model Lineage Disclosure for Reviewer Attestations (Tier 4 Pre-Approval)
+# Model Lineage Disclosure for Reviewer Attestations
 
-**Status**: design doc / pre-approval artifact for a Tier 4 merge-authority
-change. **Not implemented in this PR.** This file + the failing-current-
-state governance tests in
-`tests/governance/test_model_lineage_disclosure_recognizer.py` are the
-pre-approval artifact for the future implementation PR, per
-`docs/REVIEW_AUTHORITY_PRINCIPLES.md::Family-additive change governance`.
+**Status**: superseded implementation note. The original #7490
+preapproval proposed a soft record-only lineage variant. The later
+#7472 design approval selected stricter lineage-bound quorum counting:
+counted PR-comment evidence is keyed by canonical underlying model
+family, not by router or product surface marker.
 
-## Problem statement
+This document now records the implemented strict contract so the older
+soft-variant text does not conflict with live merge-quorum behavior.
 
-The recognizer `_infer_model_reviewer_from_text` in
-`aragora/cli/commands/review_queue.py` (lines 2266–2290 as of
-`4dfb8729c9`) reads the first markdown heading of a PR comment and
-maps it to one of seven family markers:
-`claude / codex / tesla / harvey / factory / grok / gemini`. The
-returned family marker is what the merge-quorum evaluator counts.
+## Problem
 
-**The recognizer collapses harness identity over underlying model
-lineage.** A comment headed `## Factory focused dogfood` is counted
-as the `factory` family regardless of which underlying model Factory
-actually ran. Per `docs/REVIEW_AUTHORITY_PRINCIPLES.md` Tier-
-eligibility table, "factory" is a Western family for jurisdiction
-purposes — but Factory.ai is a *router* that can dispatch to any
-underlying model the operator has configured (GPT-5.5, Claude
-Opus 4.7, Gemini, DeepSeek, etc.). The same harness identity can
-deliver Western or non-Western lineage on the same PR with no
-recognizer-visible difference.
+The old recognizer inferred a reviewer from the first markdown heading
+and counted the surface marker it found: `claude`, `codex`, `tesla`,
+`harvey`, `factory`, `grok`, or `gemini`.
 
-This was independently surfaced three times in the same week:
+That collapsed harness identity over underlying model lineage. A comment
+headed `## Factory independent semantic review...` could be produced by
+Factory routing to OpenAI, Claude, Gemini, DeepSeek, or another model,
+but the merge packet only saw `factory`. Likewise, `## Factory ...` and
+`## Codex ...` could look like two heterogeneous reviewers while both
+were actually OpenAI-lineage.
 
-1. **Operator devil's-advocate**: "factory is a harness and can run
-   Western or non-Western models" — flagged the lineage gap during
-   the #7451 settlement cycle.
-2. **Codex audit (2026-05-27)**: "Model identity remains a governance
-   weak point. The GPT-5.5/GPT-5.2 confusion and Factory-as-router
-   issue show that app labels, harness names, and underlying model
-   lineage must be treated as separate facts."
-3. **PR #7451 evidence** (head `113a706c92`): comment
-   `## Factory independent semantic review on head ...` from
-   `an0mium`, body declaring `**Reviewer:** Factory Droid (GPT-5.5)`.
-   The recognizer counted it as `factory` (Western harness) but the
-   actual technical review was produced by OpenAI's GPT-5.5
-   (Western lineage in this case — but the gate has no machinery to
-   verify that, and the same shape could deliver Chinese-routed
-   lineage undetected).
+The strict contract closes that gap by making the counted unit the
+disclosed canonical model family.
 
-Two concrete failure modes the current state permits:
+## Counted Comment Contract
 
-- **Heterogeneity laundering**: two `## Factory ...` signals from
-  two Factory runs that both routed to Anthropic Claude would look
-  heterogeneous to the recognizer (two distinct family markers
-  expected — though here both are "factory" so it's actually the
-  same family, but consider `## Factory ...` + `## Codex ...` both
-  routed to OpenAI by Factory; that LOOKS heterogeneous at the
-  family level and IS NOT at the model level).
-- **Jurisdiction laundering**: a `## Factory ...` heading produced
-  by a Factory run routed to a Chinese-routed model would count as
-  Western for the Tier 2 "≥1 Western family" floor — silently
-  defeating the jurisdictional payload boundary the principles doc
-  is built to defend.
+Router/product comments that should count must include a nearby
+structured metadata block immediately after the first markdown heading:
 
-## Non-goals
+```md
+## Factory independent semantic review on head <full-sha>
 
-- **No change to the seven-marker recognizer tuple.** Family marker
-  expansion (e.g., adding `openai`, `anthropic`, `mistral`, `deepseek`,
-  `qwen`, `kimi`) is governed by separate pre-approval (PR #7472 and
-  the family-expansion design in #7450). This design is orthogonal: it
-  layers lineage disclosure on top of the existing seven markers.
-- **No change to `aragora-merge-quorum.yml`** semantics for which
-  Tier needs which family floor. The Tier-eligibility table in
-  `REVIEW_AUTHORITY_PRINCIPLES.md` is unchanged.
-- **No change to `scripts/settle_tier4_pr.py`**. The trusted-operator-
-  allowlist, exact-head binding, and admin-squash settlement path
-  remain unchanged.
-- **No automatic rejection of router-based signals** that lack
-  lineage disclosure. This design *records* lineage when present and
-  *flags* signals when absent; the counting behavior is in the
-  variant-choice section below and is operator-decided.
-
-## Proposed contract
-
-The recognizer is extended to additionally parse a structured
-`**Reviewer:**` (or `**Reviewer lineage:**`) line from the comment
-body. The line declares the actual model that produced the review,
-separately from the harness identity in the heading.
-
-### Comment body contract
-
-For a comment to be a *fully-disclosed* signal, the body must
-contain a line matching the regex:
-
-```python
-LINEAGE_REGEX = re.compile(
-    r"^\s*\*{0,2}Reviewer(?:\s+lineage)?:\*{0,2}\s*"
-    r"(?P<harness>[A-Za-z][A-Za-z0-9 .\-_/]*?)"
-    r"\s*\((?P<model_id>[a-z][a-z0-9 .\-_/]*)\)\s*$",
-    re.MULTILINE | re.IGNORECASE,
-)
+**Reviewer harness:** factory
+**Model family:** openai
+**Model id:** gpt-5.5
+**Receipt artifact:** <local path or URL>
 ```
 
-This matches lines like:
+Canonical counted `model_family` IDs are:
 
-- `**Reviewer:** Factory Droid (gpt-5.5)`
-- `**Reviewer:** Factory Droid (claude-opus-4-7)`
-- `**Reviewer:** Claude Code (claude-sonnet-4-5)`
-- `**Reviewer:** Codex CLI (gpt-5-codex)`
-- `**Reviewer:** Aragora harness (grok-4-3-mini)`
-- `**Reviewer lineage:** Factory Droid (gpt-5.5)`
+`claude`, `openai`, `gemini`, `grok`, `mistral`, `deepseek`, `qwen`,
+`kimi`, `yi`, `glm`, `minimax`, `hermes`.
 
-The `model_id` capture is normalized by a new model-lineage prefix
-table introduced by the implementation PR. The table's provider names
-must stay aligned with the real agent-provider vocabulary validated by
-`aragora/agents/spec.py::AgentSpec` via
-`aragora.config.settings::ALLOWED_AGENT_TYPES`; it does not depend on a
-pre-existing provider allowlist constant in `aragora/agents/spec.py`.
+Rules:
 
-| model_id prefix | normalized model family |
-| --- | --- |
-| `gpt-*`, `openai-*`, `o1-*`, `o3-*` | `openai` |
-| `claude-*`, `anthropic-*` | `anthropic` |
-| `gemini-*`, `palm-*` | `google` |
-| `grok-*`, `xai-*` | `xai` |
-| `mistral-*`, `codestral-*` | `mistral` |
-| `deepseek-*` | `deepseek` |
-| `qwen-*` | `qwen` |
-| `kimi-*`, `moonshot-*` | `kimi` |
-| `llama-*` | `meta` |
-| anything else | `unknown_model_lineage` |
+1. Router/product markers `factory`, `codex`, `tesla`, and `harvey`
+   do not count by themselves.
+2. Router/product markers count only when `**Model family:**` resolves
+   to a canonical family.
+3. Direct family headings such as `## Claude ...`, `## OpenAI ...`,
+   `## Gemini ...`, and `## Grok ...` may self-map when no explicit
+   `Model family` line exists.
+4. A direct heading plus conflicting explicit `Model family` line is
+   rejected as identity-conflicted.
+5. Body prose, quoted diffs, fenced code, and later headings cannot
+   override the first heading plus nearby structured metadata block.
+6. Missing receipt artifact is reported as an identity diagnostic. It is
+   not used as the lineage count key.
 
-The harness identity is recorded but not normalized for counting
-purposes — it's audit-trail metadata.
+## Merge-Packet Contract
 
-The parser applies `LINEAGE_REGEX` only to body prose outside fenced
-Markdown code blocks. A reviewer-shaped line inside a fenced code block,
-for example `Reviewer: SomeAgent (some-model-v1)`, is example text, not
-an operator attestation, and must not populate `model_lineage`.
+`counted_reviewer_ids` remains for compatibility, but it now contains
+canonical model-family IDs. `counted_model_families` is also emitted as
+the explicit canonical lineage list.
 
-### Recognizer return shape
+Each PR-comment signal includes:
 
-The recognizer currently returns `str` (a family marker like
-`"factory"` or `"unknown_model_reviewer"`). The proposed return is a
-`tuple[str, str | None]` or a small dataclass:
+- `surface_reviewer_id`
+- `model_family`
+- `model_id`
+- `identity_source`
+- `identity_problems`
 
-```python
-class RecognizedReviewer(NamedTuple):
-    family_marker: str          # e.g. "factory" (from heading)
-    model_lineage: str | None   # e.g. "openai" (from body), or None if undisclosed
-```
+Comments with missing, unknown, or conflicting identity metadata remain
+visible in `reviewer_signals` or `dogfood_evidence` when their first
+heading names a known reviewer surface, but they do not contribute to
+quorum counting.
 
-`family_marker` retains the exact current behavior. `model_lineage`
-is `None` when the comment body has no parseable Reviewer-lineage
-line. Existing call sites that consume only the family marker
-continue to work via `recognized.family_marker`; new call sites can
-choose to weight by `model_lineage`.
+## Preserved Safety Properties
 
-### Two enforcement variants — operator choice
+The implementation preserves:
 
-The recognizer extension is the same in both variants; what differs
-is how the merge-quorum evaluator treats `model_lineage is None`.
+- exact-head grounding
+- stale-comment exclusion
+- first-heading safety
+- GitHub Actions exclusion
+- unknown-reviewer fail-closed behavior
+- focused dogfood requirements for tiers that require dogfood evidence
 
-**Variant A — soft (record-only)**. The merge-quorum evaluator
-counts the signal regardless of lineage disclosure but records
-`lineage_undeclared: true` on the per-signal record in the merge-
-packet. Operators can audit lineage-undeclared rates and ratchet
-toward Variant B over time. This is the minimum-disruption choice.
+## Out Of Scope
 
-**Variant B — hard (structural requirement)**. The merge-quorum
-evaluator does NOT count signals whose `model_lineage is None`
-for Tier 2+ PRs. Tier 0-1 signals continue to count regardless
-(matches the lower-stakes principle). This is the
-maximum-discipline choice and prevents jurisdiction laundering.
-
-The implementation PR proposes **Variant A first**, with a planned
-follow-on PR (also Tier 4 pre-approval) to migrate to Variant B
-after a documented N-week observation period where the
-`lineage_undeclared` rate is measured.
-
-## Tier classification
-
-Per `docs/REVIEW_AUTHORITY_PRINCIPLES.md` Tier 4 row ("merge-authority
-self-modifications") AND family-additive change governance, this is
-**Tier 4**: it changes the merge-quorum-counting contract that gates
-which PRs can merge to `main`.
-
-The implementation PR will need:
-
-- this design doc, merged;
-- the governance tests in
-  `tests/governance/test_model_lineage_disclosure_recognizer.py`,
-  merged in this PR (they pin the current state as the regression
-  floor);
-- explicit operator Tier 4 preapproval *at the implementation step*
-  before the recognizer code changes;
-- explicit operator Tier 4 preapproval *at the merge step* before
-  the recognizer-counting change goes live on `main`.
-
-## Risk dimensions
-
-| # | Risk | Mitigation |
-| --- | --- | --- |
-| 1 | Brittle parsing — natural-language variation in how reviewers describe their underlying model. | The regex requires the `**Reviewer:**` (or `**Reviewer lineage:**`) prefix with a model ID in parentheses. This is a structural convention, not free-form prose. Governance tests pin ≥10 positive and ≥10 negative examples. Operator-attestation comments are templated documents, not natural-language essays, so the contract is enforceable. |
-| 2 | Mis-disclosure — operator (or compromised credential) declares `**Reviewer:** Factory Droid (claude-opus-4-7)` when the run was actually `gpt-5.5`. | This design *records* the disclosure; it does not verify it cryptographically. The next-tier hardening (out of scope of this design) would be receipt-binding: requiring a receipt artifact under `.aragora/proof/<topic>/<timestamp>/` and checking the receipt's manifest matches the disclosed lineage. Pre-approval for that hardening is a separate future Tier 4 design queued behind this one. |
-| 3 | Backwards compatibility — existing comments without the `**Reviewer:**` field (e.g., the 5+ in-flight signals on #7479, #7451, #7480) would become lineage-undeclared. | Variant A grandfathers existing comments (they continue to count). Variant B (when adopted) applies only to comments posted after the variant-B-implementation PR lands; previously-posted comments retain their counting status. |
-| 4 | Heading/body disagreement — comment headed `## Claude ...` but body declares `**Reviewer:** Factory Droid (gpt-5.5)`. Is this a recognizer-bug, an operator-error, or a deliberate cross-attribution claim? | The recognizer returns `family_marker="claude"` (from heading) and `model_lineage="openai"` (from body). The merge-quorum evaluator surfaces the discrepancy as `family_lineage_mismatch: true` in the per-signal record, and (in Variant B) optionally treats the signal as `unknown_model_reviewer`. The variant-B treatment is operator-decided in the follow-on pre-approval. |
-| 5 | Model-ID drift — new model IDs (e.g., `gpt-5.6`, `claude-opus-5-0`) won't match the prefix table. | The prefix table is a *living* document. Adding new model-ID prefixes to the normalization table is a Tier 4 pre-approval pattern (same shape as #7472 for family additions). Governance tests pin the current prefix table; updates require pre-approval. |
-| 6 | Counted-quorum impact — Variant B would retroactively un-count many existing signals on open PRs. | Variant A is recommended for first implementation precisely to avoid this. Variant B's follow-on PR ships with an explicit observation-period and a per-PR transition policy (e.g., `lineage_disclosed_after: <date>` field in the merge-packet). |
-| 7 | Fenced-code spoofing — a review body includes example code containing `Reviewer: SomeAgent (some-model-v1)`, and a naive regex treats it as an attestation. | The parser contract is regex-plus-context: skip fenced Markdown code blocks before applying `LINEAGE_REGEX`. Governance tests pin this as a required safety floor so implementation cannot accidentally count example text as model lineage. |
-
-## Failing governance tests (regression floor)
-
-`tests/governance/test_model_lineage_disclosure_recognizer.py` pins
-the current state as the regression floor:
-
-- **Current recognizer return shape**: the recognizer returns a
-  bare `str` today, NOT a NamedTuple/dataclass. The implementation
-  PR changes this. If the test fails on the current code, the
-  recognizer has been changed without pre-approval discipline.
-- **Current collapse behavior**: `## Factory ...` headers all return
-  `"factory"` regardless of body content. Pin the current uniform
-  behavior so the implementation PR can be verified to break it
-  intentionally.
-- **Parser contract for `**Reviewer:**`**: ≥10 positive examples
-  matching the regex outside fenced code blocks (covering all major
-  model families); ≥10 negative examples (missing prefix, missing
-  parens, missing model-id, mis-spelled keyword, fenced-code example
-  text).
-- **Model-ID prefix normalization**: each entry in the prefix table
-  has a positive test. Unknown prefixes produce `unknown_model_lineage`.
-- **Body-detection precedence**: the parser scans the entire body,
-  not just the first heading. (This is a DIFFERENT scope from the
-  current recognizer's heading-only scan; the lineage parser is a
-  body-scan addition, not a replacement.)
-- **Backwards-compatibility floor**: comments without the
-  `**Reviewer:**` field continue to return `model_lineage=None` (not
-  some default-guess); under Variant A this still counts toward
-  quorum, under Variant B it does not.
-
-After the implementation PR lands and the recognizer is extended,
-the current-collapse-behavior tests invert (they assert the new
-disambiguated behavior), per the regression-floor pattern in
-`tests/governance/test_model_quorum_recognizer_gaps.py` and
-`tests/governance/test_advisory_review_recognizable_header.py`.
-
-## Implementation PR plan (out of scope of this PR)
-
-A future PR will:
-
-1. Replace `def _infer_model_reviewer_from_text(text: str) -> str`
-   with `def _infer_model_reviewer_from_text(text: str) -> RecognizedReviewer`
-   (or equivalent NamedTuple). Existing call sites use
-   `.family_marker`; new call sites use `.model_lineage`.
-2. Add the body-scanning `LINEAGE_REGEX` parser, fenced-code-block
-   filtering, and the prefix-normalization table as module-level
-   constants/helpers in `aragora/cli/commands/review_queue.py`.
-3. Update `aragora-merge-quorum.yml` (or its evaluator script) to
-   record `model_lineage`, `lineage_undeclared`, and
-   `family_lineage_mismatch` per per-signal record in the merge-
-   packet (Variant A behavior).
-4. Update the recognizer's docstring with the new return shape and
-   the variant-A counting behavior.
-5. Convert the current-state regression-floor tests in this PR's
-   governance suite to positive-present assertions, per the pattern
-   in #7472 / #7450.
-6. Dogfood on a real PR (e.g., post a `## Factory ...` comment with
-   and without the `**Reviewer:**` field and verify the merge-
-   packet differentiates them).
-
-## Operator preapproval requested
-
-Approving this PR constitutes preapproval to *draft* the implementation
-PR described above with **Variant A** (soft, record-only). Variant B
-(hard, structural requirement) requires a *separate* future pre-approval
-artifact after observation-period data is collected.
-
-This PR contains no live recognizer change. Until the implementation
-PR lands, the recognizer continues to collapse harness identity over
-underlying model lineage, and the Factory-as-router gap remains the
-governance weak point Codex's audit named.
+This implementation does not modify #7480 settlement-recording behavior,
+branch protection, admin-merge behavior, or Tier 4 settlement authority.
+The implementation PR itself remains Tier 4 and requires exact-head
+model evidence plus explicit operator settlement before merge.

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -1502,17 +1502,18 @@ class TestModelReviewQuorum:
         # And quorum still incomplete because dogfood is required but absent.
         assert quorum["admin_squash_allowed"] is False
 
-    def test_dogfood_from_github_actions_is_excluded_at_source(self) -> None:
+    @pytest.mark.parametrize("bot_login", ("github-actions", "github-actions[bot]"))
+    def test_dogfood_from_github_actions_is_excluded_at_source(self, bot_login: str) -> None:
         """Bot-authored dogfood comments must not count as model evidence,
         mirroring the existing filter in ``_model_review_signals_from_comments``."""
         files = ["aragora/agents/router.py"]
         pr = _make_pr(files=files)
         pr["comments"] = [
             {
-                "author": {"login": "github-actions"},
-                "body": "## Codex focused dogfood\nautomated regression sweep",
+                "author": {"login": bot_login},
+                "body": _codex_openai_body(body="automated regression sweep"),
             },
-            _dogfood_comment("## Codex focused dogfood (real reviewer)\nlocal checks pass"),
+            _codex_openai_comment(),
         ]
         quorum = _build_model_review_quorum(
             pr=pr,
@@ -1525,6 +1526,35 @@ class TestModelReviewQuorum:
         # The bot comment is filtered; the real reviewer comment passes.
         assert len(quorum["dogfood_evidence"]) == 1
         assert quorum["dogfood_evidence"][0]["github_author"] == "an0mium"
+        assert quorum["counted_reviewer_ids"] == ["openai"]
+
+    def test_model_review_signal_from_github_actions_bot_is_excluded_at_source(
+        self,
+    ) -> None:
+        """The real GitHub Actions bot login must not count as a model reviewer."""
+        files = ["aragora/agents/router.py"]
+        pr = _make_pr(files=files)
+        pr["comments"] = [
+            {
+                "author": {"login": "github-actions[bot]"},
+                "body": _codex_openai_body(
+                    heading="## Codex review",
+                    body="independent semantic review with structured lineage metadata",
+                ),
+            },
+        ]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=files,
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+        )
+
+        assert quorum["reviewer_signals"] == []
+        assert quorum["dogfood_evidence"] == []
+        assert quorum["counted_reviewer_ids"] == []
 
 
 # --- _parse_pr_number ------------------------------------------------------
@@ -2500,6 +2530,35 @@ class TestCommandDispatch:
         assert payload["dogfood_evidence"][0]["reviewer_id"] == "openai"
         assert payload["current_head_grounding_method"] == "head_sha_citation"
         assert payload["problems"] == []
+
+    def test_evidence_lint_rejects_github_actions_bot_author(self) -> None:
+        ns = argparse.Namespace(
+            review_queue_command="evidence-lint",
+            pr="7445",
+            head_sha="cd87c5a1b2db34f04167906553502db3ede9525e",
+            head_committed_at="2026-05-23T19:00:00Z",
+            body=_codex_openai_body(
+                body=(
+                    "Current head: cd87c5a1b2db34f04167906553502db3ede9525e\n"
+                    "Automated structured evidence must remain advisory-only."
+                )
+            ),
+            body_file=None,
+            author="github-actions[bot]",
+            json=True,
+        )
+
+        out = io.StringIO()
+        with redirect_stdout(out):
+            rc = cmd_review_queue(ns)
+
+        payload = json.loads(out.getvalue())
+        assert rc == 1
+        assert payload["would_count"] is False
+        assert payload["reviewer_signals"] == []
+        assert payload["dogfood_evidence"] == []
+        assert "github_actions_author_not_counted" in payload["problems"]
+        assert "no_counted_model_family" in payload["problems"]
 
     def test_evidence_lint_rejects_ungrounded_comment(self) -> None:
         ns = argparse.Namespace(

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -195,6 +195,32 @@ def _dogfood_comment(
     return {"author": {"login": "an0mium"}, "body": body}
 
 
+def _codex_openai_body(
+    heading: str = "## Codex focused dogfood",
+    body: str = "local checks pass",
+) -> str:
+    return (
+        f"{heading}\n\n"
+        "**Reviewer harness:** codex\n"
+        "**Model family:** openai\n"
+        "**Model id:** gpt-5-codex\n"
+        "**Receipt artifact:** /tmp/codex-review.md\n\n"
+        f"{body}"
+    )
+
+
+def _codex_openai_comment(
+    *,
+    heading: str = "## Codex focused dogfood",
+    body: str = "local checks pass",
+    created_at: str | None = None,
+) -> dict[str, Any]:
+    comment = _dogfood_comment(_codex_openai_body(heading=heading, body=body))
+    if created_at is not None:
+        comment["createdAt"] = created_at
+    return comment
+
+
 def _executed_protocol(*, dissent: bool = False) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "status": EXECUTED_PROTOCOL_STATUS,
@@ -975,14 +1001,20 @@ class TestModelReviewQuorum:
     def test_duplicate_codex_comments_do_not_satisfy_tier_two_quorum(self) -> None:
         pr = _make_pr(files=["aragora/cli/commands/swarm.py"])
         pr["comments"] = [
-            _dogfood_comment("## Codex focused dogfood\nlocal checks pass"),
+            _codex_openai_comment(),
             {
                 "author": {"login": "an0mium"},
-                "body": "## Codex review\nLGTM after local dogfood.",
+                "body": _codex_openai_body(
+                    heading="## Codex review",
+                    body="LGTM after local dogfood.",
+                ),
             },
             {
                 "author": {"login": "an0mium"},
-                "body": "## Codex review\nSecond same-model note.",
+                "body": _codex_openai_body(
+                    heading="## Codex review",
+                    body="Second same-model note.",
+                ),
             },
         ]
         quorum = _build_model_review_quorum(
@@ -996,13 +1028,13 @@ class TestModelReviewQuorum:
         assert quorum["tier"] == 2
         assert quorum["status"] == "needs_model_review_quorum"
         assert quorum["admin_squash_allowed"] is False
-        assert quorum["counted_reviewer_ids"] == ["codex"]
+        assert quorum["counted_reviewer_ids"] == ["openai"]
         assert "model quorum incomplete: 1/2 signal(s)" in quorum["reasons"]
 
     def test_codex_dogfood_and_grok_review_satisfy_tier_two_quorum(self) -> None:
         pr = _make_pr(files=["aragora/cli/commands/swarm.py"])
         pr["comments"] = [
-            _dogfood_comment("## Codex focused dogfood\nlocal checks pass"),
+            _codex_openai_comment(),
             {
                 "author": {"login": "an0mium"},
                 "body": "## Grok independent model review\nVerdict: approve.",
@@ -1019,7 +1051,10 @@ class TestModelReviewQuorum:
         assert quorum["tier"] == 2
         assert quorum["status"] == "satisfied"
         assert quorum["admin_squash_allowed"] is True
-        assert quorum["counted_reviewer_ids"] == ["codex", "grok"]
+        assert quorum["counted_reviewer_ids"] == ["grok", "openai"]
+        assert quorum["counted_model_families"] == ["grok", "openai"]
+        assert quorum["dogfood_evidence"][0]["surface_reviewer_id"] == "codex"
+        assert quorum["dogfood_evidence"][0]["model_family"] == "openai"
 
     def test_unknown_dogfood_does_not_count_or_satisfy_required_dogfood(self) -> None:
         pr = _make_pr(files=["aragora/cli/commands/swarm.py"])
@@ -1048,7 +1083,7 @@ class TestModelReviewQuorum:
         has no model-review heading must not be tagged as a Codex signal."""
         pr = _make_pr(files=["aragora/cli/commands/swarm.py"])
         pr["comments"] = [
-            _dogfood_comment("## Codex focused dogfood\nlocal checks pass"),
+            _codex_openai_comment(),
             {
                 "author": {"login": "an0mium"},
                 "body": (
@@ -1072,14 +1107,14 @@ class TestModelReviewQuorum:
         # The rebase note's heading does not contain a model name.  The
         # heuristic must NOT scan the entire body and pick up the branch
         # name ``codex/...`` in line 2 of the body.
-        assert quorum["counted_reviewer_ids"] == ["codex"]
+        assert quorum["counted_reviewer_ids"] == ["openai"]
         # The dogfood evidence list should still include both comments
         # (the rebase note matches "rebased" → not a marker; "drain"
         # → not a marker; but the body does not actually contain any
         # of dogfood/adversarial/cross-author/recheck), so it is not
         # added to dogfood_evidence at all.
         dogfood_authors = [entry.get("reviewer_id") for entry in quorum["dogfood_evidence"]]
-        assert "codex" in dogfood_authors
+        assert "openai" in dogfood_authors
         # Ensure the rebase note didn't sneak into reviewer_signals.
         for sig in quorum["reviewer_signals"]:
             assert "rebase" not in (sig.get("summary", "") or "").lower()
@@ -1124,7 +1159,7 @@ class TestModelReviewQuorum:
             # Posted BEFORE the head was committed → stale.
             {
                 "author": {"login": "an0mium"},
-                "body": "## Codex focused dogfood\nlocal checks pass",
+                "body": _codex_openai_body(),
                 "createdAt": "2026-04-28T18:00:00Z",
             },
             {
@@ -1155,7 +1190,7 @@ class TestModelReviewQuorum:
         pr["comments"] = [
             {
                 "author": {"login": "an0mium"},
-                "body": "## Codex focused dogfood\nlocal checks pass",
+                "body": _codex_openai_body(),
                 "createdAt": "2026-04-28T20:05:00Z",
             },
             {
@@ -1172,7 +1207,7 @@ class TestModelReviewQuorum:
             has_pending=False,
             has_failures=False,
         )
-        assert quorum["counted_reviewer_ids"] == ["codex", "grok"]
+        assert quorum["counted_reviewer_ids"] == ["grok", "openai"]
         assert quorum["status"] == "satisfied"
 
     def test_stale_comment_with_head_sha_citation_still_counts(self) -> None:
@@ -1188,9 +1223,8 @@ class TestModelReviewQuorum:
             # Predates head BUT cites head SHA → grounded.
             {
                 "author": {"login": "an0mium"},
-                "body": (
-                    f"## Codex focused dogfood\n"
-                    f"Reviewed at head {head_sha[:7]} – local checks pass."
+                "body": _codex_openai_body(
+                    body=f"Reviewed at head {head_sha[:7]} - local checks pass."
                 ),
                 "createdAt": "2026-04-28T18:00:00Z",
             },
@@ -1208,7 +1242,7 @@ class TestModelReviewQuorum:
             has_pending=False,
             has_failures=False,
         )
-        assert quorum["counted_reviewer_ids"] == ["codex", "grok"]
+        assert quorum["counted_reviewer_ids"] == ["grok", "openai"]
         assert quorum["status"] == "satisfied"
 
     def test_unresolved_dissent_forces_human_risk_settlement(self) -> None:
@@ -1357,7 +1391,7 @@ class TestModelReviewQuorum:
     def test_independent_model_review_comment_counts_as_quorum_signal(self) -> None:
         pr = _make_pr(files=["aragora/debate/team_selector.py"])
         pr["comments"] = [
-            _dogfood_comment("## Codex focused dogfood\n10/10 pass"),
+            _codex_openai_comment(body="10/10 pass"),
             {
                 "author": {"login": "an0mium"},
                 "body": "## Grok independent semantic review\nVerdict: approve after human risk settlement.",
@@ -1376,7 +1410,7 @@ class TestModelReviewQuorum:
         assert len(quorum["reviewer_signals"]) == 1
         assert quorum["reviewer_signals"][0]["reviewer_id"] == "grok"
         assert len(quorum["dogfood_evidence"]) == 1
-        assert quorum["counted_reviewer_ids"] == ["codex", "grok"]
+        assert quorum["counted_reviewer_ids"] == ["grok", "openai"]
 
     def test_github_actions_advisory_review_does_not_count_as_model_signal(self) -> None:
         pr = _make_pr(files=["aragora/debate/team_selector.py"])
@@ -1421,7 +1455,7 @@ class TestModelReviewQuorum:
         files = ["aragora/cli/commands/review_queue.py"]
         pr = _make_pr(files=files)
         pr["comments"] = [
-            _dogfood_comment("## Codex focused dogfood\nlocal checks pass"),
+            _codex_openai_comment(),
             {
                 "author": {"login": "an0mium"},
                 "body": "## Grok independent model review\nVerdict: approve.",
@@ -2443,10 +2477,11 @@ class TestCommandDispatch:
             pr="7445",
             head_sha="cd87c5a1b2db34f04167906553502db3ede9525e",
             head_committed_at="2026-05-23T19:00:00Z",
-            body=(
-                "## Codex focused dogfood\n\n"
-                "Current head: cd87c5a1b2db34f04167906553502db3ede9525e\n"
-                "Validation passed for the exact touched surface."
+            body=_codex_openai_body(
+                body=(
+                    "Current head: cd87c5a1b2db34f04167906553502db3ede9525e\n"
+                    "Validation passed for the exact touched surface."
+                )
             ),
             body_file=None,
             author="an0mium",
@@ -2461,8 +2496,8 @@ class TestCommandDispatch:
         assert rc == 0
         assert payload["mode"] == "evidence_lint"
         assert payload["would_count"] is True
-        assert payload["counted_reviewer_ids"] == ["codex"]
-        assert payload["dogfood_evidence"][0]["reviewer_id"] == "codex"
+        assert payload["counted_reviewer_ids"] == ["openai"]
+        assert payload["dogfood_evidence"][0]["reviewer_id"] == "openai"
         assert payload["current_head_grounding_method"] == "head_sha_citation"
         assert payload["problems"] == []
 

--- a/tests/governance/test_advisory_review_recognizable_header.py
+++ b/tests/governance/test_advisory_review_recognizable_header.py
@@ -3,8 +3,7 @@
 These tests are the Tier 4 pre-approval regression target for the design
 in ``docs/specs/ADVISORY_REVIEW_RECOGNIZABLE_HEADER.md``.
 
-They intentionally characterize today's unsafe behavior. The future
-implementation PR should invert the gap assertions so counted quorum
+They pin the strict lineage-bound implementation: counted quorum
 signals are keyed by disclosed underlying model family, not by
 router/product surface markers such as ``factory`` or ``codex``.
 """
@@ -57,67 +56,83 @@ def _counted_from_bodies(*bodies: str) -> list[str]:
     return _counted_model_reviewer_ids(signals, [])
 
 
-def test_current_factory_without_model_family_counts_as_factory_gap() -> None:
-    """Current gap: a router marker counts without lineage disclosure.
+def _signals_from_bodies(*bodies: str) -> list[dict[str, Any]]:
+    return _model_review_signals_from_comments(
+        [_comment(body) for body in bodies],
+        head_sha=HEAD_SHA,
+    )
 
-    Desired implementation behavior: advisory-only, with
-    ``missing_model_family_disclosure`` in the signal's identity
-    problems.
-    """
+
+def test_factory_without_model_family_is_advisory_only() -> None:
+    """Router markers require explicit lineage disclosure to count."""
     body = _review_body("Factory")
 
     assert _infer_model_reviewer_from_text(body) == "factory"
-    assert _counted_from_bodies(body) == ["factory"]
+    assert _counted_from_bodies(body) == []
+    signal = _signals_from_bodies(body)[0]
+    assert signal["surface_reviewer_id"] == "factory"
+    assert "missing_model_family_disclosure" in signal["identity_problems"]
 
 
-def test_current_codex_without_model_family_counts_as_codex_gap() -> None:
-    """Current gap: Codex counts as a family without model disclosure.
-
-    The selected policy requires Codex to disclose underlying model
-    lineage before it contributes to heterogeneity.
-    """
+def test_codex_without_model_family_is_advisory_only() -> None:
+    """Codex is a product/harness marker and must disclose model lineage."""
     body = _review_body("Codex")
 
     assert _infer_model_reviewer_from_text(body) == "codex"
-    assert _counted_from_bodies(body) == ["codex"]
+    assert _counted_from_bodies(body) == []
+    signal = _signals_from_bodies(body)[0]
+    assert signal["surface_reviewer_id"] == "codex"
+    assert "missing_model_family_disclosure" in signal["identity_problems"]
 
 
-def test_current_factory_and_codex_openai_disclosures_still_count_as_two_surface_ids() -> None:
-    """Current gap: lineage metadata is ignored during counting.
-
-    Both comments disclose OpenAI lineage, but today's packet would
-    count the surface markers as two signals: ``codex`` and ``factory``.
-    The implementation must count this as one model family: ``openai``.
-    """
+def test_factory_and_codex_openai_disclosures_count_as_one_model_family() -> None:
+    """Two router comments disclosing the same family count once."""
     factory = _review_body("Factory", model_family="openai", model_id="gpt-5.5")
     codex = _review_body("Codex", model_family="openai", model_id="gpt-5.5-codex")
 
-    assert _counted_from_bodies(factory, codex) == ["codex", "factory"]
+    assert _counted_from_bodies(factory, codex) == ["openai"]
 
 
-def test_current_factory_openai_and_claude_count_for_wrong_reason() -> None:
-    """Current behavior satisfies two-signal quorum for the wrong reason.
-
-    Desired implementation behavior is still two counted families, but
-    they should be ``claude`` and ``openai`` rather than ``claude`` and
-    ``factory``.
-    """
+def test_factory_openai_and_claude_count_as_two_model_families() -> None:
+    """Mixed router and direct-family signals count by lineage."""
     factory = _review_body("Factory", model_family="openai", model_id="gpt-5.5")
     claude = _review_body("Claude", model_family="claude", model_id="claude-opus-4-7")
 
-    assert _counted_from_bodies(factory, claude) == ["claude", "factory"]
+    assert _counted_from_bodies(factory, claude) == ["claude", "openai"]
 
 
-def test_current_heading_model_family_conflict_counts_heading_gap() -> None:
-    """Current gap: explicit conflicting lineage does not reject a signal.
-
-    Desired implementation behavior: ``## Claude ...`` plus
-    ``Model family: openai`` is identity-conflicted and does not count.
-    """
+def test_heading_model_family_conflict_is_rejected() -> None:
+    """``## Claude ...`` plus ``Model family: openai`` does not count."""
     body = _review_body("Claude", model_family="openai", model_id="gpt-5.5")
 
     assert _infer_model_reviewer_from_text(body) == "claude"
-    assert _counted_from_bodies(body) == ["claude"]
+    assert _counted_from_bodies(body) == []
+    signal = _signals_from_bodies(body)[0]
+    assert "heading_model_family_conflict" in signal["identity_problems"]
+
+
+def test_unknown_model_family_disclosure_is_visible_but_uncounted() -> None:
+    body = _review_body("Factory", model_family="unknown-provider", model_id="mystery-v1")
+
+    assert _counted_from_bodies(body) == []
+    signal = _signals_from_bodies(body)[0]
+    assert signal["surface_reviewer_id"] == "factory"
+    assert "unknown_model_family" in signal["identity_problems"]
+
+
+def test_missing_receipt_artifact_is_diagnostic_metadata() -> None:
+    body = (
+        f"## Factory independent semantic review on head {HEAD_SHA}\n\n"
+        "**Reviewer harness:** factory\n"
+        "**Model family:** openai\n"
+        "**Model id:** gpt-5.5\n\n"
+        "No blocking findings. This is an independent semantic review.\n"
+    )
+
+    assert _counted_from_bodies(body) == ["openai"]
+    signal = _signals_from_bodies(body)[0]
+    assert signal["model_family"] == "openai"
+    assert "missing_receipt_artifact" in signal["identity_problems"]
 
 
 def test_current_advisory_aragora_header_stays_unknown() -> None:

--- a/tests/governance/test_model_lineage_disclosure_recognizer.py
+++ b/tests/governance/test_model_lineage_disclosure_recognizer.py
@@ -1,455 +1,115 @@
-"""Governance tests for the model-lineage-disclosure recognizer extension.
-
-These tests are the Tier 4 pre-approval regression target for the
-change designed in
-`docs/specs/MODEL_LINEAGE_DISCLOSURE.md`. They exist for two reasons:
-
-1. They *pin* the current recognizer state — bare-`str` return shape,
-   collapsed harness-vs-lineage behavior, heading-only scanning —
-   so the implementation PR has a machine-checkable regression
-   floor. If a future change quietly extends the recognizer
-   without going through the pre-approval discipline, these tests
-   fail loudly.
-
-2. They *codify* the proposed contract — the `LINEAGE_REGEX`,
-   the model-ID prefix normalization table, the body-scan
-   precedence, the backwards-compatibility floor — as a passing
-   executable spec. The implementation PR's job is to make the
-   recognizer satisfy these same predicates, not to invent new
-   ones.
-
-Per `docs/REVIEW_AUTHORITY_PRINCIPLES.md::Family-additive change
-governance`:
-
-  > "A change that adds a new family marker to the recognizer in
-  >  aragora/cli/commands/review_queue.py::_infer_model_reviewer_from_text,
-  >  or changes which family counts at which Tier, is a Tier 4
-  >  merge-authority self-modification per the Tier table above.
-  >  It requires human preapproval before implementation and
-  >  before merge."
-
-This file IS that pre-approval test surface. The implementation
-that satisfies the proposed contract waits for explicit operator
-Tier 4 preapproval at the implementation step.
-"""
+"""Governance tests for strict lineage-bound reviewer identity parsing."""
 
 from __future__ import annotations
 
-import re
-
-import pytest
-
-from aragora.cli.commands.review_queue import _infer_model_reviewer_from_text
-
-# ---------------------------------------------------------------------------
-# Current-state regression floor: the recognizer returns a bare str
-# and collapses harness identity over model lineage. The implementation
-# PR will change both behaviors; until then, these tests pin the floor.
-# ---------------------------------------------------------------------------
+from aragora.cli.commands.review_queue import _resolve_model_review_identity
 
 
-def test_recognizer_currently_returns_bare_str() -> None:
-    """REGRESSION FLOOR: today the recognizer returns a plain str.
+def _body(
+    heading: str,
+    *,
+    model_family: str | None = None,
+    model_id: str = "gpt-5.5",
+    receipt: str | None = "/tmp/review.md",
+) -> str:
+    text = f"## {heading}\n\n"
+    text += "**Reviewer harness:** factory\n"
+    if model_family is not None:
+        text += f"**Model family:** {model_family}\n"
+    text += f"**Model id:** {model_id}\n"
+    if receipt is not None:
+        text += f"**Receipt artifact:** {receipt}\n"
+    text += "\nNo blocking findings.\n"
+    return text
 
-    The implementation PR will change this to a NamedTuple/dataclass
-    with `family_marker` and `model_lineage` fields. Until then,
-    callers consume a plain str. If this test fails, the recognizer
-    has been changed without pre-approval discipline.
-    """
-    result = _infer_model_reviewer_from_text("## Factory focused dogfood\n")
-    assert isinstance(result, str), (
-        "Recognizer return type changed from str to a structured "
-        "type without the lineage-disclosure pre-approval. If the "
-        "implementation PR has landed, invert this test (or move it "
-        "to a positive-present suite) — it is the regression floor "
-        "documenting that the change went through Tier 4 discipline."
+
+def test_router_heading_requires_model_family_disclosure() -> None:
+    identity = _resolve_model_review_identity(_body("Factory focused dogfood"))
+
+    assert identity.surface_reviewer_id == "factory"
+    assert identity.model_family == ""
+    assert "missing_model_family_disclosure" in identity.identity_problems
+
+
+def test_router_heading_with_canonical_family_counts_by_model_family() -> None:
+    identity = _resolve_model_review_identity(
+        _body("Factory focused dogfood", model_family="openai", model_id="gpt-5.5")
     )
 
+    assert identity.surface_reviewer_id == "factory"
+    assert identity.model_family == "openai"
+    assert identity.model_id == "gpt-5.5"
+    assert identity.identity_source == "model_family_metadata"
 
-@pytest.mark.parametrize(
-    "body, expected_family",
-    [
-        # All five of these have IDENTICAL recognizer output today
-        # despite naming wildly different underlying models in the
-        # body. That uniform collapse IS the gap this design closes.
-        (
-            "## Factory focused dogfood\n\n**Reviewer:** Factory Droid (gpt-5.5)\n",
-            "factory",
-        ),
-        (
-            "## Factory focused dogfood\n\n**Reviewer:** Factory Droid (claude-opus-4-7)\n",
-            "factory",
-        ),
-        (
-            "## Factory focused dogfood\n\n**Reviewer:** Factory Droid (gemini-3.5-flash)\n",
-            "factory",
-        ),
-        (
-            "## Factory focused dogfood\n\n**Reviewer:** Factory Droid (deepseek-v3)\n",
-            "factory",
-        ),
-        (
-            "## Factory focused dogfood\n\n(no Reviewer field; pre-lineage-disclosure era)\n",
-            "factory",
-        ),
-    ],
-)
-def test_recognizer_currently_collapses_harness_over_lineage(
-    body: str, expected_family: str
-) -> None:
-    """REGRESSION FLOOR: today's recognizer cannot see model lineage.
 
-    All five inputs above return `"factory"` today regardless of which
-    underlying model the comment body declares. The implementation PR
-    will distinguish them via the `model_lineage` field. Until then,
-    the uniform collapse is pinned as a regression floor — proves the
-    gap is real and forces the implementation to break this test
-    intentionally.
-    """
-    assert _infer_model_reviewer_from_text(body) == expected_family, (
-        "Recognizer's harness-level collapse changed without the "
-        "lineage-disclosure pre-approval. If the implementation PR "
-        "has landed, invert these assertions (or move them to a "
-        "positive-present suite asserting the new disambiguated "
-        "behavior)."
+def test_direct_family_heading_self_maps_without_model_family_metadata() -> None:
+    identity = _resolve_model_review_identity(
+        "## Claude independent semantic review on head abc1234\n\nNo findings.\n"
     )
 
-
-# ---------------------------------------------------------------------------
-# Proposed contract: LINEAGE_REGEX parses well-formed Reviewer fields.
-# The implementation's body parser MUST behave equivalently. Tests
-# below pin both sides as a passing executable spec.
-# ---------------------------------------------------------------------------
+    assert identity.surface_reviewer_id == "claude"
+    assert identity.model_family == "claude"
+    assert identity.identity_source == "direct_heading"
 
 
-# Reference implementation of the lineage-disclosure regex. The
-# implementation PR MUST use this exact pattern (or a strict
-# refinement, in which case the refinement itself is a Tier 4 pre-
-# approval).
-LINEAGE_REGEX = re.compile(
-    r"^\s*\*{0,2}Reviewer(?:\s+lineage)?:\*{0,2}\s*"
-    r"(?P<harness>[A-Za-z][A-Za-z0-9 .\-_/]*?)"
-    r"\s*\((?P<model_id>[a-z][a-z0-9 .\-_/]*)\)\s*$",
-    re.MULTILINE | re.IGNORECASE,
-)
-
-
-def _strip_fenced_code_blocks(markdown: str) -> str:
-    """Reference contract: lineage parsing ignores fenced code blocks."""
-    prose_lines: list[str] = []
-    in_fence = False
-    fence_marker: str | None = None
-
-    for line in markdown.splitlines():
-        stripped = line.lstrip()
-        if stripped.startswith(("```", "~~~")):
-            marker = stripped[:3]
-            if not in_fence:
-                in_fence = True
-                fence_marker = marker
-            elif marker == fence_marker:
-                in_fence = False
-                fence_marker = None
-            continue
-        if not in_fence:
-            prose_lines.append(line)
-
-    return "\n".join(prose_lines)
-
-
-def _search_lineage_body_prose(markdown: str) -> re.Match[str] | None:
-    """Reference parser shape: apply LINEAGE_REGEX only to body prose."""
-    return LINEAGE_REGEX.search(_strip_fenced_code_blocks(markdown))
-
-
-@pytest.mark.parametrize(
-    "body, expected_harness, expected_model_id",
-    [
-        # Bold-prefixed (canonical operator-attestation form).
-        (
-            "**Reviewer:** Factory Droid (gpt-5.5)",
-            "Factory Droid",
-            "gpt-5.5",
-        ),
-        (
-            "**Reviewer:** Factory Droid (claude-opus-4-7)",
-            "Factory Droid",
-            "claude-opus-4-7",
-        ),
-        (
-            "**Reviewer:** Claude Code (claude-sonnet-4-5)",
-            "Claude Code",
-            "claude-sonnet-4-5",
-        ),
-        (
-            "**Reviewer:** Codex CLI (gpt-5-codex)",
-            "Codex CLI",
-            "gpt-5-codex",
-        ),
-        (
-            "**Reviewer:** Aragora harness (grok-4-3-mini)",
-            "Aragora harness",
-            "grok-4-3-mini",
-        ),
-        (
-            "**Reviewer:** Factory Droid (gemini-3.5-flash)",
-            "Factory Droid",
-            "gemini-3.5-flash",
-        ),
-        # Reviewer lineage variant.
-        (
-            "**Reviewer lineage:** Factory Droid (deepseek-v3)",
-            "Factory Droid",
-            "deepseek-v3",
-        ),
-        # Non-bold variant (still valid).
-        (
-            "Reviewer: Factory Droid (qwen-2.5-72b)",
-            "Factory Droid",
-            "qwen-2.5-72b",
-        ),
-        # Single-asterisk italic variant.
-        (
-            "*Reviewer:* Codex CLI (gpt-5-codex)",
-            "Codex CLI",
-            "gpt-5-codex",
-        ),
-        # Mistral with dotted version.
-        (
-            "**Reviewer:** Aragora harness (mistral-large-2.1)",
-            "Aragora harness",
-            "mistral-large-2.1",
-        ),
-    ],
-)
-def test_lineage_regex_accepts_well_formed_disclosures(
-    body: str, expected_harness: str, expected_model_id: str
-) -> None:
-    """LINEAGE_REGEX positive cases — well-formed disclosures match."""
-    match = LINEAGE_REGEX.search(body)
-    assert match is not None, (
-        f"body {body!r} should match LINEAGE_REGEX but did not. The "
-        "regex contract has drifted to under-accept."
-    )
-    assert match.group("harness").strip() == expected_harness, (
-        f"body {body!r} captured wrong harness "
-        f"{match.group('harness')!r} (expected {expected_harness!r})"
-    )
-    assert match.group("model_id").strip().lower() == expected_model_id.lower(), (
-        f"body {body!r} captured wrong model_id "
-        f"{match.group('model_id')!r} (expected {expected_model_id!r})"
+def test_direct_heading_conflicting_model_family_is_rejected() -> None:
+    identity = _resolve_model_review_identity(
+        _body("Claude independent semantic review", model_family="openai", model_id="gpt-5.5")
     )
 
+    assert identity.surface_reviewer_id == "claude"
+    assert identity.model_family == "openai"
+    assert "heading_model_family_conflict" in identity.identity_problems
 
-@pytest.mark.parametrize(
-    "body",
-    [
-        # Empty / arbitrary.
-        "",
-        "Some random review body without a Reviewer field.",
-        # Missing the keyword.
-        "**Model:** Factory Droid (gpt-5.5)",
-        "**Author:** Factory Droid (gpt-5.5)",
-        # Missing parens.
-        "**Reviewer:** Factory Droid gpt-5.5",
-        # Missing model_id inside parens.
-        "**Reviewer:** Factory Droid ()",
-        # Missing harness.
-        "**Reviewer:** (gpt-5.5)",
-        # Mis-spelled keyword.
-        "**Reviwer:** Factory Droid (gpt-5.5)",
-        "**Reveiwer:** Factory Droid (gpt-5.5)",
-        # Note: uppercase model_id like "GPT-5.5" is technically
-        # accepted by the current regex (IGNORECASE flag makes
-        # `[a-z]` match `[a-zA-Z]`). Convention is lowercase
-        # (matching the implementation PR's lineage prefix table,
-        # which must stay aligned with AgentSpec/ALLOWED_AGENT_TYPES)
-        # but the regex itself doesn't enforce case. Operators
-        # treating uppercase model_id as a different lineage than
-        # lowercase would need to add a separate normalization
-        # check — out of scope of this design.
-    ],
-)
-def test_lineage_regex_rejects_ill_formed_disclosures(body: str) -> None:
-    """LINEAGE_REGEX negative cases — ill-formed bodies do NOT match."""
-    assert LINEAGE_REGEX.search(body) is None, (
-        f"body {body!r} should NOT match LINEAGE_REGEX but did. The "
-        "regex contract has drifted to over-accept."
+
+def test_unknown_model_family_is_reported() -> None:
+    identity = _resolve_model_review_identity(
+        _body("Factory independent semantic review", model_family="not-a-family")
     )
 
-
-# ---------------------------------------------------------------------------
-# Proposed contract: model-ID prefix → normalized lineage family.
-# ---------------------------------------------------------------------------
-
-
-MODEL_LINEAGE_PREFIX_TABLE = {
-    # OpenAI lineage.
-    "gpt-": "openai",
-    "openai-": "openai",
-    "o1-": "openai",
-    "o3-": "openai",
-    # Anthropic lineage.
-    "claude-": "anthropic",
-    "anthropic-": "anthropic",
-    # Google lineage.
-    "gemini-": "google",
-    "palm-": "google",
-    # xAI lineage.
-    "grok-": "xai",
-    "xai-": "xai",
-    # Mistral lineage.
-    "mistral-": "mistral",
-    "codestral-": "mistral",
-    # DeepSeek lineage.
-    "deepseek-": "deepseek",
-    # Qwen lineage.
-    "qwen-": "qwen",
-    # Kimi / Moonshot lineage.
-    "kimi-": "kimi",
-    "moonshot-": "kimi",
-    # Meta / Llama lineage.
-    "llama-": "meta",
-}
+    assert identity.surface_reviewer_id == "factory"
+    assert identity.model_family == ""
+    assert "unknown_model_family" in identity.identity_problems
 
 
-def _normalize_model_lineage(model_id: str) -> str:
-    """Reference implementation of the model-lineage normalization.
-
-    The implementation MUST use this exact prefix table (or a strict
-    superset, in which case the additions are themselves a Tier 4
-    pre-approval).
-    """
-    lower = model_id.lower().strip()
-    for prefix, lineage in MODEL_LINEAGE_PREFIX_TABLE.items():
-        if lower.startswith(prefix):
-            return lineage
-    return "unknown_model_lineage"
-
-
-@pytest.mark.parametrize(
-    "model_id, expected_lineage",
-    [
-        # OpenAI variants.
-        ("gpt-5.5", "openai"),
-        ("gpt-5-codex", "openai"),
-        ("gpt-4o", "openai"),
-        ("o1-preview", "openai"),
-        ("o3-mini", "openai"),
-        # Anthropic variants.
-        ("claude-opus-4-7", "anthropic"),
-        ("claude-sonnet-4-5", "anthropic"),
-        ("claude-haiku-4", "anthropic"),
-        # Google variants.
-        ("gemini-3.5-flash", "google"),
-        ("gemini-2.0-pro", "google"),
-        # xAI variants.
-        ("grok-4-3", "xai"),
-        ("grok-4-3-mini", "xai"),
-        # Mistral variants.
-        ("mistral-large-2.1", "mistral"),
-        ("codestral-2501", "mistral"),
-        # DeepSeek / Qwen / Kimi / Llama.
-        ("deepseek-v3", "deepseek"),
-        ("qwen-2.5-72b", "qwen"),
-        ("kimi-k2", "kimi"),
-        ("moonshot-v1", "kimi"),
-        ("llama-3.1-70b", "meta"),
-        # Unknown prefix.
-        ("unknown-model-x", "unknown_model_lineage"),
-        ("custom-finetune-v1", "unknown_model_lineage"),
-    ],
-)
-def test_model_lineage_prefix_normalization(model_id: str, expected_lineage: str) -> None:
-    """Model-ID prefix table positive cases — each prefix normalizes."""
-    assert _normalize_model_lineage(model_id) == expected_lineage, (
-        f"model_id {model_id!r} normalized to wrong lineage. The "
-        "prefix table has drifted from the spec."
+def test_body_only_metadata_does_not_override_unknown_heading() -> None:
+    identity = _resolve_model_review_identity(
+        "## Aragora Code Review\n\n"
+        "**Reviewer harness:** factory\n"
+        "**Model family:** openai\n"
+        "**Model id:** gpt-5.5\n"
+        "**Receipt artifact:** /tmp/review.md\n"
     )
 
-
-# ---------------------------------------------------------------------------
-# Backwards-compatibility floor: comments without the Reviewer field
-# MUST still resolve to a recognizable family marker today. The
-# implementation PR's Variant A (recommended) preserves this; Variant
-# B (future) un-counts them for Tier 2+.
-# ---------------------------------------------------------------------------
+    assert identity.surface_reviewer_id == "unknown_model_reviewer"
+    assert identity.model_family == "openai"
+    assert "unknown_surface_reviewer" in identity.identity_problems
 
 
-def test_pre_lineage_era_comments_still_count_under_variant_a() -> None:
-    """Backwards compat: pre-lineage-era comments still produce a family.
-
-    The implementation PR will return
-    `RecognizedReviewer(family_marker="factory", model_lineage=None)`
-    for comments lacking the Reviewer field. Under Variant A
-    (recommended for first implementation), the merge-quorum evaluator
-    still counts the signal; the `lineage_undeclared: true` flag is
-    recorded for observability.
-
-    Today (pre-implementation), the recognizer returns just "factory"
-    for such comments. This test pins the family-marker continuity
-    floor: the implementation PR cannot quietly drop the family marker
-    even when the body has no Reviewer field.
-    """
-    pre_lineage_bodies = [
-        "## Factory focused dogfood\n\nLooks good.\n",
-        "## Codex review\n\nVerdict: approve.\n",
-        "## Claude independent semantic review on head abc1234\n\nNo findings.\n",
-        "## Grok independent model review\n\nReceipt verified.\n",
-    ]
-    for body in pre_lineage_bodies:
-        family = _infer_model_reviewer_from_text(body)
-        assert family != "unknown_model_reviewer", (
-            f"pre-lineage-era body {body!r} should still produce a "
-            "recognized family marker. The implementation PR cannot "
-            "quietly demote pre-lineage comments to unknown — that "
-            "would invalidate existing in-flight evidence on open PRs."
-        )
-
-
-# ---------------------------------------------------------------------------
-# Safety floor: the LINEAGE_REGEX must NOT match heading-only or
-# code-block content, only structured Reviewer fields in body prose.
-# ---------------------------------------------------------------------------
-
-
-def test_lineage_regex_does_not_match_heading() -> None:
-    """Heading-only content with a paren expression is NOT a Reviewer field."""
-    body = "## Reviewer notes (gpt-5.5)\n\nSome review.\n"
-    match = LINEAGE_REGEX.search(body)
-    # The heading line "## Reviewer notes (gpt-5.5)" starts with "## "
-    # not the "Reviewer:" prefix. Must not match.
-    assert match is None, (
-        "LINEAGE_REGEX matched a markdown heading; the implementation "
-        "must scan body prose for the structured Reviewer field, not "
-        "any line containing 'Reviewer' and parens."
+def test_fenced_metadata_does_not_override_nearby_block() -> None:
+    identity = _resolve_model_review_identity(
+        "## Factory independent semantic review\n\n"
+        "```md\n"
+        "**Model family:** openai\n"
+        "```\n"
+        "No structured metadata outside the example block.\n"
     )
 
+    assert identity.surface_reviewer_id == "factory"
+    assert identity.model_family == ""
+    assert "missing_model_family_disclosure" in identity.identity_problems
 
-def test_lineage_parser_ignores_reviewer_shaped_code_block_content() -> None:
-    """Reviewer-shaped lines in code blocks are not attestations.
 
-    Defensive concern: a reviewer pasting code with a literal
-    `Reviewer: foo (bar)` line (no comment-marker prefix) must not
-    populate model_lineage. The implementation PR must use this
-    regex-plus-context contract, not the raw regex alone.
-
-    Note: bodies with `# Reviewer: ...` (hash-prefixed Python comments)
-    do NOT match because the regex starts with `^\\s*\\*{0,2}Reviewer`
-    and `#` is neither whitespace nor an asterisk. Only un-prefixed
-    Reviewer-shaped lines inside code blocks need explicit fence
-    filtering.
-    """
-    body = "Sample code:\n\n```\nReviewer: SomeAgent (some-model-v1)\n```\n"
-    raw_match = LINEAGE_REGEX.search(body)
-    assert raw_match is not None, (
-        "This fixture must remain capable of demonstrating why raw "
-        "LINEAGE_REGEX is insufficient by itself."
+def test_later_heading_metadata_does_not_override_first_heading() -> None:
+    identity = _resolve_model_review_identity(
+        "## Factory independent semantic review\n\n"
+        "No metadata near the first heading.\n\n"
+        "## Claude follow-up\n\n"
+        "**Model family:** claude\n"
+        "**Model id:** claude-opus-4-7\n"
+        "**Receipt artifact:** /tmp/review.md\n"
     )
 
-    prose_match = _search_lineage_body_prose(body)
-    assert prose_match is None, (
-        "The lineage parser contract must ignore Reviewer-shaped "
-        "lines inside fenced code blocks so example text cannot be "
-        "laundered into model-lineage evidence."
-    )
+    assert identity.surface_reviewer_id == "factory"
+    assert identity.model_family == ""
+    assert "missing_model_family_disclosure" in identity.identity_problems

--- a/tests/governance/test_model_quorum_recognizer_gaps.py
+++ b/tests/governance/test_model_quorum_recognizer_gaps.py
@@ -1,24 +1,19 @@
-"""Governance tests pinning the current state of `_infer_model_reviewer_from_text`.
+"""Governance tests for direct model-family recognition.
 
-These tests are the current-state characterization target for the Tier 4
+These tests were the current-state characterization target for the Tier 4
 model-quorum-family expansion patch designed in
-`docs/specs/MODEL_QUORUM_FAMILY_EXPANSION.md`. They exist for two reasons:
+`docs/specs/MODEL_QUORUM_FAMILY_EXPANSION.md`. After the lineage-bound
+quorum implementation they pin the new positive behavior:
 
 1. They *pin* the current state of the recognizer so that the Tier 4 patch
    has an explicit, machine-checkable regression floor: the patch must
    keep the existing claude/codex/gemini/grok/tesla/harvey/factory markers
    working while *adding* recognition for the gap families.
 
-2. They *demonstrate* the gap: already-routed families such as OpenAI,
-   Mistral/Codestral, DeepSeek, Qwen, Kimi/Moonshot and new proposed
-   families such as GLM, MiniMax, Yi, and Hermes currently return
-   `unknown_model_reviewer`, which means a reviewer signal posted by that
-   family — even if grounded on the current head SHA, even if posted by a
-   non-author account — would not be counted toward the quorum.
-
-After the Tier 4 patch lands, the gap-demonstration tests will need to be
-inverted (assert that the family IS recognized). At that point this file
-also becomes the regression floor for the new state.
+2. They assert that canonical model-family headings such as OpenAI,
+   Mistral/Codestral, DeepSeek, Qwen, Kimi/Moonshot, GLM, MiniMax, Yi,
+   and Hermes now resolve to canonical family IDs for lineage-bound
+   quorum evidence.
 
 Per `docs/REVIEW_AUTHORITY_PRINCIPLES.md::Family-additive change governance`:
 
@@ -28,8 +23,8 @@ Per `docs/REVIEW_AUTHORITY_PRINCIPLES.md::Family-additive change governance`:
   >  in tests/governance/ that characterize the current gate behavior
   >  and pin the gap to be inverted by the implementation."
 
-This file IS that pre-approval test surface. The implementation that
-inverts the gap-demonstration assertions waits for operator preapproval.
+This file now records that the pre-approved implementation intentionally
+inverted the former gap-demonstration assertions.
 """
 
 from __future__ import annotations
@@ -77,62 +72,40 @@ def test_existing_recognizers_still_resolve(comment_body: str, expected_family: 
     assert _infer_model_reviewer_from_text(comment_body) == expected_family
 
 
-# ----- Markers expected to NOT resolve today (gap demonstration) -----
+# ----- Markers expected to resolve after lineage-bound implementation -----
 #
-# Each of these families is either (a) already routable via OpenRouter
-# but not recognized as a reviewer source, or (b) a new family to be
-# added per the design spec. After the Tier 4 patch these assertions
-# should INVERT — but until then, this file documents the gap.
+# Each of these families is canonical for lineage-bound quorum counting.
 
 
 _GAP_MARKERS_HEAD_SHA = "abc1234"
 
 
 @pytest.mark.parametrize(
-    "comment_body, family_name",
+    "comment_body, expected_family",
     [
-        # Already-routed-by-aragora families that the recognizer DOES NOT count today.
-        # This is the surprise gap: aragora pays for OpenRouter access to these models
-        # via api_agents/openrouter.py, but their PR-comment signals are silently dropped.
         ("OpenAI independent model review on head abc1234", "openai"),
-        ("Anthropic independent semantic review on head abc1234", "anthropic"),
+        ("Anthropic independent semantic review on head abc1234", "claude"),
         ("Mistral independent model review on head abc1234", "mistral"),
-        ("Codestral independent semantic review on head abc1234", "mistral (via codestral marker)"),
+        ("Codestral independent semantic review on head abc1234", "mistral"),
         ("DeepSeek independent semantic review on head abc1234", "deepseek"),
         ("Qwen independent semantic review on head abc1234", "qwen"),
         ("Kimi independent semantic review on head abc1234", "kimi"),
-        ("Moonshot independent semantic review on head abc1234", "kimi (via moonshot marker)"),
-        # New families to add per the design spec + operator answer #2.
+        ("Moonshot independent semantic review on head abc1234", "kimi"),
         ("GLM independent semantic review on head abc1234", "glm"),
-        ("Zhipu independent semantic review on head abc1234", "glm (via zhipu marker)"),
-        ("Z-AI independent semantic review on head abc1234", "glm (via z-ai marker)"),
+        ("Zhipu independent semantic review on head abc1234", "glm"),
+        ("Z-AI independent semantic review on head abc1234", "glm"),
         ("MiniMax independent semantic review on head abc1234", "minimax"),
         ("Yi-Large independent semantic review on head abc1234", "yi"),
         ("Nous Hermes independent semantic review on head abc1234", "hermes"),
         ("Hermes independent semantic review on head abc1234", "hermes"),
     ],
 )
-def test_proposed_family_markers_currently_unrecognized(
+def test_canonical_model_family_markers_resolve(
     comment_body: str,
-    family_name: str,
+    expected_family: str,
 ) -> None:
-    """GAP DEMONSTRATION: families that should resolve after the patch.
-
-    Each input here would post a valid reviewer comment that the
-    recognizer SHOULD count under the design in
-    `docs/specs/MODEL_QUORUM_FAMILY_EXPANSION.md`, but today it returns
-    `unknown_model_reviewer` because the marker is missing from
-    `_infer_model_reviewer_from_text`'s current seven-marker tuple.
-
-    After the Tier 4 patch lands this test will be inverted (or moved
-    to a positive-recognition test parameterized by the new families).
-    The current assertion is the gap-of-record.
-    """
-    assert _infer_model_reviewer_from_text(comment_body) == "unknown_model_reviewer", (
-        f"Family {family_name!r} now appears to be recognized. If the Tier 4 patch "
-        "has landed, invert this assertion (or move to the positive-recognition "
-        f"suite) — the comment {comment_body!r} should now resolve to {family_name!r}."
-    )
+    """Canonical families resolve to the lineage ID used by quorum counting."""
+    assert _infer_model_reviewer_from_text(comment_body) == expected_family
 
 
 def test_unknown_garbage_stays_unknown() -> None:


### PR DESCRIPTION
## Summary

Implements the merged #7472 lineage-bound model review quorum design as a Tier 4 implementation PR. It also supersedes #7490's earlier soft record-only lineage direction with the strict #7472 policy now encoded in the merge-packet implementation.

This PR does not modify #7480 and does not include settlement-recording work.

## Changes

- Count merge-quorum evidence by canonical `model_family` rather than router/product surface marker.
- Keep `counted_reviewer_ids` for compatibility while adding `counted_model_families`.
- Add per-signal identity fields: `surface_reviewer_id`, `model_family`, `model_id`, `identity_source`, and `identity_problems`.
- Keep router/product comments visible but uncounted when model-family metadata is missing, unknown, or conflicting.
- Preserve exact-head grounding, first-heading safety, GitHub Actions exclusion, stale-comment exclusion, and unknown-reviewer fail-closed behavior.
- Update focused governance and review-queue tests for the strict lineage-bound contract.

## Advisory workflow note

I inspected `.github/workflows/aragora-review-gate.yml` and did not update the emitter. The current workflow posts an aggregate GitHub Actions `## Aragora Code Review` comment, and GitHub Actions comments are intentionally excluded from quorum counting. Adding model-family metadata there would fabricate countable identity for an aggregate advisory artifact rather than binding evidence to a real independent reviewer run.

## Validation

- `pytest tests/governance/test_advisory_review_recognizable_header.py -q` — 10 passed
- `pytest tests/cli/commands/test_review_queue.py -q` — 162 passed
- `pytest tests/governance/test_model_quorum_recognizer_gaps.py tests/governance/test_model_lineage_disclosure_recognizer.py -q` — 32 passed
- `ruff check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py tests/governance/test_advisory_review_recognizable_header.py tests/governance/test_model_quorum_recognizer_gaps.py tests/governance/test_model_lineage_disclosure_recognizer.py` — passed
- `ruff format --check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py tests/governance/test_advisory_review_recognizable_header.py tests/governance/test_model_quorum_recognizer_gaps.py tests/governance/test_model_lineage_disclosure_recognizer.py` — passed
- `git diff --check` — passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` — passed

## Tier 4 boundary

This remains a Tier 4 merge-authority self-modification. It requires fresh exact-head model evidence and explicit operator settlement before merge. This PR does not authorize mark-ready, merge, admin merge, branch-protection changes, status writes, or any settlement action.
