### PR TITLE
feat(loop-control): retire merge-arbiter fault-vs-waiting curated gap

### DIFF
--- a/aragora/swarm/loop_control.py
+++ b/aragora/swarm/loop_control.py
@@ -429,13 +429,18 @@ LOOP_SPECS: dict[LoopKind, LoopSpec] = {
         guards=HaltGuards(
             max_iteration=True,
             no_progress=True,
-            no_progress_distinguishes_fault=False,
+            no_progress_distinguishes_fault=True,
             budget_ceiling=False,
-            code_ref="aragora/swarm/merge_arbiter.py MergeArbiterConfig (max_runtime_hours=12, max_consecutive_failures=3)",
+            code_ref=(
+                "aragora/swarm/merge_arbiter.py ArbiterOperationalError + MergeArbiter.run "
+                "(max_runtime_hours=12, max_consecutive_failures=3)"
+            ),
             notes=(
-                "circuit breaker trips on failure-only polls without separating an operational "
-                "fault from not-ready PRs (the #7879 bug class); eval/merge fault path still "
-                "bypasses the breaker",
+                "breaker trips only on systemic operational faults: a candidate list-fetch "
+                "fault, or every evaluation in a poll faulting; not-ready PRs and a single "
+                "poison-pill PR never trip it (#7879, PR #8125). Residual: merge-API failures "
+                "during a merge attempt are recorded as results, not faults, and are bounded "
+                "by max_runtime_hours",
             ),
         ),
         feedback_kind="quorum",

--- a/docs/governance/LOOP_CONTROL_PLANE.md
+++ b/docs/governance/LOOP_CONTROL_PLANE.md
@@ -44,7 +44,8 @@ audits each loop's guards against them (`audit_halt_readiness`):
 2. **No-progress detection that distinguishes fault from waiting.** The loop
    must notice it is not advancing **and** correctly separate an *operational
    fault* (halt, fail closed) from *normal waiting on not-ready work*
-   (keep waiting). Getting this wrong is the live `merge_arbiter` defect (§4).
+   (keep waiting). Getting this wrong was the `merge_arbiter` defect (§4),
+   fixed by PR #8125.
 3. **Budget ceiling.** A spend ceiling so a stuck-but-busy loop cannot run up an
    unbounded bill. This is the article's headline risk.
 
@@ -56,13 +57,19 @@ The audit verdict per loop is:
 
 ### Current findings (curated; see §6)
 
-Every standing loop is currently `incomplete`. Two systemic gaps dominate:
+Every standing loop is currently `incomplete`. One systemic gap dominates:
 
 - **No loop has a dollar/budget ceiling.** They are bounded by time/iterations
   only. Wiring real per-loop budgets is the highest-value follow-up.
-- **`merge_arbiter`'s no-progress detection does not distinguish an operational
-  fault from not-ready PRs** (the #7879 bug class), so its circuit breaker can
-  trip on benign waiting and/or spin to `max_runtime` on a real fault.
+
+Retired findings:
+
+- **`merge_arbiter` fault-vs-waiting (the #7879 bug class): fixed by PR #8125.**
+  The breaker now trips only on systemic operational faults
+  (`ArbiterOperationalError` on candidate list fetch, or every evaluation in a
+  poll faulting); not-ready PRs and a single poison-pill PR never trip it.
+  Residual, recorded in the spec notes: merge-API failures during a merge
+  attempt are reported as results, not faults, bounded by `max_runtime_hours`.
 
 These are honest, code-referenced findings, not fabricated alarms.
 
@@ -125,9 +132,11 @@ Control Plane encodes the correct distinction directly in `classify_loop`:
 - an unreadable loop -> state `unknown`, next action `report_only` (never an
   implied "continue").
 
-`audit_halt_readiness` then flags `merge_arbiter` as `incomplete` precisely
-because its *guard* does not yet make this distinction, so the gap is visible at
-the fleet level until the loop itself is fixed.
+The loop itself now makes the same distinction (PR #8125): `merge_arbiter`
+raises `ArbiterOperationalError` for genuine faults and its breaker counts only
+systemic ones, so `audit_halt_readiness` no longer flags the fault-vs-waiting
+gap. The arbiter stays `incomplete` solely for the missing budget ceiling, and
+that residual is visible at the fleet level until budgets are wired.
 
 ---
 
@@ -151,7 +160,7 @@ The stable, machine-readable fields:
              "source": "none", "source_status": "unavailable"},
   "feedback_gate": {"kind": "quorum", "status": "quorum"},
   "halt_readiness": {"max_iteration": true, "no_progress": true,
-                     "no_progress_distinguishes_fault": false,
+                     "no_progress_distinguishes_fault": true,
                      "budget_ceiling": false,
                      "verdict": "incomplete", "gaps": ["..."], "notes": ["..."]},
   "durability": {"state_path": null, "restart_safe": false},

--- a/tests/swarm/test_loop_control.py
+++ b/tests/swarm/test_loop_control.py
@@ -196,11 +196,15 @@ def test_record_is_json_serializable() -> None:
     assert "loop-control/v1" in json.dumps(rec.to_dict())
 
 
-def test_registry_complete_and_merge_arbiter_flagged() -> None:
+def test_registry_complete_and_merge_arbiter_fault_distinction_retired() -> None:
     for kind in LoopKind:
         assert kind in LOOP_SPECS
-    # The #7879 lesson is encoded as a curated gap on the merge arbiter.
-    assert LOOP_SPECS[LoopKind.MERGE_ARBITER].guards.no_progress_distinguishes_fault is False
+    # The #7879 curated gap was retired by PR #8125: the arbiter breaker now
+    # trips only on systemic operational faults, never on not-ready PRs.
+    assert LOOP_SPECS[LoopKind.MERGE_ARBITER].guards.no_progress_distinguishes_fault is True
+    arbiter_audit = audit_halt_readiness(LOOP_SPECS[LoopKind.MERGE_ARBITER].guards)
+    assert arbiter_audit.verdict == "incomplete"  # budget ceiling still missing
+    assert arbiter_audit.gaps == ["no dollar/budget ceiling (bounded by time/iterations only)"]
 
 
 def test_source_paths_and_status_propagated() -> None:


### PR DESCRIPTION
## Summary
PR #8125 (merged as c2a48a306dfe) fixed the #7879 fault-vs-waiting defect in the merge arbiter: the circuit breaker now trips only on systemic operational faults (candidate list-fetch fault, or every evaluation in a poll faulting), never on not-ready PRs, and a single poison-pill PR cannot halt the queue.

This PR retires the corresponding curated gap in the Loop Control Plane:
- `LOOP_SPECS[MERGE_ARBITER].guards.no_progress_distinguishes_fault` -> `True`, with updated `code_ref` and honest residual notes (merge-API failures during a merge attempt are recorded as results, bounded by `max_runtime_hours`)
- `docs/governance/LOOP_CONTROL_PLANE.md`: findings section moves the defect to 'Retired findings', sections 2 and 4 updated to reflect the fix, JSON example updated
- `tests/swarm/test_loop_control.py`: registry test now asserts the flag is True and that the arbiter's only remaining audit gap is the budget ceiling

## Validation
- 30/30 `tests/swarm/test_loop_control.py` on current main (b12cc7305bb2)
- mypy clean on `aragora/swarm/loop_control.py`; ruff clean; pre-commit hooks pass