### PR TITLE
fix(benchmarks): validate code intelligence selections

### DIFF
--- a/scripts/benchmark_code_intelligence.py
+++ b/scripts/benchmark_code_intelligence.py
@@ -53,6 +53,20 @@ def _positive_int(raw: str) -> int:
     return value
 
 
+def _selected_benchmark_names(
+    requested: list[str] | None,
+    available: dict[str, Callable[[], object]],
+) -> list[str]:
+    if requested is None:
+        return list(available.keys())
+    if not requested:
+        raise ValueError("benchmark selection requires at least one benchmark")
+    unknown = sorted(set(requested) - set(available.keys()))
+    if unknown:
+        raise ValueError(f"unknown benchmark selection: {', '.join(unknown)}")
+    return list(requested)
+
+
 @dataclass
 class BenchmarkResult:
     """Result of a single benchmark run."""
@@ -280,6 +294,14 @@ async def run_benchmarks(
     """Run all benchmarks."""
     _require_positive_int(iterations, label="iterations")
 
+    all_benchmarks = {
+        "indexing": lambda: benchmark_codebase_indexing(path, iterations),
+        "query": lambda: benchmark_understanding_query(path, iterations),
+        "security": lambda: benchmark_security_scan(path, iterations),
+        "review": lambda: benchmark_code_review(iterations),
+    }
+    selected_benchmarks = _selected_benchmark_names(benchmarks, all_benchmarks)
+
     suite = BenchmarkSuite(path=path)
 
     # Count files
@@ -287,20 +309,7 @@ async def run_benchmarks(
     suite.file_count, suite.line_count = count_files_and_lines(path)
     print(f"Found {suite.file_count} source files ({suite.line_count:,} lines)")
 
-    all_benchmarks = {
-        "indexing": lambda: benchmark_codebase_indexing(path, iterations),
-        "query": lambda: benchmark_understanding_query(path, iterations),
-        "security": lambda: benchmark_security_scan(path, iterations),
-        "review": lambda: benchmark_code_review(iterations),
-    }
-
-    benchmarks = benchmarks or list(all_benchmarks.keys())
-
-    for name in benchmarks:
-        if name not in all_benchmarks:
-            print(f"Unknown benchmark: {name}")
-            continue
-
+    for name in selected_benchmarks:
         print(f"\nRunning {name} benchmark ({iterations} iterations)...")
         result = await all_benchmarks[name]()
         suite.results.append(result)

--- a/tests/scripts/test_benchmark_code_intelligence.py
+++ b/tests/scripts/test_benchmark_code_intelligence.py
@@ -51,3 +51,25 @@ def test_run_benchmarks_rejects_bool_iterations(tmp_path: Path) -> None:
                 benchmarks=["indexing"],
             )
         )
+
+
+def test_run_benchmarks_rejects_empty_benchmark_selection(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="requires at least one benchmark"):
+        asyncio.run(
+            benchmark_code_intelligence.run_benchmarks(
+                str(tmp_path),
+                iterations=1,
+                benchmarks=[],
+            )
+        )
+
+
+def test_run_benchmarks_rejects_unknown_benchmark_selection(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="unknown benchmark selection: made_up"):
+        asyncio.run(
+            benchmark_code_intelligence.run_benchmarks(
+                str(tmp_path),
+                iterations=1,
+                benchmarks=["made_up"],
+            )
+        )


### PR DESCRIPTION
Summary:
- Fail closed when programmatic code-intelligence benchmark callers pass an empty benchmark selection or unknown benchmark names.
- Validate requested benchmark names before counting files or emitting a success-looking empty suite.
- Add focused regressions for empty and unknown benchmark selections.

Validation:
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_benchmark_code_intelligence.py -q
- git diff --check
- bash scripts/automation_pr_preflight.sh origin/main HEAD