### PR TITLE
docs(agents): sync allowlist count

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ commit") from the v12/v13 lessons; soft-reset and re-commit instead.
 
 ## Agent Types
 
-Aragora currently registers 43 agent types across CLI, direct API, OpenRouter, local inference, and external framework proxies. Use `list_available_agents()` to see the full registry at runtime. Server-side validation uses the allowlist in `aragora/config/settings.py` (`ALLOWED_AGENT_TYPES`, 34 types as of 2026-02-12). Entries marked **opt-in** are registered but not allowlisted by default.
+Aragora currently registers 43 agent types across CLI, direct API, OpenRouter, local inference, and external framework proxies. Use `list_available_agents()` to see the full registry at runtime. Server-side validation uses the allowlist in `aragora/config/settings.py` (`ALLOWED_AGENT_TYPES`, 35 types as of 2026-06-06). Entries marked **opt-in** are registered but not allowlisted by default.
 
 ### CLI-Based Agents (allowlisted)
 
@@ -113,7 +113,7 @@ Aragora currently registers 43 agent types across CLI, direct API, OpenRouter, l
 | `openai-api` | OpenAI | gpt-4.1 | `OPENAI_API_KEY` | allowlisted |
 | `gemini` | Google | gemini-3.1-pro-preview | `GEMINI_API_KEY` or `GOOGLE_API_KEY` | allowlisted |
 | `grok` | xAI | grok-4-latest | `XAI_API_KEY` or `GROK_API_KEY` | allowlisted |
-| `mistral-api` | Mistral | mistral-large-2512 | `MISTRAL_API_KEY` | opt-in |
+| `mistral-api` | Mistral | mistral-large-2512 | `MISTRAL_API_KEY` | allowlisted |
 | `codestral` | Mistral | codestral-latest | `MISTRAL_API_KEY` | opt-in |
 
 ### Local & Legacy Direct Agents


### PR DESCRIPTION
## Summary
- Update AGENTS.md declared ALLOWED_AGENT_TYPES count from 34 to 35.
- Mark mistral-api as allowlisted to match aragora/config/settings.py.

## CI failure repaired
- Main Lint run 27071423448 failed in Agent Registry Sync on commit 2af703f1051ae527f025985c862760d0511ee6f7.
- Failing message: declared allowlist count does not match ALLOWED_AGENT_TYPES: declared=34, runtime=35.

## Validation
- PATH=/Users/armand/.pyenv/versions/3.11.11/bin:$PATH python3 scripts/check_agent_registry_sync.py
- git diff --check origin/main HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD

No CI rerun was requested or performed.