### PR TITLE
feat(review-queue): recognize droid as a Factory router surface (Tier 4)

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -97,7 +97,14 @@ DIRECT_MODEL_FAMILY_MARKERS: dict[str, tuple[str, ...]] = {
     "minimax": ("minimax",),
     "hermes": ("hermes", "nous hermes"),
 }
-ROUTER_SURFACE_REVIEWERS: frozenset[str] = frozenset(("factory", "codex", "tesla", "harvey"))
+# Harness/product surfaces that route to an underlying model rather than being a
+# model family themselves. They never count as a family on their own; they count
+# only via a disclosed ``**Model family:**`` line (see _resolve_model_review_identity).
+# ``factory`` and ``droid`` are the same Factory harness (DroidTransport is
+# registered under both names), so they are treated identically.
+ROUTER_SURFACE_REVIEWERS: frozenset[str] = frozenset(
+    ("factory", "droid", "codex", "tesla", "harvey")
+)
 IDENTITY_COUNT_BLOCKERS: frozenset[str] = frozenset(
     (
         "missing_model_family_disclosure",
@@ -3657,7 +3664,7 @@ def _first_heading_candidate(text: str) -> tuple[str, int | None]:
 
 def _infer_surface_reviewer_from_candidate(candidate: str) -> str:
     lower = str(candidate or "").lower()
-    for name in ("claude", "codex", "tesla", "harvey", "factory", "grok", "gemini"):
+    for name in ("claude", "codex", "tesla", "harvey", "factory", "droid", "grok", "gemini"):
         if name in lower:
             return name
     for family, markers in DIRECT_MODEL_FAMILY_MARKERS.items():

--- a/docs/specs/ADVISORY_REVIEW_RECOGNIZABLE_HEADER.md
+++ b/docs/specs/ADVISORY_REVIEW_RECOGNIZABLE_HEADER.md
@@ -12,11 +12,11 @@ pre-approval artifact required by
 `aragora/cli/commands/review_queue.py`. Today the comment recognizer
 infers a reviewer from the first markdown heading and counts the
 surface marker it finds: `claude`, `codex`, `tesla`, `harvey`,
-`factory`, `grok`, or `gemini`.
+`factory`, `droid`, `grok`, or `gemini`.
 
-That is not enough for router-style tools. `Factory`, `Codex`, `Tesla`,
-and `Harvey` are harness/product identities, not necessarily underlying
-model lineages. A comment headed `## Factory independent semantic
+That is not enough for router-style tools. `Factory`/`Droid`, `Codex`,
+`Tesla`, and `Harvey` are harness/product identities, not necessarily
+underlying model lineages. A comment headed `## Factory independent semantic
 review...` may disclose `Factory Droid (GPT-5.5)` in the body, but the
 merge packet only records `factory`. A second comment headed
 `## Codex independent semantic review...` then counts as `codex`, even
@@ -54,10 +54,12 @@ The canonical counted `model_family` IDs are:
 
 Rules:
 
-1. Router/product surface markers (`factory`, `codex`, `tesla`,
+1. Router/product surface markers (`factory`, `droid`, `codex`, `tesla`,
    `harvey`) are not counted families by themselves. They count only
    when the structured `**Model family:** ...` line resolves to a
-   canonical model family.
+   canonical model family. `factory` and `droid` are the same Factory
+   harness (`DroidTransport` is registered under both names) and are
+   treated identically.
 2. Direct family headings (`## Claude ...`, `## Gemini ...`,
    `## Grok ...`, `## OpenAI ...`) may self-map to their model family
    when no explicit `Model family` line is present.
@@ -163,3 +165,41 @@ lineage-bound implementation PR described above. It does not authorize
 merge of the implementation PR. That future PR remains Tier 4 and
 requires exact-head model evidence plus explicit operator settlement
 before merge.
+
+## Addendum: `droid` router-surface parity
+
+**Status:** Tier 4 merge-authority change. The lineage-bound counting
+contract above is now implemented on `main`
+(`ROUTER_SURFACE_REVIEWERS`, `_resolve_model_review_identity`,
+`counted_model_families`). This addendum extends that landed design with
+a single missing alias and is prepared for exact-head operator
+settlement — it is **not** self-merged.
+
+**Gap:** `factory` is a recognized router surface, but its own CLI name
+`droid` was not. `DroidTransport` is registered under both `droid` and
+`factory` (`aragora/swarm/agent_bridge/harnesses/__init__.py`), so they
+are the same Factory harness. Yet a review headed
+`## Droid independent semantic review on head <sha>` resolved to
+`unknown_model_reviewer` and was fail-closed out of the quorum even when
+it disclosed a valid `**Model family:**` — while the identical comment
+headed `## Factory ...` counted. That is an inconsistency, not a policy.
+
+**Change:** add `droid` to the heading recognizer
+(`_infer_surface_reviewer_from_candidate`) and to
+`ROUTER_SURFACE_REVIEWERS`, so `droid` is treated exactly like
+`factory`:
+
+- `droid` is **never** a counted family by itself, and is **not** mapped
+  to any fixed model family (Factory/Droid can pin GPT, Claude, Gemini,
+  Kimi, etc.).
+- A `droid` review counts **only** via a disclosed canonical
+  `**Model family:**` line; missing/unknown disclosure stays advisory
+  (`missing_model_family_disclosure` / `unknown_model_family`).
+- Anti-laundering is preserved: `Droid(openai)` + `Factory(openai)`
+  dedupe to a single `openai` family; `Droid(openai)` + `Claude` count
+  as two (`openai`, `claude`).
+
+No new model family is added; `CANONICAL_MODEL_FAMILIES` is unchanged.
+This addendum + `tests/governance/test_model_lineage_disclosure_recognizer.py`
+are the pre-approval/characterization artifact. Merge still requires
+exact-head model evidence and explicit operator settlement.

--- a/tests/governance/test_advisory_review_recognizable_header.py
+++ b/tests/governance/test_advisory_review_recognizable_header.py
@@ -85,6 +85,40 @@ def test_codex_without_model_family_is_advisory_only() -> None:
     assert "missing_model_family_disclosure" in signal["identity_problems"]
 
 
+def test_droid_without_model_family_is_advisory_only() -> None:
+    """Droid is the same Factory harness and must disclose model lineage."""
+    body = _review_body("Droid")
+
+    assert _infer_model_reviewer_from_text(body) == "droid"
+    assert _counted_from_bodies(body) == []
+    signal = _signals_from_bodies(body)[0]
+    assert signal["surface_reviewer_id"] == "droid"
+    assert "missing_model_family_disclosure" in signal["identity_problems"]
+
+
+def test_droid_openai_disclosure_counts_by_model_family() -> None:
+    """A Droid review counts via its disclosed underlying family, not 'droid'."""
+    body = _review_body("Droid", model_family="openai", model_id="gpt-5.5")
+
+    assert _counted_from_bodies(body) == ["openai"]
+
+
+def test_droid_and_factory_openai_count_as_one_model_family() -> None:
+    """Two names for the same Factory harness disclosing one family count once."""
+    droid = _review_body("Droid", model_family="openai", model_id="gpt-5.5")
+    factory = _review_body("Factory", model_family="openai", model_id="gpt-5.5")
+
+    assert _counted_from_bodies(droid, factory) == ["openai"]
+
+
+def test_droid_openai_and_claude_count_as_two_model_families() -> None:
+    """Droid pinning a distinct lineage adds heterogeneity by family."""
+    droid = _review_body("Droid", model_family="openai", model_id="gpt-5.5")
+    claude = _review_body("Claude", model_family="claude", model_id="claude-opus-4-7")
+
+    assert _counted_from_bodies(droid, claude) == ["claude", "openai"]
+
+
 def test_factory_and_codex_openai_disclosures_count_as_one_model_family() -> None:
     """Two router comments disclosing the same family count once."""
     factory = _review_body("Factory", model_family="openai", model_id="gpt-5.5")

--- a/tests/governance/test_model_lineage_disclosure_recognizer.py
+++ b/tests/governance/test_model_lineage_disclosure_recognizer.py
@@ -113,3 +113,65 @@ def test_later_heading_metadata_does_not_override_first_heading() -> None:
     assert identity.surface_reviewer_id == "factory"
     assert identity.model_family == ""
     assert "missing_model_family_disclosure" in identity.identity_problems
+
+
+def _droid_body(
+    heading: str,
+    *,
+    model_family: str | None = None,
+    model_id: str = "gpt-5.5",
+    receipt: str | None = "/tmp/review.md",
+) -> str:
+    text = f"## {heading}\n\n"
+    text += "**Reviewer harness:** droid\n"
+    if model_family is not None:
+        text += f"**Model family:** {model_family}\n"
+    text += f"**Model id:** {model_id}\n"
+    if receipt is not None:
+        text += f"**Receipt artifact:** {receipt}\n"
+    text += "\nNo blocking findings.\n"
+    return text
+
+
+def test_droid_router_heading_requires_model_family_disclosure() -> None:
+    # ``droid`` is the same Factory harness as ``factory`` and must disclose
+    # an underlying model family to count.
+    identity = _resolve_model_review_identity(_droid_body("Droid focused dogfood"))
+
+    assert identity.surface_reviewer_id == "droid"
+    assert identity.model_family == ""
+    assert "missing_model_family_disclosure" in identity.identity_problems
+
+
+def test_droid_router_heading_with_canonical_family_counts_by_model_family() -> None:
+    identity = _resolve_model_review_identity(
+        _droid_body("Droid focused dogfood", model_family="gemini", model_id="gemini-3.1-pro")
+    )
+
+    assert identity.surface_reviewer_id == "droid"
+    assert identity.model_family == "gemini"
+    assert identity.identity_source == "model_family_metadata"
+
+
+def test_droid_is_not_bound_to_any_fixed_model_family() -> None:
+    # Factory/Droid is a harness/router, not a model lineage: the same surface
+    # counts as whatever model it discloses -- never a hard-coded family.
+    openai_identity = _resolve_model_review_identity(
+        _droid_body("Droid review", model_family="openai")
+    )
+    claude_identity = _resolve_model_review_identity(
+        _droid_body("Droid review", model_family="claude", model_id="claude-opus-4-7")
+    )
+
+    assert openai_identity.model_family == "openai"
+    assert claude_identity.model_family == "claude"
+
+
+def test_droid_unknown_model_family_is_reported() -> None:
+    identity = _resolve_model_review_identity(
+        _droid_body("Droid independent semantic review", model_family="not-a-family")
+    )
+
+    assert identity.surface_reviewer_id == "droid"
+    assert identity.model_family == ""
+    assert "unknown_model_family" in identity.identity_problems


### PR DESCRIPTION
## Summary

Recognize **`droid`** as a Factory **router surface** in the lineage-bound model-review quorum, exactly like `factory`. This closes a recognizer inconsistency, not a policy change: `factory` and `droid` are the **same Factory harness** (`DroidTransport` is registered under both names in `aragora/swarm/agent_bridge/harnesses/__init__.py`), yet only `factory` was recognized.

### The gap
The quorum counts a router/product surface (`factory`, `codex`, `tesla`, `harvey`) **only** via a disclosed canonical `**Model family:**` line — the surface name itself is never a counted family (`docs/specs/ADVISORY_REVIEW_RECOGNIZABLE_HEADER.md`, `_resolve_model_review_identity`). But `droid` was absent from both the heading recognizer and `ROUTER_SURFACE_REVIEWERS`, so a review headed `## Droid independent semantic review on head <sha>` resolved to `unknown_model_reviewer` and was fail-closed out of the quorum **even when it disclosed a valid model family** — while the identical `## Factory …` comment counted.

### The change
Add `droid` to `_infer_surface_reviewer_from_candidate` and `ROUTER_SURFACE_REVIEWERS` (two one-token additions + a clarifying comment). `droid` is then handled identically to `factory`:
- **never** a counted family by itself, and **not** mapped to any fixed model family — Factory/Droid can pin GPT, Claude, Gemini, Kimi, etc. (the underlying disclosed `Model family:` is the sole counted identity);
- counts **only** via a disclosed canonical `Model family:`; missing/unknown disclosure stays advisory (`missing_model_family_disclosure` / `unknown_model_family`);
- **anti-laundering preserved**: `Droid(openai)` + `Factory(openai)` dedupe to a single `openai`; `Droid(openai)` + `Claude` count as two.

No new model family is added; `CANONICAL_MODEL_FAMILIES` is unchanged.

## Why (the correction this encodes)
Factory is an **independent harness/router company**, not a model lineage. So neither `factory` nor `droid` may ever be a counted family or be hard-mapped to `openai` (or any family). This PR keeps the counted identity bound strictly to the **disclosed underlying model family**.

## Validation
- `pytest tests/governance/test_model_lineage_disclosure_recognizer.py tests/governance/test_advisory_review_recognizable_header.py tests/cli/commands/test_review_queue.py` → **250 passed** (9 new droid tests: identity-level + end-to-end counting/dedupe).
- `pre-commit run --files <changed>` → all hooks pass.

## Tier 4 — settlement required (do NOT auto-merge)
This changes which evidence satisfies the model-quorum gate (merge-authority self-modification per `docs/REVIEW_AUTHORITY_PRINCIPLES.md`). Prepared for **exact-head operator settlement**; not self-merged. Rollback tag `elves/pre-droid-router-surface`. Founder root untouched; all work in an isolated worktree at `origin/main` (`dd892d6868`).

Settlement helper:
`python3 scripts/settle_tier4_pr.py --check --pr <N> --head 9cc6441f0e89...`
