### PR TITLE
fix(ops): fleet sentinel launchd installer renders PATH (gh_auth FileNotFoundError under launchd)

### DIFF
--- a/scripts/install_fleet_sentinel_launchd.sh
+++ b/scripts/install_fleet_sentinel_launchd.sh
@@ -17,6 +17,9 @@ INTERVAL="${INTERVAL:-600}"
 LABEL="com.aragora.fleet-sentinel"
 LOG_PATH="${REPO_ROOT}/.aragora/overnight/fleet-sentinel.log"
 PLIST_PATH="${HOME}/Library/LaunchAgents/${LABEL}.plist"
+# launchd agents get a minimal PATH without /opt/homebrew/bin; the sentinel's
+# gh_auth check needs `gh` on PATH or it reports status unknown (exit 2).
+SENTINEL_PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 
 render_plist() {
   cat <<EOF
@@ -34,6 +37,11 @@ render_plist() {
     </array>
     <key>WorkingDirectory</key>
     <string>${REPO_ROOT}</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>${SENTINEL_PATH}</string>
+    </dict>
     <key>StartInterval</key>
     <integer>${INTERVAL}</integer>
     <key>RunAtLoad</key>

--- a/tests/scripts/test_install_fleet_sentinel_launchd.py
+++ b/tests/scripts/test_install_fleet_sentinel_launchd.py
@@ -1,0 +1,44 @@
+"""The fleet sentinel launchd installer must render a usable PATH.
+
+Regression guard: launchd agents inherit a minimal PATH that lacks
+/opt/homebrew/bin, so the sentinel's gh_auth check died with
+FileNotFoundError('gh') -> status unknown -> exit 2. The rendered plist
+must carry an EnvironmentVariables dict whose PATH includes Homebrew and
+the standard system bins (mirrors scripts/install_boss_loop_launchd.sh,
+which exports PATH in its command string).
+"""
+
+from __future__ import annotations
+
+import plistlib
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALLER = REPO_ROOT / "scripts" / "install_fleet_sentinel_launchd.sh"
+
+EXPECTED_PATH = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+
+def _render_dry_run() -> bytes:
+    proc = subprocess.run(
+        ["/bin/bash", str(INSTALLER), "--dry-run"],
+        capture_output=True,
+        check=False,
+    )
+    assert proc.returncode == 0, f"--dry-run failed: {proc.stderr.decode()}"
+    return proc.stdout
+
+
+def test_dry_run_renders_environment_path() -> None:
+    data = plistlib.loads(_render_dry_run())
+    env = data.get("EnvironmentVariables")
+    assert env is not None, "plist is missing the EnvironmentVariables dict"
+    assert env.get("PATH") == EXPECTED_PATH
+
+
+def test_dry_run_plist_keeps_core_keys() -> None:
+    data = plistlib.loads(_render_dry_run())
+    assert data["Label"] == "com.aragora.fleet-sentinel"
+    assert data["ProgramArguments"][-1] == "--json"
+    assert data["RunAtLoad"] is True


### PR DESCRIPTION
## Problem

`scripts/install_fleet_sentinel_launchd.sh` (landed in #8147) renders a launchd plist whose environment lacks `/opt/homebrew/bin` on PATH. Under launchd the sentinel's `gh_auth` check fails with `FileNotFoundError('gh')` → signal status `unknown` → exit 2 every cycle.

The live plist at `~/Library/LaunchAgents/com.aragora.fleet-sentinel.plist` was hand-patched on 2026-06-10 (EnvironmentVariables.PATH added), but any reinstall via the script regresses the fix.

## Fix

- Render an `EnvironmentVariables` dict with `PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin` into the plist — mirrors `scripts/install_boss_loop_launchd.sh`, which exports the same PATH in its command string.
- New render test `tests/scripts/test_install_fleet_sentinel_launchd.py`: asserts `--dry-run` output parses as a plist, carries the expected PATH in `EnvironmentVariables`, and keeps core keys (Label, `--json` arg, RunAtLoad).

## Evidence

- TDD: test written first, failed RED on missing `EnvironmentVariables`, GREEN after fix.
- `pytest tests/scripts/test_install_fleet_sentinel_launchd.py tests/scripts/test_fleet_sentinel.py tests/scripts/test_launchd_installers.py` → 40 passed.
- `bash -n` clean; `--dry-run` output passes `plutil -lint`.

Tier 2 — two-family evidence + quorum settlement to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)