### PR TITLE
fix(reports): validate openapi coverage thresholds

### DIFF
--- a/scripts/analyze_openapi_coverage.py
+++ b/scripts/analyze_openapi_coverage.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import sys
 from pathlib import Path
 from typing import Any
@@ -194,7 +195,14 @@ def print_report(analysis: dict[str, Any], verbose: bool = False) -> None:
             print(f"  [{tags}] {endpoint['method']:6} {endpoint['path']}")
 
 
-def main():
+def validate_fail_threshold(value: float) -> float:
+    """Return a safe coverage threshold or raise ValueError."""
+    if isinstance(value, bool) or not math.isfinite(value) or value < 0 or value > 100:
+        raise ValueError("--fail-threshold must be a finite percentage between 0 and 100")
+    return value
+
+
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Analyze OpenAPI schema coverage")
     parser.add_argument("--json", action="store_true", help="Output as JSON")
     parser.add_argument("--verbose", "-v", action="store_true", help="Show all missing endpoints")
@@ -204,7 +212,16 @@ def main():
         default=None,
         help="Fail (exit 1) if response coverage is below this percentage (0-100)",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
+
+    if args.fail_threshold is not None:
+        try:
+            fail_threshold = validate_fail_threshold(args.fail_threshold)
+        except ValueError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+    else:
+        fail_threshold = None
 
     spec = load_openapi_spec()
     analysis = analyze_coverage(spec)
@@ -216,11 +233,11 @@ def main():
     else:
         print_report(analysis, verbose=args.verbose)
 
-    if args.fail_threshold is not None:
+    if fail_threshold is not None:
         coverage = analysis["summary"]["response_coverage_pct"]
-        if coverage < args.fail_threshold:
+        if coverage < fail_threshold:
             print(
-                f"\n::error::OpenAPI coverage {coverage:.1f}% is below threshold {args.fail_threshold:.1f}%",
+                f"\n::error::OpenAPI coverage {coverage:.1f}% is below threshold {fail_threshold:.1f}%",
                 file=sys.stderr,
             )
             return 1

--- a/tests/scripts/test_analyze_openapi_coverage.py
+++ b/tests/scripts/test_analyze_openapi_coverage.py
@@ -1,0 +1,75 @@
+"""Tests for scripts/analyze_openapi_coverage.py."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import pytest
+
+import scripts.analyze_openapi_coverage as coverage
+
+
+def _spec_with_response_schema() -> dict[str, Any]:
+    return {
+        "paths": {
+            "/health": {
+                "get": {
+                    "operationId": "getHealth",
+                    "tags": ["Health"],
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": {"ok": {"type": "boolean"}},
+                                    }
+                                }
+                            }
+                        }
+                    },
+                }
+            }
+        }
+    }
+
+
+@pytest.mark.parametrize("value", [0.0, 50.5, 100.0])
+def test_validate_fail_threshold_accepts_percentages(value: float) -> None:
+    assert coverage.validate_fail_threshold(value) == value
+
+
+@pytest.mark.parametrize("value", [-0.1, 100.1, math.nan, math.inf, -math.inf, True])
+def test_validate_fail_threshold_rejects_impossible_values(value: float) -> None:
+    with pytest.raises(ValueError, match="finite percentage between 0 and 100"):
+        coverage.validate_fail_threshold(value)
+
+
+@pytest.mark.parametrize("value", ["nan", "inf", "-inf", "-1", "101"])
+def test_main_refuses_invalid_fail_threshold_before_loading_spec(
+    value: str,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def fail_load() -> dict[str, Any]:
+        raise AssertionError("spec should not be loaded for invalid threshold")
+
+    monkeypatch.setattr(coverage, "load_openapi_spec", fail_load)
+
+    rc = coverage.main([f"--fail-threshold={value}", "--json"])
+
+    assert rc == 2
+    assert "finite percentage between 0 and 100" in capsys.readouterr().err
+
+
+def test_main_accepts_valid_fail_threshold(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(coverage, "load_openapi_spec", _spec_with_response_schema)
+
+    rc = coverage.main(["--fail-threshold=100", "--json"])
+
+    assert rc == 0
+    assert '"response_coverage_pct": 100.0' in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- validate OpenAPI coverage fail thresholds as finite percentages in the 0-100 range
- fail closed before loading specs or emitting reports when the threshold is impossible
- add focused regression coverage for invalid threshold inputs and a valid CLI path

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_analyze_openapi_coverage.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/analyze_openapi_coverage.py tests/scripts/test_analyze_openapi_coverage.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/analyze_openapi_coverage.py tests/scripts/test_analyze_openapi_coverage.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD