### PR TITLE
fix(settlement): atomically post human-settlement status from record-settlement

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -509,6 +509,24 @@ def add_review_queue_parser(subparsers: argparse._SubParsersAction) -> None:
             "commit as the exact guard. Default is dry-run/report only."
         ),
     )
+    record_p.add_argument(
+        "--post-github-status",
+        action="store_true",
+        help=(
+            "After the local receipt is durably written, atomically POST the "
+            "'aragora/human-settlement'=success commit status for the exact head "
+            "SHA. This is the ONLY GitHub mutation this command performs, and it "
+            "is the safe replacement for running 'gh api ... statuses' as a "
+            "separate command: the status can never be set unless the receipt "
+            "write succeeded first (receipt => status, never status => no "
+            "receipt). If the receipt write fails, the status is never posted."
+        ),
+    )
+    record_p.add_argument(
+        "--github-status-context",
+        default="aragora/human-settlement",
+        help="Commit-status context to post with --post-github-status.",
+    )
     record_p.add_argument("--json", action="store_true", help="Output local receipt as JSON")
 
     merge_packet_p = sub.add_parser(
@@ -1042,10 +1060,52 @@ def _cmd_record_settlement(args: argparse.Namespace) -> int:
     except _GhError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
+
+    # Atomic settlement signal: the receipt is now durably written. Only here do
+    # we publish the gate-trusted 'aragora/human-settlement' commit status, so a
+    # green status can never exist without its backing receipt. (Running
+    # 'gh api ... statuses' as a separate command decoupled the two and could set
+    # the status even when the receipt write crashed/failed.) A failure posting
+    # the status leaves a receipt with no status — the safe direction: the
+    # operator simply retries, and the merge gate stays closed until it lands.
+    github_status: dict[str, Any] | None = None
+    status_failed = False
+    if getattr(args, "post_github_status", False):
+        try:
+            github_status = _post_human_settlement_status(
+                repo_slug=_resolve_settlement_repo_slug(getattr(args, "repo", None)),
+                head_sha=head_sha,
+                context=str(
+                    getattr(args, "github_status_context", "") or "aragora/human-settlement"
+                ),
+                pr_ref=str(getattr(args, "pr")),
+                receipt_sha256=result.receipt_sha256,
+            )
+        except _GhError as exc:
+            status_failed = True
+            github_status = {"posted": False, "error": str(exc)}
+
     if json_output:
-        print(json.dumps(result.to_dict(), indent=2))
+        payload = result.to_dict()
+        if github_status is not None:
+            payload["github_status"] = github_status
+        print(json.dumps(payload, indent=2))
     else:
         _render_recorded_settlement_result(result)
+        if github_status is not None and not status_failed:
+            print(
+                f"  github-status: {github_status.get('context')}="
+                f"{github_status.get('state')} @ {head_sha[:12]}"
+            )
+
+    if status_failed:
+        print(
+            "error: receipt written but GitHub status POST failed "
+            f"({github_status.get('error') if github_status else 'unknown'}); "
+            "re-run record-settlement --post-github-status to retry.",
+            file=sys.stderr,
+        )
+        return 1
     return 1 if result.post_merge_lane_audit_failed else 0
 
 
@@ -1327,6 +1387,63 @@ def _gh_json(args: list[str]) -> Any:
         return json.loads(out)
     except json.JSONDecodeError as exc:
         raise _GhError(f"gh {' '.join(args)} returned malformed JSON: {exc}") from exc
+
+
+def _resolve_settlement_repo_slug(repo_override: str | None) -> str:
+    """Return ``owner/name``, preferring an explicit override then ``gh`` context."""
+    slug = str(repo_override or "").strip()
+    if slug:
+        return slug
+    data = _gh_json(["repo", "view", "--json", "nameWithOwner"])
+    if isinstance(data, dict):
+        slug = str(data.get("nameWithOwner", "") or "").strip()
+    if not slug:
+        raise _GhError("could not resolve repo slug; pass --repo owner/name")
+    return slug
+
+
+def _post_human_settlement_status(
+    *,
+    repo_slug: str,
+    head_sha: str,
+    context: str,
+    pr_ref: str,
+    receipt_sha256: str,
+) -> dict[str, Any]:
+    """POST the head-bound human-settlement commit status, citing the receipt.
+
+    Only called after the local receipt is durably written, so the status is
+    always backed by a receipt. The receipt sha is embedded in the status
+    description for an auditable status->receipt link.
+    """
+    pr_digits = "".join(ch for ch in str(pr_ref) if ch.isdigit()) or str(pr_ref)
+    description = (f"Settlement receipt {receipt_sha256} recorded for PR #{pr_digits}")[:140]
+    resp = _gh_json(
+        [
+            "api",
+            "--method",
+            "POST",
+            f"repos/{repo_slug}/statuses/{head_sha}",
+            "-f",
+            "state=success",
+            "-f",
+            f"context={context}",
+            "-f",
+            f"description={description}",
+        ]
+    )
+    state = ""
+    posted_context = context
+    if isinstance(resp, dict):
+        state = str(resp.get("state", "") or "")
+        posted_context = str(resp.get("context", context) or context)
+    return {
+        "posted": True,
+        "context": posted_context,
+        "state": state,
+        "head_sha": head_sha,
+        "receipt_sha256": receipt_sha256,
+    }
 
 
 def _build_queue(*, limit: int) -> list[QueueItem]:

--- a/tests/cli/commands/test_review_queue_settlement_status.py
+++ b/tests/cli/commands/test_review_queue_settlement_status.py
@@ -1,0 +1,147 @@
+"""Atomic 'aragora/human-settlement' status posting for record-settlement.
+
+Guards the integrity property: a green human-settlement commit status can only
+exist when its backing receipt was durably written. The status POST is performed
+by record-settlement itself (after the receipt), never as a decoupled
+``gh api ... statuses`` command that runs regardless of receipt success.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+from contextlib import redirect_stdout
+from types import SimpleNamespace
+
+import pytest
+
+from aragora.cli.commands import review_queue as rq
+
+
+def _args(**over):
+    base = dict(
+        pr="7521",
+        head_sha="83611936eed7d10d683c15b0af21411288e16b17",
+        action="approve",
+        reason="Operator risk settlement: Tier 4",
+        repo="synaptent/aragora",
+        review_queue_root=None,
+        apply_post_merge_lane_audit=False,
+        post_github_status=True,
+        github_status_context="aragora/human-settlement",
+        json=True,
+    )
+    base.update(over)
+    return argparse.Namespace(**base)
+
+
+def _fake_result():
+    receipt = SimpleNamespace(to_dict=lambda: {"head_sha": "83611936eed7", "pr_number": 7521})
+    return SimpleNamespace(
+        receipt=receipt,
+        receipt_sha256="sha256:1dc0212113e65dd0c7c2d3101494e1aa739cfc34d",
+        idempotent=False,
+        written=True,
+        post_merge_lane_audit_failed=False,
+        to_dict=lambda: {
+            "head_sha": "83611936eed7",
+            "pr_number": 7521,
+            "receipt_sha256": "sha256:1dc0212113e65dd0c7c2d3101494e1aa739cfc34d",
+            "written": True,
+        },
+    )
+
+
+@pytest.fixture
+def gh_calls(monkeypatch):
+    calls: list[list[str]] = []
+
+    def fake_gh_json(args):
+        calls.append(list(args))
+        if args[:3] == ["repo", "view", "--json"]:
+            return {"nameWithOwner": "synaptent/aragora"}
+        if args[:1] == ["api"]:
+            return {"state": "success", "context": "aragora/human-settlement"}
+        return None
+
+    monkeypatch.setattr(rq, "_gh_json", fake_gh_json)
+    monkeypatch.setattr(rq, "_require_clean_worktree", lambda repo_root: None)
+    return calls
+
+
+def _statuses_posts(calls):
+    return [c for c in calls if c[:1] == ["api"] and any("statuses/" in part for part in c)]
+
+
+def test_status_posted_after_successful_receipt(gh_calls, monkeypatch):
+    monkeypatch.setattr(rq, "_record_external_settlement", lambda **kw: _fake_result())
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = rq._cmd_record_settlement(_args())
+
+    assert rc == 0
+    posts = _statuses_posts(gh_calls)
+    assert len(posts) == 1, gh_calls
+    flat = " ".join(posts[0])
+    assert "state=success" in flat
+    assert "context=aragora/human-settlement" in flat
+    # The receipt sha is embedded in the status description (status->receipt link).
+    assert "sha256:1dc0212113e65dd0c7c2d3101494e1aa739cfc34d" in flat
+    payload = json.loads(buf.getvalue())
+    assert payload["github_status"]["posted"] is True
+
+
+def test_status_NEVER_posted_when_receipt_write_fails(gh_calls, monkeypatch):
+    """The integrity property: a failed/aborted receipt must not yield a status."""
+
+    def boom(**kw):
+        raise rq._GhError("settlement requires a clean worktree")
+
+    monkeypatch.setattr(rq, "_record_external_settlement", boom)
+
+    rc = rq._cmd_record_settlement(_args())
+
+    assert rc == 1
+    assert _statuses_posts(gh_calls) == [], "status POST must not run when receipt write fails"
+
+
+def test_status_failure_after_receipt_returns_error_but_keeps_receipt(monkeypatch):
+    """Safe direction: receipt written, status POST fails -> exit 1, no green status."""
+    monkeypatch.setattr(rq, "_require_clean_worktree", lambda repo_root: None)
+    monkeypatch.setattr(rq, "_record_external_settlement", lambda **kw: _fake_result())
+
+    def fake_gh_json(args):
+        if args[:3] == ["repo", "view", "--json"]:
+            return {"nameWithOwner": "synaptent/aragora"}
+        raise rq._GhError("status endpoint 422")
+
+    monkeypatch.setattr(rq, "_gh_json", fake_gh_json)
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = rq._cmd_record_settlement(_args())
+
+    assert rc == 1
+    payload = json.loads(buf.getvalue())
+    assert payload["github_status"]["posted"] is False
+    assert payload["written"] is True  # receipt survived
+
+
+def test_no_status_posted_without_flag(gh_calls, monkeypatch):
+    monkeypatch.setattr(rq, "_record_external_settlement", lambda **kw: _fake_result())
+
+    rc = rq._cmd_record_settlement(_args(post_github_status=False))
+
+    assert rc == 0
+    assert _statuses_posts(gh_calls) == []
+
+
+def test_resolve_repo_slug_prefers_override():
+    assert rq._resolve_settlement_repo_slug("owner/name") == "owner/name"
+
+
+def test_resolve_repo_slug_falls_back_to_gh(monkeypatch):
+    monkeypatch.setattr(rq, "_gh_json", lambda args: {"nameWithOwner": "synaptent/aragora"})
+    assert rq._resolve_settlement_repo_slug(None) == "synaptent/aragora"


### PR DESCRIPTION
## Problem (decision-integrity hole)
The merge gate (`aragora-merge-quorum.yml`) trusts a head-bound `aragora/human-settlement`=success commit status as proof of Tier-3/4 human risk acceptance — its comment says it's set *"AFTER recording the local settlement receipt."* CI can't read the local receipt, so the status is the only trust anchor, yet operators set it with a **separate, unchained** command:

```
review-queue record-settlement …          # writes the receipt
gh api … POST …/statuses … state=success  # sets the gate status
```

The status POST ran **regardless of whether record-settlement succeeded**. It failed repeatedly in the field (the dateutil `collections.Callable` crash; the `requires a clean worktree` guard) yet the status was still posted → **green gate status with no backing receipt** (observed #7495, #7567). Exactly the failure the receipt system exists to prevent.

## Fix
`record-settlement --post-github-status`: after the receipt is durably written, the command itself POSTs the status, embedding the receipt sha256 in the description. Ordering makes the dangerous direction impossible: **receipt ⟹ status, never status ⟹ no receipt.** A status POST that fails after a written receipt returns exit 1 (operator retries; gate stays closed). Opt-in flag; default behavior unchanged.

## Tests
6 tests incl. `test_status_NEVER_posted_when_receipt_write_fails` and the safe-direction case (receipt written + status fails → exit 1, receipt survives). 223 existing review_queue tests pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)