### PR TITLE
feat(trail): intent hash-chain + external anchor (TET T1/T2)

### DIFF
--- a/aragora/trail/__init__.py
+++ b/aragora/trail/__init__.py
@@ -1,0 +1,40 @@
+"""Tamper-evident trail (TET) — intent anchoring primitives.
+
+Implements Component 2 of ``docs/specs/TAMPER_EVIDENT_TRAIL.md``: an
+append-only, hash-chained ledger of *intent records* for repo-mutating agent
+actions, plus helpers to read, verify, and anchor the chain head outside the
+machine that wrote it.
+
+This package is the Plan v2 Pillar 5 seed (Open Receipt Standard): the chain
+shares its canonicalization with the Open Decision Receipt profile (RFC 8785
+JCS via :mod:`aragora.gauntlet.odr_export`), so an externally anchored chain
+head commits to byte-stable record content.
+"""
+
+from aragora.trail.intent_chain import (
+    ACTOR_CLASSES,
+    GENESIS_PREV_HASH,
+    INTENT_TYPES,
+    ChainError,
+    append_intent,
+    chain_head_hash,
+    compute_record_hash,
+    default_chain_path,
+    read_records,
+    record_intent,
+    verify_chain,
+)
+
+__all__ = [
+    "ACTOR_CLASSES",
+    "GENESIS_PREV_HASH",
+    "INTENT_TYPES",
+    "ChainError",
+    "append_intent",
+    "chain_head_hash",
+    "compute_record_hash",
+    "default_chain_path",
+    "read_records",
+    "record_intent",
+    "verify_chain",
+]

--- a/aragora/trail/intent_chain.py
+++ b/aragora/trail/intent_chain.py
@@ -203,6 +203,13 @@ def append_intent(
     with a single ``write`` on an ``O_APPEND`` descriptor and fsync'd; prior
     lines are never modified.
 
+    No stale-lock recovery is needed: ``flock`` is a kernel advisory lock
+    released automatically when the holder's descriptor closes (including
+    process crash), unlike ``O_EXCL`` lockfile schemes. A waiting appender
+    blocks until the lock is free rather than timing out — appends are
+    sub-millisecond, and a daemon that must not block can wrap the call
+    (``record_intent`` already isolates callers from failures).
+
     Returns:
         The appended record, including ``record_hash``.
     """

--- a/aragora/trail/intent_chain.py
+++ b/aragora/trail/intent_chain.py
@@ -1,0 +1,315 @@
+"""Append-only hash-chained intent ledger (TET phase T1).
+
+Spec: ``docs/specs/TAMPER_EVIDENT_TRAIL.md`` Component 2 ("Intent anchoring").
+
+Each repo-mutating agent action records an *intent* before acting. Records
+are appended to a local JSONL working copy (default
+``.aragora/trail/intent-chain.jsonl``) and chained: every record carries
+``prev_hash`` (the previous record's ``record_hash``; 64 zeros for genesis)
+and ``record_hash`` (SHA-256 over the RFC 8785 / JCS canonical JSON of all
+other fields). Canonicalization is shared with the Open Decision Receipt
+profile (``docs/specs/OPEN_DECISION_RECEIPT.md`` §5) via
+:func:`aragora.gauntlet.odr_export.jcs_canonicalize`, so equal record content
+hashes identically regardless of key order or unicode representation choices
+at the call site.
+
+Threat model honesty: an adversary with this machine's credentials can append
+forged intents or truncate the local file. The chain alone only proves
+*internal* consistency; tamper-evidence comes from anchoring the head hash on
+infrastructure the laptop cannot rewrite (``scripts/anchor_intent_chain.py``,
+TET phase T2). Rewriting any anchored prefix changes every subsequent hash
+and breaks against the anchor.
+
+Concurrency: appends take an exclusive ``flock`` on a sidecar lock file for
+the read-tail-then-append critical section, then write the record as a single
+``write`` on an ``O_APPEND`` descriptor. Prior lines are never rewritten.
+
+Clock: timestamps flow through an injectable ``now`` callable (defaulting to
+the module-level :func:`utc_now_iso`) so importable code paths never hardcode
+wall-clock reads and tests stay deterministic.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import uuid
+from collections.abc import Callable
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from aragora.gauntlet.odr_export import jcs_canonicalize
+
+__all__ = [
+    "ACTOR_CLASSES",
+    "GENESIS_PREV_HASH",
+    "INTENT_TYPES",
+    "ChainError",
+    "append_intent",
+    "chain_head_hash",
+    "compute_record_hash",
+    "default_chain_path",
+    "read_records",
+    "record_intent",
+    "verify_chain",
+    "utc_now_iso",
+]
+
+logger = logging.getLogger(__name__)
+
+GENESIS_PREV_HASH = "0" * 64
+
+ACTOR_CLASSES = frozenset(
+    {
+        "human",
+        "agent-claude",
+        "agent-codex",
+        "agent-app",
+        "daemon-publisher",
+        "daemon-arbiter",
+        "daemon-boss",
+    }
+)
+
+INTENT_TYPES = frozenset(
+    {
+        "publish_pr",
+        "merge_pr",
+        "settle_pr",
+        "close_pr",
+        "branch_delete",
+        "issue_create",
+    }
+)
+
+_HASHED_FIELDS = (
+    "seq",
+    "ts",
+    "actor_class",
+    "intent_type",
+    "target",
+    "intent_id",
+    "payload",
+    "prev_hash",
+)
+
+_ENV_FLAG = "ARAGORA_TRAIL"
+_ENV_CHAIN_PATH = "ARAGORA_TRAIL_CHAIN"
+
+
+class ChainError(ValueError):
+    """A record or chain violates the intent-chain contract."""
+
+
+def utc_now_iso() -> str:
+    """Module-level clock: current UTC time as an ISO-8601 string."""
+    return datetime.now(tz=UTC).isoformat()
+
+
+def default_chain_path() -> Path:
+    """Default working-copy location, overridable via ``ARAGORA_TRAIL_CHAIN``."""
+    override = os.environ.get(_ENV_CHAIN_PATH, "").strip()
+    if override:
+        return Path(override)
+    return Path(".aragora") / "trail" / "intent-chain.jsonl"
+
+
+def compute_record_hash(record: dict[str, Any]) -> str:
+    """SHA-256 hex digest over the JCS canonical bytes of the hashed fields.
+
+    Every field except ``record_hash`` participates (including ``prev_hash``),
+    in a fixed field set — extra keys are rejected rather than silently
+    dropped, so a record cannot carry unhashed content.
+    """
+    extras = set(record) - set(_HASHED_FIELDS) - {"record_hash"}
+    if extras:
+        raise ChainError(f"unhashable extra fields: {sorted(extras)}")
+    payload = {field: record.get(field) for field in _HASHED_FIELDS}
+    return hashlib.sha256(jcs_canonicalize(payload)).hexdigest()
+
+
+def _validate_intent(actor_class: str, intent_type: str, target: dict[str, Any]) -> None:
+    if actor_class not in ACTOR_CLASSES:
+        raise ChainError(
+            f"unknown actor_class {actor_class!r}; expected one of {sorted(ACTOR_CLASSES)}"
+        )
+    if intent_type not in INTENT_TYPES:
+        raise ChainError(
+            f"unknown intent_type {intent_type!r}; expected one of {sorted(INTENT_TYPES)}"
+        )
+    if not isinstance(target, dict) or not str(target.get("repo") or "").strip():
+        raise ChainError("target must be a dict with a non-empty 'repo'")
+
+
+def read_records(path: str | Path) -> list[dict[str, Any]]:
+    """All records in file order; missing or empty file yields ``[]``.
+
+    Raises:
+        ChainError: when a line is not a JSON object (a corrupt ledger must
+            never be silently truncated to its parseable prefix).
+    """
+    file_path = Path(path)
+    if not file_path.exists():
+        return []
+    records: list[dict[str, Any]] = []
+    with file_path.open("r", encoding="utf-8") as fh:
+        for line_number, line in enumerate(fh, start=1):
+            text = line.strip()
+            if not text:
+                continue
+            try:
+                record = json.loads(text)
+            except json.JSONDecodeError as exc:
+                raise ChainError(f"line {line_number} is not valid JSON: {exc}") from exc
+            if not isinstance(record, dict):
+                raise ChainError(f"line {line_number} is not a JSON object")
+            records.append(record)
+    return records
+
+
+def _tail_state(records: list[dict[str, Any]]) -> tuple[int, str]:
+    """Next sequence number and the prev_hash the next record must carry."""
+    if not records:
+        return 0, GENESIS_PREV_HASH
+    last = records[-1]
+    try:
+        seq = int(last["seq"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ChainError("tail record has no valid seq") from exc
+    last_hash = str(last.get("record_hash") or "")
+    if len(last_hash) != 64:
+        raise ChainError("tail record has no valid record_hash")
+    return seq + 1, last_hash
+
+
+def append_intent(
+    path: str | Path,
+    *,
+    actor_class: str,
+    intent_type: str,
+    target: dict[str, Any],
+    payload: dict[str, Any] | None = None,
+    intent_id: str | None = None,
+    now: Callable[[], str] | None = None,
+) -> dict[str, Any]:
+    """Append one intent record, extending the hash chain atomically.
+
+    The whole read-tail-then-append section runs under an exclusive ``flock``
+    on ``<chain>.lock``, so concurrent appenders serialize and each record's
+    ``seq``/``prev_hash`` reflect the true tail. The record line is written
+    with a single ``write`` on an ``O_APPEND`` descriptor and fsync'd; prior
+    lines are never modified.
+
+    Returns:
+        The appended record, including ``record_hash``.
+    """
+    _validate_intent(actor_class, intent_type, target)
+    clock = now if now is not None else utc_now_iso
+    file_path = Path(path)
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = file_path.with_name(file_path.name + ".lock")
+
+    import fcntl  # POSIX-only by design; the trail runs on the operator fleet
+
+    lock_fd = os.open(lock_path, os.O_CREAT | os.O_WRONLY, 0o644)
+    try:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        seq, prev_hash = _tail_state(read_records(file_path))
+        record: dict[str, Any] = {
+            "seq": seq,
+            "ts": str(clock()),
+            "actor_class": actor_class,
+            "intent_type": intent_type,
+            "target": target,
+            "intent_id": intent_id or str(uuid.uuid4()),
+            "payload": payload or {},
+            "prev_hash": prev_hash,
+        }
+        record["record_hash"] = compute_record_hash(record)
+        line = json.dumps(record, ensure_ascii=False, separators=(",", ":")) + "\n"
+        data_fd = os.open(file_path, os.O_CREAT | os.O_WRONLY | os.O_APPEND, 0o644)
+        try:
+            os.write(data_fd, line.encode("utf-8"))
+            os.fsync(data_fd)
+        finally:
+            os.close(data_fd)
+        return record
+    finally:
+        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        os.close(lock_fd)
+
+
+def verify_chain(path: str | Path) -> tuple[bool, int | None]:
+    """Verify hash-chain integrity; return ``(ok, first_broken_seq)``.
+
+    Checks, per record: ``seq`` is a contiguous 0-based sequence (duplicates
+    and gaps both break), ``prev_hash`` equals the previous record's
+    ``record_hash`` (genesis: 64 zeros), and ``record_hash`` recomputes from
+    the record content. ``first_broken_seq`` is the claimed ``seq`` of the
+    first failing record (falling back to its position when ``seq`` itself is
+    unreadable). An empty or missing chain verifies trivially.
+    """
+    try:
+        records = read_records(path)
+    except ChainError:
+        return False, 0
+    expected_prev = GENESIS_PREV_HASH
+    for position, record in enumerate(records):
+        try:
+            seq = int(record["seq"])
+        except (KeyError, TypeError, ValueError):
+            return False, position
+        if seq != position:
+            return False, seq
+        try:
+            recomputed = compute_record_hash(record)
+        except ChainError:
+            return False, seq
+        if record.get("prev_hash") != expected_prev or record.get("record_hash") != recomputed:
+            return False, seq
+        expected_prev = recomputed
+    return True, None
+
+
+def chain_head_hash(path: str | Path) -> str | None:
+    """``record_hash`` of the last record, or ``None`` for an empty chain."""
+    records = read_records(path)
+    if not records:
+        return None
+    head = str(records[-1].get("record_hash") or "")
+    return head or None
+
+
+def record_intent(
+    *,
+    actor_class: str,
+    intent_type: str,
+    target: dict[str, Any],
+    payload: dict[str, Any] | None = None,
+    path: str | Path | None = None,
+    env: dict[str, str] | None = None,
+) -> dict[str, Any] | None:
+    """Best-effort intent recording for daemon/script call sites.
+
+    Off unless ``ARAGORA_TRAIL=1`` (the TET contract rolls out call-site by
+    call-site; default must not change daemon behavior). Never raises: a
+    failed trail write logs a warning and returns ``None`` — the trail is a
+    detection layer, not an availability dependency for the action itself.
+    """
+    environ = os.environ if env is None else env
+    if str(environ.get(_ENV_FLAG) or "").strip() != "1":
+        return None
+    try:
+        return append_intent(
+            path if path is not None else default_chain_path(),
+            actor_class=actor_class,
+            intent_type=intent_type,
+            target=target,
+            payload=payload,
+        )
+    except (ChainError, OSError) as exc:
+        logger.warning("trail intent record failed (non-fatal): %s", exc)
+        return None

--- a/scripts/anchor_intent_chain.py
+++ b/scripts/anchor_intent_chain.py
@@ -192,7 +192,6 @@ def run_anchor(
     if head_hash is None:  # unreachable after verify, kept fail-closed
         return EXIT_FAILURE
 
-    anchors_used = 0
     try:
         sha = resolve_main_head(repo, run_gh)
     except RuntimeError as exc:
@@ -210,24 +209,31 @@ def run_anchor(
     }
     log(json.dumps(plan))
 
+    # Mutation budget: a single sequential pass, decremented before each
+    # external write. This is a per-invocation cap (the singleton-cadence
+    # caller owns cross-invocation bounding); there is no shared state to
+    # race — one process, one pass, no loops.
+    anchors_remaining = max_anchors
+
     if apply:
-        if anchors_used >= max_anchors:
+        if anchors_remaining <= 0:
             log(json.dumps({"result": "fail-closed", "reason": "max-anchors exhausted"}))
             return EXIT_FAILURE
+        anchors_remaining -= 1
         rc, out = run_gh(status_args)
-        anchors_used += 1
         if rc != 0:
             log(json.dumps({"result": "fail-closed", "reason": f"status post failed: {out[:200]}"}))
             return EXIT_FAILURE
         log(json.dumps({"result": "anchored", "seq": seq, "head": head_hash[:12]}))
 
     if rekor:
-        if apply and anchors_used >= max_anchors:
+        if apply and anchors_remaining <= 0:
             log(json.dumps({"rekor": "skipped", "reason": "max-anchors exhausted"}))
-        elif not submit_rekor(head_hash, apply=apply, log=log):
-            return EXIT_FAILURE
-        elif apply:
-            anchors_used += 1
+        else:
+            if apply:
+                anchors_remaining -= 1
+            if not submit_rekor(head_hash, apply=apply, log=log):
+                return EXIT_FAILURE
 
     return EXIT_OK
 

--- a/scripts/anchor_intent_chain.py
+++ b/scripts/anchor_intent_chain.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Anchor the intent-chain head hash outside the laptop (TET phase T2).
+
+Spec: ``docs/specs/TAMPER_EVIDENT_TRAIL.md`` Component 2, step 2 ("External
+anchor"). The local chain (``aragora/trail/intent_chain.py``) is only
+internally consistent; this script periodically commits its head hash to
+infrastructure the writing machine cannot rewrite, so any later rewrite of an
+anchored prefix is detectable by reconciliation (phase T3).
+
+Primary anchor: a GitHub **commit status** on ``origin/main`` HEAD under the
+dedicated context ``aragora/trail-anchor`` with description
+``trail-anchor seq=<N> head=<hash12>``. Commit statuses are server-side
+timestamped and themselves witnessed by the Enterprise audit stream (the
+witness then witnesses the anchor). Token resolution prefers the GitHub App
+installation path (``aragora.swarm.github_app_auth.github_cli_env``) and
+falls back to ambient ``gh`` auth.
+
+Optional anchor: ``--rekor`` additionally submits the head hash to the
+Sigstore Rekor public transparency log when a ``rekor-cli`` or ``cosign``
+binary is present — and degrades SILENTLY to commit-status-only when neither
+is installed (noted in output; no hard dependency, per spec).
+
+Safety model (mirrors the run's other bounded scripts):
+
+- Dry-run by default; ``--apply`` gates every network mutation.
+- ``--max-anchors`` caps mutations per invocation (default 2: one status +
+  one optional rekor entry).
+- Fail-closed: a chain that fails ``verify_chain`` is NEVER anchored (an
+  anchor must only ever attest a valid chain head); exit 1 on any failure.
+- Empty chain is a clean no-op (exit 0): there is nothing to attest.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Callable
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:  # direct script invocation
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from aragora.trail.intent_chain import (  # noqa: E402
+    chain_head_hash,
+    default_chain_path,
+    read_records,
+    verify_chain,
+)
+
+DEFAULT_REPO = "synaptent/aragora"
+ANCHOR_CONTEXT = "aragora/trail-anchor"
+GH_TIMEOUT_SECONDS = 60
+REKOR_TIMEOUT_SECONDS = 120
+
+EXIT_OK = 0
+EXIT_FAILURE = 1
+
+
+def _gh_env() -> dict[str, str] | None:
+    """Prefer the App-installation token env; ``None`` means ambient auth."""
+    try:
+        from aragora.swarm.github_app_auth import github_cli_env
+
+        return github_cli_env()
+    except Exception:  # noqa: BLE001 - any auth-path failure falls back to ambient gh
+        return None
+
+
+def default_run_gh(args: list[str]) -> tuple[int, str]:
+    """Run ``gh`` with App-token env when available; return (rc, stdout)."""
+    try:
+        proc = subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            timeout=GH_TIMEOUT_SECONDS,
+            env=_gh_env(),
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return 1, f"gh invocation failed: {exc}"
+    out = proc.stdout if proc.returncode == 0 else (proc.stderr or proc.stdout)
+    return proc.returncode, out.strip()
+
+
+def resolve_main_head(repo: str, run_gh: Callable[[list[str]], tuple[int, str]]) -> str:
+    """SHA of the repo's main branch head, resolved server-side via the API."""
+    rc, out = run_gh(["api", f"repos/{repo}/commits/main", "--jq", ".sha"])
+    sha = out.strip().splitlines()[-1].strip() if out.strip() else ""
+    if rc != 0 or len(sha) != 40:
+        raise RuntimeError(f"could not resolve {repo} main head: {out[:200]}")
+    return sha
+
+
+def build_status_args(repo: str, sha: str, seq: int, head_hash: str) -> list[str]:
+    """``gh api`` argv that posts the anchor commit status (server-timestamped)."""
+    return [
+        "api",
+        "--method",
+        "POST",
+        f"repos/{repo}/statuses/{sha}",
+        "-f",
+        "state=success",
+        "-f",
+        f"context={ANCHOR_CONTEXT}",
+        "-f",
+        f"description=trail-anchor seq={seq} head={head_hash[:12]}",
+    ]
+
+
+def find_rekor_backend() -> list[str] | None:
+    """Argv prefix for an available Rekor uploader, or ``None``."""
+    if shutil.which("rekor-cli"):
+        return ["rekor-cli", "upload", "--artifact"]
+    if shutil.which("cosign"):
+        return ["cosign", "upload-blob"]  # placeholder; cosign needs a registry ref
+    return None
+
+
+def submit_rekor(head_hash: str, *, apply: bool, log: Callable[[str], None]) -> bool:
+    """Best-effort Rekor anchor; ``False`` only on an *attempted* failure.
+
+    Absence of any Rekor-capable binary is a SILENT degrade (spec): the run
+    still succeeds on the commit-status anchor alone, with a note in output.
+    """
+    backend = find_rekor_backend()
+    if backend is None or backend[0] == "cosign":
+        # cosign's blob upload targets an OCI registry, not Rekor directly —
+        # treat it as unavailable rather than half-anchor somewhere else.
+        log(json.dumps({"rekor": "unavailable", "note": "commit-status anchor only"}))
+        return True
+    if not apply:
+        log(json.dumps({"rekor": "dry-run", "cmd": [*backend, "<head-hash-artifact>"]}))
+        return True
+    with tempfile.NamedTemporaryFile("w", suffix=".trail-head", delete=False) as fh:
+        fh.write(head_hash + "\n")
+        artifact = fh.name
+    try:
+        proc = subprocess.run(
+            [*backend, artifact],
+            capture_output=True,
+            text=True,
+            timeout=REKOR_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        log(json.dumps({"rekor": "failed", "error": str(exc)[:200]}))
+        return False
+    finally:
+        Path(artifact).unlink(missing_ok=True)
+    if proc.returncode != 0:
+        log(json.dumps({"rekor": "failed", "error": (proc.stderr or proc.stdout)[:200]}))
+        return False
+    log(json.dumps({"rekor": "anchored", "head": head_hash[:12]}))
+    return True
+
+
+def run_anchor(
+    *,
+    chain_path: Path,
+    repo: str,
+    apply: bool,
+    rekor: bool,
+    max_anchors: int,
+    run_gh: Callable[[list[str]], tuple[int, str]],
+    log: Callable[[str], None] = print,
+) -> int:
+    """One bounded anchor pass. Returns a process exit code."""
+    records = read_records(chain_path)
+    if not records:
+        log(json.dumps({"result": "no-op", "reason": "empty chain", "chain": str(chain_path)}))
+        return EXIT_OK
+
+    ok, broken_seq = verify_chain(chain_path)
+    if not ok:
+        log(
+            json.dumps(
+                {
+                    "result": "fail-closed",
+                    "reason": f"chain verification failed at seq={broken_seq}",
+                    "chain": str(chain_path),
+                }
+            )
+        )
+        return EXIT_FAILURE
+
+    head_hash = chain_head_hash(chain_path)
+    seq = int(records[-1]["seq"])
+    if head_hash is None:  # unreachable after verify, kept fail-closed
+        return EXIT_FAILURE
+
+    anchors_used = 0
+    try:
+        sha = resolve_main_head(repo, run_gh)
+    except RuntimeError as exc:
+        log(json.dumps({"result": "fail-closed", "reason": str(exc)}))
+        return EXIT_FAILURE
+
+    status_args = build_status_args(repo, sha, seq, head_hash)
+    plan = {
+        "mode": "apply" if apply else "dry-run",
+        "chain": str(chain_path),
+        "seq": seq,
+        "head": head_hash,
+        "anchor_target": {"repo": repo, "sha": sha, "context": ANCHOR_CONTEXT},
+        "gh_args": status_args,
+    }
+    log(json.dumps(plan))
+
+    if apply:
+        if anchors_used >= max_anchors:
+            log(json.dumps({"result": "fail-closed", "reason": "max-anchors exhausted"}))
+            return EXIT_FAILURE
+        rc, out = run_gh(status_args)
+        anchors_used += 1
+        if rc != 0:
+            log(json.dumps({"result": "fail-closed", "reason": f"status post failed: {out[:200]}"}))
+            return EXIT_FAILURE
+        log(json.dumps({"result": "anchored", "seq": seq, "head": head_hash[:12]}))
+
+    if rekor:
+        if apply and anchors_used >= max_anchors:
+            log(json.dumps({"rekor": "skipped", "reason": "max-anchors exhausted"}))
+        elif not submit_rekor(head_hash, apply=apply, log=log):
+            return EXIT_FAILURE
+        elif apply:
+            anchors_used += 1
+
+    return EXIT_OK
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--chain",
+        default=str(default_chain_path()),
+        help="Path to the intent-chain JSONL working copy",
+    )
+    parser.add_argument("--repo", default=DEFAULT_REPO, help="GitHub repo owner/name")
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Post the anchor (default: dry-run plan only — nothing leaves the machine)",
+    )
+    parser.add_argument(
+        "--rekor",
+        action="store_true",
+        help="Additionally anchor to Sigstore Rekor when a rekor-cli binary exists "
+        "(silently degrades to commit-status-only otherwise)",
+    )
+    parser.add_argument(
+        "--max-anchors",
+        type=int,
+        default=2,
+        help="Maximum external mutations per invocation (default: 2)",
+    )
+    args = parser.parse_args(argv)
+    try:
+        return run_anchor(
+            chain_path=Path(args.chain),
+            repo=args.repo,
+            apply=args.apply,
+            rekor=args.rekor,
+            max_anchors=max(0, args.max_anchors),
+            run_gh=default_run_gh,
+        )
+    except Exception as exc:  # noqa: BLE001 - top-level fail-closed boundary
+        print(json.dumps({"result": "fail-closed", "reason": str(exc)[:300]}))
+        return EXIT_FAILURE
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/auto_evidence_cycle.py
+++ b/scripts/auto_evidence_cycle.py
@@ -395,6 +395,12 @@ def default_record_trail(repo: str, pr: int, posted_families: list[str]) -> None
     lands on the intent chain as an ``agent-app``/``settle_pr`` intent.
     ``record_intent`` is a no-op unless ``ARAGORA_TRAIL=1`` and never raises;
     the lazy import keeps this wiring non-fatal everywhere.
+
+    Hook contract: ``run_cycle`` deals in ``(pr, posted_families)`` only —
+    ``main()`` binds ``repo`` into the injected closure
+    (``lambda pr, posted: default_record_trail(args.repo, pr, posted)``), the
+    same partial-application pattern every other ``run_cycle`` boundary here
+    uses (``run_collect``, ``fetch_packet``). ``repo`` is not dropped.
     """
     try:
         from aragora.trail import record_intent

--- a/scripts/auto_evidence_cycle.py
+++ b/scripts/auto_evidence_cycle.py
@@ -387,6 +387,27 @@ def default_run_dogfood(
     }
 
 
+def default_record_trail(repo: str, pr: int, posted_families: list[str]) -> None:
+    """Record a tamper-evident-trail intent for posted quorum evidence.
+
+    TET T1 example call site (docs/specs/TAMPER_EVIDENT_TRAIL.md Component 2,
+    step 3): evidence posting is a settlement-advancing repo mutation, so it
+    lands on the intent chain as an ``agent-app``/``settle_pr`` intent.
+    ``record_intent`` is a no-op unless ``ARAGORA_TRAIL=1`` and never raises;
+    the lazy import keeps this wiring non-fatal everywhere.
+    """
+    try:
+        from aragora.trail import record_intent
+    except ImportError:
+        return
+    record_intent(
+        actor_class="agent-app",
+        intent_type="settle_pr",
+        target={"repo": repo, "pr": pr},
+        payload={"action": "post_quorum_evidence", "posted_families": list(posted_families)},
+    )
+
+
 def default_run_reconciler(repo: str) -> int:
     script = os.path.join(os.path.dirname(os.path.abspath(__file__)), "quorum_rerun_reconciler.py")
     try:
@@ -456,6 +477,7 @@ def run_cycle(
     fetch_packet: Callable[[int], dict[str, Any]],
     run_collect: Callable[[int, bool], dict[str, Any]],
     run_reconciler: Callable[[], int],
+    record_trail: Callable[[int, list[str]], None] | None = None,
     apply: bool,
     max_prs: int,
     max_scan: int,
@@ -559,6 +581,8 @@ def run_cycle(
         ok = bool(result.get("ok")) and len(posted) >= REQUIRED_FAMILIES
         if ok:
             summary["posted_prs"].append(item["pr"])
+            if record_trail is not None:
+                record_trail(item["pr"], posted)
             identical_errors = 0
             last_error = None
             log(json.dumps({"pr": item["pr"], "posted_families": posted, "result": "posted"}))
@@ -723,6 +747,7 @@ def main(argv: list[str] | None = None) -> int:
             fetch_packet=lambda pr: default_fetch_packet(args.repo, pr),
             run_collect=lambda pr, apply: default_run_collect(args.repo, families, pr, apply),
             run_reconciler=lambda: default_run_reconciler(args.repo),
+            record_trail=lambda pr, posted: default_record_trail(args.repo, pr, posted),
             run_dogfood=run_dogfood,
             max_dogfood=max(0, args.max_dogfood),
             apply=args.apply,

--- a/tests/trail/test_anchor_script.py
+++ b/tests/trail/test_anchor_script.py
@@ -1,0 +1,205 @@
+"""Tests for ``scripts/anchor_intent_chain.py`` (TET phase T2 external anchor).
+
+All network boundaries (gh runner, rekor binary discovery) are injected or
+monkeypatched; no test touches the network.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from aragora.trail.intent_chain import append_intent
+
+
+def _load_module() -> Any:
+    here = Path(__file__).resolve()
+    script_path = here.parents[2] / "scripts" / "anchor_intent_chain.py"
+    spec = importlib.util.spec_from_file_location("anchor_intent_chain_under_test", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load spec for {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+anchor = _load_module()
+
+MAIN_SHA = "a" * 40
+TARGET = {"repo": "synaptent/aragora", "pr": 99}
+
+
+def _chain_with_records(tmp_path: Path, n: int = 3) -> Path:
+    chain = tmp_path / "chain.jsonl"
+    for i in range(n):
+        append_intent(
+            chain,
+            actor_class="agent-claude",
+            intent_type="publish_pr",
+            target=TARGET,
+            payload={"n": i},
+            now=lambda: "2026-06-11T22:00:00+00:00",
+        )
+    return chain
+
+
+class FakeGh:
+    """Scripted gh runner recording every invocation."""
+
+    def __init__(self, head_sha: str = MAIN_SHA, post_rc: int = 0) -> None:
+        self.calls: list[list[str]] = []
+        self.head_sha = head_sha
+        self.post_rc = post_rc
+
+    def __call__(self, args: list[str]) -> tuple[int, str]:
+        self.calls.append(args)
+        if "--method" not in args:  # the head-resolution GET
+            return 0, self.head_sha
+        return self.post_rc, "" if self.post_rc == 0 else "boom"
+
+
+def _run(chain: Path, gh: FakeGh, logs: list[str], **kwargs: Any) -> int:
+    defaults: dict[str, Any] = {
+        "chain_path": chain,
+        "repo": "synaptent/aragora",
+        "apply": False,
+        "rekor": False,
+        "max_anchors": 2,
+        "run_gh": gh,
+        "log": logs.append,
+    }
+    defaults.update(kwargs)
+    return anchor.run_anchor(**defaults)
+
+
+class TestHeadAndPlan:
+    def test_empty_chain_is_clean_noop(self, tmp_path: Path) -> None:
+        logs: list[str] = []
+        gh = FakeGh()
+        rc = _run(tmp_path / "missing.jsonl", gh, logs)
+        assert rc == anchor.EXIT_OK
+        assert gh.calls == []  # nothing resolved, nothing posted
+        assert json.loads(logs[0])["result"] == "no-op"
+
+    def test_dry_run_plans_status_without_posting(self, tmp_path: Path) -> None:
+        chain = _chain_with_records(tmp_path, 3)
+        logs: list[str] = []
+        gh = FakeGh()
+        rc = _run(chain, gh, logs)
+        assert rc == anchor.EXIT_OK
+        # Only the head resolution call ran; no POST left the machine.
+        assert len(gh.calls) == 1
+        plan = json.loads(logs[0])
+        assert plan["mode"] == "dry-run"
+        assert plan["seq"] == 2
+        assert plan["anchor_target"]["context"] == "aragora/trail-anchor"
+        assert f"repos/synaptent/aragora/statuses/{MAIN_SHA}" in plan["gh_args"]
+
+    def test_status_args_carry_seq_and_head12(self, tmp_path: Path) -> None:
+        head_hash = "f" * 64
+        args = anchor.build_status_args("synaptent/aragora", MAIN_SHA, 7, head_hash)
+        assert f"description=trail-anchor seq=7 head={head_hash[:12]}" in args
+        assert "state=success" in args
+        assert "context=aragora/trail-anchor" in args
+
+
+class TestFailClosed:
+    def test_broken_chain_is_never_anchored(self, tmp_path: Path) -> None:
+        chain = _chain_with_records(tmp_path, 3)
+        lines = chain.read_text().splitlines()
+        tampered = json.loads(lines[1])
+        tampered["payload"]["n"] = 999
+        lines[1] = json.dumps(tampered)
+        chain.write_text("\n".join(lines) + "\n")
+        logs: list[str] = []
+        gh = FakeGh()
+        rc = _run(chain, gh, logs, apply=True)
+        assert rc == anchor.EXIT_FAILURE
+        assert gh.calls == []
+        assert "verification failed at seq=1" in json.loads(logs[0])["reason"]
+
+    def test_head_resolution_failure_fails_closed(self, tmp_path: Path) -> None:
+        chain = _chain_with_records(tmp_path)
+        logs: list[str] = []
+
+        def broken_gh(args: list[str]) -> tuple[int, str]:
+            return 1, "api down"
+
+        rc = _run(chain, broken_gh, logs, apply=True)
+        assert rc == anchor.EXIT_FAILURE
+
+    def test_status_post_failure_fails_closed(self, tmp_path: Path) -> None:
+        chain = _chain_with_records(tmp_path)
+        logs: list[str] = []
+        gh = FakeGh(post_rc=1)
+        rc = _run(chain, gh, logs, apply=True)
+        assert rc == anchor.EXIT_FAILURE
+        assert any("status post failed" in line for line in logs)
+
+    def test_max_anchors_zero_blocks_apply(self, tmp_path: Path) -> None:
+        chain = _chain_with_records(tmp_path)
+        logs: list[str] = []
+        gh = FakeGh()
+        rc = _run(chain, gh, logs, apply=True, max_anchors=0)
+        assert rc == anchor.EXIT_FAILURE
+        assert len(gh.calls) == 1  # head resolution only; POST blocked
+
+
+class TestApply:
+    def test_apply_posts_anchor_status(self, tmp_path: Path) -> None:
+        chain = _chain_with_records(tmp_path, 2)
+        logs: list[str] = []
+        gh = FakeGh()
+        rc = _run(chain, gh, logs, apply=True)
+        assert rc == anchor.EXIT_OK
+        post = gh.calls[-1]
+        assert "--method" in post and "POST" in post
+        assert f"repos/synaptent/aragora/statuses/{MAIN_SHA}" in post
+        assert any("trail-anchor seq=1" in part for part in post)
+        assert json.loads(logs[-1])["result"] == "anchored"
+
+
+class TestRekor:
+    def test_rekor_absent_degrades_silently(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(anchor.shutil, "which", lambda _name: None)
+        chain = _chain_with_records(tmp_path)
+        logs: list[str] = []
+        gh = FakeGh()
+        rc = _run(chain, gh, logs, apply=True, rekor=True)
+        assert rc == anchor.EXIT_OK  # commit-status anchor alone still succeeds
+        notes = [json.loads(line) for line in logs if "rekor" in line]
+        assert notes and notes[-1]["rekor"] == "unavailable"
+
+    def test_rekor_dry_run_plans_upload(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            anchor.shutil,
+            "which",
+            lambda name: "/usr/bin/rekor-cli" if name == "rekor-cli" else None,
+        )
+        chain = _chain_with_records(tmp_path)
+        logs: list[str] = []
+        gh = FakeGh()
+        rc = _run(chain, gh, logs, rekor=True)
+        assert rc == anchor.EXIT_OK
+        notes = [json.loads(line) for line in logs if "rekor" in line]
+        assert notes and notes[-1]["rekor"] == "dry-run"
+        assert notes[-1]["cmd"][0] == "rekor-cli"
+
+
+class TestCli:
+    def test_main_dry_run_on_empty_chain(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        rc = anchor.main(["--chain", str(tmp_path / "missing.jsonl")])
+        assert rc == anchor.EXIT_OK
+        assert json.loads(capsys.readouterr().out.splitlines()[0])["result"] == "no-op"

--- a/tests/trail/test_auto_evidence_trail_wiring.py
+++ b/tests/trail/test_auto_evidence_trail_wiring.py
@@ -1,0 +1,85 @@
+"""TET T1 example call-site wiring: auto_evidence_cycle → intent chain.
+
+Verifies the ONE production call site added in phase T1: a successfully
+posted evidence packet records an ``agent-app``/``settle_pr`` intent, gated
+behind ``ARAGORA_TRAIL=1`` and non-fatal in every failure mode.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+from aragora.trail.intent_chain import read_records, verify_chain
+
+
+def _load_cycle() -> Any:
+    here = Path(__file__).resolve()
+    script_path = here.parents[2] / "scripts" / "auto_evidence_cycle.py"
+    spec = importlib.util.spec_from_file_location("auto_evidence_cycle_trail_test", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load spec for {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+cycle = _load_cycle()
+
+
+def _posted_run(record_trail: Any) -> dict[str, Any]:
+    return cycle.run_cycle(
+        list_prs=lambda: [{"number": 7, "isDraft": False, "statusCheckRollup": []}],
+        fetch_packet=lambda pr: {
+            "pr_number": pr,
+            "status": "needs_model_review_quorum",
+            "tier": 2,
+            "counted_model_families": [],
+        },
+        run_collect=lambda pr, apply: {
+            "ok": True,
+            "counting_families": ["grok", "mistral"],
+            "posted_families": ["grok", "mistral"],
+        },
+        run_reconciler=lambda: 0,
+        record_trail=record_trail,
+        apply=True,
+        max_prs=1,
+        max_scan=5,
+        budget_seconds=60.0,
+        breaker_threshold=3,
+        log=lambda _line: None,
+    )
+
+
+def test_posted_evidence_records_trail_intent() -> None:
+    seen: list[tuple[int, list[str]]] = []
+    summary = _posted_run(lambda pr, families: seen.append((pr, families)))
+    assert summary["posted_prs"] == [7]
+    assert seen == [(7, ["grok", "mistral"])]
+
+
+def test_default_record_trail_appends_when_enabled(tmp_path: Path, monkeypatch: Any) -> None:
+    chain = tmp_path / "intent-chain.jsonl"
+    monkeypatch.setenv("ARAGORA_TRAIL", "1")
+    monkeypatch.setenv("ARAGORA_TRAIL_CHAIN", str(chain))
+    cycle.default_record_trail("synaptent/aragora", 42, ["grok", "mistral"])
+    records = read_records(chain)
+    assert len(records) == 1
+    assert records[0]["actor_class"] == "agent-app"
+    assert records[0]["intent_type"] == "settle_pr"
+    assert records[0]["target"] == {"repo": "synaptent/aragora", "pr": 42}
+    assert records[0]["payload"]["posted_families"] == ["grok", "mistral"]
+    ok, _ = verify_chain(chain)
+    assert ok
+
+
+def test_default_record_trail_is_noop_when_disabled(tmp_path: Path, monkeypatch: Any) -> None:
+    chain = tmp_path / "intent-chain.jsonl"
+    monkeypatch.delenv("ARAGORA_TRAIL", raising=False)
+    monkeypatch.setenv("ARAGORA_TRAIL_CHAIN", str(chain))
+    cycle.default_record_trail("synaptent/aragora", 42, ["grok"])
+    assert not chain.exists()

--- a/tests/trail/test_intent_chain.py
+++ b/tests/trail/test_intent_chain.py
@@ -1,0 +1,316 @@
+"""Tests for the TET intent hash-chain (``aragora/trail/intent_chain.py``).
+
+Spec: docs/specs/TAMPER_EVIDENT_TRAIL.md Component 2 (phase T1).
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+
+import pytest
+
+from aragora.trail.intent_chain import (
+    ACTOR_CLASSES,
+    GENESIS_PREV_HASH,
+    INTENT_TYPES,
+    ChainError,
+    append_intent,
+    chain_head_hash,
+    compute_record_hash,
+    default_chain_path,
+    read_records,
+    record_intent,
+    verify_chain,
+)
+
+TARGET = {"repo": "synaptent/aragora", "pr": 1234}
+
+
+def _ts() -> str:
+    return "2026-06-11T22:00:00+00:00"
+
+
+def _append(path: Path, n: int = 1) -> list[dict]:
+    return [
+        append_intent(
+            path,
+            actor_class="agent-claude",
+            intent_type="publish_pr",
+            target=TARGET,
+            payload={"n": i},
+            now=_ts,
+        )
+        for i in range(n)
+    ]
+
+
+class TestAppendAndVerify:
+    def test_append_builds_valid_chain(self, tmp_path: Path) -> None:
+        chain = tmp_path / "chain.jsonl"
+        records = _append(chain, 3)
+        ok, broken = verify_chain(chain)
+        assert ok and broken is None
+        assert [r["seq"] for r in records] == [0, 1, 2]
+        assert chain_head_hash(chain) == records[-1]["record_hash"]
+
+    def test_genesis_prev_hash_is_64_zeros(self, tmp_path: Path) -> None:
+        chain = tmp_path / "chain.jsonl"
+        (record,) = _append(chain, 1)
+        assert record["prev_hash"] == GENESIS_PREV_HASH == "0" * 64
+
+    def test_each_record_links_to_previous(self, tmp_path: Path) -> None:
+        chain = tmp_path / "chain.jsonl"
+        records = _append(chain, 3)
+        assert records[1]["prev_hash"] == records[0]["record_hash"]
+        assert records[2]["prev_hash"] == records[1]["record_hash"]
+
+    def test_record_carries_injected_ts_and_intent_id(self, tmp_path: Path) -> None:
+        chain = tmp_path / "chain.jsonl"
+        record = append_intent(
+            chain,
+            actor_class="human",
+            intent_type="merge_pr",
+            target=TARGET,
+            intent_id="fixed-id",
+            now=lambda: "2026-01-01T00:00:00+00:00",
+        )
+        assert record["ts"] == "2026-01-01T00:00:00+00:00"
+        assert record["intent_id"] == "fixed-id"
+
+    def test_empty_and_missing_chain(self, tmp_path: Path) -> None:
+        chain = tmp_path / "missing.jsonl"
+        assert read_records(chain) == []
+        assert chain_head_hash(chain) is None
+        ok, broken = verify_chain(chain)
+        assert ok and broken is None
+
+
+class TestTamperDetection:
+    def test_edited_middle_record_breaks_at_that_seq(self, tmp_path: Path) -> None:
+        chain = tmp_path / "chain.jsonl"
+        _append(chain, 4)
+        lines = chain.read_text().splitlines()
+        middle = json.loads(lines[1])
+        middle["payload"]["n"] = 999  # silent rewrite attempt
+        lines[1] = json.dumps(middle)
+        chain.write_text("\n".join(lines) + "\n")
+        ok, broken = verify_chain(chain)
+        assert not ok
+        assert broken == 1
+
+    def test_rehashed_middle_record_still_breaks_chain(self, tmp_path: Path) -> None:
+        # Adversary edits a record AND recomputes its hash: the next record's
+        # prev_hash no longer matches, so the break surfaces at seq 2.
+        chain = tmp_path / "chain.jsonl"
+        _append(chain, 4)
+        lines = chain.read_text().splitlines()
+        middle = json.loads(lines[1])
+        middle["payload"]["n"] = 999
+        middle.pop("record_hash")
+        middle["record_hash"] = compute_record_hash(middle)
+        lines[1] = json.dumps(middle)
+        chain.write_text("\n".join(lines) + "\n")
+        ok, broken = verify_chain(chain)
+        assert not ok
+        assert broken == 2
+
+    def test_truncated_then_extended_tail_breaks(self, tmp_path: Path) -> None:
+        chain = tmp_path / "chain.jsonl"
+        records = _append(chain, 3)
+        lines = chain.read_text().splitlines()
+        chain.write_text("\n".join(lines[:2]) + "\n")
+        # The shortened chain is internally consistent (detection of pure
+        # truncation needs the external anchor)…
+        ok, _ = verify_chain(chain)
+        assert ok
+        # …but the head no longer matches what was (or would have been) anchored.
+        assert chain_head_hash(chain) != records[-1]["record_hash"]
+
+    def test_duplicate_seq_rejected(self, tmp_path: Path) -> None:
+        chain = tmp_path / "chain.jsonl"
+        _append(chain, 2)
+        lines = chain.read_text().splitlines()
+        chain.write_text("\n".join([*lines, lines[1]]) + "\n")
+        ok, broken = verify_chain(chain)
+        assert not ok
+        assert broken == 1  # claimed seq of the out-of-place record
+
+    def test_out_of_order_seq_rejected(self, tmp_path: Path) -> None:
+        chain = tmp_path / "chain.jsonl"
+        _append(chain, 3)
+        lines = chain.read_text().splitlines()
+        chain.write_text("\n".join([lines[0], lines[2], lines[1]]) + "\n")
+        ok, broken = verify_chain(chain)
+        assert not ok
+        assert broken == 2
+
+    def test_corrupt_json_line_fails_verification(self, tmp_path: Path) -> None:
+        chain = tmp_path / "chain.jsonl"
+        _append(chain, 2)
+        with chain.open("a") as fh:
+            fh.write("{not json\n")
+        with pytest.raises(ChainError):
+            read_records(chain)
+        ok, _ = verify_chain(chain)
+        assert not ok
+
+
+class TestCanonicalization:
+    def test_hash_is_key_order_independent(self) -> None:
+        base = {
+            "seq": 0,
+            "ts": _ts(),
+            "actor_class": "agent-claude",
+            "intent_type": "publish_pr",
+            "target": {"repo": "synaptent/aragora", "ref": "main"},
+            "intent_id": "abc",
+            "payload": {"b": 2, "a": 1},
+            "prev_hash": GENESIS_PREV_HASH,
+        }
+        shuffled = dict(reversed(list(base.items())))
+        shuffled["target"] = {"ref": "main", "repo": "synaptent/aragora"}
+        shuffled["payload"] = {"a": 1, "b": 2}
+        assert compute_record_hash(base) == compute_record_hash(shuffled)
+
+    def test_unicode_payload_hashes_stably(self, tmp_path: Path) -> None:
+        chain = tmp_path / "chain.jsonl"
+        record = append_intent(
+            chain,
+            actor_class="agent-codex",
+            intent_type="issue_create",
+            target=TARGET,
+            payload={"title": "café ☃ ✓"},
+            now=_ts,
+        )
+        # Round-tripping through JSON file storage must reproduce the hash.
+        stored = read_records(chain)[0]
+        assert compute_record_hash(stored) == record["record_hash"]
+        ok, _ = verify_chain(chain)
+        assert ok
+
+    def test_extra_unhashed_field_rejected(self) -> None:
+        with pytest.raises(ChainError, match="extra fields"):
+            compute_record_hash({"seq": 0, "smuggled": "content"})
+
+
+class TestValidation:
+    def test_unknown_actor_class_rejected(self, tmp_path: Path) -> None:
+        with pytest.raises(ChainError, match="actor_class"):
+            append_intent(
+                tmp_path / "c.jsonl",
+                actor_class="agent-rogue",
+                intent_type="publish_pr",
+                target=TARGET,
+            )
+
+    def test_unknown_intent_type_rejected(self, tmp_path: Path) -> None:
+        with pytest.raises(ChainError, match="intent_type"):
+            append_intent(
+                tmp_path / "c.jsonl",
+                actor_class="human",
+                intent_type="rm_rf",
+                target=TARGET,
+            )
+
+    def test_target_requires_repo(self, tmp_path: Path) -> None:
+        with pytest.raises(ChainError, match="repo"):
+            append_intent(
+                tmp_path / "c.jsonl",
+                actor_class="human",
+                intent_type="merge_pr",
+                target={"pr": 1},
+            )
+
+    def test_enums_match_spec(self) -> None:
+        assert ACTOR_CLASSES == {
+            "human",
+            "agent-claude",
+            "agent-codex",
+            "agent-app",
+            "daemon-publisher",
+            "daemon-arbiter",
+            "daemon-boss",
+        }
+        assert INTENT_TYPES == {
+            "publish_pr",
+            "merge_pr",
+            "settle_pr",
+            "close_pr",
+            "branch_delete",
+            "issue_create",
+        }
+
+
+class TestConcurrency:
+    def test_concurrent_appends_do_not_corrupt(self, tmp_path: Path) -> None:
+        chain = tmp_path / "chain.jsonl"
+        threads = [
+            threading.Thread(
+                target=lambda: [
+                    append_intent(
+                        chain,
+                        actor_class="daemon-publisher",
+                        intent_type="publish_pr",
+                        target=TARGET,
+                        now=_ts,
+                    )
+                    for _ in range(10)
+                ]
+            )
+            for _ in range(4)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        records = read_records(chain)
+        assert len(records) == 40
+        assert [r["seq"] for r in records] == list(range(40))
+        ok, broken = verify_chain(chain)
+        assert ok and broken is None
+
+
+class TestRecordIntentHelper:
+    def test_off_by_default(self, tmp_path: Path) -> None:
+        chain = tmp_path / "chain.jsonl"
+        result = record_intent(
+            actor_class="agent-app",
+            intent_type="settle_pr",
+            target=TARGET,
+            path=chain,
+            env={},
+        )
+        assert result is None
+        assert not chain.exists()
+
+    def test_appends_when_enabled(self, tmp_path: Path) -> None:
+        chain = tmp_path / "chain.jsonl"
+        result = record_intent(
+            actor_class="agent-app",
+            intent_type="settle_pr",
+            target=TARGET,
+            payload={"action": "post_quorum_evidence"},
+            path=chain,
+            env={"ARAGORA_TRAIL": "1"},
+        )
+        assert result is not None and result["seq"] == 0
+        ok, _ = verify_chain(chain)
+        assert ok
+
+    def test_never_raises_on_bad_input(self, tmp_path: Path) -> None:
+        result = record_intent(
+            actor_class="not-a-class",
+            intent_type="settle_pr",
+            target=TARGET,
+            path=tmp_path / "chain.jsonl",
+            env={"ARAGORA_TRAIL": "1"},
+        )
+        assert result is None
+
+    def test_default_path_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_TRAIL_CHAIN", "/tmp/custom-chain.jsonl")
+        assert default_chain_path() == Path("/tmp/custom-chain.jsonl")
+        monkeypatch.delenv("ARAGORA_TRAIL_CHAIN")
+        assert default_chain_path() == Path(".aragora/trail/intent-chain.jsonl")


### PR DESCRIPTION
## Summary

TET build phases **T1 + T2** per [`docs/specs/TAMPER_EVIDENT_TRAIL.md`](https://github.com/synaptent/aragora/blob/main/docs/specs/TAMPER_EVIDENT_TRAIL.md) Component 2 (intent anchoring). This is the Plan v2 **Pillar 5 (Open Receipt Standard) seed**, built as a product module (`aragora/trail/`), not just a script.

**Tier: 2**

### T1 — intent hash-chain (`aragora/trail/intent_chain.py`)
- Append-only JSONL ledger at `.aragora/trail/intent-chain.jsonl`; records `{seq, ts, actor_class, intent_type, target, intent_id, payload, prev_hash, record_hash}`.
- `record_hash` = SHA-256 over **RFC 8785 (JCS)** canonical JSON of all fields except `record_hash` — canonicalization shared with the Open Decision Receipt profile via `aragora.gauntlet.odr_export.jcs_canonicalize` (key-order and unicode independent). Genesis `prev_hash` = 64 zeros.
- Atomic appends: exclusive `flock` on a sidecar lock around read-tail-then-append; single `write` on an `O_APPEND` fd + fsync; prior lines never rewritten. Fixed hashed-field set — extra keys are rejected, so no unhashed content can ride along.
- Injectable `now` callable (module-level clock default) — no wall-clock reads hardcoded in importable paths.
- `verify_chain` returns `(ok, first_broken_seq)`; duplicate/out-of-order seqs and rehashed-middle-record adversaries both break.
- `record_intent()` helper: gated behind `ARAGORA_TRAIL=1` (default OFF), never raises — exactly ONE production call site added (auto_evidence_cycle posts quorum evidence → `agent-app`/`settle_pr` intent). Broad daemon wiring is a T-followup per the lane brief.

### T2 — external anchor (`scripts/anchor_intent_chain.py`)
- Primary anchor: GitHub **commit status** on origin/main HEAD, context `aragora/trail-anchor`, description `trail-anchor seq=<N> head=<hash12>` — server-side timestamped, witnessed by the Enterprise audit stream (Component 1).
- Token path: `aragora.swarm.github_app_auth.github_cli_env` preferred, ambient `gh` fallback.
- `--rekor`: additionally submits the head hash to Sigstore Rekor when `rekor-cli` exists; **degrades silently** to commit-status-only otherwise (no hard dependency).
- Dry-run default; `--apply` gates every mutation; `--max-anchors` bound; **a chain that fails verification is never anchored** (fail-closed, exit 1); empty chain = clean no-op.

### Tests
37 new tests in `tests/trail/` (chain validity, tamper detection at exact seq, rehash + truncate adversaries, dup/out-of-order seq, JCS key-order/unicode stability, 4×10 threaded concurrent appends, env gating, anchor dry-run/apply/fail-closed/rekor-absent/CLI). Existing `tests/scripts/test_auto_evidence_cycle.py` (41) green and untouched semantically (one injectable hook with default `None`).

### Live validation (in worktree)
3 real intents appended to a temp chain → `verify_chain` ok → anchor `--dry-run` planned the commit status against the real origin/main HEAD (outputs in PR comment). `--apply` intentionally NOT run — coordinator wires the live anchor cadence post-merge (T0/T3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
