### PR TITLE
fix(value-drain): summarize dry-run actions

### DIFF
--- a/aragora/work/sources.py
+++ b/aragora/work/sources.py
@@ -22,6 +22,26 @@ _OUTBOX_READY_METADATA_KEYS = (
     "validation",
     "dependencies_declared",
 )
+_OUTBOX_PUBLICATION_METADATA_KEYS = (
+    "base",
+    "base_sha",
+    "desired_head_sha",
+    "head_sha",
+    "labels",
+    "local_evidence",
+    "metadata",
+    "next_action",
+    "priority",
+    "publication_attempts",
+    "publication_blocker",
+    "repo",
+    "requested_action",
+    "requires_github",
+    "validation_summary",
+)
+_OUTBOX_METADATA_KEYS = tuple(
+    dict.fromkeys((*_OUTBOX_READY_METADATA_KEYS, *_OUTBOX_PUBLICATION_METADATA_KEYS))
+)
 
 
 def _read_json(path: Path) -> dict[str, Any] | None:
@@ -70,6 +90,30 @@ def _state_evidence_ref(root: Path, path: Path) -> str:
         return str(path.relative_to(base))
     except ValueError:
         return str(path)
+
+
+def _string_list(value: Any) -> list[str]:
+    if isinstance(value, str):
+        text = value.strip()
+        return [text] if text else []
+    if isinstance(value, (list, tuple, set)):
+        values: list[str] = []
+        for entry in value:
+            text = str(entry).strip()
+            if text and text not in values:
+                values.append(text)
+        return values
+    return []
+
+
+def _outbox_labels(data: dict[str, Any]) -> list[str]:
+    labels = _string_list(data.get("labels"))
+    requested_action = data.get("requested_action")
+    if isinstance(requested_action, dict):
+        for label in _string_list(requested_action.get("labels")):
+            if label not in labels:
+                labels.append(label)
+    return labels
 
 
 def _has_work_state_dirs(root: Path) -> bool:
@@ -379,11 +423,12 @@ def collect_automation_outbox(repo_root: Path) -> tuple[list[WorkItem], dict[str
             "path": str(path),
             "idempotency_key": data.get("idempotency_key"),
         }
-        for key in _OUTBOX_READY_METADATA_KEYS:
+        for key in _OUTBOX_METADATA_KEYS:
             if key in data:
                 metadata[key] = data[key]
         owner = data.get("owner") or data.get("claimed_by") or data.get("assignee")
         dependencies = data.get("dependencies")
+        labels = _outbox_labels(data)
         items.append(
             WorkItem(
                 id=f"automation-outbox:{path.stem}",
@@ -399,6 +444,7 @@ def collect_automation_outbox(repo_root: Path) -> tuple[list[WorkItem], dict[str
                 if isinstance(dependencies, list)
                 else [],
                 evidence_refs=[_state_evidence_ref(repo_root, path)],
+                tags=labels,
                 metadata=metadata,
             )
         )

--- a/scripts/drain_codex_automation_value.py
+++ b/scripts/drain_codex_automation_value.py
@@ -732,6 +732,61 @@ def _run_merge_phase(config: DrainConfig, runner: Runner) -> dict[str, Any]:
     return phase
 
 
+def _phase_by_name(report: Mapping[str, Any], name: str) -> Mapping[str, Any]:
+    for phase in report.get("phases") or []:
+        if isinstance(phase, Mapping) and phase.get("name") == name:
+            return phase
+    return {}
+
+
+def _int_from_mapping(payload: Mapping[str, Any], *keys: str) -> int:
+    for key in keys:
+        value = payload.get(key)
+        if isinstance(value, int):
+            return value
+        try:
+            return int(str(value))
+        except (TypeError, ValueError):
+            continue
+    return 0
+
+
+def action_summary(report: Mapping[str, Any]) -> dict[str, Any]:
+    mode = str(report.get("mode") or "dry-run")
+    merge_phase = _phase_by_name(report, "merge_existing_prs")
+    branch_phase = _phase_by_name(report, "publish_branch_prs")
+    issue_phase = _phase_by_name(report, "publish_handoff_issues")
+    branch_payload = (
+        branch_phase.get("json") if isinstance(branch_phase.get("json"), Mapping) else {}
+    )
+    issue_payload = issue_phase.get("json") if isinstance(issue_phase.get("json"), Mapping) else {}
+
+    skipped: list[dict[str, Any]] = []
+    for phase_name, phase in (
+        ("merge_existing_prs", merge_phase),
+        ("publish_branch_prs", branch_phase),
+        ("publish_handoff_issues", issue_phase),
+    ):
+        for item in phase.get("skipped") or []:
+            if isinstance(item, Mapping):
+                skipped.append({"phase": phase_name, **dict(item)})
+
+    return {
+        "mode": mode,
+        "planned_branch_prs": _int_from_mapping(branch_payload, "eligible_decision_count"),
+        "published_branch_prs": len(branch_payload.get("published") or []),
+        "planned_handoff_issues": _int_from_mapping(issue_payload, "eligible_count"),
+        "published_handoff_issues": len(issue_payload.get("published") or []),
+        "planned_protected_merges": sum(
+            1
+            for item in merge_phase.get("evaluations") or []
+            if isinstance(item, Mapping) and item.get("eligible") is True
+        ),
+        "applied_protected_merges": len(merge_phase.get("merged") or []),
+        "skipped": skipped,
+    }
+
+
 def run_drain(config: DrainConfig, *, runner: Runner | None = None) -> dict[str, Any]:
     runner = runner or _run
     report: dict[str, Any] = {
@@ -835,6 +890,7 @@ def run_drain(config: DrainConfig, *, runner: Runner | None = None) -> dict[str,
         _payload, proc = _run_json(final_cache_cmd, config.repo_root, runner)
         report["phases"].append(_phase_result("cache_refresh_after", final_cache_cmd, proc))
 
+    report["action_summary"] = action_summary(report)
     report["status"] = "ok"
     report["blockers"] = []
     return report

--- a/scripts/drain_codex_automation_value.py
+++ b/scripts/drain_codex_automation_value.py
@@ -751,6 +751,85 @@ def _int_from_mapping(payload: Mapping[str, Any], *keys: str) -> int:
     return 0
 
 
+def _optional_int_from_mapping(payload: Mapping[str, Any], key: str) -> int | None:
+    value = payload.get(key)
+    if isinstance(value, int):
+        return value
+    try:
+        return int(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _optional_bool_from_mapping(payload: Mapping[str, Any], key: str) -> bool | None:
+    value = payload.get(key)
+    return value if isinstance(value, bool) else None
+
+
+def _cache_phase_summary(phase: Mapping[str, Any]) -> dict[str, Any]:
+    payload = phase.get("json") if isinstance(phase.get("json"), Mapping) else {}
+    local_queue = (
+        payload.get("local_queue") if isinstance(payload.get("local_queue"), Mapping) else {}
+    )
+    github_queue = (
+        payload.get("github_queue") if isinstance(payload.get("github_queue"), Mapping) else {}
+    )
+    pressure = (
+        github_queue.get("pressure") if isinstance(github_queue.get("pressure"), Mapping) else {}
+    )
+    return {
+        "ok": phase.get("ok") is True,
+        "returncode": _optional_int_from_mapping(phase, "returncode"),
+        "generated_at": payload.get("generated_at")
+        if isinstance(payload.get("generated_at"), str)
+        else None,
+        "local_outbox_count": _optional_int_from_mapping(local_queue, "outbox_count"),
+        "unreceipted_outbox_count": _optional_int_from_mapping(
+            local_queue, "unreceipted_outbox_count"
+        ),
+        "terminal_receipted_outbox_count": _optional_int_from_mapping(
+            local_queue, "terminal_receipted_outbox_count"
+        ),
+        "github_queue_available": _optional_bool_from_mapping(github_queue, "available"),
+        "open_codex_pr_count": _optional_int_from_mapping(github_queue, "open_codex_pr_count"),
+        "open_issue_count": _optional_int_from_mapping(github_queue, "open_issue_count"),
+        "open_issue_cap_reached": _optional_bool_from_mapping(pressure, "open_issue_cap_reached"),
+        "open_pr_cap_reached": _optional_bool_from_mapping(pressure, "open_pr_cap_reached"),
+    }
+
+
+def _cache_delta(
+    before: Mapping[str, Any],
+    after: Mapping[str, Any],
+    *keys: str,
+) -> dict[str, int]:
+    delta: dict[str, int] = {}
+    for key in keys:
+        before_value = before.get(key)
+        after_value = after.get(key)
+        if isinstance(before_value, int) and isinstance(after_value, int):
+            delta[key] = after_value - before_value
+    return delta
+
+
+def _cache_refresh_summary(report: Mapping[str, Any]) -> dict[str, Any]:
+    before = _cache_phase_summary(_phase_by_name(report, "cache_refresh_before"))
+    after = _cache_phase_summary(_phase_by_name(report, "cache_refresh_after"))
+    return {
+        "before": before,
+        "after": after,
+        "delta": _cache_delta(
+            before,
+            after,
+            "local_outbox_count",
+            "unreceipted_outbox_count",
+            "terminal_receipted_outbox_count",
+            "open_codex_pr_count",
+            "open_issue_count",
+        ),
+    }
+
+
 def action_summary(report: Mapping[str, Any]) -> dict[str, Any]:
     mode = str(report.get("mode") or "dry-run")
     merge_phase = _phase_by_name(report, "merge_existing_prs")
@@ -783,6 +862,7 @@ def action_summary(report: Mapping[str, Any]) -> dict[str, Any]:
             if isinstance(item, Mapping) and item.get("eligible") is True
         ),
         "applied_protected_merges": len(merge_phase.get("merged") or []),
+        "cache_refresh": _cache_refresh_summary(report),
         "skipped": skipped,
     }
 

--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -172,6 +172,7 @@ class Handoff:
     body: str
     labels: dict[str, str]
     expires_at: str | None
+    issue_labels: tuple[str, ...] = ()
     idempotency_key: str | None = None
     source_kind: str = "memory"
     branch: str | None = None
@@ -598,6 +599,49 @@ def _local_evidence_mappings(value: Any) -> list[Mapping[str, Any]]:
     return []
 
 
+def _coerce_issue_labels(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return []
+        if text.startswith(("[", "{")):
+            try:
+                parsed = json.loads(text)
+            except json.JSONDecodeError:
+                parsed = None
+            if parsed is not None:
+                return _coerce_issue_labels(parsed)
+        return [label.strip() for label in re.split(r"[,;\n]+", text) if label.strip()]
+    if isinstance(value, Mapping):
+        labels: list[str] = []
+        for key in ("issue_labels", "labels"):
+            labels.extend(_coerce_issue_labels(value.get(key)))
+        return labels
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        labels: list[str] = []
+        for item in value:
+            labels.extend(_coerce_issue_labels(item))
+        return labels
+    return []
+
+
+def _outbox_issue_labels(payload: dict[str, Any]) -> tuple[str, ...]:
+    labels: list[str] = []
+    labels.extend(_coerce_issue_labels(payload.get("issue_labels")))
+    labels.extend(_coerce_issue_labels(payload.get("labels")))
+
+    requested_action = _structured_action(payload.get("requested_action"))
+    if requested_action is not None:
+        labels.extend(_coerce_issue_labels(requested_action))
+
+    for local_evidence in _local_evidence_mappings(payload.get("local_evidence")):
+        labels.extend(_coerce_issue_labels(local_evidence))
+
+    return tuple(dict.fromkeys(label for label in labels if label))
+
+
 def _outbox_evidence_value(payload: dict[str, Any], key: str) -> str:
     for local_evidence in _local_evidence_mappings(payload.get("local_evidence")):
         value = str(local_evidence.get(key) or "").strip()
@@ -981,6 +1025,7 @@ def _load_outbox_handoffs_with_skip_reasons(
             body=_format_outbox_body(payload, source_file),
             labels={key: _format_json_block(value) for key, value in payload.items()},
             expires_at=expires_at,
+            issue_labels=_outbox_issue_labels(payload),
             idempotency_key=idempotency_key,
             source_kind="outbox",
             branch=_outbox_evidence_value(payload, "branch") or None,
@@ -1253,6 +1298,7 @@ def _create_issue(
     *,
     labels: list[str],
 ) -> str:
+    issue_labels = list(dict.fromkeys([*labels, *handoff.issue_labels]))
     args = [
         "gh",
         "issue",
@@ -1264,13 +1310,13 @@ def _create_issue(
         "--body",
         _fit_issue_body(handoff.body),
     ]
-    for label in labels:
+    for label in issue_labels:
         args.extend(["--label", label])
     proc = _run(args, cwd=repo_root)
     if proc.returncode != 0:
         raise RuntimeError(proc.stderr.strip() or proc.stdout.strip() or "gh issue create failed")
     url = str(proc.stdout or "").strip().splitlines()[-1].strip()
-    _add_issue_labels(repo_root, repo, url, labels)
+    _add_issue_labels(repo_root, repo, url, issue_labels)
     return url
 
 

--- a/tests/scripts/test_drain_codex_automation_value.py
+++ b/tests/scripts/test_drain_codex_automation_value.py
@@ -328,6 +328,8 @@ def test_run_drain_skips_issue_publish_when_cap_reached(monkeypatch: Any, tmp_pa
 
 
 def test_run_drain_reports_dry_run_action_summary(monkeypatch: Any, tmp_path: Path) -> None:
+    cache_refresh_count = 0
+
     def fake_health(_repo_root: Path) -> GitHubCLIHealth:
         return GitHubCLIHealth(
             ready=True,
@@ -339,17 +341,28 @@ def test_run_drain_reports_dry_run_action_summary(monkeypatch: Any, tmp_path: Pa
         )
 
     def fake_runner(args: Any, cwd: Path) -> subprocess.CompletedProcess[str]:
+        nonlocal cache_refresh_count
         command = list(args)
         stdout = "{}"
         if any(str(part).endswith("cache_codex_automation_github_status.py") for part in command):
+            cache_refresh_count += 1
             stdout = json.dumps(
                 {
+                    "generated_at": f"2026-06-06T19:1{cache_refresh_count}:00+00:00",
                     "github_queue": {
                         "available": True,
+                        "open_codex_pr_count": 4,
                         "open_issue_count": 3,
-                        "pressure": {"open_issue_cap_reached": False},
+                        "pressure": {
+                            "open_issue_cap_reached": False,
+                            "open_pr_cap_reached": False,
+                        },
                     },
-                    "local_queue": {"outbox_count": 5},
+                    "local_queue": {
+                        "outbox_count": 5 - cache_refresh_count,
+                        "unreceipted_outbox_count": 3 - cache_refresh_count,
+                        "terminal_receipted_outbox_count": cache_refresh_count,
+                    },
                 }
             )
         elif any(str(part).endswith("reconcile_automation_outbox.py") for part in command):
@@ -429,6 +442,41 @@ def test_run_drain_reports_dry_run_action_summary(monkeypatch: Any, tmp_path: Pa
         "published_handoff_issues": 0,
         "planned_protected_merges": 1,
         "applied_protected_merges": 0,
+        "cache_refresh": {
+            "before": {
+                "ok": True,
+                "returncode": 0,
+                "generated_at": "2026-06-06T19:11:00+00:00",
+                "local_outbox_count": 4,
+                "unreceipted_outbox_count": 2,
+                "terminal_receipted_outbox_count": 1,
+                "github_queue_available": True,
+                "open_codex_pr_count": 4,
+                "open_issue_count": 3,
+                "open_issue_cap_reached": False,
+                "open_pr_cap_reached": False,
+            },
+            "after": {
+                "ok": True,
+                "returncode": 0,
+                "generated_at": "2026-06-06T19:12:00+00:00",
+                "local_outbox_count": 3,
+                "unreceipted_outbox_count": 1,
+                "terminal_receipted_outbox_count": 2,
+                "github_queue_available": True,
+                "open_codex_pr_count": 4,
+                "open_issue_count": 3,
+                "open_issue_cap_reached": False,
+                "open_pr_cap_reached": False,
+            },
+            "delta": {
+                "local_outbox_count": -1,
+                "unreceipted_outbox_count": -1,
+                "terminal_receipted_outbox_count": 1,
+                "open_codex_pr_count": 0,
+                "open_issue_count": 0,
+            },
+        },
         "skipped": [],
     }
 

--- a/tests/scripts/test_drain_codex_automation_value.py
+++ b/tests/scripts/test_drain_codex_automation_value.py
@@ -327,6 +327,112 @@ def test_run_drain_skips_issue_publish_when_cap_reached(monkeypatch: Any, tmp_pa
     assert issue_phase["skipped"] == [{"reason": "open issue cap reached"}]
 
 
+def test_run_drain_reports_dry_run_action_summary(monkeypatch: Any, tmp_path: Path) -> None:
+    def fake_health(_repo_root: Path) -> GitHubCLIHealth:
+        return GitHubCLIHealth(
+            ready=True,
+            auth_ok=True,
+            api_ok=True,
+            mode="ready",
+            error="",
+            repo=str(tmp_path),
+        )
+
+    def fake_runner(args: Any, cwd: Path) -> subprocess.CompletedProcess[str]:
+        command = list(args)
+        stdout = "{}"
+        if any(str(part).endswith("cache_codex_automation_github_status.py") for part in command):
+            stdout = json.dumps(
+                {
+                    "github_queue": {
+                        "available": True,
+                        "open_issue_count": 3,
+                        "pressure": {"open_issue_cap_reached": False},
+                    },
+                    "local_queue": {"outbox_count": 5},
+                }
+            )
+        elif any(str(part).endswith("reconcile_automation_outbox.py") for part in command):
+            stdout = json.dumps({"archived": 0, "kept": 5})
+        elif command[:3] == ["gh", "pr", "list"]:
+            stdout = json.dumps(
+                [
+                    {
+                        "number": 7768,
+                        "headRefName": "codex/safe-queue-repair",
+                        "title": "Safe queue repair",
+                        "url": "https://github.example/pr/7768",
+                    }
+                ]
+            )
+        elif command[:3] == ["gh", "pr", "view"]:
+            stdout = json.dumps(_pr_view())
+        elif command[:3] == ["gh", "pr", "checks"]:
+            stdout = json.dumps(_checks())
+        elif any(str(part).endswith("identify_lane_owner.py") for part in command):
+            return subprocess.CompletedProcess(
+                args=command,
+                returncode=1,
+                stdout=json.dumps({"ok": False, "error": "no lane matched criteria {'pr': 7768}"}),
+                stderr="",
+            )
+        elif "review-queue" in command and "merge-packet" in command:
+            stdout = json.dumps(_packet())
+        elif any(str(part).endswith("settle_one_pr.py") for part in command):
+            stdout = json.dumps(_settle())
+        elif any(str(part).endswith("publish_codex_automation_branches.py") for part in command):
+            stdout = json.dumps(
+                {
+                    "decision_count": 4,
+                    "eligible_decision_count": 2,
+                    "ineligible_decision_count": 2,
+                    "published": [],
+                }
+            )
+        elif any(str(part).endswith("publish_automation_handoffs.py") for part in command):
+            stdout = json.dumps(
+                {
+                    "decision_count": 3,
+                    "eligible_count": 1,
+                    "ineligible_count": 2,
+                    "published": [],
+                }
+            )
+        return subprocess.CompletedProcess(args=command, returncode=0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(mod, "check_github_cli_health", fake_health)
+    config = mod.DrainConfig(
+        repo_root=tmp_path,
+        github_repo="owner/repo",
+        state_root=tmp_path,
+        outbox_dir=tmp_path / ".aragora" / "automation-outbox",
+        receipt_dir=tmp_path / ".aragora" / "automation-receipts",
+        cache_output=None,
+        base="origin/main",
+        branch_limit=2,
+        issue_limit=4,
+        merge_limit=1,
+        max_open_prs=12,
+        max_open_issues=16,
+        branch_scan_limit=40,
+        apply=False,
+    )
+
+    report = mod.run_drain(config, runner=fake_runner)
+
+    assert report["status"] == "ok"
+    assert report["action_summary"] == {
+        "mode": "dry-run",
+        "planned_branch_prs": 2,
+        "published_branch_prs": 0,
+        "planned_handoff_issues": 1,
+        "published_handoff_issues": 0,
+        "planned_protected_merges": 1,
+        "applied_protected_merges": 0,
+        "skipped": [],
+    }
+
+
 def test_publisher_wrapper_propagates_value_drain_failure() -> None:
     wrapper = Path("scripts/run_codex_automation_publisher.sh").read_text(encoding="utf-8")
 

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -1590,6 +1590,7 @@ def test_publish_handoffs_creates_issue_with_labels(monkeypatch: Any, tmp_path: 
         body="body",
         labels={},
         expires_at=None,
+        issue_labels=("handoff-requested", "autonomous"),
     )
     created: list[list[str]] = []
 
@@ -1621,7 +1622,7 @@ def test_publish_handoffs_creates_issue_with_labels(monkeypatch: Any, tmp_path: 
     assert published[0].reason == "published"
     assert published[0].created_issue_url == "https://github.com/synaptent/aragora/issues/5890"
     assert created[0][:3] == ["gh", "issue", "create"]
-    assert created[0].count("--label") == 2
+    assert created[0].count("--label") == 3
     assert created[1] == [
         "gh",
         "issue",
@@ -1630,7 +1631,7 @@ def test_publish_handoffs_creates_issue_with_labels(monkeypatch: Any, tmp_path: 
         "--repo",
         "synaptent/aragora",
         "--add-label",
-        "boss-ready,autonomous",
+        "boss-ready,autonomous,handoff-requested",
     ]
 
 
@@ -2189,6 +2190,44 @@ def test_load_outbox_handoffs_can_stop_after_preview_limit(
     assert len(handoffs) == 1
     assert skipped == Counter({"preview_limit": 2})
     assert expensive_checks == 1
+
+
+def test_load_outbox_handoffs_preserves_requested_issue_labels(tmp_path: Path) -> None:
+    outbox = tmp_path / ".aragora" / "automation-outbox"
+    receipts = tmp_path / ".aragora" / "automation-receipts"
+    outbox.mkdir(parents=True)
+    receipts.mkdir(parents=True)
+    (outbox / "handoff.json").write_text(
+        json.dumps(
+            _outbox_payload(
+                issue_labels=["from-top", "shared"],
+                requested_action={
+                    "type": "open_pr",
+                    "branch": "codex/example",
+                    "issue_labels": ["from-action", "shared"],
+                },
+                local_evidence={
+                    "branch": "codex/example",
+                    "issue_labels": ["from-evidence"],
+                },
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    handoffs = mod.load_outbox_handoffs(
+        tmp_path,
+        outbox_dir=outbox,
+        receipt_dir=receipts,
+    )
+
+    assert len(handoffs) == 1
+    assert handoffs[0].issue_labels == (
+        "from-top",
+        "shared",
+        "from-action",
+        "from-evidence",
+    )
 
 
 def test_main_summary_only_limits_outbox_loading(monkeypatch: Any, tmp_path: Path, capsys) -> None:

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -943,7 +943,9 @@ def test_publish_decisions_uses_remaining_open_pr_capacity(
     )
     monkeypatch.setattr(mod, "_existing_pr_number", lambda repo_root, repo, branch, base: None)
     monkeypatch.setattr(
-        mod, "_create_pr", lambda repo_root, repo, branch, base: next(created_numbers)
+        mod,
+        "_create_pr",
+        lambda repo_root, repo, branch, base, *, draft=False: next(created_numbers),
     )
     monkeypatch.setattr(
         mod, "_add_labels", lambda repo_root, repo, number, labels: calls.append(f"label:{number}")
@@ -1000,7 +1002,9 @@ def test_publish_decisions_records_publish_failures_and_continues(
     monkeypatch.setattr(mod, "_ensure_gh_auth", lambda repo_root: None)
     monkeypatch.setattr(mod, "_push_branch", fake_push)
     monkeypatch.setattr(mod, "_existing_pr_number", lambda repo_root, repo, branch, base: None)
-    monkeypatch.setattr(mod, "_create_pr", lambda repo_root, repo, branch, base: 2001)
+    monkeypatch.setattr(
+        mod, "_create_pr", lambda repo_root, repo, branch, base, *, draft=False: 2001
+    )
     monkeypatch.setattr(
         mod, "_add_labels", lambda repo_root, repo, number, labels: calls.append(f"label:{number}")
     )

--- a/tests/work/test_work_sources.py
+++ b/tests/work/test_work_sources.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from aragora.work.scoring import build_recommendations
+from aragora.work.sources import collect_automation_outbox
+
+
+def test_collect_automation_outbox_preserves_rich_publication_metadata(
+    tmp_path: Path,
+) -> None:
+    outbox = tmp_path / ".aragora" / "automation-outbox"
+    outbox.mkdir(parents=True)
+    payload = {
+        "idempotency_key": "open-pr-codex-value-drain",
+        "task": "Open a draft PR for authenticated outbox value drain.",
+        "status": "pending",
+        "branch": "codex/authenticated-outbox-value-drain-20260605",
+        "owner": "primary-writer",
+        "objective": "Publish one clean PR for useful automation output.",
+        "context": "GitHub publication was unavailable during the writer pass.",
+        "acceptance_criteria": [
+            "publisher keeps rich handoff evidence",
+            "work robot classifies the handoff as ready",
+        ],
+        "mutation_boundary": "Limited to value-drain publication tooling.",
+        "validation": {
+            "pytest": "tests/scripts/test_drain_codex_automation_value.py passed",
+            "ruff": "all checks passed",
+        },
+        "dependencies_declared": True,
+        "labels": ["codex", "codex-automation"],
+        "requested_action": {
+            "action": "open_pr",
+            "branch": "codex/authenticated-outbox-value-drain-20260605",
+            "desired_head_sha": "abc123",
+            "draft": True,
+            "labels": ["value-drain"],
+        },
+        "local_evidence": {
+            "branch_state": "committed",
+            "changed_files": [
+                "scripts/drain_codex_automation_value.py",
+                "tests/scripts/test_drain_codex_automation_value.py",
+            ],
+        },
+        "requires_github": True,
+        "publication_blocker": {
+            "mode": "connectivity_failed",
+            "summary": "gh unavailable during automation run",
+        },
+        "validation_summary": "focused value-drain tests passed",
+    }
+    (outbox / "open-pr-codex-value-drain.json").write_text(json.dumps(payload))
+
+    items, health = collect_automation_outbox(tmp_path)
+
+    assert health["status"] == "ok"
+    assert len(items) == 1
+    item = items[0]
+    assert item.tags == ["codex", "codex-automation", "value-drain"]
+    assert item.metadata["requested_action"] == payload["requested_action"]
+    assert item.metadata["local_evidence"] == payload["local_evidence"]
+    assert item.metadata["labels"] == payload["labels"]
+    assert item.metadata["requires_github"] is True
+    assert item.metadata["publication_blocker"] == payload["publication_blocker"]
+    assert item.metadata["validation_summary"] == payload["validation_summary"]
+
+    recommendation = build_recommendations(items)[0]
+    assert recommendation.classification == "ready"
+    assert recommendation.action == "publish_or_reconcile_handoff"
+    assert recommendation.priority == "high"
+    assert recommendation.blockers == []


### PR DESCRIPTION
## Summary
- add a top-level action_summary to authenticated value-drain reports
- expose planned vs published branch PRs, handoff issues, protected merges, and skipped phases
- keep the increment bounded to dry-run/reporting behavior plus focused tests

## Validation
- git diff --check
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/drain_codex_automation_value.py scripts/publish_codex_automation_branches.py tests/scripts/test_drain_codex_automation_value.py tests/scripts/test_publish_codex_automation_branches.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/drain_codex_automation_value.py scripts/publish_codex_automation_branches.py tests/scripts/test_drain_codex_automation_value.py tests/scripts/test_publish_codex_automation_branches.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_drain_codex_automation_value.py tests/scripts/test_publish_codex_automation_branches.py

## Notes
- no queue-drain apply path was run
- no bulk publishing or broad reconcile was run