### PR TITLE
fix(benchmarks): validate convergence thresholds

### DIFF
--- a/scripts/benchmark_convergence.py
+++ b/scripts/benchmark_convergence.py
@@ -20,6 +20,7 @@ Usage:
 
 from __future__ import annotations
 
+import math
 import os
 import sys
 import time
@@ -274,6 +275,10 @@ def run_single_debate(
     """Run a single debate and track convergence."""
     if max_rounds <= 0:
         raise ValueError("max_rounds must be a positive integer")
+    if isinstance(convergence_threshold, bool) or not math.isfinite(convergence_threshold):
+        raise ValueError("convergence_threshold must be a finite number between 0.0 and 1.0")
+    if convergence_threshold < 0.0 or convergence_threshold > 1.0:
+        raise ValueError("convergence_threshold must be between 0.0 and 1.0")
     if not agents:
         raise ValueError("agents must include at least one persona")
     unknown_agents = sorted(agent for agent in agents if agent not in PERSONAS)

--- a/tests/scripts/test_benchmark_convergence.py
+++ b/tests/scripts/test_benchmark_convergence.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -19,6 +20,26 @@ def test_run_single_debate_rejects_non_positive_round_count() -> None:
         benchmark_convergence.run_single_debate(
             max_rounds=0,
             agents=["analyst"],
+        )
+
+
+@pytest.mark.parametrize(
+    ("threshold", "message"),
+    [
+        (True, "finite number"),
+        (float("nan"), "finite number"),
+        (1.5, "between 0.0 and 1.0"),
+    ],
+)
+def test_run_single_debate_rejects_invalid_convergence_thresholds(
+    threshold: Any,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        benchmark_convergence.run_single_debate(
+            max_rounds=2,
+            agents=["analyst"],
+            convergence_threshold=threshold,
         )
 
 


### PR DESCRIPTION
## Summary
- Validate convergence benchmark thresholds before constructing the detector.
- Reject boolean, non-finite, and out-of-range thresholds that would make similarity savings reports misleading.
- Add focused regression coverage for invalid threshold inputs.

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_benchmark_convergence.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/benchmark_convergence.py tests/scripts/test_benchmark_convergence.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/benchmark_convergence.py tests/scripts/test_benchmark_convergence.py
- git diff --check
- bash scripts/automation_pr_preflight.sh origin/main HEAD