### PR TITLE
fix(decide): degrade gracefully for advertised advanced --mode values

### DIFF
--- a/aragora/cli/commands/decide.py
+++ b/aragora/cli/commands/decide.py
@@ -225,6 +225,16 @@ async def run_decide(
                 print("[decide] Template system not available")
 
     # Apply mode overrides
+    #
+    # NOTE: the ``--mode`` choices advertised by the parser include both
+    # operational modes (architect/coder/reviewer/...) that live in the
+    # ``ModeRegistry`` AND advanced modes (redteam/deep_audit/prober) that are
+    # implemented as separate orchestration subsystems (RedTeamMode,
+    # DeepAuditOrchestrator, CapabilityProber) and are NOT registered there.
+    # ``decide`` does not yet wire those advanced subsystems into the debate
+    # path, so an unresolved mode must degrade gracefully with a clean notice
+    # rather than crashing the command with a raw KeyError traceback.
+    _ADVANCED_MODES = {"redteam", "deep_audit", "prober"}
     mode_config: dict[str, Any] = {}
     if mode and mode != "standard":
         try:
@@ -241,11 +251,19 @@ async def run_decide(
                 }
                 if verbose:
                     print(f"[decide] Using mode: {mode}")
+            elif mode in _ADVANCED_MODES:
+                # Advertised advanced mode without a registry entry — the
+                # dedicated subsystem is not yet integrated into `decide`.
+                print(
+                    f"[decide] Advanced mode '{mode}' is not yet wired into "
+                    "the decide pipeline; proceeding with standard deliberation."
+                )
             else:
                 available = ", ".join(ModeRegistry.list_all())
-                raise KeyError(f"Mode '{mode}' not found. Available: {available}")
-        except KeyError:
-            raise
+                print(
+                    f"[decide] Mode '{mode}' not found "
+                    f"(available: {available}); proceeding with standard deliberation."
+                )
         except ImportError:
             if verbose:
                 print(f"[decide] Mode system not available, ignoring --mode {mode}")

--- a/tests/cli/test_decide_command.py
+++ b/tests/cli/test_decide_command.py
@@ -241,6 +241,86 @@ async def test_run_decide_forwards_wrapped_spec_artifacts(tmp_path) -> None:
     assert result["run_id"] == "run-cli-wrapped"
 
 
+@pytest.mark.parametrize("mode", ["redteam", "deep_audit", "prober"])
+@pytest.mark.asyncio
+async def test_run_decide_advertised_advanced_mode_does_not_crash(tmp_path, mode, capsys) -> None:
+    """Advertised --mode advanced modes (redteam/deep_audit/prober) are not in the
+    operational ModeRegistry, but the parser offers them as valid choices. They must
+    degrade gracefully with a clean notice rather than raising a raw KeyError traceback.
+    """
+    from aragora.cli.commands.decide import run_decide
+
+    spec_path = tmp_path / "spec.json"
+    spec_path.write_text('{"specification":{"title":"Spec","objective":"test"}}')
+
+    plan = MagicMock()
+    plan.id = "plan-mode"
+    plan.status = SimpleNamespace(value="approved")
+    plan.risk_register = None
+    plan.requires_human_approval = False
+
+    with (
+        patch(
+            "aragora.pipeline.decision_plan.DecisionPlanFactory.from_specification",
+            return_value=plan,
+        ),
+        patch(
+            "aragora.cli.commands.decide._seed_cli_backbone_run",
+            return_value="run-mode",
+        ),
+    ):
+        # Must not raise KeyError for an advertised-but-unregistered mode.
+        result = await run_decide(
+            task="Ship the feature",
+            agents_str="claude,gemini",
+            dry_run=True,
+            spec_file=str(spec_path),
+            mode=mode,
+            verbose=True,
+        )
+
+    assert result["plan"] is plan
+    # A clean, human-readable notice is printed instead of a traceback.
+    out = capsys.readouterr().out
+    assert mode in out
+
+
+@pytest.mark.asyncio
+async def test_run_decide_unknown_mode_does_not_crash(tmp_path, capsys) -> None:
+    """A genuinely unknown mode should still degrade gracefully (no raw traceback)."""
+    from aragora.cli.commands.decide import run_decide
+
+    spec_path = tmp_path / "spec.json"
+    spec_path.write_text('{"specification":{"title":"Spec","objective":"test"}}')
+
+    plan = MagicMock()
+    plan.id = "plan-unknown-mode"
+    plan.status = SimpleNamespace(value="approved")
+    plan.risk_register = None
+    plan.requires_human_approval = False
+
+    with (
+        patch(
+            "aragora.pipeline.decision_plan.DecisionPlanFactory.from_specification",
+            return_value=plan,
+        ),
+        patch(
+            "aragora.cli.commands.decide._seed_cli_backbone_run",
+            return_value="run-unknown-mode",
+        ),
+    ):
+        result = await run_decide(
+            task="Ship the feature",
+            agents_str="claude,gemini",
+            dry_run=True,
+            spec_file=str(spec_path),
+            mode="totally_unknown_mode",
+            verbose=True,
+        )
+
+    assert result["plan"] is plan
+
+
 @pytest.mark.asyncio
 async def test_run_decide_executes_via_backbone_helper(tmp_path) -> None:
     """run_decide should execute plans through the backbone helper and surface IDs."""


### PR DESCRIPTION
## Problem

`aragora decide --mode {redteam,deep_audit,prober}` crashes with an uncaught `KeyError` traceback (exit 1), even via the fully offline spec path:

```
echo '{"specification": {"title": "Test", "objective": "test"}}' > /tmp/testspec.json
python3 -m aragora.cli.main decide "t" --spec /tmp/testspec.json --dry-run --mode redteam
# KeyError: "Mode 'redteam' not found. Available: architect, coder, reviewer, debugger, orchestrator, epistemic_hygiene"  (exit 1)
```

This affects all three advanced modes (`redteam`, `deep_audit`, `prober`).

## Root cause

`aragora/cli/parser.py:2670` advertises `redteam/deep_audit/prober` as valid `--mode` choices, so argparse passes them through. But `aragora/cli/commands/decide.py` resolved every mode through the operational `ModeRegistry`, which only registers `architect/coder/reviewer/debugger/orchestrator/epistemic_hygiene`.

The advanced modes are implemented as **separate orchestration subsystems** (`RedTeamMode`, `DeepAuditOrchestrator`, `CapabilityProber`) and are intentionally not `ModeRegistry` entries. When `ModeRegistry.get()` returned `None`, `decide.py:246` raised a bare `KeyError` that was immediately re-raised (`except KeyError: raise`) and propagated uncaught through `asyncio.run` -> the parser wrapper -> `main`, printing a full Python traceback.

The resolved `mode_config` is unused metadata (`# noqa: F841 — stored for future mode injection`), so the crash gated the entire command on a purely cosmetic lookup. The parser's advertised choice list and the registry were mutually inconsistent.

## Fix

When a mode does not resolve in `ModeRegistry`, print a clean one-line notice and proceed with standard deliberation instead of raising:

- Advertised advanced modes (`redteam/deep_audit/prober`) get a dedicated `not yet wired into the decide pipeline` message.
- Any other unresolved mode gets an `available modes` notice.

No raw traceback reaches the user; the command exits 0. This matches the existing `ImportError` graceful-degradation branch immediately below.

### Before / After

Before:
```
$ aragora decide "t" --spec /tmp/testspec.json --dry-run --mode redteam
Traceback (most recent call last):
  ...
KeyError: "Mode 'redteam' not found. Available: ..."   # exit 1
```

After:
```
$ aragora decide "t" --spec /tmp/testspec.json --dry-run --mode redteam
[decide] Advanced mode 'redteam' is not yet wired into the decide pipeline; proceeding with standard deliberation.
...
Plan Status: awaiting_approval                          # exit 0
```

## Tests (TDD)

Added to `tests/cli/test_decide_command.py`:
- `test_run_decide_advertised_advanced_mode_does_not_crash` (parametrized over `redteam`/`deep_audit`/`prober`) — asserts no `KeyError` and a clean notice.
- `test_run_decide_unknown_mode_does_not_crash` — asserts a genuinely unknown mode also degrades gracefully.

Failing before the fix, green after. Full `tests/cli/test_decide_command.py` module passes (13 tests).

Fixes the `decide` defect in the spec-json lane (`/tmp/fix_lanes.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)