### PR TITLE
feat(merge-arbiter): scope agent-owned aragora/spec/ as auto-merge candidate prefix (Tier 4)

### DIFF
--- a/aragora/swarm/merge_arbiter.py
+++ b/aragora/swarm/merge_arbiter.py
@@ -37,6 +37,9 @@ AUTOMATION_BRANCH_PREFIXES: list[str] = [
     "codex/",
     "factory/",
     "aragora/boss-harvest/",
+    # Scoped agent-owned spec namespace. Bare ``spec/`` is intentionally NOT
+    # listed so human design branches never become auto-merge candidates.
+    "aragora/spec/",
 ]
 PASSING_CHECK_STATES = frozenset({"SUCCESS", "NEUTRAL", "SKIPPED"})
 READY_SUITE_GATE_CHECKS = frozenset({"Prioritize Required Checks"})
@@ -134,6 +137,11 @@ def _normalize_branch_prefixes(branch_prefixes: list[str] | None) -> list[str]:
         "aragora/boss-harvest": "aragora/boss-harvest/",
         "codex": "codex/",
         "factory": "factory/",
+        # Map any bare "spec" form to the scoped agent-owned namespace so an
+        # operator can never accidentally widen the gate to human "spec/" work.
+        "spec": "aragora/spec/",
+        "spec/": "aragora/spec/",
+        "aragora/spec": "aragora/spec/",
     }
     for prefix in raw_prefixes:
         value = aliases.get(str(prefix or "").strip(), str(prefix or "").strip())

--- a/docs/governance/ARBITER_SCOPED_SPEC_PREFIX.md
+++ b/docs/governance/ARBITER_SCOPED_SPEC_PREFIX.md
@@ -1,0 +1,68 @@
+# Scoped agent-owned spec prefix for the autonomous merge-arbiter
+
+Status: **Tier-4 merge-authority change — requires exact-head human settlement.**
+Decision owner: repo founder. This PR prepares the change; it must not be merged
+without explicit, repo-visible operator settlement on the exact head SHA.
+
+## Decision
+
+Add **`aragora/spec/`** to the merge-arbiter's automation-owned branch prefixes
+(`aragora/swarm/merge_arbiter.py::AUTOMATION_BRANCH_PREFIXES`) so that
+**agent-produced spec work** (e.g. a ground-truth-integrity benchmark spec) can be
+judged and settled by the autonomous frontier-LLM quorum harness — the same path
+that already serves `codex/`, `factory/`, and `aragora/boss-harvest/`.
+
+Bare **`spec/` is deliberately excluded.** `spec/` is a generic, human-natural
+namespace for design/WIP; making it arbiter-eligible would let any green+quorum'd
+human design draft become an auto-merge candidate. Scoping to the `aragora/`
+automation namespace (which already hosts `aragora/boss-harvest/`) keeps the
+ownership boundary intact: agents publish autonomy-bound specs under
+`aragora/spec/<topic>-<date>`; humans keep design drafts on bare `spec/`.
+
+## Why scoped, not bare (the rejected option)
+
+The branch-prefix gate is a **merge-authority boundary**, not a convenience. The
+autonomous arbiter only *considers* PRs whose head branch is automation-owned.
+Widening it to bare `spec/` is a broad, repo-wide expansion into human design
+space; the scoped `aragora/spec/` form delivers the same autonomy for agent work
+with a narrow, named blast radius.
+
+## What this changes — and what it does NOT
+
+- **Candidacy only.** The prefix gate decides whether the arbiter *looks* at a PR.
+  It does **not** bypass any quality gate. An `aragora/spec/` PR still requires:
+  all required checks green, a real ≥2-family model quorum, tier classification,
+  the Tier 0-2 authorization packet / recorded merge-on-green, and dogfood evidence
+  for proof surfaces — exactly as for any other automation branch.
+- **Drafts stay manual.** Draft PRs are not auto-promoted/merged. Keeping an
+  `aragora/spec/` PR in draft is the manual hold lever.
+- **Draft auto-promotion is untouched.** `boss_loop.py::_draft_promotion_ownership`
+  (which can *un-draft* PRs) intentionally matches only `aragora/boss-harvest/issue-`
+  and `codex/swarm-`; it is **not** modified here, so spec drafts are never
+  auto-undrafted.
+- **Launch-arg safety.** `_normalize_branch_prefixes` maps any bare `spec` / `spec/`
+  / `aragora/spec` launch argument to the scoped `aragora/spec/`, so an operator
+  cannot accidentally widen the gate to human `spec/` work via `--branch-prefix`.
+- **Ownership class.** `aragora/spec/` classifies as `queue-owned` (like `codex/` /
+  `factory/`), not `boss-owned` (reserved for `aragora/boss-harvest/`).
+
+## Scope of this change
+
+`aragora/swarm/merge_arbiter.py` only (the daemon the request named). The separate
+proof-first harness (`scripts/run_proof_first_shift.py`) keeps its own prefix list;
+extending it to `aragora/spec/` is a deliberately separate follow-up decision, kept
+out of this PR to bound the Tier-4 blast radius.
+
+## Usage
+
+Name autonomy-bound agent spec branches `aragora/spec/<topic>-<YYYYMMDD>`. They then
+flow through the existing autonomous Tier-1/2 quorum-judged settlement path, subject
+to all gates above. Human design drafts remain on bare `spec/` and stay manual.
+
+## Tier-4 settlement
+
+This is merge-authority self-modification (per `docs/AGENT_OPERATING_CONTRACT.md` and
+the elves-aragora governance gate): prepared autonomously, **merged only** after
+explicit exact-head operator settlement
+(`python3 scripts/settle_tier4_pr.py --check --pr <N> --head <SHA>` + repo-visible
+authorization).

--- a/tests/swarm/test_merge_arbiter.py
+++ b/tests/swarm/test_merge_arbiter.py
@@ -15,12 +15,14 @@ from aragora.swarm.merge_arbiter import (
     MergeArbiter,
     MergeArbiterConfig,
     MergeResult,
+    classify_automation_branch_ownership,
     _classify_required_checks,
     _evaluate_pr,
     _get_check_status,
     _has_local_settlement_receipt,
     _has_matching_human_approval,
     _list_candidate_prs,
+    _normalize_branch_prefixes,
     _review_counts_as_human_approval,
     _merge_pr,
     _promote_draft,
@@ -543,3 +545,48 @@ class TestFullRun:
 
         assert 7 in summary.merged
         assert summary.polls >= 1
+
+
+# ---------------------------------------------------------------------------
+# Scoped agent-owned spec prefix (aragora/spec/) — Tier-4 merge-authority scope
+# ---------------------------------------------------------------------------
+
+
+class TestScopedSpecPrefix:
+    def test_scoped_spec_branch_is_queue_owned_candidate(self):
+        assert (
+            classify_automation_branch_ownership("aragora/spec/ground-truth-integrity-20260606")
+            == "queue-owned"
+        )
+
+    def test_bare_spec_branch_is_never_owned(self):
+        # The whole point of scoping: human "spec/" design branches stay manual.
+        assert classify_automation_branch_ownership("spec/ground-truth-integrity-20260606") is None
+
+    def test_scoped_spec_is_distinct_from_boss_harvest(self):
+        assert classify_automation_branch_ownership("aragora/boss-harvest/issue-1") == "boss-owned"
+        assert classify_automation_branch_ownership("aragora/spec/x") == "queue-owned"
+
+    def test_bare_spec_alias_normalizes_to_scoped_namespace(self):
+        # Passing "spec" or "spec/" at launch must NOT widen the gate to bare spec/.
+        normalized = _normalize_branch_prefixes(["spec"])
+        assert "aragora/spec/" in normalized
+        assert "spec/" not in normalized
+        assert classify_automation_branch_ownership("spec/x", branch_prefixes=["spec"]) is None
+        assert (
+            classify_automation_branch_ownership("aragora/spec/x", branch_prefixes=["spec"])
+            == "queue-owned"
+        )
+
+    def test_list_candidate_prs_includes_scoped_spec_excludes_bare_spec(self):
+        prs = [
+            _pr(1, "aragora/spec/gti-20260606"),
+            _pr(2, "spec/human-design-draft"),
+            _pr(3, "codex/task"),
+            _pr(4, "feat/manual"),
+        ]
+        config = MergeArbiterConfig()
+        with patch("aragora.swarm.merge_arbiter._run_gh") as mock_gh:
+            mock_gh.return_value = _make_gh_result(stdout=json.dumps(prs))
+            result = _list_candidate_prs(config)
+        assert [pr["number"] for pr in result] == [1, 3]


### PR DESCRIPTION
## Summary

**Tier-4 merge-authority change (draft — do not merge without exact-head settlement).**

Adds **`aragora/spec/`** to the merge-arbiter's automation-owned candidate prefixes (`aragora/swarm/merge_arbiter.py::AUTOMATION_BRANCH_PREFIXES`) so **agent-produced spec work** can be judged/settled by the autonomous frontier-LLM quorum harness — the path that already serves `codex/`, `factory/`, `aragora/boss-harvest/`.

Chosen via explicit operator decision (option **B**: a *scoped* agent-owned prefix). Bare `spec/` is **deliberately excluded** — it is a generic human design namespace, and widening merge authority to it would make any green+quorum'd human draft an auto-merge candidate. Scoping to the `aragora/` automation namespace (which already hosts `aragora/boss-harvest/`) preserves the ownership boundary.

Files (3): `aragora/swarm/merge_arbiter.py`, `tests/swarm/test_merge_arbiter.py`, `docs/governance/ARBITER_SCOPED_SPEC_PREFIX.md`.

## What changes — and what it does NOT

- **Candidacy only.** Decides whether the arbiter *looks* at a PR; bypasses **no** quality gate. An `aragora/spec/` PR still needs all required checks green, a real **≥2-family model quorum**, tier classification, the Tier 0-2 authorization packet, and dogfood evidence for proof surfaces.
- **Drafts stay manual**; `boss_loop._draft_promotion_ownership` (which can *un-draft* PRs) is **not** modified, so spec drafts are never auto-undrafted.
- **Launch-arg safety:** `_normalize_branch_prefixes` maps any bare `spec` / `spec/` / `aragora/spec` arg to scoped `aragora/spec/`, so `--branch-prefix` can't accidentally widen the gate.
- **Ownership:** `aragora/spec/` → `queue-owned` (not `boss-owned`).
- **Scope:** `merge_arbiter.py` only; `run_proof_first_shift.py` parity is a separate follow-up (bounds Tier-4 blast radius).

## Validation
- `pytest tests/swarm/test_merge_arbiter.py` → **31/31** (5 new in `TestScopedSpecPrefix`: scoped eligible/queue-owned; bare `spec/` never owned; alias normalization; candidate-list inclusion/exclusion).
- `pre-commit run --files <the 3 files>` → pass. Built from a clean disposable worktree at origin/main `d92d3f1fad`.

## Why draft
This PR modifies merge authority. Opened as **draft** to keep a hard manual gate (the arbiter skips drafts). Mark ready when you want the real quorum eval; settle per Tier-4: `python3 scripts/settle_tier4_pr.py --check --pr <N> --head <SHA>` + repo-visible authorization. **I will not merge.**
