### PR TITLE
fix(metrics): validate work-loss PR snapshots

### DIFF
--- a/scripts/measure_work_loss.py
+++ b/scripts/measure_work_loss.py
@@ -29,7 +29,7 @@ import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Sequence
+from typing import Any, Sequence
 
 if __package__ in (None, ""):
     sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -112,7 +112,8 @@ def fetch_all_prs(repo: str) -> list[dict]:
         check=True,
         timeout=1800,
     )
-    return [json.loads(line) for line in proc.stdout.splitlines() if line.strip()]
+    records = [json.loads(line) for line in proc.stdout.splitlines() if line.strip()]
+    return _validate_pr_records(records, source=f"GitHub PR API for {repo}")
 
 
 def parse_ls_remote(text: str) -> set[str]:
@@ -145,6 +146,49 @@ def load_outbox_items(dirs: Sequence[Path]) -> tuple[list[dict], int]:
             else:
                 unreadable += 1
     return items, unreadable
+
+
+def _validate_pr_records(payload: Any, *, source: str) -> list[dict]:
+    """Validate PR snapshot records before they can drive waste accounting."""
+    if not isinstance(payload, list):
+        raise ValueError(f"{source} must be a JSON list of PR records")
+
+    records: list[dict] = []
+    for index, item in enumerate(payload, start=1):
+        prefix = f"{source} PR record {index}"
+        if not isinstance(item, dict):
+            raise ValueError(f"{prefix} must be a JSON object")
+
+        number = item.get("number")
+        if isinstance(number, bool) or not isinstance(number, int) or number <= 0:
+            raise ValueError(f"{prefix} must include a positive integer number")
+
+        head_ref = item.get("head_ref")
+        if head_ref is not None and not isinstance(head_ref, str):
+            raise ValueError(f"{prefix} head_ref must be a string or null")
+
+        state = item.get("state")
+        if state is not None and not isinstance(state, str):
+            raise ValueError(f"{prefix} state must be a string or null")
+
+        merged = item.get("merged")
+        if merged is not None and not isinstance(merged, bool):
+            raise ValueError(f"{prefix} merged must be a boolean or null")
+
+        for field in ("merged_at", "closed_at"):
+            value = item.get(field)
+            if value is not None and not isinstance(value, str):
+                raise ValueError(f"{prefix} {field} must be an ISO timestamp string or null")
+            if value and _parse_iso(value) is None:
+                raise ValueError(f"{prefix} {field} must be a valid ISO timestamp")
+
+        records.append(item)
+    return records
+
+
+def load_pr_records(path: Path) -> list[dict]:
+    payload = json.loads(path.read_text())
+    return _validate_pr_records(payload, source=str(path))
 
 
 # ---------------------------------------------------------------------------
@@ -333,25 +377,35 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--status-doc", default=DEFAULT_STATUS_DOC)
     args = parser.parse_args(argv)
 
-    now = datetime.now(timezone.utc)
-    if args.since:
-        window_start = datetime.fromisoformat(args.since.replace("Z", "+00:00"))
-    else:
-        window_start = now - timedelta(days=args.window_days)
+    try:
+        now = datetime.now(timezone.utc)
+        if args.since:
+            window_start = datetime.fromisoformat(args.since.replace("Z", "+00:00"))
+        else:
+            window_start = now - timedelta(days=args.window_days)
 
-    outbox_dirs = [Path(d) for d in (args.outbox_dir or DEFAULT_OUTBOX_DIRS)]
-    outbox_items, unreadable = load_outbox_items(outbox_dirs)
+        outbox_dirs = [Path(d) for d in (args.outbox_dir or DEFAULT_OUTBOX_DIRS)]
+        outbox_items, unreadable = load_outbox_items(outbox_dirs)
 
-    if args.ls_remote_file:
-        ls_remote_text = Path(args.ls_remote_file).read_text()
-    else:
-        ls_remote_text = run_ls_remote()
-    remote_heads = parse_ls_remote(ls_remote_text)
+        if args.ls_remote_file:
+            ls_remote_text = Path(args.ls_remote_file).read_text()
+        else:
+            ls_remote_text = run_ls_remote()
+        remote_heads = parse_ls_remote(ls_remote_text)
 
-    if args.prs_file:
-        prs = json.loads(Path(args.prs_file).read_text())
-    else:
-        prs = fetch_all_prs(args.repo)
+        if args.prs_file:
+            prs = load_pr_records(Path(args.prs_file))
+        else:
+            prs = fetch_all_prs(args.repo)
+    except (
+        OSError,
+        ValueError,
+        json.JSONDecodeError,
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+    ) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
 
     result = compute_work_loss(
         outbox_items=outbox_items,

--- a/tests/scripts/test_measure_work_loss.py
+++ b/tests/scripts/test_measure_work_loss.py
@@ -16,6 +16,7 @@ from scripts.measure_work_loss import (
     UNIT_DEFINITIONS,
     compute_work_loss,
     load_outbox_items,
+    load_pr_records,
     main,
     parse_ls_remote,
     render_waste_block,
@@ -237,6 +238,39 @@ class TestLoadOutboxItems:
         assert unreadable == 0
 
 
+class TestLoadPrRecords:
+    def test_loads_valid_pr_snapshot(self, tmp_path: Path) -> None:
+        path = tmp_path / "prs.json"
+        path.write_text(json.dumps([_pr(42, "codex/example", merged_at="2026-06-10T01:00:00Z")]))
+
+        records = load_pr_records(path)
+
+        assert records[0]["number"] == 42
+        assert records[0]["head_ref"] == "codex/example"
+
+    @pytest.mark.parametrize(
+        ("payload", "message"),
+        [
+            ({}, "must be a JSON list"),
+            ([[]], "must be a JSON object"),
+            ([{"head_ref": "codex/x"}], "positive integer number"),
+            ([{"number": True, "head_ref": "codex/x"}], "positive integer number"),
+            ([{"number": 1, "head_ref": {"bad": "shape"}}], "head_ref must be"),
+            ([{"number": 1, "merged": "yes"}], "merged must be"),
+            ([{"number": 1, "merged_at": 123}], "merged_at must be"),
+            ([{"number": 1, "closed_at": "not-a-date"}], "closed_at must be a valid"),
+        ],
+    )
+    def test_rejects_malformed_pr_snapshot(
+        self, tmp_path: Path, payload: object, message: str
+    ) -> None:
+        path = tmp_path / "prs.json"
+        path.write_text(json.dumps(payload))
+
+        with pytest.raises(ValueError, match=message):
+            load_pr_records(path)
+
+
 class TestMainJson:
     def test_end_to_end_with_injected_files(
         self, tmp_path: Path, capsys: pytest.CaptureFixture
@@ -283,6 +317,33 @@ class TestMainJson:
         assert out["lost_units"] == 3
         assert out["waste_ratio"] == pytest.approx(3.0)
         assert "unit_definitions" in out
+
+    def test_main_fails_closed_on_malformed_pr_snapshot(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        outbox = tmp_path / "outbox"
+        outbox.mkdir()
+        ls_remote = tmp_path / "heads.txt"
+        ls_remote.write_text("abc\trefs/heads/main\n")
+        prs_file = tmp_path / "prs.json"
+        prs_file.write_text(json.dumps([{"head_ref": "codex/missing-number"}]))
+
+        rc = main(
+            [
+                "--outbox-dir",
+                str(outbox),
+                "--ls-remote-file",
+                str(ls_remote),
+                "--prs-file",
+                str(prs_file),
+                "--json",
+            ]
+        )
+
+        captured = capsys.readouterr()
+        assert rc == 2
+        assert captured.out == ""
+        assert "positive integer number" in captured.err
 
     def test_publish_updates_waste_block_only(
         self, tmp_path: Path, capsys: pytest.CaptureFixture


### PR DESCRIPTION
## Summary
- validates captured PR snapshot records before work-loss metrics compute lost/produced units
- fails closed with a CLI error for malformed PR snapshot input instead of crashing or miscounting
- adds focused tests for valid, malformed, and CLI error paths

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_measure_work_loss.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/measure_work_loss.py tests/scripts/test_measure_work_loss.py
- git diff --check
- bash scripts/automation_pr_preflight.sh origin/main HEAD