### PR TITLE
fix(billing): handle unlimited token limits and null invoice amounts

### DIFF
--- a/aragora/cli/billing.py
+++ b/aragora/cli/billing.py
@@ -75,7 +75,13 @@ def cmd_status(args: argparse.Namespace) -> int:
 
         print("\nUsage this period:")
         print(f"  Debates: {usage.get('debates', 0)} / {limits.get('debates', 'unlimited')}")
-        print(f"  Tokens: {usage.get('tokens', 0):,} / {limits.get('tokens', 'unlimited'):,}")
+        token_limit = limits.get("tokens", "unlimited")
+        # A numeric limit gets thousands separators; an unlimited (string) limit
+        # is rendered verbatim, since ':,' is invalid on strings.
+        token_limit_str = (
+            f"{token_limit:,}" if isinstance(token_limit, (int, float)) else token_limit
+        )
+        print(f"  Tokens: {usage.get('tokens', 0):,} / {token_limit_str}")
         cost = usage.get("cost_usd", "0")
         print(f"  Cost: ${float(cost):.2f}")
 
@@ -319,7 +325,8 @@ def cmd_invoices(args: argparse.Namespace) -> int:
 
         for inv in invoices:
             date = inv.get("date", "")[:10]
-            amount = inv.get("amount", 0) / 100  # cents to dollars
+            # Coalesce an explicit JSON null (not just a missing key) to 0 cents.
+            amount = (inv.get("amount") or 0) / 100  # cents to dollars
             status = inv.get("status", "unknown")
             inv_id = inv.get("id", "")[:20]
             print(f"{date:<12} ${amount:>9.2f} {status:<10} {inv_id}")

--- a/tests/test_cli_billing.py
+++ b/tests/test_cli_billing.py
@@ -211,6 +211,21 @@ class TestCmdStatus:
         captured = capsys.readouterr()
         assert "Error:" in captured.out
 
+    @patch("aragora.cli.billing.api_request")
+    def test_renders_unlimited_token_limit(self, mock_request, mock_args, capsys):
+        """Free/unlimited-token plans (limits omits 'tokens') must not crash."""
+        mock_request.return_value = {
+            "plan": {"name": "Free", "status": "active"},
+            "current_usage": {"debates": 5, "tokens": 12345, "cost_usd": "1.50"},
+            "limits": {"debates": 100},
+        }
+
+        result = cmd_status(mock_args)
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "Tokens: 12,345 / unlimited" in captured.out
+
 
 class TestCmdStatusLocal:
     """Tests for cmd_status_local function."""
@@ -444,6 +459,23 @@ class TestCmdInvoices:
 
         captured = capsys.readouterr()
         assert "No invoices found" in captured.out
+
+    @patch("aragora.cli.billing.api_request")
+    def test_handles_null_invoice_amount(self, mock_request, mock_args, capsys):
+        """An explicit JSON null amount must render as $0.00, not crash."""
+        mock_args.limit = 10
+        mock_request.return_value = {
+            "invoices": [
+                {"date": "2026-05-01", "amount": None, "status": "paid", "id": "in_123"},
+            ]
+        }
+
+        result = cmd_invoices(mock_args)
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "0.00" in captured.out
+        assert "paid" in captured.out
 
 
 class TestCmdBillingDefault:


### PR DESCRIPTION
## Root cause

Two `aragora billing` subcommands crashed with raw tracebacks (exit 1) on common, valid server payloads. Both handlers only catch `RuntimeError`, so these escaped to the user.

### 1. `billing status` — unlimited token plans (high)
`aragora/cli/billing.py` `cmd_status` rendered the tokens line as:
```python
print(f"  Tokens: {usage.get('tokens', 0):,} / {limits.get('tokens', 'unlimited'):,}")
```
When `limits` omits `tokens` (the default/free unlimited case), the default value is the string `'unlimited'`, and the `:,` thousands format is invalid on strings:
```
ValueError: Cannot specify ',' with 's'.
```
This is the default path for any unlimited-token plan (free tier, etc.).

### 2. `billing invoices` — null invoice amount (medium)
`cmd_invoices` computed:
```python
amount = inv.get("amount", 0) / 100
```
`.get('amount', 0)` only defaults a *missing* key, not an explicit JSON `null`. An invoice with `"amount": null` yields `None / 100`:
```
TypeError: unsupported operand type(s) for /: 'NoneType' and 'int'
```

## Fix
- **status**: format the token limit with thousands separators only when it is numeric; render a string limit verbatim.
- **invoices**: coalesce an explicit `null` amount to `0` cents with `or 0`.

Both commands now exit 0 on these inputs.

## Before / after

Free-plan status payload `{"limits":{"debates":100}}`:
- before: `ValueError: Cannot specify ',' with 's'.` (exit 1)
- after: `Tokens: 12,345 / unlimited` (exit 0)

Invoice payload `{"amount": null, "status":"paid", ...}`:
- before: `TypeError: unsupported operand type(s) for /: 'NoneType' and 'int'` (exit 1)
- after: `2026-05-01   $     0.00 paid       in_123` (exit 0)

## Tests
Added TDD regression tests to `tests/test_cli_billing.py`:
- `TestCmdStatus::test_renders_unlimited_token_limit`
- `TestCmdInvoices::test_handles_null_invoice_amount`

Both fail on the base and pass with the fix. The numeric-limit path (`test_shows_billing_status`, `test_lists_invoices`) is unchanged and still green. (One pre-existing unrelated failure, `test_handles_import_error`, fails identically on `origin/main` and is out of scope.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)