### PR TITLE
[DIC-26] coherence-scan --write: persist report to docs/status/generated/coherence_reports/

### DIFF
--- a/aragora/cli/commands/dic26_coherence.py
+++ b/aragora/cli/commands/dic26_coherence.py
@@ -9,6 +9,13 @@ Reads a JSON file where each element is a BeliefEntry dict:
 Flag: ``ARAGORA_COHERENCE_MONITOR_ENABLED`` (default OFF).
 Live queue effect: none — read-only operator report.
 Advances: issue #6220 (DIC-26).
+
+Report persistence (``--write``):
+    Pass ``--write`` to write a timestamped JSON report under the output
+    directory (default: ``docs/status/generated/coherence_reports/``
+    relative to the current working directory). Override with
+    ``--output-dir``. Writing is a separate, additive action — stdout
+    output is still emitted regardless.
 """
 
 from __future__ import annotations
@@ -17,11 +24,13 @@ import argparse
 import json
 import logging
 import sys
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
 from aragora.epistemic.coherence import (
     BeliefEntry,
+    CoherenceReport,
     coherence_monitor_enabled,
     scan_coherence,
 )
@@ -31,6 +40,7 @@ logger = logging.getLogger(__name__)
 _FLAG = "ARAGORA_COHERENCE_MONITOR_ENABLED"
 _DEFAULT_GAP: float = 0.5
 _DEFAULT_MIN_CONFIDENCE: float = 0.3
+_DEFAULT_OUTPUT_DIR = "docs/status/generated/coherence_reports"
 
 
 def _load_entries(path: Path) -> list[BeliefEntry]:
@@ -57,6 +67,21 @@ def _load_entries(path: Path) -> list[BeliefEntry]:
         except (KeyError, ValueError, TypeError) as exc:
             logger.warning("belief entry %d skipped: %s", idx, exc)
     return entries
+
+
+def _write_report(report: CoherenceReport, output_dir: Path) -> Path:
+    """Write *report* as timestamped JSON under *output_dir*.
+
+    Creates the directory (and all parents) if absent. Returns the path
+    of the written file. Never raises on directory creation — callers
+    should handle ``OSError`` from ``write_text``.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(tz=UTC).strftime("%Y%m%dT%H%M%SZ")
+    filename = f"coherence_report_{stamp}.json"
+    dest = output_dir / filename
+    dest.write_text(json.dumps(report.to_dict(), indent=2), encoding="utf-8")
+    return dest
 
 
 def cmd_coherence_scan(args: argparse.Namespace) -> int:
@@ -89,18 +114,29 @@ def cmd_coherence_scan(args: argparse.Namespace) -> int:
     as_json: bool = getattr(args, "json", False)
     if as_json:
         print(json.dumps(report.to_dict(), indent=2))
-        return 0
+    else:
+        print(f"Coherence scan: {input_path}")
+        print(f"  scanned            : {report.scanned}")
+        print(f"  coherent           : {report.coherent}")
+        print(f"  contradictions     : {report.contradiction_count}")
+        print(f"  evidence conflicts : {report.evidence_conflict_count}")
+        print(f"  confidence rot     : {report.confidence_rot_count}")
+        if report.issues:
+            print()
+            for issue in report.issues:
+                ids = ", ".join(issue.belief_ids)
+                print(f"  [{issue.severity}] {issue.kind.value}: {ids}")
+                print(f"    {issue.detail}")
 
-    print(f"Coherence scan: {input_path}")
-    print(f"  scanned            : {report.scanned}")
-    print(f"  coherent           : {report.coherent}")
-    print(f"  contradictions     : {report.contradiction_count}")
-    print(f"  evidence conflicts : {report.evidence_conflict_count}")
-    print(f"  confidence rot     : {report.confidence_rot_count}")
-    if report.issues:
-        print()
-        for issue in report.issues:
-            ids = ", ".join(issue.belief_ids)
-            print(f"  [{issue.severity}] {issue.kind.value}: {ids}")
-            print(f"    {issue.detail}")
+    do_write: bool = getattr(args, "write", False)
+    if do_write:
+        raw_dir: str = getattr(args, "output_dir", None) or _DEFAULT_OUTPUT_DIR
+        output_dir = Path(raw_dir).expanduser()
+        try:
+            dest = _write_report(report, output_dir)
+            print(f"report written: {dest}", file=sys.stderr)
+        except OSError as exc:
+            print(f"error: could not write report to {output_dir}: {exc}", file=sys.stderr)
+            return 1
+
     return 0

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -726,6 +726,25 @@ def _add_coherence_scan_parser(subparsers) -> None:
         help="Minimum confidence threshold for rot detection (default: 0.3)",
     )
     p.add_argument("--json", action="store_true", help="Emit JSON instead of text")
+    p.add_argument(
+        "--write",
+        action="store_true",
+        default=False,
+        help=(
+            "Persist a timestamped JSON report to --output-dir "
+            "(default: docs/status/generated/coherence_reports/)"
+        ),
+    )
+    p.add_argument(
+        "--output-dir",
+        dest="output_dir",
+        default=None,
+        metavar="DIR",
+        help=(
+            "Directory for written reports when --write is set "
+            "(default: docs/status/generated/coherence_reports/)"
+        ),
+    )
     p.set_defaults(func=_lazy("aragora.cli.commands.dic26_coherence", "cmd_coherence_scan"))
 
 

--- a/tests/cli/test_dic26_coherence.py
+++ b/tests/cli/test_dic26_coherence.py
@@ -142,9 +142,7 @@ def _args_write(
     return ns
 
 
-def test_write_flag_creates_report_file(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_write_flag_creates_report_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """--write persists a timestamped JSON report to the output directory."""
     monkeypatch.setenv("ARAGORA_COHERENCE_MONITOR_ENABLED", "1")
     out_dir = tmp_path / "coherence_reports"
@@ -155,9 +153,7 @@ def test_write_flag_creates_report_file(
     assert len(reports) == 1, f"expected 1 report file, found: {reports}"
 
 
-def test_write_flag_report_json_is_valid(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_write_flag_report_json_is_valid(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Report written to disk is valid JSON with expected top-level keys."""
     monkeypatch.setenv("ARAGORA_COHERENCE_MONITOR_ENABLED", "1")
     out_dir = tmp_path / "reports"
@@ -185,9 +181,7 @@ def test_write_flag_creates_output_dir_if_absent(
     assert nested.is_dir()
 
 
-def test_write_flag_off_leaves_no_file(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_write_flag_off_leaves_no_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Without --write, no report file is created."""
     monkeypatch.setenv("ARAGORA_COHERENCE_MONITOR_ENABLED", "1")
     out_dir = tmp_path / "reports"

--- a/tests/cli/test_dic26_coherence.py
+++ b/tests/cli/test_dic26_coherence.py
@@ -123,3 +123,74 @@ def test_load_entries_accepts_single_object(tmp_path: Path) -> None:
     p.write_text(json.dumps(raw), encoding="utf-8")
     entries = _load_entries(p)
     assert len(entries) == 1 and entries[0].belief_id == "singleton"
+
+
+# ---------------------------------------------------------------------------
+# --write flag: report persistence (DIC-26 acceptance criterion)
+# ---------------------------------------------------------------------------
+
+
+def _args_write(
+    input_path: str,
+    output_dir: str,
+    *,
+    json_output: bool = False,
+) -> argparse.Namespace:
+    ns = _args(input_path, json_output=json_output)
+    ns.write = True
+    ns.output_dir = output_dir
+    return ns
+
+
+def test_write_flag_creates_report_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """--write persists a timestamped JSON report to the output directory."""
+    monkeypatch.setenv("ARAGORA_COHERENCE_MONITOR_ENABLED", "1")
+    out_dir = tmp_path / "coherence_reports"
+    input_file = _write(tmp_path, [])
+    rc = cmd_coherence_scan(_args_write(str(input_file), str(out_dir)))
+    assert rc == 0
+    reports = list(out_dir.glob("coherence_report_*.json"))
+    assert len(reports) == 1, f"expected 1 report file, found: {reports}"
+
+
+def test_write_flag_report_json_is_valid(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Report written to disk is valid JSON with expected top-level keys."""
+    monkeypatch.setenv("ARAGORA_COHERENCE_MONITOR_ENABLED", "1")
+    out_dir = tmp_path / "reports"
+    entries = [
+        {"belief_id": "b1", "subject": "claim.rate_limit", "confidence": 0.9, "status": "pass"}
+    ]
+    rc = cmd_coherence_scan(_args_write(str(_write(tmp_path, entries)), str(out_dir)))
+    assert rc == 0
+    report_file = next(out_dir.glob("coherence_report_*.json"))
+    data = json.loads(report_file.read_text(encoding="utf-8"))
+    for key in ("scanned", "coherent", "issue_count", "contradiction_count"):
+        assert key in data, f"missing key {key!r} in written report"
+    assert data["scanned"] == 1
+
+
+def test_write_flag_creates_output_dir_if_absent(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """--write creates the output directory tree when it does not exist."""
+    monkeypatch.setenv("ARAGORA_COHERENCE_MONITOR_ENABLED", "1")
+    nested = tmp_path / "deep" / "nested" / "coherence_reports"
+    assert not nested.exists()
+    rc = cmd_coherence_scan(_args_write(str(_write(tmp_path, [])), str(nested)))
+    assert rc == 0
+    assert nested.is_dir()
+
+
+def test_write_flag_off_leaves_no_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Without --write, no report file is created."""
+    monkeypatch.setenv("ARAGORA_COHERENCE_MONITOR_ENABLED", "1")
+    out_dir = tmp_path / "reports"
+    rc = cmd_coherence_scan(_args(str(_write(tmp_path, []))))
+    assert rc == 0
+    assert not out_dir.exists()


### PR DESCRIPTION
## Slice
Adds `--write` and `--output-dir` flags to the `aragora coherence-scan` CLI
command so a timestamped JSON report is persisted under
`docs/status/generated/coherence_reports/` (or a caller-supplied directory),
satisfying the acceptance criterion in issue #6220 that was unmet by the
existing stdout-only implementation.

## Gating
- Default: OFF (flag: `ARAGORA_COHERENCE_MONITOR_ENABLED=1` required; `--write` must be passed explicitly)
- Live queue effect: none — purely additive file-write on the read-only report path
- Advances issue: #6220

## Tests
- `test_write_flag_creates_report_file` — `--write` produces exactly one `coherence_report_*.json` in the output dir
- `test_write_flag_report_json_is_valid` — written file is valid JSON with `scanned`, `coherent`, `issue_count`, `contradiction_count` keys
- `test_write_flag_creates_output_dir_if_absent` — `--write` creates the full directory tree when absent
- `test_write_flag_off_leaves_no_file` — without `--write`, no report file is created

All 13 tests in the file pass (9 pre-existing + 4 new).

## Validation
- `pytest tests/cli/test_dic26_coherence.py --noconftest` — 13 passed
- `ruff check aragora/cli/commands/dic26_coherence.py aragora/cli/parser.py tests/cli/test_dic26_coherence.py` — clean
- `mypy aragora/cli/commands/dic26_coherence.py --ignore-missing-imports` — clean

## Out of scope
- Writing to the default `docs/status/generated/coherence_reports/` path on CI (that's an operator trigger decision, not a code gate)
- DIC-28 gardening report persistence (same pattern applies; separate slice)
- DIC-17 followup-bridge wiring from the CLI surface (tracked separately)
- Automated scheduling of periodic coherence scans (DIC-28 concern)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVMxy9d3t8c76ou4H1DrTq)_