### PR TITLE
fix(cli): suppress work-board broken pipe tracebacks

### DIFF
--- a/aragora/cli/commands/work_board.py
+++ b/aragora/cli/commands/work_board.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -106,11 +108,21 @@ def _render_human(payload: dict[str, Any]) -> str:
 
 
 def _emit(payload: dict[str, Any], *, as_json: bool) -> int:
-    if as_json:
-        print(json.dumps(payload, sort_keys=True, indent=2))
-        return 0
-    print(_render_human(payload))
+    output = json.dumps(payload, sort_keys=True, indent=2) if as_json else _render_human(payload)
+    try:
+        print(output)
+    except BrokenPipeError:
+        _mute_stdout_after_broken_pipe()
     return 0
+
+
+def _mute_stdout_after_broken_pipe() -> None:
+    """Avoid interpreter-shutdown tracebacks after downstream pipes close."""
+    try:
+        sys.stdout.close()
+    except OSError:
+        pass
+    sys.stdout = open(os.devnull, "w", encoding="utf-8")
 
 
 def cmd_work_list(args: argparse.Namespace) -> int:

--- a/tests/cli/test_work_board.py
+++ b/tests/cli/test_work_board.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+from aragora.cli.commands import work_board as work_board_cmd
 from aragora.cli.main import main as cli_main
 from aragora.cli.parser import build_parser
 from aragora.cli.commands.work_board import (
@@ -139,6 +140,25 @@ def test_work_list_json_flag_emits_parseable_json(
     payload = json.loads(capsys.readouterr().out)
 
     assert payload["schema_version"] == "aragora.work.v1"
+
+
+@pytest.mark.parametrize("as_json", [True, False])
+def test_work_emit_suppresses_broken_pipe(monkeypatch: pytest.MonkeyPatch, as_json: bool) -> None:
+    """Closed downstream pipes should not produce CLI tracebacks."""
+    muted_stdout = []
+
+    def broken_print(*_args, **_kwargs) -> None:
+        raise BrokenPipeError("downstream closed")
+
+    monkeypatch.setattr("builtins.print", broken_print)
+    monkeypatch.setattr(
+        work_board_cmd,
+        "_mute_stdout_after_broken_pipe",
+        lambda: muted_stdout.append(True),
+    )
+
+    assert work_board_cmd._emit({"schema_version": "aragora.work.v1"}, as_json=as_json) == 0
+    assert muted_stdout == [True]
 
 
 def test_work_list_reads_current_outbox(


### PR DESCRIPTION
Summary
- Treat closed downstream stdout pipes as a clean early exit in aragora work-board output.
- Redirect stdout to /dev/null after BrokenPipeError to avoid interpreter-shutdown tracebacks.
- Add regression coverage for JSON and human output.

Tests
- python3 -m pytest -q tests/cli/test_work_board.py
- python3 -m ruff check aragora/cli/commands/work_board.py tests/cli/test_work_board.py
- python3 -m aragora.cli.main work list --json | head -5
