### PR TITLE
feat(profiles): audit Claude pool for subscription-seat (orgId) collisions

### DIFF
--- a/aragora/agents/claude_profile_audit.py
+++ b/aragora/agents/claude_profile_audit.py
@@ -1,0 +1,173 @@
+"""Audit the Claude subscription-profile pool for subscription-seat collisions.
+
+The pool (``~/.aragora-claude/max-*``, driven by ``scripts/claude_profile.sh``)
+backs the debate/review Claude agents. Each profile is one authenticated
+claude.ai *session*, but a session is keyed by the *organization* it bills
+inference to — not by the login email. A single login (email) can belong to
+several organizations (e.g. a personal Max org and a shared Team org), and two
+profiles that select **different** orgs are genuinely distinct subscription
+seats even when their email matches.
+
+The failure that actually hurts the pool is two profiles sharing the **same
+org** (same ``orgId``): they draw on one subscription seat / rate-limit pool and
+a fresh login to that org can rotate the other's session. That collision can
+occur with the *same* email (a true duplicate) or — easy to miss — with two
+*different* emails that both belong to the same Team org.
+
+This module is the pure, dependency-free analysis. ``scripts/audit_claude_profiles.py``
+collects the live identities (via ``claude auth status``) and renders the report.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class ProfileIdentity:
+    """One profile's claude.ai identity, parsed from ``claude auth status``."""
+
+    profile: str
+    email: str = ""
+    org_id: str = ""
+    org_name: str = ""
+    plan: str = ""
+    # Optional live-probe / expiry result: True=usable, False=expired/401,
+    # None=unknown. Audit logic never *depends* on this; it is passed through
+    # for the rendered report.
+    token_live: bool | None = None
+
+
+@dataclass(frozen=True)
+class CollisionGroup:
+    kind: str  # "org_seat" | "shared_credential"
+    severity: str  # "high" | "warn"
+    key: str  # the shared org_id or email
+    label: str  # human label (org name or email)
+    profiles: tuple[str, ...]
+    detail: str
+
+
+@dataclass
+class AuditResult:
+    profile_count: int
+    distinct_org_count: int
+    distinct_email_count: int
+    org_seat_collisions: list[CollisionGroup] = field(default_factory=list)
+    shared_credential_collisions: list[CollisionGroup] = field(default_factory=list)
+    recommendations: list[str] = field(default_factory=list)
+
+    @property
+    def has_collisions(self) -> bool:
+        return bool(self.org_seat_collisions or self.shared_credential_collisions)
+
+    def to_dict(self) -> dict:
+        def _grp(g: CollisionGroup) -> dict:
+            return {
+                "kind": g.kind,
+                "severity": g.severity,
+                "key": g.key,
+                "label": g.label,
+                "profiles": list(g.profiles),
+                "detail": g.detail,
+            }
+
+        return {
+            "profile_count": self.profile_count,
+            "distinct_org_count": self.distinct_org_count,
+            "distinct_email_count": self.distinct_email_count,
+            "org_seat_collisions": [_grp(g) for g in self.org_seat_collisions],
+            "shared_credential_collisions": [_grp(g) for g in self.shared_credential_collisions],
+            "recommendations": list(self.recommendations),
+        }
+
+
+def _group(identities, key):
+    out: dict[str, list[ProfileIdentity]] = {}
+    for ident in identities:
+        value = (key(ident) or "").strip()
+        if value:
+            out.setdefault(value, []).append(ident)
+    return out
+
+
+def analyze_profiles(identities: list[ProfileIdentity]) -> AuditResult:
+    """Compute subscription-seat and shared-credential collisions.
+
+    - **org_seat** (high): >=2 profiles share a non-empty ``org_id`` — same
+      subscription seat. The dangerous one; covers same-email duplicates *and*
+      different-email-same-Team-org collisions.
+    - **shared_credential** (warn): >=2 profiles share an ``email`` but span
+      >=2 distinct ``org_id`` values — distinct subscriptions reached through one
+      login. Usually fine, but the user-level session may still contend.
+    """
+    by_org = _group(identities, lambda i: i.org_id)
+    by_email = _group(identities, lambda i: i.email)
+
+    org_seat: list[CollisionGroup] = []
+    for org_id, members in sorted(by_org.items()):
+        if len(members) < 2:
+            continue
+        names = sorted(m.profile for m in members)
+        label = next((m.org_name for m in members if m.org_name), org_id)
+        org_seat.append(
+            CollisionGroup(
+                kind="org_seat",
+                severity="high",
+                key=org_id,
+                label=label,
+                profiles=tuple(names),
+                detail=(
+                    f"{', '.join(names)} all bill inference to org '{label}' "
+                    f"({org_id[:8]}) — one subscription seat shared across "
+                    f"{len(names)} profiles."
+                ),
+            )
+        )
+
+    shared_cred: list[CollisionGroup] = []
+    for email, members in sorted(by_email.items()):
+        if len(members) < 2:
+            continue
+        distinct_orgs = {m.org_id for m in members if m.org_id}
+        if len(distinct_orgs) < 2:
+            # Same email + (same or unknown org) is already captured by org_seat
+            # when the org matches; nothing distinct to flag here.
+            continue
+        names = sorted(m.profile for m in members)
+        shared_cred.append(
+            CollisionGroup(
+                kind="shared_credential",
+                severity="warn",
+                key=email,
+                label=email,
+                profiles=tuple(names),
+                detail=(
+                    f"{', '.join(names)} share login '{email}' across "
+                    f"{len(distinct_orgs)} different orgs — distinct subscriptions, "
+                    "but one user-level session token may still rotate the others."
+                ),
+            )
+        )
+
+    recommendations: list[str] = []
+    for g in org_seat:
+        keep, *drop = g.profiles
+        recommendations.append(
+            f"Consolidate org-seat collision on '{g.label}': keep {keep}, free "
+            f"{', '.join(drop)}, and point the freed slot(s) at a distinct account."
+        )
+    for g in shared_cred:
+        recommendations.append(
+            f"Shared login '{g.label}' spans {', '.join(g.profiles)}: prefer "
+            "separate logins per profile to avoid session-level contention."
+        )
+
+    return AuditResult(
+        profile_count=len(identities),
+        distinct_org_count=len({i.org_id for i in identities if i.org_id}),
+        distinct_email_count=len({i.email for i in identities if i.email}),
+        org_seat_collisions=org_seat,
+        shared_credential_collisions=shared_cred,
+        recommendations=recommendations,
+    )

--- a/scripts/audit_claude_profiles.py
+++ b/scripts/audit_claude_profiles.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Audit the Claude subscription-profile pool for subscription-seat collisions.
+
+Collects each profile's live claude.ai identity (``claude_profile.sh status``)
+plus its access-token expiry, then reports the topology and any collisions via
+:mod:`aragora.agents.claude_profile_audit`.
+
+Usage:
+    python3 scripts/audit_claude_profiles.py [--json] [profile ...]
+
+Without explicit profiles it audits max-01..max-13 (override with
+``ARAGORA_CLAUDE_REVIEW_PROFILES``). Read-only: it runs ``status`` (no login,
+no live inference probe) and reads local credential files only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from aragora.agents.claude_profile_audit import (  # noqa: E402
+    ProfileIdentity,
+    analyze_profiles,
+)
+
+DEFAULT_PROFILES = tuple(f"max-{i:02d}" for i in range(1, 14))
+
+
+def _default_profiles() -> list[str]:
+    raw = os.environ.get("ARAGORA_CLAUDE_REVIEW_PROFILES", "").strip()
+    if not raw:
+        return list(DEFAULT_PROFILES)
+    out: list[str] = []
+    for item in raw.split(","):
+        name = item.strip()
+        if name and name not in out:
+            out.append(name)
+    return out or list(DEFAULT_PROFILES)
+
+
+def _profile_root() -> Path:
+    override = os.environ.get("CLAUDE_PROFILE_ROOT", "").strip()
+    return Path(override) if override else Path.home() / ".aragora-claude"
+
+
+def _status_json(profile_tool: Path, profile: str) -> dict:
+    try:
+        proc = subprocess.run(
+            [str(profile_tool), "status", profile],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return {}
+    out = proc.stdout.strip()
+    if not out:
+        return {}
+    # status may prepend wrapper lines; find the JSON object.
+    start = out.find("{")
+    if start < 0:
+        return {}
+    try:
+        return json.loads(out[start:])
+    except json.JSONDecodeError:
+        return {}
+
+
+def _token_live(profile_root: Path, profile: str) -> bool | None:
+    cred = profile_root / profile / ".claude" / ".credentials.json"
+    try:
+        data = json.loads(cred.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    oauth = data.get("claudeAiOauth") or data.get("oauth") or data
+    exp = oauth.get("expiresAt") or oauth.get("expires_at")
+    if not isinstance(exp, (int, float)):
+        return None
+    seconds = exp / 1000 if exp > 1e12 else exp
+    return datetime.fromtimestamp(seconds, tz=timezone.utc) > datetime.now(timezone.utc)
+
+
+def _collect(profiles: list[str]) -> list[ProfileIdentity]:
+    profile_tool = REPO_ROOT / "scripts" / "claude_profile.sh"
+    profile_root = _profile_root()
+    identities: list[ProfileIdentity] = []
+    for profile in profiles:
+        status = _status_json(profile_tool, profile)
+        identities.append(
+            ProfileIdentity(
+                profile=profile,
+                email=str(status.get("email", "") or ""),
+                org_id=str(status.get("orgId", "") or ""),
+                org_name=str(status.get("orgName", "") or ""),
+                plan=str(status.get("subscriptionType", "") or ""),
+                token_live=_token_live(profile_root, profile),
+            )
+        )
+    return identities
+
+
+def _render(identities: list[ProfileIdentity], result) -> None:
+    def live(t: bool | None) -> str:
+        return "live" if t else ("EXPIRED" if t is False else "?")
+
+    print("Claude profile pool topology")
+    print("=" * 78)
+    print(f"{'profile':9} {'token':8} {'plan':5} {'org':30} {'email'}")
+    for i in identities:
+        print(
+            f"{i.profile:9} {live(i.token_live):8} {i.plan or '-':5} "
+            f"{(i.org_name or '-')[:30]:30} {i.email or '-'}"
+        )
+    print(
+        f"\n{result.profile_count} profiles | {result.distinct_org_count} distinct orgs "
+        f"| {result.distinct_email_count} distinct logins"
+    )
+    if result.org_seat_collisions:
+        print("\n[HIGH] Same-subscription-seat collisions (consolidate):")
+        for g in result.org_seat_collisions:
+            print(f"  - {g.detail}")
+    if result.shared_credential_collisions:
+        print("\n[warn] Shared-login (different orgs — distinct subs, may contend):")
+        for g in result.shared_credential_collisions:
+            print(f"  - {g.detail}")
+    if result.recommendations:
+        print("\nRecommendations:")
+        for rec in result.recommendations:
+            print(f"  * {rec}")
+    if not result.has_collisions:
+        print("\nNo subscription-seat collisions detected.")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("profiles", nargs="*", help="Profiles to audit (default: max-01..max-13)")
+    parser.add_argument("--json", action="store_true", help="Emit JSON")
+    args = parser.parse_args(argv)
+
+    profiles = args.profiles or _default_profiles()
+    identities = _collect(profiles)
+    result = analyze_profiles(identities)
+
+    if args.json:
+        payload = result.to_dict()
+        payload["profiles"] = [
+            {
+                "profile": i.profile,
+                "email": i.email,
+                "org_id": i.org_id,
+                "org_name": i.org_name,
+                "plan": i.plan,
+                "token_live": i.token_live,
+            }
+            for i in identities
+        ]
+        print(json.dumps(payload, indent=2))
+    else:
+        _render(identities, result)
+    # Exit non-zero on a high-severity (org-seat) collision so CI/cron can alert.
+    return 1 if result.org_seat_collisions else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/agents/test_claude_profile_audit.py
+++ b/tests/agents/test_claude_profile_audit.py
@@ -1,0 +1,85 @@
+"""Tests for Claude profile-pool subscription-seat collision analysis."""
+
+from __future__ import annotations
+
+from aragora.agents.claude_profile_audit import ProfileIdentity, analyze_profiles
+
+
+def _real_pool() -> list[ProfileIdentity]:
+    # The live topology observed 2026-06-04. Exercises every collision type:
+    #   - max-03/max-06: same email AND same org (121e7534) -> org_seat
+    #   - max-09/max-12: DIFFERENT emails, same Team org (d16e9a80) -> org_seat
+    #   - max-08/max-09: same email, different orgs -> shared_credential
+    #   - max-12/max-13: same email, different orgs -> shared_credential
+    return [
+        ProfileIdentity("max-01", "anomium@gmail.com", "4f4be2d3", "anomium org", "max"),
+        ProfileIdentity("max-02", "scarmani@gmail.com", "f3dc8855", "scarmani org", "max"),
+        ProfileIdentity("max-03", "ap@synaptent.com", "121e7534", "ap org", "max"),
+        ProfileIdentity("max-04", "liftmode@liftmode.com", "26bee17b", "liftmode org", "max"),
+        ProfileIdentity("max-05", "root@liftmode.com", "640528f9", "root org", "max"),
+        ProfileIdentity("max-06", "ap@synaptent.com", "121e7534", "ap org", "max"),
+        ProfileIdentity("max-07", "radnoem@gmail.com", "1e896949", "radnoem org", "max"),
+        ProfileIdentity("max-08", "synaptent@synaptent.com", "0ff1715d", "synaptent org", "max"),
+        ProfileIdentity("max-09", "synaptent@synaptent.com", "d16e9a80", "Synaptent", "team"),
+        ProfileIdentity("max-10", "armand.tuzel@gmail.com", "2c14611b", "tuzel org", "max"),
+        ProfileIdentity("max-11", "verborgen.doel@gmail.com", "d70bbcb2", "verborgen org", "max"),
+        ProfileIdentity("max-12", "armand@synaptent.com", "d16e9a80", "Synaptent", "team"),
+        ProfileIdentity("max-13", "armand@synaptent.com", "dd44fcd1", "armand org", "max"),
+    ]
+
+
+def test_org_seat_collisions_catch_same_org_even_with_different_emails():
+    result = analyze_profiles(_real_pool())
+    seats = {g.key: g.profiles for g in result.org_seat_collisions}
+    assert seats == {
+        "121e7534": ("max-03", "max-06"),  # same email + same org
+        "d16e9a80": ("max-09", "max-12"),  # different emails, same Team org (the hidden one)
+    }
+    assert all(g.severity == "high" for g in result.org_seat_collisions)
+
+
+def test_shared_credential_flags_same_email_across_distinct_orgs():
+    result = analyze_profiles(_real_pool())
+    creds = {g.key: g.profiles for g in result.shared_credential_collisions}
+    assert creds == {
+        "synaptent@synaptent.com": ("max-08", "max-09"),
+        "armand@synaptent.com": ("max-12", "max-13"),
+    }
+    assert all(g.severity == "warn" for g in result.shared_credential_collisions)
+
+
+def test_same_email_same_org_is_only_a_seat_collision_not_credential():
+    # max-03/max-06 share email AND org; must NOT also appear as shared_credential.
+    result = analyze_profiles(_real_pool())
+    cred_keys = {g.key for g in result.shared_credential_collisions}
+    assert "ap@synaptent.com" not in cred_keys
+
+
+def test_distinct_pool_has_no_collisions():
+    pool = [
+        ProfileIdentity("max-01", "a@x.com", "org-a", "A", "max"),
+        ProfileIdentity("max-02", "b@x.com", "org-b", "B", "max"),
+        ProfileIdentity("max-03", "c@x.com", "org-c", "C", "team"),
+    ]
+    result = analyze_profiles(pool)
+    assert not result.has_collisions
+    assert result.distinct_org_count == 3
+    assert result.recommendations == []
+
+
+def test_missing_org_id_does_not_create_false_collisions():
+    # Two profiles with blank org_id must not be grouped together.
+    pool = [
+        ProfileIdentity("max-01", "a@x.com", "", "", ""),
+        ProfileIdentity("max-02", "b@x.com", "", "", ""),
+    ]
+    result = analyze_profiles(pool)
+    assert result.org_seat_collisions == []
+
+
+def test_recommendations_name_keep_and_free_profiles():
+    result = analyze_profiles(_real_pool())
+    joined = "\n".join(result.recommendations)
+    # Each high-severity seat collision yields a keep/free recommendation.
+    assert "keep max-03" in joined and "free max-06" in joined
+    assert "keep max-09" in joined and "free max-12" in joined


### PR DESCRIPTION
## Why
The Claude subscription-profile pool (`~/.aragora-claude/max-*`) decays partly because profiles collide on the **organization that bills inference (`orgId`)**, not the login email. Keying on email is both wrong and incomplete:
- `max-09` (`synaptent@synaptent.com`) and `max-12` (`armand@synaptent.com`) have **different emails** but both bill the **same 'Synaptent' Team org** (`d16e9a80`) — one seat, two profiles. Email-matching misses this entirely.
- `max-08`/`max-09` and `max-12`/`max-13` share an **email** but sit in **different orgs** (personal Max vs Team) — genuinely distinct subscriptions that email-matching would wrongly flag as duplicates.

## What
- `aragora/agents/claude_profile_audit.py` — pure, dependency-free analysis: flags **HIGH** org-seat collisions (≥2 profiles sharing an `orgId`) and **warns** on shared-login-across-distinct-orgs.
- `scripts/audit_claude_profiles.py` — collects live identities (`claude_profile.sh status` + token expiry), renders the topology table + collisions + consolidation recommendations; exits non-zero on a seat collision for cron alerting.

## Verified on the real pool
```
[HIGH] Same-subscription-seat collisions (consolidate):
  - max-03, max-06 → org 'ap@synaptent.com's Organization' (121e7534)
  - max-09, max-12 → org 'Synaptent' (d16e9a80)   ← different emails, same Team org
[warn] Shared-login (different orgs — distinct subs, may contend):
  - max-08, max-09 → 'synaptent@synaptent.com'
```
Bonus finding it surfaced: the configured pool (`ARAGORA_CLAUDE_REVIEW_PROFILES`) is **max-01..max-12** — so **max-13**, currently the freshest *live* profile, is excluded from routing entirely.

6 tests over the observed topology (incl. the different-email-same-org case and that same-email-same-org is not double-counted); ruff clean.

## Operator follow-up (auth-side, not in this PR)
Consolidate the two seat collisions (keep max-03 / max-09, free max-06 / max-12) and point freed slots at distinct accounts; the deeper durability fix is keeping token refresh alive so profiles don't silently age out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)