### PR TITLE
fix(quorum): guard reruns on packet divergence

### DIFF
--- a/aragora/swarm/merge_quorum_io.py
+++ b/aragora/swarm/merge_quorum_io.py
@@ -17,7 +17,12 @@ import sys
 import tempfile
 from typing import Any
 
-from aragora.swarm.merge_quorum_reconcile import EvidenceComment, QuorumRun
+from aragora.swarm.merge_quorum_reconcile import (
+    EvidenceComment,
+    PacketClassification,
+    QuorumRun,
+    parse_ci_packet_classification,
+)
 
 QUORUM_CHECK_NAME = "aragora-merge-quorum"
 QUORUM_WORKFLOW_FILE = "aragora-merge-quorum.yml"
@@ -218,6 +223,12 @@ def fetch_human_settlement_present(repo: str, head_sha: str) -> bool:
 
 def fetch_pr_tier(repo: str, pr: int) -> int | None:
     """Best-effort tier from ``review-queue merge-packet``; ``None`` if unknown."""
+    packet = fetch_merge_packet_classification(repo, pr)
+    return packet.tier if packet is not None else None
+
+
+def fetch_merge_packet_classification(repo: str, pr: int) -> PacketClassification | None:
+    """Best-effort current local merge-packet classification for one PR."""
     try:
         proc = run(
             [
@@ -260,23 +271,58 @@ def fetch_pr_tier(repo: str, pr: int) -> int | None:
         except (TypeError, ValueError):
             return None
 
+    def _packet(entry: dict[str, Any]) -> PacketClassification | None:
+        tier = _coerce(entry.get("tier"))
+        pr_value = _coerce(entry.get("pr_number"))
+        if pr_value is None:
+            pr_value = pr
+        if pr_value != pr or entry.get("tier") is None:
+            return None
+        return PacketClassification(
+            source="local",
+            pr_number=pr_value,
+            head_sha=str(entry.get("head_sha") or ""),
+            tier=tier,
+            status=str(entry.get("status") or ""),
+            verdict=str(entry.get("verdict") or ""),
+            requires_human_risk_settlement=bool(entry.get("requires_human_risk_settlement")),
+        )
+
     # Prefer the row whose pr_number matches the requested PR. The normal
     # single-PR --json shape always discloses pr_number, so a multi-PR envelope
     # can never resolve the wrong PR's tier (which would mis-gate posting).
     for entry in entries:
-        if (
-            isinstance(entry, dict)
-            and _coerce(entry.get("pr_number")) == pr
-            and entry.get("tier") is not None
-        ):
-            return _coerce(entry["tier"])
+        if not isinstance(entry, dict):
+            continue
+        packet = _packet(entry)
+        if packet is not None and _coerce(entry.get("pr_number")) == pr:
+            return packet
     # Fall back to the first disclosed tier only when NO row carries a pr_number
     # (forward-compat shapes such as a bare list or single entry).
     if not any(isinstance(e, dict) and e.get("pr_number") is not None for e in entries):
         for entry in entries:
-            if isinstance(entry, dict) and entry.get("tier") is not None:
-                return _coerce(entry["tier"])
+            if not isinstance(entry, dict):
+                continue
+            packet = _packet(entry)
+            if packet is not None:
+                return packet
     return None
+
+
+def fetch_quorum_run_packet_classification(
+    repo: str, *, run_id: int, pr: int, head_sha: str
+) -> PacketClassification | None:
+    """Best-effort CI packet classification parsed from a merge-quorum run log."""
+    try:
+        proc = run(
+            ["gh", "run", "view", str(run_id), "--repo", repo, "--log"],
+            timeout=_GH_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired:
+        return None
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return None
+    return parse_ci_packet_classification(proc.stdout, pr_number=pr, head_sha=head_sha)
 
 
 def fetch_evidence_comments(

--- a/aragora/swarm/merge_quorum_reconcile.py
+++ b/aragora/swarm/merge_quorum_reconcile.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+import re
 from typing import Final
 
 # Mirrors aragora/cli/commands/review_queue.py::_tier_requirement. This is a
@@ -113,6 +114,20 @@ class RerunDecision:
     should_rerun: bool
     reason: str
     run_id: int | None = None
+    next_prompt: str = ""
+
+
+@dataclass(frozen=True)
+class PacketClassification:
+    """Semantic merge-packet classification from CI or a local packet."""
+
+    source: str
+    pr_number: int
+    head_sha: str
+    tier: int | None
+    status: str
+    verdict: str
+    requires_human_risk_settlement: bool
 
 
 @dataclass(frozen=True)
@@ -211,6 +226,129 @@ def plan_rerun(
     return decide(
         True,
         "stale quorum check predates newer countable evidence; safe read-only re-run",
+    )
+
+
+_CI_PACKET_RE: Final[re.Pattern[str]] = re.compile(
+    r"PR\s+#(?P<pr>\d+)\s+\|\s+Tier\s+(?P<tier>\d+|None|null)\s+\|\s+"
+    r"status=(?P<status>[^\s|]+)\s+\|\s+verdict=(?P<verdict>[^\s|]+)"
+)
+
+
+def _requires_human_from_ci_packet(*, tier: int | None, status: str, verdict: str) -> bool:
+    text = f"{status} {verdict}".lower()
+    return tier in {3, 4} or "human_preapproval" in text or "human_risk" in text
+
+
+def parse_ci_packet_classification(
+    log_text: str, *, pr_number: int, head_sha: str
+) -> PacketClassification | None:
+    """Parse the CI merge-packet line emitted by ``aragora-merge-quorum``."""
+    for match in _CI_PACKET_RE.finditer(log_text):
+        parsed_pr = int(match.group("pr"))
+        if parsed_pr != pr_number:
+            continue
+        raw_tier = match.group("tier")
+        tier = None if raw_tier.lower() in {"none", "null"} else int(raw_tier)
+        status = match.group("status")
+        verdict = match.group("verdict")
+        return PacketClassification(
+            source="ci",
+            pr_number=parsed_pr,
+            head_sha=head_sha,
+            tier=tier,
+            status=status,
+            verdict=verdict,
+            requires_human_risk_settlement=_requires_human_from_ci_packet(
+                tier=tier, status=status, verdict=verdict
+            ),
+        )
+    return None
+
+
+def packet_classification_summary(packet: PacketClassification | None) -> str:
+    """Human-readable packet classification for logs and prompts."""
+    if packet is None:
+        return "unavailable"
+    human = "human-risk" if packet.requires_human_risk_settlement else "no-human-risk"
+    return (
+        f"{packet.source}: head={packet.head_sha or 'unknown'} "
+        f"tier={packet.tier} status={packet.status} verdict={packet.verdict} {human}"
+    )
+
+
+def packet_classifications_diverge(
+    ci_packet: PacketClassification | None,
+    local_packet: PacketClassification | None,
+) -> bool:
+    """Return true when CI and local packets disagree on semantic risk tier."""
+    if ci_packet is None or local_packet is None:
+        return False
+    if ci_packet.pr_number != local_packet.pr_number:
+        return False
+    if ci_packet.head_sha and local_packet.head_sha and ci_packet.head_sha != local_packet.head_sha:
+        return False
+    return (
+        ci_packet.tier != local_packet.tier
+        or ci_packet.requires_human_risk_settlement != local_packet.requires_human_risk_settlement
+    )
+
+
+def classification_divergence_prompt(
+    *,
+    pr_number: int,
+    head_sha: str,
+    ci_packet: PacketClassification,
+    local_packet: PacketClassification,
+) -> str:
+    """Build the bounded follow-up prompt when a rerun would mask policy drift."""
+    return "\n".join(
+        [
+            "Start from live repo truth. Do not trust prior transcript state. "
+            "Duplicate-owner detection first. Check Aragora operator-steering mailbox before lane work.",
+            "",
+            f"Goal: diagnose and repair only the aragora-merge-quorum classification divergence for PR #{pr_number} at exact head {head_sha}. Do not merge, rerun CI/quorum, mark ready, label, cleanup, mutate publisher/outbox state, touch automations, raw transcripts, unrelated PRs, unrelated worktrees, or unrelated dirty files.",
+            "",
+            "Run root status, fetch origin/main, publisher freshness, active-session conflicts, identify_lane_owner/read_operator_steering for the PR and branch, gh pr view/checks, full check rollup, branch-protection required contexts, latest aragora-merge-quorum log, and a clean current-main/local review-queue merge-packet for the exact PR/head.",
+            "",
+            "Proceed only if the live blocker remains CI/local policy classification divergence:",
+            f"- CI packet: {packet_classification_summary(ci_packet)}",
+            f"- Local packet: {packet_classification_summary(local_packet)}",
+            "",
+            "If clean, use a clean isolated worktree and repair only the smallest policy/classification surface needed so aragora-merge-quorum and merge-packet classify the exact-head PR consistently from workflow context. Preserve the intended policy behavior and do not broaden risk policy.",
+            "",
+            "Validate focused policy classification tests, the exact PR merge-packet where practical, git diff --check, automation_pr_preflight if applicable, and pre-push hooks if pushing. Push only the repair branch if clean. Do not merge.",
+        ]
+    )
+
+
+def guard_rerun_classification_divergence(
+    decision: RerunDecision,
+    *,
+    ci_packet: PacketClassification | None,
+    local_packet: PacketClassification | None,
+    head_sha: str,
+) -> RerunDecision:
+    """Suppress a stale-quorum rerun when CI and local packets disagree."""
+    if not decision.should_rerun or not packet_classifications_diverge(ci_packet, local_packet):
+        return decision
+    if ci_packet is None or local_packet is None:
+        return decision
+    return RerunDecision(
+        pr_number=decision.pr_number,
+        should_rerun=False,
+        reason=(
+            "classification_divergence: CI merge-quorum packet differs from "
+            f"clean local merge-packet; {packet_classification_summary(ci_packet)}; "
+            f"{packet_classification_summary(local_packet)}"
+        ),
+        run_id=decision.run_id,
+        next_prompt=classification_divergence_prompt(
+            pr_number=decision.pr_number,
+            head_sha=head_sha,
+            ci_packet=ci_packet,
+            local_packet=local_packet,
+        ),
     )
 
 

--- a/scripts/reconcile_merge_quorum.py
+++ b/scripts/reconcile_merge_quorum.py
@@ -39,13 +39,16 @@ sys.path.insert(0, str(REPO_ROOT))
 from aragora.swarm.merge_quorum_io import (  # noqa: E402
     fetch_evidence_comments,
     fetch_latest_quorum_run,
+    fetch_merge_packet_classification,
     fetch_pr_context,
+    fetch_quorum_run_packet_classification,
     list_open_prs,
     run,
 )
 from aragora.swarm.merge_quorum_reconcile import (  # noqa: E402
     QuorumRun,
     RerunDecision,
+    guard_rerun_classification_divergence,
     parse_iso8601,
     plan_rerun,
 )
@@ -131,6 +134,17 @@ def evaluate_pr(
         max_reruns_per_head=max_reruns,
         has_real_required_failure=ctx["has_real_required_failure"],
     )
+    if decision.should_rerun and quorum_run is not None:
+        ci_packet = fetch_quorum_run_packet_classification(
+            repo, run_id=quorum_run.run_id, pr=pr, head_sha=head_sha
+        )
+        local_packet = fetch_merge_packet_classification(repo, pr)
+        decision = guard_rerun_classification_divergence(
+            decision,
+            ci_packet=ci_packet,
+            local_packet=local_packet,
+            head_sha=head_sha,
+        )
     return decision, quorum_run
 
 
@@ -187,6 +201,8 @@ def main(argv: list[str] | None = None) -> int:
             "run_id": decision.run_id,
             "applied": False,
         }
+        if decision.next_prompt:
+            record["next_prompt"] = decision.next_prompt
         if decision.should_rerun and args.apply and quorum_run is not None:
             if execute_rerun(args.repo, quorum_run.run_id):
                 record["applied"] = True

--- a/tests/swarm/test_merge_quorum_io.py
+++ b/tests/swarm/test_merge_quorum_io.py
@@ -25,6 +25,48 @@ def test_fetch_pr_tier_reads_nested_entries(monkeypatch) -> None:
     assert m.fetch_pr_tier("o/r", 7742) == 4
 
 
+def test_fetch_merge_packet_classification_reads_semantic_fields(monkeypatch) -> None:
+    payload = {
+        "version": "merge_authorization_packet.v1",
+        "entries": [
+            {
+                "pr_number": 7754,
+                "head_sha": "abc123",
+                "tier": 2,
+                "status": "repair_or_wait",
+                "verdict": "not_ready_for_settlement",
+                "requires_human_risk_settlement": False,
+            }
+        ],
+    }
+    monkeypatch.setattr(m, "run", lambda *a, **k: _proc(json.dumps(payload)))
+
+    packet = m.fetch_merge_packet_classification("o/r", 7754)
+
+    assert packet is not None
+    assert packet.pr_number == 7754
+    assert packet.head_sha == "abc123"
+    assert packet.tier == 2
+    assert packet.status == "repair_or_wait"
+    assert packet.verdict == "not_ready_for_settlement"
+    assert packet.requires_human_risk_settlement is False
+
+
+def test_fetch_quorum_run_packet_classification_parses_log(monkeypatch) -> None:
+    log = (
+        "PR #7754 | Tier 4 | status=human_preapproval_required | "
+        "verdict=tier_4_human_preapproval_required\n"
+    )
+    monkeypatch.setattr(m, "run", lambda *a, **k: _proc(log))
+
+    packet = m.fetch_quorum_run_packet_classification("o/r", run_id=123, pr=7754, head_sha="abc123")
+
+    assert packet is not None
+    assert packet.source == "ci"
+    assert packet.tier == 4
+    assert packet.requires_human_risk_settlement is True
+
+
 def test_fetch_pr_tier_filters_by_pr_number(monkeypatch) -> None:
     # A multi-PR envelope must resolve the requested PR, never the first row.
     payload = {"entries": [{"pr_number": 111, "tier": 1}, {"pr_number": 7742, "tier": 4}]}

--- a/tests/swarm/test_merge_quorum_reconcile.py
+++ b/tests/swarm/test_merge_quorum_reconcile.py
@@ -19,8 +19,11 @@ from aragora.swarm.merge_quorum_io import (
 )
 from aragora.swarm.merge_quorum_reconcile import (
     EvidenceComment,
+    PacketClassification,
     QuorumRun,
     counted_reviewer_ids,
+    guard_rerun_classification_divergence,
+    parse_ci_packet_classification,
     parse_iso8601,
     plan_rerun,
     summarize_settlement,
@@ -152,6 +155,88 @@ class TestPlanRerun:
         )
         assert decision.should_rerun is False
         assert "unparseable" in decision.reason
+
+    def test_classification_divergence_blocks_wasted_rerun(self) -> None:
+        decision = self._call()
+        ci_packet = PacketClassification(
+            source="ci",
+            pr_number=7754,
+            head_sha="abc123",
+            tier=4,
+            status="human_preapproval_required",
+            verdict="tier_4_human_preapproval_required",
+            requires_human_risk_settlement=True,
+        )
+        local_packet = PacketClassification(
+            source="local",
+            pr_number=7754,
+            head_sha="abc123",
+            tier=2,
+            status="repair_or_wait",
+            verdict="not_ready_for_settlement",
+            requires_human_risk_settlement=False,
+        )
+
+        guarded = guard_rerun_classification_divergence(
+            decision,
+            ci_packet=ci_packet,
+            local_packet=local_packet,
+            head_sha="abc123",
+        )
+
+        assert guarded.should_rerun is False
+        assert "classification_divergence" in guarded.reason
+        assert "CI packet: ci: head=abc123 tier=4" in guarded.next_prompt
+        assert "Local packet: local: head=abc123 tier=2" in guarded.next_prompt
+
+    def test_status_only_packet_difference_keeps_rerun_allowed(self) -> None:
+        decision = self._call()
+        ci_packet = PacketClassification(
+            source="ci",
+            pr_number=7754,
+            head_sha="abc123",
+            tier=2,
+            status="needs_model_review_quorum",
+            verdict="collect_model_quorum_before_merge",
+            requires_human_risk_settlement=False,
+        )
+        local_packet = PacketClassification(
+            source="local",
+            pr_number=7754,
+            head_sha="abc123",
+            tier=2,
+            status="repair_or_wait",
+            verdict="not_ready_for_settlement",
+            requires_human_risk_settlement=False,
+        )
+
+        guarded = guard_rerun_classification_divergence(
+            decision,
+            ci_packet=ci_packet,
+            local_packet=local_packet,
+            head_sha="abc123",
+        )
+
+        assert guarded.should_rerun is True
+        assert guarded.reason == decision.reason
+
+
+def test_parse_ci_packet_classification_from_quorum_log() -> None:
+    packet = parse_ci_packet_classification(
+        "\n".join(
+            [
+                "noise",
+                "aragora-merge-quorum\tEvaluate merge quorum\tPR #7754 | Tier 4 | status=human_preapproval_required | verdict=tier_4_human_preapproval_required",
+            ]
+        ),
+        pr_number=7754,
+        head_sha="abc123",
+    )
+
+    assert packet is not None
+    assert packet.pr_number == 7754
+    assert packet.tier == 4
+    assert packet.requires_human_risk_settlement is True
 
 
 class TestSummarizeSettlement:

--- a/uv.lock
+++ b/uv.lock
@@ -271,6 +271,9 @@ wheels = [
 name = "aragora-debate"
 version = "2.9.0"
 source = { editable = "." }
+dependencies = [
+    { name = "python-dateutil" },
+]
 
 [package.optional-dependencies]
 all = [
@@ -344,6 +347,7 @@ requires-dist = [
     { name = "pydantic-settings", marker = "extra == 'test'", specifier = ">=2.14.1,<3.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0.3,<10.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=1.3.0,<2.0" },
+    { name = "python-dateutil", specifier = ">=2.8.2" },
     { name = "python3-saml", marker = "extra == 'all'", specifier = ">=1.16.0,<2.0" },
     { name = "python3-saml", marker = "extra == 'enterprise'", specifier = ">=1.16.0,<2.0" },
     { name = "pyyaml", marker = "extra == 'test'", specifier = ">=6.0.3,<7.0" },


### PR DESCRIPTION
## Summary
- add a semantic packet classification model for merge-quorum CI logs and current local merge-packet output
- make reconcile_merge_quorum suppress reruns when CI and local packets disagree on tier or human-risk settlement
- surface a bounded classification-divergence follow-up prompt instead of spending another rerun

## Validation
- python3 -m pytest tests/swarm/test_merge_quorum_reconcile.py tests/swarm/test_merge_quorum_io.py -q
- python3 -m ruff check aragora/swarm/merge_quorum_reconcile.py aragora/swarm/merge_quorum_io.py scripts/reconcile_merge_quorum.py tests/swarm/test_merge_quorum_reconcile.py tests/swarm/test_merge_quorum_io.py
- git diff --check origin/main HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- pre-push hooks passed, including mypy on changed Aragora files

## Notes
- No CI/quorum rerun, merge, publisher/outbox mutation, or #7754 branch edit was performed.