### PR TITLE
fix(benchmarks): require dogfood summary runs

### DIFF
--- a/scripts/run_dogfood_benchmark.py
+++ b/scripts/run_dogfood_benchmark.py
@@ -230,6 +230,9 @@ def _safe_max(values: list[float]) -> float | None:
 
 
 def _summarize(runs: list[dict[str, Any]]) -> dict[str, Any]:
+    if not runs:
+        raise ValueError("dogfood benchmark summary requires at least one run")
+
     total = len(runs)
     non_timeout = [run for run in runs if not run["timed_out"]]
     successful = [run for run in runs if run["exit_code"] == 0 and not run["timed_out"]]
@@ -292,7 +295,7 @@ def _summarize(runs: list[dict[str, Any]]) -> dict[str, Any]:
         "successful_runs": len(successful),
         "quality_present_runs": len(quality_present),
         "passed_quality_and_practicality_runs": len(passed),
-        "pass_rate": round(len(passed) / total, 4) if total else 0.0,
+        "pass_rate": round(len(passed) / total, 4),
         "duration_seconds": {
             "mean": _safe_mean(durations),
             "median": _safe_median(durations),

--- a/tests/scripts/test_run_dogfood_benchmark.py
+++ b/tests/scripts/test_run_dogfood_benchmark.py
@@ -124,6 +124,10 @@ class TestExtractPipelineChecks:
 
 
 class TestSummarizeHardCheckRates:
+    def test_rejects_empty_run_collection(self) -> None:
+        with pytest.raises(ValueError, match="requires at least one run"):
+            run_dogfood_benchmark._summarize([])
+
     def test_missing_values_count_as_failed_rate(self) -> None:
         runs = [
             _run_template(


### PR DESCRIPTION
## Summary
- Fail closed when the dogfood benchmark summary helper is asked to summarize zero runs.
- Remove the misleading zero-run pass_rate fallback once the helper proves a nonempty run set.
- Add focused regression coverage for direct helper/report use.

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_run_dogfood_benchmark.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/run_dogfood_benchmark.py tests/scripts/test_run_dogfood_benchmark.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/run_dogfood_benchmark.py tests/scripts/test_run_dogfood_benchmark.py
- git diff --check
- bash scripts/automation_pr_preflight.sh origin/main HEAD