### PR TITLE
fix(benchmarks): reject empty triage profile reports

### DIFF
--- a/scripts/benchmark_triage_profiles.py
+++ b/scripts/benchmark_triage_profiles.py
@@ -8,6 +8,7 @@ import asyncio
 import json
 import sys
 from pathlib import Path
+from typing import Any
 
 from aragora.inbox.triage_profile_benchmark import render_benchmark_report, run_fixture_benchmark
 
@@ -45,6 +46,39 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def _positive_int(value: Any, *, label: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise ValueError(f"{label} must be a positive integer")
+    return value
+
+
+def validate_report_shape(report: dict[str, Any]) -> None:
+    comparison = report.get("comparison")
+    profiles = report.get("profiles")
+    if not isinstance(comparison, dict):
+        raise ValueError("benchmark report comparison must be an object")
+    if not isinstance(profiles, dict):
+        raise ValueError("benchmark report profiles must be an object")
+
+    message_count = _positive_int(
+        comparison.get("message_count"),
+        label="comparison.message_count",
+    )
+    for profile in ("baseline", "staged_v1"):
+        profile_payload = profiles.get(profile)
+        if not isinstance(profile_payload, dict):
+            raise ValueError(f"profiles.{profile} must be an object")
+        profile_count = _positive_int(
+            profile_payload.get("message_count"),
+            label=f"profiles.{profile}.message_count",
+        )
+        if profile_count != message_count:
+            raise ValueError(
+                f"profiles.{profile}.message_count ({profile_count}) must match "
+                f"comparison.message_count ({message_count})"
+            )
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     report = asyncio.run(
@@ -54,6 +88,11 @@ def main(argv: list[str] | None = None) -> int:
             verbose=args.verbose,
         )
     )
+    try:
+        validate_report_shape(report)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
 
     print(render_benchmark_report(report))
     if args.output is not None:

--- a/tests/scripts/test_benchmark_triage_profiles.py
+++ b/tests/scripts/test_benchmark_triage_profiles.py
@@ -19,6 +19,7 @@ def test_main_writes_report_and_returns_success(monkeypatch, tmp_path, capsys) -
         "generated_at": "2026-03-25T00:00:00Z",
         "profiles": {
             "baseline": {
+                "message_count": 4,
                 "total_duration_seconds": 12.0,
                 "diagnostics_artifact_dir": "/tmp/baseline",
                 "meta": {
@@ -29,6 +30,7 @@ def test_main_writes_report_and_returns_success(monkeypatch, tmp_path, capsys) -
                 },
             },
             "staged_v1": {
+                "message_count": 4,
                 "total_duration_seconds": 7.0,
                 "diagnostics_artifact_dir": "/tmp/staged",
                 "meta": {
@@ -81,6 +83,7 @@ def test_main_fails_when_thresholds_missed(monkeypatch, tmp_path) -> None:
         "generated_at": "2026-03-25T00:00:00Z",
         "profiles": {
             "baseline": {
+                "message_count": 4,
                 "total_duration_seconds": 12.0,
                 "diagnostics_artifact_dir": "/tmp/baseline",
                 "meta": {
@@ -91,6 +94,7 @@ def test_main_fails_when_thresholds_missed(monkeypatch, tmp_path) -> None:
                 },
             },
             "staged_v1": {
+                "message_count": 4,
                 "total_duration_seconds": 11.0,
                 "diagnostics_artifact_dir": "/tmp/staged",
                 "meta": {
@@ -130,3 +134,46 @@ def test_main_fails_when_thresholds_missed(monkeypatch, tmp_path) -> None:
     )
 
     assert exit_code == 1
+
+
+def test_main_rejects_empty_comparison_before_writing_report(monkeypatch, tmp_path, capsys) -> None:
+    report = {
+        "fixture_path": "/tmp/fixtures.json",
+        "generated_at": "2026-03-25T00:00:00Z",
+        "profiles": {
+            "baseline": {
+                "message_count": 0,
+                "total_duration_seconds": 0.0,
+                "diagnostics_artifact_dir": "/tmp/baseline",
+                "meta": {},
+            },
+            "staged_v1": {
+                "message_count": 0,
+                "total_duration_seconds": 0.0,
+                "diagnostics_artifact_dir": "/tmp/staged",
+                "meta": {},
+            },
+        },
+        "comparison": {
+            "message_count": 0,
+            "passes_all_thresholds": False,
+        },
+    }
+
+    async def _fake_run(*args, **kwargs):
+        del args, kwargs
+        return report
+
+    fixture_path = tmp_path / "fixtures.json"
+    fixture_path.write_text("[]", encoding="utf-8")
+    output_path = tmp_path / "report.json"
+    monkeypatch.setattr(benchmark_triage_profiles, "run_fixture_benchmark", _fake_run)
+
+    exit_code = benchmark_triage_profiles.main(
+        ["--fixtures", str(fixture_path), "--output", str(output_path)]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "comparison.message_count must be a positive integer" in captured.err
+    assert not output_path.exists()


### PR DESCRIPTION
## Summary
- validate triage benchmark report shape before rendering or writing output
- require a positive comparison message count and matching baseline/staged profile message counts
- add regression coverage that verifies a zero-message report exits before writing an artifact

## Scope
Tier 2 benchmark/product-proof reporting guard. This does not touch queue authority, settlement, merge logic, security policy, workflows, public API, or persistence semantics.

## Validation
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_benchmark_triage_profiles.py -q`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/benchmark_triage_profiles.py tests/scripts/test_benchmark_triage_profiles.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/benchmark_triage_profiles.py tests/scripts/test_benchmark_triage_profiles.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`