### PR TITLE
[outbox-harvest] Clean merge-arbiter breaker restack is validated, pushed, and ready for draft PR publication.

### DIFF
--- a/aragora/swarm/initiative_integrator.py
+++ b/aragora/swarm/initiative_integrator.py
@@ -27,6 +27,7 @@ from aragora.swarm.campaign import (
 )
 from aragora.swarm.merge_arbiter import (
     REQUIRED_CHECKS,
+    ArbiterOperationalError,
     _classify_required_checks,
     _get_check_status,
     _merge_pr,
@@ -555,7 +556,12 @@ class InitiativeIntegrator:
     ) -> dict[str, Any]:
         snapshot = self._resolve_project_pr_snapshot(project)
         pr_number = _parse_pr_number((snapshot or {}).get("number") or (snapshot or {}).get("url"))
-        checks = _get_check_status(pr_number, self.repo) if pr_number is not None else {}
+        try:
+            checks = _get_check_status(pr_number, self.repo) if pr_number is not None else {}
+        except ArbiterOperationalError:
+            # Status reporting degrades to "checks unknown" on gh faults; only
+            # the arbiter poll loop feeds these faults to its circuit breaker.
+            checks = {}
         missing_checks, failing_checks = _classify_required_checks(checks)
         dependency_blockers = _dependency_blockers(manifest, project)
         promotion_blockers: list[str] = []

--- a/aragora/swarm/merge_arbiter.py
+++ b/aragora/swarm/merge_arbiter.py
@@ -295,7 +295,10 @@ def _get_check_status(pr_number: int, repo: str) -> dict[str, str]:
     """Return a mapping of check-name -> conclusion for a PR.
 
     Merges both status checks and GitHub Actions check runs.
-    """
+
+    Raises ``ArbiterOperationalError`` when ``gh pr checks`` fails without
+    producing parseable JSON (transport/auth fault). An empty mapping means
+    the call succeeded but reported no checks (a normal not-ready state)."""
     result = _run_gh(
         [
             "pr",
@@ -307,12 +310,21 @@ def _get_check_status(pr_number: int, repo: str) -> dict[str, str]:
             "name,state",
         ]
     )
-    if result.returncode != 0:
-        logger.debug("gh pr checks failed for #%d: %s", pr_number, result.stderr.strip())
-        return {}
+    # gh pr checks uses non-zero exits for pending/failing checks too, so the
+    # exit code alone does not distinguish "checks are red" from "gh broke".
+    # Parseable JSON output is the truth regardless of exit code; no JSON plus
+    # a non-zero exit is an operational fault, not a not-ready PR.
     try:
-        checks = json.loads(result.stdout)
+        checks = json.loads(result.stdout) if result.stdout else None
     except (json.JSONDecodeError, TypeError):
+        checks = None
+    if not isinstance(checks, list):
+        checks = None
+    if checks is None:
+        if result.returncode != 0:
+            raise ArbiterOperationalError(
+                f"gh pr checks failed for #{pr_number}: {result.stderr.strip()}"
+            )
         return {}
     return {c["name"]: c.get("state", "").upper() for c in checks if "name" in c}
 
@@ -669,12 +681,14 @@ class MergeArbiter:
         while time.monotonic() < deadline:
             summary.polls += 1
             collected_this_poll = False
-            operational_fault_this_poll = False
+            list_fault_this_poll = False
+            eval_faults_this_poll = 0
+            clean_evaluations_this_poll = 0
 
             try:
                 candidates = _list_candidate_prs(self.config)
             except ArbiterOperationalError as exc:
-                operational_fault_this_poll = True
+                list_fault_this_poll = True
                 candidates = []
                 logger.warning("Poll %d: candidate fetch fault: %s", summary.polls, exc)
             logger.debug("Poll %d: %d candidate PRs", summary.polls, len(candidates))
@@ -685,7 +699,7 @@ class MergeArbiter:
                 except ArbiterOperationalError as exc:
                     # Genuine evaluation fault (not "PR not ready"): count it, skip
                     # this PR, keep polling the rest.
-                    operational_fault_this_poll = True
+                    eval_faults_this_poll += 1
                     logger.warning(
                         "Poll %d: evaluation fault for #%s: %s",
                         summary.polls,
@@ -693,6 +707,7 @@ class MergeArbiter:
                         exc,
                     )
                     continue
+                clean_evaluations_this_poll += 1
                 if result.success:
                     summary.merged.append(result.pr_number)
                     logger.info("PR #%d: %s (%s)", result.pr_number, result.reason, result.branch)
@@ -727,8 +742,15 @@ class MergeArbiter:
                 ):
                     collected_this_poll = True
 
-            # Circuit breaker: trip only on consecutive polls with a genuine
-            # operational fault (cannot list / evaluate), never on not-ready PRs.
+            # Circuit breaker: trip only on consecutive polls with a *systemic*
+            # operational fault, never on not-ready PRs. A list-fetch fault is
+            # always systemic. Evaluation faults are systemic only when every
+            # evaluation in the poll faulted: a single PR that consistently
+            # faults (a poison pill) must not halt the arbiter for the healthy
+            # rest of the queue.
+            operational_fault_this_poll = list_fault_this_poll or (
+                eval_faults_this_poll > 0 and clean_evaluations_this_poll == 0
+            )
             if operational_fault_this_poll:
                 self._consecutive_failures += 1
             else:

--- a/aragora/swarm/merge_arbiter.py
+++ b/aragora/swarm/merge_arbiter.py
@@ -250,8 +250,18 @@ def _run_gh(
     return gh_subprocess_run(args, timeout=timeout, write_op=write_op)
 
 
+class ArbiterOperationalError(RuntimeError):
+    """A genuine arbiter-operational fault (e.g. cannot list PRs), as opposed to a
+    PR merely not being ready. Only these faults feed the circuit breaker."""
+
+
 def _list_candidate_prs(config: MergeArbiterConfig) -> list[dict]:
-    """Return open PRs whose head branch matches any configured prefix."""
+    """Return open PRs whose head branch matches any configured prefix.
+
+    Raises ``ArbiterOperationalError`` when the underlying ``gh pr list`` call or
+    its JSON output cannot be obtained — a transient/operational fault that the
+    poll loop counts toward the circuit breaker. An *empty* list means the fetch
+    succeeded but no open PR matched a configured prefix (not a fault)."""
     prefixes = _normalize_branch_prefixes(config.branch_prefixes)
     result = _run_gh(
         [
@@ -268,13 +278,11 @@ def _list_candidate_prs(config: MergeArbiterConfig) -> list[dict]:
         ]
     )
     if result.returncode != 0:
-        logger.warning("gh pr list failed: %s", result.stderr.strip())
-        return []
+        raise ArbiterOperationalError(f"gh pr list failed: {result.stderr.strip()}")
     try:
         prs = json.loads(result.stdout)
-    except (json.JSONDecodeError, TypeError):
-        logger.warning("Failed to parse gh pr list output")
-        return []
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise ArbiterOperationalError("failed to parse gh pr list output") from exc
     candidates = []
     for pr in prs:
         branch = pr.get("headRefName", "")
@@ -660,29 +668,43 @@ class MergeArbiter:
 
         while time.monotonic() < deadline:
             summary.polls += 1
-            any_failure_this_poll = False
-            any_merge_this_poll = False
             collected_this_poll = False
+            operational_fault_this_poll = False
 
-            candidates = _list_candidate_prs(self.config)
+            try:
+                candidates = _list_candidate_prs(self.config)
+            except ArbiterOperationalError as exc:
+                operational_fault_this_poll = True
+                candidates = []
+                logger.warning("Poll %d: candidate fetch fault: %s", summary.polls, exc)
             logger.debug("Poll %d: %d candidate PRs", summary.polls, len(candidates))
 
             for pr in candidates:
-                result = _evaluate_pr(pr, self.config)
+                try:
+                    result = _evaluate_pr(pr, self.config)
+                except ArbiterOperationalError as exc:
+                    # Genuine evaluation fault (not "PR not ready"): count it, skip
+                    # this PR, keep polling the rest.
+                    operational_fault_this_poll = True
+                    logger.warning(
+                        "Poll %d: evaluation fault for #%s: %s",
+                        summary.polls,
+                        pr.get("number"),
+                        exc,
+                    )
+                    continue
                 if result.success:
                     summary.merged.append(result.pr_number)
-                    any_merge_this_poll = True
-                    logger.info(
-                        "PR #%d: %s (%s)",
-                        result.pr_number,
-                        result.reason,
-                        result.branch,
-                    )
+                    logger.info("PR #%d: %s (%s)", result.pr_number, result.reason, result.branch)
                 elif "failing" in result.reason or "failed" in result.reason:
+                    # A PR with failing/missing required checks is NOT ready — a
+                    # normal waiting state, NOT an arbiter fault. Record it for
+                    # reporting, but it must never trip the circuit breaker: a
+                    # normal all-red queue would otherwise stop the engine before
+                    # it can post the very evidence that turns those checks green.
                     summary.failed.append(result.pr_number)
-                    any_failure_this_poll = True
                     logger.info(
-                        "PR #%d skipped: %s (%s)",
+                        "PR #%d not ready: %s (%s)",
                         result.pr_number,
                         result.reason,
                         result.branch,
@@ -705,15 +727,16 @@ class MergeArbiter:
                 ):
                     collected_this_poll = True
 
-            # Circuit breaker: track consecutive polls with only failures
-            if any_failure_this_poll and not any_merge_this_poll:
+            # Circuit breaker: trip only on consecutive polls with a genuine
+            # operational fault (cannot list / evaluate), never on not-ready PRs.
+            if operational_fault_this_poll:
                 self._consecutive_failures += 1
             else:
                 self._consecutive_failures = 0
 
             if self._consecutive_failures >= self.config.max_consecutive_failures:
                 summary.stop_reason = (
-                    f"circuit breaker: {self._consecutive_failures} consecutive failure-only polls"
+                    f"circuit breaker: {self._consecutive_failures} consecutive operational faults"
                 )
                 logger.warning("Merge arbiter stopping: %s", summary.stop_reason)
                 break

--- a/tests/swarm/test_merge_arbiter.py
+++ b/tests/swarm/test_merge_arbiter.py
@@ -11,6 +11,7 @@ import pytest
 from aragora.swarm.merge_arbiter import (
     AUTOMATION_REVIEWER_LOGINS,
     REQUIRED_CHECKS,
+    ArbiterOperationalError,
     ArbiterSummary,
     MergeArbiter,
     MergeArbiterConfig,
@@ -96,17 +97,19 @@ class TestListCandidatePrs:
         assert result[0]["number"] == 1
         assert result[1]["number"] == 2
 
-    def test_returns_empty_on_gh_failure(self):
+    def test_raises_operational_error_on_gh_failure(self):
         config = MergeArbiterConfig()
         with patch("aragora.swarm.merge_arbiter._run_gh") as mock_gh:
-            mock_gh.return_value = _make_gh_result(returncode=1, stderr="error")
-            assert _list_candidate_prs(config) == []
+            mock_gh.return_value = _make_gh_result(returncode=1, stderr="error connecting")
+            with pytest.raises(ArbiterOperationalError):
+                _list_candidate_prs(config)
 
-    def test_returns_empty_on_bad_json(self):
+    def test_raises_operational_error_on_bad_json(self):
         config = MergeArbiterConfig()
         with patch("aragora.swarm.merge_arbiter._run_gh") as mock_gh:
             mock_gh.return_value = _make_gh_result(stdout="not json")
-            assert _list_candidate_prs(config) == []
+            with pytest.raises(ArbiterOperationalError):
+                _list_candidate_prs(config)
 
 
 # ---------------------------------------------------------------------------
@@ -455,11 +458,14 @@ class TestEvaluatePrDraft:
 
 class TestCircuitBreaker:
     @pytest.mark.asyncio
-    async def test_stops_after_consecutive_failures(self):
+    async def test_not_ready_prs_never_trip_the_breaker(self):
+        # A queue of PRs with failing required checks (the common all-red state,
+        # incl. PRs waiting on the quorum check) must NOT stop the engine — else
+        # the arbiter would stop before posting the evidence that turns them green.
         config = MergeArbiterConfig(
             max_consecutive_failures=3,
-            poll_interval_seconds=0.01,
-            max_runtime_hours=0.01,
+            poll_interval_seconds=0.001,
+            max_runtime_hours=0.0002,  # ~0.7s of polling
         )
         arbiter = MergeArbiter(config=config)
 
@@ -467,15 +473,11 @@ class TestCircuitBreaker:
         failing_checks = _all_passing_ready_checks()
         failing_checks["lint"] = "FAILURE"
 
-        call_count = 0
-
-        def fake_list(_cfg):
-            nonlocal call_count
-            call_count += 1
-            return [failing_pr]
-
         with (
-            patch("aragora.swarm.merge_arbiter._list_candidate_prs", side_effect=fake_list),
+            patch(
+                "aragora.swarm.merge_arbiter._list_candidate_prs",
+                return_value=[failing_pr],
+            ),
             patch(
                 "aragora.swarm.merge_arbiter._get_required_checks",
                 return_value=list(REQUIRED_CHECKS),
@@ -484,8 +486,29 @@ class TestCircuitBreaker:
         ):
             summary = await arbiter.run()
 
-        assert "circuit breaker" in summary.stop_reason
-        assert call_count == 3
+        assert "circuit breaker" not in summary.stop_reason
+        assert summary.stop_reason == "max runtime reached"
+        assert summary.merged == []
+        assert 1 in summary.failed  # recorded for reporting, but did not stop the engine
+
+    @pytest.mark.asyncio
+    async def test_consecutive_operational_faults_trip_the_breaker(self):
+        # Genuine operational faults (cannot list PRs) SHOULD fail closed.
+        config = MergeArbiterConfig(
+            max_consecutive_failures=3,
+            poll_interval_seconds=0.001,
+            max_runtime_hours=1.0,  # long; breaker should stop us well before this
+        )
+        arbiter = MergeArbiter(config=config)
+
+        with patch(
+            "aragora.swarm.merge_arbiter._list_candidate_prs",
+            side_effect=ArbiterOperationalError("gh pr list failed: error connecting"),
+        ):
+            summary = await arbiter.run()
+
+        assert "operational faults" in summary.stop_reason
+        assert summary.polls == 3
 
 
 # ---------------------------------------------------------------------------

--- a/tests/swarm/test_merge_arbiter.py
+++ b/tests/swarm/test_merge_arbiter.py
@@ -127,10 +127,11 @@ class TestGetCheckStatus:
         for name in REQUIRED_CHECKS:
             assert result[name] == "SUCCESS"
 
-    def test_returns_empty_on_failure(self):
+    def test_raises_operational_error_on_failure_without_json(self):
         with patch("aragora.swarm.merge_arbiter._run_gh") as mock_gh:
             mock_gh.return_value = _make_gh_result(returncode=1)
-            assert _get_check_status(1, "owner/repo") == {}
+            with pytest.raises(ArbiterOperationalError):
+                _get_check_status(1, "owner/repo")
 
 
 class TestHumanSettlement:
@@ -509,6 +510,87 @@ class TestCircuitBreaker:
 
         assert "operational faults" in summary.stop_reason
         assert summary.polls == 3
+
+    @pytest.mark.asyncio
+    async def test_systemic_evaluation_faults_trip_the_breaker(self):
+        # Every evaluation faulting (e.g. gh auth death mid-run) is systemic
+        # and SHOULD fail closed, even though listing still works.
+        config = MergeArbiterConfig(
+            max_consecutive_failures=3,
+            poll_interval_seconds=0.001,
+            max_runtime_hours=1.0,
+        )
+        arbiter = MergeArbiter(config=config)
+
+        with (
+            patch(
+                "aragora.swarm.merge_arbiter._list_candidate_prs",
+                return_value=[_pr(1, "codex/poison")],
+            ),
+            patch(
+                "aragora.swarm.merge_arbiter._evaluate_pr",
+                side_effect=ArbiterOperationalError("gh pr checks failed for #1: timeout"),
+            ),
+        ):
+            summary = await arbiter.run()
+
+        assert "operational faults" in summary.stop_reason
+        assert summary.polls == 3
+
+    @pytest.mark.asyncio
+    async def test_single_poison_pill_pr_does_not_halt_the_arbiter(self):
+        # One PR that faults on every evaluation must not stop the engine while
+        # the rest of the queue evaluates cleanly.
+        config = MergeArbiterConfig(
+            max_consecutive_failures=3,
+            poll_interval_seconds=0.001,
+            max_runtime_hours=0.0002,  # ~0.7s of polling
+        )
+        arbiter = MergeArbiter(config=config)
+
+        poison = _pr(1, "codex/poison")
+        healthy = _pr(2, "codex/healthy")
+        failing_checks = _all_passing_ready_checks()
+        failing_checks["lint"] = "FAILURE"
+
+        def evaluate(pr, _config):
+            if pr["number"] == 1:
+                raise ArbiterOperationalError("gh pr checks failed for #1: timeout")
+            return MergeResult(2, "codex/healthy", False, "failing required checks: lint")
+
+        with (
+            patch(
+                "aragora.swarm.merge_arbiter._list_candidate_prs",
+                return_value=[poison, healthy],
+            ),
+            patch("aragora.swarm.merge_arbiter._evaluate_pr", side_effect=evaluate),
+        ):
+            summary = await arbiter.run()
+
+        assert "circuit breaker" not in summary.stop_reason
+        assert summary.stop_reason == "max runtime reached"
+        assert 2 in summary.failed
+        assert summary.polls >= config.max_consecutive_failures
+
+
+class TestGetCheckStatusFaults:
+    def test_raises_operational_error_when_gh_fails_without_json(self):
+        with patch("aragora.swarm.merge_arbiter._run_gh") as mock_gh:
+            mock_gh.return_value = _make_gh_result(returncode=1, stdout="", stderr="auth dead")
+            with pytest.raises(ArbiterOperationalError):
+                _get_check_status(1, "owner/repo")
+
+    def test_parseable_json_is_truth_even_on_nonzero_exit(self):
+        # gh pr checks exits non-zero for pending/failing checks; output wins.
+        payload = json.dumps([{"name": "lint", "state": "failure"}])
+        with patch("aragora.swarm.merge_arbiter._run_gh") as mock_gh:
+            mock_gh.return_value = _make_gh_result(returncode=8, stdout=payload)
+            assert _get_check_status(1, "owner/repo") == {"lint": "FAILURE"}
+
+    def test_zero_exit_without_checks_is_not_a_fault(self):
+        with patch("aragora.swarm.merge_arbiter._run_gh") as mock_gh:
+            mock_gh.return_value = _make_gh_result(returncode=0, stdout="[]")
+            assert _get_check_status(1, "owner/repo") == {}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Outbox harvest (run-20260610 shift 4)
Published by the gh-authenticated coordinator from `.aragora/automation-outbox` — the writer-lane sandbox validated this branch but could not open the PR (gh unauthenticated; publisher daemon stale since May 18).

- **Branch:** `codex/merge-arbiter-breaker-faults-primary-r2-20260609` @ `c65da471b01a` (head matches outbox record: True)
- **Idempotency key:** `open-pr-codex-merge-arbiter-breaker-faults-primary-r2-20260609-c65da471`
- **Writer objective:** Open the validated clean merge-arbiter breaker restack as a draft PR.
- **Mutation boundary:** Replayed and conflict-resolved one existing merge-arbiter breaker fix onto current origin/main in a disposable worktree; no dirty root-checkout files were touched.
- **Acceptance criteria:** Merge arbiter not-ready PRs with failing or missing checks remain reportable queue state and do not feed the circuit breaker.; Merge arbiter still trips the circuit breaker after consecutive genuine operational faults such as candidate-list or evaluation failures.; Focused pytest, direct smoke, py_compile, Ruff, format check, diff checks, merge-tree, pre-push hooks, and automation PR preflight pass at the exact head.
- **Writer validation:** {'automation_pr_preflight': 'bash scripts/automation_pr_preflight.sh origin/main HEAD: preflight ok; changed files are aragora/swarm/merge_arbiter.py and tests/swarm/test_merge_arbiter.py.', 'diff_check': 'git diff --check origin/main...HEAD and git diff --check: passed.', 'direct_smoke': 'PYTHONPATH=. /Users/armand/.pyenv/versions/3.11.11/bin/python direct smoke: not-ready PR polls reached max ru

Draft for CI + worth-triage; settlement via the standard quorum path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)