### PR TITLE
fix(security): enforce aiohttp floor in extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ gateway = [
     "uvicorn>=0.48.0,<1.0",
 ]
 blockchain = [
+    "aiohttp>=3.14.0,<4.0",
     "web3>=7.16.0,<8.0",
 ]
 enterprise = [
@@ -64,6 +65,7 @@ dev = [
 all = [
     "fastapi>=0.136.3,<1.0",
     "uvicorn>=0.48.0,<1.0",
+    "aiohttp>=3.14.0,<4.0",
     "web3>=7.16.0,<8.0",
     "asyncpg>=0.31.0,<1.0",
     "python3-saml>=1.16.0,<2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -275,6 +275,7 @@ source = { editable = "." }
 [package.optional-dependencies]
 all = [
     { name = "aio-pika" },
+    { name = "aiohttp" },
     { name = "aiokafka" },
     { name = "asyncpg" },
     { name = "fastapi" },
@@ -285,6 +286,7 @@ all = [
     { name = "web3" },
 ]
 blockchain = [
+    { name = "aiohttp" },
     { name = "web3" },
 ]
 connectors = [
@@ -324,6 +326,8 @@ test = [
 requires-dist = [
     { name = "aio-pika", marker = "extra == 'all'", specifier = ">=9.6.2,<10.0" },
     { name = "aio-pika", marker = "extra == 'connectors'", specifier = ">=9.6.2,<10.0" },
+    { name = "aiohttp", marker = "extra == 'all'", specifier = ">=3.14.0,<4.0" },
+    { name = "aiohttp", marker = "extra == 'blockchain'", specifier = ">=3.14.0,<4.0" },
     { name = "aiokafka", marker = "extra == 'all'", specifier = ">=0.14.0,<1.0" },
     { name = "aiokafka", marker = "extra == 'connectors'", specifier = ">=0.14.0,<1.0" },
     { name = "asyncpg", marker = "extra == 'all'", specifier = ">=0.31.0,<1.0" },


### PR DESCRIPTION
## Summary
- Follow-up to #7727: declare aiohttp>=3.14.0,<4.0 in the blockchain and all extras.
- Keeps fresh optional-extra resolution aligned with the locked aiohttp 3.14.0 package.
- Updates only pyproject.toml and editable-package metadata in uv.lock.

## Validation
- uv lock --locked
- uv lock --check
- git diff --check
- PYTHONDONTWRITEBYTECODE=1 uv run --with pip-audit python scripts/run_pip_audit_gate.py
- python3 -m pytest -q tests/ci/test_release_gates.py::TestPipAuditGate

## Context
A no-publish non-OpenAI review of #7727 flagged that the lock-only aiohttp bump did not declare a resolver floor for fresh installs using extras that can pull aiohttp via web3. #7727 has already merged; this PR closes that remaining packaging-safety gap.