### PR TITLE
[AGT-05] Wire StalePolicy into settle_claim — expired claims fail closed

### DIFF
--- a/aragora/reputation/settlement.py
+++ b/aragora/reputation/settlement.py
@@ -17,13 +17,19 @@ Inconclusive and invalid outcomes always return zero delta: under
 ``refund_on_inconclusive`` semantics the stake is returned; under
 ``forfeit_on_loss`` the caller may separately decide to forfeit.
 This module only computes the delta.
+
+Since AGT-05 SD-4: ``settle_claim`` accepts an optional *stale_policy*
+(``aragora.reputation.stale_policy.StalePolicy``). When supplied, expired
+claims (age > hard_limit_days) are rejected before scoring and stale claims
+(age >= stale_days) are settled but annotated in the ``reason`` dict.
+Passing ``None`` (the default) preserves full backward compatibility.
 """
 
 from __future__ import annotations
 
 import hashlib
 from datetime import UTC, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from aragora.reputation.types import (
     ReputationDelta,
@@ -31,6 +37,9 @@ from aragora.reputation.types import (
     ScoringRule,
     StakeableClaim,
 )
+
+if TYPE_CHECKING:
+    from aragora.reputation.stale_policy import StalePolicy
 
 
 class SettlementError(RuntimeError):
@@ -54,17 +63,48 @@ def settle_claim(
     scoring_rule: ScoringRule = "brier_proper",
     decay_half_life_days: float | None = 30.0,
     applied_at: str | None = None,
+    stale_policy: "StalePolicy | None" = None,
 ) -> ReputationDelta:
     """Compute the reputation delta for a resolved claim.
 
+    When *stale_policy* is provided, claims are evaluated against the
+    policy before scoring:
+
+    - **Expired** claims (age > ``hard_limit_days``) raise
+      :class:`SettlementError` immediately; no delta is produced.
+    - **Stale** claims (``stale_days <= age <= hard_limit_days``) settle
+      normally but carry ``reason[\"stale_warning\"] = True`` and
+      ``reason[\"staleness_age_days\"]`` for audit visibility.
+    - **Fresh** claims settle without any annotation.
+
+    Omitting *stale_policy* (default ``None``) preserves the existing
+    behavior for all current callers.
+
     Raises :class:`SettlementError` if the claim and resolution do not
-    refer to the same ``claim_id``, or if the scoring rule is not
-    supported for the given claim shape.
+    refer to the same ``claim_id``, if the scoring rule is not
+    supported for the given claim shape, or if *stale_policy* is set and
+    the claim is expired.
     """
     if claim.claim_id != resolved.claim_id:
         raise SettlementError(
             f"claim_id mismatch: claim={claim.claim_id!r} vs resolved={resolved.claim_id!r}"
         )
+
+    # Stale-policy gate (AGT-05 SD-4).  One call to is_stale covers both
+    # the expired-rejection and the stale-annotation paths so we never
+    # compute the age twice.
+    stale_decision = None
+    if stale_policy is not None:
+        from aragora.reputation.stale_policy import is_stale
+
+        stale_decision = is_stale(claim_iso=claim.created_at, policy=stale_policy)
+        if stale_decision.is_expired:
+            raise SettlementError(
+                f"claim {claim.claim_id!r} is expired "
+                f"(age={stale_decision.age_days:.1f}d "
+                f"> hard_limit={stale_policy.hard_limit_days}d); "
+                "settlement refused"
+            )
 
     reason: dict[str, Any] = {
         "claim_id": claim.claim_id,
@@ -74,6 +114,9 @@ def settle_claim(
         "outcome": resolved.outcome,
         "stake_units": claim.stake_units,
     }
+    if stale_decision is not None and stale_decision.is_stale:
+        reason["stale_warning"] = True
+        reason["staleness_age_days"] = round(stale_decision.age_days, 2)
 
     if resolved.outcome in {"inconclusive", "invalid"}:
         delta = 0.0

--- a/tests/reputation/test_settle_stale_policy.py
+++ b/tests/reputation/test_settle_stale_policy.py
@@ -1,0 +1,189 @@
+"""Tests for stale-policy integration in settle_claim (AGT-05 SD-4).
+
+Verifies that:
+- ``stale_policy=None`` (the default) is backward-compatible; existing
+  callers that omit the kwarg are completely unaffected.
+- Fresh claims (<fresh_days old) settle without a stale annotation.
+- Stale claims (>=stale_days but <hard_limit_days) settle normally but
+  carry ``reason[\"stale_warning\"]`` and ``reason[\"staleness_age_days\"]``.
+- Expired claims (>=hard_limit_days) raise SettlementError before any
+  scoring runs, and the error message names the claim and explains why.
+- Custom StalePolicy bounds are respected.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from aragora.reputation.settlement import SettlementError, settle_claim
+from aragora.reputation.stale_policy import StalePolicy
+from aragora.reputation.types import (
+    DOMAIN_PREDICTION_MARKET,
+    ResolvedClaim,
+    StakeableClaim,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _claim(created_at: str, *, probability: float = 0.8) -> StakeableClaim:
+    return StakeableClaim.create(
+        agent_id="alice",
+        domain=DOMAIN_PREDICTION_MARKET,
+        statement="Event will occur",
+        position="yes",
+        stake_units=10,
+        resolution_source="synthetic_github",
+        resolution_id="mkt_abc",
+        predicted_probability=probability,
+        created_at=created_at,
+    )
+
+
+def _resolved(claim: StakeableClaim, outcome: str = "yes") -> ResolvedClaim:
+    return ResolvedClaim(
+        claim_id=claim.claim_id,
+        outcome=outcome,  # type: ignore[arg-type]
+        resolved_at=_iso(datetime.now(UTC)),
+        resolution_source="synthetic_github",
+    )
+
+
+@pytest.fixture()
+def default_policy() -> StalePolicy:
+    return StalePolicy()
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility — stale_policy=None
+# ---------------------------------------------------------------------------
+
+
+class TestNoStalePolicyBackwardCompat:
+    def test_omitting_stale_policy_settles_any_age(self) -> None:
+        # A 200-day-old claim must still settle when stale_policy is not passed.
+        claim = _claim(_iso(datetime.now(UTC) - timedelta(days=200)))
+        delta = settle_claim(claim, _resolved(claim))  # no stale_policy keyword
+        assert isinstance(delta.delta, float)
+        assert "stale_warning" not in delta.reason
+
+    def test_explicit_none_is_neutral(self) -> None:
+        claim = _claim(_iso(datetime.now(UTC) - timedelta(days=100)))
+        delta = settle_claim(claim, _resolved(claim), stale_policy=None)
+        assert "stale_warning" not in delta.reason
+        assert "staleness_age_days" not in delta.reason
+
+
+# ---------------------------------------------------------------------------
+# Fresh claims
+# ---------------------------------------------------------------------------
+
+
+class TestFreshClaim:
+    def test_fresh_claim_no_stale_annotation(self, default_policy: StalePolicy) -> None:
+        claim = _claim(_iso(datetime.now(UTC) - timedelta(hours=1)))
+        delta = settle_claim(claim, _resolved(claim), stale_policy=default_policy)
+        assert "stale_warning" not in delta.reason
+        assert "staleness_age_days" not in delta.reason
+
+    def test_fresh_claim_delta_is_computed_correctly(self, default_policy: StalePolicy) -> None:
+        # probability=0.8, outcome=yes → brier=(0.8-1)²=0.04 → fraction=0.92 → delta=9.2
+        claim = _claim(_iso(datetime.now(UTC) - timedelta(hours=1)), probability=0.8)
+        delta = settle_claim(
+            claim, _resolved(claim), stale_policy=default_policy, scoring_rule="brier_proper"
+        )
+        assert delta.delta == pytest.approx(9.2, abs=1e-6)
+
+    def test_just_under_stale_threshold_is_fresh(self, default_policy: StalePolicy) -> None:
+        # Default stale_days=30; 29.5 days old should be fresh.
+        claim = _claim(_iso(datetime.now(UTC) - timedelta(days=29, hours=12)))
+        delta = settle_claim(claim, _resolved(claim), stale_policy=default_policy)
+        assert "stale_warning" not in delta.reason
+
+
+# ---------------------------------------------------------------------------
+# Stale claims
+# ---------------------------------------------------------------------------
+
+
+class TestStaleClaim:
+    def test_stale_claim_carries_warning(self, default_policy: StalePolicy) -> None:
+        # 40 days old — past stale_days (30) but under hard_limit_days (180).
+        claim = _claim(_iso(datetime.now(UTC) - timedelta(days=40)))
+        delta = settle_claim(claim, _resolved(claim), stale_policy=default_policy)
+        assert delta.reason.get("stale_warning") is True
+
+    def test_stale_claim_includes_age_days_in_reason(self, default_policy: StalePolicy) -> None:
+        claim = _claim(_iso(datetime.now(UTC) - timedelta(days=40)))
+        delta = settle_claim(claim, _resolved(claim), stale_policy=default_policy)
+        age = delta.reason.get("staleness_age_days")
+        assert age is not None
+        assert 39.0 < float(age) < 41.0
+
+    def test_stale_claim_still_produces_delta(self, default_policy: StalePolicy) -> None:
+        # Settlement must complete; the stale annotation is advisory, not blocking.
+        claim = _claim(_iso(datetime.now(UTC) - timedelta(days=40)))
+        delta = settle_claim(claim, _resolved(claim), stale_policy=default_policy)
+        assert isinstance(delta.delta, float)
+
+    def test_just_under_hard_limit_is_stale_not_expired(self) -> None:
+        # 179 days old with default hard_limit=180: stale but not expired.
+        claim = _claim(_iso(datetime.now(UTC) - timedelta(days=179)))
+        delta = settle_claim(claim, _resolved(claim), stale_policy=StalePolicy())
+        assert delta.reason.get("stale_warning") is True
+        assert "staleness_age_days" in delta.reason
+
+
+# ---------------------------------------------------------------------------
+# Expired claims
+# ---------------------------------------------------------------------------
+
+
+class TestExpiredClaim:
+    def test_expired_raises_settlement_error(self, default_policy: StalePolicy) -> None:
+        claim = _claim(_iso(datetime.now(UTC) - timedelta(days=200)))
+        with pytest.raises(SettlementError):
+            settle_claim(claim, _resolved(claim), stale_policy=default_policy)
+
+    def test_expired_error_names_claim_id(self, default_policy: StalePolicy) -> None:
+        claim = _claim(_iso(datetime.now(UTC) - timedelta(days=200)))
+        with pytest.raises(SettlementError, match=claim.claim_id):
+            settle_claim(claim, _resolved(claim), stale_policy=default_policy)
+
+    def test_expired_error_says_settlement_refused(self, default_policy: StalePolicy) -> None:
+        claim = _claim(_iso(datetime.now(UTC) - timedelta(days=200)))
+        with pytest.raises(SettlementError, match="settlement refused"):
+            settle_claim(claim, _resolved(claim), stale_policy=default_policy)
+
+    def test_no_delta_produced_for_expired_claim(self, default_policy: StalePolicy) -> None:
+        # Verify no ReputationDelta is returned — only SettlementError.
+        claim = _claim(_iso(datetime.now(UTC) - timedelta(days=200)))
+        result = None
+        try:
+            result = settle_claim(claim, _resolved(claim), stale_policy=default_policy)
+        except SettlementError:
+            pass
+        assert result is None
+
+    def test_custom_hard_limit_respected(self) -> None:
+        # Custom policy: hard_limit=90d; 100-day-old claim is expired.
+        strict = StalePolicy(fresh_days=1, stale_days=7, hard_limit_days=90)
+        claim = _claim(_iso(datetime.now(UTC) - timedelta(days=100)))
+        with pytest.raises(SettlementError):
+            settle_claim(claim, _resolved(claim), stale_policy=strict)
+
+    def test_same_claim_settles_without_policy(self) -> None:
+        # The claim is expired under the policy, but a caller without the
+        # policy must still see a successful settlement.
+        claim = _claim(_iso(datetime.now(UTC) - timedelta(days=200)))
+        delta = settle_claim(claim, _resolved(claim))  # no stale_policy
+        assert isinstance(delta.delta, float)


### PR DESCRIPTION
## Slice

Wires the existing `aragora.reputation.stale_policy.StalePolicy` (a shadow-only module with no production callers, as its own docstring notes) into `settle_claim` via an optional `stale_policy` keyword argument. Expired claims (age > `hard_limit_days`) now raise `SettlementError` before any scoring runs; stale claims (age ≥ `stale_days`) settle normally but carry audit annotations in `reason`.

## Gating

- Default: **OFF** — `stale_policy` defaults to `None`; all existing callers without the kwarg are completely unaffected.
- Live queue effect: **none** — `settle_claim` is called only from reputation settlement paths, not from dispatch, boss loop, or swarm supervisor.
- Advances issue: #6066 (AGT-05 sub-deliverable 4 — settlement and dispute window enforcement)

## Changes

| File | What changed |
|------|-------------|
| `aragora/reputation/settlement.py` | Add `stale_policy: StalePolicy \| None = None` kwarg; stale-gate logic before scoring (one `is_stale` call covers both expired-rejection and stale-annotation); extended docstring; `TYPE_CHECKING` import block |
| `tests/reputation/test_settle_stale_policy.py` | New test file — 11 focused tests (see below) |

## Tests

- `TestNoStalePolicyBackwardCompat.test_omitting_stale_policy_settles_any_age` — a 200-day-old claim settles when `stale_policy` is not passed; no `stale_warning` in reason.
- `TestNoStalePolicyBackwardCompat.test_explicit_none_is_neutral` — `stale_policy=None` is indistinguishable from omitting it.
- `TestFreshClaim.test_fresh_claim_no_stale_annotation` — claim <1h old settles without annotation.
- `TestFreshClaim.test_fresh_claim_delta_is_computed_correctly` — Brier delta is unchanged (`p=0.8, outcome=yes → delta=9.2`).
- `TestFreshClaim.test_just_under_stale_threshold_is_fresh` — 29.5-day-old claim is not annotated.
- `TestStaleClaim.test_stale_claim_carries_warning` — 40-day-old claim has `reason["stale_warning"] = True`.
- `TestStaleClaim.test_stale_claim_includes_age_days_in_reason` — `reason["staleness_age_days"]` ≈ 40.0.
- `TestStaleClaim.test_stale_claim_still_produces_delta` — settlement completes; stale annotation is advisory.
- `TestStaleClaim.test_just_under_hard_limit_is_stale_not_expired` — 179-day-old claim is stale, not expired.
- `TestExpiredClaim.test_expired_raises_settlement_error` — 200-day-old claim raises `SettlementError`.
- `TestExpiredClaim.test_expired_error_names_claim_id` — error message includes the `claim_id` for audit trails.
- `TestExpiredClaim.test_expired_error_says_settlement_refused` — error message ends with `"settlement refused"`.
- `TestExpiredClaim.test_no_delta_produced_for_expired_claim` — no `ReputationDelta` object is returned for expired claims.
- `TestExpiredClaim.test_custom_hard_limit_respected` — custom `StalePolicy(hard_limit_days=90)` rejects 100-day-old claims.
- `TestExpiredClaim.test_same_claim_settles_without_policy` — the same expired claim settles successfully when called without the kwarg.

## Validation

- `pytest tests/reputation/test_settle_stale_policy.py tests/reputation/test_settlement.py` — existing tests must stay green; new tests verify the gate
- `ruff check aragora/reputation/settlement.py tests/reputation/test_settle_stale_policy.py` — clean
- `mypy aragora/reputation/settlement.py --ignore-missing-imports` — clean (`StalePolicy` is TYPE_CHECKING-only; runtime import is local inside the function)
- Net diff: **~205 LOC** (2 files: +~30 settlement.py, +~175 new test file) — well under 300 LOC limit

## Out of scope

- Wiring `is_stale` into the calibration leaderboard or the rev-4 staging scorecard — noted as a future slice in `stale_policy.py`.
- Hard `forfeit_on_loss` enforcement for stale (not expired) claims — policy is advisory per `stale_policy.py` design; callers decide what to do with the annotation.
- Auto-scheduling stale scans across the full `ReputationStore` — follow-on once the operator has validated per-call behaviour.
- On-chain anchoring of stale decisions — deferred to AGT-05 Step 5 (ERC-8004 registry write).

## Gate status

Per `docs/status/NEXT_STEPS_CANONICAL.md`, `AGT-01..06` are in the **Delay** track. The proof-first Foreman gate has **not** opened. This PR is planning truth and flag-gated operator tooling only; no `boss-ready` label applied. Kept as draft.

---
_Generated by [Claude Code](https://claude.ai/code/session_015sRsXDAoBcJWgDVEqNUa5g)_