### PR TITLE
test(debate)+chore(metrics): numpy-absent import guard + METRICS drift refresh

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -12,12 +12,12 @@
 
 | Metric | Value | Source | Command |
 |---|---|---|---|
-| Python files under aragora/ | `4157` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1950127` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python files under aragora/ | `4164` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
+| Python lines of code under aragora/ | `1953695` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `141` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5259` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `219622` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
-| @pytest.mark.parametrize decorators | `717` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
+| Test files (test_*.py under tests/) | `5273` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `219932` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| @pytest.mark.parametrize decorators | `725` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `77` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2870` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
 | OpenAPI operations (HTTP verbs) | `3297` | `docs/api/openapi.json` | `python -c "import json; spec=json.load(open('docs/api/openapi.json')); print(sum(1 for p in spec['paths'].values() for m in p if m.lower() in {'get','post','put','delete','patch','head','options'}))"` |
@@ -28,8 +28,8 @@
 | Allowlisted agent types | `35` | `aragora/config/settings.py` | `grep -A 50 'ALLOWED_AGENT_TYPES' aragora/config/settings.py \| grep -oE "'[a-z-]+'" \| sort -u \| wc -l` |
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `46` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |
-| Markdown files under docs/ | `970` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
-| GitHub Actions workflows | `87` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
+| Markdown files under docs/ | `973` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
+| GitHub Actions workflows | `88` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
 | Mypy baseline errors (grandfathered) | `3115` | `.mypy-baseline` | `wc -l .mypy-baseline` |
 
 ## Notes on counting methodology

--- a/tests/debate/similarity/test_backends.py
+++ b/tests/debate/similarity/test_backends.py
@@ -1297,3 +1297,30 @@ class TestNumpyAbsentImport:
         )
         assert proc.returncode == 0, proc.stderr
         assert "IMPORT_OK" in proc.stdout
+
+    def test_similarity_package_imports_without_numpy(self):
+        """Guard the package ``__init__`` chain, not just ``.backends``.
+
+        The boss-loop / swarm crash flowed through ``import
+        aragora.debate.similarity`` (the package), which imports both
+        ``backends`` and ``ann``. The submodule-only test above would not
+        catch a regression that drops deferred annotations from ``ann`` (or
+        any other eager ``np.ndarray`` use reachable from the package
+        ``__init__``), so assert the whole entrypoint imports cleanly.
+        """
+        code = (
+            "import sys; sys.modules['numpy'] = None;"
+            "import aragora.debate.similarity as s;"
+            "assert s.SentenceTransformerBackend.__name__ == 'SentenceTransformerBackend';"
+            "from aragora.debate.similarity import ann;"
+            "assert ann.HAS_NUMPY is False;"
+            "print('IMPORT_OK')"
+        )
+        proc = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert "IMPORT_OK" in proc.stdout


### PR DESCRIPTION
## Summary

Two bounded, in-scope hygiene fixes found by dogfooding Aragora's own health probes from a clean `origin/main` observer worktree.

1. **`test(debate)` — Tier 0:** Add a package-level numpy-absent import regression test. The boss loop historically crashed with `AttributeError: 'NoneType' object has no attribute 'ndarray'` when importing `aragora.debate.similarity` (the package, which imports both `backends.py` and `ann.py` via `__init__`) under a numpy-less interpreter. That root cause is already fixed on `main` (#7585 deferred annotations, #7697 runtime interpreter guard), but the existing regression test only imports the `.backends` submodule, so it would miss an `ann.py` regression on the exact path the boss loop exercises. This closes that coverage gap.
2. **`chore(metrics)` — Tier 1:** Regenerate `docs/METRICS.md` via `scripts/regenerate_metrics.py` to clear drift flagged by `metrics-drift.yml`: `@pytest.mark.parametrize` 717→725 and GitHub Actions workflows 87→88 (both > 0.5% gate). Generated artifact; no behavior change.

## Validation (local truth)

- `pytest tests/debate/similarity/test_backends.py` → 113 passed (was 112; test count increased).
- `pytest tests/debate/similarity/test_backends.py::TestNumpyAbsentImport` → 2 passed.
- `scripts/regenerate_metrics.py --check` → "No drift beyond 0.5% threshold."
- `pre-commit run --files <both files>` → all hooks pass.

## Review-gate note (transparency)

This batch was produced under the `elves-aragora` validation discipline. The heterogeneous-model adversarial-review step could **not** complete locally: the env `GEMINI_API_KEY` is expired and grok/CLI agents timed out under heavy concurrent load (46 live automation processes). No debate receipt was fabricated. This PR therefore relies on the authoritative CI review gates (`metrics-drift.yml`, `aragora-merge-quorum.yml`, required checks) for settlement rather than a local auto-settlement.

Tier: 1 (max of the two changes). Founder root left untouched; all work done in an isolated worktree at `origin/main`.
