### PR TITLE
chore(docs): regenerate capability matrix — 107→108 CLI commands

### DIFF
--- a/docs-site/docs/contributing/capability-matrix.md
+++ b/docs-site/docs/contributing/capability-matrix.md
@@ -8,7 +8,7 @@
 | Surface | Inventory | Capability Coverage |
 |---------|-----------|---------------------|
 | **HTTP API** | 1772 paths / 2100 operations | 81.1% |
-| **CLI** | 107 commands | 43.2% |
+| **CLI** | 108 commands | 43.2% |
 | **SDK (Python)** | 191 namespaces | 70.3% |
 | **SDK (TypeScript)** | 190 namespaces | 70.3% |
 | **UI** | tracked in capability surfaces | 86.5% |

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -8,7 +8,7 @@
 | Surface | Inventory | Capability Coverage |
 |---------|-----------|---------------------|
 | **HTTP API** | 1772 paths / 2100 operations | 81.1% |
-| **CLI** | 107 commands | 43.2% |
+| **CLI** | 108 commands | 43.2% |
 | **SDK (Python)** | 191 namespaces | 70.3% |
 | **SDK (TypeScript)** | 190 namespaces | 70.3% |
 | **UI** | tracked in capability surfaces | 86.5% |


### PR DESCRIPTION
## Summary

- `docs/CAPABILITY_MATRIX.md` and `docs-site/docs/contributing/capability-matrix.md` were out of sync with `aragora/capability_surfaces.yaml` after recent CLI additions (DIC-20 `decay-monitor` and one other command)
- Regenerated both files via `python scripts/generate_capability_matrix.py`
- Fixes the **Status Doc Reconciliation** (CRITICAL) and **Version Alignment** CI failures that were surfaced on #7576

## Test plan

- [ ] Status Doc Reconciliation CI check passes (0 critical findings)
- [ ] Version Alignment CI check passes
- [ ] `docs/CAPABILITY_MATRIX.md` shows 108 CLI commands
- [ ] `docs-site/docs/contributing/capability-matrix.md` shows 108 CLI commands

https://claude.ai/code/session_01WPmEmANJFGkmf1yFfrcAB5

---
_Generated by [Claude Code](https://claude.ai/code/session_01WPmEmANJFGkmf1yFfrcAB5)_