### PR TITLE
Improve cleanup safety diagnostics

### DIFF
--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -939,8 +939,8 @@ def _active_lane_identity_conflicts(records: list["LaneRecord"]) -> list[dict[st
 
 def _collect_health_issues(
     sessions: list[Session], records: list[LaneRecord]
-) -> list[dict[str, str]]:
-    issues: list[dict[str, str]] = []
+) -> list[dict[str, Any]]:
+    issues: list[dict[str, Any]] = []
     active_lane_owners = {
         record.owner_session for record in records if record.status in ACTIVE_LANE_STATUSES
     }
@@ -968,6 +968,14 @@ def _collect_health_issues(
                         "type": "stale_worktree",
                         "session": s.name,
                         "detail": f"dead session with lingering worktree: {s.worktree}",
+                        "owner_state": "stale_session",
+                        "lifecycle": lifecycle,
+                        "worktree": s.worktree,
+                        "worktree_exists": True,
+                        "cleanup_state": "stale_lingering_worktree",
+                        "recommended_operator_action": (
+                            "inspect with safe_worktree_cleanup.py before any removal"
+                        ),
                     }
                 )
             continue
@@ -979,6 +987,14 @@ def _collect_health_issues(
                     "type": "stale_worktree",
                     "session": s.name,
                     "detail": f"worktree path missing: {s.worktree}",
+                    "owner_state": "active_or_current_session",
+                    "lifecycle": lifecycle,
+                    "worktree": s.worktree,
+                    "worktree_exists": False,
+                    "cleanup_state": "missing_path_metadata",
+                    "recommended_operator_action": (
+                        "verify lane ownership before pruning metadata"
+                    ),
                 }
             )
 
@@ -994,6 +1010,12 @@ def _collect_health_issues(
                     "type": "ambiguous_lane",
                     "session": ", ".join(owners),
                     "detail": f"lane '{lane_id}' claimed by multiple active sessions",
+                    "owner_state": "duplicate_active_owner",
+                    "lane_id": lane_id,
+                    "owner_sessions": owners,
+                    "recommended_operator_action": (
+                        "resolve duplicate active owners before mutation or cleanup"
+                    ),
                 }
             )
 
@@ -1006,6 +1028,13 @@ def _collect_health_issues(
                     "type": "lane_missing_next_action",
                     "session": r.owner_session,
                     "detail": f"active lane '{r.lane_id}' has no actionable next_action",
+                    "owner_state": "active_lane_incomplete_metadata",
+                    "lane_id": r.lane_id,
+                    "status": r.status,
+                    "worktree": r.worktree or None,
+                    "recommended_operator_action": (
+                        "refresh the lane with a concrete next_action before routing"
+                    ),
                 }
             )
         if not r.last_steering_outcome or r.last_steering_outcome == DEFAULT_STEERING_OUTCOME:
@@ -1014,6 +1043,13 @@ def _collect_health_issues(
                     "type": "lane_missing_steering_outcome",
                     "session": r.owner_session,
                     "detail": f"active lane '{r.lane_id}' has no explicit steering outcome",
+                    "owner_state": "active_lane_incomplete_metadata",
+                    "lane_id": r.lane_id,
+                    "status": r.status,
+                    "worktree": r.worktree or None,
+                    "recommended_operator_action": (
+                        "record last_steering_outcome before claiming clean routing"
+                    ),
                 }
             )
         if not r.last_heartbeat_at:
@@ -1022,6 +1058,14 @@ def _collect_health_issues(
                     "type": "lane_missing_heartbeat",
                     "session": r.owner_session,
                     "detail": f"active lane '{r.lane_id}' has no heartbeat timestamp",
+                    "owner_state": "active_lane_missing_liveness",
+                    "lane_id": r.lane_id,
+                    "status": r.status,
+                    "worktree": r.worktree or None,
+                    "heartbeat_state": "missing",
+                    "recommended_operator_action": (
+                        "start or refresh agent_heartbeat.py before treating owner as live"
+                    ),
                 }
             )
 
@@ -1033,6 +1077,15 @@ def _collect_health_issues(
                     "type": "lane_conflict",
                     "session": r.owner_session,
                     "detail": f"lane '{r.lane_id}' in conflict with {r.conflict_session}: {r.conflict_reason}",
+                    "owner_state": "lane_conflict",
+                    "lane_id": r.lane_id,
+                    "status": r.status,
+                    "worktree": r.worktree or None,
+                    "conflict_session": r.conflict_session,
+                    "conflict_reason": r.conflict_reason,
+                    "recommended_operator_action": (
+                        "resolve_lane_conflicts.py dry-run before mutation or cleanup"
+                    ),
                 }
             )
 
@@ -1042,6 +1095,14 @@ def _collect_health_issues(
                 "type": str(conflict["type"]),
                 "session": ", ".join(conflict["owner_sessions"]),
                 "detail": str(conflict["detail"]),
+                "owner_state": "duplicate_active_owner",
+                "key_kind": conflict["key_kind"],
+                "key_value": conflict["key_value"],
+                "lane_ids": conflict["lane_ids"],
+                "owner_sessions": conflict["owner_sessions"],
+                "recommended_operator_action": (
+                    "resolve duplicate active owners before mutation or cleanup"
+                ),
             }
         )
 

--- a/scripts/codex_worktree_value_inventory.py
+++ b/scripts/codex_worktree_value_inventory.py
@@ -80,6 +80,15 @@ PROTECTED_CLASSES = {
     "receipt_protected",
     "lookup_failed",
 }
+SAFETY_CLASSES = (
+    "owned",
+    "unsafe_to_delete",
+    "unknown_preserve",
+    "referenced_preserve",
+    "harvested_or_duplicate",
+    "stale_or_merged",
+    "stale_residue",
+)
 
 
 @dataclass(frozen=True)
@@ -105,6 +114,17 @@ class GitInfo:
 
 
 @dataclass
+class CleanupSafety:
+    safety_class: str
+    preserve: bool
+    safe_to_delete: bool
+    requires_live_cleanup_inspect: bool
+    reason: str
+    next_action: str
+    signals: list[str] = field(default_factory=list)
+
+
+@dataclass
 class WorktreeCandidate:
     candidate_id: str
     path: str
@@ -115,6 +135,7 @@ class WorktreeCandidate:
     classification: str
     decision: str
     cleanup_candidate: bool
+    cleanup_safety: CleanupSafety
     proof: list[str]
     active_session: bool
     lock_files: list[str]
@@ -819,6 +840,15 @@ def build_candidate(
     else:
         decision = "preserve"
         next_action = "review classification before cleanup"
+    cleanup_safety = cleanup_safety_for_candidate(
+        classification=classification,
+        decision=decision,
+        cleanup_candidate=cleanup_candidate,
+        active_session=active_session,
+        lock_files=lock_files,
+        git=git,
+        links=links,
+    )
     return WorktreeCandidate(
         candidate_id=candidate_id(candidate_root, repo_path),
         path=str(candidate_root),
@@ -829,12 +859,113 @@ def build_candidate(
         classification=classification,
         decision=decision,
         cleanup_candidate=cleanup_candidate,
+        cleanup_safety=cleanup_safety,
         proof=proof,
         active_session=active_session,
         lock_files=lock_files,
         git=git,
         links=links,
         next_action=next_action,
+    )
+
+
+def cleanup_safety_for_candidate(
+    *,
+    classification: str,
+    decision: str,
+    cleanup_candidate: bool,
+    active_session: bool,
+    lock_files: list[str],
+    git: GitInfo,
+    links: dict[str, Any],
+) -> CleanupSafety:
+    if active_session or lock_files:
+        return CleanupSafety(
+            safety_class="owned",
+            preserve=True,
+            safe_to_delete=False,
+            requires_live_cleanup_inspect=False,
+            reason="active session or owner lock marker is present",
+            next_action="route to the active owner or wait for explicit release",
+            signals=["owned"],
+        )
+    if git.dirty or decision == "harvest_candidate":
+        reason = (
+            "branch has unique unharvested work"
+            if decision == "harvest_candidate"
+            else "git status is dirty or unavailable"
+        )
+        return CleanupSafety(
+            safety_class="unsafe_to_delete",
+            preserve=True,
+            safe_to_delete=False,
+            requires_live_cleanup_inspect=False,
+            reason=reason,
+            next_action="preserve and harvest or resolve dirty state before any cleanup",
+            signals=["unsafe_to_delete"],
+        )
+    if git.lookup_failed or classification == "lookup_failed":
+        return CleanupSafety(
+            safety_class="unknown_preserve",
+            preserve=True,
+            safe_to_delete=False,
+            requires_live_cleanup_inspect=False,
+            reason="one or more identity, git, GitHub, or patch-equivalence lookups failed",
+            next_action="preserve until lookup succeeds and a fresh cleanup inspect agrees",
+            signals=["unknown", "unsafe_to_delete"],
+        )
+    if classification == "open_pr_or_outbox":
+        signals = ["referenced"]
+        if links.get("open_prs"):
+            signals.append("duplicate")
+        return CleanupSafety(
+            safety_class="referenced_preserve",
+            preserve=True,
+            safe_to_delete=False,
+            requires_live_cleanup_inspect=False,
+            reason="open PR or unresolved outbox still references the branch",
+            next_action="preserve or route to the owning publication/handoff lane",
+            signals=signals,
+        )
+    if classification == "receipt_protected":
+        return CleanupSafety(
+            safety_class="referenced_preserve",
+            preserve=True,
+            safe_to_delete=False,
+            requires_live_cleanup_inspect=False,
+            reason="terminal receipt references this branch or head",
+            next_action="preserve unless a bounded cleanup lane verifies supersedence",
+            signals=["referenced", "harvested"],
+        )
+    if classification == "patch_equivalent_or_merged":
+        safety_class = "stale_or_merged" if git.registered_worktree else "harvested_or_duplicate"
+        return CleanupSafety(
+            safety_class=safety_class,
+            preserve=False,
+            safe_to_delete=False,
+            requires_live_cleanup_inspect=True,
+            reason="branch has no unique diff against base or matches a merged patch",
+            next_action="run fresh safe_worktree_cleanup.py inspect before any removal",
+            signals=["stale", "harvested", "duplicate"],
+        )
+    if cleanup_candidate and classification in {"unregistered_git_residue", "no_git_cache_residue"}:
+        return CleanupSafety(
+            safety_class="stale_residue",
+            preserve=False,
+            safe_to_delete=False,
+            requires_live_cleanup_inspect=True,
+            reason="local residue has no active owner or unique confirmed work in inventory",
+            next_action="run fresh safe_worktree_cleanup.py inspect before any removal",
+            signals=["stale"],
+        )
+    return CleanupSafety(
+        safety_class="unknown_preserve",
+        preserve=True,
+        safe_to_delete=False,
+        requires_live_cleanup_inspect=False,
+        reason=f"inventory classification is not cleanup-authoritative: {classification}",
+        next_action="preserve until a narrower helper provides cleanup authority",
+        signals=["unknown"],
     )
 
 
@@ -934,6 +1065,7 @@ def candidate_roots_from(roots: list[Path], limit: int | None = None) -> list[Pa
 
 def build_summary(candidates: list[WorktreeCandidate]) -> dict[str, Any]:
     counts = Counter(candidate.classification for candidate in candidates)
+    safety_counts = Counter(candidate.cleanup_safety.safety_class for candidate in candidates)
     bytes_by_class: dict[str, int] = dict.fromkeys(VALUE_CLASSES, 0)
     known_bytes = 0
     size_lookup_failures = 0
@@ -953,10 +1085,12 @@ def build_summary(candidates: list[WorktreeCandidate]) -> dict[str, Any]:
             {
                 "path": candidate.path,
                 "classification": candidate.classification,
+                "safety_class": candidate.cleanup_safety.safety_class,
                 "size_bytes": candidate.size_bytes,
                 "branch": candidate.git.branch,
                 "head": candidate.git.head,
                 "decision": candidate.decision,
+                "cleanup_safety": asdict(candidate.cleanup_safety),
                 "proof": candidate.proof,
             }
             for candidate in selected[:20]
@@ -967,6 +1101,7 @@ def build_summary(candidates: list[WorktreeCandidate]) -> dict[str, Any]:
         "classified_candidates": sum(counts.values()),
         "unknown_candidates": counts.get("lookup_failed", 0),
         "count_by_class": {name: counts.get(name, 0) for name in VALUE_CLASSES},
+        "count_by_safety_class": {name: safety_counts.get(name, 0) for name in SAFETY_CLASSES},
         "bytes_by_class": bytes_by_class,
         "known_size_bytes": known_bytes,
         "size_lookup_failures": size_lookup_failures,
@@ -1217,6 +1352,9 @@ def main(argv: list[str] | None = None) -> int:
         print(f"harvest_candidates: {summary['harvest_candidate_count']}")
         print("classes:")
         for name, count in summary["count_by_class"].items():
+            print(f"  {name}: {count}")
+        print("safety_classes:")
+        for name, count in summary["count_by_safety_class"].items():
             print(f"  {name}: {count}")
     return 0
 

--- a/scripts/identify_lane_owner.py
+++ b/scripts/identify_lane_owner.py
@@ -196,6 +196,11 @@ class LaneOwnerInfo:
     dispatch_blocker: str | None
     steering_command: str | None
     harness_confidence: str
+    owner_state: str
+    liveness_state: str
+    cleanup_state: str
+    owner_state_reason: str
+    recommended_operator_action: str
 
 
 # ---------------------------------------------------------------------------
@@ -1012,6 +1017,80 @@ def _harness_confidence_for(
     return "mailbox_only"
 
 
+def _owner_state_for(
+    lane: dict[str, Any],
+    *,
+    owner_session: str,
+    live: dict[str, Any],
+    heartbeat: dict[str, Any] | None,
+) -> dict[str, str]:
+    status = str(lane.get("status") or "").strip().lower()
+    if live.get("found"):
+        liveness_state = "live_process"
+    elif heartbeat is None:
+        liveness_state = "missing_heartbeat"
+    elif heartbeat.get("fresh"):
+        liveness_state = "fresh_heartbeat"
+    else:
+        liveness_state = "stale_heartbeat"
+
+    if not owner_session:
+        return {
+            "owner_state": "unowned",
+            "liveness_state": liveness_state,
+            "cleanup_state": "unowned_requires_fresh_cleanup_inspect",
+            "owner_state_reason": "lane has no owner_session",
+            "recommended_operator_action": "claim the lane before mutation; run cleanup inspection before deletion",
+        }
+    if status in CONFLICT_STATUSES:
+        return {
+            "owner_state": "duplicate",
+            "liveness_state": liveness_state,
+            "cleanup_state": "preserve_duplicate_owner",
+            "owner_state_reason": "lane is in conflict status",
+            "recommended_operator_action": "resolve the lane conflict before mutation or cleanup",
+        }
+    if status in COMPLETED_STATUSES:
+        return {
+            "owner_state": "stale",
+            "liveness_state": liveness_state,
+            "cleanup_state": "historical_requires_cleanup_inspect",
+            "owner_state_reason": f"lane status is {status}",
+            "recommended_operator_action": "treat as historical; run fresh cleanup inspection before any deletion",
+        }
+    if status in ACTIVE_STATUSES:
+        if liveness_state == "stale_heartbeat":
+            return {
+                "owner_state": "owned",
+                "liveness_state": liveness_state,
+                "cleanup_state": "preserve_stale_owner",
+                "owner_state_reason": "active lane has stale heartbeat evidence",
+                "recommended_operator_action": "preserve; refresh heartbeat or contact owner before mutation or cleanup",
+            }
+        if liveness_state == "missing_heartbeat":
+            return {
+                "owner_state": "owned",
+                "liveness_state": liveness_state,
+                "cleanup_state": "preserve_unverified_owner",
+                "owner_state_reason": "active lane has no heartbeat evidence",
+                "recommended_operator_action": "preserve; start or refresh agent heartbeat before cleanup decisions",
+            }
+        return {
+            "owner_state": "owned",
+            "liveness_state": liveness_state,
+            "cleanup_state": "preserve_live_owner",
+            "owner_state_reason": f"lane status is {status} with current liveness evidence",
+            "recommended_operator_action": "route work through owner_session; do not cleanup without owner release",
+        }
+    return {
+        "owner_state": "unknown",
+        "liveness_state": liveness_state,
+        "cleanup_state": "preserve_unknown_owner_state",
+        "owner_state_reason": f"lane status is {status or 'unknown'}",
+        "recommended_operator_action": "preserve until lane status is clarified",
+    }
+
+
 # ---------------------------------------------------------------------------
 # Composition
 # ---------------------------------------------------------------------------
@@ -1043,6 +1122,7 @@ def build_owner_info(
         freshness_seconds=heartbeat_fresh_seconds,
     )
     dispatch_blocker = _dispatch_blocker_for(lane, owner)
+    owner_state = _owner_state_for(lane, owner_session=owner, live=live, heartbeat=heartbeat)
 
     raw_pr = lane.get("pr_number")
     try:
@@ -1093,6 +1173,11 @@ def build_owner_info(
             claude=claude,
             factory=factory,
         ),
+        owner_state=owner_state["owner_state"],
+        liveness_state=owner_state["liveness_state"],
+        cleanup_state=owner_state["cleanup_state"],
+        owner_state_reason=owner_state["owner_state_reason"],
+        recommended_operator_action=owner_state["recommended_operator_action"],
     )
 
 
@@ -1110,6 +1195,11 @@ def _print_human(info: LaneOwnerInfo) -> None:
     print(f"owner_session:  {info.owner_session or '(none)'}")
     print(f"source:         {info.source or '(unspecified)'}")
     print(f"status:         {info.status or '(unspecified)'}")
+    print(f"owner_state:    {info.owner_state}")
+    print(f"liveness_state: {info.liveness_state}")
+    print(f"cleanup_state:  {info.cleanup_state}")
+    print(f"owner_reason:   {info.owner_state_reason}")
+    print(f"recommended_action: {info.recommended_operator_action}")
     print(f"branch:         {info.branch or '-'}")
     print(f"worktree:       {info.worktree or '-'}")
     print(f"pr_number:      {info.pr_number if info.pr_number is not None else '-'}")

--- a/scripts/safe_worktree_cleanup.py
+++ b/scripts/safe_worktree_cleanup.py
@@ -40,6 +40,126 @@ class WorktreeInspection:
     blockers: list[str]
 
 
+_BLOCKER_DETAILS: dict[str, tuple[str, str, str]] = {
+    "missing_path": (
+        "absent",
+        "Path no longer exists; there is nothing for this helper to remove.",
+        "verify registry state separately before pruning metadata",
+    ),
+    "active_session": (
+        "owned",
+        "An active session marker was detected for this worktree.",
+        "preserve and route cleanup through the live owner",
+    ),
+    "dirty_worktree": (
+        "unsafe_to_delete",
+        "The worktree has uncommitted changes or git status could not prove cleanliness.",
+        "preserve until dirty state is harvested, discarded by owner, or independently proven safe",
+    ),
+    "branch_ahead_of_origin_main": (
+        "unsafe_to_delete",
+        "The branch has commits not proven present or patch-equivalent on origin/main.",
+        "harvest or reconcile branch value before cleanup",
+    ),
+    "patch_equivalence_lookup_failed": (
+        "unknown",
+        "Patch-equivalence lookup failed, so duplicate/harvested status is unproven.",
+        "rerun inspection when patch-equivalence helper is healthy",
+    ),
+    "branch_lookup_failed": (
+        "unknown",
+        "Branch lookup timed out or failed, so ownership and value checks are incomplete.",
+        "preserve until branch identity can be recovered",
+    ),
+    "open_pr": (
+        "referenced",
+        "A live open PR references this branch.",
+        "preserve until the PR is merged, closed, or explicitly superseded",
+    ),
+    "ahead_lookup_failed": (
+        "unknown",
+        "Ahead/behind lookup failed, so unique-commit status is unproven.",
+        "preserve until git history lookup succeeds",
+    ),
+    "pr_lookup_failed": (
+        "unknown",
+        "Open-PR lookup failed while the branch may still contain unique work.",
+        "preserve until GitHub lookup succeeds or local proof is sufficient",
+    ),
+}
+
+
+def cleanup_safety(inspection: WorktreeInspection) -> dict[str, Any]:
+    """Return structured deletion-safety diagnostics for cleanup agents.
+
+    ``blockers`` remains the stable fail-closed contract.  This derived
+    payload explains *why* each blocker matters and classifies clear cases
+    such as owned, harvested, stale, referenced, and unsafe-to-delete.
+    """
+
+    blocker_details = [
+        {
+            "blocker": blocker,
+            "category": _BLOCKER_DETAILS.get(blocker, ("unknown", "", ""))[0],
+            "reason": _BLOCKER_DETAILS.get(blocker, ("unknown", "Unclassified blocker.", ""))[1],
+            "next_action": _BLOCKER_DETAILS.get(
+                blocker, ("unknown", "", "preserve until manually reviewed")
+            )[2],
+        }
+        for blocker in inspection.blockers
+    ]
+    categories = {detail["category"] for detail in blocker_details}
+
+    if "owned" in categories:
+        classification = "owned"
+        decision = "preserve"
+    elif "unsafe_to_delete" in categories:
+        classification = "unsafe_to_delete"
+        decision = "preserve"
+    elif "unknown" in categories:
+        classification = "unknown_preserve"
+        decision = "preserve"
+    elif "referenced" in categories:
+        classification = "referenced_preserve"
+        decision = "preserve"
+    elif "absent" in categories:
+        classification = "absent_noop"
+        decision = "noop"
+    elif inspection.patch_equivalent_to_origin_main:
+        classification = "harvested_or_duplicate"
+        decision = "cleanup_candidate"
+    elif inspection.branch and inspection.unique_commits_ahead == 0:
+        classification = "stale_or_merged"
+        decision = "cleanup_candidate"
+    elif inspection.exists and not inspection.tracked_worktree:
+        classification = "untracked_residue"
+        decision = "cleanup_candidate"
+    else:
+        classification = "cleanup_candidate"
+        decision = "cleanup_candidate"
+
+    return {
+        "removable": not inspection.blockers,
+        "classification": classification,
+        "decision": decision,
+        "blocker_details": blocker_details,
+        "signals": {
+            "exists": inspection.exists,
+            "tracked_worktree": inspection.tracked_worktree,
+            "branch": inspection.branch,
+            "active_session": inspection.active_session,
+            "lock_files": inspection.lock_files,
+            "dirty": inspection.dirty,
+            "unique_commits_ahead": inspection.unique_commits_ahead,
+            "ahead_lookup_failed": inspection.ahead_lookup_failed,
+            "patch_equivalent_to_origin_main": inspection.patch_equivalent_to_origin_main,
+            "patch_equivalence_lookup_failed": inspection.patch_equivalence_lookup_failed,
+            "open_pr_count": len(inspection.open_prs),
+            "pr_lookup_failed": inspection.pr_lookup_failed,
+        },
+    }
+
+
 def _active_lock_files(path: Path) -> list[str]:
     return [
         name
@@ -310,6 +430,7 @@ def inspect_worktree(
 def _print_inspection(inspection: WorktreeInspection, *, as_json: bool) -> None:
     payload = asdict(inspection)
     payload["removable"] = not inspection.blockers
+    payload["cleanup_safety"] = cleanup_safety(inspection)
     if as_json:
         print(json.dumps(payload, indent=2))
         return
@@ -332,10 +453,13 @@ def _print_inspection(inspection: WorktreeInspection, *, as_json: bool) -> None:
         for pr in inspection.open_prs:
             print(f"  - #{pr.get('number')} {pr.get('title')} :: {pr.get('url')}")
     print(f"removable: {not inspection.blockers}")
+    safety = cleanup_safety(inspection)
+    print(f"cleanup_classification: {safety['classification']}")
+    print(f"cleanup_decision: {safety['decision']}")
     if inspection.blockers:
         print("blockers:")
-        for blocker in inspection.blockers:
-            print(f"  - {blocker}")
+        for detail in safety["blocker_details"]:
+            print(f"  - {detail['blocker']} [{detail['category']}]: {detail['next_action']}")
 
 
 def _delete_branch(repo_root: Path, branch: str) -> bool:
@@ -370,6 +494,7 @@ def remove_worktree(
         "branch_deleted": False,
         "path_purged": False,
         "blockers": list(inspection.blockers),
+        "cleanup_safety": cleanup_safety(inspection),
     }
     path = Path(inspection.path)
     if inspection.blockers and not force:

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -1063,7 +1063,49 @@ def test_operator_snapshot_counts_active_duplicate_pr_lanes_as_conflicts(
     assert payload["summary"]["conflict_lanes"] == 2
     assert payload["lane_conflicts"][0]["key_kind"] == "branch"
     assert payload["health"]["ok"] is False
-    assert payload["health"]["issues"][0]["type"] == "lane_identity_conflict"
+    issue = payload["health"]["issues"][0]
+    assert issue["type"] == "lane_identity_conflict"
+    assert issue["owner_state"] == "duplicate_active_owner"
+    assert issue["key_kind"] == "branch"
+    assert issue["key_value"] == "worktree-codex-insights"
+    assert issue["owner_sessions"] == ["codex-A", "codex-B"]
+    assert issue["recommended_operator_action"] == (
+        "resolve duplicate active owners before mutation or cleanup"
+    )
+
+
+def test_health_missing_heartbeat_has_liveness_diagnostic() -> None:
+    import agent_bridge as mod
+
+    issues = mod._collect_health_issues(
+        [],
+        [
+            mod.LaneRecord(
+                lane_id="lane-no-heartbeat",
+                owner_session="codex-worker",
+                status="active",
+                next_action="finish one safe cleanup diagnostic",
+                last_steering_outcome="obeyed",
+                worktree="/tmp/owned-worktree",
+            )
+        ],
+    )
+
+    assert issues == [
+        {
+            "type": "lane_missing_heartbeat",
+            "session": "codex-worker",
+            "detail": "active lane 'lane-no-heartbeat' has no heartbeat timestamp",
+            "owner_state": "active_lane_missing_liveness",
+            "lane_id": "lane-no-heartbeat",
+            "status": "active",
+            "worktree": "/tmp/owned-worktree",
+            "heartbeat_state": "missing",
+            "recommended_operator_action": (
+                "start or refresh agent_heartbeat.py before treating owner as live"
+            ),
+        }
+    ]
 
 
 def test_operator_snapshot_does_not_conflict_same_owner_refreshes(
@@ -2312,13 +2354,18 @@ def test_health_reports_dead_non_root_worktree(
 
     assert mod.cmd_health(argparse.Namespace(json=True)) == 1
     payload = json.loads(capsys.readouterr().out)
-    assert payload["issues"] == [
-        {
-            "type": "stale_worktree",
-            "session": "codex-old-lane",
-            "detail": f"dead session with lingering worktree: {worktree}",
-        }
-    ]
+    assert len(payload["issues"]) == 1
+    issue = payload["issues"][0]
+    assert issue["type"] == "stale_worktree"
+    assert issue["session"] == "codex-old-lane"
+    assert issue["detail"] == f"dead session with lingering worktree: {worktree}"
+    assert issue["owner_state"] == "stale_session"
+    assert issue["worktree"] == str(worktree)
+    assert issue["worktree_exists"] is True
+    assert issue["cleanup_state"] == "stale_lingering_worktree"
+    assert issue["recommended_operator_action"] == (
+        "inspect with safe_worktree_cleanup.py before any removal"
+    )
 
 
 def test_health_ignores_dead_tmux_session_kept_current_by_broker_state(
@@ -2462,13 +2509,16 @@ def test_health_reports_claimed_claude_transcript_missing_worktree(tmp_path: Pat
         ],
     )
 
-    assert issues == [
-        {
-            "type": "stale_worktree",
-            "session": "claude-review",
-            "detail": f"worktree path missing: {removed_worktree}",
-        }
-    ]
+    assert len(issues) == 1
+    issue = issues[0]
+    assert issue["type"] == "stale_worktree"
+    assert issue["session"] == "claude-review"
+    assert issue["detail"] == f"worktree path missing: {removed_worktree}"
+    assert issue["owner_state"] == "active_or_current_session"
+    assert issue["worktree"] == str(removed_worktree)
+    assert issue["worktree_exists"] is False
+    assert issue["cleanup_state"] == "missing_path_metadata"
+    assert issue["recommended_operator_action"] == "verify lane ownership before pruning metadata"
 
 
 def test_gc_dry_run_archives_only_bridge_owned_tmux_candidates(

--- a/tests/scripts/test_codex_worktree_value_inventory.py
+++ b/tests/scripts/test_codex_worktree_value_inventory.py
@@ -163,6 +163,9 @@ def test_no_git_cache_residue_is_cleanup_candidate(tmp_path: Path) -> None:
     assert candidate.classification == "no_git_cache_residue"
     assert candidate.cleanup_candidate is True
     assert candidate.decision == "cleanup_candidate"
+    assert candidate.cleanup_safety.safety_class == "stale_residue"
+    assert candidate.cleanup_safety.requires_live_cleanup_inspect is True
+    assert candidate.cleanup_safety.safe_to_delete is False
 
 
 def test_no_git_active_marker_is_preserved(tmp_path: Path) -> None:
@@ -181,6 +184,9 @@ def test_no_git_active_marker_is_preserved(tmp_path: Path) -> None:
     assert candidate.classification == "active_or_dirty"
     assert candidate.cleanup_candidate is False
     assert candidate.decision == "preserve"
+    assert candidate.cleanup_safety.safety_class == "owned"
+    assert candidate.cleanup_safety.preserve is True
+    assert candidate.cleanup_safety.signals == ["owned"]
 
 
 def test_anchor_only_wrapper_is_not_active(tmp_path: Path) -> None:
@@ -284,6 +290,8 @@ def test_dirty_repo_takes_priority_over_unique_work(
 
     assert candidate.classification == "active_or_dirty"
     assert "git status is dirty or unavailable" in candidate.proof
+    assert candidate.cleanup_safety.safety_class == "unsafe_to_delete"
+    assert "unsafe_to_delete" in candidate.cleanup_safety.signals
 
 
 def test_open_pr_classification_blocks_cleanup(
@@ -307,6 +315,8 @@ def test_open_pr_classification_blocks_cleanup(
 
     assert candidate.classification == "open_pr_or_outbox"
     assert candidate.cleanup_candidate is False
+    assert candidate.cleanup_safety.safety_class == "referenced_preserve"
+    assert "duplicate" in candidate.cleanup_safety.signals
 
 
 def test_unresolved_outbox_classification_blocks_cleanup(
@@ -345,6 +355,8 @@ def test_terminal_receipt_classification_blocks_cleanup(
 
     assert candidate.classification == "receipt_protected"
     assert candidate.cleanup_candidate is False
+    assert candidate.cleanup_safety.safety_class == "referenced_preserve"
+    assert "harvested" in candidate.cleanup_safety.signals
 
 
 def test_unique_unharvested_when_ahead_and_not_patch_equivalent(
@@ -365,6 +377,8 @@ def test_unique_unharvested_when_ahead_and_not_patch_equivalent(
     assert candidate.classification == "unique_unharvested"
     assert candidate.decision == "harvest_candidate"
     assert candidate.cleanup_candidate is False
+    assert candidate.cleanup_safety.safety_class == "unsafe_to_delete"
+    assert candidate.cleanup_safety.preserve is True
 
 
 def test_patch_equivalent_ahead_work_is_cleanup_candidate(
@@ -384,6 +398,34 @@ def test_patch_equivalent_ahead_work_is_cleanup_candidate(
 
     assert candidate.classification == "patch_equivalent_or_merged"
     assert candidate.cleanup_candidate is True
+    assert candidate.cleanup_safety.safety_class == "harvested_or_duplicate"
+    assert {"harvested", "duplicate"} <= set(candidate.cleanup_safety.signals)
+
+
+def test_registered_no_unique_commits_is_stale_or_merged_safety(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import codex_worktree_value_inventory as mod
+
+    root = _candidate(tmp_path)
+    repo_path = root / "aragora"
+    _stub_clean_git(monkeypatch, ahead=0)
+
+    candidate = mod.classify_candidate(
+        root,
+        context=_context(
+            tmp_path,
+            worktrees_by_path={
+                str(repo_path.resolve()): mod.WorktreeEntry(path=repo_path, branch="codex/test")
+            },
+        ),
+        size_bytes=1024,
+        size_lookup_failed=False,
+    )
+
+    assert candidate.classification == "patch_equivalent_or_merged"
+    assert candidate.cleanup_safety.safety_class == "stale_or_merged"
+    assert candidate.cleanup_safety.requires_live_cleanup_inspect is True
 
 
 def test_smart_merge_detection_default_off_preserves_unique_harvest(
@@ -550,6 +592,8 @@ def test_lookup_failure_preserves_candidate(
     assert candidate.classification == "lookup_failed"
     assert candidate.cleanup_candidate is False
     assert "open PR lookup failed" in candidate.git.lookup_errors
+    assert candidate.cleanup_safety.safety_class == "unknown_preserve"
+    assert "unsafe_to_delete" in candidate.cleanup_safety.signals
 
 
 def test_summary_reports_top_cleanup_and_harvest_candidates(
@@ -578,8 +622,13 @@ def test_summary_reports_top_cleanup_and_harvest_candidates(
 
     assert summary["cleanup_candidate_count"] == 1
     assert summary["harvest_candidate_count"] == 1
+    assert summary["count_by_safety_class"]["stale_residue"] == 1
+    assert summary["count_by_safety_class"]["unsafe_to_delete"] == 1
     assert summary["top_cleanup_candidates"][0]["path"] == str(cleanup_root)
+    assert summary["top_cleanup_candidates"][0]["safety_class"] == "stale_residue"
+    assert summary["top_cleanup_candidates"][0]["cleanup_safety"]["safe_to_delete"] is False
     assert summary["top_unique_unharvested"][0]["path"] == str(unique_root)
+    assert summary["top_unique_unharvested"][0]["safety_class"] == "unsafe_to_delete"
 
 
 def test_write_ledger_creates_snapshot_latest_and_jsonl(tmp_path: Path) -> None:

--- a/tests/scripts/test_identify_lane_owner.py
+++ b/tests/scripts/test_identify_lane_owner.py
@@ -268,6 +268,12 @@ class TestHeartbeatSummary:
             == "droid/P16-stage2-auto-merge-bucket-a-20260518-002325"
         )
         assert info.latest_heartbeat["pr_number"] == 7292
+        assert info.owner_state == "owned"
+        assert info.liveness_state == "fresh_heartbeat"
+        assert info.cleanup_state == "preserve_live_owner"
+        assert info.recommended_operator_action == (
+            "route work through owner_session; do not cleanup without owner release"
+        )
 
     def test_build_owner_info_marks_stale_heartbeat(self, tmp_path: Path) -> None:
         heartbeat_path = tmp_path / "heartbeats.json"
@@ -298,6 +304,12 @@ class TestHeartbeatSummary:
         assert info.latest_heartbeat is not None
         assert info.latest_heartbeat["fresh"] is False
         assert info.latest_heartbeat["age_seconds"] == 1200
+        assert info.owner_state == "owned"
+        assert info.liveness_state == "stale_heartbeat"
+        assert info.cleanup_state == "preserve_stale_owner"
+        assert info.recommended_operator_action == (
+            "preserve; refresh heartbeat or contact owner before mutation or cleanup"
+        )
 
     def test_build_owner_info_prefers_claimed_owner_heartbeat(self, tmp_path: Path) -> None:
         heartbeat_path = tmp_path / "heartbeats.json"
@@ -900,6 +912,10 @@ class TestBuildOwnerInfo:
         assert info.live_process["found"] is False
         assert info.claude_session["found"] is False
         assert info.factory_droid["found"] is False
+        assert info.owner_state == "owned"
+        assert info.liveness_state == "missing_heartbeat"
+        assert info.cleanup_state == "preserve_unverified_owner"
+        assert info.owner_state_reason == "active lane has no heartbeat evidence"
 
     def test_contact_metadata_surfaces_and_controls_dispatch_split(self, tmp_path: Path) -> None:
         bg = tmp_path / "factory_bg.json"
@@ -931,6 +947,61 @@ class TestBuildOwnerInfo:
         assert info.last_ack_at == "2026-05-20T01:02:00Z"
         assert info.mailbox_dispatchable is True
         assert info.live_prompt_dispatchable is True
+
+    def test_owner_state_marks_conflict_as_duplicate_preserve(self, tmp_path: Path) -> None:
+        bg = tmp_path / "factory_bg.json"
+        bg.write_text("[]", encoding="utf-8")
+        lane = {
+            "lane_id": "duplicate-lane",
+            "owner_session": "codex-conflict",
+            "status": "conflict",
+            "worktree": "/tmp/duplicate-worktree",
+        }
+
+        info = ilo.build_owner_info(
+            lane,
+            snapshot_provider=lambda: fake_snapshot_records([]),
+            sessions_root=tmp_path / "codex_sessions",
+            projects_root=tmp_path / "claude_projects",
+            bg_path=bg,
+            steering_inbox_root=tmp_path / "steering",
+        )
+
+        assert info.owner_state == "duplicate"
+        assert info.liveness_state == "missing_heartbeat"
+        assert info.cleanup_state == "preserve_duplicate_owner"
+        assert info.dispatchable is False
+        assert info.recommended_operator_action == (
+            "resolve the lane conflict before mutation or cleanup"
+        )
+
+    def test_owner_state_marks_completed_lane_as_stale_historical(self, tmp_path: Path) -> None:
+        bg = tmp_path / "factory_bg.json"
+        bg.write_text("[]", encoding="utf-8")
+        lane = {
+            "lane_id": "completed-lane",
+            "owner_session": "codex-finished",
+            "status": "completed",
+            "worktree": "/tmp/completed-worktree",
+        }
+
+        info = ilo.build_owner_info(
+            lane,
+            snapshot_provider=lambda: fake_snapshot_records([]),
+            sessions_root=tmp_path / "codex_sessions",
+            projects_root=tmp_path / "claude_projects",
+            bg_path=bg,
+            steering_inbox_root=tmp_path / "steering",
+        )
+
+        assert info.owner_state == "stale"
+        assert info.liveness_state == "missing_heartbeat"
+        assert info.cleanup_state == "historical_requires_cleanup_inspect"
+        assert info.dispatchable is False
+        assert info.owner_state_reason == "lane status is completed"
+        assert info.recommended_operator_action == (
+            "treat as historical; run fresh cleanup inspection before any deletion"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scripts/test_safe_worktree_cleanup.py
+++ b/tests/scripts/test_safe_worktree_cleanup.py
@@ -327,6 +327,13 @@ def test_inspect_blocks_dirty_and_ahead_worktrees(
     assert inspection.dirty is True
     assert inspection.unique_commits_ahead == 2
     assert inspection.blockers == ["dirty_worktree", "branch_ahead_of_origin_main"]
+    safety = mod.cleanup_safety(inspection)
+    assert safety["classification"] == "unsafe_to_delete"
+    assert safety["decision"] == "preserve"
+    assert [row["category"] for row in safety["blocker_details"]] == [
+        "unsafe_to_delete",
+        "unsafe_to_delete",
+    ]
 
 
 def test_inspect_allows_pr_lookup_failure_for_branch_with_no_unique_commits(
@@ -355,6 +362,10 @@ def test_inspect_allows_pr_lookup_failure_for_branch_with_no_unique_commits(
     assert inspection.pr_lookup_failed is True
     assert inspection.unique_commits_ahead == 0
     assert inspection.blockers == []
+    safety = mod.cleanup_safety(inspection)
+    assert safety["classification"] == "stale_or_merged"
+    assert safety["decision"] == "cleanup_candidate"
+    assert safety["removable"] is True
 
 
 def test_inspect_allows_patch_equivalent_branch_when_pr_lookup_fails(
@@ -385,6 +396,10 @@ def test_inspect_allows_patch_equivalent_branch_when_pr_lookup_fails(
     assert inspection.unique_commits_ahead == 4
     assert inspection.patch_equivalent_to_origin_main is True
     assert inspection.blockers == []
+    safety = mod.cleanup_safety(inspection)
+    assert safety["classification"] == "harvested_or_duplicate"
+    assert safety["decision"] == "cleanup_candidate"
+    assert safety["signals"]["patch_equivalent_to_origin_main"] is True
 
 
 def test_inspect_reports_stale_lock_files_without_blocking_cleanup(
@@ -444,6 +459,54 @@ def test_inspect_blocks_active_session_and_history_lookup_failure(
     assert inspection.active_session is True
     assert inspection.ahead_lookup_failed is True
     assert inspection.blockers == ["active_session", "ahead_lookup_failed"]
+    safety = mod.cleanup_safety(inspection)
+    assert safety["classification"] == "owned"
+    assert safety["decision"] == "preserve"
+    assert [row["category"] for row in safety["blocker_details"]] == ["owned", "unknown"]
+    assert safety["blocker_details"][0]["next_action"] == (
+        "preserve and route cleanup through the live owner"
+    )
+
+
+def test_inspect_json_includes_cleanup_safety_payload(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import safe_worktree_cleanup as mod
+
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    inspection = mod.WorktreeInspection(
+        path=str(worktree),
+        exists=True,
+        tracked_worktree=True,
+        branch="codex/test",
+        active_session=False,
+        lock_files=[],
+        dirty=False,
+        unique_commits_ahead=0,
+        ahead_lookup_failed=False,
+        patch_equivalent_to_origin_main=False,
+        patch_equivalence_lookup_failed=False,
+        open_prs=[{"number": 1361, "title": "Open PR", "url": "https://example.com/pr/1361"}],
+        pr_lookup_failed=False,
+        blockers=["open_pr"],
+    )
+
+    mod._print_inspection(inspection, as_json=True)
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["removable"] is False
+    assert payload["cleanup_safety"]["classification"] == "referenced_preserve"
+    assert payload["cleanup_safety"]["decision"] == "preserve"
+    assert payload["cleanup_safety"]["blocker_details"] == [
+        {
+            "blocker": "open_pr",
+            "category": "referenced",
+            "reason": "A live open PR references this branch.",
+            "next_action": "preserve until the PR is merged, closed, or explicitly superseded",
+        }
+    ]
 
 
 def test_worktree_is_not_dirty_for_empty_nested_wrapper(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add structured owner/lane/heartbeat diagnostics so active, stale, duplicate, and missing-liveness states are explicit.
- Add cleanup safety payloads for safe_worktree_cleanup and worktree inventory so agents can distinguish owned, stale, harvested/duplicate, referenced, unknown, and unsafe-to-delete cases.
- Add focused tests covering the new diagnostics vocabulary without changing cleanup/remove behavior.

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/scripts/test_codex_worktree_value_inventory.py tests/scripts/test_agent_bridge.py tests/scripts/test_identify_lane_owner.py tests/scripts/test_safe_worktree_cleanup.py
- python3 -m ruff check scripts/agent_bridge.py scripts/identify_lane_owner.py scripts/safe_worktree_cleanup.py scripts/codex_worktree_value_inventory.py tests/scripts/test_agent_bridge.py tests/scripts/test_identify_lane_owner.py tests/scripts/test_safe_worktree_cleanup.py tests/scripts/test_codex_worktree_value_inventory.py
- python3 -m ruff format --check scripts/agent_bridge.py scripts/identify_lane_owner.py scripts/safe_worktree_cleanup.py scripts/codex_worktree_value_inventory.py tests/scripts/test_agent_bridge.py tests/scripts/test_identify_lane_owner.py tests/scripts/test_safe_worktree_cleanup.py tests/scripts/test_codex_worktree_value_inventory.py
- git diff --check

Head: 2a71d9a8dda8c0ccf8a402a3e98e99e1dcb979f5