### PR TITLE
[outbox-harvest] operator-snapshot now reports configured live proof/status docs in JSON and text output.

### DIFF
--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -97,6 +97,10 @@ RESOLVED_STEERING_OUTCOMES = {
     "completed",
 }
 DEFAULT_B0_SCORECARD_TIMEOUT_SECONDS = 5.0
+LIVE_PROOF_SURFACE_DOCS = (
+    "docs/status/B0_BENCHMARK_TRUTH_STATUS.md",
+    "docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md",
+)
 
 
 class _LazyTransportError(Exception):
@@ -2325,6 +2329,17 @@ def _collect_b0_success_rate(repo_root: Path | None = None) -> float | None:
     return _coerce_success_rate(payload.get("no_rescue_success_rate", payload.get("success_rate")))
 
 
+def _collect_proof_surfaces(repo_root: Path | None = None) -> list[dict[str, Any]]:
+    root = repo_root or CANONICAL_REPO_ROOT
+    return [
+        {
+            "path": path,
+            "exists": (root / path).exists(),
+        }
+        for path in LIVE_PROOF_SURFACE_DOCS
+    ]
+
+
 def _mute_stdout_after_broken_pipe() -> None:
     """Avoid interpreter-shutdown tracebacks after downstream pipes close.
 
@@ -2424,6 +2439,7 @@ def cmd_operator_snapshot(args: argparse.Namespace) -> int:
         "agent_heartbeats": agent_heartbeats,
         "queue_depth": _operator_queue_depth(summary, pending_steering),
         "success_rate": _collect_b0_success_rate(),
+        "proof_surfaces": _collect_proof_surfaces(),
         "recent_blockers": _operator_recent_blockers(issues, pending_steering),
         "boss_loop_alive": bool(boss_loop_status["alive"]),
         "boss_loop_status": boss_loop_status,
@@ -2457,6 +2473,10 @@ def cmd_operator_snapshot(args: argparse.Namespace) -> int:
     lines.append(f"Processes:{summary['active_processes']} recognized ({process_roles})")
     boss_loop_label = "alive" if boss_loop_status["alive"] else "idle"
     lines.append(f"BossLoop: {boss_loop_label} ({boss_loop_status['reason']})")
+    proof_surface_paths = ", ".join(
+        str(surface["path"]) for surface in snapshot["proof_surfaces"] if surface.get("exists")
+    )
+    lines.append(f"Proof:    {proof_surface_paths or 'no live proof status docs found'}")
     health_status = "OK" if snapshot["health"]["ok"] else f"{summary['health_issues']} issue(s)"
     lines.append(f"Health:   {health_status}")
 

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -555,8 +555,13 @@ def test_operator_snapshot_exposes_b0_issue_contract_fields(
     repo_root = tmp_path / "repo"
     (repo_root / "scripts").mkdir(parents=True)
     (repo_root / "docs" / "benchmarks").mkdir(parents=True)
+    (repo_root / "docs" / "status").mkdir(parents=True)
     (repo_root / "scripts" / "measure_b0_scorecard.py").write_text("# fixture\n")
     (repo_root / "docs" / "benchmarks" / "corpus.json").write_text("{}\n")
+    (repo_root / "docs" / "status" / "TW03_RESCUE_PRODUCTIZATION_STATUS.md").write_text(
+        "# TW03 status\n",
+        encoding="utf-8",
+    )
     mod.AGENT_BRIDGE_DIR.mkdir(parents=True, exist_ok=True)
     mod.LANE_REGISTRY_FILE.write_text(
         json.dumps(
@@ -649,6 +654,16 @@ def test_operator_snapshot_exposes_b0_issue_contract_fields(
     payload = json.loads(capsys.readouterr().out)
     assert payload["queue_depth"] == 3
     assert payload["success_rate"] == 0.625
+    assert payload["proof_surfaces"] == [
+        {
+            "path": "docs/status/B0_BENCHMARK_TRUTH_STATUS.md",
+            "exists": False,
+        },
+        {
+            "path": "docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md",
+            "exists": True,
+        },
+    ]
     assert payload["boss_loop_alive"] is True
     assert payload["boss_loop_status"] == {
         "alive": True,
@@ -944,6 +959,26 @@ def test_collect_b0_success_rate_times_out_fail_closed(
     monkeypatch.setattr(mod.subprocess, "run", fake_run)
 
     assert mod._collect_b0_success_rate(repo_root) is None
+
+
+def test_collect_proof_surfaces_reports_status_doc_existence(tmp_path: Path) -> None:
+    import agent_bridge as mod
+
+    repo_root = tmp_path / "repo"
+    proof_doc = repo_root / "docs" / "status" / "B0_BENCHMARK_TRUTH_STATUS.md"
+    proof_doc.parent.mkdir(parents=True)
+    proof_doc.write_text("# B0 status\n", encoding="utf-8")
+
+    assert mod._collect_proof_surfaces(repo_root) == [
+        {
+            "path": "docs/status/B0_BENCHMARK_TRUTH_STATUS.md",
+            "exists": True,
+        },
+        {
+            "path": "docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md",
+            "exists": False,
+        },
+    ]
 
 
 def test_operator_snapshot_summary_counts_repo_local_lane_when_user_registry_exists(


### PR DESCRIPTION
## Outbox harvest (run-20260610 shift 4)
Published by the gh-authenticated coordinator from `.aragora/automation-outbox` — the writer-lane sandbox validated this branch but could not open the PR (gh unauthenticated; publisher daemon stale since May 18).

- **Branch:** `codex/operator-snapshot-proof-surfaces-primary-20260606` @ `93abb05f053e` (head matches outbox record: True)
- **Idempotency key:** `open-pr-codex-operator-snapshot-proof-surfaces-primary-20260606-93abb05f`
- **Writer objective:** Surface live proof/status documents in operator snapshots so automation lanes can see whether benchmark-truth and TW03 productization proof surfaces exist without opening docs manually.
- **Mutation boundary:** Limited to operator-snapshot proof-surface output in scripts/agent_bridge.py plus focused tests/scripts/test_agent_bridge.py coverage.
- **Acceptance criteria:** Open or update a draft PR from codex/operator-snapshot-proof-surfaces-primary-20260606 to main.; Apply labels codex and codex-automation.; Bind publication to exact head 93abb05f053e67478b64f5dc0e8e5afb0e944214.; Keep the PR scoped to scripts/agent_bridge.py and tests/scripts/test_agent_bridge.py.
- **Writer validation:** {'automation_pr_preflight': 'bash scripts/automation_pr_preflight.sh origin/main HEAD: preflight ok; changed files are scripts/agent_bridge.py and tests/scripts/test_agent_bridge.py.', 'diff_check': 'git diff --check origin/main...HEAD and git diff --check: passed.', 'focused_pytest': "PYTHONDONTWRITEBYTECODE=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTEST_ADDOPTS='-p no:cacheprovider' /Users/armand/.py

Draft for CI + worth-triage; settlement via the standard quorum path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)