### PR TITLE
feat(automation): boss PR dedupe janitor (one draft per issue)

### DIFF
--- a/scripts/boss_pr_janitor.py
+++ b/scripts/boss_pr_janitor.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""Boss PR dedupe janitor: enforce one draft PR per boss-loop issue.
+
+The boss loop opens draft PRs on branches matching
+``aragora/boss-harvest/issue-<N>-boss-<hash>`` and
+``aragora/boss/issue-<N>-...``. Duplicate drafts for the same issue burn
+merge-quorum review capacity, one of the stall classes described in
+``docs/governance/BOSS_LOOP_MERGE_GATE_RESILIENCE.md``. This janitor
+net-closes those duplicates per Sprint 3 goal 3(ii) (anti-goal clause (b):
+prefer net-closing existing queue items over creating new work).
+
+Behavior:
+
+* Reads open PRs via ``gh pr list`` (read-only).
+* Groups PRs by issue number extracted from the head branch name; only the
+  two boss prefixes above are ever considered.
+* For each issue with two or more *draft* PRs, selects one keeper — the most
+  recently created draft whose checks are passing or pending, falling back to
+  the most recently created draft — and plans ``gh pr close`` for the rest
+  with a comment naming the keeper. Branches are preserved (no
+  ``--delete-branch``).
+* Ready (non-draft) PRs are NEVER closed, even when duplicated.
+* Dry-run is the default: without ``--apply`` the plan is printed as JSON
+  lines and no mutating ``gh`` command is invoked. Exit code 0.
+* With ``--apply``, any failed mutation fails closed: exit code 1.
+* ``--max-closes`` (default 10) caps the number of planned closes per run.
+
+Stdlib-only by design so it can run anywhere ``gh`` is authenticated.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from typing import Any, Sequence
+
+DEFAULT_REPO = "synaptent/aragora"
+DEFAULT_MAX_CLOSES = 10
+GH_TIMEOUT_SECONDS = 60
+
+# Only these boss-loop branch prefixes are ever considered.
+_BOSS_BRANCH_RE = re.compile(r"^aragora/boss(?:-harvest)?/issue-(\d+)(?:-|$)")
+
+# Check states/conclusions that disqualify a PR from preferred-keeper status.
+_FAILING_STATES = {
+    "FAILURE",
+    "ERROR",
+    "CANCELLED",
+    "TIMED_OUT",
+    "ACTION_REQUIRED",
+    "STARTUP_FAILURE",
+}
+
+
+def extract_issue_number(head_ref: str) -> int | None:
+    """Return the issue number for a boss-loop branch, else None.
+
+    Only ``aragora/boss-harvest/issue-<N>-...`` and
+    ``aragora/boss/issue-<N>-...`` qualify; anything else is ignored.
+    """
+    match = _BOSS_BRANCH_RE.match(head_ref or "")
+    if match is None:
+        return None
+    return int(match.group(1))
+
+
+def _has_failing_checks(pr: dict[str, Any]) -> bool:
+    rollup = pr.get("statusCheckRollup") or []
+    if not isinstance(rollup, list):
+        return False
+    for check in rollup:
+        if not isinstance(check, dict):
+            continue
+        state = str(check.get("state") or check.get("conclusion") or "").upper()
+        conclusion = str(check.get("conclusion") or "").upper()
+        if state in _FAILING_STATES or conclusion in _FAILING_STATES:
+            return True
+    return False
+
+
+def _created_at(pr: dict[str, Any]) -> str:
+    return str(pr.get("createdAt") or "")
+
+
+def select_keeper(drafts: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    """Pick the keeper among duplicate draft PRs.
+
+    Most recently created among those with passing/pending checks; if every
+    draft has failing checks, fall back to the most recently created draft.
+    """
+    healthy = [pr for pr in drafts if not _has_failing_checks(pr)]
+    pool = healthy if healthy else list(drafts)
+    return max(pool, key=lambda pr: (_created_at(pr), int(pr.get("number") or 0)))
+
+
+def _close_comment(keeper_number: int) -> str:
+    return (
+        f"Superseded by #{keeper_number} (boss PR janitor: one draft per issue; branch preserved)."
+    )
+
+
+def build_plan(
+    prs: Sequence[dict[str, Any]], max_closes: int = DEFAULT_MAX_CLOSES
+) -> list[dict[str, Any]]:
+    """Build the close plan. Pure function; never touches the network.
+
+    Only draft PRs on boss-loop branches are ever planned for closure.
+    """
+    groups: dict[int, list[dict[str, Any]]] = {}
+    for pr in prs:
+        issue = extract_issue_number(str(pr.get("headRefName") or ""))
+        if issue is None:
+            continue
+        groups.setdefault(issue, []).append(pr)
+
+    plan: list[dict[str, Any]] = []
+    for issue in sorted(groups):
+        drafts = [pr for pr in groups[issue] if pr.get("isDraft") is True]
+        if len(drafts) < 2:
+            continue
+        keeper = select_keeper(drafts)
+        keeper_number = int(keeper["number"])
+        losers = sorted(
+            (pr for pr in drafts if int(pr["number"]) != keeper_number),
+            key=lambda pr: int(pr["number"]),
+        )
+        for pr in losers:
+            plan.append(
+                {
+                    "action": "close",
+                    "issue": issue,
+                    "pr": int(pr["number"]),
+                    "keeper": keeper_number,
+                    "head_ref": pr.get("headRefName"),
+                    "title": pr.get("title"),
+                    "comment": _close_comment(keeper_number),
+                }
+            )
+
+    cap = max(0, int(max_closes))
+    return plan[:cap]
+
+
+def fetch_open_prs(repo: str) -> list[dict[str, Any]]:
+    """Read open PRs via gh (read-only).
+
+    Deliberately omits ``statusCheckRollup`` here: requesting it for 200 PRs
+    reliably 504s GitHub's GraphQL API. Rollups are fetched lazily per-PR by
+    :func:`enrich_duplicate_drafts` for duplicate draft groups only.
+    """
+    command = [
+        "gh",
+        "pr",
+        "list",
+        "--repo",
+        repo,
+        "--state",
+        "open",
+        "--json",
+        "number,headRefName,isDraft,createdAt,title",
+        "--limit",
+        "200",
+    ]
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        timeout=GH_TIMEOUT_SECONDS,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"gh pr list failed (exit {result.returncode}): {result.stderr.strip()}")
+    payload = json.loads(result.stdout or "[]")
+    if not isinstance(payload, list):
+        raise RuntimeError("gh pr list returned unexpected payload (expected a list)")
+    return payload
+
+
+def fetch_status_rollup(repo: str, number: int) -> list[dict[str, Any]]:
+    """Read a single PR's check rollup via gh (read-only)."""
+    command = [
+        "gh",
+        "pr",
+        "view",
+        str(number),
+        "--repo",
+        repo,
+        "--json",
+        "statusCheckRollup",
+    ]
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        timeout=GH_TIMEOUT_SECONDS,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"gh pr view {number} failed (exit {result.returncode}): {result.stderr.strip()}"
+        )
+    payload = json.loads(result.stdout or "{}")
+    rollup = payload.get("statusCheckRollup") if isinstance(payload, dict) else None
+    return rollup if isinstance(rollup, list) else []
+
+
+def enrich_duplicate_drafts(repo: str, prs: list[dict[str, Any]]) -> None:
+    """Attach ``statusCheckRollup`` to drafts in duplicate groups (in place).
+
+    Read-only. PRs that already carry a ``statusCheckRollup`` key are left
+    untouched. A failed per-PR fetch degrades to an empty rollup (treated as
+    pending), which only influences keeper choice among drafts — it can never
+    cause a ready PR to be closed.
+    """
+    groups: dict[int, list[dict[str, Any]]] = {}
+    for pr in prs:
+        issue = extract_issue_number(str(pr.get("headRefName") or ""))
+        if issue is None:
+            continue
+        groups.setdefault(issue, []).append(pr)
+
+    for members in groups.values():
+        drafts = [pr for pr in members if pr.get("isDraft") is True]
+        if len(drafts) < 2:
+            continue
+        for pr in drafts:
+            if "statusCheckRollup" in pr:
+                continue
+            try:
+                pr["statusCheckRollup"] = fetch_status_rollup(repo, int(pr["number"]))
+            except (RuntimeError, json.JSONDecodeError, OSError, subprocess.SubprocessError):
+                pr["statusCheckRollup"] = []
+
+
+def _close_command(repo: str, action: dict[str, Any]) -> list[str]:
+    return [
+        "gh",
+        "pr",
+        "close",
+        str(action["pr"]),
+        "--repo",
+        repo,
+        "--comment",
+        str(action["comment"]),
+    ]
+
+
+def apply_plan(repo: str, plan: Sequence[dict[str, Any]]) -> int:
+    """Apply close actions. Returns the number of failures (fail closed)."""
+    failures = 0
+    for action in plan:
+        command = _close_command(repo, action)
+        try:
+            result = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=GH_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            failures += 1
+            print(json.dumps({**action, "applied": False, "error": f"{type(exc).__name__}"}))
+            continue
+        ok = result.returncode == 0
+        if not ok:
+            failures += 1
+        print(
+            json.dumps(
+                {
+                    **action,
+                    "applied": ok,
+                    **({"error": result.stderr.strip()[:300]} if not ok else {}),
+                }
+            )
+        )
+    return failures
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Boss PR dedupe janitor: keep one draft PR per boss-loop issue, "
+            "close the rest. Dry-run by default."
+        )
+    )
+    parser.add_argument("--repo", default=DEFAULT_REPO, help="GitHub repo (owner/name)")
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        default=False,
+        help="Actually close duplicate draft PRs (default: dry-run, read-only)",
+    )
+    parser.add_argument(
+        "--max-closes",
+        type=int,
+        default=DEFAULT_MAX_CLOSES,
+        help=f"Maximum PRs to close per run (default {DEFAULT_MAX_CLOSES})",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        prs = fetch_open_prs(args.repo)
+    except (RuntimeError, json.JSONDecodeError, OSError, subprocess.SubprocessError) as exc:
+        print(json.dumps({"action": "error", "error": str(exc)[:500]}), file=sys.stderr)
+        return 1
+
+    enrich_duplicate_drafts(args.repo, prs)
+    plan = build_plan(prs, max_closes=args.max_closes)
+
+    if not args.apply:
+        for action in plan:
+            print(json.dumps({**action, "dry_run": True}))
+        print(
+            json.dumps(
+                {
+                    "action": "summary",
+                    "dry_run": True,
+                    "open_prs": len(prs),
+                    "planned_closes": len(plan),
+                    "max_closes": args.max_closes,
+                }
+            )
+        )
+        return 0
+
+    failures = apply_plan(args.repo, plan)
+    print(
+        json.dumps(
+            {
+                "action": "summary",
+                "dry_run": False,
+                "planned_closes": len(plan),
+                "failures": failures,
+            }
+        )
+    )
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_boss_pr_janitor.py
+++ b/tests/scripts/test_boss_pr_janitor.py
@@ -1,0 +1,402 @@
+"""Tests for ``scripts/boss_pr_janitor.py`` (boss PR dedupe janitor).
+
+The janitor must never hit the network in tests: the ``gh`` boundary is
+mocked via ``monkeypatch`` on the module's ``subprocess.run`` and/or its
+``fetch_open_prs`` function, mirroring the style of
+``tests/scripts/test_settle_tier4_pr.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _load_module(script_name: str) -> Any:
+    here = Path(__file__).resolve()
+    script_path = here.parents[2] / "scripts" / script_name
+    spec = importlib.util.spec_from_file_location(f"{script_name}_under_test", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load spec for {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+janitor = _load_module("boss_pr_janitor.py")
+
+
+def _pr(
+    number: int,
+    head: str,
+    *,
+    draft: bool = True,
+    created: str = "2026-06-09T00:00:00Z",
+    checks: list[dict[str, str]] | None = None,
+    title: str = "boss: automated change",
+) -> dict[str, Any]:
+    return {
+        "number": number,
+        "headRefName": head,
+        "isDraft": draft,
+        "createdAt": created,
+        "title": title,
+        "statusCheckRollup": checks if checks is not None else [],
+    }
+
+
+def _failing_check() -> list[dict[str, str]]:
+    return [{"state": "FAILURE", "conclusion": "FAILURE"}]
+
+
+def _passing_check() -> list[dict[str, str]]:
+    return [{"state": "SUCCESS", "conclusion": "SUCCESS"}]
+
+
+# ---------------------------------------------------------------------------
+# (a) duplicate drafts → one keeper, rest closed with comment naming keeper
+# ---------------------------------------------------------------------------
+
+
+def test_two_drafts_same_issue_keeps_one_closes_other() -> None:
+    prs = [
+        _pr(100, "aragora/boss-harvest/issue-8061-boss-aaaa", created="2026-06-08T00:00:00Z"),
+        _pr(101, "aragora/boss-harvest/issue-8061-boss-bbbb", created="2026-06-09T00:00:00Z"),
+    ]
+    plan = janitor.build_plan(prs)
+
+    assert len(plan) == 1
+    action = plan[0]
+    assert action["action"] == "close"
+    assert action["pr"] == 100
+    assert action["keeper"] == 101
+    assert action["issue"] == 8061
+    assert "#101" in action["comment"]
+    assert "Superseded by #101" in action["comment"]
+
+
+def test_keeper_prefers_most_recent_with_passing_or_pending_checks() -> None:
+    # Newest PR has failing checks; keeper must be the most recent among
+    # passing/pending ones instead.
+    prs = [
+        _pr(
+            200,
+            "aragora/boss-harvest/issue-8002-boss-aaaa",
+            created="2026-06-07T00:00:00Z",
+            checks=_passing_check(),
+        ),
+        _pr(
+            201,
+            "aragora/boss-harvest/issue-8002-boss-bbbb",
+            created="2026-06-08T00:00:00Z",
+            checks=[],  # pending / no checks yet → eligible
+        ),
+        _pr(
+            202,
+            "aragora/boss-harvest/issue-8002-boss-cccc",
+            created="2026-06-09T00:00:00Z",
+            checks=_failing_check(),
+        ),
+    ]
+    plan = janitor.build_plan(prs)
+
+    keepers = {a["keeper"] for a in plan}
+    closed = sorted(a["pr"] for a in plan)
+    assert keepers == {201}
+    assert closed == [200, 202]
+
+
+def test_keeper_falls_back_to_most_recent_when_all_failing() -> None:
+    prs = [
+        _pr(
+            300,
+            "aragora/boss/issue-7818-fix-old",
+            created="2026-06-07T00:00:00Z",
+            checks=_failing_check(),
+        ),
+        _pr(
+            301,
+            "aragora/boss/issue-7818-fix-new",
+            created="2026-06-09T00:00:00Z",
+            checks=_failing_check(),
+        ),
+    ]
+    plan = janitor.build_plan(prs)
+
+    assert len(plan) == 1
+    assert plan[0]["pr"] == 300
+    assert plan[0]["keeper"] == 301
+
+
+# ---------------------------------------------------------------------------
+# (b) single PR per issue → untouched
+# ---------------------------------------------------------------------------
+
+
+def test_single_pr_per_issue_untouched() -> None:
+    prs = [
+        _pr(400, "aragora/boss-harvest/issue-1111-boss-aaaa"),
+        _pr(401, "aragora/boss/issue-2222-something"),
+    ]
+    assert janitor.build_plan(prs) == []
+
+
+# ---------------------------------------------------------------------------
+# (c) non-draft (ready) PRs are NEVER closed even if duplicated
+# ---------------------------------------------------------------------------
+
+
+def test_ready_prs_never_closed() -> None:
+    prs = [
+        _pr(500, "aragora/boss-harvest/issue-3333-boss-aaaa", draft=False),
+        _pr(501, "aragora/boss-harvest/issue-3333-boss-bbbb", draft=False),
+    ]
+    assert janitor.build_plan(prs) == []
+
+
+def test_ready_pr_in_mixed_group_untouched_drafts_deduped() -> None:
+    prs = [
+        _pr(600, "aragora/boss-harvest/issue-4444-boss-aaaa", draft=False),
+        _pr(601, "aragora/boss-harvest/issue-4444-boss-bbbb", created="2026-06-08T00:00:00Z"),
+        _pr(602, "aragora/boss-harvest/issue-4444-boss-cccc", created="2026-06-09T00:00:00Z"),
+    ]
+    plan = janitor.build_plan(prs)
+
+    closed = {a["pr"] for a in plan}
+    assert 600 not in closed, "ready PR must never be closed"
+    assert closed == {601}
+    assert plan[0]["keeper"] == 602
+
+
+def test_single_draft_duplicating_ready_pr_not_closed() -> None:
+    # Only one draft in the group → nothing to dedupe among drafts.
+    prs = [
+        _pr(700, "aragora/boss-harvest/issue-5555-boss-aaaa", draft=False),
+        _pr(701, "aragora/boss-harvest/issue-5555-boss-bbbb"),
+    ]
+    assert janitor.build_plan(prs) == []
+
+
+# ---------------------------------------------------------------------------
+# (d) branches outside boss prefixes are never considered
+# ---------------------------------------------------------------------------
+
+
+def test_non_boss_branches_never_considered() -> None:
+    prs = [
+        _pr(800, "feature/issue-6666-cool-thing"),
+        _pr(801, "codex/issue-6666-other-thing"),
+        _pr(802, "elves/run-20260610-issue-6666"),
+        _pr(803, "aragora/bossy/issue-6666-trap"),
+        _pr(804, "prefix/aragora/boss-harvest/issue-6666-nested"),
+    ]
+    assert janitor.build_plan(prs) == []
+
+
+def test_extract_issue_number_prefix_matching() -> None:
+    assert janitor.extract_issue_number("aragora/boss-harvest/issue-8061-boss-ab12") == 8061
+    assert janitor.extract_issue_number("aragora/boss/issue-7818-fix-thing") == 7818
+    assert janitor.extract_issue_number("aragora/boss-harvest/issue-") is None
+    assert janitor.extract_issue_number("feature/issue-123-x") is None
+    assert janitor.extract_issue_number("aragora/boss-harvestissue-123") is None
+
+
+# ---------------------------------------------------------------------------
+# (e) dry-run is the default: no mutating gh command without --apply
+# ---------------------------------------------------------------------------
+
+
+def _duplicate_fixture() -> list[dict[str, Any]]:
+    return [
+        _pr(900, "aragora/boss-harvest/issue-9001-boss-aaaa", created="2026-06-08T00:00:00Z"),
+        _pr(901, "aragora/boss-harvest/issue-9001-boss-bbbb", created="2026-06-09T00:00:00Z"),
+    ]
+
+
+def test_dry_run_default_invokes_no_mutating_gh_command(monkeypatch: Any, capsys: Any) -> None:
+    calls: list[list[str]] = []
+
+    def record_run(command: list[str], **kwargs: Any) -> Any:
+        calls.append(list(command))
+        raise AssertionError(f"subprocess must not run in dry-run with mocked fetch: {command}")
+
+    monkeypatch.setattr(janitor, "fetch_open_prs", lambda repo: _duplicate_fixture())
+    monkeypatch.setattr(janitor.subprocess, "run", record_run)
+
+    exit_code = janitor.main(["--repo", "synaptent/aragora"])
+
+    assert exit_code == 0
+    assert calls == []
+    out_lines = [line for line in capsys.readouterr().out.splitlines() if line.strip()]
+    plans = [json.loads(line) for line in out_lines]
+    close_plans = [p for p in plans if p.get("action") == "close"]
+    assert len(close_plans) == 1
+    assert close_plans[0]["pr"] == 900
+    assert close_plans[0]["keeper"] == 901
+    assert close_plans[0]["dry_run"] is True
+
+
+def test_apply_invokes_close_and_fails_closed_on_error(monkeypatch: Any) -> None:
+    commands: list[list[str]] = []
+
+    def fake_run(command: list[str], **kwargs: Any) -> Any:
+        commands.append(list(command))
+        return subprocess.CompletedProcess(command, returncode=1, stdout="", stderr="boom")
+
+    monkeypatch.setattr(janitor, "fetch_open_prs", lambda repo: _duplicate_fixture())
+    monkeypatch.setattr(janitor.subprocess, "run", fake_run)
+
+    exit_code = janitor.main(["--repo", "synaptent/aragora", "--apply"])
+
+    assert exit_code == 1, "any failed apply mutation must fail closed"
+    close_commands = [c for c in commands if "close" in c]
+    assert len(close_commands) == 1
+    cmd = close_commands[0]
+    assert cmd[:3] == ["gh", "pr", "close"]
+    assert "900" in cmd
+    assert any("Superseded by #901" in part for part in cmd)
+
+
+def test_apply_success_exits_zero(monkeypatch: Any) -> None:
+    def fake_run(command: list[str], **kwargs: Any) -> Any:
+        return subprocess.CompletedProcess(command, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(janitor, "fetch_open_prs", lambda repo: _duplicate_fixture())
+    monkeypatch.setattr(janitor.subprocess, "run", fake_run)
+
+    assert janitor.main(["--repo", "synaptent/aragora", "--apply"]) == 0
+
+
+def test_apply_never_closes_ready_prs(monkeypatch: Any) -> None:
+    commands: list[list[str]] = []
+
+    def fake_run(command: list[str], **kwargs: Any) -> Any:
+        commands.append(list(command))
+        return subprocess.CompletedProcess(command, returncode=0, stdout="", stderr="")
+
+    ready_dupes = [
+        _pr(950, "aragora/boss-harvest/issue-9050-boss-aaaa", draft=False),
+        _pr(951, "aragora/boss-harvest/issue-9050-boss-bbbb", draft=False),
+    ]
+    monkeypatch.setattr(janitor, "fetch_open_prs", lambda repo: ready_dupes)
+    monkeypatch.setattr(janitor.subprocess, "run", fake_run)
+
+    assert janitor.main(["--repo", "synaptent/aragora", "--apply"]) == 0
+    assert all("close" not in c for c in commands)
+
+
+# ---------------------------------------------------------------------------
+# Lazy check-rollup enrichment (read-only, duplicate draft groups only)
+# ---------------------------------------------------------------------------
+
+
+def test_enrich_fetches_rollup_only_for_drafts_in_duplicate_groups(
+    monkeypatch: Any,
+) -> None:
+    fetched: list[int] = []
+
+    def fake_rollup(repo: str, number: int) -> list[dict[str, str]]:
+        fetched.append(number)
+        return []
+
+    prs = [
+        # duplicate draft group → both fetched (rollup key removed below)
+        _pr(910, "aragora/boss-harvest/issue-9100-boss-aaaa"),
+        _pr(911, "aragora/boss-harvest/issue-9100-boss-bbbb"),
+        # ready duplicate in same group → never fetched
+        _pr(912, "aragora/boss-harvest/issue-9100-boss-cccc", draft=False),
+        # singleton draft → never fetched
+        _pr(913, "aragora/boss-harvest/issue-9200-boss-aaaa"),
+        # non-boss branch → never fetched
+        _pr(914, "feature/issue-9100-unrelated"),
+    ]
+    for pr in prs:
+        pr.pop("statusCheckRollup", None)
+
+    monkeypatch.setattr(janitor, "fetch_status_rollup", fake_rollup)
+    janitor.enrich_duplicate_drafts("synaptent/aragora", prs)
+
+    assert sorted(fetched) == [910, 911]
+
+
+def test_dry_run_with_lazy_enrichment_invokes_only_read_commands(
+    monkeypatch: Any, capsys: Any
+) -> None:
+    commands: list[list[str]] = []
+
+    def fake_run(command: list[str], **kwargs: Any) -> Any:
+        commands.append(list(command))
+        stdout = "{}"
+        if command[:3] == ["gh", "pr", "view"]:
+            stdout = json.dumps({"statusCheckRollup": []})
+        return subprocess.CompletedProcess(command, returncode=0, stdout=stdout, stderr="")
+
+    fixture = _duplicate_fixture()
+    for pr in fixture:
+        pr.pop("statusCheckRollup", None)
+
+    monkeypatch.setattr(janitor, "fetch_open_prs", lambda repo: fixture)
+    monkeypatch.setattr(janitor.subprocess, "run", fake_run)
+
+    assert janitor.main(["--repo", "synaptent/aragora"]) == 0
+    assert all(c[:3] == ["gh", "pr", "view"] for c in commands), commands
+    assert all("close" not in c for c in commands)
+
+
+# ---------------------------------------------------------------------------
+# (f) --max-closes cap (default 10) respected
+# ---------------------------------------------------------------------------
+
+
+def _many_duplicate_groups(groups: int) -> list[dict[str, Any]]:
+    prs: list[dict[str, Any]] = []
+    number = 1000
+    for issue in range(1, groups + 1):
+        for suffix in ("aaaa", "bbbb"):
+            prs.append(
+                _pr(
+                    number,
+                    f"aragora/boss-harvest/issue-{issue}-boss-{suffix}",
+                    created=f"2026-06-0{1 + (number % 2)}T00:00:00Z",
+                )
+            )
+            number += 1
+    return prs
+
+
+def test_max_closes_default_cap_is_ten() -> None:
+    plan = janitor.build_plan(_many_duplicate_groups(15))
+    assert len(plan) == 10
+
+
+def test_max_closes_explicit_cap() -> None:
+    plan = janitor.build_plan(_many_duplicate_groups(15), max_closes=3)
+    assert len(plan) == 3
+
+
+def test_max_closes_cap_respected_in_apply(monkeypatch: Any) -> None:
+    commands: list[list[str]] = []
+
+    def fake_run(command: list[str], **kwargs: Any) -> Any:
+        commands.append(list(command))
+        return subprocess.CompletedProcess(command, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(janitor, "fetch_open_prs", lambda repo: _many_duplicate_groups(15))
+    monkeypatch.setattr(janitor.subprocess, "run", fake_run)
+
+    exit_code = janitor.main(["--repo", "synaptent/aragora", "--apply", "--max-closes", "2"])
+
+    assert exit_code == 0
+    close_commands = [c for c in commands if "close" in c]
+    assert len(close_commands) == 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## Summary

Batch 2.2 of autonomous run run-20260610 (Lane C): `scripts/boss_pr_janitor.py`, a stdlib-only janitor that enforces one draft boss-loop PR per issue. Duplicate drafts on `aragora/boss-harvest/issue-<N>-boss-<hash>` and `aragora/boss/issue-<N>-...` branches burn merge-quorum review capacity (stall class described in `docs/governance/BOSS_LOOP_MERGE_GATE_RESILIENCE.md`).

Sprint 3 goal 3(ii) / anti-goal clause (b): this net-closes existing queue items — live duplicate groups at sprint open: #8061 x2, #8002 x3, #7818 x2.

## Behavior

- **Dry-run by default** (truly read-only): prints the close plan as JSON lines, exit 0. Mutations require explicit `--apply`.
- **Keeper selection**: most recently created draft with passing/pending checks, falling back to most recent. Check rollups fetched lazily per duplicate group only (bulk `statusCheckRollup` at `--limit 200` reliably 504s GitHub GraphQL — verified live).
- **Ready (non-draft) PRs are never closed**, even when duplicated; non-boss branches never considered.
- **Fail closed**: any failed `--apply` mutation → exit 1.
- **`--max-closes` cap** (default 10) bounds blast radius.
- Closes use `gh pr close <n> --comment "Superseded by #<keeper> ..."`; branches preserved (no `--delete-branch`).

## Verification

- 18 new tests in `tests/scripts/test_boss_pr_janitor.py` (mocked gh boundary, no network): `python -m pytest tests/scripts/test_boss_pr_janitor.py -q` → 18 passed.
- Real read-only dry-run against synaptent/aragora planned exactly the 4 known duplicate closes (keepers #7999, #8070, #8084); nothing mutated. Coordinator runs the live apply.

## Dogfood gate

- Agents: grok, mistral-api (`aragora ask --rounds 1 --decision-integrity`; receipt records grok)
- Verdict: PASS / Recommend MERGE, confidence 0.8, dissenting_views: none
- Receipt: `.aragora/run-20260610/receipts/batch_2_2_janitor.json` (`aragora receipt verify` → VALID, 3/3 checks)
- Head SHA: 6dad0694efd0d23b3fc6336f73885e15bcd1b680

Tier: 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)