### PR TITLE
fix(settle-one): honor effective required check gate

### DIFF
--- a/scripts/settle_one_pr.py
+++ b/scripts/settle_one_pr.py
@@ -158,6 +158,24 @@ def _is_green_summary(summary: str) -> bool:
     return "green" in lower and "failing" not in lower and "pending" not in lower
 
 
+def _effective_check_summary(entry: dict[str, Any]) -> str:
+    check_surfaces = entry.get("check_surfaces")
+    if not isinstance(check_surfaces, dict):
+        return str(entry.get("checks_summary", ""))
+    effective_gate = check_surfaces.get("effective_gate")
+    if isinstance(effective_gate, dict):
+        source = str(effective_gate.get("source", "") or "")
+        summary = str(effective_gate.get("summary", "") or "")
+        if source and summary:
+            return summary
+    required_gate = check_surfaces.get("required_pr_checks")
+    if isinstance(required_gate, dict) and bool(required_gate.get("gate_selected")):
+        summary = str(required_gate.get("summary", "") or "")
+        if summary:
+            return summary
+    return str(entry.get("checks_summary", ""))
+
+
 def _entry_by_pr(packet: dict[str, Any], pr_number: int) -> dict[str, Any] | None:
     for entry in packet.get("entries") or []:
         if isinstance(entry, dict) and _entry_pr(entry) == pr_number:
@@ -694,7 +712,7 @@ def entry_blockers(entry: dict[str, Any]) -> list[str]:
         blockers.append("requires_human_risk_settlement=true")
     if bool(entry.get("unresolved_dissent")):
         blockers.append("unresolved_dissent=true")
-    summary = str(entry.get("checks_summary", ""))
+    summary = _effective_check_summary(entry)
     if "failing" in summary.lower():
         blockers.append(f"checks failing: {summary}")
     if "pending" in summary.lower():

--- a/scripts/settle_one_pr.py
+++ b/scripts/settle_one_pr.py
@@ -733,6 +733,13 @@ def evidence_summary(entry: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def evidence_blockers(summary: dict[str, Any]) -> list[str]:
+    blockers = [str(reason) for reason in summary.get("missing_model_quorum") or []]
+    if summary.get("missing_focused_dogfood"):
+        blockers.append("focused adversarial dogfood evidence is required")
+    return blockers
+
+
 def owner_blockers(payload: Any) -> list[str]:
     if not isinstance(payload, dict):
         return []
@@ -1500,6 +1507,9 @@ def build_report(
     for item in report["validation"]:
         if item.get("status") == "blocked":
             blockers.append(f"validation failed: {item.get('command')}")
+
+    if blockers:
+        blockers.extend(evidence_blockers(report["evidence"]))
 
     if (
         not blockers

--- a/tests/scripts/test_settle_one_pr.py
+++ b/tests/scripts/test_settle_one_pr.py
@@ -1402,6 +1402,34 @@ def test_tier3_or_human_risk_is_report_only() -> None:
     assert "requires_human_risk_settlement=true" in blockers
 
 
+def test_entry_blockers_use_effective_required_checks_gate() -> None:
+    entry = _entry(
+        1005,
+        status="satisfied",
+        verdict="admin_squash_allowed",
+        admin_squash_allowed=True,
+        reasons=["bounded helper reliability surface"],
+        checks_summary="2 pending / 21 total",
+    )
+    entry["check_surfaces"] = {
+        "effective_gate": {
+            "source": "required_pr_checks",
+            "summary": "6/6 required green (required PR checks)",
+        },
+        "required_pr_checks": {
+            "available": True,
+            "gate_selected": True,
+            "summary": "6/6 required green",
+            "pending": [],
+            "failing_or_cancelled": [],
+        },
+    }
+
+    blockers = entry_blockers(entry)
+
+    assert blockers == []
+
+
 def test_owner_payload_blocks_active_owner() -> None:
     blockers = owner_blockers(
         {

--- a/tests/scripts/test_settle_one_pr.py
+++ b/tests/scripts/test_settle_one_pr.py
@@ -1473,6 +1473,62 @@ def test_missing_evidence_yields_ready_for_minimum_evidence() -> None:
     assert report["recursive_best_next_prompt"].endswith(CONVERGENCE_SENTENCE)
 
 
+def test_draft_pr_does_not_hide_missing_evidence_blockers(monkeypatch) -> None:
+    entry = _entry(
+        1005,
+        reasons=[
+            "live automation surface",
+            "model quorum incomplete: 0/2 signal(s)",
+            "focused adversarial dogfood evidence is required",
+        ],
+    )
+
+    def fake_run_json(args, *, cwd, timeout=120):
+        command = " ".join(args)
+        result = {"command": command, "returncode": 0, "stdout": "{}", "stderr": ""}
+        if args[:3] == ["python3", "scripts/agent_bridge.py", "operator-snapshot"]:
+            return {"active_owned_prs": []}, result
+        if args[:2] == ["python3", "scripts/identify_lane_owner.py"]:
+            return {}, result
+        if args[:2] == ["python3", "scripts/read_operator_steering.py"]:
+            return {}, result
+        if args[:3] == ["gh", "pr", "view"]:
+            return {
+                "headRefOid": entry["head_sha"],
+                "baseRefName": "main",
+                "isDraft": True,
+                "mergeable": "MERGEABLE",
+                "mergeStateStatus": "CLEAN",
+                "statusCheckRollup": [],
+            }, result
+        if args[:2] == ["gh", "api"] and "protection/required_status_checks" in args[2]:
+            return {"checks": []}, result
+        if args[:2] == ["gh", "api"] and "check-runs" in args[2]:
+            return {"check_runs": []}, result
+        if args[:3] == ["gh", "pr", "checks"]:
+            return [], result
+        raise AssertionError(command)
+
+    monkeypatch.setattr(settle_one_pr, "_run_json", fake_run_json)
+
+    report = build_report(
+        _packet(entry),
+        cwd=Path.cwd(),
+        state_root=Path.cwd(),
+        explicit_pr=1005,
+        exclude_prs=set(),
+        live=True,
+        validate=False,
+    )
+
+    assert report["status"] == "blocked"
+    assert report["blockers"] == [
+        "PR is draft",
+        "model quorum incomplete: 0/2 signal(s)",
+        "focused adversarial dogfood evidence is required",
+    ]
+
+
 def test_no_candidate_report_includes_actionable_diagnostics() -> None:
     report = build_report(
         _packet(


### PR DESCRIPTION
## Summary
- teaches settle_one_pr.py to prefer merge-packet's selected effective required-check gate before falling back to full PR rollup summary
- prevents non-required pending rollup rows from becoming false checks pending blockers when branch-protection required checks are green
- keeps fail-closed behavior for pending/failing effective required-check gates

## Validation
- PYTHONDONTWRITEBYTECODE=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_settle_one_pr.py -q (58 passed)
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/settle_one_pr.py tests/scripts/test_settle_one_pr.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/settle_one_pr.py tests/scripts/test_settle_one_pr.py
- git diff --check origin/main...HEAD
- bash scripts/automation_pr_preflight.sh --json origin/main HEAD (status=ok)
- /Users/armand/.pyenv/versions/3.11.11/bin/python scripts/nomic_ci_test_selector.py --changed-files scripts/settle_one_pr.py tests/scripts/test_settle_one_pr.py --dry-run (selected tests/scripts/test_settle_one_pr.py)

## Governance
This is a read-only steward/reporting helper fix. It does not settle, mark ready, merge, rerun CI, post comments, alter branch protection, or change required-check authority. It aligns settle_one_pr.py with merge-packet's selected required-check gate while preserving fail-closed behavior when that effective gate is pending or failing.