### PR TITLE
fix(cli): return review-pr routing failures as artifacts

### DIFF
--- a/aragora/cli/commands/review_pr.py
+++ b/aragora/cli/commands/review_pr.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from aragora.connectors.github import GitHubConnector
-from aragora.swarm.review_routing import generate_review_response
+from aragora.swarm.review_routing import ReviewRoutingError, generate_review_response
 from aragora.swarm.worker_launcher import LaunchConfig, WorkerLauncher
 from aragora.worktree.fleet import resolve_repo_root
 
@@ -393,13 +393,31 @@ async def _run_review_pass(
     repo_root: Path,
 ) -> ReviewPass:
     prompt = _build_review_prompt(target=target, diff_text=diff_text)
-    routing = await generate_review_response(
-        prompt,
-        worker_model=worker_model,
-        preferred_review_model=reviewer,
-        repo_root=repo_root,
-        candidate_blocker=_review_candidate_blocker(reviewer),
-    )
+    try:
+        routing = await generate_review_response(
+            prompt,
+            worker_model=worker_model,
+            preferred_review_model=reviewer,
+            repo_root=repo_root,
+            candidate_blocker=_review_candidate_blocker(reviewer),
+        )
+    except ReviewRoutingError as exc:
+        return ReviewPass(
+            reviewer=reviewer,
+            reviewed_at=_now_iso(),
+            status="blocked_nonreviewable",
+            summary=exc.public_message,
+            findings=[
+                {
+                    "title": "Review routing failed",
+                    "body": exc.public_message,
+                    "priority": "P1",
+                    "category": exc.category,
+                }
+            ],
+            attempts=[dict(item) for item in exc.attempts if isinstance(item, dict)],
+            raw_response="",
+        )
     candidate = dict(routing.get("candidate") or {})
     attempts = [dict(item) for item in routing.get("attempts", []) if isinstance(item, dict)]
     blocked = routing.get("blocked")

--- a/tests/cli/commands/test_review_pr.py
+++ b/tests/cli/commands/test_review_pr.py
@@ -299,6 +299,69 @@ async def test_run_review_pr_loop_skips_github_review_when_publish_disabled(
 
 
 @pytest.mark.asyncio
+async def test_run_review_pr_loop_records_routing_failure_without_traceback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    sample_target: review_pr.PullRequestTarget,
+) -> None:
+    monkeypatch.setattr(review_pr, "_fetch_pr_target", lambda *_, **__: sample_target)
+    monkeypatch.setattr(review_pr, "_fetch_pr_diff", lambda *_: "diff --git a/foo b/foo\n+ok\n")
+
+    async def _routing_failure(*_: object, **__: object) -> dict[str, object]:
+        raise review_pr.ReviewRoutingError(
+            [
+                {
+                    "candidate": "claude:max-01",
+                    "stage": "generate",
+                    "kind": "auth_or_billing",
+                    "detail": "Credit balance is too low",
+                }
+            ],
+            category="billing_exhausted",
+            public_message="Reviewer capacity is exhausted.",
+        )
+
+    monkeypatch.setattr(review_pr, "generate_review_response", _routing_failure)
+
+    result = await review_pr.run_review_pr_loop(
+        pr_ref="1137",
+        repo_root=tmp_path,
+        reviewer="claude",
+        artifact_root=tmp_path / "artifacts",
+        publish_review=False,
+    )
+
+    assert result["final_status"] == "blocked_nonreviewable"
+    assert result["github_review"] == {
+        "posted": False,
+        "event": None,
+        "mode": "advisory",
+        "url": None,
+        "error": None,
+    }
+    review_run = result["review_runs"][0]
+    assert review_run["summary"] == "Reviewer capacity is exhausted."
+    assert review_run["findings"] == [
+        {
+            "title": "Review routing failed",
+            "body": "Reviewer capacity is exhausted.",
+            "priority": "P1",
+            "category": "billing_exhausted",
+        }
+    ]
+    assert review_run["attempts"] == [
+        {
+            "candidate": "claude:max-01",
+            "stage": "generate",
+            "kind": "auth_or_billing",
+            "detail": "Credit balance is too low",
+        }
+    ]
+    persisted = json.loads((Path(result["artifact_dir"]) / "run.json").read_text())
+    assert persisted["final_status"] == "blocked_nonreviewable"
+
+
+@pytest.mark.asyncio
 async def test_review_pr_loop_changes_requested_without_fixer_does_not_run_fix_pass(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Summary
- Convert reviewer routing exhaustion into a structured `blocked_nonreviewable` review pass instead of an uncaught traceback.
- Preserve reviewer attempt diagnostics in `review_runs` and still write `run.json` artifacts.
- Add regression coverage for failed routing under `run_review_pr_loop`.

Live dogfood
- `python3 -m aragora.cli.main review-pr 7698 --reviewer claude --artifact-dir /tmp/aragora-review-pr-7698-claude-fixed-rebased --json --no-publish-review` now returns structured JSON with `final_status=blocked_nonreviewable`, exact head `660fee8f8b787cafe2c866580457a906d69442d9`, preserved failed attempts, and no Python traceback.

Tests
- `python3 -m pytest -q tests/cli/commands/test_review_pr.py`
- `python3 -m ruff check aragora/cli/commands/review_pr.py tests/cli/commands/test_review_pr.py`
- `git diff --check`
