### PR TITLE
fix(settlement): bound settle-one packet timeouts

### DIFF
--- a/scripts/settle_one_pr.py
+++ b/scripts/settle_one_pr.py
@@ -15,6 +15,7 @@ import argparse
 import json
 import os
 import re
+import signal
 import subprocess
 import sys
 from datetime import UTC, datetime
@@ -32,6 +33,24 @@ VERSION = "settle_one_steward.v1"
 MERGE_QUORUM = "aragora-merge-quorum"
 HUMAN_RISK_EXCLUDES = {7407, 7425, 7438, 7439, 7443}
 BROAD_PACKET_NEAR_SELECTED_LOOKAHEAD = 8
+
+
+def _env_timeout_seconds(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return default
+
+
+GH_METADATA_TIMEOUT_SECONDS = _env_timeout_seconds("SETTLE_ONE_GH_TIMEOUT_SECONDS", 60)
+OPERATOR_SNAPSHOT_TIMEOUT_SECONDS = _env_timeout_seconds(
+    "SETTLE_ONE_OPERATOR_SNAPSHOT_TIMEOUT_SECONDS", 30
+)
+BROAD_PACKET_TIMEOUT_SECONDS = _env_timeout_seconds("SETTLE_ONE_BROAD_PACKET_TIMEOUT_SECONDS", 90)
+SINGLE_PACKET_TIMEOUT_SECONDS = _env_timeout_seconds("SETTLE_ONE_SINGLE_PACKET_TIMEOUT_SECONDS", 90)
 OPEN_PR_LIGHT_FIELDS = (
     "number,title,url,headRefName,headRefOid,isDraft,mergeable,mergeStateStatus,"
     "reviewDecision,labels,author,additions,deletions,changedFiles"
@@ -68,19 +87,37 @@ def _state_repo_root(cwd: Path) -> Path:
 
 
 def _run(args: list[str], *, cwd: Path, timeout: int = 120) -> dict[str, Any]:
-    proc = subprocess.run(
+    proc = subprocess.Popen(
         args,
         cwd=cwd,
-        capture_output=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         text=True,
-        timeout=timeout,
-        check=False,
+        start_new_session=True,
     )
+    try:
+        stdout, stderr = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except (AttributeError, OSError, ProcessLookupError):
+            proc.kill()
+        stdout, stderr = proc.communicate()
+        return {
+            "command": " ".join(args),
+            "returncode": 124,
+            "stdout": (stdout or "").strip(),
+            "stderr": (
+                (stderr or "").strip() or f"command timed out after {timeout}s and was terminated"
+            ),
+            "timed_out": True,
+            "timeout_seconds": timeout,
+        }
     return {
         "command": " ".join(args),
         "returncode": proc.returncode,
-        "stdout": proc.stdout.strip(),
-        "stderr": proc.stderr.strip(),
+        "stdout": (stdout or "").strip(),
+        "stderr": (stderr or "").strip(),
     }
 
 
@@ -753,6 +790,7 @@ def load_open_pr_metadata(
             repo,
         ),
         cwd=cwd,
+        timeout=GH_METADATA_TIMEOUT_SECONDS,
     )
     metadata: dict[int, dict[str, Any]] = {}
     if isinstance(payload, list):
@@ -774,6 +812,7 @@ def load_pr_policy_metadata(
             repo,
         ),
         cwd=cwd,
+        timeout=GH_METADATA_TIMEOUT_SECONDS,
     )
     if isinstance(payload, dict):
         return payload, command
@@ -784,6 +823,7 @@ def load_active_owned_prs(cwd: Path) -> tuple[set[int], dict[str, Any]]:
     payload, command = _run_json(
         ["python3", "scripts/agent_bridge.py", "operator-snapshot", "--json"],
         cwd=cwd,
+        timeout=OPERATOR_SNAPSHOT_TIMEOUT_SECONDS,
     )
     active_owned: set[int] = set()
     if isinstance(payload, dict):
@@ -1257,7 +1297,7 @@ def _load_single_pr_packet(*, cwd: Path, pr: int, repo: str | None) -> dict[str,
     ]
     if repo:
         command.extend(["--repo", repo])
-    payload, result = _run_json(command, cwd=cwd, timeout=600)
+    payload, result = _run_json(command, cwd=cwd, timeout=SINGLE_PACKET_TIMEOUT_SECONDS)
     if result["returncode"] != 0:
         raise RuntimeError(result["stderr"] or result["stdout"] or "merge-packet failed")
     if not isinstance(payload, dict):
@@ -1278,7 +1318,7 @@ def _load_broad_packet_bulk(*, cwd: Path, limit: int, repo: str | None) -> dict[
     ]
     if repo:
         command.extend(["--repo", repo])
-    payload, result = _run_json(command, cwd=cwd, timeout=600)
+    payload, result = _run_json(command, cwd=cwd, timeout=BROAD_PACKET_TIMEOUT_SECONDS)
     if result["returncode"] != 0:
         raise RuntimeError(result["stderr"] or result["stdout"] or "merge-packet failed")
     if not isinstance(payload, dict):

--- a/tests/scripts/test_settle_one_pr.py
+++ b/tests/scripts/test_settle_one_pr.py
@@ -75,10 +75,13 @@ def test_run_reports_timeout_and_terminates_process_group(monkeypatch) -> None:
         def __init__(self) -> None:
             self.communicate_calls = 0
 
-        def communicate(self, timeout: int | None = None) -> tuple[str, str]:
+        def communicate(self, timeout: float | None = None) -> tuple[str, str]:
             self.communicate_calls += 1
             if self.communicate_calls == 1:
-                raise subprocess.TimeoutExpired(cmd=["slow"], timeout=timeout)
+                raise subprocess.TimeoutExpired(
+                    cmd=["slow"],
+                    timeout=timeout if timeout is not None else 0.0,
+                )
             self.returncode = -9
             return "", ""
 

--- a/tests/scripts/test_settle_one_pr.py
+++ b/tests/scripts/test_settle_one_pr.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 import scripts.settle_one_pr as settle_one_pr
@@ -62,6 +63,49 @@ def _packet(*entries: dict, admin_order: list[int] | None = None) -> dict:
             entry["pr_number"] for entry in entries if entry["requires_human_risk_settlement"]
         ],
     }
+
+
+def test_run_reports_timeout_and_terminates_process_group(monkeypatch) -> None:
+    killed: list[tuple[int, int]] = []
+
+    class SlowProc:
+        pid = 4242
+        returncode = None
+
+        def __init__(self) -> None:
+            self.communicate_calls = 0
+
+        def communicate(self, timeout: int | None = None) -> tuple[str, str]:
+            self.communicate_calls += 1
+            if self.communicate_calls == 1:
+                raise subprocess.TimeoutExpired(cmd=["slow"], timeout=timeout)
+            self.returncode = -9
+            return "", ""
+
+        def kill(self) -> None:
+            self.returncode = -9
+
+    proc = SlowProc()
+
+    def fake_popen(*args, **kwargs):
+        assert args[0] == ["slow"]
+        assert kwargs["start_new_session"] is True
+        return proc
+
+    monkeypatch.setattr(settle_one_pr.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(
+        settle_one_pr.os,
+        "killpg",
+        lambda pid, sig: killed.append((pid, sig)),
+    )
+
+    result = settle_one_pr._run(["slow"], cwd=Path.cwd(), timeout=7)
+
+    assert result["returncode"] == 124
+    assert result["timed_out"] is True
+    assert result["timeout_seconds"] == 7
+    assert "timed out after 7s" in result["stderr"]
+    assert killed == [(4242, settle_one_pr.signal.SIGKILL)]
 
 
 def test_select_candidate_prefers_admin_order() -> None:
@@ -500,6 +544,46 @@ def test_broad_packet_lazy_loader_falls_back_when_bulk_packet_fails(
     assert targeted[0][targeted[0].index("--pr") + 1] == "7449"
 
 
+def test_broad_packet_lazy_loader_falls_back_when_bulk_packet_times_out(
+    monkeypatch,
+) -> None:
+    def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
+        del cwd, timeout
+        if args[:5] == ["python3", "-m", "aragora.cli.main", "review-queue", "merge-packet"]:
+            if "--limit" in args:
+                return None, {
+                    "command": "bulk-packet",
+                    "returncode": 124,
+                    "stderr": "command timed out after 90s and was terminated",
+                    "timed_out": True,
+                }
+            pr_number = int(args[args.index("--pr") + 1])
+            return _packet(_entry(pr_number)), {"command": "packet", "returncode": 0}
+        if args[:3] == ["gh", "pr", "list"]:
+            return (
+                [
+                    {
+                        "number": 7449,
+                        "title": "fix(settlement): exclude unsafe PR surfaces",
+                        "headRefName": "codex/settle-one-policy-exclusions-20260523",
+                    },
+                ],
+                {"command": "metadata", "returncode": 0},
+            )
+        if args[:3] == ["python3", "scripts/agent_bridge.py", "operator-snapshot"]:
+            return {"lanes": []}, {"command": "snapshot", "returncode": 0}
+        raise AssertionError(args)
+
+    monkeypatch.setattr(settle_one_pr, "_run_json", fake_run_json)
+
+    packet = load_broad_packet_lazily(cwd=Path.cwd(), limit=100, repo=None)
+
+    assert [entry["pr_number"] for entry in packet["entries"]] == [7449]
+    assert packet["load_warnings"] == [
+        "bulk merge-packet failed; using fallback: command timed out after 90s and was terminated"
+    ]
+
+
 def test_broad_packet_lazy_loader_returns_empty_when_bulk_and_light_metadata_fail(
     monkeypatch,
 ) -> None:
@@ -555,6 +639,46 @@ def test_broad_packet_lazy_loader_surfaces_targeted_packet_failures(
     assert packet["entries"] == []
     assert packet["load_warnings"] == ["bulk merge-packet failed; using fallback: HTTP 504"]
     assert packet["load_blockers"] == ["merge-packet for #7449 failed: GraphQL timeout"]
+
+
+def test_broad_packet_lazy_loader_surfaces_targeted_packet_timeout(
+    monkeypatch,
+) -> None:
+    def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
+        del cwd, timeout
+        if args[:5] == ["python3", "-m", "aragora.cli.main", "review-queue", "merge-packet"]:
+            if "--limit" in args:
+                return None, {"command": "bulk-packet", "returncode": 1, "stderr": "HTTP 504"}
+            return None, {
+                "command": "packet",
+                "returncode": 124,
+                "stderr": "command timed out after 90s and was terminated",
+                "timed_out": True,
+            }
+        if args[:3] == ["gh", "pr", "list"]:
+            return (
+                [
+                    {
+                        "number": 7449,
+                        "title": "fix(settlement): exclude unsafe PR surfaces",
+                        "headRefName": "codex/settle-one-policy-exclusions-20260523",
+                    },
+                ],
+                {"command": "metadata", "returncode": 0},
+            )
+        if args[:3] == ["python3", "scripts/agent_bridge.py", "operator-snapshot"]:
+            return {"lanes": []}, {"command": "snapshot", "returncode": 0}
+        raise AssertionError(args)
+
+    monkeypatch.setattr(settle_one_pr, "_run_json", fake_run_json)
+
+    packet = load_broad_packet_lazily(cwd=Path.cwd(), limit=100, repo=None)
+
+    assert packet["entries"] == []
+    assert packet["load_warnings"] == ["bulk merge-packet failed; using fallback: HTTP 504"]
+    assert packet["load_blockers"] == [
+        "merge-packet for #7449 failed: command timed out after 90s and was terminated"
+    ]
 
 
 def test_broad_packet_lazy_loader_warns_on_large_fallback_fanout(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- adds bounded process-group timeouts to settle-one steward subprocess calls
- lowers broad and per-PR merge-packet waits so broad steward dogfood fails closed instead of hanging indefinitely
- adds focused tests for bulk packet timeout fallback and targeted packet timeout blockers

## Validation

- `ruff check scripts/settle_one_pr.py tests/scripts/test_settle_one_pr.py`
- `ruff format --check scripts/settle_one_pr.py tests/scripts/test_settle_one_pr.py`
- `git diff --check -- scripts/settle_one_pr.py tests/scripts/test_settle_one_pr.py`
- direct conda-Python focused timeout/fallback assertions
- `SETTLE_ONE_BROAD_PACKET_TIMEOUT_SECONDS=5 SETTLE_ONE_OPERATOR_SNAPSHOT_TIMEOUT_SECONDS=5 SETTLE_ONE_SINGLE_PACKET_TIMEOUT_SECONDS=5 SETTLE_ONE_GH_TIMEOUT_SECONDS=10 python3 scripts/settle_one_pr.py --json` returns fail-closed operator-snapshot blocker instead of hanging

## Notes

Standard `python3 -m pytest tests/scripts/test_settle_one_pr.py -k ... -q` timed out with no output in this local shell; the focused behavior was validated with repo-available conda Python assertions.