### PR TITLE
fix(benchmarks): reject duplicate terminal-truth fixtures

### DIFF
--- a/scripts/score_benchmark.py
+++ b/scripts/score_benchmark.py
@@ -83,6 +83,10 @@ def _validate_row(row: object) -> list[str]:
     return errors
 
 
+def _canonical_row_key(row: dict[str, object]) -> str:
+    return json.dumps(row, sort_keys=True, separators=(",", ":"))
+
+
 def score_fixtures(fixtures_dir: Path) -> tuple[bool, str]:
     """Load and score all fixture files.
 
@@ -99,6 +103,7 @@ def score_fixtures(fixtures_dir: Path) -> tuple[bool, str]:
     total_pass = 0
     total_fail = 0
     lines: list[str] = []
+    seen_examples: dict[str, str] = {}
 
     for fixture_file in fixture_files:
         with fixture_file.open() as fh:
@@ -121,6 +126,16 @@ def score_fixtures(fixtures_dir: Path) -> tuple[bool, str]:
                 for err in row_errors:
                     file_errors.append(f"  [{idx}] schema error: {err}")
                 continue
+
+            row_key = _canonical_row_key(row)
+            first_seen = seen_examples.get(row_key)
+            if first_seen is not None:
+                file_fail += 1
+                file_errors.append(
+                    f"  [{idx}] duplicate benchmark example also seen in {first_seen}"
+                )
+                continue
+            seen_examples[row_key] = f"{fixture_file.name}[{idx}]"
 
             expected = row.get("expected_class", "")
             result = classify_from_metrics(row)

--- a/tests/scripts/test_score_benchmark.py
+++ b/tests/scripts/test_score_benchmark.py
@@ -1,0 +1,97 @@
+"""Tests for scripts/score_benchmark.py."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+_scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
+if _scripts_dir not in sys.path:
+    sys.path.insert(0, _scripts_dir)
+
+import score_benchmark  # noqa: E402
+
+
+def _fixture_row(**overrides: object) -> dict[str, object]:
+    row: dict[str, object] = {
+        "worker_status": "completed",
+        "worker_outcome": "pr_created",
+        "elapsed_seconds": 12.5,
+        "files_changed": 2,
+        "has_deliverable": True,
+        "publish_action": "opened_pr",
+        "expected_class": "deliverable_pr_created",
+    }
+    row.update(overrides)
+    return row
+
+
+def _write_fixture(path: Path, rows: list[dict[str, object]]) -> None:
+    path.write_text(json.dumps(rows, indent=2), encoding="utf-8")
+
+
+def test_score_fixtures_accepts_unique_examples(tmp_path: Path, monkeypatch) -> None:
+    fixtures_dir = tmp_path / "fixtures"
+    fixtures_dir.mkdir()
+    _write_fixture(fixtures_dir / "cases.json", [_fixture_row()])
+
+    monkeypatch.setattr(
+        score_benchmark,
+        "classify_from_metrics",
+        lambda row: SimpleNamespace(value=row["expected_class"]),
+    )
+
+    all_passed, report = score_benchmark.score_fixtures(fixtures_dir)
+
+    assert all_passed is True
+    assert "Terminal-truth benchmark: PASS" in report
+    assert "Examples: 1" in report
+    assert "Pass: 1" in report
+
+
+def test_score_fixtures_rejects_duplicate_examples_in_one_file(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    fixtures_dir = tmp_path / "fixtures"
+    fixtures_dir.mkdir()
+    row = _fixture_row()
+    _write_fixture(fixtures_dir / "cases.json", [row, dict(row)])
+
+    monkeypatch.setattr(
+        score_benchmark,
+        "classify_from_metrics",
+        lambda row: SimpleNamespace(value=row["expected_class"]),
+    )
+
+    all_passed, report = score_benchmark.score_fixtures(fixtures_dir)
+
+    assert all_passed is False
+    assert "Terminal-truth benchmark: FAIL" in report
+    assert "duplicate benchmark example also seen in cases.json[0]" in report
+    assert "Pass: 1" in report
+    assert "Fail: 1" in report
+
+
+def test_score_fixtures_rejects_duplicate_examples_across_files(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    fixtures_dir = tmp_path / "fixtures"
+    fixtures_dir.mkdir()
+    row = _fixture_row()
+    _write_fixture(fixtures_dir / "a.json", [row])
+    _write_fixture(fixtures_dir / "b.json", [dict(row)])
+
+    monkeypatch.setattr(
+        score_benchmark,
+        "classify_from_metrics",
+        lambda row: SimpleNamespace(value=row["expected_class"]),
+    )
+
+    all_passed, report = score_benchmark.score_fixtures(fixtures_dir)
+
+    assert all_passed is False
+    assert "duplicate benchmark example also seen in a.json[0]" in report


### PR DESCRIPTION
## Summary
- add duplicate fixture-row detection to terminal-truth benchmark scoring
- fail same-file and cross-file duplicate examples instead of letting them inflate pass counts
- add focused coverage for unique, same-file duplicate, and cross-file duplicate fixture scoring

## Validation
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_score_benchmark.py -q`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/score_benchmark.py tests/scripts/test_score_benchmark.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- push-time pre-push hooks, including mypy for the changed Python surface

Tier: 1 benchmark-truth/regression-coverage guard; no queue authority, security, workflow, public API, or settlement surfaces touched.
