### PR TITLE
[DIC-23] Add aragora dialectical-loop CLI verb for runtime loop operator surface

### DIFF
--- a/aragora/cli/commands/dic23_runtime_loop.py
+++ b/aragora/cli/commands/dic23_runtime_loop.py
@@ -1,0 +1,97 @@
+"""CLI verb: ``aragora dialectical-loop`` (DIC-23 / #6217).
+
+Reads a DecaySignal JSON file, runs one DIC-23 orchestration pass, and
+emits the DialecticalEvent as a text report or JSON.
+
+Flag gate: ``ARAGORA_DIALECTICAL_RUNTIME_ENABLED`` (default off).
+Live queue effect: none — report-only trace; no issues created.
+
+Signal JSON shape (from DecaySignal.to_dict()):
+    {"code_unit_id": "...", "integrity_score": 0.45,
+     "recommended_action": "repair_required",
+     "reasons": [{"kind": "failed_claim", "detail": "..."}]}
+
+Advances: issue #6217 (DIC-23).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from aragora.epistemic.decay_monitor import DecayReason, DecaySignal
+from aragora.epistemic.runtime_loop import (
+    DialecticalRuntimeError,
+    dialectical_runtime_enabled,
+    run_dialectical_loop,
+)
+
+_FLAG = "ARAGORA_DIALECTICAL_RUNTIME_ENABLED"
+
+
+def _load_signal(path: Path) -> DecaySignal:
+    obj = json.loads(path.read_text(encoding="utf-8"))
+    reasons = [
+        DecayReason(
+            kind=str(r["kind"]),
+            detail=str(r.get("detail", "")),
+            claim_id=str(r.get("claim_id", "")),
+            crux_id=str(r.get("crux_id", "")),
+        )
+        for r in obj.get("reasons", [])
+    ]
+    return DecaySignal(
+        code_unit_id=str(obj["code_unit_id"]),
+        integrity_score=float(obj["integrity_score"]),
+        reasons=reasons,
+        recommended_action=str(obj.get("recommended_action", "report_only")),
+    )
+
+
+def cmd_dialectical_loop(args: argparse.Namespace) -> int:
+    """Handle the ``aragora dialectical-loop`` subcommand."""
+    if not dialectical_runtime_enabled():
+        print(f"error: {_FLAG} is not set; set it to '1' to enable", file=sys.stderr)
+        return 1
+
+    signal_path = Path(str(getattr(args, "signal", ""))).expanduser()
+    if not signal_path.exists():
+        print(f"error: signal file not found: {signal_path}", file=sys.stderr)
+        return 1
+
+    try:
+        signal = _load_signal(signal_path)
+    except (json.JSONDecodeError, KeyError, ValueError, OSError) as exc:
+        print(f"error: failed to load signal: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        event = run_dialectical_loop(
+            signal,
+            code_unit_class=str(getattr(args, "unit_class", "default")),
+            enable_repair_proposal=bool(getattr(args, "repair", False)),
+            require_enabled=True,
+        )
+    except DialecticalRuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if getattr(args, "json", False):
+        print(json.dumps(event.to_dict(), indent=2))
+        return 0
+
+    print(f"Dialectical Runtime Loop  {event.event_id}")
+    print(f"  code_unit_id    : {event.code_unit_id}")
+    print(f"  integrity_score : {event.integrity_score:.4f}")
+    print(f"  recommended     : {event.recommended_action}")
+    print(f"  quarantine      : {event.quarantine_action}")
+    print(f"  crux_probe      : {'skipped' if event.crux_probe_skipped else 'ran'}")
+    if event.repair_spec is not None:
+        print(f"  repair_spec     : {event.repair_spec.code_unit_id} (kind={event.repair_spec.repair_kind})")
+    print(f"  created_at      : {event.created_at}")
+    return 0
+
+
+__all__ = ["cmd_dialectical_loop"]

--- a/aragora/cli/commands/dic23_runtime_loop.py
+++ b/aragora/cli/commands/dic23_runtime_loop.py
@@ -89,7 +89,9 @@ def cmd_dialectical_loop(args: argparse.Namespace) -> int:
     print(f"  quarantine      : {event.quarantine_action}")
     print(f"  crux_probe      : {'skipped' if event.crux_probe_skipped else 'ran'}")
     if event.repair_spec is not None:
-        print(f"  repair_spec     : {event.repair_spec.code_unit_id} (kind={event.repair_spec.repair_kind})")
+        print(
+            f"  repair_spec     : {event.repair_spec.code_unit_id} (kind={event.repair_spec.repair_kind})"
+        )
     print(f"  created_at      : {event.created_at}")
     return 0
 

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -227,6 +227,9 @@ Examples:
     # DIC-28: proactive crux gardening operator surface
     _add_crux_garden_parser(subparsers)
 
+    # DIC-23: dialectical runtime loop operator surface
+    _add_dialectical_loop_parser(subparsers)
+
     return parser
 
 
@@ -842,6 +845,43 @@ def _add_crux_garden_parser(subparsers) -> None:
     )
     p.add_argument("--json", action="store_true", help="Emit report as JSON.")
     p.set_defaults(func=_lazy("aragora.cli.commands.dic28_crux_garden", "cmd_crux_garden"))
+
+
+def _add_dialectical_loop_parser(subparsers) -> None:
+    """DIC-23: dialectical runtime loop operator surface (issue #6217).
+
+    Flag-gated: ARAGORA_DIALECTICAL_RUNTIME_ENABLED. Live queue effect: none.
+    """
+    p = subparsers.add_parser(
+        "dialectical-loop",
+        help="DIC-23: run one dialectical runtime loop pass on a DecaySignal",
+        description=(
+            "Read a DecaySignal JSON file and run one DIC-23 orchestration pass. "
+            "Emits a DialecticalEvent report. Report-only; no debates started, no "
+            "issues created. Requires ARAGORA_DIALECTICAL_RUNTIME_ENABLED=1."
+        ),
+    )
+    p.add_argument(
+        "--signal",
+        required=True,
+        help="Path to a DecaySignal JSON file (from decay_monitor output).",
+    )
+    p.add_argument(
+        "--class",
+        dest="unit_class",
+        default="default",
+        choices=["live_dispatch", "report_surface", "demo", "pure_policy", "default"],
+        help="Policy class to apply (default: 'default').",
+    )
+    p.add_argument(
+        "--repair",
+        action="store_true",
+        help="Propose a repair spec when quarantine action is repair_required.",
+    )
+    p.add_argument("--json", action="store_true", help="Emit event as JSON.")
+    p.set_defaults(
+        func=_lazy("aragora.cli.commands.dic23_runtime_loop", "cmd_dialectical_loop")
+    )
 
 
 def _add_ask_parser(subparsers) -> None:

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -879,9 +879,7 @@ def _add_dialectical_loop_parser(subparsers) -> None:
         help="Propose a repair spec when quarantine action is repair_required.",
     )
     p.add_argument("--json", action="store_true", help="Emit event as JSON.")
-    p.set_defaults(
-        func=_lazy("aragora.cli.commands.dic23_runtime_loop", "cmd_dialectical_loop")
-    )
+    p.set_defaults(func=_lazy("aragora.cli.commands.dic23_runtime_loop", "cmd_dialectical_loop"))
 
 
 def _add_ask_parser(subparsers) -> None:

--- a/tests/cli/test_dic23_runtime_loop.py
+++ b/tests/cli/test_dic23_runtime_loop.py
@@ -1,0 +1,141 @@
+"""CLI tests for DIC-23 ``aragora dialectical-loop`` command.
+
+Flag: ARAGORA_DIALECTICAL_RUNTIME_ENABLED (default OFF)
+Live queue effect: none
+Advances: issue #6217 (DIC-23)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from aragora.cli.commands.dic23_runtime_loop import _load_signal, cmd_dialectical_loop
+
+_FLAG = "ARAGORA_DIALECTICAL_RUNTIME_ENABLED"
+
+
+def _args(signal_path: str, *, json_output: bool = False, unit_class: str = "default", repair: bool = False) -> argparse.Namespace:
+    ns = argparse.Namespace()
+    ns.signal = signal_path
+    ns.json = json_output
+    ns.unit_class = unit_class
+    ns.repair = repair
+    return ns
+
+
+def _write(tmp_path: Path, data: object) -> Path:
+    p = tmp_path / "signal.json"
+    p.write_text(json.dumps(data), encoding="utf-8")
+    return p
+
+
+def _sig(unit_id: str = "u.test", integrity: float = 0.8, action: str = "report_only", reasons: list | None = None) -> dict:
+    return {"code_unit_id": unit_id, "integrity_score": integrity, "recommended_action": action, "reasons": reasons or []}
+
+
+# ---------------------------------------------------------------------------
+# Flag gate
+# ---------------------------------------------------------------------------
+
+def test_flag_off_exits_1(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.delenv(_FLAG, raising=False)
+    assert cmd_dialectical_loop(_args(str(_write(tmp_path, _sig())))) == 1
+
+
+def test_flag_off_names_flag_in_stderr(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    monkeypatch.delenv(_FLAG, raising=False)
+    cmd_dialectical_loop(_args(str(_write(tmp_path, _sig()))))
+    assert _FLAG in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("val", ["1", "true", "yes", "on"])
+def test_flag_truthy_values_exit_0(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, val: str) -> None:
+    monkeypatch.setenv(_FLAG, val)
+    assert cmd_dialectical_loop(_args(str(_write(tmp_path, _sig())))) == 0
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+def test_missing_signal_file_exits_1(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    assert cmd_dialectical_loop(_args(str(tmp_path / "absent.json"))) == 1
+
+
+def test_bad_json_exits_1(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    p = tmp_path / "bad.json"
+    p.write_text("{not json", encoding="utf-8")
+    assert cmd_dialectical_loop(_args(str(p))) == 1
+
+
+def test_missing_code_unit_id_exits_1(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    assert cmd_dialectical_loop(_args(str(_write(tmp_path, {"integrity_score": 0.9})))) == 1
+
+
+# ---------------------------------------------------------------------------
+# Successful runs
+# ---------------------------------------------------------------------------
+
+def test_text_output_contains_event_id(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    assert cmd_dialectical_loop(_args(str(_write(tmp_path, _sig())))) == 0
+    assert "drt_" in capsys.readouterr().out
+
+
+def test_json_output_is_valid(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    assert cmd_dialectical_loop(_args(str(_write(tmp_path, _sig(unit_id="u.abc"))), json_output=True)) == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["code_unit_id"] == "u.abc"
+    assert "event_id" in data and "quarantine_action" in data
+
+
+def test_low_integrity_triggers_fail_closed(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    cmd_dialectical_loop(_args(str(_write(tmp_path, _sig(integrity=0.1))), json_output=True))
+    assert json.loads(capsys.readouterr().out)["quarantine_action"] == "fail_closed"
+
+
+def test_live_dispatch_raises_threshold(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    # live_dispatch fail_closed_threshold=0.6; integrity 0.55 < 0.6 → fail_closed
+    cmd_dialectical_loop(_args(str(_write(tmp_path, _sig(integrity=0.55))), json_output=True, unit_class="live_dispatch"))
+    assert json.loads(capsys.readouterr().out)["quarantine_action"] == "fail_closed"
+
+
+# ---------------------------------------------------------------------------
+# _load_signal unit tests
+# ---------------------------------------------------------------------------
+
+def test_load_signal_parses_reasons_and_defaults(tmp_path: Path) -> None:
+    raw = {
+        "code_unit_id": "u.x",
+        "integrity_score": 0.7,
+        "recommended_action": "degrade",
+        "reasons": [
+            {"kind": "failed_claim", "detail": "foo failed", "claim_id": "c.foo"},
+            {"kind": "stale_evidence", "detail": "old"},
+        ],
+    }
+    p = tmp_path / "s.json"
+    p.write_text(json.dumps(raw), encoding="utf-8")
+    sig = _load_signal(p)
+    assert sig.code_unit_id == "u.x"
+    assert sig.recommended_action == "degrade"
+    assert len(sig.reasons) == 2
+    assert sig.reasons[0].claim_id == "c.foo"
+    assert sig.reasons[1].crux_id == ""
+
+
+def test_load_signal_defaults_recommended_action(tmp_path: Path) -> None:
+    p = tmp_path / "s.json"
+    p.write_text(json.dumps({"code_unit_id": "u.y", "integrity_score": 1.0}), encoding="utf-8")
+    sig = _load_signal(p)
+    assert sig.recommended_action == "report_only" and sig.reasons == []

--- a/tests/cli/test_dic23_runtime_loop.py
+++ b/tests/cli/test_dic23_runtime_loop.py
@@ -18,7 +18,13 @@ from aragora.cli.commands.dic23_runtime_loop import _load_signal, cmd_dialectica
 _FLAG = "ARAGORA_DIALECTICAL_RUNTIME_ENABLED"
 
 
-def _args(signal_path: str, *, json_output: bool = False, unit_class: str = "default", repair: bool = False) -> argparse.Namespace:
+def _args(
+    signal_path: str,
+    *,
+    json_output: bool = False,
+    unit_class: str = "default",
+    repair: bool = False,
+) -> argparse.Namespace:
     ns = argparse.Namespace()
     ns.signal = signal_path
     ns.json = json_output
@@ -33,27 +39,42 @@ def _write(tmp_path: Path, data: object) -> Path:
     return p
 
 
-def _sig(unit_id: str = "u.test", integrity: float = 0.8, action: str = "report_only", reasons: list | None = None) -> dict:
-    return {"code_unit_id": unit_id, "integrity_score": integrity, "recommended_action": action, "reasons": reasons or []}
+def _sig(
+    unit_id: str = "u.test",
+    integrity: float = 0.8,
+    action: str = "report_only",
+    reasons: list | None = None,
+) -> dict:
+    return {
+        "code_unit_id": unit_id,
+        "integrity_score": integrity,
+        "recommended_action": action,
+        "reasons": reasons or [],
+    }
 
 
 # ---------------------------------------------------------------------------
 # Flag gate
 # ---------------------------------------------------------------------------
 
+
 def test_flag_off_exits_1(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.delenv(_FLAG, raising=False)
     assert cmd_dialectical_loop(_args(str(_write(tmp_path, _sig())))) == 1
 
 
-def test_flag_off_names_flag_in_stderr(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+def test_flag_off_names_flag_in_stderr(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
     monkeypatch.delenv(_FLAG, raising=False)
     cmd_dialectical_loop(_args(str(_write(tmp_path, _sig()))))
     assert _FLAG in capsys.readouterr().err
 
 
 @pytest.mark.parametrize("val", ["1", "true", "yes", "on"])
-def test_flag_truthy_values_exit_0(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, val: str) -> None:
+def test_flag_truthy_values_exit_0(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, val: str
+) -> None:
     monkeypatch.setenv(_FLAG, val)
     assert cmd_dialectical_loop(_args(str(_write(tmp_path, _sig())))) == 0
 
@@ -61,6 +82,7 @@ def test_flag_truthy_values_exit_0(monkeypatch: pytest.MonkeyPatch, tmp_path: Pa
 # ---------------------------------------------------------------------------
 # Input validation
 # ---------------------------------------------------------------------------
+
 
 def test_missing_signal_file_exits_1(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv(_FLAG, "1")
@@ -83,36 +105,55 @@ def test_missing_code_unit_id_exits_1(monkeypatch: pytest.MonkeyPatch, tmp_path:
 # Successful runs
 # ---------------------------------------------------------------------------
 
-def test_text_output_contains_event_id(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+
+def test_text_output_contains_event_id(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
     monkeypatch.setenv(_FLAG, "1")
     assert cmd_dialectical_loop(_args(str(_write(tmp_path, _sig())))) == 0
     assert "drt_" in capsys.readouterr().out
 
 
-def test_json_output_is_valid(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+def test_json_output_is_valid(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
     monkeypatch.setenv(_FLAG, "1")
-    assert cmd_dialectical_loop(_args(str(_write(tmp_path, _sig(unit_id="u.abc"))), json_output=True)) == 0
+    assert (
+        cmd_dialectical_loop(_args(str(_write(tmp_path, _sig(unit_id="u.abc"))), json_output=True))
+        == 0
+    )
     data = json.loads(capsys.readouterr().out)
     assert data["code_unit_id"] == "u.abc"
     assert "event_id" in data and "quarantine_action" in data
 
 
-def test_low_integrity_triggers_fail_closed(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+def test_low_integrity_triggers_fail_closed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
     monkeypatch.setenv(_FLAG, "1")
     cmd_dialectical_loop(_args(str(_write(tmp_path, _sig(integrity=0.1))), json_output=True))
     assert json.loads(capsys.readouterr().out)["quarantine_action"] == "fail_closed"
 
 
-def test_live_dispatch_raises_threshold(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+def test_live_dispatch_raises_threshold(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
     monkeypatch.setenv(_FLAG, "1")
     # live_dispatch fail_closed_threshold=0.6; integrity 0.55 < 0.6 → fail_closed
-    cmd_dialectical_loop(_args(str(_write(tmp_path, _sig(integrity=0.55))), json_output=True, unit_class="live_dispatch"))
+    cmd_dialectical_loop(
+        _args(
+            str(_write(tmp_path, _sig(integrity=0.55))),
+            json_output=True,
+            unit_class="live_dispatch",
+        )
+    )
     assert json.loads(capsys.readouterr().out)["quarantine_action"] == "fail_closed"
 
 
 # ---------------------------------------------------------------------------
 # _load_signal unit tests
 # ---------------------------------------------------------------------------
+
 
 def test_load_signal_parses_reasons_and_defaults(tmp_path: Path) -> None:
     raw = {


### PR DESCRIPTION
## Slice

Adds `aragora dialectical-loop --signal <file>` — a flag-gated CLI verb that reads a `DecaySignal` JSON file, runs one DIC-23 orchestration pass via `run_dialectical_loop`, and emits the `DialecticalEvent` as a text report or JSON. This is the only DIC-23..28 module that has a backend (`aragora/epistemic/runtime_loop.py`) and tests but no CLI operator surface; this slice closes that gap.

## Gating

- Default: **OFF** (flag: `ARAGORA_DIALECTICAL_RUNTIME_ENABLED=1`)
- Live queue effect: **none** — report-only trace; no debates started, no issues created, no queue writes
- Advances issue: #6217 (DIC-23 Dialectical Runtime Loop orchestrator)

## Tests

- `test_flag_off_exits_1` — unset flag → rc=1
- `test_flag_off_names_flag_in_stderr` — stderr includes the flag name
- `test_flag_truthy_values_exit_0[1/true/yes/on]` — parametrized over all truthy spellings
- `test_missing_signal_file_exits_1` — absent path → rc=1
- `test_bad_json_exits_1` — malformed JSON → rc=1
- `test_missing_code_unit_id_exits_1` — JSON missing required field → rc=1
- `test_text_output_contains_event_id` — human-readable output includes `drt_` prefix
- `test_json_output_is_valid` — `--json` emits parseable JSON with `event_id`, `quarantine_action`, `code_unit_id`
- `test_low_integrity_triggers_fail_closed` — integrity 0.1 < default threshold 0.4 → `fail_closed`
- `test_live_dispatch_raises_threshold` — `--class live_dispatch` threshold=0.6; integrity 0.55 → `fail_closed`
- `test_load_signal_parses_reasons_and_defaults` — full reason parsing with `claim_id` / `crux_id` fields
- `test_load_signal_defaults_recommended_action` — absent field defaults to `report_only`

## Validation

- `pytest tests/cli/test_dic23_runtime_loop.py --noconftest` — **15 passed**
- `ruff check aragora/cli/commands/dic23_runtime_loop.py tests/cli/test_dic23_runtime_loop.py` — **clean**
- `mypy aragora/cli/commands/dic23_runtime_loop.py --ignore-missing-imports` — **clean**
- Net diff: **278 LOC** across 3 files (2 new, 1 modified)

## Out of scope

- `--repair` flag exercises the `enable_repair_proposal` path; test coverage for non-`report_only` repair spec display is deferred (requires a signal with integrity below the repair threshold and a specific class — a follow-on test slice)
- `--crux-probe` / crux emission integration: deferred; requires `ARAGORA_CRUXSET_EMISSION_ENABLED` flag and a populated `BeliefNetwork` — separate slice
- Scheduling or recurring dialectical loop runs — deferred to DIC-23 integration slice once the Foreman gate opens

## Gate status

Per `docs/status/NEXT_STEPS_CANONICAL.md`, `DIC-13..22` (and by extension DIC-23..28) are in the **Delay** track. The proof-first Foreman gate has **not** opened. This PR is planning truth and flag-gated operator tooling only; no `boss-ready` label applied.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B11gxkaEDAcC9k3zCDydQD)_