### PR TITLE
[outbox-harvest] Open a draft PR for the Improver Writer agent heartbeat BrokenPipe fix.

### DIFF
--- a/scripts/agent_heartbeat.py
+++ b/scripts/agent_heartbeat.py
@@ -249,5 +249,28 @@ def main(argv: Sequence[str] | None = None) -> int:
     return 0
 
 
+def _coerce_exit_code(code: object) -> int:
+    if code is None:
+        return 0
+    if isinstance(code, int):
+        return code
+    print(code, file=sys.stderr)
+    return 1
+
+
+def _cli_entrypoint() -> int:
+    try:
+        rc = main()
+    except BrokenPipeError:
+        return 0
+    except SystemExit as exc:
+        rc = _coerce_exit_code(exc.code)
+    try:
+        sys.stdout.flush()
+    except BrokenPipeError:
+        os._exit(0)
+    return rc
+
+
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(_cli_entrypoint())

--- a/tests/scripts/test_agent_heartbeat.py
+++ b/tests/scripts/test_agent_heartbeat.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -164,3 +165,18 @@ def test_cli_writes_to_shared_state_root_from_stateless_repo(
     assert json.loads(result.stdout)["lane_id"] == "Q245-primary-agent-heartbeat-shared-state"
     assert payload[0]["owner_session"] == "engineering-autopilot-Q245"
     assert not (repo_root / ".aragora").exists()
+
+
+def test_cli_help_is_pipe_safe_when_downstream_closes() -> None:
+    command = f"{shlex.quote(sys.executable)} {shlex.quote(str(SCRIPT_PATH))} --help | head -5"
+
+    result = subprocess.run(
+        ["bash", "-o", "pipefail", "-c", command],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+    assert result.returncode == 0
+    assert "usage: agent_heartbeat.py" in result.stdout
+    assert "BrokenPipeError" not in result.stderr


### PR DESCRIPTION
## Outbox harvest (run-20260610 shift 4)
Published by the gh-authenticated coordinator from `.aragora/automation-outbox` — the writer-lane sandbox validated this branch but could not open the PR (gh unauthenticated; publisher daemon stale since May 18).

- **Branch:** `codex/agent-heartbeat-help-broken-pipe-improver-20260609` @ `a5d53dcb5ab0` (head matches outbox record: True)
- **Idempotency key:** `open-pr-codex-agent-heartbeat-help-broken-pipe-improver-20260609-a5d53dcb`
- **Writer objective:** Keep the agent heartbeat helper quiet when operators sample help or JSON output through head.
- **Mutation boundary:** Limited to agent heartbeat CLI shutdown pipe handling and focused heartbeat regression tests.
- **Acceptance criteria:** scripts/agent_heartbeat.py --help suppresses BrokenPipeError when downstream output sampling closes early.; Normal JSON heartbeat output remains pipe-safe when sampled with head.; Focused heartbeat tests, Ruff, format check, py_compile, live pipe smokes, diff checks, merge-tree, and automation PR preflight pass at the exact head.
- **Writer validation:** {'source': 'local_evidence.validation', 'summary': 'Current-base branch passed focused heartbeat tests, static checks, live pipe smokes, merge-tree, automation PR preflight, and branch push; PR creation remains blocked by gh auth and connector permissions.'}

Draft for CI + worth-triage; settlement via the standard quorum path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)