### PR TITLE
fix(lanes): target stale lane sweeps

### DIFF
--- a/scripts/sweep_stale_lane_claims.py
+++ b/scripts/sweep_stale_lane_claims.py
@@ -206,6 +206,23 @@ def evaluate_row(
     return reasons
 
 
+def _normalize_selectors(values: Iterable[str] | None) -> set[str]:
+    return {str(value).strip() for value in values or [] if str(value).strip()}
+
+
+def _matches_selectors(
+    row: dict[str, Any],
+    *,
+    lane_ids: set[str],
+    owner_sessions: set[str],
+) -> bool:
+    if lane_ids and str(row.get("lane_id") or "") not in lane_ids:
+        return False
+    if owner_sessions and str(row.get("owner_session") or "") not in owner_sessions:
+        return False
+    return True
+
+
 def sweep(
     *,
     registry_path: Path,
@@ -216,13 +233,26 @@ def sweep(
     check_remote: bool,
     now: dt.datetime | None = None,
     branch_grace_hours: float = 1.0,
+    lane_ids: Iterable[str] | None = None,
+    owner_sessions: Iterable[str] | None = None,
 ) -> dict[str, Any]:
     rows = _read_existing(registry_path)
     if now is None:
         now = _utc_now()
+    lane_id_selectors = _normalize_selectors(lane_ids)
+    owner_session_selectors = _normalize_selectors(owner_sessions)
     active_rows = [r for r in rows if r.get("status") in ACTIVE_STATUSES]
+    matched_active_rows = [
+        r
+        for r in active_rows
+        if _matches_selectors(
+            r,
+            lane_ids=lane_id_selectors,
+            owner_sessions=owner_session_selectors,
+        )
+    ]
     stale_records: list[dict[str, Any]] = []
-    for row in active_rows:
+    for row in matched_active_rows:
         reasons = evaluate_row(
             row,
             now=now,
@@ -265,9 +295,14 @@ def sweep(
         "scanned_at": now.isoformat().replace("+00:00", "Z"),
         "total_rows": len(rows),
         "active_rows": len(active_rows),
+        "matched_active_rows": len(matched_active_rows),
         "stale_rows": len(stale_records),
         "stale_records": stale_records,
         "applied": applied,
+        "selectors": {
+            "lane_ids": sorted(lane_id_selectors),
+            "owner_sessions": sorted(owner_session_selectors),
+        },
     }
 
 
@@ -299,6 +334,24 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Skip branch_missing detection for active rows newer than this. "
             "Allows freshly-claimed lanes time to push their branch (default 1h)"
+        ),
+    )
+    parser.add_argument(
+        "--lane-id",
+        action="append",
+        default=[],
+        help=(
+            "Only evaluate active rows with this lane_id. May be passed more than once. "
+            "When combined with --owner-session, both selectors must match."
+        ),
+    )
+    parser.add_argument(
+        "--owner-session",
+        action="append",
+        default=[],
+        help=(
+            "Only evaluate active rows with this owner_session. May be passed more than once. "
+            "When combined with --lane-id, both selectors must match."
         ),
     )
     parser.add_argument(
@@ -348,13 +401,16 @@ def main(argv: list[str] | None = None) -> int:
         check_branches=not args.skip_branch_check,
         check_remote=not args.skip_remote_check,
         branch_grace_hours=args.branch_grace_hours,
+        lane_ids=args.lane_id,
+        owner_sessions=args.owner_session,
     )
     if args.json:
         print(json.dumps(report, indent=2, sort_keys=True))
     else:
         print(
             f"registry={report['registry_path']} total={report['total_rows']} "
-            f"active={report['active_rows']} stale={report['stale_rows']} "
+            f"active={report['active_rows']} matched={report['matched_active_rows']} "
+            f"stale={report['stale_rows']} "
             f"applied={report['applied']}"
         )
         for record in report["stale_records"]:

--- a/tests/scripts/test_sweep_stale_lane_claims.py
+++ b/tests/scripts/test_sweep_stale_lane_claims.py
@@ -129,6 +129,102 @@ def test_apply_expires_stale_rows(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
     assert by_lane["live"]["status"] == "active"
 
 
+def test_dry_run_lane_id_filter_reports_only_matching_stale_row(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import sweep_stale_lane_claims as mod
+
+    registry = tmp_path / "lanes.json"
+    _write_registry(
+        registry,
+        [
+            {
+                "lane_id": "target-lane",
+                "owner_session": "target-owner",
+                "branch": "missing-target",
+                "status": "active",
+                "updated_at": "2026-05-15T12:00:00Z",
+            },
+            {
+                "lane_id": "other-stale",
+                "owner_session": "other-owner",
+                "branch": "missing-other",
+                "status": "active",
+                "updated_at": "2026-05-15T12:00:00Z",
+            },
+        ],
+    )
+
+    monkeypatch.setattr(mod, "branch_exists_locally", lambda *_a, **_k: False)
+    monkeypatch.setattr(mod, "branch_exists_remotely", lambda *_a, **_k: False)
+
+    report = mod.sweep(
+        registry_path=registry,
+        repo=tmp_path,
+        max_age_hours=24.0,
+        apply=False,
+        check_branches=True,
+        check_remote=True,
+        now=dt.datetime(2026, 5, 18, 18, 0, tzinfo=dt.UTC),
+        lane_ids={"target-lane"},
+    )
+
+    assert report["active_rows"] == 2
+    assert report["matched_active_rows"] == 1
+    assert report["stale_rows"] == 1
+    assert report["stale_records"][0]["lane_id"] == "target-lane"
+
+
+def test_apply_owner_filter_expires_only_matching_stale_row(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import sweep_stale_lane_claims as mod
+
+    registry = tmp_path / "lanes.json"
+    _write_registry(
+        registry,
+        [
+            {
+                "lane_id": "target-lane",
+                "owner_session": "target-owner",
+                "branch": "missing-target",
+                "status": "active",
+                "updated_at": "2026-05-15T12:00:00Z",
+            },
+            {
+                "lane_id": "other-stale",
+                "owner_session": "other-owner",
+                "branch": "missing-other",
+                "status": "active",
+                "updated_at": "2026-05-15T12:00:00Z",
+            },
+        ],
+    )
+
+    monkeypatch.setattr(mod, "branch_exists_locally", lambda *_a, **_k: False)
+    monkeypatch.setattr(mod, "branch_exists_remotely", lambda *_a, **_k: False)
+
+    report = mod.sweep(
+        registry_path=registry,
+        repo=tmp_path,
+        max_age_hours=24.0,
+        apply=True,
+        check_branches=True,
+        check_remote=True,
+        now=dt.datetime(2026, 5, 18, 18, 0, tzinfo=dt.UTC),
+        owner_sessions={"target-owner"},
+    )
+
+    assert report["applied"] is True
+    assert report["matched_active_rows"] == 1
+    assert report["stale_rows"] == 1
+
+    persisted = json.loads(registry.read_text())
+    by_lane = {r["lane_id"]: r for r in persisted}
+    assert by_lane["target-lane"]["status"] == "expired"
+    assert by_lane["other-stale"]["status"] == "active"
+
+
 def test_new_lifecycle_statuses_participate_in_stale_sweep(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- Add `--lane-id` and `--owner-session` selectors to `scripts/sweep_stale_lane_claims.py`.
- Preserve broad-sweep defaults, but allow dry-run/apply to operate on one proven stale lane.
- Report `matched_active_rows` plus selector metadata so targeted sweeps are auditable.

## Live dogfood evidence
A full dry-run currently finds 292 stale rows, so broad `--apply` is too wide for a single operator action. The new targeted dry-run for `claude-7749-evidence-20260604T185057Z` reports `active_rows=302`, `matched_active_rows=1`, and `stale_rows=1`, with reason `stale_updated_at`.

## Tests
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_sweep_stale_lane_claims.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/sweep_stale_lane_claims.py tests/scripts/test_sweep_stale_lane_claims.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m mypy scripts/sweep_stale_lane_claims.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
