### PR TITLE
fix(aft): require nonempty seeded mlx splits

### DIFF
--- a/scripts/aft_seeded_train_eval.py
+++ b/scripts/aft_seeded_train_eval.py
@@ -79,7 +79,8 @@ def split_corpus(corpus: Path, out_dir: Path, holdout_size: int, seed: int) -> t
 
 def build_mlx_dir(t_corpus: Path, out_dir: Path, seed: int, valid_frac: float = 0.10) -> Path:
     """Convert a training-corpus JSONL into mlx_lm-format {train,valid}.jsonl."""
-    out_dir.mkdir(parents=True, exist_ok=True)
+    if not 0.0 < valid_frac < 1.0:
+        raise ValueError("valid_frac must be greater than 0 and less than 1")
     rows: list[dict] = []
     with t_corpus.open("r", encoding="utf-8") as fh:
         for line in fh:
@@ -93,11 +94,14 @@ def build_mlx_dir(t_corpus: Path, out_dir: Path, seed: int, valid_frac: float = 
             conv = aft_to_mlx_chat.convert_row(row)
             if conv is not None:
                 rows.append(conv)
+    if len(rows) < 2:
+        raise ValueError("AFT seeded MLX split requires at least two convertible training examples")
     rng = random.Random(seed)
     rng.shuffle(rows)
     n = len(rows)
-    n_valid = max(1, int(n * valid_frac))
+    n_valid = min(max(1, int(n * valid_frac)), n - 1)
     splits = {"train": rows[n_valid:], "valid": rows[:n_valid]}
+    out_dir.mkdir(parents=True, exist_ok=True)
     for name, batch in splits.items():
         path = out_dir / f"{name}.jsonl"
         with path.open("w", encoding="utf-8") as fh:

--- a/tests/scripts/test_aft_functions.py
+++ b/tests/scripts/test_aft_functions.py
@@ -16,6 +16,7 @@ deterministic. This is the safe coverage floor under the AFT spec's
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
 
 import pytest
@@ -33,6 +34,7 @@ from scripts.aft_harness import (
     brier_score,
     mcnemar_p,
 )
+from scripts import aft_seeded_train_eval
 from scripts.aft_repeated_eval import aggregate
 from scripts.aft_to_mlx_chat import convert_row
 
@@ -359,6 +361,56 @@ class TestConvertRow:
         out = convert_row(row)
         assert out is not None
         assert '"label": "closed_no_merge"' in out["messages"][2]["content"]
+
+
+# ----- aft_seeded_train_eval::build_mlx_dir --------------------------------
+
+
+def _write_training_rows(path: _pl.Path, labels: list[str]) -> None:
+    path.write_text(
+        "\n".join(
+            json.dumps({"pr_number": idx, "decision": label})
+            for idx, label in enumerate(labels, start=1)
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+class TestSeededTrainEvalMlxSplit:
+    def test_build_mlx_dir_rejects_one_convertible_row_before_writing(
+        self, tmp_path: _pl.Path
+    ) -> None:
+        corpus = tmp_path / "train.jsonl"
+        out_dir = tmp_path / "mlx"
+        _write_training_rows(corpus, ["merged_fast"])
+
+        with pytest.raises(ValueError, match="at least two convertible training examples"):
+            aft_seeded_train_eval.build_mlx_dir(corpus, out_dir, seed=17)
+
+        assert not out_dir.exists()
+
+    def test_build_mlx_dir_keeps_train_and_valid_examples(self, tmp_path: _pl.Path) -> None:
+        corpus = tmp_path / "train.jsonl"
+        out_dir = tmp_path / "mlx"
+        _write_training_rows(corpus, ["merged_fast", "closed_no_merge"])
+
+        aft_seeded_train_eval.build_mlx_dir(corpus, out_dir, seed=17)
+
+        assert len((out_dir / "train.jsonl").read_text(encoding="utf-8").splitlines()) == 1
+        assert len((out_dir / "valid.jsonl").read_text(encoding="utf-8").splitlines()) == 1
+
+    def test_build_mlx_dir_clamps_validation_split_to_leave_training_rows(
+        self, tmp_path: _pl.Path
+    ) -> None:
+        corpus = tmp_path / "train.jsonl"
+        out_dir = tmp_path / "mlx"
+        _write_training_rows(corpus, ["merged_fast", "closed_no_merge", "open_aged"])
+
+        aft_seeded_train_eval.build_mlx_dir(corpus, out_dir, seed=17, valid_frac=0.99)
+
+        assert len((out_dir / "train.jsonl").read_text(encoding="utf-8").splitlines()) == 1
+        assert len((out_dir / "valid.jsonl").read_text(encoding="utf-8").splitlines()) == 2
 
 
 # ----- aggregate (repeated-seed summary) -----------------------------------


### PR DESCRIPTION
## Summary
- reject seeded AFT MLX split generation when fewer than two corpus rows convert into training examples
- validate valid_frac and clamp validation sizing so train/valid artifacts both contain examples
- add pure-function regression coverage without invoking training, subprocesses, or model loading

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_aft_functions.py -q
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/aft_seeded_train_eval.py tests/scripts/test_aft_functions.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/aft_seeded_train_eval.py tests/scripts/test_aft_functions.py
- git diff --check origin/main..HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD