### PR TITLE
fix(github-cli-health): clarify draft publisher scope

### DIFF
--- a/scripts/github_cli_health.py
+++ b/scripts/github_cli_health.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Bounded GitHub CLI health probe for automation publisher flows."""
+"""Bounded GitHub CLI health probe for automation draft PR publisher flows."""
 
 from __future__ import annotations
 
@@ -181,7 +181,9 @@ def ensure_github_cli_ready(
 
 
 def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Check whether gh can reach GitHub from here.")
+    parser = argparse.ArgumentParser(
+        description="Check whether gh can reach GitHub before draft PR publishing."
+    )
     parser.add_argument("--repo", default=".", help="Path inside the target repository")
     parser.add_argument(
         "--timeout-seconds",


### PR DESCRIPTION
## Summary
- Clarifies the GitHub CLI health probe docstring and CLI description around draft PR publisher flows.
- Harvests a previously local-only unowned micro-branch into a draft PR without changing behavior.

## Validation
- python -m pytest tests/scripts/test_github_cli_health.py -q
- pre-commit run --files scripts/github_cli_health.py tests/scripts/test_github_cli_health.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD

## Governance
- Draft PR only; do not mark ready or merge in this cycle.
- Source branch: codex/swarm-e2cc977e-micro-3
- Source head: 7c285da2abbabd1fe769480a2e4d3536a8ad9df5
