### PR TITLE
fix(steering): default heartbeats to shared state

### DIFF
--- a/scripts/agent_heartbeat.py
+++ b/scripts/agent_heartbeat.py
@@ -30,6 +30,7 @@ except ImportError:
 
 DEFAULT_REPO_ROOT = Path(__file__).resolve().parents[1]
 HEARTBEAT_RELATIVE_PATH = Path(".aragora") / "agent-bridge" / "heartbeats.json"
+AUTOMATION_STATE_ROOT_ENV = "ARAGORA_AUTOMATION_STATE_ROOT"
 SAFE_OWNER_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 
 
@@ -71,6 +72,50 @@ def _atomic_write(path: Path, rows: list[dict[str, Any]]) -> None:
     except Exception:
         tmp_path.unlink(missing_ok=True)
         raise
+
+
+def _state_dir(root: Path) -> Path:
+    expanded = root.expanduser()
+    if expanded.name == ".aragora":
+        return expanded
+    return expanded / ".aragora"
+
+
+def _has_agent_bridge_state(root: Path) -> bool:
+    return (_state_dir(root) / "agent-bridge").is_dir()
+
+
+def _automation_state_root(repo_root: Path) -> Path:
+    """Return the checkout or direct .aragora dir backing heartbeat state."""
+
+    if _has_agent_bridge_state(repo_root):
+        return repo_root
+
+    configured = os.environ.get(AUTOMATION_STATE_ROOT_ENV)
+    candidates: list[Path] = []
+    if configured:
+        candidates.append(Path(configured).expanduser())
+    candidates.append(Path.home() / "Development" / "aragora")
+
+    for candidate in candidates:
+        if _has_agent_bridge_state(candidate):
+            return candidate
+    return repo_root
+
+
+def _automation_state_default_path(state_root: Path, default_relative: Path) -> Path:
+    expanded = state_root.expanduser()
+    if default_relative.parts[:1] == (".aragora",) and expanded.name == ".aragora":
+        return expanded.joinpath(*default_relative.parts[1:])
+    return expanded / default_relative
+
+
+def resolve_heartbeat_path(*, repo_root: Path, explicit: Path | None = None) -> Path:
+    if explicit is not None:
+        return explicit
+    return _automation_state_default_path(
+        _automation_state_root(repo_root), HEARTBEAT_RELATIVE_PATH
+    )
 
 
 @contextmanager
@@ -165,7 +210,10 @@ def build_parser() -> argparse.ArgumentParser:
         "--repo-root",
         type=Path,
         default=DEFAULT_REPO_ROOT,
-        help=f"Repo root (default: {DEFAULT_REPO_ROOT}).",
+        help=(
+            f"Repo root (default: {DEFAULT_REPO_ROOT}). Heartbeat state defaults to this "
+            f"root's .aragora, then ${AUTOMATION_STATE_ROOT_ENV}, then ~/Development/aragora."
+        ),
     )
     parser.add_argument("--json", action="store_true")
     return parser
@@ -173,7 +221,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
-    heartbeat_path = args.heartbeat_path or args.repo_root / HEARTBEAT_RELATIVE_PATH
+    heartbeat_path = resolve_heartbeat_path(repo_root=args.repo_root, explicit=args.heartbeat_path)
     try:
         row = record_heartbeat(
             heartbeat_path=heartbeat_path,

--- a/tests/scripts/test_agent_heartbeat.py
+++ b/tests/scripts/test_agent_heartbeat.py
@@ -89,3 +89,78 @@ def test_concurrent_heartbeat_writes_preserve_all_rows(tmp_path: Path) -> None:
     assert all(returncode == 0 for _stdout, _stderr, returncode in results), results
     payload = json.loads(heartbeat_path.read_text(encoding="utf-8"))
     assert sorted(row["lane_id"] for row in payload) == [f"lane-{idx:02d}" for idx in range(12)]
+
+
+def test_resolve_heartbeat_path_prefers_repo_local_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_bridge = repo_root / ".aragora" / "agent-bridge"
+    shared_root = tmp_path / "shared"
+    repo_bridge.mkdir(parents=True)
+    (shared_root / ".aragora" / "agent-bridge").mkdir(parents=True)
+    monkeypatch.setenv("ARAGORA_AUTOMATION_STATE_ROOT", str(shared_root))
+
+    resolved = heartbeat.resolve_heartbeat_path(repo_root=repo_root)
+
+    assert resolved == repo_bridge / "heartbeats.json"
+
+
+def test_resolve_heartbeat_path_uses_env_checkout_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_root = tmp_path / "repo"
+    shared_root = tmp_path / "shared"
+    (shared_root / ".aragora" / "agent-bridge").mkdir(parents=True)
+    monkeypatch.setenv("ARAGORA_AUTOMATION_STATE_ROOT", str(shared_root))
+
+    resolved = heartbeat.resolve_heartbeat_path(repo_root=repo_root)
+
+    assert resolved == shared_root / ".aragora" / "agent-bridge" / "heartbeats.json"
+
+
+def test_resolve_heartbeat_path_accepts_direct_env_state_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_root = tmp_path / "repo"
+    shared_state = tmp_path / "shared" / ".aragora"
+    (shared_state / "agent-bridge").mkdir(parents=True)
+    monkeypatch.setenv("ARAGORA_AUTOMATION_STATE_ROOT", str(shared_state))
+
+    resolved = heartbeat.resolve_heartbeat_path(repo_root=repo_root)
+
+    assert resolved == shared_state / "agent-bridge" / "heartbeats.json"
+
+
+def test_cli_writes_to_shared_state_root_from_stateless_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_root = tmp_path / "repo"
+    shared_root = tmp_path / "shared"
+    (shared_root / ".aragora" / "agent-bridge").mkdir(parents=True)
+    monkeypatch.setenv("ARAGORA_AUTOMATION_STATE_ROOT", str(shared_root))
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--repo-root",
+            str(repo_root),
+            "--lane-id",
+            "Q245-primary-agent-heartbeat-shared-state",
+            "--owner-session",
+            "engineering-autopilot-Q245",
+            "--last-seen-at",
+            "2026-06-01T23:00:00Z",
+            "--json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    heartbeat_path = shared_root / ".aragora" / "agent-bridge" / "heartbeats.json"
+    payload = json.loads(heartbeat_path.read_text(encoding="utf-8"))
+    assert json.loads(result.stdout)["lane_id"] == "Q245-primary-agent-heartbeat-shared-state"
+    assert payload[0]["owner_session"] == "engineering-autopilot-Q245"
+    assert not (repo_root / ".aragora").exists()


### PR DESCRIPTION
## Summary

- Defaults the agent heartbeat sidecar to the shared automation state root when launched from disposable worktrees.
- Preserves explicit state-root behavior while making owner/liveness surfaces visible across isolated checkouts.
- Adds focused tests for the shared-state default.

## Validation

- `python3 -m pytest -q tests/scripts/test_agent_heartbeat.py -p no:rerunfailures -p no:cacheprovider` -> 7 passed
- `python3 -m ruff check scripts/agent_heartbeat.py tests/scripts/test_agent_heartbeat.py` -> passed
- `python3 -m ruff format --check scripts/agent_heartbeat.py tests/scripts/test_agent_heartbeat.py` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> passed
- `ARAGORA_AUTOMATION_STATE_ROOT=/Users/armand/Development/aragora python3 scripts/agent_heartbeat.py --repo-root /private/tmp/nonexistent-aragora-stateless --lane-id Q245-primary-agent-heartbeat-shared-state --owner-session codex-validation --json` -> wrote heartbeat via shared state root

## Notes

Published from recovered handoff `open-pr-codex-agent-heartbeat-shared-state-primary-20260601-df900986`; the prior blocker was GitHub availability. No merge requested.
