### PR TITLE
fix(metrics): validate crash prompt counts

### DIFF
--- a/scripts/analyze_crash_patterns.py
+++ b/scripts/analyze_crash_patterns.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import sys
 from collections import Counter
 from pathlib import Path
@@ -20,6 +21,25 @@ from aragora.swarm.issue_scanner import (  # noqa: E402
 from aragora.swarm.terminal_truth import classify_from_metrics  # noqa: E402
 
 
+def _prompt_chars_value(row: dict[str, Any], *, line_number: int) -> float:
+    raw_value = row.get("prompt_chars", 0)
+    if raw_value in (None, ""):
+        return 0.0
+    if isinstance(raw_value, bool):
+        raise ValueError(
+            f"boss metrics row {line_number} field `prompt_chars` must be a numeric value"
+        )
+    try:
+        value = float(raw_value)
+    except (TypeError, ValueError):
+        raise ValueError(
+            f"boss metrics row {line_number} field `prompt_chars` must be a numeric value"
+        ) from None
+    if not math.isfinite(value):
+        raise ValueError(f"boss metrics row {line_number} field `prompt_chars` must be finite")
+    return value
+
+
 def load_prompt_rows(metrics_file: Path) -> list[dict[str, Any]]:
     """Load prompt-era rows only (`prompt_chars > 0`)."""
     if not metrics_file.exists():
@@ -27,14 +47,14 @@ def load_prompt_rows(metrics_file: Path) -> list[dict[str, Any]]:
 
     rows: list[dict[str, Any]] = []
     with metrics_file.open(encoding="utf-8", errors="replace") as fh:
-        for line in fh:
+        for line_number, line in enumerate(fh, start=1):
             try:
                 row = json.loads(line)
             except json.JSONDecodeError:
                 continue
             if not isinstance(row, dict):
                 continue
-            if float(row.get("prompt_chars", 0) or 0) <= 0:
+            if _prompt_chars_value(row, line_number=line_number) <= 0:
                 continue
             rows.append(row)
     return rows

--- a/tests/scripts/test_analyze_crash_patterns.py
+++ b/tests/scripts/test_analyze_crash_patterns.py
@@ -30,6 +30,28 @@ def test_load_prompt_rows_filters_prompt_versions(tmp_path: Path) -> None:
     assert [row["issue_number"] for row in rows] == [2]
 
 
+@pytest.mark.parametrize(
+    ("prompt_chars", "message"),
+    [
+        (True, "numeric value"),
+        ("NaN", "finite"),
+    ],
+)
+def test_load_prompt_rows_rejects_malformed_prompt_counts(
+    tmp_path: Path,
+    prompt_chars: object,
+    message: str,
+) -> None:
+    metrics_path = tmp_path / "boss_metrics.jsonl"
+    metrics_path.write_text(
+        json.dumps({"issue_number": 3, "prompt_chars": prompt_chars}) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=message):
+        load_prompt_rows(metrics_path)
+
+
 def test_terminal_class_counts_and_report(tmp_path: Path) -> None:
     rows = [
         {


### PR DESCRIPTION
## Summary
- Validate crash-pattern metrics row prompt_chars before classifying prompt-era rows.
- Reject boolean and non-finite prompt counts instead of letting them distort prompt-era crash analysis.
- Add focused regression coverage for malformed prompt count inputs.

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_analyze_crash_patterns.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/analyze_crash_patterns.py tests/scripts/test_analyze_crash_patterns.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/analyze_crash_patterns.py tests/scripts/test_analyze_crash_patterns.py
- git diff --check
- bash scripts/automation_pr_preflight.sh origin/main HEAD