### PR TITLE
fix(boss-loop): preflight runtime imports

### DIFF
--- a/scripts/run_boss_cycle.sh
+++ b/scripts/run_boss_cycle.sh
@@ -13,6 +13,7 @@ resolve_python_bin() {
     local candidates=()
     local candidate=""
     local python_cmd=""
+    local probe='import pydantic; import aragora.cli.commands.swarm'
 
     if [[ -n "${ARAGORA_PYTHON:-}" ]]; then
         if [[ -x "${ARAGORA_PYTHON}" ]]; then
@@ -34,21 +35,25 @@ resolve_python_bin() {
         if [[ -z "${candidate}" || ! -x "${candidate}" ]]; then
             continue
         fi
-        if "${candidate}" -c 'import pydantic' >/dev/null 2>&1; then
+        if (cd "${REPO_ROOT}" && "${candidate}" -c "${probe}" >/dev/null 2>&1); then
             printf '%s\n' "${candidate}"
             return 0
         fi
+        echo "Skipping Python candidate without usable boss-loop imports: ${candidate}" >&2
     done
 
     if command -v pyenv >/dev/null 2>&1; then
         candidate="$(pyenv which python3 2>/dev/null || true)"
-        if [[ -n "${candidate}" && -x "${candidate}" ]] && "${candidate}" -c 'import pydantic' >/dev/null 2>&1; then
+        if [[ -n "${candidate}" && -x "${candidate}" ]] && (cd "${REPO_ROOT}" && "${candidate}" -c "${probe}" >/dev/null 2>&1); then
             printf '%s\n' "${candidate}"
             return 0
         fi
+        if [[ -n "${candidate}" && -x "${candidate}" ]]; then
+            echo "Skipping Python candidate without usable boss-loop imports: ${candidate}" >&2
+        fi
     fi
 
-    echo "No usable python interpreter with pydantic found for boss-loop runtime." >&2
+    echo "No usable python interpreter with pydantic and boss-loop imports found for boss-loop runtime." >&2
     return 1
 }
 

--- a/tests/scripts/test_run_boss_cycle.py
+++ b/tests/scripts/test_run_boss_cycle.py
@@ -29,6 +29,9 @@ set -euo pipefail
 if [[ "${1:-}" == "-u" ]]; then
   exit "${FAKE_PYTHON3_BOSS_EXIT:-0}"
 fi
+if [[ "${1:-}" == "-c" && "${2:-}" == *"${FAKE_PYTHON3_IMPORT_FAIL_PATTERN:-__never_match__}"* ]]; then
+  exit "${FAKE_PYTHON3_IMPORT_FAIL_EXIT:-23}"
+fi
 exit "${FAKE_PYTHON3_REFILL_EXIT:-0}"
 """,
         encoding="utf-8",
@@ -44,13 +47,13 @@ def _read_calls(log_path: Path) -> list[list[str]]:
 
 
 def _runtime_calls(log_path: Path) -> list[list[str]]:
-    return [call for call in _read_calls(log_path) if call[:2] != ["-c", "import pydantic"]]
+    return [call for call in _read_calls(log_path) if call[:1] != ["-c"]]
 
 
 def test_run_boss_cycle_runs_post_loop_refill_after_success(tmp_path: Path) -> None:
     _fake_python3, log_path = _write_fake_python3(tmp_path)
     env = os.environ.copy()
-    env["PATH"] = f"{tmp_path}:{env['PATH']}"
+    env["PATH"] = f"{tmp_path}:/usr/bin:/bin:/usr/sbin:/sbin"
     env["FAKE_PYTHON3_LOG"] = str(log_path)
     env["FAKE_PYTHON3_BOSS_EXIT"] = "0"
     env["FAKE_PYTHON3_REFILL_EXIT"] = "0"
@@ -124,3 +127,35 @@ def test_run_boss_cycle_skips_post_loop_refill_after_failure(tmp_path: Path) -> 
     assert len(calls) == 1
     assert calls[0][:5] == ["-u", "-m", "aragora.cli.main", "swarm", "boss-loop"]
     assert "Skipping post-loop issue refill because boss loop exited non-zero." in result.stderr
+
+
+def test_run_boss_cycle_rejects_python_without_boss_loop_imports(tmp_path: Path) -> None:
+    _fake_python3, log_path = _write_fake_python3(tmp_path)
+    env = os.environ.copy()
+    env["PATH"] = f"{tmp_path}:/usr/bin:/bin:/usr/sbin:/sbin"
+    env["FAKE_PYTHON3_LOG"] = str(log_path)
+    env["FAKE_PYTHON3_IMPORT_FAIL_PATTERN"] = "aragora.cli.commands.swarm"
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(SCRIPT_PATH),
+            "--boss-repo",
+            "org/repo",
+            "--label",
+            "boss-ready",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert _runtime_calls(log_path) == []
+    assert "Skipping Python candidate without usable boss-loop imports:" in result.stderr
+    assert (
+        "No usable python interpreter with pydantic and boss-loop imports found for boss-loop runtime."
+        in result.stderr
+    )


### PR DESCRIPTION
## Summary
- Require boss-loop launcher Python candidates to import the actual swarm command surface, not just pydantic.
- Skip broken interpreters with an actionable log line before starting a cycle.
- Add regression coverage for rejecting an interpreter whose boss-loop imports fail.

## Validation
- python3 -m pytest -q tests/scripts/test_run_boss_cycle.py
- python3 -m ruff check tests/scripts/test_run_boss_cycle.py
- python3 -m ruff format --check tests/scripts/test_run_boss_cycle.py
- bash -n scripts/run_boss_cycle.sh
- ARAGORA_POST_LOOP_ISSUE_REFILL=0 bash scripts/run_boss_cycle.sh --help
- git diff --check origin/main...HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD

## Notes
This does not modify launchd state or shared-root dirt. It is intended to prevent choosing Python environments that will immediately crash on boss-loop imports, matching the current launchd failure mode.