### PR TITLE
[outbox-harvest] Offline receipt verifier now mutes downstream pipe closures.

### DIFF
--- a/scripts/verify_receipt.py
+++ b/scripts/verify_receipt.py
@@ -40,6 +40,39 @@ from typing import Any
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 
+class PipeSafeArgumentParser(argparse.ArgumentParser):
+    """ArgumentParser that exits quietly when downstream closes stdout."""
+
+    def _print_message(self, message: str, file: Any | None = None) -> None:
+        if not message:
+            return
+        handle = file or sys.stderr
+        try:
+            handle.write(message)
+            handle.flush()
+        except BrokenPipeError:
+            if handle is sys.stdout:
+                _mute_stdout_after_broken_pipe()
+                raise SystemExit(0) from None
+            raise
+
+
+def _mute_stdout_after_broken_pipe() -> None:
+    try:
+        sys.stdout.close()
+    except OSError:
+        pass
+    sys.stdout = open(os.devnull, "w", encoding="utf-8")
+
+
+def _print_stdout(message: str = "") -> None:
+    try:
+        print(message, flush=True)
+    except BrokenPipeError:
+        _mute_stdout_after_broken_pipe()
+        raise SystemExit(0) from None
+
+
 def load_receipt(path: str) -> dict:
     """Load and parse receipt JSON file."""
     with open(path) as f:
@@ -168,39 +201,39 @@ def print_receipt_info(data: dict, verbose: bool = False):
     receipt = data.get("receipt", {})
     metadata = data.get("signature_metadata", {})
 
-    print("\nReceipt Information:")
-    print(f"  Decision ID: {receipt.get('decision_id', 'N/A')}")
-    print(f"  Verdict: {receipt.get('verdict', 'N/A')}")
-    print(f"  Confidence: {receipt.get('confidence', 'N/A')}")
+    _print_stdout("\nReceipt Information:")
+    _print_stdout(f"  Decision ID: {receipt.get('decision_id', 'N/A')}")
+    _print_stdout(f"  Verdict: {receipt.get('verdict', 'N/A')}")
+    _print_stdout(f"  Confidence: {receipt.get('confidence', 'N/A')}")
 
-    print("\nSignature Metadata:")
-    print(f"  Algorithm: {metadata.get('algorithm', 'N/A')}")
-    print(f"  Timestamp: {metadata.get('timestamp', 'N/A')}")
-    print(f"  Key ID: {metadata.get('key_id', 'N/A')}")
-    print(f"  Version: {metadata.get('version', 'N/A')}")
+    _print_stdout("\nSignature Metadata:")
+    _print_stdout(f"  Algorithm: {metadata.get('algorithm', 'N/A')}")
+    _print_stdout(f"  Timestamp: {metadata.get('timestamp', 'N/A')}")
+    _print_stdout(f"  Key ID: {metadata.get('key_id', 'N/A')}")
+    _print_stdout(f"  Version: {metadata.get('version', 'N/A')}")
 
     # Print signatory info if present
     signatory = metadata.get("signatory")
     if signatory:
-        print("\nSignatory Information:")
-        print(f"  Name: {signatory.get('name', 'N/A')}")
-        print(f"  Email: {signatory.get('email', 'N/A')}")
+        _print_stdout("\nSignatory Information:")
+        _print_stdout(f"  Name: {signatory.get('name', 'N/A')}")
+        _print_stdout(f"  Email: {signatory.get('email', 'N/A')}")
         if signatory.get("title"):
-            print(f"  Title: {signatory['title']}")
+            _print_stdout(f"  Title: {signatory['title']}")
         if signatory.get("organization"):
-            print(f"  Organization: {signatory['organization']}")
+            _print_stdout(f"  Organization: {signatory['organization']}")
         if signatory.get("role"):
-            print(f"  Role: {signatory['role']}")
+            _print_stdout(f"  Role: {signatory['role']}")
         if signatory.get("department"):
-            print(f"  Department: {signatory['department']}")
+            _print_stdout(f"  Department: {signatory['department']}")
 
     if verbose:
-        print("\nFull Receipt Data:")
-        print(json.dumps(receipt, indent=2, default=str))
+        _print_stdout("\nFull Receipt Data:")
+        _print_stdout(json.dumps(receipt, indent=2, default=str))
 
 
 def main():
-    parser = argparse.ArgumentParser(
+    parser = PipeSafeArgumentParser(
         description="Verify decision receipt signatures offline",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=__doc__,
@@ -298,14 +331,14 @@ def main():
         }
         if metadata.get("signatory"):
             result["signatory"] = metadata["signatory"]
-        print(json.dumps(result, indent=2))
+        _print_stdout(json.dumps(result, indent=2))
     elif args.quiet:
-        print("VALID" if is_valid else "INVALID")
+        _print_stdout("VALID" if is_valid else "INVALID")
     else:
         if is_valid:
-            print("\n[VALID] Signature verification successful")
+            _print_stdout("\n[VALID] Signature verification successful")
         else:
-            print("\n[INVALID] Signature verification failed")
+            _print_stdout("\n[INVALID] Signature verification failed")
 
         if not args.quiet:
             print_receipt_info(data, verbose=args.verbose)

--- a/tests/scripts/test_verify_receipt.py
+++ b/tests/scripts/test_verify_receipt.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -246,6 +247,19 @@ class TestVerifyReceiptCLI:
 
         assert result.returncode == 2
         assert "requires a signing key" in result.stderr
+
+    def test_help_pipe_closes_cleanly(self):
+        """Closed downstream help pipes should not emit BrokenPipeError noise."""
+        command = f"{shlex.quote(sys.executable)} {shlex.quote(str(SCRIPT_PATH))} --help | head -5"
+        result = subprocess.run(
+            ["bash", "-o", "pipefail", "-c", command],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0
+        assert "Verify decision receipt signatures offline" in result.stdout
+        assert "BrokenPipeError" not in result.stderr
 
 
 class TestVerifyReceiptWithRSA:


### PR DESCRIPTION
## Outbox harvest (run-20260610 shift 4)
Published by the gh-authenticated coordinator from `.aragora/automation-outbox` — the writer-lane sandbox validated this branch but could not open the PR (gh unauthenticated; publisher daemon stale since May 18).

- **Branch:** `codex/verify-receipt-help-broken-pipe-improver-20260609` @ `307f45f68d58` (head matches outbox record: True)
- **Idempotency key:** `open-pr-codex-verify-receipt-help-broken-pipe-improver-20260609-307f45f6`
- **Writer objective:** Keep the offline receipt verifier quiet when operators sample help or result output through head.
- **Mutation boundary:** Limited to verify_receipt CLI shutdown pipe handling and focused receipt verifier regression tests.
- **Acceptance criteria:** scripts/verify_receipt.py --help suppresses BrokenPipeError when downstream output sampling closes early.; Normal verify_receipt stdout result paths remain pipe-safe.; Focused verify-receipt tests, Ruff, format check, py_compile, live pipe smoke, diff checks, merge-tree, and automation PR preflight pass at the exact head.
- **Writer validation:** {'source': 'local_evidence.validation', 'summary': 'Current-base branch passed focused tests, static checks, live pipe smoke, merge-tree, automation PR preflight, and branch push; PR creation remains blocked by gh auth and connector permissions.'}

Draft for CI + worth-triage; settlement via the standard quorum path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)