### PR TITLE
feat(swarm): docs-sync drift detector as a governed loop

### DIFF
--- a/aragora/swarm/loop_control.py
+++ b/aragora/swarm/loop_control.py
@@ -1,7 +1,8 @@
 """Loop Control Plane v1 - pure classification (no IO).
 
 Read-only governance observability for Aragora's standing loops (boss loop,
-merge arbiter, proof-first shift, publisher, worktree autopilot, nomic). This
+merge arbiter, proof-first shift, publisher, worktree autopilot, nomic,
+docs-sync drift detector). This
 module is *pure*: it takes already-collected raw signals (see
 ``loop_control_io``) plus a static per-loop spec and returns normalized
 ``LoopRecord`` objects. It performs no subprocess, filesystem, or network IO,
@@ -38,6 +39,7 @@ class LoopKind(str, Enum):
     PUBLISHER = "publisher"
     WORKTREE_AUTOPILOT = "worktree_autopilot"
     NOMIC = "nomic"
+    DOCS_SYNC_DRIFT = "docs_sync_drift"
 
 
 class LoopState(str, Enum):
@@ -190,7 +192,9 @@ class LoopSpec:
     title: str
     role: str  # supervisor | orchestration | maintenance | publication | self_improvement
     guards: HaltGuards
-    feedback_kind: str  # quorum | proof_freshness | publisher_freshness | worktree_health | none
+    feedback_kind: (
+        str  # quorum | proof_freshness | publisher_freshness | worktree_health | docs_drift | none
+    )
     durable_state_path: str | None
     human_gate_required: bool
     source_paths: tuple[str, ...]
@@ -514,5 +518,32 @@ LOOP_SPECS: dict[LoopKind, LoopSpec] = {
         durable_state_path=".aragora_beads",
         human_gate_required=True,
         source_paths=("scripts/nomic_loop.py",),
+    ),
+    LoopKind.DOCS_SYNC_DRIFT: LoopSpec(
+        kind=LoopKind.DOCS_SYNC_DRIFT,
+        title="Docs-site sync drift detector",
+        role="maintenance",
+        guards=HaltGuards(
+            max_iteration=True,
+            no_progress=True,
+            no_progress_distinguishes_fault=True,
+            budget_ceiling=False,
+            code_ref=(
+                "scripts/docs_sync_drift_detector.py (launchd single-shot per fire; "
+                "FAULT_OUTCOMES separates fault from waiting-on-PR; fail-closed outside "
+                "the generated-mirror allowlist)"
+            ),
+            notes=(
+                "sync PRs settle through the normal model-quorum gate; "
+                "the detector never merges, approves, or comments",
+            ),
+        ),
+        feedback_kind="docs_drift",
+        durable_state_path=".aragora/docs_drift_status.json",
+        human_gate_required=False,
+        source_paths=(
+            "scripts/docs_sync_drift_detector.py",
+            "scripts/install_docs_drift_launchd.sh",
+        ),
     ),
 }

--- a/aragora/swarm/loop_control_io.py
+++ b/aragora/swarm/loop_control_io.py
@@ -266,7 +266,7 @@ def collect_docs_sync_drift(
         errors = int(payload.get("consecutive_errors", 0) or 0)
     except (TypeError, ValueError):
         errors = 0
-    fault = outcome in ("error", "drift_outside_allowlist")
+    fault = outcome in ("error", "drift_outside_allowlist")  # detector FAULT_OUTCOMES
     waiting = outcome in ("drift_pr_open", "drift_pr_opened", "drift_detected")
     stop_reason: str | None = None
     if fault:

--- a/aragora/swarm/loop_control_io.py
+++ b/aragora/swarm/loop_control_io.py
@@ -11,6 +11,7 @@ the Loop Control Plane that touches the world, and it only ever reads:
 * ``scripts/publisher_freshness_check.py --json`` / ``scripts/agent_bridge.py
   operator-snapshot --json`` (themselves read-only)
 * ``.aragora/proof_first_shift/runtime_state.json`` (file read)
+* ``.aragora/docs_drift_status.json`` (file read)
 
 It never merges, comments, reruns, pushes, or passes an ``--apply`` flag, and it
 writes nothing. Collectors degrade gracefully (``source_status`` of ``degraded``
@@ -43,6 +44,9 @@ LAUNCHD_LABELS: dict[LoopKind, str] = {
 NETWORK_TOUCHING: frozenset[LoopKind] = frozenset({LoopKind.BOSS_LOOP})
 
 _PROOF_FIRST_STATE_FRESH_SECONDS = 900.0
+# Daily launchd cadence plus slack; staler than this means the detector
+# stopped firing (halted), not that it is broken.
+_DOCS_DRIFT_STATE_FRESH_SECONDS = 26 * 3600.0
 
 
 def _iso(epoch_seconds: float) -> str:
@@ -246,6 +250,47 @@ def collect_nomic(repo_root: Path, *, timeout: float = 5.0) -> dict[str, Any]:
     return {"source_status": "unavailable", "feedback_status": "none"}
 
 
+def collect_docs_sync_drift(
+    repo_root: Path, *, timeout: float = 5.0, now: float | None = None
+) -> dict[str, Any]:
+    path = repo_root / ".aragora" / "docs_drift_status.json"
+    if not path.is_file():
+        return {"source_status": "unavailable", "feedback_status": "docs_drift"}
+    payload = _read_json(path)
+    if payload is None:
+        return {"source_status": "degraded", "error": "docs drift status unreadable"}
+    now = now if now is not None else time.time()
+    age = max(0.0, now - path.stat().st_mtime)
+    outcome = str(payload.get("outcome") or "unknown")
+    try:
+        errors = int(payload.get("consecutive_errors", 0) or 0)
+    except (TypeError, ValueError):
+        errors = 0
+    fault = outcome in ("error", "drift_outside_allowlist")
+    waiting = outcome in ("drift_pr_open", "drift_pr_opened", "drift_detected")
+    stop_reason: str | None = None
+    if fault:
+        raw_error = payload.get("error")
+        stop_reason = (
+            str(raw_error)
+            if isinstance(raw_error, str) and raw_error
+            else "drift outside generated-mirror allowlist"
+        )
+    return {
+        "source_status": "ok",
+        "alive": age < _DOCS_DRIFT_STATE_FRESH_SECONDS,
+        "operational_fault": fault,
+        "stop_reason": stop_reason,
+        "waiting_only": waiting and not fault,
+        "no_progress_ticks": errors,
+        "last_progress_at": (
+            payload.get("generated_at") if isinstance(payload.get("generated_at"), str) else None
+        ),
+        "feedback_status": outcome,
+        "owner": "launchd",
+    }
+
+
 def collect_budget(repo_root: Path, *, timeout: float = 5.0) -> dict[str, Any]:
     """Side-effect-free budget read.
 
@@ -284,6 +329,7 @@ _COLLECTORS: dict[LoopKind, Callable[..., dict[str, Any]]] = {
     LoopKind.PUBLISHER: collect_publisher,
     LoopKind.WORKTREE_AUTOPILOT: collect_worktree_autopilot,
     LoopKind.NOMIC: collect_nomic,
+    LoopKind.DOCS_SYNC_DRIFT: collect_docs_sync_drift,
 }
 
 

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -12,12 +12,12 @@
 
 | Metric | Value | Source | Command |
 |---|---|---|---|
-| Python files under aragora/ | `4164` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1953862` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python files under aragora/ | `4166` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
+| Python lines of code under aragora/ | `1954885` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `141` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5290` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `220085` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
-| @pytest.mark.parametrize decorators | `729` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
+| Test files (test_*.py under tests/) | `5303` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `220387` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| @pytest.mark.parametrize decorators | `746` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `77` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2870` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
 | OpenAPI operations (HTTP verbs) | `3297` | `docs/api/openapi.json` | `python -c "import json; spec=json.load(open('docs/api/openapi.json')); print(sum(1 for p in spec['paths'].values() for m in p if m.lower() in {'get','post','put','delete','patch','head','options'}))"` |
@@ -28,7 +28,7 @@
 | Allowlisted agent types | `35` | `aragora/config/settings.py` | `grep -A 50 'ALLOWED_AGENT_TYPES' aragora/config/settings.py \| grep -oE "'[a-z-]+'" \| sort -u \| wc -l` |
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `46` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |
-| Markdown files under docs/ | `977` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
+| Markdown files under docs/ | `983` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
 | GitHub Actions workflows | `88` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
 | Mypy baseline errors (grandfathered) | `3115` | `.mypy-baseline` | `wc -l .mypy-baseline` |
 

--- a/docs/governance/LOOP_CONTROL_PLANE.md
+++ b/docs/governance/LOOP_CONTROL_PLANE.md
@@ -82,6 +82,26 @@ a feedback gate, and a durable-state location. This is the curated registry in
 | `publisher` | publication | publisher_freshness | `.aragora/automation-github-status` | no |
 | `worktree_autopilot` | maintenance | worktree_health | `.worktrees` | no |
 | `nomic` | self_improvement | (none) | `.aragora_beads` | yes (approval checkpoints) |
+| `docs_sync_drift` | maintenance | docs_drift | `.aragora/docs_drift_status.json` | no (its PRs settle through the quorum gate) |
+
+### `docs_sync_drift` (added after PR #8089)
+
+`scripts/docs_sync_drift_detector.py` is a bounded single-shot iteration
+(launchd daily via `scripts/install_docs_drift_launchd.sh`) that regenerates
+the docs surface against a throwaway worktree of `origin/main` using the exact
+commands the `Build Documentation (PR Check)` workflow runs. It exists because
+the external run-canceller (`docs/governance/PR_RUN_CANCELLATION_DIAGNOSIS.md`)
+can kill that advisory check on a source-doc PR, letting source changes land
+without regenerated mirrors (observed escapes: #7829, #7814) - the next
+doc-touching PR then inherits a red docs check it did not cause.
+
+Guard design: drift confined to generated mirrors (`docs-site/docs/**`) yields
+at most **one** open sync PR (branch namespace `bot/docs-site-sync`), which
+settles through the normal model-quorum merge gate - the detector never merges,
+approves, or comments. Drift touching anything else (for example `doc_stats`
+stamp targets such as protected `CLAUDE.md`) **fails closed to report-only**
+(`drift_outside_allowlist`). Waiting on an already-open sync PR is classified
+as *waiting*, not a fault - the §4 distinction applied to a brand-new loop.
 
 ---
 

--- a/scripts/docs_sync_drift_detector.py
+++ b/scripts/docs_sync_drift_detector.py
@@ -320,10 +320,12 @@ def run_iteration(repo_root: Path, *, apply: bool, base_ref: str, timeout: float
         outcome = OUTCOME_ERROR
         error = f"{type(exc).__name__}: {exc}"
     finally:
-        if worktree is not None:
-            cleanup_worktree(repo_root, worktree, timeout)
-        if scratch is not None:
-            shutil.rmtree(scratch, ignore_errors=True)
+        try:
+            if worktree is not None:
+                cleanup_worktree(repo_root, worktree, timeout)
+        finally:
+            if scratch is not None:
+                shutil.rmtree(scratch, ignore_errors=True)
     return {
         "outcome": outcome,
         "error": error,

--- a/scripts/docs_sync_drift_detector.py
+++ b/scripts/docs_sync_drift_detector.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+"""Docs-site sync drift detector - a bounded, single-shot governed loop iteration.
+
+Root cause being closed (Loop Control Plane follow-up): generated docs-site
+mirrors drift on ``main`` when a source-doc PR's advisory "Build Documentation
+(PR Check)" run is cancelled by the external canceller documented in
+``docs/governance/PR_RUN_CANCELLATION_DIAGNOSIS.md`` and never re-run (observed
+escapes: #7829, #7814). The next doc-touching PR then inherits a red docs check
+it did not cause.
+
+Each invocation is one bounded iteration (launchd provides the cadence):
+
+1. Fetch the base ref and regenerate the docs surface inside a throwaway
+   detached worktree (``python scripts/doc_stats.py --write`` +
+   ``node docs-site/scripts/sync-docs.js`` - the exact commands CI runs).
+2. If nothing drifted: report ``clean``.
+3. If only generated mirrors under ``docs-site/docs/`` drifted: in ``--apply``
+   mode open (at most) one sync PR that settles through the normal
+   model-quorum merge gate; otherwise just report ``drift_detected``.
+4. If anything *outside* the generated-mirror allowlist drifted (for example
+   ``doc_stats`` stamp targets such as protected ``CLAUDE.md``): fail closed
+   to report-only (``drift_outside_allowlist``) - never auto-PR those.
+
+Hard bounds and guarantees: single iteration per invocation, per-subprocess
+timeout, at most one open sync PR (branch namespace ``bot/docs-site-sync``),
+no force-push, and the detector never merges, approves, comments, or reruns
+anything. Status is written atomically to ``.aragora/docs_drift_status.json``
+for the Loop Control Plane collector (``aragora/swarm/loop_control_io.py``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+STATUS_SCHEMA = "docs-drift/v1"
+BRANCH_PREFIX = "bot/docs-site-sync"
+MIRROR_ALLOWLIST_PREFIX = "docs-site/docs/"
+DEFAULT_BASE_REF = "origin/main"
+DEFAULT_STATUS_RELPATH = Path(".aragora") / "docs_drift_status.json"
+DEFAULT_TIMEOUT_S = 300.0
+
+OUTCOME_CLEAN = "clean"
+OUTCOME_DRIFT_DETECTED = "drift_detected"
+OUTCOME_DRIFT_PR_OPEN = "drift_pr_open"
+OUTCOME_DRIFT_PR_OPENED = "drift_pr_opened"
+OUTCOME_OUTSIDE_ALLOWLIST = "drift_outside_allowlist"
+OUTCOME_ERROR = "error"
+
+# Outcomes that count toward the no-progress fault streak. Waiting on an open
+# sync PR is *waiting*, not a fault (the #7879 fault-vs-waiting distinction).
+FAULT_OUTCOMES = frozenset({OUTCOME_ERROR, OUTCOME_OUTSIDE_ALLOWLIST})
+
+EXIT_BY_OUTCOME = {
+    OUTCOME_CLEAN: 0,
+    OUTCOME_DRIFT_PR_OPEN: 0,
+    OUTCOME_DRIFT_PR_OPENED: 0,
+    OUTCOME_DRIFT_DETECTED: 1,
+    OUTCOME_OUTSIDE_ALLOWLIST: 2,
+    OUTCOME_ERROR: 2,
+}
+
+
+class DetectorError(RuntimeError):
+    """Operational failure of one iteration (fail-closed to ``error``)."""
+
+
+def _run(cmd: list[str], cwd: Path, timeout: float) -> subprocess.CompletedProcess[str] | None:
+    """Single subprocess seam (tests fake this to prove the command surface)."""
+    try:
+        return subprocess.run(
+            cmd,
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+
+
+def _run_ok(
+    cmd: list[str], cwd: Path, timeout: float, what: str
+) -> subprocess.CompletedProcess[str]:
+    proc = _run(cmd, cwd, timeout)
+    if proc is None:
+        raise DetectorError(f"{what} failed to execute: {' '.join(cmd)}")
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "").strip().splitlines()
+        tail = detail[-1] if detail else ""
+        raise DetectorError(f"{what} failed (rc={proc.returncode}): {tail}")
+    return proc
+
+
+def parse_porcelain(text: str) -> list[str]:
+    """Paths from ``git status --porcelain`` output (rename-aware, deduped)."""
+    paths: set[str] = set()
+    for line in text.splitlines():
+        if len(line) < 4:
+            continue
+        entry = line[3:]
+        if line[0] in "RC" and " -> " in entry:
+            entry = entry.split(" -> ", 1)[1]
+        entry = entry.strip()
+        if entry.startswith('"') and entry.endswith('"') and len(entry) >= 2:
+            entry = entry[1:-1]
+        if entry:
+            paths.add(entry)
+    return sorted(paths)
+
+
+def partition_drift(paths: list[str]) -> tuple[list[str], list[str]]:
+    """Split drifted paths into (allowlisted mirrors, everything else)."""
+    mirrors = [p for p in paths if p.startswith(MIRROR_ALLOWLIST_PREFIX)]
+    other = [p for p in paths if not p.startswith(MIRROR_ALLOWLIST_PREFIX)]
+    return mirrors, other
+
+
+def next_consecutive_errors(previous: int, outcome: str) -> int:
+    return previous + 1 if outcome in FAULT_OUTCOMES else 0
+
+
+def load_previous_status(path: Path) -> dict[str, Any]:
+    try:
+        with path.open(encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (OSError, json.JSONDecodeError, ValueError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def write_status_atomic(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=path.name, dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        os.replace(tmp_name, path)
+    except OSError:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def find_open_sync_pr(repo_root: Path, timeout: float) -> str | None:
+    proc = _run_ok(
+        ["gh", "pr", "list", "--state", "open", "--limit", "100", "--json", "url,headRefName"],
+        repo_root,
+        timeout,
+        "gh pr list",
+    )
+    try:
+        items = json.loads(proc.stdout or "[]")
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise DetectorError(f"gh pr list returned invalid JSON: {exc}") from exc
+    if not isinstance(items, list):
+        raise DetectorError("gh pr list returned non-list JSON")
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        head = str(item.get("headRefName") or "")
+        if head.startswith(BRANCH_PREFIX):
+            url = str(item.get("url") or "")
+            return url or None
+    return None
+
+
+def regenerate_docs(worktree: Path, timeout: float) -> None:
+    _run_ok(
+        [sys.executable, "scripts/doc_stats.py", "--write"],
+        worktree,
+        timeout,
+        "doc_stats --write",
+    )
+    _run_ok(
+        ["node", "docs-site/scripts/sync-docs.js"],
+        worktree,
+        timeout,
+        "sync-docs",
+    )
+
+
+def open_sync_pr(
+    repo_root: Path,
+    worktree: Path,
+    mirrors: list[str],
+    base_sha: str,
+    timeout: float,
+) -> str:
+    branch = f"{BRANCH_PREFIX}-{datetime.now(timezone.utc):%Y%m%d-%H%M%S}"
+    _run_ok(["git", "checkout", "-b", branch], worktree, timeout, "git checkout -b")
+    _run_ok(["git", "add", "--", *mirrors], worktree, timeout, "git add")
+    commit_message = (
+        "chore(docs-site): sync generated doc mirrors (drift detector)\n\n"
+        "Mechanical regeneration of generated docs-site mirrors that drifted on\n"
+        f"main ({base_sha}); produced by the exact commands CI runs\n"
+        "(python scripts/doc_stats.py --write && node docs-site/scripts/sync-docs.js).\n"
+        "Opened by scripts/docs_sync_drift_detector.py; settles through the normal\n"
+        "model-quorum merge gate. See docs/governance/LOOP_CONTROL_PLANE.md and\n"
+        "docs/governance/PR_RUN_CANCELLATION_DIAGNOSIS.md.\n\n"
+        "Co-authored-by: claude[bot] <claude[bot]@users.noreply.github.com>"
+    )
+    _run_ok(["git", "commit", "-m", commit_message], worktree, timeout, "git commit")
+    _run_ok(["git", "push", "-u", "origin", branch], worktree, timeout, "git push")
+    drifted_lines = "\n".join(f"- `{p}`" for p in mirrors)
+    body = (
+        f"## Summary\n\n"
+        f"Generated docs-site mirrors drifted on main (`{base_sha}`). This PR is the\n"
+        f"mechanical regeneration produced by the exact commands the\n"
+        f"`Build Documentation (PR Check)` workflow runs:\n\n"
+        f"```\npython scripts/doc_stats.py --write\nnode docs-site/scripts/sync-docs.js\n```\n\n"
+        f"Drifted mirrors:\n\n{drifted_lines}\n\n"
+        f"## Why this exists\n\n"
+        f"Source-doc PRs whose advisory docs check is cancelled by the external\n"
+        f"canceller (see `docs/governance/PR_RUN_CANCELLATION_DIAGNOSIS.md`; observed\n"
+        f"escapes #7829, #7814) can land source changes without regenerated mirrors,\n"
+        f"making the *next* doc-touching PR inherit a red docs check. The drift\n"
+        f"detector (`scripts/docs_sync_drift_detector.py`, a governed loop in\n"
+        f"`docs/governance/LOOP_CONTROL_PLANE.md`) opens at most one such sync PR.\n\n"
+        f"## Guarantees\n\n"
+        f"- Generated-mirror files only (`docs-site/docs/**`); anything else fails closed.\n"
+        f"- The detector never merges, approves, or comments; this PR settles through\n"
+        f"  the normal model-quorum merge gate.\n"
+    )
+    proc = _run_ok(
+        [
+            "gh",
+            "pr",
+            "create",
+            "--title",
+            "chore(docs-site): sync generated doc mirrors (drift detector)",
+            "--body",
+            body,
+        ],
+        worktree,
+        timeout,
+        "gh pr create",
+    )
+    url = (proc.stdout or "").strip().splitlines()
+    return url[-1].strip() if url else ""
+
+
+def cleanup_worktree(repo_root: Path, worktree: Path, timeout: float) -> None:
+    _run(["git", "worktree", "remove", "--force", str(worktree)], repo_root, timeout)
+    _run(["git", "worktree", "prune"], repo_root, timeout)
+
+
+def run_iteration(repo_root: Path, *, apply: bool, base_ref: str, timeout: float) -> dict[str, Any]:
+    started = time.time()
+    worktree: Path | None = None
+    pr_url: str | None = None
+    error: str | None = None
+    base_sha: str | None = None
+    mirrors: list[str] = []
+    other: list[str] = []
+    outcome = OUTCOME_ERROR
+    try:
+        remote, _, branch = base_ref.partition("/")
+        if not remote or not branch:
+            raise DetectorError(f"base ref must look like 'origin/main', got {base_ref!r}")
+        _run_ok(["git", "fetch", "--quiet", remote, branch], repo_root, timeout, "git fetch")
+        base_sha = _run_ok(
+            ["git", "rev-parse", base_ref], repo_root, timeout, "git rev-parse"
+        ).stdout.strip()
+        worktree = Path(tempfile.mkdtemp(prefix="docs-drift-wt-"))
+        _run_ok(
+            ["git", "worktree", "add", "--detach", str(worktree), base_ref],
+            repo_root,
+            timeout,
+            "git worktree add",
+        )
+        regenerate_docs(worktree, timeout)
+        drifted = parse_porcelain(
+            _run_ok(["git", "status", "--porcelain"], worktree, timeout, "git status").stdout
+        )
+        mirrors, other = partition_drift(drifted)
+        if other:
+            outcome = OUTCOME_OUTSIDE_ALLOWLIST
+            shown = ", ".join(other[:10])
+            error = f"drift outside generated-mirror allowlist (report-only): {shown}"
+        elif not mirrors:
+            outcome = OUTCOME_CLEAN
+        elif not apply:
+            outcome = OUTCOME_DRIFT_DETECTED
+        else:
+            existing = find_open_sync_pr(repo_root, timeout)
+            if existing:
+                pr_url = existing
+                outcome = OUTCOME_DRIFT_PR_OPEN
+            else:
+                pr_url = open_sync_pr(repo_root, worktree, mirrors, base_sha, timeout)
+                outcome = OUTCOME_DRIFT_PR_OPENED
+    except DetectorError as exc:
+        outcome = OUTCOME_ERROR
+        error = str(exc)
+    except Exception as exc:  # noqa: BLE001 - one iteration must fail closed, not raise
+        outcome = OUTCOME_ERROR
+        error = f"{type(exc).__name__}: {exc}"
+    finally:
+        if worktree is not None:
+            cleanup_worktree(repo_root, worktree, timeout)
+    return {
+        "outcome": outcome,
+        "error": error,
+        "base_sha": base_sha,
+        "pr_url": pr_url,
+        "drifted_mirror_paths": mirrors,
+        "drifted_other_paths": other,
+        "duration_s": round(time.time() - started, 2),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Open (at most) one sync PR when only generated mirrors drifted",
+    )
+    parser.add_argument("--json", action="store_true", help="Print the status payload as JSON")
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Repository root (default: parent of scripts/)",
+    )
+    parser.add_argument(
+        "--status-path",
+        type=Path,
+        default=None,
+        help="Status JSON path (default: <repo-root>/.aragora/docs_drift_status.json)",
+    )
+    parser.add_argument("--base-ref", default=DEFAULT_BASE_REF, help="Base ref to audit")
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=DEFAULT_TIMEOUT_S,
+        help="Per-subprocess timeout in seconds",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = (args.repo_root or Path(__file__).resolve().parents[1]).resolve()
+    status_path = args.status_path or (repo_root / DEFAULT_STATUS_RELPATH)
+    previous = load_previous_status(status_path)
+    try:
+        previous_errors = int(previous.get("consecutive_errors", 0) or 0)
+    except (TypeError, ValueError):
+        previous_errors = 0
+
+    result = run_iteration(
+        repo_root, apply=args.apply, base_ref=args.base_ref, timeout=args.timeout
+    )
+    outcome = result["outcome"]
+    payload: dict[str, Any] = {
+        "schema": STATUS_SCHEMA,
+        "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "apply": bool(args.apply),
+        "base_ref": args.base_ref,
+        "consecutive_errors": next_consecutive_errors(previous_errors, outcome),
+        **result,
+    }
+    write_status_atomic(status_path, payload)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(f"docs-sync drift: {outcome}")
+        if payload.get("error"):
+            print(f"  error: {payload['error']}")
+        if payload.get("drifted_mirror_paths"):
+            for path in payload["drifted_mirror_paths"]:
+                print(f"  mirror: {path}")
+        if payload.get("pr_url"):
+            print(f"  pr: {payload['pr_url']}")
+    return EXIT_BY_OUTCOME.get(outcome, 2)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/docs_sync_drift_detector.py
+++ b/scripts/docs_sync_drift_detector.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -101,18 +102,25 @@ def _run_ok(
     return proc
 
 
-def parse_porcelain(text: str) -> list[str]:
-    """Paths from ``git status --porcelain`` output (rename-aware, deduped)."""
+def parse_porcelain(data: str) -> list[str]:
+    """Paths from ``git status --porcelain -z`` output (NUL-delimited, deduped).
+
+    The ``-z`` form never quotes or octal-escapes paths, so unicode and
+    special characters survive verbatim. Rename/copy entries carry the
+    destination in the status token and the *original* path in the next
+    NUL token, which is consumed and ignored.
+    """
     paths: set[str] = set()
-    for line in text.splitlines():
-        if len(line) < 4:
+    tokens = data.split("\0")
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        index += 1
+        if len(token) < 4 or token[2] != " ":
             continue
-        entry = line[3:]
-        if line[0] in "RC" and " -> " in entry:
-            entry = entry.split(" -> ", 1)[1]
-        entry = entry.strip()
-        if entry.startswith('"') and entry.endswith('"') and len(entry) >= 2:
-            entry = entry[1:-1]
+        if token[0] in "RC" and index < len(tokens):
+            index += 1
+        entry = token[3:]
         if entry:
             paths.add(entry)
     return sorted(paths)
@@ -197,6 +205,7 @@ def open_sync_pr(
     worktree: Path,
     mirrors: list[str],
     base_sha: str,
+    remote: str,
     timeout: float,
 ) -> str:
     branch = f"{BRANCH_PREFIX}-{datetime.now(timezone.utc):%Y%m%d-%H%M%S}"
@@ -213,7 +222,7 @@ def open_sync_pr(
         "Co-authored-by: claude[bot] <claude[bot]@users.noreply.github.com>"
     )
     _run_ok(["git", "commit", "-m", commit_message], worktree, timeout, "git commit")
-    _run_ok(["git", "push", "-u", "origin", branch], worktree, timeout, "git push")
+    _run_ok(["git", "push", "-u", remote, branch], worktree, timeout, "git push")
     drifted_lines = "\n".join(f"- `{p}`" for p in mirrors)
     body = (
         f"## Summary\n\n"
@@ -259,6 +268,7 @@ def cleanup_worktree(repo_root: Path, worktree: Path, timeout: float) -> None:
 
 def run_iteration(repo_root: Path, *, apply: bool, base_ref: str, timeout: float) -> dict[str, Any]:
     started = time.time()
+    scratch: Path | None = None
     worktree: Path | None = None
     pr_url: str | None = None
     error: str | None = None
@@ -274,7 +284,8 @@ def run_iteration(repo_root: Path, *, apply: bool, base_ref: str, timeout: float
         base_sha = _run_ok(
             ["git", "rev-parse", base_ref], repo_root, timeout, "git rev-parse"
         ).stdout.strip()
-        worktree = Path(tempfile.mkdtemp(prefix="docs-drift-wt-"))
+        scratch = Path(tempfile.mkdtemp(prefix="docs-drift-wt-"))
+        worktree = scratch / "worktree"
         _run_ok(
             ["git", "worktree", "add", "--detach", str(worktree), base_ref],
             repo_root,
@@ -283,7 +294,7 @@ def run_iteration(repo_root: Path, *, apply: bool, base_ref: str, timeout: float
         )
         regenerate_docs(worktree, timeout)
         drifted = parse_porcelain(
-            _run_ok(["git", "status", "--porcelain"], worktree, timeout, "git status").stdout
+            _run_ok(["git", "status", "--porcelain", "-z"], worktree, timeout, "git status").stdout
         )
         mirrors, other = partition_drift(drifted)
         if other:
@@ -300,7 +311,7 @@ def run_iteration(repo_root: Path, *, apply: bool, base_ref: str, timeout: float
                 pr_url = existing
                 outcome = OUTCOME_DRIFT_PR_OPEN
             else:
-                pr_url = open_sync_pr(repo_root, worktree, mirrors, base_sha, timeout)
+                pr_url = open_sync_pr(repo_root, worktree, mirrors, base_sha, remote, timeout)
                 outcome = OUTCOME_DRIFT_PR_OPENED
     except DetectorError as exc:
         outcome = OUTCOME_ERROR
@@ -311,6 +322,8 @@ def run_iteration(repo_root: Path, *, apply: bool, base_ref: str, timeout: float
     finally:
         if worktree is not None:
             cleanup_worktree(repo_root, worktree, timeout)
+        if scratch is not None:
+            shutil.rmtree(scratch, ignore_errors=True)
     return {
         "outcome": outcome,
         "error": error,

--- a/scripts/install_docs_drift_launchd.sh
+++ b/scripts/install_docs_drift_launchd.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Install a launchd job that runs the docs-site sync drift detector once a day.
+#
+# The detector (scripts/docs_sync_drift_detector.py) is a bounded single-shot
+# governed loop iteration: launchd provides the cadence, the script provides
+# the iteration. No KeepAlive - one fire per StartCalendarInterval.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LABEL="com.aragora.docs-sync-drift"
+PLIST_PATH="${HOME}/Library/LaunchAgents/${LABEL}.plist"
+LOG_PATH="${REPO_ROOT}/.aragora/overnight/docs-sync-drift-launchd.log"
+HOUR="${DOCS_DRIFT_HOUR:-7}"
+MINUTE="${DOCS_DRIFT_MINUTE:-45}"
+CHECK_ONLY=false
+
+usage() {
+    cat <<'EOF'
+Usage: ./scripts/install_docs_drift_launchd.sh [options]
+
+Options:
+  --hour <0-23>       Daily fire hour (default: 7)
+  --minute <0-59>     Daily fire minute (default: 45)
+  --log-path <file>   Log file path (default: .aragora/overnight/docs-sync-drift-launchd.log)
+  --check-only        Install in report-only mode (omit --apply; no PRs opened)
+  --help              Show this help
+EOF
+}
+
+validate_integer() {
+    local label="$1"
+    local value="$2"
+    if ! [[ "$value" =~ ^[0-9]+$ ]]; then
+        echo "${label} must be numeric" >&2
+        exit 2
+    fi
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --hour)
+            HOUR="${2:-$HOUR}"
+            shift 2
+            ;;
+        --minute)
+            MINUTE="${2:-$MINUTE}"
+            shift 2
+            ;;
+        --log-path)
+            LOG_PATH="${2:-$LOG_PATH}"
+            shift 2
+            ;;
+        --check-only)
+            CHECK_ONLY=true
+            shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage
+            exit 2
+            ;;
+    esac
+done
+
+validate_integer "hour" "${HOUR}"
+validate_integer "minute" "${MINUTE}"
+if (( HOUR > 23 )) || (( MINUTE > 59 )); then
+    echo "hour must be 0-23 and minute 0-59" >&2
+    exit 2
+fi
+
+mkdir -p "$(dirname "${PLIST_PATH}")"
+mkdir -p "$(dirname "${LOG_PATH}")"
+
+apply_flag="--apply"
+if [[ "${CHECK_ONLY}" == true ]]; then
+    apply_flag=""
+fi
+command_string="cd \"${REPO_ROOT}\" && export PATH=\"/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:\$HOME/.pyenv/shims:\$PATH\" && exec python3 scripts/docs_sync_drift_detector.py ${apply_flag} --json"
+command_xml="${command_string//&/&amp;}"
+
+cat >"${PLIST_PATH}" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>-lc</string>
+    <string>${command_xml}</string>
+  </array>
+  <key>RunAtLoad</key>
+  <false/>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key>
+    <integer>${HOUR}</integer>
+    <key>Minute</key>
+    <integer>${MINUTE}</integer>
+  </dict>
+  <key>WorkingDirectory</key>
+  <string>${REPO_ROOT}</string>
+  <key>StandardOutPath</key>
+  <string>${LOG_PATH}</string>
+  <key>StandardErrorPath</key>
+  <string>${LOG_PATH}</string>
+</dict>
+</plist>
+EOF
+
+launchctl unload "${PLIST_PATH}" >/dev/null 2>&1 || true
+launchctl load "${PLIST_PATH}"
+
+echo "Installed launchd job: ${LABEL}"
+echo "Plist: ${PLIST_PATH}"
+echo "Log: ${LOG_PATH}"
+echo "Fires daily at $(printf '%02d:%02d' "${HOUR}" "${MINUTE}")"
+if [[ "${CHECK_ONLY}" == true ]]; then
+    echo "Mode: check-only (no PRs opened)"
+else
+    echo "Mode: apply (opens at most one sync PR; never merges)"
+fi

--- a/tests/scripts/test_docs_sync_drift_detector.py
+++ b/tests/scripts/test_docs_sync_drift_detector.py
@@ -1,0 +1,369 @@
+"""Tests for ``scripts/docs_sync_drift_detector.py`` and its loop-control wiring.
+
+The central assertions mirror the Loop Control Plane v1 proof style: driving the
+detector with a faked subprocess seam records every command issued, so tests can
+prove the mutation surface exactly - check mode issues no ``commit``/``push``/
+``gh pr`` calls at all, apply mode pushes and opens at most one PR, and **no**
+mode ever merges, approves, comments, or reruns anything.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import aragora.swarm.loop_control_io as io_mod  # noqa: E402
+from aragora.swarm.loop_control import (  # noqa: E402
+    LOOP_SPECS,
+    HaltVerdict,
+    LoopKind,
+    audit_halt_readiness,
+    classify_loop,
+)
+
+
+def _load_detector() -> Any:
+    script_path = REPO_ROOT / "scripts" / "docs_sync_drift_detector.py"
+    spec = importlib.util.spec_from_file_location("docs_sync_drift_under_test", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+detector = _load_detector()
+
+# Arguments that must never appear as an exact arg in any command the detector
+# issues, in any mode.
+FORBIDDEN_ARGS = {
+    "merge",
+    "--admin",
+    "approve",
+    "--approve",
+    "comment",
+    "rerun",
+    "--force-with-lease",
+}
+
+SHA = "1234567890abcdef1234567890abcdef12345678"
+MIRROR = "docs-site/docs/contributing/b0-benchmark-truth-status.md"
+
+
+class FakeRunner:
+    """Scriptable stand-in for the detector's single subprocess seam."""
+
+    def __init__(self, responses: list[tuple[Any, int, str]] | None = None) -> None:
+        self.commands: list[list[str]] = []
+        self._responses = responses or []
+
+    def __call__(
+        self, cmd: list[str], cwd: Path, timeout: float
+    ) -> subprocess.CompletedProcess[str]:
+        self.commands.append(list(cmd))
+        for match, returncode, stdout in self._responses:
+            if self._matches(cmd, match):
+                return subprocess.CompletedProcess(cmd, returncode, stdout, "")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    @staticmethod
+    def _matches(cmd: list[str], match: Any) -> bool:
+        if callable(match):
+            return bool(match(cmd))
+        prefix = list(match)
+        return cmd[: len(prefix)] == prefix
+
+    def issued(self, *prefix: str) -> list[list[str]]:
+        return [c for c in self.commands if c[: len(prefix)] == list(prefix)]
+
+
+def _base_responses(porcelain: str, pr_list: str = "[]") -> list[tuple[Any, int, str]]:
+    return [
+        (("git", "rev-parse"), 0, SHA + "\n"),
+        (("git", "status", "--porcelain"), 0, porcelain),
+        (("gh", "pr", "list"), 0, pr_list),
+        (("gh", "pr", "create"), 0, "https://github.com/synaptent/aragora/pull/9999\n"),
+    ]
+
+
+def _run_main(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    runner: FakeRunner,
+    *args: str,
+) -> tuple[int, dict[str, Any]]:
+    monkeypatch.setattr(detector, "_run", runner)
+    status_path = tmp_path / "status.json"
+    code = detector.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--status-path",
+            str(status_path),
+            "--json",
+            *args,
+        ]
+    )
+    payload = json.loads(status_path.read_text()) if status_path.exists() else {}
+    return code, payload
+
+
+def _assert_no_forbidden(runner: FakeRunner) -> None:
+    for cmd in runner.commands:
+        assert not FORBIDDEN_ARGS.intersection(cmd), f"forbidden arg in {cmd}"
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def test_parse_porcelain_handles_variants() -> None:
+    text = (
+        f" M {MIRROR}\n"
+        "?? docs-site/docs/new-file.md\n"
+        "R  docs/OLD.md -> docs/NEW.md\n"
+        ' M "docs-site/docs/with space.md"\n'
+        f" M {MIRROR}\n"
+        "x\n"
+    )
+    paths = detector.parse_porcelain(text)
+    assert paths == sorted(
+        {MIRROR, "docs-site/docs/new-file.md", "docs/NEW.md", "docs-site/docs/with space.md"}
+    )
+
+
+def test_partition_drift_splits_on_allowlist() -> None:
+    mirrors, other = detector.partition_drift([MIRROR, "CLAUDE.md", "docs/METRICS.md"])
+    assert mirrors == [MIRROR]
+    assert other == ["CLAUDE.md", "docs/METRICS.md"]
+
+
+def test_next_consecutive_errors_counts_faults_only() -> None:
+    assert detector.next_consecutive_errors(2, detector.OUTCOME_ERROR) == 3
+    assert detector.next_consecutive_errors(2, detector.OUTCOME_OUTSIDE_ALLOWLIST) == 3
+    assert detector.next_consecutive_errors(2, detector.OUTCOME_CLEAN) == 0
+    assert detector.next_consecutive_errors(2, detector.OUTCOME_DRIFT_PR_OPEN) == 0
+    assert detector.next_consecutive_errors(2, detector.OUTCOME_DRIFT_DETECTED) == 0
+
+
+def test_exit_codes_cover_every_outcome() -> None:
+    outcomes = {
+        detector.OUTCOME_CLEAN,
+        detector.OUTCOME_DRIFT_DETECTED,
+        detector.OUTCOME_DRIFT_PR_OPEN,
+        detector.OUTCOME_DRIFT_PR_OPENED,
+        detector.OUTCOME_OUTSIDE_ALLOWLIST,
+        detector.OUTCOME_ERROR,
+    }
+    assert set(detector.EXIT_BY_OUTCOME) == outcomes
+    assert detector.EXIT_BY_OUTCOME[detector.OUTCOME_DRIFT_DETECTED] == 1
+    assert detector.EXIT_BY_OUTCOME[detector.OUTCOME_ERROR] == 2
+
+
+def test_status_write_is_atomic_and_reloadable(tmp_path: Path) -> None:
+    path = tmp_path / "nested" / "status.json"
+    detector.write_status_atomic(path, {"outcome": "clean", "consecutive_errors": 0})
+    assert detector.load_previous_status(path)["outcome"] == "clean"
+    assert [p.name for p in path.parent.iterdir()] == ["status.json"]
+
+
+def test_load_previous_status_tolerates_garbage(tmp_path: Path) -> None:
+    path = tmp_path / "status.json"
+    path.write_text("not json")
+    assert detector.load_previous_status(path) == {}
+    assert detector.load_previous_status(tmp_path / "missing.json") == {}
+
+
+# ---------------------------------------------------------------------------
+# Iterations through the faked subprocess seam
+# ---------------------------------------------------------------------------
+
+
+def test_check_mode_reports_drift_without_mutating(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    runner = FakeRunner(_base_responses(f" M {MIRROR}\n"))
+    code, payload = _run_main(monkeypatch, tmp_path, runner)
+    assert code == 1
+    assert payload["outcome"] == detector.OUTCOME_DRIFT_DETECTED
+    assert payload["drifted_mirror_paths"] == [MIRROR]
+    assert payload["base_sha"] == SHA
+    for verb in (("git", "commit"), ("git", "push"), ("gh",)):
+        assert runner.issued(*verb) == []
+    _assert_no_forbidden(runner)
+
+
+def test_check_mode_clean(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    runner = FakeRunner(_base_responses(""))
+    code, payload = _run_main(monkeypatch, tmp_path, runner)
+    assert code == 0
+    assert payload["outcome"] == detector.OUTCOME_CLEAN
+    assert payload["consecutive_errors"] == 0
+
+
+def test_drift_outside_allowlist_fails_closed_even_with_apply(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    runner = FakeRunner(_base_responses(f" M {MIRROR}\n M CLAUDE.md\n"))
+    code, payload = _run_main(monkeypatch, tmp_path, runner, "--apply")
+    assert code == 2
+    assert payload["outcome"] == detector.OUTCOME_OUTSIDE_ALLOWLIST
+    assert payload["drifted_other_paths"] == ["CLAUDE.md"]
+    assert "CLAUDE.md" in (payload["error"] or "")
+    for verb in (("git", "commit"), ("git", "push"), ("gh",)):
+        assert runner.issued(*verb) == []
+
+
+def test_apply_is_idempotent_when_sync_pr_already_open(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    pr_list = json.dumps(
+        [
+            {"url": "https://github.com/synaptent/aragora/pull/9001", "headRefName": "feature/x"},
+            {
+                "url": "https://github.com/synaptent/aragora/pull/9002",
+                "headRefName": f"{detector.BRANCH_PREFIX}-20260601-000000",
+            },
+        ]
+    )
+    runner = FakeRunner(_base_responses(f" M {MIRROR}\n", pr_list=pr_list))
+    code, payload = _run_main(monkeypatch, tmp_path, runner, "--apply")
+    assert code == 0
+    assert payload["outcome"] == detector.OUTCOME_DRIFT_PR_OPEN
+    assert payload["pr_url"].endswith("/9002")
+    assert runner.issued("git", "push") == []
+    assert runner.issued("gh", "pr", "create") == []
+
+
+def test_apply_opens_single_pr_and_never_merges(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    runner = FakeRunner(_base_responses(f" M {MIRROR}\n"))
+    code, payload = _run_main(monkeypatch, tmp_path, runner, "--apply")
+    assert code == 0
+    assert payload["outcome"] == detector.OUTCOME_DRIFT_PR_OPENED
+    assert payload["pr_url"] == "https://github.com/synaptent/aragora/pull/9999"
+    pushes = runner.issued("git", "push")
+    assert len(pushes) == 1
+    assert pushes[0][:4] == ["git", "push", "-u", "origin"]
+    assert pushes[0][4].startswith(detector.BRANCH_PREFIX)
+    creates = runner.issued("gh", "pr", "create")
+    assert len(creates) == 1
+    adds = runner.issued("git", "add")
+    assert adds and adds[0][3:] == [MIRROR]
+    _assert_no_forbidden(runner)
+
+
+def test_regen_failure_is_fault_and_increments_streak(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    status_path = tmp_path / "status.json"
+    detector.write_status_atomic(status_path, {"outcome": "error", "consecutive_errors": 2})
+    runner = FakeRunner([(("node",), 1, "boom")] + _base_responses(""))
+    monkeypatch.setattr(detector, "_run", runner)
+    code = detector.main(
+        ["--repo-root", str(tmp_path), "--status-path", str(status_path), "--json"]
+    )
+    payload = json.loads(status_path.read_text())
+    assert code == 2
+    assert payload["outcome"] == detector.OUTCOME_ERROR
+    assert "sync-docs" in payload["error"]
+    assert payload["consecutive_errors"] == 3
+
+
+def test_worktree_is_cleaned_up_even_on_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    runner = FakeRunner([(("node",), 1, "boom")] + _base_responses(""))
+    code, _payload = _run_main(monkeypatch, tmp_path, runner)
+    assert code == 2
+    assert runner.issued("git", "worktree", "remove") != []
+    assert runner.issued("git", "worktree", "prune") != []
+
+
+# ---------------------------------------------------------------------------
+# Loop Control Plane wiring
+# ---------------------------------------------------------------------------
+
+
+def _write_status(root: Path, payload: dict[str, Any]) -> Path:
+    path = root / ".aragora" / "docs_drift_status.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload))
+    return path
+
+
+def test_spec_is_registered_with_honest_budget_gap() -> None:
+    spec = LOOP_SPECS[LoopKind.DOCS_SYNC_DRIFT]
+    readiness = audit_halt_readiness(spec.guards)
+    assert readiness.verdict == HaltVerdict.INCOMPLETE.value
+    assert readiness.gaps == ["no dollar/budget ceiling (bounded by time/iterations only)"]
+    assert spec.durable_state_path == ".aragora/docs_drift_status.json"
+
+
+def test_collector_missing_file_is_unavailable(tmp_path: Path) -> None:
+    raw = io_mod.collect_docs_sync_drift(tmp_path)
+    assert raw["source_status"] == "unavailable"
+    record = classify_loop(LOOP_SPECS[LoopKind.DOCS_SYNC_DRIFT], raw)
+    assert record.state == "unknown"
+    assert record.next_action == "report_only"
+
+
+def test_collector_waiting_on_open_pr_is_waiting_not_fault(tmp_path: Path) -> None:
+    path = _write_status(
+        tmp_path,
+        {
+            "outcome": "drift_pr_open",
+            "consecutive_errors": 0,
+            "generated_at": "2026-06-10T08:00:00Z",
+        },
+    )
+    raw = io_mod.collect_docs_sync_drift(tmp_path, now=path.stat().st_mtime + 60.0)
+    assert raw["waiting_only"] is True
+    assert raw["operational_fault"] is False
+    record = classify_loop(LOOP_SPECS[LoopKind.DOCS_SYNC_DRIFT], raw)
+    assert record.state == "waiting"
+    assert record.next_action == "wait"
+
+
+def test_collector_fault_outcome_halts(tmp_path: Path) -> None:
+    path = _write_status(
+        tmp_path,
+        {"outcome": "drift_outside_allowlist", "consecutive_errors": 1, "error": "CLAUDE.md"},
+    )
+    raw = io_mod.collect_docs_sync_drift(tmp_path, now=path.stat().st_mtime + 60.0)
+    assert raw["operational_fault"] is True
+    record = classify_loop(LOOP_SPECS[LoopKind.DOCS_SYNC_DRIFT], raw)
+    assert record.state == "blocked"
+    assert record.next_action == "halt"
+    assert record.blocker == "CLAUDE.md"
+
+
+def test_collector_stale_status_is_halted_report_only(tmp_path: Path) -> None:
+    path = _write_status(tmp_path, {"outcome": "clean", "consecutive_errors": 0})
+    stale_now = path.stat().st_mtime + io_mod._DOCS_DRIFT_STATE_FRESH_SECONDS + 1.0
+    raw = io_mod.collect_docs_sync_drift(tmp_path, now=stale_now)
+    assert raw["alive"] is False
+    record = classify_loop(LOOP_SPECS[LoopKind.DOCS_SYNC_DRIFT], raw)
+    assert record.state == "halted"
+    assert record.next_action == "report_only"
+
+
+def test_collector_fresh_clean_is_running(tmp_path: Path) -> None:
+    path = _write_status(tmp_path, {"outcome": "clean", "consecutive_errors": 0})
+    raw = io_mod.collect_docs_sync_drift(tmp_path, now=path.stat().st_mtime + 60.0)
+    record = classify_loop(LOOP_SPECS[LoopKind.DOCS_SYNC_DRIFT], raw)
+    assert record.state == "running"
+    assert record.next_action == "continue"
+    assert record.source_status == "ok"

--- a/tests/scripts/test_docs_sync_drift_detector.py
+++ b/tests/scripts/test_docs_sync_drift_detector.py
@@ -103,6 +103,15 @@ def _run_main(
     *args: str,
 ) -> tuple[int, dict[str, Any]]:
     monkeypatch.setattr(detector, "_run", runner)
+    scratches: list[Path] = []
+
+    def fake_mkdtemp(prefix: str = "tmp") -> str:
+        scratch = tmp_path / f"{prefix}{len(scratches)}"
+        scratch.mkdir()
+        scratches.append(scratch)
+        return str(scratch)
+
+    monkeypatch.setattr(detector.tempfile, "mkdtemp", fake_mkdtemp)
     status_path = tmp_path / "status.json"
     code = detector.main(
         [
@@ -115,6 +124,8 @@ def _run_main(
         ]
     )
     payload = json.loads(status_path.read_text()) if status_path.exists() else {}
+    leaked = [str(s) for s in scratches if s.exists()]
+    assert not leaked, f"scratch dirs leaked: {leaked}"
     return code, payload
 
 
@@ -130,17 +141,25 @@ def _assert_no_forbidden(runner: FakeRunner) -> None:
 
 def test_parse_porcelain_handles_variants() -> None:
     text = (
-        f" M {MIRROR}\n"
-        "?? docs-site/docs/new-file.md\n"
-        "R  docs/OLD.md -> docs/NEW.md\n"
-        ' M "docs-site/docs/with space.md"\n'
-        f" M {MIRROR}\n"
-        "x\n"
+        f" M {MIRROR}\x00"
+        "?? docs-site/docs/new-file.md\x00"
+        "R  docs/NEW.md\x00docs/OLD.md\x00"
+        " M docs-site/docs/with space.md\x00"
+        ' M docs-site/docs/"quoted" \u00fcnicode.md\x00'
+        f" M {MIRROR}\x00"
+        "x\x00"
     )
     paths = detector.parse_porcelain(text)
     assert paths == sorted(
-        {MIRROR, "docs-site/docs/new-file.md", "docs/NEW.md", "docs-site/docs/with space.md"}
+        {
+            MIRROR,
+            "docs-site/docs/new-file.md",
+            "docs/NEW.md",
+            "docs-site/docs/with space.md",
+            'docs-site/docs/"quoted" \u00fcnicode.md',
+        }
     )
+    assert "docs/OLD.md" not in paths
 
 
 def test_partition_drift_splits_on_allowlist() -> None:
@@ -193,7 +212,7 @@ def test_load_previous_status_tolerates_garbage(tmp_path: Path) -> None:
 def test_check_mode_reports_drift_without_mutating(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    runner = FakeRunner(_base_responses(f" M {MIRROR}\n"))
+    runner = FakeRunner(_base_responses(f" M {MIRROR}\x00"))
     code, payload = _run_main(monkeypatch, tmp_path, runner)
     assert code == 1
     assert payload["outcome"] == detector.OUTCOME_DRIFT_DETECTED
@@ -215,7 +234,7 @@ def test_check_mode_clean(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> No
 def test_drift_outside_allowlist_fails_closed_even_with_apply(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    runner = FakeRunner(_base_responses(f" M {MIRROR}\n M CLAUDE.md\n"))
+    runner = FakeRunner(_base_responses(f" M {MIRROR}\x00 M CLAUDE.md\x00"))
     code, payload = _run_main(monkeypatch, tmp_path, runner, "--apply")
     assert code == 2
     assert payload["outcome"] == detector.OUTCOME_OUTSIDE_ALLOWLIST
@@ -237,7 +256,7 @@ def test_apply_is_idempotent_when_sync_pr_already_open(
             },
         ]
     )
-    runner = FakeRunner(_base_responses(f" M {MIRROR}\n", pr_list=pr_list))
+    runner = FakeRunner(_base_responses(f" M {MIRROR}\x00", pr_list=pr_list))
     code, payload = _run_main(monkeypatch, tmp_path, runner, "--apply")
     assert code == 0
     assert payload["outcome"] == detector.OUTCOME_DRIFT_PR_OPEN
@@ -249,7 +268,7 @@ def test_apply_is_idempotent_when_sync_pr_already_open(
 def test_apply_opens_single_pr_and_never_merges(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    runner = FakeRunner(_base_responses(f" M {MIRROR}\n"))
+    runner = FakeRunner(_base_responses(f" M {MIRROR}\x00"))
     code, payload = _run_main(monkeypatch, tmp_path, runner, "--apply")
     assert code == 0
     assert payload["outcome"] == detector.OUTCOME_DRIFT_PR_OPENED
@@ -262,6 +281,23 @@ def test_apply_opens_single_pr_and_never_merges(
     assert len(creates) == 1
     adds = runner.issued("git", "add")
     assert adds and adds[0][3:] == [MIRROR]
+    _assert_no_forbidden(runner)
+
+
+def test_apply_pushes_to_remote_parsed_from_base_ref(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    runner = FakeRunner(_base_responses(f" M {MIRROR}\x00"))
+    code, payload = _run_main(
+        monkeypatch, tmp_path, runner, "--apply", "--base-ref", "upstream/main"
+    )
+    assert code == 0
+    assert payload["outcome"] == detector.OUTCOME_DRIFT_PR_OPENED
+    fetches = runner.issued("git", "fetch")
+    assert fetches and fetches[0][3:] == ["upstream", "main"]
+    pushes = runner.issued("git", "push")
+    assert len(pushes) == 1
+    assert pushes[0][:4] == ["git", "push", "-u", "upstream"]
     _assert_no_forbidden(runner)
 
 


### PR DESCRIPTION
## Summary

Closes the docs-site mirror drift root cause surfaced while landing #8089: generated mirrors drift on main when the **external run-canceller** (`docs/governance/PR_RUN_CANCELLATION_DIAGNOSIS.md`) kills the advisory `Build Documentation (PR Check)` on a source-doc PR and it never re-runs. Observed escapes: #7829 (`docs/status/B0_BENCHMARK_TRUTH_STATUS.md`) and #7814 (`docs/status/NEXT_STEPS_CANONICAL.md`) - the next doc-touching PR (#8089) then inherited a red docs check it did not cause.

Investigation note: the regeneration itself is **deterministic** (clean worktrees of `d71d8b9bbb`, `a35bcca6c4`, and `c1bef41d08` all regen clean once mirrors are synced), so the fix is escape-detection, not stamp removal. Per the cancellation diagnosis doc, a workflow-side re-trigger guardian remains a separate, approval-required follow-up; this PR adds no workflow changes.

- `scripts/docs_sync_drift_detector.py` - bounded single-shot governed loop iteration: fetch base ref, regenerate the docs surface in a throwaway detached worktree using the exact CI commands (`doc_stats.py --write` + `sync-docs.js`), then classify drift.
- **Fail-closed allowlist:** only `docs-site/docs/**` mirror drift may auto-PR. Anything else (e.g. `doc_stats` stamp targets such as protected `CLAUDE.md`) reports `drift_outside_allowlist` and exits nonzero - never auto-PRed.
- **At most one open sync PR** (branch namespace `bot/docs-site-sync`), which settles through the normal model-quorum merge gate. The detector never merges, approves, comments, reruns, or force-pushes.
- Registered as a governed loop: `LoopKind.DOCS_SYNC_DRIFT` in `LOOP_SPECS` + a `docs_drift` collector reading `.aragora/docs_drift_status.json` (atomic writes). Waiting on an open sync PR classifies as **waiting**, not fault - the #7879 distinction applied to a new loop on day one.
- `scripts/install_docs_drift_launchd.sh` - optional daily launchd installer (single-shot, no KeepAlive; `--check-only` mode available).
- `docs/governance/LOOP_CONTROL_PLANE.md` - loop-to-ladder row + root-cause section.

## Validation

- pytest: 55/55 (19 new + 36 existing loop-control tests; total test count increases)
- New tests prove the mutation surface through the subprocess seam: check mode issues zero `commit`/`push`/`gh` calls; apply mode pushes once and opens one PR; no mode ever issues `merge`/`approve`/`comment`/`rerun`.
- mypy: 0 errors on the 3 touched modules; pre-commit: all hooks pass
- Live smoke: `outcome=clean` against current `origin/main` (`c1bef41d08`), 4.9s; `loop_control_status --loop docs_sync_drift` picks up the new kind with honest `unknown`/`incomplete` verdicts
- `scripts/automation_pr_preflight.sh origin/main HEAD`: ok

## Governance

- Tier 2 (live automation + observability wiring + docs/tests). No workflows, merge policy, secrets, or protected files touched.
- Model-quorum evidence to follow on this head; not to be merged without quorum settlement.
