### PR TITLE
fix(automation): env-configurable trusted-author allowlists (public-safe defaults)

### DIFF
--- a/aragora/config/trusted_authors.py
+++ b/aragora/config/trusted_authors.py
@@ -1,0 +1,40 @@
+"""Configurable trusted-author / automation-identity allowlists.
+
+The committed defaults intentionally contain only generic automation identities
+(bot accounts, automation name fragments) and never a personal GitHub login, so
+a public fork does not auto-trust an operator's handle for auto-merge or triage
+decisions. Operators add their own logins via ``ARAGORA_TRUSTED_AUTHORS`` (comma
+separated); individual call sites may additionally honor a context-specific
+environment variable.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable, Mapping
+
+TRUSTED_AUTHORS_ENV = "ARAGORA_TRUSTED_AUTHORS"
+
+
+def _tokens(raw: str | None) -> set[str]:
+    if not raw:
+        return set()
+    return {token.strip() for token in raw.split(",") if token.strip()}
+
+
+def resolve_trusted_authors(
+    defaults: Iterable[str] = (),
+    *,
+    env_vars: Iterable[str] = (TRUSTED_AUTHORS_ENV,),
+    env: Mapping[str, str] | None = None,
+) -> frozenset[str]:
+    """Return ``defaults`` unioned with comma-separated logins from ``env_vars``.
+
+    ``env`` defaults to ``os.environ``. Surrounding whitespace is trimmed and
+    empty entries are dropped.
+    """
+    source = os.environ if env is None else env
+    result: set[str] = {entry.strip() for entry in defaults if entry and entry.strip()}
+    for var in env_vars:
+        result |= _tokens(source.get(var))
+    return frozenset(result)

--- a/aragora/swarm/merge_arbiter.py
+++ b/aragora/swarm/merge_arbiter.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
 
+from aragora.config.trusted_authors import resolve_trusted_authors
 from aragora.swarm.github_app_auth import gh_subprocess_run
 
 logger = logging.getLogger(__name__)
@@ -50,9 +51,10 @@ REDUCED_LANE_ONLY_CHECKS = frozenset(
         "changes",
     }
 )
-AUTOMATION_REVIEWER_LOGINS = frozenset(
+# Generic automation identities only; operators add personal logins via
+# ARAGORA_TRUSTED_AUTHORS (comma separated) so a public fork trusts no handle.
+AUTOMATION_REVIEWER_LOGINS = resolve_trusted_authors(
     {
-        "an0mium",
         "github-actions[bot]",
         "dependabot[bot]",
         "aragora-automation[bot]",

--- a/aragora/triage/evidence.py
+++ b/aragora/triage/evidence.py
@@ -23,13 +23,17 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Sequence
 
+from aragora.config.trusted_authors import resolve_trusted_authors
+
 ISSUE_REF_PATTERN = re.compile(r"#(\d{2,6})\b")
 FILE_PATH_PATTERN = re.compile(
     r"(?:^|[\s`(])([a-zA-Z0-9_./\\-]+\.(?:py|md|yml|yaml|toml|cfg|sh|ts|tsx|js|jsx|json))(?=[\s`):,.]|$)"
 )
-AUTOMATION_AUTHOR_HINTS = (
+# Generic automation name fragments only; no personal login is hardcoded so a
+# public fork flags nobody by default. Operators add their own logins via
+# ARAGORA_TRUSTED_AUTHORS.
+_DEFAULT_AUTOMATION_AUTHOR_HINTS = (
     "[bot]",
-    "an0mium",
     "boss-loop",
     "stage-gate",
     "swarm-",
@@ -37,6 +41,21 @@ AUTOMATION_AUTHOR_HINTS = (
     "codex-automation",
     "github-actions",
 )
+
+
+def automation_author_hints() -> tuple[str, ...]:
+    """Resolve automation name fragments (generic defaults + env logins).
+
+    Lowercased for case-insensitive substring matching; resolved per call so
+    ``ARAGORA_TRUSTED_AUTHORS`` changes take effect without re-import.
+    """
+    return tuple(
+        sorted(hint.lower() for hint in resolve_trusted_authors(_DEFAULT_AUTOMATION_AUTHOR_HINTS))
+    )
+
+
+# Generic defaults snapshot for backward-compatible imports.
+AUTOMATION_AUTHOR_HINTS = automation_author_hints()
 
 
 @dataclass(frozen=True)
@@ -106,7 +125,7 @@ def is_automation_generated(
     judge substantive value regardless of this flag.
     """
     author_lower = author.lower()
-    if any(hint in author_lower for hint in AUTOMATION_AUTHOR_HINTS):
+    if any(hint in author_lower for hint in automation_author_hints()):
         return True
     automation_labels = {"automation", "automated", "stage-gate-drift", "boss-stuck"}
     if any(label.lower() in automation_labels for label in labels):

--- a/docs/reference/ENVIRONMENT.md
+++ b/docs/reference/ENVIRONMENT.md
@@ -502,6 +502,28 @@ explicitly if you need consistent pooling across subsystems.
 | `ARAGORA_AUDIENCE_INBOX_MAX_SIZE` | Optional | Audience inbox queue size | `1000` |
 | `ARAGORA_MAX_EVENT_QUEUE_SIZE` | Optional | Event queue size (server) | `10000` |
 
+## Automation Trust (Auto-Merge & Triage)
+
+The merge arbiter and PR triage / auto-merge tooling gate decisions on an
+allowlist of trusted author / reviewer logins. The committed defaults contain
+only generic automation identities (bot accounts) and **no personal GitHub
+login**, so a public fork never auto-trusts an operator's handle. Operators opt
+their own logins in via environment variables (comma-separated, whitespace
+trimmed):
+
+| Variable | Required | Description | Default |
+|----------|----------|-------------|---------|
+| `ARAGORA_TRUSTED_AUTHORS` | Optional | Logins trusted for auto-merge / triage and treated as automation authors. Unioned with the generic defaults. | _(empty)_ |
+| `ARAGORA_BUCKET_A_TRUSTED_AUTHORS` | Optional | Extra logins trusted specifically by `scripts/auto_merge_bucket_a.py` (unioned with `ARAGORA_TRUSTED_AUTHORS`). | _(empty)_ |
+
+Consumed by `aragora/swarm/merge_arbiter.py`, `aragora/triage/evidence.py`,
+`scripts/triage_open_prs.py`, and `scripts/auto_merge_bucket_a.py` through the
+shared resolver `aragora.config.trusted_authors.resolve_trusted_authors`.
+
+**Migration note:** earlier releases hardcoded `an0mium` as a default trusted
+login. To preserve that behavior set `ARAGORA_TRUSTED_AUTHORS=an0mium` in your
+`.env` (and in any CI / launchd environment where this tooling runs).
+
 ## Reserved / Not Yet Wired
 
 These variables exist in the settings schema but are not currently wired into runtime behavior.

--- a/scripts/auto_merge_bucket_a.py
+++ b/scripts/auto_merge_bucket_a.py
@@ -53,6 +53,10 @@ POLICY_DOC = REPO_ROOT / "docs" / "governance" / "OPERATOR_DELEGATION_POLICY.md"
 
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
+from aragora.config.trusted_authors import (  # noqa: E402
+    TRUSTED_AUTHORS_ENV as GLOBAL_TRUSTED_AUTHORS_ENV,
+    resolve_trusted_authors,
+)
 from scripts.post_merge_lane_audit import (  # noqa: E402
     post_merge_lane_audit_failed,
     post_merge_lane_audit_failure_reason,
@@ -89,7 +93,9 @@ PROTECTED_PREFIXES: tuple[str, ...] = (
     "secrets/",
 )
 
-DEFAULT_TRUSTED_AUTHORS: frozenset[str] = frozenset({"an0mium"})
+# No personal login is trusted by default; operators opt in via the global
+# ARAGORA_TRUSTED_AUTHORS or the bucket-specific env var below.
+DEFAULT_TRUSTED_AUTHORS: frozenset[str] = frozenset()
 TRUSTED_AUTHORS_ENV = "ARAGORA_BUCKET_A_TRUSTED_AUTHORS"
 
 # Labels that require a human/operator stop even if Stage 1 accidentally
@@ -152,15 +158,16 @@ def _default_runner(args: list[str]) -> subprocess.CompletedProcess[str]:
 def trusted_authors(env: Mapping[str, str] | None = None) -> frozenset[str]:
     """Return the configured Bucket-A trusted authors.
 
-    The default mirrors the policy doc. Operators can extend the set for
-    automation identities without editing this script by setting
-    ``ARAGORA_BUCKET_A_TRUSTED_AUTHORS`` to a comma-separated login list.
+    No personal login is trusted by default. Operators opt in without editing
+    this script by setting the global ``ARAGORA_TRUSTED_AUTHORS`` or the
+    bucket-specific ``ARAGORA_BUCKET_A_TRUSTED_AUTHORS`` to a comma-separated
+    login list; the two sources are unioned.
     """
-    source = os.environ if env is None else env
-    configured = frozenset(
-        login.strip() for login in source.get(TRUSTED_AUTHORS_ENV, "").split(",") if login.strip()
+    return resolve_trusted_authors(
+        DEFAULT_TRUSTED_AUTHORS,
+        env_vars=(GLOBAL_TRUSTED_AUTHORS_ENV, TRUSTED_AUTHORS_ENV),
+        env=env,
     )
-    return DEFAULT_TRUSTED_AUTHORS | configured
 
 
 def _git_stdout(args: list[str], *, cwd: Path) -> str | None:

--- a/scripts/triage_open_prs.py
+++ b/scripts/triage_open_prs.py
@@ -55,6 +55,11 @@ from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import Any
 
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+from aragora.config.trusted_authors import resolve_trusted_authors  # noqa: E402
+
 # ---------------------------------------------------------------------------
 # Policy constants — keep in sync with docs/governance/OPERATOR_DELEGATION_POLICY.md
 # ---------------------------------------------------------------------------
@@ -77,10 +82,15 @@ PROTECTED_PATHS: frozenset[str] = frozenset(
     }
 )
 
-# Trusted authors — Bucket A is gated on author membership here. Adding
-# a new entry is itself an operator-only tripwire (the policy doc names
+
+# Trusted authors — Bucket A is gated on author membership here. No personal
+# login is trusted by default; operators opt in via ARAGORA_TRUSTED_AUTHORS
+# (comma separated). Resolved per call so env/test changes take effect. Adding
+# a trusted author is itself an operator-only tripwire (the policy doc names
 # this explicitly).
-TRUSTED_AUTHORS: frozenset[str] = frozenset({"an0mium"})
+def trusted_authors() -> frozenset[str]:
+    return resolve_trusted_authors()
+
 
 # Labels that cannot be added by a Bucket-A PR without an operator look.
 OPERATOR_ONLY_LABELS: frozenset[str] = frozenset({"boss-ready", "autonomous"})
@@ -384,7 +394,7 @@ def _would_qualify_for_bucket_a(
         return False
     author_raw = pr.get("author") or {}
     author = author_raw.get("login", "") if isinstance(author_raw, dict) else str(author_raw)
-    if author not in TRUSTED_AUTHORS:
+    if author not in trusted_authors():
         return False
     if bool(pr.get("isDraft")):
         return False
@@ -705,7 +715,7 @@ def classify(
         )
 
     # --- Bucket C: non-trusted author ---
-    if author not in TRUSTED_AUTHORS:
+    if author not in trusted_authors():
         return _result(
             n,
             title,

--- a/tests/config/test_trusted_authors.py
+++ b/tests/config/test_trusted_authors.py
@@ -1,0 +1,59 @@
+"""Tests for the shared trusted-author allowlist resolver."""
+
+from __future__ import annotations
+
+from aragora.config.trusted_authors import (
+    TRUSTED_AUTHORS_ENV,
+    resolve_trusted_authors,
+)
+
+
+def test_defaults_only_when_env_empty() -> None:
+    result = resolve_trusted_authors({"alpha[bot]", "beta[bot]"}, env={})
+    assert result == frozenset({"alpha[bot]", "beta[bot]"})
+
+
+def test_no_personal_default_means_empty_without_env() -> None:
+    # The whole point: a bare resolver (no defaults, no env) trusts nobody.
+    assert resolve_trusted_authors(env={}) == frozenset()
+
+
+def test_env_adds_and_trims_tokens() -> None:
+    result = resolve_trusted_authors(
+        {"alpha[bot]"},
+        env={TRUSTED_AUTHORS_ENV: " me ,  teammate "},
+    )
+    assert result == frozenset({"alpha[bot]", "me", "teammate"})
+
+
+def test_empty_and_whitespace_tokens_dropped() -> None:
+    result = resolve_trusted_authors(env={TRUSTED_AUTHORS_ENV: "a,, ,b,"})
+    assert result == frozenset({"a", "b"})
+
+
+def test_multiple_env_vars_are_unioned() -> None:
+    result = resolve_trusted_authors(
+        {"alpha[bot]"},
+        env_vars=("GLOBAL", "SPECIFIC"),
+        env={"GLOBAL": "g1", "SPECIFIC": "s1,s2"},
+    )
+    assert result == frozenset({"alpha[bot]", "g1", "s1", "s2"})
+
+
+def test_missing_env_var_is_ignored() -> None:
+    result = resolve_trusted_authors({"alpha[bot]"}, env_vars=("ABSENT",), env={})
+    assert result == frozenset({"alpha[bot]"})
+
+
+def test_defaults_are_trimmed_and_filtered() -> None:
+    result = resolve_trusted_authors({" alpha[bot] ", "", "  "}, env={})
+    assert result == frozenset({"alpha[bot]"})
+
+
+def test_falls_back_to_os_environ(monkeypatch) -> None:
+    monkeypatch.setenv(TRUSTED_AUTHORS_ENV, "from-os")
+    assert "from-os" in resolve_trusted_authors()
+
+
+def test_returns_frozenset() -> None:
+    assert isinstance(resolve_trusted_authors({"a"}, env={}), frozenset)

--- a/tests/scripts/test_auto_merge_bucket_a.py
+++ b/tests/scripts/test_auto_merge_bucket_a.py
@@ -46,6 +46,13 @@ def _load_module() -> Any:
 amba = _load_module()
 
 
+@pytest.fixture(autouse=True)
+def _trust_default_test_author(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The canonical fixture author is ``an0mium``; the production default no
+    # longer trusts any personal login, so tests opt in via the env contract.
+    monkeypatch.setenv("ARAGORA_TRUSTED_AUTHORS", "an0mium")
+
+
 NOW = datetime.datetime(2026, 5, 18, 1, 0, 0, tzinfo=datetime.timezone.utc)
 
 

--- a/tests/scripts/test_triage_issues_via_debate.py
+++ b/tests/scripts/test_triage_issues_via_debate.py
@@ -143,12 +143,18 @@ def test_panel_prompt_rubric_explicit_about_automation_not_being_bad():
 
 def test_is_automation_generated_handles_bots_and_labels():
     assert is_automation_generated(author="github-actions[bot]")
-    assert is_automation_generated(author="an0mium")
+    # Personal logins are not automation by default (public-safe default).
+    assert not is_automation_generated(author="an0mium")
     assert is_automation_generated(author="alice", labels=("stage-gate-drift",))
     assert is_automation_generated(
         author="alice", labels=(), body="This issue was opened by the swarm boss loop."
     )
     assert not is_automation_generated(author="founder", labels=("bug",), body="repro: ...")
+
+
+def test_is_automation_generated_honors_trusted_authors_env(monkeypatch):
+    monkeypatch.setenv("ARAGORA_TRUSTED_AUTHORS", "an0mium")
+    assert is_automation_generated(author="an0mium")
 
 
 def test_extract_file_references_finds_python_paths():

--- a/tests/scripts/test_triage_open_prs.py
+++ b/tests/scripts/test_triage_open_prs.py
@@ -38,6 +38,13 @@ def _load_module() -> Any:
 tri = _load_module()
 
 
+@pytest.fixture(autouse=True)
+def _trust_default_test_author(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The canonical fixture author is ``an0mium``; the production default no
+    # longer trusts any personal login, so tests opt in via the env contract.
+    monkeypatch.setenv("ARAGORA_TRUSTED_AUTHORS", "an0mium")
+
+
 # ---------------------------------------------------------------------------
 # Fixture helpers
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What & why

Part of the **public-readiness portability** effort (audit #7688). The merge
arbiter and PR triage / auto-merge tooling hardcoded the personal GitHub login
`an0mium` in their trusted-author / automation-identity allowlists. In a public
fork that means an arbitrary user named `an0mium` would be auto-trusted for
auto-merge and triage decisions — a security-relevant default.

This change removes the personal login from **all four** allowlists and resolves
them through one shared helper, `aragora.config.trusted_authors.resolve_trusted_authors`.
Committed defaults now contain **only generic bot identities**; operators opt
their own logins in via env.

## Changes
- **New** `aragora/config/trusted_authors.py` — `resolve_trusted_authors(defaults, *, env_vars=(ARAGORA_TRUSTED_AUTHORS,), env=None)` unions generic defaults with comma-separated logins from env (whitespace-trimmed, empties dropped).
- `aragora/swarm/merge_arbiter.py` — `AUTOMATION_REVIEWER_LOGINS` now bot-only + env.
- `aragora/triage/evidence.py` — `is_automation_generated` resolves hints per call (defaults bot-fragments only) + env; `an0mium` no longer hardcoded.
- `scripts/auto_merge_bucket_a.py` — empty default; `trusted_authors()` unions `ARAGORA_TRUSTED_AUTHORS` + `ARAGORA_BUCKET_A_TRUSTED_AUTHORS`.
- `scripts/triage_open_prs.py` — call-time `trusted_authors()` (was an import-time constant), repo-root on `sys.path` for the shared import.
- `docs/reference/ENVIRONMENT.md` — new **Automation Trust** section documenting both env vars + migration note.

## Behavior change (action required to preserve current behavior)
Set in `.env` (and any CI / launchd environment running this tooling):
```
ARAGORA_TRUSTED_AUTHORS=an0mium
```
Without it, `an0mium` is no longer auto-trusted for auto-merge / triage.

## Tests
- New `tests/config/test_trusted_authors.py` (9) for the resolver.
- New evidence env-path test; updated the default-behavior assertion.
- `test_auto_merge_bucket_a.py` / `test_triage_open_prs.py` get a module autouse fixture setting `ARAGORA_TRUSTED_AUTHORS=an0mium` (their canonical fixture author), preserving all existing assertions.
- 241 passed locally; ruff + pre-commit (ruff-format, gitleaks, detect-private-key) green.

Draft: touches automation trust/security defaults — wants human review before ready.

🤖 Generated with [Droid](https://factory.ai)