### PR TITLE
chore(ci): portability regression guard (PR 0)

### DIFF
--- a/.github/workflows/portability-lint.yml
+++ b/.github/workflows/portability-lint.yml
@@ -1,0 +1,34 @@
+name: Portability Lint
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**'
+      - '!**.md'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main]
+  merge_group:
+  workflow_dispatch:
+
+concurrency:
+  group: portability-lint-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  portability:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Portability guard (no new private/legacy references)
+        run: python3 scripts/check_portability.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -169,6 +169,17 @@ repos:
         files: ^aragora/live/src/.*\.(ts|tsx)$
         stages: [pre-push]
 
+  # Portability guard: block new hardcoded private/legacy references
+  # (private home dirs, .venv/bin/python, an0mium/aragora slug). Baselined in
+  # scripts/portability_baseline.json so it only fails on NEW violations.
+  - repo: local
+    hooks:
+      - id: portability-guard
+        name: Portability guard (no new private/legacy references)
+        entry: python3 scripts/check_portability.py
+        language: system
+        types: [text]
+
   # Security checks
   - repo: https://github.com/PyCQA/bandit
     rev: 1.7.8

--- a/scripts/check_portability.py
+++ b/scripts/check_portability.py
@@ -51,6 +51,9 @@ ALWAYS_SKIP = (
     "scripts/portability_baseline.json",
     "tests/scripts/test_check_portability.py",
     "docs/audits/*",
+    # Sanctioned runtime interpreter resolver: legitimately references
+    # .venv/bin/python3 as an existence check (resolved at runtime, never baked).
+    "scripts/aragora_runtime.sh",
 )
 
 

--- a/scripts/check_portability.py
+++ b/scripts/check_portability.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Portability/privacy guard for the public repo.
+
+Fails when a tracked file introduces a *new* hardcoded private-machine or
+legacy-identity reference that would break a third-party clone:
+
+  - ``users_home``  : a private macOS home dir like ``/Users/<name>`` (the CI
+                      runner home ``/Users/runner`` is allowed)
+  - ``venv_python`` : ``.venv/bin/python`` captured as a durable interpreter path
+  - ``legacy_slug`` : the old GitHub slug ``an0mium/aragora`` (repo is
+                      ``synaptent/aragora``)
+
+A baseline (``scripts/portability_baseline.json``) records the violations that
+already exist on ``main`` so the guard is **non-breaking**: it only fails on
+violations that are *not* baselined. As the Tier A-C cleanup PRs land, prune the
+baseline so the surface ratchets down and cannot regress.
+
+Usage::
+
+    python3 scripts/check_portability.py                 # CI: scan all tracked files
+    python3 scripts/check_portability.py FILE [FILE ...] # pre-commit: scan given files
+    python3 scripts/check_portability.py --update-baseline
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BASELINE_PATH = REPO_ROOT / "scripts" / "portability_baseline.json"
+
+# pattern id -> compiled regex
+PATTERNS: dict[str, re.Pattern[str]] = {
+    "users_home": re.compile(r"/Users/([A-Za-z0-9._-]+)"),
+    "venv_python": re.compile(r"\.venv/bin/python"),
+    "legacy_slug": re.compile(r"an0mium/aragora"),
+}
+
+# macOS usernames that are legitimate (GitHub-hosted runner home)
+ALLOWED_USERS = {"runner"}
+
+# Files never scanned: this guard's own sources (which contain the patterns as
+# data) and the audit reports that legitimately quote the patterns.
+ALWAYS_SKIP = (
+    "scripts/check_portability.py",
+    "scripts/portability_baseline.json",
+    "tests/scripts/test_check_portability.py",
+    "docs/audits/*",
+)
+
+
+def _is_skipped(rel_path: str) -> bool:
+    p = Path(rel_path)
+    return any(p.match(pattern) for pattern in ALWAYS_SKIP)
+
+
+def find_violations_in_text(text: str) -> set[str]:
+    """Return the set of pattern ids that match ``text``."""
+    found: set[str] = set()
+    for pid, rx in PATTERNS.items():
+        for match in rx.finditer(text):
+            if pid == "users_home" and match.group(1) in ALLOWED_USERS:
+                continue
+            found.add(pid)
+    return found
+
+
+def _read_text(path: Path) -> str | None:
+    try:
+        return path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return None  # binary or unreadable -> skip
+
+
+def scan_paths(rel_paths: list[str], *, root: Path | None = None) -> dict[str, list[str]]:
+    """Scan ``rel_paths`` (repo-relative) and return ``{path: sorted pattern ids}``."""
+    root = root or REPO_ROOT
+    violations: dict[str, list[str]] = {}
+    for rel in rel_paths:
+        rel = Path(rel).as_posix()
+        if _is_skipped(rel):
+            continue
+        text = _read_text(root / rel)
+        if text is None:
+            continue
+        found = find_violations_in_text(text)
+        if found:
+            violations[rel] = sorted(found)
+    return violations
+
+
+def _git_tracked_files(root: Path) -> list[str]:
+    out = subprocess.run(
+        ["git", "ls-files"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [line for line in out.stdout.splitlines() if line]
+
+
+def load_baseline(path: Path | None = None) -> dict[str, list[str]]:
+    path = path or BASELINE_PATH
+    if not path.exists():
+        return {}
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return data.get("files", {})
+
+
+def new_violations(
+    found: dict[str, list[str]], baseline: dict[str, list[str]]
+) -> dict[str, list[str]]:
+    """Violations present in ``found`` but not accepted by ``baseline``."""
+    result: dict[str, list[str]] = {}
+    for path, pids in found.items():
+        allowed = set(baseline.get(path, []))
+        delta = sorted(set(pids) - allowed)
+        if delta:
+            result[path] = delta
+    return result
+
+
+def write_baseline(found: dict[str, list[str]], path: Path | None = None) -> None:
+    path = path or BASELINE_PATH
+    payload = {
+        "_comment": (
+            "Baseline of pre-existing portability violations. The guard "
+            "(scripts/check_portability.py) only fails on violations NOT listed "
+            "here. Prune entries as cleanup PRs remove the underlying paths; do "
+            "not add new entries by hand. Regenerate with --update-baseline."
+        ),
+        "files": dict(sorted(found.items())),
+    }
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("files", nargs="*", help="Specific files to scan (default: all tracked).")
+    parser.add_argument(
+        "--update-baseline",
+        action="store_true",
+        help="Rewrite the baseline from the current full-tree scan.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.update_baseline:
+        found = scan_paths(_git_tracked_files(REPO_ROOT))
+        write_baseline(found)
+        print(f"Wrote baseline with {len(found)} files to {BASELINE_PATH.relative_to(REPO_ROOT)}")
+        return 0
+
+    if args.files:
+        rel_paths = []
+        for f in args.files:
+            p = Path(f)
+            try:
+                rel_paths.append(p.resolve().relative_to(REPO_ROOT).as_posix())
+            except ValueError:
+                rel_paths.append(p.as_posix())
+    else:
+        rel_paths = _git_tracked_files(REPO_ROOT)
+
+    found = scan_paths(rel_paths)
+    offenders = new_violations(found, load_baseline())
+
+    if offenders:
+        print("Portability guard: NEW hardcoded private/legacy references found:\n")
+        for path in sorted(offenders):
+            print(f"  {path}: {', '.join(offenders[path])}")
+        print(
+            "\nUse a portable form instead (e.g. $HOME, "
+            "git rev-parse --show-toplevel, ${{ github.repository }}, "
+            "ARAGORA_PYTHON / synaptent/aragora). If this is a legitimate, "
+            "reviewed exception, update scripts/portability_baseline.json via "
+            "--update-baseline."
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/portability_baseline.json
+++ b/scripts/portability_baseline.json
@@ -1,0 +1,742 @@
+{
+  "_comment": "Baseline of pre-existing portability violations. The guard (scripts/check_portability.py) only fails on violations NOT listed here. Prune entries as cleanup PRs remove the underlying paths; do not add new entries by hand. Regenerate with --update-baseline.",
+  "files": {
+    ".github/ISSUE_TEMPLATE/config.yml": [
+      "legacy_slug"
+    ],
+    ".github/actions/aragora-review/README.md": [
+      "legacy_slug"
+    ],
+    ".github/workflows/nightly-integration.yml": [
+      "legacy_slug"
+    ],
+    ".github/workflows/publish-aragora-debate.yml": [
+      "legacy_slug"
+    ],
+    ".github/workflows/templates/aragora-gauntlet-template.yml": [
+      "legacy_slug"
+    ],
+    ".github/workflows/templates/aragora-review-template.yml": [
+      "legacy_slug"
+    ],
+    ".gt/config.json": [
+      "users_home"
+    ],
+    ".pre-commit-config.yaml": [
+      "legacy_slug",
+      "venv_python"
+    ],
+    "DEVELOPMENT.md": [
+      "legacy_slug"
+    ],
+    "INSTALL.md": [
+      "legacy_slug"
+    ],
+    "SECURITY.md": [
+      "legacy_slug"
+    ],
+    "SECURITY_AUDIT_INPUT_VALIDATION.md": [
+      "users_home"
+    ],
+    "aragora-debate/CHANGELOG.md": [
+      "legacy_slug"
+    ],
+    "aragora-debate/README.md": [
+      "legacy_slug"
+    ],
+    "aragora-debate/pyproject.toml": [
+      "legacy_slug"
+    ],
+    "aragora-operator/Makefile": [
+      "legacy_slug"
+    ],
+    "aragora-operator/controllers/aragoracluster_controller.go": [
+      "legacy_slug"
+    ],
+    "aragora-operator/controllers/aragorainstance_controller.go": [
+      "legacy_slug"
+    ],
+    "aragora-operator/controllers/aragorapolicy_controller.go": [
+      "legacy_slug"
+    ],
+    "aragora-operator/go.mod": [
+      "legacy_slug"
+    ],
+    "aragora-operator/helm/aragora-operator/Chart.yaml": [
+      "legacy_slug"
+    ],
+    "aragora-operator/helm/aragora-operator/values.yaml": [
+      "legacy_slug"
+    ],
+    "aragora-operator/internal/aragora/client.go": [
+      "legacy_slug"
+    ],
+    "aragora-operator/main.go": [
+      "legacy_slug"
+    ],
+    "aragora/live/e2e/admin.spec.ts": [
+      "users_home"
+    ],
+    "benchmarks/bench_readiness/README.md": [
+      "venv_python"
+    ],
+    "benchmarks/bench_readiness/flag_ablation_smoke.py": [
+      "venv_python"
+    ],
+    "benchmarks/bench_readiness/manifest.json": [
+      "users_home",
+      "venv_python"
+    ],
+    "benchmarks/bench_readiness/write_manifest.py": [
+      "venv_python"
+    ],
+    "demos/pr-review/01_sql_injection/expected_comment.md": [
+      "legacy_slug"
+    ],
+    "demos/pr-review/02_caching_tradeoff/expected_comment.md": [
+      "legacy_slug"
+    ],
+    "demos/pr-review/03_async_conversion/expected_comment.md": [
+      "legacy_slug"
+    ],
+    "demos/pr-review/04_error_handling/expected_comment.md": [
+      "legacy_slug"
+    ],
+    "deploy/DEPLOYMENT_CHECKLIST_v2.md": [
+      "legacy_slug"
+    ],
+    "deploy/DEPLOYMENT_PLAN_ARCHIVED.md": [
+      "legacy_slug"
+    ],
+    "deploy/DISASTER_RECOVERY.md": [
+      "legacy_slug"
+    ],
+    "deploy/QUICK_SETUP.md": [
+      "legacy_slug"
+    ],
+    "deploy/argo-rollouts/README.md": [
+      "legacy_slug"
+    ],
+    "deploy/argo-rollouts/rollout.yaml": [
+      "legacy_slug"
+    ],
+    "deploy/argocd/README.md": [
+      "legacy_slug"
+    ],
+    "deploy/argocd/applications/applicationset.yaml": [
+      "legacy_slug"
+    ],
+    "deploy/argocd/install/values.yaml": [
+      "legacy_slug"
+    ],
+    "deploy/argocd/projects/aragora-project.yaml": [
+      "legacy_slug"
+    ],
+    "deploy/docker-compose.production.yml": [
+      "legacy_slug"
+    ],
+    "deploy/docker-compose.yml": [
+      "legacy_slug"
+    ],
+    "deploy/ec2-userdata.sh": [
+      "legacy_slug"
+    ],
+    "deploy/kubernetes/backend-deployment.yaml": [
+      "legacy_slug"
+    ],
+    "deploy/kubernetes/backup-verification-cronjob.yaml": [
+      "legacy_slug"
+    ],
+    "deploy/kubernetes/deployment.yaml": [
+      "legacy_slug"
+    ],
+    "deploy/kubernetes/frontend-deployment.yaml": [
+      "legacy_slug"
+    ],
+    "deploy/kubernetes/migration-job.yaml": [
+      "legacy_slug"
+    ],
+    "deploy/kubernetes/secrets-rotation/cronjob.yaml": [
+      "legacy_slug"
+    ],
+    "deploy/kyverno/README.md": [
+      "legacy_slug"
+    ],
+    "deploy/lightsail-setup.sh": [
+      "legacy_slug"
+    ],
+    "deploy/openclaw/docker-compose.devops.yml": [
+      "legacy_slug"
+    ],
+    "deploy/openclaw/docker-compose.pr-reviewer.yml": [
+      "legacy_slug"
+    ],
+    "deploy/openclaw/pr-reviewer-setup.sh": [
+      "legacy_slug"
+    ],
+    "deploy/quickstart.sh": [
+      "legacy_slug"
+    ],
+    "deploy/self-hosted/.env.example": [
+      "legacy_slug"
+    ],
+    "deploy/self-hosted/README.md": [
+      "legacy_slug"
+    ],
+    "deploy/self-hosted/docker-compose.yml": [
+      "legacy_slug"
+    ],
+    "deploy/systemd/aragora-pr-watcher.service": [
+      "venv_python"
+    ],
+    "docs-site/docs/contributing/tw03-rescue-productization-status.md": [
+      "users_home"
+    ],
+    "docs-site/docs/guides/connectors.md": [
+      "users_home"
+    ],
+    "docs/FOCUS.md": [
+      "users_home"
+    ],
+    "docs/benchmarks/corpus_honesty_audit_2026-04-17.md": [
+      "users_home"
+    ],
+    "docs/briefs/automation-merge-contract.md": [
+      "users_home"
+    ],
+    "docs/briefs/codex-desktop-automation-autonomy.md": [
+      "users_home"
+    ],
+    "docs/examples/boss-lane-manifest-2026-03-19.yaml": [
+      "users_home"
+    ],
+    "docs/examples/decision-quality-delta-benchmark-prompt-pack.yaml": [
+      "users_home"
+    ],
+    "docs/examples/founder-overnight-prompt-pack.yaml": [
+      "users_home"
+    ],
+    "docs/examples/inbox-trust-wedge-activation-prompt-pack.yaml": [
+      "users_home"
+    ],
+    "docs/examples/pmf-tranche-prompt-pack.yaml": [
+      "users_home"
+    ],
+    "docs/experiments/phase0b_role_benchmark/results.csv": [
+      "users_home"
+    ],
+    "docs/experiments/phase0b_role_benchmark/results.json": [
+      "users_home"
+    ],
+    "docs/experiments/phase0b_role_benchmark/runs/phase0b-b3-commit-early-20260318/p-claude_w-codex_r-claude.json": [
+      "users_home"
+    ],
+    "docs/experiments/phase0b_role_benchmark/runs/phase0b-b3-validation-980-20260318/p-claude_w-codex_r-claude.json": [
+      "users_home"
+    ],
+    "docs/experiments/phase0b_role_benchmark/runs/phase0b-b6-matrix-20260317/p-claude_w-claude_r-claude.json": [
+      "users_home"
+    ],
+    "docs/experiments/phase0b_role_benchmark/runs/phase0b-b6-matrix-20260317/p-claude_w-claude_r-codex.json": [
+      "users_home"
+    ],
+    "docs/experiments/phase0b_role_benchmark/runs/phase0b-b6-matrix-20260317/p-claude_w-codex_r-claude.json": [
+      "users_home"
+    ],
+    "docs/experiments/phase0b_role_benchmark/runs/phase0b-b6-matrix-20260317/p-claude_w-codex_r-codex.json": [
+      "users_home"
+    ],
+    "docs/experiments/phase0b_role_benchmark/runs/phase0b-b6-matrix-20260317/p-codex_w-claude_r-claude.json": [
+      "users_home"
+    ],
+    "docs/experiments/phase0b_role_benchmark/runs/phase0b-b6-matrix-20260317/p-codex_w-claude_r-codex.json": [
+      "users_home"
+    ],
+    "docs/experiments/phase0b_role_benchmark/runs/phase0b-b6-matrix-20260317/p-codex_w-codex_r-claude.json": [
+      "users_home"
+    ],
+    "docs/experiments/phase0b_role_benchmark/runs/phase0b-b6-matrix-20260317/p-codex_w-codex_r-codex.json": [
+      "users_home"
+    ],
+    "docs/experiments/phase0b_role_benchmark/runs/phase0b-b6-phase2-20260317/p-claude_w-claude_r-claude.json": [
+      "users_home"
+    ],
+    "docs/experiments/phase0b_role_benchmark/runs/phase0b-b6-phase2-20260317/p-claude_w-codex_r-claude.json": [
+      "users_home"
+    ],
+    "docs/experiments/phase0b_role_benchmark/runs/phase0b-b6-phase2-20260317/p-codex_w-claude_r-claude.json": [
+      "users_home"
+    ],
+    "docs/experiments/phase0b_role_benchmark/runs/phase0b-engine-hardening-rerun-20260318/p-claude_w-codex_r-claude.json": [
+      "users_home"
+    ],
+    "docs/experiments/phase0b_role_benchmark/runs/phase0b-ralph-clean-v5-20260318/p-claude_w-codex_r-claude.json": [
+      "users_home"
+    ],
+    "docs/guides/ISSUE_TRIAGE.md": [
+      "venv_python"
+    ],
+    "docs/index.html": [
+      "legacy_slug"
+    ],
+    "docs/integrations/CONNECTORS.md": [
+      "users_home"
+    ],
+    "docs/missions/H1_DISCIPLINED_MISSION_PROMPT.md": [
+      "users_home"
+    ],
+    "docs/openapi.json": [
+      "legacy_slug"
+    ],
+    "docs/plans/2026-03-01-doc-consolidation-dogfood.md": [
+      "users_home"
+    ],
+    "docs/plans/2026-03-02-ship-and-verify-plan.md": [
+      "users_home"
+    ],
+    "docs/plans/2026-03-05-next-roadmap-items-plan.md": [
+      "users_home"
+    ],
+    "docs/plans/2026-03-05-prove-the-engine.md": [
+      "users_home"
+    ],
+    "docs/plans/2026-03-24-overnight-founder-process.md": [
+      "users_home"
+    ],
+    "docs/plans/2026-04-17-trust-compound-plan.md": [
+      "legacy_slug"
+    ],
+    "docs/plans/2026-04-21-agent-bridge-pr2-scoping.md": [
+      "users_home"
+    ],
+    "docs/plans/2026-04-28-p8-parity-gap-audit.md": [
+      "users_home"
+    ],
+    "docs/plans/dogfood_benchmark_2026-03-01.json": [
+      "users_home"
+    ],
+    "docs/plans/dogfood_benchmark_2026-03-01_final.json": [
+      "users_home"
+    ],
+    "docs/plans/dogfood_benchmark_2026-03-01_post_fix.json": [
+      "users_home"
+    ],
+    "docs/plans/dogfood_benchmark_2026-03-01_rebalanced.json": [
+      "users_home"
+    ],
+    "docs/plans/dogfood_benchmark_2026-03-01_synthesis_guided.json": [
+      "users_home"
+    ],
+    "docs/plans/dogfood_benchmark_2026-03-03.json": [
+      "users_home"
+    ],
+    "docs/plans/dogfood_benchmark_2026-03-06_pipeline_hardening.json": [
+      "users_home"
+    ],
+    "docs/plans/dogfood_timeout3600_single_run_analysis.json": [
+      "users_home"
+    ],
+    "docs/plans/dogfood_timeout_gate_report_2026-02-28.json": [
+      "users_home"
+    ],
+    "docs/plans/dogfood_timeout_gate_report_2026-02-28_5runs_contractfile_timeout600.json": [
+      "users_home"
+    ],
+    "docs/plans/dogfood_timeout_gate_report_2026-02-28_timeout1200_api_roster.json": [
+      "users_home"
+    ],
+    "docs/plans/dogfood_timeout_gate_report_2026-02-28_timeout1200_api_roster_reclassified.json": [
+      "users_home"
+    ],
+    "docs/plans/dogfood_timeout_gate_report_2026-02-28_timeout1800_quality.json": [
+      "users_home"
+    ],
+    "docs/plans/dogfood_timeout_gate_report_2026-02-28_timeout360.json": [
+      "users_home"
+    ],
+    "docs/plans/dogfood_timeout_gate_report_2026-02-28_timeout720_strict.json": [
+      "users_home"
+    ],
+    "docs/prompts/MASTER_FANOUT_PROMPT.md": [
+      "users_home"
+    ],
+    "docs/receipts/heterogeneity/beta-live-rerun-calibrated-20260501T0125Z.receipt.json": [
+      "users_home"
+    ],
+    "docs/receipts/observe-outcomes/2026-05-13-three-model-verification-dialog.jsonl": [
+      "users_home"
+    ],
+    "docs/receipts/paused-writer-remediation-20260517T013316Z.json": [
+      "users_home"
+    ],
+    "docs/runbooks/RUNBOOK_ROOT_GUARD_HYGIENE.md": [
+      "users_home"
+    ],
+    "docs/status/AGENT_FANOUT_JOURNAL.md": [
+      "users_home"
+    ],
+    "docs/status/BACKLOG_Q1_2026_SPRINT_2_PR_PLAN.md": [
+      "users_home"
+    ],
+    "docs/status/P03-lane-registry-claim-helper-rebase_RECEIPT_droid-DC5A5821.md": [
+      "users_home",
+      "venv_python"
+    ],
+    "docs/status/P05-publication-freshness-probe-rebase_RECEIPT_droid-A5312D6A.md": [
+      "users_home",
+      "venv_python"
+    ],
+    "docs/status/P102_HARVEST_RECOVERY_RECEIPT_claude-51C05A58.md": [
+      "users_home"
+    ],
+    "docs/status/P29-steering-mailbox-writer_RECEIPT_claude-86616832.md": [
+      "users_home"
+    ],
+    "docs/status/P45-legacy-worktree-dir-audit-clean_RECEIPT_codex-5B032BF7.md": [
+      "users_home"
+    ],
+    "docs/status/P67_PUBLICATION_FRESHNESS_PROBE_RECEIPT_20260518T193316Z.md": [
+      "users_home"
+    ],
+    "docs/status/P68-cherry-patch-equivalence-sweep_RECEIPT_droid-P68-2B0AEE5B.md": [
+      "users_home"
+    ],
+    "docs/status/P71_MYPY_PREEMPT_RECEIPT_20260518T193210Z.md": [
+      "users_home"
+    ],
+    "docs/status/P72-publish-reconcile-outbox-target-filter_RECEIPT_codex-80DCFB2B.md": [
+      "users_home"
+    ],
+    "docs/status/P73-lane-registry-sweep-cadence_RECEIPT_droid-04B8F610.md": [
+      "users_home"
+    ],
+    "docs/status/Q09-observer-truth-probe_RECEIPT_droid-E288A23E.md": [
+      "users_home"
+    ],
+    "docs/status/SESSION_BRIEF_codex-5B032BF7.md": [
+      "users_home"
+    ],
+    "docs/status/SESSION_BRIEF_codex-80DCFB2B.md": [
+      "users_home"
+    ],
+    "docs/status/SESSION_BRIEF_droid-DC5A5821.md": [
+      "users_home"
+    ],
+    "docs/status/STRUCTURAL_UNJAM_PATH_claude-1843EC1A.md": [
+      "users_home"
+    ],
+    "docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md": [
+      "users_home"
+    ],
+    "docs/status/WORKTREE_VALUE_INVENTORY_STATUS.md": [
+      "users_home"
+    ],
+    "docs/status/aft_manifest_v0.2.json": [
+      "users_home"
+    ],
+    "docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/latest.json": [
+      "users_home"
+    ],
+    "docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/rev-2/scorecard-20260415T221228Z.json": [
+      "users_home"
+    ],
+    "docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/rev-3/latest.json": [
+      "users_home"
+    ],
+    "docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/rev-3/scorecard-20260422T113332Z.json": [
+      "users_home"
+    ],
+    "docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/rev-4/latest.json": [
+      "users_home"
+    ],
+    "docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/rev-4/scorecard-20260430T160156Z.json": [
+      "users_home"
+    ],
+    "docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/rev-4/scorecard-20260515T163115Z.json": [
+      "users_home"
+    ],
+    "docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/rev-4/scorecard-20260517T143651Z.json": [
+      "users_home"
+    ],
+    "docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/rev-4/scorecard-20260521T025329Z.json": [
+      "users_home"
+    ],
+    "docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/rev-5/latest.json": [
+      "users_home"
+    ],
+    "docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/rev-5/scorecard-20260528T171236Z.json": [
+      "users_home"
+    ],
+    "docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/rev-5/scorecard-20260602T235625Z.json": [
+      "users_home"
+    ],
+    "docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/latest.json": [
+      "users_home"
+    ],
+    "docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/rev-2/truth-20260415T221227Z.json": [
+      "users_home"
+    ],
+    "docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/rev-3/latest.json": [
+      "users_home"
+    ],
+    "docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/rev-3/truth-20260422T113322Z.json": [
+      "users_home"
+    ],
+    "docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/rev-3/truth-20260422T113330Z.json": [
+      "users_home"
+    ],
+    "docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/rev-4/latest.json": [
+      "users_home"
+    ],
+    "docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/rev-4/truth-20260430T160155Z.json": [
+      "users_home"
+    ],
+    "docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/rev-4/truth-20260514T194033Z.json": [
+      "users_home"
+    ],
+    "docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/rev-4/truth-20260517T143631Z.json": [
+      "users_home"
+    ],
+    "docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/rev-4/truth-20260517T143642Z.json": [
+      "users_home"
+    ],
+    "docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/rev-4/truth-20260521T025253Z.json": [
+      "users_home"
+    ],
+    "docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/rev-4/truth-20260521T025316Z.json": [
+      "users_home"
+    ],
+    "docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/rev-5/latest.json": [
+      "users_home"
+    ],
+    "docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/rev-5/truth-20260528T171224Z.json": [
+      "users_home"
+    ],
+    "docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/rev-5/truth-20260602T235612Z.json": [
+      "users_home"
+    ],
+    "docs/status/generated/publication_freshness_probe/latest.json": [
+      "users_home"
+    ],
+    "docs/status/generated/publication_freshness_probe/probe-20260517T062448Z.json": [
+      "users_home"
+    ],
+    "docs/status/generated/publication_freshness_probe/probe-20260517T204842Z.json": [
+      "users_home"
+    ],
+    "docs/status/generated/rescue_productization/latest.json": [
+      "users_home"
+    ],
+    "docs/status/generated/rescue_productization/rescue-productization-20260414T194547Z.json": [
+      "users_home"
+    ],
+    "docs/status/generated/rescue_productization/rescue-productization-20260415T044304Z.json": [
+      "users_home"
+    ],
+    "docs/status/generated/rescue_productization/rescue-productization-20260415T230542Z.json": [
+      "users_home"
+    ],
+    "docs/status/generated/rescue_productization/rescue-productization-20260416T150931Z.json": [
+      "users_home"
+    ],
+    "docs/status/generated/rescue_productization/rescue-productization-20260417T124142Z.json": [
+      "users_home"
+    ],
+    "docs/status/generated/rescue_productization/rescue-productization-20260417T125728Z.json": [
+      "users_home"
+    ],
+    "docs/status/generated/rescue_productization/rescue-productization-20260519T035802Z.json": [
+      "users_home"
+    ],
+    "docs/status/generated/rescue_productization/rescue-productization-20260601T165159Z.json": [
+      "users_home"
+    ],
+    "docs/status/generated/worktree_value_inventory/latest.json": [
+      "users_home"
+    ],
+    "docs/status/generated/worktree_value_inventory/worktree-value-inventory-20260517T040800Z.json": [
+      "users_home"
+    ],
+    "docs/status/generated/worktree_value_inventory/worktree-value-inventory-20260518T051014Z.json": [
+      "users_home"
+    ],
+    "docs/status/generated/worktree_value_inventory/worktree-value-inventory-20260518T170310Z.json": [
+      "users_home"
+    ],
+    "docs/status/inventories/codex_worktree_value_20260518T174656Z_droid-56778BD7_include-pr-state.json": [
+      "users_home"
+    ],
+    "examples/github-action/advanced.yml": [
+      "legacy_slug"
+    ],
+    "examples/github-action/aragora-review-strict.yml": [
+      "legacy_slug"
+    ],
+    "examples/github-action/aragora-review.yml": [
+      "legacy_slug"
+    ],
+    "examples/github-action/basic.yml": [
+      "legacy_slug"
+    ],
+    "examples/nextjs-app-router/README.md": [
+      "legacy_slug"
+    ],
+    "examples/quickstart/code_review.py": [
+      "legacy_slug"
+    ],
+    "examples/typescript-web/index.html": [
+      "legacy_slug"
+    ],
+    "openapi.json": [
+      "legacy_slug"
+    ],
+    "pyproject.toml": [
+      "legacy_slug"
+    ],
+    "scripts/_tighten_knowledge_exceptions.py": [
+      "users_home"
+    ],
+    "scripts/audit_branch_backlog_parallel.py": [
+      "users_home"
+    ],
+    "scripts/audit_test_skips.py": [
+      "users_home"
+    ],
+    "scripts/claim_active_agent_lane.py": [
+      "users_home"
+    ],
+    "scripts/create-sprint-worktrees.sh": [
+      "users_home"
+    ],
+    "scripts/demo_design_partner.sh": [
+      "users_home"
+    ],
+    "scripts/disk_recovery_coordinator.py": [
+      "users_home"
+    ],
+    "scripts/inspect_cold_review_surface.py": [
+      "legacy_slug"
+    ],
+    "scripts/install_boss_loop_launchd.sh": [
+      "venv_python"
+    ],
+    "scripts/install_merge_arbiter_launchd.sh": [
+      "venv_python"
+    ],
+    "scripts/pr_check_followup.py": [
+      "users_home"
+    ],
+    "scripts/publish_automation_handoffs.py": [
+      "users_home"
+    ],
+    "scripts/rename_to_aragora.py": [
+      "users_home"
+    ],
+    "scripts/root_guarded_queue.py": [
+      "users_home"
+    ],
+    "scripts/run_boss_cycle.sh": [
+      "venv_python"
+    ],
+    "scripts/run_codex_automation_publisher.sh": [
+      "users_home"
+    ],
+    "scripts/run_codex_insights_digest.sh": [
+      "venv_python"
+    ],
+    "scripts/run_offline_golden_path.sh": [
+      "venv_python"
+    ],
+    "scripts/runners/com.aragora.runner-health.plist": [
+      "users_home"
+    ],
+    "scripts/settle_one_pr.py": [
+      "users_home"
+    ],
+    "scripts/settlement_followup.py": [
+      "users_home"
+    ],
+    "sdk/python/pyproject.toml": [
+      "legacy_slug"
+    ],
+    "sdk/python/tests/test_scim.py": [
+      "users_home"
+    ],
+    "sdk/typescript/package.json": [
+      "legacy_slug"
+    ],
+    "sdk/typescript/src/namespaces/__tests__/scim.test.ts": [
+      "users_home"
+    ],
+    "test_debate.py": [
+      "users_home"
+    ],
+    "tests/agents/test_devops_agent.py": [
+      "legacy_slug"
+    ],
+    "tests/auth/scim/test_scim.py": [
+      "users_home"
+    ],
+    "tests/benchmarks/test_rescue_productization.py": [
+      "users_home"
+    ],
+    "tests/codex/conftest.py": [
+      "users_home"
+    ],
+    "tests/compat/openclaw/test_next_steps_runner.py": [
+      "legacy_slug"
+    ],
+    "tests/debate/test_graph.py": [
+      "users_home"
+    ],
+    "tests/handlers/test_scim_handler.py": [
+      "users_home"
+    ],
+    "tests/nomic/test_dev_coordination.py": [
+      "users_home"
+    ],
+    "tests/ralph/test_classifier.py": [
+      "users_home"
+    ],
+    "tests/review/test_health.py": [
+      "users_home",
+      "venv_python"
+    ],
+    "tests/scripts/test_agent_bridge.py": [
+      "users_home"
+    ],
+    "tests/scripts/test_agent_bridge_sessions.py": [
+      "users_home"
+    ],
+    "tests/scripts/test_claim_active_agent_lane.py": [
+      "users_home"
+    ],
+    "tests/scripts/test_disk_recovery_coordinator.py": [
+      "users_home"
+    ],
+    "tests/scripts/test_identify_lane_owner.py": [
+      "users_home"
+    ],
+    "tests/scripts/test_list_active_agent_sessions.py": [
+      "users_home"
+    ],
+    "tests/scripts/test_probe_boss_loop_launchd.py": [
+      "users_home"
+    ],
+    "tests/scripts/test_render_rescue_productization_status.py": [
+      "users_home"
+    ],
+    "tests/scripts/test_render_worktree_harvest_unblock_map.py": [
+      "users_home"
+    ],
+    "tests/scripts/test_run_proof_first_shift.py": [
+      "users_home"
+    ],
+    "tests/server/handlers/test_scim_handler.py": [
+      "users_home"
+    ],
+    "tests/workflow/test_checkpoint.py": [
+      "users_home"
+    ]
+  }
+}

--- a/tests/scripts/test_check_portability.py
+++ b/tests/scripts/test_check_portability.py
@@ -1,0 +1,102 @@
+"""Tests for scripts/check_portability.py."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+
+
+@pytest.fixture(autouse=True)
+def _setup_path():
+    sys.path.insert(0, str(SCRIPTS_DIR))
+    yield
+    sys.path.remove(str(SCRIPTS_DIR))
+
+
+@pytest.fixture
+def cp():
+    import check_portability
+
+    return check_portability
+
+
+def test_find_violations_detects_each_pattern(cp):
+    assert cp.find_violations_in_text("home is /Users/alice/dev") == {"users_home"}
+    assert cp.find_violations_in_text("exec .venv/bin/python3 foo") == {"venv_python"}
+    assert cp.find_violations_in_text("uses: an0mium/aragora@main") == {"legacy_slug"}
+
+
+def test_find_violations_allows_runner_home(cp):
+    # GitHub-hosted macOS runner home is legitimate.
+    assert cp.find_violations_in_text("/Users/runner/work/aragora") == set()
+
+
+def test_find_violations_clean_text(cp):
+    assert cp.find_violations_in_text("$HOME/dev synaptent/aragora python3") == set()
+
+
+def test_scan_paths_detects_skips_and_binary(cp, tmp_path):
+    (tmp_path / "scripts").mkdir()
+    (tmp_path / "docs" / "audits").mkdir(parents=True)
+    bad = tmp_path / "scripts" / "tool.py"
+    bad.write_text('CWD = "/Users/bob/aragora"\n', encoding="utf-8")
+    # Always-skip: audit docs legitimately quote the patterns.
+    skipped = tmp_path / "docs" / "audits" / "report.md"
+    skipped.write_text("/Users/bob and .venv/bin/python\n", encoding="utf-8")
+    # Binary file must be ignored without error.
+    binary = tmp_path / "blob.bin"
+    binary.write_bytes(b"\x00\xff/Users/bob\x00")
+
+    found = cp.scan_paths(["scripts/tool.py", "docs/audits/report.md", "blob.bin"], root=tmp_path)
+    assert found == {"scripts/tool.py": ["users_home"]}
+
+
+def test_new_violations_filters_baseline(cp):
+    found = {"a.py": ["users_home", "venv_python"], "b.py": ["legacy_slug"]}
+    baseline = {"a.py": ["users_home"]}
+    assert cp.new_violations(found, baseline) == {
+        "a.py": ["venv_python"],
+        "b.py": ["legacy_slug"],
+    }
+
+
+def test_baseline_round_trip(cp, tmp_path):
+    path = tmp_path / "baseline.json"
+    found = {"z.py": ["users_home"], "a.py": ["legacy_slug", "users_home"]}
+    cp.write_baseline(found, path=path)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert list(payload["files"].keys()) == ["a.py", "z.py"]  # sorted
+    assert cp.load_baseline(path) == found
+
+
+def test_main_passes_when_violation_is_baselined(cp, tmp_path, monkeypatch):
+    (tmp_path / "scripts").mkdir()
+    target = tmp_path / "scripts" / "legacy.py"
+    target.write_text('HOME = "/Users/carol/aragora"\n', encoding="utf-8")
+    baseline = tmp_path / "scripts" / "portability_baseline.json"
+    cp.write_baseline({"scripts/legacy.py": ["users_home"]}, path=baseline)
+
+    monkeypatch.setattr(cp, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(cp, "BASELINE_PATH", baseline)
+    monkeypatch.chdir(tmp_path)
+
+    assert cp.main(["scripts/legacy.py"]) == 0
+
+
+def test_main_fails_on_new_violation(cp, tmp_path, monkeypatch):
+    (tmp_path / "scripts").mkdir()
+    target = tmp_path / "scripts" / "fresh.py"
+    target.write_text('HOME = "/Users/dave/aragora"\n', encoding="utf-8")
+    baseline = tmp_path / "scripts" / "portability_baseline.json"
+    cp.write_baseline({}, path=baseline)
+
+    monkeypatch.setattr(cp, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(cp, "BASELINE_PATH", baseline)
+    monkeypatch.chdir(tmp_path)
+
+    assert cp.main(["scripts/fresh.py"]) == 1


### PR DESCRIPTION
## What

PR 0 of the public-readiness remediation: a **non-breaking regression guard** that stops *new* hardcoded private/legacy references from landing.

- `scripts/check_portability.py` — scans tracked files (CI) or staged files (pre-commit) for:
  - `users_home` — private macOS home `/Users/<name>` (CI `/Users/runner` allowed)
  - `venv_python` — `.venv/bin/python` captured as a durable interpreter
  - `legacy_slug` — `an0mium/aragora` (repo is `synaptent/aragora`)
- `scripts/portability_baseline.json` — **244 pre-existing offenders baselined**, so the guard only fails on NEW violations. Prune as Tier A–C PRs land.
- `.pre-commit-config.yaml` — local `portability-guard` hook (staged text files).
- `.github/workflows/portability-lint.yml` — CI full-tree scan.
- `tests/scripts/test_check_portability.py` — 8 unit tests.

## Why

The repo is meant for public use, but install-time/author-machine state leaked into tracked files (152 with `/Users/armand`, 127 with `an0mium`, 14 with `.venv/bin/python`). Without a ratchet, cleanup re-rots. See the audit + plan in #7688.

## Validation

- `python3 scripts/check_portability.py` → exit 0 on the current tree (baselined).
- Planted violation → exit 1 (caught).
- `pytest tests/scripts/test_check_portability.py` → 8 passed.
- `ruff check` + `ruff format --check` clean; pre-commit (incl. the new hook) green.

## Reviewer note

Adds a workflow under `.github/workflows/` (protected surface) — **draft** pending human review per the operating contract. Behavior-preserving; no existing files' logic changed.