### PR TITLE
fix(coverage): validate selector changed counts

### DIFF
--- a/scripts/check_zero_coverage_gate.py
+++ b/scripts/check_zero_coverage_gate.py
@@ -38,6 +38,15 @@ def _new_zero_coverage_files(coverage: dict[str, Any], baseline: set[str]) -> li
     return sorted(zero_cov)
 
 
+def _invalid_changed_python_count(changed_python_count: int) -> list[str] | None:
+    if changed_python_count < 0:
+        return [
+            f"::error::Changed Python file count cannot be negative: {changed_python_count}",
+            "::error::PR-scoped coverage selector metadata is invalid; zero-coverage gate cannot verify this change",
+        ]
+    return None
+
+
 def evaluate_zero_coverage_gate(
     *,
     coverage_path: Path,
@@ -45,6 +54,10 @@ def evaluate_zero_coverage_gate(
     selector_status: str,
     changed_python_count: int,
 ) -> tuple[bool, list[str]]:
+    count_errors = _invalid_changed_python_count(changed_python_count)
+    if count_errors:
+        return False, count_errors
+
     if selector_status == "skipped":
         return True, ["No changed Python files required PR-scoped zero-coverage probing; skipping."]
 

--- a/tests/scripts/test_check_zero_coverage_gate.py
+++ b/tests/scripts/test_check_zero_coverage_gate.py
@@ -47,6 +47,32 @@ def test_unmapped_python_changes_fail_even_without_coverage(tmp_path):
     assert "must fail the zero-coverage gate" in messages[1]
 
 
+def test_negative_changed_python_count_fails_before_skip(tmp_path):
+    mod = _load_module()
+    ok, messages = mod.evaluate_zero_coverage_gate(
+        coverage_path=tmp_path / "cov.json",
+        baseline_path=tmp_path / "baseline",
+        selector_status="skipped",
+        changed_python_count=-1,
+    )
+    assert ok is False
+    assert "cannot be negative" in messages[0]
+    assert "metadata is invalid" in messages[1]
+
+
+def test_negative_changed_python_count_fails_before_unmapped_message(tmp_path):
+    mod = _load_module()
+    ok, messages = mod.evaluate_zero_coverage_gate(
+        coverage_path=tmp_path / "cov.json",
+        baseline_path=tmp_path / "baseline",
+        selector_status="unmapped_python_changes",
+        changed_python_count=-3,
+    )
+    assert ok is False
+    assert "cannot be negative" in messages[0]
+    assert "unmapped Python changes" not in "\n".join(messages)
+
+
 def test_missing_coverage_fails_for_non_skipped_selector(tmp_path):
     mod = _load_module()
     ok, messages = mod.evaluate_zero_coverage_gate(
@@ -144,3 +170,24 @@ def test_main_cli_returns_failure_for_missing_coverage(monkeypatch, tmp_path, ca
     exit_code = mod.main()
     assert exit_code == 1
     assert "Coverage data not available" in capsys.readouterr().out
+
+
+def test_main_cli_returns_failure_for_negative_changed_count(monkeypatch, tmp_path, capsys):
+    mod = _load_module()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "check_zero_coverage_gate.py",
+            "--coverage-path",
+            "cov.json",
+            "--selector-status",
+            "skipped",
+            "--changed-python-count",
+            "-1",
+        ],
+    )
+    exit_code = mod.main()
+    assert exit_code == 1
+    assert "cannot be negative" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- fail closed when zero-coverage selector metadata reports a negative changed-Python count
- validate the impossible count before skipped/unmapped status handling
- add focused regression coverage for evaluator and CLI paths

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_check_zero_coverage_gate.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/check_zero_coverage_gate.py tests/scripts/test_check_zero_coverage_gate.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/check_zero_coverage_gate.py tests/scripts/test_check_zero_coverage_gate.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD