### PR TITLE
fix(reports): validate worktree unblock sizes

### DIFF
--- a/scripts/render_worktree_harvest_unblock_map.py
+++ b/scripts/render_worktree_harvest_unblock_map.py
@@ -19,11 +19,18 @@ def _utc_now() -> str:
     return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
-def _size_bytes(candidate: dict[str, Any]) -> int:
-    try:
-        return int(candidate.get("size_bytes") or 0)
-    except (TypeError, ValueError):
+def _coerce_size_bytes(value: Any, *, field_name: str) -> int:
+    if value is None:
         return 0
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{field_name} must be a non-negative integer byte count")
+    if value < 0:
+        raise ValueError(f"{field_name} must be a non-negative integer byte count")
+    return value
+
+
+def _size_bytes(candidate: dict[str, Any]) -> int:
+    return _coerce_size_bytes(candidate.get("size_bytes"), field_name="candidate.size_bytes")
 
 
 def _size_gib(size_bytes: int) -> float:
@@ -115,8 +122,17 @@ def render_unblock_map(inventory: dict[str, Any], *, limit: int = DEFAULT_LIMIT)
     candidates = [
         candidate for candidate in inventory.get("candidates", []) if isinstance(candidate, dict)
     ]
+    for index, candidate in enumerate(candidates):
+        _coerce_size_bytes(
+            candidate.get("size_bytes"),
+            field_name=f"candidates[{index}].size_bytes",
+        )
     raw_summary = inventory.get("summary")
     summary: dict[str, Any] = raw_summary if isinstance(raw_summary, dict) else {}
+    known_size_bytes = _coerce_size_bytes(
+        summary.get("known_size_bytes"),
+        field_name="summary.known_size_bytes",
+    )
     family_counts: Counter[str] = Counter()
     family_bytes: defaultdict[str, int] = defaultdict(int)
     for candidate in candidates:
@@ -158,7 +174,7 @@ def render_unblock_map(inventory: dict[str, Any], *, limit: int = DEFAULT_LIMIT)
             ),
             "harvest_candidate_count": summary.get("harvest_candidate_count"),
             "known_size_bytes": summary.get("known_size_bytes"),
-            "known_size_gib": _size_gib(int(summary.get("known_size_bytes") or 0)),
+            "known_size_gib": _size_gib(known_size_bytes),
         },
         "blocker_families": blocker_families,
         "top_cleanup_candidates": _top(cleanup_candidates, limit=limit),

--- a/tests/scripts/test_render_worktree_harvest_unblock_map.py
+++ b/tests/scripts/test_render_worktree_harvest_unblock_map.py
@@ -4,6 +4,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 _scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
 if _scripts_dir not in sys.path:
     sys.path.insert(0, _scripts_dir)
@@ -134,6 +136,44 @@ def test_rendered_next_commands_are_read_only_guidance() -> None:
         assert " rm " not in f" {command} "
         assert "git branch -D" not in command
         assert "git push --force" not in command
+
+
+@pytest.mark.parametrize("bad_size", [-1, "1024", 1.5, True])
+def test_render_unblock_map_rejects_malformed_candidate_size_bytes(bad_size: object) -> None:
+    inventory = _inventory()
+    candidates = inventory["candidates"]
+    assert isinstance(candidates, list)
+    candidates[0]["size_bytes"] = bad_size
+
+    with pytest.raises(ValueError, match=r"candidates\[0\]\.size_bytes"):
+        unblock_map.render_unblock_map(inventory)
+
+
+@pytest.mark.parametrize("bad_size", [-1, "1024", 1.5, False])
+def test_render_unblock_map_rejects_malformed_summary_known_size_bytes(
+    bad_size: object,
+) -> None:
+    inventory = _inventory()
+    summary = inventory["summary"]
+    assert isinstance(summary, dict)
+    summary["known_size_bytes"] = bad_size
+
+    with pytest.raises(ValueError, match=r"summary\.known_size_bytes"):
+        unblock_map.render_unblock_map(inventory)
+
+
+def test_render_unblock_map_allows_unknown_candidate_size_bytes() -> None:
+    inventory = _inventory()
+    candidates = inventory["candidates"]
+    assert isinstance(candidates, list)
+    candidates[0]["size_bytes"] = None
+
+    result = unblock_map.render_unblock_map(inventory, limit=10)
+
+    rows = result["top_human_review_candidates"]
+    dirty_row = next(row for row in rows if row["path"] == "/Users/armand/.codex/worktrees/dirty")
+    assert dirty_row["size_bytes"] == 0
+    assert dirty_row["size_gib"] == 0.0
 
 
 def test_main_writes_json_output(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- fail closed when worktree-harvest unblock-map inputs contain malformed or negative byte counts
- keep legacy unknown candidate sizes renderable as zero-sized unknowns
- add focused regression coverage for candidate `size_bytes`, summary `known_size_bytes`, and nullable candidate sizes

## Validation

- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_render_worktree_harvest_unblock_map.py -q`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/render_worktree_harvest_unblock_map.py tests/scripts/test_render_worktree_harvest_unblock_map.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
