### PR TITLE
fix(profiles): set explicit PATH in pool-verify launchd job

### DIFF
--- a/scripts/install_claude_pool_verify_launchd.sh
+++ b/scripts/install_claude_pool_verify_launchd.sh
@@ -14,12 +14,18 @@ INTERVAL_SECONDS=3600  # hourly: matches the routing snapshot TTL (1h)
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 LOG_PATH="${HOME}/.aragora/claude-pool-verify.log"
 PYTHON_BIN="${ARAGORA_PYTHON:-python3}"
+# launchd runs with a minimal PATH (/usr/bin:/bin:...) that lacks ~/.local/bin
+# (where the `claude` CLI lives) and Homebrew (gh/git). Without these on PATH the
+# profile probe silently fails and every profile is misreported as expired, so
+# set an explicit PATH for the job. Override with --path if your tools differ.
+BIN_PATH="${HOME}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [--interval-seconds <n>] [--python <path>]
+Usage: $(basename "$0") [--interval-seconds <n>] [--python <path>] [--path <PATH>]
   --interval-seconds <n>   launchd StartInterval (default: ${INTERVAL_SECONDS})
   --python <path>          Python interpreter (default: ${PYTHON_BIN})
+  --path <PATH>            PATH for the job (must include the claude CLI dir)
 EOF
 }
 
@@ -27,6 +33,7 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --interval-seconds) INTERVAL_SECONDS="$2"; shift 2 ;;
     --python) PYTHON_BIN="$2"; shift 2 ;;
+    --path) BIN_PATH="$2"; shift 2 ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown argument: $1" >&2; usage; exit 2 ;;
   esac
@@ -47,7 +54,7 @@ cat >"${PLIST_PATH}" <<EOF
   <array>
     <string>/bin/bash</string>
     <string>-lc</string>
-    <string>cd "${REPO_ROOT}" &amp;&amp; "${PYTHON_BIN}" scripts/claude_pool_verify.py</string>
+    <string>export PATH="${BIN_PATH}" &amp;&amp; cd "${REPO_ROOT}" &amp;&amp; "${PYTHON_BIN}" scripts/claude_pool_verify.py</string>
   </array>
   <key>RunAtLoad</key>
   <true/>


### PR DESCRIPTION
## Problem
The launchd job from #7767 ran `/bin/bash -lc 'cd … && python3 scripts/claude_pool_verify.py'` with launchd's minimal PATH (`/usr/bin:/bin:…`), which lacks **`~/.local/bin`** (the `claude` CLI) and Homebrew (`gh`/`git`). So every profile probe silently failed and got misreported as `expired` — the first real run logged **0/12 healthy with empty emails**, and that snapshot would have steered review/debate routing *away from perfectly good profiles*.

## Fix
Set an explicit `PATH` for the job (`~/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin`), overridable via `--path`. One-line change to the generated plist's command + a new flag.

## Verified
Re-installed locally: the same job went from **0/12** (PATH-broken) to the correct **7/12 healthy** with real per-profile emails, matching the manual run. The Python interpreter was already pinned by absolute path, so only the CLI/tool PATH needed fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)