### PR TITLE
fix(benchmarks): require positive debate benchmark counts

### DIFF
--- a/scripts/benchmark_debate.py
+++ b/scripts/benchmark_debate.py
@@ -327,37 +327,47 @@ def _print_json(results: BenchmarkResults) -> None:
 # ---------------------------------------------------------------------------
 
 
-def main() -> None:
+def _positive_int(raw: str) -> int:
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a positive integer") from exc
+    if value <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return value
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Benchmark the aragora-debate engine (no API keys required).",
     )
     parser.add_argument(
         "--agents",
-        type=int,
+        type=_positive_int,
         default=3,
         help="Number of agents per debate (default: 3)",
     )
     parser.add_argument(
         "--rounds",
-        type=int,
+        type=_positive_int,
         default=2,
         help="Number of debate rounds (default: 2)",
     )
     parser.add_argument(
         "--concurrent",
-        type=int,
+        type=_positive_int,
         default=None,
         help="Run a single concurrency level instead of the default [5,10,25,50]",
     )
     parser.add_argument(
         "--large-panel-agents",
-        type=int,
+        type=_positive_int,
         default=10,
         help="Number of agents in the large panel scenario (default: 10)",
     )
     parser.add_argument(
         "--large-panel-rounds",
-        type=int,
+        type=_positive_int,
         default=3,
         help="Number of rounds in the large panel scenario (default: 3)",
     )
@@ -367,7 +377,11 @@ def main() -> None:
         help="Output results as JSON",
     )
 
-    args = parser.parse_args()
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
 
     if args.concurrent is not None:
         concurrent_levels = [args.concurrent]

--- a/tests/scripts/test_benchmark_debate.py
+++ b/tests/scripts/test_benchmark_debate.py
@@ -1,0 +1,53 @@
+"""Tests for scripts/benchmark_debate.py."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
+if _scripts_dir not in sys.path:
+    sys.path.insert(0, _scripts_dir)
+
+import benchmark_debate  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    ("flag", "value"),
+    [
+        ("--agents", "0"),
+        ("--rounds", "0"),
+        ("--concurrent", "0"),
+        ("--large-panel-agents", "0"),
+        ("--large-panel-rounds", "0"),
+        ("--agents", "-1"),
+    ],
+)
+def test_parse_args_rejects_non_positive_benchmark_counts(flag: str, value: str) -> None:
+    with pytest.raises(SystemExit):
+        benchmark_debate.parse_args([flag, value])
+
+
+def test_parse_args_accepts_positive_benchmark_counts() -> None:
+    args = benchmark_debate.parse_args(
+        [
+            "--agents",
+            "2",
+            "--rounds",
+            "1",
+            "--concurrent",
+            "3",
+            "--large-panel-agents",
+            "4",
+            "--large-panel-rounds",
+            "2",
+        ]
+    )
+
+    assert args.agents == 2
+    assert args.rounds == 1
+    assert args.concurrent == 3
+    assert args.large_panel_agents == 4
+    assert args.large_panel_rounds == 2


### PR DESCRIPTION
## Summary
- reject non-positive debate benchmark CLI counts before execution
- expose argument parsing for focused validation without running the heavy benchmark
- add regression coverage for zero/negative agents, rounds, concurrency, and large-panel counts

## Scope
Tier 2 benchmark/product-proof reporting guard. This does not touch queue authority, settlement, merge logic, security policy, workflows, public API, or persistence semantics.

## Validation
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_benchmark_debate.py -q`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/benchmark_debate.py tests/scripts/test_benchmark_debate.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/benchmark_debate.py tests/scripts/test_benchmark_debate.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`