### PR TITLE
fix(receipts): preserve generated schema containers

### DIFF
--- a/scripts/generate_receipt_schema.py
+++ b/scripts/generate_receipt_schema.py
@@ -38,20 +38,25 @@ _PYTHON_TO_JSON_TYPE: dict[str, str | list[str]] = {
 def _python_type_to_json(annotation: str) -> str | list[str]:
     """Map a simplified Python type annotation to a JSON Schema type string."""
     clean = annotation.replace("typing.", "").strip()
+    is_optional = "None" in clean
+
     # Handle Optional / union with None
-    if "None" in clean:
-        base = (
+    if is_optional:
+        clean = (
             clean.replace("| None", "")
             .replace("None |", "")
             .replace("Optional[", "")
             .rstrip("]")
             .strip()
         )
-        json_type = _PYTHON_TO_JSON_TYPE.get(base, "string")
+
+    base = clean.split("[", 1)[0].strip()
+    json_type = _PYTHON_TO_JSON_TYPE.get(base, "string")
+    if is_optional:
         if isinstance(json_type, list):
             return [*json_type, "null"]
         return [json_type, "null"]
-    return _PYTHON_TO_JSON_TYPE.get(clean, "string")
+    return json_type
 
 
 def _field_schema(f: dataclasses.Field[Any]) -> dict[str, Any]:

--- a/tests/scripts/test_generate_receipt_schema.py
+++ b/tests/scripts/test_generate_receipt_schema.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "generate_receipt_schema.py"
+
+
+def _load_module() -> Any:
+    spec = importlib.util.spec_from_file_location("generate_receipt_schema", SCRIPT_PATH)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules["generate_receipt_schema"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+schema_mod = _load_module()
+
+
+def test_python_type_to_json_maps_generic_containers() -> None:
+    assert schema_mod._python_type_to_json("list[str]") == "array"
+    assert schema_mod._python_type_to_json("list[ReceiptFinding]") == "array"
+    assert schema_mod._python_type_to_json("dict[str, Any]") == "object"
+    assert schema_mod._python_type_to_json("dict[str, Any] | None") == ["object", "null"]
+    assert schema_mod._python_type_to_json("list[dict] | None") == ["array", "null"]
+
+
+def test_export_decision_receipt_schema_preserves_container_types() -> None:
+    schema = schema_mod.generate_decision_receipt_schema()
+    properties = schema["properties"]
+
+    assert properties["findings"]["type"] == "array"
+    assert properties["mitigations"]["type"] == "array"
+    assert properties["dissenting_views"]["type"] == "array"
+    assert properties["verified_claims"]["type"] == "array"
+    assert properties["cost_summary"]["type"] == ["object", "null"]
+
+
+def test_gauntlet_receipt_schema_preserves_container_types() -> None:
+    schema = schema_mod.generate_gauntlet_receipt_schema()
+    properties = schema["properties"]
+
+    assert properties["vulnerability_details"]["type"] == "array"
+    assert properties["dissenting_views"]["type"] == "array"
+    assert properties["provenance_chain"]["type"] == "array"
+    assert properties["agent_responses"]["type"] == "array"
+    assert properties["explainability"]["type"] == ["object", "null"]
+    assert properties["settlement_metadata"]["type"] == ["object", "null"]
+    assert properties["config_used"]["type"] == "object"


### PR DESCRIPTION
## Summary
- render generic receipt schema list fields as JSON Schema arrays instead of strings
- render generic dict fields and nullable dicts as object/object-or-null
- add focused tests for the receipt schema type renderer and generated receipt schemas

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_generate_receipt_schema.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/generate_receipt_schema.py tests/scripts/test_generate_receipt_schema.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/generate_receipt_schema.py tests/scripts/test_generate_receipt_schema.py
- git diff --check origin/main...HEAD
- /Users/armand/.pyenv/versions/3.11.11/bin/python scripts/generate_receipt_schema.py --stdout | /Users/armand/.pyenv/versions/3.11.11/bin/python -c 'import sys; text=sys.stdin.read(); assert "\\\"findings\\\": {\\n      \\\"type\\\": \\\"array\\\"" in text; assert "\\\"cost_summary\\\": {\\n      \\\"type\\\": [\\n        \\\"object\\\",\\n        \\\"null\\\"" in text; assert "\\\"config_used\\\": {\\n      \\\"type\\\": \\\"object\\\"" in text'\n- bash scripts/automation_pr_preflight.sh origin/main HEAD