### PR TITLE
docs(specs): ODR honesty deltas — source.artifact_hash subset-coverage note + verifier consistency cross-check

### DIFF
--- a/docs/specs/OPEN_DECISION_RECEIPT.md
+++ b/docs/specs/OPEN_DECISION_RECEIPT.md
@@ -174,7 +174,18 @@ metadata (channels, jurisdictional residency) in a later minor version.
 Links the neutral profile back to the emitting system's native record
 (`system`, `schema`, `schema_version`, `receipt_id`, `artifact_hash`) so an
 auditor can pull the full-fidelity original. Aragora populates it with the
-`DecisionReceipt` id and its content-addressable `artifact_hash`.
+`DecisionReceipt` id and its `artifact_hash`.
+
+**Honest-linkage note:** `DecisionReceipt.artifact_hash` is computed over a
+six-field subset of the native record (`receipt_id`, `gauntlet_id`,
+`input_hash`, `risk_summary`, `verdict`, `confidence`; see
+`DecisionReceipt._calculate_hash`). Fields such as `verdict_reasoning`,
+`dissenting_views`, and `agent_responses` can change without changing it.
+Consumers MUST treat `source.artifact_hash` as a stable locator plus an
+integrity check on those six fields, not as a content digest of the full
+original. Full-payload integrity for the *neutral* artifact is exactly what
+`odr_digest` (§5) provides; widening the native hash's coverage would re-hash
+every stored receipt and is out of scope for v0.1.
 
 ## 5. Canonicalization and hashing — RFC 8785 (JCS)
 
@@ -257,6 +268,11 @@ An emitter conforms to ODR v0.1 iff:
 A verifier conforms iff it validates the schema, recomputes `odr_digest` from
 JCS bytes, and treats `"undisclosed"`/absent markers as *weakening* rather
 than failing the receipt (policy thresholds are the verifier's choice).
+
+A verifier SHOULD additionally cross-check internal consistency: every name
+in `quorum.supporting_agents` and `quorum.dissent.dissenting_agents` should
+appear among `quorum.participants[].agent`. A mismatch is a malformed-receipt
+signal (emitter bug or tampering), not a mere weakening.
 
 ## 9. Versioning
 


### PR DESCRIPTION
Part of #8223; docs-only follow-up to #8239 (ODR-1, #8224). Carries the two salvageable deltas found by deep-diffing the superseded draft #8246 against the merged spec.

## Delta 1 — §4.9 honest-linkage note (audit-significant)

The merged §4.9 described `source.artifact_hash` as the `DecisionReceipt`'s "content-addressable" hash, implying full-fidelity verification of the pulled original. In fact `DecisionReceipt._calculate_hash` (aragora/gauntlet/receipt_models.py) covers a six-field subset: `receipt_id`, `gauntlet_id`, `input_hash`, `risk_summary`, `verdict`, `confidence`. `verdict_reasoning`, `dissenting_views`, and `agent_responses` can change without changing the hash. An auditor relying on it to verify the full native record would be misled.

The note states the real coverage, repositions the field as locator + six-field integrity check, points at `odr_digest` (§5) for full-payload integrity of the neutral artifact, and records why widening the native hash is out of scope for v0.1 (it would re-hash every stored receipt). This is the spec's own design rule 2 ("honest where it does not") applied to its provenance section.

## Delta 2 — §8 verifier consistency cross-check (SHOULD)

Adds one paragraph: verifiers SHOULD cross-check that names in `quorum.supporting_agents` and `quorum.dissent.dissenting_agents` appear among `quorum.participants[].agent`, and treat a mismatch as a malformed-receipt signal rather than mere weakening. Schema validation cannot express this cross-field constraint; the conformance section is the right home.

## Non-deltas (checked and deliberately not changed)

- Independence counting for `"undisclosed"` participants: the merged emitter already excludes undisclosed from `distinct_model_families` and attaches an explicit "independence cannot be asserted" note. Equal or better than the superseded draft's rule.
- Absent markers, attestation `autonomous` disposition, calibration `provenance_ref`, per-subcategory NIST mapping: merged version is better; superseded draft offers nothing.

Docs-only, Tier 2. Preflight: docs-only diff detected, ok.
