### PR TITLE
fix(proof): reject impossible freshness thresholds

### DIFF
--- a/scripts/probe_proof_surface_freshness.py
+++ b/scripts/probe_proof_surface_freshness.py
@@ -68,6 +68,7 @@ import argparse
 import dataclasses
 import datetime as dt
 import json
+import math
 import re
 import sys
 from pathlib import Path
@@ -197,6 +198,7 @@ def probe_surface(
     now: dt.datetime,
 ) -> SurfaceProbeResult:
     """Probe a single named surface against ``max_age_days``."""
+    max_age_days = _validate_max_age_days(max_age_days)
     try:
         rel = SURFACE_PATHS[surface.lower()]
     except KeyError as exc:
@@ -249,6 +251,7 @@ def probe_surfaces(
     now: dt.datetime,
 ) -> list[SurfaceProbeResult]:
     """Probe ``surfaces`` and return one result per entry, in order."""
+    max_age_days = _validate_max_age_days(max_age_days)
     results: list[SurfaceProbeResult] = []
     for surface in surfaces:
         results.append(
@@ -285,6 +288,25 @@ def _split_surfaces(raw: str) -> list[str]:
     return deduped
 
 
+def _validate_max_age_days(value: float) -> float:
+    try:
+        days = float(value)
+    except (TypeError, ValueError) as exc:
+        raise FreshnessProbeError("--max-age-days must be a finite non-negative number") from exc
+
+    if not math.isfinite(days) or days < 0:
+        raise FreshnessProbeError("--max-age-days must be a finite non-negative number")
+
+    return days
+
+
+def _max_age_days_arg(raw: str) -> float:
+    try:
+        return _validate_max_age_days(float(raw))
+    except FreshnessProbeError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
@@ -294,7 +316,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--max-age-days",
-        type=float,
+        type=_max_age_days_arg,
         default=DEFAULT_MAX_AGE_DAYS,
         help=(
             "Maximum permitted age (in days) of the 'Last updated:' "
@@ -348,12 +370,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     surfaces = list(args.surfaces)
-    if args.max_age_days < 0:
-        print(
-            "error: --max-age-days must be non-negative",
-            file=sys.stderr,
-        )
-        return 2
+    max_age_days = _validate_max_age_days(args.max_age_days)
 
     now = dt.datetime.now(tz=dt.timezone.utc)
 
@@ -361,14 +378,14 @@ def main(argv: Sequence[str] | None = None) -> int:
         results = probe_surfaces(
             surfaces,
             repo_root=args.repo_root,
-            max_age_days=args.max_age_days,
+            max_age_days=max_age_days,
             now=now,
         )
     except FreshnessProbeError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
 
-    output = _render_json(results, max_age_days=args.max_age_days, pretty=args.pretty)
+    output = _render_json(results, max_age_days=max_age_days, pretty=args.pretty)
     print(output)
 
     stale = [r for r in results if not r.fresh]

--- a/tests/scripts/test_probe_proof_surface_freshness.py
+++ b/tests/scripts/test_probe_proof_surface_freshness.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import datetime as dt
 import importlib.util
 import json
+import math
 import subprocess
 import sys
 from pathlib import Path
@@ -148,6 +149,22 @@ def test_probe_surface_rejects_material_future_timestamp(mock_repo: Path) -> Non
         probe_mod.probe_surface("b0", repo_root=mock_repo, max_age_days=7, now=now)
 
 
+@pytest.mark.parametrize("max_age_days", [-1, math.nan, math.inf, -math.inf])
+def test_probe_surface_rejects_impossible_max_age_days(
+    mock_repo: Path,
+    max_age_days: float,
+) -> None:
+    _write_surface(
+        mock_repo,
+        "docs/status/B0_BENCHMARK_TRUTH_STATUS.md",
+        "Last updated: 2026-05-17T00:00:00Z",
+    )
+    now = dt.datetime(2026, 5, 18, 0, 0, 0, tzinfo=dt.timezone.utc)
+
+    with pytest.raises(probe_mod.FreshnessProbeError, match="finite non-negative"):
+        probe_mod.probe_surface("b0", repo_root=mock_repo, max_age_days=max_age_days, now=now)
+
+
 # ---------------------------------------------------------------------------
 # CLI / acceptance tests required by the lane brief.
 # ---------------------------------------------------------------------------
@@ -257,6 +274,25 @@ def test_cli_malformed_last_updated_raises_clear_error(
     assert "malformed" in proc.stderr.lower()
     assert "garbage-not-a-date" in proc.stderr
     assert "b0" in proc.stderr
+
+
+@pytest.mark.parametrize("max_age_days", ["-1", "nan", "inf", "-inf"])
+def test_cli_rejects_impossible_max_age_days(
+    mock_repo: Path,
+    max_age_days: str,
+) -> None:
+    fresh = _today_iso()
+    _write_surface(
+        mock_repo,
+        "docs/status/B0_BENCHMARK_TRUTH_STATUS.md",
+        f"Last updated: {fresh}",
+    )
+
+    proc = _run_cli(mock_repo, "--surfaces", "b0", f"--max-age-days={max_age_days}")
+
+    assert proc.returncode == 2, (proc.stdout, proc.stderr)
+    assert proc.stdout == ""
+    assert "finite non-negative" in proc.stderr
 
 
 def test_cli_future_last_updated_raises_clear_error(mock_repo: Path) -> None:


### PR DESCRIPTION
## Summary
- reject negative and non-finite proof-surface freshness thresholds at the CLI/parser boundary
- validate imported helper calls before rendering operator JSON
- add focused regression coverage for impossible max-age values

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_probe_proof_surface_freshness.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/probe_proof_surface_freshness.py tests/scripts/test_probe_proof_surface_freshness.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/probe_proof_surface_freshness.py tests/scripts/test_probe_proof_surface_freshness.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python scripts/probe_proof_surface_freshness.py --surfaces b0 --max-age-days 7 --pretty
- /Users/armand/.pyenv/versions/3.11.11/bin/python scripts/probe_proof_surface_freshness.py --surfaces b0 --max-age-days=nan --pretty
- git diff --check origin/main...HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD