### PR TITLE
fix(cli): handle sqlite3 errors in `export --debate-id` (no raw traceback)

### DIFF
--- a/aragora/cli/export.py
+++ b/aragora/cli/export.py
@@ -8,6 +8,7 @@ Supports HTML, JSON, and Markdown export formats.
 from __future__ import annotations
 
 import argparse
+import sqlite3
 from pathlib import Path
 
 
@@ -150,7 +151,11 @@ def main(args: argparse.Namespace) -> None:
     elif args.debate_id:
         try:
             artifact = load_artifact_from_debate(args.debate_id, getattr(args, "db", None))
-        except (OSError, RuntimeError, ValueError, KeyError) as e:
+        except (OSError, RuntimeError, ValueError, KeyError, sqlite3.Error) as e:
+            # sqlite3.Error covers the common fresh-user case where the traces
+            # DB exists but has no `traces` table (sqlite3.OperationalError),
+            # which is not a subclass of the other caught types and would
+            # otherwise surface as a raw traceback.
             print(f"Error loading debate: {e}")
             print("Use --demo for a sample export, or ensure the debate ID exists.")
             return

--- a/tests/test_cli_export.py
+++ b/tests/test_cli_export.py
@@ -271,8 +271,34 @@ class TestMain:
         """Handle load error gracefully."""
         mock_args.debate_id = "nonexistent"
         mock_args.output = str(tmp_path)
-        mock_load.side_effect = Exception("Debate not found")
+        mock_load.side_effect = OSError("Debate not found")
 
+        main(mock_args)
+
+        captured = capsys.readouterr()
+        assert "Error loading debate" in captured.out
+        assert "--demo" in captured.out
+
+    @patch("aragora.cli.export.load_artifact_from_debate")
+    def test_load_error_sqlite_operational(self, mock_load, mock_args, tmp_path, capsys):
+        """A missing traces DB/table (sqlite3.OperationalError) is handled cleanly.
+
+        Regression: DebateReplayer.from_database opens the SQLite file without
+        creating the ``traces`` schema, so a fresh user running export against a
+        directory with no prior traced debates gets
+        ``sqlite3.OperationalError: no such table: traces``. That exception is not
+        a subclass of OSError/RuntimeError/ValueError/KeyError, so it previously
+        escaped the handler and dumped a raw traceback (exit 1). It must instead
+        print the friendly message and return cleanly.
+        """
+        import sqlite3
+
+        mock_args.debate_id = "abc123"
+        mock_args.output = str(tmp_path)
+        mock_args.db = None
+        mock_load.side_effect = sqlite3.OperationalError("no such table: traces")
+
+        # Must not raise; must print the friendly guidance.
         main(mock_args)
 
         captured = capsys.readouterr()


### PR DESCRIPTION
## Defect (lane: export)

`aragora export --debate-id <id>` crashed with a **raw multi-frame `sqlite3.OperationalError` traceback** and exit 1 for the ordinary fresh-user case — running `export` from a directory with no prior traced debates.

### Repro (safe / offline — no LLM/API/money)
```bash
cd /tmp && rm -rf clean_export && mkdir clean_export && cd clean_export
python3 -m aragora.cli.main export --debate-id abc123 -f json --output ./out
```

### Root cause
`DebateReplayer.from_database` opens/creates the traces SQLite file via `DatabaseManager` but **never creates the `traces` schema** — that table is only created by the writer (`DebateTracer`). So the read path's `SELECT trace_json FROM traces WHERE trace_id = ?` (`aragora/debate/traces.py:607`) raises:

```
sqlite3.OperationalError: no such table: traces
```

The friendly handler in `aragora/cli/export.py` only caught `(OSError, RuntimeError, ValueError, KeyError)`. `sqlite3.OperationalError`'s MRO is `OperationalError → DatabaseError → Error → Exception` — **not** a subclass of any caught type — so it escaped the handler and dumped a raw traceback. The intended friendly path only fired for the narrow "DB+table exist but row absent" case (`ValueError("Trace not found")`).

## Fix
Add `sqlite3.Error` (parent of `OperationalError`/`DatabaseError`) to the caught tuple in `export.main`. No bare/broad `except` — narrow, specific exception types only, matching the file's existing convention. The existing friendly message + clean (exit 0) return path now fires for missing-DB / missing-table failures.

## Before / After

**Before** (stdout): raw `Traceback (most recent call last): ... sqlite3.OperationalError: no such table: traces`, exit 1.

**After** (stdout):
```
Error loading debate: no such table: traces
Use --demo for a sample export, or ensure the debate ID exists.
```
exit 0. (A lower-level `aragora.storage.schema` logger still emits the DB error with `exc_info` to **stderr** — that's a benign log record, not an uncaught crash; the process now exits cleanly.)

## Tests (TDD)
- Added `tests/test_cli_export.py::TestMain::test_load_error_sqlite_operational` — red before the fix (`sqlite3.OperationalError` escaped), green after.
- Narrowed the pre-existing `test_load_error` side_effect from a bare `Exception` to `OSError` so it exercises a specifically-caught type (the fix intentionally does not add a broad `except Exception`).
- Full module: **18 passed**.

## Review status
- Independent **codex review is QUEUED** (codex reviewer is capacity/auth-exhausted right now); this PR is intentionally left as **DRAFT** pending that review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)