### PR TITLE
[outbox-harvest] Validated and pushed tmux-map JSON/summary-only dogfood fix; PR creation is blocked by gh auth / connector permissions.

### DIFF
--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -2590,7 +2590,7 @@ def cmd_operator_snapshot(args: argparse.Namespace) -> int:
     return _emit_text("\n".join(lines))
 
 
-def cmd_tmux_map(args: argparse.Namespace) -> int:
+def _collect_tmux_panes() -> tuple[bool, str | None, list[dict[str, str]]]:
     try:
         result = subprocess.run(
             [
@@ -2606,16 +2606,60 @@ def cmd_tmux_map(args: argparse.Namespace) -> int:
             check=False,
         )
         if result.returncode != 0:
-            print("No tmux sessions.")
-            return 0
-        print(f"{'WINDOW':<40} {'PID':<8} COMMAND")
-        print("-" * 65)
+            return False, "No tmux sessions.", []
+        panes: list[dict[str, str]] = []
         for line in result.stdout.strip().splitlines():
             parts = line.strip().split(None, 2)
             if len(parts) >= 3 and TMUX_SESSION in parts[0]:
-                print(f"{parts[0]:<40} {parts[1]:<8} {parts[2]}")
+                panes.append({"window": parts[0], "pid": parts[1], "command": parts[2]})
+        return True, None, panes
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
-        print("tmux not available.")
+        return False, "tmux not available.", []
+
+
+def _tmux_map_summary_payload(payload: dict[str, Any], *, example_limit: int = 3) -> dict[str, Any]:
+    panes = list(payload.get("panes") or [])
+    command_counts: dict[str, int] = {}
+    window_counts: dict[str, int] = {}
+    for pane in panes:
+        command = str(pane.get("command") or "unknown")
+        window = str(pane.get("window") or "unknown")
+        command_counts[command] = command_counts.get(command, 0) + 1
+        window_counts[window] = window_counts.get(window, 0) + 1
+    examples = panes[: max(0, example_limit)]
+    summary = {
+        "ok": bool(payload.get("ok", False)),
+        "pane_count": len(panes),
+        "command_counts": dict(sorted(command_counts.items())),
+        "window_counts": dict(sorted(window_counts.items())),
+        "pane_examples": examples,
+        "panes_omitted": max(0, len(panes) - len(examples)),
+        "details_omitted": True,
+    }
+    if payload.get("error"):
+        summary["error"] = payload["error"]
+    return summary
+
+
+def cmd_tmux_map(args: argparse.Namespace) -> int:
+    ok, error, panes = _collect_tmux_panes()
+    payload: dict[str, Any] = {"ok": ok, "pane_count": len(panes), "panes": panes}
+    if error:
+        payload["error"] = error
+
+    if args.json:
+        if getattr(args, "summary_only", False):
+            payload = _tmux_map_summary_payload(payload)
+        print(json.dumps(payload, indent=2))
+        return 0
+
+    if error:
+        print(error)
+        return 0
+    print(f"{'WINDOW':<40} {'PID':<8} COMMAND")
+    print("-" * 65)
+    for pane in panes:
+        print(f"{pane['window']:<40} {pane['pid']:<8} {pane['command']}")
     return 0
 
 
@@ -2824,7 +2868,12 @@ def main() -> int:
         default=50,
         help="Maximum process records to include when not using --summary-only.",
     )
-    sub.add_parser("tmux-map", parents=[json_parent], help="Show tmux panes")
+    tmux_map_p = sub.add_parser("tmux-map", parents=[json_parent], help="Show tmux panes")
+    tmux_map_p.add_argument(
+        "--summary-only",
+        action="store_true",
+        help="Emit compact tmux pane counts and bounded examples for automation probes.",
+    )
     sub.add_parser(
         "health", parents=[json_parent], help="Check for stale worktrees and lane conflicts"
     ).add_argument(

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -353,6 +353,114 @@ def test_main_accepts_json_after_subcommand(
     assert json.loads(capsys.readouterr().out) == []
 
 
+def test_tmux_map_json_emits_structured_panes(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import agent_bridge as mod
+
+    def fake_run(*_args, **_kwargs):
+        return argparse.Namespace(
+            returncode=0,
+            stdout=(
+                "aragora:codex 12345 codex\nother:ignored 22222 zsh\naragora:factory 67890 droid\n"
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    rc = mod.cmd_tmux_map(argparse.Namespace(json=True, summary_only=False))
+
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out) == {
+        "ok": True,
+        "pane_count": 2,
+        "panes": [
+            {"window": "aragora:codex", "pid": "12345", "command": "codex"},
+            {"window": "aragora:factory", "pid": "67890", "command": "droid"},
+        ],
+    }
+
+
+def test_tmux_map_summary_only_json_omits_full_panes(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import agent_bridge as mod
+
+    def fake_run(*_args, **_kwargs):
+        return argparse.Namespace(
+            returncode=0,
+            stdout=(
+                "aragora:codex 12345 codex\n"
+                "aragora:factory 67890 droid\n"
+                "aragora:review 24680 codex\n"
+                "aragora:queue 13579 python\n"
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    rc = mod.cmd_tmux_map(argparse.Namespace(json=True, summary_only=True))
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert "panes" not in payload
+    assert payload == {
+        "ok": True,
+        "pane_count": 4,
+        "command_counts": {"codex": 2, "droid": 1, "python": 1},
+        "window_counts": {
+            "aragora:codex": 1,
+            "aragora:factory": 1,
+            "aragora:queue": 1,
+            "aragora:review": 1,
+        },
+        "pane_examples": [
+            {"window": "aragora:codex", "pid": "12345", "command": "codex"},
+            {"window": "aragora:factory", "pid": "67890", "command": "droid"},
+            {"window": "aragora:review", "pid": "24680", "command": "codex"},
+        ],
+        "panes_omitted": 1,
+        "details_omitted": True,
+    }
+
+
+def test_main_accepts_tmux_map_summary_only_after_subcommand(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import agent_bridge as mod
+
+    monkeypatch.setattr(
+        mod.subprocess,
+        "run",
+        lambda *_args, **_kwargs: argparse.Namespace(
+            returncode=0,
+            stdout="aragora:codex 12345 codex\n",
+            stderr="",
+        ),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["agent_bridge.py", "tmux-map", "--json", "--summary-only"],
+    )
+
+    assert mod.main() == 0
+    assert json.loads(capsys.readouterr().out) == {
+        "ok": True,
+        "pane_count": 1,
+        "command_counts": {"codex": 1},
+        "window_counts": {"aragora:codex": 1},
+        "pane_examples": [{"window": "aragora:codex", "pid": "12345", "command": "codex"}],
+        "panes_omitted": 0,
+        "details_omitted": True,
+    }
+
+
 def test_operator_snapshot_summary_only_json_omits_records(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Outbox harvest (run-20260610 shift 4)
Published by the gh-authenticated coordinator from `.aragora/automation-outbox` — the writer-lane sandbox validated this branch but could not open the PR (gh unauthenticated; publisher daemon stale since May 18).

- **Branch:** `codex/agent-bridge-tmux-map-summary-only-primary-20260608` @ `554bb6dae26f` (head matches outbox record: True)
- **Idempotency key:** `open-pr-codex-agent-bridge-tmux-map-summary-only-primary-20260608-554bb6da`
- **Writer objective:** Let automation and operator probes inspect tmux pane state without scraping text output or dumping full pane records.
- **Mutation boundary:** Limited to scripts/agent_bridge.py tmux-map handling/parser wiring and tests/scripts/test_agent_bridge.py.
- **Acceptance criteria:** scripts/agent_bridge.py tmux-map --json emits structured JSON with ok, pane_count, panes, and optional error.; scripts/agent_bridge.py tmux-map --json --summary-only emits compact counts and bounded pane examples without a full panes list.; Text output remains compatible with the existing tmux-map table/no-session messages.; Focused agent_bridge tests, Ruff, live JSON smokes, diff checks, merge-tree, push, and automation PR preflight pass.
- **Writer validation:** {'focused_pytest': '/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_agent_bridge.py: 65 passed.', 'ruff_check': '/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/agent_bridge.py tests/scripts/test_agent_bridge.py: All checks passed.', 'ruff_format': '/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/agent_bridge.p

Draft for CI + worth-triage; settlement via the standard quorum path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)