### PR TITLE
fix(metrics): reject bool boss issue numbers

### DIFF
--- a/scripts/boss_metrics_health.py
+++ b/scripts/boss_metrics_health.py
@@ -71,6 +71,10 @@ def _row_is_skip(row: dict[str, Any]) -> bool:
     return False
 
 
+def _valid_issue_number(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value > 0
+
+
 def top_issues_by_skip_count(rows: list[dict[str, Any]], top_n: int = 20) -> list[dict[str, Any]]:
     """Return the top-N issues ranked by skip-row count."""
     counter: Counter[int] = Counter()
@@ -78,7 +82,7 @@ def top_issues_by_skip_count(rows: list[dict[str, Any]], top_n: int = 20) -> lis
         if not _row_is_skip(row):
             continue
         issue_number = row.get("issue_number")
-        if not isinstance(issue_number, int) or issue_number <= 0:
+        if not _valid_issue_number(issue_number):
             continue
         counter[issue_number] += 1
 
@@ -130,7 +134,7 @@ def detect_stale_loops(rows: list[dict[str, Any]], min_skip_rows: int = 10) -> l
         if not _row_is_skip(row):
             continue
         issue_number = row.get("issue_number")
-        if not isinstance(issue_number, int) or issue_number <= 0:
+        if not _valid_issue_number(issue_number):
             continue
         counter[issue_number] += 1
 

--- a/tests/scripts/test_boss_metrics_health.py
+++ b/tests/scripts/test_boss_metrics_health.py
@@ -81,12 +81,23 @@ def test_top_issues_drops_invalid_issue_numbers() -> None:
         {"issue_number": None, "terminal_class": "blocked_auth_failure"},
         {"issue_number": -5, "terminal_class": "blocked_auth_failure"},
         {"issue_number": "abc", "terminal_class": "blocked_auth_failure"},
+        {"issue_number": True, "terminal_class": "blocked_auth_failure"},
+        {"issue_number": False, "terminal_class": "blocked_auth_failure"},
         {"issue_number": 0, "terminal_class": "blocked_auth_failure"},
         {"issue_number": 7, "terminal_class": "blocked_auth_failure"},
     ]
     out = mod.top_issues_by_skip_count(rows, top_n=10)
     assert len(out) == 1
     assert out[0]["issue_number"] == 7
+
+
+def test_stale_loop_detector_drops_bool_issue_numbers() -> None:
+    rows = [{"issue_number": True, "terminal_class": "blocked_auth_failure"}] * 12
+    rows += [{"issue_number": 9, "terminal_class": "blocked_auth_failure"}] * 10
+
+    out = mod.detect_stale_loops(rows, min_skip_rows=10)
+
+    assert out == [{"issue_number": 9, "skip_count": 10}]
 
 
 def test_top_issues_respects_top_n_limit() -> None:


### PR DESCRIPTION
## Summary
- reject boolean `issue_number` values from boss metrics issue/stale-loop candidate counters
- share the positive-integer issue-number validator across top-skip and stale-loop paths
- add regression coverage proving boolean issue rows remain skip rows but do not become issue candidates

## Validation
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_boss_metrics_health.py -q`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/boss_metrics_health.py tests/scripts/test_boss_metrics_health.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/boss_metrics_health.py tests/scripts/test_boss_metrics_health.py`
- `scripts/boss_metrics_health.py` JSON smoke with a boolean issue row and a real issue row
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- push-time pre-push hooks, including mypy and portability guard