### PR TITLE
fix(automation): include handoff branch in outage decisions

### DIFF
--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -159,9 +159,33 @@ class PublishDecision:
     source_file: str
     eligible: bool
     reason: str
+    branch: str | None = None
+    desired_head: str | None = None
     existing_issue_url: str | None = None
     existing_pr_url: str | None = None
     created_issue_url: str | None = None
+
+
+def _decision_for_handoff(
+    handoff: Handoff,
+    *,
+    eligible: bool,
+    reason: str,
+    existing_issue_url: str | None = None,
+    existing_pr_url: str | None = None,
+    created_issue_url: str | None = None,
+) -> PublishDecision:
+    return PublishDecision(
+        task_title=handoff.task_title,
+        source_file=handoff.source_file,
+        eligible=eligible,
+        reason=reason,
+        branch=handoff.branch,
+        desired_head=handoff.desired_head,
+        existing_issue_url=existing_issue_url,
+        existing_pr_url=existing_pr_url,
+        created_issue_url=created_issue_url,
+    )
 
 
 def summarize_decisions(decisions: Sequence[PublishDecision]) -> dict[str, Any]:
@@ -1471,9 +1495,8 @@ def main(argv: list[str] | None = None) -> int:
         decision_handoffs = handoffs[: max(args.limit, 0)]
         decisions = [
             _local_handoff_blocker(repo_root, handoff)
-            or PublishDecision(
-                task_title=handoff.task_title,
-                source_file=handoff.source_file,
+            or _decision_for_handoff(
+                handoff,
                 eligible=False,
                 reason="github_unavailable",
             )

--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -746,9 +746,8 @@ def _stale_outbox_head(repo_root: Path, handoff: Handoff) -> str | None:
 
 def _local_handoff_blocker(repo_root: Path, handoff: Handoff) -> PublishDecision | None:
     if _stale_outbox_head(repo_root, handoff):
-        return PublishDecision(
-            task_title=handoff.task_title,
-            source_file=handoff.source_file,
+        return _decision_for_handoff(
+            handoff,
             eligible=False,
             reason="stale_outbox_head",
         )

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -1349,6 +1349,8 @@ def test_decide_handoffs_blocks_stale_outbox_head_before_pr_lookup(
             source_file=handoff.source_file,
             eligible=False,
             reason="stale_outbox_head",
+            branch="codex/example",
+            desired_head=old_head,
         )
     ]
     assert mod._branch_tip(repo, "codex/example") == new_head
@@ -2120,6 +2122,8 @@ def test_main_reports_stale_outbox_head_when_github_unavailable(
     payload = json.loads(capsys.readouterr().out)
     assert payload["outbox_handoff_count"] == 1
     assert payload["decisions"][0]["reason"] == "stale_outbox_head"
+    assert payload["decisions"][0]["branch"] == "codex/example"
+    assert payload["decisions"][0]["desired_head"] == old_head
 
 
 def test_main_limits_github_unavailable_decision_preview(

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -1944,6 +1944,50 @@ def test_main_reports_github_health_when_unavailable(
     }
 
 
+def test_main_reports_handoff_context_when_github_unavailable(
+    monkeypatch: Any, tmp_path: Path, capsys
+) -> None:
+    handoff = Handoff(
+        source_file=str(tmp_path / ".aragora" / "automation-outbox" / "repair-branch.json"),
+        task_title="Publish validated repair branch",
+        priority="MEDIUM",
+        body="body",
+        labels={},
+        expires_at=None,
+        idempotency_key="open-pr-codex-example-abc123",
+        source_kind="outbox",
+        branch="codex/example",
+        desired_head="abc1234",
+    )
+    monkeypatch.setattr(mod, "_repo_root", lambda path: tmp_path)
+    monkeypatch.setattr(mod, "load_handoffs", lambda codex_home, automation_ids=None: [])
+    monkeypatch.setattr(
+        mod,
+        "load_outbox_handoffs",
+        lambda repo_root, outbox_dir=None, receipt_dir=None: [handoff],
+    )
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda repo_root: GitHubCLIHealth(
+            ready=False,
+            auth_ok=False,
+            api_ok=False,
+            mode="connectivity_failed",
+            error="error connecting to api.github.com",
+            repo=str(tmp_path),
+        ),
+    )
+
+    exit_code = mod.main(["--repo", str(tmp_path), "--codex-home", str(tmp_path), "--json"])
+
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["decisions"][0]["reason"] == "github_unavailable"
+    assert payload["decisions"][0]["branch"] == "codex/example"
+    assert payload["decisions"][0]["desired_head"] == "abc1234"
+
+
 def test_main_summary_only_omits_decisions_when_github_unavailable(
     monkeypatch: Any, tmp_path: Path, capsys
 ) -> None:


### PR DESCRIPTION
Recovered automation handoff `open-pr-codex-publisher-handoff-decision-context-primary-r2-20260530-f74c30c5`.

This branch adds branch/head context to handoff publisher degraded-mode decisions so GitHub outage results remain actionable instead of opaque.

Validation:
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_publish_automation_handoffs.py -p no:rerunfailures -p no:cacheprovider` -> 57 passed
- `python3 -m ruff check scripts/publish_automation_handoffs.py tests/scripts/test_publish_automation_handoffs.py` -> passed
- `python3 -m ruff format --check scripts/publish_automation_handoffs.py tests/scripts/test_publish_automation_handoffs.py` -> passed
- `git merge-tree --write-tree origin/main HEAD` -> clean tree
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> preflight: ok

No merge requested.