### PR TITLE
test(automation): add reconcile handoffs wrapper

### DIFF
--- a/scripts/reconcile_automation_handoffs.py
+++ b/scripts/reconcile_automation_handoffs.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+"""Compatibility entrypoint for ``reconcile_automation_outbox.py``."""
+
+from __future__ import annotations
+
+from reconcile_automation_outbox import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_reconcile_automation_outbox.py
+++ b/tests/scripts/test_reconcile_automation_outbox.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -9,6 +10,9 @@ from typing import Any
 import pytest
 
 import scripts.reconcile_automation_outbox as mod
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WRAPPER_SCRIPT_PATH = REPO_ROOT / "scripts" / "reconcile_automation_handoffs.py"
 
 
 def _unhealthy_github() -> SimpleNamespace:
@@ -166,6 +170,28 @@ def test_json_summary_only_omits_action_details(
     assert payload["action_count"] == 1
     assert payload["actions_omitted"] is True
     assert "actions" not in payload
+
+
+def test_reconcile_automation_handoffs_wrapper_executes_primary_script(tmp_path: Path) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(WRAPPER_SCRIPT_PATH),
+            "--repo",
+            str(tmp_path),
+            "--json",
+            "--summary-only",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["repo"] == str(tmp_path.resolve())
+    assert payload["outbox_count"] == 0
+    assert payload["actions_omitted"] is True
 
 
 def test_state_root_can_point_at_direct_dot_aragora(


### PR DESCRIPTION
Refreshes recovered automation handoff `open-pr-codex-reconcile-handoffs-entrypoint-20260528-33e9dd65` onto current `origin/main`.

The original handoff head validated locally but failed the current pre-push `mypy-baseline` hook when pushed as an old-base branch. This branch cherry-picks the same small wrapper change onto current main and passes validation without bypass.

Validation:
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_reconcile_automation_outbox.py -p no:rerunfailures -p no:cacheprovider` -> 29 passed
- `python3 -m ruff check scripts/reconcile_automation_handoffs.py tests/scripts/test_reconcile_automation_outbox.py` -> passed
- `python3 -m ruff format --check scripts/reconcile_automation_handoffs.py tests/scripts/test_reconcile_automation_outbox.py` -> passed
- `python3 scripts/reconcile_automation_handoffs.py --dry-run --json --summary-only` -> smoke passed
- `git merge-tree --write-tree origin/main HEAD` -> clean tree
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> preflight: ok

No merge requested.