### PR TITLE
fix(receipts): reject blank epic debate transcripts

### DIFF
--- a/scripts/generate_epic_debate_receipt.py
+++ b/scripts/generate_epic_debate_receipt.py
@@ -11,6 +11,7 @@ Usage:
 
 import hashlib
 import json
+import sys
 from datetime import datetime
 from pathlib import Path
 
@@ -27,9 +28,15 @@ from aragora.gauntlet.result import (
 )
 
 
+class TranscriptParseError(RuntimeError):
+    """Raised when a debate transcript cannot support a receipt."""
+
+
 def parse_debate_transcript(transcript_path: Path) -> dict:
     """Parse the epic debate transcript into structured data."""
-    content = transcript_path.read_text()
+    content = transcript_path.read_text(encoding="utf-8")
+    if not content.strip():
+        raise TranscriptParseError(f"Debate transcript is empty: {transcript_path}")
 
     # Extract agents that participated
     agents = [
@@ -258,15 +265,18 @@ def main():
     # Paths
     transcript_path = Path(".nomic/epic_strategic_debate/debate_transcript.txt")
     output_dir = Path(".nomic/epic_strategic_debate/receipts")
-    output_dir.mkdir(parents=True, exist_ok=True)
 
     if not transcript_path.exists():
-        print(f"Error: Transcript not found at {transcript_path}")
-        return
+        print(f"Error: Transcript not found at {transcript_path}", file=sys.stderr)
+        return 2
 
     # Parse transcript
     print("Parsing debate transcript...")
-    debate_data = parse_debate_transcript(transcript_path)
+    try:
+        debate_data = parse_debate_transcript(transcript_path)
+    except TranscriptParseError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
     print(f"  - {len(debate_data['agents'])} agents participated")
     print(f"  - {len(debate_data['consensus_points'])} consensus points")
     print(f"  - {len(debate_data['recommendations'])} recommendations")
@@ -286,6 +296,7 @@ def main():
     receipt = create_receipt_manually(result, debate_data)
 
     # Export to different formats
+    output_dir.mkdir(parents=True, exist_ok=True)
     json_path = output_dir / "epic_debate_receipt.json"
     md_path = output_dir / "epic_debate_receipt.md"
 
@@ -323,7 +334,8 @@ def main():
     print()
 
     print(f"Full receipts saved to: {output_dir}/")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/tests/scripts/test_generate_epic_debate_receipt.py
+++ b/tests/scripts/test_generate_epic_debate_receipt.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "generate_epic_debate_receipt.py"
+
+
+def _load_module() -> Any:
+    spec = importlib.util.spec_from_file_location("generate_epic_debate_receipt", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_parse_debate_transcript_rejects_blank_input(tmp_path: Path) -> None:
+    module = _load_module()
+    transcript = tmp_path / "debate_transcript.txt"
+    transcript.write_text("\n\t\n", encoding="utf-8")
+
+    try:
+        module.parse_debate_transcript(transcript)
+    except module.TranscriptParseError as exc:
+        assert "Debate transcript is empty" in str(exc)
+        assert str(transcript) in str(exc)
+    else:  # pragma: no cover - defensive assertion
+        raise AssertionError("blank transcript should fail closed")
+
+
+def test_main_rejects_blank_transcript_without_writing_receipts(tmp_path: Path) -> None:
+    debate_dir = tmp_path / ".nomic" / "epic_strategic_debate"
+    debate_dir.mkdir(parents=True)
+    (debate_dir / "debate_transcript.txt").write_text("\n\t\n", encoding="utf-8")
+
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 2
+    assert "Debate transcript is empty" in proc.stderr
+    assert "Traceback" not in proc.stderr
+    assert not (debate_dir / "receipts").exists()


### PR DESCRIPTION
## Summary
- reject blank or whitespace-only epic debate transcripts before generating decision receipt data
- avoid creating receipt output directories until transcript parsing succeeds
- add focused regression coverage for parser and CLI behavior

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_generate_epic_debate_receipt.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/generate_epic_debate_receipt.py tests/scripts/test_generate_epic_debate_receipt.py
- git diff --check origin/main...HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD