### PR TITLE
fix(review-queue): reject wrong-PR evidence lint

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3526,6 +3526,14 @@ def _proposed_evidence_pr_grounding(body: str, pr: str) -> tuple[bool, str]:
             flags=re.IGNORECASE,
         )
     }
+    cited.update(
+        match.group(1)
+        for match in re.finditer(
+            r"\bgithub\.com/[^\s)<>]+/pull/(\d+)\b",
+            str(body or ""),
+            flags=re.IGNORECASE,
+        )
+    )
     if not cited:
         return True, "no_pr_citation"
     if normalized_pr in cited:

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3427,12 +3427,13 @@ def _lint_evidence_comment(
     """Dry-run whether one proposed comment would satisfy quorum parsers."""
     grounded, grounding_method = _proposed_evidence_head_grounding(body, head_sha)
     pr_grounded, pr_grounding_method = _proposed_evidence_pr_grounding(body, pr)
+    negative_verdict = _has_blocking_or_negative_verdict(body)
     comment = {
         "author": {"login": author},
         "body": body,
         "createdAt": "",
     }
-    if grounded and pr_grounded:
+    if grounded and pr_grounded and not negative_verdict:
         dogfood_evidence = _dogfood_evidence_from_comments([comment])
         reviewer_signals = _model_review_signals_from_comments([comment])
     else:
@@ -3452,6 +3453,8 @@ def _lint_evidence_comment(
         problems.append("wrong_pr_reference")
     if _is_github_actions_author(author):
         problems.append("github_actions_author_not_counted")
+    if negative_verdict:
+        problems.append("blocking_or_negative_verdict")
     if inferred_reviewer == "unknown_model_reviewer":
         problems.append("missing_known_model_reviewer_heading")
     for problem in identity.identity_problems:
@@ -3599,6 +3602,66 @@ def _known_model_reviewer_id(item: dict[str, Any]) -> str:
 
 def _is_github_actions_author(author: str) -> bool:
     return str(author or "").strip().lower() in {"github-actions", "github-actions[bot]"}
+
+
+def _has_blocking_or_negative_verdict(body: str) -> bool:
+    """Return True for explicit evidence comments that report blockers.
+
+    Merge quorum should count independent evidence that can support readiness,
+    not a comment that visibly says the reviewer failed or blocked the PR.
+    Keep the parser deliberately label-based so ordinary prose such as
+    "no blocking findings" remains countable.
+    """
+    negative_verdict_prefixes = (
+        "fail",
+        "failed",
+        "failing",
+        "block",
+        "blocked",
+        "blocking",
+        "request changes",
+        "request_changes",
+        "changes requested",
+        "reject",
+        "rejected",
+        "not ready",
+        "needs repair",
+    )
+    non_blocking_prefixes = (
+        "none",
+        "none found",
+        "no",
+        "no blockers",
+        "no blocking findings",
+        "not found",
+        "0",
+        "n/a",
+        "not applicable",
+        "[]",
+    )
+
+    for raw_line in str(body or "").splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        line = line.lstrip("-").strip().strip("*").strip()
+        line = line.replace("**", "")
+        label, sep, value = line.partition(":")
+        if not sep:
+            continue
+        normalized_label = re.sub(r"\s+", " ", label.strip().lower())
+        normalized_value = re.sub(r"\s+", " ", value.strip().strip("*").strip().lower())
+        if normalized_label in {"verdict", "decision", "recommendation"} and any(
+            normalized_value.startswith(prefix) for prefix in negative_verdict_prefixes
+        ):
+            return True
+        if normalized_label in {"blocking finding", "blocking findings", "blocker", "blockers"}:
+            if not normalized_value or any(
+                normalized_value.startswith(value) for value in non_blocking_prefixes
+            ):
+                continue
+            return True
+    return False
 
 
 def _normalize_model_reviewer_id(value: str) -> str:
@@ -3909,6 +3972,8 @@ def _dogfood_evidence_from_comments(
         if not _is_comment_grounded_on_head(comment, head_sha, head_committed_at):
             continue
         body = str(comment.get("body", "") or "")
+        if _has_blocking_or_negative_verdict(body):
+            continue
         lower = body.lower()
         if not any(
             token in lower for token in ("dogfood", "adversarial", "cross-author", "recheck")
@@ -3948,6 +4013,8 @@ def _model_review_signals_from_comments(
         if not _is_comment_grounded_on_head(comment, head_sha, head_committed_at):
             continue
         body = str(comment.get("body", "") or "")
+        if _has_blocking_or_negative_verdict(body):
+            continue
         lower = body.lower()
         if not any(
             token in lower

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3426,12 +3426,13 @@ def _lint_evidence_comment(
 ) -> dict[str, Any]:
     """Dry-run whether one proposed comment would satisfy quorum parsers."""
     grounded, grounding_method = _proposed_evidence_head_grounding(body, head_sha)
+    pr_grounded, pr_grounding_method = _proposed_evidence_pr_grounding(body, pr)
     comment = {
         "author": {"login": author},
         "body": body,
         "createdAt": "",
     }
-    if grounded:
+    if grounded and pr_grounded:
         dogfood_evidence = _dogfood_evidence_from_comments([comment])
         reviewer_signals = _model_review_signals_from_comments([comment])
     else:
@@ -3447,6 +3448,8 @@ def _lint_evidence_comment(
         problems.append("empty_body")
     if not grounded:
         problems.append("missing_current_head_grounding")
+    if not pr_grounded:
+        problems.append("wrong_pr_reference")
     if _is_github_actions_author(author):
         problems.append("github_actions_author_not_counted")
     if inferred_reviewer == "unknown_model_reviewer":
@@ -3491,6 +3494,8 @@ def _lint_evidence_comment(
         "identity_problems": list(identity.identity_problems),
         "current_head_grounded": grounded,
         "current_head_grounding_method": grounding_method,
+        "current_pr_grounded": pr_grounded,
+        "current_pr_grounding_method": pr_grounding_method,
         "dogfood_evidence": dogfood_evidence,
         "reviewer_signals": reviewer_signals,
         "counted_reviewer_ids": counted_reviewer_ids,
@@ -3498,6 +3503,34 @@ def _lint_evidence_comment(
         "would_count": bool(counted_reviewer_ids),
         "problems": problems,
     }
+
+
+def _proposed_evidence_pr_grounding(body: str, pr: str) -> tuple[bool, str]:
+    """Fail closed when a proposed evidence comment names the wrong PR.
+
+    Evidence comments are commonly drafted from recursive prompts that include
+    both a PR number and an exact head SHA. Lint mode should not approve a
+    body that is exact-head grounded but visibly copied from a different PR.
+    Comments without an explicit PR citation remain acceptable because the
+    caller already supplies the target ``--pr`` and the head SHA is the primary
+    current-head proof.
+    """
+    normalized_pr = str(pr or "").strip().lstrip("#")
+    if not normalized_pr:
+        return False, "missing_pr_argument"
+    cited = {
+        match.group(1)
+        for match in re.finditer(
+            r"\b(?:PR|pull\s+request)\s*[:#]?\s*#?(\d+)\b",
+            str(body or ""),
+            flags=re.IGNORECASE,
+        )
+    }
+    if not cited:
+        return True, "no_pr_citation"
+    if normalized_pr in cited:
+        return True, "pr_citation"
+    return False, "wrong_pr_citation"
 
 
 def _proposed_evidence_head_grounding(body: str, head_sha: str) -> tuple[bool, str]:

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -4754,6 +4754,38 @@ class TestCommandDispatch:
         assert "wrong_pr_reference" in payload["problems"]
         assert "no_counted_model_reviewer" in payload["problems"]
 
+    def test_evidence_lint_rejects_wrong_pr_url_reference(self) -> None:
+        ns = argparse.Namespace(
+            review_queue_command="evidence-lint",
+            pr="7445",
+            head_sha="cd87c5a1b2db34f04167906553502db3ede9525e",
+            head_committed_at="2026-05-23T19:00:00Z",
+            body=_codex_openai_body(
+                body=(
+                    "Evidence comment: https://github.com/synaptent/aragora/pull/9999"
+                    "#issuecomment-123\n"
+                    "Exact head reviewed: cd87c5a1b2db34f04167906553502db3ede9525e\n"
+                    "Focused adversarial dogfood found no blockers."
+                )
+            ),
+            body_file=None,
+            author="an0mium",
+            json=True,
+        )
+
+        out = io.StringIO()
+        with redirect_stdout(out):
+            rc = cmd_review_queue(ns)
+
+        payload = json.loads(out.getvalue())
+        assert rc == 1
+        assert payload["would_count"] is False
+        assert payload["current_head_grounding_method"] == "head_sha_citation"
+        assert payload["current_pr_grounding_method"] == "wrong_pr_citation"
+        assert payload["dogfood_evidence"] == []
+        assert "wrong_pr_reference" in payload["problems"]
+        assert "no_counted_model_reviewer" in payload["problems"]
+
     def test_evidence_lint_requires_head_sha_when_timestamp_omitted(self) -> None:
         ns = argparse.Namespace(
             review_queue_command="evidence-lint",

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -4723,6 +4723,37 @@ class TestCommandDispatch:
         assert "missing_current_head_grounding" in payload["problems"]
         assert "no_counted_model_reviewer" in payload["problems"]
 
+    def test_evidence_lint_rejects_wrong_pr_reference(self) -> None:
+        ns = argparse.Namespace(
+            review_queue_command="evidence-lint",
+            pr="7445",
+            head_sha="cd87c5a1b2db34f04167906553502db3ede9525e",
+            head_committed_at="2026-05-23T19:00:00Z",
+            body=_codex_openai_body(
+                body=(
+                    "PR: #9999\n"
+                    "Current head: cd87c5a1b2db34f04167906553502db3ede9525e\n"
+                    "Focused adversarial dogfood found no blockers."
+                )
+            ),
+            body_file=None,
+            author="an0mium",
+            json=True,
+        )
+
+        out = io.StringIO()
+        with redirect_stdout(out):
+            rc = cmd_review_queue(ns)
+
+        payload = json.loads(out.getvalue())
+        assert rc == 1
+        assert payload["would_count"] is False
+        assert payload["current_head_grounding_method"] == "head_sha_citation"
+        assert payload["current_pr_grounding_method"] == "wrong_pr_citation"
+        assert payload["dogfood_evidence"] == []
+        assert "wrong_pr_reference" in payload["problems"]
+        assert "no_counted_model_reviewer" in payload["problems"]
+
     def test_evidence_lint_requires_head_sha_when_timestamp_omitted(self) -> None:
         ns = argparse.Namespace(
             review_queue_command="evidence-lint",

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -25,6 +25,7 @@ from aragora.cli.commands.review_queue import (
     _build_queue,
     _classify_pr,
     _classify_model_review_tier,
+    _dogfood_evidence_from_comments,
     _extract_validation_commands,
     _effective_required_pr_check_count,
     _filter_lanes,
@@ -2164,6 +2165,20 @@ class TestModelReviewQuorum:
         assert len(quorum["dogfood_evidence"]) == 1
         assert quorum["dogfood_evidence"][0]["model_family"] == "claude"
         assert "claude" in quorum["counted_reviewer_ids"]
+
+    def test_dogfood_negative_verdict_is_not_counted(self) -> None:
+        head = "cd87c5a1b2db34f04167906553502db3ede9525e"
+        comments = [
+            _codex_openai_comment(
+                body=(
+                    f"Current head: {head}\n"
+                    "Verdict: FAIL\n"
+                    "Blocking findings: found - exact-head evidence is stale."
+                )
+            )
+        ]
+
+        assert _dogfood_evidence_from_comments(comments, head_sha=head) == []
 
 
 # --- parenthetical model-family disclosure ---------------------------------
@@ -4784,6 +4799,37 @@ class TestCommandDispatch:
         assert payload["current_pr_grounding_method"] == "wrong_pr_citation"
         assert payload["dogfood_evidence"] == []
         assert "wrong_pr_reference" in payload["problems"]
+        assert "no_counted_model_reviewer" in payload["problems"]
+
+    def test_evidence_lint_rejects_explicit_blocking_verdict(self) -> None:
+        ns = argparse.Namespace(
+            review_queue_command="evidence-lint",
+            pr="7445",
+            head_sha="cd87c5a1b2db34f04167906553502db3ede9525e",
+            head_committed_at="2026-05-23T19:00:00Z",
+            body=_codex_openai_body(
+                body=(
+                    "PR: #7445\n"
+                    "Current head: cd87c5a1b2db34f04167906553502db3ede9525e\n"
+                    "Verdict: FAIL\n"
+                    "Blocking findings: found - helper can still misclassify stale evidence."
+                )
+            ),
+            body_file=None,
+            author="an0mium",
+            json=True,
+        )
+
+        out = io.StringIO()
+        with redirect_stdout(out):
+            rc = cmd_review_queue(ns)
+
+        payload = json.loads(out.getvalue())
+        assert rc == 1
+        assert payload["would_count"] is False
+        assert payload["reviewer_signals"] == []
+        assert payload["dogfood_evidence"] == []
+        assert "blocking_or_negative_verdict" in payload["problems"]
         assert "no_counted_model_reviewer" in payload["problems"]
 
     def test_evidence_lint_requires_head_sha_when_timestamp_omitted(self) -> None:


### PR DESCRIPTION
## Summary
- fail closed in `review-queue evidence-lint` when a proposed evidence body explicitly cites a different PR than `--pr`
- treat GitHub `pull/<number>` URLs as PR citations so wrong-PR comment links cannot bypass PR grounding
- include PR-grounding diagnostics in evidence-lint JSON output
- add regression coverage for exact-head-grounded but wrong-PR evidence bodies and wrong-PR evidence URLs

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/cli/commands/test_review_queue.py::TestCommandDispatch::test_evidence_lint_counts_current_head_dogfood tests/cli/commands/test_review_queue.py::TestCommandDispatch::test_evidence_lint_rejects_wrong_pr_reference tests/cli/commands/test_review_queue.py::TestCommandDispatch::test_evidence_lint_rejects_wrong_pr_url_reference tests/cli/commands/test_review_queue.py::TestCommandDispatch::test_evidence_lint_rejects_ungrounded_comment`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/cli/commands/test_review_queue.py` (`226 passed`)
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py`
- `git diff --check`

This is a helper reliability repair only; it is not settlement, readiness, or merge authorization.
