### PR TITLE
docs(cli): refresh generated CLI reference

### DIFF
--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -11,8 +11,8 @@ description: Generated Aragora CLI command catalog from live parser
 
 This reference documents the command surface as implemented in code. It includes all top-level commands and known aliases.
 
-- Canonical top-level commands: **105**
-- Total top-level invocations (including aliases): **106**
+- Canonical top-level commands: **106**
+- Total top-level invocations (including aliases): **107**
 
 ## Installation
 
@@ -71,6 +71,7 @@ For full runtime configuration, see [ENVIRONMENT](../getting-started/environment
 | `crux` | - | Find load-bearing disagreements on a question (crux-finder debate) | - |
 | `crux-arbitrate` | - | DIC-27: resolve persistent cruxes as reversible signed arbitration receipts | - |
 | `crux-followup` | - | Generate DIC-17 follow-up proposals from a CruxSet (flag-gated filing) | - |
+| `crux-garden` | - | DIC-28: proactive re-examination of cruxes for staleness and contradictions | - |
 | `cruxset` | - | AGT-01: inspect CruxSet payloads emitted by the debate path | `show` |
 | `decide` | - | Run full decision pipeline: debate → plan → execute | - |
 | `demo` | - | Run a self-contained adversarial debate demo (no API keys needed) | - |

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -6,8 +6,8 @@
 
 This reference documents the command surface as implemented in code. It includes all top-level commands and known aliases.
 
-- Canonical top-level commands: **105**
-- Total top-level invocations (including aliases): **106**
+- Canonical top-level commands: **106**
+- Total top-level invocations (including aliases): **107**
 
 ## Installation
 
@@ -66,6 +66,7 @@ For full runtime configuration, see [ENVIRONMENT](ENVIRONMENT.md).
 | `crux` | - | Find load-bearing disagreements on a question (crux-finder debate) | - |
 | `crux-arbitrate` | - | DIC-27: resolve persistent cruxes as reversible signed arbitration receipts | - |
 | `crux-followup` | - | Generate DIC-17 follow-up proposals from a CruxSet (flag-gated filing) | - |
+| `crux-garden` | - | DIC-28: proactive re-examination of cruxes for staleness and contradictions | - |
 | `cruxset` | - | AGT-01: inspect CruxSet payloads emitted by the debate path | `show` |
 | `decide` | - | Run full decision pipeline: debate → plan → execute | - |
 | `demo` | - | Run a self-contained adversarial debate demo (no API keys needed) | - |


### PR DESCRIPTION
## Summary

Refresh the generated Aragora CLI reference after current-main command drift from recent merges including #7655/#7654 and the now-current main tip. This PR changes only generated CLI reference docs.

## Scope

- Updates `docs/reference/CLI_REFERENCE.md`
- Updates `docs-site/docs/api/cli.md`
- Adds the generated `coherence-scan` and `proof-units` command entries
- Updates generated command counts from 102/103 to 104/105

## Validation

- `python3 scripts/generate_cli_reference.py --check`
- `git diff --check origin/main HEAD`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

This remains a draft PR. Do not merge without the normal live gate checks.