### PR TITLE
[Tier 4 — operator settlement required] feat(ci): re-evaluate merge quorum on evidence comments (B1)

### DIFF
--- a/.github/workflows/aragora-merge-quorum.yml
+++ b/.github/workflows/aragora-merge-quorum.yml
@@ -18,6 +18,14 @@ name: Aragora Merge Quorum
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  # B1 (docs/specs/QUORUM_EVIDENCE_RETRIGGER.md): model-review evidence
+  # comments are posted AFTER the pull_request events above, so the
+  # ready-triggered evaluation always pre-dates the evidence and fails
+  # stale. When a comment that plausibly carries reviewer evidence is
+  # created, the evidence-retrigger job below re-runs the head-bound
+  # pull_request evaluation so the gate re-reads the now-complete evidence.
+  issue_comment:
+    types: [created]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -26,7 +34,12 @@ on:
         type: string
 
 concurrency:
-  group: aragora-merge-quorum-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+  # Dual-event PR resolution: pull_request events carry the PR number
+  # directly; issue_comment events carry it as github.event.issue.number.
+  # Including the issue number keeps comment-triggered runs serialized
+  # per-PR (and behind any in-flight evaluation for the same PR) instead
+  # of colliding in a single repo-wide group.
+  group: aragora-merge-quorum-${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number }}
   # cancel-in-progress is intentionally false. With true, two triggers for the
   # same PR (e.g. synchronize + reopened, or rapid pushes) cancel each other;
   # a cancelled run reports a "cancelled" conclusion, which turns this REQUIRED
@@ -46,6 +59,10 @@ permissions:
 jobs:
   merge-quorum:
     name: aragora-merge-quorum
+    # issue_comment events are handled by the evidence-retrigger job below.
+    # The enforcing evaluation only runs in pull_request / workflow_dispatch
+    # context, where its check run binds to the PR head SHA.
+    if: github.event_name != 'issue_comment'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -206,3 +223,110 @@ jobs:
 
           fail(f"Unrecognized merge-quorum status '{status}' — failing closed.")
           PY
+
+  # B1 — evidence re-trigger (docs/specs/QUORUM_EVIDENCE_RETRIGGER.md).
+  #
+  # An issue_comment-triggered workflow run executes the DEFAULT-BRANCH
+  # workflow file and its check runs attach to the default-branch SHA, not
+  # the PR head (the same reason workflow_dispatch above is "debug; does not
+  # update PR check status"). So this job does NOT evaluate the packet
+  # inline — it re-runs the latest head-bound pull_request evaluation run,
+  # which re-reads the now-complete evidence and reports on the PR head.
+  # Re-running a read-only evaluation is always safe; it can never pass a
+  # genuinely failing PR (docs/governance/BOSS_LOOP_MERGE_GATE_RESILIENCE.md §6).
+  evidence-retrigger:
+    name: quorum-evidence-retrigger
+    # Cheap declarative guards: only PR comments, never comments authored by
+    # github-actions (the evidence parsers exclude that author, so such a
+    # comment can never change the quorum — and skipping it also prevents
+    # bot-comment retrigger loops). Non-matching events skip without
+    # scheduling a runner.
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request != null &&
+      github.event.comment.user.login != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Job-scoped least privilege. actions:write is required ONLY to re-run
+    # this workflow's own prior evaluation run; it cannot approve, merge,
+    # push, comment, or alter statuses. The enforcing merge-quorum job above
+    # keeps the workflow-level read-only permissions unchanged.
+    permissions:
+      actions: write
+      pull-requests: read
+    # Debounce comment floods: a newer evidence comment for the same PR
+    # cancels an older still-pending retrigger. cancel-in-progress here is
+    # safe precisely because this job is NOT the required check — the
+    # required evaluation job's group above keeps cancel-in-progress: false,
+    # so comment activity can never cancel an enforcing run into a red
+    # "cancelled" conclusion.
+    concurrency:
+      group: quorum-evidence-retrigger-${{ github.event.issue.number }}
+      cancel-in-progress: true
+    steps:
+      - name: Guard and re-trigger stale quorum evaluation
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          # Attacker-controlled content enters ONLY via env (never inline
+          # ${{ }} inside run:), so comment markdown cannot inject shell.
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Guard 1: the comment's FIRST markdown heading must name a known
+          # reviewer family — the same convention the quorum evidence
+          # parsers key on (review_queue.py heading inference + canonical
+          # model-family markers). Anything else no-ops successfully.
+          heading="$(printf '%s\n' "$COMMENT_BODY" | grep -m1 -E '^[[:space:]]{0,3}#{1,6}[[:space:]]' || true)"
+          if [[ -z "$heading" ]]; then
+            echo "No markdown heading in comment — not evidence-shaped; no-op."
+            exit 0
+          fi
+          families='claude|anthropic|codex|tesla|harvey|factory|grok|xai|gemini|openai|gpt|mistral|codestral|deepseek|qwen|kimi|moonshot|yi|glm|zhipu|minimax|hermes'
+          heading_lower="$(printf '%s' "$heading" | tr '[:upper:]' '[:lower:]')"
+          if ! printf '%s' "$heading_lower" | grep -qE "(^|[^a-z0-9])(${families})([^a-z0-9]|$)"; then
+            echo "First heading names no known reviewer family — no-op."
+            exit 0
+          fi
+
+          # Guard 2: PR must be open and non-draft (drafts defer the gate).
+          pr_json="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}")"
+          pr_state="$(jq -r '.state' <<<"$pr_json")"
+          pr_draft="$(jq -r '.draft' <<<"$pr_json")"
+          head_sha="$(jq -r '.head.sha' <<<"$pr_json")"
+          if [[ "$pr_state" != "open" || "$pr_draft" != "false" ]]; then
+            echo "PR #${PR_NUMBER} state=${pr_state} draft=${pr_draft} — gate not active; no-op."
+            exit 0
+          fi
+
+          # Guard 3: only re-run a COMPLETED, non-success evaluation bound to
+          # the CURRENT head SHA. In-flight runs will already see the new
+          # comment; a green gate needs no recount; runs for old heads are
+          # correctly superseded by the next pull_request event.
+          run_json="$(gh api "repos/${GH_REPO}/actions/workflows/aragora-merge-quorum.yml/runs?event=pull_request&head_sha=${head_sha}&per_page=1" \
+            --jq '.workflow_runs[0] // empty')"
+          if [[ -z "$run_json" ]]; then
+            echo "No prior head-bound evaluation run for ${head_sha} — no-op."
+            exit 0
+          fi
+          run_id="$(jq -r '.id' <<<"$run_json")"
+          run_status="$(jq -r '.status' <<<"$run_json")"
+          run_conclusion="$(jq -r '.conclusion' <<<"$run_json")"
+          if [[ "$run_status" != "completed" ]]; then
+            echo "Latest evaluation run ${run_id} is ${run_status} — it will see this comment; no-op."
+            exit 0
+          fi
+          if [[ "$run_conclusion" == "success" ]]; then
+            echo "Latest evaluation run ${run_id} already succeeded — no-op."
+            exit 0
+          fi
+
+          echo "Re-running stale evaluation run ${run_id} (conclusion=${run_conclusion}) for PR #${PR_NUMBER} head ${head_sha}."
+          # Tolerate rerun races (e.g. a manual rerun already in progress):
+          # failure to request a rerun must not turn comment activity into
+          # red noise. The A1 reconciler remains the safety net.
+          gh run rerun "$run_id" --repo "$GH_REPO" \
+            || echo "::warning::rerun request for run ${run_id} failed (possibly already re-running); no-op."

--- a/docs/specs/QUORUM_EVIDENCE_RETRIGGER.md
+++ b/docs/specs/QUORUM_EVIDENCE_RETRIGGER.md
@@ -1,0 +1,212 @@
+# Quorum Evidence Re-Trigger (B1, Tier 4 Pre-Approval + Draft Implementation)
+
+**Status:** Tier 4 pre-approval artifact WITH the complete draft
+implementation in the same PR. **Never merged autonomously.** The PR
+carrying this spec stays DRAFT until the operator settles it
+(preapproval + exact-head human settlement), per
+`docs/REVIEW_AUTHORITY_PRINCIPLES.md` and
+`docs/governance/BOSS_LOOP_MERGE_GATE_RESILIENCE.md` §B1 / Phase 2.
+This file and `tests/governance/test_quorum_evidence_retrigger.py` are
+the pre-approval artifact; `.github/workflows/aragora-merge-quorum.yml`
+carries the guarded change itself.
+
+## Problem Statement
+
+`aragora-merge-quorum.yml` is the enforcing, REQUIRED model-quorum
+gate. It triggers on `pull_request`
+`[opened, synchronize, reopened, ready_for_review]` and
+`workflow_dispatch` — never on comments. But the evidence it counts is
+PR comments, which are posted *after* every one of those events. The
+ready-triggered evaluation therefore always pre-dates the evidence:
+
+1. PR marked ready → gate evaluates → no countable evidence yet →
+   FAILURE (correct at that instant).
+2. Reviewer evidence comments land minutes later.
+3. The gate never re-reads them. The check sits stale-red until someone
+   (or the A1 reconciler) issues `gh run rerun`.
+
+This is root cause #1 in
+`docs/governance/BOSS_LOOP_MERGE_GATE_RESILIENCE.md` §2. It was
+observed on **every settled PR of run-20260610**: each settlement paid
+one guaranteed first failure, one wasted Actions evaluation run, and
++5–10 minutes of latency for the rerun cycle (PR #7727 sat stale-red
+~2.5 h before the pattern was understood). The A1 reconciler
+(`scripts/quorum_rerun_reconciler.py`) papers over this out-of-band;
+B1 fixes it at the source. A1 remains the safety net.
+
+## Design
+
+Add a guarded `issue_comment: types: [created]` trigger plus a new
+`evidence-retrigger` job to `aragora-merge-quorum.yml`.
+
+### Why re-run instead of evaluating inline
+
+An `issue_comment`-triggered workflow run executes the default-branch
+workflow file and its check runs attach to the **default-branch SHA,
+not the PR head**. This is the same GitHub mechanic that makes the
+existing `workflow_dispatch` path "debug; does not update PR check
+status". An inline evaluation in the comment-triggered run therefore
+could not move the head-bound required check at all.
+
+The job instead performs the known-safe deterministic recovery — the
+exact manual fix used on #7727 and the A1 reconciler motion — at the
+source: `gh run rerun <latest head-bound pull_request run>`. The rerun
+executes in the original `pull_request` context, so its check run binds
+to the PR head and the gate genuinely re-reads the evidence.
+
+### Trigger contract
+
+| Element | Value |
+| --- | --- |
+| New trigger | `issue_comment: types: [created]` |
+| PR resolution | `github.event.issue.number` (dual-event: `pull_request.number` for PR events, `issue.number` for comment events, `inputs.pr_number` for dispatch) |
+| New job | `evidence-retrigger` (name `quorum-evidence-retrigger`) — distinct from the required `aragora-merge-quorum` job |
+| Enforcing job | unchanged logic; gains `if: github.event_name != 'issue_comment'` so comment events never produce a default-branch-bound evaluation |
+| Workflow concurrency | group extended with `github.event.issue.number`; `cancel-in-progress: false` preserved for the enforcing path (the documented anti-doom-loop invariant) |
+| Retrigger concurrency | job-scoped group `quorum-evidence-retrigger-<pr>` with `cancel-in-progress: true` (debounce) |
+
+### GUARD step (no-op success unless all hold)
+
+Declarative (no runner scheduled when false):
+
+- `github.event.issue.pull_request` non-null (PR comments only);
+- comment author is not `github-actions[bot]` (the evidence parsers
+  exclude that author, so such comments can never change the quorum;
+  this also breaks any bot-comment retrigger loop).
+
+In-step (read-only `gh api` + `jq`):
+
+1. The comment's **first markdown heading** matches the known reviewer
+   family regex (mirrors `review_queue.py` heading inference:
+   `claude|anthropic|codex|tesla|harvey|factory|grok|xai|gemini|openai|gpt|mistral|codestral|deepseek|qwen|kimi|moonshot|yi|glm|zhipu|minimax|hermes`,
+   word-boundary matched, case-insensitive). Non-evidence-shaped
+   comments exit 0 in seconds.
+2. The PR is open and non-draft (drafts defer the gate by design).
+3. The latest `pull_request`-event run of this workflow **for the
+   current head SHA** exists, is `completed`, and concluded
+   non-`success`. In-flight runs will already see the comment; green
+   gates need no recount; runs for superseded heads are left alone.
+
+Only then: `gh run rerun <run_id>`, tolerating rerun races
+(an "already running" rejection logs a warning and exits 0 — comment
+activity must never manufacture red noise).
+
+### Permissions
+
+Workflow-level permissions are **unchanged** (contents/pull-requests/
+statuses: read), and the enforcing `merge-quorum` job inherits them
+unchanged.
+
+**Deliberate deviation from the one-line B1 sketch** ("permissions
+unchanged"): the `evidence-retrigger` job carries job-scoped
+`permissions: { actions: write, pull-requests: read }`. A purely
+read-permission comment-triggered run cannot move the head-bound
+required check (see "Why re-run instead of evaluating inline"), so
+`actions: write` — the capability to re-run this workflow's own prior
+read-only evaluation — is the minimum that makes B1 do anything at
+all. It cannot approve, merge, push, comment, or set statuses. The
+write scope is confined to the retrigger job; the evaluation path's
+permissions are byte-identical to before.
+
+## Threat Model
+
+**Comment-DoS.** Every repo comment fires the trigger.
+Mitigations: declarative job `if` (non-PR and bot comments skip without
+scheduling a runner); the heading guard exits in seconds for
+non-evidence comments; workflow concurrency serializes per-PR (GitHub
+keeps at most one running + one pending run per group, collapsing
+floods); the job-scoped `cancel-in-progress: true` group cancels
+superseded pending retriggers; Guard 3 makes the rerun itself
+idempotent (once a rerun is in flight, subsequent comments no-op
+because the latest run is no longer `completed`+non-success).
+Residual: bounded Actions minutes from short guard executions,
+proportional to comment rate on open non-draft PRs.
+
+**Spoofed headings.** A spoofed evidence heading can trigger a
+recount, never a pass. The rerun executes the same read-only
+`merge-packet` evaluation with the full lint rules — exact-head SHA
+grounding, `github-actions` author exclusion, lineage disclosure
+requirements, heading/metadata conflict rejection, unknown-reviewer
+fail-closed. Critically, **B1 does not widen the evidence-acceptance
+surface**: any comment that would count after a B1 recount would count
+identically at the next `synchronize` event or manual rerun today. The
+trigger adds recount opportunities, not acceptance.
+
+**Shell injection via comment body.** Attacker-controlled comment
+markdown reaches the job only through `env:` (`COMMENT_BODY`), never
+via inline `${{ }}` interpolation inside `run:`. The body is only ever
+grepped; it is never evaluated, and no other event field
+(title/branch/login) is interpolated into script text either.
+
+**Fork-PR permissions.** `issue_comment` workflows run **on the base
+repository**, from the default-branch workflow file, with the base
+repo's `GITHUB_TOKEN` — stated explicitly per the B1 caveat. The
+retrigger job checks out nothing and executes no PR-author-controlled
+code; the rerun it requests also checks out only the default branch
+(the evaluation job pins `ref: default_branch`) and is read-only. A
+fork commenter therefore gets no code execution with the token; worst
+case is triggering a read-only recount.
+
+**Cancellation abuse.** `cancel-in-progress: true` is scoped to the
+retrigger job's own per-PR group. The required evaluation runs keep
+`cancel-in-progress: false`, so comment activity cannot cancel an
+enforcing run into a red "cancelled" conclusion (the documented doom
+loop this workflow already defends against).
+
+**Retrigger loops.** Reruns are not new events and fire no triggers;
+`github-actions[bot]` comments are skipped declaratively; the
+no-op-unless-stale-failure guard means even a pathological commenter
+converges to one rerun per genuinely stale failure per head.
+
+**Gate weakening.** None of the enforcing logic changes: same packet
+evaluation, same fail-closed branches, same Tier 3-4
+`aragora/human-settlement` requirement, `enforce_admins` untouched.
+Re-running a read-only evaluation can never pass a genuinely failing
+PR (`BOSS_LOOP_MERGE_GATE_RESILIENCE.md` §6).
+
+## Tier Policy
+
+This change edits `.github/workflows/aragora-merge-quorum.yml`, which
+is by its own header a **Tier 4 merge-authority self-modification**:
+explicit human preapproval before implementation and before merge.
+
+This PR is the pre-approval artifact *and* the draft implementation:
+
+- design doc (this file)
+- governance tests pinning the trigger contract
+  (`tests/governance/test_quorum_evidence_retrigger.py`)
+- the guarded workflow change itself
+
+It performs **no merge or settlement action**. The PR remains DRAFT;
+operator settlement requires explicit preapproval plus exact-head
+model evidence and the `aragora/human-settlement` commit status before
+merge, per `docs/governance/MERGE_GATE_RECONCILIATION.md`.
+
+## Governance Test Intent
+
+`tests/governance/test_quorum_evidence_retrigger.py` parses the
+workflow with `yaml.safe_load` and pins:
+
+- `issue_comment: [created]` is a trigger;
+- the retrigger job is declaratively guarded on
+  `github.event.issue.pull_request`;
+- dual-event PR resolution (`github.event.issue.number` reaches both
+  the workflow concurrency group and the retrigger job);
+- per-PR retrigger concurrency with `cancel-in-progress: true`,
+  while the workflow-level group keeps `cancel-in-progress: false`;
+- the enforcing job is excluded from `issue_comment` events and gains
+  no write permission; the retrigger job's write surface is exactly
+  `actions: write`;
+- the comment body enters only via `env:`, never inline in `run:`;
+- the guard step references the known-reviewer-family heading match
+  and the head-bound stale-run conditions.
+
+The suite FAILS against the pre-change workflow (RED) and PASSES with
+the change (GREEN); the RED proof is captured in the PR body.
+
+## Operator Settlement Requested
+
+Approving and settling the carrying PR constitutes the Tier 4
+preapproval and merge settlement for this exact change at its exact
+head SHA. Until then nothing changes in CI: the file on `main` is
+authoritative, and `issue_comment` runs only exist after merge.

--- a/tests/governance/test_quorum_evidence_retrigger.py
+++ b/tests/governance/test_quorum_evidence_retrigger.py
@@ -1,0 +1,183 @@
+"""Governance tests for the quorum evidence re-trigger (B1).
+
+These tests are the Tier 4 pre-approval regression target for the design
+in ``docs/specs/QUORUM_EVIDENCE_RETRIGGER.md`` (root cause #1 in
+``docs/governance/BOSS_LOOP_MERGE_GATE_RESILIENCE.md``: the enforcing
+merge-quorum check always evaluates BEFORE evidence comments exist, so
+every settlement pays a guaranteed stale failure plus a manual rerun).
+
+They pin the structural contract of ``aragora-merge-quorum.yml``:
+
+* ``issue_comment: [created]`` re-triggers evaluation when evidence
+  comments arrive;
+* the re-trigger path is guarded, debounced, and least-privileged;
+* the enforcing evaluation job is untouched: no comment event reaches
+  it, its permissions stay read-only, and its anti-doom-loop
+  ``cancel-in-progress: false`` invariant is preserved.
+
+The suite must FAIL against the pre-B1 workflow and PASS with the
+change (RED/GREEN proof captured in the implementing PR).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[2] / ".github" / "workflows" / "aragora-merge-quorum.yml"
+)
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict[str, Any]:
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def triggers(workflow: dict[str, Any]) -> dict[str, Any]:
+    # YAML 1.1 parses the bare key ``on`` as boolean True.
+    return workflow.get("on") or workflow[True]
+
+
+@pytest.fixture(scope="module")
+def retrigger_job(workflow: dict[str, Any]) -> dict[str, Any]:
+    jobs = workflow["jobs"]
+    assert "evidence-retrigger" in jobs, (
+        "workflow must define the B1 evidence-retrigger job "
+        "(docs/specs/QUORUM_EVIDENCE_RETRIGGER.md)"
+    )
+    return jobs["evidence-retrigger"]
+
+
+@pytest.fixture(scope="module")
+def enforcing_job(workflow: dict[str, Any]) -> dict[str, Any]:
+    return workflow["jobs"]["merge-quorum"]
+
+
+def _run_blocks(job: dict[str, Any]) -> str:
+    return "\n".join(str(step.get("run", "")) for step in job.get("steps", []))
+
+
+class TestIssueCommentTrigger:
+    def test_issue_comment_created_is_a_trigger(self, triggers: dict[str, Any]) -> None:
+        """Evidence comments must be able to re-trigger the workflow."""
+        assert "issue_comment" in triggers
+        assert triggers["issue_comment"]["types"] == ["created"]
+
+    def test_existing_pull_request_trigger_is_preserved(self, triggers: dict[str, Any]) -> None:
+        assert triggers["pull_request"]["types"] == [
+            "opened",
+            "synchronize",
+            "reopened",
+            "ready_for_review",
+        ]
+
+
+class TestDualEventPrResolution:
+    def test_workflow_concurrency_group_resolves_issue_number(
+        self, workflow: dict[str, Any]
+    ) -> None:
+        """Comment events must serialize per-PR, not in one global group."""
+        group = workflow["concurrency"]["group"]
+        assert "github.event.pull_request.number" in group
+        assert "github.event.issue.number" in group
+
+    def test_retrigger_job_resolves_pr_from_issue_number(
+        self, retrigger_job: dict[str, Any]
+    ) -> None:
+        steps_env = "\n".join(str(step.get("env", "")) for step in retrigger_job.get("steps", []))
+        assert "github.event.issue.number" in steps_env
+
+
+class TestRetriggerGuards:
+    def test_job_is_gated_to_pr_comments_only(self, retrigger_job: dict[str, Any]) -> None:
+        """Declarative guard: issue.pull_request non-null, comment events only."""
+        condition = str(retrigger_job.get("if", ""))
+        assert "github.event_name == 'issue_comment'" in condition
+        assert "github.event.issue.pull_request != null" in condition
+
+    def test_github_actions_bot_comments_are_skipped(self, retrigger_job: dict[str, Any]) -> None:
+        """Parser-excluded authors must not burn runs or create bot loops."""
+        condition = str(retrigger_job.get("if", ""))
+        assert "github.event.comment.user.login != 'github-actions[bot]'" in condition
+
+    def test_guard_matches_known_reviewer_family_headings(
+        self, retrigger_job: dict[str, Any]
+    ) -> None:
+        """The in-step guard mirrors the quorum parsers' family markers."""
+        script = _run_blocks(retrigger_job)
+        for family in ("claude", "grok", "gemini", "mistral", "openai", "codex", "factory"):
+            assert family in script, f"guard regex must include reviewer family {family!r}"
+
+    def test_guard_requires_open_non_draft_pr_and_stale_head_bound_run(
+        self, retrigger_job: dict[str, Any]
+    ) -> None:
+        script = _run_blocks(retrigger_job)
+        # PR open + non-draft.
+        assert ".draft" in script
+        assert ".state" in script
+        # Re-run only the latest COMPLETED non-success run for the CURRENT head.
+        assert "head_sha" in script
+        assert "completed" in script
+        assert "gh run rerun" in script
+
+    def test_comment_body_enters_only_via_env(self, retrigger_job: dict[str, Any]) -> None:
+        """Injection pin: comment markdown never interpolates into run: text."""
+        script = _run_blocks(retrigger_job)
+        assert "github.event.comment.body" not in script, (
+            "comment body must reach the shell via env:, never inline ${{ }}"
+        )
+        steps_env: dict[str, Any] = {}
+        for step in retrigger_job.get("steps", []):
+            steps_env.update(step.get("env", {}) or {})
+        assert any("github.event.comment.body" in str(value) for value in steps_env.values()), (
+            "comment body must be provided to the guard step through env:"
+        )
+
+
+class TestDebounceConcurrency:
+    def test_retrigger_concurrency_is_per_pr_and_cancels_in_progress(
+        self, retrigger_job: dict[str, Any]
+    ) -> None:
+        concurrency = retrigger_job.get("concurrency") or {}
+        assert "github.event.issue.number" in str(concurrency.get("group", ""))
+        assert concurrency.get("cancel-in-progress") is True
+
+    def test_enforcing_workflow_group_still_never_cancels_in_progress(
+        self, workflow: dict[str, Any]
+    ) -> None:
+        """The anti-doom-loop invariant on the REQUIRED check is preserved."""
+        assert workflow["concurrency"]["cancel-in-progress"] is False
+
+
+class TestEnforcingJobUnchanged:
+    def test_enforcing_job_excluded_from_issue_comment_events(
+        self, enforcing_job: dict[str, Any]
+    ) -> None:
+        """A comment event must never produce a default-branch-bound evaluation."""
+        assert "github.event_name != 'issue_comment'" in str(enforcing_job.get("if", ""))
+
+    def test_workflow_level_permissions_remain_read_only(self, workflow: dict[str, Any]) -> None:
+        assert workflow["permissions"] == {
+            "contents": "read",
+            "pull-requests": "read",
+            "statuses": "read",
+        }
+
+    def test_enforcing_job_gains_no_write_permission(self, enforcing_job: dict[str, Any]) -> None:
+        permissions = enforcing_job.get("permissions") or {}
+        assert "write" not in str(permissions.values())
+
+    def test_retrigger_write_surface_is_exactly_actions(
+        self, retrigger_job: dict[str, Any]
+    ) -> None:
+        """actions:write (re-run our own evaluation) is the ONLY write scope."""
+        permissions = retrigger_job.get("permissions") or {}
+        writes = sorted(scope for scope, level in permissions.items() if level == "write")
+        assert writes == ["actions"]
+        assert permissions.get("contents") is None
+        assert permissions.get("statuses") is None


### PR DESCRIPTION
> **Tier 4 merge-authority self-modification — DRAFT by design. Do not mark ready or merge without explicit operator preapproval + exact-head human settlement (`aragora/human-settlement`).**

Implements **B1** from `docs/governance/BOSS_LOOP_MERGE_GATE_RESILIENCE.md` (Phase 2): re-evaluate `aragora-merge-quorum` when evidence comments arrive. This PR is the complete pre-approval artifact **and** the draft implementation, following the structure of merged #7472 (spec + governance tests + tier statement).

## Problem

The enforcing gate triggers only on `pull_request` events; the evidence it counts is comments posted *after* those events. Every ready-triggered evaluation therefore pre-dates the evidence → guaranteed first FAILURE + manual/reconciler rerun. Observed on **every settled PR of run-20260610**: one wasted Actions run and +5–10 min latency each (PR #7727 sat stale-red ~2.5 h).

## Design (see `docs/specs/QUORUM_EVIDENCE_RETRIGGER.md`)

- `issue_comment: types: [created]` trigger + new `evidence-retrigger` job.
- **Re-run, not inline evaluation:** an `issue_comment` run's checks attach to the default-branch SHA, not the PR head (same mechanic that makes `workflow_dispatch` "debug; does not update PR check status"). The job re-runs the latest **head-bound, completed, non-success** `pull_request` evaluation — the exact manual fix used on #7727, performed at source.
- **GUARD step (no-op success unless):** PR comment (`issue.pull_request` non-null) ∧ author ≠ `github-actions[bot]` ∧ first markdown heading names a known reviewer family (mirrors `review_queue.py` markers) ∧ PR open + non-draft ∧ latest head-bound run completed non-success.
- **Dual-event PR resolution:** `github.event.issue.number` for comment events; workflow concurrency group extended accordingly.
- **Debounce:** job-scoped concurrency `quorum-evidence-retrigger-<pr>` with `cancel-in-progress: true`. The required evaluation path keeps `cancel-in-progress: false` (anti-doom-loop invariant preserved).

### Deviation from the one-line B1 sketch (declared)

The sketch said "permissions unchanged". A purely read-permission comment run **cannot move the head-bound required check** (see above), so the retrigger job carries job-scoped `permissions: {actions: write, pull-requests: read}` — the minimum that makes B1 functional. `actions: write` can only re-run this workflow's own read-only evaluation; it cannot approve, merge, push, comment, or set statuses. Workflow-level permissions and the enforcing job are byte-identical to before.

## Threat highlights (full analysis in the spec)

- **Comment-DoS:** declarative `if` skips non-PR/bot comments without scheduling a runner; heading guard exits in seconds; per-PR concurrency collapses floods; rerun guard is idempotent (in-flight rerun absorbs subsequent comments). Residual = bounded Actions minutes.
- **Spoofed headings:** re-evaluation is read-only; the packet recounts with full lint rules (exact-head grounding, author exclusion, lineage disclosure, conflict rejection). A spoof can only trigger a recount, never a pass — B1 adds recount opportunities, not acceptance (any comment countable after B1 counts identically at the next `synchronize` today).
- **Shell injection:** comment body enters only via `env:` (`COMMENT_BODY`), never inline `${{ }}` in `run:` — pinned by test.
- **Fork PRs:** stated explicitly — `issue_comment` runs on the **base repo** from the default-branch workflow file; the retrigger checks out nothing and executes no PR code; the rerun also checks out only the default branch. No code execution for fork commenters.
- **Cancellation abuse / retrigger loops:** `cancel-in-progress: true` scoped to the non-required retrigger job only; reruns fire no events; bot comments skipped.

## RED/GREEN proof

RED — `tests/governance/test_quorum_evidence_retrigger.py` against the pre-change workflow (captured via `git stash` of the workflow change):

```
FAILED ...::TestIssueCommentTrigger::test_issue_comment_created_is_a_trigger
FAILED ...::TestDualEventPrResolution::test_workflow_concurrency_group_resolves_issue_number
FAILED ...::TestEnforcingJobUnchanged::test_enforcing_job_excluded_from_issue_comment_events
ERROR  ...::TestRetriggerGuards (5) / TestDualEventPrResolution (1) / TestDebounceConcurrency (1) / TestEnforcingJobUnchanged (1)  [missing evidence-retrigger job]
3 failed, 4 passed, 8 errors in 0.70s
```

GREEN — with the change:

```
15 passed in 0.77s
```

Validation: `yaml.safe_load` OK; `actionlint` OK (no findings); `pre-commit` clean.

## Receipts

Two-family adversarial reviews probing the threat analysis (grok + mistral-api), receipts verified VALID at:
- `.aragora/run-20260610/receipts/c08b_b1_grok.json`
- `.aragora/run-20260610/receipts/c08b_b1_mistral-api.json`

Lineage evidence comments (evidence-lint `would_count=true` before posting) are posted on this PR.

## Operator settlement (exact commands)

```bash
# 1. Review, then preapprove + settle at the EXACT head SHA:
HEAD=$(gh pr view 8169 --repo synaptent/aragora --json headRefOid -q .headRefOid)

# 2. Record the human settlement signal (Tier 4, head-bound):
gh api repos/synaptent/aragora/statuses/$HEAD \
  -f state=success -f context=aragora/human-settlement \
  -f description="Tier 4 operator settlement: B1 quorum evidence re-trigger"

# 3. Mark ready and merge (squash, exact head):
gh pr ready 8169 --repo synaptent/aragora
gh pr merge 8169 --repo synaptent/aragora --squash --match-head-commit $HEAD
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
