### PR TITLE
[outbox-harvest] Preflight JSON now suggests publisher startup import smokes for publisher helper changes.

### DIFF
--- a/scripts/automation_pr_preflight.sh
+++ b/scripts/automation_pr_preflight.sh
@@ -17,6 +17,7 @@ test_changes=""
 docs_only_changes=""
 forbidden_files=""
 rescue_publish_files=""
+publisher_startup_changes=""
 docs_only=false
 
 usage() {
@@ -49,6 +50,7 @@ emit_json() {
     export PREFLIGHT_DOCS_ONLY="${docs_only}"
     export PREFLIGHT_FORBIDDEN_FILES="${forbidden_files}"
     export PREFLIGHT_RESCUE_PUBLISH_FILES="${rescue_publish_files}"
+    export PREFLIGHT_PUBLISHER_STARTUP_CHANGES="${publisher_startup_changes}"
     python3 -c '
 import json
 import os
@@ -61,6 +63,7 @@ def lines(name: str) -> list[str]:
 
 source_changes = lines("PREFLIGHT_SOURCE_CHANGES")
 test_changes = lines("PREFLIGHT_TEST_CHANGES")
+publisher_startup_changes = lines("PREFLIGHT_PUBLISHER_STARTUP_CHANGES")
 python_sources = [path for path in source_changes if path.endswith(".py")]
 suggested_commands: list[str] = []
 if python_sources:
@@ -72,6 +75,17 @@ if python_sources:
 if test_changes:
     quoted_tests = " ".join(shlex.quote(path) for path in test_changes)
     suggested_commands.append(f"python3 -m pytest {quoted_tests} -q")
+if publisher_startup_changes:
+    startup_modules = (
+        "scripts.cache_codex_automation_github_status",
+        "scripts.publish_automation_handoffs",
+        "scripts.publish_codex_automation_branches",
+        "scripts.github_cli_health",
+    )
+    suggested_commands.append(
+        "python3 -c \"import importlib; [importlib.import_module(module) "
+        f"for module in {startup_modules!r}]\""
+    )
 
 payload = {
     "base_ref": os.environ["PREFLIGHT_BASE_REF"],
@@ -172,6 +186,7 @@ fi
 
 source_changes="$(printf '%s\n' "${changed_files}" | grep -E '(^aragora/|^scripts/|^\.github/|^tests/).*\.(py|sh|ya?ml|toml|json|ts|tsx|js|jsx)$' || true)"
 test_changes="$(printf '%s\n' "${changed_files}" | grep -E '(^tests/|__tests__/|\.test\.|\.spec\.)' || true)"
+publisher_startup_changes="$(printf '%s\n' "${changed_files}" | grep -E '^scripts/(cache_codex_automation_github_status|github_cli_health|publish_automation_handoffs|publish_codex_automation_branches)\.py$' || true)"
 docs_only_changes="$(printf '%s\n' "${changed_files}" | grep -Ev '(^docs/|^docs-site/|\.md$)' || true)"
 if [[ -z "${docs_only_changes}" ]]; then
     docs_only=true

--- a/tests/scripts/test_automation_pr_preflight.py
+++ b/tests/scripts/test_automation_pr_preflight.py
@@ -118,6 +118,32 @@ def test_automation_pr_preflight_json_suggests_validation_for_source_without_tes
     ]
 
 
+def test_automation_pr_preflight_json_suggests_publisher_startup_smoke(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _run(["git", "switch", "-c", "codex/publisher-startup-json"], cwd=repo)
+    source = repo / "scripts" / "publish_codex_automation_branches.py"
+    source.parent.mkdir()
+    source.write_text("print('publisher')\n", encoding="utf-8")
+    _run(["git", "add", "scripts/publish_codex_automation_branches.py"], cwd=repo)
+    _run(["git", "commit", "-m", "fix: update publisher startup"], cwd=repo)
+
+    proc = _run(["bash", str(SCRIPT), "--json", "origin/main", "HEAD"], cwd=repo)
+
+    assert proc.returncode == 0
+    payload = json.loads(proc.stdout)
+    assert payload["status"] == "ok"
+    startup_command = next(
+        command
+        for command in payload["suggested_validation_commands"]
+        if command.startswith('python3 -c "import importlib;')
+    )
+    assert "scripts.publish_codex_automation_branches" in startup_command
+    assert "scripts.github_cli_health" in startup_command
+    assert "'scripts.github_cli_health'" in startup_command
+
+
 def test_automation_pr_preflight_rejects_synthetic_preflight_commit_subject(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Outbox harvest (run-20260610 shift 4)
Published by the gh-authenticated coordinator from `.aragora/automation-outbox` — the writer-lane sandbox validated this branch but could not open the PR (gh unauthenticated; publisher daemon stale since May 18).

- **Branch:** `codex/preflight-publisher-startup-smoke-primary-20260608` @ `7db9e0d560d1` (head matches outbox record: True)
- **Idempotency key:** `open-pr-codex-preflight-publisher-startup-smoke-primary-20260608-7db9e0d5`
- **Writer objective:** Make automation PR preflight suggest a lightweight publisher startup import smoke for publisher/cache/GitHub-health script changes.
- **Mutation boundary:** Limited to scripts/automation_pr_preflight.sh JSON suggested-validation generation and tests/scripts/test_automation_pr_preflight.py.
- **Acceptance criteria:** automation_pr_preflight JSON suggestions include a publisher startup import-smoke command when publisher/cache/GitHub-health entrypoints change.; The emitted startup-smoke command keeps module names quoted and executable under python3 -c.; Focused preflight regression tests, Ruff, shell syntax, live JSON smoke, diff checks, merge-tree, push, and automation PR preflight pass.
- **Writer validation:** {'automation_pr_preflight': 'bash scripts/automation_pr_preflight.sh origin/main HEAD: preflight ok; changed files are scripts/automation_pr_preflight.sh and tests/scripts/test_automation_pr_preflight.py.', 'diff_check': 'git diff --check origin/main...HEAD and git diff --check: passed.', 'focused_pytest': 'python3 -m pytest tests/scripts/test_automation_pr_preflight.py -q: 17 passed.', 'git_cherr

Draft for CI + worth-triage; settlement via the standard quorum path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)