### PR TITLE
fix(benchmarks): validate phase0b result rows

### DIFF
--- a/scripts/phase0b_role_benchmark.py
+++ b/scripts/phase0b_role_benchmark.py
@@ -328,7 +328,66 @@ def build_result_row(runtime_manifest_path: Path) -> dict[str, Any]:
     }
 
 
+def _parse_json_string_list(row: dict[str, Any], field: str) -> list[str]:
+    raw_value = row.get(field)
+    if not isinstance(raw_value, str) or not raw_value.strip():
+        raise ValueError(f"{field} must be a JSON-encoded list")
+    try:
+        payload = json.loads(raw_value)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{field} must be valid JSON") from exc
+    if not isinstance(payload, list):
+        raise ValueError(f"{field} must decode to a list")
+
+    values: list[str] = []
+    for index, item in enumerate(payload):
+        if not isinstance(item, str) or not item.strip():
+            raise ValueError(f"{field}[{index}] must be a non-empty string")
+        values.append(item.strip())
+    return values
+
+
+def _non_negative_int(row: dict[str, Any], field: str) -> int:
+    value = row.get(field)
+    if isinstance(value, bool):
+        raise ValueError(f"{field} must be a non-negative integer")
+    if isinstance(value, int):
+        integer = value
+    elif isinstance(value, str) and value.strip().isdigit():
+        integer = int(value.strip())
+    else:
+        raise ValueError(f"{field} must be a non-negative integer")
+    if integer < 0:
+        raise ValueError(f"{field} must be a non-negative integer")
+    return integer
+
+
+def validate_result_row(row: dict[str, Any]) -> None:
+    """Reject internally inconsistent result rows before publishing benchmark truth."""
+    for field in ("experiment_id", "config_id", "project_id", "runtime_manifest_path"):
+        if not str(row.get(field) or "").strip():
+            raise ValueError(f"{field} is required")
+
+    branch_count = _non_negative_int(row, "worker_branch_count")
+    commit_count = _non_negative_int(row, "worker_commit_count")
+    worker_branches = _parse_json_string_list(row, "worker_branches_json")
+    worker_commits = _parse_json_string_list(row, "worker_commits_json")
+
+    if branch_count != len(worker_branches):
+        raise ValueError("worker_branch_count must match the length of worker_branches_json")
+    if commit_count != len(worker_commits):
+        raise ValueError("worker_commit_count must match the length of worker_commits_json")
+
+    primary_branch = str(row.get("worker_branch") or "").strip()
+    if primary_branch and primary_branch not in worker_branches:
+        raise ValueError("worker_branch must be included in worker_branches_json")
+    primary_commit = str(row.get("worker_commit") or "").strip()
+    if primary_commit and primary_commit not in worker_commits:
+        raise ValueError("worker_commit must be included in worker_commits_json")
+
+
 def _upsert_result(row: dict[str, Any]) -> None:
+    validate_result_row(row)
     _ensure_layout()
     payload = _load_json(RESULTS_JSON_PATH, {"runs": []})
     runs = [dict(item) for item in payload.get("runs", []) if isinstance(item, dict)]

--- a/tests/scripts/test_phase0b_role_benchmark.py
+++ b/tests/scripts/test_phase0b_role_benchmark.py
@@ -7,6 +7,7 @@ import sys
 from pathlib import Path
 
 import yaml
+import pytest
 
 from aragora.swarm.campaign import CampaignManifest, CampaignProject, save_campaign_manifest
 from aragora.swarm.spec import SwarmSpec
@@ -16,6 +17,68 @@ if _scripts_dir not in sys.path:
     sys.path.insert(0, _scripts_dir)
 
 import phase0b_role_benchmark  # noqa: E402
+
+
+def _result_row(**overrides) -> dict[str, object]:
+    row: dict[str, object] = {
+        "recorded_at": "2026-03-17T00:00:00+00:00",
+        "experiment_id": "exp-001",
+        "config_id": "p-codex_w-claude_r-claude",
+        "project_id": "B-6",
+        "runtime_manifest_path": "/tmp/phase0b-runtime.yaml",
+        "worker_branch": "codex/swarm-subtask-1",
+        "worker_commit": "abc123",
+        "worker_branch_count": 1,
+        "worker_commit_count": 1,
+        "worker_branches_json": json.dumps(["codex/swarm-subtask-1"]),
+        "worker_commits_json": json.dumps(["abc123"]),
+    }
+    row.update(overrides)
+    return row
+
+
+def test_validate_result_row_accepts_consistent_worker_metadata() -> None:
+    phase0b_role_benchmark.validate_result_row(_result_row())
+
+
+def test_validate_result_row_rejects_branch_count_mismatch() -> None:
+    row = _result_row(worker_branch_count=2)
+
+    with pytest.raises(ValueError, match="worker_branch_count"):
+        phase0b_role_benchmark.validate_result_row(row)
+
+
+def test_validate_result_row_rejects_invalid_json_list() -> None:
+    row = _result_row(worker_branches_json="not-json")
+
+    with pytest.raises(ValueError, match="worker_branches_json"):
+        phase0b_role_benchmark.validate_result_row(row)
+
+
+def test_validate_result_row_rejects_primary_commit_outside_list() -> None:
+    row = _result_row(worker_commit="missing")
+
+    with pytest.raises(ValueError, match="worker_commit"):
+        phase0b_role_benchmark.validate_result_row(row)
+
+
+def test_upsert_result_rejects_invalid_rows_before_creating_outputs(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    experiment_dir = tmp_path / "phase0b_role_benchmark"
+    monkeypatch.setattr(phase0b_role_benchmark, "EXPERIMENT_DIR", experiment_dir)
+    monkeypatch.setattr(phase0b_role_benchmark, "RUNS_DIR", experiment_dir / "runs")
+    monkeypatch.setattr(phase0b_role_benchmark, "ACTIVE_RUN_PATH", experiment_dir / "active.json")
+    monkeypatch.setattr(
+        phase0b_role_benchmark, "RESULTS_JSON_PATH", experiment_dir / "results.json"
+    )
+    monkeypatch.setattr(phase0b_role_benchmark, "RESULTS_CSV_PATH", experiment_dir / "results.csv")
+
+    with pytest.raises(ValueError, match="worker_commit_count"):
+        phase0b_role_benchmark._upsert_result(_result_row(worker_commit_count=2))
+
+    assert not experiment_dir.exists()
 
 
 def test_build_result_row_includes_multi_branch_metadata(


### PR DESCRIPTION
## Summary
- add Phase 0B benchmark result-row validation before JSON/CSV output writes
- require worker branch/commit counts to match their JSON list fields
- reject malformed list metadata and inconsistent primary worker branch/commit values

## Validation
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_phase0b_role_benchmark.py -q`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/phase0b_role_benchmark.py tests/scripts/test_phase0b_role_benchmark.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- push-time pre-push hooks, including mypy for the changed Python surface

Tier: 1/2 benchmark-truth guard; no queue authority, security, workflow, public API, or settlement surfaces touched.
