### PR TITLE
fix(ops): fleet sentinel — live status path, installer PATH, notify channel

### DIFF
--- a/scripts/fleet_sentinel.py
+++ b/scripts/fleet_sentinel.py
@@ -249,7 +249,15 @@ def breach_summary(checks: list[CheckResult]) -> str:
 def notify(notify_cmd: str, summary: str, *, runner: Callable[[list[str]], int]) -> None:
     tokens = shlex.split(notify_cmd)
     if any("{summary}" in t for t in tokens):
-        tokens = [t.replace("{summary}", summary) for t in tokens]
+        # A bare "{summary}" token becomes its own argv element — safe to pass
+        # the text through verbatim.  A placeholder embedded in a larger token
+        # lands inside another language's string literal (e.g. the installer's
+        # default AppleScript "display notification" command), so neutralize
+        # quote/backslash injection before substituting.
+        embedded_safe = summary.replace("\\", "/").replace('"', "'")
+        tokens = [
+            summary if t == "{summary}" else t.replace("{summary}", embedded_safe) for t in tokens
+        ]
     else:
         tokens.append(summary)
     try:
@@ -324,7 +332,12 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--repo-root", default=str(repo_root))
     parser.add_argument(
         "--publisher-status",
-        default=str(repo_root / ".aragora" / "automation-publisher-status.json"),
+        # Live writer path: scripts/cache_codex_automation_github_status.py
+        # refreshes this on every publisher pass.  The previous default,
+        # .aragora/automation-publisher-status.json, has been an orphan since
+        # its writer moved (~2026-05-24) — watching it would alarm forever on
+        # stale data or, worse, stay green on a frozen healthy snapshot.
+        default=str(repo_root / ".aragora" / "automation-github-status" / "latest.json"),
     )
     parser.add_argument("--publisher-max-age-hours", type=float, default=24.0)
     parser.add_argument(

--- a/scripts/install_fleet_sentinel_launchd.sh
+++ b/scripts/install_fleet_sentinel_launchd.sh
@@ -5,9 +5,20 @@
 # Runs scripts/fleet_sentinel.py from the repo root every 600 seconds,
 # logging to .aragora/overnight/fleet-sentinel.log.
 #
+# The render bakes a full PATH into EnvironmentVariables: launchd jobs get a
+# minimal environment, and on 2026-06-10 the live sentinel's gh_auth check
+# died with FileNotFoundError('gh') (exit 2, blind) because /opt/homebrew/bin
+# was not on PATH.  The live plist was hand-patched that day; reinstalls must
+# not regress it.
+#
+# A default macOS notification channel is wired through the sentinel's
+# --notify-cmd template ({summary} placeholder).  Override or disable it:
+#
 # Usage:
-#   ./scripts/install_fleet_sentinel_launchd.sh --dry-run    # print plist only
-#   ./scripts/install_fleet_sentinel_launchd.sh --install    # write + launchctl load
+#   ./scripts/install_fleet_sentinel_launchd.sh --dry-run                # print plist only
+#   ./scripts/install_fleet_sentinel_launchd.sh --install                # write + launchctl load
+#   ./scripts/install_fleet_sentinel_launchd.sh --dry-run --notify-cmd ''        # no notifications
+#   ./scripts/install_fleet_sentinel_launchd.sh --install --notify-cmd 'my-notifier {summary}'
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -17,8 +28,25 @@ INTERVAL="${INTERVAL:-600}"
 LABEL="com.aragora.fleet-sentinel"
 LOG_PATH="${REPO_ROOT}/.aragora/overnight/fleet-sentinel.log"
 PLIST_PATH="${HOME}/Library/LaunchAgents/${LABEL}.plist"
+LAUNCHD_PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+# Default notify channel: macOS notification via osascript.  Conforms to
+# fleet_sentinel.py's --notify-cmd contract: {summary} embedded in a larger
+# token is substituted (quote/backslash-sanitized) at breach time.
+DEFAULT_NOTIFY_CMD='osascript -e "display notification \"{summary}\" with title \"Aragora Fleet Sentinel\""'
+
+xml_escape() {
+  local s="$1"
+  s="${s//&/&amp;}"
+  s="${s//</&lt;}"
+  s="${s//>/&gt;}"
+  printf '%s' "$s"
+}
 
 render_plist() {
+  local notify_block=""
+  if [ -n "${NOTIFY_CMD}" ]; then
+    notify_block="$(printf '        <string>--notify-cmd</string>\n        <string>%s</string>' "$(xml_escape "${NOTIFY_CMD}")")"
+  fi
   cat <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -31,7 +59,13 @@ render_plist() {
         <string>${PYTHON_BIN}</string>
         <string>${REPO_ROOT}/scripts/fleet_sentinel.py</string>
         <string>--json</string>
+${notify_block}
     </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>${LAUNCHD_PATH}</string>
+    </dict>
     <key>WorkingDirectory</key>
     <string>${REPO_ROOT}</string>
     <key>StartInterval</key>
@@ -48,13 +82,32 @@ EOF
 }
 
 usage() {
-  echo "usage: $0 --dry-run | --install" >&2
+  echo "usage: $0 (--dry-run | --install) [--notify-cmd CMD]   (--notify-cmd '' disables notifications)" >&2
   exit 64
 }
 
-[ $# -eq 1 ] || usage
+MODE=""
+NOTIFY_CMD="${DEFAULT_NOTIFY_CMD}"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run|--install)
+      [ -z "${MODE}" ] || usage
+      MODE="$1"
+      ;;
+    --notify-cmd)
+      [ $# -ge 2 ] || usage
+      NOTIFY_CMD="$2"
+      shift
+      ;;
+    *)
+      usage
+      ;;
+  esac
+  shift
+done
+[ -n "${MODE}" ] || usage
 
-case "$1" in
+case "${MODE}" in
   --dry-run)
     render_plist
     ;;
@@ -66,8 +119,10 @@ case "$1" in
     launchctl load "${PLIST_PATH}"
     echo "installed ${LABEL} (every ${INTERVAL}s) -> ${PLIST_PATH}"
     echo "logs: ${LOG_PATH}"
-    ;;
-  *)
-    usage
+    if [ -n "${NOTIFY_CMD}" ]; then
+      echo "notify: ${NOTIFY_CMD}"
+    else
+      echo "notify: disabled"
+    fi
     ;;
 esac

--- a/tests/scripts/test_fleet_sentinel.py
+++ b/tests/scripts/test_fleet_sentinel.py
@@ -95,10 +95,19 @@ def test_publisher_status_corrupt_json_breaches(tmp_path: Path) -> None:
 def test_breach_replay_may18_publisher_incident(tmp_path: Path) -> None:
     """Acceptance: replaying the real May-18 publisher status raises the alarm.
 
-    Fixture replicates the structure of the live
-    ``.aragora/automation-publisher-status.json`` captured during the
+    Fixture replicates the status structure captured during the
     May-18 -> Jun-08 outage: ``auth_ok: false`` and ``generated_at``
     of 2026-05-18.  Even with a *fresh* file mtime the sentinel must breach.
+
+    Provenance: the original incident snapshot lived at the old
+    ``.aragora/automation-publisher-status.json`` path, whose writer moved
+    away around 2026-05-24 (the file became an orphan).  The check now
+    watches the live writer's path —
+    ``.aragora/automation-github-status/latest.json``, written by
+    ``scripts/cache_codex_automation_github_status.py`` on every publisher
+    pass — which carries the same ``generated_at`` +
+    ``github_health.auth_ok`` structure, so the breach semantics replayed
+    here are unchanged.
     """
     incident = {
         "generated_at": "2026-05-18T15:10:46.775938Z",
@@ -115,10 +124,25 @@ def test_breach_replay_may18_publisher_incident(tmp_path: Path) -> None:
         "github_queue": {"available": False, "reason": "connectivity_failed"},
         "github_repo": "synaptent/aragora",
     }
-    p = _touch(tmp_path / "automation-publisher-status.json", content=json.dumps(incident))
+    p = _touch(tmp_path / "latest.json", content=json.dumps(incident))
     result = sentinel.check_publisher_status(p, max_age_hours=24, now=NOW)
     assert result["status"] == "breach"
     assert "auth_ok" in result["detail"]
+
+
+def test_publisher_status_default_is_live_cache_path() -> None:
+    """The default must point at the live writer's file, not the orphan.
+
+    The publisher's status writer moved to
+    ``.aragora/automation-github-status/latest.json``
+    (scripts/cache_codex_automation_github_status.py) around 2026-05-24;
+    the old ``automation-publisher-status.json`` stopped being written.
+    A sentinel watching the orphan would breach forever on stale data —
+    or worse, report "ok" on a frozen healthy snapshot.
+    """
+    args = sentinel.build_parser().parse_args([])
+    default = Path(args.publisher_status)
+    assert default.parts[-3:] == (".aragora", "automation-github-status", "latest.json")
 
 
 # ---------------------------------------------------------------------------
@@ -438,30 +462,35 @@ def test_notify_cmd_not_invoked_when_all_ok(tmp_path: Path, capsys: Any) -> None
     assert not record.exists()
 
 
-# ---------------------------------------------------------------------------
-# install_fleet_sentinel_launchd.sh
-# ---------------------------------------------------------------------------
+def test_notify_bare_placeholder_token_passes_summary_raw() -> None:
+    """A standalone ``{summary}`` token is argv-level: pass the text through."""
+    captured: dict[str, list[str]] = {}
+
+    def runner(tokens: list[str]) -> int:
+        captured["tokens"] = tokens
+        return 0
+
+    sentinel.notify("notifier --msg {summary}", 'has "quotes" and \\slash', runner=runner)
+    assert captured["tokens"] == ["notifier", "--msg", 'has "quotes" and \\slash']
 
 
-def _installer_path() -> Path:
-    return Path(__file__).resolve().parents[2] / "scripts" / "install_fleet_sentinel_launchd.sh"
+def test_notify_embedded_placeholder_neutralizes_quote_injection() -> None:
+    """{summary} embedded inside a larger token (e.g. an AppleScript string
+    literal, as in the installer's default osascript notify command) must not
+    let quotes/backslashes in the summary escape the host string literal."""
+    captured: dict[str, list[str]] = {}
 
+    def runner(tokens: list[str]) -> int:
+        captured["tokens"] = tokens
+        return 0
 
-def test_installer_bash_syntax_clean() -> None:
-    proc = subprocess.run(["bash", "-n", str(_installer_path())], capture_output=True, text=True)
-    assert proc.returncode == 0, proc.stderr
-
-
-def test_installer_dry_run_renders_plist() -> None:
-    proc = subprocess.run(
-        ["bash", str(_installer_path()), "--dry-run"],
-        capture_output=True,
-        text=True,
-        cwd=str(Path(__file__).resolve().parents[2]),
-    )
-    assert proc.returncode == 0, proc.stderr
-    out = proc.stdout
-    assert "com.aragora.fleet-sentinel" in out
-    assert "<integer>600</integer>" in out
-    assert "fleet_sentinel.py" in out
-    assert ".aragora/overnight/fleet-sentinel.log" in out
+    cmd = 'osascript -e "display notification \\"{summary}\\" with title \\"Aragora Fleet Sentinel\\""'
+    sentinel.notify(cmd, 'detail "x" \\ end', runner=runner)
+    tokens = captured["tokens"]
+    assert tokens[0] == "osascript"
+    script = tokens[2]
+    # The two delimiting quotes around the summary plus the two around the
+    # title are the ONLY double quotes left — none smuggled in via summary.
+    assert script.count('"') == 4
+    assert "\\" not in script
+    assert "detail 'x' / end" in script

--- a/tests/scripts/test_install_fleet_sentinel_launchd.py
+++ b/tests/scripts/test_install_fleet_sentinel_launchd.py
@@ -1,0 +1,133 @@
+"""Tests for ``scripts/install_fleet_sentinel_launchd.sh``.
+
+Plan v2 Phase 0.1 (Pillar 6) follow-up. The installer renders the launchd
+unit for the fleet sentinel; everything here is exercised via ``--dry-run``
+so no live LaunchAgents state is touched.
+
+Live incidents this file guards against regressing:
+
+* 2026-06-10: under launchd's minimal default environment the sentinel's
+  ``gh_auth`` check raised ``FileNotFoundError('gh')`` -> exit 2, because
+  the rendered plist carried no PATH.  The live plist was hand-patched the
+  same day; a reinstall from this script must not regress that patch, so
+  the render now bakes ``EnvironmentVariables.PATH`` in.
+* Breaches were silent: the unit had no notification channel.  The render
+  now wires a default macOS ``osascript`` notification through the
+  sentinel's ``--notify-cmd`` ``{summary}`` template (disable with
+  ``--notify-cmd ''``).
+"""
+
+from __future__ import annotations
+
+import plistlib
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+EXPECTED_PATH = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+
+def _installer_path() -> Path:
+    return REPO_ROOT / "scripts" / "install_fleet_sentinel_launchd.sh"
+
+
+def _dry_run(*extra_args: str) -> str:
+    proc = subprocess.run(
+        ["bash", str(_installer_path()), "--dry-run", *extra_args],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+    )
+    assert proc.returncode == 0, proc.stderr
+    return proc.stdout
+
+
+def test_installer_bash_syntax_clean() -> None:
+    proc = subprocess.run(["bash", "-n", str(_installer_path())], capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr
+
+
+def test_installer_dry_run_renders_plist() -> None:
+    out = _dry_run()
+    assert "com.aragora.fleet-sentinel" in out
+    assert "<integer>600</integer>" in out
+    assert "fleet_sentinel.py" in out
+    assert ".aragora/overnight/fleet-sentinel.log" in out
+
+
+def test_installer_dry_run_output_is_parseable_plist() -> None:
+    payload = plistlib.loads(_dry_run().encode())
+    assert payload["Label"] == "com.aragora.fleet-sentinel"
+    assert payload["StartInterval"] == 600
+
+
+def test_installer_renders_path_environment_variable() -> None:
+    """Regression guard for the 2026-06-10 launchd FileNotFoundError('gh').
+
+    launchd jobs get a minimal PATH; without homebrew dirs the gh_auth
+    check goes blind (exit 2).  The render must bake the full PATH in.
+    """
+    payload = plistlib.loads(_dry_run().encode())
+    assert payload["EnvironmentVariables"]["PATH"] == EXPECTED_PATH
+    # And the raw output carries it too (cheap grep for humans/CI logs).
+    assert EXPECTED_PATH in _dry_run()
+
+
+def test_installer_default_notify_cmd_wired() -> None:
+    """Default render wires the macOS notification channel via osascript."""
+    payload = plistlib.loads(_dry_run().encode())
+    args = payload["ProgramArguments"]
+    assert "--notify-cmd" in args
+    notify_cmd = args[args.index("--notify-cmd") + 1]
+    assert notify_cmd.startswith("osascript -e ")
+    # Conforms to fleet_sentinel.py's template contract: {summary} placeholder
+    # embedded in the AppleScript string literal.
+    assert '\\"{summary}\\"' in notify_cmd
+    assert "Aragora Fleet Sentinel" in notify_cmd
+
+
+def test_installer_notify_cmd_empty_disables_channel() -> None:
+    out = _dry_run("--notify-cmd", "")
+    assert "--notify-cmd" not in out
+    assert "osascript" not in out
+    payload = plistlib.loads(out.encode())
+    assert "--notify-cmd" not in payload["ProgramArguments"]
+
+
+def test_installer_notify_cmd_custom_override() -> None:
+    out = _dry_run("--notify-cmd", "my-notifier --msg {summary}")
+    payload = plistlib.loads(out.encode())
+    args = payload["ProgramArguments"]
+    assert args[args.index("--notify-cmd") + 1] == "my-notifier --msg {summary}"
+    assert "osascript" not in out
+
+
+def test_installer_notify_cmd_xml_escaped() -> None:
+    """Custom notify commands with XML-significant chars must not corrupt
+    the plist render."""
+    out = _dry_run("--notify-cmd", "notifier --and=a&b --lt=<x> {summary}")
+    payload = plistlib.loads(out.encode())
+    args = payload["ProgramArguments"]
+    assert args[args.index("--notify-cmd") + 1] == "notifier --and=a&b --lt=<x> {summary}"
+
+
+def test_installer_rejects_unknown_args() -> None:
+    proc = subprocess.run(
+        ["bash", str(_installer_path()), "--bogus"],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+    )
+    assert proc.returncode == 64
+    assert "usage" in proc.stderr
+
+
+def test_installer_requires_a_mode() -> None:
+    proc = subprocess.run(
+        ["bash", str(_installer_path()), "--notify-cmd", "x"],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+    )
+    assert proc.returncode == 64


### PR DESCRIPTION
Three bounded follow-up fixes to the fleet sentinel landed in #8147 (plan v2 phase 0.1, run-20260610 sprint 4 goal 1).

## 1. Live publisher status path
The `publisher_status` check's default, `.aragora/automation-publisher-status.json`, is an **orphan** — its writer moved ~2026-05-24. The live file is `.aragora/automation-github-status/latest.json`, refreshed by `scripts/cache_codex_automation_github_status.py` on every publisher pass with the identical `generated_at` + `github_health.auth_ok` structure. A sentinel watching the orphan alarms forever on stale data (exactly what the first production run showed: it breached on the frozen May-18 file) — or worse, stays green on a frozen healthy snapshot. Parsing is unchanged, so the May-18 breach-replay acceptance test passes against the same fixture structure; its docstring now documents the path provenance, and a new test pins the default to the live writer's path.

## 2. Installer renders PATH (live incident 2026-06-10)
Under launchd's minimal environment the live sentinel's `gh_auth` check raised `FileNotFoundError('gh')` → exit 2 (blind), because `/opt/homebrew/bin` was not on PATH. The live plist was hand-patched the same day, but a reinstall from `scripts/install_fleet_sentinel_launchd.sh` would have regressed the patch. The render now bakes `EnvironmentVariables.PATH = /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin` into the plist; a render test asserts it in `--dry-run` output and via `plistlib` parse.

## 3. Default notification channel
Breaches were silent unless an operator passed `--notify-cmd` by hand. The installer now wires a default macOS channel: `--notify-cmd 'osascript -e "display notification \"{summary}\" with title \"Aragora Fleet Sentinel\""'`, conforming to `fleet_sentinel.py`'s `{summary}` template contract. `--notify-cmd ''` disables it; any custom command overrides it (XML-escaped into the plist). Hardening: `notify()` now sanitizes quotes/backslashes when `{summary}` is embedded inside a larger token, so breach text cannot escape the AppleScript string literal; a bare `{summary}` argv token still passes the summary through verbatim (covered by tests both ways).

## Validation
- `tests/scripts/test_fleet_sentinel.py` (37) + new `tests/scripts/test_install_fleet_sentinel_launchd.py` (10): **47 passed**
- `bash -n` clean on the installer (shellcheck unavailable on this host)
- Live run with the new default path (`--no-ledger`, no notify): **all 7 checks ok** — `publisher_status: fresh (0.0h) and auth_ok`, `outbox_depth: 9 item(s) queued` (post terminal-archive sweep), exit 0
- After merge the live daemon reinstall is left to the coordinator (per lane instructions).

Tier: 2
Part of run-20260610 sprint 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
