### PR TITLE
[outbox-harvest] B0 progress metrics now fail closed on malformed boss metrics JSONL rows.

### DIFF
--- a/scripts/measure_b0_progress.py
+++ b/scripts/measure_b0_progress.py
@@ -67,16 +67,19 @@ class IssueAggregate:
 def load_metrics_rows(metrics_file: Path) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
     with metrics_file.open(encoding="utf-8", errors="replace") as fh:
-        for line in fh:
-            line = line.strip()
-            if not line:
+        for line_number, line in enumerate(fh, start=1):
+            raw = line.strip()
+            if not raw:
                 continue
             try:
-                payload = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            if isinstance(payload, dict):
-                rows.append(payload)
+                payload = json.loads(raw)
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"malformed JSONL row at {metrics_file}:{line_number}: {exc.msg}"
+                ) from exc
+            if not isinstance(payload, dict):
+                raise ValueError(f"JSONL row at {metrics_file}:{line_number} must be an object")
+            rows.append(payload)
     return rows
 
 

--- a/tests/scripts/test_measure_b0_progress.py
+++ b/tests/scripts/test_measure_b0_progress.py
@@ -4,6 +4,8 @@ import json
 from datetime import datetime, timezone
 from pathlib import Path
 
+import pytest
+
 from scripts.measure_b0_progress import (
     is_b0_cohort_row,
     load_metrics_rows,
@@ -17,6 +19,30 @@ from scripts.rotate_boss_metrics import archive_path_for, rotate_metrics_file
 FIXTURE_PATH = (
     Path(__file__).resolve().parent.parent / "fixtures" / "b0_metrics" / "mixed_metrics.jsonl"
 )
+
+
+def test_load_metrics_rows_rejects_malformed_jsonl_row(tmp_path: Path) -> None:
+    metrics_path = tmp_path / "boss_metrics.jsonl"
+    metrics_path.write_text(
+        "\n".join(
+            [
+                json.dumps({"issue_number": 101, "terminal_class": "deliverable_pr_created"}),
+                "{not json}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=r"malformed JSONL row at .*boss_metrics\.jsonl:2"):
+        load_metrics_rows(metrics_path)
+
+
+def test_load_metrics_rows_rejects_non_object_jsonl_row(tmp_path: Path) -> None:
+    metrics_path = tmp_path / "boss_metrics.jsonl"
+    metrics_path.write_text(json.dumps([{"issue_number": 101}]), encoding="utf-8")
+
+    with pytest.raises(ValueError, match=r"JSONL row at .*boss_metrics\.jsonl:1 must be an object"):
+        load_metrics_rows(metrics_path)
 
 
 def test_measure_b0_progress_cohorts_and_unique_issue_aggregation() -> None:


### PR DESCRIPTION
## Outbox harvest (run-20260610 shift 4)
Published by the gh-authenticated coordinator from `.aragora/automation-outbox` — the writer-lane sandbox validated this branch but could not open the PR (gh unauthenticated; publisher daemon stale since May 18).

- **Branch:** `codex/b0-progress-jsonl-parse-guard-primary-r2-20260610` @ `6a5b3a43b83f` (head matches outbox record: True)
- **Idempotency key:** `open-pr-codex-b0-progress-jsonl-parse-guard-primary-r2-20260610-6a5b3a43`
- **Writer objective:** Prevent B0 progress reporting from silently ignoring malformed boss metrics JSONL rows.
- **Mutation boundary:** Restacked only the two-file source diff onto current origin/main because the source branch commit was already pushed and lacked the automation co-author trailer; no pushed commit was amended.
- **Acceptance criteria:** B0 progress metrics loading rejects malformed JSONL rows instead of silently skipping corrupt input.; B0 progress metrics loading rejects non-object JSONL rows before cohort aggregation.; Focused tests, static checks, direct malformed-row smoke, diff checks, merge-tree, push hooks, and automation PR preflight pass at the exact head.
- **Writer validation:** {'source': 'local_evidence.validation', 'summary': 'Current-base branch passed focused tests, static checks, malformed-row smoke, merge-tree, push hooks, and automation PR preflight; publication remains blocked by gh authentication.'}

Draft for CI + worth-triage; settlement via the standard quorum path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)