### PR TITLE
docs(b0): surface live expected issue state

### DIFF
--- a/docs/status/B0_BENCHMARK_TRUTH_STATUS.md
+++ b/docs/status/B0_BENCHMARK_TRUTH_STATUS.md
@@ -40,7 +40,9 @@ This is the repo-tracked recurring `TW-02` publication surface for the fixed ben
 | In-progress attempted issues | 8 |
 | In-progress successful issues | 2 |
 | In-progress graduation rate | 25.0% |
-| In-progress issue numbers | `#5426`, `#5427`, `#5428`, `#5764`, `#5789`, `#5790`, `#5839`, `#5844` |
+| Expected in-progress issue numbers | `#5426`, `#5427`, `#5428`, `#5764`, `#5789`, `#5790`, `#5839`, `#5844` |
+| Live-open expected issue numbers | `#5428`, `#5764`, `#5789`, `#5790`, `#5839`, `#5844` |
+| Live-closed expected issue numbers | `#5426`, `#5427` |
 
 ## Proxy Metrics
 

--- a/scripts/render_benchmark_truth_status.py
+++ b/scripts/render_benchmark_truth_status.py
@@ -166,6 +166,20 @@ def _format_issue_numbers(values: Any) -> str:
     return ", ".join(f"`#{value}`" for value in sorted(issue_numbers))
 
 
+def _issue_numbers_for_records(records: list[dict[str, Any]], *, state: str) -> list[int]:
+    normalized_state = state.strip().upper()
+    issue_numbers: list[int] = []
+    for record in records:
+        if str(record.get("expected_status") or "").strip() != "in_progress":
+            continue
+        if str(record.get("issue_state") or "").strip().upper() != normalized_state:
+            continue
+        issue_number = record.get("issue_number")
+        if isinstance(issue_number, int) and issue_number > 0:
+            issue_numbers.append(issue_number)
+    return sorted(issue_numbers)
+
+
 def _render_stale_closed_issues(issues: list[dict[str, Any]]) -> list[str]:
     lines: list[str] = []
     for issue in issues:
@@ -302,6 +316,9 @@ def render_status_markdown(
     failure_distribution = dict(scorecard_payload.get("failure_class_distribution") or {})
     rescue_counts = dict(scorecard_payload.get("rescue_counts_by_type") or {})
     neutral_classes = dict(proxy_metrics.get("neutral_classes") or {})
+    issue_records = [
+        item for item in list(truth_payload.get("issues") or []) if isinstance(item, dict)
+    ]
     corpus_freshness = dict(truth_payload.get("corpus_freshness") or {})
     stale_closed_issues = [
         item
@@ -414,8 +431,16 @@ def render_status_markdown(
                     f"{_format_percent(in_flight_metrics.get('in_progress_graduation_rate'))} |"
                 ),
                 (
-                    "| In-progress issue numbers | "
+                    "| Expected in-progress issue numbers | "
                     f"{_format_issue_numbers(in_flight_metrics.get('in_progress_issue_numbers'))} |"
+                ),
+                (
+                    "| Live-open expected issue numbers | "
+                    f"{_format_issue_numbers(_issue_numbers_for_records(issue_records, state='OPEN'))} |"
+                ),
+                (
+                    "| Live-closed expected issue numbers | "
+                    f"{_format_issue_numbers(_issue_numbers_for_records(issue_records, state='CLOSED'))} |"
                 ),
             ]
         )

--- a/tests/benchmarks/test_truth_surface_consistency.py
+++ b/tests/benchmarks/test_truth_surface_consistency.py
@@ -90,9 +90,10 @@ def _optional_section_bullets(markdown: str, section: str) -> dict[str, int]:
     return _section_bullets(markdown, section)
 
 
-def _percent_to_rate(value: str) -> float:
-    assert value.endswith("%")
-    return round(float(value[:-1]) / 100.0, 6)
+def _format_percent(value: Any) -> str:
+    if isinstance(value, (int, float)):
+        return f"{float(value):.1%}"
+    return "n/a"
 
 
 def _int_value(value: str) -> int:
@@ -147,17 +148,17 @@ def test_b0_benchmark_truth_status_matches_latest_json_artifacts() -> None:
     assert int(coverage_match.group("total")) == corpus["issue_count"]
 
     truth_metrics = _table(markdown, "Truth Metrics")
-    assert _percent_to_rate(truth_metrics["Verified truth success rate (primary)"]) == round(
-        scorecard_payload["truth_metrics"]["truth_success_rate_verified"], 6
+    assert truth_metrics["Verified truth success rate (primary)"] == _format_percent(
+        scorecard_payload["truth_metrics"]["truth_success_rate_verified"]
     )
-    assert _percent_to_rate(
-        truth_metrics["Full-corpus truth success rate (legacy/context)"]
-    ) == round(scorecard_payload["truth_metrics"]["truth_success_rate"], 6)
-    assert _percent_to_rate(truth_metrics["No-rescue truth success rate"]) == round(
-        scorecard_payload["truth_metrics"]["no_rescue_truth_success_rate"], 6
+    assert truth_metrics["Full-corpus truth success rate (legacy/context)"] == _format_percent(
+        scorecard_payload["truth_metrics"]["truth_success_rate"]
     )
-    assert _percent_to_rate(truth_metrics["Merged-only rate"]) == round(
-        scorecard_payload["truth_metrics"]["merged_only_rate"], 6
+    assert truth_metrics["No-rescue truth success rate"] == _format_percent(
+        scorecard_payload["truth_metrics"]["no_rescue_truth_success_rate"]
+    )
+    assert truth_metrics["Merged-only rate"] == _format_percent(
+        scorecard_payload["truth_metrics"]["merged_only_rate"]
     )
     assert scorecard_payload["truth_metrics"] == truth_payload["primary_metrics"]
     assert scorecard_payload["truth_artifact_generated_at"] == truth_payload["generated_at"]
@@ -176,18 +177,33 @@ def test_b0_benchmark_truth_status_matches_latest_json_artifacts() -> None:
         _int_value(in_flight_metrics["In-progress successful issues"])
         == in_flight_payload["in_progress_success_count"]
     )
-    assert _percent_to_rate(in_flight_metrics["In-progress graduation rate"]) == round(
-        in_flight_payload["in_progress_graduation_rate"], 6
+    assert in_flight_metrics["In-progress graduation rate"] == _format_percent(
+        in_flight_payload["in_progress_graduation_rate"]
     )
     assert (
-        _issue_numbers(in_flight_metrics["In-progress issue numbers"])
+        _issue_numbers(in_flight_metrics["Expected in-progress issue numbers"])
         == (in_flight_payload["in_progress_issue_numbers"])
+    )
+    in_progress_records = [
+        record
+        for record in truth_payload["issues"]
+        if record.get("expected_status") == "in_progress"
+    ]
+    assert _issue_numbers(in_flight_metrics["Live-open expected issue numbers"]) == sorted(
+        record["issue_number"]
+        for record in in_progress_records
+        if record.get("issue_state") == "OPEN"
+    )
+    assert _issue_numbers(in_flight_metrics["Live-closed expected issue numbers"]) == sorted(
+        record["issue_number"]
+        for record in in_progress_records
+        if record.get("issue_state") == "CLOSED"
     )
 
     proxy_metrics = _table(markdown, "Proxy Metrics")
     proxy_payload = scorecard_payload["proxy_metrics"]
-    assert _percent_to_rate(proxy_metrics["Proxy no-rescue success rate"]) == round(
-        proxy_payload["no_rescue_success_rate"], 6
+    assert proxy_metrics["Proxy no-rescue success rate"] == _format_percent(
+        proxy_payload["no_rescue_success_rate"]
     )
     assert (
         _int_value(proxy_metrics["Unique issues attempted"])

--- a/tests/scripts/test_render_benchmark_truth_status.py
+++ b/tests/scripts/test_render_benchmark_truth_status.py
@@ -219,6 +219,23 @@ def test_render_status_markdown_headlines_verified_rate_and_in_flight_metrics(
                 "in_progress_graduation_rate": 0.0,
                 "in_progress_issue_numbers": [5814],
             },
+            "issues": [
+                {
+                    "expected_status": "in_progress",
+                    "issue_number": 5814,
+                    "issue_state": "OPEN",
+                },
+                {
+                    "expected_status": "in_progress",
+                    "issue_number": 5815,
+                    "issue_state": "CLOSED",
+                },
+                {
+                    "expected_status": "verified",
+                    "issue_number": 5800,
+                    "issue_state": "CLOSED",
+                },
+            ],
         },
         scorecard_payload={
             "generated_at": "2026-04-17T06:05:00Z",
@@ -256,7 +273,9 @@ def test_render_status_markdown_headlines_verified_rate_and_in_flight_metrics(
     assert "| In-progress attempted issues | 0 |" in markdown
     assert "| In-progress successful issues | 0 |" in markdown
     assert "| In-progress graduation rate | 0.0% |" in markdown
-    assert "| In-progress issue numbers | `#5814` |" in markdown
+    assert "| Expected in-progress issue numbers | `#5814` |" in markdown
+    assert "| Live-open expected issue numbers | `#5814` |" in markdown
+    assert "| Live-closed expected issue numbers | `#5815` |" in markdown
 
 
 def test_render_status_markdown_surfaces_proxy_neutral_issue_classes(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Clarifies B0 in-flight graduation metrics by renaming the static corpus bucket to expected in-progress issue numbers.
- Adds live-open and live-closed expected issue rows derived from the current truth artifact.
- Regenerates B0 status so #5426/#5427 are visibly live-closed while remaining in the expected in-progress corpus bucket until a future corpus revision promotes them.

## Tests
- python3 -m pytest -q tests/scripts/test_render_benchmark_truth_status.py tests/benchmarks/test_truth_surface_consistency.py
- python3 scripts/probe_proof_surface_freshness.py --max-age-days 7 --pretty
- git diff --check origin/main...HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD
