### PR TITLE
fix(publisher): accept cache-file freshness alias

### DIFF
--- a/scripts/publisher_freshness_check.py
+++ b/scripts/publisher_freshness_check.py
@@ -338,6 +338,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "--cache-path",
         "--status-cache",
         "--cache-file",
+        "--cache",
         dest="cache_path",
         default=None,
         help="Path to the publisher status cache JSON",

--- a/scripts/publisher_freshness_check.py
+++ b/scripts/publisher_freshness_check.py
@@ -337,6 +337,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--cache-path",
         "--status-cache",
+        "--cache-file",
         dest="cache_path",
         default=None,
         help="Path to the publisher status cache JSON",

--- a/tests/scripts/test_publisher_freshness_check.py
+++ b/tests/scripts/test_publisher_freshness_check.py
@@ -316,6 +316,25 @@ def test_main_accepts_cache_file_alias(
     assert parsed["cache_path"] == str(cache_path.resolve())
 
 
+def test_main_preserves_cache_abbreviation_as_explicit_alias(
+    monkeypatch: pytest.MonkeyPatch, stub_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    cache_path = stub_repo / "custom-cache-abbrev.json"
+    cache_path.write_text(
+        json.dumps({"generated_at": "2026-05-05T12:00:00Z", "local_queue": {"outbox_count": 0}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (True, "loaded", None))
+
+    rc = mod.main(["--repo", str(stub_repo), "--cache", str(cache_path), "--json"])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    parsed = json.loads(out)
+    assert parsed["verdict"] == "ready"
+    assert parsed["cache_path"] == str(cache_path.resolve())
+
+
 def test_main_resolves_explicit_relative_paths_from_repo(
     monkeypatch: pytest.MonkeyPatch,
     stub_repo: Path,

--- a/tests/scripts/test_publisher_freshness_check.py
+++ b/tests/scripts/test_publisher_freshness_check.py
@@ -297,6 +297,25 @@ def test_main_accepts_status_cache_alias(
     assert parsed["cache_path"] == str(cache_path.resolve())
 
 
+def test_main_accepts_cache_file_alias(
+    monkeypatch: pytest.MonkeyPatch, stub_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    cache_path = stub_repo / "custom-cache-file.json"
+    cache_path.write_text(
+        json.dumps({"generated_at": "2026-05-05T12:00:00Z", "local_queue": {"outbox_count": 0}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (True, "loaded", None))
+
+    rc = mod.main(["--repo", str(stub_repo), "--cache-file", str(cache_path), "--json"])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    parsed = json.loads(out)
+    assert parsed["verdict"] == "ready"
+    assert parsed["cache_path"] == str(cache_path.resolve())
+
+
 def test_main_resolves_explicit_relative_paths_from_repo(
     monkeypatch: pytest.MonkeyPatch,
     stub_repo: Path,


### PR DESCRIPTION
Recovered automation handoff `open-pr-codex-publisher-freshness-cache-file-alias-20260528-2b17da61`.

This branch accepts the publisher freshness `--cache-file` compatibility alias, making the freshness checker easier to call from publisher/cache diagnostics.

Validation:
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_publisher_freshness_check.py -p no:rerunfailures -p no:cacheprovider` -> 31 passed
- `python3 -m ruff check scripts/publisher_freshness_check.py tests/scripts/test_publisher_freshness_check.py` -> passed
- `python3 -m ruff format --check scripts/publisher_freshness_check.py tests/scripts/test_publisher_freshness_check.py` -> passed
- `git merge-tree --write-tree origin/main HEAD` -> clean tree
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> preflight: ok

No merge requested.