### PR TITLE
feat(automation): merge-quorum rerun reconciler + settlement-status CLI (resilience Phase 1)

### DIFF
--- a/aragora/swarm/merge_quorum_io.py
+++ b/aragora/swarm/merge_quorum_io.py
@@ -269,7 +269,7 @@ def fetch_evidence_comments(
             # cannot possibly count (evidence-lint rejects github-actions
             # authors and anything too short for a head citation + heading).
             continue
-        lint = lint_comment(repo, pr, head_sha, head_committed_at, author, body, env)
+        lint = lint_comment(pr, head_sha, head_committed_at, author, body, env)
         counted = lint.get("counted_reviewer_ids") or []
         results.append(
             EvidenceComment(
@@ -282,8 +282,37 @@ def fetch_evidence_comments(
     return results
 
 
+def _evidence_lint_args(
+    pr: int, head_sha: str, head_committed_at: str, author: str, body_file: str
+) -> list[str]:
+    """Build the ``review-queue evidence-lint`` argv.
+
+    Note: ``evidence-lint`` infers the repo from the current context and does
+    *not* accept ``--repo``; passing it makes argparse reject the call. With
+    ``--head-committed-at`` supplied the lint is fully offline.
+    """
+    args = [
+        sys.executable,
+        "-m",
+        "aragora.cli.main",
+        "review-queue",
+        "evidence-lint",
+        "--pr",
+        str(pr),
+        "--head-sha",
+        head_sha,
+        "--author",
+        author,
+        "--body-file",
+        body_file,
+        "--json",
+    ]
+    if head_committed_at:
+        args.extend(["--head-committed-at", head_committed_at])
+    return args
+
+
 def lint_comment(
-    repo: str,
     pr: int,
     head_sha: str,
     head_committed_at: str,
@@ -295,26 +324,7 @@ def lint_comment(
         fh.write(body)
         body_file = fh.name
     try:
-        args = [
-            sys.executable,
-            "-m",
-            "aragora.cli.main",
-            "review-queue",
-            "evidence-lint",
-            "--pr",
-            str(pr),
-            "--head-sha",
-            head_sha,
-            "--author",
-            author,
-            "--body-file",
-            body_file,
-            "--repo",
-            repo,
-            "--json",
-        ]
-        if head_committed_at:
-            args.extend(["--head-committed-at", head_committed_at])
+        args = _evidence_lint_args(pr, head_sha, head_committed_at, author, body_file)
         try:
             proc = run(args, env=env, timeout=_EVIDENCE_LINT_TIMEOUT)
         except subprocess.TimeoutExpired:

--- a/aragora/swarm/merge_quorum_io.py
+++ b/aragora/swarm/merge_quorum_io.py
@@ -26,17 +26,35 @@ _SHADOW_MARKERS = ("shadow", "advisory")
 _FAILED_CONCLUSIONS = {"FAILURE", "TIMED_OUT", "ERROR", "STARTUP_FAILURE"}
 _MERGE_PACKET_TIMEOUT = 120
 _EVIDENCE_LINT_TIMEOUT = 90
+_GH_TIMEOUT = 60
+_GITHUB_ACTIONS_AUTHOR = "github-actions[bot]"
+_MIN_EVIDENCE_BODY = 40
+
+
+def _could_count(author: str, body: str) -> bool:
+    """Cheap pre-check mirroring evidence-lint's hard rejections.
+
+    A countable comment must have a non-github-actions author and enough text to
+    carry a 7-char head citation plus a reviewer heading. Used only to skip
+    obviously-uncountable comments before spawning the lint subprocess; the lint
+    CLI remains the source of truth for everything that passes this filter.
+    """
+    if author == _GITHUB_ACTIONS_AUTHOR:
+        return False
+    return len(body.strip()) >= _MIN_EVIDENCE_BODY
 
 
 def _looks_like_shadow(name: str) -> bool:
     """Whether a check name is a non-required shadow/advisory check.
 
-    Matches whole tokens (split on non-alphanumerics) so a required check whose
-    name merely contains the substring (e.g. ``aragora-shadow-deploy-required``)
-    is not misclassified as a shadow.
+    Shadow checks are named with a trailing marker word (e.g. ``... Shadow``),
+    so this matches only the *last* token. A required check that merely contains
+    a marker earlier in its name (e.g. ``aragora-shadow-deploy-required``, whose
+    last token is ``required``) is therefore not misclassified as a shadow. This
+    heuristic is only consulted when GitHub does not report ``isRequired``.
     """
-    tokens = re.split(r"[^a-z0-9]+", name.lower())
-    return any(marker in tokens for marker in _SHADOW_MARKERS)
+    tokens = [t for t in re.split(r"[^a-z0-9]+", name.lower()) if t]
+    return bool(tokens) and tokens[-1] in _SHADOW_MARKERS
 
 
 def aragora_env() -> dict[str, str]:
@@ -53,8 +71,13 @@ def run(
     )
 
 
-def run_json(args: list[str], *, env: dict[str, str] | None = None) -> Any:
-    proc = run(args, env=env)
+def run_json(
+    args: list[str], *, env: dict[str, str] | None = None, timeout: int = _GH_TIMEOUT
+) -> Any:
+    try:
+        proc = run(args, env=env, timeout=timeout)
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"command timed out after {timeout}s: {' '.join(args)}") from exc
     if proc.returncode != 0:
         raise RuntimeError(f"command failed ({proc.returncode}): {' '.join(args)}\n{proc.stderr}")
     return json.loads(proc.stdout or "null")
@@ -238,9 +261,12 @@ def fetch_evidence_comments(
         if not isinstance(comment, dict):
             continue
         body = str(comment.get("body") or "")
-        if not body.strip():
-            continue
         author = str((comment.get("user") or {}).get("login") or "")
+        if not _could_count(author, body):
+            # Cheap pre-filter: avoid spawning evidence-lint for comments that
+            # cannot possibly count (evidence-lint rejects github-actions
+            # authors and anything too short for a head citation + heading).
+            continue
         lint = lint_comment(repo, pr, head_sha, head_committed_at, author, body, env)
         counted = lint.get("counted_reviewer_ids") or []
         results.append(

--- a/aragora/swarm/merge_quorum_io.py
+++ b/aragora/swarm/merge_quorum_io.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -24,6 +25,18 @@ HUMAN_SETTLEMENT_CONTEXT = "aragora/human-settlement"
 _SHADOW_MARKERS = ("shadow", "advisory")
 _FAILED_CONCLUSIONS = {"FAILURE", "TIMED_OUT", "ERROR", "STARTUP_FAILURE"}
 _MERGE_PACKET_TIMEOUT = 120
+_EVIDENCE_LINT_TIMEOUT = 90
+
+
+def _looks_like_shadow(name: str) -> bool:
+    """Whether a check name is a non-required shadow/advisory check.
+
+    Matches whole tokens (split on non-alphanumerics) so a required check whose
+    name merely contains the substring (e.g. ``aragora-shadow-deploy-required``)
+    is not misclassified as a shadow.
+    """
+    tokens = re.split(r"[^a-z0-9]+", name.lower())
+    return any(marker in tokens for marker in _SHADOW_MARKERS)
 
 
 def aragora_env() -> dict[str, str]:
@@ -99,10 +112,15 @@ def fetch_pr_context(repo: str, pr: int) -> dict[str, Any]:
         if isinstance(entry, dict) and str(entry.get("oid") or "") == head_sha:
             head_committed_at = str(entry.get("committedDate") or "")
             break
-    if not head_committed_at and commits:
-        last = commits[-1]
-        if isinstance(last, dict):
-            head_committed_at = str(last.get("committedDate") or "")
+    if not head_committed_at and head_sha:
+        # The head may be beyond the returned commit slice; fetch its date
+        # directly rather than guessing from the last listed commit.
+        try:
+            commit = run_json(["gh", "api", f"repos/{repo}/commits/{head_sha}"]) or {}
+        except RuntimeError:
+            commit = {}
+        committer = (commit.get("commit") or {}).get("committer") or {}
+        head_committed_at = str(committer.get("date") or "")
 
     real_failure = False
     quorum_conclusion = ""
@@ -119,7 +137,7 @@ def fetch_pr_context(repo: str, pr: int) -> dict[str, Any]:
         is_required = check.get("isRequired")
         if is_required is True:
             real_failure = True
-        elif is_required is None and not any(m in name.lower() for m in _SHADOW_MARKERS):
+        elif is_required is None and not _looks_like_shadow(name):
             real_failure = True
     return {
         "head_sha": head_sha,
@@ -143,8 +161,15 @@ def fetch_latest_quorum_run(repo: str, head_sha: str) -> QuorumRun | None:
     if not runs:
         return None
     run_obj = runs[0]
+    raw_id = run_obj.get("id")
+    if raw_id is None:
+        return None
+    try:
+        run_id = int(raw_id)
+    except (TypeError, ValueError):
+        return None
     return QuorumRun(
-        run_id=int(run_obj.get("id")),
+        run_id=run_id,
         created_at=str(run_obj.get("created_at") or ""),
         conclusion=str(run_obj.get("conclusion") or "").upper(),
         head_sha=str(run_obj.get("head_sha") or ""),
@@ -238,7 +263,7 @@ def lint_comment(
     body: str,
     env: dict[str, str],
 ) -> dict[str, Any]:
-    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as fh:
+    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False, encoding="utf-8") as fh:
         fh.write(body)
         body_file = fh.name
     try:
@@ -262,7 +287,10 @@ def lint_comment(
         ]
         if head_committed_at:
             args.extend(["--head-committed-at", head_committed_at])
-        proc = run(args, env=env)
+        try:
+            proc = run(args, env=env, timeout=_EVIDENCE_LINT_TIMEOUT)
+        except subprocess.TimeoutExpired:
+            return {}
         if proc.returncode != 0 or not proc.stdout.strip():
             return {}
         try:

--- a/aragora/swarm/merge_quorum_io.py
+++ b/aragora/swarm/merge_quorum_io.py
@@ -1,0 +1,276 @@
+"""GitHub + ``evidence-lint`` I/O for merge-quorum reconciliation CLIs.
+
+Thin subprocess wrappers shared by ``scripts/reconcile_merge_quorum.py`` (A1)
+and ``scripts/settle_status.py`` (A2). Kept separate from the pure decision
+logic in :mod:`aragora.swarm.merge_quorum_reconcile` so the decision logic stays
+network-free and unit-testable. Counting is always delegated to the canonical
+``review-queue evidence-lint`` subcommand so these tools match the gate's parser.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from typing import Any
+
+from aragora.swarm.merge_quorum_reconcile import EvidenceComment, QuorumRun
+
+QUORUM_CHECK_NAME = "aragora-merge-quorum"
+QUORUM_WORKFLOW_FILE = "aragora-merge-quorum.yml"
+HUMAN_SETTLEMENT_CONTEXT = "aragora/human-settlement"
+_SHADOW_MARKERS = ("shadow", "advisory")
+_FAILED_CONCLUSIONS = {"FAILURE", "TIMED_OUT", "ERROR", "STARTUP_FAILURE"}
+_MERGE_PACKET_TIMEOUT = 120
+
+
+def aragora_env() -> dict[str, str]:
+    env = dict(os.environ)
+    env.setdefault("ARAGORA_USE_SECRETS_MANAGER", "false")
+    return env
+
+
+def run(
+    args: list[str], *, env: dict[str, str] | None = None, timeout: int | None = None
+) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        args, capture_output=True, text=True, check=False, env=env, timeout=timeout
+    )
+
+
+def run_json(args: list[str], *, env: dict[str, str] | None = None) -> Any:
+    proc = run(args, env=env)
+    if proc.returncode != 0:
+        raise RuntimeError(f"command failed ({proc.returncode}): {' '.join(args)}\n{proc.stderr}")
+    return json.loads(proc.stdout or "null")
+
+
+def list_open_prs(repo: str, *, limit: int, author: str | None) -> list[int]:
+    rows = (
+        run_json(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--repo",
+                repo,
+                "--state",
+                "open",
+                "--limit",
+                str(limit),
+                "--json",
+                "number,isDraft,author",
+            ]
+        )
+        or []
+    )
+    numbers: list[int] = []
+    for row in rows:
+        if not isinstance(row, dict) or row.get("isDraft"):
+            continue
+        if author and str((row.get("author") or {}).get("login", "")) != author:
+            continue
+        num = row.get("number")
+        if isinstance(num, int):
+            numbers.append(num)
+    return numbers
+
+
+def fetch_pr_context(repo: str, pr: int) -> dict[str, Any]:
+    """Head SHA, head committedDate, quorum conclusion, and real-failure flag."""
+    data = run_json(
+        [
+            "gh",
+            "pr",
+            "view",
+            str(pr),
+            "--repo",
+            repo,
+            "--json",
+            "headRefOid,commits,statusCheckRollup",
+        ]
+    )
+    head_sha = str(data.get("headRefOid") or "").strip()
+    commits = data.get("commits") or []
+    head_committed_at = ""
+    for entry in commits:
+        if isinstance(entry, dict) and str(entry.get("oid") or "") == head_sha:
+            head_committed_at = str(entry.get("committedDate") or "")
+            break
+    if not head_committed_at and commits:
+        last = commits[-1]
+        if isinstance(last, dict):
+            head_committed_at = str(last.get("committedDate") or "")
+
+    real_failure = False
+    quorum_conclusion = ""
+    for check in data.get("statusCheckRollup") or []:
+        if not isinstance(check, dict):
+            continue
+        name = str(check.get("name") or check.get("context") or "")
+        conclusion = str(check.get("conclusion") or check.get("state") or "").upper()
+        if name == QUORUM_CHECK_NAME:
+            quorum_conclusion = conclusion
+            continue
+        if conclusion not in _FAILED_CONCLUSIONS:
+            continue
+        is_required = check.get("isRequired")
+        if is_required is True:
+            real_failure = True
+        elif is_required is None and not any(m in name.lower() for m in _SHADOW_MARKERS):
+            real_failure = True
+    return {
+        "head_sha": head_sha,
+        "head_committed_at": head_committed_at,
+        "quorum_conclusion": quorum_conclusion,
+        "has_real_required_failure": real_failure,
+    }
+
+
+def fetch_latest_quorum_run(repo: str, head_sha: str) -> QuorumRun | None:
+    if not head_sha:
+        return None
+    data = run_json(
+        [
+            "gh",
+            "api",
+            f"repos/{repo}/actions/workflows/{QUORUM_WORKFLOW_FILE}/runs?head_sha={head_sha}&per_page=1",
+        ]
+    )
+    runs = (data or {}).get("workflow_runs") or []
+    if not runs:
+        return None
+    run_obj = runs[0]
+    return QuorumRun(
+        run_id=int(run_obj.get("id")),
+        created_at=str(run_obj.get("created_at") or ""),
+        conclusion=str(run_obj.get("conclusion") or "").upper(),
+        head_sha=str(run_obj.get("head_sha") or ""),
+    )
+
+
+def fetch_human_settlement_present(repo: str, head_sha: str) -> bool:
+    if not head_sha:
+        return False
+    try:
+        statuses = run_json(["gh", "api", f"repos/{repo}/commits/{head_sha}/statuses"]) or []
+    except RuntimeError:
+        return False
+    for status in statuses:
+        if not isinstance(status, dict):
+            continue
+        if str(status.get("context") or "") == HUMAN_SETTLEMENT_CONTEXT:
+            return str(status.get("state") or "").lower() == "success"
+    return False
+
+
+def fetch_pr_tier(repo: str, pr: int) -> int | None:
+    """Best-effort tier from ``review-queue merge-packet``; ``None`` if unknown."""
+    try:
+        proc = run(
+            [
+                sys.executable,
+                "-m",
+                "aragora.cli.main",
+                "review-queue",
+                "merge-packet",
+                "--pr",
+                str(pr),
+                "--repo",
+                repo,
+                "--json",
+            ],
+            env=aragora_env(),
+            timeout=_MERGE_PACKET_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired:
+        return None
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return None
+    try:
+        payload = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return None
+    entries = payload if isinstance(payload, list) else [payload]
+    for entry in entries:
+        if isinstance(entry, dict) and entry.get("tier") is not None:
+            try:
+                return int(entry["tier"])
+            except (TypeError, ValueError):
+                return None
+    return None
+
+
+def fetch_evidence_comments(
+    repo: str, pr: int, head_sha: str, head_committed_at: str
+) -> list[EvidenceComment]:
+    comments = run_json(["gh", "api", f"repos/{repo}/issues/{pr}/comments", "--paginate"]) or []
+    env = aragora_env()
+    results: list[EvidenceComment] = []
+    for comment in comments:
+        if not isinstance(comment, dict):
+            continue
+        body = str(comment.get("body") or "")
+        if not body.strip():
+            continue
+        author = str((comment.get("user") or {}).get("login") or "")
+        lint = lint_comment(repo, pr, head_sha, head_committed_at, author, body, env)
+        counted = lint.get("counted_reviewer_ids") or []
+        results.append(
+            EvidenceComment(
+                created_at=str(comment.get("created_at") or ""),
+                would_count=bool(lint.get("would_count")),
+                reviewer_id=str(counted[0]) if counted else "",
+                is_dogfood=bool(lint.get("dogfood_evidence")),
+            )
+        )
+    return results
+
+
+def lint_comment(
+    repo: str,
+    pr: int,
+    head_sha: str,
+    head_committed_at: str,
+    author: str,
+    body: str,
+    env: dict[str, str],
+) -> dict[str, Any]:
+    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as fh:
+        fh.write(body)
+        body_file = fh.name
+    try:
+        args = [
+            sys.executable,
+            "-m",
+            "aragora.cli.main",
+            "review-queue",
+            "evidence-lint",
+            "--pr",
+            str(pr),
+            "--head-sha",
+            head_sha,
+            "--author",
+            author,
+            "--body-file",
+            body_file,
+            "--repo",
+            repo,
+            "--json",
+        ]
+        if head_committed_at:
+            args.extend(["--head-committed-at", head_committed_at])
+        proc = run(args, env=env)
+        if proc.returncode != 0 or not proc.stdout.strip():
+            return {}
+        try:
+            return json.loads(proc.stdout)
+        except json.JSONDecodeError:
+            return {}
+    finally:
+        try:
+            os.unlink(body_file)
+        except OSError:
+            pass

--- a/aragora/swarm/merge_quorum_io.py
+++ b/aragora/swarm/merge_quorum_io.py
@@ -320,10 +320,12 @@ def lint_comment(
     body: str,
     env: dict[str, str],
 ) -> dict[str, Any]:
-    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False, encoding="utf-8") as fh:
-        fh.write(body)
-        body_file = fh.name
+    body_file = ""
     try:
+        with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False, encoding="utf-8") as fh:
+            # Capture the path before writing so a write failure still cleans up.
+            body_file = fh.name
+            fh.write(body)
         args = _evidence_lint_args(pr, head_sha, head_committed_at, author, body_file)
         try:
             proc = run(args, env=env, timeout=_EVIDENCE_LINT_TIMEOUT)
@@ -336,7 +338,8 @@ def lint_comment(
         except json.JSONDecodeError:
             return {}
     finally:
-        try:
-            os.unlink(body_file)
-        except OSError:
-            pass
+        if body_file:
+            try:
+                os.unlink(body_file)
+            except OSError:
+                pass

--- a/aragora/swarm/merge_quorum_io.py
+++ b/aragora/swarm/merge_quorum_io.py
@@ -64,8 +64,10 @@ def aragora_env() -> dict[str, str]:
 
 
 def run(
-    args: list[str], *, env: dict[str, str] | None = None, timeout: int | None = None
+    args: list[str], *, env: dict[str, str] | None = None, timeout: int | None = _GH_TIMEOUT
 ) -> subprocess.CompletedProcess:
+    # Default to a bounded timeout so no bare call can hang the reconciler;
+    # callers that need longer (model-review CLIs) pass an explicit timeout.
     return subprocess.run(
         args, capture_output=True, text=True, check=False, env=env, timeout=timeout
     )

--- a/aragora/swarm/merge_quorum_reconcile.py
+++ b/aragora/swarm/merge_quorum_reconcile.py
@@ -243,6 +243,8 @@ def summarize_settlement(
             "operator: record human settlement for the current head "
             "(scripts/settle_tier4_pr.py --apply)"
         )
+    elif not quorum_conclusion:
+        next_action = "wait for the aragora-merge-quorum check to run on the current head"
     else:
         next_action = (
             "re-run aragora-merge-quorum so it re-reads the current evidence "

--- a/aragora/swarm/merge_quorum_reconcile.py
+++ b/aragora/swarm/merge_quorum_reconcile.py
@@ -1,0 +1,261 @@
+"""Pure decision logic for merge-quorum reconciliation and settlement status.
+
+Background
+----------
+The enforcing merge gate (``aragora-merge-quorum``) only re-evaluates on
+``pull_request`` synchronize-type events, never on ``issue_comment``. The
+heterogeneous model-review evidence, however, is posted as PR comments *after*
+those events. The result is a recurring stall: the check computes once
+(pre-evidence) and concludes FAILURE, and never re-reads the now-complete
+evidence, so a PR sits red even though its quorum is satisfied. The safe,
+deterministic recovery is to re-run that read-only evaluation once a strictly
+newer *countable* evidence comment exists for the current head.
+
+This module is **pure** (no I/O): it takes already-fetched, already-linted
+records and returns decisions/summaries. The GitHub I/O lives in the thin CLIs
+``scripts/reconcile_merge_quorum.py`` (A1) and ``scripts/settle_status.py``
+(A2), mirroring the :mod:`aragora.swarm.unstick` pattern so this logic stays
+unit-testable without network access.
+
+Safety invariants (enforced here):
+
+* Never recommend a re-run when the gate already concluded SUCCESS.
+* Never recommend a re-run when the latest run belongs to a stale head.
+* Never recommend a re-run unless a strictly newer countable comment exists.
+* Never recommend a re-run when a *real* required-check failure is present
+  (that is a genuine red, not a stale-quorum artifact).
+* Respect a per-head cooldown and a per-head max-rerun budget.
+
+Re-running a read-only evaluation can never pass a genuinely failing PR; it only
+lets the gate re-read evidence that is already public.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Final
+
+# Mirrors aragora/cli/commands/review_queue.py::_tier_requirement. This is a
+# read-only *diagnostic* mapping used only to render the "next action" hint; it
+# never gates a merge. Tuple = (required_model_signals, requires_dogfood,
+# requires_human_settlement). Kept tiny and annotated so drift is obvious.
+TIER_REQUIREMENTS: Final[dict[int, tuple[int, bool, bool]]] = {
+    0: (1, False, False),
+    1: (2, True, False),
+    2: (2, True, False),
+    3: (2, True, True),
+    4: (2, True, True),
+}
+
+_SUCCESS: Final[str] = "SUCCESS"
+
+
+def parse_iso8601(value: str | None) -> datetime | None:
+    """Parse a GitHub ISO-8601 timestamp to an aware UTC datetime, or ``None``.
+
+    Accepts the trailing ``Z`` form GitHub returns. Returns ``None`` for empty
+    or unparseable input so callers can fail safe (treat as "unknown").
+    """
+    text = str(value or "").strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+@dataclass(frozen=True)
+class EvidenceComment:
+    """A PR comment already evaluated by ``review-queue evidence-lint``.
+
+    Attributes:
+        created_at: ISO-8601 creation timestamp of the comment.
+        would_count: ``evidence-lint``'s ``would_count`` verdict.
+        reviewer_id: The single counted reviewer family (e.g. ``"claude"``),
+            or ``""`` when the comment does not count.
+        is_dogfood: Whether the comment contributes adversarial-dogfood
+            evidence (``evidence-lint`` returned non-empty ``dogfood_evidence``).
+    """
+
+    created_at: str
+    would_count: bool
+    reviewer_id: str = ""
+    is_dogfood: bool = False
+
+
+@dataclass(frozen=True)
+class QuorumRun:
+    """The latest ``aragora-merge-quorum`` workflow run for a PR head."""
+
+    run_id: int
+    created_at: str
+    conclusion: str
+    head_sha: str
+
+
+@dataclass(frozen=True)
+class RerunDecision:
+    """Whether A1 should re-run the gate for a PR."""
+
+    pr_number: int
+    should_rerun: bool
+    reason: str
+    run_id: int | None = None
+
+
+@dataclass(frozen=True)
+class SettlementStatus:
+    """A2's read-only view of where a PR's settlement actually stands."""
+
+    pr_number: int
+    head_sha: str
+    tier: int | None
+    counted_reviewer_ids: list[str] = field(default_factory=list)
+    has_dogfood: bool = False
+    human_settlement_present: bool = False
+    quorum_conclusion: str = ""
+    next_action: str = ""
+
+    @property
+    def signal_count(self) -> int:
+        return len(self.counted_reviewer_ids)
+
+
+def _newest_countable_created_at(comments: list[EvidenceComment]) -> datetime | None:
+    newest: datetime | None = None
+    for comment in comments:
+        if not comment.would_count:
+            continue
+        created = parse_iso8601(comment.created_at)
+        if created is None:
+            continue
+        if newest is None or created > newest:
+            newest = created
+    return newest
+
+
+def counted_reviewer_ids(comments: list[EvidenceComment]) -> list[str]:
+    """Distinct counted reviewer families across countable comments."""
+    ids: set[str] = set()
+    for comment in comments:
+        if comment.would_count and comment.reviewer_id:
+            ids.add(comment.reviewer_id)
+    return sorted(ids)
+
+
+def plan_rerun(
+    *,
+    pr_number: int,
+    run: QuorumRun | None,
+    comments: list[EvidenceComment],
+    current_head_sha: str,
+    now: datetime,
+    last_rerun_at: datetime | None = None,
+    reruns_this_head: int = 0,
+    cooldown_seconds: int = 600,
+    max_reruns_per_head: int = 3,
+    has_real_required_failure: bool = False,
+) -> RerunDecision:
+    """Decide whether to re-run the gate so it re-reads current-head evidence.
+
+    All checks fail safe (a ``False`` decision) when an input is missing or
+    ambiguous. See module docstring for the safety invariants.
+    """
+
+    def decide(should: bool, reason: str) -> RerunDecision:
+        return RerunDecision(
+            pr_number=pr_number,
+            should_rerun=should,
+            reason=reason,
+            run_id=run.run_id if run else None,
+        )
+
+    if run is None:
+        return decide(False, "no aragora-merge-quorum run found for the current head")
+    if run.conclusion.upper() == _SUCCESS:
+        return decide(False, "quorum check already SUCCESS")
+    if run.head_sha and current_head_sha and run.head_sha != current_head_sha:
+        return decide(False, "latest run belongs to a stale head; await current-head run")
+    if has_real_required_failure:
+        return decide(False, "a real required-check failure is present; not a stale-quorum case")
+
+    newest = _newest_countable_created_at(comments)
+    if newest is None:
+        return decide(False, "no countable evidence present yet")
+
+    run_created = parse_iso8601(run.created_at)
+    if run_created is None:
+        return decide(False, "quorum run timestamp unparseable")
+    if not (run_created < newest):
+        return decide(False, "quorum run already postdates the newest countable evidence")
+
+    if reruns_this_head >= max_reruns_per_head:
+        return decide(False, f"max reruns reached for this head ({max_reruns_per_head})")
+    if last_rerun_at is not None:
+        elapsed = (now - last_rerun_at).total_seconds()
+        if elapsed < cooldown_seconds:
+            return decide(False, f"within cooldown ({int(elapsed)}s < {cooldown_seconds}s)")
+
+    return decide(
+        True,
+        "stale quorum check predates newer countable evidence; safe read-only re-run",
+    )
+
+
+def summarize_settlement(
+    *,
+    pr_number: int,
+    head_sha: str,
+    tier: int | None,
+    comments: list[EvidenceComment],
+    human_settlement_present: bool,
+    quorum_conclusion: str,
+) -> SettlementStatus:
+    """Compute the live settlement state directly from linted comments.
+
+    Immune to the ``merge-packet`` short-circuit (which hides the quorum detail
+    whenever the gate check is failing), because it counts evidence from the
+    comment lint results rather than from the packet.
+    """
+    ids = counted_reviewer_ids(comments)
+    has_dogfood = any(c.would_count and c.is_dogfood for c in comments)
+
+    required_signals, requires_dogfood, requires_human = TIER_REQUIREMENTS.get(
+        tier if tier is not None else -1, (2, True, True)
+    )
+
+    if quorum_conclusion.upper() == _SUCCESS:
+        next_action = "none — quorum check is green; PR is ready to merge"
+    elif len(ids) < required_signals:
+        missing = required_signals - len(ids)
+        next_action = f"collect {missing} more distinct model signal(s) on the current head"
+    elif requires_dogfood and not has_dogfood:
+        next_action = "post adversarial-dogfood evidence on the current head"
+    elif requires_human and not human_settlement_present:
+        next_action = (
+            "operator: record human settlement for the current head "
+            "(scripts/settle_tier4_pr.py --apply)"
+        )
+    else:
+        next_action = (
+            "re-run aragora-merge-quorum so it re-reads the current evidence "
+            "(scripts/reconcile_merge_quorum.py --apply)"
+        )
+
+    return SettlementStatus(
+        pr_number=pr_number,
+        head_sha=head_sha,
+        tier=tier,
+        counted_reviewer_ids=ids,
+        has_dogfood=has_dogfood,
+        human_settlement_present=human_settlement_present,
+        quorum_conclusion=quorum_conclusion,
+        next_action=next_action,
+    )

--- a/aragora/swarm/merge_quorum_reconcile.py
+++ b/aragora/swarm/merge_quorum_reconcile.py
@@ -49,6 +49,11 @@ TIER_REQUIREMENTS: Final[dict[int, tuple[int, bool, bool]]] = {
 }
 
 _SUCCESS: Final[str] = "SUCCESS"
+# Non-terminal states that may arrive via the check-run ``state`` fallback; the
+# gate has not concluded, so the right hint is "wait", not "re-run".
+_NON_FINAL_STATES: Final[frozenset[str]] = frozenset(
+    {"IN_PROGRESS", "QUEUED", "PENDING", "WAITING", "REQUESTED", "EXPECTED"}
+)
 
 
 def parse_iso8601(value: str | None) -> datetime | None:
@@ -243,7 +248,7 @@ def summarize_settlement(
             "operator: record human settlement for the current head "
             "(scripts/settle_tier4_pr.py --apply)"
         )
-    elif not quorum_conclusion:
+    elif not quorum_conclusion or quorum_conclusion.upper() in _NON_FINAL_STATES:
         next_action = "wait for the aragora-merge-quorum check to run on the current head"
     else:
         next_action = (

--- a/scripts/reconcile_merge_quorum.py
+++ b/scripts/reconcile_merge_quorum.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -50,6 +51,9 @@ from aragora.swarm.merge_quorum_reconcile import (  # noqa: E402
 DEFAULT_STATE_FILE = Path.home() / ".aragora" / "merge_quorum_reconcile_state.json"
 
 
+_MAX_STATE_ENTRIES = 500
+
+
 def _load_state(path: Path) -> dict[str, Any]:
     try:
         return json.loads(path.read_text(encoding="utf-8"))
@@ -57,10 +61,24 @@ def _load_state(path: Path) -> dict[str, Any]:
         return {}
 
 
+def _prune_state(state: dict[str, Any]) -> dict[str, Any]:
+    if len(state) <= _MAX_STATE_ENTRIES:
+        return state
+    items = sorted(
+        state.items(),
+        key=lambda kv: str((kv[1] or {}).get("last_rerun_at") or ""),
+        reverse=True,
+    )
+    return dict(items[:_MAX_STATE_ENTRIES])
+
+
 def _save_state(path: Path, state: dict[str, Any]) -> None:
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(state, indent=2, sort_keys=True), encoding="utf-8")
+        payload = json.dumps(_prune_state(state), indent=2, sort_keys=True)
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(payload, encoding="utf-8")
+        os.replace(tmp, path)
     except OSError as exc:
         print(f"warning: could not persist state to {path}: {exc}", file=sys.stderr)
 

--- a/scripts/reconcile_merge_quorum.py
+++ b/scripts/reconcile_merge_quorum.py
@@ -27,6 +27,7 @@ import argparse
 import json
 import os
 import sys
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -61,12 +62,15 @@ def _load_state(path: Path) -> dict[str, Any]:
         return {}
 
 
+_EPOCH = datetime.min.replace(tzinfo=timezone.utc)
+
+
 def _prune_state(state: dict[str, Any]) -> dict[str, Any]:
     if len(state) <= _MAX_STATE_ENTRIES:
         return state
     items = sorted(
         state.items(),
-        key=lambda kv: str((kv[1] or {}).get("last_rerun_at") or ""),
+        key=lambda kv: parse_iso8601((kv[1] or {}).get("last_rerun_at")) or _EPOCH,
         reverse=True,
     )
     return dict(items[:_MAX_STATE_ENTRIES])
@@ -76,8 +80,16 @@ def _save_state(path: Path, state: dict[str, Any]) -> None:
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         payload = json.dumps(_prune_state(state), indent=2, sort_keys=True)
-        tmp = path.with_suffix(path.suffix + ".tmp")
-        tmp.write_text(payload, encoding="utf-8")
+        with tempfile.NamedTemporaryFile(
+            "w",
+            dir=path.parent,
+            prefix=path.name + ".",
+            suffix=".tmp",
+            delete=False,
+            encoding="utf-8",
+        ) as fh:
+            fh.write(payload)
+            tmp = Path(fh.name)
         os.replace(tmp, path)
     except OSError as exc:
         print(f"warning: could not persist state to {path}: {exc}", file=sys.stderr)

--- a/scripts/reconcile_merge_quorum.py
+++ b/scripts/reconcile_merge_quorum.py
@@ -78,6 +78,7 @@ def _prune_state(state: dict[str, Any]) -> dict[str, Any]:
 
 
 def _save_state(path: Path, state: dict[str, Any]) -> None:
+    tmp: Path | None = None
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         payload = json.dumps(_prune_state(state), indent=2, sort_keys=True)
@@ -89,11 +90,19 @@ def _save_state(path: Path, state: dict[str, Any]) -> None:
             delete=False,
             encoding="utf-8",
         ) as fh:
-            fh.write(payload)
+            # Capture the path before writing so a write failure still cleans up.
             tmp = Path(fh.name)
+            fh.write(payload)
         os.replace(tmp, path)
+        tmp = None  # consumed by os.replace
     except OSError as exc:
         print(f"warning: could not persist state to {path}: {exc}", file=sys.stderr)
+    finally:
+        if tmp is not None:
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
 
 
 def evaluate_pr(

--- a/scripts/reconcile_merge_quorum.py
+++ b/scripts/reconcile_merge_quorum.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import subprocess
 import sys
 import tempfile
 from datetime import datetime, timezone
@@ -125,7 +126,11 @@ def evaluate_pr(
 
 
 def execute_rerun(repo: str, run_id: int) -> bool:
-    proc = run(["gh", "run", "rerun", str(run_id), "--repo", repo])
+    try:
+        proc = run(["gh", "run", "rerun", str(run_id), "--repo", repo])
+    except subprocess.TimeoutExpired:
+        print(f"warning: rerun timed out for run {run_id}", file=sys.stderr)
+        return False
     if proc.returncode != 0:
         print(f"warning: rerun failed for run {run_id}: {proc.stderr.strip()}", file=sys.stderr)
         return False

--- a/scripts/reconcile_merge_quorum.py
+++ b/scripts/reconcile_merge_quorum.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""A1 — merge-quorum rerun reconciler.
+
+Self-heals the recurring "evidence is complete but the PR is stuck" stall: the
+``aragora-merge-quorum`` check only re-evaluates on ``pull_request`` synchronize
+events, never on ``issue_comment``, so a check that ran before the evidence was
+posted stays FAILURE forever even once the quorum is satisfied. This reconciler
+re-runs that **read-only** evaluation once a strictly newer *countable* evidence
+comment exists for the current head.
+
+Defaults to ``--dry-run`` (prints the plan). With ``--apply`` it executes
+``gh run rerun`` for the safe cases only. It never pushes, comments, merges, or
+records settlement. Re-running a read-only evaluation cannot pass a genuinely
+failing PR — it only lets the gate re-read public evidence.
+
+Examples
+--------
+::
+
+    python3 scripts/reconcile_merge_quorum.py --repo synaptent/aragora
+    python3 scripts/reconcile_merge_quorum.py --repo synaptent/aragora --pr 7720 --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from aragora.swarm.merge_quorum_io import (  # noqa: E402
+    fetch_evidence_comments,
+    fetch_latest_quorum_run,
+    fetch_pr_context,
+    list_open_prs,
+    run,
+)
+from aragora.swarm.merge_quorum_reconcile import (  # noqa: E402
+    QuorumRun,
+    RerunDecision,
+    parse_iso8601,
+    plan_rerun,
+)
+
+DEFAULT_STATE_FILE = Path.home() / ".aragora" / "merge_quorum_reconcile_state.json"
+
+
+def _load_state(path: Path) -> dict[str, Any]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _save_state(path: Path, state: dict[str, Any]) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(state, indent=2, sort_keys=True), encoding="utf-8")
+    except OSError as exc:
+        print(f"warning: could not persist state to {path}: {exc}", file=sys.stderr)
+
+
+def evaluate_pr(
+    repo: str,
+    pr: int,
+    *,
+    now: datetime,
+    state: dict[str, Any],
+    cooldown_seconds: int,
+    max_reruns: int,
+) -> tuple[RerunDecision, QuorumRun | None]:
+    ctx = fetch_pr_context(repo, pr)
+    head_sha = ctx["head_sha"]
+    quorum_run = fetch_latest_quorum_run(repo, head_sha)
+    comments = fetch_evidence_comments(repo, pr, head_sha, ctx["head_committed_at"])
+    head_state = state.get(head_sha, {})
+    decision = plan_rerun(
+        pr_number=pr,
+        run=quorum_run,
+        comments=comments,
+        current_head_sha=head_sha,
+        now=now,
+        last_rerun_at=parse_iso8601(head_state.get("last_rerun_at")),
+        reruns_this_head=int(head_state.get("count", 0)),
+        cooldown_seconds=cooldown_seconds,
+        max_reruns_per_head=max_reruns,
+        has_real_required_failure=ctx["has_real_required_failure"],
+    )
+    return decision, quorum_run
+
+
+def execute_rerun(repo: str, run_id: int) -> bool:
+    proc = run(["gh", "run", "rerun", str(run_id), "--repo", repo])
+    if proc.returncode != 0:
+        print(f"warning: rerun failed for run {run_id}: {proc.stderr.strip()}", file=sys.stderr)
+        return False
+    return True
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="merge-quorum rerun reconciler (A1)")
+    parser.add_argument("--repo", required=True, help="GitHub repo slug (owner/name)")
+    parser.add_argument("--pr", type=int, help="Single PR to evaluate (default: all open)")
+    parser.add_argument("--author", help="Only consider PRs by this login")
+    parser.add_argument("--limit", type=int, default=200, help="Max open PRs to walk")
+    parser.add_argument("--cooldown-minutes", type=int, default=10)
+    parser.add_argument("--max-reruns", type=int, default=3, help="Max reruns per head SHA")
+    parser.add_argument("--state-file", type=Path, default=DEFAULT_STATE_FILE)
+    parser.add_argument("--apply", action="store_true", help="Execute reruns (default: dry-run)")
+    parser.add_argument("--json", action="store_true", help="Emit the plan as JSON")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    now = datetime.now(timezone.utc)
+    state = _load_state(args.state_file)
+    prs = [args.pr] if args.pr else list_open_prs(args.repo, limit=args.limit, author=args.author)
+
+    plan: list[dict[str, Any]] = []
+    for pr in prs:
+        try:
+            decision, quorum_run = evaluate_pr(
+                args.repo,
+                pr,
+                now=now,
+                state=state,
+                cooldown_seconds=args.cooldown_minutes * 60,
+                max_reruns=args.max_reruns,
+            )
+        except RuntimeError as exc:
+            plan.append({"pr": pr, "error": str(exc)})
+            continue
+        record: dict[str, Any] = {
+            "pr": pr,
+            "should_rerun": decision.should_rerun,
+            "reason": decision.reason,
+            "run_id": decision.run_id,
+            "applied": False,
+        }
+        if decision.should_rerun and args.apply and quorum_run is not None:
+            if execute_rerun(args.repo, quorum_run.run_id):
+                record["applied"] = True
+                head_state = state.setdefault(
+                    quorum_run.head_sha, {"count": 0, "last_rerun_at": None}
+                )
+                head_state["count"] = int(head_state.get("count", 0)) + 1
+                head_state["last_rerun_at"] = now.isoformat()
+        plan.append(record)
+
+    if args.apply:
+        _save_state(args.state_file, state)
+
+    if args.json:
+        print(json.dumps({"plan": plan}, indent=2))
+    else:
+        for record in plan:
+            if "error" in record:
+                print(f"PR #{record['pr']}: ERROR {record['error']}")
+                continue
+            flag = "RERUN" if record["should_rerun"] else "skip"
+            applied = " (applied)" if record["applied"] else ""
+            print(f"PR #{record['pr']}: {flag}{applied} — {record['reason']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/settle_status.py
+++ b/scripts/settle_status.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""A2 — settlement-status visibility CLI.
+
+Read-only view of where a PR's merge settlement actually stands, computed
+directly from linted evidence comments rather than from ``merge-packet`` — so it
+stays accurate even when the gate check is failing and ``merge-packet``
+short-circuits its quorum detail to an empty object.
+
+Reports the tier, the distinct counted model-reviewer families on the current
+head, whether adversarial-dogfood evidence is present, whether the operator's
+``aragora/human-settlement`` status is recorded, the quorum check conclusion, and
+the single next action. Performs no mutations.
+
+Examples
+--------
+::
+
+    python3 scripts/settle_status.py --repo synaptent/aragora --pr 7720
+    python3 scripts/settle_status.py --repo synaptent/aragora --pr 7720 --tier 4 --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from aragora.swarm.merge_quorum_io import (  # noqa: E402
+    fetch_evidence_comments,
+    fetch_human_settlement_present,
+    fetch_pr_context,
+    fetch_pr_tier,
+)
+from aragora.swarm.merge_quorum_reconcile import summarize_settlement  # noqa: E402
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="settlement-status visibility (A2)")
+    parser.add_argument("--repo", required=True, help="GitHub repo slug (owner/name)")
+    parser.add_argument("--pr", type=int, required=True, help="PR number")
+    parser.add_argument(
+        "--tier",
+        type=int,
+        choices=range(0, 5),
+        help="Override tier (default: best-effort via merge-packet)",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    ctx = fetch_pr_context(args.repo, args.pr)
+    head_sha = ctx["head_sha"]
+    tier = args.tier if args.tier is not None else fetch_pr_tier(args.repo, args.pr)
+    comments = fetch_evidence_comments(args.repo, args.pr, head_sha, ctx["head_committed_at"])
+    human_settled = fetch_human_settlement_present(args.repo, head_sha)
+
+    status = summarize_settlement(
+        pr_number=args.pr,
+        head_sha=head_sha,
+        tier=tier,
+        comments=comments,
+        human_settlement_present=human_settled,
+        quorum_conclusion=ctx["quorum_conclusion"],
+    )
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "pr": status.pr_number,
+                    "head_sha": status.head_sha,
+                    "tier": status.tier,
+                    "counted_reviewer_ids": status.counted_reviewer_ids,
+                    "signal_count": status.signal_count,
+                    "has_dogfood": status.has_dogfood,
+                    "human_settlement_present": status.human_settlement_present,
+                    "quorum_conclusion": status.quorum_conclusion,
+                    "next_action": status.next_action,
+                },
+                indent=2,
+            )
+        )
+    else:
+        tier_label = status.tier if status.tier is not None else "unknown"
+        print(f"PR #{status.pr_number} @ {status.head_sha[:12]} | Tier {tier_label}")
+        print(
+            f"  counted reviewers ({status.signal_count}): "
+            f"{', '.join(status.counted_reviewer_ids) or '(none)'}"
+        )
+        print(f"  dogfood evidence: {'yes' if status.has_dogfood else 'no'}")
+        print(f"  human settlement: {'recorded' if status.human_settlement_present else 'absent'}")
+        print(f"  quorum check: {status.quorum_conclusion or '(none)'}")
+        print(f"  next action: {status.next_action}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/swarm/test_merge_quorum_reconcile.py
+++ b/tests/swarm/test_merge_quorum_reconcile.py
@@ -1,0 +1,200 @@
+"""Unit tests for ``aragora.swarm.merge_quorum_reconcile`` (pure logic).
+
+Covers:
+
+- ``parse_iso8601`` (Z form, naive, empty, invalid).
+- ``counted_reviewer_ids`` aggregation (distinct, ignores non-counting).
+- ``plan_rerun`` — every safety guard and the happy path.
+- ``summarize_settlement`` — every ``next_action`` branch.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from aragora.swarm.merge_quorum_reconcile import (
+    EvidenceComment,
+    QuorumRun,
+    counted_reviewer_ids,
+    parse_iso8601,
+    plan_rerun,
+    summarize_settlement,
+)
+
+NOW = datetime(2026, 6, 4, 3, 0, 0, tzinfo=timezone.utc)
+
+
+def _ts(offset_minutes: int) -> str:
+    return (NOW + timedelta(minutes=offset_minutes)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _run(
+    conclusion: str = "FAILURE", *, created_offset: int = -30, head: str = "abc123"
+) -> QuorumRun:
+    return QuorumRun(
+        run_id=999, created_at=_ts(created_offset), conclusion=conclusion, head_sha=head
+    )
+
+
+def _counting_comment(
+    reviewer: str = "claude", *, offset: int = -10, dogfood: bool = True
+) -> EvidenceComment:
+    return EvidenceComment(
+        created_at=_ts(offset), would_count=True, reviewer_id=reviewer, is_dogfood=dogfood
+    )
+
+
+class TestParseIso8601:
+    def test_z_form(self) -> None:
+        dt = parse_iso8601("2026-06-04T03:00:00Z")
+        assert dt == NOW
+
+    def test_naive_assumed_utc(self) -> None:
+        dt = parse_iso8601("2026-06-04T03:00:00")
+        assert dt == NOW
+
+    def test_empty_and_invalid(self) -> None:
+        assert parse_iso8601("") is None
+        assert parse_iso8601(None) is None
+        assert parse_iso8601("not-a-date") is None
+
+
+class TestCountedReviewerIds:
+    def test_distinct_and_sorted(self) -> None:
+        comments = [
+            _counting_comment("claude"),
+            _counting_comment("openai"),
+            _counting_comment("claude"),
+            EvidenceComment(created_at=_ts(-5), would_count=False, reviewer_id="grok"),
+        ]
+        assert counted_reviewer_ids(comments) == ["claude", "openai"]
+
+    def test_empty(self) -> None:
+        assert counted_reviewer_ids([]) == []
+
+
+class TestPlanRerun:
+    def _call(self, **overrides):
+        kwargs = dict(
+            pr_number=7720,
+            run=_run(),
+            comments=[_counting_comment(offset=-10)],
+            current_head_sha="abc123",
+            now=NOW,
+            last_rerun_at=None,
+            reruns_this_head=0,
+            cooldown_seconds=600,
+            max_reruns_per_head=3,
+            has_real_required_failure=False,
+        )
+        kwargs.update(overrides)
+        return plan_rerun(**kwargs)
+
+    def test_happy_path(self) -> None:
+        decision = self._call()
+        assert decision.should_rerun is True
+        assert decision.run_id == 999
+
+    def test_no_run(self) -> None:
+        decision = self._call(run=None)
+        assert decision.should_rerun is False
+        assert "no aragora-merge-quorum run" in decision.reason
+
+    def test_already_success(self) -> None:
+        decision = self._call(run=_run(conclusion="SUCCESS"))
+        assert decision.should_rerun is False
+        assert "already SUCCESS" in decision.reason
+
+    def test_stale_head(self) -> None:
+        decision = self._call(run=_run(head="oldsha"))
+        assert decision.should_rerun is False
+        assert "stale head" in decision.reason
+
+    def test_real_required_failure(self) -> None:
+        decision = self._call(has_real_required_failure=True)
+        assert decision.should_rerun is False
+        assert "real required-check failure" in decision.reason
+
+    def test_no_countable_evidence(self) -> None:
+        non_counting = [EvidenceComment(created_at=_ts(-5), would_count=False)]
+        decision = self._call(comments=non_counting)
+        assert decision.should_rerun is False
+        assert "no countable evidence" in decision.reason
+
+    def test_run_postdates_evidence(self) -> None:
+        # Run created after the newest countable comment.
+        decision = self._call(run=_run(created_offset=-5), comments=[_counting_comment(offset=-10)])
+        assert decision.should_rerun is False
+        assert "postdates" in decision.reason
+
+    def test_max_reruns(self) -> None:
+        decision = self._call(reruns_this_head=3, max_reruns_per_head=3)
+        assert decision.should_rerun is False
+        assert "max reruns" in decision.reason
+
+    def test_within_cooldown(self) -> None:
+        decision = self._call(last_rerun_at=NOW - timedelta(seconds=120), cooldown_seconds=600)
+        assert decision.should_rerun is False
+        assert "cooldown" in decision.reason
+
+    def test_cooldown_elapsed_allows(self) -> None:
+        decision = self._call(last_rerun_at=NOW - timedelta(seconds=900), cooldown_seconds=600)
+        assert decision.should_rerun is True
+
+    def test_unparseable_run_timestamp(self) -> None:
+        decision = self._call(
+            run=QuorumRun(run_id=1, created_at="bad", conclusion="FAILURE", head_sha="abc123")
+        )
+        assert decision.should_rerun is False
+        assert "unparseable" in decision.reason
+
+
+class TestSummarizeSettlement:
+    def _call(self, **overrides):
+        kwargs = dict(
+            pr_number=7720,
+            head_sha="abc123def456",
+            tier=2,
+            comments=[_counting_comment("claude"), _counting_comment("openai")],
+            human_settlement_present=False,
+            quorum_conclusion="FAILURE",
+        )
+        kwargs.update(overrides)
+        return summarize_settlement(**kwargs)
+
+    def test_signal_count_property(self) -> None:
+        status = self._call()
+        assert status.signal_count == 2
+        assert status.counted_reviewer_ids == ["claude", "openai"]
+
+    def test_green_quorum_ready_to_merge(self) -> None:
+        status = self._call(quorum_conclusion="SUCCESS")
+        assert "ready to merge" in status.next_action
+
+    def test_needs_more_signals(self) -> None:
+        status = self._call(comments=[_counting_comment("claude")])
+        assert "1 more distinct model signal" in status.next_action
+
+    def test_needs_dogfood(self) -> None:
+        status = self._call(
+            comments=[
+                _counting_comment("claude", dogfood=False),
+                _counting_comment("openai", dogfood=False),
+            ]
+        )
+        assert "adversarial-dogfood" in status.next_action
+        assert status.has_dogfood is False
+
+    def test_tier4_needs_human_settlement(self) -> None:
+        status = self._call(tier=4, human_settlement_present=False)
+        assert "human settlement" in status.next_action
+
+    def test_stale_quorum_rerun_hint(self) -> None:
+        # Tier 2: signals + dogfood present, no human needed, but check still failing.
+        status = self._call(tier=2, quorum_conclusion="FAILURE")
+        assert "re-run aragora-merge-quorum" in status.next_action
+
+    def test_unknown_tier_defaults_strict(self) -> None:
+        status = self._call(tier=None, human_settlement_present=False)
+        # Strict default requires human settlement.
+        assert "human settlement" in status.next_action

--- a/tests/swarm/test_merge_quorum_reconcile.py
+++ b/tests/swarm/test_merge_quorum_reconcile.py
@@ -194,6 +194,11 @@ class TestSummarizeSettlement:
         status = self._call(tier=2, quorum_conclusion="FAILURE")
         assert "re-run aragora-merge-quorum" in status.next_action
 
+    def test_no_run_yet_waits(self) -> None:
+        # Everything satisfied but the check has not produced a conclusion yet.
+        status = self._call(tier=2, quorum_conclusion="")
+        assert "wait for the aragora-merge-quorum check" in status.next_action
+
     def test_unknown_tier_defaults_strict(self) -> None:
         status = self._call(tier=None, human_settlement_present=False)
         # Strict default requires human settlement.

--- a/tests/swarm/test_merge_quorum_reconcile.py
+++ b/tests/swarm/test_merge_quorum_reconcile.py
@@ -12,7 +12,11 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
-from aragora.swarm.merge_quorum_io import _could_count, _looks_like_shadow
+from aragora.swarm.merge_quorum_io import (
+    _could_count,
+    _evidence_lint_args,
+    _looks_like_shadow,
+)
 from aragora.swarm.merge_quorum_reconcile import (
     EvidenceComment,
     QuorumRun,
@@ -224,6 +228,28 @@ class TestLooksLikeShadow:
     def test_plain_required_check(self) -> None:
         assert _looks_like_shadow("aragora-merge-quorum") is False
         assert _looks_like_shadow("") is False
+
+
+class TestEvidenceLintArgs:
+    def test_never_passes_repo(self) -> None:
+        # evidence-lint rejects --repo; building it would break every lint call.
+        args = _evidence_lint_args(7735, "abc1234", "2026-06-04T13:18:35Z", "someone", "/tmp/b.md")
+        assert "--repo" not in args
+
+    def test_includes_required_flags(self) -> None:
+        args = _evidence_lint_args(7735, "abc1234", "", "someone", "/tmp/b.md")
+        assert "evidence-lint" in args
+        assert args[args.index("--pr") + 1] == "7735"
+        assert args[args.index("--head-sha") + 1] == "abc1234"
+        assert args[args.index("--body-file") + 1] == "/tmp/b.md"
+        assert args[args.index("--author") + 1] == "someone"
+        assert "--json" in args
+        # No committed-at supplied -> flag omitted.
+        assert "--head-committed-at" not in args
+
+    def test_includes_committed_at_when_present(self) -> None:
+        args = _evidence_lint_args(7735, "abc1234", "2026-06-04T13:18:35Z", "someone", "/tmp/b.md")
+        assert args[args.index("--head-committed-at") + 1] == "2026-06-04T13:18:35Z"
 
 
 class TestCouldCount:

--- a/tests/swarm/test_merge_quorum_reconcile.py
+++ b/tests/swarm/test_merge_quorum_reconcile.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
+from aragora.swarm.merge_quorum_io import _could_count, _looks_like_shadow
 from aragora.swarm.merge_quorum_reconcile import (
     EvidenceComment,
     QuorumRun,
@@ -203,3 +204,30 @@ class TestSummarizeSettlement:
         status = self._call(tier=None, human_settlement_present=False)
         # Strict default requires human settlement.
         assert "human settlement" in status.next_action
+
+
+class TestLooksLikeShadow:
+    def test_trailing_marker_is_shadow(self) -> None:
+        assert _looks_like_shadow("Mac TypeScript SDK Shadow") is True
+        assert _looks_like_shadow("Hetzner Offline Golden Path Shadow") is True
+        assert _looks_like_shadow("deploy advisory") is True
+
+    def test_hyphenated_required_not_misclassified(self) -> None:
+        # Marker appears mid-name but the last token is "required".
+        assert _looks_like_shadow("aragora-shadow-deploy-required") is False
+
+    def test_plain_required_check(self) -> None:
+        assert _looks_like_shadow("aragora-merge-quorum") is False
+        assert _looks_like_shadow("") is False
+
+
+class TestCouldCount:
+    def test_github_actions_author_rejected(self) -> None:
+        assert _could_count("github-actions[bot]", "x" * 80) is False
+
+    def test_short_body_rejected(self) -> None:
+        assert _could_count("someone", "too short") is False
+
+    def test_plausible_comment_passes(self) -> None:
+        body = "Claude review of head abc1234: VERDICT passed, dogfood adversarial check."
+        assert _could_count("someone", body) is True

--- a/tests/swarm/test_merge_quorum_reconcile.py
+++ b/tests/swarm/test_merge_quorum_reconcile.py
@@ -200,6 +200,11 @@ class TestSummarizeSettlement:
         status = self._call(tier=2, quorum_conclusion="")
         assert "wait for the aragora-merge-quorum check" in status.next_action
 
+    def test_non_final_state_waits(self) -> None:
+        # A non-terminal state (via the check-run state fallback) is not a stale run.
+        status = self._call(tier=2, quorum_conclusion="IN_PROGRESS")
+        assert "wait for the aragora-merge-quorum check" in status.next_action
+
     def test_unknown_tier_defaults_strict(self) -> None:
         status = self._call(tier=None, human_settlement_present=False)
         # Strict default requires human settlement.


### PR DESCRIPTION
## Summary

Phase 1 of the boss-loop merge-gate resilience design
([`docs/governance/BOSS_LOOP_MERGE_GATE_RESILIENCE.md`](https://github.com/synaptent/aragora/blob/main/docs/governance/BOSS_LOOP_MERGE_GATE_RESILIENCE.md)).
Adds two additive, read-by-default automation surfaces that close the
recurring "evidence is complete but the PR is stuck" stall observed while
settling #7727 and #7720.

### A1 — `scripts/reconcile_merge_quorum.py` (rerun reconciler)
The `aragora-merge-quorum` check only re-evaluates on `pull_request`
synchronize events, never on `issue_comment` — so a check that ran before the
model-review evidence was posted stays FAILURE forever even once the quorum is
satisfied (**root cause #1**). This reconciler re-runs that **read-only**
evaluation when, and only when, a strictly newer *countable* evidence comment
exists for the current head.

- Defaults to `--dry-run` (prints the plan); `--apply` executes `gh run rerun`
  for safe stale-quorum cases only.
- Fail-safe guards: no run / already SUCCESS / stale head / real required-check
  failure / no countable evidence / run postdates evidence / per-head cooldown +
  max-rerun budget.
- **Never** pushes, comments, merges, or records settlement. Re-running a
  read-only evaluation cannot pass a genuinely failing PR.

### A2 — `scripts/settle_status.py` (settlement-status visibility)
Read-only view of where a PR's settlement actually stands, computed directly
from linted evidence comments rather than `merge-packet` — so it stays accurate
even when the gate is failing and `merge-packet` short-circuits its quorum
detail to an empty object (**root cause #3**). Reports tier, distinct counted
model-reviewer families, dogfood presence, the `aragora/human-settlement`
status, the quorum conclusion, and the single next action.

## Design

- Pure decision logic in `aragora/swarm/merge_quorum_reconcile.py`
  (`plan_rerun`, `summarize_settlement`, frozen dataclasses) — network-free and
  unit-tested.
- gh + `evidence-lint` I/O in `aragora/swarm/merge_quorum_io.py`, shared by both
  CLIs (mirrors the `aragora.swarm.unstick` + `scripts/boss_loop_unstick_plan.py`
  pattern).
- Counting is delegated to the canonical `review-queue evidence-lint`
  subcommand, so these tools always match the gate's own parser.

## Scope / safety

- **Tier 2 only**: touches `scripts/` and `aragora/swarm/` exclusively; no
  governance files (`review_queue.py`, `parser.py`, workflows) are modified, so
  the gate it reconciles is unchanged.
- Invariants preserved: never auto-settles Tier 3/4, never fabricates evidence,
  never bypasses `enforce_admins`.
- Evidence channel: reads PR **issue comments** (the boss-loop's evidence
  channel); the SUCCESS path defers to the gate's authoritative conclusion.

## Test plan

- `ruff check` / `ruff format` clean.
- `pytest tests/swarm/test_merge_quorum_reconcile.py` — 23 passing (every
  `plan_rerun` guard + happy path; every `summarize_settlement` branch;
  `parse_iso8601`; `counted_reviewer_ids`).
- Live read-only smoke test: A1 correctly skips a PR whose quorum is already
  SUCCESS; A2 renders the full settlement view from live data.

If this PR's own quorum stalls on the stale-check race, it can be unstuck by its
own A1 reconciler — a fitting dogfood.
