### PR TITLE
[outbox-harvest] Operator-steering reader now mutes downstream help pipe closures.

### DIFF
--- a/scripts/read_operator_steering.py
+++ b/scripts/read_operator_steering.py
@@ -36,6 +36,52 @@ READ_RECEIPT_SCHEMA_VERSION = "aragora-operator-steering-read-receipt/1.0"
 OUTCOME_CHOICES = ("read", "obeyed", "held", "stale", "superseded", "blocked", "completed")
 
 
+def _mute_stdout_after_broken_pipe() -> None:
+    try:
+        devnull_fd = os.open(os.devnull, os.O_WRONLY)
+        try:
+            os.dup2(devnull_fd, sys.stdout.fileno())
+        finally:
+            os.close(devnull_fd)
+    except Exception:
+        try:
+            sys.stdout = open(os.devnull, "w", encoding="utf-8")
+        except OSError:
+            pass
+
+
+def _emit_stdout(text: str) -> bool:
+    try:
+        sys.stdout.write(text)
+        sys.stdout.flush()
+    except BrokenPipeError:
+        _mute_stdout_after_broken_pipe()
+        return False
+    return True
+
+
+def _emit_json(payload: dict[str, Any]) -> bool:
+    return _emit_stdout(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+class _PipeSafeArgumentParser(argparse.ArgumentParser):
+    def _print_message(self, message: str, file: Any | None = None) -> None:
+        if not message:
+            return
+        if file is None or file is sys.stdout:
+            if not _emit_stdout(message):
+                raise SystemExit(0)
+            return
+        try:
+            file.write(message)
+            file.flush()
+        except BrokenPipeError:
+            if file is sys.stdout:
+                _mute_stdout_after_broken_pipe()
+                raise SystemExit(0)
+            raise
+
+
 def _default_state_dir() -> Path:
     configured = os.environ.get("ARAGORA_AUTOMATION_STATE_ROOT")
     if configured:
@@ -211,7 +257,7 @@ def _default_read_by_session(owner_session: str) -> str:
 
 
 def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
+    parser = _PipeSafeArgumentParser(
         prog="read_operator_steering.py",
         description="Read one operator-steering mailbox and optionally write read receipts.",
     )
@@ -278,7 +324,8 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "read_receipt_paths": [],
                 "no_receipt": bool(args.no_receipt),
             }
-            print(json.dumps(out, indent=2, sort_keys=True))
+            if not _emit_json(out):
+                return 0
             return 2
         print(f"ERROR: {exc}", file=sys.stderr)
         return 2
@@ -316,20 +363,29 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.quiet_empty and not files:
         return 0
     if args.json:
-        print(json.dumps(out, indent=2, sort_keys=True))
+        if not _emit_json(out):
+            return 0
     else:
-        print(f"owner_session: {owner_session}")
-        print(f"steering_inbox_path: {out['steering_inbox_path']}")
-        print(f"message_count: {len(files)}")
-        print(f"receipt_count: {len(receipt_paths)}")
+        lines = [
+            f"owner_session: {owner_session}",
+            f"steering_inbox_path: {out['steering_inbox_path']}",
+            f"message_count: {len(files)}",
+            f"receipt_count: {len(receipt_paths)}",
+        ]
         for msg in out["messages"]:
-            print(
+            lines.append(
                 f"- {msg['filename']} priority={msg['priority']} "
                 f"sent_at_utc={msg['sent_at_utc']} sha256_valid={msg['sha256_valid']} "
                 f"subject={msg['subject']}"
             )
+        if not _emit_stdout("\n".join(lines) + "\n"):
+            return 0
     return 0
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    try:
+        sys.exit(main())
+    except BrokenPipeError:
+        _mute_stdout_after_broken_pipe()
+        sys.exit(0)

--- a/tests/scripts/test_read_operator_steering.py
+++ b/tests/scripts/test_read_operator_steering.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import subprocess
 import sys
 import types
 from pathlib import Path
@@ -46,6 +47,32 @@ def _write_message(root: Path, recipient: str, body: str = "body") -> Path:
 def _receipt_files(root: Path, recipient: str) -> list[Path]:
     receipt_dir = root / recipient / "_read_receipts"
     return sorted(receipt_dir.glob("*.json")) if receipt_dir.is_dir() else []
+
+
+def _assert_help_pipe_safe(script_name: str) -> None:
+    script_path = Path(__file__).resolve().parents[2] / "scripts" / script_name
+    proc = subprocess.Popen(
+        [sys.executable, str(script_path), "--help"],
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    assert proc.stdout is not None
+    assert proc.stderr is not None
+    sampled = [proc.stdout.readline() for _ in range(5)]
+    proc.stdout.close()
+    stderr = proc.stderr.read()
+    returncode = proc.wait(timeout=10)
+
+    assert returncode == 0
+    assert any("usage:" in line for line in sampled)
+    assert "BrokenPipeError" not in stderr
+    assert stderr == ""
+
+
+def test_help_output_is_pipe_safe() -> None:
+    _assert_help_pipe_safe("read_operator_steering.py")
+    _assert_help_pipe_safe("check_operator_steering.py")
 
 
 def test_reads_only_selected_owner_and_writes_bound_receipt(tmp_path: Path, capsys: Any) -> None:


### PR DESCRIPTION
## Outbox harvest (run-20260610 shift 4)
Published by the gh-authenticated coordinator from `.aragora/automation-outbox` — the writer-lane sandbox validated this branch but could not open the PR (gh unauthenticated; publisher daemon stale since May 18).

- **Branch:** `codex/read-steering-help-broken-pipe-improver-20260609` @ `e89306ff1c21` (head matches outbox record: True)
- **Idempotency key:** `open-pr-codex-read-steering-help-broken-pipe-improver-20260609-e89306ff`
- **Writer objective:** Keep operator-steering startup hooks quiet when operators sample help output through head.
- **Mutation boundary:** Limited to read_operator_steering CLI stdout/help pipe handling and focused reader regression tests.
- **Acceptance criteria:** scripts/read_operator_steering.py --help suppresses BrokenPipeError when downstream output sampling closes early.; scripts/check_operator_steering.py --help inherits the same pipe-safe behavior.; Focused read-steering tests, Ruff, format check, py_compile, live pipe smokes, diff checks, merge-tree, automation PR preflight, and branch push pass at the exact head.
- **Writer validation:** {'source': 'local_evidence.validation', 'summary': 'Current-base branch passed focused tests, static checks, live pipe smokes, merge-tree, automation PR preflight, and branch push; PR creation remains blocked by gh auth and connector permissions.'}

Draft for CI + worth-triage; settlement via the standard quorum path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)