### PR TITLE
fix(ci): correct legacy GitHub slug (an0mium/aragora -> synaptent/aragora)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,14 +1,14 @@
 blank_issues_enabled: false
 contact_links:
   - name: Documentation
-    url: https://github.com/an0mium/aragora/tree/main/docs
+    url: https://github.com/synaptent/aragora/tree/main/docs
     about: Browse the full documentation before opening an issue.
   - name: Troubleshooting Guide
-    url: https://github.com/an0mium/aragora/blob/main/docs/deployment/TROUBLESHOOTING.md
+    url: https://github.com/synaptent/aragora/blob/main/docs/deployment/TROUBLESHOOTING.md
     about: Step-by-step troubleshooting for common deployment issues.
   - name: Zero-Config Guide
-    url: https://github.com/an0mium/aragora/blob/main/docs/ZERO_CONFIG.md
+    url: https://github.com/synaptent/aragora/blob/main/docs/ZERO_CONFIG.md
     about: Get started without any API keys.
   - name: Security Advisories (Private Disclosure)
-    url: https://github.com/an0mium/aragora/security/advisories/new
+    url: https://github.com/synaptent/aragora/security/advisories/new
     about: Report critical security vulnerabilities privately.

--- a/.github/actions/aragora-review/README.md
+++ b/.github/actions/aragora-review/README.md
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Review Design
-        uses: an0mium/aragora/.github/actions/aragora-review@main
+        uses: synaptent/aragora/.github/actions/aragora-review@main
         with:
           api-key: ${{ secrets.ARAGORA_API_KEY }}
           file: docs/design.md
@@ -41,7 +41,7 @@ jobs:
 
 ```yaml
 - name: SOX Compliance Review
-  uses: an0mium/aragora/.github/actions/aragora-review@main
+  uses: synaptent/aragora/.github/actions/aragora-review@main
   with:
     api-key: ${{ secrets.ARAGORA_API_KEY }}
     file: docs/financial-system.md
@@ -53,7 +53,7 @@ jobs:
 
 ```yaml
 - name: HIPAA Compliance Review
-  uses: an0mium/aragora/.github/actions/aragora-review@main
+  uses: synaptent/aragora/.github/actions/aragora-review@main
   with:
     api-key: ${{ secrets.ARAGORA_API_KEY }}
     file: docs/patient-data-flow.md
@@ -65,7 +65,7 @@ jobs:
 
 ```yaml
 - name: PCI-DSS Review
-  uses: an0mium/aragora/.github/actions/aragora-review@main
+  uses: synaptent/aragora/.github/actions/aragora-review@main
   with:
     api-key: ${{ secrets.ARAGORA_API_KEY }}
     file: docs/payment-processing.md

--- a/.github/workflows/nightly-integration.yml
+++ b/.github/workflows/nightly-integration.yml
@@ -15,7 +15,7 @@ jobs:
     name: Live Debate E2E
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: github.repository == 'an0mium/aragora'
+    if: github.repository == 'synaptent/aragora'
 
     steps:
       - name: Checkout

--- a/.github/workflows/publish-aragora-debate.yml
+++ b/.github/workflows/publish-aragora-debate.yml
@@ -202,7 +202,7 @@ jobs:
             python -m pip install "aragora-debate[all]==${{ needs.resolve-version.outputs.version }}"
             ```
 
-            [Changelog](https://github.com/an0mium/aragora/blob/main/aragora-debate/CHANGELOG.md) |
-            [README](https://github.com/an0mium/aragora/tree/main/aragora-debate)
+            [Changelog](https://github.com/synaptent/aragora/blob/main/aragora-debate/CHANGELOG.md) |
+            [README](https://github.com/synaptent/aragora/tree/main/aragora-debate)
           draft: false
           prerelease: ${{ contains(needs.resolve-version.outputs.version, 'beta') || contains(needs.resolve-version.outputs.version, 'alpha') || contains(needs.resolve-version.outputs.version, 'rc') }}

--- a/.github/workflows/templates/aragora-gauntlet-template.yml
+++ b/.github/workflows/templates/aragora-gauntlet-template.yml
@@ -8,7 +8,7 @@
 #   - api-design-review: REST API best practices
 #   - architecture-stress-test: Scalability assessment
 #
-# Documentation: https://github.com/an0mium/aragora/blob/main/docs/GITHUB_ACTIONS.md
+# Documentation: https://github.com/synaptent/aragora/blob/main/docs/GITHUB_ACTIONS.md
 
 name: Aragora Gauntlet Security Audit
 
@@ -194,7 +194,7 @@ jobs:
           echo "View the full report in the workflow artifacts." >> ./artifacts/summary.md
           echo "" >> ./artifacts/summary.md
           echo "---" >> ./artifacts/summary.md
-          echo "*Powered by [Aragora Gauntlet](https://github.com/an0mium/aragora)*" >> ./artifacts/summary.md
+          echo "*Powered by [Aragora Gauntlet](https://github.com/synaptent/aragora)*" >> ./artifacts/summary.md
 
       - name: Upload Artifacts
         if: steps.check-keys.outputs.has_keys == 'true'

--- a/.github/workflows/templates/aragora-review-template.yml
+++ b/.github/workflows/templates/aragora-review-template.yml
@@ -5,7 +5,7 @@
 #   1. Add API key secrets (at least one): ANTHROPIC_API_KEY, OPENAI_API_KEY, OPENROUTER_API_KEY
 #   2. Copy this file to: .github/workflows/aragora-review.yml
 #
-# Documentation: https://github.com/an0mium/aragora/blob/main/docs/GITHUB_ACTIONS.md
+# Documentation: https://github.com/synaptent/aragora/blob/main/docs/GITHUB_ACTIONS.md
 
 name: Aragora AI Code Review
 


### PR DESCRIPTION
## What

PR 1 of the public-readiness remediation. Replaces **14 stale `an0mium/aragora` references** across `.github/` with the canonical **`synaptent/aragora`**.

| File | Hits |
|---|---|
| `ISSUE_TEMPLATE/config.yml` | 4 help URLs |
| `actions/aragora-review/README.md` | 4 `uses:` examples |
| `workflows/nightly-integration.yml` | 1 — **the gating bug** |
| `workflows/publish-aragora-debate.yml` | 2 changelog/readme URLs |
| `workflows/templates/aragora-gauntlet-template.yml` | 2 doc/attribution URLs |
| `workflows/templates/aragora-review-template.yml` | 1 doc URL |

## Why — active bug, not cosmetic

`nightly-integration.yml` was gated:

```yaml
if: github.repository == 'an0mium/aragora'
```

The canonical repo is `synaptent/aragora`, so **the nightly integration workflow never ran**. Now fixed to `== 'synaptent/aragora'`. The issue-template and README/template URLs also pointed users at a non-canonical repo.

## Scope / non-goals

- **Kept** personal `@an0mium` handles in `CODEOWNERS` and the `benchmark.yml` alert CC — these are legitimate owner references per the owner-identity decision, not wrong repo slugs.
- 1:1 substitution only (14 insertions / 14 deletions); no logic changes.

## Validation

- `git grep 'an0mium/aragora' -- .github/` → **none remain**.
- All changed YAML parses cleanly.
- pre-commit (check-yaml, gitleaks, etc.) green.

## Notes

- Touches `.github/workflows/**` (protected surface) → **draft** pending human review per the operating contract.
- Follows the audit/plan in #7688 and the regression guard in #7690 (the guard's `legacy_slug` check will keep this from regressing once merged).