### PR TITLE
feat(profiles): verify-cron that keeps the Claude pool health snapshot honest (and refreshes valid tokens)

### DIFF
--- a/aragora/agents/claude_pool_health.py
+++ b/aragora/agents/claude_pool_health.py
@@ -1,0 +1,84 @@
+"""Pure helpers for the Claude profile-pool verify snapshot.
+
+``scripts/claude_pool_verify.py`` live-probes each profile and writes
+``.aragora/claude_pool_health.json``. That snapshot is the *verify-backed* health
+source consumed by:
+  - ``aragora/swarm/review_routing.py`` (skip unhealthy review profiles), and
+  - ``aragora/agents/claude_profile_pool.py`` (skip unhealthy debate profiles).
+
+``claude auth status`` is deliberately not used for liveness: it reports
+``loggedIn: true`` even for expired/revoked tokens. Only a real completion probe
+distinguishes a usable profile, so this module classifies *probe output*.
+
+Snapshot shape (matches the format both consumers parse)::
+
+    {"generated_at": "...Z", "healthy": 2, "total": 13,
+     "profiles": [{"name": "max-01", "email": "a@x", "state": "ok"}, ...]}
+"""
+
+from __future__ import annotations
+
+# States consumers treat as unusable (mirror review_routing._UNHEALTHY_PROFILE_STATES).
+UNHEALTHY_STATES = {"expired", "not_configured", "unauthenticated", "logged_out"}
+
+_AUTH_FAILURE_MARKERS = (
+    "401",
+    "invalid authentication",
+    "failed to authenticate",
+    "unauthorized",
+    "oauth token has expired",
+)
+_NOT_CONFIGURED_MARKERS = (
+    "no such file",
+    "not logged in",
+    "no credentials",
+    "claude_profile.sh not found",
+)
+
+
+def classify_probe(stdout: str, *, returncode: int | None = None, timed_out: bool = False) -> str:
+    """Map a completion-probe result to a health state.
+
+    - ``ok``: the probe produced real model output.
+    - ``expired``: an auth failure (401 / invalid / expired token) — the common
+      revoked/expired case.
+    - ``not_configured``: the profile has no usable credentials at all.
+    - ``unauthenticated``: timed out or produced no output (treated as unusable).
+    """
+    text = (stdout or "").strip()
+    lowered = text.lower()
+    if timed_out:
+        return "unauthenticated"
+    if any(marker in lowered for marker in _NOT_CONFIGURED_MARKERS):
+        return "not_configured"
+    if any(marker in lowered for marker in _AUTH_FAILURE_MARKERS):
+        return "expired"
+    if not text:
+        # No output and not a recognized error: cannot confirm liveness.
+        return "unauthenticated"
+    if returncode not in (None, 0):
+        return "expired"
+    return "ok"
+
+
+def is_healthy(state: str) -> bool:
+    return state not in UNHEALTHY_STATES
+
+
+def build_snapshot(records: list[dict], *, generated_at: str) -> dict:
+    """Build the snapshot dict from per-profile ``{name,email,state}`` records."""
+    profiles = [
+        {
+            "name": str(r.get("name", "")),
+            "email": str(r.get("email", "") or ""),
+            "state": str(r.get("state", "unauthenticated")),
+        }
+        for r in records
+    ]
+    healthy = sum(1 for p in profiles if is_healthy(p["state"]))
+    return {
+        "generated_at": generated_at,
+        "healthy": healthy,
+        "total": len(profiles),
+        "profiles": profiles,
+    }

--- a/scripts/claude_pool_verify.py
+++ b/scripts/claude_pool_verify.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Live-probe the Claude profile pool and write the verify-backed health snapshot.
+
+For each configured profile this runs a real (minimal) completion through
+``scripts/claude_profile.sh exec <profile>`` — the only way to tell a usable
+profile from one whose token is expired/revoked, since ``claude auth status``
+reports ``loggedIn: true`` even for dead tokens. It writes
+``.aragora/claude_pool_health.json`` (consumed by the review/debate routing and
+the audit tool) and exits non-zero when any configured profile is unusable, so
+a launchd/cron job can surface "go re-auth" without magic.
+
+Refresh side effect: probing an **expired** access token makes the CLI exchange
+its **refresh token** for a fresh access token (when the refresh token is still
+valid), so running this on a schedule (hourly < the ~9h access-token TTL) keeps
+valid-refresh profiles alive **without a browser login**. What it canNOT do is
+revive a **revoked** refresh token — those (duplicate accounts, same-org seats,
+or the same account used concurrently across machines) still need a one-time
+``scripts/claude_profiles_bootstrap.sh login <profile>`` or a long-lived
+``claude setup-token``. The non-zero exit + "Re-auth needed" line flags exactly
+those.
+
+Usage:
+    python3 scripts/claude_pool_verify.py [--json] [--prompt hi] [profile ...]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from aragora.agents.claude_pool_health import (  # noqa: E402
+    build_snapshot,
+    classify_probe,
+    is_healthy,
+)
+
+DEFAULT_PROFILES = tuple(f"max-{i:02d}" for i in range(1, 14))
+SNAPSHOT_PATH = REPO_ROOT / ".aragora" / "claude_pool_health.json"
+
+
+def _configured_profiles() -> list[str]:
+    raw = os.environ.get("ARAGORA_CLAUDE_REVIEW_PROFILES", "").strip()
+    if not raw:
+        return list(DEFAULT_PROFILES)
+    out: list[str] = []
+    for item in raw.split(","):
+        name = item.strip()
+        if name and name not in out:
+            out.append(name)
+    return out or list(DEFAULT_PROFILES)
+
+
+def _profile_email(profile_tool: Path, profile: str) -> str:
+    try:
+        proc = subprocess.run(
+            [str(profile_tool), "status", profile],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    out = proc.stdout
+    start = out.find("{")
+    if start < 0:
+        return ""
+    try:
+        return str(json.loads(out[start:]).get("email", "") or "")
+    except json.JSONDecodeError:
+        return ""
+
+
+def _probe(profile_tool: Path, profile: str, prompt: str, timeout: int) -> str:
+    try:
+        proc = subprocess.run(
+            [str(profile_tool), "exec", profile, "--", "claude", "--print", "-p", "-"],
+            input=prompt,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return "unauthenticated"
+    except OSError as exc:
+        return classify_probe(str(exc))
+    # Strip the claude_profile.sh wrapper preamble before classifying.
+    lines = [
+        ln
+        for ln in (proc.stdout or "").splitlines()
+        if not (ln.startswith("Using profile home:") or ln.startswith("Command:"))
+    ]
+    combined = "\n".join(lines)
+    if not combined.strip():
+        combined = proc.stderr or ""
+    return classify_probe(combined, returncode=proc.returncode)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("profiles", nargs="*", help="Profiles (default: configured pool)")
+    parser.add_argument("--prompt", default="hi", help="Minimal probe prompt")
+    parser.add_argument("--timeout", type=int, default=60, help="Per-probe timeout (s)")
+    parser.add_argument("--json", action="store_true", help="Emit the snapshot as JSON")
+    parser.add_argument(
+        "--snapshot-path",
+        default=str(SNAPSHOT_PATH),
+        help="Where to write the health snapshot",
+    )
+    args = parser.parse_args(argv)
+
+    profile_tool = REPO_ROOT / "scripts" / "claude_profile.sh"
+    profiles = args.profiles or _configured_profiles()
+
+    records: list[dict] = []
+    for profile in profiles:
+        state = _probe(profile_tool, profile, args.prompt, args.timeout)
+        records.append(
+            {
+                "name": profile,
+                "email": _profile_email(profile_tool, profile),
+                "state": state,
+            }
+        )
+
+    generated_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    snapshot = build_snapshot(records, generated_at=generated_at)
+
+    snapshot_path = Path(args.snapshot_path)
+    snapshot_path.parent.mkdir(parents=True, exist_ok=True)
+    snapshot_path.write_text(json.dumps(snapshot, indent=2), encoding="utf-8")
+
+    if args.json:
+        print(json.dumps(snapshot, indent=2))
+    else:
+        print(f"Claude pool verify — {snapshot['healthy']}/{snapshot['total']} healthy")
+        for p in snapshot["profiles"]:
+            flag = "ok " if is_healthy(p["state"]) else "DEAD"
+            print(f"  [{flag}] {p['name']:9} {p['state']:15} {p['email']}")
+        print(f"\nSnapshot: {snapshot_path}")
+        dead = [p["name"] for p in snapshot["profiles"] if not is_healthy(p["state"])]
+        if dead:
+            print(f"Re-auth needed: {', '.join(dead)}")
+
+    # Non-zero when any configured profile is unusable, for cron alerting.
+    return 0 if snapshot["healthy"] == snapshot["total"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/install_claude_pool_verify_launchd.sh
+++ b/scripts/install_claude_pool_verify_launchd.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Install a launchd job that periodically verifies the Claude profile pool and
+# refreshes .aragora/claude_pool_health.json (consumed by review/debate routing).
+#
+# Probing an expired access token makes the CLI refresh it from the (valid)
+# refresh token, so this hourly job keeps valid-refresh profiles alive WITHOUT a
+# browser login. Revoked refresh tokens (duplicate/same-org/cross-machine seats)
+# still need a one-time `scripts/claude_profiles_bootstrap.sh login <profile>` or
+# a long-lived `claude setup-token`; the job's log + non-zero exit flag those.
+set -euo pipefail
+
+LABEL="com.aragora.claude-pool-verify"
+INTERVAL_SECONDS=3600  # hourly: matches the routing snapshot TTL (1h)
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOG_PATH="${HOME}/.aragora/claude-pool-verify.log"
+PYTHON_BIN="${ARAGORA_PYTHON:-python3}"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [--interval-seconds <n>] [--python <path>]
+  --interval-seconds <n>   launchd StartInterval (default: ${INTERVAL_SECONDS})
+  --python <path>          Python interpreter (default: ${PYTHON_BIN})
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --interval-seconds) INTERVAL_SECONDS="$2"; shift 2 ;;
+    --python) PYTHON_BIN="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+PLIST_PATH="${HOME}/Library/LaunchAgents/${LABEL}.plist"
+mkdir -p "$(dirname "$PLIST_PATH")"
+mkdir -p "$(dirname "$LOG_PATH")"
+
+cat >"${PLIST_PATH}" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>-lc</string>
+    <string>cd "${REPO_ROOT}" &amp;&amp; "${PYTHON_BIN}" scripts/claude_pool_verify.py</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>StartInterval</key>
+  <integer>${INTERVAL_SECONDS}</integer>
+  <key>WorkingDirectory</key>
+  <string>${REPO_ROOT}</string>
+  <key>StandardOutPath</key>
+  <string>${LOG_PATH}</string>
+  <key>StandardErrorPath</key>
+  <string>${LOG_PATH}</string>
+</dict>
+</plist>
+EOF
+
+launchctl unload "${PLIST_PATH}" >/dev/null 2>&1 || true
+launchctl load "${PLIST_PATH}"
+
+echo "Installed launchd job: ${LABEL}"
+echo "Plist: ${PLIST_PATH}"
+echo "Interval: ${INTERVAL_SECONDS}s"
+echo "Log: ${LOG_PATH}"
+echo "Uninstall: launchctl unload \"${PLIST_PATH}\" && rm \"${PLIST_PATH}\""

--- a/tests/agents/test_claude_pool_health.py
+++ b/tests/agents/test_claude_pool_health.py
@@ -1,0 +1,60 @@
+"""Tests for the Claude pool verify-snapshot helpers."""
+
+from __future__ import annotations
+
+from aragora.agents.claude_pool_health import build_snapshot, classify_probe, is_healthy
+
+
+def test_classify_real_output_is_ok():
+    assert classify_probe("OK", returncode=0) == "ok"
+    assert classify_probe("Here is your answer.\nLine two", returncode=0) == "ok"
+
+
+def test_classify_401_is_expired():
+    assert (
+        classify_probe("Failed to authenticate. API Error: 401 Invalid authentication credentials")
+        == "expired"
+    )
+    assert classify_probe("OAuth token has expired") == "expired"
+
+
+def test_classify_missing_credentials_is_not_configured():
+    assert classify_probe("No such file or directory: .credentials.json") == "not_configured"
+    assert classify_probe("not logged in") == "not_configured"
+
+
+def test_classify_timeout_and_empty_are_unauthenticated():
+    assert classify_probe("", timed_out=True) == "unauthenticated"
+    assert classify_probe("") == "unauthenticated"
+
+
+def test_classify_nonzero_returncode_without_text_marker_is_expired():
+    assert classify_probe("weird failure", returncode=2) == "expired"
+
+
+def test_is_healthy_matches_routing_unhealthy_set():
+    assert is_healthy("ok")
+    for bad in ("expired", "not_configured", "unauthenticated", "logged_out"):
+        assert not is_healthy(bad)
+
+
+def test_build_snapshot_shape_and_counts():
+    records = [
+        {"name": "max-01", "email": "a@x", "state": "ok"},
+        {"name": "max-02", "email": "b@x", "state": "ok"},
+        {"name": "max-03", "email": "c@x", "state": "expired"},
+    ]
+    snap = build_snapshot(records, generated_at="2026-06-05T02:25:00Z")
+    assert snap["generated_at"] == "2026-06-05T02:25:00Z"
+    assert snap["total"] == 3
+    assert snap["healthy"] == 2
+    assert snap["profiles"][0] == {"name": "max-01", "email": "a@x", "state": "ok"}
+    # The snapshot is consumable by review_routing._load_pool_health (name+state).
+    states = {p["name"]: p["state"] for p in snap["profiles"]}
+    assert states["max-03"] == "expired"
+
+
+def test_build_snapshot_defaults_missing_state():
+    snap = build_snapshot([{"name": "max-09"}], generated_at="x")
+    assert snap["profiles"][0]["state"] == "unauthenticated"
+    assert snap["healthy"] == 0


### PR DESCRIPTION
## What
A scheduled job that live-probes each configured Claude profile and writes `.aragora/claude_pool_health.json` — the verify-backed snapshot consumed by review routing (#7757) and the audit tool (#7763). Exits non-zero with a `Re-auth needed: …` list when any profile is unusable, so launchd/cron surfaces it.

- `aragora/agents/claude_pool_health.py` — pure `classify_probe`/`build_snapshot` (8 tests).
- `scripts/claude_pool_verify.py` — probes the pool, writes the snapshot, exits 1 if any dead.
- `scripts/install_claude_pool_verify_launchd.sh` — hourly launchd job (matches the repo's installer pattern).

## Why a *probe*, not `claude auth status`
`claude auth status` reports `loggedIn: true` even for expired/revoked tokens (documented in `claude_profiles_bootstrap.sh`). Only a real completion distinguishes a usable profile.

## Refresh side effect (the useful part)
Probing an **expired** access token makes the CLI exchange its **refresh token** for a fresh access token — *when the refresh token is still valid*. So running this hourly (well under the ~9h access-token TTL) **keeps valid-refresh profiles alive without any browser login**. Verified live: profiles that were expired in their credential file came back `ok` (expiresAt advanced) after a probe.

What it can't do: revive a **revoked** refresh token. Those are the duplicate accounts, same-org Team seats, and accounts used concurrently across the fleet — they still need a one-time `claude_profiles_bootstrap.sh login <profile>` (or a long-lived `claude setup-token`). The job flags exactly those via the non-zero exit + log.

## Live result on the real pool
```
Claude pool verify — 8/13 healthy
  [ok ] max-01/02/07/08/10/11/12/13
  [DEAD] max-03 not_configured   (interrupted login)
  [DEAD] max-04/05/06/09 expired (revoked refresh tokens — re-auth)
Re-auth needed: max-03, max-04, max-05, max-06, max-09
```
The probe itself refreshed max-08/10/11/12 from expired → ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)