### PR TITLE
[outbox-harvest] review-queue merge-packet --json now emits transport_blocked preserve/no-mutate JSON for GitHub transport outages.

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -79,6 +79,7 @@ _GITHUB_TRANSPORT_ERROR_MARKERS = (
     "context deadline exceeded",
     "could not resolve host",
     "error connecting",
+    "failed to start",
     "http 502",
     "http 503",
     "http 504",
@@ -1451,6 +1452,8 @@ def _gh_text(args: list[str]) -> str:
         raise _GhError(
             _command_timeout_message(cmd, int(exc.timeout or GH_COMMAND_TIMEOUT_SECONDS))
         ) from exc
+    except OSError as exc:
+        raise _GhError(f"{' '.join(cmd)} failed to start: {exc}") from exc
     if proc.returncode != 0:
         stderr = proc.stderr.strip() or "no stderr"
         raise _GhError(f"gh {' '.join(args)} failed: {stderr}")
@@ -1472,6 +1475,8 @@ def _gh_json(args: list[str]) -> Any:
         raise _GhError(
             _command_timeout_message(cmd, int(exc.timeout or GH_COMMAND_TIMEOUT_SECONDS))
         ) from exc
+    except OSError as exc:
+        raise _GhError(f"{' '.join(cmd)} failed to start: {exc}") from exc
     if proc.returncode != 0:
         stderr = proc.stderr.strip() or "no stderr"
         raise _GhError(f"gh {' '.join(args)} failed: {stderr}")

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -68,6 +68,28 @@ MODEL_REVIEW_QUEUE_CAP = 6
 MODEL_REVIEW_QUORUM_VERSION = "model_review_quorum.v1"
 HUMAN_SETTLEMENT_CONTEXT = "aragora/human-settlement"
 TIER_FOUR_SETTLEMENT_MARKER = "Tier-4 Human Settlement Authorization"
+GITHUB_TRANSPORT_ERROR_KIND = "github_transport"
+GITHUB_TRANSPORT_BLOCKED_STATUS = "transport_blocked"
+_GITHUB_TRANSPORT_ERROR_MARKERS = (
+    "check your internet connection",
+    "client.timeout exceeded",
+    "connection refused",
+    "connection reset",
+    "connection timed out",
+    "context deadline exceeded",
+    "could not resolve host",
+    "error connecting",
+    "http 502",
+    "http 503",
+    "http 504",
+    "i/o timeout",
+    "net/http",
+    "no such host",
+    "operation timed out",
+    "temporary failure in name resolution",
+    "timeout awaiting response headers",
+    "tls handshake timeout",
+)
 TIER_FOUR_AUTHORIZED_MERGE_TOKENS = ("admin_squash_merge", "admin squash")
 CANONICAL_MODEL_FAMILIES: tuple[str, ...] = (
     "claude",
@@ -1206,6 +1228,15 @@ def _cmd_merge_packet(args: argparse.Namespace) -> int:
             ignore_own_quorum_check=bool(getattr(args, "ignore_own_quorum_check", False)),
         )
     except _GhError as exc:
+        if json_output and _is_github_transport_error(exc):
+            packet = _merge_packet_transport_blocked_envelope(
+                error=str(exc),
+                pr_refs=list(getattr(args, "pr", []) or []),
+                repo_override=getattr(args, "repo", None),
+                limit=int(getattr(args, "limit", 30) or 30),
+            )
+            print(json.dumps(packet, indent=2, sort_keys=True))
+            return 1
         print(f"error: {exc}", file=sys.stderr)
         return 1
     if json_output:
@@ -1451,6 +1482,74 @@ def _gh_json(args: list[str]) -> Any:
         return json.loads(out)
     except json.JSONDecodeError as exc:
         raise _GhError(f"gh {' '.join(args)} returned malformed JSON: {exc}") from exc
+
+
+def _gh_error_kind(error: object) -> str:
+    """Return a stable machine-readable kind for GitHub helper failures."""
+    text = str(error or "").lower()
+    if any(marker in text for marker in _GITHUB_TRANSPORT_ERROR_MARKERS):
+        return GITHUB_TRANSPORT_ERROR_KIND
+    return "github_error"
+
+
+def _is_github_transport_error(error: object) -> bool:
+    return _gh_error_kind(error) == GITHUB_TRANSPORT_ERROR_KIND
+
+
+def _numeric_pr_refs(pr_refs: list[str]) -> list[int]:
+    numbers: list[int] = []
+    for ref in pr_refs:
+        try:
+            numbers.append(_parse_pr_number(str(ref)))
+        except Exception:
+            continue
+    return numbers
+
+
+def _transport_blocked_next_prompt(command_name: str, pr_refs: list[str]) -> str:
+    pr_text = ", ".join(f"#{number}" for number in _numeric_pr_refs(pr_refs)) or "the queue"
+    return (
+        "Do not rely on transcript state. Re-check live GitHub/local state first. "
+        f"Retry {command_name} for {pr_text} only after GitHub API transport recovers. "
+        "Treat this packet as preserve/no-mutate: do not mark ready, collect evidence, "
+        "record settlement, merge, close, label, rerun workflows, or touch branch protection "
+        "while transport is blocked."
+    )
+
+
+def _merge_packet_transport_blocked_envelope(
+    *,
+    error: str,
+    pr_refs: list[str],
+    repo_override: str | None,
+    limit: int,
+) -> dict[str, Any]:
+    return {
+        "version": "merge_authorization_packet.v1",
+        "generated_at": datetime.now(UTC).isoformat(),
+        "status": GITHUB_TRANSPORT_BLOCKED_STATUS,
+        "transport_blocked": True,
+        "preserve_no_mutate": True,
+        "retryable": _is_github_transport_error(error),
+        "error_kind": _gh_error_kind(error),
+        "error": error,
+        "command": "review-queue merge-packet",
+        "repo": repo_override or "",
+        "limit": limit,
+        "pr_refs": [str(ref) for ref in pr_refs],
+        "queue_pressure": {
+            "current_open_prs": len(pr_refs),
+            "cap": MODEL_REVIEW_QUEUE_CAP,
+            "active": False,
+            "scope": "explicit_pr_refs" if pr_refs else "open_pr_queue",
+        },
+        "entries": [],
+        "admin_squash_order": [],
+        "human_risk_settlement_required": [],
+        "not_ready": _numeric_pr_refs(pr_refs),
+        "admin_squash_allowed": False,
+        "next_prompt": _transport_blocked_next_prompt("review-queue merge-packet", pr_refs),
+    }
 
 
 def _resolve_settlement_repo_slug(repo_override: str | None) -> str:

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -5516,6 +5516,80 @@ class TestSettlementHelpers:
         assert payload["admin_squash_order"] == list(range(1, MODEL_REVIEW_QUEUE_CAP + 2))
         assert payload["entries"][0]["verdict"] == "admin_squash_allowed"
 
+    def test_merge_packet_json_reports_transport_blocked(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def fail_transport(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            raise _GhError(
+                "gh pr view 1 --json number failed: error connecting to api.github.com\n"
+                "check your internet connection or https://githubstatus.com"
+            )
+
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._build_merge_authorization_packet",
+            fail_transport,
+        )
+        ns = argparse.Namespace(
+            review_queue_command="merge-packet",
+            pr=["1"],
+            repo="synaptent/aragora",
+            review_queue_root=None,
+            limit=30,
+            execute_reviewers=False,
+            ignore_own_quorum_check=False,
+            json=True,
+        )
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            rc = cmd_review_queue(ns)
+
+        assert rc == 1
+        assert stderr.getvalue() == ""
+        payload = json.loads(stdout.getvalue())
+        assert payload["status"] == "transport_blocked"
+        assert payload["transport_blocked"] is True
+        assert payload["preserve_no_mutate"] is True
+        assert payload["error_kind"] == "github_transport"
+        assert payload["command"] == "review-queue merge-packet"
+        assert payload["repo"] == "synaptent/aragora"
+        assert payload["pr_refs"] == ["1"]
+        assert payload["not_ready"] == [1]
+        assert payload["entries"] == []
+        assert payload["admin_squash_order"] == []
+        assert "do not mark ready" in payload["next_prompt"]
+
+    def test_merge_packet_json_keeps_non_transport_errors_on_stderr(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def fail_permission(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            raise _GhError("gh pr view 1 failed: GraphQL: Resource not accessible by integration")
+
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._build_merge_authorization_packet",
+            fail_permission,
+        )
+        ns = argparse.Namespace(
+            review_queue_command="merge-packet",
+            pr=["1"],
+            repo="synaptent/aragora",
+            review_queue_root=None,
+            limit=30,
+            execute_reviewers=False,
+            ignore_own_quorum_check=False,
+            json=True,
+        )
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            rc = cmd_review_queue(ns)
+
+        assert rc == 1
+        assert stdout.getvalue() == ""
+        assert "Resource not accessible by integration" in stderr.getvalue()
+
     def test_act_command_requires_reason_for_request_changes(self) -> None:
         ns = argparse.Namespace(
             review_queue_command="act",

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -31,7 +31,9 @@ from aragora.cli.commands.review_queue import (
     _filter_lanes,
     _GhError,
     _gh_json,
+    _gh_text,
     _is_high_risk_path,
+    _is_github_transport_error,
     _is_merge_quorum_check,
     _parse_pr_number,
     _record_external_settlement,
@@ -2380,6 +2382,30 @@ class TestGhTimeouts:
             _gh_json(["pr", "view", "7811"])
 
         assert captured["kwargs"]["timeout"] > 0
+
+    def test_gh_json_fails_closed_on_startup_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def fake_run(*_args: Any, **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+            raise OSError("gh executable unavailable")
+
+        monkeypatch.setattr("aragora.cli.commands.review_queue.subprocess.run", fake_run)
+
+        with pytest.raises(_GhError) as exc_info:
+            _gh_json(["pr", "view", "7811"])
+
+        assert "gh pr view 7811 failed to start: gh executable unavailable" in str(exc_info.value)
+        assert _is_github_transport_error(exc_info.value) is True
+
+    def test_gh_text_fails_closed_on_startup_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def fake_run(*_args: Any, **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+            raise OSError("permission denied")
+
+        monkeypatch.setattr("aragora.cli.commands.review_queue.subprocess.run", fake_run)
+
+        with pytest.raises(_GhError) as exc_info:
+            _gh_text(["repo", "view"])
+
+        assert "gh repo view failed to start: permission denied" in str(exc_info.value)
+        assert _is_github_transport_error(exc_info.value) is True
 
 
 # --- _build_queue + _build_packet (with mocked gh) -------------------------


### PR DESCRIPTION
## Outbox harvest (run-20260610 shift 4)

Published by the gh-authenticated coordinator from `.aragora/automation-outbox`; this branch remains scoped to merge-packet helper reliability.

- **Branch:** `codex/merge-packet-transport-json-primary-20260610`
- **Current head:** `1624390088ad54d74cf56bedf701eb32bd08f095`
- **Original idempotency key:** `open-pr-codex-merge-packet-transport-json-primary-20260610-32c350ce`
- **Writer objective:** Keep `review-queue merge-packet --json` machine-readable and preserve/no-mutate during GitHub transport or local `gh` startup outages.
- **Mutation boundary:** Limited to `aragora/cli/commands/review_queue.py` and `tests/cli/commands/test_review_queue.py`.

## Current change

- Emits a `transport_blocked` JSON envelope for merge-packet GitHub transport failures.
- Treats low-level `gh` process-start `OSError` failures as `_GhError` instead of traceback/no-JSON behavior.
- Classifies `gh ... failed to start` as preserve/no-mutate transport-blocked infrastructure failure.

## Validation

- `python3 -m pytest -q tests/cli/commands/test_review_queue.py -k 'GhTimeouts or merge_packet_json_reports_transport_blocked'` -> 4 passed, 225 deselected.
- `python3 -m pytest -q tests/cli/commands/test_review_queue.py` -> 229 passed.
- `python3 -m ruff check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py` -> passed.
- `python3 -m ruff format --check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py` -> already formatted.
- `git diff --check` / `git diff --cached --check` -> passed.
- Commit/push hooks passed, including mypy for changed Aragora files, ruff, ruff format, gitleaks, and portability guard.

Draft for CI + evidence/settlement; settlement via the standard quorum path. This PR does not authorize merge, settlement, branch protection changes, or operator action.
