### PR TITLE
fix(explain): catch AragoraAPIError so local fallback runs (no raw traceback)

### DIFF
--- a/aragora/cli/commands/explain.py
+++ b/aragora/cli/commands/explain.py
@@ -107,6 +107,7 @@ def _try_api_explanation(debate_id: str, args: argparse.Namespace) -> dict[str, 
         import os
 
         from aragora.client.client import AragoraClient
+        from aragora.client.errors import AragoraAPIError
 
         api_url = getattr(args, "api_url", None) or os.environ.get(
             "ARAGORA_API_URL", "http://localhost:8080"
@@ -166,7 +167,11 @@ def _try_api_explanation(debate_id: str, args: argparse.Namespace) -> dict[str, 
     except ImportError:
         logger.debug("AragoraClient not available")
         return None
-    except (OSError, ConnectionError, RuntimeError, ValueError, KeyError) as e:
+    except (AragoraAPIError, OSError, ConnectionError, RuntimeError, ValueError, KeyError) as e:
+        # AragoraAPIError covers the SDK client's connection/HTTP failures
+        # (URLError re-raised in client._get, NotFoundError/etc. via _handle_http_error).
+        # It derives from AragoraError(Exception), not OSError, so it must be caught
+        # explicitly to reach the local fallback in cmd_explain.
         logger.debug("API explanation failed: %s", e)
         return None
 

--- a/tests/cli/test_explain_command.py
+++ b/tests/cli/test_explain_command.py
@@ -264,6 +264,41 @@ class TestExplainAPIPath:
 
         assert result is None
 
+    def test_api_aragora_api_error_returns_none(self):
+        """When the client raises AragoraAPIError (the real connection-error type), returns None.
+
+        Regression: the client's _get re-raises URLError as AragoraAPIError, which derives
+        only from AragoraError(Exception) -- not OSError/ConnectionError/RuntimeError. Before
+        the fix, this propagated as a raw traceback and bypassed the local fallback.
+        """
+        from aragora.client.errors import AragoraAPIError
+
+        mock_client = MagicMock()
+        mock_client.explainability.get_explanation.side_effect = AragoraAPIError(
+            "Connection error", "CONNECTION_ERROR", 0
+        )
+
+        with patch("aragora.client.client.AragoraClient") as mock_cls:
+            mock_cls.return_value = mock_client
+            result = _try_api_explanation("d1", _make_args())
+
+        assert result is None
+
+    def test_api_not_found_error_returns_none(self):
+        """When the API returns 404 (NotFoundError subclass of AragoraAPIError), returns None."""
+        from aragora.client.errors import NotFoundError
+
+        mock_client = MagicMock()
+        mock_client.explainability.get_explanation.side_effect = NotFoundError(
+            "Debate not found", "debate"
+        )
+
+        with patch("aragora.client.client.AragoraClient") as mock_cls:
+            mock_cls.return_value = mock_client
+            result = _try_api_explanation("d1", _make_args())
+
+        assert result is None
+
     def test_api_uses_custom_url_and_key(self):
         """API path uses --api-url and --api-key from args."""
         mock_explanation = MagicMock()


### PR DESCRIPTION
## Problem

`aragora explain <id>` prints a raw multi-frame Python traceback (and skips its own documented local fallback) whenever the API server is unreachable or returns an error — the default offline case.

Repro (no server on :8080):
```
python3 -m aragora.cli.main explain nonexistent_debate_id_xyz123 --api-url http://localhost:8080
```
Before: full urllib + `AragoraAPIError: Connection error` traceback to stderr, exit 1.

## Root cause

`_try_api_explanation` (`aragora/cli/commands/explain.py:169`) caught `(OSError, ConnectionError, RuntimeError, ValueError, KeyError)`. But the SDK client re-raises connection failures as `AragoraAPIError` (`client.py:341`, from `URLError`) and HTTP errors as `NotFoundError`/other subclasses via `_handle_http_error`. `AragoraAPIError` derives only from `AragoraError(Exception)` (`client/errors.py:12`), so it is **not** a subclass of any caught type. The exception propagated uncaught:

1. raw traceback to the user, and
2. the documented local `ExplanationBuilder` fallback (`cmd_explain` lines 82-83) and friendly-error branch (lines 85-94) were never reached — the stack terminated in `cmd_explain` at line 79.

This contradicts the handler's own contract: *"Tries API-first via AragoraClient, falls back to local ExplanationBuilder."*

## Fix

Import `AragoraAPIError` and add it to the caught tuple. It is the base of every SDK error subclass (`NotFoundError`, `RateLimitError`, `AuthenticationError`, etc.), so all API failure modes now degrade to the local builder, and if that also fails the user gets the intended one-line message.

After:
```
Error: Could not retrieve explanation for debate <id>.
Ensure the API server is running or the debate exists locally.
```
exit 1, no traceback.

## Tests

The existing failure tests mocked `ConnectionError`/`RuntimeError`/`ValueError` — all already in the caught tuple — giving false-green coverage that never exercised the real exception. Added two TDD tests raising the actual `AragoraAPIError` and `NotFoundError` the client emits. Full module: 41 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)