### PR TITLE
fix(metrics): reject empty prompt-engine profiles

### DIFF
--- a/scripts/profile_prompt_engine.py
+++ b/scripts/profile_prompt_engine.py
@@ -197,6 +197,9 @@ def build_profile_report(
     mode: str,
 ) -> dict[str, Any]:
     """Aggregate one or more prompt-engine timing samples."""
+    if not timings:
+        raise ValueError("prompt engine profile report requires at least one timing sample")
+
     stage_samples: dict[str, list[float]] = defaultdict(list)
     operation_samples: dict[str, list[float]] = defaultdict(list)
     operation_meta: dict[str, dict[str, str]] = {}

--- a/tests/scripts/test_profile_prompt_engine.py
+++ b/tests/scripts/test_profile_prompt_engine.py
@@ -1,7 +1,22 @@
 from __future__ import annotations
 
+import pytest
+
 from aragora.prompt_engine.timing import OperationTiming, PipelineTiming
 from scripts.profile_prompt_engine import build_profile_report
+
+
+def test_build_profile_report_rejects_empty_timing_samples() -> None:
+    with pytest.raises(ValueError, match="requires at least one timing sample"):
+        build_profile_report(
+            prompt="Profile the prompt engine",
+            timings=[],
+            profile="founder",
+            depth="quick",
+            skip_research=False,
+            skip_interrogation=False,
+            mode="mock-agent",
+        )
 
 
 def test_build_profile_report_aggregates_stage_and_operation_baselines() -> None:


### PR DESCRIPTION
## Summary
- Opened from automation outbox handoff `open-pr-codex-salvage-prompt-engine-profile-guards-20260609-c919355e`.
- Rejects empty prompt-engine profiling samples instead of emitting misleading zero-sample aggregate reports.
- Scope is limited to `scripts/profile_prompt_engine.py` and `tests/scripts/test_profile_prompt_engine.py`.

## Handoff Evidence
- Desired head: `c919355e133bab9e5c883c7b9871c712c3e7852b`
- Local validation recorded in the handoff:
  - `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_profile_prompt_engine.py -q`: 2 passed
  - `python -m py_compile scripts/profile_prompt_engine.py tests/scripts/test_profile_prompt_engine.py`: passed
  - `git diff --check origin/main..HEAD`: passed
  - `git merge-tree --write-tree origin/main HEAD`: passed
  - `bash scripts/automation_pr_preflight.sh origin/main HEAD`: preflight ok

## Current Publication Check
- Remote branch exists at exact desired head.
- Current `origin/main` compare shows 1 commit, 2 changed files.
- Current `git merge-tree --write-tree origin/main refs/remotes/origin/codex/salvage-prompt-engine-profile-guards-20260609` succeeds.

## Governance
Draft PR only. Do not mark ready, collect evidence, rerun CI, merge, or archive the outbox handoff without separate explicit operator authorization.
