### PR TITLE
fix(queue): classify pending rollup gates before evidence

### DIFF
--- a/scripts/pr_check_followup.py
+++ b/scripts/pr_check_followup.py
@@ -53,6 +53,13 @@ META_AUTOMATION_SENTENCE = (
 FAILURE_CONCLUSIONS = {"FAILURE", "TIMED_OUT", "ACTION_REQUIRED"}
 GREEN_CONCLUSIONS = {"SUCCESS", "SKIPPED", "NEUTRAL"}
 PENDING_STATUSES = {"IN_PROGRESS", "QUEUED", "PENDING", "EXPECTED", "REQUESTED", "WAITING"}
+NAMED_NON_REQUIRED_ROLLUP_WORKFLOWS = {
+    "aragora code review",
+    "core suites",
+    "release readiness",
+    "security gate",
+    "smoke tests",
+}
 CHECKOUT_MARKERS = ("checkout", "sparse-checkout", "repository checkout")
 SUBSTANTIVE_MARKERS = (
     "verify",
@@ -369,6 +376,23 @@ def _has_dependency_security_failure(check: CheckDiagnosis) -> bool:
 
 def _has_superseding_dependency_pr(check: CheckDiagnosis) -> bool:
     return bool(check.superseding_dependency_prs) and _has_dependency_security_failure(check)
+
+
+def _is_named_non_required_rollup_gate(check: CheckDiagnosis) -> bool:
+    workflow = check.workflow.lower()
+    if workflow == "tests":
+        return True
+    return any(marker in workflow for marker in NAMED_NON_REQUIRED_ROLLUP_WORKFLOWS)
+
+
+def _pending_named_non_required_rollup_gates(
+    checks: list[CheckDiagnosis],
+) -> list[CheckDiagnosis]:
+    return [
+        check
+        for check in checks
+        if check.classification == "in_progress" and _is_named_non_required_rollup_gate(check)
+    ]
 
 
 def _dependency_repair_file(path: str) -> bool:
@@ -702,6 +726,8 @@ def _derive_action(
         return "rerun_cancelled"
 
     real_checks = [check for check in checks if check.classification == "real_failure"]
+    if _pending_named_non_required_rollup_gates(checks):
+        return "monitor_named_rollup_gates"
     if real_checks and any(_has_superseding_dependency_pr(check) for check in real_checks):
         unsuperseded = [check for check in real_checks if not _has_superseding_dependency_pr(check)]
         if all(_has_model_quorum_blocker(check) for check in unsuperseded):
@@ -866,6 +892,13 @@ def build_prompt(
                 "",
             ]
         )
+    elif action == "monitor_named_rollup_gates":
+        lines.extend(
+            [
+                f"Goal: monitor #{pr_number} at head {pin} until named non-required rollup gates settle. Do not collect model evidence, merge, rerun, push, edit files, start cleanup, or start broader queue settlement while these gates are pending.",
+                "",
+            ]
+        )
     elif action == "diagnose_branch_conflict":
         lines.extend(
             [
@@ -980,6 +1013,10 @@ def build_prompt(
         )
     elif action == "monitor":
         lines.append("If checks are still in progress, report exact names and stop.")
+    elif action == "monitor_named_rollup_gates":
+        lines.append(
+            "Named non-required rollup gates are still pending. Report the exact pending names and stop; do not collect model evidence or start repair until they settle."
+        )
     elif action == "green":
         lines.append(
             f"If #{pr_number} remains green/green-equivalent, run review-queue merge-packet for the PR. Do not merge."

--- a/tests/scripts/test_pr_check_followup.py
+++ b/tests/scripts/test_pr_check_followup.py
@@ -123,7 +123,7 @@ def test_in_progress_checks_monitor_without_repair_or_rerun() -> None:
         _pr(
             [
                 {
-                    "workflowName": "Tests",
+                    "workflowName": "Metrics Drift",
                     "name": "Type Check",
                     "status": "IN_PROGRESS",
                     "conclusion": "",
@@ -136,6 +136,52 @@ def test_in_progress_checks_monitor_without_repair_or_rerun() -> None:
     assert result.action == "monitor"
     assert result.rerun_commands == []
     assert "monitor #7443" in result.prompt
+
+
+def test_pending_named_rollup_gate_preempts_model_evidence_prompt() -> None:
+    result = followup.build_followup_result(
+        _pr(
+            [
+                _check(
+                    "Aragora Merge Quorum",
+                    "aragora-merge-quorum",
+                    "FAILURE",
+                    run_id="7",
+                    job_id="70",
+                ),
+                {
+                    "workflowName": "Tests",
+                    "name": "test-fast (infra, tests/nomic tests/control_plane, infra, 30)",
+                    "status": "IN_PROGRESS",
+                    "conclusion": "",
+                    "detailsUrl": ("https://github.com/synaptent/aragora/actions/runs/8/job/80"),
+                    "startedAt": "2026-05-23T19:27:02Z",
+                    "completedAt": "",
+                },
+            ],
+            head="evidence-head",
+        ),
+        run_data_by_id={
+            "7": {
+                "headSha": "evidence-head",
+                "workflowName": "Aragora Merge Quorum",
+                "jobs": [_job("aragora-merge-quorum", "failure", job_id="70")],
+            }
+        },
+        log_summary_by_job={
+            "70": [
+                "PR #7474 | Tier 2 | status=needs_model_review_quorum | verdict=collect_model_quorum_before_merge",
+                "- model quorum incomplete: 0/2 signal(s)",
+                "- focused adversarial dogfood evidence is required",
+            ]
+        },
+    )
+
+    assert result.action == "monitor_named_rollup_gates"
+    assert result.rerun_commands == []
+    assert "named non-required rollup gates settle" in result.prompt
+    assert "Tests / test-fast (infra" in result.prompt
+    assert "Post exactly one valid PR comment" not in result.prompt
 
 
 def test_expected_head_drift_stops_followup() -> None:


### PR DESCRIPTION
## Summary
- classify pending named rollup gates before merge-quorum model evidence routing
- emit a monitor prompt that tells operators not to collect evidence or repair while Tests/Security/Release/Review/Core/Smoke gates are still pending
- add focused coverage for the model-quorum plus pending Tests rollup case

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q -p no:cacheprovider tests/scripts/test_pr_check_followup.py
- ruff check scripts/pr_check_followup.py tests/scripts/test_pr_check_followup.py
- ruff format --check scripts/pr_check_followup.py tests/scripts/test_pr_check_followup.py
- git diff --check
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- /Users/armand/.pyenv/versions/3.11.11/bin/python scripts/pr_check_followup.py --pr 7736 --head 212fd463d477c2a906de980a7073d7d9d60b7240 --json (returned action=monitor_named_rollup_gates)
