### PR TITLE
fix(ci): bandit nosec for https-pinned Rekor urlopen — unbreaks Security Scan on all PRs

### DIFF
--- a/aragora/trail/rekor.py
+++ b/aragora/trail/rekor.py
@@ -168,7 +168,7 @@ def _default_http(method: str, url: str, body: bytes | None) -> tuple[int, bytes
         },
     )
     try:
-        with urllib.request.urlopen(  # noqa: S310 - scheme pinned to https above
+        with urllib.request.urlopen(  # noqa: S310  # nosec B310 - scheme pinned to https above
             request, timeout=HTTP_TIMEOUT_SECONDS
         ) as response:
             return int(response.status), response.read()


### PR DESCRIPTION
## Summary
The **Security Scan** job fails on every non-draft PR since [#8267](https://github.com/synaptent/aragora/pull/8267) merged: `aragora/trail/rekor.py:171` trips bandit **B310** (urlopen audit), and the job compares against a baseline that predates the file.

The call is safe: `_default_http` raises `RekorError` for any non-https URL two lines above (covered by `TestTransportGuards::test_default_transport_refuses_plain_http`), and the line already carries ruff's `# noqa: S310` for exactly this reason. Bandit needs its own `# nosec B310` marker — this PR adds it.

## Verification
- `bandit -c pyproject.toml -r aragora/ -ll -iii -b scripts/baselines/bandit_medium_high_confidence.json` → zero issues (was 1)
- `tests/trail/test_rekor.py` → 31 passed
- ruff clean (noqa preserved)

One-line change; no baseline edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
