### PR TITLE
fix(benchmarks): reject empty debate quality runs

### DIFF
--- a/scripts/debate_quality_benchmark.py
+++ b/scripts/debate_quality_benchmark.py
@@ -662,6 +662,8 @@ async def run_benchmark(
     dry_run: bool = False,
 ) -> BenchmarkSummary:
     """Run the full A/B benchmark pipeline."""
+    if not prompts:
+        raise ValueError("debate quality benchmark requires at least one prompt")
 
     if dry_run:
         single_agent = MockAgent("single-agent", response_bank=_MOCK_SINGLE)
@@ -914,7 +916,12 @@ def save_results(summary: BenchmarkSummary, output_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def parse_args() -> argparse.Namespace:
+def select_prompts(prompt_limit: int) -> list[dict[str, str]]:
+    """Select benchmark prompts while preserving 0 as the all-prompts CLI sentinel."""
+    return PROMPTS[:prompt_limit] if prompt_limit > 0 else PROMPTS
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="A/B benchmark: single-agent vs multi-agent debate consensus.",
     )
@@ -936,13 +943,13 @@ def parse_args() -> argparse.Namespace:
         default=str(PROJECT_ROOT / "artifacts" / "benchmark_results.json"),
         help="Output path for JSON results.",
     )
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
 async def main() -> None:
     args = parse_args()
 
-    selected = PROMPTS[: args.prompts] if args.prompts > 0 else PROMPTS
+    selected = select_prompts(args.prompts)
 
     logger.info(
         "Starting benchmark: %d prompts, dry_run=%s",

--- a/tests/scripts/test_debate_quality_benchmark.py
+++ b/tests/scripts/test_debate_quality_benchmark.py
@@ -1,0 +1,40 @@
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = ROOT / "scripts" / "debate_quality_benchmark.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("debate_quality_benchmark", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_run_benchmark_rejects_empty_prompt_collection() -> None:
+    module = _load_module()
+
+    with pytest.raises(ValueError, match="requires at least one prompt"):
+        asyncio.run(module.run_benchmark([], dry_run=True))
+
+
+def test_select_prompts_zero_preserves_all_prompts_sentinel() -> None:
+    module = _load_module()
+
+    assert module.parse_args(["--prompts", "0"]).prompts == 0
+    assert module.select_prompts(0) == module.PROMPTS
+
+
+def test_select_prompts_positive_limit_returns_prefix() -> None:
+    module = _load_module()
+
+    assert module.select_prompts(2) == module.PROMPTS[:2]


### PR DESCRIPTION
## Summary
- fail closed when the debate quality benchmark core is called with an empty prompt collection
- keep the documented `--prompts 0` CLI sentinel as all prompts via a testable selector
- add focused script tests for empty input and prompt selection

## Validation
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_debate_quality_benchmark.py -q`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/debate_quality_benchmark.py tests/scripts/test_debate_quality_benchmark.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/debate_quality_benchmark.py tests/scripts/test_debate_quality_benchmark.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python scripts/debate_quality_benchmark.py --dry-run --prompts 1 --output /tmp/aragora-debate-quality-benchmark-smoke.json`

Tier: 1/2 benchmark/report integrity guard; no queue authority, settlement, security, API, or workflow changes.
