### PR TITLE
[outbox-harvest] Boss metrics health scorecards now reject invalid top-N and stale-loop thresholds.

### DIFF
--- a/scripts/boss_metrics_health.py
+++ b/scripts/boss_metrics_health.py
@@ -75,8 +75,15 @@ def _valid_issue_number(value: Any) -> bool:
     return isinstance(value, int) and not isinstance(value, bool) and value > 0
 
 
+def _positive_int(value: int, *, field: str) -> int:
+    if value <= 0:
+        raise ValueError(f"{field} must be a positive integer")
+    return value
+
+
 def top_issues_by_skip_count(rows: list[dict[str, Any]], top_n: int = 20) -> list[dict[str, Any]]:
     """Return the top-N issues ranked by skip-row count."""
+    top_n = _positive_int(top_n, field="top_n")
     counter: Counter[int] = Counter()
     for row in rows:
         if not _row_is_skip(row):
@@ -129,6 +136,7 @@ def detect_stale_loops(rows: list[dict[str, Any]], min_skip_rows: int = 10) -> l
     operator can join this list with ``aragora/swarm/unstick.py``
     output.
     """
+    min_skip_rows = _positive_int(min_skip_rows, field="min_skip_rows")
     counter: Counter[int] = Counter()
     for row in rows:
         if not _row_is_skip(row):
@@ -152,6 +160,8 @@ def render_scorecard(
     stale_threshold: int = 10,
 ) -> dict[str, Any]:
     """Compute the full scorecard payload."""
+    top_n = _positive_int(top_n, field="top_n")
+    stale_threshold = _positive_int(stale_threshold, field="stale_threshold")
     return {
         "total_rows": len(rows),
         "skip_rows": sum(1 for row in rows if _row_is_skip(row)),
@@ -239,7 +249,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default="json",
         help="Output format (default: json)",
     )
-    return parser.parse_args(argv)
+    args = parser.parse_args(argv)
+    if args.top_n <= 0:
+        parser.error("--top-n must be a positive integer")
+    if args.stale_threshold <= 0:
+        parser.error("--stale-threshold must be a positive integer")
+    return args
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/scripts/test_boss_metrics_health.py
+++ b/tests/scripts/test_boss_metrics_health.py
@@ -106,6 +106,13 @@ def test_top_issues_respects_top_n_limit() -> None:
     assert len(out) == 3
 
 
+def test_top_issues_rejects_non_positive_top_n() -> None:
+    rows = [{"issue_number": 1, "terminal_class": "blocked_auth_failure"}]
+
+    with pytest.raises(ValueError, match="top_n must be a positive integer"):
+        mod.top_issues_by_skip_count(rows, top_n=0)
+
+
 def test_aggregate_skip_reasons_prefers_dispatch_skip_reason() -> None:
     rows = [
         {"dispatch_skip_reason": "no_work_orders"},
@@ -145,6 +152,13 @@ def test_detect_stale_loops_threshold() -> None:
     assert out[0]["skip_count"] == 12
 
 
+def test_detect_stale_loops_rejects_non_positive_threshold() -> None:
+    rows = [{"issue_number": 1, "terminal_class": "blocked_auth_failure"}]
+
+    with pytest.raises(ValueError, match="min_skip_rows must be a positive integer"):
+        mod.detect_stale_loops(rows, min_skip_rows=0)
+
+
 def test_detect_stale_loops_empty_when_no_skip_rows() -> None:
     rows = [{"issue_number": 1, "terminal_class": "deliverable_pr_created"}] * 20
     assert mod.detect_stale_loops(rows, min_skip_rows=10) == []
@@ -166,6 +180,15 @@ def test_render_scorecard_shape() -> None:
     assert "top_issues_by_skip_count" in out
     assert out["stale_threshold"] == 2
     assert "stale_loops" in out
+
+
+def test_render_scorecard_rejects_non_positive_threshold_controls() -> None:
+    rows = [{"issue_number": 1, "terminal_class": "blocked_auth_failure"}]
+
+    with pytest.raises(ValueError, match="top_n must be a positive integer"):
+        mod.render_scorecard(rows, top_n=0, stale_threshold=1)
+    with pytest.raises(ValueError, match="stale_threshold must be a positive integer"):
+        mod.render_scorecard(rows, top_n=1, stale_threshold=0)
 
 
 def test_render_markdown_includes_all_sections() -> None:
@@ -220,3 +243,12 @@ def test_main_markdown_output(tmp_path: Path, capsys: pytest.CaptureFixture[str]
     out = capsys.readouterr().out
     assert rc == 0
     assert "boss-loop metrics health scorecard" in out
+
+
+def test_main_rejects_non_positive_cli_controls(tmp_path: Path) -> None:
+    p = _write(tmp_path, [{"issue_number": 1, "terminal_class": "blocked_auth_failure"}])
+
+    with pytest.raises(SystemExit):
+        mod.main(["--metrics", str(p), "--top-n", "0"])
+    with pytest.raises(SystemExit):
+        mod.main(["--metrics", str(p), "--stale-threshold", "0"])


### PR DESCRIPTION
## Outbox harvest (run-20260610 shift 4)
Published by the gh-authenticated coordinator from `.aragora/automation-outbox` — the writer-lane sandbox validated this branch but could not open the PR (gh unauthenticated; publisher daemon stale since May 18).

- **Branch:** `codex/boss-metrics-health-threshold-guards-primary-r2-20260609` @ `7c7bfaa8733c` (head matches outbox record: True)
- **Idempotency key:** `open-pr-codex-boss-metrics-health-threshold-guards-primary-r2-20260609-7c7bfaa8`
- **Writer objective:** Prevent boss metrics health reports from accepting invalid top issue and stale-loop threshold controls.
- **Mutation boundary:** Limited to boss_metrics_health positive threshold validation and focused regression tests; stale-base review_queue and proof-first-shift diffs from the source branch were intentionally not carried forward.
- **Acceptance criteria:** Boss metrics health helpers reject non-positive top issue limits and stale-loop thresholds before rendering scorecards.; The CLI rejects --top-n 0 and --stale-threshold 0 with clear argparse errors.; Focused boss metrics tests, static checks, diff checks, merge-tree, push, and automation PR preflight pass at the exact head.
- **Writer validation:** {'source': 'local_evidence.validation', 'summary': 'Current-base branch passed focused tests, static checks, invalid-control smokes, merge-tree, push hooks, and automation PR preflight; publication remains blocked by gh authentication.'}

Draft for CI + worth-triage; settlement via the standard quorum path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)