### PR TITLE
fix(benchmarks): fail closed on smoke command failure

### DIFF
--- a/scripts/run_factory_review_benchmark_smoke.py
+++ b/scripts/run_factory_review_benchmark_smoke.py
@@ -270,6 +270,12 @@ def execute_run_plan(
                 "stderr": result.stderr,
             }
         )
+    failed = [execution for execution in executed if int(execution["returncode"]) != 0]
+    if failed:
+        offenders = ", ".join(
+            f"{execution['case_id']}(returncode={execution['returncode']})" for execution in failed
+        )
+        raise ValueError(f"benchmark smoke command failed: {offenders}")
     updated = dict(plan)
     updated["guardrails"] = {**dict(plan.get("guardrails", {})), "mode": "executed"}
     updated["executions"] = executed

--- a/tests/scripts/test_run_factory_review_benchmark_smoke.py
+++ b/tests/scripts/test_run_factory_review_benchmark_smoke.py
@@ -172,6 +172,39 @@ def test_execute_run_plan_writes_normalized_receipt(tmp_path: Path, monkeypatch:
     assert case_receipt["judge_swap_variance_pp"] is None
 
 
+def test_execute_run_plan_rejects_failed_command_without_receipt(
+    tmp_path: Path,
+    monkeypatch: object,
+) -> None:
+    plan = smoke.build_run_plan(_manifest(), artifact_root=tmp_path / "artifacts")
+    receipt_path = tmp_path / "receipt.json"
+
+    def fake_current_head_sha(pr_url: str) -> str:
+        assert pr_url == "https://github.com/droid-code-review-evals/droid-sentry/pull/6"
+        return "cb7212e11dbdbc1813237ad129c7bc108f944e3d"
+
+    def fake_run(command: list[str], check: bool, capture_output: bool, text: bool):
+        del check, capture_output, text
+        return smoke.subprocess.CompletedProcess(
+            args=command,
+            returncode=2,
+            stdout="",
+            stderr="review failed",
+        )
+
+    monkeypatch.setattr(smoke, "_current_pr_head_sha", fake_current_head_sha)
+    monkeypatch.setattr(smoke.subprocess, "run", fake_run)
+
+    try:
+        smoke.execute_run_plan(plan, receipt_output=receipt_path)
+    except ValueError as exc:
+        assert "benchmark smoke command failed: droid-sentry-pr-6(returncode=2)" in str(exc)
+    else:
+        raise AssertionError("failed smoke command should fail closed")
+
+    assert not receipt_path.exists()
+
+
 def test_main_accepts_receipt_output_for_execute(tmp_path: Path, monkeypatch: object) -> None:
     manifest_path = tmp_path / "manifest.json"
     output_path = tmp_path / "plan.json"


### PR DESCRIPTION
## Summary
- fail closed when any Factory review benchmark smoke case command exits non-zero
- prevent failed smoke executions from writing a normal executed receipt
- add regression coverage that verifies a failed case does not create the receipt file

## Scope
Tier 2 benchmark/product-proof reporting guard. This does not touch queue authority, settlement, merge logic, security policy, workflows, public API, or persistence semantics.

## Validation
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_run_factory_review_benchmark_smoke.py -q`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/run_factory_review_benchmark_smoke.py tests/scripts/test_run_factory_review_benchmark_smoke.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/run_factory_review_benchmark_smoke.py tests/scripts/test_run_factory_review_benchmark_smoke.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`