### PR TITLE
fix(work): hold policy-excluded Dependabot PRs

### DIFF
--- a/aragora/work/scoring.py
+++ b/aragora/work/scoring.py
@@ -12,6 +12,7 @@ RECOMMENDATION_CLASSES = {
     "blocked",
     "duplicate",
     "stale",
+    "policy-excluded",
     "review-only",
     "human-gated",
 }
@@ -105,6 +106,28 @@ def _swarm_ready_blockers(item: WorkItem) -> list[str]:
     return blockers
 
 
+def _metadata_author_login(item: WorkItem) -> str:
+    raw = item.metadata.get("author_login")
+    if raw:
+        return str(raw)
+    author = item.metadata.get("author")
+    if isinstance(author, dict):
+        return str(author.get("login") or "")
+    if author:
+        return str(author)
+    return ""
+
+
+def _is_dependabot_pr(item: WorkItem) -> bool:
+    if item.source != "github_pr":
+        return False
+    author_login = _metadata_author_login(item).lower()
+    if author_login.startswith("dependabot"):
+        return True
+    branch = str(item.branch or item.metadata.get("headRefName") or "").lower()
+    return branch.startswith("dependabot/")
+
+
 def score_work_item(item: WorkItem, *, now: datetime | None = None) -> WorkScore:
     status = item.status.lower()
     title = item.title.lower()
@@ -113,7 +136,10 @@ def score_work_item(item: WorkItem, *, now: datetime | None = None) -> WorkScore
 
     readiness = 0.45
     if source == "github_pr":
-        if item.metadata.get("is_draft"):
+        if _is_dependabot_pr(item):
+            readiness = 0.18
+            rationale.append("policy-excluded Dependabot PR")
+        elif item.metadata.get("is_draft"):
             readiness = 0.25
             rationale.append("draft PR is not ready for settlement")
         elif item.metadata.get("review_decision") == "REVIEW_REQUIRED":
@@ -257,6 +283,8 @@ def classify_work_item(item: WorkItem, *, score: WorkScore | None = None) -> tup
         return "duplicate", ["receipt says work was already satisfied or published"]
     if not is_current_status(status) or item.scope == "historical":
         return "stale", ["terminal or historical work item"]
+    if _is_dependabot_pr(item):
+        return "policy-excluded", ["policy-excluded: Dependabot PR"]
     if item.metadata.get("human_gate") or item.metadata.get("tier") in {3, 4, "3", "4"}:
         return "human-gated", ["human-gated risk surface"]
     if item.metadata.get("blocked") or item.metadata.get("blockers"):
@@ -281,6 +309,9 @@ def classify_work_item(item: WorkItem, *, score: WorkScore | None = None) -> tup
 def recommended_action(item: WorkItem) -> tuple[str, str, list[str]]:
     blockers: list[str] = []
     if item.source == "github_pr":
+        if _is_dependabot_pr(item):
+            blockers.append("policy-excluded: Dependabot PR")
+            return "hold_policy_excluded_pr", "hold", blockers
         if item.metadata.get("is_draft"):
             blockers.append("draft PR")
             return "keep_draft_until_evidence_ready", "hold", blockers
@@ -313,7 +344,7 @@ def build_recommendations(items: list[WorkItem]) -> list[WorkRecommendation]:
         score = item.score or WorkScore()
         classification, class_blockers = classify_work_item(item, score=score)
         blockers = [*blockers, *class_blockers]
-        if classification in {"human-gated", "blocked"}:
+        if classification in {"human-gated", "blocked", "policy-excluded"}:
             priority = "hold"
         elif classification == "needs-polish" and priority == "high":
             priority = "medium"

--- a/aragora/work/sources.py
+++ b/aragora/work/sources.py
@@ -284,7 +284,7 @@ def collect_github_prs(repo_root: Path) -> tuple[list[WorkItem], dict[str, Any]]
         return [], _health("github_pr", "degraded", "gh executable not found")
 
     fields = (
-        "number,title,url,state,isDraft,headRefName,headRefOid,"
+        "number,title,url,state,isDraft,author,headRefName,headRefOid,"
         "updatedAt,createdAt,reviewDecision,mergeStateStatus,labels,assignees"
     )
     try:
@@ -322,6 +322,9 @@ def collect_github_prs(repo_root: Path) -> tuple[list[WorkItem], dict[str, Any]]
             for assignee in pr.get("assignees") or []
             if isinstance(assignee, dict)
         ]
+        raw_author = pr.get("author")
+        author = raw_author if isinstance(raw_author, dict) else {}
+        author_login = str(author.get("login") or "") if author else ""
         item = WorkItem(
             id=f"pr:{number}",
             source="github_pr",
@@ -338,7 +341,10 @@ def collect_github_prs(repo_root: Path) -> tuple[list[WorkItem], dict[str, Any]]
             metadata={
                 "number": number,
                 "is_draft": bool(pr.get("isDraft")),
+                "author": author,
+                "author_login": author_login or None,
                 "head_sha": pr.get("headRefOid"),
+                "headRefName": pr.get("headRefName"),
                 "review_decision": pr.get("reviewDecision"),
                 "merge_state_status": pr.get("mergeStateStatus"),
                 "labels": labels,

--- a/tests/cli/test_work_board.py
+++ b/tests/cli/test_work_board.py
@@ -241,6 +241,53 @@ def test_work_robot_marks_tier_four_pr_human_gated(
     assert payload["recommendations"][0]["item"]["metadata"]["tier"] == 4
 
 
+def test_work_robot_marks_dependabot_pr_policy_excluded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    monkeypatch.setattr("aragora.work.sources.shutil.which", lambda name: "/usr/bin/gh")
+
+    def fake_run(*_args, **_kwargs):
+        return subprocess.CompletedProcess(
+            args=["gh"],
+            returncode=0,
+            stdout=json.dumps(
+                [
+                    {
+                        "number": 7463,
+                        "title": "chore(deps): update fastapi requirement",
+                        "url": "https://github.com/synaptent/aragora/pull/7463",
+                        "state": "OPEN",
+                        "isDraft": False,
+                        "author": {"login": "app/dependabot", "is_bot": True},
+                        "headRefName": "dependabot/pip/fastapi-gte-0.136.3-and-lt-1.0",
+                        "headRefOid": "d8efb8681a85b8835abbb496ffd6e706e44961a7",
+                        "updatedAt": _now_iso(),
+                        "createdAt": _now_iso(),
+                        "reviewDecision": "APPROVED",
+                        "mergeStateStatus": "BLOCKED",
+                        "labels": [],
+                        "assignees": [],
+                    }
+                ]
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr("aragora.work.sources.subprocess.run", fake_run)
+
+    assert cmd_work_robot(_args(tmp_path)) == 0
+    payload = _capture_json(capsys)
+    recommendation = payload["recommendations"][0]
+
+    assert recommendation["item_id"] == "pr:7463"
+    assert recommendation["classification"] == "policy-excluded"
+    assert recommendation["action"] == "hold_policy_excluded_pr"
+    assert recommendation["priority"] == "hold"
+    assert "policy-excluded: Dependabot PR" in recommendation["blockers"]
+    assert recommendation["action"] != "review_and_settle_when_policy_clean"
+    assert recommendation["item"]["metadata"]["author_login"] == "app/dependabot"
+
+
 def test_work_show_enriches_github_pr_with_active_lane_owner(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
 ) -> None:

--- a/tests/work/test_work_scoring.py
+++ b/tests/work/test_work_scoring.py
@@ -162,3 +162,27 @@ def test_human_gated_pr_is_not_auto_ready() -> None:
 
     assert recommendations[0].classification == "human-gated"
     assert "human-gated risk surface" in recommendations[0].blockers
+
+
+def test_dependabot_pr_is_policy_excluded_not_auto_ready() -> None:
+    item = WorkItem(
+        id="pr:7463",
+        source="github_pr",
+        item_type="pull_request",
+        title="chore(deps): update fastapi requirement",
+        status="open",
+        branch="dependabot/pip/fastapi-gte-0.136.3-and-lt-1.0",
+        metadata={
+            "is_draft": False,
+            "review_decision": "APPROVED",
+            "author_login": "app/dependabot",
+        },
+    )
+
+    recommendation = build_recommendations([item])[0]
+
+    assert recommendation.classification == "policy-excluded"
+    assert recommendation.action == "hold_policy_excluded_pr"
+    assert recommendation.priority == "hold"
+    assert "policy-excluded: Dependabot PR" in recommendation.blockers
+    assert recommendation.action != "review_and_settle_when_policy_clean"


### PR DESCRIPTION
## Summary
- classify Dependabot GitHub PR work items as `policy-excluded` instead of `ready`
- route them to `hold_policy_excluded_pr` instead of `review_and_settle_when_policy_clean`
- add PR author metadata to work-board collection so work robot aligns with settle policy signals

## Context
#7463 at d8efb8681a85b8835abbb496ffd6e706e44961a7 is settlement-excluded as `Dependabot PR`, but work robot could classify it as high/ready and loop queue selection onto an unmergeable policy-excluded PR.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/work/test_work_scoring.py tests/cli/test_work_board.py tests/scripts/test_settle_one_pr.py::test_select_candidate_excludes_active_owned_and_dependabot tests/scripts/test_settle_one_pr.py::test_policy_exclusion_reasons_uses_reliable_dependabot_signals -q -p no:cacheprovider`
- `python3 -m ruff check aragora/work/scoring.py aragora/work/sources.py tests/work/test_work_scoring.py tests/cli/test_work_board.py`
- `python3 -m ruff format --check aragora/work/scoring.py aragora/work/sources.py tests/work/test_work_scoring.py tests/cli/test_work_board.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`