### PR TITLE
[outbox-harvest] review-queue evidence lint now rejects wrong-PR and negative evidence.

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3524,7 +3524,7 @@ def _proposed_evidence_pr_grounding(body: str, pr: str) -> tuple[bool, str]:
     cited = {
         match.group(1)
         for match in re.finditer(
-            r"\b(?:PR|pull\s+request)\s*[:#]?\s*#?(\d+)\b",
+            r"\b(?:PR(?:\s+Number)?|pull\s+request)\s*[:#-]?\s*#?(\d+)\b",
             str(body or ""),
             flags=re.IGNORECASE,
         )
@@ -3654,11 +3654,13 @@ def _has_blocking_or_negative_verdict(body: str) -> bool:
         # and "> **Verdict:** FAIL" still expose the label.
         line = line.lstrip("#>-* ").strip()
         line = line.replace("**", "")
-        label, sep, value = line.partition(":")
-        if not sep:
+        match = re.match(r"^(?P<label>[^:—–-]+?)\s*(?::|—|–|-)\s*(?P<value>.*)$", line)
+        if not match:
             continue
-        normalized_label = re.sub(r"\s+", " ", label.strip().lower())
-        normalized_value = re.sub(r"\s+", " ", value.strip().strip("*").strip().lower())
+        normalized_label = re.sub(r"\s+", " ", match.group("label").strip().lower())
+        normalized_value = re.sub(
+            r"\s+", " ", match.group("value").strip().strip("*").strip().lower()
+        )
         if normalized_label in {"verdict", "decision", "recommendation"} and _starts_with_phrase(
             normalized_value, negative_verdict_prefixes
         ):

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3677,11 +3677,24 @@ def _has_blocking_or_negative_verdict(body: str) -> bool:
             return True
         if normalized_label in {"blocking finding", "blocking findings", "blocker", "blockers"}:
             candidate = re.sub(r"^(?:[-*+]\s+|\d+[.)]\s+)", "", normalized_value)
-            if candidate in {"", "-", "*", "[]", "[ ]"}:
+            if candidate in {"-", "*", "[]", "[ ]", "—", "–"}:
+                # An inline empty marker ("Blockers: []", "Blockers: -") is an
+                # explicit "no blockers"; never read the next line as a blocker.
+                continue
+            if not candidate:
                 # The blockers may be listed on the following lines:
                 # "Blocking findings:\n- crash on startup" must stay blocking,
                 # while "Blockers:\nNone found." must stay countable.
                 follow = next((entry for entry in lines[idx + 1 :] if entry), "")
+                is_list_item = bool(re.match(r"^(?:[-*+]\s+|\d+[.)]\s+)", follow))
+                if not is_list_item:
+                    if follow.startswith("#"):
+                        # An empty blockers section followed by a heading.
+                        continue
+                    if re.match(r"^[^:]+?:\s+\S", follow):
+                        # An empty blockers section followed by a new labeled
+                        # section ("Verdict: PASS") is not a blocker entry.
+                        continue
                 candidate = _normalize_value(_strip_decoration(follow))
             if not candidate or _starts_with_phrase(candidate, non_blocking_prefixes):
                 continue

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3616,6 +3616,8 @@ def _has_blocking_or_negative_verdict(body: str) -> bool:
         "fail",
         "failed",
         "failing",
+        "fails",
+        "failure",
         "block",
         "blocked",
         "blocking",
@@ -3635,6 +3637,8 @@ def _has_blocking_or_negative_verdict(body: str) -> bool:
         "no blocking findings",
         "not found",
         "0",
+        "zero",
+        "false",
         "n/a",
         "not applicable",
         "[]",
@@ -3646,27 +3650,40 @@ def _has_blocking_or_negative_verdict(body: str) -> bool:
         # "block" must never cover "blockchain".
         return any(re.match(rf"{re.escape(phrase)}(?!\w)", value) for phrase in phrases)
 
-    for raw_line in str(body or "").splitlines():
-        line = raw_line.strip()
-        if not line:
+    def _strip_decoration(text: str) -> str:
+        # Markdown list/heading/quote decoration and numbered-list markers:
+        # "### Verdict", "1. Verdict", "> **Verdict**" all expose the label.
+        return re.sub(r"^(?:[#>\-*+\s]+|\d+[.)]\s+)+", "", text.strip())
+
+    def _normalize_value(text: str) -> str:
+        text = text.replace("**", "").replace("__", "")
+        return re.sub(r"\s+", " ", text.strip().strip("*_").strip().lower())
+
+    lines = [raw_line.strip() for raw_line in str(body or "").splitlines()]
+    for idx, stripped in enumerate(lines):
+        if not stripped:
             continue
-        # Strip markdown list/heading/quote decoration so "### Verdict: FAIL"
-        # and "> **Verdict:** FAIL" still expose the label.
-        line = line.lstrip("#>-* ").strip()
-        line = line.replace("**", "")
+        line = _strip_decoration(stripped)
+        line = line.replace("**", "").replace("__", "")
         match = re.match(r"^(?P<label>[^:—–-]+?)\s*(?::|—|–|-)\s*(?P<value>.*)$", line)
         if not match:
             continue
         normalized_label = re.sub(r"\s+", " ", match.group("label").strip().lower())
-        normalized_value = re.sub(
-            r"\s+", " ", match.group("value").strip().strip("*").strip().lower()
-        )
+        normalized_label = normalized_label.strip("*_ ")
+        normalized_value = _normalize_value(match.group("value"))
         if normalized_label in {"verdict", "decision", "recommendation"} and _starts_with_phrase(
             normalized_value, negative_verdict_prefixes
         ):
             return True
         if normalized_label in {"blocking finding", "blocking findings", "blocker", "blockers"}:
-            if not normalized_value or _starts_with_phrase(normalized_value, non_blocking_prefixes):
+            candidate = re.sub(r"^(?:[-*+]\s+|\d+[.)]\s+)", "", normalized_value)
+            if candidate in {"", "-", "*", "[]", "[ ]"}:
+                # The blockers may be listed on the following lines:
+                # "Blocking findings:\n- crash on startup" must stay blocking,
+                # while "Blockers:\nNone found." must stay countable.
+                follow = next((entry for entry in lines[idx + 1 :] if entry), "")
+                candidate = _normalize_value(_strip_decoration(follow))
+            if not candidate or _starts_with_phrase(candidate, non_blocking_prefixes):
                 continue
             return True
     return False

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3640,25 +3640,31 @@ def _has_blocking_or_negative_verdict(body: str) -> bool:
         "[]",
     )
 
+    def _starts_with_phrase(value: str, phrases: tuple[str, ...]) -> bool:
+        # Word-boundary matching, not raw prefixes: "no" must cover "no" /
+        # "no blockers" but never "node crashes" or "not working", and
+        # "block" must never cover "blockchain".
+        return any(re.match(rf"{re.escape(phrase)}(?!\w)", value) for phrase in phrases)
+
     for raw_line in str(body or "").splitlines():
         line = raw_line.strip()
         if not line:
             continue
-        line = line.lstrip("-").strip().strip("*").strip()
+        # Strip markdown list/heading/quote decoration so "### Verdict: FAIL"
+        # and "> **Verdict:** FAIL" still expose the label.
+        line = line.lstrip("#>-* ").strip()
         line = line.replace("**", "")
         label, sep, value = line.partition(":")
         if not sep:
             continue
         normalized_label = re.sub(r"\s+", " ", label.strip().lower())
         normalized_value = re.sub(r"\s+", " ", value.strip().strip("*").strip().lower())
-        if normalized_label in {"verdict", "decision", "recommendation"} and any(
-            normalized_value.startswith(prefix) for prefix in negative_verdict_prefixes
+        if normalized_label in {"verdict", "decision", "recommendation"} and _starts_with_phrase(
+            normalized_value, negative_verdict_prefixes
         ):
             return True
         if normalized_label in {"blocking finding", "blocking findings", "blocker", "blockers"}:
-            if not normalized_value or any(
-                normalized_value.startswith(value) for value in non_blocking_prefixes
-            ):
+            if not normalized_value or _starts_with_phrase(normalized_value, non_blocking_prefixes):
                 continue
             return True
     return False

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3526,6 +3526,14 @@ def _proposed_evidence_pr_grounding(body: str, pr: str) -> tuple[bool, str]:
             flags=re.IGNORECASE,
         )
     }
+    cited.update(
+        match.group(1)
+        for match in re.finditer(
+            r"\bgithub\.com/[^\s)<>]+/pull/(\d+)\b",
+            str(body or ""),
+            flags=re.IGNORECASE,
+        )
+    )
     if not cited:
         return True, "no_pr_citation"
     if normalized_pr in cited:

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3427,12 +3427,13 @@ def _lint_evidence_comment(
     """Dry-run whether one proposed comment would satisfy quorum parsers."""
     grounded, grounding_method = _proposed_evidence_head_grounding(body, head_sha)
     pr_grounded, pr_grounding_method = _proposed_evidence_pr_grounding(body, pr)
+    negative_verdict = _has_blocking_or_negative_verdict(body)
     comment = {
         "author": {"login": author},
         "body": body,
         "createdAt": "",
     }
-    if grounded and pr_grounded:
+    if grounded and pr_grounded and not negative_verdict:
         dogfood_evidence = _dogfood_evidence_from_comments([comment])
         reviewer_signals = _model_review_signals_from_comments([comment])
     else:
@@ -3452,6 +3453,8 @@ def _lint_evidence_comment(
         problems.append("wrong_pr_reference")
     if _is_github_actions_author(author):
         problems.append("github_actions_author_not_counted")
+    if negative_verdict:
+        problems.append("blocking_or_negative_verdict")
     if inferred_reviewer == "unknown_model_reviewer":
         problems.append("missing_known_model_reviewer_heading")
     for problem in identity.identity_problems:
@@ -3599,6 +3602,66 @@ def _known_model_reviewer_id(item: dict[str, Any]) -> str:
 
 def _is_github_actions_author(author: str) -> bool:
     return str(author or "").strip().lower() in {"github-actions", "github-actions[bot]"}
+
+
+def _has_blocking_or_negative_verdict(body: str) -> bool:
+    """Return True for explicit evidence comments that report blockers.
+
+    Merge quorum should count independent evidence that can support readiness,
+    not a comment that visibly says the reviewer failed or blocked the PR.
+    Keep the parser deliberately label-based so ordinary prose such as
+    "no blocking findings" remains countable.
+    """
+    negative_verdict_prefixes = (
+        "fail",
+        "failed",
+        "failing",
+        "block",
+        "blocked",
+        "blocking",
+        "request changes",
+        "request_changes",
+        "changes requested",
+        "reject",
+        "rejected",
+        "not ready",
+        "needs repair",
+    )
+    non_blocking_prefixes = (
+        "none",
+        "none found",
+        "no",
+        "no blockers",
+        "no blocking findings",
+        "not found",
+        "0",
+        "n/a",
+        "not applicable",
+        "[]",
+    )
+
+    for raw_line in str(body or "").splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        line = line.lstrip("-").strip().strip("*").strip()
+        line = line.replace("**", "")
+        label, sep, value = line.partition(":")
+        if not sep:
+            continue
+        normalized_label = re.sub(r"\s+", " ", label.strip().lower())
+        normalized_value = re.sub(r"\s+", " ", value.strip().strip("*").strip().lower())
+        if normalized_label in {"verdict", "decision", "recommendation"} and any(
+            normalized_value.startswith(prefix) for prefix in negative_verdict_prefixes
+        ):
+            return True
+        if normalized_label in {"blocking finding", "blocking findings", "blocker", "blockers"}:
+            if not normalized_value or any(
+                normalized_value.startswith(value) for value in non_blocking_prefixes
+            ):
+                continue
+            return True
+    return False
 
 
 def _normalize_model_reviewer_id(value: str) -> str:
@@ -3909,6 +3972,8 @@ def _dogfood_evidence_from_comments(
         if not _is_comment_grounded_on_head(comment, head_sha, head_committed_at):
             continue
         body = str(comment.get("body", "") or "")
+        if _has_blocking_or_negative_verdict(body):
+            continue
         lower = body.lower()
         if not any(
             token in lower for token in ("dogfood", "adversarial", "cross-author", "recheck")
@@ -3948,6 +4013,8 @@ def _model_review_signals_from_comments(
         if not _is_comment_grounded_on_head(comment, head_sha, head_committed_at):
             continue
         body = str(comment.get("body", "") or "")
+        if _has_blocking_or_negative_verdict(body):
+            continue
         lower = body.lower()
         if not any(
             token in lower

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3426,12 +3426,13 @@ def _lint_evidence_comment(
 ) -> dict[str, Any]:
     """Dry-run whether one proposed comment would satisfy quorum parsers."""
     grounded, grounding_method = _proposed_evidence_head_grounding(body, head_sha)
+    pr_grounded, pr_grounding_method = _proposed_evidence_pr_grounding(body, pr)
     comment = {
         "author": {"login": author},
         "body": body,
         "createdAt": "",
     }
-    if grounded:
+    if grounded and pr_grounded:
         dogfood_evidence = _dogfood_evidence_from_comments([comment])
         reviewer_signals = _model_review_signals_from_comments([comment])
     else:
@@ -3447,6 +3448,8 @@ def _lint_evidence_comment(
         problems.append("empty_body")
     if not grounded:
         problems.append("missing_current_head_grounding")
+    if not pr_grounded:
+        problems.append("wrong_pr_reference")
     if _is_github_actions_author(author):
         problems.append("github_actions_author_not_counted")
     if inferred_reviewer == "unknown_model_reviewer":
@@ -3491,6 +3494,8 @@ def _lint_evidence_comment(
         "identity_problems": list(identity.identity_problems),
         "current_head_grounded": grounded,
         "current_head_grounding_method": grounding_method,
+        "current_pr_grounded": pr_grounded,
+        "current_pr_grounding_method": pr_grounding_method,
         "dogfood_evidence": dogfood_evidence,
         "reviewer_signals": reviewer_signals,
         "counted_reviewer_ids": counted_reviewer_ids,
@@ -3498,6 +3503,34 @@ def _lint_evidence_comment(
         "would_count": bool(counted_reviewer_ids),
         "problems": problems,
     }
+
+
+def _proposed_evidence_pr_grounding(body: str, pr: str) -> tuple[bool, str]:
+    """Fail closed when a proposed evidence comment names the wrong PR.
+
+    Evidence comments are commonly drafted from recursive prompts that include
+    both a PR number and an exact head SHA. Lint mode should not approve a
+    body that is exact-head grounded but visibly copied from a different PR.
+    Comments without an explicit PR citation remain acceptable because the
+    caller already supplies the target ``--pr`` and the head SHA is the primary
+    current-head proof.
+    """
+    normalized_pr = str(pr or "").strip().lstrip("#")
+    if not normalized_pr:
+        return False, "missing_pr_argument"
+    cited = {
+        match.group(1)
+        for match in re.finditer(
+            r"\b(?:PR|pull\s+request)\s*[:#]?\s*#?(\d+)\b",
+            str(body or ""),
+            flags=re.IGNORECASE,
+        )
+    }
+    if not cited:
+        return True, "no_pr_citation"
+    if normalized_pr in cited:
+        return True, "pr_citation"
+    return False, "wrong_pr_citation"
 
 
 def _proposed_evidence_head_grounding(body: str, head_sha: str) -> tuple[bool, str]:

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -4754,6 +4754,38 @@ class TestCommandDispatch:
         assert "wrong_pr_reference" in payload["problems"]
         assert "no_counted_model_reviewer" in payload["problems"]
 
+    def test_evidence_lint_rejects_wrong_pr_url_reference(self) -> None:
+        ns = argparse.Namespace(
+            review_queue_command="evidence-lint",
+            pr="7445",
+            head_sha="cd87c5a1b2db34f04167906553502db3ede9525e",
+            head_committed_at="2026-05-23T19:00:00Z",
+            body=_codex_openai_body(
+                body=(
+                    "Evidence comment: https://github.com/synaptent/aragora/pull/9999"
+                    "#issuecomment-123\n"
+                    "Exact head reviewed: cd87c5a1b2db34f04167906553502db3ede9525e\n"
+                    "Focused adversarial dogfood found no blockers."
+                )
+            ),
+            body_file=None,
+            author="an0mium",
+            json=True,
+        )
+
+        out = io.StringIO()
+        with redirect_stdout(out):
+            rc = cmd_review_queue(ns)
+
+        payload = json.loads(out.getvalue())
+        assert rc == 1
+        assert payload["would_count"] is False
+        assert payload["current_head_grounding_method"] == "head_sha_citation"
+        assert payload["current_pr_grounding_method"] == "wrong_pr_citation"
+        assert payload["dogfood_evidence"] == []
+        assert "wrong_pr_reference" in payload["problems"]
+        assert "no_counted_model_reviewer" in payload["problems"]
+
     def test_evidence_lint_requires_head_sha_when_timestamp_omitted(self) -> None:
         ns = argparse.Namespace(
             review_queue_command="evidence-lint",

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -26,6 +26,7 @@ from aragora.cli.commands.review_queue import (
     _classify_pr,
     _classify_model_review_tier,
     _dogfood_evidence_from_comments,
+    _has_blocking_or_negative_verdict,
     _extract_validation_commands,
     _effective_required_pr_check_count,
     _filter_lanes,
@@ -2179,6 +2180,27 @@ class TestModelReviewQuorum:
         ]
 
         assert _dogfood_evidence_from_comments(comments, head_sha=head) == []
+
+
+class TestHasBlockingOrNegativeVerdict:
+    def test_blocker_value_starting_with_no_letters_is_still_blocking(self) -> None:
+        # Word-boundary regression: "node"/"not working" must not be swallowed
+        # by the non-blocking prefix "no".
+        assert _has_blocking_or_negative_verdict("Blockers: node crashes on startup")
+        assert _has_blocking_or_negative_verdict("Blocking findings: not working under load")
+
+    def test_markdown_heading_labels_are_recognized(self) -> None:
+        assert _has_blocking_or_negative_verdict("### Verdict: FAIL")
+        assert _has_blocking_or_negative_verdict("> **Verdict:** blocked on stale evidence")
+
+    def test_word_boundary_does_not_flag_blockchain_verdict(self) -> None:
+        assert not _has_blocking_or_negative_verdict("Verdict: blockchain summary attached")
+
+    def test_non_blocking_values_remain_countable(self) -> None:
+        assert not _has_blocking_or_negative_verdict("Blockers: none")
+        assert not _has_blocking_or_negative_verdict("Blocking findings: no blocking findings")
+        assert not _has_blocking_or_negative_verdict("#### Blockers: N/A")
+        assert not _has_blocking_or_negative_verdict("Verdict: **passed**, zero findings.")
 
 
 # --- parenthetical model-family disclosure ---------------------------------

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -4723,6 +4723,37 @@ class TestCommandDispatch:
         assert "missing_current_head_grounding" in payload["problems"]
         assert "no_counted_model_reviewer" in payload["problems"]
 
+    def test_evidence_lint_rejects_wrong_pr_reference(self) -> None:
+        ns = argparse.Namespace(
+            review_queue_command="evidence-lint",
+            pr="7445",
+            head_sha="cd87c5a1b2db34f04167906553502db3ede9525e",
+            head_committed_at="2026-05-23T19:00:00Z",
+            body=_codex_openai_body(
+                body=(
+                    "PR: #9999\n"
+                    "Current head: cd87c5a1b2db34f04167906553502db3ede9525e\n"
+                    "Focused adversarial dogfood found no blockers."
+                )
+            ),
+            body_file=None,
+            author="an0mium",
+            json=True,
+        )
+
+        out = io.StringIO()
+        with redirect_stdout(out):
+            rc = cmd_review_queue(ns)
+
+        payload = json.loads(out.getvalue())
+        assert rc == 1
+        assert payload["would_count"] is False
+        assert payload["current_head_grounding_method"] == "head_sha_citation"
+        assert payload["current_pr_grounding_method"] == "wrong_pr_citation"
+        assert payload["dogfood_evidence"] == []
+        assert "wrong_pr_reference" in payload["problems"]
+        assert "no_counted_model_reviewer" in payload["problems"]
+
     def test_evidence_lint_requires_head_sha_when_timestamp_omitted(self) -> None:
         ns = argparse.Namespace(
             review_queue_command="evidence-lint",

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -25,6 +25,7 @@ from aragora.cli.commands.review_queue import (
     _build_queue,
     _classify_pr,
     _classify_model_review_tier,
+    _dogfood_evidence_from_comments,
     _extract_validation_commands,
     _effective_required_pr_check_count,
     _filter_lanes,
@@ -2164,6 +2165,20 @@ class TestModelReviewQuorum:
         assert len(quorum["dogfood_evidence"]) == 1
         assert quorum["dogfood_evidence"][0]["model_family"] == "claude"
         assert "claude" in quorum["counted_reviewer_ids"]
+
+    def test_dogfood_negative_verdict_is_not_counted(self) -> None:
+        head = "cd87c5a1b2db34f04167906553502db3ede9525e"
+        comments = [
+            _codex_openai_comment(
+                body=(
+                    f"Current head: {head}\n"
+                    "Verdict: FAIL\n"
+                    "Blocking findings: found - exact-head evidence is stale."
+                )
+            )
+        ]
+
+        assert _dogfood_evidence_from_comments(comments, head_sha=head) == []
 
 
 # --- parenthetical model-family disclosure ---------------------------------
@@ -4784,6 +4799,37 @@ class TestCommandDispatch:
         assert payload["current_pr_grounding_method"] == "wrong_pr_citation"
         assert payload["dogfood_evidence"] == []
         assert "wrong_pr_reference" in payload["problems"]
+        assert "no_counted_model_reviewer" in payload["problems"]
+
+    def test_evidence_lint_rejects_explicit_blocking_verdict(self) -> None:
+        ns = argparse.Namespace(
+            review_queue_command="evidence-lint",
+            pr="7445",
+            head_sha="cd87c5a1b2db34f04167906553502db3ede9525e",
+            head_committed_at="2026-05-23T19:00:00Z",
+            body=_codex_openai_body(
+                body=(
+                    "PR: #7445\n"
+                    "Current head: cd87c5a1b2db34f04167906553502db3ede9525e\n"
+                    "Verdict: FAIL\n"
+                    "Blocking findings: found - helper can still misclassify stale evidence."
+                )
+            ),
+            body_file=None,
+            author="an0mium",
+            json=True,
+        )
+
+        out = io.StringIO()
+        with redirect_stdout(out):
+            rc = cmd_review_queue(ns)
+
+        payload = json.loads(out.getvalue())
+        assert rc == 1
+        assert payload["would_count"] is False
+        assert payload["reviewer_signals"] == []
+        assert payload["dogfood_evidence"] == []
+        assert "blocking_or_negative_verdict" in payload["problems"]
         assert "no_counted_model_reviewer" in payload["problems"]
 
     def test_evidence_lint_requires_head_sha_when_timestamp_omitted(self) -> None:

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -2193,6 +2193,10 @@ class TestHasBlockingOrNegativeVerdict:
         assert _has_blocking_or_negative_verdict("### Verdict: FAIL")
         assert _has_blocking_or_negative_verdict("> **Verdict:** blocked on stale evidence")
 
+    def test_dash_separated_negative_labels_are_recognized(self) -> None:
+        assert _has_blocking_or_negative_verdict("Verdict - FAIL")
+        assert _has_blocking_or_negative_verdict("Blocking findings — found stale evidence")
+
     def test_word_boundary_does_not_flag_blockchain_verdict(self) -> None:
         assert not _has_blocking_or_negative_verdict("Verdict: blockchain summary attached")
 
@@ -4790,6 +4794,35 @@ class TestCommandDispatch:
         assert payload["dogfood_evidence"] == []
         assert "wrong_pr_reference" in payload["problems"]
         assert "no_counted_model_reviewer" in payload["problems"]
+
+    def test_evidence_lint_rejects_wrong_pr_number_label(self) -> None:
+        ns = argparse.Namespace(
+            review_queue_command="evidence-lint",
+            pr="7445",
+            head_sha="cd87c5a1b2db34f04167906553502db3ede9525e",
+            head_committed_at="2026-05-23T19:00:00Z",
+            body=_codex_openai_body(
+                body=(
+                    "PR Number: #9999\n"
+                    "Current head: cd87c5a1b2db34f04167906553502db3ede9525e\n"
+                    "Focused adversarial dogfood found no blockers."
+                )
+            ),
+            body_file=None,
+            author="an0mium",
+            json=True,
+        )
+
+        out = io.StringIO()
+        with redirect_stdout(out):
+            rc = cmd_review_queue(ns)
+
+        payload = json.loads(out.getvalue())
+        assert rc == 1
+        assert payload["would_count"] is False
+        assert payload["current_pr_grounding_method"] == "wrong_pr_citation"
+        assert payload["dogfood_evidence"] == []
+        assert "wrong_pr_reference" in payload["problems"]
 
     def test_evidence_lint_rejects_wrong_pr_url_reference(self) -> None:
         ns = argparse.Namespace(

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -2221,6 +2221,21 @@ class TestHasBlockingOrNegativeVerdict:
     def test_word_boundary_does_not_flag_blockchain_verdict(self) -> None:
         assert not _has_blocking_or_negative_verdict("Verdict: blockchain summary attached")
 
+    def test_inline_empty_markers_never_consume_the_next_section(self) -> None:
+        # "Blockers: []" is an explicit empty list; the following unrelated
+        # section must not be read as a blocker entry.
+        assert not _has_blocking_or_negative_verdict("Blockers: []\nVerdict: PASS")
+        assert not _has_blocking_or_negative_verdict("Blockers: -\nScope reviewed: full diff")
+        assert not _has_blocking_or_negative_verdict("Blocking findings: [ ]\n\nVerdict: passed")
+
+    def test_empty_blockers_followed_by_new_section_or_heading_is_countable(self) -> None:
+        assert not _has_blocking_or_negative_verdict("Blockers:\nVerdict: PASS")
+        assert not _has_blocking_or_negative_verdict("Blockers:\n### Validation notes")
+
+    def test_lookahead_still_catches_list_items_with_colons(self) -> None:
+        assert _has_blocking_or_negative_verdict("Blockers:\n- crash: stack overflow in parser")
+        assert _has_blocking_or_negative_verdict("Blockers:\n1. regression: settle gate bypassed")
+
     def test_non_blocking_values_remain_countable(self) -> None:
         assert not _has_blocking_or_negative_verdict("Blockers: none")
         assert not _has_blocking_or_negative_verdict("Blocking findings: no blocking findings")

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -2197,6 +2197,27 @@ class TestHasBlockingOrNegativeVerdict:
         assert _has_blocking_or_negative_verdict("Verdict - FAIL")
         assert _has_blocking_or_negative_verdict("Blocking findings — found stale evidence")
 
+    def test_multi_line_blocker_lists_are_blocking(self) -> None:
+        assert _has_blocking_or_negative_verdict("Blocking findings:\n- Crash on startup")
+        assert _has_blocking_or_negative_verdict("Blockers:\n\n1. Stale exact-head evidence")
+
+    def test_multi_line_non_blocking_values_remain_countable(self) -> None:
+        assert not _has_blocking_or_negative_verdict("Blockers:\nNone found.")
+        assert not _has_blocking_or_negative_verdict("Blocking findings:")
+
+    def test_decorated_and_numbered_labels_are_recognized(self) -> None:
+        assert _has_blocking_or_negative_verdict("1. Verdict: FAIL")
+        assert _has_blocking_or_negative_verdict("*Verdict*: FAIL")
+        assert _has_blocking_or_negative_verdict("__Verdict__: FAIL")
+
+    def test_failure_verdict_and_inline_list_blockers_are_negative(self) -> None:
+        assert _has_blocking_or_negative_verdict("Verdict: Failure")
+        assert _has_blocking_or_negative_verdict("Blockers: - broken auth flow")
+
+    def test_boolean_and_zero_values_remain_countable(self) -> None:
+        assert not _has_blocking_or_negative_verdict("Blockers: false")
+        assert not _has_blocking_or_negative_verdict("Blocking findings: zero")
+
     def test_word_boundary_does_not_flag_blockchain_verdict(self) -> None:
         assert not _has_blocking_or_negative_verdict("Verdict: blockchain summary attached")
 


### PR DESCRIPTION
## Summary

- Prevent `review-queue evidence-lint` and model quorum from counting proposed evidence that cites a different PR than the target `--pr`.
- Prevent proposed and persisted dogfood/model evidence with explicit blocking or negative verdicts from counting as merge-supporting evidence.
- Harden common operator/comment formats: `PR Number: #...` now participates in wrong-PR grounding, and `Verdict - FAIL` / `Blocking findings — found ...` are recognized as negative labels.

## Current head

`72b598b930fcb8f0a284891e6812115f7b100bcb`

## Validation

- RED: `python3 -m pytest -q tests/cli/commands/test_review_queue.py::TestHasBlockingOrNegativeVerdict::test_dash_separated_negative_labels_are_recognized tests/cli/commands/test_review_queue.py::TestCommandDispatch::test_evidence_lint_rejects_wrong_pr_number_label` failed on the current branch before implementation.
- GREEN: same targeted command -> 2 passed.
- `python3 -m pytest -q tests/cli/commands/test_review_queue.py` -> 234 passed.
- `python3 -m ruff check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py` -> passed.
- `python3 -m ruff format --check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py` -> already formatted.
- `git diff --check` / `git diff --check origin/main...HEAD` -> passed.
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> preflight ok; changed files are `aragora/cli/commands/review_queue.py` and `tests/cli/commands/test_review_queue.py`.
- Commit/push hooks passed, including mypy for changed files, ruff, ruff format, gitleaks, and portability guard.

## Governance

This is evidence parser hardening only. No settlement, mark-ready, merge/admin-merge, branch-protection mutation, manual status, label, close, comment, or queue drain was performed.
