### PR TITLE
docs: sync CLI reference after lint-comment

### DIFF
--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -120,7 +120,7 @@ For full runtime configuration, see [ENVIRONMENT](../getting-started/environment
 | `replay` | - | Replay stored debates | - |
 | `review` | - | Run AI code review on a diff or PR | - |
 | `review-pr` | - | Review a live GitHub PR head and optionally run a fixer loop | - |
-| `review-queue` | - | PR review queue + advisory packets + human settlement | `act`, `baseline`, `build`, `evidence-lint`, `health`, `health-alert`, `merge-packet`, `observe-outcomes`, `packet`, `record-settlement`, `run` |
+| `review-queue` | - | PR review queue + advisory packets + human settlement | `act`, `baseline`, `build`, `evidence-lint`, `health`, `health-alert`, `lint-comment`, `merge-packet`, `observe-outcomes`, `packet`, `record-settlement`, `run` |
 | `rlm` | - | RLM (Recursive Language Models) operations | `clear-cache`, `compress`, `query`, `stats` |
 | `secrets` | - | Inspect AWS Secrets Manager-backed secret presence | `health`, `hydrate` |
 | `security` | - | Security operations (encryption, key rotation) | `health`, `list-tokens`, `migrate`, `rotate-key`, `rotate-token`, `status`, `verify-token` |

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -115,7 +115,7 @@ For full runtime configuration, see [ENVIRONMENT](ENVIRONMENT.md).
 | `replay` | - | Replay stored debates | - |
 | `review` | - | Run AI code review on a diff or PR | - |
 | `review-pr` | - | Review a live GitHub PR head and optionally run a fixer loop | - |
-| `review-queue` | - | PR review queue + advisory packets + human settlement | `act`, `baseline`, `build`, `evidence-lint`, `health`, `health-alert`, `merge-packet`, `observe-outcomes`, `packet`, `record-settlement`, `run` |
+| `review-queue` | - | PR review queue + advisory packets + human settlement | `act`, `baseline`, `build`, `evidence-lint`, `health`, `health-alert`, `lint-comment`, `merge-packet`, `observe-outcomes`, `packet`, `record-settlement`, `run` |
 | `rlm` | - | RLM (Recursive Language Models) operations | `clear-cache`, `compress`, `query`, `stats` |
 | `secrets` | - | Inspect AWS Secrets Manager-backed secret presence | `health`, `hydrate` |
 | `security` | - | Security operations (encryption, key rotation) | `health`, `list-tokens`, `migrate`, `rotate-key`, `rotate-token`, `status`, `verify-token` |


### PR DESCRIPTION
## Summary

- repair current-main CLI reference drift after #7714 added `review-queue lint-comment`
- update only generated CLI reference outputs in `docs/reference/CLI_REFERENCE.md` and `docs-site/docs/api/cli.md`

## Validation

- `python scripts/generate_cli_reference.py --check`
- `python scripts/generate_cli_reference.py --check --check-site`
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

This remains a draft generated-doc repair PR; it should get fresh exact-head evidence before ready/merge.