### PR TITLE
fix(proof-first): enforce shift time budget

### DIFF
--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -135,7 +135,7 @@ For full runtime configuration, see [ENVIRONMENT](../getting-started/environment
 | `tenant` | - | Manage multi-tenant deployments | `activate`, `create`, `delete`, `export`, `list`, `quota-get`, `quota-set`, `suspend` |
 | `testfixer` | - | Run automated test-fix loop | - |
 | `triage` | - | Inbox triage via adversarial debate with receipt-gated actions | `audit`, `auth`, `calibrate`, `digest`, `label`, `queue`, `run`, `status` |
-| `validate` | - | Validate API keys by making test calls | - |
+| `validate` | - | Run a full health check, including live API-key validation | - |
 | `validate-env` | - | Validate environment configuration and backend connectivity | - |
 | `verify` | - | Verify a decision receipt's integrity | - |
 | `verticals` | - | Manage vertical specialist configurations | - |

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -130,7 +130,7 @@ For full runtime configuration, see [ENVIRONMENT](ENVIRONMENT.md).
 | `tenant` | - | Manage multi-tenant deployments | `activate`, `create`, `delete`, `export`, `list`, `quota-get`, `quota-set`, `suspend` |
 | `testfixer` | - | Run automated test-fix loop | - |
 | `triage` | - | Inbox triage via adversarial debate with receipt-gated actions | `audit`, `auth`, `calibrate`, `digest`, `label`, `queue`, `run`, `status` |
-| `validate` | - | Validate API keys by making test calls | - |
+| `validate` | - | Run a full health check, including live API-key validation | - |
 | `validate-env` | - | Validate environment configuration and backend connectivity | - |
 | `verify` | - | Verify a decision receipt's integrity | - |
 | `verticals` | - | Manage vertical specialist configurations | - |

--- a/scripts/run_proof_first_shift.py
+++ b/scripts/run_proof_first_shift.py
@@ -35,6 +35,10 @@ MAX_UNAUTHORIZED_MERGE_LIMIT = 1
 DEFAULT_REFRESH_MINUTES = 120
 DEFAULT_MAX_HOURS = 12.0
 DEFAULT_INTERVAL_SECONDS = 120
+MIN_CYCLE_START_SECONDS = 60.0
+MIN_ACTION_BUDGET_SECONDS = 5.0
+MERGE_APPLY_TIMEOUT_SECONDS = 120.0
+BENCHMARK_TRIGGER_TIMEOUT_SECONDS = 45.0
 DEFAULT_BOSS_LABEL = "com.aragora.swarm-boss-loop"
 DEFAULT_MERGE_LABEL = "com.aragora.swarm-merge-arbiter"
 DEFAULT_BOSS_PROCESS_PATTERN = r"aragora\.cli\.main swarm boss-loop|run_boss_cycle\.sh"
@@ -156,6 +160,54 @@ class LaunchdServiceStatus:
     last_exit_code: int | None = None
     stdout_path: str = ""
     detail: str = ""
+
+
+@dataclass(frozen=True)
+class ShiftTimeBudget:
+    deadline_time: float
+    max_hours: float
+    now: Callable[[], float] = time.time
+    min_action_seconds: float = MIN_ACTION_BUDGET_SECONDS
+
+    @classmethod
+    def from_controller(cls, controller: ShiftController) -> ShiftTimeBudget | None:
+        state = controller.state
+        if state is None:
+            return None
+        max_hours = float(controller.config.max_duration_hours)
+        return cls(
+            deadline_time=float(state.started_at) + max_hours * 3600.0,
+            max_hours=max_hours,
+        )
+
+    def remaining_seconds(self) -> float:
+        return max(0.0, float(self.deadline_time) - float(self.now()))
+
+    def elapsed_hours(self) -> float:
+        return max(0.0, float(self.max_hours) - self.remaining_seconds() / 3600.0)
+
+    def insufficient_reason(self, action: str, required_seconds: float) -> str:
+        remaining = self.remaining_seconds()
+        if remaining >= required_seconds:
+            return ""
+        return (
+            f"TimeBudgetInsufficient: {action} requires at least {required_seconds:.2f}s "
+            f"remaining ({remaining:.2f}s left before max {self.max_hours:.2f}h)"
+        )
+
+    def bounded_timeout(self, action: str, requested_seconds: float) -> tuple[float | None, str]:
+        remaining = self.remaining_seconds()
+        if remaining <= self.min_action_seconds:
+            return None, self.insufficient_reason(action, self.min_action_seconds)
+        return min(float(requested_seconds), remaining - self.min_action_seconds), ""
+
+    def to_report(self) -> dict[str, Any]:
+        return {
+            "bounded": True,
+            "max_hours": float(self.max_hours),
+            "remaining_seconds": round(self.remaining_seconds(), 2),
+            "min_action_seconds": float(self.min_action_seconds),
+        }
 
 
 def _utc_now() -> datetime:
@@ -307,7 +359,7 @@ def _run(
     args: list[str],
     *,
     cwd: Path,
-    timeout: int = 30,
+    timeout: float = 30,
 ) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         args,
@@ -319,7 +371,7 @@ def _run(
     )
 
 
-def _run_json(args: list[str], *, cwd: Path, timeout: int = 30) -> Any:
+def _run_json(args: list[str], *, cwd: Path, timeout: float = 30) -> Any:
     proc = _run(args, cwd=cwd, timeout=timeout)
     if proc.returncode != 0:
         raise RuntimeError(
@@ -905,18 +957,27 @@ def restart_boss_service(
     repo_root: Path,
     repo: str,
     process_pattern: str,
+    start_timeout_seconds: float | None = None,
 ) -> tuple[bool, str, str]:
     initial_status = inspect_launchd_service(DEFAULT_BOSS_LABEL)
     if launchd_service_missing(initial_status):
+        bootstrap_kwargs: dict[str, float] = {}
+        if start_timeout_seconds is not None:
+            bootstrap_kwargs["start_timeout_seconds"] = start_timeout_seconds
         restarted, detail = start_detached_boss_loop(
             repo_root=repo_root,
             repo=repo,
             process_pattern=process_pattern,
+            **bootstrap_kwargs,
         )
         return restarted, detail, "bootstrap_boss_loop_direct"
+    restart_kwargs: dict[str, float] = {}
+    if start_timeout_seconds is not None:
+        restart_kwargs["start_timeout_seconds"] = start_timeout_seconds
     restarted, detail = restart_service_via_launchd(
         label=DEFAULT_BOSS_LABEL,
         process_pattern=process_pattern,
+        **restart_kwargs,
     )
     return restarted, detail, "restart_boss_loop"
 
@@ -946,6 +1007,7 @@ def run_merge_arbiter_apply(
     repo_root: Path,
     repo: str,
     limit: int,
+    timeout_seconds: float = MERGE_APPLY_TIMEOUT_SECONDS,
 ) -> dict[str, Any]:
     payload = _run_json(
         [
@@ -961,7 +1023,7 @@ def run_merge_arbiter_apply(
             "--json",
         ],
         cwd=repo_root,
-        timeout=120,
+        timeout=timeout_seconds,
     )
     if not isinstance(payload, dict):
         raise RuntimeError("merge arbiter helper returned a non-object payload")
@@ -985,11 +1047,16 @@ def resolve_merge_limit(
     return merge_limit
 
 
-def trigger_benchmark_workflow(*, repo_root: Path, repo: str) -> None:
+def trigger_benchmark_workflow(
+    *,
+    repo_root: Path,
+    repo: str,
+    timeout_seconds: float = BENCHMARK_TRIGGER_TIMEOUT_SECONDS,
+) -> None:
     proc = _run(
         ["gh", "workflow", "run", "Benchmark Truth Publication", "--repo", repo],
         cwd=repo_root,
-        timeout=45,
+        timeout=timeout_seconds,
     )
     if proc.returncode != 0:
         raise RuntimeError(proc.stderr.strip() or proc.stdout.strip() or "gh workflow run failed")
@@ -1067,6 +1134,7 @@ def run_shift_cycle(
     allow_multiple_merges: bool = False,
     ledger: ShiftLedger | None = None,
     max_hours: float = DEFAULT_MAX_HOURS,
+    time_budget: ShiftTimeBudget | None = None,
 ) -> dict[str, Any]:
     effective_merge_limit = resolve_merge_limit(
         merge_limit=merge_limit,
@@ -1118,6 +1186,7 @@ def run_shift_cycle(
             "actions": outage_actions,
             "stop_reason": stop_reason,
             "failure_policy": failure_policy,
+            "time_budget": time_budget.to_report() if time_budget else {"bounded": False},
             "green_shift_evaluation": evaluate_green_shift(
                 queue_report=queue_report,
                 queue_count=0,
@@ -1163,7 +1232,9 @@ def run_shift_cycle(
         actions.append(f"boss_{verdict}: {boss_throttle_reason}")
     service_failures: list[str] = []
     runtime_failures: list[str] = []
+    time_budget_failures: list[str] = []
     repeated_failure_classes: list[str] = []
+    stop_reason = ""
     if dry_run and (not boss_running) and canonical_queue_count > 0:
         actions.append("boss_restart_skipped:dry_run")
     elif should_restart_service(
@@ -1171,32 +1242,45 @@ def run_shift_cycle(
         pending_count=canonical_queue_count,
         restart_count=runtime_state.boss_restart_count,
     ):
-        restarted, detail, boss_restart_action = restart_boss_service(
-            repo_root=repo_root,
-            repo=repo,
-            process_pattern=DEFAULT_BOSS_PROCESS_PATTERN,
-        )
-        runtime_state.boss_restart_count += 1
-        record_recovery_attempt(
-            ledger,
-            runtime_state,
-            failure_class=BOSS_RESTART_FAILURE,
-            action=boss_restart_action,
-            success=restarted,
-            detail=detail,
-        )
-        if restarted:
-            boss_running = True
-            actions.append(boss_restart_action)
-            if ledger:
-                ledger.record_service_restart(service="boss_loop", success=True, detail=detail)
-        else:
-            actions.append(f"{boss_restart_action}_failed")
-            stop_reason = f"BossRestartFailed: {detail or 'boss loop restart did not produce a running process'}"
-            service_failures.append(stop_reason)
-            if ledger:
-                ledger.record_service_restart(service="boss_loop", success=False, detail=detail)
-                ledger.record_failure(failure_type="service_failure", detail=stop_reason)
+        restart_kwargs: dict[str, float] = {}
+        if time_budget is not None and not time_budget_failures:
+            restart_timeout, budget_reason = time_budget.bounded_timeout(
+                "restart_boss_loop",
+                DEFAULT_LAUNCHD_START_TIMEOUT_SECONDS,
+            )
+            if budget_reason:
+                actions.append("boss_restart_skipped:time_budget")
+                time_budget_failures.append(budget_reason)
+            elif restart_timeout is not None:
+                restart_kwargs["start_timeout_seconds"] = restart_timeout
+        if not time_budget_failures:
+            restarted, detail, boss_restart_action = restart_boss_service(
+                repo_root=repo_root,
+                repo=repo,
+                process_pattern=DEFAULT_BOSS_PROCESS_PATTERN,
+                **restart_kwargs,
+            )
+            runtime_state.boss_restart_count += 1
+            record_recovery_attempt(
+                ledger,
+                runtime_state,
+                failure_class=BOSS_RESTART_FAILURE,
+                action=boss_restart_action,
+                success=restarted,
+                detail=detail,
+            )
+            if restarted:
+                boss_running = True
+                actions.append(boss_restart_action)
+                if ledger:
+                    ledger.record_service_restart(service="boss_loop", success=True, detail=detail)
+            else:
+                actions.append(f"{boss_restart_action}_failed")
+                stop_reason = f"BossRestartFailed: {detail or 'boss loop restart did not produce a running process'}"
+                service_failures.append(stop_reason)
+                if ledger:
+                    ledger.record_service_restart(service="boss_loop", success=False, detail=detail)
+                    ledger.record_failure(failure_type="service_failure", detail=stop_reason)
     elif (not boss_running) and canonical_queue_count > 0 and runtime_state.boss_restart_count >= 1:
         repeated_failure_classes.append(BOSS_RESTART_FAILURE)
         service_failures.append(RECOVERY_STOP_REASONS[BOSS_RESTART_FAILURE])
@@ -1209,31 +1293,46 @@ def run_shift_cycle(
         pending_count=open_pr_count,
         restart_count=runtime_state.merge_restart_count,
     ):
-        restarted, detail = restart_service_via_launchd(
-            label=DEFAULT_MERGE_LABEL,
-            process_pattern=DEFAULT_MERGE_PROCESS_PATTERN,
-        )
-        runtime_state.merge_restart_count += 1
-        record_recovery_attempt(
-            ledger,
-            runtime_state,
-            failure_class=MERGE_RESTART_FAILURE,
-            action="restart_merge_arbiter",
-            success=restarted,
-            detail=detail,
-        )
-        if restarted:
-            merge_running = True
-            actions.append("restart_merge_arbiter")
-            if ledger:
-                ledger.record_service_restart(service="merge_arbiter", success=True)
-        else:
-            actions.append("restart_merge_arbiter_failed")
-            stop_reason = f"MergeArbiterRestartFailed: {detail or 'merge arbiter restart did not produce a running process'}"
-            service_failures.append(stop_reason)
-            if ledger:
-                ledger.record_service_restart(service="merge_arbiter", success=False, detail=detail)
-                ledger.record_failure(failure_type="service_failure", detail=stop_reason)
+        restart_kwargs = {}
+        if time_budget is not None and not time_budget_failures:
+            restart_timeout, budget_reason = time_budget.bounded_timeout(
+                "restart_merge_arbiter",
+                DEFAULT_LAUNCHD_START_TIMEOUT_SECONDS,
+            )
+            if budget_reason:
+                actions.append("merge_arbiter_restart_skipped:time_budget")
+                time_budget_failures.append(budget_reason)
+            elif restart_timeout is not None:
+                restart_kwargs["start_timeout_seconds"] = restart_timeout
+        if not time_budget_failures:
+            restarted, detail = restart_service_via_launchd(
+                label=DEFAULT_MERGE_LABEL,
+                process_pattern=DEFAULT_MERGE_PROCESS_PATTERN,
+                **restart_kwargs,
+            )
+            runtime_state.merge_restart_count += 1
+            record_recovery_attempt(
+                ledger,
+                runtime_state,
+                failure_class=MERGE_RESTART_FAILURE,
+                action="restart_merge_arbiter",
+                success=restarted,
+                detail=detail,
+            )
+            if restarted:
+                merge_running = True
+                actions.append("restart_merge_arbiter")
+                if ledger:
+                    ledger.record_service_restart(service="merge_arbiter", success=True)
+            else:
+                actions.append("restart_merge_arbiter_failed")
+                stop_reason = f"MergeArbiterRestartFailed: {detail or 'merge arbiter restart did not produce a running process'}"
+                service_failures.append(stop_reason)
+                if ledger:
+                    ledger.record_service_restart(
+                        service="merge_arbiter", success=False, detail=detail
+                    )
+                    ledger.record_failure(failure_type="service_failure", detail=stop_reason)
     elif (not merge_running) and open_pr_count > 0 and runtime_state.merge_restart_count >= 1:
         repeated_failure_classes.append(MERGE_RESTART_FAILURE)
         service_failures.append(RECOVERY_STOP_REASONS[MERGE_RESTART_FAILURE])
@@ -1242,12 +1341,31 @@ def run_shift_cycle(
         reason = "dry_run" if dry_run else "no_merge"
         merge_report = {"merged": [], "skipped": True, "reason": reason}
         actions.append(f"merge_arbiter_apply_skipped:{reason}")
+    elif time_budget_failures:
+        merge_report = {"merged": [], "skipped": True, "reason": "time_budget"}
+        actions.append("merge_arbiter_apply_skipped:time_budget")
     else:
-        merge_report = run_merge_arbiter_apply(
-            repo_root=repo_root,
-            repo=repo,
-            limit=effective_merge_limit,
-        )
+        merge_kwargs: dict[str, float] = {}
+        if time_budget is not None:
+            merge_timeout, budget_reason = time_budget.bounded_timeout(
+                "merge_arbiter_apply",
+                MERGE_APPLY_TIMEOUT_SECONDS,
+            )
+            if budget_reason:
+                merge_report = {"merged": [], "skipped": True, "reason": "time_budget"}
+                actions.append("merge_arbiter_apply_skipped:time_budget")
+                time_budget_failures.append(budget_reason)
+            elif merge_timeout is not None:
+                merge_kwargs["timeout_seconds"] = merge_timeout
+        if time_budget_failures:
+            merge_report = {"merged": [], "skipped": True, "reason": "time_budget"}
+        else:
+            merge_report = run_merge_arbiter_apply(
+                repo_root=repo_root,
+                repo=repo,
+                limit=effective_merge_limit,
+                **merge_kwargs,
+            )
     merged_numbers = list(merge_report.get("merged") or [])
     if merged_numbers:
         actions.append(f"merged_prs:{','.join(str(number) for number in merged_numbers)}")
@@ -1332,7 +1450,6 @@ def run_shift_cycle(
         truth_state_drift_detected=bool(int(benchmark_truth_drift.get("issue_count", 0) or 0)),
         max_age_hours=max_hours,
     )
-    stop_reason = ""
     if should_trigger:
         if dry_run:
             actions.append(f"trigger_benchmark_skipped:dry_run:{trigger_reason}")
@@ -1340,60 +1457,94 @@ def run_shift_cycle(
             if recovery_budget_remaining(runtime_state, latest_failure_class) <= 0:
                 repeated_failure_classes.append(latest_failure_class)
                 stop_reason = RECOVERY_STOP_REASONS[latest_failure_class]
+            elif time_budget_failures:
+                actions.append(f"trigger_benchmark_skipped:time_budget:{trigger_reason}")
             else:
+                trigger_kwargs: dict[str, float] = {}
+                if time_budget is not None:
+                    trigger_timeout, budget_reason = time_budget.bounded_timeout(
+                        "trigger_benchmark_workflow",
+                        BENCHMARK_TRIGGER_TIMEOUT_SECONDS,
+                    )
+                    if budget_reason:
+                        time_budget_failures.append(budget_reason)
+                        actions.append(f"trigger_benchmark_skipped:time_budget:{trigger_reason}")
+                    elif trigger_timeout is not None:
+                        trigger_kwargs["timeout_seconds"] = trigger_timeout
+                if not time_budget_failures:
+                    try:
+                        trigger_benchmark_workflow(
+                            repo_root=repo_root,
+                            repo=repo,
+                            **trigger_kwargs,
+                        )
+                    except RuntimeError as exc:
+                        detail = str(exc).strip() or "benchmark workflow trigger failed"
+                        runtime_state.runtime_failure_count += 1
+                        runtime_failures.append(f"RuntimeFailure: {detail}")
+                        actions.append(f"trigger_benchmark_failed:{trigger_reason}")
+                        record_recovery_attempt(
+                            ledger,
+                            runtime_state,
+                            failure_class=latest_failure_class,
+                            action="trigger_benchmark_workflow",
+                            success=False,
+                            detail=detail,
+                        )
+                        if ledger:
+                            ledger.record_failure(failure_type="runtime_failure", detail=detail)
+                    else:
+                        actions.append(f"trigger_benchmark:{trigger_reason}")
+                        record_recovery_attempt(
+                            ledger,
+                            runtime_state,
+                            failure_class=latest_failure_class,
+                            action="trigger_benchmark_workflow",
+                            success=True,
+                            detail=latest_failure_detail or trigger_reason,
+                        )
+                        if latest_run is not None:
+                            runtime_state.last_triggered_benchmark_run_id = int(
+                                latest_run.get("databaseId", 0) or 0
+                            )
+                        else:
+                            runtime_state.last_triggered_benchmark_run_id = -1
+        else:
+            trigger_kwargs = {}
+            if time_budget_failures:
+                actions.append(f"trigger_benchmark_skipped:time_budget:{trigger_reason}")
+            elif time_budget is not None:
+                trigger_timeout, budget_reason = time_budget.bounded_timeout(
+                    "trigger_benchmark_workflow",
+                    BENCHMARK_TRIGGER_TIMEOUT_SECONDS,
+                )
+                if budget_reason:
+                    time_budget_failures.append(budget_reason)
+                    actions.append(f"trigger_benchmark_skipped:time_budget:{trigger_reason}")
+                elif trigger_timeout is not None:
+                    trigger_kwargs["timeout_seconds"] = trigger_timeout
+            if not time_budget_failures:
                 try:
-                    trigger_benchmark_workflow(repo_root=repo_root, repo=repo)
+                    trigger_benchmark_workflow(repo_root=repo_root, repo=repo, **trigger_kwargs)
                 except RuntimeError as exc:
                     detail = str(exc).strip() or "benchmark workflow trigger failed"
                     runtime_state.runtime_failure_count += 1
                     runtime_failures.append(f"RuntimeFailure: {detail}")
                     actions.append(f"trigger_benchmark_failed:{trigger_reason}")
-                    record_recovery_attempt(
-                        ledger,
-                        runtime_state,
-                        failure_class=latest_failure_class,
-                        action="trigger_benchmark_workflow",
-                        success=False,
-                        detail=detail,
-                    )
                     if ledger:
                         ledger.record_failure(failure_type="runtime_failure", detail=detail)
                 else:
                     actions.append(f"trigger_benchmark:{trigger_reason}")
-                    record_recovery_attempt(
-                        ledger,
-                        runtime_state,
-                        failure_class=latest_failure_class,
-                        action="trigger_benchmark_workflow",
-                        success=True,
-                        detail=latest_failure_detail or trigger_reason,
-                    )
                     if latest_run is not None:
                         runtime_state.last_triggered_benchmark_run_id = int(
                             latest_run.get("databaseId", 0) or 0
                         )
                     else:
                         runtime_state.last_triggered_benchmark_run_id = -1
-        else:
-            try:
-                trigger_benchmark_workflow(repo_root=repo_root, repo=repo)
-            except RuntimeError as exc:
-                detail = str(exc).strip() or "benchmark workflow trigger failed"
-                runtime_state.runtime_failure_count += 1
-                runtime_failures.append(f"RuntimeFailure: {detail}")
-                actions.append(f"trigger_benchmark_failed:{trigger_reason}")
-                if ledger:
-                    ledger.record_failure(failure_type="runtime_failure", detail=detail)
-            else:
-                actions.append(f"trigger_benchmark:{trigger_reason}")
-                if latest_run is not None:
-                    runtime_state.last_triggered_benchmark_run_id = int(
-                        latest_run.get("databaseId", 0) or 0
-                    )
-                else:
-                    runtime_state.last_triggered_benchmark_run_id = -1
 
-    if not stop_reason and runtime_failures:
+    if not stop_reason and time_budget_failures:
+        stop_reason = time_budget_failures[0]
+    elif not stop_reason and runtime_failures:
         stop_reason = runtime_failures[0]
     elif not stop_reason and service_failures:
         stop_reason = service_failures[0]
@@ -1454,6 +1605,7 @@ def run_shift_cycle(
         "actions": actions,
         "stop_reason": stop_reason,
         "failure_policy": failure_policy,
+        "time_budget": time_budget.to_report() if time_budget else {"bounded": False},
         "green_shift_evaluation": evaluate_green_shift(
             queue_report=queue_report,
             queue_count=canonical_queue_count,
@@ -1541,6 +1693,22 @@ async def _run_shift(args: argparse.Namespace) -> dict[str, Any]:
                 )
                 break
 
+        time_budget = ShiftTimeBudget.from_controller(controller)
+        if time_budget is not None:
+            time_budget_reason = time_budget.insufficient_reason(
+                "next_shift_cycle",
+                MIN_CYCLE_START_SECONDS,
+            )
+            if time_budget_reason:
+                controller.complete_shift(time_budget_reason)
+                ledger.record_shift_stop(
+                    shift_id=shift_id,
+                    reason=time_budget_reason,
+                    cycles=cycle_count,
+                    duration_seconds=time.monotonic() - shift_start_time,
+                )
+                break
+
         report = run_shift_cycle(
             repo_root=repo_root,
             repo=args.repo,
@@ -1553,13 +1721,24 @@ async def _run_shift(args: argparse.Namespace) -> dict[str, Any]:
             runtime_state=runtime_state,
             ledger=ledger,
             max_hours=float(args.max_hours),
+            time_budget=time_budget,
         )
         cycle_reports.append(report)
         cycle_count += 1
         save_runtime_state(runtime_state_path, runtime_state)
 
         objective = build_cycle_objective(report)
-        await controller.run_cycle(objective)
+        cycle_result = await controller.run_cycle(objective)
+        controller_stop_reason = str(cycle_result.get("stop_reason") or "")
+        if controller_stop_reason:
+            controller.complete_shift(controller_stop_reason)
+            ledger.record_shift_stop(
+                shift_id=shift_id,
+                reason=controller_stop_reason,
+                cycles=cycle_count,
+                duration_seconds=time.monotonic() - shift_start_time,
+            )
+            break
         if report["stop_reason"]:
             controller.complete_shift(str(report["stop_reason"]))
             ledger.record_shift_stop(

--- a/scripts/run_proof_first_shift.py
+++ b/scripts/run_proof_first_shift.py
@@ -37,6 +37,13 @@ DEFAULT_MAX_HOURS = 12.0
 DEFAULT_INTERVAL_SECONDS = 120
 MIN_CYCLE_START_SECONDS = 60.0
 MIN_ACTION_BUDGET_SECONDS = 5.0
+QUEUE_RECONCILE_MIN_SECONDS = 60.0
+BOSS_LANE_SNAPSHOT_MIN_SECONDS = 120.0
+PROCESS_PROBE_MIN_SECONDS = 30.0
+BENCHMARK_DRIFT_MIN_SECONDS = 60.0
+LIST_OPEN_PRS_TIMEOUT_SECONDS = 45.0
+LATEST_BENCHMARK_TIMEOUT_SECONDS = 45.0
+FETCH_FAILURE_LOG_TIMEOUT_SECONDS = 60.0
 MERGE_APPLY_TIMEOUT_SECONDS = 120.0
 BENCHMARK_TRIGGER_TIMEOUT_SECONDS = 45.0
 DEFAULT_BOSS_LABEL = "com.aragora.swarm-boss-loop"
@@ -417,7 +424,12 @@ def collect_boss_lane_snapshot(*, repo_root: Path, repo: str) -> dict[str, Any]:
     return collect_snapshot(args)
 
 
-def list_open_prs(*, repo_root: Path, repo: str) -> list[dict[str, Any]]:
+def list_open_prs(
+    *,
+    repo_root: Path,
+    repo: str,
+    timeout_seconds: float = LIST_OPEN_PRS_TIMEOUT_SECONDS,
+) -> list[dict[str, Any]]:
     payload = _run_json(
         [
             "gh",
@@ -433,7 +445,7 @@ def list_open_prs(*, repo_root: Path, repo: str) -> list[dict[str, Any]]:
             "number,title,headRefName,isDraft,url",
         ],
         cwd=repo_root,
-        timeout=45,
+        timeout=timeout_seconds,
     )
     if not isinstance(payload, list):
         raise RuntimeError("gh pr list returned a non-list payload")
@@ -459,7 +471,12 @@ def has_open_benchmark_publication_pr(prs: list[dict[str, Any]]) -> bool:
     )
 
 
-def latest_benchmark_run(*, repo_root: Path, repo: str) -> dict[str, Any] | None:
+def latest_benchmark_run(
+    *,
+    repo_root: Path,
+    repo: str,
+    timeout_seconds: float = LATEST_BENCHMARK_TIMEOUT_SECONDS,
+) -> dict[str, Any] | None:
     payload = _run_json(
         [
             "gh",
@@ -475,7 +492,7 @@ def latest_benchmark_run(*, repo_root: Path, repo: str) -> dict[str, Any] | None
             "databaseId,createdAt,status,conclusion",
         ],
         cwd=repo_root,
-        timeout=45,
+        timeout=timeout_seconds,
     )
     if not isinstance(payload, list) or not payload:
         return None
@@ -632,11 +649,16 @@ def build_failure_policy_status(
     return status
 
 
-def fetch_benchmark_failure_log(*, repo_root: Path, run_id: int) -> str:
+def fetch_benchmark_failure_log(
+    *,
+    repo_root: Path,
+    run_id: int,
+    timeout_seconds: float = FETCH_FAILURE_LOG_TIMEOUT_SECONDS,
+) -> str:
     proc = _run(
         ["gh", "run", "view", str(run_id), "--log-failed"],
         cwd=repo_root,
-        timeout=60,
+        timeout=timeout_seconds,
     )
     return proc.stdout or proc.stderr or ""
 
@@ -1136,12 +1158,38 @@ def run_shift_cycle(
     max_hours: float = DEFAULT_MAX_HOURS,
     time_budget: ShiftTimeBudget | None = None,
 ) -> dict[str, Any]:
+    actions: list[str] = []
+    service_failures: list[str] = []
+    runtime_failures: list[str] = []
+    time_budget_failures: list[str] = []
+    repeated_failure_classes: list[str] = []
+    stop_reason = ""
+
+    def reserve_time(action: str, required_seconds: float) -> bool:
+        if time_budget is None or time_budget_failures:
+            return not time_budget_failures
+        reason = time_budget.insufficient_reason(action, required_seconds)
+        if reason:
+            time_budget_failures.append(reason)
+            actions.append(f"{action}_skipped:time_budget")
+            return False
+        return True
+
+    reserve_time("queue_reconciliation", QUEUE_RECONCILE_MIN_SECONDS)
     effective_merge_limit = resolve_merge_limit(
         merge_limit=merge_limit,
         no_merge=no_merge or dry_run,
         allow_multiple_merges=allow_multiple_merges,
     )
-    queue_report = reconcile_proof_first_queue(repo=repo, repo_root=repo_root, apply=not dry_run)
+    queue_report = (
+        reconcile_proof_first_queue(repo=repo, repo_root=repo_root, apply=not dry_run)
+        if not time_budget_failures
+        else {
+            "kept": [],
+            "removed": [],
+            "github_status": {"available": True, "skipped": "time_budget"},
+        }
+    )
     github_status = dict(queue_report.get("github_status") or {})
     queue_removed_count = len(queue_report.get("removed") or [])
     if github_status.get("available") is False:
@@ -1201,15 +1249,39 @@ def run_shift_cycle(
                 repeated_failure_classes=outage_repeated_failure_classes,
             ),
         }
-    snapshot = collect_boss_lane_snapshot(repo_root=repo_root, repo=repo)
-    prs = list_open_prs(repo_root=repo_root, repo=repo)
+    snapshot = (
+        collect_boss_lane_snapshot(repo_root=repo_root, repo=repo)
+        if reserve_time("boss_lane_snapshot", BOSS_LANE_SNAPSHOT_MIN_SECONDS)
+        else {}
+    )
+    list_timeout: float | None = None
+    if time_budget is not None and not time_budget_failures:
+        list_timeout, budget_reason = time_budget.bounded_timeout(
+            "list_open_prs",
+            LIST_OPEN_PRS_TIMEOUT_SECONDS,
+        )
+        if budget_reason:
+            time_budget_failures.append(budget_reason)
+            actions.append("list_open_prs_skipped:time_budget")
+    prs = (
+        list_open_prs(
+            repo_root=repo_root,
+            repo=repo,
+            **({"timeout_seconds": list_timeout} if list_timeout is not None else {}),
+        )
+        if not time_budget_failures
+        else []
+    )
     actionable_prs = actionable_open_prs(prs)
     automation_backlog = count_automation_backlog(actionable_prs)
     open_pr_count = len(actionable_prs)
     draft_pr_count = len(prs) - open_pr_count
     canonical_queue_count = len(queue_report["kept"])
 
-    boss_process_running = process_running(DEFAULT_BOSS_PROCESS_PATTERN)
+    reserve_time("process_probe", PROCESS_PROBE_MIN_SECONDS)
+    boss_process_running = (
+        process_running(DEFAULT_BOSS_PROCESS_PATTERN) if not time_budget_failures else False
+    )
     boss_throttle_healthy = False
     boss_throttle_reason = ""
     if not boss_process_running:
@@ -1220,9 +1292,10 @@ def run_shift_cycle(
     # and respawns after ThrottleInterval. Treat the throttle window as healthy
     # so the shift does not burn its restart budget on a non-failure.
     boss_running = boss_process_running or boss_throttle_healthy
-    merge_running = process_running(DEFAULT_MERGE_PROCESS_PATTERN)
+    merge_running = (
+        process_running(DEFAULT_MERGE_PROCESS_PATTERN) if not time_budget_failures else False
+    )
 
-    actions: list[str] = []
     # Surface the throttle-helper's verdict in the cycle_tick payload so that
     # transient launchd states (e.g. brief launchctl-print stalls right after
     # a kickstart) can be diagnosed without re-running the shift. The marker
@@ -1230,11 +1303,6 @@ def run_shift_cycle(
     if not boss_process_running and boss_throttle_reason:
         verdict = "throttle_healthy" if boss_throttle_healthy else "throttle_unhealthy"
         actions.append(f"boss_{verdict}: {boss_throttle_reason}")
-    service_failures: list[str] = []
-    runtime_failures: list[str] = []
-    time_budget_failures: list[str] = []
-    repeated_failure_classes: list[str] = []
-    stop_reason = ""
     if dry_run and (not boss_running) and canonical_queue_count > 0:
         actions.append("boss_restart_skipped:dry_run")
     elif should_restart_service(
@@ -1373,8 +1441,29 @@ def run_shift_cycle(
             for num in merged_numbers:
                 ledger.record_pr_merged(pr_number=int(num))
 
-    latest_run = latest_benchmark_run(repo_root=repo_root, repo=repo)
-    benchmark_truth_drift = benchmark_truth_state_drift(repo_root=repo_root, repo=repo)
+    latest_timeout: float | None = None
+    if time_budget is not None and not time_budget_failures:
+        latest_timeout, budget_reason = time_budget.bounded_timeout(
+            "latest_benchmark_run",
+            LATEST_BENCHMARK_TIMEOUT_SECONDS,
+        )
+        if budget_reason:
+            time_budget_failures.append(budget_reason)
+            actions.append("latest_benchmark_run_skipped:time_budget")
+    latest_run = (
+        latest_benchmark_run(
+            repo_root=repo_root,
+            repo=repo,
+            **({"timeout_seconds": latest_timeout} if latest_timeout is not None else {}),
+        )
+        if not time_budget_failures
+        else None
+    )
+    benchmark_truth_drift = (
+        benchmark_truth_state_drift(repo_root=repo_root, repo=repo)
+        if reserve_time("benchmark_truth_state_drift", BENCHMARK_DRIFT_MIN_SECONDS)
+        else {"status": "skipped_time_budget", "issue_count": 0, "issues": []}
+    )
     latest_failure_class = ""
     latest_failure_detail = ""
     if latest_run is not None:
@@ -1389,7 +1478,28 @@ def run_shift_cycle(
                     created_at=str(latest_run.get("createdAt", "")),
                 )
             if conclusion == "failure":
-                failure_log = fetch_benchmark_failure_log(repo_root=repo_root, run_id=run_id)
+                failure_timeout: float | None = None
+                if time_budget is not None and not time_budget_failures:
+                    failure_timeout, budget_reason = time_budget.bounded_timeout(
+                        "fetch_benchmark_failure_log",
+                        FETCH_FAILURE_LOG_TIMEOUT_SECONDS,
+                    )
+                    if budget_reason:
+                        time_budget_failures.append(budget_reason)
+                        actions.append("fetch_benchmark_failure_log_skipped:time_budget")
+                failure_log = (
+                    fetch_benchmark_failure_log(
+                        repo_root=repo_root,
+                        run_id=run_id,
+                        **(
+                            {"timeout_seconds": failure_timeout}
+                            if failure_timeout is not None
+                            else {}
+                        ),
+                    )
+                    if not time_budget_failures
+                    else ""
+                )
                 failure_class = classify_benchmark_failure_log(failure_log)
                 if failure_class == "auth_failure":
                     runtime_state.auth_failure_count += 1

--- a/tests/scripts/test_run_proof_first_shift.py
+++ b/tests/scripts/test_run_proof_first_shift.py
@@ -463,13 +463,60 @@ def test_run_shift_stops_before_cycle_when_time_budget_is_too_small(tmp_path: Pa
     assert summary["shift"]["stop_reason"].startswith("TimeBudgetInsufficient")
 
 
+def test_run_shift_cycle_stops_before_probe_when_budget_drops_after_queue() -> None:
+    state = mod.ProofFirstRuntimeState()
+    now_values = iter([0.0, 970.0, 970.0])
+    time_budget = mod.ShiftTimeBudget(
+        deadline_time=1000.0,
+        max_hours=4.0,
+        now=lambda: next(now_values, 970.0),
+    )
+
+    with (
+        patch(
+            "scripts.run_proof_first_shift.reconcile_proof_first_queue",
+            return_value={"kept": [], "removed": []},
+        ),
+        patch(
+            "scripts.run_proof_first_shift.collect_boss_lane_snapshot",
+            side_effect=AssertionError("must not collect snapshot without enough time"),
+        ),
+        patch(
+            "scripts.run_proof_first_shift.list_open_prs",
+            side_effect=AssertionError("must not list PRs after time-budget failure"),
+        ),
+        patch(
+            "scripts.run_proof_first_shift.run_merge_arbiter_apply",
+            side_effect=AssertionError("must not merge after time-budget failure"),
+        ),
+        patch("scripts.run_proof_first_shift.latest_benchmark_run", return_value=None),
+        patch(
+            "scripts.run_proof_first_shift.benchmark_truth_state_drift",
+            return_value={"issue_count": 0},
+        ),
+    ):
+        report = mod.run_shift_cycle(
+            repo_root=Path(".").resolve(),
+            repo="synaptent/aragora",
+            benchmark_mode="disabled",
+            automation_backlog_limit=12,
+            runtime_state=state,
+            time_budget=time_budget,
+        )
+
+    assert "boss_lane_snapshot_skipped:time_budget" in report["actions"]
+    assert report["stop_reason"].startswith("TimeBudgetInsufficient")
+    assert report["open_pr_count"] == 0
+
+
 def test_run_shift_cycle_bounds_merge_apply_timeout_to_remaining_budget() -> None:
     state = mod.ProofFirstRuntimeState()
     repo_root = Path(".").resolve()
+    now_values = iter([0.0, 0.0, 0.0, 0.0, 910.0, 910.0, 910.0])
     time_budget = mod.ShiftTimeBudget(
-        deadline_time=100.0,
+        deadline_time=1000.0,
         max_hours=4.0,
-        now=lambda: 10.0,
+        now=lambda: next(now_values, 910.0),
     )
 
     with (
@@ -515,10 +562,11 @@ def test_run_shift_cycle_bounds_merge_apply_timeout_to_remaining_budget() -> Non
 
 def test_run_shift_cycle_fails_closed_when_merge_apply_has_too_little_time() -> None:
     state = mod.ProofFirstRuntimeState()
+    now_values = iter([0.0, 0.0, 0.0, 0.0, 998.0, 998.0])
     time_budget = mod.ShiftTimeBudget(
-        deadline_time=103.0,
+        deadline_time=1000.0,
         max_hours=4.0,
-        now=lambda: 100.0,
+        now=lambda: next(now_values, 998.0),
     )
 
     with (

--- a/tests/scripts/test_run_proof_first_shift.py
+++ b/tests/scripts/test_run_proof_first_shift.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import subprocess
 from datetime import UTC, datetime
@@ -416,6 +417,145 @@ def test_dry_run_uses_single_merge_limit_and_is_read_only() -> None:
     assert "merge_arbiter_restart_skipped:dry_run" in report["actions"]
     assert "merge_arbiter_apply_skipped:dry_run" in report["actions"]
     assert "trigger_benchmark_skipped:dry_run:stale_publication_window" in report["actions"]
+
+
+def test_run_shift_stops_before_cycle_when_time_budget_is_too_small(tmp_path: Path) -> None:
+    parser = mod._build_parser()
+    args = parser.parse_args(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--max-hours",
+            "4",
+            "--dry-run",
+            "--once",
+            "--json",
+        ]
+    )
+    started_at = 1_000.0
+    now = started_at + 4 * 3600 - (mod.MIN_CYCLE_START_SECONDS / 2)
+    restored_state = ShiftState(
+        shift_id="restored-shift",
+        started_at=started_at,
+        config={"checkpoint_dir": str(tmp_path / "checkpoints")},
+        status="running",
+        current_cycle=0,
+        last_refresh_at=started_at,
+    )
+
+    def restore(controller: ShiftController, *, checkpoint_dir: Path) -> ShiftState:
+        controller._state = restored_state  # noqa: SLF001
+        return restored_state
+
+    with (
+        patch("scripts.run_proof_first_shift.restore_shift_controller", side_effect=restore),
+        patch("scripts.run_proof_first_shift.time.time", return_value=now),
+        patch("aragora.nomic.shift_controller.time.time", return_value=now),
+        patch(
+            "scripts.run_proof_first_shift.run_shift_cycle",
+            side_effect=AssertionError("must not start a cycle without enough time left"),
+        ),
+    ):
+        summary = asyncio.run(mod._run_shift(args))
+
+    assert summary["cycles"] == []
+    assert summary["shift"]["status"] == "completed"
+    assert summary["shift"]["stop_reason"].startswith("TimeBudgetInsufficient")
+
+
+def test_run_shift_cycle_bounds_merge_apply_timeout_to_remaining_budget() -> None:
+    state = mod.ProofFirstRuntimeState()
+    repo_root = Path(".").resolve()
+    time_budget = mod.ShiftTimeBudget(
+        deadline_time=100.0,
+        max_hours=4.0,
+        now=lambda: 10.0,
+    )
+
+    with (
+        patch(
+            "scripts.run_proof_first_shift.reconcile_proof_first_queue",
+            return_value={"kept": [], "removed": []},
+        ),
+        patch(
+            "scripts.run_proof_first_shift.collect_boss_lane_snapshot", return_value={"ok": True}
+        ),
+        patch(
+            "scripts.run_proof_first_shift.list_open_prs",
+            return_value=[{"headRefName": "codex/ready", "isDraft": False}],
+        ),
+        patch("scripts.run_proof_first_shift.process_running", return_value=True),
+        patch(
+            "scripts.run_proof_first_shift.run_merge_arbiter_apply",
+            return_value={"merged": []},
+        ) as merge_mock,
+        patch("scripts.run_proof_first_shift.latest_benchmark_run", return_value=None),
+        patch(
+            "scripts.run_proof_first_shift.benchmark_truth_state_drift",
+            return_value={"issue_count": 0},
+        ),
+    ):
+        report = mod.run_shift_cycle(
+            repo_root=repo_root,
+            repo="synaptent/aragora",
+            benchmark_mode="disabled",
+            automation_backlog_limit=12,
+            runtime_state=state,
+            time_budget=time_budget,
+        )
+
+    merge_mock.assert_called_once_with(
+        repo_root=repo_root,
+        repo="synaptent/aragora",
+        limit=1,
+        timeout_seconds=85.0,
+    )
+    assert report["time_budget"]["remaining_seconds"] == 90.0
+
+
+def test_run_shift_cycle_fails_closed_when_merge_apply_has_too_little_time() -> None:
+    state = mod.ProofFirstRuntimeState()
+    time_budget = mod.ShiftTimeBudget(
+        deadline_time=103.0,
+        max_hours=4.0,
+        now=lambda: 100.0,
+    )
+
+    with (
+        patch(
+            "scripts.run_proof_first_shift.reconcile_proof_first_queue",
+            return_value={"kept": [], "removed": []},
+        ),
+        patch(
+            "scripts.run_proof_first_shift.collect_boss_lane_snapshot", return_value={"ok": True}
+        ),
+        patch(
+            "scripts.run_proof_first_shift.list_open_prs",
+            return_value=[{"headRefName": "codex/ready", "isDraft": False}],
+        ),
+        patch("scripts.run_proof_first_shift.process_running", return_value=True),
+        patch(
+            "scripts.run_proof_first_shift.run_merge_arbiter_apply",
+            side_effect=AssertionError("must not apply merge without enough time"),
+        ),
+        patch("scripts.run_proof_first_shift.latest_benchmark_run", return_value=None),
+        patch(
+            "scripts.run_proof_first_shift.benchmark_truth_state_drift",
+            return_value={"issue_count": 0},
+        ),
+    ):
+        report = mod.run_shift_cycle(
+            repo_root=Path(".").resolve(),
+            repo="synaptent/aragora",
+            benchmark_mode="disabled",
+            automation_backlog_limit=12,
+            runtime_state=state,
+            time_budget=time_budget,
+        )
+
+    assert report["merge_report"] == {"merged": [], "skipped": True, "reason": "time_budget"}
+    assert "merge_arbiter_apply_skipped:time_budget" in report["actions"]
+    assert report["stop_reason"].startswith("TimeBudgetInsufficient")
 
 
 def test_parser_defaults_to_single_merge_limit_independent_of_backlog_limit() -> None:


### PR DESCRIPTION
## Summary
- adds a wall-clock time budget to proof-first shifts so the runner stops before starting another cycle when too little time remains
- bounds long helper actions (service restarts, merge apply, benchmark trigger) to the remaining time budget, failing closed when insufficient
- preserves dry-run/no-merge behavior and existing no-budget helper call shapes

## Validation
- python3 -m pytest -q tests/scripts/test_run_proof_first_shift.py -> 65 passed
- python3 -m ruff check scripts/run_proof_first_shift.py tests/scripts/test_run_proof_first_shift.py
- python3 -m ruff format --check scripts/run_proof_first_shift.py tests/scripts/test_run_proof_first_shift.py
- git diff --check
- bash scripts/automation_pr_preflight.sh origin/main HEAD

## Observer Shift
Ran one short observer cycle only:
- command: python3 scripts/run_proof_first_shift.py --repo-root /private/tmp/aragora-proof-first-shift-timebox-20260602 --max-hours 0.05 --interval-seconds 1 --once --dry-run --no-merge --json
- cycles: 1
- merge_limit: 0
- actions included: boss_restart_skipped:dry_run, merge_arbiter_restart_skipped:dry_run, merge_arbiter_apply_skipped:dry_run
- remaining time reported in cycle time_budget: ~160s

No merge, no admin merge, no manual statuses, no branch protection changes.