### PR TITLE
fix(settle-one): use current Python for helper probes

### DIFF
--- a/scripts/settle_one_pr.py
+++ b/scripts/settle_one_pr.py
@@ -33,6 +33,7 @@ VERSION = "settle_one_steward.v1"
 MERGE_QUORUM = "aragora-merge-quorum"
 HUMAN_RISK_EXCLUDES = {7407, 7425, 7438, 7439, 7443}
 BROAD_PACKET_NEAR_SELECTED_LOOKAHEAD = 8
+PYTHON_EXECUTABLE = sys.executable or "python3"
 
 
 def _env_timeout_seconds(name: str, default: int) -> int:
@@ -1025,7 +1026,7 @@ def _has_policy_file_scope(metadata: dict[str, Any]) -> bool:
 
 def load_active_owned_prs(cwd: Path) -> tuple[set[int], dict[str, Any]]:
     payload, command = _run_json(
-        ["python3", "scripts/agent_bridge.py", "operator-snapshot", "--json"],
+        [PYTHON_EXECUTABLE, "scripts/agent_bridge.py", "operator-snapshot", "--json"],
         cwd=cwd,
         timeout=OPERATOR_SNAPSHOT_TIMEOUT_SECONDS,
     )
@@ -1367,7 +1368,7 @@ def build_report(
         steering_root = state_root / ".aragora" / "operator-steering"
         owner_payload, owner_cmd = _run_json(
             [
-                "python3",
+                PYTHON_EXECUTABLE,
                 "scripts/identify_lane_owner.py",
                 "--pr",
                 str(pr_number),
@@ -1384,7 +1385,7 @@ def build_report(
 
         steering_payload, steering_cmd = _run_json(
             [
-                "python3",
+                PYTHON_EXECUTABLE,
                 "scripts/read_operator_steering.py",
                 "--pr",
                 str(pr_number),
@@ -1512,7 +1513,7 @@ def build_report(
 
 def _load_single_pr_packet(*, cwd: Path, pr: int, repo: str | None) -> dict[str, Any]:
     command = [
-        "python3",
+        PYTHON_EXECUTABLE,
         "-m",
         "aragora.cli.main",
         "review-queue",
@@ -1533,7 +1534,7 @@ def _load_single_pr_packet(*, cwd: Path, pr: int, repo: str | None) -> dict[str,
 
 def _load_broad_packet_bulk(*, cwd: Path, limit: int, repo: str | None) -> dict[str, Any]:
     command = [
-        "python3",
+        PYTHON_EXECUTABLE,
         "-m",
         "aragora.cli.main",
         "review-queue",

--- a/scripts/settle_one_pr.py
+++ b/scripts/settle_one_pr.py
@@ -34,6 +34,12 @@ MERGE_QUORUM = "aragora-merge-quorum"
 HUMAN_RISK_EXCLUDES = {7407, 7425, 7438, 7439, 7443}
 BROAD_PACKET_NEAR_SELECTED_LOOKAHEAD = 8
 PYTHON_EXECUTABLE = sys.executable or "python3"
+OPERATOR_SNAPSHOT_COMMAND = [
+    PYTHON_EXECUTABLE,
+    "scripts/agent_bridge.py",
+    "operator-snapshot",
+    "--json",
+]
 
 
 def _env_timeout_seconds(name: str, default: int) -> int:
@@ -1035,7 +1041,7 @@ def _has_policy_file_scope(metadata: dict[str, Any]) -> bool:
 
 def load_active_owned_prs(cwd: Path) -> tuple[set[int], dict[str, Any]]:
     payload, command = _run_json(
-        [PYTHON_EXECUTABLE, "scripts/agent_bridge.py", "operator-snapshot", "--json"],
+        OPERATOR_SNAPSHOT_COMMAND,
         cwd=cwd,
         timeout=OPERATOR_SNAPSHOT_TIMEOUT_SECONDS,
     )
@@ -1278,7 +1284,7 @@ def build_report(
                 preselection_blockers.append(snapshot_blocker)
         elif snapshot_preblocked:
             active_owned_command = {
-                "command": "python3 scripts/agent_bridge.py operator-snapshot --json",
+                "command": " ".join(OPERATOR_SNAPSHOT_COMMAND),
                 "returncode": None,
                 "skipped": True,
                 "reason": "operator-snapshot failure already carried by packet load_blockers",

--- a/scripts/settle_one_pr.py
+++ b/scripts/settle_one_pr.py
@@ -88,14 +88,23 @@ def _state_repo_root(cwd: Path) -> Path:
 
 
 def _run(args: list[str], *, cwd: Path, timeout: int = 120) -> dict[str, Any]:
-    proc = subprocess.Popen(
-        args,
-        cwd=cwd,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        start_new_session=True,
-    )
+    try:
+        proc = subprocess.Popen(
+            args,
+            cwd=cwd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            start_new_session=True,
+        )
+    except OSError as exc:
+        return {
+            "command": " ".join(args),
+            "returncode": 127,
+            "stdout": "",
+            "stderr": f"command failed to start: {exc}",
+            "start_failed": True,
+        }
     try:
         stdout, stderr = proc.communicate(timeout=timeout)
     except subprocess.TimeoutExpired:

--- a/tests/scripts/test_settle_one_pr.py
+++ b/tests/scripts/test_settle_one_pr.py
@@ -127,6 +127,23 @@ def test_run_reports_timeout_and_terminates_process_group(monkeypatch) -> None:
     assert killed == [(4242, settle_one_pr.signal.SIGKILL)]
 
 
+def test_run_reports_process_start_failure(monkeypatch) -> None:
+    def fake_popen(*args, **kwargs):
+        assert args[0] == ["missing-helper"]
+        assert kwargs["start_new_session"] is True
+        raise FileNotFoundError("missing-helper")
+
+    monkeypatch.setattr(settle_one_pr.subprocess, "Popen", fake_popen)
+
+    result = settle_one_pr._run(["missing-helper"], cwd=Path.cwd(), timeout=7)
+
+    assert result["returncode"] == 127
+    assert result["start_failed"] is True
+    assert result["stdout"] == ""
+    assert "command failed to start" in result["stderr"]
+    assert "missing-helper" in result["stderr"]
+
+
 def test_select_candidate_prefers_admin_order() -> None:
     unauthorized = _entry(1001)
     authorized = _entry(

--- a/tests/scripts/test_settle_one_pr.py
+++ b/tests/scripts/test_settle_one_pr.py
@@ -25,6 +25,20 @@ SURFACE_REASON = (
     "security/auth/RBAC/secrets/deploy/workflow/legal/compliance/destructive/"
     "migration/public-API surface"
 )
+MERGE_PACKET_PREFIX = [
+    settle_one_pr.PYTHON_EXECUTABLE,
+    "-m",
+    "aragora.cli.main",
+    "review-queue",
+    "merge-packet",
+]
+OPERATOR_SNAPSHOT_PREFIX = [
+    settle_one_pr.PYTHON_EXECUTABLE,
+    "scripts/agent_bridge.py",
+    "operator-snapshot",
+]
+OWNER_PREFIX = [settle_one_pr.PYTHON_EXECUTABLE, "scripts/identify_lane_owner.py", "--pr"]
+STEERING_PREFIX = [settle_one_pr.PYTHON_EXECUTABLE, "scripts/read_operator_steering.py", "--pr"]
 
 
 def _entry(
@@ -548,7 +562,7 @@ def test_broad_packet_lazy_loader_uses_single_bulk_packet(monkeypatch) -> None:
     def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
         del cwd, timeout
         commands.append(args)
-        if args[:5] == ["python3", "-m", "aragora.cli.main", "review-queue", "merge-packet"]:
+        if args[:5] == MERGE_PACKET_PREFIX:
             assert "--limit" in args
             assert "--pr" not in args
             return _packet(_entry(7376), _entry(7449)), {"command": "packet", "returncode": 0}
@@ -572,7 +586,7 @@ def test_broad_packet_lazy_loader_falls_back_when_bulk_packet_fails(
         nonlocal bulk_calls
         del cwd, timeout
         commands.append(args)
-        if args[:5] == ["python3", "-m", "aragora.cli.main", "review-queue", "merge-packet"]:
+        if args[:5] == MERGE_PACKET_PREFIX:
             if "--limit" in args:
                 bulk_calls += 1
                 return None, {"command": "bulk-packet", "returncode": 1, "stderr": "HTTP 504"}
@@ -594,7 +608,7 @@ def test_broad_packet_lazy_loader_falls_back_when_bulk_packet_fails(
                 ],
                 {"command": "metadata", "returncode": 0},
             )
-        if args[:3] == ["python3", "scripts/agent_bridge.py", "operator-snapshot"]:
+        if args[:3] == OPERATOR_SNAPSHOT_PREFIX:
             return {"lanes": []}, {"command": "snapshot", "returncode": 0}
         raise AssertionError(args)
 
@@ -615,7 +629,7 @@ def test_broad_packet_lazy_loader_falls_back_when_bulk_packet_times_out(
 ) -> None:
     def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
         del cwd, timeout
-        if args[:5] == ["python3", "-m", "aragora.cli.main", "review-queue", "merge-packet"]:
+        if args[:5] == MERGE_PACKET_PREFIX:
             if "--limit" in args:
                 return None, {
                     "command": "bulk-packet",
@@ -636,7 +650,7 @@ def test_broad_packet_lazy_loader_falls_back_when_bulk_packet_times_out(
                 ],
                 {"command": "metadata", "returncode": 0},
             )
-        if args[:3] == ["python3", "scripts/agent_bridge.py", "operator-snapshot"]:
+        if args[:3] == OPERATOR_SNAPSHOT_PREFIX:
             return {"lanes": []}, {"command": "snapshot", "returncode": 0}
         raise AssertionError(args)
 
@@ -655,7 +669,7 @@ def test_broad_packet_lazy_loader_returns_empty_when_bulk_and_light_metadata_fai
 ) -> None:
     def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
         del cwd, timeout
-        if args[:5] == ["python3", "-m", "aragora.cli.main", "review-queue", "merge-packet"]:
+        if args[:5] == MERGE_PACKET_PREFIX:
             return None, {"command": "bulk-packet", "returncode": 1, "stderr": "HTTP 504"}
         if args[:3] == ["gh", "pr", "list"]:
             return None, {"command": "metadata", "returncode": 1, "stderr": "HTTP 504"}
@@ -674,7 +688,7 @@ def test_broad_packet_lazy_loader_surfaces_targeted_packet_failures(
 ) -> None:
     def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
         del cwd, timeout
-        if args[:5] == ["python3", "-m", "aragora.cli.main", "review-queue", "merge-packet"]:
+        if args[:5] == MERGE_PACKET_PREFIX:
             if "--limit" in args:
                 return None, {"command": "bulk-packet", "returncode": 1, "stderr": "HTTP 504"}
             pr_number = args[args.index("--pr") + 1]
@@ -694,7 +708,7 @@ def test_broad_packet_lazy_loader_surfaces_targeted_packet_failures(
                 ],
                 {"command": "metadata", "returncode": 0},
             )
-        if args[:3] == ["python3", "scripts/agent_bridge.py", "operator-snapshot"]:
+        if args[:3] == OPERATOR_SNAPSHOT_PREFIX:
             return {"lanes": []}, {"command": "snapshot", "returncode": 0}
         raise AssertionError(args)
 
@@ -712,7 +726,7 @@ def test_broad_packet_lazy_loader_surfaces_targeted_packet_timeout(
 ) -> None:
     def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
         del cwd, timeout
-        if args[:5] == ["python3", "-m", "aragora.cli.main", "review-queue", "merge-packet"]:
+        if args[:5] == MERGE_PACKET_PREFIX:
             if "--limit" in args:
                 return None, {"command": "bulk-packet", "returncode": 1, "stderr": "HTTP 504"}
             return None, {
@@ -732,7 +746,7 @@ def test_broad_packet_lazy_loader_surfaces_targeted_packet_timeout(
                 ],
                 {"command": "metadata", "returncode": 0},
             )
-        if args[:3] == ["python3", "scripts/agent_bridge.py", "operator-snapshot"]:
+        if args[:3] == OPERATOR_SNAPSHOT_PREFIX:
             return {"lanes": []}, {"command": "snapshot", "returncode": 0}
         raise AssertionError(args)
 
@@ -750,7 +764,7 @@ def test_broad_packet_lazy_loader_surfaces_targeted_packet_timeout(
 def test_broad_packet_lazy_loader_warns_on_large_fallback_fanout(monkeypatch) -> None:
     def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
         del cwd, timeout
-        if args[:5] == ["python3", "-m", "aragora.cli.main", "review-queue", "merge-packet"]:
+        if args[:5] == MERGE_PACKET_PREFIX:
             if "--limit" in args:
                 return None, {"command": "bulk-packet", "returncode": 1, "stderr": "HTTP 504"}
             pr_number = int(args[args.index("--pr") + 1])
@@ -772,7 +786,7 @@ def test_broad_packet_lazy_loader_warns_on_large_fallback_fanout(monkeypatch) ->
                 ],
                 {"command": "metadata", "returncode": 0},
             )
-        if args[:3] == ["python3", "scripts/agent_bridge.py", "operator-snapshot"]:
+        if args[:3] == OPERATOR_SNAPSHOT_PREFIX:
             return {"lanes": []}, {"command": "snapshot", "returncode": 0}
         raise AssertionError(args)
 
@@ -789,7 +803,7 @@ def test_broad_packet_lazy_loader_warns_on_large_fallback_fanout(monkeypatch) ->
 def test_combine_packets_preserves_source_packet_timestamps(monkeypatch) -> None:
     def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
         del cwd, timeout
-        if args[:5] == ["python3", "-m", "aragora.cli.main", "review-queue", "merge-packet"]:
+        if args[:5] == MERGE_PACKET_PREFIX:
             if "--limit" in args:
                 return None, {"command": "bulk-packet", "returncode": 1, "stderr": "HTTP 504"}
             pr_number = int(args[args.index("--pr") + 1])
@@ -804,7 +818,7 @@ def test_combine_packets_preserves_source_packet_timestamps(monkeypatch) -> None
                 ],
                 {"command": "metadata", "returncode": 0},
             )
-        if args[:3] == ["python3", "scripts/agent_bridge.py", "operator-snapshot"]:
+        if args[:3] == OPERATOR_SNAPSHOT_PREFIX:
             return {"lanes": []}, {"command": "snapshot", "returncode": 0}
         raise AssertionError(args)
 
@@ -855,7 +869,7 @@ def test_build_report_threads_repo_to_policy_metadata(monkeypatch) -> None:
                 ],
                 {"command": "metadata", "returncode": 0},
             )
-        if args[:3] == ["python3", "scripts/agent_bridge.py", "operator-snapshot"]:
+        if args[:3] == OPERATOR_SNAPSHOT_PREFIX:
             return {"lanes": []}, {"command": "snapshot", "returncode": 0}
         if args[:3] == ["gh", "pr", "view"] and args[3] == "7451":
             return (
@@ -913,7 +927,7 @@ def test_build_report_explicit_pr_loads_policy_metadata_without_broad_list(monke
                 },
                 {"command": "policy-view", "returncode": 0},
             )
-        if args[:3] == ["python3", "scripts/agent_bridge.py", "operator-snapshot"]:
+        if args[:3] == OPERATOR_SNAPSHOT_PREFIX:
             return {"lanes": []}, {"command": "snapshot", "returncode": 0}
         raise AssertionError(args)
 
@@ -950,7 +964,7 @@ def test_build_report_fails_closed_when_operator_snapshot_fails(monkeypatch) -> 
                 [{"number": 7451, "title": "fix: candidate", "headRefName": "codex/candidate"}],
                 {"command": "metadata", "returncode": 0},
             )
-        if args[:3] == ["python3", "scripts/agent_bridge.py", "operator-snapshot"]:
+        if args[:3] == OPERATOR_SNAPSHOT_PREFIX:
             return None, {"command": "snapshot", "returncode": 1, "stderr": "snapshot failed"}
         if args[:3] == ["gh", "pr", "view"] and args[3] == "7451":
             return (
@@ -1000,7 +1014,7 @@ def test_build_report_does_not_reload_snapshot_when_packet_already_failed_closed
         del cwd, timeout
         if args[:3] == ["gh", "pr", "list"]:
             return [], {"command": "metadata", "returncode": 0}
-        if args[:3] == ["python3", "scripts/agent_bridge.py", "operator-snapshot"]:
+        if args[:3] == OPERATOR_SNAPSHOT_PREFIX:
             snapshot_called = True
             return None, {"command": "snapshot", "returncode": 1, "stderr": "outage"}
         raise AssertionError(args)
@@ -1034,7 +1048,7 @@ def test_build_report_blocks_repo_mismatch_when_repo_override_supplied(monkeypat
                 [{"number": 7451, "title": "fix: candidate", "headRefName": "codex/candidate"}],
                 {"command": "metadata", "returncode": 0},
             )
-        if args[:3] == ["python3", "scripts/agent_bridge.py", "operator-snapshot"]:
+        if args[:3] == OPERATOR_SNAPSHOT_PREFIX:
             snapshot_called = True
             return {"lanes": []}, {"command": "snapshot", "returncode": 0}
         if args[:3] == ["gh", "pr", "view"] and args[3] == "7451":
@@ -1094,11 +1108,11 @@ def test_lazy_policy_metadata_continues_past_failed_pr_view(monkeypatch) -> None
                 ],
                 {"command": "metadata", "returncode": 0},
             )
-        if args[:3] == ["python3", "scripts/agent_bridge.py", "operator-snapshot"]:
+        if args[:3] == OPERATOR_SNAPSHOT_PREFIX:
             return {"lanes": []}, {"command": "snapshot", "returncode": 0}
-        if args[:3] == ["python3", "scripts/identify_lane_owner.py", "--pr"]:
+        if args[:3] == OWNER_PREFIX:
             return {"status": "completed"}, {"command": "owner", "returncode": 0}
-        if args[:3] == ["python3", "scripts/read_operator_steering.py", "--pr"]:
+        if args[:3] == STEERING_PREFIX:
             return {"message_count": 0}, {"command": "mailbox", "returncode": 0}
         if args[:3] == ["gh", "pr", "view"] and args[3] == "7451":
             return None, {"command": "policy-view-7451", "returncode": 1, "stderr": "timeout"}
@@ -1194,11 +1208,11 @@ def test_explicit_pr_reuses_preloaded_policy_file_scope(monkeypatch) -> None:
     def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
         nonlocal policy_view_calls
         del cwd, timeout
-        if args[:3] == ["python3", "scripts/agent_bridge.py", "operator-snapshot"]:
+        if args[:3] == OPERATOR_SNAPSHOT_PREFIX:
             return {"lanes": []}, {"command": "snapshot", "returncode": 0}
-        if args[:3] == ["python3", "scripts/identify_lane_owner.py", "--pr"]:
+        if args[:3] == OWNER_PREFIX:
             return {"status": "completed"}, {"command": "owner", "returncode": 0}
-        if args[:3] == ["python3", "scripts/read_operator_steering.py", "--pr"]:
+        if args[:3] == STEERING_PREFIX:
             return {"message_count": 0}, {"command": "mailbox", "returncode": 0}
         if (
             args[:3] == ["gh", "pr", "view"]
@@ -1308,7 +1322,7 @@ def test_build_report_fails_closed_when_selected_policy_metadata_unavailable(
                 ],
                 {"command": "metadata", "returncode": 0},
             )
-        if args[:3] == ["python3", "scripts/agent_bridge.py", "operator-snapshot"]:
+        if args[:3] == OPERATOR_SNAPSHOT_PREFIX:
             return {"lanes": []}, {"command": "snapshot", "returncode": 0}
         if args[:3] == ["gh", "pr", "view"] and args[3] == "7451":
             return None, {"command": "policy-view", "returncode": 1, "stderr": "timeout"}
@@ -1349,7 +1363,7 @@ def test_build_report_lazy_loads_file_scope_for_selected_candidate(monkeypatch) 
                 ],
                 {"command": "metadata", "returncode": 0},
             )
-        if args[:3] == ["python3", "scripts/agent_bridge.py", "operator-snapshot"]:
+        if args[:3] == OPERATOR_SNAPSHOT_PREFIX:
             return {"lanes": []}, {"command": "snapshot", "returncode": 0}
         if args[:3] == ["gh", "pr", "view"] and args[3] == "7451":
             return (
@@ -1673,11 +1687,11 @@ def test_build_report_reads_required_checks_from_pr_base_branch(monkeypatch) -> 
         commands.append(args)
         if args[:3] == ["gh", "pr", "list"]:
             return [], {"command": "metadata", "returncode": 0}
-        if args[:3] == ["python3", "scripts/agent_bridge.py", "operator-snapshot"]:
+        if args[:3] == OPERATOR_SNAPSHOT_PREFIX:
             return {"lanes": []}, {"command": "snapshot", "returncode": 0}
-        if args[:3] == ["python3", "scripts/identify_lane_owner.py", "--pr"]:
+        if args[:3] == OWNER_PREFIX:
             return {"status": "completed"}, {"command": "owner", "returncode": 0}
-        if args[:3] == ["python3", "scripts/read_operator_steering.py", "--pr"]:
+        if args[:3] == STEERING_PREFIX:
             return {"message_count": 0}, {"command": "mailbox", "returncode": 0}
         if args[:3] == ["gh", "pr", "view"]:
             return (
@@ -1757,11 +1771,11 @@ def test_build_report_fails_closed_when_required_check_sources_unreadable(monkey
         del cwd, timeout
         if args[:3] == ["gh", "pr", "list"]:
             return [], {"command": "metadata", "returncode": 0}
-        if args[:3] == ["python3", "scripts/agent_bridge.py", "operator-snapshot"]:
+        if args[:3] == OPERATOR_SNAPSHOT_PREFIX:
             return {"lanes": []}, {"command": "snapshot", "returncode": 0}
-        if args[:3] == ["python3", "scripts/identify_lane_owner.py", "--pr"]:
+        if args[:3] == OWNER_PREFIX:
             return {"status": "completed"}, {"command": "owner", "returncode": 0}
-        if args[:3] == ["python3", "scripts/read_operator_steering.py", "--pr"]:
+        if args[:3] == STEERING_PREFIX:
             return {"message_count": 0}, {"command": "mailbox", "returncode": 0}
         if args[:3] == ["gh", "pr", "view"]:
             return (

--- a/tests/scripts/test_settle_one_pr.py
+++ b/tests/scripts/test_settle_one_pr.py
@@ -1052,6 +1052,9 @@ def test_build_report_does_not_reload_snapshot_when_packet_already_failed_closed
 
     assert snapshot_called is False
     assert report["blockers"].count(blocker) == 1
+    assert report["policy_context"]["operator_snapshot_command"]["command"] == (
+        f"{settle_one_pr.PYTHON_EXECUTABLE} scripts/agent_bridge.py operator-snapshot --json"
+    )
 
 
 def test_build_report_blocks_repo_mismatch_when_repo_override_supplied(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- use the invoking Python executable for `settle_one_pr.py` nested local helper probes instead of hardcoded `python3`
- keep `merge-packet`, operator-snapshot, owner, and steering helper calls on the same runtime as the steward process
- report local helper process-start failures as structured command results instead of letting `Popen` `OSError` escape
- update settle-one tests so command-prefix fakes assert the current interpreter path and missing helper startup failures fail closed

## Validation
- `PYTHONDONTWRITEBYTECODE=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_settle_one_pr.py` (`58 passed`)
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/settle_one_pr.py tests/scripts/test_settle_one_pr.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/settle_one_pr.py tests/scripts/test_settle_one_pr.py`
- `git diff --check`

This is a helper reliability repair only; it is not settlement, readiness, or merge authorization.
