### PR TITLE
fix(benchmarks): validate corpus recurrence scheduling

### DIFF
--- a/scripts/run_benchmark_corpus_recurrence.py
+++ b/scripts/run_benchmark_corpus_recurrence.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import subprocess
 import sys
 from pathlib import Path
@@ -197,6 +198,38 @@ def append_skipped_open_issue_rows(
     return appended
 
 
+def _positive_int_option(value: int | None, *, label: str, allow_none: bool = False) -> int | None:
+    if value is None and allow_none:
+        return None
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise ValueError(f"{label} must be a positive integer")
+    return value
+
+
+def _positive_finite_float_option(value: float, *, label: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{label} must be a positive finite number")
+    numeric = float(value)
+    if not math.isfinite(numeric) or numeric <= 0:
+        raise ValueError(f"{label} must be a positive finite number")
+    return numeric
+
+
+def validate_recurrence_options(
+    *,
+    max_ticks: int | None,
+    interval_seconds: float,
+    max_consecutive_failures: int,
+    max_hours: float,
+) -> tuple[int | None, float, int, float]:
+    return (
+        _positive_int_option(max_ticks, label="max_ticks", allow_none=True),
+        _positive_finite_float_option(interval_seconds, label="interval_seconds"),
+        _positive_int_option(max_consecutive_failures, label="max_consecutive_failures"),
+        _positive_finite_float_option(max_hours, label="max_hours"),
+    )
+
+
 def build_boss_loop_command(
     *,
     repo: str,
@@ -209,6 +242,12 @@ def build_boss_loop_command(
 ) -> list[str]:
     if not issue_numbers:
         raise ValueError("issue_numbers must not be empty")
+    max_ticks, interval_seconds, max_consecutive_failures, max_hours = validate_recurrence_options(
+        max_ticks=max_ticks,
+        interval_seconds=interval_seconds,
+        max_consecutive_failures=max_consecutive_failures,
+        max_hours=max_hours,
+    )
     # BossLoop can consume one initial attempt plus two repair attempts before
     # recording a terminal class for one issue. Budget for that full envelope so
     # later corpus issues are not omitted from the publication window.
@@ -270,6 +309,12 @@ def run_recurrence(
     dry_run: bool = False,
     runner: Any = subprocess.run,
 ) -> dict[str, Any]:
+    max_ticks, interval_seconds, max_consecutive_failures, max_hours = validate_recurrence_options(
+        max_ticks=max_ticks,
+        interval_seconds=interval_seconds,
+        max_consecutive_failures=max_consecutive_failures,
+        max_hours=max_hours,
+    )
     corpus = load_corpus(corpus_path)
     issue_numbers = corpus_issue_numbers(corpus)
     issue_titles = corpus_issue_titles(corpus)

--- a/tests/scripts/test_run_benchmark_corpus_recurrence.py
+++ b/tests/scripts/test_run_benchmark_corpus_recurrence.py
@@ -87,6 +87,56 @@ def test_build_boss_loop_command_uses_explicit_issue_list_contract() -> None:
     assert command[command.index("--autonomy") + 1] == "fire_and_forget"
 
 
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"max_ticks": 0}, "max_ticks must be a positive integer"),
+        ({"interval_seconds": 0.0}, "interval_seconds must be a positive finite number"),
+        (
+            {"max_consecutive_failures": 0},
+            "max_consecutive_failures must be a positive integer",
+        ),
+        ({"max_hours": float("inf")}, "max_hours must be a positive finite number"),
+    ],
+)
+def test_build_boss_loop_command_rejects_invalid_schedule_options(
+    kwargs: dict[str, object],
+    match: str,
+) -> None:
+    with pytest.raises(ValueError, match=match):
+        mod.build_boss_loop_command(
+            repo="synaptent/aragora",
+            issue_numbers=[2712],
+            **kwargs,
+        )
+
+
+def test_run_recurrence_rejects_invalid_schedule_options_without_dispatch(
+    tmp_path: Path,
+) -> None:
+    corpus_path = _write_json(
+        tmp_path / "corpus.json",
+        {
+            "corpus_id": "tw-01-bounded-execution-v1",
+            "revision": 10,
+            "recorded_on": "2026-04-18",
+            "success_contract": "mergeable_pr_or_merged_pr",
+            "issues": [{"issue_id": 1064, "title": "Closed issue"}],
+        },
+    )
+    metrics_path = tmp_path / "boss_metrics.jsonl"
+
+    with pytest.raises(ValueError, match="interval_seconds must be a positive finite number"):
+        mod.run_recurrence(
+            corpus_path=corpus_path,
+            repo="synaptent/aragora",
+            metrics_file=metrics_path,
+            interval_seconds=-1.0,
+        )
+
+    assert not metrics_path.exists()
+
+
 def test_run_recurrence_rotates_metrics_appends_closed_rows_and_dispatches_open_issue(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
Summary: Validate run_benchmark_corpus_recurrence scheduling options before building or reporting boss-loop commands, including the no-dispatch path. Tests: /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_run_benchmark_corpus_recurrence.py -q; /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/run_benchmark_corpus_recurrence.py tests/scripts/test_run_benchmark_corpus_recurrence.py; /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/run_benchmark_corpus_recurrence.py tests/scripts/test_run_benchmark_corpus_recurrence.py; git diff --check; bash scripts/automation_pr_preflight.sh origin/main HEAD.