### PR TITLE
fix(public): correct legacy slug in deploy manifests + examples

### DIFF
--- a/deploy/argo-rollouts/rollout.yaml
+++ b/deploy/argo-rollouts/rollout.yaml
@@ -38,7 +38,7 @@ spec:
 
       containers:
         - name: aragora
-          image: ghcr.io/an0mium/aragora:2.1.10
+          image: ghcr.io/synaptent/aragora:2.1.10
           imagePullPolicy: Always
 
           ports:

--- a/deploy/argocd/applications/applicationset.yaml
+++ b/deploy/argocd/applications/applicationset.yaml
@@ -53,7 +53,7 @@ spec:
 
       # Source repository
       source:
-        repoURL: https://github.com/an0mium/aragora
+        repoURL: https://github.com/synaptent/aragora
         targetRevision: main
         path: deploy/helm/aragora
         helm:
@@ -140,7 +140,7 @@ spec:
       project: aragora-staging
 
       source:
-        repoURL: https://github.com/an0mium/aragora
+        repoURL: https://github.com/synaptent/aragora
         targetRevision: '{{branch}}'
         path: deploy/helm/aragora
         helm:

--- a/deploy/argocd/install/values.yaml
+++ b/deploy/argocd/install/values.yaml
@@ -140,7 +140,7 @@ configs:
   # Repository credentials
   repositories:
     aragora:
-      url: https://github.com/an0mium/aragora
+      url: https://github.com/synaptent/aragora
       type: git
       # Use deploy key or GitHub App for authentication
       # sshPrivateKey: $repository-ssh-key

--- a/deploy/argocd/projects/aragora-project.yaml
+++ b/deploy/argocd/projects/aragora-project.yaml
@@ -11,7 +11,7 @@ spec:
 
   # Source repositories
   sourceRepos:
-    - https://github.com/an0mium/aragora
+    - https://github.com/synaptent/aragora
     - https://charts.bitnami.com/bitnami  # For dependencies
 
   # Destination clusters and namespaces
@@ -146,7 +146,7 @@ spec:
   description: Aragora Staging Environment
 
   sourceRepos:
-    - https://github.com/an0mium/aragora
+    - https://github.com/synaptent/aragora
 
   destinations:
     - server: https://staging.aragora.k8s.local

--- a/deploy/docker-compose.production.yml
+++ b/deploy/docker-compose.production.yml
@@ -73,7 +73,7 @@ services:
   # ===========================================================================
 
   aragora:
-    image: ${ARAGORA_IMAGE:-ghcr.io/an0mium/aragora:2.1.10}
+    image: ${ARAGORA_IMAGE:-ghcr.io/synaptent/aragora:2.1.10}
     build:
       context: ..
       dockerfile: deploy/Dockerfile
@@ -253,7 +253,7 @@ services:
   # ===========================================================================
 
   debate-worker:
-    image: ${ARAGORA_IMAGE:-ghcr.io/an0mium/aragora:2.1.10}
+    image: ${ARAGORA_IMAGE:-ghcr.io/synaptent/aragora:2.1.10}
     build:
       context: ..
       dockerfile: deploy/Dockerfile

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   backend:
-    image: ${ARAGORA_BACKEND_IMAGE:-ghcr.io/an0mium/aragora/backend:2.1.10}
+    image: ${ARAGORA_BACKEND_IMAGE:-ghcr.io/synaptent/aragora/backend:2.1.10}
     build:
       context: ..
       dockerfile: deploy/Dockerfile.backend
@@ -48,7 +48,7 @@ services:
           memory: 4G
 
   frontend:
-    image: ${ARAGORA_FRONTEND_IMAGE:-ghcr.io/an0mium/aragora/frontend:2.1.10}
+    image: ${ARAGORA_FRONTEND_IMAGE:-ghcr.io/synaptent/aragora/frontend:2.1.10}
     build:
       context: ..
       dockerfile: deploy/Dockerfile.frontend

--- a/deploy/ec2-userdata.sh
+++ b/deploy/ec2-userdata.sh
@@ -27,7 +27,7 @@ useradd -m -s /bin/bash aragora || true
 
 # Clone aragora repository
 cd /home/aragora
-sudo -u aragora git clone https://github.com/an0mium/aragora.git || (cd aragora && sudo -u aragora git pull)
+sudo -u aragora git clone https://github.com/synaptent/aragora.git || (cd aragora && sudo -u aragora git pull)
 
 # Install Python dependencies
 cd /home/aragora/aragora

--- a/deploy/kubernetes/backend-deployment.yaml
+++ b/deploy/kubernetes/backend-deployment.yaml
@@ -29,7 +29,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backend
-          image: ghcr.io/an0mium/aragora/backend:2.1.10
+          image: ghcr.io/synaptent/aragora/backend:2.1.10
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/kubernetes/backup-verification-cronjob.yaml
+++ b/deploy/kubernetes/backup-verification-cronjob.yaml
@@ -60,7 +60,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: verify
-              image: ghcr.io/an0mium/aragora:2.1.10
+              image: ghcr.io/synaptent/aragora:2.1.10
               imagePullPolicy: Always
               command:
                 - python
@@ -136,7 +136,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: verify
-          image: ghcr.io/an0mium/aragora:2.1.10
+          image: ghcr.io/synaptent/aragora:2.1.10
           imagePullPolicy: Always
           command:
             - python

--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -47,7 +47,7 @@ spec:
                 topologyKey: kubernetes.io/hostname
       containers:
         - name: aragora
-          image: ghcr.io/an0mium/aragora:2.1.10
+          image: ghcr.io/synaptent/aragora:2.1.10
           imagePullPolicy: Always
           ports:
             - name: http

--- a/deploy/kubernetes/frontend-deployment.yaml
+++ b/deploy/kubernetes/frontend-deployment.yaml
@@ -25,7 +25,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: frontend
-          image: ghcr.io/an0mium/aragora/frontend:2.1.10
+          image: ghcr.io/synaptent/aragora/frontend:2.1.10
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/kubernetes/migration-job.yaml
+++ b/deploy/kubernetes/migration-job.yaml
@@ -92,7 +92,7 @@ spec:
 
       containers:
         - name: migrate
-          image: ghcr.io/an0mium/aragora:2.1.10  # Will be overridden by kustomize
+          image: ghcr.io/synaptent/aragora:2.1.10  # Will be overridden by kustomize
           imagePullPolicy: IfNotPresent
           command:
             - python
@@ -165,7 +165,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: status
-          image: ghcr.io/an0mium/aragora:2.1.10
+          image: ghcr.io/synaptent/aragora:2.1.10
           imagePullPolicy: IfNotPresent
           command:
             - python

--- a/deploy/kubernetes/secrets-rotation/cronjob.yaml
+++ b/deploy/kubernetes/secrets-rotation/cronjob.yaml
@@ -60,7 +60,7 @@ spec:
 
           containers:
             - name: rotation
-              image: ghcr.io/an0mium/aragora/secrets-rotation:2.1.10
+              image: ghcr.io/synaptent/aragora/secrets-rotation:2.1.10
               imagePullPolicy: Always
 
               command:

--- a/deploy/lightsail-setup.sh
+++ b/deploy/lightsail-setup.sh
@@ -3,7 +3,7 @@
 # Run this on a fresh Ubuntu 22.04 Lightsail instance
 #
 # Usage:
-#   curl -sL https://raw.githubusercontent.com/an0mium/aragora/main/deploy/lightsail-setup.sh | bash
+#   curl -sL https://raw.githubusercontent.com/synaptent/aragora/main/deploy/lightsail-setup.sh | bash
 #
 # Or manually:
 #   chmod +x lightsail-setup.sh && ./lightsail-setup.sh
@@ -27,7 +27,7 @@ cd /home/ubuntu
 if [ -d "aragora" ]; then
     cd aragora && git pull
 else
-    git clone https://github.com/an0mium/aragora.git
+    git clone https://github.com/synaptent/aragora.git
     cd aragora
 fi
 

--- a/deploy/openclaw/docker-compose.devops.yml
+++ b/deploy/openclaw/docker-compose.devops.yml
@@ -5,16 +5,16 @@
 #
 # Usage:
 #   # Dry run (preview actions)
-#   GITHUB_REPO=an0mium/aragora docker compose -f docker-compose.devops.yml up
+#   GITHUB_REPO=synaptent/aragora docker compose -f docker-compose.devops.yml up
 #
 #   # Live mode with PR reviews
-#   GITHUB_REPO=an0mium/aragora \
+#   GITHUB_REPO=synaptent/aragora \
 #   ANTHROPIC_API_KEY=sk-ant-... \
 #   OPENAI_API_KEY=sk-... \
 #   docker compose -f docker-compose.devops.yml --profile live up
 #
 #   # Watch mode (continuous polling)
-#   GITHUB_REPO=an0mium/aragora \
+#   GITHUB_REPO=synaptent/aragora \
 #   AGENT_MODE=watch \
 #   docker compose -f docker-compose.devops.yml --profile live up
 
@@ -26,7 +26,7 @@ services:
     container_name: aragora-devops-agent
     command: >
       python scripts/run_devops_agent.py
-        --repo ${GITHUB_REPO:-an0mium/aragora}
+        --repo ${GITHUB_REPO:-synaptent/aragora}
         --task ${AGENT_TASK:-health-check}
         --mode ${AGENT_MODE:-once}
         --poll-interval ${POLL_INTERVAL:-300}

--- a/deploy/openclaw/docker-compose.pr-reviewer.yml
+++ b/deploy/openclaw/docker-compose.pr-reviewer.yml
@@ -29,7 +29,7 @@ services:
     container_name: aragora-pr-reviewer
     command: >
       python scripts/run_devops_agent.py
-        --repo ${GITHUB_REPO:-an0mium/aragora}
+        --repo ${GITHUB_REPO:-synaptent/aragora}
         --task review-prs
         --mode ${AGENT_MODE:-once}
         --poll-interval ${POLL_INTERVAL:-300}

--- a/deploy/openclaw/pr-reviewer-setup.sh
+++ b/deploy/openclaw/pr-reviewer-setup.sh
@@ -2,7 +2,7 @@
 # Aragora PR Reviewer — One-Command Setup
 #
 # Usage:
-#   ./pr-reviewer-setup.sh                   # Dry-run review of an0mium/aragora
+#   ./pr-reviewer-setup.sh                   # Dry-run review of synaptent/aragora
 #   ./pr-reviewer-setup.sh --repo owner/repo  # Review a specific repo
 #   ./pr-reviewer-setup.sh --install-workflow  # Also install the GH Actions workflow
 #   ./pr-reviewer-setup.sh --help
@@ -15,7 +15,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COMPOSE_FILE="$SCRIPT_DIR/docker-compose.pr-reviewer.yml"
 
 # Defaults
-REPO="${GITHUB_REPO:-an0mium/aragora}"
+REPO="${GITHUB_REPO:-synaptent/aragora}"
 MODE="once"
 DRY_RUN="true"
 INSTALL_WORKFLOW=false
@@ -28,7 +28,7 @@ Aragora PR Reviewer Setup
 Usage: $(basename "$0") [OPTIONS]
 
 Options:
-  --repo OWNER/REPO     GitHub repo to review (default: an0mium/aragora)
+  --repo OWNER/REPO     GitHub repo to review (default: synaptent/aragora)
   --pr URL              Review a specific PR URL
   --live                Enable live mode (posts comments to PRs)
   --watch               Watch for new PRs and review continuously

--- a/deploy/quickstart.sh
+++ b/deploy/quickstart.sh
@@ -81,7 +81,7 @@ deploy_docker() {
         work_dir="${HOME}/.aragora"; compose_file="${work_dir}/docker-compose.yml"
         mkdir -p "$work_dir"
         info "Downloading docker-compose.yml..."
-        curl -sSfL "https://raw.githubusercontent.com/an0mium/aragora/main/deploy/docker-compose.yml" \
+        curl -sSfL "https://raw.githubusercontent.com/synaptent/aragora/main/deploy/docker-compose.yml" \
             -o "$compose_file" || fatal "Download failed"
     fi
     ok "Compose file: $compose_file"

--- a/deploy/self-hosted/.env.example
+++ b/deploy/self-hosted/.env.example
@@ -29,8 +29,8 @@ ANTHROPIC_API_KEY=
 # =============================================================================
 # Image pins (recommended for deterministic upgrades)
 # =============================================================================
-# ARAGORA_IMAGE=ghcr.io/an0mium/aragora:2.8.0
-# ARAGORA_DASHBOARD_IMAGE=ghcr.io/an0mium/aragora-dashboard:2.8.0
+# ARAGORA_IMAGE=ghcr.io/synaptent/aragora:2.8.0
+# ARAGORA_DASHBOARD_IMAGE=ghcr.io/synaptent/aragora-dashboard:2.8.0
 
 # =============================================================================
 # Database (defaults work out of the box)

--- a/deploy/self-hosted/docker-compose.yml
+++ b/deploy/self-hosted/docker-compose.yml
@@ -196,7 +196,7 @@ services:
           memory: 32M
 
   aragora:
-    image: ${ARAGORA_IMAGE:-ghcr.io/an0mium/aragora:2.8.0}
+    image: ${ARAGORA_IMAGE:-ghcr.io/synaptent/aragora:2.8.0}
     build:
       context: ../..
       dockerfile: Dockerfile
@@ -270,7 +270,7 @@ services:
   # =============================================================================
 
   dashboard:
-    image: ${ARAGORA_DASHBOARD_IMAGE:-ghcr.io/an0mium/aragora-dashboard:2.8.0}
+    image: ${ARAGORA_DASHBOARD_IMAGE:-ghcr.io/synaptent/aragora-dashboard:2.8.0}
     build:
       context: ../../aragora/live
       dockerfile: Dockerfile
@@ -304,7 +304,7 @@ services:
   # =============================================================================
 
   debate-worker:
-    image: ${ARAGORA_IMAGE:-ghcr.io/an0mium/aragora:2.8.0}
+    image: ${ARAGORA_IMAGE:-ghcr.io/synaptent/aragora:2.8.0}
     build:
       context: ../..
       dockerfile: Dockerfile

--- a/docs/index.html
+++ b/docs/index.html
@@ -591,7 +591,7 @@
                     <span>PyPI</span>
                     <span style="color: var(--green);">v0.7.0</span>
                 </a>
-                <a href="https://github.com/an0mium/aragora" class="badge">
+                <a href="https://github.com/synaptent/aragora" class="badge">
                     <span>GitHub</span>
                 </a>
                 <span class="badge">
@@ -848,7 +848,7 @@
             <a href="https://aragora.ai" class="btn btn-primary">
                 Watch Live
             </a>
-            <a href="https://github.com/an0mium/aragora" class="btn btn-secondary">
+            <a href="https://github.com/synaptent/aragora" class="btn btn-secondary">
                 View on GitHub
             </a>
             <a href="https://pypi.org/project/aragora/" class="btn btn-secondary">
@@ -858,7 +858,7 @@
 
         <footer>
             <p>Built for the open marketplace of ideas.</p>
-            <p style="margin-top: 0.5rem;">Released under <a href="https://github.com/an0mium/aragora/blob/main/LICENSE">MIT License</a>.</p>
+            <p style="margin-top: 0.5rem;">Released under <a href="https://github.com/synaptent/aragora/blob/main/LICENSE">MIT License</a>.</p>
         </footer>
     </div>
 

--- a/examples/github-action/advanced.yml
+++ b/examples/github-action/advanced.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - name: Run Aragora Review (Strict)
         id: review
-        uses: an0mium/aragora@main
+        uses: synaptent/aragora@main
         with:
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}

--- a/examples/github-action/aragora-review-strict.yml
+++ b/examples/github-action/aragora-review-strict.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Run Aragora Review
         id: review
-        uses: an0mium/aragora@main
+        uses: synaptent/aragora@main
         with:
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}

--- a/examples/github-action/aragora-review.yml
+++ b/examples/github-action/aragora-review.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - name: Run Aragora Review
         id: review
-        uses: an0mium/aragora@main
+        uses: synaptent/aragora@main
         with:
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}

--- a/examples/github-action/basic.yml
+++ b/examples/github-action/basic.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Run Aragora Review
         id: review
-        uses: an0mium/aragora@main
+        uses: synaptent/aragora@main
         with:
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}

--- a/examples/quickstart/code_review.py
+++ b/examples/quickstart/code_review.py
@@ -143,7 +143,7 @@ def findings_to_sarif(findings: list[ReviewFinding]) -> dict:
                     "driver": {
                         "name": "aragora-review",
                         "version": "1.0.0",
-                        "informationUri": "https://github.com/an0mium/aragora",
+                        "informationUri": "https://github.com/synaptent/aragora",
                         "rules": rules,
                     }
                 },

--- a/examples/typescript-web/index.html
+++ b/examples/typescript-web/index.html
@@ -186,7 +186,7 @@
 
     <footer>
       <p>
-        <a href="https://github.com/an0mium/aragora" target="_blank">GitHub</a> |
+        <a href="https://github.com/synaptent/aragora" target="_blank">GitHub</a> |
         <a href="../../docs/guides/typescript-quickstart.md">Documentation</a>
       </p>
     </footer>

--- a/scripts/portability_baseline.json
+++ b/scripts/portability_baseline.json
@@ -20,66 +20,6 @@
     "benchmarks/bench_readiness/write_manifest.py": [
       "venv_python"
     ],
-    "deploy/argo-rollouts/rollout.yaml": [
-      "legacy_slug"
-    ],
-    "deploy/argocd/applications/applicationset.yaml": [
-      "legacy_slug"
-    ],
-    "deploy/argocd/install/values.yaml": [
-      "legacy_slug"
-    ],
-    "deploy/argocd/projects/aragora-project.yaml": [
-      "legacy_slug"
-    ],
-    "deploy/docker-compose.production.yml": [
-      "legacy_slug"
-    ],
-    "deploy/docker-compose.yml": [
-      "legacy_slug"
-    ],
-    "deploy/ec2-userdata.sh": [
-      "legacy_slug"
-    ],
-    "deploy/kubernetes/backend-deployment.yaml": [
-      "legacy_slug"
-    ],
-    "deploy/kubernetes/backup-verification-cronjob.yaml": [
-      "legacy_slug"
-    ],
-    "deploy/kubernetes/deployment.yaml": [
-      "legacy_slug"
-    ],
-    "deploy/kubernetes/frontend-deployment.yaml": [
-      "legacy_slug"
-    ],
-    "deploy/kubernetes/migration-job.yaml": [
-      "legacy_slug"
-    ],
-    "deploy/kubernetes/secrets-rotation/cronjob.yaml": [
-      "legacy_slug"
-    ],
-    "deploy/lightsail-setup.sh": [
-      "legacy_slug"
-    ],
-    "deploy/openclaw/docker-compose.devops.yml": [
-      "legacy_slug"
-    ],
-    "deploy/openclaw/docker-compose.pr-reviewer.yml": [
-      "legacy_slug"
-    ],
-    "deploy/openclaw/pr-reviewer-setup.sh": [
-      "legacy_slug"
-    ],
-    "deploy/quickstart.sh": [
-      "legacy_slug"
-    ],
-    "deploy/self-hosted/.env.example": [
-      "legacy_slug"
-    ],
-    "deploy/self-hosted/docker-compose.yml": [
-      "legacy_slug"
-    ],
     "docs-site/docs/guides/connectors.md": [
       "users_home"
     ],
@@ -101,9 +41,6 @@
     "docs/guides/ISSUE_TRIAGE.md": [
       "venv_python"
     ],
-    "docs/index.html": [
-      "legacy_slug"
-    ],
     "docs/integrations/CONNECTORS.md": [
       "users_home"
     ],
@@ -112,24 +49,6 @@
     ],
     "docs/status/P05-publication-freshness-probe-rebase_RECEIPT_droid-A5312D6A.md": [
       "venv_python"
-    ],
-    "examples/github-action/advanced.yml": [
-      "legacy_slug"
-    ],
-    "examples/github-action/aragora-review-strict.yml": [
-      "legacy_slug"
-    ],
-    "examples/github-action/aragora-review.yml": [
-      "legacy_slug"
-    ],
-    "examples/github-action/basic.yml": [
-      "legacy_slug"
-    ],
-    "examples/quickstart/code_review.py": [
-      "legacy_slug"
-    ],
-    "examples/typescript-web/index.html": [
-      "legacy_slug"
     ],
     "scripts/inspect_cold_review_surface.py": [
       "legacy_slug"


### PR DESCRIPTION
Part of the public-readiness slug migration (follow-up to #7707).

## Changes (27 files — pure string refs, no structural changes)
- **Container images**: `ghcr.io/an0mium/aragora[/backend|/frontend|-dashboard|/secrets-rotation]` → `ghcr.io/synaptent/…` (argo rollout, `docker-compose*.yml` ×4, `kubernetes/*`, `self-hosted/*`)
- **Clone / raw URLs** in setup scripts (`ec2-userdata.sh`, `lightsail-setup.sh`, `quickstart.sh`) → `github.com/synaptent/aragora` (the repo lives there)
- **ArgoCD** `repoURL`/source/project URLs → synaptent
- **GitHub Action examples** `uses: an0mium/aragora@main` → `synaptent/aragora@main`
- **openclaw** `GITHUB_REPO` defaults + help text → synaptent
- **HTML/links**: `docs/index.html`, `examples/typescript-web/index.html`, `examples/quickstart/code_review.py`

## Validation
- Every changed line is **slug-only** (verified: all added lines contain `synaptent/aragora`).
- Coupled tests pass (**47**): `test_check_self_host_compose.py`, `test_check_self_host_runtime.py`, `tests/cli/test_openclaw.py` — none assert the namespace.
- check-yaml / check-json / portability-guard / gitleaks green; baseline ratcheted down (27 dropped, 0 added).

## Note
`ghcr.io/synaptent/…` image refs are **forward-correct** for the public repo
(assumes CI publishes under the `synaptent` namespace — standard first-publish
prerequisite).

Merge ordering: full-tree guard re-greened by #7706.

🤖 Generated with [Droid](https://factory.ai)