### PR TITLE
chore(tiers): refresh module_tiers.yaml

### DIFF
--- a/aragora/module_tiers.yaml
+++ b/aragora/module_tiers.yaml
@@ -34,9 +34,9 @@ modules:
   # --- core (21) ---
   - name: agents
     tier: core
-    py_files: 80
-    importer_count: 181
-    test_file_count: 156
+    py_files: 83
+    importer_count: 184
+    test_file_count: 163
     override_reason: "Agent factory, 43 registered types"
   - name: billing
     tier: core
@@ -45,15 +45,15 @@ modules:
     test_file_count: 118
   - name: cli
     tier: core
-    py_files: 107
+    py_files: 114
     importer_count: 6
-    test_file_count: 122
+    test_file_count: 140
     override_reason: "aragora CLI — primary developer surface"
   - name: config
     tier: core
-    py_files: 16
-    importer_count: 331
-    test_file_count: 81
+    py_files: 17
+    importer_count: 359
+    test_file_count: 86
     override_reason: "Pydantic settings + allowlist — load bearing"
   - name: connectors
     tier: core
@@ -76,7 +76,7 @@ modules:
     tier: core
     py_files: 263
     importer_count: 162
-    test_file_count: 596
+    test_file_count: 597
     override_reason: "Arena + DebateProtocol + consensus — mainline flow"
   - name: events
     tier: core
@@ -86,18 +86,18 @@ modules:
   - name: gauntlet
     tier: core
     py_files: 36
-    importer_count: 64
-    test_file_count: 98
+    importer_count: 65
+    test_file_count: 102
   - name: knowledge
     tier: core
     py_files: 177
     importer_count: 179
-    test_file_count: 227
+    test_file_count: 229
   - name: memory
     tier: core
     py_files: 56
     importer_count: 114
-    test_file_count: 115
+    test_file_count: 116
     override_reason: "ContinuumMemory + CritiqueStore — persistent state"
   - name: nomic
     tier: core
@@ -118,7 +118,7 @@ modules:
     tier: core
     py_files: 25
     importer_count: 72
-    test_file_count: 54
+    test_file_count: 55
     override_reason: "ELO skill tracking — feeds team selection"
   - name: rbac
     tier: core
@@ -139,7 +139,7 @@ modules:
     tier: core
     py_files: 1115
     importer_count: 180
-    test_file_count: 1879
+    test_file_count: 1881
     override_reason: "FastAPI server + 3K+ API operations"
   - name: storage
     tier: core
@@ -166,9 +166,9 @@ modules:
     test_file_count: 6
   - name: audit
     tier: integrated
-    py_files: 43
+    py_files: 44
     importer_count: 85
-    test_file_count: 35
+    test_file_count: 36
   - name: auth
     tier: integrated
     py_files: 15
@@ -218,7 +218,7 @@ modules:
     tier: integrated
     py_files: 41
     importer_count: 8
-    test_file_count: 47
+    test_file_count: 49
   - name: compat
     tier: integrated
     py_files: 13
@@ -226,9 +226,9 @@ modules:
     test_file_count: 16
   - name: compliance
     tier: integrated
-    py_files: 9
+    py_files: 10
     importer_count: 20
-    test_file_count: 19
+    test_file_count: 20
   - name: computer_use
     tier: integrated
     py_files: 9
@@ -257,8 +257,8 @@ modules:
   - name: epistemic
     tier: integrated
     py_files: 21
-    importer_count: 6
-    test_file_count: 22
+    importer_count: 12
+    test_file_count: 25
   - name: essay
     tier: integrated
     py_files: 6
@@ -424,7 +424,7 @@ modules:
     tier: integrated
     py_files: 27
     importer_count: 136
-    test_file_count: 25
+    test_file_count: 26
   - name: plugins
     tier: integrated
     py_files: 11
@@ -509,7 +509,7 @@ modules:
     tier: integrated
     py_files: 23
     importer_count: 62
-    test_file_count: 40
+    test_file_count: 41
   - name: services
     tier: integrated
     py_files: 44
@@ -537,9 +537,9 @@ modules:
     test_file_count: 5
   - name: swarm
     tier: integrated
-    py_files: 102
+    py_files: 105
     importer_count: 32
-    test_file_count: 162
+    test_file_count: 166
   - name: templates
     tier: integrated
     py_files: 1
@@ -631,7 +631,7 @@ modules:
     tier: experimental
     py_files: 2
     importer_count: 4
-    test_file_count: 3
+    test_file_count: 4
   - name: factory
     tier: experimental
     py_files: 2


### PR DESCRIPTION
## Summary

Regenerate `aragora/module_tiers.yaml` via `scripts/regenerate_module_tiers.py` to clear **pre-existing metric-count drift** on `origin/main`. The "Module Tier Drift Check" CI job currently reports `module_tiers.yaml` as stale on PRs against main; this refreshes it.

## Why this is safe (Tier 0)

The diff is **counts-only** — `py_files`, `importer_count`, `test_file_count` updated as modules gained files/tests since the last regen. There are **zero `tier:`, `override_reason:`, or module `name:` changes**, so there is **no governance / tier-classification impact**.

```
 aragora/module_tiers.yaml | 54 +++++++++++++++++++++++------------------------
 1 file changed, 27 insertions(+), 27 deletions(-)
```

Verified the diff contains no `tier:`/`override_reason:`/`name:` lines (counts only). Generated from a clean disposable worktree at `origin/main` `6c2ce5da66`.

## Validation
- `python3 scripts/regenerate_module_tiers.py` → "Wrote aragora/module_tiers.yaml with 141 modules."
- `pre-commit run --files aragora/module_tiers.yaml` → all hooks pass.

## Notes
Standalone chore — intentionally **not** bundled into #7844 or #7836. Single-file, deterministic regeneration; re-running the generator on a fresh main reproduces this exact result.
