### PR TITLE
docs(automation): use boss-loop wrapper in merge contract

### DIFF
--- a/docs/briefs/automation-merge-contract.md
+++ b/docs/briefs/automation-merge-contract.md
@@ -131,9 +131,10 @@ Use this repo's automation merge contract at `docs/briefs/automation-merge-contr
 Run the boss loop with shared coordination state when multiple hosts are active:
 
 ```bash
-export ARAGORA_DEV_COORDINATION_DB=~/aragora/.aragora/dev_coordination.sqlite3
+export ARAGORA_REPO_ROOT="${ARAGORA_REPO_ROOT:-$PWD}"
+export ARAGORA_DEV_COORDINATION_DB="${ARAGORA_REPO_ROOT}/.aragora/dev_coordination.sqlite3"
 export ARAGORA_BOSS_VERIFIED_RUNNER_TARGET=0
-python3.11 -u -m aragora.cli.main swarm boss-loop \
+ARAGORA_POST_LOOP_ISSUE_REFILL=0 ./scripts/run_boss_cycle.sh \
   --boss-repo synaptent/aragora \
   --target-branch main \
   --worker-model claude \

--- a/tests/test_automation_merge_contract_docs.py
+++ b/tests/test_automation_merge_contract_docs.py
@@ -1,0 +1,17 @@
+"""Regression tests for copy-paste automation merge contract snippets."""
+
+from pathlib import Path
+
+
+def test_boss_loop_snippet_uses_repo_root_coordination_db():
+    repo_root = Path(__file__).resolve().parents[1]
+    contract = (repo_root / "docs/briefs/automation-merge-contract.md").read_text(encoding="utf-8")
+
+    assert 'export ARAGORA_REPO_ROOT="${ARAGORA_REPO_ROOT:-$PWD}"' in contract
+    assert (
+        'export ARAGORA_DEV_COORDINATION_DB="${ARAGORA_REPO_ROOT}/.aragora/dev_coordination.sqlite3"'
+        in contract
+    )
+    assert "ARAGORA_POST_LOOP_ISSUE_REFILL=0 ./scripts/run_boss_cycle.sh \\" in contract
+    assert "ARAGORA_DEV_COORDINATION_DB=~/aragora/.aragora/dev_coordination.sqlite3" not in contract
+    assert "python3.11 -u -m aragora.cli.main swarm boss-loop" not in contract


### PR DESCRIPTION
## Summary
- update the boss-loop operator snippet in the automation merge contract to derive shared coordination DB state from the active repo root instead of hard-coding `~/aragora`
- use `./scripts/run_boss_cycle.sh` so the documented command follows the repo's live runtime resolver instead of assuming raw `python3.11` has dependencies installed
- keep the snippet as a direct boss-loop run by setting `ARAGORA_POST_LOOP_ISSUE_REFILL=0`
- add a focused docs regression test for the copy-paste snippet

## Validation
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/test_automation_merge_contract_docs.py -q` -> 1 passed
- `ARAGORA_POST_LOOP_ISSUE_REFILL=0 ./scripts/run_boss_cycle.sh --help` -> resolves a working Python interpreter and exposes the documented boss-loop flags
- `git diff --check` -> clean
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> ok

## Risk
- docs/test only; no AGENTS.md, workflow, branch protection, release, or merge-authority semantics changes