### PR TITLE
fix(work): bound work board output

### DIFF
--- a/aragora/cli/commands/work_board.py
+++ b/aragora/cli/commands/work_board.py
@@ -49,6 +49,10 @@ def _render_human(payload: dict[str, Any]) -> str:
         lines.append(f"scope: {payload['scope']}")
     if "count" in payload:
         lines.append(f"count: {payload['count']}")
+    if "emitted_count" in payload and payload.get("emitted_count") != payload.get("count"):
+        limit = payload.get("limit")
+        suffix = f" (limit: {limit})" if limit is not None else ""
+        lines.append(f"emitted_count: {payload['emitted_count']}{suffix}")
 
     if "items" in payload:
         items = payload.get("items") or []
@@ -111,12 +115,16 @@ def _emit(payload: dict[str, Any], *, as_json: bool) -> int:
 
 def cmd_work_list(args: argparse.Namespace) -> int:
     items, health = collect_work_items(_repo_root(args), scope=args.scope)
+    limit = getattr(args, "limit", None)
+    emitted_items = items[:limit] if limit is not None else items
     return _emit(
         {
             "schema_version": SCHEMA_VERSION,
             "scope": args.scope,
             "count": len(items),
-            "items": [item.to_dict() for item in items],
+            "emitted_count": len(emitted_items),
+            "limit": limit,
+            "items": [item.to_dict() for item in emitted_items],
             "source_health": health,
         },
         as_json=getattr(args, "json", False),
@@ -143,12 +151,16 @@ def cmd_work_graph(args: argparse.Namespace) -> int:
 
 def cmd_work_robot(args: argparse.Namespace) -> int:
     recommendations, health = build_robot_recommendations(_repo_root(args), scope="current")
+    limit = getattr(args, "limit", None)
+    emitted_recommendations = recommendations[:limit] if limit is not None else recommendations
     return _emit(
         {
             "schema_version": SCHEMA_VERSION,
             "scope": "current",
             "count": len(recommendations),
-            "recommendations": [rec.to_dict() for rec in recommendations],
+            "emitted_count": len(emitted_recommendations),
+            "limit": limit,
+            "recommendations": [rec.to_dict() for rec in emitted_recommendations],
             "source_health": health,
             "mutations": [],
         },

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -298,6 +298,13 @@ def _add_metrics_parser(subparsers) -> None:
 
 def _add_work_parser(subparsers) -> None:
     """Add the read-only Aragora-native work board commands."""
+
+    def _nonnegative_int(raw: str) -> int:
+        value = int(raw)
+        if value < 0:
+            raise argparse.ArgumentTypeError("must be >= 0")
+        return value
+
     work = subparsers.add_parser(
         "work",
         help="Inspect the read-only Aragora work board",
@@ -322,6 +329,14 @@ def _add_work_parser(subparsers) -> None:
         p.add_argument("--repo", default=".", help="Repository root to inspect (default: cwd)")
         p.add_argument("--json", action="store_true", help="Emit stable JSON")
 
+    def add_limit(p) -> None:
+        p.add_argument(
+            "--limit",
+            type=_nonnegative_int,
+            default=None,
+            help="Maximum number of records to emit while preserving the total count",
+        )
+
     list_cmd = work_sub.add_parser("list", help="List normalized work items")
     add_common(list_cmd)
     list_cmd.add_argument(
@@ -330,6 +345,7 @@ def _add_work_parser(subparsers) -> None:
         default="current",
         help="current excludes terminal/historical noise; all includes context records",
     )
+    add_limit(list_cmd)
     list_cmd.set_defaults(func=_lazy("aragora.cli.commands.work_board", "cmd_work_list"))
 
     show_cmd = work_sub.add_parser("show", help="Show one normalized work item")
@@ -347,6 +363,7 @@ def _add_work_parser(subparsers) -> None:
         help="Rank current work into read-only actionable recommendations",
     )
     add_common(robot_cmd)
+    add_limit(robot_cmd)
     robot_cmd.set_defaults(func=_lazy("aragora.cli.commands.work_board", "cmd_work_robot"))
 
 

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -130,7 +130,7 @@ For full runtime configuration, see [ENVIRONMENT](ENVIRONMENT.md).
 | `tenant` | - | Manage multi-tenant deployments | `activate`, `create`, `delete`, `export`, `list`, `quota-get`, `quota-set`, `suspend` |
 | `testfixer` | - | Run automated test-fix loop | - |
 | `triage` | - | Inbox triage via adversarial debate with receipt-gated actions | `audit`, `auth`, `calibrate`, `digest`, `label`, `queue`, `run`, `status` |
-| `validate` | - | Validate API keys by making test calls | - |
+| `validate` | - | Run a full health check, including live API-key validation | - |
 | `validate-env` | - | Validate environment configuration and backend connectivity | - |
 | `verify` | - | Verify a decision receipt's integrity | - |
 | `verticals` | - | Manage vertical specialist configurations | - |

--- a/tests/cli/test_work_board.py
+++ b/tests/cli/test_work_board.py
@@ -19,7 +19,13 @@ from aragora.cli.commands.work_board import (
 
 
 def _args(tmp_path: Path, **kwargs) -> argparse.Namespace:
-    defaults = {"repo": str(tmp_path), "json": True, "scope": "current", "work_id": None}
+    defaults = {
+        "repo": str(tmp_path),
+        "json": True,
+        "scope": "current",
+        "work_id": None,
+        "limit": None,
+    }
     defaults.update(kwargs)
     return argparse.Namespace(**defaults)
 
@@ -54,6 +60,31 @@ def test_work_parser_registers_read_only_robot_command() -> None:
     assert args.command == "work"
     assert args.work_cmd == "robot"
     assert args.json is True
+
+
+def test_work_parser_registers_robot_limit() -> None:
+    parser = build_parser()
+    args = parser.parse_args(["work", "robot", "--json", "--limit", "4"])
+
+    assert args.command == "work"
+    assert args.work_cmd == "robot"
+    assert args.limit == 4
+
+
+def test_work_parser_registers_list_limit() -> None:
+    parser = build_parser()
+    args = parser.parse_args(["work", "list", "--json", "--limit", "3"])
+
+    assert args.command == "work"
+    assert args.work_cmd == "list"
+    assert args.limit == 3
+
+
+def test_work_parser_rejects_negative_list_limit() -> None:
+    parser = build_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["work", "list", "--limit", "-1"])
 
 
 def test_work_with_no_subcommand_prints_help_without_traceback(
@@ -127,6 +158,26 @@ def test_work_list_reads_current_outbox(
     assert payload["count"] == 1
     assert payload["items"][0]["id"] == "automation-outbox:handoff"
     assert payload["items"][0]["branch"] == "codex/repair"
+
+
+def test_work_list_limit_bounds_emitted_items_but_preserves_total_count(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    monkeypatch.setattr("aragora.work.sources.shutil.which", lambda name: None)
+    outbox = tmp_path / ".aragora" / "automation-outbox"
+    outbox.mkdir(parents=True)
+    for name in ("one", "two", "three"):
+        (outbox / f"{name}.json").write_text(
+            json.dumps({"task": f"repair {name}", "branch": f"codex/{name}"}),
+            encoding="utf-8",
+        )
+
+    assert cmd_work_list(_args(tmp_path, scope="current", limit=2)) == 0
+    payload = _capture_json(capsys)
+
+    assert payload["count"] == 3
+    assert payload["emitted_count"] == 2
+    assert len(payload["items"]) == 2
 
 
 def test_work_robot_marks_tier_four_pr_human_gated(
@@ -419,6 +470,27 @@ def test_work_robot_ranks_actionable_current_work(tmp_path: Path, monkeypatch, c
     assert payload["recommendations"][0]["item_id"] == "automation-outbox:repair"
     assert payload["recommendations"][0]["classification"] == "needs-polish"
     assert payload["recommendations"][0]["action"] == "publish_or_reconcile_handoff"
+
+
+def test_work_robot_limit_bounds_emitted_recommendations_but_preserves_total_count(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    monkeypatch.setattr("aragora.work.sources.shutil.which", lambda name: None)
+    outbox = tmp_path / ".aragora" / "automation-outbox"
+    outbox.mkdir(parents=True)
+    for name in ("one", "two", "three"):
+        (outbox / f"{name}.json").write_text(
+            json.dumps({"task": f"repair {name}", "branch": f"codex/{name}"}),
+            encoding="utf-8",
+        )
+
+    assert cmd_work_robot(_args(tmp_path, limit=2)) == 0
+    payload = _capture_json(capsys)
+
+    assert payload["count"] == 3
+    assert payload["emitted_count"] == 2
+    assert len(payload["recommendations"]) == 2
+    assert payload["mutations"] == []
 
 
 def test_work_robot_emits_ready_for_polished_bead(tmp_path: Path, monkeypatch, capsys) -> None:


### PR DESCRIPTION
## Summary
- add `--limit` to `aragora work list` and `aragora work robot`
- preserve total `count` while exposing `emitted_count` and `limit` for bounded output consumers
- reject negative limits at parse time

## Validation
- `python3 -m pytest -q tests/cli/test_work_board.py`
- `python3 -m ruff check aragora/cli/parser.py aragora/cli/commands/work_board.py tests/cli/test_work_board.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- dogfood: `work list --repo /Users/armand/Development/aragora --json --limit 5` returned `count=152`, `emitted_count=5`
- dogfood: `work robot --repo /Users/armand/Development/aragora --json --limit 5` returned `count=152`, `emitted_count=5`
