### PR TITLE
fix(server): resolve 2 route collisions (debates-summary, notifications-history) + shrink baseline 50→48

### DIFF
--- a/aragora/server/handlers/explainability.py
+++ b/aragora/server/handlers/explainability.py
@@ -6,7 +6,13 @@ Provides endpoints for understanding debate decisions:
 - GET /api/v1/debates/{id}/evidence - Evidence chain
 - GET /api/v1/debates/{id}/votes/pivots - Vote influence analysis
 - GET /api/v1/debates/{id}/counterfactuals - Counterfactual analysis
-- GET /api/v1/debates/{id}/summary - Human-readable summary
+
+Note: the human-readable ``/api/v1/debates/{id}/summary`` endpoint is owned by
+``DebatesHandler`` (``aragora.server.handlers.debates``), the canonical debate
+resource. This handler used to also claim ``/summary`` but was registered after
+DebatesHandler, so its claim was silently shadowed (never received traffic). The
+duplicate claim has been removed; use ``/explanation`` for the explainability
+view of a debate.
 
 Batch operations:
 - POST /api/v1/explainability/batch - Process multiple debates
@@ -268,7 +274,9 @@ class ExplainabilityHandler(BaseHandler):
         "/api/v1/debates/*/evidence",
         "/api/v1/debates/*/votes/pivots",
         "/api/v1/debates/*/counterfactuals",
-        "/api/v1/debates/*/summary",
+        # NOTE: "/api/v1/debates/*/summary" is owned by DebatesHandler (the
+        # canonical debate resource, registered earlier). This handler's claim
+        # was first-wins shadowed since registration; the duplicate is removed.
         "/api/v1/explain",
         "/api/v1/explain/*",
         # Batch endpoints
@@ -321,7 +329,7 @@ class ExplainabilityHandler(BaseHandler):
                 "/evidence",
                 "/votes/pivots",
                 "/counterfactuals",
-                "/summary",
+                # "/summary" intentionally omitted — owned by DebatesHandler.
                 "/explainability/export",
             ]
         ):
@@ -393,8 +401,7 @@ class ExplainabilityHandler(BaseHandler):
                 return await self._handle_vote_pivots(debate_id, query_params, is_legacy)
             elif endpoint == "counterfactuals":
                 return await self._handle_counterfactuals(debate_id, query_params, is_legacy)
-            elif endpoint == "summary":
-                return await self._handle_summary(debate_id, query_params, is_legacy)
+            # "summary" is owned by DebatesHandler — not dispatched here.
             elif endpoint == "explainability/export":
                 return await self._handle_export(debate_id, query_params)
 
@@ -591,89 +598,6 @@ class ExplainabilityHandler(BaseHandler):
         except (KeyError, ValueError, TypeError, AttributeError) as e:
             logger.error("Counterfactual error for %s: %s", debate_id, e)
             return error_response("Counterfactual retrieval failed", 500)
-
-    async def _handle_summary(
-        self, debate_id: str, query_params: dict[str, Any], is_legacy: bool
-    ) -> HandlerResult:
-        """Handle human-readable summary request."""
-        decision = None
-        try:
-            decision = await self._get_or_build_decision(debate_id)
-
-            if not decision:
-                return error_response(f"Debate not found: {debate_id}", 404)
-
-            from aragora.explainability import ExplanationBuilder
-
-            builder = ExplanationBuilder()
-            summary = builder.generate_summary(decision)
-
-            # Get format preference
-            format_type = get_string_param(query_params, "format", "markdown")
-
-            if format_type == "json":
-                result = json_response(
-                    {
-                        "debate_id": debate_id,
-                        "summary": summary,
-                        "confidence": decision.confidence,
-                        "consensus_reached": decision.consensus_reached,
-                    }
-                )
-            elif format_type == "html":
-                # markdown package has no type stubs; use Any for untyped module
-                import markdown as md_lib  # type: ignore[import-untyped]
-
-                html_body: str = str(md_lib.markdown(summary))
-                html_content = f"""
-<!DOCTYPE html>
-<html>
-<head><title>Decision Summary - {debate_id}</title>
-<style>
-body {{ font-family: system-ui, sans-serif; max-width: 800px; margin: 2rem auto; padding: 1rem; }}
-h2 {{ color: #333; }}
-h3 {{ color: #666; }}
-</style>
-</head>
-<body>
-{html_body}
-</body>
-</html>
-"""
-                result = HandlerResult(
-                    status_code=200,
-                    content_type="text/html",
-                    body=html_content.encode("utf-8"),
-                )
-            else:
-                result = HandlerResult(
-                    status_code=200,
-                    content_type="text/markdown",
-                    body=summary.encode("utf-8"),
-                )
-
-            return self._add_headers(result, is_legacy)
-
-        except ImportError:
-            # markdown not available, return plain text
-            if decision is None:
-                return error_response(f"Debate not found: {debate_id}", 404)
-
-            from aragora.explainability import ExplanationBuilder
-
-            builder = ExplanationBuilder()
-            summary = builder.generate_summary(decision)
-
-            result = HandlerResult(
-                status_code=200,
-                content_type="text/plain",
-                body=summary.encode("utf-8"),
-            )
-            return self._add_headers(result, is_legacy)
-
-        except (KeyError, ValueError, TypeError, AttributeError) as e:
-            logger.error("Summary error for %s: %s", debate_id, e)
-            return error_response("Summary generation failed", 500)
 
     async def _handle_export(self, debate_id: str, query_params: dict[str, Any]) -> HandlerResult:
         """Handle export request for decision explanation in various formats."""

--- a/aragora/server/handlers/social/notifications.py
+++ b/aragora/server/handlers/social/notifications.py
@@ -340,9 +340,15 @@ class NotificationsHandler(SecureHandler):
 
     RESOURCE_TYPE = "notification"
 
+    # NOTE: "/api/v1/notifications/history" is intentionally NOT claimed here.
+    # The working implementation lives in
+    # ``aragora.server.handlers.notifications.history.NotificationHistoryHandler``
+    # (``_get_history``, guarded by ``notifications:read``). This handler's
+    # ``handle()`` has no /history branch (it returns ``None``), so its
+    # first-wins claim on that path silently shadowed the real handler and left
+    # the endpoint broken. Dropping the dead claim restores it.
     ROUTES = [
         "/api/v1/notifications/status",
-        "/api/v1/notifications/history",
         "/api/v1/notifications/email/recipients",
         "/api/v1/notifications/email/config",
         "/api/v1/notifications/telegram/config",

--- a/tests/handlers/social/test_notifications.py
+++ b/tests/handlers/social/test_notifications.py
@@ -163,10 +163,9 @@ class TestCanHandle:
         assert not handler.can_handle("/api/v1/integrations/teams")
 
     def test_routes_list_complete(self, handler):
-        assert len(handler.ROUTES) == 8
+        assert len(handler.ROUTES) == 7
         expected = [
             "/api/v1/notifications/status",
-            "/api/v1/notifications/history",
             "/api/v1/notifications/email/recipients",
             "/api/v1/notifications/email/config",
             "/api/v1/notifications/telegram/config",
@@ -176,6 +175,17 @@ class TestCanHandle:
         ]
         for route in expected:
             assert route in handler.ROUTES
+
+    def test_history_route_not_claimed(self, handler):
+        """History is owned by NotificationHistoryHandler, not this handler.
+
+        The social NotificationsHandler previously claimed
+        /api/v1/notifications/history in ROUTES but never served it (handle()
+        has no /history branch), shadowing the real NotificationHistoryHandler
+        and breaking the endpoint. The dead claim was removed (run-20260611
+        PROD route-collision lane).
+        """
+        assert "/api/v1/notifications/history" not in handler.ROUTES
 
     def test_resource_type(self, handler):
         assert handler.RESOURCE_TYPE == "notification"

--- a/tests/handlers/test_explainability.py
+++ b/tests/handlers/test_explainability.py
@@ -43,9 +43,16 @@ class TestExplainabilityHandlerRouting:
         """Test matching counterfactuals route."""
         assert handler.can_handle("/api/v1/debates/debate_123/counterfactuals", "GET")
 
-    def test_can_handle_summary_route(self, handler):
-        """Test matching summary route."""
-        assert handler.can_handle("/api/v1/debates/debate_123/summary", "GET")
+    def test_does_not_handle_summary_route(self, handler):
+        """Summary is owned by DebatesHandler, not ExplainabilityHandler.
+
+        ExplainabilityHandler previously also claimed
+        /api/v1/debates/{id}/summary but was first-wins shadowed by
+        DebatesHandler since registration. The duplicate claim was removed
+        (run-20260611 PROD route-collision lane), so this handler must no
+        longer match the summary route.
+        """
+        assert not handler.can_handle("/api/v1/debates/debate_123/summary", "GET")
 
     def test_can_handle_explain_shortcut(self, handler):
         """Test matching explain shortcut route."""
@@ -308,7 +315,14 @@ class TestExplainabilityHandlerCounterfactuals:
 
 
 class TestExplainabilityHandlerSummary:
-    """Tests for summary endpoint."""
+    """Summary ownership moved to DebatesHandler (run-20260611 PROD lane).
+
+    ``/api/v1/debates/{id}/summary`` is served by DebatesHandler
+    (``_get_summary`` via ``aragora.debate.summarizer.summarize_debate``).
+    ExplainabilityHandler used to carry a duplicate, first-wins-shadowed claim
+    on the same path; the claim, its dispatch branch, and the now-dead
+    ``_handle_summary`` method were removed. These tests pin that removal.
+    """
 
     @pytest.fixture
     def handler(self):
@@ -317,31 +331,21 @@ class TestExplainabilityHandlerSummary:
 
         return ExplainabilityHandler({})
 
-    @pytest.fixture
-    def mock_decision(self):
-        """Create mock decision."""
-        decision = MagicMock()
-        decision.debate_id = "debate_123"
-        decision.outcome = "consensus"
-        return decision
-
     @pytest.mark.asyncio
-    async def test_handle_summary_success(self, handler, mock_decision):
-        """Test successful summary request."""
+    async def test_handle_summary_not_dispatched(self, handler):
+        """ExplainabilityHandler must not dispatch the summary endpoint."""
         mock_handler = MagicMock()
 
-        with patch.object(
-            handler, "_get_or_build_decision", new=AsyncMock(return_value=mock_decision)
-        ):
-            with patch("aragora.explainability.ExplanationBuilder") as MockBuilder:
-                MockBuilder.return_value.generate_summary.return_value = (
-                    "The debate reached consensus with high confidence."
-                )
-                result = await handler.handle(
-                    "/api/v1/debates/debate_123/summary", {}, mock_handler
-                )
+        result = await handler.handle("/api/v1/debates/debate_123/summary", {}, mock_handler)
 
-        assert result.status_code == 200
+        # No summary branch remains: dispatch falls through to the invalid-endpoint
+        # response rather than generating a summary.
+        assert result is not None
+        assert result.status_code == 400
+
+    def test_handle_summary_method_removed(self, handler):
+        """The dead ``_handle_summary`` method must no longer exist."""
+        assert not hasattr(handler, "_handle_summary")
 
 
 class TestExplainabilityHandlerBatch:

--- a/tests/server/test_route_collisions.py
+++ b/tests/server/test_route_collisions.py
@@ -217,7 +217,8 @@ KNOWN_COLLISIONS: dict[tuple[str, str], frozenset[str]] = {
     ("*", "/api/v1/billing/usage"): frozenset({"BillingHandler", "UsageMeteringHandler"}),
     ("*", "/api/v1/billing/usage/export"): frozenset({"BillingHandler", "UsageMeteringHandler"}),
     ("*", "/api/v1/debates/*/share"): frozenset({"DebateShareHandler", "SharingHandler"}),
-    ("*", "/api/v1/debates/*/summary"): frozenset({"DebatesHandler", "ExplainabilityHandler"}),
+    # RESOLVED (run-20260611 PROD lane): /api/v1/debates/*/summary now owned solely
+    # by DebatesHandler; duplicate claim removed from ExplainabilityHandler.
     ("*", "/api/v1/email/prioritize"): frozenset({"EmailDebateHandler", "EmailHandler"}),
     ("*", "/api/v1/health/database"): frozenset({"HealthHandler", "StorageHealthHandler"}),
     ("*", "/api/v1/health/stores"): frozenset({"HealthHandler", "StorageHealthHandler"}),
@@ -238,9 +239,10 @@ KNOWN_COLLISIONS: dict[tuple[str, str], frozenset[str]] = {
     ("*", "/api/v1/marketplace/templates/*"): frozenset(
         {"MarketplaceBrowseHandler", "MarketplaceHandler", "TemplateMarketplaceHandler"}
     ),
-    ("*", "/api/v1/notifications/history"): frozenset(
-        {"NotificationHistoryHandler", "NotificationsHandler"}
-    ),
+    # RESOLVED (run-20260611 PROD lane): /api/v1/notifications/history now owned
+    # solely by NotificationHistoryHandler (the real implementation). The social
+    # NotificationsHandler claimed the path but never served it (broken endpoint);
+    # the dead claim was removed, restoring the working handler.
     ("*", "/api/v1/pipeline"): frozenset({"DecompositionHandler", "PipelineExecuteHandler"}),
     ("*", "/api/v1/rlm/codebase/health"): frozenset({"RLMContextHandler", "RLMHandler"}),
     ("*", "/api/v1/rlm/compress"): frozenset({"RLMContextHandler", "RLMHandler"}),

--- a/tests/server/test_route_ownership_prod.py
+++ b/tests/server/test_route_ownership_prod.py
@@ -1,0 +1,68 @@
+"""Route-ownership assertions for resolved collisions (run-20260611 PROD lane).
+
+PR #8098 froze 50 route collisions in ``test_route_collisions.py``. This lane
+resolves a distinct subset of them (disjoint from the cluster-1 work in PR
+#8163) and pins the *correct owner* of each formerly-colliding path so that a
+future re-introduction of the duplicate claim fails loudly here, not silently
+in production.
+
+For each path we assert exactly one handler class claims it (no collision) AND
+that the surviving handler is the canonical, behavior-preserving owner:
+
+* ``/api/v1/debates/{id}/summary`` -> ``DebatesHandler``
+  Canonical debate-resource owner; already the live first-wins winner, so
+  existing clients see no change. ``ExplainabilityHandler`` carried a duplicate
+  (shadowed-since-registration) ``/summary`` claim that is removed.
+
+* ``/api/v1/notifications/history`` -> ``NotificationHistoryHandler``
+  This is a genuine *fix*: the social ``NotificationsHandler`` claimed the path
+  first but its ``handle()`` has no ``/history`` branch (returns ``None``), so
+  the endpoint was broken. ``NotificationHistoryHandler._get_history`` is the
+  real implementation (with ``notifications:read`` RBAC); removing the dead
+  claim restores it.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from aragora.server.handler_registry import HANDLER_REGISTRY
+from aragora.server.handler_registry.core import _DeferredImport
+
+
+@lru_cache(maxsize=1)
+def _claims() -> dict[str, set[str]]:
+    """Map every exact (normalized-version) route string to the handler names that claim it."""
+    out: dict[str, set[str]] = {}
+    for _attr, entry in HANDLER_REGISTRY:
+        cls = entry.resolve() if isinstance(entry, _DeferredImport) else entry
+        if cls is None:
+            continue
+        for raw in getattr(cls, "ROUTES", None) or []:
+            if not isinstance(raw, str):
+                continue
+            out.setdefault(raw, set()).add(cls.__name__)
+    return out
+
+
+def _owners(path: str) -> set[str]:
+    return _claims().get(path, set())
+
+
+def test_debates_summary_owned_only_by_debates_handler() -> None:
+    owners = _owners("/api/v1/debates/*/summary")
+    assert owners == {"DebatesHandler"}, (
+        "Expected DebatesHandler to be the sole owner of "
+        f"/api/v1/debates/*/summary, got {sorted(owners)}. ExplainabilityHandler "
+        "must not re-claim this path."
+    )
+
+
+def test_notifications_history_owned_only_by_history_handler() -> None:
+    owners = _owners("/api/v1/notifications/history")
+    assert owners == {"NotificationHistoryHandler"}, (
+        "Expected NotificationHistoryHandler (the real implementation) to be the "
+        "sole owner of /api/v1/notifications/history, got "
+        f"{sorted(owners)}. The social NotificationsHandler must not claim it — "
+        "its handle() has no /history branch and shadowed the working handler."
+    )


### PR DESCRIPTION
## Summary

Resolves **2 route-collision bugs** frozen in `KNOWN_COLLISIONS` by PR #8098 (`tests/server/test_route_collisions.py`), **disjoint from PR #8163** (which covers the cluster-1 health/metrics/auth-revoke entries). `HANDLER_REGISTRY` → `RouteIndex.build()` uses **first-wins** exact-route insertion, so a later handler claiming an already-claimed path is silently shadowed.

**Baseline: 50 → 48 known collisions.**

## Per-collision decisions

### 1. `/api/v1/debates/*/summary` — surviving owner: `DebatesHandler` (zero behavior change)

`DebatesHandler` (registry pos 159) registers **before** `ExplainabilityHandler` (pos 180), so it is the live first-wins winner today — `ExplainabilityHandler`'s `/summary` claim has been **shadowed since registration** (never received traffic). `DebatesHandler._get_summary` is the OpenAPI-documented (`@api_endpoint`) canonical debate-resource endpoint returning `{debate_id, summary, task, consensus_reached, confidence}`.

**Fix:** removed `ExplainabilityHandler`'s duplicate `/summary` ROUTES entry, its `can_handle` suffix, its dispatch branch, and the now-dead `_handle_summary` method. **Zero behavior change** for existing clients. The explainability view of a debate remains reachable at `/api/v1/debates/{id}/explanation`.

### 2. `/api/v1/notifications/history` — surviving owner: `NotificationHistoryHandler` (**genuine bug fix**)

The social `NotificationsHandler` (pos 319) registers **before** `NotificationHistoryHandler` (pos 327) and so wins — **but its `handle()` has no `/history` branch**: for that path it falls through and returns `None` (endpoint effectively broken). The real implementation is `NotificationHistoryHandler._get_history` (gated by `@require_permission("notifications:read")`, with pagination + channel filter), which was shadowed.

**Fix:** removed `/api/v1/notifications/history` from the social `NotificationsHandler` ROUTES (it keeps `/status`, `/email/*`, `/test`, `/send` — 7 routes). The exact-route table now routes `/history` to `NotificationHistoryHandler`, **restoring a broken endpoint**.

## Guard + tests

- 2 entries **deleted** from `KNOWN_COLLISIONS` (the staleness guard enforces deletion — baseline can only shrink; the collision test fails if a claim returns).
- **New** `tests/server/test_route_ownership_prod.py` pins `DebatesHandler` as sole owner of `/summary` and `NotificationHistoryHandler` as sole owner of `/history`.
- Existing handler tests updated to **characterize** the removals (not weakened): `ExplainabilityHandler` test asserts `can_handle("/summary") is False`, `_handle_summary` removed, dispatch returns 400; social `NotificationsHandler` test asserts 7 routes and that `/history` is unclaimed.
- All green: 14/14 collision+ownership, 394 explainability/notifications, 46 registry/debates. Pre-commit (ruff, gitleaks, portability) passed.

## Scope note (deferred)

The `/api/flips/{recent,summary}` collision (`AgentsHandler` vs `InsightsHandler`) is **intentionally left for a follow-up**: resolving it requires choosing canonical flip semantics and removing a real (if shadowed) implementation with its own ~10-test suite — higher blast radius than this lane's bound. `AgentsHandler` (OpenAPI-documented, live winner) is the likely canonical owner.

## Adversarial review (two families)

Both families returned **PASS** (consensus, confidence 0.8) on probes covering correct-owner choice, client-compatibility, the `/history` routing correctness, and baseline-shrink honesty:

- grok (`grok-4-latest`, xAI): receipt VALID — `.aragora/run-20260610/receipts/lanePROD_grok.json`
- mistral-api (`mistral-large-2512`): receipt VALID — `.aragora/run-20260610/receipts/lanePROD_mistral-api.json`

Lineage: branch `elves/run-20260611-prod-route-collisions` @ `1b93e43`; run-20260610 PROD lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)