### PR TITLE
fix(ask): fail-closed when --quality-fail-closed conflicts with --no-post-consensus-quality

### DIFF
--- a/aragora/cli/commands/debate.py
+++ b/aragora/cli/commands/debate.py
@@ -1835,6 +1835,21 @@ def cmd_ask(args: argparse.Namespace) -> None:
         or "required sections" in task_lower
         or "section headings" in task_lower
     )
+    # Fail-closed cannot be honored when the post-consensus quality pipeline is
+    # disabled (and we are not in comparison mode, which has its own enforcement
+    # path). Both the config-validation guard below and the runtime gate inside
+    # _post_consensus_quality_pipeline are skipped when post_consensus_quality is
+    # False, so silently accepting --quality-fail-closed here would emit a false
+    # green in CI. Reject the contradictory combination explicitly instead.
+    if quality_fail_closed and not post_consensus_quality and not comparison_mode:
+        print(
+            "Debate configuration invalid: --quality-fail-closed cannot be "
+            "enforced together with --no-post-consensus-quality. The fail-closed "
+            "quality gate runs inside the post-consensus quality pipeline, which "
+            "is disabled. Remove --no-post-consensus-quality to enforce the gate.",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
     if post_consensus_quality or comparison_mode:
         from aragora.debate.output_quality import build_contract_context_block
 

--- a/tests/cli/test_offline_golden_path.py
+++ b/tests/cli/test_offline_golden_path.py
@@ -982,6 +982,79 @@ def test_cmd_ask_quality_fail_closed_requires_contract(monkeypatch, capsys):
     assert "--quality-fail-closed requires an explicit output contract" in err
 
 
+def test_cmd_ask_quality_fail_closed_conflicts_with_no_post_consensus_quality(
+    monkeypatch, capsys, tmp_path
+):
+    """--quality-fail-closed must not be silently dropped when post-consensus
+    quality is disabled.
+
+    Regression: combining --quality-fail-closed with --no-post-consensus-quality
+    used to bypass both the config-validation guard and the runtime gate, so the
+    command exited 0 even when output violated the contract (a false CI green).
+    The contradictory combination must now fail closed with a clear configuration
+    error.
+    """
+    from aragora.cli.commands import debate as debate_cmd
+
+    monkeypatch.delenv("ARAGORA_OFFLINE", raising=False)
+    contract_path = tmp_path / "contract.json"
+    contract_path.write_text(
+        '{"required_sections": ["Decision", "Rollback Plan", "Success Metrics"]}',
+        encoding="utf-8",
+    )
+
+    args = argparse.Namespace(
+        task="Should we adopt a four day work week for the team",
+        agents="claude,openai",
+        rounds=2,
+        consensus="judge",
+        context="",
+        learn=True,
+        db=":memory:",
+        demo=True,
+        api=False,
+        local=True,
+        graph=False,
+        matrix=False,
+        decision_integrity=False,
+        auto_select=False,
+        auto_select_config=None,
+        enable_verticals=False,
+        vertical=None,
+        calibration=True,
+        evidence_weighting=True,
+        trending=True,
+        mode=None,
+        api_url="http://localhost:8080",
+        api_key=None,
+        verbose=False,
+        graph_rounds=3,
+        branch_threshold=0.7,
+        max_branches=3,
+        scenario=None,
+        matrix_rounds=3,
+        di_include_context=False,
+        di_plan_strategy="single_task",
+        di_execution_mode=None,
+        timeout=30,
+        post_consensus_quality=False,
+        upgrade_to_good=True,
+        quality_upgrade_max_loops=2,
+        quality_min_score=9.0,
+        quality_fail_closed=True,
+        required_sections=None,
+        output_contract_file=str(contract_path),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        debate_cmd.cmd_ask(args)
+
+    assert exc_info.value.code == 2
+    err = capsys.readouterr().err
+    assert "--quality-fail-closed cannot be" in err
+    assert "--no-post-consensus-quality" in err
+
+
 def test_cmd_ask_quality_fail_closed_invalid_output_contract_file(monkeypatch, capsys):
     """Invalid output contract file path should fail fast with clear configuration error."""
     from aragora.cli.commands import debate as debate_cmd


### PR DESCRIPTION
## Root cause

The \`ask\` command's fail-closed quality enforcement lives entirely inside the post-consensus quality pipeline:

- The config-validation guard (the \`Debate configuration invalid\` block in \`aragora/cli/commands/debate.py\`) is nested under \`if post_consensus_quality or comparison_mode:\`.
- The runtime fail-closed gate inside \`_post_consensus_quality_pipeline\` early-returns when \`post_consensus_quality\` is \`False\`.

So combining \`--quality-fail-closed\` with \`--no-post-consensus-quality\` (which sets \`post_consensus_quality=False\`; \`comparison_mode\` is \`False\` for a single agent set) bypassed **both** the guard and the gate. The run completed and exited \`0\` even when output violated the contract — a **false CI green**. The help text (\`parser.py\`) promises the flag will _"Exit non-zero when post-consensus output still fails quality gates after repair loops."_

## Fix

Add an explicit configuration guard before the post-consensus block. When \`--quality-fail-closed\` is requested but \`post_consensus_quality\` is disabled and we are not in comparison mode (which has its own enforcement path at the comparison summary check), reject the contradictory combination with a clear \`Debate configuration invalid\` message and exit \`2\` — instead of silently dropping the request.

## Before / After

Repro:
\`\`\`
printf '{"required_sections": ["Decision", "Rollback Plan", "Success Metrics"]}' > /tmp/contract.json
python3 -m aragora.cli.main ask 'Should we adopt a four day work week for the team' \
  --demo --quality-fail-closed --no-post-consensus-quality --output-contract-file /tmp/contract.json
\`\`\`

- **Before:** exit \`0\` (false green, no error/warning)
- **After:** exit \`2\` with \`Debate configuration invalid: --quality-fail-closed cannot be enforced together with --no-post-consensus-quality...\`

Unchanged behavior verified:
- Fail-closed **with** post-consensus enabled still exits \`1\` on gate failure.
- \`--no-post-consensus-quality\` **without** fail-closed still exits \`0\` (benign).

## Tests

TDD: added \`test_cmd_ask_quality_fail_closed_conflicts_with_no_post_consensus_quality\` to \`tests/cli/test_offline_golden_path.py\` (red on the origin/main base, green with the fix). Full module: 18 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)