### PR TITLE
fix(benchmarks): validate triage profile metrics

### DIFF
--- a/scripts/benchmark_triage_profiles.py
+++ b/scripts/benchmark_triage_profiles.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import math
 import sys
 from pathlib import Path
 from typing import Any
@@ -65,6 +66,25 @@ def _bool(value: Any, *, label: str) -> bool:
     return value
 
 
+def _finite_number(value: Any, *, label: str) -> float:
+    if not isinstance(value, (int, float)) or isinstance(value, bool) or not math.isfinite(value):
+        raise ValueError(f"{label} must be a finite number")
+    return float(value)
+
+
+def _bounded_number(
+    value: Any,
+    *,
+    label: str,
+    minimum: float,
+    maximum: float,
+) -> float:
+    number = _finite_number(value, label=label)
+    if number < minimum or number > maximum:
+        raise ValueError(f"{label} must be between {minimum:g} and {maximum:g}")
+    return number
+
+
 def validate_report_shape(report: dict[str, Any]) -> None:
     comparison = report.get("comparison")
     profiles = report.get("profiles")
@@ -80,6 +100,22 @@ def validate_report_shape(report: dict[str, Any]) -> None:
     acceptance = comparison.get("acceptance")
     if not isinstance(acceptance, dict):
         raise ValueError("comparison.acceptance must be an object")
+    _bounded_number(
+        comparison.get("agreement_rate"),
+        label="comparison.agreement_rate",
+        minimum=0.0,
+        maximum=1.0,
+    )
+    _finite_number(
+        comparison.get("latency_improvement_pct"),
+        label="comparison.latency_improvement_pct",
+    )
+    _bounded_number(
+        comparison.get("blocked_rate_delta_pp"),
+        label="comparison.blocked_rate_delta_pp",
+        minimum=-100.0,
+        maximum=100.0,
+    )
     acceptance_values = [
         _bool(acceptance.get(key), label=f"comparison.acceptance.{key}") for key in ACCEPTANCE_KEYS
     ]

--- a/tests/scripts/test_benchmark_triage_profiles.py
+++ b/tests/scripts/test_benchmark_triage_profiles.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 import sys
 from pathlib import Path
 
@@ -193,6 +194,9 @@ def test_main_rejects_missing_acceptance_field_before_writing_report(
         },
         "comparison": {
             "message_count": 2,
+            "agreement_rate": 1.0,
+            "latency_improvement_pct": 10.0,
+            "blocked_rate_delta_pp": 0.0,
             "acceptance": {
                 "decision_agreement": True,
                 "latency_improvement": True,
@@ -235,6 +239,9 @@ def test_main_rejects_inconsistent_acceptance_summary_before_writing_report(
         },
         "comparison": {
             "message_count": 2,
+            "agreement_rate": 1.0,
+            "latency_improvement_pct": 10.0,
+            "blocked_rate_delta_pp": 0.0,
             "acceptance": {
                 "decision_agreement": True,
                 "latency_improvement": False,
@@ -261,4 +268,96 @@ def test_main_rejects_inconsistent_acceptance_summary_before_writing_report(
     captured = capsys.readouterr()
     assert exit_code == 2
     assert "comparison.passes_all_thresholds must match" in captured.err
+    assert not output_path.exists()
+
+
+def test_main_rejects_impossible_comparison_rates_before_writing_report(
+    monkeypatch,
+    tmp_path,
+    capsys,
+) -> None:
+    report = {
+        "fixture_path": "/tmp/fixtures.json",
+        "generated_at": "2026-03-25T00:00:00Z",
+        "profiles": {
+            "baseline": {"message_count": 2},
+            "staged_v1": {"message_count": 2},
+        },
+        "comparison": {
+            "message_count": 2,
+            "agreement_rate": 1.2,
+            "latency_improvement_pct": 10.0,
+            "blocked_rate_delta_pp": 0.0,
+            "acceptance": {
+                "decision_agreement": True,
+                "latency_improvement": True,
+                "blocked_rate_delta": True,
+                "unsafe_auto_approval": True,
+            },
+            "passes_all_thresholds": True,
+        },
+    }
+
+    async def _fake_run(*args, **kwargs):
+        del args, kwargs
+        return report
+
+    fixture_path = tmp_path / "fixtures.json"
+    fixture_path.write_text("[]", encoding="utf-8")
+    output_path = tmp_path / "report.json"
+    monkeypatch.setattr(benchmark_triage_profiles, "run_fixture_benchmark", _fake_run)
+
+    exit_code = benchmark_triage_profiles.main(
+        ["--fixtures", str(fixture_path), "--output", str(output_path)]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "comparison.agreement_rate must be between 0 and 1" in captured.err
+    assert not output_path.exists()
+
+
+def test_main_rejects_non_finite_latency_metric_before_writing_report(
+    monkeypatch,
+    tmp_path,
+    capsys,
+) -> None:
+    report = {
+        "fixture_path": "/tmp/fixtures.json",
+        "generated_at": "2026-03-25T00:00:00Z",
+        "profiles": {
+            "baseline": {"message_count": 2},
+            "staged_v1": {"message_count": 2},
+        },
+        "comparison": {
+            "message_count": 2,
+            "agreement_rate": 1.0,
+            "latency_improvement_pct": math.inf,
+            "blocked_rate_delta_pp": 0.0,
+            "acceptance": {
+                "decision_agreement": True,
+                "latency_improvement": True,
+                "blocked_rate_delta": True,
+                "unsafe_auto_approval": True,
+            },
+            "passes_all_thresholds": True,
+        },
+    }
+
+    async def _fake_run(*args, **kwargs):
+        del args, kwargs
+        return report
+
+    fixture_path = tmp_path / "fixtures.json"
+    fixture_path.write_text("[]", encoding="utf-8")
+    output_path = tmp_path / "report.json"
+    monkeypatch.setattr(benchmark_triage_profiles, "run_fixture_benchmark", _fake_run)
+
+    exit_code = benchmark_triage_profiles.main(
+        ["--fixtures", str(fixture_path), "--output", str(output_path)]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "comparison.latency_improvement_pct must be a finite number" in captured.err
     assert not output_path.exists()


### PR DESCRIPTION
## Summary
- reject impossible triage profile benchmark comparison rates before rendering reports
- reject non-finite latency improvement metrics before writing JSON output
- add focused regression coverage for malformed metric outputs

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_benchmark_triage_profiles.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/benchmark_triage_profiles.py tests/scripts/test_benchmark_triage_profiles.py
- git diff --check origin/main...HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD