### PR TITLE
fix(runtime): resolve service interpreter at runtime, not install time

### DIFF
--- a/deploy/systemd/aragora-pr-watcher.service
+++ b/deploy/systemd/aragora-pr-watcher.service
@@ -9,7 +9,9 @@ User=aragora
 Group=aragora
 WorkingDirectory=/opt/aragora
 EnvironmentFile=-/etc/aragora/pr-watcher.env
-ExecStart=/opt/aragora/.venv/bin/python -m aragora.compat.openclaw.pr_watch_daemon
+# Resolves the interpreter at runtime (prefers /opt/aragora/.venv, falls back to
+# system python3); pin ARAGORA_PYTHON in the EnvironmentFile above to override.
+ExecStart=/opt/aragora/scripts/run_pr_watch.sh
 Restart=on-failure
 RestartSec=30
 StandardOutput=journal

--- a/scripts/aragora_runtime.sh
+++ b/scripts/aragora_runtime.sh
@@ -1,0 +1,86 @@
+# shellcheck shell=bash
+# Shared Aragora runtime helpers. Source this file; do not execute it.
+#
+#   source "$(dirname "$0")/aragora_runtime.sh"
+#   PYTHON_BIN="$(resolve_aragora_python 'import pydantic' 'aragora' 'aragora runtime')"
+#
+# resolve_aragora_python resolves a usable interpreter AT RUNTIME so a moved or
+# removed .venv degrades gracefully instead of breaking a long-running launchd/
+# systemd service. Installers must call this at launch time (via a wrapper),
+# never bake an absolute interpreter path into the generated unit.
+
+# Determine the repository root. Honors ARAGORA_REPO_ROOT, otherwise derives it
+# from this file's location (scripts/.. == repo root) regardless of the caller.
+aragora_repo_root() {
+    if [[ -n "${ARAGORA_REPO_ROOT:-}" && -d "${ARAGORA_REPO_ROOT}" ]]; then
+        printf '%s\n' "${ARAGORA_REPO_ROOT}"
+        return 0
+    fi
+    (cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+}
+
+# Return 0 if interpreter $1 is executable and can run probe $2 from dir $3.
+# An empty probe accepts any executable interpreter (no import check).
+_aragora_python_ok() {
+    local interp="$1"
+    local probe="$2"
+    local root="$3"
+    [[ -n "${interp}" && -x "${interp}" ]] || return 1
+    (cd "${root}" && "${interp}" -c "${probe}" >/dev/null 2>&1)
+}
+
+# resolve_aragora_python [probe] [import_label] [runtime_label]
+#
+# Echoes the path of the first usable interpreter; returns 1 with a diagnostic
+# if none qualify. Resolution order:
+#   1. $ARAGORA_PYTHON   2. <repo>/.venv/bin/python3   3. python3
+#   4. python            5. pyenv which python3
+resolve_aragora_python() {
+    local probe="${1-import pydantic}"
+    local import_label="${2:-aragora}"
+    local runtime_label="${3:-aragora runtime}"
+    local repo_root
+    local candidate=""
+    local python_cmd=""
+    local candidates=()
+    repo_root="$(aragora_repo_root)"
+
+    if [[ -n "${ARAGORA_PYTHON:-}" ]]; then
+        if _aragora_python_ok "${ARAGORA_PYTHON}" "${probe}" "${repo_root}"; then
+            printf '%s\n' "${ARAGORA_PYTHON}"
+            return 0
+        fi
+        echo "Skipping ARAGORA_PYTHON without usable ${import_label} imports: ${ARAGORA_PYTHON}" >&2
+    fi
+
+    if [[ -x "${repo_root}/.venv/bin/python3" ]]; then
+        candidates+=("${repo_root}/.venv/bin/python3")
+    fi
+    if python_cmd="$(command -v python3 2>/dev/null)"; then
+        candidates+=("${python_cmd}")
+    fi
+    if python_cmd="$(command -v python 2>/dev/null)"; then
+        candidates+=("${python_cmd}")
+    fi
+    if command -v pyenv >/dev/null 2>&1; then
+        python_cmd="$(pyenv which python3 2>/dev/null || true)"
+        if [[ -n "${python_cmd}" ]]; then
+            candidates+=("${python_cmd}")
+        fi
+    fi
+
+    if [[ ${#candidates[@]} -gt 0 ]]; then
+        for candidate in "${candidates[@]}"; do
+            if _aragora_python_ok "${candidate}" "${probe}" "${repo_root}"; then
+                printf '%s\n' "${candidate}"
+                return 0
+            fi
+            echo "Skipping Python candidate without usable ${import_label} imports: ${candidate}" >&2
+        done
+    fi
+
+    echo "No usable python interpreter with pydantic and ${import_label} imports found for ${runtime_label}." >&2
+    echo "  Tried: \$ARAGORA_PYTHON, ${repo_root}/.venv/bin/python3, python3, python, pyenv." >&2
+    echo "  Set ARAGORA_PYTHON to a working interpreter or install deps (e.g. pip install -e .)." >&2
+    return 1
+}

--- a/scripts/install_boss_loop_launchd.sh
+++ b/scripts/install_boss_loop_launchd.sh
@@ -67,44 +67,8 @@ trim_text() {
     printf '%s' "$1" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
 }
 
-resolve_python_bin() {
-    local candidates=()
-    local candidate=""
-    local python_cmd=""
-
-    if [[ -n "${ARAGORA_PYTHON:-}" ]]; then
-        candidates+=("${ARAGORA_PYTHON}")
-    fi
-    if [[ -x "${REPO_ROOT}/.venv/bin/python3" ]]; then
-        candidates+=("${REPO_ROOT}/.venv/bin/python3")
-    fi
-    if python_cmd="$(command -v python3 2>/dev/null)"; then
-        candidates+=("${python_cmd}")
-    fi
-    if python_cmd="$(command -v python 2>/dev/null)"; then
-        candidates+=("${python_cmd}")
-    fi
-    for candidate in "${candidates[@]}"; do
-        if [[ -z "${candidate}" || ! -x "${candidate}" ]]; then
-            continue
-        fi
-        if "${candidate}" -c 'import pydantic' >/dev/null 2>&1; then
-            printf '%s\n' "${candidate}"
-            return 0
-        fi
-    done
-
-    if command -v pyenv >/dev/null 2>&1; then
-        candidate="$(pyenv which python3 2>/dev/null || true)"
-        if [[ -n "${candidate}" && -x "${candidate}" ]] && "${candidate}" -c 'import pydantic' >/dev/null 2>&1; then
-            printf '%s\n' "${candidate}"
-            return 0
-        fi
-    fi
-
-    echo "No usable python interpreter with pydantic found for boss-loop launchd install." >&2
-    exit 2
-}
+# shellcheck source=scripts/aragora_runtime.sh
+source "${REPO_ROOT}/scripts/aragora_runtime.sh"
 
 validate_integer() {
     local label="$1"
@@ -250,9 +214,10 @@ mkdir -p "$(dirname "${PLIST_PATH}")"
 mkdir -p "$(dirname "${LOG_PATH}")"
 mkdir -p "${REPO_ROOT}/.aragora/overnight"
 
-PYTHON_BIN="$(resolve_python_bin)"
-PYTHON_DIR="$(dirname "${PYTHON_BIN}")"
-command_string="cd \"${REPO_ROOT}\" && export PATH=\"${PYTHON_DIR}:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:\$PATH\" && export ARAGORA_USER_ID=\"${ARAGORA_USER_ID}\" && export ARAGORA_WORKSPACE_ID=\"${ARAGORA_WORKSPACE_ID}\" && export ARAGORA_PYTHON=\"${PYTHON_BIN}\""
+if ! INSTALL_PYTHON="$(resolve_aragora_python 'import pydantic' 'boss-loop' 'boss-loop launchd install')"; then
+    exit 2
+fi
+command_string="cd \"${REPO_ROOT}\" && export PATH=\"/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:\$HOME/.pyenv/shims:\$PATH\" && export ARAGORA_USER_ID=\"${ARAGORA_USER_ID}\" && export ARAGORA_WORKSPACE_ID=\"${ARAGORA_WORKSPACE_ID}\""
 if [[ -n "${ARAGORA_CLAUDE_PROFILE}" ]]; then
     command_string="${command_string} && export ARAGORA_CLAUDE_PROFILE=\"${ARAGORA_CLAUDE_PROFILE}\""
 fi
@@ -309,6 +274,7 @@ launchctl load "${PLIST_PATH}"
 echo "Installed launchd job: ${LABEL}"
 echo "Plist: ${PLIST_PATH}"
 echo "Log: ${LOG_PATH}"
-echo "Python: ${PYTHON_BIN}"
+echo "Python (install-time check): ${INSTALL_PYTHON}"
+echo "Interpreter is resolved at runtime via scripts/aragora_runtime.sh"
 echo "Boss repo: ${BOSS_REPO}"
 echo "Labels: ${LABELS[*]}"

--- a/scripts/install_merge_arbiter_launchd.sh
+++ b/scripts/install_merge_arbiter_launchd.sh
@@ -38,44 +38,8 @@ Options:
 EOF
 }
 
-resolve_python_bin() {
-    local candidates=()
-    local candidate=""
-    local python_cmd=""
-
-    if [[ -n "${ARAGORA_PYTHON:-}" ]]; then
-        candidates+=("${ARAGORA_PYTHON}")
-    fi
-    if [[ -x "${REPO_ROOT}/.venv/bin/python3" ]]; then
-        candidates+=("${REPO_ROOT}/.venv/bin/python3")
-    fi
-    if python_cmd="$(command -v python3 2>/dev/null)"; then
-        candidates+=("${python_cmd}")
-    fi
-    if python_cmd="$(command -v python 2>/dev/null)"; then
-        candidates+=("${python_cmd}")
-    fi
-    for candidate in "${candidates[@]}"; do
-        if [[ -z "${candidate}" || ! -x "${candidate}" ]]; then
-            continue
-        fi
-        if "${candidate}" -c 'import pydantic' >/dev/null 2>&1; then
-            printf '%s\n' "${candidate}"
-            return 0
-        fi
-    done
-
-    if command -v pyenv >/dev/null 2>&1; then
-        candidate="$(pyenv which python3 2>/dev/null || true)"
-        if [[ -n "${candidate}" && -x "${candidate}" ]] && "${candidate}" -c 'import pydantic' >/dev/null 2>&1; then
-            printf '%s\n' "${candidate}"
-            return 0
-        fi
-    fi
-
-    echo "No usable python interpreter with pydantic found for merge-arbiter launchd install." >&2
-    exit 2
-}
+# shellcheck source=scripts/aragora_runtime.sh
+source "${REPO_ROOT}/scripts/aragora_runtime.sh"
 
 validate_integer() {
     local label="$1"
@@ -156,9 +120,10 @@ mkdir -p "$(dirname "${PLIST_PATH}")"
 mkdir -p "$(dirname "${LOG_PATH}")"
 mkdir -p "${REPO_ROOT}/.aragora/overnight"
 
-PYTHON_BIN="$(resolve_python_bin)"
-PYTHON_DIR="$(dirname "${PYTHON_BIN}")"
-command_string="cd \"${REPO_ROOT}\" && export PATH=\"${PYTHON_DIR}:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:\$PATH\" && export ARAGORA_USER_ID=\"${ARAGORA_USER_ID}\" && export ARAGORA_WORKSPACE_ID=\"${ARAGORA_WORKSPACE_ID}\" && export ARAGORA_PYTHON=\"${PYTHON_BIN}\" && exec \"${PYTHON_BIN}\" -u -m aragora.cli.main swarm merge-arbiter --boss-repo \"${BOSS_REPO}\" --branch-prefix \"${BRANCH_PREFIXES}\" --interval \"${INTERVAL_SECONDS}\" --max-hours \"${MAX_HOURS}\" --max-consecutive-failures \"${MAX_CONSECUTIVE_FAILURES}\""
+if ! INSTALL_PYTHON="$(resolve_aragora_python 'import pydantic' 'merge-arbiter' 'merge-arbiter launchd install')"; then
+    exit 2
+fi
+command_string="cd \"${REPO_ROOT}\" && export PATH=\"/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:\$HOME/.pyenv/shims:\$PATH\" && export ARAGORA_USER_ID=\"${ARAGORA_USER_ID}\" && export ARAGORA_WORKSPACE_ID=\"${ARAGORA_WORKSPACE_ID}\" && exec \"${REPO_ROOT}/scripts/run_merge_arbiter.sh\" --boss-repo \"${BOSS_REPO}\" --branch-prefix \"${BRANCH_PREFIXES}\" --interval \"${INTERVAL_SECONDS}\" --max-hours \"${MAX_HOURS}\" --max-consecutive-failures \"${MAX_CONSECUTIVE_FAILURES}\""
 if [[ "${DRY_RUN}" == true ]]; then
     command_string="${command_string} --dry-run"
 fi
@@ -200,5 +165,6 @@ launchctl load "${PLIST_PATH}"
 echo "Installed launchd job: ${LABEL}"
 echo "Plist: ${PLIST_PATH}"
 echo "Log: ${LOG_PATH}"
-echo "Python: ${PYTHON_BIN}"
+echo "Python (install-time check): ${INSTALL_PYTHON}"
+echo "Interpreter is resolved at runtime via scripts/aragora_runtime.sh"
 echo "Branch prefixes: ${BRANCH_PREFIXES}"

--- a/scripts/run_boss_cycle.sh
+++ b/scripts/run_boss_cycle.sh
@@ -9,53 +9,8 @@ POST_LOOP_LABEL="${ARAGORA_POST_LOOP_LABEL:-}"
 boss_repo=""
 boss_label=""
 
-resolve_python_bin() {
-    local candidates=()
-    local candidate=""
-    local python_cmd=""
-    local probe='import pydantic; import aragora.cli.commands.swarm'
-
-    if [[ -n "${ARAGORA_PYTHON:-}" ]]; then
-        if [[ -x "${ARAGORA_PYTHON}" ]]; then
-            printf '%s\n' "${ARAGORA_PYTHON}"
-            return 0
-        fi
-        echo "ARAGORA_PYTHON is set but not executable: ${ARAGORA_PYTHON}" >&2
-    fi
-    if [[ -x "${REPO_ROOT}/.venv/bin/python3" ]]; then
-        candidates+=("${REPO_ROOT}/.venv/bin/python3")
-    fi
-    if python_cmd="$(command -v python3 2>/dev/null)"; then
-        candidates+=("${python_cmd}")
-    fi
-    if python_cmd="$(command -v python 2>/dev/null)"; then
-        candidates+=("${python_cmd}")
-    fi
-    for candidate in "${candidates[@]}"; do
-        if [[ -z "${candidate}" || ! -x "${candidate}" ]]; then
-            continue
-        fi
-        if (cd "${REPO_ROOT}" && "${candidate}" -c "${probe}" >/dev/null 2>&1); then
-            printf '%s\n' "${candidate}"
-            return 0
-        fi
-        echo "Skipping Python candidate without usable boss-loop imports: ${candidate}" >&2
-    done
-
-    if command -v pyenv >/dev/null 2>&1; then
-        candidate="$(pyenv which python3 2>/dev/null || true)"
-        if [[ -n "${candidate}" && -x "${candidate}" ]] && (cd "${REPO_ROOT}" && "${candidate}" -c "${probe}" >/dev/null 2>&1); then
-            printf '%s\n' "${candidate}"
-            return 0
-        fi
-        if [[ -n "${candidate}" && -x "${candidate}" ]]; then
-            echo "Skipping Python candidate without usable boss-loop imports: ${candidate}" >&2
-        fi
-    fi
-
-    echo "No usable python interpreter with pydantic and boss-loop imports found for boss-loop runtime." >&2
-    return 1
-}
+# shellcheck source=scripts/aragora_runtime.sh
+source "${REPO_ROOT}/scripts/aragora_runtime.sh"
 
 args=("$@")
 for ((i = 0; i < ${#args[@]}; i++)); do
@@ -75,7 +30,7 @@ done
 
 boss_repo="${boss_repo:-synaptent/aragora}"
 boss_label="${POST_LOOP_LABEL:-${boss_label:-boss-ready}}"
-PYTHON_BIN="$(resolve_python_bin)"
+PYTHON_BIN="$(resolve_aragora_python 'import pydantic; import aragora.cli.commands.swarm' 'boss-loop' 'boss-loop runtime')"
 
 cd "${REPO_ROOT}"
 

--- a/scripts/run_codex_insights_digest.sh
+++ b/scripts/run_codex_insights_digest.sh
@@ -13,23 +13,18 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "${REPO_ROOT}"
+# shellcheck source=scripts/aragora_runtime.sh
+source "${REPO_ROOT}/scripts/aragora_runtime.sh"
 
 SINCE="${ARAGORA_CODEX_INSIGHTS_SINCE:-1h}"
 INGEST_KM="${ARAGORA_CODEX_INSIGHTS_INGEST_KM:-1}"
 RECEIPT_DIR="${ARAGORA_CODEX_INSIGHTS_RECEIPT_DIR:-${REPO_ROOT}/.aragora/codex_insights}"
-ARAGORA_PYTHON="${ARAGORA_PYTHON:-}"
 
 mkdir -p "${RECEIPT_DIR}"
 
-if [[ -z "${ARAGORA_PYTHON}" ]]; then
-    if [[ -x "${REPO_ROOT}/.venv/bin/python3" ]]; then
-        ARAGORA_PYTHON="${REPO_ROOT}/.venv/bin/python3"
-    elif command -v python3 >/dev/null 2>&1; then
-        ARAGORA_PYTHON="$(command -v python3)"
-    else
-        echo "$(date -u +'%Y-%m-%dT%H:%M:%SZ') ERROR: no python3 found" >&2
-        exit 2
-    fi
+if ! ARAGORA_PYTHON="$(resolve_aragora_python 'import pydantic' 'codex-insights' 'codex insights digest')"; then
+    echo "$(date -u +'%Y-%m-%dT%H:%M:%SZ') ERROR: no usable python3 found" >&2
+    exit 2
 fi
 
 DIGEST_ARGS=(codex insights digest "--since" "${SINCE}" "--emit-receipt" "--receipt-dir" "${RECEIPT_DIR}")

--- a/scripts/run_merge_arbiter.sh
+++ b/scripts/run_merge_arbiter.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Resolve the Python interpreter at runtime, then run the swarm merge-arbiter.
+# Used as the launchd entrypoint so a moved/removed .venv degrades gracefully
+# instead of breaking the service with a stale interpreter path.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# shellcheck source=scripts/aragora_runtime.sh
+source "${REPO_ROOT}/scripts/aragora_runtime.sh"
+
+PYTHON_BIN="$(resolve_aragora_python 'import pydantic; import aragora.cli.commands.swarm' 'merge-arbiter' 'merge-arbiter runtime')"
+
+cd "${REPO_ROOT}"
+echo "Starting swarm merge-arbiter..."
+echo "Using Python interpreter: ${PYTHON_BIN}"
+exec "${PYTHON_BIN}" -u -m aragora.cli.main swarm merge-arbiter "$@"

--- a/scripts/run_pr_watch.sh
+++ b/scripts/run_pr_watch.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Resolve the Python interpreter at runtime, then run the PR watch daemon.
+# Used as the systemd ExecStart entrypoint so the unit no longer hardcodes an
+# absolute interpreter path; an operator can still pin ARAGORA_PYTHON via the
+# unit's EnvironmentFile.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# shellcheck source=scripts/aragora_runtime.sh
+source "${REPO_ROOT}/scripts/aragora_runtime.sh"
+
+PYTHON_BIN="$(resolve_aragora_python 'import pydantic' 'pr-watch' 'pr-watch daemon')"
+
+cd "${REPO_ROOT}"
+echo "Starting Aragora PR watch daemon..."
+echo "Using Python interpreter: ${PYTHON_BIN}"
+exec "${PYTHON_BIN}" -m aragora.compat.openclaw.pr_watch_daemon "$@"

--- a/tests/scripts/test_aragora_runtime.py
+++ b/tests/scripts/test_aragora_runtime.py
@@ -1,0 +1,118 @@
+"""Tests for the shared ``scripts/aragora_runtime.sh`` interpreter resolver.
+
+The resolver must pick a usable interpreter AT RUNTIME so a moved/removed
+``.venv`` degrades gracefully instead of stranding a long-running service on a
+stale absolute path.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HELPER = REPO_ROOT / "scripts" / "aragora_runtime.sh"
+
+# Absolute shebang so the stub execs under a minimal/empty PATH.
+_OK = "#!/bin/bash\nexit 0\n"
+# Fails the import probe (-c ...) but is otherwise executable.
+_BAD = '#!/bin/bash\nif [[ "${1:-}" == "-c" ]]; then exit 1; fi\nexit 0\n'
+# Only succeeds for an empty probe (-c "").
+_EMPTY_ONLY = (
+    "#!/bin/bash\n"
+    'if [[ "${1:-}" == "-c" ]]; then\n'
+    '  if [[ -z "${2:-}" ]]; then exit 0; else exit 1; fi\n'
+    "fi\nexit 0\n"
+)
+
+
+def _mkpy(path: Path, body: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+    return path
+
+
+def _resolve(
+    *,
+    repo_root: Path,
+    path_dirs: list[str],
+    aragora_python: str | None = None,
+    probe: str = "import pydantic",
+) -> subprocess.CompletedProcess[str]:
+    repo_root.mkdir(parents=True, exist_ok=True)
+    env = {
+        "PATH": ":".join(path_dirs),
+        "ARAGORA_REPO_ROOT": str(repo_root),
+        "HOME": str(repo_root),
+    }
+    if aragora_python is not None:
+        env["ARAGORA_PYTHON"] = aragora_python
+    return subprocess.run(
+        ["/bin/bash", "-c", f'source "{HELPER}"; resolve_aragora_python "$1"', "_", probe],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_honors_aragora_python_when_probe_passes(tmp_path: Path) -> None:
+    ok = _mkpy(tmp_path / "ok" / "python3", _OK)
+    result = _resolve(repo_root=tmp_path / "root", path_dirs=[], aragora_python=str(ok))
+    assert result.returncode == 0
+    assert result.stdout.strip() == str(ok)
+
+
+def test_skips_unusable_aragora_python_and_falls_back(tmp_path: Path) -> None:
+    bad = _mkpy(tmp_path / "bad" / "python3-bad", _BAD)
+    good = _mkpy(tmp_path / "bin" / "python3", _OK)
+    result = _resolve(
+        repo_root=tmp_path / "root",
+        path_dirs=[str(good.parent)],
+        aragora_python=str(bad),
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == str(good)
+    assert "Skipping ARAGORA_PYTHON" in result.stderr
+
+
+def test_prefers_repo_venv_interpreter(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    venv_py = _mkpy(root / ".venv" / "bin" / "python3", _OK)
+    other = _mkpy(tmp_path / "bin" / "python3", _OK)
+    result = _resolve(repo_root=root, path_dirs=[str(other.parent)])
+    assert result.returncode == 0
+    assert result.stdout.strip() == str(venv_py)
+
+
+def test_falls_back_to_path_python3_without_venv(tmp_path: Path) -> None:
+    good = _mkpy(tmp_path / "bin" / "python3", _OK)
+    result = _resolve(repo_root=tmp_path / "root", path_dirs=[str(good.parent)])
+    assert result.returncode == 0
+    assert result.stdout.strip() == str(good)
+
+
+def test_fails_loudly_when_no_interpreter_usable(tmp_path: Path) -> None:
+    bad = _mkpy(tmp_path / "bin" / "python3", _BAD)
+    result = _resolve(repo_root=tmp_path / "root", path_dirs=[str(bad.parent)])
+    assert result.returncode == 1
+    assert "No usable python interpreter" in result.stderr
+
+
+def test_empty_probe_accepts_any_executable(tmp_path: Path) -> None:
+    only_empty = _mkpy(tmp_path / "bin" / "python3", _EMPTY_ONLY)
+    # With the default pydantic probe this interpreter would be rejected...
+    rejected = _resolve(repo_root=tmp_path / "root", path_dirs=[str(only_empty.parent)])
+    assert rejected.returncode == 1
+    # ...but an empty probe skips the import check and accepts it.
+    accepted = _resolve(repo_root=tmp_path / "root", path_dirs=[str(only_empty.parent)], probe="")
+    assert accepted.returncode == 0
+    assert accepted.stdout.strip() == str(only_empty)
+
+
+def test_helper_is_sourced_not_executed() -> None:
+    # The helper defines functions and must be sourced; it should not be marked
+    # executable (callers use `source`).
+    assert not os.access(HELPER, os.X_OK)

--- a/tests/scripts/test_launchd_installers.py
+++ b/tests/scripts/test_launchd_installers.py
@@ -1,0 +1,108 @@
+"""The launchd installers must generate plists that resolve Python AT RUNTIME.
+
+Regression guard for the install-time interpreter-capture bug: the generated
+plist must invoke a repo-owned wrapper script and must never bake an absolute
+interpreter path (``export ARAGORA_PYTHON=...`` or a captured ``.venv/bin/python``)
+that goes stale when the venv moves or is removed.
+"""
+
+from __future__ import annotations
+
+import plistlib
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_OK_PY = "#!/bin/bash\nexit 0\n"
+_STUB = "#!/bin/bash\nexit 0\n"
+
+# installer, label, wrapper referenced by the generated plist, extra CLI args
+CASES = [
+    (
+        "install_merge_arbiter_launchd.sh",
+        "com.aragora.swarm-merge-arbiter",
+        "scripts/run_merge_arbiter.sh",
+        [],
+    ),
+    (
+        "install_boss_loop_launchd.sh",
+        "com.aragora.swarm-boss-loop",
+        "scripts/run_boss_cycle.sh",
+        ["--label", "boss-ready"],
+    ),
+]
+
+_NEEDED_SCRIPTS = [
+    "aragora_runtime.sh",
+    "run_merge_arbiter.sh",
+    "run_pr_watch.sh",
+    "run_boss_cycle.sh",
+]
+
+
+def _mk(path: Path, body: str, *, executable: bool) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    if executable:
+        path.chmod(0o755)
+    return path
+
+
+def _run_installer(installer: str, args: list[str], tmp_path: Path) -> tuple[Path, Path]:
+    repo = tmp_path / "repo"
+    (repo / "scripts").mkdir(parents=True)
+    for name in [installer, *_NEEDED_SCRIPTS]:
+        shutil.copy2(REPO_ROOT / "scripts" / name, repo / "scripts" / name)
+
+    bindir = tmp_path / "bin"
+    fake_py = _mk(bindir / "python3", _OK_PY, executable=True)
+    _mk(bindir / "launchctl", _STUB, executable=True)
+
+    home = tmp_path / "home"
+    home.mkdir()
+
+    env = {
+        "PATH": f"{bindir}:/usr/bin:/bin:/usr/sbin:/sbin",
+        "HOME": str(home),
+        "USER": "tester",
+    }
+    proc = subprocess.run(
+        ["/bin/bash", str(repo / "scripts" / installer), *args],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, f"installer failed: {proc.stderr}\n{proc.stdout}"
+    return home, fake_py
+
+
+@pytest.mark.parametrize("installer,label,wrapper,args", CASES)
+def test_generated_plist_invokes_wrapper_not_captured_interpreter(
+    installer: str, label: str, wrapper: str, args: list[str], tmp_path: Path
+) -> None:
+    home, fake_py = _run_installer(installer, args, tmp_path)
+    plist_path = home / "Library" / "LaunchAgents" / f"{label}.plist"
+    assert plist_path.exists(), "installer did not write the plist into HOME"
+
+    raw = plist_path.read_text(encoding="utf-8")
+    data = plistlib.loads(plist_path.read_bytes())
+    program_args = data["ProgramArguments"]
+    command = program_args[-1]
+
+    # Plist is well-formed and runs the repo-owned wrapper.
+    assert program_args[:2] == ["/bin/bash", "-lc"]
+    assert wrapper in command
+
+    # No baked interpreter: neither an exported ARAGORA_PYTHON nor a captured
+    # .venv interpreter nor the install-time interpreter path may appear.
+    assert "ARAGORA_PYTHON=" not in command
+    assert ".venv/bin/python" not in raw
+    assert str(fake_py) not in raw
+    # No real user home leaked into the generated unit.
+    assert "/Users/" not in raw


### PR DESCRIPTION
## What

PR 2 of the public-readiness remediation. Stops the launchd/systemd services from depending on an **install-time-captured interpreter path**, so a moved or removed `.venv` degrades gracefully instead of bricking the service.

## Root cause (confirmed)

The installers resolved Python **at install time** and baked the absolute path into the generated unit:

- `install_merge_arbiter_launchd.sh` generated a plist that did `export ARAGORA_PYTHON="<path>"` **and `exec`'d the captured `.venv/bin/python3` directly** (no wrapper). When `.venv` was later removed, the service failed to launch → **exit 126** (the failure observed in the dogfood run).
- `install_boss_loop_launchd.sh` similarly baked `ARAGORA_PYTHON=` + a `PATH` containing the captured interpreter dir.
- `deploy/systemd/aragora-pr-watcher.service` hardcoded `ExecStart=/opt/aragora/.venv/bin/python …`.

## Change

- **New `scripts/aragora_runtime.sh`** — shared `resolve_aragora_python` helper. Resolves at **runtime**: `ARAGORA_PYTHON` → repo `.venv/bin/python3` → `python3` → `python` → `pyenv`, each validated by an import probe; fails loudly with a diagnostic listing what it tried. (Sourced, not executed.)
- **New wrappers** `scripts/run_merge_arbiter.sh` and `scripts/run_pr_watch.sh` resolve the interpreter at launch then `exec` the daemon.
- **Installers** now generate plists that invoke the repo-owned wrappers (`run_boss_cycle.sh` / `run_merge_arbiter.sh`); they only *validate* an interpreter exists at install time and no longer bake `ARAGORA_PYTHON`/`PATH`.
- **systemd** `ExecStart` → `run_pr_watch.sh` (operator can still pin `ARAGORA_PYTHON` via the existing optional `EnvironmentFile`).
- `run_boss_cycle.sh` and `run_codex_insights_digest.sh` now source the shared resolver (de-duplicates 4 near-identical copies).

## Behavior

Behavior-preserving on a healthy setup (still prefers the repo `.venv`); recovers automatically when the venv is absent instead of failing. The boss-loop wrapper's existing runtime resolver already worked — the fix there is purely installer-side.

## Tests / validation

- `tests/scripts/test_aragora_runtime.py` (7) — honors/skips `ARAGORA_PYTHON`, prefers `.venv`, falls back, fails loudly, empty-probe.
- `tests/scripts/test_launchd_installers.py` (2) — hermetic temp repo + temp `HOME` + stubbed `launchctl`: asserts each generated plist invokes the **wrapper** and contains **no** `ARAGORA_PYTHON=`, **no** `.venv/bin/python`, **no** captured interpreter path, **no** `/Users/` leak.
- Existing `tests/scripts/test_run_boss_cycle.py` (3) still passes (refactor preserved its exact stderr contract).
- `bash -n` clean on all 7 scripts; `ruff check`/`ruff format` clean; pre-commit green.

## Notes

- Touches operational surfaces (launchd installers + systemd unit) → **draft** pending human review.
- **Guard interaction:** `scripts/aragora_runtime.sh` legitimately references `.venv/bin/python3` (a runtime existence check). When this lands alongside #7690, either add it to the guard's allowlist or run `python3 scripts/check_portability.py --update-baseline`. I'll push a one-line allowlist entry to #7690 so `main` stays green regardless of merge order.
- Follows the audit/plan in #7688.