### PR TITLE
fix(queue): generate merge-ready prompts

### DIFF
--- a/scripts/build_next_prompt.py
+++ b/scripts/build_next_prompt.py
@@ -820,12 +820,72 @@ def _packet_not_ready(merge_packet: Any) -> list[Any]:
     return not_ready if isinstance(not_ready, list) else []
 
 
+def _packet_not_ready_prs(merge_packet: Any) -> set[int]:
+    prs: set[int] = set()
+    for raw in _packet_not_ready(merge_packet):
+        try:
+            prs.add(int(raw))
+        except (TypeError, ValueError):
+            continue
+    return prs
+
+
 def _packet_authorizes(merge_packet: Any, *, pr: int | None) -> bool:
     entry = _merge_packet_entry(merge_packet, pr)
     if not entry.get("admin_squash_allowed"):
         return False
-    not_ready = _packet_not_ready(merge_packet)
+    not_ready = _packet_not_ready_prs(merge_packet)
     return not not_ready or (pr is not None and pr not in not_ready)
+
+
+def _packet_admin_squash_order(merge_packet: Any) -> list[int]:
+    if not isinstance(merge_packet, dict):
+        return []
+    order: list[int] = []
+    for raw in merge_packet.get("admin_squash_order") or []:
+        try:
+            order.append(int(raw))
+        except (TypeError, ValueError):
+            continue
+    return order
+
+
+def _select_merge_ready_entry(merge_packet: Any, *, pr: int | None = None) -> dict[str, Any]:
+    if not isinstance(merge_packet, dict):
+        return {}
+    target_pr = pr
+    if target_pr is None:
+        order = _packet_admin_squash_order(merge_packet)
+        target_pr = order[0] if order else None
+    return _merge_packet_entry(merge_packet, target_pr)
+
+
+def _merge_ready_prompt_blocker(merge_packet: Any, *, pr: int | None = None) -> str:
+    if not isinstance(merge_packet, dict) or not merge_packet:
+        return "merge-packet is missing or malformed"
+    entry = _select_merge_ready_entry(merge_packet, pr=pr)
+    if not entry:
+        target = f"PR #{pr}" if pr is not None else "admin_squash_order"
+        return f"merge-packet has no ready entry for {target}"
+    try:
+        pr_number = int(entry.get("pr_number"))
+    except (TypeError, ValueError):
+        return "merge-packet ready entry is missing a parseable pr_number"
+    if pr_number in _packet_not_ready_prs(merge_packet):
+        return f"merge-packet still lists PR #{pr_number} as not_ready"
+    if not str(entry.get("head_sha") or entry.get("headRefOid") or ""):
+        return f"merge-packet ready entry for PR #{pr_number} is missing an exact head"
+    if not entry.get("admin_squash_allowed"):
+        return f"merge-packet does not allow admin squash for PR #{pr_number}"
+    if entry.get("requires_human_risk_settlement") or entry.get("requires_human_preapproval"):
+        return f"PR #{pr_number} still requires human risk/preapproval settlement"
+    try:
+        tier = int(entry.get("tier"))
+    except (TypeError, ValueError):
+        tier = 99
+    if tier >= 3:
+        return f"PR #{pr_number} is Tier {tier}, not an autonomous merge-ready prompt target"
+    return ""
 
 
 def _packet_authorization_reason(merge_packet: Any, *, pr: int | None) -> str | None:
@@ -1051,6 +1111,93 @@ def build_post_merge_fast_packet(
         packet["blockers"].append("merged PR still has active target lane")
         packet["selected_action"] = "post_merge_lane_retirement_coordination"
     return packet
+
+
+def build_merge_ready_packet(
+    *,
+    repo_root: Path = DEFAULT_REPO_ROOT,
+    pr: int | None = None,
+    limit: int = 30,
+    command_runner: CommandRunner | None = None,
+) -> dict[str, Any]:
+    """Read a live merge-packet for exact-head merge prompt generation."""
+
+    runner = command_runner or _repo_runner(repo_root)
+    command = [
+        "python3",
+        "-m",
+        "aragora.cli.main",
+        "review-queue",
+        "merge-packet",
+    ]
+    if pr is not None:
+        command.extend(["--pr", str(pr)])
+    else:
+        command.extend(["--limit", str(limit)])
+    command.append("--json")
+    packet = _run_json(command, runner)
+    return (
+        packet if isinstance(packet, dict) else {"error": "merge-packet did not return an object"}
+    )
+
+
+def build_merge_ready_prompt(
+    merge_packet: dict[str, Any],
+    *,
+    repo_root: Path = DEFAULT_REPO_ROOT,
+    pr: int | None = None,
+) -> str:
+    """Build a human-copyable exact-head prompt for one ready Tier 0-2 PR."""
+
+    blocker = _merge_ready_prompt_blocker(merge_packet, pr=pr)
+    entry = _select_merge_ready_entry(merge_packet, pr=pr)
+    if blocker:
+        return "\n".join(
+            [
+                f"Start from live repo truth in {repo_root}. Do not trust prior transcript state.",
+                "",
+                "Goal: stop because no safe merge-ready authorization prompt can be generated from the live merge-packet.",
+                f"Blocker: {blocker}.",
+                "",
+                "Re-check root status, open PR list, and review-queue merge-packet. Do not merge, mark-ready, set statuses, rerun checks, or broaden queue scope from this prompt.",
+                "Final report: exact blocker, packet summary, and the next single bounded target.",
+                CONVERGENCE_SENTENCE,
+                "",
+            ]
+        )
+
+    pr_number = int(entry["pr_number"])
+    head = str(entry.get("head_sha") or entry.get("headRefOid") or "")
+    title = str(entry.get("title") or "")
+    tier = entry.get("tier")
+    checks_summary = str(entry.get("checks_summary") or "unknown")
+    return "\n".join(
+        [
+            f"Start from live repo truth in {repo_root}. Do not trust transcript state. Do not touch shared-root dirt.",
+            "",
+            f"Goal: merge exactly one queue-head PR if live gates still match: PR #{pr_number} at exact head {head}.",
+            f"I authorize normal protected squash merge for PR #{pr_number} at exact head {head}.",
+            "",
+            f"Packet fact to verify, not trust: title={title!r}, tier={tier}, checks={checks_summary}, verdict={entry.get('verdict') or 'unknown'}.",
+            "",
+            "First re-check:",
+            "git status --short --branch --untracked-files=all",
+            f"python3 scripts/read_operator_steering.py --pr {pr_number} --json --no-receipt || true",
+            f"python3 scripts/identify_lane_owner.py --pr {pr_number} --json || true",
+            f"gh pr view {pr_number} --json number,title,state,isDraft,headRefOid,mergeable,mergeStateStatus,url",
+            f"gh pr checks {pr_number} --required",
+            f"python3 -m aragora.cli.main review-queue merge-packet --pr {pr_number} --json",
+            f"python3 scripts/settle_one_pr.py --pr {pr_number} --json",
+            "",
+            f"Proceed only if PR #{pr_number} remains open, non-draft, exact head {head}, MERGEABLE, required checks green, no active conflicting owner, merge-packet is satisfied/admin_squash_allowed, no Tier 3/Tier 4 settlement required, and settle_one has no blockers.",
+            "",
+            f"If safe, merge PR #{pr_number} by normal protected squash with --match-head-commit only. No admin merge, no bypass, no branch protection, no broad-drain, and do not touch unrelated PRs or shared-root dirt.",
+            "",
+            "After merge, verify state, mergedAt, mergeCommit, then re-run review-queue merge-packet --limit 30 --json and report the next single bounded target.",
+            CONVERGENCE_SENTENCE,
+            "",
+        ]
+    )
 
 
 def build_settlement_guard(
@@ -1455,6 +1602,17 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Emit a fail-closed settlement guard prompt populated from live truth.",
     )
+    parser.add_argument(
+        "--merge-ready-prompt",
+        action="store_true",
+        help="Emit a human-copyable exact-head prompt for one live merge-packet ready PR.",
+    )
+    parser.add_argument(
+        "--merge-ready-limit",
+        type=int,
+        default=30,
+        help="Open queue limit used with --merge-ready-prompt when --pr is omitted.",
+    )
     parser.add_argument("--json", action="store_true")
     return parser
 
@@ -1464,6 +1622,29 @@ def main(argv: Sequence[str] | None = None) -> int:
     prompt: str | None = None
     packet: dict[str, Any] | None = None
     guard_prompt: str | None = None
+    if args.merge_ready_prompt:
+        merge_packet = build_merge_ready_packet(
+            repo_root=args.repo_root,
+            pr=args.pr,
+            limit=args.merge_ready_limit,
+        )
+        prompt = build_merge_ready_prompt(merge_packet, repo_root=args.repo_root, pr=args.pr)
+        prompt = _operator_choice_placeholder_guard_prompt(prompt, repo_root=args.repo_root)
+        if args.json:
+            _emit_stdout(
+                json.dumps(
+                    {
+                        "prompt": prompt,
+                        "merge_packet": merge_packet,
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+                + "\n"
+            )
+        else:
+            _emit_stdout(prompt)
+        return 0
     if args.pr is not None:
         fast_packet = build_post_merge_fast_packet(
             registry_path=args.registry_path,

--- a/scripts/build_next_prompt.py
+++ b/scripts/build_next_prompt.py
@@ -838,6 +838,10 @@ def _packet_authorizes(merge_packet: Any, *, pr: int | None) -> bool:
     return not not_ready or (pr is not None and pr not in not_ready)
 
 
+def _prompt_one_line(value: Any) -> str:
+    return " ".join(str(value or "").split())
+
+
 def _packet_admin_squash_order(merge_packet: Any) -> list[int]:
     if not isinstance(merge_packet, dict):
         return []
@@ -1168,7 +1172,7 @@ def build_merge_ready_prompt(
 
     pr_number = int(entry["pr_number"])
     head = str(entry.get("head_sha") or entry.get("headRefOid") or "")
-    title = str(entry.get("title") or "")
+    title = _prompt_one_line(entry.get("title"))
     tier = entry.get("tier")
     checks_summary = str(entry.get("checks_summary") or "unknown")
     return "\n".join(
@@ -1178,7 +1182,7 @@ def build_merge_ready_prompt(
             f"Goal: merge exactly one queue-head PR if live gates still match: PR #{pr_number} at exact head {head}.",
             f"I authorize normal protected squash merge for PR #{pr_number} at exact head {head}.",
             "",
-            f"Packet fact to verify, not trust: title={title!r}, tier={tier}, checks={checks_summary}, verdict={entry.get('verdict') or 'unknown'}.",
+            f"Packet fact to verify, not trust: title={title or 'unknown'}, tier={tier}, checks={checks_summary}, verdict={entry.get('verdict') or 'unknown'}.",
             "",
             "First re-check:",
             "git status --short --branch --untracked-files=all",

--- a/scripts/build_next_prompt.py
+++ b/scripts/build_next_prompt.py
@@ -882,7 +882,7 @@ def _merge_ready_prompt_blocker(merge_packet: Any, *, pr: int | None = None) -> 
     try:
         tier = int(entry.get("tier"))
     except (TypeError, ValueError):
-        tier = 99
+        return f"merge-packet ready entry for PR #{pr_number} is missing a parseable tier"
     if tier >= 3:
         return f"PR #{pr_number} is Tier {tier}, not an autonomous merge-ready prompt target"
     return ""

--- a/tests/scripts/test_build_next_prompt.py
+++ b/tests/scripts/test_build_next_prompt.py
@@ -832,6 +832,36 @@ def test_merge_ready_prompt_fails_closed_for_string_not_ready_entry(tmp_path: Pa
     assert "I authorize normal protected squash merge" not in prompt
 
 
+def test_merge_ready_cli_json_emits_prompt_and_packet(monkeypatch: Any, capsys: Any) -> None:
+    packet = _merge_ready_packet()
+    calls: list[dict[str, Any]] = []
+
+    def fake_build_merge_ready_packet(**kwargs: Any) -> dict[str, Any]:
+        calls.append(kwargs)
+        return packet
+
+    monkeypatch.setattr(
+        prompt_builder,
+        "build_merge_ready_packet",
+        fake_build_merge_ready_packet,
+    )
+
+    result = prompt_builder.main(
+        [
+            "--merge-ready-prompt",
+            "--pr",
+            "7827",
+            "--json",
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert result == 0
+    assert calls[0]["pr"] == 7827
+    assert payload["merge_packet"]["admin_squash_order"] == [7828, 7827]
+    assert "PR #7827 at exact head d5d91763c26bbe31e5938bd30fa837ec586e0f94" in payload["prompt"]
+
+
 def test_decision_packet_detects_merged_pr_with_active_tmux_evidence_lane(
     tmp_path: Path,
 ) -> None:

--- a/tests/scripts/test_build_next_prompt.py
+++ b/tests/scripts/test_build_next_prompt.py
@@ -750,6 +750,88 @@ def test_settlement_guard_prompt_uses_pr_mailbox_when_only_completed_lane_matche
     assert "--lane-id completed-lane" not in prompt
 
 
+def _merge_ready_packet() -> dict[str, Any]:
+    return {
+        "admin_squash_order": [7828, 7827],
+        "not_ready": [],
+        "entries": [
+            {
+                "pr_number": 7828,
+                "title": "fix(review): clear recovered boss-loop failure detail",
+                "head_sha": "9b80ed8dc28d132ce2b2712db4d8ad2492025649",
+                "checks_summary": "63/63 green",
+                "tier": 1,
+                "verdict": "admin_squash_allowed",
+                "status": "satisfied",
+                "admin_squash_allowed": True,
+                "requires_human_risk_settlement": False,
+                "requires_human_preapproval": False,
+            },
+            {
+                "pr_number": 7827,
+                "title": "fix(automation): suppress handoff publisher broken pipes",
+                "head_sha": "d5d91763c26bbe31e5938bd30fa837ec586e0f94",
+                "checks_summary": "60/60 green",
+                "tier": 2,
+                "verdict": "admin_squash_allowed",
+                "status": "satisfied",
+                "admin_squash_allowed": True,
+                "requires_human_risk_settlement": False,
+                "requires_human_preapproval": False,
+            },
+        ],
+    }
+
+
+def test_merge_ready_prompt_selects_first_admin_squash_order(tmp_path: Path) -> None:
+    prompt = prompt_builder.build_merge_ready_prompt(
+        _merge_ready_packet(),
+        repo_root=tmp_path,
+    )
+
+    assert "PR #7828 at exact head 9b80ed8dc28d132ce2b2712db4d8ad2492025649" in prompt
+    assert (
+        "I authorize normal protected squash merge for PR #7828 at exact head "
+        "9b80ed8dc28d132ce2b2712db4d8ad2492025649"
+    ) in prompt
+    assert "python3 scripts/read_operator_steering.py --pr 7828 --json --no-receipt" in prompt
+    assert "gh pr checks 7828 --required" in prompt
+    assert "--match-head-commit only" in prompt
+    assert "No admin merge, no bypass, no branch protection" in prompt
+
+
+def test_merge_ready_prompt_respects_explicit_pr(tmp_path: Path) -> None:
+    prompt = prompt_builder.build_merge_ready_prompt(
+        _merge_ready_packet(),
+        repo_root=tmp_path,
+        pr=7827,
+    )
+
+    assert "PR #7827 at exact head d5d91763c26bbe31e5938bd30fa837ec586e0f94" in prompt
+    assert "PR #7828 at exact head" not in prompt
+
+
+def test_merge_ready_prompt_fails_closed_for_human_settlement(tmp_path: Path) -> None:
+    packet = _merge_ready_packet()
+    packet["entries"][0]["requires_human_risk_settlement"] = True
+
+    prompt = prompt_builder.build_merge_ready_prompt(packet, repo_root=tmp_path)
+
+    assert "no safe merge-ready authorization prompt can be generated" in prompt
+    assert "requires human risk/preapproval settlement" in prompt
+    assert "Do not merge, mark-ready, set statuses, rerun checks, or broaden queue scope" in prompt
+
+
+def test_merge_ready_prompt_fails_closed_for_string_not_ready_entry(tmp_path: Path) -> None:
+    packet = _merge_ready_packet()
+    packet["not_ready"] = ["7828"]
+
+    prompt = prompt_builder.build_merge_ready_prompt(packet, repo_root=tmp_path)
+
+    assert "merge-packet still lists PR #7828 as not_ready" in prompt
+    assert "I authorize normal protected squash merge" not in prompt
+
+
 def test_decision_packet_detects_merged_pr_with_active_tmux_evidence_lane(
     tmp_path: Path,
 ) -> None:

--- a/tests/scripts/test_build_next_prompt.py
+++ b/tests/scripts/test_build_next_prompt.py
@@ -832,6 +832,20 @@ def test_merge_ready_prompt_fails_closed_for_string_not_ready_entry(tmp_path: Pa
     assert "I authorize normal protected squash merge" not in prompt
 
 
+def test_packet_authorizes_blocks_string_not_ready_pr() -> None:
+    packet = {
+        "entries": [
+            {
+                "pr_number": 7828,
+                "admin_squash_allowed": True,
+            }
+        ],
+        "not_ready": ["7828"],
+    }
+
+    assert prompt_builder._packet_authorizes(packet, pr=7828) is False
+
+
 def test_merge_ready_cli_json_emits_prompt_and_packet(monkeypatch: Any, capsys: Any) -> None:
     packet = _merge_ready_packet()
     calls: list[dict[str, Any]] = []


### PR DESCRIPTION
## Summary
- add scripts/build_next_prompt.py --merge-ready-prompt to emit one exact-head, human-copyable merge prompt from live review-queue merge-packet data
- fail closed when the selected PR is not_ready, Tier 3+, missing exact head/tier, or still requires human settlement/preapproval
- harden string/int not_ready handling in _packet_authorizes and cover the CLI JSON branch directly

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/armand/.pyenv/versions/3.11.11/bin/python3 -m pytest -q tests/scripts/test_build_next_prompt.py (33 passed)
- ruff check scripts/build_next_prompt.py tests/scripts/test_build_next_prompt.py
- ruff format --check scripts/build_next_prompt.py tests/scripts/test_build_next_prompt.py
- git diff --check
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- python3 scripts/build_next_prompt.py --merge-ready-prompt --pr 7828 --json
- python3 scripts/build_next_prompt.py --merge-ready-prompt --pr 7779 --json
- python3 -m aragora.cli.main review-queue collect-evidence --pr 7830 --repo synaptent/aragora --reviewers claude grok --apply --json
- gh pr checks 7830 --required
- python3 -m aragora.cli.main review-queue merge-packet --pr 7830 --json
- python3 scripts/settle_one_pr.py --pr 7830 --json

## Final live state
- exact head: 0212ba03a6f68c67ec43dddeda291d55470f8d24
- Tier 2, non-draft, required checks green
- counted evidence: Claude + Grok PASS comments posted
- merge-packet: satisfied/admin_squash_allowed
- settle_one_pr.py: packet_authorized_dry_run, blockers=[]
