### PR TITLE
fix(benchmarks): reject duplicate factory smoke cases

### DIFF
--- a/scripts/run_factory_review_benchmark_smoke.py
+++ b/scripts/run_factory_review_benchmark_smoke.py
@@ -74,7 +74,18 @@ def _validate_manifest(manifest: dict[str, Any]) -> list[dict[str, Any]]:
     cases = manifest.get("smoke_cases")
     if not isinstance(cases, list) or not cases:
         raise ValueError("manifest must include a non-empty smoke_cases list")
-    return [_validate_case(row, index) for index, row in enumerate(cases)]
+    validated = [_validate_case(row, index) for index, row in enumerate(cases)]
+    seen_case_ids: dict[str, int] = {}
+    for index, case in enumerate(validated):
+        case_id = str(case["case_id"])
+        first_index = seen_case_ids.get(case_id)
+        if first_index is not None:
+            raise ValueError(
+                f"smoke_cases[{index}].case_id duplicates smoke_cases[{first_index}].case_id: "
+                f"{case_id}"
+            )
+        seen_case_ids[case_id] = index
+    return validated
 
 
 def _artifact_dir(artifact_root: Path, case: dict[str, Any]) -> Path:

--- a/tests/scripts/test_run_factory_review_benchmark_smoke.py
+++ b/tests/scripts/test_run_factory_review_benchmark_smoke.py
@@ -94,6 +94,27 @@ def test_manifest_rejects_malformed_case() -> None:
         raise AssertionError("malformed case should fail")
 
 
+def test_manifest_rejects_duplicate_case_ids() -> None:
+    manifest = _manifest()
+    first_case = dict(manifest["smoke_cases"][0])
+    duplicate_case = {
+        **first_case,
+        "pr_number": 7,
+        "pr_url": "https://github.com/droid-code-review-evals/droid-sentry/pull/7",
+        "head_sha": "f" * 40,
+    }
+    manifest["smoke_cases"] = [first_case, duplicate_case]
+
+    try:
+        smoke.build_run_plan(manifest)
+    except ValueError as exc:
+        assert (
+            "smoke_cases[1].case_id duplicates smoke_cases[0].case_id: droid-sentry-pr-6"
+        ) in str(exc)
+    else:
+        raise AssertionError("duplicate case_id should fail closed")
+
+
 def test_verify_case_head_rejects_head_drift(monkeypatch: object) -> None:
     manifest = _manifest()
     plan = smoke.build_run_plan(manifest)


### PR DESCRIPTION
Summary: Reject duplicate Factory review benchmark smoke case IDs before building a run plan, so execution receipts cannot collapse multiple cases onto one case_id. Tests: /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_run_factory_review_benchmark_smoke.py -q; /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/run_factory_review_benchmark_smoke.py tests/scripts/test_run_factory_review_benchmark_smoke.py; /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/run_factory_review_benchmark_smoke.py tests/scripts/test_run_factory_review_benchmark_smoke.py; git diff --check; bash scripts/automation_pr_preflight.sh origin/main HEAD.