### PR TITLE
fix(coverage): validate report thresholds

### DIFF
--- a/scripts/coverage_report.py
+++ b/scripts/coverage_report.py
@@ -15,6 +15,7 @@ Usage:
 
 import argparse
 import json
+import math
 import subprocess
 import sys
 from pathlib import Path
@@ -211,6 +212,17 @@ def get_overall_coverage(coverage_data: dict) -> float:
     return totals.get("percent_covered", 0)
 
 
+def coverage_percentage(raw: str) -> float:
+    """Parse a finite percentage threshold for coverage-report CLI flags."""
+    try:
+        value = float(raw)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a number from 0 to 100") from exc
+    if not math.isfinite(value) or value < 0 or value > 100:
+        raise argparse.ArgumentTypeError("must be a finite percentage from 0 to 100")
+    return value
+
+
 def main():
     parser = argparse.ArgumentParser(description="Generate module-level coverage report")
     parser.add_argument("--json", action="store_true", help="Output as JSON")
@@ -223,7 +235,7 @@ def main():
     )
     parser.add_argument(
         "--min-coverage",
-        type=float,
+        type=coverage_percentage,
         default=0,
         help="Minimum overall coverage percentage required",
     )

--- a/tests/scripts/test_coverage_report.py
+++ b/tests/scripts/test_coverage_report.py
@@ -1,0 +1,62 @@
+"""Tests for scripts/coverage_report.py."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+import pytest
+
+import scripts.coverage_report as coverage_report
+
+
+@pytest.mark.parametrize("raw, expected", [("0", 0.0), ("50.5", 50.5), ("100", 100.0)])
+def test_coverage_percentage_accepts_valid_percentages(raw: str, expected: float) -> None:
+    assert coverage_report.coverage_percentage(raw) == expected
+
+
+@pytest.mark.parametrize("raw", ["-0.1", "100.1", "nan", "inf", "-inf", "not-a-number"])
+def test_coverage_percentage_rejects_impossible_values(raw: str) -> None:
+    with pytest.raises(argparse.ArgumentTypeError):
+        coverage_report.coverage_percentage(raw)
+
+
+@pytest.mark.parametrize("raw", ["-1", "101", "nan", "inf", "-inf"])
+def test_main_rejects_invalid_min_coverage_before_running(
+    raw: str,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def fail_run() -> dict:
+        raise AssertionError("coverage should not run for invalid threshold")
+
+    monkeypatch.setattr(coverage_report, "run_coverage", fail_run)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["coverage_report.py", f"--min-coverage={raw}", "--json"],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        coverage_report.main()
+
+    assert exc.value.code == 2
+    assert "finite percentage from 0 to 100" in capsys.readouterr().err
+
+
+def test_main_accepts_valid_min_coverage(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        coverage_report,
+        "run_coverage",
+        lambda: {"files": {}, "totals": {"percent_covered": 100.0}},
+    )
+    monkeypatch.setattr(sys, "argv", ["coverage_report.py", "--min-coverage=100"])
+
+    with pytest.raises(SystemExit) as exc:
+        coverage_report.main()
+
+    assert exc.value.code == 0
+    assert "OVERALL COVERAGE: 100.0%" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- validate coverage_report.py --min-coverage as a finite percentage in the 0-100 range
- reject impossible thresholds before running coverage or emitting reports
- add focused regression coverage for parser and CLI behavior

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_coverage_report.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/coverage_report.py tests/scripts/test_coverage_report.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/coverage_report.py tests/scripts/test_coverage_report.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD