### PR TITLE
fix(agent-bridge): ignore removed preflight temp worktrees

### DIFF
--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -896,6 +896,11 @@ def _is_repo_root_path(path: str) -> bool:
         return False
 
 
+def _is_preflight_temp_worktree_path(path: str) -> bool:
+    worktree = Path(path)
+    return worktree.name.startswith("preflight-preflight-") and worktree.parent.name == ".worktrees"
+
+
 def _lane_identity_values(record: "LaneRecord") -> list[tuple[str, str]]:
     values: list[tuple[str, str]] = []
     if record.pr_number is not None:
@@ -982,6 +987,8 @@ def _collect_health_issues(
             continue
         if not worktree_exists:
             if lifecycle == "historical" and s.name not in active_lane_owners:
+                continue
+            if s.name not in active_lane_owners and _is_preflight_temp_worktree_path(s.worktree):
                 continue
             issues.append(
                 {

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -2494,6 +2494,70 @@ def test_health_ignores_dead_session_with_removed_worktree(
     assert json.loads(capsys.readouterr().out) == {"ok": True, "issues": []}
 
 
+def test_health_ignores_unclaimed_preflight_temp_missing_worktree(
+    tmp_path: Path,
+) -> None:
+    import agent_bridge as mod
+
+    removed_worktree = tmp_path / ".worktrees" / "preflight-preflight-20260612-061500"
+
+    issues = mod._collect_health_issues(
+        [
+            mod.Session(
+                name="codex-019eba4f",
+                agent="codex",
+                status="alive",
+                lifecycle="live",
+                worktree=str(removed_worktree),
+            )
+        ],
+        [],
+    )
+
+    assert issues == []
+
+
+def test_health_reports_claimed_preflight_temp_missing_worktree(
+    tmp_path: Path,
+) -> None:
+    import agent_bridge as mod
+
+    removed_worktree = tmp_path / ".worktrees" / "preflight-preflight-20260612-061500"
+
+    issues = mod._collect_health_issues(
+        [
+            mod.Session(
+                name="codex-019eba4f",
+                agent="codex",
+                status="alive",
+                lifecycle="live",
+                worktree=str(removed_worktree),
+            )
+        ],
+        [
+            mod.LaneRecord(
+                lane_id="preflight",
+                owner_session="codex-019eba4f",
+                status="active",
+                next_action="finish preflight",
+                last_steering_outcome="obeyed",
+                last_heartbeat_at="2026-06-12T06:15:00Z",
+            )
+        ],
+    )
+
+    assert len(issues) == 1
+    issue = issues[0]
+    assert issue["type"] == "stale_worktree"
+    assert issue["session"] == "codex-019eba4f"
+    assert issue["detail"] == f"worktree path missing: {removed_worktree}"
+    assert issue["owner_state"] == "active_or_current_session"
+    assert issue["worktree"] == str(removed_worktree)
+    assert issue["worktree_exists"] is False
+    assert issue["cleanup_state"] == "missing_path_metadata"
+    assert issue["recommended_operator_action"] == "verify lane ownership before pruning metadata"
+
+
 def test_cmd_health_summary_only_json_counts_issue_types(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Treat discarded automation preflight scratch worktrees as non-actionable health metadata unless an active lane still owns the session. This keeps health output focused on real routing blockers while preserving claimed-session protection.

Co-authored-by: codex[bot] <codex[bot]@users.noreply.github.com>
