### PR TITLE
fix(reports): report malformed boss metrics jsonl

### DIFF
--- a/scripts/report_code_quality.py
+++ b/scripts/report_code_quality.py
@@ -61,6 +61,7 @@ _SUPPRESSION_PATTERNS = {
 }
 
 _INVALID_BOSS_ISSUE_REASON = "invalid issue_number in v2 prompt data"
+_MALFORMED_BOSS_METRICS_REASON = "malformed boss metrics JSONL"
 
 
 def count_lines(path: Path) -> int:
@@ -150,12 +151,26 @@ def scan_boss_metrics() -> dict:
 
     rows = []
     try:
-        with metrics_path.open() as f:
-            for line in f:
+        with metrics_path.open(encoding="utf-8") as f:
+            for line_number, line in enumerate(f, start=1):
                 line = line.strip()
                 if line:
-                    rows.append(json.loads(line))
-    except (OSError, json.JSONDecodeError):
+                    try:
+                        row = json.loads(line)
+                    except json.JSONDecodeError:
+                        return {
+                            "available": False,
+                            "reason": _MALFORMED_BOSS_METRICS_REASON,
+                            "line": line_number,
+                        }
+                    if not isinstance(row, dict):
+                        return {
+                            "available": False,
+                            "reason": _MALFORMED_BOSS_METRICS_REASON,
+                            "line": line_number,
+                        }
+                    rows.append(row)
+    except OSError:
         return {"available": False}
 
     # Filter to v2 prompt runs
@@ -280,6 +295,14 @@ def main() -> None:
             print(f"  Issues completed: {boss_metrics['issues_completed']}")
             print(f"  Per-issue success rate: {boss_metrics['per_issue_success_rate']:.1%}")
             print(f"  Meets B0 target (>=50%): {boss_metrics['meets_b0_target']}")
+        elif boss_metrics.get("reason"):
+            print("\nBoss Loop Metrics:")
+            line_suffix = (
+                f" (line {boss_metrics['line']})"
+                if isinstance(boss_metrics.get("line"), int)
+                else ""
+            )
+            print(f"  Unavailable: {boss_metrics['reason']}{line_suffix}")
 
         if comparison is not None:
             print(

--- a/tests/scripts/test_report_code_quality.py
+++ b/tests/scripts/test_report_code_quality.py
@@ -150,6 +150,45 @@ def test_scan_boss_metrics_rejects_invalid_issue_numbers(
     }
 
 
+def test_scan_boss_metrics_reports_malformed_jsonl(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    metrics_path = tmp_path / ".aragora" / "overnight" / "boss_metrics.jsonl"
+    metrics_path.parent.mkdir(parents=True, exist_ok=True)
+    metrics_path.write_text(
+        '{"issue_number": 1, "prompt_chars": 100, "worker_status": "completed"}\n{not json}\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(report_code_quality, "REPO_ROOT", tmp_path)
+
+    metrics = report_code_quality.scan_boss_metrics()
+
+    assert metrics == {
+        "available": False,
+        "reason": "malformed boss metrics JSONL",
+        "line": 2,
+    }
+
+
+def test_scan_boss_metrics_reports_non_object_jsonl_rows(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    metrics_path = tmp_path / ".aragora" / "overnight" / "boss_metrics.jsonl"
+    metrics_path.parent.mkdir(parents=True, exist_ok=True)
+    metrics_path.write_text("[]\n", encoding="utf-8")
+    monkeypatch.setattr(report_code_quality, "REPO_ROOT", tmp_path)
+
+    metrics = report_code_quality.scan_boss_metrics()
+
+    assert metrics == {
+        "available": False,
+        "reason": "malformed boss metrics JSONL",
+        "line": 1,
+    }
+
+
 def test_scan_boss_metrics_skips_missing_issue_numbers(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -225,3 +264,41 @@ def test_main_text_compare_prints_baseline_section(
     assert "baseline_date: 2026-04-12" in output
     assert "except_exception" in output
     assert "delta=+1" in output
+
+
+def test_main_text_reports_unavailable_boss_metrics_reason(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["report_code_quality.py"])
+    monkeypatch.setattr(
+        report_code_quality,
+        "scan_all_aragora",
+        lambda: {"except_exception": 0, "type_ignore": 0, "noqa": 0, "todo": 0, "fixme": 0},
+    )
+    monkeypatch.setattr(
+        report_code_quality,
+        "scan_boss_metrics",
+        lambda: {
+            "available": False,
+            "reason": "malformed boss metrics JSONL",
+            "line": 3,
+        },
+    )
+    monkeypatch.setattr(
+        report_code_quality,
+        "scan_subsystem",
+        lambda name, path: {
+            "name": name,
+            "files": 0,
+            "loc": 0,
+            "test_ratio": 0.0,
+            "suppressions": {"except_exception": 0, "noqa": 0},
+            "top5_largest": [],
+        },
+    )
+
+    report_code_quality.main()
+
+    output = capsys.readouterr().out
+    assert "Boss Loop Metrics:" in output
+    assert "Unavailable: malformed boss metrics JSONL (line 3)" in output


### PR DESCRIPTION
## Summary
- reports malformed boss metrics JSONL with an explicit unavailable reason and line number in code-quality metrics
- treats non-object JSONL rows as malformed instead of silently hiding boss-loop metrics proof
- surfaces unavailable boss-loop metrics reasons in the text report

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_report_code_quality.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/report_code_quality.py tests/scripts/test_report_code_quality.py
- git diff --check origin/main...HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD