### PR TITLE
fix(metrics): correct debate dispatch ratio

### DIFF
--- a/scripts/load_test_debate.py
+++ b/scripts/load_test_debate.py
@@ -41,6 +41,7 @@ import asyncio
 import gc
 import json
 import logging
+import math
 import os
 import random
 import resource
@@ -201,6 +202,28 @@ class MockAgent:
         return 0  # Always vote for first proposal
 
 
+def _dispatch_concurrency_ratio(
+    dispatch_duration_s: float, response_delays_s: list[float]
+) -> float:
+    """Estimate whether proposal dispatch ran in parallel.
+
+    Fully parallel dispatch should take about as long as the slowest individual
+    response; sequential dispatch should take closer to the sum of responses.
+    """
+    if not math.isfinite(dispatch_duration_s) or dispatch_duration_s <= 0:
+        return 0.0
+
+    valid_delays = [
+        float(delay)
+        for delay in response_delays_s
+        if math.isfinite(float(delay)) and float(delay) > 0
+    ]
+    if not valid_delays:
+        return 0.0
+
+    return min(1.0, max(valid_delays) / dispatch_duration_s)
+
+
 async def run_mock_debate(
     debate_id: str,
     question: str,
@@ -241,6 +264,7 @@ async def run_mock_debate(
     first_token_start = time.monotonic()
     proposals = []
     proposal_tasks = [agent.generate(f"Propose a solution for: {question}") for agent in agents]
+    response_delays = [agent._response_delay for agent in agents]
     # Run proposals concurrently to measure dispatch concurrency
     dispatch_start = time.monotonic()
     results = await asyncio.gather(*proposal_tasks, return_exceptions=True)
@@ -256,11 +280,7 @@ async def run_mock_debate(
     if not proposals:
         raise RuntimeError(f"No proposals generated for debate {debate_id}")
 
-    # Calculate dispatch concurrency ratio
-    # If fully parallel, total time ~ single agent time
-    # If sequential, total time ~ sum of agent times
-    single_agent_est = max(0.01, dispatch_duration / max(num_agents, 1))
-    dispatch_ratio = min(1.0, single_agent_est / max(dispatch_duration, 0.001))
+    dispatch_ratio = _dispatch_concurrency_ratio(dispatch_duration, response_delays)
 
     # Phase 2: Rounds (critique and revision)
     for round_num in range(num_rounds):

--- a/tests/scripts/test_load_test_debate.py
+++ b/tests/scripts/test_load_test_debate.py
@@ -1,0 +1,46 @@
+"""Tests for scripts/load_test_debate.py."""
+
+from __future__ import annotations
+
+import scripts.load_test_debate as load_test_debate
+
+
+def test_dispatch_concurrency_ratio_parallel_dispatch_is_near_one() -> None:
+    ratio = load_test_debate._dispatch_concurrency_ratio(
+        dispatch_duration_s=0.041,
+        response_delays_s=[0.02, 0.03, 0.04],
+    )
+
+    assert 0.97 < ratio <= 1.0
+
+
+def test_dispatch_concurrency_ratio_sequential_dispatch_is_penalized() -> None:
+    ratio = load_test_debate._dispatch_concurrency_ratio(
+        dispatch_duration_s=0.09,
+        response_delays_s=[0.02, 0.03, 0.04],
+    )
+
+    assert 0.44 < ratio < 0.45
+
+
+def test_dispatch_concurrency_ratio_rejects_invalid_inputs() -> None:
+    assert load_test_debate._dispatch_concurrency_ratio(0.0, [0.01]) == 0.0
+    assert load_test_debate._dispatch_concurrency_ratio(0.1, []) == 0.0
+    assert load_test_debate._dispatch_concurrency_ratio(0.1, [0.0, -1.0]) == 0.0
+
+
+def test_validate_against_slos_counts_parallel_dispatch_as_passing() -> None:
+    metrics = load_test_debate.DebateLoadMetrics(
+        total_debates=3,
+        completed=3,
+        failed=0,
+        debate_latencies_ms=[1000.0, 1200.0, 1300.0],
+        first_token_latencies_ms=[100.0, 120.0, 130.0],
+        consensus_latencies_ms=[50.0, 55.0, 60.0],
+        dispatch_concurrency_samples=[0.95, 0.98, 1.0],
+    )
+
+    result = load_test_debate.validate_against_slos(metrics)
+
+    assert result["agent_dispatch_concurrency"]["actual"] == 0.977
+    assert result["agent_dispatch_concurrency"]["passed"] is True


### PR DESCRIPTION
Summary:
- correct the debate load-test dispatch concurrency metric so parallel proposal dispatch trends toward 1.0 instead of 1 / agents
- add focused regression coverage for parallel, sequential, and invalid dispatch ratio inputs
- cover SLO validation for passing parallel dispatch samples

Validation:
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_load_test_debate.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python scripts/load_test_debate.py --no-guard --debates 3 --concurrency 3 --agents 3 --rounds 1 --fail-rate 0 --validate-slos
- bash scripts/automation_pr_preflight.sh origin/main HEAD