### PR TITLE
fix(audit): use cached open PR heads

### DIFF
--- a/scripts/audit_codex_branch_backlog.py
+++ b/scripts/audit_codex_branch_backlog.py
@@ -38,6 +38,7 @@ ACTIVE_SESSION_FILES = (
 DEFAULT_OUTBOX_DIR = Path(".aragora/automation-outbox")
 DEFAULT_RECEIPT_DIR = Path(".aragora/automation-receipts")
 DEFAULT_GITHUB_STATUS_CACHE = Path(".aragora/automation-github-status/latest.json")
+DEFAULT_CACHED_OPEN_PR_HEADS_MAX_AGE_HOURS = 24
 TERMINAL_RECEIPT_STATUSES = {"published", "already_satisfied", "completed", "skipped"}
 COMMIT_PREFIX_RE = re.compile(r"^[0-9a-f]{7,40}$", re.IGNORECASE)
 BRANCH_IDEMPOTENCY_PREFIXES = ("open-pr-", "already-satisfied-")
@@ -744,12 +745,49 @@ def _github_status_cache_paths(
     return deduped
 
 
+def _parse_cache_timestamp(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _cache_open_pr_heads_observed_at(payload: Mapping[str, Any]) -> datetime | None:
+    github_queue = payload.get("github_queue")
+    if isinstance(github_queue, Mapping):
+        cached_at = _parse_cache_timestamp(github_queue.get("open_pr_heads_cached_at"))
+        if cached_at is not None:
+            return cached_at
+    return _parse_cache_timestamp(payload.get("generated_at"))
+
+
+def _cache_open_pr_heads_fresh(
+    payload: Mapping[str, Any],
+    *,
+    max_age_hours: int,
+    now: datetime | None = None,
+) -> bool:
+    if max_age_hours <= 0:
+        return False
+    observed_at = _cache_open_pr_heads_observed_at(payload)
+    if observed_at is None:
+        return False
+    current = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    return observed_at >= current - timedelta(hours=max_age_hours)
+
+
 def cached_open_pr_heads(
     root: Path,
     prefix: str,
     *,
     outbox_dir: Path | None = None,
     receipt_dir: Path | None = None,
+    max_age_hours: int = DEFAULT_CACHED_OPEN_PR_HEADS_MAX_AGE_HOURS,
 ) -> set[str]:
     """Return cached open PR branch heads from local publisher status evidence."""
 
@@ -758,6 +796,8 @@ def cached_open_pr_heads(
     ):
         payload = _json_mapping(cache_path)
         if payload is None:
+            continue
+        if not _cache_open_pr_heads_fresh(payload, max_age_hours=max_age_hours):
             continue
         github_queue = payload.get("github_queue")
         if not isinstance(github_queue, Mapping):
@@ -1058,11 +1098,15 @@ def audit(
         open_pr_lookup_skipped = True
     resolved_outbox_dir = _automation_state_path(root, outbox_dir, DEFAULT_OUTBOX_DIR)
     resolved_receipt_dir = _automation_state_path(root, receipt_dir, DEFAULT_RECEIPT_DIR)
-    cached_prs = cached_open_pr_heads(
-        root,
-        prefix,
-        outbox_dir=resolved_outbox_dir,
-        receipt_dir=resolved_receipt_dir,
+    cached_prs = (
+        cached_open_pr_heads(
+            root,
+            prefix,
+            outbox_dir=resolved_outbox_dir,
+            receipt_dir=resolved_receipt_dir,
+        )
+        if open_pr_lookup_skipped
+        else set()
     )
     handoff_receipted_branch_heads = terminal_receipted_handoff_branch_heads(
         root,
@@ -1092,6 +1136,7 @@ def audit(
     handoff_outbox_patch_ids: set[str] | None = None
 
     records: list[BranchRecord] = []
+    cached_open_pr_lookup_used = False
     patch_equivalence_skipped_branches = 0
     patch_equivalence_budget_exhausted = False
     for row in rows:
@@ -1101,7 +1146,9 @@ def audit(
         dirty_paths = [str(path) for path in paths if dirty_worktree(path)]
         active_paths = [str(path) for path in paths if active_worktree(path)]
         open_pr = prs.get(branch) if prs is not None else None
-        open_pr_cached = open_pr is None and branch in cached_prs
+        open_pr_cached = open_pr is None and open_pr_lookup_skipped and branch in cached_prs
+        if open_pr_cached:
+            cached_open_pr_lookup_used = True
         handoff_receipted = branch in handoff_receipted_branches
         handoff_outbox = branch in handoff_outbox_branches
         protected_before_patch_check = (
@@ -1351,7 +1398,7 @@ def audit(
         "receipt_dir": str(resolved_receipt_dir),
         "github_health": github_health.to_dict(),
         "open_pr_lookup_skipped": open_pr_lookup_skipped,
-        "cached_open_pr_lookup_used": bool(cached_prs),
+        "cached_open_pr_lookup_used": cached_open_pr_lookup_used,
         "cached_open_pr_head_count": len(cached_prs),
         "branch_count": len(records),
         "summary": {

--- a/scripts/audit_codex_branch_backlog.py
+++ b/scripts/audit_codex_branch_backlog.py
@@ -37,6 +37,7 @@ ACTIVE_SESSION_FILES = (
 )
 DEFAULT_OUTBOX_DIR = Path(".aragora/automation-outbox")
 DEFAULT_RECEIPT_DIR = Path(".aragora/automation-receipts")
+DEFAULT_GITHUB_STATUS_CACHE = Path(".aragora/automation-github-status/latest.json")
 TERMINAL_RECEIPT_STATUSES = {"published", "already_satisfied", "completed", "skipped"}
 COMMIT_PREFIX_RE = re.compile(r"^[0-9a-f]{7,40}$", re.IGNORECASE)
 BRANCH_IDEMPOTENCY_PREFIXES = ("open-pr-", "already-satisfied-")
@@ -60,6 +61,7 @@ COMPACT_RECORD_EXAMPLE_FIELDS = (
     "divergence_lookup_failed",
     "patch_equivalence_skipped",
     "open_pr",
+    "open_pr_cached",
     "worktree_paths",
     "active_worktree_paths",
     "dirty_worktree_paths",
@@ -85,6 +87,7 @@ class BranchRecord:
     patch_equivalence_skipped: bool
     remote_branch_exists: bool
     open_pr: int | None
+    open_pr_cached: bool
     worktree_paths: list[str]
     dirty_worktree_paths: list[str]
     active_worktree_paths: list[str]
@@ -710,6 +713,68 @@ def open_pr_heads(root: Path, repo: str, prefix: str) -> dict[str, int] | None:
     return heads
 
 
+def _github_status_cache_paths(
+    root: Path,
+    *,
+    outbox_dir: Path | None = None,
+    receipt_dir: Path | None = None,
+) -> list[Path]:
+    candidates: list[Path] = []
+    for state_path in (outbox_dir, receipt_dir):
+        if state_path is None:
+            continue
+        resolved = _repo_relative(root, state_path)
+        if resolved.name in {"automation-outbox", "automation-receipts"}:
+            candidates.append(resolved.parent / "automation-github-status" / "latest.json")
+    candidates.append(
+        _automation_state_default_path(_automation_state_root(root), DEFAULT_GITHUB_STATUS_CACHE)
+    )
+
+    deduped: list[Path] = []
+    seen: set[Path] = set()
+    for candidate in candidates:
+        try:
+            key = candidate.resolve()
+        except OSError:
+            key = candidate
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(candidate)
+    return deduped
+
+
+def cached_open_pr_heads(
+    root: Path,
+    prefix: str,
+    *,
+    outbox_dir: Path | None = None,
+    receipt_dir: Path | None = None,
+) -> set[str]:
+    """Return cached open PR branch heads from local publisher status evidence."""
+
+    for cache_path in _github_status_cache_paths(
+        root, outbox_dir=outbox_dir, receipt_dir=receipt_dir
+    ):
+        payload = _json_mapping(cache_path)
+        if payload is None:
+            continue
+        github_queue = payload.get("github_queue")
+        if not isinstance(github_queue, Mapping):
+            continue
+        open_pr_heads_value = github_queue.get("open_pr_heads")
+        if not isinstance(open_pr_heads_value, Sequence) or isinstance(
+            open_pr_heads_value, (str, bytes, bytearray)
+        ):
+            continue
+        return {
+            item
+            for item in open_pr_heads_value
+            if isinstance(item, str) and item.startswith(prefix)
+        }
+    return set()
+
+
 def count_ahead(root: Path, base: str, branch: str) -> int | None:
     divergence = branch_divergence(root, base, branch)
     if divergence is None:
@@ -993,6 +1058,12 @@ def audit(
         open_pr_lookup_skipped = True
     resolved_outbox_dir = _automation_state_path(root, outbox_dir, DEFAULT_OUTBOX_DIR)
     resolved_receipt_dir = _automation_state_path(root, receipt_dir, DEFAULT_RECEIPT_DIR)
+    cached_prs = cached_open_pr_heads(
+        root,
+        prefix,
+        outbox_dir=resolved_outbox_dir,
+        receipt_dir=resolved_receipt_dir,
+    )
     handoff_receipted_branch_heads = terminal_receipted_handoff_branch_heads(
         root,
         outbox_dir=resolved_outbox_dir,
@@ -1030,10 +1101,12 @@ def audit(
         dirty_paths = [str(path) for path in paths if dirty_worktree(path)]
         active_paths = [str(path) for path in paths if active_worktree(path)]
         open_pr = prs.get(branch) if prs is not None else None
+        open_pr_cached = open_pr is None and branch in cached_prs
         handoff_receipted = branch in handoff_receipted_branches
         handoff_outbox = branch in handoff_outbox_branches
         protected_before_patch_check = (
             open_pr is not None
+            or open_pr_cached
             or bool(active_paths)
             or bool(dirty_paths)
             or handoff_receipted
@@ -1144,7 +1217,7 @@ def audit(
             assert ahead_count is not None
             assert behind_count is not None
             category = classify(
-                open_pr=open_pr,
+                open_pr=open_pr if open_pr is not None else (0 if open_pr_cached else None),
                 active_paths=active_paths,
                 dirty_paths=dirty_paths,
                 ahead_count=ahead_count,
@@ -1181,7 +1254,7 @@ def audit(
                 assert ahead_count is not None
                 assert behind_count is not None
                 category = classify(
-                    open_pr=open_pr,
+                    open_pr=open_pr if open_pr is not None else (0 if open_pr_cached else None),
                     active_paths=active_paths,
                     dirty_paths=dirty_paths,
                     ahead_count=ahead_count,
@@ -1213,6 +1286,7 @@ def audit(
                 patch_equivalence_skipped=patch_equivalence_skipped,
                 remote_branch_exists=remote_exists,
                 open_pr=open_pr,
+                open_pr_cached=open_pr_cached,
                 worktree_paths=[str(path) for path in paths],
                 dirty_worktree_paths=dirty_paths,
                 active_worktree_paths=active_paths,
@@ -1277,6 +1351,8 @@ def audit(
         "receipt_dir": str(resolved_receipt_dir),
         "github_health": github_health.to_dict(),
         "open_pr_lookup_skipped": open_pr_lookup_skipped,
+        "cached_open_pr_lookup_used": bool(cached_prs),
+        "cached_open_pr_head_count": len(cached_prs),
         "branch_count": len(records),
         "summary": {
             "safe_cleanup_candidates": safe_cleanup,

--- a/scripts/cache_codex_automation_github_status.py
+++ b/scripts/cache_codex_automation_github_status.py
@@ -653,7 +653,7 @@ def preserve_cached_github_queue(path: Path, payload: dict[str, Any]) -> dict[st
         if key in previous_queue:
             merged_queue[key] = previous_queue[key]
     merged_queue["open_pr_heads_preserved_from_cache"] = True
-    cached_at = previous.get("generated_at")
+    cached_at = previous_queue.get("open_pr_heads_cached_at") or previous.get("generated_at")
     if isinstance(cached_at, str) and cached_at:
         merged_queue["open_pr_heads_cached_at"] = cached_at
 

--- a/scripts/cache_codex_automation_github_status.py
+++ b/scripts/cache_codex_automation_github_status.py
@@ -67,6 +67,16 @@ LOCAL_QUEUE_DETAIL_KEYS = (
     "unsatisfied_receipted_outbox",
     "stale_target_pr_receipted_outbox",
 )
+GITHUB_QUEUE_PRESERVED_KEYS = (
+    "open_pr_heads",
+    "open_codex_pr_count",
+    "unhealthy_open_pr_count",
+    "all_open_prs_unhealthy",
+    "merge_state_counts",
+    "open_issue_count",
+    "labels",
+    "pressure",
+)
 
 
 def _has_queue_state_dirs(state_root: Path) -> bool:
@@ -617,6 +627,41 @@ def write_status(path: Path, payload: dict[str, Any]) -> None:
     Path(temp_name).replace(path)
 
 
+def preserve_cached_github_queue(path: Path, payload: dict[str, Any]) -> dict[str, Any]:
+    """Carry forward cached open PR heads when a refresh cannot query GitHub."""
+
+    github_queue = payload.get("github_queue")
+    if not isinstance(github_queue, Mapping) or github_queue.get("available") is not False:
+        return payload
+    try:
+        previous = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return payload
+    if not isinstance(previous, Mapping):
+        return payload
+    previous_queue = previous.get("github_queue")
+    if not isinstance(previous_queue, Mapping):
+        return payload
+    previous_heads = previous_queue.get("open_pr_heads")
+    if not isinstance(previous_heads, Sequence) or isinstance(
+        previous_heads, (str, bytes, bytearray)
+    ):
+        return payload
+
+    merged_queue = dict(github_queue)
+    for key in GITHUB_QUEUE_PRESERVED_KEYS:
+        if key in previous_queue:
+            merged_queue[key] = previous_queue[key]
+    merged_queue["open_pr_heads_preserved_from_cache"] = True
+    cached_at = previous.get("generated_at")
+    if isinstance(cached_at, str) and cached_at:
+        merged_queue["open_pr_heads_cached_at"] = cached_at
+
+    preserved = dict(payload)
+    preserved["github_queue"] = merged_queue
+    return preserved
+
+
 def summary_only_payload(payload: dict[str, Any]) -> dict[str, Any]:
     """Return compact queue status for recurring automation startup logs."""
 
@@ -719,6 +764,7 @@ def main(argv: list[str] | None = None) -> int:
             else None
         ),
     )
+    payload = preserve_cached_github_queue(output, payload)
     write_status(output, payload)
     if args.json:
         output_payload = summary_only_payload(payload) if args.summary_only else payload

--- a/tests/scripts/test_audit_codex_branch_backlog.py
+++ b/tests/scripts/test_audit_codex_branch_backlog.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import subprocess
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -384,6 +384,7 @@ def test_audit_uses_cached_open_pr_heads_when_github_health_degraded(
     (cache_dir / "latest.json").write_text(
         json.dumps(
             {
+                "generated_at": datetime.now(timezone.utc).isoformat(),
                 "github_health": {"ready": True, "mode": "ready"},
                 "github_queue": {
                     "available": True,
@@ -433,6 +434,118 @@ def test_audit_uses_cached_open_pr_heads_when_github_health_degraded(
     assert record["category"] == "protected_open_pr"
     assert payload["summary"]["protected"] == 1
     assert payload["summary"]["publishable_branch_backlog"] == 0
+
+
+def test_audit_does_not_let_cache_override_successful_live_open_pr_lookup(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    row = _branch_row("codex/closed-pr", ahead_count="0")
+    _stub_git_inventory(monkeypatch, row)
+    cache_dir = tmp_path / ".aragora" / "automation-github-status"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "latest.json").write_text(
+        json.dumps(
+            {
+                "generated_at": datetime.now(timezone.utc).isoformat(),
+                "github_queue": {
+                    "available": True,
+                    "open_pr_heads": ["codex/closed-pr"],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda _root, **_kwargs: GitHubCLIHealth(
+            ready=True,
+            auth_ok=True,
+            api_ok=True,
+            mode="ready",
+            error="",
+            repo=str(tmp_path),
+        ),
+    )
+    monkeypatch.setattr(mod, "open_pr_heads", lambda *_args, **_kwargs: {})
+
+    payload = mod.audit(
+        root=tmp_path,
+        base="origin/main",
+        repo="synaptent/aragora",
+        prefix="codex/",
+        recent_hours=72,
+        max_branches=None,
+        include_patch_equivalence=False,
+        publisher_backlog_limit=12,
+    )
+
+    record = payload["records"][0]
+    assert payload["open_pr_lookup_skipped"] is False
+    assert payload["cached_open_pr_lookup_used"] is False
+    assert payload["cached_open_pr_head_count"] == 0
+    assert record["open_pr"] is None
+    assert record["open_pr_cached"] is False
+    assert record["category"] == "cleanup_local_merged"
+
+
+def test_audit_ignores_stale_cached_open_pr_heads_when_github_health_degraded(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    row = _branch_row("codex/stale-cached-pr")
+    _stub_git_inventory(monkeypatch, row)
+    cache_dir = tmp_path / ".aragora" / "automation-github-status"
+    cache_dir.mkdir(parents=True)
+    stale_at = datetime.now(timezone.utc) - timedelta(hours=48)
+    (cache_dir / "latest.json").write_text(
+        json.dumps(
+            {
+                "generated_at": stale_at.isoformat(),
+                "github_queue": {
+                    "available": True,
+                    "open_pr_heads": ["codex/stale-cached-pr"],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda _root, **_kwargs: GitHubCLIHealth(
+            ready=False,
+            auth_ok=False,
+            api_ok=False,
+            mode="connectivity_failed",
+            error="offline",
+            repo=str(tmp_path),
+        ),
+    )
+    monkeypatch.setattr(
+        mod,
+        "open_pr_heads",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("live PR lookup should be skipped")
+        ),
+    )
+
+    payload = mod.audit(
+        root=tmp_path,
+        base="origin/main",
+        repo="synaptent/aragora",
+        prefix="codex/",
+        recent_hours=72,
+        max_branches=None,
+        include_patch_equivalence=False,
+        publisher_backlog_limit=12,
+    )
+
+    record = payload["records"][0]
+    assert payload["open_pr_lookup_skipped"] is True
+    assert payload["cached_open_pr_lookup_used"] is False
+    assert payload["cached_open_pr_head_count"] == 0
+    assert record["open_pr_cached"] is False
+    assert record["category"] == "salvage_recent_unique"
 
 
 def test_audit_passes_bounded_timeout_to_github_health(tmp_path: Path, monkeypatch: Any) -> None:

--- a/tests/scripts/test_audit_codex_branch_backlog.py
+++ b/tests/scripts/test_audit_codex_branch_backlog.py
@@ -374,6 +374,67 @@ def test_audit_skips_open_pr_lookup_when_github_health_degraded(
     assert payload["records"][0]["category"] == "salvage_recent_unique"
 
 
+def test_audit_uses_cached_open_pr_heads_when_github_health_degraded(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    row = _branch_row("codex/has-cached-pr")
+    _stub_git_inventory(monkeypatch, row)
+    cache_dir = tmp_path / ".aragora" / "automation-github-status"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "latest.json").write_text(
+        json.dumps(
+            {
+                "github_health": {"ready": True, "mode": "ready"},
+                "github_queue": {
+                    "available": True,
+                    "open_pr_heads": ["codex/has-cached-pr", "other/branch"],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda _root, **_kwargs: GitHubCLIHealth(
+            ready=False,
+            auth_ok=False,
+            api_ok=False,
+            mode="connectivity_failed",
+            error="offline",
+            repo=str(tmp_path),
+        ),
+    )
+    monkeypatch.setattr(
+        mod,
+        "open_pr_heads",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("live PR lookup should be skipped")
+        ),
+    )
+
+    payload = mod.audit(
+        root=tmp_path,
+        base="origin/main",
+        repo="synaptent/aragora",
+        prefix="codex/",
+        recent_hours=72,
+        max_branches=None,
+        include_patch_equivalence=False,
+        publisher_backlog_limit=12,
+    )
+
+    record = payload["records"][0]
+    assert payload["open_pr_lookup_skipped"] is True
+    assert payload["cached_open_pr_lookup_used"] is True
+    assert payload["cached_open_pr_head_count"] == 1
+    assert record["open_pr"] is None
+    assert record["open_pr_cached"] is True
+    assert record["category"] == "protected_open_pr"
+    assert payload["summary"]["protected"] == 1
+    assert payload["summary"]["publishable_branch_backlog"] == 0
+
+
 def test_audit_passes_bounded_timeout_to_github_health(tmp_path: Path, monkeypatch: Any) -> None:
     _stub_git_inventory(monkeypatch, _branch_row())
     observed_timeouts: list[int] = []

--- a/tests/scripts/test_cache_codex_automation_github_status.py
+++ b/tests/scripts/test_cache_codex_automation_github_status.py
@@ -99,6 +99,46 @@ def test_build_status_keeps_local_queue_when_remote_query_fails(
     assert payload["local_queue"]["unreceipted_outbox_count"] == 1
 
 
+def test_preserves_cached_open_pr_heads_when_github_queue_unavailable(tmp_path: Path) -> None:
+    cache_path = tmp_path / ".aragora" / "automation-github-status" / "latest.json"
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-06-02T07:49:13Z",
+                "github_queue": {
+                    "available": True,
+                    "open_codex_pr_count": 2,
+                    "open_pr_heads": ["codex/a", "codex/b"],
+                    "merge_state_counts": {"BLOCKED": 2},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    payload = {
+        "generated_at": "2026-06-02T08:01:18Z",
+        "github_queue": {
+            "available": False,
+            "reason": "connectivity_failed",
+        },
+        "local_queue": {"outbox_count": 3},
+    }
+
+    preserved = mod.preserve_cached_github_queue(cache_path, payload)
+
+    assert preserved["local_queue"] == {"outbox_count": 3}
+    assert preserved["github_queue"] == {
+        "available": False,
+        "reason": "connectivity_failed",
+        "open_pr_heads": ["codex/a", "codex/b"],
+        "open_codex_pr_count": 2,
+        "merge_state_counts": {"BLOCKED": 2},
+        "open_pr_heads_preserved_from_cache": True,
+        "open_pr_heads_cached_at": "2026-06-02T07:49:13Z",
+    }
+
+
 def test_local_queue_state_matches_receipts_by_idempotency_key(tmp_path: Path) -> None:
     outbox = tmp_path / ".aragora" / "automation-outbox"
     receipts = tmp_path / ".aragora" / "automation-receipts"

--- a/tests/scripts/test_cache_codex_automation_github_status.py
+++ b/tests/scripts/test_cache_codex_automation_github_status.py
@@ -139,6 +139,69 @@ def test_preserves_cached_open_pr_heads_when_github_queue_unavailable(tmp_path: 
     }
 
 
+def test_preserve_cached_github_queue_leaves_available_queue_untouched(tmp_path: Path) -> None:
+    cache_path = tmp_path / ".aragora" / "automation-github-status" / "latest.json"
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-06-02T07:49:13Z",
+                "github_queue": {
+                    "available": True,
+                    "open_pr_heads": ["codex/old"],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    payload = {
+        "generated_at": "2026-06-02T08:01:18Z",
+        "github_queue": {
+            "available": True,
+            "open_pr_heads": ["codex/new"],
+        },
+    }
+
+    preserved = mod.preserve_cached_github_queue(cache_path, payload)
+
+    assert preserved == payload
+    assert "open_pr_heads_preserved_from_cache" not in preserved["github_queue"]
+
+
+def test_preserve_cached_github_queue_keeps_original_open_pr_heads_cached_at(
+    tmp_path: Path,
+) -> None:
+    cache_path = tmp_path / ".aragora" / "automation-github-status" / "latest.json"
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-06-02T08:01:18Z",
+                "github_queue": {
+                    "available": False,
+                    "reason": "remote_query_failed",
+                    "open_pr_heads": ["codex/a"],
+                    "open_pr_heads_cached_at": "2026-06-02T07:49:13Z",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    payload = {
+        "generated_at": "2026-06-02T08:30:00Z",
+        "github_queue": {
+            "available": False,
+            "reason": "connectivity_failed",
+        },
+    }
+
+    preserved = mod.preserve_cached_github_queue(cache_path, payload)
+
+    assert preserved["github_queue"]["open_pr_heads"] == ["codex/a"]
+    assert preserved["github_queue"]["open_pr_heads_cached_at"] == "2026-06-02T07:49:13Z"
+    assert preserved["github_queue"]["open_pr_heads_preserved_from_cache"] is True
+
+
 def test_local_queue_state_matches_receipts_by_idempotency_key(tmp_path: Path) -> None:
     outbox = tmp_path / ".aragora" / "automation-outbox"
     receipts = tmp_path / ".aragora" / "automation-receipts"


### PR DESCRIPTION
## Summary

- Teaches branch backlog audit to use cached open PR heads when live GitHub is degraded.
- Preserves cached open PR heads during degraded cache refreshes instead of wiping useful open-PR truth.
- Adds focused coverage for degraded GitHub fallback behavior.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/scripts/test_cache_codex_automation_github_status.py tests/scripts/test_audit_codex_branch_backlog.py` -> 77 passed, 2 existing warnings
- `python3 -m ruff check scripts/cache_codex_automation_github_status.py tests/scripts/test_cache_codex_automation_github_status.py scripts/audit_codex_branch_backlog.py tests/scripts/test_audit_codex_branch_backlog.py` -> passed
- `python3 -m ruff format --check scripts/cache_codex_automation_github_status.py tests/scripts/test_cache_codex_automation_github_status.py scripts/audit_codex_branch_backlog.py tests/scripts/test_audit_codex_branch_backlog.py` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> passed

## Notes

Published from recovered handoff `open-pr-codex-audit-cached-open-pr-heads-20260602-ff5047b0`; the prior blocker was GitHub DNS/auth availability. No merge requested.
