### PR TITLE
fix(reporting): reject invalid benchmark rates

### DIFF
--- a/scripts/reporting.py
+++ b/scripts/reporting.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -19,10 +20,20 @@ def _pct(summary: dict[str, Any], key: str) -> float:
     >>> _pct({"rate": "0.4"}, "rate")
     0.4
     """
-    try:
-        return float(summary.get(key, 0.0) or 0.0)
-    except (TypeError, ValueError):
+    raw_value = summary.get(key, 0.0)
+    if raw_value in (None, ""):
         return 0.0
+    if isinstance(raw_value, bool):
+        raise ValueError(f"benchmark report field `{key}` must be a numeric rate")
+    try:
+        value = float(raw_value)
+    except (TypeError, ValueError):
+        raise ValueError(f"benchmark report field `{key}` must be a numeric rate") from None
+    if not math.isfinite(value):
+        raise ValueError(f"benchmark report field `{key}` must be finite")
+    if value < 0.0 or value > 1.0:
+        raise ValueError(f"benchmark report field `{key}` must be between 0.0 and 1.0")
+    return value
 
 
 def _int(summary: dict[str, Any], key: str) -> int:

--- a/tests/scripts/test_reporting.py
+++ b/tests/scripts/test_reporting.py
@@ -4,6 +4,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 _scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
 if _scripts_dir not in sys.path:
     sys.path.insert(0, _scripts_dir)
@@ -87,3 +89,41 @@ def test_build_scorecard_reads_published_truth_artifact_payload(
     assert run["no_rescue_truth_success_rate"] == 0.8
     assert run["merged_issue_rate"] == 0.6
     assert run["rescue_count"] == 1
+
+
+def test_build_scorecard_rejects_non_finite_rate_values(tmp_path: Path) -> None:
+    corpus_path = _write_corpus(tmp_path / "corpus.json")
+    report_path = _write_json(
+        tmp_path / "truth-artifact.json",
+        {
+            "generated_at": "2026-04-15T23:05:32Z",
+            "coverage": {"attempted_issue_count": 1},
+            "primary_metrics": {
+                "truth_success_rate": "NaN",
+                "no_rescue_truth_success_rate": 0.5,
+                "merged_only_rate": 0.5,
+            },
+        },
+    )
+
+    with pytest.raises(ValueError, match="truth_success_rate.*finite"):
+        mod.build_scorecard([report_path], corpus_path=corpus_path)
+
+
+def test_build_scorecard_rejects_out_of_range_rate_values(tmp_path: Path) -> None:
+    corpus_path = _write_corpus(tmp_path / "corpus.json")
+    report_path = _write_json(
+        tmp_path / "truth-artifact.json",
+        {
+            "generated_at": "2026-04-15T23:05:32Z",
+            "coverage": {"attempted_issue_count": 1},
+            "primary_metrics": {
+                "truth_success_rate": 0.75,
+                "no_rescue_truth_success_rate": 1.2,
+                "merged_only_rate": 0.5,
+            },
+        },
+    )
+
+    with pytest.raises(ValueError, match="no_rescue_truth_success_rate.*between 0.0 and 1.0"):
+        mod.build_scorecard([report_path], corpus_path=corpus_path)


### PR DESCRIPTION
## Summary
- fail closed when B0 reporting inputs contain non-finite or out-of-range rate fields
- preserve missing/blank rate defaults for legacy sparse reports
- add focused regressions for NaN and >100% benchmark rates

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_reporting.py -q
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/reporting.py tests/scripts/test_reporting.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/reporting.py tests/scripts/test_reporting.py
- git diff --check HEAD~1..HEAD
- /Users/armand/.pyenv/versions/3.11.11/bin/python scripts/reporting.py docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/latest.json --corpus docs/benchmarks/corpus.json --json
- bash scripts/automation_pr_preflight.sh origin/main HEAD