### PR TITLE
fix(automation): suppress handoff publisher broken pipes

### DIFF
--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -1602,8 +1602,11 @@ def main(argv: list[str] | None = None) -> int:
             return 0
         return 1 if handoffs else 0
 
+    decision_handoffs = (
+        handoffs[: max(args.limit, 0)] if args.summary_only and not args.apply else handoffs
+    )
     decisions = decide_handoffs(
-        handoffs,
+        decision_handoffs,
         repo_root=repo_root,
         repo=args.github_repo,
         labels=labels,

--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -139,6 +139,31 @@ except Exception:  # pragma: no cover - fallback for partially bootstrapped scri
         )
 
 
+def _mute_stdout_after_broken_pipe() -> None:
+    """Avoid interpreter-shutdown tracebacks after downstream pipes close."""
+    try:
+        devnull_fd = os.open(os.devnull, os.O_WRONLY)
+        try:
+            os.dup2(devnull_fd, sys.stdout.fileno())
+        finally:
+            os.close(devnull_fd)
+    except Exception:
+        try:
+            sys.stdout = open(os.devnull, "w", encoding="utf-8")
+        except OSError:
+            pass
+
+
+def _emit_stdout(text: str) -> bool:
+    try:
+        sys.stdout.write(f"{text}\n")
+        sys.stdout.flush()
+    except BrokenPipeError:
+        _mute_stdout_after_broken_pipe()
+        return False
+    return True
+
+
 @dataclass(frozen=True)
 class Handoff:
     source_file: str
@@ -1563,12 +1588,18 @@ def main(argv: list[str] | None = None) -> int:
         }
         if args.json:
             output_payload = summary_only_payload(payload) if args.summary_only else payload
-            print(json.dumps(output_payload, indent=2))
+            emitted = _emit_stdout(json.dumps(output_payload, indent=2))
         else:
             if handoffs:
-                print(f"github_unavailable: {github_health.mode} {github_health.error}".strip())
+                emitted = _emit_stdout(
+                    f"github_unavailable: {github_health.mode} {github_health.error}".strip()
+                )
             else:
-                print(f"noop: no handoffs to publish; github_unavailable={github_health.mode}")
+                emitted = _emit_stdout(
+                    f"noop: no handoffs to publish; github_unavailable={github_health.mode}"
+                )
+        if not emitted:
+            return 0
         return 1 if handoffs else 0
 
     decisions = decide_handoffs(
@@ -1618,7 +1649,8 @@ def main(argv: list[str] | None = None) -> int:
     }
     if args.json:
         output_payload = summary_only_payload(payload) if args.summary_only else payload
-        print(json.dumps(output_payload, indent=2))
+        if not _emit_stdout(json.dumps(output_payload, indent=2)):
+            return 0
     else:
         for item in results:
             marker = (
@@ -1629,7 +1661,8 @@ def main(argv: list[str] | None = None) -> int:
                 else "publish"
             )
             target = item.created_issue_url or item.existing_issue_url or item.existing_pr_url or ""
-            print(f"{marker}: {item.task_title} [{item.reason}] {target}".strip())
+            if not _emit_stdout(f"{marker}: {item.task_title} [{item.reason}] {target}".strip()):
+                return 0
     return 0
 
 

--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -888,12 +888,14 @@ def load_outbox_handoffs(
     outbox_dir: Path | None = None,
     receipt_dir: Path | None = None,
     now: datetime | None = None,
+    max_handoffs: int | None = None,
 ) -> list[Handoff]:
     handoffs, _skip_reasons = _load_outbox_handoffs_with_skip_reasons(
         repo_root,
         outbox_dir=outbox_dir,
         receipt_dir=receipt_dir,
         now=now,
+        max_handoffs=max_handoffs,
     )
     return handoffs
 
@@ -904,19 +906,30 @@ def _load_outbox_handoffs_with_skip_reasons(
     outbox_dir: Path | None = None,
     receipt_dir: Path | None = None,
     now: datetime | None = None,
+    max_handoffs: int | None = None,
 ) -> tuple[list[Handoff], Counter[str]]:
     outbox_root = _automation_state_path(repo_root, outbox_dir, DEFAULT_OUTBOX_DIR).resolve()
     receipt_root = _automation_state_path(repo_root, receipt_dir, DEFAULT_RECEIPT_DIR).resolve()
     current_time = now or datetime.now(UTC)
     terminal_receipts = _terminal_receipts_by_key(receipt_root)
-    terminal_fingerprints = _terminal_outbox_fingerprints(
-        repo_root,
-        outbox_root,
-        terminal_receipts,
+    terminal_fingerprints = (
+        set()
+        if max_handoffs is not None
+        else _terminal_outbox_fingerprints(
+            repo_root,
+            outbox_root,
+            terminal_receipts,
+        )
     )
     handoffs_by_identity: dict[tuple[str, str], Handoff] = {}
     skipped_reasons: Counter[str] = Counter()
-    for source_file in _outbox_files(outbox_root):
+    source_files = _outbox_files(outbox_root)
+    if max_handoffs is not None:
+        source_files = sorted(source_files, key=_source_mtime, reverse=True)
+    for index, source_file in enumerate(source_files):
+        if max_handoffs is not None and len(handoffs_by_identity) >= max_handoffs:
+            skipped_reasons["preview_limit"] += len(source_files) - index
+            break
         try:
             payload = json.loads(source_file.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
@@ -1541,11 +1554,20 @@ def main(argv: list[str] | None = None) -> int:
         outbox_handoffs = []
         outbox_skipped_reason_counts: Counter[str] = Counter()
     else:
-        outbox_handoffs, outbox_skipped_reason_counts = _load_outbox_handoffs_with_skip_reasons(
-            repo_root,
-            outbox_dir=outbox_dir,
-            receipt_dir=receipt_dir,
-        )
+        outbox_preview_limit = max(args.limit, 0) if args.summary_only and not args.apply else None
+        if outbox_preview_limit is None:
+            outbox_handoffs, outbox_skipped_reason_counts = _load_outbox_handoffs_with_skip_reasons(
+                repo_root,
+                outbox_dir=outbox_dir,
+                receipt_dir=receipt_dir,
+            )
+        else:
+            outbox_handoffs, outbox_skipped_reason_counts = _load_outbox_handoffs_with_skip_reasons(
+                repo_root,
+                outbox_dir=outbox_dir,
+                receipt_dir=receipt_dir,
+                max_handoffs=outbox_preview_limit,
+            )
     outbox_file_count = 0 if args.no_outbox else len(_outbox_files(outbox_dir))
     outbox_skipped_count = sum(outbox_skipped_reason_counts.values())
     if outbox_skipped_count == 0:

--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -147,7 +147,7 @@ def _mute_stdout_after_broken_pipe() -> None:
             os.dup2(devnull_fd, sys.stdout.fileno())
         finally:
             os.close(devnull_fd)
-    except Exception:
+    except (AttributeError, OSError, ValueError):
         try:
             sys.stdout = open(os.devnull, "w", encoding="utf-8")
         except OSError:
@@ -1550,6 +1550,7 @@ def main(argv: list[str] | None = None) -> int:
     labels = list(dict.fromkeys(args.labels))
     automation_ids = set(args.automation_ids or DEFAULT_AUTOMATION_IDS)
     memory_handoffs = load_handoffs(codex_home, automation_ids=automation_ids)
+    outbox_preview_limit = None
     if args.no_outbox:
         outbox_handoffs = []
         outbox_skipped_reason_counts: Counter[str] = Counter()
@@ -1603,6 +1604,8 @@ def main(argv: list[str] | None = None) -> int:
             "outbox_handoff_count": len(outbox_handoffs),
             "outbox_skipped_count": outbox_skipped_count,
             "outbox_skipped_reason_counts": outbox_skipped_reason_counts_payload,
+            "outbox_preview_limited": outbox_preview_limit is not None,
+            "outbox_preview_limit": outbox_preview_limit,
             "handoff_count": len(handoffs),
             "github_health": github_health.to_dict(),
             "decisions": [asdict(item) for item in decisions],
@@ -1667,6 +1670,8 @@ def main(argv: list[str] | None = None) -> int:
         "outbox_handoff_count": len(outbox_handoffs),
         "outbox_skipped_count": outbox_skipped_count,
         "outbox_skipped_reason_counts": outbox_skipped_reason_counts_payload,
+        "outbox_preview_limited": outbox_preview_limit is not None,
+        "outbox_preview_limit": outbox_preview_limit,
         "handoff_count": len(handoffs),
         "github_health": github_health.to_dict(),
         "decisions": [asdict(item) for item in results],

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -2151,6 +2151,114 @@ def test_main_summary_only_limits_github_ready_decision_preview(
     }
 
 
+def test_load_outbox_handoffs_can_stop_after_preview_limit(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    outbox = tmp_path / ".aragora" / "automation-outbox"
+    receipts = tmp_path / ".aragora" / "automation-receipts"
+    outbox.mkdir(parents=True)
+    receipts.mkdir(parents=True)
+    for index in range(3):
+        (outbox / f"active-{index}.json").write_text(
+            json.dumps(
+                _outbox_payload(
+                    task=f"Publish validated repair branch {index}",
+                    idempotency_key=f"open-pr-active-{index}",
+                    branch=f"codex/example-{index}",
+                )
+            ),
+            encoding="utf-8",
+        )
+    expensive_checks = 0
+
+    def fake_already_merged(repo_root: Path, payload: dict[str, Any]) -> bool:
+        nonlocal expensive_checks
+        expensive_checks += 1
+        return False
+
+    monkeypatch.setattr(mod, "_outbox_branch_already_merged", fake_already_merged)
+    monkeypatch.setattr(mod, "_outbox_branch_patch_equivalent", lambda repo_root, payload: False)
+
+    handoffs, skipped = mod._load_outbox_handoffs_with_skip_reasons(
+        tmp_path,
+        max_handoffs=1,
+    )
+
+    assert len(handoffs) == 1
+    assert skipped == Counter({"preview_limit": 2})
+    assert expensive_checks == 1
+
+
+def test_main_summary_only_limits_outbox_loading(monkeypatch: Any, tmp_path: Path, capsys) -> None:
+    handoff = Handoff(
+        source_file=str(tmp_path / ".aragora" / "automation-outbox" / "example.json"),
+        task_title="Publish validated repair branch",
+        priority="MEDIUM",
+        body="body",
+        labels={},
+        expires_at=None,
+        idempotency_key="open-pr-codex-example-abc123",
+        source_kind="outbox",
+    )
+    captured: dict[str, int | None] = {}
+    monkeypatch.setattr(mod, "_repo_root", lambda path: tmp_path)
+    monkeypatch.setattr(mod, "load_handoffs", lambda codex_home, automation_ids=None: [])
+
+    def fake_load_outbox_handoffs(
+        repo_root: Path,
+        *,
+        outbox_dir: Path | None = None,
+        receipt_dir: Path | None = None,
+        max_handoffs: int | None = None,
+    ) -> tuple[list[Handoff], Counter[str]]:
+        captured["max_handoffs"] = max_handoffs
+        return [handoff], Counter()
+
+    monkeypatch.setattr(mod, "_load_outbox_handoffs_with_skip_reasons", fake_load_outbox_handoffs)
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda repo_root: GitHubCLIHealth(
+            ready=True,
+            auth_ok=True,
+            api_ok=True,
+            mode="ready",
+            error="",
+            repo=str(tmp_path),
+        ),
+    )
+    monkeypatch.setattr(
+        mod,
+        "decide_handoffs",
+        lambda *args, **kwargs: [
+            PublishDecision(
+                task_title=handoff.task_title,
+                source_file=handoff.source_file,
+                eligible=True,
+                reason="eligible",
+            )
+        ],
+    )
+
+    exit_code = mod.main(
+        [
+            "--repo",
+            str(tmp_path),
+            "--codex-home",
+            str(tmp_path),
+            "--json",
+            "--summary-only",
+            "--limit",
+            "1",
+        ]
+    )
+
+    assert exit_code == 0
+    assert captured["max_handoffs"] == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["decision_count"] == 1
+
+
 def test_main_summary_only_reports_outbox_files_skipped_before_publish(
     monkeypatch: Any, tmp_path: Path, capsys
 ) -> None:

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -2259,6 +2259,55 @@ def test_main_limits_github_unavailable_decision_preview(
     }
 
 
+def test_emit_stdout_suppresses_flush_time_broken_pipe(monkeypatch: Any) -> None:
+    muted_stdout = []
+
+    class FlushBrokenStdout:
+        def write(self, text: str) -> int:
+            return len(text)
+
+        def flush(self) -> None:
+            raise BrokenPipeError("downstream closed")
+
+    monkeypatch.setattr(mod.sys, "stdout", FlushBrokenStdout())
+    monkeypatch.setattr(mod, "_mute_stdout_after_broken_pipe", lambda: muted_stdout.append(True))
+
+    assert mod._emit_stdout("payload") is False
+    assert muted_stdout == [True]
+
+
+def test_main_json_pipe_close_returns_success(monkeypatch: Any, tmp_path: Path) -> None:
+    handoffs = [
+        Handoff(
+            source_file=str(tmp_path / "handoff.md"),
+            task_title="Offline handoff",
+            priority="MEDIUM",
+            body="body",
+            labels={},
+            expires_at=None,
+        )
+    ]
+    monkeypatch.setattr(mod, "_repo_root", lambda path: tmp_path)
+    monkeypatch.setattr(mod, "load_handoffs", lambda codex_home, automation_ids=None: handoffs)
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda repo_root: GitHubCLIHealth(
+            ready=False,
+            auth_ok=True,
+            api_ok=False,
+            mode="connectivity_failed",
+            error="error connecting to api.github.com",
+            repo=str(tmp_path),
+        ),
+    )
+    monkeypatch.setattr(mod, "_emit_stdout", lambda text: False)
+
+    exit_code = mod.main(["--repo", str(tmp_path), "--codex-home", str(tmp_path), "--json"])
+
+    assert exit_code == 0
+
+
 def test_parser_rejects_abbreviated_max_options() -> None:
     parser = mod._build_parser()
 

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -2069,6 +2069,88 @@ def test_main_summary_only_omits_decisions_when_github_unavailable(
     }
 
 
+def test_main_summary_only_limits_github_ready_decision_preview(
+    monkeypatch: Any, tmp_path: Path, capsys
+) -> None:
+    handoffs = [
+        Handoff(
+            source_file=str(tmp_path / f"handoff-{index}.md"),
+            task_title=f"Ready handoff {index}",
+            priority="MEDIUM",
+            body="body",
+            labels={},
+            expires_at=None,
+        )
+        for index in range(3)
+    ]
+    captured: dict[str, int] = {}
+    monkeypatch.setattr(mod, "_repo_root", lambda path: tmp_path)
+    monkeypatch.setattr(mod, "load_handoffs", lambda codex_home, automation_ids=None: handoffs)
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda repo_root: GitHubCLIHealth(
+            ready=True,
+            auth_ok=True,
+            api_ok=True,
+            mode="ready",
+            error="",
+            repo=str(tmp_path),
+        ),
+    )
+
+    def fake_decide_handoffs(
+        preview_handoffs: list[Handoff],
+        *,
+        repo_root: Path,
+        repo: str,
+        labels: list[str],
+        max_open_issues: int,
+    ) -> list[PublishDecision]:
+        captured["count"] = len(preview_handoffs)
+        return [
+            PublishDecision(
+                task_title=handoff.task_title,
+                source_file=handoff.source_file,
+                eligible=True,
+                reason="eligible",
+            )
+            for handoff in preview_handoffs
+        ]
+
+    monkeypatch.setattr(mod, "decide_handoffs", fake_decide_handoffs)
+
+    exit_code = mod.main(
+        [
+            "--repo",
+            str(tmp_path),
+            "--codex-home",
+            str(tmp_path),
+            "--json",
+            "--summary-only",
+            "--limit",
+            "1",
+        ]
+    )
+
+    assert exit_code == 0
+    assert captured["count"] == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert "decisions" not in payload
+    assert payload["handoff_count"] == 3
+    assert payload["decision_count"] == 1
+    assert payload["decision_omitted_count"] == 2
+    assert payload["decisions_truncated"] is True
+    assert payload["decision_summary"] == {
+        "total": 1,
+        "eligible_count": 1,
+        "ineligible_count": 0,
+        "reason_counts": {
+            "eligible": 1,
+        },
+    }
+
+
 def test_main_summary_only_reports_outbox_files_skipped_before_publish(
     monkeypatch: Any, tmp_path: Path, capsys
 ) -> None:

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -2141,6 +2141,8 @@ def test_main_summary_only_limits_github_ready_decision_preview(
     assert payload["decision_count"] == 1
     assert payload["decision_omitted_count"] == 2
     assert payload["decisions_truncated"] is True
+    assert payload["outbox_preview_limited"] is True
+    assert payload["outbox_preview_limit"] == 1
     assert payload["decision_summary"] == {
         "total": 1,
         "eligible_count": 1,
@@ -2257,6 +2259,8 @@ def test_main_summary_only_limits_outbox_loading(monkeypatch: Any, tmp_path: Pat
     assert captured["max_handoffs"] == 1
     payload = json.loads(capsys.readouterr().out)
     assert payload["decision_count"] == 1
+    assert payload["outbox_preview_limited"] is True
+    assert payload["outbox_preview_limit"] == 1
 
 
 def test_main_summary_only_reports_outbox_files_skipped_before_publish(


### PR DESCRIPTION
## Summary
- Suppress BrokenPipeError tracebacks when handoff publisher JSON output is piped to short readers.
- Bound `--summary-only` dry-run decision evaluation by `--limit`, so compact automation smokes do not evaluate every live outbox handoff before emitting JSON.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTEST_ADDOPTS='-p no:cacheprovider' /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_publish_automation_handoffs.py`
- `RUFF_CACHE_DIR=/private/tmp/ruff-cache-publisher-handoffs-pipe-final /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/publish_automation_handoffs.py tests/scripts/test_publish_automation_handoffs.py`
- `RUFF_CACHE_DIR=/private/tmp/ruff-cache-publisher-handoffs-pipe-final-format /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/publish_automation_handoffs.py tests/scripts/test_publish_automation_handoffs.py`
- `git diff --check origin/main...HEAD && bash scripts/automation_pr_preflight.sh origin/main HEAD`
- Live shared-outbox compact smoke: `timeout 60 python scripts/publish_automation_handoffs.py --state-root /Users/armand/Development/aragora/.aragora --dry-run --json --summary-only --limit 1`
- Live short-reader pipe smoke: same command piped to `head -5`, exited 0 without BrokenPipeError.

## Notes
- The shared root was not modified.
- The old outbox handoff exact head was `92582f52f01235b58b77d0b4e1cae6ac4c8dd16f`; this PR intentionally advances the branch to include the newly diagnosed bounded-summary guard at `d2c11b164b58c522b1eaddc88881b5e1e87e90a6`.
