### PR TITLE
fix(cli): elo agent reports not-found instead of fabricating 1500; error paths exit non-zero

### DIFF
--- a/aragora/cli/commands/stats.py
+++ b/aragora/cli/commands/stats.py
@@ -182,8 +182,12 @@ def cmd_memory(args: argparse.Namespace) -> None:
         print(f"Cleanup complete: {stats}")
 
 
-def cmd_elo(args: argparse.Namespace) -> None:
-    """Handle 'elo' command - view ELO ratings and history."""
+def cmd_elo(args: argparse.Namespace) -> int:
+    """Handle 'elo' command - view ELO ratings and history.
+
+    Returns a process exit code: ``0`` on success, non-zero on error paths
+    (missing required arguments, unknown agent) so scripts can detect failure.
+    """
     from aragora.persistence.db_config import DatabaseType, get_db_path
     from aragora.ranking.elo import EloSystem
 
@@ -219,7 +223,7 @@ def cmd_elo(args: argparse.Namespace) -> None:
         agent = getattr(args, "agent", None)
         if not agent:
             print("Error: --agent is required for history")
-            return
+            return 2
 
         limit = getattr(args, "limit", 20)
         history = elo.get_elo_history(agent, limit=limit)
@@ -229,7 +233,7 @@ def cmd_elo(args: argparse.Namespace) -> None:
 
         if not history:
             print("  No history found")
-            return
+            return 0
 
         for timestamp, elo_value in history:
             print(f"  {timestamp[:19]}  {elo_value:>7.0f}")
@@ -243,7 +247,7 @@ def cmd_elo(args: argparse.Namespace) -> None:
 
         if not matches:
             print("  No matches found")
-            return
+            return 0
 
         for match in matches:
             winner = match.get("winner_name", "?")
@@ -260,9 +264,17 @@ def cmd_elo(args: argparse.Namespace) -> None:
         agent = getattr(args, "agent", None)
         if not agent:
             print("Error: --agent is required")
-            return
+            return 2
 
         try:
+            # get_rating() is get-or-create: it synthesises a default 1500
+            # rating for unknown agents. Check for a real recorded rating first
+            # so a typo'd / never-seen agent is reported as not-found rather than
+            # shown a fabricated default record.
+            if not elo.has_rating(agent):
+                print(f"Agent not found: {agent}")
+                return 1
+
             rating = elo.get_rating(agent)
             print(f"\nAgent: {rating.agent_name}")
             print("=" * 40)
@@ -293,9 +305,13 @@ def cmd_elo(args: argparse.Namespace) -> None:
         except (KeyError, ValueError) as e:
             logger.warning("Agent lookup failed for '%s': %s", agent, e)
             print(f"Agent not found: {agent}")
+            return 1
         except (OSError, TypeError) as e:
             logger.warning("ELO database error for agent '%s': %s", agent, e)
             print(f"Agent not found: {agent}")
+            return 1
+
+    return 0
 
 
 def cmd_cross_pollination(args: argparse.Namespace) -> None:

--- a/aragora/ranking/elo.py
+++ b/aragora/ranking/elo.py
@@ -391,6 +391,23 @@ class EloSystem(KMAdapterMixin):
         self._rating_cache.set(cache_key, rating)
         return rating
 
+    def has_rating(self, agent_name: str) -> bool:
+        """Return True if a rating row exists for this agent.
+
+        Unlike :meth:`get_rating` (which is get-or-create and synthesises a
+        default 1500 rating for unknown agents), this performs a pure existence
+        check so callers can distinguish a real recorded rating from a
+        fabricated default.
+        """
+        _validate_agent_name(agent_name)
+        with self._db.connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT 1 FROM ratings WHERE agent_name = ? LIMIT 1",
+                (agent_name,),
+            )
+            return cursor.fetchone() is not None
+
     def _rating_from_row(self, row: tuple[Any, ...]) -> AgentRating:
         """Create AgentRating from a database row (leaderboard query format)."""
         return AgentRating(

--- a/tests/cli/test_elo_command.py
+++ b/tests/cli/test_elo_command.py
@@ -1,0 +1,107 @@
+"""Tests for the `aragora elo` CLI command (cmd_elo).
+
+Covers two correctness/trust defects:
+
+1. ``elo agent --agent <typo>`` must report the agent is *not found* rather than
+   fabricating a confident-looking default 1500 ELO record for an agent that has
+   never participated.
+2. ``elo`` error paths (missing required ``--agent``, agent-not-found) must exit
+   non-zero so scripts can detect failure.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from aragora.cli.commands.stats import cmd_elo
+from aragora.ranking.elo import EloSystem
+
+
+def _args(db_path: Path, **kwargs) -> argparse.Namespace:
+    base = {"db": str(db_path), "action": "leaderboard", "agent": None, "limit": 10}
+    base.update(kwargs)
+    return argparse.Namespace(**base)
+
+
+class TestEloAgentNotFound:
+    def test_unknown_agent_reports_not_found_not_fabricated_rating(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        """A typo'd / unknown agent must NOT yield a fabricated 1500 record."""
+        db_path = tmp_path / "elo.db"
+        # Touch the system so the schema exists but no agent is registered.
+        EloSystem(db_path=str(db_path))
+
+        result = cmd_elo(_args(db_path, action="agent", agent="totally_made_up_agent_xyz"))
+
+        out = capsys.readouterr().out
+        assert "not found" in out.lower()
+        assert "totally_made_up_agent_xyz" in out
+        # Must not present a fabricated rating as real data.
+        assert "1500" not in out
+        assert "ELO Rating" not in out
+        # Error path -> non-zero exit.
+        assert isinstance(result, int)
+        assert result != 0
+
+    def test_known_agent_shows_real_record(self, tmp_path: Path, capsys) -> None:
+        """An agent with a recorded match still shows its real record and exits 0."""
+        db_path = tmp_path / "elo.db"
+        elo = EloSystem(db_path=str(db_path))
+        # record_match persists rating rows for both participants.
+        elo.record_match(winner="real_agent", loser="other_agent")
+
+        result = cmd_elo(_args(db_path, action="agent", agent="real_agent"))
+
+        out = capsys.readouterr().out
+        assert "real_agent" in out
+        assert "ELO Rating" in out
+        assert "not found" not in out.lower()
+        # Success -> exit 0 (None or 0 both treated as success by dispatcher).
+        assert result in (None, 0)
+
+
+class TestEloErrorExitCodes:
+    def test_agent_action_missing_agent_arg_exits_nonzero(self, tmp_path: Path, capsys) -> None:
+        db_path = tmp_path / "elo.db"
+        result = cmd_elo(_args(db_path, action="agent", agent=None))
+
+        out = capsys.readouterr().out
+        assert "--agent is required" in out
+        assert isinstance(result, int)
+        assert result != 0
+
+    def test_history_action_missing_agent_arg_exits_nonzero(self, tmp_path: Path, capsys) -> None:
+        db_path = tmp_path / "elo.db"
+        result = cmd_elo(_args(db_path, action="history", agent=None))
+
+        out = capsys.readouterr().out
+        assert "--agent is required" in out
+        assert isinstance(result, int)
+        assert result != 0
+
+    def test_leaderboard_success_returns_zero(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "elo.db"
+        EloSystem(db_path=str(db_path))
+        result = cmd_elo(_args(db_path, action="leaderboard"))
+        assert result in (None, 0)
+
+
+class TestEloSystemHasRating:
+    def test_has_rating_false_for_unknown(self, tmp_path: Path) -> None:
+        elo = EloSystem(db_path=str(tmp_path / "elo.db"))
+        assert elo.has_rating("nobody") is False
+
+    def test_has_rating_true_after_recorded_match(self, tmp_path: Path) -> None:
+        elo = EloSystem(db_path=str(tmp_path / "elo.db"))
+        elo.record_match(winner="somebody", loser="rival")
+        assert elo.has_rating("somebody") is True
+
+    def test_has_rating_does_not_create_row(self, tmp_path: Path) -> None:
+        """Existence check must not implicitly register the agent."""
+        elo = EloSystem(db_path=str(tmp_path / "elo.db"))
+        elo.has_rating("ghost")
+        assert "ghost" not in elo.list_agents()

--- a/tests/cli/test_elo_command.py
+++ b/tests/cli/test_elo_command.py
@@ -12,12 +12,34 @@ Covers two correctness/trust defects:
 from __future__ import annotations
 
 import argparse
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
 from aragora.cli.commands.stats import cmd_elo
 from aragora.ranking.elo import EloSystem
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run_elo_cli(db_path: Path, *cli_args: str) -> subprocess.CompletedProcess[str]:
+    """Spawn the *real* ``aragora elo`` CLI process and return its result.
+
+    This drives the full dispatcher chain (``python -m aragora.cli.main`` ->
+    ``main()`` -> ``args.func(args)`` -> ``raise SystemExit(main())``) so the
+    assertion is on the actual OS-level process exit code, not just the value
+    ``cmd_elo`` returns in-process. A unit test that only inspects ``cmd_elo``'s
+    return value would pass even if the dispatcher dropped the int on the floor.
+    """
+    return subprocess.run(
+        [sys.executable, "-m", "aragora.cli.main", "elo", *cli_args, "--db", str(db_path)],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
 
 
 def _args(db_path: Path, **kwargs) -> argparse.Namespace:
@@ -105,3 +127,68 @@ class TestEloSystemHasRating:
         elo = EloSystem(db_path=str(tmp_path / "elo.db"))
         elo.has_rating("ghost")
         assert "ghost" not in elo.list_agents()
+
+
+class TestEloCliProcessExitCode:
+    """Process-level regression tests for ``aragora elo`` exit codes.
+
+    The unit tests above call ``cmd_elo`` directly and assert on its *return
+    value*. That alone does not prove a script running ``aragora elo ...`` sees a
+    non-zero exit: the dispatcher must propagate the int return into the process
+    exit code. These tests spawn the real CLI subprocess and assert on
+    ``returncode`` to lock that end-to-end contract.
+    """
+
+    def test_agent_unknown_process_exits_nonzero(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "elo.db"
+        EloSystem(db_path=str(db_path))  # create schema, no agents
+
+        result = _run_elo_cli(db_path, "agent", "--agent", "totally_made_up_xyz")
+
+        assert result.returncode != 0, result.stdout + result.stderr
+        assert result.returncode == 1
+        assert "not found" in result.stdout.lower()
+        # Must not leak a fabricated default record.
+        assert "1500" not in result.stdout
+        assert "ELO Rating" not in result.stdout
+
+    def test_agent_missing_required_arg_process_exits_nonzero(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "elo.db"
+        EloSystem(db_path=str(db_path))
+
+        result = _run_elo_cli(db_path, "agent")
+
+        assert result.returncode != 0, result.stdout + result.stderr
+        assert result.returncode == 2
+        assert "--agent is required" in result.stdout
+
+    def test_history_missing_required_arg_process_exits_nonzero(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "elo.db"
+        EloSystem(db_path=str(db_path))
+
+        result = _run_elo_cli(db_path, "history")
+
+        assert result.returncode != 0, result.stdout + result.stderr
+        assert result.returncode == 2
+        assert "--agent is required" in result.stdout
+
+    def test_leaderboard_success_process_exits_zero(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "elo.db"
+        EloSystem(db_path=str(db_path))
+
+        result = _run_elo_cli(db_path)
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "Leaderboard" in result.stdout
+
+    def test_known_agent_process_exits_zero(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "elo.db"
+        elo = EloSystem(db_path=str(db_path))
+        elo.record_match(winner="real_agent", loser="other_agent")
+
+        result = _run_elo_cli(db_path, "agent", "--agent", "real_agent")
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "real_agent" in result.stdout
+        assert "ELO Rating" in result.stdout
+        assert "not found" not in result.stdout.lower()


### PR DESCRIPTION
## Summary

Fixes the two `aragora elo` CLI defects in the **elo** defect lane, both in `cmd_elo` (`aragora/cli/commands/stats.py`). Reproduced both first (pure-local sqlite, no LLM/API), fixed via TDD (failing tests first), then verified green.

## Defect 1 (medium, trust): `elo agent --agent <typo>` fabricated a fake 1500-ELO record

**Root cause:** `EloSystem.get_rating()` (`aragora/ranking/elo.py`) is get-or-create — when no row exists it synthesises `AgentRating(agent_name=..., elo=1500)`. So an unknown/typo'd agent was presented with a confident-looking default record as if it were real data. The handler's `except (KeyError, ValueError)` "Agent not found" branch was dead code for the ordinary missing-agent case (the only raise in the path, `_validate_agent_name`, fires solely on over-length names).

**Fix:** Added `EloSystem.has_rating(agent_name) -> bool`, a pure existence check against the `ratings` table (does not create a row). `cmd_elo` now gates the agent view on it and prints `Agent not found: <name>` for unknown agents.

### Before / After
```
# BEFORE
$ aragora elo agent --agent totally_made_up_agent_xyz --db /tmp/elo_probe.db
Agent: totally_made_up_agent_xyz
========================================
  ELO Rating:       1500
  Wins/Losses:   0/0
  Win Rate:      0.0%
  Total Games:   0
# EXIT=0

# AFTER
$ aragora elo agent --agent totally_made_up_agent_xyz --db /tmp/elo_probe.db
Agent not found: totally_made_up_agent_xyz
# EXIT=1
```
A real agent (with a recorded match) still shows its full record and exits 0.

## Defect 2 (low, contract): `elo` error paths returned exit code 0

**Root cause:** `cmd_elo` was declared `-> None` and bare-`return`ed on every error branch. The dispatcher (`aragora/cli/main.py`: `if isinstance(result, int): return result`) only propagates non-zero codes when the handler returns an int — so error paths fell through to `return 0`.

**Fix:** `cmd_elo` is now `-> int`: missing-required-arg → `2`, agent-not-found → `1`, success → `0`.

### Before / After
```
# BEFORE
$ aragora elo agent --db /tmp/x.db;   echo EXIT=$?   # Error: --agent is required            -> EXIT=0
$ aragora elo history --db /tmp/x.db; echo EXIT=$?   # Error: --agent is required for history -> EXIT=0

# AFTER
$ aragora elo agent --db /tmp/x.db;   echo EXIT=$?   # Error: --agent is required            -> EXIT=2
$ aragora elo history --db /tmp/x.db; echo EXIT=$?   # Error: --agent is required for history -> EXIT=2
$ aragora elo --db /tmp/x.db; echo EXIT=$?           # leaderboard (success)                 -> EXIT=0
```

## Tests

New `tests/cli/test_elo_command.py` (8 tests, all green):
- unknown agent reported as not-found, **no fabricated 1500**, exit ≠ 0
- known agent (recorded match) still shows real record, exit 0
- missing `--agent` for `agent` and `history` → exit ≠ 0
- leaderboard success → exit 0
- `has_rating()` semantics: false for unknown, true after recorded match, no implicit row creation

Regression: `tests/cli/test_elo_command.py` + `tests/ranking` → **597 passed, 2 skipped**; `tests/test_cli_main.py -k "elo or stats"` → 2 passed.

## Notes
- Codex review is **QUEUED** (codex exhausted).
- No protected files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)