### PR TITLE
docs(prompts): use repo-root path guidance

### DIFF
--- a/docs/missions/H1_DISCIPLINED_MISSION_PROMPT.md
+++ b/docs/missions/H1_DISCIPLINED_MISSION_PROMPT.md
@@ -9,9 +9,9 @@
 > and [CANONICAL_GOALS.md](../CANONICAL_GOALS.md).
 >
 > **How to use:** paste the "Mission Prompt" block below as the first message
-> to a fresh Droid session on `~/aragora`. Append a
-> mission id (e.g. `mission-id: h1-YYYY-MM-DD-<slot>`) so ledger filenames
-> don't collide across runs.
+> to a fresh Droid session from the Aragora repo root or a managed worktree.
+> Append a mission id (e.g. `mission-id: h1-YYYY-MM-DD-<slot>`) so ledger
+> filenames don't collide across runs.
 
 ## Mission Prompt
 

--- a/docs/prompts/MASTER_FANOUT_PROMPT.md
+++ b/docs/prompts/MASTER_FANOUT_PROMPT.md
@@ -2,8 +2,8 @@
 
 Canonical idempotent prompt for autonomous parallel agents working the Aragora
 proof-first loop. Drop this prompt unchanged into any agent (Claude Code, Codex
-CLI, Codex Desktop, Factory Droid) running against `~/aragora`
-or any worktree thereof. Multiple sessions can run concurrently — coordination
+CLI, Codex Desktop, Factory Droid) running from the Aragora repo root or any
+managed worktree thereof. Multiple sessions can run concurrently — coordination
 is by file-locked lane registry and append-only journal, not by shared context.
 
 **Why this exists:** Earlier versions of this prompt inflated to >1M tokens by

--- a/tests/test_prompt_path_guidance_docs.py
+++ b/tests/test_prompt_path_guidance_docs.py
@@ -1,0 +1,18 @@
+"""Regression tests for repo-root guidance in reusable agent prompts."""
+
+from pathlib import Path
+
+
+def test_recursive_prompts_do_not_assume_home_aragora_symlink():
+    repo_root = Path(__file__).resolve().parents[1]
+    prompt_paths = [
+        repo_root / "docs/prompts/MASTER_FANOUT_PROMPT.md",
+        repo_root / "docs/missions/H1_DISCIPLINED_MISSION_PROMPT.md",
+    ]
+
+    for path in prompt_paths:
+        text = path.read_text(encoding="utf-8")
+        assert "`~/aragora`" not in text
+        assert "~/aragora" not in text
+        assert "repo root" in text
+        assert "worktree" in text


### PR DESCRIPTION
## Summary
- update the master fan-out prompt to tell agents to run from the Aragora repo root or a managed worktree instead of assuming a `~/aragora` symlink
- update the H1 mission prompt with the same repo-root/worktree launch guidance
- add a focused regression test so reusable prompts do not reintroduce `~/aragora` as required path guidance

## Validation
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/test_prompt_path_guidance_docs.py -q` -> 1 passed
- `git diff --check` -> clean
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> ok

## Risk
- docs/test only; no AGENTS.md, workflow, branch protection, release, or merge-authority semantics changes