### PR TITLE
fix(review-queue): ignore optional pending rows with required gate

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -2323,6 +2323,16 @@ def _build_packet(
         }
         if required_surface.get("error"):
             check_surfaces["required_pr_checks"]["error"] = str(required_surface.get("error"))
+        if (
+            required_available
+            and effective_required_count > 0
+            and not required_has_pending
+            and has_pending
+        ):
+            # Required-check gating can separate branch-protection waits from
+            # optional full-rollup capacity noise even when a required check
+            # still fails and keeps the packet blocked.
+            has_pending = False
         if effective_required_count > 0 and not required_has_failures and not required_has_pending:
             required_pr_check_gate_satisfied = True
             check_surfaces["required_pr_checks"]["gate_selected"] = True

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -2664,6 +2664,12 @@ class TestBuildQueueAndPacket:
         assert packet.machine_recommendation == "repair_first"
         assert packet.model_review_quorum["admin_squash_allowed"] is False
         assert packet.model_review_quorum["status"] == "repair_or_wait"
+        assert (
+            "checks are failing; repair before settlement" in packet.model_review_quorum["reasons"]
+        )
+        assert not any(
+            "checks are pending" in reason for reason in packet.model_review_quorum["reasons"]
+        )
 
     def test_required_pr_checks_gate_keeps_non_self_required_failure_blocking(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary
- prevent non-required full-rollup pending rows from adding a `checks are pending` merge-packet blocker when branch-protection required-check gating is available and required pending is empty
- keep required failures blocking, including stale required `aragora-merge-quorum`
- add regression coverage for the #7463 shadow-capacity/no required-pending shape

## Context
This is a bounded meta-tooling repair for #7463 at head `d8efb8681a85b8835abbb496ffd6e706e44961a7`. The patched local packet counts reviewers as `["claude", "openai"]`, required pending is `[]`, non-quorum required checks are green, optional Self-Hosted Shadow CI rows remain queued as non-required full-rollup noise, and the only remaining blocker is stale required `Aragora Merge Quorum / aragora-merge-quorum` run `26898956026` job `79345724901`.

## Validation
- `python3 -m pytest tests/cli/commands/test_review_queue.py -k 'required_pr_checks_gate or required_gate_classifies_real_rollup_shaped_long_queued_shadows or merge_quorum_self_check_uses_required_gate'`
- `python3 -m aragora.cli.main review-queue merge-packet --pr 7463 --json`
- push hooks passed, including mypy for changed Aragora files and portability guard

## Boundaries
This PR does not merge #7463, rerun CI, write settlement receipts, or apply admin merge. It only publishes the merge-packet gating repair needed before a fresh #7463 merge-quorum gate can evaluate repaired code.
