### PR TITLE
fix(agent-bridge): compact supervisor output

### DIFF
--- a/scripts/agent_bridge_supervise.py
+++ b/scripts/agent_bridge_supervise.py
@@ -108,6 +108,37 @@ class SupervisorSnapshot:
             "lanes": [decision.to_dict() for decision in self.decisions],
         }
 
+    def to_summary_dict(self, *, top_lanes_limit: int = 5) -> dict[str, Any]:
+        action_counts: dict[str, int] = {}
+        status_counts: dict[str, int] = {}
+        for decision in self.decisions:
+            action_counts[decision.next_action] = action_counts.get(decision.next_action, 0) + 1
+            status_counts[decision.status] = status_counts.get(decision.status, 0) + 1
+        return {
+            "generated_at": self.generated_at,
+            "warning_count": len(self.warnings),
+            "warnings": list(self.warnings),
+            "lane_count": len(self.decisions),
+            "action_counts": dict(sorted(action_counts.items())),
+            "status_counts": dict(sorted(status_counts.items())),
+            "top_lanes": [
+                {
+                    key: value
+                    for key, value in {
+                        "lane_id": decision.lane_id,
+                        "owner_session": decision.owner_session,
+                        "status": decision.status,
+                        "next_action": decision.next_action,
+                        "branch": decision.branch,
+                        "pr_number": decision.pr_number,
+                    }.items()
+                    if value not in ("", None)
+                }
+                for decision in self.decisions[:top_lanes_limit]
+            ],
+            "details_omitted": True,
+        }
+
 
 def _now_iso() -> str:
     return datetime.now(UTC).isoformat()
@@ -703,6 +734,25 @@ def _render_text(snapshot: SupervisorSnapshot) -> str:
     return "\n".join(lines)
 
 
+def _mute_stdout_after_broken_pipe() -> None:
+    """Avoid interpreter-shutdown tracebacks after downstream pipes close."""
+    try:
+        sys.stdout.close()
+    except OSError:
+        pass
+    sys.stdout = open(os.devnull, "w", encoding="utf-8")
+
+
+def _emit_text(output: str) -> int:
+    try:
+        sys.stdout.write(output)
+        sys.stdout.write("\n")
+        sys.stdout.flush()
+    except BrokenPipeError:
+        _mute_stdout_after_broken_pipe()
+    return 0
+
+
 _SAFE_AUTO_ACTIONS = frozenset(
     {
         "approve_prompt",
@@ -824,6 +874,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--json", action="store_true", help="Render machine-readable JSON.")
     parser.add_argument(
+        "--summary-only",
+        action="store_true",
+        help="With JSON output, omit full lane records and render compact counts.",
+    )
+    parser.add_argument(
         "--execute",
         action="store_true",
         help="Execute safe bounded actions (approve prompts, send followups). Without this flag, only reports.",
@@ -854,27 +909,27 @@ def main(argv: list[str] | None = None) -> int:
                     result = _execute_decision(decision, dry_run=args.dry_run)
                     actions_taken.append(result)
 
-            if args.json:
-                print(
-                    json.dumps(
-                        {
-                            **snapshot.to_dict(),
-                            "actions_taken": actions_taken,
-                        },
-                        indent=2,
-                    )
-                )
+            if args.json or args.summary_only:
+                payload = snapshot.to_summary_dict() if args.summary_only else snapshot.to_dict()
+                _emit_text(json.dumps({**payload, "actions_taken": actions_taken}, indent=2))
             else:
-                print(_render_text(snapshot))
+                output = _render_text(snapshot)
                 if actions_taken:
-                    print("\n--- Actions ---")
-                    for action in actions_taken:
-                        print(f"  {action}")
+                    output = "\n".join(
+                        [
+                            output,
+                            "",
+                            "--- Actions ---",
+                            *[f"  {action}" for action in actions_taken],
+                        ]
+                    )
+                _emit_text(output)
         else:
-            if args.json:
-                print(json.dumps(snapshot.to_dict(), indent=2))
+            if args.json or args.summary_only:
+                payload = snapshot.to_summary_dict() if args.summary_only else snapshot.to_dict()
+                _emit_text(json.dumps(payload, indent=2))
             else:
-                print(_render_text(snapshot))
+                _emit_text(_render_text(snapshot))
 
         if run_once:
             return 0

--- a/tests/scripts/test_agent_bridge_supervise.py
+++ b/tests/scripts/test_agent_bridge_supervise.py
@@ -285,6 +285,68 @@ def test_main_once_json_renders_snapshot(
     assert payload["warnings"] == ["gh unavailable"]
 
 
+def test_main_summary_only_json_omits_full_lane_records(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import agent_bridge_supervise as mod
+
+    snapshot = mod.SupervisorSnapshot(
+        generated_at="2026-04-13T22:30:00+00:00",
+        decisions=[
+            mod.LaneDecision(
+                lane_id="bridge-hardening",
+                owner_session="codex-bridge",
+                status="active",
+                next_action="send_followup",
+                reason="Need one bounded follow-up prompt",
+                evidence=["large transcript detail"],
+            ),
+            mod.LaneDecision(
+                lane_id="bridge-review",
+                owner_session="codex-review",
+                status="blocked",
+                next_action="ready_for_review",
+                reason="Checks passed",
+            ),
+        ],
+        warnings=["gh unavailable"],
+    )
+    monkeypatch.setattr(mod, "collect_supervisor_snapshot", lambda: snapshot)
+
+    rc = mod.main(["--once", "--summary-only"])
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["details_omitted"] is True
+    assert payload["lane_count"] == 2
+    assert payload["action_counts"] == {"ready_for_review": 1, "send_followup": 1}
+    assert "lanes" not in payload
+    assert "evidence" not in payload["top_lanes"][0]
+
+
+def test_emit_text_mutes_stdout_after_broken_pipe(monkeypatch: pytest.MonkeyPatch) -> None:
+    import agent_bridge_supervise as mod
+
+    muted = False
+
+    class BrokenStdout:
+        def write(self, _output: str) -> int:
+            raise BrokenPipeError
+
+        def flush(self) -> None:
+            raise AssertionError("flush should not be reached after a broken write")
+
+    def fake_mute() -> None:
+        nonlocal muted
+        muted = True
+
+    monkeypatch.setattr(mod.sys, "stdout", BrokenStdout())
+    monkeypatch.setattr(mod, "_mute_stdout_after_broken_pipe", fake_mute)
+
+    assert mod._emit_text("payload") == 0
+    assert muted is True
+
+
 def test_collect_supervisor_snapshot_caps_records_and_warns(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- adds `--summary-only` output for the passive agent-bridge supervisor
- emits JSON through a pipe-safe path so truncated automation probes avoid BrokenPipe tracebacks
- adds focused supervisor coverage for compact output and broken-pipe handling

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/scripts/test_agent_bridge_supervise.py`
- `python3 -m ruff check scripts/agent_bridge_supervise.py tests/scripts/test_agent_bridge_supervise.py`
- `python3 -m ruff format --check scripts/agent_bridge_supervise.py tests/scripts/test_agent_bridge_supervise.py`
- `bash -o pipefail -c 'python3 scripts/agent_bridge_supervise.py --once --json | head -5'`
- `bash -o pipefail -c 'python3 scripts/agent_bridge_supervise.py --once --summary-only | head -20'`
- `git diff --check origin/main...HEAD && git rev-list --left-right --count origin/main...HEAD && bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Handoff
- Outbox: `open-pr-codex-agent-bridge-supervise-summary-only-improver-20260606-d3016f6e.json`
- Exact head: `d3016f6ece3f8adcdd7275bbf27d445012374a31`