### PR TITLE
fix(ci): skip plist-generator test in portability guard (re-green main)

### DIFF
--- a/scripts/check_portability.py
+++ b/scripts/check_portability.py
@@ -53,6 +53,10 @@ ALWAYS_SKIP = (
     # Regression test that asserts installers never bake .venv/bin/python; it
     # holds the pattern as fixture/assertion data, not a real interpreter capture.
     "tests/scripts/test_launchd_installers.py",
+    # Regression test that asserts the generated runner-health plist is clean
+    # (e.g. `/Users/<name>` absent); the literal is negative assertion data, not
+    # a real hardcoded path.
+    "tests/scripts/test_generate_runner_health_plist.py",
     # Machine-local gt store config (gitignored; its `workspace` is a per-clone
     # absolute path). Untracked, so never a portability concern.
     ".gt/config.json",

--- a/tests/scripts/test_check_portability.py
+++ b/tests/scripts/test_check_portability.py
@@ -61,6 +61,9 @@ def test_always_skip_covers_pattern_holding_tests(cp):
     # not flagged (e.g. the installer regression guard from the runtime PR).
     assert cp._is_skipped("tests/scripts/test_launchd_installers.py")
     assert cp._is_skipped("tests/scripts/test_check_portability.py")
+    # Regression test asserting the generated runner-health plist is clean holds
+    # the `/Users/<name>` literal as negative assertion data, not a real path.
+    assert cp._is_skipped("tests/scripts/test_generate_runner_health_plist.py")
     assert cp._is_skipped(".gt/config.json")
     assert not cp._is_skipped("tests/scripts/test_something_else.py")
 


### PR DESCRIPTION
## Problem

`portability-lint` is **RED on main**. The guard (`scripts/check_portability.py`) flags:

```
tests/scripts/test_generate_runner_health_plist.py: users_home
```

That file (added by #7704) contains at line 37:

```python
assert "/Users/armand" not in out
```

This is a **negative regression assertion** — it proves the generated runner-health plist is clean (never bakes a private home path). The literal is assertion *data*, not a real hardcoded path.

This is exactly the same shape as `tests/scripts/test_launchd_installers.py` and `tests/scripts/test_check_portability.py`, which are **already** in the guard's `ALWAYS_SKIP`. The new test was simply omitted from `ALWAYS_SKIP` when #7704 and #7706 landed in parallel.

## Fix (minimal, matches existing pattern)

1. Add `tests/scripts/test_generate_runner_health_plist.py` to the `ALWAYS_SKIP` tuple in `scripts/check_portability.py`, next to its sibling assertion-data tests, with a matching comment.
2. Add a mirroring `_is_skipped(...)` assertion to `tests/scripts/test_check_portability.py`.

## Verification

- `python3 scripts/check_portability.py` → **exit 0** (re-greened; was exit 1)
- Planted `/Users/<priv>/x` literal in a non-skipped temp file → **exit 1** (guard still fires on real new leaks)
- `pytest tests/scripts/test_check_portability.py` → **9 passed**
- `ruff check` on both files → clean
- Pre-commit portability guard hook → Passed

Re-greens `portability-lint` on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)