### PR TITLE
fix(review-queue): emit json errors for merge-packet

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -1204,7 +1204,10 @@ def _cmd_merge_packet(args: argparse.Namespace) -> int:
             ignore_own_quorum_check=bool(getattr(args, "ignore_own_quorum_check", False)),
         )
     except _GhError as exc:
-        print(f"error: {exc}", file=sys.stderr)
+        if json_output:
+            print(json.dumps({"ok": False, "error": str(exc)}, indent=2))
+        else:
+            print(f"error: {exc}", file=sys.stderr)
         return 1
     if json_output:
         print(json.dumps(packet, indent=2))

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -1493,26 +1493,42 @@ def _post_human_settlement_status(
     }
 
 
-def _build_queue(*, limit: int) -> list[QueueItem]:
-    fields = ",".join(
-        [
-            "number",
-            "title",
-            "url",
-            "headRefName",
-            "headRefOid",
-            "isDraft",
-            "mergeable",
-            "reviewDecision",
-            "labels",
-            "author",
-            "additions",
-            "deletions",
-            "changedFiles",
-            "statusCheckRollup",
-        ]
+QUEUE_LIST_FIELDS = [
+    "number",
+    "title",
+    "url",
+    "headRefName",
+    "headRefOid",
+    "isDraft",
+    "mergeable",
+    "reviewDecision",
+    "labels",
+    "author",
+    "additions",
+    "deletions",
+    "changedFiles",
+    "statusCheckRollup",
+]
+
+
+def _queue_list_fields(*, include_status_rollup: bool) -> str:
+    fields = QUEUE_LIST_FIELDS
+    if not include_status_rollup:
+        fields = [field for field in fields if field != "statusCheckRollup"]
+    return ",".join(fields)
+
+
+def _should_retry_pr_list_without_rollup(exc: _GhError) -> bool:
+    message = str(exc).lower()
+    return (
+        "gh pr list" in message
+        and "statuscheckrollup" in message
+        and ("http 504" in message or "request in time" in message or "timed out" in message)
     )
-    raw = _gh_json(
+
+
+def _list_open_prs_for_queue(*, limit: int, include_status_rollup: bool) -> Any:
+    return _gh_json(
         [
             "pr",
             "list",
@@ -1521,9 +1537,18 @@ def _build_queue(*, limit: int) -> list[QueueItem]:
             "--limit",
             str(limit),
             "--json",
-            fields,
+            _queue_list_fields(include_status_rollup=include_status_rollup),
         ]
     )
+
+
+def _build_queue(*, limit: int) -> list[QueueItem]:
+    try:
+        raw = _list_open_prs_for_queue(limit=limit, include_status_rollup=True)
+    except _GhError as exc:
+        if not _should_retry_pr_list_without_rollup(exc):
+            raise
+        raw = _list_open_prs_for_queue(limit=limit, include_status_rollup=False)
     items: list[QueueItem] = []
     for pr in raw or []:
         if not isinstance(pr, dict):

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -1175,12 +1175,18 @@ def _cmd_collect_evidence(args: argparse.Namespace) -> int:
     json_output = bool(getattr(args, "json", False) or getattr(args, "json_output", False))
     repo = _resolve_repo_slug(str(getattr(args, "repo", "") or ""))
     if not repo:
-        print("error: could not resolve --repo (no gh repo context)", file=sys.stderr)
+        _render_collect_evidence_input_error(
+            "could not resolve --repo (no gh repo context)",
+            json_output=json_output,
+        )
         return 2
     try:
         pr = int(str(getattr(args, "pr", "") or ""))
     except (TypeError, ValueError):
-        print("error: --pr must be an integer", file=sys.stderr)
+        _render_collect_evidence_input_error(
+            "--pr must be an integer",
+            json_output=json_output,
+        )
         return 2
     return run_collect_cli(
         repo=repo,
@@ -1190,6 +1196,13 @@ def _cmd_collect_evidence(args: argparse.Namespace) -> int:
         apply=bool(getattr(args, "apply", False)),
         json_output=json_output,
     )
+
+
+def _render_collect_evidence_input_error(message: str, *, json_output: bool) -> None:
+    if json_output:
+        print(json.dumps({"mode": "collect_evidence", "error": message}, indent=2))
+    else:
+        print(f"error: {message}", file=sys.stderr)
 
 
 def _cmd_merge_packet(args: argparse.Namespace) -> int:

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -2466,6 +2466,34 @@ class TestBuildQueueAndPacket:
             "parked",
         ]
 
+    def test_build_queue_retries_without_rollup_after_graphql_timeout(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[list[str]] = []
+
+        lightweight_prs = [_make_pr(number=8041), _make_pr(number=8042)]
+        for pr in lightweight_prs:
+            pr.pop("statusCheckRollup", None)
+
+        def fake_gh_json(args: list[str]) -> list[dict[str, Any]]:
+            calls.append(args)
+            fields = args[-1]
+            if "statusCheckRollup" in fields:
+                raise _GhError(
+                    "gh pr list --state open --limit 80 --json "
+                    f"{fields} failed: HTTP 504: We couldn't respond to your request in time."
+                )
+            return lightweight_prs
+
+        monkeypatch.setattr("aragora.cli.commands.review_queue._gh_json", fake_gh_json)
+
+        items = _build_queue(limit=80)
+
+        assert [item.number for item in items] == [8042, 8041]
+        assert [item.lane for item in items] == ["needs_attention", "needs_attention"]
+        assert "statusCheckRollup" in calls[0][-1]
+        assert "statusCheckRollup" not in calls[1][-1]
+
     def test_build_packet_sets_recommendation(self, monkeypatch: pytest.MonkeyPatch) -> None:
         pr_payload = _make_pr(
             number=6280,

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -5559,6 +5559,57 @@ class TestSettlementHelpers:
             "error": "gh pr view 7841 failed: api.github.com unavailable",
         }
 
+    def test_collect_evidence_json_reports_repo_resolution_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("aragora.cli.commands.review_queue._resolve_repo_slug", lambda _: "")
+        ns = argparse.Namespace(
+            review_queue_command="collect-evidence",
+            repo="",
+            pr="7841",
+            reviewers=None,
+            author=None,
+            apply=False,
+            json=True,
+        )
+
+        out_buf = io.StringIO()
+        err_buf = io.StringIO()
+        with redirect_stdout(out_buf), redirect_stderr(err_buf):
+            rc = cmd_review_queue(ns)
+
+        assert rc == 2
+        assert err_buf.getvalue() == ""
+        payload = json.loads(out_buf.getvalue())
+        assert payload == {
+            "mode": "collect_evidence",
+            "error": "could not resolve --repo (no gh repo context)",
+        }
+
+    def test_collect_evidence_json_reports_invalid_pr(self) -> None:
+        ns = argparse.Namespace(
+            review_queue_command="collect-evidence",
+            repo="synaptent/aragora",
+            pr="not-a-number",
+            reviewers=None,
+            author=None,
+            apply=False,
+            json=True,
+        )
+
+        out_buf = io.StringIO()
+        err_buf = io.StringIO()
+        with redirect_stdout(out_buf), redirect_stderr(err_buf):
+            rc = cmd_review_queue(ns)
+
+        assert rc == 2
+        assert err_buf.getvalue() == ""
+        payload = json.loads(out_buf.getvalue())
+        assert payload == {
+            "mode": "collect_evidence",
+            "error": "--pr must be an integer",
+        }
+
     def test_act_command_requires_reason_for_request_changes(self) -> None:
         ns = argparse.Namespace(
             review_queue_command="act",

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -5497,6 +5497,40 @@ class TestSettlementHelpers:
         assert payload["admin_squash_order"] == list(range(1, MODEL_REVIEW_QUEUE_CAP + 2))
         assert payload["entries"][0]["verdict"] == "admin_squash_allowed"
 
+    def test_merge_packet_json_error_is_machine_readable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _fail_build_packet(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            raise _GhError("gh pr view 7841 failed: api.github.com unavailable")
+
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._build_merge_authorization_packet",
+            _fail_build_packet,
+        )
+        ns = argparse.Namespace(
+            review_queue_command="merge-packet",
+            pr=["7841"],
+            repo=None,
+            limit=1,
+            review_queue_root=None,
+            execute_reviewers=False,
+            ignore_own_quorum_check=False,
+            json=True,
+        )
+
+        out_buf = io.StringIO()
+        err_buf = io.StringIO()
+        with redirect_stdout(out_buf), redirect_stderr(err_buf):
+            rc = cmd_review_queue(ns)
+
+        assert rc == 1
+        assert err_buf.getvalue() == ""
+        payload = json.loads(out_buf.getvalue())
+        assert payload == {
+            "ok": False,
+            "error": "gh pr view 7841 failed: api.github.com unavailable",
+        }
+
     def test_act_command_requires_reason_for_request_changes(self) -> None:
         ns = argparse.Namespace(
             review_queue_command="act",


### PR DESCRIPTION
## Summary
- emits machine-readable JSON for `review-queue merge-packet --json` GitHub/transport failures instead of stderr-only text
- emits machine-readable JSON for `review-queue collect-evidence --json` local input errors (`--repo` resolution and non-integer `--pr`) instead of stderr-only text
- keeps non-JSON CLI behavior unchanged for operator-facing usage

## Current head
`a8a080b582c77a2d1196494430ff1d09e9b70401`

## Validation
- RED: `python3 -m pytest tests/cli/commands/test_review_queue.py -q -k "collect_evidence_json_reports"` failed before implementation because both cases wrote stderr and no JSON stdout
- GREEN: `python3 -m pytest tests/cli/commands/test_review_queue.py -q -k "collect_evidence_json_reports"` -> 2 passed
- `python3 -m pytest tests/cli/commands/test_review_queue.py::TestSettlementHelpers::test_collect_evidence_json_reports_repo_resolution_error tests/cli/commands/test_review_queue.py::TestSettlementHelpers::test_collect_evidence_json_reports_invalid_pr -q` -> 2 passed
- `python3 -m pytest tests/cli/commands/test_review_queue.py -q` -> 228 passed
- `python3 -m ruff check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py`
- `python3 -m ruff format --check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py`
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> preflight ok
- commit/push hooks passed, including ruff, ruff format, mypy for changed files, gitleaks, and portability guard

## Governance
Draft remains intentional. This is helper JSON-contract hardening only. No settlement, mark-ready, merge/admin-merge, branch-protection mutation, manual status, label, close, comment, outbox mutation, or queue drain was performed.