### PR TITLE
[outbox-harvest] settle_one_pr now respects the effective required-check gate.

### DIFF
--- a/scripts/settle_one_pr.py
+++ b/scripts/settle_one_pr.py
@@ -158,6 +158,24 @@ def _is_green_summary(summary: str) -> bool:
     return "green" in lower and "failing" not in lower and "pending" not in lower
 
 
+def _effective_check_summary(entry: dict[str, Any]) -> str:
+    check_surfaces = entry.get("check_surfaces")
+    if not isinstance(check_surfaces, dict):
+        return str(entry.get("checks_summary", ""))
+    effective_gate = check_surfaces.get("effective_gate")
+    if isinstance(effective_gate, dict):
+        source = str(effective_gate.get("source", "") or "")
+        summary = str(effective_gate.get("summary", "") or "")
+        if source and summary:
+            return summary
+    required_gate = check_surfaces.get("required_pr_checks")
+    if isinstance(required_gate, dict) and bool(required_gate.get("gate_selected")):
+        summary = str(required_gate.get("summary", "") or "")
+        if summary:
+            return summary
+    return str(entry.get("checks_summary", ""))
+
+
 def _entry_by_pr(packet: dict[str, Any], pr_number: int) -> dict[str, Any] | None:
     for entry in packet.get("entries") or []:
         if isinstance(entry, dict) and _entry_pr(entry) == pr_number:
@@ -694,7 +712,7 @@ def entry_blockers(entry: dict[str, Any]) -> list[str]:
         blockers.append("requires_human_risk_settlement=true")
     if bool(entry.get("unresolved_dissent")):
         blockers.append("unresolved_dissent=true")
-    summary = str(entry.get("checks_summary", ""))
+    summary = _effective_check_summary(entry)
     if "failing" in summary.lower():
         blockers.append(f"checks failing: {summary}")
     if "pending" in summary.lower():

--- a/tests/scripts/test_settle_one_pr.py
+++ b/tests/scripts/test_settle_one_pr.py
@@ -1402,6 +1402,34 @@ def test_tier3_or_human_risk_is_report_only() -> None:
     assert "requires_human_risk_settlement=true" in blockers
 
 
+def test_entry_blockers_use_effective_required_checks_gate() -> None:
+    entry = _entry(
+        1005,
+        status="satisfied",
+        verdict="admin_squash_allowed",
+        admin_squash_allowed=True,
+        reasons=["bounded helper reliability surface"],
+        checks_summary="2 pending / 21 total",
+    )
+    entry["check_surfaces"] = {
+        "effective_gate": {
+            "source": "required_pr_checks",
+            "summary": "6/6 required green (required PR checks)",
+        },
+        "required_pr_checks": {
+            "available": True,
+            "gate_selected": True,
+            "summary": "6/6 required green",
+            "pending": [],
+            "failing_or_cancelled": [],
+        },
+    }
+
+    blockers = entry_blockers(entry)
+
+    assert blockers == []
+
+
 def test_owner_payload_blocks_active_owner() -> None:
     blockers = owner_blockers(
         {


### PR DESCRIPTION
## Outbox harvest (run-20260610 shift 4)
Published by the gh-authenticated coordinator from `.aragora/automation-outbox` — the writer-lane sandbox validated this branch but could not open the PR (gh unauthenticated; publisher daemon stale since May 18).

- **Branch:** `codex/settle-one-required-gate-primary-r2-20260609` @ `61495b241b63` (head matches outbox record: True)
- **Idempotency key:** `open-pr-codex-settle-one-required-gate-primary-r2-20260609-61495b24`
- **Writer objective:** Prevent settle_one_pr from blocking on stale broad check summaries when required PR checks are the effective green gate.
- **Mutation boundary:** Limited to settle_one_pr blocker summary selection and a focused settle_one_pr regression test.
- **Acceptance criteria:** settle_one_pr uses the packet's effective required-check gate when reporting blockers.; Legacy packets without check_surfaces continue to fall back to checks_summary.; Focused settle-one tests, static checks, diff checks, merge-tree, automation PR preflight, and push-time hooks pass at the exact head.
- **Writer validation:** {'source': 'local_evidence.validation', 'summary': 'Current-base branch passed focused tests, static checks, direct smoke, merge-tree, automation PR preflight, and branch push; PR creation remains blocked by gh auth and connector permissions.'}

Draft for CI + worth-triage; settlement via the standard quorum path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)