### PR TITLE
fix(tests): defuse v1-sunset calendar time-bomb in deprecation warning test

### DIFF
--- a/tests/server/middleware/test_deprecation.py
+++ b/tests/server/middleware/test_deprecation.py
@@ -126,14 +126,20 @@ class TestGetV1DeprecationHeaders:
         assert headers["X-API-Version"] == "v1"
 
     def test_returns_x_api_version_warning(self):
-        """Should return X-API-Version-Warning header."""
+        """Should return X-API-Version-Warning header.
+
+        The wording changes with the live deprecation phase (warning /
+        critical / sunset), so only assert the phase-independent contract
+        here; per-phase wording is covered by the dedicated level tests.
+        """
         from aragora.server.middleware.deprecation import get_v1_deprecation_headers
 
         headers = get_v1_deprecation_headers()
 
         assert "X-API-Version-Warning" in headers
-        assert "deprecated" in headers["X-API-Version-Warning"].lower()
-        assert "v2" in headers["X-API-Version-Warning"]
+        warning = headers["X-API-Version-Warning"]
+        assert "deprecated" in warning.lower() or "sunset" in warning.lower()
+        assert "v2" in warning
 
     def test_returns_x_api_sunset(self):
         """Should return X-API-Sunset header with ISO date."""


### PR DESCRIPTION
## Summary
- `test_returns_x_api_version_warning` froze the pre-sunset wording (`'deprecated' in warning`), so once the v1 sunset date (2026-06-01) passed and the middleware switched to its designed post-sunset message ("has passed its sunset date"), the test began failing for every PR that runs the `test-fast (server-rest)` slice. Confirmed failing on current main locally (1 failed, 82 passed).
- This is currently blocking dependabot PRs #7981, #7982, #7984 (their only real CI failure; types-pyyaml is stubs-only and cannot break runtime REST tests, confirming a shared-base cause).
- Fix asserts the phase-independent contract (header present, mentions v2, says deprecated-or-sunset); exact per-phase wording is already covered by the dedicated `test_critical_level_urgent_warning`, `test_sunset_level_warning_message`, and `test_warning_level_standard_message` tests, which patch the level explicitly and have no calendar dependence.

## Validation
- `python3 -m pytest tests/server/middleware/test_deprecation.py -q` -> 83/83 passed (was 1 failed, 82 passed on main)

## Risk
- Test-only change; no production code touched. Tier 2 (CI-unblocking test repair).