### PR TITLE
fix(review-queue): ignore quoted evidence head citations

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3685,7 +3685,18 @@ def _first_heading_candidate(text: str) -> tuple[str, int | None]:
             candidate = stripped.lstrip("#").strip()
             if candidate:
                 return candidate, index
-    return str(text)[:200], None
+    fallback_lines: list[str] = []
+    in_fence = False
+    for line in re.sub(r"<!--.*?-->", "", str(text), flags=re.DOTALL).splitlines():
+        stripped = line.strip()
+        if stripped.startswith(("```", "~~~")):
+            in_fence = not in_fence
+            continue
+        if in_fence or line.startswith(("    ", "\t")) or stripped.startswith(">"):
+            continue
+        if stripped:
+            fallback_lines.append(stripped)
+    return "\n".join(fallback_lines)[:200], None
 
 
 def _infer_surface_reviewer_from_candidate(candidate: str) -> str:
@@ -4077,8 +4088,19 @@ def _resolve_review_object_model_identity(body: str) -> ModelReviewIdentity:
 
 def _review_pr_metadata_from_body(body: str) -> dict[str, str]:
     metadata: dict[str, str] = {}
-    for line in str(body).splitlines():
+    text = re.sub(r"<!--.*?-->", "", str(body), flags=re.DOTALL)
+    in_fence = False
+    for line in text.splitlines():
         stripped = line.strip()
+        if stripped.startswith(("```", "~~~")):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        if line.startswith(("    ", "\t")) or stripped.startswith(">"):
+            continue
+        if re.match(r"^\[[^\]]+\]:", stripped):
+            continue
         if stripped.startswith("-"):
             stripped = stripped[1:].strip()
         label, sep, value = stripped.partition(":")

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3539,6 +3539,8 @@ def _evidence_grounding_text(body: str) -> str:
             continue
         if in_fence or stripped.startswith(">"):
             continue
+        if re.match(r"^\[[^\]]+\]:", stripped):
+            continue
         raw_line = re.sub(r"!?\[([^\]]*)\]\([^)]*\)", r"\1", raw_line)
         lines.append(re.sub(r"`[^`]*`", "", raw_line))
     return "\n".join(lines).lower()

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3522,10 +3522,11 @@ def _evidence_grounding_text(body: str) -> str:
     A target SHA quoted in a template, prior comment, or inline example does
     not prove the evidence reviewed the exact head.
     """
+    text = re.sub(r"<!--.*?-->", "", str(body or ""), flags=re.DOTALL)
     lines: list[str] = []
     in_fence = False
     fence_marker = ""
-    for raw_line in str(body or "").splitlines():
+    for raw_line in text.splitlines():
         stripped = raw_line.strip()
         if stripped.startswith(("```", "~~~")):
             marker = stripped[:3]

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3510,9 +3510,36 @@ def _proposed_evidence_head_grounding(body: str, head_sha: str) -> tuple[bool, s
     normalized_head = str(head_sha or "").strip().lower()
     if len(normalized_head) < 7:
         return False, "missing_head_sha_argument"
-    if normalized_head[:7] in str(body or "").lower():
+    grounding_text = _evidence_lint_grounding_text(body)
+    if normalized_head[:7] in grounding_text:
         return True, "head_sha_citation"
     return False, "missing_head_sha_citation"
+
+
+def _evidence_lint_grounding_text(body: str) -> str:
+    """Return prose eligible to ground a proposed evidence-lint comment.
+
+    A target SHA quoted in a template, prior comment, or inline example does
+    not prove the proposed evidence reviewed the exact head.
+    """
+    lines: list[str] = []
+    in_fence = False
+    fence_marker = ""
+    for raw_line in str(body or "").splitlines():
+        stripped = raw_line.strip()
+        if stripped.startswith(("```", "~~~")):
+            marker = stripped[:3]
+            if not in_fence:
+                in_fence = True
+                fence_marker = marker
+            elif marker == fence_marker:
+                in_fence = False
+                fence_marker = ""
+            continue
+        if in_fence or stripped.startswith(">"):
+            continue
+        lines.append(re.sub(r"`[^`]*`", "", raw_line))
+    return "\n".join(lines).lower()
 
 
 def _head_committed_at_from_pr(pr: dict[str, Any]) -> str:

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3510,17 +3510,17 @@ def _proposed_evidence_head_grounding(body: str, head_sha: str) -> tuple[bool, s
     normalized_head = str(head_sha or "").strip().lower()
     if len(normalized_head) < 7:
         return False, "missing_head_sha_argument"
-    grounding_text = _evidence_lint_grounding_text(body)
+    grounding_text = _evidence_grounding_text(body)
     if normalized_head[:7] in grounding_text:
         return True, "head_sha_citation"
     return False, "missing_head_sha_citation"
 
 
-def _evidence_lint_grounding_text(body: str) -> str:
-    """Return prose eligible to ground a proposed evidence-lint comment.
+def _evidence_grounding_text(body: str) -> str:
+    """Return prose eligible to ground exact-head evidence.
 
     A target SHA quoted in a template, prior comment, or inline example does
-    not prove the proposed evidence reviewed the exact head.
+    not prove the evidence reviewed the exact head.
     """
     lines: list[str] = []
     in_fence = False
@@ -4145,7 +4145,7 @@ def _is_comment_grounded_on_head(
         return True
     body = str(comment.get("body", "") or "")
     head_short = head_sha[:7]
-    if head_short and head_short in body:
+    if head_short and head_short in _evidence_grounding_text(body):
         return True
     created = str(comment.get("createdAt", "") or "")
     if not created:

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3527,6 +3527,8 @@ def _evidence_grounding_text(body: str) -> str:
     in_fence = False
     fence_marker = ""
     for raw_line in text.splitlines():
+        if raw_line.startswith(("    ", "\t")):
+            continue
         stripped = raw_line.strip()
         if stripped.startswith(("```", "~~~")):
             marker = stripped[:3]
@@ -3796,6 +3798,8 @@ def _model_family_from_body(body: str) -> str:
     in_fence = False
     fence_marker = ""
     for raw_line in str(body).splitlines():
+        if raw_line.startswith(("    ", "\t")):
+            continue
         stripped = raw_line.strip()
         # Track fenced code blocks and skip everything inside them.
         if stripped.startswith(("```", "~~~")):

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3707,6 +3707,8 @@ def _structured_identity_metadata(text: str, heading_index: int | None) -> dict[
     in_fence = False
     fence_marker = ""
     for line in lines[heading_index + 1 : heading_index + 26]:
+        if line.startswith(("    ", "\t")):
+            continue
         stripped = line.strip()
         if stripped.startswith(("```", "~~~")):
             marker = stripped[:3]

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3539,6 +3539,7 @@ def _evidence_grounding_text(body: str) -> str:
             continue
         if in_fence or stripped.startswith(">"):
             continue
+        raw_line = re.sub(r"!?\[([^\]]*)\]\([^)]*\)", r"\1", raw_line)
         lines.append(re.sub(r"`[^`]*`", "", raw_line))
     return "\n".join(lines).lower()
 

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -1355,6 +1355,10 @@ class TestModelReviewQuorum:
                 "I reviewed this earlier, but the later exact-head citation is a quoted note:\n\n"
                 "> Current head: abcdef1234567890abcdef1234567890abcdef12\n"
             ),
+            (
+                "I reviewed this earlier, but the later exact-head citation is hidden:\n\n"
+                "<!-- Current head: abcdef1234567890abcdef1234567890abcdef12 -->\n"
+            ),
         ],
     )
     def test_stale_comment_with_non_prose_head_sha_citation_still_excluded(
@@ -4740,6 +4744,11 @@ class TestCommandDispatch:
             (
                 "I reviewed the diff, but this is only a quoted prior note:\n\n"
                 "> Current head: cd87c5a1b2db34f04167906553502db3ede9525e\n\n"
+                "Validation passed for the touched surface."
+            ),
+            (
+                "I reviewed the diff, but this exact-head citation is hidden:\n\n"
+                "<!-- Current head: cd87c5a1b2db34f04167906553502db3ede9525e -->\n\n"
                 "Validation passed for the touched surface."
             ),
         ],

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -1338,6 +1338,57 @@ class TestModelReviewQuorum:
         assert quorum["counted_reviewer_ids"] == ["grok", "openai"]
         assert quorum["status"] == "satisfied"
 
+    @pytest.mark.parametrize(
+        "body_suffix",
+        [
+            (
+                "I reviewed this earlier, but the later exact-head citation is only a template:\n\n"
+                "```\n"
+                "Current head: abcdef1234567890abcdef1234567890abcdef12\n"
+                "```\n"
+            ),
+            (
+                "I reviewed this earlier, but the later exact-head citation is only inline code: "
+                "`Current head: abcdef1234567890abcdef1234567890abcdef12`."
+            ),
+            (
+                "I reviewed this earlier, but the later exact-head citation is a quoted note:\n\n"
+                "> Current head: abcdef1234567890abcdef1234567890abcdef12\n"
+            ),
+        ],
+    )
+    def test_stale_comment_with_non_prose_head_sha_citation_still_excluded(
+        self, body_suffix: str
+    ) -> None:
+        head_sha = "abcdef1234567890abcdef1234567890abcdef12"
+        pr = _make_pr(files=["aragora/cli/commands/swarm.py"])
+        pr["headRefOid"] = head_sha
+        pr["commits"] = [
+            {"oid": head_sha, "committedDate": "2026-04-28T20:00:00Z"},
+        ]
+        pr["comments"] = [
+            {
+                "author": {"login": "an0mium"},
+                "body": _codex_openai_body(body=body_suffix),
+                "createdAt": "2026-04-28T18:00:00Z",
+            },
+            {
+                "author": {"login": "an0mium"},
+                "body": "## Grok independent model review\nVerdict: approve.",
+                "createdAt": "2026-04-28T20:10:00Z",
+            },
+        ]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=["aragora/cli/commands/swarm.py"],
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+        )
+        assert quorum["counted_reviewer_ids"] == ["grok"]
+        assert quorum["status"] == "needs_model_review_quorum"
+
     def test_unresolved_dissent_forces_human_risk_settlement(self) -> None:
         pr = _make_pr(files=["aragora/cli/commands/swarm.py"])
         pr["comments"] = [_dogfood_comment()]

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -1950,6 +1950,37 @@ class TestModelReviewQuorum:
         assert quorum["dogfood_evidence"] == []
         assert quorum["counted_reviewer_ids"] == []
 
+    def test_model_review_metadata_in_indented_code_block_is_not_counted(self) -> None:
+        files = ["aragora/agents/router.py"]
+        pr = _make_pr(files=files)
+        pr["comments"] = [
+            {
+                "author": {"login": "an0mium"},
+                "body": (
+                    "## Codex review\n\n"
+                    "Template copied from the reviewer instructions:\n\n"
+                    "    **Model family:** openai\n"
+                    "    **Model id:** gpt-5-codex\n"
+                    "    **Receipt artifact:** /tmp/codex-review.md\n\n"
+                    "independent model review example only."
+                ),
+            },
+        ]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=files,
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+        )
+
+        assert quorum["counted_reviewer_ids"] == []
+        assert quorum["reviewer_signals"][0]["identity_problems"] == [
+            "missing_model_family_disclosure",
+            "missing_receipt_artifact",
+        ]
+
     # --- Plain-headed dogfood with body-named model (PR #7587 regression) ---
     #
     # A dogfood comment headed `## Focused adversarial dogfood` (no `(claude)`
@@ -2215,6 +2246,38 @@ class TestModelReviewQuorum:
             "6/6 cases pass."
         )
         assert _model_family_from_body(body) == ""
+
+    def test_dogfood_structured_metadata_in_indented_code_block_is_not_counted(
+        self,
+    ) -> None:
+        files = ["aragora/agents/router.py"]
+        pr = _make_pr(files=files)
+        pr["comments"] = [
+            {
+                "author": {"login": "an0mium"},
+                "body": (
+                    "## Codex focused adversarial dogfood\n\n"
+                    "Template copied from the reviewer instructions:\n\n"
+                    "    **Model family:** openai\n"
+                    "    **Model id:** gpt-5-codex\n"
+                    "    **Receipt artifact:** /tmp/codex-dogfood.md\n\n"
+                    "6/6 adversarial examples pass in the pasted template."
+                ),
+            },
+        ]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=files,
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+        )
+        assert quorum["counted_reviewer_ids"] == []
+        assert quorum["dogfood_evidence"][0]["identity_problems"] == [
+            "missing_model_family_disclosure",
+            "missing_receipt_artifact",
+        ]
 
     def test_dogfood_real_family_line_outside_fence_still_counts(self) -> None:
         """A genuine `Model family:` disclosure outside any code fence still

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -1359,6 +1359,12 @@ class TestModelReviewQuorum:
                 "I reviewed this earlier, but the later exact-head citation is hidden:\n\n"
                 "<!-- Current head: abcdef1234567890abcdef1234567890abcdef12 -->\n"
             ),
+            (
+                "I reviewed this earlier, but the later exact-head citation is only a "
+                "Markdown link destination:\n\n"
+                "[current head](https://github.com/synaptent/aragora/commit/"
+                "abcdef1234567890abcdef1234567890abcdef12)\n"
+            ),
         ],
     )
     def test_stale_comment_with_non_prose_head_sha_citation_still_excluded(
@@ -4749,6 +4755,13 @@ class TestCommandDispatch:
             (
                 "I reviewed the diff, but this exact-head citation is hidden:\n\n"
                 "<!-- Current head: cd87c5a1b2db34f04167906553502db3ede9525e -->\n\n"
+                "Validation passed for the touched surface."
+            ),
+            (
+                "I reviewed the diff, but this exact-head citation is only a Markdown "
+                "link destination:\n\n"
+                "[current head](https://github.com/synaptent/aragora/commit/"
+                "cd87c5a1b2db34f04167906553502db3ede9525e)\n\n"
                 "Validation passed for the touched surface."
             ),
         ],

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -4671,6 +4671,51 @@ class TestCommandDispatch:
         assert payload["current_head_grounding_method"] == "head_sha_citation"
         assert payload["problems"] == []
 
+    @pytest.mark.parametrize(
+        "body_suffix",
+        [
+            (
+                "I reviewed the diff, but this is only a quoted template:\n\n"
+                "```\n"
+                "Current head: cd87c5a1b2db34f04167906553502db3ede9525e\n"
+                "```\n\n"
+                "Validation passed for the touched surface."
+            ),
+            (
+                "I reviewed the diff, but this is only an inline template: "
+                "`Current head: cd87c5a1b2db34f04167906553502db3ede9525e`.\n\n"
+                "Validation passed for the touched surface."
+            ),
+            (
+                "I reviewed the diff, but this is only a quoted prior note:\n\n"
+                "> Current head: cd87c5a1b2db34f04167906553502db3ede9525e\n\n"
+                "Validation passed for the touched surface."
+            ),
+        ],
+    )
+    def test_evidence_lint_rejects_non_prose_head_sha_citation(self, body_suffix: str) -> None:
+        ns = argparse.Namespace(
+            review_queue_command="evidence-lint",
+            pr="7445",
+            head_sha="cd87c5a1b2db34f04167906553502db3ede9525e",
+            head_committed_at="2026-05-23T19:00:00Z",
+            body=_codex_openai_body(body=body_suffix),
+            body_file=None,
+            author="an0mium",
+            json=True,
+        )
+
+        out = io.StringIO()
+        with redirect_stdout(out):
+            rc = cmd_review_queue(ns)
+
+        payload = json.loads(out.getvalue())
+        assert rc == 1
+        assert payload["would_count"] is False
+        assert payload["current_head_grounding_method"] == "missing_head_sha_citation"
+        assert "missing_current_head_grounding" in payload["problems"]
+        assert "no_counted_model_reviewer" in payload["problems"]
+
     def test_evidence_lint_rejects_github_actions_bot_author(self) -> None:
         ns = argparse.Namespace(
             review_queue_command="evidence-lint",

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -1371,6 +1371,11 @@ class TestModelReviewQuorum:
                 "[current-head]: https://github.com/synaptent/aragora/commit/"
                 "abcdef1234567890abcdef1234567890abcdef12\n"
             ),
+            (
+                "I reviewed this earlier, but the later exact-head citation is only "
+                "inside an indented code block:\n\n"
+                "    Current head: abcdef1234567890abcdef1234567890abcdef12\n"
+            ),
         ],
     )
     def test_stale_comment_with_non_prose_head_sha_citation_still_excluded(
@@ -2195,6 +2200,18 @@ class TestModelReviewQuorum:
         body = (
             "## Focused adversarial dogfood\n\n"
             "I left a note saying `Model family: claude` as an example only.\n\n"
+            "6/6 cases pass."
+        )
+        assert _model_family_from_body(body) == ""
+
+    def test_dogfood_model_family_in_indented_code_block_is_not_counted(self) -> None:
+        """An indented-code `Model family:` example is not a real disclosure."""
+        from aragora.cli.commands.review_queue import _model_family_from_body
+
+        body = (
+            "## Focused adversarial dogfood\n\n"
+            "The old template looked like this:\n\n"
+            "    Model family: claude\n\n"
             "6/6 cases pass."
         )
         assert _model_family_from_body(body) == ""
@@ -4775,6 +4792,12 @@ class TestCommandDispatch:
                 "reference definition:\n\n"
                 "[current-head]: https://github.com/synaptent/aragora/commit/"
                 "cd87c5a1b2db34f04167906553502db3ede9525e\n\n"
+                "Validation passed for the touched surface."
+            ),
+            (
+                "I reviewed the diff, but this exact-head citation is only inside "
+                "an indented code block:\n\n"
+                "    Current head: cd87c5a1b2db34f04167906553502db3ede9525e\n\n"
                 "Validation passed for the touched surface."
             ),
         ],

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -1365,6 +1365,12 @@ class TestModelReviewQuorum:
                 "[current head](https://github.com/synaptent/aragora/commit/"
                 "abcdef1234567890abcdef1234567890abcdef12)\n"
             ),
+            (
+                "I reviewed this earlier, but the later exact-head citation is only a "
+                "Markdown reference definition:\n\n"
+                "[current-head]: https://github.com/synaptent/aragora/commit/"
+                "abcdef1234567890abcdef1234567890abcdef12\n"
+            ),
         ],
     )
     def test_stale_comment_with_non_prose_head_sha_citation_still_excluded(
@@ -4762,6 +4768,13 @@ class TestCommandDispatch:
                 "link destination:\n\n"
                 "[current head](https://github.com/synaptent/aragora/commit/"
                 "cd87c5a1b2db34f04167906553502db3ede9525e)\n\n"
+                "Validation passed for the touched surface."
+            ),
+            (
+                "I reviewed the diff, but this exact-head citation is only a Markdown "
+                "reference definition:\n\n"
+                "[current-head]: https://github.com/synaptent/aragora/commit/"
+                "cd87c5a1b2db34f04167906553502db3ede9525e\n\n"
                 "Validation passed for the touched surface."
             ),
         ],

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -1646,6 +1646,50 @@ class TestModelReviewQuorum:
         )
         assert not any("GitHub review object from codex" in reason for reason in quorum["reasons"])
 
+    def test_review_pr_object_ignores_metadata_inside_fenced_template(
+        self,
+    ) -> None:
+        head_sha = "abcdef1234567890abcdef1234567890abcdef12"
+        pr = _make_pr(files=["aragora/cli/commands/swarm.py"])
+        pr["headRefOid"] = head_sha
+        pr["commits"] = [
+            {"oid": head_sha, "committedDate": "2026-04-28T20:00:00Z"},
+        ]
+        pr["comments"] = [
+            {
+                **_dogfood_comment("## Claude focused dogfood\n10/10 pass"),
+                "createdAt": "2026-04-28T20:05:00Z",
+            },
+        ]
+        pr["reviews"] = [
+            {
+                "author": {"login": "an0mium"},
+                "body": (
+                    "Template for the review-pr output to mirror:\n\n"
+                    "```markdown\n"
+                    "- Reviewer: `codex`\n"
+                    "- Model family: `openai`\n"
+                    "- Model id: `gpt-5-codex`\n"
+                    f"- Head SHA: `{head_sha}`\n"
+                    "- Final status: `passed`\n"
+                    "```\n"
+                ),
+                "commit": {"oid": head_sha},
+                "state": "COMMENTED",
+                "submittedAt": "2026-04-28T20:10:00Z",
+            }
+        ]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=["aragora/cli/commands/swarm.py"],
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+        )
+        assert quorum["counted_reviewer_ids"] == ["claude"]
+        assert not any("GitHub review object" in reason for reason in quorum["reasons"])
+
     def test_review_pr_object_with_router_reviewer_requires_model_family_metadata(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- makes exact-head evidence grounding fail closed when the only SHA citation is inside a fenced code block, indented code block, inline-code span, Markdown blockquote, hidden HTML comment, Markdown link destination, or Markdown reference definition
- applies that boundary to both `review-queue evidence-lint` proposed comments and persisted PR comments used by merge-packet model quorum
- prevents dogfood/model-review `Model family:` disclosures that appear only inside fenced, inline, or indented code examples from inflating model quorum while preserving diagnostic identity-problem entries
- prevents GitHub review-object advisory warnings from treating fenced `review-pr` output templates as live Reviewer/Model family metadata

## Validation
- red first: `python3 -m pytest tests/cli/commands/test_review_queue.py::TestModelReviewQuorum::test_review_pr_object_ignores_metadata_inside_fenced_template -q` failed because fenced template metadata produced a GitHub review-object warning
- focused green: `python3 -m pytest tests/cli/commands/test_review_queue.py::TestModelReviewQuorum::test_current_head_review_pr_object_warns_that_comment_form_is_required tests/cli/commands/test_review_queue.py::TestModelReviewQuorum::test_review_pr_object_ignores_metadata_inside_fenced_template tests/cli/commands/test_review_queue.py::TestModelReviewQuorum::test_review_pr_object_with_router_reviewer_requires_model_family_metadata tests/cli/commands/test_review_queue.py::TestModelReviewQuorum::test_off_head_review_pr_object_does_not_warn_as_current_evidence -q` (`4 passed`)
- `python3 -m pytest tests/cli/commands/test_review_queue.py::TestModelReviewQuorum -q` (`75 passed`)
- `python3 -m pytest tests/cli/commands/test_review_queue.py -q` (`242 passed`)
- `python3 -m ruff check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py`
- `python3 -m ruff format --check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py`
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` (`preflight: ok`)

## Governance
This touches review/merge-gate authority code, so the PR remains draft and review-only. It does not settle, mark ready, merge, change branch protection, or alter required-check authority. The behavior change is fail-closed evidence grounding/model-family parsing only.