### PR TITLE
fix(steering): mark successful reads ok

### DIFF
--- a/scripts/read_operator_steering.py
+++ b/scripts/read_operator_steering.py
@@ -300,6 +300,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
 
     out = {
+        "ok": True,
         "owner_session": owner_session,
         "resolved_via": resolved_via,
         "lane_id": lane.get("lane_id") if isinstance(lane, dict) else None,

--- a/tests/scripts/test_read_operator_steering.py
+++ b/tests/scripts/test_read_operator_steering.py
@@ -197,6 +197,7 @@ def test_resolves_owner_by_lane_id(tmp_path: Path, capsys: Any) -> None:
 
     assert rc == 0
     out = json.loads(capsys.readouterr().out)
+    assert out["ok"] is True
     assert out["owner_session"] == "codex-lane-owner"
     assert out["resolved_via"] == "lane-id"
     assert out["message_count"] == 1


### PR DESCRIPTION
## Summary
- add `ok: true` to successful `read_operator_steering.py --json` output
- assert the success marker in focused steering reader coverage

## Validation
- `PYTHONDONTWRITEBYTECODE=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_read_operator_steering.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m py_compile scripts/read_operator_steering.py tests/scripts/test_read_operator_steering.py`
- `RUFF_CACHE_DIR=/private/tmp/ruff-cache-read-steering-ok /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/read_operator_steering.py tests/scripts/test_read_operator_steering.py`
- `RUFF_CACHE_DIR=/private/tmp/ruff-cache-read-steering-ok-format /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/read_operator_steering.py tests/scripts/test_read_operator_steering.py`
- `git diff --check origin/main...HEAD`
- `git rev-list --left-right --count origin/main...HEAD` => `0 1`
- `git cherry -v origin/main HEAD`
- `git merge-tree --write-tree origin/main HEAD`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`