### PR TITLE
fix(benchmarks): validate benchmark stats

### DIFF
--- a/scripts/check_benchmark_regression.py
+++ b/scripts/check_benchmark_regression.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import sys
 from pathlib import Path
 
@@ -60,6 +61,16 @@ def extract_means(data: dict) -> dict[str, float]:
         if mean is not None:
             results[name] = mean
     return results
+
+
+def _non_negative_finite_float(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        candidate = float(value)
+        if math.isfinite(candidate) and candidate >= 0:
+            return candidate
+    return None
 
 
 def _format_name_sample(names: set[str]) -> str:
@@ -190,11 +201,25 @@ def validate_results(results_path: Path) -> int:
 
     # Check for any benchmarks with suspicious stats (e.g., extremely slow)
     warnings = 0
+    invalid_stats = 0
     for bench in benchmarks:
         name = bench.get("name", "unknown")
         stats = bench.get("stats", {})
-        mean = stats.get("mean", 0)
-        stddev = stats.get("stddev", 0)
+        if not isinstance(stats, dict):
+            print(f"  ERROR: {name} has invalid stats payload")
+            invalid_stats += 1
+            continue
+
+        mean = _non_negative_finite_float(stats.get("mean"))
+        stddev = _non_negative_finite_float(stats.get("stddev", 0))
+        if mean is None:
+            print(f"  ERROR: {name} has invalid mean stat: {stats.get('mean')!r}")
+            invalid_stats += 1
+            continue
+        if stddev is None:
+            print(f"  ERROR: {name} has invalid stddev stat: {stats.get('stddev')!r}")
+            invalid_stats += 1
+            continue
 
         # Flag benchmarks with coefficient of variation > 100% (highly unstable)
         if mean > 0 and stddev / mean > 1.0:
@@ -206,6 +231,10 @@ def validate_results(results_path: Path) -> int:
 
     if warnings:
         print(f"\n{warnings} benchmark(s) with high variance (informational only).")
+
+    if invalid_stats:
+        print(f"\nFAILED: {invalid_stats} benchmark(s) with invalid numeric stats.")
+        return 1
 
     print("PASSED: Benchmark results file is valid.")
     return 0

--- a/tests/scripts/test_check_benchmark_regression.py
+++ b/tests/scripts/test_check_benchmark_regression.py
@@ -40,6 +40,11 @@ def _write_benchmarks(path: Path, means: dict[str, float]) -> Path:
     return path
 
 
+def _write_benchmark_entries(path: Path, benchmarks: list[dict[str, object]]) -> Path:
+    path.write_text(json.dumps({"benchmarks": benchmarks}), encoding="utf-8")
+    return path
+
+
 def test_compare_fails_when_current_and_baseline_share_no_benchmark_names(
     tmp_path: Path,
     capsys,
@@ -78,3 +83,24 @@ def test_compare_allows_partial_overlap_without_regression(tmp_path: Path, capsy
     assert rc == 0
     assert "PASSED: 1 benchmark(s)" in captured.out
     assert "No shared benchmark names" not in captured.out
+
+
+def test_validate_rejects_invalid_numeric_stats(tmp_path: Path, capsys) -> None:
+    results = _write_benchmark_entries(
+        tmp_path / "results.json",
+        [
+            {"name": "bench_bool_mean", "stats": {"mean": True, "stddev": 0.0}},
+            {"name": "bench_negative_stddev", "stats": {"mean": 0.1, "stddev": -0.1}},
+            {"name": "bench_bad_stats", "stats": "not-an-object"},
+            {"name": "bench_valid", "stats": {"mean": 0.1, "stddev": 0.01}},
+        ],
+    )
+
+    rc = bench_mod.validate_results(results)
+
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "bench_bool_mean has invalid mean stat" in captured.out
+    assert "bench_negative_stddev has invalid stddev stat" in captured.out
+    assert "bench_bad_stats has invalid stats payload" in captured.out
+    assert "FAILED: 3 benchmark(s) with invalid numeric stats." in captured.out


### PR DESCRIPTION
## Summary
- validate benchmark result stats as real non-negative finite numbers in `check_benchmark_regression.py validate`
- reject boolean means, negative/non-finite stddevs, and non-object stats payloads with explicit error lines
- add regression coverage so malformed benchmark JSON cannot pass validation silently

## Validation
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_check_benchmark_regression.py -q`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/check_benchmark_regression.py tests/scripts/test_check_benchmark_regression.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/check_benchmark_regression.py tests/scripts/test_check_benchmark_regression.py`
- CLI validate smoke with boolean `mean` exits 1 and reports invalid numeric stats
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- push-time pre-push hooks, including mypy and portability guard