### PR TITLE
fix(automation): add compact branch publisher output

### DIFF
--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -1257,6 +1257,41 @@ def _publish_decisions(
     return results
 
 
+def summary_only_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return compact JSON for automation startup logs."""
+
+    compact = dict(payload)
+    decisions = payload.get("decisions")
+    if isinstance(decisions, list):
+        reason_counts: dict[str, int] = {}
+        eligible_count = 0
+        for decision in decisions:
+            if not isinstance(decision, Mapping):
+                continue
+            if decision.get("eligible") is True:
+                eligible_count += 1
+            reason = decision.get("reason")
+            reason_key = reason if isinstance(reason, str) and reason else "unknown"
+            reason_counts[reason_key] = reason_counts.get(reason_key, 0) + 1
+        compact["decision_count"] = len(decisions)
+        compact["eligible_decision_count"] = eligible_count
+        compact["ineligible_decision_count"] = len(decisions) - eligible_count
+        compact["decision_reason_counts"] = reason_counts
+        compact["decisions_omitted"] = True
+        compact.pop("decisions", None)
+
+    queue_health = compact.get("queue_health")
+    if isinstance(queue_health, Mapping):
+        compact_queue = dict(queue_health)
+        unhealthy_open_prs = compact_queue.pop("unhealthy_open_prs", None)
+        if isinstance(unhealthy_open_prs, list):
+            compact_queue["unhealthy_open_prs_omitted"] = len(unhealthy_open_prs)
+        compact["queue_health"] = compact_queue
+
+    compact["details_omitted"] = True
+    return compact
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Publish recent committed codex automation branches into GitHub PRs."
@@ -1310,6 +1345,11 @@ def _build_parser() -> argparse.ArgumentParser:
         "--json",
         action="store_true",
         help="Print machine-readable output",
+    )
+    parser.add_argument(
+        "--summary-only",
+        action="store_true",
+        help="With --json, omit verbose decision and open-PR detail lists.",
     )
     mode_group = parser.add_mutually_exclusive_group()
     mode_group.add_argument(
@@ -1427,6 +1467,8 @@ def main(argv: list[str] | None = None) -> int:
             "decisions": [],
         }
         if args.json:
+            if args.summary_only:
+                unavailable_payload = summary_only_payload(unavailable_payload)
             print(json.dumps(unavailable_payload, indent=2))
         else:
             print(f"github_unavailable: {github_health.mode} {github_health.error}".strip())
@@ -1536,6 +1578,9 @@ def main(argv: list[str] | None = None) -> int:
                 preflight_script=None if args.skip_preflight else str(args.preflight_script),
             )
             payload["published"] = published
+
+    if args.summary_only:
+        payload = summary_only_payload(payload)
 
     if args.json:
         print(json.dumps(payload, indent=2))

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -143,6 +143,78 @@ def test_parser_defaults_match_publisher_budget_constants() -> None:
     assert args.outbox_dir is None
     assert args.allow_unhealthy_queue_publish is False
     assert args.receipt_dir is None
+    assert args.summary_only is False
+
+
+def test_main_summary_only_omits_decisions_and_unhealthy_pr_details(
+    monkeypatch: Any, tmp_path: Path, capsys: Any
+) -> None:
+    branch = _branch("codex/compact-publisher")
+
+    monkeypatch.setattr(mod, "_repo_root", lambda path: tmp_path)
+    monkeypatch.setattr(mod, "_local_codex_branches", lambda repo_root: [branch])
+    monkeypatch.setattr(mod, "_list_worktrees", lambda repo_root, branch_filter=None: [])
+    monkeypatch.setattr(mod, "_branch_is_merged", lambda repo_root, base, branch: False)
+    monkeypatch.setattr(
+        mod, "_branch_patch_equivalent_to_base", lambda repo_root, base, branch: False
+    )
+    monkeypatch.setattr(mod, "_branch_has_pr_diff", lambda repo_root, base, branch: True)
+    monkeypatch.setattr(mod, "_branch_unique_commit_count", lambda repo_root, base, branch: 1)
+    monkeypatch.setattr(mod, "outbox_superseded_branches", lambda repo_root, outbox_dir=None: set())
+    monkeypatch.setattr(mod, "_duplicate_open_pr_patch_branches", lambda *args: set())
+    monkeypatch.setattr(mod, "_branches_with_pr_history", lambda *args: set())
+    monkeypatch.setattr(mod, "_branches_with_resolved_related_work", lambda *args: set())
+    monkeypatch.setattr(mod, "_branch_remote_head", lambda repo_root, branch: None)
+    monkeypatch.setattr(
+        mod,
+        "evaluate_automation_guardrails",
+        lambda repo_root, open_pr_count, max_open_prs: mod.AutomationGuardrailReport(
+            ok=True,
+            blockers=[],
+            metrics={},
+        ),
+    )
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda repo_root: GitHubCLIHealth(
+            ready=True,
+            auth_ok=True,
+            api_ok=True,
+            mode="ready",
+            error="",
+            repo=str(tmp_path),
+        ),
+    )
+    monkeypatch.setattr(
+        mod,
+        "_open_codex_prs",
+        lambda repo_root, repo: [
+            {
+                "number": 7001,
+                "title": "Failing automation PR",
+                "headRefName": "codex/failing",
+                "mergeStateStatus": "DIRTY",
+                "reviewDecision": None,
+                "statusCheckRollup": [],
+            }
+        ],
+    )
+
+    exit_code = mod.main(["--repo", str(tmp_path), "--json", "--summary-only"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert "decisions" not in payload
+    assert payload["decision_count"] == 1
+    assert payload["eligible_decision_count"] == 1
+    assert payload["ineligible_decision_count"] == 0
+    assert payload["decision_reason_counts"] == {"eligible": 1}
+    assert payload["decisions_omitted"] is True
+    assert payload["details_omitted"] is True
+    assert payload["queue_health"]["unhealthy_open_pr_count"] == 1
+    assert "unhealthy_open_prs" not in payload["queue_health"]
+    assert payload["queue_health"]["unhealthy_open_prs_omitted"] == 1
 
 
 def test_parser_accepts_receipt_dir_for_shared_cli_compatibility(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Adds compact `--summary-only` output to the Codex automation branch publisher path.
- Keeps detailed output available while allowing automation health checks to avoid large branch payloads.
- Adds focused coverage for the compact publisher output shape.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/scripts/test_publish_codex_automation_branches.py -q -p no:rerunfailures -p no:cacheprovider` -> 42 passed
- `python3 -m ruff check scripts/publish_codex_automation_branches.py tests/scripts/test_publish_codex_automation_branches.py` -> passed
- `python3 -m ruff format --check scripts/publish_codex_automation_branches.py tests/scripts/test_publish_codex_automation_branches.py` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> passed

## Notes

Published from recovered handoff `open-pr-codex-publisher-branch-summary-only-primary-r5-20260602-3cdf1767`; the prior blocker was GitHub availability. No merge requested.
