### PR TITLE
fix(tests): validate baseline run controls

### DIFF
--- a/scripts/run_test_baseline.py
+++ b/scripts/run_test_baseline.py
@@ -26,7 +26,24 @@ def _run(cmd: list[str]) -> None:
     subprocess.run(cmd, check=True)
 
 
+def _positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a positive integer") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
+def _require_positive_int(value: int, *, label: str) -> None:
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise ValueError(f"{label} must be a positive integer")
+
+
 def _build_pytest_command(args: argparse.Namespace) -> list[str]:
+    _require_positive_int(args.timeout, label="timeout")
+    _require_positive_int(args.maxfail, label="maxfail")
     pytest_cmd = [
         sys.executable,
         "-m",
@@ -69,13 +86,13 @@ def main() -> int:
     )
     parser.add_argument(
         "--timeout",
-        type=int,
+        type=_positive_int,
         default=120,
         help="Per-test timeout in seconds",
     )
     parser.add_argument(
         "--maxfail",
-        type=int,
+        type=_positive_int,
         default=1,
         help="Stop after this many failures",
     )

--- a/tests/scripts/test_run_test_baseline.py
+++ b/tests/scripts/test_run_test_baseline.py
@@ -7,6 +7,8 @@ import importlib.util
 from pathlib import Path
 from types import ModuleType
 
+import pytest
+
 
 def _load_script_module() -> ModuleType:
     script_path = Path(__file__).resolve().parents[2] / "scripts" / "run_test_baseline.py"
@@ -37,3 +39,39 @@ def test_build_pytest_command_includes_default_ignores_and_collect_only() -> Non
         ]
     assert "--collect-only" in command
     assert "-q" in command
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("timeout", 0),
+        ("timeout", -1),
+        ("maxfail", 0),
+        ("maxfail", -1),
+    ],
+)
+def test_build_pytest_command_rejects_non_positive_numeric_controls(
+    field: str,
+    value: int,
+) -> None:
+    module = _load_script_module()
+    args = argparse.Namespace(
+        paths=["tests/"],
+        markers=module.DEFAULT_MARKERS,
+        timeout=120,
+        maxfail=1,
+        run=False,
+        verbose=False,
+    )
+    setattr(args, field, value)
+
+    with pytest.raises(ValueError, match=f"{field} must be a positive integer"):
+        module._build_pytest_command(args)
+
+
+@pytest.mark.parametrize("value", ["0", "-1", "not-an-int"])
+def test_positive_int_argparse_type_rejects_invalid_values(value: str) -> None:
+    module = _load_script_module()
+
+    with pytest.raises(argparse.ArgumentTypeError, match="must be a positive integer"):
+        module._positive_int(value)


### PR DESCRIPTION
Summary: Validate deterministic baseline-test timeout and maxfail controls before building pytest commands, preventing zero or negative values from weakening regression coverage runs. Tests: /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_run_test_baseline.py -q; /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/run_test_baseline.py tests/scripts/test_run_test_baseline.py; /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/run_test_baseline.py tests/scripts/test_run_test_baseline.py; git diff --check; bash scripts/automation_pr_preflight.sh origin/main HEAD.