### PR TITLE
[DIC-19] Benchmark truth proof-carrying code unit + corpus constraint-graph tests

### DIFF
--- a/docs/status/proof_units/benchmark_truth_publication.yaml
+++ b/docs/status/proof_units/benchmark_truth_publication.yaml
@@ -1,0 +1,34 @@
+code_unit_id: benchmark_truth.publication.render
+symbol: scripts.render_benchmark_truth_status.render
+source_path: scripts/render_benchmark_truth_status.py
+owner: proof-first-runtime
+
+decision_receipts:
+  - benchmark_truth_publication
+
+claims:
+  - b0.benchmark_truth.complete_current_corpus
+
+assumptions:
+  - "The benchmark truth artifact for the current corpus revision exists under docs/status/generated/benchmark_truth_artifacts/."
+  - "scripts/render_benchmark_truth_status.py reads the artifact and emits a coverage summary without mutation."
+
+verifiers:
+  - kind: command
+    command: "python3 scripts/render_benchmark_truth_status.py --output /tmp/aragora-b0-benchmark-truth-check.md"
+
+freshness_sla_hours: 24
+
+decay_policy:
+  failed_claim: repair_required
+  stale_evidence: report_only
+  unresolved_crux: report_only
+
+fallback_policy:
+  default: fail_closed
+  operator_message: >-
+    Benchmark truth publication is stale or the renderer cannot produce a
+    complete coverage summary. Do not widen autonomous scope until the
+    recurring publication is restored and the coverage surface is fresh.
+
+linked_crux_ids: []

--- a/tests/epistemic/test_dic19_proof_unit_corpus.py
+++ b/tests/epistemic/test_dic19_proof_unit_corpus.py
@@ -1,0 +1,163 @@
+"""Tests for the DIC-19 proof-unit corpus (docs/status/proof_units/).
+
+Validates that every committed manifest loads through the schema and that the
+constraint graph correctly resolves cross-unit claim relationships.  No network
+access, no subprocess execution, no queue mutation.
+
+Advances issue #6030 (DIC-19 — proof-carrying code unit constraint graph).
+Flag: ARAGORA_PROOF_UNIT_SCAN_ENABLED (default OFF).  Tests that exercise the
+directory scanner call enable_proof_unit_scan() directly so they never mutate
+os.environ and always clean up via the autouse fixture.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aragora.epistemic.constraint_graph import ProofUnitConstraintGraph
+from aragora.epistemic.proof_unit import (
+    enable_proof_unit_scan,
+    load_proof_unit_from_yaml,
+    load_proof_units_from_dir,
+    reset_proof_unit_scan,
+)
+
+_PROOF_UNITS_DIR = Path(__file__).parents[2] / "docs" / "status" / "proof_units"
+_BENCHMARK_YAML = _PROOF_UNITS_DIR / "benchmark_truth_publication.yaml"
+_SHIFT_YAML = _PROOF_UNITS_DIR / "proof_first_shift.yaml"
+_SHARED_CLAIM = "b0.benchmark_truth.complete_current_corpus"
+
+
+@pytest.fixture(autouse=True)
+def _reset_scan() -> pytest.IterableFixture:  # type: ignore[type-arg]
+    reset_proof_unit_scan()
+    yield
+    reset_proof_unit_scan()
+
+
+class TestBenchmarkTruthPublicationManifest:
+    """benchmark_truth_publication.yaml schema and field assertions."""
+
+    def test_manifest_file_exists(self) -> None:
+        assert _BENCHMARK_YAML.exists(), f"fixture missing: {_BENCHMARK_YAML}"
+
+    def test_loads_without_error(self) -> None:
+        unit = load_proof_unit_from_yaml(_BENCHMARK_YAML)
+        assert unit is not None
+
+    def test_code_unit_id(self) -> None:
+        unit = load_proof_unit_from_yaml(_BENCHMARK_YAML)
+        assert unit.code_unit_id == "benchmark_truth.publication.render"
+
+    def test_source_path_points_to_real_script(self) -> None:
+        unit = load_proof_unit_from_yaml(_BENCHMARK_YAML)
+        repo_root = Path(__file__).parents[2]
+        assert (repo_root / unit.source_path).exists(), (
+            f"source_path {unit.source_path!r} does not exist in the repo"
+        )
+
+    def test_shared_claim_present(self) -> None:
+        unit = load_proof_unit_from_yaml(_BENCHMARK_YAML)
+        assert _SHARED_CLAIM in unit.claims
+
+    def test_decay_policy_repair_required(self) -> None:
+        unit = load_proof_unit_from_yaml(_BENCHMARK_YAML)
+        assert unit.decay_policy.failed_claim == "repair_required"
+
+    def test_fallback_policy_fail_closed(self) -> None:
+        unit = load_proof_unit_from_yaml(_BENCHMARK_YAML)
+        assert unit.fallback_policy.default == "fail_closed"
+
+    def test_passes_schema_validation(self) -> None:
+        unit = load_proof_unit_from_yaml(_BENCHMARK_YAML)
+        assert unit.validate() == []
+
+    def test_freshness_sla_at_least_one_hour(self) -> None:
+        unit = load_proof_unit_from_yaml(_BENCHMARK_YAML)
+        assert unit.freshness_sla_hours >= 1
+
+    def test_owner_is_set(self) -> None:
+        unit = load_proof_unit_from_yaml(_BENCHMARK_YAML)
+        assert unit.owner
+
+    def test_has_at_least_one_verifier(self) -> None:
+        unit = load_proof_unit_from_yaml(_BENCHMARK_YAML)
+        assert unit.verifiers
+
+    def test_verifier_is_command_kind(self) -> None:
+        unit = load_proof_unit_from_yaml(_BENCHMARK_YAML)
+        kinds = [v.get("kind") for v in unit.verifiers]
+        assert "command" in kinds
+
+    def test_has_at_least_one_decision_receipt(self) -> None:
+        unit = load_proof_unit_from_yaml(_BENCHMARK_YAML)
+        assert unit.decision_receipts
+
+
+class TestConstraintGraphCorpus:
+    """Cross-unit impact analysis over the full proof_units corpus."""
+
+    def test_corpus_has_two_units(self) -> None:
+        enable_proof_unit_scan()
+        units = load_proof_units_from_dir(_PROOF_UNITS_DIR)
+        assert len(units) == 2
+
+    def test_corpus_contains_both_known_ids(self) -> None:
+        enable_proof_unit_scan()
+        units = load_proof_units_from_dir(_PROOF_UNITS_DIR)
+        ids = {u.code_unit_id for u in units}
+        assert "proof_first.shift.green_criteria" in ids
+        assert "benchmark_truth.publication.render" in ids
+
+    def test_graph_builds_from_full_corpus(self) -> None:
+        enable_proof_unit_scan()
+        units = load_proof_units_from_dir(_PROOF_UNITS_DIR)
+        graph = ProofUnitConstraintGraph(units)
+        assert graph.unit_count == 2
+
+    def test_shared_claim_impacts_both_units(self) -> None:
+        enable_proof_unit_scan()
+        units = load_proof_units_from_dir(_PROOF_UNITS_DIR)
+        graph = ProofUnitConstraintGraph(units)
+        impact = graph.impact_set([_SHARED_CLAIM])
+        assert "proof_first.shift.green_criteria" in impact
+        assert "benchmark_truth.publication.render" in impact
+
+    def test_unrelated_claim_impacts_no_units(self) -> None:
+        enable_proof_unit_scan()
+        units = load_proof_units_from_dir(_PROOF_UNITS_DIR)
+        graph = ProofUnitConstraintGraph(units)
+        assert graph.impact_set(["nonexistent.claim.xyz"]) == set()
+
+    def test_impact_set_without_edges_equals_multi_hop(self) -> None:
+        enable_proof_unit_scan()
+        units = load_proof_units_from_dir(_PROOF_UNITS_DIR)
+        graph = ProofUnitConstraintGraph(units)
+        direct = graph.impact_set([_SHARED_CLAIM])
+        multi = graph.multi_hop_impact_set([_SHARED_CLAIM])
+        assert direct == multi
+
+    def test_to_dict_snapshot_includes_both_units(self) -> None:
+        enable_proof_unit_scan()
+        units = load_proof_units_from_dir(_PROOF_UNITS_DIR)
+        graph = ProofUnitConstraintGraph(units)
+        snap = graph.to_dict()
+        assert snap["unit_count"] == 2
+        assert "benchmark_truth.publication.render" in snap["units"]
+        assert "proof_first.shift.green_criteria" in snap["units"]
+
+    def test_claim_index_contains_shared_claim(self) -> None:
+        enable_proof_unit_scan()
+        units = load_proof_units_from_dir(_PROOF_UNITS_DIR)
+        graph = ProofUnitConstraintGraph(units)
+        snap = graph.to_dict()
+        assert _SHARED_CLAIM in snap["claim_index"]
+        assert len(snap["claim_index"][_SHARED_CLAIM]) == 2
+
+    def test_no_dependency_edges_by_default(self) -> None:
+        enable_proof_unit_scan()
+        units = load_proof_units_from_dir(_PROOF_UNITS_DIR)
+        graph = ProofUnitConstraintGraph(units)
+        assert graph.edge_count == 0


### PR DESCRIPTION
## Slice

Adds `docs/status/proof_units/benchmark_truth_publication.yaml` — the second proof-carrying code unit manifest, for `scripts/render_benchmark_truth_status.py`. This unit shares the `b0.benchmark_truth.complete_current_corpus` claim with the existing `proof_first_shift.yaml`, so the constraint graph's cross-unit impact analysis now returns both units when that claim is queried.

## Gating

- Default: **OFF** (flag: `ARAGORA_PROOF_UNIT_SCAN_ENABLED` — same flag as `proof_unit_scanner.py`; the directory scanner returns `[]` unless explicitly enabled)
- Live queue effect: **none** — YAML manifest and tests only; no changes to debate paths, dispatch, or boss loop
- Advances issue: #6030 (DIC-19 — proof-carrying code unit constraint graph)

## Tests

- `TestBenchmarkTruthPublicationManifest` (12 tests): manifest exists on disk, loads without error, correct `code_unit_id`, `source_path` resolves to a real repo script, shared claim present, `decay_policy.failed_claim == "repair_required"`, `fallback_policy.default == "fail_closed"`, `validate() == []`, freshness SLA ≥ 1, owner set, at least one command-kind verifier, at least one receipt
- `TestConstraintGraphCorpus` (9 tests): corpus now has 2 units, both known IDs present, graph builds without error, `impact_set` for the shared claim returns **both** units, unrelated claim returns empty set, `multi_hop_impact_set` matches `impact_set` (no edges), `to_dict` snapshot includes both unit IDs, claim index records 2 dependents, edge count is 0

## Validation

- `pytest tests/epistemic/test_dic19_proof_unit_corpus.py --noconftest` — **22 passed** in 0.31 s
- `ruff check tests/epistemic/test_dic19_proof_unit_corpus.py` — clean
- `mypy tests/epistemic/test_dic19_proof_unit_corpus.py --ignore-missing-imports` — clean
- Net diff: **197 LOC** (34 YAML + 163 tests, 2 new files)

## Out of scope

- Adding a third proof-carrying code unit (e.g., for queue-governance rules) — natural follow-on once these two manifest the pattern
- Wiring the benchmark-truth unit into the live `dic19_proof_units` CLI decay-monitor pipeline — deferred; this slice is fixture-and-test only
- CI workflow for automated corpus freshness checks — DIC-14/Epistemic-CI scope, not DIC-19

## Gate status

Per `docs/status/NEXT_STEPS_CANONICAL.md`, the `DIC-13..22` tranche is in the **Delay** track; the proof-first Foreman gate has not opened. This PR is planning-truth and flag-gated operator tooling only. No `boss-ready` label applied. Kept as draft.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HsoRVFqLQ4K1pMfPqkaS1e)_