### PR TITLE
fix(epistemic): validate regression fixture ids

### DIFF
--- a/scripts/check_epistemic_compliance_regression.py
+++ b/scripts/check_epistemic_compliance_regression.py
@@ -41,6 +41,31 @@ def _load_json(path: Path) -> dict[str, Any]:
         raise RuntimeError(f"Invalid JSON in {path}: {exc}") from exc
 
 
+def _validate_cases(cases: list[Any]) -> list[dict[str, Any]]:
+    """Validate fixture case identity before metrics can be overwritten."""
+    validated: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    errors: list[str] = []
+
+    for index, case in enumerate(cases):
+        if not isinstance(case, dict):
+            errors.append(f"case[{index}] must be an object")
+            continue
+        case_id = str(case.get("id", "")).strip()
+        if not case_id:
+            errors.append(f"case[{index}] is missing non-empty id")
+            continue
+        if case_id in seen_ids:
+            errors.append(f"case[{index}] duplicate id {case_id!r}")
+            continue
+        seen_ids.add(case_id)
+        validated.append(case)
+
+    if errors:
+        raise RuntimeError("Invalid fixture cases: " + "; ".join(errors))
+    return validated
+
+
 def _compute_metrics(cases: list[dict[str, Any]]) -> tuple[dict[str, Any], dict[str, Any]]:
     from aragora.debate.epistemic_hygiene import score_response
 
@@ -207,6 +232,7 @@ def main() -> int:
     cases = fixture_doc.get("cases", [])
     if not isinstance(cases, list):
         raise RuntimeError("fixtures JSON must contain a list field named 'cases'")
+    cases = _validate_cases(cases)
 
     model_metrics, case_results = _compute_metrics(cases)
     regressions = _check_thresholds(model_metrics, case_results, baseline_doc)

--- a/tests/scripts/test_check_epistemic_compliance_regression.py
+++ b/tests/scripts/test_check_epistemic_compliance_regression.py
@@ -78,3 +78,76 @@ def test_checker_fails_when_case_threshold_is_too_strict(tmp_path: Path) -> None
     assert result.returncode == 1
     assert "FAIL" in result.stdout
     assert "above threshold" in result.stdout
+
+
+def test_checker_rejects_duplicate_case_ids_before_scoring(tmp_path: Path) -> None:
+    fixtures_path = tmp_path / "fixtures.json"
+    fixtures_path.write_text(
+        json.dumps(
+            {
+                "cases": [
+                    {
+                        "id": "duplicate_case",
+                        "model": "strict_model",
+                        "text": "Confidence: 0.4; alternative: retry.",
+                    },
+                    {
+                        "id": "duplicate_case",
+                        "model": "strict_model",
+                        "text": "Confidence: 0.9 and no caveats.",
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(
+        json.dumps({"global": {"min_total_cases": 2}, "models": {}, "cases": {}}),
+        encoding="utf-8",
+    )
+
+    result = _run(
+        "--fixtures",
+        str(fixtures_path),
+        "--baseline",
+        str(baseline_path),
+    )
+
+    assert result.returncode == 1
+    assert "Invalid fixture cases" in result.stderr
+    assert "duplicate id 'duplicate_case'" in result.stderr
+
+
+def test_checker_rejects_blank_case_id_before_scoring(tmp_path: Path) -> None:
+    fixtures_path = tmp_path / "fixtures.json"
+    fixtures_path.write_text(
+        json.dumps(
+            {
+                "cases": [
+                    {
+                        "id": " ",
+                        "model": "strict_model",
+                        "text": "Confidence: 0.4; alternative: retry.",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(
+        json.dumps({"global": {"min_total_cases": 1}, "models": {}, "cases": {}}),
+        encoding="utf-8",
+    )
+
+    result = _run(
+        "--fixtures",
+        str(fixtures_path),
+        "--baseline",
+        str(baseline_path),
+    )
+
+    assert result.returncode == 1
+    assert "Invalid fixture cases" in result.stderr
+    assert "missing non-empty id" in result.stderr


### PR DESCRIPTION
## Summary
- validate epistemic compliance regression fixture cases before scoring
- fail closed on blank or duplicate case ids so case-specific thresholds cannot be skipped or overwritten
- add focused regressions for duplicate and blank fixture ids

## Tier / Scope
- Tier 1-2: proof-surface regression-checker hardening and test coverage only
- No queue authority, settlement, workflow, security, semantic API, or merge behavior changes

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_check_epistemic_compliance_regression.py -q
- /Users/armand/.pyenv/versions/3.11.11/bin/python scripts/check_epistemic_compliance_regression.py --strict --json-out /tmp/epistemic-fixture-id-validation.json --md-out /tmp/epistemic-fixture-id-validation.md
- bash scripts/automation_pr_preflight.sh origin/main HEAD