### PR TITLE
feat(swarm): Loop Control Plane v1 - read-only fleet loop governance

### DIFF
--- a/aragora/swarm/loop_control.py
+++ b/aragora/swarm/loop_control.py
@@ -282,7 +282,8 @@ def classify_loop(spec: LoopSpec, raw: dict[str, Any]) -> LoopRecord:
     awaiting_human = bool(raw.get("awaiting_human", False))
     human_present = bool(raw.get("human_settlement_present", False))
 
-    raw_budget = raw.get("budget") if isinstance(raw.get("budget"), dict) else {}
+    raw_budget_value = raw.get("budget")
+    raw_budget: dict[str, Any] = raw_budget_value if isinstance(raw_budget_value, dict) else {}
     budget = Budget(
         spend_usd=_as_float(raw_budget.get("spend_usd")),
         ceiling_usd=_as_float(raw_budget.get("ceiling_usd")),

--- a/aragora/swarm/loop_control.py
+++ b/aragora/swarm/loop_control.py
@@ -70,6 +70,9 @@ class HaltVerdict(str, Enum):
 _NORMAL_STOP_FRAGMENTS = (
     "max runtime reached",
     "max-runtime",
+    "max runtime",
+    "timelimit",
+    "time limit",
     "no candidates",
     "no candidate",
     "completed",

--- a/aragora/swarm/loop_control.py
+++ b/aragora/swarm/loop_control.py
@@ -1,0 +1,514 @@
+"""Loop Control Plane v1 - pure classification (no IO).
+
+Read-only governance observability for Aragora's standing loops (boss loop,
+merge arbiter, proof-first shift, publisher, worktree autopilot, nomic). This
+module is *pure*: it takes already-collected raw signals (see
+``loop_control_io``) plus a static per-loop spec and returns normalized
+``LoopRecord`` objects. It performs no subprocess, filesystem, or network IO,
+which keeps it trivially unit-testable and keeps the read-only guarantee
+auditable - only the IO layer touches the world.
+
+It applies the loop-governance lesson that a loop is only safe to keep running
+when it (1) is bounded by a max iteration/runtime, (2) has no-progress detection
+that distinguishes a genuine *operational fault* (halt) from *normal waiting*
+(continue), and (3) has a spend ceiling. See
+``docs/governance/LOOP_CONTROL_PLANE.md``.
+
+The halt-readiness guards in ``LOOP_SPECS`` are a *curated* design-level audit
+with code references, not auto-derived facts; update them when a loop's guards
+change. v1 deliberately does not auto-derive them (see doc follow-ups).
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from typing import Any
+
+# Stable contract version. Carried on every record as a forward-compatible hook
+# for the future append-only LoopLedger (documented as a follow-up; not written
+# in v1).
+SCHEMA_VERSION = "loop-control/v1"
+
+
+class LoopKind(str, Enum):
+    BOSS_LOOP = "boss_loop"
+    MERGE_ARBITER = "merge_arbiter"
+    PROOF_FIRST_SHIFT = "proof_first_shift"
+    PUBLISHER = "publisher"
+    WORKTREE_AUTOPILOT = "worktree_autopilot"
+    NOMIC = "nomic"
+
+
+class LoopState(str, Enum):
+    RUNNING = "running"
+    WAITING = "waiting"
+    BLOCKED = "blocked"
+    BUDGET_EXHAUSTED = "budget_exhausted"
+    HALTED = "halted"
+    HUMAN_GATED = "human_gated"
+    STALE_OWNER = "stale_owner"
+    UNKNOWN = "unknown"
+
+
+class NextAction(str, Enum):
+    REPORT_ONLY = "report_only"
+    CONTINUE = "continue"
+    WAIT = "wait"
+    HALT = "halt"
+    ESCALATE_HUMAN = "escalate_human"
+
+
+class HaltVerdict(str, Enum):
+    OK = "ok"
+    INCOMPLETE = "incomplete"
+    MISSING = "missing"
+
+
+# Stop-reason fragments that denote a *normal* terminal state (not a fault).
+# Anything else is treated as an operational fault (fail-closed).
+_NORMAL_STOP_FRAGMENTS = (
+    "max runtime reached",
+    "max-runtime",
+    "no candidates",
+    "no candidate",
+    "completed",
+    "deadline reached",
+    "shift complete",
+)
+
+
+def _is_fault_stop(stop_reason: str) -> bool:
+    """True when ``stop_reason`` denotes an operational fault that should halt.
+
+    Fail-closed: an unrecognized non-empty stop reason is treated as a fault.
+    """
+    text = stop_reason.strip().lower()
+    if not text:
+        return False
+    return not any(fragment in text for fragment in _NORMAL_STOP_FRAGMENTS)
+
+
+def _as_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_float(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+
+
+@dataclass(frozen=True)
+class HaltGuards:
+    """Curated, design-level declaration of a loop's halt guards.
+
+    Reflects the loop's source as of ``code_ref``; update when guards change.
+    """
+
+    max_iteration: bool
+    no_progress: bool
+    no_progress_distinguishes_fault: bool
+    budget_ceiling: bool
+    code_ref: str = ""
+    notes: tuple[str, ...] = ()
+
+
+@dataclass
+class HaltReadiness:
+    max_iteration: bool
+    no_progress: bool
+    no_progress_distinguishes_fault: bool
+    budget_ceiling: bool
+    verdict: str
+    gaps: list[str]
+    notes: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def audit_halt_readiness(guards: HaltGuards) -> HaltReadiness:
+    """Audit a loop's halt guards against the three hard stops.
+
+    ``ok`` requires all three: a max iteration/runtime bound, no-progress
+    detection that distinguishes operational fault from normal waiting, and a
+    budget ceiling. Anything partial is ``incomplete``; none is ``missing``.
+    """
+    gaps: list[str] = []
+    if not guards.max_iteration:
+        gaps.append("no max-iteration/runtime bound")
+    if not guards.no_progress:
+        gaps.append("no no-progress detection")
+    elif not guards.no_progress_distinguishes_fault:
+        gaps.append(
+            "no-progress detection does not distinguish operational fault from normal waiting"
+        )
+    if not guards.budget_ceiling:
+        gaps.append("no dollar/budget ceiling (bounded by time/iterations only)")
+
+    has_iteration = guards.max_iteration
+    has_no_progress = guards.no_progress and guards.no_progress_distinguishes_fault
+    has_budget = guards.budget_ceiling
+    present = sum((has_iteration, has_no_progress, has_budget))
+    if present == 3:
+        verdict = HaltVerdict.OK.value
+    elif present == 0:
+        verdict = HaltVerdict.MISSING.value
+    else:
+        verdict = HaltVerdict.INCOMPLETE.value
+
+    return HaltReadiness(
+        max_iteration=guards.max_iteration,
+        no_progress=guards.no_progress,
+        no_progress_distinguishes_fault=guards.no_progress_distinguishes_fault,
+        budget_ceiling=guards.budget_ceiling,
+        verdict=verdict,
+        gaps=gaps,
+        notes=list(guards.notes),
+    )
+
+
+@dataclass(frozen=True)
+class LoopSpec:
+    kind: LoopKind
+    title: str
+    role: str  # supervisor | orchestration | maintenance | publication | self_improvement
+    guards: HaltGuards
+    feedback_kind: str  # quorum | proof_freshness | publisher_freshness | worktree_health | none
+    durable_state_path: str | None
+    human_gate_required: bool
+    source_paths: tuple[str, ...]
+
+
+@dataclass
+class Budget:
+    spend_usd: float | None
+    ceiling_usd: float | None
+    remaining_usd: float | None
+    source: str
+    source_status: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class FeedbackGate:
+    kind: str
+    status: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class Durability:
+    state_path: str | None
+    restart_safe: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class HumanGate:
+    required: bool
+    present: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class LoopRecord:
+    schema_version: str
+    loop_id: str
+    kind: str
+    role: str
+    owner: str | None
+    state: str
+    ticks: int | None
+    max_ticks: int | None
+    runtime_s: float | None
+    max_runtime_s: float | None
+    last_progress_at: str | None
+    no_progress_ticks: int | None
+    budget: Budget
+    feedback_gate: FeedbackGate
+    halt_readiness: HaltReadiness
+    durability: Durability
+    human_gate: HumanGate
+    blocker: str | None
+    next_action: str
+    source_paths: list[str] = field(default_factory=list)
+    source_status: str = "unavailable"
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def classify_loop(spec: LoopSpec, raw: dict[str, Any]) -> LoopRecord:
+    """Classify one loop's normalized raw signals into a ``LoopRecord``.
+
+    Pure and fail-closed: missing/unknown signals yield ``state=unknown`` with
+    ``next_action=report_only``; an operational fault or exhausted budget yields
+    ``halt``; a not-ready *waiting* loop yields ``wait`` (continue waiting), never
+    a halt - the distinction that the merge-arbiter circuit-breaker bug (#7879)
+    got wrong.
+    """
+    source_status = str(raw.get("source_status", "unavailable"))
+    owner = raw.get("owner")
+    alive = raw.get("alive")
+    stop_reason = raw.get("stop_reason")
+    operational_fault = bool(raw.get("operational_fault", False))
+    waiting_only = bool(raw.get("waiting_only", False))
+    owner_stale = bool(raw.get("owner_stale", False))
+    awaiting_human = bool(raw.get("awaiting_human", False))
+    human_present = bool(raw.get("human_settlement_present", False))
+
+    raw_budget = raw.get("budget") if isinstance(raw.get("budget"), dict) else {}
+    budget = Budget(
+        spend_usd=_as_float(raw_budget.get("spend_usd")),
+        ceiling_usd=_as_float(raw_budget.get("ceiling_usd")),
+        remaining_usd=_as_float(raw_budget.get("remaining_usd")),
+        source=str(raw_budget.get("source", "none")),
+        source_status=str(raw_budget.get("source_status", "unavailable")),
+    )
+
+    halt_readiness = audit_halt_readiness(spec.guards)
+    feedback_gate = FeedbackGate(
+        kind=spec.feedback_kind,
+        status=str(raw.get("feedback_status", "unknown")),
+    )
+    human_gate = HumanGate(required=spec.human_gate_required, present=human_present)
+    durability = Durability(
+        state_path=spec.durable_state_path,
+        restart_safe=spec.durable_state_path is not None,
+    )
+
+    blocker: str | None = None
+    has_live_signal = alive is not None or bool(stop_reason) or operational_fault
+
+    if source_status == "unavailable" and not has_live_signal:
+        state, action = LoopState.UNKNOWN, NextAction.REPORT_ONLY
+    elif spec.human_gate_required and awaiting_human and not human_present:
+        state, action = LoopState.HUMAN_GATED, NextAction.ESCALATE_HUMAN
+        blocker = "awaiting human settlement"
+    elif budget.remaining_usd is not None and budget.remaining_usd <= 0:
+        state, action = LoopState.BUDGET_EXHAUSTED, NextAction.HALT
+        blocker = "budget exhausted"
+    elif operational_fault or (isinstance(stop_reason, str) and _is_fault_stop(stop_reason)):
+        state, action = LoopState.BLOCKED, NextAction.HALT
+        blocker = (
+            stop_reason if isinstance(stop_reason, str) and stop_reason else "operational fault"
+        )
+    elif owner_stale:
+        state, action = LoopState.STALE_OWNER, NextAction.REPORT_ONLY
+        blocker = "owner heartbeat stale"
+    elif alive is True and waiting_only:
+        state, action = LoopState.WAITING, NextAction.WAIT
+    elif alive is True:
+        state, action = LoopState.RUNNING, NextAction.CONTINUE
+    elif alive is False:
+        # Cleanly stopped with a normal (non-fault) reason, or simply idle.
+        state, action = LoopState.HALTED, NextAction.REPORT_ONLY
+        blocker = stop_reason if isinstance(stop_reason, str) and stop_reason else None
+    else:
+        state, action = LoopState.UNKNOWN, NextAction.REPORT_ONLY
+
+    return LoopRecord(
+        schema_version=SCHEMA_VERSION,
+        loop_id=spec.kind.value,
+        kind=spec.kind.value,
+        role=spec.role,
+        owner=owner if isinstance(owner, str) else None,
+        state=state.value,
+        ticks=_as_int(raw.get("ticks")),
+        max_ticks=_as_int(raw.get("max_ticks")),
+        runtime_s=_as_float(raw.get("runtime_s")),
+        max_runtime_s=_as_float(raw.get("max_runtime_s")),
+        last_progress_at=(
+            raw.get("last_progress_at") if isinstance(raw.get("last_progress_at"), str) else None
+        ),
+        no_progress_ticks=_as_int(raw.get("no_progress_ticks")),
+        budget=budget,
+        feedback_gate=feedback_gate,
+        halt_readiness=halt_readiness,
+        durability=durability,
+        human_gate=human_gate,
+        blocker=blocker,
+        next_action=action.value,
+        source_paths=list(spec.source_paths),
+        source_status=source_status,
+    )
+
+
+def summarize(records: list[LoopRecord]) -> dict[str, Any]:
+    """Fleet-level rollup of loop records (pure)."""
+    by_state: dict[str, int] = {}
+    by_action: dict[str, int] = {}
+    by_halt: dict[str, int] = {}
+    for record in records:
+        by_state[record.state] = by_state.get(record.state, 0) + 1
+        by_action[record.next_action] = by_action.get(record.next_action, 0) + 1
+        verdict = record.halt_readiness.verdict
+        by_halt[verdict] = by_halt.get(verdict, 0) + 1
+
+    any_blocked = any(
+        r.state in (LoopState.BLOCKED.value, LoopState.BUDGET_EXHAUSTED.value) for r in records
+    )
+    any_human_gated = any(r.state == LoopState.HUMAN_GATED.value for r in records)
+    halt_gaps = [
+        {"loop": r.kind, "verdict": r.halt_readiness.verdict, "gaps": r.halt_readiness.gaps}
+        for r in records
+        if r.halt_readiness.verdict != HaltVerdict.OK.value
+    ]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "loops": len(records),
+        "by_state": by_state,
+        "by_next_action": by_action,
+        "by_halt_verdict": by_halt,
+        "any_blocked": any_blocked,
+        "any_human_gated": any_human_gated,
+        "fleet_safe_to_continue": not any_blocked and not any_human_gated,
+        "halt_readiness_gaps": halt_gaps,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Static loop registry (curated halt-readiness audit; see module docstring).
+# Guard values reflect current ``origin/main`` with the cited code references.
+# ---------------------------------------------------------------------------
+LOOP_SPECS: dict[LoopKind, LoopSpec] = {
+    LoopKind.BOSS_LOOP: LoopSpec(
+        kind=LoopKind.BOSS_LOOP,
+        title="Boss loop (settlement supervisor)",
+        role="supervisor",
+        guards=HaltGuards(
+            max_iteration=True,
+            no_progress=True,
+            no_progress_distinguishes_fault=True,
+            budget_ceiling=False,
+            code_ref="scripts/run_boss_cycle.sh -> aragora/swarm/boss_loop.py",
+            notes=(
+                "self-heal/unstick recovery is advisory, not executed deterministically "
+                "(BOSS_LOOP_MERGE_GATE_RESILIENCE.md root cause #5)",
+            ),
+        ),
+        feedback_kind="quorum",
+        durable_state_path=".aragora/operator_steering",
+        human_gate_required=False,
+        source_paths=("scripts/run_boss_cycle.sh", "aragora/swarm/boss_loop.py"),
+    ),
+    LoopKind.MERGE_ARBITER: LoopSpec(
+        kind=LoopKind.MERGE_ARBITER,
+        title="Merge arbiter (auto-merge-on-green)",
+        role="supervisor",
+        guards=HaltGuards(
+            max_iteration=True,
+            no_progress=True,
+            no_progress_distinguishes_fault=False,
+            budget_ceiling=False,
+            code_ref="aragora/swarm/merge_arbiter.py MergeArbiterConfig (max_runtime_hours=12, max_consecutive_failures=3)",
+            notes=(
+                "circuit breaker trips on failure-only polls without separating an operational "
+                "fault from not-ready PRs (the #7879 bug class); eval/merge fault path still "
+                "bypasses the breaker",
+            ),
+        ),
+        feedback_kind="quorum",
+        durable_state_path=None,
+        human_gate_required=True,
+        source_paths=("scripts/run_merge_arbiter.sh", "aragora/swarm/merge_arbiter.py"),
+    ),
+    LoopKind.PROOF_FIRST_SHIFT: LoopSpec(
+        kind=LoopKind.PROOF_FIRST_SHIFT,
+        title="Proof-first shift (bounded Foreman)",
+        role="orchestration",
+        guards=HaltGuards(
+            max_iteration=True,
+            no_progress=True,
+            no_progress_distinguishes_fault=True,
+            budget_ceiling=False,
+            code_ref="scripts/run_proof_first_shift.py RECOVERY_STOP_REASONS + AUTH_FAILURE_STOP_AFTER",
+            notes=(
+                "recovery failures are classified by type and fail closed after bounded retries",
+            ),
+        ),
+        feedback_kind="proof_freshness",
+        durable_state_path=".aragora/proof_first_shift",
+        human_gate_required=False,
+        source_paths=("scripts/run_proof_first_shift.py",),
+    ),
+    LoopKind.PUBLISHER: LoopSpec(
+        kind=LoopKind.PUBLISHER,
+        title="Codex automation publisher",
+        role="publication",
+        guards=HaltGuards(
+            max_iteration=True,
+            no_progress=True,
+            no_progress_distinguishes_fault=True,
+            budget_ceiling=False,
+            code_ref="scripts/publisher_freshness_check.py (launchd single-shot per fire)",
+            notes=("launchd cron single-shot; freshness verdict separates warming from degraded",),
+        ),
+        feedback_kind="publisher_freshness",
+        durable_state_path=".aragora/automation-github-status",
+        human_gate_required=False,
+        source_paths=(
+            "scripts/run_codex_automation_publisher.sh",
+            "scripts/publisher_freshness_check.py",
+        ),
+    ),
+    LoopKind.WORKTREE_AUTOPILOT: LoopSpec(
+        kind=LoopKind.WORKTREE_AUTOPILOT,
+        title="Worktree autopilot (reconcile/cleanup)",
+        role="maintenance",
+        guards=HaltGuards(
+            max_iteration=True,
+            no_progress=False,
+            no_progress_distinguishes_fault=False,
+            budget_ceiling=False,
+            code_ref="scripts/codex_worktree_autopilot.py + scripts/worktree_maintainer.sh (TTL-bounded)",
+            notes=("TTL-bounded maintenance reconcile; no progress metric applies",),
+        ),
+        feedback_kind="worktree_health",
+        durable_state_path=".worktrees",
+        human_gate_required=False,
+        source_paths=(
+            "scripts/codex_worktree_autopilot.py",
+            "scripts/worktree_maintainer.sh",
+        ),
+    ),
+    LoopKind.NOMIC: LoopSpec(
+        kind=LoopKind.NOMIC,
+        title="Nomic self-improvement loop",
+        role="self_improvement",
+        guards=HaltGuards(
+            max_iteration=True,
+            no_progress=False,
+            no_progress_distinguishes_fault=False,
+            budget_ceiling=False,
+            code_ref="scripts/nomic_loop.py (--cycles bound; protected file)",
+            notes=("cycle-bounded with human approval checkpoints; protected file",),
+        ),
+        feedback_kind="none",
+        durable_state_path=".aragora_beads",
+        human_gate_required=True,
+        source_paths=("scripts/nomic_loop.py",),
+    ),
+}

--- a/aragora/swarm/loop_control_io.py
+++ b/aragora/swarm/loop_control_io.py
@@ -74,6 +74,14 @@ def _loads(proc: subprocess.CompletedProcess[str] | None) -> dict[str, Any] | No
     return payload if isinstance(payload, dict) else None
 
 
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
 def _read_json(path: Path) -> dict[str, Any] | None:
     try:
         with path.open(encoding="utf-8") as handle:
@@ -107,7 +115,7 @@ def collect_publisher(repo_root: Path, *, timeout: float = 10.0) -> dict[str, An
     if payload is None:
         return {"source_status": "unavailable", "error": "publisher freshness check unreadable"}
     verdict = payload.get("verdict")
-    blockers = payload.get("blockers") if isinstance(payload.get("blockers"), list) else []
+    blockers = _as_list(payload.get("blockers"))
     degraded = verdict == "degraded"
     return {
         "source_status": "ok",
@@ -134,15 +142,11 @@ def collect_boss_loop(repo_root: Path, *, timeout: float = 20.0) -> dict[str, An
     payload = _loads(proc)
     if payload is None:
         return {"source_status": "unavailable", "error": "operator snapshot unreadable"}
-    status = (
-        payload.get("boss_loop_status") if isinstance(payload.get("boss_loop_status"), dict) else {}
-    )
-    heartbeats = (
-        payload.get("agent_heartbeats") if isinstance(payload.get("agent_heartbeats"), dict) else {}
-    )
+    status = _as_dict(payload.get("boss_loop_status"))
+    heartbeats = _as_dict(payload.get("agent_heartbeats"))
     count = int(heartbeats.get("count", 0) or 0)
     fresh = int(heartbeats.get("fresh_count", 0) or 0)
-    health = payload.get("health") if isinstance(payload.get("health"), dict) else {}
+    health = _as_dict(payload.get("health"))
     queue_depth = payload.get("queue_depth")
     return {
         "source_status": "ok",

--- a/aragora/swarm/loop_control_io.py
+++ b/aragora/swarm/loop_control_io.py
@@ -1,0 +1,352 @@
+"""Loop Control Plane v1 - read-only collectors (IO layer).
+
+Each collector wraps an *existing* read-only surface (operator snapshot, publisher
+freshness check, launchd job status, proof-first runtime state, git worktree list)
+and returns a normalized raw-signal dict consumable by
+``aragora.swarm.loop_control.classify_loop``. This module is the *only* part of
+the Loop Control Plane that touches the world, and it only ever reads:
+
+* ``launchctl print`` (job liveness)
+* ``git worktree list --porcelain``
+* ``scripts/publisher_freshness_check.py --json`` / ``scripts/agent_bridge.py
+  operator-snapshot --json`` (themselves read-only)
+* ``.aragora/proof_first_shift/runtime_state.json`` (file read)
+
+It never merges, comments, reruns, pushes, or passes an ``--apply`` flag, and it
+writes nothing. Collectors degrade gracefully (``source_status`` of ``degraded``
+or ``unavailable``) on missing files, rate limits, timeouts, or non-POSIX hosts
+rather than raising.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+from aragora.swarm.loop_control import LOOP_SPECS, LoopKind, LoopRecord, classify_loop
+
+LAUNCHD_LABELS: dict[LoopKind, str] = {
+    LoopKind.BOSS_LOOP: "com.aragora.swarm-boss-loop",
+    LoopKind.MERGE_ARBITER: "com.aragora.swarm-merge-arbiter",
+    LoopKind.PUBLISHER: "com.aragora.codex-automation-publisher",
+    LoopKind.WORKTREE_AUTOPILOT: "com.aragora.codex-worktree-maintainer",
+}
+
+# Collectors that may reach the network (skipped under allow_network=False).
+NETWORK_TOUCHING: frozenset[LoopKind] = frozenset({LoopKind.BOSS_LOOP})
+
+_PROOF_FIRST_STATE_FRESH_SECONDS = 900.0
+
+
+def _iso(epoch_seconds: float) -> str:
+    return datetime.fromtimestamp(epoch_seconds, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _run(cmd: list[str], cwd: Path, timeout: float) -> subprocess.CompletedProcess[str] | None:
+    """Run a *read-only* command, returning None on any execution failure."""
+    try:
+        return subprocess.run(
+            cmd,
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+
+
+def _loads(proc: subprocess.CompletedProcess[str] | None) -> dict[str, Any] | None:
+    if proc is None or not proc.stdout:
+        return None
+    try:
+        payload = json.loads(proc.stdout)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    try:
+        with path.open(encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (OSError, json.JSONDecodeError, ValueError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _launchctl_loaded(label: str, timeout: float) -> tuple[bool | None, str]:
+    """Return ``(loaded, detail)``; ``loaded`` is None when launchctl is unusable."""
+    try:
+        uid = os.getuid()
+    except AttributeError:
+        return None, "non-posix-platform"
+    proc = _run(["launchctl", "print", f"gui/{uid}/{label}"], Path.cwd(), timeout)
+    if proc is None:
+        return None, "launchctl-unavailable"
+    if proc.returncode == 0:
+        return True, "loaded"
+    return False, "not-loaded"
+
+
+def collect_publisher(repo_root: Path, *, timeout: float = 10.0) -> dict[str, Any]:
+    proc = _run(
+        [sys.executable, "scripts/publisher_freshness_check.py", "--json", "--summary-only"],
+        repo_root,
+        timeout,
+    )
+    payload = _loads(proc)
+    if payload is None:
+        return {"source_status": "unavailable", "error": "publisher freshness check unreadable"}
+    verdict = payload.get("verdict")
+    blockers = payload.get("blockers") if isinstance(payload.get("blockers"), list) else []
+    degraded = verdict == "degraded"
+    return {
+        "source_status": "ok",
+        "alive": bool(payload.get("launchd_loaded")),
+        "operational_fault": degraded,
+        "stop_reason": "; ".join(str(b) for b in blockers) if degraded else None,
+        "feedback_status": str(verdict) if verdict else "unknown",
+        "owner": "launchd",
+    }
+
+
+def collect_boss_loop(repo_root: Path, *, timeout: float = 20.0) -> dict[str, Any]:
+    proc = _run(
+        [
+            sys.executable,
+            "scripts/agent_bridge.py",
+            "operator-snapshot",
+            "--json",
+            "--summary-only",
+        ],
+        repo_root,
+        timeout,
+    )
+    payload = _loads(proc)
+    if payload is None:
+        return {"source_status": "unavailable", "error": "operator snapshot unreadable"}
+    status = (
+        payload.get("boss_loop_status") if isinstance(payload.get("boss_loop_status"), dict) else {}
+    )
+    heartbeats = (
+        payload.get("agent_heartbeats") if isinstance(payload.get("agent_heartbeats"), dict) else {}
+    )
+    count = int(heartbeats.get("count", 0) or 0)
+    fresh = int(heartbeats.get("fresh_count", 0) or 0)
+    health = payload.get("health") if isinstance(payload.get("health"), dict) else {}
+    queue_depth = payload.get("queue_depth")
+    return {
+        "source_status": "ok",
+        "alive": bool(payload.get("boss_loop_alive")),
+        "owner_stale": count > 0 and fresh == 0,
+        "feedback_status": "ok" if health.get("ok", True) else "degraded",
+        "ticks": queue_depth if isinstance(queue_depth, int) else None,
+        "owner": str(status.get("owner") or "swarm-boss-loop"),
+        "last_progress_at": payload.get("timestamp")
+        if isinstance(payload.get("timestamp"), str)
+        else None,
+    }
+
+
+def collect_merge_arbiter(repo_root: Path, *, timeout: float = 10.0) -> dict[str, Any]:
+    max_runtime_s: float | None = None
+    max_ticks: int | None = None
+    try:
+        from aragora.swarm.merge_arbiter import MergeArbiterConfig
+
+        config = MergeArbiterConfig()
+        max_runtime_s = float(config.max_runtime_hours) * 3600.0
+        max_ticks = int(config.max_consecutive_failures)
+    except Exception:  # noqa: BLE001 - config import is best-effort context
+        pass
+
+    loaded, detail = _launchctl_loaded(LAUNCHD_LABELS[LoopKind.MERGE_ARBITER], timeout)
+    base: dict[str, Any] = {
+        "max_runtime_s": max_runtime_s,
+        "max_ticks": max_ticks,
+        "feedback_status": "quorum",
+        "human_settlement_present": False,
+        "owner": "launchd",
+    }
+    if loaded is None:
+        # In-process arbiter exposes no state file; without launchd we can only
+        # report the config-grounded bounds.
+        return {"source_status": "degraded", "error": detail, **base}
+    base["source_status"] = "ok"
+    base["alive"] = loaded
+    return base
+
+
+def collect_proof_first(
+    repo_root: Path, *, timeout: float = 5.0, now: float | None = None
+) -> dict[str, Any]:
+    path = repo_root / ".aragora" / "proof_first_shift" / "runtime_state.json"
+    if not path.is_file():
+        return {"source_status": "unavailable", "feedback_status": "proof_freshness"}
+    payload = _read_json(path)
+    if payload is None:
+        return {"source_status": "degraded", "error": "runtime_state unreadable"}
+    now = now if now is not None else time.time()
+    mtime = path.stat().st_mtime
+    age = max(0.0, now - mtime)
+    failure_counts = (
+        "boss_restart_count",
+        "merge_restart_count",
+        "auth_failure_count",
+        "publication_failure_count",
+        "rate_limit_failure_count",
+        "permission_mismatch_count",
+        "runtime_failure_count",
+        "github_outage_count",
+    )
+    failures = sum(int(payload.get(key, 0) or 0) for key in failure_counts)
+    return {
+        "source_status": "ok",
+        "alive": age < _PROOF_FIRST_STATE_FRESH_SECONDS,
+        "no_progress_ticks": failures,
+        "last_progress_at": _iso(mtime),
+        "feedback_status": "proof_freshness",
+        "owner": str(payload.get("recovery_shift_id") or "proof-first-shift"),
+    }
+
+
+def collect_worktree_autopilot(repo_root: Path, *, timeout: float = 10.0) -> dict[str, Any]:
+    proc = _run(["git", "worktree", "list", "--porcelain"], repo_root, timeout)
+    count: int | None = None
+    if proc is not None and proc.returncode == 0:
+        count = sum(1 for line in proc.stdout.splitlines() if line.startswith("worktree "))
+    loaded, _detail = _launchctl_loaded(LAUNCHD_LABELS[LoopKind.WORKTREE_AUTOPILOT], timeout)
+    if count is None and loaded is None:
+        return {"source_status": "unavailable", "feedback_status": "worktree_health"}
+    return {
+        "source_status": "ok" if loaded is not None else "degraded",
+        "alive": loaded,
+        "ticks": count,
+        "feedback_status": "worktree_health",
+        "owner": "launchd",
+    }
+
+
+def collect_nomic(repo_root: Path, *, timeout: float = 5.0) -> dict[str, Any]:
+    # The nomic loop is launched manually (protected file) and exposes no
+    # standing daemon to read; report unavailable rather than fabricate state.
+    return {"source_status": "unavailable", "feedback_status": "none"}
+
+
+def collect_budget(repo_root: Path, *, timeout: float = 5.0) -> dict[str, Any]:
+    """Side-effect-free budget read.
+
+    v1 does not wire per-loop dollar ceilings into the standing loops, so this
+    reports ``unavailable`` unless ``ARAGORA_LOOP_BUDGET_USD`` is set. The gap is
+    carried by each loop's halt-readiness (``budget_ceiling=False``) rather than
+    fabricated here.
+    """
+    raw = os.environ.get("ARAGORA_LOOP_BUDGET_USD")
+    if raw:
+        try:
+            remaining = float(raw)
+        except ValueError:
+            remaining = None
+        if remaining is not None:
+            return {
+                "source": "env:ARAGORA_LOOP_BUDGET_USD",
+                "source_status": "ok",
+                "remaining_usd": remaining,
+                "ceiling_usd": remaining,
+                "spend_usd": None,
+            }
+    return {
+        "source": "none",
+        "source_status": "unavailable",
+        "remaining_usd": None,
+        "ceiling_usd": None,
+        "spend_usd": None,
+    }
+
+
+_COLLECTORS: dict[LoopKind, Callable[..., dict[str, Any]]] = {
+    LoopKind.BOSS_LOOP: collect_boss_loop,
+    LoopKind.MERGE_ARBITER: collect_merge_arbiter,
+    LoopKind.PROOF_FIRST_SHIFT: collect_proof_first,
+    LoopKind.PUBLISHER: collect_publisher,
+    LoopKind.WORKTREE_AUTOPILOT: collect_worktree_autopilot,
+    LoopKind.NOMIC: collect_nomic,
+}
+
+
+def _safe_collect(
+    fn: Callable[..., dict[str, Any]], repo_root: Path, timeout: float
+) -> dict[str, Any]:
+    try:
+        return fn(repo_root, timeout=timeout)
+    except Exception as exc:  # noqa: BLE001 - collectors must never raise to the fleet
+        return {"source_status": "unavailable", "error": f"{type(exc).__name__}: {exc}"}
+
+
+def collect_all(
+    repo_root: Path | str,
+    *,
+    timeout: float = 15.0,
+    allow_network: bool = True,
+    kinds: list[LoopKind] | None = None,
+) -> dict[LoopKind, dict[str, Any]]:
+    """Collect raw signals for the selected loops, concurrently and read-only."""
+    root = Path(repo_root)
+    selected = list(kinds) if kinds else list(_COLLECTORS)
+    budget = collect_budget(root)
+    out: dict[LoopKind, dict[str, Any]] = {}
+
+    pending: list[LoopKind] = []
+    for kind in selected:
+        if not allow_network and kind in NETWORK_TOUCHING:
+            out[kind] = {
+                "source_status": "unavailable",
+                "error": "skipped: --no-network",
+                "budget": budget,
+            }
+            continue
+        pending.append(kind)
+
+    if pending:
+        with ThreadPoolExecutor(max_workers=max(1, len(pending))) as executor:
+            futures = {
+                executor.submit(_safe_collect, _COLLECTORS[kind], root, timeout): kind
+                for kind in pending
+            }
+            for future in as_completed(futures):
+                kind = futures[future]
+                raw = future.result()
+                raw.setdefault("budget", budget)
+                out[kind] = raw
+    return out
+
+
+def build_records(raw_by_kind: dict[LoopKind, dict[str, Any]]) -> list[LoopRecord]:
+    """Classify collected raw signals into records, in registry order."""
+    records: list[LoopRecord] = []
+    for kind, spec in LOOP_SPECS.items():
+        if kind in raw_by_kind:
+            records.append(classify_loop(spec, raw_by_kind[kind]))
+    return records
+
+
+def collect_fleet(
+    repo_root: Path | str,
+    *,
+    timeout: float = 15.0,
+    allow_network: bool = True,
+    kinds: list[LoopKind] | None = None,
+) -> list[LoopRecord]:
+    """Convenience: collect raw signals and classify them into records."""
+    return build_records(
+        collect_all(repo_root, timeout=timeout, allow_network=allow_network, kinds=kinds)
+    )

--- a/docs-site/docs/contributing/b0-benchmark-truth-status.md
+++ b/docs-site/docs/contributing/b0-benchmark-truth-status.md
@@ -5,7 +5,7 @@ description: B0 Benchmark Truth Status
 
 # B0 Benchmark Truth Status
 
-Last updated: 2026-06-02T23:56:25Z
+Last updated: 2026-06-06T11:42:57Z
 
 This is the repo-tracked recurring `TW-02` publication surface for the fixed benchmark corpus.
 
@@ -13,8 +13,8 @@ This is the repo-tracked recurring `TW-02` publication surface for the fixed ben
 
 - Corpus manifest: `docs/benchmarks/corpus.json`
 - Corpus id: `tw-01-bounded-execution-v1`
-- Revision: `5`
-- Recorded on: `2026-05-28`
+- Revision: `6`
+- Recorded on: `2026-06-05`
 - Success contract: `mergeable_pr_or_merged_pr`
 - Verified expected issues: `5`
 - In-progress expected issues: `8`
@@ -25,17 +25,17 @@ This is the repo-tracked recurring `TW-02` publication surface for the fixed ben
 
 - Latest truth artifact: `docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/latest.json`
 - Latest scorecard: `docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/latest.json`
-- Revision-scoped truth pointer: `docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/rev-5/latest.json`
-- Revision-scoped scorecard pointer: `docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/rev-5/latest.json`
+- Revision-scoped truth pointer: `docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/rev-6/latest.json`
+- Revision-scoped scorecard pointer: `docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/rev-6/latest.json`
 
 ## Truth Metrics
 
 | Metric | Value |
 | --- | --- |
 | Verified truth success rate (primary) | 100.0% |
-| Full-corpus truth success rate (legacy/context) | 53.8% |
-| No-rescue truth success rate | 53.8% |
-| Merged-only rate | 53.8% |
+| Full-corpus truth success rate (legacy/context) | 69.2% |
+| No-rescue truth success rate | 69.2% |
+| Merged-only rate | 69.2% |
 
 ## In-Flight Graduation Metrics
 
@@ -43,43 +43,42 @@ This is the repo-tracked recurring `TW-02` publication surface for the fixed ben
 | --- | --- |
 | In-progress expected issues | 8 |
 | In-progress attempted issues | 8 |
-| In-progress successful issues | 2 |
-| In-progress graduation rate | 25.0% |
-| Expected in-progress issue numbers | `#5426`, `#5427`, `#5428`, `#5764`, `#5789`, `#5790`, `#5839`, `#5844` |
-| Live-open expected issue numbers | `#5428`, `#5764`, `#5789`, `#5790`, `#5839`, `#5844` |
-| Live-closed expected issue numbers | `#5426`, `#5427` |
+| In-progress successful issues | 4 |
+| In-progress graduation rate | 50.0% |
+| Expected in-progress issue numbers | `#5182`, `#5183`, `#5184`, `#5186`, `#5426`, `#5427`, `#5839`, `#5844` |
+| Live-open expected issue numbers | `#5182`, `#5183`, `#5184`, `#5186` |
+| Live-closed expected issue numbers | `#5426`, `#5427`, `#5839`, `#5844` |
 
 ## Proxy Metrics
 
 | Metric | Value |
 | --- | --- |
-| Proxy no-rescue success rate | 76.9% |
+| Proxy no-rescue success rate | 92.3% |
 | Unique issues attempted | 13 |
-| Unique issues succeeded | 10 |
-| Unique issues failed | 3 |
+| Unique issues succeeded | 12 |
+| Unique issues failed | 1 |
 | Unique issues neutral | 0 |
-| Total ticks | 28 |
+| Total ticks | 30 |
 
 ## Failure Class Distribution
 
-- `blocked_auth_failure`: 7
-- `blocked_not_dispatch_bounded`: 8
-- `blocked_sanitation_failed`: 2
-- `rescue_no_deliverable`: 1
+- `blocked_auth_failure`: 5
+- `blocked_not_dispatch_bounded`: 12
+- `blocked_sanitation_failed`: 1
 
 ## Rescue Counts By Type
 
-- `rescue_no_deliverable`: 1
+- none
 
 ## Previous Published Artifact
 
-- Previous artifact path: `docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/rev-5/scorecard-20260528T171236Z.json`
-- Previous generated_at: `2026-05-28T17:12:36Z`
+- Previous artifact path: `docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/rev-6/scorecard-20260605T180625Z.json`
+- Previous generated_at: `2026-06-05T18:06:25Z`
 
 ## Deltas
 
-- Merged-only rate (`merged_only_rate`): 0.1539
-- No-rescue truth success rate (`no_rescue_truth_success_rate`): 0.1539
+- Merged-only rate (`merged_only_rate`): 0.0769
+- No-rescue truth success rate (`no_rescue_truth_success_rate`): 0.0769
 - Proxy no-rescue success rate (`proxy_no_rescue_success_rate`): 0.0000
-- Full-corpus truth success rate (legacy/context) (`truth_success_rate`): 0.1539
+- Full-corpus truth success rate (legacy/context) (`truth_success_rate`): 0.0769
 - Unique issues attempted (`unique_issues_attempted`): 0.0000

--- a/docs-site/docs/contributing/next-steps-canonical.md
+++ b/docs-site/docs/contributing/next-steps-canonical.md
@@ -5,7 +5,7 @@ description: Next Steps (Canonical)
 
 # Next Steps (Canonical)
 
-Last updated: 2026-05-28
+Last updated: 2026-06-05
 
 This is the single source of truth for short-horizon execution priorities.
 [CANONICAL_GOALS](./canonical-goals) defines what Aragora is and why.
@@ -17,11 +17,11 @@ This is the single source of truth for short-horizon execution priorities.
 
 The immediate gate is operating the proof loop that already exists: keep recurring benchmark truth publication complete, fresh, and trustworthy on current `main`; keep `CS-01..03` narrower than measured proof; and do not expand the `B2` guard until repeated runs support it. The execution epics [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806) are now closed; the current obligation is operationalizing the proof-first loop, not adding new roadmap scope.
 
-Current May 28 proof-loop state:
+Current proof-loop state for `CS-01..03` reconciliation:
 
 - `docs/THESIS.md` is v4 canonical.
 - H1-01 rev-4 was promoted into the canonical corpus and rev-5 now graduates the first five strict linked successes.
-- Fresh B0 publication remains complete for the canonical corpus and reports 100.0% `truth_success_rate_verified` over five verified entries; full-corpus truth remains 38.5%, with eight entries still in progress.
+- `docs/status/B0_BENCHMARK_TRUTH_STATUS.md` and `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md` are the live measured proof surfaces. Do not copy volatile percentages into this file; require those surfaces to be fresh, complete for their current corpus/ledger window, and no broader than current proof before expanding `CS-01..03` or the `B2` guard.
 - The remaining Sprint 2 outreach proof gate now has product-scope frontier evidence: Claude reviewed SDK websocket PR [#7513](https://github.com/synaptent/aragora/pull/7513) at exact head `6531ebad2968ae9e2888f08ba237473c41eb0e21`, preserved unmodified in [the PR comment](https://github.com/synaptent/aragora/pull/7513#issuecomment-4567004963), and approved with non-blocking follow-ups. This satisfies the frontier/adversarial-review evidence gate; actual outreach remains an operator decision.
 - The first settlement receipt exists for `#7060`, and `review-queue observe-outcomes --window-days 14 --max-receipts 5 --json` dry-runs over it successfully with all five v2 outcome signals false and no receipt JSON writes.
 - The first `observe-outcomes --write` remains a separate Tier-4 operator decision over a bounded manually verifiable receipt slice.

--- a/docs/governance/LOOP_CONTROL_PLANE.md
+++ b/docs/governance/LOOP_CONTROL_PLANE.md
@@ -1,0 +1,244 @@
+# Loop Control Plane (v1)
+
+> Status: v1, **read-only**. No mutation, no active controller. This is a
+> governance *observability* surface, not new autonomy.
+
+Aragora runs several standing loops (the boss loop, the merge arbiter, the
+proof-first shift, the codex automation publisher, the worktree autopilot, the
+nomic loop). Each was built and operated on its own. The Loop Control Plane
+unifies them into a single, budgeted, halt-aware inventory and answers one
+governance question per loop:
+
+> **Is this loop safe to keep running right now?**
+
+It is computed entirely from surfaces that already exist; it never becomes a
+competing source of truth and it never acts.
+
+---
+
+## 1. The "loops" lesson, mapped to Aragora
+
+This work applies the framing from Matt Van Horn's *"WTF Is a Loop?"*:
+
+| Article idea | Aragora realization |
+|---|---|
+| A loop is *a scheduler plus a decision-maker* | launchd job (e.g. `com.aragora.swarm-merge-arbiter`) + the loop's in-process decision logic (`aragora/swarm/merge_arbiter.py`) |
+| Loops need **hard stops** or they run forever / overspend | max-iteration / max-runtime bounds, no-progress detection, and a spend ceiling (see §2) |
+| Loops need **self-verification / a feedback gate** | the model quorum (`aragora-merge-quorum`), proof-first freshness, publisher freshness, worktree health |
+| **Skills/tools are the reusable unit** the loop drives | the loop dispatches workers/agents and shells out to repo scripts |
+| The dangerous failure is **silent drift** | a loop that keeps "succeeding" while making no real progress, or that conflates *waiting* with *broken* (see §4) |
+
+The point of the article is not "add more loops"; it is "make the loops you
+already run *legible* and *stoppable*." v1 does exactly that and no more.
+
+---
+
+## 2. The three hard stops
+
+A loop is only *safe to keep running* when all three of these hold. The plane
+audits each loop's guards against them (`audit_halt_readiness`):
+
+1. **Max iteration / runtime.** A bound that guarantees termination
+   (e.g. `MergeArbiterConfig.max_runtime_hours = 12`,
+   `--max-hours` on the proof-first shift).
+2. **No-progress detection that distinguishes fault from waiting.** The loop
+   must notice it is not advancing **and** correctly separate an *operational
+   fault* (halt, fail closed) from *normal waiting on not-ready work*
+   (keep waiting). Getting this wrong is the live `merge_arbiter` defect (§4).
+3. **Budget ceiling.** A spend ceiling so a stuck-but-busy loop cannot run up an
+   unbounded bill. This is the article's headline risk.
+
+The audit verdict per loop is:
+
+- `ok` - all three present.
+- `incomplete` - some present, with specific `gaps` listed.
+- `missing` - none present.
+
+### Current findings (curated; see §6)
+
+Every standing loop is currently `incomplete`. Two systemic gaps dominate:
+
+- **No loop has a dollar/budget ceiling.** They are bounded by time/iterations
+  only. Wiring real per-loop budgets is the highest-value follow-up.
+- **`merge_arbiter`'s no-progress detection does not distinguish an operational
+  fault from not-ready PRs** (the #7879 bug class), so its circuit breaker can
+  trip on benign waiting and/or spin to `max_runtime` on a real fault.
+
+These are honest, code-referenced findings, not fabricated alarms.
+
+---
+
+## 3. The loop-to-ladder map
+
+Each loop maps to a review tier (`docs/REVIEW_AUTHORITY_PRINCIPLES.md`), a role,
+a feedback gate, and a durable-state location. This is the curated registry in
+`aragora/swarm/loop_control.py::LOOP_SPECS`.
+
+| Loop | Role | Feedback gate | Durable state | Human gate |
+|---|---|---|---|---|
+| `boss_loop` | supervisor | quorum | `.aragora/operator_steering` | no |
+| `merge_arbiter` | supervisor | quorum | (in-process) | yes (Tier 3-4 settlement) |
+| `proof_first_shift` | orchestration | proof_freshness | `.aragora/proof_first_shift` | no |
+| `publisher` | publication | publisher_freshness | `.aragora/automation-github-status` | no |
+| `worktree_autopilot` | maintenance | worktree_health | `.worktrees` | no |
+| `nomic` | self_improvement | (none) | `.aragora_beads` | yes (approval checkpoints) |
+
+---
+
+## 4. The fault-vs-waiting distinction (why v1 exists)
+
+The merge arbiter's circuit breaker is meant to *fail closed* on operational
+faults. But "made no merge this poll" is **not** the same as "is broken":
+
+- **Waiting:** no PR is mergeable yet (checks pending, quorum not yet reached).
+  Correct action: **keep waiting.**
+- **Fault:** the GitHub API is failing, auth is broken, or evaluation/merge is
+  raising. Correct action: **halt / fail closed.**
+
+Conflating them (PR #7879's defect class) means the loop either trips its breaker
+on benign waiting or spins uselessly to `max_runtime` on a real fault. The Loop
+Control Plane encodes the correct distinction directly in `classify_loop`:
+
+- a not-ready, *waiting* loop -> state `waiting`, next action `wait`;
+- an operational fault (or unrecognized stop reason, fail-closed) -> state
+  `blocked`, next action `halt`;
+- an unreadable loop -> state `unknown`, next action `report_only` (never an
+  implied "continue").
+
+`audit_halt_readiness` then flags `merge_arbiter` as `incomplete` precisely
+because its *guard* does not yet make this distinction, so the gap is visible at
+the fleet level until the loop itself is fixed.
+
+---
+
+## 5. The `LoopRecord` contract
+
+Every loop is normalized into a `LoopRecord` (`aragora/swarm/loop_control.py`).
+The stable, machine-readable fields:
+
+```jsonc
+{
+  "schema_version": "loop-control/v1",   // forward-compat hook (see §7)
+  "loop_id": "merge_arbiter",
+  "kind": "merge_arbiter",
+  "role": "supervisor",
+  "owner": "launchd",
+  "state": "running|waiting|blocked|budget_exhausted|halted|human_gated|stale_owner|unknown",
+  "ticks": null, "max_ticks": 3,
+  "runtime_s": null, "max_runtime_s": 43200.0,
+  "last_progress_at": null, "no_progress_ticks": null,
+  "budget": {"spend_usd": null, "ceiling_usd": null, "remaining_usd": null,
+             "source": "none", "source_status": "unavailable"},
+  "feedback_gate": {"kind": "quorum", "status": "quorum"},
+  "halt_readiness": {"max_iteration": true, "no_progress": true,
+                     "no_progress_distinguishes_fault": false,
+                     "budget_ceiling": false,
+                     "verdict": "incomplete", "gaps": ["..."], "notes": ["..."]},
+  "durability": {"state_path": null, "restart_safe": false},
+  "human_gate": {"required": true, "present": false},
+  "blocker": null,
+  "next_action": "report_only|continue|wait|halt|escalate_human",
+  "source_paths": ["scripts/run_merge_arbiter.sh", "aragora/swarm/merge_arbiter.py"],
+  "source_status": "ok|degraded|unavailable"
+}
+```
+
+`source_status` and `source_paths` make every record self-describing: a consumer
+can tell *how fresh / trustworthy* a record is and *where it came from* without
+re-deriving it. `schema_version` is carried on every record so a future ledger
+(§7) can evolve the shape without breaking readers.
+
+---
+
+## 6. Usage and guarantees
+
+```bash
+# Human table for the whole fleet
+python3 scripts/loop_control_status.py
+
+# JSON (records + fleet summary) for automation
+python3 scripts/loop_control_status.py --json
+
+# One loop, offline (skips the network-touching operator snapshot)
+python3 scripts/loop_control_status.py --loop merge_arbiter --no-network --json
+
+# Non-zero exit if any loop should halt/escalate or the fleet is unsafe
+python3 scripts/loop_control_status.py --exit-nonzero-on-halt
+```
+
+**Read-only guarantee.** The IO layer (`aragora/swarm/loop_control_io.py`) is the
+only part that touches the world, and it only ever *reads*: `launchctl print`,
+`git worktree list --porcelain`, `scripts/publisher_freshness_check.py --json`,
+`scripts/agent_bridge.py operator-snapshot --json`, and a file read of
+`.aragora/proof_first_shift/runtime_state.json`. It never merges, comments,
+reruns, pushes, or passes `--apply`, and it writes nothing. Collectors degrade to
+`degraded`/`unavailable` on missing files, rate limits, timeouts, or non-POSIX
+hosts rather than raising. The classifier (`loop_control.py`) is pure - no IO at
+all - which is what makes the read-only property auditable and the logic
+trivially unit-testable.
+
+### Relationship to existing surfaces ("A2, generalized")
+
+- `scripts/settle_status.py` is the **per-PR** read-only settlement view (A2).
+  The Loop Control Plane is the **per-loop, fleet-level** generalization of that
+  same "derive truth read-only from existing evidence" pattern.
+- `scripts/reconcile_merge_quorum.py` / `aragora/swarm/merge_quorum_reconcile.py`
+  reconcile merge-quorum settlement (A1). The plane *observes* the loops that
+  drive A1; it does not reconcile.
+- Feedback gates referenced: `docs/governance/QUORUM_EVIDENCE_RUNBOOK.md`,
+  `docs/governance/MERGE_GATE_RECONCILIATION.md`,
+  `docs/governance/BOSS_LOOP_MERGE_GATE_PHASE3_DESIGN.md`.
+
+> The halt-readiness guards in `LOOP_SPECS` are a **curated, code-referenced
+> audit** of each loop's design as of the cited revision - not auto-derived
+> facts. Update them when a loop's guards change. v1 deliberately does not
+> attempt to auto-derive guards from source (see §7).
+
+---
+
+## 7. Future LoopLedger Contract (follow-up, NOT in v1)
+
+v1 ships `LoopRecord` and exercises its shape, but it does **not** write any
+ledger files and does **not** integrate loop emitters. The following is a
+documented intent only, to be designed once `LoopRecord` has proven stable
+across all loops.
+
+A future **LoopLedger** would be an append-only, restart-safe history of
+`LoopRecord` snapshots, enabling: long-running loop audits, "no progress for N
+ticks across restarts" detection, and post-hoc spend/halt accounting.
+
+Proposed (not frozen) contract:
+
+- **Location:** `.aragora/loop_control/ledger.jsonl` (one JSON `LoopRecord`
+  envelope per line), mirroring `proof_first_shift/shift_ledger.jsonl`.
+- **Envelope:** `{ "schema_version", "recorded_at", "record": <LoopRecord> }`.
+  Readers MUST branch on `schema_version` and ignore unknown fields.
+- **Producer:** an opt-in emitter that calls `collect_fleet(...)` on the existing
+  poll cadence and appends; it MUST remain read-only with respect to the loops
+  themselves (it only observes them).
+- **Retention/compaction:** TTL + size cap, reusing the worktree-autopilot TTL
+  conventions.
+
+**Explicit non-goals for v1 (and until the ledger is designed):**
+
+- No ledger files are written.
+- No loop is modified to emit records.
+- No active controller: nothing in this plane halts, reruns, reconciles, or
+  otherwise changes any loop's behavior. Surfacing `next_action: halt` is a
+  *recommendation* for a human or a separately-authorized controller, not an
+  action taken here.
+
+When the ledger is built, the only schema change expected is additive; the
+`schema_version` field exists so that change does not break existing readers.
+
+---
+
+## 8. Scope summary
+
+| In v1 | Not in v1 |
+|---|---|
+| Read-only fleet inventory of standing loops | Any mutation of any loop |
+| Per-loop `next_action` (continue/wait/halt/escalate/report) | An active controller that performs those actions |
+| Curated halt-readiness audit (3 hard stops) with code refs | Auto-derivation of guards from source |
+| `LoopRecord` with `schema_version` forward-compat hook | A written LoopLedger or loop-emitter integration |
+| Budget *surfacing* (and flagging the missing ceiling) | Wiring real per-loop dollar budgets |

--- a/scripts/loop_control_status.py
+++ b/scripts/loop_control_status.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Loop Control Plane v1 - fleet status CLI (read-only).
+
+Unifies Aragora's standing loops (boss loop, merge arbiter, proof-first shift,
+publisher, worktree autopilot, nomic) into one budgeted, halt-aware inventory and
+reports, per loop, whether it is safe to continue. Computed entirely from
+existing read-only surfaces; performs no mutations.
+
+The single governance question per loop: *is it safe to keep running?* A loop
+that is merely waiting on not-ready work keeps waiting (``wait``); a loop with an
+operational fault or exhausted budget should ``halt``; an unreadable loop is
+``report_only`` (fail-closed), never an implied continue.
+
+Examples
+--------
+::
+
+    python3 scripts/loop_control_status.py
+    python3 scripts/loop_control_status.py --json
+    python3 scripts/loop_control_status.py --loop merge_arbiter --json
+    python3 scripts/loop_control_status.py --no-network --exit-nonzero-on-halt
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from aragora.swarm.loop_control import (  # noqa: E402
+    LoopKind,
+    LoopRecord,
+    NextAction,
+    summarize,
+)
+from aragora.swarm.loop_control_io import build_records, collect_all  # noqa: E402
+
+
+def _parse_kinds(values: list[str] | None) -> list[LoopKind] | None:
+    if not values:
+        return None
+    valid = {kind.value: kind for kind in LoopKind}
+    kinds: list[LoopKind] = []
+    for value in values:
+        if value not in valid:
+            raise SystemExit(f"unknown loop kind: {value} (choices: {', '.join(sorted(valid))})")
+        kinds.append(valid[value])
+    return kinds
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Loop Control Plane v1 - fleet status (read-only)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--repo", default=".", help="Path inside the target repository (default: cwd)"
+    )
+    parser.add_argument(
+        "--loop",
+        action="append",
+        dest="loops",
+        metavar="KIND",
+        help="Restrict to loop kind(s); repeatable",
+    )
+    parser.add_argument(
+        "--timeout", type=float, default=15.0, help="Per-source collector timeout (seconds)"
+    )
+    parser.add_argument(
+        "--no-network",
+        action="store_true",
+        help="Skip collectors that may reach the network (operator snapshot)",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON (records + fleet summary)")
+    parser.add_argument(
+        "--exit-nonzero-on-halt",
+        action="store_true",
+        help="Exit 1 when any loop should halt/escalate or the fleet is unsafe to continue",
+    )
+    return parser
+
+
+def _print_table(records: list[LoopRecord], summary: dict[str, object], repo_root: Path) -> None:
+    print(f"Loop Control Plane @ {repo_root}")
+    print("=" * 96)
+    print(f"{'LOOP':<20} {'STATE':<16} {'ACTION':<14} {'HALT':<11} {'SRC':<11} BLOCKER")
+    print("-" * 96)
+    for record in records:
+        blocker = record.blocker or "-"
+        if len(blocker) > 28:
+            blocker = blocker[:25] + "..."
+        print(
+            f"{record.kind:<20} {record.state:<16} {record.next_action:<14} "
+            f"{record.halt_readiness.verdict:<11} {record.source_status:<11} {blocker}"
+        )
+    print("-" * 96)
+    print(
+        f"fleet_safe_to_continue: {summary['fleet_safe_to_continue']}  | "
+        f"loops={summary['loops']}  by_state={summary['by_state']}"
+    )
+    gaps = summary.get("halt_readiness_gaps") or []
+    if isinstance(gaps, list) and gaps:
+        print("halt-readiness gaps:")
+        for gap in gaps:
+            print(f"  - {gap['loop']} ({gap['verdict']}): {'; '.join(gap['gaps'])}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    repo_root = Path(args.repo).resolve()
+    kinds = _parse_kinds(args.loops)
+    raw = collect_all(
+        repo_root, timeout=args.timeout, allow_network=not args.no_network, kinds=kinds
+    )
+    records = build_records(raw)
+    summary = summarize(records)
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "generated_at": datetime.now(tz=timezone.utc)
+                    .isoformat()
+                    .replace("+00:00", "Z"),
+                    "repo": str(repo_root),
+                    "records": [record.to_dict() for record in records],
+                    "summary": summary,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        _print_table(records, summary, repo_root)
+
+    if args.exit_nonzero_on_halt:
+        unsafe = (not summary["fleet_safe_to_continue"]) or any(
+            record.next_action in (NextAction.HALT.value, NextAction.ESCALATE_HUMAN.value)
+            for record in records
+        )
+        return 1 if unsafe else 0
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_loop_control_status.py
+++ b/tests/scripts/test_loop_control_status.py
@@ -1,0 +1,207 @@
+"""Tests for ``scripts/loop_control_status.py`` and the IO collectors.
+
+The central assertion is the **read-only proof**: driving the CLI with subprocess
+faked records every command issued and asserts they are all read-only (no merge /
+comment / rerun / push / --apply), and that no filesystem write occurs.
+"""
+
+from __future__ import annotations
+
+import builtins
+import importlib.util
+import json
+import pathlib
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import aragora.swarm.loop_control_io as io_mod  # noqa: E402
+
+
+def _load_cli() -> Any:
+    script_path = REPO_ROOT / "scripts" / "loop_control_status.py"
+    spec = importlib.util.spec_from_file_location("loop_control_status_under_test", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+cli = _load_cli()
+
+# Mutating arguments that must never appear as an exact arg in any command the
+# plane issues. Scanned as exact args (not substrings) so a benign launchd label
+# such as ``com.aragora.swarm-merge-arbiter`` is not a false positive.
+FORBIDDEN_TOKENS = (
+    "merge",
+    "comment",
+    "rerun",
+    "--apply",
+    "push",
+    "approve",
+    "commit",
+    "reset",
+    "checkout",
+    "clean",
+    "-X",
+    "POST",
+    "PATCH",
+    "DELETE",
+)
+ALLOWED_PY_SCRIPTS = ("publisher_freshness_check.py", "agent_bridge.py")
+
+
+class _FakeProc:
+    def __init__(self, stdout: str = "", returncode: int = 0) -> None:
+        self.stdout = stdout
+        self.stderr = ""
+        self.returncode = returncode
+
+
+def _healthy_run(recorded: list[list[str]]):
+    def run(cmd, *args, **kwargs):  # type: ignore[no-untyped-def]
+        recorded.append(list(cmd))
+        joined = " ".join(cmd)
+        if "publisher_freshness_check.py" in joined:
+            return _FakeProc(
+                json.dumps({"verdict": "ready", "launchd_loaded": True, "blockers": []})
+            )
+        if "agent_bridge.py" in joined:
+            return _FakeProc(
+                json.dumps(
+                    {
+                        "boss_loop_alive": True,
+                        "boss_loop_status": {"owner": "swarm-boss-loop"},
+                        "agent_heartbeats": {"count": 2, "fresh_count": 2},
+                        "health": {"ok": True},
+                        "queue_depth": 0,
+                        "timestamp": "2026-06-09T00:00:00Z",
+                    }
+                )
+            )
+        if cmd[:2] == ["launchctl", "print"]:
+            return _FakeProc("loaded", 0)
+        if cmd[:3] == ["git", "worktree", "list"]:
+            return _FakeProc("worktree /a\nworktree /b\n", 0)
+        return _FakeProc("", 0)
+
+    return run
+
+
+def test_cli_json_offline(monkeypatch: pytest.MonkeyPatch, capsys, tmp_path: Path) -> None:
+    recorded: list[list[str]] = []
+    monkeypatch.setattr(io_mod.subprocess, "run", _healthy_run(recorded))
+    rc = cli.main(["--repo", str(tmp_path), "--no-network", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["records"], "expected at least one record"
+    for record in payload["records"]:
+        assert record["schema_version"] == "loop-control/v1"
+    assert "fleet_safe_to_continue" in payload["summary"]
+    # --no-network must not invoke the operator snapshot.
+    assert all("agent_bridge.py" not in " ".join(cmd) for cmd in recorded)
+
+
+def test_cli_with_network_invokes_operator_snapshot(
+    monkeypatch: pytest.MonkeyPatch, capsys, tmp_path: Path
+) -> None:
+    recorded: list[list[str]] = []
+    monkeypatch.setattr(io_mod.subprocess, "run", _healthy_run(recorded))
+    rc = cli.main(["--repo", str(tmp_path), "--json"])
+    assert rc == 0
+    assert any("agent_bridge.py" in " ".join(cmd) for cmd in recorded)
+    assert any("operator-snapshot" in cmd for cmd in recorded)
+
+
+def test_only_read_only_commands(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    recorded: list[list[str]] = []
+    monkeypatch.setattr(io_mod.subprocess, "run", _healthy_run(recorded))
+    cli.main(["--repo", str(tmp_path), "--json"])
+    assert recorded, "expected commands to be issued"
+    for cmd in recorded:
+        # Exact-arg scan (not substring) so labels like swarm-merge-arbiter pass.
+        for bad in FORBIDDEN_TOKENS:
+            assert bad not in cmd, f"mutating arg {bad!r} found in {cmd}"
+        head = cmd[0]
+        is_python = "python" in head.lower() or head == sys.executable
+        assert head in ("launchctl", "git") or is_python, f"unexpected command head: {cmd}"
+        if head == "git":
+            assert cmd[:3] == ["git", "worktree", "list"], f"non-read-only git command: {cmd}"
+        elif head == "launchctl":
+            assert cmd[1] == "print", f"non-read-only launchctl command: {cmd}"
+        else:
+            script = next((arg for arg in cmd if arg.endswith(".py")), "")
+            assert any(script.endswith(name) for name in ALLOWED_PY_SCRIPTS), f"unexpected: {cmd}"
+            if script.endswith("agent_bridge.py"):
+                assert "operator-snapshot" in cmd, f"agent_bridge used non-read-only: {cmd}"
+
+
+def test_no_filesystem_writes(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    recorded: list[list[str]] = []
+    monkeypatch.setattr(io_mod.subprocess, "run", _healthy_run(recorded))
+
+    def _boom_write_text(self: pathlib.Path, *args: Any, **kwargs: Any) -> int:
+        raise AssertionError(f"unexpected write_text to {self}")
+
+    monkeypatch.setattr(pathlib.Path, "write_text", _boom_write_text)
+
+    real_open = builtins.open
+    write_opens: list[tuple[str, str]] = []
+
+    def _guarded_open(file: Any, mode: str = "r", *args: Any, **kwargs: Any):  # type: ignore[no-untyped-def]
+        if any(flag in mode for flag in ("w", "a", "x", "+")):
+            write_opens.append((str(file), mode))
+        return real_open(file, mode, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", _guarded_open)
+
+    rc = cli.main(["--repo", str(tmp_path), "--json"])
+    assert rc == 0
+    assert write_opens == [], f"unexpected filesystem writes: {write_opens}"
+
+
+def test_exit_nonzero_on_halt(monkeypatch: pytest.MonkeyPatch, capsys, tmp_path: Path) -> None:
+    def degraded_run(cmd, *args, **kwargs):  # type: ignore[no-untyped-def]
+        joined = " ".join(cmd)
+        if "publisher_freshness_check.py" in joined:
+            return _FakeProc(
+                json.dumps(
+                    {
+                        "verdict": "degraded",
+                        "launchd_loaded": False,
+                        "blockers": ["launchd: not-loaded"],
+                    }
+                )
+            )
+        return _FakeProc("", 0)
+
+    monkeypatch.setattr(io_mod.subprocess, "run", degraded_run)
+    rc = cli.main(
+        ["--repo", str(tmp_path), "--loop", "publisher", "--no-network", "--exit-nonzero-on-halt"]
+    )
+    assert rc == 1
+    # And the same fleet is "safe" when nothing is degraded.
+    recorded: list[list[str]] = []
+    monkeypatch.setattr(io_mod.subprocess, "run", _healthy_run(recorded))
+    rc_ok = cli.main(
+        ["--repo", str(tmp_path), "--loop", "publisher", "--no-network", "--exit-nonzero-on-halt"]
+    )
+    assert rc_ok == 0
+
+
+def test_collect_all_skips_network_when_disabled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    recorded: list[list[str]] = []
+    monkeypatch.setattr(io_mod.subprocess, "run", _healthy_run(recorded))
+    raw = io_mod.collect_all(tmp_path, allow_network=False)
+    boss = raw[io_mod.LoopKind.BOSS_LOOP]
+    assert boss["source_status"] == "unavailable"
+    assert "no-network" in boss.get("error", "")

--- a/tests/swarm/test_loop_control.py
+++ b/tests/swarm/test_loop_control.py
@@ -1,0 +1,209 @@
+"""Tests for ``aragora/swarm/loop_control.py`` (pure classifier + halt audit)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from aragora.swarm.loop_control import (
+    LOOP_SPECS,
+    SCHEMA_VERSION,
+    HaltGuards,
+    HaltVerdict,
+    LoopKind,
+    LoopState,
+    NextAction,
+    _is_fault_stop,
+    audit_halt_readiness,
+    classify_loop,
+    summarize,
+)
+
+ARBITER = LOOP_SPECS[LoopKind.MERGE_ARBITER]
+PROOF = LOOP_SPECS[LoopKind.PROOF_FIRST_SHIFT]
+BOSS = LOOP_SPECS[LoopKind.BOSS_LOOP]
+
+
+def test_waiting_is_not_blocked() -> None:
+    rec = classify_loop(ARBITER, {"source_status": "ok", "alive": True, "waiting_only": True})
+    assert rec.state == LoopState.WAITING.value
+    assert rec.next_action == NextAction.WAIT.value
+    assert rec.blocker is None
+
+
+def test_operational_fault_halts() -> None:
+    rec = classify_loop(
+        ARBITER,
+        {"source_status": "ok", "alive": True, "stop_reason": "GitHub API 500 during evaluate"},
+    )
+    assert rec.state == LoopState.BLOCKED.value
+    assert rec.next_action == NextAction.HALT.value
+    assert "GitHub" in (rec.blocker or "")
+
+
+def test_operational_fault_flag_halts_without_reason() -> None:
+    rec = classify_loop(ARBITER, {"source_status": "ok", "alive": True, "operational_fault": True})
+    assert rec.state == LoopState.BLOCKED.value
+    assert rec.next_action == NextAction.HALT.value
+
+
+def test_normal_stop_is_not_a_fault() -> None:
+    rec = classify_loop(
+        ARBITER,
+        {"source_status": "ok", "alive": False, "stop_reason": "TimeLimit: max runtime reached"},
+    )
+    assert rec.state == LoopState.HALTED.value
+    assert rec.next_action == NextAction.REPORT_ONLY.value
+
+
+def test_unknown_is_fail_closed() -> None:
+    rec = classify_loop(ARBITER, {"source_status": "unavailable"})
+    assert rec.state == LoopState.UNKNOWN.value
+    assert rec.next_action == NextAction.REPORT_ONLY.value
+
+
+def test_budget_exhausted_halts() -> None:
+    rec = classify_loop(
+        BOSS,
+        {
+            "source_status": "ok",
+            "alive": True,
+            "budget": {"remaining_usd": 0.0, "source": "test", "source_status": "ok"},
+        },
+    )
+    assert rec.state == LoopState.BUDGET_EXHAUSTED.value
+    assert rec.next_action == NextAction.HALT.value
+
+
+def test_negative_budget_halts() -> None:
+    rec = classify_loop(
+        BOSS,
+        {
+            "source_status": "ok",
+            "alive": True,
+            "budget": {"remaining_usd": -1.5, "source": "test", "source_status": "ok"},
+        },
+    )
+    assert rec.next_action == NextAction.HALT.value
+
+
+def test_human_gated_escalates() -> None:
+    rec = classify_loop(
+        ARBITER,
+        {
+            "source_status": "ok",
+            "alive": True,
+            "awaiting_human": True,
+            "human_settlement_present": False,
+        },
+    )
+    assert rec.state == LoopState.HUMAN_GATED.value
+    assert rec.next_action == NextAction.ESCALATE_HUMAN.value
+
+
+def test_human_gate_satisfied_does_not_escalate() -> None:
+    rec = classify_loop(
+        ARBITER,
+        {
+            "source_status": "ok",
+            "alive": True,
+            "awaiting_human": True,
+            "human_settlement_present": True,
+        },
+    )
+    assert rec.state != LoopState.HUMAN_GATED.value
+
+
+def test_owner_stale_reports_only() -> None:
+    rec = classify_loop(BOSS, {"source_status": "ok", "alive": True, "owner_stale": True})
+    assert rec.state == LoopState.STALE_OWNER.value
+    assert rec.next_action == NextAction.REPORT_ONLY.value
+
+
+def test_running_continues() -> None:
+    rec = classify_loop(PROOF, {"source_status": "ok", "alive": True})
+    assert rec.state == LoopState.RUNNING.value
+    assert rec.next_action == NextAction.CONTINUE.value
+
+
+@pytest.mark.parametrize(
+    "reason,is_fault",
+    [
+        ("max runtime reached", False),
+        ("TimeLimit: 12.01h >= max 12.00h", False),
+        ("no candidates", False),
+        ("shift complete", False),
+        ("", False),
+        ("circuit breaker tripped", True),
+        ("RepeatedAuthFailure", True),
+        ("GitHub outage detected", True),
+        ("something unrecognized", True),
+    ],
+)
+def test_is_fault_stop(reason: str, is_fault: bool) -> None:
+    assert _is_fault_stop(reason) is is_fault
+
+
+def test_halt_audit_ok() -> None:
+    result = audit_halt_readiness(HaltGuards(True, True, True, True))
+    assert result.verdict == HaltVerdict.OK.value
+    assert result.gaps == []
+
+
+def test_halt_audit_incomplete_no_budget() -> None:
+    result = audit_halt_readiness(HaltGuards(True, True, True, False))
+    assert result.verdict == HaltVerdict.INCOMPLETE.value
+    assert any("budget" in gap for gap in result.gaps)
+
+
+def test_halt_audit_incomplete_fault_not_distinguished() -> None:
+    result = audit_halt_readiness(HaltGuards(True, True, False, True))
+    assert result.verdict == HaltVerdict.INCOMPLETE.value
+    assert any("distinguish" in gap for gap in result.gaps)
+
+
+def test_halt_audit_missing() -> None:
+    result = audit_halt_readiness(HaltGuards(False, False, False, False))
+    assert result.verdict == HaltVerdict.MISSING.value
+
+
+def test_summarize_unsafe_when_blocked() -> None:
+    blocked = classify_loop(
+        ARBITER, {"source_status": "ok", "alive": True, "operational_fault": True}
+    )
+    waiting = classify_loop(ARBITER, {"source_status": "ok", "alive": True, "waiting_only": True})
+    summary = summarize([blocked, waiting])
+    assert summary["any_blocked"] is True
+    assert summary["fleet_safe_to_continue"] is False
+
+
+def test_summarize_safe_when_running_or_waiting() -> None:
+    running = classify_loop(PROOF, {"source_status": "ok", "alive": True})
+    waiting = classify_loop(ARBITER, {"source_status": "ok", "alive": True, "waiting_only": True})
+    summary = summarize([running, waiting])
+    assert summary["fleet_safe_to_continue"] is True
+    assert summary["schema_version"] == SCHEMA_VERSION
+
+
+def test_schema_version_on_record() -> None:
+    rec = classify_loop(PROOF, {"source_status": "ok", "alive": True})
+    assert rec.schema_version == SCHEMA_VERSION
+
+
+def test_record_is_json_serializable() -> None:
+    rec = classify_loop(ARBITER, {"source_status": "ok", "alive": True, "waiting_only": True})
+    assert "loop-control/v1" in json.dumps(rec.to_dict())
+
+
+def test_registry_complete_and_merge_arbiter_flagged() -> None:
+    for kind in LoopKind:
+        assert kind in LOOP_SPECS
+    # The #7879 lesson is encoded as a curated gap on the merge arbiter.
+    assert LOOP_SPECS[LoopKind.MERGE_ARBITER].guards.no_progress_distinguishes_fault is False
+
+
+def test_source_paths_and_status_propagated() -> None:
+    rec = classify_loop(ARBITER, {"source_status": "ok", "alive": True})
+    assert rec.source_paths == list(ARBITER.source_paths)
+    assert rec.source_status == "ok"


### PR DESCRIPTION
## Summary

Applies the "WTF Is a Loop?" governance lesson to Aragora's standing loops (boss loop, merge arbiter, proof-first shift, publisher, worktree autopilot, nomic): one **read-only**, halt-aware fleet inventory that answers, per loop, *"is this safe to keep running?"*

- `aragora/swarm/loop_control.py` — pure classifier: `LoopRecord` (carries `schema_version: loop-control/v1`), fail-closed `classify_loop`, `audit_halt_readiness` (the 3 hard stops: max-iteration bound, fault-vs-waiting no-progress, budget ceiling), curated `LOOP_SPECS` registry with code refs.
- `aragora/swarm/loop_control_io.py` — read-only collectors wrapping existing surfaces (`launchctl print`, `git worktree list --porcelain`, `publisher_freshness_check.py --json`, `agent_bridge.py operator-snapshot --json`, proof-first `runtime_state.json`). Concurrent, per-source timeout, graceful degrade to `degraded`/`unavailable`.
- `scripts/loop_control_status.py` — thin CLI (`--json`, `--loop KIND`, `--timeout`, `--no-network`, `--exit-nonzero-on-halt`), mirroring `settle_status.py` (A2, generalized from per-PR to per-loop fleet).
- `docs/governance/LOOP_CONTROL_PLANE.md` — article-to-Aragora map, loop-to-ladder table, `LoopRecord` contract, read-only guarantees, and a documented-only **Future LoopLedger Contract** (no ledger files, no emitter integration in v1).
- 36 tests, including an explicit **read-only proof** (subprocess allowlist + no-filesystem-write assertion) and the #7879 fault-vs-waiting distinction.

## Honest findings surfaced

- **No standing loop has a dollar/budget ceiling** (time/iteration bounds only) — every loop audits `incomplete`. Wiring per-loop budgets is the highest-value follow-up.
- **`merge_arbiter` no-progress detection does not distinguish an operational fault from not-ready PRs** (the #7879 bug class); encoded as a curated halt-readiness gap until the loop itself is fixed.

## Read-only guarantee

The IO layer is the only part that touches the world and it only ever reads. It never merges, comments, reruns, pushes, or passes `--apply`, and writes nothing. Enforced by tests (`tests/scripts/test_loop_control_status.py`).

## Validation

- pytest: 36/36 new tests pass (total test count increases)
- mypy: 0 errors in the 3 new modules
- pre-commit: all hooks pass on all changed files
- `scripts/automation_pr_preflight.sh origin/main HEAD`: ok
- Live smoke: table/JSON/filter/exit-code modes verified against live launchd state

## Governance

- Feature surface is additive-only: 6 new files. The only change to existing files is the follow-up commit `chore(docs-site): sync generated doc mirrors inherited from main` (2 generated docs-site mirrors; the identical drift reproduces on a clean origin/main d71d8b9bbb worktree, so it is inherited, not introduced - committed here because Build Documentation (PR Check) requires synced mirrors). No merge policy, CI, workflows, secrets, or protected files touched.
- Self-classification: Tier 1-2 (internal observability + CLI + docs/tests).
- Not to be merged without quorum settlement per `docs/governance/QUORUM_EVIDENCE_RUNBOOK.md`; model-quorum evidence to follow on this head.
