### PR TITLE
fix(proof-shift): stop before post-cycle timebox overshoot

### DIFF
--- a/scripts/run_proof_first_shift.py
+++ b/scripts/run_proof_first_shift.py
@@ -1710,20 +1710,26 @@ async def _run_shift(args: argparse.Namespace) -> dict[str, Any]:
 
     cycle_reports: list[dict[str, Any]] = []
     cycle_count = 0
-    while True:
+
+    def stop_if_time_budget_exhausted(action: str) -> bool:
         deadline_reason = _time_budget_blocker(
             deadline_monotonic=deadline_monotonic,
             max_hours=max_hours,
-            action="shift_cycle",
+            action=action,
         )
-        if deadline_reason:
-            controller.complete_shift(deadline_reason)
-            ledger.record_shift_stop(
-                shift_id=shift_id,
-                reason=deadline_reason,
-                cycles=cycle_count,
-                duration_seconds=time.monotonic() - shift_start_time,
-            )
+        if not deadline_reason:
+            return False
+        controller.complete_shift(deadline_reason)
+        ledger.record_shift_stop(
+            shift_id=shift_id,
+            reason=deadline_reason,
+            cycles=cycle_count,
+            duration_seconds=time.monotonic() - shift_start_time,
+        )
+        return True
+
+    while True:
+        if stop_if_time_budget_exhausted("shift_cycle"):
             break
 
         should_stop, reason = controller.check_should_stop()
@@ -1770,8 +1776,12 @@ async def _run_shift(args: argparse.Namespace) -> dict[str, Any]:
         cycle_count += 1
         save_runtime_state(runtime_state_path, runtime_state)
 
+        if stop_if_time_budget_exhausted("controller_cycle"):
+            break
         objective = build_cycle_objective(report)
         await controller.run_cycle(objective)
+        if stop_if_time_budget_exhausted("post_cycle_wait"):
+            break
         if report["stop_reason"]:
             controller.complete_shift(str(report["stop_reason"]))
             ledger.record_shift_stop(

--- a/tests/scripts/test_run_proof_first_shift.py
+++ b/tests/scripts/test_run_proof_first_shift.py
@@ -374,6 +374,55 @@ def test_run_shift_stops_before_starting_cycle_after_deadline(tmp_path: Path) ->
     assert str(summary["shift"]["stop_reason"]).startswith("TimeLimit:")
 
 
+def test_run_shift_stops_before_controller_cycle_when_cycle_exhausts_deadline(
+    tmp_path: Path,
+) -> None:
+    args = mod._build_parser().parse_args(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--max-hours",
+            "0.01",
+            "--interval-seconds",
+            "1",
+        ]
+    )
+
+    cycle_completed = False
+
+    def fake_monotonic() -> float:
+        return 37.0 if cycle_completed else 0.0
+
+    def slow_cycle_report(**_: object) -> dict[str, object]:
+        nonlocal cycle_completed
+        cycle_completed = True
+        return {
+            "queue_report": {"kept": [], "removed": []},
+            "open_pr_count": 0,
+            "automation_backlog": 0,
+            "actions": ["slow_cycle"],
+            "stop_reason": "",
+            "green_shift_evaluation": {"is_green": False},
+        }
+
+    with (
+        patch("scripts.run_proof_first_shift.time.monotonic", side_effect=fake_monotonic),
+        patch(
+            "scripts.run_proof_first_shift.run_shift_cycle",
+            side_effect=slow_cycle_report,
+        ),
+        patch.object(
+            mod.ShiftController,
+            "run_cycle",
+            side_effect=AssertionError("expired shift must not start controller cycle"),
+        ),
+    ):
+        summary = asyncio.run(mod._run_shift(args))
+
+    assert len(summary["cycles"]) == 1
+    assert str(summary["shift"]["stop_reason"]).startswith("TimeLimit:")
+
+
 def test_run_shift_cycle_caps_merge_apply_timeout_to_remaining_shift_budget() -> None:
     state = mod.ProofFirstRuntimeState()
     repo_root = Path(".").resolve()


### PR DESCRIPTION
## Summary
- fail closed before starting `ShiftController.run_cycle()` when a completed shift cycle has already exhausted `--max-hours`
- reuse one local stop helper for pre-cycle, pre-controller-cycle, and post-controller-cycle deadline checks
- add a regression test proving an expired shift does not start the next controller action

## Validation
- `python3 -m pytest -q tests/scripts/test_run_proof_first_shift.py::test_run_shift_stops_before_starting_cycle_after_deadline tests/scripts/test_run_proof_first_shift.py::test_run_shift_stops_before_controller_cycle_when_cycle_exhausts_deadline tests/scripts/test_run_proof_first_shift.py::test_run_shift_cycle_caps_merge_apply_timeout_to_remaining_shift_budget tests/scripts/test_run_proof_first_shift.py::test_dry_run_uses_single_merge_limit_and_is_read_only`
- `python3 -m pytest -q tests/scripts/test_run_proof_first_shift.py`
- `python3 scripts/run_proof_first_shift.py --help`
- one observer run: `python3 scripts/run_proof_first_shift.py --repo-root /private/tmp/aragora-proof-first-shift-timebox-guard-r4-20260602 --repo synaptent/aragora --max-hours 0.05 --interval-seconds 1 --once --dry-run --no-merge --benchmark-mode disabled --json`

## Observer Result
- dry-run/no-merge completed one cycle with `merge_limit=0` and no merged PRs
- proof surfaces were fresh from the origin/main worktree
- publisher cache was ready from shared-root live state
- review-queue shared-root health remained stale because briefs/boss metrics are stale

No merge, admin merge, manual status, branch protection, or broad-drain action was performed.