### PR TITLE
fix(benchmarks): require positive dogfood runs

### DIFF
--- a/scripts/run_dogfood_benchmark.py
+++ b/scripts/run_dogfood_benchmark.py
@@ -373,6 +373,11 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv or sys.argv[1:])
+    if args.runs <= 0:
+        raise SystemExit("--runs must be a positive integer")
+    if args.timeout <= 0:
+        raise SystemExit("--timeout must be a positive integer")
+
     base_report = Path(args.base_report)
     if not base_report.is_file():
         raise SystemExit(f"Base report not found: {base_report}")

--- a/tests/scripts/test_run_dogfood_benchmark.py
+++ b/tests/scripts/test_run_dogfood_benchmark.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 from pathlib import Path
+
+import pytest
 
 # Ensure scripts/ is importable.
 _scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
@@ -27,6 +30,46 @@ def test_cli_help_runs_from_checked_out_script_path() -> None:
 
     assert result.returncode == 0, result.stderr
     assert "Run controlled dogfood benchmark loops" in result.stdout
+
+
+def test_main_rejects_zero_runs_before_writing_report(tmp_path: Path) -> None:
+    base_report = tmp_path / "base.json"
+    output = tmp_path / "report.json"
+    base_report.write_text(json.dumps({"command": [sys.executable, "--version"]}))
+
+    with pytest.raises(SystemExit, match="--runs must be a positive integer"):
+        run_dogfood_benchmark.main(
+            [
+                "--base-report",
+                str(base_report),
+                "--output",
+                str(output),
+                "--runs",
+                "0",
+            ]
+        )
+
+    assert not output.exists()
+
+
+def test_main_rejects_zero_timeout_before_writing_report(tmp_path: Path) -> None:
+    base_report = tmp_path / "base.json"
+    output = tmp_path / "report.json"
+    base_report.write_text(json.dumps({"command": [sys.executable, "--version"]}))
+
+    with pytest.raises(SystemExit, match="--timeout must be a positive integer"):
+        run_dogfood_benchmark.main(
+            [
+                "--base-report",
+                str(base_report),
+                "--output",
+                str(output),
+                "--timeout",
+                "0",
+            ]
+        )
+
+    assert not output.exists()
 
 
 def _run_template(checks: dict[str, bool | None]) -> dict[str, object]:


### PR DESCRIPTION
## Summary
- reject non-positive dogfood benchmark `--runs` before loading or writing reports
- reject non-positive dogfood benchmark `--timeout` before a benchmark report can be emitted
- add regression coverage that verifies no report file is written for either invalid value

## Scope
Tier 2 benchmark/product-proof reporting guard. This does not touch queue authority, settlement, merge logic, security policy, workflows, public API, or persistence semantics.

## Validation
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_run_dogfood_benchmark.py -q`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/run_dogfood_benchmark.py tests/scripts/test_run_dogfood_benchmark.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/run_dogfood_benchmark.py tests/scripts/test_run_dogfood_benchmark.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`