### PR TITLE
fix(benchmarks): validate debate benchmark config

### DIFF
--- a/scripts/benchmark_debate.py
+++ b/scripts/benchmark_debate.py
@@ -196,6 +196,31 @@ async def _run_concurrent_debates(
     )
 
 
+def _require_positive_int(value: int, *, label: str) -> None:
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise ValueError(f"{label} must be a positive integer")
+
+
+def _validate_benchmark_config(
+    *,
+    num_agents: int,
+    num_rounds: int,
+    concurrent_levels: list[int],
+    large_panel_agents: int,
+    large_panel_rounds: int,
+) -> None:
+    _require_positive_int(num_agents, label="num_agents")
+    _require_positive_int(num_rounds, label="num_rounds")
+    _require_positive_int(large_panel_agents, label="large_panel_agents")
+    _require_positive_int(large_panel_rounds, label="large_panel_rounds")
+    if not concurrent_levels:
+        raise ValueError("concurrent_levels must include at least one level")
+    for index, level in enumerate(concurrent_levels):
+        _require_positive_int(level, label=f"concurrent_levels[{index}]")
+    if len(set(concurrent_levels)) != len(concurrent_levels):
+        raise ValueError("concurrent_levels must not contain duplicate levels")
+
+
 # ---------------------------------------------------------------------------
 # Main benchmark runner
 # ---------------------------------------------------------------------------
@@ -211,6 +236,13 @@ async def run_benchmark(
     """Execute the full benchmark suite."""
     if concurrent_levels is None:
         concurrent_levels = [5, 10, 25, 50]
+    _validate_benchmark_config(
+        num_agents=num_agents,
+        num_rounds=num_rounds,
+        concurrent_levels=concurrent_levels,
+        large_panel_agents=large_panel_agents,
+        large_panel_rounds=large_panel_rounds,
+    )
 
     results = BenchmarkResults(
         config={

--- a/tests/scripts/test_benchmark_debate.py
+++ b/tests/scripts/test_benchmark_debate.py
@@ -51,3 +51,47 @@ def test_parse_args_accepts_positive_benchmark_counts() -> None:
     assert args.concurrent == 3
     assert args.large_panel_agents == 4
     assert args.large_panel_rounds == 2
+
+
+def test_validate_benchmark_config_rejects_empty_concurrency_levels() -> None:
+    with pytest.raises(ValueError, match="concurrent_levels must include at least one level"):
+        benchmark_debate._validate_benchmark_config(
+            num_agents=2,
+            num_rounds=1,
+            concurrent_levels=[],
+            large_panel_agents=4,
+            large_panel_rounds=2,
+        )
+
+
+def test_validate_benchmark_config_rejects_duplicate_concurrency_levels() -> None:
+    with pytest.raises(ValueError, match="concurrent_levels must not contain duplicate levels"):
+        benchmark_debate._validate_benchmark_config(
+            num_agents=2,
+            num_rounds=1,
+            concurrent_levels=[3, 3],
+            large_panel_agents=4,
+            large_panel_rounds=2,
+        )
+
+
+def test_validate_benchmark_config_rejects_non_positive_programmatic_values() -> None:
+    with pytest.raises(ValueError, match=r"concurrent_levels\[1\] must be a positive integer"):
+        benchmark_debate._validate_benchmark_config(
+            num_agents=2,
+            num_rounds=1,
+            concurrent_levels=[3, 0],
+            large_panel_agents=4,
+            large_panel_rounds=2,
+        )
+
+
+def test_validate_benchmark_config_rejects_bool_programmatic_values() -> None:
+    with pytest.raises(ValueError, match="num_agents must be a positive integer"):
+        benchmark_debate._validate_benchmark_config(
+            num_agents=True,
+            num_rounds=1,
+            concurrent_levels=[3],
+            large_panel_agents=4,
+            large_panel_rounds=2,
+        )


### PR DESCRIPTION
## Summary
- validate debate benchmark config before running scenarios
- reject empty, non-positive, bool, and duplicate concurrency levels
- prevent duplicate concurrency levels from silently overwriting retained batch metrics

## Validation
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_benchmark_debate.py -q`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/benchmark_debate.py tests/scripts/test_benchmark_debate.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- push-time pre-push hooks, including mypy for the changed Python surface

Tier: 1 benchmark-truth guard; no queue authority, security, workflow, public API, or settlement surfaces touched.
