### PR TITLE
fix(public): rename Go operator module to synaptent/aragora-operator

### DIFF
--- a/aragora-operator/Makefile
+++ b/aragora-operator/Makefile
@@ -1,5 +1,5 @@
 # Image URL to use all building/pushing image targets
-IMG ?= ghcr.io/an0mium/aragora-operator:latest
+IMG ?= ghcr.io/synaptent/aragora-operator:latest
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.29.0

--- a/aragora-operator/controllers/aragoracluster_controller.go
+++ b/aragora-operator/controllers/aragoracluster_controller.go
@@ -35,14 +35,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	aragorav1alpha1 "github.com/an0mium/aragora-operator/api/v1alpha1"
-	"github.com/an0mium/aragora-operator/internal/aragora"
-	"github.com/an0mium/aragora-operator/internal/metrics"
+	aragorav1alpha1 "github.com/synaptent/aragora-operator/api/v1alpha1"
+	"github.com/synaptent/aragora-operator/internal/aragora"
+	"github.com/synaptent/aragora-operator/internal/metrics"
 )
 
 const (
 	clusterFinalizer = "aragora.ai/cluster-finalizer"
-	defaultImage     = "ghcr.io/an0mium/aragora:latest"
+	defaultImage     = "ghcr.io/synaptent/aragora:latest"
 )
 
 // AragoraClusterReconciler reconciles an AragoraCluster object

--- a/aragora-operator/controllers/aragorainstance_controller.go
+++ b/aragora-operator/controllers/aragorainstance_controller.go
@@ -36,8 +36,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	aragorav1alpha1 "github.com/an0mium/aragora-operator/api/v1alpha1"
-	"github.com/an0mium/aragora-operator/internal/metrics"
+	aragorav1alpha1 "github.com/synaptent/aragora-operator/api/v1alpha1"
+	"github.com/synaptent/aragora-operator/internal/metrics"
 )
 
 const (

--- a/aragora-operator/controllers/aragorapolicy_controller.go
+++ b/aragora-operator/controllers/aragorapolicy_controller.go
@@ -33,9 +33,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	aragorav1alpha1 "github.com/an0mium/aragora-operator/api/v1alpha1"
-	"github.com/an0mium/aragora-operator/internal/aragora"
-	"github.com/an0mium/aragora-operator/internal/metrics"
+	aragorav1alpha1 "github.com/synaptent/aragora-operator/api/v1alpha1"
+	"github.com/synaptent/aragora-operator/internal/aragora"
+	"github.com/synaptent/aragora-operator/internal/metrics"
 )
 
 const (

--- a/aragora-operator/go.mod
+++ b/aragora-operator/go.mod
@@ -1,4 +1,4 @@
-module github.com/an0mium/aragora-operator
+module github.com/synaptent/aragora-operator
 
 go 1.24.0
 

--- a/aragora-operator/helm/aragora-operator/Chart.yaml
+++ b/aragora-operator/helm/aragora-operator/Chart.yaml
@@ -10,9 +10,9 @@ keywords:
   - multi-agent
   - llm
   - operator
-home: https://github.com/an0mium/aragora
+home: https://github.com/synaptent/aragora
 sources:
-  - https://github.com/an0mium/aragora-operator
+  - https://github.com/synaptent/aragora-operator
 maintainers:
   - name: Aragora Team
     email: team@aragora.ai

--- a/aragora-operator/helm/aragora-operator/values.yaml
+++ b/aragora-operator/helm/aragora-operator/values.yaml
@@ -3,7 +3,7 @@
 
 # Operator image settings
 image:
-  repository: ghcr.io/an0mium/aragora-operator
+  repository: ghcr.io/synaptent/aragora-operator
   pullPolicy: IfNotPresent
   tag: ""  # Overrides the image tag whose default is the chart appVersion
 

--- a/aragora-operator/internal/aragora/client.go
+++ b/aragora-operator/internal/aragora/client.go
@@ -27,7 +27,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	aragorav1alpha1 "github.com/an0mium/aragora-operator/api/v1alpha1"
+	aragorav1alpha1 "github.com/synaptent/aragora-operator/api/v1alpha1"
 )
 
 // Client is the Aragora control plane API client

--- a/aragora-operator/main.go
+++ b/aragora-operator/main.go
@@ -29,9 +29,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	aragorav1alpha1 "github.com/an0mium/aragora-operator/api/v1alpha1"
-	"github.com/an0mium/aragora-operator/controllers"
-	"github.com/an0mium/aragora-operator/internal/metrics"
+	aragorav1alpha1 "github.com/synaptent/aragora-operator/api/v1alpha1"
+	"github.com/synaptent/aragora-operator/controllers"
+	"github.com/synaptent/aragora-operator/internal/metrics"
 )
 
 var (

--- a/scripts/portability_baseline.json
+++ b/scripts/portability_baseline.json
@@ -47,33 +47,6 @@
     "aragora-debate/pyproject.toml": [
       "legacy_slug"
     ],
-    "aragora-operator/Makefile": [
-      "legacy_slug"
-    ],
-    "aragora-operator/controllers/aragoracluster_controller.go": [
-      "legacy_slug"
-    ],
-    "aragora-operator/controllers/aragorainstance_controller.go": [
-      "legacy_slug"
-    ],
-    "aragora-operator/controllers/aragorapolicy_controller.go": [
-      "legacy_slug"
-    ],
-    "aragora-operator/go.mod": [
-      "legacy_slug"
-    ],
-    "aragora-operator/helm/aragora-operator/Chart.yaml": [
-      "legacy_slug"
-    ],
-    "aragora-operator/helm/aragora-operator/values.yaml": [
-      "legacy_slug"
-    ],
-    "aragora-operator/internal/aragora/client.go": [
-      "legacy_slug"
-    ],
-    "aragora-operator/main.go": [
-      "legacy_slug"
-    ],
     "aragora/live/e2e/admin.spec.ts": [
       "users_home"
     ],


### PR DESCRIPTION
Part of the public-readiness slug migration (follow-up to #7707).

## Changes (all of `aragora-operator/`)
- **`go.mod`**: module path → `github.com/synaptent/aragora-operator`
- **`*.go`** (`controllers/`, `internal/aragora/client.go`, `main.go`):
  intra-module import paths updated consistently
- **image refs** (`defaultImage` in the cluster controller, `Makefile` `IMG`,
  `helm/.../values.yaml` `repository`): `ghcr.io/an0mium/…` → `ghcr.io/synaptent/…`
- **`helm/.../Chart.yaml`** `home`/`sources` URLs → synaptent

## Validation
- ✅ `go build ./...` (go1.26) compiles cleanly — confirms the module rename +
  all import paths are consistent. `go.sum` unchanged (a module's own path is
  not recorded there).
- Portability baseline ratcheted down (9 `legacy_slug` entries dropped, 0 added);
  guard clean over the PR's files; pre-commit green.

## Notes
- `ghcr.io/synaptent/aragora[-operator]` is **forward-correct** for the public
  repo — assumes CI publishes images under the `synaptent` namespace (operational
  prerequisite, same as any first publish).
- `controllers/aragorapolicy_controller.go` and `internal/metrics/collector.go`
  are **already gofmt-unclean on `main`**; that pre-existing formatting is left
  as-is (my slug edits are gofmt-neutral).

Merge ordering: full-tree guard re-greened by #7706.

🤖 Generated with [Droid](https://factory.ai)