### PR TITLE
fix(benchmarks): reject negative debate quality prompts

### DIFF
--- a/scripts/debate_quality_benchmark.py
+++ b/scripts/debate_quality_benchmark.py
@@ -916,8 +916,20 @@ def save_results(summary: BenchmarkSummary, output_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _non_negative_int(raw: str) -> int:
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a non-negative integer") from exc
+    if value < 0:
+        raise argparse.ArgumentTypeError("must be a non-negative integer")
+    return value
+
+
 def select_prompts(prompt_limit: int) -> list[dict[str, str]]:
     """Select benchmark prompts while preserving 0 as the all-prompts CLI sentinel."""
+    if prompt_limit < 0:
+        raise ValueError("prompt_limit must be a non-negative integer")
     return PROMPTS[:prompt_limit] if prompt_limit > 0 else PROMPTS
 
 
@@ -932,7 +944,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--prompts",
-        type=int,
+        type=_non_negative_int,
         default=0,
         metavar="N",
         help="Run only the first N prompts (0 = all 12).",

--- a/tests/scripts/test_debate_quality_benchmark.py
+++ b/tests/scripts/test_debate_quality_benchmark.py
@@ -34,6 +34,15 @@ def test_select_prompts_zero_preserves_all_prompts_sentinel() -> None:
     assert module.select_prompts(0) == module.PROMPTS
 
 
+def test_prompt_limit_rejects_negative_values() -> None:
+    module = _load_module()
+
+    with pytest.raises(SystemExit):
+        module.parse_args(["--prompts", "-1"])
+    with pytest.raises(ValueError, match="non-negative integer"):
+        module.select_prompts(-1)
+
+
 def test_select_prompts_positive_limit_returns_prefix() -> None:
     module = _load_module()
 


### PR DESCRIPTION
## Summary
- reject negative `--prompts` values in the debate quality benchmark CLI instead of treating them like the all-prompts sentinel
- add a helper-level guard so programmatic prompt selection also fails closed for negative limits
- extend focused regression coverage for negative prompt limits

## Validation
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_debate_quality_benchmark.py -q`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/debate_quality_benchmark.py tests/scripts/test_debate_quality_benchmark.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/debate_quality_benchmark.py tests/scripts/test_debate_quality_benchmark.py`
- CLI smoke: `/Users/armand/.pyenv/versions/3.11.11/bin/python scripts/debate_quality_benchmark.py --dry-run --prompts -1` exits through argparse with code 2
- `git diff --check origin/main..HEAD`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- push-time pre-push hooks, including mypy and portability guard