### PR TITLE
fix(agent-bridge): bound operator snapshot hangs

### DIFF
--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -43,9 +43,6 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from aragora.swarm.agent_bridge.exceptions import TransportError
-from aragora.swarm.agent_bridge.harnesses import create_transport
-
 try:
     # When run as `python3 scripts/agent_bridge.py`, Python adds scripts/ to
     # sys.path automatically, so this direct import works.  For package-style
@@ -93,6 +90,26 @@ DEFAULT_STALE_TTL_HOURS = 24
 HEARTBEAT_FRESH_SECONDS = 15 * 60
 DEFAULT_ACTIVE_NEXT_ACTION = "unspecified active lane action"
 DEFAULT_STEERING_OUTCOME = "unknown"
+DEFAULT_B0_SCORECARD_TIMEOUT_SECONDS = 5.0
+
+
+class _LazyTransportError(Exception):
+    """Placeholder so tests can monkeypatch create_transport without eager imports."""
+
+
+TransportError: type[Exception] = _LazyTransportError
+create_transport: Any | None = None
+
+
+def _load_transport_runtime() -> tuple[type[Exception], Any]:
+    global TransportError, create_transport
+    if create_transport is None:
+        from aragora.swarm.agent_bridge.exceptions import TransportError as bridge_error
+        from aragora.swarm.agent_bridge.harnesses import create_transport as bridge_transport
+
+        TransportError = bridge_error
+        create_transport = bridge_transport
+    return TransportError, create_transport
 
 
 def _state_root_bridge_dir() -> Path:
@@ -791,35 +808,52 @@ def _active_owner_payload(
 
 
 def _load_broker_run_summaries() -> list[dict[str, Any]]:
-    try:
-        from aragora.swarm.agent_bridge.store import BridgeStore
-    except ImportError:
+    runs_root = CANONICAL_REPO_ROOT / ".aragora" / "agent_bridge" / "runs"
+    if not runs_root.exists():
         return []
-
+    runs: list[dict[str, Any]] = []
     try:
-        store = BridgeStore(CANONICAL_REPO_ROOT)
-        runs = []
-        for run_path in store.runs_root().glob("*/run.json"):
-            run = store.load_run(run_path.parent.name)
+        for run_path in runs_root.glob("*/run.json"):
+            run_payload = json.loads(run_path.read_text(encoding="utf-8"))
+            if not isinstance(run_payload, dict):
+                continue
+            run_id = str(run_payload.get("run_id") or run_path.parent.name)
+            sessions: dict[str, dict[str, Any]] = {}
+            sessions_path = run_path.parent / "sessions.json"
             try:
-                registry = store.load_sessions(run.run_id)
-                sessions = {role: session.to_dict() for role, session in registry.sessions.items()}
-            except (OSError, TypeError, json.JSONDecodeError, KeyError):
+                sessions_payload = json.loads(sessions_path.read_text(encoding="utf-8"))
+                raw_sessions = (
+                    sessions_payload.get("sessions", {})
+                    if isinstance(sessions_payload, dict)
+                    else {}
+                )
+                if isinstance(raw_sessions, dict):
+                    sessions = {
+                        str(role): session
+                        for role, session in raw_sessions.items()
+                        if isinstance(session, dict)
+                    }
+            except (OSError, TypeError, json.JSONDecodeError):
                 sessions = {}
+            participants = run_payload.get("participants", [])
+            if not isinstance(participants, list):
+                participants = []
             runs.append(
                 {
-                    "run_id": run.run_id,
-                    "status": run.status,
-                    "updated_at": run.updated_at,
-                    "next_actor": run.next_actor,
-                    "last_turn_index": run.last_turn_index,
-                    "participants": [participant.to_dict() for participant in run.participants],
+                    "run_id": run_id,
+                    "status": run_payload.get("status"),
+                    "updated_at": run_payload.get("updated_at"),
+                    "next_actor": run_payload.get("next_actor"),
+                    "last_turn_index": run_payload.get("last_turn_index"),
+                    "participants": [
+                        participant for participant in participants if isinstance(participant, dict)
+                    ],
                     "sessions": sessions,
                 }
             )
         runs.sort(key=lambda item: str(item.get("updated_at", "")), reverse=True)
         return runs
-    except (OSError, TypeError, json.JSONDecodeError, KeyError, ValueError):
+    except (OSError, TypeError, json.JSONDecodeError, ValueError):
         return []
 
 
@@ -1453,14 +1487,33 @@ def cmd_exec(args: argparse.Namespace) -> int:
     allowed_roles = set(args.allowed_role or ["reviewer"])
 
     try:
-        transport = create_transport(
+        transport_error, transport_factory = _load_transport_runtime()
+    except (ImportError, OSError, RuntimeError, ValueError) as exc:
+        if args.json:
+            print(
+                json.dumps(
+                    {
+                        "ok": False,
+                        "agent": agent,
+                        "cwd": str(launch_cwd),
+                        "error": str(exc),
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            print(f"Exec failed: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        transport = transport_factory(
             agent,
             cwd=launch_cwd,
             model=str(args.model).strip() if args.model else None,
             harness_options=harness_options,
         )
         result = transport.launch(prompt, allowed_roles=allowed_roles)
-    except (TransportError, OSError, ValueError) as exc:
+    except (transport_error, OSError, ValueError) as exc:
         if args.json:
             print(
                 json.dumps(
@@ -2116,6 +2169,17 @@ def _coerce_success_rate(raw_rate: Any) -> float | None:
         return None
 
 
+def _b0_scorecard_timeout_seconds() -> float:
+    raw = os.environ.get("AGENT_BRIDGE_B0_SCORECARD_TIMEOUT_SECONDS", "").strip()
+    if not raw:
+        return DEFAULT_B0_SCORECARD_TIMEOUT_SECONDS
+    try:
+        timeout = float(raw)
+    except ValueError:
+        return DEFAULT_B0_SCORECARD_TIMEOUT_SECONDS
+    return max(0.1, timeout)
+
+
 def _collect_b0_success_rate(repo_root: Path | None = None) -> float | None:
     root = repo_root or CANONICAL_REPO_ROOT
     scorecard_script = root / "scripts" / "measure_b0_scorecard.py"
@@ -2134,7 +2198,7 @@ def _collect_b0_success_rate(repo_root: Path | None = None) -> float | None:
             cwd=root,
             capture_output=True,
             text=True,
-            timeout=60,
+            timeout=_b0_scorecard_timeout_seconds(),
             check=False,
         )
     except (OSError, subprocess.TimeoutExpired):

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -540,6 +540,29 @@ def test_operator_snapshot_exposes_b0_issue_contract_fields(
     ]
 
 
+def test_collect_b0_success_rate_times_out_fail_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import agent_bridge as mod
+
+    repo_root = tmp_path / "repo"
+    (repo_root / "scripts").mkdir(parents=True)
+    (repo_root / "docs" / "benchmarks").mkdir(parents=True)
+    (repo_root / "scripts" / "measure_b0_scorecard.py").write_text("# fixture\n")
+    (repo_root / "docs" / "benchmarks" / "corpus.json").write_text("{}\n")
+    monkeypatch.setenv("AGENT_BRIDGE_B0_SCORECARD_TIMEOUT_SECONDS", "0.25")
+
+    def fake_run(args: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
+        assert "measure_b0_scorecard.py" in args[1]
+        assert kwargs["timeout"] == 0.25
+        raise subprocess.TimeoutExpired(args, kwargs["timeout"])
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    assert mod._collect_b0_success_rate(repo_root) is None
+
+
 def test_operator_snapshot_summary_counts_repo_local_lane_when_user_registry_exists(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1451,6 +1474,61 @@ def test_operator_snapshot_includes_broker_runs(
     payload = json.loads(capsys.readouterr().out)
     assert payload["summary"]["active_broker_runs"] == 1
     assert payload["broker_runs"][0]["run_id"] == "bridge-next-work"
+
+
+def test_load_broker_run_summaries_reads_json_without_package_import(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import agent_bridge as mod
+
+    repo_root = tmp_path / "repo"
+    run_dir = repo_root / ".aragora" / "agent_bridge" / "runs" / "bridge-next-work"
+    run_dir.mkdir(parents=True)
+    (run_dir / "run.json").write_text(
+        json.dumps(
+            {
+                "run_id": "bridge-next-work",
+                "status": "running",
+                "updated_at": "2026-05-31T12:00:00Z",
+                "next_actor": "critic",
+                "last_turn_index": 2,
+                "participants": [{"role": "critic", "harness": "codex"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (run_dir / "sessions.json").write_text(
+        json.dumps(
+            {
+                "sessions": {
+                    "critic": {
+                        "role": "critic",
+                        "session_id": "session-critic",
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mod, "CANONICAL_REPO_ROOT", repo_root)
+
+    assert mod._load_broker_run_summaries() == [
+        {
+            "run_id": "bridge-next-work",
+            "status": "running",
+            "updated_at": "2026-05-31T12:00:00Z",
+            "next_actor": "critic",
+            "last_turn_index": 2,
+            "participants": [{"role": "critic", "harness": "codex"}],
+            "sessions": {
+                "critic": {
+                    "role": "critic",
+                    "session_id": "session-critic",
+                }
+            },
+        }
+    ]
 
 
 def test_cmd_launch_invokes_tmux_launcher_for_droid(


### PR DESCRIPTION
## Summary
- avoid eager bridge transport imports before argparse help or non-exec commands need them
- load broker run summaries by reading JSON files directly instead of importing the broad swarm package
- bound the optional B0 scorecard subprocess used by operator-snapshot and fail closed with `success_rate: null`

## Validation
- `timeout 10s python3 scripts/agent_bridge.py operator-snapshot --help`
- `timeout 20s env AGENT_BRIDGE_B0_SCORECARD_TIMEOUT_SECONDS=1 python3 scripts/agent_bridge.py operator-snapshot --json --summary-only`
- `timeout 20s python3 scripts/agent_bridge.py operator-snapshot --json`
- direct focused assertions for B0 timeout, broker run JSON parsing, and summary-only no-write behavior
- `python3 -m ruff check scripts/agent_bridge.py tests/scripts/test_agent_bridge.py`
- `python3 -m ruff format --check scripts/agent_bridge.py tests/scripts/test_agent_bridge.py`
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Note
`python3 -m pytest ...` currently hangs in this environment before selected tests emit output, so the focused assertions above were used to verify the changed paths.
