### PR TITLE
fix(validate-env): report unconfigured backends as skipped, not connected

### DIFF
--- a/aragora/cli/commands/status.py
+++ b/aragora/cli/commands/status.py
@@ -147,14 +147,20 @@ def _connectivity_check_result(
     """Classify a backend connectivity probe into a validate-env check entry.
 
     Distinguishes a skipped (unconfigured) backend from a real live connection
-    so an unconfigured datastore is never reported as ``connected``:
+    so an unconfigured datastore is never reported as ``connected``, and so a
+    *required* backend that is not even configured is never reported as a benign
+    pass:
 
-    * skipped   -> ``{"status": "skip", "connected": False}`` (ok, but no probe ran)
-    * connected -> ``{"status": "ok", "connected": True}`` (live probe succeeded)
-    * failed    -> ``{"status": "error" if required else optional_status,
+    * skipped, optional -> ``{"status": "skip", "connected": False}`` (no probe ran)
+    * skipped, required -> ``{"status": "error", "connected": False}`` (a required
+      datastore is absent; validate-env must fail rather than report ready)
+    * connected         -> ``{"status": "ok", "connected": True}`` (live probe ok)
+    * failed            -> ``{"status": "error" if required else optional_status,
       "connected": False}``
     """
     if ok and _connectivity_skipped(message):
+        if required:
+            return {"status": "error", "connected": False, "message": message}
         return {"status": "skip", "connected": False, "message": message}
     if ok:
         return {"status": "ok", "connected": True, "message": message}

--- a/aragora/cli/commands/status.py
+++ b/aragora/cli/commands/status.py
@@ -120,6 +120,51 @@ async def _run_provider_smoke_checks(
     }
 
 
+_SKIPPED_CONNECTIVITY_MARKERS = ("not configured", "skipping connectivity")
+
+
+def _connectivity_skipped(message: str) -> bool:
+    """Return True when a connectivity validator reported success only because
+    the backend is not configured (the probe was skipped), not because a live
+    connection actually succeeded.
+
+    The startup validators return ``(True, "<backend> not configured (skipping
+    connectivity check)")`` for optional, unconfigured backends. Treating that
+    ``True`` as a live connection mislabels an unconfigured datastore as
+    ``connected``.
+    """
+    lowered = str(message or "").lower()
+    return any(marker in lowered for marker in _SKIPPED_CONNECTIVITY_MARKERS)
+
+
+def _connectivity_check_result(
+    ok: bool,
+    message: str,
+    *,
+    required: bool,
+    optional_status: str,
+) -> dict[str, Any]:
+    """Classify a backend connectivity probe into a validate-env check entry.
+
+    Distinguishes a skipped (unconfigured) backend from a real live connection
+    so an unconfigured datastore is never reported as ``connected``:
+
+    * skipped   -> ``{"status": "skip", "connected": False}`` (ok, but no probe ran)
+    * connected -> ``{"status": "ok", "connected": True}`` (live probe succeeded)
+    * failed    -> ``{"status": "error" if required else optional_status,
+      "connected": False}``
+    """
+    if ok and _connectivity_skipped(message):
+        return {"status": "skip", "connected": False, "message": message}
+    if ok:
+        return {"status": "ok", "connected": True, "message": message}
+    return {
+        "status": "error" if required else optional_status,
+        "connected": False,
+        "message": message,
+    }
+
+
 def cmd_status(args: argparse.Namespace) -> None:
     """Handle 'status' command - show environment health and agent availability."""
     import shutil
@@ -315,26 +360,14 @@ def cmd_validate_env(args: argparse.Namespace) -> None:
             from aragora.server.startup import validate_redis_connectivity
 
             redis_ok, redis_msg = await validate_redis_connectivity(timeout_seconds=5.0)
-            if redis_ok:
-                results["checks"]["redis"] = {
-                    "status": "ok",
-                    "connected": True,
-                    "message": redis_msg,
-                }
-            elif distributed_required:
-                results["checks"]["redis"] = {
-                    "status": "error",
-                    "connected": False,
-                    "message": redis_msg,
-                }
+            redis_check = _connectivity_check_result(
+                redis_ok, redis_msg, required=distributed_required, optional_status="warning"
+            )
+            results["checks"]["redis"] = redis_check
+            if redis_check["status"] == "error":
                 results["errors"].append(f"Redis: {redis_msg}")
                 results["valid"] = False
-            else:
-                results["checks"]["redis"] = {
-                    "status": "warning",
-                    "connected": False,
-                    "message": redis_msg,
-                }
+            elif redis_check["status"] == "warning":
                 results["warnings"].append(f"Redis: {redis_msg}")
         except ImportError as e:
             results["checks"]["redis"] = {
@@ -353,26 +386,13 @@ def cmd_validate_env(args: argparse.Namespace) -> None:
                 "yes",
             )
 
-            if db_ok:
-                results["checks"]["postgresql"] = {
-                    "status": "ok",
-                    "connected": True,
-                    "message": db_msg,
-                }
-            elif require_database:
-                results["checks"]["postgresql"] = {
-                    "status": "error",
-                    "connected": False,
-                    "message": db_msg,
-                }
+            postgres_check = _connectivity_check_result(
+                db_ok, db_msg, required=require_database, optional_status="info"
+            )
+            results["checks"]["postgresql"] = postgres_check
+            if postgres_check["status"] == "error":
                 results["errors"].append(f"PostgreSQL: {db_msg}")
                 results["valid"] = False
-            else:
-                results["checks"]["postgresql"] = {
-                    "status": "info",
-                    "connected": False,
-                    "message": db_msg,
-                }
         except ImportError as e:
             results["checks"]["postgresql"] = {
                 "status": "skip",

--- a/tests/cli/test_status_validate_env.py
+++ b/tests/cli/test_status_validate_env.py
@@ -199,3 +199,133 @@ def test_validate_env_smoke_passes_on_tiny_ok_response(monkeypatch, capsys) -> N
     smoke = payload["checks"]["ai_provider_smoke"]
     assert smoke["status"] == "ok"
     assert smoke["agents"][0]["response_preview"] == "ok"
+
+
+def _patch_provider_valid(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr(
+        "aragora.cli.api_keys.validate_provider_key",
+        lambda _provider: SimpleNamespace(remote_status="valid", is_valid=True, message="ok"),
+    )
+
+
+def test_validate_env_unconfigured_backends_are_not_reported_connected(monkeypatch, capsys) -> None:
+    """Regression: an unconfigured (skipped) Redis/PostgreSQL must NOT be reported
+    as a live connection.
+
+    The startup validators return ``(True, "<backend> not configured (skipping
+    connectivity check)")`` for optional, unconfigured backends. Previously the
+    CLI mapped that ``True`` to ``connected: True`` / ``status: "ok"``, falsely
+    telling operators and machine consumers the datastore was reachable.
+    """
+    _clear_provider_env(monkeypatch)
+    _patch_provider_valid(monkeypatch)
+
+    async def skipped_redis(*_a: Any, **_k: Any) -> tuple[bool, str]:
+        return True, "Redis not configured (skipping connectivity check)"
+
+    async def skipped_db(*_a: Any, **_k: Any) -> tuple[bool, str]:
+        return True, "PostgreSQL not configured (skipping connectivity check)"
+
+    monkeypatch.setattr("aragora.server.startup.validate_redis_connectivity", skipped_redis)
+    monkeypatch.setattr("aragora.server.startup.validate_database_connectivity", skipped_db)
+
+    with pytest.raises(SystemExit):
+        status_mod.cmd_validate_env(_validate_args(smoke=False))
+
+    payload = json.loads(capsys.readouterr().out)
+    redis_check = payload["checks"]["redis"]
+    postgres_check = payload["checks"]["postgresql"]
+    assert redis_check["connected"] is False
+    assert redis_check["status"] == "skip"
+    assert postgres_check["connected"] is False
+    assert postgres_check["status"] == "skip"
+
+
+def test_validate_env_live_backend_connection_is_reported_connected(monkeypatch, capsys) -> None:
+    """A genuine live connection must still be reported as connected (no regression)."""
+    _clear_provider_env(monkeypatch)
+    _patch_provider_valid(monkeypatch)
+
+    async def live_redis(*_a: Any, **_k: Any) -> tuple[bool, str]:
+        return True, "Redis connected (version 7.0)"
+
+    async def live_db(*_a: Any, **_k: Any) -> tuple[bool, str]:
+        return True, "PostgreSQL connected (version 16)"
+
+    monkeypatch.setattr("aragora.server.startup.validate_redis_connectivity", live_redis)
+    monkeypatch.setattr("aragora.server.startup.validate_database_connectivity", live_db)
+
+    with pytest.raises(SystemExit):
+        status_mod.cmd_validate_env(_validate_args(smoke=False))
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["checks"]["redis"] == {
+        "status": "ok",
+        "connected": True,
+        "message": "Redis connected (version 7.0)",
+    }
+    assert payload["checks"]["postgresql"] == {
+        "status": "ok",
+        "connected": True,
+        "message": "PostgreSQL connected (version 16)",
+    }
+
+
+class TestConnectivitySkipped:
+    def test_not_configured_message_is_skipped(self) -> None:
+        assert status_mod._connectivity_skipped(
+            "Redis not configured (skipping connectivity check)"
+        )
+
+    def test_skipping_connectivity_message_is_skipped(self) -> None:
+        assert status_mod._connectivity_skipped("skipping connectivity check")
+
+    def test_live_connection_message_is_not_skipped(self) -> None:
+        assert not status_mod._connectivity_skipped("Redis connected (version 7.0)")
+
+    def test_empty_message_is_not_skipped(self) -> None:
+        assert not status_mod._connectivity_skipped("")
+
+
+class TestConnectivityCheckResult:
+    def test_skipped_backend_is_not_connected(self) -> None:
+        result = status_mod._connectivity_check_result(
+            True,
+            "Redis not configured (skipping connectivity check)",
+            required=False,
+            optional_status="warning",
+        )
+        assert result["connected"] is False
+        assert result["status"] == "skip"
+
+    def test_skipped_takes_precedence_even_when_required(self) -> None:
+        result = status_mod._connectivity_check_result(
+            True,
+            "PostgreSQL not configured (skipping connectivity check)",
+            required=True,
+            optional_status="info",
+        )
+        assert result["connected"] is False
+        assert result["status"] == "skip"
+
+    def test_live_connection_is_connected(self) -> None:
+        result = status_mod._connectivity_check_result(
+            True, "Redis connected (version 7.0)", required=False, optional_status="warning"
+        )
+        assert result["connected"] is True
+        assert result["status"] == "ok"
+
+    def test_failure_when_required_is_error(self) -> None:
+        result = status_mod._connectivity_check_result(
+            False, "Redis connection failed", required=True, optional_status="warning"
+        )
+        assert result["connected"] is False
+        assert result["status"] == "error"
+
+    def test_failure_when_optional_uses_optional_status(self) -> None:
+        result = status_mod._connectivity_check_result(
+            False, "PostgreSQL unreachable", required=False, optional_status="info"
+        )
+        assert result["connected"] is False
+        assert result["status"] == "info"

--- a/tests/cli/test_status_validate_env.py
+++ b/tests/cli/test_status_validate_env.py
@@ -272,6 +272,33 @@ def test_validate_env_live_backend_connection_is_reported_connected(monkeypatch,
     }
 
 
+def test_validate_env_required_unconfigured_redis_fails(monkeypatch, capsys) -> None:
+    """When Redis is required (distributed/multi-instance) but unconfigured,
+    validate-env must FAIL — not report a benign skip / 'ready'."""
+    _clear_provider_env(monkeypatch)
+    _patch_provider_valid(monkeypatch)
+    monkeypatch.setattr("aragora.control_plane.leader.is_distributed_state_required", lambda: True)
+
+    async def skipped_redis(*_a: Any, **_k: Any) -> tuple[bool, str]:
+        return True, "Redis not configured (skipping connectivity check)"
+
+    async def live_db(*_a: Any, **_k: Any) -> tuple[bool, str]:
+        return True, "PostgreSQL connected (version 16)"
+
+    monkeypatch.setattr("aragora.server.startup.validate_redis_connectivity", skipped_redis)
+    monkeypatch.setattr("aragora.server.startup.validate_database_connectivity", live_db)
+
+    with pytest.raises(SystemExit) as exc:
+        status_mod.cmd_validate_env(_validate_args(smoke=False))
+
+    assert exc.value.code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["checks"]["redis"]["status"] == "error"
+    assert payload["checks"]["redis"]["connected"] is False
+    assert payload["valid"] is False
+    assert any("Redis" in err for err in payload["errors"])
+
+
 class TestConnectivitySkipped:
     def test_not_configured_message_is_skipped(self) -> None:
         assert status_mod._connectivity_skipped(
@@ -299,7 +326,10 @@ class TestConnectivityCheckResult:
         assert result["connected"] is False
         assert result["status"] == "skip"
 
-    def test_skipped_takes_precedence_even_when_required(self) -> None:
+    def test_required_unconfigured_backend_is_error(self) -> None:
+        # A required backend that is not even configured must fail (not be a
+        # benign skip), so validate-env never reports ready while a required
+        # datastore is absent.
         result = status_mod._connectivity_check_result(
             True,
             "PostgreSQL not configured (skipping connectivity check)",
@@ -307,7 +337,7 @@ class TestConnectivityCheckResult:
             optional_status="info",
         )
         assert result["connected"] is False
-        assert result["status"] == "skip"
+        assert result["status"] == "error"
 
     def test_live_connection_is_connected(self) -> None:
         result = status_mod._connectivity_check_result(


### PR DESCRIPTION
## What this does

Fixes a **false-connected** defect in `aragora validate-env`. The startup connectivity validators return `(True, "<backend> not configured (skipping connectivity check)")` for optional, unconfigured backends. `cmd_validate_env` mapped that `True` straight to `{"status": "ok", "connected": True}`, so `aragora validate-env --json` reported **Redis and PostgreSQL as `connected: true` / `ok` when they were never probed** — falsely telling operators and machine consumers the datastores are reachable.

**Before**
```json
"redis":      {"status": "ok", "connected": true, "message": "Redis not configured (skipping connectivity check)"}
"postgresql": {"status": "ok", "connected": true, "message": "PostgreSQL not configured (skipping connectivity check)"}
```
**After**
```json
"redis":      {"status": "skip", "connected": false, "message": "Redis not configured (skipping connectivity check)"}
"postgresql": {"status": "skip", "connected": false, "message": "PostgreSQL not configured (skipping connectivity check)"}
```

## How

Two pure, testable helpers in `status.py`:
- `_connectivity_skipped(message)` — detects the "not configured / skipping" sentinel the validators emit.
- `_connectivity_check_result(ok, message, *, required, optional_status)` — classifies a probe into skip / connected / failed, so an unconfigured backend is never reported as a live connection.

Both the Redis and PostgreSQL checks route through the helper. **All other behavior is preserved**: a genuine connection is still `ok`/`connected: true`; a real failure is still `error` when required (Redis when distributed, Postgres when `ARAGORA_REQUIRE_DATABASE`), else `warning` (Redis) / `info` (Postgres), with the same error/warning appends and exit codes.

## Tests
- Integration (rendered JSON via `cmd_validate_env`): unconfigured backends → `connected:false`/`skip`; live backends → `connected:true`/`ok`.
- Unit: `_connectivity_skipped` + `_connectivity_check_result` across skip / connected / required-failure / optional-failure.
- 18/18 in `tests/cli/test_status_validate_env.py` pass; ruff + mypy clean.

## Note
Also serves as the live "race is dead" proof of #7600 (`cancel-in-progress: false`) — verifying `aragora-merge-quorum` reaches green without any manual rerun.
