### PR TITLE
test(policy): refresh required-check priority fixture

### DIFF
--- a/tests/scripts/test_check_required_check_priority_policy.py
+++ b/tests/scripts/test_check_required_check_priority_policy.py
@@ -18,6 +18,7 @@ jobs:
         with:
           script: |
             const alwaysKeepWorkflowPaths = new Set([
+              '.github/workflows/aragora-merge-quorum.yml',
               '.github/workflows/aragora-review-gate.yml',
               '.github/workflows/autopilot-worktree-e2e.yml',
               '.github/workflows/build.yml',
@@ -40,6 +41,7 @@ jobs:
               '.github/workflows/required-check-priority.yml',
             ]);
             const alwaysKeepWorkflowNames = new Set([
+              'Aragora Merge Quorum',
               'Aragora Code Review',
               'Autopilot Worktree E2E',
               'Build Documentation (PR Check)',
@@ -117,6 +119,10 @@ def test_policy_detects_missing_context_marker_in_mapped_workflow(tmp_path: Path
     wf_dir = repo_root / ".github" / "workflows"
     wf_dir.mkdir(parents=True)
 
+    (wf_dir / "aragora-merge-quorum.yml").write_text(
+        "name: Aragora Merge Quorum\njobs:\n  aragora-merge-quorum:\n    runs-on: ubuntu-latest\n",
+        encoding="utf-8",
+    )
     (wf_dir / "lint.yml").write_text(
         "name: Lint\njobs:\n  lint:\n    runs-on: ubuntu-latest\n", encoding="utf-8"
     )
@@ -205,6 +211,7 @@ jobs:
         with:
           script: |
             const alwaysKeepWorkflowPaths = new Set([
+              '.github/workflows/aragora-merge-quorum.yml',
               '.github/workflows/aragora-review-gate.yml',
               '.github/workflows/autopilot-worktree-e2e.yml',
               '.github/workflows/build.yml',
@@ -227,6 +234,7 @@ jobs:
               '.github/workflows/smoke-offline.yml',
             ]);
             const alwaysKeepWorkflowNames = new Set([
+              'Aragora Merge Quorum',
               'Aragora Code Review',
               'Autopilot Worktree E2E',
               'Build Documentation (PR Check)',


### PR DESCRIPTION
Harvested unique unrepresented work from local branch codex/required-check-priority-policy-test-fix-20260606 at 16978565bcbe776516c18dbe1d0130d1ae9a0e8b. Updates the required-check priority policy fixture so Aragora Merge Quorum stays in the always-keep workflow path/name sets. Validation: python3 -m pytest -q tests/scripts/test_check_required_check_priority_policy.py; pre-commit and pre-push hooks passed.