### PR TITLE
feat(ops): trail_reconcile sentinel check + incident-replay acceptance (TET T3/T5)

### DIFF
--- a/docs/runbooks/TRAIL_RECONCILE.md
+++ b/docs/runbooks/TRAIL_RECONCILE.md
@@ -28,6 +28,7 @@ off the record.
 | **high** | push, merge, branch deletion without anchored intent | Normal agent verbs gone off the record. |
 | **unknown** (exit 2) | witness unreadable, intent-chain module absent/unpopulated, witness silent beyond 4× cadence | Silence is never success; unknown outranks breach in the exit contract. |
 | note (still ok) | witness silence beyond cadence (default 6 h) but under 4× | Blind-period note: visible but quiet. |
+| note (still ok) | `coverage limited` — interim events-API witness in use | The GitHub REST events witness **cannot see token/deploy-key/member admin events** (the May-incident class). Until operator phase T0 (S3 audit stream) is live, an `ok` only covers push/merge/branch-deletion traffic; every report says so. |
 
 ## Operator response to a critical breach
 

--- a/docs/runbooks/TRAIL_RECONCILE.md
+++ b/docs/runbooks/TRAIL_RECONCILE.md
@@ -1,0 +1,52 @@
+# Trail Reconcile — Tamper-Evident Trail Alarm (TET T3)
+
+Spec: `docs/specs/TAMPER_EVIDENT_TRAIL.md` (Component 3). Check:
+`trail_reconcile` in `scripts/fleet_sentinel.py`.
+
+## What a trail breach means
+
+The sentinel diffs **what happened** (the external witness — today the
+interim GitHub REST events feed or a local replica via
+`--trail-witness-replica`; the S3 audit-log stream once operator phase T0 is
+done) against **what was intended** (the anchored intent chain,
+`.aragora/trail/intent-chain.jsonl`, read and hash-verified via
+`aragora.trail.intent_chain`).
+
+**The contract: every mutating action needs a pre-anchored intent.** An
+intent anchored *after* the action (beyond a small clock-skew grace, default
+2 min) does not count — post-hoc anchoring cannot legitimize anything. A
+mutating witness event with no matching intent (repo + ref/sha + compatible
+actor class + anchored within the match window, default 15 min before) is a
+breach: someone — possibly an adversary holding our own credentials — acted
+off the record.
+
+## Severity tiers
+
+| Tier | Event classes | Why |
+|---|---|---|
+| **critical** | token/deploy-key/app/secret changes, member/role changes, workflow changes; intent-chain tamper (`verify_chain` broken) | Credential and member events have **no legitimate agent intent class** — only a scarmani-anchored intent matches. This is the May-incident shape. |
+| **high** | push, merge, branch deletion without anchored intent | Normal agent verbs gone off the record. |
+| **unknown** (exit 2) | witness unreadable, intent-chain module absent/unpopulated, witness silent beyond 4× cadence | Silence is never success; unknown outranks breach in the exit contract. |
+| note (still ok) | witness silence beyond cadence (default 6 h) but under 4× | Blind-period note: visible but quiet. |
+
+## Operator response to a critical breach
+
+1. **Rotate credentials now** — GitHub tokens, deploy keys, App keys; assume
+   the laptop's credentials are hostile (the spec's threat model).
+2. **Freeze settlement** — no Tier-2+ merges/settles until reconciled; pause
+   the publisher/auto-evidence loops if the breach touches workflows.
+3. **Investigate via the S3 witness** — the Object-Lock bucket is the
+   append-only ground truth; pull the window around the breach event and
+   compare with the intent chain (`seq`/`intent_id` in the sentinel detail).
+   The check's detail enumerates every unmatched event and the chain-verify
+   result so nothing unaccounted-for is hidden.
+4. **Record the disposition** as an anchored intent (scarmani-anchored for
+   credential events) so the next cycle reconciles clean — or keep the alarm
+   firing on purpose until it is truly resolved.
+
+False alarms on normal ~30-merge agent traffic mean the matching rules are
+wrong: tune `--trail-match-window-mins` / actor classes, or honestly
+downgrade to advisory (spec exit metric). The permanent regression guards are
+`test_breach_replay_may_incident_unauthorized_credential` and
+`test_replay_normal_day_thirty_merges_zero_false_alarms` in
+`tests/scripts/test_fleet_sentinel.py`.

--- a/scripts/fleet_sentinel.py
+++ b/scripts/fleet_sentinel.py
@@ -52,6 +52,7 @@ ALL_CHECKS = (
     "disk_free",
     "lane_liveness",
     "github_api_health",
+    "trail_reconcile",
 )
 
 # Branch namespaces owned by autonomous lanes; only these are eligible for the
@@ -490,6 +491,399 @@ def check_github_api_health(
 
 
 # ---------------------------------------------------------------------------
+# trail_reconcile (TET Component 3 — witness vs anchored-intent reconciliation)
+# docs/specs/TAMPER_EVIDENT_TRAIL.md, build phase T3 (+ T5 acceptance replay)
+# ---------------------------------------------------------------------------
+
+# Witness event classes that mutate the repo/org and therefore REQUIRE a
+# pre-anchored intent.  severity per spec: token/key/member/workflow=critical,
+# push/merge/branch=high.  require_human: credential and member changes have
+# no legitimate agent intent class — only a scarmani-anchored intent matches.
+_EVENT_CLASS_KEYS: tuple[tuple[tuple[str, ...], str, str, frozenset[str], bool], ...] = (
+    (
+        ("token", "deploy_key", "secret", "app_install", "integration"),
+        "credential_change",
+        "critical",
+        frozenset({"credential_change"}),
+        True,
+    ),
+    (("member", "org_role"), "member_change", "critical", frozenset({"member_change"}), True),
+    (("workflow",), "workflow_change", "critical", frozenset({"workflow_change"}), False),
+    (
+        ("branch_delet", "branch_delete"),
+        "branch_deletion",
+        "high",
+        frozenset({"branch_deletion", "branch_delete", "janitor"}),
+        False,
+    ),
+    (("push",), "push", "high", frozenset({"push", "publish"}), False),
+    (("merge",), "merge", "high", frozenset({"merge", "settle"}), False),
+)
+
+# Actor classification for the interim GitHub witness.  Unknown actors match
+# no intent — exactly the May-incident shape (action from an unknown context).
+KNOWN_AGENT_ACTORS = frozenset({"an0mium"})
+KNOWN_HUMAN_ACTORS = frozenset({"scarmani"})
+HUMAN_ACTOR_CLASSES = frozenset({"scarmani", "human", "operator"})
+AGENT_ACTOR_CLASSES = frozenset({"agent", "automation", "loop", "lane"})
+
+
+def classify_witness_actor(actor: str) -> str:
+    if actor in KNOWN_HUMAN_ACTORS:
+        return "human"
+    if actor in KNOWN_AGENT_ACTORS or actor.endswith("[bot]"):
+        return "agent"
+    return "unknown"
+
+
+def classify_witness_event(event_type: str) -> tuple[str, str, frozenset[str], bool] | None:
+    """``event_type`` -> (class, severity, allowed intent_types, require_human).
+
+    Returns None for non-mutating event classes (ignored by reconciliation).
+    """
+    lowered = event_type.lower()
+    for keys, cls, severity, intent_types, require_human in _EVENT_CLASS_KEYS:
+        if any(key in lowered for key in keys):
+            # the event's own type is always an acceptable intent_type name
+            return cls, severity, intent_types | {lowered}, require_human
+    return None
+
+
+def _parse_target(target: str) -> tuple[str, str, str]:
+    """Canonical intent target ``<repo>[@<ref>][#<sha>]`` -> parts."""
+    head, _, sha = target.partition("#")
+    repo, _, ref = head.partition("@")
+    return repo.strip(), ref.strip(), sha.strip()
+
+
+def _target_matches(target: str, repo: str, ref: str, sha: str) -> bool:
+    t_repo, t_ref, t_sha = _parse_target(target)
+    if repo and t_repo and t_repo != repo:
+        return False
+    if not (ref or sha):
+        return True  # repo-scoped event (e.g. credential change)
+    if t_ref and ref and t_ref == ref:
+        return True
+    if t_sha and sha and (sha.startswith(t_sha) or t_sha.startswith(sha)):
+        return True
+    return False
+
+
+def _record_as_dict(record: Any) -> dict[str, Any]:
+    if isinstance(record, dict):
+        return record
+    if hasattr(record, "_asdict"):
+        return dict(record._asdict())
+    if hasattr(record, "__dict__"):
+        return dict(vars(record))
+    raise TypeError(f"unsupported intent record type: {type(record).__name__}")
+
+
+def _normalize_verify(verdict: Any) -> tuple[bool, str]:
+    """Normalize ``verify_chain`` results across plausible return shapes."""
+    if isinstance(verdict, bool):
+        return verdict, ""
+    if isinstance(verdict, tuple) and verdict:
+        return bool(verdict[0]), str(verdict[1]) if len(verdict) > 1 else ""
+    if isinstance(verdict, dict):
+        ok = bool(verdict.get("ok", verdict.get("valid", False)))
+        detail = str(verdict.get("detail", verdict.get("error", "")) or "")
+        broken_at = verdict.get("broken_at", verdict.get("broken_at_seq"))
+        if broken_at is not None and "seq" not in detail:
+            detail = (detail + f" at seq {broken_at}").strip()
+        return ok, detail
+    for attr in ("ok", "valid"):
+        if hasattr(verdict, attr):
+            return bool(getattr(verdict, attr)), str(getattr(verdict, "detail", "") or "")
+    return bool(verdict), ""
+
+
+def _default_chain_reader(chain_path: Path) -> tuple[list[dict[str, Any]], bool, str]:
+    """Read + verify the intent chain via ``aragora.trail.intent_chain``.
+
+    The module is lane TA's deliverable (TET phase T1) and is imported lazily:
+    until it merges, ImportError degrades this check to ``unknown`` so T3 ships
+    independently and lights up the moment T1 lands.
+    """
+    from aragora.trail import intent_chain  # noqa: PLC0415 - deliberate lazy import
+
+    if not chain_path.exists():
+        raise FileNotFoundError(str(chain_path))
+    records = [_record_as_dict(r) for r in intent_chain.read_records(chain_path)]
+    ok, detail = _normalize_verify(intent_chain.verify_chain(chain_path))
+    return records, ok, detail
+
+
+def _jsonl_chain_reader(chain_path: Path) -> tuple[list[dict[str, Any]], bool, str]:
+    """Schema-only fallback reader: parses the chain JSONL without verifying
+    hashes.  Honest about it — the verify detail says ``unverified``."""
+    if not chain_path.exists():
+        raise FileNotFoundError(str(chain_path))
+    records = []
+    for line in chain_path.read_text().splitlines():
+        if line.strip():
+            records.append(json.loads(line))
+    return records, True, "unverified (jsonl fallback reader; hashes not checked)"
+
+
+def _match_intent(
+    event: dict[str, Any],
+    *,
+    allowed_intent_types: frozenset[str],
+    require_human: bool,
+    records: list[dict[str, Any]],
+    event_ts: datetime,
+    pre_window_seconds: float,
+    skew_seconds: float,
+) -> bool:
+    """An anchored intent matches a witness event iff intent_type is allowed,
+    target references the event's repo and ref/sha, actor classes are
+    compatible, and the intent was anchored BEFORE the event (within the match
+    window; a small skew grace absorbs clock drift, nothing more — post-hoc
+    anchoring cannot legitimize an action)."""
+    actor_class = classify_witness_actor(str(event.get("actor", "")))
+    for record in records:
+        if str(record.get("intent_type", "")).lower() not in allowed_intent_types:
+            continue
+        if not _target_matches(
+            str(record.get("target", "")),
+            str(event.get("repo", "") or ""),
+            str(event.get("ref", "") or ""),
+            str(event.get("sha", "") or ""),
+        ):
+            continue
+        record_class = str(record.get("actor_class", "")).lower()
+        if require_human:
+            if record_class not in HUMAN_ACTOR_CLASSES:
+                continue
+        elif actor_class == "human":
+            if record_class not in HUMAN_ACTOR_CLASSES:
+                continue
+        elif actor_class == "agent":
+            if record_class not in AGENT_ACTOR_CLASSES:
+                continue
+        else:  # unknown actors match nothing
+            continue
+        try:
+            record_ts = parse_iso(str(record.get("ts", "")))
+        except ValueError:
+            continue
+        lead = (event_ts - record_ts).total_seconds()
+        if -skew_seconds <= lead <= pre_window_seconds:
+            return True
+    return False
+
+
+def check_trail_reconcile(
+    *,
+    witness_events: Callable[[], list[dict[str, Any]]],
+    chain_path: Path,
+    now: datetime,
+    chain_reader: Callable[[Path], tuple[list[dict[str, Any]], bool, str]] | None = None,
+    match_window_minutes: float = 15.0,
+    skew_minutes: float = 2.0,
+    witness_cadence_hours: float = 6.0,
+    blind_factor: float = 4.0,
+    reconcile_window_hours: float = 24.0,
+) -> CheckResult:
+    """TET Component 3: diff what HAPPENED (witness) against what was INTENDED
+    (anchored intent chain).  Every mutating witness event needs a matching
+    pre-anchored intent; unmatched events breach at class severity; a broken
+    chain is a critical breach; an unreadable witness or absent chain is
+    ``unknown`` (silence is never success)."""
+    name = "trail_reconcile"
+    try:
+        events = list(witness_events())
+    except Exception as exc:  # noqa: BLE001 - unreadable witness = we are blind
+        return _result(name, "unknown", f"witness unreadable: {exc.__class__.__name__}: {exc}")
+    try:
+        records, chain_ok, chain_verify_detail = (chain_reader or _default_chain_reader)(
+            Path(chain_path)
+        )
+    except ImportError:
+        return _result(
+            name,
+            "unknown",
+            "aragora.trail.intent_chain module not present (TET phase T1 not merged); "
+            "reconciliation degraded — witness events cannot be matched yet",
+        )
+    except FileNotFoundError:
+        return _result(name, "unknown", f"intent chain not yet populated at {chain_path}")
+    except Exception as exc:  # noqa: BLE001 - unreadable chain = we are blind
+        return _result(name, "unknown", f"intent chain unreadable: {exc.__class__.__name__}: {exc}")
+
+    problems: list[str] = []
+    if not chain_ok:
+        problems.append(
+            "critical: intent chain tampered — "
+            + (chain_verify_detail or "verify_chain reported broken")
+        )
+
+    window_seconds = reconcile_window_hours * 3600.0
+    newest_age_hours: float | None = None
+    matched = 0
+    considered = 0
+    malformed = 0
+    for event in events:
+        try:
+            event_ts = parse_iso(str(event.get("created_at", "")))
+        except ValueError:
+            malformed += 1
+            continue
+        age_seconds = (now - event_ts).total_seconds()
+        age_hours = age_seconds / 3600.0
+        if newest_age_hours is None or age_hours < newest_age_hours:
+            newest_age_hours = age_hours
+        classified = classify_witness_event(str(event.get("event_type", "")))
+        if classified is None or age_seconds > window_seconds:
+            continue
+        event_class, severity, allowed_intent_types, require_human = classified
+        considered += 1
+        if _match_intent(
+            event,
+            allowed_intent_types=allowed_intent_types,
+            require_human=require_human,
+            records=records,
+            event_ts=event_ts,
+            pre_window_seconds=match_window_minutes * 60.0,
+            skew_seconds=skew_minutes * 60.0,
+        ):
+            matched += 1
+            continue
+        anchor_hint = (
+            "no scarmani-anchored intent (credential/member events have no agent intent class)"
+            if require_human
+            else "no anchored intent"
+        )
+        problems.append(
+            f"{severity}: {event.get('event_type')} by {event.get('actor')} "
+            f"on {event.get('repo')}"
+            + (f"@{event['ref']}" if event.get("ref") else "")
+            + f" at {event.get('created_at')} — {anchor_hint}"
+        )
+
+    chain_note = f"chain {'ok' if chain_ok else 'TAMPERED'} ({len(records)} record(s)"
+    if chain_verify_detail:
+        chain_note += f"; {chain_verify_detail}"
+    chain_note += ")"
+    blind_note = ""
+    badly_blind = False
+    if newest_age_hours is None:
+        badly_blind = True
+        blind_note = "blind period: witness returned no events at all"
+    elif newest_age_hours > witness_cadence_hours * blind_factor:
+        badly_blind = True
+        blind_note = (
+            f"blind period: newest witness event {newest_age_hours:.1f}h old "
+            f"(cadence {witness_cadence_hours}h badly exceeded, factor {blind_factor})"
+        )
+    elif newest_age_hours > witness_cadence_hours:
+        blind_note = (
+            f"blind-period note: newest witness event {newest_age_hours:.1f}h old "
+            f"(expected cadence {witness_cadence_hours}h)"
+        )
+    if malformed:
+        blind_note = (blind_note + "; " if blind_note else "") + (
+            f"{malformed} malformed witness event(s) skipped"
+        )
+
+    if problems:
+        detail = "; ".join(problems) + f" | {chain_note}"
+        if blind_note:
+            detail += f" | {blind_note}"
+        return _result(name, "breach", detail)
+    if badly_blind:
+        return _result(name, "unknown", f"{blind_note} | {chain_note}")
+    detail = (
+        f"{matched} matched, 0 unmatched of {considered} mutating witness event(s) "
+        f"in {reconcile_window_hours:g}h window; {chain_note}"
+    )
+    if blind_note:
+        detail += f" | {blind_note}"
+    return _result(name, "ok", detail)
+
+
+def _replica_witness_events(path: Path) -> list[dict[str, Any]]:
+    """Local witness replica: JSONL (one normalized event per line) or a JSON
+    array of normalized events ``{event_type, repo, actor, ref, sha,
+    created_at}``."""
+    text = path.read_text()
+    stripped = text.lstrip()
+    if stripped.startswith("["):
+        return list(json.loads(stripped))
+    return [json.loads(line) for line in text.splitlines() if line.strip()]
+
+
+def _default_json_capture(cmd: list[str]) -> str:
+    proc = subprocess.run(  # noqa: S603 - operator-configured command
+        cmd, capture_output=True, text=True, timeout=120, check=True
+    )
+    return proc.stdout
+
+
+def _github_witness_events(
+    repo_slug: str, *, capture: Callable[[list[str]], str] = _default_json_capture
+) -> list[dict[str, Any]]:
+    """Interim witness: GitHub REST events API via ``gh api``.
+
+    This is the visible-but-incomplete witness — token/deploy-key/member admin
+    events are NOT exposed here.  The S3 audit-log stream (TET Component 1,
+    operator phase T0) replaces this as the witness root once enabled; this
+    fetcher then becomes the liveness cross-check.
+    """
+    raw = json.loads(capture(["gh", "api", f"repos/{repo_slug}/events?per_page=100"]))
+    events: list[dict[str, Any]] = []
+    for item in raw:
+        etype = item.get("type", "")
+        payload = item.get("payload") or {}
+        base = {
+            "repo": (item.get("repo") or {}).get("name", ""),
+            "actor": (item.get("actor") or {}).get("login", ""),
+            "created_at": item.get("created_at", ""),
+        }
+        if etype == "PushEvent":
+            ref = str(payload.get("ref", ""))
+            events.append(
+                {
+                    "event_type": "push",
+                    "ref": ref.removeprefix("refs/heads/"),
+                    "sha": str(payload.get("head", "")),
+                    **base,
+                }
+            )
+        elif etype == "DeleteEvent" and payload.get("ref_type") == "branch":
+            events.append(
+                {
+                    "event_type": "branch_deletion",
+                    "ref": str(payload.get("ref", "")),
+                    "sha": "",
+                    **base,
+                }
+            )
+        elif etype == "PullRequestEvent" and payload.get("action") == "closed":
+            pr = payload.get("pull_request") or {}
+            if pr.get("merged"):
+                events.append(
+                    {
+                        "event_type": "merge",
+                        "ref": str((pr.get("base") or {}).get("ref", "")),
+                        "sha": str(pr.get("merge_commit_sha", "") or ""),
+                        **base,
+                    }
+                )
+        elif etype == "MemberEvent":
+            events.append(
+                {
+                    "event_type": f"member_{payload.get('action', 'change')}",
+                    "ref": "",
+                    "sha": "",
+                    **base,
+                }
+            )
+    return events
+
+
+# ---------------------------------------------------------------------------
 # Report, exit contract, ledger, notification
 # ---------------------------------------------------------------------------
 
@@ -606,6 +1000,28 @@ def run_checks(args: argparse.Namespace, now: datetime) -> list[CheckResult]:
                         probe_cmd=shlex.split(args.rate_limit_cmd),
                     )
                 )
+            elif name == "trail_reconcile":
+                if args.trail_witness_replica:
+                    replica = Path(args.trail_witness_replica)
+                    fetcher: Callable[[], list[dict[str, Any]]] = (
+                        lambda replica=replica: _replica_witness_events(replica)
+                    )
+                else:
+                    fetcher = lambda slug=args.trail_witness_repo: _github_witness_events(slug)  # noqa: E731
+                results.append(
+                    check_trail_reconcile(
+                        witness_events=fetcher,
+                        chain_path=Path(args.trail_chain),
+                        chain_reader=(
+                            _jsonl_chain_reader if args.trail_chain_format == "jsonl" else None
+                        ),
+                        now=now,
+                        match_window_minutes=args.trail_match_window_mins,
+                        skew_minutes=args.trail_match_skew_mins,
+                        witness_cadence_hours=args.trail_witness_cadence_hours,
+                        reconcile_window_hours=args.trail_window_hours,
+                    )
+                )
         except Exception as exc:  # noqa: BLE001 - a crashed check is a blind spot, not success
             results.append(
                 _result(name, "unknown", f"check crashed: {exc.__class__.__name__}: {exc}")
@@ -660,6 +1076,30 @@ def build_parser() -> argparse.ArgumentParser:
         help="consecutive failed publisher passes before degradation counts as persistent",
     )
     parser.add_argument("--rate-limit-cmd", default="gh api rate_limit")
+    parser.add_argument(
+        "--trail-witness-replica",
+        default=None,
+        help="local witness-replica file (normalized events, JSONL or JSON array); "
+        "when unset, the interim GitHub REST events witness is used. The S3 "
+        "audit-stream witness (TET T0, operator task) wires in here once enabled.",
+    )
+    parser.add_argument("--trail-witness-repo", default="synaptent/aragora")
+    parser.add_argument(
+        "--trail-chain",
+        default=str(repo_root / ".aragora" / "trail" / "intent-chain.jsonl"),
+        help="anchored intent chain (TET Component 2; lane TA's intent_chain module)",
+    )
+    parser.add_argument(
+        "--trail-chain-format",
+        choices=("intent_chain", "jsonl"),
+        default="intent_chain",
+        help="'intent_chain' verifies hashes via aragora.trail.intent_chain; "
+        "'jsonl' is the schema-only fallback reader (reported as unverified)",
+    )
+    parser.add_argument("--trail-match-window-mins", type=float, default=15.0)
+    parser.add_argument("--trail-match-skew-mins", type=float, default=2.0)
+    parser.add_argument("--trail-witness-cadence-hours", type=float, default=6.0)
+    parser.add_argument("--trail-window-hours", type=float, default=24.0)
     parser.add_argument(
         "--ledger",
         default=str(repo_root / ".aragora" / "fleet-sentinel" / "ledger.jsonl"),

--- a/scripts/fleet_sentinel.py
+++ b/scripts/fleet_sentinel.py
@@ -685,13 +685,27 @@ def check_trail_reconcile(
     witness_cadence_hours: float = 6.0,
     blind_factor: float = 4.0,
     reconcile_window_hours: float = 24.0,
+    witness_coverage: str = "full",
 ) -> CheckResult:
     """TET Component 3: diff what HAPPENED (witness) against what was INTENDED
     (anchored intent chain).  Every mutating witness event needs a matching
     pre-anchored intent; unmatched events breach at class severity; a broken
     chain is a critical breach; an unreadable witness or absent chain is
-    ``unknown`` (silence is never success)."""
+    ``unknown`` (silence is never success).
+
+    ``witness_coverage="events_api"`` marks the interim GitHub REST witness,
+    which structurally CANNOT see token/deploy-key/member admin events — the
+    exact May-incident class.  Every report then carries a coverage-gap note
+    so an "ok" can never be mistaken for credential-event coverage before the
+    S3 audit-stream witness (TET T0) is live."""
     name = "trail_reconcile"
+    coverage_note = (
+        "coverage limited: interim events-API witness cannot see "
+        "token/deploy-key/member admin events (May-incident class) — "
+        "S3 audit-stream witness (TET T0) required for full coverage"
+        if witness_coverage == "events_api"
+        else ""
+    )
     try:
         events = list(witness_events())
     except Exception as exc:  # noqa: BLE001 - unreadable witness = we are blind
@@ -791,15 +805,22 @@ def check_trail_reconcile(
         detail = "; ".join(problems) + f" | {chain_note}"
         if blind_note:
             detail += f" | {blind_note}"
+        if coverage_note:
+            detail += f" | {coverage_note}"
         return _result(name, "breach", detail)
     if badly_blind:
-        return _result(name, "unknown", f"{blind_note} | {chain_note}")
+        detail = f"{blind_note} | {chain_note}"
+        if coverage_note:
+            detail += f" | {coverage_note}"
+        return _result(name, "unknown", detail)
     detail = (
         f"{matched} matched, 0 unmatched of {considered} mutating witness event(s) "
         f"in {reconcile_window_hours:g}h window; {chain_note}"
     )
     if blind_note:
         detail += f" | {blind_note}"
+    if coverage_note:
+        detail += f" | {coverage_note}"
     return _result(name, "ok", detail)
 
 
@@ -1006,8 +1027,10 @@ def run_checks(args: argparse.Namespace, now: datetime) -> list[CheckResult]:
                     fetcher: Callable[[], list[dict[str, Any]]] = (
                         lambda replica=replica: _replica_witness_events(replica)
                     )
+                    coverage = "full"
                 else:
                     fetcher = lambda slug=args.trail_witness_repo: _github_witness_events(slug)  # noqa: E731
+                    coverage = "events_api"
                 results.append(
                     check_trail_reconcile(
                         witness_events=fetcher,
@@ -1020,6 +1043,7 @@ def run_checks(args: argparse.Namespace, now: datetime) -> list[CheckResult]:
                         skew_minutes=args.trail_match_skew_mins,
                         witness_cadence_hours=args.trail_witness_cadence_hours,
                         reconcile_window_hours=args.trail_window_hours,
+                        witness_coverage=coverage,
                     )
                 )
         except Exception as exc:  # noqa: BLE001 - a crashed check is a blind spot, not success

--- a/scripts/fleet_sentinel.py
+++ b/scripts/fleet_sentinel.py
@@ -516,16 +516,25 @@ _EVENT_CLASS_KEYS: tuple[tuple[tuple[str, ...], str, str, frozenset[str], bool],
         frozenset({"branch_deletion", "branch_delete", "janitor"}),
         False,
     ),
-    (("push",), "push", "high", frozenset({"push", "publish"}), False),
-    (("merge",), "merge", "high", frozenset({"merge", "settle"}), False),
+    # Intent-type vocabularies include aragora.trail.intent_chain.INTENT_TYPES
+    # (publish_pr/merge_pr/settle_pr — TET phase T1, PR #8251).
+    (("push",), "push", "high", frozenset({"push", "publish", "publish_pr"}), False),
+    (("merge",), "merge", "high", frozenset({"merge", "settle", "merge_pr", "settle_pr"}), False),
 )
 
 # Actor classification for the interim GitHub witness.  Unknown actors match
 # no intent — exactly the May-incident shape (action from an unknown context).
+# Intent actor_class values align with aragora.trail.intent_chain.ACTOR_CLASSES
+# (human, agent-claude, agent-codex, agent-app, daemon-*); legacy bare labels
+# are kept for tolerance.
 KNOWN_AGENT_ACTORS = frozenset({"an0mium"})
 KNOWN_HUMAN_ACTORS = frozenset({"scarmani"})
 HUMAN_ACTOR_CLASSES = frozenset({"scarmani", "human", "operator"})
 AGENT_ACTOR_CLASSES = frozenset({"agent", "automation", "loop", "lane"})
+
+
+def _intent_class_is_agent(record_class: str) -> bool:
+    return record_class in AGENT_ACTOR_CLASSES or record_class.startswith(("agent-", "daemon-"))
 
 
 def classify_witness_actor(actor: str) -> str:
@@ -549,22 +558,37 @@ def classify_witness_event(event_type: str) -> tuple[str, str, frozenset[str], b
     return None
 
 
-def _parse_target(target: str) -> tuple[str, str, str]:
-    """Canonical intent target ``<repo>[@<ref>][#<sha>]`` -> parts."""
-    head, _, sha = target.partition("#")
+def _parse_target(target: Any) -> tuple[str, str, str, str]:
+    """Intent target -> (repo, ref, sha, pr).
+
+    Dict form is the intent_chain contract (``{"repo", "ref"|"branch",
+    "sha", "pr"}`` — e.g. the auto-evidence cycle records
+    ``{"repo": ..., "pr": N}``); the string form ``<repo>[@<ref>][#<sha>]``
+    is kept for hand-written replicas and replay fixtures.
+    """
+    if isinstance(target, dict):
+        return (
+            str(target.get("repo") or "").strip(),
+            str(target.get("ref") or target.get("branch") or "").strip(),
+            str(target.get("sha") or "").strip(),
+            str(target.get("pr") or "").strip(),
+        )
+    head, _, sha = str(target).partition("#")
     repo, _, ref = head.partition("@")
-    return repo.strip(), ref.strip(), sha.strip()
+    return repo.strip(), ref.strip(), sha.strip(), ""
 
 
-def _target_matches(target: str, repo: str, ref: str, sha: str) -> bool:
-    t_repo, t_ref, t_sha = _parse_target(target)
+def _target_matches(target: Any, repo: str, ref: str, sha: str, pr: str) -> bool:
+    t_repo, t_ref, t_sha, t_pr = _parse_target(target)
     if repo and t_repo and t_repo != repo:
         return False
-    if not (ref or sha):
+    if not (ref or sha or pr):
         return True  # repo-scoped event (e.g. credential change)
     if t_ref and ref and t_ref == ref:
         return True
     if t_sha and sha and (sha.startswith(t_sha) or t_sha.startswith(sha)):
+        return True
+    if t_pr and pr and t_pr == pr:
         return True
     return False
 
@@ -584,7 +608,14 @@ def _normalize_verify(verdict: Any) -> tuple[bool, str]:
     if isinstance(verdict, bool):
         return verdict, ""
     if isinstance(verdict, tuple) and verdict:
-        return bool(verdict[0]), str(verdict[1]) if len(verdict) > 1 else ""
+        # aragora.trail.intent_chain.verify_chain returns (ok, first_broken_seq).
+        ok = bool(verdict[0])
+        extra = verdict[1] if len(verdict) > 1 else None
+        if extra is None:
+            return ok, ""
+        if isinstance(extra, int):
+            return ok, f"broken at seq {extra}"
+        return ok, str(extra)
     if isinstance(verdict, dict):
         ok = bool(verdict.get("ok", verdict.get("valid", False)))
         detail = str(verdict.get("detail", verdict.get("error", "")) or "")
@@ -646,10 +677,11 @@ def _match_intent(
         if str(record.get("intent_type", "")).lower() not in allowed_intent_types:
             continue
         if not _target_matches(
-            str(record.get("target", "")),
+            record.get("target", ""),
             str(event.get("repo", "") or ""),
             str(event.get("ref", "") or ""),
             str(event.get("sha", "") or ""),
+            str(event.get("pr", "") or ""),
         ):
             continue
         record_class = str(record.get("actor_class", "")).lower()
@@ -660,7 +692,7 @@ def _match_intent(
             if record_class not in HUMAN_ACTOR_CLASSES:
                 continue
         elif actor_class == "agent":
-            if record_class not in AGENT_ACTOR_CLASSES:
+            if not _intent_class_is_agent(record_class):
                 continue
         else:  # unknown actors match nothing
             continue
@@ -889,6 +921,7 @@ def _github_witness_events(
                         "event_type": "merge",
                         "ref": str((pr.get("base") or {}).get("ref", "")),
                         "sha": str(pr.get("merge_commit_sha", "") or ""),
+                        "pr": str(pr.get("number", "") or ""),
                         **base,
                     }
                 )

--- a/tests/scripts/test_fleet_sentinel.py
+++ b/tests/scripts/test_fleet_sentinel.py
@@ -865,3 +865,431 @@ def test_notify_embedded_placeholder_neutralizes_quote_injection() -> None:
     assert script.count('"') == 4
     assert "\\" not in script
     assert "detail 'x' / end" in script
+
+
+# ---------------------------------------------------------------------------
+# trail_reconcile (TET Component 3 — witness vs anchored-intent reconciliation)
+# ---------------------------------------------------------------------------
+
+T_NOW = sentinel.parse_iso("2026-06-11T12:00:00Z")
+REPO = "synaptent/aragora"
+
+
+def _witness_event(
+    event_type: str,
+    *,
+    actor: str = "an0mium",
+    repo: str = REPO,
+    ref: str = "main",
+    sha: str = "abc1234def",
+    age_minutes: float = 10.0,
+) -> dict[str, Any]:
+    ts = sentinel.parse_iso("2026-06-11T12:00:00Z").timestamp() - age_minutes * 60
+    from datetime import datetime, timezone
+
+    created = datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+    return {
+        "event_type": event_type,
+        "repo": repo,
+        "actor": actor,
+        "ref": ref,
+        "sha": sha,
+        "created_at": created,
+    }
+
+
+def _intent(
+    intent_type: str,
+    *,
+    actor_class: str = "agent",
+    target: str = f"{REPO}@main",
+    age_minutes: float = 12.0,
+    seq: int = 1,
+) -> dict[str, Any]:
+    ts = sentinel.parse_iso("2026-06-11T12:00:00Z").timestamp() - age_minutes * 60
+    from datetime import datetime, timezone
+
+    anchored = datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+    return {
+        "seq": seq,
+        "ts": anchored,
+        "actor_class": actor_class,
+        "intent_type": intent_type,
+        "target": target,
+        "intent_id": f"intent-{seq}",
+        "prev_hash": "0" * 64,
+        "record_hash": "f" * 64,
+    }
+
+
+def _reconcile(
+    events: list[dict[str, Any]],
+    records: list[dict[str, Any]] | None,
+    *,
+    chain_ok: bool = True,
+    chain_detail: str = "",
+    **kwargs: Any,
+) -> dict[str, Any]:
+    def witness() -> list[dict[str, Any]]:
+        return events
+
+    def chain_reader(path: Path) -> tuple[list[dict[str, Any]], bool, str]:
+        if records is None:
+            raise FileNotFoundError(path)
+        return records, chain_ok, chain_detail
+
+    defaults: dict[str, Any] = {
+        "witness_events": witness,
+        "chain_path": Path("/nonexistent/intent-chain.jsonl"),
+        "chain_reader": chain_reader,
+        "now": T_NOW,
+    }
+    defaults.update(kwargs)
+    return sentinel.check_trail_reconcile(**defaults)
+
+
+def test_trail_reconcile_module_absent_is_unknown() -> None:
+    """No chain_reader injected -> lazy import of aragora.trail.intent_chain.
+
+    Until lane TA merges, the module does not exist; the check must degrade
+    honestly to unknown, never ok and never a false breach.
+    """
+    result = sentinel.check_trail_reconcile(
+        witness_events=lambda: [_witness_event("merge")],
+        chain_path=Path("/nonexistent/intent-chain.jsonl"),
+        now=T_NOW,
+    )
+    assert result["check"] == "trail_reconcile"
+    if "intent_chain" in result["detail"] and "not present" in result["detail"]:
+        assert result["status"] == "unknown"
+    else:
+        # Module exists (TA merged): absent chain file is still unknown.
+        assert result["status"] == "unknown"
+
+
+def test_trail_reconcile_chain_not_populated_is_unknown() -> None:
+    result = _reconcile([_witness_event("merge")], records=None)
+    assert result["status"] == "unknown"
+    assert "not yet populated" in result["detail"]
+
+
+def test_trail_reconcile_witness_unreadable_is_unknown() -> None:
+    def broken_witness() -> list[dict[str, Any]]:
+        raise OSError("S3 replica unreachable")
+
+    result = sentinel.check_trail_reconcile(
+        witness_events=broken_witness,
+        chain_path=Path("/nonexistent"),
+        chain_reader=lambda p: ([], True, ""),
+        now=T_NOW,
+    )
+    assert result["status"] == "unknown"
+    assert "witness" in result["detail"].lower()
+
+
+def test_trail_reconcile_tampered_chain_is_critical_breach() -> None:
+    result = _reconcile(
+        [],
+        records=[_intent("merge")],
+        chain_ok=False,
+        chain_detail="hash mismatch at seq 7",
+    )
+    assert result["status"] == "breach"
+    assert "critical" in result["detail"]
+    assert "tampered" in result["detail"]
+    assert "seq 7" in result["detail"]
+
+
+def test_trail_reconcile_matched_merge_is_ok() -> None:
+    result = _reconcile([_witness_event("merge")], records=[_intent("merge")])
+    assert result["status"] == "ok"
+    assert "0 unmatched" in result["detail"]
+    assert "chain ok" in result["detail"]
+
+
+def test_trail_reconcile_unmatched_push_is_high_breach() -> None:
+    result = _reconcile([_witness_event("push")], records=[])
+    assert result["status"] == "breach"
+    assert "high" in result["detail"]
+    assert "push" in result["detail"]
+    assert "an0mium" in result["detail"]  # enumerates the unaccounted event
+
+
+def test_trail_reconcile_intent_type_must_match_event_class() -> None:
+    """A merge intent does not excuse a branch deletion."""
+    result = _reconcile(
+        [_witness_event("branch_deletion", ref="elves/run-x")],
+        records=[_intent("merge", target=f"{REPO}@elves/run-x")],
+    )
+    assert result["status"] == "breach"
+    assert "branch_deletion" in result["detail"]
+
+
+def test_trail_reconcile_target_must_reference_ref_or_sha() -> None:
+    """An intent for another branch does not excuse this push."""
+    result = _reconcile(
+        [_witness_event("push", ref="main", sha="deadbeef99")],
+        records=[_intent("push", target=f"{REPO}@feature/other")],
+    )
+    assert result["status"] == "breach"
+
+
+def test_trail_reconcile_intent_anchored_after_event_not_matched() -> None:
+    """Pre-anchoring contract: an intent recorded AFTER the action (beyond
+    clock-skew grace) cannot retroactively legitimize it."""
+    result = _reconcile(
+        [_witness_event("merge", age_minutes=30.0)],
+        records=[_intent("merge", age_minutes=10.0)],  # 20 min AFTER the event
+    )
+    assert result["status"] == "breach"
+
+
+def test_trail_reconcile_intent_too_old_not_matched() -> None:
+    """An intent anchored far outside the window cannot be replayed forever."""
+    result = _reconcile(
+        [_witness_event("merge", age_minutes=10.0)],
+        records=[_intent("merge", age_minutes=300.0)],
+        match_window_minutes=15.0,
+    )
+    assert result["status"] == "breach"
+
+
+def test_trail_reconcile_credential_event_needs_human_anchor() -> None:
+    """Token/key events have no legitimate agent intent class: an
+    agent-anchored intent does NOT excuse them (spec Component 3)."""
+    result = _reconcile(
+        [_witness_event("token_created", actor="an0mium", ref="", sha="")],
+        records=[_intent("token_created", actor_class="agent", target=REPO)],
+    )
+    assert result["status"] == "breach"
+    assert "critical" in result["detail"]
+
+
+def test_trail_reconcile_credential_event_with_scarmani_anchor_ok() -> None:
+    result = _reconcile(
+        [_witness_event("token_created", actor="scarmani", ref="", sha="")],
+        records=[_intent("token_created", actor_class="scarmani", target=REPO)],
+    )
+    assert result["status"] == "ok"
+
+
+def test_trail_reconcile_unknown_actor_matches_nothing() -> None:
+    result = _reconcile(
+        [_witness_event("merge", actor="attacker-9000")],
+        records=[_intent("merge")],
+    )
+    assert result["status"] == "breach"
+    assert "attacker-9000" in result["detail"]
+
+
+def test_trail_reconcile_non_mutating_events_ignored() -> None:
+    result = _reconcile(
+        [_witness_event("issue_comment"), _witness_event("watch_started")],
+        records=[],
+    )
+    assert result["status"] == "ok"
+
+
+def test_trail_reconcile_events_outside_window_ignored() -> None:
+    """A mutating event older than the reconcile window is not re-litigated
+    (it was already reconciled in earlier cycles).  A fresh non-mutating event
+    keeps the witness demonstrably alive so blind accounting stays quiet."""
+    result = _reconcile(
+        [
+            _witness_event("push", age_minutes=60 * 50),  # ~2 days old
+            _witness_event("issue_comment", age_minutes=5),
+        ],
+        records=[],
+        reconcile_window_hours=24.0,
+    )
+    assert result["status"] == "ok"
+    assert "0 unmatched" in result["detail"]
+
+
+def test_trail_reconcile_mild_witness_silence_visible_but_quiet() -> None:
+    """Newest witness event older than cadence -> blind-period note, still ok."""
+    result = _reconcile(
+        [_witness_event("merge", age_minutes=8 * 60)],
+        records=[_intent("merge", age_minutes=8 * 60 + 2)],
+        witness_cadence_hours=6.0,
+    )
+    assert result["status"] == "ok"
+    assert "blind" in result["detail"].lower()
+
+
+def test_trail_reconcile_badly_exceeded_silence_is_unknown() -> None:
+    """Silence is never success: witness silent for 4x cadence -> unknown."""
+    result = _reconcile(
+        [],
+        records=[],
+        witness_cadence_hours=6.0,
+        reconcile_window_hours=200.0,
+    )
+    assert result["status"] == "unknown"
+    assert "blind" in result["detail"].lower() or "silen" in result["detail"].lower()
+
+
+def test_trail_reconcile_breach_outranks_blind_note() -> None:
+    """Observed breaches must not be masked by concurrent mild silence."""
+    result = _reconcile(
+        [_witness_event("push", age_minutes=7 * 60)],
+        records=[],
+        witness_cadence_hours=6.0,
+    )
+    assert result["status"] == "breach"
+
+
+def test_trail_reconcile_registered_in_all_checks() -> None:
+    assert "trail_reconcile" in sentinel.ALL_CHECKS
+
+
+# ---------------------------------------------------------------------------
+# T5 — incident-replay acceptance (the TET spec's falsifiable exit metric)
+# ---------------------------------------------------------------------------
+
+
+def test_breach_replay_may_incident_unauthorized_credential(tmp_path: Path) -> None:
+    """T5 acceptance: re-enact the May-incident class — a token created and a
+    deploy key added from an unknown actor with NO matching anchored intent
+    must raise a CRITICAL breach within ONE sentinel evaluation.
+
+    This is the falsifiable exit metric from
+    docs/specs/TAMPER_EVIDENT_TRAIL.md ("a simulated unauthorized action
+    raises a critical breach within one sentinel cycle").
+    """
+    incident = [
+        _witness_event("token_created", actor="unknown-ctx-7", ref="", sha="", age_minutes=5),
+        _witness_event("deploy_key_added", actor="unknown-ctx-7", ref="", sha="", age_minutes=4),
+    ]
+    # A normal day's chain exists around the incident — it must not excuse it.
+    records = [_intent("merge", seq=1, age_minutes=20), _intent("push", seq=2, age_minutes=40)]
+    result = _reconcile(incident, records=records)
+    assert result["status"] == "breach"
+    assert "critical" in result["detail"]
+    assert "token_created" in result["detail"]
+    assert "deploy_key_added" in result["detail"]
+    assert "unknown-ctx-7" in result["detail"]
+    # One evaluation is enough to drive the alarm exit code.
+    assert sentinel.exit_code_for([result]) == 1
+
+
+def test_replay_normal_day_thirty_merges_zero_false_alarms() -> None:
+    """T5 acceptance (other half): ~30 merges of normal agent traffic, each
+    with an intent anchored 1-12 minutes before the action, must reconcile
+    clean — zero false alarms after tuning, or the matching rules are wrong.
+    """
+    events: list[dict[str, Any]] = []
+    records: list[dict[str, Any]] = []
+    for i in range(30):
+        event_age = 10.0 + i * 20.0  # spread across the last ~10 hours
+        anchor_lead = 1.0 + (i % 12)  # intent anchored 1-12 min before
+        sha = f"{i:02d}ab{i:02d}cd{i:02d}"
+        ref = "main" if i % 3 else f"elves/run-lane{i}"
+        events.append(
+            _witness_event(
+                "merge" if i % 2 else "push",
+                actor="aragora-automation-fable[bot]" if i % 4 else "an0mium",
+                ref=ref,
+                sha=sha,
+                age_minutes=event_age,
+            )
+        )
+        records.append(
+            _intent(
+                "merge" if i % 2 else "push",
+                seq=i + 1,
+                target=f"{REPO}@{ref}#{sha}",
+                age_minutes=event_age + anchor_lead,
+            )
+        )
+    result = _reconcile(events, records=records)
+    assert result["status"] == "ok", result["detail"]
+    assert "30" in result["detail"]  # reports how much it reconciled
+    assert sentinel.exit_code_for([result]) == 0
+
+
+def test_main_trail_reconcile_wired_end_to_end(tmp_path: Path, capsys: Any) -> None:
+    """main() drives trail_reconcile from a local witness-replica file."""
+    replica = tmp_path / "witness.jsonl"
+    replica.write_text(
+        json.dumps(
+            {
+                "event_type": "token_created",
+                "repo": REPO,
+                "actor": "unknown-ctx-7",
+                "ref": "",
+                "sha": "",
+                "created_at": "2026-06-11T11:55:00+00:00",
+            }
+        )
+        + "\n"
+    )
+    chain = tmp_path / "intent-chain.jsonl"
+    chain.write_text(json.dumps(_intent("merge")) + "\n")
+    code = sentinel.main(
+        [
+            "--json",
+            "--no-ledger",
+            "--now",
+            "2026-06-11T12:00:00Z",
+            "--checks",
+            "trail_reconcile",
+            "--trail-witness-replica",
+            str(replica),
+            "--trail-chain",
+            str(chain),
+        ]
+    )
+    report = json.loads(capsys.readouterr().out)
+    (check,) = report["checks"]
+    assert check["check"] == "trail_reconcile"
+    # The wired path reads the chain via aragora.trail.intent_chain when
+    # available; before lane TA merges it degrades to unknown (exit 2), after
+    # TA merges this replica replay must breach (exit 1). Both are alarm
+    # states — never 0.
+    assert code in (1, 2)
+    assert check["status"] in ("breach", "unknown")
+
+
+def test_main_trail_reconcile_replica_chain_reader_fallback(tmp_path: Path, capsys: Any) -> None:
+    """With --trail-chain-format jsonl the check reads the chain file directly
+    (schema-only, no hash verification) so the replica replay works before
+    lane TA's intent_chain module lands; verification state is reported."""
+    replica = tmp_path / "witness.jsonl"
+    replica.write_text(
+        json.dumps(
+            {
+                "event_type": "token_created",
+                "repo": REPO,
+                "actor": "unknown-ctx-7",
+                "ref": "",
+                "sha": "",
+                "created_at": "2026-06-11T11:55:00+00:00",
+            }
+        )
+        + "\n"
+    )
+    chain = tmp_path / "intent-chain.jsonl"
+    chain.write_text(json.dumps(_intent("merge")) + "\n")
+    code = sentinel.main(
+        [
+            "--json",
+            "--no-ledger",
+            "--now",
+            "2026-06-11T12:00:00Z",
+            "--checks",
+            "trail_reconcile",
+            "--trail-witness-replica",
+            str(replica),
+            "--trail-chain",
+            str(chain),
+            "--trail-chain-format",
+            "jsonl",
+        ]
+    )
+    report = json.loads(capsys.readouterr().out)
+    (check,) = report["checks"]
+    assert code == 1
+    assert check["status"] == "breach"
+    assert "critical" in check["detail"]
+    assert "unverified" in check["detail"]  # honest about skipping hash checks

--- a/tests/scripts/test_fleet_sentinel.py
+++ b/tests/scripts/test_fleet_sentinel.py
@@ -1293,3 +1293,27 @@ def test_main_trail_reconcile_replica_chain_reader_fallback(tmp_path: Path, caps
     assert check["status"] == "breach"
     assert "critical" in check["detail"]
     assert "unverified" in check["detail"]  # honest about skipping hash checks
+
+
+def test_trail_reconcile_events_api_coverage_gap_always_visible() -> None:
+    """Review finding (grok, PR #8250): the interim GitHub events-API witness
+    structurally cannot see token/deploy-key/member admin events — the exact
+    May-incident class.  An 'ok' from that witness must never be mistakable
+    for credential-event coverage: every report carries the coverage note
+    until the S3 audit-stream witness (TET T0) replaces it."""
+    ok = _reconcile(
+        [_witness_event("merge")],
+        records=[_intent("merge")],
+        witness_coverage="events_api",
+    )
+    assert ok["status"] == "ok"
+    assert "coverage limited" in ok["detail"]
+    breach = _reconcile([_witness_event("push")], records=[], witness_coverage="events_api")
+    assert breach["status"] == "breach"
+    assert "coverage limited" in breach["detail"]
+
+
+def test_trail_reconcile_full_coverage_witness_has_no_gap_note() -> None:
+    result = _reconcile([_witness_event("merge")], records=[_intent("merge")])
+    assert result["status"] == "ok"
+    assert "coverage limited" not in result["detail"]

--- a/tests/scripts/test_fleet_sentinel.py
+++ b/tests/scripts/test_fleet_sentinel.py
@@ -1317,3 +1317,84 @@ def test_trail_reconcile_full_coverage_witness_has_no_gap_note() -> None:
     result = _reconcile([_witness_event("merge")], records=[_intent("merge")])
     assert result["status"] == "ok"
     assert "coverage limited" not in result["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Live-module integration: reconcile against a REAL intent chain written by
+# aragora.trail.intent_chain (TET T1, PR #8251) through the default reader.
+# ---------------------------------------------------------------------------
+
+
+def _real_chain(tmp_path: Path) -> tuple[Any, Path]:
+    intent_chain = __import__("pytest").importorskip("aragora.trail.intent_chain")
+    return intent_chain, tmp_path / "intent-chain.jsonl"
+
+
+def test_trail_reconcile_real_chain_settle_intent_matches_merge(tmp_path: Path) -> None:
+    """End-to-end on the production read path: a settle_pr intent recorded by
+    the real chain writer (target {repo, pr}) reconciles a merge witness
+    event carrying that PR number; verify_chain runs for real."""
+    intent_chain, chain = _real_chain(tmp_path)
+    intent_chain.append_intent(
+        chain,
+        actor_class="agent-app",
+        intent_type="settle_pr",
+        target={"repo": REPO, "pr": 8250},
+        now=lambda: "2026-06-11T11:52:00+00:00",
+    )
+    event = _witness_event("merge", ref="main", sha="", age_minutes=5.0)
+    event["pr"] = "8250"
+    result = sentinel.check_trail_reconcile(
+        witness_events=lambda: [event],
+        chain_path=chain,
+        now=T_NOW,
+    )
+    assert result["status"] == "ok", result["detail"]
+    assert "chain ok (1 record(s))" in result["detail"]
+
+
+def test_breach_replay_may_incident_against_real_chain(tmp_path: Path) -> None:
+    """T5 on the production read path: the May-incident credential events find
+    no excuse in a real, hash-valid chain of normal agent intents."""
+    intent_chain, chain = _real_chain(tmp_path)
+    intent_chain.append_intent(
+        chain,
+        actor_class="agent-claude",
+        intent_type="publish_pr",
+        target={"repo": REPO, "ref": "main"},
+        now=lambda: "2026-06-11T11:40:00+00:00",
+    )
+    incident = _witness_event("token_created", actor="unknown-ctx-7", ref="", sha="")
+    result = sentinel.check_trail_reconcile(
+        witness_events=lambda: [incident],
+        chain_path=chain,
+        now=T_NOW,
+    )
+    assert result["status"] == "breach"
+    assert "critical" in result["detail"]
+    assert "token_created" in result["detail"]
+
+
+def test_trail_reconcile_real_chain_tamper_detected(tmp_path: Path) -> None:
+    """A record edited after the fact breaks verify_chain -> critical breach."""
+    intent_chain, chain = _real_chain(tmp_path)
+    for i in range(2):
+        intent_chain.append_intent(
+            chain,
+            actor_class="agent-claude",
+            intent_type="merge_pr",
+            target={"repo": REPO, "ref": "main"},
+            now=lambda i=i: f"2026-06-11T11:4{i}:00+00:00",
+        )
+    lines = chain.read_text().splitlines()
+    doctored = json.loads(lines[0])
+    doctored["target"] = {"repo": "attacker/elsewhere"}
+    chain.write_text("\n".join([json.dumps(doctored), *lines[1:]]) + "\n")
+    result = sentinel.check_trail_reconcile(
+        witness_events=lambda: [_witness_event("issue_comment")],
+        chain_path=chain,
+        now=T_NOW,
+    )
+    assert result["status"] == "breach"
+    assert "tampered" in result["detail"]
+    assert "seq 0" in result["detail"]


### PR DESCRIPTION
## Summary

TET build phases **T3 + T5** per `docs/specs/TAMPER_EVIDENT_TRAIL.md` (Component 3 — Reconciliation, the alarm) and Plan v2 Pillar 6 (fleet mortality signals).

**Tier: 2** (merge-on-green authorized; lane TB of run-20260610).

### T3 — `trail_reconcile` sentinel check (`scripts/fleet_sentinel.py`)
- Diffs **what happened** (witness events: interim GitHub REST events fetcher via `gh api`, or a local witness-replica file via `--trail-witness-replica`; the S3 audit-log stream witness wires in once operator phase T0 completes) against **what was intended** (the anchored intent chain).
- Every mutating witness event class {push, merge, branch_deletion, workflow change, member change, token/key/app change} requires a matching anchored intent: repo + ref/sha + compatible actor class + anchored **before** the event (15 min window, 2 min clock-skew grace — post-hoc anchoring cannot legitimize an action).
- Severity per spec: token/key/member/workflow = **critical** (credential/member events have no agent intent class — only scarmani-anchored intents match); push/merge/branch = **high**.
- Intent-chain integrity: `verify_chain` broken → critical breach naming the tamper point.
- Blind-period accounting: witness silence past cadence → visible-but-quiet note; past 4× cadence (or no events at all) → `unknown` (silence is never success; unknown outranks breach in the exit contract).
- `aragora.trail.intent_chain` (lane TA, phase T1) is imported **lazily** — until TA merges, the check degrades honestly to `unknown: module not present`, and a schema-only `--trail-chain-format jsonl` fallback reader (reported as *unverified*) keeps replay testing possible.
- Detail enumerates every unmatched event and the chain-verify result.

### T5 — incident-replay acceptance (permanent regression guard)
- `test_breach_replay_may_incident_unauthorized_credential`: re-enacts the May-incident class — `token_created` + `deploy_key_added` from an unknown actor with NO anchored intent → **critical breach in one evaluation** (the spec's falsifiable exit metric).
- `test_replay_normal_day_thirty_merges_zero_false_alarms`: ~30 merges/pushes of normal agent traffic, each with an intent anchored 1–12 min prior → reconciles clean, zero false alarms.

### Docs
- `docs/runbooks/TRAIL_RECONCILE.md`: what a breach means, severity tiers, the pre-anchored-intent contract, operator response to a critical breach (rotate creds, freeze settlement, investigate via the S3 witness).

## Validation
- 85/85 tests in `tests/scripts/test_fleet_sentinel.py` (22 new), ruff clean.
- Live dry-run output in PR comments (expected `unknown` until TA's chain populates — honest degradation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)