### PR TITLE
fix(benchmarks): validate heterogeneity judge runtime controls

### DIFF
--- a/scripts/judge_heterogeneity_transcripts.py
+++ b/scripts/judge_heterogeneity_transcripts.py
@@ -35,6 +35,16 @@ DISPATCH_FAILED_VERDICT = "dispatch_failed"
 VALID_OUTPUT_VERDICTS = VALID_JUDGE_VERDICTS | frozenset({DISPATCH_FAILED_VERDICT})
 
 
+def _positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be an integer") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--transcript-dir", type=Path, required=True)
@@ -45,8 +55,8 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--raw-output-dir", type=Path, default=None)
     parser.add_argument("--reuse-raw", action="store_true")
     parser.add_argument("--all-prompts", action="store_true")
-    parser.add_argument("--limit", type=int, default=None)
-    parser.add_argument("--timeout-seconds", type=int, default=240)
+    parser.add_argument("--limit", type=_positive_int, default=None)
+    parser.add_argument("--timeout-seconds", type=_positive_int, default=240)
     parser.add_argument("--json", action="store_true")
     return parser.parse_args(argv)
 

--- a/tests/scripts/test_judge_heterogeneity_transcripts.py
+++ b/tests/scripts/test_judge_heterogeneity_transcripts.py
@@ -298,3 +298,57 @@ def test_judge_bridge_rejects_missing_transcript(tmp_path: Path) -> None:
 
     assert proc.returncode == 1
     assert "expected exactly one transcript" in proc.stderr
+
+
+def test_judge_bridge_rejects_zero_limit_before_output(tmp_path: Path) -> None:
+    transcript_dir = tmp_path / "transcripts"
+    transcript_dir.mkdir()
+    output = tmp_path / "classifications.json"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--transcript-dir",
+            str(transcript_dir),
+            "--limit",
+            "0",
+            "--output",
+            str(output),
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert proc.returncode == 2
+    assert "must be a positive integer" in proc.stderr
+    assert not output.exists()
+
+
+def test_judge_bridge_rejects_zero_timeout_before_output(tmp_path: Path) -> None:
+    transcript_dir = tmp_path / "transcripts"
+    transcript_dir.mkdir()
+    output = tmp_path / "classifications.json"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--transcript-dir",
+            str(transcript_dir),
+            "--limit",
+            "1",
+            "--timeout-seconds",
+            "0",
+            "--output",
+            str(output),
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert proc.returncode == 2
+    assert "must be a positive integer" in proc.stderr
+    assert not output.exists()


### PR DESCRIPTION
Summary:
- Fail closed when heterogeneity transcript judging receives a zero/negative prompt limit or judge timeout.
- Prevent empty classification artifacts caused by --limit 0 before any output path is written.
- Add focused CLI regressions for invalid limit and timeout inputs.

Validation:
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_judge_heterogeneity_transcripts.py -q
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/judge_heterogeneity_transcripts.py tests/scripts/test_judge_heterogeneity_transcripts.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/judge_heterogeneity_transcripts.py tests/scripts/test_judge_heterogeneity_transcripts.py
- git diff --check
- bash scripts/automation_pr_preflight.sh origin/main HEAD