### PR TITLE
fix(metrics): reject invalid boss issue numbers

### DIFF
--- a/scripts/report_code_quality.py
+++ b/scripts/report_code_quality.py
@@ -60,6 +60,8 @@ _SUPPRESSION_PATTERNS = {
     "fixme": re.compile(r"#\s*FIXME\b", re.IGNORECASE),
 }
 
+_INVALID_BOSS_ISSUE_REASON = "invalid issue_number in v2 prompt data"
+
 
 def count_lines(path: Path) -> int:
     try:
@@ -136,6 +138,10 @@ def scan_all_aragora() -> dict[str, int]:
     return totals
 
 
+def _is_positive_int(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value > 0
+
+
 def scan_boss_metrics() -> dict:
     """Analyze latest boss metrics for success rate."""
     metrics_path = REPO_ROOT / ".aragora" / "overnight" / "boss_metrics.jsonl"
@@ -163,6 +169,8 @@ def scan_boss_metrics() -> dict:
         num = r.get("issue_number")
         if not num:
             continue
+        if not _is_positive_int(num):
+            return {"available": False, "reason": _INVALID_BOSS_ISSUE_REASON}
         by_issue[num] = str(r.get("worker_status") or "")
 
     total = len(by_issue)

--- a/tests/scripts/test_report_code_quality.py
+++ b/tests/scripts/test_report_code_quality.py
@@ -130,6 +130,48 @@ def test_scan_boss_metrics_uses_latest_issue_outcome(
     assert metrics["per_issue_success_rate"] == expected_rate
 
 
+@pytest.mark.parametrize("issue_number", ["1", True, -1])
+def test_scan_boss_metrics_rejects_invalid_issue_numbers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    issue_number: object,
+) -> None:
+    _write_boss_metrics(
+        tmp_path,
+        [{"issue_number": issue_number, "prompt_chars": 100, "worker_status": "completed"}],
+    )
+    monkeypatch.setattr(report_code_quality, "REPO_ROOT", tmp_path)
+
+    metrics = report_code_quality.scan_boss_metrics()
+
+    assert metrics == {
+        "available": False,
+        "reason": "invalid issue_number in v2 prompt data",
+    }
+
+
+def test_scan_boss_metrics_skips_missing_issue_numbers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_boss_metrics(
+        tmp_path,
+        [
+            {"prompt_chars": 100, "worker_status": "completed"},
+            {"issue_number": 0, "prompt_chars": 100, "worker_status": "completed"},
+        ],
+    )
+    monkeypatch.setattr(report_code_quality, "REPO_ROOT", tmp_path)
+
+    metrics = report_code_quality.scan_boss_metrics()
+
+    assert metrics["available"] is True
+    assert metrics["total_iterations"] == 2
+    assert metrics["unique_issues"] == 0
+    assert metrics["issues_completed"] == 0
+    assert metrics["per_issue_success_rate"] == 0.0
+
+
 def test_main_json_compare_includes_baseline_comparison(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
## Summary
- fail closed when v2 boss metrics contain non-integer, boolean, or negative `issue_number` values
- keep existing skip behavior for missing or zero issue numbers so empty issue surfaces remain non-inflating
- add focused regression coverage for malformed issue identifiers in `scan_boss_metrics`

## Validation
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_report_code_quality.py -q`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/report_code_quality.py tests/scripts/test_report_code_quality.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/report_code_quality.py tests/scripts/test_report_code_quality.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python scripts/report_code_quality.py --json --compare`
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- push-time pre-push hooks, including mypy and portability guard