### PR TITLE
fix(settle-one): reuse preloaded policy metadata

### DIFF
--- a/scripts/settle_one_pr.py
+++ b/scripts/settle_one_pr.py
@@ -1019,6 +1019,10 @@ def load_pr_policy_metadata(
     return {}, command
 
 
+def _has_policy_file_scope(metadata: dict[str, Any]) -> bool:
+    return "files" in metadata
+
+
 def load_active_owned_prs(cwd: Path) -> tuple[set[int], dict[str, Any]]:
     payload, command = _run_json(
         ["python3", "scripts/agent_bridge.py", "operator-snapshot", "--json"],
@@ -1115,7 +1119,11 @@ def select_candidate_with_lazy_policy_metadata(
 ) -> tuple[dict[str, Any] | None, list[str], list[dict[str, Any]], list[dict[str, Any]]]:
     """Select a candidate while loading heavy file metadata only as needed."""
     metadata_commands: list[dict[str, Any]] = []
-    loaded: set[int] = set()
+    loaded: set[int] = {
+        pr_number
+        for pr_number, metadata in policy_metadata.items()
+        if isinstance(metadata, dict) and _has_policy_file_scope(metadata)
+    }
     unavailable: set[int] = set()
     accumulated_exclusions: list[dict[str, Any]] = []
     max_attempts = len([entry for entry in packet.get("entries") or [] if isinstance(entry, dict)])

--- a/tests/scripts/test_settle_one_pr.py
+++ b/tests/scripts/test_settle_one_pr.py
@@ -1188,6 +1188,110 @@ def test_lazy_policy_metadata_continues_past_failed_pr_view(monkeypatch) -> None
     ]
 
 
+def test_explicit_pr_reuses_preloaded_policy_file_scope(monkeypatch) -> None:
+    policy_view_calls = 0
+
+    def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
+        nonlocal policy_view_calls
+        del cwd, timeout
+        if args[:3] == ["python3", "scripts/agent_bridge.py", "operator-snapshot"]:
+            return {"lanes": []}, {"command": "snapshot", "returncode": 0}
+        if args[:3] == ["python3", "scripts/identify_lane_owner.py", "--pr"]:
+            return {"status": "completed"}, {"command": "owner", "returncode": 0}
+        if args[:3] == ["python3", "scripts/read_operator_steering.py", "--pr"]:
+            return {"message_count": 0}, {"command": "mailbox", "returncode": 0}
+        if (
+            args[:3] == ["gh", "pr", "view"]
+            and args[3] == "7451"
+            and args[5] == settle_one_pr.PR_POLICY_FIELDS
+        ):
+            policy_view_calls += 1
+            if policy_view_calls > 1:
+                return None, {
+                    "command": "policy-view-7451",
+                    "returncode": 1,
+                    "stderr": "error connecting to api.github.com",
+                }
+            return (
+                {
+                    "number": 7451,
+                    "title": "docs: candidate",
+                    "headRefName": "codex/docs-candidate",
+                    "mergeable": "MERGEABLE",
+                    "mergeStateStatus": "CLEAN",
+                    "files": [{"path": "docs/status/example.md"}],
+                },
+                {"command": "policy-view-7451", "returncode": 0},
+            )
+        if (
+            args[:3] == ["gh", "pr", "view"]
+            and args[3] == "7451"
+            and "statusCheckRollup" in args[5]
+        ):
+            return (
+                {
+                    "headRefOid": "0000000000000000000000000000000000007451",
+                    "baseRefName": "main",
+                    "isDraft": False,
+                    "mergeable": "MERGEABLE",
+                    "mergeStateStatus": "CLEAN",
+                    "statusCheckRollup": [
+                        {
+                            "__typename": "CheckRun",
+                            "name": "aragora-merge-quorum",
+                            "conclusion": "SUCCESS",
+                        }
+                    ],
+                },
+                {"command": "view-7451", "returncode": 0},
+            )
+        if args[:2] == ["gh", "api"] and args[2].endswith("/required_status_checks"):
+            return (
+                {"checks": [{"context": "aragora-merge-quorum", "app_id": 15368}]},
+                {"command": "protection", "returncode": 0},
+            )
+        if args[:2] == ["gh", "api"] and args[2].endswith("/check-runs?per_page=100"):
+            return (
+                {
+                    "check_runs": [
+                        {
+                            "name": "aragora-merge-quorum",
+                            "conclusion": "success",
+                            "app": {"id": 15368},
+                        }
+                    ]
+                },
+                {"command": "check-runs", "returncode": 0},
+            )
+        if args[:3] == ["gh", "pr", "checks"]:
+            return (
+                [{"name": "aragora-merge-quorum", "state": "SUCCESS"}],
+                {"command": "checks", "returncode": 0},
+            )
+        raise AssertionError(args)
+
+    monkeypatch.setattr(settle_one_pr, "_run_json", fake_run_json)
+
+    report = build_report(
+        _packet(
+            _entry(
+                7451, tier=0, reasons=["docs/tests/status-only", "model quorum incomplete: 0/1"]
+            ),
+        ),
+        cwd=Path.cwd(),
+        state_root=Path.cwd(),
+        explicit_pr=7451,
+        exclude_prs=set(),
+        live=True,
+        validate=False,
+    )
+
+    assert policy_view_calls == 1
+    assert report["selected_pr"] == 7451
+    assert report["status"] == "ready_for_minimum_evidence"
+    assert report["policy_exclusions"] == []
+
+
 def test_build_report_fails_closed_when_selected_policy_metadata_unavailable(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes a steward false-negative found while reconciling #7751: `scripts/settle_one_pr.py` could load explicit PR policy metadata successfully, then lazily issue the same `gh pr view --json number,title,headRefName,author,mergeable,mergeStateStatus,files` call again. If the duplicate call hit a transient GitHub API failure, the steward reported `no_candidate` / `selected-candidate policy metadata unavailable` even though the candidate had already been file-scope classified.

This keeps fail-closed behavior for truly unavailable metadata, while reusing already file-scoped policy metadata for explicit PRs.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/scripts/test_settle_one_pr.py`
- `python3 -m ruff check scripts/settle_one_pr.py tests/scripts/test_settle_one_pr.py`
- `python3 -m ruff format --check scripts/settle_one_pr.py tests/scripts/test_settle_one_pr.py`
- `git diff --check origin/main...HEAD`
- push hooks: ruff, ruff format, mypy, gitleaks, portability guard

## Notes

Opened as draft because this changes settlement/steward behavior and should go through the normal Aragora evidence gate before merge.
