### PR TITLE
fix(benchmarks): reject empty adaptive stopping runs

### DIFF
--- a/scripts/benchmarks/bench_adaptive_stopping.py
+++ b/scripts/benchmarks/bench_adaptive_stopping.py
@@ -49,7 +49,15 @@ def _get_detector() -> Any:
         return None
 
 
+def _require_positive_int(value: int, *, label: str) -> None:
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise ValueError(f"{label} must be a positive integer")
+
+
 def run_benchmark(iterations: int, votes_per_round: int) -> StabilityBenchmarkResult:
+    _require_positive_int(iterations, label="iterations")
+    _require_positive_int(votes_per_round, label="votes_per_round")
+
     rng = random.Random(42)
     result = StabilityBenchmarkResult(iterations=iterations)
     detector = _get_detector()
@@ -74,12 +82,25 @@ def run_benchmark(iterations: int, votes_per_round: int) -> StabilityBenchmarkRe
     return result
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(description="Benchmark adaptive stability detection")
-    parser.add_argument("--iterations", type=int, default=200)
-    parser.add_argument("--votes-per-round", type=int, default=7)
-    args = parser.parse_args()
+def _positive_int(raw: str) -> int:
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a positive integer") from exc
+    if value <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return value
 
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Benchmark adaptive stability detection")
+    parser.add_argument("--iterations", type=_positive_int, default=200)
+    parser.add_argument("--votes-per-round", type=_positive_int, default=7)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
     result = run_benchmark(args.iterations, args.votes_per_round)
     print("Adaptive Stability Benchmark")
     print(f"Iterations: {result.iterations}")

--- a/tests/scripts/test_bench_adaptive_stopping.py
+++ b/tests/scripts/test_bench_adaptive_stopping.py
@@ -1,0 +1,57 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = ROOT / "scripts" / "benchmarks" / "bench_adaptive_stopping.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("bench_adaptive_stopping", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_run_benchmark_rejects_empty_iteration_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_module()
+    monkeypatch.setattr(module, "_get_detector", lambda: pytest.fail("detector should not load"))
+
+    with pytest.raises(ValueError, match="iterations must be a positive integer"):
+        module.run_benchmark(0, 7)
+
+
+def test_run_benchmark_rejects_empty_vote_rounds(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_module()
+    monkeypatch.setattr(module, "_get_detector", lambda: pytest.fail("detector should not load"))
+
+    with pytest.raises(ValueError, match="votes_per_round must be a positive integer"):
+        module.run_benchmark(3, 0)
+
+
+def test_parse_args_rejects_non_positive_values() -> None:
+    module = _load_module()
+
+    with pytest.raises(SystemExit):
+        module.parse_args(["--iterations", "0"])
+    with pytest.raises(SystemExit):
+        module.parse_args(["--votes-per-round", "-1"])
+
+
+def test_run_benchmark_records_one_score_per_iteration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_module()
+    monkeypatch.setattr(module, "_get_detector", lambda: None)
+
+    result = module.run_benchmark(3, 2)
+
+    assert result.iterations == 3
+    assert len(result.stability_scores) == 3
+    assert len(result.times_ms) == 3


### PR DESCRIPTION
## Summary
- reject non-positive adaptive-stopping benchmark iterations before producing empty latency/stability summaries
- reject non-positive `--votes-per-round` values so fallback stability cannot benchmark empty votes as `0.0`
- add focused regression tests for CLI and programmatic guardrails

## Validation
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_bench_adaptive_stopping.py -q`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/benchmarks/bench_adaptive_stopping.py tests/scripts/test_bench_adaptive_stopping.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/benchmarks/bench_adaptive_stopping.py tests/scripts/test_bench_adaptive_stopping.py`
- CLI smoke: `/Users/armand/.pyenv/versions/3.11.11/bin/python scripts/benchmarks/bench_adaptive_stopping.py --iterations 0` exits through argparse with code 2
- `git diff --check origin/main..HEAD`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- push-time pre-push hooks, including mypy and portability guard