### PR TITLE
fix(benchmarks): validate convergence benchmark inputs

### DIFF
--- a/scripts/benchmark_convergence.py
+++ b/scripts/benchmark_convergence.py
@@ -272,6 +272,14 @@ def run_single_debate(
     convergence_threshold: float = 0.85,
 ) -> DebateRunResult:
     """Run a single debate and track convergence."""
+    if max_rounds <= 0:
+        raise ValueError("max_rounds must be a positive integer")
+    if not agents:
+        raise ValueError("agents must include at least one persona")
+    unknown_agents = sorted(agent for agent in agents if agent not in PERSONAS)
+    if unknown_agents:
+        raise ValueError(f"unknown convergence benchmark agent(s): {', '.join(unknown_agents)}")
+
     detector = ConvergenceDetector(
         convergence_threshold=convergence_threshold,
         divergence_threshold=0.40,

--- a/tests/scripts/test_benchmark_convergence.py
+++ b/tests/scripts/test_benchmark_convergence.py
@@ -1,0 +1,55 @@
+"""Tests for scripts/benchmark_convergence.py."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
+if _scripts_dir not in sys.path:
+    sys.path.insert(0, _scripts_dir)
+
+import benchmark_convergence  # noqa: E402
+
+
+def test_run_single_debate_rejects_non_positive_round_count() -> None:
+    with pytest.raises(ValueError, match="max_rounds must be a positive integer"):
+        benchmark_convergence.run_single_debate(
+            max_rounds=0,
+            agents=["analyst"],
+        )
+
+
+def test_run_single_debate_rejects_empty_agent_list() -> None:
+    with pytest.raises(ValueError, match="agents must include at least one persona"):
+        benchmark_convergence.run_single_debate(
+            max_rounds=2,
+            agents=[],
+        )
+
+
+def test_run_single_debate_rejects_unknown_agent_names() -> None:
+    with pytest.raises(
+        ValueError,
+        match="unknown convergence benchmark agent\\(s\\): unknown-agent",
+    ):
+        benchmark_convergence.run_single_debate(
+            max_rounds=2,
+            agents=["analyst", "unknown-agent"],
+        )
+
+
+def test_run_single_debate_records_valid_rounds() -> None:
+    result = benchmark_convergence.run_single_debate(
+        max_rounds=2,
+        agents=["analyst", "critic"],
+        convergence_threshold=0.99,
+    )
+
+    assert result.max_rounds == 2
+    assert result.rounds_executed >= 1
+    assert result.rounds_saved >= 0
+    assert result.agents == ["analyst", "critic"]
+    assert result.round_metrics


### PR DESCRIPTION
## Summary
- fail closed on non-positive convergence benchmark round counts
- reject empty agent lists and unknown convergence benchmark persona names before similarity savings are computed
- add focused regression coverage for invalid inputs and a small valid benchmark run

## Scope
Tier 2 benchmark/similarity reporting guard. This does not touch queue authority, settlement, merge logic, security policy, workflows, public API, or persistence semantics.

## Validation
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_benchmark_convergence.py -q`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/benchmark_convergence.py tests/scripts/test_benchmark_convergence.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/benchmark_convergence.py tests/scripts/test_benchmark_convergence.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`