### PR TITLE
test(scripts): regression-guard publisher username-leak collapse (#7739 follow-up)

### DIFF
--- a/tests/scripts/test_publish_rescue_productization_report.py
+++ b/tests/scripts/test_publish_rescue_productization_report.py
@@ -156,3 +156,33 @@ def test_main_dry_run_does_not_publish_report_bundle(tmp_path: Path, capsys) -> 
     assert "generated_at" in payload
     assert payload["summary"]["repeated_class_count"] == 1
     assert not publish_dir.exists()
+
+
+def test_home_relative_path_collapses_home_rooted_path(monkeypatch, tmp_path):
+    # Regression guard for the #7706/#7739 username leak: a $HOME-rooted path
+    # written into the committed truth surface must serialize as ~-relative.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    raw = str(tmp_path / ".aragora" / "rescue_events.jsonl")
+    assert mod._home_relative_path(raw) == "~/.aragora/rescue_events.jsonl"
+
+
+def test_home_relative_path_leaves_non_home_path_untouched(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert mod._home_relative_path("/etc/ci/rescue_events.jsonl") == "/etc/ci/rescue_events.jsonl"
+
+
+def test_repo_stable_path_collapses_home_ledger_to_tilde(monkeypatch, tmp_path):
+    # _repo_stable_path resolves the path first, so use a resolved HOME to keep
+    # the assertion hermetic across platforms with symlinked temp dirs (macOS).
+    home = tmp_path.resolve()
+    monkeypatch.setenv("HOME", str(home))
+    ledger = home / ".aragora" / "rescue_events.jsonl"
+    result = mod._repo_stable_path(ledger)
+    assert result == "~/.aragora/rescue_events.jsonl"
+    assert not result.startswith("/")
+    assert home.name not in result
+
+
+def test_repo_stable_path_keeps_repo_relative_posix():
+    target = mod.REPO_ROOT / "docs" / "benchmarks" / "rescue_productization.json"
+    assert mod._repo_stable_path(target) == "docs/benchmarks/rescue_productization.json"


### PR DESCRIPTION
## Summary

Adds a regression test for the proof-rescue publisher username-leak guard. Found by dogfooding Aragora's own health probes from a clean `origin/main` worktree.

Commit `b37b1bbc47` (#7739) added `_home_relative_path()` / `_repo_stable_path()` to `scripts/publish_rescue_productization_report.py` so the publisher writes `~/.aragora/...` instead of an absolute `/Users/<name>/...` path into the **committed public truth surface** (which would re-introduce leak #7706 and trip `check_portability.py` + the truth-surface consistency test). That fix shipped **without a regression test**, so a future refactor dropping the `_home_relative_path` call would silently re-leak the local username during an unattended proof refresh.

This adds four hermetic tests:
- `_home_relative_path` collapses a `$HOME`-rooted path to `~`-relative.
- `_home_relative_path` leaves non-home / CI paths untouched.
- `_repo_stable_path` collapses a home-rooted ledger to `~/.aragora/...` (resolved-HOME to stay hermetic on symlinked temp dirs).
- `_repo_stable_path` keeps a repo-rooted path repo-relative (POSIX).

## Validation

- `pytest tests/scripts/test_publish_rescue_productization_report.py` → 7 passed (was 3; +4, count increased).
- `pre-commit run --files <file>` → all hooks pass (ruff/gitleaks/portability).

## Tier

Tier 0 (test-only, additive, reversible). Not in any frozen governance surface. Founder root untouched; all work in an isolated worktree at `origin/main`.
