### PR TITLE
fix(review-queue): bound gh helper calls

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -1275,14 +1275,48 @@ class _GhError(RuntimeError):
     """Raised when a 'gh' invocation fails or returns malformed JSON."""
 
 
+def _env_timeout_seconds(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+REVIEW_QUEUE_GH_TIMEOUT_SECONDS = _env_timeout_seconds(
+    "REVIEW_QUEUE_GH_TIMEOUT_SECONDS",
+    30,
+)
+
+
+def _format_gh_timeout(args: list[str], timeout: float | None) -> str:
+    timeout_value = timeout if timeout is not None else REVIEW_QUEUE_GH_TIMEOUT_SECONDS
+    return f"gh {' '.join(args)} timed out after {timeout_value:g}s"
+
+
+def _run_gh(
+    args: list[str],
+    *,
+    run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        return run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=REVIEW_QUEUE_GH_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise _GhError(_format_gh_timeout(args, exc.timeout)) from exc
+
+
 def _gh_text(args: list[str]) -> str:
     """Run a 'gh' command and return plain stdout."""
-    proc = subprocess.run(
-        ["gh", *args],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    proc = _run_gh(args)
     if proc.returncode != 0:
         stderr = proc.stderr.strip() or "no stderr"
         raise _GhError(f"gh {' '.join(args)} failed: {stderr}")
@@ -1291,12 +1325,7 @@ def _gh_text(args: list[str]) -> str:
 
 def _gh_json(args: list[str]) -> Any:
     """Run a 'gh' command and parse JSON output. Returns None for empty stdout."""
-    proc = subprocess.run(
-        ["gh", *args],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    proc = _run_gh(args)
     if proc.returncode != 0:
         stderr = proc.stderr.strip() or "no stderr"
         raise _GhError(f"gh {' '.join(args)} failed: {stderr}")

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import io
 import json
+import subprocess
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from typing import Any
@@ -33,6 +34,7 @@ from aragora.cli.commands.review_queue import (
     _record_external_settlement,
     _render_packet,
     _requested_action,
+    _run_gh,
     _settle_packet,
     _subsystem_for,
     _summarize_checks,
@@ -1978,6 +1980,22 @@ class TestModelReviewQuorum:
 
 
 # --- _parse_pr_number ------------------------------------------------------
+
+
+class TestGhHelpers:
+    def test_run_gh_fails_closed_on_subprocess_timeout(self) -> None:
+        calls: list[tuple[list[str], dict[str, Any]]] = []
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+            calls.append((cmd, kwargs))
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=kwargs["timeout"])
+
+        with pytest.raises(_GhError, match="timed out"):
+            _run_gh(["pr", "view", "1", "--json", "number"], run=fake_run)
+
+        assert calls
+        assert calls[0][0] == ["gh", "pr", "view", "1", "--json", "number"]
+        assert calls[0][1]["timeout"] > 0
 
 
 class TestParsePRNumber:


### PR DESCRIPTION
## Summary
- Add an env-configurable timeout for review-queue gh helper calls.
- Convert gh subprocess timeouts into _GhError so merge-packet fails closed instead of hanging.
- Add a focused unit test for timeout handling.

## Validation
- python3 -m pytest -q tests/cli/commands/test_review_queue.py -> 200 passed in 8.44s before merge-forward
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/cli/commands/test_review_queue.py -> 200 passed, 2 config warnings in 10.69s after merge-forward
- python3 -m ruff check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py
- python3 -m ruff format --check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py
- git diff --check
- live smoke: python3 -m aragora.cli.main review-queue merge-packet --pr 7733 --json returned promptly and classified merged #7733 as not settle-applicable

Co-authored-by: codex[bot] <175728472+codex[bot]@users.noreply.github.com>