### PR TITLE
fix(cli): fix `aragora work` no-subcommand crash and no-op --json flag

### DIFF
--- a/aragora/cli/commands/work_board.py
+++ b/aragora/cli/commands/work_board.py
@@ -15,11 +15,97 @@ def _repo_root(args: argparse.Namespace) -> Path:
     return Path(getattr(args, "repo", ".")).expanduser().resolve()
 
 
+def _render_human(payload: dict[str, Any]) -> str:
+    """Render a work-board payload as a compact, human-readable summary.
+
+    Mirrors the JSON payload's information without raw braces. The ``--json``
+    flag selects the machine-stable JSON form; the default is this view.
+    """
+    lines: list[str] = []
+    schema = payload.get("schema_version")
+    if schema:
+        lines.append(f"schema: {schema}")
+
+    def _fmt_item(item: dict[str, Any], *, indent: str = "  ") -> None:
+        item_id = item.get("id", "?")
+        title = item.get("title") or ""
+        status = item.get("status") or "unknown"
+        header = f"{indent}- {item_id} [{status}]"
+        if title:
+            header += f" {title}"
+        lines.append(header)
+        owner = item.get("owner")
+        if owner:
+            lines.append(f"{indent}  owner: {owner}")
+        url = item.get("url")
+        if url:
+            lines.append(f"{indent}  url: {url}")
+        deps = item.get("dependencies") or []
+        if deps:
+            lines.append(f"{indent}  depends_on: {', '.join(deps)}")
+
+    # work list / robot share a top-level scope + count.
+    if "scope" in payload:
+        lines.append(f"scope: {payload['scope']}")
+    if "count" in payload:
+        lines.append(f"count: {payload['count']}")
+
+    if "items" in payload:
+        items = payload.get("items") or []
+        if not items:
+            lines.append("items: (none)")
+        else:
+            lines.append("items:")
+            for item in items:
+                _fmt_item(item)
+
+    if "recommendations" in payload:
+        recs = payload.get("recommendations") or []
+        if not recs:
+            lines.append("recommendations: (none)")
+        else:
+            lines.append("recommendations:")
+            for rec in recs:
+                lines.append(
+                    f"  #{rec.get('rank')} {rec.get('item_id')} "
+                    f"[{rec.get('classification')}] -> {rec.get('action')} "
+                    f"({rec.get('priority')})"
+                )
+                blockers = rec.get("blockers") or []
+                if blockers:
+                    lines.append(f"    blockers: {', '.join(blockers)}")
+
+    # work show emits a single item under "found"/"item".
+    if "found" in payload:
+        lines.append(f"id: {payload.get('id')}")
+        lines.append(f"found: {payload.get('found')}")
+        item = payload.get("item")
+        if item:
+            _fmt_item(item)
+
+    # work graph emits edges.
+    if "edges" in payload:
+        edges = payload.get("edges") or []
+        if edges:
+            lines.append("edges:")
+            for edge in edges:
+                lines.append(f"  {edge.get('from')} --{edge.get('relation')}--> {edge.get('to')}")
+        else:
+            lines.append("edges: (none)")
+
+    for health in payload.get("source_health") or []:
+        status = health.get("status")
+        if status and status != "ok":
+            lines.append(f"source {health.get('source')}: {status}")
+
+    return "\n".join(lines) if lines else "(no work)"
+
+
 def _emit(payload: dict[str, Any], *, as_json: bool) -> int:
     if as_json:
         print(json.dumps(payload, sort_keys=True, indent=2))
         return 0
-    print(json.dumps(payload, sort_keys=True, indent=2))
+    print(_render_human(payload))
     return 0
 
 

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -307,6 +307,15 @@ def _add_work_parser(subparsers) -> None:
             "closes, or mutates work."
         ),
     )
+
+    def _work_parent_help(_args: argparse.Namespace) -> int:
+        work.print_help()
+        return 2
+
+    # Running ``aragora work`` with no subcommand prints help and exits cleanly
+    # (mirrors the sibling ``codex`` parser) instead of raising AttributeError
+    # when main.py dispatches args.func.
+    work.set_defaults(func=_work_parent_help)
     work_sub = work.add_subparsers(dest="work_cmd")
 
     def add_common(p) -> None:

--- a/tests/cli/test_work_board.py
+++ b/tests/cli/test_work_board.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+from aragora.cli.main import main as cli_main
 from aragora.cli.parser import build_parser
 from aragora.cli.commands.work_board import (
     cmd_work_graph,
@@ -53,6 +54,60 @@ def test_work_parser_registers_read_only_robot_command() -> None:
     assert args.command == "work"
     assert args.work_cmd == "robot"
     assert args.json is True
+
+
+def test_work_with_no_subcommand_prints_help_without_traceback(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """`aragora work` with no subcommand should exit cleanly with usage, not crash.
+
+    Regression: previously raised an uncaught AttributeError because the work
+    subparser group set no default ``func`` (parser.py:310), unlike the sibling
+    ``codex`` parser which prints help and returns a non-zero exit code.
+    """
+    monkeypatch.setattr("sys.argv", ["aragora", "work"])
+
+    exit_code = cli_main()
+
+    out = capsys.readouterr().out
+    # Non-zero so scripts can detect "no subcommand given", matching `codex`.
+    assert exit_code == 2
+    # Help/usage text is printed instead of a traceback.
+    assert "work" in out
+    assert "list" in out  # one of the documented subcommands appears in help
+
+
+def test_work_list_default_is_human_readable_not_json(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """Without ``--json`` the output must NOT be raw JSON.
+
+    Regression: the ``--json`` flag was a no-op (both branches of _emit printed
+    json.dumps), so default output was always JSON despite help text implying a
+    human-readable default.
+    """
+    monkeypatch.setattr("aragora.work.sources.shutil.which", lambda name: None)
+
+    assert cmd_work_list(_args(tmp_path, scope="current", json=False)) == 0
+    out = capsys.readouterr().out
+
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(out)
+    # Human-readable rendering surfaces the schema-aware summary, not raw braces.
+    assert out.strip() != ""
+    assert not out.lstrip().startswith("{")
+
+
+def test_work_list_json_flag_emits_parseable_json(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """With ``--json`` the output must remain stable, parseable JSON."""
+    monkeypatch.setattr("aragora.work.sources.shutil.which", lambda name: None)
+
+    assert cmd_work_list(_args(tmp_path, scope="current", json=True)) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["schema_version"] == "aragora.work.v1"
 
 
 def test_work_list_reads_current_outbox(


### PR DESCRIPTION
## Summary

Fixes the two defects in the read-only `aragora work` CLI lane (from the `work` defect lane). DRAFT — not for merge yet.

## Defect 1 (medium): `aragora work` with no subcommand crashes

**Root cause:** The `work` subparser group (`aragora/cli/parser.py:310`) set no default `func`. `main.py` only guards the top-level `args.command is None` case (line 165), so dispatch fell through to `args.func(args)` (line 183) and raised an uncaught `AttributeError: 'Namespace' object has no attribute 'func'`, dumping a full traceback with exit 1.

**Fix:** Set a default `func` on the `work` parser that prints help and returns `2`, mirroring the established sibling `codex` parser convention (`parser.py:_add_codex_parser` uses the same `print_help` + `return 2` pattern). Surgical: only the `work` parser is touched; subcommands still route to their own funcs.

### Before / after

```
# BEFORE
$ aragora work
Traceback (most recent call last):
  ...
  File ".../aragora/cli/main.py", line 183, in main
    result = args.func(args)
AttributeError: 'Namespace' object has no attribute 'func'
# exit 1

# AFTER
$ aragora work
usage: aragora work [-h] {list,show,graph,robot} ...

Read-only Agent Flywheel kernel over PRs, automation, broker runs, ...
  ...
# exit 2 (clean usage, no traceback)
```

## Defect 2 (low): `work --json` flag is a no-op

**Root cause:** `_emit()` in `aragora/cli/commands/work_board.py` had byte-identical bodies in the `if as_json` and `else` branches (both `print(json.dumps(...))`), so output was always JSON regardless of the flag — contradicting the help text "Emit stable JSON" (which implies a human-readable default). Affected all four verbs (list/show/graph/robot).

**Fix:** Made the flag meaningful — default output is now a compact human-readable summary; JSON is emitted only with `--json`. The JSON path is byte-for-byte unchanged for machine consumers.

### Before / after

```
# BEFORE
$ diff <(aragora work list) <(aragora work list --json)   # identical (no-op)

# AFTER
$ aragora work list
schema: aragora.work.v1
scope: current
count: 37
items:
  - pr:7585 [open] fix(debate): defer annotations ...
    url: https://github.com/synaptent/aragora/pull/7585
  ...
$ aragora work list --json
{ "count": 37, "items": [ ... ], "schema_version": "aragora.work.v1", ... }
# the two now differ
```

## Tests (TDD)

Added 3 failing-first tests in `tests/cli/test_work_board.py`:
- `test_work_with_no_subcommand_prints_help_without_traceback` — `aragora work` exits 2 with help text, no traceback
- `test_work_list_default_is_human_readable_not_json` — default output is not raw JSON
- `test_work_list_json_flag_emits_parseable_json` — `--json` stays stable, parseable JSON

All 15 `tests/cli/test_work_board.py` tests pass; `tests/cli/test_worktree_command.py`, `test_main.py`, and `test_cli_commands.py` regression suites green.

## Notes

- No protected files touched.
- Codex review: QUEUED (codex exhausted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)