### PR TITLE
fix(metrics): reject empty prompt-engine profiles

### DIFF
--- a/scripts/profile_prompt_engine.py
+++ b/scripts/profile_prompt_engine.py
@@ -197,6 +197,9 @@ def build_profile_report(
     mode: str,
 ) -> dict[str, Any]:
     """Aggregate one or more prompt-engine timing samples."""
+    if not timings:
+        raise ValueError("prompt engine profile report requires at least one timing sample")
+
     stage_samples: dict[str, list[float]] = defaultdict(list)
     operation_samples: dict[str, list[float]] = defaultdict(list)
     operation_meta: dict[str, dict[str, str]] = {}

--- a/tests/scripts/test_profile_prompt_engine.py
+++ b/tests/scripts/test_profile_prompt_engine.py
@@ -1,7 +1,22 @@
 from __future__ import annotations
 
+import pytest
+
 from aragora.prompt_engine.timing import OperationTiming, PipelineTiming
 from scripts.profile_prompt_engine import build_profile_report
+
+
+def test_build_profile_report_rejects_empty_timing_samples() -> None:
+    with pytest.raises(ValueError, match="requires at least one timing sample"):
+        build_profile_report(
+            prompt="Profile the prompt engine",
+            timings=[],
+            profile="founder",
+            depth="quick",
+            skip_research=False,
+            skip_interrogation=False,
+            mode="mock-agent",
+        )
 
 
 def test_build_profile_report_aggregates_stage_and_operation_baselines() -> None:


### PR DESCRIPTION
## Summary
- fail closed when prompt-engine latency profile reports are built without timing samples
- prevent structurally valid `runs=0` profile reports from representing an unmeasured baseline
- add focused regression coverage for empty and normal timing sample aggregation

## Validation
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_profile_prompt_engine.py -q`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/profile_prompt_engine.py tests/scripts/test_profile_prompt_engine.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/profile_prompt_engine.py tests/scripts/test_profile_prompt_engine.py`
- `git diff --check origin/main..HEAD`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- push-time pre-push hooks, including mypy and portability guard