### PR TITLE
fix(automation): report branch publisher github blockers

### DIFF
--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -427,7 +427,10 @@ def _free_disk_gib(path: Path) -> float:
 
 
 def _codex_rss_gib() -> float | None:
-    proc = _run(["ps", "-axo", "rss=,comm="], cwd=REPO_ROOT)
+    try:
+        proc = _run(["ps", "-axo", "rss=,comm="], cwd=REPO_ROOT)
+    except OSError:
+        return None
     if proc.returncode != 0:
         return None
     rss_kib = 0
@@ -1053,6 +1056,28 @@ def select_publishable_branches(
     return decisions
 
 
+def _mark_github_unavailable(decisions: list[PublishDecision]) -> list[PublishDecision]:
+    unavailable: list[PublishDecision] = []
+    for decision in decisions:
+        if not decision.eligible:
+            unavailable.append(decision)
+            continue
+        unavailable.append(
+            PublishDecision(
+                branch=decision.branch,
+                eligible=False,
+                reason="github_unavailable",
+                subject=decision.subject,
+                head_sha=decision.head_sha,
+                unique_commit_count=decision.unique_commit_count,
+                upstream=decision.upstream,
+                committed_at=decision.committed_at,
+                worktree_paths=decision.worktree_paths,
+            )
+        )
+    return unavailable
+
+
 def _ensure_gh_auth(repo_root: Path) -> None:
     health = check_github_cli_health(repo_root)
     if not health.ready:
@@ -1404,6 +1429,26 @@ def main(argv: list[str] | None = None) -> int:
 
     github_health = check_github_cli_health(repo_root)
     if not github_health.ready:
+        decisions = _mark_github_unavailable(
+            select_publishable_branches(
+                hydrated_branches,
+                worktrees,
+                set(),
+                cutoff=cutoff,
+                base=args.base,
+                is_merged=merged_lookup,
+                is_patch_equivalent=patch_equivalent_lookup,
+                historical_pr_branches=set(),
+                resolved_related_branches=set(),
+                remote_head_lookup={
+                    branch.branch: _branch_remote_head(repo_root, branch.branch)
+                    for branch in hydrated_branches
+                },
+                has_pr_diff=pr_diff_lookup,
+                superseded_outbox_branches=superseded_outbox_lookup,
+                duplicate_open_pr_patch_branches=set(),
+            )
+        )
         unavailable_payload: dict[str, Any] = {
             "repo": str(repo_root),
             "base": args.base,
@@ -1412,8 +1457,11 @@ def main(argv: list[str] | None = None) -> int:
             "scanned_branch_count": len(hydrated_branches),
             "open_pr_count": 0,
             "max_open_prs": args.max_open_prs,
+            "open_pr_lookup_skipped": True,
+            "historical_pr_lookup_skipped": True,
+            "related_work_lookup_skipped": True,
             "github_health": github_health.to_dict(),
-            "decisions": [],
+            "decisions": [asdict(decision) for decision in decisions],
         }
         if args.json:
             print(json.dumps(unavailable_payload, indent=2))

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -694,6 +694,7 @@ def test_main_reports_github_health_failure_when_unavailable_with_local_candidat
     monkeypatch.setattr(mod, "_branch_has_pr_diff", lambda repo_root, base, branch: True)
     monkeypatch.setattr(mod, "_branch_unique_commit_count", lambda repo_root, base, branch: 1)
     monkeypatch.setattr(mod, "outbox_superseded_branches", lambda repo_root, outbox_dir=None: set())
+    monkeypatch.setattr(mod, "_branch_remote_head", lambda repo_root, branch: None)
     monkeypatch.setattr(
         mod,
         "check_github_cli_health",
@@ -713,7 +714,10 @@ def test_main_reports_github_health_failure_when_unavailable_with_local_candidat
     out = capsys.readouterr().out
     assert '"mode": "connectivity_failed"' in out
     assert '"scanned_branch_count": 1' in out
-    assert '"decisions": []' in out
+    assert '"open_pr_lookup_skipped": true' in out
+    assert '"branch": "codex/ready"' in out
+    assert '"eligible": false' in out
+    assert '"reason": "github_unavailable"' in out
 
 
 def test_publish_decisions_respects_open_pr_cap(monkeypatch: Any, tmp_path: Path) -> None:


### PR DESCRIPTION
Recovered automation handoff `open-pr-codex-branch-publisher-health-decisions-primary-20260530-27194e33`.

This branch makes the Codex automation branch publisher emit explicit local branch decisions when GitHub health is unavailable, instead of returning an empty decision set.

Validation:
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_publish_codex_automation_branches.py -p no:rerunfailures -p no:cacheprovider` -> 39 passed
- `python3 -m ruff check scripts/publish_codex_automation_branches.py tests/scripts/test_publish_codex_automation_branches.py` -> passed
- `python3 -m ruff format --check scripts/publish_codex_automation_branches.py tests/scripts/test_publish_codex_automation_branches.py` -> passed
- `git merge-tree --write-tree origin/main HEAD` -> clean tree
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> preflight: ok

No merge requested.