### PR TITLE
fix(cli/skills): honor ARAGORA_API_URL/TOKEN, correct port, fix install hint

### DIFF
--- a/aragora/cli/commands/skills.py
+++ b/aragora/cli/commands/skills.py
@@ -17,27 +17,34 @@ import argparse
 import asyncio
 import json
 import logging
+import os
 from typing import Any
 
 import httpx
 
-from aragora.config.settings import get_settings
-
 logger = logging.getLogger(__name__)
+
+# Default API URL, consistent with nomic.py/verticals.py/debate.py/consensus.py.
+DEFAULT_API_URL = os.environ.get("ARAGORA_API_URL", "http://localhost:8080")
 
 
 def _get_api_base() -> str:
-    """Get the API base URL from settings."""
-    settings = get_settings()
-    host = getattr(settings, "server_host", "localhost")
-    port = getattr(settings, "server_port", 8000)
-    return f"http://{host}:{port}"
+    """Get the API base URL.
+
+    Honors ``ARAGORA_API_URL`` and defaults to the documented server port
+    (8080), matching the other CLI clients (nomic, verticals, debate,
+    consensus).
+    """
+    return os.environ.get("ARAGORA_API_URL", "http://localhost:8080")
 
 
 def _get_auth_headers() -> dict[str, str]:
-    """Get authentication headers if available."""
-    settings = get_settings()
-    token = getattr(settings, "api_token", None)
+    """Get authentication headers if available.
+
+    Reads ``ARAGORA_API_TOKEN`` (falling back to ``ARAGORA_API_KEY``),
+    consistent with the other CLI clients.
+    """
+    token = os.environ.get("ARAGORA_API_TOKEN") or os.environ.get("ARAGORA_API_KEY")
     if token:
         return {"Authorization": f"Bearer {token}"}
     return {}
@@ -181,7 +188,7 @@ async def _cmd_list(args: argparse.Namespace) -> None:
 
         if not skills:
             print("  No skills installed.")
-            print("\n  Install skills with: aragora marketplace install <skill_id>")
+            print("\n  Install skills with: aragora skills install <skill_id>")
             return
 
         for skill in skills:
@@ -211,7 +218,7 @@ async def _cmd_install(args: argparse.Namespace) -> None:
 
     if not skill_id:
         print("\nError: skill_id is required")
-        print("Usage: aragora marketplace install <skill_id>")
+        print("Usage: aragora skills install <skill_id>")
         return
 
     data: dict[str, Any] = {}
@@ -252,7 +259,7 @@ async def _cmd_uninstall(args: argparse.Namespace) -> None:
 
     if not skill_id:
         print("\nError: skill_id is required")
-        print("Usage: aragora marketplace uninstall <skill_id>")
+        print("Usage: aragora skills uninstall <skill_id>")
         return
 
     try:
@@ -288,7 +295,7 @@ async def _cmd_info(args: argparse.Namespace) -> None:
 
     if not skill_id:
         print("\nError: skill_id is required")
-        print("Usage: aragora marketplace info <skill_id>")
+        print("Usage: aragora skills info <skill_id>")
         return
 
     try:

--- a/tests/cli/test_skills_client.py
+++ b/tests/cli/test_skills_client.py
@@ -1,0 +1,83 @@
+"""Tests for the skills CLI client helpers (base URL, auth headers, hints).
+
+Regression coverage for three defects:
+- _get_auth_headers ignored ARAGORA_API_TOKEN (read a non-existent settings attr).
+- _get_api_base targeted localhost:8000 and ignored ARAGORA_API_URL.
+- The empty-list hint pointed at the non-existent 'aragora marketplace install'.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from aragora.cli.commands import skills as skills_mod
+from aragora.cli.commands.skills import _get_api_base, _get_auth_headers
+
+
+class TestGetApiBase:
+    """Tests for _get_api_base."""
+
+    def test_defaults_to_documented_port_8080(self, monkeypatch):
+        """With no env override, base resolves to the documented 8080 port."""
+        monkeypatch.delenv("ARAGORA_API_URL", raising=False)
+        assert _get_api_base() == "http://localhost:8080"
+
+    def test_honors_aragora_api_url(self, monkeypatch):
+        """ARAGORA_API_URL overrides the default, matching other CLI clients."""
+        monkeypatch.setenv("ARAGORA_API_URL", "https://api.example.com:9443")
+        assert _get_api_base() == "https://api.example.com:9443"
+
+    def test_never_uses_legacy_8000_port(self, monkeypatch):
+        """The old localhost:8000 fallback must not reappear."""
+        monkeypatch.delenv("ARAGORA_API_URL", raising=False)
+        assert "8000" not in _get_api_base()
+
+
+class TestGetAuthHeaders:
+    """Tests for _get_auth_headers."""
+
+    def test_returns_bearer_when_token_set(self, monkeypatch):
+        """ARAGORA_API_TOKEN must be sent as a Bearer Authorization header."""
+        monkeypatch.setenv("ARAGORA_API_TOKEN", "test-token-12345")
+        monkeypatch.delenv("ARAGORA_API_KEY", raising=False)
+        assert _get_auth_headers() == {"Authorization": "Bearer test-token-12345"}
+
+    def test_falls_back_to_api_key(self, monkeypatch):
+        """ARAGORA_API_KEY is honored when ARAGORA_API_TOKEN is unset."""
+        monkeypatch.delenv("ARAGORA_API_TOKEN", raising=False)
+        monkeypatch.setenv("ARAGORA_API_KEY", "key-abc")
+        assert _get_auth_headers() == {"Authorization": "Bearer key-abc"}
+
+    def test_token_takes_precedence_over_key(self, monkeypatch):
+        """ARAGORA_API_TOKEN wins over ARAGORA_API_KEY when both are set."""
+        monkeypatch.setenv("ARAGORA_API_TOKEN", "tok")
+        monkeypatch.setenv("ARAGORA_API_KEY", "key")
+        assert _get_auth_headers() == {"Authorization": "Bearer tok"}
+
+    def test_empty_when_no_token(self, monkeypatch):
+        """No credentials -> no Authorization header."""
+        monkeypatch.delenv("ARAGORA_API_TOKEN", raising=False)
+        monkeypatch.delenv("ARAGORA_API_KEY", raising=False)
+        assert _get_auth_headers() == {}
+
+
+class TestCommandHints:
+    """The empty-list / usage hints must reference working commands."""
+
+    def test_no_marketplace_install_hint(self):
+        """Source must not point users at the non-existent 'marketplace install'."""
+        src = inspect.getsource(skills_mod)
+        assert "aragora marketplace install" not in src
+        assert "aragora marketplace uninstall" not in src
+        assert "aragora marketplace info" not in src
+
+    def test_uses_skills_install_hint(self):
+        """The working 'aragora skills install' guidance is present."""
+        src = inspect.getsource(skills_mod)
+        assert "aragora skills install <skill_id>" in src
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

The `aragora skills` CLI client diverged from every other CLI command (nomic, verticals, debate, consensus) and never worked against a real running server. Fixes three verified defects in `aragora/cli/commands/skills.py`.

## Root causes & fixes

### 1. (high) No auth header — `ARAGORA_API_TOKEN` ignored
`_get_auth_headers()` read `getattr(settings, "api_token", None)`, but the settings model has **no** `api_token` attribute, so the token was never read. Every authenticated subcommand (`list`/`install`/`uninstall`) hit 401 — while the error message ironically told users to "Set ARAGORA_API_TOKEN".

- **Before:** `ARAGORA_API_TOKEN=test python -c '...'` → `_get_auth_headers()` returns `{}`
- **After:** returns `{'Authorization': 'Bearer test'}` (falls back to `ARAGORA_API_KEY`), mirroring `nomic.py`/`verticals.py`.

### 2. (high) Wrong port / `ARAGORA_API_URL` ignored
`_get_api_base()` read absent `server_host`/`server_port` settings attrs and always fell back to `localhost:8000`. The server runs on **8080**, and `ARAGORA_API_URL` was never consulted.

- **Before:** `_get_api_base()` → `http://localhost:8000` (even with `ARAGORA_API_URL` set)
- **After:** honors `ARAGORA_API_URL`, defaults to `http://localhost:8080`, consistent with the other CLI clients and `--api-port 8080` docs.

### 3. (medium) Empty-list hint pointed at a crashing command
`aragora skills list` (empty) suggested `aragora marketplace install <skill_id>`, but the marketplace command has no `install` subcommand:

```
$ aragora marketplace install some_skill_id
click.exceptions.UsageError: No such command 'install'.
```

- **After:** hint reads `aragora skills install <skill_id>`. The matching dead-code usage strings in install/uninstall/info were corrected too.

## Tests

Adds `tests/cli/test_skills_client.py` (9 tests) covering base-URL resolution, auth-header construction (token, key fallback, precedence, empty), and the corrected hints. Red on origin/main (8 failing), green with the fix. Existing `tests/cli/test_skills_scan.py` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)