### PR TITLE
[outbox-harvest] Publisher planning no longer crashes on vanished worktree metadata.

### DIFF
--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -673,9 +673,14 @@ def _has_active_session(path: Path) -> bool:
 
 
 def _worktree_is_dirty(path: Path) -> bool:
+    if not path.is_dir():
+        return False
     # Ignore untracked files here so unrelated local docs/scratch files in an
     # attached worktree do not block publishing an already committed branch.
-    proc = _run(["git", "status", "--porcelain", "--untracked-files=no"], cwd=path)
+    try:
+        proc = _run(["git", "status", "--porcelain", "--untracked-files=no"], cwd=path)
+    except FileNotFoundError:
+        return False
     if proc.returncode != 0:
         return False
     return bool(proc.stdout.strip())

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -773,6 +773,32 @@ branch refs/heads/codex/b
     assert dirty_checked == [str(Path("/tmp/codex-b").resolve())]
 
 
+def test_list_worktrees_tolerates_missing_worktree_path(monkeypatch: Any, tmp_path: Path) -> None:
+    missing = tmp_path / "missing-worktree"
+    payload = f"""
+worktree {missing}
+HEAD abc123
+branch refs/heads/codex/missing
+""".strip()
+
+    def fake_run(
+        args: list[str], *, cwd: Path, check: bool = False, env_overrides=None
+    ) -> subprocess.CompletedProcess[str]:
+        if args[:3] == ["git", "worktree", "list"]:
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout=payload, stderr="")
+        raise FileNotFoundError(str(cwd))
+
+    monkeypatch.setattr(mod, "_run", fake_run)
+    monkeypatch.setattr(mod, "_has_active_session", lambda path: False)
+
+    snapshots = mod._list_worktrees(tmp_path)
+
+    assert len(snapshots) == 1
+    assert snapshots[0].branch == "codex/missing"
+    assert snapshots[0].dirty is False
+    assert snapshots[0].active_session is False
+
+
 def test_main_treats_unavailable_github_with_empty_local_queue_as_noop(
     monkeypatch: Any, tmp_path: Path, capsys
 ) -> None:
@@ -943,7 +969,9 @@ def test_publish_decisions_uses_remaining_open_pr_capacity(
     )
     monkeypatch.setattr(mod, "_existing_pr_number", lambda repo_root, repo, branch, base: None)
     monkeypatch.setattr(
-        mod, "_create_pr", lambda repo_root, repo, branch, base: next(created_numbers)
+        mod,
+        "_create_pr",
+        lambda repo_root, repo, branch, base, draft=False: next(created_numbers),
     )
     monkeypatch.setattr(
         mod, "_add_labels", lambda repo_root, repo, number, labels: calls.append(f"label:{number}")
@@ -1000,7 +1028,7 @@ def test_publish_decisions_records_publish_failures_and_continues(
     monkeypatch.setattr(mod, "_ensure_gh_auth", lambda repo_root: None)
     monkeypatch.setattr(mod, "_push_branch", fake_push)
     monkeypatch.setattr(mod, "_existing_pr_number", lambda repo_root, repo, branch, base: None)
-    monkeypatch.setattr(mod, "_create_pr", lambda repo_root, repo, branch, base: 2001)
+    monkeypatch.setattr(mod, "_create_pr", lambda repo_root, repo, branch, base, draft=False: 2001)
     monkeypatch.setattr(
         mod, "_add_labels", lambda repo_root, repo, number, labels: calls.append(f"label:{number}")
     )


### PR DESCRIPTION
## Outbox harvest (run-20260610 shift 4)
Published by the gh-authenticated coordinator from `.aragora/automation-outbox` — the writer-lane sandbox validated this branch but could not open the PR (gh unauthenticated; publisher daemon stale since May 18).

- **Branch:** `codex/publisher-missing-worktree-guard-repair-20260609` @ `b9dc7afe28a6` (head matches outbox record: True)
- **Idempotency key:** `open-pr-codex-publisher-missing-worktree-guard-repair-20260609-b9dc7afe`
- **Writer objective:** Open the validated publisher missing-worktree guard as a draft PR.
- **Mutation boundary:** Limited to publisher worktree dirtiness probing and focused publisher-helper tests.
- **Acceptance criteria:** Publisher planning tolerates stale git worktree metadata paths instead of crashing with FileNotFoundError.; Focused publisher-helper regressions cover missing worktree paths and current draft PR creation stubs.; Focused pytest, Ruff, format check, py_compile, diff checks, live dry-run smoke, merge-tree, and automation PR preflight pass at the exact head.
- **Writer validation:** {'automation_pr_preflight': 'bash scripts/automation_pr_preflight.sh origin/main HEAD: preflight ok; changed files are scripts/publish_codex_automation_branches.py and tests/scripts/test_publish_codex_automation_branches.py.', 'diff_check': 'git diff --check: passed.', 'focused_pytest': 'PYENV_VERSION=3.11.11 python3 -m pytest tests/scripts/test_publish_codex_automation_branches.py -q -p no:rerunf

Draft for CI + worth-triage; settlement via the standard quorum path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)