### PR TITLE
[DIC-25] aragora stress-test CLI operator surface

### DIFF
--- a/aragora/cli/commands/dic25_stress_test.py
+++ b/aragora/cli/commands/dic25_stress_test.py
@@ -1,0 +1,104 @@
+"""CLI command: ``aragora stress-test`` (DIC-25 / #6219).
+
+Flag: ``ARAGORA_STRESS_TEST_ENABLED`` (default OFF).
+Live queue effect: none — read-only fragility report; no queue writes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+_FLAG = "ARAGORA_STRESS_TEST_ENABLED"
+
+
+def _flag_enabled() -> bool:
+    return os.environ.get(_FLAG, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _load_catalog(path: Path) -> list[dict]:
+    raw = path.read_text(encoding="utf-8").strip()
+    parsed = json.loads(raw)
+    return parsed if isinstance(parsed, list) else [parsed]
+
+
+def _load_units(path: Path) -> dict[str, float]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def cmd_stress_test(args: argparse.Namespace) -> int:
+    if not _flag_enabled():
+        print(
+            f"error: {_FLAG} is not set; set it to '1' to enable stress-test",
+            file=sys.stderr,
+        )
+        return 1
+
+    catalog_path = Path(args.catalog).expanduser()
+    if not catalog_path.exists():
+        print(f"error: catalog file not found: {catalog_path}", file=sys.stderr)
+        return 1
+
+    units_path = Path(args.units).expanduser()
+    if not units_path.exists():
+        print(f"error: units file not found: {units_path}", file=sys.stderr)
+        return 1
+
+    try:
+        raw_perturbations = _load_catalog(catalog_path)
+    except (json.JSONDecodeError, ValueError) as exc:
+        print(f"error: invalid catalog JSON: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        integrities: dict[str, float] = _load_units(units_path)
+    except (json.JSONDecodeError, ValueError) as exc:
+        print(f"error: invalid units JSON: {exc}", file=sys.stderr)
+        return 1
+
+    from aragora.epistemic.stress_test import StressPerturbation, run_stress_test
+
+    perturbations: list[StressPerturbation] = []
+    for row in raw_perturbations:
+        try:
+            perturbations.append(
+                StressPerturbation(
+                    perturbation_id=str(row["perturbation_id"]),
+                    kind=row["kind"],
+                    description=str(row["description"]),
+                    simulated_impact=float(row.get("simulated_impact", 0.0)),
+                    affected_claim_ids=list(row.get("affected_claim_ids", [])),
+                    affected_proof_unit_ids=list(row.get("affected_proof_unit_ids", [])),
+                )
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            print(f"warning: perturbation row skipped: {exc}", file=sys.stderr)
+
+    result = run_stress_test(perturbations, integrities, enabled=True)
+
+    if getattr(args, "json", False):
+        print(json.dumps(result.to_dict(), indent=2))
+    else:
+        print(
+            f"Stress-test: {result.perturbations_tested} perturbation(s) × "
+            f"{result.proof_units_probed} unit(s)\n"
+        )
+        high = result.high_fragility_units
+        if high:
+            print(f"High-fragility reports ({len(high)}):")
+            for r in high:
+                print(
+                    f"  {r.proof_unit_id} [{r.perturbation_id}]: "
+                    f"delta={r.fragility_delta:.3f}  action={r.recommended_action}"
+                )
+        else:
+            print("No high-fragility reports (delta ≤ 0.3 for all units).")
+        if result.most_fragile_unit_id:
+            print(
+                f"\nMost fragile: {result.most_fragile_unit_id} "
+                f"(max delta={result.max_fragility_delta:.3f})"
+            )
+    return 0

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -223,8 +223,6 @@ Examples:
     _add_truth_map_parser(subparsers)  # DIC-18 / #6028
     _add_decay_monitor_parser(subparsers)  # DIC-20 / #6031
     _add_epistemic_check_parser(subparsers)  # DIC-14 / #6024
-
-    # DIC-25: adversarial world-state stress-test operator surface
     _add_stress_test_parser(subparsers)  # DIC-25 / #6219
 
     # DIC-27: operator crux arbitration surface
@@ -791,35 +789,13 @@ def _add_decay_monitor_parser(subparsers) -> None:
 
 
 def _add_stress_test_parser(subparsers) -> None:
-    """Add the 'stress-test' subcommand (DIC-25 / #6219).
-
-    Flag-gated: ARAGORA_STRESS_TEST_ENABLED. Live queue effect: none.
-    """
+    """Add the 'stress-test' subcommand (DIC-25 / #6219)."""
     p = subparsers.add_parser(
         "stress-test",
         help="DIC-25: probe proof-carrying code units with adversarial world-state perturbations",
-        description=(
-            "Read-only offline stress-test: load a perturbation catalog and proof-unit "
-            "integrity scores, then report fragility deltas before reality invalidates them. "
-            "No queue mutation. Requires ARAGORA_STRESS_TEST_ENABLED=1."
-        ),
     )
-    p.add_argument(
-        "--catalog",
-        required=True,
-        metavar="JSON",
-        help=(
-            "Path to a JSON file containing a list of StressPerturbation dicts "
-            "(fields: perturbation_id, kind, description, simulated_impact, "
-            "affected_claim_ids, affected_proof_unit_ids)"
-        ),
-    )
-    p.add_argument(
-        "--units",
-        required=True,
-        metavar="JSON",
-        help="Path to a JSON file containing a {proof_unit_id: integrity_score} dict",
-    )
+    p.add_argument("--catalog", required=True, metavar="JSON", help="Perturbation catalog JSON")
+    p.add_argument("--units", required=True, metavar="JSON", help="Proof-unit integrities JSON")
     p.add_argument("--json", action="store_true", help="Emit JSON instead of human-readable text")
     p.set_defaults(func=_lazy("aragora.cli.commands.dic25_stress_test", "cmd_stress_test"))
 

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -224,6 +224,9 @@ Examples:
     _add_decay_monitor_parser(subparsers)  # DIC-20 / #6031
     _add_epistemic_check_parser(subparsers)  # DIC-14 / #6024
 
+    # DIC-25: adversarial world-state stress-test operator surface
+    _add_stress_test_parser(subparsers)  # DIC-25 / #6219
+
     # DIC-27: operator crux arbitration surface
     _add_crux_arbitrate_parser(subparsers)
 
@@ -785,6 +788,40 @@ def _add_decay_monitor_parser(subparsers) -> None:
     )
     p.add_argument("--json", action="store_true", help="Emit JSON instead of text")
     p.set_defaults(func=_lazy("aragora.cli.commands.dic20_decay_monitor", "cmd_decay_monitor"))
+
+
+def _add_stress_test_parser(subparsers) -> None:
+    """Add the 'stress-test' subcommand (DIC-25 / #6219).
+
+    Flag-gated: ARAGORA_STRESS_TEST_ENABLED. Live queue effect: none.
+    """
+    p = subparsers.add_parser(
+        "stress-test",
+        help="DIC-25: probe proof-carrying code units with adversarial world-state perturbations",
+        description=(
+            "Read-only offline stress-test: load a perturbation catalog and proof-unit "
+            "integrity scores, then report fragility deltas before reality invalidates them. "
+            "No queue mutation. Requires ARAGORA_STRESS_TEST_ENABLED=1."
+        ),
+    )
+    p.add_argument(
+        "--catalog",
+        required=True,
+        metavar="JSON",
+        help=(
+            "Path to a JSON file containing a list of StressPerturbation dicts "
+            "(fields: perturbation_id, kind, description, simulated_impact, "
+            "affected_claim_ids, affected_proof_unit_ids)"
+        ),
+    )
+    p.add_argument(
+        "--units",
+        required=True,
+        metavar="JSON",
+        help="Path to a JSON file containing a {proof_unit_id: integrity_score} dict",
+    )
+    p.add_argument("--json", action="store_true", help="Emit JSON instead of human-readable text")
+    p.set_defaults(func=_lazy("aragora.cli.commands.dic25_stress_test", "cmd_stress_test"))
 
 
 def _add_crux_arbitrate_parser(subparsers) -> None:

--- a/tests/cli/test_dic25_stress_test.py
+++ b/tests/cli/test_dic25_stress_test.py
@@ -64,13 +64,18 @@ def units_file(tmp_path: Path) -> Path:
 # ── Flag gating ──────────────────────────────────────────────────────────────
 
 
-def test_flag_off_exits_1(monkeypatch: pytest.MonkeyPatch, catalog_file: Path, units_file: Path) -> None:
+def test_flag_off_exits_1(
+    monkeypatch: pytest.MonkeyPatch, catalog_file: Path, units_file: Path
+) -> None:
     monkeypatch.delenv(_FLAG, raising=False)
     assert cmd_stress_test(_ns(str(catalog_file), str(units_file))) == 1
 
 
 def test_flag_off_names_flag_in_stderr(
-    monkeypatch: pytest.MonkeyPatch, catalog_file: Path, units_file: Path, capsys: pytest.CaptureFixture
+    monkeypatch: pytest.MonkeyPatch,
+    catalog_file: Path,
+    units_file: Path,
+    capsys: pytest.CaptureFixture,
 ) -> None:
     monkeypatch.delenv(_FLAG, raising=False)
     cmd_stress_test(_ns(str(catalog_file), str(units_file)))
@@ -106,7 +111,10 @@ def test_missing_units_exits_1(
 
 
 def test_text_output_mentions_counts(
-    monkeypatch: pytest.MonkeyPatch, catalog_file: Path, units_file: Path, capsys: pytest.CaptureFixture
+    monkeypatch: pytest.MonkeyPatch,
+    catalog_file: Path,
+    units_file: Path,
+    capsys: pytest.CaptureFixture,
 ) -> None:
     monkeypatch.setenv(_FLAG, "1")
     cmd_stress_test(_ns(str(catalog_file), str(units_file)))
@@ -121,14 +129,18 @@ def test_high_fragility_appears_in_output(
     monkeypatch.setenv(_FLAG, "1")
     catalog = tmp_path / "catalog_high.json"
     catalog.write_text(
-        json.dumps([{
-            "perturbation_id": "p_high",
-            "kind": "dependency_drop",
-            "description": "Critical dep dropped",
-            "simulated_impact": 0.7,
-            "affected_claim_ids": [],
-            "affected_proof_unit_ids": [],
-        }]),
+        json.dumps(
+            [
+                {
+                    "perturbation_id": "p_high",
+                    "kind": "dependency_drop",
+                    "description": "Critical dep dropped",
+                    "simulated_impact": 0.7,
+                    "affected_claim_ids": [],
+                    "affected_proof_unit_ids": [],
+                }
+            ]
+        ),
         encoding="utf-8",
     )
     assert cmd_stress_test(_ns(str(catalog), str(units_file))) == 0
@@ -141,14 +153,18 @@ def test_no_high_fragility_message(
     monkeypatch.setenv(_FLAG, "1")
     catalog = tmp_path / "catalog_low.json"
     catalog.write_text(
-        json.dumps([{
-            "perturbation_id": "p_low",
-            "kind": "api_rate_limit_shift",
-            "description": "Minor rate limit shift",
-            "simulated_impact": 0.05,
-            "affected_claim_ids": [],
-            "affected_proof_unit_ids": [],
-        }]),
+        json.dumps(
+            [
+                {
+                    "perturbation_id": "p_low",
+                    "kind": "api_rate_limit_shift",
+                    "description": "Minor rate limit shift",
+                    "simulated_impact": 0.05,
+                    "affected_claim_ids": [],
+                    "affected_proof_unit_ids": [],
+                }
+            ]
+        ),
         encoding="utf-8",
     )
     assert cmd_stress_test(_ns(str(catalog), str(units_file))) == 0
@@ -159,7 +175,10 @@ def test_no_high_fragility_message(
 
 
 def test_json_output_is_valid(
-    monkeypatch: pytest.MonkeyPatch, catalog_file: Path, units_file: Path, capsys: pytest.CaptureFixture
+    monkeypatch: pytest.MonkeyPatch,
+    catalog_file: Path,
+    units_file: Path,
+    capsys: pytest.CaptureFixture,
 ) -> None:
     monkeypatch.setenv(_FLAG, "1")
     rc = cmd_stress_test(_ns(str(catalog_file), str(units_file), json_out=True))
@@ -171,7 +190,10 @@ def test_json_output_is_valid(
 
 
 def test_json_report_fields(
-    monkeypatch: pytest.MonkeyPatch, catalog_file: Path, units_file: Path, capsys: pytest.CaptureFixture
+    monkeypatch: pytest.MonkeyPatch,
+    catalog_file: Path,
+    units_file: Path,
+    capsys: pytest.CaptureFixture,
 ) -> None:
     monkeypatch.setenv(_FLAG, "1")
     cmd_stress_test(_ns(str(catalog_file), str(units_file), json_out=True))
@@ -187,7 +209,10 @@ def test_json_report_fields(
 
 
 def test_boss_ready_never_in_output(
-    monkeypatch: pytest.MonkeyPatch, catalog_file: Path, units_file: Path, capsys: pytest.CaptureFixture
+    monkeypatch: pytest.MonkeyPatch,
+    catalog_file: Path,
+    units_file: Path,
+    capsys: pytest.CaptureFixture,
 ) -> None:
     monkeypatch.setenv(_FLAG, "1")
     cmd_stress_test(_ns(str(catalog_file), str(units_file), json_out=True))
@@ -218,14 +243,18 @@ def test_scoped_perturbation_skips_out_of_scope_units(
     monkeypatch.setenv(_FLAG, "1")
     catalog = tmp_path / "scoped.json"
     catalog.write_text(
-        json.dumps([{
-            "perturbation_id": "p_scoped",
-            "kind": "corpus_revision",
-            "description": "Scoped to a unit not in units file",
-            "simulated_impact": 0.8,
-            "affected_claim_ids": [],
-            "affected_proof_unit_ids": ["nonexistent.unit"],
-        }]),
+        json.dumps(
+            [
+                {
+                    "perturbation_id": "p_scoped",
+                    "kind": "corpus_revision",
+                    "description": "Scoped to a unit not in units file",
+                    "simulated_impact": 0.8,
+                    "affected_claim_ids": [],
+                    "affected_proof_unit_ids": ["nonexistent.unit"],
+                }
+            ]
+        ),
         encoding="utf-8",
     )
     rc = cmd_stress_test(_ns(str(catalog), str(units_file), json_out=True))

--- a/tests/cli/test_dic25_stress_test.py
+++ b/tests/cli/test_dic25_stress_test.py
@@ -1,0 +1,234 @@
+"""Tests for aragora.cli.commands.dic25_stress_test (DIC-25 / #6219).
+
+Hermetic: no network, queue, or database access.
+
+Note: the `aragora.epistemic` package __init__ imports `claim_verifier` which
+requires pyyaml. Stub it here so the hermetic uv-tool pytest venv (no pyyaml
+installed) can import the package cleanly. The same pattern is used by DIC-21
+and DIC-23 CLI tests.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+# Install yaml stub before any aragora.epistemic import is triggered.
+if "yaml" not in sys.modules:
+    _yaml = types.ModuleType("yaml")
+    _yaml.safe_load = lambda s: None  # type: ignore[attr-defined]
+    sys.modules["yaml"] = _yaml
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from aragora.cli.commands.dic25_stress_test import _FLAG, cmd_stress_test
+
+_CATALOG_1 = [
+    {
+        "perturbation_id": "p1",
+        "kind": "cve_drop",
+        "description": "OpenSSL CVE drop — global scope",
+        "simulated_impact": 0.4,
+        "affected_claim_ids": [],
+        "affected_proof_unit_ids": [],
+    }
+]
+_UNITS_1: dict[str, float] = {
+    "proof_first.shift.green_criteria": 0.9,
+    "benchmark.truth.publication": 0.8,
+}
+
+
+def _ns(catalog: str, units: str, json_out: bool = False) -> argparse.Namespace:
+    return argparse.Namespace(catalog=catalog, units=units, json=json_out)
+
+
+@pytest.fixture()
+def catalog_file(tmp_path: Path) -> Path:
+    p = tmp_path / "catalog.json"
+    p.write_text(json.dumps(_CATALOG_1), encoding="utf-8")
+    return p
+
+
+@pytest.fixture()
+def units_file(tmp_path: Path) -> Path:
+    p = tmp_path / "units.json"
+    p.write_text(json.dumps(_UNITS_1), encoding="utf-8")
+    return p
+
+
+# ── Flag gating ──────────────────────────────────────────────────────────────
+
+
+def test_flag_off_exits_1(monkeypatch: pytest.MonkeyPatch, catalog_file: Path, units_file: Path) -> None:
+    monkeypatch.delenv(_FLAG, raising=False)
+    assert cmd_stress_test(_ns(str(catalog_file), str(units_file))) == 1
+
+
+def test_flag_off_names_flag_in_stderr(
+    monkeypatch: pytest.MonkeyPatch, catalog_file: Path, units_file: Path, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.delenv(_FLAG, raising=False)
+    cmd_stress_test(_ns(str(catalog_file), str(units_file)))
+    assert _FLAG in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("val", ["1", "true", "yes", "on"])
+def test_flag_truthy_values_exit_0(
+    monkeypatch: pytest.MonkeyPatch, catalog_file: Path, units_file: Path, val: str
+) -> None:
+    monkeypatch.setenv(_FLAG, val)
+    assert cmd_stress_test(_ns(str(catalog_file), str(units_file))) == 0
+
+
+# ── File validation ───────────────────────────────────────────────────────────
+
+
+def test_missing_catalog_exits_1(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, units_file: Path
+) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    assert cmd_stress_test(_ns(str(tmp_path / "missing.json"), str(units_file))) == 1
+
+
+def test_missing_units_exits_1(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, catalog_file: Path
+) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    assert cmd_stress_test(_ns(str(catalog_file), str(tmp_path / "missing.json"))) == 1
+
+
+# ── Text output ───────────────────────────────────────────────────────────────
+
+
+def test_text_output_mentions_counts(
+    monkeypatch: pytest.MonkeyPatch, catalog_file: Path, units_file: Path, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    cmd_stress_test(_ns(str(catalog_file), str(units_file)))
+    out = capsys.readouterr().out
+    assert "1 perturbation" in out
+    assert "2 unit" in out
+
+
+def test_high_fragility_appears_in_output(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, units_file: Path, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    catalog = tmp_path / "catalog_high.json"
+    catalog.write_text(
+        json.dumps([{
+            "perturbation_id": "p_high",
+            "kind": "dependency_drop",
+            "description": "Critical dep dropped",
+            "simulated_impact": 0.7,
+            "affected_claim_ids": [],
+            "affected_proof_unit_ids": [],
+        }]),
+        encoding="utf-8",
+    )
+    assert cmd_stress_test(_ns(str(catalog), str(units_file))) == 0
+    assert "High-fragility" in capsys.readouterr().out
+
+
+def test_no_high_fragility_message(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, units_file: Path, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    catalog = tmp_path / "catalog_low.json"
+    catalog.write_text(
+        json.dumps([{
+            "perturbation_id": "p_low",
+            "kind": "api_rate_limit_shift",
+            "description": "Minor rate limit shift",
+            "simulated_impact": 0.05,
+            "affected_claim_ids": [],
+            "affected_proof_unit_ids": [],
+        }]),
+        encoding="utf-8",
+    )
+    assert cmd_stress_test(_ns(str(catalog), str(units_file))) == 0
+    assert "No high-fragility" in capsys.readouterr().out
+
+
+# ── JSON output ───────────────────────────────────────────────────────────────
+
+
+def test_json_output_is_valid(
+    monkeypatch: pytest.MonkeyPatch, catalog_file: Path, units_file: Path, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    rc = cmd_stress_test(_ns(str(catalog_file), str(units_file), json_out=True))
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["perturbations_tested"] == 1
+    assert data["proof_units_probed"] == 2
+    assert len(data["reports"]) == 2
+
+
+def test_json_report_fields(
+    monkeypatch: pytest.MonkeyPatch, catalog_file: Path, units_file: Path, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    cmd_stress_test(_ns(str(catalog_file), str(units_file), json_out=True))
+    rep = json.loads(capsys.readouterr().out)["reports"][0]
+    assert "proof_unit_id" in rep
+    assert "perturbation_id" in rep
+    assert "fragility_delta" in rep
+    assert "recommended_action" in rep
+    assert "baseline_integrity" in rep
+
+
+# ── Queue governance ──────────────────────────────────────────────────────────
+
+
+def test_boss_ready_never_in_output(
+    monkeypatch: pytest.MonkeyPatch, catalog_file: Path, units_file: Path, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    cmd_stress_test(_ns(str(catalog_file), str(units_file), json_out=True))
+    raw = capsys.readouterr().out
+    assert "boss-ready" not in raw
+    assert "boss_ready" not in raw
+
+
+# ── Edge cases ────────────────────────────────────────────────────────────────
+
+
+def test_empty_catalog_returns_zero_reports(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, units_file: Path, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    catalog = tmp_path / "empty.json"
+    catalog.write_text("[]", encoding="utf-8")
+    rc = cmd_stress_test(_ns(str(catalog), str(units_file), json_out=True))
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["perturbations_tested"] == 0
+    assert data["reports"] == []
+
+
+def test_scoped_perturbation_skips_out_of_scope_units(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, units_file: Path, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    catalog = tmp_path / "scoped.json"
+    catalog.write_text(
+        json.dumps([{
+            "perturbation_id": "p_scoped",
+            "kind": "corpus_revision",
+            "description": "Scoped to a unit not in units file",
+            "simulated_impact": 0.8,
+            "affected_claim_ids": [],
+            "affected_proof_unit_ids": ["nonexistent.unit"],
+        }]),
+        encoding="utf-8",
+    )
+    rc = cmd_stress_test(_ns(str(catalog), str(units_file), json_out=True))
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert all(r["fragility_delta"] == 0.0 for r in data["reports"])


### PR DESCRIPTION
## Slice

Adds `aragora stress-test` — a flag-gated CLI verb that reads a JSON perturbation catalog and a JSON proof-unit integrity map, then runs one offline pass via the existing `run_stress_test` backend and emits fragility deltas. The DIC-25 backend (`aragora/epistemic/stress_test.py`) has existed on `main` since the DIC-23..28 tranche landed; this slice closes the missing operator CLI surface gap using the same pattern as DIC-21 (`quarantine-eval`) and DIC-23 (`dialectical-loop`).

## Gating

- Default: **OFF** (flag: `ARAGORA_STRESS_TEST_ENABLED=1`)
- Live queue effect: **none** — read-only fragility report; no debates started, no queue writes, no routing changes
- Advances issue: #6219 (DIC-25 — Adversarial World-State Stress-Test)

## Tests

- `test_flag_off_exits_1` / `test_flag_off_names_flag_in_stderr` — unset flag → rc=1; stderr names the flag
- `test_flag_truthy_values_exit_0[1/true/yes/on]` — parametrized over all truthy spellings
- `test_missing_catalog_exits_1` / `test_missing_units_exits_1` — absent paths → rc=1
- `test_text_output_mentions_counts` — text report includes perturbation and unit counts
- `test_high_fragility_appears_in_output` — impact 0.7 on baseline 0.9 triggers "High-fragility" label in report
- `test_no_high_fragility_message` — impact 0.05 (delta < 0.3) shows "No high-fragility" message
- `test_json_output_is_valid` — `--json` emits parseable JSON with `perturbations_tested`, `proof_units_probed`, `reports`; 1 perturbation × 2 units → 2 reports
- `test_json_report_fields` — each report carries `proof_unit_id`, `perturbation_id`, `fragility_delta`, `recommended_action`, `baseline_integrity`
- `test_boss_ready_never_in_output` — queue governance: `boss-ready` never appears in output
- `test_empty_catalog_returns_zero_reports` — empty perturbation list → 0 reports, rc=0
- `test_scoped_perturbation_skips_out_of_scope_units` — perturbation scoped to a nonexistent unit → `fragility_delta=0.0` for all in-scope units

## Validation

- `pytest tests/cli/test_dic25_stress_test.py --noconftest` — **16 passed** in 0.20 s
- `ruff check aragora/cli/commands/dic25_stress_test.py tests/cli/test_dic25_stress_test.py` — **clean**
- `/root/.local/share/uv/tools/mypy/bin/mypy aragora/cli/commands/dic25_stress_test.py --ignore-missing-imports` — **Success: no issues found**
- Net diff: **298 non-blank LOC** (3 files: 104 CLI command, 37 parser, 157 tests)

Note: tests install a minimal `yaml` stub in `sys.modules` before any `aragora.epistemic` import so they run cleanly in the hermetic uv-tool pytest venv — the same pattern used by DIC-21 and DIC-23.

## Out of scope

- Wiring `aragora stress-test` output into the DIC-17 follow-up bridge or DIC-21 quarantine policy — natural follow-on once the operator has validated per-catalog runs
- Scheduling recurring stress-test runs across a proof-units directory — deferred; this slice is deliberate single-catalog evaluation only
- Integrating `StressTestResult` into the DIC-18 truth-map report — deferred to a DIC-25 follow-on slice

## Gate status

Per `docs/status/NEXT_STEPS_CANONICAL.md`, `DIC-13..22` (and by extension DIC-23..28) are in the **Delay** track. The proof-first Foreman gate has **not** opened. This PR is planning truth and flag-gated operator tooling only; no `boss-ready` label applied. Kept as draft.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCUuvFJukzn1XaMipe5xpy)_