### PR TITLE
docs(automation): use backlog audit state-root defaults

### DIFF
--- a/docs/briefs/codex-desktop-automation-autonomy.md
+++ b/docs/briefs/codex-desktop-automation-autonomy.md
@@ -16,10 +16,12 @@ The fleet should continuously turn local evidence into small, reviewable improve
 Every automation should start from live repo evidence, not prior narration:
 
 1. Read its own memory at `~/.codex/automations/<automation-id>/memory.md` if present.
-2. Inspect `~/aragora/.aragora/automation-outbox` and `.aragora/automation-receipts`.
+2. Inspect the shared `.aragora/automation-outbox` and `.aragora/automation-receipts` state.
+   From disposable worktrees, let the helper resolve the shared state root, or pass
+   `--state-root <repo-root-or-.aragora>` when running from a nonstandard checkout.
 3. Run the relevant local status command before choosing a lane:
    - `python3 scripts/check_codex_desktop_automations.py --json --summary-only`
-   - `python3 scripts/audit_codex_branch_backlog.py --max-branches 200 --json --summary-only --outbox-dir ~/aragora/.aragora/automation-outbox --receipt-dir ~/aragora/.aragora/automation-receipts`
+   - `python3 scripts/audit_codex_branch_backlog.py --max-branches 200 --json --summary-only`
    - `python3 scripts/agent_bridge.py operator-snapshot --json --summary-only` for gating, or omit `--summary-only` when detailed session context is needed.
 4. Treat sandboxed GitHub failure as expected. Use local git, shared outbox files, and receipts as the primary automation substrate.
 

--- a/tests/test_docs_only.py
+++ b/tests/test_docs_only.py
@@ -87,3 +87,18 @@ def test_master_fanout_prompt_uses_live_agent_bridge_json_order():
     assert "python3 scripts/agent_bridge.py --json operator-snapshot --summary-only" not in prompt
     assert "python3 scripts/agent_bridge.py --json health" not in prompt
     assert "must precede subcommand" not in prompt
+
+
+def test_codex_desktop_autonomy_uses_backlog_audit_state_root_defaults():
+    repo_root = Path(__file__).resolve().parents[1]
+    brief = (repo_root / "docs/briefs/codex-desktop-automation-autonomy.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert (
+        "python3 scripts/audit_codex_branch_backlog.py --max-branches 200 --json --summary-only"
+        in brief
+    )
+    assert "--state-root <repo-root-or-.aragora>" in brief
+    assert "--outbox-dir ~/aragora/.aragora/automation-outbox" not in brief
+    assert "--receipt-dir ~/aragora/.aragora/automation-receipts" not in brief


### PR DESCRIPTION
## Summary
- align the Codex Desktop autonomy brief with the backlog audit helper's shared state-root/default behavior
- remove the non-portable explicit `~/aragora` outbox/receipt flags from the startup command
- add a docs-only regression test for the command shape and `--state-root` guidance

## Validation
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/test_docs_only.py -q` -> 14 passed
- `python3 scripts/audit_codex_branch_backlog.py --max-branches 200 --json --summary-only` -> resolves shared outbox/receipt dirs under `/Users/armand/Development/aragora/.aragora`, publishable backlog 0
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> ok

## Risk
- docs/test only; no AGENTS.md, workflow, branch protection, release, or merge-authority semantics changes