### PR TITLE
fix(ci): keep aragora-merge-quorum from being cancelled by Required Check Priority

### DIFF
--- a/.github/workflows/required-check-priority.yml
+++ b/.github/workflows/required-check-priority.yml
@@ -40,6 +40,13 @@ jobs:
             // Tests plus offline/shadow smoke workflows so PR CI reflects real
             // outcomes instead of looking cancelled after prioritization sweeps.
             const alwaysKeepWorkflowPaths = new Set([
+              // aragora-merge-quorum is a REQUIRED status check. The live
+              // branch-protection read below cannot run under GITHUB_TOKEN (no
+              // administration scope -> 403), so this static keep-list is the
+              // only thing that actually protects required checks from being
+              // cancelled. Omitting the merge-quorum gate let it be cancelled
+              // into a red "cancelled" required status that needed a manual rerun.
+              '.github/workflows/aragora-merge-quorum.yml',
               '.github/workflows/aragora-review-gate.yml',
               '.github/workflows/autopilot-worktree-e2e.yml',
               '.github/workflows/core-suites.yml',
@@ -59,6 +66,7 @@ jobs:
               '.github/workflows/required-check-priority.yml',
             ]);
             const alwaysKeepWorkflowNames = new Set([
+              'Aragora Merge Quorum',
               'Aragora Code Review',
               'Autopilot Worktree E2E',
               'Core Suites (Decision Integrity)',
@@ -77,6 +85,22 @@ jobs:
               'Tests',
               'OpenAPI Spec',
             ]);
+
+            // Fail closed if the static keep-list ever resolves empty (an edit
+            // regression or parse error). The keep-list is the only mechanism
+            // that protects required checks from cancellation, so when it is
+            // empty we cancel nothing this invocation rather than risk
+            // cancelling a required check. This guards a broken keep-list only;
+            // it is intentionally independent of the (best-effort) branch
+            // protection read below.
+            const keepListEmpty =
+              alwaysKeepWorkflowPaths.size === 0 && alwaysKeepWorkflowNames.size === 0;
+            if (keepListEmpty) {
+              core.warning(
+                'Required-check keep-list resolved empty; failing closed and ' +
+                  'cancelling no runs this invocation.'
+              );
+            }
 
             const requiredContexts = new Set();
             try {
@@ -185,6 +209,8 @@ jobs:
                 if (run.head_sha !== headSha) continue;
                 if (run.id === selfRunId) continue;
                 if (run.status !== 'queued' && run.status !== 'in_progress') continue;
+                // Fail closed on a broken (empty) keep-list: cancel nothing.
+                if (keepListEmpty) continue;
                 passConsidered += 1;
 
                 const workflowPath = (run.path || '').split('@')[0];

--- a/.github/workflows/required-check-priority.yml
+++ b/.github/workflows/required-check-priority.yml
@@ -45,7 +45,7 @@ jobs:
               // administration scope -> 403), so this static keep-list is the
               // only thing that actually protects required checks from being
               // cancelled. Omitting the merge-quorum gate let it be cancelled
-              // into a red "cancelled" required status that needed a manual rerun.
+              // into a red cancelled required status that needed a manual rerun.
               '.github/workflows/aragora-merge-quorum.yml',
               '.github/workflows/aragora-review-gate.yml',
               '.github/workflows/autopilot-worktree-e2e.yml',

--- a/scripts/check_required_check_priority_policy.py
+++ b/scripts/check_required_check_priority_policy.py
@@ -18,6 +18,7 @@ class Violation:
 WORKFLOW_PATH = Path(".github/workflows/required-check-priority.yml")
 
 REQUIRED_KEEP_WORKFLOW_PATHS = {
+    ".github/workflows/aragora-merge-quorum.yml",
     ".github/workflows/aragora-review-gate.yml",
     ".github/workflows/autopilot-worktree-e2e.yml",
     ".github/workflows/core-suites.yml",
@@ -38,6 +39,7 @@ REQUIRED_KEEP_WORKFLOW_PATHS = {
 }
 
 REQUIRED_KEEP_WORKFLOW_NAMES = {
+    "Aragora Merge Quorum",
     "Aragora Code Review",
     "Autopilot Worktree E2E",
     "Core Suites (Decision Integrity)",


### PR DESCRIPTION
## The recurring quorum-race, root-caused

This is the durable structural fix for the quorum-gate race that has been hand-won repeatedly. It complements #7600 (`cancel-in-progress: false`), which closed the merge-quorum workflow's *self*-cancel. This PR closes a **second, independent cancel-source**.

### Evidence (from PR #7615's proof run)
The `aragora-merge-quorum` required check went red as `cancelled`. The `Required Check Priority` run log shows exactly why:
```
##[warning]Could not read branch protection for 'main'
  (continuing with static required-workflow keep-list): Resource not accessible by integration
Canceled run 26787173332 (Aragora Merge Quorum)
Sweep 1/4: considered 14 run(s), canceled 1 run(s)
```

### Root cause
`required-check-priority.yml` cancels in-progress PR runs that aren't in its static keep-list. Two layers were supposed to protect required checks:
1. **Static keep-list** — already lists every required workflow (`lint`, `sdk-parity`, `sdk-test`, …) **except `aragora-merge-quorum`** (the lone omission).
2. **Dynamic net** — "keep any run owning a branch-protection required context." This **cannot work under `GITHUB_TOKEN`**: there is no `administration` permission scope, so `getBranchProtection` returns 403 permanently. The static keep-list is the *only* protection actually in effect.

Both layers missed merge-quorum → it was cancelled into a red `cancelled` required status → needed a manual rerun to win a green window.

### Fix (minimal, zero new drift surface)
- Add `aragora-merge-quorum` to **both** `alwaysKeepWorkflowPaths` and `alwaysKeepWorkflowNames` — it joins every other required workflow already protected there.
- **Fail closed only if the keep-list itself ever resolves empty** (an edit/parse regression): cancel nothing that invocation. This is independent of the (best-effort, always-403) branch-protection read — we never disable cancellation on read-failure (that would starve the self-hosted runners).

The `administration:read` and live-read approaches were considered and rejected: `GITHUB_TOKEN` has no `administration` scope (actionlint + GitHub docs confirm), and a PAT/App-token secret would trade a one-time deterministic omission for a fragile, expirable secret on a Tier-4 merge-authority surface.

### Validation
- `actionlint` clean; YAML parses; embedded `github-script` passes `node --check`.
- Reviewed by genuine claude + codex at the exact head, plus an adversarial dogfood (see PR comments).

### Governance
Tier 4 (`.github/workflows/` — merge-authority self-modification). Prepared for explicit exact-head operator settlement; not to be merged unilaterally.
