### PR TITLE
fix(agent-bridge): add compact health summaries

### DIFF
--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -1794,8 +1794,27 @@ def cmd_processes(args: argparse.Namespace) -> int:
     return 0
 
 
+def _health_summary_payload(
+    issues: list[dict[str, str]], *, example_limit: int = 3
+) -> dict[str, Any]:
+    issue_type_counts: dict[str, int] = {}
+    for issue in issues:
+        issue_type = str(issue.get("type") or "unknown")
+        issue_type_counts[issue_type] = issue_type_counts.get(issue_type, 0) + 1
+    examples = issues[: max(0, example_limit)]
+    return {
+        "ok": len(issues) == 0,
+        "issue_count": len(issues),
+        "issue_type_counts": dict(sorted(issue_type_counts.items())),
+        "issue_examples": examples,
+        "issues_omitted": max(0, len(issues) - len(examples)),
+        "details_omitted": True,
+    }
+
+
 def cmd_health(args: argparse.Namespace) -> int:
     """Report stale worktrees, ambiguous lane ownership, and dead sessions."""
+    summary_only = bool(getattr(args, "summary_only", False))
     sessions, _broker_runs, _active_broker_ids = _discover_with_broker_state()
     _enrich_prs(sessions)
     records = _sync_lane_records(_load_lane_registry(), sessions)
@@ -1828,8 +1847,22 @@ def cmd_health(args: argparse.Namespace) -> int:
         pass
 
     if args.json:
+        if summary_only:
+            print(json.dumps(_health_summary_payload(issues), indent=2))
+            return 0 if not issues else 1
         print(json.dumps({"ok": len(issues) == 0, "issues": issues}, indent=2))
         return 0 if not issues else 1
+
+    if summary_only:
+        payload = _health_summary_payload(issues)
+        if not issues:
+            print("Health OK: 0 issue(s).")
+            return 0
+        issue_counts = ", ".join(
+            f"{issue_type}={count}" for issue_type, count in payload["issue_type_counts"].items()
+        )
+        print(f"Health has {payload['issue_count']} issue(s): {issue_counts}")
+        return 1
 
     if not issues:
         print("Health OK: no stale worktrees, no lane conflicts.")
@@ -2733,6 +2766,10 @@ def main() -> int:
     sub.add_parser("tmux-map", parents=[json_parent], help="Show tmux panes")
     sub.add_parser(
         "health", parents=[json_parent], help="Check for stale worktrees and lane conflicts"
+    ).add_argument(
+        "--summary-only",
+        action="store_true",
+        help="Emit compact health counts and bounded examples for automation probes.",
     )
     gc_p = sub.add_parser(
         "gc",

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -2414,6 +2414,105 @@ def test_health_ignores_dead_session_with_removed_worktree(
     assert json.loads(capsys.readouterr().out) == {"ok": True, "issues": []}
 
 
+def test_cmd_health_summary_only_json_counts_issue_types(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import agent_bridge as mod
+
+    _patch_bridge_paths(mod, tmp_path, monkeypatch)
+    root = tmp_path / "repo"
+    missing_worktree = tmp_path / "missing-worktree"
+    root.mkdir()
+    monkeypatch.setattr(mod, "CANONICAL_REPO_ROOT", root)
+    monkeypatch.setattr(
+        mod,
+        "discover",
+        lambda: [
+            mod.Session(
+                name="codex-active",
+                agent="codex",
+                status="alive",
+                worktree=str(missing_worktree),
+            )
+        ],
+    )
+    monkeypatch.setattr(mod, "_enrich_prs", lambda _sessions: None)
+    monkeypatch.setattr(
+        mod,
+        "_load_lane_registry",
+        lambda: [
+            mod.LaneRecord(
+                lane_id="Q390-health",
+                owner_session="codex-active",
+                status="active",
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        mod.subprocess,
+        "run",
+        lambda *args, **kwargs: argparse.Namespace(returncode=1, stdout="", stderr=""),
+    )
+
+    rc = mod.cmd_health(argparse.Namespace(json=True, summary_only=True))
+
+    assert rc == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {
+        "ok": False,
+        "issue_count": 4,
+        "issue_type_counts": {
+            "lane_missing_heartbeat": 1,
+            "lane_missing_next_action": 1,
+            "lane_missing_steering_outcome": 1,
+            "stale_worktree": 1,
+        },
+        "issue_examples": payload["issue_examples"],
+        "issues_omitted": 1,
+        "details_omitted": True,
+    }
+    assert len(payload["issue_examples"]) == 3
+    assert "issues" not in payload
+
+
+def test_main_accepts_health_summary_only_after_subcommand(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import agent_bridge as mod
+
+    _patch_bridge_paths(mod, tmp_path, monkeypatch)
+    root = tmp_path / "repo"
+    root.mkdir()
+    monkeypatch.setattr(mod, "CANONICAL_REPO_ROOT", root)
+    monkeypatch.setattr(mod, "discover", lambda: [])
+    monkeypatch.setattr(mod, "_enrich_prs", lambda _sessions: None)
+    monkeypatch.setattr(mod, "_load_lane_registry", lambda: [])
+    monkeypatch.setattr(
+        mod.subprocess,
+        "run",
+        lambda *args, **kwargs: argparse.Namespace(returncode=1, stdout="", stderr=""),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["agent_bridge.py", "health", "--json", "--summary-only"],
+    )
+
+    assert mod.main() == 0
+    assert json.loads(capsys.readouterr().out) == {
+        "ok": True,
+        "issue_count": 0,
+        "issue_type_counts": {},
+        "issue_examples": [],
+        "issues_omitted": 0,
+        "details_omitted": True,
+    }
+
+
 def test_health_ignores_orphan_claude_transcript_missing_worktree(tmp_path: Path) -> None:
     import agent_bridge as mod
 


### PR DESCRIPTION
## Summary
- harvest Q390 blocked unique work into a current-main branch
- add agent_bridge.py health --summary-only for bounded automation probes
- include compact JSON/text summaries with issue counts, type counts, bounded examples, and omitted detail markers

## Source
- harvested from codex/agent-bridge-health-summary-only-improver-20260606 at ab1371e711c398a181510d567ea98aa1e1f25f0f

## Validation
- python3 -m pytest -q tests/scripts/test_agent_bridge.py
- pre-commit hooks during commit
- pre-push hooks during push