### PR TITLE
fix(deps): floor python-dateutil>=2.8.2 (collections.Callable crash)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,14 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Typing :: Typed",
 ]
-dependencies = []
+dependencies = [
+    # botocore (pulled in transitively by boto3/supabase for AWS Secrets Manager)
+    # accepts python-dateutil>=2.1, but versions <2.8.1 call the removed
+    # ``collections.Callable`` and crash on Python 3.10+ during AWS timestamp
+    # parsing — which aborts ``hydrate_env_from_secrets`` and the whole
+    # settlement/secrets CLI path. Floor it above the fixed release.
+    "python-dateutil>=2.8.2",
+]
 
 [project.optional-dependencies]
 test = [

--- a/tests/config/test_dateutil_floor.py
+++ b/tests/config/test_dateutil_floor.py
@@ -1,0 +1,31 @@
+"""Regression guard for the python-dateutil floor.
+
+python-dateutil < 2.8.1 calls the removed ``collections.Callable`` and crashes
+on Python 3.10+ when botocore parses AWS response timestamps with ``tzinfos=``.
+That abort cascaded through ``hydrate_env_from_secrets`` and broke the entire
+settlement/secrets CLI path (observed with 2.6.1 in the field). pyproject pins
+``python-dateutil>=2.8.2``; these tests fail loudly if a broken version is ever
+resolved into the environment again.
+"""
+
+from __future__ import annotations
+
+from importlib import metadata
+
+from dateutil import parser as dateutil_parser
+from dateutil.tz import tzutc
+
+
+def test_dateutil_version_is_at_or_above_floor():
+    version = metadata.version("python-dateutil")
+    parts = tuple(int(p) for p in version.split(".")[:3] if p.isdigit())
+    assert parts >= (2, 8, 2), f"python-dateutil {version} is below the >=2.8.2 floor"
+
+
+def test_parse_timestamp_with_tzinfos_does_not_crash():
+    # Mirrors botocore's AWS timestamp parsing: dateutil.parser.parse(value,
+    # tzinfos={'GMT': tzutc()}). On <2.8.1 this raised
+    # AttributeError: module 'collections' has no attribute 'Callable'.
+    parsed = dateutil_parser.parse("2026-06-04T23:44:00 GMT", tzinfos={"GMT": tzutc()})
+    assert parsed.year == 2026
+    assert parsed.tzinfo is not None


### PR DESCRIPTION
## Problem
`python-dateutil < 2.8.1` calls the removed `collections.Callable` and **crashes on Python 3.10+** when botocore parses AWS response timestamps with `tzinfos=` (during `assume_role`/credential refresh):

```
File ".../dateutil/parser.py", line 587, in parse
    if (isinstance(tzinfos, collections.Callable) or
AttributeError: module 'collections' has no attribute 'Callable'
```

In the field (env had **2.6.1**, from 2017) this aborted `hydrate_env_from_secrets` and the **entire settlement/secrets CLI path** — `review-queue record-settlement` and `settle_tier4_pr.py` both died this way, which is part of why Tier-4 settlements fell back to manual `gh pr merge --admin`.

botocore (transitive via boto3/supabase) only requires `dateutil>=2.1`, so a stale 2.6.1 satisfied resolution and never got upgraded.

## Fix
Add a base floor `python-dateutil>=2.8.2` to `pyproject.toml` so the broken range can't resolve. Plus a regression test that reproduces botocore's exact `parse(value, tzinfos={'GMT': tzutc()})` call and asserts the installed version.

## Verification
- The new test **reproduces the crash** on 2.6.1 and **passes** on 2.9.0.post0.
- Upgraded the affected local env to 2.9.0.post0 (`pip install -U python-dateutil>=2.8.2`) — settlement/secrets path no longer hits the AttributeError.

## Operator note
Existing environments still on the old version need `pip install -U 'python-dateutil>=2.8.2'` (the pyproject floor only governs fresh resolves). The local dev env on this machine has already been upgraded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)