### PR TITLE
fix(worktree): detect squash-merged branches in autopilot cleanup

### DIFF
--- a/scripts/codex_worktree_autopilot.py
+++ b/scripts/codex_worktree_autopilot.py
@@ -213,6 +213,13 @@ def _classify_session(
     last_activity = _session_last_activity(session)
     within_ttl = bool(last_activity and (_utc_now() - last_activity) <= ttl)
     ahead = _branch_ahead_count(repo_root, base_branch, branch) if branch else 0
+    # A squash-merged branch reports ahead>0 forever (its commits never become
+    # ancestors of base). Fall back to a content comparison so reclaimable
+    # worktrees are not stuck in skipped_unmerged. Only checked when ahead>0 to
+    # avoid the extra git calls on the common already-ancestor path.
+    effectively_merged = bool(
+        branch and ahead > 0 and _branch_effectively_merged(repo_root, base_branch, branch)
+    )
     dirty = _safe_worktree_dirty(repo_root, path, base_branch) if tracked_worktree else False
 
     cleanup_lock = False
@@ -233,7 +240,11 @@ def _classify_session(
         cleanup_lock_reason = "active_lease"
     elif tracked_worktree and within_ttl:
         lifecycle_state = "grace"
-    elif str(lease.get("lease_status")) == "expired" or dirty or ahead > 0:
+    elif (
+        str(lease.get("lease_status")) == "expired"
+        or dirty
+        or (ahead > 0 and not effectively_merged)
+    ):
         lifecycle_state = "expired"
     else:
         lifecycle_state = "safe-to-clean"
@@ -247,6 +258,7 @@ def _classify_session(
         "active_session": active_session,
         "dirty": dirty,
         "ahead": ahead,
+        "effectively_merged": effectively_merged,
         "base_branch": base_branch,
         "base_sha": _resolve_ref_sha(repo_root, _base_ref(base_branch)),
         "last_heartbeat_at": lease.get("last_heartbeat_at"),
@@ -1056,6 +1068,45 @@ def _branch_ahead_count(repo_root: Path, base: str, branch: str) -> int:
     return int(out) if out.isdigit() else 0
 
 
+def _branch_effectively_merged(repo_root: Path, base: str, branch: str) -> bool:
+    """Return True if the branch's net changes are already present in ``base``.
+
+    Commit-ancestry (``rev-list base..branch``) cannot see a **squash-merge**:
+    the squashed commit on ``base`` is brand new, so the branch's original
+    commits never become ancestors and ``ahead`` stays positive forever. That
+    is the root cause of worktrees being stuck in ``skipped_unmerged`` and
+    never reclaimed.
+
+    This compares *content* instead of ancestry. For every path the branch
+    changed (relative to its merge-base with ``base``), it checks whether that
+    path is byte-identical between the base tip and the branch tip. If they all
+    match, the branch's work is fully reflected in ``base`` (whether it landed
+    via merge, rebase, or squash) and the worktree is safe to reclaim.
+
+    Fail-closed: any git error, an unresolvable merge-base, or a real content
+    difference returns False so the worktree is conservatively kept.
+    """
+    base_ref = _base_ref(base)
+    merge_base_proc = _run_git(repo_root, "merge-base", base_ref, branch)
+    if merge_base_proc.returncode != 0:
+        return False
+    merge_base = merge_base_proc.stdout.strip()
+    if not merge_base:
+        return False
+    changed_proc = _run_git(repo_root, "diff", "--name-only", f"{merge_base}..{branch}")
+    if changed_proc.returncode != 0:
+        return False
+    changed_paths = [line for line in changed_proc.stdout.splitlines() if line.strip()]
+    if not changed_paths:
+        # Branch introduces nothing over the merge-base: nothing to integrate.
+        return True
+    # ``git diff --quiet`` exits 0 when there is no difference, 1 when there is,
+    # and >1 on error. Restrict to the branch's own paths so unrelated newer
+    # work on base does not mask a genuine squash-merge.
+    diff_proc = _run_git(repo_root, "diff", "--quiet", base_ref, branch, "--", *changed_paths)
+    return diff_proc.returncode == 0
+
+
 def _pid_alive(pid: int) -> bool:
     if pid <= 0:
         return False
@@ -1293,7 +1344,7 @@ def cmd_cleanup(args: argparse.Namespace) -> int:
 
         if metadata["tracked_worktree"] and branch:
             ahead = metadata["ahead"]
-            if ahead > 0 and not args.force_unmerged:
+            if ahead > 0 and not metadata.get("effectively_merged") and not args.force_unmerged:
                 kept.append(session)
                 skipped_unmerged += 1
                 results.append(

--- a/tests/scripts/test_codex_worktree_autopilot.py
+++ b/tests/scripts/test_codex_worktree_autopilot.py
@@ -2119,3 +2119,93 @@ def test_cmd_status_reports_lifecycle_and_lock_metadata(
     assert payload["sessions"][0]["lifecycle_state"] == "active"
     assert payload["sessions"][0]["cleanup_lock_reason"] == "active_session"
     assert payload["sessions"][1]["lifecycle_state"] == "safe-to-clean"
+
+
+# --- squash-merge detection (real git repos) ---------------------------------
+
+
+def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True, check=True)
+
+
+def _init_repo_with_origin(tmp_path: Path) -> Path:
+    """Create a work repo whose ``origin/main`` tracks a bare remote."""
+    origin = tmp_path / "origin.git"
+    subprocess.run(
+        ["git", "init", "--bare", "-b", "main", str(origin)],
+        check=True,
+        capture_output=True,
+    )
+    work = tmp_path / "work"
+    subprocess.run(["git", "clone", str(origin), str(work)], check=True, capture_output=True)
+    _git(work, "config", "user.email", "t@example.com")
+    _git(work, "config", "user.name", "Tester")
+    (work / "base.txt").write_text("base\n", encoding="utf-8")
+    _git(work, "add", "-A")
+    _git(work, "commit", "-m", "init")
+    _git(work, "branch", "-M", "main")
+    _git(work, "push", "-u", "origin", "main")
+    return work
+
+
+def test_branch_effectively_merged_detects_squash_merge(tmp_path):
+    import importlib
+
+    mod = importlib.import_module("codex_worktree_autopilot")
+    work = _init_repo_with_origin(tmp_path)
+
+    _git(work, "checkout", "-b", "feature")
+    (work / "feature.txt").write_text("feature work\n", encoding="utf-8")
+    _git(work, "add", "-A")
+    _git(work, "commit", "-m", "feature change")
+
+    # Squash-merge feature into main, then publish to origin.
+    _git(work, "checkout", "main")
+    _git(work, "merge", "--squash", "feature")
+    _git(work, "commit", "-m", "squash: land feature")
+    _git(work, "push", "origin", "main")
+    _git(work, "fetch", "origin")
+
+    # Commit-ancestry still reports the branch as ahead (the squash defeats it)...
+    assert mod._branch_ahead_count(work, "origin/main", "feature") > 0
+    # ...but the content-based check correctly sees the work as merged.
+    assert mod._branch_effectively_merged(work, "main", "feature") is True
+
+
+def test_branch_effectively_merged_false_for_genuinely_unmerged(tmp_path):
+    import importlib
+
+    mod = importlib.import_module("codex_worktree_autopilot")
+    work = _init_repo_with_origin(tmp_path)
+
+    _git(work, "checkout", "-b", "feature")
+    (work / "feature.txt").write_text("unmerged work\n", encoding="utf-8")
+    _git(work, "add", "-A")
+    _git(work, "commit", "-m", "feature change")
+    _git(work, "fetch", "origin")
+
+    # Nothing landed on origin/main, so the branch is genuinely unmerged.
+    assert mod._branch_effectively_merged(work, "main", "feature") is False
+
+
+def test_branch_effectively_merged_false_when_base_diverged_on_branch_paths(tmp_path):
+    import importlib
+
+    mod = importlib.import_module("codex_worktree_autopilot")
+    work = _init_repo_with_origin(tmp_path)
+
+    _git(work, "checkout", "-b", "feature")
+    (work / "feature.txt").write_text("feature v1\n", encoding="utf-8")
+    _git(work, "add", "-A")
+    _git(work, "commit", "-m", "feature change")
+
+    # Base independently changes the SAME path to different content.
+    _git(work, "checkout", "main")
+    (work / "feature.txt").write_text("base-owned different content\n", encoding="utf-8")
+    _git(work, "add", "-A")
+    _git(work, "commit", "-m", "base touches feature.txt")
+    _git(work, "push", "origin", "main")
+    _git(work, "fetch", "origin")
+
+    # Branch path differs between base tip and branch tip → conservatively kept.
+    assert mod._branch_effectively_merged(work, "main", "feature") is False


### PR DESCRIPTION
## Problem
`codex_worktree_autopilot.py cleanup` decides a branch is unmerged via commit-ancestry (`git rev-list base..branch`). A **squash-merge** creates a brand-new commit on base, so the branch's original commits never become ancestors and `ahead` stays >0 **forever** → the worktree is pinned in `skipped_unmerged` and never reclaimed. Observed in dogfood: **0/299 removed** despite the work having landed, which pushes operators toward the forbidden raw `rm -rf` path (CLAUDE.md explicitly bans it).

## Fix
`_branch_effectively_merged()` — a **content** comparison: a branch counts as merged when every path it changed (relative to its merge-base with base) is byte-identical between the base tip and the branch tip. Covers squash, rebase, and ordinary merges. **Fail-closed** on any git error, unresolvable merge-base, or genuine difference, so a worktree is only reclaimed when its work is provably present in base. Both `ahead > 0` gates (lifecycle classification + cleanup skip) now consult it.

## Tests
3 real-git-repo tests added (squash detected as merged; genuinely-unmerged kept; base-diverged-on-branch-paths conservatively kept). Full autopilot suite: **43 passed**. ruff clean.

## Dogfood provenance
Proposed by adversarial debate receipts `22f16ee2` / `04df0842` and validated against the live worktree-sprawl pain (the 5 stale `/tmp/wt-*` worktrees this very session left behind).

🤖 Generated with [Claude Code](https://claude.com/claude-code)