### PR TITLE
fix(agent-bridge): suppress resolved steering blockers

### DIFF
--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -1975,7 +1975,7 @@ def _collect_pending_steering_messages(
                 str(data.get("message_sha256") or ""),
             )
             read_keys.add(key)
-            if str(data.get("outcome") or "") in RESOLVED_STEERING_OUTCOMES:
+            if str(data.get("outcome") or "").strip().lower() in RESOLVED_STEERING_OUTCOMES:
                 resolved_keys.add(key)
 
         unread = 0

--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -92,10 +92,8 @@ DEFAULT_ACTIVE_NEXT_ACTION = "unspecified active lane action"
 DEFAULT_STEERING_OUTCOME = "unknown"
 RESOLVED_STEERING_OUTCOMES = {
     "obeyed",
-    "held",
     "stale",
     "superseded",
-    "blocked",
     "completed",
 }
 DEFAULT_B0_SCORECARD_TIMEOUT_SECONDS = 5.0

--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -90,6 +90,14 @@ DEFAULT_STALE_TTL_HOURS = 24
 HEARTBEAT_FRESH_SECONDS = 15 * 60
 DEFAULT_ACTIVE_NEXT_ACTION = "unspecified active lane action"
 DEFAULT_STEERING_OUTCOME = "unknown"
+RESOLVED_STEERING_OUTCOMES = {
+    "obeyed",
+    "held",
+    "stale",
+    "superseded",
+    "blocked",
+    "completed",
+}
 DEFAULT_B0_SCORECARD_TIMEOUT_SECONDS = 5.0
 
 
@@ -1860,9 +1868,12 @@ def _collect_pending_steering_messages(
 
         scoped:
           {count: int, latest_three: [{subject, sent_at_utc, priority,
-                                        lane_id_hint, pr_hint}]}
+                                        lane_id_hint, pr_hint}],
+           unresolved_count: int, latest_unresolved_three: [...]}
         roll-up:
-          {count: int, by_recipient: {<session>: int}, latest_three: [...]}
+          {count: int, by_recipient: {<session>: int}, latest_three: [...],
+           unresolved_count: int, unresolved_by_recipient: {<session>: int},
+           latest_unresolved_three: [...]}
 
     Acknowledged messages live in the per-recipient ``_acked/`` subdir
     (Phase D convention; the directory name starts with ``_`` so this
@@ -1874,8 +1885,29 @@ def _collect_pending_steering_messages(
         steering_root = REPO_ROOT / ".aragora" / "operator-steering"
     if not steering_root.is_dir():
         if session_name:
-            return {"count": 0, "latest_three": []}
-        return {"count": 0, "by_recipient": {}, "latest_three": []}
+            return {
+                "count": 0,
+                "latest_three": [],
+                "unresolved_count": 0,
+                "latest_unresolved_three": [],
+            }
+        return {
+            "count": 0,
+            "by_recipient": {},
+            "latest_three": [],
+            "unresolved_count": 0,
+            "unresolved_by_recipient": {},
+            "latest_unresolved_three": [],
+        }
+
+    def _message_key(path: Path) -> tuple[str, str]:
+        try:
+            message = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            message = {}
+        if not isinstance(message, dict):
+            message = {}
+        return (path.name, str(message.get("message_sha256") or ""))
 
     def _summary_from(path: Path) -> dict[str, Any]:
         try:
@@ -1911,17 +1943,24 @@ def _collect_pending_steering_messages(
         # consumed messages per the Phase D convention.
         return [p for p in dir_path.glob("*.json") if p.is_file()]
 
-    def _read_receipt_summary(dir_path: Path, files: list[Path]) -> dict[str, Any]:
+    def _read_receipt_summary(
+        dir_path: Path,
+        files: list[Path],
+    ) -> tuple[dict[str, Any], set[tuple[str, str]]]:
         receipt_dir = dir_path / "_read_receipts"
         if not receipt_dir.is_dir():
-            return {
-                "read_receipt_count": 0,
-                "unread_message_count": len(files),
-                "latest_read_receipt": None,
-            }
+            return (
+                {
+                    "read_receipt_count": 0,
+                    "unread_message_count": len(files),
+                    "latest_read_receipt": None,
+                },
+                set(),
+            )
 
         receipts: list[dict[str, Any]] = []
         read_keys: set[tuple[str, str]] = set()
+        resolved_keys: set[tuple[str, str]] = set()
         for receipt_path in receipt_dir.glob("*.json"):
             if not receipt_path.is_file():
                 continue
@@ -1933,22 +1972,17 @@ def _collect_pending_steering_messages(
                 continue
             data["_receipt_filename"] = receipt_path.name
             receipts.append(data)
-            read_keys.add(
-                (
-                    str(data.get("message_filename") or ""),
-                    str(data.get("message_sha256") or ""),
-                )
+            key = (
+                str(data.get("message_filename") or ""),
+                str(data.get("message_sha256") or ""),
             )
+            read_keys.add(key)
+            if str(data.get("outcome") or "") in RESOLVED_STEERING_OUTCOMES:
+                resolved_keys.add(key)
 
         unread = 0
         for message_path in files:
-            try:
-                message = json.loads(message_path.read_text(encoding="utf-8"))
-            except (OSError, json.JSONDecodeError):
-                message = {}
-            if not isinstance(message, dict):
-                message = {}
-            key = (message_path.name, str(message.get("message_sha256") or ""))
+            key = _message_key(message_path)
             if key not in read_keys:
                 unread += 1
 
@@ -1965,54 +1999,85 @@ def _collect_pending_steering_messages(
                 "outcome": raw.get("outcome"),
                 "subject": raw.get("subject"),
             }
-        return {
-            "read_receipt_count": len(receipts),
-            "unread_message_count": unread,
-            "latest_read_receipt": latest,
-        }
+        return (
+            {
+                "read_receipt_count": len(receipts),
+                "unread_message_count": unread,
+                "latest_read_receipt": latest,
+            },
+            resolved_keys,
+        )
+
+    def _unresolved_files(files: list[Path], resolved_keys: set[tuple[str, str]]) -> list[Path]:
+        return [
+            message_path
+            for message_path in files
+            if _message_key(message_path) not in resolved_keys
+        ]
 
     if session_name:
         inbox_dir = steering_root / session_name
         files = _inbox_files(inbox_dir)
+        receipt_summary, resolved_keys = _read_receipt_summary(inbox_dir, files)
+        unresolved_files = _unresolved_files(files, resolved_keys)
         summaries = sorted(
             (_summary_from(p) for p in files),
+            key=lambda s: s["sent_at_utc"],
+            reverse=True,
+        )
+        unresolved_summaries = sorted(
+            (_summary_from(p) for p in unresolved_files),
             key=lambda s: s["sent_at_utc"],
             reverse=True,
         )
         return {
             "count": len(files),
             "latest_three": summaries[:3],
-            **_read_receipt_summary(inbox_dir, files),
+            "unresolved_count": len(unresolved_files),
+            "latest_unresolved_three": unresolved_summaries[:3],
+            **receipt_summary,
         }
 
     # Roll-up across all recipient dirs.
     by_recipient: dict[str, int] = {}
+    unresolved_by_recipient: dict[str, int] = {}
     read_receipts_by_recipient: dict[str, int] = {}
     all_summaries: list[dict[str, Any]] = []
+    all_unresolved_summaries: list[dict[str, Any]] = []
     total_read_receipts = 0
     total_unread = 0
+    total_unresolved = 0
     latest_receipts: list[dict[str, Any]] = []
     for child in sorted(steering_root.iterdir()):
         if not child.is_dir() or child.name.startswith("."):
             continue
         files = _inbox_files(child)
+        receipt_summary, resolved_keys = _read_receipt_summary(child, files)
+        unresolved_files = _unresolved_files(files, resolved_keys)
         if files:
             by_recipient[child.name] = len(files)
             all_summaries.extend(_summary_from(p) for p in files)
-        receipt_summary = _read_receipt_summary(child, files)
+        if unresolved_files:
+            unresolved_by_recipient[child.name] = len(unresolved_files)
+            all_unresolved_summaries.extend(_summary_from(p) for p in unresolved_files)
         total_read_receipts += int(receipt_summary["read_receipt_count"])
         total_unread += int(receipt_summary["unread_message_count"])
+        total_unresolved += len(unresolved_files)
         if receipt_summary["read_receipt_count"]:
             read_receipts_by_recipient[child.name] = int(receipt_summary["read_receipt_count"])
         latest = receipt_summary["latest_read_receipt"]
         if isinstance(latest, dict):
             latest_receipts.append(latest)
     all_summaries.sort(key=lambda s: s["sent_at_utc"], reverse=True)
+    all_unresolved_summaries.sort(key=lambda s: s["sent_at_utc"], reverse=True)
     latest_receipts.sort(key=lambda r: str(r.get("read_at_utc") or ""), reverse=True)
     return {
         "count": sum(by_recipient.values()),
         "by_recipient": by_recipient,
         "latest_three": all_summaries[:3],
+        "unresolved_count": total_unresolved,
+        "unresolved_by_recipient": unresolved_by_recipient,
+        "latest_unresolved_three": all_unresolved_summaries[:3],
         "read_receipt_count": total_read_receipts,
         "unread_message_count": total_unread,
         "read_receipts_by_recipient": read_receipts_by_recipient,
@@ -2107,8 +2172,9 @@ def _collect_agent_heartbeats(
 
 
 def _operator_pending_steering_count(pending_steering: dict[str, Any]) -> int:
+    key = "unresolved_count" if "unresolved_count" in pending_steering else "count"
     try:
-        return max(0, int(pending_steering.get("count", 0)))
+        return max(0, int(pending_steering.get(key, 0)))
     except (TypeError, ValueError):
         return 0
 
@@ -2140,7 +2206,10 @@ def _operator_recent_blockers(
 ) -> list[dict[str, Any]]:
     blockers: list[dict[str, Any]] = []
     if _operator_pending_steering_count(pending_steering):
-        for message in pending_steering.get("latest_three", []):
+        messages = pending_steering.get("latest_unresolved_three")
+        if messages is None:
+            messages = pending_steering.get("latest_three", [])
+        for message in messages:
             if not isinstance(message, dict):
                 continue
             blockers.append(

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -644,6 +644,106 @@ def test_operator_snapshot_exposes_b0_issue_contract_fields(
     ]
 
 
+def test_collect_pending_steering_messages_completed_receipts_are_not_actionable(
+    tmp_path: Path,
+) -> None:
+    import agent_bridge as mod
+
+    steering_root = tmp_path / "operator-steering"
+    inbox = steering_root / "owner-session"
+    receipts = inbox / "_read_receipts"
+    receipts.mkdir(parents=True)
+    message = {
+        "subject": "Operator selected Option 1 for #7741",
+        "sent_at_utc": "2026-06-04T15:49:57.982Z",
+        "priority": "blocking",
+        "lane_id_hint": "Q324-repair-build-next-prompt-merged-active-lane-handoff",
+        "pr_hint": 7741,
+        "message_sha256": "sha-completed",
+    }
+    (inbox / "2026-06-04T15-49-57-982Z-message.json").write_text(
+        json.dumps(message),
+        encoding="utf-8",
+    )
+    receipt = {
+        "read_at_utc": "2026-06-04T21:32:54.925Z",
+        "read_by_session": "codex-repair",
+        "message_filename": "2026-06-04T15-49-57-982Z-message.json",
+        "message_sha256": "sha-completed",
+        "outcome": "completed",
+        "subject": message["subject"],
+    }
+    (receipts / "2026-06-04T21-32-54-925Z-receipt.json").write_text(
+        json.dumps(receipt),
+        encoding="utf-8",
+    )
+
+    payload = mod._collect_pending_steering_messages(None, steering_root)
+
+    assert payload["count"] == 1
+    assert payload["by_recipient"] == {"owner-session": 1}
+    assert payload["unread_message_count"] == 0
+    assert payload["unresolved_count"] == 0
+    assert payload["unresolved_by_recipient"] == {}
+    assert payload["latest_three"][0]["subject"] == message["subject"]
+    assert payload["latest_unresolved_three"] == []
+    assert mod._operator_recent_blockers([], payload) == []
+    assert mod._operator_queue_depth({"active_lanes": 2, "active_broker_runs": 0}, payload) == 2
+
+
+def test_collect_pending_steering_messages_read_receipts_remain_actionable(
+    tmp_path: Path,
+) -> None:
+    import agent_bridge as mod
+
+    steering_root = tmp_path / "operator-steering"
+    inbox = steering_root / "owner-session"
+    receipts = inbox / "_read_receipts"
+    receipts.mkdir(parents=True)
+    message = {
+        "subject": "Need B0 action",
+        "sent_at_utc": "2026-05-28T12:01:00Z",
+        "priority": "high",
+        "lane_id_hint": "b0-5426",
+        "pr_hint": 5426,
+        "message_sha256": "sha-read",
+    }
+    (inbox / "2026-05-28T12-01-00Z-message.json").write_text(
+        json.dumps(message),
+        encoding="utf-8",
+    )
+    receipt = {
+        "read_at_utc": "2026-05-28T12:02:00Z",
+        "read_by_session": "codex-b0",
+        "message_filename": "2026-05-28T12-01-00Z-message.json",
+        "message_sha256": "sha-read",
+        "outcome": "read",
+        "subject": message["subject"],
+    }
+    (receipts / "2026-05-28T12-02-00Z-receipt.json").write_text(
+        json.dumps(receipt),
+        encoding="utf-8",
+    )
+
+    payload = mod._collect_pending_steering_messages("owner-session", steering_root)
+
+    assert payload["count"] == 1
+    assert payload["unread_message_count"] == 0
+    assert payload["unresolved_count"] == 1
+    assert payload["latest_unresolved_three"][0]["subject"] == "Need B0 action"
+    assert mod._operator_pending_steering_count(payload) == 1
+    assert mod._operator_recent_blockers([], payload) == [
+        {
+            "type": "pending_steering",
+            "source": "operator_steering",
+            "detail": "Need B0 action",
+            "priority": "high",
+            "lane_id_hint": "b0-5426",
+            "pr_hint": 5426,
+        }
+    ]
+
+
 def test_collect_b0_success_rate_times_out_fail_closed(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -744,6 +744,51 @@ def test_collect_pending_steering_messages_read_receipts_remain_actionable(
     ]
 
 
+@pytest.mark.parametrize("outcome", ["blocked", "held"])
+def test_collect_pending_steering_messages_blocked_or_held_receipts_remain_actionable(
+    tmp_path: Path,
+    outcome: str,
+) -> None:
+    import agent_bridge as mod
+
+    steering_root = tmp_path / "operator-steering"
+    inbox = steering_root / "owner-session"
+    receipts = inbox / "_read_receipts"
+    receipts.mkdir(parents=True)
+    message = {
+        "subject": f"Steering {outcome}",
+        "sent_at_utc": "2026-06-05T12:01:00Z",
+        "priority": "blocking",
+        "lane_id_hint": "blocked-lane",
+        "pr_hint": None,
+        "message_sha256": f"sha-{outcome}",
+    }
+    (inbox / f"2026-06-05T12-01-00Z-{outcome}.json").write_text(
+        json.dumps(message),
+        encoding="utf-8",
+    )
+    receipt = {
+        "read_at_utc": "2026-06-05T12:02:00Z",
+        "read_by_session": "codex-worker",
+        "message_filename": f"2026-06-05T12-01-00Z-{outcome}.json",
+        "message_sha256": f"sha-{outcome}",
+        "outcome": outcome,
+        "subject": message["subject"],
+    }
+    (receipts / f"2026-06-05T12-02-00Z-{outcome}-receipt.json").write_text(
+        json.dumps(receipt),
+        encoding="utf-8",
+    )
+
+    payload = mod._collect_pending_steering_messages(None, steering_root)
+
+    assert payload["count"] == 1
+    assert payload["unresolved_count"] == 1
+    assert payload["latest_unresolved_three"][0]["subject"] == f"Steering {outcome}"
+    assert mod._operator_pending_steering_count(payload) == 1
+    assert mod._operator_recent_blockers([], payload)[0]["detail"] == f"Steering {outcome}"
+
+
 def test_collect_b0_success_rate_times_out_fail_closed(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -691,6 +691,47 @@ def test_collect_pending_steering_messages_completed_receipts_are_not_actionable
     assert mod._operator_queue_depth({"active_lanes": 2, "active_broker_runs": 0}, payload) == 2
 
 
+def test_collect_pending_steering_messages_normalizes_terminal_receipt_outcomes(
+    tmp_path: Path,
+) -> None:
+    import agent_bridge as mod
+
+    steering_root = tmp_path / "operator-steering"
+    inbox = steering_root / "owner-session"
+    receipts = inbox / "_read_receipts"
+    receipts.mkdir(parents=True)
+    message = {
+        "subject": "Completed with padded outcome",
+        "sent_at_utc": "2026-06-05T12:01:00Z",
+        "priority": "blocking",
+        "lane_id_hint": "completed-lane",
+        "pr_hint": None,
+        "message_sha256": "sha-completed-padded",
+    }
+    (inbox / "2026-06-05T12-01-00Z-completed.json").write_text(
+        json.dumps(message),
+        encoding="utf-8",
+    )
+    receipt = {
+        "read_at_utc": "2026-06-05T12:02:00Z",
+        "read_by_session": "codex-worker",
+        "message_filename": "2026-06-05T12-01-00Z-completed.json",
+        "message_sha256": "sha-completed-padded",
+        "outcome": " Completed ",
+        "subject": message["subject"],
+    }
+    (receipts / "2026-06-05T12-02-00Z-completed-receipt.json").write_text(
+        json.dumps(receipt),
+        encoding="utf-8",
+    )
+
+    payload = mod._collect_pending_steering_messages("owner-session", steering_root)
+
+    assert payload["count"] == 1
+    assert payload["unresolved_count"] == 0
+    assert payload["latest_unresolved_three"] == []
+
+
 def test_collect_pending_steering_messages_read_receipts_remain_actionable(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- keep raw operator-steering top-level message counts visible for observability
- add unresolved steering counts derived from terminal read-receipt outcomes
- route operator queue depth and recent blockers through unresolved steering so completed/superseded receipts do not keep stale blocker rows alive

## Validation
- PYTHONDONTWRITEBYTECODE=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/scripts/test_agent_bridge.py
- python3 -m ruff check scripts/agent_bridge.py tests/scripts/test_agent_bridge.py
- python3 -m ruff format --check scripts/agent_bridge.py tests/scripts/test_agent_bridge.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- python3 scripts/agent_bridge.py operator-snapshot --json --summary-only

## Live Smoke
- pending_steering_messages.unresolved_count=0
- recent_blockers no longer includes pending_steering for the completed Q324 receipt
- remaining blockers are unrelated lane health rows
