### PR TITLE
fix(benchmark-truth): fail closed on malformed scorecard metrics

### DIFF
--- a/scripts/measure_b0_scorecard.py
+++ b/scripts/measure_b0_scorecard.py
@@ -432,11 +432,20 @@ def load_metrics(path: Path, window: int | None = None) -> list[dict[str, Any]]:
         return []
     rows: list[dict[str, Any]] = []
     try:
-        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
-            try:
-                rows.append(json.loads(line))
-            except json.JSONDecodeError:
+        for line_number, line in enumerate(
+            path.read_text(encoding="utf-8", errors="replace").splitlines(),
+            start=1,
+        ):
+            raw = line.strip()
+            if not raw:
                 continue
+            try:
+                payload = json.loads(raw)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"malformed JSONL row at {path}:{line_number}: {exc.msg}") from exc
+            if not isinstance(payload, dict):
+                raise ValueError(f"JSONL row at {path}:{line_number} must be an object")
+            rows.append(payload)
     except OSError:
         return []
     if window and window > 0:

--- a/tests/scripts/test_measure_b0_scorecard.py
+++ b/tests/scripts/test_measure_b0_scorecard.py
@@ -4,6 +4,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 _scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
 if _scripts_dir not in sys.path:
     sys.path.insert(0, _scripts_dir)
@@ -93,6 +95,30 @@ def test_main_json_mode_keeps_json_output(tmp_path: Path, capsys) -> None:
     assert payload["status"] == "active"
     assert payload["no_rescue_success_rate"] == 1.0
     assert payload["unique_issues_attempted"] == 1
+
+
+def test_load_metrics_rejects_malformed_jsonl_row(tmp_path: Path) -> None:
+    metrics_path = tmp_path / "boss_metrics.jsonl"
+    metrics_path.write_text(
+        "\n".join(
+            [
+                json.dumps({"issue_number": 1001, "terminal_class": "deliverable_pr_created"}),
+                "{not json}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=r"malformed JSONL row at .*boss_metrics\.jsonl:2"):
+        mod.load_metrics(metrics_path)
+
+
+def test_load_metrics_rejects_non_object_jsonl_row(tmp_path: Path) -> None:
+    metrics_path = tmp_path / "boss_metrics.jsonl"
+    metrics_path.write_text(json.dumps([{"issue_number": 1001}]), encoding="utf-8")
+
+    with pytest.raises(ValueError, match=r"JSONL row at .*boss_metrics\.jsonl:1 must be an object"):
+        mod.load_metrics(metrics_path)
 
 
 def test_main_uses_resolved_metrics_path_for_default_metrics(


### PR DESCRIPTION
Summary: Make the B0 scorecard publisher fail closed on malformed metrics JSONL instead of silently skipping bad rows or accepting non-object rows. The loader now reports file and line number for malformed JSON and non-object rows before scorecards can be published. Validation: /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_measure_b0_scorecard.py -q; /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/measure_b0_scorecard.py tests/scripts/test_measure_b0_scorecard.py; git diff --check; bash scripts/automation_pr_preflight.sh origin/main HEAD.