### PR TITLE
fix(proof-first): enforce shift time budget

### DIFF
--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -135,7 +135,7 @@ For full runtime configuration, see [ENVIRONMENT](../getting-started/environment
 | `tenant` | - | Manage multi-tenant deployments | `activate`, `create`, `delete`, `export`, `list`, `quota-get`, `quota-set`, `suspend` |
 | `testfixer` | - | Run automated test-fix loop | - |
 | `triage` | - | Inbox triage via adversarial debate with receipt-gated actions | `audit`, `auth`, `calibrate`, `digest`, `label`, `queue`, `run`, `status` |
-| `validate` | - | Validate API keys by making test calls | - |
+| `validate` | - | Run a full health check, including live API-key validation | - |
 | `validate-env` | - | Validate environment configuration and backend connectivity | - |
 | `verify` | - | Verify a decision receipt's integrity | - |
 | `verticals` | - | Manage vertical specialist configurations | - |

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -130,7 +130,7 @@ For full runtime configuration, see [ENVIRONMENT](ENVIRONMENT.md).
 | `tenant` | - | Manage multi-tenant deployments | `activate`, `create`, `delete`, `export`, `list`, `quota-get`, `quota-set`, `suspend` |
 | `testfixer` | - | Run automated test-fix loop | - |
 | `triage` | - | Inbox triage via adversarial debate with receipt-gated actions | `audit`, `auth`, `calibrate`, `digest`, `label`, `queue`, `run`, `status` |
-| `validate` | - | Validate API keys by making test calls | - |
+| `validate` | - | Run a full health check, including live API-key validation | - |
 | `validate-env` | - | Validate environment configuration and backend connectivity | - |
 | `verify` | - | Verify a decision receipt's integrity | - |
 | `verticals` | - | Manage vertical specialist configurations | - |

--- a/scripts/run_proof_first_shift.py
+++ b/scripts/run_proof_first_shift.py
@@ -35,6 +35,8 @@ MAX_UNAUTHORIZED_MERGE_LIMIT = 1
 DEFAULT_REFRESH_MINUTES = 120
 DEFAULT_MAX_HOURS = 12.0
 DEFAULT_INTERVAL_SECONDS = 120
+DEFAULT_MIN_ACTION_SECONDS = 5.0
+DEFAULT_TIME_BUDGET_MARGIN_SECONDS = 1.0
 DEFAULT_BOSS_LABEL = "com.aragora.swarm-boss-loop"
 DEFAULT_MERGE_LABEL = "com.aragora.swarm-merge-arbiter"
 DEFAULT_BOSS_PROCESS_PATTERN = r"aragora\.cli\.main swarm boss-loop|run_boss_cycle\.sh"
@@ -133,6 +135,10 @@ RECOVERY_STOP_REASONS = {
 }
 
 
+class ShiftTimeBudgetExceeded(RuntimeError):
+    """Raised when starting another expensive shift action would exceed the timebox."""
+
+
 @dataclass
 class ProofFirstRuntimeState:
     recovery_shift_id: str | None = None
@@ -168,6 +174,81 @@ def _assessment_id() -> str:
 
 def _runtime_state_path(repo_root: Path) -> Path:
     return repo_root / ".aragora" / DEFAULT_SHIFT_DIRNAME / "runtime_state.json"
+
+
+def _remaining_shift_seconds(
+    deadline_monotonic: float | None,
+    *,
+    now: Callable[[], float] | None = None,
+) -> float | None:
+    if deadline_monotonic is None:
+        return None
+    now_fn = now or time.monotonic
+    return float(deadline_monotonic) - float(now_fn())
+
+
+def _time_limit_reason(
+    *,
+    remaining_seconds: float,
+    max_hours: float,
+    action: str,
+    minimum_seconds: float = DEFAULT_MIN_ACTION_SECONDS,
+) -> str:
+    if remaining_seconds <= 0:
+        elapsed_hours = float(max_hours) + abs(float(remaining_seconds)) / 3600.0
+        return f"TimeLimit: {elapsed_hours:.2f}h >= max {float(max_hours):.2f}h"
+    required_seconds = float(minimum_seconds) + DEFAULT_TIME_BUDGET_MARGIN_SECONDS
+    return (
+        f"TimeLimit: insufficient remaining time for {action}: "
+        f"{remaining_seconds:.1f}s left < {required_seconds:.1f}s required "
+        f"(max {float(max_hours):.2f}h)"
+    )
+
+
+def _time_budget_blocker(
+    *,
+    deadline_monotonic: float | None,
+    max_hours: float,
+    action: str,
+    minimum_seconds: float = DEFAULT_MIN_ACTION_SECONDS,
+    now: Callable[[], float] | None = None,
+) -> str:
+    remaining_seconds = _remaining_shift_seconds(deadline_monotonic, now=now)
+    if remaining_seconds is None:
+        return ""
+    if remaining_seconds - DEFAULT_TIME_BUDGET_MARGIN_SECONDS >= float(minimum_seconds):
+        return ""
+    return _time_limit_reason(
+        remaining_seconds=remaining_seconds,
+        max_hours=max_hours,
+        action=action,
+        minimum_seconds=minimum_seconds,
+    )
+
+
+def _bounded_timeout_seconds(
+    default_timeout_seconds: int | float,
+    *,
+    deadline_monotonic: float | None,
+    max_hours: float,
+    action: str,
+    minimum_seconds: float = DEFAULT_MIN_ACTION_SECONDS,
+    now: Callable[[], float] | None = None,
+) -> int:
+    blocker = _time_budget_blocker(
+        deadline_monotonic=deadline_monotonic,
+        max_hours=max_hours,
+        action=action,
+        minimum_seconds=minimum_seconds,
+        now=now,
+    )
+    if blocker:
+        raise ShiftTimeBudgetExceeded(blocker)
+    remaining_seconds = _remaining_shift_seconds(deadline_monotonic, now=now)
+    if remaining_seconds is None:
+        return int(default_timeout_seconds)
+    available_seconds = max(1.0, remaining_seconds - DEFAULT_TIME_BUDGET_MARGIN_SECONDS)
+    return max(1, min(int(default_timeout_seconds), int(available_seconds)))
 
 
 def _default_recovery_attempt_counts() -> dict[str, int]:
@@ -365,7 +446,7 @@ def collect_boss_lane_snapshot(*, repo_root: Path, repo: str) -> dict[str, Any]:
     return collect_snapshot(args)
 
 
-def list_open_prs(*, repo_root: Path, repo: str) -> list[dict[str, Any]]:
+def list_open_prs(*, repo_root: Path, repo: str, timeout: int = 45) -> list[dict[str, Any]]:
     payload = _run_json(
         [
             "gh",
@@ -381,7 +462,7 @@ def list_open_prs(*, repo_root: Path, repo: str) -> list[dict[str, Any]]:
             "number,title,headRefName,isDraft,url",
         ],
         cwd=repo_root,
-        timeout=45,
+        timeout=timeout,
     )
     if not isinstance(payload, list):
         raise RuntimeError("gh pr list returned a non-list payload")
@@ -407,7 +488,12 @@ def has_open_benchmark_publication_pr(prs: list[dict[str, Any]]) -> bool:
     )
 
 
-def latest_benchmark_run(*, repo_root: Path, repo: str) -> dict[str, Any] | None:
+def latest_benchmark_run(
+    *,
+    repo_root: Path,
+    repo: str,
+    timeout: int = 45,
+) -> dict[str, Any] | None:
     payload = _run_json(
         [
             "gh",
@@ -423,7 +509,7 @@ def latest_benchmark_run(*, repo_root: Path, repo: str) -> dict[str, Any] | None
             "databaseId,createdAt,status,conclusion",
         ],
         cwd=repo_root,
-        timeout=45,
+        timeout=timeout,
     )
     if not isinstance(payload, list) or not payload:
         return None
@@ -580,21 +666,21 @@ def build_failure_policy_status(
     return status
 
 
-def fetch_benchmark_failure_log(*, repo_root: Path, run_id: int) -> str:
+def fetch_benchmark_failure_log(*, repo_root: Path, run_id: int, timeout: int = 60) -> str:
     proc = _run(
         ["gh", "run", "view", str(run_id), "--log-failed"],
         cwd=repo_root,
-        timeout=60,
+        timeout=timeout,
     )
     return proc.stdout or proc.stderr or ""
 
 
-def process_running(pattern: str) -> bool:
+def process_running(pattern: str, *, timeout: int = 10) -> bool:
     proc = subprocess.run(
         ["pgrep", "-f", pattern],
         text=True,
         capture_output=True,
-        timeout=10,
+        timeout=timeout,
         check=False,
     )
     return proc.returncode == 0 and bool(proc.stdout.strip())
@@ -905,18 +991,27 @@ def restart_boss_service(
     repo_root: Path,
     repo: str,
     process_pattern: str,
+    start_timeout_seconds: float | None = None,
 ) -> tuple[bool, str, str]:
     initial_status = inspect_launchd_service(DEFAULT_BOSS_LABEL)
     if launchd_service_missing(initial_status):
+        bootstrap_kwargs: dict[str, float] = {}
+        if start_timeout_seconds is not None:
+            bootstrap_kwargs["start_timeout_seconds"] = start_timeout_seconds
         restarted, detail = start_detached_boss_loop(
             repo_root=repo_root,
             repo=repo,
             process_pattern=process_pattern,
+            **bootstrap_kwargs,
         )
         return restarted, detail, "bootstrap_boss_loop_direct"
+    restart_kwargs: dict[str, float] = {}
+    if start_timeout_seconds is not None:
+        restart_kwargs["start_timeout_seconds"] = start_timeout_seconds
     restarted, detail = restart_service_via_launchd(
         label=DEFAULT_BOSS_LABEL,
         process_pattern=process_pattern,
+        **restart_kwargs,
     )
     return restarted, detail, "restart_boss_loop"
 
@@ -946,6 +1041,7 @@ def run_merge_arbiter_apply(
     repo_root: Path,
     repo: str,
     limit: int,
+    timeout: int = 120,
 ) -> dict[str, Any]:
     payload = _run_json(
         [
@@ -961,7 +1057,7 @@ def run_merge_arbiter_apply(
             "--json",
         ],
         cwd=repo_root,
-        timeout=120,
+        timeout=timeout,
     )
     if not isinstance(payload, dict):
         raise RuntimeError("merge arbiter helper returned a non-object payload")
@@ -985,11 +1081,11 @@ def resolve_merge_limit(
     return merge_limit
 
 
-def trigger_benchmark_workflow(*, repo_root: Path, repo: str) -> None:
+def trigger_benchmark_workflow(*, repo_root: Path, repo: str, timeout: int = 45) -> None:
     proc = _run(
         ["gh", "workflow", "run", "Benchmark Truth Publication", "--repo", repo],
         cwd=repo_root,
-        timeout=45,
+        timeout=timeout,
     )
     if proc.returncode != 0:
         raise RuntimeError(proc.stderr.strip() or proc.stdout.strip() or "gh workflow run failed")
@@ -1067,12 +1163,65 @@ def run_shift_cycle(
     allow_multiple_merges: bool = False,
     ledger: ShiftLedger | None = None,
     max_hours: float = DEFAULT_MAX_HOURS,
+    deadline_monotonic: float | None = None,
 ) -> dict[str, Any]:
+    def require_time_budget(
+        action: str, *, minimum_seconds: float = DEFAULT_MIN_ACTION_SECONDS
+    ) -> None:
+        blocker = _time_budget_blocker(
+            deadline_monotonic=deadline_monotonic,
+            max_hours=max_hours,
+            action=action,
+            minimum_seconds=minimum_seconds,
+        )
+        if blocker:
+            raise ShiftTimeBudgetExceeded(blocker)
+
+    def bounded_timeout(
+        default_timeout_seconds: int,
+        action: str,
+        *,
+        minimum_seconds: float = DEFAULT_MIN_ACTION_SECONDS,
+    ) -> int:
+        return _bounded_timeout_seconds(
+            default_timeout_seconds,
+            deadline_monotonic=deadline_monotonic,
+            max_hours=max_hours,
+            action=action,
+            minimum_seconds=minimum_seconds,
+        )
+
+    def timeout_kwargs(
+        default_timeout_seconds: int,
+        action: str,
+        *,
+        minimum_seconds: float = DEFAULT_MIN_ACTION_SECONDS,
+    ) -> dict[str, int]:
+        if deadline_monotonic is None:
+            return {}
+        return {
+            "timeout": bounded_timeout(
+                default_timeout_seconds,
+                action,
+                minimum_seconds=minimum_seconds,
+            )
+        }
+
+    def start_timeout_kwargs(
+        default_timeout_seconds: int,
+        action: str,
+    ) -> dict[str, int]:
+        if deadline_monotonic is None:
+            return {}
+        return {"start_timeout_seconds": bounded_timeout(default_timeout_seconds, action)}
+
+    require_time_budget("shift_cycle")
     effective_merge_limit = resolve_merge_limit(
         merge_limit=merge_limit,
         no_merge=no_merge or dry_run,
         allow_multiple_merges=allow_multiple_merges,
     )
+    require_time_budget("queue_reconciliation")
     queue_report = reconcile_proof_first_queue(repo=repo, repo_root=repo_root, apply=not dry_run)
     github_status = dict(queue_report.get("github_status") or {})
     queue_removed_count = len(queue_report.get("removed") or [])
@@ -1132,15 +1281,23 @@ def run_shift_cycle(
                 repeated_failure_classes=outage_repeated_failure_classes,
             ),
         }
+    require_time_budget("boss_lane_snapshot")
     snapshot = collect_boss_lane_snapshot(repo_root=repo_root, repo=repo)
-    prs = list_open_prs(repo_root=repo_root, repo=repo)
+    prs = list_open_prs(
+        repo_root=repo_root,
+        repo=repo,
+        **timeout_kwargs(45, "list_open_prs"),
+    )
     actionable_prs = actionable_open_prs(prs)
     automation_backlog = count_automation_backlog(actionable_prs)
     open_pr_count = len(actionable_prs)
     draft_pr_count = len(prs) - open_pr_count
     canonical_queue_count = len(queue_report["kept"])
 
-    boss_process_running = process_running(DEFAULT_BOSS_PROCESS_PATTERN)
+    boss_process_running = process_running(
+        DEFAULT_BOSS_PROCESS_PATTERN,
+        **timeout_kwargs(10, "boss_process_check", minimum_seconds=1.0),
+    )
     boss_throttle_healthy = False
     boss_throttle_reason = ""
     if not boss_process_running:
@@ -1151,7 +1308,10 @@ def run_shift_cycle(
     # and respawns after ThrottleInterval. Treat the throttle window as healthy
     # so the shift does not burn its restart budget on a non-failure.
     boss_running = boss_process_running or boss_throttle_healthy
-    merge_running = process_running(DEFAULT_MERGE_PROCESS_PATTERN)
+    merge_running = process_running(
+        DEFAULT_MERGE_PROCESS_PATTERN,
+        **timeout_kwargs(10, "merge_process_check", minimum_seconds=1.0),
+    )
 
     actions: list[str] = []
     # Surface the throttle-helper's verdict in the cycle_tick payload so that
@@ -1175,6 +1335,7 @@ def run_shift_cycle(
             repo_root=repo_root,
             repo=repo,
             process_pattern=DEFAULT_BOSS_PROCESS_PATTERN,
+            **start_timeout_kwargs(int(DEFAULT_LAUNCHD_START_TIMEOUT_SECONDS), "restart_boss_loop"),
         )
         runtime_state.boss_restart_count += 1
         record_recovery_attempt(
@@ -1212,6 +1373,10 @@ def run_shift_cycle(
         restarted, detail = restart_service_via_launchd(
             label=DEFAULT_MERGE_LABEL,
             process_pattern=DEFAULT_MERGE_PROCESS_PATTERN,
+            **start_timeout_kwargs(
+                int(DEFAULT_LAUNCHD_START_TIMEOUT_SECONDS),
+                "restart_merge_arbiter",
+            ),
         )
         runtime_state.merge_restart_count += 1
         record_recovery_attempt(
@@ -1247,6 +1412,7 @@ def run_shift_cycle(
             repo_root=repo_root,
             repo=repo,
             limit=effective_merge_limit,
+            **timeout_kwargs(120, "merge_arbiter_apply"),
         )
     merged_numbers = list(merge_report.get("merged") or [])
     if merged_numbers:
@@ -1255,7 +1421,12 @@ def run_shift_cycle(
             for num in merged_numbers:
                 ledger.record_pr_merged(pr_number=int(num))
 
-    latest_run = latest_benchmark_run(repo_root=repo_root, repo=repo)
+    latest_run = latest_benchmark_run(
+        repo_root=repo_root,
+        repo=repo,
+        **timeout_kwargs(45, "latest_benchmark_run"),
+    )
+    require_time_budget("benchmark_truth_state_drift")
     benchmark_truth_drift = benchmark_truth_state_drift(repo_root=repo_root, repo=repo)
     latest_failure_class = ""
     latest_failure_detail = ""
@@ -1271,7 +1442,11 @@ def run_shift_cycle(
                     created_at=str(latest_run.get("createdAt", "")),
                 )
             if conclusion == "failure":
-                failure_log = fetch_benchmark_failure_log(repo_root=repo_root, run_id=run_id)
+                failure_log = fetch_benchmark_failure_log(
+                    repo_root=repo_root,
+                    run_id=run_id,
+                    **timeout_kwargs(60, "fetch_benchmark_failure_log"),
+                )
                 failure_class = classify_benchmark_failure_log(failure_log)
                 if failure_class == "auth_failure":
                     runtime_state.auth_failure_count += 1
@@ -1342,7 +1517,11 @@ def run_shift_cycle(
                 stop_reason = RECOVERY_STOP_REASONS[latest_failure_class]
             else:
                 try:
-                    trigger_benchmark_workflow(repo_root=repo_root, repo=repo)
+                    trigger_benchmark_workflow(
+                        repo_root=repo_root,
+                        repo=repo,
+                        **timeout_kwargs(45, "trigger_benchmark_workflow"),
+                    )
                 except RuntimeError as exc:
                     detail = str(exc).strip() or "benchmark workflow trigger failed"
                     runtime_state.runtime_failure_count += 1
@@ -1376,7 +1555,11 @@ def run_shift_cycle(
                         runtime_state.last_triggered_benchmark_run_id = -1
         else:
             try:
-                trigger_benchmark_workflow(repo_root=repo_root, repo=repo)
+                trigger_benchmark_workflow(
+                    repo_root=repo_root,
+                    repo=repo,
+                    **timeout_kwargs(45, "trigger_benchmark_workflow"),
+                )
             except RuntimeError as exc:
                 detail = str(exc).strip() or "benchmark workflow trigger failed"
                 runtime_state.runtime_failure_count += 1
@@ -1491,10 +1674,12 @@ async def _run_shift(args: argparse.Namespace) -> dict[str, Any]:
     ledger = ShiftLedger(path=repo_root / ".aragora" / DEFAULT_SHIFT_DIRNAME / "shift_ledger.jsonl")
     shift_id = _assessment_id()
     shift_start_time = time.monotonic()
+    max_hours = float(args.max_hours)
+    deadline_monotonic = shift_start_time + max_hours * 3600.0
 
     controller = ShiftController(
         ShiftConfig(
-            max_duration_hours=float(args.max_hours),
+            max_duration_hours=max_hours,
             refresh_interval_minutes=float(args.refresh_minutes),
             budget_limit_usd=9999.0,
             max_cycles=10000,
@@ -1526,6 +1711,21 @@ async def _run_shift(args: argparse.Namespace) -> dict[str, Any]:
     cycle_reports: list[dict[str, Any]] = []
     cycle_count = 0
     while True:
+        deadline_reason = _time_budget_blocker(
+            deadline_monotonic=deadline_monotonic,
+            max_hours=max_hours,
+            action="shift_cycle",
+        )
+        if deadline_reason:
+            controller.complete_shift(deadline_reason)
+            ledger.record_shift_stop(
+                shift_id=shift_id,
+                reason=deadline_reason,
+                cycles=cycle_count,
+                duration_seconds=time.monotonic() - shift_start_time,
+            )
+            break
+
         should_stop, reason = controller.check_should_stop()
         if should_stop:
             if reason.startswith("RefreshDue"):
@@ -1541,19 +1741,31 @@ async def _run_shift(args: argparse.Namespace) -> dict[str, Any]:
                 )
                 break
 
-        report = run_shift_cycle(
-            repo_root=repo_root,
-            repo=args.repo,
-            benchmark_mode=args.benchmark_mode,
-            automation_backlog_limit=int(args.automation_backlog_limit),
-            merge_limit=int(args.merge_limit),
-            no_merge=bool(args.no_merge),
-            dry_run=bool(args.dry_run),
-            allow_multiple_merges=bool(args.allow_multiple_merges),
-            runtime_state=runtime_state,
-            ledger=ledger,
-            max_hours=float(args.max_hours),
-        )
+        try:
+            report = run_shift_cycle(
+                repo_root=repo_root,
+                repo=args.repo,
+                benchmark_mode=args.benchmark_mode,
+                automation_backlog_limit=int(args.automation_backlog_limit),
+                merge_limit=int(args.merge_limit),
+                no_merge=bool(args.no_merge),
+                dry_run=bool(args.dry_run),
+                allow_multiple_merges=bool(args.allow_multiple_merges),
+                runtime_state=runtime_state,
+                ledger=ledger,
+                max_hours=max_hours,
+                deadline_monotonic=deadline_monotonic,
+            )
+        except ShiftTimeBudgetExceeded as exc:
+            reason = str(exc)
+            controller.complete_shift(reason)
+            ledger.record_shift_stop(
+                shift_id=shift_id,
+                reason=reason,
+                cycles=cycle_count,
+                duration_seconds=time.monotonic() - shift_start_time,
+            )
+            break
         cycle_reports.append(report)
         cycle_count += 1
         save_runtime_state(runtime_state_path, runtime_state)
@@ -1578,13 +1790,17 @@ async def _run_shift(args: argparse.Namespace) -> dict[str, Any]:
                 duration_seconds=time.monotonic() - shift_start_time,
             )
             break
-        await asyncio.sleep(float(args.interval_seconds))
+        sleep_seconds = float(args.interval_seconds)
+        remaining_seconds = _remaining_shift_seconds(deadline_monotonic)
+        if remaining_seconds is not None:
+            sleep_seconds = min(sleep_seconds, max(0.0, remaining_seconds))
+        await asyncio.sleep(sleep_seconds)
 
     summary = {
         "shift": controller.get_progress_summary(),
         "runtime_state": asdict(runtime_state),
         "cycles": cycle_reports,
-        "ledger_status": ledger.get_status_summary(max_age_hours=float(args.max_hours)),
+        "ledger_status": ledger.get_status_summary(max_age_hours=max_hours),
         "green_shift_evaluation": (
             cycle_reports[-1]["green_shift_evaluation"]
             if cycle_reports
@@ -1597,7 +1813,7 @@ async def _run_shift(args: argparse.Namespace) -> dict[str, Any]:
                 latest_run=None,
                 benchmark_drift_open=True,
                 runtime_state=runtime_state,
-                max_age_hours=float(args.max_hours),
+                max_age_hours=max_hours,
                 stop_reason=str(controller.get_progress_summary().get("stop_reason") or ""),
                 repeated_failure_classes=[],
             )

--- a/tests/scripts/test_run_proof_first_shift.py
+++ b/tests/scripts/test_run_proof_first_shift.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import subprocess
 from datetime import UTC, datetime
@@ -341,6 +342,77 @@ def test_run_shift_cycle_no_merge_skips_restart_and_apply() -> None:
     assert report["merge_report"] == {"merged": [], "skipped": True, "reason": "no_merge"}
     assert "merge_arbiter_restart_skipped:no_merge" in report["actions"]
     assert "merge_arbiter_apply_skipped:no_merge" in report["actions"]
+
+
+def test_run_shift_stops_before_starting_cycle_after_deadline(tmp_path: Path) -> None:
+    args = mod._build_parser().parse_args(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--max-hours",
+            "0.001",
+            "--interval-seconds",
+            "1",
+        ]
+    )
+
+    monotonic_values = iter([0.0])
+
+    def fake_monotonic() -> float:
+        return next(monotonic_values, 4.0)
+
+    with (
+        patch("scripts.run_proof_first_shift.time.monotonic", side_effect=fake_monotonic),
+        patch(
+            "scripts.run_proof_first_shift.run_shift_cycle",
+            side_effect=AssertionError("expired shift must not start another cycle"),
+        ),
+    ):
+        summary = asyncio.run(mod._run_shift(args))
+
+    assert summary["cycles"] == []
+    assert str(summary["shift"]["stop_reason"]).startswith("TimeLimit:")
+
+
+def test_run_shift_cycle_caps_merge_apply_timeout_to_remaining_shift_budget() -> None:
+    state = mod.ProofFirstRuntimeState()
+    repo_root = Path(".").resolve()
+
+    with (
+        patch(
+            "scripts.run_proof_first_shift.reconcile_proof_first_queue",
+            return_value={"kept": [], "removed": []},
+        ),
+        patch(
+            "scripts.run_proof_first_shift.collect_boss_lane_snapshot", return_value={"ok": True}
+        ),
+        patch("scripts.run_proof_first_shift.list_open_prs", return_value=[]),
+        patch("scripts.run_proof_first_shift.process_running", return_value=True),
+        patch(
+            "scripts.run_proof_first_shift.run_merge_arbiter_apply", return_value={"merged": []}
+        ) as merge_mock,
+        patch("scripts.run_proof_first_shift.latest_benchmark_run", return_value=None),
+        patch(
+            "scripts.run_proof_first_shift.benchmark_truth_state_drift",
+            return_value={"issue_count": 0},
+        ),
+        patch("scripts.run_proof_first_shift.time.monotonic", return_value=100.0),
+    ):
+        mod.run_shift_cycle(
+            repo_root=repo_root,
+            repo="synaptent/aragora",
+            benchmark_mode="disabled",
+            automation_backlog_limit=12,
+            runtime_state=state,
+            deadline_monotonic=130.0,
+        )
+
+    merge_mock.assert_called_once_with(
+        repo_root=repo_root,
+        repo="synaptent/aragora",
+        limit=1,
+        timeout=29,
+    )
 
 
 def test_dry_run_uses_single_merge_limit_and_is_read_only() -> None:


### PR DESCRIPTION
## Summary
- Enforce the proof-first shift wall-clock deadline before dispatching another cycle.
- Thread a monotonic deadline through expensive cycle actions so subprocess helpers get bounded remaining-time timeouts.
- Fail closed when remaining time is insufficient while preserving dry-run/no-merge and single-merge guard behavior.

## Verification
- `python3 -m pytest -q tests/scripts/test_run_proof_first_shift.py` (`64 passed`)
- `python3 -m ruff check scripts/run_proof_first_shift.py tests/scripts/test_run_proof_first_shift.py`
- `git diff --check`
- One observer run only: `python3 scripts/run_proof_first_shift.py --repo-root /private/tmp/aragora-proof-shift-deadline-20260602 --repo synaptent/aragora --max-hours 0.05 --interval-seconds 1 --once --dry-run --no-merge --benchmark-mode disabled --json`

## Observer Shift Result
- No merges, no restarts, no workflow triggers.
- Proof freshness from clean origin/main worktree: fresh (`b0` age 4.6358d, `tw03` age 0.6501d).
- Publisher readiness from shared root: ready (`cache_age=2.7m`, `outbox=103`, `cache=103`).
- Review-queue health from shared root: stale due stale `briefs` and `boss_metrics`; boss-loop log is fresh but reports historical crash/fail counts.

No merge/admin-merge/status/branch-protection changes were performed.
