### PR TITLE
fix(audit): split open-pr handoff counts

### DIFF
--- a/scripts/audit_codex_branch_backlog.py
+++ b/scripts/audit_codex_branch_backlog.py
@@ -498,6 +498,40 @@ def _outbox_payload_branch_heads(payload: dict[str, Any]) -> dict[str, set[str |
     return refs
 
 
+OPEN_PR_ACTION_VALUES: frozenset[str] = frozenset(
+    {
+        "create_pr",
+        "create_pull_request",
+        "open_pr",
+        "open_pull_request",
+        "pull_request",
+    }
+)
+
+
+def _normalise_action_value(value: Any) -> str:
+    if not isinstance(value, str):
+        return ""
+    return value.strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def _is_open_pr_handoff_payload(payload: Mapping[str, Any]) -> bool:
+    idempotency_key = str(payload.get("idempotency_key") or "").strip()
+    if idempotency_key.startswith("open-pr-"):
+        return True
+
+    requested_action = payload.get("requested_action")
+    action_values: list[Any] = [requested_action]
+    structured = _structured_action(requested_action)
+    if structured is not None:
+        action_values.extend(
+            structured.get(key) for key in ("action", "kind", "requested_action", "type")
+        )
+    action_values.extend(payload.get(key) for key in ("action", "kind", "type"))
+
+    return any(_normalise_action_value(value) in OPEN_PR_ACTION_VALUES for value in action_values)
+
+
 def terminal_receipt_branches(receipt_root: Path) -> set[str]:
     """Return branch references stored directly in terminal receipt payloads."""
 
@@ -682,6 +716,7 @@ def unresolved_outbox_handoff_branches(
     *,
     outbox_dir: Path | None = None,
     receipt_dir: Path | None = None,
+    open_pr_only: bool = False,
 ) -> set[str]:
     """Return branch names that already have unresolved automation outbox handoffs."""
 
@@ -698,6 +733,8 @@ def unresolved_outbox_handoff_branches(
             continue
         idempotency_key = str(payload.get("idempotency_key") or "").strip()
         if not idempotency_key or idempotency_key in terminal_keys:
+            continue
+        if open_pr_only and not _is_open_pr_handoff_payload(payload):
             continue
         branches.update(_outbox_payload_branches(payload))
     return branches
@@ -1173,6 +1210,12 @@ def audit(
         outbox_dir=resolved_outbox_dir,
         receipt_dir=resolved_receipt_dir,
     )
+    open_pr_handoff_outbox_branches = unresolved_outbox_handoff_branches(
+        root,
+        outbox_dir=resolved_outbox_dir,
+        receipt_dir=resolved_receipt_dir,
+        open_pr_only=True,
+    )
     patch_deadline = _patch_budget_deadline(patch_equivalence_time_budget_seconds)
     handoff_receipted_patch_ids: set[str] | None = None
     handoff_outbox_patch_ids: set[str] | None = None
@@ -1432,9 +1475,15 @@ def audit(
     direct_handoff_outbox_branches = sum(
         1 for record in records if record.name in handoff_outbox_branches
     )
+    direct_open_pr_handoff_outbox_branches = sum(
+        1 for record in records if record.name in open_pr_handoff_outbox_branches
+    )
     audited_branch_names = {record.name for record in records}
     unresolved_handoff_outbox_refs_outside_audit = len(
         handoff_outbox_branches - audited_branch_names
+    )
+    unresolved_open_pr_handoff_outbox_refs_outside_audit = len(
+        open_pr_handoff_outbox_branches - audited_branch_names
     )
     patch_equivalent_handoff_outbox_branches = sum(
         1
@@ -1477,6 +1526,11 @@ def audit(
             "direct_handoff_outbox_branches": direct_handoff_outbox_branches,
             "unresolved_handoff_outbox_refs_outside_audit": (
                 unresolved_handoff_outbox_refs_outside_audit
+            ),
+            "unresolved_open_pr_handoff_outbox_branch_refs": (len(open_pr_handoff_outbox_branches)),
+            "direct_open_pr_handoff_outbox_branches": direct_open_pr_handoff_outbox_branches,
+            "unresolved_open_pr_handoff_outbox_refs_outside_audit": (
+                unresolved_open_pr_handoff_outbox_refs_outside_audit
             ),
             "patch_equivalent_handoff_outbox_branches": (patch_equivalent_handoff_outbox_branches),
             "writer_should_pause_for_branch_backlog": (
@@ -1573,6 +1627,19 @@ def print_markdown(payload: dict[str, Any], *, examples: int) -> None:
         print(
             "- Patch-equivalent handoff-outbox branches: "
             f"`{summary['patch_equivalent_handoff_outbox_branches']}`"
+        )
+    if "unresolved_open_pr_handoff_outbox_branch_refs" in summary:
+        print(
+            "- Open-PR handoff-outbox branch refs: "
+            f"`{summary['unresolved_open_pr_handoff_outbox_branch_refs']}`"
+        )
+        print(
+            "- Direct open-PR handoff-outbox branches: "
+            f"`{summary['direct_open_pr_handoff_outbox_branches']}`"
+        )
+        print(
+            "- Open-PR handoff-outbox refs outside audit: "
+            f"`{summary['unresolved_open_pr_handoff_outbox_refs_outside_audit']}`"
         )
     print(
         f"- Patch-equivalence budget exhausted: `{payload['patch_equivalence_budget_exhausted']}`"

--- a/tests/scripts/test_audit_codex_branch_backlog.py
+++ b/tests/scripts/test_audit_codex_branch_backlog.py
@@ -379,6 +379,13 @@ def test_print_markdown_includes_revision_metadata(tmp_path: Path, capsys: Any) 
             "diverged_salvage_candidates": 0,
             "handoff_receipted_branches": 0,
             "handoff_outbox_branches": 0,
+            "unresolved_handoff_outbox_branch_refs": 0,
+            "direct_handoff_outbox_branches": 0,
+            "unresolved_handoff_outbox_refs_outside_audit": 0,
+            "patch_equivalent_handoff_outbox_branches": 0,
+            "unresolved_open_pr_handoff_outbox_branch_refs": 2,
+            "direct_open_pr_handoff_outbox_branches": 1,
+            "unresolved_open_pr_handoff_outbox_refs_outside_audit": 1,
             "writer_should_pause_for_branch_backlog": False,
             "protected": 0,
             "by_category": {},
@@ -391,6 +398,9 @@ def test_print_markdown_includes_revision_metadata(tmp_path: Path, capsys: Any) 
 
     assert "- Worktree HEAD: `1111111111111111111111111111111111111111`" in out
     assert "- Base SHA: `2222222222222222222222222222222222222222`" in out
+    assert "- Open-PR handoff-outbox branch refs: `2`" in out
+    assert "- Direct open-PR handoff-outbox branches: `1`" in out
+    assert "- Open-PR handoff-outbox refs outside audit: `1`" in out
 
 
 def test_audit_skips_open_pr_lookup_when_github_health_degraded(
@@ -1531,6 +1541,78 @@ def test_audit_excludes_unresolved_outbox_handoffs_from_publishable_backlog(
     assert handed_off["category"] == "protected_handoff_outbox"
 
 
+def test_audit_counts_open_pr_handoff_refs_separately_from_other_outbox(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    now = datetime.now(timezone.utc)
+    rows = [
+        _branch_row("codex/open-pr", committed_at=now),
+        _branch_row("codex/non-pr", committed_at=now),
+        _branch_row("codex/new-work", committed_at=now),
+    ]
+    outbox = tmp_path / ".aragora" / "automation-outbox"
+    outbox.mkdir(parents=True)
+    (outbox / "open-pr.json").write_text(
+        json.dumps(
+            {
+                "task": "Publish open-pr branch",
+                "requires_github": True,
+                "requested_action": "open_pr",
+                "repo": "synaptent/aragora",
+                "local_evidence": {"branch": "codex/open-pr", "head": "abc123"},
+                "idempotency_key": "publish-codex-open-pr-abc123",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (outbox / "non-pr.json").write_text(
+        json.dumps(
+            {
+                "task": "Notify about non-PR branch",
+                "requested_action": "notify_operator",
+                "repo": "synaptent/aragora",
+                "local_evidence": {"branch": "codex/non-pr", "head": "def456"},
+                "idempotency_key": "notify-codex-non-pr-def456",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mod, "local_branches", lambda _root, _prefix, _base: rows)
+    monkeypatch.setattr(mod, "remote_branch_names", lambda _root, _prefix: set())
+    monkeypatch.setattr(mod, "merged_branch_names", lambda _root, _base, _prefix: set())
+    monkeypatch.setattr(mod, "worktree_map", lambda _root: {})
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda _root, **_kwargs: GitHubCLIHealth(
+            ready=False,
+            auth_ok=False,
+            api_ok=False,
+            mode="connectivity_failed",
+            error="offline",
+            repo=str(tmp_path),
+        ),
+    )
+
+    payload = mod.audit(
+        root=tmp_path,
+        base="origin/main",
+        repo="synaptent/aragora",
+        prefix="codex/",
+        recent_hours=72,
+        max_branches=None,
+        include_patch_equivalence=False,
+        publisher_backlog_limit=2,
+    )
+
+    assert payload["summary"]["unresolved_handoff_outbox_branch_refs"] == 2
+    assert payload["summary"]["direct_handoff_outbox_branches"] == 2
+    assert payload["summary"]["unresolved_open_pr_handoff_outbox_branch_refs"] == 1
+    assert payload["summary"]["direct_open_pr_handoff_outbox_branches"] == 1
+    assert payload["summary"]["unresolved_open_pr_handoff_outbox_refs_outside_audit"] == 0
+    assert payload["summary"]["publishable_branch_backlog"] == 1
+
+
 def test_audit_protects_list_local_evidence_branch_handoffs(
     tmp_path: Path, monkeypatch: Any
 ) -> None:
@@ -2041,6 +2123,9 @@ def test_audit_treats_superseded_branch_as_unresolved_handoff(
     assert payload["summary"]["unresolved_handoff_outbox_branch_refs"] == 2
     assert payload["summary"]["direct_handoff_outbox_branches"] == 1
     assert payload["summary"]["unresolved_handoff_outbox_refs_outside_audit"] == 1
+    assert payload["summary"]["unresolved_open_pr_handoff_outbox_branch_refs"] == 2
+    assert payload["summary"]["direct_open_pr_handoff_outbox_branches"] == 1
+    assert payload["summary"]["unresolved_open_pr_handoff_outbox_refs_outside_audit"] == 1
     assert payload["summary"]["patch_equivalent_handoff_outbox_branches"] == 0
     assert payload["summary"]["publishable_branch_backlog"] == 1
     original = next(
@@ -2109,6 +2194,9 @@ def test_audit_counts_direct_outbox_refs_even_when_active_worktree_wins_category
     assert payload["summary"]["unresolved_handoff_outbox_branch_refs"] == 1
     assert payload["summary"]["direct_handoff_outbox_branches"] == 1
     assert payload["summary"]["unresolved_handoff_outbox_refs_outside_audit"] == 0
+    assert payload["summary"]["unresolved_open_pr_handoff_outbox_branch_refs"] == 1
+    assert payload["summary"]["direct_open_pr_handoff_outbox_branches"] == 1
+    assert payload["summary"]["unresolved_open_pr_handoff_outbox_refs_outside_audit"] == 0
     assert payload["summary"]["patch_equivalent_handoff_outbox_branches"] == 0
 
 


### PR DESCRIPTION
## Summary\n- add open-PR-specific unresolved handoff outbox summary counts\n- classify PR handoffs by open-pr idempotency keys or requested_action=open_pr\n- expose the new counts in markdown output\n\n## Validation\n- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_audit_codex_branch_backlog.py\n- /Users/armand/.pyenv/versions/3.11.11/bin/python -m py_compile scripts/audit_codex_branch_backlog.py tests/scripts/test_audit_codex_branch_backlog.py\n- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/audit_codex_branch_backlog.py tests/scripts/test_audit_codex_branch_backlog.py\n- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/audit_codex_branch_backlog.py tests/scripts/test_audit_codex_branch_backlog.py\n- git diff --check origin/main...HEAD\n- bash scripts/automation_pr_preflight.sh origin/main HEAD