### PR TITLE
fix(benchmarks): reject malformed dogfood timeout payloads

### DIFF
--- a/scripts/dogfood_score.py
+++ b/scripts/dogfood_score.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
@@ -27,6 +28,10 @@ STANDARD_SECTIONS = [
     "Rollback Plan",
     "Gate Criteria",
 ]
+
+
+class DogfoodScoreInputError(RuntimeError):
+    """Raised when score input artifacts cannot be trusted."""
 
 
 @dataclass
@@ -52,25 +57,34 @@ def _read_text(path: Path) -> str:
     return path.read_text(encoding="utf-8") if path.exists() else ""
 
 
+def _parse_timeout_payload(raw: str, *, source: str) -> dict[str, Any] | None:
+    raw = raw.strip()
+    if not raw:
+        return None
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise DogfoodScoreInputError(f"invalid timeout JSON in {source}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise DogfoodScoreInputError(f"timeout JSON in {source} must be an object")
+    return payload
+
+
 def _load_timeout_payload(report_path: Path | None, stdout_text: str) -> dict[str, Any] | None:
     if report_path and report_path.exists():
-        raw = _read_text(report_path).strip()
-        if raw:
-            try:
-                return json.loads(raw)
-            except json.JSONDecodeError:
-                pass
+        payload = _parse_timeout_payload(_read_text(report_path), source=str(report_path))
+        if payload is not None:
+            return payload
 
     for line in stdout_text.splitlines():
         if not line.startswith(TIMEOUT_PREFIX):
             continue
-        raw = line[len(TIMEOUT_PREFIX) :].strip()
-        if not raw:
-            continue
-        try:
-            return json.loads(raw)
-        except json.JSONDecodeError:
-            continue
+        payload = _parse_timeout_payload(
+            line[len(TIMEOUT_PREFIX) :],
+            source=f"{TIMEOUT_PREFIX} line",
+        )
+        if payload is not None:
+            return payload
     return None
 
 
@@ -283,26 +297,31 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     repo_root = Path(args.repo_root).expanduser().resolve()
 
-    baseline = _score_run(
-        name="baseline",
-        stdout_path=Path(args.baseline_stdout).expanduser(),
-        timeout_report_path=(
-            Path(args.baseline_timeout_report).expanduser()
-            if args.baseline_timeout_report
-            else None
-        ),
-        repo_root=repo_root,
-    )
-    enhanced = _score_run(
-        name="enhanced",
-        stdout_path=Path(args.enhanced_stdout).expanduser(),
-        timeout_report_path=(
-            Path(args.enhanced_timeout_report).expanduser()
-            if args.enhanced_timeout_report
-            else None
-        ),
-        repo_root=repo_root,
-    )
+    try:
+        baseline = _score_run(
+            name="baseline",
+            stdout_path=Path(args.baseline_stdout).expanduser(),
+            timeout_report_path=(
+                Path(args.baseline_timeout_report).expanduser()
+                if args.baseline_timeout_report
+                else None
+            ),
+            repo_root=repo_root,
+        )
+        enhanced = _score_run(
+            name="enhanced",
+            stdout_path=Path(args.enhanced_stdout).expanduser(),
+            timeout_report_path=(
+                Path(args.enhanced_timeout_report).expanduser()
+                if args.enhanced_timeout_report
+                else None
+            ),
+            repo_root=repo_root,
+        )
+    except DogfoodScoreInputError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
     summary = _build_summary(baseline, enhanced)
 
     payload = {

--- a/tests/scripts/test_dogfood_score.py
+++ b/tests/scripts/test_dogfood_score.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import pytest
+
+from scripts import dogfood_score
+
+
+def test_load_timeout_payload_reads_valid_report_file(tmp_path) -> None:
+    report = tmp_path / "timeout.json"
+    report.write_text(
+        '{"status": "timeout", "timeout_seconds": 30, "elapsed_seconds": 30.1}',
+        encoding="utf-8",
+    )
+
+    payload = dogfood_score._load_timeout_payload(report, "")
+
+    assert payload == {
+        "status": "timeout",
+        "timeout_seconds": 30,
+        "elapsed_seconds": 30.1,
+    }
+
+
+def test_load_timeout_payload_rejects_malformed_report_file(tmp_path) -> None:
+    report = tmp_path / "timeout.json"
+    report.write_text('{"status": ', encoding="utf-8")
+
+    with pytest.raises(dogfood_score.DogfoodScoreInputError, match="invalid timeout JSON"):
+        dogfood_score._load_timeout_payload(report, "")
+
+
+def test_load_timeout_payload_rejects_non_object_report_file(tmp_path) -> None:
+    report = tmp_path / "timeout.json"
+    report.write_text('["timeout"]', encoding="utf-8")
+
+    with pytest.raises(dogfood_score.DogfoodScoreInputError, match="must be an object"):
+        dogfood_score._load_timeout_payload(report, "")
+
+
+def test_load_timeout_payload_rejects_malformed_stdout_sentinel() -> None:
+    stdout = "setup\nARAGORA_TIMEOUT_JSON={bad\n"
+
+    with pytest.raises(
+        dogfood_score.DogfoodScoreInputError,
+        match="invalid timeout JSON in ARAGORA_TIMEOUT_JSON= line",
+    ):
+        dogfood_score._load_timeout_payload(None, stdout)
+
+
+def test_main_rejects_malformed_timeout_report_before_writing_outputs(tmp_path, capsys) -> None:
+    baseline_stdout = tmp_path / "baseline.out"
+    enhanced_stdout = tmp_path / "enhanced.out"
+    timeout_report = tmp_path / "baseline-timeout.json"
+    output_json = tmp_path / "score.json"
+
+    baseline_stdout.write_text("FINAL ANSWER:\n", encoding="utf-8")
+    enhanced_stdout.write_text("FINAL ANSWER:\n", encoding="utf-8")
+    timeout_report.write_text("{bad", encoding="utf-8")
+
+    rc = dogfood_score.main(
+        [
+            "--baseline-stdout",
+            str(baseline_stdout),
+            "--enhanced-stdout",
+            str(enhanced_stdout),
+            "--baseline-timeout-report",
+            str(timeout_report),
+            "--repo-root",
+            str(tmp_path),
+            "--output-json",
+            str(output_json),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "invalid timeout JSON" in captured.err
+    assert not output_json.exists()


### PR DESCRIPTION
## Summary

- fail closed when dogfood timeout reports or `ARAGORA_TIMEOUT_JSON=` sentinels contain malformed JSON
- reject non-object timeout payloads instead of silently scoring as if timeout evidence were absent
- return exit code 2 before score artifacts are written when timeout inputs are untrusted

## Validation

- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_dogfood_score.py -q`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/dogfood_score.py tests/scripts/test_dogfood_score.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
