### PR TITLE
fix(prompts): align build_next_prompt health JSON command

### DIFF
--- a/scripts/build_next_prompt.py
+++ b/scripts/build_next_prompt.py
@@ -1453,7 +1453,7 @@ def build_prompt(
         "",
         "Run read-only live truth first:",
         "git status --short --branch --untracked-files=all",
-        "python3 scripts/agent_bridge.py --json health || true",
+        "python3 scripts/agent_bridge.py health --json || true",
         "python3 scripts/agent_bridge.py operator-snapshot --json --summary-only || true",
         "python3 scripts/list_active_agent_sessions.py --json --codex-session-scan-limit 120",
     ]

--- a/tests/scripts/test_build_next_prompt.py
+++ b/tests/scripts/test_build_next_prompt.py
@@ -114,6 +114,8 @@ def test_prompt_starts_with_mailbox_and_owner_verification(tmp_path: Path) -> No
 
     assert prompt.startswith("Start from live repo truth")
     assert "Before lane work, check your Aragora operator-steering mailbox" in prompt
+    assert "python3 scripts/agent_bridge.py health --json || true" in prompt
+    assert "python3 scripts/agent_bridge.py --json health || true" not in prompt
     assert (
         "python3 scripts/read_operator_steering.py --lane-id P106-merge-gate-settlement" in prompt
     )


### PR DESCRIPTION
## Summary
- update build_next_prompt recursive live-truth prompts to emit `agent_bridge.py health --json`
- keep the generated prompt aligned with live subcommand help and the static fanout prompt direction
- add a focused regression in `tests/scripts/test_build_next_prompt.py`

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_build_next_prompt.py -q
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/build_next_prompt.py tests/scripts/test_build_next_prompt.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/build_next_prompt.py tests/scripts/test_build_next_prompt.py
- git diff --check origin/main...HEAD
- git merge-tree --write-tree origin/main HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- `agent_bridge.py health --help` exposes `--json`; `agent_bridge.py health --json` accepts the subcommand-local form