### PR TITLE
fix(scripts): attribute Codex Desktop sessions in agent_bridge_sessions

### DIFF
--- a/scripts/agent_bridge_sessions.py
+++ b/scripts/agent_bridge_sessions.py
@@ -136,14 +136,23 @@ def _safe_repo_root(candidate: str | None) -> Path | None:
 
 
 def _tail_lines(path: Path, *, max_bytes: int = TAIL_BYTES) -> list[str]:
-    if not path.exists():
+    # Seek to the tail instead of slurping the whole file: Codex rollouts can be
+    # hundreds of MB, and only the trailing ``max_bytes`` are ever needed.
+    try:
+        with path.open("rb") as handle:
+            handle.seek(0, os.SEEK_END)
+            size = handle.tell()
+            if size > max_bytes:
+                handle.seek(size - max_bytes)
+                data = handle.read()
+                newline = data.find(b"\n")
+                if newline >= 0:
+                    data = data[newline + 1 :]
+            else:
+                handle.seek(0)
+                data = handle.read()
+    except OSError:
         return []
-    data = path.read_bytes()
-    if len(data) > max_bytes:
-        data = data[-max_bytes:]
-        newline = data.find(b"\n")
-        if newline >= 0:
-            data = data[newline + 1 :]
     return data.decode("utf-8", errors="replace").splitlines()
 
 
@@ -641,8 +650,10 @@ def _extract_codex_summary(path: Path) -> str:
     """Best-effort last visible message text from a Codex rollout tail.
 
     Bounded to the trailing ``TAIL_BYTES`` so it stays cheap even on multi-hundred
-    megabyte rollouts. Tool-call/token-count noise lines are skipped.
+    megabyte rollouts. Prefers the most recent assistant message, falling back to
+    the most recent visible text; tool-call/token-count noise lines are skipped.
     """
+    fallback = ""
     for line in reversed(_tail_lines(path)):
         if not line.strip():
             continue
@@ -653,10 +664,16 @@ def _extract_codex_summary(path: Path) -> str:
         text = _codex_line_text(obj)
         if not text:
             continue
-        cleaned = _clean_display_line(text)
-        if cleaned:
-            return _collapse(cleaned)
-    return ""
+        cleaned = _collapse(_clean_display_line(text))
+        if not cleaned:
+            continue
+        payload = obj.get("payload") if isinstance(obj, dict) else None
+        role = str(payload.get("role") or "") if isinstance(payload, dict) else ""
+        if role == "assistant":
+            return cleaned
+        if not fallback:
+            fallback = cleaned
+    return fallback
 
 
 def load_codex_sessions(
@@ -669,23 +686,39 @@ def load_codex_sessions(
     sessions_dir = codex_home / "sessions"
     if not sessions_dir.exists():
         return []
+    limit = max(0, int(scan_limit))
+    if limit == 0:
+        return []
     try:
-        candidates = sorted(
-            (p for p in sessions_dir.rglob("*.jsonl") if p.is_file()),
-            key=lambda p: p.stat().st_mtime,
-            reverse=True,
-        )
+        all_paths = list(sessions_dir.rglob("*.jsonl"))
     except OSError:
         return []
+    # Codex writes rollouts under a date-partitioned tree with an ISO timestamp
+    # embedded in each filename, so lexical name order tracks creation order.
+    # Sort by name (no stat), bound to a window around scan_limit, then do the
+    # precise mtime ordering on just that window -- keeping stat() work O(limit)
+    # even when ~/.codex/sessions holds thousands of multi-hundred-MB rollouts.
+    all_paths.sort(key=lambda p: p.name, reverse=True)
+    window = all_paths[: limit * 4]
+
+    def _mtime(path: Path) -> float:
+        try:
+            return path.stat().st_mtime
+        except OSError:
+            return -1.0
+
+    window.sort(key=_mtime, reverse=True)
     records: list[SessionRecord] = []
-    for path in candidates[: max(0, int(scan_limit))]:
+    for path in window[:limit]:
         meta = _read_codex_session_meta(path)
         if not meta:
             continue
         cwd = meta.get("cwd")
         if not _repo_match(_safe_repo_root(cwd), repo_root):
             continue
-        is_desktop = (meta.get("originator") or "").strip().lower() == CODEX_DESKTOP_ORIGINATOR
+        # Match by containment so a versioned originator ("Codex Desktop 1.2")
+        # still classifies as desktop rather than silently falling back to cli.
+        is_desktop = CODEX_DESKTOP_ORIGINATOR in (meta.get("originator") or "").strip().lower()
         try:
             updated_at = datetime.fromtimestamp(path.stat().st_mtime, tz=UTC).isoformat()
         except OSError:

--- a/scripts/agent_bridge_sessions.py
+++ b/scripts/agent_bridge_sessions.py
@@ -4,6 +4,11 @@
 This is a read-only bridge inventory tool. It combines:
 - tmux-managed session metadata/logs under ``~/.aragora/tmux-sessions``
 - Claude Code transcript tails under ``~/.claude/projects/.../*.jsonl``
+- Codex rollout sessions under ``~/.codex/sessions/**/*.jsonl`` (both manual
+  Codex CLI runs and Codex Desktop automations; the ``session_meta`` payload's
+  ``originator == "Codex Desktop"`` is what marks a desktop-automation run, so
+  Codex activity is attributed to ``codex`` rather than being omitted or
+  surfaced only through the ``claude -p`` reviewer transcripts it spawns)
 
 The goal is to give a small supervisor process one machine-readable view of:
 - which sessions exist
@@ -556,15 +561,169 @@ def load_claude_sessions(
     return records
 
 
+DEFAULT_CODEX_HOME = Path.home() / ".codex"
+DEFAULT_CODEX_SCAN_LIMIT = 500
+CODEX_DESKTOP_ORIGINATOR = "codex desktop"
+_CODEX_NOISE_TYPES = frozenset(
+    {"function_call", "function_call_output", "token_count", "reasoning"}
+)
+
+
+def _read_codex_session_meta(path: Path, *, max_lines: int = 50) -> dict[str, str]:
+    """Extract identifying metadata from a Codex rollout JSONL file.
+
+    Only the ``session_meta`` payload is inspected (cwd, git branch, originator,
+    thread id) — message content is ignored here. ``originator == "Codex
+    Desktop"`` distinguishes a Codex Desktop automation run from a manual Codex
+    CLI session. Field names mirror ``list_active_agent_sessions.py`` so the two
+    tools that surface these files agree on attribution.
+    """
+    try:
+        handle = path.open("r", encoding="utf-8")
+    except OSError:
+        return {}
+    with handle:
+        for index, line in enumerate(handle):
+            if index >= max_lines:
+                break
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(obj, dict) or obj.get("type") != "session_meta":
+                continue
+            payload = obj.get("payload")
+            if not isinstance(payload, dict):
+                continue
+            git = payload.get("git")
+            git_payload = git if isinstance(git, dict) else {}
+            branch = git_payload.get("branch")
+            if isinstance(branch, str):
+                branch = re.sub(r"^refs/heads/", "", branch.strip())
+            meta: dict[str, str] = {}
+            for key, value in (
+                ("thread_id", payload.get("id")),
+                ("originator", payload.get("originator")),
+                ("cwd", payload.get("cwd")),
+                ("branch", branch),
+                ("commit_hash", git_payload.get("commit_hash")),
+            ):
+                if isinstance(value, str) and value.strip():
+                    meta[key] = value.strip()
+            if meta:
+                return meta
+    return {}
+
+
+def _codex_line_text(obj: Any) -> str:
+    if not isinstance(obj, dict):
+        return ""
+    payload = obj.get("payload")
+    if not isinstance(payload, dict) or payload.get("type") in _CODEX_NOISE_TYPES:
+        return ""
+    content = payload.get("content")
+    if isinstance(content, list):
+        parts = [
+            block.get("text") or block.get("output_text")
+            for block in content
+            if isinstance(block, dict)
+        ]
+        joined = " ".join(part for part in parts if isinstance(part, str) and part.strip())
+        if joined.strip():
+            return joined
+    text = payload.get("text")
+    if isinstance(text, str) and text.strip():
+        return text
+    return ""
+
+
+def _extract_codex_summary(path: Path) -> str:
+    """Best-effort last visible message text from a Codex rollout tail.
+
+    Bounded to the trailing ``TAIL_BYTES`` so it stays cheap even on multi-hundred
+    megabyte rollouts. Tool-call/token-count noise lines are skipped.
+    """
+    for line in reversed(_tail_lines(path)):
+        if not line.strip():
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        text = _codex_line_text(obj)
+        if not text:
+            continue
+        cleaned = _clean_display_line(text)
+        if cleaned:
+            return _collapse(cleaned)
+    return ""
+
+
+def load_codex_sessions(
+    *,
+    repo_root: Path,
+    codex_home: Path,
+    include_summaries: bool = True,
+    scan_limit: int = DEFAULT_CODEX_SCAN_LIMIT,
+) -> list[SessionRecord]:
+    sessions_dir = codex_home / "sessions"
+    if not sessions_dir.exists():
+        return []
+    try:
+        candidates = sorted(
+            (p for p in sessions_dir.rglob("*.jsonl") if p.is_file()),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+    except OSError:
+        return []
+    records: list[SessionRecord] = []
+    for path in candidates[: max(0, int(scan_limit))]:
+        meta = _read_codex_session_meta(path)
+        if not meta:
+            continue
+        cwd = meta.get("cwd")
+        if not _repo_match(_safe_repo_root(cwd), repo_root):
+            continue
+        is_desktop = (meta.get("originator") or "").strip().lower() == CODEX_DESKTOP_ORIGINATOR
+        try:
+            updated_at = datetime.fromtimestamp(path.stat().st_mtime, tz=UTC).isoformat()
+        except OSError:
+            updated_at = ""
+        thread_id = meta.get("thread_id")
+        name = f"codex-{thread_id[:8]}" if thread_id else path.stem
+        records.append(
+            SessionRecord(
+                source="codex_desktop" if is_desktop else "codex_cli",
+                session_id=thread_id or path.stem,
+                name=name,
+                agent="codex",
+                status="unknown",
+                updated_at=updated_at,
+                branch=meta.get("branch"),
+                cwd=cwd,
+                prompt_file=None,
+                summary=_extract_codex_summary(path) if include_summaries else "",
+                transcript_file=str(path),
+                last_role=None,
+                last_user_text=None,
+                last_assistant_text=None,
+            )
+        )
+    return records
+
+
 def collect_sessions(
     *,
     repo_root: Path,
     tmux_dir: Path,
     claude_projects_root: Path,
+    codex_home: Path = DEFAULT_CODEX_HOME,
     source: str = "all",
     limit: int = 100,
     resolve_repo: bool = True,
     include_summaries: bool = True,
+    codex_scan_limit: int = DEFAULT_CODEX_SCAN_LIMIT,
 ) -> list[SessionRecord]:
     normalized_repo = (
         resolve_canonical_repo_root(repo_root) if resolve_repo else repo_root.resolve()
@@ -584,6 +743,15 @@ def collect_sessions(
                 repo_root=normalized_repo,
                 projects_root=claude_projects_root,
                 include_summaries=include_summaries,
+            )
+        )
+    if source in {"all", "codex"}:
+        records.extend(
+            load_codex_sessions(
+                repo_root=normalized_repo,
+                codex_home=codex_home,
+                include_summaries=include_summaries,
+                scan_limit=codex_scan_limit,
             )
         )
     records.sort(key=lambda item: item.updated_at or "", reverse=True)
@@ -610,7 +778,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--repo", default=".", help="Repo path or worktree path (default: cwd)")
     parser.add_argument(
         "--source",
-        choices=("all", "tmux", "claude"),
+        choices=("all", "tmux", "claude", "codex"),
         default="all",
         help="Which local session sources to read",
     )
@@ -626,6 +794,17 @@ def _build_parser() -> argparse.ArgumentParser:
         default=str(Path.home() / ".claude" / "projects"),
         help="Claude project transcript root",
     )
+    parser.add_argument(
+        "--codex-home",
+        default=str(DEFAULT_CODEX_HOME),
+        help="Codex home directory (rollout sessions read from <home>/sessions)",
+    )
+    parser.add_argument(
+        "--codex-scan-limit",
+        type=int,
+        default=DEFAULT_CODEX_SCAN_LIMIT,
+        help="Maximum Codex rollout files to scan (most-recent first)",
+    )
     return parser
 
 
@@ -636,9 +815,11 @@ def main() -> int:
         repo_root=repo_root,
         tmux_dir=Path(args.tmux_dir).expanduser(),
         claude_projects_root=Path(args.claude_projects_root).expanduser(),
+        codex_home=Path(args.codex_home).expanduser(),
         source=args.source,
         limit=max(1, int(args.limit)),
         resolve_repo=False,
+        codex_scan_limit=max(0, int(args.codex_scan_limit)),
     )
 
     payload = {

--- a/scripts/list_active_agent_sessions.py
+++ b/scripts/list_active_agent_sessions.py
@@ -336,6 +336,10 @@ def read_codex_session_metadata(path: Path, *, max_lines: int = 50) -> dict[str,
                 metadata["thread_id"] = payload["id"]
             if isinstance(payload.get("source"), str):
                 metadata["source"] = payload["source"]
+            if isinstance(payload.get("originator"), str):
+                metadata["originator"] = payload["originator"]
+            if isinstance(payload.get("thread_source"), str):
+                metadata["thread_source"] = payload["thread_source"]
             if isinstance(cwd, str) and cwd.strip():
                 metadata["cwd"] = cwd.strip()
             if branch:

--- a/tests/scripts/test_agent_bridge_sessions.py
+++ b/tests/scripts/test_agent_bridge_sessions.py
@@ -645,6 +645,32 @@ def test_collect_sessions_labels_codex_cli_when_not_desktop(tmp_path: Path) -> N
     assert sessions[0].agent == "codex"
 
 
+def test_collect_sessions_codex_desktop_versioned_originator(tmp_path: Path) -> None:
+    import agent_bridge_sessions as mod
+
+    repo_root = tmp_path / "aragora"
+    repo_root.mkdir()
+    codex_home = tmp_path / "codex"
+    _write_codex_rollout(
+        codex_home,
+        rel="2026/06/04/rollout-desktop-v2.jsonl",
+        cwd=str(repo_root),
+        originator="Codex Desktop 1.2.3",
+    )
+
+    sessions = mod.collect_sessions(
+        repo_root=repo_root,
+        tmux_dir=tmp_path / "tmux",
+        claude_projects_root=tmp_path / "claude",
+        codex_home=codex_home,
+        source="codex",
+        resolve_repo=False,
+    )
+
+    assert len(sessions) == 1
+    assert sessions[0].source == "codex_desktop"
+
+
 def test_load_codex_sessions_filters_out_other_repos(tmp_path: Path) -> None:
     import agent_bridge_sessions as mod
 

--- a/tests/scripts/test_agent_bridge_sessions.py
+++ b/tests/scripts/test_agent_bridge_sessions.py
@@ -108,6 +108,7 @@ def test_collect_sessions_merges_tmux_and_claude_sources(
         repo_root=repo_root,
         tmux_dir=tmux_dir,
         claude_projects_root=claude_projects_root,
+        codex_home=tmp_path / "codex",
         resolve_repo=False,
     )
 
@@ -203,6 +204,7 @@ def test_collect_sessions_can_skip_expensive_summaries(
         repo_root=repo_root,
         tmux_dir=tmux_dir,
         claude_projects_root=claude_projects_root,
+        codex_home=tmp_path / "codex",
         resolve_repo=False,
         include_summaries=False,
     )
@@ -544,3 +546,131 @@ def test_main_json_output(
     assert payload["repo_root"] == str(repo_root)
     assert payload["count"] == 1
     assert payload["sessions"][0]["name"] == "codex-strategic"
+
+
+def _write_codex_rollout(
+    codex_home: Path,
+    *,
+    rel: str,
+    cwd: str,
+    originator: str | None,
+    branch: str = "droid/example",
+    assistant_text: str = "Recorded settlement receipt for #7760.",
+) -> Path:
+    path = codex_home / "sessions" / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    meta_payload: dict = {
+        "id": "019e9551-5640-7a82-b18e-b9dbb8cc4f2f",
+        "source": "vscode",
+        "cwd": cwd,
+        "git": {"branch": branch, "commit_hash": "abc123"},
+    }
+    if originator is not None:
+        meta_payload["originator"] = originator
+    lines = [
+        json.dumps({"type": "session_meta", "payload": meta_payload}),
+        json.dumps(
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": assistant_text}],
+                },
+            }
+        ),
+    ]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def test_collect_sessions_labels_codex_desktop_not_claude(tmp_path: Path) -> None:
+    """A Codex Desktop automation rollout must attribute to codex, never claude."""
+    import agent_bridge_sessions as mod
+
+    repo_root = tmp_path / "aragora"
+    repo_root.mkdir()
+    codex_home = tmp_path / "codex"
+    _write_codex_rollout(
+        codex_home,
+        rel="2026/06/04/rollout-desktop.jsonl",
+        cwd=str(repo_root),
+        originator="Codex Desktop",
+    )
+
+    sessions = mod.collect_sessions(
+        repo_root=repo_root,
+        tmux_dir=tmp_path / "tmux",
+        claude_projects_root=tmp_path / "claude",
+        codex_home=codex_home,
+        source="codex",
+        resolve_repo=False,
+    )
+
+    assert len(sessions) == 1
+    record = sessions[0]
+    assert record.source == "codex_desktop"
+    assert record.agent == "codex"
+    assert record.source != "claude_jsonl"
+    assert record.name == "codex-019e9551"
+    assert record.branch == "droid/example"
+    assert record.cwd == str(repo_root)
+    assert "settlement receipt" in record.summary
+
+
+def test_collect_sessions_labels_codex_cli_when_not_desktop(tmp_path: Path) -> None:
+    import agent_bridge_sessions as mod
+
+    repo_root = tmp_path / "aragora"
+    repo_root.mkdir()
+    codex_home = tmp_path / "codex"
+    _write_codex_rollout(
+        codex_home,
+        rel="2026/06/04/rollout-cli.jsonl",
+        cwd=str(repo_root),
+        originator=None,
+    )
+
+    sessions = mod.collect_sessions(
+        repo_root=repo_root,
+        tmux_dir=tmp_path / "tmux",
+        claude_projects_root=tmp_path / "claude",
+        codex_home=codex_home,
+        source="codex",
+        resolve_repo=False,
+    )
+
+    assert len(sessions) == 1
+    assert sessions[0].source == "codex_cli"
+    assert sessions[0].agent == "codex"
+
+
+def test_load_codex_sessions_filters_out_other_repos(tmp_path: Path) -> None:
+    import agent_bridge_sessions as mod
+
+    repo_root = tmp_path / "aragora"
+    repo_root.mkdir()
+    codex_home = tmp_path / "codex"
+    _write_codex_rollout(
+        codex_home,
+        rel="2026/06/04/rollout-other.jsonl",
+        cwd=str(tmp_path / "other-repo"),
+        originator="Codex Desktop",
+    )
+
+    records = mod.load_codex_sessions(
+        repo_root=repo_root.resolve(),
+        codex_home=codex_home,
+    )
+
+    assert records == []
+
+
+def test_load_codex_sessions_absent_home_returns_empty(tmp_path: Path) -> None:
+    import agent_bridge_sessions as mod
+
+    records = mod.load_codex_sessions(
+        repo_root=(tmp_path / "aragora").resolve(),
+        codex_home=tmp_path / "missing-codex",
+    )
+    assert records == []


### PR DESCRIPTION
## Problem

`scripts/agent_bridge_sessions.py` is documented (module docstring + `--help`) as listing **"Codex/Claude sessions"**, but `collect_sessions` only read **tmux + claude** transcripts — there was no codex reader (`--source` choices were just `all/tmux/claude`). 

Because a Codex Desktop automation run spawns `claude -p` reviewers, the only transcripts this tool could see were those `~/.claude/projects` children, which it tags `source="claude_jsonl"`. **Net effect: Codex Desktop activity (e.g. the #7750 Tier-4 settlement) was mislabeled as a claude session** (or omitted). The consolidated `list_active_agent_sessions.py` attributes correctly; this narrower tool did not, so the two disagreed.

## Fix

- Add a **codex source** to `agent_bridge_sessions.py`: reads `~/.codex/sessions/**/*.jsonl` rollouts, classifies **`codex_desktop` vs `codex_cli`** via the `session_meta` payload's `originator` field (`"Codex Desktop"`), agent=`codex`. Bounded scan (`--codex-scan-limit`, default 500) + tail-bounded summary so it stays cheap on large rollouts.
- New flags: `--source codex`, `--codex-home`, `--codex-scan-limit`.
- Capture `originator`/`thread_source` in `list_active_agent_sessions.read_codex_session_metadata` so both tools agree on attribution (additive; existing exact-dict tests unaffected).

## Verification

Live against this repo (formerly mislabeled): `--source codex` now yields **6 `codex_desktop` + 2 `codex_cli`, all `agent=codex`** (none as `claude_jsonl`), with correct branch/cwd/summary.

- 61 unit tests pass (4 new: desktop-not-claude, cli, repo-filter, absent-home; 2 isolated for the new param)
- ruff, mypy, portability guard: all green; pre-commit hooks passed

## Context

Surfaced while auditing Codex Desktop session activity on #7750 — the operator's settlement was driven by Codex Desktop engineering-autopilot (`originator="Codex Desktop"`), not claude.