### PR TITLE
docs(boss-loop): use runtime wrapper in live proof runbook

### DIFF
--- a/docs/briefs/boss-loop-live-proof-runbook.md
+++ b/docs/briefs/boss-loop-live-proof-runbook.md
@@ -14,7 +14,7 @@ Historical note: this runbook captures the bounded execution contract used for t
 Run a single bounded live tick:
 
 ```bash
-ARAGORA_USER_ID=an0mium python -m aragora.cli.main swarm boss-loop \
+ARAGORA_USER_ID=an0mium ARAGORA_POST_LOOP_ISSUE_REFILL=0 ./scripts/run_boss_cycle.sh \
   --boss-label-filter boss-loop-test \
   --boss-issue-number <ISSUE_NUMBER> \
   --max-ticks 1 \

--- a/tests/test_boss_loop_live_proof_runbook_docs.py
+++ b/tests/test_boss_loop_live_proof_runbook_docs.py
@@ -1,0 +1,16 @@
+"""Regression tests for boss-loop live proof runbook command snippets."""
+
+from pathlib import Path
+
+
+def test_live_proof_launch_uses_runtime_resolving_wrapper():
+    repo_root = Path(__file__).resolve().parents[1]
+    runbook = (repo_root / "docs/briefs/boss-loop-live-proof-runbook.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert (
+        "ARAGORA_USER_ID=an0mium ARAGORA_POST_LOOP_ISSUE_REFILL=0 ./scripts/run_boss_cycle.sh \\"
+    ) in runbook
+    assert "python -m aragora.cli.main swarm boss-loop \\" not in runbook
+    assert "python3 -m aragora.cli.main swarm boss-loop \\" not in runbook


### PR DESCRIPTION
## Summary
- update the boss-loop live proof runbook launch command to use `./scripts/run_boss_cycle.sh`, which resolves the repo's working Aragora runtime
- disable post-loop issue refill in the one-tick live proof command with `ARAGORA_POST_LOOP_ISSUE_REFILL=0`
- add a focused docs regression test so the launch snippet does not regress to raw `python -m aragora.cli.main swarm boss-loop`

## Validation
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/test_boss_loop_live_proof_runbook_docs.py -q` -> 1 passed
- `ARAGORA_USER_ID=an0mium ARAGORA_POST_LOOP_ISSUE_REFILL=0 ./scripts/run_boss_cycle.sh --help` -> resolves a working Python interpreter and exposes the documented boss-loop flags
- `git diff --check` -> clean
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> ok

## Risk
- docs/test only; no AGENTS.md, workflow, branch protection, release, or merge-authority semantics changes