### PR TITLE
fix(benchmarks): fail closed on empty comparison overlap

### DIFF
--- a/scripts/check_benchmark_regression.py
+++ b/scripts/check_benchmark_regression.py
@@ -62,6 +62,16 @@ def extract_means(data: dict) -> dict[str, float]:
     return results
 
 
+def _format_name_sample(names: set[str]) -> str:
+    ordered = sorted(names)
+    if not ordered:
+        return "none"
+    sample = ", ".join(ordered[:10])
+    if len(ordered) > 10:
+        sample += f", ... (+{len(ordered) - 10} more)"
+    return sample
+
+
 def compare_benchmarks(
     current_path: Path,
     baseline_path: Path,
@@ -81,14 +91,14 @@ def compare_benchmarks(
         print("WARNING: Baseline has no benchmarks to compare against.")
         return 0
 
+    matched_names = sorted(set(current_means) & set(baseline_means))
+
     regressions: list[str] = []
     improvements: list[str] = []
     unchanged: list[str] = []
 
-    for name, current_mean in sorted(current_means.items()):
-        if name not in baseline_means:
-            continue
-
+    for name in matched_names:
+        current_mean = current_means[name]
         baseline_mean = baseline_means[name]
         if baseline_mean == 0:
             continue
@@ -149,7 +159,13 @@ def compare_benchmarks(
         print(f"FAILED: {len(regressions)} benchmark(s) regressed by more than {threshold_pct}%.")
         return 1
 
-    matched = len([n for n in current_means if n in baseline_means])
+    matched = len(matched_names)
+    if matched == 0:
+        print("FAILED: No shared benchmark names between current and baseline results.")
+        print(f"  Current-only:  {_format_name_sample(set(current_means) - set(baseline_means))}")
+        print(f"  Baseline-only: {_format_name_sample(set(baseline_means) - set(current_means))}")
+        return 1
+
     print(f"PASSED: {matched} benchmark(s) within {threshold_pct}% threshold.")
     return 0
 

--- a/tests/scripts/test_check_benchmark_regression.py
+++ b/tests/scripts/test_check_benchmark_regression.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "check_benchmark_regression.py"
+
+
+def _load_module() -> Any:
+    spec = importlib.util.spec_from_file_location("check_benchmark_regression", SCRIPT_PATH)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules["check_benchmark_regression"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+bench_mod = _load_module()
+
+
+def _write_benchmarks(path: Path, means: dict[str, float]) -> Path:
+    payload = {
+        "benchmarks": [
+            {
+                "name": name,
+                "stats": {
+                    "mean": mean,
+                },
+            }
+            for name, mean in means.items()
+        ]
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_compare_fails_when_current_and_baseline_share_no_benchmark_names(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    current = _write_benchmarks(tmp_path / "current.json", {"bench_new": 0.001})
+    baseline = _write_benchmarks(tmp_path / "baseline.json", {"bench_old": 0.001})
+
+    rc = bench_mod.compare_benchmarks(current, baseline, threshold_pct=20.0)
+
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "No shared benchmark names" in captured.out
+    assert "bench_new" in captured.out
+    assert "bench_old" in captured.out
+
+
+def test_compare_allows_partial_overlap_without_regression(tmp_path: Path, capsys) -> None:
+    current = _write_benchmarks(
+        tmp_path / "current.json",
+        {
+            "bench_shared": 0.0011,
+            "bench_current_only": 0.004,
+        },
+    )
+    baseline = _write_benchmarks(
+        tmp_path / "baseline.json",
+        {
+            "bench_shared": 0.0010,
+            "bench_baseline_only": 0.004,
+        },
+    )
+
+    rc = bench_mod.compare_benchmarks(current, baseline, threshold_pct=20.0)
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "PASSED: 1 benchmark(s)" in captured.out
+    assert "No shared benchmark names" not in captured.out


### PR DESCRIPTION
## Summary
- fail benchmark regression comparisons when current and baseline results share zero benchmark names
- keep partial-overlap comparisons allowed, so filtered or newly added benchmarks do not fail unless the comparable set is empty
- add focused regression coverage for no-overlap failure and partial-overlap success

## Tier / Scope
- Tier 1-2: benchmark-truth CI helper hardening and regression coverage only
- No queue authority, settlement, workflow, security, semantic API, or merge behavior changes

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_check_benchmark_regression.py -q
- bash scripts/automation_pr_preflight.sh origin/main HEAD