### PR TITLE
fix(reconcile): honor superseded outbox keys

### DIFF
--- a/scripts/reconcile_automation_outbox.py
+++ b/scripts/reconcile_automation_outbox.py
@@ -445,6 +445,42 @@ def _superseded_targets(
     return targets
 
 
+def _string_list(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [str(item).strip() for item in value if str(item).strip()]
+    return []
+
+
+def _superseded_outbox_keys(
+    outbox_payloads: Sequence[tuple[Path, dict[str, Any]]],
+) -> dict[str, dict[str, str]]:
+    """Map explicitly superseded outbox idempotency keys to their replacement handoff."""
+    targets: dict[str, dict[str, str]] = {}
+    for path, payload in outbox_payloads:
+        superseder_key = str(payload.get("idempotency_key") or path.stem).strip()
+        superseder_branch = _branch_from_payload(payload)
+        for local_evidence in _local_evidence_mappings(payload.get("local_evidence")):
+            keys = _string_list(local_evidence.get("supersedes_outbox_keys"))
+            source_candidates = local_evidence.get("source_candidates")
+            if isinstance(source_candidates, Sequence) and not isinstance(
+                source_candidates, (str, bytes, bytearray)
+            ):
+                for candidate in source_candidates:
+                    if isinstance(candidate, Mapping):
+                        keys.append(str(candidate.get("idempotency_key") or "").strip())
+            for key in keys:
+                if not key or key == superseder_key:
+                    continue
+                targets[key] = {
+                    "branch": superseder_branch,
+                    "idempotency_key": superseder_key,
+                    "path": str(path),
+                }
+    return targets
+
+
 def _write_synthetic_receipt(
     *,
     receipt_dir: Path,
@@ -644,7 +680,9 @@ def main(argv: list[str] | None = None) -> int:
         payload = _load_json(path)
         if isinstance(payload, dict):
             parsed_outbox_payloads[path] = payload
-    superseded_targets = _superseded_targets(list(parsed_outbox_payloads.items()))
+    parsed_outbox_items = list(parsed_outbox_payloads.items())
+    superseded_targets = _superseded_targets(parsed_outbox_items)
+    superseded_keys = _superseded_outbox_keys(parsed_outbox_items)
 
     target_keys = {str(key).strip() for key in args.idempotency_key if str(key).strip()}
     target_files = {_resolve_outbox_file_filter(outbox_dir, path) for path in args.outbox_file}
@@ -775,6 +813,31 @@ def main(argv: list[str] | None = None) -> int:
                 }
             )
             if args.apply:
+                shutil.move(str(path), str(archive_dir / path.name))
+            continue
+
+        key_superseder = superseded_keys.get(idem)
+        if key_superseder is not None and key_superseder["idempotency_key"] != idem:
+            reason = f"superseded by active handoff {key_superseder['idempotency_key']}"
+            counts["satisfied_by_superseded_handoff"] += 1
+            actions.append(
+                {
+                    "path": str(path),
+                    "branch": branch,
+                    "decision": "archive",
+                    "reason": reason,
+                    "superseded_by": key_superseder,
+                    "synthetic_receipt": True,
+                }
+            )
+            if args.apply:
+                _write_synthetic_receipt(
+                    receipt_dir=receipt_dir,
+                    outbox_payload=payload,
+                    reason=reason,
+                    pr_number=None,
+                    apply=True,
+                )
                 shutil.move(str(path), str(archive_dir / path.name))
             continue
 

--- a/tests/scripts/test_reconcile_automation_outbox.py
+++ b/tests/scripts/test_reconcile_automation_outbox.py
@@ -440,6 +440,70 @@ def test_apply_archives_outbox_handoff_superseded_by_active_handoff(
     assert receipt_payload["synthetic_reason"] == f"superseded by active handoff {new_key}"
 
 
+def test_apply_archives_outbox_handoff_superseded_by_idempotency_key(
+    tmp_path: Path,
+    monkeypatch: Any,
+    capsys: Any,
+) -> None:
+    outbox_dir = tmp_path / ".aragora" / "automation-outbox"
+    old_key = "open-pr-codex-example-oldaaaa"
+    new_key = "open-pr-codex-example-restack-newbbbb"
+    old_path = _write_outbox_handoff(
+        outbox_dir,
+        branch="codex/example",
+        key=old_key,
+        local_evidence={
+            "branch": "codex/example",
+            "head_sha": "oldaaaa1111",
+        },
+    )
+    new_path = _write_outbox_handoff(
+        outbox_dir,
+        branch="codex/example-restack",
+        key=new_key,
+        local_evidence={
+            "branch": "codex/example-restack",
+            "head_sha": "newbbbb2222",
+            "supersedes_outbox_keys": [old_key],
+            "source_candidates": [
+                {
+                    "idempotency_key": old_key,
+                    "source_branch": "codex/example",
+                    "head_sha": "oldaaaa1111",
+                }
+            ],
+        },
+    )
+
+    monkeypatch.setattr(mod, "check_github_cli_health", lambda _root: _ready_github())
+    monkeypatch.setattr(mod, "open_pr_heads", lambda *_args: {})
+
+    def fake_run_git(args: list[str], *_args: Any, **_kwargs: Any) -> subprocess.CompletedProcess:
+        if args[:2] == ["rev-parse", "--verify"]:
+            return subprocess.CompletedProcess(args=["git"], returncode=0, stdout="head\n")
+        if args and args[0] == "merge-base":
+            return subprocess.CompletedProcess(args=["git"], returncode=1, stdout="")
+        if args and args[0] == "cherry":
+            return subprocess.CompletedProcess(args=["git"], returncode=0, stdout="+ newbbbb\n")
+        return subprocess.CompletedProcess(args=["git"], returncode=0, stdout="")
+
+    monkeypatch.setattr(mod, "run_git", fake_run_git)
+
+    assert mod.main(["--repo", str(tmp_path), "--apply", "--json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["counts"]["satisfied_by_superseded_handoff"] == 1
+    assert payload["archived"] == 1
+    assert old_path.exists() is False
+    assert new_path.exists() is True
+    archived = tmp_path / ".aragora" / "automation-outbox-archive" / old_path.name
+    receipt = tmp_path / ".aragora" / "automation-receipts" / f"{old_key}.json"
+    assert archived.exists()
+    receipt_payload = json.loads(receipt.read_text(encoding="utf-8"))
+    assert receipt_payload["status"] == "already_satisfied"
+    assert receipt_payload["synthetic_reason"] == f"superseded by active handoff {new_key}"
+
+
 def test_dry_run_can_write_report_when_requested(
     tmp_path: Path, monkeypatch: Any, capsys: Any
 ) -> None:


### PR DESCRIPTION
Refreshes recovered automation handoff `open-pr-codex-reconcile-outbox-key-supersedes-20260524-07c41827` onto current `origin/main`.

The branch teaches `reconcile_automation_outbox.py` to honor superseded outbox keys so stale handoffs do not keep already-superseded work protected forever.

Validation:
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_reconcile_automation_outbox.py -p no:rerunfailures -p no:cacheprovider` -> 29 passed
- `python3 -m ruff check scripts/reconcile_automation_outbox.py tests/scripts/test_reconcile_automation_outbox.py` -> passed
- `python3 -m ruff format --check scripts/reconcile_automation_outbox.py tests/scripts/test_reconcile_automation_outbox.py` -> passed
- `python3 scripts/reconcile_automation_outbox.py --repo /Users/armand/Development/aragora --state-root /Users/armand/Development/aragora --base origin/main --dry-run --json --summary-only --outbox-file /Users/armand/Development/aragora/.aragora/automation-outbox/open-pr-codex-reconcile-outbox-key-supersedes-20260524-07c41827.json` -> dry-run kept exactly one active handoff
- `git merge-tree --write-tree origin/main HEAD` -> clean tree
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> preflight: ok

No merge requested.