### PR TITLE
fix(public): correct legacy slug in Python packaging metadata (pyproject x3)

### DIFF
--- a/aragora-debate/pyproject.toml
+++ b/aragora-debate/pyproject.toml
@@ -56,11 +56,11 @@ all = [
 dev = ["pytest>=8.0", "pytest-asyncio>=0.23"]
 
 [project.urls]
-Homepage = "https://github.com/an0mium/aragora"
-Documentation = "https://github.com/an0mium/aragora/blob/main/docs/START_HERE.md"
-Repository = "https://github.com/an0mium/aragora/tree/main/aragora-debate"
-Changelog = "https://github.com/an0mium/aragora/blob/main/aragora-debate/CHANGELOG.md"
-"Bug Tracker" = "https://github.com/an0mium/aragora/issues"
+Homepage = "https://github.com/synaptent/aragora"
+Documentation = "https://github.com/synaptent/aragora/blob/main/docs/START_HERE.md"
+Repository = "https://github.com/synaptent/aragora/tree/main/aragora-debate"
+Changelog = "https://github.com/synaptent/aragora/blob/main/aragora-debate/CHANGELOG.md"
+"Bug Tracker" = "https://github.com/synaptent/aragora/issues"
 
 [tool.hatch.build.targets.sdist]
 exclude = ["CLAUDE.md", "**/CLAUDE.md", ".nomic/", ".benchmarks/"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,8 +77,8 @@ all = [
 
 [project.urls]
 Homepage = "https://aragora.ai"
-Repository = "https://github.com/an0mium/aragora"
-Issues = "https://github.com/an0mium/aragora/issues"
+Repository = "https://github.com/synaptent/aragora"
+Issues = "https://github.com/synaptent/aragora/issues"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/scripts/portability_baseline.json
+++ b/scripts/portability_baseline.json
@@ -23,9 +23,6 @@
     "aragora-debate/README.md": [
       "legacy_slug"
     ],
-    "aragora-debate/pyproject.toml": [
-      "legacy_slug"
-    ],
     "aragora/live/e2e/admin.spec.ts": [
       "users_home"
     ],
@@ -286,17 +283,11 @@
     "examples/typescript-web/index.html": [
       "legacy_slug"
     ],
-    "pyproject.toml": [
-      "legacy_slug"
-    ],
     "scripts/inspect_cold_review_surface.py": [
       "legacy_slug"
     ],
     "scripts/run_offline_golden_path.sh": [
       "venv_python"
-    ],
-    "sdk/python/pyproject.toml": [
-      "legacy_slug"
     ],
     "sdk/python/tests/test_scim.py": [
       "users_home"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -56,11 +56,11 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/an0mium/aragora"
-Documentation = "https://github.com/an0mium/aragora/blob/main/docs/guides/python-quickstart.md"
-Repository = "https://github.com/an0mium/aragora/tree/main/sdk/python"
-Changelog = "https://github.com/an0mium/aragora/blob/main/sdk/python/CHANGELOG.md"
-"Getting Started" = "https://github.com/an0mium/aragora/blob/main/docs/START_HERE.md"
+Homepage = "https://github.com/synaptent/aragora"
+Documentation = "https://github.com/synaptent/aragora/blob/main/docs/guides/python-quickstart.md"
+Repository = "https://github.com/synaptent/aragora/tree/main/sdk/python"
+Changelog = "https://github.com/synaptent/aragora/blob/main/sdk/python/CHANGELOG.md"
+"Getting Started" = "https://github.com/synaptent/aragora/blob/main/docs/START_HERE.md"
 
 [tool.hatch.build.targets.wheel]
 packages = ["aragora_sdk"]


### PR DESCRIPTION
Part of the public-readiness slug migration (follow-up to #7707).

## Changes (metadata only)
- `pyproject.toml` (root): `Repository`, `Issues`
- `sdk/python/pyproject.toml`: `Homepage`, `Documentation`, `Repository`, `Changelog`, `Getting Started`
- `aragora-debate/pyproject.toml`: `Homepage`, `Documentation`, `Repository`, `Changelog`, `Bug Tracker`

All `github.com/an0mium/aragora…` → `…/synaptent/aragora…`, so PyPI package
pages link to the real repo. Baseline ratcheted down (3 `legacy_slug` entries
dropped, 0 added).

## Validation
All three TOML files re-validated as parseable; portability guard clean over the
PR's files; pre-commit green.

Merge ordering: full-tree guard re-greened by #7706 (pre-existing #7697 issue);
this PR's files are guard-clean and rebase trivially.

🤖 Generated with [Droid](https://factory.ai)