### PR TITLE
fix(dogfood): reject malformed reclassify reports

### DIFF
--- a/scripts/reclassify_dogfood_report.py
+++ b/scripts/reclassify_dogfood_report.py
@@ -23,12 +23,15 @@ def reclassify_report(data: dict[str, Any]) -> dict[str, Any]:
     runs = data.get("runs")
     if not isinstance(runs, list):
         raise ValueError("Report must contain runs list.")
+    if not runs:
+        raise ValueError("Report runs list must contain at least one run.")
+    for index, run in enumerate(runs):
+        if not isinstance(run, dict):
+            raise ValueError(f"Report runs[{index}] must be an object.")
 
     warning_only_runs = 0
     blocker_runs = 0
     for run in runs:
-        if not isinstance(run, dict):
-            continue
         stderr_excerpt = str(run.get("stderr_excerpt") or "")
         classified = classify_stderr_signals(stderr_excerpt)
         run["runtime_blockers"] = classified["runtime_blockers"]

--- a/tests/scripts/test_reclassify_dogfood_report.py
+++ b/tests/scripts/test_reclassify_dogfood_report.py
@@ -1,0 +1,51 @@
+"""Tests for scripts/reclassify_dogfood_report.py report-shape guards."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
+if _scripts_dir not in sys.path:
+    sys.path.insert(0, _scripts_dir)
+
+import reclassify_dogfood_report  # noqa: E402
+
+
+def test_reclassify_report_rejects_empty_runs() -> None:
+    with pytest.raises(ValueError, match="at least one run"):
+        reclassify_dogfood_report.reclassify_report({"runs": []})
+
+
+def test_reclassify_report_rejects_non_object_run_before_mutation() -> None:
+    report = {"runs": ["not-a-run"]}
+
+    with pytest.raises(ValueError, match=r"runs\[0\] must be an object"):
+        reclassify_dogfood_report.reclassify_report(report)
+
+    assert report == {"runs": ["not-a-run"]}
+
+
+def test_reclassify_report_counts_warning_only_and_blocker_runs() -> None:
+    report = {
+        "runs": [
+            {
+                "stderr_excerpt": (
+                    "ResourceWarning: unclosed transport\n"
+                    "ResourceWarning: Enable tracemalloc to get the object allocation traceback"
+                )
+            },
+            {"stderr_excerpt": "Debate timed out after 120s"},
+        ]
+    }
+
+    updated = reclassify_dogfood_report.reclassify_report(report)
+
+    assert updated["runtime_blockers_zero"] is False
+    assert updated["warning_only_runs"] == 1
+    assert updated["blocker_runs"] == 1
+    assert updated["runs"][0]["warning_only"] is True
+    assert "debate_timeout" in updated["runs"][1]["runtime_blockers"]


### PR DESCRIPTION
## Summary
- require dogfood reclassification reports to include at least one run object
- reject non-object run entries before rewriting runtime blocker metadata
- add focused tests for empty, malformed, warning-only, and blocker report cases

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_reclassify_dogfood_report.py -q
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/reclassify_dogfood_report.py tests/scripts/test_reclassify_dogfood_report.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/reclassify_dogfood_report.py tests/scripts/test_reclassify_dogfood_report.py
- git diff --check HEAD~1..HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD