### PR TITLE
fix(reports): validate rescue map schema versions

### DIFF
--- a/scripts/publish_rescue_productization_report.py
+++ b/scripts/publish_rescue_productization_report.py
@@ -112,6 +112,12 @@ def write_json(path: Path, payload: dict[str, Any]) -> Path:
     return path
 
 
+def _coerce_schema_version(value: Any, *, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{label} schema_version must be a positive integer")
+    return value
+
+
 def load_productization_map_payload(path: Path) -> dict[str, Any]:
     if not path.exists():
         return {"schema_version": 1, "entries": []}
@@ -122,7 +128,10 @@ def load_productization_map_payload(path: Path) -> dict[str, Any]:
     if not isinstance(entries, list):
         raise ValueError(f"Productization map at {path} must contain an 'entries' list")
     return {
-        "schema_version": int(payload.get("schema_version", 1) or 1),
+        "schema_version": _coerce_schema_version(
+            payload.get("schema_version", 1),
+            label=f"Productization map at {path}",
+        ),
         "entries": entries,
     }
 
@@ -135,7 +144,10 @@ def write_productization_map_payload(path: Path, payload: dict[str, Any]) -> Pat
     ]
     entries.sort(key=lambda entry: str(entry.get("class") or "").strip())
     normalized = {
-        "schema_version": int(payload.get("schema_version", 1) or 1),
+        "schema_version": _coerce_schema_version(
+            payload.get("schema_version", 1),
+            label=f"Productization map payload for {path}",
+        ),
         "entries": entries,
     }
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/scripts/test_publish_rescue_productization_report.py
+++ b/tests/scripts/test_publish_rescue_productization_report.py
@@ -4,6 +4,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 from aragora.swarm.rescue_events import RescueEvent, RescueEventLedger
 
 _scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
@@ -107,6 +109,36 @@ def test_publish_report_bundle_writes_timestamped_and_latest(tmp_path: Path) -> 
     assert json.loads(written["latest"].read_text(encoding="utf-8"))["generated_at"] == (
         "2026-04-14T18:36:07Z"
     )
+
+
+@pytest.mark.parametrize("schema_version", [0, -1, True, "1"])
+def test_load_productization_map_rejects_invalid_schema_version(
+    tmp_path: Path,
+    schema_version: object,
+) -> None:
+    productization_map_path = tmp_path / "rescue_productization.json"
+    productization_map_path.write_text(
+        json.dumps({"schema_version": schema_version, "entries": []}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="schema_version must be a positive integer"):
+        mod.load_productization_map_payload(productization_map_path)
+
+
+def test_write_productization_map_rejects_invalid_schema_version(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="schema_version must be a positive integer"):
+        mod.write_productization_map_payload(
+            tmp_path / "rescue_productization.json",
+            {
+                "schema_version": False,
+                "entries": [
+                    {
+                        "class": "followup_prompt:needs explicit next step from founder",
+                    }
+                ],
+            },
+        )
 
 
 def test_main_dry_run_does_not_publish_report_bundle(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary
- require rescue productization map schema_version values to be positive integers
- reject booleans, strings, zero, and negative values before TW-03 report publication carries invalid metadata
- add focused read/write regression coverage for malformed productization map schema versions

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_publish_rescue_productization_report.py -q
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/publish_rescue_productization_report.py tests/scripts/test_publish_rescue_productization_report.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/publish_rescue_productization_report.py tests/scripts/test_publish_rescue_productization_report.py
- git diff --check
- bash scripts/automation_pr_preflight.sh origin/main HEAD