### PR TITLE
fix(review): report boss-loop runtime checkout drift

### DIFF
--- a/aragora/review/health.py
+++ b/aragora/review/health.py
@@ -41,6 +41,7 @@ DEFAULT_WATCHDOG_LOG_REL = DEFAULT_OVERNIGHT_REL / "watchdog.log"
 DEFAULT_B0_STATUS_REL = Path("docs") / "status" / "B0_BENCHMARK_TRUTH_STATUS.md"
 DEFAULT_TW03_STATUS_REL = Path("docs") / "status" / "TW03_RESCUE_PRODUCTIZATION_STATUS.md"
 GIT_SHOW_TIMEOUT_SECONDS = 5
+GIT_STATUS_TIMEOUT_SECONDS = 5
 
 # Status severities (ordered ascending so max() returns worst).
 STATUS_FRESH = "fresh"
@@ -380,7 +381,75 @@ _PYTHON_WARNING_PATTERN = re.compile(r"ARAGORA_PYTHON is set but not executable:
 _PYTHON_INTERPRETER_PATTERN = re.compile(r"Using Python interpreter: .+")
 
 
-def _check_boss_loop_log(path: Path, warn_h: float, crit_h: float) -> SurfaceCheck:
+def _git_output(repo: Path, *args: str) -> str | None:
+    """Run a local read-only git command and return stripped stdout."""
+    try:
+        proc = subprocess.run(
+            ["git", *args],
+            cwd=str(repo),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+            timeout=GIT_STATUS_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.SubprocessError, UnicodeDecodeError):
+        return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.strip()
+
+
+def _runtime_checkout_extra(repo: Path) -> dict[str, object]:
+    """Return local checkout drift diagnostics for a daemon runtime repo."""
+    if not (repo / ".git").exists():
+        return {"runtime_repo": str(repo), "runtime_checkout_status": "not_git"}
+
+    head = _git_output(repo, "rev-parse", "HEAD")
+    origin_main = _git_output(repo, "rev-parse", "origin/main")
+    merge_base = (
+        _git_output(repo, "merge-base", "HEAD", "origin/main") if head and origin_main else None
+    )
+    status_text = _git_output(repo, "status", "--short", "--untracked-files=all")
+    dirty_count = len(status_text.splitlines()) if status_text else 0
+
+    if not head:
+        checkout_status = "unknown"
+    elif not origin_main:
+        checkout_status = "no_origin_main"
+    elif head == origin_main:
+        checkout_status = "current"
+    elif merge_base == head:
+        checkout_status = "behind_origin_main"
+    elif merge_base == origin_main:
+        checkout_status = "ahead_of_origin_main"
+    elif merge_base:
+        checkout_status = "diverged_from_origin_main"
+    else:
+        checkout_status = "unknown"
+
+    extra: dict[str, object] = {
+        "runtime_repo": str(repo),
+        "runtime_checkout_status": checkout_status,
+        "runtime_checkout_dirty_count": dirty_count,
+    }
+    if head:
+        extra["runtime_head"] = head
+    if origin_main:
+        extra["runtime_origin_main"] = origin_main
+    if merge_base:
+        extra["runtime_merge_base"] = merge_base
+    return extra
+
+
+def _check_boss_loop_log(
+    path: Path,
+    warn_h: float,
+    crit_h: float,
+    *,
+    runtime_repo_root: Path | None = None,
+) -> SurfaceCheck:
     if not path.exists():
         return SurfaceCheck(
             name="boss_loop_log",
@@ -446,6 +515,8 @@ def _check_boss_loop_log(path: Path, warn_h: float, crit_h: float) -> SurfaceChe
         extra["latest_python_warning"] = latest_python_warning[-240:]
     if latest_python_interpreter:
         extra["latest_python_interpreter"] = latest_python_interpreter[-240:]
+    if last_terminal_event in {"traceback", "exit_fail"} and runtime_repo_root is not None:
+        extra.update(_runtime_checkout_extra(runtime_repo_root))
     detail = (
         f"tracebacks={tracebacks_total} crashes={crashes_total} "
         f"ok={exits_ok_total} fail={exits_fail_total}"
@@ -454,6 +525,9 @@ def _check_boss_loop_log(path: Path, warn_h: float, crit_h: float) -> SurfaceChe
         detail = f"{detail}; latest_failure={latest_failure[-120:]}"
     if latest_failure_signature and latest_failure_signature != latest_failure:
         detail = f"{detail}; failure_signature={latest_failure_signature[-120:]}"
+    checkout_status = extra.get("runtime_checkout_status")
+    if checkout_status and checkout_status != "current":
+        detail = f"{detail}; runtime_checkout={checkout_status}"
     return SurfaceCheck(
         name="boss_loop_log",
         status=status,
@@ -596,6 +670,7 @@ def gather_health(
             on_root / "boss-loop-launchd.log",
             warn_h=warn_hours_boss_log,
             crit_h=warn_hours_boss_log * crit_multiplier,
+            runtime_repo_root=state_dir.parent,
         )
     )
 

--- a/tests/review/test_health.py
+++ b/tests/review/test_health.py
@@ -42,6 +42,20 @@ def _write_status_doc(path: Path, last_updated: str) -> None:
     path.write_text(f"# A status doc\n\nLast updated: {last_updated}\n\nsome content\n")
 
 
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def _git_stdout(repo: Path, *args: str) -> str:
+    return _git(repo, *args).stdout.strip()
+
+
 def _setup_proof_loop(tmp_path: Path) -> dict[str, Path]:
     """Create the canonical directory layout the health command inspects."""
     repo = tmp_path / "repo"
@@ -480,6 +494,63 @@ class TestBossLoopLogCounter:
             == "Using Python interpreter: /Users/armand/miniforge3/bin/python"
         )
         assert "failure_signature=AttributeError" in str(bl.detail)
+
+    def test_failed_exit_reports_stale_runtime_checkout(self, tmp_path: Path) -> None:
+        layout = _setup_proof_loop(tmp_path)
+        repo = layout["repo"]
+        _git(repo, "init")
+        (repo / "tracked.txt").write_text("stale checkout\n", encoding="utf-8")
+        _git(repo, "add", "tracked.txt")
+        _git(
+            repo,
+            "-c",
+            "user.name=Aragora Test",
+            "-c",
+            "user.email=aragora-test@example.com",
+            "commit",
+            "-m",
+            "stale checkout",
+        )
+        stale_head = _git_stdout(repo, "rev-parse", "HEAD")
+        (repo / "tracked.txt").write_text("origin main\n", encoding="utf-8")
+        _git(repo, "add", "tracked.txt")
+        _git(
+            repo,
+            "-c",
+            "user.name=Aragora Test",
+            "-c",
+            "user.email=aragora-test@example.com",
+            "commit",
+            "-m",
+            "origin main",
+        )
+        origin_main = _git_stdout(repo, "rev-parse", "HEAD")
+        _git(repo, "update-ref", "refs/remotes/origin/main", origin_main)
+        _git(repo, "checkout", "-q", stale_head)
+
+        log = layout["overnight"] / "boss-loop-launchd.log"
+        log.write_text(
+            "Traceback (most recent call last):\n"
+            "AttributeError: 'NoneType' object has no attribute 'ndarray'\n"
+            "Boss loop exited with status 1\n",
+            encoding="utf-8",
+        )
+        os.utime(log, (time.time() - 600, time.time() - 600))
+
+        report = gather_health(
+            repo_root=repo,
+            review_queue_root=layout["review_queue_root"],
+            overnight_root=layout["overnight"],
+            automation_receipts_root=layout["auto"],
+        )
+
+        bl = {s.name: s for s in report.surfaces}["boss_loop_log"]
+        assert bl.status == STATUS_STALE
+        assert bl.extra["runtime_repo"] == str(repo)
+        assert bl.extra["runtime_checkout_status"] == "behind_origin_main"
+        assert bl.extra["runtime_head"] == stale_head
+        assert bl.extra["runtime_origin_main"] == origin_main
+        assert "runtime_checkout=behind_origin_main" in str(bl.detail)
 
     def test_later_success_clears_historical_boss_loop_failures(self, tmp_path: Path) -> None:
         layout = _setup_proof_loop(tmp_path)


### PR DESCRIPTION
## Summary
- add read-only git checkout diagnostics to the boss-loop health surface after failed launchd cycles
- expose runtime repo, HEAD, origin/main, merge-base, dirty count, and checkout status in health JSON
- verified live health now reports the current shared-root daemon as diverged_from_origin_main instead of only showing the ndarray traceback

## Live evidence
From this branch, review-queue health reports boss_loop_log stale with runtime_checkout=diverged_from_origin_main, runtime_head=cc3648fa7262788c4c11e5252233f562513aa600, runtime_origin_main=43183bbd51aa9125933be87151551e6aa75b1da1, runtime_merge_base=ad74d83eec734367fbaf543cbcd7fde7e02d4416, and runtime_checkout_dirty_count=14.

## Tests
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/review/test_health.py
- python3 -m ruff check aragora/review/health.py tests/review/test_health.py
- python3 -m ruff format --check aragora/review/health.py tests/review/test_health.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD

No merge requested.