### PR TITLE
[outbox-harvest] Mandatory synthesis now guards empty LLM outputs without discarding valid fallbacks.

### DIFF
--- a/aragora/debate/phases/synthesis_generator.py
+++ b/aragora/debate/phases/synthesis_generator.py
@@ -159,6 +159,8 @@ class SynthesisGenerator:
                     synthesizer.generate(user_prompt),
                     timeout=60.0,
                 )
+            if opus_synthesis is None:
+                raise RuntimeError("synthesis agent returned no output")
             synthesis = await self._ensure_complete_synthesis(
                 ctx=ctx,
                 synthesizer=synthesizer,
@@ -193,6 +195,8 @@ class SynthesisGenerator:
                         synthesizer.generate(user_prompt),
                         timeout=30.0,
                     )
+                if sonnet_synthesis is None:
+                    raise RuntimeError("fallback synthesis agent returned no output")
                 synthesis = await self._ensure_complete_synthesis(
                     ctx=ctx,
                     synthesizer=synthesizer,

--- a/tests/debate/phases/test_synthesis_generator.py
+++ b/tests/debate/phases/test_synthesis_generator.py
@@ -519,6 +519,37 @@ class TestGenerateMandatorySynthesis:
         assert "Sonnet synthesis" in ctx.result.synthesis
 
     @pytest.mark.asyncio
+    async def test_opus_none_falls_back_to_sonnet(self):
+        """Empty Opus output falls back without discarding a valid Sonnet synthesis."""
+        ctx = MockDebateContext()
+        ctx.proposals = {"agent1": "Proposal"}
+
+        gen = SynthesisGenerator()
+
+        call_count = 0
+
+        async def mock_generate(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return None
+            return "Sonnet synthesis"
+
+        with (
+            patch("aragora.utils.env.is_offline_mode", return_value=False),
+            patch.object(gen, "_anthropic_synthesis_available", return_value=True),
+            patch("aragora.agents.api_agents.anthropic.AnthropicAPIAgent") as mock_agent_class,
+        ):
+            mock_agent = MagicMock()
+            mock_agent.generate = mock_generate
+            mock_agent_class.return_value = mock_agent
+
+            result = await gen.generate_mandatory_synthesis(ctx)
+
+        assert result is True
+        assert ctx.result.synthesis == "Sonnet synthesis"
+
+    @pytest.mark.asyncio
     async def test_import_error_falls_back_to_combined(self):
         """Import error falls back to combined proposals."""
         ctx = MockDebateContext()


### PR DESCRIPTION
## Outbox harvest (run-20260610 shift 4)
Published by the gh-authenticated coordinator from `.aragora/automation-outbox` — the writer-lane sandbox validated this branch but could not open the PR (gh unauthenticated; publisher daemon stale since May 18).

- **Branch:** `codex/harvest-fresh-provider-ask-isolation-primary-r6-20260609` @ `769ce1d519f3` (head matches outbox record: True)
- **Idempotency key:** `open-pr-codex-harvest-fresh-provider-ask-isolation-primary-r6-20260609-769ce1d5`
- **Writer objective:** Guard missing mandatory synthesis LLM outputs without discarding valid fallback synthesis.
- **Mutation boundary:** Limited to mandatory synthesis None-output guards and a focused synthesis generator regression test.
- **Acceptance criteria:** Mandatory synthesis preserves a successful Opus response.; A missing Opus response falls back to a valid Sonnet response instead of discarding it.; Focused synthesis/provider-isolation tests, Ruff, py_compile, diff checks, merge-tree, push, and automation PR preflight pass.
- **Writer validation:** {'automation_pr_preflight': 'bash scripts/automation_pr_preflight.sh origin/main HEAD: preflight ok; changed files are aragora/debate/phases/synthesis_generator.py and tests/debate/phases/test_synthesis_generator.py.', 'diff_check': 'git diff --check origin/main...HEAD and git diff --check: passed.', 'focused_pytest': 'python3 -m pytest tests/debate/phases/test_synthesis_generator.py::TestGenerate

Draft for CI + worth-triage; settlement via the standard quorum path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)