### PR TITLE
[outbox-harvest] Validated and pushed draft-default open_pr helper fix; PR creation is blocked by gh auth / connector permissions.

### DIFF
--- a/scripts/open_pr.sh
+++ b/scripts/open_pr.sh
@@ -4,18 +4,18 @@ set -euo pipefail
 usage() {
   cat <<'EOF'
 Usage:
-  scripts/open_pr.sh [--base <branch>] [--draft] [-- <extra gh pr create args>]
+  scripts/open_pr.sh [--base <branch>] [--draft|--no-draft] [-- <extra gh pr create args>]
 
 Examples:
   scripts/open_pr.sh
-  scripts/open_pr.sh --draft
+  scripts/open_pr.sh --no-draft
   scripts/open_pr.sh --base main -- --label governance --reviewer octocat
 
 Behavior:
   - Fails on main/master branch.
   - Fails when working tree is dirty.
   - Pushes current branch to origin.
-  - Creates PR with gh using --fill (unless one already exists).
+  - Creates a draft PR with gh using --fill (unless one already exists).
 EOF
 }
 
@@ -48,6 +48,7 @@ fi
 
 base_branch="${BASE_BRANCH:-main}"
 extra_args=()
+draft_pr=true
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -60,7 +61,10 @@ while [[ $# -gt 0 ]]; do
       base_branch="$1"
       ;;
     --draft)
-      extra_args+=("--draft")
+      draft_pr=true
+      ;;
+    --no-draft)
+      draft_pr=false
       ;;
     --)
       shift
@@ -78,6 +82,10 @@ while [[ $# -gt 0 ]]; do
   esac
   shift
 done
+
+if [[ "$draft_pr" == "true" ]]; then
+  extra_args+=("--draft")
+fi
 
 branch="$(git rev-parse --abbrev-ref HEAD)"
 if [[ "$branch" == "main" || "$branch" == "master" ]]; then

--- a/tests/scripts/test_open_pr.py
+++ b/tests/scripts/test_open_pr.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import shlex
 import stat
 import subprocess
 from pathlib import Path
@@ -34,8 +35,13 @@ def _init_repo(tmp_path: Path) -> Path:
     return repo
 
 
-def _stub_gh(path: Path, *, token_available: bool) -> None:
+def _stub_gh(path: Path, *, token_available: bool, calls_file: Path | None = None) -> None:
     token_block = "echo fake-token\nexit 0" if token_available else "exit 1"
+    record_create = (
+        f"  printf '%s\\n' \"$*\" > {shlex.quote(str(calls_file))}\n"
+        if calls_file is not None
+        else ""
+    )
     path.write_text(
         "\n".join(
             [
@@ -59,6 +65,7 @@ def _stub_gh(path: Path, *, token_available: bool) -> None:
                 "  exit 0",
                 "fi",
                 'if [[ "$cmd" == "pr" && "$subcmd" == "create" ]]; then',
+                record_create.rstrip("\n"),
                 '  echo "https://example.com/pr/123"',
                 "  exit 0",
                 "fi",
@@ -72,10 +79,12 @@ def _stub_gh(path: Path, *, token_available: bool) -> None:
     path.chmod(path.stat().st_mode | stat.S_IEXEC)
 
 
-def _env_with_stub(tmp_path: Path, *, token_available: bool) -> dict[str, str]:
+def _env_with_stub(
+    tmp_path: Path, *, token_available: bool, calls_file: Path | None = None
+) -> dict[str, str]:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
-    _stub_gh(bin_dir / "gh", token_available=token_available)
+    _stub_gh(bin_dir / "gh", token_available=token_available, calls_file=calls_file)
     env = os.environ.copy()
     env["PATH"] = f"{bin_dir}:{env['PATH']}"
     return env
@@ -90,6 +99,45 @@ def test_open_pr_uses_cached_token_when_auth_status_is_unavailable(tmp_path: Pat
     assert proc.returncode == 0
     assert "https://example.com/pr/123" in proc.stdout
     assert "gh is not authenticated" not in proc.stderr
+
+
+def test_open_pr_creates_draft_by_default(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    calls_file = tmp_path / "gh-pr-create.args"
+    env = _env_with_stub(tmp_path, token_available=True, calls_file=calls_file)
+
+    proc = _run(["bash", str(SCRIPT)], cwd=repo, env=env)
+
+    assert proc.returncode == 0, proc.stderr
+    assert calls_file.read_text(encoding="utf-8").strip().split() == [
+        "pr",
+        "create",
+        "--base",
+        "main",
+        "--head",
+        "codex/fix-open-pr-auth",
+        "--fill",
+        "--draft",
+    ]
+
+
+def test_open_pr_no_draft_omits_draft_flag(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    calls_file = tmp_path / "gh-pr-create.args"
+    env = _env_with_stub(tmp_path, token_available=True, calls_file=calls_file)
+
+    proc = _run(["bash", str(SCRIPT), "--no-draft"], cwd=repo, env=env)
+
+    assert proc.returncode == 0, proc.stderr
+    assert calls_file.read_text(encoding="utf-8").strip().split() == [
+        "pr",
+        "create",
+        "--base",
+        "main",
+        "--head",
+        "codex/fix-open-pr-auth",
+        "--fill",
+    ]
 
 
 def test_open_pr_still_fails_when_no_gh_token_is_available(tmp_path: Path) -> None:


### PR DESCRIPTION
## Outbox harvest (run-20260610 shift 4)
Published by the gh-authenticated coordinator from `.aragora/automation-outbox` — the writer-lane sandbox validated this branch but could not open the PR (gh unauthenticated; publisher daemon stale since May 18).

- **Branch:** `codex/open-pr-draft-default-primary-20260608` @ `02767c6ce1cc` (head matches outbox record: True)
- **Idempotency key:** `open-pr-codex-open-pr-draft-default-primary-20260608-02767c6c`
- **Writer objective:** Keep automation publication branches safely draft-first while preserving an explicit non-draft escape hatch for authenticated publisher operators.
- **Mutation boundary:** Limited to scripts/open_pr.sh and tests/scripts/test_open_pr.py.
- **Acceptance criteria:** scripts/open_pr.sh creates draft pull requests by default.; scripts/open_pr.sh supports --no-draft as the explicit opt-out.; tests/scripts/test_open_pr.py asserts the exact gh pr create arguments for default draft and --no-draft modes.; The change is one commit ahead of origin/main, merge-tree clean, pushed to origin, and automation PR preflight clean.
- **Writer validation:** {'focused_pytest': '/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_open_pr.py -q: 4 passed.', 'ruff_check': '/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check tests/scripts/test_open_pr.py: All checks passed.', 'ruff_format': '/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check tests/scripts/test_open_pr.py: 1 file already formatted.'

Draft for CI + worth-triage; settlement via the standard quorum path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)