### PR TITLE
fix(review): harden Claude Max review-pool health + actionable errors

### DIFF
--- a/aragora/swarm/review_routing.py
+++ b/aragora/swarm/review_routing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import shutil
@@ -9,6 +10,7 @@ import ssl
 import subprocess
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -19,7 +21,10 @@ from aragora.config.secrets import get_secret_presence
 logger = logging.getLogger(__name__)
 
 DEFAULT_REVIEW_PROVIDER_ORDER = ("codex", "claude", "openrouter")
-DEFAULT_CLAUDE_REVIEW_PROFILES = tuple(f"max-{index:02d}" for index in range(1, 13))
+DEFAULT_CLAUDE_REVIEW_PROFILES = tuple(f"max-{index:02d}" for index in range(1, 14))
+DEFAULT_POOL_HEALTH_TTL_SECONDS = 3600.0
+_POOL_HEALTH_RELATIVE_PATH = ".aragora/claude_pool_health.json"
+_UNHEALTHY_PROFILE_STATES = {"expired", "not_configured", "unauthenticated", "logged_out"}
 _BILLING_MARKERS = ("credit balance", "billing", "payment required", "purchase credits")
 _DIRECT_API_PROVIDER_KEYS = {
     "gemini": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
@@ -150,13 +155,15 @@ async def generate_review_response(
     ):
         preflight = preflight_review_candidate(candidate, repo_root=repo_root)
         if not preflight.get("ok", False):
-            attempts.append(
-                {
-                    "candidate": candidate.label,
-                    "stage": "preflight",
-                    "detail": str(preflight.get("detail", "unavailable")).strip() or "unavailable",
-                }
-            )
+            attempt = {
+                "candidate": candidate.label,
+                "stage": "preflight",
+                "detail": str(preflight.get("detail", "unavailable")).strip() or "unavailable",
+            }
+            preflight_kind = str(preflight.get("kind", "")).strip()
+            if preflight_kind:
+                attempt["kind"] = preflight_kind
+            attempts.append(attempt)
             continue
         blocked = candidate_blocker(candidate) if candidate_blocker else None
         if blocked:
@@ -272,6 +279,30 @@ def _claude_profile_preflight(candidate: ReviewCandidate, *, repo_root: Path) ->
         return {"ok": False, "detail": "Claude review profile is missing"}
     if not shutil.which("claude"):
         return {"ok": False, "detail": "claude CLI not found on PATH"}
+
+    # ``status`` only reports the locally cached login flag, which stays "true"
+    # even after the subscription token has expired. Prefer a verify-backed
+    # health snapshot (or a live probe) so expired profiles are skipped instead
+    # of wasting a full generate attempt on every dead profile in the pool.
+    mode = _review_probe_mode()
+    if mode in {"snapshot", "live"}:
+        health = _load_pool_health(repo_root)
+        state = health.get(candidate.profile) if health else None
+        if state in _UNHEALTHY_PROFILE_STATES:
+            return {
+                "ok": False,
+                "kind": "claude_unauthenticated",
+                "detail": (
+                    f"{candidate.label} token is {state} "
+                    "(scripts/claude_profiles_bootstrap.sh login)"
+                ),
+            }
+        if state == "ok":
+            return {"ok": True, "detail": f"{candidate.label} verified (snapshot)"}
+        if mode == "live":
+            return _claude_live_probe(candidate, script=script, repo_root=repo_root)
+        # snapshot mode with no fresh signal falls back to the local status check
+
     result = subprocess.run(
         [str(script), "status", candidate.profile],
         cwd=str(repo_root),
@@ -283,7 +314,11 @@ def _claude_profile_preflight(candidate: ReviewCandidate, *, repo_root: Path) ->
     if result.returncode == 0:
         return {"ok": True, "detail": f"{candidate.label} authenticated"}
     detail = (result.stderr or result.stdout or "").strip()
-    return {"ok": False, "detail": detail or f"{candidate.label} is unavailable"}
+    return {
+        "ok": False,
+        "kind": "claude_unauthenticated",
+        "detail": detail or f"{candidate.label} is unavailable",
+    }
 
 
 def _openrouter_preflight() -> dict[str, Any]:
@@ -310,6 +345,113 @@ def _direct_api_provider_preflight(provider: str) -> dict[str, Any]:
 def _claude_profile_script(repo_root: Path) -> Path | None:
     script = (repo_root / "scripts" / "claude_profile.sh").resolve()
     return script if script.exists() else None
+
+
+def _review_probe_mode() -> str:
+    raw = str(os.environ.get("ARAGORA_CLAUDE_REVIEW_PROBE", "")).strip().lower()
+    if raw in {"snapshot", "live", "status"}:
+        return raw
+    return "snapshot"
+
+
+def _pool_health_path(repo_root: Path) -> Path:
+    override = str(os.environ.get("ARAGORA_CLAUDE_POOL_HEALTH_FILE", "")).strip()
+    if override:
+        return Path(override).expanduser()
+    return repo_root / _POOL_HEALTH_RELATIVE_PATH
+
+
+def _pool_health_ttl_seconds() -> float:
+    raw = str(os.environ.get("ARAGORA_CLAUDE_POOL_HEALTH_TTL", "")).strip()
+    if not raw:
+        return DEFAULT_POOL_HEALTH_TTL_SECONDS
+    try:
+        value = float(raw)
+    except ValueError:
+        return DEFAULT_POOL_HEALTH_TTL_SECONDS
+    return value if value >= 0 else DEFAULT_POOL_HEALTH_TTL_SECONDS
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    if not value:
+        return None
+    text = str(value).strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _load_pool_health(repo_root: Path) -> dict[str, str] | None:
+    """Return ``{profile_name: state}`` from a fresh verify-backed snapshot.
+
+    Returns ``None`` when the snapshot is missing, malformed, or older than the
+    configured TTL so callers fall back to a best-effort local status check.
+    """
+    path = _pool_health_path(repo_root)
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        payload = json.loads(raw)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    ttl = _pool_health_ttl_seconds()
+    if ttl > 0:
+        generated_at = _parse_timestamp(payload.get("generated_at"))
+        if generated_at is None:
+            return None
+        age = (datetime.now(timezone.utc) - generated_at).total_seconds()
+        if age > ttl:
+            return None
+    states: dict[str, str] = {}
+    for entry in payload.get("profiles", []) or []:
+        if not isinstance(entry, dict):
+            continue
+        name = str(entry.get("name", "")).strip()
+        state = str(entry.get("state", "")).strip().lower()
+        if name and state:
+            states[name] = state
+    return states or None
+
+
+def _claude_live_probe(
+    candidate: ReviewCandidate, *, script: Path, repo_root: Path
+) -> dict[str, Any]:
+    profile = candidate.profile or ""
+    if not profile:
+        return {"ok": False, "detail": "Claude review profile is missing"}
+    try:
+        result = subprocess.run(
+            [str(script), "exec", profile, "--", "claude", "-p", "ok"],
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            timeout=20,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            "ok": False,
+            "kind": "claude_unauthenticated",
+            "detail": f"{candidate.label} live probe timed out",
+        }
+    if result.returncode == 0:
+        return {"ok": True, "detail": f"{candidate.label} live-probe ok"}
+    detail = (result.stderr or result.stdout or "").strip()
+    return {
+        "ok": False,
+        "kind": "claude_unauthenticated",
+        "detail": detail[:200] or f"{candidate.label} live probe failed",
+    }
 
 
 async def _run_claude_profile_candidate(
@@ -393,14 +535,27 @@ def _failure_attempt(candidate: str, *, stage: str, exc: Exception) -> dict[str,
 
 
 def _review_routing_category(attempts: list[dict[str, Any]]) -> str:
-    if any(str(item.get("kind", "")).strip() == "billing_exhausted" for item in attempts):
+    kinds = [str(item.get("kind", "")).strip() for item in attempts]
+    if "billing_exhausted" in kinds:
         return "billing_exhausted"
+    has_claude_unauth = "claude_unauthenticated" in kinds
+    tried_non_claude = any(
+        not str(item.get("candidate", "")).strip().startswith("claude") for item in attempts
+    )
+    if has_claude_unauth and not tried_non_claude:
+        return "claude_pool_unauthenticated"
     return "unavailable"
 
 
 def _review_routing_public_message(category: str) -> str:
     if category == "billing_exhausted":
         return "Reviewer capacity is exhausted. Check the active reviewer account and available credits."
+    if category == "claude_pool_unauthenticated":
+        return (
+            "No authenticated Claude Max review profile is available. "
+            "Re-login with: scripts/claude_profiles_bootstrap.sh login "
+            "(then refresh: scripts/claude_profiles_bootstrap.sh verify --json)."
+        )
     return "No configured review candidate succeeded. Check logs for detail."
 
 

--- a/scripts/claude_profiles_bootstrap.sh
+++ b/scripts/claude_profiles_bootstrap.sh
@@ -32,6 +32,15 @@ if [[ "$MODE" == "login" && $# -gt 0 && "$1" == "--force" ]]; then
   shift
 fi
 
+JSON_OUTPUT=0
+if [[ "$MODE" == "verify" && $# -gt 0 && "$1" == "--json" ]]; then
+  JSON_OUTPUT=1
+  shift
+fi
+
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+HEALTH_FILE="${ARAGORA_CLAUDE_POOL_HEALTH_FILE:-${REPO_ROOT}/.aragora/claude_pool_health.json}"
+
 default_profiles=(
   max-01
   max-02
@@ -74,34 +83,40 @@ already_logged_in() {
   return 0
 }
 
+# Populates LAST_VERIFY_STATE (ok|expired|logged_out|not_configured) and
+# LAST_VERIFY_EMAIL so callers can emit a machine-readable health snapshot.
 verify_profile() {
   local profile="$1"
 
   printf "  %-10s " "$profile"
 
+  LAST_VERIFY_STATE="unknown"
+  LAST_VERIFY_EMAIL=""
+
   local status_output
   if ! status_output="$("${PROFILE_TOOL}" status "$profile" 2>/dev/null)"; then
     echo "NOT CONFIGURED"
+    LAST_VERIFY_STATE="not_configured"
     return 1
   fi
   if ! grep -q '"loggedIn": true' <<<"$status_output"; then
     echo "NOT LOGGED IN"
+    LAST_VERIFY_STATE="logged_out"
     return 1
   fi
 
+  local email
+  email="$(grep -o '"email": "[^"]*"' <<<"$status_output" | head -1 | sed 's/"email": "//;s/"//')"
+  LAST_VERIFY_EMAIL="$email"
+
   # Live probe with /dev/null stdin and 15s timeout
-  local probe_output
-  if probe_output="$(timeout 15 "${PROFILE_TOOL}" exec "$profile" -- claude -p "ok" </dev/null 2>&1)"; then
-    local email
-    email="$(grep -o '"email": "[^"]*"' <<<"$status_output" | head -1 | sed 's/"email": "//;s/"//')"
+  if timeout 15 "${PROFILE_TOOL}" exec "$profile" -- claude -p "ok" </dev/null >/dev/null 2>&1; then
     echo "OK  ($email)"
+    LAST_VERIFY_STATE="ok"
     return 0
   else
-    local email
-    email="$(grep -o '"email": "[^"]*"' <<<"$status_output" | head -1 | sed 's/"email": "//;s/"//')"
-    local err_line
-    err_line="$(echo "$probe_output" | grep -i -m1 'expired\|401\|error\|failed' || echo "$probe_output" | tail -1)"
     echo "EXPIRED  ($email)"
+    LAST_VERIFY_STATE="expired"
     return 1
   fi
 }
@@ -403,15 +418,32 @@ case "$MODE" in
     echo
     pass=0
     fail=0
+    json_entries=()
     for profile in "${profiles[@]}"; do
       if verify_profile "$profile"; then
         ((pass++)) || true
       else
         ((fail++)) || true
       fi
+      json_entries+=("$(printf '{"name": "%s", "email": "%s", "state": "%s"}' \
+        "$profile" "${LAST_VERIFY_EMAIL:-}" "${LAST_VERIFY_STATE:-unknown}")")
     done
     echo
     echo "${pass} passed, ${fail} failed"
+    if [[ "$JSON_OUTPUT" -eq 1 ]]; then
+      mkdir -p "$(dirname "$HEALTH_FILE")"
+      {
+        printf '{\n  "generated_at": "%s",\n  "healthy": %s,\n  "total": %s,\n  "profiles": [\n' \
+          "$(date -u +%FT%TZ)" "$pass" "${#profiles[@]}"
+        json_first=1
+        for entry in "${json_entries[@]}"; do
+          if [[ $json_first -eq 1 ]]; then json_first=0; else printf ',\n'; fi
+          printf '    %s' "$entry"
+        done
+        printf '\n  ]\n}\n'
+      } >"$HEALTH_FILE"
+      echo "Wrote health snapshot: $HEALTH_FILE"
+    fi
     if [[ $fail -gt 0 ]]; then
       echo "Run: $0 login [profile...] to fix expired tokens"
       exit 1

--- a/tests/swarm/test_review_routing.py
+++ b/tests/swarm/test_review_routing.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import json
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -14,6 +16,26 @@ from aragora.swarm.review_routing import (
     preflight_review_candidate,
     resolve_review_candidates,
 )
+
+
+def _make_repo_with_profile_script(root: Path) -> Path:
+    scripts_dir = root / "scripts"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    (scripts_dir / "claude_profile.sh").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    return root
+
+
+def _write_pool_health(
+    root: Path, profiles: list[dict[str, str]], *, age_seconds: float = 0.0
+) -> None:
+    generated_at = datetime.now(timezone.utc) - timedelta(seconds=age_seconds)
+    payload = {
+        "generated_at": generated_at.isoformat().replace("+00:00", "Z"),
+        "profiles": profiles,
+    }
+    health_path = root / ".aragora" / "claude_pool_health.json"
+    health_path.parent.mkdir(parents=True, exist_ok=True)
+    health_path.write_text(json.dumps(payload), encoding="utf-8")
 
 
 def test_resolve_review_candidates_skips_worker_family_and_expands_claude_profiles(
@@ -304,6 +326,129 @@ async def test_generate_review_response_raises_with_attempt_history() -> None:
             "detail": "OpenRouter TLS check failed",
         },
     ]
+
+
+def test_resolve_review_candidates_includes_max_13_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("ARAGORA_CLAUDE_REVIEW_PROFILES", raising=False)
+    monkeypatch.setenv("ARAGORA_REVIEW_PROVIDER_ORDER", "codex,claude")
+
+    candidates = resolve_review_candidates(
+        worker_model="codex",
+        preferred_review_model="claude",
+    )
+    claude_profiles = [c.profile for c in candidates if c.provider == "claude"]
+
+    assert claude_profiles == [f"max-{i:02d}" for i in range(1, 14)]
+    assert "max-13" in claude_profiles
+
+
+def test_claude_preflight_skips_expired_profile_from_snapshot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ARAGORA_CLAUDE_REVIEW_PROBE", "snapshot")
+    repo = _make_repo_with_profile_script(tmp_path)
+    _write_pool_health(repo, [{"name": "max-01", "email": "a@b.c", "state": "expired"}])
+
+    with patch("aragora.swarm.review_routing.shutil.which", return_value="/usr/bin/claude"):
+        result = preflight_review_candidate(
+            ReviewCandidate(provider="claude", label="claude:max-01", profile="max-01"),
+            repo_root=repo,
+        )
+
+    assert result["ok"] is False
+    assert result["kind"] == "claude_unauthenticated"
+    assert "login" in result["detail"]
+
+
+def test_claude_preflight_trusts_ok_snapshot_without_status_call(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ARAGORA_CLAUDE_REVIEW_PROBE", "snapshot")
+    repo = _make_repo_with_profile_script(tmp_path)
+    _write_pool_health(repo, [{"name": "max-02", "email": "a@b.c", "state": "ok"}])
+
+    run_spy = MagicMock(
+        side_effect=AssertionError("status subprocess must not run for ok snapshot")
+    )
+    with (
+        patch("aragora.swarm.review_routing.shutil.which", return_value="/usr/bin/claude"),
+        patch("aragora.swarm.review_routing.subprocess.run", run_spy),
+    ):
+        result = preflight_review_candidate(
+            ReviewCandidate(provider="claude", label="claude:max-02", profile="max-02"),
+            repo_root=repo,
+        )
+
+    assert result == {"ok": True, "detail": "claude:max-02 verified (snapshot)"}
+    run_spy.assert_not_called()
+
+
+def test_claude_preflight_falls_back_to_status_when_snapshot_stale(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ARAGORA_CLAUDE_REVIEW_PROBE", "snapshot")
+    monkeypatch.setenv("ARAGORA_CLAUDE_POOL_HEALTH_TTL", "3600")
+    repo = _make_repo_with_profile_script(tmp_path)
+    _write_pool_health(
+        repo,
+        [{"name": "max-03", "email": "a@b.c", "state": "expired"}],
+        age_seconds=7200,
+    )
+
+    with (
+        patch("aragora.swarm.review_routing.shutil.which", return_value="/usr/bin/claude"),
+        patch(
+            "aragora.swarm.review_routing.subprocess.run",
+            return_value=SimpleNamespace(returncode=0, stdout="", stderr=""),
+        ),
+    ):
+        result = preflight_review_candidate(
+            ReviewCandidate(provider="claude", label="claude:max-03", profile="max-03"),
+            repo_root=repo,
+        )
+
+    assert result == {"ok": True, "detail": "claude:max-03 authenticated"}
+
+
+@pytest.mark.asyncio
+async def test_generate_review_response_reports_claude_pool_unauthenticated() -> None:
+    with (
+        patch(
+            "aragora.swarm.review_routing.resolve_review_candidates",
+            return_value=[
+                ReviewCandidate(provider="claude", label="claude:max-01", profile="max-01"),
+                ReviewCandidate(provider="claude", label="claude:max-02", profile="max-02"),
+            ],
+        ),
+        patch(
+            "aragora.swarm.review_routing.preflight_review_candidate",
+            side_effect=[
+                {
+                    "ok": False,
+                    "kind": "claude_unauthenticated",
+                    "detail": "max-01 token is expired",
+                },
+                {
+                    "ok": False,
+                    "kind": "claude_unauthenticated",
+                    "detail": "max-02 token is expired",
+                },
+            ],
+        ),
+    ):
+        with pytest.raises(ReviewRoutingError) as exc_info:
+            await generate_review_response(
+                "review this",
+                worker_model="codex",
+                preferred_review_model="claude",
+                repo_root=Path("/tmp/repo"),
+            )
+
+    assert exc_info.value.category == "claude_pool_unauthenticated"
+    assert "claude_profiles_bootstrap.sh login" in str(exc_info.value)
+    assert exc_info.value.attempts[0]["kind"] == "claude_unauthenticated"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why
Live `claude_profiles_bootstrap.sh verify` shows the Claude Max pool can be **entirely expired** while local `claude auth status` still reports `loggedIn: true`. The review router's claude preflight trusted that local flag, so a codex (OpenAI) worker would attempt every "healthy-looking" Max profile, fail each `claude` call at generate-time, and end in a generic `ReviewRoutingError` — i.e. **"can't get a non-OpenAI review."**

## What
- `claude_profiles_bootstrap.sh verify --json` writes a verify-backed health snapshot to `.aragora/claude_pool_health.json` (`{generated_at, healthy, total, profiles:[{name,email,state}]}`, state ∈ `ok|expired|logged_out|not_configured`).
- `review_routing` claude preflight now consults that snapshot (TTL-bounded) and **skips expired/unconfigured profiles** instead of trusting the local login flag. Mode is selectable via `ARAGORA_CLAUDE_REVIEW_PROBE=snapshot|live|status` (default `snapshot`, falls back to local `status` when no fresh snapshot exists).
- Default pool now includes **max-13** (was max-01..max-12; bootstrap defines 13).
- A fully-unauthenticated pool now raises the actionable category `claude_pool_unauthenticated`: *"Re-login with: scripts/claude_profiles_bootstrap.sh login …"* instead of a generic message.

## Tests
`tests/swarm/test_review_routing.py`: snapshot-skips-expired, trusts-ok-snapshot-without-status-call, stale-snapshot-falls-back-to-status, max-13 inclusion, `claude_pool_unauthenticated` surfacing. 18/18 routing + 20/20 campaign-reviewer pass; ruff clean; `automation_pr_preflight.sh` green.

Draft dogfood PR (branch `dogfood/*`, not labeled boss-ready). Part 1 of A+B+C+D from the Claude-Max-pool spec.
