### PR TITLE
[outbox-harvest] Dogfood A/B pair-count guard branch is validated and ready for draft PR publication.

### DIFF
--- a/scripts/run_dogfood_ab_pairs.py
+++ b/scripts/run_dogfood_ab_pairs.py
@@ -345,6 +345,16 @@ def _score_pair(
     return json.loads(summary_json.read_text(encoding="utf-8"))
 
 
+def _positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be an integer") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -355,7 +365,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--pairs",
-        type=int,
+        type=_positive_int,
         default=5,
         help="Number of control/focused pairs to run (default: 5).",
     )

--- a/tests/scripts/test_run_dogfood_ab_pairs.py
+++ b/tests/scripts/test_run_dogfood_ab_pairs.py
@@ -1,0 +1,39 @@
+"""Tests for scripts/run_dogfood_ab_pairs.py benchmark input validation."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
+if _scripts_dir not in sys.path:
+    sys.path.insert(0, _scripts_dir)
+
+import run_dogfood_ab_pairs  # noqa: E402
+
+
+def test_parse_args_accepts_positive_pair_count() -> None:
+    args = run_dogfood_ab_pairs.parse_args(["--pairs", "1"])
+
+    assert args.pairs == 1
+
+
+def test_main_rejects_zero_pairs_before_writing_output(tmp_path: Path) -> None:
+    output_root = tmp_path / "dogfood-ab-output"
+
+    with pytest.raises(SystemExit):
+        run_dogfood_ab_pairs.main(["--pairs", "0", "--output-root", str(output_root)])
+
+    assert not output_root.exists()
+
+
+def test_main_rejects_negative_pairs_before_writing_output(tmp_path: Path) -> None:
+    output_root = tmp_path / "dogfood-ab-output"
+
+    with pytest.raises(SystemExit):
+        run_dogfood_ab_pairs.main(["--pairs", "-2", "--output-root", str(output_root)])
+
+    assert not output_root.exists()


### PR DESCRIPTION
## Outbox harvest (run-20260610 shift 4)
Published by the gh-authenticated coordinator from `.aragora/automation-outbox` — the writer-lane sandbox validated this branch but could not open the PR (gh unauthenticated; publisher daemon stale since May 18).

- **Branch:** `codex/dogfood-ab-reject-empty-pairs-primary-r2-20260609` @ `55842cc9e137` (head matches outbox record: True)
- **Idempotency key:** `open-pr-codex-dogfood-ab-reject-empty-pairs-primary-r2-20260609-55842cc9`
- **Writer objective:** Open the validated dogfood A/B pair-count guard branch as a draft PR.
- **Mutation boundary:** No source edits beyond replaying the existing one-commit dogfood A/B pair-count guard into a writable Primary branch from current origin/main.
- **Acceptance criteria:** Dogfood A/B benchmark rejects zero or negative pair counts before running or writing aggregate artifacts.; Focused regressions cover positive, zero, and negative --pairs values.; Focused pytest, Ruff, format check, diff checks, merge-tree, pre-push hooks, and automation PR preflight pass at the exact head.
- **Writer validation:** {'automation_pr_preflight': 'bash scripts/automation_pr_preflight.sh origin/main HEAD: preflight ok; changed files are scripts/run_dogfood_ab_pairs.py and tests/scripts/test_run_dogfood_ab_pairs.py.', 'default_runtime_note': 'Default python3 plugin-disabled pytest could not load repo deps in this sandbox (ModuleNotFoundError: pydantic_settings); default plugin-autoload pytest was unreachable after

Draft for CI + worth-triage; settlement via the standard quorum path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)