### PR TITLE
[outbox-harvest] Backlog audit JSON output now suppresses downstream broken pipes.

### DIFF
--- a/scripts/audit_codex_branch_backlog.py
+++ b/scripts/audit_codex_branch_backlog.py
@@ -1527,6 +1527,25 @@ def summary_only_payload(
     return compact
 
 
+def _mute_stdout_after_broken_pipe() -> None:
+    close = getattr(sys.stdout, "close", None)
+    if callable(close):
+        try:
+            close()
+        except OSError:
+            pass
+    sys.stdout = open(os.devnull, "w", encoding="utf-8")
+
+
+def _emit_output(output: str) -> None:
+    try:
+        sys.stdout.write(output)
+        sys.stdout.write("\n")
+        sys.stdout.flush()
+    except BrokenPipeError:
+        _mute_stdout_after_broken_pipe()
+
+
 def print_markdown(payload: dict[str, Any], *, examples: int) -> None:
     summary = payload["summary"]
     print("# Codex Branch Backlog Audit\n")
@@ -1754,11 +1773,14 @@ def main(argv: list[str] | None = None) -> int:
                 DEFAULT_SUMMARY_EXAMPLES_PER_CATEGORY if args.examples is None else args.examples
             ),
         )
-    if args.markdown:
-        print_markdown(payload, examples=10 if args.examples is None else args.examples)
-    else:
-        # JSON is the default to make automation consumption explicit.
-        print(json.dumps(payload, indent=2 if args.json else None))
+    try:
+        if args.markdown:
+            print_markdown(payload, examples=10 if args.examples is None else args.examples)
+        else:
+            # JSON is the default to make automation consumption explicit.
+            _emit_output(json.dumps(payload, indent=2 if args.json else None))
+    except BrokenPipeError:
+        _mute_stdout_after_broken_pipe()
     return 0
 
 

--- a/tests/scripts/test_audit_codex_branch_backlog.py
+++ b/tests/scripts/test_audit_codex_branch_backlog.py
@@ -317,6 +317,52 @@ def test_main_summary_only_json_honors_examples_flag(
     assert compact["record_examples_limit"] == 0
 
 
+def test_main_suppresses_flush_time_broken_pipe(tmp_path: Path, monkeypatch: Any) -> None:
+    payload = {
+        "branch_count": 0,
+        "summary": {"by_category": {}},
+        "records": [],
+    }
+    monkeypatch.setattr(mod, "repo_root", lambda _path: tmp_path)
+    monkeypatch.setattr(mod, "audit", lambda **_kwargs: payload)
+
+    class FlushBrokenStdout:
+        def __init__(self) -> None:
+            self.writes: list[str] = []
+
+        def write(self, text: str) -> int:
+            self.writes.append(text)
+            return len(text)
+
+        def flush(self) -> None:
+            raise BrokenPipeError("downstream closed")
+
+    stream = FlushBrokenStdout()
+    monkeypatch.setattr(mod.sys, "stdout", stream)
+
+    assert mod.main(["--repo", str(tmp_path), "--json"]) == 0
+    assert stream.writes
+    assert mod.sys.stdout is not stream
+    mod.sys.stdout.close()
+
+
+def test_emit_output_suppresses_write_time_broken_pipe(monkeypatch: Any) -> None:
+    class WriteBrokenStdout:
+        def write(self, text: str) -> int:
+            raise BrokenPipeError("downstream closed")
+
+        def flush(self) -> None:
+            raise AssertionError("flush should not run after write failure")
+
+    stream = WriteBrokenStdout()
+    monkeypatch.setattr(mod.sys, "stdout", stream)
+
+    mod._emit_output("payload")
+
+    assert mod.sys.stdout is not stream
+    mod.sys.stdout.close()
+
+
 def test_print_markdown_includes_revision_metadata(tmp_path: Path, capsys: Any) -> None:
     payload = {
         "repo": str(tmp_path),


### PR DESCRIPTION
## Outbox harvest (run-20260610 shift 4)
Published by the gh-authenticated coordinator from `.aragora/automation-outbox` — the writer-lane sandbox validated this branch but could not open the PR (gh unauthenticated; publisher daemon stale since May 18).

- **Branch:** `codex/audit-backlog-broken-pipe-primary-20260609` @ `c1d685d9f137` (head matches outbox record: True)
- **Idempotency key:** `open-pr-codex-audit-backlog-broken-pipe-primary-20260609-c1d685d9`
- **Writer objective:** Suppress noisy nonzero broken-pipe exits from sampled backlog audit output.
- **Mutation boundary:** Limited to audit_codex_branch_backlog.py output handling and focused regression tests.
- **Acceptance criteria:** Sampling audit_codex_branch_backlog.py JSON output with head exits cleanly without BrokenPipeError.; Write-time and flush-time broken pipe cases are covered by focused regressions.; Focused backlog-auditor tests, Ruff, py_compile, diff checks, merge-tree, push, and automation PR preflight pass.
- **Writer validation:** {'automation_pr_preflight': 'bash scripts/automation_pr_preflight.sh origin/main HEAD: preflight ok; changed files are scripts/audit_codex_branch_backlog.py and tests/scripts/test_audit_codex_branch_backlog.py.', 'diff_check': 'git diff --check origin/main...HEAD and git diff --check: passed.', 'focused_pytest': 'python3 -m pytest tests/scripts/test_audit_codex_branch_backlog.py -q: 63 passed.', '

Draft for CI + worth-triage; settlement via the standard quorum path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)