### PR TITLE
fix(preflight): suggest benchmark truth status validation

### DIFF
--- a/scripts/automation_pr_preflight.sh
+++ b/scripts/automation_pr_preflight.sh
@@ -61,6 +61,7 @@ def lines(name: str) -> list[str]:
     return [line for line in os.environ.get(name, "").splitlines() if line]
 
 
+changed_paths = set(lines("PREFLIGHT_CHANGED_FILES"))
 source_changes = lines("PREFLIGHT_SOURCE_CHANGES")
 test_changes = lines("PREFLIGHT_TEST_CHANGES")
 publisher_startup_changes = lines("PREFLIGHT_PUBLISHER_STARTUP_CHANGES")
@@ -75,6 +76,16 @@ if python_sources:
 if test_changes:
     quoted_tests = " ".join(shlex.quote(path) for path in test_changes)
     suggested_commands.append(f"python3 -m pytest {quoted_tests} -q")
+if changed_paths & {
+    "scripts/render_benchmark_truth_status.py",
+    "tests/scripts/test_render_benchmark_truth_status.py",
+}:
+    suggested_commands.append("python3 -m py_compile scripts/render_benchmark_truth_status.py")
+    renderer_test_command = (
+        "python3 -m pytest tests/scripts/test_render_benchmark_truth_status.py -q"
+    )
+    if renderer_test_command not in suggested_commands:
+        suggested_commands.append(renderer_test_command)
 if publisher_startup_changes:
     startup_modules = (
         "scripts.cache_codex_automation_github_status",

--- a/tests/scripts/test_automation_pr_preflight.py
+++ b/tests/scripts/test_automation_pr_preflight.py
@@ -118,6 +118,33 @@ def test_automation_pr_preflight_json_suggests_validation_for_source_without_tes
     ]
 
 
+def test_automation_pr_preflight_json_suggests_benchmark_truth_status_validation(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _run(["git", "switch", "-c", "codex/benchmark-truth-status-json"], cwd=repo)
+    source = repo / "scripts" / "render_benchmark_truth_status.py"
+    source.parent.mkdir()
+    source.write_text("print('status')\n", encoding="utf-8")
+    _run(["git", "add", "scripts/render_benchmark_truth_status.py"], cwd=repo)
+    _run(["git", "commit", "-m", "fix: update benchmark truth status renderer"], cwd=repo)
+
+    proc = _run(["bash", str(SCRIPT), "--json", "origin/main", "HEAD"], cwd=repo)
+
+    assert proc.returncode == 0
+    payload = json.loads(proc.stdout)
+    assert payload["status"] == "ok"
+    assert payload["suggested_validation_commands"] == [
+        (
+            "python3 scripts/nomic_ci_test_selector.py --changed-files "
+            "scripts/render_benchmark_truth_status.py --dry-run"
+        ),
+        "python3 -m ruff check scripts/render_benchmark_truth_status.py",
+        "python3 -m py_compile scripts/render_benchmark_truth_status.py",
+        "python3 -m pytest tests/scripts/test_render_benchmark_truth_status.py -q",
+    ]
+
+
 def test_automation_pr_preflight_json_suggests_publisher_startup_smoke(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Add JSON preflight suggestions for benchmark truth status renderer changes so automation branches get the focused compile and pytest commands alongside selector and Ruff hints.

Co-authored-by: codex[bot] <codex[bot]@users.noreply.github.com>
