### PR TITLE
fix(skills): elves-aragora v0.2.1 — lanes finish synchronously (no background watchers)

### DIFF
--- a/.agents/skills/elves-aragora/SKILL.md
+++ b/.agents/skills/elves-aragora/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Works with Codex (.agents/skills) and Claude Code (.claude/skills
 metadata:
   author: Synaptent (aragora) — forked from aigorahub/elves (MIT)
   upstream: https://github.com/aigorahub/elves
-  version: "0.2.0-aragora"
+  version: "0.2.1-aragora"
   argument-hint: Path to plan file, or plan text directly.
 ---
 
@@ -95,6 +95,13 @@ immediately and surface to the user when any of these fire:
   --base main --force-new --print-path`); lanes must touch file-disjoint surfaces; only the
   coordinator writes the execution log / survival guide and records settlements. Within any
   one worktree, a surprise tip move = collision, not diverge → stop that lane.
+- **Lanes finish synchronously — never via background watchers.** A lane's background
+  monitors/waiters die with the lane; "standing by for the watcher to re-invoke me" is lane
+  death (observed 4× in run-20260610: lanes ended mid-settlement and required manual
+  resumption). Wait for external state with bounded *foreground* until-loops
+  (`until <check>; do sleep 20; done`, hard-capped), and register every lane in the run's
+  lane ledger (`.aragora/run-<id>/lanes/<lane>.json`: lane, agent_id, branch, brief,
+  launched_at, status) at launch so the sentinel's liveness check can detect silent death.
 - No destructive git (`reset --hard`, `checkout .`, `clean -fd`, `push --force`, rebase on shared).
 - Receipts are mandatory per batch. A batch with no verified receipt is not complete. Store
   receipts under the run-scoped dir `.aragora/run-<run-id>/receipts/` (legacy


### PR DESCRIPTION
## Summary
One-rule addition driven by 4 live lane deaths in run-20260610: lanes ended mid-settlement after delegating completion to background monitors that die with the lane, each requiring manual resumption. New non-negotiable: **finish synchronously with bounded foreground until-loops; register every lane in the run's lane ledger** (.aragora/run-<id>/lanes/<lane>.json) so the sentinel's lane_liveness check (in build, Lane W) can detect silent death.

## Dogfood gate
Two-family review (grok + mistral PASS, zero dissent; probed rule conflicts, polling-cap sufficiency, ledger schema). Receipts VALID: .aragora/run-20260610/receipts/d03_skill021_{grok,mistral}.json (head: f8792ffe61c3). Tier: 2 (agent behavior contract).

Part of run-20260610 shift 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)