### PR TITLE
[outbox-harvest] summary-only branch backlog audits now include one compact record example per category by default.

### DIFF
--- a/scripts/audit_codex_branch_backlog.py
+++ b/scripts/audit_codex_branch_backlog.py
@@ -73,7 +73,7 @@ COMPACT_RECORD_EXAMPLE_FIELDS = (
     "handoff_receipt_exists",
     "handoff_outbox_exists",
 )
-DEFAULT_SUMMARY_EXAMPLES_PER_CATEGORY = 0
+DEFAULT_SUMMARY_EXAMPLES_PER_CATEGORY = 1
 DIVERGENCE_REF_BATCH_SIZE = 200
 
 
@@ -1712,7 +1712,10 @@ def build_parser() -> argparse.ArgumentParser:
         "--examples",
         type=int,
         default=None,
-        help="Examples per Markdown category or summary-only JSON category",
+        help=(
+            "Examples per Markdown category or summary-only JSON category "
+            f"(default: {DEFAULT_SUMMARY_EXAMPLES_PER_CATEGORY} for summary-only JSON)"
+        ),
     )
     return parser
 

--- a/tests/scripts/test_audit_codex_branch_backlog.py
+++ b/tests/scripts/test_audit_codex_branch_backlog.py
@@ -158,7 +158,7 @@ def test_summary_only_payload_omits_records_without_mutating_source() -> None:
     assert compact["records"] == []
     assert compact["records_omitted"] is True
     assert compact["record_examples"] == {}
-    assert compact["record_examples_limit"] == 0
+    assert compact["record_examples_limit"] == 1
     assert payload["records"] == [{"name": "codex/one"}, {"name": "codex/two"}]
 
 
@@ -315,6 +315,54 @@ def test_main_summary_only_json_honors_examples_flag(
     assert compact["records"] == []
     assert compact["record_examples"] == {}
     assert compact["record_examples_limit"] == 0
+
+
+def test_main_summary_only_json_defaults_to_one_category_example(
+    tmp_path: Path, monkeypatch: Any, capsys: Any
+) -> None:
+    payload = {
+        "branch_count": 2,
+        "summary": {"by_category": {"salvage_recent_unique": 2}},
+        "records": [
+            {
+                "name": "codex/salvage-one",
+                "category": "salvage_recent_unique",
+                "head_sha": "1111111",
+                "committed_at": "2026-05-06T00:00:00+00:00",
+                "subject": "first salvage",
+                "ahead_count": 1,
+                "behind_count": 0,
+            },
+            {
+                "name": "codex/salvage-two",
+                "category": "salvage_recent_unique",
+                "head_sha": "2222222",
+                "committed_at": "2026-05-06T00:01:00+00:00",
+                "subject": "second salvage",
+                "ahead_count": 1,
+                "behind_count": 0,
+            },
+        ],
+    }
+    monkeypatch.setattr(mod, "repo_root", lambda _path: tmp_path)
+    monkeypatch.setattr(mod, "audit", lambda **_kwargs: payload)
+
+    assert mod.main(["--repo", str(tmp_path), "--json", "--summary-only"]) == 0
+    compact = json.loads(capsys.readouterr().out)
+
+    assert compact["records"] == []
+    assert compact["record_examples_limit"] == 1
+    assert compact["record_examples"]["salvage_recent_unique"] == [
+        {
+            "name": "codex/salvage-one",
+            "category": "salvage_recent_unique",
+            "head_sha": "1111111",
+            "committed_at": "2026-05-06T00:00:00+00:00",
+            "subject": "first salvage",
+            "ahead_count": 1,
+            "behind_count": 0,
+        }
+    ]
 
 
 def test_print_markdown_includes_revision_metadata(tmp_path: Path, capsys: Any) -> None:


### PR DESCRIPTION
## Outbox harvest (run-20260610 shift 4)
Published by the gh-authenticated coordinator from `.aragora/automation-outbox` — the writer-lane sandbox validated this branch but could not open the PR (gh unauthenticated; publisher daemon stale since May 18).

- **Branch:** `codex/backlog-summary-default-examples-primary-20260610` @ `4b371cd69324` (head matches outbox record: True)
- **Idempotency key:** `open-pr-codex-backlog-summary-default-examples-primary-20260610-4b371cd6`
- **Writer objective:** Make compact branch-backlog audits useful for automation lane selection by including one compact record example per category by default.
- **Mutation boundary:** Limited to the backlog audit summary-only example default and focused tests for default and explicit --examples 0 behavior.
- **Acceptance criteria:** Open or update a draft PR from codex/backlog-summary-default-examples-primary-20260610 to main.; Apply labels codex and codex-automation.; Bind publication to exact head 4b371cd69324d66abe5dca61aab2403df06e8caa.; Keep the PR scoped to scripts/audit_codex_branch_backlog.py and tests/scripts/test_audit_codex_branch_backlog.py.
- **Writer validation:** {'automation_pr_preflight': 'bash scripts/automation_pr_preflight.sh origin/main HEAD: preflight ok; changed files are scripts/audit_codex_branch_backlog.py and tests/scripts/test_audit_codex_branch_backlog.py.', 'diff_check': 'git diff --check origin/main...HEAD and git diff --check: passed.', 'focused_pytest': 'PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/scripts/test_audit_codex_bra

Draft for CI + worth-triage; settlement via the standard quorum path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)