### PR TITLE
fix(settle-one): bound GitHub retries and helper runtime

### DIFF
--- a/scripts/settle_one_pr.py
+++ b/scripts/settle_one_pr.py
@@ -97,14 +97,23 @@ def _state_repo_root(cwd: Path) -> Path:
 
 
 def _run(args: list[str], *, cwd: Path, timeout: int = 120) -> dict[str, Any]:
-    proc = subprocess.Popen(
-        args,
-        cwd=cwd,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        start_new_session=True,
-    )
+    try:
+        proc = subprocess.Popen(
+            args,
+            cwd=cwd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            start_new_session=True,
+        )
+    except OSError as exc:
+        return {
+            "command": " ".join(args),
+            "returncode": 127,
+            "stdout": "",
+            "stderr": f"failed to start command: {exc}",
+            "start_failed": True,
+        }
     try:
         stdout, stderr = proc.communicate(timeout=timeout)
     except subprocess.TimeoutExpired:

--- a/scripts/settle_one_pr.py
+++ b/scripts/settle_one_pr.py
@@ -164,7 +164,16 @@ def _bounded_command_result(result: dict[str, Any]) -> dict[str, Any]:
 
 def _command_failure_detail(result: dict[str, Any], fallback: str) -> str:
     bounded = _bounded_command_result(result)
-    return str(bounded.get("stderr") or bounded.get("stdout") or fallback)
+    return str(
+        bounded.get("stderr") or bounded.get("json_error") or bounded.get("stdout") or fallback
+    )
+
+
+def _json_payload_failure_detail(result: dict[str, Any], fallback: str) -> str:
+    detail = str(result.get("json_error") or "").strip()
+    if detail:
+        return _truncate_text(detail)
+    return fallback
 
 
 def _is_transient_gh_failure(args: list[str], result: dict[str, Any]) -> bool:
@@ -1597,7 +1606,9 @@ def _load_single_pr_packet(*, cwd: Path, pr: int, repo: str | None) -> dict[str,
     if result["returncode"] != 0:
         raise RuntimeError(_command_failure_detail(result, "merge-packet failed"))
     if not isinstance(payload, dict):
-        raise RuntimeError("merge-packet did not return a JSON object")
+        raise RuntimeError(
+            _json_payload_failure_detail(result, "merge-packet did not return a JSON object")
+        )
     return payload
 
 
@@ -1618,7 +1629,9 @@ def _load_broad_packet_bulk(*, cwd: Path, limit: int, repo: str | None) -> dict[
     if result["returncode"] != 0:
         raise RuntimeError(_command_failure_detail(result, "merge-packet failed"))
     if not isinstance(payload, dict):
-        raise RuntimeError("merge-packet did not return a JSON object")
+        raise RuntimeError(
+            _json_payload_failure_detail(result, "merge-packet did not return a JSON object")
+        )
     return payload
 
 

--- a/scripts/settle_one_pr.py
+++ b/scripts/settle_one_pr.py
@@ -51,6 +51,11 @@ OPERATOR_SNAPSHOT_TIMEOUT_SECONDS = _env_timeout_seconds(
 )
 BROAD_PACKET_TIMEOUT_SECONDS = _env_timeout_seconds("SETTLE_ONE_BROAD_PACKET_TIMEOUT_SECONDS", 90)
 SINGLE_PACKET_TIMEOUT_SECONDS = _env_timeout_seconds("SETTLE_ONE_SINGLE_PACKET_TIMEOUT_SECONDS", 90)
+GH_JSON_RETRIES = max(1, _env_timeout_seconds("SETTLE_ONE_GH_JSON_RETRIES", 2))
+COMMAND_OUTPUT_CHAR_LIMIT = max(
+    200,
+    _env_timeout_seconds("SETTLE_ONE_COMMAND_OUTPUT_CHAR_LIMIT", 2000),
+)
 OPEN_PR_LIGHT_FIELDS = (
     "number,title,url,headRefName,headRefOid,isDraft,mergeable,mergeStateStatus,"
     "reviewDecision,labels,author,additions,deletions,changedFiles"
@@ -132,6 +137,64 @@ def _run_json(
     except json.JSONDecodeError as exc:
         result["json_error"] = str(exc)
         return None, result
+
+
+def _truncate_text(value: str, *, limit: int = COMMAND_OUTPUT_CHAR_LIMIT) -> str:
+    if len(value) <= limit:
+        return value
+    omitted = len(value) - limit
+    return f"{value[:limit]}...[truncated {omitted} chars]"
+
+
+def _bounded_command_result(result: dict[str, Any]) -> dict[str, Any]:
+    bounded = dict(result)
+    for key in ("stdout", "stderr"):
+        value = bounded.get(key)
+        if isinstance(value, str) and len(value) > COMMAND_OUTPUT_CHAR_LIMIT:
+            bounded[f"{key}_truncated"] = True
+            bounded[f"{key}_original_chars"] = len(value)
+            bounded[key] = _truncate_text(value, limit=COMMAND_OUTPUT_CHAR_LIMIT)
+    return bounded
+
+
+def _command_failure_detail(result: dict[str, Any], fallback: str) -> str:
+    bounded = _bounded_command_result(result)
+    return str(bounded.get("stderr") or bounded.get("stdout") or fallback)
+
+
+def _is_transient_gh_failure(args: list[str], result: dict[str, Any]) -> bool:
+    if not args or args[0] != "gh" or result.get("returncode") == 0:
+        return False
+    detail = f"{result.get('stderr') or ''}\n{result.get('stdout') or ''}".lower()
+    transient_markers = (
+        "error connecting to api.github.com",
+        "http 5",
+        "graphql timeout",
+        "connection reset",
+        "connection refused",
+        "could not resolve host",
+        "tls handshake timeout",
+        "operation timed out",
+    )
+    return any(marker in detail for marker in transient_markers)
+
+
+def _run_json_with_gh_retries(
+    args: list[str], *, cwd: Path, timeout: int = 120, retries: int = GH_JSON_RETRIES
+) -> tuple[Any | None, dict[str, Any]]:
+    attempts: list[dict[str, Any]] = []
+    payload: Any | None = None
+    result: dict[str, Any] = {}
+    for _attempt in range(1, max(1, retries) + 1):
+        payload, result = _run_json(args, cwd=cwd, timeout=timeout)
+        attempts.append(_bounded_command_result(result))
+        if payload is not None or not _is_transient_gh_failure(args, result):
+            break
+    if len(attempts) > 1:
+        result = dict(result)
+        result["attempt_count"] = len(attempts)
+        result["attempts"] = attempts
+    return payload, result
 
 
 def _with_repo(args: list[str], repo: str | None) -> list[str]:
@@ -974,7 +1037,7 @@ def validation_report(
 def load_open_pr_metadata(
     cwd: Path, *, limit: int = 200, repo: str | None = None
 ) -> tuple[dict[int, dict[str, Any]], dict[str, Any]]:
-    payload, command = _run_json(
+    payload, command = _run_json_with_gh_retries(
         _with_repo(
             [
                 "gh",
@@ -1000,13 +1063,13 @@ def load_open_pr_metadata(
             pr_number = _coerce_int(item.get("number"))
             if pr_number is not None:
                 metadata[pr_number] = item
-    return metadata, command
+    return metadata, _bounded_command_result(command)
 
 
 def load_pr_policy_metadata(
     cwd: Path, pr_number: int, *, repo: str | None = None
 ) -> tuple[dict[str, Any], dict[str, Any]]:
-    payload, command = _run_json(
+    payload, command = _run_json_with_gh_retries(
         _with_repo(
             ["gh", "pr", "view", str(pr_number), "--json", PR_POLICY_FIELDS],
             repo,
@@ -1015,8 +1078,8 @@ def load_pr_policy_metadata(
         timeout=GH_METADATA_TIMEOUT_SECONDS,
     )
     if isinstance(payload, dict):
-        return payload, command
-    return {}, command
+        return payload, _bounded_command_result(command)
+    return {}, _bounded_command_result(command)
 
 
 def _has_policy_file_scope(metadata: dict[str, Any]) -> bool:
@@ -1044,7 +1107,7 @@ def load_active_owned_prs(cwd: Path) -> tuple[set[int], dict[str, Any]]:
         command["operator_snapshot_ok"] = False
         if command.get("returncode") == 0 and not command.get("json_error"):
             command["json_error"] = "operator-snapshot did not return a JSON object"
-    return active_owned, command
+    return active_owned, _bounded_command_result(command)
 
 
 def active_owned_snapshot_blocker(command: dict[str, Any]) -> str | None:
@@ -1280,7 +1343,9 @@ def build_report(
             "active_owned_prs": sorted(active_owned_prs),
         }
         if repo is not None:
-            policy_context["cwd_repo_command"] = repo_command
+            policy_context["cwd_repo_command"] = (
+                _bounded_command_result(repo_command) if repo_command else None
+            )
             policy_context["cwd_repo"] = cwd_repo
         if load_warnings:
             policy_context["load_warnings"] = load_warnings
@@ -1379,7 +1444,7 @@ def build_report(
             ],
             cwd=cwd,
         )
-        report["owner_check"] = owner_cmd
+        report["owner_check"] = _bounded_command_result(owner_cmd)
         blockers.extend(owner_blockers(owner_payload))
 
         steering_payload, steering_cmd = _run_json(
@@ -1400,11 +1465,11 @@ def build_report(
             ],
             cwd=cwd,
         )
-        report["mailbox_check"] = steering_cmd
+        report["mailbox_check"] = _bounded_command_result(steering_cmd)
         if isinstance(steering_payload, dict) and steering_payload.get("message"):
             blockers.append("operator steering message exists; read and obey before settlement")
 
-        pr_view, view_cmd = _run_json(
+        pr_view, view_cmd = _run_json_with_gh_retries(
             [
                 "gh",
                 "pr",
@@ -1418,7 +1483,7 @@ def build_report(
             ],
             cwd=cwd,
         )
-        report["pr_view_check"] = view_cmd
+        report["pr_view_check"] = _bounded_command_result(view_cmd)
         blockers.extend(head_blockers(selected, pr_view))
 
         base_ref = "main"
@@ -1426,7 +1491,7 @@ def build_report(
             base_ref = str(pr_view.get("baseRefName") or base_ref)
         protected_branch = quote(base_ref, safe="")
 
-        protection, protection_cmd = _run_json(
+        protection, protection_cmd = _run_json_with_gh_retries(
             [
                 "gh",
                 "api",
@@ -1434,12 +1499,12 @@ def build_report(
             ],
             cwd=cwd,
         )
-        report["required_check_source_command"] = protection_cmd
+        report["required_check_source_command"] = _bounded_command_result(protection_cmd)
 
         head_ref = report["head_sha"]
         if isinstance(pr_view, dict):
             head_ref = str(pr_view.get("headRefOid") or head_ref)
-        check_runs_payload, check_runs_cmd = _run_json(
+        check_runs_payload, check_runs_cmd = _run_json_with_gh_retries(
             [
                 "gh",
                 "api",
@@ -1452,9 +1517,9 @@ def build_report(
             ],
             cwd=cwd,
         )
-        report["check_run_source_command"] = check_runs_cmd
+        report["check_run_source_command"] = _bounded_command_result(check_runs_cmd)
 
-        required_checks, required_cmd = _run_json(
+        required_checks, required_cmd = _run_json_with_gh_retries(
             [
                 "gh",
                 "pr",
@@ -1466,7 +1531,7 @@ def build_report(
             ],
             cwd=cwd,
         )
-        report["required_checks_command"] = required_cmd
+        report["required_checks_command"] = _bounded_command_result(required_cmd)
         check_report = required_check_report(required_checks)
         report["checks"]["required"] = check_report
         blockers.extend(check_report["blockers"])
@@ -1525,7 +1590,7 @@ def _load_single_pr_packet(*, cwd: Path, pr: int, repo: str | None) -> dict[str,
         command.extend(["--repo", repo])
     payload, result = _run_json(command, cwd=cwd, timeout=SINGLE_PACKET_TIMEOUT_SECONDS)
     if result["returncode"] != 0:
-        raise RuntimeError(result["stderr"] or result["stdout"] or "merge-packet failed")
+        raise RuntimeError(_command_failure_detail(result, "merge-packet failed"))
     if not isinstance(payload, dict):
         raise RuntimeError("merge-packet did not return a JSON object")
     return payload
@@ -1546,7 +1611,7 @@ def _load_broad_packet_bulk(*, cwd: Path, limit: int, repo: str | None) -> dict[
         command.extend(["--repo", repo])
     payload, result = _run_json(command, cwd=cwd, timeout=BROAD_PACKET_TIMEOUT_SECONDS)
     if result["returncode"] != 0:
-        raise RuntimeError(result["stderr"] or result["stdout"] or "merge-packet failed")
+        raise RuntimeError(_command_failure_detail(result, "merge-packet failed"))
     if not isinstance(payload, dict):
         raise RuntimeError("merge-packet did not return a JSON object")
     return payload

--- a/scripts/settle_one_pr.py
+++ b/scripts/settle_one_pr.py
@@ -65,6 +65,11 @@ SURFACE_EXCLUDE_REASON = (
     "security/auth/RBAC/secrets/deploy/workflow/legal/compliance/destructive/"
     "migration/public-API surface"
 )
+PYTHON_EXECUTABLE = sys.executable or "python3"
+
+
+def _python_command(*args: str) -> list[str]:
+    return [PYTHON_EXECUTABLE, *args]
 
 
 def _repo_root() -> Path:
@@ -1088,7 +1093,7 @@ def _has_policy_file_scope(metadata: dict[str, Any]) -> bool:
 
 def load_active_owned_prs(cwd: Path) -> tuple[set[int], dict[str, Any]]:
     payload, command = _run_json(
-        ["python3", "scripts/agent_bridge.py", "operator-snapshot", "--json"],
+        _python_command("scripts/agent_bridge.py", "operator-snapshot", "--json"),
         cwd=cwd,
         timeout=OPERATOR_SNAPSHOT_TIMEOUT_SECONDS,
     )
@@ -1331,7 +1336,7 @@ def build_report(
                 preselection_blockers.append(snapshot_blocker)
         elif snapshot_preblocked:
             active_owned_command = {
-                "command": "python3 scripts/agent_bridge.py operator-snapshot --json",
+                "command": f"{PYTHON_EXECUTABLE} scripts/agent_bridge.py operator-snapshot --json",
                 "returncode": None,
                 "skipped": True,
                 "reason": "operator-snapshot failure already carried by packet load_blockers",
@@ -1432,7 +1437,7 @@ def build_report(
         steering_root = state_root / ".aragora" / "operator-steering"
         owner_payload, owner_cmd = _run_json(
             [
-                "python3",
+                PYTHON_EXECUTABLE,
                 "scripts/identify_lane_owner.py",
                 "--pr",
                 str(pr_number),
@@ -1449,7 +1454,7 @@ def build_report(
 
         steering_payload, steering_cmd = _run_json(
             [
-                "python3",
+                PYTHON_EXECUTABLE,
                 "scripts/read_operator_steering.py",
                 "--pr",
                 str(pr_number),
@@ -1577,7 +1582,7 @@ def build_report(
 
 def _load_single_pr_packet(*, cwd: Path, pr: int, repo: str | None) -> dict[str, Any]:
     command = [
-        "python3",
+        PYTHON_EXECUTABLE,
         "-m",
         "aragora.cli.main",
         "review-queue",
@@ -1598,7 +1603,7 @@ def _load_single_pr_packet(*, cwd: Path, pr: int, repo: str | None) -> dict[str,
 
 def _load_broad_packet_bulk(*, cwd: Path, limit: int, repo: str | None) -> dict[str, Any]:
     command = [
-        "python3",
+        PYTHON_EXECUTABLE,
         "-m",
         "aragora.cli.main",
         "review-queue",

--- a/tests/scripts/test_settle_one_pr.py
+++ b/tests/scripts/test_settle_one_pr.py
@@ -601,7 +601,13 @@ def test_broad_packet_lazy_loader_uses_single_bulk_packet(monkeypatch) -> None:
     def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
         del cwd, timeout
         commands.append(args)
-        if args[:5] == ["python3", "-m", "aragora.cli.main", "review-queue", "merge-packet"]:
+        if args[:5] == [
+            settle_one_pr.PYTHON_EXECUTABLE,
+            "-m",
+            "aragora.cli.main",
+            "review-queue",
+            "merge-packet",
+        ]:
             assert "--limit" in args
             assert "--pr" not in args
             return _packet(_entry(7376), _entry(7449)), {"command": "packet", "returncode": 0}
@@ -625,7 +631,13 @@ def test_broad_packet_lazy_loader_falls_back_when_bulk_packet_fails(
         nonlocal bulk_calls
         del cwd, timeout
         commands.append(args)
-        if args[:5] == ["python3", "-m", "aragora.cli.main", "review-queue", "merge-packet"]:
+        if args[:5] == [
+            settle_one_pr.PYTHON_EXECUTABLE,
+            "-m",
+            "aragora.cli.main",
+            "review-queue",
+            "merge-packet",
+        ]:
             if "--limit" in args:
                 bulk_calls += 1
                 return None, {"command": "bulk-packet", "returncode": 1, "stderr": "HTTP 504"}
@@ -647,7 +659,11 @@ def test_broad_packet_lazy_loader_falls_back_when_bulk_packet_fails(
                 ],
                 {"command": "metadata", "returncode": 0},
             )
-        if args[:3] == ["python3", "scripts/agent_bridge.py", "operator-snapshot"]:
+        if args[:3] == [
+            settle_one_pr.PYTHON_EXECUTABLE,
+            "scripts/agent_bridge.py",
+            "operator-snapshot",
+        ]:
             return {"lanes": []}, {"command": "snapshot", "returncode": 0}
         raise AssertionError(args)
 
@@ -668,7 +684,13 @@ def test_broad_packet_lazy_loader_falls_back_when_bulk_packet_times_out(
 ) -> None:
     def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
         del cwd, timeout
-        if args[:5] == ["python3", "-m", "aragora.cli.main", "review-queue", "merge-packet"]:
+        if args[:5] == [
+            settle_one_pr.PYTHON_EXECUTABLE,
+            "-m",
+            "aragora.cli.main",
+            "review-queue",
+            "merge-packet",
+        ]:
             if "--limit" in args:
                 return None, {
                     "command": "bulk-packet",
@@ -689,7 +711,11 @@ def test_broad_packet_lazy_loader_falls_back_when_bulk_packet_times_out(
                 ],
                 {"command": "metadata", "returncode": 0},
             )
-        if args[:3] == ["python3", "scripts/agent_bridge.py", "operator-snapshot"]:
+        if args[:3] == [
+            settle_one_pr.PYTHON_EXECUTABLE,
+            "scripts/agent_bridge.py",
+            "operator-snapshot",
+        ]:
             return {"lanes": []}, {"command": "snapshot", "returncode": 0}
         raise AssertionError(args)
 
@@ -708,7 +734,13 @@ def test_broad_packet_lazy_loader_returns_empty_when_bulk_and_light_metadata_fai
 ) -> None:
     def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
         del cwd, timeout
-        if args[:5] == ["python3", "-m", "aragora.cli.main", "review-queue", "merge-packet"]:
+        if args[:5] == [
+            settle_one_pr.PYTHON_EXECUTABLE,
+            "-m",
+            "aragora.cli.main",
+            "review-queue",
+            "merge-packet",
+        ]:
             return None, {"command": "bulk-packet", "returncode": 1, "stderr": "HTTP 504"}
         if args[:3] == ["gh", "pr", "list"]:
             return None, {"command": "metadata", "returncode": 1, "stderr": "HTTP 504"}
@@ -727,7 +759,13 @@ def test_broad_packet_lazy_loader_surfaces_targeted_packet_failures(
 ) -> None:
     def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
         del cwd, timeout
-        if args[:5] == ["python3", "-m", "aragora.cli.main", "review-queue", "merge-packet"]:
+        if args[:5] == [
+            settle_one_pr.PYTHON_EXECUTABLE,
+            "-m",
+            "aragora.cli.main",
+            "review-queue",
+            "merge-packet",
+        ]:
             if "--limit" in args:
                 return None, {"command": "bulk-packet", "returncode": 1, "stderr": "HTTP 504"}
             pr_number = args[args.index("--pr") + 1]
@@ -747,7 +785,11 @@ def test_broad_packet_lazy_loader_surfaces_targeted_packet_failures(
                 ],
                 {"command": "metadata", "returncode": 0},
             )
-        if args[:3] == ["python3", "scripts/agent_bridge.py", "operator-snapshot"]:
+        if args[:3] == [
+            settle_one_pr.PYTHON_EXECUTABLE,
+            "scripts/agent_bridge.py",
+            "operator-snapshot",
+        ]:
             return {"lanes": []}, {"command": "snapshot", "returncode": 0}
         raise AssertionError(args)
 
@@ -765,7 +807,13 @@ def test_broad_packet_lazy_loader_surfaces_targeted_packet_timeout(
 ) -> None:
     def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
         del cwd, timeout
-        if args[:5] == ["python3", "-m", "aragora.cli.main", "review-queue", "merge-packet"]:
+        if args[:5] == [
+            settle_one_pr.PYTHON_EXECUTABLE,
+            "-m",
+            "aragora.cli.main",
+            "review-queue",
+            "merge-packet",
+        ]:
             if "--limit" in args:
                 return None, {"command": "bulk-packet", "returncode": 1, "stderr": "HTTP 504"}
             return None, {
@@ -785,7 +833,11 @@ def test_broad_packet_lazy_loader_surfaces_targeted_packet_timeout(
                 ],
                 {"command": "metadata", "returncode": 0},
             )
-        if args[:3] == ["python3", "scripts/agent_bridge.py", "operator-snapshot"]:
+        if args[:3] == [
+            settle_one_pr.PYTHON_EXECUTABLE,
+            "scripts/agent_bridge.py",
+            "operator-snapshot",
+        ]:
             return {"lanes": []}, {"command": "snapshot", "returncode": 0}
         raise AssertionError(args)
 
@@ -803,7 +855,13 @@ def test_broad_packet_lazy_loader_surfaces_targeted_packet_timeout(
 def test_broad_packet_lazy_loader_warns_on_large_fallback_fanout(monkeypatch) -> None:
     def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
         del cwd, timeout
-        if args[:5] == ["python3", "-m", "aragora.cli.main", "review-queue", "merge-packet"]:
+        if args[:5] == [
+            settle_one_pr.PYTHON_EXECUTABLE,
+            "-m",
+            "aragora.cli.main",
+            "review-queue",
+            "merge-packet",
+        ]:
             if "--limit" in args:
                 return None, {"command": "bulk-packet", "returncode": 1, "stderr": "HTTP 504"}
             pr_number = int(args[args.index("--pr") + 1])
@@ -825,7 +883,11 @@ def test_broad_packet_lazy_loader_warns_on_large_fallback_fanout(monkeypatch) ->
                 ],
                 {"command": "metadata", "returncode": 0},
             )
-        if args[:3] == ["python3", "scripts/agent_bridge.py", "operator-snapshot"]:
+        if args[:3] == [
+            settle_one_pr.PYTHON_EXECUTABLE,
+            "scripts/agent_bridge.py",
+            "operator-snapshot",
+        ]:
             return {"lanes": []}, {"command": "snapshot", "returncode": 0}
         raise AssertionError(args)
 
@@ -842,7 +904,13 @@ def test_broad_packet_lazy_loader_warns_on_large_fallback_fanout(monkeypatch) ->
 def test_combine_packets_preserves_source_packet_timestamps(monkeypatch) -> None:
     def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
         del cwd, timeout
-        if args[:5] == ["python3", "-m", "aragora.cli.main", "review-queue", "merge-packet"]:
+        if args[:5] == [
+            settle_one_pr.PYTHON_EXECUTABLE,
+            "-m",
+            "aragora.cli.main",
+            "review-queue",
+            "merge-packet",
+        ]:
             if "--limit" in args:
                 return None, {"command": "bulk-packet", "returncode": 1, "stderr": "HTTP 504"}
             pr_number = int(args[args.index("--pr") + 1])
@@ -857,7 +925,11 @@ def test_combine_packets_preserves_source_packet_timestamps(monkeypatch) -> None
                 ],
                 {"command": "metadata", "returncode": 0},
             )
-        if args[:3] == ["python3", "scripts/agent_bridge.py", "operator-snapshot"]:
+        if args[:3] == [
+            settle_one_pr.PYTHON_EXECUTABLE,
+            "scripts/agent_bridge.py",
+            "operator-snapshot",
+        ]:
             return {"lanes": []}, {"command": "snapshot", "returncode": 0}
         raise AssertionError(args)
 
@@ -908,7 +980,11 @@ def test_build_report_threads_repo_to_policy_metadata(monkeypatch) -> None:
                 ],
                 {"command": "metadata", "returncode": 0},
             )
-        if args[:3] == ["python3", "scripts/agent_bridge.py", "operator-snapshot"]:
+        if args[:3] == [
+            settle_one_pr.PYTHON_EXECUTABLE,
+            "scripts/agent_bridge.py",
+            "operator-snapshot",
+        ]:
             return {"lanes": []}, {"command": "snapshot", "returncode": 0}
         if args[:3] == ["gh", "pr", "view"] and args[3] == "7451":
             return (
@@ -966,7 +1042,11 @@ def test_build_report_explicit_pr_loads_policy_metadata_without_broad_list(monke
                 },
                 {"command": "policy-view", "returncode": 0},
             )
-        if args[:3] == ["python3", "scripts/agent_bridge.py", "operator-snapshot"]:
+        if args[:3] == [
+            settle_one_pr.PYTHON_EXECUTABLE,
+            "scripts/agent_bridge.py",
+            "operator-snapshot",
+        ]:
             return {"lanes": []}, {"command": "snapshot", "returncode": 0}
         raise AssertionError(args)
 
@@ -1003,7 +1083,11 @@ def test_build_report_fails_closed_when_operator_snapshot_fails(monkeypatch) -> 
                 [{"number": 7451, "title": "fix: candidate", "headRefName": "codex/candidate"}],
                 {"command": "metadata", "returncode": 0},
             )
-        if args[:3] == ["python3", "scripts/agent_bridge.py", "operator-snapshot"]:
+        if args[:3] == [
+            settle_one_pr.PYTHON_EXECUTABLE,
+            "scripts/agent_bridge.py",
+            "operator-snapshot",
+        ]:
             return None, {"command": "snapshot", "returncode": 1, "stderr": "snapshot failed"}
         if args[:3] == ["gh", "pr", "view"] and args[3] == "7451":
             return (
@@ -1053,7 +1137,11 @@ def test_build_report_does_not_reload_snapshot_when_packet_already_failed_closed
         del cwd, timeout
         if args[:3] == ["gh", "pr", "list"]:
             return [], {"command": "metadata", "returncode": 0}
-        if args[:3] == ["python3", "scripts/agent_bridge.py", "operator-snapshot"]:
+        if args[:3] == [
+            settle_one_pr.PYTHON_EXECUTABLE,
+            "scripts/agent_bridge.py",
+            "operator-snapshot",
+        ]:
             snapshot_called = True
             return None, {"command": "snapshot", "returncode": 1, "stderr": "outage"}
         raise AssertionError(args)
@@ -1087,7 +1175,11 @@ def test_build_report_blocks_repo_mismatch_when_repo_override_supplied(monkeypat
                 [{"number": 7451, "title": "fix: candidate", "headRefName": "codex/candidate"}],
                 {"command": "metadata", "returncode": 0},
             )
-        if args[:3] == ["python3", "scripts/agent_bridge.py", "operator-snapshot"]:
+        if args[:3] == [
+            settle_one_pr.PYTHON_EXECUTABLE,
+            "scripts/agent_bridge.py",
+            "operator-snapshot",
+        ]:
             snapshot_called = True
             return {"lanes": []}, {"command": "snapshot", "returncode": 0}
         if args[:3] == ["gh", "pr", "view"] and args[3] == "7451":
@@ -1147,11 +1239,19 @@ def test_lazy_policy_metadata_continues_past_failed_pr_view(monkeypatch) -> None
                 ],
                 {"command": "metadata", "returncode": 0},
             )
-        if args[:3] == ["python3", "scripts/agent_bridge.py", "operator-snapshot"]:
+        if args[:3] == [
+            settle_one_pr.PYTHON_EXECUTABLE,
+            "scripts/agent_bridge.py",
+            "operator-snapshot",
+        ]:
             return {"lanes": []}, {"command": "snapshot", "returncode": 0}
-        if args[:3] == ["python3", "scripts/identify_lane_owner.py", "--pr"]:
+        if args[:3] == [settle_one_pr.PYTHON_EXECUTABLE, "scripts/identify_lane_owner.py", "--pr"]:
             return {"status": "completed"}, {"command": "owner", "returncode": 0}
-        if args[:3] == ["python3", "scripts/read_operator_steering.py", "--pr"]:
+        if args[:3] == [
+            settle_one_pr.PYTHON_EXECUTABLE,
+            "scripts/read_operator_steering.py",
+            "--pr",
+        ]:
             return {"message_count": 0}, {"command": "mailbox", "returncode": 0}
         if args[:3] == ["gh", "pr", "view"] and args[3] == "7451":
             return None, {"command": "policy-view-7451", "returncode": 1, "stderr": "timeout"}
@@ -1247,11 +1347,19 @@ def test_explicit_pr_reuses_preloaded_policy_file_scope(monkeypatch) -> None:
     def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
         nonlocal policy_view_calls
         del cwd, timeout
-        if args[:3] == ["python3", "scripts/agent_bridge.py", "operator-snapshot"]:
+        if args[:3] == [
+            settle_one_pr.PYTHON_EXECUTABLE,
+            "scripts/agent_bridge.py",
+            "operator-snapshot",
+        ]:
             return {"lanes": []}, {"command": "snapshot", "returncode": 0}
-        if args[:3] == ["python3", "scripts/identify_lane_owner.py", "--pr"]:
+        if args[:3] == [settle_one_pr.PYTHON_EXECUTABLE, "scripts/identify_lane_owner.py", "--pr"]:
             return {"status": "completed"}, {"command": "owner", "returncode": 0}
-        if args[:3] == ["python3", "scripts/read_operator_steering.py", "--pr"]:
+        if args[:3] == [
+            settle_one_pr.PYTHON_EXECUTABLE,
+            "scripts/read_operator_steering.py",
+            "--pr",
+        ]:
             return {"message_count": 0}, {"command": "mailbox", "returncode": 0}
         if (
             args[:3] == ["gh", "pr", "view"]
@@ -1361,7 +1469,11 @@ def test_build_report_fails_closed_when_selected_policy_metadata_unavailable(
                 ],
                 {"command": "metadata", "returncode": 0},
             )
-        if args[:3] == ["python3", "scripts/agent_bridge.py", "operator-snapshot"]:
+        if args[:3] == [
+            settle_one_pr.PYTHON_EXECUTABLE,
+            "scripts/agent_bridge.py",
+            "operator-snapshot",
+        ]:
             return {"lanes": []}, {"command": "snapshot", "returncode": 0}
         if args[:3] == ["gh", "pr", "view"] and args[3] == "7451":
             return None, {"command": "policy-view", "returncode": 1, "stderr": "timeout"}
@@ -1402,7 +1514,11 @@ def test_build_report_lazy_loads_file_scope_for_selected_candidate(monkeypatch) 
                 ],
                 {"command": "metadata", "returncode": 0},
             )
-        if args[:3] == ["python3", "scripts/agent_bridge.py", "operator-snapshot"]:
+        if args[:3] == [
+            settle_one_pr.PYTHON_EXECUTABLE,
+            "scripts/agent_bridge.py",
+            "operator-snapshot",
+        ]:
             return {"lanes": []}, {"command": "snapshot", "returncode": 0}
         if args[:3] == ["gh", "pr", "view"] and args[3] == "7451":
             return (
@@ -1726,11 +1842,19 @@ def test_build_report_reads_required_checks_from_pr_base_branch(monkeypatch) -> 
         commands.append(args)
         if args[:3] == ["gh", "pr", "list"]:
             return [], {"command": "metadata", "returncode": 0}
-        if args[:3] == ["python3", "scripts/agent_bridge.py", "operator-snapshot"]:
+        if args[:3] == [
+            settle_one_pr.PYTHON_EXECUTABLE,
+            "scripts/agent_bridge.py",
+            "operator-snapshot",
+        ]:
             return {"lanes": []}, {"command": "snapshot", "returncode": 0}
-        if args[:3] == ["python3", "scripts/identify_lane_owner.py", "--pr"]:
+        if args[:3] == [settle_one_pr.PYTHON_EXECUTABLE, "scripts/identify_lane_owner.py", "--pr"]:
             return {"status": "completed"}, {"command": "owner", "returncode": 0}
-        if args[:3] == ["python3", "scripts/read_operator_steering.py", "--pr"]:
+        if args[:3] == [
+            settle_one_pr.PYTHON_EXECUTABLE,
+            "scripts/read_operator_steering.py",
+            "--pr",
+        ]:
             return {"message_count": 0}, {"command": "mailbox", "returncode": 0}
         if args[:3] == ["gh", "pr", "view"]:
             return (
@@ -1810,11 +1934,19 @@ def test_build_report_fails_closed_when_required_check_sources_unreadable(monkey
         del cwd, timeout
         if args[:3] == ["gh", "pr", "list"]:
             return [], {"command": "metadata", "returncode": 0}
-        if args[:3] == ["python3", "scripts/agent_bridge.py", "operator-snapshot"]:
+        if args[:3] == [
+            settle_one_pr.PYTHON_EXECUTABLE,
+            "scripts/agent_bridge.py",
+            "operator-snapshot",
+        ]:
             return {"lanes": []}, {"command": "snapshot", "returncode": 0}
-        if args[:3] == ["python3", "scripts/identify_lane_owner.py", "--pr"]:
+        if args[:3] == [settle_one_pr.PYTHON_EXECUTABLE, "scripts/identify_lane_owner.py", "--pr"]:
             return {"status": "completed"}, {"command": "owner", "returncode": 0}
-        if args[:3] == ["python3", "scripts/read_operator_steering.py", "--pr"]:
+        if args[:3] == [
+            settle_one_pr.PYTHON_EXECUTABLE,
+            "scripts/read_operator_steering.py",
+            "--pr",
+        ]:
             return {"message_count": 0}, {"command": "mailbox", "returncode": 0}
         if args[:3] == ["gh", "pr", "view"]:
             return (

--- a/tests/scripts/test_settle_one_pr.py
+++ b/tests/scripts/test_settle_one_pr.py
@@ -113,6 +113,59 @@ def test_run_reports_timeout_and_terminates_process_group(monkeypatch) -> None:
     assert killed == [(4242, settle_one_pr.signal.SIGKILL)]
 
 
+def test_run_json_with_gh_retries_retries_transient_connection_error(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
+        del cwd, timeout
+        calls.append(args)
+        if len(calls) == 1:
+            return None, {
+                "command": "gh pr view 7766",
+                "returncode": 1,
+                "stdout": "",
+                "stderr": "error connecting to api.github.com",
+            }
+        return (
+            {"number": 7766},
+            {
+                "command": "gh pr view 7766",
+                "returncode": 0,
+                "stdout": '{"number":7766}',
+                "stderr": "",
+            },
+        )
+
+    monkeypatch.setattr(settle_one_pr, "_run_json", fake_run_json)
+
+    payload, result = settle_one_pr._run_json_with_gh_retries(
+        ["gh", "pr", "view", "7766"],
+        cwd=Path.cwd(),
+        retries=2,
+    )
+
+    assert payload == {"number": 7766}
+    assert result["returncode"] == 0
+    assert result["attempt_count"] == 2
+    assert len(result["attempts"]) == 2
+
+
+def test_bounded_command_result_truncates_embedded_stdout() -> None:
+    result = {
+        "command": "python3 scripts/agent_bridge.py operator-snapshot --json",
+        "returncode": 0,
+        "stdout": "x" * (settle_one_pr.COMMAND_OUTPUT_CHAR_LIMIT + 50),
+        "stderr": "",
+    }
+
+    bounded = settle_one_pr._bounded_command_result(result)
+
+    assert bounded["stdout_truncated"] is True
+    assert bounded["stdout_original_chars"] == settle_one_pr.COMMAND_OUTPUT_CHAR_LIMIT + 50
+    assert len(bounded["stdout"]) < len(result["stdout"])
+    assert "[truncated 50 chars]" in bounded["stdout"]
+
+
 def test_select_candidate_prefers_admin_order() -> None:
     unauthorized = _entry(1001)
     authorized = _entry(

--- a/tests/scripts/test_settle_one_pr.py
+++ b/tests/scripts/test_settle_one_pr.py
@@ -852,6 +852,65 @@ def test_broad_packet_lazy_loader_surfaces_targeted_packet_timeout(
     ]
 
 
+def test_single_packet_reports_json_parse_error(monkeypatch) -> None:
+    def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
+        del args, cwd, timeout
+        return None, {
+            "command": "packet",
+            "returncode": 0,
+            "stdout": "<html>not json</html>",
+            "stderr": "",
+            "json_error": "Expecting value: line 1 column 1 (char 0)",
+        }
+
+    monkeypatch.setattr(settle_one_pr, "_run_json", fake_run_json)
+
+    try:
+        settle_one_pr._load_single_pr_packet(cwd=Path.cwd(), pr=7449, repo=None)
+    except RuntimeError as exc:
+        message = str(exc)
+    else:
+        raise AssertionError("expected RuntimeError")
+
+    assert "Expecting value" in message
+    assert "not json" not in message
+
+
+def test_broad_packet_lazy_loader_reports_bulk_json_parse_error(monkeypatch) -> None:
+    def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
+        del cwd, timeout
+        if args[:5] == [
+            settle_one_pr.PYTHON_EXECUTABLE,
+            "-m",
+            "aragora.cli.main",
+            "review-queue",
+            "merge-packet",
+        ]:
+            return None, {
+                "command": "bulk-packet",
+                "returncode": 0,
+                "stdout": "<html>not json</html>",
+                "stderr": "",
+                "json_error": "Expecting value: line 1 column 1 (char 0)",
+            }
+        if args[:3] == ["gh", "pr", "list"]:
+            return None, {"command": "metadata", "returncode": 1, "stderr": "HTTP 504"}
+        raise AssertionError(args)
+
+    monkeypatch.setattr(settle_one_pr, "_run_json", fake_run_json)
+
+    packet = load_broad_packet_lazily(cwd=Path.cwd(), limit=100, repo=None)
+
+    assert packet["entries"] == []
+    assert packet["load_warnings"] == [
+        "bulk merge-packet failed; using fallback: Expecting value: line 1 column 1 (char 0)"
+    ]
+    assert packet["load_blockers"] == [
+        "Expecting value: line 1 column 1 (char 0)",
+        "HTTP 504",
+    ]
+
+
 def test_broad_packet_lazy_loader_warns_on_large_fallback_fanout(monkeypatch) -> None:
     def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
         del cwd, timeout

--- a/tests/scripts/test_settle_one_pr.py
+++ b/tests/scripts/test_settle_one_pr.py
@@ -113,6 +113,22 @@ def test_run_reports_timeout_and_terminates_process_group(monkeypatch) -> None:
     assert killed == [(4242, settle_one_pr.signal.SIGKILL)]
 
 
+def test_run_reports_process_start_oserror(monkeypatch) -> None:
+    def fake_popen(*args, **kwargs):
+        assert args[0] == ["missing-helper"]
+        assert kwargs["start_new_session"] is True
+        raise OSError("helper unavailable")
+
+    monkeypatch.setattr(settle_one_pr.subprocess, "Popen", fake_popen)
+
+    result = settle_one_pr._run(["missing-helper"], cwd=Path.cwd(), timeout=7)
+
+    assert result["returncode"] == 127
+    assert result["stdout"] == ""
+    assert "failed to start command" in result["stderr"]
+    assert "helper unavailable" in result["stderr"]
+
+
 def test_run_json_with_gh_retries_retries_transient_connection_error(monkeypatch) -> None:
     calls: list[list[str]] = []
 


### PR DESCRIPTION
## Summary
- bounds `settle_one_pr.py` helper command output and transient GitHub retry reporting
- reuses the current Python executable for nested helper calls
- preserves merge-packet JSON parse errors when nested `merge-packet --json` exits zero with invalid JSON, instead of replacing them with a generic non-JSON blocker
- reports helper process-start `OSError` failures as structured command results instead of crashing the steward

## Current head
`4ca66663f4bd1802a2664e71fa103838533b015b`

## Validation
- RED: `PYTHONDONTWRITEBYTECODE=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_settle_one_pr.py::test_run_reports_process_start_oserror` failed before the process-start fix with uncaught `OSError: helper unavailable`
- GREEN: `PYTHONDONTWRITEBYTECODE=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_settle_one_pr.py::test_run_reports_process_start_oserror tests/scripts/test_settle_one_pr.py::test_run_reports_timeout_and_terminates_process_group` -> 2 passed
- `PYTHONDONTWRITEBYTECODE=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_settle_one_pr.py` -> 62 passed
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/settle_one_pr.py tests/scripts/test_settle_one_pr.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/settle_one_pr.py tests/scripts/test_settle_one_pr.py`
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> preflight ok
- Branch push hooks passed, including ruff, ruff format, mypy for changed files, gitleaks, and portability guard

## Governance
Draft remains intentional. Do not mark ready, settle, or merge from this PR without the normal exact-head gates and separate authorization.
