### PR TITLE
[outbox-harvest] rescue productization report publication now rejects malformed schema_version values.

### DIFF
--- a/scripts/publish_rescue_productization_report.py
+++ b/scripts/publish_rescue_productization_report.py
@@ -112,6 +112,12 @@ def write_json(path: Path, payload: dict[str, Any]) -> Path:
     return path
 
 
+def _coerce_schema_version(value: Any, *, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{label} schema_version must be a positive integer")
+    return value
+
+
 def load_productization_map_payload(path: Path) -> dict[str, Any]:
     if not path.exists():
         return {"schema_version": 1, "entries": []}
@@ -122,7 +128,10 @@ def load_productization_map_payload(path: Path) -> dict[str, Any]:
     if not isinstance(entries, list):
         raise ValueError(f"Productization map at {path} must contain an 'entries' list")
     return {
-        "schema_version": int(payload.get("schema_version", 1) or 1),
+        "schema_version": _coerce_schema_version(
+            payload.get("schema_version", 1),
+            label=f"Productization map at {path}",
+        ),
         "entries": entries,
     }
 
@@ -135,7 +144,10 @@ def write_productization_map_payload(path: Path, payload: dict[str, Any]) -> Pat
     ]
     entries.sort(key=lambda entry: str(entry.get("class") or "").strip())
     normalized = {
-        "schema_version": int(payload.get("schema_version", 1) or 1),
+        "schema_version": _coerce_schema_version(
+            payload.get("schema_version", 1),
+            label=f"Productization map payload for {path}",
+        ),
         "entries": entries,
     }
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/scripts/test_publish_rescue_productization_report.py
+++ b/tests/scripts/test_publish_rescue_productization_report.py
@@ -4,6 +4,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 from aragora.swarm.rescue_events import RescueEvent, RescueEventLedger
 
 _scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
@@ -107,6 +109,36 @@ def test_publish_report_bundle_writes_timestamped_and_latest(tmp_path: Path) -> 
     assert json.loads(written["latest"].read_text(encoding="utf-8"))["generated_at"] == (
         "2026-04-14T18:36:07Z"
     )
+
+
+@pytest.mark.parametrize("schema_version", [0, -1, True, "1"])
+def test_load_productization_map_rejects_invalid_schema_version(
+    tmp_path: Path,
+    schema_version: object,
+) -> None:
+    productization_map_path = tmp_path / "rescue_productization.json"
+    productization_map_path.write_text(
+        json.dumps({"schema_version": schema_version, "entries": []}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="schema_version must be a positive integer"):
+        mod.load_productization_map_payload(productization_map_path)
+
+
+def test_write_productization_map_rejects_invalid_schema_version(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="schema_version must be a positive integer"):
+        mod.write_productization_map_payload(
+            tmp_path / "rescue_productization.json",
+            {
+                "schema_version": False,
+                "entries": [
+                    {
+                        "class": "followup_prompt:needs explicit next step from founder",
+                    }
+                ],
+            },
+        )
 
 
 def test_main_dry_run_does_not_publish_report_bundle(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Outbox harvest (run-20260610 shift 4)
Published by the gh-authenticated coordinator from `.aragora/automation-outbox` — the writer-lane sandbox validated this branch but could not open the PR (gh unauthenticated; publisher daemon stale since May 18).

- **Branch:** `codex/rescue-productization-map-schema-guard-primary-r2-20260609` @ `26269092eabc` (head matches outbox record: True)
- **Idempotency key:** `open-pr-codex-rescue-productization-map-schema-guard-primary-r2-20260609-26269092`
- **Writer objective:** Prevent TW-03 rescue productization report publication from accepting malformed schema_version metadata in the productization map.
- **Mutation boundary:** Limited to rescue productization report schema_version validation and focused publisher regression tests.
- **Acceptance criteria:** rescue productization map loading rejects non-positive, boolean, string, and otherwise non-integer schema_version values.; rescue productization map writing rejects invalid schema_version values before writing committed truth-surface metadata.; Focused rescue productization publisher tests, static checks, direct repro smokes, diff checks, merge-tree, automation PR preflight, and push-time hooks pass at the exact head.
- **Writer validation:** {'source': 'local_evidence.validation', 'summary': 'Current-base branch passed focused tests, static checks, direct smokes, merge-tree, automation PR preflight, and branch push; PR creation remains blocked by gh auth and connector permissions.'}

Draft for CI + worth-triage; settlement via the standard quorum path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)