### PR TITLE
fix(review-health): flag latest boss-loop failures

### DIFF
--- a/aragora/review/health.py
+++ b/aragora/review/health.py
@@ -315,7 +315,10 @@ def _check_status_doc(
     )
 
 
-_CRASH_PATTERN = re.compile(r"ModuleNotFoundError")
+_TRACEBACK_PATTERN = re.compile(r"Traceback \(most recent call last\):")
+_CRASH_PATTERN = re.compile(
+    r"\b(?:AttributeError|ImportError|ModuleNotFoundError|RuntimeError|ValueError|TypeError):"
+)
 _EXIT_OK_PATTERN = re.compile(r"Boss loop exited with status 0")
 _EXIT_FAIL_PATTERN = re.compile(r"Boss loop exited with status 1")
 
@@ -333,27 +336,51 @@ def _check_boss_loop_log(path: Path, warn_h: float, crit_h: float) -> SurfaceChe
     age = _age_hours(mtime, now) if mtime is not None else None
     status = _classify_age(age, warn_h, crit_h) if age is not None else STATUS_AGING
 
+    tracebacks_total = 0
     crashes_total = 0
     exits_ok_total = 0
     exits_fail_total = 0
+    last_terminal_event = ""
+    latest_failure = ""
     try:
         with path.open("r", encoding="utf-8", errors="replace") as handle:
             for line in handle:
-                if _CRASH_PATTERN.search(line):
+                stripped = line.strip()
+                if _TRACEBACK_PATTERN.search(line):
+                    tracebacks_total += 1
+                    last_terminal_event = "traceback"
+                    latest_failure = stripped
+                elif _CRASH_PATTERN.search(line):
                     crashes_total += 1
+                    latest_failure = stripped
                 elif _EXIT_OK_PATTERN.search(line):
                     exits_ok_total += 1
+                    last_terminal_event = "exit_ok"
                 elif _EXIT_FAIL_PATTERN.search(line):
                     exits_fail_total += 1
+                    last_terminal_event = "exit_fail"
+                    latest_failure = stripped
     except OSError:
         pass
 
+    if last_terminal_event in {"traceback", "exit_fail"}:
+        status = STATUS_STALE
+
     extra: dict[str, object] = {
+        "tracebacks_total": tracebacks_total,
         "crashes_total": crashes_total,
         "exits_ok_total": exits_ok_total,
         "exits_fail_total": exits_fail_total,
+        "last_terminal_event": last_terminal_event or None,
     }
-    detail = f"crashes={crashes_total} ok={exits_ok_total} fail={exits_fail_total}"
+    if latest_failure:
+        extra["latest_failure"] = latest_failure[-240:]
+    detail = (
+        f"tracebacks={tracebacks_total} crashes={crashes_total} "
+        f"ok={exits_ok_total} fail={exits_fail_total}"
+    )
+    if latest_failure:
+        detail = f"{detail}; latest_failure={latest_failure[-120:]}"
     return SurfaceCheck(
         name="boss_loop_log",
         status=status,

--- a/tests/review/test_health.py
+++ b/tests/review/test_health.py
@@ -276,7 +276,7 @@ class TestGatherHealthStaleness:
 
 
 class TestBossLoopLogCounter:
-    def test_counts_crashes_and_exits(self, tmp_path: Path) -> None:
+    def test_counts_crashes_and_marks_latest_failed_exit_stale(self, tmp_path: Path) -> None:
         layout = _setup_proof_loop(tmp_path)
         log = layout["overnight"] / "boss-loop-launchd.log"
         log.write_text(
@@ -296,10 +296,39 @@ class TestBossLoopLogCounter:
         )
         by_name = {s.name: s for s in report.surfaces}
         bl = by_name["boss_loop_log"]
-        assert bl.status == STATUS_FRESH
+        assert bl.status == STATUS_STALE
+        assert bl.extra["tracebacks_total"] == 0
         assert bl.extra["crashes_total"] == 2
         assert bl.extra["exits_ok_total"] == 2
         assert bl.extra["exits_fail_total"] == 1
+        assert bl.extra["last_terminal_event"] == "exit_fail"
+        assert str(bl.extra["latest_failure"]) == "Boss loop exited with status 1"
+
+    def test_later_success_clears_historical_boss_loop_failures(self, tmp_path: Path) -> None:
+        layout = _setup_proof_loop(tmp_path)
+        log = layout["overnight"] / "boss-loop-launchd.log"
+        log.write_text(
+            "Traceback (most recent call last):\n"
+            "AttributeError: boom\n"
+            "Boss loop exited with status 1\n"
+            "Starting boss-loop cycle for synaptent/aragora (label=boss-ready)...\n"
+            "Boss loop exited with status 0\n"
+        )
+        os.utime(log, (time.time() - 600, time.time() - 600))
+        report = gather_health(
+            repo_root=layout["repo"],
+            review_queue_root=layout["review_queue_root"],
+            overnight_root=layout["overnight"],
+            automation_receipts_root=layout["auto"],
+        )
+        by_name = {s.name: s for s in report.surfaces}
+        bl = by_name["boss_loop_log"]
+        assert bl.status == STATUS_FRESH
+        assert bl.extra["tracebacks_total"] == 1
+        assert bl.extra["crashes_total"] == 1
+        assert bl.extra["exits_ok_total"] == 1
+        assert bl.extra["exits_fail_total"] == 1
+        assert bl.extra["last_terminal_event"] == "exit_ok"
 
 
 class TestBossMetricsJsonlCounter:


### PR DESCRIPTION
## Summary
- mark `review-queue health` boss-loop log stale when the most recent terminal event is a failed exit or traceback, even if the log mtime is fresh
- preserve historical crash/exit counters and add `tracebacks_total`, `last_terminal_event`, and `latest_failure` diagnostics
- add focused tests proving a latest failure blocks freshness and a later successful exit clears old failures

## Validation
- `python3 -m pytest -q tests/review/test_health.py`
- `python3 -m ruff check aragora/review/health.py tests/review/test_health.py`
- pre-push hooks: ruff, ruff format, changed-file mypy, gitleaks

## Live dogfood
From a clean `origin/main` worktree with this branch applied, `python3 -m aragora.cli.main review-queue health --json` now reports current local boss-loop state as stale with `last_terminal_event=exit_fail` and `latest_failure="Boss loop exited with status 1."`; B0 and TW03 proof surfaces remain fresh.

This PR does not touch launchd state, branch protection, settlement, or shared-root dirt.
