### PR TITLE
fix(benchmarks): reject empty dogfood ab pairs

### DIFF
--- a/scripts/run_dogfood_ab_pairs.py
+++ b/scripts/run_dogfood_ab_pairs.py
@@ -345,6 +345,16 @@ def _score_pair(
     return json.loads(summary_json.read_text(encoding="utf-8"))
 
 
+def _positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be an integer") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -355,7 +365,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--pairs",
-        type=int,
+        type=_positive_int,
         default=5,
         help="Number of control/focused pairs to run (default: 5).",
     )

--- a/tests/scripts/test_run_dogfood_ab_pairs.py
+++ b/tests/scripts/test_run_dogfood_ab_pairs.py
@@ -1,0 +1,39 @@
+"""Tests for scripts/run_dogfood_ab_pairs.py benchmark input validation."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
+if _scripts_dir not in sys.path:
+    sys.path.insert(0, _scripts_dir)
+
+import run_dogfood_ab_pairs  # noqa: E402
+
+
+def test_parse_args_accepts_positive_pair_count() -> None:
+    args = run_dogfood_ab_pairs.parse_args(["--pairs", "1"])
+
+    assert args.pairs == 1
+
+
+def test_main_rejects_zero_pairs_before_writing_output(tmp_path: Path) -> None:
+    output_root = tmp_path / "dogfood-ab-output"
+
+    with pytest.raises(SystemExit):
+        run_dogfood_ab_pairs.main(["--pairs", "0", "--output-root", str(output_root)])
+
+    assert not output_root.exists()
+
+
+def test_main_rejects_negative_pairs_before_writing_output(tmp_path: Path) -> None:
+    output_root = tmp_path / "dogfood-ab-output"
+
+    with pytest.raises(SystemExit):
+        run_dogfood_ab_pairs.main(["--pairs", "-2", "--output-root", str(output_root)])
+
+    assert not output_root.exists()


### PR DESCRIPTION
## Summary
- reject non-positive --pairs values in scripts/run_dogfood_ab_pairs.py during argument parsing
- add regression coverage proving zero/negative pair counts fail before output artifacts are created

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_run_dogfood_ab_pairs.py -q
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/run_dogfood_ab_pairs.py tests/scripts/test_run_dogfood_ab_pairs.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/run_dogfood_ab_pairs.py tests/scripts/test_run_dogfood_ab_pairs.py
- git diff --check origin/main..HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD