### PR TITLE
fix(steering): default reader to shared state

### DIFF
--- a/scripts/read_operator_steering.py
+++ b/scripts/read_operator_steering.py
@@ -26,11 +26,39 @@ if str(SCRIPT_DIR) not in sys.path:
 import identify_lane_owner as owner_lookup
 import send_operator_steering as steering_writer
 
+try:
+    import agent_bridge_sessions  # type: ignore[import-not-found]
+except ModuleNotFoundError:  # pragma: no cover - compatibility for stale script copies.
+    agent_bridge_sessions = None  # type: ignore[assignment]
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
-STEERING_INBOX_ROOT_DEFAULT = REPO_ROOT / ".aragora" / "operator-steering"
-LANE_REGISTRY_DEFAULT = REPO_ROOT / ".aragora" / "agent-bridge" / "lanes.json"
 READ_RECEIPT_SCHEMA_VERSION = "aragora-operator-steering-read-receipt/1.0"
 OUTCOME_CHOICES = ("read", "obeyed", "held", "stale", "superseded", "blocked", "completed")
+
+
+def _default_state_dir() -> Path:
+    configured = os.environ.get("ARAGORA_AUTOMATION_STATE_ROOT")
+    if configured:
+        root = Path(configured).expanduser()
+        return root if root.name == ".aragora" else root / ".aragora"
+    if agent_bridge_sessions is not None:
+        try:
+            return agent_bridge_sessions.resolve_canonical_repo_root(REPO_ROOT) / ".aragora"
+        except (OSError, RuntimeError, ValueError):
+            pass
+    return REPO_ROOT / ".aragora"
+
+
+def _default_steering_inbox_root() -> Path:
+    return _default_state_dir() / "operator-steering"
+
+
+def _default_lane_registry_path() -> Path:
+    return _default_state_dir() / "agent-bridge" / "lanes.json"
+
+
+STEERING_INBOX_ROOT_DEFAULT = _default_steering_inbox_root()
+LANE_REGISTRY_DEFAULT = _default_lane_registry_path()
 
 
 def _now_utc_iso() -> str:
@@ -145,8 +173,10 @@ def build_read_receipt(
 def write_read_receipt(
     receipt: dict[str, Any],
     *,
-    steering_inbox_root: Path = STEERING_INBOX_ROOT_DEFAULT,
+    steering_inbox_root: Path | None = None,
 ) -> Path:
+    if steering_inbox_root is None:
+        steering_inbox_root = _default_steering_inbox_root()
     owner_session = str(receipt.get("owner_session") or "")
     inbox = steering_writer.validate_to_session(
         owner_session, steering_inbox_root=steering_inbox_root
@@ -207,13 +237,13 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--steering-inbox-root",
         type=Path,
-        default=STEERING_INBOX_ROOT_DEFAULT,
+        default=_default_steering_inbox_root(),
         help="Override .aragora/operator-steering root.",
     )
     parser.add_argument(
         "--registry-path",
         type=Path,
-        default=LANE_REGISTRY_DEFAULT,
+        default=_default_lane_registry_path(),
         help="Override .aragora/agent-bridge/lanes.json.",
     )
     return parser

--- a/tests/scripts/test_read_operator_steering.py
+++ b/tests/scripts/test_read_operator_steering.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import sys
+import types
 from pathlib import Path
 from typing import Any
 
@@ -199,3 +200,47 @@ def test_resolves_owner_by_lane_id(tmp_path: Path, capsys: Any) -> None:
     assert out["owner_session"] == "codex-lane-owner"
     assert out["resolved_via"] == "lane-id"
     assert out["message_count"] == 1
+
+
+def test_default_paths_use_canonical_shared_state_from_linked_worktree(
+    tmp_path: Path,
+    capsys: Any,
+    monkeypatch: Any,
+) -> None:
+    linked_worktree = tmp_path / "linked-worktree"
+    canonical_repo = tmp_path / "canonical-repo"
+    registry = canonical_repo / ".aragora" / "agent-bridge" / "lanes.json"
+    registry.parent.mkdir(parents=True)
+    registry.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "Q-shared-state",
+                    "owner_session": "codex-shared-owner",
+                    "status": "blocked",
+                    "branch": "codex/shared-state",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    _write_message(canonical_repo / ".aragora" / "operator-steering", "codex-shared-owner")
+
+    monkeypatch.delenv("ARAGORA_AUTOMATION_STATE_ROOT", raising=False)
+    monkeypatch.setattr(ros, "REPO_ROOT", linked_worktree)
+    monkeypatch.setattr(
+        ros,
+        "agent_bridge_sessions",
+        types.SimpleNamespace(resolve_canonical_repo_root=lambda _path: canonical_repo),
+        raising=False,
+    )
+
+    rc = ros.main(["--lane-id", "Q-shared-state", "--no-receipt", "--json"])
+
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["owner_session"] == "codex-shared-owner"
+    assert out["message_count"] == 1
+    assert out["steering_inbox_path"] == str(
+        canonical_repo / ".aragora" / "operator-steering" / "codex-shared-owner"
+    )


### PR DESCRIPTION
Recovered automation handoff `open-pr-codex-harvest-read-steering-shared-state-defaults-20260525-2268a959`.

This branch defaults `read_operator_steering.py` to the shared Aragora state so lane mailbox checks work from isolated worktrees without requiring explicit state-root plumbing.

Validation:
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_read_operator_steering.py -p no:rerunfailures -p no:cacheprovider` -> 6 passed
- `python3 -m ruff check scripts/read_operator_steering.py tests/scripts/test_read_operator_steering.py` -> passed
- `python3 -m ruff format --check scripts/read_operator_steering.py tests/scripts/test_read_operator_steering.py` -> passed
- `git merge-tree --write-tree origin/main HEAD` -> clean tree
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> preflight: ok

No merge requested.