### PR TITLE
fix(metrics): validate belief benchmark probabilities

### DIFF
--- a/scripts/benchmark_belief_network.py
+++ b/scripts/benchmark_belief_network.py
@@ -21,6 +21,7 @@ Usage:
 
 from __future__ import annotations
 
+import math
 import sys
 import time
 from dataclasses import dataclass, field
@@ -567,6 +568,31 @@ def validate_benchmark_results(results: BenchmarkResults) -> None:
         raise ValueError("belief network benchmark requires at least one crux claim")
     if len(results.crux_details) != results.cruxes_found:
         raise ValueError("belief network crux count must match crux details")
+    _require_unit_interval(results.graph_density, "graph_density")
+    _require_unit_interval(results.average_uncertainty, "average_uncertainty")
+    _require_unit_interval(results.consensus_probability, "consensus_probability")
+    _require_nonnegative_finite(results.convergence_barrier, "convergence_barrier")
+    _require_nonnegative_finite(results.propagation_max_change, "propagation_max_change")
+    if results.propagation_iterations < 0:
+        raise ValueError("belief network propagation_iterations must be non-negative")
+    if results.contested_claims < 0:
+        raise ValueError("belief network contested_claims must be non-negative")
+    if results.contested_claims > results.total_claims:
+        raise ValueError("belief network contested_claims cannot exceed total_claims")
+
+
+def _require_nonnegative_finite(value: float, field_name: str) -> float:
+    number = float(value)
+    if not math.isfinite(number) or number < 0:
+        raise ValueError(f"belief network {field_name} must be a finite non-negative value")
+    return number
+
+
+def _require_unit_interval(value: float, field_name: str) -> float:
+    number = _require_nonnegative_finite(value, field_name)
+    if number > 1:
+        raise ValueError(f"belief network {field_name} must be between 0 and 1")
+    return number
 
 
 def generate_report(results: BenchmarkResults) -> str:

--- a/scripts/benchmark_belief_network.py
+++ b/scripts/benchmark_belief_network.py
@@ -569,7 +569,7 @@ def validate_benchmark_results(results: BenchmarkResults) -> None:
     if len(results.crux_details) != results.cruxes_found:
         raise ValueError("belief network crux count must match crux details")
     _require_unit_interval(results.graph_density, "graph_density")
-    _require_unit_interval(results.average_uncertainty, "average_uncertainty")
+    _require_nonnegative_finite(results.average_uncertainty, "average_uncertainty")
     _require_unit_interval(results.consensus_probability, "consensus_probability")
     _require_nonnegative_finite(results.convergence_barrier, "convergence_barrier")
     _require_nonnegative_finite(results.propagation_max_change, "propagation_max_change")

--- a/tests/scripts/test_benchmark_belief_network.py
+++ b/tests/scripts/test_benchmark_belief_network.py
@@ -38,9 +38,8 @@ def test_generate_report_rejects_crux_count_without_details() -> None:
         module.generate_report(results)
 
 
-def test_generate_report_accepts_minimal_valid_results() -> None:
-    module = _load_module()
-    results = module.BenchmarkResults(
+def _minimal_valid_results(module):
+    return module.BenchmarkResults(
         total_claims=2,
         total_relations=1,
         graph_density=0.5,
@@ -62,6 +61,38 @@ def test_generate_report_accepts_minimal_valid_results() -> None:
         consensus_probability=0.7,
         contested_claims=1,
     )
+
+
+def test_generate_report_rejects_impossible_probability_fields() -> None:
+    module = _load_module()
+    results = _minimal_valid_results(module)
+    results.consensus_probability = 1.5
+
+    with pytest.raises(ValueError, match="consensus_probability must be between 0 and 1"):
+        module.generate_report(results)
+
+
+def test_generate_report_rejects_non_finite_rate_fields() -> None:
+    module = _load_module()
+    results = _minimal_valid_results(module)
+    results.graph_density = float("nan")
+
+    with pytest.raises(ValueError, match="graph_density must be a finite non-negative value"):
+        module.generate_report(results)
+
+
+def test_generate_report_rejects_contested_count_above_total_claims() -> None:
+    module = _load_module()
+    results = _minimal_valid_results(module)
+    results.contested_claims = 3
+
+    with pytest.raises(ValueError, match="contested_claims cannot exceed total_claims"):
+        module.generate_report(results)
+
+
+def test_generate_report_accepts_minimal_valid_results() -> None:
+    module = _load_module()
+    results = _minimal_valid_results(module)
 
     report = module.generate_report(results)
 

--- a/tests/scripts/test_benchmark_belief_network.py
+++ b/tests/scripts/test_benchmark_belief_network.py
@@ -1,4 +1,5 @@
 import importlib.util
+import math
 import sys
 from pathlib import Path
 
@@ -78,6 +79,31 @@ def test_generate_report_rejects_non_finite_rate_fields() -> None:
     results.graph_density = float("nan")
 
     with pytest.raises(ValueError, match="graph_density must be a finite non-negative value"):
+        module.generate_report(results)
+
+
+def test_generate_report_accepts_raw_maximum_average_uncertainty() -> None:
+    module = _load_module()
+    results = _minimal_valid_results(module)
+    results.average_uncertainty = math.log2(3)
+
+    report = module.generate_report(results)
+
+    assert "| Average uncertainty | 1.585 |" in report
+
+
+@pytest.mark.parametrize("invalid_uncertainty", [float("nan"), float("inf"), -0.01])
+def test_generate_report_rejects_invalid_average_uncertainty(
+    invalid_uncertainty: float,
+) -> None:
+    module = _load_module()
+    results = _minimal_valid_results(module)
+    results.average_uncertainty = invalid_uncertainty
+
+    with pytest.raises(
+        ValueError,
+        match="average_uncertainty must be a finite non-negative value",
+    ):
         module.generate_report(results)
 
 


### PR DESCRIPTION
Summary:
- Fail closed before rendering belief-network benchmark reports with impossible probability/rate fields.
- Validate graph density, average uncertainty, consensus probability, convergence/max-change values, propagation iterations, and contested-claim counts.
- Add focused regressions for impossible consensus probability, non-finite graph density, and contested claims exceeding total claims.

Validation:
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_benchmark_belief_network.py -q
- git diff --check
- bash scripts/automation_pr_preflight.sh origin/main HEAD