### PR TITLE
fix(audit): protect nested handoff branch refs

### DIFF
--- a/scripts/audit_codex_branch_backlog.py
+++ b/scripts/audit_codex_branch_backlog.py
@@ -355,6 +355,22 @@ def _local_evidence_mappings(value: Any) -> list[Mapping[str, Any]]:
     return []
 
 
+def _nested_evidence_mappings(value: Any) -> list[Mapping[str, Any]]:
+    mappings: list[Mapping[str, Any]] = []
+
+    def visit(item: Any) -> None:
+        if isinstance(item, Mapping):
+            mappings.append(item)
+            for child in item.values():
+                visit(child)
+        elif isinstance(item, Sequence) and not isinstance(item, (str, bytes, bytearray)):
+            for child in item:
+                visit(child)
+
+    visit(value)
+    return mappings
+
+
 def _outbox_payload_branch(payload: dict[str, Any]) -> str:
     for local_evidence in _local_evidence_mappings(payload.get("local_evidence")):
         branch = str(local_evidence.get("branch") or "").strip()
@@ -405,11 +421,12 @@ def _outbox_payload_branches(payload: dict[str, Any]) -> set[str]:
         _add_branch_reference(branches, requested_action.get("branch"))
 
     containers: list[Mapping[str, Any]] = [
-        *_local_evidence_mappings(payload.get("local_evidence")),
+        *_nested_evidence_mappings(payload.get("local_evidence")),
         payload,
     ]
 
     for container in containers:
+        _add_branch_reference(branches, container.get("branch"))
         _add_branch_reference(branches, container.get("supersedes_branch"))
         supersedes_branches = container.get("supersedes_branches")
         if isinstance(supersedes_branches, list):
@@ -452,7 +469,7 @@ def _outbox_payload_branch_heads(payload: dict[str, Any]) -> dict[str, set[str |
         if branch:
             refs[branch].add(head)
 
-    for local_evidence in _local_evidence_mappings(payload.get("local_evidence")):
+    for local_evidence in _nested_evidence_mappings(payload.get("local_evidence")):
         branch = str(local_evidence.get("branch") or "").strip()
         add(branch, _outbox_evidence_head(local_evidence))
 

--- a/tests/scripts/test_audit_codex_branch_backlog.py
+++ b/tests/scripts/test_audit_codex_branch_backlog.py
@@ -1883,6 +1883,71 @@ def test_audit_treats_superseded_branch_as_terminal_receipt(
     assert payload["records"][0]["category"] == "protected_handoff_receipt"
 
 
+def test_audit_treats_nested_refresh_branch_as_terminal_receipt(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    outbox = tmp_path / ".aragora" / "automation-outbox"
+    receipts = tmp_path / ".aragora" / "automation-receipts"
+    outbox.mkdir(parents=True)
+    receipts.mkdir(parents=True)
+    key = "open-pr-codex-current-refresh-def456"
+    (outbox / "refresh.json").write_text(
+        json.dumps(
+            {
+                "task": "Publish refreshed branch",
+                "requires_github": True,
+                "requested_action": "open_pr",
+                "repo": "synaptent/aragora",
+                "local_evidence": {
+                    "branch": "codex/current-refresh",
+                    "head": "def456",
+                    "improver_refresh_20260601T1431Z": {
+                        "branch": "codex/previous-refresh",
+                        "head_sha": "abc1234",
+                    },
+                },
+                "validation": ["pytest tests/example.py -q"],
+                "idempotency_key": key,
+                "created_at": "2026-04-24T16:00:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (receipts / f"{key}.json").write_text(
+        json.dumps({"idempotency_key": key, "status": "already_satisfied"}),
+        encoding="utf-8",
+    )
+    _stub_git_inventory(monkeypatch, _branch_row("codex/previous-refresh"))
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda _root, **_kwargs: GitHubCLIHealth(
+            ready=False,
+            auth_ok=False,
+            api_ok=False,
+            mode="connectivity_failed",
+            error="offline",
+            repo=str(tmp_path),
+        ),
+    )
+
+    payload = mod.audit(
+        root=tmp_path,
+        base="origin/main",
+        repo="synaptent/aragora",
+        prefix="codex/",
+        recent_hours=72,
+        max_branches=None,
+        include_patch_equivalence=False,
+        publisher_backlog_limit=1,
+    )
+
+    assert payload["summary"]["handoff_receipted_branches"] == 1
+    assert payload["summary"]["publishable_branch_backlog"] == 0
+    assert payload["records"][0]["handoff_receipt_exists"] is True
+    assert payload["records"][0]["category"] == "protected_handoff_receipt"
+
+
 def test_audit_reads_top_level_branch_for_terminal_outbox_receipts(
     tmp_path: Path, monkeypatch: Any
 ) -> None:


### PR DESCRIPTION
## Summary
- protect automation handoff branches stored under nested `local_evidence` from being misclassified as salvage candidates
- add regression coverage for nested handoff branch references in the branch backlog audit

## Validation
- `PYTHONDONTWRITEBYTECODE=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/scripts/test_audit_codex_branch_backlog.py -p no:cacheprovider` -> 57 passed, 2 existing config warnings
- `python3 -m ruff check scripts/audit_codex_branch_backlog.py tests/scripts/test_audit_codex_branch_backlog.py` -> passed
- `python3 -m ruff format --check scripts/audit_codex_branch_backlog.py tests/scripts/test_audit_codex_branch_backlog.py` -> passed
- `git diff --check origin/main...HEAD && git diff --check` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> passed

## Handoff
Published from outbox idempotency key `open-pr-codex-audit-nested-handoff-refs-primary-r2-20260602-64073a90`.
Exact head: `64073a9002ef92ad9d1ae510f983512d6f90f987`.
