### PR TITLE
fix(benchmarks): verify recurrence issue metadata

### DIFF
--- a/scripts/run_benchmark_corpus_recurrence.py
+++ b/scripts/run_benchmark_corpus_recurrence.py
@@ -79,6 +79,15 @@ def fetch_issue_metadata(
             ],
             runner=runner,
         )
+        payload_number = payload.get("number")
+        if (
+            not isinstance(payload_number, int)
+            or isinstance(payload_number, bool)
+            or payload_number != issue_number
+        ):
+            raise RuntimeError(
+                f"issue metadata number mismatch: requested {issue_number}, got {payload_number!r}"
+            )
         labels: list[str] = []
         for label in list(payload.get("labels") or []):
             if isinstance(label, dict):
@@ -88,7 +97,7 @@ def fetch_issue_metadata(
             if label_name:
                 labels.append(label_name)
         metadata[issue_number] = {
-            "number": int(payload.get("number") or issue_number),
+            "number": payload_number,
             "state": str(payload.get("state") or "").strip().upper(),
             "labels": labels,
             "title": str(payload.get("title") or "").strip(),

--- a/tests/scripts/test_run_benchmark_corpus_recurrence.py
+++ b/tests/scripts/test_run_benchmark_corpus_recurrence.py
@@ -50,6 +50,29 @@ def test_filter_open_issue_numbers_only_keeps_open_issues() -> None:
     ) == [1001, 1003]
 
 
+def test_fetch_issue_metadata_rejects_wrong_issue_number() -> None:
+    def runner(
+        cmd: list[str],
+        *,
+        capture_output: bool,
+        text: bool,
+        check: bool,
+        cwd: str | None = None,
+    ) -> SimpleNamespace:
+        del cmd, capture_output, text, check, cwd
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps({"number": 9999, "state": "OPEN"}),
+            stderr="",
+        )
+
+    with pytest.raises(
+        RuntimeError,
+        match="issue metadata number mismatch: requested 1001, got 9999",
+    ):
+        mod.fetch_issue_metadata("synaptent/aragora", [1001], runner=runner)
+
+
 def test_build_boss_loop_command_uses_explicit_issue_list_contract() -> None:
     command = mod.build_boss_loop_command(
         repo="synaptent/aragora",


### PR DESCRIPTION
## Summary
- fail closed when recurrence benchmark issue metadata returns a different issue number than requested
- preserve the verified payload number instead of silently substituting the requested corpus issue
- add regression coverage for mismatched GitHub issue metadata

## Scope
Tier 2 benchmark/product-proof reporting guard. This does not touch queue authority, settlement, merge logic, security policy, workflows, public API, or persistence semantics.

## Validation
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_run_benchmark_corpus_recurrence.py -q`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/run_benchmark_corpus_recurrence.py tests/scripts/test_run_benchmark_corpus_recurrence.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/run_benchmark_corpus_recurrence.py tests/scripts/test_run_benchmark_corpus_recurrence.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`