### PR TITLE
[outbox-harvest] operator-snapshot now supports an opt-in lane detail cap while preserving complete routing summaries.

### DIFF
--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -569,6 +569,16 @@ def _sync_lane_records(records: list[LaneRecord], sessions: list[Session]) -> li
     return records
 
 
+def _non_negative_int(raw: str) -> int:
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a non-negative integer") from exc
+    if value < 0:
+        raise argparse.ArgumentTypeError("must be a non-negative integer")
+    return value
+
+
 def _conflict_lane_resolved_by_completed_owner(
     record: LaneRecord, records: list[LaneRecord]
 ) -> bool:
@@ -2443,6 +2453,7 @@ def _emit_text(output: str) -> int:
 def cmd_operator_snapshot(args: argparse.Namespace) -> int:
     """Output a unified operator snapshot combining sessions, lanes, and health."""
     summary_only = bool(getattr(args, "summary_only", False))
+    lane_limit = getattr(args, "lane_limit", None)
     include_historical = bool(getattr(args, "include_historical", False)) or (
         getattr(args, "scope", "current") == "all"
     )
@@ -2461,6 +2472,11 @@ def cmd_operator_snapshot(args: argparse.Namespace) -> int:
     records = _sync_lane_records(_load_lane_registry(), sessions)
     if not include_historical:
         records = _filter_current_lane_records(records)
+    visible_records = records
+    lane_records_omitted = 0
+    if lane_limit is not None and not summary_only:
+        visible_records = records[:lane_limit]
+        lane_records_omitted = max(0, len(records) - len(visible_records))
 
     issues = _collect_health_issues(sessions, records)
     lane_conflicts = _active_lane_identity_conflicts(records)
@@ -2510,7 +2526,7 @@ def cmd_operator_snapshot(args: argparse.Namespace) -> int:
         "timestamp": _now_iso(),
         "sessions": [s.to_dict() for s in sessions],
         "broker_runs": broker_runs,
-        "lanes": [r.to_dict() for r in records],
+        "lanes": [r.to_dict() for r in visible_records],
         "lane_conflicts": lane_conflicts,
         "process_census": process_census,
         "health": {"ok": len(issues) == 0, "issues": issues},
@@ -2523,6 +2539,9 @@ def cmd_operator_snapshot(args: argparse.Namespace) -> int:
         "boss_loop_status": boss_loop_status,
         "summary": summary,
     }
+    if lane_limit is not None and not summary_only:
+        snapshot["lane_record_limit"] = lane_limit
+        snapshot["lane_records_omitted"] = lane_records_omitted
     if summary_only:
         snapshot.pop("sessions")
         snapshot.pop("lanes")
@@ -2546,6 +2565,8 @@ def cmd_operator_snapshot(args: argparse.Namespace) -> int:
     lines.append(
         f"Lanes:    {summary['active_lanes']} active / {summary['conflict_lanes']} conflict"
     )
+    if lane_limit is not None and not summary_only:
+        lines.append(f"LaneRows: {len(visible_records)} shown / {lane_records_omitted} omitted")
     active_process_roles = [str(role) for role in summary.get("active_process_roles", [])]
     process_roles = ", ".join(active_process_roles) or "-"
     lines.append(f"Processes:{summary['active_processes']} recognized ({process_roles})")
@@ -2562,10 +2583,10 @@ def cmd_operator_snapshot(args: argparse.Namespace) -> int:
             summary_text = (s.summary[:40] + "..." if len(s.summary) > 40 else s.summary) or "-"
             lines.append(f"{s.name:<24} {s.agent:<8} {s.status:<8} {branch:<28} {summary_text}")
 
-    if records and not summary_only:
+    if visible_records and not summary_only:
         lines.extend(["", f"{'LANE':<22} {'OWNER':<24} {'STATUS':<10} NEXT ACTION"])
         lines.append("-" * 90)
-        for r in records:
+        for r in visible_records:
             next_action = (
                 r.next_action[:40] + "..." if len(r.next_action) > 40 else r.next_action
             ) or "-"
@@ -2848,6 +2869,16 @@ def main() -> int:
         "--summary-only",
         action="store_true",
         help="Omit session and lane records from output for compact automation checks.",
+    )
+    operator_snapshot_p.add_argument(
+        "--lane-limit",
+        type=_non_negative_int,
+        default=None,
+        metavar="N",
+        help=(
+            "Maximum lane records to include in full snapshots. Summary counts, "
+            "health checks, and conflict detection still use all lanes."
+        ),
     )
     operator_snapshot_p.add_argument(
         "--include-historical",

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -440,6 +440,71 @@ def test_operator_snapshot_summary_only_json_omits_records(
     assert discover_include_summaries == [False]
 
 
+def test_operator_snapshot_lane_limit_bounds_full_json_records(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import agent_bridge as mod
+
+    _patch_bridge_paths(mod, tmp_path, monkeypatch)
+    lane_records = [
+        mod.LaneRecord(
+            lane_id=f"lane-{index}",
+            owner_session=f"codex-{index}",
+            status="active",
+            next_action=f"work item {index}",
+        )
+        for index in range(3)
+    ]
+    monkeypatch.setattr(
+        mod,
+        "_discover_with_broker_state",
+        lambda **_kwargs: ([], [], set()),
+    )
+    monkeypatch.setattr(mod, "_enrich_prs", lambda _sessions: None)
+    monkeypatch.setattr(mod, "_write_session_snapshot", lambda _sessions: None)
+    monkeypatch.setattr(mod, "_load_lane_registry", lambda: lane_records)
+    monkeypatch.setattr(
+        mod,
+        "_collect_agent_process_census",
+        lambda *, include_records=True, record_limit=None, ps_lines=None: {
+            "ok": True,
+            "total": 0,
+            "by_role": {},
+        },
+    )
+    monkeypatch.setattr(
+        mod,
+        "_collect_pending_steering_messages",
+        lambda _recipient: {"count": 0, "latest_three": []},
+    )
+    monkeypatch.setattr(
+        mod,
+        "_collect_agent_heartbeats",
+        lambda: {"count": 0, "fresh_count": 0, "stale_count": 0, "latest_by_owner": {}},
+    )
+    monkeypatch.setattr(mod, "_collect_b0_success_rate", lambda: None)
+
+    rc = mod.cmd_operator_snapshot(
+        argparse.Namespace(
+            json=True,
+            summary_only=False,
+            include_historical=False,
+            scope="current",
+            lane_limit=1,
+            steering_recipient=None,
+        )
+    )
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert [lane["lane_id"] for lane in payload["lanes"]] == ["lane-0"]
+    assert payload["summary"]["active_lanes"] == 3
+    assert payload["lane_record_limit"] == 1
+    assert payload["lane_records_omitted"] == 2
+
+
 def test_operator_snapshot_json_suppresses_broken_pipe(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Outbox harvest (run-20260610 shift 4)
Published by the gh-authenticated coordinator from `.aragora/automation-outbox` — the writer-lane sandbox validated this branch but could not open the PR (gh unauthenticated; publisher daemon stale since May 18).

- **Branch:** `codex/operator-snapshot-lane-limit-primary-20260610` @ `67f2619dbf16` (head matches outbox record: True)
- **Idempotency key:** `open-pr-codex-operator-snapshot-lane-limit-primary-20260610-67f2619d`
- **Writer objective:** Let operators inspect bounded full operator-snapshot lane detail without losing complete summary, health, and conflict calculations.
- **Mutation boundary:** Added an opt-in --lane-limit flag for full operator-snapshot output; default full snapshots and summary-only behavior remain unchanged.
- **Acceptance criteria:** Open or update a draft PR from codex/operator-snapshot-lane-limit-primary-20260610 to main.; Apply labels codex and codex-automation.; Bind publication to exact head 67f2619dbf16e757ef807dc836562ffddbe8dd04.; Keep the PR scoped to opt-in operator-snapshot lane record limiting plus focused tests.
- **Writer validation:** {'source': 'local_evidence.validation', 'summary': 'Current-base branch passed focused tests, static checks, live smoke, merge-tree, push hooks, and automation PR preflight; publication remains blocked by gh authentication.'}

Draft for CI + worth-triage; settlement via the standard quorum path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)