### PR TITLE
fix(benchmarks): validate lara routing inputs

### DIFF
--- a/scripts/benchmarks/bench_lara_routing.py
+++ b/scripts/benchmarks/bench_lara_routing.py
@@ -47,7 +47,27 @@ def sample_queries() -> list[str]:
     ]
 
 
+def _require_positive_int(value: int, *, label: str) -> None:
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise ValueError(f"{label} must be a positive integer")
+
+
+def _require_non_negative_int(value: int, *, label: str) -> None:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise ValueError(f"{label} must be a non-negative integer")
+
+
+def _validate_benchmark_inputs(iterations: int, min_nodes: int, max_nodes: int) -> None:
+    _require_positive_int(iterations, label="iterations")
+    _require_non_negative_int(min_nodes, label="min_nodes")
+    _require_non_negative_int(max_nodes, label="max_nodes")
+    if min_nodes > max_nodes:
+        raise ValueError("min_nodes must be less than or equal to max_nodes")
+
+
 def run_benchmark(iterations: int, min_nodes: int, max_nodes: int) -> RoutingBenchmarkResult:
+    _validate_benchmark_inputs(iterations, min_nodes, max_nodes)
+
     rng = random.Random(42)
     router = LaRARouter()
     queries = sample_queries()
@@ -69,13 +89,39 @@ def run_benchmark(iterations: int, min_nodes: int, max_nodes: int) -> RoutingBen
     return result
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(description="Benchmark LaRA routing decisions")
-    parser.add_argument("--iterations", type=int, default=200)
-    parser.add_argument("--min-nodes", type=int, default=0)
-    parser.add_argument("--max-nodes", type=int, default=5000)
-    args = parser.parse_args()
+def _positive_int(raw: str) -> int:
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a positive integer") from exc
+    if value <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return value
 
+
+def _non_negative_int(raw: str) -> int:
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a non-negative integer") from exc
+    if value < 0:
+        raise argparse.ArgumentTypeError("must be a non-negative integer")
+    return value
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Benchmark LaRA routing decisions")
+    parser.add_argument("--iterations", type=_positive_int, default=200)
+    parser.add_argument("--min-nodes", type=_non_negative_int, default=0)
+    parser.add_argument("--max-nodes", type=_non_negative_int, default=5000)
+    args = parser.parse_args(argv)
+    if args.min_nodes > args.max_nodes:
+        parser.error("--min-nodes must be less than or equal to --max-nodes")
+    return args
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
     result = run_benchmark(args.iterations, args.min_nodes, args.max_nodes)
 
     print("LaRA Routing Benchmark")

--- a/tests/scripts/test_bench_lara_routing.py
+++ b/tests/scripts/test_bench_lara_routing.py
@@ -1,0 +1,65 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = ROOT / "scripts" / "benchmarks" / "bench_lara_routing.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("bench_lara_routing", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_run_benchmark_rejects_empty_iteration_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_module()
+    monkeypatch.setattr(module, "LaRARouter", lambda: pytest.fail("router should not load"))
+
+    with pytest.raises(ValueError, match="iterations must be a positive integer"):
+        module.run_benchmark(0, 0, 5)
+
+
+def test_run_benchmark_rejects_invalid_node_ranges(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_module()
+    monkeypatch.setattr(module, "LaRARouter", lambda: pytest.fail("router should not load"))
+
+    with pytest.raises(ValueError, match="min_nodes must be a non-negative integer"):
+        module.run_benchmark(3, -1, 5)
+    with pytest.raises(ValueError, match="min_nodes must be less than or equal to max_nodes"):
+        module.run_benchmark(3, 10, 5)
+
+
+def test_parse_args_rejects_invalid_cli_ranges() -> None:
+    module = _load_module()
+
+    with pytest.raises(SystemExit):
+        module.parse_args(["--iterations", "0"])
+    with pytest.raises(SystemExit):
+        module.parse_args(["--min-nodes", "-1"])
+    with pytest.raises(SystemExit):
+        module.parse_args(["--min-nodes", "10", "--max-nodes", "5"])
+
+
+def test_run_benchmark_records_one_route_per_iteration(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_module()
+
+    class _Router:
+        def route(self, *_args, **_kwargs):
+            return SimpleNamespace(route="mock-route")
+
+    monkeypatch.setattr(module, "LaRARouter", _Router)
+
+    result = module.run_benchmark(3, 0, 0)
+
+    assert result.iterations == 3
+    assert len(result.times_ms) == 3
+    assert result.route_counts == {"mock-route": 3}


### PR DESCRIPTION
## Summary
- reject non-positive LaRA routing benchmark iterations before producing empty latency/route summaries
- reject negative node bounds and inverted min/max node ranges in both CLI and programmatic callers
- add focused regression tests for CLI guardrails, programmatic guardrails, and a small valid run

## Validation
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_bench_lara_routing.py -q`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/benchmarks/bench_lara_routing.py tests/scripts/test_bench_lara_routing.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/benchmarks/bench_lara_routing.py tests/scripts/test_bench_lara_routing.py`
- CLI smoke: `/Users/armand/.pyenv/versions/3.11.11/bin/python scripts/benchmarks/bench_lara_routing.py --iterations 0` exits through argparse with code 2
- `git diff --check origin/main..HEAD`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- push-time pre-push hooks, including mypy and portability guard