### PR TITLE
fix(metrics): validate AFT seeded aggregate values

### DIFF
--- a/scripts/aft_seeded_train_eval.py
+++ b/scripts/aft_seeded_train_eval.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import math
 import random
 import statistics
 import subprocess
@@ -199,6 +200,33 @@ def run_harness(
     return json.loads(summaries[0].read_text())
 
 
+def _finite_metric_value(stats: dict, metric: str, *, condition: str) -> float | None:
+    if metric not in stats or stats[metric] is None:
+        return None
+
+    value = stats[metric]
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"AFT seeded summary field {condition}.{metric} must be a finite number")
+
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError(f"AFT seeded summary field {condition}.{metric} must be finite")
+    return result
+
+
+def _bonferroni_p_value(stats: dict, *, pair: str) -> float:
+    value = stats.get("p_value_bonferroni", 1.0)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"AFT seeded pair {pair} p_value_bonferroni must be a number")
+
+    result = float(value)
+    if not math.isfinite(result) or not 0.0 <= result <= 1.0:
+        raise ValueError(
+            f"AFT seeded pair {pair} p_value_bonferroni must be finite and between 0 and 1"
+        )
+    return result
+
+
 def aggregate(summaries: list[dict], extra: dict) -> dict:
     metrics = ("accuracy", "brier", "cost_usd_total", "latency_ms_mean")
     agg: dict = {
@@ -222,9 +250,9 @@ def aggregate(summaries: list[dict], extra: dict) -> dict:
             if not stats:
                 continue
             for m in metrics:
-                v = stats.get(m)
-                if isinstance(v, (int, float)):
-                    values[m].append(float(v))
+                value = _finite_metric_value(stats, m, condition=name)
+                if value is not None:
+                    values[m].append(value)
         for m, vs in values.items():
             if not vs:
                 per[m] = {"mean": None, "stddev": None, "n": 0}
@@ -242,10 +270,11 @@ def aggregate(summaries: list[dict], extra: dict) -> dict:
     pair_p_values: dict = {}
     for s in summaries:
         for pair, stats in s.get("pairwise_significance", {}).items():
+            p_value = _bonferroni_p_value(stats, pair=pair)
             pair_counts.setdefault(pair, {"significant_at_0.05": 0, "n": 0})
             pair_counts[pair]["n"] += 1
-            pair_p_values.setdefault(pair, []).append(stats.get("p_value_bonferroni", 1.0))
-            if stats.get("p_value_bonferroni", 1.0) < 0.05:
+            pair_p_values.setdefault(pair, []).append(p_value)
+            if p_value < 0.05:
                 pair_counts[pair]["significant_at_0.05"] += 1
     for pair, counts in pair_counts.items():
         ps = pair_p_values[pair]

--- a/tests/scripts/test_aft_functions.py
+++ b/tests/scripts/test_aft_functions.py
@@ -413,6 +413,65 @@ class TestSeededTrainEvalMlxSplit:
         assert len((out_dir / "valid.jsonl").read_text(encoding="utf-8").splitlines()) == 2
 
 
+# ----- aft_seeded_train_eval::aggregate ------------------------------------
+
+
+class TestSeededTrainEvalAggregate:
+    def _summary(self, *, metric_value: object = 0.8, p_value: object = 0.04) -> dict:
+        return {
+            "conditions": {
+                "local_advocate": {
+                    "accuracy": metric_value,
+                    "brier": 0.2,
+                    "cost_usd_total": 0.0,
+                    "latency_ms_mean": 12.5,
+                }
+            },
+            "pairwise_significance": {
+                "local_vs_rules": {"p_value_bonferroni": p_value},
+            },
+        }
+
+    def test_seeded_aggregate_accepts_finite_metrics_and_p_values(self) -> None:
+        result = aft_seeded_train_eval.aggregate(
+            [self._summary(metric_value=0.8), self._summary(metric_value=0.6)],
+            {"model": "test-model"},
+        )
+
+        accuracy = result["conditions"]["local_advocate"]["accuracy"]
+        assert accuracy["mean"] == pytest.approx(0.7, abs=1e-9)
+        assert accuracy["values"] == [0.8, 0.6]
+        pair = result["pairwise_significance"]["local_vs_rules"]
+        assert pair["significant_at_0.05"] == 2
+        assert pair["p_bonferroni_mean"] == pytest.approx(0.04, abs=1e-9)
+
+    @pytest.mark.parametrize("metric_value", [float("nan"), float("inf"), -float("inf")])
+    def test_seeded_aggregate_rejects_non_finite_metric_values(self, metric_value: float) -> None:
+        with pytest.raises(ValueError, match="local_advocate.accuracy must be finite"):
+            aft_seeded_train_eval.aggregate([self._summary(metric_value=metric_value)], {})
+
+    @pytest.mark.parametrize("metric_value", [True, "0.8"])
+    def test_seeded_aggregate_rejects_non_numeric_metric_values(self, metric_value: object) -> None:
+        with pytest.raises(ValueError, match="local_advocate.accuracy must be a finite number"):
+            aft_seeded_train_eval.aggregate([self._summary(metric_value=metric_value)], {})
+
+    @pytest.mark.parametrize("p_value", [float("nan"), float("inf"), -0.1, 1.1])
+    def test_seeded_aggregate_rejects_invalid_pairwise_p_values(self, p_value: float) -> None:
+        with pytest.raises(
+            ValueError,
+            match="local_vs_rules p_value_bonferroni must be finite and between 0 and 1",
+        ):
+            aft_seeded_train_eval.aggregate([self._summary(p_value=p_value)], {})
+
+    @pytest.mark.parametrize("p_value", [False, "0.04"])
+    def test_seeded_aggregate_rejects_non_numeric_pairwise_p_values(self, p_value: object) -> None:
+        with pytest.raises(
+            ValueError,
+            match="local_vs_rules p_value_bonferroni must be a number",
+        ):
+            aft_seeded_train_eval.aggregate([self._summary(p_value=p_value)], {})
+
+
 # ----- aggregate (repeated-seed summary) -----------------------------------
 
 


### PR DESCRIPTION
Summary:
- fail closed on non-finite AFT seeded aggregate metrics before writing proof JSON
- validate Bonferroni p-values are numeric, finite, and in [0, 1]
- add focused regression coverage for valid aggregate output and invalid metric/p-value inputs

Validation:
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_aft_functions.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python - <<'PY' ... seeded aggregate smoke ... PY
- bash scripts/automation_pr_preflight.sh origin/main HEAD