### PR TITLE
feat(ops): systemd installer for boss loop + launchd jitter (Mac monoculture de-risk)

### DIFF
--- a/scripts/install_boss_loop_launchd.sh
+++ b/scripts/install_boss_loop_launchd.sh
@@ -225,17 +225,21 @@ if [[ -n "${ARAGORA_DEV_COORDINATION_DB}" ]]; then
     command_string="${command_string} && export ARAGORA_DEV_COORDINATION_DB=\"${ARAGORA_DEV_COORDINATION_DB}\""
 fi
 command_string="${command_string} && export ARAGORA_POST_LOOP_ISSUE_REFILL=\"${BOSS_POST_LOOP_ISSUE_REFILL}\" && export ARAGORA_POST_LOOP_MAX_ISSUES=\"${BOSS_POST_LOOP_MAX_ISSUES}\" && export ARAGORA_POST_LOOP_DRY_RUN=\"${BOSS_POST_LOOP_DRY_RUN}\""
-command_string="${command_string} && exec \"${REPO_ROOT}/scripts/run_boss_cycle.sh\" --boss-repo \"${BOSS_REPO}\" --target-branch \"${TARGET_BRANCH}\" --worker-model \"${WORKER_MODEL}\" --review-model \"${REVIEW_MODEL}\""
+runner_string="\"${REPO_ROOT}/scripts/run_boss_cycle.sh\" --boss-repo \"${BOSS_REPO}\" --target-branch \"${TARGET_BRANCH}\" --worker-model \"${WORKER_MODEL}\" --review-model \"${REVIEW_MODEL}\""
 for label in "${LABELS[@]}"; do
-    command_string="${command_string} --label \"${label}\""
+    runner_string="${runner_string} --label \"${label}\""
 done
 if [[ -n "${CLAUDE_RUNNER_PROFILES}" ]]; then
-    command_string="${command_string} --claude-runner-profiles \"${CLAUDE_RUNNER_PROFILES}\""
+    runner_string="${runner_string} --claude-runner-profiles \"${CLAUDE_RUNNER_PROFILES}\""
 fi
-command_string="${command_string} --max-ticks \"${MAX_TICKS}\" --interval \"${INTERVAL_SECONDS}\" --max-consecutive-failures \"${MAX_CONSECUTIVE_FAILURES}\" --autonomy \"${AUTONOMY_MODE}\" --max-hours \"${MAX_HOURS}\" --boss-max-parallel-dispatches \"${MAX_PARALLEL_DISPATCHES}\""
+runner_string="${runner_string} --max-ticks \"${MAX_TICKS}\" --interval \"${INTERVAL_SECONDS}\" --max-consecutive-failures \"${MAX_CONSECUTIVE_FAILURES}\" --autonomy \"${AUTONOMY_MODE}\" --max-hours \"${MAX_HOURS}\" --boss-max-parallel-dispatches \"${MAX_PARALLEL_DISPATCHES}\""
 if [[ "${PING_PONG}" == true ]]; then
-    command_string="${command_string} --ping-pong"
+    runner_string="${runner_string} --ping-pong"
 fi
+# Jittered failure throttle: on a failed exit, sleep the configured throttle
+# plus 0-59s of jitter before exiting so a fleet of hosts sharing launchd's
+# fixed ThrottleInterval does not restart (and hit GitHub) in lockstep.
+command_string="${command_string} && export THROTTLE_SECONDS=\"${THROTTLE_SECONDS}\" && { ${runner_string}; } || { rc=\$?; sleep \$(( \${THROTTLE_SECONDS:-300} + RANDOM % 60 )); exit \"\${rc}\"; }"
 command_xml="${command_string//&/&amp;}"
 
 keepalive_block=""

--- a/scripts/install_boss_loop_systemd.sh
+++ b/scripts/install_boss_loop_systemd.sh
@@ -1,0 +1,392 @@
+#!/usr/bin/env bash
+# Install a systemd --user unit that keeps swarm boss-loop running on Linux.
+#
+# Mirrors scripts/install_boss_loop_launchd.sh (macOS) so the boss loop is no
+# longer a launchd monoculture. Same env contract: BOSS_INTERVAL_SECONDS,
+# BOSS_MAX_HOURS, BOSS_MAX_CONSECUTIVE_FAILURES, BOSS_THROTTLE_SECONDS,
+# BOSS_LABELS, ARAGORA_* passthrough (incl. ARAGORA_TIER4_TRUSTED_OPERATORS
+# when present in the installer's environment).
+#
+# Default mode is --dry-run: prints the wrapper script, .service and .timer
+# unit text to stdout without touching the filesystem. --install writes to
+# ~/.config/systemd/user/, reloads the daemon, and enables the units.
+# The interpreter is resolved at LAUNCH time by the wrapper (via
+# scripts/aragora_runtime.sh); no interpreter path is baked into any unit.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+UNIT_NAME="aragora-boss-loop"
+UNIT_DIR="${HOME}/.config/systemd/user"
+WRAPPER_PATH="${REPO_ROOT}/.aragora/overnight/${UNIT_NAME}-wrapper.sh"
+LOG_PATH="${REPO_ROOT}/.aragora/overnight/boss-loop-systemd.log"
+BOSS_REPO="${BOSS_REPO:-synaptent/aragora}"
+TARGET_BRANCH="${TARGET_BRANCH:-main}"
+WORKER_MODEL="${WORKER_MODEL:-codex}"
+REVIEW_MODEL="${REVIEW_MODEL:-codex}"
+CLAUDE_RUNNER_PROFILES="${CLAUDE_RUNNER_PROFILES:-}"
+BOSS_LABELS_RAW="${BOSS_LABELS:-boss-ready}"
+MAX_TICKS="${BOSS_MAX_TICKS:-50}"
+INTERVAL_SECONDS="${BOSS_INTERVAL_SECONDS:-60}"
+MAX_HOURS="${BOSS_MAX_HOURS:-7}"
+MAX_CONSECUTIVE_FAILURES="${BOSS_MAX_CONSECUTIVE_FAILURES:-12}"
+MAX_PARALLEL_DISPATCHES="${BOSS_MAX_PARALLEL_DISPATCHES:-1}"
+AUTONOMY_MODE="${BOSS_AUTONOMY_MODE:-full-auto}"
+BOSS_POST_LOOP_ISSUE_REFILL="${BOSS_POST_LOOP_ISSUE_REFILL:-1}"
+BOSS_POST_LOOP_MAX_ISSUES="${BOSS_POST_LOOP_MAX_ISSUES:-20}"
+BOSS_POST_LOOP_DRY_RUN="${BOSS_POST_LOOP_DRY_RUN:-0}"
+THROTTLE_SECONDS="${BOSS_THROTTLE_SECONDS:-300}"
+ARAGORA_USER_ID="${ARAGORA_USER_ID:-${USER:-aragora}}"
+ARAGORA_WORKSPACE_ID="${ARAGORA_WORKSPACE_ID:-aragora}"
+ARAGORA_CLAUDE_PROFILE="${ARAGORA_CLAUDE_PROFILE:-}"
+ARAGORA_DEV_COORDINATION_DB="${ARAGORA_DEV_COORDINATION_DB:-}"
+MODE="dry-run"
+RESTART_POLICY="on-failure"
+PING_PONG=false
+LABELS=()
+
+usage() {
+    cat <<'EOF'
+Usage: ./scripts/install_boss_loop_systemd.sh [options]
+
+Modes:
+  --dry-run                       Print wrapper + .service + .timer text (default)
+  --install                       Write units to ~/.config/systemd/user/ and enable
+                                  (Linux only; refused on darwin — use the launchd installer)
+
+Options (env contract mirrors install_boss_loop_launchd.sh):
+  --repo <owner/repo>             GitHub repo for boss-loop issue feed (default: synaptent/aragora)
+  --target-branch <branch>        Target branch for boss-loop deliverables (default: main)
+  --label <label>                 Label filter for boss-loop issue selection (repeatable)
+  --worker-model <model>          Worker model (default: codex)
+  --review-model <model>          Review model (default: codex)
+  --claude-runner-profiles <csv>  Preferred Claude profiles for boss-loop routing
+  --max-ticks <n>                 Maximum boss-loop iterations before recycle (default: 50)
+  --interval-seconds <n>          Boss-loop polling interval seconds (default: 60)
+  --max-hours <n>                 Maximum runtime hours before recycle (default: 7)
+  --max-consecutive-failures <n>  Stop after N hard failures (default: 12)
+  --max-parallel-dispatches <n>   Maximum parallel boss-loop dispatches (default: 1)
+  --autonomy <mode>               Autonomy mode passed to boss-loop (default: full-auto)
+  --ping-pong                     Enable ping-pong retry mode
+  --post-loop-max-issues <n>      Create up to N fresh issues after a clean exit (default: 20)
+  --post-loop-dry-run             Preview post-loop issue generation without creating issues
+  --no-post-loop-issue-refill     Disable post-loop boss-ready issue generation
+  --user-id <id>                  Export ARAGORA_USER_ID for the service
+  --workspace-id <id>             Export ARAGORA_WORKSPACE_ID for the service
+  --claude-profile <name>         Export ARAGORA_CLAUDE_PROFILE for the service
+  --coordination-db <path>        Export ARAGORA_DEV_COORDINATION_DB for shared handoff
+  --throttle-seconds <n>          Restart backoff seconds after exits (default: 300)
+  --log-path <file>               Log file path (default: .aragora/overnight/boss-loop-systemd.log)
+  --no-keepalive                  Do not auto-restart the service after exits
+  --help                          Show this help
+EOF
+}
+
+trim_text() {
+    printf '%s' "$1" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
+}
+
+validate_integer() {
+    local label="$1"
+    local value="$2"
+    if ! [[ "$value" =~ ^[0-9]+$ ]]; then
+        echo "${label} must be numeric" >&2
+        exit 2
+    fi
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run)
+            MODE="dry-run"
+            shift
+            ;;
+        --install)
+            MODE="install"
+            shift
+            ;;
+        --repo)
+            BOSS_REPO="${2:-$BOSS_REPO}"
+            shift 2
+            ;;
+        --target-branch)
+            TARGET_BRANCH="${2:-$TARGET_BRANCH}"
+            shift 2
+            ;;
+        --label)
+            LABELS+=("$(trim_text "${2:-}")")
+            shift 2
+            ;;
+        --worker-model)
+            WORKER_MODEL="${2:-$WORKER_MODEL}"
+            shift 2
+            ;;
+        --review-model)
+            REVIEW_MODEL="${2:-$REVIEW_MODEL}"
+            shift 2
+            ;;
+        --claude-runner-profiles)
+            CLAUDE_RUNNER_PROFILES="${2:-$CLAUDE_RUNNER_PROFILES}"
+            shift 2
+            ;;
+        --max-ticks)
+            MAX_TICKS="${2:-$MAX_TICKS}"
+            shift 2
+            ;;
+        --interval-seconds)
+            INTERVAL_SECONDS="${2:-$INTERVAL_SECONDS}"
+            shift 2
+            ;;
+        --max-hours)
+            MAX_HOURS="${2:-$MAX_HOURS}"
+            shift 2
+            ;;
+        --max-consecutive-failures)
+            MAX_CONSECUTIVE_FAILURES="${2:-$MAX_CONSECUTIVE_FAILURES}"
+            shift 2
+            ;;
+        --max-parallel-dispatches)
+            MAX_PARALLEL_DISPATCHES="${2:-$MAX_PARALLEL_DISPATCHES}"
+            shift 2
+            ;;
+        --autonomy)
+            AUTONOMY_MODE="${2:-$AUTONOMY_MODE}"
+            shift 2
+            ;;
+        --ping-pong)
+            PING_PONG=true
+            shift
+            ;;
+        --post-loop-max-issues)
+            BOSS_POST_LOOP_MAX_ISSUES="${2:-$BOSS_POST_LOOP_MAX_ISSUES}"
+            shift 2
+            ;;
+        --post-loop-dry-run)
+            BOSS_POST_LOOP_DRY_RUN=1
+            shift
+            ;;
+        --no-post-loop-issue-refill)
+            BOSS_POST_LOOP_ISSUE_REFILL=0
+            shift
+            ;;
+        --user-id)
+            ARAGORA_USER_ID="${2:-$ARAGORA_USER_ID}"
+            shift 2
+            ;;
+        --workspace-id)
+            ARAGORA_WORKSPACE_ID="${2:-$ARAGORA_WORKSPACE_ID}"
+            shift 2
+            ;;
+        --claude-profile)
+            ARAGORA_CLAUDE_PROFILE="${2:-$ARAGORA_CLAUDE_PROFILE}"
+            shift 2
+            ;;
+        --coordination-db)
+            ARAGORA_DEV_COORDINATION_DB="${2:-$ARAGORA_DEV_COORDINATION_DB}"
+            shift 2
+            ;;
+        --throttle-seconds)
+            THROTTLE_SECONDS="${2:-$THROTTLE_SECONDS}"
+            shift 2
+            ;;
+        --log-path)
+            LOG_PATH="${2:-$LOG_PATH}"
+            shift 2
+            ;;
+        --no-keepalive)
+            RESTART_POLICY="no"
+            shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage
+            exit 2
+            ;;
+    esac
+done
+
+if [[ ${#LABELS[@]} -eq 0 ]]; then
+    IFS=',' read -r -a raw_labels <<< "${BOSS_LABELS_RAW}"
+    for raw_label in "${raw_labels[@]}"; do
+        trimmed_label="$(trim_text "${raw_label}")"
+        if [[ -n "${trimmed_label}" ]]; then
+            LABELS+=("${trimmed_label}")
+        fi
+    done
+fi
+
+if [[ ${#LABELS[@]} -eq 0 ]]; then
+    echo "At least one --label (or BOSS_LABELS env var) is required." >&2
+    exit 2
+fi
+
+validate_integer "max-ticks" "${MAX_TICKS}"
+validate_integer "interval-seconds" "${INTERVAL_SECONDS}"
+validate_integer "max-consecutive-failures" "${MAX_CONSECUTIVE_FAILURES}"
+validate_integer "max-parallel-dispatches" "${MAX_PARALLEL_DISPATCHES}"
+validate_integer "throttle-seconds" "${THROTTLE_SECONDS}"
+if ! [[ "${MAX_HOURS}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+    echo "max-hours must be numeric" >&2
+    exit 2
+fi
+
+if [[ "${MODE}" == "install" && "$(uname -s)" == "Darwin" ]]; then
+    echo "Refusing --install on darwin (macOS): systemd is not available here." >&2
+    echo "Use ./scripts/install_boss_loop_launchd.sh on macOS instead." >&2
+    exit 1
+fi
+
+# Boss-loop runner flags (identical contract to the launchd installer).
+runner_args="--boss-repo \"${BOSS_REPO}\" --target-branch \"${TARGET_BRANCH}\" --worker-model \"${WORKER_MODEL}\" --review-model \"${REVIEW_MODEL}\""
+for label in "${LABELS[@]}"; do
+    runner_args="${runner_args} --label \"${label}\""
+done
+if [[ -n "${CLAUDE_RUNNER_PROFILES}" ]]; then
+    runner_args="${runner_args} --claude-runner-profiles \"${CLAUDE_RUNNER_PROFILES}\""
+fi
+runner_args="${runner_args} --max-ticks \"${MAX_TICKS}\" --interval \"${INTERVAL_SECONDS}\" --max-consecutive-failures \"${MAX_CONSECUTIVE_FAILURES}\" --autonomy \"${AUTONOMY_MODE}\" --max-hours \"${MAX_HOURS}\" --boss-max-parallel-dispatches \"${MAX_PARALLEL_DISPATCHES}\""
+if [[ "${PING_PONG}" == true ]]; then
+    runner_args="${runner_args} --ping-pong"
+fi
+
+# Wrapper: resolves the interpreter at LAUNCH time via aragora_runtime.sh so a
+# moved/rebuilt .venv degrades gracefully. No interpreter path is baked into
+# the unit or this wrapper.
+render_wrapper() {
+    cat <<WRAP
+#!/usr/bin/env bash
+# Generated by scripts/install_boss_loop_systemd.sh — do not edit by hand.
+set -euo pipefail
+REPO_ROOT="${REPO_ROOT}"
+export PATH="/usr/local/bin:/usr/bin:/bin:\${HOME}/.pyenv/shims:\${HOME}/.local/bin:\${PATH}"
+# shellcheck source=scripts/aragora_runtime.sh
+source "\${REPO_ROOT}/scripts/aragora_runtime.sh"
+# Launch-time interpreter validation; run_boss_cycle.sh re-resolves on exec.
+PYTHON_BIN="\$(resolve_aragora_python 'import pydantic' 'boss-loop' 'boss-loop systemd wrapper')"
+echo "boss-loop systemd wrapper using interpreter: \${PYTHON_BIN}"
+cd "\${REPO_ROOT}"
+exec "\${REPO_ROOT}/scripts/run_boss_cycle.sh" ${runner_args}
+WRAP
+}
+
+# Exponential restart backoff (RestartSteps/RestartMaxDelaySec) requires
+# systemd >= 254; emit the directives commented out on older/unknown hosts.
+render_restart_backoff() {
+    local ver=""
+    if command -v systemctl >/dev/null 2>&1; then
+        ver="$(systemctl --version 2>/dev/null | awk 'NR==1 {print $2}')"
+    fi
+    if [[ "${ver}" =~ ^[0-9]+$ ]] && (( ver >= 254 )); then
+        cat <<EOF
+# Exponential backoff: RestartSec -> RestartMaxDelaySec over RestartSteps.
+RestartMaxDelaySec=3600
+RestartSteps=6
+EOF
+    else
+        cat <<EOF
+# RestartMaxDelaySec/RestartSteps need systemd >= 254 (detected: ${ver:-none}).
+# Uncomment after confirming with: systemctl --version
+# RestartMaxDelaySec=3600
+# RestartSteps=6
+EOF
+    fi
+}
+
+render_service() {
+    local start_limit_interval=$(( MAX_CONSECUTIVE_FAILURES * THROTTLE_SECONDS ))
+    cat <<EOF
+[Unit]
+Description=Aragora swarm boss-loop (mirrors com.aragora.swarm-boss-loop launchd job)
+After=network-online.target
+Wants=network-online.target
+# Mirror launchd MAX_CONSECUTIVE_FAILURES: stop restarting after N failures
+# inside the window, then the timer re-kicks the service later.
+StartLimitIntervalSec=${start_limit_interval}
+StartLimitBurst=${MAX_CONSECUTIVE_FAILURES}
+
+[Service]
+Type=simple
+WorkingDirectory=${REPO_ROOT}
+ExecStart=${WRAPPER_PATH}
+Restart=${RESTART_POLICY}
+RestartSec=${THROTTLE_SECONDS}
+$(render_restart_backoff)
+Environment="ARAGORA_USER_ID=${ARAGORA_USER_ID}"
+Environment="ARAGORA_WORKSPACE_ID=${ARAGORA_WORKSPACE_ID}"
+Environment="ARAGORA_POST_LOOP_ISSUE_REFILL=${BOSS_POST_LOOP_ISSUE_REFILL}"
+Environment="ARAGORA_POST_LOOP_MAX_ISSUES=${BOSS_POST_LOOP_MAX_ISSUES}"
+Environment="ARAGORA_POST_LOOP_DRY_RUN=${BOSS_POST_LOOP_DRY_RUN}"
+EOF
+    if [[ -n "${ARAGORA_CLAUDE_PROFILE}" ]]; then
+        echo "Environment=\"ARAGORA_CLAUDE_PROFILE=${ARAGORA_CLAUDE_PROFILE}\""
+    fi
+    if [[ -n "${ARAGORA_DEV_COORDINATION_DB}" ]]; then
+        echo "Environment=\"ARAGORA_DEV_COORDINATION_DB=${ARAGORA_DEV_COORDINATION_DB}\""
+    fi
+    if [[ -n "${ARAGORA_TIER4_TRUSTED_OPERATORS:-}" ]]; then
+        echo "Environment=\"ARAGORA_TIER4_TRUSTED_OPERATORS=${ARAGORA_TIER4_TRUSTED_OPERATORS}\""
+    fi
+    cat <<EOF
+StandardOutput=append:${LOG_PATH}
+StandardError=append:${LOG_PATH}
+
+[Install]
+WantedBy=default.target
+EOF
+}
+
+render_timer() {
+    cat <<EOF
+[Unit]
+Description=Re-kick aragora boss-loop after boot or start-limit lockout
+
+[Timer]
+Unit=${UNIT_NAME}.service
+OnBootSec=60
+# Safety net: if the service hit StartLimitBurst and went inactive, restart it
+# once the start-limit window has lapsed (mirrors launchd KeepAlive+Throttle).
+OnUnitInactiveSec=$(( MAX_CONSECUTIVE_FAILURES * THROTTLE_SECONDS + THROTTLE_SECONDS ))
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+EOF
+}
+
+if [[ "${MODE}" == "dry-run" ]]; then
+    echo "# ==== wrapper: ${WRAPPER_PATH} ===="
+    render_wrapper
+    echo
+    echo "# ==== unit: ${UNIT_DIR}/${UNIT_NAME}.service ===="
+    render_service
+    echo
+    echo "# ==== unit: ${UNIT_DIR}/${UNIT_NAME}.timer ===="
+    render_timer
+    echo
+    echo "# Dry run only. Re-run with --install on a Linux host to activate." >&2
+    exit 0
+fi
+
+mkdir -p "${UNIT_DIR}"
+mkdir -p "$(dirname "${WRAPPER_PATH}")"
+mkdir -p "$(dirname "${LOG_PATH}")"
+
+render_wrapper >"${WRAPPER_PATH}"
+chmod 0755 "${WRAPPER_PATH}"
+render_service >"${UNIT_DIR}/${UNIT_NAME}.service"
+render_timer >"${UNIT_DIR}/${UNIT_NAME}.timer"
+
+systemctl --user daemon-reload
+systemctl --user enable --now "${UNIT_NAME}.timer"
+systemctl --user enable --now "${UNIT_NAME}.service"
+
+echo "Installed systemd user units: ${UNIT_NAME}.service, ${UNIT_NAME}.timer"
+echo "Wrapper: ${WRAPPER_PATH}"
+echo "Log: ${LOG_PATH}"
+echo "Interpreter is resolved at runtime via scripts/aragora_runtime.sh"
+echo "Boss repo: ${BOSS_REPO}"
+echo "Labels: ${LABELS[*]}"

--- a/scripts/install_merge_arbiter_launchd.sh
+++ b/scripts/install_merge_arbiter_launchd.sh
@@ -123,10 +123,15 @@ mkdir -p "${REPO_ROOT}/.aragora/overnight"
 if ! INSTALL_PYTHON="$(resolve_aragora_python 'import pydantic' 'merge-arbiter' 'merge-arbiter launchd install')"; then
     exit 2
 fi
-command_string="cd \"${REPO_ROOT}\" && export PATH=\"/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:\$HOME/.pyenv/shims:\$PATH\" && export ARAGORA_USER_ID=\"${ARAGORA_USER_ID}\" && export ARAGORA_WORKSPACE_ID=\"${ARAGORA_WORKSPACE_ID}\" && exec \"${REPO_ROOT}/scripts/run_merge_arbiter.sh\" --boss-repo \"${BOSS_REPO}\" --branch-prefix \"${BRANCH_PREFIXES}\" --interval \"${INTERVAL_SECONDS}\" --max-hours \"${MAX_HOURS}\" --max-consecutive-failures \"${MAX_CONSECUTIVE_FAILURES}\""
+command_string="cd \"${REPO_ROOT}\" && export PATH=\"/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:\$HOME/.pyenv/shims:\$PATH\" && export ARAGORA_USER_ID=\"${ARAGORA_USER_ID}\" && export ARAGORA_WORKSPACE_ID=\"${ARAGORA_WORKSPACE_ID}\""
+runner_string="\"${REPO_ROOT}/scripts/run_merge_arbiter.sh\" --boss-repo \"${BOSS_REPO}\" --branch-prefix \"${BRANCH_PREFIXES}\" --interval \"${INTERVAL_SECONDS}\" --max-hours \"${MAX_HOURS}\" --max-consecutive-failures \"${MAX_CONSECUTIVE_FAILURES}\""
 if [[ "${DRY_RUN}" == true ]]; then
-    command_string="${command_string} --dry-run"
+    runner_string="${runner_string} --dry-run"
 fi
+# Jittered failure throttle: on a failed exit, sleep the configured throttle
+# plus 0-59s of jitter before exiting so a fleet of hosts sharing launchd's
+# fixed ThrottleInterval does not restart (and hit GitHub) in lockstep.
+command_string="${command_string} && export THROTTLE_SECONDS=\"${THROTTLE_SECONDS}\" && { ${runner_string}; } || { rc=\$?; sleep \$(( \${THROTTLE_SECONDS:-300} + RANDOM % 60 )); exit \"\${rc}\"; }"
 command_xml="${command_string//&/&amp;}"
 
 keepalive_block=""

--- a/tests/scripts/test_aragora_runtime.py
+++ b/tests/scripts/test_aragora_runtime.py
@@ -8,11 +8,18 @@ stale absolute path.
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 HELPER = REPO_ROOT / "scripts" / "aragora_runtime.sh"
+
+requires_bash = pytest.mark.skipif(
+    shutil.which("bash") is None, reason="bash is required to exercise the resolver"
+)
 
 # Absolute shebang so the stub execs under a minimal/empty PATH.
 _OK = "#!/bin/bash\nexit 0\n"
@@ -116,3 +123,83 @@ def test_helper_is_sourced_not_executed() -> None:
     # The helper defines functions and must be sourced; it should not be marked
     # executable (callers use `source`).
     assert not os.access(HELPER, os.X_OK)
+
+
+# ---------------------------------------------------------------------------
+# Contract tests against the REAL host environment (no PATH sandboxing).
+# These pin the resolver's launch-time behavior for systemd/launchd wrappers.
+# ---------------------------------------------------------------------------
+
+
+@requires_bash
+def test_contract_empty_probe_resolves_real_interpreter() -> None:
+    """An empty probe must resolve some executable interpreter on this host."""
+    result = subprocess.run(
+        ["bash", "-c", f'source "{HELPER}" && resolve_aragora_python ""'],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    resolved = result.stdout.strip()
+    assert resolved, "resolver printed nothing"
+    assert os.access(resolved, os.X_OK), f"not executable: {resolved}"
+
+
+@requires_bash
+def test_contract_nonexistent_aragora_python_falls_back_with_diagnostic() -> None:
+    """Characterization: a bogus ARAGORA_PYTHON is skipped with a diagnostic.
+
+    The resolver does NOT fail closed on a bad ARAGORA_PYTHON; it warns on
+    stderr ("Skipping ARAGORA_PYTHON ...") and continues down the fallback
+    chain (.venv, python3, python, pyenv). With an empty probe the host always
+    has at least one fallback, so the call still succeeds.
+    """
+    env = dict(os.environ, ARAGORA_PYTHON="/nonexistent")
+    result = subprocess.run(
+        ["bash", "-c", f'source "{HELPER}" && resolve_aragora_python ""'],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert "Skipping ARAGORA_PYTHON" in result.stderr
+    assert "/nonexistent" in result.stderr
+    assert result.returncode == 0, result.stderr
+    resolved = result.stdout.strip()
+    assert resolved != "/nonexistent"
+    assert os.access(resolved, os.X_OK)
+
+
+@requires_bash
+def test_contract_repo_root_env_honored(tmp_path: Path) -> None:
+    """aragora_repo_root() must prefer an existing ARAGORA_REPO_ROOT dir."""
+    override = tmp_path / "elsewhere"
+    override.mkdir()
+    env = dict(os.environ, ARAGORA_REPO_ROOT=str(override))
+    result = subprocess.run(
+        ["bash", "-c", f'source "{HELPER}" && aragora_repo_root'],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert Path(result.stdout.strip()) == override
+
+
+@requires_bash
+def test_contract_repo_root_ignores_missing_override_dir(tmp_path: Path) -> None:
+    """A nonexistent ARAGORA_REPO_ROOT is ignored; derived root wins."""
+    env = dict(os.environ, ARAGORA_REPO_ROOT=str(tmp_path / "does-not-exist"))
+    result = subprocess.run(
+        ["bash", "-c", f'source "{HELPER}" && aragora_repo_root'],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert Path(result.stdout.strip()).resolve() == REPO_ROOT.resolve()

--- a/tests/scripts/test_install_boss_loop_systemd.py
+++ b/tests/scripts/test_install_boss_loop_systemd.py
@@ -1,0 +1,169 @@
+"""Render tests for ``scripts/install_boss_loop_systemd.sh``.
+
+The installer mirrors the launchd installer's env contract but targets
+systemd user units so the boss loop can run on Linux runners (de-risking the
+macOS launchd monoculture). ``--dry-run`` (the default) must print the
+wrapper script plus the ``.service`` and ``.timer`` unit text to stdout
+without touching the filesystem; ``--install`` must refuse to run on darwin.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALLER = REPO_ROOT / "scripts" / "install_boss_loop_systemd.sh"
+
+requires_bash = pytest.mark.skipif(
+    shutil.which("bash") is None, reason="bash is required to run the installer"
+)
+
+
+def _run(
+    *args: str,
+    env_overrides: dict[str, str] | None = None,
+    drop: tuple[str, ...] = (),
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    for key in drop:
+        env.pop(key, None)
+    env.update(env_overrides or {})
+    return subprocess.run(
+        ["bash", str(INSTALLER), *args],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@requires_bash
+def test_dry_run_is_default_and_prints_service_and_timer() -> None:
+    result = _run(drop=("ARAGORA_TIER4_TRUSTED_OPERATORS",))
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    assert "aragora-boss-loop.service" in out
+    assert "aragora-boss-loop.timer" in out
+    assert "[Service]" in out
+    assert "[Timer]" in out
+    assert "ExecStart=" in out
+
+
+@requires_bash
+def test_dry_run_renders_env_contract_values() -> None:
+    result = _run(
+        env_overrides={
+            "BOSS_INTERVAL_SECONDS": "77",
+            "BOSS_MAX_HOURS": "5",
+            "BOSS_MAX_CONSECUTIVE_FAILURES": "9",
+            "BOSS_THROTTLE_SECONDS": "123",
+        },
+    )
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    # Loop flags flow into the rendered wrapper.
+    assert '--interval "77"' in out
+    assert '--max-hours "5"' in out
+    assert '--max-consecutive-failures "9"' in out
+    # Throttle flows into the restart backoff.
+    assert "RestartSec=123" in out
+    # Start-limit window mirrors MAX_CONSECUTIVE_FAILURES.
+    assert "StartLimitBurst=9" in out
+    assert f"StartLimitIntervalSec={9 * 123}" in out
+
+
+@requires_bash
+def test_dry_run_renders_restart_directives() -> None:
+    result = _run()
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    assert "Restart=on-failure" in out
+    assert "RestartSec=" in out
+    assert "StartLimitIntervalSec=" in out
+    assert "StartLimitBurst=" in out
+    # Exponential backoff directives are present (active or guard-commented
+    # depending on the host's systemd version).
+    assert "RestartMaxDelaySec=3600" in out
+    assert "RestartSteps=6" in out
+
+
+@requires_bash
+def test_wrapper_resolves_python_at_launch_time_never_baked() -> None:
+    result = _run()
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    assert "aragora_runtime.sh" in out
+    assert "resolve_aragora_python" in out
+    # No interpreter path may be baked into ExecStart or the wrapper.
+    for line in out.splitlines():
+        if line.startswith("ExecStart="):
+            assert "python" not in line, f"baked interpreter in: {line}"
+    baked_venv_interpreter = "/".join((".venv", "bin", "python"))
+    assert baked_venv_interpreter not in out
+
+
+@requires_bash
+def test_label_and_env_passthrough() -> None:
+    result = _run(
+        "--label",
+        "custom-lane",
+        "--user-id",
+        "test-user",
+        "--workspace-id",
+        "test-ws",
+        env_overrides={"ARAGORA_TIER4_TRUSTED_OPERATORS": "alice,bob"},
+    )
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    assert '--label "custom-lane"' in out
+    assert 'Environment="ARAGORA_USER_ID=test-user"' in out
+    assert 'Environment="ARAGORA_WORKSPACE_ID=test-ws"' in out
+    assert 'Environment="ARAGORA_TIER4_TRUSTED_OPERATORS=alice,bob"' in out
+
+
+@requires_bash
+def test_tier4_operators_omitted_when_unset() -> None:
+    result = _run(drop=("ARAGORA_TIER4_TRUSTED_OPERATORS",))
+    assert result.returncode == 0, result.stderr
+    assert "ARAGORA_TIER4_TRUSTED_OPERATORS" not in result.stdout
+
+
+@requires_bash
+def test_install_refused_on_darwin(tmp_path: Path) -> None:
+    """--install must hard-refuse when uname reports Darwin (use launchd)."""
+    shim_dir = tmp_path / "shim"
+    shim_dir.mkdir()
+    fake_uname = shim_dir / "uname"
+    fake_uname.write_text('#!/bin/bash\necho "Darwin"\n', encoding="utf-8")
+    fake_uname.chmod(0o755)
+    result = _run(
+        "--install",
+        env_overrides={"PATH": f"{shim_dir}:{os.environ.get('PATH', '')}"},
+    )
+    assert result.returncode == 1
+    combined = (result.stdout + result.stderr).lower()
+    assert "darwin" in combined or "macos" in combined
+    assert "launchd" in combined
+
+
+@requires_bash
+def test_dry_run_does_not_write_unit_files(tmp_path: Path) -> None:
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    result = _run(env_overrides={"HOME": str(fake_home)})
+    assert result.returncode == 0, result.stderr
+    assert not (fake_home / ".config" / "systemd").exists()
+
+
+@requires_bash
+def test_installer_passes_bash_syntax_check() -> None:
+    result = subprocess.run(
+        ["bash", "-n", str(INSTALLER)], capture_output=True, text=True, check=False
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
# feat(ops): systemd installer for boss loop + launchd jitter (Mac monoculture de-risk)

## Summary

Batches 4.1+4.2 of run-20260610 (Lane D). All scheduled automation currently runs only via launchd on macOS — a single point of failure. This PR:

- **`scripts/install_boss_loop_systemd.sh` (new)** — systemd `--user` unit installer mirroring `install_boss_loop_launchd.sh`'s env contract (`BOSS_INTERVAL_SECONDS`, `BOSS_MAX_HOURS`, `BOSS_MAX_CONSECUTIVE_FAILURES`, `BOSS_THROTTLE_SECONDS`, `BOSS_LABELS`, full `ARAGORA_*` passthrough incl. `ARAGORA_TIER4_TRUSTED_OPERATORS` when present).
  - `--dry-run` (default) prints the wrapper script + `.service` + `.timer` unit text to stdout, touching nothing.
  - `--install` writes to `~/.config/systemd/user/`, `daemon-reload`s, and `enable --now`s both units. **Refused on darwin** (exit 1, points at the launchd installer).
  - The `ExecStart` wrapper sources `scripts/aragora_runtime.sh` and resolves the interpreter at **launch** time — no interpreter path is baked into any unit (a moved/rebuilt `.venv` degrades gracefully).
  - `Restart=on-failure`, `RestartSec=$THROTTLE_SECONDS`, `StartLimitBurst=$MAX_CONSECUTIVE_FAILURES`, `StartLimitIntervalSec=burst*throttle`; `RestartMaxDelaySec=3600`/`RestartSteps=6` emitted active on systemd >= 254, guard-commented otherwise. A `.timer` re-kicks the service after boot or start-limit lockout (mirrors launchd `KeepAlive`+`ThrottleInterval`).
- **Launchd jitter (4.2)** — `install_boss_loop_launchd.sh` and `install_merge_arbiter_launchd.sh` now render a jittered failure throttle into the plist command: on a failed exit, `sleep $(( ${THROTTLE_SECONDS:-300} + RANDOM % 60 ))` before exiting, so a fleet of Macs sharing the same fixed `ThrottleInterval` no longer restarts (and hits GitHub) in lockstep. `THROTTLE_SECONDS` is exported in the command prefix so the operator's `--throttle-seconds` is honored at runtime.
- **Runtime resolver contract pinned** — `tests/scripts/test_aragora_runtime.py` gains characterization tests against the real host: empty probe resolves an executable path (exit 0); a bogus `ARAGORA_PYTHON` is *skipped with a stderr diagnostic* and falls back down the chain (the resolver does not fail closed on a bad override); `aragora_repo_root()` honors an existing `ARAGORA_REPO_ROOT` and ignores a missing one.
- **`tests/scripts/test_install_boss_loop_systemd.py` (new)** — render tests: env contract values flow into wrapper flags and Restart/StartLimit directives, resolver referenced with no baked interpreter, tier4 operator passthrough (present/absent), darwin `--install` refusal (PATH-shimmed `uname`), dry-run filesystem purity, `bash -n` clean.

Tests: 20 passed (`test_aragora_runtime.py` 11, `test_install_boss_loop_systemd.py` 9). `bash -n` clean on all three shell scripts; shellcheck not on PATH locally (skipped). Rendered plists verified with `plutil -lint` + `bash -n` on the embedded command via shimmed `launchctl`.

## Deployment runbook stub — Hetzner runner (operator executes)

```bash
# On the Hetzner box (Linux, systemd user session with lingering enabled):
sudo loginctl enable-linger "$USER"
git clone https://github.com/synaptent/aragora.git ~/aragora && cd ~/aragora
python3 -m venv .venv && .venv/bin/pip install -e .        # or set ARAGORA_PYTHON
gh auth login                                              # boss loop needs gh
./scripts/install_boss_loop_systemd.sh --dry-run           # inspect units first
BOSS_THROTTLE_SECONDS=300 ./scripts/install_boss_loop_systemd.sh --install \
  --label boss-ready --max-hours 7
systemctl --user status aragora-boss-loop.service
tail -f .aragora/overnight/boss-loop-systemd.log
```

## Dogfood gate (Tier 2)

- Verdict: PASS (consensus reached, recommendation MERGE, confidence 0.8, risk summary 0/0/0/0)
- Dissent: none (dissenting_views: [])
- Receipt: `.aragora/run-20260610/receipts/batch_4_ops.json` (verify: VALID, 3/3 checks passed)
- Head SHA: 8c57fb34171210c70e159b365a52eaab587cea0f

Tier: 2
Part of run-20260610

🤖 Generated with [Claude Code](https://claude.com/claude-code)
