### PR TITLE
chore(cache): accept status cache CLI aliases

### DIFF
--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -1234,16 +1234,7 @@ def _add_doctor_parser(subparsers) -> None:
 def _add_validate_parser(subparsers) -> None:
     """Add the 'validate' subcommand parser."""
     validate_parser = subparsers.add_parser(
-        "validate",
-        help="Run a full health check, including live API-key validation",
-        description=(
-            "Run Aragora's health check (Environment, Packages, API Keys, "
-            "Storage, and Server sections) with live API-key validation enabled. "
-            "Configured provider keys are probed against the provider where "
-            "possible; a key that cannot be verified is reported as present but "
-            "unverified rather than as a passing check. Exits 0 only when all "
-            "checks pass."
-        ),
+        "validate", help="Validate API keys by making test calls"
     )
     validate_parser.set_defaults(func=_lazy("aragora.cli.commands.status", "cmd_validate"))
 

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -1234,7 +1234,16 @@ def _add_doctor_parser(subparsers) -> None:
 def _add_validate_parser(subparsers) -> None:
     """Add the 'validate' subcommand parser."""
     validate_parser = subparsers.add_parser(
-        "validate", help="Validate API keys by making test calls"
+        "validate",
+        help="Run a full health check, including live API-key validation",
+        description=(
+            "Run Aragora's health check (Environment, Packages, API Keys, "
+            "Storage, and Server sections) with live API-key validation enabled. "
+            "Configured provider keys are probed against the provider where "
+            "possible; a key that cannot be verified is reported as present but "
+            "unverified rather than as a passing check. Exits 0 only when all "
+            "checks pass."
+        ),
     )
     validate_parser.set_defaults(func=_lazy("aragora.cli.commands.status", "cmd_validate"))
 

--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -135,7 +135,7 @@ For full runtime configuration, see [ENVIRONMENT](../getting-started/environment
 | `tenant` | - | Manage multi-tenant deployments | `activate`, `create`, `delete`, `export`, `list`, `quota-get`, `quota-set`, `suspend` |
 | `testfixer` | - | Run automated test-fix loop | - |
 | `triage` | - | Inbox triage via adversarial debate with receipt-gated actions | `audit`, `auth`, `calibrate`, `digest`, `label`, `queue`, `run`, `status` |
-| `validate` | - | Validate API keys by making test calls | - |
+| `validate` | - | Run a full health check, including live API-key validation | - |
 | `validate-env` | - | Validate environment configuration and backend connectivity | - |
 | `verify` | - | Verify a decision receipt's integrity | - |
 | `verticals` | - | Manage vertical specialist configurations | - |

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -130,7 +130,7 @@ For full runtime configuration, see [ENVIRONMENT](ENVIRONMENT.md).
 | `tenant` | - | Manage multi-tenant deployments | `activate`, `create`, `delete`, `export`, `list`, `quota-get`, `quota-set`, `suspend` |
 | `testfixer` | - | Run automated test-fix loop | - |
 | `triage` | - | Inbox triage via adversarial debate with receipt-gated actions | `audit`, `auth`, `calibrate`, `digest`, `label`, `queue`, `run`, `status` |
-| `validate` | - | Validate API keys by making test calls | - |
+| `validate` | - | Run a full health check, including live API-key validation | - |
 | `validate-env` | - | Validate environment configuration and backend connectivity | - |
 | `verify` | - | Verify a decision receipt's integrity | - |
 | `verticals` | - | Manage vertical specialist configurations | - |

--- a/scripts/cache_codex_automation_github_status.py
+++ b/scripts/cache_codex_automation_github_status.py
@@ -626,10 +626,17 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--output",
         "--cache-path",
+        "--status-cache",
         dest="output",
         type=Path,
-        default=DEFAULT_OUTPUT,
+        default=None,
         help="Path to write the cached status payload.",
+    )
+    parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        default=None,
+        help="Directory containing latest.json for compatibility with publisher probes.",
     )
     parser.add_argument(
         "--state-root",
@@ -658,11 +665,21 @@ def main(argv: list[str] | None = None) -> int:
     repo_root = _repo_root(Path(args.repo))
     state_root = args.state_root.expanduser() if args.state_root is not None else None
     output_base = state_root if state_root is not None else _shared_state_root(repo_root)
-    output = (
-        args.output
-        if args.output.is_absolute()
-        else _automation_state_default_path(output_base, args.output)
-    )
+    if args.output is not None:
+        output = (
+            args.output
+            if args.output.is_absolute()
+            else _automation_state_default_path(output_base, args.output)
+        )
+    elif args.cache_dir is not None:
+        cache_dir = (
+            args.cache_dir
+            if args.cache_dir.is_absolute()
+            else _automation_state_default_path(output_base, args.cache_dir)
+        )
+        output = cache_dir / "latest.json"
+    else:
+        output = _automation_state_default_path(output_base, DEFAULT_OUTPUT)
     payload = build_status(
         repo_root=repo_root,
         github_repo=args.github_repo,

--- a/tests/scripts/test_cache_codex_automation_github_status.py
+++ b/tests/scripts/test_cache_codex_automation_github_status.py
@@ -537,6 +537,98 @@ def test_main_accepts_cache_path_alias(
     assert cache_path.is_file()
 
 
+def test_main_accepts_status_cache_alias(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "disposable-worktree"
+    repo_root.mkdir()
+    cache_path = tmp_path / "status-cache.json"
+    monkeypatch.setattr(mod, "_repo_root", lambda _path: repo_root)
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda repo_root: GitHubCLIHealth(
+            ready=False,
+            auth_ok=False,
+            api_ok=False,
+            mode="connectivity_failed",
+            error="sandboxed",
+            repo=str(repo_root),
+        ),
+    )
+
+    rc = mod.main(["--repo", str(repo_root), "--status-cache", str(cache_path)])
+
+    assert rc == 0
+    assert cache_path.is_file()
+
+
+def test_main_accepts_cache_dir_alias(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "disposable-worktree"
+    repo_root.mkdir()
+    cache_dir = tmp_path / "automation-github-status"
+    monkeypatch.setattr(mod, "_repo_root", lambda _path: repo_root)
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda repo_root: GitHubCLIHealth(
+            ready=False,
+            auth_ok=False,
+            api_ok=False,
+            mode="connectivity_failed",
+            error="sandboxed",
+            repo=str(repo_root),
+        ),
+    )
+
+    rc = mod.main(["--repo", str(repo_root), "--cache-dir", str(cache_dir)])
+
+    assert rc == 0
+    assert (cache_dir / "latest.json").is_file()
+
+
+def test_main_status_cache_overrides_cache_dir_alias(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "disposable-worktree"
+    repo_root.mkdir()
+    cache_path = tmp_path / "custom-status-cache.json"
+    cache_dir = tmp_path / "automation-github-status"
+    monkeypatch.setattr(mod, "_repo_root", lambda _path: repo_root)
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda repo_root: GitHubCLIHealth(
+            ready=False,
+            auth_ok=False,
+            api_ok=False,
+            mode="connectivity_failed",
+            error="sandboxed",
+            repo=str(repo_root),
+        ),
+    )
+
+    rc = mod.main(
+        [
+            "--repo",
+            str(repo_root),
+            "--status-cache",
+            str(cache_path),
+            "--cache-dir",
+            str(cache_dir),
+        ]
+    )
+
+    assert rc == 0
+    assert cache_path.is_file()
+    assert not (cache_dir / "latest.json").exists()
+
+
 def test_refresh_entrypoint_delegates_to_cache_main(monkeypatch: Any) -> None:
     calls: list[list[str] | None] = []
 


### PR DESCRIPTION
Recovered automation handoff `open-pr-codex-cache-status-cli-aliases-20260524-e7589353`.

This branch accepts compatibility aliases for the automation GitHub status cache CLI, reducing brittle caller differences across publisher/status helpers.

Validation:
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_cache_codex_automation_github_status.py -p no:rerunfailures -p no:cacheprovider` -> 20 passed
- `python3 -m ruff check scripts/cache_codex_automation_github_status.py tests/scripts/test_cache_codex_automation_github_status.py` -> passed
- `python3 -m ruff format --check scripts/cache_codex_automation_github_status.py tests/scripts/test_cache_codex_automation_github_status.py` -> passed
- `git merge-tree --write-tree origin/main HEAD` -> clean tree
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> preflight: ok

No merge requested.