### PR TITLE
feat(metrics): leverage + waste instruments (sprint 4 goal 2)

### DIFF
--- a/docs/status/LEVERAGE.md
+++ b/docs/status/LEVERAGE.md
@@ -1,0 +1,82 @@
+# Leverage & Waste Status
+
+<!-- leverage-managed:begin -->
+Last updated: 2026-06-10T21:26:37Z
+
+Repo-tracked recurring publication surface for the steering-leverage program
+(Operating Plan v2, Phase 0.2): leverage ratio (LR) and waste ratio together.
+
+## Leverage Ratio (LR)
+
+<!-- leverage-lr:begin -->
+| Metric | Value |
+| --- | --- |
+| Window | 2026-06-10T00:00:00Z -> 2026-06-10T21:22:09Z (7d) |
+| Merged PRs in window (total) | 31 |
+| Merged PRs receipt-backed (verified) | 28 |
+| Receipts failed verify | 0 |
+| Receipt refs unresolved locally | 0 |
+| Operator minutes (self-reported) | 25.0 |
+| Leverage ratio (verified merged outcomes / operator-minute) | 1.12 |
+| Steering integrity (SI) | null — pending: crux_shown, within_attention_budget, not_reversed_on_audit |
+| Methodology version | 1 |
+
+Operator-minutes note: baseline day estimate ~25 min: approval messages + design-review read + queue replies
+<!-- leverage-lr:end -->
+
+## Waste Ratio (Work-Loss Accounting)
+
+<!-- leverage-waste:begin -->
+| Metric | Value |
+| --- | --- |
+| Window (produced/closed units) | 2026-06-10T00:00:00Z -> 2026-06-10T21:24:37Z |
+| Branches pushed, never PR'd | 238 |
+| Outbox items expired unpublished | 21 |
+| Outbox items lost, never pushed | 355 |
+| PRs closed unmerged (window) | 9 |
+| Lost units (deduplicated) | 623 |
+| Produced units (merged PRs in window) | 32 |
+| Waste ratio (lost_units / max(1, produced_units)) | 19.47 |
+| Outbox items scanned / unreadable | 869 / 0 |
+| Methodology version | 1 |
+
+Unit definitions:
+- `branches_pushed_never_prd`: Non-protected branch present on origin that has never been the head ref of any PR and is not already claimed by an outbox loss category.
+- `outbox_expired_unpublished`: Outbox item (live or archive) whose expires_at has passed and which never reached a published state (no explicit publication marker, no PR for its branch, not marked already-satisfied).
+- `outbox_lost_never_pushed`: Unpublished outbox item whose branch never reached origin — the work exists (or existed) only locally.
+- `prs_closed_unmerged`: PR closed without merge, with closed_at inside the window.
+- `produced_units`: PRs merged inside the window (merged_at >= window start).
+- `lost_units`: Sum of the four loss categories after de-duplication by unit key (branch name when present, else outbox idempotency key); each lost unit counts in exactly one category.
+- `waste_ratio`: lost_units / max(1, produced_units).
+<!-- leverage-waste:end -->
+
+## Caveats (honest limits of these numbers)
+
+- **Operator-minutes are self-reported.** There is no attention capture yet;
+  the denominator is an operator estimate passed explicitly on the CLI, and
+  the script refuses to run without it.
+- **Steering Integrity (SI) is not yet instrumented.** It is published as
+  `null` — never a number — until crux_shown, within_attention_budget, and
+  not_reversed_on_audit are actually captured.
+- **Receipt linkage is text-based.** A PR counts as receipt-backed when its
+  body/comments reference a receipt path that exists locally and verifies;
+  this can undercount (receipts not referenced) or be gamed by splitting work
+  into more PRs — the merged_total column is published alongside to keep the
+  numerator auditable.
+- **Waste units are defined in the waste table above**; categories are
+  de-duplicated by unit key (branch name, else outbox idempotency key) so a
+  unit of lost work is counted at most once.
+<!-- leverage-managed:end -->
+
+## Blind-Period Log
+
+Manual entries below are preserved across re-renders; the publisher never
+touches text outside the managed region above.
+
+- 2026-05-27 -> 2026-06-05: automation publisher dead / loop blind
+  (source: `.aragora/run-20260610/OPERATOR_STEERING_AUDIT.md`).
+- Baseline reference (2026-06-10 outbox harvest, the manual prototype of the
+  waste instrument): 134 lost-never-pushed, 45 expired, 37 PRs recovered from
+  254 triaged items. The instrumented numbers above scan a wider corpus
+  (live + nested archive + archive dirs, 869 items) and so differ from the
+  harvest snapshot.

--- a/docs/status/LEVERAGE.md
+++ b/docs/status/LEVERAGE.md
@@ -1,7 +1,7 @@
 # Leverage & Waste Status
 
 <!-- leverage-managed:begin -->
-Last updated: 2026-06-10T21:26:37Z
+Last updated: 2026-06-10T21:33:55Z
 
 Repo-tracked recurring publication surface for the steering-leverage program
 (Operating Plan v2, Phase 0.2): leverage ratio (LR) and waste ratio together.
@@ -11,13 +11,15 @@ Repo-tracked recurring publication surface for the steering-leverage program
 <!-- leverage-lr:begin -->
 | Metric | Value |
 | --- | --- |
-| Window | 2026-06-10T00:00:00Z -> 2026-06-10T21:22:09Z (7d) |
-| Merged PRs in window (total) | 31 |
-| Merged PRs receipt-backed (verified) | 28 |
+| Window | 2026-06-10T00:00:00Z -> 2026-06-10T21:33:26Z (7d) |
+| Merged PRs in window (total) | 32 |
+| Merged PRs receipt-backed (verified) | 29 |
+| Unique verified receipts backing them | 50 |
+| Split factor (receipt-backed PRs / unique receipts; >1 = splitting) | 0.58 |
 | Receipts failed verify | 0 |
 | Receipt refs unresolved locally | 0 |
 | Operator minutes (self-reported) | 25.0 |
-| Leverage ratio (verified merged outcomes / operator-minute) | 1.12 |
+| Leverage ratio (verified merged outcomes / operator-minute) | 1.16 |
 | Steering integrity (SI) | null — pending: crux_shown, within_attention_budget, not_reversed_on_audit |
 | Methodology version | 1 |
 
@@ -61,8 +63,8 @@ Unit definitions:
 - **Receipt linkage is text-based.** A PR counts as receipt-backed when its
   body/comments reference a receipt path that exists locally and verifies;
   this can undercount (receipts not referenced) or be gamed by splitting work
-  into more PRs — the merged_total column is published alongside to keep the
-  numerator auditable.
+  into more PRs — merged_total, unique_receipts_backed, and split_factor are
+  published alongside so splitting is visible, not hidden.
 - **Waste units are defined in the waste table above**; categories are
   de-duplicated by unit key (branch name, else outbox idempotency key) so a
   unit of lost work is counted at most once.

--- a/scripts/measure_leverage_ratio.py
+++ b/scripts/measure_leverage_ratio.py
@@ -164,6 +164,7 @@ def compute_leverage(
     refs_unresolved = 0
     verified_cache: dict[Path, bool] = {}
     backed_prs: list[int] = []
+    unique_receipts: set[str] = set()
 
     for pr in merged_prs:
         texts = [pr.get("body") or ""]
@@ -181,9 +182,16 @@ def compute_leverage(
                     failed_verify_paths.append(str(path))
             if verified_cache[path]:
                 backed = True
+                unique_receipts.add(str(path))
         if backed:
             merged_receipt_backed += 1
             backed_prs.append(pr["number"])
+
+    # Anti-gaming guard: splitting one piece of work across N PRs that all
+    # cite the same receipt inflates merged_receipt_backed but not
+    # unique_receipts_backed; split_factor > 1 surfaces the divergence.
+    unique_receipts_backed = len(unique_receipts)
+    split_factor = merged_receipt_backed / unique_receipts_backed if unique_receipts_backed else 0.0
 
     return {
         "methodology_version": METHODOLOGY_VERSION,
@@ -196,6 +204,8 @@ def compute_leverage(
         "operator_minutes_note": operator_minutes_note,
         "merged_total": len(merged_prs),
         "merged_receipt_backed": merged_receipt_backed,
+        "unique_receipts_backed": unique_receipts_backed,
+        "split_factor": split_factor,
         "receipt_backed_pr_numbers": backed_prs,
         "receipts_failed_verify": len(failed_verify_paths),
         "failed_verify_paths": failed_verify_paths,
@@ -231,8 +241,8 @@ CAVEATS = """\
 - **Receipt linkage is text-based.** A PR counts as receipt-backed when its
   body/comments reference a receipt path that exists locally and verifies;
   this can undercount (receipts not referenced) or be gamed by splitting work
-  into more PRs — the merged_total column is published alongside to keep the
-  numerator auditable.
+  into more PRs — merged_total, unique_receipts_backed, and split_factor are
+  published alongside so splitting is visible, not hidden.
 - **Waste units are defined in the waste table above**; categories are
   de-duplicated by unit key (branch name, else outbox idempotency key) so a
   unit of lost work is counted at most once.
@@ -325,6 +335,11 @@ def render_lr_block(result: dict) -> str:
         ),
         ("Merged PRs in window (total)", result["merged_total"]),
         ("Merged PRs receipt-backed (verified)", result["merged_receipt_backed"]),
+        ("Unique verified receipts backing them", result["unique_receipts_backed"]),
+        (
+            "Split factor (receipt-backed PRs / unique receipts; >1 = splitting)",
+            f"{result['split_factor']:.4g}",
+        ),
         ("Receipts failed verify", result["receipts_failed_verify"]),
         ("Receipt refs unresolved locally", result["receipt_refs_unresolved"]),
         ("Operator minutes (self-reported)", result["operator_minutes"]),

--- a/scripts/measure_leverage_ratio.py
+++ b/scripts/measure_leverage_ratio.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+"""Measure the steering-program Leverage Ratio (LR).
+
+Sprint 4 goal 2 / Steering Leverage Operating Plan v2, Phase 0.2.
+
+LR = verified merged outcomes / operator-minutes, per window.
+
+A "verified outcome" is a PR merged inside the window whose body or comments
+reference a DecisionReceipt path that exists locally AND passes
+``aragora receipt verify``. Receipts that exist but fail verification are
+counted separately (``receipts_failed_verify``) and never silently dropped.
+
+Contract guarantees (see the program doc):
+- ``--operator-minutes`` is REQUIRED. The script refuses to run without it
+  (exit 2): the number is operator-estimated until attention capture exists,
+  and this script will never invent it.
+- ``steering_integrity`` is published as ``null`` — never a number — until its
+  three components (crux_shown, within_attention_budget, not_reversed_on_audit)
+  are actually instrumented.
+
+``--publish`` renders/updates ``docs/status/LEVERAGE.md`` inside a
+marker-delimited managed region; text outside the region (e.g. the manual
+Blind-Period Log entries) is never touched.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Callable, Sequence
+
+METHODOLOGY_VERSION = 1
+DEFAULT_REPO = "synaptent/aragora"
+DEFAULT_RECEIPTS_DIRS = (".aragora/run-20260610/receipts",)
+DEFAULT_STATUS_DOC = "docs/status/LEVERAGE.md"
+
+SI_COMPONENTS_PENDING = [
+    "crux_shown",
+    "within_attention_budget",
+    "not_reversed_on_audit",
+]
+
+OPERATOR_MINUTES_REFUSAL = (
+    "refusing to run: --operator-minutes is required and must be > 0.\n"
+    "Operator-minutes are operator-estimated (self-reported) until attention "
+    "capture exists; this script will never invent the number. Estimate the "
+    "human minutes actually spent steering this window (approvals, design "
+    "reviews, queue replies) and pass it explicitly."
+)
+
+# Receipt references in PR bodies/comments: any path-ish token whose parent
+# directory chain contains a `receipts/` segment and that ends in .json.
+RECEIPT_REF_RE = re.compile(r"[\w@~./\-]*receipts/[\w.@\-]+\.json")
+
+
+# ---------------------------------------------------------------------------
+# Subprocess boundaries (mockable)
+# ---------------------------------------------------------------------------
+
+
+def _run_gh(args: list[str]) -> str:
+    """Run a gh CLI command and return stdout (raises on failure)."""
+    proc = subprocess.run(["gh", *args], capture_output=True, text=True, check=True, timeout=300)
+    return proc.stdout
+
+
+def fetch_merged_prs(repo: str, since: datetime) -> list[dict]:
+    """Fetch PRs merged at/after ``since`` via the GitHub search REST API."""
+    since_str = since.strftime("%Y-%m-%dT%H:%M:%SZ")
+    query = f"repo:{repo} is:pr is:merged merged:>={since_str}"
+    out = _run_gh(
+        [
+            "api",
+            "--paginate",
+            "-X",
+            "GET",
+            "search/issues",
+            "-f",
+            f"q={query}",
+            "--jq",
+            ".items[] | {number: .number, title: .title, body: .body, "
+            "merged_at: .pull_request.merged_at}",
+        ]
+    )
+    return [json.loads(line) for line in out.splitlines() if line.strip()]
+
+
+def fetch_issue_comments(repo: str, number: int) -> list[str]:
+    """Fetch issue-comment bodies for a PR."""
+    out = _run_gh(
+        [
+            "api",
+            "--paginate",
+            f"repos/{repo}/issues/{number}/comments",
+            "--jq",
+            ".[].body",
+        ]
+    )
+    # --jq emits raw strings per line; comments may be multi-line, so fetch
+    # as JSON instead when precision matters. For receipt-path scanning,
+    # newline-joined text is sufficient.
+    return [out] if out.strip() else []
+
+
+def verify_receipt(path: Path) -> bool:
+    """Verify a receipt via ``aragora receipt verify`` (subprocess boundary)."""
+    try:
+        proc = subprocess.run(
+            ["aragora", "receipt", "verify", str(path)],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return proc.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def find_receipt_refs(text: str) -> list[str]:
+    """Extract unique receipt-path references from free text, in order."""
+    seen: dict[str, None] = {}
+    for match in RECEIPT_REF_RE.finditer(text or ""):
+        seen.setdefault(match.group(0), None)
+    return list(seen)
+
+
+def resolve_receipt_path(ref: str, receipts_dirs: Sequence[Path]) -> Path | None:
+    """Resolve a referenced receipt path to a local file, or None."""
+    candidates = [Path(ref).expanduser()]
+    basename = Path(ref).name
+    candidates.extend(Path(d) / basename for d in receipts_dirs)
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def compute_leverage(
+    *,
+    merged_prs: list[dict],
+    operator_minutes: float,
+    receipts_dirs: Sequence[Path],
+    comments_fetcher: Callable[[int], list[str]],
+    verifier: Callable[[Path], bool],
+    window_start: datetime,
+    window_end: datetime,
+    window_days: int,
+    repo: str,
+    operator_minutes_note: str = "",
+) -> dict:
+    """Compute the leverage-ratio report from already-fetched inputs."""
+    merged_receipt_backed = 0
+    failed_verify_paths: list[str] = []
+    refs_unresolved = 0
+    verified_cache: dict[Path, bool] = {}
+    backed_prs: list[int] = []
+
+    for pr in merged_prs:
+        texts = [pr.get("body") or ""]
+        texts.extend(comments_fetcher(pr["number"]))
+        refs = find_receipt_refs("\n".join(texts))
+        backed = False
+        for ref in refs:
+            path = resolve_receipt_path(ref, receipts_dirs)
+            if path is None:
+                refs_unresolved += 1
+                continue
+            if path not in verified_cache:
+                verified_cache[path] = verifier(path)
+                if not verified_cache[path]:
+                    failed_verify_paths.append(str(path))
+            if verified_cache[path]:
+                backed = True
+        if backed:
+            merged_receipt_backed += 1
+            backed_prs.append(pr["number"])
+
+    return {
+        "methodology_version": METHODOLOGY_VERSION,
+        "repo": repo,
+        "window_days": window_days,
+        "window_start": window_start.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "window_end": window_end.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "operator_minutes": operator_minutes,
+        "operator_minutes_source": ("self-reported (operator-estimated; no attention capture yet)"),
+        "operator_minutes_note": operator_minutes_note,
+        "merged_total": len(merged_prs),
+        "merged_receipt_backed": merged_receipt_backed,
+        "receipt_backed_pr_numbers": backed_prs,
+        "receipts_failed_verify": len(failed_verify_paths),
+        "failed_verify_paths": failed_verify_paths,
+        "receipt_refs_unresolved": refs_unresolved,
+        "leverage_ratio": merged_receipt_backed / operator_minutes,
+        "steering_integrity": None,
+        "si_components_pending": SI_COMPONENTS_PENDING,
+    }
+
+
+# ---------------------------------------------------------------------------
+# LEVERAGE.md managed-region rendering
+# ---------------------------------------------------------------------------
+
+MANAGED_BEGIN = "<!-- leverage-managed:begin -->"
+MANAGED_END = "<!-- leverage-managed:end -->"
+LR_BEGIN = "<!-- leverage-lr:begin -->"
+LR_END = "<!-- leverage-lr:end -->"
+WASTE_BEGIN = "<!-- leverage-waste:begin -->"
+WASTE_END = "<!-- leverage-waste:end -->"
+LR_PLACEHOLDER = "_Leverage ratio not yet measured._"
+WASTE_PLACEHOLDER = "_Waste ratio not yet measured._"
+
+CAVEATS = """\
+## Caveats (honest limits of these numbers)
+
+- **Operator-minutes are self-reported.** There is no attention capture yet;
+  the denominator is an operator estimate passed explicitly on the CLI, and
+  the script refuses to run without it.
+- **Steering Integrity (SI) is not yet instrumented.** It is published as
+  `null` — never a number — until crux_shown, within_attention_budget, and
+  not_reversed_on_audit are actually captured.
+- **Receipt linkage is text-based.** A PR counts as receipt-backed when its
+  body/comments reference a receipt path that exists locally and verifies;
+  this can undercount (receipts not referenced) or be gamed by splitting work
+  into more PRs — the merged_total column is published alongside to keep the
+  numerator auditable.
+- **Waste units are defined in the waste table above**; categories are
+  de-duplicated by unit key (branch name, else outbox idempotency key) so a
+  unit of lost work is counted at most once.
+"""
+
+BLIND_PERIOD_SEED = """\
+## Blind-Period Log
+
+Manual entries below are preserved across re-renders; the publisher never
+touches text outside the managed region above.
+
+- 2026-05-27 -> 2026-06-05: automation publisher dead / loop blind
+  (source: `.aragora/run-20260610/OPERATOR_STEERING_AUDIT.md`).
+"""
+
+
+def _extract_block(text: str, begin: str, end: str) -> str | None:
+    try:
+        start = text.index(begin) + len(begin)
+        stop = text.index(end, start)
+    except ValueError:
+        return None
+    return text[start:stop].strip("\n")
+
+
+def _render_managed(lr_block: str, waste_block: str, now_iso: str) -> str:
+    return (
+        f"{MANAGED_BEGIN}\n"
+        f"Last updated: {now_iso}\n\n"
+        "Repo-tracked recurring publication surface for the steering-leverage "
+        "program\n(Operating Plan v2, Phase 0.2): leverage ratio (LR) and "
+        "waste ratio together.\n\n"
+        "## Leverage Ratio (LR)\n\n"
+        f"{LR_BEGIN}\n{lr_block}\n{LR_END}\n\n"
+        "## Waste Ratio (Work-Loss Accounting)\n\n"
+        f"{WASTE_BEGIN}\n{waste_block}\n{WASTE_END}\n\n"
+        f"{CAVEATS}"
+        f"{MANAGED_END}\n"
+    )
+
+
+def update_leverage_md(
+    path: Path,
+    *,
+    lr_block: str | None = None,
+    waste_block: str | None = None,
+    now: datetime | None = None,
+) -> str:
+    """Create/update the managed region of LEVERAGE.md.
+
+    Only the managed region between the markers is rewritten. Whichever of
+    ``lr_block`` / ``waste_block`` is not supplied is carried over from the
+    existing file (or a placeholder on first render). Text outside the
+    managed region is never modified.
+    """
+    now_iso = (now or datetime.now(timezone.utc)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    existing = path.read_text() if path.exists() else ""
+
+    prior_lr = _extract_block(existing, LR_BEGIN, LR_END)
+    prior_waste = _extract_block(existing, WASTE_BEGIN, WASTE_END)
+    managed = _render_managed(
+        lr_block if lr_block is not None else (prior_lr or LR_PLACEHOLDER),
+        waste_block if waste_block is not None else (prior_waste or WASTE_PLACEHOLDER),
+        now_iso,
+    )
+
+    if MANAGED_BEGIN in existing and MANAGED_END in existing:
+        start = existing.index(MANAGED_BEGIN)
+        stop = existing.index(MANAGED_END) + len(MANAGED_END)
+        new_text = existing[:start] + managed.rstrip("\n") + existing[stop:]
+        if not new_text.endswith("\n"):
+            new_text += "\n"
+    elif existing:
+        new_text = existing.rstrip("\n") + "\n\n" + managed
+    else:
+        new_text = "# Leverage & Waste Status\n\n" + managed + "\n" + BLIND_PERIOD_SEED
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(new_text)
+    return new_text
+
+
+def render_lr_block(result: dict) -> str:
+    """Render the LR markdown table from a compute_leverage() result."""
+    si_pending = ", ".join(result["si_components_pending"])
+    rows = [
+        (
+            "Window",
+            f"{result['window_start']} -> {result['window_end']} ({result['window_days']}d)",
+        ),
+        ("Merged PRs in window (total)", result["merged_total"]),
+        ("Merged PRs receipt-backed (verified)", result["merged_receipt_backed"]),
+        ("Receipts failed verify", result["receipts_failed_verify"]),
+        ("Receipt refs unresolved locally", result["receipt_refs_unresolved"]),
+        ("Operator minutes (self-reported)", result["operator_minutes"]),
+        (
+            "Leverage ratio (verified merged outcomes / operator-minute)",
+            f"{result['leverage_ratio']:.4g}",
+        ),
+        ("Steering integrity (SI)", f"null — pending: {si_pending}"),
+        ("Methodology version", result["methodology_version"]),
+    ]
+    lines = ["| Metric | Value |", "| --- | --- |"]
+    lines.extend(f"| {k} | {v} |" for k, v in rows)
+    if result.get("operator_minutes_note"):
+        lines.append("")
+        lines.append(f"Operator-minutes note: {result['operator_minutes_note']}")
+    if result.get("failed_verify_paths"):
+        lines.append("")
+        lines.append("Receipts that failed verification (never silent):")
+        lines.extend(f"- `{p}`" for p in result["failed_verify_paths"])
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--window-days", type=int, default=7)
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument(
+        "--operator-minutes",
+        type=float,
+        default=None,
+        help="REQUIRED. Self-reported operator minutes for the window; the "
+        "script refuses to invent this number.",
+    )
+    parser.add_argument(
+        "--operator-minutes-note",
+        default="",
+        help="Free-text provenance for the operator-minutes estimate.",
+    )
+    parser.add_argument(
+        "--receipts-dir",
+        action="append",
+        default=None,
+        help="Local receipts dir(s) used to resolve referenced receipt paths "
+        f"(repeatable; default: {DEFAULT_RECEIPTS_DIRS[0]}).",
+    )
+    parser.add_argument(
+        "--since",
+        default=None,
+        help="ISO8601 UTC window start override (default: now - window-days).",
+    )
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    parser.add_argument("--publish", action="store_true")
+    parser.add_argument("--status-doc", default=DEFAULT_STATUS_DOC)
+    args = parser.parse_args(argv)
+
+    if args.operator_minutes is None or args.operator_minutes <= 0:
+        print(OPERATOR_MINUTES_REFUSAL, file=sys.stderr)
+        return 2
+
+    window_end = datetime.now(timezone.utc)
+    if args.since:
+        window_start = datetime.fromisoformat(args.since.replace("Z", "+00:00"))
+    else:
+        window_start = window_end - timedelta(days=args.window_days)
+
+    receipts_dirs = [Path(d) for d in (args.receipts_dir or DEFAULT_RECEIPTS_DIRS)]
+    merged_prs = fetch_merged_prs(args.repo, window_start)
+    result = compute_leverage(
+        merged_prs=merged_prs,
+        operator_minutes=args.operator_minutes,
+        receipts_dirs=receipts_dirs,
+        comments_fetcher=lambda n: fetch_issue_comments(args.repo, n),
+        verifier=verify_receipt,
+        window_start=window_start,
+        window_end=window_end,
+        window_days=args.window_days,
+        repo=args.repo,
+        operator_minutes_note=args.operator_minutes_note,
+    )
+
+    if args.as_json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(
+            f"LR={result['leverage_ratio']:.4g} "
+            f"({result['merged_receipt_backed']}/{result['merged_total']} merged "
+            f"PRs receipt-backed; {result['receipts_failed_verify']} failed "
+            f"verify; {result['operator_minutes']} operator-min; SI=null)"
+        )
+
+    if args.publish:
+        doc = Path(args.status_doc)
+        update_leverage_md(doc, lr_block=render_lr_block(result))
+        print(f"published LR section to {doc}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/measure_work_loss.py
+++ b/scripts/measure_work_loss.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""Measure agent work-loss (the waste ratio) — the leverage ratio's dual.
+
+Sprint 4 goal 2 / Steering Leverage Operating Plan v2, Pillar 7 MVP.
+
+Waste accounting from three injectable inputs:
+1. Outbox dir items (live + archive, with publication state),
+2. ``git ls-remote --heads origin`` output (or a captured file),
+3. A PR list with head refs / state / merge timestamps (or a captured file).
+
+Computed units (defined in ``UNIT_DEFINITIONS`` and printed in --json output):
+``branches_pushed_never_prd``, ``outbox_expired_unpublished``,
+``outbox_lost_never_pushed``, ``prs_closed_unmerged``, ``produced_units``.
+
+``waste_ratio = lost_units / max(1, produced_units)``; loss categories are
+de-duplicated by unit key (branch name when present, else outbox idempotency
+key) so a unit of lost work counts in exactly one category.
+
+``--publish`` updates the waste section of ``docs/status/LEVERAGE.md`` via the
+same managed-region renderer as measure_leverage_ratio.py; manual text outside
+the managed region is never touched.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Sequence
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from measure_leverage_ratio import (  # type: ignore[no-redef]
+        DEFAULT_REPO,
+        DEFAULT_STATUS_DOC,
+        update_leverage_md,
+    )
+else:  # imported as scripts.measure_work_loss
+    from scripts.measure_leverage_ratio import (
+        DEFAULT_REPO,
+        DEFAULT_STATUS_DOC,
+        update_leverage_md,
+    )
+
+METHODOLOGY_VERSION = 1
+DEFAULT_OUTBOX_DIRS = (
+    ".aragora/automation-outbox",
+    ".aragora/automation-outbox/archive",
+    ".aragora/automation-outbox-archive",
+)
+PROTECTED_BRANCHES = {"main", "master", "gh-pages", "HEAD"}
+
+UNIT_DEFINITIONS = {
+    "branches_pushed_never_prd": (
+        "Non-protected branch present on origin that has never been the head "
+        "ref of any PR and is not already claimed by an outbox loss category."
+    ),
+    "outbox_expired_unpublished": (
+        "Outbox item (live or archive) whose expires_at has passed and which "
+        "never reached a published state (no explicit publication marker, no "
+        "PR for its branch, not marked already-satisfied)."
+    ),
+    "outbox_lost_never_pushed": (
+        "Unpublished outbox item whose branch never reached origin — the work "
+        "exists (or existed) only locally."
+    ),
+    "prs_closed_unmerged": ("PR closed without merge, with closed_at inside the window."),
+    "produced_units": "PRs merged inside the window (merged_at >= window start).",
+    "lost_units": (
+        "Sum of the four loss categories after de-duplication by unit key "
+        "(branch name when present, else outbox idempotency key); each lost "
+        "unit counts in exactly one category."
+    ),
+    "waste_ratio": "lost_units / max(1, produced_units).",
+}
+
+
+# ---------------------------------------------------------------------------
+# Input loading / subprocess boundaries (all injectable via CLI files)
+# ---------------------------------------------------------------------------
+
+
+def run_ls_remote() -> str:
+    proc = subprocess.run(
+        ["git", "ls-remote", "--heads", "origin"],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=120,
+    )
+    return proc.stdout
+
+
+def fetch_all_prs(repo: str) -> list[dict]:
+    """Fetch head-ref/state/merge info for all PRs via gh REST (paginated)."""
+    proc = subprocess.run(
+        [
+            "gh",
+            "api",
+            "--paginate",
+            f"repos/{repo}/pulls?state=all&per_page=100",
+            "--jq",
+            ".[] | {number: .number, head_ref: .head.ref, state: .state, "
+            "merged: (.merged_at != null), merged_at: .merged_at, "
+            "closed_at: .closed_at}",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=1800,
+    )
+    return [json.loads(line) for line in proc.stdout.splitlines() if line.strip()]
+
+
+def parse_ls_remote(text: str) -> set[str]:
+    """Parse ``git ls-remote --heads`` output into a set of branch names."""
+    heads: set[str] = set()
+    for line in text.splitlines():
+        parts = line.split("\t")
+        if len(parts) == 2 and parts[1].startswith("refs/heads/"):
+            heads.add(parts[1][len("refs/heads/") :].strip())
+    return heads
+
+
+def load_outbox_items(dirs: Sequence[Path]) -> tuple[list[dict], int]:
+    """Load outbox item JSON files; unreadable files are counted, not hidden."""
+    items: list[dict] = []
+    unreadable = 0
+    for d in dirs:
+        if not d.is_dir():
+            continue
+        for f in sorted(d.glob("*.json")):
+            try:
+                item = json.loads(f.read_text())
+            except (OSError, json.JSONDecodeError):
+                unreadable += 1
+                continue
+            if isinstance(item, dict):
+                item["_source"] = str(d)
+                item["_file"] = f.name
+                items.append(item)
+            else:
+                unreadable += 1
+    return items, unreadable
+
+
+# ---------------------------------------------------------------------------
+# Pure computation
+# ---------------------------------------------------------------------------
+
+
+def _parse_iso(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _as_str(value: object) -> str | None:
+    """Return value only when it is a non-empty string (real outbox data
+    occasionally carries dicts/lists in these fields)."""
+    return value if isinstance(value, str) and value else None
+
+
+def _item_branch(item: dict) -> str | None:
+    branch = _as_str(item.get("branch"))
+    if not branch:
+        evidence = item.get("local_evidence")
+        if isinstance(evidence, dict):
+            branch = _as_str(evidence.get("branch"))
+    return branch
+
+
+def _item_published(item: dict, pr_head_refs: set[str]) -> bool:
+    if item.get("published") is True:
+        return True
+    publication = item.get("publication")
+    if isinstance(publication, dict) and (
+        publication.get("published") is True or publication.get("state") == "published"
+    ):
+        return True
+    if item.get("pr_number") or item.get("pr_url"):
+        return True
+    if "already_satisfied" in str(item.get("requested_action", "")):
+        return True
+    branch = _item_branch(item)
+    return bool(branch and branch in pr_head_refs)
+
+
+def compute_work_loss(
+    *,
+    outbox_items: list[dict],
+    remote_heads: set[str],
+    prs: list[dict],
+    now: datetime,
+    window_start: datetime,
+    unreadable_outbox_items: int = 0,
+) -> dict:
+    """Compute the waste report from already-loaded inputs."""
+    pr_head_refs = {ref for pr in prs if (ref := _as_str(pr.get("head_ref")))}
+    claimed: set[str] = set()
+    lost_never_pushed: list[str] = []
+    expired_unpublished: list[str] = []
+
+    for item in outbox_items:
+        branch = _item_branch(item)
+        key = branch or _as_str(item.get("idempotency_key")) or _as_str(item.get("_file")) or ""
+        if not key or key in claimed:
+            continue
+        if _item_published(item, pr_head_refs):
+            continue
+        expires_at = _parse_iso(item.get("expires_at"))
+        if branch and branch not in remote_heads:
+            # Never pushed wins over expired: the work exists only locally.
+            lost_never_pushed.append(key)
+            claimed.add(key)
+            if branch:
+                claimed.add(branch)
+        elif expires_at and expires_at < now:
+            expired_unpublished.append(key)
+            claimed.add(key)
+            if branch:
+                claimed.add(branch)
+
+    orphan_branches = sorted(
+        b for b in remote_heads - PROTECTED_BRANCHES if b not in pr_head_refs and b not in claimed
+    )
+    claimed.update(orphan_branches)
+
+    closed_unmerged = []
+    produced = []
+    for pr in prs:
+        merged_at = _parse_iso(pr.get("merged_at"))
+        if pr.get("merged") and merged_at and merged_at >= window_start:
+            produced.append(pr["number"])
+        elif pr.get("state") == "closed" and not pr.get("merged"):
+            closed_at = _parse_iso(pr.get("closed_at"))
+            if closed_at and closed_at >= window_start:
+                closed_unmerged.append(pr["number"])
+
+    lost_units = (
+        len(lost_never_pushed)
+        + len(expired_unpublished)
+        + len(orphan_branches)
+        + len(closed_unmerged)
+    )
+    produced_units = len(produced)
+    return {
+        "methodology_version": METHODOLOGY_VERSION,
+        "window_start": window_start.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "window_end": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "branches_pushed_never_prd": len(orphan_branches),
+        "outbox_expired_unpublished": len(expired_unpublished),
+        "outbox_lost_never_pushed": len(lost_never_pushed),
+        "prs_closed_unmerged": len(closed_unmerged),
+        "produced_units": produced_units,
+        "lost_units": lost_units,
+        "waste_ratio": lost_units / max(1, produced_units),
+        "outbox_items_scanned": len(outbox_items),
+        "unreadable_outbox_items": unreadable_outbox_items,
+        "remote_heads_scanned": len(remote_heads),
+        "prs_scanned": len(prs),
+        "sample_lost_never_pushed": lost_never_pushed[:10],
+        "sample_expired_unpublished": expired_unpublished[:10],
+        "sample_branches_never_prd": orphan_branches[:10],
+        "unit_definitions": UNIT_DEFINITIONS,
+    }
+
+
+def render_waste_block(result: dict) -> str:
+    """Render the waste markdown table from a compute_work_loss() result."""
+    rows = [
+        ("Window (produced/closed units)", f"{result['window_start']} -> {result['window_end']}"),
+        ("Branches pushed, never PR'd", result["branches_pushed_never_prd"]),
+        ("Outbox items expired unpublished", result["outbox_expired_unpublished"]),
+        ("Outbox items lost, never pushed", result["outbox_lost_never_pushed"]),
+        ("PRs closed unmerged (window)", result["prs_closed_unmerged"]),
+        ("Lost units (deduplicated)", result["lost_units"]),
+        ("Produced units (merged PRs in window)", result["produced_units"]),
+        ("Waste ratio (lost_units / max(1, produced_units))", f"{result['waste_ratio']:.4g}"),
+        (
+            "Outbox items scanned / unreadable",
+            f"{result['outbox_items_scanned']} / {result['unreadable_outbox_items']}",
+        ),
+        ("Methodology version", result["methodology_version"]),
+    ]
+    lines = ["| Metric | Value |", "| --- | --- |"]
+    lines.extend(f"| {k} | {v} |" for k, v in rows)
+    lines.append("")
+    lines.append("Unit definitions:")
+    lines.extend(f"- `{k}`: {v}" for k, v in result["unit_definitions"].items())
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--window-days", type=int, default=7)
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument(
+        "--outbox-dir",
+        action="append",
+        default=None,
+        help="Outbox dir(s) to scan (repeatable; default: live + archive).",
+    )
+    parser.add_argument(
+        "--ls-remote-file",
+        default=None,
+        help="Captured `git ls-remote --heads origin` output (default: run git).",
+    )
+    parser.add_argument(
+        "--prs-file",
+        default=None,
+        help="JSON list of PRs with number/head_ref/state/merged/merged_at/"
+        "closed_at (default: fetch all PRs via gh REST).",
+    )
+    parser.add_argument(
+        "--since",
+        default=None,
+        help="ISO8601 UTC window start override (default: now - window-days).",
+    )
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    parser.add_argument("--publish", action="store_true")
+    parser.add_argument("--status-doc", default=DEFAULT_STATUS_DOC)
+    args = parser.parse_args(argv)
+
+    now = datetime.now(timezone.utc)
+    if args.since:
+        window_start = datetime.fromisoformat(args.since.replace("Z", "+00:00"))
+    else:
+        window_start = now - timedelta(days=args.window_days)
+
+    outbox_dirs = [Path(d) for d in (args.outbox_dir or DEFAULT_OUTBOX_DIRS)]
+    outbox_items, unreadable = load_outbox_items(outbox_dirs)
+
+    if args.ls_remote_file:
+        ls_remote_text = Path(args.ls_remote_file).read_text()
+    else:
+        ls_remote_text = run_ls_remote()
+    remote_heads = parse_ls_remote(ls_remote_text)
+
+    if args.prs_file:
+        prs = json.loads(Path(args.prs_file).read_text())
+    else:
+        prs = fetch_all_prs(args.repo)
+
+    result = compute_work_loss(
+        outbox_items=outbox_items,
+        remote_heads=remote_heads,
+        prs=prs,
+        now=now,
+        window_start=window_start,
+        unreadable_outbox_items=unreadable,
+    )
+
+    if args.as_json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(
+            f"waste_ratio={result['waste_ratio']:.4g} "
+            f"(lost={result['lost_units']} "
+            f"[never-pushed={result['outbox_lost_never_pushed']}, "
+            f"expired={result['outbox_expired_unpublished']}, "
+            f"orphan-branches={result['branches_pushed_never_prd']}, "
+            f"closed-unmerged={result['prs_closed_unmerged']}] / "
+            f"produced={result['produced_units']})"
+        )
+
+    if args.publish:
+        doc = Path(args.status_doc)
+        update_leverage_md(doc, waste_block=render_waste_block(result))
+        print(f"published waste section to {doc}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_measure_leverage_ratio.py
+++ b/tests/scripts/test_measure_leverage_ratio.py
@@ -265,6 +265,8 @@ def _lr_result(**overrides) -> dict:
         "operator_minutes_note": "baseline day estimate",
         "merged_total": 9,
         "merged_receipt_backed": 4,
+        "unique_receipts_backed": 4,
+        "split_factor": 1.0,
         "receipts_failed_verify": 0,
         "receipt_refs_unresolved": 1,
         "failed_verify_paths": [],
@@ -339,3 +341,67 @@ class TestUpdateLeverageMdIdempotency:
         assert "<!-- leverage-managed:end -->#" not in text
         # blind-period heading still starts at a line boundary
         assert "\n## Blind-Period Log" in text
+
+
+class TestAntiSplitting:
+    """LR gameability guard: PR-splitting inflates merged_receipt_backed but
+    not unique_receipts_backed; split_factor surfaces the divergence."""
+
+    def test_unique_receipts_and_split_factor(self, tmp_path: Path) -> None:
+        rdir = tmp_path / "receipts"
+        rdir.mkdir()
+        (rdir / "shared.json").write_text("{}")
+        prs = [
+            _pr(1, body="receipts/shared.json"),
+            _pr(2, body="receipts/shared.json"),
+            _pr(3, body="receipts/shared.json"),
+        ]
+        result = compute_leverage(
+            merged_prs=prs,
+            operator_minutes=10.0,
+            receipts_dirs=[rdir],
+            comments_fetcher=lambda n: [],
+            verifier=lambda p: True,
+            window_start=WINDOW_START,
+            window_end=NOW,
+            window_days=7,
+            repo="synaptent/aragora",
+        )
+        assert result["merged_receipt_backed"] == 3
+        assert result["unique_receipts_backed"] == 1
+        assert result["split_factor"] == pytest.approx(3.0)
+
+    def test_split_factor_one_when_distinct(self, tmp_path: Path) -> None:
+        rdir = tmp_path / "receipts"
+        rdir.mkdir()
+        (rdir / "a.json").write_text("{}")
+        (rdir / "b.json").write_text("{}")
+        prs = [_pr(1, body="receipts/a.json"), _pr(2, body="receipts/b.json")]
+        result = compute_leverage(
+            merged_prs=prs,
+            operator_minutes=10.0,
+            receipts_dirs=[rdir],
+            comments_fetcher=lambda n: [],
+            verifier=lambda p: True,
+            window_start=WINDOW_START,
+            window_end=NOW,
+            window_days=7,
+            repo="synaptent/aragora",
+        )
+        assert result["unique_receipts_backed"] == 2
+        assert result["split_factor"] == pytest.approx(1.0)
+
+    def test_no_backed_prs_zero_unique(self, tmp_path: Path) -> None:
+        result = compute_leverage(
+            merged_prs=[_pr(1)],
+            operator_minutes=10.0,
+            receipts_dirs=[tmp_path],
+            comments_fetcher=lambda n: [],
+            verifier=lambda p: True,
+            window_start=WINDOW_START,
+            window_end=NOW,
+            window_days=7,
+            repo="synaptent/aragora",
+        )
+        assert result["unique_receipts_backed"] == 0
+        assert result["split_factor"] == 0.0

--- a/tests/scripts/test_measure_leverage_ratio.py
+++ b/tests/scripts/test_measure_leverage_ratio.py
@@ -1,0 +1,341 @@
+"""Tests for scripts/measure_leverage_ratio.py (steering program Phase 0.2).
+
+All network and subprocess boundaries are injected; no gh / git / aragora
+calls happen in these tests.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from scripts.measure_leverage_ratio import (
+    METHODOLOGY_VERSION,
+    SI_COMPONENTS_PENDING,
+    compute_leverage,
+    find_receipt_refs,
+    main,
+    render_lr_block,
+    resolve_receipt_path,
+    update_leverage_md,
+)
+
+NOW = datetime(2026, 6, 10, 12, 0, 0, tzinfo=timezone.utc)
+WINDOW_START = datetime(2026, 6, 10, 0, 0, 0, tzinfo=timezone.utc)
+
+
+def _pr(number: int, body: str = "") -> dict:
+    return {
+        "number": number,
+        "title": f"pr {number}",
+        "body": body,
+        "merged_at": "2026-06-10T08:00:00Z",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Receipt reference extraction / resolution
+# ---------------------------------------------------------------------------
+
+
+class TestFindReceiptRefs:
+    def test_extracts_receipt_paths(self) -> None:
+        text = (
+            "Receipt artifact: .aragora/run-20260610/receipts/c03_instruments_grok.json\n"
+            "and also `receipts/other_one.json` inline."
+        )
+        refs = find_receipt_refs(text)
+        assert ".aragora/run-20260610/receipts/c03_instruments_grok.json" in refs
+        assert any(r.endswith("receipts/other_one.json") for r in refs)
+
+    def test_ignores_non_receipt_json(self) -> None:
+        assert find_receipt_refs("see config/settings.json and data.json") == []
+
+    def test_empty_text(self) -> None:
+        assert find_receipt_refs("") == []
+
+    def test_deduplicates(self) -> None:
+        text = "receipts/a.json receipts/a.json"
+        assert len(find_receipt_refs(text)) == 1
+
+
+class TestResolveReceiptPath:
+    def test_resolves_by_basename_in_receipts_dir(self, tmp_path: Path) -> None:
+        rdir = tmp_path / "receipts"
+        rdir.mkdir()
+        (rdir / "x.json").write_text("{}")
+        got = resolve_receipt_path(".aragora/run-x/receipts/x.json", [rdir])
+        assert got == rdir / "x.json"
+
+    def test_resolves_direct_path(self, tmp_path: Path) -> None:
+        rdir = tmp_path / "receipts"
+        rdir.mkdir()
+        p = rdir / "y.json"
+        p.write_text("{}")
+        assert resolve_receipt_path(str(p), []) == p
+
+    def test_missing_returns_none(self, tmp_path: Path) -> None:
+        assert resolve_receipt_path("receipts/nope.json", [tmp_path]) is None
+
+
+# ---------------------------------------------------------------------------
+# Core LR computation
+# ---------------------------------------------------------------------------
+
+
+class TestComputeLeverage:
+    def _receipts_dir(self, tmp_path: Path) -> Path:
+        rdir = tmp_path / "receipts"
+        rdir.mkdir()
+        (rdir / "good.json").write_text("{}")
+        (rdir / "bad.json").write_text("{}")
+        return rdir
+
+    def test_counts_and_ratio(self, tmp_path: Path) -> None:
+        rdir = self._receipts_dir(tmp_path)
+        prs = [
+            _pr(1, body="Receipt artifact: receipts/good.json"),
+            _pr(2, body="Receipt artifact: receipts/bad.json"),
+            _pr(3, body="no receipts here"),
+        ]
+        result = compute_leverage(
+            merged_prs=prs,
+            operator_minutes=25.0,
+            receipts_dirs=[rdir],
+            comments_fetcher=lambda n: [],
+            verifier=lambda p: p.name == "good.json",
+            window_start=WINDOW_START,
+            window_end=NOW,
+            window_days=7,
+            repo="synaptent/aragora",
+        )
+        assert result["merged_total"] == 3
+        assert result["merged_receipt_backed"] == 1
+        assert result["receipts_failed_verify"] == 1
+        assert result["failed_verify_paths"] == [str(rdir / "bad.json")]
+        assert result["leverage_ratio"] == pytest.approx(1 / 25.0)
+        assert result["methodology_version"] == METHODOLOGY_VERSION
+
+    def test_steering_integrity_is_null_never_a_number(self, tmp_path: Path) -> None:
+        result = compute_leverage(
+            merged_prs=[],
+            operator_minutes=10.0,
+            receipts_dirs=[tmp_path],
+            comments_fetcher=lambda n: [],
+            verifier=lambda p: True,
+            window_start=WINDOW_START,
+            window_end=NOW,
+            window_days=7,
+            repo="synaptent/aragora",
+        )
+        assert result["steering_integrity"] is None
+        assert result["si_components_pending"] == SI_COMPONENTS_PENDING
+        assert result["si_components_pending"] == [
+            "crux_shown",
+            "within_attention_budget",
+            "not_reversed_on_audit",
+        ]
+
+    def test_receipt_ref_in_comments_counts(self, tmp_path: Path) -> None:
+        rdir = self._receipts_dir(tmp_path)
+        result = compute_leverage(
+            merged_prs=[_pr(7)],
+            operator_minutes=5.0,
+            receipts_dirs=[rdir],
+            comments_fetcher=lambda n: ["Receipt artifact: receipts/good.json"],
+            verifier=lambda p: True,
+            window_start=WINDOW_START,
+            window_end=NOW,
+            window_days=7,
+            repo="synaptent/aragora",
+        )
+        assert result["merged_receipt_backed"] == 1
+
+    def test_ref_to_missing_local_receipt_not_backed_not_silent(self, tmp_path: Path) -> None:
+        result = compute_leverage(
+            merged_prs=[_pr(8, body="receipts/ghost.json")],
+            operator_minutes=5.0,
+            receipts_dirs=[tmp_path],
+            comments_fetcher=lambda n: [],
+            verifier=lambda p: True,
+            window_start=WINDOW_START,
+            window_end=NOW,
+            window_days=7,
+            repo="synaptent/aragora",
+        )
+        assert result["merged_receipt_backed"] == 0
+        assert result["receipt_refs_unresolved"] == 1
+
+    def test_failed_verify_pr_with_another_good_receipt_still_backed(self, tmp_path: Path) -> None:
+        rdir = self._receipts_dir(tmp_path)
+        result = compute_leverage(
+            merged_prs=[_pr(9, body="receipts/bad.json and receipts/good.json")],
+            operator_minutes=5.0,
+            receipts_dirs=[rdir],
+            comments_fetcher=lambda n: [],
+            verifier=lambda p: p.name == "good.json",
+            window_start=WINDOW_START,
+            window_end=NOW,
+            window_days=7,
+            repo="synaptent/aragora",
+        )
+        assert result["merged_receipt_backed"] == 1
+        assert result["receipts_failed_verify"] == 1
+
+
+# ---------------------------------------------------------------------------
+# CLI refusal contract: operator-minutes must never be invented
+# ---------------------------------------------------------------------------
+
+
+class TestOperatorMinutesRefusal:
+    def test_refuses_without_operator_minutes(self, capsys: pytest.CaptureFixture) -> None:
+        rc = main(["--json"])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "operator-minutes" in err
+        assert "operator-estimated" in err
+
+    def test_refuses_zero_operator_minutes(self, capsys: pytest.CaptureFixture) -> None:
+        rc = main(["--operator-minutes", "0"])
+        assert rc == 2
+
+    def test_refuses_negative_operator_minutes(self, capsys: pytest.CaptureFixture) -> None:
+        rc = main(["--operator-minutes", "-3"])
+        assert rc == 2
+
+
+class TestMainJson:
+    def test_json_output(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        rdir = tmp_path / "receipts"
+        rdir.mkdir()
+        (rdir / "good.json").write_text("{}")
+
+        import scripts.measure_leverage_ratio as mlr
+
+        monkeypatch.setattr(
+            mlr,
+            "fetch_merged_prs",
+            lambda repo, since: [_pr(1, body="receipts/good.json"), _pr(2)],
+        )
+        monkeypatch.setattr(mlr, "fetch_issue_comments", lambda repo, n: [])
+        monkeypatch.setattr(mlr, "verify_receipt", lambda p: True)
+
+        rc = main(
+            [
+                "--operator-minutes",
+                "25",
+                "--receipts-dir",
+                str(rdir),
+                "--json",
+            ]
+        )
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["merged_total"] == 2
+        assert out["merged_receipt_backed"] == 1
+        assert out["leverage_ratio"] == pytest.approx(1 / 25.0)
+        assert out["steering_integrity"] is None
+        assert out["operator_minutes"] == 25.0
+        assert "self-reported" in out["operator_minutes_source"]
+
+
+# ---------------------------------------------------------------------------
+# LEVERAGE.md managed-region rendering
+# ---------------------------------------------------------------------------
+
+
+def _lr_result(**overrides) -> dict:
+    base = {
+        "methodology_version": METHODOLOGY_VERSION,
+        "repo": "synaptent/aragora",
+        "window_days": 7,
+        "window_start": "2026-06-10T00:00:00Z",
+        "window_end": "2026-06-10T12:00:00Z",
+        "operator_minutes": 25.0,
+        "operator_minutes_source": "self-reported",
+        "operator_minutes_note": "baseline day estimate",
+        "merged_total": 9,
+        "merged_receipt_backed": 4,
+        "receipts_failed_verify": 0,
+        "receipt_refs_unresolved": 1,
+        "failed_verify_paths": [],
+        "leverage_ratio": 0.16,
+        "steering_integrity": None,
+        "si_components_pending": SI_COMPONENTS_PENDING,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestUpdateLeverageMd:
+    def test_creates_skeleton_with_all_sections(self, tmp_path: Path) -> None:
+        doc = tmp_path / "LEVERAGE.md"
+        update_leverage_md(doc, lr_block=render_lr_block(_lr_result()))
+        text = doc.read_text()
+        assert "<!-- leverage-managed:begin -->" in text
+        assert "<!-- leverage-managed:end -->" in text
+        assert "Last updated:" in text
+        assert "## Leverage Ratio" in text
+        assert "## Waste Ratio" in text
+        assert "## Blind-Period Log" in text
+        assert "## Caveats" in text
+        assert "self-reported" in text
+        assert "not yet instrumented" in text
+        # waste not yet measured -> placeholder
+        assert "not yet measured" in text
+
+    def test_manual_text_outside_region_preserved(self, tmp_path: Path) -> None:
+        doc = tmp_path / "LEVERAGE.md"
+        update_leverage_md(doc, lr_block=render_lr_block(_lr_result()))
+        manual = "- 2026-05-27 -> 2026-06-05: loop was blind (manual entry).\n"
+        doc.write_text(doc.read_text() + manual)
+        update_leverage_md(doc, lr_block=render_lr_block(_lr_result(merged_total=11)))
+        text = doc.read_text()
+        assert manual in text
+        assert "| Merged PRs in window (total) | 11 |" in text
+        assert text.count("<!-- leverage-managed:begin -->") == 1
+
+    def test_other_metric_block_preserved_on_partial_update(self, tmp_path: Path) -> None:
+        doc = tmp_path / "LEVERAGE.md"
+        update_leverage_md(doc, waste_block="WASTE-SENTINEL-CONTENT")
+        update_leverage_md(doc, lr_block="LR-SENTINEL-CONTENT")
+        text = doc.read_text()
+        assert "WASTE-SENTINEL-CONTENT" in text
+        assert "LR-SENTINEL-CONTENT" in text
+
+    def test_appends_managed_region_to_unmanaged_file(self, tmp_path: Path) -> None:
+        doc = tmp_path / "LEVERAGE.md"
+        doc.write_text("# Hand-written header\n\nkeep me\n")
+        update_leverage_md(doc, lr_block="LR-X")
+        text = doc.read_text()
+        assert text.startswith("# Hand-written header")
+        assert "keep me" in text
+        assert "LR-X" in text
+
+    def test_render_lr_block_si_row_is_null(self) -> None:
+        block = render_lr_block(_lr_result())
+        assert "null" in block
+        assert "crux_shown" in block
+        assert "0.16" in block
+
+
+class TestUpdateLeverageMdIdempotency:
+    def test_rerender_does_not_glue_following_text_to_end_marker(self, tmp_path: Path) -> None:
+        doc = tmp_path / "LEVERAGE.md"
+        update_leverage_md(doc, lr_block="LR-1")
+        update_leverage_md(doc, lr_block="LR-2")
+        update_leverage_md(doc, waste_block="W-1")
+        text = doc.read_text()
+        assert "<!-- leverage-managed:end -->\n" in text
+        assert "<!-- leverage-managed:end -->#" not in text
+        # blind-period heading still starts at a line boundary
+        assert "\n## Blind-Period Log" in text

--- a/tests/scripts/test_measure_work_loss.py
+++ b/tests/scripts/test_measure_work_loss.py
@@ -1,0 +1,361 @@
+"""Tests for scripts/measure_work_loss.py (steering program Phase 0.2, Pillar 7).
+
+All three inputs (outbox items, ls-remote output, PR list) are injected;
+no git / gh subprocess calls happen in these tests.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from scripts.measure_work_loss import (
+    UNIT_DEFINITIONS,
+    compute_work_loss,
+    load_outbox_items,
+    main,
+    parse_ls_remote,
+    render_waste_block,
+)
+
+NOW = datetime(2026, 6, 10, 12, 0, 0, tzinfo=timezone.utc)
+WINDOW_START = datetime(2026, 6, 3, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _pr(
+    number: int,
+    head_ref: str,
+    *,
+    state: str = "closed",
+    merged_at: str | None = None,
+    closed_at: str | None = None,
+) -> dict:
+    return {
+        "number": number,
+        "head_ref": head_ref,
+        "state": state,
+        "merged": merged_at is not None,
+        "merged_at": merged_at,
+        "closed_at": closed_at or merged_at,
+    }
+
+
+class TestParseLsRemote:
+    def test_parses_branch_names(self) -> None:
+        text = (
+            "abc123\trefs/heads/main\n"
+            "def456\trefs/heads/codex/fix-thing\n"
+            "0a0a0a\trefs/heads/elves/run-x\n"
+        )
+        assert parse_ls_remote(text) == {"main", "codex/fix-thing", "elves/run-x"}
+
+    def test_ignores_garbage_lines(self) -> None:
+        assert parse_ls_remote("\nnot-a-ref-line\n") == set()
+
+
+class TestComputeWorkLoss:
+    def test_categories_and_ratio(self) -> None:
+        outbox = [
+            # expired, branch pushed, never published -> expired_unpublished
+            {
+                "idempotency_key": "k1",
+                "branch": "codex/expired-pushed",
+                "expires_at": "2026-06-01T00:00:00Z",
+                "_source": "live",
+            },
+            # branch never pushed, not published -> lost_never_pushed
+            {
+                "idempotency_key": "k2",
+                "branch": "codex/never-pushed",
+                "expires_at": "2026-07-01T00:00:00Z",
+                "_source": "live",
+            },
+            # published via PR for its branch -> not lost
+            {
+                "idempotency_key": "k3",
+                "branch": "codex/published",
+                "expires_at": "2026-06-01T00:00:00Z",
+                "_source": "archive",
+            },
+        ]
+        remote_heads = {
+            "main",
+            "codex/expired-pushed",
+            "codex/published",
+            "codex/orphan-branch",  # pushed, never PR'd
+        }
+        prs = [
+            _pr(1, "codex/published", merged_at="2026-06-09T00:00:00Z"),
+            _pr(2, "codex/closed-unmerged", closed_at="2026-06-08T00:00:00Z"),
+            _pr(3, "feature/old-merge", merged_at="2026-01-01T00:00:00Z"),
+        ]
+        result = compute_work_loss(
+            outbox_items=outbox,
+            remote_heads=remote_heads,
+            prs=prs,
+            now=NOW,
+            window_start=WINDOW_START,
+        )
+        assert result["outbox_expired_unpublished"] == 1
+        assert result["outbox_lost_never_pushed"] == 1
+        # orphan-branch only; expired-pushed is claimed by the outbox category
+        assert result["branches_pushed_never_prd"] == 1
+        assert result["prs_closed_unmerged"] == 1
+        assert result["produced_units"] == 1  # only PR 1 merged inside window
+        assert result["lost_units"] == 4
+        assert result["waste_ratio"] == pytest.approx(4 / 1)
+        assert result["methodology_version"] == 1
+
+    def test_no_double_counting_expired_and_never_pushed(self) -> None:
+        outbox = [
+            {
+                "idempotency_key": "k1",
+                "branch": "codex/gone",
+                "expires_at": "2026-01-01T00:00:00Z",
+                "_source": "live",
+            }
+        ]
+        result = compute_work_loss(
+            outbox_items=outbox,
+            remote_heads={"main"},
+            prs=[],
+            now=NOW,
+            window_start=WINDOW_START,
+        )
+        # expired AND never pushed -> exactly one unit, in lost_never_pushed
+        assert result["outbox_lost_never_pushed"] == 1
+        assert result["outbox_expired_unpublished"] == 0
+        assert result["lost_units"] == 1
+
+    def test_branch_claimed_by_outbox_not_recounted_as_orphan(self) -> None:
+        outbox = [
+            {
+                "idempotency_key": "k1",
+                "branch": "codex/expired-pushed",
+                "expires_at": "2026-01-01T00:00:00Z",
+                "_source": "live",
+            }
+        ]
+        result = compute_work_loss(
+            outbox_items=outbox,
+            remote_heads={"main", "codex/expired-pushed"},
+            prs=[],
+            now=NOW,
+            window_start=WINDOW_START,
+        )
+        assert result["outbox_expired_unpublished"] == 1
+        assert result["branches_pushed_never_prd"] == 0
+        assert result["lost_units"] == 1
+
+    def test_explicit_publication_state_respected(self) -> None:
+        outbox = [
+            {
+                "idempotency_key": "k1",
+                "branch": "codex/x",
+                "expires_at": "2026-01-01T00:00:00Z",
+                "publication": {"state": "published"},
+                "_source": "archive",
+            },
+            {
+                "idempotency_key": "k2",
+                "branch": "codex/y",
+                "expires_at": "2026-01-01T00:00:00Z",
+                "requested_action": "mark_already_satisfied_or_close_stale_branch",
+                "_source": "archive",
+            },
+        ]
+        result = compute_work_loss(
+            outbox_items=outbox,
+            remote_heads={"main"},
+            prs=[],
+            now=NOW,
+            window_start=WINDOW_START,
+        )
+        assert result["lost_units"] == 0
+
+    def test_waste_ratio_denominator_floor(self) -> None:
+        result = compute_work_loss(
+            outbox_items=[],
+            remote_heads={"main", "codex/orphan"},
+            prs=[],
+            now=NOW,
+            window_start=WINDOW_START,
+        )
+        assert result["produced_units"] == 0
+        assert result["waste_ratio"] == pytest.approx(1 / 1)
+
+    def test_closed_unmerged_outside_window_excluded(self) -> None:
+        prs = [_pr(2, "codex/old-close", closed_at="2026-01-01T00:00:00Z")]
+        result = compute_work_loss(
+            outbox_items=[],
+            remote_heads={"main"},
+            prs=prs,
+            now=NOW,
+            window_start=WINDOW_START,
+        )
+        assert result["prs_closed_unmerged"] == 0
+
+    def test_unit_definitions_in_result(self) -> None:
+        result = compute_work_loss(
+            outbox_items=[],
+            remote_heads=set(),
+            prs=[],
+            now=NOW,
+            window_start=WINDOW_START,
+        )
+        assert result["unit_definitions"] == UNIT_DEFINITIONS
+        for key in (
+            "branches_pushed_never_prd",
+            "outbox_expired_unpublished",
+            "outbox_lost_never_pushed",
+            "prs_closed_unmerged",
+            "produced_units",
+            "lost_units",
+            "waste_ratio",
+        ):
+            assert key in UNIT_DEFINITIONS
+
+
+class TestLoadOutboxItems:
+    def test_loads_json_and_counts_unreadable(self, tmp_path: Path) -> None:
+        d = tmp_path / "outbox"
+        d.mkdir()
+        (d / "a.json").write_text(json.dumps({"branch": "codex/a"}))
+        (d / "broken.json").write_text("{not json")
+        items, unreadable = load_outbox_items([d])
+        assert len(items) == 1
+        assert items[0]["branch"] == "codex/a"
+        assert items[0]["_source"] == str(d)
+        assert unreadable == 1
+
+    def test_missing_dir_is_skipped(self, tmp_path: Path) -> None:
+        items, unreadable = load_outbox_items([tmp_path / "nope"])
+        assert items == []
+        assert unreadable == 0
+
+
+class TestMainJson:
+    def test_end_to_end_with_injected_files(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        outbox = tmp_path / "outbox"
+        outbox.mkdir()
+        (outbox / "i1.json").write_text(
+            json.dumps(
+                {
+                    "idempotency_key": "k1",
+                    "branch": "codex/never-pushed",
+                    "expires_at": "2026-07-01T00:00:00Z",
+                }
+            )
+        )
+        ls_remote = tmp_path / "heads.txt"
+        ls_remote.write_text("abc\trefs/heads/main\ndef\trefs/heads/codex/orphan\n")
+        prs_file = tmp_path / "prs.json"
+        prs_file.write_text(
+            json.dumps(
+                [
+                    _pr(1, "codex/merged", merged_at="2026-06-10T01:00:00Z"),
+                    _pr(2, "codex/dead", closed_at="2026-06-09T00:00:00Z"),
+                ]
+            )
+        )
+        rc = main(
+            [
+                "--outbox-dir",
+                str(outbox),
+                "--ls-remote-file",
+                str(ls_remote),
+                "--prs-file",
+                str(prs_file),
+                "--json",
+            ]
+        )
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["outbox_lost_never_pushed"] == 1
+        assert out["branches_pushed_never_prd"] == 1
+        assert out["prs_closed_unmerged"] == 1
+        assert out["produced_units"] == 1
+        assert out["lost_units"] == 3
+        assert out["waste_ratio"] == pytest.approx(3.0)
+        assert "unit_definitions" in out
+
+    def test_publish_updates_waste_block_only(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        from scripts.measure_leverage_ratio import update_leverage_md
+
+        doc = tmp_path / "LEVERAGE.md"
+        update_leverage_md(doc, lr_block="LR-SENTINEL")
+        outbox = tmp_path / "outbox"
+        outbox.mkdir()
+        ls_remote = tmp_path / "heads.txt"
+        ls_remote.write_text("abc\trefs/heads/main\n")
+        prs_file = tmp_path / "prs.json"
+        prs_file.write_text("[]")
+        rc = main(
+            [
+                "--outbox-dir",
+                str(outbox),
+                "--ls-remote-file",
+                str(ls_remote),
+                "--prs-file",
+                str(prs_file),
+                "--publish",
+                "--status-doc",
+                str(doc),
+            ]
+        )
+        assert rc == 0
+        text = doc.read_text()
+        assert "LR-SENTINEL" in text
+        assert "Waste ratio" in text
+
+
+class TestRenderWasteBlock:
+    def test_contains_counts_and_definitions(self) -> None:
+        result = compute_work_loss(
+            outbox_items=[],
+            remote_heads={"main", "codex/orphan"},
+            prs=[],
+            now=NOW,
+            window_start=WINDOW_START,
+        )
+        block = render_waste_block(result)
+        assert "Branches pushed, never PR'd" in block
+        assert "Waste ratio" in block
+        assert "lost_units / max(1, produced_units)" in block
+
+
+class TestMalformedItems:
+    def test_non_string_branch_and_key_do_not_crash(self) -> None:
+        outbox = [
+            {"branch": {"weird": "dict"}, "idempotency_key": ["also", "weird"]},
+            {"branch": 42, "expires_at": "2026-01-01T00:00:00Z"},
+            {"local_evidence": {"branch": {"nested": "dict"}}, "_file": "x.json"},
+        ]
+        result = compute_work_loss(
+            outbox_items=outbox,
+            remote_heads={"main"},
+            prs=[],
+            now=NOW,
+            window_start=WINDOW_START,
+        )
+        # Items without a usable string identity fall back to file name or are
+        # skipped; the computation must not crash and must not invent units.
+        assert isinstance(result["lost_units"], int)
+
+    def test_non_string_head_ref_ignored(self) -> None:
+        prs = [{"number": 1, "head_ref": {"odd": True}, "state": "closed", "merged": False}]
+        result = compute_work_loss(
+            outbox_items=[],
+            remote_heads={"main"},
+            prs=prs,
+            now=NOW,
+            window_start=WINDOW_START,
+        )
+        assert isinstance(result["lost_units"], int)


### PR DESCRIPTION
## Summary

Sprint 4 goal 2 (operator adoption decision: Plan v2 Phase 0 items into Sprint 4) — Steering Leverage Operating Plan v2, **Phase 0.2: leverage + waste instruments** (`docs/superpowers/plans/2026-06-10-steering-leverage-operating-plan-v2.md`, Pillar 7 + Phase 0; metric definitions in `docs/superpowers/plans/2026-06-10-steering-leverage-program.md`).

- **`scripts/measure_leverage_ratio.py`** — LR = verified merged outcomes / operator-minutes.
  - REFUSES to run without `--operator-minutes` (exit 2): the denominator is operator-estimated until attention capture exists and is never invented.
  - Verified outcome = PR merged in window whose body/comments reference a receipt path that exists locally AND passes `aragora receipt verify` (subprocess boundary, mockable).
  - `merged_total`, `merged_receipt_backed`, `receipts_failed_verify` counted separately — failures are never silent.
  - `steering_integrity` is honestly `null` with `si_components_pending = [crux_shown, within_attention_budget, not_reversed_on_audit]`; `methodology_version: 1`.
- **`scripts/measure_work_loss.py`** — waste accounting from three injectable inputs (outbox dirs live+archive, `git ls-remote --heads origin`, PR head-ref list). Computes `branches_pushed_never_prd`, `outbox_expired_unpublished`, `outbox_lost_never_pushed`, `prs_closed_unmerged`, `produced_units`; `waste_ratio = lost_units / max(1, produced_units)` with unit definitions printed in `--json` output and categories de-duplicated by unit key (no double counting).
- **`docs/status/LEVERAGE.md`** — rendered by `--publish` on either script (B0-truth publication style): marker-delimited managed region (LR table, waste table, honest caveats); manual blind-period log entries outside the region are never touched on re-render.

## First real publication (2026-06-10, window since 2026-06-10T00:00:00Z)

| Metric | Value |
| --- | --- |
| Merged PRs (total / receipt-backed verified) | 31 / 28 |
| Receipts failed verify | 0 |
| Operator minutes (self-reported) | 25 ("baseline day estimate ~25 min: approval messages + design-review read + queue replies") |
| **Leverage ratio** | **1.12** verified merged outcomes per operator-minute |
| Steering integrity | null (not yet instrumented) |
| Lost units (never-pushed 355 / expired 21 / orphan branches 238 / closed-unmerged 9) | 623 |
| Produced units (merged PRs in window) | 32 |
| **Waste ratio** | **19.47** |

Baseline reference from the 2026-06-10 outbox harvest (manual prototype of this instrument): 134 lost-never-pushed, 45 expired, 37 PRs recovered from 254 triaged items. The instrument scans a wider corpus (869 items across live + nested archive + archive dirs), hence the larger counts.

## Testing

- 38 unit tests in `tests/scripts/test_measure_leverage_ratio.py` + `tests/scripts/test_measure_work_loss.py` (TDD; all fetcher/subprocess boundaries injected; no network in tests).
- `ruff check` + `ruff format` clean; `mypy` clean on both scripts.
- One real run of each instrument published `docs/status/LEVERAGE.md` (committed per the #7557 generated-status-surface precedent).

Tier: 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
