### PR TITLE
fix(reports): fail closed on malformed contract drift plans

### DIFF
--- a/scripts/generate_contract_drift_issue_plan.py
+++ b/scripts/generate_contract_drift_issue_plan.py
@@ -11,10 +11,20 @@ from pathlib import Path
 from typing import Any
 
 
+class BacklogJsonError(RuntimeError):
+    """Raised when the contract drift backlog cannot be trusted."""
+
+
 def _load(path: Path) -> dict[str, Any]:
     if not path.exists():
         return {}
-    return json.loads(path.read_text())
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise BacklogJsonError(f"Cannot load contract drift backlog {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise BacklogJsonError(f"Contract drift backlog must be a JSON object: {path}")
+    return payload
 
 
 def _issue_title(ticket: dict[str, Any]) -> str:
@@ -165,7 +175,10 @@ def main() -> int:
     parser.add_argument("--max-tickets", type=int, default=40, help="Maximum issue seeds")
     args = parser.parse_args()
 
-    backlog = _load(Path(args.backlog_json))
+    try:
+        backlog = _load(Path(args.backlog_json))
+    except BacklogJsonError as exc:
+        raise SystemExit(str(exc)) from None
     if not backlog:
         raise SystemExit(f"Backlog file missing or empty: {args.backlog_json}")
 

--- a/tests/scripts/test_generate_contract_drift_issue_plan.py
+++ b/tests/scripts/test_generate_contract_drift_issue_plan.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -85,3 +86,60 @@ def test_generates_issue_plan_outputs(monkeypatch, tmp_path: Path):
     assert plan["waves"]
     first_ticket = plan["waves"][0]["tickets"][0]
     assert "Contract drift:" in first_ticket["issue_title"]
+
+
+def test_load_rejects_malformed_backlog_json(tmp_path: Path) -> None:
+    backlog_path = tmp_path / "backlog.json"
+    backlog_path.write_text("{not json}\n", encoding="utf-8")
+
+    try:
+        issue_plan._load(backlog_path)
+    except issue_plan.BacklogJsonError as exc:
+        assert "Cannot load contract drift backlog" in str(exc)
+        assert str(backlog_path) in str(exc)
+        assert "line 1 column 2" in str(exc)
+    else:  # pragma: no cover - defensive assertion
+        raise AssertionError("malformed backlog JSON should fail closed")
+
+
+def test_load_rejects_non_object_backlog_json(tmp_path: Path) -> None:
+    backlog_path = tmp_path / "backlog.json"
+    backlog_path.write_text(json.dumps(["CD-001"]) + "\n", encoding="utf-8")
+
+    try:
+        issue_plan._load(backlog_path)
+    except issue_plan.BacklogJsonError as exc:
+        assert "must be a JSON object" in str(exc)
+        assert str(backlog_path) in str(exc)
+    else:  # pragma: no cover - defensive assertion
+        raise AssertionError("non-object backlog JSON should fail closed")
+
+
+def test_main_reports_malformed_backlog_without_writing_outputs(tmp_path: Path) -> None:
+    backlog_path = tmp_path / "backlog.json"
+    md_out = tmp_path / "issue_plan.md"
+    json_out = tmp_path / "issue_plan.json"
+    backlog_path.write_text("{not json}\n", encoding="utf-8")
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(Path("scripts/generate_contract_drift_issue_plan.py")),
+            "--backlog-json",
+            str(backlog_path),
+            "--markdown-out",
+            str(md_out),
+            "--json-out",
+            str(json_out),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 1
+    assert "Cannot load contract drift backlog" in proc.stderr
+    assert "line 1 column 2" in proc.stderr
+    assert "Traceback" not in proc.stderr
+    assert not md_out.exists()
+    assert not json_out.exists()


### PR DESCRIPTION
## Summary
- report malformed contract drift backlog JSON as a bounded issue-plan input failure instead of a traceback
- reject non-object backlog payloads before rendering plan artifacts
- add focused regression coverage that verifies malformed input writes no report outputs

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_generate_contract_drift_issue_plan.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/generate_contract_drift_issue_plan.py tests/scripts/test_generate_contract_drift_issue_plan.py
- git diff --check origin/main...HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD