### PR TITLE
[outbox-harvest] Dogfood report malformed-run guard branch is validated and ready for draft PR publication.

### DIFF
--- a/scripts/reclassify_dogfood_report.py
+++ b/scripts/reclassify_dogfood_report.py
@@ -23,12 +23,15 @@ def reclassify_report(data: dict[str, Any]) -> dict[str, Any]:
     runs = data.get("runs")
     if not isinstance(runs, list):
         raise ValueError("Report must contain runs list.")
+    if not runs:
+        raise ValueError("Report runs list must contain at least one run.")
+    for index, run in enumerate(runs):
+        if not isinstance(run, dict):
+            raise ValueError(f"Report runs[{index}] must be an object.")
 
     warning_only_runs = 0
     blocker_runs = 0
     for run in runs:
-        if not isinstance(run, dict):
-            continue
         stderr_excerpt = str(run.get("stderr_excerpt") or "")
         classified = classify_stderr_signals(stderr_excerpt)
         run["runtime_blockers"] = classified["runtime_blockers"]

--- a/tests/scripts/test_reclassify_dogfood_report.py
+++ b/tests/scripts/test_reclassify_dogfood_report.py
@@ -1,0 +1,51 @@
+"""Tests for scripts/reclassify_dogfood_report.py report-shape guards."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
+if _scripts_dir not in sys.path:
+    sys.path.insert(0, _scripts_dir)
+
+import reclassify_dogfood_report  # noqa: E402
+
+
+def test_reclassify_report_rejects_empty_runs() -> None:
+    with pytest.raises(ValueError, match="at least one run"):
+        reclassify_dogfood_report.reclassify_report({"runs": []})
+
+
+def test_reclassify_report_rejects_non_object_run_before_mutation() -> None:
+    report = {"runs": ["not-a-run"]}
+
+    with pytest.raises(ValueError, match=r"runs\[0\] must be an object"):
+        reclassify_dogfood_report.reclassify_report(report)
+
+    assert report == {"runs": ["not-a-run"]}
+
+
+def test_reclassify_report_counts_warning_only_and_blocker_runs() -> None:
+    report = {
+        "runs": [
+            {
+                "stderr_excerpt": (
+                    "ResourceWarning: unclosed transport\n"
+                    "ResourceWarning: Enable tracemalloc to get the object allocation traceback"
+                )
+            },
+            {"stderr_excerpt": "Debate timed out after 120s"},
+        ]
+    }
+
+    updated = reclassify_dogfood_report.reclassify_report(report)
+
+    assert updated["runtime_blockers_zero"] is False
+    assert updated["warning_only_runs"] == 1
+    assert updated["blocker_runs"] == 1
+    assert updated["runs"][0]["warning_only"] is True
+    assert "debate_timeout" in updated["runs"][1]["runtime_blockers"]


### PR DESCRIPTION
## Outbox harvest (run-20260610 shift 4)
Published by the gh-authenticated coordinator from `.aragora/automation-outbox` — the writer-lane sandbox validated this branch but could not open the PR (gh unauthenticated; publisher daemon stale since May 18).

- **Branch:** `codex/dogfood-report-malformed-runs-primary-r2-20260609` @ `1aa64f4318be` (head matches outbox record: True)
- **Idempotency key:** `open-pr-codex-dogfood-report-malformed-runs-primary-r2-20260609-1aa64f43`
- **Writer objective:** Open the validated dogfood report malformed-run guard branch as a draft PR.
- **Mutation boundary:** No source edits beyond replaying the existing one-commit dogfood report validation patch into a writable Primary branch from current origin/main.
- **Acceptance criteria:** Dogfood report reclassification rejects missing, empty, or non-object runs instead of producing a clean-looking zero-blocker summary.; Focused regression covers empty runs, non-object runs, and normal warning/blocker count preservation.; Focused pytest, Ruff, format check, diff checks, merge-tree, pre-push hooks, and automation PR preflight pass at the exact head.
- **Writer validation:** {'automation_pr_preflight': 'bash scripts/automation_pr_preflight.sh origin/main HEAD: preflight ok; changed files are scripts/reclassify_dogfood_report.py and tests/scripts/test_reclassify_dogfood_report.py.', 'diff_check': 'git diff --check origin/main HEAD: passed.', 'focused_pytest': 'python3 -m pytest -q tests/scripts/test_reclassify_dogfood_report.py: 3 passed in 0.54s; /Users/armand/.pyenv/

Draft for CI + worth-triage; settlement via the standard quorum path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)