### PR TITLE
feat(observability): fleet-health monitor for blocked_auth_failure inputs

### DIFF
--- a/scripts/fleet_health_monitor.sh
+++ b/scripts/fleet_health_monitor.sh
@@ -43,11 +43,10 @@ if command -v gh >/dev/null 2>&1; then
   runner_json="$(timeout 25 gh api "repos/${REPO}/actions/runners" \
     --jq '[.runners[] | {name, status}]' 2>/dev/null || echo '[]')"
 fi
-# Parse the runner inventory robustly (handles any JSON spacing/key order, unlike grep).
-declare -A RUNNER_STATUS
-while IFS=$'\t' read -r _rn _rs; do
-  [ -n "$_rn" ] && RUNNER_STATUS["$_rn"]="$_rs"
-done < <(printf '%s' "$runner_json" | python3 -c '
+# Parse the runner inventory into "name<TAB>status" lines (robust to any JSON
+# spacing/key order). Avoids bash-4 associative arrays so it runs under macOS
+# /bin/bash 3.2 (which launchd uses).
+runner_lines="$(printf '%s' "$runner_json" | python3 -c '
 import json, sys
 try:
     arr = json.load(sys.stdin)
@@ -56,13 +55,14 @@ except Exception:
 for d in arr if isinstance(arr, list) else []:
     if isinstance(d, dict):
         print((d.get("name") or "") + "\t" + (d.get("status") or "unknown"))
-' 2>/dev/null)
+' 2>/dev/null)"
 
 offline_watched=""
 IFS=',' read -r -a _watch <<< "$WATCH_RUNNERS"
 for r in "${_watch[@]}"; do
   [ -z "$r" ] && continue
-  st="${RUNNER_STATUS[$r]:-unknown}"
+  st="$(printf '%s\n' "$runner_lines" | awk -F'\t' -v n="$r" '$1==n{print $2; exit}')"
+  [ -z "$st" ] && st="unknown"
   if [ "$st" != "online" ]; then
     offline_watched="${offline_watched} ${r}(${st})"
     degraded=1
@@ -78,14 +78,42 @@ fi
 [ "$gh_auth" = "UNAUTHENTICATED" ] && alerts+=("GITHUB_API slice degraded — gh is not authenticated → workers will queue/blocked_auth_failure")
 
 # --- 3. proof freshness ------------------------------------------------------
+# Check the PUBLISHED surfaces on origin/main, not the local working tree — the local
+# checkout may sit on an older branch and would otherwise false-alarm.
 proof="unknown"
-probe="${REPO_ROOT}/scripts/probe_proof_surface_freshness.py"
-if [ -f "$probe" ]; then
-  if timeout 25 python3 "$probe" --surfaces b0,tw03 --max-age-days "$MAX_AGE_DAYS" >/dev/null 2>&1; then
-    proof="fresh"
-  else
-    proof="STALE"; degraded=1
-    alerts+=("PROOF surfaces STALE (>${MAX_AGE_DAYS}d) — published claim drifting from measured truth")
+if [ -n "$REPO_ROOT" ] && git -C "$REPO_ROOT" rev-parse --git-dir >/dev/null 2>&1; then
+  timeout 20 git -C "$REPO_ROOT" fetch origin main --quiet 2>/dev/null || true
+  proof="$(
+    {
+      git -C "$REPO_ROOT" show origin/main:docs/status/B0_BENCHMARK_TRUTH_STATUS.md 2>/dev/null
+      echo '---FLEET-SURFACE-SEP---'
+      git -C "$REPO_ROOT" show origin/main:docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md 2>/dev/null
+    } | MAX_AGE_DAYS="$MAX_AGE_DAYS" python3 -c '
+import sys, re, os, datetime as _dt
+txt = sys.stdin.read()
+maxage = float(os.environ.get("MAX_AGE_DAYS", "7"))
+now = _dt.datetime.now(_dt.timezone.utc)
+ages = []
+for block in txt.split("---FLEET-SURFACE-SEP---"):
+    m = re.search(r"Last updated:\s*([0-9T:+\-]+Z?)", block)
+    if not m:
+        continue
+    s = m.group(1).strip()
+    try:
+        d = _dt.datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except Exception:
+        try:
+            d = _dt.datetime.strptime(s[:10], "%Y-%m-%d").replace(tzinfo=_dt.timezone.utc)
+        except Exception:
+            continue
+    ages.append((now - d).total_seconds() / 86400.0)
+print("unknown" if not ages else ("fresh" if max(ages) <= maxage else "STALE"))
+' 2>/dev/null
+  )"
+  proof="${proof:-unknown}"
+  if [ "$proof" = "STALE" ]; then
+    degraded=1
+    alerts+=("PROOF surfaces STALE (>${MAX_AGE_DAYS}d on origin/main) — published claim drifting from measured truth")
   fi
 fi
 

--- a/scripts/fleet_health_monitor.sh
+++ b/scripts/fleet_health_monitor.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Fleet health monitor — watches the exact inputs to `blocked_auth_failure`.
+#
+# Why this exists
+#   The B0 benchmark's dominant failure class is `blocked_auth_failure`, raised by the
+#   dispatch contract gate when a worker is missing a credential "slice" — `runner`,
+#   `github_api`, or `provider` (see aragora/swarm/dispatch_contract_gate.py). When any
+#   of those degrade, B0 issues cannot dispatch and product proof silently caps. The
+#   runner fleet died unnoticed for 6 days (Mac exhaustion + Hetzner IP-block) and zeroed
+#   in-progress graduation without any alert. This monitor watches those slices directly,
+#   so degradation pages the operator BEFORE it quietly drops the benchmark.
+#
+# Checks (all read-only; best-effort; a hang in one never blocks the others):
+#   1. runner slice    — GitHub Actions self-hosted runners online (alert on offline)
+#   2. github_api slice — `gh auth status` healthy
+#   3. proof freshness  — B0/TW03 surfaces within the freshness threshold
+#
+# Run locally (where gh is authenticated, like the rest of the fleet). NEVER remotely —
+# a sandbox without gh auth would false-alarm (and is itself the github_api failure mode).
+#   crontab: 23 */2 * * *  /path/to/aragora/scripts/fleet_health_monitor.sh >> ~/.aragora/fleet_health.log 2>&1
+#
+# Exit: 0 = all healthy; 1 = degraded (at least one slice/proof unhealthy). The status
+# JSON is always written so a wrapper can render it even on the failure path.
+set -uo pipefail
+
+REPO="${ARAGORA_GH_REPO:-synaptent/aragora}"
+STATUS_FILE="${FLEET_HEALTH_STATUS:-${HOME}/.aragora/fleet_health_status.json}"
+MAX_AGE_DAYS="${PROOF_MAX_AGE_DAYS:-7}"
+# Self-hosted runners that gate self-hosted shadow CI; offline → blocked_auth_failure risk.
+# Override with a comma-separated list. Default covers the known fleet name prefixes.
+WATCH_RUNNERS="${FLEET_WATCH_RUNNERS:-mac-studio-m3ultra,aragora-hetzner-cpu1,aragora-hetzner-cpu2,aragora-hetzner-cpu3}"
+ts() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+REPO_ROOT="${ARAGORA_REPO:-$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel 2>/dev/null)}"
+mkdir -p "$(dirname "$STATUS_FILE")"
+
+degraded=0
+alerts=()
+
+# --- 1. runner slice ---------------------------------------------------------
+runner_json='[]'
+if command -v gh >/dev/null 2>&1; then
+  runner_json="$(timeout 25 gh api "repos/${REPO}/actions/runners" \
+    --jq '[.runners[] | {name, status}]' 2>/dev/null || echo '[]')"
+fi
+# Parse the runner inventory robustly (handles any JSON spacing/key order, unlike grep).
+declare -A RUNNER_STATUS
+while IFS=$'\t' read -r _rn _rs; do
+  [ -n "$_rn" ] && RUNNER_STATUS["$_rn"]="$_rs"
+done < <(printf '%s' "$runner_json" | python3 -c '
+import json, sys
+try:
+    arr = json.load(sys.stdin)
+except Exception:
+    arr = []
+for d in arr if isinstance(arr, list) else []:
+    if isinstance(d, dict):
+        print((d.get("name") or "") + "\t" + (d.get("status") or "unknown"))
+' 2>/dev/null)
+
+offline_watched=""
+IFS=',' read -r -a _watch <<< "$WATCH_RUNNERS"
+for r in "${_watch[@]}"; do
+  [ -z "$r" ] && continue
+  st="${RUNNER_STATUS[$r]:-unknown}"
+  if [ "$st" != "online" ]; then
+    offline_watched="${offline_watched} ${r}(${st})"
+    degraded=1
+  fi
+done
+[ -n "$offline_watched" ] && alerts+=("RUNNER slice degraded — offline:${offline_watched} → blocked_auth_failure risk; check host power/network/billing")
+
+# --- 2. github_api slice -----------------------------------------------------
+gh_auth="unknown"
+if command -v gh >/dev/null 2>&1; then
+  if timeout 15 gh auth status >/dev/null 2>&1; then gh_auth="ok"; else gh_auth="UNAUTHENTICATED"; degraded=1; fi
+fi
+[ "$gh_auth" = "UNAUTHENTICATED" ] && alerts+=("GITHUB_API slice degraded — gh is not authenticated → workers will queue/blocked_auth_failure")
+
+# --- 3. proof freshness ------------------------------------------------------
+proof="unknown"
+probe="${REPO_ROOT}/scripts/probe_proof_surface_freshness.py"
+if [ -f "$probe" ]; then
+  if timeout 25 python3 "$probe" --surfaces b0,tw03 --max-age-days "$MAX_AGE_DAYS" >/dev/null 2>&1; then
+    proof="fresh"
+  else
+    proof="STALE"; degraded=1
+    alerts+=("PROOF surfaces STALE (>${MAX_AGE_DAYS}d) — published claim drifting from measured truth")
+  fi
+fi
+
+# --- emit status -------------------------------------------------------------
+{
+  printf '{"checked_at":"%s","degraded":%s,"github_api":"%s","proof":"%s",' \
+    "$(ts)" "$([ "$degraded" -eq 0 ] && echo false || echo true)" "$gh_auth" "$proof"
+  printf '"offline_runners":"%s","alerts":%s}\n' \
+    "$(echo "$offline_watched" | sed 's/^ *//')" \
+    "$([ "${#alerts[@]}" -eq 0 ] && echo '[]' || printf '%s' "$(printf '%s\n' "${alerts[@]}" | python3 -c 'import json,sys; print(json.dumps([l.rstrip() for l in sys.stdin if l.strip()]))')")"
+} > "$STATUS_FILE"
+
+if [ "$degraded" -eq 0 ]; then
+  echo "[$(ts)] fleet healthy — runners online, gh authed, proof ${proof}."
+  exit 0
+fi
+echo "[$(ts)] FLEET DEGRADED:"
+for a in "${alerts[@]}"; do echo "  - $a"; done
+exit 1

--- a/tests/scripts/test_fleet_health_monitor.py
+++ b/tests/scripts/test_fleet_health_monitor.py
@@ -1,0 +1,98 @@
+"""Hermetic tests for scripts/fleet_health_monitor.sh.
+
+The monitor watches the credential slices that produce `blocked_auth_failure`
+(runner / github_api), so its alert path is load-bearing for catching silent
+benchmark regressions. These tests stub `gh` on PATH and point ARAGORA_REPO at a
+probe-less temp dir (so the proof check is skipped) to isolate the runner slice.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MONITOR = REPO_ROOT / "scripts" / "fleet_health_monitor.sh"
+
+
+def _fake_gh(bin_dir: Path, runners: list[dict], *, auth_ok: bool = True) -> None:
+    """Write a fake `gh` that answers `api .../runners` and `auth status`."""
+    payload = json.dumps({"runners": runners})
+    script = f"""#!/usr/bin/env bash
+if [ "$1" = "auth" ]; then exit {0 if auth_ok else 1}; fi
+if [ "$1" = "api" ]; then
+  # honor the --jq the monitor passes by emitting the already-filtered shape
+  cat <<'JSON'
+{json.dumps([{"name": r["name"], "status": r["status"]} for r in runners])}
+JSON
+  exit 0
+fi
+exit 0
+"""
+    gh = bin_dir / "gh"
+    gh.write_text(script)
+    gh.chmod(0o755)
+    _ = payload  # the monitor uses --jq; fake emits filtered list directly
+
+
+def _run(tmp_path: Path, runners: list[dict], watch: str, *, auth_ok: bool = True):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _fake_gh(bin_dir, runners, auth_ok=auth_ok)
+    status_file = tmp_path / "status.json"
+    env = {
+        **os.environ,
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+        "ARAGORA_REPO": str(tmp_path),  # no scripts/probe... here -> proof check skipped
+        "FLEET_WATCH_RUNNERS": watch,
+        "FLEET_HEALTH_STATUS": str(status_file),
+    }
+    proc = subprocess.run(
+        ["bash", str(MONITOR)], env=env, capture_output=True, text=True, timeout=60
+    )
+    status = json.loads(status_file.read_text())
+    return proc, status
+
+
+def test_healthy_when_watched_runner_online(tmp_path):
+    proc, status = _run(
+        tmp_path,
+        [{"name": "mac-studio-m3ultra", "status": "online"}],
+        "mac-studio-m3ultra",
+    )
+    assert proc.returncode == 0
+    assert status["degraded"] is False
+    assert status["offline_runners"] == ""
+
+
+def test_degraded_and_alerts_when_runner_offline(tmp_path):
+    proc, status = _run(
+        tmp_path,
+        [{"name": "aragora-hetzner-cpu1", "status": "offline"}],
+        "aragora-hetzner-cpu1",
+    )
+    assert proc.returncode == 1
+    assert status["degraded"] is True
+    assert "aragora-hetzner-cpu1" in status["offline_runners"]
+    assert any("blocked_auth_failure" in a for a in status["alerts"])
+
+
+def test_degraded_when_runner_absent_from_inventory(tmp_path):
+    proc, status = _run(tmp_path, [], "mac-studio-m3ultra")
+    assert proc.returncode == 1
+    assert status["degraded"] is True
+    assert "mac-studio-m3ultra(unknown)" in status["offline_runners"]
+
+
+def test_github_api_slice_flagged_when_unauthenticated(tmp_path):
+    proc, status = _run(
+        tmp_path,
+        [{"name": "mac-studio-m3ultra", "status": "online"}],
+        "mac-studio-m3ultra",
+        auth_ok=False,
+    )
+    assert proc.returncode == 1
+    assert status["github_api"] == "UNAUTHENTICATED"
+    assert any("GITHUB_API" in a for a in status["alerts"])


### PR DESCRIPTION
## Why
The B0 benchmark's dominant failure class is `blocked_auth_failure` — raised by the dispatch contract gate when a worker is missing a credential **slice** (`runner` / `github_api` / `provider`, see aragora/swarm/dispatch_contract_gate.py). When those degrade, B0 issues can't dispatch and product proof silently caps. The runner fleet died unnoticed for **6 days** (Mac network exhaustion + Hetzner IP-block for non-payment), zeroing in-progress graduation with no alert.

This makes the boring infra reliability — which is a *literal causal input* to the benchmark — observable.

## What
`scripts/fleet_health_monitor.sh` watches exactly those slices:
- **runner** — GitHub Actions runner inventory (alert on offline)
- **github_api** — `gh auth status`
- **proof freshness** — B0/TW03 surfaces

Local cron/launchd (needs gh auth, like the rest of the fleet). Read-only, best-effort, one check never blocks another; emits a JSON status file + exit 1 on degradation. +4 hermetic tests (stubbed gh).

## Validation
- 4/4 tests pass; ruff clean; preflight clean; portability guard clean.
- Live healthy run: `fleet healthy — runners online, gh authed, proof fresh`.
- Negative smoke: offline runner → exit 1 + `blocked_auth_failure risk` alert.

Tier 2 (additive operability automation). No launchd wiring here — scheduling it is the operator's step.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>