### PR TITLE
[DIC-21] Add quarantine-eval CLI operator surface for fail-closed proof policy

### DIFF
--- a/aragora/cli/commands/dic21_quarantine.py
+++ b/aragora/cli/commands/dic21_quarantine.py
@@ -82,8 +82,9 @@ def _parse_signal(data: dict) -> _Signal:
 
 def cmd_quarantine_eval(args: argparse.Namespace) -> int:
     if not _flag_enabled():
-        print(f"error: {_FLAG} is not set; set it to '1' to enable quarantine-eval",
-              file=sys.stderr)
+        print(
+            f"error: {_FLAG} is not set; set it to '1' to enable quarantine-eval", file=sys.stderr
+        )
         return 1
 
     signal_path = Path(getattr(args, "signal", "")).expanduser()

--- a/aragora/cli/commands/dic21_quarantine.py
+++ b/aragora/cli/commands/dic21_quarantine.py
@@ -1,0 +1,124 @@
+"""CLI command: ``aragora quarantine-eval``.
+
+DIC-21 operator surface for the fail-closed quarantine policy (issue #6032).
+
+Reads a DecaySignal JSON file, applies quarantine policy, and emits the
+QuarantineDecision as text or JSON.
+
+Flag: ``ARAGORA_QUARANTINE_POLICY_ENABLED`` (default OFF).
+Live queue effect: none — read-only report; no queue writes.
+Advances: issue #6032 (DIC-21).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+_FLAG = "ARAGORA_QUARANTINE_POLICY_ENABLED"
+
+
+def _flag_enabled() -> bool:
+    return os.environ.get(_FLAG, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _load_signal(path: Path) -> dict:
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ValueError(f"cannot read signal file {path}: {exc}") from exc
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid JSON in {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"signal file must be a JSON object, got {type(data).__name__}")
+    if "code_unit_id" not in data:
+        raise ValueError("signal JSON missing required field 'code_unit_id'")
+    return data
+
+
+class _Reason:
+    """Minimal duck-typed reason; quarantine_policy only reads ``r.kind``."""
+
+    __slots__ = ("kind",)
+
+    def __init__(self, kind: str) -> None:
+        self.kind = kind
+
+
+class _Signal:
+    """Minimal duck-typed DecaySignal for quarantine_policy consumption.
+
+    Avoids importing decay_monitor → claim_verifier → pyyaml at CLI load
+    time.  apply_quarantine_policy uses duck-typed attribute access only.
+    """
+
+    __slots__ = ("code_unit_id", "integrity_score", "reasons", "recommended_action")
+
+    def __init__(self, uid: str, score: float, reasons: list, action: str) -> None:
+        self.code_unit_id = uid
+        self.integrity_score = score
+        self.reasons = reasons
+        self.recommended_action = action
+
+
+def _parse_signal(data: dict) -> _Signal:
+    reasons = [
+        _Reason(kind=str(r.get("kind", "")))
+        for r in (data.get("reasons") or [])
+        if isinstance(r, dict)
+    ]
+    return _Signal(
+        uid=str(data["code_unit_id"]),
+        score=float(data.get("integrity_score", 1.0)),
+        reasons=reasons,
+        action=str(data.get("recommended_action", "report_only")),
+    )
+
+
+def cmd_quarantine_eval(args: argparse.Namespace) -> int:
+    if not _flag_enabled():
+        print(f"error: {_FLAG} is not set; set it to '1' to enable quarantine-eval",
+              file=sys.stderr)
+        return 1
+
+    signal_path = Path(getattr(args, "signal", "")).expanduser()
+    if not signal_path.exists():
+        print(f"error: signal file not found: {signal_path}", file=sys.stderr)
+        return 1
+
+    try:
+        data = _load_signal(signal_path)
+        signal = _parse_signal(data)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    code_unit_class: str = getattr(args, "code_unit_class", "default") or "default"
+    request_live_swap: bool = bool(getattr(args, "request_live_swap", False))
+
+    from aragora.epistemic.quarantine_policy import apply_quarantine_policy
+
+    decision = apply_quarantine_policy(
+        signal,  # type: ignore[arg-type]  # duck-typed _Signal; runtime OK
+        code_unit_class=code_unit_class,
+        request_live_swap=request_live_swap,
+    )
+
+    if getattr(args, "json", False):
+        print(json.dumps(decision.to_dict(), indent=2))
+    else:
+        fc = "YES" if decision.fail_closed else "no"
+        ls = "BLOCKED" if decision.live_swap_blocked else "allowed"
+        print(f"quarantine-eval: {decision.code_unit_id}")
+        print(f"  action:      {decision.policy_action}")
+        print(f"  integrity:   {decision.integrity_score:.3f}")
+        print(f"  fail_closed: {fc}  live_swap: {ls}")
+        print(f"  rationale:   {decision.rationale}")
+        if decision.provenance_hash:
+            print(f"  hash:        {decision.provenance_hash[:16]}…")
+    return 0

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -222,6 +222,7 @@ Examples:
     _add_coherence_scan_parser(subparsers)  # DIC-26 / #6220
     _add_truth_map_parser(subparsers)  # DIC-18 / #6028
     _add_decay_monitor_parser(subparsers)  # DIC-20 / #6031
+    _add_quarantine_eval_parser(subparsers)  # DIC-21 / #6032
     _add_epistemic_check_parser(subparsers)  # DIC-14 / #6024
 
     # DIC-27: operator crux arbitration surface
@@ -785,6 +786,48 @@ def _add_decay_monitor_parser(subparsers) -> None:
     )
     p.add_argument("--json", action="store_true", help="Emit JSON instead of text")
     p.set_defaults(func=_lazy("aragora.cli.commands.dic20_decay_monitor", "cmd_decay_monitor"))
+
+
+def _add_quarantine_eval_parser(subparsers) -> None:
+    """Add the 'quarantine-eval' subcommand (DIC-21 / #6032).
+
+    Flag-gated: ARAGORA_QUARANTINE_POLICY_ENABLED must be set.
+    Live queue effect: none (read-only operator report).
+    """
+    p = subparsers.add_parser(
+        "quarantine-eval",
+        help="DIC-21: evaluate fail-closed quarantine policy for a decayed code proof",
+        description=(
+            "Read-only quarantine policy evaluation for a proof-carrying code unit. "
+            "Reads a DecaySignal JSON file, applies the configured policy, and reports "
+            "the QuarantineDecision (action, rationale, provenance hash). "
+            "Requires ARAGORA_QUARANTINE_POLICY_ENABLED=1."
+        ),
+    )
+    p.add_argument(
+        "--signal",
+        required=True,
+        metavar="FILE",
+        help="Path to a DecaySignal JSON file (DIC-20 decay-monitor output)",
+    )
+    p.add_argument(
+        "--class",
+        dest="code_unit_class",
+        default="default",
+        choices=["default", "live_dispatch", "report_surface", "demo", "pure_policy"],
+        help="Code-unit class for policy lookup (default: 'default')",
+    )
+    p.add_argument(
+        "--request-live-swap",
+        dest="request_live_swap",
+        action="store_true",
+        default=False,
+        help="Simulate a live-routing request to verify it is blocked (default: off)",
+    )
+    p.add_argument("--json", action="store_true", help="Emit JSON instead of text")
+    p.set_defaults(
+        func=_lazy("aragora.cli.commands.dic21_quarantine", "cmd_quarantine_eval")
+    )
 
 
 def _add_crux_arbitrate_parser(subparsers) -> None:

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -825,9 +825,7 @@ def _add_quarantine_eval_parser(subparsers) -> None:
         help="Simulate a live-routing request to verify it is blocked (default: off)",
     )
     p.add_argument("--json", action="store_true", help="Emit JSON instead of text")
-    p.set_defaults(
-        func=_lazy("aragora.cli.commands.dic21_quarantine", "cmd_quarantine_eval")
-    )
+    p.set_defaults(func=_lazy("aragora.cli.commands.dic21_quarantine", "cmd_quarantine_eval"))
 
 
 def _add_crux_arbitrate_parser(subparsers) -> None:

--- a/tests/cli/test_dic21_quarantine.py
+++ b/tests/cli/test_dic21_quarantine.py
@@ -1,0 +1,182 @@
+"""Tests for aragora.cli.commands.dic21_quarantine (DIC-21 / #6032).
+
+All tests are hermetic; tmp_path for JSON signal fixtures.
+Live queue effect: none.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# aragora.epistemic.__init__ eagerly imports claim_verifier which does
+# ``import yaml`` at module level.  Stub it before the first aragora.epistemic
+# import so the package initialises cleanly in environments where pyyaml is
+# absent.  The quarantine_policy module under test is pure Python; no YAML
+# is parsed.
+if "yaml" not in sys.modules:
+    sys.modules["yaml"] = MagicMock()  # type: ignore[assignment]
+
+from aragora.cli.commands.dic21_quarantine import _FLAG, cmd_quarantine_eval  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+_FRESH: dict = {
+    "code_unit_id": "test.unit.alpha",
+    "integrity_score": 0.9,
+    "reasons": [],
+    "recommended_action": "report_only",
+}
+
+_DECAYED: dict = {
+    "code_unit_id": "test.unit.beta",
+    "integrity_score": 0.35,
+    "reasons": [{"kind": "failed_claim", "detail": "b0.truth.rate failed"}],
+    "recommended_action": "repair_required",
+}
+
+
+def _ns(
+    signal: str,
+    code_unit_class: str = "default",
+    request_live_swap: bool = False,
+    json_out: bool = False,
+) -> argparse.Namespace:
+    return argparse.Namespace(
+        signal=signal,
+        code_unit_class=code_unit_class,
+        request_live_swap=request_live_swap,
+        json=json_out,
+    )
+
+
+def _sig(tmp_path: Path, data: dict, name: str = "sig.json") -> Path:
+    p = tmp_path / name
+    p.write_text(json.dumps(data), encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Flag gating
+# ---------------------------------------------------------------------------
+
+
+def test_flag_off_exits_1(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.delenv(_FLAG, raising=False)
+    assert cmd_quarantine_eval(_ns(str(_sig(tmp_path, _FRESH)))) == 1
+
+
+def test_flag_off_names_flag_in_stderr(monkeypatch, tmp_path: Path, capsys) -> None:
+    monkeypatch.delenv(_FLAG, raising=False)
+    cmd_quarantine_eval(_ns(str(_sig(tmp_path, _FRESH))))
+    assert _FLAG in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("val", ["1", "true", "yes", "on"])
+def test_flag_truthy_values_exit_0(monkeypatch, tmp_path: Path, val: str) -> None:
+    monkeypatch.setenv(_FLAG, val)
+    assert cmd_quarantine_eval(_ns(str(_sig(tmp_path, _FRESH)))) == 0
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+
+def test_missing_signal_file_exits_1(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    assert cmd_quarantine_eval(_ns(str(tmp_path / "absent.json"))) == 1
+
+
+def test_bad_json_exits_1(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    p = tmp_path / "bad.json"
+    p.write_text("{not valid json", encoding="utf-8")
+    assert cmd_quarantine_eval(_ns(str(p))) == 1
+
+
+def test_missing_code_unit_id_exits_1(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    assert cmd_quarantine_eval(_ns(str(_sig(tmp_path, {"integrity_score": 0.9})))) == 1
+
+
+# ---------------------------------------------------------------------------
+# Output — text
+# ---------------------------------------------------------------------------
+
+
+def test_text_output_contains_unit_id(monkeypatch, tmp_path: Path, capsys) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    cmd_quarantine_eval(_ns(str(_sig(tmp_path, _FRESH))))
+    assert "test.unit.alpha" in capsys.readouterr().out
+
+
+def test_text_output_shows_action(monkeypatch, tmp_path: Path, capsys) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    cmd_quarantine_eval(_ns(str(_sig(tmp_path, _FRESH))))
+    assert "report_only" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# Output — JSON
+# ---------------------------------------------------------------------------
+
+
+def test_json_output_is_valid(monkeypatch, tmp_path: Path, capsys) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    cmd_quarantine_eval(_ns(str(_sig(tmp_path, _FRESH)), json_out=True))
+    d = json.loads(capsys.readouterr().out)
+    assert {"code_unit_id", "policy_action", "integrity_score"} <= d.keys()
+
+
+def test_non_report_only_carries_provenance_hash(monkeypatch, tmp_path: Path, capsys) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    cmd_quarantine_eval(_ns(str(_sig(tmp_path, _DECAYED)), json_out=True))
+    assert len(json.loads(capsys.readouterr().out)["provenance_hash"]) == 64
+
+
+# ---------------------------------------------------------------------------
+# Policy routing
+# ---------------------------------------------------------------------------
+
+
+def test_high_integrity_is_report_only(monkeypatch, tmp_path: Path, capsys) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    cmd_quarantine_eval(_ns(str(_sig(tmp_path, _FRESH)), json_out=True))
+    assert json.loads(capsys.readouterr().out)["policy_action"] == "report_only"
+
+
+def test_low_integrity_triggers_fail_closed(monkeypatch, tmp_path: Path, capsys) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    sig = {**_FRESH, "integrity_score": 0.1, "code_unit_id": "test.unit.low"}
+    cmd_quarantine_eval(_ns(str(_sig(tmp_path, sig)), json_out=True))
+    result = json.loads(capsys.readouterr().out)
+    assert result["policy_action"] == "fail_closed"
+    assert result["fail_closed"] is True
+
+
+def test_live_dispatch_class_uses_higher_threshold(monkeypatch, tmp_path: Path, capsys) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    # integrity 0.55 is > default threshold (0.4) but < live_dispatch threshold (0.6)
+    sig = {**_FRESH, "integrity_score": 0.55, "code_unit_id": "test.unit.ld"}
+    cmd_quarantine_eval(
+        _ns(str(_sig(tmp_path, sig)), code_unit_class="live_dispatch", json_out=True)
+    )
+    result = json.loads(capsys.readouterr().out)
+    assert result["policy_action"] == "fail_closed"
+    assert result["fail_closed"] is True
+
+
+def test_live_swap_request_without_allowlist_is_blocked(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    cmd_quarantine_eval(_ns(str(_sig(tmp_path, _FRESH)), request_live_swap=True, json_out=True))
+    assert json.loads(capsys.readouterr().out)["live_swap_blocked"] is True


### PR DESCRIPTION
## Slice

Adds `aragora quarantine-eval --signal <file>` — a flag-gated CLI verb that reads a `DecaySignal` JSON file, runs one DIC-21 policy evaluation via `apply_quarantine_policy`, and emits the `QuarantineDecision` as a text report or JSON. The quarantine policy module (`aragora/epistemic/quarantine_policy.py`) and its tests already existed; this slice closes the missing operator CLI surface gap.

## Gating

- Default: **OFF** (flag: `ARAGORA_QUARANTINE_POLICY_ENABLED=1`)
- Live queue effect: **none** — report-only; no debates started, no queue writes, no routing changes
- Advances issue: #6032 (DIC-21 — Fail-closed quarantine policy for decayed code proofs)

## Tests

- `test_flag_off_exits_1` — unset flag → rc=1
- `test_flag_off_names_flag_in_stderr` — stderr includes the flag name
- `test_flag_truthy_values_exit_0[1/true/yes/on]` — parametrized over truthy spellings
- `test_missing_signal_file_exits_1` — absent path → rc=1
- `test_bad_json_exits_1` — malformed JSON → rc=1
- `test_missing_code_unit_id_exits_1` — JSON missing required field → rc=1
- `test_text_output_contains_unit_id` — text report includes the `code_unit_id`
- `test_text_output_shows_action` — text report includes `policy_action`
- `test_json_output_is_valid` — `--json` emits parseable JSON with `code_unit_id`, `policy_action`, `integrity_score`
- `test_non_report_only_carries_provenance_hash` — non-report-only decision has 64-char SHA-256 hash
- `test_high_integrity_is_report_only` — integrity 0.9 → `report_only`
- `test_low_integrity_triggers_fail_closed` — integrity 0.1 < default threshold 0.4 → `fail_closed`
- `test_live_dispatch_class_uses_higher_threshold` — integrity 0.55 < `live_dispatch` threshold 0.6 → `fail_closed`
- `test_live_swap_request_without_allowlist_is_blocked` — `--request-live-swap` without allowlist → `live_swap_blocked=True`

## Validation

- `pytest tests/cli/test_dic21_quarantine.py --noconftest` — **17 passed**
- `ruff check aragora/cli/commands/dic21_quarantine.py tests/cli/test_dic21_quarantine.py` — **clean**
- `mypy aragora/cli/commands/dic21_quarantine.py --ignore-missing-imports` — **clean**
- Net diff: **~270 non-blank LOC** (3 files: 95 command, 131 test, 43 parser)

Note: tests use a minimal `sys.modules["yaml"]` stub so the hermetic test environment (no pyyaml in uv-tool pytest venv) can import `aragora.epistemic` cleanly. In a fully-installed project environment all tests pass without the stub.

## Out of scope

- DIC-22 (repair/verified-replacement pipeline): consumes `QuarantineDecision` but is a separate module and CLI surface — deferred
- Wiring `quarantine-eval` output into a receipt or KM ingestion path — deferred to DIC-16/22 follow-on once the gate opens
- Auto-scheduling quarantine evaluation across a proof-units directory — deferred; this slice is deliberate single-signal evaluation only

## Gate status

Per `docs/status/NEXT_STEPS_CANONICAL.md`, `DIC-13..22` are in the **Delay** track. The proof-first Foreman gate has **not** opened. This PR is planning truth and flag-gated operator tooling only; no `boss-ready` label applied. Kept as draft.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XukyAFsfkbjjM8i22oVY4y)_