### PR TITLE
fix(reports): validate rescue status issue numbers

### DIFF
--- a/scripts/render_rescue_productization_status.py
+++ b/scripts/render_rescue_productization_status.py
@@ -34,10 +34,20 @@ def _format_value(value: Any) -> str:
     return str(value)
 
 
-def _issue_numbers_cell(value: Any) -> str:
-    if not isinstance(value, list) or not value:
+def _issue_numbers_cell(value: Any, *, field_name: str = "issue_numbers") -> str:
+    if value is None:
         return "-"
-    return ", ".join(f"#{int(item)}" for item in value if isinstance(item, int))
+    if not isinstance(value, list):
+        raise ValueError(f"{field_name} must be a list of positive integer issue numbers")
+    if not value:
+        return "-"
+
+    issue_numbers: list[int] = []
+    for index, item in enumerate(value):
+        if isinstance(item, bool) or not isinstance(item, int) or item <= 0:
+            raise ValueError(f"{field_name}[{index}] must be a positive integer issue number")
+        issue_numbers.append(item)
+    return ", ".join(f"#{item}" for item in issue_numbers)
 
 
 def _render_repeated_classes(rows: list[dict[str, Any]]) -> list[str]:
@@ -48,14 +58,14 @@ def _render_repeated_classes(rows: list[dict[str, Any]]) -> list[str]:
         "| Rescue class | Count | Productization | Target | Example issues |",
         "| --- | --- | --- | --- | --- |",
     ]
-    for row in rows:
+    for index, row in enumerate(rows):
         lines.append(
             "| "
             f"`{str(row.get('class') or '').strip()}` | "
             f"{int(row.get('count', 0) or 0)} | "
             f"`{str(row.get('productization_status') or 'unlinked').strip() or 'unlinked'}` | "
             f"`{str(row.get('productization_target') or '-').strip() or '-'}` | "
-            f"{_issue_numbers_cell(row.get('issue_numbers'))} |"
+            f"{_issue_numbers_cell(row.get('issue_numbers'), field_name=f'repeated_classes[{index}].issue_numbers')} |"
         )
     return lines
 

--- a/tests/scripts/test_render_rescue_productization_status.py
+++ b/tests/scripts/test_render_rescue_productization_status.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 _scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
 if _scripts_dir not in sys.path:
     sys.path.insert(0, _scripts_dir)
@@ -131,3 +133,39 @@ def test_main_writes_output_from_latest_report(tmp_path: Path) -> None:
     rendered = output_path.read_text(encoding="utf-8")
     assert "No repeated rescue classes found in the current ledger window." in rendered
     assert "Last updated: 2026-04-14T18:42:00Z" in rendered
+
+
+@pytest.mark.parametrize(
+    "issue_numbers",
+    [
+        "5512",
+        ["5512"],
+        [0],
+        [-1],
+        [True],
+    ],
+)
+def test_render_status_markdown_rejects_malformed_repeated_issue_numbers(
+    tmp_path: Path, issue_numbers: object
+) -> None:
+    report_path = tmp_path / "latest.json"
+    payload = {
+        "generated_at": "2026-04-14T18:40:00Z",
+        "summary": {},
+        "repeated_classes": [
+            {
+                "class": "manual_merge:required review gate",
+                "count": 2,
+                "productization_status": "unlinked",
+                "productization_target": "",
+                "issue_numbers": issue_numbers,
+            }
+        ],
+        "issue_linkage_results": [],
+        "issue_drafts": [],
+        "one_off_classes": [],
+        "below_threshold_classes": [],
+    }
+
+    with pytest.raises(ValueError, match=r"repeated_classes\[0\]\.issue_numbers"):
+        mod.render_status_markdown(report_path=report_path, payload=payload)


### PR DESCRIPTION
## Summary

- fail closed when repeated rescue-class `issue_numbers` are malformed in the TW-03 status renderer
- preserve empty/missing example lists as `-`, but reject non-list, non-integer, boolean, zero, and negative issue numbers
- add focused regression coverage so malformed rescue report provenance cannot disappear from the rendered proof surface

## Validation

- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_render_rescue_productization_status.py -q`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/render_rescue_productization_status.py tests/scripts/test_render_rescue_productization_status.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
