### PR TITLE
fix(benchmarks): validate factory smoke head shas

### DIFF
--- a/scripts/run_factory_review_benchmark_smoke.py
+++ b/scripts/run_factory_review_benchmark_smoke.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 from datetime import UTC, datetime
@@ -36,6 +37,7 @@ REQUIRED_CASE_FIELDS = {
     "validation_path",
     "validation_url",
 }
+FULL_COMMIT_SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 
 
 def _utc_now() -> str:
@@ -60,6 +62,7 @@ def _validate_case(row: object, index: int) -> dict[str, Any]:
     missing = sorted(field for field in REQUIRED_CASE_FIELDS if field not in row)
     if missing:
         raise ValueError(f"smoke_cases[{index}] missing required fields: {', '.join(missing)}")
+    validated = dict(row)
     for field in REQUIRED_CASE_FIELDS:
         if field == "pr_number":
             if not isinstance(row[field], int) or isinstance(row[field], bool) or row[field] <= 0:
@@ -67,7 +70,14 @@ def _validate_case(row: object, index: int) -> dict[str, Any]:
             continue
         if not isinstance(row[field], str) or not row[field].strip():
             raise ValueError(f"smoke_cases[{index}].{field} must be a non-empty string")
-    return dict(row)
+        if field == "head_sha" and not FULL_COMMIT_SHA_PATTERN.fullmatch(row[field].strip()):
+            raise ValueError(
+                f"smoke_cases[{index}].head_sha must be a full 40-character lowercase "
+                "hex commit SHA"
+            )
+        if field == "head_sha":
+            validated[field] = row[field].strip()
+    return validated
 
 
 def _validate_manifest(manifest: dict[str, Any]) -> list[dict[str, Any]]:

--- a/tests/scripts/test_run_factory_review_benchmark_smoke.py
+++ b/tests/scripts/test_run_factory_review_benchmark_smoke.py
@@ -82,6 +82,21 @@ def test_manifest_rejects_missing_validation_url() -> None:
         raise AssertionError("missing validation_url should fail")
 
 
+def test_manifest_rejects_malformed_head_sha() -> None:
+    manifest = _manifest()
+    case = dict(manifest["smoke_cases"][0])
+    case["head_sha"] = "cb7212e"
+    manifest["smoke_cases"] = [case]
+
+    try:
+        smoke.build_run_plan(manifest)
+    except ValueError as exc:
+        assert "head_sha" in str(exc)
+        assert "40-character lowercase hex commit SHA" in str(exc)
+    else:
+        raise AssertionError("short head_sha should fail")
+
+
 def test_manifest_rejects_malformed_case() -> None:
     manifest = _manifest()
     manifest["smoke_cases"] = ["not-a-case"]


### PR DESCRIPTION
## Summary
- require Factory review smoke manifest head_sha values to be full 40-character lowercase hex commit SHAs
- reject malformed benchmark cases before they can be copied into planned proof artifacts
- add focused regression coverage for malformed head_sha input

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_run_factory_review_benchmark_smoke.py -q
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/run_factory_review_benchmark_smoke.py tests/scripts/test_run_factory_review_benchmark_smoke.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/run_factory_review_benchmark_smoke.py tests/scripts/test_run_factory_review_benchmark_smoke.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD