### PR TITLE
docs(runbooks): route proof surface refresh through wrapper

### DIFF
--- a/docs/runbooks/RUNBOOK_PROOF_FIRST_TMUX_OPERATOR.md
+++ b/docs/runbooks/RUNBOOK_PROOF_FIRST_TMUX_OPERATOR.md
@@ -54,6 +54,7 @@ Recommended ownership:
 
 - `benchmark-proof`
   `scripts/reconcile_b0_pr_truth.py`
+  `scripts/refresh_proof_surfaces.sh`
   `scripts/build_benchmark_truth_artifact.py`
   `scripts/render_benchmark_truth_status.py`
   focused tests under `tests/scripts/`
@@ -73,6 +74,18 @@ python3 scripts/codex_worktree_autopilot.py ensure --agent codex --base main --r
 ```
 
 Create prompt files under `~/.aragora/tmux-prompts/` so prompts are reusable and auditable.
+
+## Proof Surface Refresh
+
+Use the repo-native refresher as the first proof-surface command so check-only and scoped refresh behavior stays aligned with live tooling:
+
+```bash
+bash scripts/refresh_proof_surfaces.sh --check
+bash scripts/refresh_proof_surfaces.sh --surface b0 --check
+bash scripts/refresh_proof_surfaces.sh --surface tw03 --check
+```
+
+When a lane intentionally owns the refresh, run the same wrapper without `--check` for the scoped surface. Add `--commit` only when the lane is authorized to create a local commit; the wrapper does not push. B0 publisher runs remain owned by the benchmark lane and are not replaced by tmux babysitting.
 
 ## Launch
 

--- a/tests/test_proof_first_tmux_runbook_docs.py
+++ b/tests/test_proof_first_tmux_runbook_docs.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RUNBOOK = REPO_ROOT / "docs" / "runbooks" / "RUNBOOK_PROOF_FIRST_TMUX_OPERATOR.md"
+REFRESH_SCRIPT = REPO_ROOT / "scripts" / "refresh_proof_surfaces.sh"
+
+
+def test_proof_first_tmux_runbook_routes_surface_checks_through_wrapper() -> None:
+    text = RUNBOOK.read_text()
+    help_result = subprocess.run(
+        ["bash", str(REFRESH_SCRIPT), "--help"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert help_result.returncode == 0
+    assert "--surface {all,b0,tw03}" in help_result.stdout
+    assert "--check" in help_result.stdout
+    assert "bash scripts/refresh_proof_surfaces.sh --check" in text
+    assert "bash scripts/refresh_proof_surfaces.sh --surface b0 --check" in text
+    assert "bash scripts/refresh_proof_surfaces.sh --surface tw03 --check" in text
+
+
+def test_proof_first_tmux_runbook_assigns_wrapper_to_benchmark_lane() -> None:
+    text = RUNBOOK.read_text()
+    ownership = text.split("Recommended ownership:", 1)[1].split("## Setup", 1)[0]
+
+    assert "`benchmark-proof`" in ownership
+    assert "`scripts/refresh_proof_surfaces.sh`" in ownership


### PR DESCRIPTION
## Summary
- assign `scripts/refresh_proof_surfaces.sh` to the benchmark-proof lane in the proof-first tmux runbook
- document check-only and scoped B0/TW03 refresh commands through the wrapper
- add a focused docs regression that reads the wrapper help and verifies the runbook snippets

## Validation
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/test_proof_first_tmux_runbook_docs.py tests/scripts/test_refresh_proof_surfaces.py -q`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/test_proof_first_tmux_runbook_docs.py -q`
- `bash scripts/refresh_proof_surfaces.sh --surface b0 --check`
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`