### PR TITLE
Fix quorum rerun after evidence collection

### DIFF
--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -93,6 +93,7 @@ _MAX_DIFF_CHARS = 60_000
 _MAX_REVIEWER_CHARS = 32_000
 _CLAUDE_TIMEOUT = 300
 _REVIEWER_TIMEOUT = 300
+_REVIEWER_CLEANUP_TIMEOUT = 10
 
 
 def _cap_text(text: str) -> str:
@@ -395,7 +396,9 @@ async def _close_api_agent_resources(agent: Any) -> None:
         try:
             result = close()
             if inspect.isawaitable(result):
-                await result
+                await asyncio.wait_for(result, timeout=_REVIEWER_CLEANUP_TIMEOUT)
+        except TimeoutError:
+            logger.debug("collect-evidence API agent close timed out")
         except Exception as exc:  # noqa: BLE001 - cleanup must not mask reviewer results.
             logger.debug("collect-evidence API agent close failed: %s", exc)
 
@@ -410,7 +413,9 @@ async def _close_api_agent_resources(agent: Any) -> None:
         # loop, so the shared aiohttp connector must be released before that
         # loop is torn down. The collector dispatches reviewers serially; if it
         # ever fans reviewers out, cleanup must move outside the per-reviewer path.
-        await close_shared_connector()
+        await asyncio.wait_for(close_shared_connector(), timeout=_REVIEWER_CLEANUP_TIMEOUT)
+    except TimeoutError:
+        logger.debug("collect-evidence shared connector close timed out")
     except Exception as exc:  # noqa: BLE001 - cleanup must not mask reviewer results.
         logger.debug("collect-evidence shared connector close failed: %s", exc)
 

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -29,11 +29,11 @@ from __future__ import annotations
 import asyncio
 import inspect
 import logging
+import multiprocessing
 import os
+import queue
 import re
-import signal
 import subprocess
-import threading
 import time
 from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
@@ -368,47 +368,69 @@ def _run_claude_cli(prompt: str) -> ReviewerResult:
 
 
 def _run_api_agent(family: str, prompt: str) -> ReviewerResult:
+    ctx = multiprocessing.get_context(
+        "fork" if "fork" in multiprocessing.get_all_start_methods() else "spawn"
+    )
+    result_queue: multiprocessing.Queue = ctx.Queue(maxsize=1)
+    process = ctx.Process(
+        target=_api_agent_worker,
+        args=(family, prompt, result_queue),
+        daemon=True,
+    )
+    process.start()
+    process.join(_REVIEWER_TIMEOUT + _REVIEWER_CLEANUP_TIMEOUT)
+    if process.is_alive():
+        process.terminate()
+        process.join(5)
+        if process.is_alive():  # pragma: no cover - defensive hard kill.
+            process.kill()
+            process.join(5)
+        return ReviewerResult(
+            family, "", False, f"{family} reviewer timed out after {_REVIEWER_TIMEOUT}s"
+        )
+    try:
+        payload = result_queue.get_nowait()
+    except queue.Empty:
+        return ReviewerResult(
+            family,
+            "",
+            False,
+            f"{family} reviewer exited without returning a result",
+        )
+    if isinstance(payload, ReviewerResult):
+        return payload
+    if isinstance(payload, dict):
+        return ReviewerResult(
+            str(payload.get("family") or family),
+            str(payload.get("text") or ""),
+            bool(payload.get("ok")),
+            str(payload.get("error") or ""),
+        )
+    return ReviewerResult(family, "", False, f"{family} reviewer returned invalid result")
+
+
+def _api_agent_worker(
+    family: str,
+    prompt: str,
+    result_queue: multiprocessing.Queue,
+) -> None:
+    result_queue.put(_run_api_agent_in_current_process(family, prompt))
+
+
+def _run_api_agent_in_current_process(family: str, prompt: str) -> ReviewerResult:
     try:
         from aragora.agents import create_agent
     except Exception as exc:  # pragma: no cover - import guard
         return ReviewerResult(family, "", False, f"create_agent import failed: {exc}")
     try:
-        with _api_reviewer_wall_clock_timeout(family):
-            agent = create_agent(family, name=f"{family}_reviewer", role="critic")
-            text = asyncio.run(_generate_with_api_agent_cleanup(agent, prompt))
-    except TimeoutError:
-        return ReviewerResult(
-            family, "", False, f"{family} reviewer timed out after {_REVIEWER_TIMEOUT}s"
-        )
+        agent = create_agent(family, name=f"{family}_reviewer", role="critic")
+        text = asyncio.run(_generate_with_api_agent_cleanup(agent, prompt))
     except Exception as exc:
         return ReviewerResult(family, "", False, f"{type(exc).__name__}: {str(exc)[:200]}")
     text = (text or "").strip()
     if not text:
         return ReviewerResult(family, "", False, "empty reviewer output")
     return ReviewerResult(family, _cap_text(text), True)
-
-
-@contextmanager
-def _api_reviewer_wall_clock_timeout(family: str) -> Iterator[None]:
-    """Interrupt API reviewers that block the event loop despite ``wait_for``."""
-    if threading.current_thread() is not threading.main_thread() or not hasattr(
-        signal, "setitimer"
-    ):
-        yield
-        return
-
-    def _raise_timeout(signum: int, frame: Any) -> None:
-        raise TimeoutError(f"{family} reviewer timed out after {_REVIEWER_TIMEOUT}s")
-
-    previous_handler = signal.getsignal(signal.SIGALRM)
-    previous_timer = signal.getitimer(signal.ITIMER_REAL)
-    signal.signal(signal.SIGALRM, _raise_timeout)
-    signal.setitimer(signal.ITIMER_REAL, _REVIEWER_TIMEOUT)
-    try:
-        yield
-    finally:
-        signal.setitimer(signal.ITIMER_REAL, previous_timer[0], previous_timer[1])
-        signal.signal(signal.SIGALRM, previous_handler)
 
 
 async def _generate_with_api_agent_cleanup(agent: Any, prompt: str) -> str:

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -31,7 +31,9 @@ import inspect
 import logging
 import os
 import re
+import signal
 import subprocess
+import threading
 import time
 from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
@@ -371,14 +373,42 @@ def _run_api_agent(family: str, prompt: str) -> ReviewerResult:
     except Exception as exc:  # pragma: no cover - import guard
         return ReviewerResult(family, "", False, f"create_agent import failed: {exc}")
     try:
-        agent = create_agent(family, name=f"{family}_reviewer", role="critic")
-        text = asyncio.run(_generate_with_api_agent_cleanup(agent, prompt))
+        with _api_reviewer_wall_clock_timeout(family):
+            agent = create_agent(family, name=f"{family}_reviewer", role="critic")
+            text = asyncio.run(_generate_with_api_agent_cleanup(agent, prompt))
+    except TimeoutError:
+        return ReviewerResult(
+            family, "", False, f"{family} reviewer timed out after {_REVIEWER_TIMEOUT}s"
+        )
     except Exception as exc:
         return ReviewerResult(family, "", False, f"{type(exc).__name__}: {str(exc)[:200]}")
     text = (text or "").strip()
     if not text:
         return ReviewerResult(family, "", False, "empty reviewer output")
     return ReviewerResult(family, _cap_text(text), True)
+
+
+@contextmanager
+def _api_reviewer_wall_clock_timeout(family: str) -> Iterator[None]:
+    """Interrupt API reviewers that block the event loop despite ``wait_for``."""
+    if threading.current_thread() is not threading.main_thread() or not hasattr(
+        signal, "setitimer"
+    ):
+        yield
+        return
+
+    def _raise_timeout(signum: int, frame: Any) -> None:
+        raise TimeoutError(f"{family} reviewer timed out after {_REVIEWER_TIMEOUT}s")
+
+    previous_handler = signal.getsignal(signal.SIGALRM)
+    previous_timer = signal.getitimer(signal.ITIMER_REAL)
+    signal.signal(signal.SIGALRM, _raise_timeout)
+    signal.setitimer(signal.ITIMER_REAL, _REVIEWER_TIMEOUT)
+    try:
+        yield
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, previous_timer[0], previous_timer[1])
+        signal.signal(signal.SIGALRM, previous_handler)
 
 
 async def _generate_with_api_agent_cleanup(agent: Any, prompt: str) -> str:

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -31,9 +31,11 @@ import inspect
 import logging
 import re
 import subprocess
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterator, Sequence
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
 from aragora.swarm import merge_quorum_io
@@ -78,6 +80,9 @@ DEFAULT_FAMILIES: tuple[str, ...] = ("claude", "grok")
 
 # Tiers at or above this require exact-head operator settlement; never auto-post.
 SETTLEMENT_TIER_FLOOR = 3
+
+QUORUM_RERUN_COOLDOWN_SECONDS = 10 * 60
+QUORUM_RERUN_MAX_PER_HEAD = 3
 # Cap the diff fed to reviewers so a huge PR cannot blow the model context.
 _MAX_DIFF_CHARS = 60_000
 # Cap reviewer output so a runaway model cannot exceed GitHub's per-comment limit.
@@ -464,41 +469,55 @@ def resolve_author(default: str = "local") -> str:
     return login or default
 
 
+@contextmanager
+def _locked_quorum_reconcile_state(path: Path) -> Iterator[None]:
+    """Serialize load/evaluate/rerun/save for the shared merge-quorum state file."""
+    import fcntl
+
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+", encoding="utf-8") as lock_fh:
+        fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
+
+
 def default_quorum_reconciler(repo: str, pr: int) -> dict[str, Any]:
     """Run the A1 stale-quorum reconciler for one PR after evidence posting."""
     from scripts import reconcile_merge_quorum
 
-    state = reconcile_merge_quorum._load_state(reconcile_merge_quorum.DEFAULT_STATE_FILE)
-    decision, quorum_run = reconcile_merge_quorum.evaluate_pr(
-        repo,
-        pr,
-        now=datetime.now(timezone.utc),
-        state=state,
-        cooldown_seconds=10 * 60,
-        max_reruns=3,
-    )
-    record: dict[str, Any] = {
-        "should_rerun": decision.should_rerun,
-        "reason": decision.reason,
-        "run_id": decision.run_id,
-        "applied": False,
-    }
-    if decision.next_prompt:
-        record["next_prompt"] = decision.next_prompt
-    if decision.should_rerun and quorum_run is not None:
-        record["applied"] = reconcile_merge_quorum.execute_rerun(repo, quorum_run.run_id)
-        if record["applied"]:
-            head_state = state.setdefault(
-                quorum_run.head_sha,
-                {"count": 0, "last_rerun_at": None},
-            )
-            head_state["count"] = int(head_state.get("count", 0)) + 1
-            head_state["last_rerun_at"] = datetime.now(timezone.utc).isoformat()
-            reconcile_merge_quorum._save_state(
-                reconcile_merge_quorum.DEFAULT_STATE_FILE,
-                state,
-            )
-    return record
+    state_file = reconcile_merge_quorum.DEFAULT_STATE_FILE
+    with _locked_quorum_reconcile_state(state_file):
+        state = reconcile_merge_quorum._load_state(state_file)
+        decision, quorum_run = reconcile_merge_quorum.evaluate_pr(
+            repo,
+            pr,
+            now=datetime.now(timezone.utc),
+            state=state,
+            cooldown_seconds=QUORUM_RERUN_COOLDOWN_SECONDS,
+            max_reruns=QUORUM_RERUN_MAX_PER_HEAD,
+        )
+        record: dict[str, Any] = {
+            "should_rerun": decision.should_rerun,
+            "reason": decision.reason,
+            "run_id": decision.run_id,
+            "applied": False,
+        }
+        if decision.next_prompt:
+            record["next_prompt"] = decision.next_prompt
+        if decision.should_rerun and quorum_run is not None:
+            record["applied"] = reconcile_merge_quorum.execute_rerun(repo, quorum_run.run_id)
+            if record["applied"]:
+                head_state = state.setdefault(
+                    quorum_run.head_sha,
+                    {"count": 0, "last_rerun_at": None},
+                )
+                head_state["count"] = int(head_state.get("count", 0)) + 1
+                head_state["last_rerun_at"] = datetime.now(timezone.utc).isoformat()
+                reconcile_merge_quorum._save_state(state_file, state)
+        return record
 
 
 # --- Orchestrator ----------------------------------------------------------

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -121,6 +121,15 @@ class EvidenceItem:
     would_count: bool
     counted_reviewer_ids: list[str] = field(default_factory=list)
     problems: list[str] = field(default_factory=list)
+    verdict: str = "unknown"
+
+    @property
+    def supportive(self) -> bool:
+        return self.would_count and self.verdict == "pass"
+
+    @property
+    def dissenting(self) -> bool:
+        return self.verdict == "changes_requested"
 
 
 @dataclass
@@ -142,6 +151,18 @@ class CollectOutcome:
     def counting_families(self) -> list[str]:
         return [item.family for item in self.items if item.would_count]
 
+    @property
+    def supportive_families(self) -> list[str]:
+        return [item.family for item in self.items if item.supportive]
+
+    @property
+    def dissenting_families(self) -> list[str]:
+        return [item.family for item in self.items if item.dissenting]
+
+    @property
+    def has_supportive_quorum(self) -> bool:
+        return len(self.supportive_families) >= 2
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "mode": "collect_evidence",
@@ -153,6 +174,9 @@ class CollectOutcome:
             "action": self.action,
             "action_reason": self.action_reason,
             "counting_families": self.counting_families,
+            "supportive_families": self.supportive_families,
+            "dissenting_families": self.dissenting_families,
+            "has_supportive_quorum": self.has_supportive_quorum,
             "posted_families": list(self.posted),
             "post_errors": list(self.post_errors),
             "quorum_rerun": self.quorum_rerun,
@@ -160,6 +184,7 @@ class CollectOutcome:
                 {
                     "family": item.family,
                     "would_count": item.would_count,
+                    "verdict": item.verdict,
                     "counted_reviewer_ids": item.counted_reviewer_ids,
                     "problems": item.problems,
                     "body": item.body,
@@ -223,6 +248,22 @@ def _neutralize_reviewer_text(text: str) -> str:
         else:
             out.append(line)
     return "\n".join(out)
+
+
+def _reviewer_verdict(text: str) -> str:
+    """Parse the first reviewer verdict line without inventing support."""
+    for line in text.splitlines():
+        stripped = line.strip().lower()
+        if not stripped:
+            continue
+        if stripped.startswith("verdict:"):
+            verdict = stripped.split(":", 1)[1].strip()
+            if verdict.startswith("pass"):
+                return "pass"
+            if verdict.startswith("changes-requested") or verdict.startswith("changes requested"):
+                return "changes_requested"
+            return "unknown"
+    return "unknown"
 
 
 def compose_evidence_comment(
@@ -613,12 +654,20 @@ def collect_evidence(
                 family=family,
                 body=body,
                 would_count=bool(lint.get("would_count")),
+                verdict=_reviewer_verdict(result.text),
                 counted_reviewer_ids=list(lint.get("counted_reviewer_ids") or []),
                 problems=list(lint.get("problems") or []),
             )
         )
 
     if action == "post":
+        if outcome.dissenting_families:
+            outcome.action = "prepare"
+            outcome.action_reason = (
+                "reviewer dissent present "
+                f"({', '.join(outcome.dissenting_families)}); prepared evidence only"
+            )
+            return outcome
         # Reviewers can take minutes; re-verify the head and tier immediately
         # before posting so a head that moved or a PR promoted to a settlement
         # tier in the meantime is never posted against.
@@ -641,7 +690,7 @@ def collect_evidence(
             )
         else:
             for item in outcome.items:
-                if not item.would_count:
+                if not item.supportive:
                     continue
                 try:
                     poster(repo, pr, item.body)
@@ -650,7 +699,7 @@ def collect_evidence(
                     outcome.post_errors.append(f"{item.family}: {str(exc)[:200]}")
                     continue
                 outcome.posted.append(item.family)
-        if outcome.posted and quorum_reconciler is not None:
+        if outcome.posted and outcome.has_supportive_quorum and quorum_reconciler is not None:
             try:
                 outcome.quorum_rerun = quorum_reconciler(repo, pr)
             except Exception as exc:  # noqa: BLE001 - evidence posts should remain reported.
@@ -665,6 +714,8 @@ def _render_outcome(outcome: CollectOutcome) -> str:
         f"  head: {outcome.head_sha[:10]}  tier: {outcome.tier}",
         f"  action: {outcome.action} ({outcome.action_reason})",
         f"  counting families: {', '.join(outcome.counting_families) or 'none'}",
+        f"  supportive families: {', '.join(outcome.supportive_families) or 'none'}",
+        f"  dissenting families: {', '.join(outcome.dissenting_families) or 'none'}",
     ]
     if outcome.posted:
         lines.append(f"  posted: {', '.join(outcome.posted)}")
@@ -677,7 +728,7 @@ def _render_outcome(outcome: CollectOutcome) -> str:
         lines.append(f"  quorum rerun: {action} ({reason})")
     for item in outcome.items:
         flag = "counts" if item.would_count else f"DOES NOT count ({', '.join(item.problems)})"
-        lines.append(f"  - {item.family}: {flag}")
+        lines.append(f"  - {item.family}: {flag}; verdict={item.verdict}")
     for failure in outcome.failures:
         lines.append(f"  - {failure.family}: reviewer failed ({failure.error})")
     if outcome.action == "prepare":
@@ -735,4 +786,4 @@ def run_collect_cli(
         printer(json.dumps(outcome.to_dict(), indent=2))
     else:
         printer(_render_outcome(outcome))
-    return 0 if len(outcome.counting_families) >= 2 else 1
+    return 0 if outcome.has_supportive_quorum else 1

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -29,8 +29,10 @@ from __future__ import annotations
 import asyncio
 import inspect
 import logging
+import os
 import re
 import subprocess
+import time
 from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -83,6 +85,8 @@ SETTLEMENT_TIER_FLOOR = 3
 
 QUORUM_RERUN_COOLDOWN_SECONDS = 10 * 60
 QUORUM_RERUN_MAX_PER_HEAD = 3
+QUORUM_STATE_LOCK_TIMEOUT_SECONDS = 60.0
+QUORUM_STATE_LOCK_POLL_SECONDS = 0.2
 # Cap the diff fed to reviewers so a huge PR cannot blow the model context.
 _MAX_DIFF_CHARS = 60_000
 # Cap reviewer output so a runaway model cannot exceed GitHub's per-comment limit.
@@ -472,16 +476,29 @@ def resolve_author(default: str = "local") -> str:
 @contextmanager
 def _locked_quorum_reconcile_state(path: Path) -> Iterator[None]:
     """Serialize load/evaluate/rerun/save for the shared merge-quorum state file."""
-    import fcntl
-
-    lock_path = path.with_suffix(path.suffix + ".lock")
+    lock_path = Path(f"{path}.lock")
     lock_path.parent.mkdir(parents=True, exist_ok=True)
-    with lock_path.open("a+", encoding="utf-8") as lock_fh:
-        fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
+    deadline = time.monotonic() + QUORUM_STATE_LOCK_TIMEOUT_SECONDS
+    fd: int | None = None
+    while fd is None:
         try:
-            yield
-        finally:
-            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
+            fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            os.write(
+                fd,
+                f"pid={os.getpid()} acquired_at={datetime.now(timezone.utc).isoformat()}\n".encode(),
+            )
+        except FileExistsError:
+            if time.monotonic() >= deadline:
+                raise RuntimeError(f"timed out waiting for merge-quorum state lock: {lock_path}")
+            time.sleep(QUORUM_STATE_LOCK_POLL_SECONDS)
+    try:
+        yield
+    finally:
+        os.close(fd)
+        try:
+            lock_path.unlink()
+        except OSError:
+            pass
 
 
 def default_quorum_reconciler(repo: str, pr: int) -> dict[str, Any]:
@@ -508,12 +525,16 @@ def default_quorum_reconciler(repo: str, pr: int) -> dict[str, Any]:
         if decision.next_prompt:
             record["next_prompt"] = decision.next_prompt
         if decision.should_rerun and quorum_run is not None:
+            head_state = state.setdefault(
+                quorum_run.head_sha,
+                {"count": 0, "last_rerun_at": None},
+            )
+            if int(head_state.get("count", 0)) >= QUORUM_RERUN_MAX_PER_HEAD:
+                record["should_rerun"] = False
+                record["reason"] = "max_reruns_reached_in_locked_state"
+                return record
             record["applied"] = reconcile_merge_quorum.execute_rerun(repo, quorum_run.run_id)
             if record["applied"]:
-                head_state = state.setdefault(
-                    quorum_run.head_sha,
-                    {"count": 0, "last_rerun_at": None},
-                )
                 head_state["count"] = int(head_state.get("count", 0)) + 1
                 head_state["last_rerun_at"] = datetime.now(timezone.utc).isoformat()
                 reconcile_merge_quorum._save_state(state_file, state)

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -368,7 +368,7 @@ def _run_claude_cli(prompt: str) -> ReviewerResult:
 
 
 def _run_api_agent(family: str, prompt: str) -> ReviewerResult:
-    ctx = multiprocessing.get_context(
+    ctx: Any = multiprocessing.get_context(
         "fork" if "fork" in multiprocessing.get_all_start_methods() else "spawn"
     )
     result_queue: multiprocessing.Queue = ctx.Queue(maxsize=1)

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -33,6 +33,7 @@ import re
 import subprocess
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from typing import Any
 
 from aragora.swarm import merge_quorum_io
@@ -126,6 +127,7 @@ class CollectOutcome:
     failures: list[ReviewerResult] = field(default_factory=list)
     posted: list[str] = field(default_factory=list)
     post_errors: list[str] = field(default_factory=list)
+    quorum_rerun: dict[str, Any] | None = None
 
     @property
     def counting_families(self) -> list[str]:
@@ -144,6 +146,7 @@ class CollectOutcome:
             "counting_families": self.counting_families,
             "posted_families": list(self.posted),
             "post_errors": list(self.post_errors),
+            "quorum_rerun": self.quorum_rerun,
             "items": [
                 {
                     "family": item.family,
@@ -461,6 +464,43 @@ def resolve_author(default: str = "local") -> str:
     return login or default
 
 
+def default_quorum_reconciler(repo: str, pr: int) -> dict[str, Any]:
+    """Run the A1 stale-quorum reconciler for one PR after evidence posting."""
+    from scripts import reconcile_merge_quorum
+
+    state = reconcile_merge_quorum._load_state(reconcile_merge_quorum.DEFAULT_STATE_FILE)
+    decision, quorum_run = reconcile_merge_quorum.evaluate_pr(
+        repo,
+        pr,
+        now=datetime.now(timezone.utc),
+        state=state,
+        cooldown_seconds=10 * 60,
+        max_reruns=3,
+    )
+    record: dict[str, Any] = {
+        "should_rerun": decision.should_rerun,
+        "reason": decision.reason,
+        "run_id": decision.run_id,
+        "applied": False,
+    }
+    if decision.next_prompt:
+        record["next_prompt"] = decision.next_prompt
+    if decision.should_rerun and quorum_run is not None:
+        record["applied"] = reconcile_merge_quorum.execute_rerun(repo, quorum_run.run_id)
+        if record["applied"]:
+            head_state = state.setdefault(
+                quorum_run.head_sha,
+                {"count": 0, "last_rerun_at": None},
+            )
+            head_state["count"] = int(head_state.get("count", 0)) + 1
+            head_state["last_rerun_at"] = datetime.now(timezone.utc).isoformat()
+            reconcile_merge_quorum._save_state(
+                reconcile_merge_quorum.DEFAULT_STATE_FILE,
+                state,
+            )
+    return record
+
+
 # --- Orchestrator ----------------------------------------------------------
 
 
@@ -477,6 +517,7 @@ def collect_evidence(
     reviewer_runner: Callable[[str, str], ReviewerResult] = default_reviewer_runner,
     linter: Callable[..., dict[str, Any]] = default_linter,
     poster: Callable[[str, int, str], None] = default_poster,
+    quorum_reconciler: Callable[[str, int], dict[str, Any] | None] | None = None,
     env: dict[str, str] | None = None,
 ) -> CollectOutcome:
     """Run reviewers, validate evidence, and post only when tier-gating allows."""
@@ -569,6 +610,11 @@ def collect_evidence(
                     outcome.post_errors.append(f"{item.family}: {str(exc)[:200]}")
                     continue
                 outcome.posted.append(item.family)
+        if outcome.posted and quorum_reconciler is not None:
+            try:
+                outcome.quorum_rerun = quorum_reconciler(repo, pr)
+            except Exception as exc:  # noqa: BLE001 - evidence posts should remain reported.
+                outcome.quorum_rerun = {"applied": False, "error": str(exc)[:200]}
 
     return outcome
 
@@ -584,6 +630,11 @@ def _render_outcome(outcome: CollectOutcome) -> str:
         lines.append(f"  posted: {', '.join(outcome.posted)}")
     if outcome.post_errors:
         lines.append(f"  post errors: {'; '.join(outcome.post_errors)}")
+    if outcome.quorum_rerun:
+        rerun = outcome.quorum_rerun
+        action = "applied" if rerun.get("applied") else "not applied"
+        reason = rerun.get("reason") or rerun.get("error") or "unknown"
+        lines.append(f"  quorum rerun: {action} ({reason})")
     for item in outcome.items:
         flag = "counts" if item.would_count else f"DOES NOT count ({', '.join(item.problems)})"
         lines.append(f"  - {item.family}: {flag}")
@@ -627,6 +678,7 @@ def run_collect_cli(
             author=resolved_author,
             apply=apply,
             env=merge_quorum_io.aragora_env(),
+            quorum_reconciler=default_quorum_reconciler if apply else None,
         )
     except (ValueError, RuntimeError, OSError, subprocess.SubprocessError) as exc:
         if json_output:

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -89,6 +89,8 @@ QUORUM_RERUN_COOLDOWN_SECONDS = 10 * 60
 QUORUM_RERUN_MAX_PER_HEAD = 3
 QUORUM_STATE_LOCK_TIMEOUT_SECONDS = 60.0
 QUORUM_STATE_LOCK_POLL_SECONDS = 0.2
+QUORUM_STATE_LOCK_STALE_SECONDS = 15 * 60
+_REVIEWER_RESULT_QUEUE_TIMEOUT = 1.0
 # Cap the diff fed to reviewers so a huge PR cannot blow the model context.
 _MAX_DIFF_CHARS = 60_000
 # Cap reviewer output so a runaway model cannot exceed GitHub's per-comment limit.
@@ -368,15 +370,9 @@ def _run_claude_cli(prompt: str) -> ReviewerResult:
 
 
 def _run_api_agent(family: str, prompt: str) -> ReviewerResult:
-    ctx: Any = multiprocessing.get_context(
-        "fork" if "fork" in multiprocessing.get_all_start_methods() else "spawn"
-    )
+    ctx = _api_agent_process_context()
     result_queue: multiprocessing.Queue = ctx.Queue(maxsize=1)
-    process = ctx.Process(
-        target=_api_agent_worker,
-        args=(family, prompt, result_queue),
-        daemon=True,
-    )
+    process = _start_api_agent_worker_process(ctx, family, prompt, result_queue)
     process.start()
     process.join(_REVIEWER_TIMEOUT + _REVIEWER_CLEANUP_TIMEOUT)
     if process.is_alive():
@@ -389,7 +385,7 @@ def _run_api_agent(family: str, prompt: str) -> ReviewerResult:
             family, "", False, f"{family} reviewer timed out after {_REVIEWER_TIMEOUT}s"
         )
     try:
-        payload = result_queue.get_nowait()
+        payload = result_queue.get(timeout=_REVIEWER_RESULT_QUEUE_TIMEOUT)
     except queue.Empty:
         return ReviewerResult(
             family,
@@ -407,6 +403,24 @@ def _run_api_agent(family: str, prompt: str) -> ReviewerResult:
             str(payload.get("error") or ""),
         )
     return ReviewerResult(family, "", False, f"{family} reviewer returned invalid result")
+
+
+def _api_agent_process_context() -> Any:
+    """Use spawn so API reviewer children do not inherit parent connector state."""
+    return multiprocessing.get_context("spawn")
+
+
+def _start_api_agent_worker_process(
+    ctx: Any,
+    family: str,
+    prompt: str,
+    result_queue: multiprocessing.Queue,
+) -> multiprocessing.Process:
+    return ctx.Process(
+        target=_api_agent_worker,
+        args=(family, prompt, result_queue),
+        daemon=True,
+    )
 
 
 def _api_agent_worker(
@@ -580,12 +594,21 @@ def _locked_quorum_reconcile_state(path: Path) -> Iterator[None]:
     fd: int | None = None
     while fd is None:
         try:
-            fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
+            flags |= getattr(os, "O_CLOEXEC", 0)
+            flags |= getattr(os, "O_NOFOLLOW", 0)
+            fd = os.open(lock_path, flags)
             os.write(
                 fd,
                 f"pid={os.getpid()} acquired_at={datetime.now(timezone.utc).isoformat()}\n".encode(),
             )
         except FileExistsError:
+            if _quorum_state_lock_is_stale(lock_path):
+                try:
+                    lock_path.unlink()
+                except FileNotFoundError:
+                    pass
+                continue
             if time.monotonic() >= deadline:
                 raise RuntimeError(f"timed out waiting for merge-quorum state lock: {lock_path}")
             time.sleep(QUORUM_STATE_LOCK_POLL_SECONDS)
@@ -597,6 +620,35 @@ def _locked_quorum_reconcile_state(path: Path) -> Iterator[None]:
             lock_path.unlink()
         except OSError:
             pass
+
+
+def _quorum_state_lock_is_stale(lock_path: Path) -> bool:
+    try:
+        stat = lock_path.lstat()
+    except OSError:
+        return False
+    if lock_path.is_symlink():
+        raise RuntimeError(f"refusing symlink merge-quorum state lock: {lock_path}")
+    age_seconds = max(0.0, time.time() - stat.st_mtime)
+    if age_seconds < QUORUM_STATE_LOCK_STALE_SECONDS:
+        return False
+    try:
+        text = lock_path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    match = re.search(r"\bpid=(\d+)\b", text)
+    if not match:
+        return True
+    pid = int(match.group(1))
+    if pid <= 0 or pid == os.getpid():
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return True
+    except PermissionError:
+        return False
+    return False
 
 
 def default_quorum_reconciler(repo: str, pr: int) -> dict[str, Any]:
@@ -723,6 +775,13 @@ def collect_evidence(
             outcome.action_reason = (
                 "reviewer dissent present "
                 f"({', '.join(outcome.dissenting_families)}); prepared evidence only"
+            )
+            return outcome
+        if not outcome.has_supportive_quorum:
+            outcome.action = "prepare"
+            outcome.action_reason = (
+                "supportive quorum incomplete "
+                f"({len(outcome.supportive_families)}/2); prepared evidence only"
             )
             return outcome
         # Reviewers can take minutes; re-verify the head and tier immediately

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -11,6 +11,9 @@ The compose helper is checked against the *real* evidence parser
 
 from __future__ import annotations
 
+from contextlib import contextmanager
+from types import SimpleNamespace
+
 import pytest
 
 from aragora.swarm import quorum_evidence as qe
@@ -496,6 +499,111 @@ def test_collect_low_tier_apply_triggers_same_pr_quorum_reconciler_after_posts()
 
     assert calls == [("o/r", 1, 2)]
     assert outcome.quorum_rerun == {"should_rerun": True, "run_id": 123, "applied": True}
+
+
+def test_collect_records_quorum_reconciler_error_after_successful_posts() -> None:
+    fakes, posted = _fakes(tier=1)
+
+    def quorum_reconciler(repo: str, pr: int) -> dict:
+        raise RuntimeError("rerun surface unavailable")
+
+    outcome = collect_evidence(
+        repo="o/r",
+        pr=1,
+        families=["claude", "grok"],
+        author="me",
+        apply=True,
+        quorum_reconciler=quorum_reconciler,
+        **fakes,
+    )
+
+    assert len(posted) == 2
+    assert sorted(outcome.posted) == ["claude", "grok"]
+    assert outcome.quorum_rerun == {"applied": False, "error": "rerun surface unavailable"}
+
+
+def test_collect_does_not_reconcile_when_no_evidence_was_posted() -> None:
+    fakes, posted = _fakes(tier=1, would_count=False)
+    calls: list[tuple[str, int]] = []
+
+    def quorum_reconciler(repo: str, pr: int) -> dict:
+        calls.append((repo, pr))
+        return {"applied": True}
+
+    outcome = collect_evidence(
+        repo="o/r",
+        pr=1,
+        families=["claude", "grok"],
+        author="me",
+        apply=True,
+        quorum_reconciler=quorum_reconciler,
+        **fakes,
+    )
+
+    assert posted == []
+    assert calls == []
+    assert outcome.quorum_rerun is None
+
+
+def test_default_quorum_reconciler_holds_lock_through_state_update(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    from scripts import reconcile_merge_quorum
+
+    events: list[str] = []
+    state: dict = {}
+
+    @contextmanager
+    def fake_lock(path):
+        events.append("lock-enter")
+        yield
+        events.append("lock-exit")
+
+    def load_state(path):
+        events.append("load")
+        return state
+
+    def evaluate_pr(repo, pr, *, now, state, cooldown_seconds, max_reruns):
+        events.append("evaluate")
+        assert repo == "o/r"
+        assert pr == 1
+        assert cooldown_seconds == qe.QUORUM_RERUN_COOLDOWN_SECONDS
+        assert max_reruns == qe.QUORUM_RERUN_MAX_PER_HEAD
+        decision = SimpleNamespace(
+            should_rerun=True,
+            reason="stale-success-after-new-evidence",
+            run_id=123,
+            next_prompt=None,
+        )
+        quorum_run = SimpleNamespace(run_id=123, head_sha="abc123")
+        return decision, quorum_run
+
+    def execute_rerun(repo, run_id):
+        events.append("execute")
+        assert (repo, run_id) == ("o/r", 123)
+        return True
+
+    def save_state(path, next_state):
+        events.append("save")
+        assert next_state["abc123"]["count"] == 1
+
+    monkeypatch.setattr(qe, "_locked_quorum_reconcile_state", fake_lock)
+    monkeypatch.setattr(reconcile_merge_quorum, "DEFAULT_STATE_FILE", tmp_path / "state.json")
+    monkeypatch.setattr(reconcile_merge_quorum, "_load_state", load_state)
+    monkeypatch.setattr(reconcile_merge_quorum, "evaluate_pr", evaluate_pr)
+    monkeypatch.setattr(reconcile_merge_quorum, "execute_rerun", execute_rerun)
+    monkeypatch.setattr(reconcile_merge_quorum, "_save_state", save_state)
+
+    record = qe.default_quorum_reconciler("o/r", 1)
+
+    assert record == {
+        "should_rerun": True,
+        "reason": "stale-success-after-new-evidence",
+        "run_id": 123,
+        "applied": True,
+    }
+    assert events == ["lock-enter", "load", "evaluate", "execute", "save", "lock-exit"]
 
 
 def test_collect_high_tier_apply_never_posts() -> None:

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -476,6 +476,28 @@ def test_collect_low_tier_apply_posts_both() -> None:
     assert len(posted) == 2
 
 
+def test_collect_low_tier_apply_triggers_same_pr_quorum_reconciler_after_posts() -> None:
+    fakes, posted = _fakes(tier=1)
+    calls: list[tuple[str, int, int]] = []
+
+    def quorum_reconciler(repo: str, pr: int) -> dict:
+        calls.append((repo, pr, len(posted)))
+        return {"should_rerun": True, "run_id": 123, "applied": True}
+
+    outcome = collect_evidence(
+        repo="o/r",
+        pr=1,
+        families=["claude", "grok"],
+        author="me",
+        apply=True,
+        quorum_reconciler=quorum_reconciler,
+        **fakes,
+    )
+
+    assert calls == [("o/r", 1, 2)]
+    assert outcome.quorum_rerun == {"should_rerun": True, "run_id": 123, "applied": True}
+
+
 def test_collect_high_tier_apply_never_posts() -> None:
     fakes, posted = _fakes(tier=4)
     outcome = collect_evidence(

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -12,6 +12,7 @@ The compose helper is checked against the *real* evidence parser
 from __future__ import annotations
 
 import asyncio
+import os
 import time
 from contextlib import contextmanager
 from types import SimpleNamespace
@@ -274,17 +275,46 @@ def test_run_api_agent_timeout_terminates_blocked_worker(
 ) -> None:
     monkeypatch.setattr(qe, "_REVIEWER_TIMEOUT", 0.05)
     monkeypatch.setattr(qe, "_REVIEWER_CLEANUP_TIMEOUT", 0.01)
+    events: list[str] = []
 
-    def blocked_worker(family: str, prompt: str) -> ReviewerResult:
-        time.sleep(1)
-        return ReviewerResult(family, "Verdict: PASS", True)
+    class FakeQueue:
+        def get(self, timeout: float):
+            raise AssertionError("timed-out worker result must not be read")
 
-    monkeypatch.setattr(qe, "_run_api_agent_in_current_process", blocked_worker, raising=False)
+    class FakeContext:
+        def Queue(self, maxsize: int) -> FakeQueue:
+            assert maxsize == 1
+            return FakeQueue()
+
+    class FakeProcess:
+        def start(self) -> None:
+            events.append("start")
+
+        def join(self, timeout: float) -> None:
+            events.append(f"join:{timeout:.2f}")
+
+        def is_alive(self) -> bool:
+            return True
+
+        def terminate(self) -> None:
+            events.append("terminate")
+
+        def kill(self) -> None:
+            events.append("kill")
+
+    monkeypatch.setattr(qe, "_api_agent_process_context", lambda: FakeContext(), raising=False)
+    monkeypatch.setattr(
+        qe,
+        "_start_api_agent_worker_process",
+        lambda ctx, family, prompt, result_queue: FakeProcess(),
+        raising=False,
+    )
 
     result = qe._run_api_agent("grok", "review prompt")
 
     assert result.ok is False
     assert "timed out" in result.error
+    assert events == ["start", "join:0.06", "terminate", "join:5.00", "kill", "join:5.00"]
 
 
 def test_api_agent_cleanup_does_not_hang_on_stuck_agent_close(
@@ -599,6 +629,38 @@ def test_collect_low_tier_apply_prepares_only_when_reviewer_dissents() -> None:
     assert outcome.quorum_rerun is None
 
 
+def test_collect_low_tier_apply_prepares_when_supportive_quorum_incomplete() -> None:
+    fakes, posted = _fakes(tier=1)
+    calls: list[tuple[str, int]] = []
+
+    def reviewer_runner(family: str, prompt: str) -> ReviewerResult:
+        if family == "grok":
+            return ReviewerResult("grok", "Verdict: inconclusive\n- unsure", True)
+        return ReviewerResult("claude", "Verdict: PASS\n- no blockers", True)
+
+    def quorum_reconciler(repo: str, pr: int) -> dict:
+        calls.append((repo, pr))
+        return {"applied": True}
+
+    fakes["reviewer_runner"] = reviewer_runner
+    outcome = collect_evidence(
+        repo="o/r",
+        pr=1,
+        families=["claude", "grok"],
+        author="me",
+        apply=True,
+        quorum_reconciler=quorum_reconciler,
+        **fakes,
+    )
+
+    assert outcome.action == "prepare"
+    assert "supportive quorum incomplete" in outcome.action_reason
+    assert outcome.supportive_families == ["claude"]
+    assert posted == []
+    assert calls == []
+    assert outcome.quorum_rerun is None
+
+
 def test_collect_success_requires_two_supportive_reviewers() -> None:
     fakes, _posted = _fakes(tier=1)
 
@@ -621,6 +683,24 @@ def test_collect_success_requires_two_supportive_reviewers() -> None:
     assert outcome.supportive_families == ["claude"]
     assert outcome.dissenting_families == ["grok"]
     assert outcome.has_supportive_quorum is False
+
+
+def test_locked_quorum_state_recovers_stale_pid_lock(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    state_file = tmp_path / "state.json"
+    lock_file = tmp_path / "state.json.lock"
+    lock_file.write_text("pid=999999 acquired_at=2026-06-06T00:00:00+00:00\n", encoding="utf-8")
+    old = time.time() - 3600
+    os.utime(lock_file, (old, old))
+    monkeypatch.setattr(qe, "QUORUM_STATE_LOCK_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(qe, "QUORUM_STATE_LOCK_POLL_SECONDS", 0.01)
+
+    with qe._locked_quorum_reconcile_state(state_file):
+        assert lock_file.exists()
+
+    assert not lock_file.exists()
 
 
 def test_collect_records_quorum_reconciler_error_after_successful_posts() -> None:
@@ -809,8 +889,10 @@ def test_collect_never_fabricates_on_reviewer_failure() -> None:
         repo="o/r", pr=1, families=["claude", "grok"], author="me", apply=True, **fakes
     )
     assert [f.family for f in outcome.failures] == ["grok"]
-    assert outcome.posted == ["claude"]
-    assert len(posted) == 1
+    assert outcome.action == "prepare"
+    assert "supportive quorum incomplete" in outcome.action_reason
+    assert outcome.posted == []
+    assert posted == []
 
 
 def test_collect_does_not_post_uncountable_evidence() -> None:
@@ -818,7 +900,8 @@ def test_collect_does_not_post_uncountable_evidence() -> None:
     outcome = collect_evidence(
         repo="o/r", pr=1, families=["claude", "grok"], author="me", apply=True, **fakes
     )
-    assert outcome.action == "post"
+    assert outcome.action == "prepare"
+    assert "supportive quorum incomplete" in outcome.action_reason
     assert outcome.posted == []
     assert posted == []
     assert all(not item.would_count for item in outcome.items)
@@ -830,7 +913,10 @@ def test_collect_rejects_unsupported_family() -> None:
         repo="o/r", pr=1, families=["claude", "bogus"], author="me", apply=True, **fakes
     )
     assert "bogus" in [f.family for f in outcome.failures]
-    assert "claude" in outcome.posted
+    assert outcome.action == "prepare"
+    assert "supportive quorum incomplete" in outcome.action_reason
+    assert outcome.posted == []
+    assert posted == []
     assert "bogus" not in outcome.counting_families
 
 

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -11,6 +11,7 @@ The compose helper is checked against the *real* evidence parser
 
 from __future__ import annotations
 
+import asyncio
 from contextlib import contextmanager
 from types import SimpleNamespace
 
@@ -265,6 +266,52 @@ def test_run_api_agent_closes_resources_after_generate_failure(
     assert result.ok is False
     assert "RuntimeError: model failed" in result.error
     assert events == ["generate", "agent_close", "connector_close"]
+
+
+def test_api_agent_cleanup_does_not_hang_on_stuck_agent_close(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+
+    class FakeAgent:
+        async def close(self) -> None:
+            events.append("agent_close_start")
+            await asyncio.sleep(3600)
+
+    async def fake_close_shared_connector() -> None:
+        events.append("connector_close")
+
+    from aragora.agents.api_agents import common
+
+    monkeypatch.setattr(qe, "_REVIEWER_CLEANUP_TIMEOUT", 0.01, raising=False)
+    monkeypatch.setattr(common, "close_shared_connector", fake_close_shared_connector)
+
+    asyncio.run(asyncio.wait_for(qe._close_api_agent_resources(FakeAgent()), timeout=0.05))
+
+    assert events == ["agent_close_start", "connector_close"]
+
+
+def test_api_agent_cleanup_does_not_hang_on_stuck_shared_connector(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+
+    class FakeAgent:
+        async def close(self) -> None:
+            events.append("agent_close")
+
+    async def fake_close_shared_connector() -> None:
+        events.append("connector_close_start")
+        await asyncio.sleep(3600)
+
+    from aragora.agents.api_agents import common
+
+    monkeypatch.setattr(qe, "_REVIEWER_CLEANUP_TIMEOUT", 0.01, raising=False)
+    monkeypatch.setattr(common, "close_shared_connector", fake_close_shared_connector)
+
+    asyncio.run(asyncio.wait_for(qe._close_api_agent_resources(FakeAgent()), timeout=0.05))
+
+    assert events == ["agent_close", "connector_close_start"]
 
 
 def test_run_api_agent_closes_shared_connector_after_agent_close_failure(

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -501,6 +501,62 @@ def test_collect_low_tier_apply_triggers_same_pr_quorum_reconciler_after_posts()
     assert outcome.quorum_rerun == {"should_rerun": True, "run_id": 123, "applied": True}
 
 
+def test_collect_low_tier_apply_prepares_only_when_reviewer_dissents() -> None:
+    fakes, posted = _fakes(tier=1)
+    calls: list[tuple[str, int]] = []
+
+    def reviewer_runner(family: str, prompt: str) -> ReviewerResult:
+        if family == "grok":
+            return ReviewerResult("grok", "Verdict: CHANGES-REQUESTED\n- [P1] blocker", True)
+        return ReviewerResult("claude", "Verdict: PASS\n- no blockers", True)
+
+    def quorum_reconciler(repo: str, pr: int) -> dict:
+        calls.append((repo, pr))
+        return {"applied": True}
+
+    fakes["reviewer_runner"] = reviewer_runner
+    outcome = collect_evidence(
+        repo="o/r",
+        pr=1,
+        families=["claude", "grok"],
+        author="me",
+        apply=True,
+        quorum_reconciler=quorum_reconciler,
+        **fakes,
+    )
+
+    assert outcome.action == "prepare"
+    assert "reviewer dissent" in outcome.action_reason
+    assert outcome.dissenting_families == ["grok"]
+    assert posted == []
+    assert calls == []
+    assert outcome.quorum_rerun is None
+
+
+def test_collect_success_requires_two_supportive_reviewers() -> None:
+    fakes, _posted = _fakes(tier=1)
+
+    def reviewer_runner(family: str, prompt: str) -> ReviewerResult:
+        if family == "grok":
+            return ReviewerResult("grok", "Verdict: CHANGES-REQUESTED\n- [P1] blocker", True)
+        return ReviewerResult("claude", "Verdict: PASS\n- no blockers", True)
+
+    fakes["reviewer_runner"] = reviewer_runner
+    outcome = collect_evidence(
+        repo="o/r",
+        pr=1,
+        families=["claude", "grok"],
+        author="me",
+        apply=False,
+        **fakes,
+    )
+
+    assert outcome.counting_families == ["claude", "grok"]
+    assert outcome.supportive_families == ["claude"]
+    assert outcome.dissenting_families == ["grok"]
+    assert outcome.has_supportive_quorum is False
+
+
 def test_collect_records_quorum_reconciler_error_after_successful_posts() -> None:
     fakes, posted = _fakes(tier=1)
 
@@ -805,8 +861,8 @@ def test_run_collect_cli_exit_code_quorum_met(monkeypatch, capsys) -> None:
             action="post",
             action_reason="ok",
             items=[
-                EvidenceItem("claude", "body", True, ["claude"], []),
-                EvidenceItem("grok", "body", True, ["grok"], []),
+                EvidenceItem("claude", "body", True, ["claude"], [], "pass"),
+                EvidenceItem("grok", "body", True, ["grok"], [], "pass"),
             ],
             posted=["claude", "grok"],
         )

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -12,6 +12,7 @@ The compose helper is checked against the *real* evidence parser
 from __future__ import annotations
 
 import asyncio
+import time
 from contextlib import contextmanager
 from types import SimpleNamespace
 
@@ -266,6 +267,41 @@ def test_run_api_agent_closes_resources_after_generate_failure(
     assert result.ok is False
     assert "RuntimeError: model failed" in result.error
     assert events == ["generate", "agent_close", "connector_close"]
+
+
+def test_run_api_agent_wall_clock_timeout_interrupts_blocked_generate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+
+    class FakeAgent:
+        async def generate(self, prompt: str) -> str:
+            events.append("generate_start")
+            time.sleep(1)
+            return "Verdict: PASS"
+
+        async def close(self) -> None:
+            events.append("agent_close")
+
+    def fake_create_agent(family: str, *, name: str, role: str) -> FakeAgent:
+        return FakeAgent()
+
+    async def fake_close_shared_connector() -> None:
+        events.append("connector_close")
+
+    import aragora.agents
+    from aragora.agents.api_agents import common
+
+    monkeypatch.setattr(qe, "_REVIEWER_TIMEOUT", 0.05)
+    monkeypatch.setattr(qe, "_REVIEWER_CLEANUP_TIMEOUT", 0.01)
+    monkeypatch.setattr(aragora.agents, "create_agent", fake_create_agent)
+    monkeypatch.setattr(common, "close_shared_connector", fake_close_shared_connector)
+
+    result = qe._run_api_agent("grok", "review prompt")
+
+    assert result.ok is False
+    assert "timed out" in result.error
+    assert events == ["generate_start", "agent_close", "connector_close"]
 
 
 def test_api_agent_cleanup_does_not_hang_on_stuck_agent_close(

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -606,6 +606,52 @@ def test_default_quorum_reconciler_holds_lock_through_state_update(
     assert events == ["lock-enter", "load", "evaluate", "execute", "save", "lock-exit"]
 
 
+def test_default_quorum_reconciler_rechecks_rerun_cap_under_lock(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    from scripts import reconcile_merge_quorum
+
+    state = {
+        "abc123": {
+            "count": qe.QUORUM_RERUN_MAX_PER_HEAD,
+            "last_rerun_at": None,
+        }
+    }
+
+    @contextmanager
+    def fake_lock(path):
+        yield
+
+    def evaluate_pr(repo, pr, *, now, state, cooldown_seconds, max_reruns):
+        decision = SimpleNamespace(
+            should_rerun=True,
+            reason="stale-success-after-new-evidence",
+            run_id=123,
+            next_prompt=None,
+        )
+        quorum_run = SimpleNamespace(run_id=123, head_sha="abc123")
+        return decision, quorum_run
+
+    def execute_rerun(repo, run_id):
+        raise AssertionError("rerun must not execute after locked count reaches the cap")
+
+    monkeypatch.setattr(qe, "_locked_quorum_reconcile_state", fake_lock)
+    monkeypatch.setattr(reconcile_merge_quorum, "DEFAULT_STATE_FILE", tmp_path / "state.json")
+    monkeypatch.setattr(reconcile_merge_quorum, "_load_state", lambda path: state)
+    monkeypatch.setattr(reconcile_merge_quorum, "evaluate_pr", evaluate_pr)
+    monkeypatch.setattr(reconcile_merge_quorum, "execute_rerun", execute_rerun)
+
+    record = qe.default_quorum_reconciler("o/r", 1)
+
+    assert record == {
+        "should_rerun": False,
+        "reason": "max_reruns_reached_in_locked_state",
+        "run_id": 123,
+        "applied": False,
+    }
+
+
 def test_collect_high_tier_apply_never_posts() -> None:
     fakes, posted = _fakes(tier=4)
     outcome = collect_evidence(

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -226,7 +226,7 @@ def test_run_api_agent_closes_agent_and_shared_connector(monkeypatch: pytest.Mon
     monkeypatch.setattr(aragora.agents, "create_agent", fake_create_agent)
     monkeypatch.setattr(common, "close_shared_connector", fake_close_shared_connector)
 
-    result = qe._run_api_agent("grok", "review prompt")
+    result = qe._run_api_agent_in_current_process("grok", "review prompt")
 
     assert result == ReviewerResult("grok", "Verdict: PASS", True)
     assert events == [
@@ -262,46 +262,29 @@ def test_run_api_agent_closes_resources_after_generate_failure(
     monkeypatch.setattr(aragora.agents, "create_agent", fake_create_agent)
     monkeypatch.setattr(common, "close_shared_connector", fake_close_shared_connector)
 
-    result = qe._run_api_agent("grok", "review prompt")
+    result = qe._run_api_agent_in_current_process("grok", "review prompt")
 
     assert result.ok is False
     assert "RuntimeError: model failed" in result.error
     assert events == ["generate", "agent_close", "connector_close"]
 
 
-def test_run_api_agent_wall_clock_timeout_interrupts_blocked_generate(
+def test_run_api_agent_timeout_terminates_blocked_worker(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    events: list[str] = []
-
-    class FakeAgent:
-        async def generate(self, prompt: str) -> str:
-            events.append("generate_start")
-            time.sleep(1)
-            return "Verdict: PASS"
-
-        async def close(self) -> None:
-            events.append("agent_close")
-
-    def fake_create_agent(family: str, *, name: str, role: str) -> FakeAgent:
-        return FakeAgent()
-
-    async def fake_close_shared_connector() -> None:
-        events.append("connector_close")
-
-    import aragora.agents
-    from aragora.agents.api_agents import common
-
     monkeypatch.setattr(qe, "_REVIEWER_TIMEOUT", 0.05)
     monkeypatch.setattr(qe, "_REVIEWER_CLEANUP_TIMEOUT", 0.01)
-    monkeypatch.setattr(aragora.agents, "create_agent", fake_create_agent)
-    monkeypatch.setattr(common, "close_shared_connector", fake_close_shared_connector)
+
+    def blocked_worker(family: str, prompt: str) -> ReviewerResult:
+        time.sleep(1)
+        return ReviewerResult(family, "Verdict: PASS", True)
+
+    monkeypatch.setattr(qe, "_run_api_agent_in_current_process", blocked_worker, raising=False)
 
     result = qe._run_api_agent("grok", "review prompt")
 
     assert result.ok is False
     assert "timed out" in result.error
-    assert events == ["generate_start", "agent_close", "connector_close"]
 
 
 def test_api_agent_cleanup_does_not_hang_on_stuck_agent_close(
@@ -376,7 +359,7 @@ def test_run_api_agent_closes_shared_connector_after_agent_close_failure(
     monkeypatch.setattr(aragora.agents, "create_agent", fake_create_agent)
     monkeypatch.setattr(common, "close_shared_connector", fake_close_shared_connector)
 
-    result = qe._run_api_agent("grok", "review prompt")
+    result = qe._run_api_agent_in_current_process("grok", "review prompt")
 
     assert result == ReviewerResult("grok", "Verdict: PASS", True)
     assert events == ["generate", "agent_close", "connector_close"]
@@ -404,7 +387,7 @@ def test_run_api_agent_closes_shared_connector_without_agent_close(
     monkeypatch.setattr(aragora.agents, "create_agent", fake_create_agent)
     monkeypatch.setattr(common, "close_shared_connector", fake_close_shared_connector)
 
-    result = qe._run_api_agent("grok", "review prompt")
+    result = qe._run_api_agent_in_current_process("grok", "review prompt")
 
     assert result == ReviewerResult("grok", "Verdict: PASS", True)
     assert events == ["generate", "connector_close"]
@@ -433,7 +416,7 @@ def test_run_api_agent_supports_sync_agent_close(monkeypatch: pytest.MonkeyPatch
     monkeypatch.setattr(aragora.agents, "create_agent", fake_create_agent)
     monkeypatch.setattr(common, "close_shared_connector", fake_close_shared_connector)
 
-    result = qe._run_api_agent("grok", "review prompt")
+    result = qe._run_api_agent_in_current_process("grok", "review prompt")
 
     assert result == ReviewerResult("grok", "Verdict: PASS", True)
     assert events == ["generate", "agent_close", "connector_close"]
@@ -465,7 +448,7 @@ def test_run_api_agent_keeps_result_when_shared_connector_close_fails(
     monkeypatch.setattr(aragora.agents, "create_agent", fake_create_agent)
     monkeypatch.setattr(common, "close_shared_connector", fake_close_shared_connector)
 
-    result = qe._run_api_agent("grok", "review prompt")
+    result = qe._run_api_agent_in_current_process("grok", "review prompt")
 
     assert result == ReviewerResult("grok", "Verdict: PASS", True)
     assert events == ["generate", "agent_close", "connector_close"]
@@ -497,8 +480,8 @@ def test_run_api_agent_allows_consecutive_one_shot_calls(
     monkeypatch.setattr(aragora.agents, "create_agent", fake_create_agent)
     monkeypatch.setattr(common, "close_shared_connector", fake_close_shared_connector)
 
-    first = qe._run_api_agent("grok", "one")
-    second = qe._run_api_agent("grok", "two")
+    first = qe._run_api_agent_in_current_process("grok", "one")
+    second = qe._run_api_agent_in_current_process("grok", "two")
 
     assert first == ReviewerResult("grok", "Verdict: PASS one", True)
     assert second == ReviewerResult("grok", "Verdict: PASS two", True)


### PR DESCRIPTION
## Summary
- Trigger the same-PR merge-quorum reconciler after `review-queue collect-evidence --apply` successfully posts low-tier evidence.
- Keep Tier 3/Tier 4 behavior prepare-only; the default CLI reconciler is only wired in apply mode and only after successful posts.
- Preserve A1 safety by reusing the reconciler cooldown, max-rerun, and real-failure guards instead of adding a new rerun path.

## Context
- Live dogfood on #7814 showed the seam: collect-evidence posted countable Claude/Grok evidence, but stale `aragora-merge-quorum` still needed a separate manual rerun.
- This change closes that B3/A1 handoff gap without broad-draining or changing merge authority.

## Tests
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/swarm/test_quorum_evidence.py::test_collect_low_tier_apply_triggers_same_pr_quorum_reconciler_after_posts`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/swarm/test_quorum_evidence.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/swarm/test_quorum_evidence.py tests/swarm/test_merge_quorum_reconcile.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check aragora/swarm/quorum_evidence.py tests/swarm/test_quorum_evidence.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m compileall -q aragora/swarm/quorum_evidence.py`
- `git diff --check`