### PR TITLE
fix(review): clear recovered boss-loop failure detail

### DIFF
--- a/aragora/review/health.py
+++ b/aragora/review/health.py
@@ -485,6 +485,7 @@ def _check_boss_loop_log(
                     latest_failure = stripped
                 elif _CRASH_PATTERN.search(line):
                     crashes_total += 1
+                    last_terminal_event = "crash"
                     latest_failure = stripped
                     latest_failure_signature = stripped
                 elif _EXIT_OK_PATTERN.search(line):
@@ -499,7 +500,7 @@ def _check_boss_loop_log(
     except OSError:
         pass
 
-    if last_terminal_event in {"traceback", "exit_fail"}:
+    if last_terminal_event in {"traceback", "crash", "exit_fail"}:
         status = STATUS_STALE
 
     extra: dict[str, object] = {
@@ -517,7 +518,7 @@ def _check_boss_loop_log(
         extra["latest_python_warning"] = latest_python_warning[-240:]
     if latest_python_interpreter:
         extra["latest_python_interpreter"] = latest_python_interpreter[-240:]
-    if last_terminal_event in {"traceback", "exit_fail"} and runtime_repo_root is not None:
+    if last_terminal_event in {"traceback", "crash", "exit_fail"} and runtime_repo_root is not None:
         extra.update(_runtime_checkout_extra(runtime_repo_root))
     detail = (
         f"tracebacks={tracebacks_total} crashes={crashes_total} "

--- a/aragora/review/health.py
+++ b/aragora/review/health.py
@@ -490,6 +490,8 @@ def _check_boss_loop_log(
                 elif _EXIT_OK_PATTERN.search(line):
                     exits_ok_total += 1
                     last_terminal_event = "exit_ok"
+                    latest_failure = ""
+                    latest_failure_signature = ""
                 elif _EXIT_FAIL_PATTERN.search(line):
                     exits_fail_total += 1
                     last_terminal_event = "exit_fail"

--- a/tests/review/test_health.py
+++ b/tests/review/test_health.py
@@ -577,6 +577,10 @@ class TestBossLoopLogCounter:
         assert bl.extra["exits_ok_total"] == 1
         assert bl.extra["exits_fail_total"] == 1
         assert bl.extra["last_terminal_event"] == "exit_ok"
+        assert "latest_failure" not in bl.extra
+        assert "latest_failure_signature" not in bl.extra
+        assert "latest_failure=" not in str(bl.detail)
+        assert "failure_signature=" not in str(bl.detail)
 
 
 class TestBossMetricsJsonlCounter:

--- a/tests/review/test_health.py
+++ b/tests/review/test_health.py
@@ -495,6 +495,26 @@ class TestBossLoopLogCounter:
         )
         assert "failure_signature=AttributeError" in str(bl.detail)
 
+    def test_bare_crash_line_marks_boss_loop_stale(self, tmp_path: Path) -> None:
+        layout = _setup_proof_loop(tmp_path)
+        log = layout["overnight"] / "boss-loop-launchd.log"
+        log.write_text("AttributeError: 'NoneType' object has no attribute 'ndarray'\n")
+        os.utime(log, (time.time() - 600, time.time() - 600))
+        report = gather_health(
+            repo_root=layout["repo"],
+            review_queue_root=layout["review_queue_root"],
+            overnight_root=layout["overnight"],
+            automation_receipts_root=layout["auto"],
+        )
+        bl = {s.name: s for s in report.surfaces}["boss_loop_log"]
+        assert bl.status == STATUS_STALE
+        assert bl.extra["last_terminal_event"] == "crash"
+        assert (
+            bl.extra["latest_failure_signature"]
+            == "AttributeError: 'NoneType' object has no attribute 'ndarray'"
+        )
+        assert "latest_failure=AttributeError" in str(bl.detail)
+
     def test_failed_exit_reports_stale_runtime_checkout(self, tmp_path: Path) -> None:
         layout = _setup_proof_loop(tmp_path)
         repo = layout["repo"]


### PR DESCRIPTION
## Summary
- clears stale `latest_failure` / `latest_failure_signature` fields when a later boss-loop cycle exits with status 0
- preserves aggregate historical counters so old crashes remain visible without being reported as current actionable failures
- marks a bare exception line as an actionable terminal `crash` when no later clean exit has cleared it
- tightens regression tests for recovered cycles and bare crash lines

## Validation
- `python3 -m pytest -q tests/review/test_health.py`
- `python3 -m aragora.cli.main review-queue health --json | jq '{boss_loop:(.surfaces[] | select(.name=="boss_loop_log")), stale:[.surfaces[] | select(.status=="stale") | .name]}'`\n- `bash scripts/automation_pr_preflight.sh origin/main HEAD`\n- push hooks: pre-commit, changed-file mypy, gitleaks, portability guard\n\n## Live evidence\nAgainst the current boss-loop launchd log, `boss_loop_log` reports `status=fresh`, `last_terminal_event=exit_ok`, and no stale failure signature. The only remaining stale health surface is `briefs`.\n\nCo-authored-by: codex[bot] <codex[bot]@users.noreply.github.com>