### PR TITLE
[outbox-harvest] agent_bridge.py owner now falls back from stale worktree metadata to the local branch head.

### DIFF
--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -622,6 +622,33 @@ def _head_for_worktree(path: str | Path | None) -> str | None:
     return head or None
 
 
+def _head_for_branch(branch: str | None, repo_root: Path | None = None) -> str | None:
+    if not branch:
+        return None
+    root = repo_root or CANONICAL_REPO_ROOT
+    ref_candidates = [f"refs/heads/{branch}", f"refs/remotes/origin/{branch}"]
+    for ref in ref_candidates:
+        try:
+            result = subprocess.run(
+                ["git", "-C", str(root), "rev-parse", "--verify", ref],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+            return None
+        if result.returncode == 0:
+            head = result.stdout.strip()
+            if head:
+                return head
+    return None
+
+
+def _head_for_owner_record(record: LaneRecord) -> str | None:
+    return _head_for_worktree(record.worktree) or _head_for_branch(record.branch)
+
+
 def _worktree_matches(record_worktree: str, query_worktree: str | None) -> bool:
     if not query_worktree:
         return False
@@ -684,7 +711,7 @@ def _owned_owner_payload(record: LaneRecord) -> dict[str, Any]:
         "pr_number": record.pr_number,
         "branch": record.branch or None,
         "worktree": record.worktree or None,
-        "head": _head_for_worktree(record.worktree),
+        "head": _head_for_owner_record(record),
         "status": record.status,
         "updated_at": record.updated_at or None,
         "recommended_operator_action": _owner_action_for(record),
@@ -700,7 +727,7 @@ def _historical_owner_payload(record: LaneRecord) -> dict[str, Any]:
         "pr_number": record.pr_number,
         "branch": record.branch or None,
         "worktree": record.worktree or None,
-        "head": _head_for_worktree(record.worktree),
+        "head": _head_for_owner_record(record),
         "status": record.status,
         "updated_at": record.updated_at or None,
         "recommended_operator_action": (
@@ -719,7 +746,7 @@ def _conflict_status_owner_payload(record: LaneRecord) -> dict[str, Any]:
         "pr_number": record.pr_number,
         "branch": record.branch or None,
         "worktree": record.worktree or None,
-        "head": _head_for_worktree(record.worktree),
+        "head": _head_for_owner_record(record),
         "status": record.status,
         "updated_at": record.updated_at or None,
         "conflict_session": record.conflict_session or None,

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -1268,6 +1268,50 @@ def test_cmd_owner_json_reports_active_pr_owner(
     }
 
 
+def test_cmd_owner_json_falls_back_to_branch_head_when_worktree_is_stale(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import agent_bridge as mod
+
+    stale_worktree = tmp_path / "missing-worktree"
+    _patch_bridge_paths(mod, tmp_path, monkeypatch)
+    mod.AGENT_BRIDGE_DIR.mkdir(parents=True, exist_ok=True)
+    mod.LANE_REGISTRY_FILE.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "q01-settle-7292",
+                    "owner_session": "codex-owner",
+                    "status": "active",
+                    "updated_at": "2026-05-18T17:00:00Z",
+                    "branch": "droid/P16-stage2",
+                    "worktree": str(stale_worktree),
+                    "pr_number": 7292,
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mod, "discover", lambda **_kwargs: [])
+    monkeypatch.setattr(mod, "_head_for_worktree", lambda _path: None)
+    monkeypatch.setattr(
+        mod,
+        "_head_for_branch",
+        lambda branch: "b" * 40 if branch == "droid/P16-stage2" else None,
+    )
+
+    rc = mod.cmd_owner(
+        argparse.Namespace(json=True, pr=None, branch="droid/P16-stage2", worktree=None)
+    )
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["owner_status"] == "owned"
+    assert payload["head"] == "b" * 40
+
+
 def test_cmd_owner_preserves_registry_identity_when_live_session_is_sparse(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Outbox harvest (run-20260610 shift 4)
Published by the gh-authenticated coordinator from `.aragora/automation-outbox` — the writer-lane sandbox validated this branch but could not open the PR (gh unauthenticated; publisher daemon stale since May 18).

- **Branch:** `codex/agent-bridge-owner-branch-head-primary-20260610` @ `cdaefc9de4c4` (head matches outbox record: True)
- **Idempotency key:** `open-pr-codex-agent-bridge-owner-branch-head-primary-20260610-cdaefc9d`
- **Writer objective:** Let agents and operators see a lane owner's branch head even when recorded worktree metadata is stale.
- **Mutation boundary:** Limited to agent_bridge owner head resolution and focused owner-command regression tests.
- **Acceptance criteria:** Open or update a draft PR from codex/agent-bridge-owner-branch-head-primary-20260610 to main.; Apply labels codex and codex-automation.; Bind publication to exact head cdaefc9de4c433a8ca4dcb6f4288487fc8d48944.; Keep the PR scoped to scripts/agent_bridge.py and tests/scripts/test_agent_bridge.py.
- **Writer validation:** {'automation_pr_preflight': 'bash scripts/automation_pr_preflight.sh origin/main HEAD: preflight ok; changed files are scripts/agent_bridge.py and tests/scripts/test_agent_bridge.py.', 'diff_check': 'git diff --check: passed.', 'focused_pytest': "PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/scripts/test_agent_bridge.py -k 'cmd_owner': 9 passed, 54 deselected, 2 existing pytest confi

Draft for CI + worth-triage; settlement via the standard quorum path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)