### PR TITLE
fix(agent-bridge): filter terminal broker runs from current snapshots

### DIFF
--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -857,10 +857,18 @@ def _load_broker_run_summaries() -> list[dict[str, Any]]:
         return []
 
 
+def _is_current_broker_run(run: dict[str, Any]) -> bool:
+    return run.get("status") in ACTIVE_LANE_STATUSES or run.get("status") == "awaiting_human"
+
+
+def _filter_current_broker_runs(broker_runs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [run for run in broker_runs if _is_current_broker_run(run)]
+
+
 def _active_broker_session_ids(broker_runs: list[dict[str, Any]]) -> set[str]:
     ids: set[str] = set()
     for run in broker_runs:
-        if run.get("status") not in ACTIVE_LANE_STATUSES and run.get("status") != "awaiting_human":
+        if not _is_current_broker_run(run):
             continue
         sessions = run.get("sessions", {})
         if not isinstance(sessions, dict):
@@ -2224,6 +2232,8 @@ def cmd_operator_snapshot(args: argparse.Namespace) -> int:
         include_summaries=not summary_only,
         include_historical=include_historical or not summary_only,
     )
+    if not include_historical:
+        broker_runs = _filter_current_broker_runs(broker_runs)
     sessions = (
         discovered_sessions if include_historical else _filter_current_sessions(discovered_sessions)
     )

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -1476,6 +1476,61 @@ def test_operator_snapshot_includes_broker_runs(
     assert payload["broker_runs"][0]["run_id"] == "bridge-next-work"
 
 
+def test_operator_snapshot_current_scope_filters_terminal_broker_runs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import agent_bridge as mod
+
+    _patch_bridge_paths(mod, tmp_path, monkeypatch)
+    monkeypatch.setattr(mod, "discover", lambda **_kwargs: [])
+    monkeypatch.setattr(mod, "_enrich_prs", lambda _sessions: None)
+    monkeypatch.setattr(mod, "_load_lane_registry", lambda: [])
+    monkeypatch.setattr(
+        mod,
+        "_load_broker_run_summaries",
+        lambda: [
+            {"run_id": "completed-run", "status": "completed"},
+            {"run_id": "failed-run", "status": "failed"},
+            {"run_id": "running-run", "status": "running"},
+            {"run_id": "human-run", "status": "awaiting_human"},
+        ],
+    )
+    monkeypatch.setattr(
+        mod,
+        "_collect_agent_process_census",
+        lambda *, include_records=True, record_limit=None, ps_lines=None: {
+            "ok": True,
+            "total": 0,
+            "by_role": {},
+            **({"records": []} if include_records else {}),
+        },
+    )
+    monkeypatch.setattr(mod, "_collect_pending_steering_messages", lambda _recipient: {"count": 0})
+    monkeypatch.setattr(
+        mod,
+        "_collect_agent_heartbeats",
+        lambda: {"count": 0, "fresh_count": 0, "stale_count": 0, "latest_by_owner": {}},
+    )
+
+    assert (
+        mod.cmd_operator_snapshot(
+            argparse.Namespace(
+                json=True,
+                summary_only=False,
+                include_historical=False,
+                scope="current",
+            )
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert [run["run_id"] for run in payload["broker_runs"]] == ["running-run", "human-run"]
+    assert payload["summary"]["active_broker_runs"] == 2
+
+
 def test_load_broker_run_summaries_reads_json_without_package_import(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

- Filters terminal broker runs from current-scope `operator-snapshot --json` output.
- Keeps historical broker records available through historical/all scopes.
- Adds focused coverage for current-scope broker run filtering.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/scripts/test_agent_bridge.py -k 'broker_runs or current_output_preserves_full_canonical_snapshot' -q -p no:rerunfailures -p no:cacheprovider` -> 3 passed, 46 deselected, 2 existing warnings
- `python3 -m ruff check scripts/agent_bridge.py tests/scripts/test_agent_bridge.py` -> passed
- `python3 -m ruff format --check scripts/agent_bridge.py tests/scripts/test_agent_bridge.py` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> passed

## Notes

Published from refreshed recovered handoff `open-pr-codex-operator-snapshot-current-broker-runs-20260530-6d8be853`. The JSON requested action still referenced stale r9, but local evidence refreshed the branch to `codex/harvest-operator-snapshot-current-broker-runs-r10-20260602` at this head on current `origin/main`. No merge requested.
