### PR TITLE
fix(benchmarks): validate adaptive stability scores

### DIFF
--- a/scripts/benchmarks/bench_adaptive_stopping.py
+++ b/scripts/benchmarks/bench_adaptive_stopping.py
@@ -9,6 +9,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import math
 import random
 import statistics
 import time
@@ -54,6 +55,16 @@ def _require_positive_int(value: int, *, label: str) -> None:
         raise ValueError(f"{label} must be a positive integer")
 
 
+def _require_stability_score(value: float, *, label: str) -> float:
+    try:
+        score = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{label} must be a finite score between 0 and 1") from exc
+    if not math.isfinite(score) or score < 0 or score > 1:
+        raise ValueError(f"{label} must be a finite score between 0 and 1")
+    return score
+
+
 def run_benchmark(iterations: int, votes_per_round: int) -> StabilityBenchmarkResult:
     _require_positive_int(iterations, label="iterations")
     _require_positive_int(votes_per_round, label="votes_per_round")
@@ -75,6 +86,7 @@ def run_benchmark(iterations: int, votes_per_round: int) -> StabilityBenchmarkRe
             )
         else:
             stability = agreement
+        stability = _require_stability_score(stability, label="stability")
         elapsed = (time.perf_counter() - start) * 1000
         result.times_ms.append(elapsed)
         result.stability_scores.append(stability)

--- a/tests/scripts/test_bench_adaptive_stopping.py
+++ b/tests/scripts/test_bench_adaptive_stopping.py
@@ -55,3 +55,38 @@ def test_run_benchmark_records_one_score_per_iteration(
     assert result.iterations == 3
     assert len(result.stability_scores) == 3
     assert len(result.times_ms) == 3
+
+
+def test_run_benchmark_accepts_detector_score_object(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_module()
+
+    class Detector:
+        def calculate_stability(self, values):
+            assert values
+            return type("Score", (), {"stability": 0.75})()
+
+    monkeypatch.setattr(module, "_get_detector", lambda: Detector())
+
+    result = module.run_benchmark(1, 3)
+
+    assert result.stability_scores == [0.75]
+
+
+@pytest.mark.parametrize("bad_score", [float("nan"), float("inf"), -0.1, 1.1])
+def test_run_benchmark_rejects_invalid_detector_scores(
+    bad_score: float,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_module()
+
+    class Detector:
+        def calculate_stability(self, values):
+            assert values
+            return bad_score
+
+    monkeypatch.setattr(module, "_get_detector", lambda: Detector())
+
+    with pytest.raises(ValueError, match="stability must be a finite score between 0 and 1"):
+        module.run_benchmark(1, 3)


### PR DESCRIPTION
Summary: fail closed when the adaptive stopping benchmark detector returns non-finite or out-of-range stability scores before recording benchmark metrics. Validation: /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_bench_adaptive_stopping.py; /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/benchmarks/bench_adaptive_stopping.py tests/scripts/test_bench_adaptive_stopping.py; bash scripts/automation_pr_preflight.sh origin/main HEAD.