### PR TITLE
feat(ops): lane-liveness + api-degradation sentinel checks, lane janitor, publisher retry

### DIFF
--- a/docs/runbooks/LANE_RESILIENCE.md
+++ b/docs/runbooks/LANE_RESILIENCE.md
@@ -1,0 +1,70 @@
+# Lane Resilience Runbook
+
+Two live failure classes from 2026-06-10/11, now systematically detected by
+`scripts/fleet_sentinel.py` and remediated (bounded) by `scripts/lane_janitor.py`.
+
+## Failure class A — silent lane death
+
+Coordinator-spawned lanes die at setup, leaving `status=in_progress` ledgers
+(`.aragora/run-*/lanes/<lane>.json`) and empty branches on origin that nobody
+notices (incident: `elves/run-20260610-c06/c07/c08-*`, found only by a manual
+morning sweep).
+
+**Detection** — sentinel check `lane_liveness` breaches when:
+
+- a ledger entry is `in_progress`, older than `--lane-max-age-hours` (default 3),
+  and its branch has **zero commits ahead of origin/main** (or is absent); or
+- any origin branch matching `elves/*` / `aragora/boss*` is zero-commits-ahead
+  with a tip older than 24h (ledger-less orphan sweep).
+
+**What the breach means:** a lane burned its setup window and produced nothing
+durable. Its work is NOT lost (there was none); it needs relaunch.
+
+**One-command fix:**
+
+```bash
+python3 scripts/lane_janitor.py            # dry-run: show the plan
+python3 scripts/lane_janitor.py --apply    # mark dead + queue + sweep branches
+```
+
+The janitor (a) marks dead ledgers (`status=dead`, `detected_at`), (b) writes
+`.aragora/run-*/lanes/RELAUNCH_QUEUE.md` listing dead lanes with their briefs,
+and (c) deletes remote branches only when zero-commits-ahead AND ledger-dead
+(or ledger-less orphans in lane namespaces) AND older than `--branch-ttl-hours`
+(default 24). **A branch with any unique commit is never deleted.**
+
+**Relaunch-queue convention:** the janitor never relaunches. The coordinator /
+operator reads `RELAUNCH_QUEUE.md` and relaunches each lane with its original
+brief, checking off entries as they go.
+
+## Failure class B — external API degradation
+
+GitHub GraphQL 502/504 streaks stall the publisher's branch pass; the cached
+`github_health` flips `auth_ok:false`, previously breaching the sentinel
+without distinguishing a transient blip from a persistent outage.
+
+**Detection** — sentinel check `github_api_health` combines a live probe
+(`gh api rate_limit`) with the trailing failed-pass streak in
+`.aragora/overnight/codex-automation-publisher.log`:
+
+- **breach** only on persistent degradation: probe fails AND streak >=
+  `--persist-threshold` (default 3 consecutive failed passes);
+- transient blips (short streak, or probe already recovered) stay
+  visible-but-quiet: streak count + last error class (e.g. `HTTP 504`) are
+  recorded in the check detail and sentinel ledger, exit stays green;
+- **unknown** when the log is unreadable or the probe cannot run.
+
+**What the breach means:** GitHub has been failing the publisher repeatedly AND
+is still down right now. Check <https://githubstatus.com>; the publisher's
+bounded retry (2 retries, 30s/60s backoff per branch pass, spend caps enforced
+inside each attempt) rides out anything shorter.
+
+## Routine invocations
+
+```bash
+python3 scripts/fleet_sentinel.py                  # all checks, appends ledger
+python3 scripts/fleet_sentinel.py --no-ledger --checks lane_liveness,github_api_health
+python3 scripts/lane_janitor.py --json             # machine-readable dry-run
+```
+
+Exit codes (sentinel): 0 ok, 1 breach, 2 unknown/blind (outranks breach).

--- a/scripts/fleet_sentinel.py
+++ b/scripts/fleet_sentinel.py
@@ -27,13 +27,16 @@ Contract:
 from __future__ import annotations
 
 import argparse
+import glob as glob_module
 import json
 import plistlib
+import re
 import shlex
 import shutil
 import subprocess
 import sys
 from datetime import datetime, timezone
+from fnmatch import fnmatch
 from pathlib import Path
 from typing import Any, Callable
 
@@ -47,7 +50,14 @@ ALL_CHECKS = (
     "checkout_invariant",
     "outbox_depth",
     "disk_free",
+    "lane_liveness",
+    "github_api_health",
 )
+
+# Branch namespaces owned by autonomous lanes; only these are eligible for the
+# ledger-less orphan-branch sweep (failure class A, 2026-06-10/11: coordinator
+# lanes died at setup leaving empty elves/run-* branches nobody noticed).
+ORPHAN_BRANCH_PATTERNS = ("elves/*", "aragora/boss*")
 
 
 def parse_iso(value: str) -> datetime:
@@ -226,6 +236,260 @@ def check_disk_free(
 
 
 # ---------------------------------------------------------------------------
+# lane_liveness (failure class A — silent lane death, 2026-06-10/11)
+# ---------------------------------------------------------------------------
+
+
+def _default_remote_heads(repo: Path) -> dict[str, str]:
+    """``git ls-remote --heads origin`` → ``{branch: sha}``."""
+    proc = subprocess.run(  # noqa: S603
+        ["git", "-C", str(repo), "ls-remote", "--heads", "origin"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=True,
+    )
+    heads: dict[str, str] = {}
+    for line in proc.stdout.splitlines():
+        sha, _, ref = line.partition("\t")
+        prefix = "refs/heads/"
+        if ref.startswith(prefix):
+            heads[ref[len(prefix) :].strip()] = sha.strip()
+    return heads
+
+
+def _default_ahead_counter(repo: Path) -> Callable[[str], int | None]:
+    """Commits ahead of origin/main for a sha; None when unresolvable.
+
+    A zero-ahead branch tip is by definition an ancestor of origin/main and
+    therefore present locally once origin/main is fetched.  An unresolvable
+    sha thus means the branch carries unfetched unique commits — callers must
+    treat None as "has commits" (never as empty).
+    """
+
+    def count(sha: str) -> int | None:
+        proc = subprocess.run(  # noqa: S603
+            ["git", "-C", str(repo), "rev-list", "--count", f"origin/main..{sha}"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        if proc.returncode != 0:
+            return None
+        try:
+            return int(proc.stdout.strip())
+        except ValueError:
+            return None
+
+    return count
+
+
+def _default_commit_dater(repo: Path) -> Callable[[str], datetime | None]:
+    def commit_date(sha: str) -> datetime | None:
+        proc = subprocess.run(  # noqa: S603
+            ["git", "-C", str(repo), "log", "-1", "--format=%cI", sha],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        out = proc.stdout.strip()
+        if proc.returncode != 0 or not out:
+            return None
+        try:
+            return parse_iso(out)
+        except ValueError:
+            return None
+
+    return commit_date
+
+
+def check_lane_liveness(
+    lanes_glob: str,
+    *,
+    lane_max_age_hours: float,
+    orphan_age_hours: float,
+    now: datetime,
+    remote_heads: Callable[[], dict[str, str]],
+    ahead_counter: Callable[[str], int | None],
+    commit_dater: Callable[[str], datetime | None],
+) -> CheckResult:
+    """Detect silently dead lanes and ledger-less orphan branches.
+
+    Rule 1 (ledger): a lane-ledger entry (``.aragora/run-*/lanes/<lane>.json``)
+    with ``status=in_progress``, ``launched_at`` older than
+    ``lane_max_age_hours``, whose branch has zero commits ahead of origin/main
+    (or is absent from origin entirely) is a dead lane — it burned its setup
+    window and produced nothing durable.
+
+    Rule 2 (orphan sweep): any origin branch matching
+    ``ORPHAN_BRANCH_PATTERNS`` with zero commits ahead of origin/main whose
+    tip commit is older than ``orphan_age_hours`` is an orphan — a lane died
+    before its first commit and left no ledger to read.
+    """
+    name = "lane_liveness"
+    try:
+        heads = remote_heads()
+    except Exception as exc:  # noqa: BLE001 - git failure means we are blind
+        return _result(
+            name, "unknown", f"could not list origin heads: {exc.__class__.__name__}: {exc}"
+        )
+    unreadable: list[str] = []
+    problems: list[str] = []
+    in_progress = 0
+    ledger_files = sorted(glob_module.glob(str(Path(lanes_glob) / "*.json")))
+    for ledger_file in ledger_files:
+        try:
+            entry = json.loads(Path(ledger_file).read_text())
+            lane = str(entry["lane"])
+            status = str(entry.get("status", ""))
+            launched_at = parse_iso(str(entry["launched_at"]))
+        except (OSError, json.JSONDecodeError, KeyError, ValueError, TypeError) as exc:
+            unreadable.append(f"{ledger_file} ({exc.__class__.__name__})")
+            continue
+        if status != "in_progress":
+            continue
+        in_progress += 1
+        age_hours = (now - launched_at).total_seconds() / 3600.0
+        if age_hours <= lane_max_age_hours:
+            continue
+        branch = str(entry.get("branch", ""))
+        sha = heads.get(branch)
+        if sha is None:
+            problems.append(
+                f"lane {lane}: in_progress {age_hours:.1f}h (max {lane_max_age_hours}h), "
+                f"branch {branch} absent from origin"
+            )
+            continue
+        if ahead_counter(sha) == 0:
+            problems.append(
+                f"lane {lane}: in_progress {age_hours:.1f}h (max {lane_max_age_hours}h), "
+                f"branch {branch} has zero commits ahead of origin/main"
+            )
+    if unreadable:
+        return _result(name, "unknown", "unreadable lane ledger(s): " + "; ".join(unreadable))
+    pattern_branches = 0
+    for branch in sorted(heads):
+        if not any(fnmatch(branch, pat) for pat in ORPHAN_BRANCH_PATTERNS):
+            continue
+        pattern_branches += 1
+        if ahead_counter(heads[branch]) != 0:
+            continue
+        tip_date = commit_dater(heads[branch])
+        if tip_date is None:
+            continue
+        tip_age_hours = (now - tip_date).total_seconds() / 3600.0
+        if tip_age_hours > orphan_age_hours:
+            problems.append(
+                f"orphan branch {branch}: zero commits ahead of origin/main, "
+                f"tip {tip_age_hours / 24:.1f}d old (max {orphan_age_hours}h) — "
+                "lane likely died at setup; no ledger claims it"
+            )
+    if problems:
+        return _result(name, "breach", "; ".join(problems))
+    return _result(
+        name,
+        "ok",
+        f"{in_progress} in_progress lane(s) live; "
+        f"{pattern_branches} lane-pattern branch(es) on origin, no orphans",
+    )
+
+
+# ---------------------------------------------------------------------------
+# github_api_health (failure class B — external API degradation, 2026-06-10/11)
+# ---------------------------------------------------------------------------
+
+
+def _read_tail_lines(path: Path, max_lines: int) -> list[str]:
+    """Read up to the last ``max_lines`` lines without loading the whole file."""
+    step = 1 << 16
+    with path.open("rb") as fh:
+        fh.seek(0, 2)
+        pos = fh.tell()
+        data = b""
+        while pos > 0 and data.count(b"\n") <= max_lines:
+            read = min(step, pos)
+            pos -= read
+            fh.seek(pos)
+            data = fh.read(read) + data
+            step = min(step * 2, 1 << 22)
+    return data.decode("utf-8", errors="replace").splitlines()[-max_lines:]
+
+
+def publisher_failure_streak(lines: list[str]) -> tuple[int, str]:
+    """Trailing consecutive failed branch-publish passes + last error class.
+
+    Counts ``branch publish pass failed`` markers backwards from the end of
+    the log, stopping at the first ``branch publish pass complete`` marker.
+    Per-attempt retry lines (``branch publish pass attempt N/M failed``) are
+    NOT pass failures and are not counted.  The error class is the most
+    recent ``HTTP <code>`` (or ``connectivity_failed``) seen in the window.
+    """
+    streak = 0
+    for line in reversed(lines):
+        if "branch publish pass failed" in line:
+            streak += 1
+        elif "branch publish pass complete" in line:
+            break
+    last_error = "none"
+    for line in reversed(lines):
+        match = re.search(r"HTTP (\d{3})", line)
+        if match:
+            last_error = f"HTTP {match.group(1)}"
+            break
+        if "connectivity_failed" in line:
+            last_error = "connectivity_failed"
+            break
+    return streak, last_error
+
+
+def check_github_api_health(
+    log_path: Path,
+    *,
+    persist_threshold: int,
+    tail_lines: int,
+    probe_runner: Callable[[list[str]], int],
+    probe_cmd: list[str] | None = None,
+) -> CheckResult:
+    """Distinguish persistent GitHub API degradation from transient blips.
+
+    A cheap live probe (``gh api rate_limit``) plus the publisher log's
+    failed-pass streak.  Breach ONLY when both agree the degradation is
+    persistent: probe fails AND streak >= ``persist_threshold``.  Transient
+    blips (short streak, or probe already recovered) stay visible-but-quiet:
+    recorded in the detail/ledger, exit stays green.
+    """
+    name = "github_api_health"
+    command = probe_cmd or ["gh", "api", "rate_limit"]
+    probe_error = ""
+    probe_ok: bool | None
+    try:
+        probe_ok = probe_runner(command) == 0
+    except Exception as exc:  # noqa: BLE001 - a probe we cannot run is a blind spot
+        probe_ok = None
+        probe_error = f"{exc.__class__.__name__}: {exc}"
+    if not log_path.exists():
+        return _result(name, "unknown", f"publisher log missing: {log_path}")
+    try:
+        lines = _read_tail_lines(log_path, tail_lines)
+    except OSError as exc:
+        return _result(
+            name, "unknown", f"publisher log unreadable: {exc.__class__.__name__}: {exc}"
+        )
+    streak, last_error = publisher_failure_streak(lines)
+    base = (
+        f"failed-pass streak={streak} (persist-threshold {persist_threshold}); "
+        f"last_error={last_error}"
+    )
+    if probe_ok is None:
+        return _result(name, "unknown", f"probe could not run ({probe_error}); {base}")
+    if probe_ok:
+        return _result(name, "ok", f"probe ok; {base}")
+    if streak >= persist_threshold:
+        return _result(name, "breach", f"persistent degradation: probe failed and {base}")
+    return _result(name, "ok", f"transient degradation (no breach): probe failed but {base}")
+
+
+# ---------------------------------------------------------------------------
 # Report, exit contract, ledger, notification
 # ---------------------------------------------------------------------------
 
@@ -319,6 +583,29 @@ def run_checks(args: argparse.Namespace, now: datetime) -> list[CheckResult]:
                 results.append(
                     check_disk_free(Path(args.repo_root), min_free_gib=args.min_free_gib)
                 )
+            elif name == "lane_liveness":
+                repo = Path(args.repo_root)
+                results.append(
+                    check_lane_liveness(
+                        args.lanes_glob,
+                        lane_max_age_hours=args.lane_max_age_hours,
+                        orphan_age_hours=args.orphan_branch_age_hours,
+                        now=now,
+                        remote_heads=lambda repo=repo: _default_remote_heads(repo),
+                        ahead_counter=_default_ahead_counter(repo),
+                        commit_dater=_default_commit_dater(repo),
+                    )
+                )
+            elif name == "github_api_health":
+                results.append(
+                    check_github_api_health(
+                        Path(args.publisher_log),
+                        persist_threshold=args.persist_threshold,
+                        tail_lines=args.publisher_log_tail_lines,
+                        probe_runner=_default_command_runner,
+                        probe_cmd=shlex.split(args.rate_limit_cmd),
+                    )
+                )
         except Exception as exc:  # noqa: BLE001 - a crashed check is a blind spot, not success
             results.append(
                 _result(name, "unknown", f"check crashed: {exc.__class__.__name__}: {exc}")
@@ -353,6 +640,26 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--outbox-max", type=int, default=50)
     parser.add_argument("--outbox-max-age-days", type=float, default=7.0)
     parser.add_argument("--min-free-gib", type=float, default=25.0)
+    parser.add_argument(
+        "--lanes-glob",
+        # Lane-ledger convention: .aragora/run-*/lanes/<lane>.json
+        default=str(repo_root / ".aragora" / "run-*" / "lanes"),
+        help="glob for lane-ledger directories (entries are <lane>.json inside)",
+    )
+    parser.add_argument("--lane-max-age-hours", type=float, default=3.0)
+    parser.add_argument("--orphan-branch-age-hours", type=float, default=24.0)
+    parser.add_argument(
+        "--publisher-log",
+        default=str(repo_root / ".aragora" / "overnight" / "codex-automation-publisher.log"),
+    )
+    parser.add_argument("--publisher-log-tail-lines", type=int, default=2000)
+    parser.add_argument(
+        "--persist-threshold",
+        type=int,
+        default=3,
+        help="consecutive failed publisher passes before degradation counts as persistent",
+    )
+    parser.add_argument("--rate-limit-cmd", default="gh api rate_limit")
     parser.add_argument(
         "--ledger",
         default=str(repo_root / ".aragora" / "fleet-sentinel" / "ledger.jsonl"),

--- a/scripts/lane_janitor.py
+++ b/scripts/lane_janitor.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+"""Lane janitor — bounded auto-fix for silent lane death (failure class A).
+
+Companion to ``scripts/fleet_sentinel.py``'s ``lane_liveness`` check.  The
+sentinel detects; this janitor remediates, within hard bounds:
+
+  (a) mark lane-ledger entries dead (``status=dead`` + ``detected_at``) when
+      the liveness rule fires: ``status=in_progress``, ``launched_at`` older
+      than ``--lane-max-age-hours`` (default 3), and the lane's branch has
+      zero commits ahead of origin/main (or is absent from origin);
+  (b) emit ``RELAUNCH_QUEUE.md`` next to each run's lane ledgers, listing
+      dead lanes with their briefs.  The coordinator/operator consumes it —
+      autonomous relaunch is intentionally NOT done by the janitor;
+  (c) delete remote branches that are zero-commits-ahead AND ledger-dead (or
+      ledger-less orphans in the lane-owned namespaces) AND older than
+      ``--branch-ttl-hours`` (default 24).
+
+Hard guarantee: a branch with ANY unique commit ahead of origin/main is never
+deleted, regardless of ledger state or age.  Unresolvable ahead counts and
+unknown tip dates also block deletion — when in doubt, keep.
+
+Dry-run is the default; ``--apply`` gates every mutation.  stdlib only.
+
+Motivating incident (2026-06-10/11): three coordinator-spawned lanes
+(elves/run-20260610-c06/c07/c08-*) died at setup overnight, leaving
+in_progress ledgers and empty branches on origin that nobody noticed until a
+manual morning sweep.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob as glob_module
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from fnmatch import fnmatch
+from pathlib import Path
+from typing import Any
+
+# Branch namespaces owned by autonomous lanes; only these are eligible for
+# ledger-less orphan deletion.  Must stay in sync with fleet_sentinel.py.
+ORPHAN_BRANCH_PATTERNS = ("elves/*", "aragora/boss*")
+
+
+def parse_iso(value: str) -> datetime:
+    """Parse an ISO-8601 timestamp (``Z`` suffix accepted) to aware UTC."""
+    dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def iso_z(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _hours_between(now: datetime, then: datetime) -> float:
+    return (now - then).total_seconds() / 3600.0
+
+
+class GitBoundary:
+    """All git interaction lives here; tests inject a fake with this shape."""
+
+    def __init__(self, repo: Path) -> None:
+        self.repo = repo
+
+    def _run(self, *cmd: str, timeout: float = 120) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(  # noqa: S603
+            ["git", "-C", str(self.repo), *cmd],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+
+    def remote_heads(self) -> dict[str, str]:
+        proc = self._run("ls-remote", "--heads", "origin")
+        if proc.returncode != 0:
+            raise RuntimeError(f"git ls-remote failed: {proc.stderr.strip()[:200]}")
+        heads: dict[str, str] = {}
+        for line in proc.stdout.splitlines():
+            sha, _, ref = line.partition("\t")
+            prefix = "refs/heads/"
+            if ref.startswith(prefix):
+                heads[ref[len(prefix) :].strip()] = sha.strip()
+        return heads
+
+    def ahead_count(self, sha: str) -> int | None:
+        """Commits ahead of origin/main; None when unresolvable.
+
+        A zero-ahead tip is an ancestor of origin/main and therefore present
+        locally; an unresolvable sha means unfetched unique commits.  Callers
+        MUST treat None as "has commits" — never as empty.
+        """
+        proc = self._run("rev-list", "--count", f"origin/main..{sha}", timeout=60)
+        if proc.returncode != 0:
+            return None
+        try:
+            return int(proc.stdout.strip())
+        except ValueError:
+            return None
+
+    def commit_date(self, sha: str) -> datetime | None:
+        proc = self._run("log", "-1", "--format=%cI", sha, timeout=60)
+        out = proc.stdout.strip()
+        if proc.returncode != 0 or not out:
+            return None
+        try:
+            return parse_iso(out)
+        except ValueError:
+            return None
+
+    def delete_remote_branch(self, branch: str) -> None:
+        proc = self._run("push", "origin", "--delete", branch, timeout=180)
+        if proc.returncode != 0:
+            raise RuntimeError(f"git push --delete {branch} failed: {proc.stderr.strip()[:200]}")
+
+
+def _load_ledgers(runs_glob: str, errors: list[str]) -> list[dict[str, Any]]:
+    """All readable lane-ledger entries under ``<runs_glob>/*.json``."""
+    records: list[dict[str, Any]] = []
+    for lanes_dir in sorted(glob_module.glob(runs_glob)):
+        lanes_path = Path(lanes_dir)
+        if not lanes_path.is_dir():
+            continue
+        for ledger_file in sorted(lanes_path.glob("*.json")):
+            try:
+                entry = json.loads(ledger_file.read_text())
+                if not isinstance(entry, dict):
+                    raise ValueError("ledger entry is not an object")
+            except (OSError, json.JSONDecodeError, ValueError) as exc:
+                errors.append(f"unreadable ledger {ledger_file}: {exc.__class__.__name__}")
+                continue
+            records.append({"path": ledger_file, "lanes_dir": lanes_path, "entry": entry})
+    return records
+
+
+def _is_dead(
+    entry: dict[str, Any],
+    *,
+    now: datetime,
+    lane_max_age_hours: float,
+    heads: dict[str, str],
+    git: Any,
+    errors: list[str],
+) -> tuple[bool, float]:
+    """Apply the liveness rule to one in_progress ledger entry."""
+    try:
+        launched = parse_iso(str(entry["launched_at"]))
+    except (KeyError, ValueError, TypeError):
+        errors.append(f"ledger for lane {entry.get('lane')!r} has bad launched_at")
+        return False, 0.0
+    age_hours = _hours_between(now, launched)
+    if age_hours <= lane_max_age_hours:
+        return False, age_hours
+    branch = str(entry.get("branch", ""))
+    sha = heads.get(branch)
+    if sha is None:
+        return True, age_hours  # never pushed anything durable
+    return git.ahead_count(sha) == 0, age_hours
+
+
+def _write_relaunch_queue(
+    lanes_dir: Path, dead_entries: list[dict[str, Any]], now: datetime
+) -> Path:
+    path = lanes_dir / "RELAUNCH_QUEUE.md"
+    lines = [
+        f"# Relaunch queue — generated {iso_z(now)} by scripts/lane_janitor.py",
+        "",
+        "Lanes below died at setup (status=dead: no commits ahead of origin/main",
+        "after the liveness window). The coordinator/operator should relaunch each",
+        "with its original brief. The janitor never relaunches autonomously.",
+        "",
+    ]
+    for entry in dead_entries:
+        lines.append(
+            f"- [ ] lane {entry.get('lane')} — branch `{entry.get('branch')}` — "
+            f"brief: {entry.get('brief')} "
+            f"(launched {entry.get('launched_at')}, "
+            f"detected dead {entry.get('detected_at', iso_z(now))})"
+        )
+    lines.append("")
+    path.write_text("\n".join(lines))
+    return path
+
+
+def build_plan(
+    runs_glob: str,
+    *,
+    git: Any,
+    now: datetime,
+    lane_max_age_hours: float,
+    branch_ttl_hours: float,
+    apply: bool,
+) -> dict[str, Any]:
+    """Compute (and, when ``apply``, execute) the janitor plan."""
+    errors: list[str] = []
+    plan: dict[str, Any] = {
+        "generated_at": iso_z(now),
+        "applied": apply,
+        "mark_dead": [],
+        "relaunch_queue": [],
+        "delete_branches": [],
+        "skipped": [],
+        "errors": errors,
+    }
+    try:
+        heads = git.remote_heads()
+    except Exception as exc:  # noqa: BLE001 - blind janitor must not act
+        errors.append(f"could not list origin heads: {exc.__class__.__name__}: {exc}")
+        return plan
+
+    records = _load_ledgers(runs_glob, errors)
+
+    # (a) dead-lane detection.
+    newly_dead: list[dict[str, Any]] = []
+    for record in records:
+        entry = record["entry"]
+        if str(entry.get("status", "")) != "in_progress":
+            continue
+        dead, age_hours = _is_dead(
+            entry,
+            now=now,
+            lane_max_age_hours=lane_max_age_hours,
+            heads=heads,
+            git=git,
+            errors=errors,
+        )
+        if not dead:
+            continue
+        newly_dead.append(record)
+        plan["mark_dead"].append(
+            {
+                "lane": entry.get("lane"),
+                "branch": entry.get("branch"),
+                "ledger": str(record["path"]),
+                "age_hours": round(age_hours, 1),
+            }
+        )
+
+    if apply:
+        for record in newly_dead:
+            record["entry"]["status"] = "dead"
+            record["entry"]["detected_at"] = iso_z(now)
+            record["path"].write_text(json.dumps(record["entry"], indent=1))
+
+    # Effective ledger status per branch (newly dead count as dead even in
+    # dry-run so the deletion *plan* reflects what apply would do).
+    effective_status: dict[str, str] = {}
+    for record in records:
+        entry = record["entry"]
+        branch = str(entry.get("branch", ""))
+        status = str(entry.get("status", ""))
+        if record in newly_dead:
+            status = "dead"
+        # A live in_progress claim always wins over any other entry's status.
+        if effective_status.get(branch) == "in_progress":
+            continue
+        effective_status[branch] = status
+
+    # (b) relaunch queues — one per run lanes dir that has dead lanes.
+    dirs_seen: dict[Path, list[dict[str, Any]]] = {}
+    for record in records:
+        status = str(record["entry"].get("status", ""))
+        if status == "dead" or record in newly_dead:
+            dirs_seen.setdefault(record["lanes_dir"], []).append(record["entry"])
+    for lanes_dir, dead_entries in sorted(dirs_seen.items()):
+        queue_path = lanes_dir / "RELAUNCH_QUEUE.md"
+        plan["relaunch_queue"].append(
+            {"path": str(queue_path), "lanes": [e.get("lane") for e in dead_entries]}
+        )
+        if apply:
+            _write_relaunch_queue(lanes_dir, dead_entries, now)
+
+    # (c) bounded branch deletion.
+    for branch in sorted(heads):
+        sha = heads[branch]
+        status = effective_status.get(branch)
+        if status is None:
+            if not any(fnmatch(branch, pat) for pat in ORPHAN_BRANCH_PATTERNS):
+                continue  # not a lane-owned namespace; never ours to touch
+            reason = "ledger-less orphan"
+        elif status == "dead":
+            reason = "ledger-dead"
+        elif status == "in_progress":
+            plan["skipped"].append({"branch": branch, "reason": "live ledger (in_progress)"})
+            continue
+        else:
+            plan["skipped"].append({"branch": branch, "reason": f"ledger status {status!r}"})
+            continue
+        ahead = git.ahead_count(sha)
+        if ahead is None:
+            plan["skipped"].append({"branch": branch, "reason": "ahead count unresolvable — keep"})
+            continue
+        if ahead != 0:
+            plan["skipped"].append(
+                {"branch": branch, "reason": f"{ahead} unique commit(s) — never delete"}
+            )
+            continue
+        tip_date = git.commit_date(sha)
+        if tip_date is None:
+            plan["skipped"].append({"branch": branch, "reason": "unknown tip date — keep"})
+            continue
+        tip_age_hours = _hours_between(now, tip_date)
+        if tip_age_hours <= branch_ttl_hours:
+            plan["skipped"].append(
+                {
+                    "branch": branch,
+                    "reason": f"tip {tip_age_hours:.1f}h old <= ttl {branch_ttl_hours}h",
+                }
+            )
+            continue
+        plan["delete_branches"].append(
+            {
+                "branch": branch,
+                "sha": sha,
+                "reason": reason,
+                "tip_age_hours": round(tip_age_hours, 1),
+            }
+        )
+
+    if apply:
+        for deletion in plan["delete_branches"]:
+            try:
+                git.delete_remote_branch(deletion["branch"])
+            except Exception as exc:  # noqa: BLE001 - one failed delete must not stop the rest
+                errors.append(
+                    f"delete failed for {deletion['branch']}: {exc.__class__.__name__}: {exc}"
+                )
+    return plan
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    repo_root = Path(__file__).resolve().parents[1]
+    parser.add_argument("--repo-root", default=str(repo_root))
+    parser.add_argument(
+        "--runs-glob",
+        default=str(repo_root / ".aragora" / "run-*" / "lanes"),
+        help="glob for lane-ledger directories (entries are <lane>.json inside)",
+    )
+    parser.add_argument("--lane-max-age-hours", type=float, default=3.0)
+    parser.add_argument("--branch-ttl-hours", type=float, default=24.0)
+    parser.add_argument("--apply", action="store_true", help="execute the plan (default: dry-run)")
+    parser.add_argument("--json", action="store_true", help="emit the JSON plan to stdout")
+    parser.add_argument(
+        "--now", default=None, help="ISO-8601 timestamp override (for tests/replays)"
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    now = parse_iso(args.now) if args.now else datetime.now(timezone.utc)
+    git = GitBoundary(Path(args.repo_root))
+    plan = build_plan(
+        args.runs_glob,
+        git=git,
+        now=now,
+        lane_max_age_hours=args.lane_max_age_hours,
+        branch_ttl_hours=args.branch_ttl_hours,
+        apply=args.apply,
+    )
+    if args.json:
+        print(json.dumps(plan, indent=2, sort_keys=True))
+    else:
+        mode = "APPLY" if plan["applied"] else "DRY-RUN"
+        print(f"lane-janitor [{mode}] generated_at={plan['generated_at']}")
+        for item in plan["mark_dead"]:
+            print(f"  mark dead: lane {item['lane']} ({item['branch']}) — {item['ledger']}")
+        for item in plan["relaunch_queue"]:
+            print(f"  relaunch queue: {item['path']} lanes={item['lanes']}")
+        for item in plan["delete_branches"]:
+            print(
+                f"  delete branch: {item['branch']} ({item['reason']}, "
+                f"tip {item['tip_age_hours']}h old)"
+            )
+        for item in plan["skipped"]:
+            print(f"  skip: {item['branch']} — {item['reason']}")
+        if not (plan["mark_dead"] or plan["delete_branches"]):
+            print("  nothing to do")
+        for err in plan["errors"]:
+            print(f"  ERROR: {err}", file=sys.stderr)
+    return 1 if plan["errors"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_codex_automation_publisher.sh
+++ b/scripts/run_codex_automation_publisher.sh
@@ -131,7 +131,26 @@ BRANCH_PUBLISH_ARGS=(
 if [[ "${ALLOW_UNHEALTHY_QUEUE_PUBLISH}" == "1" || "${ALLOW_UNHEALTHY_QUEUE_PUBLISH}" == "true" || "${ALLOW_UNHEALTHY_QUEUE_PUBLISH}" == "yes" ]]; then
   BRANCH_PUBLISH_ARGS+=(--allow-unhealthy-queue-publish)
 fi
-if python3 scripts/publish_codex_automation_branches.py "${BRANCH_PUBLISH_ARGS[@]}"; then
+# Bounded retry (failure class B, 2026-06-10/11): GitHub GraphQL 502/504
+# streaks stalled this pass overnight.  Up to 2 retries with 30s/60s backoff;
+# limits/spend caps are enforced inside the publish script on every attempt.
+BRANCH_PASS_OK="false"
+BRANCH_PASS_MAX_ATTEMPTS=3
+for attempt in $(seq 1 "${BRANCH_PASS_MAX_ATTEMPTS}"); do
+  if python3 scripts/publish_codex_automation_branches.py "${BRANCH_PUBLISH_ARGS[@]}"; then
+    BRANCH_PASS_OK="true"
+    break
+  else
+    rc=$?
+  fi
+  echo "$(STAMP) [codex-automation-publisher] branch publish pass attempt ${attempt}/${BRANCH_PASS_MAX_ATTEMPTS} failed (exit ${rc})"
+  if [[ "${attempt}" -lt "${BRANCH_PASS_MAX_ATTEMPTS}" ]]; then
+    backoff=$((attempt * 30))
+    echo "$(STAMP) [codex-automation-publisher] retrying branch publish pass in ${backoff}s"
+    sleep "${backoff}"
+  fi
+done
+if [[ "${BRANCH_PASS_OK}" == "true" ]]; then
   echo "$(STAMP) [codex-automation-publisher] branch publish pass complete"
 else
   echo "$(STAMP) [codex-automation-publisher] branch publish pass failed"

--- a/tests/scripts/test_fleet_sentinel.py
+++ b/tests/scripts/test_fleet_sentinel.py
@@ -474,6 +474,377 @@ def test_notify_bare_placeholder_token_passes_summary_raw() -> None:
     assert captured["tokens"] == ["notifier", "--msg", 'has "quotes" and \\slash']
 
 
+# ---------------------------------------------------------------------------
+# lane_liveness  (failure class A: the silent c06/c07/c08 lane deaths of
+# 2026-06-10/11 — three coordinator-spawned lanes died at setup, left empty
+# branches on origin, and nobody noticed until a manual morning sweep)
+# ---------------------------------------------------------------------------
+
+
+def _write_lane_ledger(
+    lanes_dir: Path,
+    lane: str,
+    *,
+    branch: str,
+    launched_at: str,
+    status: str = "in_progress",
+) -> Path:
+    lanes_dir.mkdir(parents=True, exist_ok=True)
+    path = lanes_dir / f"{lane}.json"
+    path.write_text(
+        json.dumps(
+            {
+                "lane": lane,
+                "agent_id": "a0000000000000000",
+                "branch": branch,
+                "brief": f"brief for {lane}",
+                "launched_at": launched_at,
+                "status": status,
+            }
+        )
+    )
+    return path
+
+
+def _liveness(
+    lanes_dir: Path,
+    *,
+    heads: dict[str, str],
+    ahead: dict[str, int | None],
+    dates: dict[str, str] | None = None,
+    lane_max_age_hours: float = 3.0,
+    orphan_age_hours: float = 24.0,
+) -> Any:
+    date_map = {sha: sentinel.parse_iso(d) for sha, d in (dates or {}).items()}
+    return sentinel.check_lane_liveness(
+        str(lanes_dir),
+        lane_max_age_hours=lane_max_age_hours,
+        orphan_age_hours=orphan_age_hours,
+        now=NOW,
+        remote_heads=lambda: heads,
+        ahead_counter=lambda sha: ahead.get(sha),
+        commit_dater=lambda sha: date_map.get(sha),
+    )
+
+
+def test_lane_liveness_fresh_in_progress_ok(tmp_path: Path) -> None:
+    _write_lane_ledger(tmp_path, "q2", branch="elves/run-x-q2", launched_at="2026-06-10T11:00:00Z")
+    result = _liveness(tmp_path, heads={"elves/run-x-q2": "aaa"}, ahead={"aaa": 0})
+    assert result["status"] == "ok"
+
+
+def test_lane_liveness_stale_zero_ahead_breaches(tmp_path: Path) -> None:
+    _write_lane_ledger(tmp_path, "q2", branch="elves/run-x-q2", launched_at="2026-06-10T07:00:00Z")
+    result = _liveness(tmp_path, heads={"elves/run-x-q2": "aaa"}, ahead={"aaa": 0})
+    assert result["status"] == "breach"
+    assert "q2" in result["detail"]
+    assert "zero commits ahead" in result["detail"]
+
+
+def test_lane_liveness_stale_branch_absent_breaches(tmp_path: Path) -> None:
+    _write_lane_ledger(tmp_path, "q2", branch="elves/run-x-q2", launched_at="2026-06-10T07:00:00Z")
+    result = _liveness(tmp_path, heads={}, ahead={})
+    assert result["status"] == "breach"
+    assert "absent from origin" in result["detail"]
+
+
+def test_lane_liveness_stale_with_commits_ok(tmp_path: Path) -> None:
+    _write_lane_ledger(tmp_path, "q2", branch="elves/run-x-q2", launched_at="2026-06-10T07:00:00Z")
+    result = _liveness(tmp_path, heads={"elves/run-x-q2": "aaa"}, ahead={"aaa": 2})
+    assert result["status"] == "ok"
+
+
+def test_lane_liveness_unresolvable_ahead_is_not_dead(tmp_path: Path) -> None:
+    """None from the ahead counter means unfetched unique commits — never dead."""
+    _write_lane_ledger(tmp_path, "q2", branch="elves/run-x-q2", launched_at="2026-06-10T07:00:00Z")
+    result = _liveness(tmp_path, heads={"elves/run-x-q2": "aaa"}, ahead={"aaa": None})
+    assert result["status"] == "ok"
+
+
+def test_lane_liveness_non_in_progress_ignored(tmp_path: Path) -> None:
+    _write_lane_ledger(
+        tmp_path,
+        "q2",
+        branch="elves/run-x-q2",
+        launched_at="2026-06-10T07:00:00Z",
+        status="dead",
+    )
+    result = _liveness(tmp_path, heads={}, ahead={})
+    assert result["status"] == "ok"
+
+
+def test_lane_liveness_orphan_branch_breaches(tmp_path: Path) -> None:
+    result = _liveness(
+        tmp_path,
+        heads={"elves/run-20260610-c06-dead": "aaa"},
+        ahead={"aaa": 0},
+        dates={"aaa": "2026-06-09T06:00:00Z"},  # 30h old at NOW
+    )
+    assert result["status"] == "breach"
+    assert "orphan branch elves/run-20260610-c06-dead" in result["detail"]
+
+
+def test_lane_liveness_boss_pattern_orphan_breaches(tmp_path: Path) -> None:
+    result = _liveness(
+        tmp_path,
+        heads={"aragora/boss-harvest/issue-1-boss-x": "bbb"},
+        ahead={"bbb": 0},
+        dates={"bbb": "2026-06-08T12:00:00Z"},
+    )
+    assert result["status"] == "breach"
+
+
+def test_lane_liveness_young_empty_branch_ok(tmp_path: Path) -> None:
+    result = _liveness(
+        tmp_path,
+        heads={"elves/run-x-young": "aaa"},
+        ahead={"aaa": 0},
+        dates={"aaa": "2026-06-10T10:00:00Z"},  # 2h old
+    )
+    assert result["status"] == "ok"
+
+
+def test_lane_liveness_old_branch_with_commits_ok(tmp_path: Path) -> None:
+    result = _liveness(
+        tmp_path,
+        heads={"elves/run-x-real-work": "aaa"},
+        ahead={"aaa": 1},
+        dates={"aaa": "2026-06-01T00:00:00Z"},
+    )
+    assert result["status"] == "ok"
+
+
+def test_lane_liveness_non_pattern_branch_ignored(tmp_path: Path) -> None:
+    result = _liveness(
+        tmp_path,
+        heads={"feature/unrelated": "aaa"},
+        ahead={"aaa": 0},
+        dates={"aaa": "2026-06-01T00:00:00Z"},
+    )
+    assert result["status"] == "ok"
+
+
+def test_lane_liveness_remote_failure_is_unknown(tmp_path: Path) -> None:
+    def boom() -> dict[str, str]:
+        raise subprocess.CalledProcessError(128, ["git"])
+
+    result = sentinel.check_lane_liveness(
+        str(tmp_path),
+        lane_max_age_hours=3,
+        orphan_age_hours=24,
+        now=NOW,
+        remote_heads=boom,
+        ahead_counter=lambda sha: 0,
+        commit_dater=lambda sha: None,
+    )
+    assert result["status"] == "unknown"
+
+
+def test_lane_liveness_unreadable_ledger_is_unknown(tmp_path: Path) -> None:
+    tmp_path.mkdir(exist_ok=True)
+    (tmp_path / "broken.json").write_text("{not json")
+    result = _liveness(tmp_path, heads={}, ahead={})
+    assert result["status"] == "unknown"
+    assert "broken.json" in result["detail"]
+
+
+def test_breach_replay_jun10_silent_lane_death(tmp_path: Path) -> None:
+    """Acceptance: replaying the real 2026-06-10/11 incident raises the alarm.
+
+    Three coordinator-spawned lanes (c06/c07/c08) died at setup overnight.
+    Their branches sat on origin with zero commits ahead of main until a
+    manual morning sweep found them.  With ledgers present the ledger rule
+    fires; without ledgers (as on the real morning after) the orphan-branch
+    rule fires for every one of them.
+    """
+    heads = {
+        "elves/run-20260610-c06-mixed-family-fix": "c06sha",
+        "elves/run-20260610-c07-auto-evidence": "c07sha",
+        "elves/run-20260610-c08-b1-retrigger": "c08sha",
+    }
+    ahead: dict[str, int | None] = {"c06sha": 0, "c07sha": 0, "c08sha": 0}
+    dates = dict.fromkeys(ahead, "2026-06-09T02:00:00Z")  # ~34h old at NOW
+    # Ledger-less variant (the real morning-after state):
+    result = _liveness(tmp_path / "lanes", heads=heads, ahead=ahead, dates=dates)
+    assert result["status"] == "breach"
+    for branch in heads:
+        assert branch in result["detail"]
+    # Ledger-present variant: the ledger rule also catches each lane.
+    lanes = tmp_path / "run-20260610" / "lanes"
+    for lane, branch in (
+        ("c06", "elves/run-20260610-c06-mixed-family-fix"),
+        ("c07", "elves/run-20260610-c07-auto-evidence"),
+        ("c08", "elves/run-20260610-c08-b1-retrigger"),
+    ):
+        _write_lane_ledger(lanes, lane, branch=branch, launched_at="2026-06-09T02:00:00Z")
+    result = _liveness(lanes, heads=heads, ahead=ahead, dates=dates)
+    assert result["status"] == "breach"
+    assert result["detail"].count("lane c0") == 3
+
+
+# ---------------------------------------------------------------------------
+# github_api_health  (failure class B: GraphQL 502/504 streaks of 2026-06-10/11
+# stalled the publisher; the cached github_health flipped auth_ok:false so the
+# sentinel breached without distinguishing transient from persistent)
+# ---------------------------------------------------------------------------
+
+
+def _publisher_log(tmp_path: Path, passes: list[str], *, errors: list[str] | None = None) -> Path:
+    """Build a publisher log: one start/end marker pair per pass outcome."""
+    lines: list[str] = []
+    for i, outcome in enumerate(passes):
+        lines.append(
+            f"2026-06-11T0{i % 10}:00:00Z [codex-automation-publisher] starting branch publish pass"
+        )
+        for err in errors or []:
+            lines.append(f'    "error": "{err}",')
+        lines.append(
+            f"2026-06-11T0{i % 10}:01:00Z [codex-automation-publisher] branch publish pass {outcome}"
+        )
+    path = tmp_path / "codex-automation-publisher.log"
+    path.write_text("\n".join(lines) + "\n")
+    return path
+
+
+def test_github_api_health_probe_ok_no_streak(tmp_path: Path) -> None:
+    log = _publisher_log(tmp_path, ["complete", "complete"])
+    result = sentinel.check_github_api_health(
+        log, persist_threshold=3, tail_lines=2000, probe_runner=lambda cmd: 0
+    )
+    assert result["status"] == "ok"
+    assert "streak=0" in result["detail"]
+
+
+def test_github_api_health_transient_blip_visible_but_quiet(tmp_path: Path) -> None:
+    """Probe down + short streak = transient: recorded in detail, NO breach."""
+    log = _publisher_log(
+        tmp_path,
+        ["complete", "failed", "failed"],
+        errors=["HTTP 502: 502 Bad Gateway (https://api.github.com/graphql)"],
+    )
+    result = sentinel.check_github_api_health(
+        log, persist_threshold=3, tail_lines=2000, probe_runner=lambda cmd: 1
+    )
+    assert result["status"] == "ok"
+    assert "streak=2" in result["detail"]
+    assert "HTTP 502" in result["detail"]
+
+
+def test_github_api_health_persistent_degradation_breaches(tmp_path: Path) -> None:
+    log = _publisher_log(
+        tmp_path,
+        ["complete", "failed", "failed", "failed"],
+        errors=["HTTP 504: We couldn't respond in time (https://api.github.com/graphql)"],
+    )
+    result = sentinel.check_github_api_health(
+        log, persist_threshold=3, tail_lines=2000, probe_runner=lambda cmd: 1
+    )
+    assert result["status"] == "breach"
+    assert "streak=3" in result["detail"]
+    assert "HTTP 504" in result["detail"]
+
+
+def test_github_api_health_probe_recovered_long_streak_ok(tmp_path: Path) -> None:
+    """Streak alone never breaches: a green probe means the API recovered."""
+    log = _publisher_log(tmp_path, ["failed", "failed", "failed", "failed"])
+    result = sentinel.check_github_api_health(
+        log, persist_threshold=3, tail_lines=2000, probe_runner=lambda cmd: 0
+    )
+    assert result["status"] == "ok"
+    assert "streak=4" in result["detail"]
+
+
+def test_github_api_health_streak_resets_on_complete(tmp_path: Path) -> None:
+    log = _publisher_log(tmp_path, ["failed", "failed", "complete", "failed"])
+    result = sentinel.check_github_api_health(
+        log, persist_threshold=3, tail_lines=2000, probe_runner=lambda cmd: 1
+    )
+    assert result["status"] == "ok"
+    assert "streak=1" in result["detail"]
+
+
+def test_github_api_health_attempt_lines_not_counted_as_pass_failures(tmp_path: Path) -> None:
+    lines = [
+        "2026-06-11T00:00:00Z [codex-automation-publisher] starting branch publish pass",
+        "2026-06-11T00:00:30Z [codex-automation-publisher] branch publish pass attempt 1/3 failed (exit 1); retrying in 30s",
+        "2026-06-11T00:01:30Z [codex-automation-publisher] branch publish pass complete",
+    ]
+    log = tmp_path / "pub.log"
+    log.write_text("\n".join(lines) + "\n")
+    streak, _ = sentinel.publisher_failure_streak(lines)
+    assert streak == 0
+    result = sentinel.check_github_api_health(
+        log, persist_threshold=3, tail_lines=2000, probe_runner=lambda cmd: 1
+    )
+    assert result["status"] == "ok"
+
+
+def test_github_api_health_log_missing_is_unknown(tmp_path: Path) -> None:
+    result = sentinel.check_github_api_health(
+        tmp_path / "absent.log", persist_threshold=3, tail_lines=2000, probe_runner=lambda cmd: 0
+    )
+    assert result["status"] == "unknown"
+
+
+def test_github_api_health_probe_crash_is_unknown(tmp_path: Path) -> None:
+    log = _publisher_log(tmp_path, ["complete"])
+
+    def boom(cmd: list[str]) -> int:
+        raise FileNotFoundError("gh not installed")
+
+    result = sentinel.check_github_api_health(
+        log, persist_threshold=3, tail_lines=2000, probe_runner=boom
+    )
+    assert result["status"] == "unknown"
+
+
+def test_new_checks_registered_in_all_checks() -> None:
+    assert "lane_liveness" in sentinel.ALL_CHECKS
+    assert "github_api_health" in sentinel.ALL_CHECKS
+
+
+def test_main_github_api_health_wired_end_to_end(tmp_path: Path, capsys: Any) -> None:
+    log = _publisher_log(tmp_path, ["complete"])
+    code = sentinel.main(
+        [
+            "--json",
+            "--no-ledger",
+            "--now",
+            "2026-06-10T12:00:00Z",
+            "--checks",
+            "github_api_health",
+            "--publisher-log",
+            str(log),
+            "--rate-limit-cmd",
+            f"{sys.executable} -c pass",
+        ]
+    )
+    assert code == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["checks"][0]["check"] == "github_api_health"
+
+
+def test_main_lane_liveness_blind_repo_exits_two(tmp_path: Path, capsys: Any) -> None:
+    """Wiring test without network: a non-repo root makes the check blind."""
+    code = sentinel.main(
+        [
+            "--json",
+            "--no-ledger",
+            "--now",
+            "2026-06-10T12:00:00Z",
+            "--checks",
+            "lane_liveness",
+            "--repo-root",
+            str(tmp_path),
+            "--lanes-glob",
+            str(tmp_path / "run-*" / "lanes"),
+        ]
+    )
+    assert code == 2
+    report = json.loads(capsys.readouterr().out)
+    assert report["blind_checks"] == 1
+
+
 def test_notify_embedded_placeholder_neutralizes_quote_injection() -> None:
     """{summary} embedded inside a larger token (e.g. an AppleScript string
     literal, as in the installer's default osascript notify command) must not

--- a/tests/scripts/test_lane_janitor.py
+++ b/tests/scripts/test_lane_janitor.py
@@ -1,0 +1,404 @@
+"""Tests for ``scripts/lane_janitor.py`` — dead-lane detection and bounded cleanup.
+
+Failure class A (2026-06-10/11): coordinator-spawned lanes died at setup,
+leaving in_progress ledgers and empty branches on origin that nobody noticed.
+All git interaction goes through an injected FakeGit — no network in tests.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _load_module(script_name: str) -> Any:
+    here = Path(__file__).resolve()
+    script_path = here.parents[2] / "scripts" / script_name
+    spec = importlib.util.spec_from_file_location(f"{script_name}_under_test", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load spec for {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+janitor = _load_module("lane_janitor.py")
+
+NOW = janitor.parse_iso("2026-06-11T12:00:00Z")
+
+
+class FakeGit:
+    """Injected git boundary: remote heads, ahead counts, tip dates, deletion."""
+
+    def __init__(
+        self,
+        heads: dict[str, str],
+        ahead: dict[str, int | None],
+        dates: dict[str, str] | None = None,
+    ) -> None:
+        self.heads = heads
+        self.ahead = ahead
+        self.dates = {sha: janitor.parse_iso(d) for sha, d in (dates or {}).items()}
+        self.deleted: list[str] = []
+
+    def remote_heads(self) -> dict[str, str]:
+        return dict(self.heads)
+
+    def ahead_count(self, sha: str) -> int | None:
+        return self.ahead.get(sha)
+
+    def commit_date(self, sha: str) -> Any:
+        return self.dates.get(sha)
+
+    def delete_remote_branch(self, branch: str) -> None:
+        self.deleted.append(branch)
+        self.heads.pop(branch, None)
+
+
+def _write_ledger(
+    lanes_dir: Path,
+    lane: str,
+    *,
+    branch: str,
+    launched_at: str,
+    status: str = "in_progress",
+    brief: str = "do the thing",
+    **extra: Any,
+) -> Path:
+    lanes_dir.mkdir(parents=True, exist_ok=True)
+    path = lanes_dir / f"{lane}.json"
+    entry = {
+        "lane": lane,
+        "agent_id": "a0000000000000000",
+        "branch": branch,
+        "brief": brief,
+        "launched_at": launched_at,
+        "status": status,
+    }
+    entry.update(extra)
+    path.write_text(json.dumps(entry))
+    return path
+
+
+def _run(tmp_path: Path, git: FakeGit, *, apply: bool = False, **kw: Any) -> dict[str, Any]:
+    return janitor.build_plan(
+        str(tmp_path / "run-*" / "lanes"),
+        git=git,
+        now=NOW,
+        lane_max_age_hours=kw.pop("lane_max_age_hours", 3.0),
+        branch_ttl_hours=kw.pop("branch_ttl_hours", 24.0),
+        apply=apply,
+    )
+
+
+def _lanes_dir(tmp_path: Path, run: str = "run-20260610") -> Path:
+    return tmp_path / run / "lanes"
+
+
+# ---------------------------------------------------------------------------
+# dead-lane detection + marking
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_plans_dead_lane_without_writing(tmp_path: Path) -> None:
+    lanes = _lanes_dir(tmp_path)
+    path = _write_ledger(lanes, "c06", branch="elves/run-x-c06", launched_at="2026-06-11T02:00:00Z")
+    git = FakeGit({"elves/run-x-c06": "aaa"}, {"aaa": 0}, {"aaa": "2026-06-11T02:00:00Z"})
+    plan = _run(tmp_path, git)
+    assert [d["lane"] for d in plan["mark_dead"]] == ["c06"]
+    assert plan["applied"] is False
+    # Dry run: ledger untouched, no queue file, no deletions.
+    assert json.loads(path.read_text())["status"] == "in_progress"
+    assert not (lanes / "RELAUNCH_QUEUE.md").exists()
+    assert git.deleted == []
+
+
+def test_apply_marks_ledger_dead_with_detected_at(tmp_path: Path) -> None:
+    lanes = _lanes_dir(tmp_path)
+    path = _write_ledger(lanes, "c06", branch="elves/run-x-c06", launched_at="2026-06-11T02:00:00Z")
+    git = FakeGit({"elves/run-x-c06": "aaa"}, {"aaa": 0})
+    plan = _run(tmp_path, git, apply=True)
+    assert plan["applied"] is True
+    entry = json.loads(path.read_text())
+    assert entry["status"] == "dead"
+    assert entry["detected_at"] == "2026-06-11T12:00:00Z"
+    # Original fields preserved.
+    assert entry["brief"] == "do the thing"
+    assert entry["agent_id"] == "a0000000000000000"
+
+
+def test_fresh_lane_not_marked_dead(tmp_path: Path) -> None:
+    _write_ledger(
+        _lanes_dir(tmp_path),
+        "q2",
+        branch="elves/run-x-q2",
+        launched_at="2026-06-11T11:00:00Z",  # 1h old
+    )
+    git = FakeGit({"elves/run-x-q2": "aaa"}, {"aaa": 0})
+    plan = _run(tmp_path, git)
+    assert plan["mark_dead"] == []
+
+
+def test_stale_lane_with_commits_not_marked_dead(tmp_path: Path) -> None:
+    _write_ledger(
+        _lanes_dir(tmp_path),
+        "q2",
+        branch="elves/run-x-q2",
+        launched_at="2026-06-11T02:00:00Z",
+    )
+    git = FakeGit({"elves/run-x-q2": "aaa"}, {"aaa": 3})
+    plan = _run(tmp_path, git)
+    assert plan["mark_dead"] == []
+
+
+def test_stale_lane_branch_absent_marked_dead(tmp_path: Path) -> None:
+    _write_ledger(
+        _lanes_dir(tmp_path),
+        "c07",
+        branch="elves/run-x-c07",
+        launched_at="2026-06-11T02:00:00Z",
+    )
+    git = FakeGit({}, {})
+    plan = _run(tmp_path, git)
+    assert [d["lane"] for d in plan["mark_dead"]] == ["c07"]
+
+
+def test_unresolvable_ahead_count_never_dead(tmp_path: Path) -> None:
+    _write_ledger(
+        _lanes_dir(tmp_path),
+        "q2",
+        branch="elves/run-x-q2",
+        launched_at="2026-06-11T02:00:00Z",
+    )
+    git = FakeGit({"elves/run-x-q2": "aaa"}, {"aaa": None})
+    plan = _run(tmp_path, git)
+    assert plan["mark_dead"] == []
+
+
+# ---------------------------------------------------------------------------
+# relaunch queue
+# ---------------------------------------------------------------------------
+
+
+def test_apply_writes_relaunch_queue_with_briefs(tmp_path: Path) -> None:
+    lanes = _lanes_dir(tmp_path)
+    _write_ledger(
+        lanes,
+        "c06",
+        branch="elves/run-x-c06",
+        launched_at="2026-06-11T02:00:00Z",
+        brief="fix #8101 three sub-bugs; Tier2 merge-on-green",
+    )
+    git = FakeGit({"elves/run-x-c06": "aaa"}, {"aaa": 0})
+    _run(tmp_path, git, apply=True)
+    queue = (lanes / "RELAUNCH_QUEUE.md").read_text()
+    assert "c06" in queue
+    assert "fix #8101 three sub-bugs; Tier2 merge-on-green" in queue
+    assert "elves/run-x-c06" in queue
+
+
+def test_relaunch_queue_includes_previously_dead_lanes(tmp_path: Path) -> None:
+    lanes = _lanes_dir(tmp_path)
+    _write_ledger(
+        lanes,
+        "old-dead",
+        branch="elves/run-x-old",
+        launched_at="2026-06-10T02:00:00Z",
+        status="dead",
+        detected_at="2026-06-10T08:00:00Z",
+        brief="previously detected",
+    )
+    _write_ledger(lanes, "c06", branch="elves/run-x-c06", launched_at="2026-06-11T02:00:00Z")
+    git = FakeGit({"elves/run-x-c06": "aaa"}, {"aaa": 0})
+    _run(tmp_path, git, apply=True)
+    queue = (lanes / "RELAUNCH_QUEUE.md").read_text()
+    assert "old-dead" in queue
+    assert "c06" in queue
+
+
+def test_no_dead_lanes_no_queue_file(tmp_path: Path) -> None:
+    lanes = _lanes_dir(tmp_path)
+    _write_ledger(lanes, "q2", branch="elves/run-x-q2", launched_at="2026-06-11T11:30:00Z")
+    git = FakeGit({"elves/run-x-q2": "aaa"}, {"aaa": 0})
+    _run(tmp_path, git, apply=True)
+    assert not (lanes / "RELAUNCH_QUEUE.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# branch deletion — bounded, with the hard "never delete real work" guarantee
+# ---------------------------------------------------------------------------
+
+
+def test_never_deletes_branch_with_unique_commits(tmp_path: Path) -> None:
+    """HARD GUARANTEE: a branch with any unique commit is never deleted,
+    even when its ledger is dead and the branch is older than the TTL."""
+    lanes = _lanes_dir(tmp_path)
+    _write_ledger(
+        lanes,
+        "c06",
+        branch="elves/run-x-c06",
+        launched_at="2026-06-09T02:00:00Z",
+        status="dead",
+        detected_at="2026-06-10T02:00:00Z",
+    )
+    git = FakeGit({"elves/run-x-c06": "aaa"}, {"aaa": 1}, {"aaa": "2026-06-01T00:00:00Z"})
+    plan = _run(tmp_path, git, apply=True)
+    assert plan["delete_branches"] == []
+    assert git.deleted == []
+
+
+def test_never_deletes_branch_with_unresolvable_ahead(tmp_path: Path) -> None:
+    git = FakeGit({"elves/run-x-mystery": "aaa"}, {"aaa": None}, {"aaa": "2026-06-01T00:00:00Z"})
+    plan = _run(tmp_path, git, apply=True)
+    assert plan["delete_branches"] == []
+    assert git.deleted == []
+
+
+def test_deletes_ledger_dead_zero_ahead_old_branch_on_apply(tmp_path: Path) -> None:
+    lanes = _lanes_dir(tmp_path)
+    _write_ledger(
+        lanes,
+        "c06",
+        branch="elves/run-x-c06",
+        launched_at="2026-06-10T02:00:00Z",
+        status="dead",
+        detected_at="2026-06-10T08:00:00Z",
+    )
+    git = FakeGit({"elves/run-x-c06": "aaa"}, {"aaa": 0}, {"aaa": "2026-06-09T02:00:00Z"})
+    plan = _run(tmp_path, git, apply=True)
+    assert [d["branch"] for d in plan["delete_branches"]] == ["elves/run-x-c06"]
+    assert git.deleted == ["elves/run-x-c06"]
+
+
+def test_newly_detected_dead_lane_branch_deletable_same_run(tmp_path: Path) -> None:
+    """A lane marked dead in this run is immediately eligible (if old + empty)."""
+    lanes = _lanes_dir(tmp_path)
+    _write_ledger(lanes, "c06", branch="elves/run-x-c06", launched_at="2026-06-09T02:00:00Z")
+    git = FakeGit({"elves/run-x-c06": "aaa"}, {"aaa": 0}, {"aaa": "2026-06-09T02:00:00Z"})
+    plan = _run(tmp_path, git, apply=True)
+    assert [d["lane"] for d in plan["mark_dead"]] == ["c06"]
+    assert git.deleted == ["elves/run-x-c06"]
+
+
+def test_dry_run_plans_deletion_without_deleting(tmp_path: Path) -> None:
+    git = FakeGit(
+        {"elves/run-20260610-c06-dead": "aaa"}, {"aaa": 0}, {"aaa": "2026-06-09T02:00:00Z"}
+    )
+    plan = _run(tmp_path, git)
+    assert [d["branch"] for d in plan["delete_branches"]] == ["elves/run-20260610-c06-dead"]
+    assert git.deleted == []
+
+
+def test_deletes_ledgerless_orphan_pattern_branch(tmp_path: Path) -> None:
+    """The real morning-after state: empty branch, no ledger anywhere."""
+    git = FakeGit(
+        {"aragora/boss-harvest/issue-1-boss-x": "bbb"},
+        {"bbb": 0},
+        {"bbb": "2026-06-08T00:00:00Z"},
+    )
+    plan = _run(tmp_path, git, apply=True)
+    assert git.deleted == ["aragora/boss-harvest/issue-1-boss-x"]
+    assert plan["delete_branches"][0]["reason"] == "ledger-less orphan"
+
+
+def test_never_deletes_non_pattern_ledgerless_branch(tmp_path: Path) -> None:
+    git = FakeGit({"feature/manual-work": "aaa"}, {"aaa": 0}, {"aaa": "2026-06-01T00:00:00Z"})
+    plan = _run(tmp_path, git, apply=True)
+    assert plan["delete_branches"] == []
+    assert git.deleted == []
+
+
+def test_never_deletes_branch_younger_than_ttl(tmp_path: Path) -> None:
+    git = FakeGit(
+        {"elves/run-x-young": "aaa"},
+        {"aaa": 0},
+        {"aaa": "2026-06-11T02:00:00Z"},  # 10h
+    )
+    plan = _run(tmp_path, git, apply=True)
+    assert plan["delete_branches"] == []
+    assert git.deleted == []
+
+
+def test_never_deletes_branch_of_live_in_progress_lane(tmp_path: Path) -> None:
+    """A fresh lane whose branch tip is an old main commit (stale base) must
+    be protected by its live ledger even though the branch looks old+empty."""
+    lanes = _lanes_dir(tmp_path)
+    _write_ledger(
+        lanes,
+        "q2",
+        branch="elves/run-x-q2",
+        launched_at="2026-06-11T11:30:00Z",  # 30 min old — alive
+    )
+    git = FakeGit({"elves/run-x-q2": "aaa"}, {"aaa": 0}, {"aaa": "2026-06-08T00:00:00Z"})
+    plan = _run(tmp_path, git, apply=True)
+    assert plan["delete_branches"] == []
+    assert git.deleted == []
+    assert any("live ledger" in s["reason"] for s in plan["skipped"])
+
+
+def test_unknown_commit_date_never_deleted(tmp_path: Path) -> None:
+    git = FakeGit({"elves/run-x-undated": "aaa"}, {"aaa": 0}, {})
+    plan = _run(tmp_path, git, apply=True)
+    assert plan["delete_branches"] == []
+    assert git.deleted == []
+
+
+# ---------------------------------------------------------------------------
+# CLI surface
+# ---------------------------------------------------------------------------
+
+
+def test_main_dry_run_json_exits_zero(tmp_path: Path, capsys: Any, monkeypatch: Any) -> None:
+    lanes = _lanes_dir(tmp_path)
+    _write_ledger(lanes, "c06", branch="elves/run-x-c06", launched_at="2026-06-11T02:00:00Z")
+    git = FakeGit({"elves/run-x-c06": "aaa"}, {"aaa": 0})
+    monkeypatch.setattr(janitor, "GitBoundary", lambda repo: git)
+    code = janitor.main(
+        [
+            "--json",
+            "--runs-glob",
+            str(tmp_path / "run-*" / "lanes"),
+            "--now",
+            "2026-06-11T12:00:00Z",
+        ]
+    )
+    assert code == 0
+    plan = json.loads(capsys.readouterr().out)
+    assert plan["applied"] is False
+    assert [d["lane"] for d in plan["mark_dead"]] == ["c06"]
+    assert git.deleted == []
+
+
+def test_main_apply_executes_plan(tmp_path: Path, capsys: Any, monkeypatch: Any) -> None:
+    lanes = _lanes_dir(tmp_path)
+    path = _write_ledger(lanes, "c06", branch="elves/run-x-c06", launched_at="2026-06-09T02:00:00Z")
+    git = FakeGit({"elves/run-x-c06": "aaa"}, {"aaa": 0}, {"aaa": "2026-06-09T02:00:00Z"})
+    monkeypatch.setattr(janitor, "GitBoundary", lambda repo: git)
+    code = janitor.main(
+        [
+            "--apply",
+            "--json",
+            "--runs-glob",
+            str(tmp_path / "run-*" / "lanes"),
+            "--now",
+            "2026-06-11T12:00:00Z",
+        ]
+    )
+    assert code == 0
+    assert json.loads(path.read_text())["status"] == "dead"
+    assert (lanes / "RELAUNCH_QUEUE.md").exists()
+    assert git.deleted == ["elves/run-x-c06"]
+
+
+def test_relaunch_queue_md_not_parsed_as_ledger(tmp_path: Path) -> None:
+    lanes = _lanes_dir(tmp_path)
+    lanes.mkdir(parents=True)
+    (lanes / "RELAUNCH_QUEUE.md").write_text("# queue\n")
+    git = FakeGit({}, {})
+    plan = _run(tmp_path, git)
+    assert plan["mark_dead"] == []
+    assert plan["errors"] == []


### PR DESCRIPTION
## Summary

Systematizes detection, visibility, and bounded auto-fix for the two live failure classes observed 2026-06-10/11.

**Tier: 2** (merge-on-green authorized). Cites: operator instruction 2026-06-11 (Lane W batch, run-20260610) + Plan v2 Pillar 6 (Dead Man's Signals, `docs/superpowers/plans/2026-06-10-steering-leverage-operating-plan-v2.md`).

### Failure class A — silent lane death
- **`lane_liveness` sentinel check** (`scripts/fleet_sentinel.py`): breaches on `in_progress` lane-ledger entries (`.aragora/run-*/lanes/*.json`) older than `--lane-max-age-hours` (3) whose branch has zero commits ahead of origin/main or is absent; plus a ledger-less orphan sweep over `elves/*` / `aragora/boss*` (zero-ahead, tip > 24h). Includes a breach-replay acceptance test of the real Jun-10 c06/c07/c08 incident.
- **`scripts/lane_janitor.py`** (new, stdlib, TDD, dry-run default / `--apply` gated): marks dead ledgers (`status=dead` + `detected_at`), emits `RELAUNCH_QUEUE.md` with briefs for the coordinator/operator (never relaunches autonomously), and deletes remote branches only when zero-commits-ahead AND ledger-dead (or ledger-less lane-namespace orphan) AND older than `--branch-ttl-hours` (24). **Hard-tested guarantee: a branch with any unique commit is never deleted**; unresolvable ahead counts and unknown tip dates also block deletion.

### Failure class B — external API degradation
- **`github_api_health` sentinel check**: live `gh api rate_limit` probe (injectable runner) + trailing failed-pass streak parsed from the publisher log. Breach only on persistent degradation (probe fails AND streak >= `--persist-threshold`, default 3); transient blips are visible-but-quiet (streak + last error class, e.g. `HTTP 504`, recorded in detail/ledger); unknown when the log is unreadable.
- **Publisher bounded retry** (`scripts/run_codex_automation_publisher.sh`): branch-publish pass retries up to 2 times with 30s/60s backoff and attempt logging. Spend/limit caps unchanged — enforced inside `publish_codex_automation_branches.py` on every attempt. Exact `branch publish pass complete|failed` log markers preserved for the sentinel's streak parser. `bash -n` clean.

### Docs
- `docs/runbooks/LANE_RESILIENCE.md`: the two failure classes, detection, breach meaning, one-command janitor apply, relaunch-queue convention.

## Validation
- 48 new tests; touched files green: `tests/scripts/test_fleet_sentinel.py` (62) + `tests/scripts/test_lane_janitor.py` (22). Full `tests/scripts/` run: only pre-existing `test_agent_bridge_steering.py` failures (reproduced on pristine main, unrelated).
- Live sentinel run (no-ledger): `lane_liveness ok (3 in_progress lanes live; 15 pattern branches, no orphans)`; `github_api_health ok; streak=0; last_error=HTTP 504` — the overnight 502/504 streak had just been reset by a completing pass; the transient error class stays visible without breaching.
- Live janitor dry-run: all 15 lane-namespace branches with unique commits skipped "never delete"; live `in_progress` lane branch protected by its ledger; nothing to do (last night's empty c06/c07/c08 branches were already manually swept before this lane ran). Incident replayed through the real CLI from reconstructed ledgers: 3 dead-lane detections + relaunch queue planned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
