### PR TITLE
feat(swarm): net-closure floor throttles issue generation (Sprint 4 goal 3)

### DIFF
--- a/scripts/generate_boss_issues.py
+++ b/scripts/generate_boss_issues.py
@@ -20,6 +20,7 @@ import subprocess
 import sys
 import time
 from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 # Add repo root to path
@@ -461,6 +462,91 @@ def select_with_substrate_cap(
     return selected, substrate_skipped
 
 
+def apply_net_closure_floor(
+    max_issues: int,
+    created_7d: int,
+    closed_7d: int,
+    floor: float,
+) -> tuple[int, str]:
+    """Throttle issue-creation appetite by the trailing closed:created ratio.
+
+    Pure function (FOCUS.md Sprint 4 goal 3 / plan v2 Phase 0.3; audit basis
+    215 created : 0 closed). When the trailing-window ``closed:created`` ratio
+    is at or above ``floor``, the full ``max_issues`` allowance applies. Below
+    the floor the allowance scales linearly with the ratio:
+    ``allowed = min(max_issues, int(max_issues * ratio / floor))`` — at
+    ratio == floor you get full allowance, at zero closures you get zero new
+    issues. ``floor <= 0`` disables the throttle; ``created_7d == 0`` means
+    there is nothing to throttle against. Returns (allowed_count, reason) —
+    the reason always states the numbers so skips are reported, never silent.
+    """
+    if floor <= 0:
+        return max_issues, (
+            f"Closure floor disabled (floor={floor:g}): created_7d={created_7d} "
+            f"closed_7d={closed_7d} allowed={max_issues}"
+        )
+    if created_7d <= 0:
+        return max_issues, (
+            f"Closure floor {floor:g}: nothing to throttle against "
+            f"(created_7d={created_7d} closed_7d={closed_7d}) allowed={max_issues}"
+        )
+    ratio = closed_7d / max(1, created_7d)
+    if ratio >= floor:
+        return max_issues, (
+            f"Closure floor {floor:g} met (ratio={ratio:.3f}): "
+            f"created_7d={created_7d} closed_7d={closed_7d} allowed={max_issues}"
+        )
+    allowed = min(max_issues, int(max_issues * ratio / floor))
+    return allowed, (
+        f"Closure floor {floor:g} NOT met (ratio={ratio:.3f}): "
+        f"created_7d={created_7d} closed_7d={closed_7d} -> throttled "
+        f"allowed={allowed} of max_issues={max_issues}"
+    )
+
+
+def _search_issue_total(repo: str, qualifier: str) -> int | None:
+    """Return the total_count of a GitHub issue search, or None on failure."""
+    query = f"repo:{repo} type:issue {qualifier}"
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "api",
+                "-X",
+                "GET",
+                "search/issues",
+                "-f",
+                f"q={query}",
+                "-f",
+                "per_page=1",
+                "--jq",
+                ".total_count",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode == 0:
+            return int(result.stdout.strip() or "0")
+    except (subprocess.TimeoutExpired, OSError, ValueError):
+        pass
+    return None
+
+
+def fetch_closure_counts_7d(repo: str) -> tuple[int, int] | None:
+    """Fetch (created_7d, closed_7d) issue counts via the gh REST search API.
+
+    Returns None when either count is unavailable so the caller can fail open
+    with an explicit report instead of throttling on bad data.
+    """
+    since = (datetime.now(timezone.utc) - timedelta(days=7)).strftime("%Y-%m-%d")
+    created = _search_issue_total(repo, f"created:>={since}")
+    closed = _search_issue_total(repo, f"closed:>={since}")
+    if created is None or closed is None:
+        return None
+    return created, closed
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Generate boss-ready GitHub issues by scanning the codebase"
@@ -478,6 +564,29 @@ def main() -> None:
             "candidates are never skipped by this cap. 1.0 disables the cap. "
             "FOCUS.md Sprint 3 goal 2."
         ),
+    )
+    parser.add_argument(
+        "--closure-floor",
+        type=float,
+        default=0.25,
+        help=(
+            "Minimum trailing-7d closed:created issue ratio for the full "
+            "--max-issues allowance. Below the floor the allowance scales "
+            "linearly with the ratio (zero closures -> zero new issues). "
+            "0 disables. FOCUS.md Sprint 4 goal 3."
+        ),
+    )
+    parser.add_argument(
+        "--created-7d",
+        type=int,
+        default=None,
+        help="Override the trailing-7d created-issue count (skips the gh fetch; testing)",
+    )
+    parser.add_argument(
+        "--closed-7d",
+        type=int,
+        default=None,
+        help="Override the trailing-7d closed-issue count (skips the gh fetch; testing)",
     )
     parser.add_argument("--categories", nargs="*", help="Filter to specific categories")
     parser.add_argument("--label", default="boss-ready", help="Primary label for created issues")
@@ -620,6 +729,35 @@ def main() -> None:
             f"{substrate_skipped} substrate-surface candidates "
             f"(substrate_skipped={substrate_skipped})"
         )
+
+    # 5b. Net-closure floor (Sprint 4 goal 3): throttle total appetite when
+    # the trailing-7d closed:created ratio falls below the floor.
+    created_7d = args.created_7d
+    closed_7d = args.closed_7d
+    counts_available = True
+    if args.closure_floor > 0 and (created_7d is None or closed_7d is None):
+        counts = fetch_closure_counts_7d(args.repo)
+        if counts is None:
+            counts_available = False
+            print(
+                f"  Closure floor {args.closure_floor:g}: 7d issue counts "
+                "unavailable (gh search failed); floor NOT applied "
+                f"(fail-open, allowed={args.max_issues})"
+            )
+        else:
+            if created_7d is None:
+                created_7d = counts[0]
+            if closed_7d is None:
+                closed_7d = counts[1]
+    if counts_available:
+        allowed, closure_reason = apply_net_closure_floor(
+            args.max_issues, created_7d or 0, closed_7d or 0, args.closure_floor
+        )
+        print(f"  {closure_reason}")
+        if allowed < len(to_create):
+            # Re-apply the substrate cap at the throttled budget so the
+            # cap's composition is preserved while the total shrinks.
+            to_create, _ = select_with_substrate_cap(to_create, allowed, args.substrate_cap)
 
     # 6. Create or dry-run
     if args.dry_run:

--- a/scripts/generate_boss_issues.py
+++ b/scripts/generate_boss_issues.py
@@ -505,7 +505,12 @@ def apply_net_closure_floor(
 
 
 def _search_issue_total(repo: str, qualifier: str) -> int | None:
-    """Return the total_count of a GitHub issue search, or None on failure."""
+    """Return the total_count of a GitHub issue search, or None on failure.
+
+    Failures are reported (never silent): the underlying gh exit code /
+    stderr / parse error is printed so a fail-open closure floor is always
+    attributable to a concrete cause.
+    """
     query = f"repo:{repo} type:issue {qualifier}"
     try:
         result = subprocess.run(
@@ -528,8 +533,12 @@ def _search_issue_total(repo: str, qualifier: str) -> int | None:
         )
         if result.returncode == 0:
             return int(result.stdout.strip() or "0")
-    except (subprocess.TimeoutExpired, OSError, ValueError):
-        pass
+        stderr = (result.stderr or "").strip()
+        print(
+            f"  gh search failed for {qualifier!r}: rc={result.returncode} stderr={stderr[:200]!r}"
+        )
+    except (subprocess.TimeoutExpired, OSError, ValueError) as exc:
+        print(f"  gh search failed for {qualifier!r}: {type(exc).__name__}: {exc}")
     return None
 
 

--- a/scripts/run_boss_cycle.sh
+++ b/scripts/run_boss_cycle.sh
@@ -72,6 +72,8 @@ refill_cmd=(
     "${boss_label}"
     --substrate-cap
     "${ARAGORA_SUBSTRATE_CAP:-0.3}"
+    --closure-floor
+    "${ARAGORA_CLOSURE_FLOOR:-0.25}"
 )
 if [[ "${POST_LOOP_DRY_RUN}" == "1" ]]; then
     refill_cmd+=(--dry-run)

--- a/tests/scripts/test_generate_boss_issues.py
+++ b/tests/scripts/test_generate_boss_issues.py
@@ -12,6 +12,14 @@ from aragora.swarm.roadmap_priority import RoadmapPriorityPolicy
 from scripts import generate_boss_issues as mod
 
 
+@pytest.fixture(autouse=True)
+def _healthy_closure_counts(monkeypatch):
+    """Keep main() tests off the network: default the closure-floor counts
+    boundary to a healthy trailing-7d ratio. Tests that exercise the floor
+    override this explicitly."""
+    monkeypatch.setattr(mod, "fetch_closure_counts_7d", lambda repo: (1, 1))
+
+
 def _candidate(name: str, *, file_scope: list[str]) -> BossIssueCandidate:
     return BossIssueCandidate(
         category="test_coverage",
@@ -958,3 +966,219 @@ class TestSelectWithSubstrateCap:
         selected, skipped = mod.select_with_substrate_cap(items, 10, 0.0)
         assert len(selected) == 10
         assert skipped == 0
+
+
+class TestNetClosureFloor:
+    """Net-closure floor on issue appetite (Sprint 4 goal 3, plan v2 Phase 0.3).
+
+    Audit basis: 215 issues created, 0 closed over two weeks. The floor
+    scales the generator's allowance by the trailing closed:created ratio.
+    """
+
+    def test_zero_closures_allows_zero_with_clear_reason(self) -> None:
+        allowed, reason = mod.apply_net_closure_floor(20, 215, 0, 0.25)
+        assert allowed == 0
+        assert "215" in reason
+        assert "closed" in reason.lower()
+        assert "0.25" in reason
+        assert "allowed=0" in reason
+
+    def test_ratio_at_floor_gives_full_allowance(self) -> None:
+        allowed, reason = mod.apply_net_closure_floor(20, 100, 25, 0.25)
+        assert allowed == 20
+        assert "allowed=20" in reason
+
+    def test_ratio_at_half_floor_gives_half_allowance(self) -> None:
+        # ratio = 1/8 = 0.125, half of the 0.25 floor -> half of max_issues
+        allowed, reason = mod.apply_net_closure_floor(20, 8, 1, 0.25)
+        assert allowed == 10
+        assert "allowed=10" in reason
+
+    def test_floor_zero_disables_with_full_allowance(self) -> None:
+        allowed, reason = mod.apply_net_closure_floor(20, 215, 0, 0.0)
+        assert allowed == 20
+        assert "disabled" in reason.lower()
+        assert "allowed=20" in reason
+
+    def test_no_created_issues_gives_full_allowance(self) -> None:
+        allowed, reason = mod.apply_net_closure_floor(20, 0, 5, 0.25)
+        assert allowed == 20
+        assert "allowed=20" in reason
+
+    def test_ratio_above_floor_never_exceeds_max(self) -> None:
+        allowed, _ = mod.apply_net_closure_floor(20, 10, 9, 0.25)
+        assert allowed == 20
+
+    def test_reason_always_states_the_numbers(self) -> None:
+        cases = [
+            (20, 215, 0, 0.25),
+            (20, 100, 25, 0.25),
+            (20, 0, 0, 0.25),
+            (20, 8, 1, 0.25),
+            (20, 5, 1, 0.0),
+        ]
+        for max_issues, created, closed, floor in cases:
+            allowed, reason = mod.apply_net_closure_floor(max_issues, created, closed, floor)
+            assert f"created_7d={created}" in reason, reason
+            assert f"closed_7d={closed}" in reason, reason
+            assert f"allowed={allowed}" in reason, reason
+            assert 0 <= allowed <= max_issues
+
+
+class TestClosureFloorMainWiring:
+    """main() wiring for the net-closure floor (skips reported, never silent)."""
+
+    @staticmethod
+    def _eligible(n: int, *, substrate: int = 0) -> list[BossIssueCandidate]:
+        cands = []
+        for i in range(n):
+            scope = [f"scripts/tool_{i}.py"] if i < substrate else [f"aragora/server/mod_{i}.py"]
+            cands.append(
+                BossIssueCandidate(
+                    category="test_coverage",
+                    title=f"Closure floor candidate {i}",
+                    description="x",
+                    file_scope=scope,
+                    new_files=[],
+                )
+            )
+        return cands
+
+    def _patch_pipeline(self, monkeypatch, candidates: list[BossIssueCandidate]) -> None:
+        monkeypatch.setattr(
+            mod,
+            "scan_all",
+            lambda repo_root, categories=None, min_success_rate=0.3: list(candidates),
+        )
+        monkeypatch.setattr(mod, "fetch_existing_boss_issues", lambda repo: [])
+        monkeypatch.setattr(mod, "fetch_open_pr_files", lambda repo: set())
+        monkeypatch.setattr(mod, "validate_body", lambda body: (True, ""))
+        monkeypatch.setattr(mod, "load_roadmap_priority_policy", lambda repo_root: None)
+
+    def test_overrides_throttle_to_zero_without_fetching(self, monkeypatch, capsys) -> None:
+        self._patch_pipeline(monkeypatch, self._eligible(3))
+
+        def _boom(repo: str):
+            raise AssertionError("fetch_closure_counts_7d must not be called with overrides")
+
+        monkeypatch.setattr(mod, "fetch_closure_counts_7d", _boom)
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "generate_boss_issues.py",
+                "--repo",
+                "org/repo",
+                "--dry-run",
+                "--max-issues",
+                "5",
+                "--label",
+                "lane:test",
+                "--closure-floor",
+                "0.25",
+                "--created-7d",
+                "215",
+                "--closed-7d",
+                "0",
+            ],
+        )
+        mod.main()
+        out = capsys.readouterr().out
+        assert "would create 0 issues" in out
+        assert "created_7d=215" in out
+        assert "closed_7d=0" in out
+        assert "allowed=0" in out
+
+    def test_fetches_counts_when_overrides_absent(self, monkeypatch, capsys) -> None:
+        self._patch_pipeline(monkeypatch, self._eligible(3))
+        fetch_calls: list[str] = []
+        monkeypatch.setattr(
+            mod,
+            "fetch_closure_counts_7d",
+            lambda repo: (fetch_calls.append(repo) or (10, 10)),
+        )
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "generate_boss_issues.py",
+                "--repo",
+                "org/repo",
+                "--dry-run",
+                "--max-issues",
+                "5",
+                "--label",
+                "lane:test",
+                "--closure-floor",
+                "0.25",
+            ],
+        )
+        mod.main()
+        out = capsys.readouterr().out
+        assert fetch_calls == ["org/repo"]
+        assert "would create 3 issues" in out
+        assert "created_7d=10" in out and "closed_7d=10" in out
+
+    def test_counts_unavailable_fails_open_with_report(self, monkeypatch, capsys) -> None:
+        self._patch_pipeline(monkeypatch, self._eligible(3))
+        monkeypatch.setattr(mod, "fetch_closure_counts_7d", lambda repo: None)
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "generate_boss_issues.py",
+                "--repo",
+                "org/repo",
+                "--dry-run",
+                "--max-issues",
+                "5",
+                "--label",
+                "lane:test",
+                "--closure-floor",
+                "0.25",
+            ],
+        )
+        mod.main()
+        out = capsys.readouterr().out
+        assert "unavailable" in out.lower()
+        assert "would create 3 issues" in out
+
+    def test_partial_throttle_preserves_substrate_cap_composition(
+        self, monkeypatch, capsys
+    ) -> None:
+        # 10 substrate-first then 10 product candidates; cap 0.3 at max 10
+        # selects 3 substrate + 7 product. Floor at half ratio throttles the
+        # total to 5; re-selection keeps the cap (1 substrate + 4 product),
+        # never product-starved.
+        self._patch_pipeline(monkeypatch, self._eligible(20, substrate=10))
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "generate_boss_issues.py",
+                "--repo",
+                "org/repo",
+                "--dry-run",
+                "--max-issues",
+                "10",
+                "--label",
+                "lane:test",
+                "--substrate-cap",
+                "0.3",
+                "--closure-floor",
+                "0.25",
+                "--created-7d",
+                "8",
+                "--closed-7d",
+                "1",
+            ],
+        )
+        mod.main()
+        out = capsys.readouterr().out
+        assert "would create 5 issues" in out
+        assert "allowed=5" in out
+        files_lines = [ln for ln in out.splitlines() if ln.startswith("FILES:")]
+        substrate_files = [ln for ln in files_lines if "scripts/" in ln]
+        product_files = [ln for ln in files_lines if "aragora/server/" in ln]
+        assert len(substrate_files) == 1
+        assert len(product_files) == 4

--- a/tests/scripts/test_generate_boss_issues.py
+++ b/tests/scripts/test_generate_boss_issues.py
@@ -1182,3 +1182,30 @@ class TestClosureFloorMainWiring:
         product_files = [ln for ln in files_lines if "aragora/server/" in ln]
         assert len(substrate_files) == 1
         assert len(product_files) == 4
+
+
+class TestSearchIssueTotalFailureReporting:
+    """gh search failures are reported with cause, never swallowed silently
+    (grok review task 3 on PR #8148)."""
+
+    def test_nonzero_exit_reports_rc_and_stderr(self, monkeypatch, capsys) -> None:
+        monkeypatch.setattr(
+            mod.subprocess,
+            "run",
+            lambda *a, **k: SimpleNamespace(returncode=4, stdout="", stderr="gh: API rate limit"),
+        )
+        assert mod._search_issue_total("org/repo", "created:>=2026-06-03") is None
+        out = capsys.readouterr().out
+        assert "gh search failed" in out
+        assert "rc=4" in out
+        assert "rate limit" in out
+
+    def test_exception_reports_type_and_message(self, monkeypatch, capsys) -> None:
+        def _raise(*a, **k):
+            raise OSError("gh not found")
+
+        monkeypatch.setattr(mod.subprocess, "run", _raise)
+        assert mod._search_issue_total("org/repo", "closed:>=2026-06-03") is None
+        out = capsys.readouterr().out
+        assert "gh search failed" in out
+        assert "OSError" in out and "gh not found" in out


### PR DESCRIPTION
## Summary

Implements the **net-closure floor** in the boss issue generator — FOCUS.md **Sprint 4 goal 3** / operating-plan-v2 **Phase 0.3**. Audit basis: **215 issues created, 0 closed** in the trailing two weeks; open backlog 1,219. The generator's appetite now scales with the loop's demonstrated ability to close what it opens.

## What changed

- **`apply_net_closure_floor(max_issues, created_7d, closed_7d, floor)`** (pure function, `scripts/generate_boss_issues.py`): trailing-7d closed:created ratio at or above the floor ⇒ full allowance; below it the allowance scales linearly — `allowed = min(max_issues, int(max_issues * ratio / floor))` — so zero closures means zero new issues. `floor=0` disables; `created_7d=0` is a no-throttle case. The reason string always states created/closed/floor/allowed: skips reported, never silent (the `select_with_substrate_cap` pattern applied to appetite).
- **main() wiring**: `--closure-floor` (default 0.25) plus `--created-7d`/`--closed-7d` overrides for testability. Without overrides, real counts come from the gh REST search API through a mockable boundary (`fetch_closure_counts_7d`); counts unavailable ⇒ fail-open with an explicit printed report. Applied **after** substrate-cap selection; a throttled total is re-selected through the cap so the cap's composition is preserved.
- **`scripts/run_boss_cycle.sh`**: appends `--closure-floor "${ARAGORA_CLOSURE_FLOOR:-0.25}"` to the refill command, mirroring the `ARAGORA_SUBSTRATE_CAP` wiring. `bash -n` clean.

## Acceptance demonstration (live dry-run probe)

```
$ python scripts/generate_boss_issues.py --repo synaptent/aragora --dry-run --max-issues 20 --closure-floor 0.25
  Closure floor 0.25 NOT met (ratio=0.064): created_7d=171 closed_7d=11 -> throttled allowed=5 of max_issues=20
```

The floor throttles a 20-issue appetite down to 5 against the real repo state (171 created : 11 closed in 7d).

## Testing

- TDD: 11 new tests (`TestNetClosureFloor` pure-function edges + `TestClosureFloorMainWiring` for overrides, fetch boundary, fail-open reporting, and substrate-cap composition preservation), RED → GREEN.
- Full touched file: `pytest tests/scripts/test_generate_boss_issues.py` — **41 passed** (no regressions).
- `ruff check` + `ruff format` clean; `bash -n scripts/run_boss_cycle.sh` clean.

**Tier: 2** — receipt-backed two-family model quorum, merge-on-green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)