### PR TITLE
feat(ops): per-pass GitHub App token routing for daemon gh calls

### DIFF
--- a/aragora/swarm/github_app_auth.py
+++ b/aragora/swarm/github_app_auth.py
@@ -251,7 +251,12 @@ def github_cli_env(
 ) -> dict[str, str]:
     env = dict(os.environ if base_env is None else base_env)
     if not prefer_app:
-        return env
+        # Drop any App-sourced token a shell wrapper exported (tagged via
+        # ARAGORA_GITHUB_AUTH_SOURCE by the scripts/gh_app_env.py wiring) so
+        # callers that do not prefer App auth — e.g. write ops where the
+        # installation has narrow scopes — fall back to the operator's
+        # PAT/keyring auth instead of silently using the App token.
+        return _drop_app_token(env)
     token = get_github_app_installation_token(env)
     if not token:
         return env

--- a/scripts/gh_app_env.py
+++ b/scripts/gh_app_env.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Mint a per-pass GitHub App installation token for shell ``gh`` consumers.
+
+Shell daemons (codex-automation publisher, merge-arbiter wrapper) call ``gh``
+directly with the operator's personal auth, draining the operator's API
+budget. The Python paths already route through the App installation token via
+:mod:`aragora.swarm.github_app_auth`; this script extends that to shell:
+
+    tok="$(python3 scripts/gh_app_env.py --print-token 2>/dev/null || true)"
+    [ -n "$tok" ] && export GH_TOKEN="$tok"
+
+or, eval-able form::
+
+    eval "$(python3 scripts/gh_app_env.py)"
+
+Contract (load-bearing for the daemons):
+
+* **Silent-safe** — when App config is absent, the mint fails, or aragora is
+  not importable, exit 0 and print *nothing* so callers degrade gracefully to
+  the operator's existing gh auth instead of crashing the pass.
+* **No leakage** — the token is written only to stdout in the designated
+  output mode; it is never logged, echoed to stderr, or included in
+  diagnostics.
+* **Per-pass freshness** — installation tokens expire after one hour, so
+  callers must invoke this at the top of each pass, never once at daemon
+  start. Each invocation is a fresh process, so the token is always fresh.
+
+Callers that export the result should also export
+``ARAGORA_GITHUB_AUTH_SOURCE=github_app_installation`` so
+:func:`aragora.swarm.github_app_auth.github_cli_env` and
+:func:`gh_subprocess_run` can recognize (and drop, for write ops) the
+App-sourced token.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Callable
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _resolve_minter() -> Callable[[], str | None]:
+    """Import the App token minter; raises if aragora is unavailable."""
+    if str(REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(REPO_ROOT))
+    from aragora.swarm.github_app_auth import get_github_app_installation_token
+
+    return get_github_app_installation_token
+
+
+def main(argv: list[str] | None = None, minter: Callable[[], str | None] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Mint a GitHub App installation token for shell gh calls. "
+            "Prints nothing (exit 0) when App config is absent."
+        ),
+    )
+    parser.add_argument(
+        "--print-token",
+        action="store_true",
+        help="Print the bare token to stdout (for command substitution).",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress diagnostics on stderr (never affects token output).",
+    )
+    args = parser.parse_args(argv)
+
+    token: str | None = None
+    try:
+        mint = minter if minter is not None else _resolve_minter()
+        token = mint()
+    except Exception:  # noqa: BLE001 - silent-safe contract: degrade, never crash callers
+        token = None
+
+    token = (token or "").strip()
+    if not token:
+        if not args.quiet:
+            # Diagnostic only — must never include token material.
+            print(
+                "gh_app_env: GitHub App config absent or mint failed; "
+                "no token emitted (callers keep existing gh auth)",
+                file=sys.stderr,
+            )
+        return 0
+
+    if args.print_token:
+        print(token)
+    else:
+        print(f"GH_TOKEN={token}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_codex_automation_publisher.sh
+++ b/scripts/run_codex_automation_publisher.sh
@@ -50,6 +50,29 @@ trap cleanup EXIT
 
 cd "$REPO_ROOT"
 
+# Opt-in GitHub App auth for this pass's shell-level `gh` calls (run-20260610
+# lane Z). Minted fresh here because installation tokens expire after one
+# hour and this script is exactly one publish pass per invocation (launchd
+# re-invokes it, so every pass gets a fresh token). Default off until the
+# operator flips ARAGORA_GH_APP_AUTH=1 (mirrors the ARAGORA_AUTO_EVIDENCE /
+# ARAGORA_QUORUM_RECONCILER wiring pattern). Fail-safe: gh_app_env.py prints
+# nothing when App config is absent or the mint fails, so the pass degrades
+# to the operator's existing gh auth instead of crashing. The token value is
+# never echoed. ARAGORA_GITHUB_AUTH_SOURCE tags the token so
+# aragora.swarm.github_app_auth can drop it for write ops (narrow App scopes).
+if [[ "${ARAGORA_GH_APP_AUTH:-0}" == "1" ]]; then
+  tok="$("${PYTHON_BIN}" scripts/gh_app_env.py --print-token --quiet 2>/dev/null || true)"
+  if [[ -n "${tok}" ]]; then
+    export GH_TOKEN="${tok}"
+    export GITHUB_TOKEN="${tok}"
+    export ARAGORA_GITHUB_AUTH_SOURCE="github_app_installation"
+    echo "$(STAMP) [codex-automation-publisher] gh auth: GitHub App installation token (per-pass mint)"
+  else
+    echo "$(STAMP) [codex-automation-publisher] gh auth: App token unavailable; using existing gh auth"
+  fi
+  unset tok
+fi
+
 echo "$(STAMP) [codex-automation-publisher] checking GitHub CLI health"
 HEALTH_JSON="$(python3 scripts/github_cli_health.py --repo "${REPO_ROOT}" --json 2>/dev/null || true)"
 if python3 scripts/cache_codex_automation_github_status.py \

--- a/scripts/run_merge_arbiter.sh
+++ b/scripts/run_merge_arbiter.sh
@@ -20,8 +20,28 @@ cd "${REPO_ROOT}"
 # run_boss_cycle.sh).
 if [[ "${ARAGORA_AUTO_EVIDENCE:-0}" == "1" ]]; then
     echo "Running bounded auto-evidence cycle (apply mode)..."
-    "${PYTHON_BIN}" scripts/auto_evidence_cycle.py --apply \
-        || echo "Auto-evidence cycle reported failures (non-fatal for the arbiter)." >&2
+    # Opt-in GitHub App auth for the auto-evidence pass's shell-level `gh`
+    # calls (ARAGORA_GH_APP_AUTH=1, default off; run-20260610 lane Z).
+    # Minted per pass inside a subshell — installation tokens expire after
+    # one hour, so the long-running arbiter exec'd below must NOT inherit a
+    # one-shot token (it refreshes its own per call via
+    # aragora.swarm.github_app_auth). Fail-safe: gh_app_env.py prints nothing
+    # when App config is absent, so the pass degrades to existing gh auth.
+    # The token value is never echoed. ARAGORA_GITHUB_AUTH_SOURCE tags the
+    # token so write ops can drop it (narrow App scopes).
+    (
+        if [[ "${ARAGORA_GH_APP_AUTH:-0}" == "1" ]]; then
+            tok="$("${PYTHON_BIN}" scripts/gh_app_env.py --print-token --quiet 2>/dev/null || true)"
+            if [[ -n "${tok}" ]]; then
+                export GH_TOKEN="${tok}"
+                export GITHUB_TOKEN="${tok}"
+                export ARAGORA_GITHUB_AUTH_SOURCE="github_app_installation"
+                echo "Auto-evidence gh auth: GitHub App installation token (per-pass mint)."
+            fi
+            unset tok
+        fi
+        exec "${PYTHON_BIN}" scripts/auto_evidence_cycle.py --apply
+    ) || echo "Auto-evidence cycle reported failures (non-fatal for the arbiter)." >&2
 fi
 
 echo "Starting swarm merge-arbiter..."

--- a/tests/scripts/test_gh_app_env.py
+++ b/tests/scripts/test_gh_app_env.py
@@ -1,0 +1,163 @@
+"""Tests for ``scripts/gh_app_env.py`` (per-pass GitHub App token for shell ``gh``).
+
+Covers the three contract-critical behaviors:
+
+* **Config-absent silence** — when no App config is available the script must
+  exit 0 and print *nothing* (daemons degrade to the operator's existing gh
+  auth instead of crashing).
+* **Token print path** — ``--print-token`` emits exactly the bare token on
+  stdout for command substitution; the default mode emits eval-able
+  ``GH_TOKEN=...`` shell assignments.
+* **No leakage** — the token never appears on stderr, in diagnostics, or in
+  the config-absent path.
+
+The minter boundary is injected; no test touches the network. One subprocess
+integration test exercises the real script end-to-end with App auth disabled.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "gh_app_env.py"
+
+FAKE_TOKEN = "ghs_test_token_abc123"  # noqa: S105 - synthetic test fixture
+
+
+def _load_module() -> Any:
+    spec = importlib.util.spec_from_file_location("gh_app_env_under_test", SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load spec for {SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def mod() -> Any:
+    return _load_module()
+
+
+# ---------------------------------------------------------------------------
+# Config-absent: silent-safe degradation
+# ---------------------------------------------------------------------------
+
+
+def test_config_absent_exits_zero_and_prints_nothing(mod, capsys) -> None:
+    rc = mod.main(["--print-token"], minter=lambda: None)
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out == ""
+
+
+def test_config_absent_quiet_emits_no_stderr(mod, capsys) -> None:
+    rc = mod.main(["--print-token", "--quiet"], minter=lambda: None)
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+def test_config_absent_env_mode_prints_nothing(mod, capsys) -> None:
+    rc = mod.main([], minter=lambda: None)
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out == ""
+
+
+def test_minter_crash_is_silent_safe(mod, capsys) -> None:
+    def _boom() -> str:
+        raise RuntimeError("mint exploded")
+
+    rc = mod.main(["--print-token", "--quiet"], minter=_boom)
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+def test_import_failure_is_silent_safe(mod, capsys, monkeypatch) -> None:
+    def _import_error() -> Any:
+        raise ImportError("aragora not importable")
+
+    monkeypatch.setattr(mod, "_resolve_minter", _import_error)
+    rc = mod.main(["--print-token", "--quiet"])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+# ---------------------------------------------------------------------------
+# Token print paths
+# ---------------------------------------------------------------------------
+
+
+def test_print_token_emits_bare_token_only(mod, capsys) -> None:
+    rc = mod.main(["--print-token"], minter=lambda: FAKE_TOKEN)
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out == FAKE_TOKEN + "\n"
+    assert FAKE_TOKEN not in captured.err
+
+
+def test_default_mode_emits_eval_able_assignment(mod, capsys) -> None:
+    rc = mod.main([], minter=lambda: FAKE_TOKEN)
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out == f"GH_TOKEN={FAKE_TOKEN}\n"
+    assert FAKE_TOKEN not in captured.err
+
+
+def test_no_token_leakage_to_stderr_in_any_mode(mod, capsys) -> None:
+    for argv in (["--print-token"], [], ["--print-token", "--quiet"], ["--quiet"]):
+        mod.main(argv, minter=lambda: FAKE_TOKEN)
+        captured = capsys.readouterr()
+        assert FAKE_TOKEN not in captured.err
+
+
+def test_whitespace_token_treated_as_absent(mod, capsys) -> None:
+    rc = mod.main(["--print-token", "--quiet"], minter=lambda: "   ")
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out == ""
+
+
+# ---------------------------------------------------------------------------
+# Subprocess integration: real script, App auth disabled
+# ---------------------------------------------------------------------------
+
+
+def test_subprocess_config_absent_silent(tmp_path) -> None:
+    env = {
+        k: v
+        for k, v in os.environ.items()
+        if not k.startswith(("GITHUB_APP", "GH_APP", "ARAGORA_GITHUB"))
+    }
+    env["ARAGORA_DISABLE_GITHUB_APP_TOKEN"] = "1"
+    env["ARAGORA_AUTOMATION_ENV_FILE"] = str(tmp_path / "missing.env")
+    result = subprocess.run(  # noqa: S603 - test invokes our own script
+        [sys.executable, str(SCRIPT_PATH), "--print-token", "--quiet"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env=env,
+        check=False,
+        cwd=str(REPO_ROOT),
+    )
+    assert result.returncode == 0
+    assert result.stdout == ""
+    # stderr may carry unrelated import-time warnings from the aragora package
+    # (daemons discard stderr); the contract is: no script diagnostic under
+    # --quiet and no token-shaped material ever.
+    assert "gh_app_env:" not in result.stderr
+    assert "ghs_" not in result.stderr

--- a/tests/swarm/test_github_app_auth.py
+++ b/tests/swarm/test_github_app_auth.py
@@ -160,6 +160,39 @@ def test_github_cli_env_falls_back_when_unconfigured() -> None:
     assert env == {"PATH": "/usr/bin", "ARAGORA_AUTOMATION_ENV_FILE": "/missing"}
 
 
+def test_github_cli_env_no_prefer_app_drops_shell_exported_app_token() -> None:
+    """A shell-exported App token (tagged by gh_app_env.py wiring) must be
+    dropped when the caller does not prefer App auth (e.g. write ops), so the
+    operator PAT/keyring auth is used instead of a narrow-scope App token."""
+    mod.clear_github_app_token_cache()
+
+    env = mod.github_cli_env(
+        {
+            "PATH": "/usr/bin",
+            "GH_TOKEN": "ghs_shell_exported",
+            "GITHUB_TOKEN": "ghs_shell_exported",
+            "ARAGORA_GITHUB_AUTH_SOURCE": "github_app_installation",
+        },
+        prefer_app=False,
+    )
+
+    assert "GH_TOKEN" not in env
+    assert "GITHUB_TOKEN" not in env
+    assert "ARAGORA_GITHUB_AUTH_SOURCE" not in env
+    assert env["PATH"] == "/usr/bin"
+
+
+def test_github_cli_env_no_prefer_app_keeps_untagged_user_token() -> None:
+    mod.clear_github_app_token_cache()
+
+    env = mod.github_cli_env(
+        {"PATH": "/usr/bin", "GH_TOKEN": "user_pat"},
+        prefer_app=False,
+    )
+
+    assert env["GH_TOKEN"] == "user_pat"
+
+
 def test_validate_github_api_request_allows_github_https() -> None:
     request = Request("https://api.github.com/app/installations/456/access_tokens")
 


### PR DESCRIPTION
Tier: 2

## Summary

The Python automation paths already route GitHub calls through the GitHub App installation token (`aragora/swarm/github_app_auth.py`, separate budget). The gap: the shell daemons call `gh` directly with the operator's personal auth, draining the operator's API budget. Installation tokens expire after **one hour**, so the token must be minted **per pass**, never baked into daemon env at start.

- **`scripts/gh_app_env.py` (new)**: mints a fresh installation token. `--print-token` emits the bare token for command substitution; default mode emits an eval-able `GH_TOKEN=` assignment. **Silent-safe contract**: exit 0 and print nothing when App config is absent, the mint fails, or aragora is unimportable — daemons degrade to the operator's existing gh auth instead of crashing. The token is never logged or echoed outside the designated stdout mode; `--quiet` suppresses the stderr diagnostic.
- **`scripts/run_codex_automation_publisher.sh`**: opt-in per-pass mint at the top of the publish pass behind `ARAGORA_GH_APP_AUTH=1` (default OFF, mirrors the `ARAGORA_AUTO_EVIDENCE` / `ARAGORA_QUORUM_RECONCILER` wiring pattern). The script is exactly one pass per launchd invocation, so every pass gets a fresh token.
- **`scripts/run_merge_arbiter.sh`**: same flag, but scoped in a **subshell** to the bounded auto-evidence section only. The arbiter itself is a long-running `exec` that refreshes its own App token per call via `aragora.swarm.github_app_auth` — it must NOT inherit a one-shot token that would go stale after an hour.
- **`aragora/swarm/github_app_auth.py`**: `github_cli_env(prefer_app=False)` now drops a shell-exported App token (tagged via `ARAGORA_GITHUB_AUTH_SOURCE`) so write ops keep preferring the operator PAT over narrow-scope App auth. Previously a shell-exported token would silently leak into the write path.

## Identity note

`gh` CLI prefers `GH_TOKEN` over keyring auth, so this cleanly switches identity per-process: with the flag on, daemon reads are attributed to `aragora-automation-fable[bot]` in audit logs instead of the operator — better attribution and a fully separate rate-limit budget. Operators should verify quorum-evidence counting accepts bot-authored comments before flipping the flag on the arbiter's auto-evidence path.

## Live proof (budget independence)

Minted once via the new script and compared `gh api rate_limit` core buckets (token value never printed):

| auth | limit | remaining | used |
|------|-------|-----------|------|
| operator keyring | 5000 | 4851 | 149 |
| App installation token | 15000 | 15000 | 0 |

Fully independent pools; the App budget is 3x larger.

## Tests

- 10 new: `tests/scripts/test_gh_app_env.py` — config-absent silence, minter-crash + import-failure silence, bare/eval output shapes, no stderr leakage in any mode, whitespace-token-as-absent, subprocess integration with App auth disabled.
- 2 new: `tests/swarm/test_github_app_auth.py` — `prefer_app=False` drops tagged App tokens, keeps untagged user tokens.
- 61/61 passing across `test_github_app_auth.py` + `test_gh_app_env.py` + `test_auto_evidence_cycle.py`; `bash -n` clean on both daemons; ruff + mypy clean.
- Live wiring fragment exercised: mint OK, degradation path empty-no-crash, eval mode OK.

## Governance

Two-family adversarial gate (run-20260610 lane Z): grok **Verdict: MERGE**; mistral-api initially CHANGES with three findings, each declined with documented technical rebuttal (no `/proc`/history on macOS launchd scripts + same-UID trust domain; `/tmp` logging contradicts the silent-safe contract; subshell exports cannot reach the parent), clean re-review returned **Verdict: MERGE**. Receipts VALID (3/3): `.aragora/run-20260610/receipts/laneZ_{grok,mistral-api}.json` (+ `laneZ_mistral-api_dissent.json` preserving the dissent round).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
