### PR TITLE
fix(audit): report outbox refs outside capped branch audit

### DIFF
--- a/scripts/audit_codex_branch_backlog.py
+++ b/scripts/audit_codex_branch_backlog.py
@@ -1252,6 +1252,10 @@ def audit(
     direct_handoff_outbox_branches = sum(
         1 for record in records if record.name in handoff_outbox_branches
     )
+    audited_branch_names = {record.name for record in records}
+    unresolved_handoff_outbox_refs_outside_audit = len(
+        handoff_outbox_branches - audited_branch_names
+    )
     patch_equivalent_handoff_outbox_branches = sum(
         1
         for record in records
@@ -1289,6 +1293,9 @@ def audit(
             "handoff_outbox_branches": counts["protected_handoff_outbox"],
             "unresolved_handoff_outbox_branch_refs": len(handoff_outbox_branches),
             "direct_handoff_outbox_branches": direct_handoff_outbox_branches,
+            "unresolved_handoff_outbox_refs_outside_audit": (
+                unresolved_handoff_outbox_refs_outside_audit
+            ),
             "patch_equivalent_handoff_outbox_branches": (patch_equivalent_handoff_outbox_branches),
             "writer_should_pause_for_branch_backlog": (
                 publishable_branch_backlog >= publisher_backlog_limit
@@ -1358,6 +1365,10 @@ def print_markdown(payload: dict[str, Any], *, examples: int) -> None:
             f"`{summary['unresolved_handoff_outbox_branch_refs']}`"
         )
         print(f"- Direct handoff-outbox branches: `{summary['direct_handoff_outbox_branches']}`")
+        print(
+            "- Unresolved handoff-outbox refs outside audit: "
+            f"`{summary['unresolved_handoff_outbox_refs_outside_audit']}`"
+        )
         print(
             "- Patch-equivalent handoff-outbox branches: "
             f"`{summary['patch_equivalent_handoff_outbox_branches']}`"

--- a/tests/scripts/test_audit_codex_branch_backlog.py
+++ b/tests/scripts/test_audit_codex_branch_backlog.py
@@ -1751,6 +1751,7 @@ def test_audit_treats_superseded_branch_as_unresolved_handoff(
     assert payload["summary"]["handoff_outbox_branches"] == 1
     assert payload["summary"]["unresolved_handoff_outbox_branch_refs"] == 2
     assert payload["summary"]["direct_handoff_outbox_branches"] == 1
+    assert payload["summary"]["unresolved_handoff_outbox_refs_outside_audit"] == 1
     assert payload["summary"]["patch_equivalent_handoff_outbox_branches"] == 0
     assert payload["summary"]["publishable_branch_backlog"] == 1
     original = next(
@@ -1818,6 +1819,7 @@ def test_audit_counts_direct_outbox_refs_even_when_active_worktree_wins_category
     assert payload["summary"]["handoff_outbox_branches"] == 0
     assert payload["summary"]["unresolved_handoff_outbox_branch_refs"] == 1
     assert payload["summary"]["direct_handoff_outbox_branches"] == 1
+    assert payload["summary"]["unresolved_handoff_outbox_refs_outside_audit"] == 0
     assert payload["summary"]["patch_equivalent_handoff_outbox_branches"] == 0
 
 


### PR DESCRIPTION
## Summary

- Adds summary visibility for unresolved outbox refs outside capped branch-audit records.
- Helps operators distinguish direct audited branch refs from unresolved handoff refs that sit outside the current audit cap.
- Adds focused coverage for the compact audit summary fields.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_audit_codex_branch_backlog.py -p no:rerunfailures -p no:cacheprovider` -> 56 passed
- `python3 -m ruff check scripts/audit_codex_branch_backlog.py tests/scripts/test_audit_codex_branch_backlog.py` -> passed
- `python3 -m ruff format --check scripts/audit_codex_branch_backlog.py tests/scripts/test_audit_codex_branch_backlog.py` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> passed

## Notes

Published from recovered handoff `open-pr-codex-audit-outbox-outside-summary-primary-20260601-71c65aa4`; the prior blocker was GitHub availability. No merge requested.
