### PR TITLE
test(benchmark-truth): require latest pointer parity

### DIFF
--- a/scripts/render_benchmark_truth_status.py
+++ b/scripts/render_benchmark_truth_status.py
@@ -114,6 +114,22 @@ def _load_expected_latest_payload(
     return payload
 
 
+def _require_matching_latest_payloads(
+    *,
+    corpus_latest_payload: dict[str, Any],
+    revision_latest_payload: dict[str, Any],
+    corpus_latest_path: Path,
+    revision_latest_path: Path,
+    label: str,
+) -> None:
+    if corpus_latest_payload == revision_latest_payload:
+        return
+    raise SystemExit(
+        f"{label} latest pointer mismatch: "
+        f"{corpus_latest_path} does not match {revision_latest_path}"
+    )
+
+
 def _format_percent(value: Any) -> str:
     if isinstance(value, (int, float)):
         return f"{float(value):.1%}"
@@ -633,23 +649,37 @@ def main(argv: list[str] | None = None) -> int:
         expected_corpus_id=expected_corpus_id,
         expected_revision=expected_revision,
     )
+    truth_revision_payload = _load_expected_latest_payload(
+        path=latest_paths["truth_revision_latest"],
+        label="truth artifact revision latest.json",
+        expected_corpus_id=expected_corpus_id,
+        expected_revision=expected_revision,
+    )
+    _require_matching_latest_payloads(
+        corpus_latest_payload=truth_payload,
+        revision_latest_payload=truth_revision_payload,
+        corpus_latest_path=truth_path,
+        revision_latest_path=latest_paths["truth_revision_latest"],
+        label="truth artifact",
+    )
     scorecard_payload = _load_expected_latest_payload(
         path=scorecard_path,
         label="scorecard latest.json",
         expected_corpus_id=expected_corpus_id,
         expected_revision=expected_revision,
     )
-    _load_expected_latest_payload(
-        path=latest_paths["truth_revision_latest"],
-        label="truth artifact revision latest.json",
-        expected_corpus_id=expected_corpus_id,
-        expected_revision=expected_revision,
-    )
-    _load_expected_latest_payload(
+    scorecard_revision_payload = _load_expected_latest_payload(
         path=latest_paths["scorecard_revision_latest"],
         label="scorecard revision latest.json",
         expected_corpus_id=expected_corpus_id,
         expected_revision=expected_revision,
+    )
+    _require_matching_latest_payloads(
+        corpus_latest_payload=scorecard_payload,
+        revision_latest_payload=scorecard_revision_payload,
+        corpus_latest_path=scorecard_path,
+        revision_latest_path=latest_paths["scorecard_revision_latest"],
+        label="scorecard",
     )
 
     content = render_status_markdown(

--- a/tests/scripts/test_render_benchmark_truth_status.py
+++ b/tests/scripts/test_render_benchmark_truth_status.py
@@ -721,6 +721,102 @@ def test_main_rejects_stale_corpus_latest_payload_revision(tmp_path: Path) -> No
     assert not output_path.exists()
 
 
+def test_main_rejects_truth_latest_pointer_payload_divergence(tmp_path: Path) -> None:
+    corpus_path = _write_json(
+        tmp_path / "docs" / "benchmarks" / "corpus.json",
+        {
+            "corpus_id": "tw-01-bounded-execution-v1",
+            "revision": 2,
+            "recorded_on": "2026-04-14",
+            "success_contract": "mergeable_pr_or_merged_pr",
+            "issues": [{"issue_id": 1064, "title": "Issue A"}],
+        },
+    )
+    truth_root = tmp_path / "docs" / "status" / "generated" / "benchmark_truth_artifacts"
+    scorecard_root = tmp_path / "docs" / "status" / "generated" / "benchmark_scorecards"
+    _write_json(
+        truth_root / "tw-01-bounded-execution-v1" / "latest.json",
+        _truth_payload(revision=2, generated_at="2026-04-14T20:00:00Z"),
+    )
+    _write_json(
+        truth_root / "tw-01-bounded-execution-v1" / "rev-2" / "latest.json",
+        _truth_payload(revision=2, generated_at="2026-04-14T20:30:00Z"),
+    )
+    _write_json(
+        scorecard_root / "tw-01-bounded-execution-v1" / "latest.json",
+        _scorecard_payload(revision=2),
+    )
+    _write_json(
+        scorecard_root / "tw-01-bounded-execution-v1" / "rev-2" / "latest.json",
+        _scorecard_payload(revision=2),
+    )
+    output_path = tmp_path / "docs" / "status" / "B0_BENCHMARK_TRUTH_STATUS.md"
+
+    with pytest.raises(SystemExit, match="truth artifact latest pointer mismatch"):
+        mod.main(
+            [
+                "--corpus",
+                str(corpus_path),
+                "--truth-root",
+                str(truth_root),
+                "--scorecard-root",
+                str(scorecard_root),
+                "--output",
+                str(output_path),
+            ]
+        )
+
+    assert not output_path.exists()
+
+
+def test_main_rejects_scorecard_latest_pointer_payload_divergence(tmp_path: Path) -> None:
+    corpus_path = _write_json(
+        tmp_path / "docs" / "benchmarks" / "corpus.json",
+        {
+            "corpus_id": "tw-01-bounded-execution-v1",
+            "revision": 2,
+            "recorded_on": "2026-04-14",
+            "success_contract": "mergeable_pr_or_merged_pr",
+            "issues": [{"issue_id": 1064, "title": "Issue A"}],
+        },
+    )
+    truth_root = tmp_path / "docs" / "status" / "generated" / "benchmark_truth_artifacts"
+    scorecard_root = tmp_path / "docs" / "status" / "generated" / "benchmark_scorecards"
+    _write_json(
+        truth_root / "tw-01-bounded-execution-v1" / "latest.json",
+        _truth_payload(revision=2),
+    )
+    _write_json(
+        truth_root / "tw-01-bounded-execution-v1" / "rev-2" / "latest.json",
+        _truth_payload(revision=2),
+    )
+    _write_json(
+        scorecard_root / "tw-01-bounded-execution-v1" / "latest.json",
+        _scorecard_payload(revision=2, generated_at="2026-04-14T20:05:00Z"),
+    )
+    _write_json(
+        scorecard_root / "tw-01-bounded-execution-v1" / "rev-2" / "latest.json",
+        _scorecard_payload(revision=2, generated_at="2026-04-14T20:35:00Z"),
+    )
+    output_path = tmp_path / "docs" / "status" / "B0_BENCHMARK_TRUTH_STATUS.md"
+
+    with pytest.raises(SystemExit, match="scorecard latest pointer mismatch"):
+        mod.main(
+            [
+                "--corpus",
+                str(corpus_path),
+                "--truth-root",
+                str(truth_root),
+                "--scorecard-root",
+                str(scorecard_root),
+                "--output",
+                str(output_path),
+            ]
+        )
+
+    assert not output_path.exists()
+
+
 def test_repo_checked_in_benchmark_truth_surfaces_match_current_corpus(tmp_path: Path) -> None:
     corpus_path = mod.DEFAULT_CORPUS_PATH
     latest_paths = mod.resolve_latest_paths(


### PR DESCRIPTION
## Summary
- require benchmark truth corpus-level latest pointers to exactly match their revision-scoped latest pointers before rendering the B0 status page
- add regression coverage for truth-artifact and scorecard pointer divergence so stale mixed surfaces fail closed before writing markdown

## Tier / Scope
- Tier 1-2: benchmark-truth proof-surface hardening and regression coverage only
- No queue-authority, settlement, workflow, security, semantic API, or merge behavior changes

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_render_benchmark_truth_status.py -q
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/benchmarks/test_truth_surface_consistency.py::test_b0_benchmark_truth_status_matches_latest_json_artifacts -q
- /Users/armand/.pyenv/versions/3.11.11/bin/python scripts/render_benchmark_truth_status.py --output /tmp/aragora-b0-benchmark-truth-status-parity.md
- bash scripts/automation_pr_preflight.sh origin/main HEAD