### PR TITLE
fix(benchmarks): validate compare means

### DIFF
--- a/scripts/check_benchmark_regression.py
+++ b/scripts/check_benchmark_regression.py
@@ -51,18 +51,6 @@ def load_benchmark_json(path: Path) -> dict:
     return data
 
 
-def extract_means(data: dict) -> dict[str, float]:
-    """Extract benchmark name -> mean time mapping."""
-    results: dict[str, float] = {}
-    for bench in data["benchmarks"]:
-        name = bench.get("name", bench.get("fullname", "unknown"))
-        stats = bench.get("stats", {})
-        mean = stats.get("mean")
-        if mean is not None:
-            results[name] = mean
-    return results
-
-
 def _non_negative_finite_float(value: object) -> float | None:
     if isinstance(value, bool):
         return None
@@ -71,6 +59,26 @@ def _non_negative_finite_float(value: object) -> float | None:
         if math.isfinite(candidate) and candidate >= 0:
             return candidate
     return None
+
+
+def extract_means(data: dict, *, source_label: str = "benchmark") -> dict[str, float]:
+    """Extract benchmark name -> validated mean time mapping."""
+    results: dict[str, float] = {}
+    for bench in data["benchmarks"]:
+        name = bench.get("name", bench.get("fullname", "unknown"))
+        stats = bench.get("stats", {})
+        if not isinstance(stats, dict):
+            raise ValueError(f"{source_label} benchmark {name} has invalid stats payload")
+        mean_value = stats.get("mean")
+        if mean_value is None:
+            continue
+        mean = _non_negative_finite_float(mean_value)
+        if mean is None:
+            raise ValueError(
+                f"{source_label} benchmark {name} has invalid mean stat: {mean_value!r}"
+            )
+        results[name] = mean
+    return results
 
 
 def _format_name_sample(names: set[str]) -> str:
@@ -95,8 +103,12 @@ def compare_benchmarks(
     current = load_benchmark_json(current_path)
     baseline = load_benchmark_json(baseline_path)
 
-    current_means = extract_means(current)
-    baseline_means = extract_means(baseline)
+    try:
+        current_means = extract_means(current, source_label="current")
+        baseline_means = extract_means(baseline, source_label="baseline")
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
 
     if not baseline_means:
         print("WARNING: Baseline has no benchmarks to compare against.")

--- a/tests/scripts/test_check_benchmark_regression.py
+++ b/tests/scripts/test_check_benchmark_regression.py
@@ -85,6 +85,34 @@ def test_compare_allows_partial_overlap_without_regression(tmp_path: Path, capsy
     assert "No shared benchmark names" not in captured.out
 
 
+def test_compare_rejects_invalid_current_mean(tmp_path: Path, capsys) -> None:
+    current = _write_benchmark_entries(
+        tmp_path / "current.json",
+        [{"name": "bench_shared", "stats": {"mean": "slow"}}],
+    )
+    baseline = _write_benchmarks(tmp_path / "baseline.json", {"bench_shared": 0.001})
+
+    rc = bench_mod.compare_benchmarks(current, baseline, threshold_pct=20.0)
+
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "current benchmark bench_shared has invalid mean stat" in captured.err
+
+
+def test_compare_rejects_invalid_baseline_stats_payload(tmp_path: Path, capsys) -> None:
+    current = _write_benchmarks(tmp_path / "current.json", {"bench_shared": 0.001})
+    baseline = _write_benchmark_entries(
+        tmp_path / "baseline.json",
+        [{"name": "bench_shared", "stats": "not-a-dict"}],
+    )
+
+    rc = bench_mod.compare_benchmarks(current, baseline, threshold_pct=20.0)
+
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "baseline benchmark bench_shared has invalid stats payload" in captured.err
+
+
 def test_validate_rejects_invalid_numeric_stats(tmp_path: Path, capsys) -> None:
     results = _write_benchmark_entries(
         tmp_path / "results.json",


### PR DESCRIPTION
## Summary
- validate benchmark-regression compare mean stats before percentage arithmetic
- fail closed with malformed-input status for non-numeric stats payloads or invalid means
- add focused regression coverage for current and baseline compare inputs

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_check_benchmark_regression.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/check_benchmark_regression.py tests/scripts/test_check_benchmark_regression.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/check_benchmark_regression.py tests/scripts/test_check_benchmark_regression.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD