### PR TITLE
fix(benchmarks): require publish artifact identity

### DIFF
--- a/scripts/build_benchmark_truth_artifact.py
+++ b/scripts/build_benchmark_truth_artifact.py
@@ -873,18 +873,37 @@ def _revision_publish_dir(*, publish_dir: Path, corpus: dict[str, Any]) -> Path:
     return _corpus_publish_dir(publish_dir=publish_dir, corpus=corpus) / f"rev-{revision}"
 
 
+def _publishable_artifact_identity(artifact: dict[str, Any]) -> tuple[dict[str, Any], str]:
+    corpus = artifact.get("corpus")
+    if not isinstance(corpus, dict):
+        raise ValueError("benchmark truth artifact must contain a corpus object before publishing")
+    corpus_id = str(corpus.get("corpus_id") or "").strip()
+    if not corpus_id:
+        raise ValueError("benchmark truth artifact corpus.corpus_id is required before publishing")
+    try:
+        revision = int(corpus.get("revision", 0) or 0)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "benchmark truth artifact corpus.revision must be a positive integer before publishing"
+        ) from exc
+    if revision <= 0:
+        raise ValueError(
+            "benchmark truth artifact corpus.revision must be a positive integer before publishing"
+        )
+    generated_at = artifact.get("generated_at")
+    if not isinstance(generated_at, str) or not generated_at.strip():
+        raise ValueError("benchmark truth artifact generated_at is required before publishing")
+    normalized_generated_at = normalize_generated_at(generated_at)
+    return {"corpus_id": corpus_id, "revision": revision}, normalized_generated_at
+
+
 def resolve_published_artifact_path(
     *,
     publish_dir: Path,
     artifact: dict[str, Any],
 ) -> Path:
-    corpus = artifact.get("corpus")
-    if not isinstance(corpus, dict):
-        corpus = {}
-    generated_at = artifact.get("generated_at")
-    timestamp = _coerce_utc_datetime(
-        generated_at if isinstance(generated_at, str) else None
-    ).strftime("%Y%m%dT%H%M%SZ")
+    corpus, generated_at = _publishable_artifact_identity(artifact)
+    timestamp = _coerce_utc_datetime(generated_at).strftime("%Y%m%dT%H%M%SZ")
     filename = f"truth-{timestamp}.json"
     return _revision_publish_dir(publish_dir=publish_dir, corpus=corpus) / filename
 
@@ -894,9 +913,7 @@ def resolve_latest_artifact_paths(
     publish_dir: Path,
     artifact: dict[str, Any],
 ) -> dict[str, Path]:
-    corpus = artifact.get("corpus")
-    if not isinstance(corpus, dict):
-        corpus = {}
+    corpus, _generated_at = _publishable_artifact_identity(artifact)
     return {
         "corpus_latest": _corpus_publish_dir(publish_dir=publish_dir, corpus=corpus)
         / "latest.json",

--- a/tests/scripts/test_build_benchmark_truth_artifact.py
+++ b/tests/scripts/test_build_benchmark_truth_artifact.py
@@ -1263,6 +1263,43 @@ def test_resolve_latest_artifact_paths_use_corpus_and_revision_roots() -> None:
     }
 
 
+def test_publish_artifact_bundle_rejects_missing_identity(tmp_path: Path) -> None:
+    valid_artifact = {
+        "generated_at": "2026-04-14T02:03:04Z",
+        "corpus": {
+            "corpus_id": "tw-01-bounded-execution-v1",
+            "revision": 7,
+            "issue_count": 1,
+        },
+        "primary_metrics": {"truth_success_rate": 1.0},
+    }
+
+    cases = [
+        (
+            {**valid_artifact, "generated_at": ""},
+            "generated_at is required",
+        ),
+        (
+            {**valid_artifact, "corpus": {**valid_artifact["corpus"], "corpus_id": ""}},
+            "corpus.corpus_id is required",
+        ),
+        (
+            {**valid_artifact, "corpus": {**valid_artifact["corpus"], "revision": 0}},
+            "corpus.revision must be a positive integer",
+        ),
+    ]
+
+    for artifact, expected_message in cases:
+        publish_dir = tmp_path / expected_message.split()[0]
+        try:
+            mod.publish_artifact_bundle(publish_dir=publish_dir, artifact=artifact)
+        except ValueError as exc:
+            assert expected_message in str(exc)
+        else:
+            raise AssertionError(f"expected ValueError containing {expected_message!r}")
+        assert not publish_dir.exists()
+
+
 def test_main_publish_dir_writes_timestamped_artifact_and_prints_path(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## Summary
- Require benchmark truth artifacts to include `generated_at`, `corpus.corpus_id`, and a positive `corpus.revision` before publishing.
- Fail before writing timestamped or `latest.json` pointers when artifact identity is incomplete.
- Add regression coverage for malformed publish identity.

## Validation
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_build_benchmark_truth_artifact.py -q`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/build_benchmark_truth_artifact.py tests/scripts/test_build_benchmark_truth_artifact.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Scope
Tier 2 benchmark-truth publication hardening only. No queue authority, settlement, merge, workflow, security, API, or semantic benchmark changes.