### PR TITLE
fix(prompts): align PR follow-up health command

### DIFF
--- a/scripts/pr_check_followup.py
+++ b/scripts/pr_check_followup.py
@@ -918,7 +918,7 @@ def build_prompt(
         [
             "Run read-only first:",
             "- git status --short --branch --untracked-files=all",
-            "- python3 scripts/agent_bridge.py --json health || true",
+            "- python3 scripts/agent_bridge.py health --json || true",
             f"- python3 scripts/identify_lane_owner.py --pr {pr_number} --json || true",
             f"- gh pr view {pr_number} --json number,state,isDraft,headRefName,headRefOid,mergeable,mergeStateStatus,statusCheckRollup,url",
             "",

--- a/tests/scripts/test_pr_check_followup.py
+++ b/tests/scripts/test_pr_check_followup.py
@@ -533,6 +533,8 @@ def test_prompt_always_contains_recursive_convergence_sentences() -> None:
 
     assert followup.INCREMENTAL_PROGRESS_SENTENCE in result.prompt
     assert followup.META_AUTOMATION_SENTENCE in result.prompt
+    assert "- python3 scripts/agent_bridge.py health --json || true" in result.prompt
+    assert "- python3 scripts/agent_bridge.py --json health || true" not in result.prompt
 
 
 def test_wait_check_waits_for_matching_status_row_then_emits_reruns(monkeypatch: Any) -> None:


### PR DESCRIPTION
## Summary
- update `pr_check_followup.py` recursive follow-up prompts to emit `agent_bridge.py health --json`
- keep the generated read-only probe aligned with live subcommand help and the other prompt alignment PRs
- add a focused regression in `tests/scripts/test_pr_check_followup.py`

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_pr_check_followup.py -q
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/pr_check_followup.py tests/scripts/test_pr_check_followup.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/pr_check_followup.py tests/scripts/test_pr_check_followup.py
- `agent_bridge.py health --help` exposes `--json`; `agent_bridge.py health --json` accepts the subcommand-local form
- no `agent_bridge.py --json health` remains in `scripts/pr_check_followup.py`
- git diff --check origin/main...HEAD
- git merge-tree --write-tree origin/main HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD