### PR TITLE
fix(steering): resolve owner state from linked worktrees

### DIFF
--- a/scripts/identify_lane_owner.py
+++ b/scripts/identify_lane_owner.py
@@ -62,9 +62,62 @@ from typing import Any
 # ---------------------------------------------------------------------------
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-LANE_REGISTRY_DEFAULT = REPO_ROOT / ".aragora" / "agent-bridge" / "lanes.json"
-HEARTBEATS_DEFAULT = REPO_ROOT / ".aragora" / "agent-bridge" / "heartbeats.json"
-STEERING_INBOX_ROOT_DEFAULT = REPO_ROOT / ".aragora" / "operator-steering"
+
+
+def _state_root_from_env() -> Path | None:
+    configured = os.environ.get("ARAGORA_AUTOMATION_STATE_ROOT")
+    if not configured:
+        return None
+    root = Path(configured).expanduser()
+    return root if root.name == ".aragora" else root / ".aragora"
+
+
+def _git_common_repo_root(repo_root: Path) -> Path | None:
+    try:
+        proc = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo_root),
+                "rev-parse",
+                "--path-format=absolute",
+                "--git-common-dir",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if proc.returncode != 0:
+        return None
+    common_dir = Path(proc.stdout.strip())
+    if common_dir.name == ".git":
+        return common_dir.parent
+    return None
+
+
+def _default_state_root(repo_root: Path) -> Path:
+    env_root = _state_root_from_env()
+    if env_root is not None:
+        return env_root
+
+    local_root = repo_root / ".aragora"
+    if (local_root / "agent-bridge" / "lanes.json").exists():
+        return local_root
+
+    common_repo_root = _git_common_repo_root(repo_root)
+    if common_repo_root is not None:
+        return common_repo_root / ".aragora"
+
+    return local_root
+
+
+STATE_ROOT_DEFAULT = _default_state_root(REPO_ROOT)
+LANE_REGISTRY_DEFAULT = STATE_ROOT_DEFAULT / "agent-bridge" / "lanes.json"
+HEARTBEATS_DEFAULT = STATE_ROOT_DEFAULT / "agent-bridge" / "heartbeats.json"
+STEERING_INBOX_ROOT_DEFAULT = STATE_ROOT_DEFAULT / "operator-steering"
 CODEX_SESSIONS_ROOT_DEFAULT = Path.home() / ".codex" / "sessions"
 CLAUDE_PROJECTS_ROOT_DEFAULT = Path.home() / ".claude" / "projects"
 FACTORY_BG_PROCESSES_DEFAULT = Path.home() / ".factory" / "background-processes.json"

--- a/tests/scripts/test_identify_lane_owner.py
+++ b/tests/scripts/test_identify_lane_owner.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any
@@ -94,6 +95,47 @@ def fake_snapshot_records(
     """Build a fake operator-snapshot payload matching the live contract."""
 
     return {"process_census": {"by_role": by_role or {}, "records": records}}
+
+
+def test_default_state_root_prefers_local_lane_registry(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    worktree = tmp_path / "worktree"
+    local_registry = worktree / ".aragora" / "agent-bridge" / "lanes.json"
+    local_registry.parent.mkdir(parents=True)
+    local_registry.write_text("[]", encoding="utf-8")
+
+    def fail_run(*_args: Any, **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        raise AssertionError("git lookup should not run when local registry exists")
+
+    monkeypatch.setattr(ilo.subprocess, "run", fail_run)
+
+    assert ilo._default_state_root(worktree) == worktree / ".aragora"
+
+
+def test_default_state_root_uses_git_common_dir_for_linked_worktree(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    worktree = tmp_path / "linked" / "aragora"
+    canonical = tmp_path / "main" / "aragora"
+    worktree.mkdir(parents=True)
+    canonical.mkdir(parents=True)
+
+    def fake_run(args: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args, 0, f"{canonical / '.git'}\n", "")
+
+    monkeypatch.setattr(ilo.subprocess, "run", fake_run)
+
+    assert ilo._default_state_root(worktree) == canonical / ".aragora"
+
+
+def test_default_state_root_honors_automation_state_root(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    state_root = tmp_path / "state-root"
+    monkeypatch.setenv("ARAGORA_AUTOMATION_STATE_ROOT", str(state_root))
+
+    assert ilo._default_state_root(tmp_path / "worktree") == state_root / ".aragora"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Recovered automation handoff `open-pr-codex-identify-lane-owner-shared-state-primary-20260527-7483c5de`.

This branch lets `identify_lane_owner.py` resolve owner state from linked Codex worktrees/shared state, improving owner detection from isolated worktrees.

Validation:
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_identify_lane_owner.py -p no:rerunfailures -p no:cacheprovider` -> 57 passed
- `python3 -m ruff check scripts/identify_lane_owner.py tests/scripts/test_identify_lane_owner.py` -> passed
- `python3 -m ruff format --check scripts/identify_lane_owner.py tests/scripts/test_identify_lane_owner.py` -> passed
- `git merge-tree --write-tree origin/main HEAD` -> clean tree
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> preflight: ok

No merge requested.