### PR TITLE
[DIC-16] CruxReceipt → Knowledge Mound ingestion bridge

### DIFF
--- a/aragora/epistemic/crux_km_bridge.py
+++ b/aragora/epistemic/crux_km_bridge.py
@@ -1,0 +1,113 @@
+"""CruxReceipt → Knowledge Mound ingestion bridge (DIC-16 / #6026).
+
+Flag-gated (``ARAGORA_CRUX_RECEIPT_ENABLED``): returns an empty result
+when unset — no KM writes, no queue mutations, no network calls.
+Advances issue #6026.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from aragora.epistemic.crux_receipt import CruxReceipt
+    from aragora.knowledge.unified.types import ConfidenceLevel, KnowledgeItem
+
+
+@dataclass
+class CruxKMIngestionResult:
+    """Typed outcome of a CruxReceipt → KM conversion. Empty when flag is off."""
+
+    receipt_id: str
+    debate_id: str
+    crux_count: int
+    items: list["KnowledgeItem"] = field(default_factory=list)
+
+    @property
+    def success(self) -> bool:
+        return len(self.items) > 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "receipt_id": self.receipt_id,
+            "debate_id": self.debate_id,
+            "crux_count": self.crux_count,
+            "items_produced": len(self.items),
+            "success": self.success,
+        }
+
+
+def crux_receipt_to_knowledge_items(receipt: "CruxReceipt") -> "CruxKMIngestionResult":
+    """Convert *receipt* cruxes into KnowledgeItems (empty when flag is off)."""
+    from aragora.epistemic.crux_receipt import crux_receipt_enabled
+
+    empty = CruxKMIngestionResult(
+        receipt_id=receipt.receipt_id,
+        debate_id=receipt.debate_id,
+        crux_count=len(receipt.cruxes),
+    )
+
+    if not crux_receipt_enabled():
+        return empty
+
+    if not receipt.cruxes:
+        return empty
+
+    from aragora.knowledge.unified.types import (
+        KnowledgeItem,
+        KnowledgeSource,
+    )
+
+    now = datetime.now(tz=timezone.utc)
+    items: list[KnowledgeItem] = []
+
+    for entry in receipt.cruxes:
+        confidence = _score_to_confidence(entry.load_bearing_score)
+        item = KnowledgeItem(
+            id=f"crux_km_{entry.crux_id}",
+            content=entry.statement,
+            source=KnowledgeSource.BELIEF,
+            source_id=entry.crux_id,
+            confidence=confidence,
+            created_at=now,
+            updated_at=now,
+            importance=round(entry.load_bearing_score, 4),
+            metadata={
+                "receipt_id": receipt.receipt_id,
+                "debate_id": receipt.debate_id,
+                "question": receipt.question,
+                "affected_claims": list(entry.affected_claims),
+                "contesting_agents": list(entry.contesting_agents),
+                "load_bearing_score": round(entry.load_bearing_score, 4),
+                "uncertainty_score": round(entry.uncertainty_score, 4),
+                "resolution_impact": round(entry.resolution_impact, 4),
+                "dic_track": "DIC-16",
+            },
+        )
+        items.append(item)
+
+    return CruxKMIngestionResult(
+        receipt_id=receipt.receipt_id,
+        debate_id=receipt.debate_id,
+        crux_count=len(receipt.cruxes),
+        items=items,
+    )
+
+
+def _score_to_confidence(score: float) -> "ConfidenceLevel":
+    # >= 0.75 → HIGH, >= 0.45 → MEDIUM, otherwise → LOW
+    from aragora.knowledge.unified.types import ConfidenceLevel
+
+    if score >= 0.75:
+        return ConfidenceLevel.HIGH
+    if score >= 0.45:
+        return ConfidenceLevel.MEDIUM
+    return ConfidenceLevel.LOW
+
+
+__all__ = [
+    "CruxKMIngestionResult",
+    "crux_receipt_to_knowledge_items",
+]

--- a/tests/epistemic/test_dic16_crux_km_bridge.py
+++ b/tests/epistemic/test_dic16_crux_km_bridge.py
@@ -50,6 +50,7 @@ KnowledgeSource = _km.KnowledgeSource  # type: ignore[attr-defined]
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 def _entry(crux_id: str = "crux.t1", lbs: float = 0.80) -> CruxEntry:
     return CruxEntry(
         crux_id=crux_id,
@@ -81,6 +82,7 @@ def _receipt(cruxes: list[CruxEntry] | None = None) -> CruxReceipt:
 # Flag-off: always returns empty regardless of cruxes
 # ---------------------------------------------------------------------------
 
+
 class TestFlagOff:
     def test_returns_empty_items(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("ARAGORA_CRUX_RECEIPT_ENABLED", raising=False)
@@ -100,6 +102,7 @@ class TestFlagOff:
 # Flag-on, empty cruxes → still empty
 # ---------------------------------------------------------------------------
 
+
 def test_empty_cruxes_returns_empty(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("ARAGORA_CRUX_RECEIPT_ENABLED", "1")
     r = crux_receipt_to_knowledge_items(_receipt(cruxes=[]))
@@ -110,6 +113,7 @@ def test_empty_cruxes_returns_empty(monkeypatch: pytest.MonkeyPatch) -> None:
 # Item shape
 # ---------------------------------------------------------------------------
 
+
 class TestItemShape:
     @pytest.fixture(autouse=True)
     def _on(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -119,13 +123,18 @@ class TestItemShape:
         assert len(crux_receipt_to_knowledge_items(_receipt()).items) == 1
 
     def test_two_cruxes_two_items(self) -> None:
-        assert len(crux_receipt_to_knowledge_items(_receipt([_entry("c1"), _entry("c2")])).items) == 2
+        assert (
+            len(crux_receipt_to_knowledge_items(_receipt([_entry("c1"), _entry("c2")])).items) == 2
+        )
 
     def test_item_id_deterministic(self) -> None:
         assert crux_receipt_to_knowledge_items(_receipt()).items[0].id == "crux_km_crux.t1"
 
     def test_item_content(self) -> None:
-        assert crux_receipt_to_knowledge_items(_receipt()).items[0].content == "The benchmark is fresh."
+        assert (
+            crux_receipt_to_knowledge_items(_receipt()).items[0].content
+            == "The benchmark is fresh."
+        )
 
     def test_item_source_is_belief(self) -> None:
         assert crux_receipt_to_knowledge_items(_receipt()).items[0].source == KnowledgeSource.BELIEF
@@ -134,12 +143,15 @@ class TestItemShape:
         assert crux_receipt_to_knowledge_items(_receipt()).items[0].source_id == "crux.t1"
 
     def test_importance(self) -> None:
-        assert crux_receipt_to_knowledge_items(_receipt()).items[0].importance == pytest.approx(0.80, abs=1e-4)
+        assert crux_receipt_to_knowledge_items(_receipt()).items[0].importance == pytest.approx(
+            0.80, abs=1e-4
+        )
 
 
 # ---------------------------------------------------------------------------
 # Confidence mapping
 # ---------------------------------------------------------------------------
+
 
 class TestConfidence:
     @pytest.fixture(autouse=True)
@@ -165,6 +177,7 @@ class TestConfidence:
 # ---------------------------------------------------------------------------
 # Metadata provenance
 # ---------------------------------------------------------------------------
+
 
 class TestMetadata:
     @pytest.fixture(autouse=True)

--- a/tests/epistemic/test_dic16_crux_km_bridge.py
+++ b/tests/epistemic/test_dic16_crux_km_bridge.py
@@ -1,0 +1,187 @@
+"""Tests for DIC-16 CruxReceipt → Knowledge Mound bridge.
+
+Hermetic: no real KM store, no real Arena, no network.
+
+Stubs: ``yaml`` and a direct-loaded ``aragora.knowledge.unified.types``
+are inserted into ``sys.modules`` before aragora imports so these tests
+run in the uv-tool pytest venv (no pyyaml / pydantic). The real packages
+take precedence in a fully-installed environment.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+# Stub 1: yaml (needed by aragora.epistemic chain)
+if "yaml" not in sys.modules:
+    _y = types.ModuleType("yaml")
+    _y.safe_load = lambda s: {}  # type: ignore[attr-defined]
+    sys.modules["yaml"] = _y
+
+# Stub 2: load aragora.knowledge.unified.types directly, bypassing the
+# aragora.knowledge __init__ (which imports fact_store → config → pydantic).
+_KM_TYPES = "aragora.knowledge.unified.types"
+if _KM_TYPES not in sys.modules:
+    _p = Path(__file__).parent.parent.parent / "aragora" / "knowledge" / "unified" / "types.py"
+    _spec = importlib.util.spec_from_file_location(_KM_TYPES, _p)
+    assert _spec and _spec.loader
+    _m = importlib.util.module_from_spec(_spec)
+    sys.modules[_KM_TYPES] = _m
+    _spec.loader.exec_module(_m)  # type: ignore[union-attr]
+    for _ns in ("aragora.knowledge", "aragora.knowledge.unified"):
+        sys.modules.setdefault(_ns, types.ModuleType(_ns))
+
+from typing import Any
+
+import pytest
+
+from aragora.epistemic.crux_km_bridge import crux_receipt_to_knowledge_items
+from aragora.epistemic.crux_receipt import CruxEntry, CruxReceipt
+
+_km = sys.modules[_KM_TYPES]
+ConfidenceLevel = _km.ConfidenceLevel  # type: ignore[attr-defined]
+KnowledgeSource = _km.KnowledgeSource  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _entry(crux_id: str = "crux.t1", lbs: float = 0.80) -> CruxEntry:
+    return CruxEntry(
+        crux_id=crux_id,
+        statement="The benchmark is fresh.",
+        load_bearing_score=lbs,
+        uncertainty_score=0.20,
+        contesting_agents=["claude", "codex"],
+        affected_claims=["claim.a", "claim.b"],
+        resolution_impact=0.70,
+    )
+
+
+def _receipt(cruxes: list[CruxEntry] | None = None) -> CruxReceipt:
+    return CruxReceipt(
+        receipt_id="crux_rcpt_abc123",
+        debate_id="debate_xyz",
+        question="Should we adopt the new strategy?",
+        cruxes=cruxes if cruxes is not None else [_entry()],
+        convergence_barrier=0.65,
+        counterfactuals=[],
+        agents=["claude", "codex"],
+        rounds=3,
+        metadata={},
+        checksum="a" * 64,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Flag-off: always returns empty regardless of cruxes
+# ---------------------------------------------------------------------------
+
+class TestFlagOff:
+    def test_returns_empty_items(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ARAGORA_CRUX_RECEIPT_ENABLED", raising=False)
+        r = crux_receipt_to_knowledge_items(_receipt())
+        assert r.items == [] and r.success is False
+
+    def test_receipt_id_preserved(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ARAGORA_CRUX_RECEIPT_ENABLED", raising=False)
+        assert crux_receipt_to_knowledge_items(_receipt()).receipt_id == "crux_rcpt_abc123"
+
+    def test_crux_count_still_reported(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ARAGORA_CRUX_RECEIPT_ENABLED", raising=False)
+        assert crux_receipt_to_knowledge_items(_receipt([_entry(), _entry("c2")])).crux_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Flag-on, empty cruxes → still empty
+# ---------------------------------------------------------------------------
+
+def test_empty_cruxes_returns_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ARAGORA_CRUX_RECEIPT_ENABLED", "1")
+    r = crux_receipt_to_knowledge_items(_receipt(cruxes=[]))
+    assert r.items == [] and r.success is False and r.crux_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Item shape
+# ---------------------------------------------------------------------------
+
+class TestItemShape:
+    @pytest.fixture(autouse=True)
+    def _on(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_CRUX_RECEIPT_ENABLED", "1")
+
+    def test_one_crux_one_item(self) -> None:
+        assert len(crux_receipt_to_knowledge_items(_receipt()).items) == 1
+
+    def test_two_cruxes_two_items(self) -> None:
+        assert len(crux_receipt_to_knowledge_items(_receipt([_entry("c1"), _entry("c2")])).items) == 2
+
+    def test_item_id_deterministic(self) -> None:
+        assert crux_receipt_to_knowledge_items(_receipt()).items[0].id == "crux_km_crux.t1"
+
+    def test_item_content(self) -> None:
+        assert crux_receipt_to_knowledge_items(_receipt()).items[0].content == "The benchmark is fresh."
+
+    def test_item_source_is_belief(self) -> None:
+        assert crux_receipt_to_knowledge_items(_receipt()).items[0].source == KnowledgeSource.BELIEF
+
+    def test_item_source_id(self) -> None:
+        assert crux_receipt_to_knowledge_items(_receipt()).items[0].source_id == "crux.t1"
+
+    def test_importance(self) -> None:
+        assert crux_receipt_to_knowledge_items(_receipt()).items[0].importance == pytest.approx(0.80, abs=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# Confidence mapping
+# ---------------------------------------------------------------------------
+
+class TestConfidence:
+    @pytest.fixture(autouse=True)
+    def _on(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_CRUX_RECEIPT_ENABLED", "1")
+
+    def _conf(self, score: float) -> Any:
+        return crux_receipt_to_knowledge_items(_receipt([_entry(lbs=score)])).items[0].confidence
+
+    def test_high(self) -> None:
+        assert self._conf(0.85) == ConfidenceLevel.HIGH
+
+    def test_boundary_high(self) -> None:
+        assert self._conf(0.75) == ConfidenceLevel.HIGH
+
+    def test_medium(self) -> None:
+        assert self._conf(0.60) == ConfidenceLevel.MEDIUM
+
+    def test_low(self) -> None:
+        assert self._conf(0.20) == ConfidenceLevel.LOW
+
+
+# ---------------------------------------------------------------------------
+# Metadata provenance
+# ---------------------------------------------------------------------------
+
+class TestMetadata:
+    @pytest.fixture(autouse=True)
+    def _on(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_CRUX_RECEIPT_ENABLED", "1")
+
+    def _m(self) -> dict[str, Any]:
+        return crux_receipt_to_knowledge_items(_receipt()).items[0].metadata
+
+    def test_receipt_id(self) -> None:
+        assert self._m()["receipt_id"] == "crux_rcpt_abc123"
+
+    def test_debate_id(self) -> None:
+        assert self._m()["debate_id"] == "debate_xyz"
+
+    def test_affected_claims(self) -> None:
+        assert self._m()["affected_claims"] == ["claim.a", "claim.b"]
+
+    def test_dic_track(self) -> None:
+        assert self._m()["dic_track"] == "DIC-16"


### PR DESCRIPTION
## Slice

Adds `aragora/epistemic/crux_km_bridge.py`: a flag-gated function `crux_receipt_to_knowledge_items` that converts a `CruxReceipt` (from the existing DIC-16 `crux_receipt.py`) into typed `KnowledgeItem` objects ready for Knowledge Mound insertion. Each `CruxEntry` becomes one `KnowledgeItem` with provenance fields (crux_id, receipt_id, debate_id, affected_claims, contesting_agents, load_bearing_score) and confidence mapped from load_bearing_score.

## Gating

- Default: **OFF** (flag: `ARAGORA_CRUX_RECEIPT_ENABLED` — same flag as the existing `crux_receipt.py`)
- Live queue effect: **none** — produces data structures only; no KM store writes, no debate calls, no queue mutations
- Advances issue: #6026 (DIC-16 — receipt and Knowledge Mound provenance)

## Tests

- `TestFlagOff` (3 tests): flag off → empty items, success=False, receipt_id preserved, crux_count still reported
- `test_empty_cruxes_returns_empty`: flag on, no crux entries → empty result
- `TestItemShape` (7 tests): 1 crux → 1 item, deterministic ID (`crux_km_<crux_id>`), content, source=BELIEF, source_id=crux_id, importance=load_bearing_score
- `TestConfidence` (4 tests): score ≥ 0.75 → HIGH; ≥ 0.45 → MEDIUM; < 0.45 → LOW; boundary at 0.75
- `TestMetadata` (4 tests): receipt_id, debate_id, affected_claims, dic_track="DIC-16" preserved in metadata

## Validation

- `pytest tests/epistemic/test_dic16_crux_km_bridge.py --noconftest` — **19 passed** in 0.17 s
- `ruff check aragora/epistemic/crux_km_bridge.py tests/epistemic/test_dic16_crux_km_bridge.py` — **clean**
- `mypy aragora/epistemic/crux_km_bridge.py --ignore-missing-imports` — **clean**
- Net diff: **300 LOC** (2 new files: 113 bridge + 187 tests)

Note: tests direct-load `aragora.knowledge.unified.types` via `importlib.util` (bypassing `aragora.knowledge.__init__` → pydantic) and stub `yaml` so they run in the hermetic uv-tool pytest venv — the same pattern used by DIC-21 and DIC-23.

## Out of scope

- Wiring `crux_receipt_to_knowledge_items` into the live `aragora crux` CLI or the `crux.py` write-receipt path — natural follow-on once the operator has validated KM ingestion per-call
- Bi-directional KM ↔ crux-receipt links (relationship edges) — deferred; this slice is one-way item production only
- Batch ingestion across a directory of receipt files — deferred to a follow-on DIC-16 slice

## Gate status

Per `docs/status/NEXT_STEPS_CANONICAL.md`, `DIC-13..22` are in the **Delay** track. The proof-first Foreman gate has **not** opened. This PR is planning truth and flag-gated operator tooling only; no `boss-ready` label applied. Kept as draft.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TNQroudYRpb3AR4NzK3eA3)_