### PR TITLE
fix(truth-map): fail closed on genealogy errors

### DIFF
--- a/aragora/epistemic/truth_map.py
+++ b/aragora/epistemic/truth_map.py
@@ -173,19 +173,16 @@ def build_truth_map(
         from aragora.epistemic.genealogy import get_genealogy
 
         for unit_id, store in genealogy_inputs:
-            try:
-                gen = get_genealogy(unit_id, store, require_enabled=False)
-                genealogy_rows.append(
-                    GenealogyRow(
-                        code_unit_id=gen.code_unit_id,
-                        entry_count=len(gen.entries),
-                        chain_checksum=gen.chain_checksum,
-                        generated_at=gen.generated_at,
-                        entries=[e.to_dict() for e in gen.entries],
-                    )
+            gen = get_genealogy(unit_id, store, require_enabled=False)
+            genealogy_rows.append(
+                GenealogyRow(
+                    code_unit_id=gen.code_unit_id,
+                    entry_count=len(gen.entries),
+                    chain_checksum=gen.chain_checksum,
+                    generated_at=gen.generated_at,
+                    entries=[e.to_dict() for e in gen.entries],
                 )
-            except (ValueError, RuntimeError):
-                pass
+            )
 
     return OrgTruthMapReport(
         generated_at=datetime.datetime.utcnow().isoformat() + "Z",

--- a/tests/epistemic/test_truth_map.py
+++ b/tests/epistemic/test_truth_map.py
@@ -210,6 +210,19 @@ class TestGenealogyRows:
         assert len(row.chain_checksum) == 64  # SHA-256 hex
         assert len(row.entries) == 2
 
+    def test_genealogy_enabled_surfaces_store_errors(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class BrokenStore:
+            def get_entries(self, code_unit_id: str) -> list[object]:
+                raise RuntimeError(f"broken lineage for {code_unit_id}")
+
+        monkeypatch.setenv("ARAGORA_GENEALOGY_ENABLED", "1")
+
+        with pytest.raises(RuntimeError, match="broken lineage"):
+            build_truth_map(
+                claim_results=[],
+                genealogy_inputs=[("unit.a", BrokenStore())],  # type: ignore[list-item]
+            )
+
     def test_proof_first_shift_unit_id_accepted(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """The real DIC-24 target code unit ID round-trips through the report."""
         monkeypatch.setenv("ARAGORA_GENEALOGY_ENABLED", "1")


### PR DESCRIPTION
## Summary
- make requested genealogy drill-down retrieval fail closed instead of silently omitting rows when the genealogy store raises ValueError or RuntimeError
- add focused regression coverage for surfacing genealogy store errors when genealogy is enabled

## Validation
- python3 -m pytest tests/epistemic/test_truth_map.py::TestGenealogyRows -q
- python3 scripts/check_portability.py
- git diff --check origin/main...HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- pre-push hooks: ruff, ruff format, mypy, gitleaks, RBAC audit, env mutation audit, portability guard

## Notes
- follow-up to merged #7713; this branch does not touch the merged #7713 branch
- scope is limited to aragora/epistemic/truth_map.py and tests/epistemic/test_truth_map.py