### PR TITLE
[outbox-harvest] Prompt builder live-truth instructions now use canonical agent_bridge health JSON ordering.

### DIFF
--- a/scripts/build_next_prompt.py
+++ b/scripts/build_next_prompt.py
@@ -1453,7 +1453,7 @@ def build_prompt(
         "",
         "Run read-only live truth first:",
         "git status --short --branch --untracked-files=all",
-        "python3 scripts/agent_bridge.py --json health || true",
+        "python3 scripts/agent_bridge.py health --json || true",
         "python3 scripts/agent_bridge.py operator-snapshot --json --summary-only || true",
         "python3 scripts/list_active_agent_sessions.py --json --codex-session-scan-limit 120",
     ]

--- a/tests/scripts/test_build_next_prompt.py
+++ b/tests/scripts/test_build_next_prompt.py
@@ -114,6 +114,8 @@ def test_prompt_starts_with_mailbox_and_owner_verification(tmp_path: Path) -> No
 
     assert prompt.startswith("Start from live repo truth")
     assert "Before lane work, check your Aragora operator-steering mailbox" in prompt
+    assert "python3 scripts/agent_bridge.py health --json || true" in prompt
+    assert "python3 scripts/agent_bridge.py --json health || true" not in prompt
     assert (
         "python3 scripts/read_operator_steering.py --lane-id P106-merge-gate-settlement" in prompt
     )


### PR DESCRIPTION
## Outbox harvest (run-20260610 shift 4)
Published by the gh-authenticated coordinator from `.aragora/automation-outbox` — the writer-lane sandbox validated this branch but could not open the PR (gh unauthenticated; publisher daemon stale since May 18).

- **Branch:** `codex/build-next-prompt-health-json-order-primary-r2-20260609` @ `960111fb8dbf` (head matches outbox record: True)
- **Idempotency key:** `open-pr-codex-build-next-prompt-health-json-order-primary-r2-20260609-960111fb`
- **Writer objective:** Align generated next prompts with the canonical agent_bridge health JSON command ordering.
- **Mutation boundary:** Limited to build_next_prompt.py live-truth command text and focused prompt-builder regression tests.
- **Acceptance criteria:** Generated next prompts use `python3 scripts/agent_bridge.py health --json || true` in the read-only live-truth block.; Generated next prompts do not regress to the stale `python3 scripts/agent_bridge.py --json health || true` ordering.; Focused prompt-builder tests, static checks, merge-tree, push, and automation PR preflight pass at the exact head.
- **Writer validation:** {'automation_pr_preflight': 'bash scripts/automation_pr_preflight.sh origin/main HEAD: preflight ok; changed files are scripts/build_next_prompt.py and tests/scripts/test_build_next_prompt.py.', 'diff_check': 'git diff --check origin/main...HEAD and git diff --check: passed.', 'focused_pytest': 'PYTHONDONTWRITEBYTECODE=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/armand/.pyenv/versions/3.11.11/bin/py

Draft for CI + worth-triage; settlement via the standard quorum path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)