### PR TITLE
fix(automation): accept publisher freshness cache dir

### DIFF
--- a/scripts/publisher_freshness_check.py
+++ b/scripts/publisher_freshness_check.py
@@ -341,6 +341,14 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Path to the publisher status cache JSON",
     )
+    parser.add_argument(
+        "--cache-dir",
+        default=None,
+        help=(
+            "Directory containing publisher status cache latest.json. "
+            "Accepted for CLI compatibility with publisher helpers."
+        ),
+    )
     parser.add_argument("--outbox-dir", default=None)
     parser.add_argument(
         "--receipt-dir",
@@ -424,6 +432,10 @@ def main(argv: list[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
     repo_root = Path(args.repo).resolve()
     cache_path = _resolve_explicit_path(repo_root, args.cache_path)
+    if cache_path is None:
+        cache_dir = _resolve_explicit_path(repo_root, args.cache_dir)
+        if cache_dir is not None:
+            cache_path = cache_dir / "latest.json"
     outbox_dir = _resolve_explicit_path(repo_root, args.outbox_dir)
     state_root = Path(args.state_root).expanduser().resolve() if args.state_root else None
     report = evaluate(

--- a/tests/scripts/test_publisher_freshness_check.py
+++ b/tests/scripts/test_publisher_freshness_check.py
@@ -297,6 +297,27 @@ def test_main_accepts_status_cache_alias(
     assert parsed["cache_path"] == str(cache_path.resolve())
 
 
+def test_main_accepts_cache_dir_alias(
+    monkeypatch: pytest.MonkeyPatch, stub_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    cache_dir = stub_repo / ".aragora" / "automation-github-status"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    cache_path = cache_dir / "latest.json"
+    cache_path.write_text(
+        json.dumps({"generated_at": "2026-05-05T12:00:00Z", "local_queue": {"outbox_count": 0}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (True, "loaded", None))
+
+    rc = mod.main(["--repo", str(stub_repo), "--cache-dir", str(cache_dir), "--json"])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    parsed = json.loads(out)
+    assert parsed["verdict"] == "ready"
+    assert parsed["cache_path"] == str(cache_path.resolve())
+
+
 def test_main_resolves_explicit_relative_paths_from_repo(
     monkeypatch: pytest.MonkeyPatch,
     stub_repo: Path,


### PR DESCRIPTION
Recovered automation handoff `open-pr-codex-publisher-freshness-cache-dir-alias-20260530-7b6206f7`.

This branch accepts the publisher freshness `--cache-dir` compatibility alias, reducing friction in read-only publisher diagnostics.

Validation:
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_publisher_freshness_check.py -p no:rerunfailures -p no:cacheprovider` -> 31 passed
- `python3 -m ruff check scripts/publisher_freshness_check.py tests/scripts/test_publisher_freshness_check.py` -> passed
- `python3 -m ruff format --check scripts/publisher_freshness_check.py tests/scripts/test_publisher_freshness_check.py` -> passed
- `git merge-tree --write-tree origin/main HEAD` -> clean tree
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> preflight: ok

No merge requested.