### PR TITLE
fix(inventory): preserve branchless receipt-backed worktrees

### DIFF
--- a/scripts/codex_worktree_value_inventory.py
+++ b/scripts/codex_worktree_value_inventory.py
@@ -34,6 +34,7 @@ sys.path.insert(0, str(REPO_ROOT / "scripts"))
 from audit_codex_branch_backlog import (  # noqa: E402
     DEFAULT_OUTBOX_DIR,
     DEFAULT_RECEIPT_DIR,
+    TERMINAL_RECEIPT_STATUSES,
     _commit_prefix_matches,
     is_patch_equivalent,
     terminal_receipted_handoff_branch_heads,
@@ -45,11 +46,38 @@ DEFAULT_LEGACY_ROOT = Path.home() / ".codex" / "worktrees"
 DEFAULT_CANONICAL_REL_ROOT = Path(".worktrees") / "codex-auto"
 DEFAULT_ROOT = DEFAULT_LEGACY_ROOT  # kept for backward compatibility
 DEFAULT_LEDGER_ROOT = Path(".aragora/worktree-harvest")
+DEFAULT_HARVEST_RECEIPT_REL_DIR = DEFAULT_LEDGER_ROOT / "harvest-receipts"
 ACTIVE_SESSION_FILES = (
     ".claude-session-active",
     ".codex_session_active",
     ".nomic-session-active",
 )
+RECEIPT_PATH_KEYS = frozenset(
+    {
+        "candidate_path",
+        "candidate_repo_path",
+        "checkout_path",
+        "path",
+        "repo_path",
+        "source_path",
+        "source_repo_path",
+        "worktree",
+        "worktree_path",
+    }
+)
+RECEIPT_HEAD_KEYS = frozenset(
+    {
+        "candidate_head",
+        "candidate_head_sha",
+        "commit",
+        "head",
+        "head_sha",
+        "sha",
+        "source_head",
+        "source_head_sha",
+    }
+)
+TERMINAL_HARVEST_DECISION_PREFIXES = ("already_", "preserve_")
 PROJECT_MARKER_FILES = (
     ".git",
     "pyproject.toml",
@@ -163,6 +191,7 @@ class InventoryContext:
     smart_merge_detection: bool = False
     smart_merge_main_subjects: list[str] = field(default_factory=list)
     open_pr_heads_cache: dict[str, list[dict[str, Any]]] | None = None
+    terminal_receipt_path_heads: dict[str, set[str | None]] = field(default_factory=dict)
 
 
 def utc_now() -> datetime:
@@ -286,6 +315,109 @@ def branch_matches_receipt(
     return any(
         receipt_head is None or _commit_prefix_matches(receipt_head, head) for receipt_head in heads
     )
+
+
+def _absolute_path_key(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    path = Path(text).expanduser()
+    if not path.is_absolute():
+        return None
+    return str(path.resolve(strict=False))
+
+
+def _receipt_heads_from_mapping(payload: dict[str, Any]) -> set[str | None]:
+    heads: set[str | None] = set()
+    for key, value in payload.items():
+        if key not in RECEIPT_HEAD_KEYS:
+            continue
+        if value is None:
+            heads.add(None)
+            continue
+        if isinstance(value, str):
+            text = value.strip()
+            if text:
+                heads.add(text)
+    return heads
+
+
+def _receipt_path_head_pairs(
+    value: Any,
+    *,
+    inherited_heads: set[str | None] | None = None,
+) -> list[tuple[str, str | None]]:
+    heads = set(inherited_heads or set())
+    pairs: list[tuple[str, str | None]] = []
+
+    if isinstance(value, dict):
+        local_heads = _receipt_heads_from_mapping(value)
+        if local_heads:
+            heads = local_heads
+        for key, item in value.items():
+            if key in RECEIPT_PATH_KEYS:
+                path_key = _absolute_path_key(item)
+                if path_key:
+                    for head in heads or {None}:
+                        pairs.append((path_key, head))
+            if isinstance(item, (dict, list)):
+                pairs.extend(_receipt_path_head_pairs(item, inherited_heads=heads))
+    elif isinstance(value, list):
+        for item in value:
+            pairs.extend(_receipt_path_head_pairs(item, inherited_heads=heads))
+
+    return pairs
+
+
+def _terminal_path_receipt(payload: dict[str, Any]) -> bool:
+    status = str(payload.get("status") or "").strip()
+    if status in TERMINAL_RECEIPT_STATUSES:
+        return True
+    decision = str(payload.get("decision") or "").strip()
+    if decision.startswith(TERMINAL_HARVEST_DECISION_PREFIXES):
+        return True
+    return False
+
+
+def terminal_receipt_path_heads(receipt_roots: list[Path]) -> dict[str, set[str | None]]:
+    """Return terminal receipt path refs with optional exact-head evidence."""
+
+    refs: dict[str, set[str | None]] = {}
+    for receipt_root in receipt_roots:
+        for receipt_file in json_files(receipt_root):
+            payload = load_json_mapping(receipt_file)
+            if payload is None or not _terminal_path_receipt(payload):
+                continue
+            for path_key, head in _receipt_path_head_pairs(payload):
+                refs.setdefault(path_key, set()).add(head)
+    return refs
+
+
+def path_matches_receipt(
+    candidate_path: Path,
+    repo_path: Path | None,
+    head: str | None,
+    receipt_path_heads: dict[str, set[str | None]],
+) -> bool:
+    path_keys = {_absolute_path_key(str(candidate_path))}
+    if repo_path is not None:
+        path_keys.add(_absolute_path_key(str(repo_path)))
+    for path_key in {item for item in path_keys if item}:
+        heads = receipt_path_heads.get(path_key, set())
+        if not heads:
+            continue
+        if not head:
+            if None in heads:
+                return True
+            continue
+        if any(
+            receipt_head is None or _commit_prefix_matches(receipt_head, head)
+            for receipt_head in heads
+        ):
+            return True
+    return False
 
 
 def outbox_files_for_branch(outbox_dir: Path, branch: str | None) -> list[str]:
@@ -728,11 +860,18 @@ def classify_candidate(
     links["outbox_files"] = outbox_files_for_branch(context.outbox_dir, branch)
     links["receipt_files"] = receipt_files_for_branch(context.receipt_dir, branch)
     outbox_protected = bool(branch and branch in context.unresolved_outbox_branches)
-    receipt_protected = branch_matches_receipt(
+    branch_receipt_protected = branch_matches_receipt(
         branch,
         head,
         context.terminal_receipt_branch_heads,
     )
+    path_receipt_protected = path_matches_receipt(
+        candidate_root,
+        repo_path,
+        head,
+        context.terminal_receipt_path_heads,
+    )
+    receipt_protected = branch_receipt_protected or path_receipt_protected
 
     if active_session or lock_files or dirty:
         classification = "active_or_dirty"
@@ -753,7 +892,10 @@ def classify_candidate(
             proof.append("unresolved automation outbox references branch")
     elif receipt_protected:
         classification = "receipt_protected"
-        proof.append("terminal automation receipt references branch/head")
+        if branch_receipt_protected:
+            proof.append("terminal automation receipt references branch/head")
+        if path_receipt_protected:
+            proof.append("terminal receipt references path/head")
     elif git.ahead and git.ahead > 0:
         patch_equivalent = False
         try:
@@ -1172,6 +1314,12 @@ def inventory(
             repo,
             outbox_dir=outbox_dir,
             receipt_dir=receipt_dir,
+        ),
+        terminal_receipt_path_heads=terminal_receipt_path_heads(
+            [
+                receipt_dir if receipt_dir.is_absolute() else repo / receipt_dir,
+                repo / DEFAULT_HARVEST_RECEIPT_REL_DIR,
+            ]
         ),
         skip_gh=skip_gh,
         git_timeout=git_timeout,

--- a/tests/scripts/test_codex_worktree_value_inventory.py
+++ b/tests/scripts/test_codex_worktree_value_inventory.py
@@ -359,6 +359,88 @@ def test_terminal_receipt_classification_blocks_cleanup(
     assert "harvested" in candidate.cleanup_safety.signals
 
 
+def test_terminal_path_receipt_classification_blocks_branchless_candidate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import codex_worktree_value_inventory as mod
+
+    root = _candidate(tmp_path)
+    repo_path = root / "aragora"
+    _stub_clean_git(monkeypatch, branch=None, ahead=2, head="abcdef123456")
+
+    candidate = mod.classify_candidate(
+        root,
+        context=_context(
+            tmp_path,
+            terminal_receipt_path_heads={str(repo_path.resolve()): {"abcdef1"}},
+        ),
+        size_bytes=1024,
+        size_lookup_failed=False,
+    )
+
+    assert candidate.classification == "receipt_protected"
+    assert candidate.cleanup_candidate is False
+    assert "terminal receipt references path/head" in candidate.proof
+
+
+def test_terminal_path_receipt_head_mismatch_stays_unique(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import codex_worktree_value_inventory as mod
+
+    root = _candidate(tmp_path)
+    repo_path = root / "aragora"
+    _stub_clean_git(
+        monkeypatch,
+        branch=None,
+        ahead=2,
+        head="abcdef123456",
+        patch_equivalent=False,
+    )
+
+    candidate = mod.classify_candidate(
+        root,
+        context=_context(
+            tmp_path,
+            terminal_receipt_path_heads={str(repo_path.resolve()): {"9999999"}},
+        ),
+        size_bytes=1024,
+        size_lookup_failed=False,
+    )
+
+    assert candidate.classification == "unique_unharvested"
+    assert candidate.decision == "harvest_candidate"
+
+
+def test_terminal_receipt_path_heads_reads_harvest_receipt_source_candidate(
+    tmp_path: Path,
+) -> None:
+    import codex_worktree_value_inventory as mod
+
+    root = _candidate(tmp_path)
+    repo_path = root / "aragora"
+    receipt_dir = tmp_path / ".aragora" / "worktree-harvest" / "harvest-receipts"
+    receipt_dir.mkdir(parents=True)
+    (receipt_dir / "preserve.json").write_text(
+        json.dumps(
+            {
+                "decision": "preserve_existing_pr",
+                "source_candidate": {
+                    "path": str(root),
+                    "repo_path": str(repo_path),
+                    "head": "abcdef123456",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    refs = mod.terminal_receipt_path_heads([receipt_dir])
+
+    assert refs[str(root.resolve())] == {"abcdef123456"}
+    assert refs[str(repo_path.resolve())] == {"abcdef123456"}
+
+
 def test_unique_unharvested_when_ahead_and_not_patch_equivalent(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- teach `codex_worktree_value_inventory.py` to preserve branchless worktrees when a terminal receipt references the exact worktree path/repo path and head
- include both `.aragora/automation-receipts` and `.aragora/worktree-harvest/harvest-receipts` as path/head receipt sources
- keep branch/head receipt behavior unchanged and keep mismatched-head branchless work harvestable

## Why
The current backlog-pressure inventory can surface already-represented branchless worktrees as `unique_unharvested` because terminal receipts are indexed only by branch/head. The current known false positives are receipt-backed settle-one worktrees represented by PR/outbox/harvest receipts.

## Validation
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_codex_worktree_value_inventory.py -q` -> `42 passed`
- `pre-commit run --files scripts/codex_worktree_value_inventory.py tests/scripts/test_codex_worktree_value_inventory.py` -> passed
- targeted real-data smoke against the three known branchless receipt-backed settle-one worktrees: `receipt_protected=3`, `unique_unharvested=0`

## Governance
Draft PR only. Do not mark ready or merge in the same harvest cycle.
