### PR TITLE
fix(proof-surface): reject future freshness timestamps

### DIFF
--- a/scripts/probe_proof_surface_freshness.py
+++ b/scripts/probe_proof_surface_freshness.py
@@ -30,6 +30,9 @@ Behaviour
 * Exits ``0`` when every probed surface is fresh, non-zero otherwise.
 * Treats a malformed or missing ``Last updated:`` line as a hard error
   and exits non-zero with a clear message on stderr.
+* Treats a materially future-dated ``Last updated:`` line as a hard
+  error, so bad clock data cannot make a stale proof surface appear
+  fresh. A small tolerance absorbs benign runner clock skew.
 
 Design constraints
 ~~~~~~~~~~~~~~~~~~
@@ -88,6 +91,7 @@ SURFACE_PATHS: dict[str, Path] = {
 
 DEFAULT_SURFACES: tuple[str, ...] = ("b0", "tw03")
 DEFAULT_MAX_AGE_DAYS: int = 7
+FUTURE_TIMESTAMP_TOLERANCE_SECONDS: int = 5 * 60
 
 _LAST_UPDATED_PATTERN = re.compile(
     r"^\s*Last\s+updated\s*:\s*(?P<value>\S+)\s*$",
@@ -213,7 +217,15 @@ def probe_surface(
         raise FreshnessProbeError(f"surface {surface!r} at {path}: {exc}") from exc
 
     age = now - last_updated
-    age_days = age.total_seconds() / 86400.0
+    if age.total_seconds() < -FUTURE_TIMESTAMP_TOLERANCE_SECONDS:
+        future_days = abs(age.total_seconds()) / 86400.0
+        raise FreshnessProbeError(
+            f"surface {surface!r} at {path}: 'Last updated:' value "
+            f"{last_updated.strftime('%Y-%m-%dT%H:%M:%SZ')} is {future_days:.2f} "
+            "day(s) in the future"
+        )
+
+    age_days = max(age.total_seconds(), 0.0) / 86400.0
     fresh = age_days <= max_age_days
 
     # Render the timestamp in canonical ``Z`` form for deterministic

--- a/tests/scripts/test_probe_proof_surface_freshness.py
+++ b/tests/scripts/test_probe_proof_surface_freshness.py
@@ -125,6 +125,29 @@ def test_probe_surface_marks_stale_beyond_window(mock_repo: Path) -> None:
     assert result.age_days > 7
 
 
+def test_probe_surface_tolerates_small_future_clock_skew(mock_repo: Path) -> None:
+    _write_surface(
+        mock_repo,
+        "docs/status/B0_BENCHMARK_TRUTH_STATUS.md",
+        "Last updated: 2026-05-18T00:04:00Z",
+    )
+    now = dt.datetime(2026, 5, 18, 0, 0, 0, tzinfo=dt.timezone.utc)
+    result = probe_mod.probe_surface("b0", repo_root=mock_repo, max_age_days=7, now=now)
+    assert result.fresh is True
+    assert result.age_days == 0.0
+
+
+def test_probe_surface_rejects_material_future_timestamp(mock_repo: Path) -> None:
+    _write_surface(
+        mock_repo,
+        "docs/status/B0_BENCHMARK_TRUTH_STATUS.md",
+        "Last updated: 2026-05-20T00:00:00Z",
+    )
+    now = dt.datetime(2026, 5, 18, 0, 0, 0, tzinfo=dt.timezone.utc)
+    with pytest.raises(probe_mod.FreshnessProbeError, match="future"):
+        probe_mod.probe_surface("b0", repo_root=mock_repo, max_age_days=7, now=now)
+
+
 # ---------------------------------------------------------------------------
 # CLI / acceptance tests required by the lane brief.
 # ---------------------------------------------------------------------------
@@ -234,6 +257,29 @@ def test_cli_malformed_last_updated_raises_clear_error(
     assert "malformed" in proc.stderr.lower()
     assert "garbage-not-a-date" in proc.stderr
     assert "b0" in proc.stderr
+
+
+def test_cli_future_last_updated_raises_clear_error(mock_repo: Path) -> None:
+    future = (dt.datetime.now(tz=dt.timezone.utc) + dt.timedelta(days=2)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+    _write_surface(
+        mock_repo,
+        "docs/status/B0_BENCHMARK_TRUTH_STATUS.md",
+        f"Last updated: {future}",
+    )
+    _write_surface(
+        mock_repo,
+        "docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md",
+        f"Last updated: {_today_iso()}",
+    )
+
+    proc = _run_cli(mock_repo, "--surfaces", "b0,tw03")
+
+    assert proc.returncode == 2, (proc.stdout, proc.stderr)
+    assert "future" in proc.stderr.lower()
+    assert "b0" in proc.stderr
+    assert future in proc.stderr
 
 
 def test_cli_surfaces_flag_scopes_probe(mock_repo: Path) -> None:


### PR DESCRIPTION
## Summary
- fail closed when a proof-surface `Last updated:` timestamp is materially in the future
- clamp small tolerated future clock skew to zero age so runner drift does not create negative freshness ages
- add module and CLI regressions for tolerated skew and impossible future-dated surfaces

## Tier / Scope
- Tier 1-2: proof-surface observability hardening and regression coverage only
- No queue authority, settlement, workflow, security, semantic API, or merge behavior changes

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_probe_proof_surface_freshness.py -q
- /Users/armand/.pyenv/versions/3.11.11/bin/python scripts/probe_proof_surface_freshness.py --surfaces b0 --max-age-days 30
- bash scripts/automation_pr_preflight.sh origin/main HEAD