### PR TITLE
fix(benchmarks): validate heterogeneity probe limits

### DIFF
--- a/scripts/run_heterogeneity_probe.py
+++ b/scripts/run_heterogeneity_probe.py
@@ -61,6 +61,16 @@ VALID_CLASSIFICATION_VERDICTS = frozenset(
 )
 
 
+def _positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be an integer") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--prompt-root", type=Path, default=DEFAULT_PROMPT_ROOT)
@@ -98,7 +108,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
             "write transcripts. This does not judge responses or claim a verdict."
         ),
     )
-    parser.add_argument("--limit", type=int, default=None, help="Limit selected prompts.")
+    parser.add_argument("--limit", type=_positive_int, default=None, help="Limit selected prompts.")
     parser.add_argument("--json", action="store_true", help="Print machine-readable summary.")
     return parser.parse_args(argv)
 

--- a/tests/scripts/test_run_heterogeneity_probe.py
+++ b/tests/scripts/test_run_heterogeneity_probe.py
@@ -82,6 +82,31 @@ def test_probe_script_writes_synthetic_fixture_receipt(tmp_path) -> None:
     assert "synthetic fixture only" in receipt["scope_caveats"][0]
 
 
+def test_probe_script_rejects_zero_limit_before_writing_output(tmp_path) -> None:
+    output_root = tmp_path / "out"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--synthetic-fixture",
+            "--limit",
+            "0",
+            "--output-root",
+            str(output_root),
+            "--run-id",
+            "fixture",
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert proc.returncode == 2
+    assert "must be a positive integer" in proc.stderr
+    assert not output_root.exists()
+
+
 def test_probe_script_writes_receipt_from_classifications_file(tmp_path) -> None:
     fixture = ROOT / "tests" / "heterogeneity" / "fixtures" / "classifications_minimal.json"
     proc = subprocess.run(


### PR DESCRIPTION
Summary:
- Fail closed when the heterogeneity probe runner receives a zero/negative prompt limit.
- Prevent empty prompt selections from reaching synthetic receipt or classification receipt paths.
- Add a focused CLI regression proving invalid limits stop before output artifacts are written.

Validation:
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_run_heterogeneity_probe.py -q
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/run_heterogeneity_probe.py tests/scripts/test_run_heterogeneity_probe.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/run_heterogeneity_probe.py tests/scripts/test_run_heterogeneity_probe.py
- git diff --check
- bash scripts/automation_pr_preflight.sh origin/main HEAD