### PR TITLE
fix(live): update dompurify lockfile for security audit

### DIFF
--- a/aragora/live/package-lock.json
+++ b/aragora/live/package-lock.json
@@ -6062,9 +6062,9 @@
       "peer": true
     },
     "node_modules/dompurify": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.4.tgz",
-      "integrity": "sha512-r8K7KGKEcztXfA/nfabSYB2hg9tDphORJTdf8xprN/luSLGmNhOBN8dm1/SYjqLLet6YUFEXOcrdTuwryp/Bew==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.7.tgz",
+      "integrity": "sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"


### PR DESCRIPTION
## Summary

Updates the `aragora/live` lockfile so the production DOMPurify dependency resolves from `3.4.4` to `3.4.7` while keeping the declared dependency range unchanged.

## Why

GitHub Actions Security Gate currently reports high-severity advisory `GHSA-87xg-pxx2-7hvx` for `dompurify@3.4.4`. The minimal lockfile refresh clears the high/critical production audit gate without changing application code.

## Validation

- `cd aragora/live && npm audit fix --package-lock-only --omit=dev`
- `cd aragora/live && npm audit --omit=dev --audit-level=high --package-lock-only --json` -> `high=0`, `critical=0`, `total=0`
- `cd aragora/live && npm install --package-lock-only --ignore-scripts`
- `python3 -m json.tool aragora/live/package-lock.json >/dev/null`
- `git diff --check`

Draft until the normal review/queue process catches up.
