### PR TITLE
fix(metrics): fail closed on malformed boss metrics jsonl

### DIFF
--- a/scripts/analyze_boss_metrics.py
+++ b/scripts/analyze_boss_metrics.py
@@ -20,15 +20,17 @@ def _load_jsonl(path: Path) -> list[dict[str, Any]]:
     if not path.exists():
         raise FileNotFoundError(f"metrics file not found: {path}")
     records: list[dict[str, Any]] = []
-    for line in path.read_text(encoding="utf-8").splitlines():
-        if not line.strip():
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        raw = line.strip()
+        if not raw:
             continue
         try:
-            payload = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        if isinstance(payload, dict):
-            records.append(payload)
+            payload = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"malformed JSONL row at {path}:{line_number}: {exc.msg}") from exc
+        if not isinstance(payload, dict):
+            raise ValueError(f"JSONL row at {path}:{line_number} must be an object")
+        records.append(payload)
     return records
 
 

--- a/tests/scripts/test_analyze_boss_metrics.py
+++ b/tests/scripts/test_analyze_boss_metrics.py
@@ -1,6 +1,9 @@
 """Tests for analyze_boss_metrics script."""
 
+import json
 from pathlib import Path
+
+import pytest
 
 from scripts.analyze_boss_metrics import analyze_boss_metrics, analyze_metrics, render_text
 
@@ -73,3 +76,40 @@ def test_render_text_includes_invalid_numeric_metrics():
 
     assert "invalid numeric metrics" in text
     assert "prompt_chars: 1" in text
+
+
+def test_analyze_boss_metrics_rejects_malformed_metrics_jsonl(tmp_path: Path):
+    metrics_path = tmp_path / "boss_metrics.jsonl"
+    metrics_path.write_text(
+        "\n".join(
+            [
+                json.dumps({"issue_number": 1064, "terminal_class": "deliverable_pr_created"}),
+                "{not json}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=r"malformed JSONL row at .*boss_metrics\.jsonl:2"):
+        analyze_boss_metrics(metrics_path=metrics_path, signals_path=None)
+
+
+def test_analyze_boss_metrics_rejects_non_object_metrics_jsonl(tmp_path: Path):
+    metrics_path = tmp_path / "boss_metrics.jsonl"
+    metrics_path.write_text(json.dumps([{"issue_number": 1064}]), encoding="utf-8")
+
+    with pytest.raises(ValueError, match=r"JSONL row at .*boss_metrics\.jsonl:1 must be an object"):
+        analyze_boss_metrics(metrics_path=metrics_path, signals_path=None)
+
+
+def test_analyze_boss_metrics_rejects_malformed_signals_jsonl(tmp_path: Path):
+    metrics_path = tmp_path / "boss_metrics.jsonl"
+    metrics_path.write_text(
+        json.dumps({"issue_number": 1064, "terminal_class": "deliverable_pr_created"}),
+        encoding="utf-8",
+    )
+    signals_path = tmp_path / "outcome_signals.jsonl"
+    signals_path.write_text("{not json}", encoding="utf-8")
+
+    with pytest.raises(ValueError, match=r"malformed JSONL row at .*outcome_signals\.jsonl:1"):
+        analyze_boss_metrics(metrics_path=metrics_path, signals_path=signals_path)


### PR DESCRIPTION
Summary: Make the boss metrics analyzer fail closed on malformed JSONL input instead of silently dropping bad rows. The loader now reports file and line number for malformed JSON and non-object rows, including outcome signals input. Validation: /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_analyze_boss_metrics.py -q; /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/analyze_boss_metrics.py tests/scripts/test_analyze_boss_metrics.py; git diff --check; bash scripts/automation_pr_preflight.sh origin/main HEAD.