### PR TITLE
feat(loop-control): per-loop dollar budgets — policy file, spend ledger, truthful resolution

### DIFF
--- a/aragora/swarm/loop_budget.py
+++ b/aragora/swarm/loop_budget.py
@@ -28,6 +28,7 @@ this module provides the rails, not the retirement.
 from __future__ import annotations
 
 import json
+import math
 import os
 import tempfile
 import time
@@ -47,16 +48,24 @@ ENV_FLEET_DEFAULT = "ARAGORA_LOOP_BUDGET_USD"
 
 
 def _as_float(value: Any) -> float | None:
+    """Parse a finite float; NaN/inf are rejected.
+
+    A NaN spend or ceiling would fail open: ``NaN <= 0`` is False, so an
+    exhausted budget would never classify ``budget_exhausted``.
+    """
     if isinstance(value, bool):
         return None
+    parsed: float
     if isinstance(value, (int, float)):
-        return float(value)
-    if isinstance(value, str):
+        parsed = float(value)
+    elif isinstance(value, str):
         try:
-            return float(value)
+            parsed = float(value)
         except ValueError:
             return None
-    return None
+    else:
+        return None
+    return parsed if math.isfinite(parsed) else None
 
 
 def _utc_now_iso() -> str:
@@ -145,8 +154,8 @@ def record_loop_spend(
     The control-plane collectors never call this; loops (or their wrappers)
     adopt it to make their spend readable.
     """
-    if spend_usd < 0:
-        raise ValueError(f"spend_usd must be non-negative, got {spend_usd}")
+    if not math.isfinite(spend_usd) or spend_usd < 0:
+        raise ValueError(f"spend_usd must be a finite non-negative number, got {spend_usd}")
     path = spend_path(repo_root, loop_id)
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = {
@@ -158,9 +167,17 @@ def record_loop_spend(
     }
     fd, tmp_name = tempfile.mkstemp(prefix=f".{loop_id}-", suffix=".json", dir=str(path.parent))
     try:
-        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        try:
+            handle = os.fdopen(fd, "w", encoding="utf-8")
+        except BaseException:
+            os.close(fd)
+            raise
+        with handle:
             json.dump(payload, handle, indent=2, sort_keys=True)
             handle.write("\n")
+        # mkstemp creates 0600; widen to a normal data-file mode so a reader
+        # running as a different user than the writing loop is not locked out.
+        os.chmod(tmp_name, 0o644)
         os.replace(tmp_name, path)
     except BaseException:
         try:

--- a/aragora/swarm/loop_budget.py
+++ b/aragora/swarm/loop_budget.py
@@ -1,0 +1,262 @@
+"""Loop Control Plane v2 - per-loop dollar budgets.
+
+Two small, honest pieces:
+
+* **Policy** (`.aragora/loop_budgets.json`, operator-owned): per-loop dollar
+  ceilings with an optional fleet default. The v1 ``ARAGORA_LOOP_BUDGET_USD``
+  environment variable remains the lowest-precedence fleet default.
+* **Spend ledger** (`.aragora/loop_spend/<loop_id>.json`): a snapshot each loop
+  (or its wrapper) writes via :func:`record_loop_spend`. The control plane only
+  ever *reads* it; a loop that does not write spend is reported as such rather
+  than fabricated.
+
+:func:`resolve_loop_budget` composes both into the raw ``budget`` dict consumed
+by ``aragora.swarm.loop_control.classify_loop``:
+
+* ceiling + fresh spend  -> ``ok`` with a real ``remaining_usd`` (a
+  non-positive remainder classifies the loop ``budget_exhausted`` -> ``halt``);
+* ceiling, but no/stale spend -> ``degraded`` and **no** ``remaining_usd``
+  (never halt a loop on unknown or stale spend);
+* spend, but no ceiling  -> ``degraded`` (visible spend, nothing to gate on);
+* neither                -> ``unavailable``.
+
+A loop's halt-readiness ``budget_ceiling`` guard stays ``False`` until the loop
+itself enforces its ceiling in-loop (or is wrapped by an enforcement point);
+this module provides the rails, not the retirement.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+POLICY_RELPATH = Path(".aragora") / "loop_budgets.json"
+SPEND_DIR_RELPATH = Path(".aragora") / "loop_spend"
+
+# Daily launchd cadence plus slack (matches the docs-drift freshness window):
+# spend older than this cannot prove anything about the current window.
+DEFAULT_SPEND_FRESH_SECONDS = 26 * 3600.0
+
+ENV_FLEET_DEFAULT = "ARAGORA_LOOP_BUDGET_USD"
+
+
+def _as_float(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+@dataclass
+class BudgetPolicy:
+    """Operator-owned per-loop dollar ceilings."""
+
+    default_ceiling_usd: float | None = None
+    per_loop_ceiling_usd: dict[str, float] = field(default_factory=dict)
+    spend_fresh_seconds: float = DEFAULT_SPEND_FRESH_SECONDS
+    source: str = "none"
+
+    @classmethod
+    def load(cls, repo_root: Path | str) -> "BudgetPolicy":
+        """Read the policy file, falling back to the v1 fleet-default env var.
+
+        Missing or unreadable policy degrades to the env fallback (or an empty
+        policy) instead of raising; the budget surface must never take the
+        fleet inventory down.
+        """
+        path = Path(repo_root) / POLICY_RELPATH
+        payload: dict[str, Any] | None = None
+        try:
+            with path.open(encoding="utf-8") as handle:
+                loaded = json.load(handle)
+            payload = loaded if isinstance(loaded, dict) else None
+        except (OSError, json.JSONDecodeError, ValueError):
+            payload = None
+
+        env_default = _as_float(os.environ.get(ENV_FLEET_DEFAULT))
+        if payload is None:
+            if env_default is not None:
+                return cls(default_ceiling_usd=env_default, source=f"env:{ENV_FLEET_DEFAULT}")
+            return cls()
+
+        per_loop: dict[str, float] = {}
+        raw_loops = payload.get("loops")
+        if isinstance(raw_loops, dict):
+            for loop_id, entry in raw_loops.items():
+                ceiling = _as_float(entry.get("ceiling_usd")) if isinstance(entry, dict) else None
+                if ceiling is not None and ceiling >= 0:
+                    per_loop[str(loop_id)] = ceiling
+
+        default_ceiling = _as_float(payload.get("default_ceiling_usd"))
+        source = f"policy:{POLICY_RELPATH}"
+        if default_ceiling is None and env_default is not None:
+            default_ceiling = env_default
+            source = f"policy:{POLICY_RELPATH}+env:{ENV_FLEET_DEFAULT}"
+
+        fresh = _as_float(payload.get("spend_fresh_seconds"))
+        return cls(
+            default_ceiling_usd=default_ceiling,
+            per_loop_ceiling_usd=per_loop,
+            spend_fresh_seconds=(
+                fresh if fresh is not None and fresh > 0 else DEFAULT_SPEND_FRESH_SECONDS
+            ),
+            source=source,
+        )
+
+    def ceiling_for(self, loop_id: str) -> tuple[float | None, str]:
+        """Return ``(ceiling_usd, source)`` for one loop."""
+        if loop_id in self.per_loop_ceiling_usd:
+            return self.per_loop_ceiling_usd[loop_id], f"{self.source}#loops.{loop_id}"
+        if self.default_ceiling_usd is not None:
+            return self.default_ceiling_usd, f"{self.source}#default"
+        return None, "none"
+
+
+def spend_path(repo_root: Path | str, loop_id: str) -> Path:
+    return Path(repo_root) / SPEND_DIR_RELPATH / f"{loop_id}.json"
+
+
+def record_loop_spend(
+    repo_root: Path | str,
+    loop_id: str,
+    spend_usd: float,
+    *,
+    source: str,
+    window_start: str | None = None,
+) -> Path:
+    """Atomically write one loop's spend snapshot (the loop-side writer API).
+
+    The control-plane collectors never call this; loops (or their wrappers)
+    adopt it to make their spend readable.
+    """
+    if spend_usd < 0:
+        raise ValueError(f"spend_usd must be non-negative, got {spend_usd}")
+    path = spend_path(repo_root, loop_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "loop_id": loop_id,
+        "spend_usd": float(spend_usd),
+        "window_start": window_start,
+        "updated_at": _utc_now_iso(),
+        "source": source,
+    }
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{loop_id}-", suffix=".json", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        os.replace(tmp_name, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+    return path
+
+
+def read_loop_spend(
+    repo_root: Path | str, loop_id: str, *, now: float | None = None
+) -> dict[str, Any] | None:
+    """Read one loop's spend snapshot; ``None`` when absent or unreadable."""
+    path = spend_path(repo_root, loop_id)
+    try:
+        with path.open(encoding="utf-8") as handle:
+            payload = json.load(handle)
+        mtime = path.stat().st_mtime
+    except (OSError, json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    spend = _as_float(payload.get("spend_usd"))
+    if spend is None or spend < 0:
+        return None
+    now = now if now is not None else time.time()
+    return {
+        "spend_usd": spend,
+        "window_start": (
+            payload.get("window_start") if isinstance(payload.get("window_start"), str) else None
+        ),
+        "updated_at": (
+            payload.get("updated_at") if isinstance(payload.get("updated_at"), str) else None
+        ),
+        "source": str(payload.get("source") or "ledger"),
+        "age_s": max(0.0, now - mtime),
+    }
+
+
+def resolve_loop_budget(
+    repo_root: Path | str,
+    loop_id: str,
+    policy: BudgetPolicy | None = None,
+    *,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Compose one loop's raw ``budget`` dict for ``classify_loop``."""
+    policy = policy if policy is not None else BudgetPolicy.load(repo_root)
+    ceiling, ceiling_source = policy.ceiling_for(loop_id)
+    spend_record = read_loop_spend(repo_root, loop_id, now=now)
+
+    if spend_record is None and ceiling is None:
+        return {
+            "source": "none",
+            "source_status": "unavailable",
+            "spend_usd": None,
+            "ceiling_usd": None,
+            "remaining_usd": None,
+        }
+
+    spend: float | None = None
+    spend_fresh = False
+    spend_source = "ledger:absent"
+    if spend_record is not None:
+        spend = spend_record["spend_usd"]
+        spend_fresh = spend_record["age_s"] <= policy.spend_fresh_seconds
+        spend_source = f"ledger:{SPEND_DIR_RELPATH / (loop_id + '.json')}" + (
+            "" if spend_fresh else " (stale)"
+        )
+
+    if ceiling is None:
+        return {
+            "source": spend_source,
+            "source_status": "degraded",
+            "spend_usd": spend,
+            "ceiling_usd": None,
+            "remaining_usd": None,
+        }
+
+    if spend is not None and spend_fresh:
+        return {
+            "source": f"{ceiling_source} + {spend_source}",
+            "source_status": "ok",
+            "spend_usd": spend,
+            "ceiling_usd": ceiling,
+            "remaining_usd": ceiling - spend,
+        }
+
+    # A ceiling with unknown or stale spend is visible but never halts: a halt
+    # on stale spend would be exactly the fabricated-alarm class the control
+    # plane exists to avoid.
+    return {
+        "source": f"{ceiling_source} + {spend_source}",
+        "source_status": "degraded",
+        "spend_usd": spend,
+        "ceiling_usd": ceiling,
+        "remaining_usd": None,
+    }

--- a/aragora/swarm/loop_budget.py
+++ b/aragora/swarm/loop_budget.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import json
 import math
 import os
+import re
 import tempfile
 import time
 from dataclasses import dataclass, field
@@ -137,7 +138,18 @@ class BudgetPolicy:
         return None, "none"
 
 
+_LOOP_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+
+
 def spend_path(repo_root: Path | str, loop_id: str) -> Path:
+    """Resolve one loop's snapshot path; the loop id is a filename component.
+
+    Reject anything that is not a plain snake-case identifier so a hostile or
+    buggy ``loop_id`` (absolute path, ``..``, separators) can never escape the
+    spend directory.
+    """
+    if not _LOOP_ID_RE.fullmatch(loop_id):
+        raise ValueError(f"invalid loop_id: {loop_id!r}")
     return Path(repo_root) / SPEND_DIR_RELPATH / f"{loop_id}.json"
 
 
@@ -195,8 +207,10 @@ def read_loop_spend(
     path = spend_path(repo_root, loop_id)
     try:
         with path.open(encoding="utf-8") as handle:
+            # fstat the open descriptor so the freshness mtime belongs to the
+            # same snapshot we parsed, even across a concurrent atomic replace.
+            mtime = os.fstat(handle.fileno()).st_mtime
             payload = json.load(handle)
-        mtime = path.stat().st_mtime
     except (OSError, json.JSONDecodeError, ValueError):
         return None
     if not isinstance(payload, dict):

--- a/aragora/swarm/loop_control_io.py
+++ b/aragora/swarm/loop_control_io.py
@@ -295,19 +295,6 @@ def collect_docs_sync_drift(
     }
 
 
-def collect_budget(repo_root: Path, loop_id: str, *, timeout: float = 5.0) -> dict[str, Any]:
-    """Side-effect-free per-loop budget read.
-
-    v2 resolves a per-loop dollar ceiling from the operator policy file
-    (``.aragora/loop_budgets.json``, with ``ARAGORA_LOOP_BUDGET_USD`` as the
-    v1 fleet-default fallback) plus the loop's spend-ledger snapshot
-    (``.aragora/loop_spend/<loop_id>.json``). Loops that do not write spend are
-    reported ``degraded``/``unavailable`` - carried by each loop's
-    halt-readiness (``budget_ceiling=False``) rather than fabricated here.
-    """
-    return resolve_loop_budget(repo_root, loop_id)
-
-
 _COLLECTORS: dict[LoopKind, Callable[..., dict[str, Any]]] = {
     LoopKind.BOSS_LOOP: collect_boss_loop,
     LoopKind.MERGE_ARBITER: collect_merge_arbiter,
@@ -335,7 +322,13 @@ def collect_all(
     allow_network: bool = True,
     kinds: list[LoopKind] | None = None,
 ) -> dict[LoopKind, dict[str, Any]]:
-    """Collect raw signals for the selected loops, concurrently and read-only."""
+    """Collect raw signals for the selected loops, concurrently and read-only.
+
+    Each loop's raw dict carries a per-loop ``budget`` resolved from the
+    operator policy file plus that loop's spend-ledger snapshot (see
+    ``aragora.swarm.loop_budget``); loops without a ceiling or written spend
+    are reported ``degraded``/``unavailable`` rather than fabricated.
+    """
     root = Path(repo_root)
     selected = list(kinds) if kinds else list(_COLLECTORS)
     policy = BudgetPolicy.load(root)

--- a/aragora/swarm/loop_control_io.py
+++ b/aragora/swarm/loop_control_io.py
@@ -12,6 +12,9 @@ the Loop Control Plane that touches the world, and it only ever reads:
   operator-snapshot --json`` (themselves read-only)
 * ``.aragora/proof_first_shift/runtime_state.json`` (file read)
 * ``.aragora/docs_drift_status.json`` (file read)
+* ``.aragora/loop_budgets.json`` + ``.aragora/loop_spend/<loop_id>.json`` (file
+  reads; the spend-ledger *writer* lives in ``aragora.swarm.loop_budget`` and is
+  called by loops, never by collectors)
 
 It never merges, comments, reruns, pushes, or passes an ``--apply`` flag, and it
 writes nothing. Collectors degrade gracefully (``source_status`` of ``degraded``
@@ -31,6 +34,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
 
+from aragora.swarm.loop_budget import BudgetPolicy, resolve_loop_budget
 from aragora.swarm.loop_control import LOOP_SPECS, LoopKind, LoopRecord, classify_loop
 
 LAUNCHD_LABELS: dict[LoopKind, str] = {
@@ -291,35 +295,17 @@ def collect_docs_sync_drift(
     }
 
 
-def collect_budget(repo_root: Path, *, timeout: float = 5.0) -> dict[str, Any]:
-    """Side-effect-free budget read.
+def collect_budget(repo_root: Path, loop_id: str, *, timeout: float = 5.0) -> dict[str, Any]:
+    """Side-effect-free per-loop budget read.
 
-    v1 does not wire per-loop dollar ceilings into the standing loops, so this
-    reports ``unavailable`` unless ``ARAGORA_LOOP_BUDGET_USD`` is set. The gap is
-    carried by each loop's halt-readiness (``budget_ceiling=False``) rather than
-    fabricated here.
+    v2 resolves a per-loop dollar ceiling from the operator policy file
+    (``.aragora/loop_budgets.json``, with ``ARAGORA_LOOP_BUDGET_USD`` as the
+    v1 fleet-default fallback) plus the loop's spend-ledger snapshot
+    (``.aragora/loop_spend/<loop_id>.json``). Loops that do not write spend are
+    reported ``degraded``/``unavailable`` - carried by each loop's
+    halt-readiness (``budget_ceiling=False``) rather than fabricated here.
     """
-    raw = os.environ.get("ARAGORA_LOOP_BUDGET_USD")
-    if raw:
-        try:
-            remaining = float(raw)
-        except ValueError:
-            remaining = None
-        if remaining is not None:
-            return {
-                "source": "env:ARAGORA_LOOP_BUDGET_USD",
-                "source_status": "ok",
-                "remaining_usd": remaining,
-                "ceiling_usd": remaining,
-                "spend_usd": None,
-            }
-    return {
-        "source": "none",
-        "source_status": "unavailable",
-        "remaining_usd": None,
-        "ceiling_usd": None,
-        "spend_usd": None,
-    }
+    return resolve_loop_budget(repo_root, loop_id)
 
 
 _COLLECTORS: dict[LoopKind, Callable[..., dict[str, Any]]] = {
@@ -352,7 +338,7 @@ def collect_all(
     """Collect raw signals for the selected loops, concurrently and read-only."""
     root = Path(repo_root)
     selected = list(kinds) if kinds else list(_COLLECTORS)
-    budget = collect_budget(root)
+    policy = BudgetPolicy.load(root)
     out: dict[LoopKind, dict[str, Any]] = {}
 
     pending: list[LoopKind] = []
@@ -361,7 +347,7 @@ def collect_all(
             out[kind] = {
                 "source_status": "unavailable",
                 "error": "skipped: --no-network",
-                "budget": budget,
+                "budget": resolve_loop_budget(root, kind.value, policy),
             }
             continue
         pending.append(kind)
@@ -375,7 +361,7 @@ def collect_all(
             for future in as_completed(futures):
                 kind = futures[future]
                 raw = future.result()
-                raw.setdefault("budget", budget)
+                raw.setdefault("budget", resolve_loop_budget(root, kind.value, policy))
                 out[kind] = raw
     return out
 

--- a/aragora/swarm/loop_control_io.py
+++ b/aragora/swarm/loop_control_io.py
@@ -354,7 +354,8 @@ def collect_all(
             for future in as_completed(futures):
                 kind = futures[future]
                 raw = future.result()
-                raw.setdefault("budget", resolve_loop_budget(root, kind.value, policy))
+                if "budget" not in raw:
+                    raw["budget"] = resolve_loop_budget(root, kind.value, policy)
                 out[kind] = raw
     return out
 

--- a/docs/governance/LOOP_CONTROL_PLANE.md
+++ b/docs/governance/LOOP_CONTROL_PLANE.md
@@ -47,7 +47,15 @@ audits each loop's guards against them (`audit_halt_readiness`):
    (keep waiting). Getting this wrong was the `merge_arbiter` defect (§4),
    fixed by PR #8125.
 3. **Budget ceiling.** A spend ceiling so a stuck-but-busy loop cannot run up an
-   unbounded bill. This is the article's headline risk.
+   unbounded bill. This is the article's headline risk. v2 ships the rails:
+   per-loop ceilings come from the operator policy file
+   `.aragora/loop_budgets.json` (`{"default_ceiling_usd": ..., "loops":
+   {"<loop_id>": {"ceiling_usd": ...}}}`, with `ARAGORA_LOOP_BUDGET_USD` as the
+   v1 fleet-default fallback), and per-loop spend comes from the spend ledger
+   `.aragora/loop_spend/<loop_id>.json`, written by each loop via
+   `aragora.swarm.loop_budget.record_loop_spend`. A loop's `budget_ceiling`
+   guard flips to `True` only when that loop both writes its spend and
+   enforces its ceiling in-loop (or is wrapped by an enforcement point).
 
 The audit verdict per loop is:
 
@@ -59,8 +67,13 @@ The audit verdict per loop is:
 
 Every standing loop is currently `incomplete`. One systemic gap dominates:
 
-- **No loop has a dollar/budget ceiling.** They are bounded by time/iterations
-  only. Wiring real per-loop budgets is the highest-value follow-up.
+- **No loop enforces a dollar/budget ceiling in-loop.** They are bounded by
+  time/iterations only. The control plane now resolves real per-loop ceilings
+  and spend (policy file + spend ledger, §3) and classifies a non-positive
+  remainder as `budget_exhausted -> halt`, but no standing loop writes its
+  spend or checks its ceiling yet, so every `budget_ceiling` guard honestly
+  stays `False`. Adopting the ledger in the expensive loops (boss loop,
+  proof-first, nomic) is the highest-value follow-up.
 
 Retired findings:
 
@@ -156,8 +169,11 @@ The stable, machine-readable fields:
   "ticks": null, "max_ticks": 3,
   "runtime_s": null, "max_runtime_s": 43200.0,
   "last_progress_at": null, "no_progress_ticks": null,
-  "budget": {"spend_usd": null, "ceiling_usd": null, "remaining_usd": null,
-             "source": "none", "source_status": "unavailable"},
+  "budget": {"spend_usd": null, "ceiling_usd": 5.0, "remaining_usd": null,
+             "source": "policy:.aragora/loop_budgets.json#loops.merge_arbiter + ledger:absent",
+             "source_status": "degraded"},  // ok only with ceiling + fresh ledger spend;
+                                            // remaining_usd <= 0 => budget_exhausted/halt;
+                                            // unknown/stale spend never halts
   "feedback_gate": {"kind": "quorum", "status": "quorum"},
   "halt_readiness": {"max_iteration": true, "no_progress": true,
                      "no_progress_distinguishes_fault": true,
@@ -198,8 +214,11 @@ python3 scripts/loop_control_status.py --exit-nonzero-on-halt
 **Read-only guarantee.** The IO layer (`aragora/swarm/loop_control_io.py`) is the
 only part that touches the world, and it only ever *reads*: `launchctl print`,
 `git worktree list --porcelain`, `scripts/publisher_freshness_check.py --json`,
-`scripts/agent_bridge.py operator-snapshot --json`, and a file read of
-`.aragora/proof_first_shift/runtime_state.json`. It never merges, comments,
+`scripts/agent_bridge.py operator-snapshot --json`, and file reads of
+`.aragora/proof_first_shift/runtime_state.json`, `.aragora/loop_budgets.json`,
+and `.aragora/loop_spend/<loop_id>.json` (the spend-ledger *writer*,
+`aragora.swarm.loop_budget.record_loop_spend`, is called by loops, never by
+collectors). It never merges, comments,
 reruns, pushes, or passes `--apply`, and it writes nothing. Collectors degrade to
 `degraded`/`unavailable` on missing files, rate limits, timeouts, or non-POSIX
 hosts rather than raising. The classifier (`loop_control.py`) is pure - no IO at

--- a/tests/swarm/test_loop_budget.py
+++ b/tests/swarm/test_loop_budget.py
@@ -67,9 +67,32 @@ class TestBudgetPolicy:
     ) -> None:
         monkeypatch.setenv("ARAGORA_LOOP_BUDGET_USD", "7")
         path = tmp_path / ".aragora" / "loop_budgets.json"
-        path.parent.mkdir(parents=True)
+        path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text("{not json")
         assert BudgetPolicy.load(tmp_path).ceiling_for("nomic")[0] == 7.0
+
+    def test_malformed_env_default_is_ignored(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ARAGORA_LOOP_BUDGET_USD", "not-a-number")
+        assert BudgetPolicy.load(tmp_path).ceiling_for("boss_loop") == (None, "none")
+
+    def test_non_finite_ceilings_are_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # NaN would fail open downstream (NaN <= 0 is False), so it must never
+        # become a ceiling.
+        monkeypatch.setenv("ARAGORA_LOOP_BUDGET_USD", "nan")
+        assert BudgetPolicy.load(tmp_path).ceiling_for("boss_loop") == (None, "none")
+        monkeypatch.delenv("ARAGORA_LOOP_BUDGET_USD")
+        path = _write_policy(
+            tmp_path,
+            {"default_ceiling_usd": float("inf"), "loops": {"nomic": {"ceiling_usd": None}}},
+        )
+        assert "Infinity" in path.read_text()  # json.dump emits non-finite literals
+        policy = BudgetPolicy.load(tmp_path)
+        assert policy.ceiling_for("nomic") == (None, "none")
+        assert policy.ceiling_for("boss_loop") == (None, "none")
 
     def test_negative_and_malformed_loop_ceilings_are_ignored(self, tmp_path: Path) -> None:
         _write_policy(
@@ -103,18 +126,30 @@ class TestSpendLedger:
         assert record["source"] == "gate-debates"
         assert record["age_s"] < 60
 
-    def test_negative_spend_is_rejected(self, tmp_path: Path) -> None:
+    def test_negative_and_non_finite_spend_is_rejected(self, tmp_path: Path) -> None:
         with pytest.raises(ValueError):
             record_loop_spend(tmp_path, "boss_loop", -0.01, source="x")
+        with pytest.raises(ValueError):
+            record_loop_spend(tmp_path, "boss_loop", float("nan"), source="x")
+        with pytest.raises(ValueError):
+            record_loop_spend(tmp_path, "boss_loop", float("inf"), source="x")
 
     def test_absent_and_corrupt_snapshots_read_as_none(self, tmp_path: Path) -> None:
         assert read_loop_spend(tmp_path, "publisher") is None
         path = spend_path(tmp_path, "publisher")
-        path.parent.mkdir(parents=True)
+        path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text("{broken")
         assert read_loop_spend(tmp_path, "publisher") is None
         path.write_text(json.dumps({"spend_usd": -4}))
         assert read_loop_spend(tmp_path, "publisher") is None
+        # Python's json module parses bare NaN; a NaN spend would fail open
+        # downstream, so the reader must reject it.
+        path.write_text('{"spend_usd": NaN}')
+        assert read_loop_spend(tmp_path, "publisher") is None
+
+    def test_snapshot_is_world_readable(self, tmp_path: Path) -> None:
+        path = record_loop_spend(tmp_path, "boss_loop", 1.0, source="x")
+        assert path.stat().st_mode & 0o077 == 0o044
 
     def test_staleness_uses_injected_now(self, tmp_path: Path) -> None:
         record_loop_spend(tmp_path, "nomic", 1.0, source="x")
@@ -191,6 +226,19 @@ class TestClassification:
         assert record.state == LoopState.BUDGET_EXHAUSTED.value
         assert record.next_action == NextAction.HALT.value
         assert record.blocker == "budget exhausted"
+
+    def test_overspend_yields_negative_remaining_and_halts(self, tmp_path: Path) -> None:
+        # remaining_usd is the honest remainder, not capped at zero.
+        _write_policy(tmp_path, {"loops": {"boss_loop": {"ceiling_usd": 5.0}}})
+        record_loop_spend(tmp_path, "boss_loop", 9.0, source="gate-debates")
+        budget = resolve_loop_budget(tmp_path, "boss_loop")
+        assert budget["remaining_usd"] == pytest.approx(-4.0)
+        record = classify_loop(
+            LOOP_SPECS[LoopKind.BOSS_LOOP],
+            {"source_status": "ok", "alive": True, "budget": budget},
+        )
+        assert record.state == LoopState.BUDGET_EXHAUSTED.value
+        assert record.next_action == NextAction.HALT.value
 
     def test_degraded_budget_never_halts(self, tmp_path: Path) -> None:
         _write_policy(tmp_path, {"loops": {"boss_loop": {"ceiling_usd": 5.0}}})

--- a/tests/swarm/test_loop_budget.py
+++ b/tests/swarm/test_loop_budget.py
@@ -260,6 +260,25 @@ class TestClassification:
         assert record.state == LoopState.RUNNING.value
         assert record.next_action == NextAction.CONTINUE.value
 
+    def test_collect_all_degrades_on_corrupt_policy_and_ledger(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Loops write the ledger concurrently with collection; a torn or
+        # corrupt file must degrade the budget, never raise into the fleet.
+        monkeypatch.delenv("ARAGORA_LOOP_BUDGET_USD", raising=False)
+        policy_file = tmp_path / ".aragora" / "loop_budgets.json"
+        policy_file.parent.mkdir(parents=True, exist_ok=True)
+        policy_file.write_text('{"default_ceiling_usd": 9.0, "loops": {tor')
+        ledger = spend_path(tmp_path, "merge_arbiter")
+        ledger.parent.mkdir(parents=True, exist_ok=True)
+        ledger.write_text('{"spend_usd": 1.')
+        raw = collect_all(
+            tmp_path, timeout=0.5, allow_network=False, kinds=[LoopKind.MERGE_ARBITER]
+        )
+        budget = raw[LoopKind.MERGE_ARBITER]["budget"]
+        assert budget["source_status"] == "unavailable"  # corrupt policy + corrupt ledger
+        assert budget["remaining_usd"] is None
+
     def test_collect_all_attaches_per_loop_budgets(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/swarm/test_loop_budget.py
+++ b/tests/swarm/test_loop_budget.py
@@ -1,0 +1,229 @@
+"""Loop Control Plane v2 - per-loop budget policy, spend ledger, resolution."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from aragora.swarm.loop_budget import (
+    DEFAULT_SPEND_FRESH_SECONDS,
+    BudgetPolicy,
+    read_loop_spend,
+    record_loop_spend,
+    resolve_loop_budget,
+    spend_path,
+)
+from aragora.swarm.loop_control import LOOP_SPECS, LoopKind, LoopState, NextAction, classify_loop
+from aragora.swarm.loop_control_io import collect_all
+
+
+def _write_policy(repo_root: Path, payload: dict) -> Path:
+    path = repo_root / ".aragora" / "loop_budgets.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload))
+    return path
+
+
+# --- policy -----------------------------------------------------------------
+
+
+class TestBudgetPolicy:
+    def test_missing_file_yields_empty_policy(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("ARAGORA_LOOP_BUDGET_USD", raising=False)
+        policy = BudgetPolicy.load(tmp_path)
+        assert policy.ceiling_for("merge_arbiter") == (None, "none")
+        assert policy.source == "none"
+
+    def test_env_fleet_default_is_v1_fallback(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ARAGORA_LOOP_BUDGET_USD", "12.5")
+        ceiling, source = BudgetPolicy.load(tmp_path).ceiling_for("boss_loop")
+        assert ceiling == 12.5
+        assert "env:ARAGORA_LOOP_BUDGET_USD" in source
+
+    def test_per_loop_overrides_default_and_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ARAGORA_LOOP_BUDGET_USD", "99")
+        _write_policy(
+            tmp_path,
+            {"default_ceiling_usd": 25.0, "loops": {"merge_arbiter": {"ceiling_usd": 5.0}}},
+        )
+        policy = BudgetPolicy.load(tmp_path)
+        arbiter_ceiling, arbiter_source = policy.ceiling_for("merge_arbiter")
+        assert arbiter_ceiling == 5.0
+        assert arbiter_source.endswith("#loops.merge_arbiter")
+        other_ceiling, other_source = policy.ceiling_for("boss_loop")
+        assert other_ceiling == 25.0
+        assert other_source.endswith("#default")
+
+    def test_invalid_file_degrades_to_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ARAGORA_LOOP_BUDGET_USD", "7")
+        path = tmp_path / ".aragora" / "loop_budgets.json"
+        path.parent.mkdir(parents=True)
+        path.write_text("{not json")
+        assert BudgetPolicy.load(tmp_path).ceiling_for("nomic")[0] == 7.0
+
+    def test_negative_and_malformed_loop_ceilings_are_ignored(self, tmp_path: Path) -> None:
+        _write_policy(
+            tmp_path,
+            {"loops": {"boss_loop": {"ceiling_usd": -1}, "nomic": "not-a-dict"}},
+        )
+        policy = BudgetPolicy.load(tmp_path)
+        assert policy.ceiling_for("boss_loop") == (None, "none")
+        assert policy.ceiling_for("nomic") == (None, "none")
+
+    def test_spend_fresh_seconds_knob(self, tmp_path: Path) -> None:
+        _write_policy(tmp_path, {"spend_fresh_seconds": 60})
+        assert BudgetPolicy.load(tmp_path).spend_fresh_seconds == 60.0
+        _write_policy(tmp_path, {"spend_fresh_seconds": -5})
+        assert BudgetPolicy.load(tmp_path).spend_fresh_seconds == DEFAULT_SPEND_FRESH_SECONDS
+
+
+# --- spend ledger -----------------------------------------------------------
+
+
+class TestSpendLedger:
+    def test_record_then_read_round_trip(self, tmp_path: Path) -> None:
+        path = record_loop_spend(
+            tmp_path, "boss_loop", 3.21, source="gate-debates", window_start="2026-06-11T00:00:00Z"
+        )
+        assert path == spend_path(tmp_path, "boss_loop")
+        record = read_loop_spend(tmp_path, "boss_loop")
+        assert record is not None
+        assert record["spend_usd"] == 3.21
+        assert record["window_start"] == "2026-06-11T00:00:00Z"
+        assert record["source"] == "gate-debates"
+        assert record["age_s"] < 60
+
+    def test_negative_spend_is_rejected(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError):
+            record_loop_spend(tmp_path, "boss_loop", -0.01, source="x")
+
+    def test_absent_and_corrupt_snapshots_read_as_none(self, tmp_path: Path) -> None:
+        assert read_loop_spend(tmp_path, "publisher") is None
+        path = spend_path(tmp_path, "publisher")
+        path.parent.mkdir(parents=True)
+        path.write_text("{broken")
+        assert read_loop_spend(tmp_path, "publisher") is None
+        path.write_text(json.dumps({"spend_usd": -4}))
+        assert read_loop_spend(tmp_path, "publisher") is None
+
+    def test_staleness_uses_injected_now(self, tmp_path: Path) -> None:
+        record_loop_spend(tmp_path, "nomic", 1.0, source="x")
+        mtime = spend_path(tmp_path, "nomic").stat().st_mtime
+        record = read_loop_spend(tmp_path, "nomic", now=mtime + 100.0)
+        assert record is not None
+        assert record["age_s"] == pytest.approx(100.0)
+
+
+# --- resolution -------------------------------------------------------------
+
+
+class TestResolveLoopBudget:
+    def test_no_ceiling_no_spend_is_unavailable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("ARAGORA_LOOP_BUDGET_USD", raising=False)
+        budget = resolve_loop_budget(tmp_path, "merge_arbiter")
+        assert budget["source_status"] == "unavailable"
+        assert budget["remaining_usd"] is None
+
+    def test_ceiling_with_fresh_spend_is_ok_with_remaining(self, tmp_path: Path) -> None:
+        _write_policy(tmp_path, {"loops": {"boss_loop": {"ceiling_usd": 10.0}}})
+        record_loop_spend(tmp_path, "boss_loop", 4.0, source="gate-debates")
+        budget = resolve_loop_budget(tmp_path, "boss_loop")
+        assert budget["source_status"] == "ok"
+        assert budget["remaining_usd"] == pytest.approx(6.0)
+        assert "#loops.boss_loop" in budget["source"]
+        assert "ledger:" in budget["source"]
+
+    def test_ceiling_without_spend_is_degraded_and_never_computes_remaining(
+        self, tmp_path: Path
+    ) -> None:
+        _write_policy(tmp_path, {"loops": {"publisher": {"ceiling_usd": 2.0}}})
+        budget = resolve_loop_budget(tmp_path, "publisher")
+        assert budget["source_status"] == "degraded"
+        assert budget["ceiling_usd"] == 2.0
+        assert budget["spend_usd"] is None
+        assert budget["remaining_usd"] is None
+
+    def test_stale_spend_is_visible_but_never_yields_remaining(self, tmp_path: Path) -> None:
+        _write_policy(tmp_path, {"loops": {"nomic": {"ceiling_usd": 5.0}}})
+        record_loop_spend(tmp_path, "nomic", 9.0, source="x")
+        mtime = spend_path(tmp_path, "nomic").stat().st_mtime
+        budget = resolve_loop_budget(tmp_path, "nomic", now=mtime + DEFAULT_SPEND_FRESH_SECONDS + 1)
+        assert budget["source_status"] == "degraded"
+        assert budget["spend_usd"] == 9.0
+        assert budget["remaining_usd"] is None
+        assert "(stale)" in budget["source"]
+
+    def test_spend_without_ceiling_is_degraded(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("ARAGORA_LOOP_BUDGET_USD", raising=False)
+        record_loop_spend(tmp_path, "docs_sync_drift", 0.0, source="no-model-calls")
+        budget = resolve_loop_budget(tmp_path, "docs_sync_drift")
+        assert budget["source_status"] == "degraded"
+        assert budget["spend_usd"] == 0.0
+        assert budget["ceiling_usd"] is None
+
+
+# --- classification + fleet integration -------------------------------------
+
+
+class TestClassification:
+    def test_exhausted_budget_halts_the_loop(self, tmp_path: Path) -> None:
+        _write_policy(tmp_path, {"loops": {"boss_loop": {"ceiling_usd": 5.0}}})
+        record_loop_spend(tmp_path, "boss_loop", 5.0, source="gate-debates")
+        budget = resolve_loop_budget(tmp_path, "boss_loop")
+        record = classify_loop(
+            LOOP_SPECS[LoopKind.BOSS_LOOP],
+            {"source_status": "ok", "alive": True, "budget": budget},
+        )
+        assert record.state == LoopState.BUDGET_EXHAUSTED.value
+        assert record.next_action == NextAction.HALT.value
+        assert record.blocker == "budget exhausted"
+
+    def test_degraded_budget_never_halts(self, tmp_path: Path) -> None:
+        _write_policy(tmp_path, {"loops": {"boss_loop": {"ceiling_usd": 5.0}}})
+        budget = resolve_loop_budget(tmp_path, "boss_loop")
+        record = classify_loop(
+            LOOP_SPECS[LoopKind.BOSS_LOOP],
+            {"source_status": "ok", "alive": True, "budget": budget},
+        )
+        assert record.state == LoopState.RUNNING.value
+        assert record.next_action == NextAction.CONTINUE.value
+
+    def test_collect_all_attaches_per_loop_budgets(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("ARAGORA_LOOP_BUDGET_USD", raising=False)
+        _write_policy(
+            tmp_path,
+            {"default_ceiling_usd": 20.0, "loops": {"merge_arbiter": {"ceiling_usd": 5.0}}},
+        )
+        record_loop_spend(tmp_path, "merge_arbiter", 1.0, source="x")
+        raw = collect_all(
+            tmp_path,
+            timeout=0.5,
+            allow_network=False,
+            kinds=[LoopKind.MERGE_ARBITER, LoopKind.BOSS_LOOP, LoopKind.NOMIC],
+        )
+        arbiter = raw[LoopKind.MERGE_ARBITER]["budget"]
+        assert arbiter["ceiling_usd"] == 5.0
+        assert arbiter["remaining_usd"] == pytest.approx(4.0)
+        assert arbiter["source_status"] == "ok"
+        boss = raw[LoopKind.BOSS_LOOP]["budget"]
+        assert boss["ceiling_usd"] == 20.0
+        assert boss["source_status"] == "degraded"  # default ceiling, no spend written
+        nomic = raw[LoopKind.NOMIC]["budget"]
+        assert nomic["ceiling_usd"] == 20.0
+        assert nomic["remaining_usd"] is None

--- a/tests/swarm/test_loop_budget.py
+++ b/tests/swarm/test_loop_budget.py
@@ -134,6 +134,16 @@ class TestSpendLedger:
         with pytest.raises(ValueError):
             record_loop_spend(tmp_path, "boss_loop", float("inf"), source="x")
 
+    def test_path_escaping_loop_ids_are_rejected(self, tmp_path: Path) -> None:
+        # The loop id is a filename component; it must never traverse out of
+        # the spend directory or resolve to an absolute path.
+        for hostile in ("/etc/passwd", "../escape", "a/b", "..", "", "Boss Loop", "no.dots"):
+            with pytest.raises(ValueError):
+                spend_path(tmp_path, hostile)
+            with pytest.raises(ValueError):
+                record_loop_spend(tmp_path, hostile, 1.0, source="x")
+        assert spend_path(tmp_path, "boss_loop").name == "boss_loop.json"
+
     def test_absent_and_corrupt_snapshots_read_as_none(self, tmp_path: Path) -> None:
         assert read_loop_spend(tmp_path, "publisher") is None
         path = spend_path(tmp_path, "publisher")


### PR DESCRIPTION
## Summary
Loop Control Plane v2 budget rails (plan phase 2; the v1 findings' highest-value follow-up):

- **`aragora/swarm/loop_budget.py` (new):** operator policy file `.aragora/loop_budgets.json` (per-loop `ceiling_usd` + `default_ceiling_usd`; `ARAGORA_LOOP_BUDGET_USD` kept as the v1 fleet-default fallback), an atomic per-loop spend ledger `.aragora/loop_spend/<loop_id>.json` written via `record_loop_spend` (the loop-side writer API), and `resolve_loop_budget` composing both into the `classify_loop` budget contract.
- **Truthful resolution semantics:** ceiling + fresh spend → `ok` with a real `remaining_usd` (non-positive classifies `budget_exhausted` → `halt`); ceiling with unknown/stale spend → `degraded` and never halts; spend without ceiling → `degraded`; neither → `unavailable`. No fabricated numbers anywhere.
- **`loop_control_io.py`:** `collect_all` attaches a per-loop resolved budget (collectors remain strictly read-only; the writer is never called by the control plane; the read-only regression test still passes).
- **Docs:** `LOOP_CONTROL_PLANE.md` §3 documents the policy + ledger contract and the retirement criterion (a loop's `budget_ceiling` guard flips only when it enforces its ceiling in-loop); curated findings reworded accordingly; §5 JSON example and §6 read-only guarantee updated.
- **Guards unchanged:** every loop honestly stays `budget_ceiling=False` until it adopts the ledger and enforces in-loop; adopting it in the expensive loops (boss loop, proof-first, nomic) is the named follow-up.

## Validation
- 74/74: `tests/swarm/test_loop_budget.py` (18 new), `tests/swarm/test_loop_control.py`, `tests/scripts/test_loop_control_status.py` (incl. the no-filesystem-writes guarantee), `tests/scripts/test_docs_sync_drift_detector.py`
- mypy clean on both swarm modules; ruff clean; pre-commit hooks pass
- `python3 scripts/loop_control_status.py --no-network` smoke: fleet renders, per-loop budget gaps reported