### PR TITLE
Expose automation status counts at top level

### DIFF
--- a/scripts/check_codex_desktop_automations.py
+++ b/scripts/check_codex_desktop_automations.py
@@ -214,19 +214,23 @@ def audit(records: list[AutomationRecord]) -> list[AuditIssue]:
 def build_payload(root: Path) -> dict[str, Any]:
     records, load_issues = _load_records_with_issues(root)
     issues = [*load_issues, *audit(records)]
+    summary = {
+        "error_count": sum(1 for issue in issues if issue.severity == "error"),
+        "warning_count": sum(1 for issue in issues if issue.severity == "warning"),
+        "active_count": sum(1 for record in records if _normalized_status(record) == "ACTIVE"),
+    }
     return {
         "root": str(root),
         "automation_count": _automation_file_count(root),
+        "active_count": summary["active_count"],
+        "error_count": summary["error_count"],
+        "warning_count": summary["warning_count"],
         "core_writers": {
             writer_id: next((asdict(r) for r in records if r.id == writer_id), None)
             for writer_id in CORE_WRITERS
         },
         "issues": [asdict(issue) for issue in issues],
-        "summary": {
-            "error_count": sum(1 for issue in issues if issue.severity == "error"),
-            "warning_count": sum(1 for issue in issues if issue.severity == "warning"),
-            "active_count": sum(1 for record in records if _normalized_status(record) == "ACTIVE"),
-        },
+        "summary": summary,
     }
 
 

--- a/tests/scripts/test_check_codex_desktop_automations.py
+++ b/tests/scripts/test_check_codex_desktop_automations.py
@@ -109,6 +109,26 @@ def test_audit_accepts_staggered_writer_contracts(tmp_path: Path) -> None:
     assert payload["summary"] == {"active_count": 4, "error_count": 0, "warning_count": 0}
 
 
+def test_build_payload_exposes_summary_counts_at_top_level(tmp_path: Path) -> None:
+    import check_codex_desktop_automations as mod
+
+    prompt = "Read memory, repair one branch, validate locally, run preflight, then refresh outbox."
+    for automation_id, minute in mod.CORE_WRITERS.items():
+        _write_automation(
+            tmp_path,
+            automation_id,
+            name=f"{automation_id} Writer",
+            prompt=prompt,
+            byminute=minute,
+        )
+
+    payload = mod.build_payload(tmp_path)
+
+    assert payload["active_count"] == payload["summary"]["active_count"] == 4
+    assert payload["error_count"] == payload["summary"]["error_count"] == 0
+    assert payload["warning_count"] == payload["summary"]["warning_count"] == 0
+
+
 def test_audit_warns_active_writer_missing_memory_file(tmp_path: Path) -> None:
     import check_codex_desktop_automations as mod
 


### PR DESCRIPTION
Recovered automation handoff `open-pr-codex-check-codex-top-level-counts-20260530-2a7ec88c`.

This branch exposes Codex Desktop automation status counts at the top level of the JSON payload while preserving the nested summary counts, making automation health snapshots easier to consume.

Validation:
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_check_codex_desktop_automations.py -p no:rerunfailures -p no:cacheprovider` -> 11 passed
- `python3 -m ruff check scripts/check_codex_desktop_automations.py tests/scripts/test_check_codex_desktop_automations.py` -> passed
- `python3 -m ruff format --check scripts/check_codex_desktop_automations.py tests/scripts/test_check_codex_desktop_automations.py` -> passed
- `git merge-tree --write-tree origin/main HEAD` -> clean tree
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> preflight: ok

No merge requested.