### PR TITLE
fix(proof): fail closed on observer rev-list errors

### DIFF
--- a/scripts/observer_truth_probe.py
+++ b/scripts/observer_truth_probe.py
@@ -145,22 +145,27 @@ def ahead_behind(repo_root: Path) -> tuple[int, int]:
     missing ``origin/main`` ref). Callers should already have detected
     that case via :func:`origin_main_sha`.
     """
+    ahead, behind, _reason = _ahead_behind_probe(repo_root)
+    return ahead, behind
+
+
+def _ahead_behind_probe(repo_root: Path) -> tuple[int, int, str | None]:
     try:
         result = _run_git(
             ["rev-list", "--left-right", "--count", "origin/main...HEAD"],
             repo_root=repo_root,
         )
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
-        return (0, 0)
+        return (0, 0, "ahead_behind_probe_failed")
     parts = result.stdout.split()
     if len(parts) != 2:
-        return (0, 0)
+        return (0, 0, "ahead_behind_probe_failed")
     try:
         behind = int(parts[0])
         ahead = int(parts[1])
     except ValueError:
-        return (0, 0)
-    return ahead, behind
+        return (0, 0, "ahead_behind_probe_failed")
+    return ahead, behind, None
 
 
 def untracked_files(repo_root: Path) -> list[str]:
@@ -265,9 +270,10 @@ def probe(
         reasons.append("origin_main_unavailable")
 
     if head and origin:
-        ahead, behind = ahead_behind(repo_root)
+        ahead, behind, ahead_behind_probe_reason = _ahead_behind_probe(repo_root)
     else:
         ahead, behind = (0, 0)
+        ahead_behind_probe_reason = None
 
     untracked, untracked_probe_reason = _untracked_files_probe(repo_root)
     uncommitted, uncommitted_probe_reason = _uncommitted_modified_files_probe(repo_root)
@@ -282,6 +288,7 @@ def probe(
     status_probe_reasons = [
         reason
         for reason in (
+            ahead_behind_probe_reason,
             untracked_probe_reason,
             uncommitted_probe_reason,
             submodule_probe_reason,

--- a/tests/scripts/test_observer_truth_probe.py
+++ b/tests/scripts/test_observer_truth_probe.py
@@ -311,3 +311,77 @@ def test_probe_fails_closed_when_submodule_status_unavailable(
     assert result["clean"] is False
     assert result["submodule_dirty"] is False
     assert "submodule_status_probe_failed" in result["reasons"]
+
+
+def test_probe_fails_closed_when_ahead_behind_status_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import observer_truth_probe as mod
+
+    sha = "d" * 40
+
+    def fake_run_git(
+        args: list[str],
+        *,
+        repo_root: Path,
+        check: bool = True,
+        timeout: float = mod.GIT_TIMEOUT_SECONDS,
+    ) -> subprocess.CompletedProcess[str]:
+        if args == ["rev-parse", "HEAD"] or args == ["rev-parse", "origin/main"]:
+            return subprocess.CompletedProcess(args, 0, stdout=f"{sha}\n", stderr="")
+        if args == ["rev-list", "--left-right", "--count", "origin/main...HEAD"]:
+            raise subprocess.TimeoutExpired(args, timeout=timeout)
+        if args == ["ls-files", "--others", "--exclude-standard"]:
+            return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+        if args[0] == "diff":
+            return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+        if args == ["submodule", "status", "--recursive"]:
+            return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+        raise AssertionError(f"unexpected git args: {args!r}")
+
+    monkeypatch.setattr(mod, "_run_git", fake_run_git)
+
+    result = mod.probe(tmp_path, fetch=False)
+
+    assert result["clean"] is False
+    assert result["ahead"] == 0
+    assert result["behind"] == 0
+    assert "ahead_behind_probe_failed" in result["reasons"]
+
+
+def test_probe_fails_closed_when_ahead_behind_output_is_malformed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import observer_truth_probe as mod
+
+    sha = "e" * 40
+
+    def fake_run_git(
+        args: list[str],
+        *,
+        repo_root: Path,
+        check: bool = True,
+        timeout: float = mod.GIT_TIMEOUT_SECONDS,
+    ) -> subprocess.CompletedProcess[str]:
+        if args == ["rev-parse", "HEAD"] or args == ["rev-parse", "origin/main"]:
+            return subprocess.CompletedProcess(args, 0, stdout=f"{sha}\n", stderr="")
+        if args == ["rev-list", "--left-right", "--count", "origin/main...HEAD"]:
+            return subprocess.CompletedProcess(args, 0, stdout="0 nope\n", stderr="")
+        if args == ["ls-files", "--others", "--exclude-standard"]:
+            return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+        if args[0] == "diff":
+            return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+        if args == ["submodule", "status", "--recursive"]:
+            return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+        raise AssertionError(f"unexpected git args: {args!r}")
+
+    monkeypatch.setattr(mod, "_run_git", fake_run_git)
+
+    result = mod.probe(tmp_path, fetch=False)
+
+    assert result["clean"] is False
+    assert result["ahead"] == 0
+    assert result["behind"] == 0
+    assert "ahead_behind_probe_failed" in result["reasons"]


### PR DESCRIPTION
## Summary
- fail closed when observer-truth ahead/behind comparison cannot be trusted
- preserve the public ahead_behind helper while recording probe failure reasons in the main observer report
- cover timeout and malformed rev-list output regressions

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_observer_truth_probe.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/observer_truth_probe.py tests/scripts/test_observer_truth_probe.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/observer_truth_probe.py tests/scripts/test_observer_truth_probe.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD