### PR TITLE
ci: run merge quorum tooling from current main

### DIFF
--- a/.github/workflows/aragora-merge-quorum.yml
+++ b/.github/workflows/aragora-merge-quorum.yml
@@ -51,6 +51,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # The quorum evaluator is merge-authority tooling. Run the current
+          # default-branch implementation so old PR-event reruns do not execute
+          # stale packet logic from an outdated synthetic merge ref.
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Set up Python
         id: setup-python

--- a/tests/workflows/test_aragora_merge_quorum_workflow.py
+++ b/tests/workflows/test_aragora_merge_quorum_workflow.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / ".github/workflows/aragora-merge-quorum.yml"
+
+
+def _workflow() -> dict[str, Any]:
+    data = yaml.load(WORKFLOW_PATH.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    assert isinstance(data, dict)
+    return data
+
+
+def test_merge_quorum_uses_current_default_branch_tooling() -> None:
+    workflow = _workflow()
+    steps = workflow["jobs"]["merge-quorum"]["steps"]
+    checkout_step = next(
+        step
+        for step in steps
+        if isinstance(step, dict) and str(step.get("uses", "")).startswith("actions/checkout@")
+    )
+
+    assert (
+        checkout_step.get("with", {}).get("ref") == "${{ github.event.repository.default_branch }}"
+    )


### PR DESCRIPTION
## Summary

- make the `aragora-merge-quorum` workflow check out the repository default branch before installing/running `review-queue merge-packet`
- add a focused workflow regression test that prevents the quorum evaluator from returning to stale PR merge-ref tooling

## Why

A rerun of #7458's merge-quorum job executed an old synthetic PR merge ref and therefore used stale merge-packet check-surface logic. Current `origin/main` already separates the quorum self-check from non-required Metrics Drift noise when model quorum is satisfied; this change makes future quorum runs evaluate with the current default-branch merge-authority implementation rather than stale PR-event code.

## Validation

- `python3 -m pytest tests/workflows/test_aragora_merge_quorum_workflow.py -q`
- `python3 -m pytest tests/cli/commands/test_review_queue.py -k "required_pr_checks_gate or merge_quorum_self_check or non_required_rollup_failures" -q`
- `python3 scripts/check_required_check_priority_policy.py --repo-root .`
- `python3 scripts/check_workflow_checkout_integrity_policy.py --repo-root .`
- `GITHUB_WORKFLOW='Aragora Merge Quorum' GITHUB_JOB='merge-quorum' GITHUB_RUN_ID='26382669339' GITHUB_REPOSITORY='synaptent/aragora' GITHUB_SERVER_URL='https://github.com' python3 -m aragora.cli.main review-queue merge-packet --pr 7458 --json`

## Notes

Draft intentionally: this modifies merge-authority workflow behavior and should go through exact-head evidence/settlement before merge consideration.
