### PR TITLE
fix(benchmarks): report malformed score fixtures

### DIFF
--- a/scripts/score_benchmark.py
+++ b/scripts/score_benchmark.py
@@ -106,12 +106,27 @@ def score_fixtures(fixtures_dir: Path) -> tuple[bool, str]:
     seen_examples: dict[str, str] = {}
 
     for fixture_file in fixture_files:
-        with fixture_file.open() as fh:
-            examples = json.load(fh)
-
         file_pass = 0
         file_fail = 0
         file_errors: list[str] = []
+
+        try:
+            with fixture_file.open(encoding="utf-8") as fh:
+                examples = json.load(fh)
+        except OSError as exc:
+            total_examples += 1
+            total_fail += 1
+            lines.append(f"  FAIL  {fixture_file.name} (0/1)")
+            lines.append(f"  [root] could not read fixture: {exc}")
+            continue
+        except json.JSONDecodeError as exc:
+            total_examples += 1
+            total_fail += 1
+            lines.append(f"  FAIL  {fixture_file.name} (0/1)")
+            lines.append(
+                f"  [root] fixture must be valid JSON: line {exc.lineno} column {exc.colno}"
+            )
+            continue
 
         if not isinstance(examples, list):
             total_fail += 1

--- a/tests/scripts/test_score_benchmark.py
+++ b/tests/scripts/test_score_benchmark.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -95,3 +96,40 @@ def test_score_fixtures_rejects_duplicate_examples_across_files(
 
     assert all_passed is False
     assert "duplicate benchmark example also seen in a.json[0]" in report
+
+
+def test_score_fixtures_reports_malformed_fixture_json(tmp_path: Path) -> None:
+    fixtures_dir = tmp_path / "fixtures"
+    fixtures_dir.mkdir()
+    (fixtures_dir / "broken.json").write_text("{not json}\n", encoding="utf-8")
+
+    all_passed, report = score_benchmark.score_fixtures(fixtures_dir)
+
+    assert all_passed is False
+    assert "Terminal-truth benchmark: FAIL" in report
+    assert "FAIL  broken.json (0/1)" in report
+    assert "fixture must be valid JSON: line 1 column 2" in report
+    assert "Examples: 1" in report
+    assert "Fail: 1" in report
+
+
+def test_main_returns_failure_for_malformed_fixture_json(tmp_path: Path) -> None:
+    fixtures_dir = tmp_path / "fixtures"
+    fixtures_dir.mkdir()
+    (fixtures_dir / "broken.json").write_text("{not json}\n", encoding="utf-8")
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(Path("scripts/score_benchmark.py")),
+            "--fixtures-dir",
+            str(fixtures_dir),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 1
+    assert "fixture must be valid JSON" in proc.stdout
+    assert "Traceback" not in proc.stderr


### PR DESCRIPTION
## Summary
- report malformed terminal-truth benchmark fixture JSON as a benchmark failure instead of crashing with a traceback
- keep missing/empty fixture directory behavior unchanged while adding focused regression coverage for score fixture JSON parse failures

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_score_benchmark.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/score_benchmark.py tests/scripts/test_score_benchmark.py
- git diff --check origin/main...HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD