### PR TITLE
fix(reports): validate contract drift ratchet program

### DIFF
--- a/scripts/check_contract_drift_ratchet.py
+++ b/scripts/check_contract_drift_ratchet.py
@@ -44,6 +44,13 @@ def _target_after_weeks(start_total: int, weekly_reduction: float, weeks: int) -
     return current
 
 
+def _require_non_negative_int(program: dict[str, Any], field: str) -> int:
+    value = program.get(field)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"Program baseline has invalid '{field}'")
+    return value
+
+
 def build_ratchet_result(
     *,
     program_baseline: Path,
@@ -60,14 +67,12 @@ def build_ratchet_result(
         )
 
     start_date_raw = program.get("start_date")
-    start_total = int(program.get("start_total_items", 0))
+    start_total = _require_non_negative_int(program, "start_total_items")
     weekly_reduction = float(program.get("weekly_reduction", 0.1))
-    grace_weeks = int(program.get("grace_weeks", 0))
+    grace_weeks = _require_non_negative_int(program, "grace_weeks")
 
     if not start_date_raw:
         raise ValueError("Program baseline must include 'start_date'")
-    if start_total < 0:
-        raise ValueError("Program baseline has invalid 'start_total_items'")
     if not (0.0 < weekly_reduction < 1.0):
         raise ValueError("Program baseline 'weekly_reduction' must be between 0 and 1")
 

--- a/tests/scripts/test_check_contract_drift_ratchet.py
+++ b/tests/scripts/test_check_contract_drift_ratchet.py
@@ -7,6 +7,8 @@ import sys
 from datetime import date, timedelta
 from pathlib import Path
 
+import pytest
+
 import scripts.check_contract_drift_ratchet as ratchet
 
 
@@ -111,3 +113,65 @@ def test_strict_fails_when_above_target(monkeypatch, tmp_path: Path):
     )
 
     assert ratchet.main() == 1
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("start_total_items", "10"),
+        ("start_total_items", True),
+        ("start_total_items", -1),
+        ("grace_weeks", "0"),
+        ("grace_weeks", False),
+        ("grace_weeks", -1),
+    ],
+)
+def test_build_ratchet_result_rejects_invalid_program_integers(
+    tmp_path: Path,
+    field: str,
+    value: object,
+) -> None:
+    verify, routes, parity, program = _seed_files(tmp_path)
+    payload: dict[str, object] = {
+        "start_date": date.today().isoformat(),
+        "start_total_items": 10,
+        "weekly_reduction": 0.1,
+        "grace_weeks": 0,
+    }
+    payload[field] = value
+    _write_json(program, payload)
+
+    with pytest.raises(ValueError, match=f"invalid '{field}'"):
+        ratchet.build_ratchet_result(
+            program_baseline=program,
+            verify_baseline=verify,
+            routes_baseline=routes,
+            parity_baseline=parity,
+            as_of=date.today(),
+        )
+
+
+def test_build_ratchet_result_allows_zero_program_integers(tmp_path: Path) -> None:
+    verify, routes, parity, program = _seed_files(tmp_path)
+    today = date.today()
+    _write_json(
+        program,
+        {
+            "start_date": today.isoformat(),
+            "start_total_items": 0,
+            "weekly_reduction": 0.1,
+            "grace_weeks": 0,
+        },
+    )
+
+    result = ratchet.build_ratchet_result(
+        program_baseline=program,
+        verify_baseline=verify,
+        routes_baseline=routes,
+        parity_baseline=parity,
+        as_of=today,
+    )
+
+    assert result["program"]["start_total_items"] == 0
+    assert result["program"]["grace_weeks"] == 0
+    assert result["target"]["max_open_items"] == 0


### PR DESCRIPTION
Summary:
- fail closed when contract drift ratchet program integer fields are strings, booleans, or negative values
- validate start_total_items and grace_weeks before computing the ratchet target
- add focused regression coverage for invalid and zero-valued program fields

Validation:
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_check_contract_drift_ratchet.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD