### PR TITLE
fix(review-queue): tolerate parenthetical model-family disclosure in quorum evidence

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3230,16 +3230,22 @@ def _normalize_model_family(value: str) -> str:
     # e.g. ``openai (gpt-5.5, codex exec --sandbox read-only)`` or
     # ``claude (opus-4.8)``. The parenthetical is descriptive metadata, not part
     # of the canonical family token, so a literal lookup of the whole string used
-    # to fail and de-count an otherwise-valid reviewer. Strip a trailing
-    # ``(...)`` and retry; if still unresolved, fall back to the leading
-    # whitespace-delimited token. A genuinely-unknown leading token (e.g.
-    # ``mystery (x)``) still resolves to "" and stays a blocker — the gate is
-    # not weakened, only the well-formed disclosures that were being lost.
+    # to fail and de-count an otherwise-valid reviewer.
+    #
+    # We ONLY relax the lookup when a trailing ``(...)`` is actually present:
+    # strip it and retry, then fall back to the leading whitespace-delimited
+    # token of the *parenthetical-stripped* value (handles ``openai (gpt-5.5)``).
+    # When no parenthetical is present we deliberately do NOT take a leading
+    # token, so malformed multi-word disclosures such as ``openai claude`` or
+    # ``openai not-a-valid-family`` still resolve to "" and stay a count blocker
+    # exactly as before. This keeps the gate fail-closed for everything except
+    # the well-formed parenthetical disclosures that were being lost.
+    if "(" not in lower:
+        return ""
     stripped = re.sub(r"\s*\(.*$", "", lower).strip()
-    if stripped != lower:
-        resolved = _lookup(stripped)
-        if resolved:
-            return resolved
+    resolved = _lookup(stripped)
+    if resolved:
+        return resolved
     leading = stripped.split()[0] if stripped.split() else ""
     if leading and leading != stripped:
         resolved = _lookup(leading)

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3232,26 +3232,32 @@ def _normalize_model_family(value: str) -> str:
     # of the canonical family token, so a literal lookup of the whole string used
     # to fail and de-count an otherwise-valid reviewer.
     #
-    # We ONLY relax the lookup when a trailing ``(...)`` is actually present:
-    # strip it and retry, then fall back to the leading whitespace-delimited
-    # token of the *parenthetical-stripped* value (handles ``openai (gpt-5.5)``).
-    # When no parenthetical is present we deliberately do NOT take a leading
-    # token, so malformed multi-word disclosures such as ``openai claude`` or
-    # ``openai not-a-valid-family`` still resolve to "" and stay a count blocker
-    # exactly as before. This keeps the gate fail-closed for everything except
-    # the well-formed parenthetical disclosures that were being lost.
-    if "(" not in lower:
+    # We ONLY relax the lookup for a *well-formed, trailing, closed*
+    # parenthetical suffix: ``<token> (<detail>)`` with nothing but optional
+    # whitespace after the closing ``)``. The match captures the text before the
+    # ``(`` as ``head`` and the canonical token is the head's *single*
+    # whitespace-delimited word (which covers ``openai (gpt-5.5)``). This keeps
+    # the gate fail-closed for everything the PR intends to remain blocked:
+    #   - no parenthetical at all (``openai claude``) -> no match -> "".
+    #   - text *after* the closing paren (``openai (gpt-5.5) claude``) -> the
+    #     ``$`` anchor rejects it -> "".
+    #   - unclosed parenthetical (``openai (``, ``openai (not closed``) -> no
+    #     ``)`` -> no match -> "".
+    #   - multi-word head (``openai gpt (x)``) -> head has >1 word -> "".
+    # A genuinely-unknown leading token (``mystery (x)``) still resolves to "".
+    match = re.fullmatch(r"\s*([^()]*?)\s*\([^()]*\)\s*", lower)
+    if not match:
         return ""
-    stripped = re.sub(r"\s*\(.*$", "", lower).strip()
-    resolved = _lookup(stripped)
-    if resolved:
-        return resolved
-    leading = stripped.split()[0] if stripped.split() else ""
-    if leading and leading != stripped:
-        resolved = _lookup(leading)
+    head = match.group(1).strip()
+    head_words = head.split()
+    if len(head_words) != 1:
+        # Multi-word alias such as "nous hermes (8x7b)" is still a legitimate
+        # disclosure: try the full head before rejecting a >1-word head.
+        resolved = _lookup(head)
         if resolved:
             return resolved
-    return ""
+        return ""
+    return _lookup(head_words[0])
 
 
 def _first_heading_candidate(text: str) -> tuple[str, int | None]:

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3203,8 +3203,6 @@ def _normalize_model_family(value: str) -> str:
     lower = str(value or "").strip().lower()
     if not lower:
         return ""
-    if lower in CANONICAL_MODEL_FAMILIES:
-        return lower
     aliases = {
         "anthropic": "claude",
         "google": "gemini",
@@ -3216,7 +3214,38 @@ def _normalize_model_family(value: str) -> str:
         "nous-hermes": "hermes",
         "nous hermes": "hermes",
     }
-    return aliases.get(lower, "")
+
+    def _lookup(token: str) -> str:
+        if token in CANONICAL_MODEL_FAMILIES:
+            return token
+        return aliases.get(token, "")
+
+    # Fast path: the disclosed value is already a bare canonical family or a
+    # known (possibly multi-word) alias such as "nous hermes".
+    resolved = _lookup(lower)
+    if resolved:
+        return resolved
+
+    # Agents commonly disclose the family with a trailing parenthetical detail,
+    # e.g. ``openai (gpt-5.5, codex exec --sandbox read-only)`` or
+    # ``claude (opus-4.8)``. The parenthetical is descriptive metadata, not part
+    # of the canonical family token, so a literal lookup of the whole string used
+    # to fail and de-count an otherwise-valid reviewer. Strip a trailing
+    # ``(...)`` and retry; if still unresolved, fall back to the leading
+    # whitespace-delimited token. A genuinely-unknown leading token (e.g.
+    # ``mystery (x)``) still resolves to "" and stays a blocker — the gate is
+    # not weakened, only the well-formed disclosures that were being lost.
+    stripped = re.sub(r"\s*\(.*$", "", lower).strip()
+    if stripped != lower:
+        resolved = _lookup(stripped)
+        if resolved:
+            return resolved
+    leading = stripped.split()[0] if stripped.split() else ""
+    if leading and leading != stripped:
+        resolved = _lookup(leading)
+        if resolved:
+            return resolved
+    return ""
 
 
 def _first_heading_candidate(text: str) -> tuple[str, int | None]:

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -1977,6 +1977,128 @@ class TestModelReviewQuorum:
         assert "claude" in quorum["counted_reviewer_ids"]
 
 
+# --- parenthetical model-family disclosure ---------------------------------
+
+
+class TestParentheticalModelFamily:
+    """Agents commonly disclose `**Model family:** openai (gpt-5.5, harness)`.
+
+    The trailing parenthetical detail used to contaminate the value so the
+    canonical/alias lookup returned "" → ``unknown_model_family`` → the reviewer
+    was NOT counted → the merge quorum stalled at 1/2. The normalizer now
+    tolerates the parenthetical without weakening the gate.
+    """
+
+    def test_paren_openai_normalizes_to_openai(self) -> None:
+        from aragora.cli.commands.review_queue import _normalize_model_family
+
+        assert _normalize_model_family("openai (gpt-5.5, harness)") == "openai"
+        assert _normalize_model_family("openai (gpt-5.5)") == "openai"
+        assert _normalize_model_family("openai(gpt-5.5)") == "openai"
+
+    def test_paren_claude_normalizes_to_claude(self) -> None:
+        from aragora.cli.commands.review_queue import _normalize_model_family
+
+        assert _normalize_model_family("claude (opus-4.8)") == "claude"
+
+    def test_bare_tokens_still_work(self) -> None:
+        from aragora.cli.commands.review_queue import _normalize_model_family
+
+        assert _normalize_model_family("openai") == "openai"
+        assert _normalize_model_family("claude") == "claude"
+
+    def test_aliases_still_resolve_including_multiword(self) -> None:
+        from aragora.cli.commands.review_queue import _normalize_model_family
+
+        # Single-token alias.
+        assert _normalize_model_family("anthropic") == "claude"
+        # Multi-word alias must NOT be truncated to its first token.
+        assert _normalize_model_family("nous hermes") == "hermes"
+        assert _normalize_model_family("nous-hermes") == "hermes"
+        # Multi-word alias with a trailing parenthetical still resolves.
+        assert _normalize_model_family("nous hermes (8x7b)") == "hermes"
+
+    def test_unknown_leading_token_still_unknown(self) -> None:
+        from aragora.cli.commands.review_queue import _normalize_model_family
+
+        # A genuinely-unknown leading token must still fail-closed even when a
+        # parenthetical is present — the gate is not weakened.
+        assert _normalize_model_family("mystery (x)") == ""
+        assert _normalize_model_family("acme-frontier-9000") == ""
+        assert _normalize_model_family("acme (gpt-5.5)") == ""
+
+    def test_paren_disclosure_still_detects_heading_conflict(self) -> None:
+        """A real heading/disclosed conflict must STILL fire even after the
+        parenthetical is stripped — the disclosed family resolves correctly
+        (``openai``) but it conflicts with the ``claude`` heading."""
+        from aragora.cli.commands.review_queue import (
+            _resolve_model_review_identity,
+        )
+
+        body = (
+            "## Claude review\n\n"
+            "**Model family:** openai (gpt-5.5, codex exec --sandbox read-only)\n"
+            "**Model id:** gpt-5.5\n"
+            "**Receipt artifact:** /tmp/r.md\n\n"
+            "review."
+        )
+        ident = _resolve_model_review_identity(body)
+        assert "heading_model_family_conflict" in ident.identity_problems
+
+    def test_paren_disclosure_non_conflict_now_counts(self) -> None:
+        """An ``openai (gpt-5.5)`` disclosure under a codex/openai heading must
+        resolve to ``openai`` with NO ``unknown_model_family`` blocker, so the
+        reviewer is counted (the bug that stalled the tail PRs)."""
+        from aragora.cli.commands.review_queue import (
+            _resolve_model_review_identity,
+        )
+
+        body = (
+            "## Codex review\n\n"
+            "**Reviewer harness:** codex\n"
+            "**Model family:** openai (gpt-5.5)\n"
+            "**Model id:** gpt-5.5\n"
+            "**Receipt artifact:** /tmp/r.md\n\n"
+            "review."
+        )
+        ident = _resolve_model_review_identity(body)
+        assert ident.model_family == "openai"
+        assert "unknown_model_family" not in ident.identity_problems
+        assert "heading_model_family_conflict" not in ident.identity_problems
+
+    def test_paren_disclosure_counts_in_full_quorum(self) -> None:
+        """End-to-end: a dogfood comment disclosing ``openai (gpt-5.5)`` under a
+        codex heading is counted in the model-review quorum (previously it was
+        silently dropped, stalling quorum at 1/2)."""
+        files = ["aragora/agents/router.py"]  # Tier 1
+        pr = _make_pr(files=files)
+        pr["comments"] = [
+            {
+                "author": {"login": "an0mium"},
+                "body": (
+                    "## Codex review\n\n"
+                    "**Reviewer harness:** codex\n"
+                    "**Model family:** openai (gpt-5.5, codex exec)\n"
+                    "**Model id:** gpt-5.5\n"
+                    "**Receipt artifact:** /tmp/r.md\n\n"
+                    "codex review: 6/6 cases pass."
+                ),
+            },
+        ]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=files,
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+        )
+        # The reviewer is now counted (previously the parenthetical de-counted
+        # it, leaving counted_reviewer_ids empty). The quorum credits the
+        # resolved model family, so "openai" appears.
+        assert quorum["counted_reviewer_ids"] == ["openai"]
+
+
 # --- _parse_pr_number ------------------------------------------------------
 
 

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -2027,6 +2027,22 @@ class TestParentheticalModelFamily:
         assert _normalize_model_family("acme-frontier-9000") == ""
         assert _normalize_model_family("acme (gpt-5.5)") == ""
 
+    def test_non_parenthetical_extra_text_stays_unknown(self) -> None:
+        """Codex-review regression (PR #7743): the first-token fallback must be
+        scoped to the parenthetical-stripped path ONLY. A malformed multi-word
+        disclosure with NO parenthetical — e.g. ``openai claude`` or
+        ``openai not-a-valid-family`` — must still resolve to "" and stay a
+        ``unknown_model_family`` blocker, exactly as before this fix. Otherwise
+        the gate would be weakened beyond the stated scope by silently accepting
+        the leading token of any multi-word value."""
+        from aragora.cli.commands.review_queue import _normalize_model_family
+
+        assert _normalize_model_family("openai claude") == ""
+        assert _normalize_model_family("claude unknown") == ""
+        assert _normalize_model_family("openai not-a-valid-family") == ""
+        # The fix's intended cases (parenthetical present) still resolve.
+        assert _normalize_model_family("openai (gpt-5.5)") == "openai"
+
     def test_paren_disclosure_still_detects_heading_conflict(self) -> None:
         """A real heading/disclosed conflict must STILL fire even after the
         parenthetical is stripped — the disclosed family resolves correctly

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -2043,6 +2043,25 @@ class TestParentheticalModelFamily:
         # The fix's intended cases (parenthetical present) still resolve.
         assert _normalize_model_family("openai (gpt-5.5)") == "openai"
 
+    def test_malformed_or_non_trailing_parenthetical_stays_unknown(self) -> None:
+        """Second codex-review regression (PR #7743): only a *well-formed,
+        trailing, closed* ``(...)`` suffix is tolerated. Text after the closing
+        paren, an unclosed paren, or a multi-word head must all stay "" so they
+        remain ``unknown_model_family`` blockers — the relaxation must not be a
+        blanket "strip from the first ``(`` to end of string"."""
+        from aragora.cli.commands.review_queue import _normalize_model_family
+
+        # Text after the closing parenthetical -> not a trailing suffix.
+        assert _normalize_model_family("openai (gpt-5.5) claude") == ""
+        # Unclosed parenthetical.
+        assert _normalize_model_family("openai (") == ""
+        assert _normalize_model_family("openai (not actually closed") == ""
+        # Multi-word head before a closed parenthetical.
+        assert _normalize_model_family("openai gpt (x)") == ""
+        # Well-formed trailing suffix (incl. multi-word alias head) still works.
+        assert _normalize_model_family("openai (gpt-5.5)") == "openai"
+        assert _normalize_model_family("nous hermes (8x7b)") == "hermes"
+
     def test_paren_disclosure_still_detects_heading_conflict(self) -> None:
         """A real heading/disclosed conflict must STILL fire even after the
         parenthetical is stripped — the disclosed family resolves correctly


### PR DESCRIPTION
## Root cause

The merge-quorum evidence parser's `_normalize_model_family()` (in
`aragora/cli/commands/review_queue.py`) only accepted a **bare** canonical
family token (e.g. `openai`, `claude`) or a known alias. Agents commonly
disclose the family with a trailing parenthetical detail, e.g.:

```
**Model family:** openai (gpt-5.5, codex exec --sandbox read-only)
```

The parenthetical contaminated the value, so the literal lookup returned `""` →
`unknown_model_family` blocker → the reviewer was **not counted** → the
model-review quorum stalled at **1/2**. This de-counting stalled the tail PRs
(#7707 / #7708) for multiple cycles.

## Fix (minimal, gate not weakened)

In `_normalize_model_family`, before failing the lookup:

1. Try the value as-is (preserves multi-word aliases like `nous hermes`).
2. Strip a trailing `(...)` and retry.
3. Fall back to the leading whitespace-delimited token.

So `openai (gpt-5.5, ...)` → `openai` and `claude (opus-4.8)` → `claude`,
while a genuinely-unknown leading token (`mystery (x)`, `acme-frontier-9000`,
`acme (gpt-5.5)`) still resolves to `""` and stays a count blocker. All
disclosure-parsing paths (`_resolve_model_review_identity`,
`_model_family_from_body`, item-level normalization) funnel through this one
function, so this is the single root-cause point.

## Conflict detection preserved

Stripping the parenthetical makes the **disclosed** family resolve correctly
(more accurate), which only improves the conflict check:

- A real conflict — heading `## Claude review` vs disclosed
  `openai (gpt-5.5, ...)` — **still** produces `heading_model_family_conflict`
  and stays uncounted.
- A non-conflict — `openai (gpt-5.5)` under a `## Codex review` / openai
  heading — now resolves to `openai` with no `unknown_model_family` blocker and
  **counts**.

Both are covered by new focused tests in
`TestParentheticalModelFamily` (normalize cases (a)-(e) + both conflict /
non-conflict identity-resolution cases + an end-to-end quorum case).

## Tests / checks

- `tests/cli/commands/test_review_queue.py` — 207 passed (incl. new class).
- `test_review_queue_baseline.py` + handler review_queue suites — 67 passed.
- ruff + mypy clean on touched files; `scripts/check_portability.py` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
