### PR TITLE
fix(reports): validate contract drift backlog sources

### DIFF
--- a/scripts/generate_contract_drift_backlog.py
+++ b/scripts/generate_contract_drift_backlog.py
@@ -41,10 +41,36 @@ OWNER_MAP = {
 }
 
 
+class BacklogSourceError(RuntimeError):
+    """Raised when contract drift source baselines cannot be trusted."""
+
+
 def _load(path: Path) -> dict[str, Any]:
     if not path.exists():
         return {}
-    return json.loads(path.read_text())
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise BacklogSourceError(f"Cannot load contract drift baseline {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise BacklogSourceError(f"Contract drift baseline must be a JSON object: {path}")
+    return payload
+
+
+def _source_list(payload: dict[str, Any], key: str, *, path: Path) -> list[str]:
+    value = payload.get(key, [])
+    if not isinstance(value, list):
+        raise BacklogSourceError(f"Contract drift baseline field {key!r} must be a list: {path}")
+
+    items: list[str] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, str) or not item.strip():
+            raise BacklogSourceError(
+                f"Contract drift baseline field {key!r} item {index} "
+                f"must be a non-empty string: {path}"
+            )
+        items.append(item)
+    return items
 
 
 def _route_domain(path: str) -> str:
@@ -87,16 +113,22 @@ def _targets(
 
 
 def build_backlog() -> dict[str, Any]:
-    verify = _load(PROJECT_ROOT / "scripts/baselines/verify_sdk_contracts.json")
-    routes = _load(PROJECT_ROOT / "scripts/baselines/validate_openapi_routes.json")
-    parity = _load(PROJECT_ROOT / "scripts/baselines/check_sdk_parity.json")
+    verify_path = PROJECT_ROOT / "scripts/baselines/verify_sdk_contracts.json"
+    routes_path = PROJECT_ROOT / "scripts/baselines/validate_openapi_routes.json"
+    parity_path = PROJECT_ROOT / "scripts/baselines/check_sdk_parity.json"
+
+    verify = _load(verify_path)
+    routes = _load(routes_path)
+    parity = _load(parity_path)
 
     items_by_source: dict[str, list[str]] = {
-        "verify_python_sdk_drift": list(verify.get("python_sdk_drift", [])),
-        "verify_typescript_sdk_drift": list(verify.get("typescript_sdk_drift", [])),
-        "routes_missing_in_spec": list(routes.get("missing_in_spec", [])),
-        "routes_orphaned_in_spec": list(routes.get("orphaned_in_spec", [])),
-        "sdk_missing_from_both": list(parity.get("missing_from_both_sdks", [])),
+        "verify_python_sdk_drift": _source_list(verify, "python_sdk_drift", path=verify_path),
+        "verify_typescript_sdk_drift": _source_list(
+            verify, "typescript_sdk_drift", path=verify_path
+        ),
+        "routes_missing_in_spec": _source_list(routes, "missing_in_spec", path=routes_path),
+        "routes_orphaned_in_spec": _source_list(routes, "orphaned_in_spec", path=routes_path),
+        "sdk_missing_from_both": _source_list(parity, "missing_from_both_sdks", path=parity_path),
     }
 
     domain_counts: dict[str, Counter[str]] = {}
@@ -192,7 +224,10 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    data = build_backlog()
+    try:
+        data = build_backlog()
+    except BacklogSourceError as exc:
+        raise SystemExit(str(exc)) from None
     md = to_markdown(data)
 
     md_path = PROJECT_ROOT / args.markdown_out

--- a/tests/scripts/test_generate_contract_drift_backlog.py
+++ b/tests/scripts/test_generate_contract_drift_backlog.py
@@ -1,0 +1,120 @@
+"""Tests for scripts/generate_contract_drift_backlog.py."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import scripts.generate_contract_drift_backlog as backlog
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+
+def test_build_backlog_counts_valid_source_lists(monkeypatch, tmp_path: Path) -> None:
+    baselines = tmp_path / "scripts" / "baselines"
+    _write_json(
+        baselines / "verify_sdk_contracts.json",
+        {
+            "python_sdk_drift": ["GET /api/v1/auth/sessions"],
+            "typescript_sdk_drift": ["POST /api/v1/debates"],
+        },
+    )
+    _write_json(
+        baselines / "validate_openapi_routes.json",
+        {
+            "missing_in_spec": ["GET /api/v1/chat/messages"],
+            "orphaned_in_spec": ["GET /api/v1/billing/invoices"],
+        },
+    )
+    _write_json(
+        baselines / "check_sdk_parity.json",
+        {"missing_from_both_sdks": ["GET /api/v1/knowledge/items"]},
+    )
+    monkeypatch.setattr(backlog, "PROJECT_ROOT", tmp_path)
+
+    result = backlog.build_backlog()
+
+    assert result["total_items"] == 5
+    assert result["counts_by_source"] == {
+        "verify_python_sdk_drift": 1,
+        "verify_typescript_sdk_drift": 1,
+        "routes_missing_in_spec": 1,
+        "routes_orphaned_in_spec": 1,
+        "sdk_missing_from_both": 1,
+    }
+    assert {ticket["domain"] for ticket in result["tickets"]} == {
+        "auth",
+        "billing",
+        "chat",
+        "debates",
+        "knowledge",
+    }
+
+
+def test_build_backlog_rejects_non_list_source_field(monkeypatch, tmp_path: Path) -> None:
+    baseline = tmp_path / "scripts" / "baselines" / "verify_sdk_contracts.json"
+    _write_json(baseline, {"python_sdk_drift": "GET /api/v1/auth/sessions"})
+    monkeypatch.setattr(backlog, "PROJECT_ROOT", tmp_path)
+
+    try:
+        backlog.build_backlog()
+    except backlog.BacklogSourceError as exc:
+        assert "field 'python_sdk_drift' must be a list" in str(exc)
+        assert str(baseline) in str(exc)
+    else:  # pragma: no cover - defensive assertion
+        raise AssertionError("non-list source field should fail closed")
+
+
+def test_build_backlog_rejects_non_string_source_item(monkeypatch, tmp_path: Path) -> None:
+    baseline = tmp_path / "scripts" / "baselines" / "check_sdk_parity.json"
+    _write_json(baseline, {"missing_from_both_sdks": ["GET /api/v1/auth/sessions", 42]})
+    monkeypatch.setattr(backlog, "PROJECT_ROOT", tmp_path)
+
+    try:
+        backlog.build_backlog()
+    except backlog.BacklogSourceError as exc:
+        assert "field 'missing_from_both_sdks' item 1 must be a non-empty string" in str(exc)
+        assert str(baseline) in str(exc)
+    else:  # pragma: no cover - defensive assertion
+        raise AssertionError("non-string source item should fail closed")
+
+
+def test_main_reports_untrusted_sources_without_writing_outputs(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    baseline = tmp_path / "scripts" / "baselines" / "verify_sdk_contracts.json"
+    md_out = tmp_path / "backlog.md"
+    json_out = tmp_path / "backlog.json"
+    _write_json(baseline, {"python_sdk_drift": [""]})
+    monkeypatch.setattr(backlog, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate_contract_drift_backlog.py",
+            "--markdown-out",
+            str(md_out),
+            "--json-out",
+            str(json_out),
+        ],
+    )
+
+    try:
+        backlog.main()
+    except SystemExit as exc:
+        assert str(exc) == (
+            f"Contract drift baseline field 'python_sdk_drift' item 0 "
+            f"must be a non-empty string: {baseline}"
+        )
+    else:  # pragma: no cover - defensive assertion
+        raise AssertionError("untrusted source field should stop report generation")
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+    assert not md_out.exists()
+    assert not json_out.exists()


### PR DESCRIPTION
Summary:
- fail closed on malformed contract drift backlog source baselines
- reject non-list source fields and non-empty/non-string source items before counting backlog rows
- add focused regression coverage for valid and invalid backlog source payloads

Validation:
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_generate_contract_drift_backlog.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python scripts/generate_contract_drift_backlog.py --markdown-out <tmp>/backlog.md --json-out <tmp>/backlog.json
- bash scripts/automation_pr_preflight.sh origin/main HEAD