### PR TITLE
fix(ci): archive Vercel deploy uploads

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -198,7 +198,7 @@ jobs:
         run: |
           # Run from repo root; Vercel project rootDirectory is configured server-side.
           npx vercel pull --yes --environment=production --token="${{ secrets.VERCEL_TOKEN }}"
-          DEPLOY_URL=$(npx vercel deploy --prod --yes --token="${{ secrets.VERCEL_TOKEN }}")
+          DEPLOY_URL=$(npx vercel deploy --prod --yes --archive=tgz --token="${{ secrets.VERCEL_TOKEN }}")
           echo "deploy_url=$DEPLOY_URL" >> "$GITHUB_OUTPUT"
           echo "Deployed URL: $DEPLOY_URL"
         env:

--- a/.github/workflows/deploy-secure.yml
+++ b/.github/workflows/deploy-secure.yml
@@ -141,7 +141,7 @@ jobs:
         run: |
           # Run from repo root; Vercel project rootDirectory is configured server-side.
           npx vercel pull --yes --environment=production --token="${{ secrets.VERCEL_TOKEN }}"
-          DEPLOY_URL=$(npx vercel deploy --prod --yes --token="${{ secrets.VERCEL_TOKEN }}")
+          DEPLOY_URL=$(npx vercel deploy --prod --yes --archive=tgz --token="${{ secrets.VERCEL_TOKEN }}")
           echo "deploy_url=$DEPLOY_URL" >> "$GITHUB_OUTPUT"
           echo "Deployed URL: $DEPLOY_URL"
         env:


### PR DESCRIPTION
## Summary
- add `--archive=tgz` to the production Vercel deploy command in Deploy (Secure)
- apply the same archive mode to the equivalent production Vercel path in Deploy Frontend

## Incident
Deploy (Secure) run 27355124418 failed in job deploy-vercel 80827474131 at main head 6697cd97b03f827cf77e2cb9148895d4e3d9accc because Vercel rejected 15374 uploaded files and suggested `--archive=tgz`.

Current origin/main is e68f4237167bef823425031664743ca2bd4151a3 and contains the incident head. Both changed workflows currently run repo-root production Vercel deploys with the same Vercel project secrets.

## Validation
- `actionlint .github/workflows/deploy-secure.yml .github/workflows/deploy-frontend.yml`
- focused YAML/static assertion that both production deploy commands include `--archive=tgz` and no unarchived production deploy command remains
- `git diff --check origin/main HEAD`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

No deploy, product-proof, or unrelated CI reruns were triggered.