### PR TITLE
fix(cli): local fallback for consensus detect when API is unavailable

### DIFF
--- a/aragora/cli/commands/consensus.py
+++ b/aragora/cli/commands/consensus.py
@@ -209,8 +209,17 @@ def cmd_consensus_detect(args: argparse.Namespace) -> int:
         print("Error: No valid proposals found", file=sys.stderr)
         return 1
 
-    # Try API-first
-    result = _try_api_detect(task, proposals, threshold, args)
+    # Try API-first. _try_api_detect returns None when the server is
+    # unavailable (so we fall back to local); a genuine client-side request
+    # error (4xx) is re-raised and surfaced here as a clean CLI message
+    # instead of an uncaught traceback.
+    from aragora.client.errors import AragoraAPIError
+
+    try:
+        result = _try_api_detect(task, proposals, threshold, args)
+    except AragoraAPIError as e:
+        print(f"Error: API request failed: {e}", file=sys.stderr)
+        return 1
 
     # Fallback to local detection
     if result is None:
@@ -295,6 +304,7 @@ def _try_api_detect(
         import os
 
         from aragora.client.client import AragoraClient
+        from aragora.client.errors import AragoraAPIError
 
         api_url = getattr(args, "api_url", None) or os.environ.get(
             "ARAGORA_API_URL", "http://localhost:8080"
@@ -313,6 +323,19 @@ def _try_api_detect(
         return result
     except ImportError:
         logger.debug("AragoraClient not available")
+        return None
+    except AragoraAPIError as e:
+        # When the server is unavailable -- connection refused (status_code 0)
+        # or a 5xx server error -- fall back to local detection, since
+        # consensus over caller-supplied proposals is computable in-process.
+        # Genuine client-side request errors (4xx, e.g. validation) indicate a
+        # bad request rather than an unavailable server, so re-raise them.
+        status = getattr(e, "status_code", 0) or 0
+        if 400 <= status < 500:
+            raise
+        logger.debug(
+            "API consensus detect unavailable (status=%s); using local fallback: %s", status, e
+        )
         return None
     except (OSError, ConnectionError, RuntimeError, ValueError, KeyError) as e:
         logger.debug("API consensus detect failed: %s", e)

--- a/tests/cli/commands/test_consensus.py
+++ b/tests/cli/commands/test_consensus.py
@@ -278,3 +278,106 @@ class TestConsensusMainCommand:
 
         captured = capsys.readouterr()
         assert "aragora consensus" in captured.out
+
+
+class TestConsensusDetectOfflineFallback:
+    """Regression: when the API server is unavailable, `consensus detect` must
+    fall back to local detection instead of crashing.
+
+    Previously ``_try_api_detect`` only caught a fixed tuple of builtin
+    exceptions, so the ``AragoraAPIError`` raised by the SDK client on a
+    connection failure propagated out and the documented local fallback never
+    ran (the command exited non-zero with a connection error).
+    """
+
+    @staticmethod
+    def _args(**kw):
+        base = dict(api_url=None, api_key=None)
+        base.update(kw)
+        return argparse.Namespace(**base)
+
+    def test_api_connection_error_falls_back(self):
+        from aragora.cli.commands.consensus import _try_api_detect
+        from aragora.client.errors import AragoraAPIError
+
+        with patch("aragora.client.client.AragoraClient") as MockClient:
+            MockClient.return_value.request.side_effect = AragoraAPIError(
+                "Connection error", "CONNECTION_ERROR", 0
+            )
+            result = _try_api_detect(
+                "Choose a DB", [{"agent": "a", "content": "Use Postgres"}], 0.7, self._args()
+            )
+        assert result is None
+
+    def test_api_server_5xx_falls_back(self):
+        from aragora.cli.commands.consensus import _try_api_detect
+        from aragora.client.errors import AragoraAPIError
+
+        with patch("aragora.client.client.AragoraClient") as MockClient:
+            MockClient.return_value.request.side_effect = AragoraAPIError(
+                "Server error", "INTERNAL", 500
+            )
+            result = _try_api_detect(
+                "Choose a DB", [{"agent": "a", "content": "Use Postgres"}], 0.7, self._args()
+            )
+        assert result is None
+
+    def test_api_client_4xx_is_reraised(self):
+        from aragora.cli.commands.consensus import _try_api_detect
+        from aragora.client.errors import ValidationError
+
+        with patch("aragora.client.client.AragoraClient") as MockClient:
+            MockClient.return_value.request.side_effect = ValidationError(
+                "bad proposals", field="proposals"
+            )
+            with pytest.raises(ValidationError):
+                _try_api_detect("Choose a DB", [{"agent": "a", "content": "x"}], 0.7, self._args())
+
+    @patch("aragora.cli.commands.consensus._try_local_detect")
+    def test_detect_command_falls_back_to_local_when_api_down(self, mock_local):
+        from aragora.client.errors import AragoraAPIError
+
+        mock_local.return_value = {
+            "debate_id": "detect-x",
+            "consensus_reached": True,
+            "confidence": 0.8,
+        }
+        args = argparse.Namespace(
+            task="Choose a DB",
+            proposals='["Use PostgreSQL", "PostgreSQL with Redis"]',
+            file=None,
+            stdin=False,
+            threshold=0.7,
+            output_format="json",
+            api_url=None,
+            api_key=None,
+        )
+        with patch("aragora.client.client.AragoraClient") as MockClient:
+            MockClient.return_value.request.side_effect = AragoraAPIError(
+                "Connection error", "CONNECTION_ERROR", 0
+            )
+            result = cmd_consensus_detect(args)
+        assert result == 0
+        mock_local.assert_called_once()
+
+    def test_detect_command_surfaces_client_4xx(self, capsys):
+        from aragora.client.errors import ValidationError
+
+        args = argparse.Namespace(
+            task="Choose a DB",
+            proposals='["Use PostgreSQL"]',
+            file=None,
+            stdin=False,
+            threshold=0.7,
+            output_format="text",
+            api_url=None,
+            api_key=None,
+        )
+        with patch("aragora.client.client.AragoraClient") as MockClient:
+            MockClient.return_value.request.side_effect = ValidationError(
+                "bad proposals", field="proposals"
+            )
+            result = cmd_consensus_detect(args)
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "API request failed" in captured.err


### PR DESCRIPTION
## What

`aragora consensus detect` documents an API-first path that "falls back to local
`ConsensusBuilder`", but `_try_api_detect` only caught a fixed tuple of builtin
exceptions. The SDK client raises `AragoraAPIError` (code `CONNECTION_ERROR`,
`status_code=0`) when no server is reachable, so the exception propagated and the
documented fallback never ran — `consensus detect` crashed offline instead of
computing consensus locally over the supplied proposals.

## Fix

- Catch `AragoraAPIError` in `_try_api_detect`: fall back to local detection on
  connection-class (status 0) and 5xx server failures; re-raise genuine
  client-side 4xx errors.
- Surface re-raised 4xx as a clean CLI error (`Error: API request failed: ...`,
  exit 1) instead of an uncaught traceback.

Behavior is unchanged when the API server is reachable.

## Validation

- `ruff check` clean; 22/22 `tests/cli/commands/test_consensus.py` pass — 5 new
  regression tests: connection→local, 5xx→local, 4xx re-raised, command-level
  fallback, command-level 4xx surfaced.
- Real offline smoke: `aragora consensus detect --task ... --proposals '[...]'`
  with no server now returns valid JSON (exit 0).

## Provenance

Found while dogfooding the offline decision-integrity surface. The fix spec was
adversarially stress-tested via `aragora gauntlet` (verdict **APPROVED**, 95%
confidence, 0 findings) before implementation.

Draft: opened for review, not for auto-merge.
