### PR TITLE
fix(automation): avoid eager publisher startup imports

### DIFF
--- a/scripts/automation_pr_preflight.sh
+++ b/scripts/automation_pr_preflight.sh
@@ -17,6 +17,7 @@ test_changes=""
 docs_only_changes=""
 forbidden_files=""
 rescue_publish_files=""
+publisher_startup_changes=""
 docs_only=false
 
 usage() {
@@ -49,6 +50,7 @@ emit_json() {
     export PREFLIGHT_DOCS_ONLY="${docs_only}"
     export PREFLIGHT_FORBIDDEN_FILES="${forbidden_files}"
     export PREFLIGHT_RESCUE_PUBLISH_FILES="${rescue_publish_files}"
+    export PREFLIGHT_PUBLISHER_STARTUP_CHANGES="${publisher_startup_changes}"
     python3 -c '
 import json
 import os
@@ -61,6 +63,7 @@ def lines(name: str) -> list[str]:
 
 source_changes = lines("PREFLIGHT_SOURCE_CHANGES")
 test_changes = lines("PREFLIGHT_TEST_CHANGES")
+publisher_startup_changes = lines("PREFLIGHT_PUBLISHER_STARTUP_CHANGES")
 python_sources = [path for path in source_changes if path.endswith(".py")]
 suggested_commands: list[str] = []
 if python_sources:
@@ -72,6 +75,16 @@ if python_sources:
 if test_changes:
     quoted_tests = " ".join(shlex.quote(path) for path in test_changes)
     suggested_commands.append(f"python3 -m pytest {quoted_tests} -q")
+if publisher_startup_changes:
+    suggested_commands.append(
+        "python3 -c \"import importlib; [importlib.import_module(module) "
+        "for module in ("
+        "'scripts.cache_codex_automation_github_status', "
+        "'scripts.publish_automation_handoffs', "
+        "'scripts.publish_codex_automation_branches', "
+        "'scripts.github_cli_health'"
+        ")]\""
+    )
 
 payload = {
     "base_ref": os.environ["PREFLIGHT_BASE_REF"],
@@ -172,6 +185,7 @@ fi
 
 source_changes="$(printf '%s\n' "${changed_files}" | grep -E '(^aragora/|^scripts/|^\.github/|^tests/).*\.(py|sh|ya?ml|toml|json|ts|tsx|js|jsx)$' || true)"
 test_changes="$(printf '%s\n' "${changed_files}" | grep -E '(^tests/|__tests__/|\.test\.|\.spec\.)' || true)"
+publisher_startup_changes="$(printf '%s\n' "${changed_files}" | grep -E '^scripts/(cache_codex_automation_github_status|github_app_auth_shim|github_cli_health|publish_automation_handoffs|publish_codex_automation_branches)\.py$' || true)"
 docs_only_changes="$(printf '%s\n' "${changed_files}" | grep -Ev '(^docs/|^docs-site/|\.md$)' || true)"
 if [[ -z "${docs_only_changes}" ]]; then
     docs_only=true

--- a/scripts/cache_codex_automation_github_status.py
+++ b/scripts/cache_codex_automation_github_status.py
@@ -27,14 +27,6 @@ import sys
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
-from scripts.github_cli_health import check_github_cli_health
-from scripts.publish_automation_handoffs import _open_boss_ready_count
-from scripts.publish_codex_automation_branches import (
-    CODEX_BRANCH_PREFIX,
-    _open_codex_pr_is_unhealthy,
-    _open_codex_prs,
-)
-
 UTC = timezone.utc
 DEFAULT_REPO = "synaptent/aragora"
 DEFAULT_LABELS = ("boss-ready",)
@@ -85,6 +77,31 @@ GITHUB_QUEUE_PRESERVED_KEYS = (
     "labels",
     "pressure",
 )
+CODEX_BRANCH_PREFIX = "codex/"
+
+
+def check_github_cli_health(repo_root: Path) -> Any:
+    from scripts.github_cli_health import check_github_cli_health as _check_github_cli_health
+
+    return _check_github_cli_health(repo_root)
+
+
+def _open_boss_ready_count(repo_root: Path, repo: str, labels: list[str]) -> int:
+    from scripts.publish_automation_handoffs import _open_boss_ready_count as impl
+
+    return impl(repo_root, repo, labels)
+
+
+def _open_codex_prs(repo_root: Path, repo: str) -> list[dict[str, Any]]:
+    from scripts.publish_codex_automation_branches import _open_codex_prs as impl
+
+    return impl(repo_root, repo)
+
+
+def _open_codex_pr_is_unhealthy(item: Mapping[str, Any]) -> bool:
+    from scripts.publish_codex_automation_branches import _open_codex_pr_is_unhealthy as impl
+
+    return impl(item)
 
 
 def _has_queue_state_dirs(state_root: Path) -> bool:

--- a/scripts/github_cli_health.py
+++ b/scripts/github_cli_health.py
@@ -71,9 +71,12 @@ def github_cli_env(
     if not prefer_app:
         return env
     try:
-        from aragora.swarm.github_app_auth import github_cli_env as app_github_cli_env
+        from scripts.github_app_auth_shim import github_cli_env as app_github_cli_env
     except Exception:  # pragma: no cover - fallback for partially bootstrapped script contexts
-        return env
+        try:
+            from github_app_auth_shim import github_cli_env as app_github_cli_env
+        except Exception:
+            return env
     return app_github_cli_env(env, prefer_app=True)
 
 

--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -105,30 +105,35 @@ STOPWORDS = {
     "with",
 }
 
-try:
-    from aragora.swarm.github_app_auth import gh_subprocess_run, github_cli_env
-except Exception:  # pragma: no cover - fallback for partially bootstrapped script contexts
 
-    def github_cli_env(
-        base_env: Mapping[str, str] | None = None,
-        *,
-        prefer_app: bool = True,
-    ) -> dict[str, str]:
+def github_cli_env(
+    base_env: Mapping[str, str] | None = None,
+    *,
+    prefer_app: bool = True,
+) -> dict[str, str]:
+    try:
+        from aragora.swarm.github_app_auth import github_cli_env as _github_cli_env
+    except Exception:  # pragma: no cover - fallback for partially bootstrapped script contexts
         return dict(os.environ if base_env is None else base_env)
+    return _github_cli_env(base_env, prefer_app=prefer_app)
 
-    def gh_subprocess_run(
-        args: Sequence[str],
-        *,
-        timeout: float = 30.0,
-        prefer_app: bool = True,
-        write_op: bool = False,
-        env: Mapping[str, str] | None = None,
-        max_retries: int = 3,
-        base_backoff: float = 5.0,
-        max_backoff: float = 600.0,
-        sleep: Callable[[float], None] | None = None,
-    ) -> subprocess.CompletedProcess[str]:
-        del prefer_app, write_op, max_retries, base_backoff, max_backoff, sleep
+
+def gh_subprocess_run(
+    args: Sequence[str],
+    *,
+    timeout: float = 30.0,
+    prefer_app: bool = True,
+    write_op: bool = False,
+    env: Mapping[str, str] | None = None,
+    max_retries: int = 3,
+    base_backoff: float = 5.0,
+    max_backoff: float = 600.0,
+    sleep: Callable[[float], None] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        from aragora.swarm.github_app_auth import gh_subprocess_run as _gh_subprocess_run
+    except Exception:  # pragma: no cover - fallback for partially bootstrapped script contexts
+        _ = (prefer_app, write_op, max_retries, base_backoff, max_backoff, sleep)
         return subprocess.run(
             ["gh", *list(args)],
             capture_output=True,
@@ -137,6 +142,17 @@ except Exception:  # pragma: no cover - fallback for partially bootstrapped scri
             env=dict(os.environ if env is None else env),
             check=False,
         )
+    return _gh_subprocess_run(
+        args,
+        timeout=timeout,
+        prefer_app=prefer_app,
+        write_op=write_op,
+        env=env,
+        max_retries=max_retries,
+        base_backoff=base_backoff,
+        max_backoff=max_backoff,
+        sleep=sleep,
+    )
 
 
 def _mute_stdout_after_broken_pipe() -> None:

--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -110,38 +110,89 @@ class OpenCodexPrLookupError(RuntimeError):
         self.cache_meta = cache_meta
 
 
-try:
-    from aragora.swarm.github_app_auth import gh_subprocess_run, github_cli_env
-except Exception:  # pragma: no cover - fallback for partially bootstrapped script contexts
+_GITHUB_APP_AUTH: tuple[Any, Any] | None = None
 
-    def github_cli_env(
-        base_env: Mapping[str, str] | None = None,
-        *,
-        prefer_app: bool = True,
-    ) -> dict[str, str]:
-        return dict(os.environ if base_env is None else base_env)
 
-    def gh_subprocess_run(
-        args: Sequence[str],
-        *,
-        timeout: float = 30.0,
-        prefer_app: bool = True,
-        write_op: bool = False,
-        env: Mapping[str, str] | None = None,
-        max_retries: int = 3,
-        base_backoff: float = 5.0,
-        max_backoff: float = 600.0,
-        sleep: Callable[[float], None] | None = None,
-    ) -> subprocess.CompletedProcess[str]:
-        del prefer_app, write_op, max_retries, base_backoff, max_backoff, sleep
-        return subprocess.run(
-            ["gh", *list(args)],
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-            env=dict(os.environ if env is None else env),
-            check=False,
-        )
+def _fallback_github_cli_env(
+    base_env: Mapping[str, str] | None = None,
+    *,
+    prefer_app: bool = True,
+) -> dict[str, str]:
+    del prefer_app
+    return dict(os.environ if base_env is None else base_env)
+
+
+def _fallback_gh_subprocess_run(
+    args: Sequence[str],
+    *,
+    timeout: float = 30.0,
+    prefer_app: bool = True,
+    write_op: bool = False,
+    env: Mapping[str, str] | None = None,
+    max_retries: int = 3,
+    base_backoff: float = 5.0,
+    max_backoff: float = 600.0,
+    sleep: Callable[[float], None] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    del prefer_app, write_op, max_retries, base_backoff, max_backoff, sleep
+    return subprocess.run(
+        ["gh", *list(args)],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env=dict(os.environ if env is None else env),
+        check=False,
+    )
+
+
+def _github_app_auth() -> tuple[Any, Any]:
+    global _GITHUB_APP_AUTH
+    if _GITHUB_APP_AUTH is None:
+        try:
+            from aragora.swarm.github_app_auth import (
+                gh_subprocess_run as loaded_gh_subprocess_run,
+                github_cli_env as loaded_github_cli_env,
+            )
+        except Exception:  # pragma: no cover - fallback for partially bootstrapped script contexts
+            _GITHUB_APP_AUTH = (_fallback_gh_subprocess_run, _fallback_github_cli_env)
+        else:
+            _GITHUB_APP_AUTH = (loaded_gh_subprocess_run, loaded_github_cli_env)
+    return _GITHUB_APP_AUTH
+
+
+def github_cli_env(
+    base_env: Mapping[str, str] | None = None,
+    *,
+    prefer_app: bool = True,
+) -> dict[str, str]:
+    _, loaded_github_cli_env = _github_app_auth()
+    return loaded_github_cli_env(base_env, prefer_app=prefer_app)
+
+
+def gh_subprocess_run(
+    args: Sequence[str],
+    *,
+    timeout: float = 30.0,
+    prefer_app: bool = True,
+    write_op: bool = False,
+    env: Mapping[str, str] | None = None,
+    max_retries: int = 3,
+    base_backoff: float = 5.0,
+    max_backoff: float = 600.0,
+    sleep: Callable[[float], None] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    loaded_gh_subprocess_run, _ = _github_app_auth()
+    return loaded_gh_subprocess_run(
+        args,
+        timeout=timeout,
+        prefer_app=prefer_app,
+        write_op=write_op,
+        env=env,
+        max_retries=max_retries,
+        base_backoff=base_backoff,
+        max_backoff=max_backoff,
+        sleep=sleep,
+    )
 
 
 @dataclass(frozen=True)

--- a/tests/scripts/test_cache_codex_automation_github_status.py
+++ b/tests/scripts/test_cache_codex_automation_github_status.py
@@ -1,12 +1,56 @@
 from __future__ import annotations
 
 import json
+import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
 import scripts.cache_codex_automation_github_status as mod
 import scripts.refresh_automation_status_cache as refresh_mod
 from scripts.github_cli_health import GitHubCLIHealth
+
+
+def _assert_subprocess_avoids_swarm_import(statement: str) -> None:
+    script = f"""
+import builtins
+
+attempts = []
+real_import = builtins.__import__
+
+
+def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+    if name.startswith("aragora.swarm"):
+        attempts.append(name)
+        raise ImportError(f"blocked eager import: {{name}}")
+    return real_import(name, globals, locals, fromlist, level)
+
+
+builtins.__import__ = guarded_import
+{statement}
+if attempts:
+    raise AssertionError(f"eager aragora.swarm imports: {{attempts!r}}")
+"""
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=Path(__file__).resolve().parents[2],
+        text=True,
+        capture_output=True,
+        timeout=15,
+    )
+
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+
+
+def test_cache_status_import_avoids_swarm_eager_import() -> None:
+    _assert_subprocess_avoids_swarm_import("import scripts.cache_codex_automation_github_status")
+
+
+def test_github_cli_health_prefers_auth_shim_without_swarm_import() -> None:
+    _assert_subprocess_avoids_swarm_import(
+        "from scripts.github_cli_health import github_cli_env\n"
+        "github_cli_env({'EXISTING': '1'}, prefer_app=True)"
+    )
 
 
 def test_build_status_uses_local_queue_when_github_unavailable(

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import sys
 from collections import Counter
 from datetime import datetime, timezone
 from pathlib import Path
@@ -148,6 +149,37 @@ def _repo_with_stale_outbox_head(tmp_path: Path) -> tuple[Path, str, str]:
     git("commit", "-am", "new")
     new_head = git("rev-parse", "HEAD")
     return repo, old_head, new_head
+
+
+def test_publish_handoffs_import_avoids_swarm_eager_import() -> None:
+    script = """
+import builtins
+
+attempts = []
+real_import = builtins.__import__
+
+
+def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+    if name.startswith("aragora.swarm"):
+        attempts.append(name)
+        raise ImportError(f"blocked eager import: {name}")
+    return real_import(name, globals, locals, fromlist, level)
+
+
+builtins.__import__ = guarded_import
+import scripts.publish_automation_handoffs
+if attempts:
+    raise AssertionError(f"eager aragora.swarm imports: {attempts!r}")
+"""
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=Path(__file__).resolve().parents[2],
+        text=True,
+        capture_output=True,
+        timeout=15,
+    )
+
+    assert proc.returncode == 0, proc.stderr or proc.stdout
 
 
 def test_load_handoffs_parses_structured_memory(tmp_path: Path) -> None:

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
@@ -61,6 +62,37 @@ def _worktree(
         dirty=dirty,
         active_session=active_session,
     )
+
+
+def test_branch_publisher_import_avoids_swarm_eager_import() -> None:
+    script = """
+import builtins
+
+attempts = []
+real_import = builtins.__import__
+
+
+def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+    if name.startswith("aragora.swarm"):
+        attempts.append(name)
+        raise ImportError(f"blocked eager import: {name}")
+    return real_import(name, globals, locals, fromlist, level)
+
+
+builtins.__import__ = guarded_import
+import scripts.publish_codex_automation_branches
+if attempts:
+    raise AssertionError(f"eager aragora.swarm imports: {attempts!r}")
+"""
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=Path(__file__).resolve().parents[2],
+        text=True,
+        capture_output=True,
+        timeout=15,
+    )
+
+    assert proc.returncode == 0, proc.stderr or proc.stdout
 
 
 def test_duplicate_patch_branches_skips_older_candidate(tmp_path: Path) -> None:

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -975,7 +975,9 @@ def test_publish_decisions_uses_remaining_open_pr_capacity(
     )
     monkeypatch.setattr(mod, "_existing_pr_number", lambda repo_root, repo, branch, base: None)
     monkeypatch.setattr(
-        mod, "_create_pr", lambda repo_root, repo, branch, base: next(created_numbers)
+        mod,
+        "_create_pr",
+        lambda repo_root, repo, branch, base, draft=False: next(created_numbers),
     )
     monkeypatch.setattr(
         mod, "_add_labels", lambda repo_root, repo, number, labels: calls.append(f"label:{number}")
@@ -1032,7 +1034,11 @@ def test_publish_decisions_records_publish_failures_and_continues(
     monkeypatch.setattr(mod, "_ensure_gh_auth", lambda repo_root: None)
     monkeypatch.setattr(mod, "_push_branch", fake_push)
     monkeypatch.setattr(mod, "_existing_pr_number", lambda repo_root, repo, branch, base: None)
-    monkeypatch.setattr(mod, "_create_pr", lambda repo_root, repo, branch, base: 2001)
+    monkeypatch.setattr(
+        mod,
+        "_create_pr",
+        lambda repo_root, repo, branch, base, draft=False: 2001,
+    )
     monkeypatch.setattr(
         mod, "_add_labels", lambda repo_root, repo, number, labels: calls.append(f"label:{number}")
     )


### PR DESCRIPTION
Publishes outbox handoff open-pr-codex-salvage-publisher-startup-preflight-20260608-f84f8a34.\n\nScope: automation publisher startup import repair plus preflight coverage.\n\nValidation before publication:\n- git diff --check origin/main...codex/salvage-publisher-startup-preflight-20260608\n- git merge-tree --write-tree origin/main codex/salvage-publisher-startup-preflight-20260608\n- bash scripts/automation_pr_preflight.sh origin/main codex/salvage-publisher-startup-preflight-20260608\n- git push pre-push hooks passed\n\nNo merge, ready transition, evidence collection, CI rerun, status mutation, or outbox archive is authorized by this publication step.