### PR TITLE
fix(review): honor requested direct reviewer families

### DIFF
--- a/aragora/swarm/review_routing.py
+++ b/aragora/swarm/review_routing.py
@@ -21,13 +21,25 @@ logger = logging.getLogger(__name__)
 DEFAULT_REVIEW_PROVIDER_ORDER = ("codex", "claude", "openrouter")
 DEFAULT_CLAUDE_REVIEW_PROFILES = tuple(f"max-{index:02d}" for index in range(1, 13))
 _BILLING_MARKERS = ("credit balance", "billing", "payment required", "purchase credits")
+_DIRECT_API_PROVIDER_KEYS = {
+    "gemini": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
+    "grok": ("XAI_API_KEY", "GROK_API_KEY"),
+}
+_SUPPORTED_REVIEW_PROVIDERS = frozenset(
+    (*DEFAULT_REVIEW_PROVIDER_ORDER, *_DIRECT_API_PROVIDER_KEYS)
+)
 _MODEL_FAMILY_OVERRIDES = {
     "anthropic-api": "claude",
     "claude": "claude",
     "codex": "codex",
+    "gemini-cli": "gemini",
+    "google": "gemini",
+    "grok-cli": "grok",
     "openai": "codex",
     "openai-api": "codex",
     "openrouter": "openrouter",
+    "x-ai": "grok",
+    "xai": "grok",
 }
 
 
@@ -78,7 +90,7 @@ def resolve_review_candidates(
 
     if (
         preferred_family
-        and preferred_family in configured_order
+        and preferred_family in _SUPPORTED_REVIEW_PROVIDERS
         and preferred_family != worker_family
     ):
         families.append(preferred_family)
@@ -115,6 +127,8 @@ def preflight_review_candidate(
         return _claude_profile_preflight(candidate, repo_root=repo_root)
     if candidate.provider == "openrouter":
         return _openrouter_preflight()
+    if candidate.provider in _DIRECT_API_PROVIDER_KEYS:
+        return _direct_api_provider_preflight(candidate.provider)
     return {
         "ok": False,
         "detail": f"Unsupported review provider: {candidate.provider}",
@@ -225,6 +239,22 @@ async def _run_review_candidate(
             enable_fallback=False,
         )
         return await agent.generate(prompt)
+    if candidate.provider == "gemini":
+        agent = create_agent(
+            "gemini",
+            name="campaign-review",
+            role="critic",
+            enable_fallback=False,
+        )
+        return await agent.generate(prompt)
+    if candidate.provider == "grok":
+        agent = create_agent(
+            "grok",
+            name="campaign-review",
+            role="critic",
+            enable_fallback=False,
+        )
+        return await agent.generate(prompt)
     raise RuntimeError(f"Unsupported review provider: {candidate.provider}")
 
 
@@ -267,6 +297,14 @@ def _openrouter_preflight() -> dict[str, Any]:
     except OSError as exc:
         return {"ok": False, "detail": f"OpenRouter TLS check failed: {exc}"}
     return {"ok": True, "detail": "OpenRouter API key and TLS look healthy"}
+
+
+def _direct_api_provider_preflight(provider: str) -> dict[str, Any]:
+    key_names = _DIRECT_API_PROVIDER_KEYS[provider]
+    for key_name in key_names:
+        if get_secret_presence(key_name).source in {"aws", "env"}:
+            return {"ok": True, "detail": f"{provider} API key is configured"}
+    return {"ok": False, "detail": f"{' or '.join(key_names)} is not configured"}
 
 
 def _claude_profile_script(repo_root: Path) -> Path | None:

--- a/tests/swarm/test_review_routing.py
+++ b/tests/swarm/test_review_routing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -10,6 +11,7 @@ from aragora.swarm.review_routing import (
     ReviewCandidate,
     ReviewRoutingError,
     generate_review_response,
+    preflight_review_candidate,
     resolve_review_candidates,
 )
 
@@ -30,6 +32,67 @@ def test_resolve_review_candidates_skips_worker_family_and_expands_claude_profil
         "claude:max-02",
         "openrouter",
     ]
+
+
+@pytest.mark.parametrize(
+    ("preferred_review_model", "expected_label"),
+    [
+        ("gemini", "gemini"),
+        ("gemini-cli", "gemini"),
+        ("grok", "grok"),
+        ("grok-cli", "grok"),
+    ],
+)
+def test_resolve_review_candidates_honors_requested_direct_provider_family(
+    monkeypatch: pytest.MonkeyPatch,
+    preferred_review_model: str,
+    expected_label: str,
+) -> None:
+    monkeypatch.setenv("ARAGORA_REVIEW_PROVIDER_ORDER", "codex,claude,openrouter")
+    monkeypatch.setenv("ARAGORA_CLAUDE_REVIEW_PROFILES", "max-01")
+
+    candidates = resolve_review_candidates(
+        worker_model="codex",
+        preferred_review_model=preferred_review_model,
+    )
+
+    assert [candidate.label for candidate in candidates] == [
+        expected_label,
+        "claude:max-01",
+        "openrouter",
+    ]
+
+
+def test_preflight_review_candidate_accepts_direct_provider_key() -> None:
+    def fake_secret_presence(name: str):
+        source = "env" if name == "GOOGLE_API_KEY" else "none"
+        return SimpleNamespace(source=source)
+
+    with patch(
+        "aragora.swarm.review_routing.get_secret_presence", side_effect=fake_secret_presence
+    ):
+        result = preflight_review_candidate(
+            ReviewCandidate(provider="gemini", label="gemini"),
+            repo_root=Path("/tmp/repo"),
+        )
+
+    assert result == {"ok": True, "detail": "gemini API key is configured"}
+
+
+def test_preflight_review_candidate_blocks_missing_direct_provider_key() -> None:
+    with patch(
+        "aragora.swarm.review_routing.get_secret_presence",
+        return_value=SimpleNamespace(source="none"),
+    ):
+        result = preflight_review_candidate(
+            ReviewCandidate(provider="grok", label="grok"),
+            repo_root=Path("/tmp/repo"),
+        )
+
+    assert result == {
+        "ok": False,
+        "detail": "XAI_API_KEY or GROK_API_KEY is not configured",
+    }
 
 
 @pytest.mark.asyncio
@@ -75,6 +138,46 @@ async def test_generate_review_response_fails_over_to_next_candidate() -> None:
     assert result["attempts"][0]["candidate"] == "codex"
     assert result["attempts"][0]["kind"] == "cli_failure"
     assert result["attempts"][1]["candidate"] == "claude:max-01"
+
+
+@pytest.mark.asyncio
+async def test_generate_review_response_runs_requested_direct_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ARAGORA_REVIEW_PROVIDER_ORDER", "codex,claude,openrouter")
+
+    agent = AsyncMock()
+    agent.generate = AsyncMock(return_value='{"status":"passed","findings":[]}')
+
+    with (
+        patch(
+            "aragora.swarm.review_routing.preflight_review_candidate",
+            return_value={"ok": True, "detail": "gemini available"},
+        ),
+        patch("aragora.swarm.review_routing.create_agent", return_value=agent) as create_agent,
+    ):
+        result = await generate_review_response(
+            "review this",
+            worker_model="codex",
+            preferred_review_model="gemini",
+            repo_root=Path("/tmp/repo"),
+        )
+
+    assert result["candidate"]["label"] == "gemini"
+    assert result["attempts"] == [
+        {
+            "candidate": "gemini",
+            "stage": "generate",
+            "detail": "ok",
+        }
+    ]
+    create_agent.assert_called_once_with(
+        "gemini",
+        name="campaign-review",
+        role="critic",
+        enable_fallback=False,
+    )
+    agent.generate.assert_awaited_once_with("review this")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Treat explicitly requested Gemini/Grok reviewer families as supported review candidates even when the default review provider order remains conservative.
- Add direct API-key preflight for Gemini and Grok before generation.
- Run direct Gemini/Grok agents with fallback disabled so review-pr no longer silently routes a requested non-OpenAI reviewer to Codex first.

## Tests
- python3 -m pytest -q tests/swarm/test_review_routing.py
- python3 -m ruff check aragora/swarm/review_routing.py tests/swarm/test_review_routing.py
- git diff --check
- commit/push hooks: ruff, ruff format, mypy, gitleaks, portability guard

## Notes
- This does not merge, mark-ready, set statuses, or touch branch protection.
- Shared-root dirt was not modified.