### PR TITLE
fix(reports): reject malformed rev4 readiness metrics

### DIFF
--- a/scripts/render_rev4_promotion_readiness.py
+++ b/scripts/render_rev4_promotion_readiness.py
@@ -65,15 +65,20 @@ def load_metrics(path: Path) -> list[dict[str, Any]]:
     if not path.exists():
         return []
     rows: list[dict[str, Any]] = []
-    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
-        if not line.strip():
+    for line_number, line in enumerate(
+        path.read_text(encoding="utf-8", errors="replace").splitlines(),
+        start=1,
+    ):
+        stripped = line.strip()
+        if not stripped:
             continue
         try:
-            payload = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        if isinstance(payload, dict):
-            rows.append(payload)
+            payload = json.loads(stripped)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Metrics JSONL at {path}:{line_number} is invalid JSON") from exc
+        if not isinstance(payload, dict):
+            raise ValueError(f"Metrics JSONL at {path}:{line_number} must be a JSON object")
+        rows.append(payload)
     return rows
 
 

--- a/tests/scripts/test_render_rev4_promotion_readiness.py
+++ b/tests/scripts/test_render_rev4_promotion_readiness.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 _scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
 if _scripts_dir not in sys.path:
     sys.path.insert(0, _scripts_dir)
@@ -45,6 +47,29 @@ def _write_metrics(path: Path, rows: list[dict[str, object]]) -> Path:
         encoding="utf-8",
     )
     return path
+
+
+def test_load_metrics_returns_empty_for_missing_file(tmp_path: Path) -> None:
+    assert mod.load_metrics(tmp_path / "missing.jsonl") == []
+
+
+def test_load_metrics_rejects_malformed_jsonl_line(tmp_path: Path) -> None:
+    metrics_path = tmp_path / "boss_metrics.jsonl"
+    metrics_path.write_text(
+        json.dumps({"issue_number": 1001}) + "\n{bad\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=r"boss_metrics\.jsonl:2.*invalid JSON"):
+        mod.load_metrics(metrics_path)
+
+
+def test_load_metrics_rejects_non_object_jsonl_line(tmp_path: Path) -> None:
+    metrics_path = tmp_path / "boss_metrics.jsonl"
+    metrics_path.write_text('{"issue_number": 1001}\n["not", "a", "row"]\n', encoding="utf-8")
+
+    with pytest.raises(ValueError, match=r"boss_metrics\.jsonl:2.*must be a JSON object"):
+        mod.load_metrics(metrics_path)
 
 
 def test_build_readiness_reports_gap_to_promotion_floor() -> None:


### PR DESCRIPTION
## Summary

- fail closed when H1-01 rev-4 promotion readiness metrics JSONL contains malformed rows
- reject non-object JSONL rows instead of silently dropping evidence from the promotion-readiness surface
- keep missing metrics files as "no evidence yet" while adding line-numbered errors for invalid files

## Validation

- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_render_rev4_promotion_readiness.py -q`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/render_rev4_promotion_readiness.py tests/scripts/test_render_rev4_promotion_readiness.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
