### PR TITLE
fix(triage): handle SecretNotFoundError in `triage status` (strict-secrets crash)

### DIFF
--- a/aragora/cli/commands/triage.py
+++ b/aragora/cli/commands/triage.py
@@ -38,9 +38,16 @@ def _load_local_dotenv() -> None:
 def _get_secret_fallback(name: str) -> str:
     """Resolve a secret via Aragora's secret loader when available."""
     try:
-        from aragora.config.secrets import get_secret
+        from aragora.config.secrets import SecretNotFoundError, get_secret
 
         return str(get_secret(name) or "")
+    except SecretNotFoundError as exc:
+        # Strict-secrets / production posture: a CRITICAL_SECRET absent from
+        # AWS Secrets Manager raises rather than falling back to env. For
+        # read-only diagnostics ("is this key configured?") that simply means
+        # "not available" -- degrade to "" instead of crashing the command.
+        logger.debug("Secret %s not available in strict mode: %s", name, exc)
+        return ""
     except (ImportError, OSError, ValueError) as exc:
         logger.debug("Secret fallback for %s unavailable: %s", name, exc)
         return ""

--- a/tests/cli/test_triage_command.py
+++ b/tests/cli/test_triage_command.py
@@ -477,6 +477,45 @@ def test_get_gmail_connector_uses_secret_fallback_for_credentials(tmp_path, monk
     assert connector._refresh_token == "refresh-from-file"
 
 
+def test_get_secret_fallback_returns_empty_on_secret_not_found(monkeypatch):
+    """Strict-mode SecretNotFoundError must degrade to '' (read-only diagnostics)."""
+    from aragora.config.secrets import SecretNotFoundError
+
+    def _raise(name, *args, **kwargs):
+        raise SecretNotFoundError(name)
+
+    monkeypatch.setattr("aragora.config.secrets.get_secret", _raise)
+
+    assert triage_cmd._get_secret_fallback("OPENROUTER_API_KEY") == ""
+
+
+def test_show_status_survives_strict_secrets(tmp_path, monkeypatch, capsys):
+    """`triage status` must not crash when critical secrets are absent in strict mode."""
+    from aragora.config.secrets import SecretNotFoundError
+
+    token_dir = Path(tmp_path) / ".aragora"
+    token_dir.mkdir()
+    (token_dir / "signing.key").write_text("dummy-signing-key")
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("GMAIL_CLIENT_ID", raising=False)
+    monkeypatch.delenv("GMAIL_CLIENT_SECRET", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    def _raise(name, *args, **kwargs):
+        raise SecretNotFoundError(name)
+
+    with (
+        patch("aragora.config.secrets.get_secret", _raise),
+        patch.object(triage_cmd, "_load_local_dotenv"),
+    ):
+        triage_cmd._show_status()
+
+    out = capsys.readouterr().out
+    assert "OpenRouter fallback:  NO" in out
+    assert "Durable signing key:  yes" in out
+
+
 def test_show_status_reports_refresh_token(tmp_path, monkeypatch, capsys):
     token_dir = Path(tmp_path) / ".aragora"
     token_dir.mkdir()


### PR DESCRIPTION
## Problem

`aragora triage status` crashes with an uncaught `SecretNotFoundError` traceback (exit 1) under the strict-secrets / production posture — the canonical AWS Secrets Manager posture.

Repro (safe / offline):
```bash
cd /tmp && env -i PATH="$PATH" HOME="$HOME" \
  ARAGORA_SECRETS_STRICT=true ARAGORA_USE_SECRETS_MANAGER=false \
  python3 -m aragora.cli.main triage status; echo $?
```
Also reproduces via `ARAGORA_ENV=production`.

## Root cause

`_show_status()` (triage.py:705+) probes provider keys via `_get_secret_fallback(...)` for `OPENROUTER_API_KEY`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`. All four are `CRITICAL_SECRETS` (secrets.py:165-170), so in strict mode `get_secret()` raises `SecretNotFoundError` instead of falling back to env (secrets.py:593).

`SecretNotFoundError` subclasses plain `Exception` (secrets.py:181), but `_get_secret_fallback` only caught `(ImportError, OSError, ValueError)` — so it propagated as a raw traceback. The crash fired on the first provider probe, so the status table printed only partially, interleaved after the traceback.

Same root-cause class as the doctor AWS-secrets fix (#7395), but a distinct, still-broken command path.

## Fix

Catch `SecretNotFoundError` explicitly in `_get_secret_fallback` and degrade to `""`. `triage status` is read-only diagnostics: "is this key configured?" should report `NO`, not abort. One helper fix covers all four provider probes.

## Before / After

Before: exit `1`, full traceback ending in `SecretNotFoundError`, partial table.

After:
```
Inbox Triage Status
────────────────────────────────────────
  Gmail configured:     yes
  Durable signing key:  yes
  Gmail refresh token:  yes
  OpenRouter fallback:  NO
  Anthropic key:        no
  OpenAI key:           no
  Gemini key:           no
```
Exit `0`, full table.

## Tests (TDD)

- `test_get_secret_fallback_returns_empty_on_secret_not_found` — helper degrades to `""` on `SecretNotFoundError`.
- `test_show_status_survives_strict_secrets` — `_show_status()` completes and reports `OpenRouter fallback:  NO`.

Both fail on `main` (reproduce the crash at unit level) and pass after the fix. Full `tests/cli/test_triage_command.py` passes (21/21) with secrets-manager loading disabled; the only failures seen otherwise are pre-existing AWS-credential test-cache pollution among the unrelated `run_triage_*` tests (count actually drops from 4→1 with this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)