### PR TITLE
fix(review-health): flag stale proof checkouts

### DIFF
--- a/aragora/review/health.py
+++ b/aragora/review/health.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import subprocess
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -39,6 +40,7 @@ DEFAULT_BOSS_LOG_REL = DEFAULT_OVERNIGHT_REL / "boss-loop-launchd.log"
 DEFAULT_WATCHDOG_LOG_REL = DEFAULT_OVERNIGHT_REL / "watchdog.log"
 DEFAULT_B0_STATUS_REL = Path("docs") / "status" / "B0_BENCHMARK_TRUTH_STATUS.md"
 DEFAULT_TW03_STATUS_REL = Path("docs") / "status" / "TW03_RESCUE_PRODUCTIZATION_STATUS.md"
+GIT_SHOW_TIMEOUT_SECONDS = 5
 
 # Status severities (ordered ascending so max() returns worst).
 STATUS_FRESH = "fresh"
@@ -261,12 +263,8 @@ def _count_jsonl_rows(path: Path) -> dict[str, object]:
 _LAST_UPDATED_RE = re.compile(r"^Last updated:\s*(\S+)", re.MULTILINE)
 
 
-def _parse_status_doc_last_updated(path: Path) -> datetime | None:
-    """Read the 'Last updated:' line from a status markdown doc."""
-    try:
-        text = path.read_text(encoding="utf-8")
-    except OSError:
-        return None
+def _parse_status_doc_last_updated_text(text: str) -> datetime | None:
+    """Parse the 'Last updated:' line from a status markdown doc body."""
     match = _LAST_UPDATED_RE.search(text)
     if not match:
         return None
@@ -281,12 +279,45 @@ def _parse_status_doc_last_updated(path: Path) -> datetime | None:
         return None
 
 
+def _parse_status_doc_last_updated(path: Path) -> datetime | None:
+    """Read the 'Last updated:' line from a status markdown doc."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    return _parse_status_doc_last_updated_text(text)
+
+
+def _status_doc_last_updated_from_origin_main(repo: Path, rel_path: Path) -> datetime | None:
+    """Best-effort parse of a status doc from the local ``origin/main`` ref.
+
+    This is intentionally local and timeout-bounded: no fetch, no network, no
+    mutation. Missing refs or non-git fixture repos simply return ``None``.
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "show", f"origin/main:{rel_path.as_posix()}"],
+            cwd=str(repo),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=GIT_SHOW_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if proc.returncode != 0:
+        return None
+    return _parse_status_doc_last_updated_text(proc.stdout)
+
+
 def _check_status_doc(
     *,
     name: str,
     path: Path,
     warn_h: float,
     crit_h: float,
+    repo_root: Path | None = None,
+    rel_path: Path | None = None,
 ) -> SurfaceCheck:
     if not path.exists():
         return SurfaceCheck(
@@ -306,12 +337,34 @@ def _check_status_doc(
     now = _now()
     age = _age_hours(last, now)
     status = _classify_age(age, warn_h, crit_h)
+    extra: dict[str, object] = {}
+    detail: str | None = None
+    if repo_root is not None and rel_path is not None:
+        origin_last = _status_doc_last_updated_from_origin_main(repo_root, rel_path)
+        if origin_last is not None and origin_last > last:
+            origin_age = _age_hours(origin_last, now)
+            origin_status = _classify_age(origin_age, warn_h, crit_h)
+            extra.update(
+                {
+                    "checkout_stale_possible": True,
+                    "origin_main_last_updated": origin_last.isoformat(),
+                    "origin_main_age_hours": round(origin_age, 2),
+                    "origin_main_status": origin_status,
+                    "origin_main_fresh": origin_status == STATUS_FRESH,
+                }
+            )
+            detail = (
+                "origin/main has fresher Last updated "
+                f"({origin_last.isoformat()}); observer checkout may be stale"
+            )
     return SurfaceCheck(
         name=name,
         status=status,
         latest_mtime=last,
         age_hours=age,
         path=str(path),
+        detail=detail,
+        extra=extra,
     )
 
 
@@ -543,6 +596,8 @@ def gather_health(
             path=repo / DEFAULT_B0_STATUS_REL,
             warn_h=warn_hours_status_doc,
             crit_h=warn_hours_status_doc * crit_multiplier,
+            repo_root=repo,
+            rel_path=DEFAULT_B0_STATUS_REL,
         )
     )
 
@@ -553,6 +608,8 @@ def gather_health(
             path=repo / DEFAULT_TW03_STATUS_REL,
             warn_h=warn_hours_status_doc,
             crit_h=warn_hours_status_doc * crit_multiplier,
+            repo_root=repo,
+            rel_path=DEFAULT_TW03_STATUS_REL,
         )
     )
 

--- a/aragora/review/health.py
+++ b/aragora/review/health.py
@@ -300,10 +300,12 @@ def _status_doc_last_updated_from_origin_main(repo: Path, rel_path: Path) -> dat
             cwd=str(repo),
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             check=False,
             timeout=GIT_SHOW_TIMEOUT_SECONDS,
         )
-    except (OSError, subprocess.TimeoutExpired):
+    except (OSError, subprocess.SubprocessError, UnicodeDecodeError):
         return None
     if proc.returncode != 0:
         return None
@@ -339,7 +341,7 @@ def _check_status_doc(
     status = _classify_age(age, warn_h, crit_h)
     extra: dict[str, object] = {}
     detail: str | None = None
-    if repo_root is not None and rel_path is not None:
+    if status != STATUS_FRESH and repo_root is not None and rel_path is not None:
         origin_last = _status_doc_last_updated_from_origin_main(repo_root, rel_path)
         if origin_last is not None and origin_last > last:
             origin_age = _age_hours(origin_last, now)

--- a/tests/review/test_health.py
+++ b/tests/review/test_health.py
@@ -293,7 +293,6 @@ class TestGatherHealthStaleness:
             health_module,
             "_status_doc_last_updated_from_origin_main",
             fake_origin_last_updated,
-            raising=False,
         )
 
         report = gather_health(
@@ -351,6 +350,28 @@ class TestGatherHealthStaleness:
             raise UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte")
 
         monkeypatch.setattr(health_module.subprocess, "run", raise_decode_error)
+
+        assert (
+            health_module._status_doc_last_updated_from_origin_main(
+                tmp_path, health_module.DEFAULT_TW03_STATUS_REL
+            )
+            is None
+        )
+
+    def test_origin_main_missing_ref_degrades_to_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def return_missing_ref(
+            *_args: object, **_kwargs: object
+        ) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(
+                args=["git", "show"],
+                returncode=128,
+                stdout="",
+                stderr="fatal: invalid object name 'origin/main'",
+            )
+
+        monkeypatch.setattr(health_module.subprocess, "run", return_missing_ref)
 
         assert (
             health_module._status_doc_last_updated_from_origin_main(

--- a/tests/review/test_health.py
+++ b/tests/review/test_health.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import time
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
@@ -11,6 +12,7 @@ from pathlib import Path
 
 import pytest
 
+import aragora.review.health as health_module
 from aragora.cli.commands.review_queue import _cmd_health
 from aragora.review.health import (
     HealthReport,
@@ -273,6 +275,77 @@ class TestGatherHealthStaleness:
         )
         by_name = {s.name: s for s in report.surfaces}
         assert by_name["b0_publication"].status == STATUS_AGING
+
+    def test_status_doc_reports_when_origin_main_has_fresher_surface(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        layout = _setup_proof_loop(tmp_path)
+        stale = (datetime.now(UTC) - timedelta(days=60)).strftime("%Y-%m-%d")
+        fresh = datetime.now(UTC).replace(microsecond=0)
+        _write_status_doc(layout["docs_status"] / "TW03_RESCUE_PRODUCTIZATION_STATUS.md", stale)
+
+        def fake_origin_last_updated(repo: Path, rel: Path) -> datetime | None:
+            assert repo == layout["repo"]
+            assert rel == health_module.DEFAULT_TW03_STATUS_REL
+            return fresh
+
+        monkeypatch.setattr(
+            health_module,
+            "_status_doc_last_updated_from_origin_main",
+            fake_origin_last_updated,
+            raising=False,
+        )
+
+        report = gather_health(
+            repo_root=layout["repo"],
+            review_queue_root=layout["review_queue_root"],
+            overnight_root=layout["overnight"],
+            automation_receipts_root=layout["auto"],
+            warn_hours_status_doc=168,
+        )
+
+        by_name = {s.name: s for s in report.surfaces}
+        tw03 = by_name["tw03_rescue"]
+        assert tw03.status == STATUS_STALE
+        assert tw03.extra["checkout_stale_possible"] is True
+        assert tw03.extra["origin_main_fresh"] is True
+        assert tw03.extra["origin_main_last_updated"] == fresh.isoformat()
+        assert "origin/main has fresher Last updated" in str(tw03.detail)
+
+    def test_origin_main_status_doc_parser_reads_local_ref(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        status_doc = repo / health_module.DEFAULT_TW03_STATUS_REL
+        _write_status_doc(status_doc, "2026-06-01T16:51:59Z")
+        subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        subprocess.run(
+            [
+                "git",
+                "-c",
+                "user.name=Aragora Test",
+                "-c",
+                "user.email=aragora-test@example.com",
+                "commit",
+                "-m",
+                "seed status doc",
+            ],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "update-ref", "refs/remotes/origin/main", "HEAD"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+        )
+
+        parsed = health_module._status_doc_last_updated_from_origin_main(
+            repo, health_module.DEFAULT_TW03_STATUS_REL
+        )
+
+        assert parsed == datetime(2026, 6, 1, 16, 51, 59, tzinfo=UTC)
 
 
 class TestBossLoopLogCounter:

--- a/tests/review/test_health.py
+++ b/tests/review/test_health.py
@@ -312,6 +312,53 @@ class TestGatherHealthStaleness:
         assert tw03.extra["origin_main_last_updated"] == fresh.isoformat()
         assert "origin/main has fresher Last updated" in str(tw03.detail)
 
+    def test_fresh_status_docs_do_not_probe_origin_main(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        layout = _setup_proof_loop(tmp_path)
+        fresh = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+        _write_status_doc(layout["docs_status"] / "B0_BENCHMARK_TRUTH_STATUS.md", fresh)
+        _write_status_doc(layout["docs_status"] / "TW03_RESCUE_PRODUCTIZATION_STATUS.md", fresh)
+
+        def fail_if_called(repo: Path, rel: Path) -> datetime | None:
+            raise AssertionError(f"unexpected origin/main lookup for {repo}:{rel}")
+
+        monkeypatch.setattr(
+            health_module,
+            "_status_doc_last_updated_from_origin_main",
+            fail_if_called,
+        )
+
+        report = gather_health(
+            repo_root=layout["repo"],
+            review_queue_root=layout["review_queue_root"],
+            overnight_root=layout["overnight"],
+            automation_receipts_root=layout["auto"],
+        )
+
+        by_name = {s.name: s for s in report.surfaces}
+        assert by_name["b0_publication"].status == STATUS_FRESH
+        assert by_name["tw03_rescue"].status == STATUS_FRESH
+        assert by_name["b0_publication"].extra == {}
+        assert by_name["tw03_rescue"].extra == {}
+
+    def test_origin_main_decode_failure_degrades_to_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def raise_decode_error(
+            *_args: object, **_kwargs: object
+        ) -> subprocess.CompletedProcess[str]:
+            raise UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte")
+
+        monkeypatch.setattr(health_module.subprocess, "run", raise_decode_error)
+
+        assert (
+            health_module._status_doc_last_updated_from_origin_main(
+                tmp_path, health_module.DEFAULT_TW03_STATUS_REL
+            )
+            is None
+        )
+
     def test_origin_main_status_doc_parser_reads_local_ref(self, tmp_path: Path) -> None:
         repo = tmp_path / "repo"
         repo.mkdir()


### PR DESCRIPTION
## Summary
- annotate proof-status health surfaces when the current checkout is older than local origin/main
- keep review-queue health network-free and read-only by using timeout-bounded local git show only
- add direct and health-level tests for stale-checkout diagnostics

## Tests
- python3 -m pytest -q tests/review/test_health.py
- python3 -m pytest -q tests/review/test_health.py tests/review/test_alert.py tests/cli/commands/test_review_queue.py::TestCommandDispatch::test_parser_registers_build_packet_run_and_act
- git diff --check
- bash scripts/automation_pr_preflight.sh origin/main HEAD

No merge requested.