### PR TITLE
fix(review): make grok a default counting fallback for codex outages

### DIFF
--- a/aragora/swarm/review_routing.py
+++ b/aragora/swarm/review_routing.py
@@ -20,7 +20,14 @@ from aragora.config.secrets import get_secret_presence
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_REVIEW_PROVIDER_ORDER = ("codex", "claude", "openrouter")
+# grok precedes openrouter so that when codex (the usual distinct counter) is
+# unavailable, the next default fallback is a provider whose family still COUNTS
+# toward the heterogeneous merge quorum (claude/codex/grok/factory). openrouter
+# does not count, so leaving it as the only fallback turned codex into a single
+# point of failure for quorum. grok stays key-gated: if XAI_API_KEY/GROK_API_KEY
+# is unset its preflight fails and routing falls through to openrouter as before,
+# so this is non-breaking when grok is not configured.
+DEFAULT_REVIEW_PROVIDER_ORDER = ("codex", "claude", "grok", "openrouter")
 DEFAULT_CLAUDE_REVIEW_PROFILES = tuple(f"max-{index:02d}" for index in range(1, 14))
 DEFAULT_POOL_HEALTH_TTL_SECONDS = 3600.0
 _POOL_HEALTH_RELATIVE_PATH = ".aragora/claude_pool_health.json"

--- a/tests/swarm/test_review_routing.py
+++ b/tests/swarm/test_review_routing.py
@@ -560,3 +560,30 @@ async def test_generate_review_response_marks_billing_exhaustion() -> None:
             "detail": "Reviewer credits are exhausted.",
         }
     ]
+
+
+def test_default_provider_order_includes_grok_as_counting_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """grok must be a DEFAULT fallback (no env override) so codex outages do not
+    strand the merge quorum on the non-counting openrouter family.
+
+    Regression guard for the codex single-point-of-failure: when codex is the
+    requested reviewer and the worker is claude, the default candidate order
+    must offer grok (a counting family) *before* openrouter (which does not
+    count toward the heterogeneous quorum).
+    """
+    monkeypatch.delenv("ARAGORA_REVIEW_PROVIDER_ORDER", raising=False)
+    monkeypatch.setenv("ARAGORA_CLAUDE_REVIEW_PROFILES", "max-01")
+
+    candidates = resolve_review_candidates(
+        worker_model="claude",
+        preferred_review_model="codex",
+    )
+    labels = [candidate.label for candidate in candidates]
+
+    assert "grok" in labels, labels
+    assert "openrouter" in labels, labels
+    assert labels.index("grok") < labels.index("openrouter"), labels
+    # codex stays first (the preferred reviewer); grok is the counting fallback.
+    assert labels[0] == "codex", labels


### PR DESCRIPTION
## Problem
Reviewer routing (`aragora/swarm/review_routing.py`) already supports **grok** as a provider (preflight + run + family detection), but `DEFAULT_REVIEW_PROVIDER_ORDER` was `(codex, claude, openrouter)` — grok was only reachable via an explicit `--reviewer grok` or an `ARAGORA_REVIEW_PROVIDER_ORDER` override.

So **by default**, when codex (the usual distinct counter) is unavailable, the only fallback is **openrouter**, whose family does **not** count toward the heterogeneous merge quorum (only claude/codex/grok/factory count). A codex outage therefore strands reviews with no counting second signal — codex is a **single point of failure** for quorum. Observed in dogfood receipt `1fc07e93`.

## Fix
Add grok to the default order, positioned **before** openrouter, so the first default fallback after codex is a **counting** family. One line + rationale comment.

**Non-breaking / key-gated:** grok's preflight requires `XAI_API_KEY`/`GROK_API_KEY`. If unset, preflight fails and routing falls through to openrouter exactly as before. Heterogeneity integrity is preserved — grok evidence is labeled `grok`, never silently substituted for codex.

## Tests
New regression test asserts grok precedes openrouter in the default (no-env-override) candidate order, with codex still first. Full routing suite: **22 passed**. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)