### PR TITLE
[outbox-harvest] Rescue productization map loading and writing now reject invalid schema versions and malformed entries.

### DIFF
--- a/scripts/publish_rescue_productization_report.py
+++ b/scripts/publish_rescue_productization_report.py
@@ -112,30 +112,54 @@ def write_json(path: Path, payload: dict[str, Any]) -> Path:
     return path
 
 
+def _validate_productization_map_schema_version(path: Path, value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"Productization map at {path} schema_version must be a positive integer")
+    return value
+
+
+def _validate_productization_map_entries(path: Path, entries: Any) -> list[dict[str, Any]]:
+    if not isinstance(entries, list):
+        raise ValueError(f"Productization map at {path} must contain an 'entries' list")
+
+    validated: list[dict[str, Any]] = []
+    for entry in entries:
+        if not isinstance(entry, dict) or not str(entry.get("class") or "").strip():
+            raise ValueError(
+                f"Productization map at {path} entries must be JSON objects "
+                "with a non-empty `class`"
+            )
+        validated.append(entry)
+    return validated
+
+
 def load_productization_map_payload(path: Path) -> dict[str, Any]:
     if not path.exists():
         return {"schema_version": 1, "entries": []}
     payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
         raise ValueError(f"Productization map at {path} must be a JSON object")
-    entries = payload.get("entries")
-    if not isinstance(entries, list):
-        raise ValueError(f"Productization map at {path} must contain an 'entries' list")
+    schema_version = _validate_productization_map_schema_version(
+        path,
+        payload.get("schema_version", 1),
+    )
+    entries = _validate_productization_map_entries(path, payload.get("entries"))
     return {
-        "schema_version": int(payload.get("schema_version", 1) or 1),
+        "schema_version": schema_version,
         "entries": entries,
     }
 
 
 def write_productization_map_payload(path: Path, payload: dict[str, Any]) -> Path:
-    entries = [
-        entry
-        for entry in list(payload.get("entries") or [])
-        if isinstance(entry, dict) and str(entry.get("class") or "").strip()
-    ]
+    schema_version = _validate_productization_map_schema_version(
+        path,
+        payload.get("schema_version", 1),
+    )
+    raw_entries = payload.get("entries", [])
+    entries = _validate_productization_map_entries(path, [] if raw_entries is None else raw_entries)
     entries.sort(key=lambda entry: str(entry.get("class") or "").strip())
     normalized = {
-        "schema_version": int(payload.get("schema_version", 1) or 1),
+        "schema_version": schema_version,
         "entries": entries,
     }
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/scripts/test_publish_rescue_productization_report.py
+++ b/tests/scripts/test_publish_rescue_productization_report.py
@@ -4,6 +4,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 from aragora.swarm.rescue_events import RescueEvent, RescueEventLedger
 
 _scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
@@ -107,6 +109,73 @@ def test_publish_report_bundle_writes_timestamped_and_latest(tmp_path: Path) -> 
     assert json.loads(written["latest"].read_text(encoding="utf-8"))["generated_at"] == (
         "2026-04-14T18:36:07Z"
     )
+
+
+@pytest.mark.parametrize("schema_version", [0, -1, True, "1"])
+def test_load_productization_map_rejects_invalid_schema_version(
+    tmp_path: Path,
+    schema_version: object,
+) -> None:
+    productization_map_path = tmp_path / "rescue_productization.json"
+    productization_map_path.write_text(
+        json.dumps({"schema_version": schema_version, "entries": []}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="schema_version must be a positive integer"):
+        mod.load_productization_map_payload(productization_map_path)
+
+
+def test_write_productization_map_rejects_invalid_schema_version(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="schema_version must be a positive integer"):
+        mod.write_productization_map_payload(
+            tmp_path / "rescue_productization.json",
+            {
+                "schema_version": False,
+                "entries": [
+                    {
+                        "class": "followup_prompt:needs explicit next step from founder",
+                    }
+                ],
+            },
+        )
+
+
+@pytest.mark.parametrize(
+    "entries",
+    [
+        {"class": "not-a-list"},
+        [{"target": "#6001"}],
+        ["followup_prompt:needs explicit next step from founder"],
+    ],
+)
+def test_load_productization_map_rejects_invalid_entries(
+    tmp_path: Path,
+    entries: object,
+) -> None:
+    productization_map_path = tmp_path / "rescue_productization.json"
+    productization_map_path.write_text(
+        json.dumps({"schema_version": 1, "entries": entries}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="entries"):
+        mod.load_productization_map_payload(productization_map_path)
+
+
+def test_write_productization_map_rejects_invalid_entries(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="non-empty `class`"):
+        mod.write_productization_map_payload(
+            tmp_path / "rescue_productization.json",
+            {
+                "schema_version": 1,
+                "entries": [
+                    {
+                        "target": "#6001",
+                    }
+                ],
+            },
+        )
 
 
 def test_main_dry_run_does_not_publish_report_bundle(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Outbox harvest (run-20260610 shift 4)
Published by the gh-authenticated coordinator from `.aragora/automation-outbox` — the writer-lane sandbox validated this branch but could not open the PR (gh unauthenticated; publisher daemon stale since May 18).

- **Branch:** `codex/rescue-productization-map-guard-primary-20260610` @ `2b67d64f1486` (head matches outbox record: True)
- **Idempotency key:** `open-pr-codex-rescue-productization-map-guard-primary-20260610-2b67d64f`
- **Writer objective:** Fail closed when recurring rescue productization artifacts are backed by malformed productization-map inputs.
- **Mutation boundary:** Limited to rescue productization map schema_version and entry validation plus focused tests.
- **Acceptance criteria:** Open or update a draft PR from codex/rescue-productization-map-guard-primary-20260610 to main.; Apply labels codex and codex-automation.; Bind publication to exact head 2b67d64f1486e8feb017f8f4282aed8ee9b7be75.; Keep the PR scoped to scripts/publish_rescue_productization_report.py and tests/scripts/test_publish_rescue_productization_report.py.
- **Writer validation:** {'automation_pr_preflight': 'bash scripts/automation_pr_preflight.sh origin/main HEAD: preflight ok; changed files are scripts/publish_rescue_productization_report.py and tests/scripts/test_publish_rescue_productization_report.py.', 'diff_check': 'git diff --check origin/main...HEAD and git diff --check: passed.', 'focused_pytest': 'PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/scrip

Draft for CI + worth-triage; settlement via the standard quorum path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)