### PR TITLE
fix(review): close API connector after review CLI

### DIFF
--- a/aragora/cli/commands/review_pr.py
+++ b/aragora/cli/commands/review_pr.py
@@ -10,11 +10,13 @@ import re
 import subprocess
 import sys
 import tempfile
+from collections.abc import Awaitable
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from aragora.agents.api_agents.common import close_shared_connector
 from aragora.connectors.github import GitHubConnector
 from aragora.swarm.review_routing import ReviewRoutingError, generate_review_response
 from aragora.swarm.worker_launcher import LaunchConfig, WorkerLauncher
@@ -155,18 +157,20 @@ def _normalize_optional_agent(value: object) -> str | None:
 def cmd_review_pr(args: argparse.Namespace) -> int:
     repo_root = resolve_repo_root(Path.cwd())
     result = asyncio.run(
-        run_review_pr_loop(
-            pr_ref=str(args.pr),
-            repo_root=repo_root,
-            repo_override=getattr(args, "repo", None),
-            reviewer=str(getattr(args, "reviewer", "claude") or "claude"),
-            fixer=_normalize_optional_agent(getattr(args, "fixer", None)),
-            auto_rerun=bool(getattr(args, "auto_rerun", False)),
-            artifact_root=Path(getattr(args, "artifact_dir", "")).resolve()
-            if getattr(args, "artifact_dir", None)
-            else None,
-            keep_worktree=bool(getattr(args, "keep_worktree", False)),
-            publish_review=bool(getattr(args, "publish_review", True)),
+        _await_with_api_cleanup(
+            run_review_pr_loop(
+                pr_ref=str(args.pr),
+                repo_root=repo_root,
+                repo_override=getattr(args, "repo", None),
+                reviewer=str(getattr(args, "reviewer", "claude") or "claude"),
+                fixer=_normalize_optional_agent(getattr(args, "fixer", None)),
+                auto_rerun=bool(getattr(args, "auto_rerun", False)),
+                artifact_root=Path(getattr(args, "artifact_dir", "")).resolve()
+                if getattr(args, "artifact_dir", None)
+                else None,
+                keep_worktree=bool(getattr(args, "keep_worktree", False)),
+                publish_review=bool(getattr(args, "publish_review", True)),
+            )
         )
     )
     if getattr(args, "json_output", False):
@@ -179,6 +183,13 @@ def cmd_review_pr(args: argparse.Namespace) -> int:
     if final_status == "changes_requested":
         return 2
     return 1
+
+
+async def _await_with_api_cleanup(awaitable: Awaitable[dict[str, Any]]) -> dict[str, Any]:
+    try:
+        return await awaitable
+    finally:
+        await close_shared_connector()
 
 
 async def run_review_pr_loop(

--- a/tests/cli/commands/test_review_pr.py
+++ b/tests/cli/commands/test_review_pr.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import json
 import subprocess
 from dataclasses import asdict
@@ -68,6 +69,43 @@ def test_normalize_optional_agent_rejects_placeholder_none() -> None:
     assert review_pr._normalize_optional_agent("None") is None
     assert review_pr._normalize_optional_agent("null") is None
     assert review_pr._normalize_optional_agent(" codex ") == "codex"
+
+
+def test_cmd_review_pr_closes_shared_api_connector(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    closed = False
+
+    async def _fake_review_loop(**_: object) -> dict[str, object]:
+        return {"final_status": "passed"}
+
+    async def _fake_close_shared_connector() -> None:
+        nonlocal closed
+        closed = True
+
+    monkeypatch.setattr(review_pr, "resolve_repo_root", lambda *_: tmp_path)
+    monkeypatch.setattr(review_pr, "run_review_pr_loop", _fake_review_loop)
+    monkeypatch.setattr(review_pr, "close_shared_connector", _fake_close_shared_connector)
+
+    exit_code = review_pr.cmd_review_pr(
+        argparse.Namespace(
+            pr="1137",
+            repo=None,
+            reviewer="grok",
+            fixer=None,
+            auto_rerun=False,
+            artifact_dir=None,
+            keep_worktree=False,
+            publish_review=False,
+            json_output=True,
+        )
+    )
+
+    assert exit_code == 0
+    assert closed is True
+    assert json.loads(capsys.readouterr().out)["final_status"] == "passed"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Closes the shared API-agent aiohttp connector after `review-pr` CLI invocations.
- Keeps the existing shared connector behavior for long-lived services and agents.
- Adds a command-level regression test that verifies `cmd_review_pr` closes the connector before returning.

## Context

During live Aragora dogfood, successful Grok review calls completed with valid JSON but then emitted aiohttp unclosed-connector ResourceWarnings. The shared connector is intentionally reused while a process is active, but short-lived review CLI commands need to release it before `asyncio.run()` tears down the event loop.

## Validation

- `python3 -m pytest -q tests/cli/commands/test_review_pr.py` -> 26 passed
- `python3 -m pytest -q tests/agents/api_agents/test_grok.py` -> 34 passed, 1 pre-existing stream-test warning
- `python3 -m ruff check aragora/cli/commands/review_pr.py tests/cli/commands/test_review_pr.py` -> passed
- `python3 -m ruff format --check aragora/cli/commands/review_pr.py tests/cli/commands/test_review_pr.py` -> passed
- `git diff --check` -> passed
- Live no-publish smoke: `python3 -m aragora.cli.main review-pr 7731 --reviewer grok --no-publish-review --artifact-dir /private/tmp/review-pr-grok-close-smoke-20260604 --json` -> passed without the previous unclosed-connector warning

## Notes

This PR does not merge or settle anything. It is a bounded CLI resource-cleanup fix.
