### PR TITLE
feat(automation): bounded auto-evidence cycle for ready PRs (throughput lever 1)

### DIFF
--- a/scripts/auto_evidence_cycle.py
+++ b/scripts/auto_evidence_cycle.py
@@ -322,6 +322,54 @@ def default_run_reconciler(repo: str) -> int:
     return proc.returncode
 
 
+# --- Singleton lock -------------------------------------------------------------
+
+
+class CycleLockHeld(RuntimeError):
+    """Another auto-evidence cycle currently holds the singleton lock."""
+
+
+def acquire_cycle_lock(
+    lock_path: str,
+    *,
+    stale_after_seconds: float = 7200.0,
+    now: Callable[[], float] = time.time,
+) -> Callable[[], None]:
+    """Take an exclusive advisory lock for apply mode; return a release callable.
+
+    Two concurrent ``--apply`` invocations (e.g. the merge-arbiter wiring racing
+    a manual run) could both pass selection before either posts, double-posting
+    evidence. ``O_CREAT | O_EXCL`` makes acquisition atomic; a lock older than
+    ``stale_after_seconds`` (default 2h — well past any sane ``--budget-seconds``)
+    is treated as a crash leftover and reclaimed. Raises :class:`CycleLockHeld`
+    when a live lock exists (caller fails closed without posting anything).
+    """
+    try:
+        age = now() - os.path.getmtime(lock_path)
+        if age > stale_after_seconds:
+            os.unlink(lock_path)
+    except OSError:
+        pass  # no lock file (common case) or it vanished between checks
+    try:
+        fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+    except FileExistsError:
+        raise CycleLockHeld(f"lock {lock_path} is held by another invocation") from None
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        fh.write(f"pid={os.getpid()}\n")
+
+    def release() -> None:
+        try:
+            os.unlink(lock_path)
+        except OSError:
+            pass
+
+    return release
+
+
+def default_lock_path() -> str:
+    return os.path.join(os.path.expanduser("~"), ".aragora", "auto_evidence_cycle.lock")
+
+
 # --- Orchestrator --------------------------------------------------------------
 
 
@@ -478,6 +526,21 @@ def main(argv: list[str] | None = None) -> int:
         print(f"error: need >= {REQUIRED_FAMILIES} reviewer families", file=sys.stderr)
         return EXIT_FAILURES
 
+    release: Callable[[], None] = lambda: None
+    if args.apply:
+        # Mutations require the singleton lock: two racing --apply invocations
+        # could both pass selection and double-post evidence on the same PR.
+        lock_dir = os.path.dirname(default_lock_path())
+        try:
+            os.makedirs(lock_dir, exist_ok=True)
+            release = acquire_cycle_lock(default_lock_path())
+        except CycleLockHeld as exc:
+            print(f"error: {exc}; refusing to run concurrently", file=sys.stderr)
+            return EXIT_FAILURES
+        except OSError as exc:
+            print(f"error: could not take cycle lock: {exc}", file=sys.stderr)
+            return EXIT_FAILURES
+
     try:
         summary = run_cycle(
             list_prs=lambda: default_list_prs(args.repo),
@@ -493,6 +556,8 @@ def main(argv: list[str] | None = None) -> int:
     except RuntimeError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return EXIT_FAILURES
+    finally:
+        release()
     print(
         json.dumps(
             {key: value for key, value in summary.items() if key != "plan"}

--- a/scripts/auto_evidence_cycle.py
+++ b/scripts/auto_evidence_cycle.py
@@ -1,0 +1,506 @@
+#!/usr/bin/env python3
+"""Bounded auto-evidence cycle for ready PRs (throughput lever 1, run-20260610).
+
+Open, ready (non-draft) PRs that are missing counted model-review evidence sit
+behind the merge-quorum gate until a human coordinator runs reviewers by hand.
+This wrapper closes that loop autonomously and *boundedly*: it selects up to
+``--max-prs`` such PRs, produces two-family evidence through the proven
+``review-queue collect-evidence`` pipeline (which lint-validates every comment
+with the gate's own ``evidence-lint`` parser *before* posting), then invokes
+``scripts/quorum_rerun_reconciler.py --apply`` so stale quorum checks re-run.
+
+Probe (cheapest reliable, two stages):
+
+1. One ``gh pr list --json number,isDraft,statusCheckRollup`` call prunes
+   drafts and PRs whose latest ``aragora-merge-quorum`` check already concluded
+   SUCCESS (counted evidence exists at that head). Cheap but potentially stale.
+2. Each surviving candidate is confirmed with ``review-queue merge-packet
+   --pr N --json`` — the gate's own parser, hence the ground truth the
+   reconciler also trusts. Only ``needs_model_review_quorum`` entries at
+   Tier 0-2 with <2 counted families, no human-risk settlement requirement and
+   no unresolved dissent are selected. Raw comment grepping would be cheaper
+   than stage 2 but drifts from the canonical parser, so it is not used.
+
+Safety model (mirrors ``quorum_rerun_reconciler.py``):
+
+- Dry-run by default: prints the plan, runs nothing that spends or posts.
+  ``--apply`` gates ALL mutations (reviewer spend, comment posting, reruns).
+- Per-invocation caps: ``--max-prs`` (default 3), ``--max-scan`` packet probes
+  (default 15), ``--budget-seconds`` wall clock (default 1800).
+- Identical-error breaker: 3 consecutive identical collect failures abort the
+  cycle (exit 2) — a systemic fault (CLI missing, auth broken) must not burn
+  the whole budget.
+- Never-post-on-lint-fail is enforced *inside* collect-evidence; this wrapper
+  additionally requires >=2 posted families before counting a PR as done.
+- Tier gating is enforced twice: by this wrapper's selection and again by
+  collect-evidence itself (Tier 3+/unknown always prepare-only).
+- Secrets guard: collect-evidence subprocesses run with
+  ``ARAGORA_SECRETS_STRICT=false`` and ``ARAGORA_USE_SECRETS_MANAGER=false``
+  forced, because API reviewer construction under strict MFA-gated AWS dies on
+  an interactive MFA prompt EOF (Lane V, run-20260609).
+- Fail-closed exits: 0 clean (including empty plan), 1 any failure,
+  2 breaker tripped.
+
+Opt-in wiring: ``scripts/run_merge_arbiter.sh`` runs this before the arbiter
+when ``ARAGORA_AUTO_EVIDENCE=1`` (default off, non-fatal for the arbiter).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from typing import Any, Callable
+
+DEFAULT_REPO = "synaptent/aragora"
+DEFAULT_FAMILIES = ("claude", "grok")
+SELECTABLE_STATUS = "needs_model_review_quorum"
+AUTO_POSTABLE_TIERS = {0, 1, 2}
+REQUIRED_FAMILIES = 2
+GH_TIMEOUT_SECONDS = 120
+PACKET_TIMEOUT_SECONDS = 300
+COLLECT_TIMEOUT_SECONDS = 1200
+RECONCILER_TIMEOUT_SECONDS = 600
+
+EXIT_OK = 0
+EXIT_FAILURES = 1
+EXIT_BREAKER = 2
+
+
+def _sanitized_env() -> dict[str, str]:
+    """Child env for collect-evidence: never enter the MFA-gated secrets path.
+
+    Lane V (run-20260609) saw ``scripts/collect_quorum_evidence.py`` API
+    reviewers crash under ``ARAGORA_SECRETS_STRICT=true`` with MFA-gated AWS:
+    ``create_agent`` triggered an interactive MFA prompt that EOFs in an
+    unattended run. Reviewer API keys come from the local environment instead.
+    """
+    env = dict(os.environ)
+    env["ARAGORA_SECRETS_STRICT"] = "false"
+    env["ARAGORA_USE_SECRETS_MANAGER"] = "false"
+    return env
+
+
+def latest_quorum_conclusion(pr_row: dict[str, Any]) -> str:
+    """Latest ``aragora-merge-quorum`` check conclusion at the PR head, or ``""``."""
+    best_key = ""
+    conclusion = ""
+    for check in pr_row.get("statusCheckRollup") or []:
+        if not isinstance(check, dict):
+            continue
+        workflow = str(check.get("workflowName") or "").lower()
+        name = str(check.get("name") or check.get("context") or "").lower()
+        if (
+            "merge-quorum" not in workflow
+            and "merge quorum" not in workflow
+            and "merge-quorum" not in name
+        ):
+            continue
+        key = str(check.get("completedAt") or check.get("startedAt") or "")
+        if key >= best_key:
+            best_key = key
+            conclusion = str(check.get("conclusion") or "").upper()
+    return conclusion
+
+
+def stage1_candidates(prs: list[dict[str, Any]]) -> list[int]:
+    """Ready (non-draft) PRs whose latest quorum check is not SUCCESS, oldest first."""
+    out: list[int] = []
+    for pr in prs:
+        if not isinstance(pr, dict) or pr.get("isDraft"):
+            continue
+        try:
+            number = int(pr["number"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        if latest_quorum_conclusion(pr) == "SUCCESS":
+            continue
+        out.append(number)
+    return sorted(out)
+
+
+def needs_evidence(entry: dict[str, Any]) -> bool:
+    """Whether a merge-packet entry is selectable for bounded auto-evidence."""
+    if not entry:
+        return False
+    if str(entry.get("status") or "").strip().lower() != SELECTABLE_STATUS:
+        return False
+    try:
+        tier = int(entry.get("tier"))
+    except (TypeError, ValueError):
+        return False  # unknown tier: fail safe, never auto-postable anyway
+    if tier not in AUTO_POSTABLE_TIERS:
+        return False
+    if entry.get("requires_human_risk_settlement"):
+        return False
+    if entry.get("unresolved_dissent"):
+        return False
+    families = entry.get("counted_model_families")
+    if families is None:
+        families = entry.get("counted_reviewer_ids") or []
+    return len(families) < REQUIRED_FAMILIES
+
+
+def parse_collect_output(returncode: int, stdout: str, stderr: str) -> dict[str, Any]:
+    """Normalize a collect-evidence ``--json`` run into the wrapper's result shape."""
+    try:
+        payload = json.loads(stdout or "{}")
+        if not isinstance(payload, dict):
+            raise ValueError("non-object payload")
+    except (json.JSONDecodeError, ValueError):
+        return {
+            "ok": False,
+            "counting_families": [],
+            "posted_families": [],
+            "error": f"unparseable collect-evidence output (exit {returncode}): "
+            f"{(stderr or stdout or '').strip()[:200]}",
+        }
+    counting = list(payload.get("counting_families") or [])
+    posted = list(payload.get("posted_families") or [])
+    error = str(payload.get("error") or "")
+    post_errors = list(payload.get("post_errors") or [])
+    ok = returncode == 0 and len(counting) >= REQUIRED_FAMILIES and not error
+    if not ok and not error:
+        problems = [
+            f"{item.get('family')}: {', '.join(item.get('problems') or [])}"
+            for item in payload.get("items") or []
+            if isinstance(item, dict) and not item.get("would_count")
+        ]
+        failures = [
+            f"{item.get('family')}: {item.get('error')}"
+            for item in payload.get("failures") or []
+            if isinstance(item, dict)
+        ]
+        error = "; ".join(["<2 counting families"] + failures + problems + post_errors)
+    return {"ok": ok, "counting_families": counting, "posted_families": posted, "error": error}
+
+
+# --- Default (real) I/O callables --------------------------------------------
+
+
+def _gh_pr_list(repo: str, fields: str, limit: int) -> list[dict[str, Any]] | None:
+    try:
+        proc = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--repo",
+                repo,
+                "--state",
+                "open",
+                "--json",
+                fields,
+                "--limit",
+                str(limit),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=GH_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return None
+    try:
+        payload = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, list) else None
+
+
+def default_list_prs(repo: str) -> list[dict[str, Any]]:
+    """Open-PR listing with graceful degradation.
+
+    ``statusCheckRollup`` over many PRs 504s GitHub's GraphQL endpoint
+    (observed live at ``--limit 50``), so try shrinking pages, then fall back
+    to a light listing without rollups — stage 1 then only prunes drafts and
+    the canonical stage-2 probe (bounded by ``--max-scan``) carries selection.
+    Fails closed with a clean error when even the light listing is down.
+    """
+    for limit in (100, 50, 30):
+        rows = _gh_pr_list(repo, "number,isDraft,statusCheckRollup", limit)
+        if rows is not None:
+            return rows
+    rows = _gh_pr_list(repo, "number,isDraft", 200)
+    if rows is not None:
+        return rows
+    raise RuntimeError(f"gh pr list failed for {repo} (heavy and light listings)")
+
+
+def default_fetch_packet(repo: str, pr: int) -> dict[str, Any]:
+    """Canonical per-PR probe: ``review-queue merge-packet --pr N --json``."""
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "aragora.cli.main",
+                "review-queue",
+                "merge-packet",
+                "--pr",
+                str(pr),
+                "--repo",
+                repo,
+                "--json",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=PACKET_TIMEOUT_SECONDS,
+            env=_sanitized_env(),
+        )
+    except subprocess.TimeoutExpired:
+        return {}
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return {}
+    try:
+        payload = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return {}
+    if isinstance(payload, dict):
+        entries = payload.get("entries")
+        entries = entries if isinstance(entries, list) else [payload]
+    elif isinstance(payload, list):
+        entries = payload
+    else:
+        return {}
+    for entry in entries:
+        if isinstance(entry, dict) and str(entry.get("pr_number")) == str(pr):
+            return entry
+    return {}
+
+
+def default_run_collect(
+    repo: str, families: tuple[str, ...], pr: int, apply: bool
+) -> dict[str, Any]:
+    cmd = [
+        sys.executable,
+        "-m",
+        "aragora.cli.main",
+        "review-queue",
+        "collect-evidence",
+        "--pr",
+        str(pr),
+        "--repo",
+        repo,
+        "--reviewers",
+        *families,
+        "--json",
+    ]
+    if apply:
+        cmd.append("--apply")
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=COLLECT_TIMEOUT_SECONDS,
+            env=_sanitized_env(),
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            "ok": False,
+            "counting_families": [],
+            "posted_families": [],
+            "error": f"collect-evidence timed out after {COLLECT_TIMEOUT_SECONDS}s",
+        }
+    return parse_collect_output(proc.returncode, proc.stdout, proc.stderr)
+
+
+def default_run_reconciler(repo: str) -> int:
+    script = os.path.join(os.path.dirname(os.path.abspath(__file__)), "quorum_rerun_reconciler.py")
+    try:
+        proc = subprocess.run(
+            [sys.executable, script, "--repo", repo, "--apply"],
+            timeout=RECONCILER_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return 1
+    return proc.returncode
+
+
+# --- Orchestrator --------------------------------------------------------------
+
+
+def run_cycle(
+    *,
+    list_prs: Callable[[], list[dict[str, Any]]],
+    fetch_packet: Callable[[int], dict[str, Any]],
+    run_collect: Callable[[int, bool], dict[str, Any]],
+    run_reconciler: Callable[[], int],
+    apply: bool,
+    max_prs: int,
+    max_scan: int,
+    budget_seconds: float,
+    breaker_threshold: int,
+    clock: Callable[[], float] = time.monotonic,
+    log: Callable[[str], None] = print,
+) -> dict[str, Any]:
+    """Plan and (with ``apply``) execute one bounded auto-evidence cycle."""
+    started = clock()
+
+    def over_budget() -> bool:
+        return clock() - started > budget_seconds
+
+    summary: dict[str, Any] = {
+        "mode": "apply" if apply else "dry-run",
+        "plan": [],
+        "posted_prs": [],
+        "failed_prs": [],
+        "breaker_tripped": False,
+        "budget_exhausted": False,
+        "reconciler_exit": None,
+        "exit_code": EXIT_OK,
+    }
+
+    candidates = stage1_candidates(list_prs())
+    probes = 0
+    for number in candidates:
+        if len(summary["plan"]) >= max_prs or probes >= max_scan:
+            break
+        if over_budget():
+            summary["budget_exhausted"] = True
+            break
+        probes += 1
+        entry = fetch_packet(number)
+        if not needs_evidence(entry):
+            continue
+        families = entry.get("counted_model_families") or entry.get("counted_reviewer_ids") or []
+        summary["plan"].append(
+            {
+                "pr": number,
+                "tier": entry.get("tier"),
+                "status": entry.get("status"),
+                "counted_families": list(families),
+            }
+        )
+
+    for item in summary["plan"]:
+        log(json.dumps({**item, "mode": summary["mode"]}))
+    if not summary["plan"]:
+        log(json.dumps({"plan": "empty", "mode": summary["mode"]}))
+
+    if not apply:
+        return summary
+
+    identical_errors = 0
+    last_error = None
+    for item in summary["plan"]:
+        if over_budget():
+            summary["budget_exhausted"] = True
+            break
+        result = run_collect(item["pr"], True)
+        posted = list(result.get("posted_families") or [])
+        ok = bool(result.get("ok")) and len(posted) >= REQUIRED_FAMILIES
+        if ok:
+            summary["posted_prs"].append(item["pr"])
+            identical_errors = 0
+            last_error = None
+            log(json.dumps({"pr": item["pr"], "posted_families": posted, "result": "posted"}))
+            continue
+        if result.get("ok"):
+            # Collected fine but posted <2 families: not quorum evidence.
+            error = f"only {len(posted)} family posted ({', '.join(posted) or 'none'}); not quorum"
+        else:
+            error = str(result.get("error") or "collect failed")
+        summary["failed_prs"].append(item["pr"])
+        log(json.dumps({"pr": item["pr"], "result": "failed", "error": error[:300]}))
+        identical_errors = identical_errors + 1 if error == last_error else 1
+        last_error = error
+        if identical_errors >= breaker_threshold:
+            summary["breaker_tripped"] = True
+            log(
+                json.dumps(
+                    {
+                        "result": "breaker_tripped",
+                        "identical_errors": identical_errors,
+                        "error": error[:300],
+                    }
+                )
+            )
+            break
+
+    if summary["posted_prs"]:
+        summary["reconciler_exit"] = run_reconciler()
+        log(json.dumps({"reconciler_exit": summary["reconciler_exit"]}))
+
+    if summary["breaker_tripped"]:
+        summary["exit_code"] = EXIT_BREAKER
+    elif summary["failed_prs"] or (summary["reconciler_exit"] not in (None, 0)):
+        summary["exit_code"] = EXIT_FAILURES
+    return summary
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--repo", default=DEFAULT_REPO, help="GitHub repo owner/name")
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Run reviewers, post counting evidence, and rerun stale quorum checks "
+        "(default: dry-run plan only — nothing is spent or posted)",
+    )
+    parser.add_argument(
+        "--max-prs", type=int, default=3, help="Maximum PRs to produce evidence for (default: 3)"
+    )
+    parser.add_argument(
+        "--max-scan",
+        type=int,
+        default=15,
+        help="Maximum merge-packet probes per invocation (default: 15)",
+    )
+    parser.add_argument(
+        "--budget-seconds",
+        type=float,
+        default=1800.0,
+        help="Wall-clock budget; no new work starts past this (default: 1800)",
+    )
+    parser.add_argument(
+        "--breaker-threshold",
+        type=int,
+        default=3,
+        help="Consecutive identical collect failures that abort the cycle (default: 3)",
+    )
+    parser.add_argument(
+        "--families",
+        default=",".join(DEFAULT_FAMILIES),
+        help="Comma-separated reviewer model families (default: claude,grok)",
+    )
+    args = parser.parse_args(argv)
+
+    families = tuple(f.strip() for f in str(args.families).split(",") if f.strip())
+    if len(families) < REQUIRED_FAMILIES:
+        print(f"error: need >= {REQUIRED_FAMILIES} reviewer families", file=sys.stderr)
+        return EXIT_FAILURES
+
+    try:
+        summary = run_cycle(
+            list_prs=lambda: default_list_prs(args.repo),
+            fetch_packet=lambda pr: default_fetch_packet(args.repo, pr),
+            run_collect=lambda pr, apply: default_run_collect(args.repo, families, pr, apply),
+            run_reconciler=lambda: default_run_reconciler(args.repo),
+            apply=args.apply,
+            max_prs=max(0, args.max_prs),
+            max_scan=max(0, args.max_scan),
+            budget_seconds=args.budget_seconds,
+            breaker_threshold=max(1, args.breaker_threshold),
+        )
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return EXIT_FAILURES
+    print(
+        json.dumps(
+            {key: value for key, value in summary.items() if key != "plan"}
+            | {"planned_prs": [item["pr"] for item in summary["plan"]]}
+        )
+    )
+    return int(summary["exit_code"])
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_merge_arbiter.sh
+++ b/scripts/run_merge_arbiter.sh
@@ -11,6 +11,19 @@ source "${REPO_ROOT}/scripts/aragora_runtime.sh"
 PYTHON_BIN="$(resolve_aragora_python 'import pydantic; import aragora.cli.commands.swarm' 'merge-arbiter' 'merge-arbiter runtime')"
 
 cd "${REPO_ROOT}"
+
+# Opt-in bounded auto-evidence cycle (throughput lever 1, run-20260610 c07b).
+# Produces lint-validated two-family model-review evidence for ready Tier 0-2
+# PRs missing counted evidence, then re-runs stale quorum checks. Best-effort:
+# never blocks the arbiter. Default off until the operator flips
+# ARAGORA_AUTO_EVIDENCE=1 (mirrors the ARAGORA_QUORUM_RECONCILER pattern in
+# run_boss_cycle.sh).
+if [[ "${ARAGORA_AUTO_EVIDENCE:-0}" == "1" ]]; then
+    echo "Running bounded auto-evidence cycle (apply mode)..."
+    "${PYTHON_BIN}" scripts/auto_evidence_cycle.py --apply \
+        || echo "Auto-evidence cycle reported failures (non-fatal for the arbiter)." >&2
+fi
+
 echo "Starting swarm merge-arbiter..."
 echo "Using Python interpreter: ${PYTHON_BIN}"
 exec "${PYTHON_BIN}" -u -m aragora.cli.main swarm merge-arbiter "$@"

--- a/tests/scripts/test_auto_evidence_cycle.py
+++ b/tests/scripts/test_auto_evidence_cycle.py
@@ -415,6 +415,45 @@ def test_parse_collect_output_garbage_is_failure() -> None:
     assert result["error"]
 
 
+# --- Singleton lock (double-post guard) --------------------------------------------
+
+
+def test_cycle_lock_blocks_second_acquirer(tmp_path: Any) -> None:
+    lock = str(tmp_path / "cycle.lock")
+    release = cycle.acquire_cycle_lock(lock)
+    try:
+        try:
+            cycle.acquire_cycle_lock(lock)
+        except cycle.CycleLockHeld:
+            pass
+        else:
+            raise AssertionError("expected CycleLockHeld")
+    finally:
+        release()
+    # After release the lock is acquirable again.
+    cycle.acquire_cycle_lock(lock)()
+
+
+def test_cycle_lock_reclaims_stale_lock(tmp_path: Any) -> None:
+    lock = str(tmp_path / "cycle.lock")
+    cycle.acquire_cycle_lock(lock)  # crashed invocation: never released
+    fake_now = __import__("os").path.getmtime(lock) + 7201.0
+    release = cycle.acquire_cycle_lock(lock, now=lambda: fake_now)
+    release()
+
+
+def test_cycle_lock_fresh_lock_is_not_reclaimed(tmp_path: Any) -> None:
+    lock = str(tmp_path / "cycle.lock")
+    cycle.acquire_cycle_lock(lock)
+    fake_now = __import__("os").path.getmtime(lock) + 60.0
+    try:
+        cycle.acquire_cycle_lock(lock, now=lambda: fake_now)
+    except cycle.CycleLockHeld:
+        pass
+    else:
+        raise AssertionError("expected CycleLockHeld")
+
+
 # --- Listing degradation ----------------------------------------------------------
 
 

--- a/tests/scripts/test_auto_evidence_cycle.py
+++ b/tests/scripts/test_auto_evidence_cycle.py
@@ -1,0 +1,475 @@
+"""Tests for ``scripts/auto_evidence_cycle.py`` (bounded auto-evidence cycle).
+
+All boundaries (PR listing, merge-packet probe, collect-evidence runner,
+reconciler runner, clock) are injected; no test touches the network or spawns
+a subprocess.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _load_module(script_name: str) -> Any:
+    here = Path(__file__).resolve()
+    script_path = here.parents[2] / "scripts" / script_name
+    spec = importlib.util.spec_from_file_location(f"{script_name}_under_test", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load spec for {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+cycle = _load_module("auto_evidence_cycle.py")
+
+
+def _quorum_check(conclusion: str = "FAILURE") -> dict[str, Any]:
+    return {
+        "workflowName": "aragora-merge-quorum",
+        "name": "merge-quorum",
+        "conclusion": conclusion,
+        "completedAt": "2026-06-10T10:00:00Z",
+    }
+
+
+def _pr(
+    number: int,
+    *,
+    draft: bool = False,
+    checks: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "number": number,
+        "isDraft": draft,
+        "statusCheckRollup": checks if checks is not None else [_quorum_check()],
+    }
+
+
+def _entry(
+    pr: int,
+    *,
+    status: str = "needs_model_review_quorum",
+    tier: int | None = 1,
+    families: list[str] | None = None,
+    human: bool = False,
+    dissent: bool = False,
+) -> dict[str, Any]:
+    return {
+        "pr_number": pr,
+        "status": status,
+        "tier": tier,
+        "counted_model_families": families or [],
+        "requires_human_risk_settlement": human,
+        "unresolved_dissent": dissent,
+    }
+
+
+class CollectRecorder:
+    """Injected collect-evidence runner that records calls."""
+
+    def __init__(self, results: dict[int, dict[str, Any]] | None = None) -> None:
+        self.calls: list[tuple[int, bool]] = []
+        self.results = results or {}
+
+    def __call__(self, pr: int, apply: bool) -> dict[str, Any]:
+        self.calls.append((pr, apply))
+        return self.results.get(
+            pr,
+            {
+                "ok": True,
+                "counting_families": ["claude", "grok"],
+                "posted_families": ["claude", "grok"],
+                "error": "",
+            },
+        )
+
+
+class ReconcilerRecorder:
+    def __init__(self, returncode: int = 0) -> None:
+        self.calls = 0
+        self.returncode = returncode
+
+    def __call__(self) -> int:
+        self.calls += 1
+        return self.returncode
+
+
+def _run(
+    prs: list[dict[str, Any]],
+    packets: dict[int, dict[str, Any]],
+    *,
+    apply: bool = False,
+    max_prs: int = 3,
+    max_scan: int = 30,
+    budget_seconds: float = 1200.0,
+    collect: CollectRecorder | None = None,
+    reconciler: ReconcilerRecorder | None = None,
+    clock: Any = None,
+    breaker_threshold: int = 3,
+) -> tuple[dict[str, Any], CollectRecorder, ReconcilerRecorder]:
+    collect = collect or CollectRecorder()
+    reconciler = reconciler or ReconcilerRecorder()
+    packet_calls: list[int] = []
+
+    def fetch_packet(pr: int) -> dict[str, Any]:
+        packet_calls.append(pr)
+        return packets.get(pr, {})
+
+    ticks = iter(range(100000)) if clock is None else clock
+    summary = cycle.run_cycle(
+        list_prs=lambda: prs,
+        fetch_packet=fetch_packet,
+        run_collect=collect,
+        run_reconciler=reconciler,
+        apply=apply,
+        max_prs=max_prs,
+        max_scan=max_scan,
+        budget_seconds=budget_seconds,
+        breaker_threshold=breaker_threshold,
+        clock=(lambda: next(ticks) * 0.001) if clock is None else clock,
+    )
+    summary["_packet_calls"] = packet_calls
+    return summary, collect, reconciler
+
+
+# --- Stage-1 selection -------------------------------------------------------
+
+
+def test_drafts_are_never_candidates() -> None:
+    summary, collect, _ = _run(
+        [_pr(1, draft=True), _pr(2)],
+        {2: _entry(2)},
+    )
+    assert [item["pr"] for item in summary["plan"]] == [2]
+    assert 1 not in summary["_packet_calls"]
+    assert collect.calls == []  # dry-run
+
+
+def test_quorum_success_heads_are_skipped_without_packet_probe() -> None:
+    summary, _, _ = _run(
+        [_pr(1, checks=[_quorum_check("SUCCESS")]), _pr(2)],
+        {2: _entry(2)},
+    )
+    assert summary["_packet_calls"] == [2]
+    assert [item["pr"] for item in summary["plan"]] == [2]
+
+
+def test_pr_without_quorum_check_is_still_probed() -> None:
+    summary, _, _ = _run([_pr(3, checks=[])], {3: _entry(3)})
+    assert summary["_packet_calls"] == [3]
+    assert [item["pr"] for item in summary["plan"]] == [3]
+
+
+def test_candidates_scanned_oldest_first() -> None:
+    summary, _, _ = _run(
+        [_pr(9), _pr(4), _pr(7)],
+        {4: _entry(4), 7: _entry(7), 9: _entry(9)},
+    )
+    assert summary["_packet_calls"] == [4, 7, 9]
+
+
+# --- Stage-2 selection (canonical merge-packet probe) -------------------------
+
+
+def test_satisfied_packets_are_not_selected() -> None:
+    summary, _, _ = _run(
+        [_pr(1), _pr(2)],
+        {1: _entry(1, status="satisfied", families=["claude", "grok"]), 2: _entry(2)},
+    )
+    assert [item["pr"] for item in summary["plan"]] == [2]
+
+
+def test_tier3_and_unknown_tier_are_never_selected() -> None:
+    summary, _, _ = _run(
+        [_pr(1), _pr(2), _pr(3)],
+        {1: _entry(1, tier=3), 2: _entry(2, tier=None), 3: _entry(3, tier=2)},
+    )
+    assert [item["pr"] for item in summary["plan"]] == [3]
+
+
+def test_human_settlement_and_dissent_are_never_selected() -> None:
+    summary, _, _ = _run(
+        [_pr(1), _pr(2), _pr(3)],
+        {1: _entry(1, human=True), 2: _entry(2, dissent=True), 3: _entry(3)},
+    )
+    assert [item["pr"] for item in summary["plan"]] == [3]
+
+
+def test_packet_with_two_counted_families_is_not_selected() -> None:
+    summary, _, _ = _run(
+        [_pr(1)],
+        {1: _entry(1, families=["claude", "grok"])},
+    )
+    assert summary["plan"] == []
+
+
+def test_empty_packet_probe_is_skipped_failsafe() -> None:
+    summary, _, _ = _run([_pr(1)], {1: {}})
+    assert summary["plan"] == []
+
+
+# --- Caps ---------------------------------------------------------------------
+
+
+def test_max_prs_caps_the_plan() -> None:
+    prs = [_pr(n) for n in (1, 2, 3, 4, 5)]
+    packets = {n: _entry(n) for n in (1, 2, 3, 4, 5)}
+    summary, _, _ = _run(prs, packets, max_prs=2)
+    assert [item["pr"] for item in summary["plan"]] == [1, 2]
+    # Probing stops once the plan is full.
+    assert summary["_packet_calls"] == [1, 2]
+
+
+def test_max_scan_caps_packet_probes() -> None:
+    prs = [_pr(n) for n in range(1, 11)]
+    packets = {n: _entry(n, status="satisfied", families=["claude", "grok"]) for n in range(1, 11)}
+    summary, _, _ = _run(prs, packets, max_scan=4)
+    assert len(summary["_packet_calls"]) == 4
+    assert summary["plan"] == []
+
+
+def test_budget_exhaustion_stops_scanning() -> None:
+    ticks = iter([0.0, 0.0, 10_000.0, 10_000.0, 10_000.0, 10_000.0, 10_000.0])
+    summary, collect, _ = _run(
+        [_pr(1), _pr(2)],
+        {1: _entry(1), 2: _entry(2)},
+        budget_seconds=60.0,
+        clock=lambda: next(ticks),
+    )
+    assert summary["budget_exhausted"] is True
+    assert collect.calls == []
+
+
+# --- Dry-run purity ------------------------------------------------------------
+
+
+def test_dry_run_never_collects_or_reconciles_and_exits_zero() -> None:
+    summary, collect, reconciler = _run([_pr(1)], {1: _entry(1)}, apply=False)
+    assert collect.calls == []
+    assert reconciler.calls == 0
+    assert summary["exit_code"] == 0
+    assert summary["mode"] == "dry-run"
+    assert [item["pr"] for item in summary["plan"]] == [1]
+
+
+# --- Apply path ----------------------------------------------------------------
+
+
+def test_apply_runs_collect_with_apply_then_reconciler_once() -> None:
+    summary, collect, reconciler = _run(
+        [_pr(1), _pr(2)],
+        {1: _entry(1), 2: _entry(2)},
+        apply=True,
+    )
+    assert collect.calls == [(1, True), (2, True)]
+    assert reconciler.calls == 1
+    assert summary["exit_code"] == 0
+    assert sorted(summary["posted_prs"]) == [1, 2]
+
+
+def test_lint_fail_counts_as_failure_and_skips_reconciler() -> None:
+    # collect-evidence returns ok=False when <2 families produce counting
+    # evidence; the wrapper must treat that as failure and never reconcile.
+    collect = CollectRecorder(
+        results={
+            1: {
+                "ok": False,
+                "counting_families": ["claude"],
+                "posted_families": [],
+                "error": "only 1 counting family",
+            },
+        }
+    )
+    summary, _, reconciler = _run([_pr(1)], {1: _entry(1)}, apply=True, collect=collect)
+    assert reconciler.calls == 0
+    assert summary["posted_prs"] == []
+    assert summary["exit_code"] == 1
+    assert summary["failed_prs"] == [1]
+
+
+def test_reconciler_failure_fails_closed() -> None:
+    reconciler = ReconcilerRecorder(returncode=1)
+    summary, _, rec = _run([_pr(1)], {1: _entry(1)}, apply=True, reconciler=reconciler)
+    assert rec.calls == 1
+    assert summary["exit_code"] == 1
+
+
+def test_identical_error_breaker_trips_after_threshold() -> None:
+    err = {
+        "ok": False,
+        "counting_families": [],
+        "posted_families": [],
+        "error": "claude CLI not found on PATH",
+    }
+    collect = CollectRecorder(results={1: err, 2: err, 3: err, 4: err})
+    summary, rec_collect, reconciler = _run(
+        [_pr(n) for n in (1, 2, 3, 4)],
+        {n: _entry(n) for n in (1, 2, 3, 4)},
+        apply=True,
+        max_prs=4,
+        collect=collect,
+        breaker_threshold=3,
+    )
+    assert len(rec_collect.calls) == 3  # stopped at the breaker, PR 4 untouched
+    assert summary["breaker_tripped"] is True
+    assert summary["exit_code"] == 2
+    assert reconciler.calls == 0
+
+
+def test_distinct_errors_do_not_trip_breaker() -> None:
+    collect = CollectRecorder(
+        results={
+            1: {"ok": False, "counting_families": [], "posted_families": [], "error": "error A"},
+            2: {"ok": False, "counting_families": [], "posted_families": [], "error": "error B"},
+            3: {"ok": False, "counting_families": [], "posted_families": [], "error": "error A"},
+        }
+    )
+    summary, rec_collect, _ = _run(
+        [_pr(n) for n in (1, 2, 3)],
+        {n: _entry(n) for n in (1, 2, 3)},
+        apply=True,
+        collect=collect,
+    )
+    assert len(rec_collect.calls) == 3
+    assert summary["breaker_tripped"] is False
+    assert summary["exit_code"] == 1
+
+
+def test_success_resets_breaker_counter() -> None:
+    err = {"ok": False, "counting_families": [], "posted_families": [], "error": "same"}
+    collect = CollectRecorder(results={1: err, 2: err})  # 3 succeeds by default
+    summary, rec_collect, _ = _run(
+        [_pr(n) for n in (1, 2, 3, 4)],
+        {n: _entry(n) for n in (1, 2, 3, 4)},
+        apply=True,
+        max_prs=4,
+        collect=collect,
+        breaker_threshold=3,
+    )
+    assert len(rec_collect.calls) == 4
+    assert summary["breaker_tripped"] is False
+
+
+def test_partial_post_is_a_failure() -> None:
+    # One posted family is not quorum evidence; do not treat it as success.
+    collect = CollectRecorder(
+        results={
+            1: {
+                "ok": True,
+                "counting_families": ["claude", "grok"],
+                "posted_families": ["claude"],
+                "error": "",
+            },
+        }
+    )
+    summary, _, reconciler = _run([_pr(1)], {1: _entry(1)}, apply=True, collect=collect)
+    assert summary["posted_prs"] == []
+    assert summary["failed_prs"] == [1]
+    assert summary["exit_code"] == 1
+    assert reconciler.calls == 0
+
+
+# --- Secrets guard --------------------------------------------------------------
+
+
+def test_sanitized_env_forces_secrets_off(monkeypatch: Any) -> None:
+    # Lane V (run-20260609): collect-evidence API reviewers crash under
+    # ARAGORA_SECRETS_STRICT=true with MFA-gated AWS (interactive prompt EOF).
+    monkeypatch.setenv("ARAGORA_SECRETS_STRICT", "true")
+    monkeypatch.setenv("ARAGORA_USE_SECRETS_MANAGER", "true")
+    env = cycle._sanitized_env()
+    assert env["ARAGORA_SECRETS_STRICT"] == "false"
+    assert env["ARAGORA_USE_SECRETS_MANAGER"] == "false"
+
+
+# --- Result parsing --------------------------------------------------------------
+
+
+def test_parse_collect_output_success() -> None:
+    payload = {
+        "mode": "collect_evidence",
+        "counting_families": ["claude", "grok"],
+        "posted_families": ["claude", "grok"],
+        "post_errors": [],
+    }
+    result = cycle.parse_collect_output(0, __import__("json").dumps(payload), "")
+    assert result["ok"] is True
+    assert result["posted_families"] == ["claude", "grok"]
+
+
+def test_parse_collect_output_failure_uses_error_field() -> None:
+    payload = {"mode": "collect_evidence", "error": "could not resolve head SHA"}
+    result = cycle.parse_collect_output(1, __import__("json").dumps(payload), "")
+    assert result["ok"] is False
+    assert "could not resolve head SHA" in result["error"]
+
+
+def test_parse_collect_output_garbage_is_failure() -> None:
+    result = cycle.parse_collect_output(0, "not json", "boom")
+    assert result["ok"] is False
+    assert result["error"]
+
+
+# --- Listing degradation ----------------------------------------------------------
+
+
+def test_list_prs_falls_back_to_light_listing(monkeypatch: Any) -> None:
+    # statusCheckRollup over many PRs 504s GitHub GraphQL (observed live);
+    # the lister must degrade to a light listing instead of crashing.
+    calls: list[tuple[str, int]] = []
+
+    def fake_gh_pr_list(repo: str, fields: str, limit: int) -> list[dict[str, Any]] | None:
+        calls.append((fields, limit))
+        if "statusCheckRollup" in fields:
+            return None  # heavy query 504s at every page size
+        return [{"number": 5, "isDraft": False}]
+
+    monkeypatch.setattr(cycle, "_gh_pr_list", fake_gh_pr_list)
+    rows = cycle.default_list_prs("owner/repo")
+    assert rows == [{"number": 5, "isDraft": False}]
+    assert calls[-1] == ("number,isDraft", 200)
+    assert [limit for fields, limit in calls if "statusCheckRollup" in fields] == [100, 50, 30]
+
+
+def test_list_prs_fails_closed_when_all_listings_fail(monkeypatch: Any) -> None:
+    monkeypatch.setattr(cycle, "_gh_pr_list", lambda repo, fields, limit: None)
+    try:
+        cycle.default_list_prs("owner/repo")
+    except RuntimeError as exc:
+        assert "gh pr list failed" in str(exc)
+    else:
+        raise AssertionError("expected RuntimeError")
+
+
+def test_list_prs_prefers_first_successful_heavy_page(monkeypatch: Any) -> None:
+    def fake_gh_pr_list(repo: str, fields: str, limit: int) -> list[dict[str, Any]] | None:
+        if "statusCheckRollup" in fields and limit == 30:
+            return [{"number": 7, "isDraft": False, "statusCheckRollup": []}]
+        if "statusCheckRollup" in fields:
+            return None
+        raise AssertionError("light listing should not be reached")
+
+    monkeypatch.setattr(cycle, "_gh_pr_list", fake_gh_pr_list)
+    rows = cycle.default_list_prs("owner/repo")
+    assert rows[0]["number"] == 7
+
+
+# --- Quorum-check rollup helper ---------------------------------------------------
+
+
+def test_latest_quorum_conclusion_uses_latest_row() -> None:
+    checks = [
+        {**_quorum_check("FAILURE"), "completedAt": "2026-06-10T10:00:00Z"},
+        {**_quorum_check("SUCCESS"), "completedAt": "2026-06-10T11:00:00Z"},
+    ]
+    assert cycle.latest_quorum_conclusion({"statusCheckRollup": checks}) == "SUCCESS"
+
+
+def test_latest_quorum_conclusion_missing() -> None:
+    assert cycle.latest_quorum_conclusion({"statusCheckRollup": []}) == ""
+    assert cycle.latest_quorum_conclusion({}) == ""


### PR DESCRIPTION
## Summary

Bounded auto-evidence cycle so ready PRs get model-review evidence without a human coordinator (**throughput lever 1**, operator instruction of 2026-06-10, run-20260610 lane R2/c07b).

**Tier: 2**

- `scripts/auto_evidence_cycle.py` (new, standalone): selects up to `--max-prs` (default 3) open **ready** (non-draft) Tier 0-2 PRs missing counted two-family evidence, produces evidence via the proven `review-queue collect-evidence` pipeline, then invokes `scripts/quorum_rerun_reconciler.py --apply` so stale quorum checks re-run.
- **Probe (documented, cheapest reliable)**: stage 1 = one `gh pr list` call (drafts + quorum-SUCCESS heads pruned; degrades page size on GraphQL 504, falls back to a light listing); stage 2 = canonical `review-queue merge-packet --pr N --json` (the gate's own parser) confirming `needs_model_review_quorum`, Tier 0-2, <2 counted families, no human-risk settlement, no unresolved dissent.
- **Lint before post**: `collect-evidence` validates every composed comment with `review-queue evidence-lint` *before* posting; the wrapper additionally requires >=2 posted families per PR before invoking the reconciler.
- **Safety**: dry-run default (plan only, zero spend/posts); `--apply` gates all mutations; per-invocation caps (`--max-prs`, `--max-scan` 15, `--budget-seconds` 1800); identical-error breaker (3) exits 2; fail-closed exit 1 on any failure; secrets guard forces `ARAGORA_SECRETS_STRICT=false` / `ARAGORA_USE_SECRETS_MANAGER=false` in child processes so API reviewers never hit the MFA-gated interactive prompt EOF (Lane V, run-20260609).
- **Opt-in wiring**: `scripts/run_merge_arbiter.sh` runs the cycle before the arbiter only when `ARAGORA_AUTO_EVIDENCE=1` (default off, non-fatal) — mirrors the `ARAGORA_QUORUM_RECONCILER` pattern in `run_boss_cycle.sh`. No workflow files, `review_queue.py`, or `settle_*.py` touched.

## Validation

- 29 offline tests, injected boundaries, no network (`tests/scripts/test_auto_evidence_cycle.py`): selection (ready-only, missing-evidence-only, tier/dissent/human-settlement gates), caps, dry-run purity, breaker, lint-fail handling, listing degradation, secrets guard.
- Full `tests/scripts/` suite: 2702 passed; 7 failures are pre-existing on main (reproduced on untouched main checkout), unrelated.
- Live dry-run against synaptent/aragora: exit 0, read-only, clean JSON plan output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
