### PR TITLE
fix(audit): include changed paths in backlog records

### DIFF
--- a/scripts/audit_codex_branch_backlog.py
+++ b/scripts/audit_codex_branch_backlog.py
@@ -41,6 +41,7 @@ TERMINAL_RECEIPT_STATUSES = {"published", "already_satisfied", "completed", "ski
 COMMIT_PREFIX_RE = re.compile(r"^[0-9a-f]{7,40}$", re.IGNORECASE)
 BRANCH_IDEMPOTENCY_PREFIXES = ("open-pr-", "already-satisfied-")
 DEFAULT_GITHUB_HEALTH_TIMEOUT_SECONDS = 5
+DEFAULT_CHANGED_PATH_EXAMPLE_LIMIT = 8
 SALVAGE_CATEGORIES = {
     "salvage_recent_unique",
     "salvage_stale_remote_unique",
@@ -57,6 +58,9 @@ COMPACT_RECORD_EXAMPLE_FIELDS = (
     "subject",
     "ahead_count",
     "behind_count",
+    "changed_path_count",
+    "changed_path_examples",
+    "changed_paths_truncated",
     "divergence_lookup_failed",
     "patch_equivalence_skipped",
     "open_pr",
@@ -79,6 +83,9 @@ class BranchRecord:
     subject: str
     ahead_count: int | None
     behind_count: int | None
+    changed_path_count: int | None
+    changed_path_examples: list[str]
+    changed_paths_truncated: bool
     divergence_lookup_failed: bool
     merged_to_base: bool
     patch_equivalent_to_base: bool
@@ -803,6 +810,24 @@ def has_empty_branch_diff(
     return run_git(["diff", "--quiet", f"{base}...{branch}"], root, timeout=timeout).returncode == 0
 
 
+def branch_changed_paths(
+    root: Path,
+    base: str,
+    branch: str,
+    *,
+    example_limit: int = DEFAULT_CHANGED_PATH_EXAMPLE_LIMIT,
+    timeout: int = 60,
+) -> tuple[int | None, list[str], bool]:
+    """Return changed-path count plus compact examples for a branch diff."""
+
+    proc = run_git(["diff", "--name-only", "-z", f"{base}...{branch}"], root, timeout=timeout)
+    if proc.returncode != 0:
+        return None, [], False
+    paths = [path for path in proc.stdout.split("\0") if path]
+    limit = max(0, example_limit)
+    return len(paths), paths[:limit], len(paths) > limit
+
+
 def has_empty_changed_file_diff(
     root: Path,
     base: str,
@@ -1067,6 +1092,20 @@ def audit(
                 else:
                     ahead_count, behind_count = divergence
         merged_to_base = branch in merged_branches
+        changed_path_count: int | None = None
+        changed_path_examples: list[str] = []
+        changed_paths_truncated = False
+        if (
+            ahead_count is not None
+            and ahead_count > 0
+            and not merged_to_base
+            and not protected_before_patch_check
+        ):
+            (
+                changed_path_count,
+                changed_path_examples,
+                changed_paths_truncated,
+            ) = branch_changed_paths(root, base, branch, timeout=30)
         patch_equivalent = False
         patch_equivalence_skipped = False
         patch_id = None
@@ -1207,6 +1246,9 @@ def audit(
                 subject=row["subject"],
                 ahead_count=ahead_count,
                 behind_count=behind_count,
+                changed_path_count=changed_path_count,
+                changed_path_examples=changed_path_examples,
+                changed_paths_truncated=changed_paths_truncated,
                 divergence_lookup_failed=divergence_lookup_failed,
                 merged_to_base=merged_to_base,
                 patch_equivalent_to_base=patch_equivalent,

--- a/tests/scripts/test_audit_codex_branch_backlog.py
+++ b/tests/scripts/test_audit_codex_branch_backlog.py
@@ -217,6 +217,12 @@ def test_summary_only_payload_keeps_compact_category_examples() -> None:
                 "subject": "needs salvage",
                 "ahead_count": 2,
                 "behind_count": 4,
+                "changed_path_count": 2,
+                "changed_path_examples": [
+                    "aragora/live/package-lock.json",
+                    "aragora/live/package.json",
+                ],
+                "changed_paths_truncated": False,
                 "worktree_paths": ["/tmp/worktree"],
                 "active_worktree_paths": [],
                 "dirty_worktree_paths": [],
@@ -242,6 +248,12 @@ def test_summary_only_payload_keeps_compact_category_examples() -> None:
             "subject": "needs salvage",
             "ahead_count": 2,
             "behind_count": 4,
+            "changed_path_count": 2,
+            "changed_path_examples": [
+                "aragora/live/package-lock.json",
+                "aragora/live/package.json",
+            ],
+            "changed_paths_truncated": False,
             "worktree_paths": ["/tmp/worktree"],
             "active_worktree_paths": [],
             "dirty_worktree_paths": [],
@@ -1633,6 +1645,63 @@ def test_audit_checks_branch_equivalence_before_handoff_patch_ids(
     assert record["name"] == "codex/replayed"
     assert record["patch_equivalent_to_base"] is True
     assert record["category"] == "cleanup_patch_equivalent"
+
+
+def test_audit_includes_changed_path_examples(tmp_path: Path, monkeypatch: Any) -> None:
+    now = datetime.now(timezone.utc)
+    rows = [_branch_row("codex/stale-lockfile", committed_at=now, behind_count="2")]
+    monkeypatch.setattr(mod, "local_branches", lambda _root, _prefix, _base: rows)
+    monkeypatch.setattr(mod, "remote_branch_names", lambda _root, _prefix: set())
+    monkeypatch.setattr(mod, "merged_branch_names", lambda _root, _base, _prefix: set())
+    monkeypatch.setattr(mod, "worktree_map", lambda _root: {})
+    monkeypatch.setattr(mod, "is_patch_equivalent", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(mod, "branch_patch_id", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        mod,
+        "branch_changed_paths",
+        lambda _root, _base, _branch, **_kwargs: (
+            3,
+            [
+                "aragora/live/package-lock.json",
+                "aragora/live/package.json",
+                "tests/live/smoke.test.ts",
+            ],
+            False,
+        ),
+    )
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda _root, **_kwargs: GitHubCLIHealth(
+            ready=False,
+            auth_ok=False,
+            api_ok=False,
+            mode="connectivity_failed",
+            error="offline",
+            repo=str(tmp_path),
+        ),
+    )
+
+    payload = mod.audit(
+        root=tmp_path,
+        base="origin/main",
+        repo="synaptent/aragora",
+        prefix="codex/",
+        recent_hours=72,
+        max_branches=None,
+        include_patch_equivalence=True,
+        publisher_backlog_limit=2,
+    )
+
+    record = payload["records"][0]
+    assert record["category"] == "salvage_diverged_recent"
+    assert record["changed_path_count"] == 3
+    assert record["changed_path_examples"] == [
+        "aragora/live/package-lock.json",
+        "aragora/live/package.json",
+        "tests/live/smoke.test.ts",
+    ]
+    assert record["changed_paths_truncated"] is False
 
 
 def test_audit_does_not_spend_patch_ids_for_exact_outbox_branch(


### PR DESCRIPTION
## Summary

- Adds compact changed-path count/examples to branch backlog audit records.
- Keeps summary-only category examples useful for routing stale/salvage candidates without broad diff inspection.
- Adds focused coverage for changed-path examples in backlog output.

## Validation

- `python3 -m pytest -q tests/scripts/test_audit_codex_branch_backlog.py -p no:rerunfailures -p no:cacheprovider` -> 57 passed
- `python3 -m ruff check scripts/audit_codex_branch_backlog.py tests/scripts/test_audit_codex_branch_backlog.py` -> passed
- `python3 -m ruff format --check scripts/audit_codex_branch_backlog.py tests/scripts/test_audit_codex_branch_backlog.py` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> passed

## Notes

Published from recovered handoff `open-pr-codex-audit-content-subsumed-branches-primary-20260601-5a0a7d55`; the remote branch already existed, but no PR existed. No merge requested.
