### PR TITLE
fix(metrics): validate hot-path profile iterations

### DIFF
--- a/scripts/profile_hot_paths.py
+++ b/scripts/profile_hot_paths.py
@@ -69,6 +69,9 @@ def timer():
 
 def profile_function(func, iterations: int = 100, name: str = None) -> ProfileResult:
     """Profile a function over multiple iterations."""
+    if isinstance(iterations, bool) or iterations < 1:
+        raise ValueError("profile iterations must be a positive integer")
+
     times = []
 
     for _ in range(iterations):

--- a/tests/scripts/test_profile_hot_paths.py
+++ b/tests/scripts/test_profile_hot_paths.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pytest
+
+from scripts.profile_hot_paths import profile_function
+
+
+def test_profile_function_rejects_zero_iterations() -> None:
+    with pytest.raises(ValueError, match="positive integer"):
+        profile_function(lambda: None, iterations=0, name="noop")
+
+
+def test_profile_function_rejects_boolean_iterations() -> None:
+    with pytest.raises(ValueError, match="positive integer"):
+        profile_function(lambda: None, iterations=True, name="noop")
+
+
+def test_profile_function_accepts_single_iteration() -> None:
+    result = profile_function(lambda: None, iterations=1, name="noop")
+
+    assert result.name == "noop"
+    assert result.iterations == 1
+    assert result.total_time >= 0.0
+    assert result.avg_time >= 0.0
+    assert result.min_time >= 0.0
+    assert result.max_time >= 0.0
+    assert result.std_dev == 0.0


### PR DESCRIPTION
## Summary
- Reject invalid profile iteration counts before collecting hot-path timing samples.
- Prevent zero-iteration profile reports from failing later through empty-sample statistics.
- Add focused regression coverage for zero, boolean, and single-iteration profile calls.

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_profile_hot_paths.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/profile_hot_paths.py tests/scripts/test_profile_hot_paths.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/profile_hot_paths.py tests/scripts/test_profile_hot_paths.py
- git diff --check
- bash scripts/automation_pr_preflight.sh origin/main HEAD