### PR TITLE
fix(benchmark-truth): validate corpus freshness map schema

### DIFF
--- a/scripts/build_benchmark_truth_artifact.py
+++ b/scripts/build_benchmark_truth_artifact.py
@@ -288,16 +288,32 @@ def load_corpus_freshness_map_payload(path: Path) -> dict[str, Any]:
     payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
         raise ValueError(f"Corpus freshness map at {path} must be a JSON object")
+    schema_version = _validate_corpus_freshness_map_schema_version(
+        path,
+        payload.get("schema_version", 1),
+    )
     entries = payload.get("entries")
     if not isinstance(entries, list):
         raise ValueError(f"Corpus freshness map at {path} must contain an 'entries' list")
     return {
-        "schema_version": int(payload.get("schema_version", 1) or 1),
+        "schema_version": schema_version,
         "entries": entries,
     }
 
 
+def _validate_corpus_freshness_map_schema_version(path: Path, value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(
+            f"Corpus freshness map at {path} schema_version must be a positive integer"
+        )
+    return value
+
+
 def write_corpus_freshness_map_payload(path: Path, payload: dict[str, Any]) -> Path:
+    schema_version = _validate_corpus_freshness_map_schema_version(
+        path,
+        payload.get("schema_version", 1),
+    )
     entries = [
         entry
         for entry in list(payload.get("entries") or [])
@@ -313,7 +329,7 @@ def write_corpus_freshness_map_payload(path: Path, payload: dict[str, Any]) -> P
         )
     )
     normalized = {
-        "schema_version": int(payload.get("schema_version", 1) or 1),
+        "schema_version": schema_version,
         "entries": entries,
     }
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/scripts/test_build_benchmark_truth_artifact.py
+++ b/tests/scripts/test_build_benchmark_truth_artifact.py
@@ -5,6 +5,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 _scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
 if _scripts_dir not in sys.path:
     sys.path.insert(0, _scripts_dir)
@@ -53,6 +55,52 @@ def test_repo_stable_path_relativizes_git_common_root(tmp_path: Path, monkeypatc
     monkeypatch.setattr(mod, "git_common_repo_root", lambda _repo_root: shared_root)
 
     assert mod._repo_stable_path(metrics_path) == ".aragora/overnight/boss_metrics.jsonl"
+
+
+@pytest.mark.parametrize("schema_version", [0, -1, True, "1"])
+def test_load_corpus_freshness_map_rejects_invalid_schema_version(
+    tmp_path: Path,
+    schema_version: object,
+) -> None:
+    freshness_map_path = tmp_path / "benchmark_corpus_freshness.json"
+    freshness_map_path.write_text(
+        json.dumps({"schema_version": schema_version, "entries": []}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="schema_version must be a positive integer"):
+        mod.load_corpus_freshness_map_payload(freshness_map_path)
+
+
+def test_write_corpus_freshness_map_rejects_invalid_schema_version(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="schema_version must be a positive integer"):
+        mod.write_corpus_freshness_map_payload(
+            tmp_path / "benchmark_corpus_freshness.json",
+            {"schema_version": False, "entries": []},
+        )
+
+
+def test_write_corpus_freshness_map_preserves_valid_schema_version(tmp_path: Path) -> None:
+    freshness_map_path = tmp_path / "benchmark_corpus_freshness.json"
+
+    mod.write_corpus_freshness_map_payload(
+        freshness_map_path,
+        {
+            "schema_version": 2,
+            "entries": [
+                {
+                    "corpus_id": "tw-01-bounded-execution-v1",
+                    "revision": 4,
+                    "target": "#6001",
+                    "title": "[TW-02] Restock stale issues",
+                }
+            ],
+        },
+    )
+
+    payload = json.loads(freshness_map_path.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == 2
+    assert len(payload["entries"]) == 1
 
 
 def test_build_benchmark_truth_artifact_links_corpus_revision_and_truth_metrics(


### PR DESCRIPTION
Summary:
- fail closed on invalid corpus freshness map schema_version values
- validate the schema version on both load and write paths
- add focused regression coverage for rejected and preserved schema versions

Validation:
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_build_benchmark_truth_artifact.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD