### PR TITLE
fix(benchmarks): validate trickster rounds

### DIFF
--- a/scripts/benchmark_trickster.py
+++ b/scripts/benchmark_trickster.py
@@ -234,6 +234,21 @@ def create_agents(seed: int, *, hollow: bool = False) -> list[StyledMockAgent]:
     ]
 
 
+def _positive_int(raw: str) -> int:
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a positive integer") from exc
+    if value <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return value
+
+
+def _require_positive_int(value: int, *, label: str) -> None:
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise ValueError(f"{label} must be a positive integer")
+
+
 # ---------------------------------------------------------------------------
 # Single debate runner
 # ---------------------------------------------------------------------------
@@ -309,6 +324,7 @@ async def run_benchmark(
     """Run the full A/B benchmark across all test cases."""
     if not test_cases:
         raise ValueError("trickster benchmark requires at least one test case")
+    _require_positive_int(rounds, label="rounds")
 
     results: list[ABResult] = []
 
@@ -645,7 +661,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--rounds",
-        type=int,
+        type=_positive_int,
         default=2,
         help="Number of debate rounds per run (default: 2).",
     )

--- a/tests/scripts/test_benchmark_trickster.py
+++ b/tests/scripts/test_benchmark_trickster.py
@@ -1,5 +1,6 @@
 import asyncio
 import importlib.util
+import subprocess
 import sys
 from pathlib import Path
 
@@ -25,6 +26,41 @@ def test_run_benchmark_rejects_empty_case_collection() -> None:
 
     with pytest.raises(ValueError, match="requires at least one test case"):
         asyncio.run(module.run_benchmark([], rounds=2, seed=42))
+
+
+def test_run_benchmark_rejects_non_positive_round_count() -> None:
+    module = _load_module()
+    test_case = module.TestCase(
+        question="Should we use a simple benchmark guard?",
+        category=module.CATEGORY_CLEAR,
+    )
+
+    with pytest.raises(ValueError, match="rounds must be a positive integer"):
+        asyncio.run(module.run_benchmark([test_case], rounds=0, seed=42))
+
+
+def test_run_benchmark_rejects_boolean_round_count() -> None:
+    module = _load_module()
+    test_case = module.TestCase(
+        question="Should we use a simple benchmark guard?",
+        category=module.CATEGORY_CLEAR,
+    )
+
+    with pytest.raises(ValueError, match="rounds must be a positive integer"):
+        asyncio.run(module.run_benchmark([test_case], rounds=True, seed=42))
+
+
+def test_cli_rejects_non_positive_round_count_before_running() -> None:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "--rounds", "0", "--quick"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "must be a positive integer" in result.stderr
+    assert "Trickster A/B Benchmark" not in result.stdout
 
 
 def test_generate_report_rejects_empty_results() -> None:


### PR DESCRIPTION
## Summary
- Validate Trickster A/B benchmark rounds before running debates.
- Reject non-positive and boolean rounds through both programmatic and CLI paths.
- Add focused regression coverage for invalid rounds inputs.

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_benchmark_trickster.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/benchmark_trickster.py tests/scripts/test_benchmark_trickster.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/benchmark_trickster.py tests/scripts/test_benchmark_trickster.py
- git diff --check
- bash scripts/automation_pr_preflight.sh origin/main HEAD