### PR TITLE
fix(similarity): validate prompt dedupe thresholds

### DIFF
--- a/scripts/extract_and_rank_prompts.py
+++ b/scripts/extract_and_rank_prompts.py
@@ -203,6 +203,15 @@ def extract_user_voice(text: str) -> str:
 
 def deduplicate(prompts: list[dict], threshold: float = 0.65) -> list[dict]:
     """Remove near-duplicate prompts using word overlap."""
+    if (
+        isinstance(threshold, bool)
+        or not isinstance(threshold, int | float)
+        or not 0.0 <= threshold < 1.0
+    ):
+        raise ValueError(
+            "deduplication similarity threshold must be between 0.0 inclusive and 1.0 exclusive"
+        )
+
     seen = []
     unique = []
     for p in prompts:

--- a/scripts/extract_intent_prompts.py
+++ b/scripts/extract_intent_prompts.py
@@ -313,6 +313,15 @@ def extract_user_text(message: dict) -> str | None:
 
 def deduplicate(prompts: list[dict], threshold: float = 0.7) -> list[dict]:
     """Remove near-duplicate prompts."""
+    if (
+        isinstance(threshold, bool)
+        or not isinstance(threshold, int | float)
+        or not 0.0 <= threshold < 1.0
+    ):
+        raise ValueError(
+            "deduplication similarity threshold must be between 0.0 inclusive and 1.0 exclusive"
+        )
+
     seen = []
     unique = []
     for p in prompts:

--- a/scripts/extract_user_prompts.py
+++ b/scripts/extract_user_prompts.py
@@ -173,6 +173,15 @@ def extract_prompts(
 
 def deduplicate(prompts: list[dict], similarity_threshold: float = 0.8) -> list[dict]:
     """Remove near-duplicate prompts (same text repeated across sessions)."""
+    if (
+        isinstance(similarity_threshold, bool)
+        or not isinstance(similarity_threshold, int | float)
+        or not 0.0 <= similarity_threshold < 1.0
+    ):
+        raise ValueError(
+            "deduplication similarity threshold must be between 0.0 inclusive and 1.0 exclusive"
+        )
+
     seen_texts = []
     unique = []
 

--- a/tests/scripts/test_prompt_dedupe_thresholds.py
+++ b/tests/scripts/test_prompt_dedupe_thresholds.py
@@ -1,0 +1,63 @@
+"""Regression tests for prompt extraction dedupe similarity thresholds."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_script_module(name: str):
+    script_path = ROOT / "scripts" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+MODULES = [
+    ("extract_and_rank_prompts", "threshold"),
+    ("extract_intent_prompts", "threshold"),
+    ("extract_user_prompts", "similarity_threshold"),
+]
+
+
+def _prompts() -> list[dict[str, str]]:
+    return [
+        {"id": "first", "text": "build a durable prompt ranking similarity surface"},
+        {"id": "duplicate", "text": "build a durable prompt ranking similarity surface"},
+        {"id": "distinct", "text": "measure proof receipt freshness without queue authority"},
+    ]
+
+
+@pytest.mark.parametrize(("module_name", "threshold_kw"), MODULES)
+@pytest.mark.parametrize("invalid_threshold", [-0.01, 1.0, True, "0.5"])
+def test_deduplicate_rejects_invalid_similarity_thresholds(
+    module_name: str,
+    threshold_kw: str,
+    invalid_threshold: object,
+) -> None:
+    module = _load_script_module(module_name)
+
+    with pytest.raises(ValueError, match="between 0.0 inclusive and 1.0 exclusive"):
+        module.deduplicate(_prompts(), **{threshold_kw: invalid_threshold})
+
+
+@pytest.mark.parametrize(("module_name", "threshold_kw"), MODULES)
+def test_deduplicate_removes_exact_duplicates_with_valid_threshold(
+    module_name: str,
+    threshold_kw: str,
+) -> None:
+    module = _load_script_module(module_name)
+
+    result = module.deduplicate(_prompts(), **{threshold_kw: 0.99})
+
+    assert [item["id"] for item in result] == ["first", "distinct"]


### PR DESCRIPTION
## Summary
- fail closed on invalid prompt dedupe similarity thresholds in the prompt extraction/ranking scripts
- reject negative, boolean, non-numeric, and >=1.0 thresholds before Jaccard dedupe can collapse or disable results
- add focused regression coverage across all three prompt dedupe surfaces

## Validation
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_prompt_dedupe_thresholds.py -q`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/extract_and_rank_prompts.py scripts/extract_intent_prompts.py scripts/extract_user_prompts.py tests/scripts/test_prompt_dedupe_thresholds.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/extract_and_rank_prompts.py scripts/extract_intent_prompts.py scripts/extract_user_prompts.py tests/scripts/test_prompt_dedupe_thresholds.py`
- `git diff --check origin/main..HEAD`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- push-time pre-push hooks, including mypy and portability guard