### PR TITLE
fix(benchmark-truth): validate status corpus identity

### DIFF
--- a/scripts/render_benchmark_truth_status.py
+++ b/scripts/render_benchmark_truth_status.py
@@ -56,11 +56,28 @@ def _load_json(path: Path) -> dict[str, Any]:
     return payload
 
 
+def _positive_revision(value: Any, *, path: Path) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"Corpus at {path} must contain a positive integer revision")
+    try:
+        revision = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Corpus at {path} must contain a positive integer revision") from exc
+    if revision <= 0:
+        raise ValueError(f"Corpus at {path} must contain a positive integer revision")
+    return revision
+
+
 def load_corpus(path: Path) -> dict[str, Any]:
     payload = _load_json(path)
     issues = payload.get("issues")
     if not isinstance(issues, list) or not issues:
         raise ValueError(f"Corpus at {path} must contain a non-empty 'issues' list")
+    corpus_id = str(payload.get("corpus_id") or "").strip()
+    if not corpus_id:
+        raise ValueError(f"Corpus at {path} must contain a non-empty corpus_id")
+    payload["corpus_id"] = corpus_id
+    payload["revision"] = _positive_revision(payload.get("revision"), path=path)
     return payload
 
 

--- a/tests/scripts/test_render_benchmark_truth_status.py
+++ b/tests/scripts/test_render_benchmark_truth_status.py
@@ -163,6 +163,35 @@ def test_render_status_markdown_includes_metrics_and_paths(tmp_path: Path) -> No
     )
 
 
+def test_load_corpus_rejects_blank_corpus_id(tmp_path: Path) -> None:
+    corpus_path = _write_json(
+        tmp_path / "corpus.json",
+        {
+            "corpus_id": " ",
+            "revision": 1,
+            "issues": [{"issue_id": 1064, "title": "Issue A"}],
+        },
+    )
+
+    with pytest.raises(ValueError, match="non-empty corpus_id"):
+        mod.load_corpus(corpus_path)
+
+
+@pytest.mark.parametrize("revision", [0, -1, True, "not-a-number", None])
+def test_load_corpus_rejects_invalid_revision(tmp_path: Path, revision: object) -> None:
+    corpus_path = _write_json(
+        tmp_path / "corpus.json",
+        {
+            "corpus_id": "tw-01-bounded-execution-v1",
+            "revision": revision,
+            "issues": [{"issue_id": 1064, "title": "Issue A"}],
+        },
+    )
+
+    with pytest.raises(ValueError, match="positive integer revision"):
+        mod.load_corpus(corpus_path)
+
+
 def test_render_status_markdown_headlines_verified_rate_and_in_flight_metrics(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- reject blank benchmark corpus ids before status path resolution
- reject non-positive, boolean, and non-numeric corpus revisions before deriving latest pointers
- add focused coverage for malformed benchmark-truth status corpus manifests

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_render_benchmark_truth_status.py -q
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/render_benchmark_truth_status.py tests/scripts/test_render_benchmark_truth_status.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/render_benchmark_truth_status.py tests/scripts/test_render_benchmark_truth_status.py
- git diff --check HEAD~1..HEAD
- /Users/armand/.pyenv/versions/3.11.11/bin/python scripts/render_benchmark_truth_status.py --output /private/tmp/b0-status-smoke.md
- bash scripts/automation_pr_preflight.sh origin/main HEAD