### PR TITLE
test(e2e): expect quickstart provider fallback wording

### DIFF
--- a/tests/e2e/test_truthful_default_loop.py
+++ b/tests/e2e/test_truthful_default_loop.py
@@ -97,7 +97,8 @@ def test_truthful_default_loop_provider_block_and_receipt_surface(
     assert saved["artifact_hash"] == saved["receipt"]["artifact_hash"]
 
     output = capsys.readouterr().out
-    assert "Live provider path is blocked" in output
+    assert "Live provider preflight could not verify reachability." in output
+    assert "No live providers available. Falling back to demo mode." in output
     assert "Simulation: mock/simulated" in output
     assert "Next:" in output
     assert f"Receipt:    {saved['receipt_id']}" in output


### PR DESCRIPTION
## Summary
- Update the truthful default loop E2E assertion to match current quickstart provider preflight/fallback wording.
- Keeps the receipt/provider-path assertions intact while fixing one main Python E2E failure from run 27321414902 job 80713146918.

## Validation
- PATH=/Users/armand/.pyenv/versions/3.11.11/bin:$PATH PYTHONPATH=. python3 -m pytest -q tests/e2e/test_truthful_default_loop.py
- git diff --check origin/main HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD

## Boundaries
- Test-only repair.
- No workflow, deploy, auth, RBAC, public API, outbox, labels, branch protection, or unrelated PR changes.