### PR TITLE
[outbox-harvest] Phase0B benchmark result capture now rejects malformed existing results files instead of resetting history.

### DIFF
--- a/scripts/phase0b_role_benchmark.py
+++ b/scripts/phase0b_role_benchmark.py
@@ -94,8 +94,10 @@ def _load_json(path: Path, default: Any) -> Any:
         return default
     try:
         return json.loads(path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
-        return default
+    except OSError as exc:
+        raise ValueError(f"Cannot read JSON file {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Malformed JSON file {path}: {exc.msg}") from exc
 
 
 def _write_json(path: Path, payload: Any) -> None:
@@ -388,8 +390,12 @@ def validate_result_row(row: dict[str, Any]) -> None:
 
 def _upsert_result(row: dict[str, Any]) -> None:
     validate_result_row(row)
-    _ensure_layout()
-    payload = _load_json(RESULTS_JSON_PATH, {"runs": []})
+    if RESULTS_JSON_PATH.exists():
+        payload = _load_json(RESULTS_JSON_PATH, {"runs": []})
+        _ensure_layout()
+    else:
+        _ensure_layout()
+        payload = _load_json(RESULTS_JSON_PATH, {"runs": []})
     runs = [dict(item) for item in payload.get("runs", []) if isinstance(item, dict)]
     key = (
         str(row.get("experiment_id", "")),

--- a/tests/scripts/test_phase0b_role_benchmark.py
+++ b/tests/scripts/test_phase0b_role_benchmark.py
@@ -62,6 +62,20 @@ def test_validate_result_row_rejects_primary_commit_outside_list() -> None:
         phase0b_role_benchmark.validate_result_row(row)
 
 
+def test_load_json_returns_default_for_missing_file(tmp_path: Path) -> None:
+    default = {"runs": []}
+
+    assert phase0b_role_benchmark._load_json(tmp_path / "missing.json", default) == default
+
+
+def test_load_json_rejects_malformed_existing_file(tmp_path: Path) -> None:
+    path = tmp_path / "results.json"
+    path.write_text("{not-json", encoding="utf-8")
+
+    with pytest.raises(ValueError, match=r"Malformed JSON file .*results\.json"):
+        phase0b_role_benchmark._load_json(path, {"runs": []})
+
+
 def test_upsert_result_rejects_invalid_rows_before_creating_outputs(
     tmp_path: Path,
     monkeypatch,
@@ -79,6 +93,27 @@ def test_upsert_result_rejects_invalid_rows_before_creating_outputs(
         phase0b_role_benchmark._upsert_result(_result_row(worker_commit_count=2))
 
     assert not experiment_dir.exists()
+
+
+def test_upsert_result_rejects_malformed_existing_results_without_overwrite(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    experiment_dir = tmp_path / "phase0b_role_benchmark"
+    experiment_dir.mkdir()
+    results_json = experiment_dir / "results.json"
+    results_json.write_text("{not-json", encoding="utf-8")
+    monkeypatch.setattr(phase0b_role_benchmark, "EXPERIMENT_DIR", experiment_dir)
+    monkeypatch.setattr(phase0b_role_benchmark, "RUNS_DIR", experiment_dir / "runs")
+    monkeypatch.setattr(phase0b_role_benchmark, "ACTIVE_RUN_PATH", experiment_dir / "active.json")
+    monkeypatch.setattr(phase0b_role_benchmark, "RESULTS_JSON_PATH", results_json)
+    monkeypatch.setattr(phase0b_role_benchmark, "RESULTS_CSV_PATH", experiment_dir / "results.csv")
+
+    with pytest.raises(ValueError, match=r"Malformed JSON file .*results\.json"):
+        phase0b_role_benchmark._upsert_result(_result_row())
+
+    assert results_json.read_text(encoding="utf-8") == "{not-json"
+    assert not (experiment_dir / "results.csv").exists()
 
 
 def test_build_result_row_includes_multi_branch_metadata(


### PR DESCRIPTION
## Outbox harvest (run-20260610 shift 4)
Published by the gh-authenticated coordinator from `.aragora/automation-outbox` — the writer-lane sandbox validated this branch but could not open the PR (gh unauthenticated; publisher daemon stale since May 18).

- **Branch:** `codex/phase0b-results-json-guard-primary-r2-20260610` @ `420a309ba903` (head matches outbox record: True)
- **Idempotency key:** `open-pr-codex-phase0b-results-json-guard-primary-r2-20260610-420a309b`
- **Writer objective:** Prevent Phase0B benchmark truth from silently overwriting malformed result history with an empty default payload.
- **Mutation boundary:** Restacked only the two-file source diff onto current origin/main because the source branch commit was already pushed and lacked the automation co-author trailer; no pushed commit was amended.
- **Acceptance criteria:** Phase0B result capture rejects malformed existing results.json instead of silently replacing it with an empty default result set.; Missing results.json still initializes the default payload.; Focused tests, static checks, direct malformed-results smoke, diff checks, merge-tree, push hooks, and automation PR preflight pass at the exact head.
- **Writer validation:** {'source': 'local_evidence.validation', 'summary': 'Current-base branch passed focused tests, static checks, malformed-results smoke, merge-tree, push hooks, and automation PR preflight; publication remains blocked by gh authentication.'}

Draft for CI + worth-triage; settlement via the standard quorum path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)