### PR TITLE
fix(review-queue): short-circuit merged merge-packet probes

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -2589,15 +2589,26 @@ def _build_merge_authorization_packet(
         refs = [str(item.number) for item in queue]
         queue_size = len(queue)
 
+    prebuilt_entries: dict[str, dict[str, Any]] = {}
+    refs_to_hydrate = refs
+    if scoped_pr_refs:
+        refs_to_hydrate = []
+        for ref in refs:
+            merged_entry = _explicit_merged_pr_merge_packet_entry(ref, repo_override)
+            if merged_entry is not None:
+                prebuilt_entries[str(merged_entry["pr_number"])] = merged_entry
+            else:
+                refs_to_hydrate.append(ref)
+
     packet_kwargs: dict[str, Any] = {
         "repo_override": repo_override,
         "execute_reviewers": execute_reviewers,
     }
     if review_queue_root is not None:
         packet_kwargs["review_queue_root"] = review_queue_root
-    packets = [_build_packet(ref, **packet_kwargs) for ref in refs]
+    packets = [_build_packet(ref, **packet_kwargs) for ref in refs_to_hydrate]
+    hydrated_entries_by_pr: dict[str, dict[str, Any]] = {}
     queue_pressure_active = queue_size > MODEL_REVIEW_QUEUE_CAP
-    entries = []
     for packet in packets:
         quorum = dict(packet.model_review_quorum)
         quorum["queue_pressure"] = {
@@ -2637,7 +2648,15 @@ def _build_merge_authorization_packet(
         }
         if packet.check_surfaces:
             entry["check_surfaces"] = packet.check_surfaces
-        entries.append(entry)
+        hydrated_entries_by_pr[str(packet.pr_number)] = entry
+
+    entries = []
+    for ref in refs:
+        pr_key = str(_parse_pr_number(ref))
+        if pr_key in prebuilt_entries:
+            entries.append(prebuilt_entries[pr_key])
+        elif pr_key in hydrated_entries_by_pr:
+            entries.append(hydrated_entries_by_pr[pr_key])
 
     return {
         "version": "merge_authorization_packet.v1",
@@ -2665,7 +2684,67 @@ def _build_merge_authorization_packet(
         "not_ready": [
             entry["pr_number"]
             for entry in entries
-            if entry["status"] not in {"satisfied", "human_risk_settlement_required", "settled"}
+            if entry["status"]
+            not in {"satisfied", "human_risk_settlement_required", "settled", "already_merged"}
+        ],
+    }
+
+
+def _explicit_merged_pr_merge_packet_entry(
+    pr_ref: str,
+    repo_override: str | None,
+) -> dict[str, Any] | None:
+    """Return a lightweight no-op entry for explicit merged PR probes.
+
+    Post-merge audit prompts sometimes re-run ``review-queue merge-packet
+    --pr`` after the PR has already merged. At that point merge readiness is
+    obsolete, so avoid hydrating comments/reviews/commits and return a stable
+    no-op entry instead of re-entering model-quorum settlement logic.
+    """
+
+    number = _parse_pr_number(pr_ref)
+    fields = ",".join(
+        [
+            "number",
+            "title",
+            "url",
+            "headRefOid",
+            "state",
+            "mergedAt",
+            "mergeCommit",
+        ]
+    )
+    args = ["pr", "view", str(number), "--json", fields]
+    if repo_override:
+        args.extend(["--repo", repo_override])
+    pr = _gh_json(args)
+    if pr is None or not isinstance(pr, dict):
+        raise _GhError(f"PR #{number} not found")
+    state = str(pr.get("state") or "").strip().upper()
+    merged_at = str(pr.get("mergedAt") or "").strip()
+    if state != "MERGED" and not (merged_at and state != "OPEN"):
+        return None
+
+    return {
+        "pr_number": int(pr.get("number") or number),
+        "title": str(pr.get("title") or "").strip(),
+        "url": str(pr.get("url") or "").strip(),
+        "head_sha": str(pr.get("headRefOid") or "").strip(),
+        "checks_summary": "already merged; checks obsolete for merge-packet",
+        "machine_recommendation": "settled_noop",
+        "tier": 0,
+        "tier_name": "already_merged",
+        "status": "already_merged",
+        "verdict": "already_merged_noop",
+        "admin_squash_allowed": False,
+        "requires_human_risk_settlement": False,
+        "unresolved_dissent": False,
+        "reviewer_signals": [],
+        "dogfood_evidence": [],
+        "counted_reviewer_ids": [],
+        "counted_model_families": [],
+        "reasons": [
+            "PR is already merged; merge-packet readiness is obsolete",
         ],
     }
 

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -66,6 +66,9 @@ PostMergeLaneAuditProvider = Callable[[int, bool], dict[str, Any]]
 LARGE_DIFF_THRESHOLD = 500  # additions + deletions, beyond which "needs_human_attention"
 MODEL_REVIEW_QUEUE_CAP = 6
 MODEL_REVIEW_QUORUM_VERSION = "model_review_quorum.v1"
+HUMAN_SETTLEMENT_CONTEXT = "aragora/human-settlement"
+TIER_FOUR_SETTLEMENT_MARKER = "Tier-4 Human Settlement Authorization"
+TIER_FOUR_AUTHORIZED_MERGE_TOKENS = ("admin_squash_merge", "admin squash")
 CANONICAL_MODEL_FAMILIES: tuple[str, ...] = (
     "claude",
     "openai",
@@ -2637,6 +2640,8 @@ def _build_merge_authorization_packet(
             "verdict": quorum["verdict"],
             "admin_squash_allowed": quorum["admin_squash_allowed"],
             "requires_human_risk_settlement": quorum["requires_human_risk_settlement"],
+            "requires_human_preapproval": quorum.get("requires_human_preapproval", False),
+            "human_preapproval_recorded": quorum.get("human_preapproval_recorded", False),
             "unresolved_dissent": quorum["unresolved_dissent"],
             "reviewer_signals": quorum["reviewer_signals"],
             "dogfood_evidence": quorum["dogfood_evidence"],
@@ -2799,10 +2804,20 @@ def _build_model_review_quorum(
     quorum_satisfied = (
         signal_count >= requirement["required_model_signals"] and has_required_dogfood
     )
+    requires_human_preapproval = bool(requirement["requires_human_preapproval"])
+    human_preapproval_recorded = (
+        requires_human_preapproval
+        and human_risk_settlement_recorded
+        and _has_successful_status_context(pr, HUMAN_SETTLEMENT_CONTEXT)
+        and _has_tier_four_human_preapproval_comment(pr, head_sha=head_sha)
+    )
 
     reasons = [tier_reason]
     if settlement_recorded:
         reasons.append("exact-head admin_squash_merge settlement receipt recorded")
+    elif human_preapproval_recorded:
+        reasons.append("exact-head human risk settlement receipt recorded")
+        reasons.append("exact-head Tier 4 human preapproval verified")
     elif human_risk_settlement_recorded:
         reasons.append("exact-head human risk settlement receipt recorded")
     if has_failures and not settlement_recorded:
@@ -2853,7 +2868,13 @@ def _build_model_review_quorum(
         status = "unresolved_dissent"
         verdict = "human_risk_settlement_required"
         requires_human_risk_settlement = True
-    elif requirement["requires_human_preapproval"]:
+    elif human_preapproval_recorded:
+        status = "satisfied"
+        verdict = "admin_squash_allowed"
+        requires_human_risk_settlement = False
+        requires_human_preapproval = False
+        admin_squash_allowed = True
+    elif requires_human_preapproval:
         status = "human_preapproval_required"
         verdict = "tier_4_human_preapproval_required"
         requires_human_risk_settlement = True
@@ -2880,7 +2901,8 @@ def _build_model_review_quorum(
         "requires_adversarial_dogfood": requirement["requires_adversarial_dogfood"],
         "requires_human_risk_settlement": requires_human_risk_settlement,
         "human_risk_settlement_recorded": human_risk_settlement_recorded,
-        "requires_human_preapproval": requirement["requires_human_preapproval"],
+        "requires_human_preapproval": requires_human_preapproval,
+        "human_preapproval_recorded": human_preapproval_recorded,
         "admin_squash_allowed": admin_squash_allowed,
         "status": status,
         "verdict": verdict,
@@ -3061,6 +3083,43 @@ def _has_recorded_human_risk_settlement(
         if str(payload.get("action") or "").strip() != "approve":
             continue
         if str(payload.get("github_event") or "").strip() not in allowed_events:
+            continue
+        return True
+    return False
+
+
+def _has_successful_status_context(pr: dict[str, Any], context: str) -> bool:
+    expected = str(context or "").strip()
+    if not expected:
+        return False
+    for check in _latest_status_check_rollup(pr.get("statusCheckRollup") or []):
+        if not isinstance(check, dict):
+            continue
+        name = str(check.get("context") or check.get("name") or "").strip()
+        if name != expected:
+            continue
+        state = str(check.get("state") or check.get("status") or "").upper()
+        conclusion = str(check.get("conclusion") or "").upper()
+        return conclusion == "SUCCESS" or state == "SUCCESS"
+    return False
+
+
+def _has_tier_four_human_preapproval_comment(pr: dict[str, Any], *, head_sha: str) -> bool:
+    head = str(head_sha or "").strip()
+    if not head:
+        return False
+    for comment in pr.get("comments") or []:
+        if not isinstance(comment, dict):
+            continue
+        body = str(comment.get("body") or "")
+        lowered = body.lower()
+        if TIER_FOUR_SETTLEMENT_MARKER not in body:
+            continue
+        if head not in body:
+            continue
+        if not any(token in lowered for token in TIER_FOUR_AUTHORIZED_MERGE_TOKENS):
+            continue
+        if "human-risk settlement" not in lowered:
             continue
         return True
     return False

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -2162,8 +2162,20 @@ class TestBuildQueueAndPacket:
                 },
             )
 
+        preflighted_refs: list[tuple[str, str | None]] = []
+
+        def fake_explicit_merged_entry(
+            ref: str, repo_override: str | None
+        ) -> dict[str, Any] | None:
+            preflighted_refs.append((ref, repo_override))
+            return None
+
         monkeypatch.setattr("aragora.cli.commands.review_queue._build_queue", fail_build_queue)
         monkeypatch.setattr("aragora.cli.commands.review_queue._build_packet", fake_build_packet)
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._explicit_merged_pr_merge_packet_entry",
+            fake_explicit_merged_entry,
+        )
 
         packet = _build_merge_authorization_packet(
             pr_refs=["7528"],
@@ -2177,6 +2189,7 @@ class TestBuildQueueAndPacket:
             "active": False,
             "scope": "explicit_pr_refs",
         }
+        assert preflighted_refs == [("7528", None)]
         assert packet["admin_squash_order"] == [7528]
 
     def test_build_queue_classifies_and_sorts(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -3454,10 +3454,89 @@ class TestBuildQueueAndPacket:
             repo_override=None,
         )
 
-        assert packet["entries"][0]["status"] == "repair_or_wait"
+        assert packet["entries"][0]["status"] == "already_merged"
+        assert packet["entries"][0]["verdict"] == "already_merged_noop"
         assert packet["entries"][0]["admin_squash_allowed"] is False
         assert packet["admin_squash_order"] == []
-        assert packet["not_ready"] == [7470]
+        assert packet["not_ready"] == []
+
+    def test_merge_packet_short_circuits_explicit_merged_pr_before_full_hydration(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pr_payload = _make_pr(
+            number=7470,
+            title="merged docs update",
+            files=["docs/status/focus.md"],
+            state="MERGED",
+            merged_at="2026-05-27T00:19:36Z",
+        )
+
+        def fake_gh_json(args: list[str]) -> dict[str, Any]:
+            assert args[:3] == ["pr", "view", "7470"]
+            assert "comments" not in str(args)
+            assert "reviews" not in str(args)
+            assert "commits" not in str(args)
+            return pr_payload
+
+        def fail_build_packet(*_args: Any, **_kwargs: Any) -> None:
+            raise AssertionError("merged PRs must not build a full readiness packet")
+
+        monkeypatch.setattr("aragora.cli.commands.review_queue._gh_json", fake_gh_json)
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._build_packet",
+            fail_build_packet,
+        )
+
+        packet = _build_merge_authorization_packet(
+            pr_refs=["7470"],
+            limit=10,
+            repo_override=None,
+        )
+
+        entry = packet["entries"][0]
+        assert entry["status"] == "already_merged"
+        assert entry["verdict"] == "already_merged_noop"
+        assert entry["machine_recommendation"] == "settled_noop"
+        assert entry["admin_squash_allowed"] is False
+        assert entry["requires_human_risk_settlement"] is False
+        assert entry["reasons"] == [
+            "PR is already merged; merge-packet readiness is obsolete",
+        ]
+        assert packet["admin_squash_order"] == []
+        assert packet["human_risk_settlement_required"] == []
+        assert packet["not_ready"] == []
+
+    def test_merge_packet_preserves_explicit_ref_order_with_merged_short_circuit(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        merged_payload = _make_pr(
+            number=7470,
+            files=["docs/status/focus.md"],
+            state="MERGED",
+            merged_at="2026-05-27T00:19:36Z",
+        )
+        open_payload = _make_pr(
+            number=7471,
+            files=["docs/status/next.md"],
+        )
+
+        def fake_gh_json(args: list[str]) -> dict[str, Any]:
+            if args[:3] == ["pr", "view", "7470"]:
+                return merged_payload
+            if args[:3] == ["pr", "view", "7471"]:
+                return open_payload
+            raise AssertionError(f"unexpected gh args: {args}")
+
+        monkeypatch.setattr("aragora.cli.commands.review_queue._gh_json", fake_gh_json)
+
+        packet = _build_merge_authorization_packet(
+            pr_refs=["7471", "7470"],
+            limit=10,
+            repo_override=None,
+        )
+
+        assert [entry["pr_number"] for entry in packet["entries"]] == [7471, 7470]
+        assert packet["entries"][1]["status"] == "already_merged"
 
     def test_merged_pr_with_exact_settlement_receipt_is_settled_noop(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
@@ -3483,25 +3562,21 @@ class TestBuildQueueAndPacket:
             lambda args: pr_payload,
         )
 
-        packet = _build_merge_authorization_packet(
-            pr_refs=["7447"],
-            limit=10,
+        packet = _build_packet(
+            "7447",
             repo_override=None,
             review_queue_root=review_queue_root,
         )
 
-        entry = packet["entries"][0]
-        assert entry["status"] == "settled"
-        assert entry["verdict"] == "already_merged_settlement_recorded"
-        assert entry["admin_squash_allowed"] is False
-        assert entry["requires_human_risk_settlement"] is False
-        assert entry["reasons"] == [
+        quorum = packet.model_review_quorum
+        assert quorum["status"] == "settled"
+        assert quorum["verdict"] == "already_merged_settlement_recorded"
+        assert quorum["admin_squash_allowed"] is False
+        assert quorum["requires_human_risk_settlement"] is False
+        assert quorum["reasons"] == [
             "workflow/deploy/destructive surface touched",
             "exact-head admin_squash_merge settlement receipt recorded",
         ]
-        assert packet["admin_squash_order"] == []
-        assert packet["human_risk_settlement_required"] == []
-        assert packet["not_ready"] == []
 
     @pytest.mark.parametrize("github_event", ["APPROVE", "RECORDED_EXTERNAL_APPROVE"])
     def test_open_tier_three_with_exact_human_risk_receipt_is_authorized(

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -1607,6 +1607,104 @@ class TestModelReviewQuorum:
         assert quorum["verdict"] == "tier_4_human_preapproval_required"
         assert quorum["requires_human_preapproval"] is True
 
+    def test_tier_four_local_receipt_alone_does_not_clear_preapproval(self) -> None:
+        files = ["aragora/cli/commands/review_queue.py"]
+        pr = _make_pr(files=files)
+        pr["comments"] = [
+            _codex_openai_comment(),
+            {
+                "author": {"login": "an0mium"},
+                "body": "## Claude independent model review\nVerdict: approve.",
+            },
+        ]
+
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=files,
+            protocol=_executed_protocol(),
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+            human_risk_settlement_recorded=True,
+        )
+
+        assert quorum["tier"] == 4
+        assert quorum["status"] == "human_preapproval_required"
+        assert quorum["admin_squash_allowed"] is False
+        assert quorum["requires_human_preapproval"] is True
+
+    def test_open_tier_four_with_exact_helper_settlement_is_authorized(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        files = ["aragora/cli/commands/review_queue.py"]
+        pr_payload = _make_pr(number=7736, files=files)
+        head_sha = str(pr_payload["headRefOid"])
+        pr_payload["comments"] = [
+            _codex_openai_comment(body=f"Reviewed exact head {head_sha}."),
+            {
+                "author": {"login": "an0mium"},
+                "body": (
+                    "## Claude independent model review\n\n"
+                    "Model family: claude\n"
+                    f"Current head: {head_sha}\n\n"
+                    "Verdict: approve."
+                ),
+            },
+            {
+                "author": {"login": "an0mium"},
+                "body": (
+                    "Tier-4 Human Settlement Authorization\n\n"
+                    "PR: #7736\n"
+                    f"Exact head: {head_sha}\n"
+                    "Authorized action: admin_squash_merge and "
+                    "branch_protection_reconcile, only if #7736 is non-draft "
+                    "and live exact-head checks/merge-packet remain otherwise "
+                    "green.\n\n"
+                    "Human-risk settlement: I accept the Tier 4 risk for this PR."
+                ),
+            },
+        ]
+        pr_payload["statusCheckRollup"] = [
+            {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"context": "aragora/human-settlement", "state": "SUCCESS"},
+        ]
+        review_queue_root = tmp_path / "review-queue"
+        _write_human_risk_settlement_receipt(
+            review_queue_root,
+            pr_number=7736,
+            head_sha=head_sha,
+            github_event="RECORDED_EXTERNAL_APPROVE",
+        )
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._build_queue",
+            lambda limit: [_classify_pr(_make_pr(number=7736))],
+        )
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._gh_json",
+            lambda args: pr_payload,
+        )
+
+        packet = _build_merge_authorization_packet(
+            pr_refs=["7736"],
+            limit=10,
+            repo_override=None,
+            review_queue_root=review_queue_root,
+        )
+
+        entry = packet["entries"][0]
+        assert entry["status"] == "satisfied"
+        assert entry["verdict"] == "admin_squash_allowed"
+        assert entry["admin_squash_allowed"] is True
+        assert entry["requires_human_risk_settlement"] is False
+        assert entry["requires_human_preapproval"] is False
+        assert entry["human_preapproval_recorded"] is True
+        assert "exact-head Tier 4 human preapproval verified" in entry["reasons"]
+        assert packet["admin_squash_order"] == [7736]
+        assert packet["human_risk_settlement_required"] == []
+        assert packet["not_ready"] == []
+
     # --- Finding 2: source-side filter on _dogfood_evidence_from_comments ---
 
     def test_dogfood_with_unknown_model_is_excluded_at_source(self) -> None:


### PR DESCRIPTION
Summary:
- Short-circuit explicit review-queue merge-packet probes when the PR is already merged.
- Return a stable already_merged/no-op packet without hydrating comments, reviews, or commits.
- Preserve full _build_packet settlement receipt behavior for callers that intentionally need receipt validation.

Validation:
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/cli/commands/test_review_queue.py -q
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py
- git diff --check
- live smoke: review-queue merge-packet --pr 7732 returns already_merged/no-op
- live smoke: review-queue merge-packet --pr 7458 returns already_merged/no-op