### PR TITLE
fix(benchmarks): validate gauntlet report metrics

### DIFF
--- a/scripts/benchmark_gauntlet.py
+++ b/scripts/benchmark_gauntlet.py
@@ -23,6 +23,7 @@ Usage:
 from __future__ import annotations
 
 import hashlib
+import math
 import sys
 import time
 import uuid
@@ -560,12 +561,56 @@ def run_benchmark() -> BenchmarkResults:
 
 
 _REPORT_DECISION_CATEGORIES = {"strong", "weak"}
+_REPORT_VERDICTS = {"pass", "conditional", "fail"}
+
+
+def _validate_non_negative_int(value: int, *, label: str) -> None:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise ValueError(f"gauntlet benchmark report field {label} must be a non-negative integer")
+
+
+def _validate_unit_interval(value: float, *, label: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"gauntlet benchmark report field {label} must be a finite rate")
+    numeric = float(value)
+    if not math.isfinite(numeric):
+        raise ValueError(f"gauntlet benchmark report field {label} must be finite")
+    if not 0.0 <= numeric <= 1.0:
+        raise ValueError(f"gauntlet benchmark report field {label} must be between 0.0 and 1.0")
+
+
+def _validate_decision_report_metrics(decision: DecisionResult, *, index: int) -> None:
+    label = f"decisions[{index}]"
+    if decision.expected_verdict not in _REPORT_VERDICTS:
+        raise ValueError(f"gauntlet benchmark report field {label}.expected_verdict is unsupported")
+    if decision.actual_verdict not in _REPORT_VERDICTS:
+        raise ValueError(f"gauntlet benchmark report field {label}.actual_verdict is unsupported")
+    for field_name in (
+        "findings_count",
+        "critical_count",
+        "high_count",
+        "medium_count",
+        "low_count",
+    ):
+        _validate_non_negative_int(getattr(decision, field_name), label=f"{label}.{field_name}")
+    severity_total = (
+        decision.critical_count + decision.high_count + decision.medium_count + decision.low_count
+    )
+    if severity_total != decision.findings_count:
+        raise ValueError(
+            f"gauntlet benchmark report field {label}.findings_count must match severity totals"
+        )
+    _validate_unit_interval(decision.robustness_score, label=f"{label}.robustness_score")
+    _validate_unit_interval(decision.confidence, label=f"{label}.confidence")
 
 
 def _validate_report_corpus(results: BenchmarkResults) -> None:
     """Fail closed before computing report percentages from an invalid corpus."""
     if not results.decisions:
         raise ValueError("gauntlet benchmark report requires at least one decision")
+
+    for index, decision in enumerate(results.decisions):
+        _validate_decision_report_metrics(decision, index=index)
 
     categories = {decision.category for decision in results.decisions}
     unsupported = categories - _REPORT_DECISION_CATEGORIES

--- a/tests/scripts/test_benchmark_gauntlet.py
+++ b/tests/scripts/test_benchmark_gauntlet.py
@@ -23,22 +23,24 @@ def _load_module():
     return module
 
 
-def _decision(module, *, name: str, category: str, actual_verdict: str):
-    return module.DecisionResult(
-        name=name,
-        category=category,
-        expected_verdict=actual_verdict,
-        actual_verdict=actual_verdict,
-        verdict_correct=True,
-        findings_count=0,
-        critical_count=0,
-        high_count=0,
-        medium_count=0,
-        low_count=0,
-        robustness_score=1.0,
-        confidence=0.95,
-        verdict_reasoning="fixture verdict",
-    )
+def _decision(module, *, name: str, category: str, actual_verdict: str, **overrides):
+    payload = {
+        "name": name,
+        "category": category,
+        "expected_verdict": actual_verdict,
+        "actual_verdict": actual_verdict,
+        "verdict_correct": True,
+        "findings_count": 0,
+        "critical_count": 0,
+        "high_count": 0,
+        "medium_count": 0,
+        "low_count": 0,
+        "robustness_score": 1.0,
+        "confidence": 0.95,
+        "verdict_reasoning": "fixture verdict",
+    }
+    payload.update(overrides)
+    return module.DecisionResult(**payload)
 
 
 def test_generate_report_rejects_empty_decision_corpus() -> None:
@@ -91,6 +93,43 @@ def test_generate_report_rejects_unsupported_decision_categories() -> None:
     )
 
     with pytest.raises(ValueError, match="unsupported: neutral"):
+        module.generate_report(results)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "match"),
+    [
+        ({"findings_count": -1}, r"decisions\[0\]\.findings_count"),
+        (
+            {"findings_count": 2, "critical_count": 1},
+            r"decisions\[0\]\.findings_count must match severity totals",
+        ),
+        ({"robustness_score": 1.2}, r"decisions\[0\]\.robustness_score"),
+        ({"confidence": float("nan")}, r"decisions\[0\]\.confidence"),
+        ({"expected_verdict": "maybe"}, r"decisions\[0\]\.expected_verdict is unsupported"),
+    ],
+)
+def test_generate_report_rejects_invalid_decision_metrics(overrides, match: str) -> None:
+    module = _load_module()
+    results = module.BenchmarkResults(
+        decisions=[
+            _decision(
+                module,
+                name="Strong",
+                category="strong",
+                actual_verdict="pass",
+                **overrides,
+            ),
+            _decision(
+                module,
+                name="Weak",
+                category="weak",
+                actual_verdict="fail",
+            ),
+        ]
+    )
+
+    with pytest.raises(ValueError, match=match):
         module.generate_report(results)
 
 


### PR DESCRIPTION
Summary: Validate gauntlet benchmark report decision metrics before rendering markdown, so impossible severity counts, unsupported verdicts, and non-finite/out-of-range confidence or robustness values fail closed. Tests: /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_benchmark_gauntlet.py -q; /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/benchmark_gauntlet.py tests/scripts/test_benchmark_gauntlet.py; /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/benchmark_gauntlet.py tests/scripts/test_benchmark_gauntlet.py; git diff --check; bash scripts/automation_pr_preflight.sh origin/main HEAD.