### PR TITLE
[outbox-harvest] operator snapshots now reject non-finite and out-of-range success rates.

### DIFF
--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
 import re
 import shutil
@@ -2367,11 +2368,15 @@ def _coerce_success_rate(raw_rate: Any) -> float | None:
     if raw_rate is None or isinstance(raw_rate, bool):
         return None
     if isinstance(raw_rate, int | float):
-        return float(raw_rate)
-    try:
-        return float(str(raw_rate))
-    except ValueError:
+        rate = float(raw_rate)
+    else:
+        try:
+            rate = float(str(raw_rate))
+        except ValueError:
+            return None
+    if not math.isfinite(rate) or rate < 0.0 or rate > 1.0:
         return None
+    return rate
 
 
 def _b0_scorecard_timeout_seconds() -> float:

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -946,6 +946,39 @@ def test_collect_b0_success_rate_times_out_fail_closed(
     assert mod._collect_b0_success_rate(repo_root) is None
 
 
+@pytest.mark.parametrize(
+    ("raw_rate", "expected"),
+    [
+        (0, 0.0),
+        (1, 1.0),
+        (0.625, 0.625),
+        ("0.25", 0.25),
+        (None, None),
+        (True, None),
+        ("not-a-number", None),
+        (float("nan"), None),
+        (float("inf"), None),
+        ("-inf", None),
+        (-0.01, None),
+        (1.01, None),
+        ("nan", None),
+        ("1.01", None),
+    ],
+)
+def test_coerce_success_rate_rejects_non_finite_and_out_of_range_values(
+    raw_rate: object,
+    expected: float | None,
+) -> None:
+    import agent_bridge as mod
+
+    actual = mod._coerce_success_rate(raw_rate)
+
+    if expected is None:
+        assert actual is None
+    else:
+        assert actual == expected
+
+
 def test_operator_snapshot_summary_counts_repo_local_lane_when_user_registry_exists(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Outbox harvest (run-20260610 shift 4)
Published by the gh-authenticated coordinator from `.aragora/automation-outbox` — the writer-lane sandbox validated this branch but could not open the PR (gh unauthenticated; publisher daemon stale since May 18).

- **Branch:** `codex/operator-snapshot-success-rate-guard-primary-20260610` @ `f81183aa5022` (head matches outbox record: True)
- **Idempotency key:** `open-pr-codex-operator-snapshot-success-rate-guard-primary-20260610-f81183aa`
- **Writer objective:** Keep operator snapshots from reporting invalid B0 scorecard success rates as real automation health metrics.
- **Mutation boundary:** Limited to operator snapshot success-rate coercion and focused tests for valid, non-finite, malformed, and out-of-range values.
- **Acceptance criteria:** Open or update a draft PR from codex/operator-snapshot-success-rate-guard-primary-20260610 to main.; Apply labels codex and codex-automation.; Bind publication to exact head f81183aa5022cb11f5e9f0cdeea98d5193b19718.; Keep the PR scoped to scripts/agent_bridge.py and tests/scripts/test_agent_bridge.py.
- **Writer validation:** {'automation_pr_preflight': 'bash scripts/automation_pr_preflight.sh origin/main HEAD: preflight ok; changed files are scripts/agent_bridge.py and tests/scripts/test_agent_bridge.py.', 'diff_check': 'git diff --check origin/main...HEAD and git diff --check: passed.', 'focused_pytest': 'PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/scripts/test_agent_bridge.py: 76 passed, 2 existing p

Draft for CI + worth-triage; settlement via the standard quorum path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)