### PR TITLE
fix(review-queue): bound gh readiness probes

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -204,6 +204,8 @@ MERGE_QUORUM_WORKFLOW_NAME = "Aragora Merge Quorum"
 MERGE_QUORUM_JOB_ID = "merge-quorum"
 CHECK_SURFACE_DIAGNOSTIC_LIMIT = 12
 OPTIONAL_RUNNER_CAPACITY_NOISE_MIN_SECONDS = 60 * 60
+GH_COMMAND_TIMEOUT_SECONDS = 30
+GIT_STATUS_TIMEOUT_SECONDS = 10
 
 LANE_ORDER: dict[str, int] = {
     "ready_now": 0,
@@ -1399,14 +1401,25 @@ class _GhError(RuntimeError):
     """Raised when a 'gh' invocation fails or returns malformed JSON."""
 
 
+def _command_timeout_message(cmd: list[str], timeout_seconds: int) -> str:
+    return f"{' '.join(cmd)} timed out after {timeout_seconds}s"
+
+
 def _gh_text(args: list[str]) -> str:
     """Run a 'gh' command and return plain stdout."""
-    proc = subprocess.run(
-        ["gh", *args],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    cmd = ["gh", *args]
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=GH_COMMAND_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise _GhError(
+            _command_timeout_message(cmd, int(exc.timeout or GH_COMMAND_TIMEOUT_SECONDS))
+        ) from exc
     if proc.returncode != 0:
         stderr = proc.stderr.strip() or "no stderr"
         raise _GhError(f"gh {' '.join(args)} failed: {stderr}")
@@ -1415,12 +1428,19 @@ def _gh_text(args: list[str]) -> str:
 
 def _gh_json(args: list[str]) -> Any:
     """Run a 'gh' command and parse JSON output. Returns None for empty stdout."""
-    proc = subprocess.run(
-        ["gh", *args],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    cmd = ["gh", *args]
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=GH_COMMAND_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise _GhError(
+            _command_timeout_message(cmd, int(exc.timeout or GH_COMMAND_TIMEOUT_SECONDS))
+        ) from exc
     if proc.returncode != 0:
         stderr = proc.stderr.strip() or "no stderr"
         raise _GhError(f"gh {' '.join(args)} failed: {stderr}")
@@ -4256,13 +4276,21 @@ def _write_json(path: Path, payload: Any) -> None:
 
 
 def _require_clean_worktree(repo_root: Path) -> None:
-    proc = subprocess.run(
-        ["git", "status", "--porcelain"],
-        cwd=repo_root,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    cmd = ["git", "status", "--porcelain"]
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=GIT_STATUS_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise _GhError(
+            f"git status timed out after {int(exc.timeout or GIT_STATUS_TIMEOUT_SECONDS)}s "
+            f"in {repo_root}"
+        ) from exc
     if proc.returncode != 0:
         stderr = proc.stderr.strip() or "no stderr"
         raise _GhError(f"git status failed in {repo_root}: {stderr}")

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import io
 import json
+import subprocess
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from typing import Any
@@ -29,6 +30,7 @@ from aragora.cli.commands.review_queue import (
     _effective_required_pr_check_count,
     _filter_lanes,
     _GhError,
+    _gh_json,
     _is_high_risk_path,
     _is_merge_quorum_check,
     _parse_pr_number,
@@ -2361,6 +2363,23 @@ class TestValidationExtraction:
             "`python3 -m pytest tests/cli/commands/test_review_queue.py -q`",
             "`bash scripts/automation_pr_preflight.sh origin/main HEAD`",
         ]
+
+
+class TestGhTimeouts:
+    def test_gh_json_fails_closed_on_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: dict[str, Any] = {}
+
+        def fake_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs.get("timeout"))
+
+        monkeypatch.setattr("aragora.cli.commands.review_queue.subprocess.run", fake_run)
+
+        with pytest.raises(_GhError, match=r"gh pr view 7811 timed out after \d+s"):
+            _gh_json(["pr", "view", "7811"])
+
+        assert captured["kwargs"]["timeout"] > 0
 
 
 # --- _build_queue + _build_packet (with mocked gh) -------------------------


### PR DESCRIPTION
## Summary
- Bound review-queue GitHub CLI JSON/text probes with a 30s timeout so readiness helpers fail closed instead of hanging.
- Bound the settlement clean-worktree git status probe with a 10s timeout and diagnostic error.
- Add focused timeout coverage while keeping the diff limited to review_queue.py and its CLI tests.

## Deduplication check
- #7738 is still open/draft and overlaps the gh helper timeout surface, but it is an older branch and does not clearly supersede this current-main branch because this branch also covers the clean-worktree git status probe.
- This PR is intentionally draft until the queue decides whether to prefer this current-base branch or #7738.

## Scope
- Exact head: 249ce1b3196d22da96703bc8169c92b7dcf78feb
- Files: aragora/cli/commands/review_queue.py; tests/cli/commands/test_review_queue.py

## Validation
- git diff --check origin/main...HEAD
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/cli/commands/test_review_queue.py::TestGhTimeouts::test_gh_json_fails_closed_on_timeout tests/cli/commands/test_review_queue.py::TestBuildQueueAndPacket::test_merge_packet_explicit_pr_refs_do_not_hydrate_open_queue tests/cli/commands/test_review_queue.py::TestSettlementHelpers::test_merge_packet_json_output_with_queue_pressure