### PR TITLE
fix(agent-bridge): surface boss-loop liveness detail

### DIFF
--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -2187,13 +2187,43 @@ def _operator_queue_depth(summary: dict[str, Any], pending_steering: dict[str, A
     )
 
 
+def _operator_summary_int(summary: dict[str, Any], key: str) -> int:
+    try:
+        return max(0, int(summary.get(key, 0)))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _operator_boss_loop_status(summary: dict[str, Any]) -> dict[str, Any]:
+    """Explain the legacy boss-loop liveness boolean in operator snapshots."""
+
+    active_roles = sorted(str(role) for role in summary.get("active_process_roles", []))
+    active_role_set = set(active_roles)
+    active_broker_runs = _operator_summary_int(summary, "active_broker_runs")
+    fresh_agent_heartbeats = _operator_summary_int(summary, "fresh_agent_heartbeats")
+    has_boss_cycle_process = "boss_cycle" in active_role_set
+
+    if active_broker_runs:
+        reason = "active_broker_runs"
+    elif fresh_agent_heartbeats:
+        reason = "fresh_agent_heartbeats"
+    elif has_boss_cycle_process:
+        reason = "boss_cycle_process"
+    else:
+        reason = "idle_no_live_boss_loop_signal"
+
+    return {
+        "alive": bool(active_broker_runs or fresh_agent_heartbeats or has_boss_cycle_process),
+        "reason": reason,
+        "active_broker_runs": active_broker_runs,
+        "fresh_agent_heartbeats": fresh_agent_heartbeats,
+        "has_boss_cycle_process": has_boss_cycle_process,
+        "active_process_roles": active_roles,
+    }
+
+
 def _operator_boss_loop_alive(summary: dict[str, Any]) -> bool:
-    active_roles = set(summary.get("active_process_roles", []))
-    return bool(
-        int(summary.get("active_broker_runs", 0))
-        or int(summary.get("fresh_agent_heartbeats", 0))
-        or "boss_cycle" in active_roles
-    )
+    return bool(_operator_boss_loop_status(summary)["alive"])
 
 
 def _operator_recent_blockers(
@@ -2375,6 +2405,7 @@ def cmd_operator_snapshot(args: argparse.Namespace) -> int:
         "fresh_agent_heartbeats": int(agent_heartbeats.get("fresh_count", 0)),
     }
 
+    boss_loop_status = _operator_boss_loop_status(summary)
     snapshot: dict[str, Any] = {
         "timestamp": _now_iso(),
         "sessions": [s.to_dict() for s in sessions],
@@ -2388,7 +2419,8 @@ def cmd_operator_snapshot(args: argparse.Namespace) -> int:
         "queue_depth": _operator_queue_depth(summary, pending_steering),
         "success_rate": _collect_b0_success_rate(),
         "recent_blockers": _operator_recent_blockers(issues, pending_steering),
-        "boss_loop_alive": _operator_boss_loop_alive(summary),
+        "boss_loop_alive": bool(boss_loop_status["alive"]),
+        "boss_loop_status": boss_loop_status,
         "summary": summary,
     }
     if summary_only:
@@ -2412,6 +2444,8 @@ def cmd_operator_snapshot(args: argparse.Namespace) -> int:
     active_process_roles = [str(role) for role in summary.get("active_process_roles", [])]
     process_roles = ", ".join(active_process_roles) or "-"
     lines.append(f"Processes:{summary['active_processes']} recognized ({process_roles})")
+    boss_loop_label = "alive" if boss_loop_status["alive"] else "idle"
+    lines.append(f"BossLoop: {boss_loop_label} ({boss_loop_status['reason']})")
     health_status = "OK" if snapshot["health"]["ok"] else f"{summary['health_issues']} issue(s)"
     lines.append(f"Health:   {health_status}")
 

--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -2433,6 +2433,11 @@ def cmd_operator_snapshot(args: argparse.Namespace) -> int:
         snapshot.pop("sessions")
         snapshot.pop("lanes")
         snapshot.pop("broker_runs")
+        snapshot["agent_heartbeats"] = {
+            "count": int(agent_heartbeats.get("count", 0)),
+            "fresh_count": int(agent_heartbeats.get("fresh_count", 0)),
+            "stale_count": int(agent_heartbeats.get("stale_count", 0)),
+        }
         snapshot["records_omitted"] = True
 
     if args.json:

--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -2197,7 +2197,13 @@ def _operator_summary_int(summary: dict[str, Any], key: str) -> int:
 def _operator_boss_loop_status(summary: dict[str, Any]) -> dict[str, Any]:
     """Explain the legacy boss-loop liveness boolean in operator snapshots."""
 
-    active_roles = sorted(str(role) for role in summary.get("active_process_roles", []))
+    raw_roles = summary.get("active_process_roles") or []
+    if isinstance(raw_roles, str):
+        raw_roles = [raw_roles]
+    try:
+        active_roles = sorted(str(role) for role in raw_roles)
+    except TypeError:
+        active_roles = []
     active_role_set = set(active_roles)
     active_broker_runs = _operator_summary_int(summary, "active_broker_runs")
     fresh_agent_heartbeats = _operator_summary_int(summary, "fresh_agent_heartbeats")

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -673,6 +673,27 @@ def test_operator_boss_loop_status_reports_idle_without_live_signal() -> None:
     }
 
 
+def test_operator_boss_loop_status_tolerates_malformed_roles() -> None:
+    import agent_bridge as mod
+
+    assert mod._operator_boss_loop_status({"active_process_roles": None}) == {
+        "alive": False,
+        "reason": "idle_no_live_boss_loop_signal",
+        "active_broker_runs": 0,
+        "fresh_agent_heartbeats": 0,
+        "has_boss_cycle_process": False,
+        "active_process_roles": [],
+    }
+    assert mod._operator_boss_loop_status({"active_process_roles": object()}) == {
+        "alive": False,
+        "reason": "idle_no_live_boss_loop_signal",
+        "active_broker_runs": 0,
+        "fresh_agent_heartbeats": 0,
+        "has_boss_cycle_process": False,
+        "active_process_roles": [],
+    }
+
+
 def test_operator_boss_loop_alive_preserves_legacy_boolean() -> None:
     import agent_bridge as mod
 

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -632,6 +632,14 @@ def test_operator_snapshot_exposes_b0_issue_contract_fields(
     assert payload["queue_depth"] == 3
     assert payload["success_rate"] == 0.625
     assert payload["boss_loop_alive"] is True
+    assert payload["boss_loop_status"] == {
+        "alive": True,
+        "reason": "active_broker_runs",
+        "active_broker_runs": 1,
+        "fresh_agent_heartbeats": 1,
+        "has_boss_cycle_process": True,
+        "active_process_roles": ["boss_cycle"],
+    }
     assert payload["recent_blockers"] == [
         {
             "type": "pending_steering",
@@ -642,6 +650,52 @@ def test_operator_snapshot_exposes_b0_issue_contract_fields(
             "pr_hint": 5426,
         }
     ]
+
+
+def test_operator_boss_loop_status_reports_idle_without_live_signal() -> None:
+    import agent_bridge as mod
+
+    status = mod._operator_boss_loop_status(
+        {
+            "active_broker_runs": 0,
+            "fresh_agent_heartbeats": 0,
+            "active_process_roles": ["publisher", "review_queue"],
+        }
+    )
+
+    assert status == {
+        "alive": False,
+        "reason": "idle_no_live_boss_loop_signal",
+        "active_broker_runs": 0,
+        "fresh_agent_heartbeats": 0,
+        "has_boss_cycle_process": False,
+        "active_process_roles": ["publisher", "review_queue"],
+    }
+
+
+def test_operator_boss_loop_alive_preserves_legacy_boolean() -> None:
+    import agent_bridge as mod
+
+    assert (
+        mod._operator_boss_loop_alive(
+            {
+                "active_broker_runs": 0,
+                "fresh_agent_heartbeats": 1,
+                "active_process_roles": [],
+            }
+        )
+        is True
+    )
+    assert (
+        mod._operator_boss_loop_alive(
+            {
+                "active_broker_runs": 0,
+                "fresh_agent_heartbeats": 0,
+                "active_process_roles": ["publisher", "review_queue"],
+            }
+        )
+        is False
+    )
 
 
 def test_collect_pending_steering_messages_completed_receipts_are_not_actionable(

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -403,6 +403,23 @@ def test_operator_snapshot_summary_only_json_omits_records(
             "by_role": {},
         },
     )
+    monkeypatch.setattr(
+        mod,
+        "_collect_agent_heartbeats",
+        lambda: {
+            "count": 2,
+            "fresh_count": 1,
+            "stale_count": 1,
+            "latest_by_owner": {
+                "codex-owner": {
+                    "owner_session": "codex-owner",
+                    "cwd": "/tmp/large-detail",
+                    "worktree": "/tmp/large-detail",
+                    "last_seen_at": "2026-06-06T00:00:00Z",
+                }
+            },
+        },
+    )
 
     rc = mod.cmd_operator_snapshot(argparse.Namespace(json=True, summary_only=True))
 
@@ -418,6 +435,7 @@ def test_operator_snapshot_summary_only_json_omits_records(
     assert payload["summary"]["active_processes"] == 0
     assert payload["summary"]["active_process_roles"] == []
     assert payload["process_census"] == {"ok": True, "total": 0, "by_role": {}}
+    assert payload["agent_heartbeats"] == {"count": 2, "fresh_count": 1, "stale_count": 1}
     assert payload["health"] == {"ok": True, "issues": []}
     assert discover_include_summaries == [False]
 


### PR DESCRIPTION
## Summary
- add explicit `boss_loop_status` detail to compact operator snapshots
- preserve the existing `boss_loop_alive` compatibility field
- keep the change scoped to `agent_bridge.py` and focused tests

## Validation
- `PYTHONDONTWRITEBYTECODE=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTEST_ADDOPTS='-p no:cacheprovider' /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_agent_bridge.py -p no:cacheprovider`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/agent_bridge.py tests/scripts/test_agent_bridge.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/agent_bridge.py tests/scripts/test_agent_bridge.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
