### PR TITLE
fix(proof-surface): flag broken freshness artifacts

### DIFF
--- a/scripts/publish_publication_freshness_probe.py
+++ b/scripts/publish_publication_freshness_probe.py
@@ -266,23 +266,66 @@ def scan_benchmark_truth_artifacts(
         if not child.is_dir():
             continue
         latest = child / "latest.json"
+        latest_path = str(latest.relative_to(truth_root.parent.parent.parent))
         if not latest.exists():
+            row = {
+                "corpus_id": child.name,
+                "latest_path": latest_path,
+                "generated_at": None,
+                "age_hours": None,
+                "is_stale": False,
+                "stale_threshold_hours": stale_hours,
+                "coverage_status": None,
+                "artifact_status": "missing_latest",
+                "reason": "latest.json not present",
+            }
+            corpora.append(row)
+            drift.append(row)
             continue
         try:
             payload = json.loads(latest.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
+        except OSError as exc:
+            row = {
+                "corpus_id": child.name,
+                "latest_path": latest_path,
+                "generated_at": None,
+                "age_hours": None,
+                "is_stale": False,
+                "stale_threshold_hours": stale_hours,
+                "coverage_status": None,
+                "artifact_status": "unreadable_latest",
+                "reason": str(exc),
+            }
+            corpora.append(row)
+            drift.append(row)
+            continue
+        except json.JSONDecodeError as exc:
+            row = {
+                "corpus_id": child.name,
+                "latest_path": latest_path,
+                "generated_at": None,
+                "age_hours": None,
+                "is_stale": False,
+                "stale_threshold_hours": stale_hours,
+                "coverage_status": None,
+                "artifact_status": "invalid_latest_json",
+                "reason": str(exc),
+            }
+            corpora.append(row)
+            drift.append(row)
             continue
         generated_at = _parse_iso(payload.get("generated_at"))
         age_hours = _hours_between(now, generated_at) if generated_at else None
         is_stale = age_hours is not None and age_hours > stale_hours
         row = {
             "corpus_id": child.name,
-            "latest_path": str(latest.relative_to(truth_root.parent.parent.parent)),
+            "latest_path": latest_path,
             "generated_at": payload.get("generated_at"),
             "age_hours": round(age_hours, 2) if age_hours is not None else None,
             "is_stale": bool(is_stale),
             "stale_threshold_hours": stale_hours,
             "coverage_status": (payload.get("coverage") or {}).get("status"),
+            "artifact_status": "ok",
         }
         corpora.append(row)
         if is_stale:
@@ -420,11 +463,19 @@ def render_status_markdown(report: dict[str, Any]) -> str:
             f"drift_count={benchmark.get('drift_count')}"
         )
         for row in benchmark.get("corpora") or []:
+            artifact_status = str(row.get("artifact_status") or "ok")
             marker = "STALE" if row.get("is_stale") else "ok"
-            lines.append(
+            if artifact_status != "ok" and not row.get("is_stale"):
+                marker = "DRIFT"
+            line = (
                 f"- [{marker:5}] {row.get('corpus_id')}: age={row.get('age_hours')}h, "
                 f"coverage={row.get('coverage_status')}"
             )
+            if artifact_status != "ok":
+                line += f", artifact_status={artifact_status}"
+            if row.get("reason"):
+                line += f", reason={row.get('reason')}"
+            lines.append(line)
     else:
         lines.append(f"unavailable: {benchmark.get('reason')}")
 

--- a/tests/scripts/test_publish_publication_freshness_probe.py
+++ b/tests/scripts/test_publish_publication_freshness_probe.py
@@ -133,6 +133,29 @@ def test_scan_benchmark_truth_artifacts_flags_stale(tmp_path: Path) -> None:
     assert out["drift_count"] == 1
 
 
+def test_scan_benchmark_truth_artifacts_flags_broken_latest(tmp_path: Path) -> None:
+    truth_root = tmp_path / "tracked" / "benchmark_truth_artifacts"
+    missing_dir = truth_root / "tw-missing"
+    invalid_dir = truth_root / "tw-invalid"
+    missing_dir.mkdir(parents=True)
+    invalid_dir.mkdir(parents=True)
+    (invalid_dir / "latest.json").write_text("{not-json", encoding="utf-8")
+
+    out = publisher.scan_benchmark_truth_artifacts(
+        truth_root=truth_root, stale_hours=48.0, now=_now()
+    )
+
+    assert out["available"] is True
+    assert out["drift_count"] == 2
+    by_corpus = {row["corpus_id"]: row for row in out["corpora"]}
+    assert by_corpus["tw-missing"]["artifact_status"] == "missing_latest"
+    assert by_corpus["tw-invalid"]["artifact_status"] == "invalid_latest_json"
+    assert {row["artifact_status"] for row in out["drift_records"]} == {
+        "missing_latest",
+        "invalid_latest_json",
+    }
+
+
 def test_scan_benchmark_truth_artifacts_missing_root(tmp_path: Path) -> None:
     out = publisher.scan_benchmark_truth_artifacts(
         truth_root=tmp_path / "absent", stale_hours=48.0, now=_now()
@@ -255,7 +278,16 @@ def test_render_status_markdown_emits_sections() -> None:
                         "age_hours": 10.0,
                         "coverage_status": "complete",
                         "is_stale": False,
-                    }
+                        "artifact_status": "ok",
+                    },
+                    {
+                        "corpus_id": "tw-broken",
+                        "age_hours": None,
+                        "coverage_status": None,
+                        "is_stale": False,
+                        "artifact_status": "invalid_latest_json",
+                        "reason": "Expecting value",
+                    },
                 ],
             },
         },
@@ -266,6 +298,8 @@ def test_render_status_markdown_emits_sections() -> None:
     assert "## Canonical Metrics" in md
     assert "## Status-doc Reconciliation" in md
     assert "## Benchmark Truth Artifacts" in md
+    assert "[DRIFT]" in md
+    assert "artifact_status=invalid_latest_json" in md
     assert "ROADMAP.md" in md
 
 


### PR DESCRIPTION
## Summary
- Count missing benchmark-truth `latest.json` files as publication-freshness drift instead of skipping the corpus.
- Count unreadable or malformed benchmark-truth `latest.json` files as explicit drift records.
- Surface `artifact_status` and the parse/read reason in the markdown status output.

## Validation
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_publish_publication_freshness_probe.py -q`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/publish_publication_freshness_probe.py tests/scripts/test_publish_publication_freshness_probe.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python scripts/publish_publication_freshness_probe.py --json --dry-run`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Scope
Tier 2 reporting/proof-surface hardening only. No queue authority, settlement, merge, workflow, security, API, or semantic benchmark changes.