### PR TITLE
fix(metrics): validate work-loss windows

### DIFF
--- a/scripts/measure_work_loss.py
+++ b/scripts/measure_work_loss.py
@@ -125,6 +125,16 @@ def parse_ls_remote(text: str) -> set[str]:
     return heads
 
 
+def _positive_int(raw: str) -> int:
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a positive integer") from exc
+    if value <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return value
+
+
 def load_outbox_items(dirs: Sequence[Path]) -> tuple[list[dict], int]:
     """Load outbox item JSON files; unreadable files are counted, not hidden."""
     items: list[dict] = []
@@ -304,7 +314,7 @@ def render_waste_block(result: dict) -> str:
 
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--window-days", type=int, default=7)
+    parser.add_argument("--window-days", type=_positive_int, default=7)
     parser.add_argument("--repo", default=DEFAULT_REPO)
     parser.add_argument(
         "--outbox-dir",

--- a/tests/scripts/test_measure_work_loss.py
+++ b/tests/scripts/test_measure_work_loss.py
@@ -238,6 +238,26 @@ class TestLoadOutboxItems:
 
 
 class TestMainJson:
+    def test_refuses_non_positive_window_days_before_loading_inputs(
+        self, capsys: pytest.CaptureFixture
+    ) -> None:
+        with pytest.raises(SystemExit) as exc:
+            main(["--window-days", "0", "--json"])
+
+        assert exc.value.code == 2
+        err = capsys.readouterr().err
+        assert "argument --window-days: must be a positive integer" in err
+
+    def test_refuses_negative_window_days_before_loading_inputs(
+        self, capsys: pytest.CaptureFixture
+    ) -> None:
+        with pytest.raises(SystemExit) as exc:
+            main(["--window-days", "-3", "--json"])
+
+        assert exc.value.code == 2
+        err = capsys.readouterr().err
+        assert "argument --window-days: must be a positive integer" in err
+
     def test_end_to_end_with_injected_files(
         self, tmp_path: Path, capsys: pytest.CaptureFixture
     ) -> None:


### PR DESCRIPTION
## Summary
- Validate `measure_work_loss.py --window-days` as a positive integer.
- Reject zero and negative work-loss reporting windows before loading inputs or reaching GitHub.
- Add focused CLI regression coverage for invalid window lengths.

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_measure_work_loss.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/measure_work_loss.py tests/scripts/test_measure_work_loss.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/measure_work_loss.py tests/scripts/test_measure_work_loss.py
- git diff --check
- bash scripts/automation_pr_preflight.sh origin/main HEAD