### PR TITLE
fix(automation): fail closed on missing open PR state

### DIFF
--- a/scripts/reconcile_automation_outbox.py
+++ b/scripts/reconcile_automation_outbox.py
@@ -563,6 +563,8 @@ def _github_open_pr_state(root: Path, repo_name: str) -> tuple[dict[str, int], b
         open_prs = open_pr_heads(root, repo_name, "codex/")
     except Exception as exc:
         return {}, False, f"open PR fetch failed ({exc})"
+    if not isinstance(open_prs, dict):
+        return {}, False, "open PR fetch returned no usable data"
     return open_prs, True, f"{len(open_prs)} open codex/* PRs"
 
 

--- a/tests/scripts/test_reconcile_automation_outbox.py
+++ b/tests/scripts/test_reconcile_automation_outbox.py
@@ -116,6 +116,19 @@ def test_explicit_dry_run_flag_keeps_read_only_default(
     assert not (tmp_path / ".aragora" / "cleanup-state").exists()
 
 
+def test_github_open_pr_state_fails_closed_when_open_pr_fetch_returns_none(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    monkeypatch.setattr(mod, "check_github_cli_health", lambda *_args: _ready_github())
+    monkeypatch.setattr(mod, "open_pr_heads", lambda *_args: None)
+
+    open_prs, available, message = mod._github_open_pr_state(tmp_path, "synaptent/aragora")
+
+    assert open_prs == {}
+    assert available is False
+    assert message == "open PR fetch returned no usable data"
+
+
 def test_json_output_reports_reconciliation_without_human_preamble(
     tmp_path: Path,
     capsys: Any,


### PR DESCRIPTION
## Summary
- Make `reconcile_automation_outbox.py` fail closed when the GitHub open-PR fetch returns non-dict/no usable data, as seen under GraphQL rate limiting.
- Preserve ambiguous handoffs instead of crashing before the summary can be emitted.
- Add a focused regression test for the `None` open-PR state path.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTEST_ADDOPTS='-p no:cacheprovider' /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_reconcile_automation_outbox.py` (33 passed, 2 existing warnings)
- `RUFF_CACHE_DIR=/private/tmp/ruff-cache-reconcile-null /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/reconcile_automation_outbox.py tests/scripts/test_reconcile_automation_outbox.py`
- `RUFF_CACHE_DIR=/private/tmp/ruff-cache-reconcile-null-format /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/reconcile_automation_outbox.py tests/scripts/test_reconcile_automation_outbox.py`
- `git diff --check origin/main...HEAD`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- Live smoke under GraphQL rate limit before reset: `python3 scripts/reconcile_automation_outbox.py --repo /Users/armand/Development/aragora/.worktrees/reconcile-graphql-null-20260608 --state-root /Users/armand/Development/aragora/.aragora --base origin/main --repo-name synaptent/aragora --dry-run --json --summary-only` exited 0 and preserved ambiguous handoffs with `open PR state is unavailable` instead of crashing.

## Notes
- This is a small automation reliability fix for backlog/outbox reconciliation. Keep draft until normal checks/review gates pass; do not merge outside exact-head Tier 0-2 gate rules.
