### PR TITLE
fix(public): correct legacy an0mium/aragora slug in shipped openapi + SDK artifacts

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2062,7 +2062,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -5994,7 +5994,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -6119,7 +6119,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -6273,7 +6273,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -6406,7 +6406,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -9221,7 +9221,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -9400,7 +9400,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -9532,7 +9532,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -9619,7 +9619,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -9706,7 +9706,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -9876,7 +9876,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -9963,7 +9963,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -10133,7 +10133,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -11822,7 +11822,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -19984,7 +19984,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -20133,7 +20133,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -20201,7 +20201,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -20327,7 +20327,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -20487,7 +20487,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -20602,7 +20602,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -20713,7 +20713,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -20837,7 +20837,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -20963,7 +20963,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -21112,7 +21112,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -21224,7 +21224,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -29406,7 +29406,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -29709,7 +29709,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -32269,7 +32269,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -32537,7 +32537,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -32841,7 +32841,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -33029,7 +33029,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -36180,7 +36180,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -36331,7 +36331,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -37711,7 +37711,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -42707,7 +42707,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -42865,7 +42865,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -42989,7 +42989,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -43111,7 +43111,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -43235,7 +43235,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -43359,7 +43359,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -43490,7 +43490,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -43700,7 +43700,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -43824,7 +43824,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -43955,7 +43955,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -44079,7 +44079,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -44203,7 +44203,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -45872,7 +45872,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -45997,7 +45997,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -46151,7 +46151,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -46284,7 +46284,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -51642,7 +51642,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -51850,7 +51850,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -52019,7 +52019,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -52192,7 +52192,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -53213,7 +53213,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -53537,7 +53537,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -53702,7 +53702,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -54272,7 +54272,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -54532,7 +54532,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -54870,7 +54870,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -55049,7 +55049,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -55181,7 +55181,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -55268,7 +55268,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -55355,7 +55355,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -55546,7 +55546,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -55737,7 +55737,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -55907,7 +55907,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -56119,7 +56119,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -56386,7 +56386,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -56606,7 +56606,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -56797,7 +56797,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -57017,7 +57017,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -57222,7 +57222,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -57397,7 +57397,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -57652,7 +57652,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -57864,7 +57864,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -58119,7 +58119,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -58339,7 +58339,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -58577,7 +58577,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -58789,7 +58789,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -59009,7 +59009,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -59229,7 +59229,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -59427,7 +59427,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -59602,7 +59602,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -59777,7 +59777,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -59864,7 +59864,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -60034,7 +60034,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -60246,7 +60246,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -60623,7 +60623,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -60922,7 +60922,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -61100,7 +61100,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -61381,7 +61381,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -61567,7 +61567,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -61728,7 +61728,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -61970,7 +61970,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -62175,7 +62175,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -62398,7 +62398,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -62621,7 +62621,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -62762,7 +62762,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -63027,7 +63027,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -63219,7 +63219,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -63527,7 +63527,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -63733,7 +63733,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -63920,7 +63920,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -64207,7 +64207,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -64429,7 +64429,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -64643,7 +64643,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -65585,7 +65585,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -78854,7 +78854,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -78992,7 +78992,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -79116,7 +79116,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -79268,7 +79268,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -79355,7 +79355,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -84391,7 +84391,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -85593,7 +85593,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -85840,7 +85840,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -86132,7 +86132,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -86384,7 +86384,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -86636,7 +86636,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -86980,7 +86980,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -87178,7 +87178,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -87448,7 +87448,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -87687,7 +87687,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -87924,7 +87924,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -88122,7 +88122,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -88669,7 +88669,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -88940,7 +88940,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -89166,7 +89166,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -89478,7 +89478,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -89676,7 +89676,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -90757,7 +90757,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -90885,7 +90885,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -91068,7 +91068,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -91689,7 +91689,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -91957,7 +91957,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -92509,7 +92509,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -92733,7 +92733,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -92907,7 +92907,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -93173,7 +93173,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -93345,7 +93345,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -93475,7 +93475,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -93604,7 +93604,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -93834,7 +93834,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -94008,7 +94008,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -94201,7 +94201,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -94399,7 +94399,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -94643,7 +94643,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -94815,7 +94815,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -94977,7 +94977,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -95159,7 +95159,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -95369,7 +95369,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -95517,7 +95517,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -95665,7 +95665,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -95813,7 +95813,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -96311,7 +96311,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -96485,7 +96485,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -96615,7 +96615,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -96775,7 +96775,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -96925,7 +96925,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -98566,7 +98566,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -98759,7 +98759,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -99034,7 +99034,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -99244,7 +99244,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -99519,7 +99519,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -99747,7 +99747,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -99926,7 +99926,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -100138,7 +100138,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -100385,7 +100385,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -100668,7 +100668,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -100951,7 +100951,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -101234,7 +101234,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -102108,7 +102108,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -102340,7 +102340,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -102499,7 +102499,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -102625,7 +102625,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -102774,7 +102774,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -102842,7 +102842,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -103567,7 +103567,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -103791,7 +103791,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -103938,7 +103938,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -104081,7 +104081,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -104205,7 +104205,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -104319,7 +104319,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -104445,7 +104445,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -104736,7 +104736,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -105131,7 +105131,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -105792,7 +105792,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -105991,7 +105991,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -106186,7 +106186,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -106308,7 +106308,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -106435,7 +106435,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -107075,7 +107075,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -107250,7 +107250,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -107382,7 +107382,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -107508,7 +107508,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -107663,7 +107663,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -107797,7 +107797,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -107886,7 +107886,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -107975,7 +107975,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -108118,7 +108118,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -108225,7 +108225,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -108898,7 +108898,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -109663,7 +109663,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -109819,7 +109819,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -110009,7 +110009,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -110133,7 +110133,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -110294,7 +110294,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -110461,7 +110461,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -110619,7 +110619,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -110696,7 +110696,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -111279,7 +111279,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -111584,7 +111584,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -111740,7 +111740,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -111928,7 +111928,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -112016,7 +112016,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -116796,7 +116796,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -117026,7 +117026,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -117267,7 +117267,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -117501,7 +117501,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -117719,7 +117719,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -117991,7 +117991,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -118182,7 +118182,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -118635,7 +118635,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -118896,7 +118896,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -119213,7 +119213,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -119442,7 +119442,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -119770,7 +119770,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -120101,7 +120101,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -120346,7 +120346,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -120580,7 +120580,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -120890,7 +120890,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -121090,7 +121090,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -121423,7 +121423,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -121500,7 +121500,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -121692,7 +121692,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -121898,7 +121898,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -122196,7 +122196,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -122396,7 +122396,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -122639,7 +122639,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -122914,7 +122914,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -123163,7 +123163,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -123413,7 +123413,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -123665,7 +123665,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -123842,7 +123842,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -125243,7 +125243,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -125555,7 +125555,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -125787,7 +125787,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -130545,7 +130545,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -130754,7 +130754,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -130887,7 +130887,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -134752,7 +134752,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -134880,7 +134880,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -142234,7 +142234,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -144627,7 +144627,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -144895,7 +144895,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -145151,7 +145151,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -145368,7 +145368,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -145586,7 +145586,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -145840,7 +145840,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -146044,7 +146044,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -146182,7 +146182,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -146294,7 +146294,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -146430,7 +146430,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -146548,7 +146548,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -146745,7 +146745,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -146979,7 +146979,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -147216,7 +147216,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -147485,7 +147485,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -147735,7 +147735,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -151727,7 +151727,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }

--- a/openapi.json
+++ b/openapi.json
@@ -3875,7 +3875,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -3998,7 +3998,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -6493,7 +6493,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -6644,7 +6644,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -23476,7 +23476,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -23604,7 +23604,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -23756,7 +23756,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -23896,7 +23896,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -24092,7 +24092,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -24301,7 +24301,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -24434,7 +24434,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -27265,7 +27265,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -27420,7 +27420,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -27552,7 +27552,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -27686,7 +27686,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -27839,7 +27839,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -27994,7 +27994,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -28118,7 +28118,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -28244,7 +28244,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -36665,7 +36665,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -36872,7 +36872,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -41233,7 +41233,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -41361,7 +41361,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -41497,7 +41497,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -42749,7 +42749,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -44835,7 +44835,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -45147,7 +45147,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -45379,7 +45379,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -45467,7 +45467,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -45605,7 +45605,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -45729,7 +45729,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -45816,7 +45816,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -45968,7 +45968,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -46223,7 +46223,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -46435,7 +46435,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -46655,7 +46655,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -46853,7 +46853,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -47065,7 +47065,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -47293,7 +47293,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -47521,7 +47521,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -47749,7 +47749,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -47977,7 +47977,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -48142,7 +48142,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -48380,7 +48380,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -48592,7 +48592,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -48812,7 +48812,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -48987,7 +48987,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -49162,7 +49162,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -49417,7 +49417,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -49637,7 +49637,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -49842,7 +49842,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -50017,7 +50017,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -50284,7 +50284,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -50496,7 +50496,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -50716,7 +50716,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -50907,7 +50907,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -51098,7 +51098,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -51289,7 +51289,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -51509,7 +51509,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -51676,7 +51676,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -51763,7 +51763,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -51850,7 +51850,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -51937,7 +51937,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -52107,7 +52107,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -52277,7 +52277,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -52456,7 +52456,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -52588,7 +52588,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -52754,7 +52754,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -52841,7 +52841,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -52928,7 +52928,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -53015,7 +53015,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -53185,7 +53185,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -53355,7 +53355,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -53534,7 +53534,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -53666,7 +53666,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -53847,7 +53847,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -54029,7 +54029,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -54257,7 +54257,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -54436,7 +54436,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -54648,7 +54648,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -54895,7 +54895,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -55178,7 +55178,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -55461,7 +55461,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -55744,7 +55744,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -55972,7 +55972,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -56165,7 +56165,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -56440,7 +56440,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -56650,7 +56650,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -56925,7 +56925,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -57054,7 +57054,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -57252,7 +57252,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -57496,7 +57496,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -57668,7 +57668,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -57797,7 +57797,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -58027,7 +58027,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -58201,7 +58201,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -58411,7 +58411,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -58559,7 +58559,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -58707,7 +58707,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -58837,7 +58837,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -58985,7 +58985,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -59167,7 +59167,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -59324,7 +59324,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -59498,7 +59498,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -59628,7 +59628,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -59778,7 +59778,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -59938,7 +59938,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -60081,7 +60081,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -60305,7 +60305,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -60479,7 +60479,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -60745,7 +60745,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -60917,7 +60917,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -61047,7 +61047,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -61216,7 +61216,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -61381,7 +61381,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -61554,7 +61554,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -61648,7 +61648,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -61804,7 +61804,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -61960,7 +61960,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -62048,7 +62048,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -62180,7 +62180,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -62355,7 +62355,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -62481,7 +62481,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -62636,7 +62636,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -62770,7 +62770,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -62877,7 +62877,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -62966,7 +62966,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -63055,7 +63055,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -63198,7 +63198,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -63330,7 +63330,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -63491,7 +63491,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -63658,7 +63658,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -63816,7 +63816,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -63940,7 +63940,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -64098,7 +64098,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -64191,7 +64191,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -64315,7 +64315,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -64392,7 +64392,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -64516,7 +64516,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -64693,7 +64693,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -64870,7 +64870,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -64970,7 +64970,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -65128,7 +65128,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -65252,7 +65252,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -65374,7 +65374,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -65498,7 +65498,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -65622,7 +65622,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -65746,7 +65746,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -65870,7 +65870,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -66001,7 +66001,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -66125,7 +66125,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -66335,7 +66335,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -66466,7 +66466,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -69460,7 +69460,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -69625,7 +69625,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -69824,7 +69824,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -70019,7 +70019,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -70141,7 +70141,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -70305,7 +70305,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -70537,7 +70537,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -70696,7 +70696,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -70823,7 +70823,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -70935,7 +70935,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -71071,7 +71071,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -71189,7 +71189,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -71386,7 +71386,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -71585,7 +71585,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -71819,7 +71819,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -72056,7 +72056,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -72325,7 +72325,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -72575,7 +72575,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -72713,7 +72713,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -72872,7 +72872,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -73033,7 +73033,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -73158,7 +73158,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -73285,7 +73285,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -73395,7 +73395,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -73507,7 +73507,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -73621,7 +73621,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -73737,7 +73737,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -73860,7 +73860,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -73985,7 +73985,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -74133,7 +74133,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -74283,7 +74283,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -74408,7 +74408,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -74535,7 +74535,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -74602,7 +74602,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -74671,7 +74671,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -74819,7 +74819,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -74969,7 +74969,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -75094,7 +75094,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -75221,7 +75221,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -75332,7 +75332,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -75445,7 +75445,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -82062,7 +82062,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -82365,7 +82365,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -82719,7 +82719,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -82951,7 +82951,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -83219,7 +83219,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -83523,7 +83523,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -83809,7 +83809,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -84108,7 +84108,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -84351,7 +84351,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -84619,7 +84619,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -84875,7 +84875,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -85092,7 +85092,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -85310,7 +85310,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -85564,7 +85564,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -92495,7 +92495,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -92729,7 +92729,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -92971,7 +92971,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -93231,7 +93231,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -93479,7 +93479,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -93670,7 +93670,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -93876,7 +93876,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -94049,7 +94049,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -94330,7 +94330,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -94516,7 +94516,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -94677,7 +94677,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -94818,7 +94818,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -95083,7 +95083,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -95275,7 +95275,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -95583,7 +95583,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -95789,7 +95789,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -95976,7 +95976,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -96263,7 +96263,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -96485,7 +96485,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -96699,7 +96699,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -96941,7 +96941,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -97146,7 +97146,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -97369,7 +97369,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -97592,7 +97592,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -97769,7 +97769,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -98016,7 +98016,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -98250,7 +98250,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -98502,7 +98502,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -98754,7 +98754,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -99098,7 +99098,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -99296,7 +99296,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -99534,7 +99534,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -99773,7 +99773,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -100010,7 +100010,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -100208,7 +100208,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -100407,7 +100407,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -100678,7 +100678,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -100904,7 +100904,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -101216,7 +101216,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -101414,7 +101414,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -101657,7 +101657,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -101932,7 +101932,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -102181,7 +102181,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -102431,7 +102431,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -102683,7 +102683,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -103021,7 +103021,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -103282,7 +103282,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -103599,7 +103599,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -103833,7 +103833,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -104143,7 +104143,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -104343,7 +104343,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -104676,7 +104676,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -104882,7 +104882,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -105180,7 +105180,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -105380,7 +105380,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -105609,7 +105609,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -105937,7 +105937,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -106268,7 +106268,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -106345,7 +106345,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -106537,7 +106537,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -106782,7 +106782,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }
@@ -106959,7 +106959,7 @@
                       "error": "An unexpected error occurred",
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
-                      "support_url": "https://github.com/an0mium/aragora/issues"
+                      "support_url": "https://github.com/synaptent/aragora/issues"
                     }
                   }
                 }

--- a/scripts/portability_baseline.json
+++ b/scripts/portability_baseline.json
@@ -179,9 +179,6 @@
     "docs/missions/H1_DISCIPLINED_MISSION_PROMPT.md": [
       "users_home"
     ],
-    "docs/openapi.json": [
-      "legacy_slug"
-    ],
     "docs/plans/2026-03-01-doc-consolidation-dogfood.md": [
       "users_home"
     ],
@@ -289,9 +286,6 @@
     "examples/typescript-web/index.html": [
       "legacy_slug"
     ],
-    "openapi.json": [
-      "legacy_slug"
-    ],
     "pyproject.toml": [
       "legacy_slug"
     ],
@@ -306,9 +300,6 @@
     ],
     "sdk/python/tests/test_scim.py": [
       "users_home"
-    ],
-    "sdk/typescript/package.json": [
-      "legacy_slug"
     ],
     "sdk/typescript/src/namespaces/__tests__/scim.test.ts": [
       "users_home"

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -40,12 +40,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/an0mium/aragora.git",
+    "url": "https://github.com/synaptent/aragora.git",
     "directory": "sdk/typescript"
   },
-  "homepage": "https://github.com/an0mium/aragora/blob/main/docs/START_HERE.md",
+  "homepage": "https://github.com/synaptent/aragora/blob/main/docs/START_HERE.md",
   "bugs": {
-    "url": "https://github.com/an0mium/aragora/issues"
+    "url": "https://github.com/synaptent/aragora/issues"
   },
   "engines": {
     "node": ">=20.0.0"


### PR DESCRIPTION
## What & why
Public-facing artifacts still shipped the **legacy `an0mium/aragora` slug**,
pointing npm/SDK consumers and the published API spec at a repository that no
longer exists. The generator **source**
(`aragora/server/openapi/helpers.py`) already emits `synaptent/aragora` — the
committed artifacts were just generated before that fix.

## Changes (data only)
- **`openapi.json`** / **`docs/openapi.json`** — 270 `support_url` entries each
  (`github.com/an0mium/aragora/issues` → `…/synaptent/aragora/issues`). Stale
  generated output; source already correct, so this aligns the artifacts.
- **`sdk/typescript/package.json`** — `repository.url`, `homepage`, `bugs.url`
  (hand-maintained, so a durable fix).
- **`scripts/portability_baseline.json`** — surgical down-ratchet dropping the 3
  now-clean `legacy_slug` entries (0 added / 9 removed; PR #7705's doc entries
  untouched for conflict-free merge).

## Validation
- All 3 JSON files re-validated as parseable.
- Portability guard **clean over this PR's files** (`exit 0`); pre-commit
  (check-json, gitleaks, detect-private-key, portability-guard) green.
- `tests/scripts/test_export_openapi.py` + `test_generate_openapi.py` pass
  (no source/code changed).

## Merge ordering
The full-tree guard remains red **only** on the pre-existing
`tests/scripts/test_launchd_installers.py` (`venv_python`) introduced by #7697
and fixed by **#7706**. Merge **#7706 first** to re-green `main`; this PR's own
files are already guard-clean and it rebases trivially.

## Not included (much larger, riskier slug surface)
The slug also persists in ~600 other lines across **Go module paths**
(`aragora-operator/**`, `github.com/an0mium/aragora-operator/...`), **container
image refs** (`ghcr.io/an0mium/...` in helm/argo/deploy), **packaging**
(`pyproject.toml` ×3), **deploy/demo docs**, and **test fixtures**
(`demos/pr-review/*/expected_comment.md`, `test_devops_agent.py`,
`test_next_steps_runner.py`). Those need care (module renames, image
republishing, paired fixture+assertion edits) and are out of scope here.

Draft: large mechanical artifact diff; wants human review.

🤖 Generated with [Droid](https://factory.ai)