### PR TITLE
fix(review): close collect-evidence API connector

### DIFF
--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -355,7 +355,8 @@ async def _close_api_agent_resources(agent: Any) -> None:
     try:
         # This collector calls API reviewers through a one-shot asyncio.run()
         # loop, so the shared aiohttp connector must be released before that
-        # loop is torn down. The collector dispatches reviewers serially.
+        # loop is torn down. The collector dispatches reviewers serially; if it
+        # ever fans reviewers out, cleanup must move outside the per-reviewer path.
         await close_shared_connector()
     except Exception as exc:  # noqa: BLE001 - cleanup must not mask reviewer results.
         logger.debug("collect-evidence shared connector close failed: %s", exc)

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -343,7 +343,7 @@ async def _close_api_agent_resources(agent: Any) -> None:
             result = close()
             if inspect.isawaitable(result):
                 await result
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001 - cleanup must not mask reviewer results.
             logger.debug("collect-evidence API agent close failed: %s", exc)
 
     try:
@@ -353,8 +353,11 @@ async def _close_api_agent_resources(agent: Any) -> None:
         return
 
     try:
+        # This collector calls API reviewers through a one-shot asyncio.run()
+        # loop, so the shared aiohttp connector must be released before that
+        # loop is torn down. The collector dispatches reviewers serially.
         await close_shared_connector()
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001 - cleanup must not mask reviewer results.
         logger.debug("collect-evidence shared connector close failed: %s", exc)
 
 

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -27,6 +27,7 @@ all network/process I/O is injected so the orchestrator
 from __future__ import annotations
 
 import asyncio
+import inspect
 import re
 import subprocess
 from collections.abc import Callable, Sequence
@@ -314,13 +315,43 @@ def _run_api_agent(family: str, prompt: str) -> ReviewerResult:
         return ReviewerResult(family, "", False, f"create_agent import failed: {exc}")
     try:
         agent = create_agent(family, name=f"{family}_reviewer", role="critic")
-        text = asyncio.run(asyncio.wait_for(agent.generate(prompt), timeout=_REVIEWER_TIMEOUT))
+        text = asyncio.run(_generate_with_api_agent_cleanup(agent, prompt))
     except Exception as exc:
         return ReviewerResult(family, "", False, f"{type(exc).__name__}: {str(exc)[:200]}")
     text = (text or "").strip()
     if not text:
         return ReviewerResult(family, "", False, "empty reviewer output")
     return ReviewerResult(family, _cap_text(text), True)
+
+
+async def _generate_with_api_agent_cleanup(agent: Any, prompt: str) -> str:
+    """Generate with an API-backed agent and close one-shot network resources."""
+    try:
+        return await asyncio.wait_for(agent.generate(prompt), timeout=_REVIEWER_TIMEOUT)
+    finally:
+        await _close_api_agent_resources(agent)
+
+
+async def _close_api_agent_resources(agent: Any) -> None:
+    """Best-effort cleanup for collect-evidence one-shot API reviewer runs."""
+    close = getattr(agent, "close", None)
+    if callable(close):
+        try:
+            result = close()
+            if inspect.isawaitable(result):
+                await result
+        except Exception:
+            pass
+
+    try:
+        from aragora.agents.api_agents.common import close_shared_connector
+    except Exception:
+        return
+
+    try:
+        await close_shared_connector()
+    except Exception:
+        pass
 
 
 def default_prompt_builder(repo: str, pr: int, ctx: dict[str, Any]) -> str:

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import logging
 import re
 import subprocess
 from collections.abc import Callable, Sequence
@@ -35,6 +36,8 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from aragora.swarm import merge_quorum_io
+
+logger = logging.getLogger(__name__)
 
 # Direct model families whose name appears in the evidence heading and is
 # recognized by the quorum identity resolver as a countable model reviewer.
@@ -340,18 +343,19 @@ async def _close_api_agent_resources(agent: Any) -> None:
             result = close()
             if inspect.isawaitable(result):
                 await result
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug("collect-evidence API agent close failed: %s", exc)
 
     try:
         from aragora.agents.api_agents.common import close_shared_connector
-    except Exception:
+    except ImportError as exc:
+        logger.debug("collect-evidence shared connector cleanup unavailable: %s", exc)
         return
 
     try:
         await close_shared_connector()
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.debug("collect-evidence shared connector close failed: %s", exc)
 
 
 def default_prompt_builder(repo: str, pr: int, ctx: dict[str, Any]) -> str:

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -296,6 +296,95 @@ def test_run_api_agent_closes_shared_connector_after_agent_close_failure(
     assert events == ["generate", "agent_close", "connector_close"]
 
 
+def test_run_api_agent_closes_shared_connector_without_agent_close(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+
+    class FakeAgent:
+        async def generate(self, prompt: str) -> str:
+            events.append("generate")
+            return "Verdict: PASS"
+
+    def fake_create_agent(family: str, *, name: str, role: str) -> FakeAgent:
+        return FakeAgent()
+
+    async def fake_close_shared_connector() -> None:
+        events.append("connector_close")
+
+    import aragora.agents
+    from aragora.agents.api_agents import common
+
+    monkeypatch.setattr(aragora.agents, "create_agent", fake_create_agent)
+    monkeypatch.setattr(common, "close_shared_connector", fake_close_shared_connector)
+
+    result = qe._run_api_agent("grok", "review prompt")
+
+    assert result == ReviewerResult("grok", "Verdict: PASS", True)
+    assert events == ["generate", "connector_close"]
+
+
+def test_run_api_agent_supports_sync_agent_close(monkeypatch: pytest.MonkeyPatch) -> None:
+    events: list[str] = []
+
+    class FakeAgent:
+        async def generate(self, prompt: str) -> str:
+            events.append("generate")
+            return "Verdict: PASS"
+
+        def close(self) -> None:
+            events.append("agent_close")
+
+    def fake_create_agent(family: str, *, name: str, role: str) -> FakeAgent:
+        return FakeAgent()
+
+    async def fake_close_shared_connector() -> None:
+        events.append("connector_close")
+
+    import aragora.agents
+    from aragora.agents.api_agents import common
+
+    monkeypatch.setattr(aragora.agents, "create_agent", fake_create_agent)
+    monkeypatch.setattr(common, "close_shared_connector", fake_close_shared_connector)
+
+    result = qe._run_api_agent("grok", "review prompt")
+
+    assert result == ReviewerResult("grok", "Verdict: PASS", True)
+    assert events == ["generate", "agent_close", "connector_close"]
+
+
+def test_run_api_agent_keeps_result_when_shared_connector_close_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+
+    class FakeAgent:
+        async def generate(self, prompt: str) -> str:
+            events.append("generate")
+            return "Verdict: PASS"
+
+        async def close(self) -> None:
+            events.append("agent_close")
+
+    def fake_create_agent(family: str, *, name: str, role: str) -> FakeAgent:
+        return FakeAgent()
+
+    async def fake_close_shared_connector() -> None:
+        events.append("connector_close")
+        raise RuntimeError("connector failed")
+
+    import aragora.agents
+    from aragora.agents.api_agents import common
+
+    monkeypatch.setattr(aragora.agents, "create_agent", fake_create_agent)
+    monkeypatch.setattr(common, "close_shared_connector", fake_close_shared_connector)
+
+    result = qe._run_api_agent("grok", "review prompt")
+
+    assert result == ReviewerResult("grok", "Verdict: PASS", True)
+    assert events == ["generate", "agent_close", "connector_close"]
+
+
 # --- collect_evidence orchestration (fully offline via injected callables) ---
 
 

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -264,6 +264,38 @@ def test_run_api_agent_closes_resources_after_generate_failure(
     assert events == ["generate", "agent_close", "connector_close"]
 
 
+def test_run_api_agent_closes_shared_connector_after_agent_close_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+
+    class FakeAgent:
+        async def generate(self, prompt: str) -> str:
+            events.append("generate")
+            return "Verdict: PASS"
+
+        async def close(self) -> None:
+            events.append("agent_close")
+            raise RuntimeError("close failed")
+
+    def fake_create_agent(family: str, *, name: str, role: str) -> FakeAgent:
+        return FakeAgent()
+
+    async def fake_close_shared_connector() -> None:
+        events.append("connector_close")
+
+    import aragora.agents
+    from aragora.agents.api_agents import common
+
+    monkeypatch.setattr(aragora.agents, "create_agent", fake_create_agent)
+    monkeypatch.setattr(common, "close_shared_connector", fake_close_shared_connector)
+
+    result = qe._run_api_agent("grok", "review prompt")
+
+    assert result == ReviewerResult("grok", "Verdict: PASS", True)
+    assert events == ["generate", "agent_close", "connector_close"]
+
+
 # --- collect_evidence orchestration (fully offline via injected callables) ---
 
 

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -194,6 +194,76 @@ def test_compose_sanitizes_committed_timestamp() -> None:
     assert capped.endswith("[reviewer output truncated]")
 
 
+# --- default API reviewer cleanup ------------------------------------------
+
+
+def test_run_api_agent_closes_agent_and_shared_connector(monkeypatch: pytest.MonkeyPatch) -> None:
+    events: list[str] = []
+
+    class FakeAgent:
+        async def generate(self, prompt: str) -> str:
+            events.append(f"generate:{prompt}")
+            return "Verdict: PASS"
+
+        async def close(self) -> None:
+            events.append("agent_close")
+
+    def fake_create_agent(family: str, *, name: str, role: str) -> FakeAgent:
+        events.append(f"create:{family}:{name}:{role}")
+        return FakeAgent()
+
+    async def fake_close_shared_connector() -> None:
+        events.append("connector_close")
+
+    import aragora.agents
+    from aragora.agents.api_agents import common
+
+    monkeypatch.setattr(aragora.agents, "create_agent", fake_create_agent)
+    monkeypatch.setattr(common, "close_shared_connector", fake_close_shared_connector)
+
+    result = qe._run_api_agent("grok", "review prompt")
+
+    assert result == ReviewerResult("grok", "Verdict: PASS", True)
+    assert events == [
+        "create:grok:grok_reviewer:critic",
+        "generate:review prompt",
+        "agent_close",
+        "connector_close",
+    ]
+
+
+def test_run_api_agent_closes_resources_after_generate_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+
+    class FakeAgent:
+        async def generate(self, prompt: str) -> str:
+            events.append("generate")
+            raise RuntimeError("model failed")
+
+        async def close(self) -> None:
+            events.append("agent_close")
+
+    def fake_create_agent(family: str, *, name: str, role: str) -> FakeAgent:
+        return FakeAgent()
+
+    async def fake_close_shared_connector() -> None:
+        events.append("connector_close")
+
+    import aragora.agents
+    from aragora.agents.api_agents import common
+
+    monkeypatch.setattr(aragora.agents, "create_agent", fake_create_agent)
+    monkeypatch.setattr(common, "close_shared_connector", fake_close_shared_connector)
+
+    result = qe._run_api_agent("grok", "review prompt")
+
+    assert result.ok is False
+    assert "RuntimeError: model failed" in result.error
+    assert events == ["generate", "agent_close", "connector_close"]
+
+
 # --- collect_evidence orchestration (fully offline via injected callables) ---
 
 

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -385,6 +385,49 @@ def test_run_api_agent_keeps_result_when_shared_connector_close_fails(
     assert events == ["generate", "agent_close", "connector_close"]
 
 
+def test_run_api_agent_allows_consecutive_one_shot_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+
+    class FakeAgent:
+        async def generate(self, prompt: str) -> str:
+            events.append(f"generate:{prompt}")
+            return f"Verdict: PASS {prompt}"
+
+        async def close(self) -> None:
+            events.append("agent_close")
+
+    def fake_create_agent(family: str, *, name: str, role: str) -> FakeAgent:
+        events.append(f"create:{family}")
+        return FakeAgent()
+
+    async def fake_close_shared_connector() -> None:
+        events.append("connector_close")
+
+    import aragora.agents
+    from aragora.agents.api_agents import common
+
+    monkeypatch.setattr(aragora.agents, "create_agent", fake_create_agent)
+    monkeypatch.setattr(common, "close_shared_connector", fake_close_shared_connector)
+
+    first = qe._run_api_agent("grok", "one")
+    second = qe._run_api_agent("grok", "two")
+
+    assert first == ReviewerResult("grok", "Verdict: PASS one", True)
+    assert second == ReviewerResult("grok", "Verdict: PASS two", True)
+    assert events == [
+        "create:grok",
+        "generate:one",
+        "agent_close",
+        "connector_close",
+        "create:grok",
+        "generate:two",
+        "agent_close",
+        "connector_close",
+    ]
+
+
 # --- collect_evidence orchestration (fully offline via injected callables) ---
 
 


### PR DESCRIPTION
Summary:
- Close one-shot API reviewer resources after review-queue collect-evidence runs.
- Calls agent-level close hooks when available and closes the shared aiohttp connector before asyncio.run tears down the loop.
- Adds offline success and failure cleanup tests.

Validation:
- PYTHONDONTWRITEBYTECODE=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/swarm/test_quorum_evidence.py
- python3 -m ruff check aragora/swarm/quorum_evidence.py tests/swarm/test_quorum_evidence.py
- python3 -m ruff format --check aragora/swarm/quorum_evidence.py tests/swarm/test_quorum_evidence.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- PYTHONDONTWRITEBYTECODE=1 python3 -m aragora.cli.main review-queue collect-evidence --pr 7759 --repo synaptent/aragora --reviewers grok --json

Live trigger:
- The collect-evidence run used for #7759 emitted an unclosed aiohttp connector warning after success. This branch fixes that one-shot cleanup path. The post-fix single-Grok dry run completed without the unclosed connector warning.

Scope:
- Draft PR only. No merge, statuses, branch protection changes, or broad queue drain.