### PR TITLE
[codex] split Tier 4 settlement apply modes

### DIFF
--- a/scripts/settle_tier4_pr.py
+++ b/scripts/settle_tier4_pr.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Check or apply an exact-head Tier 4 PR settlement.
+"""Check, record, or merge-apply an exact-head Tier 4 PR settlement.
 
 Tier 4 automation may prepare a packet, but merge/protection mutation requires
 a repo-visible operator settlement comment naming the exact head and action.
@@ -469,6 +469,30 @@ def _packet_marks_tier4_human_settlement(merge_packet: dict[str, Any], *, pr: in
     return isinstance(required, list) and str(pr) in {str(item) for item in required}
 
 
+def _packet_marks_tier4_settlement_surface(merge_packet: dict[str, Any], *, pr: int) -> bool:
+    entry = _entry_for_pr(merge_packet, pr=pr)
+    if not entry:
+        return False
+    if bool(entry.get("requires_human_risk_settlement")):
+        return True
+    required = merge_packet.get("human_risk_settlement_required")
+    if isinstance(required, list) and str(pr) in {str(item) for item in required}:
+        return True
+    tier = entry.get("tier")
+    try:
+        return int(tier) >= 4
+    except (TypeError, ValueError):
+        return False
+
+
+def _required_check_name(check: dict[str, Any]) -> str:
+    return str(check.get("name") or check.get("workflow") or "required check")
+
+
+def _required_check_state(check: dict[str, Any]) -> str:
+    return str(check.get("state") or check.get("conclusion") or "UNKNOWN").upper()
+
+
 def evaluate_tier4_gate(
     *,
     pr: int,
@@ -494,8 +518,8 @@ def evaluate_tier4_gate(
     if merge_state in {"DIRTY", "CONFLICTING"}:
         blockers.append(f"PR #{pr} is {merge_state}")
     for check in required_checks or []:
-        name = str(check.get("name") or check.get("workflow") or "required check")
-        state = str(check.get("state") or check.get("conclusion") or "UNKNOWN").upper()
+        name = _required_check_name(check)
+        state = _required_check_state(check)
         if not _state_is_success(state):
             blockers.append(f"required check {name} is {state}")
     not_ready = merge_packet.get("not_ready")
@@ -563,6 +587,59 @@ def evaluate_tier4_gate(
         "blockers": blockers,
         "authorized_actions": sorted(authorized_actions),
         **diagnostic_report,
+    }
+
+
+def evaluate_tier4_settlement_preconditions(
+    *,
+    pr: int,
+    expected_head: str,
+    pr_view: dict[str, Any],
+    merge_packet: dict[str, Any],
+    required_checks: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    blockers: list[str] = []
+    actual_head = str(pr_view.get("headRefOid") or "")
+    if actual_head != expected_head:
+        blockers.append(f"head mismatch: expected {expected_head}, got {actual_head}")
+    if str(pr_view.get("state") or "").upper() != "OPEN":
+        blockers.append(f"PR #{pr} is not open")
+    if bool(pr_view.get("isDraft")):
+        blockers.append(f"PR #{pr} is draft")
+    merge_state = str(pr_view.get("mergeStateStatus") or "")
+    if merge_state in {"DIRTY", "CONFLICTING"}:
+        blockers.append(f"PR #{pr} is {merge_state}")
+
+    if not required_checks:
+        blockers.append(REQUIRED_CHECKS_BLOCKER)
+    else:
+        for check in required_checks:
+            name = _required_check_name(check)
+            state = _required_check_state(check)
+            if _state_is_success(state) or name == "aragora-merge-quorum":
+                continue
+            blockers.append(f"required check {name} is {state}")
+
+    not_ready = merge_packet.get("not_ready")
+    if isinstance(not_ready, list):
+        allowed_not_ready = set(ALLOWED_TIER4_NOT_READY)
+        allowed_not_ready.add(str(pr))
+        unexpected = sorted({str(item) for item in not_ready} - allowed_not_ready)
+        if unexpected:
+            blockers.append(f"merge-packet has unexpected blockers: {', '.join(unexpected)}")
+
+    if not _packet_marks_tier4_settlement_surface(merge_packet, pr=pr):
+        blockers.append("merge-packet does not mark Tier 4 human-risk settlement")
+    if not _packet_has_counted_tier4_evidence(merge_packet, pr=pr):
+        blockers.append(TIER4_EVIDENCE_BLOCKER)
+
+    return {
+        "ok": not blockers,
+        "pr": pr,
+        "expected_head": expected_head,
+        "actual_head": actual_head,
+        "merge_state": merge_state,
+        "blockers": blockers,
     }
 
 
@@ -664,6 +741,19 @@ def _run_command(command: list[str], *, cwd: Path, input_text: str | None = None
     subprocess.run(command, cwd=cwd, input=input_text, text=True, check=True, timeout=180)
 
 
+def _run_text_command(command: list[str], *, cwd: Path, input_text: str | None = None) -> str:
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        input=input_text,
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=180,
+    )
+    return result.stdout.strip()
+
+
 def _branch_protection_snapshot(*, repo: str, cwd: Path) -> dict[str, Any]:
     base = f"repos/{repo}/branches/main/protection"
     snapshot: dict[str, Any] = {}
@@ -729,7 +819,39 @@ def _restore_branch_protection(*, repo: str, cwd: Path, snapshot: dict[str, Any]
     return errors
 
 
-def _apply_settlement(
+def _apply_settlement_signal(*, pr: int, head: str, repo: str, cwd: Path) -> list[list[str]]:
+    comment_command = [
+        "gh",
+        "pr",
+        "comment",
+        str(pr),
+        "--body",
+        _settlement_comment_template(pr=pr, head=head),
+    ]
+    status_command = [
+        "gh",
+        "api",
+        "--method",
+        "POST",
+        f"repos/{repo}/statuses/{head}",
+        "-f",
+        "state=success",
+        "-f",
+        f"context={HUMAN_SETTLEMENT_CONTEXT}",
+        "-f",
+        f"description=Tier 4 exact-head human-risk settlement recorded for PR #{pr}",
+    ]
+    try:
+        comment_url = _run_text_command(comment_command, cwd=cwd).strip()
+        if comment_url:
+            status_command.extend(["-f", f"target_url={comment_url}"])
+        _run_command(status_command, cwd=cwd)
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise RuntimeError(f"Tier 4 settlement signal failed: {exc}") from exc
+    return [comment_command, status_command]
+
+
+def _apply_merge(
     *,
     pr: int,
     head: str,
@@ -807,7 +929,16 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     mode = parser.add_mutually_exclusive_group(required=True)
     mode.add_argument("--check", action="store_true")
-    mode.add_argument("--apply", action="store_true")
+    mode.add_argument(
+        "--settle-only",
+        action="store_true",
+        help="Post the exact-head Tier 4 settlement comment/status only; never merge.",
+    )
+    mode.add_argument(
+        "--merge-apply",
+        action="store_true",
+        help="Apply the already-settled Tier 4 merge/protection action.",
+    )
     parser.add_argument("--pr", type=int, required=True)
     parser.add_argument("--head", required=True)
     parser.add_argument("--repo", default=DEFAULT_REPO)
@@ -831,22 +962,41 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     try:
         pr_view, merge_packet, required_checks = _load_live_inputs(args.pr, cwd=args.cwd)
-        gate = evaluate_tier4_gate(
-            pr=args.pr,
-            expected_head=args.head,
-            pr_view=pr_view,
-            merge_packet=merge_packet,
-            required_checks=required_checks,
-            require_branch_protection_token=False,
-            repo=args.repo,
-            cwd=args.cwd,
-            trusted_operator_logins=args.trusted_operator_login,
-        )
         applied_commands: list[list[str]] = []
-        if args.apply:
+        if args.settle_only:
+            gate = evaluate_tier4_settlement_preconditions(
+                pr=args.pr,
+                expected_head=args.head,
+                pr_view=pr_view,
+                merge_packet=merge_packet,
+                required_checks=required_checks,
+            )
             if not gate["ok"]:
-                raise RuntimeError("Tier 4 gate is not satisfied; refusing --apply")
-            applied_commands = _apply_settlement(
+                raise RuntimeError(
+                    "Tier 4 settlement preconditions are not satisfied; refusing --settle-only"
+                )
+            applied_commands = _apply_settlement_signal(
+                pr=args.pr,
+                head=args.head,
+                repo=args.repo,
+                cwd=args.cwd,
+            )
+        else:
+            gate = evaluate_tier4_gate(
+                pr=args.pr,
+                expected_head=args.head,
+                pr_view=pr_view,
+                merge_packet=merge_packet,
+                required_checks=required_checks,
+                require_branch_protection_token=False,
+                repo=args.repo,
+                cwd=args.cwd,
+                trusted_operator_logins=args.trusted_operator_login,
+            )
+        if args.merge_apply:
+            if not gate["ok"]:
+                raise RuntimeError("Tier 4 gate is not satisfied; refusing --merge-apply")
+            applied_commands = _apply_merge(
                 pr=args.pr,
                 head=args.head,
                 repo=args.repo,

--- a/scripts/settle_tier4_pr.py
+++ b/scripts/settle_tier4_pr.py
@@ -30,6 +30,8 @@ HUMAN_SETTLEMENT_STATUS_BLOCKER = f"missing or unsuccessful {HUMAN_SETTLEMENT_CO
 MERGE_QUORUM_CONTEXT = "aragora-merge-quorum"
 OPERATOR_COMMENT_BLOCKER = "missing repo-visible Tier 4 operator settlement comment"
 REQUIRED_CHECKS_BLOCKER = "required checks are missing"
+SETTLE_ONLY_TRUSTED_OPERATOR_BLOCKER = "trusted operator allowlist is required for --settle-only"
+SETTLE_ONLY_INVOKER_BLOCKER = "could not determine gh login for --settle-only"
 TIER4_EVIDENCE_BLOCKER = "missing Tier 4 model/dogfood settlement evidence"
 SUCCESS_STATES = {"SUCCESS", "PASS", "PASSED", "SKIPPED", "NEUTRAL"}
 MIN_TIER4_COUNTED_REVIEWER_IDS = 2
@@ -102,6 +104,14 @@ def _trusted_operator_logins(extra_logins: Sequence[str] | None = None) -> froze
     }
     explicit = {login.strip().lower() for login in extra_logins or () if login.strip()}
     return frozenset(configured | explicit)
+
+
+def _current_gh_login(*, cwd: Path) -> str:
+    payload = _run_json(["gh", "api", "user"], cwd=cwd)
+    login = str(payload.get("login") or "").strip().lower()
+    if not login:
+        raise RuntimeError("gh api user did not return a login")
+    return login
 
 
 def _author_login(item: dict[str, Any]) -> str:
@@ -597,6 +607,9 @@ def evaluate_tier4_settlement_preconditions(
     pr_view: dict[str, Any],
     merge_packet: dict[str, Any],
     required_checks: list[dict[str, Any]] | None = None,
+    trusted_operator_logins: Sequence[str] | None = None,
+    invoker_login: str | None = None,
+    require_trusted_invoker: bool = False,
 ) -> dict[str, Any]:
     blockers: list[str] = []
     actual_head = str(pr_view.get("headRefOid") or "")
@@ -633,12 +646,24 @@ def evaluate_tier4_settlement_preconditions(
     if not _packet_has_counted_tier4_evidence(merge_packet, pr=pr):
         blockers.append(TIER4_EVIDENCE_BLOCKER)
 
+    allowed_logins = _trusted_operator_logins(trusted_operator_logins)
+    normalized_invoker = str(invoker_login or "").strip().lower()
+    if require_trusted_invoker:
+        if not allowed_logins:
+            blockers.append(SETTLE_ONLY_TRUSTED_OPERATOR_BLOCKER)
+        elif not normalized_invoker:
+            blockers.append(SETTLE_ONLY_INVOKER_BLOCKER)
+        elif normalized_invoker not in allowed_logins:
+            blockers.append(f"gh login {normalized_invoker} is not in trusted operator allowlist")
+
     return {
         "ok": not blockers,
         "pr": pr,
         "expected_head": expected_head,
         "actual_head": actual_head,
         "merge_state": merge_state,
+        "trusted_operator_logins": sorted(allowed_logins),
+        "invoker_login": normalized_invoker,
         "blockers": blockers,
     }
 
@@ -951,7 +976,9 @@ def build_parser() -> argparse.ArgumentParser:
             "Restrict repo-visible MEMBER authorization comments to this admin "
             "login. Repeatable; also reads comma-separated "
             f"{TRUSTED_OPERATOR_LOGINS_ENV}. If omitted, any live admin MEMBER "
-            f"may authorize when {HUMAN_SETTLEMENT_CONTEXT} is success."
+            f"may authorize when {HUMAN_SETTLEMENT_CONTEXT} is success. "
+            "--settle-only additionally requires the invoking gh login to be "
+            "present in this allowlist."
         ),
     )
     parser.add_argument("--json", action="store_true")
@@ -970,10 +997,29 @@ def main(argv: Sequence[str] | None = None) -> int:
                 pr_view=pr_view,
                 merge_packet=merge_packet,
                 required_checks=required_checks,
+                trusted_operator_logins=args.trusted_operator_login,
             )
             if not gate["ok"]:
                 raise RuntimeError(
                     "Tier 4 settlement preconditions are not satisfied; refusing --settle-only"
+                )
+            allowed_logins = _trusted_operator_logins(args.trusted_operator_login)
+            invoker_login = _current_gh_login(cwd=args.cwd) if allowed_logins else ""
+            gate = evaluate_tier4_settlement_preconditions(
+                pr=args.pr,
+                expected_head=args.head,
+                pr_view=pr_view,
+                merge_packet=merge_packet,
+                required_checks=required_checks,
+                trusted_operator_logins=args.trusted_operator_login,
+                invoker_login=invoker_login,
+                require_trusted_invoker=True,
+            )
+            if not gate["ok"]:
+                blocker_text = "; ".join(str(blocker) for blocker in gate["blockers"])
+                raise RuntimeError(
+                    "Tier 4 settlement invoker is not trusted; "
+                    f"refusing --settle-only: {blocker_text}"
                 )
             applied_commands = _apply_settlement_signal(
                 pr=args.pr,

--- a/tests/scripts/test_settle_tier4_pr.py
+++ b/tests/scripts/test_settle_tier4_pr.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 
 def _load_module(script_name: str) -> Any:
     here = Path(__file__).resolve()
@@ -801,7 +803,119 @@ def test_check_json_includes_authorization_diagnostics(
     ]
 
 
-def test_apply_uses_valid_command_sequence(monkeypatch: Any, tmp_path: Path) -> None:
+def test_settle_only_posts_comment_and_status_without_merge(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    text_commands: list[tuple[list[str], str | None]] = []
+    commands: list[tuple[list[str], str | None]] = []
+
+    monkeypatch.setattr(
+        settler,
+        "_load_live_inputs",
+        lambda pr, cwd: (
+            _pr_view(head, comments=[], human_settlement_state=None),
+            _tier4_packet(),
+            [
+                {"name": "lint", "state": "SUCCESS"},
+                {"name": "aragora-merge-quorum", "state": "FAILURE"},
+            ],
+        ),
+    )
+    monkeypatch.setattr(
+        settler,
+        "_run_text_command",
+        lambda command, cwd, input_text=None: (
+            text_commands.append((command, input_text))
+            or "https://github.example/pr/7423#issuecomment-1\n"
+        ),
+    )
+    monkeypatch.setattr(
+        settler,
+        "_run_command",
+        lambda command, cwd, input_text=None: commands.append((command, input_text)),
+    )
+
+    rc = settler.main(["--settle-only", "--pr", "7423", "--head", head, "--cwd", str(tmp_path)])
+
+    assert rc == 0
+    all_commands = [command for command, _ in [*text_commands, *commands]]
+    assert not any(command[:3] == ["gh", "pr", "merge"] for command in all_commands)
+    assert text_commands[0][0][:3] == ["gh", "pr", "comment"]
+    assert any("Tier-4 Human Settlement Authorization" in arg for arg in text_commands[0][0])
+    assert commands == [
+        (
+            [
+                "gh",
+                "api",
+                "--method",
+                "POST",
+                f"repos/synaptent/aragora/statuses/{head}",
+                "-f",
+                "state=success",
+                "-f",
+                "context=aragora/human-settlement",
+                "-f",
+                "description=Tier 4 exact-head human-risk settlement recorded for PR #7423",
+                "-f",
+                "target_url=https://github.example/pr/7423#issuecomment-1",
+            ],
+            None,
+        )
+    ]
+
+
+def test_settle_only_rejects_unrelated_required_failure(monkeypatch: Any, tmp_path: Path) -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    commands: list[tuple[list[str], str | None]] = []
+
+    monkeypatch.setattr(
+        settler,
+        "_load_live_inputs",
+        lambda pr, cwd: (
+            _pr_view(head, comments=[], human_settlement_state=None),
+            _tier4_packet(),
+            [
+                {"name": "lint", "state": "FAILURE"},
+                {"name": "aragora-merge-quorum", "state": "FAILURE"},
+            ],
+        ),
+    )
+    monkeypatch.setattr(
+        settler,
+        "_run_text_command",
+        lambda command, cwd, input_text=None: commands.append((command, input_text)) or "",
+    )
+    monkeypatch.setattr(
+        settler,
+        "_run_command",
+        lambda command, cwd, input_text=None: commands.append((command, input_text)),
+    )
+
+    rc = settler.main(
+        ["--settle-only", "--pr", "7423", "--head", head, "--cwd", str(tmp_path), "--json"]
+    )
+
+    assert rc == 2
+    assert commands == []
+
+
+def test_ambiguous_apply_mode_is_rejected() -> None:
+    with pytest.raises(SystemExit) as exc:
+        settler.main(
+            [
+                "--apply",
+                "--pr",
+                "7423",
+                "--head",
+                "57c740022e3c432718462efa12ca79f1df4f674d",
+            ]
+        )
+
+    assert exc.value.code == 2
+
+
+def test_merge_apply_uses_valid_command_sequence(monkeypatch: Any, tmp_path: Path) -> None:
     head = "57c740022e3c432718462efa12ca79f1df4f674d"
     commands: list[tuple[list[str], str | None]] = []
 
@@ -830,7 +944,7 @@ def test_apply_uses_valid_command_sequence(monkeypatch: Any, tmp_path: Path) -> 
         lambda repo, cwd: {},
     )
 
-    rc = settler.main(["--apply", "--pr", "7423", "--head", head, "--cwd", str(tmp_path)])
+    rc = settler.main(["--merge-apply", "--pr", "7423", "--head", head, "--cwd", str(tmp_path)])
 
     assert rc == 0
     assert commands[0][0] == [
@@ -896,7 +1010,7 @@ def test_required_status_check_patch_adds_missing_quorum_from_checks(
     }
 
 
-def test_apply_skips_required_status_check_patch_when_quorum_already_required(
+def test_merge_apply_skips_required_status_check_patch_when_quorum_already_required(
     monkeypatch: Any, tmp_path: Path
 ) -> None:
     head = "57c740022e3c432718462efa12ca79f1df4f674d"
@@ -927,7 +1041,7 @@ def test_apply_skips_required_status_check_patch_when_quorum_already_required(
         lambda repo, cwd: {},
     )
 
-    rc = settler.main(["--apply", "--pr", "7423", "--head", head, "--cwd", str(tmp_path)])
+    rc = settler.main(["--merge-apply", "--pr", "7423", "--head", head, "--cwd", str(tmp_path)])
 
     assert rc == 0
     command_lines = [" ".join(command) for command, _payload in commands]
@@ -937,7 +1051,7 @@ def test_apply_skips_required_status_check_patch_when_quorum_already_required(
     assert any("enforce_admins" in line for line in command_lines)
 
 
-def test_apply_merge_only_authorization_skips_branch_protection(
+def test_merge_apply_merge_only_authorization_skips_branch_protection(
     monkeypatch: Any, tmp_path: Path
 ) -> None:
     head = "57c740022e3c432718462efa12ca79f1df4f674d"
@@ -966,7 +1080,7 @@ def test_apply_merge_only_authorization_skips_branch_protection(
         lambda repo, cwd: {"unexpected": "snapshot"},
     )
 
-    rc = settler.main(["--apply", "--pr", "7423", "--head", head, "--cwd", str(tmp_path)])
+    rc = settler.main(["--merge-apply", "--pr", "7423", "--head", head, "--cwd", str(tmp_path)])
 
     assert rc == 0
     assert commands == [

--- a/tests/scripts/test_settle_tier4_pr.py
+++ b/tests/scripts/test_settle_tier4_pr.py
@@ -835,8 +835,21 @@ def test_settle_only_posts_comment_and_status_without_merge(
         "_run_command",
         lambda command, cwd, input_text=None: commands.append((command, input_text)),
     )
+    monkeypatch.setattr(settler, "_current_gh_login", lambda cwd: "trusted-member")
 
-    rc = settler.main(["--settle-only", "--pr", "7423", "--head", head, "--cwd", str(tmp_path)])
+    rc = settler.main(
+        [
+            "--settle-only",
+            "--pr",
+            "7423",
+            "--head",
+            head,
+            "--trusted-operator-login",
+            "trusted-member",
+            "--cwd",
+            str(tmp_path),
+        ]
+    )
 
     assert rc == 0
     all_commands = [command for command, _ in [*text_commands, *commands]]
@@ -863,6 +876,101 @@ def test_settle_only_posts_comment_and_status_without_merge(
             None,
         )
     ]
+
+
+def test_settle_only_rejects_untrusted_invoking_login(
+    monkeypatch: Any, tmp_path: Path, capsys: Any
+) -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    commands: list[tuple[list[str], str | None]] = []
+
+    monkeypatch.setattr(
+        settler,
+        "_load_live_inputs",
+        lambda pr, cwd: (
+            _pr_view(head, comments=[], human_settlement_state=None),
+            _tier4_packet(),
+            [
+                {"name": "lint", "state": "SUCCESS"},
+                {"name": "aragora-merge-quorum", "state": "FAILURE"},
+            ],
+        ),
+    )
+    monkeypatch.setattr(settler, "_current_gh_login", lambda cwd: "untrusted-member")
+    monkeypatch.setattr(
+        settler,
+        "_run_text_command",
+        lambda command, cwd, input_text=None: commands.append((command, input_text)) or "",
+    )
+    monkeypatch.setattr(
+        settler,
+        "_run_command",
+        lambda command, cwd, input_text=None: commands.append((command, input_text)),
+    )
+
+    rc = settler.main(
+        [
+            "--settle-only",
+            "--pr",
+            "7423",
+            "--head",
+            head,
+            "--trusted-operator-login",
+            "trusted-member",
+            "--cwd",
+            str(tmp_path),
+            "--json",
+        ]
+    )
+
+    assert rc == 2
+    assert commands == []
+    payload = settler.json.loads(capsys.readouterr().out)
+    assert payload == {
+        "ok": False,
+        "error": (
+            "Tier 4 settlement invoker is not trusted; refusing --settle-only: "
+            "gh login untrusted-member is not in trusted operator allowlist"
+        ),
+    }
+
+
+def test_settle_only_requires_trusted_operator_allowlist(monkeypatch: Any, tmp_path: Path) -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    commands: list[tuple[list[str], str | None]] = []
+
+    monkeypatch.setattr(
+        settler,
+        "_load_live_inputs",
+        lambda pr, cwd: (
+            _pr_view(head, comments=[], human_settlement_state=None),
+            _tier4_packet(),
+            [
+                {"name": "lint", "state": "SUCCESS"},
+                {"name": "aragora-merge-quorum", "state": "FAILURE"},
+            ],
+        ),
+    )
+    monkeypatch.setattr(
+        settler,
+        "_current_gh_login",
+        lambda cwd: pytest.fail("gh identity should not be queried without an allowlist"),
+    )
+    monkeypatch.setattr(
+        settler,
+        "_run_text_command",
+        lambda command, cwd, input_text=None: commands.append((command, input_text)) or "",
+    )
+    monkeypatch.setattr(
+        settler,
+        "_run_command",
+        lambda command, cwd, input_text=None: commands.append((command, input_text)),
+    )
+
+    rc = settler.main(["--settle-only", "--pr", "7423", "--head", head, "--cwd", str(tmp_path)])
+
+    assert rc == 2
+    assert commands == []
 
 
 def test_settle_only_rejects_unrelated_required_failure(monkeypatch: Any, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Split Tier 4 settlement automation into --settle-only for posting exact-head settlement comment/status and --merge-apply for merge/protection execution.
- Keep --check as the read-only gate and reject the old ambiguous --apply mode.
- Add focused tests for settle-only, rejected unsafe settlement preconditions, and merge-apply command behavior.

## Validation

- python3 -m pytest tests/scripts/test_settle_tier4_pr.py
- python3 -m ruff check scripts/settle_tier4_pr.py tests/scripts/test_settle_tier4_pr.py
- python3 -m ruff format --check scripts/settle_tier4_pr.py tests/scripts/test_settle_tier4_pr.py
- git diff --check
- python3 scripts/settle_tier4_pr.py --help
- bash scripts/automation_pr_preflight.sh origin/main HEAD

## Notes

Draft PR opened from a clean isolated worktree; unrelated root dirt and #7742 queue receipt state were not included.