### PR TITLE
fix(benchmarks): validate triage acceptance summary

### DIFF
--- a/scripts/benchmark_triage_profiles.py
+++ b/scripts/benchmark_triage_profiles.py
@@ -12,6 +12,13 @@ from typing import Any
 
 from aragora.inbox.triage_profile_benchmark import render_benchmark_report, run_fixture_benchmark
 
+ACCEPTANCE_KEYS = (
+    "decision_agreement",
+    "latency_improvement",
+    "blocked_rate_delta",
+    "unsafe_auto_approval",
+)
+
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -52,6 +59,12 @@ def _positive_int(value: Any, *, label: str) -> int:
     return value
 
 
+def _bool(value: Any, *, label: str) -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{label} must be a boolean")
+    return value
+
+
 def validate_report_shape(report: dict[str, Any]) -> None:
     comparison = report.get("comparison")
     profiles = report.get("profiles")
@@ -64,6 +77,22 @@ def validate_report_shape(report: dict[str, Any]) -> None:
         comparison.get("message_count"),
         label="comparison.message_count",
     )
+    acceptance = comparison.get("acceptance")
+    if not isinstance(acceptance, dict):
+        raise ValueError("comparison.acceptance must be an object")
+    acceptance_values = [
+        _bool(acceptance.get(key), label=f"comparison.acceptance.{key}") for key in ACCEPTANCE_KEYS
+    ]
+    passes_all_thresholds = _bool(
+        comparison.get("passes_all_thresholds"),
+        label="comparison.passes_all_thresholds",
+    )
+    expected_passes = all(acceptance_values)
+    if passes_all_thresholds != expected_passes:
+        raise ValueError(
+            "comparison.passes_all_thresholds must match the conjunction of "
+            "comparison.acceptance values"
+        )
     for profile in ("baseline", "staged_v1"):
         profile_payload = profiles.get(profile)
         if not isinstance(profile_payload, dict):

--- a/tests/scripts/test_benchmark_triage_profiles.py
+++ b/tests/scripts/test_benchmark_triage_profiles.py
@@ -177,3 +177,88 @@ def test_main_rejects_empty_comparison_before_writing_report(monkeypatch, tmp_pa
     assert exit_code == 2
     assert "comparison.message_count must be a positive integer" in captured.err
     assert not output_path.exists()
+
+
+def test_main_rejects_missing_acceptance_field_before_writing_report(
+    monkeypatch,
+    tmp_path,
+    capsys,
+) -> None:
+    report = {
+        "fixture_path": "/tmp/fixtures.json",
+        "generated_at": "2026-03-25T00:00:00Z",
+        "profiles": {
+            "baseline": {"message_count": 2},
+            "staged_v1": {"message_count": 2},
+        },
+        "comparison": {
+            "message_count": 2,
+            "acceptance": {
+                "decision_agreement": True,
+                "latency_improvement": True,
+                "blocked_rate_delta": True,
+            },
+            "passes_all_thresholds": True,
+        },
+    }
+
+    async def _fake_run(*args, **kwargs):
+        del args, kwargs
+        return report
+
+    fixture_path = tmp_path / "fixtures.json"
+    fixture_path.write_text("[]", encoding="utf-8")
+    output_path = tmp_path / "report.json"
+    monkeypatch.setattr(benchmark_triage_profiles, "run_fixture_benchmark", _fake_run)
+
+    exit_code = benchmark_triage_profiles.main(
+        ["--fixtures", str(fixture_path), "--output", str(output_path)]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "comparison.acceptance.unsafe_auto_approval must be a boolean" in captured.err
+    assert not output_path.exists()
+
+
+def test_main_rejects_inconsistent_acceptance_summary_before_writing_report(
+    monkeypatch,
+    tmp_path,
+    capsys,
+) -> None:
+    report = {
+        "fixture_path": "/tmp/fixtures.json",
+        "generated_at": "2026-03-25T00:00:00Z",
+        "profiles": {
+            "baseline": {"message_count": 2},
+            "staged_v1": {"message_count": 2},
+        },
+        "comparison": {
+            "message_count": 2,
+            "acceptance": {
+                "decision_agreement": True,
+                "latency_improvement": False,
+                "blocked_rate_delta": True,
+                "unsafe_auto_approval": True,
+            },
+            "passes_all_thresholds": True,
+        },
+    }
+
+    async def _fake_run(*args, **kwargs):
+        del args, kwargs
+        return report
+
+    fixture_path = tmp_path / "fixtures.json"
+    fixture_path.write_text("[]", encoding="utf-8")
+    output_path = tmp_path / "report.json"
+    monkeypatch.setattr(benchmark_triage_profiles, "run_fixture_benchmark", _fake_run)
+
+    exit_code = benchmark_triage_profiles.main(
+        ["--fixtures", str(fixture_path), "--output", str(output_path)]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "comparison.passes_all_thresholds must match" in captured.err
+    assert not output_path.exists()


### PR DESCRIPTION
## Summary
- validate the inbox triage benchmark acceptance object before rendering or writing reports
- require all four acceptance checks to be booleans
- fail reports whose `passes_all_thresholds` summary disagrees with the acceptance-check conjunction

## Validation
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_benchmark_triage_profiles.py -q`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/benchmark_triage_profiles.py tests/scripts/test_benchmark_triage_profiles.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- push-time pre-push hooks, including mypy for the changed Python surface

Tier: 1 benchmark-truth guard; no queue authority, security, workflow, public API, or settlement surfaces touched.
