### PR TITLE
fix(proof): validate quality prose filters

### DIFF
--- a/scripts/extract_quality_prose.py
+++ b/scripts/extract_quality_prose.py
@@ -416,7 +416,27 @@ def extract_quality_prose(
 # =============================================================================
 
 
-def main():
+def _positive_int(raw: str) -> int:
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a positive integer") from exc
+    if value <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return value
+
+
+def _non_negative_float(raw: str) -> float:
+    try:
+        value = float(raw)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a non-negative number") from exc
+    if value < 0:
+        raise argparse.ArgumentTypeError("must be a non-negative number")
+    return value
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Extract high-quality prose from conversations",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -438,29 +458,30 @@ def main():
     )
     parser.add_argument(
         "--min-quality",
-        type=float,
+        type=_non_negative_float,
         default=0.5,
         help="Minimum quality score (default: 0.5)",
     )
     parser.add_argument(
         "--min-words",
-        type=int,
+        type=_positive_int,
         default=100,
         help="Minimum words per passage (default: 100)",
     )
-    parser.add_argument(
+    role_group = parser.add_mutually_exclusive_group()
+    role_group.add_argument(
         "--user-only",
         action="store_true",
         help="Only extract user messages",
     )
-    parser.add_argument(
+    role_group.add_argument(
         "--assistant-only",
         action="store_true",
         help="Only extract assistant messages",
     )
     parser.add_argument(
         "--top-n",
-        type=int,
+        type=_positive_int,
         help="Only output top N passages by quality",
     )
     parser.add_argument(
@@ -470,7 +491,11 @@ def main():
         help="Verbose output",
     )
 
-    args = parser.parse_args()
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None):
+    args = parse_args(argv)
 
     # Load conversations
     print(f"Loading: {args.input}")

--- a/tests/scripts/test_extract_quality_prose.py
+++ b/tests/scripts/test_extract_quality_prose.py
@@ -1,0 +1,74 @@
+"""Tests for scripts/extract_quality_prose.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = ROOT / "scripts" / "extract_quality_prose.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("extract_quality_prose", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _required_args() -> list[str]:
+    return ["--input", "conversations.json", "--output", "quality.json"]
+
+
+@pytest.mark.parametrize(
+    ("flag", "value"),
+    [
+        ("--min-words", "0"),
+        ("--min-words", "-1"),
+        ("--top-n", "0"),
+        ("--top-n", "-1"),
+        ("--min-quality", "-0.1"),
+    ],
+)
+def test_parse_args_rejects_invalid_quality_filter_values(flag: str, value: str) -> None:
+    module = _load_module()
+
+    with pytest.raises(SystemExit):
+        module.parse_args([*_required_args(), flag, value])
+
+
+def test_parse_args_rejects_conflicting_role_filters() -> None:
+    module = _load_module()
+
+    with pytest.raises(SystemExit):
+        module.parse_args([*_required_args(), "--user-only", "--assistant-only"])
+
+
+def test_parse_args_accepts_valid_quality_filters() -> None:
+    module = _load_module()
+
+    args = module.parse_args(
+        [
+            *_required_args(),
+            "--min-quality",
+            "0",
+            "--min-words",
+            "50",
+            "--top-n",
+            "3",
+            "--user-only",
+        ]
+    )
+
+    assert args.min_quality == 0.0
+    assert args.min_words == 50
+    assert args.top_n == 3
+    assert args.user_only is True
+    assert args.assistant_only is False


### PR DESCRIPTION
## Summary
- add parser-level validation for quality prose extraction filters
- reject non-positive `--min-words` / `--top-n` and negative `--min-quality` before building a misleading corpus
- make `--user-only` and `--assistant-only` mutually exclusive
- add focused parser regression tests for invalid and valid filter combinations

## Validation
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_extract_quality_prose.py -q`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/extract_quality_prose.py tests/scripts/test_extract_quality_prose.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/extract_quality_prose.py tests/scripts/test_extract_quality_prose.py`
- `git diff --check origin/main..HEAD`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- push-time pre-push hooks, including mypy and portability guard