### PR TITLE
fix(benchmark-truth): reject inconsistent proxy counts

### DIFF
--- a/scripts/render_benchmark_truth_status.py
+++ b/scripts/render_benchmark_truth_status.py
@@ -267,18 +267,49 @@ def _render_issue_drafts(drafts: list[dict[str, Any]]) -> list[str]:
     ] or ["- none"]
 
 
+def _proxy_count(value: Any, *, field: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"proxy metric `{field}` must be an integer count")
+    if value < 0:
+        raise ValueError(f"proxy metric `{field}` must be non-negative")
+    return value
+
+
 def _normalize_proxy_metrics(payload: dict[str, Any]) -> dict[str, Any]:
     proxy_metrics = dict(payload)
     terminal_class_distribution = dict(proxy_metrics.get("terminal_class_distribution") or {})
 
-    if "unique_issues_neutral" not in proxy_metrics:
-        attempted = proxy_metrics.get("unique_issues_attempted")
-        succeeded = proxy_metrics.get("unique_issues_succeeded")
-        failed = proxy_metrics.get("unique_issues_failed")
-        if all(isinstance(value, (int, float)) for value in (attempted, succeeded, failed)):
-            proxy_metrics["unique_issues_neutral"] = max(
-                int(attempted) - int(succeeded) - int(failed),
-                0,
+    attempted = _proxy_count(
+        proxy_metrics.get("unique_issues_attempted"),
+        field="unique_issues_attempted",
+    )
+    succeeded = _proxy_count(
+        proxy_metrics.get("unique_issues_succeeded"),
+        field="unique_issues_succeeded",
+    )
+    failed = _proxy_count(
+        proxy_metrics.get("unique_issues_failed"),
+        field="unique_issues_failed",
+    )
+    if attempted is not None and succeeded is not None and failed is not None:
+        neutral = _proxy_count(
+            proxy_metrics.get("unique_issues_neutral"),
+            field="unique_issues_neutral",
+        )
+        expected_neutral = attempted - succeeded - failed
+        if expected_neutral < 0:
+            raise ValueError(
+                "proxy metrics inconsistent: unique_issues_succeeded + "
+                "unique_issues_failed exceeds unique_issues_attempted"
+            )
+        if neutral is None:
+            proxy_metrics["unique_issues_neutral"] = expected_neutral
+        elif neutral != expected_neutral:
+            raise ValueError(
+                "proxy metrics inconsistent: unique_issues_neutral must equal "
+                "unique_issues_attempted - unique_issues_succeeded - unique_issues_failed"
             )
 
     if "neutral_classes" not in proxy_metrics and terminal_class_distribution:

--- a/tests/scripts/test_render_benchmark_truth_status.py
+++ b/tests/scripts/test_render_benchmark_truth_status.py
@@ -363,6 +363,85 @@ def test_render_status_markdown_backfills_legacy_proxy_neutral_fields(tmp_path: 
     assert "`issue_already_resolved`: 4" in markdown
 
 
+def test_render_status_markdown_rejects_proxy_neutral_count_mismatch(
+    tmp_path: Path,
+) -> None:
+    corpus_path = _write_json(
+        tmp_path / "corpus.json",
+        {
+            "corpus_id": "tw-01-bounded-execution-v1",
+            "revision": 1,
+            "recorded_on": "2026-04-14",
+            "success_contract": "mergeable_pr_or_merged_pr",
+            "issues": [{"issue_id": 1064, "title": "Issue A"}],
+        },
+    )
+    latest_paths = mod.resolve_latest_paths(
+        corpus_path=corpus_path,
+        truth_root=tmp_path / "truth",
+        scorecard_root=tmp_path / "scorecards",
+    )
+
+    with pytest.raises(ValueError, match="unique_issues_neutral"):
+        mod.render_status_markdown(
+            corpus_path=corpus_path,
+            truth_path=latest_paths["truth_corpus_latest"],
+            scorecard_path=latest_paths["scorecard_corpus_latest"],
+            latest_paths=latest_paths,
+            truth_payload=_truth_payload(revision=1),
+            scorecard_payload={
+                **_scorecard_payload(revision=1),
+                "proxy_metrics": {
+                    "no_rescue_success_rate": 0.0,
+                    "unique_issues_attempted": 5,
+                    "unique_issues_succeeded": 1,
+                    "unique_issues_failed": 1,
+                    "unique_issues_neutral": 9,
+                    "total_ticks": 5,
+                },
+            },
+        )
+
+
+def test_render_status_markdown_rejects_proxy_success_failure_overflow(
+    tmp_path: Path,
+) -> None:
+    corpus_path = _write_json(
+        tmp_path / "corpus.json",
+        {
+            "corpus_id": "tw-01-bounded-execution-v1",
+            "revision": 1,
+            "recorded_on": "2026-04-14",
+            "success_contract": "mergeable_pr_or_merged_pr",
+            "issues": [{"issue_id": 1064, "title": "Issue A"}],
+        },
+    )
+    latest_paths = mod.resolve_latest_paths(
+        corpus_path=corpus_path,
+        truth_root=tmp_path / "truth",
+        scorecard_root=tmp_path / "scorecards",
+    )
+
+    with pytest.raises(ValueError, match="exceeds unique_issues_attempted"):
+        mod.render_status_markdown(
+            corpus_path=corpus_path,
+            truth_path=latest_paths["truth_corpus_latest"],
+            scorecard_path=latest_paths["scorecard_corpus_latest"],
+            latest_paths=latest_paths,
+            truth_payload=_truth_payload(revision=1),
+            scorecard_payload={
+                **_scorecard_payload(revision=1),
+                "proxy_metrics": {
+                    "no_rescue_success_rate": 0.0,
+                    "unique_issues_attempted": 1,
+                    "unique_issues_succeeded": 1,
+                    "unique_issues_failed": 1,
+                    "total_ticks": 2,
+                },
+            },
+        )
+
+
 def test_render_status_markdown_surfaces_stale_closed_corpus_issues(tmp_path: Path) -> None:
     corpus_path = _write_json(
         tmp_path / "corpus.json",


### PR DESCRIPTION
## Summary
- fail closed when benchmark-truth proxy issue totals contradict attempted/succeeded/failed counts
- preserve legacy neutral-count backfill when counts are internally consistent
- add renderer regressions for neutral mismatch and success/failure overflow

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_render_benchmark_truth_status.py -q
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/render_benchmark_truth_status.py tests/scripts/test_render_benchmark_truth_status.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/render_benchmark_truth_status.py tests/scripts/test_render_benchmark_truth_status.py
- git diff --check HEAD~1..HEAD
- /Users/armand/.pyenv/versions/3.11.11/bin/python scripts/render_benchmark_truth_status.py --output /private/tmp/aragora-benchmark-truth-proxy-count-guards-status.md
- bash scripts/automation_pr_preflight.sh origin/main HEAD