### PR TITLE
[codex] Route merged PR active-lane prompts

### DIFF
--- a/scripts/build_next_prompt.py
+++ b/scripts/build_next_prompt.py
@@ -51,6 +51,7 @@ PENDING_CHECK_STATES = {
     "REQUESTED",
     "WAITING",
 }
+POST_MERGE_LANE_KEYWORDS = ("evidence", "review", "quorum", "settle", "settlement")
 
 
 def _read_lanes(path: Path) -> list[dict[str, Any]]:
@@ -143,6 +144,55 @@ def _run_text(command: list[str], command_runner: CommandRunner) -> dict[str, An
         "stdout": result.stdout or "",
         "stderr": result.stderr or "",
         "returncode": result.returncode,
+    }
+
+
+def _tmux_pane_packet(command_runner: CommandRunner) -> dict[str, Any]:
+    """Return a compact tmux pane inventory for active-lane coordination."""
+
+    result = _run_text(
+        [
+            "tmux",
+            "list-panes",
+            "-a",
+            "-F",
+            "#{session_name}\t#{window_name}\t#{pane_index}\t#{pane_pid}\t#{pane_current_path}\t#{pane_current_command}",
+        ],
+        command_runner,
+    )
+    panes: list[dict[str, Any]] = []
+    if result["returncode"] != 0:
+        return {
+            "available": False,
+            "returncode": result["returncode"],
+            "stderr": result["stderr"].strip(),
+            "panes": panes,
+        }
+    for raw_line in result["stdout"].splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        parts = line.split("\t")
+        if len(parts) == 6:
+            session_name, window_name, pane_index, pane_pid, current_path, command = parts
+            panes.append(
+                {
+                    "tmux_target": f"{session_name}:{window_name}",
+                    "session_name": session_name,
+                    "window_name": window_name,
+                    "pane_index": pane_index,
+                    "pane_pid": pane_pid,
+                    "current_path": current_path,
+                    "command": command,
+                }
+            )
+        else:
+            panes.append({"raw": raw_line})
+    return {
+        "available": True,
+        "returncode": 0,
+        "stderr": "",
+        "panes": panes,
     }
 
 
@@ -553,6 +603,80 @@ def _active_target_lanes(
     return rows
 
 
+def _contains_target_token(text: str, *, pr: int | None, branch: str | None) -> bool:
+    lowered = text.lower()
+    if pr is not None and str(pr) in lowered:
+        return True
+    return bool(branch and branch.lower() in lowered)
+
+
+def _active_session_matches_target(text: str, *, pr: int | None, branch: str | None) -> bool:
+    if not _contains_target_token(text, pr=pr, branch=branch):
+        return False
+    lowered = text.lower()
+    if branch and branch.lower() in lowered:
+        return True
+    return any(keyword in lowered for keyword in POST_MERGE_LANE_KEYWORDS)
+
+
+def _post_merge_lane_matches(packet: dict[str, Any], *, pr: int | None) -> list[dict[str, Any]]:
+    """Return active lane/session rows for a PR that has already merged."""
+
+    pr_packet = packet.get("pr") if isinstance(packet.get("pr"), dict) else {}
+    branch = str(pr_packet.get("headRefName") or "")
+    rows: list[dict[str, Any]] = []
+    seen: set[str] = set()
+
+    for lane in packet.get("target_active_lanes") or []:
+        if not isinstance(lane, dict):
+            continue
+        key = f"lane:{lane.get('lane_id') or lane.get('owner_session') or id(lane)}"
+        if key in seen:
+            continue
+        seen.add(key)
+        rows.append({"source": "agent_bridge_lane", **_sanitize(lane)})
+
+    tmux_panes = packet.get("tmux_panes") if isinstance(packet.get("tmux_panes"), dict) else {}
+    for pane in tmux_panes.get("panes") or []:
+        if not isinstance(pane, dict):
+            continue
+        text = json.dumps(_sanitize(pane), sort_keys=True)
+        if not _active_session_matches_target(text, pr=pr, branch=branch):
+            continue
+        key = f"tmux:{pane.get('tmux_target') or pane.get('raw') or id(pane)}"
+        if key in seen:
+            continue
+        seen.add(key)
+        rows.append({"source": "tmux_pane", **_sanitize(pane)})
+
+    active_sessions = (
+        packet.get("active_sessions") if isinstance(packet.get("active_sessions"), dict) else {}
+    )
+    for collection_name in (
+        "agent_bridge_lanes",
+        "codex_cli_sessions",
+        "process_census",
+        "overlap_report",
+    ):
+        collection = active_sessions.get(collection_name)
+        if not collection:
+            continue
+        items = collection if isinstance(collection, list) else [collection]
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            text = json.dumps(_sanitize(item), sort_keys=True)
+            if not _active_session_matches_target(text, pr=pr, branch=branch):
+                continue
+            key = f"active:{collection_name}:{item.get('lane_id') or item.get('owner_session') or item.get('tmux_target') or id(item)}"
+            if key in seen:
+                continue
+            seen.add(key)
+            rows.append({"source": collection_name, **_sanitize(item)})
+
+    return rows
+
+
 def _merge_packet_entry(merge_packet: Any, pr: int | None) -> dict[str, Any]:
     if not isinstance(merge_packet, dict):
         return {}
@@ -616,6 +740,65 @@ def _pending_required_checks(checks: Any) -> list[dict[str, str]]:
                 }
             )
     return pending
+
+
+def build_post_merge_lane_coordination_prompt(
+    packet: dict[str, Any],
+    *,
+    repo_root: Path = DEFAULT_REPO_ROOT,
+    pr: int | None = None,
+) -> str | None:
+    """Build a stop-first prompt when a merged PR still has an active target lane."""
+
+    pr_packet = packet.get("pr") if isinstance(packet.get("pr"), dict) else {}
+    if str(pr_packet.get("state") or "").upper() != "MERGED":
+        return None
+    active_matches = _post_merge_lane_matches(packet, pr=pr)
+    if not active_matches:
+        return None
+
+    target = f"#{pr}" if pr is not None else "the target PR"
+    head = str(pr_packet.get("headRefOid") or "unknown")
+    merge_commit = pr_packet.get("mergeCommit")
+    merge_commit_oid = ""
+    if isinstance(merge_commit, dict):
+        merge_commit_oid = str(merge_commit.get("oid") or "")
+    merged_at = str(pr_packet.get("mergedAt") or "unknown")
+    lane_lines = []
+    for row in active_matches:
+        if row.get("source") == "tmux_pane":
+            label = row.get("tmux_target") or row.get("window_name") or row.get("raw")
+            cwd = row.get("current_path") or ""
+            lane_lines.append(f"- tmux {label} cwd={cwd}".rstrip())
+        else:
+            label = row.get("lane_id") or row.get("owner_session") or row.get("source")
+            lane_lines.append(f"- {row.get('source')}: {label}")
+    lane_summary = "\n".join(lane_lines) or "- active target lane detected"
+
+    return "\n".join(
+        [
+            f"Start from live repo truth in {repo_root}. Do not trust prior transcript state.",
+            "Do not duplicate active lanes. Do not touch unrelated PRs. Do not merge without separate explicit operator authorization. Do not use or mutate dirty root source files.",
+            "",
+            f"Goal: coordinate stale active lane(s) after PR {target} already merged.",
+            f"Live merged PR state to verify, not trust: head={head}, merge_commit={merge_commit_oid or 'unknown'}, merged_at={merged_at}.",
+            "",
+            "Active target lane(s) detected:",
+            lane_summary,
+            "",
+            "First re-check tmux active sessions and gh pr view for the PR. If any listed target lane is still active and no explicit operator action is present, stop and repeat these choices:",
+            "1. Let the active lane finish naturally, then re-ground queue selection from a clean current origin/main checkout.",
+            "2. Explicitly terminate/retire the active lane, then re-ground queue selection from a clean current origin/main checkout.",
+            "3. Explicitly supersede the lane only for post-merge cleanup/receipt inspection; do not collect evidence, rerun checks, mark statuses, or merge.",
+            "",
+            "If the active lane is gone, explicitly retired, or explicitly superseded, use a clean current origin/main checkout only. Re-check git status, agent health, active sessions, work robot, and open PR list before selecting the next highest-ranked unowned non-draft PR that is not policy-excluded.",
+            "Before any new lane work, check mailbox, owner state, gh pr view/checks, full checks, merge-packet, and settle_one_pr.py.",
+            "",
+            "Final report: merged PR state, active-lane coordination result, action taken or withheld, and a fresh recursive best-next prompt that starts with mailbox checking.",
+            CONVERGENCE_SENTENCE,
+            "",
+        ]
+    )
 
 
 def build_settlement_guard(
@@ -726,10 +909,12 @@ def build_decision_packet(
             ],
             runner,
         ),
+        "tmux_panes": _tmux_pane_packet(runner),
         "disk_outbox": _disk_outbox_packet(runner, repo_root=repo_root),
         "pr": {},
         "checks": {"required": []},
         "merge_packet": {},
+        "post_merge_lane_coordination": {},
         "blockers": blockers,
         "selected_action": "read_only_owner_routing"
         if "active owner exists for target" in blockers
@@ -750,7 +935,7 @@ def build_decision_packet(
                 "view",
                 str(pr),
                 "--json",
-                "number,state,isDraft,headRefOid,headRefName,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,url",
+                "number,state,isDraft,headRefOid,headRefName,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,url,mergedAt,mergeCommit",
             ],
             runner,
         )
@@ -780,6 +965,19 @@ def build_decision_packet(
             ],
             runner,
         )
+    active_post_merge_lanes = _post_merge_lane_matches(packet, pr=pr)
+    post_merge_detected = (
+        isinstance(packet.get("pr"), dict)
+        and str(packet["pr"].get("state") or "").upper() == "MERGED"
+        and bool(active_post_merge_lanes)
+    )
+    packet["post_merge_lane_coordination"] = {
+        "detected": post_merge_detected,
+        "active_lanes": active_post_merge_lanes,
+    }
+    if post_merge_detected:
+        packet["blockers"].append("merged PR still has active target lane")
+        packet["selected_action"] = "post_merge_lane_retirement_coordination"
     packet["settlement_guard"] = build_settlement_guard(packet, pr=pr, expected_head=expected_head)
     return packet
 
@@ -1008,7 +1206,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     packet: dict[str, Any] | None = None
     guard_prompt: str | None = None
-    if args.json or args.settlement_guard:
+    if args.pr is not None or args.json or args.settlement_guard:
         packet = build_decision_packet(
             registry_path=args.registry_path,
             repo_root=args.repo_root,
@@ -1017,6 +1215,23 @@ def main(argv: Sequence[str] | None = None) -> int:
             branch=args.branch,
             expected_head=args.expected_head,
         )
+        post_merge_prompt = build_post_merge_lane_coordination_prompt(
+            packet,
+            repo_root=args.repo_root,
+            pr=args.pr,
+        )
+        if post_merge_prompt:
+            prompt = post_merge_prompt
+    if args.json or args.settlement_guard:
+        if packet is None:
+            packet = build_decision_packet(
+                registry_path=args.registry_path,
+                repo_root=args.repo_root,
+                lane_id=args.lane_id,
+                pr=args.pr,
+                branch=args.branch,
+                expected_head=args.expected_head,
+            )
         guard_prompt = build_settlement_guard_prompt(
             packet,
             repo_root=args.repo_root,

--- a/scripts/build_next_prompt.py
+++ b/scripts/build_next_prompt.py
@@ -801,6 +801,59 @@ def build_post_merge_lane_coordination_prompt(
     )
 
 
+def build_post_merge_fast_packet(
+    *,
+    registry_path: Path,
+    repo_root: Path = DEFAULT_REPO_ROOT,
+    pr: int,
+    command_runner: CommandRunner | None = None,
+) -> dict[str, Any]:
+    """Build the cheapest packet needed to route merged PR stale-lane prompts."""
+
+    runner = command_runner or _repo_runner(repo_root)
+    pr_packet = _run_json(
+        [
+            "gh",
+            "pr",
+            "view",
+            str(pr),
+            "--json",
+            "number,state,headRefOid,headRefName,url,mergedAt,mergeCommit",
+        ],
+        runner,
+    )
+    pr_packet = pr_packet if isinstance(pr_packet, dict) else {}
+    lanes = _read_lanes(registry_path)
+    branch = str(pr_packet.get("headRefName") or "")
+    target_active_lanes = _active_target_lanes(
+        lanes,
+        lane=_find_lane(lanes, pr=pr, branch=branch),
+        pr=pr,
+        branch=branch or None,
+    )
+    packet: dict[str, Any] = {
+        "pr": pr_packet,
+        "target_active_lanes": target_active_lanes,
+        "active_sessions": {},
+        "tmux_panes": _tmux_pane_packet(runner),
+        "post_merge_lane_coordination": {},
+        "blockers": [],
+        "selected_action": "continue_standard_prompt",
+    }
+    active_post_merge_lanes = _post_merge_lane_matches(packet, pr=pr)
+    post_merge_detected = str(pr_packet.get("state") or "").upper() == "MERGED" and bool(
+        active_post_merge_lanes
+    )
+    packet["post_merge_lane_coordination"] = {
+        "detected": post_merge_detected,
+        "active_lanes": active_post_merge_lanes,
+    }
+    if post_merge_detected:
+        packet["blockers"].append("merged PR still has active target lane")
+        packet["selected_action"] = "post_merge_lane_retirement_coordination"
+    return packet
+
+
 def build_settlement_guard(
     packet: dict[str, Any],
     *,
@@ -1196,18 +1249,42 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
-    prompt = build_prompt(
-        registry_path=args.registry_path,
-        repo_root=args.repo_root,
-        lane_id=args.lane_id,
-        pr=args.pr,
-        branch=args.branch,
-        expected_head=args.expected_head,
-    )
+    prompt: str | None = None
     packet: dict[str, Any] | None = None
     guard_prompt: str | None = None
+    if args.pr is not None:
+        fast_packet = build_post_merge_fast_packet(
+            registry_path=args.registry_path,
+            repo_root=args.repo_root,
+            pr=args.pr,
+        )
+        post_merge_prompt = build_post_merge_lane_coordination_prompt(
+            fast_packet,
+            repo_root=args.repo_root,
+            pr=args.pr,
+        )
+        if post_merge_prompt:
+            prompt = post_merge_prompt
+            packet = fast_packet
     if args.pr is not None or args.json or args.settlement_guard:
-        packet = build_decision_packet(
+        if packet is None:
+            packet = build_decision_packet(
+                registry_path=args.registry_path,
+                repo_root=args.repo_root,
+                lane_id=args.lane_id,
+                pr=args.pr,
+                branch=args.branch,
+                expected_head=args.expected_head,
+            )
+            post_merge_prompt = build_post_merge_lane_coordination_prompt(
+                packet,
+                repo_root=args.repo_root,
+                pr=args.pr,
+            )
+            if post_merge_prompt:
+                prompt = post_merge_prompt
+    if prompt is None:
+        prompt = build_prompt(
             registry_path=args.registry_path,
             repo_root=args.repo_root,
             lane_id=args.lane_id,
@@ -1215,13 +1292,6 @@ def main(argv: Sequence[str] | None = None) -> int:
             branch=args.branch,
             expected_head=args.expected_head,
         )
-        post_merge_prompt = build_post_merge_lane_coordination_prompt(
-            packet,
-            repo_root=args.repo_root,
-            pr=args.pr,
-        )
-        if post_merge_prompt:
-            prompt = post_merge_prompt
     if args.json or args.settlement_guard:
         if packet is None:
             packet = build_decision_packet(

--- a/tests/scripts/test_build_next_prompt.py
+++ b/tests/scripts/test_build_next_prompt.py
@@ -835,7 +835,12 @@ def test_main_replaces_standard_prompt_with_post_merge_coordination(
     }
 
     monkeypatch.setattr(prompt_builder, "build_prompt", lambda **_kwargs: "standard prompt\n")
-    monkeypatch.setattr(prompt_builder, "build_decision_packet", lambda **_kwargs: packet)
+    monkeypatch.setattr(prompt_builder, "build_post_merge_fast_packet", lambda **_kwargs: packet)
+    monkeypatch.setattr(
+        prompt_builder,
+        "build_decision_packet",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("full packet not needed")),
+    )
 
     assert (
         prompt_builder.main(

--- a/tests/scripts/test_build_next_prompt.py
+++ b/tests/scripts/test_build_next_prompt.py
@@ -78,6 +78,8 @@ def _clean_checkout_runner(
 
 def test_prompt_starts_with_mailbox_and_owner_verification(tmp_path: Path) -> None:
     registry = tmp_path / "lanes.json"
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
     registry.write_text(
         json.dumps(
             [
@@ -96,8 +98,10 @@ def test_prompt_starts_with_mailbox_and_owner_verification(tmp_path: Path) -> No
 
     prompt = prompt_builder.build_prompt(
         registry_path=registry,
+        repo_root=repo_root,
         lane_id="P106-merge-gate-settlement",
         pr=7423,
+        command_runner=_clean_checkout_runner(repo_root=repo_root, root_dirty=False),
     )
 
     assert prompt.startswith("Start from live repo truth")
@@ -117,9 +121,16 @@ def test_prompt_starts_with_mailbox_and_owner_verification(tmp_path: Path) -> No
 
 def test_prompt_for_non_owner_read_only_when_no_lane_match(tmp_path: Path) -> None:
     registry = tmp_path / "lanes.json"
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
     registry.write_text("[]\n", encoding="utf-8")
 
-    prompt = prompt_builder.build_prompt(registry_path=registry, pr=7407)
+    prompt = prompt_builder.build_prompt(
+        registry_path=registry,
+        repo_root=repo_root,
+        pr=7407,
+        command_runner=_clean_checkout_runner(repo_root=repo_root, root_dirty=False),
+    )
 
     assert "If you cannot map yourself to a lane, run read-only only" in prompt
     assert "Do not paste raw transcripts" in prompt
@@ -127,6 +138,8 @@ def test_prompt_for_non_owner_read_only_when_no_lane_match(tmp_path: Path) -> No
 
 def test_prompt_shell_quotes_live_lane_values(tmp_path: Path) -> None:
     registry = tmp_path / "lanes.json"
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
     registry.write_text(
         json.dumps(
             [
@@ -142,7 +155,12 @@ def test_prompt_shell_quotes_live_lane_values(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
-    prompt = prompt_builder.build_prompt(registry_path=registry, pr=7425)
+    prompt = prompt_builder.build_prompt(
+        registry_path=registry,
+        repo_root=repo_root,
+        pr=7425,
+        command_runner=_clean_checkout_runner(repo_root=repo_root, root_dirty=False),
+    )
 
     assert "--lane-id 'lane; echo pwned'" in prompt
     assert "--lane-id lane; echo pwned" not in prompt
@@ -722,3 +740,110 @@ def test_settlement_guard_prompt_uses_pr_mailbox_when_only_completed_lane_matche
 
     assert "python3 scripts/read_operator_steering.py --pr 7435" in prompt
     assert "--lane-id completed-lane" not in prompt
+
+
+def test_decision_packet_detects_merged_pr_with_active_tmux_evidence_lane(
+    tmp_path: Path,
+) -> None:
+    registry = tmp_path / "lanes.json"
+    registry.write_text("[]\n", encoding="utf-8")
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        joined = " ".join(command)
+        if command[:2] == ["git", "status"]:
+            return subprocess.CompletedProcess(command, 0, "## main...origin/main\n", "")
+        if command[:3] == ["gh", "pr", "view"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                json.dumps(
+                    {
+                        "number": 7735,
+                        "state": "MERGED",
+                        "headRefOid": "merged-head",
+                        "headRefName": "droid/merge-quorum-reconcile",
+                        "mergedAt": "2026-06-04T13:43:56Z",
+                        "mergeCommit": {"oid": "merge-commit"},
+                    }
+                ),
+                "",
+            )
+        if command[:3] == ["gh", "pr", "checks"]:
+            return subprocess.CompletedProcess(command, 0, "[]", "")
+        if "merge-packet" in joined:
+            return subprocess.CompletedProcess(command, 0, "{}", "")
+        if command[:2] == ["df", "-h"]:
+            return subprocess.CompletedProcess(command, 0, "Filesystem Size Used Avail\n", "")
+        if command[:2] == ["tmux", "list-panes"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                "aragora\tclaude-7735-evidence-20260604T1258Z\t0\t30664\t/tmp/wt\tclaude\n",
+                "",
+            )
+        return subprocess.CompletedProcess(command, 0, "{}", "")
+
+    packet = prompt_builder.build_decision_packet(
+        registry_path=registry,
+        pr=7735,
+        command_runner=fake_runner,
+    )
+
+    coordination = packet["post_merge_lane_coordination"]
+    assert coordination["detected"] is True
+    assert coordination["active_lanes"][0]["source"] == "tmux_pane"
+    assert coordination["active_lanes"][0]["tmux_target"] == (
+        "aragora:claude-7735-evidence-20260604T1258Z"
+    )
+    assert packet["selected_action"] == "post_merge_lane_retirement_coordination"
+    assert "merged PR still has active target lane" in packet["blockers"]
+
+    prompt = prompt_builder.build_post_merge_lane_coordination_prompt(packet, pr=7735)
+
+    assert prompt is not None
+    assert "Goal: coordinate stale active lane(s) after PR #7735 already merged." in prompt
+    assert "merge_commit=merge-commit" in prompt
+    assert "aragora:claude-7735-evidence-20260604T1258Z" in prompt
+    assert "do not collect evidence, rerun checks, mark statuses, or merge" in prompt
+
+
+def test_main_replaces_standard_prompt_with_post_merge_coordination(
+    tmp_path: Path,
+    monkeypatch: Any,
+    capsys: Any,
+) -> None:
+    registry = tmp_path / "lanes.json"
+    registry.write_text("[]\n", encoding="utf-8")
+    packet = {
+        "pr": {
+            "state": "MERGED",
+            "headRefOid": "merged-head",
+            "headRefName": "droid/merge-quorum-reconcile",
+            "mergedAt": "2026-06-04T13:43:56Z",
+            "mergeCommit": {"oid": "merge-commit"},
+        },
+        "target_active_lanes": [],
+        "tmux_panes": {
+            "panes": [
+                {
+                    "tmux_target": "aragora:claude-7735-evidence-20260604T1258Z",
+                    "window_name": "claude-7735-evidence-20260604T1258Z",
+                }
+            ]
+        },
+        "active_sessions": {},
+    }
+
+    monkeypatch.setattr(prompt_builder, "build_prompt", lambda **_kwargs: "standard prompt\n")
+    monkeypatch.setattr(prompt_builder, "build_decision_packet", lambda **_kwargs: packet)
+
+    assert (
+        prompt_builder.main(
+            ["--pr", "7735", "--registry-path", str(registry), "--repo-root", str(tmp_path)]
+        )
+        == 0
+    )
+
+    out = capsys.readouterr().out
+    assert "standard prompt" not in out
+    assert "coordinate stale active lane(s) after PR #7735 already merged" in out


### PR DESCRIPTION
## Summary
- detect when a PR is already merged while a target evidence/review tmux lane is still active
- emit a stale-lane retirement coordination prompt instead of another exact-head watch/evidence prompt
- add a fast path so merged-PR lane routing avoids the expensive generic worktree scan before it can stop

## Validation
- `PYTHONDONTWRITEBYTECODE=1 /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_build_next_prompt.py -q -p no:cacheprovider`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/build_next_prompt.py tests/scripts/test_build_next_prompt.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/build_next_prompt.py tests/scripts/test_build_next_prompt.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- live read-only smoke: `scripts/build_next_prompt.py --pr 7735 --json` selected `post_merge_lane_retirement_coordination`
