### PR TITLE
fix(benchmarks): validate regression thresholds

### DIFF
--- a/scripts/check_benchmark_regression.py
+++ b/scripts/check_benchmark_regression.py
@@ -83,6 +83,25 @@ def _format_name_sample(names: set[str]) -> str:
     return sample
 
 
+def _validate_threshold_pct(value: float) -> float:
+    if not math.isfinite(value) or value < 0:
+        raise ValueError("threshold_pct must be a finite non-negative percentage")
+    return value
+
+
+def _threshold_pct_arg(value: str) -> float:
+    try:
+        parsed = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "threshold must be a finite non-negative percentage"
+        ) from exc
+    try:
+        return _validate_threshold_pct(parsed)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+
+
 def compare_benchmarks(
     current_path: Path,
     baseline_path: Path,
@@ -92,6 +111,7 @@ def compare_benchmarks(
 
     Returns 0 if no regressions exceed threshold_pct, 1 otherwise.
     """
+    threshold_pct = _validate_threshold_pct(threshold_pct)
     current = load_benchmark_json(current_path)
     baseline = load_benchmark_json(baseline_path)
 
@@ -260,7 +280,7 @@ def main() -> None:
     )
     compare.add_argument(
         "--threshold",
-        type=float,
+        type=_threshold_pct_arg,
         default=20.0,
         help="Maximum allowed regression percentage (default: 20%%)",
     )
@@ -276,7 +296,12 @@ def main() -> None:
     # Legacy positional args: --current/--baseline at top level
     parser.add_argument("--current", type=Path, dest="top_current")
     parser.add_argument("--baseline", type=Path, dest="top_baseline")
-    parser.add_argument("--threshold", type=float, default=20.0, dest="top_threshold")
+    parser.add_argument(
+        "--threshold",
+        type=_threshold_pct_arg,
+        default=20.0,
+        dest="top_threshold",
+    )
     parser.add_argument("--validate", type=Path, dest="top_validate")
 
     args = parser.parse_args()

--- a/tests/scripts/test_check_benchmark_regression.py
+++ b/tests/scripts/test_check_benchmark_regression.py
@@ -6,6 +6,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_PATH = REPO_ROOT / "scripts" / "check_benchmark_regression.py"
@@ -83,6 +85,21 @@ def test_compare_allows_partial_overlap_without_regression(tmp_path: Path, capsy
     assert rc == 0
     assert "PASSED: 1 benchmark(s)" in captured.out
     assert "No shared benchmark names" not in captured.out
+
+
+def test_compare_rejects_invalid_threshold_percentages(tmp_path: Path) -> None:
+    current = _write_benchmarks(tmp_path / "current.json", {"bench": 0.001})
+    baseline = _write_benchmarks(tmp_path / "baseline.json", {"bench": 0.001})
+
+    for threshold in (-1.0, float("nan"), float("inf")):
+        with pytest.raises(ValueError, match="finite non-negative"):
+            bench_mod.compare_benchmarks(current, baseline, threshold_pct=threshold)
+
+
+def test_threshold_parser_rejects_invalid_percentages() -> None:
+    for raw in ("-1", "nan", "inf", "not-a-number"):
+        with pytest.raises(bench_mod.argparse.ArgumentTypeError):
+            bench_mod._threshold_pct_arg(raw)
 
 
 def test_validate_rejects_invalid_numeric_stats(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary
- reject negative, NaN, and infinite benchmark regression thresholds before comparison
- apply the same validation to compare-mode and legacy CLI threshold arguments
- add focused regression coverage for direct calls and CLI parsing

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_check_benchmark_regression.py -q
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/check_benchmark_regression.py tests/scripts/test_check_benchmark_regression.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/check_benchmark_regression.py tests/scripts/test_check_benchmark_regression.py
- git diff --check
- /Users/armand/.pyenv/versions/3.11.11/bin/python scripts/check_benchmark_regression.py compare --current /tmp/missing-current.json --baseline /tmp/missing-baseline.json --threshold nan
- bash scripts/automation_pr_preflight.sh origin/main HEAD