### PR TITLE
[outbox-harvest] B0 scorecard reporting now rejects invalid benchmark rate fields instead of rendering them as valid outputs.

### DIFF
--- a/scripts/reporting.py
+++ b/scripts/reporting.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -19,10 +20,20 @@ def _pct(summary: dict[str, Any], key: str) -> float:
     >>> _pct({"rate": "0.4"}, "rate")
     0.4
     """
-    try:
-        return float(summary.get(key, 0.0) or 0.0)
-    except (TypeError, ValueError):
+    raw_value = summary.get(key, 0.0)
+    if raw_value in (None, ""):
         return 0.0
+    if isinstance(raw_value, bool):
+        raise ValueError(f"benchmark report field `{key}` must be a numeric rate")
+    try:
+        value = float(raw_value)
+    except (TypeError, ValueError):
+        raise ValueError(f"benchmark report field `{key}` must be a numeric rate") from None
+    if not math.isfinite(value):
+        raise ValueError(f"benchmark report field `{key}` must be finite")
+    if value < 0.0 or value > 1.0:
+        raise ValueError(f"benchmark report field `{key}` must be between 0.0 and 1.0")
+    return value
 
 
 def _int(summary: dict[str, Any], key: str) -> int:

--- a/tests/scripts/test_reporting.py
+++ b/tests/scripts/test_reporting.py
@@ -4,6 +4,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 _scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
 if _scripts_dir not in sys.path:
     sys.path.insert(0, _scripts_dir)
@@ -87,3 +89,41 @@ def test_build_scorecard_reads_published_truth_artifact_payload(
     assert run["no_rescue_truth_success_rate"] == 0.8
     assert run["merged_issue_rate"] == 0.6
     assert run["rescue_count"] == 1
+
+
+def test_build_scorecard_rejects_non_finite_rate_values(tmp_path: Path) -> None:
+    corpus_path = _write_corpus(tmp_path / "corpus.json")
+    report_path = _write_json(
+        tmp_path / "truth-artifact.json",
+        {
+            "generated_at": "2026-04-15T23:05:32Z",
+            "coverage": {"attempted_issue_count": 1},
+            "primary_metrics": {
+                "truth_success_rate": "NaN",
+                "no_rescue_truth_success_rate": 0.5,
+                "merged_only_rate": 0.5,
+            },
+        },
+    )
+
+    with pytest.raises(ValueError, match="truth_success_rate.*finite"):
+        mod.build_scorecard([report_path], corpus_path=corpus_path)
+
+
+def test_build_scorecard_rejects_out_of_range_rate_values(tmp_path: Path) -> None:
+    corpus_path = _write_corpus(tmp_path / "corpus.json")
+    report_path = _write_json(
+        tmp_path / "truth-artifact.json",
+        {
+            "generated_at": "2026-04-15T23:05:32Z",
+            "coverage": {"attempted_issue_count": 1},
+            "primary_metrics": {
+                "truth_success_rate": 0.75,
+                "no_rescue_truth_success_rate": 1.2,
+                "merged_only_rate": 0.5,
+            },
+        },
+    )
+
+    with pytest.raises(ValueError, match="no_rescue_truth_success_rate.*between 0.0 and 1.0"):
+        mod.build_scorecard([report_path], corpus_path=corpus_path)


### PR DESCRIPTION
## Outbox harvest (run-20260610 shift 4)
Published by the gh-authenticated coordinator from `.aragora/automation-outbox` — the writer-lane sandbox validated this branch but could not open the PR (gh unauthenticated; publisher daemon stale since May 18).

- **Branch:** `codex/b0-reporting-rate-guards-primary-r2-20260610` @ `c0dabf9fec2a` (head matches outbox record: True)
- **Idempotency key:** `open-pr-codex-b0-reporting-rate-guards-primary-r2-20260610-c0dabf9f`
- **Writer objective:** Prevent B0 scorecard reporting from silently accepting non-finite, nonnumeric, or out-of-range benchmark rate fields.
- **Mutation boundary:** Restacked only the two-file source commit onto current origin/main because the source branch had unrelated base drift; no pushed commit was amended.
- **Acceptance criteria:** B0 scorecard report inputs reject non-finite rate fields instead of rendering NaN as a valid percentage.; B0 scorecard report inputs reject out-of-range rate fields instead of accepting values outside 0.0..1.0.; Focused tests, static checks, direct malformed-rate smoke, diff checks, merge-tree, push hooks, and automation PR preflight pass at the exact head.
- **Writer validation:** {'source': 'local_evidence.validation', 'summary': 'Current-base branch passed focused tests, static checks, malformed-rate smoke, merge-tree, push hooks, and automation PR preflight; publication remains blocked by gh authentication.'}

Draft for CI + worth-triage; settlement via the standard quorum path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)