### PR TITLE
[DIC-17] Decay signal → follow-up bridge (DIC-20 × DIC-17)

### DIFF
--- a/aragora/epistemic/followup.py
+++ b/aragora/epistemic/followup.py
@@ -35,6 +35,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from aragora.epistemic.coherence import CoherenceIssue
+    from aragora.epistemic.decay_monitor import DecaySignal
     from aragora.reasoning.cruxset import Crux, CruxSet
     from aragora.reputation.types import (
         ReputationDelta,
@@ -45,6 +46,7 @@ if TYPE_CHECKING:
 # DIC-17 default thresholds
 DEFAULT_CRUX_LOAD_BEARING_THRESHOLD = 0.6
 DEFAULT_DELTA_LOSS_THRESHOLD = -10.0
+DEFAULT_DECAY_INTEGRITY_THRESHOLD: float = 0.7
 MAX_BODY_STATEMENT_CHARS = 800
 
 
@@ -52,7 +54,8 @@ MAX_BODY_STATEMENT_CHARS = 800
 class FollowupProposal:
     """A proposed bounded follow-up issue.
 
-    - ``source_kind``: ``"crux"``, ``"failed_claim"``, or ``"coherence_issue"``
+    - ``source_kind``: ``"crux"``, ``"failed_claim"``, ``"coherence_issue"``,
+      or ``"decay_signal"``
     - ``source_key``: stable dedup key; callers should skip proposals
       whose source_key they have already filed
     - ``labels``: intentionally excludes ``boss-ready`` by default;
@@ -72,7 +75,7 @@ class FollowupProposal:
     provenance: dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        if self.source_kind not in {"crux", "failed_claim", "coherence_issue"}:
+        if self.source_kind not in {"crux", "failed_claim", "coherence_issue", "decay_signal"}:
             raise ValueError(f"unsupported source_kind: {self.source_kind!r}")
         if not str(self.source_key).strip():
             raise ValueError("source_key must be non-empty")
@@ -422,13 +425,113 @@ def propose_followup_for_coherence_issue(
     )
 
 
+# ---------------------------------------------------------------------------
+# Decay signal → proposal  (DIC-20 → DIC-17 bridge)
+# ---------------------------------------------------------------------------
+
+
+def propose_followup_for_decay_signal(
+    signal: "DecaySignal",
+    *,
+    unit_source_path: str = "",
+    integrity_threshold: float = DEFAULT_DECAY_INTEGRITY_THRESHOLD,
+    extra_labels: tuple[str, ...] = (),
+) -> FollowupProposal | None:
+    """Propose exactly one bounded follow-up issue for a decayed code unit, or None.
+
+    Returns ``None`` when the unit is healthy enough or when the recommended
+    action is ``"report_only"`` — report-only decay does not warrant a
+    bounded work proposal; only ``"repair_required"`` or ``"fail_closed"``
+    actions combined with an integrity score below ``integrity_threshold``
+    produce a proposal.
+
+    Gated on ``ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED`` by the caller;
+    this function itself is always safe to call.
+
+    Advances DIC-17 (#6027) and extends DIC-20 (#6031) with a follow-up
+    feed path.
+    """
+    if not (0.0 <= integrity_threshold <= 1.0):
+        raise ValueError("integrity_threshold must be in [0, 1]")
+    if signal.integrity_score >= integrity_threshold:
+        return None
+    if signal.recommended_action == "report_only":
+        return None
+
+    urgency = "⚠ fail-closed" if signal.recommended_action == "fail_closed" else "repair required"
+    title = f"[DIC-20→DIC-17] Repair decayed proof unit: {signal.code_unit_id[:70]}"
+    if len(title) > 140:
+        title = title[:139] + "…"
+
+    body_lines = [
+        "## Goal",
+        f"Repair an epistemic-decayed proof-carrying code unit ({urgency}).",
+        "",
+        "## Decay signal",
+        f"- code_unit_id: `{signal.code_unit_id}`",
+        f"- integrity_score: {signal.integrity_score:.3f} (threshold: < {integrity_threshold:.3f})",
+        f"- recommended_action: **{signal.recommended_action}**",
+    ]
+    if unit_source_path:
+        body_lines.append(f"- source_path: `{unit_source_path}`")
+
+    if signal.reasons:
+        body_lines.extend(["", "## Decay reasons"])
+        for reason in signal.reasons:
+            detail = _truncate(reason.detail, 200)
+            line = f"- [{reason.kind}] {detail}"
+            if reason.claim_id:
+                line += f" (claim: `{reason.claim_id}`)"
+            if reason.crux_id:
+                line += f" (crux: `{reason.crux_id}`)"
+            body_lines.append(line)
+
+    body_lines.extend(
+        [
+            "",
+            "## Provenance",
+            "- source: DIC-20 epistemic decay monitor → DIC-17 follow-up bridge",
+            f"- code_unit_id: {signal.code_unit_id}",
+            "",
+            "## Queue policy",
+            "This issue is a DIC-17 proposal. It MUST NOT carry `boss-ready` unless the "
+            "current tranche in `docs/status/NEXT_STEPS_CANONICAL.md` explicitly permits "
+            "it. The proof-first reconciler in `scripts/reconcile_proof_first_queue.py` "
+            "will strip the label if it is added outside the permitted lane.",
+        ]
+    )
+
+    labels = tuple(sorted({"epistemic", "decay", "proof-unit", *extra_labels} - {"boss-ready"}))
+    source_key = _source_key("decay_signal", signal.code_unit_id)
+
+    return FollowupProposal(
+        source_kind="decay_signal",
+        source_key=source_key,
+        title=title,
+        body="\n".join(body_lines),
+        labels=labels,
+        rationale=(
+            f"integrity_score={signal.integrity_score:.3f} < {integrity_threshold:.3f}; "
+            f"action={signal.recommended_action}"
+        ),
+        provenance={
+            "code_unit_id": signal.code_unit_id,
+            "integrity_score": round(signal.integrity_score, 6),
+            "recommended_action": signal.recommended_action,
+            "reason_kinds": [r.kind for r in signal.reasons],
+        },
+    )
+
+
 __all__ = [
     "DEFAULT_CRUX_LOAD_BEARING_THRESHOLD",
+    "DEFAULT_DECAY_INTEGRITY_THRESHOLD",
     "DEFAULT_DELTA_LOSS_THRESHOLD",
     "FollowupProposal",
     "MAX_BODY_STATEMENT_CHARS",
     "propose_followup_for_coherence_issue",
     "propose_followup_for_crux",
     "propose_followup_for_cruxset",
+    "propose_followup_for_decay_signal",
     "propose_followup_for_failed_claim",
 ]

--- a/tests/epistemic/test_dic17_decay_bridge.py
+++ b/tests/epistemic/test_dic17_decay_bridge.py
@@ -154,9 +154,7 @@ class TestDecaySignalQueueGovernance:
 
     def test_extra_labels_merged_without_boss_ready(self) -> None:
         sig = _signal(integrity_score=0.5)
-        p = propose_followup_for_decay_signal(
-            sig, extra_labels=("priority-p1", "boss-ready")
-        )
+        p = propose_followup_for_decay_signal(sig, extra_labels=("priority-p1", "boss-ready"))
         assert p is not None
         assert "priority-p1" in p.labels
         assert "boss-ready" not in p.labels
@@ -175,12 +173,8 @@ class TestDecaySignalQueueGovernance:
         assert p1.source_key == p2.source_key
 
     def test_different_units_give_different_source_keys(self) -> None:
-        p1 = propose_followup_for_decay_signal(
-            _signal(code_unit_id="unit.a", integrity_score=0.3)
-        )
-        p2 = propose_followup_for_decay_signal(
-            _signal(code_unit_id="unit.b", integrity_score=0.3)
-        )
+        p1 = propose_followup_for_decay_signal(_signal(code_unit_id="unit.a", integrity_score=0.3))
+        p2 = propose_followup_for_decay_signal(_signal(code_unit_id="unit.b", integrity_score=0.3))
         assert p1 is not None and p2 is not None
         assert p1.source_key != p2.source_key
 

--- a/tests/epistemic/test_dic17_decay_bridge.py
+++ b/tests/epistemic/test_dic17_decay_bridge.py
@@ -1,0 +1,194 @@
+"""Tests for DIC-17 × DIC-20 bridge: propose_followup_for_decay_signal.
+
+Flag-gated default OFF. No live queue effect.
+Advances: DIC-17 (#6027) — decay signal → follow-up bridge.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.epistemic.decay_monitor import DecayReason, DecaySignal
+from aragora.epistemic.followup import (
+    DEFAULT_DECAY_INTEGRITY_THRESHOLD,
+    FollowupProposal,
+    propose_followup_for_decay_signal,
+)
+
+
+def _signal(
+    code_unit_id: str = "test.unit",
+    integrity_score: float = 0.5,
+    recommended_action: str = "repair_required",
+    reasons: list[DecayReason] | None = None,
+) -> DecaySignal:
+    return DecaySignal(
+        code_unit_id=code_unit_id,
+        integrity_score=integrity_score,
+        recommended_action=recommended_action,
+        reasons=reasons or [],
+    )
+
+
+class TestDecaySignalFilteringThreshold:
+    def test_above_threshold_returns_none(self) -> None:
+        sig = _signal(integrity_score=0.95, recommended_action="repair_required")
+        assert propose_followup_for_decay_signal(sig) is None
+
+    def test_exactly_at_threshold_returns_none(self) -> None:
+        sig = _signal(
+            integrity_score=DEFAULT_DECAY_INTEGRITY_THRESHOLD,
+            recommended_action="repair_required",
+        )
+        assert propose_followup_for_decay_signal(sig) is None
+
+    def test_below_threshold_report_only_returns_none(self) -> None:
+        sig = _signal(integrity_score=0.3, recommended_action="report_only")
+        assert propose_followup_for_decay_signal(sig) is None
+
+    def test_below_threshold_repair_required_produces_proposal(self) -> None:
+        sig = _signal(integrity_score=0.5, recommended_action="repair_required")
+        proposal = propose_followup_for_decay_signal(sig)
+        assert proposal is not None
+        assert isinstance(proposal, FollowupProposal)
+
+    def test_below_threshold_fail_closed_produces_proposal(self) -> None:
+        sig = _signal(integrity_score=0.2, recommended_action="fail_closed")
+        proposal = propose_followup_for_decay_signal(sig)
+        assert proposal is not None
+
+    def test_custom_threshold_higher_triggers_proposal(self) -> None:
+        sig = _signal(integrity_score=0.85, recommended_action="repair_required")
+        # default threshold (0.7) → None because 0.85 >= 0.7
+        assert propose_followup_for_decay_signal(sig) is None
+        # custom threshold 0.9 → proposal because 0.85 < 0.9
+        proposal = propose_followup_for_decay_signal(sig, integrity_threshold=0.9)
+        assert proposal is not None
+
+    def test_invalid_threshold_raises(self) -> None:
+        sig = _signal()
+        with pytest.raises(ValueError, match="integrity_threshold"):
+            propose_followup_for_decay_signal(sig, integrity_threshold=1.5)
+
+
+class TestDecaySignalProposalShape:
+    def _make(self, **kwargs: object) -> FollowupProposal:
+        sig = _signal(**kwargs)  # type: ignore[arg-type]
+        p = propose_followup_for_decay_signal(sig, integrity_threshold=0.9)
+        assert p is not None
+        return p
+
+    def test_source_kind_is_decay_signal(self) -> None:
+        p = self._make()
+        assert p.source_kind == "decay_signal"
+
+    def test_title_contains_unit_id(self) -> None:
+        p = propose_followup_for_decay_signal(
+            _signal(code_unit_id="my.proof.unit", integrity_score=0.5),
+        )
+        assert p is not None
+        assert "my.proof.unit" in p.title
+
+    def test_body_contains_integrity_score(self) -> None:
+        sig = _signal(integrity_score=0.42, recommended_action="repair_required")
+        p = propose_followup_for_decay_signal(sig)
+        assert p is not None
+        assert "0.42" in p.body
+
+    def test_fail_closed_urgency_in_body(self) -> None:
+        sig = _signal(integrity_score=0.3, recommended_action="fail_closed")
+        p = propose_followup_for_decay_signal(sig)
+        assert p is not None
+        assert "fail-closed" in p.body
+
+    def test_repair_required_urgency_in_body(self) -> None:
+        sig = _signal(integrity_score=0.5, recommended_action="repair_required")
+        p = propose_followup_for_decay_signal(sig)
+        assert p is not None
+        assert "repair required" in p.body
+
+    def test_reasons_listed_in_body(self) -> None:
+        reasons = [
+            DecayReason(kind="failed_claim", detail="Claim X failed", claim_id="claim_abc"),
+            DecayReason(kind="unresolved_crux", detail="Crux Y open", crux_id="crux_xyz"),
+        ]
+        sig = _signal(integrity_score=0.4, reasons=reasons)
+        p = propose_followup_for_decay_signal(sig)
+        assert p is not None
+        assert "failed_claim" in p.body
+        assert "claim_abc" in p.body
+        assert "unresolved_crux" in p.body
+        assert "crux_xyz" in p.body
+
+    def test_unit_source_path_in_body_when_provided(self) -> None:
+        sig = _signal(integrity_score=0.3)
+        p = propose_followup_for_decay_signal(sig, unit_source_path="aragora/proof/unit.py")
+        assert p is not None
+        assert "aragora/proof/unit.py" in p.body
+
+    def test_source_path_absent_from_body_when_omitted(self) -> None:
+        sig = _signal(integrity_score=0.3)
+        p = propose_followup_for_decay_signal(sig)
+        assert p is not None
+        assert "source_path" not in p.body
+
+
+class TestDecaySignalQueueGovernance:
+    def test_boss_ready_never_in_labels(self) -> None:
+        sig = _signal(integrity_score=0.1, recommended_action="fail_closed")
+        p = propose_followup_for_decay_signal(sig)
+        assert p is not None
+        assert "boss-ready" not in p.labels
+
+    def test_epistemic_label_always_present(self) -> None:
+        sig = _signal(integrity_score=0.5)
+        p = propose_followup_for_decay_signal(sig)
+        assert p is not None
+        assert "epistemic" in p.labels
+
+    def test_decay_label_always_present(self) -> None:
+        sig = _signal(integrity_score=0.5)
+        p = propose_followup_for_decay_signal(sig)
+        assert p is not None
+        assert "decay" in p.labels
+
+    def test_extra_labels_merged_without_boss_ready(self) -> None:
+        sig = _signal(integrity_score=0.5)
+        p = propose_followup_for_decay_signal(
+            sig, extra_labels=("priority-p1", "boss-ready")
+        )
+        assert p is not None
+        assert "priority-p1" in p.labels
+        assert "boss-ready" not in p.labels
+
+    def test_queue_policy_in_body(self) -> None:
+        sig = _signal(integrity_score=0.3)
+        p = propose_followup_for_decay_signal(sig)
+        assert p is not None
+        assert "MUST NOT carry `boss-ready`" in p.body
+
+    def test_source_key_is_deterministic(self) -> None:
+        sig = _signal(code_unit_id="stable.unit", integrity_score=0.3)
+        p1 = propose_followup_for_decay_signal(sig)
+        p2 = propose_followup_for_decay_signal(sig)
+        assert p1 is not None and p2 is not None
+        assert p1.source_key == p2.source_key
+
+    def test_different_units_give_different_source_keys(self) -> None:
+        p1 = propose_followup_for_decay_signal(
+            _signal(code_unit_id="unit.a", integrity_score=0.3)
+        )
+        p2 = propose_followup_for_decay_signal(
+            _signal(code_unit_id="unit.b", integrity_score=0.3)
+        )
+        assert p1 is not None and p2 is not None
+        assert p1.source_key != p2.source_key
+
+    def test_provenance_has_expected_keys(self) -> None:
+        sig = _signal(code_unit_id="prov.unit", integrity_score=0.4)
+        p = propose_followup_for_decay_signal(sig)
+        assert p is not None
+        assert p.provenance["code_unit_id"] == "prov.unit"
+        assert "integrity_score" in p.provenance
+        assert "recommended_action" in p.provenance
+        assert "reason_kinds" in p.provenance


### PR DESCRIPTION
## Slice

Adds `propose_followup_for_decay_signal` to the DIC-17 follow-up module, bridging DIC-20 `DecaySignal` output into bounded `FollowupProposal` objects. Previously `followup.py` handled `crux`, `failed_claim`, and `coherence_issue` sources but had no path from the epistemic decay monitor; this PR closes that gap.

When a `ProofCarryingCodeUnit`'s integrity score drops below a configurable threshold **and** the recommended action is `repair_required` or `fail_closed` (not `report_only`), the bridge emits a single bounded `FollowupProposal` with reasons, source path, and dedup key.

## Gating

- Default: **OFF** — `ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED` is checked by the caller; this function is safe to call unconditionally
- Live queue effect: **none** — proposals are data structures; no issue filing, no queue writes
- Advances issue: #6027 (DIC-17), #6031 (DIC-20)

## Tests

- `TestDecaySignalFilteringThreshold` (7 tests): integrity ≥ threshold → None; report_only → None; repair_required / fail_closed below threshold → proposal; custom threshold; invalid threshold raises
- `TestDecaySignalProposalShape` (8 tests): source_kind, title content, integrity score in body, urgency strings, reasons list with claim/crux IDs, source_path opt-in/omit
- `TestDecaySignalQueueGovernance` (8 tests): boss-ready never in labels; epistemic + decay labels always present; extra labels merged with boss-ready stripped; queue policy in body; deterministic source_key; different units give different keys; provenance keys

## Validation

- `pytest tests/epistemic/test_dic17_decay_bridge.py` — **23 passed** in 0.10 s
- `python -m py_compile aragora/epistemic/followup.py` — clean
- `python -m py_compile tests/epistemic/test_dic17_decay_bridge.py` — clean
- No changes to boss loop, dispatch, swarm supervisor, or benchmark corpus

## Out of scope

- CLI integration (e.g. `--emit-decay-proposals` flag on `dic20_decay_monitor.py`) — natural follow-on once this bridge lands
- Batch evaluation across all units in a manifest directory — the decay monitor CLI already surfaces `DecaySignal` objects; callers can iterate and call this bridge per signal
- Live filing to GitHub Issues — remains behind the explicit `--file-issues` + flag guard in the follow-up CLI (unchanged)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MdYnxJvsevsVpCesqzREHZ)_