### PR TITLE
fix(metrics): reject impossible DR timings

### DIFF
--- a/scripts/dr_metrics.py
+++ b/scripts/dr_metrics.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import math
 import sqlite3
 import sys
 import tempfile
@@ -80,6 +81,22 @@ class DRMetrics:
     def to_dict(self) -> dict:
         """Convert to dictionary for JSON serialization."""
         return asdict(self)
+
+
+def _valid_seconds(value: float) -> float | None:
+    """Return a finite, non-negative second value, or None for invalid metrics."""
+    if isinstance(value, bool):
+        return None
+
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError):
+        return None
+
+    if not math.isfinite(seconds) or seconds < 0:
+        return None
+
+    return seconds
 
 
 async def create_test_database(db_path: Path, num_records: int = 1000) -> None:
@@ -250,12 +267,18 @@ def calculate_compliance(
     Returns:
         Tuple of (rto_compliance, rpo_compliance) dicts
     """
+    restore_seconds = _valid_seconds(restore_time)
+    backup_age_seconds = _valid_seconds(backup_age)
     rto_compliance = {}
     rpo_compliance = {}
 
     for tier, targets in SLA_TARGETS.items():
-        rto_compliance[tier] = restore_time <= targets.rto_seconds
-        rpo_compliance[tier] = backup_age <= targets.rpo_seconds
+        rto_compliance[tier] = (
+            restore_seconds is not None and restore_seconds <= targets.rto_seconds
+        )
+        rpo_compliance[tier] = (
+            backup_age_seconds is not None and backup_age_seconds <= targets.rpo_seconds
+        )
 
     return rto_compliance, rpo_compliance
 

--- a/tests/scripts/test_dr_metrics.py
+++ b/tests/scripts/test_dr_metrics.py
@@ -1,0 +1,52 @@
+import math
+
+import pytest
+
+from scripts.dr_metrics import SLA_TARGETS, calculate_compliance
+
+
+def _assert_all_tiers_false(compliance: dict[str, bool]) -> None:
+    assert set(compliance) == set(SLA_TARGETS)
+    assert not any(compliance.values())
+
+
+def test_calculate_compliance_preserves_valid_tier_results() -> None:
+    rto_compliance, rpo_compliance = calculate_compliance(
+        restore_time=2 * 3600,
+        backup_age=30 * 60,
+    )
+
+    assert rto_compliance == {
+        "free": True,
+        "pro": True,
+        "enterprise": False,
+    }
+    assert rpo_compliance == {
+        "free": True,
+        "pro": True,
+        "enterprise": False,
+    }
+
+
+@pytest.mark.parametrize("restore_time", [-1.0, math.nan, math.inf, -math.inf, True])
+def test_calculate_compliance_fails_closed_for_invalid_restore_time(
+    restore_time: float,
+) -> None:
+    rto_compliance, rpo_compliance = calculate_compliance(
+        restore_time=restore_time,
+        backup_age=0.0,
+    )
+
+    _assert_all_tiers_false(rto_compliance)
+    assert all(rpo_compliance.values())
+
+
+@pytest.mark.parametrize("backup_age", [-1.0, math.nan, math.inf, -math.inf, False])
+def test_calculate_compliance_fails_closed_for_invalid_backup_age(backup_age: float) -> None:
+    rto_compliance, rpo_compliance = calculate_compliance(
+        restore_time=0.0,
+        backup_age=backup_age,
+    )
+
+    assert all(rto_compliance.values())
+    _assert_all_tiers_false(rpo_compliance)


### PR DESCRIPTION
## Summary
- reject negative, boolean, or non-finite DR timing measurements before RTO/RPO compliance reporting
- preserve existing tier compliance comparisons for valid measurements
- add focused regression coverage for impossible timing inputs

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_dr_metrics.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/dr_metrics.py tests/scripts/test_dr_metrics.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/dr_metrics.py tests/scripts/test_dr_metrics.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python scripts/dr_metrics.py --dry-run --ci-mode
- git diff --check origin/main...HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD