### PR TITLE
fix(reports): validate dogfood report roots

### DIFF
--- a/scripts/reclassify_dogfood_report.py
+++ b/scripts/reclassify_dogfood_report.py
@@ -11,8 +11,14 @@ from typing import Any
 from aragora.debate.runtime_blockers import classify_stderr_signals
 
 
+def _require_report_object(data: Any) -> dict[str, Any]:
+    if not isinstance(data, dict):
+        raise ValueError("Report must be a JSON object.")
+    return data
+
+
 def _load_json(path: Path) -> dict[str, Any]:
-    return json.loads(path.read_text(encoding="utf-8"))
+    return _require_report_object(json.loads(path.read_text(encoding="utf-8")))
 
 
 def _write_json(path: Path, data: dict[str, Any]) -> None:
@@ -20,6 +26,7 @@ def _write_json(path: Path, data: dict[str, Any]) -> None:
 
 
 def reclassify_report(data: dict[str, Any]) -> dict[str, Any]:
+    data = _require_report_object(data)
     runs = data.get("runs")
     if not isinstance(runs, list):
         raise ValueError("Report must contain runs list.")

--- a/tests/scripts/test_reclassify_dogfood_report.py
+++ b/tests/scripts/test_reclassify_dogfood_report.py
@@ -20,6 +20,19 @@ def test_reclassify_report_rejects_empty_runs() -> None:
         reclassify_dogfood_report.reclassify_report({"runs": []})
 
 
+def test_reclassify_report_rejects_non_object_report() -> None:
+    with pytest.raises(ValueError, match="JSON object"):
+        reclassify_dogfood_report.reclassify_report(["not-a-report"])  # type: ignore[arg-type]
+
+
+def test_load_json_rejects_non_object_report(tmp_path: Path) -> None:
+    report_path = tmp_path / "report.json"
+    report_path.write_text('["not-a-report"]', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="JSON object"):
+        reclassify_dogfood_report._load_json(report_path)
+
+
 def test_reclassify_report_rejects_non_object_run_before_mutation() -> None:
     report = {"runs": ["not-a-run"]}
 


### PR DESCRIPTION
Summary: Fail closed when dogfood reclassification reports are not JSON objects, before mutating or classifying run data. Add focused regressions for direct callers and disk-loaded report roots. Validation: /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_reclassify_dogfood_report.py -q; /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/reclassify_dogfood_report.py tests/scripts/test_reclassify_dogfood_report.py; /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/reclassify_dogfood_report.py tests/scripts/test_reclassify_dogfood_report.py; git diff --check; bash scripts/automation_pr_preflight.sh origin/main HEAD