### PR TITLE
fix(steering): route blocked owner lanes

### DIFF
--- a/scripts/send_operator_steering.py
+++ b/scripts/send_operator_steering.py
@@ -54,7 +54,17 @@ SCHEMA_VERSION = "aragora-operator-steering/1.0"
 SUBJECT_MAX_CHARS = 80
 PRIORITY_CHOICES = ("low", "normal", "high", "blocking")
 SHORT_UUID_BYTES = 4  # 8 hex chars; collision risk negligible per-second
-ACTIVE_STATUSES = {"active", "running", "pending", "queued", "claimed"}
+ACTIVE_STATUSES = {
+    "active",
+    "running",
+    "pending",
+    "queued",
+    "claimed",
+    "waiting_for_steering",
+    "acknowledged",
+    "working",
+    "blocked",
+}
 FAMILY_SESSION_MARKERS = (
     "aider",
     "claude",

--- a/tests/scripts/test_send_operator_steering.py
+++ b/tests/scripts/test_send_operator_steering.py
@@ -764,6 +764,85 @@ class TestActiveOwnerRouting:
         assert diagnostic["historical_related_sessions"] == []
         assert list((tmp_path / "inbox").rglob("*.json")) == []
 
+    def test_diagnose_target_treats_blocked_owner_as_active(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        registry = self._write_lanes(
+            tmp_path,
+            [
+                {
+                    "lane_id": "q388-publication",
+                    "owner_session": "codex-q388",
+                    "status": "blocked",
+                    "branch": "codex/q388",
+                    "updated_at": "2026-06-06T16:17:35Z",
+                }
+            ],
+        )
+
+        rc = sos.main(
+            [
+                "--to-owner-branch",
+                "codex/q388",
+                "--diagnose-target",
+                "--json",
+                "--lane-registry-path",
+                str(registry),
+                "--steering-inbox-root",
+                str(tmp_path / "inbox"),
+            ]
+        )
+
+        assert rc == 0
+        parsed = json.loads(capsys.readouterr().out)
+        diagnostic = parsed["_target_diagnostic"]
+        assert diagnostic["active_owner_found"] is True
+        assert diagnostic["safe_to_send"] is True
+        assert diagnostic["reason"] == "active_owner_found"
+        assert diagnostic["active_owner"]["owner_session"] == "codex-q388"
+        assert diagnostic["historical_related_sessions"] == []
+        assert list((tmp_path / "inbox").rglob("*.json")) == []
+
+    def test_dry_run_to_owner_branch_treats_blocked_owner_as_active(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        registry = self._write_lanes(
+            tmp_path,
+            [
+                {
+                    "lane_id": "q388-publication",
+                    "owner_session": "codex-q388",
+                    "status": "blocked",
+                    "branch": "codex/q388",
+                    "updated_at": "2026-06-06T16:17:35Z",
+                }
+            ],
+        )
+
+        rc = sos.main(
+            [
+                "--to-owner-branch",
+                "codex/q388",
+                "--body",
+                "finish publication or release",
+                "--dry-run",
+                "--json",
+                "--lane-registry-path",
+                str(registry),
+                "--steering-inbox-root",
+                str(tmp_path / "inbox"),
+            ]
+        )
+
+        assert rc == 0
+        parsed = json.loads(capsys.readouterr().out)
+        assert parsed["_dry_run"] is True
+        assert parsed["_would_write"] is True
+        assert parsed["_written_path"] is None
+        assert parsed["_route"]["owner_session"] == "codex-q388"
+        assert parsed["_route"]["status"] == "blocked"
+        assert list((tmp_path / "inbox").rglob("*.json")) == []
+
     def test_diagnose_target_without_selector_returns_parse_error(
         self, capsys: pytest.CaptureFixture[str]
     ) -> None:


### PR DESCRIPTION
## Summary
- Treat `blocked` lane rows as active owner targets in `send_operator_steering.py`, matching `agent_bridge.py owner`.
- Add regression coverage for `--diagnose-target` and dry-run `--to-owner-branch` routing against blocked owner lanes.

## Why
The harvest queue currently has publication handoffs where `agent_bridge.py owner` reports an active blocked owner, but `send_operator_steering.py --to-owner-branch` classifies the same row as historical/no-active-owner. That prevents safe owner coordination and encourages duplicate publication attempts. This patch lets operators steer blocked owner lanes to finish or release themselves.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_send_operator_steering.py -q -p no:cacheprovider`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/send_operator_steering.py tests/scripts/test_send_operator_steering.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/send_operator_steering.py tests/scripts/test_send_operator_steering.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m py_compile scripts/send_operator_steering.py`
- `git diff --check origin/main...HEAD`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Live smoke
After the patch, this resolves Q388 as a safe blocked owner route when pointed at the shared registry and steering root:

`/Users/armand/.pyenv/versions/3.11.11/bin/python scripts/send_operator_steering.py --to-owner-branch codex/read-steering-summary-only-primary-20260606 --lane-registry-path /Users/armand/Development/aragora/.aragora/agent-bridge/lanes.json --steering-inbox-root /Users/armand/Development/aragora/.aragora/operator-steering --diagnose-target --json`
