### PR TITLE
fix(publisher): summarize skipped outbox reasons

### DIFF
--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -841,6 +841,22 @@ def load_outbox_handoffs(
     receipt_dir: Path | None = None,
     now: datetime | None = None,
 ) -> list[Handoff]:
+    handoffs, _skip_reasons = _load_outbox_handoffs_with_skip_reasons(
+        repo_root,
+        outbox_dir=outbox_dir,
+        receipt_dir=receipt_dir,
+        now=now,
+    )
+    return handoffs
+
+
+def _load_outbox_handoffs_with_skip_reasons(
+    repo_root: Path,
+    *,
+    outbox_dir: Path | None = None,
+    receipt_dir: Path | None = None,
+    now: datetime | None = None,
+) -> tuple[list[Handoff], Counter[str]]:
     outbox_root = _automation_state_path(repo_root, outbox_dir, DEFAULT_OUTBOX_DIR).resolve()
     receipt_root = _automation_state_path(repo_root, receipt_dir, DEFAULT_RECEIPT_DIR).resolve()
     current_time = now or datetime.now(UTC)
@@ -851,14 +867,18 @@ def load_outbox_handoffs(
         terminal_receipts,
     )
     handoffs_by_identity: dict[tuple[str, str], Handoff] = {}
+    skipped_reasons: Counter[str] = Counter()
     for source_file in _outbox_files(outbox_root):
         try:
             payload = json.loads(source_file.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
+            skipped_reasons["invalid_json"] += 1
             continue
         if not isinstance(payload, dict):
+            skipped_reasons["invalid_payload"] += 1
             continue
         if not _has_required_outbox_contract(payload):
+            skipped_reasons["missing_required_contract"] += 1
             continue
         task_title = str(payload.get("task") or payload.get("title") or "").strip()
         requested_action = _normalized_requested_action(payload.get("requested_action"))
@@ -867,11 +887,14 @@ def load_outbox_handoffs(
         if isinstance(requires_github, str):
             requires_github = requires_github.strip().lower() not in {"0", "false", "no"}
         if requires_github is False:
+            skipped_reasons["requires_github_false"] += 1
             continue
         if not task_title or not requested_action or not idempotency_key:
+            skipped_reasons["missing_identity"] += 1
             continue
         expires_at = str(payload.get("expires_at") or "").strip() or None
         if _is_expired(expires_at, now=current_time):
+            skipped_reasons["expired"] += 1
             continue
         branch_fingerprint = _outbox_branch_fingerprint(payload)
         receipt_payloads = terminal_receipts.get(idempotency_key, [])
@@ -879,12 +902,16 @@ def load_outbox_handoffs(
             _receipt_satisfies_outbox(repo_root, payload, receipt_payload)
             for receipt_payload in receipt_payloads
         ):
+            skipped_reasons["terminal_receipt"] += 1
             continue
         if branch_fingerprint and branch_fingerprint in terminal_fingerprints:
+            skipped_reasons["terminal_branch_receipt"] += 1
             continue
         if _outbox_branch_already_merged(repo_root, payload):
+            skipped_reasons["already_merged"] += 1
             continue
         if _outbox_branch_patch_equivalent(repo_root, payload):
+            skipped_reasons["patch_equivalent"] += 1
             continue
         handoff = Handoff(
             source_file=str(source_file),
@@ -911,12 +938,17 @@ def load_outbox_handoffs(
             _source_mtime(existing.source_file),
             existing.source_file,
         ):
+            if existing is not None:
+                skipped_reasons["duplicate_identity"] += 1
             handoffs_by_identity[identity] = handoff
-    return sorted(
+        else:
+            skipped_reasons["duplicate_identity"] += 1
+    handoffs = sorted(
         handoffs_by_identity.values(),
         key=lambda item: (_source_mtime(item.source_file), item.priority),
         reverse=True,
     )
+    return handoffs, skipped_reasons
 
 
 def _ensure_gh_auth(repo_root: Path) -> None:
@@ -1456,13 +1488,20 @@ def main(argv: list[str] | None = None) -> int:
     labels = list(dict.fromkeys(args.labels))
     automation_ids = set(args.automation_ids or DEFAULT_AUTOMATION_IDS)
     memory_handoffs = load_handoffs(codex_home, automation_ids=automation_ids)
-    outbox_handoffs = (
-        []
-        if args.no_outbox
-        else load_outbox_handoffs(repo_root, outbox_dir=outbox_dir, receipt_dir=receipt_dir)
-    )
+    if args.no_outbox:
+        outbox_handoffs = []
+        outbox_skipped_reason_counts: Counter[str] = Counter()
+    else:
+        outbox_handoffs, outbox_skipped_reason_counts = _load_outbox_handoffs_with_skip_reasons(
+            repo_root,
+            outbox_dir=outbox_dir,
+            receipt_dir=receipt_dir,
+        )
     outbox_file_count = 0 if args.no_outbox else len(_outbox_files(outbox_dir))
-    outbox_skipped_count = max(outbox_file_count - len(outbox_handoffs), 0)
+    outbox_skipped_count = sum(outbox_skipped_reason_counts.values())
+    if outbox_skipped_count == 0:
+        outbox_skipped_count = max(outbox_file_count - len(outbox_handoffs), 0)
+    outbox_skipped_reason_counts_payload = dict(sorted(outbox_skipped_reason_counts.items()))
     handoffs = sorted(
         memory_handoffs + outbox_handoffs,
         key=lambda item: (_source_mtime(item.source_file), item.priority),
@@ -1493,6 +1532,7 @@ def main(argv: list[str] | None = None) -> int:
             "outbox_file_count": outbox_file_count,
             "outbox_handoff_count": len(outbox_handoffs),
             "outbox_skipped_count": outbox_skipped_count,
+            "outbox_skipped_reason_counts": outbox_skipped_reason_counts_payload,
             "handoff_count": len(handoffs),
             "github_health": github_health.to_dict(),
             "decisions": [asdict(item) for item in decisions],
@@ -1547,6 +1587,7 @@ def main(argv: list[str] | None = None) -> int:
         "outbox_file_count": outbox_file_count,
         "outbox_handoff_count": len(outbox_handoffs),
         "outbox_skipped_count": outbox_skipped_count,
+        "outbox_skipped_reason_counts": outbox_skipped_reason_counts_payload,
         "handoff_count": len(handoffs),
         "github_health": github_health.to_dict(),
         "decisions": [asdict(item) for item in results],

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+from collections import Counter
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -1836,13 +1837,17 @@ def test_main_derives_outbox_dirs_from_explicit_aragora_state_root(
         repo_root: Path,
         outbox_dir: Path | None = None,
         receipt_dir: Path | None = None,
-    ) -> list[Handoff]:
+    ) -> tuple[list[Handoff], Counter[str]]:
         captured["repo_root"] = repo_root
         captured["outbox_dir"] = outbox_dir
         captured["receipt_dir"] = receipt_dir
-        return []
+        return [], Counter()
 
-    monkeypatch.setattr(mod, "load_outbox_handoffs", fake_load_outbox_handoffs)
+    monkeypatch.setattr(
+        mod,
+        "_load_outbox_handoffs_with_skip_reasons",
+        fake_load_outbox_handoffs,
+    )
     monkeypatch.setattr(
         mod,
         "check_github_cli_health",
@@ -2043,6 +2048,12 @@ def test_main_summary_only_reports_outbox_files_skipped_before_publish(
         ),
         encoding="utf-8",
     )
+    incomplete = _outbox_payload(idempotency_key="open-pr-incomplete")
+    del incomplete["validation"]
+    (outbox / "incomplete.json").write_text(
+        json.dumps(incomplete),
+        encoding="utf-8",
+    )
     monkeypatch.setattr(mod, "_repo_root", lambda path: tmp_path)
     monkeypatch.setattr(
         mod,
@@ -2074,9 +2085,13 @@ def test_main_summary_only_reports_outbox_files_skipped_before_publish(
 
     assert exit_code == 1
     payload = json.loads(capsys.readouterr().out)
-    assert payload["outbox_file_count"] == 2
+    assert payload["outbox_file_count"] == 3
     assert payload["outbox_handoff_count"] == 1
-    assert payload["outbox_skipped_count"] == 1
+    assert payload["outbox_skipped_count"] == 2
+    assert payload["outbox_skipped_reason_counts"] == {
+        "expired": 1,
+        "missing_required_contract": 1,
+    }
     assert payload["handoff_count"] == 1
 
 


### PR DESCRIPTION
## Summary

- Adds skipped-reason counts to publisher summary-only JSON for automation handoff triage.
- Distinguishes expired, terminal receipt, patch-equivalent, and other skipped outbox entries without manual file inspection.
- Updates focused publisher handoff tests.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/scripts/test_publish_automation_handoffs.py` -> 57 passed, 2 existing warnings
- `python3 -m ruff check scripts/publish_automation_handoffs.py tests/scripts/test_publish_automation_handoffs.py` -> passed
- `python3 -m ruff format --check scripts/publish_automation_handoffs.py tests/scripts/test_publish_automation_handoffs.py` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> passed

## Notes

Published from recovered handoff `open-pr-codex-publisher-outbox-skipped-reasons-20260602-5f05322a`; the prior blocker was GitHub DNS/auth availability. No merge requested.
