### PR TITLE
fix(queue): route dirty-root prompts through clean checkouts

### DIFF
--- a/scripts/build_next_prompt.py
+++ b/scripts/build_next_prompt.py
@@ -404,6 +404,13 @@ def _clean_checkout_packet(
     }
 
 
+def _clean_checkout_uses_disposable_prompt(clean_checkout: dict[str, Any]) -> bool:
+    return clean_checkout.get("status") in {
+        "needs_disposable_worktree",
+        "error",
+    } and bool(clean_checkout.get("recommended_prompt"))
+
+
 def _state_dir(state_root: Path) -> Path:
     expanded = state_root.expanduser()
     return expanded if expanded.name == ".aragora" else expanded / ".aragora"
@@ -729,7 +736,7 @@ def build_decision_packet(
         else "queue_prompt_from_clean_checkout"
         if root["dirty"] and clean_checkout.get("status") == "selected"
         else "create_clean_checkout_prompt"
-        if root["dirty"] and clean_checkout.get("status") == "needs_disposable_worktree"
+        if root["dirty"] and _clean_checkout_uses_disposable_prompt(clean_checkout)
         else "repair_or_stop"
         if root["dirty"]
         else "queue_prompt",
@@ -846,11 +853,16 @@ def build_prompt(
                 clean_checkout.get("recommended_prompt") or "",
             ]
         )
-    elif clean_checkout.get("status") == "needs_disposable_worktree":
+    elif _clean_checkout_uses_disposable_prompt(clean_checkout):
+        routing_reason = (
+            "the registered clean-checkout scan failed"
+            if clean_checkout.get("status") == "error"
+            else "no registered clean origin/main checkout is available"
+        )
         lines.extend(
             [
                 "",
-                "Clean-checkout routing: no registered clean origin/main checkout is available.",
+                f"Clean-checkout routing: {routing_reason}.",
                 "Use this bounded prompt before running repo-native queue helpers:",
                 clean_checkout.get("recommended_prompt") or "",
             ]

--- a/scripts/build_next_prompt.py
+++ b/scripts/build_next_prompt.py
@@ -309,6 +309,35 @@ def _clean_checkout_prompt(
     )
 
 
+def _selected_clean_checkout_prompt(
+    selected_path: str,
+    *,
+    pr: int | None,
+    expected_head: str | None,
+) -> str:
+    pr_fragment = f"PR #{pr}" if pr is not None else "the live queue"
+    head_guard = (
+        f"Stop if {pr_fragment} head drifted from {expected_head}."
+        if expected_head and pr is not None
+        else "Stop if the target head drifts from the operator-specified exact head."
+    )
+    return "\n".join(
+        [
+            "Before using the selected clean checkout, refresh remote truth and revalidate it:",
+            f"git -C {selected_path} fetch origin main",
+            f"git -C {selected_path} status --short --branch --untracked-files=all",
+            f"git -C {selected_path} rev-parse HEAD origin/main",
+            "",
+            (
+                "Use the selected checkout for repo-native helpers only if it remains clean "
+                "and HEAD equals the refreshed origin/main after fetch."
+            ),
+            "If it is dirty or stale after fetch, do not use it; create a disposable detached triage worktree from origin/main instead.",
+            head_guard,
+        ]
+    )
+
+
 def _clean_checkout_packet(
     repo_root: Path,
     command_runner: CommandRunner,
@@ -360,7 +389,11 @@ def _clean_checkout_packet(
             "status": "selected",
             "selected_path": selected_path,
             "candidates": candidates,
-            "recommended_prompt": None,
+            "recommended_prompt": _selected_clean_checkout_prompt(
+                selected_path,
+                pr=pr,
+                expected_head=expected_head,
+            ),
         }
 
     return {
@@ -810,8 +843,7 @@ def build_prompt(
                 "",
                 "Clean-checkout routing: root is not suitable for repo-native helpers, but a registered clean origin/main checkout is available.",
                 f"Run repo-native helpers only from this checkout: {selected_path}",
-                f"git -C {selected_path} status --short --branch --untracked-files=all",
-                f"git -C {selected_path} rev-parse HEAD origin/main",
+                clean_checkout.get("recommended_prompt") or "",
             ]
         )
     elif clean_checkout.get("status") == "needs_disposable_worktree":

--- a/scripts/build_next_prompt.py
+++ b/scripts/build_next_prompt.py
@@ -156,6 +156,221 @@ def _root_packet(command_runner: CommandRunner) -> dict[str, Any]:
     return {"dirty": dirty, "status": lines, "returncode": status["returncode"]}
 
 
+def _worktree_entries(repo_root: Path, command_runner: CommandRunner) -> list[dict[str, Any]]:
+    """Return registered git worktrees from ``git worktree list --porcelain``."""
+
+    result = _run_text(["git", "worktree", "list", "--porcelain"], command_runner)
+    if result["returncode"] != 0:
+        raise RuntimeError(result["stderr"].strip() or "git worktree list failed")
+
+    entries: list[dict[str, Any]] = []
+    current: dict[str, Any] = {}
+    for line in result["stdout"].splitlines():
+        if not line:
+            if current:
+                entries.append(current)
+                current = {}
+            continue
+        key, _, value = line.partition(" ")
+        if key == "worktree":
+            if current:
+                entries.append(current)
+            current = {"path": value}
+        elif key == "HEAD":
+            current["listed_head"] = value
+        elif key == "branch":
+            current["branch"] = value
+        elif key == "detached":
+            current["detached"] = True
+        elif key == "bare":
+            current["bare"] = True
+    if current:
+        entries.append(current)
+
+    if not entries:
+        return [{"path": str(repo_root)}]
+    return entries
+
+
+def _worktree_clean_origin_main_status(
+    path: Path,
+    command_runner: CommandRunner,
+) -> dict[str, Any]:
+    """Classify whether ``path`` is clean and exactly at local ``origin/main``."""
+
+    summary: dict[str, Any] = {
+        "path": str(path),
+        "status": "missing",
+        "head": None,
+        "origin_main": None,
+        "status_lines": [],
+        "dirty_paths": [],
+    }
+    if not path.exists():
+        return summary
+
+    status = _run_text(
+        ["git", "-C", str(path), "status", "--short", "--branch", "--untracked-files=all"],
+        command_runner,
+    )
+    if status["returncode"] != 0:
+        summary.update(
+            {
+                "status": "git_error",
+                "error": status["stderr"].strip() or "git status failed",
+                "returncode": status["returncode"],
+            }
+        )
+        return summary
+
+    lines = [line for line in status["stdout"].splitlines() if line.strip()]
+    dirty_paths = [line[3:].strip() for line in lines if not line.startswith("##")]
+    summary["status_lines"] = lines
+    summary["dirty_paths"] = dirty_paths
+
+    revs = _run_text(["git", "-C", str(path), "rev-parse", "HEAD", "origin/main"], command_runner)
+    rev_lines = [line.strip() for line in revs["stdout"].splitlines() if line.strip()]
+    if revs["returncode"] == 0 and len(rev_lines) >= 2:
+        summary["head"] = rev_lines[0]
+        summary["origin_main"] = rev_lines[1]
+
+    if dirty_paths:
+        summary["status"] = "dirty"
+        return summary
+
+    if revs["returncode"] != 0 or len(rev_lines) < 2:
+        summary.update(
+            {
+                "status": "git_error",
+                "error": revs["stderr"].strip() or "git rev-parse HEAD origin/main failed",
+                "returncode": revs["returncode"],
+            }
+        )
+        return summary
+
+    summary["status"] = (
+        "usable_clean_origin_main"
+        if summary["head"] == summary["origin_main"]
+        else "stale_vs_origin_main"
+    )
+    return summary
+
+
+def _same_path(left: Path, right: Path) -> bool:
+    try:
+        return left.resolve() == right.resolve()
+    except OSError:
+        return left == right
+
+
+def _clean_checkout_prompt(
+    pr: int | None,
+    expected_head: str | None,
+    repo_root: Path,
+) -> str:
+    pr_fragment = f"PR #{pr}" if pr is not None else "the live queue"
+    worktree_name = f"aragora-pr{pr}-triage" if pr is not None else "aragora-queue-triage"
+    worktree_path = f"/private/tmp/{worktree_name}"
+    mailbox = (
+        f"python3 scripts/read_operator_steering.py --pr {pr} --no-receipt --json || true"
+        if pr is not None
+        else "python3 scripts/agent_bridge.py operator-snapshot --json --summary-only || true"
+    )
+    head_guard = (
+        f"Stop if {pr_fragment} head drifted from {expected_head}."
+        if expected_head and pr is not None
+        else "Stop if the target head drifts from the operator-specified exact head."
+    )
+    return "\n".join(
+        [
+            f"Start from live repo truth in {repo_root}. Do not trust prior transcript state.",
+            "Do not use or mutate dirty root source files. Do not merge/admin-merge without separate explicit operator authorization.",
+            "",
+            f"Goal: continue {pr_fragment} from a trusted clean current origin/main checkout.",
+            "",
+            "First create a disposable detached triage worktree because no registered clean origin/main checkout is available:",
+            "git fetch origin main",
+            f"git worktree add --detach {worktree_path} origin/main",
+            "",
+            f"Run all repo-native helpers from {worktree_path} only.",
+            "",
+            "Before lane work, check operator-steering mailbox:",
+            mailbox,
+            "",
+            "Re-check clean checkout truth:",
+            f"git -C {worktree_path} status --short --branch --untracked-files=all",
+            f"git -C {worktree_path} rev-parse HEAD origin/main",
+            "",
+            head_guard,
+            "If the clean checkout is not exactly at origin/main or becomes dirty, stop and report the blocker.",
+            "If live gates are stable, continue only within the original bounded queue prompt. Do not mutate unrelated PRs.",
+            CONVERGENCE_SENTENCE,
+        ]
+    )
+
+
+def _clean_checkout_packet(
+    repo_root: Path,
+    command_runner: CommandRunner,
+    *,
+    pr: int | None = None,
+    expected_head: str | None = None,
+) -> dict[str, Any]:
+    root_summary = _worktree_clean_origin_main_status(repo_root, command_runner)
+    candidates: list[dict[str, Any]] = [{**root_summary, "role": "root"}]
+    if root_summary["status"] == "usable_clean_origin_main":
+        return {
+            "status": "root_usable",
+            "selected_path": str(repo_root),
+            "candidates": candidates,
+            "recommended_prompt": None,
+        }
+
+    try:
+        entries = _worktree_entries(repo_root, command_runner)
+    except RuntimeError as exc:
+        return {
+            "status": "error",
+            "selected_path": None,
+            "candidates": candidates,
+            "recommended_prompt": _clean_checkout_prompt(pr, expected_head, repo_root),
+            "error": str(exc),
+        }
+
+    selected_path: str | None = None
+    for entry in entries:
+        entry_path = Path(str(entry.get("path") or ""))
+        if not entry_path or _same_path(entry_path, repo_root):
+            continue
+        summary = _worktree_clean_origin_main_status(entry_path, command_runner)
+        summary.update(
+            {
+                "role": "worktree",
+                "branch": entry.get("branch"),
+                "detached": bool(entry.get("detached")),
+                "listed_head": entry.get("listed_head"),
+            }
+        )
+        candidates.append(summary)
+        if selected_path is None and summary["status"] == "usable_clean_origin_main":
+            selected_path = str(entry_path)
+
+    if selected_path is not None:
+        return {
+            "status": "selected",
+            "selected_path": selected_path,
+            "candidates": candidates,
+            "recommended_prompt": None,
+        }
+
+    return {
+        "status": "needs_disposable_worktree",
+        "selected_path": None,
+        "candidates": candidates,
+        "recommended_prompt": _clean_checkout_prompt(pr, expected_head, repo_root),
+    }
+
+
 def _state_dir(state_root: Path) -> Path:
     expanded = state_root.expanduser()
     return expanded if expanded.name == ".aragora" else expanded / ".aragora"
@@ -434,6 +649,12 @@ def build_decision_packet(
     )
     blockers: list[str] = []
     root = _root_packet(runner)
+    clean_checkout = _clean_checkout_packet(
+        repo_root,
+        runner,
+        pr=pr,
+        expected_head=expected_head,
+    )
     if root["dirty"]:
         blockers.append("dirty root")
     if lane and str(lane.get("status") or "") in ACTIVE_STATUSES:
@@ -445,6 +666,7 @@ def build_decision_packet(
         "owner": _sanitize(lane) if lane else None,
         "target_active_lanes": target_active_lanes,
         "root": root,
+        "clean_checkout": clean_checkout,
         "owner_map": _active_owner_map(lanes),
         "bridge_health": _run_json(
             ["python3", "scripts/agent_bridge.py", "--json", "health"],
@@ -471,6 +693,10 @@ def build_decision_packet(
         "blockers": blockers,
         "selected_action": "read_only_owner_routing"
         if "active owner exists for target" in blockers
+        else "queue_prompt_from_clean_checkout"
+        if root["dirty"] and clean_checkout.get("status") == "selected"
+        else "create_clean_checkout_prompt"
+        if root["dirty"] and clean_checkout.get("status") == "needs_disposable_worktree"
         else "repair_or_stop"
         if root["dirty"]
         else "queue_prompt",
@@ -541,10 +767,19 @@ def build_prompt(
     lane_id: str | None = None,
     pr: int | None = None,
     branch: str | None = None,
+    expected_head: str | None = None,
+    command_runner: CommandRunner | None = None,
 ) -> str:
     lanes = _read_lanes(registry_path)
     lane = _find_lane(lanes, lane_id=lane_id, pr=pr, branch=branch)
     mailbox = _mailbox_command(lane, pr=pr, branch=branch)
+    runner = command_runner or _repo_runner(repo_root)
+    clean_checkout = _clean_checkout_packet(
+        repo_root,
+        runner,
+        pr=pr,
+        expected_head=expected_head,
+    )
     target = (
         f"lane {lane_id}"
         if lane_id
@@ -568,6 +803,26 @@ def build_prompt(
         "python3 scripts/agent_bridge.py operator-snapshot --json --summary-only || true",
         "python3 scripts/list_active_agent_sessions.py --json --codex-session-scan-limit 120",
     ]
+    if clean_checkout.get("status") == "selected":
+        selected_path = clean_checkout.get("selected_path")
+        lines.extend(
+            [
+                "",
+                "Clean-checkout routing: root is not suitable for repo-native helpers, but a registered clean origin/main checkout is available.",
+                f"Run repo-native helpers only from this checkout: {selected_path}",
+                f"git -C {selected_path} status --short --branch --untracked-files=all",
+                f"git -C {selected_path} rev-parse HEAD origin/main",
+            ]
+        )
+    elif clean_checkout.get("status") == "needs_disposable_worktree":
+        lines.extend(
+            [
+                "",
+                "Clean-checkout routing: no registered clean origin/main checkout is available.",
+                "Use this bounded prompt before running repo-native queue helpers:",
+                clean_checkout.get("recommended_prompt") or "",
+            ]
+        )
     if pr is not None:
         lines.extend(
             [
@@ -705,6 +960,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         lane_id=args.lane_id,
         pr=args.pr,
         branch=args.branch,
+        expected_head=args.expected_head,
     )
     packet: dict[str, Any] | None = None
     guard_prompt: str | None = None

--- a/scripts/root_guarded_queue.py
+++ b/scripts/root_guarded_queue.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shlex
 import subprocess
 import sys
 from dataclasses import asdict, dataclass
@@ -169,6 +170,16 @@ def _read_only_sequence(pr: int | None) -> str:
     )
 
 
+def _clean_checkout_routing_command(pr: int | None, expected_head: str | None) -> str:
+    command = ["python3", "scripts/build_next_prompt.py"]
+    if pr is not None:
+        command.extend(["--pr", str(pr)])
+    if expected_head:
+        command.extend(["--expected-head", expected_head])
+    command.append("--json")
+    return " ".join(shlex.quote(part) for part in command)
+
+
 def _next_prompt(
     *,
     status: str,
@@ -179,11 +190,14 @@ def _next_prompt(
 ) -> str:
     head_text = f" at exact head `{expected_head}`" if expected_head else ""
     if status == "blocked_dirty_root":
+        routing_command = _clean_checkout_routing_command(pr, expected_head)
         body = (
             f"Goal: resolve root hygiene for `{before.branch}`, then continue only after root is "
             f"clean or by using a clean isolated worktree. Dirty paths: "
             f"{', '.join(before.dirty_paths) or 'unknown'}. Do not reset, clean, stash, switch, "
-            "or commit without explicit preserve/revert/switch authorization."
+            "or commit without explicit preserve/revert/switch authorization. For clean-checkout "
+            f"queue routing, run `{routing_command}` and follow its clean_checkout.selected_path "
+            "or clean_checkout.recommended_prompt."
         )
     elif status == "blocked_root_drift":
         body = (

--- a/tests/scripts/test_build_next_prompt.py
+++ b/tests/scripts/test_build_next_prompt.py
@@ -318,6 +318,8 @@ def test_clean_checkout_packet_selects_clean_detached_origin_main_worktree(
     assert packet["selected_path"] == str(worktree)
     assert packet["candidates"][1]["status"] == "usable_clean_origin_main"
     assert packet["candidates"][1]["detached"] is True
+    assert f"git -C {worktree} fetch origin main" in packet["recommended_prompt"]
+    assert "HEAD equals the refreshed origin/main after fetch" in packet["recommended_prompt"]
 
 
 def test_clean_checkout_packet_rejects_stale_clean_worktree(tmp_path: Path) -> None:
@@ -408,7 +410,9 @@ def test_prompt_includes_selected_clean_checkout_path(tmp_path: Path) -> None:
 
     assert "Clean-checkout routing: root is not suitable" in prompt
     assert f"Run repo-native helpers only from this checkout: {worktree}" in prompt
+    assert f"git -C {worktree} fetch origin main" in prompt
     assert f"git -C {worktree} rev-parse HEAD origin/main" in prompt
+    assert "If it is dirty or stale after fetch, do not use it" in prompt
 
 
 def _settlement_runner(

--- a/tests/scripts/test_build_next_prompt.py
+++ b/tests/scripts/test_build_next_prompt.py
@@ -33,6 +33,7 @@ def _clean_checkout_runner(
     worktree_dirty: bool = False,
     worktree_head: str = "clean-head",
     origin_main: str = "clean-head",
+    worktree_list_error: bool = False,
 ) -> Any:
     def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
         if command == ["git", "status", "--short", "--branch", "--untracked-files=all"]:
@@ -41,6 +42,8 @@ def _clean_checkout_runner(
                 status += " M dirty.py\n"
             return subprocess.CompletedProcess(command, 0, status, "")
         if command == ["git", "worktree", "list", "--porcelain"]:
+            if worktree_list_error:
+                return subprocess.CompletedProcess(command, 1, "", "worktree metadata locked")
             text = f"worktree {repo_root}\nHEAD root-head\nbranch refs/heads/main\n"
             if worktree is not None:
                 text += f"\nworktree {worktree}\nHEAD {worktree_head}\ndetached\n"
@@ -391,6 +394,44 @@ def test_prompt_emits_disposable_worktree_prompt_when_no_clean_checkout(
     assert "git worktree add --detach /private/tmp/aragora-pr7561-triage origin/main" in prompt
     assert "python3 scripts/read_operator_steering.py --pr 7561 --no-receipt --json" in prompt
     assert "Stop if PR #7561 head drifted from expected-head" in prompt
+
+
+def test_prompt_emits_disposable_worktree_prompt_when_worktree_scan_fails(
+    tmp_path: Path,
+) -> None:
+    registry = tmp_path / "lanes.json"
+    registry.write_text("[]\n", encoding="utf-8")
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+
+    runner = _clean_checkout_runner(repo_root=repo_root, worktree_list_error=True)
+    packet = prompt_builder._clean_checkout_packet(
+        repo_root,
+        runner,
+        pr=7561,
+        expected_head="expected-head",
+    )
+    prompt = prompt_builder.build_prompt(
+        registry_path=registry,
+        repo_root=repo_root,
+        pr=7561,
+        expected_head="expected-head",
+        command_runner=runner,
+    )
+    decision = prompt_builder.build_decision_packet(
+        registry_path=registry,
+        repo_root=repo_root,
+        pr=7561,
+        expected_head="expected-head",
+        command_runner=runner,
+    )
+
+    assert packet["status"] == "error"
+    assert packet["error"] == "worktree metadata locked"
+    assert "Clean-checkout routing: the registered clean-checkout scan failed" in prompt
+    assert "git worktree add --detach /private/tmp/aragora-pr7561-triage origin/main" in prompt
+    assert "Stop if PR #7561 head drifted from expected-head" in prompt
+    assert decision["selected_action"] == "create_clean_checkout_prompt"
 
 
 def test_prompt_includes_selected_clean_checkout_path(tmp_path: Path) -> None:

--- a/tests/scripts/test_build_next_prompt.py
+++ b/tests/scripts/test_build_next_prompt.py
@@ -25,6 +25,54 @@ def _load_module(script_name: str) -> Any:
 prompt_builder = _load_module("build_next_prompt.py")
 
 
+def _clean_checkout_runner(
+    *,
+    repo_root: Path,
+    worktree: Path | None = None,
+    root_dirty: bool = True,
+    worktree_dirty: bool = False,
+    worktree_head: str = "clean-head",
+    origin_main: str = "clean-head",
+) -> Any:
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        if command == ["git", "status", "--short", "--branch", "--untracked-files=all"]:
+            status = "## feature...origin/main\n"
+            if root_dirty:
+                status += " M dirty.py\n"
+            return subprocess.CompletedProcess(command, 0, status, "")
+        if command == ["git", "worktree", "list", "--porcelain"]:
+            text = f"worktree {repo_root}\nHEAD root-head\nbranch refs/heads/main\n"
+            if worktree is not None:
+                text += f"\nworktree {worktree}\nHEAD {worktree_head}\ndetached\n"
+            return subprocess.CompletedProcess(command, 0, text, "")
+        if command[:3] == ["git", "-C", str(repo_root)]:
+            if command[3:6] == ["status", "--short", "--branch"]:
+                status = "## feature...origin/main\n"
+                if root_dirty:
+                    status += " M dirty.py\n"
+                return subprocess.CompletedProcess(command, 0, status, "")
+            if command[3:] == ["rev-parse", "HEAD", "origin/main"]:
+                return subprocess.CompletedProcess(command, 0, f"root-head\n{origin_main}\n", "")
+        if worktree is not None and command[:3] == ["git", "-C", str(worktree)]:
+            if command[3:6] == ["status", "--short", "--branch"]:
+                status = "## HEAD (no branch)\n"
+                if worktree_dirty:
+                    status += " M generated.py\n"
+                return subprocess.CompletedProcess(command, 0, status, "")
+            if command[3:] == ["rev-parse", "HEAD", "origin/main"]:
+                return subprocess.CompletedProcess(
+                    command,
+                    0,
+                    f"{worktree_head}\n{origin_main}\n",
+                    "",
+                )
+        if command[:2] == ["df", "-h"]:
+            return subprocess.CompletedProcess(command, 0, "Filesystem Size Used Avail\n", "")
+        return subprocess.CompletedProcess(command, 0, "{}", "")
+
+    return fake_runner
+
+
 def test_prompt_starts_with_mailbox_and_owner_verification(tmp_path: Path) -> None:
     registry = tmp_path / "lanes.json"
     registry.write_text(
@@ -249,6 +297,118 @@ def test_decision_packet_counts_shared_outbox_when_local_outbox_absent(
     assert packet["disk_outbox"]["outbox_file_count"] == 2
     assert packet["disk_outbox"]["outbox_dir"] == str(outbox)
     assert packet["disk_outbox"]["outbox_returncode"] == 0
+
+
+def test_clean_checkout_packet_selects_clean_detached_origin_main_worktree(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    worktree = tmp_path / "clean-wt"
+    repo_root.mkdir()
+    worktree.mkdir()
+
+    packet = prompt_builder._clean_checkout_packet(
+        repo_root,
+        _clean_checkout_runner(repo_root=repo_root, worktree=worktree),
+        pr=7561,
+        expected_head="expected-head",
+    )
+
+    assert packet["status"] == "selected"
+    assert packet["selected_path"] == str(worktree)
+    assert packet["candidates"][1]["status"] == "usable_clean_origin_main"
+    assert packet["candidates"][1]["detached"] is True
+
+
+def test_clean_checkout_packet_rejects_stale_clean_worktree(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    worktree = tmp_path / "stale-wt"
+    repo_root.mkdir()
+    worktree.mkdir()
+
+    packet = prompt_builder._clean_checkout_packet(
+        repo_root,
+        _clean_checkout_runner(
+            repo_root=repo_root,
+            worktree=worktree,
+            worktree_head="old-head",
+            origin_main="new-head",
+        ),
+        pr=7561,
+        expected_head="expected-head",
+    )
+
+    assert packet["status"] == "needs_disposable_worktree"
+    assert packet["selected_path"] is None
+    assert packet["candidates"][1]["status"] == "stale_vs_origin_main"
+    assert (
+        "git worktree add --detach /private/tmp/aragora-pr7561-triage origin/main"
+        in packet["recommended_prompt"]
+    )
+
+
+def test_clean_checkout_packet_rejects_dirty_worktree_even_when_head_matches(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    worktree = tmp_path / "dirty-wt"
+    repo_root.mkdir()
+    worktree.mkdir()
+
+    packet = prompt_builder._clean_checkout_packet(
+        repo_root,
+        _clean_checkout_runner(repo_root=repo_root, worktree=worktree, worktree_dirty=True),
+        pr=7561,
+        expected_head="expected-head",
+    )
+
+    assert packet["status"] == "needs_disposable_worktree"
+    assert packet["selected_path"] is None
+    assert packet["candidates"][1]["status"] == "dirty"
+    assert "generated.py" in packet["candidates"][1]["dirty_paths"]
+
+
+def test_prompt_emits_disposable_worktree_prompt_when_no_clean_checkout(
+    tmp_path: Path,
+) -> None:
+    registry = tmp_path / "lanes.json"
+    registry.write_text("[]\n", encoding="utf-8")
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+
+    prompt = prompt_builder.build_prompt(
+        registry_path=registry,
+        repo_root=repo_root,
+        pr=7561,
+        expected_head="expected-head",
+        command_runner=_clean_checkout_runner(repo_root=repo_root, worktree=None),
+    )
+
+    assert "Clean-checkout routing: no registered clean origin/main checkout is available" in prompt
+    assert "git fetch origin main" in prompt
+    assert "git worktree add --detach /private/tmp/aragora-pr7561-triage origin/main" in prompt
+    assert "python3 scripts/read_operator_steering.py --pr 7561 --no-receipt --json" in prompt
+    assert "Stop if PR #7561 head drifted from expected-head" in prompt
+
+
+def test_prompt_includes_selected_clean_checkout_path(tmp_path: Path) -> None:
+    registry = tmp_path / "lanes.json"
+    registry.write_text("[]\n", encoding="utf-8")
+    repo_root = tmp_path / "repo"
+    worktree = tmp_path / "clean-wt"
+    repo_root.mkdir()
+    worktree.mkdir()
+
+    prompt = prompt_builder.build_prompt(
+        registry_path=registry,
+        repo_root=repo_root,
+        pr=7561,
+        command_runner=_clean_checkout_runner(repo_root=repo_root, worktree=worktree),
+    )
+
+    assert "Clean-checkout routing: root is not suitable" in prompt
+    assert f"Run repo-native helpers only from this checkout: {worktree}" in prompt
+    assert f"git -C {worktree} rev-parse HEAD origin/main" in prompt
 
 
 def _settlement_runner(

--- a/tests/scripts/test_root_guarded_queue.py
+++ b/tests/scripts/test_root_guarded_queue.py
@@ -64,6 +64,8 @@ def test_dirty_root_blocks_command_without_running(tmp_path: Path) -> None:
     assert "dirty.txt" in report["before"]["dirty_paths"]
     assert not sentinel.exists()
     assert "preserve/revert/switch authorization" in report["next_prompt"]
+    assert "python3 scripts/build_next_prompt.py --pr 7466 --json" in report["next_prompt"]
+    assert "clean_checkout.selected_path" in report["next_prompt"]
 
 
 def test_detects_branch_drift_after_command(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add non-mutating clean origin/main worktree detection to build_next_prompt
- include clean_checkout JSON routing and disposable-worktree prompt fallback
- route root_guarded_queue dirty-root next prompts through build_next_prompt clean-checkout selection

## Tests
- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/scripts/test_build_next_prompt.py tests/scripts/test_root_guarded_queue.py -q -p no:cacheprovider
- python3 -m ruff check scripts/build_next_prompt.py scripts/root_guarded_queue.py tests/scripts/test_build_next_prompt.py tests/scripts/test_root_guarded_queue.py
- python3 -m ruff format --check scripts/build_next_prompt.py scripts/root_guarded_queue.py tests/scripts/test_build_next_prompt.py tests/scripts/test_root_guarded_queue.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD