### PR TITLE
fix(benchmarks): validate debate prompt limits

### DIFF
--- a/scripts/debate_quality_benchmark.py
+++ b/scripts/debate_quality_benchmark.py
@@ -930,6 +930,10 @@ def select_prompts(prompt_limit: int) -> list[dict[str, str]]:
     """Select benchmark prompts while preserving 0 as the all-prompts CLI sentinel."""
     if prompt_limit < 0:
         raise ValueError("prompt_limit must be a non-negative integer")
+    if prompt_limit > len(PROMPTS):
+        raise ValueError(
+            f"prompt_limit={prompt_limit} exceeds available prompt corpus size {len(PROMPTS)}"
+        )
     return PROMPTS[:prompt_limit] if prompt_limit > 0 else PROMPTS
 
 
@@ -961,7 +965,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 async def main() -> None:
     args = parse_args()
 
-    selected = select_prompts(args.prompts)
+    try:
+        selected = select_prompts(args.prompts)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
 
     logger.info(
         "Starting benchmark: %d prompts, dry_run=%s",

--- a/tests/scripts/test_debate_quality_benchmark.py
+++ b/tests/scripts/test_debate_quality_benchmark.py
@@ -43,6 +43,15 @@ def test_prompt_limit_rejects_negative_values() -> None:
         module.select_prompts(-1)
 
 
+def test_prompt_limit_rejects_values_larger_than_prompt_corpus() -> None:
+    module = _load_module()
+
+    oversized = len(module.PROMPTS) + 1
+    assert module.parse_args(["--prompts", str(oversized)]).prompts == oversized
+    with pytest.raises(ValueError, match="exceeds available prompt corpus size"):
+        module.select_prompts(oversized)
+
+
 def test_select_prompts_positive_limit_returns_prefix() -> None:
     module = _load_module()
 


### PR DESCRIPTION
## Summary
- fail closed when debate quality benchmark --prompts exceeds the fixed prompt corpus size
- preserve 0 as the all-prompts sentinel and valid positive prefix selection
- add focused regression coverage and a clean CLI error path

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_debate_quality_benchmark.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/debate_quality_benchmark.py tests/scripts/test_debate_quality_benchmark.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/debate_quality_benchmark.py tests/scripts/test_debate_quality_benchmark.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python scripts/debate_quality_benchmark.py --dry-run --prompts 13 (expected nonzero, bounded error)
- bash scripts/automation_pr_preflight.sh origin/main HEAD