### PR TITLE
fix(automation): summarize outbox reconcile reasons

### DIFF
--- a/scripts/reconcile_automation_outbox.py
+++ b/scripts/reconcile_automation_outbox.py
@@ -918,6 +918,10 @@ def main(argv: list[str] | None = None) -> int:
         emit(f"  {k:>40}: {v}")
     archived = sum(1 for a in actions if a["decision"] == "archive")
     kept = sum(1 for a in actions if a["decision"] == "keep")
+    reason_counts: dict[str, int] = {}
+    for action in actions:
+        reason = str(action.get("reason") or "unknown").strip() or "unknown"
+        reason_counts[reason] = reason_counts.get(reason, 0) + 1
     emit(f"\n  total: {archived} archived, {kept} kept")
 
     should_write_report = args.apply or args.write_report or args.report_path is not None
@@ -957,6 +961,7 @@ def main(argv: list[str] | None = None) -> int:
             "kept": kept,
             "outbox_count": len(outbox_files),
             "outbox_dir": str(outbox_dir),
+            "reason_counts": reason_counts,
             "receipt_dir": str(receipt_dir),
             "repo": str(root),
             "repo_name": args.repo_name,

--- a/tests/scripts/test_reconcile_automation_outbox.py
+++ b/tests/scripts/test_reconcile_automation_outbox.py
@@ -165,6 +165,7 @@ def test_json_summary_only_omits_action_details(
     assert payload["kept"] == 0
     assert payload["action_count"] == 1
     assert payload["actions_omitted"] is True
+    assert payload["reason_counts"] == {"matching receipt exists": 1}
     assert "actions" not in payload
 
 


### PR DESCRIPTION
Refreshes recovered automation handoff `open-pr-codex-reconcile-outbox-reason-counts-primary-20260523-908ef97d` onto current `origin/main`.

The branch includes compact `reason_counts` in summary-only reconcile output so operators can understand why outbox entries remain protected without expanding full action details.

Validation:
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_reconcile_automation_outbox.py -p no:rerunfailures -p no:cacheprovider` -> 28 passed
- `python3 -m ruff check scripts/reconcile_automation_outbox.py tests/scripts/test_reconcile_automation_outbox.py` -> passed
- `python3 -m ruff format --check scripts/reconcile_automation_outbox.py tests/scripts/test_reconcile_automation_outbox.py` -> passed
- `python3 scripts/reconcile_automation_outbox.py --repo /Users/armand/Development/aragora --state-root /Users/armand/Development/aragora --base origin/main --dry-run --json --summary-only --outbox-file /Users/armand/Development/aragora/.aragora/automation-outbox/open-pr-codex-reconcile-outbox-reason-counts-primary-20260523-908ef97d.json` -> reason_counts emitted
- `git merge-tree --write-tree origin/main HEAD` -> clean tree
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> preflight: ok

No merge requested.