### PR TITLE
fix(metrics): surface invalid boss metric numbers

### DIFF
--- a/scripts/analyze_boss_metrics.py
+++ b/scripts/analyze_boss_metrics.py
@@ -43,11 +43,14 @@ def _load_signals(path: Path) -> list[OutcomeSignal]:
     return signals
 
 
-def _safe_int(value: Any) -> int:
-    try:
-        return int(value or 0)
-    except (TypeError, ValueError):
+def _non_negative_metric_int(value: Any) -> int | None:
+    if value in (None, ""):
         return 0
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int) and value >= 0:
+        return value
+    return None
 
 
 def analyze_metrics(records: Iterable[dict[str, Any]]) -> dict[str, Any]:
@@ -58,12 +61,23 @@ def analyze_metrics(records: Iterable[dict[str, Any]]) -> dict[str, Any]:
     outcomes: Counter[str] = Counter()
     worker_statuses: Counter[str] = Counter()
     decomposed_counts: Counter[str] = Counter()
+    invalid_numeric_metrics: Counter[str] = Counter()
 
     total = 0
     for record in records:
         total += 1
-        prompt_chars += _safe_int(record.get("prompt_chars"))
-        enriched_context_chars += _safe_int(record.get("enriched_context_chars"))
+        prompt_value = _non_negative_metric_int(record.get("prompt_chars"))
+        if prompt_value is None:
+            invalid_numeric_metrics["prompt_chars"] += 1
+        else:
+            prompt_chars += prompt_value
+
+        context_value = _non_negative_metric_int(record.get("enriched_context_chars"))
+        if context_value is None:
+            invalid_numeric_metrics["enriched_context_chars"] += 1
+        else:
+            enriched_context_chars += context_value
+
         if record.get("has_deliverable") is True:
             has_deliverable_count += 1
 
@@ -114,6 +128,7 @@ def analyze_metrics(records: Iterable[dict[str, Any]]) -> dict[str, Any]:
         "worker_statuses": dict(sorted(worker_statuses.items())),
         "decomposed": dict(sorted(decomposed_counts.items())),
         "failure_taxonomy": dict(sorted(failure_taxonomy.items())),
+        "invalid_numeric_metrics": dict(sorted(invalid_numeric_metrics.items())),
     }
 
 
@@ -140,6 +155,7 @@ def render_text(report: dict[str, Any]) -> str:
     deliverables = metrics.get("deliverables", {})
     publish_actions = metrics.get("publish_actions", {})
     failure_taxonomy = metrics.get("failure_taxonomy", {})
+    invalid_numeric_metrics = metrics.get("invalid_numeric_metrics", {})
     terminal_truth = report.get("terminal_truth_benchmark") or {}
     no_rescue_rate = float(terminal_truth.get("no_rescue_rate", 0.0) or 0.0)
     meets_target = bool(terminal_truth.get("meets_30d_target", False))
@@ -167,6 +183,10 @@ def render_text(report: dict[str, Any]) -> str:
         lines.append("  failure taxonomy:")
         for reason, count in failure_taxonomy.items():
             lines.append(f"    - {reason}: {count}")
+    if invalid_numeric_metrics:
+        lines.append("  invalid numeric metrics:")
+        for field, count in sorted(invalid_numeric_metrics.items()):
+            lines.append(f"    - {field}: {count}")
     if terminal_families:
         lines.append("  terminal-truth families:")
         for family, count in sorted(terminal_families.items()):

--- a/tests/scripts/test_analyze_boss_metrics.py
+++ b/tests/scripts/test_analyze_boss_metrics.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from scripts.analyze_boss_metrics import analyze_boss_metrics, render_text
+from scripts.analyze_boss_metrics import analyze_boss_metrics, analyze_metrics, render_text
 
 
 def test_analyze_boss_metrics_fixture():
@@ -36,3 +36,40 @@ def test_analyze_boss_metrics_fixture():
     assert "deliverable rate" in text
     assert "terminal-truth families" in text
     assert "terminal-truth classes" in text
+
+
+def test_analyze_metrics_surfaces_invalid_numeric_fields():
+    summary = analyze_metrics(
+        [
+            {"prompt_chars": 30, "enriched_context_chars": 60},
+            {"prompt_chars": True, "enriched_context_chars": -1},
+            {"prompt_chars": "100", "enriched_context_chars": False},
+        ]
+    )
+
+    assert summary["prompt_chars"] == {"total": 30, "avg": 10.0}
+    assert summary["enriched_context_chars"] == {"total": 60, "avg": 20.0}
+    assert summary["invalid_numeric_metrics"] == {
+        "enriched_context_chars": 2,
+        "prompt_chars": 2,
+    }
+
+
+def test_render_text_includes_invalid_numeric_metrics():
+    text = render_text(
+        {
+            "metrics_summary": {
+                "totals": {"records": 1},
+                "prompt_chars": {"avg": 0},
+                "enriched_context_chars": {"avg": 0},
+                "deliverables": {"rate": 0},
+                "publish_actions": {},
+                "failure_taxonomy": {},
+                "invalid_numeric_metrics": {"prompt_chars": 1},
+            },
+            "terminal_truth_benchmark": {},
+        }
+    )
+
+    assert "invalid numeric metrics" in text
+    assert "prompt_chars: 1" in text


### PR DESCRIPTION
## Summary
- reject booleans, strings, negatives, and other malformed numeric boss-metric values from prompt/context totals
- surface invalid numeric metric counts in JSON and text reports so bad JSONL cannot silently skew averages
- add focused regression coverage for malformed numeric fields and report rendering

## Validation
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_analyze_boss_metrics.py -q`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/analyze_boss_metrics.py tests/scripts/test_analyze_boss_metrics.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/analyze_boss_metrics.py tests/scripts/test_analyze_boss_metrics.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python scripts/analyze_boss_metrics.py --metrics-file benchmarks/fixtures/swarm/sample_boss_metrics.jsonl --signals-file benchmarks/fixtures/swarm/sample_outcome_signals.jsonl`
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- push-time pre-push hooks, including mypy and portability guard