### PR TITLE
fix(metrics): validate boss metrics positive integers

### DIFF
--- a/scripts/boss_metrics_health.py
+++ b/scripts/boss_metrics_health.py
@@ -75,8 +75,8 @@ def _valid_issue_number(value: Any) -> bool:
     return isinstance(value, int) and not isinstance(value, bool) and value > 0
 
 
-def _positive_int(value: int, *, field: str) -> int:
-    if value <= 0:
+def _positive_int(value: Any, *, field: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
         raise ValueError(f"{field} must be a positive integer")
     return value
 


### PR DESCRIPTION
## Summary
- harvests the unowned `codex/swarm-1e8248cc-micro-1` candidate as a draft PR
- tightens `scripts/boss_metrics_health.py` positive-integer validation to reject non-int and bool values

## Harvest checks
- branch: `codex/swarm-1e8248cc-micro-1`
- head: `3ec3fddf2af78bda8d7670abfa95a1ecd268ffea`
- source path: `/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-1e8248cc-micro-1`
- active owner: none by branch and worktree owner probes
- existing PR: none before publication
- outbox/receipt representation: none by exact branch/head/path scan
- branch refs: local branch existed at exact head; remote branch created by this harvest
- merge-tree: clean against current `origin/main`

## Validation
- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree origin/main HEAD`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_boss_metrics_health.py -q` -> `25 passed`
- `pre-commit run --files scripts/boss_metrics_health.py tests/scripts/test_boss_metrics_health.py`
- push pre-push hooks passed, including mypy

Draft only. Do not mark ready or merge in this harvest cycle.
