### PR TITLE
fix(review-queue): ignore stale quorum self-check in required gate

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -1409,7 +1409,7 @@ def _summarize_required_pr_checks(checks: list[dict[str, Any]]) -> tuple[str, bo
     """Return ``(summary, has_failures, has_pending)`` for required PR checks."""
     success = failure = pending = 0
     for check in checks:
-        if _is_current_merge_quorum_self_check(check):
+        if _is_required_pr_check_current_merge_quorum_self_check(check):
             continue
         bucket = _required_pr_check_bucket(check)
         if bucket in {"pass", "skipping"}:
@@ -1435,7 +1435,8 @@ def _effective_required_pr_check_count(checks: list[dict[str, Any]]) -> int:
     return sum(
         1
         for check in checks
-        if isinstance(check, dict) and not _is_current_merge_quorum_self_check(check)
+        if isinstance(check, dict)
+        and not _is_required_pr_check_current_merge_quorum_self_check(check)
     )
 
 
@@ -1829,6 +1830,24 @@ def _is_current_merge_quorum_self_check(check: dict[str, Any]) -> bool:
     )
 
 
+def _is_required_pr_check_current_merge_quorum_self_check(check: dict[str, Any]) -> bool:
+    """Return true for the merge-quorum job's own required PR check row.
+
+    ``gh pr checks --required`` can report the previous merge-quorum attempt
+    while the new merge-quorum job is computing its packet. For that required
+    PR-check fallback only, the workflow must ignore its own row regardless of
+    whether GitHub labels the stale row pending, failed, or cancelled. Other
+    call sites keep the stricter URL/status match so stale completed
+    merge-quorum failures still block local settlement.
+    """
+    if not _is_merge_quorum_check(check):
+        return False
+    return (
+        os.environ.get("GITHUB_WORKFLOW") == MERGE_QUORUM_WORKFLOW_NAME
+        and os.environ.get("GITHUB_JOB") == MERGE_QUORUM_JOB_ID
+    )
+
+
 def _filter_lanes(
     items: list[QueueItem],
     *,
@@ -1924,12 +1943,13 @@ def _build_packet(
                     str(check.get("name") or "").strip()
                     for check in required_pr_checks
                     if _required_pr_check_bucket(check) in {"fail", "cancel"}
+                    and not _is_required_pr_check_current_merge_quorum_self_check(check)
                 ][:CHECK_SURFACE_DIAGNOSTIC_LIMIT],
                 "pending": [
                     str(check.get("name") or "").strip()
                     for check in required_pr_checks
                     if _required_pr_check_bucket(check) == "pending"
-                    and not _is_current_merge_quorum_self_check(check)
+                    and not _is_required_pr_check_current_merge_quorum_self_check(check)
                 ][:CHECK_SURFACE_DIAGNOSTIC_LIMIT],
             }
             if (

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -1928,6 +1928,214 @@ class TestBuildQueueAndPacket:
         assert packet.model_review_quorum["admin_squash_allowed"] is True
         assert packet.model_review_quorum["status"] == "satisfied"
 
+    def test_required_pr_checks_gate_ignores_stale_self_row_inside_quorum_run(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pr_payload = _make_pr(
+            number=7465,
+            files=["docs/status/open.md"],
+            checks=[
+                {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
+                {"name": "typecheck", "status": "COMPLETED", "conclusion": "SUCCESS"},
+                {
+                    "name": "Mac TypeScript SDK Shadow",
+                    "workflowName": "Self-Hosted Shadow CI",
+                    "status": "QUEUED",
+                    "conclusion": "",
+                },
+                {
+                    "name": "Hetzner Offline Golden Path Shadow",
+                    "workflowName": "Self-Hosted Shadow CI",
+                    "status": "QUEUED",
+                    "conclusion": "",
+                },
+                {
+                    "name": "aragora-merge-quorum",
+                    "workflowName": "Aragora Merge Quorum",
+                    "status": "COMPLETED",
+                    "conclusion": "FAILURE",
+                },
+            ],
+        )
+        pr_payload["comments"] = [
+            _dogfood_comment("## Claude focused dogfood\npass"),
+            {
+                "author": {"login": "an0mium"},
+                "body": "## Grok independent model review\nVerdict: approve.",
+            },
+        ]
+        monkeypatch.setenv("GITHUB_WORKFLOW", "Aragora Merge Quorum")
+        monkeypatch.setenv("GITHUB_JOB", "merge-quorum")
+
+        def fake_gh_json(args: list[str]) -> Any:
+            if args[:2] == ["pr", "view"]:
+                return pr_payload
+            if args[:2] == ["pr", "checks"]:
+                return [
+                    {
+                        "name": "aragora-merge-quorum",
+                        "state": "FAILURE",
+                        "bucket": "fail",
+                        "workflow": "Aragora Merge Quorum",
+                        "link": "https://github.com/synaptent/aragora/actions/runs/old/job/1",
+                    },
+                    {
+                        "name": "lint",
+                        "state": "SUCCESS",
+                        "bucket": "pass",
+                        "workflow": "Lint",
+                    },
+                    {
+                        "name": "typecheck",
+                        "state": "SUCCESS",
+                        "bucket": "pass",
+                        "workflow": "Lint",
+                    },
+                ]
+            raise AssertionError(f"unexpected gh call: {args}")
+
+        monkeypatch.setattr("aragora.cli.commands.review_queue._gh_json", fake_gh_json)
+
+        packet = _build_packet("7465", repo_override=None)
+        required = packet.check_surfaces["required_pr_checks"]
+
+        assert packet.checks_summary == "2/2 required green (required PR checks)"
+        assert required["effective_total"] == 2
+        assert required["failing_or_cancelled"] == []
+        assert required["pending"] == []
+        assert packet.machine_recommendation == "approve_candidate"
+        assert packet.model_review_quorum["admin_squash_allowed"] is True
+        assert packet.model_review_quorum["status"] == "satisfied"
+
+    def test_required_pr_checks_gate_preserves_self_row_outside_quorum_run(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pr_payload = _make_pr(
+            number=7465,
+            files=["docs/status/open.md"],
+            checks=[
+                {
+                    "name": "Mac TypeScript SDK Shadow",
+                    "workflowName": "Self-Hosted Shadow CI",
+                    "status": "QUEUED",
+                    "conclusion": "",
+                },
+                {
+                    "name": "aragora-merge-quorum",
+                    "workflowName": "Aragora Merge Quorum",
+                    "status": "COMPLETED",
+                    "conclusion": "FAILURE",
+                },
+                {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            ],
+        )
+        pr_payload["comments"] = [
+            _dogfood_comment("## Claude focused dogfood\npass"),
+            {
+                "author": {"login": "an0mium"},
+                "body": "## Grok independent model review\nVerdict: approve.",
+            },
+        ]
+
+        def fake_gh_json(args: list[str]) -> Any:
+            if args[:2] == ["pr", "view"]:
+                return pr_payload
+            if args[:2] == ["pr", "checks"]:
+                return [
+                    {
+                        "name": "aragora-merge-quorum",
+                        "state": "FAILURE",
+                        "bucket": "fail",
+                        "workflow": "Aragora Merge Quorum",
+                    },
+                    {
+                        "name": "lint",
+                        "state": "SUCCESS",
+                        "bucket": "pass",
+                        "workflow": "Lint",
+                    },
+                ]
+            raise AssertionError(f"unexpected gh call: {args}")
+
+        monkeypatch.setattr("aragora.cli.commands.review_queue._gh_json", fake_gh_json)
+
+        packet = _build_packet("7465", repo_override=None)
+
+        assert "effective_gate" not in packet.check_surfaces
+        assert packet.machine_recommendation == "repair_first"
+        assert packet.model_review_quorum["admin_squash_allowed"] is False
+        assert packet.model_review_quorum["status"] == "repair_or_wait"
+
+    def test_required_pr_checks_gate_keeps_non_self_required_failure_blocking(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pr_payload = _make_pr(
+            number=7465,
+            files=["docs/status/open.md"],
+            checks=[
+                {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
+                {"name": "typecheck", "status": "COMPLETED", "conclusion": "FAILURE"},
+                {
+                    "name": "Mac TypeScript SDK Shadow",
+                    "workflowName": "Self-Hosted Shadow CI",
+                    "status": "QUEUED",
+                    "conclusion": "",
+                },
+                {
+                    "name": "aragora-merge-quorum",
+                    "workflowName": "Aragora Merge Quorum",
+                    "status": "COMPLETED",
+                    "conclusion": "FAILURE",
+                },
+            ],
+        )
+        pr_payload["comments"] = [
+            _dogfood_comment("## Claude focused dogfood\npass"),
+            {
+                "author": {"login": "an0mium"},
+                "body": "## Grok independent model review\nVerdict: approve.",
+            },
+        ]
+        monkeypatch.setenv("GITHUB_WORKFLOW", "Aragora Merge Quorum")
+        monkeypatch.setenv("GITHUB_JOB", "merge-quorum")
+
+        def fake_gh_json(args: list[str]) -> Any:
+            if args[:2] == ["pr", "view"]:
+                return pr_payload
+            if args[:2] == ["pr", "checks"]:
+                return [
+                    {
+                        "name": "aragora-merge-quorum",
+                        "state": "FAILURE",
+                        "bucket": "fail",
+                        "workflow": "Aragora Merge Quorum",
+                    },
+                    {
+                        "name": "lint",
+                        "state": "SUCCESS",
+                        "bucket": "pass",
+                        "workflow": "Lint",
+                    },
+                    {
+                        "name": "typecheck",
+                        "state": "FAILURE",
+                        "bucket": "fail",
+                        "workflow": "Lint",
+                    },
+                ]
+            raise AssertionError(f"unexpected gh call: {args}")
+
+        monkeypatch.setattr("aragora.cli.commands.review_queue._gh_json", fake_gh_json)
+
+        packet = _build_packet("7465", repo_override=None)
+        required = packet.check_surfaces["required_pr_checks"]
+
+        assert "effective_gate" not in packet.check_surfaces
+        assert required["failing_or_cancelled"] == ["typecheck"]
+        assert packet.machine_recommendation == "repair_first"
+        assert packet.model_review_quorum["admin_squash_allowed"] is False
+        assert packet.model_review_quorum["status"] == "repair_or_wait"
+
     def test_required_pr_checks_gate_fails_closed_when_only_self_check_visible(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -2730,7 +2938,9 @@ class TestBuildQueueAndPacket:
         )
         monkeypatch.setattr(
             "aragora.cli.commands.review_queue._gh_text",
-            lambda args: "diff --git a/aragora/cli/commands/review_pr.py b/aragora/cli/commands/review_pr.py",
+            lambda args: (
+                "diff --git a/aragora/cli/commands/review_pr.py b/aragora/cli/commands/review_pr.py"
+            ),
         )
         outputs = [
             _make_reviewer_output(


### PR DESCRIPTION
## Summary
- let the Aragora Merge Quorum workflow ignore its own stale required PR-check row while computing merge-packet
- keep local/outside merge-packet runs strict so completed merge-quorum failures still block settlement
- add focused tests for stale self-check rows, outside-run blocking, and non-self required failures

## Validation
- uv run --extra all --extra test --extra dev --with defusedxml --with numpy python -m pytest tests/cli/commands/test_review_queue.py -q
- uv run --extra test --extra dev --with ruff python -m ruff check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py
- uv run --extra test --extra dev --with ruff python -m ruff format --check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py
- uv run --extra all --extra test --extra dev --with defusedxml --with numpy python -m mypy aragora/cli/commands/review_queue.py --ignore-missing-imports
- git diff --check origin/main...HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD

## Notes
This does not merge, rerun, mark ready, or write receipts for #7465. It only repairs the parity bug exposed by #7465.