### PR TITLE
fix(tests): align provider-slot test with mistral-api allowlisting

### DIFF
--- a/tests/review/test_provider_slots.py
+++ b/tests/review/test_provider_slots.py
@@ -47,8 +47,10 @@ def test_provider_slot_resolver_reports_candidate_checks(
     assert resolutions[0].candidate_checks[0].provider == "claude"
     assert resolutions[0].candidate_checks[0].available is True
     assert resolutions[1].status == "available"
-    assert resolutions[1].candidate_checks[0].allowlisted is False
-    assert "not allowlisted by default" in resolutions[1].detail
+    # mistral-api was added to ALLOWED_AGENT_TYPES in d4f488de28 (#7479)
+    assert resolutions[1].candidate_checks[0].allowlisted is True
+    assert "MISTRAL_API_KEY configured" in resolutions[1].detail
+    assert "not allowlisted by default" not in resolutions[1].detail
 
 
 def test_provider_slot_resolver_explains_unavailable_slot(


### PR DESCRIPTION
## Summary
`tests/review/test_provider_slots.py::test_provider_slot_resolver_reports_candidate_checks` fails on `main` in isolation: it still expects `mistral-api` to be outside `ALLOWED_AGENT_TYPES` (`allowlisted is False`, `"not allowlisted by default"` in the slot detail).

`mistral-api` was intentionally added to `ALLOWED_AGENT_TYPES` in d4f488de28 (#7479, *fix(ask): isolate explicit provider credentials*), so the resolver now reports `allowlisted=True` and omits the opt-in suffix. This PR updates the test expectations to match the intended behavior:
- `allowlisted is True`
- positive assertion on `"MISTRAL_API_KEY configured"` in the detail
- negative assertion that the opt-in suffix is gone

No production code changes. This failure predates and is unrelated to #8277.

## Verification
```
PYTHONPATH=.:aragora-debate/src ~/.pyenv/versions/3.11.11/bin/python -m pytest tests/review/test_provider_slots.py -q
3 passed in 0.42s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)