### PR TITLE
fix(proof-surface): fail closed on observer status probe errors

### DIFF
--- a/scripts/observer_truth_probe.py
+++ b/scripts/observer_truth_probe.py
@@ -165,14 +165,19 @@ def ahead_behind(repo_root: Path) -> tuple[int, int]:
 
 def untracked_files(repo_root: Path) -> list[str]:
     """Return the list of untracked, non-ignored files in ``repo_root``."""
+    files, _reason = _untracked_files_probe(repo_root)
+    return files
+
+
+def _untracked_files_probe(repo_root: Path) -> tuple[list[str], str | None]:
     try:
         result = _run_git(
             ["ls-files", "--others", "--exclude-standard"],
             repo_root=repo_root,
         )
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
-        return []
-    return [line for line in result.stdout.splitlines() if line.strip()]
+        return [], "untracked_files_probe_failed"
+    return [line for line in result.stdout.splitlines() if line.strip()], None
 
 
 def uncommitted_modified_files(repo_root: Path) -> list[str]:
@@ -182,7 +187,13 @@ def uncommitted_modified_files(repo_root: Path) -> list[str]:
     index) and ``git diff --name-only --cached`` (staged changes against
     HEAD), de-duplicating paths that appear in both.
     """
+    files, _reason = _uncommitted_modified_files_probe(repo_root)
+    return files
+
+
+def _uncommitted_modified_files_probe(repo_root: Path) -> tuple[list[str], str | None]:
     paths: set[str] = set()
+    failed = False
     for extra in ([], ["--cached"]):
         try:
             result = _run_git(
@@ -190,12 +201,14 @@ def uncommitted_modified_files(repo_root: Path) -> list[str]:
                 repo_root=repo_root,
             )
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+            failed = True
             continue
         for line in result.stdout.splitlines():
             line = line.strip()
             if line:
                 paths.add(line)
-    return sorted(paths)
+    reason = "uncommitted_modified_probe_failed" if failed else None
+    return sorted(paths), reason
 
 
 def submodule_dirty(repo_root: Path) -> bool:
@@ -211,6 +224,11 @@ def submodule_dirty(repo_root: Path) -> bool:
     A repo with no submodules emits no output, which is treated as
     clean.
     """
+    dirty, _reason = _submodule_dirty_probe(repo_root)
+    return dirty
+
+
+def _submodule_dirty_probe(repo_root: Path) -> tuple[bool, str | None]:
     try:
         result = _run_git(
             ["submodule", "status", "--recursive"],
@@ -218,17 +236,15 @@ def submodule_dirty(repo_root: Path) -> bool:
             check=False,
         )
     except subprocess.TimeoutExpired:
-        return False
+        return False, "submodule_status_probe_failed"
     if result.returncode != 0:
-        # Not a git repo or git too old; treat as not-dirty rather than
-        # masking the real signal.
-        return False
+        return False, "submodule_status_probe_failed"
     for line in result.stdout.splitlines():
         if not line:
             continue
         if line[0] in {"+", "-", "U"}:
-            return True
-    return False
+            return True, None
+    return False, None
 
 
 def probe(
@@ -253,9 +269,9 @@ def probe(
     else:
         ahead, behind = (0, 0)
 
-    untracked = untracked_files(repo_root)
-    uncommitted = uncommitted_modified_files(repo_root)
-    sub_dirty = submodule_dirty(repo_root)
+    untracked, untracked_probe_reason = _untracked_files_probe(repo_root)
+    uncommitted, uncommitted_probe_reason = _uncommitted_modified_files_probe(repo_root)
+    sub_dirty, submodule_probe_reason = _submodule_dirty_probe(repo_root)
 
     if untracked:
         reasons.append(f"untracked_files={len(untracked)}")
@@ -263,6 +279,16 @@ def probe(
         reasons.append(f"uncommitted_modified={len(uncommitted)}")
     if sub_dirty:
         reasons.append("submodule_dirty")
+    status_probe_reasons = [
+        reason
+        for reason in (
+            untracked_probe_reason,
+            uncommitted_probe_reason,
+            submodule_probe_reason,
+        )
+        if reason
+    ]
+    reasons.extend(status_probe_reasons)
     if ahead:
         reasons.append(f"ahead_of_origin_main={ahead}")
     if behind:
@@ -274,6 +300,7 @@ def probe(
         len(untracked) == 0
         and len(uncommitted) == 0
         and not sub_dirty
+        and not status_probe_reasons
         and ahead == 0
         and behind == 0
         and bool(head)

--- a/tests/scripts/test_observer_truth_probe.py
+++ b/tests/scripts/test_observer_truth_probe.py
@@ -203,3 +203,111 @@ def test_module_probe_pure_python(tmp_path: Path) -> None:
     }
     assert set(result.keys()) == expected_keys
     assert result["clean"] is True
+
+
+def test_probe_fails_closed_when_untracked_status_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import observer_truth_probe as mod
+
+    sha = "a" * 40
+
+    def fake_run_git(
+        args: list[str],
+        *,
+        repo_root: Path,
+        check: bool = True,
+        timeout: float = mod.GIT_TIMEOUT_SECONDS,
+    ) -> subprocess.CompletedProcess[str]:
+        if args == ["rev-parse", "HEAD"] or args == ["rev-parse", "origin/main"]:
+            return subprocess.CompletedProcess(args, 0, stdout=f"{sha}\n", stderr="")
+        if args == ["rev-list", "--left-right", "--count", "origin/main...HEAD"]:
+            return subprocess.CompletedProcess(args, 0, stdout="0 0\n", stderr="")
+        if args == ["ls-files", "--others", "--exclude-standard"]:
+            raise subprocess.CalledProcessError(128, args, stderr="status failed")
+        if args[0] == "diff":
+            return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+        if args == ["submodule", "status", "--recursive"]:
+            return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+        raise AssertionError(f"unexpected git args: {args!r}")
+
+    monkeypatch.setattr(mod, "_run_git", fake_run_git)
+
+    result = mod.probe(tmp_path, fetch=False)
+
+    assert result["clean"] is False
+    assert result["untracked_count"] == 0
+    assert "untracked_files_probe_failed" in result["reasons"]
+
+
+def test_probe_fails_closed_when_diff_status_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import observer_truth_probe as mod
+
+    sha = "b" * 40
+
+    def fake_run_git(
+        args: list[str],
+        *,
+        repo_root: Path,
+        check: bool = True,
+        timeout: float = mod.GIT_TIMEOUT_SECONDS,
+    ) -> subprocess.CompletedProcess[str]:
+        if args == ["rev-parse", "HEAD"] or args == ["rev-parse", "origin/main"]:
+            return subprocess.CompletedProcess(args, 0, stdout=f"{sha}\n", stderr="")
+        if args == ["rev-list", "--left-right", "--count", "origin/main...HEAD"]:
+            return subprocess.CompletedProcess(args, 0, stdout="0 0\n", stderr="")
+        if args == ["ls-files", "--others", "--exclude-standard"]:
+            return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+        if args[0] == "diff":
+            raise subprocess.TimeoutExpired(args, timeout=timeout)
+        if args == ["submodule", "status", "--recursive"]:
+            return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+        raise AssertionError(f"unexpected git args: {args!r}")
+
+    monkeypatch.setattr(mod, "_run_git", fake_run_git)
+
+    result = mod.probe(tmp_path, fetch=False)
+
+    assert result["clean"] is False
+    assert result["uncommitted_modified_count"] == 0
+    assert "uncommitted_modified_probe_failed" in result["reasons"]
+
+
+def test_probe_fails_closed_when_submodule_status_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import observer_truth_probe as mod
+
+    sha = "c" * 40
+
+    def fake_run_git(
+        args: list[str],
+        *,
+        repo_root: Path,
+        check: bool = True,
+        timeout: float = mod.GIT_TIMEOUT_SECONDS,
+    ) -> subprocess.CompletedProcess[str]:
+        if args == ["rev-parse", "HEAD"] or args == ["rev-parse", "origin/main"]:
+            return subprocess.CompletedProcess(args, 0, stdout=f"{sha}\n", stderr="")
+        if args == ["rev-list", "--left-right", "--count", "origin/main...HEAD"]:
+            return subprocess.CompletedProcess(args, 0, stdout="0 0\n", stderr="")
+        if args == ["ls-files", "--others", "--exclude-standard"]:
+            return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+        if args[0] == "diff":
+            return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+        if args == ["submodule", "status", "--recursive"]:
+            return subprocess.CompletedProcess(args, 128, stdout="", stderr="status failed")
+        raise AssertionError(f"unexpected git args: {args!r}")
+
+    monkeypatch.setattr(mod, "_run_git", fake_run_git)
+
+    result = mod.probe(tmp_path, fetch=False)
+
+    assert result["clean"] is False
+    assert result["submodule_dirty"] is False
+    assert "submodule_status_probe_failed" in result["reasons"]


### PR DESCRIPTION
## Summary
- Make `observer_truth_probe.py` fail closed when untracked-file, diff, or submodule status probes fail.
- Preserve the existing JSON shape while adding explicit failure reasons to `reasons`.
- Add direct regression coverage for status-probe failure cases where HEAD still matches origin/main.

## Validation
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_observer_truth_probe.py -q`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/observer_truth_probe.py tests/scripts/test_observer_truth_probe.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python scripts/observer_truth_probe.py --repo-root . --quiet --no-fetch` (expected non-zero: branch is one commit ahead of origin/main, no uncommitted files)
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Scope
Tier 2 product-proof observer hardening only. No queue authority, settlement, merge, workflow, security, API, or benchmark semantic changes.