### PR TITLE
fix(benchmarks): validate dogfood ab timeouts

### DIFF
--- a/scripts/run_dogfood_ab_pairs.py
+++ b/scripts/run_dogfood_ab_pairs.py
@@ -371,7 +371,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--timeout-seconds",
-        type=int,
+        type=_positive_int,
         default=960,
         help="Debate timeout per run (default: 960).",
     )
@@ -416,7 +416,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--codebase-context-timeout-seconds",
-        type=int,
+        type=_positive_int,
         default=120,
         help="Timeout for engineered codebase context generation.",
     )

--- a/tests/scripts/test_run_dogfood_ab_pairs.py
+++ b/tests/scripts/test_run_dogfood_ab_pairs.py
@@ -37,3 +37,30 @@ def test_main_rejects_negative_pairs_before_writing_output(tmp_path: Path) -> No
         run_dogfood_ab_pairs.main(["--pairs", "-2", "--output-root", str(output_root)])
 
     assert not output_root.exists()
+
+
+def test_main_rejects_zero_timeout_before_writing_output(tmp_path: Path) -> None:
+    output_root = tmp_path / "dogfood-ab-output"
+
+    with pytest.raises(SystemExit):
+        run_dogfood_ab_pairs.main(["--timeout-seconds", "0", "--output-root", str(output_root)])
+
+    assert not output_root.exists()
+
+
+def test_main_rejects_zero_codebase_timeout_before_writing_output(
+    tmp_path: Path,
+) -> None:
+    output_root = tmp_path / "dogfood-ab-output"
+
+    with pytest.raises(SystemExit):
+        run_dogfood_ab_pairs.main(
+            [
+                "--codebase-context-timeout-seconds",
+                "0",
+                "--output-root",
+                str(output_root),
+            ]
+        )
+
+    assert not output_root.exists()


### PR DESCRIPTION
Summary:
- Fail closed when dogfood A/B benchmark timeout controls are zero or negative.
- Reuse the existing positive integer parser for debate timeout and codebase-context timeout knobs.
- Add focused regressions proving invalid timeout inputs stop before artifact directories are written.

Validation:
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_run_dogfood_ab_pairs.py -q
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/run_dogfood_ab_pairs.py tests/scripts/test_run_dogfood_ab_pairs.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/run_dogfood_ab_pairs.py tests/scripts/test_run_dogfood_ab_pairs.py
- git diff --check
- bash scripts/automation_pr_preflight.sh origin/main HEAD