### PR TITLE
fix(tests): debate-nz shard failures — #8185 smoke-test contract + rlm load_dotenv env injection (#8277)

### DIFF
--- a/aragora/agents/registry.py
+++ b/aragora/agents/registry.py
@@ -156,6 +156,15 @@ class AgentFactory:
                 accepts_api_key=accepts_api_key,
             )
             cls._registry[type_name] = spec
+            # Record the spec on the class itself so register_all_agents()
+            # can self-heal a cleared/rebound registry without re-importing
+            # (decorators never re-run while the module is cached in
+            # sys.modules). vars() lookup avoids inheriting a parent's specs.
+            own_specs = vars(agent_cls).get("__registry_specs__")
+            if own_specs is None:
+                own_specs = []
+                setattr(agent_cls, "__registry_specs__", own_specs)
+            own_specs.append(spec)
             return agent_cls
 
         return decorator
@@ -463,6 +472,11 @@ def register_all_agents() -> None:
 
     This function should be called once at startup to ensure
     all agents are registered before create() is used.
+
+    Safe to call repeatedly: if the registry was cleared (or rebound) after
+    the agent modules were first imported, the registrations are re-applied
+    from specs recorded on the agent classes, since the cached modules'
+    @AgentRegistry.register decorators never re-run.
     """
     # Import modules to trigger @register decorators
     # These imports are intentionally side-effect only
@@ -480,3 +494,24 @@ def register_all_agents() -> None:
         from aragora.agents import api_agents  # noqa: F401
     except ImportError:
         logger.debug("api_agents module not available for registration")
+
+    _heal_registry()
+
+
+def _heal_registry() -> None:
+    """Re-apply registrations recorded on already-imported agent classes.
+
+    Only production modules (``aragora.agents.*``) are scanned, so agent
+    classes registered ad hoc by tests are never resurrected. Existing
+    entries are never overwritten, so deliberate overrides survive.
+    """
+    import sys
+
+    for module_name, module in list(sys.modules.items()):
+        if module is None or not module_name.startswith("aragora.agents"):
+            continue
+        for obj in list(vars(module).values()):
+            if not isinstance(obj, type):
+                continue
+            for spec in vars(obj).get("__registry_specs__", ()):
+                AgentFactory._registry.setdefault(spec.name, spec)

--- a/aragora/rlm/bridge.py
+++ b/aragora/rlm/bridge.py
@@ -75,9 +75,14 @@ def _secret_configured(name: str) -> bool:
     return get_secret_presence(name).source in {"aws", "env"}
 
 
-# Check if official RLM is available
+# Check if official RLM is available.
+# preserve_environ: importing rlm triggers a load_dotenv() side effect that
+# can inject a repository .env into os.environ process-wide (#8277).
+from aragora.utils.env import preserve_environ
+
 try:
-    from rlm import RLM as OfficialRLM
+    with preserve_environ():
+        from rlm import RLM as OfficialRLM
 
     HAS_OFFICIAL_RLM = True
 except ImportError:

--- a/aragora/server/handlers/features/rlm.py
+++ b/aragora/server/handlers/features/rlm.py
@@ -771,9 +771,14 @@ class RLMHandler(BaseHandler):
         }
         """
         try:
-            # Check if official RLM is available
+            # Check if official RLM is available.
+            # preserve_environ: importing rlm triggers a load_dotenv() side
+            # effect that can inject a repository .env process-wide (#8277).
             try:
-                import rlm
+                from aragora.utils.env import preserve_environ
+
+                with preserve_environ():
+                    import rlm
 
                 provider = "rlm-library"
                 version = getattr(rlm, "__version__", "unknown")

--- a/aragora/utils/env.py
+++ b/aragora/utils/env.py
@@ -7,6 +7,8 @@ Centralizes environment-variable parsing to avoid scattered ad-hoc checks.
 from __future__ import annotations
 
 import os
+from collections.abc import Iterator
+from contextlib import contextmanager
 
 _TRUTHY = {"1", "true", "yes", "y", "on"}
 _FALSY = {"0", "false", "no", "n", "off"}
@@ -30,4 +32,26 @@ def is_offline_mode() -> bool:
     return is_truthy_env("ARAGORA_OFFLINE", default=False)
 
 
-__all__ = ["is_truthy_env", "is_offline_mode"]
+@contextmanager
+def preserve_environ() -> Iterator[None]:
+    """Roll back any os.environ mutation made inside the block.
+
+    Use around imports of third-party packages with import-time environment
+    side effects. The official ``rlm`` package calls ``dotenv.load_dotenv()``
+    when ``rlm.clients`` is imported; under pytest-xdist (execnet) workers
+    python-dotenv searches from the current working directory upward, so the
+    import can inject a repository ``.env`` (including flags like
+    ARAGORA_SECRETS_STRICT) into the whole process (#8277).
+    """
+    snapshot = dict(os.environ)
+    try:
+        yield
+    finally:
+        for key in set(os.environ) - snapshot.keys():
+            del os.environ[key]
+        for key, value in snapshot.items():
+            if os.environ.get(key) != value:
+                os.environ[key] = value
+
+
+__all__ = ["is_truthy_env", "is_offline_mode", "preserve_environ"]

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -12,13 +12,13 @@
 
 | Metric | Value | Source | Command |
 |---|---|---|---|
-| Python files under aragora/ | `4166` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1954885` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
-| Top-level modules under aragora/ | `141` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5303` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `220387` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
-| @pytest.mark.parametrize decorators | `746` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
-| CLI top-level command modules | `77` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
+| Python files under aragora/ | `4172` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
+| Python lines of code under aragora/ | `1957100` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Top-level modules under aragora/ | `142` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
+| Test files (test_*.py under tests/) | `5326` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `220879` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| @pytest.mark.parametrize decorators | `752` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
+| CLI top-level command modules | `78` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2870` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
 | OpenAPI operations (HTTP verbs) | `3297` | `docs/api/openapi.json` | `python -c "import json; spec=json.load(open('docs/api/openapi.json')); print(sum(1 for p in spec['paths'].values() for m in p if m.lower() in {'get','post','put','delete','patch','head','options'}))"` |
 | @require_permission decorator calls | `1365` | `aragora/` | `git grep -E '@require_permission\(' -- aragora \| wc -l` |
@@ -28,7 +28,7 @@
 | Allowlisted agent types | `35` | `aragora/config/settings.py` | `grep -A 50 'ALLOWED_AGENT_TYPES' aragora/config/settings.py \| grep -oE "'[a-z-]+'" \| sort -u \| wc -l` |
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `46` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |
-| Markdown files under docs/ | `983` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
+| Markdown files under docs/ | `989` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
 | GitHub Actions workflows | `88` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
 | Mypy baseline errors (grandfathered) | `3115` | `.mypy-baseline` | `wc -l .mypy-baseline` |
 

--- a/tests/agents/test_registry.py
+++ b/tests/agents/test_registry.py
@@ -771,6 +771,55 @@ class TestRegisterAllAgents:
             AgentRegistry._registry.clear()
             AgentRegistry._registry.update(original)
 
+    def test_register_all_agents_self_heals_cleared_registry(self):
+        """A cleared registry is repopulated even when agent modules are cached.
+
+        Regression test for #8277: under xdist a test that clears (or rebinds)
+        AgentFactory._registry used to permanently break agent lookup for the
+        rest of the worker, because aragora.agents.cli_agents stays cached in
+        sys.modules so its @AgentRegistry.register decorators never re-run.
+        """
+        from aragora.agents.registry import AgentRegistry, register_all_agents
+
+        register_all_agents()
+        assert AgentRegistry.is_registered("claude")
+
+        AgentRegistry.clear()
+        assert not AgentRegistry.is_registered("claude")
+
+        register_all_agents()
+        assert AgentRegistry.is_registered("claude")
+        assert AgentRegistry.is_registered("openai")
+
+    def test_register_all_agents_self_heals_rebound_registry(self):
+        """Healing also works when _registry was replaced with a new dict."""
+        from aragora.agents.registry import AgentRegistry, register_all_agents
+
+        register_all_agents()
+        AgentRegistry._registry = {}
+
+        register_all_agents()
+        assert AgentRegistry.is_registered("claude")
+
+    def test_register_all_agents_does_not_clobber_existing_entries(self):
+        """Healing only fills gaps; deliberate overrides are preserved."""
+        from aragora.agents.registry import AgentRegistry, RegistrySpec, register_all_agents
+
+        register_all_agents()
+        sentinel = RegistrySpec(
+            name="claude",
+            agent_class=object,
+            default_model=None,
+            default_name="claude",
+            agent_type="CLI",
+            requires=None,
+            env_vars=None,
+        )
+        AgentRegistry._registry["claude"] = sentinel
+
+        register_all_agents()
+        assert AgentRegistry.get_spec("claude") is sentinel
+
 
 # =============================================================================
 # Module Exports Tests

--- a/tests/debate/test_pr_review_protocol_smoke.py
+++ b/tests/debate/test_pr_review_protocol_smoke.py
@@ -5,11 +5,33 @@ import pytest
 from aragora.swarm.pr_review_protocol import (
     PROTOCOL_STATUS,
     RECOMMEND_ATTENTION,
+    PRReviewerExecutionFailure,
     default_pr_review_protocol,
 )
 
+_PACKET_KWARGS = dict(
+    repo="synaptent/aragora",
+    pr_number=6355,
+    title="Add PR review protocol scaffold",
+    base_sha="base123",
+    head_sha="head456",
+    mergeable="MERGEABLE",
+    review_decision="REVIEW_REQUIRED",
+    checks_summary="2 pending / 10 total",
+    has_failures=False,
+    has_pending=True,
+    additions=650,
+    deletions=20,
+    changed_files=5,
+    labels=["parked"],
+    high_risk_paths=["aragora/swarm/pr_review_protocol.py"],
+    validation_commands=["python -m pytest tests/debate/test_pr_review_protocol_smoke.py -q"],
+    machine_recommendation=RECOMMEND_ATTENTION,
+    machine_recommendation_reason="metadata-derived attention recommendation",
+)
 
-def test_pr_review_protocol_packet_smoke(monkeypatch: pytest.MonkeyPatch) -> None:
+
+def _mock_provider_availability(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     monkeypatch.setenv("MISTRAL_API_KEY", "test-key")
 
@@ -21,36 +43,52 @@ def test_pr_review_protocol_packet_smoke(monkeypatch: pytest.MonkeyPatch) -> Non
 
     monkeypatch.setattr("aragora.review.provider_slots.shutil.which", fake_which)
 
-    packet = default_pr_review_protocol().build_packet(
-        repo="synaptent/aragora",
-        pr_number=6355,
-        title="Add PR review protocol scaffold",
-        base_sha="base123",
-        head_sha="head456",
-        mergeable="MERGEABLE",
-        review_decision="REVIEW_REQUIRED",
-        checks_summary="2 pending / 10 total",
-        has_failures=False,
-        has_pending=True,
-        additions=650,
-        deletions=20,
-        changed_files=5,
-        labels=["parked"],
-        high_risk_paths=["aragora/swarm/pr_review_protocol.py"],
-        validation_commands=["python -m pytest tests/debate/test_pr_review_protocol_smoke.py -q"],
-        machine_recommendation=RECOMMEND_ATTENTION,
-        machine_recommendation_reason="metadata-derived attention recommendation",
-    )
+
+def test_pr_review_protocol_packet_smoke() -> None:
+    """Metadata-only packets must not probe provider availability (#8185)."""
+    packet = default_pr_review_protocol().build_packet(**_PACKET_KWARGS)
 
     assert packet.status == PROTOCOL_STATUS
     assert packet.binding.pr_number == 6355
     assert packet.recommendation_class == RECOMMEND_ATTENTION
+    assert len(packet.provider_slots) == 5
+    for slot in packet.provider_slots:
+        assert slot.selected_provider is None
+        assert slot.status == "not_probed"
+        assert slot.candidate_checks == []
+    assert packet.provider_slots[0].candidates == ["claude", "anthropic-api"]
+    assert packet.provider_slots[4].candidates == ["mistral-api", "mistral"]
+    assert packet.top_findings
+    assert packet.top_findings[0].source == PROTOCOL_STATUS
+    assert packet.validation_summary["has_pending"] is True
+    assert packet.to_dict()["binding"]["head_sha"] == "head456"
+
+
+def test_pr_review_protocol_packet_probes_providers_for_live_results(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Packets carrying live reviewer results resolve real provider slots."""
+    _mock_provider_availability(monkeypatch)
+
+    packet = default_pr_review_protocol().build_packet(
+        **_PACKET_KWARGS,
+        execution_failures=[
+            PRReviewerExecutionFailure(
+                slot_id="logic",
+                review_role="logic_reviewer",
+                provider="claude",
+                reason="reviewer timed out",
+            )
+        ],
+    )
+
+    assert packet.status == f"{PROTOCOL_STATUS}_fallback_execution_failed"
+    assert packet.binding.pr_number == 6355
     assert len(packet.provider_slots) == 5
     assert packet.provider_slots[0].selected_provider == "claude"
     assert packet.provider_slots[1].selected_provider == "openai-api"
     assert packet.provider_slots[2].selected_provider == "gemini-cli"
     assert packet.provider_slots[4].selected_provider == "mistral-api"
     assert packet.top_findings
-    assert packet.top_findings[0].source == PROTOCOL_STATUS
     assert packet.validation_summary["has_pending"] is True
     assert packet.to_dict()["binding"]["head_sha"] == "head456"

--- a/tests/utils/test_preserve_environ.py
+++ b/tests/utils/test_preserve_environ.py
@@ -1,0 +1,58 @@
+"""Tests for aragora.utils.env.preserve_environ.
+
+Regression coverage for #8277: the official ``rlm`` package calls
+``dotenv.load_dotenv()`` at import time, which under pytest-xdist workers
+resolves from the current working directory upward and can inject a
+repository ``.env`` (e.g. ARAGORA_SECRETS_STRICT=true) into ``os.environ``
+process-wide. ``preserve_environ`` wraps such imports so any environment
+mutation is rolled back.
+"""
+
+from __future__ import annotations
+
+import os
+
+from aragora.utils.env import preserve_environ
+
+
+def test_added_keys_are_removed() -> None:
+    key = "PRESERVE_ENVIRON_TEST_ADDED"
+    assert key not in os.environ
+    with preserve_environ():
+        os.environ[key] = "injected"
+    assert key not in os.environ
+
+
+def test_changed_keys_are_restored(monkeypatch) -> None:
+    key = "PRESERVE_ENVIRON_TEST_CHANGED"
+    monkeypatch.setenv(key, "original")
+    with preserve_environ():
+        os.environ[key] = "mutated"
+    assert os.environ[key] == "original"
+
+
+def test_deleted_keys_are_restored(monkeypatch) -> None:
+    key = "PRESERVE_ENVIRON_TEST_DELETED"
+    monkeypatch.setenv(key, "original")
+    with preserve_environ():
+        del os.environ[key]
+    assert os.environ[key] == "original"
+
+
+def test_restores_on_exception() -> None:
+    key = "PRESERVE_ENVIRON_TEST_EXC"
+    assert key not in os.environ
+    try:
+        with preserve_environ():
+            os.environ[key] = "injected"
+            raise RuntimeError("boom")
+    except RuntimeError:
+        pass
+    assert key not in os.environ
+
+
+def test_untouched_environment_is_unchanged() -> None:
+    before = dict(os.environ)
+    with preserve_environ():
+        pass
+    assert dict(os.environ) == before


### PR DESCRIPTION
Fixes #8277

## What the issue thought was happening
#8277 attributed the `test_pr_review_protocol_packet_smoke` failure to xdist test pollution emptying `AgentFactory._registry`. That diagnosis doesn't hold: the test fails **in isolation** at the issue's own repro commit (3e8450d52b). Verified by bisection: passes at 58251e67c4^, fails at 58251e67c4.

## What is actually happening (two independent bugs)

**Bug 1 — deterministic test break by #8185.** Commit 58251e67c4 routes `build_packet()` without live reviewer results through `metadata_provider_slots()`, which intentionally skips provider probing (`selected_provider=None`, `status="not_probed"`). The smoke test still asserted probed selections.

**Bug 2 — real worker-wide env pollution, but not the registry.** The official `rlm` package calls `dotenv.load_dotenv()` when `rlm.clients` is imported. Under pytest-xdist, execnet workers' `__main__` has no `__file__`, so python-dotenv's `find_dotenv()` treats the process as interactive and searches **from cwd upward** — loading the repository `.env` (including `ARAGORA_SECRETS_STRICT=true`) into `os.environ` of every worker at conftest-import time (chain: tests/conftest.py → slack handlers → rbac → control_plane → knowledge → documents.chunking → aragora.rlm.bridge → rlm). Strict secrets mode then makes `get_secret()` raise `SecretNotFoundError` for critical secrets instead of using env vars, which failed every test touching the provider-credential path. Single-process runs search from site-packages and find nothing — hence "fails in shard, passes in isolation". This explains all 9 debate-nz failures observed on origin/main locally (pinpointed by tracing `os._Environ.__setitem__` with stack capture).

## Changes
- **Smoke test updated** to assert the post-#8185 metadata-only contract; a second test passes `execution_failures` to exercise the probed branch and keeps the original provider-selection assertions.
- **`aragora.utils.env.preserve_environ()`** context manager wraps both official-rlm import sites (`aragora/rlm/bridge.py`, `aragora/server/handlers/features/rlm.py`), rolling back any import-time env mutation. This also fixes a production-grade issue: importing `aragora.knowledge` from any directory under a tree containing `.env` mutated process env.
- **Defense-in-depth requested by the issue:** `register_all_agents()` is now self-healing — `@AgentRegistry.register` records each spec on the agent class, and a healing pass re-applies specs from already-imported `aragora.agents.*` modules, so a cleared or rebound `AgentFactory._registry` recovers despite `sys.modules` caching. Existing entries are never overwritten; test-defined agents (in `tests.*`) are never resurrected.

## Verification
3 consecutive full debate-nz shard runs (exact CI command, pyenv 3.11, `-n auto --dist loadscope`):
- Run 1: **5642 passed, 2 skipped** (1:43)
- Run 2: **5642 passed, 2 skipped** (2:26)
- Run 3: **5642 passed, 2 skipped** (2:58)

Baseline on clean origin/main with the same command: **9 failed** (incl. structural_rhetoric ×4, post_debate_pipeline_bridge ×3, post_debate_workflow_fallback ×1 — all the same strict-mode pollution).

New unit coverage: `tests/utils/test_preserve_environ.py` (5 tests), 3 self-healing registry tests in `tests/agents/test_registry.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)