### PR TITLE
chore(automation): lint dogfood evidence prompts

### DIFF
--- a/scripts/pr_check_followup.py
+++ b/scripts/pr_check_followup.py
@@ -707,7 +707,13 @@ def build_prompt(
             "If merge-packet still blocks on model quorum or focused adversarial dogfood, collect exactly one current-head non-Codex model/dogfood evidence signal."
         )
         lines.append(
-            "Post exactly one valid PR comment only if the evidence is current-head, non-Codex, lists files reviewed, puts findings first, includes validation run/not-run reasons, includes focused adversarial dogfood verdict, and states that it is not merge authorization."
+            "Before posting, lint the exact comment with `python3 -m aragora.cli.main review-queue evidence-lint --pr <PR> --head-sha <HEAD> --body-file <FILE> --author <GITHUB_LOGIN> --json` and require `would_count=true` with no problems."
+        )
+        lines.append(
+            "Use a countable header and metadata block, for example `## Codex focused adversarial dogfood`, `Exact head: <HEAD>`, `Reviewer harness: codex`, `Model family: openai`, `Model id: <MODEL>`, and `Receipt artifact: <PATH>`."
+        )
+        lines.append(
+            "Post exactly one valid PR comment only if the evidence is current-head, non-Codex/OpenAI-family, lists files reviewed, puts findings first, includes validation run/not-run reasons, includes focused adversarial dogfood verdict, and states that it is not merge authorization."
         )
         lines.append(
             "Then rerun review-queue merge-packet for the PR and report the next blocker. Do not merge."

--- a/scripts/pr_check_followup.py
+++ b/scripts/pr_check_followup.py
@@ -710,10 +710,10 @@ def build_prompt(
             "Before posting, lint the exact comment with `python3 -m aragora.cli.main review-queue evidence-lint --pr <PR> --head-sha <HEAD> --body-file <FILE> --author <GITHUB_LOGIN> --json` and require `would_count=true` with no problems."
         )
         lines.append(
-            "Use a countable header and metadata block, for example `## Codex focused adversarial dogfood`, `Exact head: <HEAD>`, `Reviewer harness: codex`, `Model family: openai`, `Model id: <MODEL>`, and `Receipt artifact: <PATH>`."
+            "Use a countable non-Codex header and metadata block, for example `## Claude focused adversarial dogfood`, `Exact head: <HEAD>`, `Reviewer harness: claude-code`, `Model family: claude`, `Model id: <MODEL>`, and `Receipt artifact: <PATH>`."
         )
         lines.append(
-            "Post exactly one valid PR comment only if the evidence is current-head, non-Codex/OpenAI-family, lists files reviewed, puts findings first, includes validation run/not-run reasons, includes focused adversarial dogfood verdict, and states that it is not merge authorization."
+            "Post exactly one valid PR comment only if the evidence is current-head, not Codex, not any OpenAI-family model, lists files reviewed, puts findings first, includes validation run/not-run reasons, includes focused adversarial dogfood verdict, and states that it is not merge authorization."
         )
         lines.append(
             "Then rerun review-queue merge-packet for the PR and report the next blocker. Do not merge."

--- a/tests/scripts/test_pr_check_followup.py
+++ b/tests/scripts/test_pr_check_followup.py
@@ -288,6 +288,10 @@ def test_merge_quorum_model_quorum_failure_emits_evidence_prompt() -> None:
         "collecting exactly one current-head non-Codex model/dogfood evidence signal"
         in result.prompt
     )
+    assert "review-queue evidence-lint" in result.prompt
+    assert "would_count=true" in result.prompt
+    assert "## Codex focused adversarial dogfood" in result.prompt
+    assert "Model family: openai" in result.prompt
     assert "Post exactly one valid PR comment" in result.prompt
     assert "Do not merge" in result.prompt
 

--- a/tests/scripts/test_pr_check_followup.py
+++ b/tests/scripts/test_pr_check_followup.py
@@ -288,10 +288,15 @@ def test_merge_quorum_model_quorum_failure_emits_evidence_prompt() -> None:
         "collecting exactly one current-head non-Codex model/dogfood evidence signal"
         in result.prompt
     )
-    assert "review-queue evidence-lint" in result.prompt
+    lint_index = result.prompt.index("review-queue evidence-lint")
+    post_index = result.prompt.index("Post exactly one valid PR comment")
+    assert lint_index < post_index
     assert "would_count=true" in result.prompt
-    assert "## Codex focused adversarial dogfood" in result.prompt
-    assert "Model family: openai" in result.prompt
+    assert "## Claude focused adversarial dogfood" in result.prompt
+    assert "Model family: claude" in result.prompt
+    assert "## Codex focused adversarial dogfood" not in result.prompt
+    assert "Model family: openai" not in result.prompt
+    assert "not Codex, not any OpenAI-family model" in result.prompt
     assert "Post exactly one valid PR comment" in result.prompt
     assert "Do not merge" in result.prompt
 


### PR DESCRIPTION
## Summary
- tighten `pr_check_followup` model-evidence prompts so agents lint evidence comments before posting
- include the countable `## Codex focused adversarial dogfood` header and metadata skeleton required by the clean merge-quorum parser
- update the focused follow-up test to lock the lint-first/countable-template guidance

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_pr_check_followup.py -p no:rerunfailures -p no:cacheprovider` -> 14 passed
- `python3 -m ruff check scripts/pr_check_followup.py tests/scripts/test_pr_check_followup.py` -> pass
- `python3 -m ruff format --check scripts/pr_check_followup.py tests/scripts/test_pr_check_followup.py` -> pass
- `git diff --check origin/main...HEAD && git diff --check` -> pass
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> pass

No merge requested.
