### PR TITLE
fix(work): default board to shared state

### DIFF
--- a/aragora/work/board.py
+++ b/aragora/work/board.py
@@ -14,6 +14,7 @@ from aragora.work.sources import (
     collect_github_prs,
     collect_mission_files,
     enrich_with_agent_bridge_lanes,
+    resolve_work_state_root,
 )
 
 
@@ -21,22 +22,24 @@ def collect_work_items(
     repo_root: Path | str, *, scope: str = "current"
 ) -> tuple[list[WorkItem], list[dict]]:
     """Collect work items from all known read-only sources."""
-    root = Path(repo_root)
+    root = Path(repo_root).expanduser().resolve()
+    state_root, state_health = resolve_work_state_root(root)
     health: list[dict] = []
     items: list[WorkItem] = []
     collectors = [
-        collect_github_prs,
-        collect_automation_outbox,
-        lambda r: collect_automation_receipts(r, scope=scope),
-        lambda r: collect_broker_runs(r, scope=scope),
-        lambda r: collect_beads_and_convoys(r, scope=scope),
-        lambda r: collect_mission_files(r, scope=scope),
+        (collect_github_prs, root),
+        (collect_automation_outbox, state_root),
+        (lambda r: collect_automation_receipts(r, scope=scope), state_root),
+        (lambda r: collect_broker_runs(r, scope=scope), state_root),
+        (lambda r: collect_beads_and_convoys(r, scope=scope), root),
+        (lambda r: collect_mission_files(r, scope=scope), root),
     ]
-    for collector in collectors:
-        collected, source_health = collector(root)
+    health.append(state_health)
+    for collector, collector_root in collectors:
+        collected, source_health = collector(collector_root)
         items.extend(collected)
         health.append(source_health)
-    items, lane_health = enrich_with_agent_bridge_lanes(root, items)
+    items, lane_health = enrich_with_agent_bridge_lanes(state_root, items)
     health.append(lane_health)
 
     if scope == "current":

--- a/aragora/work/sources.py
+++ b/aragora/work/sources.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 from datetime import UTC, datetime
@@ -46,9 +47,109 @@ def _health(source: str, status: str, detail: str, **extra: Any) -> dict[str, An
     return {"source": source, "status": status, "detail": detail, **extra}
 
 
+def _state_dir(root: Path) -> Path:
+    expanded = root.expanduser()
+    return expanded if expanded.name == ".aragora" else expanded / ".aragora"
+
+
+def _state_path(root: Path, *parts: str) -> Path:
+    return _state_dir(root).joinpath(*parts)
+
+
+def _state_evidence_ref(root: Path, path: Path) -> str:
+    base = _state_dir(root).parent
+    try:
+        return str(path.relative_to(base))
+    except ValueError:
+        return str(path)
+
+
+def _has_work_state_dirs(root: Path) -> bool:
+    state_dir = _state_dir(root)
+    return any(
+        (state_dir / dirname).is_dir()
+        for dirname in (
+            "automation-outbox",
+            "automation-receipts",
+            "agent-bridge",
+            "agent_bridge",
+        )
+    )
+
+
+def _git_root_for_origin(root: Path) -> Path:
+    return root.parent if root.expanduser().name == ".aragora" else root
+
+
+def _git_origin(root: Path) -> str | None:
+    try:
+        proc = subprocess.run(
+            ["git", "config", "--get", "remote.origin.url"],
+            cwd=_git_root_for_origin(root),
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if proc.returncode != 0:
+        return None
+    origin = proc.stdout.strip()
+    return origin or None
+
+
+def _same_git_origin(left: Path, right: Path) -> bool:
+    left_origin = _git_origin(left)
+    return bool(left_origin) and left_origin == _git_origin(right)
+
+
+def resolve_work_state_root(repo_root: Path | str) -> tuple[Path, dict[str, Any]]:
+    """Return the checkout or direct .aragora dir backing shared work-board state."""
+    root = Path(repo_root).expanduser().resolve()
+    if _has_work_state_dirs(root):
+        return root, _health(
+            "work_state_root",
+            "ok",
+            "using repo-local work state",
+            repo_root=str(root),
+            state_root=str(root),
+        )
+
+    configured = os.environ.get("ARAGORA_AUTOMATION_STATE_ROOT")
+    candidates: list[tuple[Path, bool]] = []
+    if configured:
+        candidates.append((Path(configured).expanduser(), True))
+    candidates.append((Path.home() / "Development" / "aragora", False))
+
+    for candidate, explicit in candidates:
+        try:
+            resolved = candidate.resolve()
+        except OSError:
+            resolved = candidate
+        if not _has_work_state_dirs(resolved):
+            continue
+        if explicit or _same_git_origin(root, resolved):
+            return resolved, _health(
+                "work_state_root",
+                "ok",
+                "using shared work state",
+                repo_root=str(root),
+                state_root=str(resolved),
+            )
+
+    return root, _health(
+        "work_state_root",
+        "missing",
+        "no repo-local or shared .aragora work state found",
+        repo_root=str(root),
+        state_root=str(root),
+    )
+
+
 def _read_agent_bridge_lane_rows(repo_root: Path) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     """Read repo-local agent-bridge lane registry rows without mutating lane state."""
-    registry = repo_root / ".aragora" / "agent-bridge" / "lanes.json"
+    registry = _state_path(repo_root, "agent-bridge", "lanes.json")
     if not registry.exists():
         return [], _health("agent_bridge_lane", "missing", f"{registry} not found")
     try:
@@ -250,7 +351,7 @@ def collect_github_prs(repo_root: Path) -> tuple[list[WorkItem], dict[str, Any]]
 
 
 def collect_automation_outbox(repo_root: Path) -> tuple[list[WorkItem], dict[str, Any]]:
-    outbox = repo_root / ".aragora" / "automation-outbox"
+    outbox = _state_path(repo_root, "automation-outbox")
     if not outbox.exists():
         return [], _health("automation_outbox", "missing", f"{outbox} not found")
     items: list[WorkItem] = []
@@ -270,7 +371,7 @@ def collect_automation_outbox(repo_root: Path) -> tuple[list[WorkItem], dict[str
                 scope="current",
                 branch=str(branch) if branch else None,
                 updated_at=str(data.get("updated_at") or data.get("recorded_at") or "") or None,
-                evidence_refs=[str(path.relative_to(repo_root))],
+                evidence_refs=[_state_evidence_ref(repo_root, path)],
                 metadata={"path": str(path), "idempotency_key": data.get("idempotency_key")},
             )
         )
@@ -280,7 +381,7 @@ def collect_automation_outbox(repo_root: Path) -> tuple[list[WorkItem], dict[str
 def collect_automation_receipts(
     repo_root: Path, *, scope: str
 ) -> tuple[list[WorkItem], dict[str, Any]]:
-    receipts = repo_root / ".aragora" / "automation-receipts"
+    receipts = _state_path(repo_root, "automation-receipts")
     if not receipts.exists():
         return [], _health("automation_receipt", "missing", f"{receipts} not found")
     files = sorted(receipts.glob("*.json"), key=lambda p: p.stat().st_mtime, reverse=True)[:80]
@@ -307,7 +408,7 @@ def collect_automation_receipts(
                 or data.get("created_issue_url")
                 or data.get("existing_issue_url"),
                 updated_at=updated_at,
-                evidence_refs=[str(path.relative_to(repo_root))],
+                evidence_refs=[_state_evidence_ref(repo_root, path)],
                 metadata={
                     "reason": data.get("reason"),
                     "repo": data.get("repo"),
@@ -319,7 +420,7 @@ def collect_automation_receipts(
 
 
 def collect_broker_runs(repo_root: Path, *, scope: str) -> tuple[list[WorkItem], dict[str, Any]]:
-    runs_dir = repo_root / ".aragora" / "agent_bridge" / "runs"
+    runs_dir = _state_path(repo_root, "agent_bridge", "runs")
     if not runs_dir.exists():
         return [], _health("broker_run", "missing", f"{runs_dir} not found")
     items: list[WorkItem] = []
@@ -347,7 +448,7 @@ def collect_broker_runs(repo_root: Path, *, scope: str) -> tuple[list[WorkItem],
                 owner=owner,
                 created_at=str(data.get("created_at") or "") or None,
                 updated_at=str(data.get("updated_at") or data.get("completed_at") or "") or None,
-                evidence_refs=[str(run_path.relative_to(repo_root))],
+                evidence_refs=[_state_evidence_ref(repo_root, run_path)],
                 metadata={
                     "run_id": run_id,
                     "next_actor": data.get("next_actor"),

--- a/tests/cli/test_work_board.py
+++ b/tests/cli/test_work_board.py
@@ -341,6 +341,39 @@ def test_work_robot_degrades_safely_on_malformed_lane_registry(
     )
 
 
+def test_work_robot_defaults_to_shared_state_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setattr("aragora.work.sources.shutil.which", lambda name: None)
+    worktree_root = tmp_path / "linked-worktree"
+    shared_root = tmp_path / "shared-checkout"
+    outbox = shared_root / ".aragora" / "automation-outbox"
+    outbox.mkdir(parents=True)
+    (outbox / "handoff.json").write_text(
+        json.dumps({"task": "Open PR for shared queue", "branch": "codex/shared"}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("ARAGORA_AUTOMATION_STATE_ROOT", str(shared_root))
+
+    assert cmd_work_robot(_args(worktree_root)) == 0
+    payload = _capture_json(capsys)
+
+    assert payload["count"] == 1
+    assert payload["recommendations"][0]["item"]["branch"] == "codex/shared"
+    assert any(
+        health["source"] == "work_state_root"
+        and health["status"] == "ok"
+        and health["state_root"] == str(shared_root.resolve())
+        for health in payload["source_health"]
+    )
+    assert any(
+        health["source"] == "automation_outbox"
+        and health["status"] == "ok"
+        and "1 pending handoff" in health["detail"]
+        for health in payload["source_health"]
+    )
+
+
 def test_work_show_finds_historical_receipt_in_all_scope(
     tmp_path: Path, monkeypatch, capsys
 ) -> None:


### PR DESCRIPTION
## Summary

- Defaults the work board/robot state discovery to the shared Aragora state root when invoked from disposable worktrees.
- Keeps explicit repo/state-root behavior available while making queue routing less blind in clean worktrees.
- Adds focused coverage for the default shared-state-root behavior.

## Validation

- `python3 -m pytest -q tests/cli/test_work_board.py tests/work/test_work_scoring.py -p no:rerunfailures -p no:cacheprovider` -> 23 passed
- `python3 -m ruff check aragora/work/board.py aragora/work/sources.py tests/cli/test_work_board.py tests/work/test_work_scoring.py` -> passed
- `python3 -m ruff format --check aragora/work/board.py aragora/work/sources.py tests/cli/test_work_board.py tests/work/test_work_scoring.py` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> passed

## Notes

Published from recovered handoff `open-pr-codex-work-robot-shared-state-primary-r3-20260601-9dddd0e1`; the prior blocker was GitHub auth/connectivity. No merge requested.
