### PR TITLE
fix(preflight): reject stale next-steps proof state

### DIFF
--- a/scripts/automation_pr_preflight.sh
+++ b/scripts/automation_pr_preflight.sh
@@ -177,6 +177,23 @@ if [[ -z "${docs_only_changes}" ]]; then
     docs_only=true
 fi
 
+if printf '%s\n' "${changed_files}" | grep -qx 'docs/status/NEXT_STEPS_CANONICAL.md'; then
+    next_steps_blob="${HEAD_REF}:docs/status/NEXT_STEPS_CANONICAL.md"
+    if ! git cat-file -e "${next_steps_blob}" 2>/dev/null; then
+        fail_preflight 1 "docs/status/NEXT_STEPS_CANONICAL.md must exist at ${HEAD_REF}"
+    fi
+    next_steps_content="$(git show "${next_steps_blob}")"
+    stale_proof_regex='Current May 28 proof-loop state|truth_success_rate_verified over five verified entries|full-corpus truth remains 38\.5%'
+    if printf '%s\n' "${next_steps_content}" | grep -Eq "${stale_proof_regex}"; then
+        fail_preflight 1 "docs/status/NEXT_STEPS_CANONICAL.md still contains stale proof-loop percentages"
+    fi
+    for required_ref in B0_BENCHMARK_TRUTH_STATUS TW03_RESCUE_PRODUCTIZATION_STATUS 'Current proof-loop state'; do
+        if ! printf '%s\n' "${next_steps_content}" | grep -Fq "${required_ref}"; then
+            fail_preflight 1 "docs/status/NEXT_STEPS_CANONICAL.md is missing live proof-surface reference: ${required_ref}"
+        fi
+    done
+fi
+
 if [[ "${JSON_MODE}" == "true" ]]; then
     emit_json "ok"
     exit 0

--- a/tests/scripts/test_automation_pr_preflight.py
+++ b/tests/scripts/test_automation_pr_preflight.py
@@ -301,6 +301,60 @@ def test_automation_pr_preflight_accepts_unrelated_latest_json(
     assert "preflight: ok" in proc.stdout
 
 
+def test_automation_pr_preflight_json_rejects_stale_next_steps_proof_state(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _run(["git", "switch", "-c", "codex/stale-next-steps"], cwd=repo)
+    next_steps = repo / "docs" / "status" / "NEXT_STEPS_CANONICAL.md"
+    next_steps.parent.mkdir(parents=True)
+    next_steps.write_text(
+        "# Next Steps\n\n"
+        "Current May 28 proof-loop state: full-corpus truth remains 38.5%.\n"
+        "truth_success_rate_verified over five verified entries.\n",
+        encoding="utf-8",
+    )
+    _run(["git", "add", "docs/status/NEXT_STEPS_CANONICAL.md"], cwd=repo)
+    _run(["git", "commit", "-m", "docs: refresh next steps"], cwd=repo)
+
+    proc = _run(["bash", str(SCRIPT), "--json", "origin/main", "HEAD"], cwd=repo)
+
+    assert proc.returncode == 1
+    payload = json.loads(proc.stdout)
+    assert payload["status"] == "failed"
+    assert payload["changed_files"] == ["docs/status/NEXT_STEPS_CANONICAL.md"]
+    assert (
+        payload["error"]
+        == "docs/status/NEXT_STEPS_CANONICAL.md still contains stale proof-loop percentages"
+    )
+
+
+def test_automation_pr_preflight_accepts_next_steps_with_current_proof_refs(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _run(["git", "switch", "-c", "codex/current-next-steps"], cwd=repo)
+    next_steps = repo / "docs" / "status" / "NEXT_STEPS_CANONICAL.md"
+    next_steps.parent.mkdir(parents=True)
+    next_steps.write_text(
+        "# Next Steps\n\n"
+        "Current proof-loop state: use live proof surfaces instead of copied rates.\n"
+        "- B0_BENCHMARK_TRUTH_STATUS\n"
+        "- TW03_RESCUE_PRODUCTIZATION_STATUS\n",
+        encoding="utf-8",
+    )
+    _run(["git", "add", "docs/status/NEXT_STEPS_CANONICAL.md"], cwd=repo)
+    _run(["git", "commit", "-m", "docs: refresh next steps"], cwd=repo)
+
+    proc = _run(["bash", str(SCRIPT), "--json", "origin/main", "HEAD"], cwd=repo)
+
+    assert proc.returncode == 0
+    payload = json.loads(proc.stdout)
+    assert payload["status"] == "ok"
+    assert payload["docs_only"] is True
+    assert payload["changed_files"] == ["docs/status/NEXT_STEPS_CANONICAL.md"]
+
+
 def test_github_cli_health_classifies_raw_dial_tcp_errors_as_connectivity() -> None:
     assert gh_health.is_github_connectivity_error(
         'Get "https://api.github.com/rate_limit": dial tcp 140.82.112.5:443: i/o timeout'


### PR DESCRIPTION
## Summary
- Harvests the useful part of `codex/swarm-e2cc977e-micro-4` onto current `origin/main`.
- Makes `scripts/automation_pr_preflight.sh` reject changed `docs/status/NEXT_STEPS_CANONICAL.md` files that copy stale proof-loop percentages.
- Requires changed canonical next-steps docs to reference live B0/TW03 proof surfaces instead of point-in-time rates.

## Validation
- `python3 -m pytest -q tests/scripts/test_automation_pr_preflight.py`
- `bash scripts/automation_pr_preflight.sh --json origin/main HEAD`
- push hooks: ruff, mypy gate, gitleaks, portability guard

## Notes
Opened as draft because the queue is already under pressure; do not merge until normal Tier 0-2 live gates pass.
