### PR TITLE
fix(tier4): skip redundant quorum status patch

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -188,6 +188,12 @@ TIER_4_PREFIXES: tuple[str, ...] = (
     # registration surface follow the same human-chain-of-trust rule as
     # ``review_queue.py`` itself.
     "aragora/cli/parser.py",
+    # Settlement and merge helpers can mark human-settlement status, reconcile
+    # branch protection, or merge/admin-merge PRs. A PR changing those helpers
+    # is changing the authority surface that future settlement runs trust.
+    "scripts/settle_tier4_pr.py",
+    "scripts/settle_one_pr.py",
+    "scripts/merge_codex_automation_prs.py",
 )
 PARKED_LABELS: tuple[str, ...] = ("stale", "do-not-merge", "wip", "blocked")
 MERGE_QUORUM_CHECK_NAME = "aragora-merge-quorum"

--- a/scripts/settle_tier4_pr.py
+++ b/scripts/settle_tier4_pr.py
@@ -27,6 +27,7 @@ TRUSTED_OPERATOR_LOGINS_ENV = "ARAGORA_TIER4_TRUSTED_OPERATORS"
 PermissionChecker = Callable[[str], bool]
 HUMAN_SETTLEMENT_CONTEXT = "aragora/human-settlement"
 HUMAN_SETTLEMENT_STATUS_BLOCKER = f"missing or unsuccessful {HUMAN_SETTLEMENT_CONTEXT} status"
+MERGE_QUORUM_CONTEXT = "aragora-merge-quorum"
 OPERATOR_COMMENT_BLOCKER = "missing repo-visible Tier 4 operator settlement comment"
 REQUIRED_CHECKS_BLOCKER = "required checks are missing"
 TIER4_EVIDENCE_BLOCKER = "missing Tier 4 model/dogfood settlement evidence"
@@ -636,7 +637,7 @@ def _load_live_inputs(
     return pr_view, merge_packet, required_checks
 
 
-def _required_status_check_patch(*, repo: str, cwd: Path) -> tuple[list[str], str]:
+def _required_status_check_patch(*, repo: str, cwd: Path) -> tuple[list[str], str] | None:
     endpoint = f"repos/{repo}/branches/main/protection/required_status_checks"
     current = _run_json(["gh", "api", endpoint], cwd=cwd)
     contexts = current.get("contexts")
@@ -652,7 +653,9 @@ def _required_status_check_patch(*, repo: str, cwd: Path) -> tuple[list[str], st
             else []
         )
     context_set = {str(context) for context in contexts if str(context)}
-    context_set.add("aragora-merge-quorum")
+    if MERGE_QUORUM_CONTEXT in context_set:
+        return None
+    context_set.add(MERGE_QUORUM_CONTEXT)
     payload = {"strict": bool(current.get("strict", True)), "contexts": sorted(context_set)}
     return ["gh", "api", "--method", "PATCH", endpoint, "--input", "-"], json.dumps(payload)
 
@@ -776,9 +779,11 @@ def _apply_settlement(
         )
         commands.append(reviews_command)
 
-        checks_command, checks_payload = _required_status_check_patch(repo=repo, cwd=cwd)
-        _run_command(checks_command, cwd=cwd, input_text=checks_payload)
-        commands.append(checks_command)
+        checks_patch = _required_status_check_patch(repo=repo, cwd=cwd)
+        if checks_patch is not None:
+            checks_command, checks_payload = checks_patch
+            _run_command(checks_command, cwd=cwd, input_text=checks_payload)
+            commands.append(checks_command)
 
         enforce_command = [
             "gh",

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -1018,6 +1018,9 @@ class TestModelReviewQuorum:
             # Merge-authority self-modification: see TIER_4_PREFIXES rationale.
             (["aragora/cli/commands/review_queue.py"], 4),
             (["aragora/cli/parser.py"], 4),
+            (["scripts/settle_tier4_pr.py"], 4),
+            (["scripts/settle_one_pr.py"], 4),
+            (["scripts/merge_codex_automation_prs.py"], 4),
         ],
     )
     def test_classifies_merge_tiers(self, files: list[str], expected_tier: int) -> None:

--- a/tests/scripts/test_settle_tier4_pr.py
+++ b/tests/scripts/test_settle_tier4_pr.py
@@ -847,6 +847,96 @@ def test_apply_uses_valid_command_sequence(monkeypatch: Any, tmp_path: Path) -> 
     assert commands[-1][0][-1].endswith("/protection/enforce_admins")
 
 
+def test_required_status_check_patch_skips_when_quorum_already_required(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        settler,
+        "_run_json",
+        lambda command, cwd: {
+            "strict": False,
+            "contexts": ["Generate & Validate", "aragora-merge-quorum", "lint"],
+        },
+    )
+
+    patch = settler._required_status_check_patch(repo="owner/repo", cwd=tmp_path)
+
+    assert patch is None
+
+
+def test_required_status_check_patch_adds_missing_quorum_from_checks(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        settler,
+        "_run_json",
+        lambda command, cwd: {
+            "strict": False,
+            "checks": [
+                {"context": "Generate & Validate", "app_id": 15368},
+                {"context": "lint", "app_id": 15368},
+            ],
+        },
+    )
+
+    command, payload = settler._required_status_check_patch(repo="owner/repo", cwd=tmp_path)
+
+    assert command == [
+        "gh",
+        "api",
+        "--method",
+        "PATCH",
+        "repos/owner/repo/branches/main/protection/required_status_checks",
+        "--input",
+        "-",
+    ]
+    assert settler.json.loads(payload) == {
+        "strict": False,
+        "contexts": ["Generate & Validate", "aragora-merge-quorum", "lint"],
+    }
+
+
+def test_apply_skips_required_status_check_patch_when_quorum_already_required(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    commands: list[tuple[list[str], str | None]] = []
+
+    monkeypatch.setattr(
+        settler,
+        "_load_live_inputs",
+        lambda pr, cwd: (
+            _pr_view(head, comments=[_authorized_comment(head)]),
+            _tier4_packet(),
+            _valid_checks(),
+        ),
+    )
+    monkeypatch.setattr(
+        settler,
+        "_run_command",
+        lambda command, cwd, input_text=None: commands.append((command, input_text)),
+    )
+    monkeypatch.setattr(
+        settler,
+        "_required_status_check_patch",
+        lambda repo, cwd: None,
+    )
+    monkeypatch.setattr(
+        settler,
+        "_branch_protection_snapshot",
+        lambda repo, cwd: {},
+    )
+
+    rc = settler.main(["--apply", "--pr", "7423", "--head", head, "--cwd", str(tmp_path)])
+
+    assert rc == 0
+    command_lines = [" ".join(command) for command, _payload in commands]
+    assert command_lines[0].endswith(head)
+    assert any("required_pull_request_reviews" in line for line in command_lines)
+    assert not any("required_status_checks" in line for line in command_lines)
+    assert any("enforce_admins" in line for line in command_lines)
+
+
 def test_apply_merge_only_authorization_skips_branch_protection(
     monkeypatch: Any, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary
- Avoids re-patching main required status checks during Tier-4 apply when aragora-merge-quorum is already present.
- Keeps branch-protection reconciliation idempotent and avoids reporting a successful merge as failed because of an unnecessary required_status_checks PATCH.
- Adds focused coverage for skip/add behavior and the apply command sequence.

## Evidence
- Observed after #7740: settle_tier4_pr.py --apply returned non-zero after #7740 merged, while branch protection restored cleanly and aragora/human-settlement was success.
- Current fix is deliberately narrow: no status-check PATCH is issued when the quorum context is already required.

## Tests
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/armand/.pyenv/versions/3.11.11/bin/python3 -m pytest -q tests/scripts/test_settle_tier4_pr.py
- python3 -m ruff check scripts/settle_tier4_pr.py tests/scripts/test_settle_tier4_pr.py
- python3 -m ruff format --check scripts/settle_tier4_pr.py tests/scripts/test_settle_tier4_pr.py
- git diff --check

## Risk
Tier 4 governance tooling surface. Draft until reviewed and settled.
