### PR TITLE
fix(agents): route debate Claude CLI through the authenticated profile pool

### DIFF
--- a/aragora/agents/claude_profile_pool.py
+++ b/aragora/agents/claude_profile_pool.py
@@ -105,9 +105,15 @@ def _pool_health_states(repo_root: Path) -> dict[str, str]:
 def _healthy_profiles(repo_root: Path, profiles: list[str]) -> list[str]:
     states = _pool_health_states(repo_root)
     if not states:
+        # No verify-backed snapshot: we cannot assess health, so keep the full
+        # list and let the caller's runtime fallback handle any dead profile.
         return profiles
-    filtered = [p for p in profiles if states.get(p) not in _UNHEALTHY_PROFILE_STATES]
-    return filtered or profiles
+    # A snapshot exists, so trust it even when it filters everything out: if every
+    # configured profile is known-bad, returning an empty list (=> select_profile
+    # yields None => bare claude => OpenRouter fallback) is correct. Falling back
+    # to the full known-bad list would defeat the safety gate this module exists
+    # for. Profiles absent from the snapshot (state is None) are treated as usable.
+    return [p for p in profiles if states.get(p) not in _UNHEALTHY_PROFILE_STATES]
 
 
 def select_profile(*, repo_root: Path | None = None, index: int | None = None) -> str | None:

--- a/aragora/agents/claude_profile_pool.py
+++ b/aragora/agents/claude_profile_pool.py
@@ -1,0 +1,162 @@
+"""Route the debate Claude CLI agent through the authenticated subscription pool.
+
+The debate :class:`~aragora.agents.cli_agents.ClaudeAgent` historically shelled
+out to a bare ``claude --print -p -`` against the *default* ``$HOME/.claude``.
+On hosts where that default profile is not logged in (the common case for
+headless / multi-account fleets) the call hangs or 401s, so decision-integrity
+debates silently degraded to a single agent.
+
+The review path (:mod:`aragora.swarm.review_routing`) already solves this by
+running ``scripts/claude_profile.sh exec <profile> -- claude ...`` against the
+pool of authenticated Claude Max/Team subscriptions under
+``~/.aragora-claude/max-*``. This module exposes the same routing for the agents
+layer as a small, dependency-light helper so the debate path can reuse the pool
+without importing the swarm review stack.
+
+Design notes:
+- **Non-breaking.** When ``scripts/claude_profile.sh`` is absent (e.g. an
+  installed package rather than a repo checkout) or no usable profile is found,
+  the caller is handed the original ``base_cmd`` unchanged.
+- **Health-aware.** Profiles flagged unhealthy in the verify-backed snapshot
+  (``.aragora/claude_pool_health.json``) are dropped. ``claude auth status`` is
+  deliberately *not* consulted: it reports ``loggedIn: true`` even for expired
+  tokens (see ``scripts/claude_profiles_bootstrap.sh``), so only the live-probe
+  snapshot is trusted. A missing/malformed snapshot leaves the order untouched
+  and relies on the caller's existing runtime fallback.
+- **Opt-out.** ``ARAGORA_CLAUDE_DISABLE_PROFILE_POOL`` forces the bare command.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+# Mirror of the review-side constants (aragora/swarm/review_routing.py). Kept
+# local so the agents layer does not import the swarm review stack.
+_DEFAULT_PROFILES: tuple[str, ...] = tuple(f"max-{index:02d}" for index in range(1, 14))
+_POOL_HEALTH_RELATIVE_PATH = ".aragora/claude_pool_health.json"
+_UNHEALTHY_PROFILE_STATES = {"expired", "not_configured", "unauthenticated", "logged_out"}
+_TRUTHY = {"1", "true", "yes", "on"}
+
+_PREAMBLE_PREFIXES = ("Using profile home:", "Command:")
+
+
+def _repo_root() -> Path:
+    # aragora/agents/claude_profile_pool.py -> parents[2] == repo root.
+    return Path(__file__).resolve().parents[2]
+
+
+def _profile_script(repo_root: Path) -> Path | None:
+    script = repo_root / "scripts" / "claude_profile.sh"
+    return script if script.exists() else None
+
+
+def _configured_profiles() -> list[str]:
+    raw = str(os.environ.get("ARAGORA_CLAUDE_REVIEW_PROFILES", "")).strip()
+    if not raw:
+        return list(_DEFAULT_PROFILES)
+    result: list[str] = []
+    for item in raw.split(","):
+        name = item.strip()
+        if name and name not in result:
+            result.append(name)
+    return result or list(_DEFAULT_PROFILES)
+
+
+def _pool_health_path(repo_root: Path) -> Path:
+    override = str(os.environ.get("ARAGORA_CLAUDE_POOL_HEALTH_FILE", "")).strip()
+    if override:
+        return Path(override).expanduser()
+    return repo_root / _POOL_HEALTH_RELATIVE_PATH
+
+
+def _pool_health_states(repo_root: Path) -> dict[str, str]:
+    """Return ``{profile: state}`` from the verify-backed snapshot, or ``{}``.
+
+    Accepts both shapes seen in the wild: a ``{"profiles": [{"profile", "state"}]}``
+    list and a flat ``{profile: state}`` mapping. Any error yields ``{}`` so the
+    caller leaves the profile order untouched.
+    """
+    try:
+        payload = json.loads(_pool_health_path(repo_root).read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):
+        return {}
+    if not isinstance(payload, dict):
+        return {}
+    states: dict[str, str] = {}
+    items = payload.get("profiles")
+    if isinstance(items, list):
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            name = str(item.get("profile") or item.get("name") or "").strip()
+            state = str(item.get("state") or item.get("status") or "").strip().lower()
+            if name:
+                states[name] = state
+    else:
+        for key, value in payload.items():
+            if key == "generated_at" or not isinstance(value, str):
+                continue
+            states[str(key)] = value.strip().lower()
+    return states
+
+
+def _healthy_profiles(repo_root: Path, profiles: list[str]) -> list[str]:
+    states = _pool_health_states(repo_root)
+    if not states:
+        return profiles
+    filtered = [p for p in profiles if states.get(p) not in _UNHEALTHY_PROFILE_STATES]
+    return filtered or profiles
+
+
+def select_profile(*, repo_root: Path | None = None, index: int | None = None) -> str | None:
+    """Pick a usable Claude subscription profile, or ``None`` to use bare claude.
+
+    ``ARAGORA_CLAUDE_PROFILE`` pins a specific profile. Otherwise a healthy
+    profile is chosen from the pool, rotated by ``index`` (defaulting to the
+    current pid so concurrent processes spread across subscriptions).
+    """
+    if str(os.environ.get("ARAGORA_CLAUDE_DISABLE_PROFILE_POOL", "")).strip().lower() in _TRUTHY:
+        return None
+    override = str(os.environ.get("ARAGORA_CLAUDE_PROFILE", "")).strip()
+    if override:
+        return override
+    root = repo_root or _repo_root()
+    if _profile_script(root) is None:
+        return None
+    profiles = _healthy_profiles(root, _configured_profiles())
+    if not profiles:
+        return None
+    cursor = os.getpid() if index is None else index
+    return profiles[cursor % len(profiles)]
+
+
+def build_claude_command(
+    base_cmd: list[str],
+    *,
+    repo_root: Path | None = None,
+    index: int | None = None,
+) -> tuple[list[str], bool]:
+    """Return ``(command, used_profile)``.
+
+    When a usable profile is found, wraps ``base_cmd`` in
+    ``claude_profile.sh exec <profile> -- <base_cmd>``; otherwise returns
+    ``base_cmd`` unchanged so behaviour is identical to the bare-CLI path.
+    """
+    root = repo_root or _repo_root()
+    script = _profile_script(root)
+    profile = select_profile(repo_root=root, index=index)
+    if not profile or script is None:
+        return list(base_cmd), False
+    return [str(script), "exec", profile, "--", *base_cmd], True
+
+
+def strip_profile_preamble(text: str) -> str:
+    """Drop the ``claude_profile.sh`` preamble lines from wrapped CLI output."""
+    lines = [
+        line
+        for line in text.splitlines()
+        if not any(line.startswith(prefix) for prefix in _PREAMBLE_PREFIXES)
+    ]
+    return "\n".join(lines).strip()

--- a/aragora/agents/claude_profile_pool.py
+++ b/aragora/agents/claude_profile_pool.py
@@ -39,8 +39,6 @@ _POOL_HEALTH_RELATIVE_PATH = ".aragora/claude_pool_health.json"
 _UNHEALTHY_PROFILE_STATES = {"expired", "not_configured", "unauthenticated", "logged_out"}
 _TRUTHY = {"1", "true", "yes", "on"}
 
-_PREAMBLE_PREFIXES = ("Using profile home:", "Command:")
-
 
 def _repo_root() -> Path:
     # aragora/agents/claude_profile_pool.py -> parents[2] == repo root.
@@ -159,10 +157,17 @@ def build_claude_command(
 
 
 def strip_profile_preamble(text: str) -> str:
-    """Drop the ``claude_profile.sh`` preamble lines from wrapped CLI output."""
-    lines = [
-        line
-        for line in text.splitlines()
-        if not any(line.startswith(prefix) for prefix in _PREAMBLE_PREFIXES)
-    ]
-    return "\n".join(lines).strip()
+    """Drop the ``claude_profile.sh`` preamble from wrapped CLI output.
+
+    The wrapper emits exactly two preamble lines, in order, *before* the model
+    output: ``Using profile home: ...`` then ``Command: ...``. Only that leading,
+    in-order block is removed, so a legitimate model answer line that happens to
+    start with ``Command:`` (or sits anywhere past the preamble) is preserved.
+    """
+    lines = text.splitlines()
+    index = 0
+    if index < len(lines) and lines[index].startswith("Using profile home:"):
+        index += 1
+        if index < len(lines) and lines[index].startswith("Command:"):
+            index += 1
+    return "\n".join(lines[index:]).strip()

--- a/aragora/agents/cli_agents.py
+++ b/aragora/agents/cli_agents.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Any
 from collections.abc import Callable
 
 from aragora.agents.base import MAX_CONTEXT_CHARS, MAX_MESSAGE_CHARS, CritiqueMixin
+from aragora.agents.claude_profile_pool import build_claude_command, strip_profile_preamble
 from aragora.agents.errors import (
     RATE_LIMIT_PATTERNS,
     AgentStreamError,
@@ -782,14 +783,25 @@ class ClaudeAgent(CLIAgent):
     """
 
     async def generate(self, prompt: str, context: list[Message] | None = None) -> str:
-        """Generate a response using claude CLI via stdin."""
+        """Generate a response using claude CLI via stdin.
+
+        When the authenticated ``claude_profile.sh`` subscription pool is
+        available, the bare CLI call is routed through a healthy profile so the
+        debate path uses a logged-in subscription instead of the (often
+        unauthenticated) default ``$HOME/.claude``. Falls back to the bare
+        command unchanged when no pool/profile is available.
+        """
         full_prompt = self._build_full_prompt(prompt, context)
-        # Pass prompt via stdin to avoid shell argument length limits
+        command, used_profile = build_claude_command(["claude", "--print", "-p", "-"])
+        # Pass prompt via stdin to avoid shell argument length limits.
         return await self._generate_with_fallback(
-            ["claude", "--print", "-p", "-"],
+            command,
             prompt,
             context,
             input_text=full_prompt,
+            # The profile wrapper echoes a 2-line preamble to stdout; strip it
+            # from CLI output only (the OpenRouter fallback path has no preamble).
+            response_extractor=strip_profile_preamble if used_profile else None,
         )
 
 

--- a/tests/agents/test_claude_profile_pool.py
+++ b/tests/agents/test_claude_profile_pool.py
@@ -89,7 +89,9 @@ def test_unhealthy_profiles_are_dropped(tmp_path, monkeypatch):
     # Only max-13 healthy; the rest expired/logged out.
     profiles = [{"profile": f"max-{i:02d}", "state": "expired"} for i in range(1, 13)]
     profiles.append({"profile": "max-13", "state": "ok"})
-    repo = _make_repo(tmp_path, health={"generated_at": "2026-06-04T00:00:00Z", "profiles": profiles})
+    repo = _make_repo(
+        tmp_path, health={"generated_at": "2026-06-04T00:00:00Z", "profiles": profiles}
+    )
 
     # Any rotation index must resolve to the single healthy profile.
     for idx in (0, 1, 5, 12, 99):
@@ -138,7 +140,9 @@ def test_all_unhealthy_snapshot_yields_no_profile(tmp_path, monkeypatch):
         {"profile": "max-02", "state": "logged_out"},
         {"profile": "max-03", "state": "unauthenticated"},
     ]
-    repo = _make_repo(tmp_path, health={"generated_at": "2026-06-04T00:00:00Z", "profiles": profiles})
+    repo = _make_repo(
+        tmp_path, health={"generated_at": "2026-06-04T00:00:00Z", "profiles": profiles}
+    )
 
     assert select_profile(repo_root=repo, index=0) is None
     command, used_profile = build_claude_command(BASE_CMD, repo_root=repo, index=0)

--- a/tests/agents/test_claude_profile_pool.py
+++ b/tests/agents/test_claude_profile_pool.py
@@ -156,3 +156,26 @@ def test_profiles_absent_from_snapshot_are_treated_as_usable(tmp_path, monkeypat
     )
 
     assert select_profile(repo_root=repo, index=0) == "max-09"
+
+
+def test_strip_preamble_preserves_body_lines_matching_prefixes():
+    """Only the leading wrapper block is stripped; a model answer that itself
+    contains a 'Command:' line (past the preamble) must be preserved."""
+    raw = (
+        "Using profile home: /home/x/.aragora-claude/max-01\n"
+        "Command: claude --print -p -\n"
+        "To run the migration:\n"
+        "Command: python manage.py migrate\n"
+        "Using profile home: is also a valid sentence here."
+    )
+    assert strip_profile_preamble(raw) == (
+        "To run the migration:\n"
+        "Command: python manage.py migrate\n"
+        "Using profile home: is also a valid sentence here."
+    )
+
+
+def test_strip_preamble_without_leading_wrapper_is_untouched():
+    """If output does not start with the wrapper block, nothing is stripped."""
+    raw = "Command: this is the model's first line\nsecond line"
+    assert strip_profile_preamble(raw) == raw

--- a/tests/agents/test_claude_profile_pool.py
+++ b/tests/agents/test_claude_profile_pool.py
@@ -125,3 +125,34 @@ def test_strip_profile_preamble_removes_wrapper_lines():
 
 def test_strip_profile_preamble_noop_on_plain_text():
     assert strip_profile_preamble("just a response\nsecond line") == "just a response\nsecond line"
+
+
+def test_all_unhealthy_snapshot_yields_no_profile(tmp_path, monkeypatch):
+    """Regression: when the verify snapshot marks every configured profile
+    unhealthy, selection must return None (=> bare claude => OpenRouter fallback)
+    rather than handing back a known-bad profile and defeating the safety gate.
+    """
+    monkeypatch.setenv("ARAGORA_CLAUDE_REVIEW_PROFILES", "max-01,max-02,max-03")
+    profiles = [
+        {"profile": "max-01", "state": "expired"},
+        {"profile": "max-02", "state": "logged_out"},
+        {"profile": "max-03", "state": "unauthenticated"},
+    ]
+    repo = _make_repo(tmp_path, health={"generated_at": "2026-06-04T00:00:00Z", "profiles": profiles})
+
+    assert select_profile(repo_root=repo, index=0) is None
+    command, used_profile = build_claude_command(BASE_CMD, repo_root=repo, index=0)
+    assert used_profile is False
+    assert command == BASE_CMD
+
+
+def test_profiles_absent_from_snapshot_are_treated_as_usable(tmp_path, monkeypatch):
+    """A profile not listed in the snapshot (unknown state) stays selectable."""
+    monkeypatch.setenv("ARAGORA_CLAUDE_REVIEW_PROFILES", "max-01,max-09")
+    # Snapshot only knows max-01 (expired); max-09 is unlisted => unknown => usable.
+    repo = _make_repo(
+        tmp_path,
+        health={"generated_at": "x", "profiles": [{"profile": "max-01", "state": "expired"}]},
+    )
+
+    assert select_profile(repo_root=repo, index=0) == "max-09"

--- a/tests/agents/test_claude_profile_pool.py
+++ b/tests/agents/test_claude_profile_pool.py
@@ -1,0 +1,127 @@
+"""Tests for claude_profile.sh subscription-pool routing of the debate Claude agent."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from aragora.agents.claude_profile_pool import (
+    build_claude_command,
+    select_profile,
+    strip_profile_preamble,
+)
+
+BASE_CMD = ["claude", "--print", "-p", "-"]
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_pool_env(monkeypatch):
+    """Isolate tests from the host's real Claude-pool configuration."""
+    for var in (
+        "ARAGORA_CLAUDE_REVIEW_PROFILES",
+        "ARAGORA_CLAUDE_PROFILE",
+        "ARAGORA_CLAUDE_DISABLE_PROFILE_POOL",
+        "ARAGORA_CLAUDE_POOL_HEALTH_FILE",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _make_repo(tmp_path: Path, *, with_script: bool = True, health: dict | None = None) -> Path:
+    if with_script:
+        scripts = tmp_path / "scripts"
+        scripts.mkdir(parents=True, exist_ok=True)
+        (scripts / "claude_profile.sh").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    if health is not None:
+        hp = tmp_path / ".aragora" / "claude_pool_health.json"
+        hp.parent.mkdir(parents=True, exist_ok=True)
+        hp.write_text(json.dumps(health), encoding="utf-8")
+    return tmp_path
+
+
+def test_build_command_wraps_in_profile_when_pool_available(tmp_path, monkeypatch):
+    monkeypatch.delenv("ARAGORA_CLAUDE_DISABLE_PROFILE_POOL", raising=False)
+    monkeypatch.delenv("ARAGORA_CLAUDE_PROFILE", raising=False)
+    repo = _make_repo(tmp_path)
+
+    command, used_profile = build_claude_command(BASE_CMD, repo_root=repo, index=0)
+
+    assert used_profile is True
+    assert command[0] == str(repo / "scripts" / "claude_profile.sh")
+    assert command[1] == "exec"
+    assert command[2].startswith("max-")
+    assert command[3] == "--"
+    assert command[4:] == BASE_CMD
+
+
+def test_build_command_is_bare_when_script_absent(tmp_path):
+    repo = _make_repo(tmp_path, with_script=False)
+
+    command, used_profile = build_claude_command(BASE_CMD, repo_root=repo, index=0)
+
+    assert used_profile is False
+    assert command == BASE_CMD
+
+
+def test_disable_env_forces_bare_command(tmp_path, monkeypatch):
+    monkeypatch.setenv("ARAGORA_CLAUDE_DISABLE_PROFILE_POOL", "1")
+    repo = _make_repo(tmp_path)
+
+    command, used_profile = build_claude_command(BASE_CMD, repo_root=repo, index=0)
+
+    assert used_profile is False
+    assert command == BASE_CMD
+
+
+def test_explicit_profile_override_is_honored(tmp_path, monkeypatch):
+    monkeypatch.setenv("ARAGORA_CLAUDE_PROFILE", "max-07")
+    repo = _make_repo(tmp_path)
+
+    command, used_profile = build_claude_command(BASE_CMD, repo_root=repo, index=0)
+
+    assert used_profile is True
+    assert command[2] == "max-07"
+
+
+def test_unhealthy_profiles_are_dropped(tmp_path, monkeypatch):
+    monkeypatch.delenv("ARAGORA_CLAUDE_PROFILE", raising=False)
+    # Only max-13 healthy; the rest expired/logged out.
+    profiles = [{"profile": f"max-{i:02d}", "state": "expired"} for i in range(1, 13)]
+    profiles.append({"profile": "max-13", "state": "ok"})
+    repo = _make_repo(tmp_path, health={"generated_at": "2026-06-04T00:00:00Z", "profiles": profiles})
+
+    # Any rotation index must resolve to the single healthy profile.
+    for idx in (0, 1, 5, 12, 99):
+        assert select_profile(repo_root=repo, index=idx) == "max-13"
+
+
+def test_flat_health_mapping_shape_is_supported(tmp_path, monkeypatch):
+    monkeypatch.delenv("ARAGORA_CLAUDE_PROFILE", raising=False)
+    health = {"generated_at": "x", "max-01": "expired", "max-02": "ok", "max-03": "ok"}
+    monkeypatch.setenv("ARAGORA_CLAUDE_REVIEW_PROFILES", "max-01,max-02,max-03")
+    repo = _make_repo(tmp_path, health=health)
+
+    chosen = {select_profile(repo_root=repo, index=i) for i in range(6)}
+
+    assert "max-01" not in chosen
+    assert chosen <= {"max-02", "max-03"}
+
+
+def test_rotation_spreads_across_healthy_profiles(tmp_path, monkeypatch):
+    monkeypatch.delenv("ARAGORA_CLAUDE_PROFILE", raising=False)
+    monkeypatch.setenv("ARAGORA_CLAUDE_REVIEW_PROFILES", "max-01,max-02")
+    repo = _make_repo(tmp_path)  # no health file -> all configured profiles usable
+
+    assert select_profile(repo_root=repo, index=0) == "max-01"
+    assert select_profile(repo_root=repo, index=1) == "max-02"
+    assert select_profile(repo_root=repo, index=2) == "max-01"
+
+
+def test_strip_profile_preamble_removes_wrapper_lines():
+    raw = "Using profile home: /home/x/.aragora-claude/max-01\nCommand: claude --print\nactual answer\nline two"
+    assert strip_profile_preamble(raw) == "actual answer\nline two"
+
+
+def test_strip_profile_preamble_noop_on_plain_text():
+    assert strip_profile_preamble("just a response\nsecond line") == "just a response\nsecond line"


### PR DESCRIPTION
## Problem
The debate `ClaudeAgent` (`aragora/agents/cli_agents.py`) shelled out to a bare `claude --print -p -` against the default `$HOME/.claude`. On fleets where that default profile isn't logged in, the call **hangs (exit 124) or 401s**, so `ask --decision-integrity --agents codex,claude` silently degraded to a **single agent (codex only)** — defeating the heterogeneous-consensus guarantee.

**Dogfood evidence (this session):** two decision-integrity receipts recorded `agents: ['codex']` despite requesting `codex,claude`; `claude --print -p -` exits 124; the 13 `~/.aragora-claude/max-*` subscription profiles report `loggedIn:true` but most 401 on real use (only `max-13` live), and the debate path never touched the pool the *review* path already uses.

## Fix
New `aragora/agents/claude_profile_pool.py` mirrors the review-side pool routing for the agents layer:
- Picks a **healthy** profile from the verify-backed `.aragora/claude_pool_health.json` snapshot — deliberately **not** `claude auth status`, which reports `loggedIn:true` even for expired tokens (documented in `scripts/claude_profiles_bootstrap.sh`).
- Builds `scripts/claude_profile.sh exec <profile> -- claude --print -p -` and strips the wrapper preamble (via the existing `response_extractor` hook, so CLI output only — the OpenRouter fallback is untouched).
- Honors `ARAGORA_CLAUDE_PROFILE` (pin) and `ARAGORA_CLAUDE_DISABLE_PROFILE_POOL` (opt-out).

**Non-breaking:** when `claude_profile.sh` is absent (installed package) or no usable profile is found, the bare command is returned unchanged.

## Verification
- 9 new unit tests (wrap / bare / opt-out / pin / health-filter / rotation / preamble-strip), hermetic w.r.t. host pool env.
- **E2E:** `ClaudeAgent.generate()` pinned to a live profile routes through `claude_profile.sh exec max-13` and returns a real response (`DEBATE_CLAUDE_VIA_POOL_OK`).
- 105 existing agent tests pass; ruff clean.

## Operational note
The pool's health snapshot must be refreshed (`scripts/claude_profiles_bootstrap.sh verify`) and expired profiles re-logged-in (`… login max-NN`) for selection to land on live subscriptions. Complements task to guard against false 'consensus' when an agent silently drops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)