### PR TITLE
fix(benchmarks): validate recurrence runtime controls

### DIFF
--- a/scripts/run_benchmark_corpus_recurrence.py
+++ b/scripts/run_benchmark_corpus_recurrence.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import subprocess
 import sys
 from pathlib import Path
@@ -119,6 +120,20 @@ def filter_open_issue_numbers(
     ]
 
 
+def _positive_int(value: int | None, *, name: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or value <= 0:
+        raise ValueError(f"{name} must be a positive integer")
+    return value
+
+
+def _positive_finite_float(value: float, *, name: str) -> float:
+    if isinstance(value, bool) or not math.isfinite(value) or value <= 0:
+        raise ValueError(f"{name} must be a positive finite number")
+    return value
+
+
 def append_closed_issue_rows(
     *,
     metrics_file: Path,
@@ -209,6 +224,15 @@ def build_boss_loop_command(
 ) -> list[str]:
     if not issue_numbers:
         raise ValueError("issue_numbers must not be empty")
+    max_ticks = _positive_int(max_ticks, name="max_ticks")
+    max_consecutive_failures = _positive_int(
+        max_consecutive_failures,
+        name="max_consecutive_failures",
+    )
+    if max_consecutive_failures is None:
+        raise ValueError("max_consecutive_failures must be a positive integer")
+    interval_seconds = _positive_finite_float(interval_seconds, name="interval_seconds")
+    max_hours = _positive_finite_float(max_hours, name="max_hours")
     # BossLoop can consume one initial attempt plus two repair attempts before
     # recording a terminal class for one issue. Budget for that full envelope so
     # later corpus issues are not omitted from the publication window.

--- a/tests/scripts/test_run_benchmark_corpus_recurrence.py
+++ b/tests/scripts/test_run_benchmark_corpus_recurrence.py
@@ -87,6 +87,33 @@ def test_build_boss_loop_command_uses_explicit_issue_list_contract() -> None:
     assert command[command.index("--autonomy") + 1] == "fire_and_forget"
 
 
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"max_ticks": 0}, "max_ticks must be a positive integer"),
+        ({"max_consecutive_failures": 0}, "max_consecutive_failures must be a positive integer"),
+        (
+            {"max_consecutive_failures": None},
+            "max_consecutive_failures must be a positive integer",
+        ),
+        ({"interval_seconds": 0.0}, "interval_seconds must be a positive finite number"),
+        ({"interval_seconds": float("nan")}, "interval_seconds must be a positive finite number"),
+        ({"max_hours": -1.0}, "max_hours must be a positive finite number"),
+        ({"max_hours": float("inf")}, "max_hours must be a positive finite number"),
+    ],
+)
+def test_build_boss_loop_command_rejects_invalid_runtime_controls(
+    kwargs: dict[str, object],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        mod.build_boss_loop_command(
+            repo="synaptent/aragora",
+            issue_numbers=[1064],
+            **kwargs,
+        )
+
+
 def test_run_recurrence_rotates_metrics_appends_closed_rows_and_dispatches_open_issue(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
Summary: Validate benchmark corpus recurrence runtime controls before rendering boss-loop follow-up commands. Reject non-positive or non-finite interval/max-hours and non-positive tick/failure budgets. Validation: /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_run_benchmark_corpus_recurrence.py -q; /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/run_benchmark_corpus_recurrence.py tests/scripts/test_run_benchmark_corpus_recurrence.py; git diff --check; bash scripts/automation_pr_preflight.sh origin/main HEAD.