### PR TITLE
fix(publisher): treat post-cache outbox drift as warming

### DIFF
--- a/scripts/publisher_freshness_check.py
+++ b/scripts/publisher_freshness_check.py
@@ -55,6 +55,7 @@ class FreshnessReport:
     outbox_real_count: int
     outbox_cache_count: int | None
     outbox_drift: bool
+    outbox_changed_after_cache: bool
     drift_detail: str
     blockers: list[str] = field(default_factory=list)
 
@@ -157,6 +158,27 @@ def _count_outbox_files(outbox_dir: Path) -> int:
     return sum(1 for p in outbox_dir.iterdir() if p.is_file() and p.suffix == ".json")
 
 
+def _outbox_state_mtime(outbox_dir: Path) -> float | None:
+    if not outbox_dir.is_dir():
+        return None
+    try:
+        latest = outbox_dir.stat().st_mtime
+    except OSError:
+        return None
+    try:
+        paths = list(outbox_dir.iterdir())
+    except OSError:
+        return latest
+    for path in paths:
+        if not (path.is_file() and path.suffix == ".json"):
+            continue
+        try:
+            latest = max(latest, path.stat().st_mtime)
+        except OSError:
+            continue
+    return latest
+
+
 def _run_git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         ["git", *args],
@@ -249,21 +271,36 @@ def evaluate(
 
     cache_present = cache_path.is_file()
     cache_age: float | None
+    cache_mtime: float | None = None
     if cache_present:
-        cache_age = max(0.0, now - cache_path.stat().st_mtime)
+        cache_mtime = cache_path.stat().st_mtime
+        cache_age = max(0.0, now - cache_mtime)
     else:
         cache_age = None
     cache_stale = (cache_age is None) or (cache_age > stale_threshold_seconds)
 
     outbox_real = _count_outbox_files(outbox_dir)
     outbox_cache = _read_cache_outbox_count(cache_path) if cache_present else None
+    outbox_state_mtime = _outbox_state_mtime(outbox_dir)
+    outbox_changed_after_cache = (
+        cache_mtime is not None
+        and outbox_state_mtime is not None
+        and outbox_state_mtime > cache_mtime
+    )
     # A stale cache will *necessarily* disagree with the live outbox (the
     # outbox has changed since the snapshot was taken). Reporting drift in
     # that case is double-flagging: ``cache: Nh stale`` already explains the
-    # disagreement. Only treat drift as a real signal when the cache is
-    # fresh and the counts still don't match — that is the actual operator-
+    # disagreement. A post-cache outbox write is the same class of transient:
+    # the cache accurately described an older queue snapshot. Only treat drift
+    # as a blocker when the cache is fresh, no newer outbox mutation explains
+    # the mismatch, and the counts still don't match — that is the operator-
     # actionable case (e.g. publisher writing the wrong count).
-    drift_meaningful = outbox_cache is not None and outbox_cache != outbox_real and not cache_stale
+    drift_meaningful = (
+        outbox_cache is not None
+        and outbox_cache != outbox_real
+        and not cache_stale
+        and not outbox_changed_after_cache
+    )
     drift = outbox_cache is not None and outbox_cache != outbox_real
     if outbox_cache is None:
         drift_detail = f"outbox={outbox_real} cache=missing"
@@ -287,11 +324,12 @@ def evaluate(
         blockers.append(f"drift: {drift_detail}")
 
     if not blockers:
-        verdict = "ready"
+        verdict = "warming" if drift and outbox_changed_after_cache else "ready"
     elif loaded and not launchd_failing and not drift_meaningful:
-        # cache-stale alone (without meaningful drift, with healthy launchd)
-        # is "warming": the next publisher run will refresh the cache and
-        # the operator signal will resolve without intervention.
+        # cache-stale or post-cache outbox changes (without meaningful drift,
+        # with healthy launchd) are "warming": the next publisher run will
+        # refresh the cache and the operator signal will resolve without
+        # intervention.
         verdict = "warming"
     else:
         verdict = "degraded"
@@ -324,6 +362,7 @@ def evaluate(
         outbox_real_count=outbox_real,
         outbox_cache_count=outbox_cache,
         outbox_drift=drift,
+        outbox_changed_after_cache=outbox_changed_after_cache,
         drift_detail=drift_detail,
         blockers=blockers,
     )
@@ -403,6 +442,7 @@ def summary_only_payload(payload: dict[str, Any]) -> dict[str, Any]:
         "outbox_real_count",
         "outbox_cache_count",
         "outbox_drift",
+        "outbox_changed_after_cache",
         "drift_detail",
     )
     compact = {key: payload[key] for key in keep_keys if key in payload}

--- a/tests/scripts/test_publisher_freshness_check.py
+++ b/tests/scripts/test_publisher_freshness_check.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import subprocess
 import sys
 import time
@@ -55,6 +56,10 @@ def _write_outbox_files(tmp_path: Path, count: int) -> None:
     outbox = tmp_path / ".aragora" / "automation-outbox"
     for i in range(count):
         (outbox / f"open-pr-codex-test-{i}.json").write_text("{}", encoding="utf-8")
+
+
+def _set_mtime(path: Path, timestamp: float) -> None:
+    os.utime(path, (timestamp, timestamp))
 
 
 def test_ready_when_loaded_fresh_no_drift(monkeypatch: pytest.MonkeyPatch, stub_repo: Path) -> None:
@@ -149,22 +154,25 @@ def test_degraded_when_cache_stale(monkeypatch: pytest.MonkeyPatch, stub_repo: P
     assert report.cache_age_human == "2.0h"
 
 
-def test_warming_when_loaded_but_drift(monkeypatch: pytest.MonkeyPatch, stub_repo: Path) -> None:
-    """When launchd is loaded and cache is fresh but drift exists, verdict is warming.
-
-    This represents the transient state right after a publisher cycle that ran
-    against a stale outbox snapshot — the cache should refresh on the next cycle.
-    """
+def test_warming_when_outbox_changed_after_fresh_cache(
+    monkeypatch: pytest.MonkeyPatch, stub_repo: Path
+) -> None:
+    """Fresh count drift is warming when a newer outbox write explains it."""
     cache = _write_cache(stub_repo, outbox_count=2)
     _write_outbox_files(stub_repo, 5)  # real count > cache count
+    base = time.time() - 300
+    outbox = stub_repo / ".aragora" / "automation-outbox"
+    _set_mtime(cache, base)
+    for path in outbox.glob("*.json"):
+        _set_mtime(path, base + 10)
+    _set_mtime(outbox, base + 10)
     monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (True, "loaded", None))
-    now = cache.stat().st_mtime + 60
+    now = base + 60
     report = mod.evaluate(stub_repo, now=now)
-    # drift triggers degraded since drift means writes have happened that the
-    # cache hasn't reflected yet
     assert report.outbox_drift is True
-    assert "drift: outbox=5 cache=2" in report.blockers
-    assert report.verdict == "degraded"
+    assert report.outbox_changed_after_cache is True
+    assert [b for b in report.blockers if b.startswith("drift:")] == []
+    assert report.verdict == "warming"
 
 
 def test_warming_label_when_loaded_no_drift_but_cache_just_stale(
@@ -421,15 +429,22 @@ def test_fresh_cache_with_count_disagreement_still_flags_drift(
     AND counts disagree, drift IS a real blocker (the publisher wrote
     inconsistent data).
     """
-    cache = _write_cache(stub_repo, outbox_count=2)
     _write_outbox_files(stub_repo, 5)
+    cache = _write_cache(stub_repo, outbox_count=2)
+    base = time.time() - 300
+    outbox = stub_repo / ".aragora" / "automation-outbox"
+    for path in outbox.glob("*.json"):
+        _set_mtime(path, base)
+    _set_mtime(outbox, base)
+    _set_mtime(cache, base + 10)
     monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (True, "loaded", None))
     # Cache is 60s old → fresh at default 1800s threshold.
-    now = cache.stat().st_mtime + 60
+    now = base + 70
     report = mod.evaluate(stub_repo, now=now, stale_threshold_seconds=1800)
 
     assert report.cache_stale is False
     assert report.outbox_drift is True
+    assert report.outbox_changed_after_cache is False
     drift_blockers = [b for b in report.blockers if b.startswith("drift:")]
     assert drift_blockers == ["drift: outbox=5 cache=2"]
     assert report.verdict == "degraded"


### PR DESCRIPTION
Recovered automation handoff `open-pr-codex-publisher-freshness-post-cache-drift-20260601-1896ddec`.

This branch classifies publisher cache drift caused by post-cache outbox writes as warming instead of degraded, preserving the freshness check as a readiness signal while avoiding false blockers during normal publisher lag.

Validation:
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_publisher_freshness_check.py -p no:rerunfailures -p no:cacheprovider` -> 30 passed
- `python3 -m ruff check scripts/publisher_freshness_check.py tests/scripts/test_publisher_freshness_check.py` -> passed
- `python3 -m ruff format --check scripts/publisher_freshness_check.py tests/scripts/test_publisher_freshness_check.py` -> passed
- `git merge-tree --write-tree origin/main HEAD` -> clean tree
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> preflight: ok

No merge requested.