### PR TITLE
fix(publisher): fall back to cached open PR heads

### DIFF
--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -42,6 +42,8 @@ CODEX_BRANCH_PREFIX = "codex/"
 DEFAULT_PREFLIGHT_SCRIPT = "scripts/automation_pr_preflight.sh"
 DEFAULT_PRE_PUSH_SKIP_HOOKS = "mypy-baseline"
 DEFAULT_OUTBOX_DIR = Path(".aragora/automation-outbox")
+DEFAULT_GITHUB_STATUS_CACHE = Path(".aragora/automation-github-status/latest.json")
+DEFAULT_GITHUB_STATUS_CACHE_MAX_AGE_SECONDS = 1800
 DEFAULT_SPEND_LEDGER_DIR = Path(".aragora/spend-ledger")
 VERIFY_AUTOMATION_GIT_PUSH_ENV = "ARAGORA_AUTOMATION_GIT_PUSH_VERIFY"
 MIN_FREE_GIB_ENV = "ARAGORA_AUTOMATION_MIN_FREE_GIB"
@@ -97,6 +99,16 @@ ACTIVE_SESSION_FILES = (
     ".codex_session_active",
     ".nomic-session-active",
 )
+
+
+class OpenCodexPrLookupError(RuntimeError):
+    """Raised when live open-PR listing fails and no safe cache fallback exists."""
+
+    def __init__(self, error: str, cache_meta: dict[str, Any]) -> None:
+        super().__init__(error)
+        self.error = error
+        self.cache_meta = cache_meta
+
 
 try:
     from aragora.swarm.github_app_auth import gh_subprocess_run, github_cli_env
@@ -741,6 +753,132 @@ def _open_codex_prs(repo_root: Path, repo: str) -> list[dict[str, Any]]:
         and isinstance(item.get("headRefName"), str)
         and item["headRefName"].startswith(CODEX_BRANCH_PREFIX)
     ]
+
+
+def _parse_cache_timestamp(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    normalized = value.strip()
+    if normalized.endswith("Z"):
+        normalized = f"{normalized[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _open_codex_prs_from_status_cache(
+    repo_root: Path,
+    repo: str,
+    *,
+    max_age_seconds: float = DEFAULT_GITHUB_STATUS_CACHE_MAX_AGE_SECONDS,
+) -> tuple[list[dict[str, Any]] | None, dict[str, Any]]:
+    cache_path = _automation_state_path(repo_root, None, DEFAULT_GITHUB_STATUS_CACHE)
+    meta: dict[str, Any] = {
+        "cache_path": str(cache_path),
+        "cache_usable": False,
+    }
+    try:
+        text = cache_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        meta["cache_reason"] = f"cache_read_failed:{exc.__class__.__name__}"
+        return None, meta
+
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        meta["cache_reason"] = "cache_invalid_json"
+        return None, meta
+    if not isinstance(payload, Mapping):
+        meta["cache_reason"] = "cache_not_object"
+        return None, meta
+
+    cached_repo = payload.get("github_repo")
+    if isinstance(cached_repo, str) and cached_repo and cached_repo != repo:
+        meta["cache_reason"] = f"repo_mismatch:{cached_repo}"
+        return None, meta
+
+    generated_at = payload.get("generated_at")
+    generated_dt = _parse_cache_timestamp(generated_at)
+    if generated_dt is None:
+        meta["cache_reason"] = "cache_missing_generated_at"
+        return None, meta
+    age_seconds = (datetime.now(UTC) - generated_dt).total_seconds()
+    meta["cache_generated_at"] = generated_dt.isoformat()
+    meta["cache_age_seconds"] = round(age_seconds, 3)
+    if age_seconds > max_age_seconds:
+        meta["cache_reason"] = "cache_stale"
+        return None, meta
+
+    github_queue = payload.get("github_queue")
+    if not isinstance(github_queue, Mapping):
+        meta["cache_reason"] = "cache_missing_github_queue"
+        return None, meta
+    if github_queue.get("available") is not True:
+        reason = str(github_queue.get("reason") or "unknown")
+        meta["cache_reason"] = f"github_queue_unavailable:{reason}"
+        return None, meta
+
+    raw_prs = github_queue.get("open_prs")
+    prs: list[dict[str, Any]] = []
+    if isinstance(raw_prs, list):
+        prs = [
+            item
+            for item in raw_prs
+            if isinstance(item, dict)
+            and isinstance(item.get("headRefName"), str)
+            and item["headRefName"].startswith(CODEX_BRANCH_PREFIX)
+        ]
+    else:
+        raw_heads = github_queue.get("open_pr_heads")
+        if not isinstance(raw_heads, list):
+            meta["cache_reason"] = "cache_missing_open_pr_heads"
+            return None, meta
+        prs = [
+            {"headRefName": head}
+            for head in raw_heads
+            if isinstance(head, str) and head.startswith(CODEX_BRANCH_PREFIX)
+        ]
+
+    if not prs and int(github_queue.get("open_codex_pr_count") or 0) > 0:
+        meta["cache_reason"] = "cache_open_pr_count_without_heads"
+        return None, meta
+
+    meta["cache_usable"] = True
+    meta["cache_reason"] = "usable"
+    meta["cache_queue_health"] = {
+        "open_codex_pr_count": github_queue.get("open_codex_pr_count"),
+        "unhealthy_open_pr_count": github_queue.get("unhealthy_open_pr_count"),
+        "all_open_prs_unhealthy": github_queue.get("all_open_prs_unhealthy"),
+        "merge_state_counts": github_queue.get("merge_state_counts"),
+    }
+    return prs, meta
+
+
+def _open_codex_prs_with_cache_fallback(
+    repo_root: Path,
+    repo: str,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    try:
+        return _open_codex_prs(repo_root, repo), {
+            "source": "live",
+            "status": "ok",
+        }
+    except RuntimeError as exc:
+        live_error = str(exc)
+        cached_prs, cache_meta = _open_codex_prs_from_status_cache(repo_root, repo)
+        if cached_prs is None:
+            raise OpenCodexPrLookupError(live_error, cache_meta) from exc
+        lookup_meta = {
+            "source": "cache",
+            "status": "ok",
+            "fallback_error": live_error,
+        }
+        lookup_meta.update(cache_meta)
+        return cached_prs, lookup_meta
 
 
 def _open_pr_heads(repo_root: Path, repo: str) -> set[str]:
@@ -1432,7 +1570,35 @@ def main(argv: list[str] | None = None) -> int:
             print(f"github_unavailable: {github_health.mode} {github_health.error}".strip())
         return 0 if not hydrated_branches else 1
 
-    open_codex_prs = _open_codex_prs(repo_root, args.github_repo)
+    try:
+        open_codex_prs, open_pr_lookup = _open_codex_prs_with_cache_fallback(
+            repo_root, args.github_repo
+        )
+    except OpenCodexPrLookupError as exc:
+        failed_payload: dict[str, Any] = {
+            "repo": str(repo_root),
+            "base": args.base,
+            "cutoff": cutoff.isoformat(),
+            "receipt_dir": str(args.receipt_dir) if args.receipt_dir else None,
+            "scanned_branch_count": len(hydrated_branches),
+            "open_pr_count": 0,
+            "max_open_prs": args.max_open_prs,
+            "github_health": github_health.to_dict(),
+            "open_pr_lookup": {
+                "source": "live",
+                "status": "failed",
+                "error": exc.error,
+                **exc.cache_meta,
+            },
+            "decisions": [],
+        }
+        if args.json:
+            print(json.dumps(failed_payload, indent=2))
+        else:
+            cache_reason = exc.cache_meta.get("cache_reason") or "cache_unusable"
+            print(f"open_pr_lookup_failed: {exc.error}; {cache_reason}")
+        return 0 if not hydrated_branches else 1
+
     open_pr_heads = {
         item["headRefName"] for item in open_codex_prs if isinstance(item.get("headRefName"), str)
     }
@@ -1489,6 +1655,29 @@ def main(argv: list[str] | None = None) -> int:
             )
     unhealthy_open_pr_count = len(unhealthy_open_prs)
     all_open_prs_unhealthy = bool(open_codex_prs) and unhealthy_open_pr_count == len(open_codex_prs)
+    cache_queue_health = open_pr_lookup.get("cache_queue_health")
+    if open_pr_lookup.get("source") == "cache" and isinstance(cache_queue_health, Mapping):
+        cached_merge_state_counts = cache_queue_health.get("merge_state_counts")
+        if isinstance(cached_merge_state_counts, Mapping):
+            merge_state_counts = {
+                str(key): int(value)
+                for key, value in cached_merge_state_counts.items()
+                if isinstance(value, int)
+            }
+        cached_unhealthy_count = cache_queue_health.get("unhealthy_open_pr_count")
+        if isinstance(cached_unhealthy_count, int):
+            unhealthy_open_pr_count = cached_unhealthy_count
+        cached_all_unhealthy = cache_queue_health.get("all_open_prs_unhealthy")
+        if isinstance(cached_all_unhealthy, bool):
+            all_open_prs_unhealthy = cached_all_unhealthy
+        if unhealthy_open_pr_count and not unhealthy_open_prs:
+            unhealthy_open_prs = [
+                {
+                    "reasons": [
+                        "details_unavailable_from_github_status_cache",
+                    ]
+                }
+            ]
     guardrail_report = evaluate_automation_guardrails(
         repo_root,
         open_pr_count=len(open_pr_heads),
@@ -1503,11 +1692,15 @@ def main(argv: list[str] | None = None) -> int:
         "open_pr_count": len(open_pr_heads),
         "max_open_prs": args.max_open_prs,
         "queue_health": {
+            "open_pr_lookup_source": open_pr_lookup.get("source"),
             "open_codex_pr_count": len(open_codex_prs),
             "unhealthy_open_pr_count": unhealthy_open_pr_count,
             "merge_state_counts": merge_state_counts,
             "all_open_prs_unhealthy": all_open_prs_unhealthy,
             "unhealthy_open_prs": unhealthy_open_prs,
+        },
+        "open_pr_lookup": {
+            key: value for key, value in open_pr_lookup.items() if key != "cache_queue_health"
         },
         "automation_guardrails": asdict(guardrail_report),
         "github_health": github_health.to_dict(),

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -1040,6 +1040,7 @@ def test_main_can_override_unhealthy_queue_pause_for_preflighted_branch(
         mod, "_branch_patch_equivalent_to_base", lambda repo_root, base, branch: False
     )
     monkeypatch.setattr(mod, "_branch_has_pr_diff", lambda repo_root, base, branch: True)
+    monkeypatch.setattr(mod, "_branch_unique_commit_count", lambda repo_root, base, branch: 1)
     monkeypatch.setattr(mod, "outbox_superseded_branches", lambda repo_root, outbox_dir=None: set())
     monkeypatch.setattr(mod, "_branch_remote_head", lambda repo_root, branch: None)
     monkeypatch.setattr(
@@ -1149,6 +1150,132 @@ def test_main_does_not_pause_for_green_review_required_codex_pr(
     out = capsys.readouterr().out
     assert '"publish_paused_reason"' not in out
     assert '"unhealthy_open_pr_count": 0' in out
+
+
+def test_main_falls_back_to_cached_open_pr_heads_when_live_listing_504s(
+    monkeypatch: Any, tmp_path: Path, capsys
+) -> None:
+    branch = BranchSnapshot(
+        branch="codex/already-open-from-cache",
+        upstream=None,
+        head_sha="abc1234",
+        committed_at=datetime.now(UTC),
+        subject="cached open branch",
+        unique_commit_count=1,
+    )
+    cache_path = tmp_path / ".aragora" / "automation-github-status" / "latest.json"
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_text(
+        json.dumps(
+            {
+                "generated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+                "github_repo": "synaptent/aragora",
+                "github_queue": {
+                    "available": True,
+                    "open_codex_pr_count": 1,
+                    "unhealthy_open_pr_count": 0,
+                    "all_open_prs_unhealthy": False,
+                    "merge_state_counts": {"UNSTABLE": 1},
+                    "open_pr_heads": ["codex/already-open-from-cache"],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(mod, "_repo_root", lambda path: tmp_path)
+    monkeypatch.setattr(mod, "_local_codex_branches", lambda repo_root: [branch])
+    monkeypatch.setattr(mod, "_list_worktrees", lambda repo_root, branch_filter=None: [])
+    monkeypatch.setattr(mod, "_branches_with_pr_history", lambda repo_root, repo, branches: set())
+    monkeypatch.setattr(
+        mod,
+        "_branches_with_resolved_related_work",
+        lambda repo_root, repo, branches: set(),
+    )
+    monkeypatch.setattr(
+        mod,
+        "_open_codex_prs",
+        lambda repo_root, repo: (_ for _ in ()).throw(RuntimeError("HTTP 504")),
+    )
+    monkeypatch.setattr(mod, "_branch_is_merged", lambda repo_root, base, branch: False)
+    monkeypatch.setattr(
+        mod, "_branch_patch_equivalent_to_base", lambda repo_root, base, branch: False
+    )
+    monkeypatch.setattr(mod, "_branch_has_pr_diff", lambda repo_root, base, branch: True)
+    monkeypatch.setattr(mod, "_branch_unique_commit_count", lambda repo_root, base, branch: 1)
+    monkeypatch.setattr(mod, "outbox_superseded_branches", lambda repo_root, outbox_dir=None: set())
+    monkeypatch.setattr(mod, "_branch_remote_head", lambda repo_root, branch: None)
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda repo_root: GitHubCLIHealth(
+            ready=True,
+            auth_ok=True,
+            api_ok=True,
+            mode="ready",
+            error="",
+            repo=str(tmp_path),
+        ),
+    )
+
+    exit_code = mod.main(["--repo", str(tmp_path), "--json"])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert '"source": "cache"' in out
+    assert '"fallback_error": "HTTP 504"' in out
+    assert '"open_pr_exists"' in out
+    assert '"open_pr_count": 1' in out
+
+
+def test_main_reports_open_pr_lookup_failure_when_cache_is_unusable(
+    monkeypatch: Any, tmp_path: Path, capsys
+) -> None:
+    branch = BranchSnapshot(
+        branch="codex/needs-live-open-prs",
+        upstream=None,
+        head_sha="abc1234",
+        committed_at=datetime.now(UTC),
+        subject="needs live open prs",
+        unique_commit_count=1,
+    )
+
+    monkeypatch.setattr(mod, "_repo_root", lambda path: tmp_path)
+    monkeypatch.setattr(mod, "_local_codex_branches", lambda repo_root: [branch])
+    monkeypatch.setattr(mod, "_list_worktrees", lambda repo_root, branch_filter=None: [])
+    monkeypatch.setattr(
+        mod,
+        "_open_codex_prs",
+        lambda repo_root, repo: (_ for _ in ()).throw(RuntimeError("HTTP 504")),
+    )
+    monkeypatch.setattr(mod, "_branch_is_merged", lambda repo_root, base, branch: False)
+    monkeypatch.setattr(
+        mod, "_branch_patch_equivalent_to_base", lambda repo_root, base, branch: False
+    )
+    monkeypatch.setattr(mod, "_branch_has_pr_diff", lambda repo_root, base, branch: True)
+    monkeypatch.setattr(mod, "outbox_superseded_branches", lambda repo_root, outbox_dir=None: set())
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda repo_root: GitHubCLIHealth(
+            ready=True,
+            auth_ok=True,
+            api_ok=True,
+            mode="ready",
+            error="",
+            repo=str(tmp_path),
+        ),
+    )
+
+    exit_code = mod.main(["--repo", str(tmp_path), "--json"])
+
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert '"open_pr_lookup"' in out
+    assert '"status": "failed"' in out
+    assert '"error": "HTTP 504"' in out
+    assert '"cache_usable": false' in out
+    assert '"decisions": []' in out
 
 
 def test_review_required_inflight_pr_does_not_pause_for_pending_or_advisory_cancelled() -> None:


### PR DESCRIPTION
## Summary
- catch live `gh pr list` open-PR lookup failures in the branch publisher
- fall back to a fresh `.aragora/automation-github-status/latest.json` queue snapshot when it has usable `open_pr_heads`
- return structured `open_pr_lookup` failure JSON instead of a traceback when live GitHub and cache evidence are both unusable

## Tests
- `python3 -m pytest -q tests/scripts/test_publish_codex_automation_branches.py tests/scripts/test_cache_codex_automation_github_status.py`
- `python3 -m ruff check scripts/publish_codex_automation_branches.py tests/scripts/test_publish_codex_automation_branches.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Live dogfood
- Re-ran the failing explicit-branch dry-run; it now exits with structured JSON showing `cache_reason=github_queue_unavailable:connectivity_failed` instead of throwing a Python traceback.
