### PR TITLE
fix(review-queue): make evidence reviewer timeouts configurable

### DIFF
--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import logging
+import os
 import re
 import subprocess
 from collections.abc import Callable, Sequence
@@ -83,6 +84,8 @@ _MAX_DIFF_CHARS = 60_000
 _MAX_REVIEWER_CHARS = 32_000
 _CLAUDE_TIMEOUT = 300
 _REVIEWER_TIMEOUT = 300
+_CLAUDE_TIMEOUT_ENV = "ARAGORA_COLLECT_EVIDENCE_CLAUDE_TIMEOUT_SECONDS"
+_REVIEWER_TIMEOUT_ENV = "ARAGORA_COLLECT_EVIDENCE_REVIEWER_TIMEOUT_SECONDS"
 
 
 def _cap_text(text: str) -> str:
@@ -90,6 +93,23 @@ def _cap_text(text: str) -> str:
     if len(text) > _MAX_REVIEWER_CHARS:
         return text[:_MAX_REVIEWER_CHARS].rstrip() + "\n\n[reviewer output truncated]"
     return text
+
+
+def _timeout_seconds(env_name: str, default: int) -> float:
+    raw = os.environ.get(env_name, "").strip()
+    if not raw:
+        return float(default)
+    try:
+        value = float(raw)
+    except ValueError:
+        return float(default)
+    if value <= 0:
+        return float(default)
+    return value
+
+
+def _format_seconds(seconds: float) -> str:
+    return f"{seconds:g}"
 
 
 @dataclass
@@ -283,19 +303,22 @@ def default_reviewer_runner(family: str, prompt: str) -> ReviewerResult:
 
 
 def _run_claude_cli(prompt: str) -> ReviewerResult:
+    timeout = _timeout_seconds(_CLAUDE_TIMEOUT_ENV, _CLAUDE_TIMEOUT)
     try:
         proc = subprocess.run(
             ["claude", "-p"],
             input=prompt,
             capture_output=True,
             text=True,
-            timeout=_CLAUDE_TIMEOUT,
+            timeout=timeout,
             check=False,
         )
     except FileNotFoundError:
         return ReviewerResult("claude", "", False, "claude CLI not found on PATH")
     except subprocess.TimeoutExpired:
-        return ReviewerResult("claude", "", False, f"claude CLI timed out after {_CLAUDE_TIMEOUT}s")
+        return ReviewerResult(
+            "claude", "", False, f"claude CLI timed out after {_format_seconds(timeout)}s"
+        )
     except (OSError, subprocess.SubprocessError) as exc:
         # Convert any other subprocess error (e.g. broken pipe writing stdin)
         # into a recorded failure so one bad reviewer never aborts the run.
@@ -329,8 +352,9 @@ def _run_api_agent(family: str, prompt: str) -> ReviewerResult:
 
 async def _generate_with_api_agent_cleanup(agent: Any, prompt: str) -> str:
     """Generate with an API-backed agent and close one-shot network resources."""
+    timeout = _timeout_seconds(_REVIEWER_TIMEOUT_ENV, _REVIEWER_TIMEOUT)
     try:
-        return await asyncio.wait_for(agent.generate(prompt), timeout=_REVIEWER_TIMEOUT)
+        return await asyncio.wait_for(agent.generate(prompt), timeout=timeout)
     finally:
         await _close_api_agent_resources(agent)
 

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import logging
+import math
 import os
 import re
 import subprocess
@@ -103,7 +104,7 @@ def _timeout_seconds(env_name: str, default: int) -> float:
         value = float(raw)
     except ValueError:
         return float(default)
-    if value <= 0:
+    if not math.isfinite(value) or value <= 0:
         return float(default)
     return value
 

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -206,6 +206,9 @@ def test_compose_sanitizes_committed_timestamp() -> None:
         ("not-a-number", 300.0),
         ("0", 300.0),
         ("-5", 300.0),
+        ("nan", 300.0),
+        ("inf", 300.0),
+        ("-inf", 300.0),
         ("12.5", 12.5),
     ],
 )

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -11,6 +11,8 @@ The compose helper is checked against the *real* evidence parser
 
 from __future__ import annotations
 
+import subprocess
+
 import pytest
 
 from aragora.swarm import quorum_evidence as qe
@@ -192,6 +194,51 @@ def test_compose_sanitizes_committed_timestamp() -> None:
     capped = qe._cap_text("x" * (qe._MAX_REVIEWER_CHARS + 5000))
     assert len(capped) <= qe._MAX_REVIEWER_CHARS + 64
     assert capped.endswith("[reviewer output truncated]")
+
+
+# --- reviewer timeout configuration ----------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("", 300.0),
+        ("not-a-number", 300.0),
+        ("0", 300.0),
+        ("-5", 300.0),
+        ("12.5", 12.5),
+    ],
+)
+def test_timeout_seconds_fails_closed_to_default(
+    monkeypatch: pytest.MonkeyPatch,
+    raw: str,
+    expected: float,
+) -> None:
+    monkeypatch.setenv("ARAGORA_TEST_TIMEOUT_SECONDS", raw)
+    assert qe._timeout_seconds("ARAGORA_TEST_TIMEOUT_SECONDS", 300) == expected
+
+
+def test_run_claude_cli_uses_env_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, object] = {}
+
+    def fake_run(*args, timeout, **kwargs):
+        seen["args"] = args
+        seen["timeout"] = timeout
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=timeout)
+
+    monkeypatch.setenv(qe._CLAUDE_TIMEOUT_ENV, "7")
+    monkeypatch.setattr(qe.subprocess, "run", fake_run)
+
+    result = qe._run_claude_cli("review prompt")
+
+    assert seen["args"] == (["claude", "-p"],)
+    assert seen["timeout"] == 7.0
+    assert result == ReviewerResult(
+        "claude",
+        "",
+        False,
+        "claude CLI timed out after 7s",
+    )
 
 
 # --- default API reviewer cleanup ------------------------------------------


### PR DESCRIPTION
## Summary
- make `review-queue collect-evidence` reviewer timeouts configurable through environment variables
- preserve the existing 300s default timeout for both Claude CLI and API-backed reviewers
- add focused coverage for fail-closed timeout parsing and Claude CLI timeout propagation

## Timeout knobs
- `ARAGORA_COLLECT_EVIDENCE_CLAUDE_TIMEOUT_SECONDS`
- `ARAGORA_COLLECT_EVIDENCE_REVIEWER_TIMEOUT_SECONDS`

Invalid, empty, zero, or negative values fall back to the existing default.

## Tests
- `PYTHONDONTWRITEBYTECODE=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/swarm/test_quorum_evidence.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check aragora/swarm/quorum_evidence.py tests/swarm/test_quorum_evidence.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check aragora/swarm/quorum_evidence.py tests/swarm/test_quorum_evidence.py`
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Notes
This is a bounded operator-loop safety improvement. It does not post evidence, merge PRs, alter branch protection, or change default reviewer behavior unless an operator explicitly sets the env vars.
