### PR TITLE
fix(metrics): reject non-finite weekly kpis

### DIFF
--- a/scripts/extract_weekly_epistemic_kpis.py
+++ b/scripts/extract_weekly_epistemic_kpis.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import argparse
 import datetime as dt
 import json
+import math
 import sys
 import urllib.error
 import urllib.request
@@ -32,16 +33,21 @@ DEFAULT_DASHBOARD_URL = "https://api.aragora.ai/api/v1/observability/dashboard"
 
 
 def _as_float(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
     try:
-        return float(value)
+        parsed = float(value)
     except (TypeError, ValueError):
         return None
+    return parsed if math.isfinite(parsed) else None
 
 
 def _as_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
     try:
         return int(value)
-    except (TypeError, ValueError):
+    except (OverflowError, TypeError, ValueError):
         return None
 
 

--- a/tests/scripts/test_extract_weekly_epistemic_kpis.py
+++ b/tests/scripts/test_extract_weekly_epistemic_kpis.py
@@ -124,3 +124,41 @@ def test_extract_weekly_kpis_strict_fails_when_thresholds_breached(tmp_path: Pat
     assert "settlement_success_rate" in summary["blocking_failures"]
     assert "oracle_stall_rate" in summary["blocking_failures"]
     assert "calibration_updates_realized" in summary["blocking_failures"]
+
+
+def test_extract_weekly_kpis_strict_fails_on_non_finite_metrics(tmp_path: Path) -> None:
+    fixture_path = tmp_path / "dashboard_non_finite.json"
+    fixture_path.write_text(
+        json.dumps(
+            {
+                "oracle_stream": {
+                    "available": True,
+                    "sessions_started": float("inf"),
+                    "sessions_completed": 96,
+                    "stalls_total": 0,
+                    "ttft_avg_ms": 780.4,
+                    "ttft_samples": True,
+                },
+                "settlement_review": {
+                    "available": True,
+                    "stats": {
+                        "success_rate": float("nan"),
+                        "last_result": {"unresolved_due": 0},
+                    },
+                    "calibration_outcomes": {
+                        "correct": 1,
+                        "incorrect": 0,
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = _run("--input-json", str(fixture_path), "--strict")
+
+    assert result.returncode == 1
+    summary = json.loads(result.stdout.strip())
+    assert summary["passed"] is False
+    assert "settlement_success_rate" in summary["blocking_failures"]
+    assert "oracle_stall_rate" in summary["blocking_failures"]


### PR DESCRIPTION
Summary: make scripts/extract_weekly_epistemic_kpis.py treat non-finite and boolean numeric telemetry as unknown so strict weekly KPI extraction fails instead of passing NaN/Infinity values through threshold checks. Adds a focused regression fixture covering NaN settlement success rate, Infinity oracle session count, and boolean telemetry. Validation: /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_extract_weekly_epistemic_kpis.py -q; /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/extract_weekly_epistemic_kpis.py tests/scripts/test_extract_weekly_epistemic_kpis.py; git diff --check; bash scripts/automation_pr_preflight.sh origin/main HEAD.