### PR TITLE
fix(metrics): validate leverage operator minutes

### DIFF
--- a/scripts/measure_leverage_ratio.py
+++ b/scripts/measure_leverage_ratio.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import re
 import subprocess
 import sys
@@ -52,6 +53,8 @@ OPERATOR_MINUTES_REFUSAL = (
     "human minutes actually spent steering this window (approvals, design "
     "reviews, queue replies) and pass it explicitly."
 )
+
+OPERATOR_MINUTES_INVALID = "refusing to run: --operator-minutes must be a finite positive number."
 
 # Receipt references in PR bodies/comments: any path-ish token whose parent
 # directory chain contains a `receipts/` segment and that ends in .json.
@@ -145,6 +148,17 @@ def resolve_receipt_path(ref: str, receipts_dirs: Sequence[Path]) -> Path | None
     return None
 
 
+def validate_operator_minutes(operator_minutes: float) -> float:
+    """Return a safe LR denominator or raise ValueError."""
+    if (
+        isinstance(operator_minutes, bool)
+        or not math.isfinite(operator_minutes)
+        or operator_minutes <= 0
+    ):
+        raise ValueError(OPERATOR_MINUTES_INVALID)
+    return operator_minutes
+
+
 def compute_leverage(
     *,
     merged_prs: list[dict],
@@ -159,6 +173,7 @@ def compute_leverage(
     operator_minutes_note: str = "",
 ) -> dict:
     """Compute the leverage-ratio report from already-fetched inputs."""
+    operator_minutes = validate_operator_minutes(operator_minutes)
     merged_receipt_backed = 0
     failed_verify_paths: list[str] = []
     refs_unresolved = 0
@@ -400,8 +415,13 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--status-doc", default=DEFAULT_STATUS_DOC)
     args = parser.parse_args(argv)
 
-    if args.operator_minutes is None or args.operator_minutes <= 0:
+    if args.operator_minutes is None:
         print(OPERATOR_MINUTES_REFUSAL, file=sys.stderr)
+        return 2
+    try:
+        operator_minutes = validate_operator_minutes(args.operator_minutes)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
         return 2
 
     window_end = datetime.now(timezone.utc)
@@ -414,7 +434,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     merged_prs = fetch_merged_prs(args.repo, window_start)
     result = compute_leverage(
         merged_prs=merged_prs,
-        operator_minutes=args.operator_minutes,
+        operator_minutes=operator_minutes,
         receipts_dirs=receipts_dirs,
         comments_fetcher=lambda n: fetch_issue_comments(args.repo, n),
         verifier=verify_receipt,

--- a/tests/scripts/test_measure_leverage_ratio.py
+++ b/tests/scripts/test_measure_leverage_ratio.py
@@ -7,6 +7,7 @@ calls happen in these tests.
 from __future__ import annotations
 
 import json
+import math
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -185,6 +186,23 @@ class TestComputeLeverage:
         assert result["merged_receipt_backed"] == 1
         assert result["receipts_failed_verify"] == 1
 
+    @pytest.mark.parametrize("operator_minutes", [0.0, -1.0, math.nan, math.inf, -math.inf, True])
+    def test_rejects_impossible_operator_minutes(
+        self, tmp_path: Path, operator_minutes: float
+    ) -> None:
+        with pytest.raises(ValueError, match="finite positive"):
+            compute_leverage(
+                merged_prs=[],
+                operator_minutes=operator_minutes,
+                receipts_dirs=[tmp_path],
+                comments_fetcher=lambda n: [],
+                verifier=lambda p: True,
+                window_start=WINDOW_START,
+                window_end=NOW,
+                window_days=7,
+                repo="synaptent/aragora",
+            )
+
 
 # ---------------------------------------------------------------------------
 # CLI refusal contract: operator-minutes must never be invented
@@ -206,6 +224,15 @@ class TestOperatorMinutesRefusal:
     def test_refuses_negative_operator_minutes(self, capsys: pytest.CaptureFixture) -> None:
         rc = main(["--operator-minutes", "-3"])
         assert rc == 2
+
+    @pytest.mark.parametrize("value", ["nan", "inf", "-inf"])
+    def test_refuses_non_finite_operator_minutes(
+        self, value: str, capsys: pytest.CaptureFixture
+    ) -> None:
+        rc = main([f"--operator-minutes={value}", "--json"])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "finite positive" in err
 
 
 class TestMainJson:


### PR DESCRIPTION
## Summary
- validate leverage-ratio operator minutes as a finite positive denominator in shared computation
- reuse that validation in the CLI before fetching or emitting reports
- add regression coverage for non-positive and non-finite operator-minute inputs

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_measure_leverage_ratio.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/measure_leverage_ratio.py tests/scripts/test_measure_leverage_ratio.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/measure_leverage_ratio.py tests/scripts/test_measure_leverage_ratio.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD