### PR TITLE
fix(types): guard missing synthesis output

### DIFF
--- a/aragora/debate/phases/synthesis_generator.py
+++ b/aragora/debate/phases/synthesis_generator.py
@@ -159,7 +159,7 @@ class SynthesisGenerator:
                     synthesizer.generate(user_prompt),
                     timeout=60.0,
                 )
-            if synthesis is None:
+            if opus_synthesis is None:
                 raise RuntimeError("synthesis agent returned no output")
             synthesis = await self._ensure_complete_synthesis(
                 ctx=ctx,
@@ -195,7 +195,7 @@ class SynthesisGenerator:
                         synthesizer.generate(user_prompt),
                         timeout=30.0,
                     )
-                if synthesis is None:
+                if sonnet_synthesis is None:
                     raise RuntimeError("fallback synthesis agent returned no output")
                 synthesis = await self._ensure_complete_synthesis(
                     ctx=ctx,

--- a/aragora/debate/phases/synthesis_generator.py
+++ b/aragora/debate/phases/synthesis_generator.py
@@ -159,6 +159,8 @@ class SynthesisGenerator:
                     synthesizer.generate(user_prompt),
                     timeout=60.0,
                 )
+            if synthesis is None:
+                raise RuntimeError("synthesis agent returned no output")
             synthesis = await self._ensure_complete_synthesis(
                 ctx=ctx,
                 synthesizer=synthesizer,
@@ -193,6 +195,8 @@ class SynthesisGenerator:
                         synthesizer.generate(user_prompt),
                         timeout=30.0,
                     )
+                if synthesis is None:
+                    raise RuntimeError("fallback synthesis agent returned no output")
                 synthesis = await self._ensure_complete_synthesis(
                     ctx=ctx,
                     synthesizer=synthesizer,

--- a/tests/debate/phases/test_synthesis_generator.py
+++ b/tests/debate/phases/test_synthesis_generator.py
@@ -488,6 +488,62 @@ class TestGenerateMandatorySynthesis:
         assert ctx.result.final_answer == "Generated synthesis"
 
     @pytest.mark.asyncio
+    async def test_opus_output_does_not_fall_through_to_combined(self):
+        """Non-empty Opus output should be accepted as synthesis."""
+        ctx = MockDebateContext()
+        ctx.proposals = {"agent1": "Proposal 1", "agent2": "Proposal 2"}
+
+        gen = SynthesisGenerator()
+
+        with (
+            patch("aragora.utils.env.is_offline_mode", return_value=False),
+            patch.object(gen, "_anthropic_synthesis_available", return_value=True),
+            patch("aragora.agents.api_agents.anthropic.AnthropicAPIAgent") as mock_agent_class,
+            patch.object(
+                gen, "_combine_proposals_as_synthesis", return_value="Combined synthesis"
+            ) as combine,
+        ):
+            mock_agent = MagicMock()
+            mock_agent.generate = AsyncMock(return_value="Opus synthesis.")
+            mock_agent_class.return_value = mock_agent
+
+            result = await gen.generate_mandatory_synthesis(ctx)
+
+        assert result is True
+        assert ctx.result.synthesis == "Opus synthesis."
+        assert ctx.result.final_answer == "Opus synthesis."
+        combine.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sonnet_output_does_not_fall_through_to_combined(self):
+        """Non-empty fallback output should be accepted as synthesis."""
+        ctx = MockDebateContext()
+        ctx.proposals = {"agent1": "Proposal 1", "agent2": "Proposal 2"}
+
+        gen = SynthesisGenerator()
+
+        with (
+            patch("aragora.utils.env.is_offline_mode", return_value=False),
+            patch.object(gen, "_anthropic_synthesis_available", return_value=True),
+            patch("aragora.agents.api_agents.anthropic.AnthropicAPIAgent") as mock_agent_class,
+            patch.object(
+                gen, "_combine_proposals_as_synthesis", return_value="Combined synthesis"
+            ) as combine,
+        ):
+            opus_agent = MagicMock()
+            opus_agent.generate = AsyncMock(side_effect=RuntimeError("opus failed"))
+            sonnet_agent = MagicMock()
+            sonnet_agent.generate = AsyncMock(return_value="Sonnet synthesis.")
+            mock_agent_class.side_effect = [opus_agent, sonnet_agent]
+
+            result = await gen.generate_mandatory_synthesis(ctx)
+
+        assert result is True
+        assert ctx.result.synthesis == "Sonnet synthesis."
+        assert ctx.result.final_answer == "Sonnet synthesis."
+        combine.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_opus_timeout_falls_back_to_sonnet(self):
         """Timeout on Opus falls back to Sonnet."""
         ctx = MockDebateContext()


### PR DESCRIPTION
## Summary
- Restacks the remaining fresh-provider ask isolation value onto current `origin/main`.
- Carries the one still-unique synthesis output guard from the stale r4 handoff.
- Supersedes stale outbox request `open-pr-codex-fresh-provider-ask-isolation-primary-r3-20260527-2b0fa509` / r4 desired head `afb351e8791e2753cd47fd64063aadad60e3ec8c`.

## Validation
- `git diff --check origin/main...HEAD`
- `PYTHONDONTWRITEBYTECODE=1 /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/test_fresh_provider_ask_isolation.py -q -p no:rerunfailures -p no:cacheprovider` (9 passed)
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m mypy --ignore-missing-imports --follow-imports=skip --show-error-codes aragora/debate/phases/synthesis_generator.py`
- `RUFF_CACHE_DIR=/private/tmp/ruff-cache-fresh-provider-r5 /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check aragora/debate/phases/synthesis_generator.py tests/test_fresh_provider_ask_isolation.py`
- `RUFF_CACHE_DIR=/private/tmp/ruff-cache-fresh-provider-r5-format /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check aragora/debate/phases/synthesis_generator.py tests/test_fresh_provider_ask_isolation.py`
- `PYTHONDONTWRITEBYTECODE=1 /Users/armand/.pyenv/versions/3.11.11/bin/python -m aragora.cli.main ask --help`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- `git merge-tree --write-tree origin/main HEAD` -> `82287f1c95cad8c2e40780ee6be69cacd5ccf751`

## Notes
- Initial pytest attempt with `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` failed because async pytest plugins were disabled; rerun with the existing project plugin setup passed 9/9.
- Keep draft until normal review/check gates pass. Do not merge outside the exact-head Tier 0-2 gate process.
