### PR TITLE
feat(merge-arbiter): auto-collect quorum evidence for ready codex/ candidates

### DIFF
--- a/aragora/swarm/merge_arbiter.py
+++ b/aragora/swarm/merge_arbiter.py
@@ -23,6 +23,17 @@ from pathlib import Path
 
 from aragora.config.trusted_authors import resolve_trusted_authors
 from aragora.swarm.github_app_auth import gh_subprocess_run
+from aragora.swarm.merge_quorum_io import (
+    fetch_evidence_comments,
+    fetch_pr_context,
+    fetch_pr_tier,
+)
+from aragora.swarm.merge_quorum_reconcile import TIER_REQUIREMENTS, counted_reviewer_ids
+from aragora.swarm.quorum_evidence import (
+    DEFAULT_FAMILIES,
+    collect_evidence,
+    resolve_author,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -72,6 +83,12 @@ class MergeArbiterConfig:
     max_runtime_hours: float = 12.0
     max_consecutive_failures: int = 3
     dry_run: bool = False
+    # When True, the arbiter auto-collects model-quorum evidence for ready
+    # candidates blocked solely on the quorum check (Tier 0-2 only). Posting is
+    # tier-gated inside collect_evidence; high-tier PRs never auto-post.
+    auto_collect_evidence: bool = True
+    # Reviewer families for auto-collection; falls back to DEFAULT_FAMILIES.
+    reviewer_families: list[str] | None = None
 
 
 @dataclass
@@ -507,12 +524,124 @@ def _evaluate_pr(pr: dict, config: MergeArbiterConfig) -> MergeResult:
     return MergeResult(pr_number, branch, ok, reason)
 
 
+QUORUM_REQUIRED_CHECK = "aragora-merge-quorum"
+
+
+def _required_model_signals(tier: int | None) -> int:
+    """Number of distinct countable model families a PR's tier requires."""
+    return TIER_REQUIREMENTS.get(tier if tier is not None else -1, (2, True, True))[0]
+
+
+def _result_blocked_only_on_quorum(result: MergeResult) -> bool:
+    """True when a not-ready PR is blocked solely on the merge-quorum check.
+
+    The quorum check is a branch-protection required context, so the arbiter
+    reports a quorum-only block as a 'failing'/'missing required checks' reason
+    naming exactly ``aragora-merge-quorum``. Any other failing/missing required
+    check (a real functional failure) returns False — we never spend reviewers
+    on a PR that is broken for other reasons.
+    """
+    if result.success:
+        return False
+    for prefix in ("failing required checks: ", "missing required checks: "):
+        if result.reason.startswith(prefix):
+            entries = [e.strip() for e in result.reason[len(prefix) :].split(",") if e.strip()]
+            return bool(entries) and all(
+                e.split("=", 1)[0].strip() == QUORUM_REQUIRED_CHECK for e in entries
+            )
+    return False
+
+
+def _should_collect_evidence(
+    pr: dict,
+    result: MergeResult,
+    *,
+    config: MergeArbiterConfig,
+    tier_fetcher,
+    context_fetcher,
+    evidence_reader,
+) -> bool:
+    """Decide whether to auto-collect quorum evidence for a not-ready candidate.
+
+    True iff the flag is on; the PR is blocked only on the quorum check; its tier
+    is auto-postable (0-2); and it has fewer countable model families than its
+    tier requires. All I/O is injected so this is fully testable with fakes.
+    """
+    if not config.auto_collect_evidence:
+        return False
+    if not _result_blocked_only_on_quorum(result):
+        return False
+    pr_number = pr.get("number")
+    if pr_number is None:
+        return False
+    tier = tier_fetcher(config.repo, pr_number)
+    if tier is None or tier < 0 or tier > 2:
+        return False
+    ctx = context_fetcher(config.repo, pr_number) or {}
+    head_sha = str(ctx.get("head_sha") or "")
+    if not head_sha:
+        return False
+    head_committed_at = str(ctx.get("head_committed_at") or "")
+    comments = evidence_reader(config.repo, pr_number, head_sha, head_committed_at)
+    return len(counted_reviewer_ids(comments)) < _required_model_signals(tier)
+
+
 class MergeArbiter:
     """Polling loop that auto-merges boss-loop PRs when CI passes."""
 
-    def __init__(self, config: MergeArbiterConfig | None = None) -> None:
+    def __init__(
+        self,
+        config: MergeArbiterConfig | None = None,
+        *,
+        tier_fetcher=fetch_pr_tier,
+        context_fetcher=fetch_pr_context,
+        evidence_reader=fetch_evidence_comments,
+        collector=collect_evidence,
+        author_resolver=resolve_author,
+    ) -> None:
         self.config = config or MergeArbiterConfig()
         self._consecutive_failures = 0
+        self._collected_heads: set[str] = set()
+        self._tier_fetcher = tier_fetcher
+        self._context_fetcher = context_fetcher
+        self._evidence_reader = evidence_reader
+        self._collector = collector
+        self._author_resolver = author_resolver
+
+    def _maybe_collect_evidence(self, pr: dict, result: MergeResult) -> bool:
+        """Collect quorum evidence at most once per head for a quorum-blocked PR.
+
+        Returns True iff a collection was attempted. Posting is tier-gated inside
+        ``collect_evidence`` (Tier 3+ never posts). The head is recorded before
+        collecting so a transient fault never re-triggers the costly multi-model
+        collection on the same head every poll.
+        """
+        head_sha = str(pr.get("headRefOid") or "")
+        if head_sha and head_sha in self._collected_heads:
+            return False
+        if not _should_collect_evidence(
+            pr,
+            result,
+            config=self.config,
+            tier_fetcher=self._tier_fetcher,
+            context_fetcher=self._context_fetcher,
+            evidence_reader=self._evidence_reader,
+        ):
+            return False
+        self._collected_heads.add(head_sha)
+        try:
+            self._collector(
+                repo=self.config.repo,
+                pr=pr["number"],
+                families=self.config.reviewer_families or list(DEFAULT_FAMILIES),
+                author=self._author_resolver(),
+                apply=True,
+            )
+        except Exception as exc:  # noqa: BLE001 - best-effort resilience boundary: one bad collection must not abort the poll loop
+            logger.warning("evidence collection fault for #%s: %s", pr.get("number"), exc)
+            return False
+        logger.info("Auto-collected quorum evidence for #%s", pr.get("number"))
+        return True
 
     async def run(self) -> ArbiterSummary:
         """Run the polling loop until max runtime or circuit breaker trips."""
@@ -533,6 +662,7 @@ class MergeArbiter:
             summary.polls += 1
             any_failure_this_poll = False
             any_merge_this_poll = False
+            collected_this_poll = False
 
             candidates = _list_candidate_prs(self.config)
             logger.debug("Poll %d: %d candidate PRs", summary.polls, len(candidates))
@@ -565,6 +695,15 @@ class MergeArbiter:
                         result.reason,
                         result.branch,
                     )
+
+                # Auto-collect quorum evidence for a candidate blocked only on the
+                # quorum check (at most one collection per poll, once per head).
+                if (
+                    not result.success
+                    and not collected_this_poll
+                    and self._maybe_collect_evidence(pr, result)
+                ):
+                    collected_this_poll = True
 
             # Circuit breaker: track consecutive polls with only failures
             if any_failure_this_poll and not any_merge_this_poll:

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -13,11 +13,11 @@
 | Metric | Value | Source | Command |
 |---|---|---|---|
 | Python files under aragora/ | `4164` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1953695` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python lines of code under aragora/ | `1953862` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `141` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5273` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `219932` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
-| @pytest.mark.parametrize decorators | `725` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
+| Test files (test_*.py under tests/) | `5290` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `220085` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| @pytest.mark.parametrize decorators | `729` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `77` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2870` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
 | OpenAPI operations (HTTP verbs) | `3297` | `docs/api/openapi.json` | `python -c "import json; spec=json.load(open('docs/api/openapi.json')); print(sum(1 for p in spec['paths'].values() for m in p if m.lower() in {'get','post','put','delete','patch','head','options'}))"` |
@@ -28,7 +28,7 @@
 | Allowlisted agent types | `35` | `aragora/config/settings.py` | `grep -A 50 'ALLOWED_AGENT_TYPES' aragora/config/settings.py \| grep -oE "'[a-z-]+'" \| sort -u \| wc -l` |
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `46` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |
-| Markdown files under docs/ | `973` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
+| Markdown files under docs/ | `977` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
 | GitHub Actions workflows | `88` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
 | Mypy baseline errors (grandfathered) | `3115` | `.mypy-baseline` | `wc -l .mypy-baseline` |
 

--- a/tests/swarm/test_merge_arbiter.py
+++ b/tests/swarm/test_merge_arbiter.py
@@ -543,3 +543,208 @@ class TestFullRun:
 
         assert 7 in summary.merged
         assert summary.polls >= 1
+
+
+# ---------------------------------------------------------------------------
+# Auto-collect quorum evidence for ready candidates blocked only on quorum
+# ---------------------------------------------------------------------------
+
+from aragora.swarm.merge_arbiter import (  # noqa: E402
+    QUORUM_REQUIRED_CHECK,
+    _result_blocked_only_on_quorum,
+    _should_collect_evidence,
+)
+from aragora.swarm.merge_quorum_reconcile import EvidenceComment  # noqa: E402
+
+
+def _evidence(*families: str) -> list[EvidenceComment]:
+    return [
+        EvidenceComment(created_at="2026-06-06T00:00:00Z", would_count=True, reviewer_id=f)
+        for f in families
+    ]
+
+
+class TestResultBlockedOnlyOnQuorum:
+    def test_true_when_only_quorum_check_failing(self):
+        r = MergeResult(
+            1, "codex/x", False, f"failing required checks: {QUORUM_REQUIRED_CHECK}=FAILURE"
+        )
+        assert _result_blocked_only_on_quorum(r) is True
+
+    def test_true_when_quorum_check_missing(self):
+        r = MergeResult(1, "codex/x", False, f"missing required checks: {QUORUM_REQUIRED_CHECK}")
+        assert _result_blocked_only_on_quorum(r) is True
+
+    def test_false_when_functional_check_failing(self):
+        r = MergeResult(1, "codex/x", False, "failing required checks: lint=FAILURE")
+        assert _result_blocked_only_on_quorum(r) is False
+
+    def test_false_when_mixed_with_functional_check(self):
+        r = MergeResult(
+            1,
+            "codex/x",
+            False,
+            f"failing required checks: {QUORUM_REQUIRED_CHECK}=FAILURE, lint=FAILURE",
+        )
+        assert _result_blocked_only_on_quorum(r) is False
+
+    def test_false_for_success_or_other_waiting(self):
+        assert _result_blocked_only_on_quorum(MergeResult(1, "codex/x", True, "merged")) is False
+        assert (
+            _result_blocked_only_on_quorum(
+                MergeResult(
+                    1, "codex/x", False, "waiting on full-suite checks: Core Suites=PENDING"
+                )
+            )
+            is False
+        )
+
+
+class TestShouldCollectEvidence:
+    def _quorum_blocked(self):
+        return MergeResult(
+            42, "codex/x", False, f"failing required checks: {QUORUM_REQUIRED_CHECK}=FAILURE"
+        )
+
+    def _ctx(self, *_a):
+        return {"head_sha": "abc123", "head_committed_at": "2026-06-06T00:00:00Z"}
+
+    def test_true_for_tier2_quorum_blocked_no_evidence(self):
+        assert (
+            _should_collect_evidence(
+                _pr(42, "codex/x"),
+                self._quorum_blocked(),
+                config=MergeArbiterConfig(),
+                tier_fetcher=lambda *_: 2,
+                context_fetcher=self._ctx,
+                evidence_reader=lambda *_: _evidence(),
+            )
+            is True
+        )
+
+    def test_false_when_flag_off(self):
+        assert (
+            _should_collect_evidence(
+                _pr(42, "codex/x"),
+                self._quorum_blocked(),
+                config=MergeArbiterConfig(auto_collect_evidence=False),
+                tier_fetcher=lambda *_: 2,
+                context_fetcher=self._ctx,
+                evidence_reader=lambda *_: _evidence(),
+            )
+            is False
+        )
+
+    def test_false_when_already_has_required_evidence(self):
+        assert (
+            _should_collect_evidence(
+                _pr(42, "codex/x"),
+                self._quorum_blocked(),
+                config=MergeArbiterConfig(),
+                tier_fetcher=lambda *_: 2,
+                context_fetcher=self._ctx,
+                evidence_reader=lambda *_: _evidence("claude", "grok"),
+            )
+            is False
+        )
+
+    def test_false_for_tier3_and_tier4(self):
+        for tier in (3, 4):
+            assert (
+                _should_collect_evidence(
+                    _pr(42, "codex/x"),
+                    self._quorum_blocked(),
+                    config=MergeArbiterConfig(),
+                    tier_fetcher=lambda *_a, _t=tier: _t,
+                    context_fetcher=self._ctx,
+                    evidence_reader=lambda *_: _evidence(),
+                )
+                is False
+            )
+
+    def test_false_when_not_quorum_blocked(self):
+        assert (
+            _should_collect_evidence(
+                _pr(42, "codex/x"),
+                MergeResult(42, "codex/x", False, "failing required checks: lint=FAILURE"),
+                config=MergeArbiterConfig(),
+                tier_fetcher=lambda *_: 2,
+                context_fetcher=self._ctx,
+                evidence_reader=lambda *_: _evidence(),
+            )
+            is False
+        )
+
+
+class TestAutoCollectIntegration:
+    def _arbiter_with_fakes(self, collector, *, tier=2, evidence=None):
+        calls = {"n": 0}
+
+        def counting_collector(**kw):
+            calls["n"] += 1
+            return collector(**kw)
+
+        arb = MergeArbiter(
+            config=MergeArbiterConfig(
+                poll_interval_seconds=0.001,
+                max_runtime_hours=0.0003,
+                max_consecutive_failures=99,
+            ),
+            tier_fetcher=lambda *_: tier,
+            context_fetcher=lambda *_: {
+                "head_sha": "deadbeef",
+                "head_committed_at": "2026-06-06T00:00:00Z",
+            },
+            evidence_reader=lambda *_: (evidence or []),
+            collector=counting_collector,
+            author_resolver=lambda: "an0mium",
+        )
+        return arb, calls
+
+    @pytest.mark.asyncio
+    async def test_collects_once_per_head_across_polls(self):
+        arb, calls = self._arbiter_with_fakes(lambda **kw: None)
+        quorum_pr = _pr(50, "codex/x")
+        blocked = MergeResult(
+            50, "codex/x", False, f"failing required checks: {QUORUM_REQUIRED_CHECK}=FAILURE"
+        )
+        with (
+            patch("aragora.swarm.merge_arbiter._list_candidate_prs", return_value=[quorum_pr]),
+            patch("aragora.swarm.merge_arbiter._evaluate_pr", return_value=blocked),
+        ):
+            summary = await arb.run()
+        # Many polls happen in the window, but collection is idempotent per head.
+        assert calls["n"] == 1
+        assert summary.polls >= 1
+
+    @pytest.mark.asyncio
+    async def test_does_not_collect_for_tier3(self):
+        arb, calls = self._arbiter_with_fakes(lambda **kw: None, tier=3)
+        quorum_pr = _pr(51, "codex/x")
+        blocked = MergeResult(
+            51, "codex/x", False, f"failing required checks: {QUORUM_REQUIRED_CHECK}=FAILURE"
+        )
+        with (
+            patch("aragora.swarm.merge_arbiter._list_candidate_prs", return_value=[quorum_pr]),
+            patch("aragora.swarm.merge_arbiter._evaluate_pr", return_value=blocked),
+        ):
+            await arb.run()
+        assert calls["n"] == 0
+
+    @pytest.mark.asyncio
+    async def test_collector_fault_is_swallowed(self):
+        def boom(**kw):
+            raise RuntimeError("reviewer substrate down")
+
+        arb, calls = self._arbiter_with_fakes(boom)
+        quorum_pr = _pr(52, "codex/x")
+        blocked = MergeResult(
+            52, "codex/x", False, f"failing required checks: {QUORUM_REQUIRED_CHECK}=FAILURE"
+        )
+        with (
+            patch("aragora.swarm.merge_arbiter._list_candidate_prs", return_value=[quorum_pr]),
+            patch("aragora.swarm.merge_arbiter._evaluate_pr", return_value=blocked),
+        ):
+            summary = await arb.run()  # must not raise
+        assert calls["n"] == 1  # attempted once; head recorded so no retry storm
+        assert summary.polls >= 1


### PR DESCRIPTION
## feat(merge-arbiter): auto-collect quorum evidence for ready codex/ candidates

**Closes the autonomy gap:** Tier-2 PRs blocked solely on the `aragora-merge-quorum` check
sat forever because **nothing ran the evidence collector on them** — the arbiter merges but
never collected, and collection was manual / boss-shepherded only (verified: #7877/#7879 have
0 countable evidence; the lone comment is the excluded github-actions advisory).

**What this adds:** a guarded pre-merge step in the merge-arbiter. For a candidate whose **only**
failing required check is the quorum check, is **Tier 0–2**, and has **fewer countable model
families than its tier requires**, the arbiter runs `collect_evidence(apply=True)` once per head
→ posts claude+grok comments (which satisfy both the ≥2-family quorum and dogfood) → next quorum
run counts them → the PR settles autonomously.

**Guards (safety):**
- Opt-in flag `auto_collect_evidence` (default True).
- **Tier-gated:** Tier 3+ never auto-posts — enforced both by `decide_action` and an explicit
  `tier <= 2` check.
- **Idempotent:** cheap `fetch_evidence_comments` pre-check (skip if already ≥ required) + a
  per-head set (≤1 collection per head across polls) + ≤1 per poll.
- **Fault-tolerant:** a collector exception is swallowed (logged) so one bad run never aborts the
  poll loop; the head is recorded first to avoid a retry storm.
- All I/O injected → fully tested with fakes (no real LLM/gh in tests).

**Tests:** 39/39 in `test_merge_arbiter.py` (13 new: blocked-only-on-quorum matrix, eligibility
matrix incl. tier-3/4 + flag-off + already-has-evidence, and integration: collects exactly once
per head across polls, never for tier-3, swallows collector faults). Ruff clean.

**Companions (not blockers):** #7879 (breaker fix) so a quorum-blocked queue doesn't stop the
engine before evidence is counted — this PR leaves the breaker untouched. #7832 (keyless
OpenRouter) hardens ≥2-family collection without on-disk keys.

⚠️ Tier 2 (live-automation surface) — autonomously settleable by the quorum harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
