### PR TITLE
fix(automation): archive existing_issue-decided open-PR handoffs with terminal receipts — resolves outbox archival deadlock

### DIFF
--- a/scripts/reconcile_automation_outbox.py
+++ b/scripts/reconcile_automation_outbox.py
@@ -47,6 +47,17 @@ DEFAULT_OUTBOX_DIR = Path(".aragora/automation-outbox")
 DEFAULT_RECEIPT_DIR = Path(".aragora/automation-receipts")
 DEFAULT_ARCHIVE_DIR = Path(".aragora/automation-outbox-archive")
 
+# Bounded terminal-archive policy for the existing_issue deadlock:
+# the publisher refuses to open a duplicate PR because a GitHub issue already
+# tracks the task (receipt reason "existing_issue"), while the reconciler
+# refuses to archive PR-intent handoffs satisfied only by an issue receipt.
+# Neither side ever clears the handoff. The escape valve below archives such
+# handoffs with an explicit terminal receipt, but only when ALL gates hold:
+# verified issue state, minimum item age, and a per-pass archive cap.
+DEFAULT_EXISTING_ISSUE_MIN_AGE_DAYS = 3.0
+DEFAULT_EXISTING_ISSUE_ARCHIVE_CAP = 20
+TERMINAL_DISPOSITION_EXISTING_ISSUE = "superseded_by_existing_issue"
+
 
 def _load_json(path: Path) -> dict[str, Any] | None:
     try:
@@ -389,6 +400,213 @@ def _issue_only_pr_receipt_keep_reason(
     return None
 
 
+def _issue_url_from_receipt(receipt: Mapping[str, Any]) -> str:
+    for key in ("existing_issue_url", "created_issue_url", "issue_url"):
+        url = str(receipt.get(key) or "").strip()
+        if url:
+            return url
+    return ""
+
+
+def _issue_number_from_url(url: str) -> int | None:
+    text = str(url or "").strip().rstrip("/")
+    marker = "/issues/"
+    if marker not in text:
+        return None
+    candidate = text.rsplit(marker, 1)[1].split("/", 1)[0]
+    return int(candidate) if candidate.isdigit() else None
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _outbox_item_age_days(path: Path, payload: Mapping[str, Any], now: datetime) -> float | None:
+    """Age of an outbox handoff, preferring payload timestamps over file mtime."""
+    for key in ("created_at", "updated_at"):
+        timestamp = _parse_timestamp(payload.get(key))
+        if timestamp is not None:
+            return (now - timestamp).total_seconds() / 86400.0
+    try:
+        mtime = path.stat().st_mtime
+    except OSError:
+        return None
+    return (now - datetime.fromtimestamp(mtime, tz=UTC)).total_seconds() / 86400.0
+
+
+class _IssueStateChecker:
+    """Verify linked GitHub issue state via gh, with caching and a failure circuit.
+
+    After MAX_CONSECUTIVE_FAILURES consecutive gh errors the checker stops
+    issuing new calls and reports issues as unverifiable, so a GitHub outage
+    cannot turn one reconcile pass into hundreds of 20s timeouts.
+    """
+
+    MAX_CONSECUTIVE_FAILURES = 3
+
+    def __init__(self, root: Path, default_repo: str) -> None:
+        self._root = root
+        self._default_repo = default_repo
+        self._cache: dict[tuple[str, int], tuple[Mapping[str, Any] | None, str | None]] = {}
+        self._consecutive_failures = 0
+
+    def state(
+        self, issue_url: str, receipt: Mapping[str, Any]
+    ) -> tuple[Mapping[str, Any] | None, str | None]:
+        """Return (issue_state, error). issue_state is None when unverifiable."""
+        number = _issue_number_from_url(issue_url)
+        if number is None:
+            return None, f"could not parse issue number from {issue_url!r}"
+        repo = str(receipt.get("repo") or self._default_repo).strip() or self._default_repo
+        cache_key = (repo, number)
+        if cache_key in self._cache:
+            return self._cache[cache_key]
+        if self._consecutive_failures >= self.MAX_CONSECUTIVE_FAILURES:
+            return None, "issue state lookups disabled after repeated gh failures"
+        result = self._fetch(repo, number)
+        if result[0] is None:
+            self._consecutive_failures += 1
+        else:
+            self._consecutive_failures = 0
+        self._cache[cache_key] = result
+        return result
+
+    def _fetch(self, repo: str, number: int) -> tuple[Mapping[str, Any] | None, str | None]:
+        try:
+            proc = subprocess.run(
+                [
+                    "gh",
+                    "issue",
+                    "view",
+                    str(number),
+                    "--repo",
+                    repo,
+                    "--json",
+                    "number,state,stateReason,url",
+                ],
+                cwd=self._root,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=20,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            return None, f"gh issue view failed ({exc.__class__.__name__})"
+        if proc.returncode != 0:
+            detail = (proc.stderr or "").strip().splitlines()
+            return None, f"gh issue view exited {proc.returncode}: {detail[0] if detail else ''}"
+        try:
+            payload = json.loads(proc.stdout)
+        except json.JSONDecodeError:
+            return None, "gh issue view returned unparseable JSON"
+        if not isinstance(payload, Mapping):
+            return None, "gh issue view returned non-mapping JSON"
+        return payload, None
+
+
+def _existing_issue_terminal_candidate(
+    *,
+    path: Path,
+    payload: Mapping[str, Any],
+    receipt: Mapping[str, Any],
+    min_age_days: float,
+    cap: int,
+    archived_so_far: int,
+    issue_checker: _IssueStateChecker,
+    now: datetime | None = None,
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Evaluate the bounded existing_issue terminal-archive escape valve.
+
+    Returns (terminal_info, gate_detail):
+      (info, None)    -- ALL gates hold; archive with this terminal receipt.
+      (None, detail)  -- in scope but a gate blocked it; keep, annotated.
+      (None, None)    -- out of scope; the normal issue-only keep applies.
+    """
+    if not _is_pr_publication_request(payload):
+        return None, None
+    status = str(receipt.get("status") or "").strip().lower()
+    reason = str(receipt.get("reason") or "").strip().lower()
+    if status != "already_satisfied" or reason != "existing_issue":
+        return None, None
+    if _receipt_has_pr_reference(receipt):
+        return None, None
+    issue_url = _issue_url_from_receipt(receipt)
+    if not issue_url:
+        return None, None
+
+    now_value = now or datetime.now(UTC)
+    age_days = _outbox_item_age_days(path, payload, now_value)
+    if age_days is None:
+        return None, "terminal-archive gate: item age unknown"
+    if age_days < min_age_days:
+        return None, (f"terminal-archive gate: item age {age_days:.1f}d < min {min_age_days:.1f}d")
+    if archived_so_far >= cap:
+        return None, f"terminal-archive gate: per-pass archive cap {cap} reached"
+
+    issue_state, error = issue_checker.state(issue_url, receipt)
+    if issue_state is None:
+        return None, f"terminal-archive gate: issue state unverified ({error})"
+    state = str(issue_state.get("state") or "").strip().upper()
+    state_reason = str(issue_state.get("stateReason") or "").strip().upper()
+    if state != "OPEN" and not (state == "CLOSED" and state_reason == "COMPLETED"):
+        return None, (
+            f"terminal-archive gate: issue {issue_url} is "
+            f"{state or 'UNKNOWN'}/{state_reason or 'unknown'}, not open or closed-completed"
+        )
+
+    terminal_info: dict[str, Any] = {
+        "disposition": TERMINAL_DISPOSITION_EXISTING_ISSUE,
+        "issue_url": str(issue_state.get("url") or issue_url),
+        "issue_number": issue_state.get("number"),
+        "issue_state": state,
+        "issue_state_reason": state_reason or None,
+        "issue_state_checked_at": now_value.isoformat(),
+        "decision_evidence": {
+            "publisher_decision": "existing_issue",
+            "receipt_status": status,
+            "receipt_reason": reason,
+            "receipt_recorded_at": receipt.get("recorded_at"),
+            "receipt_idempotency_key": receipt.get("idempotency_key"),
+        },
+        "item_age_days": round(age_days, 2),
+        "min_age_days": min_age_days,
+        "per_pass_archive_cap": cap,
+        "archived_by": "scripts/reconcile_automation_outbox.py",
+    }
+    return terminal_info, None
+
+
+def _archive_with_terminal_disposition(
+    path: Path,
+    archive_dir: Path,
+    payload: Mapping[str, Any],
+    terminal_info: Mapping[str, Any],
+) -> Path:
+    """Archive an outbox handoff with an explicit terminal receipt embedded.
+
+    The archived copy is written first (with terminal_disposition populated)
+    and only then is the live outbox file removed, so a failure can never
+    delete a handoff without its terminal receipt landing in the archive.
+    """
+    archived = {key: value for key, value in payload.items() if key != "__source_file"}
+    archived["terminal_disposition"] = dict(terminal_info)
+    destination = archive_dir / path.name
+    destination.write_text(json.dumps(archived, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    path.unlink()
+    return destination
+
+
 def _heads_match(expected: str, actual: str) -> bool:
     expected_value = expected.strip().lower()
     actual_value = actual.strip().lower()
@@ -628,6 +846,25 @@ def main(argv: list[str] | None = None) -> int:
             "the selected outbox directory; repeat to target multiple handoffs."
         ),
     )
+    parser.add_argument(
+        "--existing-issue-min-age-days",
+        type=float,
+        default=DEFAULT_EXISTING_ISSUE_MIN_AGE_DAYS,
+        help=(
+            "Minimum handoff age (days) before an open-PR handoff whose publisher "
+            "decision was existing_issue may be archived with a terminal receipt "
+            f"(default: {DEFAULT_EXISTING_ISSUE_MIN_AGE_DAYS})."
+        ),
+    )
+    parser.add_argument(
+        "--existing-issue-archive-cap",
+        type=int,
+        default=DEFAULT_EXISTING_ISSUE_ARCHIVE_CAP,
+        help=(
+            "Maximum existing_issue terminal archives per reconcile pass "
+            f"(default: {DEFAULT_EXISTING_ISSUE_ARCHIVE_CAP})."
+        ),
+    )
     mode = parser.add_mutually_exclusive_group()
     mode.add_argument(
         "--apply",
@@ -775,6 +1012,7 @@ def main(argv: list[str] | None = None) -> int:
 
     counts = {
         "satisfied_by_existing_receipt": 0,
+        "archived_superseded_by_existing_issue": 0,
         "blocked_receipt_pr_head_mismatch": 0,
         "blocked_receipt_issue_only": 0,
         "satisfied_by_superseded_handoff": 0,
@@ -785,6 +1023,9 @@ def main(argv: list[str] | None = None) -> int:
         "blocked_missing_branch_open_pr_unknown": 0,
         "skipped_unparseable": 0,
     }
+
+    issue_checker = _IssueStateChecker(root, args.repo_name)
+    existing_issue_archived = 0
 
     actions: list[dict[str, Any]] = []
     for path in outbox_files:
@@ -804,6 +1045,41 @@ def main(argv: list[str] | None = None) -> int:
         if receipt is not None:
             issue_only_keep_reason = _issue_only_pr_receipt_keep_reason(payload, receipt)
             if issue_only_keep_reason is not None:
+                terminal_info, gate_detail = _existing_issue_terminal_candidate(
+                    path=path,
+                    payload=payload,
+                    receipt=receipt,
+                    min_age_days=args.existing_issue_min_age_days,
+                    cap=args.existing_issue_archive_cap,
+                    archived_so_far=existing_issue_archived,
+                    issue_checker=issue_checker,
+                )
+                if terminal_info is not None:
+                    existing_issue_archived += 1
+                    counts["archived_superseded_by_existing_issue"] += 1
+                    actions.append(
+                        {
+                            "path": str(path),
+                            "branch": branch,
+                            "decision": "archive",
+                            "reason": (
+                                "superseded by existing issue "
+                                f"{terminal_info['issue_url']} (terminal receipt)"
+                            ),
+                            "terminal_disposition": terminal_info,
+                            "synthetic_receipt": False,
+                        }
+                    )
+                    if args.apply:
+                        _archive_with_terminal_disposition(
+                            path, archive_dir, payload, terminal_info
+                        )
+                    continue
+                issue_only_kept_reason = (
+                    issue_only_keep_reason
+                    if gate_detail is None
+                    else f"{issue_only_keep_reason} ({gate_detail})"
+                )
                 counts["blocked_receipt_issue_only"] += 1
                 counts["still_protecting_active_work"] += 1
                 actions.append(
@@ -811,7 +1087,7 @@ def main(argv: list[str] | None = None) -> int:
                         "path": str(path),
                         "branch": branch,
                         "decision": "keep",
-                        "reason": issue_only_keep_reason,
+                        "reason": issue_only_kept_reason,
                         "synthetic_receipt": False,
                     }
                 )
@@ -1125,6 +1401,12 @@ def main(argv: list[str] | None = None) -> int:
             "base": args.base,
             "counts": counts,
             "dry_run": not args.apply,
+            "existing_issue_policy": {
+                "archive_cap": args.existing_issue_archive_cap,
+                "archived_this_pass": existing_issue_archived,
+                "min_age_days": args.existing_issue_min_age_days,
+                "terminal_disposition": TERMINAL_DISPOSITION_EXISTING_ISSUE,
+            },
             "kept": kept,
             "outbox_count": len(outbox_files),
             "outbox_dir": str(outbox_dir),

--- a/tests/scripts/test_reconcile_automation_outbox.py
+++ b/tests/scripts/test_reconcile_automation_outbox.py
@@ -1205,3 +1205,260 @@ def test_patch_equivalent_target_pr_receipt_archives_before_remote_check(
     assert (
         payload["actions"][0]["reason"] == "branch work landed on main (merge or patch-equivalent)"
     )
+
+
+def _write_existing_issue_deadlock_fixture(
+    tmp_path: Path,
+    *,
+    key: str = "open-pr-codex-existing-issue-deadlock-abc123",
+    branch: str = "codex/existing-issue-deadlock",
+    created_at: str = "2026-06-01T00:00:00+00:00",
+    issue_url: str = "https://github.com/synaptent/aragora/issues/7808",
+    receipt_reason: str = "existing_issue",
+    receipt_status: str = "already_satisfied",
+) -> tuple[Path, Path]:
+    """Write an outbox handoff + receipt pair representing the archival deadlock."""
+    outbox_dir = tmp_path / ".aragora" / "automation-outbox"
+    receipt_dir = tmp_path / ".aragora" / "automation-receipts"
+    handoff = _write_outbox_handoff(outbox_dir, branch=branch, key=key)
+    payload = json.loads(handoff.read_text(encoding="utf-8"))
+    payload["requested_action"] = {
+        "type": "open_or_update_pr",
+        "base": "main",
+        "branch": branch,
+        "desired_head_sha": "abcdef1234567890abcdef1234567890abcdef12",
+    }
+    payload["created_at"] = created_at
+    handoff.write_text(json.dumps(payload), encoding="utf-8")
+    receipt_dir.mkdir(parents=True, exist_ok=True)
+    receipt_path = receipt_dir / f"{key}.json"
+    receipt_path.write_text(
+        json.dumps(
+            {
+                "idempotency_key": key,
+                "status": receipt_status,
+                "reason": receipt_reason,
+                "existing_issue_url": issue_url,
+                "existing_pr_url": None,
+                "recorded_at": "2026-06-12T02:00:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+    return handoff, receipt_path
+
+
+def _issue_state_response(
+    *,
+    number: int = 7808,
+    state: str = "OPEN",
+    state_reason: str = "",
+    url: str = "https://github.com/synaptent/aragora/issues/7808",
+) -> dict[str, Any]:
+    return {"number": number, "state": state, "stateReason": state_reason, "url": url}
+
+
+def _patch_issue_state(monkeypatch: Any, response: dict[str, Any] | None) -> list[Any]:
+    """Patch the gh-backed issue lookup; record calls. None simulates gh failure."""
+    calls: list[Any] = []
+
+    def fake_fetch(self: Any, repo: str, number: int) -> tuple[dict[str, Any] | None, str | None]:
+        calls.append((repo, number))
+        if response is None:
+            return None, "gh issue view exited 1: connectivity failed"
+        return response, None
+
+    monkeypatch.setattr(mod._IssueStateChecker, "_fetch", fake_fetch)
+    return calls
+
+
+def test_existing_issue_deadlock_archives_with_terminal_receipt(
+    tmp_path: Path, monkeypatch: Any, capsys: Any
+) -> None:
+    handoff, _receipt = _write_existing_issue_deadlock_fixture(tmp_path)
+    calls = _patch_issue_state(monkeypatch, _issue_state_response())
+    archive_dir = tmp_path / ".aragora" / "automation-outbox-archive"
+
+    assert mod.main(["--repo", str(tmp_path), "--apply", "--json"]) == 0
+
+    result = json.loads(capsys.readouterr().out)
+    assert result["counts"]["archived_superseded_by_existing_issue"] == 1
+    assert result["counts"]["blocked_receipt_issue_only"] == 0
+    assert calls == [("synaptent/aragora", 7808)]
+    assert not handoff.exists()
+
+    archived = json.loads((archive_dir / handoff.name).read_text(encoding="utf-8"))
+    disposition = archived["terminal_disposition"]
+    assert disposition["disposition"] == "superseded_by_existing_issue"
+    assert disposition["issue_url"] == "https://github.com/synaptent/aragora/issues/7808"
+    assert disposition["issue_state"] == "OPEN"
+    assert disposition["decision_evidence"]["publisher_decision"] == "existing_issue"
+    assert disposition["decision_evidence"]["receipt_reason"] == "existing_issue"
+    assert disposition["item_age_days"] >= 3.0
+    assert disposition["issue_state_checked_at"]
+    assert "__source_file" not in archived
+
+
+def test_existing_issue_archive_accepts_closed_completed_issue(
+    tmp_path: Path, monkeypatch: Any, capsys: Any
+) -> None:
+    handoff, _receipt = _write_existing_issue_deadlock_fixture(tmp_path)
+    _patch_issue_state(monkeypatch, _issue_state_response(state="CLOSED", state_reason="COMPLETED"))
+
+    assert mod.main(["--repo", str(tmp_path), "--apply", "--json"]) == 0
+
+    result = json.loads(capsys.readouterr().out)
+    assert result["counts"]["archived_superseded_by_existing_issue"] == 1
+    assert not handoff.exists()
+
+
+def test_existing_issue_archive_refuses_not_planned_issue(
+    tmp_path: Path, monkeypatch: Any, capsys: Any
+) -> None:
+    handoff, _receipt = _write_existing_issue_deadlock_fixture(tmp_path)
+    _patch_issue_state(
+        monkeypatch, _issue_state_response(state="CLOSED", state_reason="NOT_PLANNED")
+    )
+
+    assert mod.main(["--repo", str(tmp_path), "--apply", "--json"]) == 0
+
+    result = json.loads(capsys.readouterr().out)
+    assert result["counts"]["archived_superseded_by_existing_issue"] == 0
+    assert result["counts"]["blocked_receipt_issue_only"] == 1
+    assert result["counts"]["still_protecting_active_work"] == 1
+    assert handoff.exists()
+    assert "CLOSED/NOT_PLANNED" in result["actions"][0]["reason"]
+
+
+def test_existing_issue_archive_refuses_when_issue_state_unverifiable(
+    tmp_path: Path, monkeypatch: Any, capsys: Any
+) -> None:
+    handoff, _receipt = _write_existing_issue_deadlock_fixture(tmp_path)
+    _patch_issue_state(monkeypatch, None)
+
+    assert mod.main(["--repo", str(tmp_path), "--apply", "--json"]) == 0
+
+    result = json.loads(capsys.readouterr().out)
+    assert result["counts"]["archived_superseded_by_existing_issue"] == 0
+    assert result["counts"]["blocked_receipt_issue_only"] == 1
+    assert handoff.exists()
+    assert "issue state unverified" in result["actions"][0]["reason"]
+
+
+def test_existing_issue_archive_refuses_young_items(
+    tmp_path: Path, monkeypatch: Any, capsys: Any
+) -> None:
+    from datetime import datetime, timedelta
+
+    recent = (datetime.now(mod.UTC) - timedelta(hours=6)).isoformat()
+    handoff, _receipt = _write_existing_issue_deadlock_fixture(tmp_path, created_at=recent)
+    calls = _patch_issue_state(monkeypatch, _issue_state_response())
+
+    assert mod.main(["--repo", str(tmp_path), "--apply", "--json"]) == 0
+
+    result = json.loads(capsys.readouterr().out)
+    assert result["counts"]["archived_superseded_by_existing_issue"] == 0
+    assert result["counts"]["blocked_receipt_issue_only"] == 1
+    assert handoff.exists()
+    assert calls == []  # age gate blocks before any gh call
+    assert "item age" in result["actions"][0]["reason"]
+
+
+def test_existing_issue_archive_honors_per_pass_cap(
+    tmp_path: Path, monkeypatch: Any, capsys: Any
+) -> None:
+    handoffs = []
+    for index in range(3):
+        handoff, _receipt = _write_existing_issue_deadlock_fixture(
+            tmp_path,
+            key=f"open-pr-codex-existing-issue-cap-{index:02d}",
+            branch=f"codex/existing-issue-cap-{index}",
+        )
+        handoffs.append(handoff)
+    _patch_issue_state(monkeypatch, _issue_state_response())
+
+    assert (
+        mod.main(
+            [
+                "--repo",
+                str(tmp_path),
+                "--apply",
+                "--json",
+                "--existing-issue-archive-cap",
+                "2",
+            ]
+        )
+        == 0
+    )
+
+    result = json.loads(capsys.readouterr().out)
+    assert result["counts"]["archived_superseded_by_existing_issue"] == 2
+    assert result["counts"]["blocked_receipt_issue_only"] == 1
+    assert result["existing_issue_policy"]["archived_this_pass"] == 2
+    assert sum(1 for h in handoffs if h.exists()) == 1
+    capped = [a for a in result["actions"] if "per-pass archive cap 2 reached" in a["reason"]]
+    assert len(capped) == 1 and capped[0]["decision"] == "keep"
+
+
+def test_existing_issue_dry_run_lists_would_archive_without_moving(
+    tmp_path: Path, monkeypatch: Any, capsys: Any
+) -> None:
+    handoff, _receipt = _write_existing_issue_deadlock_fixture(tmp_path)
+    _patch_issue_state(monkeypatch, _issue_state_response())
+    archive_dir = tmp_path / ".aragora" / "automation-outbox-archive"
+
+    assert mod.main(["--repo", str(tmp_path), "--json"]) == 0
+
+    result = json.loads(capsys.readouterr().out)
+    assert result["dry_run"] is True
+    assert result["counts"]["archived_superseded_by_existing_issue"] == 1
+    action = result["actions"][0]
+    assert action["decision"] == "archive"
+    assert action["terminal_disposition"]["disposition"] == "superseded_by_existing_issue"
+    assert handoff.exists()
+    assert not archive_dir.exists() or not list(archive_dir.iterdir())
+
+
+def test_existing_issue_valve_ignores_non_existing_issue_receipts(
+    tmp_path: Path, monkeypatch: Any, capsys: Any
+) -> None:
+    """The new path must never archive an item whose decision is not existing_issue."""
+    handoff, _receipt = _write_existing_issue_deadlock_fixture(
+        tmp_path, receipt_reason="created_issue"
+    )
+    calls = _patch_issue_state(monkeypatch, _issue_state_response())
+
+    assert mod.main(["--repo", str(tmp_path), "--apply", "--json"]) == 0
+
+    result = json.loads(capsys.readouterr().out)
+    assert result["counts"]["archived_superseded_by_existing_issue"] == 0
+    assert result["counts"]["blocked_receipt_issue_only"] == 1
+    assert handoff.exists()
+    assert calls == []
+
+
+def test_issue_state_checker_circuit_stops_after_repeated_failures(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    checker = mod._IssueStateChecker(tmp_path, "synaptent/aragora")
+    attempts: list[int] = []
+
+    def failing_fetch(
+        self: Any, repo: str, number: int
+    ) -> tuple[dict[str, Any] | None, str | None]:
+        attempts.append(number)
+        return None, "boom"
+
+    monkeypatch.setattr(mod._IssueStateChecker, "_fetch", failing_fetch)
+    for number in range(1, 6):
+        state, error = checker.state(f"https://github.com/synaptent/aragora/issues/{number}", {})
+        assert state is None
+        assert error
+    assert attempts == [1, 2, 3]
+
+
+def test_issue_number_from_url_parsing() -> None:
+    assert mod._issue_number_from_url("https://github.com/o/r/issues/123") == 123
+    assert mod._issue_number_from_url("https://github.com/o/r/issues/123/") == 123
+    assert mod._issue_number_from_url("https://github.com/o/r/pull/123") is None
+    assert mod._issue_number_from_url("") is None


### PR DESCRIPTION
## Problem (DRAIN2 diagnosis, 2026-06-12 04:48 pass)

Outbox sentinel breach: **132 items vs max 50**. The publisher inspected 121 items, eligible 0 — 120 decided \`existing_issue\` (a GitHub issue already tracks the task, so the publisher correctly refuses a duplicate PR), but \`scripts/reconcile_automation_outbox.py\` refuses to archive open-PR action keys satisfied only by an issue receipt. Neither side ever clears them; items age toward 14-day expiry.

A repair handoff for the protective half of this policy sits in the outbox itself: \`open-pr-codex-reconcile-requested-action-action-issue-receipt-20260605-890c1347\` (Q366, "keep action-key PR issue receipts"). This PR honors its intent — issue-only receipts still never *silently* satisfy a PR-intent handoff — and supersedes it by adding the bounded, receipt-backed exit the deadlock needs, so the reconciler can archive that handoff too once this merges.

## Fix — bounded terminal-archive escape valve

Archive an open-PR-intent handoff whose publisher decision is \`existing_issue\` ONLY when **all** gates hold:

1. **Issue verification** — linked issue fetched via \`gh issue view\` and is OPEN or CLOSED-as-completed (\`stateReason: COMPLETED\`). CLOSED/NOT_PLANNED, unparseable URLs, and gh failures all refuse. Lookups are cached per issue with a 3-consecutive-failure circuit breaker so a GitHub outage cannot stall a pass.
2. **Min age** — item older than \`--existing-issue-min-age-days\` (default **3**), from payload \`created_at\`/\`updated_at\` (file mtime fallback). Age gate runs before any gh call.
3. **Per-pass cap** — \`--existing-issue-archive-cap\` (default **20**). Over-cap eligible items are kept with an explicit "per-pass archive cap reached" annotation.

**Never silent deletion:** the archived copy embeds an explicit terminal receipt — \`terminal_disposition: superseded_by_existing_issue\` with issue URL, verified state, check timestamp, and the publisher decision evidence — and is written to the archive **before** the live outbox file is removed.

**Refusal cases unchanged:** non-\`existing_issue\` receipts (e.g. \`created_issue\`, \`published\`), receipts with PR references, young items, unverifiable issues all keep the handoff exactly as before (keep reason annotated with the blocking gate). Default invocation remains dry-run, and dry-run shows the full would-archive list with the terminal disposition attached.

## Tests (touched-test dogfood)

\`tests/scripts/test_reconcile_automation_outbox.py\`: **42 passed** (31 existing + 11 new) — terminal receipt contents, closed-completed acceptance, NOT_PLANNED refusal, unverifiable-state refusal, age gate (verifies no gh call), cap enforcement, dry-run non-mutation, non-existing_issue refusal, circuit breaker, URL parsing.

Gates: ruff check/format clean, mypy 0 errors, pre-commit passed.

## Rollout

After merge: one bounded reconcile pass from the main checkout (dry-run first, then \`--apply\` with default cap 20). Full drain expected over multiple passes/days by design — cap intentionally NOT raised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)