### PR TITLE
fix(benchmarks): validate publication stale windows

### DIFF
--- a/scripts/benchmark_publication_run_followup.py
+++ b/scripts/benchmark_publication_run_followup.py
@@ -89,6 +89,9 @@ def classify_publication_runs(
     lookup. Apply mode should only cancel when live branch truth proves staleness
     unless the operator explicitly opts into unknown-branch cancellation.
     """
+    if stale_after_minutes < 1:
+        raise ValueError("stale_after_minutes must be >= 1")
+
     now_dt = _parse_timestamp(now) if now is not None else datetime.now(UTC)
     if now_dt is None:
         now_dt = datetime.now(UTC)
@@ -213,6 +216,9 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     if args.max_runs < 1:
         print("--max-runs must be >= 1", file=sys.stderr)
+        return 1
+    if args.stale_after_minutes < 1:
+        print("--stale-after-minutes must be >= 1", file=sys.stderr)
         return 1
     token = os.environ.get("GITHUB_TOKEN", "").strip() or os.environ.get("GH_TOKEN", "").strip()
     if not token:

--- a/tests/scripts/test_benchmark_publication_run_followup.py
+++ b/tests/scripts/test_benchmark_publication_run_followup.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import pytest
+
 from scripts.benchmark_publication_run_followup import (
     _branch_heads_for_runs,
     classify_publication_runs,
+    main,
 )
 
 
@@ -137,6 +140,30 @@ def test_classify_publication_runs_can_explicitly_cancel_unknown_branch() -> Non
     assert actions[0]["action"] == "cancel"
     assert actions[0]["reason"] == "unknown-branch-head"
     assert actions[0]["run_id"] == 42
+
+
+def test_classify_publication_runs_rejects_non_positive_stale_window() -> None:
+    with pytest.raises(ValueError, match="stale_after_minutes must be >= 1"):
+        classify_publication_runs(
+            [],
+            branch_heads={},
+            now="2026-06-03T00:54:00Z",
+            stale_after_minutes=0,
+        )
+
+
+def test_main_rejects_non_positive_stale_window_before_token_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+
+    assert main(["--stale-after-minutes", "0"]) == 1
+
+    captured = capsys.readouterr()
+    assert "--stale-after-minutes must be >= 1" in captured.err
+    assert "GITHUB_TOKEN" not in captured.err
 
 
 def test_branch_heads_for_runs_url_encodes_branch_names() -> None:


### PR DESCRIPTION
Summary:
- reject non-positive stale publication windows in the benchmark publication follow-up classifier and CLI
- fail before GitHub token/network handling when the CLI stale window is invalid
- add focused regression coverage for direct and CLI paths

Validation:
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_benchmark_publication_run_followup.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD