### PR TITLE
[outbox-harvest] generate_boss_issues.py help now avoids heavyweight swarm imports.

### DIFF
--- a/scripts/generate_boss_issues.py
+++ b/scripts/generate_boss_issues.py
@@ -21,16 +21,45 @@ import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 # Add repo root to path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
-from aragora.swarm.decomposition_bridge import DecompositionBridge  # noqa: E402
-from aragora.swarm.issue_scanner import BossIssueCandidate, scan_all  # noqa: E402
-from aragora.swarm.issue_upgrader import upgrade_issue_heuristic  # noqa: E402
-from aragora.swarm.proof_first_queue import classify_proof_first_queue_issue  # noqa: E402
-from aragora.swarm.roadmap_priority import load_roadmap_priority_policy  # noqa: E402
+if TYPE_CHECKING:
+    from aragora.swarm.issue_scanner import BossIssueCandidate
+
+
+def DecompositionBridge(*args: Any, **kwargs: Any) -> Any:
+    from aragora.swarm.decomposition_bridge import DecompositionBridge as _Bridge
+
+    return _Bridge(*args, **kwargs)
+
+
+def scan_all(*args: Any, **kwargs: Any) -> list[BossIssueCandidate]:
+    from aragora.swarm.issue_scanner import scan_all as _scan_all
+
+    return _scan_all(*args, **kwargs)
+
+
+def upgrade_issue_heuristic(*args: Any, **kwargs: Any) -> Any:
+    from aragora.swarm.issue_upgrader import upgrade_issue_heuristic as _upgrade
+
+    return _upgrade(*args, **kwargs)
+
+
+def classify_proof_first_queue_issue(*args: Any, **kwargs: Any) -> Any:
+    from aragora.swarm.proof_first_queue import classify_proof_first_queue_issue as _classify
+
+    return _classify(*args, **kwargs)
+
+
+def load_roadmap_priority_policy(*args: Any, **kwargs: Any) -> Any:
+    from aragora.swarm.roadmap_priority import load_roadmap_priority_policy as _load
+
+    return _load(*args, **kwargs)
+
 
 _GENERIC_PARENT_PHRASES: tuple[str, ...] = (
     "read the module and identify all public functions",

--- a/tests/scripts/test_generate_boss_issues.py
+++ b/tests/scripts/test_generate_boss_issues.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -10,6 +11,19 @@ import pytest
 from aragora.swarm.issue_scanner import BossIssueCandidate
 from aragora.swarm.roadmap_priority import RoadmapPriorityPolicy
 from scripts import generate_boss_issues as mod
+
+
+def test_help_does_not_load_full_swarm_stack() -> None:
+    result = subprocess.run(
+        [sys.executable, str(mod.REPO_ROOT / "scripts" / "generate_boss_issues.py"), "--help"],
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.startswith("usage: generate_boss_issues.py")
+    assert result.stderr == ""
 
 
 def _candidate(name: str, *, file_scope: list[str]) -> BossIssueCandidate:


### PR DESCRIPTION
## Outbox harvest (run-20260610 shift 4)
Published by the gh-authenticated coordinator from `.aragora/automation-outbox` — the writer-lane sandbox validated this branch but could not open the PR (gh unauthenticated; publisher daemon stale since May 18).

- **Branch:** `codex/generate-boss-issues-lazy-help-improver-20260610` @ `475ae17401a1` (head matches outbox record: True)
- **Idempotency key:** `open-pr-codex-generate-boss-issues-lazy-help-improver-20260610-475ae174`
- **Writer objective:** Make the boss issue generator help/parser path fast and discoverable for automation operators.
- **Mutation boundary:** Limited to lazy-loading generate_boss_issues.py swarm dependencies and adding one subprocess help regression; issue scanning, filtering, priority checks, decomposition behavior, and issue creation behavior are unchanged.
- **Acceptance criteria:** python3 scripts/generate_boss_issues.py --help exits quickly and prints argparse usage without importing the full swarm stack.; Existing boss issue generation behavior remains available through lazy wrappers that preserve test monkeypatch seams.; Focused pytest, py_compile, Ruff, format check, live help smoke, diff checks, merge-tree, and automation PR preflight pass at the exact head.
- **Writer validation:** {'source': 'local_evidence.validation', 'summary': 'Current-base branch passed focused tests, static checks, live help smoke, merge-tree, and automation PR preflight; branch is pushed, PR creation remains blocked by gh auth and connector permissions.'}

Draft for CI + worth-triage; settlement via the standard quorum path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)