### PR TITLE
fix(proof): reject impossible capability matrix coverage

### DIFF
--- a/scripts/capability_matrix_delta.py
+++ b/scripts/capability_matrix_delta.py
@@ -6,11 +6,16 @@ from __future__ import annotations
 import argparse
 import re
 import subprocess
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 MATRIX_PATH = Path("docs/CAPABILITY_MATRIX.md")
+
+
+class MatrixParseError(RuntimeError):
+    """Raised when capability matrix metrics cannot be trusted."""
 
 
 def _extract(pattern: str, text: str) -> tuple[int, ...] | None:
@@ -33,8 +38,16 @@ def _parse_matrix(text: str) -> dict[str, tuple[int, ...]]:
     for key, pattern in patterns.items():
         vals = _extract(pattern, text)
         if vals is None:
-            raise ValueError(f"Could not parse metric '{key}' from capability matrix")
+            raise MatrixParseError(f"Could not parse metric '{key}' from capability matrix")
         parsed[key] = vals
+
+    mapped, total = parsed["catalog"]
+    if total <= 0:
+        raise MatrixParseError("Capability Catalog total must be greater than zero")
+    if mapped > total:
+        raise MatrixParseError(
+            f"Capability Catalog mapped count {mapped} exceeds total count {total}"
+        )
 
     return parsed
 
@@ -85,8 +98,12 @@ def main() -> int:
     current_path = repo_root / MATRIX_PATH
     out_path = Path(args.out)
 
-    current_text = _load_text(current_path)
-    current = _parse_matrix(current_text)
+    try:
+        current_text = _load_text(current_path)
+        current = _parse_matrix(current_text)
+    except (OSError, MatrixParseError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
 
     base: dict[str, tuple[int, ...]] | None = None
     base_note = ""
@@ -94,7 +111,11 @@ def main() -> int:
     if args.base_ref:
         base_text = _load_base_text(repo_root, args.base_ref)
         if base_text:
-            base = _parse_matrix(base_text)
+            try:
+                base = _parse_matrix(base_text)
+            except MatrixParseError as exc:
+                print(f"Error: base capability matrix is invalid: {exc}", file=sys.stderr)
+                return 2
         else:
             base_note = (
                 f"Base matrix unavailable for ref `{args.base_ref}`; showing head snapshot only."

--- a/tests/scripts/test_capability_matrix_delta.py
+++ b/tests/scripts/test_capability_matrix_delta.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import scripts.capability_matrix_delta as capability_matrix_delta
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "capability_matrix_delta.py"
+
+
+def _matrix_text(*, mapped: int = 3, total: int = 5) -> str:
+    return "\n".join(
+        [
+            "| Surface | Coverage |",
+            "|---|---|",
+            "| **HTTP API** | 10 paths / 12 operations |",
+            "| **CLI** | 4 commands |",
+            "| **SDK (Python)** | 2 namespaces |",
+            "| **SDK (TypeScript)** | 2 namespaces |",
+            f"| **Capability Catalog** | {mapped}/{total} mapped |",
+            "",
+        ]
+    )
+
+
+def test_parse_matrix_rejects_catalog_mapped_count_above_total() -> None:
+    try:
+        capability_matrix_delta._parse_matrix(_matrix_text(mapped=9, total=3))
+    except capability_matrix_delta.MatrixParseError as exc:
+        assert "mapped count 9 exceeds total count 3" in str(exc)
+    else:  # pragma: no cover - defensive assertion
+        raise AssertionError("impossible catalog coverage should fail closed")
+
+
+def test_parse_matrix_rejects_zero_catalog_total() -> None:
+    try:
+        capability_matrix_delta._parse_matrix(_matrix_text(mapped=0, total=0))
+    except capability_matrix_delta.MatrixParseError as exc:
+        assert "total must be greater than zero" in str(exc)
+    else:  # pragma: no cover - defensive assertion
+        raise AssertionError("zero catalog total should fail closed")
+
+
+def test_cli_rejects_invalid_current_matrix_without_writing_output(tmp_path: Path) -> None:
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "CAPABILITY_MATRIX.md").write_text(
+        _matrix_text(mapped=9, total=3),
+        encoding="utf-8",
+    )
+    output = tmp_path / "summary.md"
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--root",
+            str(tmp_path),
+            "--out",
+            str(output),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 2
+    assert "mapped count 9 exceeds total count 3" in proc.stderr
+    assert "Traceback" not in proc.stderr
+    assert not output.exists()


### PR DESCRIPTION
## Summary
- reject capability matrix catalog counts where mapped capabilities exceed total capabilities
- reject zero-total capability catalog rows before rendering misleading coverage
- add focused regression coverage for parser and CLI no-output behavior

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_capability_matrix_delta.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/capability_matrix_delta.py tests/scripts/test_capability_matrix_delta.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python scripts/capability_matrix_delta.py --root . --out /tmp/<tmp>/summary.md
- git diff --check origin/main...HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD