### PR TITLE
fix(merge-arbiter): preserve breaker on operational faults

### DIFF
--- a/aragora/swarm/merge_arbiter.py
+++ b/aragora/swarm/merge_arbiter.py
@@ -250,8 +250,18 @@ def _run_gh(
     return gh_subprocess_run(args, timeout=timeout, write_op=write_op)
 
 
+class ArbiterOperationalError(RuntimeError):
+    """A genuine arbiter-operational fault (e.g. cannot list PRs), as opposed to a
+    PR merely not being ready. Only these faults feed the circuit breaker."""
+
+
 def _list_candidate_prs(config: MergeArbiterConfig) -> list[dict]:
-    """Return open PRs whose head branch matches any configured prefix."""
+    """Return open PRs whose head branch matches any configured prefix.
+
+    Raises ``ArbiterOperationalError`` when the underlying ``gh pr list`` call or
+    its JSON output cannot be obtained — a transient/operational fault that the
+    poll loop counts toward the circuit breaker. An *empty* list means the fetch
+    succeeded but no open PR matched a configured prefix (not a fault)."""
     prefixes = _normalize_branch_prefixes(config.branch_prefixes)
     result = _run_gh(
         [
@@ -268,13 +278,11 @@ def _list_candidate_prs(config: MergeArbiterConfig) -> list[dict]:
         ]
     )
     if result.returncode != 0:
-        logger.warning("gh pr list failed: %s", result.stderr.strip())
-        return []
+        raise ArbiterOperationalError(f"gh pr list failed: {result.stderr.strip()}")
     try:
         prs = json.loads(result.stdout)
-    except (json.JSONDecodeError, TypeError):
-        logger.warning("Failed to parse gh pr list output")
-        return []
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise ArbiterOperationalError("failed to parse gh pr list output") from exc
     candidates = []
     for pr in prs:
         branch = pr.get("headRefName", "")
@@ -660,29 +668,43 @@ class MergeArbiter:
 
         while time.monotonic() < deadline:
             summary.polls += 1
-            any_failure_this_poll = False
-            any_merge_this_poll = False
+            operational_fault_this_poll = False
             collected_this_poll = False
 
-            candidates = _list_candidate_prs(self.config)
+            try:
+                candidates = _list_candidate_prs(self.config)
+            except ArbiterOperationalError as exc:
+                operational_fault_this_poll = True
+                candidates = []
+                logger.warning("Poll %d: candidate fetch fault: %s", summary.polls, exc)
             logger.debug("Poll %d: %d candidate PRs", summary.polls, len(candidates))
 
             for pr in candidates:
-                result = _evaluate_pr(pr, self.config)
+                try:
+                    result = _evaluate_pr(pr, self.config)
+                except ArbiterOperationalError as exc:
+                    # Genuine evaluation fault (not "PR not ready"): count it, skip
+                    # this PR, keep polling the rest.
+                    operational_fault_this_poll = True
+                    logger.warning(
+                        "Poll %d: evaluation fault for #%s: %s",
+                        summary.polls,
+                        pr.get("number"),
+                        exc,
+                    )
+                    continue
                 if result.success:
                     summary.merged.append(result.pr_number)
-                    any_merge_this_poll = True
-                    logger.info(
-                        "PR #%d: %s (%s)",
-                        result.pr_number,
-                        result.reason,
-                        result.branch,
-                    )
+                    logger.info("PR #%d: %s (%s)", result.pr_number, result.reason, result.branch)
                 elif "failing" in result.reason or "failed" in result.reason:
+                    # A PR with failing/missing required checks is NOT ready — a
+                    # normal waiting state, NOT an arbiter fault. Record it for
+                    # reporting, but it must never trip the circuit breaker: a
+                    # normal all-red queue would otherwise stop the engine before
+                    # it can post the very evidence that turns those checks green.
                     summary.failed.append(result.pr_number)
-                    any_failure_this_poll = True
                     logger.info(
-                        "PR #%d skipped: %s (%s)",
+                        "PR #%d not ready: %s (%s)",
                         result.pr_number,
                         result.reason,
                         result.branch,
@@ -705,15 +727,16 @@ class MergeArbiter:
                 ):
                     collected_this_poll = True
 
-            # Circuit breaker: track consecutive polls with only failures
-            if any_failure_this_poll and not any_merge_this_poll:
+            # Circuit breaker: trip only on consecutive polls with a genuine
+            # operational fault (cannot list / evaluate), never on not-ready PRs.
+            if operational_fault_this_poll:
                 self._consecutive_failures += 1
             else:
                 self._consecutive_failures = 0
 
             if self._consecutive_failures >= self.config.max_consecutive_failures:
                 summary.stop_reason = (
-                    f"circuit breaker: {self._consecutive_failures} consecutive failure-only polls"
+                    f"circuit breaker: {self._consecutive_failures} consecutive operational faults"
                 )
                 logger.warning("Merge arbiter stopping: %s", summary.stop_reason)
                 break

--- a/tests/swarm/test_merge_arbiter.py
+++ b/tests/swarm/test_merge_arbiter.py
@@ -11,6 +11,7 @@ import pytest
 from aragora.swarm.merge_arbiter import (
     AUTOMATION_REVIEWER_LOGINS,
     REQUIRED_CHECKS,
+    ArbiterOperationalError,
     ArbiterSummary,
     MergeArbiter,
     MergeArbiterConfig,
@@ -96,17 +97,19 @@ class TestListCandidatePrs:
         assert result[0]["number"] == 1
         assert result[1]["number"] == 2
 
-    def test_returns_empty_on_gh_failure(self):
+    def test_raises_operational_error_on_gh_failure(self):
         config = MergeArbiterConfig()
         with patch("aragora.swarm.merge_arbiter._run_gh") as mock_gh:
-            mock_gh.return_value = _make_gh_result(returncode=1, stderr="error")
-            assert _list_candidate_prs(config) == []
+            mock_gh.return_value = _make_gh_result(returncode=1, stderr="error connecting")
+            with pytest.raises(ArbiterOperationalError):
+                _list_candidate_prs(config)
 
-    def test_returns_empty_on_bad_json(self):
+    def test_raises_operational_error_on_bad_json(self):
         config = MergeArbiterConfig()
         with patch("aragora.swarm.merge_arbiter._run_gh") as mock_gh:
             mock_gh.return_value = _make_gh_result(stdout="not json")
-            assert _list_candidate_prs(config) == []
+            with pytest.raises(ArbiterOperationalError):
+                _list_candidate_prs(config)
 
 
 # ---------------------------------------------------------------------------
@@ -455,11 +458,14 @@ class TestEvaluatePrDraft:
 
 class TestCircuitBreaker:
     @pytest.mark.asyncio
-    async def test_stops_after_consecutive_failures(self):
+    async def test_not_ready_prs_never_trip_the_breaker(self):
+        # A queue of PRs with failing required checks (the common all-red state,
+        # incl. PRs waiting on the quorum check) must NOT stop the engine — else
+        # the arbiter would stop before posting the evidence that turns them green.
         config = MergeArbiterConfig(
             max_consecutive_failures=3,
-            poll_interval_seconds=0.01,
-            max_runtime_hours=0.01,
+            poll_interval_seconds=0.001,
+            max_runtime_hours=0.0002,  # ~0.7s of polling
         )
         arbiter = MergeArbiter(config=config)
 
@@ -467,15 +473,11 @@ class TestCircuitBreaker:
         failing_checks = _all_passing_ready_checks()
         failing_checks["lint"] = "FAILURE"
 
-        call_count = 0
-
-        def fake_list(_cfg):
-            nonlocal call_count
-            call_count += 1
-            return [failing_pr]
-
         with (
-            patch("aragora.swarm.merge_arbiter._list_candidate_prs", side_effect=fake_list),
+            patch(
+                "aragora.swarm.merge_arbiter._list_candidate_prs",
+                return_value=[failing_pr],
+            ),
             patch(
                 "aragora.swarm.merge_arbiter._get_required_checks",
                 return_value=list(REQUIRED_CHECKS),
@@ -484,8 +486,29 @@ class TestCircuitBreaker:
         ):
             summary = await arbiter.run()
 
-        assert "circuit breaker" in summary.stop_reason
-        assert call_count == 3
+        assert "circuit breaker" not in summary.stop_reason
+        assert summary.stop_reason == "max runtime reached"
+        assert summary.merged == []
+        assert 1 in summary.failed  # recorded for reporting, but did not stop the engine
+
+    @pytest.mark.asyncio
+    async def test_consecutive_operational_faults_trip_the_breaker(self):
+        # Genuine operational faults (cannot list PRs) SHOULD fail closed.
+        config = MergeArbiterConfig(
+            max_consecutive_failures=3,
+            poll_interval_seconds=0.001,
+            max_runtime_hours=1.0,  # long; breaker should stop us well before this
+        )
+        arbiter = MergeArbiter(config=config)
+
+        with patch(
+            "aragora.swarm.merge_arbiter._list_candidate_prs",
+            side_effect=ArbiterOperationalError("gh pr list failed: error connecting"),
+        ):
+            summary = await arbiter.run()
+
+        assert "operational faults" in summary.stop_reason
+        assert summary.polls == 3
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Publishes the current-base Q401 restack for the merge-arbiter breaker repair.

This branch preserves the circuit breaker for real operational faults while recording ordinary not-ready PRs, such as failing required checks, as queue state that should not trip the breaker.

This is related to #7879, whose older branch remains open and blocked. This PR is a draft publication of the validated current-base replacement candidate, not a merge request in this run.

## Validation From Handoff

- `python3 -m pytest tests/swarm/test_merge_arbiter.py -q`: 40 passed
- `python3 -m py_compile aragora/swarm/merge_arbiter.py tests/swarm/test_merge_arbiter.py`: passed
- `python3 -m ruff check aragora/swarm/merge_arbiter.py tests/swarm/test_merge_arbiter.py`: passed
- `python3 -m ruff format --check aragora/swarm/merge_arbiter.py tests/swarm/test_merge_arbiter.py`: passed
- `git diff --check origin/main...HEAD && git diff --check`: passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`: preflight ok

## Harvest Notes

- Source handoff: `open-pr-codex-merge-arbiter-breaker-faults-primary-r2-20260608-2631fa24.json`
- Exact head: `2631fa24b02351137b77263f5ebb6b59b805e616`
- Branch-side work only; shared-root dirt was not touched.
