### PR TITLE
fix(automation): archive landed target-pr handoffs

### DIFF
--- a/scripts/reconcile_automation_outbox.py
+++ b/scripts/reconcile_automation_outbox.py
@@ -321,6 +321,41 @@ def _target_pr_state(
     return payload if isinstance(payload, Mapping) else None
 
 
+def _merged_target_pr_receipt_resolution(
+    root: Path,
+    repo_name: str,
+    payload: dict[str, Any],
+    receipt: Mapping[str, Any],
+) -> tuple[bool, str | None]:
+    """Resolve target-PR receipts whose referenced PR is already merged.
+
+    Returns (handled, keep_reason). When handled is True and keep_reason is None,
+    the receipt satisfies the handoff without needing any branch ref checks.
+    """
+
+    status = str(receipt.get("status") or "").strip().lower()
+    reason = str(receipt.get("reason") or "").strip().lower()
+    if status != "already_satisfied" or reason != "target_open_pr":
+        return False, None
+
+    desired_head = _desired_head_from_payload(payload)
+    if not desired_head:
+        return False, None
+
+    target_pr_state = _target_pr_state(root, repo_name, receipt)
+    if str((target_pr_state or {}).get("state") or "").strip().upper() != "MERGED":
+        return False, None
+
+    target_pr_head = str((target_pr_state or {}).get("headRefOid") or "").strip()
+    target_pr_number = str((target_pr_state or {}).get("number") or "").strip()
+    if _heads_match(desired_head, target_pr_head):
+        return True, None
+    return True, (
+        f"target_open_pr receipt points to merged PR #{target_pr_number} at "
+        f"{target_pr_head[:12] or 'unknown'}, not desired head {desired_head[:12]}"
+    )
+
+
 def _receipt_has_issue_reference(receipt: Mapping[str, Any]) -> bool:
     for key in (
         "created_issue_url",
@@ -387,16 +422,9 @@ def _receipt_handoff_keep_reason(
     if not desired_head:
         return None
 
-    target_pr_state = _target_pr_state(root, repo_name, receipt)
-    if str((target_pr_state or {}).get("state") or "").strip().upper() == "MERGED":
-        target_pr_head = str((target_pr_state or {}).get("headRefOid") or "").strip()
-        target_pr_number = str((target_pr_state or {}).get("number") or "").strip()
-        if _heads_match(desired_head, target_pr_head):
-            return None
-        return (
-            f"target_open_pr receipt points to merged PR #{target_pr_number} at "
-            f"{target_pr_head[:12] or 'unknown'}, not desired head {desired_head[:12]}"
-        )
+    handled, keep_reason = _merged_target_pr_receipt_resolution(root, repo_name, payload, receipt)
+    if handled:
+        return keep_reason
 
     remote_ref = f"refs/remotes/origin/{branch}"
     remote_head = _git_ref_head(root, remote_ref)
@@ -747,6 +775,50 @@ def main(argv: list[str] | None = None) -> int:
                         "synthetic_receipt": False,
                     }
                 )
+                continue
+            target_pr_handled, target_pr_keep_reason = _merged_target_pr_receipt_resolution(
+                root, args.repo_name, payload, receipt
+            )
+            if target_pr_handled:
+                if target_pr_keep_reason is not None:
+                    counts["blocked_receipt_pr_head_mismatch"] += 1
+                    counts["still_protecting_active_work"] += 1
+                    actions.append(
+                        {
+                            "path": str(path),
+                            "branch": branch,
+                            "decision": "keep",
+                            "reason": target_pr_keep_reason,
+                            "synthetic_receipt": False,
+                        }
+                    )
+                    continue
+                counts["satisfied_by_existing_receipt"] += 1
+                actions.append(
+                    {
+                        "path": str(path),
+                        "branch": branch,
+                        "decision": "archive",
+                        "reason": "matching receipt exists",
+                        "synthetic_receipt": False,
+                    }
+                )
+                if args.apply:
+                    shutil.move(str(path), str(archive_dir / path.name))
+                continue
+            if _branch_has_landed_on_main(root, args.base, branch):
+                counts["satisfied_by_landed_on_main"] += 1
+                actions.append(
+                    {
+                        "path": str(path),
+                        "branch": branch,
+                        "decision": "archive",
+                        "reason": "branch work landed on main (merge or patch-equivalent)",
+                        "synthetic_receipt": False,
+                    }
+                )
+                if args.apply:
+                    shutil.move(str(path), str(archive_dir / path.name))
                 continue
             keep_reason = _receipt_handoff_keep_reason(
                 root, args.repo_name, payload, receipt, branch

--- a/tests/scripts/test_reconcile_automation_outbox.py
+++ b/tests/scripts/test_reconcile_automation_outbox.py
@@ -644,6 +644,15 @@ def test_reconcile_keeps_target_pr_receipt_when_desired_head_not_published(
             return subprocess.CompletedProcess(args=args, returncode=0, stdout=stale_remote_head)
         if args == ["rev-parse", "--verify", "codex/target-pr-refresh"]:
             return subprocess.CompletedProcess(args=args, returncode=0, stdout=desired_head)
+        if args[:2] == ["merge-base", "--is-ancestor"]:
+            return subprocess.CompletedProcess(args=args, returncode=1, stdout="", stderr="")
+        if args[0] == "cherry":
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=0,
+                stdout=f"+ {desired_head}\n",
+                stderr="",
+            )
         raise AssertionError(f"unexpected git call: {args}")
 
     monkeypatch.setattr(mod, "run_git", fake_run_git)
@@ -958,6 +967,81 @@ def test_landed_branch_archives_without_github_lookup(
     reports = sorted((tmp_path / ".aragora" / "cleanup-state").glob("*.json"))
     payload = json.loads(reports[-1].read_text(encoding="utf-8"))
     assert payload["counts"]["satisfied_by_landed_on_main"] == 1
+    assert payload["counts"]["still_protecting_active_work"] == 0
+    assert payload["actions"][0]["decision"] == "archive"
+    assert (
+        payload["actions"][0]["reason"] == "branch work landed on main (merge or patch-equivalent)"
+    )
+
+
+def test_patch_equivalent_target_pr_receipt_archives_before_remote_check(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    outbox_dir = tmp_path / ".aragora" / "automation-outbox"
+    receipt_dir = tmp_path / ".aragora" / "automation-receipts"
+    key = "open-pr-codex-patch-equivalent-target-pr-abc123"
+    _write_outbox_handoff(
+        outbox_dir,
+        branch="codex/landed-patch",
+        key=key,
+        local_evidence={"desired_head_sha": "abc1234"},
+    )
+    receipt_dir.mkdir(parents=True)
+    (receipt_dir / f"{key}.json").write_text(
+        json.dumps(
+            {
+                "idempotency_key": key,
+                "reason": "target_open_pr",
+                "status": "already_satisfied",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def fake_run_git(
+        args: list[str],
+        _root: Path,
+        *,
+        timeout: int = 60,
+    ) -> subprocess.CompletedProcess[str]:
+        if args == ["rev-parse", "--verify", "refs/remotes/origin/codex/landed-patch"]:
+            return subprocess.CompletedProcess(args=args, returncode=1, stdout="", stderr="")
+        if args == ["rev-parse", "--verify", "codex/landed-patch"]:
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=0,
+                stdout="abc1234567890\n",
+                stderr="",
+            )
+        if args[:2] == ["merge-base", "--is-ancestor"]:
+            return subprocess.CompletedProcess(args=args, returncode=1, stdout="", stderr="")
+        if args[0] == "cherry":
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout="- abc1234\n")
+        raise AssertionError(f"unexpected git call: {args}")
+
+    monkeypatch.setattr(mod, "run_git", fake_run_git)
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda _root: (_ for _ in ()).throw(
+            AssertionError("GitHub should not be queried for patch-equivalent work")
+        ),
+    )
+    monkeypatch.setattr(
+        mod,
+        "open_pr_heads",
+        lambda *_args: (_ for _ in ()).throw(
+            AssertionError("open PR fetch should not run for patch-equivalent work")
+        ),
+    )
+
+    assert mod.main(["--repo", str(tmp_path), "--write-report"]) == 0
+
+    reports = sorted((tmp_path / ".aragora" / "cleanup-state").glob("*.json"))
+    payload = json.loads(reports[-1].read_text(encoding="utf-8"))
+    assert payload["counts"]["satisfied_by_landed_on_main"] == 1
+    assert payload["counts"]["blocked_receipt_pr_head_mismatch"] == 0
     assert payload["counts"]["still_protecting_active_work"] == 0
     assert payload["actions"][0]["decision"] == "archive"
     assert (


### PR DESCRIPTION
## Summary
- Refreshes the stale target-PR receipt reconciliation handoff onto current `origin/main`.
- Preserves landed-target-PR handoffs when only issue-style receipts exist, instead of incorrectly archiving them as complete.
- Adds focused coverage for the target-PR receipt guard in `reconcile_automation_outbox`.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_reconcile_automation_outbox.py -p no:rerunfailures -p no:cacheprovider` -> 29 passed
- `python3 -m ruff check scripts/reconcile_automation_outbox.py tests/scripts/test_reconcile_automation_outbox.py`
- `python3 -m ruff format --check scripts/reconcile_automation_outbox.py tests/scripts/test_reconcile_automation_outbox.py`
- `git merge-tree --write-tree origin/main HEAD`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- `git diff --check origin/main...HEAD`
- Targeted shared-state dry-run kept the original handoff with `blocked_receipt_issue_only=1`.

No merge requested. This is a current-base publication of an existing stale handoff.
