### PR TITLE
test(server): route-collision guard for handler registry

### DIFF
--- a/tests/server/test_route_collisions.py
+++ b/tests/server/test_route_collisions.py
@@ -1,0 +1,392 @@
+"""Route-collision guard for the server handler registry.
+
+The unified server dispatches /api/* requests through ``HANDLER_REGISTRY``
+(``aragora/server/handler_registry/__init__.py``), a flat ordered list of
+``(attr_name, handler_class)`` pairs. ``RouteIndex.build()``
+(``aragora/server/handler_registry/core.py``) extracts each handler's
+``ROUTES`` class attribute into an exact-match dict with FIRST-WINS
+semantics::
+
+    for path in routes:
+        if path not in self._exact_routes:
+            self._exact_routes[path] = (attr_name, handler)
+
+This means a second handler claiming a path already claimed by an earlier
+registry entry is SILENTLY SHADOWED — requests never reach it. This test
+freezes the current set of shadowed (colliding) routes so that:
+
+* Any NEW collision fails CI immediately (the new handler would silently
+  never receive traffic for that path).
+* Any RESOLVED collision also fails, prompting baseline cleanup, so the
+  baseline can only shrink intentionally.
+
+Notes on dispatch semantics covered here:
+
+* Routes in ``ROUTES`` are method-agnostic — one handler owns a path for
+  all HTTP methods (method dispatch happens inside the handler via
+  ``handle`` / ``handle_post`` / etc.). A few handlers encode a method in
+  the route entry (``"GET /path"`` strings or ``(method, path)`` tuples,
+  see ``BaseHandler.can_handle``); we key those by ``(method, path)`` so a
+  GET-only claim does not falsely collide with a POST-only claim.
+* Prefix-based dispatch (``PREFIX_PATTERNS`` inside ``RouteIndex.build``)
+  is intentionally NOT covered: overlapping prefixes are mediated at
+  request time by each handler's ``can_handle`` and cannot be statically
+  proven to collide. The exact-route table is the statically checkable
+  surface, and it is where the historical shadowing incidents lived.
+
+Runtime: importing ``aragora.server.handler_registry`` is cheap (~0.1s);
+resolving the ~330 deferred handler classes takes a few seconds. No server
+is started and no network is touched.
+"""
+
+from __future__ import annotations
+
+import re
+from functools import lru_cache
+
+import pytest
+
+from aragora.server.handler_registry import HANDLER_REGISTRY
+from aragora.server.handler_registry.core import _DeferredImport
+
+# ---------------------------------------------------------------------------
+# Path normalization
+# ---------------------------------------------------------------------------
+
+_HTTP_METHODS = frozenset({"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"})
+
+# A path segment that is a parameter placeholder in any common convention:
+#   {id}   <id>   :id   *   (regex)   <int:id>
+_PARAM_SEGMENT = re.compile(
+    r"""
+    ^(
+        \{[^/]*\}        # {id}, {debate_id}
+      | <[^/]*>          # <id>, <int:id>
+      | :[A-Za-z_][^/]*  # :id
+      | \*+              # * or **
+      | \([^/]*\)        # (regex group)
+    )$
+    """,
+    re.VERBOSE,
+)
+
+
+def normalize_path(path: str) -> str:
+    """Normalize parameter placeholders so equivalent patterns compare equal.
+
+    ``/api/debates/{id}/share``, ``/api/debates/<id>/share``,
+    ``/api/debates/:id/share`` and ``/api/debates/*/share`` all normalize to
+    ``/api/debates/*/share``. Trailing slashes are preserved because the
+    exact-route dict treats ``/api/x`` and ``/api/x/`` as distinct keys.
+    """
+    segments = path.split("/")
+    normalized = ["*" if _PARAM_SEGMENT.match(segment) else segment for segment in segments]
+    return "/".join(normalized)
+
+
+def _route_entry_to_key(entry: object) -> tuple[str, str] | None:
+    """Convert one ROUTES entry to a normalized ``(method, path)`` key.
+
+    Supports the shapes accepted by ``BaseHandler.can_handle``:
+    plain path strings, ``"METHOD /path"`` strings, and
+    ``(method, path)`` tuples/lists. Returns None for unparseable entries
+    (asserted against separately in test_routes_are_well_formed).
+    """
+    method = "*"
+    path: object = entry
+    if isinstance(entry, (tuple, list)):
+        if len(entry) >= 2:
+            method, path = str(entry[0]).upper(), entry[1]
+        elif len(entry) == 1:
+            path = entry[0]
+        else:
+            return None
+    elif isinstance(entry, str) and " " in entry:
+        prefix, _, rest = entry.partition(" ")
+        if prefix.upper() in _HTTP_METHODS:
+            method, path = prefix.upper(), rest
+        # else: a path containing a space — keep as-is (will fail
+        # test_routes_are_well_formed if it does not start with "/")
+    if not isinstance(path, str) or not path:
+        return None
+    return (method, normalize_path(path))
+
+
+# ---------------------------------------------------------------------------
+# Registry enumeration (import-time only; no server start, no network)
+# ---------------------------------------------------------------------------
+
+
+@lru_cache(maxsize=1)
+def _collect_route_claims() -> tuple[
+    dict[tuple[str, str], frozenset[str]],  # (method, normalized path) -> handler names
+    list[str],  # attr names whose handler class failed to resolve
+    list[tuple[str, object]],  # (handler name, raw entry) for malformed entries
+]:
+    """Enumerate every (method, normalized-path) claim from HANDLER_REGISTRY."""
+    claims: dict[tuple[str, str], set[str]] = {}
+    unresolved: list[str] = []
+    malformed: list[tuple[str, object]] = []
+
+    for attr_name, entry in HANDLER_REGISTRY:
+        handler_cls = entry.resolve() if isinstance(entry, _DeferredImport) else entry
+        if handler_cls is None:
+            unresolved.append(attr_name)
+            continue
+        handler_name = handler_cls.__name__
+        routes = getattr(handler_cls, "ROUTES", None) or []
+        if isinstance(routes, dict):
+            routes = list(routes.keys())
+        for raw in routes:
+            key = _route_entry_to_key(raw)
+            if key is None:
+                malformed.append((handler_name, raw))
+                continue
+            claims.setdefault(key, set()).add(handler_name)
+
+    frozen = {key: frozenset(names) for key, names in claims.items()}
+    return frozen, unresolved, malformed
+
+
+def _current_collisions() -> dict[tuple[str, str], frozenset[str]]:
+    claims, _, _ = _collect_route_claims()
+    return {key: names for key, names in claims.items() if len(names) > 1}
+
+
+# ---------------------------------------------------------------------------
+# Frozen baseline of collisions that exist TODAY (2026-06-10).
+#
+# Every entry below is a route claimed by 2+ DIFFERENT handler classes.
+# Because RouteIndex.build() is first-wins, only the handler registered
+# earliest in HANDLER_REGISTRY actually receives requests for the path;
+# the others are silently shadowed. These are real (if latent) bugs, frozen
+# here so they are visible and so the set can only shrink.
+#
+# To RESOLVE one: remove the duplicate route from the shadowed handler (or
+# consolidate the handlers), then delete the entry here.
+# Do NOT add new entries unless you have consciously decided the shadowing
+# is acceptable and documented why in your PR.
+# ---------------------------------------------------------------------------
+
+KNOWN_COLLISIONS: dict[tuple[str, str], frozenset[str]] = {
+    ("*", "/api/agent/*/domains"): frozenset({"AgentsHandler", "PersonaHandler"}),
+    ("*", "/api/agent/*/performance"): frozenset({"AgentsHandler", "PersonaHandler"}),
+    ("*", "/api/auth/revoke"): frozenset({"AuthHandler", "SystemHandler"}),
+    ("*", "/api/flips/recent"): frozenset({"AgentsHandler", "InsightsHandler"}),
+    ("*", "/api/flips/summary"): frozenset({"AgentsHandler", "InsightsHandler"}),
+    ("*", "/api/health/stores"): frozenset({"HealthHandler", "StorageHealthHandler"}),
+    ("*", "/api/v1/accounting/expenses"): frozenset({"APAutomationHandler", "ExpenseHandler"}),
+    ("*", "/api/v1/accounting/expenses/categorize"): frozenset(
+        {"APAutomationHandler", "ExpenseHandler"}
+    ),
+    ("*", "/api/v1/accounting/expenses/export"): frozenset(
+        {"APAutomationHandler", "ExpenseHandler"}
+    ),
+    ("*", "/api/v1/accounting/expenses/pending"): frozenset(
+        {"APAutomationHandler", "ExpenseHandler"}
+    ),
+    ("*", "/api/v1/accounting/expenses/stats"): frozenset(
+        {"APAutomationHandler", "ExpenseHandler"}
+    ),
+    ("*", "/api/v1/accounting/expenses/sync"): frozenset({"APAutomationHandler", "ExpenseHandler"}),
+    ("*", "/api/v1/accounting/expenses/upload"): frozenset(
+        {"APAutomationHandler", "ExpenseHandler"}
+    ),
+    ("*", "/api/v1/accounting/invoices"): frozenset({"APAutomationHandler", "InvoiceHandler"}),
+    ("*", "/api/v1/accounting/invoices/overdue"): frozenset(
+        {"APAutomationHandler", "InvoiceHandler"}
+    ),
+    ("*", "/api/v1/accounting/invoices/pending"): frozenset(
+        {"APAutomationHandler", "InvoiceHandler"}
+    ),
+    ("*", "/api/v1/accounting/invoices/stats"): frozenset(
+        {"APAutomationHandler", "InvoiceHandler"}
+    ),
+    ("*", "/api/v1/accounting/invoices/status"): frozenset(
+        {"APAutomationHandler", "InvoiceHandler"}
+    ),
+    ("*", "/api/v1/accounting/invoices/upload"): frozenset(
+        {"APAutomationHandler", "InvoiceHandler"}
+    ),
+    ("*", "/api/v1/accounting/payments/scheduled"): frozenset(
+        {"APAutomationHandler", "InvoiceHandler"}
+    ),
+    ("*", "/api/v1/accounting/purchase-orders"): frozenset(
+        {"APAutomationHandler", "InvoiceHandler"}
+    ),
+    ("*", "/api/v1/billing/usage"): frozenset({"BillingHandler", "UsageMeteringHandler"}),
+    ("*", "/api/v1/billing/usage/export"): frozenset({"BillingHandler", "UsageMeteringHandler"}),
+    ("*", "/api/v1/debates/*/share"): frozenset({"DebateShareHandler", "SharingHandler"}),
+    ("*", "/api/v1/debates/*/summary"): frozenset({"DebatesHandler", "ExplainabilityHandler"}),
+    ("*", "/api/v1/email/prioritize"): frozenset({"EmailDebateHandler", "EmailHandler"}),
+    ("*", "/api/v1/health/database"): frozenset({"HealthHandler", "StorageHealthHandler"}),
+    ("*", "/api/v1/health/stores"): frozenset({"HealthHandler", "StorageHealthHandler"}),
+    ("*", "/api/v1/marketplace/categories"): frozenset(
+        {"MarketplaceHandler", "TemplateMarketplaceHandler"}
+    ),
+    ("*", "/api/v1/marketplace/featured"): frozenset(
+        {"MarketplaceBrowseHandler", "TemplateMarketplaceHandler"}
+    ),
+    ("*", "/api/v1/marketplace/popular"): frozenset(
+        {"MarketplaceBrowseHandler", "MarketplaceHandler"}
+    ),
+    ("*", "/api/v1/marketplace/templates"): frozenset(
+        {"MarketplaceBrowseHandler", "MarketplaceHandler", "TemplateMarketplaceHandler"}
+    ),
+    # MarketplaceHandler claims a {template_id} variant that normalizes to
+    # the same pattern as the literal-'*' claims of the other two handlers.
+    ("*", "/api/v1/marketplace/templates/*"): frozenset(
+        {"MarketplaceBrowseHandler", "MarketplaceHandler", "TemplateMarketplaceHandler"}
+    ),
+    ("*", "/api/v1/notifications/history"): frozenset(
+        {"NotificationHistoryHandler", "NotificationsHandler"}
+    ),
+    ("*", "/api/v1/pipeline"): frozenset({"DecompositionHandler", "PipelineExecuteHandler"}),
+    ("*", "/api/v1/rlm/codebase/health"): frozenset({"RLMContextHandler", "RLMHandler"}),
+    ("*", "/api/v1/rlm/compress"): frozenset({"RLMContextHandler", "RLMHandler"}),
+    ("*", "/api/v1/rlm/contexts"): frozenset({"RLMContextHandler", "RLMHandler"}),
+    ("*", "/api/v1/rlm/query"): frozenset({"RLMContextHandler", "RLMHandler"}),
+    ("*", "/api/v1/rlm/stats"): frozenset({"RLMContextHandler", "RLMHandler"}),
+    ("*", "/api/v1/rlm/strategies"): frozenset({"RLMContextHandler", "RLMHandler"}),
+    ("*", "/api/v1/rlm/stream"): frozenset({"RLMContextHandler", "RLMHandler"}),
+    ("*", "/api/v1/rlm/stream/modes"): frozenset({"RLMContextHandler", "RLMHandler"}),
+    ("*", "/api/v1/webhooks"): frozenset({"AutomationHandler", "WebhookHandler"}),
+    ("*", "/api/v1/webhooks/events"): frozenset({"AutomationHandler", "WebhookHandler"}),
+    ("*", "/api/v1/webhooks/subscribe"): frozenset({"AutomationHandler", "EmailWebhooksHandler"}),
+    ("*", "/healthz"): frozenset({"HealthHandler", "LivenessHandler"}),
+    ("*", "/metrics"): frozenset({"MetricsHandler", "SystemHandler", "UnifiedMetricsHandler"}),
+    ("*", "/readyz"): frozenset({"HealthHandler", "ReadinessHandler"}),
+    ("*", "/readyz/dependencies"): frozenset({"HealthHandler", "ReadinessHandler"}),
+}
+
+
+def _format_collisions(collisions: dict[tuple[str, str], frozenset[str]]) -> str:
+    lines = []
+    for (method, path), names in sorted(collisions.items()):
+        lines.append(f"  ({method!r}, {path!r}): {sorted(names)}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_registry_is_populated_and_resolvable() -> None:
+    """Every HANDLER_REGISTRY entry must resolve to a real handler class."""
+    claims, unresolved, _ = _collect_route_claims()
+    assert len(HANDLER_REGISTRY) > 100, (
+        "HANDLER_REGISTRY suspiciously small — registry enumeration is likely "
+        "broken, which would make the collision guard vacuous."
+    )
+    assert not unresolved, (
+        f"Handler classes failed to import/resolve: {unresolved}. "
+        "These handlers are registered in HANDLER_REGISTRY but their modules "
+        "cannot be imported, so their routes are dead."
+    )
+    assert len(claims) > 500, (
+        f"Only {len(claims)} routes enumerated — ROUTES extraction is likely "
+        "broken (expected 2000+)."
+    )
+
+
+def test_routes_are_well_formed() -> None:
+    """Every ROUTES entry must normalize to an absolute path."""
+    claims, _, malformed = _collect_route_claims()
+    assert not malformed, (
+        f"Unparseable ROUTES entries (expected path str, 'METHOD /path' str, "
+        f"or (method, path) tuple): {malformed}"
+    )
+    bad_paths = sorted({key for key in claims if not key[1].startswith("/")})
+    assert not bad_paths, (
+        f"ROUTES entries that do not start with '/': {bad_paths}. "
+        "These can never match an incoming request path and are dead routes."
+    )
+
+
+def test_no_unknown_route_collisions() -> None:
+    """No two different handlers may claim the same exact route.
+
+    RouteIndex.build() (aragora/server/handler_registry/core.py) uses
+    first-wins insertion: when two handlers both list the same path in
+    ROUTES, the one registered later in HANDLER_REGISTRY is silently
+    shadowed and never receives requests for that path.
+    """
+    collisions = _current_collisions()
+
+    new = {k: v for k, v in collisions.items() if k not in KNOWN_COLLISIONS}
+    assert not new, (
+        "NEW route collision(s) introduced — multiple handlers claim the same "
+        "exact route. Because RouteIndex.build() is first-wins, the handler "
+        "registered later in HANDLER_REGISTRY will be SILENTLY SHADOWED for "
+        "these paths:\n"
+        f"{_format_collisions(new)}\n"
+        "Fix: remove or rename the duplicate route in the newer handler, or "
+        "consolidate the handlers. Only add to KNOWN_COLLISIONS in "
+        "tests/server/test_route_collisions.py if the shadowing is consciously "
+        "accepted and documented in your PR."
+    )
+
+    changed = {
+        k: collisions[k]
+        for k in collisions
+        if k in KNOWN_COLLISIONS and collisions[k] != KNOWN_COLLISIONS[k]
+    }
+    assert not changed, (
+        "Handler set changed for known collision route(s):\n"
+        f"{_format_collisions(changed)}\n"
+        "Update the corresponding KNOWN_COLLISIONS entries in "
+        "tests/server/test_route_collisions.py to match reality."
+    )
+
+
+def test_known_collisions_baseline_is_not_stale() -> None:
+    """Resolved collisions must be removed from the frozen baseline.
+
+    This keeps KNOWN_COLLISIONS an accurate audit record: it can only
+    shrink, and every entry in it is a real, currently-live collision.
+    """
+    collisions = _current_collisions()
+    resolved = {k: v for k, v in KNOWN_COLLISIONS.items() if k not in collisions}
+    assert not resolved, (
+        "These previously-known route collisions appear to be RESOLVED "
+        "(nice!). Remove them from KNOWN_COLLISIONS in "
+        "tests/server/test_route_collisions.py so the baseline stays "
+        "accurate:\n"
+        f"{_format_collisions(resolved)}"
+    )
+
+
+def test_no_duplicate_registry_attr_names() -> None:
+    """Each registry attribute slot must appear exactly once.
+
+    A duplicated attr_name in HANDLER_REGISTRY would make the second
+    entry overwrite the first during handler initialization.
+    """
+    seen: set[str] = set()
+    dupes: list[str] = []
+    for attr_name, _ in HANDLER_REGISTRY:
+        if attr_name in seen:
+            dupes.append(attr_name)
+        seen.add(attr_name)
+    assert not dupes, (
+        f"Duplicate attr_name entries in HANDLER_REGISTRY: {dupes}. "
+        "The later entry silently overwrites the earlier handler instance."
+    )
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("/api/debates/{id}/share", ("*", "/api/debates/*/share")),
+        ("/api/debates/<id>/share", ("*", "/api/debates/*/share")),
+        ("/api/debates/:id/share", ("*", "/api/debates/*/share")),
+        ("/api/debates/*/share", ("*", "/api/debates/*/share")),
+        ("GET /api/debates", ("GET", "/api/debates")),
+        (("post", "/api/debates"), ("POST", "/api/debates")),
+        ("/api/debates/", ("*", "/api/debates/")),  # trailing slash preserved
+    ],
+)
+def test_normalization_examples(raw: object, expected: tuple[str, str]) -> None:
+    """Pin the normalization rules so the guard itself is testable."""
+    assert _route_entry_to_key(raw) == expected


### PR DESCRIPTION
## Summary

Adds `tests/server/test_route_collisions.py` — an additive, tests-only collision guard over the **real** server dispatch mechanism.

## What mechanism it guards

The unified server routes `/api/*` requests through `HANDLER_REGISTRY` (`aragora/server/handler_registry/__init__.py`, ~330 entries) and `RouteIndex.build()` (`aragora/server/handler_registry/core.py`), which inserts each handler's `ROUTES` paths into an exact-match dict with **first-wins** semantics. A second handler claiming an already-claimed path is **silently shadowed** — it never receives traffic. This is the same bug family as the historical `extract_path_param` off-by-one and route-overlap incidents.

The test:
1. Enumerates every registry entry (resolving `_DeferredImport` proxies; no server start, no network) and extracts all `ROUTES` claims.
2. Normalizes path params (`{id}`, `<id>`, `:id`, regex groups, `*` → `*`) and keys by `(method, normalized-path)` — method defaults to `*` since `ROUTES` is method-agnostic, but `"METHOD /path"` / `(method, path)` entries are keyed per-method.
3. Asserts no two **different** handler classes claim the same normalized route, modulo a frozen baseline.
4. Also guards registry health: all entries resolvable, routes well-formed, no duplicate `attr_name` slots, plus parametrized pins on the normalization rules themselves.

## Baseline frozen: 50 collisions

`KNOWN_COLLISIONS` freezes the **50 collision paths that exist today** (2,150 distinct routes total). Notable clusters (later-registered handler is shadowed): APAutomationHandler vs Expense/InvoiceHandler (15 paths), RLMContextHandler vs RLMHandler (8), Marketplace trio (5), Health/Readiness/Liveness (6 incl. `/healthz`, `/readyz`), `/metrics` claimed by 3 handlers, Billing vs UsageMetering, Automation vs Webhook, Debates vs Explainability `*/summary`. New collisions fail with remediation guidance; resolved ones must be deleted from the baseline, so the set can only shrink. This is live audit data — each entry is a latent shadowing bug worth triage.

Scope note: prefix-based dispatch (`PREFIX_PATTERNS`) is intentionally not covered — overlaps there are mediated per-request by `can_handle` and are not statically provable collisions. The exact-route table is the statically checkable surface.

## Dogfood gate

- Debate: `aragora ask` adversarial review, agents grok + mistral-api, 1 round, `--decision-integrity`
- Verdict: **PASS / MERGE as authored** (confidence 0.8, consensus reached; only grok recorded in final receipt — mistral participation not captured in receipt agent list)
- Receipt: `f73342ab-8470-4ef4-abbf-c4f1be4cdc9d` — `aragora receipt verify` → **VALID (3/3 checks)**; archived at `.aragora/run-20260610/receipts/batch_5_1_routes.json`
- Reviewer follow-ups (runtime-budget marker, `RouteIndex.build()` docstring cross-ref, filing issues per collision cluster) are out of this PR's single-file scope; candidates for follow-up.

## Verification

- `pytest tests/server/test_route_collisions.py -x -q` → 12 passed in ~1.5s
- 3-seed stability (`-p randomly --randomly-seed={12345,54321,99999}`) → 12 passed each, deterministic

Tier: 1
Part of run-20260610

🤖 Generated with [Claude Code](https://claude.com/claude-code)
