### PR TITLE
fix(metrics): validate canonical headline counts

### DIFF
--- a/scripts/check_canonical_metrics.py
+++ b/scripts/check_canonical_metrics.py
@@ -158,35 +158,36 @@ def _goals_text() -> str:
     return _GOALS_TEXT_CACHE
 
 
+def _claimed_positive_headline_count(label: str) -> int | None:
+    match = re.search(rf"{re.escape(label)}\s*\|\s*([^\n|]+)", _goals_text())
+    if match is None:
+        return None
+    value = match.group(1).strip()
+    number_match = re.match(
+        r"(?P<number>(?:[1-9]\d{0,2}(?:,\d{3})+|[1-9]\d*|0))\+?(?=$|\s|/)",
+        value,
+    )
+    if number_match is None:
+        return None
+    number = int(number_match.group("number").replace(",", ""))
+    if number <= 0:
+        return None
+    return number
+
+
 def _claimed_km_adapter_count() -> int | None:
     """Parse 'Knowledge Mound adapters | <n> registered adapter specs'."""
-    match = re.search(
-        r"Knowledge Mound adapters\s*\|\s*(\d+)",
-        _goals_text(),
-    )
-    return int(match.group(1)) if match else None
+    return _claimed_positive_headline_count("Knowledge Mound adapters")
 
 
 def _claimed_python_modules_count() -> int | None:
     """Parse 'Python modules | 3,800+' → 3800."""
-    match = re.search(
-        r"Python modules\s*\|\s*([\d,]+)\+?",
-        _goals_text(),
-    )
-    if match is None:
-        return None
-    return int(match.group(1).replace(",", ""))
+    return _claimed_positive_headline_count("Python modules")
 
 
 def _claimed_test_definitions_count() -> int | None:
     """Parse 'Automated tests | 210,000+' → 210000."""
-    match = re.search(
-        r"Automated tests\s*\|\s*([\d,]+)\+?",
-        _goals_text(),
-    )
-    if match is None:
-        return None
-    return int(match.group(1).replace(",", ""))
+    return _claimed_positive_headline_count("Automated tests")
 
 
 def _claimed_version() -> str | None:

--- a/tests/scripts/test_check_canonical_metrics_counter.py
+++ b/tests/scripts/test_check_canonical_metrics_counter.py
@@ -51,6 +51,16 @@ def fake_repo(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
     return tmp_path
 
 
+@pytest.fixture
+def fake_goals(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Repoint CANONICAL_GOALS.md at a tmp file and clear the text cache."""
+
+    goals = tmp_path / "CANONICAL_GOALS.md"
+    monkeypatch.setattr(ccm, "CANONICAL_GOALS", goals)
+    monkeypatch.setattr(ccm, "_GOALS_TEXT_CACHE", None)
+    return goals
+
+
 def _write(p: Path, body: str) -> None:
     p.parent.mkdir(parents=True, exist_ok=True)
     p.write_text(body, encoding="utf-8")
@@ -195,3 +205,48 @@ class TestDocumentedMethodAlignment:
         # Expected: 5 (a, b, c, d, e); non-literal-space async forms,
         # not_a_test, and helper are excluded to match the documented grep.
         assert ccm._observe_test_definitions_count() == 5
+
+
+class TestClaimedHeadlineCountParsing:
+    def test_valid_current_headline_counts_parse(self, fake_goals: Path) -> None:
+        fake_goals.write_text(
+            "| Metric | Value | Source |\n"
+            "| Python modules | 135 top-level package directories | `docs/METRICS.md` |\n"
+            "| Automated tests | 216,016 test functions | `docs/METRICS.md` |\n"
+            "| Knowledge Mound adapters | 46 adapter files / 41 registered specs | `docs/METRICS.md` |\n",
+            encoding="utf-8",
+        )
+
+        assert ccm._claimed_python_modules_count() == 135
+        assert ccm._claimed_test_definitions_count() == 216016
+        assert ccm._claimed_km_adapter_count() == 46
+
+    def test_zero_headline_counts_are_invalid(
+        self, fake_goals: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake_goals.write_text(
+            "| Metric | Value | Source |\n"
+            "| Python modules | 0 top-level package directories | `docs/METRICS.md` |\n"
+            "| Automated tests | 0 test functions | `docs/METRICS.md` |\n"
+            "| Knowledge Mound adapters | 0 adapter files / 0 registered specs | `docs/METRICS.md` |\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(ccm, "_observe_python_modules_count", lambda: 135)
+
+        assert ccm._claimed_python_modules_count() is None
+        assert ccm._claimed_test_definitions_count() is None
+        assert ccm._claimed_km_adapter_count() is None
+        assert ccm._check_python_modules_count().status == "fail"
+
+    def test_malformed_grouped_headline_counts_are_invalid(self, fake_goals: Path) -> None:
+        fake_goals.write_text(
+            "| Metric | Value | Source |\n"
+            "| Python modules | 1,35 top-level package directories | `docs/METRICS.md` |\n"
+            "| Automated tests | 216,01 test functions | `docs/METRICS.md` |\n"
+            "| Knowledge Mound adapters | ,46 adapter files / 41 registered specs | `docs/METRICS.md` |\n",
+            encoding="utf-8",
+        )
+
+        assert ccm._claimed_python_modules_count() is None
+        assert ccm._claimed_test_definitions_count() is None
+        assert ccm._claimed_km_adapter_count() is None


### PR DESCRIPTION
## Summary
- validate canonical metric headline counts as positive integers
- reject zero and malformed comma-grouped headline values before tolerance checks
- add focused parser regressions for current values, zero counts, and malformed grouping

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_check_canonical_metrics_counter.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/check_canonical_metrics.py tests/scripts/test_check_canonical_metrics_counter.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/check_canonical_metrics.py tests/scripts/test_check_canonical_metrics_counter.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python scripts/check_canonical_metrics.py --claim canonical.python_modules.count --json
- bash scripts/automation_pr_preflight.sh origin/main HEAD