### PR TITLE
fix(benchmarks): reject zero code intelligence iterations

### DIFF
--- a/scripts/benchmark_code_intelligence.py
+++ b/scripts/benchmark_code_intelligence.py
@@ -38,6 +38,21 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
+def _require_positive_int(value: int, *, label: str) -> None:
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise ValueError(f"{label} must be a positive integer")
+
+
+def _positive_int(raw: str) -> int:
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a positive integer") from exc
+    if value <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return value
+
+
 @dataclass
 class BenchmarkResult:
     """Result of a single benchmark run."""
@@ -263,6 +278,8 @@ async def run_benchmarks(
     benchmarks: list[str] | None = None,
 ) -> BenchmarkSuite:
     """Run all benchmarks."""
+    _require_positive_int(iterations, label="iterations")
+
     suite = BenchmarkSuite(path=path)
 
     # Count files
@@ -348,7 +365,7 @@ def main():
     parser.add_argument(
         "-n",
         "--iterations",
-        type=int,
+        type=_positive_int,
         default=5,
         help="Number of iterations per benchmark (default: 5)",
     )

--- a/tests/scripts/test_benchmark_code_intelligence.py
+++ b/tests/scripts/test_benchmark_code_intelligence.py
@@ -1,0 +1,53 @@
+"""Tests for scripts/benchmark_code_intelligence.py benchmark input guards."""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
+if _scripts_dir not in sys.path:
+    sys.path.insert(0, _scripts_dir)
+
+import benchmark_code_intelligence  # noqa: E402
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "benchmark_code_intelligence.py"
+
+
+def test_cli_rejects_zero_iterations_before_emitting_results(tmp_path: Path) -> None:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), str(tmp_path), "--iterations", "0"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "must be a positive integer" in result.stderr
+    assert "CODE INTELLIGENCE BENCHMARK" not in result.stdout
+
+
+def test_run_benchmarks_rejects_zero_iterations(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="iterations must be a positive integer"):
+        asyncio.run(
+            benchmark_code_intelligence.run_benchmarks(
+                str(tmp_path),
+                iterations=0,
+                benchmarks=["indexing"],
+            )
+        )
+
+
+def test_run_benchmarks_rejects_bool_iterations(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="iterations must be a positive integer"):
+        asyncio.run(
+            benchmark_code_intelligence.run_benchmarks(
+                str(tmp_path),
+                iterations=True,
+                benchmarks=["indexing"],
+            )
+        )


### PR DESCRIPTION
## Summary
- fail closed when the code-intelligence benchmark is asked to run zero/non-positive iterations
- apply the same positive-iteration guard to programmatic `run_benchmarks` calls and CLI parsing
- add focused tests so empty benchmark runs cannot emit misleading zero-valued metrics

## Validation
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_benchmark_code_intelligence.py -q`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/benchmark_code_intelligence.py tests/scripts/test_benchmark_code_intelligence.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/benchmark_code_intelligence.py tests/scripts/test_benchmark_code_intelligence.py`
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- push-time pre-push hooks, including mypy and portability guard