### PR TITLE
feat(review-queue): merge-packet --ignore-own-quorum-check (B2, diagnostic only)

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -2320,6 +2320,9 @@ def _build_packet(
             if ignore_own_quorum_check
             else 0
         )
+        # pr_rollup is intentionally the raw "what GitHub reports" view and is not
+        # filtered by ignore_own_quorum_check; only the gating surface
+        # (required_pr_checks) honors the diagnostic flag.
         rollup_required_diagnostics = _rollup_non_green_diagnostics(
             pr.get("statusCheckRollup") or [],
             required_checks=required_pr_checks if required_available else None,

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -541,6 +541,16 @@ def add_review_queue_parser(subparsers: argparse._SubParsersAction) -> None:
         action="store_true",
         help="Attempt live heterogeneous reviewer execution for each packet.",
     )
+    merge_packet_p.add_argument(
+        "--ignore-own-quorum-check",
+        action="store_true",
+        help=(
+            "Diagnostic only: exclude a concluded aragora-merge-quorum check from "
+            "the packet's check gating so out-of-CI callers can observe the real "
+            "model-quorum state instead of short-circuiting on a stale self-failure. "
+            "The enforcing CI gate never sets this; it does not weaken the gate."
+        ),
+    )
     merge_packet_p.add_argument("--json", action="store_true", help="Output as JSON")
 
     evidence_lint_p = sub.add_parser(
@@ -1078,6 +1088,7 @@ def _cmd_merge_packet(args: argparse.Namespace) -> int:
             repo_override=getattr(args, "repo", None),
             review_queue_root=getattr(args, "review_queue_root", None),
             execute_reviewers=bool(getattr(args, "execute_reviewers", False)),
+            ignore_own_quorum_check=bool(getattr(args, "ignore_own_quorum_check", False)),
         )
     except _GhError as exc:
         print(f"error: {exc}", file=sys.stderr)
@@ -1416,13 +1427,22 @@ def _classify_pr(pr: dict[str, Any]) -> QueueItem:
     )
 
 
-def _summarize_checks(checks: list) -> tuple[str, bool, bool]:
-    """Return ``(summary, has_failures, has_pending)`` for a statusCheckRollup."""
+def _summarize_checks(checks: list, *, ignore_quorum_check: bool = False) -> tuple[str, bool, bool]:
+    """Return ``(summary, has_failures, has_pending)`` for a statusCheckRollup.
+
+    ``ignore_quorum_check`` is a diagnostic-only switch (never set by the
+    enforcing CI path) that additionally excludes a *concluded*
+    ``aragora-merge-quorum`` check, so out-of-CI callers can observe the real
+    non-self check state instead of short-circuiting on a stale self-failure.
+    See B2 in docs/governance/BOSS_LOOP_MERGE_GATE_RESILIENCE.md.
+    """
     success = failure = pending = 0
     for check in _latest_status_check_rollup(checks):
         if not isinstance(check, dict):
             continue
-        if _is_current_merge_quorum_self_check(check):
+        if _is_current_merge_quorum_self_check(check) or (
+            ignore_quorum_check and _is_merge_quorum_check(check)
+        ):
             continue
         status = str(check.get("status") or check.get("state") or "").upper()
         conclusion = str(check.get("conclusion") or "").upper()
@@ -1520,11 +1540,15 @@ def _required_pr_check_bucket(check: dict[str, Any]) -> str:
     return state.lower()
 
 
-def _summarize_required_pr_checks(checks: list[dict[str, Any]]) -> tuple[str, bool, bool]:
+def _summarize_required_pr_checks(
+    checks: list[dict[str, Any]], *, ignore_quorum_check: bool = False
+) -> tuple[str, bool, bool]:
     """Return ``(summary, has_failures, has_pending)`` for required PR checks."""
     success = failure = pending = 0
     for check in checks:
-        if _is_required_pr_check_current_merge_quorum_self_check(check):
+        if _is_required_pr_check_current_merge_quorum_self_check(check) or (
+            ignore_quorum_check and _is_merge_quorum_check(check)
+        ):
             continue
         bucket = _required_pr_check_bucket(check)
         if bucket in {"pass", "skipping"}:
@@ -1545,13 +1569,16 @@ def _summarize_required_pr_checks(checks: list[dict[str, Any]]) -> tuple[str, bo
     return ("no required checks", False, False)
 
 
-def _effective_required_pr_check_count(checks: list[dict[str, Any]]) -> int:
+def _effective_required_pr_check_count(
+    checks: list[dict[str, Any]], *, ignore_quorum_check: bool = False
+) -> int:
     """Count required PR checks after excluding the current merge-quorum self-check."""
     return sum(
         1
         for check in checks
         if isinstance(check, dict)
         and not _is_required_pr_check_current_merge_quorum_self_check(check)
+        and not (ignore_quorum_check and _is_merge_quorum_check(check))
     )
 
 
@@ -2193,6 +2220,7 @@ def _build_packet(
     repo_override: str | None,
     review_queue_root: str | Path | None = None,
     execute_reviewers: bool = False,
+    ignore_own_quorum_check: bool = False,
 ) -> ReviewPacket:
     number = _parse_pr_number(pr_ref)
     fields = ",".join(
@@ -2243,7 +2271,9 @@ def _build_packet(
     touched = sorted({_subsystem_for(p) for p in files})
     high_risk = [p for p in files if _is_high_risk_path(p)]
     checks_unavailable = _check_rollup_unavailable(pr)
-    checks_summary, has_failures, has_pending = _summarize_checks(pr.get("statusCheckRollup") or [])
+    checks_summary, has_failures, has_pending = _summarize_checks(
+        pr.get("statusCheckRollup") or [], ignore_quorum_check=ignore_own_quorum_check
+    )
     if checks_unavailable:
         checks_summary = "no checks reported"
         has_pending = True
@@ -2262,13 +2292,17 @@ def _build_packet(
         required_available = bool(required_surface.get("available"))
         if required_available:
             required_summary, required_has_failures, required_has_pending = (
-                _summarize_required_pr_checks(required_pr_checks)
+                _summarize_required_pr_checks(
+                    required_pr_checks, ignore_quorum_check=ignore_own_quorum_check
+                )
             )
         else:
             required_summary = "required PR checks unavailable"
             required_has_failures = False
             required_has_pending = True
-        effective_required_count = _effective_required_pr_check_count(required_pr_checks)
+        effective_required_count = _effective_required_pr_check_count(
+            required_pr_checks, ignore_quorum_check=ignore_own_quorum_check
+        )
         ignored_self_check_count = sum(
             1
             for check in required_pr_checks
@@ -2313,12 +2347,14 @@ def _build_packet(
                 for check in required_pr_checks
                 if _required_pr_check_bucket(check) in {"fail", "cancel"}
                 and not _is_required_pr_check_current_merge_quorum_self_check(check)
+                and not (ignore_own_quorum_check and _is_merge_quorum_check(check))
             ][:CHECK_SURFACE_DIAGNOSTIC_LIMIT],
             "pending": [
                 str(check.get("name") or "").strip()
                 for check in required_pr_checks
                 if _required_pr_check_bucket(check) == "pending"
                 and not _is_required_pr_check_current_merge_quorum_self_check(check)
+                and not (ignore_own_quorum_check and _is_merge_quorum_check(check))
             ][:CHECK_SURFACE_DIAGNOSTIC_LIMIT],
         }
         if required_surface.get("error"):
@@ -2578,6 +2614,7 @@ def _build_merge_authorization_packet(
     repo_override: str | None,
     review_queue_root: str | Path | None = None,
     execute_reviewers: bool = False,
+    ignore_own_quorum_check: bool = False,
 ) -> dict[str, Any]:
     scoped_pr_refs = False
     if pr_refs:
@@ -2592,6 +2629,7 @@ def _build_merge_authorization_packet(
     packet_kwargs: dict[str, Any] = {
         "repo_override": repo_override,
         "execute_reviewers": execute_reviewers,
+        "ignore_own_quorum_check": ignore_own_quorum_check,
     }
     if review_queue_root is not None:
         packet_kwargs["review_queue_root"] = review_queue_root

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -2320,9 +2320,10 @@ def _build_packet(
             if ignore_own_quorum_check
             else 0
         )
-        # pr_rollup is intentionally the raw "what GitHub reports" view and is not
-        # filtered by ignore_own_quorum_check; only the gating surface
-        # (required_pr_checks) honors the diagnostic flag.
+        # _rollup_non_green_diagnostics reports the raw GitHub rollup counts/sample
+        # and is intentionally not filtered by ignore_own_quorum_check. The flag's
+        # effect on the rollup is limited to the summary text computed above; the
+        # gating decision lives in the required_pr_checks surface.
         rollup_required_diagnostics = _rollup_non_green_diagnostics(
             pr.get("statusCheckRollup") or [],
             required_checks=required_pr_checks if required_available else None,

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -545,7 +545,7 @@ def add_review_queue_parser(subparsers: argparse._SubParsersAction) -> None:
         "--ignore-own-quorum-check",
         action="store_true",
         help=(
-            "Diagnostic only: exclude a concluded aragora-merge-quorum check from "
+            "Diagnostic only: exclude the aragora-merge-quorum check (any state) from "
             "the packet's check gating so out-of-CI callers can observe the real "
             "model-quorum state instead of short-circuiting on a stale self-failure. "
             "The enforcing CI gate never sets this; it does not weaken the gate."
@@ -1431,10 +1431,10 @@ def _summarize_checks(checks: list, *, ignore_quorum_check: bool = False) -> tup
     """Return ``(summary, has_failures, has_pending)`` for a statusCheckRollup.
 
     ``ignore_quorum_check`` is a diagnostic-only switch (never set by the
-    enforcing CI path) that additionally excludes a *concluded*
-    ``aragora-merge-quorum`` check, so out-of-CI callers can observe the real
-    non-self check state instead of short-circuiting on a stale self-failure.
-    See B2 in docs/governance/BOSS_LOOP_MERGE_GATE_RESILIENCE.md.
+    enforcing CI path) that additionally excludes the ``aragora-merge-quorum``
+    check in any state (pending or concluded), so out-of-CI callers can observe
+    the real non-self check state instead of short-circuiting on a stale
+    self-failure. See B2 in docs/governance/BOSS_LOOP_MERGE_GATE_RESILIENCE.md.
     """
     success = failure = pending = 0
     for check in _latest_status_check_rollup(checks):
@@ -2309,6 +2309,17 @@ def _build_packet(
             if isinstance(check, dict)
             and _is_required_pr_check_current_merge_quorum_self_check(check)
         )
+        ignored_by_flag_count = (
+            sum(
+                1
+                for check in required_pr_checks
+                if isinstance(check, dict)
+                and _is_merge_quorum_check(check)
+                and not _is_required_pr_check_current_merge_quorum_self_check(check)
+            )
+            if ignore_own_quorum_check
+            else 0
+        )
         rollup_required_diagnostics = _rollup_non_green_diagnostics(
             pr.get("statusCheckRollup") or [],
             required_checks=required_pr_checks if required_available else None,
@@ -2322,9 +2333,14 @@ def _build_packet(
                 "cannot distinguish required checks from non-required PR rollup checks."
             )
         elif effective_required_count == 0:
+            flag_note = (
+                " (and the broader aragora-merge-quorum row, --ignore-own-quorum-check set)"
+                if ignore_own_quorum_check
+                else ""
+            )
             gate_blocked_reason = (
                 "GitHub reported no effective branch-protection required checks "
-                "after ignoring the current merge-quorum self-check."
+                f"after ignoring the current merge-quorum self-check{flag_note}."
             )
         elif required_has_failures:
             gate_blocked_reason = (
@@ -2339,6 +2355,7 @@ def _build_packet(
             "total": len(required_pr_checks),
             "effective_total": effective_required_count,
             "ignored_current_merge_quorum_self_check_count": ignored_self_check_count,
+            "ignored_by_ignore_own_quorum_flag_count": ignored_by_flag_count,
             "summary": required_summary,
             "gate_selected": False,
             "gate_blocked_reason": gate_blocked_reason,

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -2453,7 +2453,7 @@ def _add_review_queue_parser(subparsers) -> None:
         "--ignore-own-quorum-check",
         action="store_true",
         help=(
-            "Diagnostic only: exclude a concluded aragora-merge-quorum check from "
+            "Diagnostic only: exclude the aragora-merge-quorum check (any state) from "
             "the packet's check gating so out-of-CI callers can observe the real "
             "model-quorum state instead of short-circuiting on a stale self-failure. "
             "The enforcing CI gate never sets this; it does not weaken the gate."

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -2450,6 +2450,16 @@ def _add_review_queue_parser(subparsers) -> None:
         help="Attempt live heterogeneous reviewer execution for each packet.",
     )
     merge_packet_parser.add_argument(
+        "--ignore-own-quorum-check",
+        action="store_true",
+        help=(
+            "Diagnostic only: exclude a concluded aragora-merge-quorum check from "
+            "the packet's check gating so out-of-CI callers can observe the real "
+            "model-quorum state instead of short-circuiting on a stale self-failure. "
+            "The enforcing CI gate never sets this; it does not weaken the gate."
+        ),
+    )
+    merge_packet_parser.add_argument(
         "--json",
         dest="json_output",
         action="store_true",

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -2587,6 +2587,71 @@ class TestBuildQueueAndPacket:
         ]
         assert rollup["long_queued_self_hosted_shadow_without_runner_metadata_count"] == 0
 
+    def test_ignore_own_quorum_flag_drops_required_quorum_row_out_of_ci(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Out-of-CI: the self-check helper does NOT ignore the merge-quorum row,
+        # so by default a concluded merge-quorum FAILURE blocks. The B2 flag is
+        # the only thing that excludes it from gating + diagnostics. An unrelated
+        # typecheck failure keeps the rollup non-green so the required surface is
+        # still fetched even when the flag drops the merge-quorum row.
+        for var in ("GITHUB_WORKFLOW", "GITHUB_JOB", "GITHUB_RUN_ID", "GITHUB_REPOSITORY"):
+            monkeypatch.delenv(var, raising=False)
+        pr_payload = _make_pr(
+            number=7465,
+            files=["docs/status/open.md"],
+            checks=[
+                {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
+                {"name": "typecheck", "status": "COMPLETED", "conclusion": "FAILURE"},
+                {
+                    "name": "aragora-merge-quorum",
+                    "workflowName": "Aragora Merge Quorum",
+                    "status": "COMPLETED",
+                    "conclusion": "FAILURE",
+                },
+            ],
+        )
+
+        def fake_gh_json(args: list[str]) -> Any:
+            if args[:2] == ["pr", "view"]:
+                return pr_payload
+            if args[:2] == ["pr", "checks"]:
+                return [
+                    {
+                        "name": "aragora-merge-quorum",
+                        "state": "FAILURE",
+                        "bucket": "fail",
+                        "workflow": "Aragora Merge Quorum",
+                        "link": "https://github.com/synaptent/aragora/actions/runs/old/job/1",
+                    },
+                    {"name": "lint", "state": "SUCCESS", "bucket": "pass", "workflow": "Lint"},
+                    {"name": "typecheck", "state": "FAILURE", "bucket": "fail", "workflow": "Lint"},
+                ]
+            raise AssertionError(f"unexpected gh call: {args}")
+
+        monkeypatch.setattr("aragora.cli.commands.review_queue._gh_json", fake_gh_json)
+
+        default_required = _build_packet("7465", repo_override=None).check_surfaces[
+            "required_pr_checks"
+        ]
+        assert default_required["effective_total"] == 3
+        assert "aragora-merge-quorum" in default_required["failing_or_cancelled"]
+        assert default_required["ignored_by_ignore_own_quorum_flag_count"] == 0
+
+        flagged_required = _build_packet(
+            "7465", repo_override=None, ignore_own_quorum_check=True
+        ).check_surfaces["required_pr_checks"]
+        assert flagged_required["effective_total"] == 2
+        # The real typecheck failure is preserved; only the merge-quorum row is dropped.
+        assert flagged_required["failing_or_cancelled"] == ["typecheck"]
+        assert flagged_required["ignored_by_ignore_own_quorum_flag_count"] == 1
+        # Diagnostic accounting stays self-consistent: total - effective_total equals
+        # the self-check exclusions plus the flag exclusions.
+        assert flagged_required["total"] - flagged_required["effective_total"] == (
+            flagged_required["ignored_current_merge_quorum_self_check_count"]
+            + flagged_required["ignored_by_ignore_own_quorum_flag_count"]
+        )
+
     def test_required_gate_classifies_real_rollup_shaped_long_queued_shadows(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -778,7 +778,8 @@ class TestIgnoreOwnQuorumCheck:
         assert has_fail  # the real typecheck failure is preserved
         assert summary == "1 failing / 2 total"
 
-    def test_required_summary_flag_excludes_quorum(self) -> None:
+    def test_required_summary_flag_excludes_quorum(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._clear_ci_env(monkeypatch)
         required = [
             {"name": "aragora-merge-quorum", "workflow": "Aragora Merge Quorum", "bucket": "fail"},
             {"name": "required-lint", "bucket": "pass"},
@@ -789,7 +790,10 @@ class TestIgnoreOwnQuorumCheck:
         assert not has_fail
         assert summary == "1/1 required green"
 
-    def test_effective_required_count_flag_excludes_quorum(self) -> None:
+    def test_effective_required_count_flag_excludes_quorum(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._clear_ci_env(monkeypatch)
         required = [
             {"name": "aragora-merge-quorum", "workflow": "Aragora Merge Quorum", "bucket": "fail"},
             {"name": "required-lint", "bucket": "pass"},

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -26,9 +26,11 @@ from aragora.cli.commands.review_queue import (
     _classify_pr,
     _classify_model_review_tier,
     _extract_validation_commands,
+    _effective_required_pr_check_count,
     _filter_lanes,
     _GhError,
     _is_high_risk_path,
+    _is_merge_quorum_check,
     _parse_pr_number,
     _record_external_settlement,
     _render_packet,
@@ -36,6 +38,7 @@ from aragora.cli.commands.review_queue import (
     _settle_packet,
     _subsystem_for,
     _summarize_checks,
+    _summarize_required_pr_checks,
     add_review_queue_parser,
     cmd_review_queue,
 )
@@ -721,6 +724,87 @@ class TestSummarizeChecks:
         assert summary == "1 failing / 2 total"
         assert has_fail
         assert not has_pending
+
+
+# --- B2: --ignore-own-quorum-check (diagnostic only) -----------------------
+
+
+class TestIgnoreOwnQuorumCheck:
+    """B2: a diagnostic-only switch that additionally excludes a *concluded*
+    merge-quorum self-check so out-of-CI callers observe the real check state.
+    The enforcing CI path never sets the flag, so default behavior is unchanged.
+    """
+
+    @staticmethod
+    def _quorum_failure_plus_green() -> list[dict[str, Any]]:
+        return [
+            {
+                "name": "aragora-merge-quorum",
+                "workflowName": "Aragora Merge Quorum",
+                "status": "COMPLETED",
+                "conclusion": "FAILURE",
+            },
+            {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
+        ]
+
+    @staticmethod
+    def _clear_ci_env(monkeypatch: pytest.MonkeyPatch) -> None:
+        for var in ("GITHUB_WORKFLOW", "GITHUB_JOB", "GITHUB_RUN_ID", "GITHUB_REPOSITORY"):
+            monkeypatch.delenv(var, raising=False)
+
+    def test_default_blocks_on_concluded_quorum_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._clear_ci_env(monkeypatch)
+        summary, has_fail, has_pending = _summarize_checks(self._quorum_failure_plus_green())
+        assert has_fail
+        assert summary == "1 failing / 2 total"
+
+    def test_flag_excludes_concluded_quorum_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._clear_ci_env(monkeypatch)
+        summary, has_fail, has_pending = _summarize_checks(
+            self._quorum_failure_plus_green(), ignore_quorum_check=True
+        )
+        assert not has_fail
+        assert not has_pending
+        assert summary == "1/1 green"
+
+    def test_flag_does_not_hide_unrelated_failures(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._clear_ci_env(monkeypatch)
+        checks = self._quorum_failure_plus_green() + [
+            {"name": "typecheck", "status": "COMPLETED", "conclusion": "FAILURE"},
+        ]
+        summary, has_fail, _ = _summarize_checks(checks, ignore_quorum_check=True)
+        assert has_fail  # the real typecheck failure is preserved
+        assert summary == "1 failing / 2 total"
+
+    def test_required_summary_flag_excludes_quorum(self) -> None:
+        required = [
+            {"name": "aragora-merge-quorum", "workflow": "Aragora Merge Quorum", "bucket": "fail"},
+            {"name": "required-lint", "bucket": "pass"},
+        ]
+        _, default_fail, _ = _summarize_required_pr_checks(required)
+        assert default_fail
+        summary, has_fail, _ = _summarize_required_pr_checks(required, ignore_quorum_check=True)
+        assert not has_fail
+        assert summary == "1/1 required green"
+
+    def test_effective_required_count_flag_excludes_quorum(self) -> None:
+        required = [
+            {"name": "aragora-merge-quorum", "workflow": "Aragora Merge Quorum", "bucket": "fail"},
+            {"name": "required-lint", "bucket": "pass"},
+        ]
+        assert _effective_required_pr_check_count(required) == 2
+        assert _effective_required_pr_check_count(required, ignore_quorum_check=True) == 1
+
+    def test_is_merge_quorum_check_matches_rollup_and_required_rows(self) -> None:
+        assert _is_merge_quorum_check(
+            {"name": "aragora-merge-quorum", "workflowName": "Aragora Merge Quorum"}
+        )
+        assert _is_merge_quorum_check(
+            {"name": "aragora-merge-quorum", "workflow": "Aragora Merge Quorum"}
+        )
+        assert not _is_merge_quorum_check({"name": "lint", "workflow": "Tests"})
 
 
 # --- _classify_pr lane logic -----------------------------------------------
@@ -4899,6 +4983,7 @@ class TestSettlementHelpers:
             *,
             repo_override: str | None,
             execute_reviewers: bool = False,
+            ignore_own_quorum_check: bool = False,
         ) -> ReviewPacket:
             return ReviewPacket(
                 pr_number=int(pr_ref),


### PR DESCRIPTION
## B2 — `merge-packet --ignore-own-quorum-check` (diagnostic only)

Phase 2 of the boss-loop merge-gate resilience design
(`docs/governance/BOSS_LOOP_MERGE_GATE_RESILIENCE.md`). Fixes **root cause #3**
(circular short-circuit) so the diagnostic surface becomes reliable. Pairs with
the merged A2 settlement viewer.

### What
Out-of-CI callers can pass `--ignore-own-quorum-check` so `merge-packet`
additionally excludes a **concluded** `aragora-merge-quorum` check from
`has_failures`. Today only the check's *own in-progress* run is ignored
(matched by `GITHUB_RUN_ID`), so a stale concluded merge-quorum FAILURE makes
the packet short-circuit to an empty quorum for any non-CI caller — hiding
whether the model quorum is actually complete.

### How
A default-`False` `ignore_quorum_check` parameter is threaded through:
- `_summarize_checks`, `_summarize_required_pr_checks`,
  `_effective_required_pr_check_count`
- `_build_packet` → `_build_merge_authorization_packet` → `_cmd_merge_packet`

The flag is registered on both the real CLI (`aragora/cli/parser.py`) and the
`review_queue.py` registration surface.

### Why this does not weaken the gate
The enforcing `aragora-merge-quorum.yml` job calls `merge-packet` **without**
the flag, so `ignore_quorum_check=False` and the gating computation is
**byte-identical** to today. Re-running a read-only evaluation can never pass a
genuinely failing PR; the flag only affects *diagnostic* output for callers that
opt in.

### Tests
7 new B2 tests (flag excludes a concluded quorum failure; default still blocks;
real unrelated failures are preserved; required-check + effective-count
variants; `_is_merge_quorum_check` row matching) + full regression (210 pass).

### Tier / settlement
Tier 4 (touches `review_queue.py` + `parser.py`). I will drive the model +
dogfood quorum, but **I will not merge** — this needs head-bound operator
settlement (`scripts/settle_tier4_pr.py`).
