### PR TITLE
fix(ops): fleet sentinel publisher_status reads the live github-status cache

### DIFF
--- a/scripts/fleet_sentinel.py
+++ b/scripts/fleet_sentinel.py
@@ -324,7 +324,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--repo-root", default=str(repo_root))
     parser.add_argument(
         "--publisher-status",
-        default=str(repo_root / ".aragora" / "automation-publisher-status.json"),
+        # The publisher's launchd pass writes this cache every 5 minutes via
+        # cache_codex_automation_github_status.py; the former default
+        # (.aragora/automation-publisher-status.json) is a legacy path no
+        # current component writes, so the check fired forever once fixed.
+        default=str(repo_root / ".aragora" / "automation-github-status" / "latest.json"),
     )
     parser.add_argument("--publisher-max-age-hours", type=float, default=24.0)
     parser.add_argument(

--- a/tests/scripts/test_fleet_sentinel.py
+++ b/tests/scripts/test_fleet_sentinel.py
@@ -347,6 +347,19 @@ def _argv(paths: dict[str, Path], **overrides: Any) -> list[str]:
     return argv
 
 
+def test_default_publisher_status_is_live_github_status_cache() -> None:
+    """Regression: the default must be the file the publisher actually writes.
+
+    The original default (``.aragora/automation-publisher-status.json``) was a
+    legacy path no current component writes, so the check breached forever
+    against a healthy publisher.  ``run_codex_automation_publisher.sh`` writes
+    ``.aragora/automation-github-status/latest.json`` (same schema:
+    ``generated_at`` + ``github_health.auth_ok``) on every 5-minute pass.
+    """
+    default = sentinel.build_parser().get_default("publisher_status")
+    assert default.endswith("/.aragora/automation-github-status/latest.json")
+
+
 def test_main_all_ok_exits_zero_and_emits_contract(tmp_path: Path, capsys: Any) -> None:
     paths = _fixture_env(tmp_path)
     code = sentinel.main(_argv(paths))


### PR DESCRIPTION
## Problem

The fleet sentinel (#8147) fired `publisher_status` breaches on its first live runs — but the publisher is healthy. The check's default path, `.aragora/automation-publisher-status.json`, is a legacy path **no current component writes**. The only file there was the frozen 2026-05-18 incident snapshot (`auth_ok:false`), so the sentinel reported a three-week-dead publisher that has in fact been running and authenticated all along.

The live status report is `.aragora/automation-github-status/latest.json`, written every 5-minute pass by `run_codex_automation_publisher.sh` → `cache_codex_automation_github_status.py`, with the same schema the check consumes (`generated_at` + `github_health.auth_ok`). If the publisher daemon dies the cache goes stale → breach; if gh auth breaks, `auth_ok:false` → breach. Same dead-man's contract, real writer.

## Change

- `scripts/fleet_sentinel.py`: `--publisher-status` default → `.aragora/automation-github-status/latest.json`
- `tests/scripts/test_fleet_sentinel.py`: regression test pinning the default to the live cache path

## Verification

- `pytest tests/scripts/test_fleet_sentinel.py`: **37 passed**
- Patched sentinel against live state: `publisher_status` = `ok — fresh (0.1h) and auth_ok`, 0 breaches (was: breach, "publisher never reported")
- ruff check + format clean

Related: #8152 (sentinel gh_auth PATH fix under launchd) — independent, no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)