### PR TITLE
fix(quorum-gate): stop the merge-quorum self-cancel race + robust dogfood recognition

### DIFF
--- a/.github/workflows/aragora-merge-quorum.yml
+++ b/.github/workflows/aragora-merge-quorum.yml
@@ -27,7 +27,16 @@ on:
 
 concurrency:
   group: aragora-merge-quorum-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
-  cancel-in-progress: true
+  # cancel-in-progress is intentionally false. With true, two triggers for the
+  # same PR (e.g. synchronize + reopened, or rapid pushes) cancel each other;
+  # a cancelled run reports a "cancelled" conclusion, which turns this REQUIRED
+  # check red and blocks the PR until a human manually reruns and wins a green
+  # window. The repo already set cancel-in-progress:false on its other
+  # non-required workflows to "stop the doom loop"; we do the same here so
+  # concurrent runs run to completion instead of cancelling into a red status.
+  # GitHub still evaluates the latest completed run per head SHA, so the gate is
+  # not weakened — only the self-cancel race is removed.
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -24,6 +24,7 @@ import argparse
 import hashlib
 import json
 import os
+import re
 import sqlite3
 import subprocess
 import sys
@@ -3000,9 +3001,30 @@ def _model_family_from_body(body: str) -> str:
     ``## Focused adversarial dogfood`` heading that names no model. Scan the full
     body for such a line and normalize it to a canonical family. Returns ``""``
     when no recognizable family is disclosed (fail-closed: no phantom inflation).
+
+    Fenced code blocks (```` ``` ````/``~~~``) and inline-code spans (`` `...` ``)
+    are skipped so a merely *quoted* ``Model family:`` example — e.g. someone
+    pasting the disclosure template into a code fence — cannot inflate quorum.
     """
-    for line in str(body).splitlines():
-        stripped = line.strip()
+    in_fence = False
+    fence_marker = ""
+    for raw_line in str(body).splitlines():
+        stripped = raw_line.strip()
+        # Track fenced code blocks and skip everything inside them.
+        if stripped.startswith(("```", "~~~")):
+            marker = stripped[:3]
+            if not in_fence:
+                in_fence = True
+                fence_marker = marker
+            elif marker == fence_marker:
+                in_fence = False
+                fence_marker = ""
+            continue
+        if in_fence:
+            continue
+        # Drop inline-code spans so a back-ticked example label is not parsed
+        # as a real disclosure line.
+        stripped = re.sub(r"`[^`]*`", "", stripped).strip()
         if stripped.startswith("-"):
             stripped = stripped[1:].strip()
         label, sep, value = stripped.partition(":")
@@ -3023,15 +3045,30 @@ def _resolve_dogfood_identity(body: str) -> ModelReviewIdentity:
 
     Starts from the shared :func:`_resolve_model_review_identity` (heading +
     post-heading structured metadata). When that yields a countable model
-    reviewer, it is returned unchanged. Otherwise — e.g. a plain
-    ``## Focused adversarial dogfood`` heading whose body still discloses a
-    ``Model family:`` line — fall back to a full-body scan and, if a known
-    family is found, synthesize a countable identity. This mirrors how the
-    model-review-signal recognizer trusts the disclosed model family rather
-    than the heading, keeping the two recognizers consistent.
+    reviewer, it is returned unchanged.
+
+    The body-family fallback is applied **only** when the original resolution
+    failed for the benign reason "no model was inferable from the heading or its
+    structured metadata" — i.e. the heading named no surface and the only
+    count-blocker is ``unknown_surface_reviewer``. If the original identity
+    carries a *real* problem — an unknown/unnormalizable disclosed family
+    (``unknown_model_family``), a router surface that disclosed no family
+    (``missing_model_family_disclosure``), or a heading/metadata family
+    *conflict* (``heading_model_family_conflict``) — we stay fail-closed and do
+    NOT count, exactly as the original resolver intended. Falling back in those
+    cases would let a body-scanned family silently override a deliberate block.
     """
     identity = _resolve_model_review_identity(body)
     if _known_model_reviewer_id(identity.as_packet_fields()):
+        return identity
+
+    # Only the benign "heading named no model" failure is eligible for the
+    # body-family fallback. Any other count-blocker is a real signal that the
+    # original resolver intentionally refused to count.
+    blockers = {
+        problem for problem in identity.identity_problems if problem in IDENTITY_COUNT_BLOCKERS
+    }
+    if blockers - {"unknown_surface_reviewer"}:
         return identity
 
     family = _model_family_from_body(body)

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -2990,6 +2990,64 @@ def _resolve_model_review_identity(text: str) -> ModelReviewIdentity:
     )
 
 
+def _model_family_from_body(body: str) -> str:
+    """Resolve a known model family from a ``Model family:`` line anywhere.
+
+    The structured-metadata reader (:func:`_structured_identity_metadata`) only
+    inspects the lines immediately following the first heading. Dogfood comments
+    in the wild disclose the model family in a ``Model family: <name>`` bullet
+    that may appear lower in the body — or under a plain
+    ``## Focused adversarial dogfood`` heading that names no model. Scan the full
+    body for such a line and normalize it to a canonical family. Returns ``""``
+    when no recognizable family is disclosed (fail-closed: no phantom inflation).
+    """
+    for line in str(body).splitlines():
+        stripped = line.strip()
+        if stripped.startswith("-"):
+            stripped = stripped[1:].strip()
+        label, sep, value = stripped.partition(":")
+        if not sep:
+            continue
+        normalized_label = label.strip().strip("*").strip().lower()
+        if normalized_label != "model family":
+            continue
+        candidate = value.strip().strip("*").strip().strip("`")
+        family = _normalize_model_family(candidate)
+        if family:
+            return family
+    return ""
+
+
+def _resolve_dogfood_identity(body: str) -> ModelReviewIdentity:
+    """Resolve dogfood-comment identity, allowing a body-named model family.
+
+    Starts from the shared :func:`_resolve_model_review_identity` (heading +
+    post-heading structured metadata). When that yields a countable model
+    reviewer, it is returned unchanged. Otherwise — e.g. a plain
+    ``## Focused adversarial dogfood`` heading whose body still discloses a
+    ``Model family:`` line — fall back to a full-body scan and, if a known
+    family is found, synthesize a countable identity. This mirrors how the
+    model-review-signal recognizer trusts the disclosed model family rather
+    than the heading, keeping the two recognizers consistent.
+    """
+    identity = _resolve_model_review_identity(body)
+    if _known_model_reviewer_id(identity.as_packet_fields()):
+        return identity
+
+    family = _model_family_from_body(body)
+    if not family:
+        return identity
+
+    metadata = _structured_identity_metadata(body, _first_heading_candidate(body)[1])
+    model_id = metadata.get("model id", "")
+    return ModelReviewIdentity(
+        surface_reviewer_id=family,
+        model_family=family,
+        model_id=model_id,
+        identity_source="dogfood_body_model_family",
+    )
+
+
 def _dogfood_evidence_from_comments(
     comments: list[Any],
     *,
@@ -3003,6 +3061,12 @@ def _dogfood_evidence_from_comments(
     comments whose first heading names a known surface but whose metadata
     is missing or conflicted remain visible in the evidence list with
     ``identity_problems``; counting remains fail-closed.
+
+    Identity is resolved via :func:`_resolve_dogfood_identity`, which accepts a
+    model family disclosed anywhere in the body (e.g. a ``Model family: claude``
+    line under a plain ``## Focused adversarial dogfood`` heading), not only one
+    named in the first heading. The head-grounding and github-actions exclusions
+    below are preserved unchanged.
     """
     evidence: list[dict[str, Any]] = []
     for comment in comments:
@@ -3016,7 +3080,7 @@ def _dogfood_evidence_from_comments(
             token in lower for token in ("dogfood", "adversarial", "cross-author", "recheck")
         ):
             continue
-        identity = _resolve_model_review_identity(body)
+        identity = _resolve_dogfood_identity(body)
         if identity.surface_reviewer_id == "unknown_model_reviewer":
             continue
         author_payload = comment.get("author")

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -1868,6 +1868,114 @@ class TestModelReviewQuorum:
         assert quorum["dogfood_evidence"] == []
         assert quorum["counted_reviewer_ids"] == []
 
+    def test_dogfood_heading_body_family_conflict_is_not_counted(self) -> None:
+        """Finding 1 (fail-closed bypass): when the heading names one family and
+        post-heading metadata names a *conflicting* family, the original
+        resolver blocks the comment with ``heading_model_family_conflict``. The
+        body-family fallback must NOT override that block — the comment stays
+        uncounted."""
+        from aragora.cli.commands.review_queue import _resolve_dogfood_identity
+
+        body = (
+            "## Claude focused adversarial dogfood\n\n"
+            "**Reviewer harness:** claude-code\n"
+            "**Model family:** openai\n"  # conflicts with the heading's "claude"
+            "**Model id:** gpt-5-codex\n"
+            "**Receipt artifact:** /tmp/r.md\n\n"
+            "6/6 cases pass."
+        )
+        identity = _resolve_dogfood_identity(body)
+        assert "heading_model_family_conflict" in identity.identity_problems
+        assert identity.identity_source != "dogfood_body_model_family"
+
+        files = ["aragora/agents/router.py"]  # Tier 1
+        pr = _make_pr(files=files)
+        pr["comments"] = [{"author": {"login": "an0mium"}, "body": body}]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=files,
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+        )
+        assert quorum["counted_reviewer_ids"] == []
+
+    def test_dogfood_model_family_inside_code_fence_is_not_counted(self) -> None:
+        """Finding 2 (code-fence inflation): a `Model family:` line that appears
+        only inside a fenced code block (e.g. a pasted example template) must NOT
+        be treated as a real disclosure."""
+        from aragora.cli.commands.review_queue import _model_family_from_body
+
+        body = (
+            "## Focused adversarial dogfood\n\n"
+            "Reviewers should disclose their model like this:\n\n"
+            "```\n"
+            "**Model family:** claude\n"
+            "```\n\n"
+            "6/6 cases pass (no real disclosure outside the fence)."
+        )
+        assert _model_family_from_body(body) == ""
+
+        files = ["aragora/agents/router.py"]
+        pr = _make_pr(files=files)
+        pr["comments"] = [{"author": {"login": "an0mium"}, "body": body}]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=files,
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+        )
+        assert quorum["dogfood_evidence"] == []
+        assert quorum["counted_reviewer_ids"] == []
+
+    def test_dogfood_model_family_in_inline_code_span_is_not_counted(self) -> None:
+        """An inline-code back-ticked `Model family:` mention must not be parsed
+        as a disclosure either."""
+        from aragora.cli.commands.review_queue import _model_family_from_body
+
+        body = (
+            "## Focused adversarial dogfood\n\n"
+            "I left a note saying `Model family: claude` as an example only.\n\n"
+            "6/6 cases pass."
+        )
+        assert _model_family_from_body(body) == ""
+
+    def test_dogfood_real_family_line_outside_fence_still_counts(self) -> None:
+        """A genuine `Model family:` disclosure outside any code fence still
+        counts even when an example fence is also present — the fence stripping
+        must not eat the real line."""
+        from aragora.cli.commands.review_queue import _model_family_from_body
+
+        body = (
+            "## Focused adversarial dogfood\n\n"
+            "Template for reference:\n\n"
+            "```\n"
+            "**Model family:** <family>\n"
+            "```\n\n"
+            "**Model family:** claude\n"
+            "**Receipt artifact:** /tmp/r.md\n\n"
+            "6/6 cases pass."
+        )
+        assert _model_family_from_body(body) == "claude"
+
+        files = ["aragora/agents/router.py"]
+        pr = _make_pr(files=files)
+        pr["comments"] = [{"author": {"login": "an0mium"}, "body": body}]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=files,
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+        )
+        assert len(quorum["dogfood_evidence"]) == 1
+        assert quorum["dogfood_evidence"][0]["model_family"] == "claude"
+        assert "claude" in quorum["counted_reviewer_ids"]
+
 
 # --- _parse_pr_number ------------------------------------------------------
 

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -1689,6 +1689,185 @@ class TestModelReviewQuorum:
         assert quorum["dogfood_evidence"] == []
         assert quorum["counted_reviewer_ids"] == []
 
+    # --- Plain-headed dogfood with body-named model (PR #7587 regression) ---
+    #
+    # A dogfood comment headed `## Focused adversarial dogfood` (no `(claude)`
+    # in the heading) but whose BODY discloses the model family must count, so
+    # long as it is head-grounded, not bot-authored, and carries the dogfood
+    # tokens. This mirrors the model-review-signal recognizer, which already
+    # reads the model family from structured metadata rather than the heading.
+
+    def test_plain_headed_dogfood_with_model_family_line_counts(self) -> None:
+        """`## Focused adversarial dogfood` heading + `Model family: claude`
+        line in the body must be recognized as Claude dogfood evidence."""
+        files = ["aragora/agents/router.py"]  # Tier 1
+        pr = _make_pr(files=files)
+        pr["comments"] = [
+            {
+                "author": {"login": "an0mium"},
+                "body": (
+                    "## Focused adversarial dogfood\n\n"
+                    "**Reviewer harness:** claude-code\n"
+                    "**Model family:** claude\n"
+                    "**Model id:** claude-opus-4-8\n"
+                    "**Receipt artifact:** /tmp/claude-dogfood.md\n\n"
+                    "6/6 adversarial cases pass."
+                ),
+            },
+        ]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=files,
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+        )
+        assert len(quorum["dogfood_evidence"]) == 1
+        entry = quorum["dogfood_evidence"][0]
+        assert entry["model_family"] == "claude"
+        assert entry["reviewer_id"] == "claude"
+        assert "claude" in quorum["counted_reviewer_ids"]
+
+    def test_plain_headed_dogfood_with_far_model_family_line_counts(self) -> None:
+        """The `Model family:` disclosure may appear anywhere in the body,
+        not only in the first lines after the heading."""
+        files = ["aragora/agents/router.py"]
+        pr = _make_pr(files=files)
+        pr["comments"] = [
+            {
+                "author": {"login": "an0mium"},
+                "body": (
+                    "## Focused adversarial dogfood\n\n"
+                    + ("Walked each adversarial case manually.\n" * 30)
+                    + "\n**Model family:** openai\n"
+                    + "**Model id:** gpt-5-codex\n"
+                    + "**Receipt artifact:** /tmp/openai-dogfood.md\n"
+                ),
+            },
+        ]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=files,
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+        )
+        assert len(quorum["dogfood_evidence"]) == 1
+        assert quorum["dogfood_evidence"][0]["model_family"] == "openai"
+        assert "openai" in quorum["counted_reviewer_ids"]
+
+    def test_plain_headed_dogfood_without_model_named_still_excluded(self) -> None:
+        """A plain-headed dogfood comment that names NO model anywhere in the
+        body must still be excluded — the relaxation only applies when a known
+        model family is discoverable in the body."""
+        files = ["aragora/agents/router.py"]
+        pr = _make_pr(files=files)
+        pr["comments"] = [
+            {
+                "author": {"login": "an0mium"},
+                "body": "## Focused adversarial dogfood\n\n6/6 cases pass, no model named.",
+            },
+        ]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=files,
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+        )
+        assert quorum["dogfood_evidence"] == []
+        assert quorum["counted_reviewer_ids"] == []
+
+    def test_plain_headed_dogfood_not_head_grounded_still_excluded(self) -> None:
+        """Even with a body-named model, a stale (non-head-grounded) dogfood
+        comment must NOT count — head-grounding is preserved."""
+        head_sha = "abcdef1234567890abcdef1234567890abcdef12"
+        files = ["aragora/agents/router.py"]
+        pr = _make_pr(files=files)
+        pr["headRefOid"] = head_sha
+        pr["commits"] = [{"oid": head_sha, "committedDate": "2026-04-28T20:00:00Z"}]
+        pr["comments"] = [
+            {
+                "author": {"login": "an0mium"},
+                # Posted BEFORE head commit and does not cite the head SHA.
+                "createdAt": "2026-04-28T18:00:00Z",
+                "body": (
+                    "## Focused adversarial dogfood\n\n"
+                    "**Model family:** claude\n"
+                    "**Model id:** claude-opus-4-8\n"
+                    "**Receipt artifact:** /tmp/r.md\n\n"
+                    "6/6 cases pass."
+                ),
+            },
+        ]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=files,
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+        )
+        assert quorum["dogfood_evidence"] == []
+        assert quorum["counted_reviewer_ids"] == []
+
+    def test_plain_headed_dogfood_from_github_actions_still_excluded(self) -> None:
+        """Even with a body-named model, a github-actions-authored dogfood
+        comment must NOT count — the bot exclusion is preserved."""
+        files = ["aragora/agents/router.py"]
+        pr = _make_pr(files=files)
+        pr["comments"] = [
+            {
+                "author": {"login": "github-actions[bot]"},
+                "body": (
+                    "## Focused adversarial dogfood\n\n"
+                    "**Model family:** claude\n"
+                    "**Model id:** claude-opus-4-8\n"
+                    "**Receipt artifact:** /tmp/r.md\n\n"
+                    "6/6 cases pass."
+                ),
+            },
+        ]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=files,
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+        )
+        assert quorum["dogfood_evidence"] == []
+        assert quorum["counted_reviewer_ids"] == []
+
+    def test_plain_headed_dogfood_with_unknown_model_family_excluded(self) -> None:
+        """A `Model family:` line that names something we cannot normalize to a
+        known family must NOT count (no phantom inflation)."""
+        files = ["aragora/agents/router.py"]
+        pr = _make_pr(files=files)
+        pr["comments"] = [
+            {
+                "author": {"login": "an0mium"},
+                "body": (
+                    "## Focused adversarial dogfood\n\n"
+                    "**Model family:** acme-frontier-9000\n\n"
+                    "6/6 cases pass."
+                ),
+            },
+        ]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=files,
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+        )
+        assert quorum["dogfood_evidence"] == []
+        assert quorum["counted_reviewer_ids"] == []
+
 
 # --- _parse_pr_number ------------------------------------------------------
 


### PR DESCRIPTION
## Root cause (verified)

Two independent defects make the required **`aragora-merge-quorum`** check flap red and stall otherwise-ready PRs:

1. **Self-cancel race.** `.github/workflows/aragora-merge-quorum.yml` set `concurrency.cancel-in-progress: true` with group `aragora-merge-quorum-<pr-number>`. When two triggers fire for the same PR (e.g. `synchronize` + `reopened`, or two rapid pushes), the newer run cancels the older one. A **cancelled** run reports a `cancelled` conclusion, which GitHub surfaces as a **red required check** — blocking the PR until a human manually reruns and happens to win a clean green window with no overlapping trigger.

2. **Brittle dogfood recognition.** `aragora/cli/commands/review_queue.py :: _dogfood_evidence_from_comments` inferred the reviewer model **only from the comment's first markdown heading**. A dogfood comment headed `## Focused adversarial dogfood` (without `(claude)` in the heading) failed to count as dogfood evidence even though its body named the model — e.g. a `Model family: claude` line. This stalled **PR #7587** until a corrected comment was posted by hand.

## Changes

### 1. Workflow — `cancel-in-progress: false`
Flip the concurrency cancel behavior so concurrent runs run to completion instead of cancelling each other into a red status. This matches the repo's existing precedent of setting `cancel-in-progress: false` on its other non-required workflows to "stop the doom loop." **The quorum's pass/fail criteria are unchanged** — only the concurrency cancel behavior. GitHub still evaluates the latest completed run per head SHA, so the gate is not weakened.

### 2. Dogfood recognition — full-body model inference
New helpers `_model_family_from_body` and `_resolve_dogfood_identity`. When the first heading names no model, the recognizer falls back to a **full-body `Model family:` scan** and, if a known/normalizable family is found, synthesizes a countable identity. This mirrors how the model-review-signal and review-object recognizers already trust disclosed model-family metadata over the heading, keeping the recognizers consistent.

**All existing safety filters are preserved unchanged:**
- head-grounding (`_is_comment_grounded_on_head`) — stale comments still excluded;
- github-actions author exclusion;
- dogfood-token requirement (`dogfood` / `adversarial` / `cross-author` / `recheck`);
- fail-closed on unknown or unnormalizable model families (no phantom inflation).

## Tests (TDD)
Added to `tests/cli/commands/test_review_queue.py`:
- ✅ plain-headed `## Focused adversarial dogfood` + `Model family: claude` line → **counts** as Claude dogfood;
- ✅ `Model family:` line far down the body (beyond the post-heading window) → **counts**;
- ✅ plain-headed comment with no model named anywhere → **excluded**;
- ✅ body-named model but **not head-grounded** → **excluded**;
- ✅ body-named model but **github-actions** author → **excluded**;
- ✅ `Model family:` naming an unnormalizable family → **excluded**.

The 2 "should-count" tests were written failing first, then made green by the implementation; the 4 negative tests passed before and after (proving the safety filters are intact).

**Test results:** `tests/cli/commands/test_review_queue.py` → **188 passed**. Settlement/auto-merge regression set (`test_settle_one_pr`, `test_settle_tier4_pr`, `test_auto_merge_bucket_a`, `test_settlement_followup`, `test_parser_lazy_review_pr`) → **181 passed**. Ruff clean. YAML parses (`cancel-in-progress = False`).

## Tier-4 / merge-authority self-modification — DRAFT ONLY
Both files are governance surfaces under `docs/REVIEW_AUTHORITY_PRINCIPLES.md`:
- `.github/workflows/aragora-merge-quorum.yml` is a **Tier-4** workflow surface;
- `aragora/cli/commands/review_queue.py` is explicitly elevated to **Tier-4** (merge-authority self-modification) in its own `TIER_4_PREFIXES`.

This PR is intentionally a **DRAFT**. It must **not** be marked ready or merged without careful operator review and a **claude + codex model quorum + head-grounded dogfood + required-green** settlement at the exact reviewed head SHA.

## Recommended follow-up (NOT done here)
To eliminate the rerun race entirely so no human ever has to win a green window:
1. Add an `issue_comment` trigger to `aragora-merge-quorum.yml` so that **posting evidence auto-re-evaluates** the quorum (latching), instead of relying on a push/`synchronize` to re-run; and/or
2. Make the required status **latch to success** once `2/2 model signals + head-grounded dogfood + required-green` is achieved at an exact head SHA, so a later unrelated re-trigger cannot flip a satisfied PR back to red.

Both are larger governance changes and deserve their own Tier-4 review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)