### PR TITLE
fix(proof): fail closed on missing capability matrix base

### DIFF
--- a/scripts/capability_matrix_delta.py
+++ b/scripts/capability_matrix_delta.py
@@ -6,11 +6,16 @@ from __future__ import annotations
 import argparse
 import re
 import subprocess
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 MATRIX_PATH = Path("docs/CAPABILITY_MATRIX.md")
+
+
+class BaseMatrixUnavailableError(RuntimeError):
+    """Raised when an explicitly requested base matrix cannot be read."""
 
 
 def _extract(pattern: str, text: str) -> tuple[int, ...] | None:
@@ -43,7 +48,7 @@ def _load_text(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
-def _load_base_text(repo_root: Path, base_ref: str) -> str | None:
+def _load_base_text(repo_root: Path, base_ref: str) -> str:
     target = f"{base_ref}:{MATRIX_PATH.as_posix()}"
     proc = subprocess.run(
         ["git", "show", target],
@@ -53,7 +58,8 @@ def _load_base_text(repo_root: Path, base_ref: str) -> str | None:
         capture_output=True,
     )
     if proc.returncode != 0:
-        return None
+        detail = proc.stderr.strip() or proc.stdout.strip() or f"git show exited {proc.returncode}"
+        raise BaseMatrixUnavailableError(f"Base matrix unavailable for ref {base_ref!r}: {detail}")
     return proc.stdout
 
 
@@ -70,7 +76,7 @@ def _metric_line(name: str, head: int, base: int | None) -> str:
     return f"| {name} | {base_val} | {head} | {_delta(head, base)} |"
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Generate capability matrix delta summary")
     parser.add_argument("--root", default=str(REPO_ROOT), help="Repo root")
     parser.add_argument("--base-ref", help="Git ref to compare against (e.g. origin/main)")
@@ -79,7 +85,7 @@ def main() -> int:
         default="/tmp/capability-matrix-summary.md",
         help="Output markdown file",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     repo_root = Path(args.root).resolve()
     current_path = repo_root / MATRIX_PATH
@@ -89,16 +95,13 @@ def main() -> int:
     current = _parse_matrix(current_text)
 
     base: dict[str, tuple[int, ...]] | None = None
-    base_note = ""
 
     if args.base_ref:
-        base_text = _load_base_text(repo_root, args.base_ref)
-        if base_text:
-            base = _parse_matrix(base_text)
-        else:
-            base_note = (
-                f"Base matrix unavailable for ref `{args.base_ref}`; showing head snapshot only."
-            )
+        try:
+            base = _parse_matrix(_load_base_text(repo_root, args.base_ref))
+        except BaseMatrixUnavailableError as exc:
+            print(str(exc), file=sys.stderr)
+            return 2
 
     now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%SZ")
     lines: list[str] = []
@@ -108,9 +111,6 @@ def main() -> int:
     lines.append(f"Source: `{MATRIX_PATH.as_posix()}`")
     if args.base_ref:
         lines.append(f"Base ref: `{args.base_ref}`")
-    if base_note:
-        lines.append("")
-        lines.append(f"> {base_note}")
     lines.append("")
 
     lines.append("| Metric | Base | Head | Delta |")

--- a/tests/scripts/test_capability_matrix_delta.py
+++ b/tests/scripts/test_capability_matrix_delta.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import scripts.capability_matrix_delta as capability_matrix_delta
+
+
+HEAD_MATRIX = """# Capability Matrix
+
+| Surface | Coverage |
+|---|---:|
+| **HTTP API** | 10 paths / 20 operations |
+| **CLI** | 3 commands |
+| **SDK (Python)** | 4 namespaces |
+| **SDK (TypeScript)** | 5 namespaces |
+| **Capability Catalog** | 6/7 mapped |
+"""
+
+BASE_MATRIX = """# Capability Matrix
+
+| Surface | Coverage |
+|---|---:|
+| **HTTP API** | 8 paths / 17 operations |
+| **CLI** | 2 commands |
+| **SDK (Python)** | 4 namespaces |
+| **SDK (TypeScript)** | 3 namespaces |
+| **Capability Catalog** | 5/7 mapped |
+"""
+
+
+def _write_head_matrix(repo_root: Path) -> None:
+    matrix_path = repo_root / "docs" / "CAPABILITY_MATRIX.md"
+    matrix_path.parent.mkdir(parents=True)
+    matrix_path.write_text(HEAD_MATRIX, encoding="utf-8")
+
+
+def test_main_without_base_ref_writes_head_snapshot(tmp_path: Path) -> None:
+    _write_head_matrix(tmp_path)
+    out_path = tmp_path / "summary.md"
+
+    rc = capability_matrix_delta.main(["--root", str(tmp_path), "--out", str(out_path)])
+
+    assert rc == 0
+    body = out_path.read_text(encoding="utf-8")
+    assert "| HTTP paths | n/a | 10 | n/a |" in body
+    assert "| Total capabilities | n/a | 7 | n/a |" in body
+    assert "Coverage: 85.7%" in body
+
+
+def test_main_with_base_ref_writes_measured_deltas(tmp_path: Path, monkeypatch) -> None:
+    _write_head_matrix(tmp_path)
+    out_path = tmp_path / "summary.md"
+
+    def fake_load_base_text(repo_root: Path, base_ref: str) -> str:
+        assert repo_root == tmp_path.resolve()
+        assert base_ref == "origin/main"
+        return BASE_MATRIX
+
+    monkeypatch.setattr(capability_matrix_delta, "_load_base_text", fake_load_base_text)
+
+    rc = capability_matrix_delta.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--base-ref",
+            "origin/main",
+            "--out",
+            str(out_path),
+        ]
+    )
+
+    assert rc == 0
+    body = out_path.read_text(encoding="utf-8")
+    assert "Base ref: `origin/main`" in body
+    assert "| HTTP paths | 8 | 10 | +2 |" in body
+    assert "| HTTP operations | 17 | 20 | +3 |" in body
+    assert "| TypeScript SDK namespaces | 3 | 5 | +2 |" in body
+    assert "Coverage: 71.4% -> 85.7% (+14.3pp)" in body
+
+
+def test_main_with_unavailable_base_ref_fails_closed(tmp_path: Path, monkeypatch, capsys) -> None:
+    _write_head_matrix(tmp_path)
+    out_path = tmp_path / "summary.md"
+
+    def fake_load_base_text(repo_root: Path, base_ref: str) -> str:
+        raise capability_matrix_delta.BaseMatrixUnavailableError(
+            "Base matrix unavailable for ref 'missing': fatal: bad revision"
+        )
+
+    monkeypatch.setattr(capability_matrix_delta, "_load_base_text", fake_load_base_text)
+
+    rc = capability_matrix_delta.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--base-ref",
+            "missing",
+            "--out",
+            str(out_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert not out_path.exists()
+    assert "Base matrix unavailable for ref 'missing'" in captured.err


### PR DESCRIPTION
Summary: fail closed when capability_matrix_delta.py is asked for an explicit base ref that cannot be read, instead of emitting a head-only n/a delta report. Adds focused tests for head-only output, successful base deltas, and unavailable-base failure. Validation: /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_capability_matrix_delta.py -q; /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/capability_matrix_delta.py tests/scripts/test_capability_matrix_delta.py; git diff --check; bash scripts/automation_pr_preflight.sh origin/main HEAD.