### PR TITLE
test(public): use synaptent/aragora slug in devops/next-steps fixtures

### DIFF
--- a/scripts/portability_baseline.json
+++ b/scripts/portability_baseline.json
@@ -671,9 +671,6 @@
     "test_debate.py": [
       "users_home"
     ],
-    "tests/agents/test_devops_agent.py": [
-      "legacy_slug"
-    ],
     "tests/auth/scim/test_scim.py": [
       "users_home"
     ],
@@ -682,9 +679,6 @@
     ],
     "tests/codex/conftest.py": [
       "users_home"
-    ],
-    "tests/compat/openclaw/test_next_steps_runner.py": [
-      "legacy_slug"
     ],
     "tests/debate/test_graph.py": [
       "users_home"

--- a/tests/agents/test_devops_agent.py
+++ b/tests/agents/test_devops_agent.py
@@ -33,7 +33,7 @@ class TestDevOpsAgentConfig:
 
     def test_from_env(self):
         env = {
-            "ARAGORA_DEVOPS_REPO": "an0mium/aragora",
+            "ARAGORA_DEVOPS_REPO": "synaptent/aragora",
             "ARAGORA_DEVOPS_POLL_INTERVAL": "600",
             "ARAGORA_DEVOPS_AGENTS": "anthropic-api",
             "ARAGORA_DEVOPS_ALLOW_DESTRUCTIVE": "true",
@@ -42,7 +42,7 @@ class TestDevOpsAgentConfig:
         }
         with patch.dict(os.environ, env, clear=False):
             config = DevOpsAgentConfig.from_env()
-        assert config.repo == "an0mium/aragora"
+        assert config.repo == "synaptent/aragora"
         assert config.poll_interval == 600
         assert config.review_agents == "anthropic-api"
         assert config.allow_destructive is True

--- a/tests/compat/openclaw/test_next_steps_runner.py
+++ b/tests/compat/openclaw/test_next_steps_runner.py
@@ -585,8 +585,8 @@ class TestNextStepsRunner:
         assert runner._github_repo == "owner/repo"
 
     def test_extract_github_repo_from_https(self):
-        runner = NextStepsRunner(repo_url="https://github.com/an0mium/aragora")
-        assert runner._github_repo == "an0mium/aragora"
+        runner = NextStepsRunner(repo_url="https://github.com/synaptent/aragora")
+        assert runner._github_repo == "synaptent/aragora"
 
     def test_extract_github_repo_none(self):
         runner = NextStepsRunner(repo_path="/tmp/no-git-here-xyz")


### PR DESCRIPTION
Part of the public-readiness slug migration (follow-up to #7707).

## Changes (fixture data only)
- `tests/agents/test_devops_agent.py`: `ARAGORA_DEVOPS_REPO` input **and** the
  `config.repo` assertion → `synaptent/aragora`
- `tests/compat/openclaw/test_next_steps_runner.py`: `repo_url` input **and** the
  `_github_repo` assertion → `synaptent/aragora`

Both the input and the expected value change together, so the parsing logic is
exercised identically. Confirmed earlier that **no production default**
references the slug (these are self-contained fixtures).

## Validation
- ✅ **113 tests pass** in both files.
- Portability guard clean over the PR's files; pre-commit green; baseline
  ratcheted down (2 `legacy_slug` entries dropped, 0 added).

Merge ordering: full-tree guard re-greened by #7706.

🤖 Generated with [Droid](https://factory.ai)