### PR TITLE
fix(publisher): degrade cache refresh on PR rollup timeout

### DIFF
--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -11,8 +11,8 @@ description: Generated Aragora CLI command catalog from live parser
 
 This reference documents the command surface as implemented in code. It includes all top-level commands and known aliases.
 
-- Canonical top-level commands: **105**
-- Total top-level invocations (including aliases): **106**
+- Canonical top-level commands: **106**
+- Total top-level invocations (including aliases): **107**
 
 ## Installation
 
@@ -71,6 +71,7 @@ For full runtime configuration, see [ENVIRONMENT](../getting-started/environment
 | `crux` | - | Find load-bearing disagreements on a question (crux-finder debate) | - |
 | `crux-arbitrate` | - | DIC-27: resolve persistent cruxes as reversible signed arbitration receipts | - |
 | `crux-followup` | - | Generate DIC-17 follow-up proposals from a CruxSet (flag-gated filing) | - |
+| `crux-garden` | - | DIC-28: proactive re-examination of cruxes for staleness and contradictions | - |
 | `cruxset` | - | AGT-01: inspect CruxSet payloads emitted by the debate path | `show` |
 | `decide` | - | Run full decision pipeline: debate → plan → execute | - |
 | `demo` | - | Run a self-contained adversarial debate demo (no API keys needed) | - |

--- a/docs-site/docs/contributing/capability-matrix.md
+++ b/docs-site/docs/contributing/capability-matrix.md
@@ -8,7 +8,7 @@
 | Surface | Inventory | Capability Coverage |
 |---------|-----------|---------------------|
 | **HTTP API** | 1772 paths / 2100 operations | 81.1% |
-| **CLI** | 106 commands | 43.2% |
+| **CLI** | 107 commands | 43.2% |
 | **SDK (Python)** | 191 namespaces | 70.3% |
 | **SDK (TypeScript)** | 190 namespaces | 70.3% |
 | **UI** | tracked in capability surfaces | 86.5% |

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -8,7 +8,7 @@
 | Surface | Inventory | Capability Coverage |
 |---------|-----------|---------------------|
 | **HTTP API** | 1772 paths / 2100 operations | 81.1% |
-| **CLI** | 106 commands | 43.2% |
+| **CLI** | 107 commands | 43.2% |
 | **SDK (Python)** | 191 namespaces | 70.3% |
 | **SDK (TypeScript)** | 190 namespaces | 70.3% |
 | **UI** | tracked in capability surfaces | 86.5% |

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -12,13 +12,13 @@
 
 | Metric | Value | Source | Command |
 |---|---|---|---|
-| Python files under aragora/ | `4154` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1949520` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python files under aragora/ | `4155` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
+| Python lines of code under aragora/ | `1949692` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `141` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5252` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `219543` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
-| @pytest.mark.parametrize decorators | `714` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
-| CLI top-level command modules | `74` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
+| Test files (test_*.py under tests/) | `5253` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `219564` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| @pytest.mark.parametrize decorators | `715` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
+| CLI top-level command modules | `75` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2870` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
 | OpenAPI operations (HTTP verbs) | `3297` | `docs/api/openapi.json` | `python -c "import json; spec=json.load(open('docs/api/openapi.json')); print(sum(1 for p in spec['paths'].values() for m in p if m.lower() in {'get','post','put','delete','patch','head','options'}))"` |
 | @require_permission decorator calls | `1365` | `aragora/` | `git grep -E '@require_permission\(' -- aragora \| wc -l` |

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -6,8 +6,8 @@
 
 This reference documents the command surface as implemented in code. It includes all top-level commands and known aliases.
 
-- Canonical top-level commands: **105**
-- Total top-level invocations (including aliases): **106**
+- Canonical top-level commands: **106**
+- Total top-level invocations (including aliases): **107**
 
 ## Installation
 
@@ -66,6 +66,7 @@ For full runtime configuration, see [ENVIRONMENT](ENVIRONMENT.md).
 | `crux` | - | Find load-bearing disagreements on a question (crux-finder debate) | - |
 | `crux-arbitrate` | - | DIC-27: resolve persistent cruxes as reversible signed arbitration receipts | - |
 | `crux-followup` | - | Generate DIC-17 follow-up proposals from a CruxSet (flag-gated filing) | - |
+| `crux-garden` | - | DIC-28: proactive re-examination of cruxes for staleness and contradictions | - |
 | `cruxset` | - | AGT-01: inspect CruxSet payloads emitted by the debate path | `show` |
 | `decide` | - | Run full decision pipeline: debate → plan → execute | - |
 | `demo` | - | Run a self-contained adversarial debate demo (no API keys needed) | - |

--- a/scripts/cache_codex_automation_github_status.py
+++ b/scripts/cache_codex_automation_github_status.py
@@ -30,6 +30,7 @@ sys.path.insert(0, str(REPO_ROOT))
 from scripts.github_cli_health import check_github_cli_health
 from scripts.publish_automation_handoffs import _open_boss_ready_count
 from scripts.publish_codex_automation_branches import (
+    CODEX_BRANCH_PREFIX,
     _open_codex_pr_is_unhealthy,
     _open_codex_prs,
 )
@@ -60,6 +61,13 @@ TERMINAL_RECEIPT_STATUS_PREFIXES = (
     "superseded_by_",
 )
 DUPLICATE_OUTBOX_EXAMPLE_LIMIT = 20
+TRANSIENT_OPEN_PR_QUERY_ERROR_MARKERS = (
+    "504",
+    "gateway timeout",
+    "couldn't respond to your request in time",
+    "timed out",
+    "timeout",
+)
 LOCAL_QUEUE_DETAIL_KEYS = (
     "nonterminal_receipts",
     "outbox_duplicate_idempotency_keys",
@@ -542,6 +550,45 @@ def _github_queue_unavailable(*, reason: str, error: str | None = None) -> dict[
     return payload
 
 
+def _is_transient_open_pr_query_error(error: str) -> bool:
+    normalized = error.casefold()
+    return any(marker in normalized for marker in TRANSIENT_OPEN_PR_QUERY_ERROR_MARKERS)
+
+
+def _open_codex_prs_lightweight(repo_root: Path, repo: str) -> list[dict[str, Any]]:
+    """List open Codex PRs without check rollups for cache-refresh degraded mode."""
+
+    proc = subprocess.run(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--limit",
+            "200",
+            "--json",
+            "number,title,headRefName,isDraft,mergeStateStatus,reviewDecision",
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.strip() or "failed to list open PRs")
+    payload = json.loads(proc.stdout or "[]")
+    return [
+        item
+        for item in payload
+        if isinstance(item, dict)
+        and isinstance(item.get("headRefName"), str)
+        and item["headRefName"].startswith(CODEX_BRANCH_PREFIX)
+    ]
+
+
 def build_status(
     *,
     repo_root: Path,
@@ -573,8 +620,31 @@ def build_status(
         payload["github_queue"] = _github_queue_unavailable(reason=health.mode)
         return payload
 
+    degraded = False
+    degraded_reason: str | None = None
     try:
         open_prs = _open_codex_prs(repo_root, github_repo)
+    except RuntimeError as exc:
+        heavy_error = str(exc)
+        if not _is_transient_open_pr_query_error(heavy_error):
+            payload["github_queue"] = _github_queue_unavailable(
+                reason="remote_query_failed",
+                error=heavy_error,
+            )
+            return payload
+        try:
+            open_prs = _open_codex_prs_lightweight(repo_root, github_repo)
+        except RuntimeError as fallback_exc:
+            payload["github_queue"] = _github_queue_unavailable(
+                reason="remote_query_failed",
+                error=str(fallback_exc),
+            )
+            payload["github_queue"]["fallback_from_error"] = heavy_error
+            return payload
+        degraded = True
+        degraded_reason = f"heavy_open_pr_query_failed:{heavy_error}"
+
+    try:
         open_issue_count = _open_boss_ready_count(repo_root, github_repo, list(labels))
     except RuntimeError as exc:
         payload["github_queue"] = _github_queue_unavailable(
@@ -583,12 +653,17 @@ def build_status(
         )
         return payload
 
-    unhealthy_open_pr_count = sum(1 for item in open_prs if _open_codex_pr_is_unhealthy(item))
+    unhealthy_open_pr_count = (
+        None if degraded else sum(1 for item in open_prs if _open_codex_pr_is_unhealthy(item))
+    )
     payload["github_queue"] = {
         "available": True,
+        "degraded": degraded,
         "open_codex_pr_count": len(open_prs),
         "unhealthy_open_pr_count": unhealthy_open_pr_count,
-        "all_open_prs_unhealthy": bool(open_prs) and unhealthy_open_pr_count == len(open_prs),
+        "all_open_prs_unhealthy": False
+        if degraded
+        else bool(open_prs) and unhealthy_open_pr_count == len(open_prs),
         "merge_state_counts": _merge_state_counts(open_prs),
         "open_issue_count": open_issue_count,
         "labels": list(labels),
@@ -600,6 +675,11 @@ def build_status(
             item.get("headRefName") for item in open_prs if isinstance(item.get("headRefName"), str)
         ],
     }
+    if degraded_reason:
+        payload["github_queue"]["degraded_reason"] = degraded_reason
+        payload["github_queue"]["unhealthy_open_pr_count_degraded_reason"] = (
+            "statusCheckRollup unavailable from lightweight fallback"
+        )
     return payload
 
 

--- a/tests/scripts/test_cache_codex_automation_github_status.py
+++ b/tests/scripts/test_cache_codex_automation_github_status.py
@@ -53,7 +53,7 @@ def test_build_status_uses_local_queue_when_github_unavailable(
     assert payload["local_queue"]["unreceipted_outbox_count"] == 1
 
 
-def test_build_status_keeps_local_queue_when_remote_query_fails(
+def test_build_status_uses_lightweight_fallback_when_remote_query_times_out(
     monkeypatch: Any,
     tmp_path: Path,
 ) -> None:
@@ -80,6 +80,72 @@ def test_build_status_keeps_local_queue_when_remote_query_fails(
         "_open_codex_prs",
         lambda repo_root, repo: (_ for _ in ()).throw(RuntimeError("HTTP 504")),
     )
+    monkeypatch.setattr(
+        mod,
+        "_open_codex_prs_lightweight",
+        lambda repo_root, repo: [
+            {
+                "number": 123,
+                "title": "repair cache",
+                "headRefName": "codex/cache-fallback",
+                "isDraft": False,
+                "mergeStateStatus": "BLOCKED",
+                "reviewDecision": "REVIEW_REQUIRED",
+            }
+        ],
+    )
+    monkeypatch.setattr(mod, "_open_boss_ready_count", lambda repo_root, repo, labels: 3)
+
+    payload = mod.build_status(
+        repo_root=tmp_path,
+        github_repo="synaptent/aragora",
+        labels=["boss-ready"],
+        max_open_prs=12,
+        max_open_issues=16,
+    )
+
+    assert payload["github_health"]["ready"] is True
+    queue = payload["github_queue"]
+    assert queue["available"] is True
+    assert queue["degraded"] is True
+    assert queue["degraded_reason"] == "heavy_open_pr_query_failed:HTTP 504"
+    assert queue["open_codex_pr_count"] == 1
+    assert queue["merge_state_counts"] == {"BLOCKED": 1}
+    assert queue["open_issue_count"] == 3
+    assert queue["open_pr_heads"] == ["codex/cache-fallback"]
+    assert queue["unhealthy_open_pr_count"] is None
+    assert queue["all_open_prs_unhealthy"] is False
+    assert payload["local_queue"]["outbox_count"] == 1
+    assert payload["local_queue"]["unreceipted_outbox_count"] == 1
+
+
+def test_build_status_still_fails_closed_for_non_timeout_remote_query_errors(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    outbox = tmp_path / ".aragora" / "automation-outbox"
+    receipts = tmp_path / ".aragora" / "automation-receipts"
+    outbox.mkdir(parents=True)
+    receipts.mkdir(parents=True)
+    (outbox / "open-pr-example.json").write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda repo_root: GitHubCLIHealth(
+            ready=True,
+            auth_ok=True,
+            api_ok=True,
+            mode="ready",
+            error="",
+            repo=str(repo_root),
+        ),
+    )
+    monkeypatch.setattr(
+        mod,
+        "_open_codex_prs",
+        lambda repo_root, repo: (_ for _ in ()).throw(RuntimeError("bad credentials")),
+    )
 
     payload = mod.build_status(
         repo_root=tmp_path,
@@ -93,7 +159,7 @@ def test_build_status_keeps_local_queue_when_remote_query_fails(
     assert payload["github_queue"] == {
         "available": False,
         "reason": "remote_query_failed",
-        "error": "HTTP 504",
+        "error": "bad credentials",
     }
     assert payload["local_queue"]["outbox_count"] == 1
     assert payload["local_queue"]["unreceipted_outbox_count"] == 1
@@ -853,6 +919,7 @@ def test_build_status_records_remote_pressure_when_github_available(
 
     queue = payload["github_queue"]
     assert queue["available"] is True
+    assert queue["degraded"] is False
     assert queue["open_codex_pr_count"] == 2
     assert queue["unhealthy_open_pr_count"] == 1
     assert queue["all_open_prs_unhealthy"] is False


### PR DESCRIPTION
## Summary
- add a lightweight open Codex PR fallback when the heavy publisher cache query times out or returns HTTP 504
- keep the normal statusCheckRollup path unchanged when it succeeds
- write fresh degraded cache metadata with local queue counts, PR counts, merge-state counts, and PR heads instead of failing publisher freshness indefinitely

## Validation
- python3 -m pytest -q tests/scripts/test_cache_codex_automation_github_status.py tests/scripts/test_publish_codex_automation_branches.py -p no:rerunfailures -p no:cacheprovider
- python3 -m ruff check scripts/cache_codex_automation_github_status.py scripts/publish_codex_automation_branches.py tests/scripts/test_cache_codex_automation_github_status.py tests/scripts/test_publish_codex_automation_branches.py
- python3 -m ruff format --check scripts/cache_codex_automation_github_status.py scripts/publish_codex_automation_branches.py tests/scripts/test_cache_codex_automation_github_status.py tests/scripts/test_publish_codex_automation_branches.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- python3 scripts/cache_codex_automation_github_status.py --repo /Users/armand/Development/aragora --state-root /Users/armand/Development/aragora --summary-only
- python3 /Users/armand/Development/aragora/scripts/publisher_freshness_check.py --json -> ready