### PR TITLE
[outbox-harvest] Prompt-engine profile guard branch is validated and ready for draft PR publication.

### DIFF
--- a/scripts/profile_prompt_engine.py
+++ b/scripts/profile_prompt_engine.py
@@ -197,6 +197,9 @@ def build_profile_report(
     mode: str,
 ) -> dict[str, Any]:
     """Aggregate one or more prompt-engine timing samples."""
+    if not timings:
+        raise ValueError("prompt engine profile report requires at least one timing sample")
+
     stage_samples: dict[str, list[float]] = defaultdict(list)
     operation_samples: dict[str, list[float]] = defaultdict(list)
     operation_meta: dict[str, dict[str, str]] = {}

--- a/tests/scripts/test_profile_prompt_engine.py
+++ b/tests/scripts/test_profile_prompt_engine.py
@@ -1,7 +1,22 @@
 from __future__ import annotations
 
+import pytest
+
 from aragora.prompt_engine.timing import OperationTiming, PipelineTiming
 from scripts.profile_prompt_engine import build_profile_report
+
+
+def test_build_profile_report_rejects_empty_timing_samples() -> None:
+    with pytest.raises(ValueError, match="requires at least one timing sample"):
+        build_profile_report(
+            prompt="Profile the prompt engine",
+            timings=[],
+            profile="founder",
+            depth="quick",
+            skip_research=False,
+            skip_interrogation=False,
+            mode="mock-agent",
+        )
 
 
 def test_build_profile_report_aggregates_stage_and_operation_baselines() -> None:


### PR DESCRIPTION
## Outbox harvest (run-20260610 shift 4)
Published by the gh-authenticated coordinator from `.aragora/automation-outbox` — the writer-lane sandbox validated this branch but could not open the PR (gh unauthenticated; publisher daemon stale since May 18).

- **Branch:** `codex/prompt-engine-profile-guards-primary-20260609` @ `a35cd3b6bd67` (head matches outbox record: True)
- **Idempotency key:** `open-pr-codex-prompt-engine-profile-guards-primary-20260609-a35cd3b6`
- **Writer objective:** Open the validated prompt-engine profile guard branch as a draft PR.
- **Mutation boundary:** No source edits beyond replaying the existing one-commit prompt-engine profile guard into a writable Primary branch from current origin/main.
- **Acceptance criteria:** Prompt-engine profile report generation rejects empty timing samples instead of emitting a zero-run aggregate.; Focused regression covers the empty timing sample path.; Focused pytest, Ruff, format check, diff checks, merge-tree, pre-push hooks, and automation PR preflight pass at the exact head.
- **Writer validation:** {'automation_pr_preflight': 'bash scripts/automation_pr_preflight.sh origin/main HEAD: preflight ok; changed files are scripts/profile_prompt_engine.py and tests/scripts/test_profile_prompt_engine.py.', 'diff_check': 'git diff --check origin/main...HEAD: passed; git diff --check: passed.', 'focused_pytest': 'PYTHONDONTWRITEBYTECODE=1 /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests

Draft for CI + worth-triage; settlement via the standard quorum path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)