### PR TITLE
fix(review-health): expose boss-loop failure signature

### DIFF
--- a/aragora/review/health.py
+++ b/aragora/review/health.py
@@ -321,6 +321,8 @@ _CRASH_PATTERN = re.compile(
 )
 _EXIT_OK_PATTERN = re.compile(r"Boss loop exited with status 0")
 _EXIT_FAIL_PATTERN = re.compile(r"Boss loop exited with status 1")
+_PYTHON_WARNING_PATTERN = re.compile(r"ARAGORA_PYTHON is set but not executable: .+")
+_PYTHON_INTERPRETER_PATTERN = re.compile(r"Using Python interpreter: .+")
 
 
 def _check_boss_loop_log(path: Path, warn_h: float, crit_h: float) -> SurfaceCheck:
@@ -342,17 +344,25 @@ def _check_boss_loop_log(path: Path, warn_h: float, crit_h: float) -> SurfaceChe
     exits_fail_total = 0
     last_terminal_event = ""
     latest_failure = ""
+    latest_failure_signature = ""
+    latest_python_warning = ""
+    latest_python_interpreter = ""
     try:
         with path.open("r", encoding="utf-8", errors="replace") as handle:
             for line in handle:
                 stripped = line.strip()
-                if _TRACEBACK_PATTERN.search(line):
+                if _PYTHON_WARNING_PATTERN.search(line):
+                    latest_python_warning = stripped
+                elif _PYTHON_INTERPRETER_PATTERN.search(line):
+                    latest_python_interpreter = stripped
+                elif _TRACEBACK_PATTERN.search(line):
                     tracebacks_total += 1
                     last_terminal_event = "traceback"
                     latest_failure = stripped
                 elif _CRASH_PATTERN.search(line):
                     crashes_total += 1
                     latest_failure = stripped
+                    latest_failure_signature = stripped
                 elif _EXIT_OK_PATTERN.search(line):
                     exits_ok_total += 1
                     last_terminal_event = "exit_ok"
@@ -375,12 +385,20 @@ def _check_boss_loop_log(path: Path, warn_h: float, crit_h: float) -> SurfaceChe
     }
     if latest_failure:
         extra["latest_failure"] = latest_failure[-240:]
+    if latest_failure_signature:
+        extra["latest_failure_signature"] = latest_failure_signature[-240:]
+    if latest_python_warning:
+        extra["latest_python_warning"] = latest_python_warning[-240:]
+    if latest_python_interpreter:
+        extra["latest_python_interpreter"] = latest_python_interpreter[-240:]
     detail = (
         f"tracebacks={tracebacks_total} crashes={crashes_total} "
         f"ok={exits_ok_total} fail={exits_fail_total}"
     )
     if latest_failure:
         detail = f"{detail}; latest_failure={latest_failure[-120:]}"
+    if latest_failure_signature and latest_failure_signature != latest_failure:
+        detail = f"{detail}; failure_signature={latest_failure_signature[-120:]}"
     return SurfaceCheck(
         name="boss_loop_log",
         status=status,

--- a/tests/review/test_health.py
+++ b/tests/review/test_health.py
@@ -304,6 +304,42 @@ class TestBossLoopLogCounter:
         assert bl.extra["last_terminal_event"] == "exit_fail"
         assert str(bl.extra["latest_failure"]) == "Boss loop exited with status 1"
 
+    def test_failed_exit_keeps_actionable_boss_loop_failure_signature(self, tmp_path: Path) -> None:
+        layout = _setup_proof_loop(tmp_path)
+        log = layout["overnight"] / "boss-loop-launchd.log"
+        log.write_text(
+            "ARAGORA_PYTHON is set but not executable: /repo/.venv/bin/python3\n"
+            "Starting boss-loop cycle for synaptent/aragora (label=boss-ready)...\n"
+            "Using Python interpreter: /Users/armand/miniforge3/bin/python\n"
+            "Traceback (most recent call last):\n"
+            "AttributeError: 'NoneType' object has no attribute 'ndarray'\n"
+            "Boss loop exited with status 1\n"
+        )
+        os.utime(log, (time.time() - 600, time.time() - 600))
+        report = gather_health(
+            repo_root=layout["repo"],
+            review_queue_root=layout["review_queue_root"],
+            overnight_root=layout["overnight"],
+            automation_receipts_root=layout["auto"],
+        )
+        by_name = {s.name: s for s in report.surfaces}
+        bl = by_name["boss_loop_log"]
+        assert bl.status == STATUS_STALE
+        assert bl.extra["latest_failure"] == "Boss loop exited with status 1"
+        assert (
+            bl.extra["latest_failure_signature"]
+            == "AttributeError: 'NoneType' object has no attribute 'ndarray'"
+        )
+        assert (
+            bl.extra["latest_python_warning"]
+            == "ARAGORA_PYTHON is set but not executable: /repo/.venv/bin/python3"
+        )
+        assert (
+            bl.extra["latest_python_interpreter"]
+            == "Using Python interpreter: /Users/armand/miniforge3/bin/python"
+        )
+        assert "failure_signature=AttributeError" in str(bl.detail)
+
     def test_later_success_clears_historical_boss_loop_failures(self, tmp_path: Path) -> None:
         layout = _setup_proof_loop(tmp_path)
         log = layout["overnight"] / "boss-loop-launchd.log"


### PR DESCRIPTION
## Summary
- Preserve the actionable boss-loop exception line separately from the terminal `Boss loop exited with status 1` line in `review-queue health`.
- Add Python runtime hints for the latest unusable `ARAGORA_PYTHON` value and selected interpreter.
- Keep existing `latest_failure` semantics intact for current consumers.

## Live Dogfood
From the current shared boss-loop log, this branch now reports:
- `latest_failure`: `Boss loop exited with status 1.`
- `latest_failure_signature`: `AttributeError: 'NoneType' object has no attribute 'ndarray'`
- `latest_python_warning`: `ARAGORA_PYTHON is set but not executable: /Users/armand/Development/aragora/.venv/bin/python3`
- `latest_python_interpreter`: `Using Python interpreter: /Users/armand/miniforge3/bin/python`

## Validation
- `python3 -m pytest -q tests/review/test_health.py` -> 20 passed
- `python3 -m ruff check aragora/review/health.py tests/review/test_health.py` -> passed
- `python3 -m ruff format --check aragora/review/health.py tests/review/test_health.py` -> passed
- `python3 -m aragora.cli.main review-queue health --json` -> surfaced the live failure signature and interpreter hints
- `git diff --check` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> passed
- commit hooks -> passed
- pre-push hooks -> passed, including `mypy`

## Scope
This is read-only health reporting only. It does not touch launchd, branch protection, merge behavior, outbox state, or shared-root dirt.
