### PR TITLE
fix(validate): stop fabricated DeepSeek keys passing as verified; document validate command

### DIFF
--- a/aragora/cli/api_keys.py
+++ b/aragora/cli/api_keys.py
@@ -67,7 +67,15 @@ class ProviderStatus:
 
 @dataclass(frozen=True)
 class ValidationReport:
-    """Validation result for a provider key."""
+    """Validation result for a provider key.
+
+    ``is_valid`` is reserved for keys that have been *verified* against the
+    provider (``remote_status == "valid"``). A key whose live validation could
+    not be performed (``remote_status == "skipped"``) is reported as
+    ``unverified`` — present but not proven usable — and must NOT be rendered as
+    a verified pass. Only ``remote_status in {"invalid", "error"}`` represents a
+    failure.
+    """
 
     provider: str
     display_name: str
@@ -79,6 +87,10 @@ class ValidationReport:
     remote_status: str
     is_valid: bool
     message: str
+    # True when the key is configured and format-valid but live validation could
+    # not actually verify it (e.g. no network probe implemented/available). Such
+    # a key is "present (unverified)", distinct from a verified pass.
+    unverified: bool = False
 
 
 PROVIDERS: dict[str, ProviderSpec] = {
@@ -315,7 +327,12 @@ def validate_provider_key(provider: str) -> ValidationReport:
         )
 
     remote_status, remote_message = _probe_provider_key(spec, value)
-    is_valid = remote_status in {"valid", "skipped"}
+    # Only a successful live probe ("valid") counts as a verified pass. A
+    # "skipped" probe means we could not actually confirm the key — it is
+    # present but unverified, NOT a green pass (was previously conflated with
+    # "valid", letting fabricated keys render as passing checks).
+    is_valid = remote_status == "valid"
+    unverified = remote_status == "skipped"
 
     return ValidationReport(
         provider=spec.name,
@@ -328,6 +345,7 @@ def validate_provider_key(provider: str) -> ValidationReport:
         remote_status=remote_status,
         is_valid=is_valid,
         message=remote_message,
+        unverified=unverified,
     )
 
 
@@ -609,10 +627,14 @@ def _probe_provider_key(spec: ProviderSpec, value: str) -> tuple[str, str]:
             return _status_from_response(response)
 
         if spec.name == "deepseek":
-            return (
-                "skipped",
-                "DeepSeek keys are accepted for CLI/OpenRouter workflows; live validation is not implemented",
+            # DeepSeek exposes an OpenAI-compatible models endpoint; a real
+            # listing call verifies the key instead of rubber-stamping it.
+            response = safe_get(
+                "https://api.deepseek.com/v1/models",
+                headers={"Authorization": f"Bearer {value}"},
+                timeout=10.0,
             )
+            return _status_from_response(response)
 
         return "skipped", "No live validator implemented for this provider"
     except (OSError, ConnectionError, TimeoutError, RuntimeError) as exc:

--- a/aragora/cli/doctor.py
+++ b/aragora/cli/doctor.py
@@ -202,7 +202,7 @@ def check_api_keys(validate_live: bool = False) -> list[HealthCheck]:
         env_label = "/".join(provider.checked_env_vars)
         if provider.configured:
             status = "configured"
-            ok = True
+            ok: bool | None = True
             if validate_live:
                 from aragora.cli.api_keys import get_supported_provider_names, validate_provider_key
 
@@ -210,12 +210,21 @@ def check_api_keys(validate_live: bool = False) -> list[HealthCheck]:
                 if validation_provider in set(get_supported_provider_names()):
                     validation_report = validate_provider_key(validation_provider)
                     status = f"{status}; live {validation_report.remote_status}"
-                    if not validation_report.is_valid:
+                    if getattr(validation_report, "unverified", False):
+                        # Key is present and format-valid but could not be
+                        # verified live. Do NOT render as a green pass — report
+                        # it as optional/unverified so a fabricated or unusable
+                        # key is never counted as "ready".
+                        status = f"{status} (present, unverified)"
+                        ok = None
+                    elif not validation_report.is_valid:
                         status = f"{status}: {validation_report.message}"
                         invalid_providers.append(provider.provider)
                         ok = False
                 else:
-                    status = f"{status}; live skipped"
+                    # No live validator for this provider: present but unverified.
+                    status = f"{status}; live skipped (present, unverified)"
+                    ok = None
             checks.append((env_label, status, ok))
         else:
             checks.append((env_label, "not set", None))

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -1243,7 +1243,16 @@ def _add_doctor_parser(subparsers) -> None:
 def _add_validate_parser(subparsers) -> None:
     """Add the 'validate' subcommand parser."""
     validate_parser = subparsers.add_parser(
-        "validate", help="Validate API keys by making test calls"
+        "validate",
+        help="Run a full health check, including live API-key validation",
+        description=(
+            "Run Aragora's health check (Environment, Packages, API Keys, "
+            "Storage, and Server sections) with live API-key validation enabled. "
+            "Configured provider keys are probed against the provider where "
+            "possible; a key that cannot be verified is reported as present but "
+            "unverified rather than as a passing check. Exits 0 only when all "
+            "checks pass."
+        ),
     )
     validate_parser.set_defaults(func=_lazy("aragora.cli.commands.status", "cmd_validate"))
 

--- a/tests/cli/test_api_key_command.py
+++ b/tests/cli/test_api_key_command.py
@@ -13,6 +13,7 @@ from aragora.cli.api_keys import (
     get_provider_key,
     hydrate_env_from_secure_store,
     list_provider_statuses,
+    validate_provider_key,
 )
 from aragora.cli.commands.api_key import cmd_api_key
 from aragora.cli.parser import build_parser
@@ -50,6 +51,31 @@ class TestApiKeyParser:
         assert args.command == "api-key"
         assert args.api_key_command == "validate"
         assert args.provider == "anthropic"
+
+
+class TestValidateParserHelp:
+    """The top-level ``validate`` command must document what it actually does."""
+
+    def _validate_subparser(self):
+        parser = build_parser()
+        # argparse stores subparsers under the _SubParsersAction choices.
+        for action in parser._actions:  # noqa: SLF001 - introspecting argparse
+            choices = getattr(action, "choices", None)
+            if choices and "validate" in choices:
+                return choices["validate"]
+        raise AssertionError("validate subparser not found")
+
+    def test_validate_has_a_description(self):
+        subparser = self._validate_subparser()
+        assert subparser.description, "validate subparser must set a description"
+        # Description should mention the actual behavior (full health check).
+        assert "health" in subparser.description.lower()
+
+    def test_validate_help_output_includes_description(self, capsys):
+        subparser = self._validate_subparser()
+        help_text = subparser.format_help()
+        # The empty-description bug emitted only usage + the -h line.
+        assert "health" in help_text.lower()
 
 
 class TestApiKeyCommands:
@@ -140,6 +166,62 @@ class TestApiKeyCommands:
         assert exc_info.value.code == 1
         output = capsys.readouterr().out
         assert "No API key configured for Mistral" in output
+
+    def test_deepseek_validation_makes_a_real_test_call(self, tmp_path, monkeypatch):
+        """A DeepSeek key must be live-probed, not rubber-stamped as a pass.
+
+        Regression: ``_probe_provider_key`` previously returned ``"skipped"``
+        for DeepSeek with no network call, and ``"skipped"`` was mapped to
+        ``is_valid=True`` — so a fabricated key reported a verified pass.
+        """
+        for key, value in _file_store_env(tmp_path).items():
+            monkeypatch.setenv(key, value)
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-totallyfakekey1234567890abcdef")
+
+        # 200 → key really is valid.
+        ok_response = MagicMock(status_code=200)
+        with patch("aragora.security.safe_http.safe_get", return_value=ok_response) as mock_get:
+            report = validate_provider_key("deepseek")
+
+        # A real test call was made against DeepSeek.
+        mock_get.assert_called_once()
+        assert "deepseek.com" in mock_get.call_args.args[0]
+        assert report.remote_status == "valid"
+        assert report.is_valid is True
+        assert report.unverified is False
+
+    def test_bogus_deepseek_key_is_not_reported_valid(self, tmp_path, monkeypatch):
+        """A fabricated DeepSeek key rejected by the provider must report as
+        invalid (is_valid False), not as a passing/verified check."""
+        for key, value in _file_store_env(tmp_path).items():
+            monkeypatch.setenv(key, value)
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-totallyfakekey1234567890abcdef")
+
+        rejected = MagicMock(status_code=401)
+        with patch("aragora.security.safe_http.safe_get", return_value=rejected):
+            report = validate_provider_key("deepseek")
+
+        assert report.is_valid is False
+        assert report.unverified is False
+        assert report.remote_status == "invalid"
+
+    def test_skipped_remote_status_is_unverified_not_valid(self, tmp_path, monkeypatch):
+        """When live validation genuinely cannot run (probe returns 'skipped'),
+        the key is reported as present-but-unverified, never a verified pass."""
+        for key, value in _file_store_env(tmp_path).items():
+            monkeypatch.setenv(key, value)
+        monkeypatch.setenv("MISTRAL_API_KEY", "sk-mistral-fakekey1234567890")
+
+        with patch(
+            "aragora.cli.api_keys._probe_provider_key",
+            return_value=("skipped", "live validation is unavailable"),
+        ):
+            report = validate_provider_key("mistral")
+
+        assert report.remote_status == "skipped"
+        # The crux: skipped must NOT be a verified pass.
+        assert report.is_valid is False
+        assert report.unverified is True
 
     def test_list_provider_statuses_shows_environment_alias(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HOME", str(tmp_path))

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -407,6 +407,68 @@ class TestCheckApiKeys:
         ]
         assert llm_provider == [("LLM Provider", "invalid provider(s): gemini", False)]
 
+    def test_live_validation_unverified_key_is_not_a_green_pass(self, monkeypatch):
+        """A configured key whose live validation is skipped must render as
+        optional/unverified (ok is None), never a green pass (ok is True).
+
+        Regression: a fabricated DeepSeek key previously showed a green
+        ``✓ configured; live skipped`` check counting toward "ready to use".
+        """
+        _clear_provider_env(monkeypatch)
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-totallyfakekey1234567890abcdef")
+
+        def fake_validate_provider_key(provider: str) -> SimpleNamespace:
+            assert provider == "deepseek"
+            return SimpleNamespace(
+                remote_status="skipped",
+                is_valid=False,
+                unverified=True,
+                message="live validation is unavailable",
+            )
+
+        monkeypatch.setattr(
+            "aragora.cli.api_keys.validate_provider_key",
+            fake_validate_provider_key,
+        )
+
+        result = check_api_keys(validate_live=True)
+        deepseek = [item for item in result if item[0] == "DEEPSEEK_API_KEY"]
+
+        assert len(deepseek) == 1
+        label, status, ok = deepseek[0]
+        # Must NOT be a green pass.
+        assert ok is not True
+        # Optional/unverified — yellow circle, not green check, not red X.
+        assert ok is None
+        assert "unverified" in status.lower()
+
+    def test_live_validation_marks_rejected_deepseek_unready(self, monkeypatch):
+        """A bogus DeepSeek key rejected by a real live probe is a failure,
+        not a pass — DeepSeek now makes an actual test call."""
+        _clear_provider_env(monkeypatch)
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-totallyfakekey1234567890abcdef")
+
+        def fake_validate_provider_key(provider: str) -> SimpleNamespace:
+            assert provider == "deepseek"
+            return SimpleNamespace(
+                remote_status="invalid",
+                is_valid=False,
+                unverified=False,
+                message="Provider rejected the API key",
+            )
+
+        monkeypatch.setattr(
+            "aragora.cli.api_keys.validate_provider_key",
+            fake_validate_provider_key,
+        )
+
+        result = check_api_keys(validate_live=True)
+        deepseek = [item for item in result if item[0] == "DEEPSEEK_API_KEY"]
+        llm_provider = [item for item in result if item[0] == "LLM Provider"]
+
+        assert deepseek[0][2] is False
+        assert llm_provider == [("LLM Provider", "invalid provider(s): deepseek", False)]
+
 
 # ===========================================================================
 # Tests: check_storage


### PR DESCRIPTION
## Summary

Fixes the two defects in the `aragora validate` (doctor) CLI lane.

### Defect 1 (medium, TRUST): bogus DeepSeek key reported as a passing green check

**Root cause.** `_probe_provider_key` (api_keys.py) returned `("skipped", ...)` for DeepSeek **unconditionally, with no network call**, and `validate_provider_key` mapped `remote_status in {"valid", "skipped"}` → `is_valid=True`. So an unverified — or outright fabricated — key was conflated with a verified one. In `doctor.check_api_keys` this produced `✓ DEEPSEEK_API_KEY: configured; live skipped` (green), counted toward "passed", and the run exited 0 with "Aragora is ready to use!". The format check only required non-empty/no-whitespace/len≥12, so a 30-char fake string sailed through.

**Fix.**
- Implement a **real** DeepSeek live probe against its OpenAI-compatible `https://api.deepseek.com/v1/models` endpoint — an actual test call, honoring the command's contract.
- `is_valid` now means **verified** (`remote_status == "valid"`) only. A genuinely un-probable key (`remote_status == "skipped"`, e.g. `safe_http` unavailable) is reported via a new `ValidationReport.unverified` field — *present but not proven usable*.
- `doctor.check_api_keys` renders unverified keys as **optional** (yellow ○ "present, unverified"), never a green pass, so they no longer count toward passed/exit-0. A key the provider **rejects** renders red ✗ and fails the run.

### Defect 2 (low, UX): `validate --help` had no description

The validate subparser set only `help=` (no `description=`), so `validate --help` printed just `usage` + `-h`. The registered help also understated the command — it actually runs the **full** doctor health check (Environment/Packages/API Keys/Storage/Server) with an exit code over all checks. Added an accurate `description=` and `help=` to the validate subparser (surgical: only that subparser in the shared `parser.py`).

## Before / After

**`validate --help`**

Before:
```
usage: main.py validate [-h]

-h, --help  show this help message and exit
```
After:
```
usage: main.py validate [-h]

Run Aragora's health check (Environment, Packages, API Keys, Storage, and
Server sections) with live API-key validation enabled. Configured provider
keys are probed against the provider where possible; a key that cannot be
verified is reported as present but unverified rather than as a passing check.
Exits 0 only when all checks pass.
```

**Bogus DeepSeek key** (`DEEPSEEK_API_KEY="sk-totallyfakekey..."`)

Before: `✓ DEEPSEEK_API_KEY: configured; live skipped` · `✓ LLM Provider: configured: deepseek` · Summary `20 passed, 0 failed` · `✓ Aragora is ready to use!` · **exit 0**

After (provider rejects the key via real probe): `✗ DEEPSEEK_API_KEY: configured; live invalid: Provider rejected the API key` · `✗ LLM Provider: invalid provider(s): deepseek` · `✗ Some required checks failed.` · **exit 1**

After (live validation genuinely unavailable): `○ DEEPSEEK_API_KEY: configured; live skipped (present, unverified)` — counted under *optional*, not *passed*.

## Tests (TDD — failing first, then green; all offline-safe)

`tests/cli/test_api_key_command.py`
- `test_deepseek_validation_makes_a_real_test_call` — DeepSeek probes `deepseek.com`, 200 → verified valid.
- `test_bogus_deepseek_key_is_not_reported_valid` — 401 → `is_valid=False`, not a pass.
- `test_skipped_remote_status_is_unverified_not_valid` — `skipped` → `unverified=True`, `is_valid=False`.
- `TestValidateParserHelp::{test_validate_has_a_description, test_validate_help_output_includes_description}`.

`tests/cli/test_doctor.py`
- `test_live_validation_unverified_key_is_not_a_green_pass` — unverified renders `ok is None`, never `True`.
- `test_live_validation_marks_rejected_deepseek_unready` — rejected DeepSeek fails the run.

Verified the 6 new tests fail against the original source and pass with the fix. Full relevant CLI suite: **403 passed**. Mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)