### PR TITLE
fix(reports): fail closed on malformed coverage json

### DIFF
--- a/scripts/coverage_report.py
+++ b/scripts/coverage_report.py
@@ -39,6 +39,24 @@ COVERAGE_THRESHOLDS = {
 }
 
 
+class CoverageJsonError(RuntimeError):
+    """Raised when coverage.json cannot be trusted."""
+
+
+def load_coverage_json(path: Path) -> dict:
+    """Load a coverage.py JSON report or raise a bounded input error."""
+    try:
+        with path.open(encoding="utf-8") as f:
+            payload = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise CoverageJsonError(
+            f"Error: coverage JSON at {path} could not be loaded: {exc}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise CoverageJsonError(f"Error: coverage JSON at {path} must be an object.")
+    return payload
+
+
 def run_coverage() -> dict:
     """Run pytest with coverage and return results."""
     cmd = [
@@ -64,8 +82,7 @@ def run_coverage() -> dict:
         print("Error: coverage.json not found. Run pytest with --cov first.")
         sys.exit(1)
 
-    with open(coverage_file) as f:
-        return json.load(f)
+    return load_coverage_json(coverage_file)
 
 
 def analyze_coverage(coverage_data: dict) -> dict:
@@ -239,10 +256,17 @@ def main():
         if not coverage_file.exists():
             print("Error: coverage.json not found. Run without --no-run first.")
             sys.exit(1)
-        with open(coverage_file) as f:
-            coverage_data = json.load(f)
+        try:
+            coverage_data = load_coverage_json(coverage_file)
+        except CoverageJsonError as exc:
+            print(str(exc), file=sys.stderr)
+            sys.exit(1)
     else:
-        coverage_data = run_coverage()
+        try:
+            coverage_data = run_coverage()
+        except CoverageJsonError as exc:
+            print(str(exc), file=sys.stderr)
+            sys.exit(1)
 
     module_coverage = analyze_coverage(coverage_data)
     overall_coverage = get_overall_coverage(coverage_data)

--- a/tests/scripts/test_coverage_report.py
+++ b/tests/scripts/test_coverage_report.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import scripts.coverage_report as coverage_report
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "coverage_report.py"
+
+
+def test_load_coverage_json_rejects_malformed_json(tmp_path: Path) -> None:
+    coverage_path = tmp_path / "coverage.json"
+    coverage_path.write_text("{not json}\n", encoding="utf-8")
+
+    try:
+        coverage_report.load_coverage_json(coverage_path)
+    except coverage_report.CoverageJsonError as exc:
+        assert "could not be loaded" in str(exc)
+        assert str(coverage_path) in str(exc)
+        assert "line 1 column 2" in str(exc)
+    else:  # pragma: no cover - defensive assertion
+        raise AssertionError("malformed coverage JSON should fail closed")
+
+
+def test_load_coverage_json_rejects_non_object_payload(tmp_path: Path) -> None:
+    coverage_path = tmp_path / "coverage.json"
+    coverage_path.write_text(json.dumps(["coverage"]) + "\n", encoding="utf-8")
+
+    try:
+        coverage_report.load_coverage_json(coverage_path)
+    except coverage_report.CoverageJsonError as exc:
+        assert "must be an object" in str(exc)
+        assert str(coverage_path) in str(exc)
+    else:  # pragma: no cover - defensive assertion
+        raise AssertionError("non-object coverage JSON should fail closed")
+
+
+def test_no_run_json_reports_malformed_coverage_without_traceback(tmp_path: Path) -> None:
+    (tmp_path / "coverage.json").write_text("{not json}\n", encoding="utf-8")
+
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "--no-run", "--json"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 1
+    assert "could not be loaded" in proc.stderr
+    assert "line 1 column 2" in proc.stderr
+    assert "Traceback" not in proc.stderr
+    assert proc.stdout == ""


### PR DESCRIPTION
## Summary
- report malformed `coverage.json` as a bounded coverage-report input failure instead of a traceback
- reject non-object coverage JSON payloads before rendering module coverage summaries
- add focused regression coverage for the `--no-run --json` path

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_coverage_report.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/coverage_report.py tests/scripts/test_coverage_report.py
- git diff --check origin/main...HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD