### PR TITLE
fix(benchmarks): validate lara route labels

### DIFF
--- a/scripts/benchmarks/bench_lara_routing.py
+++ b/scripts/benchmarks/bench_lara_routing.py
@@ -13,8 +13,12 @@ import random
 import statistics
 import time
 from dataclasses import dataclass, field
+from typing import get_args
 
-from aragora.knowledge.mound.api.router import DocumentFeatures, LaRARouter
+from aragora.knowledge.mound.api.router import DocumentFeatures, LaRARouter, RouteType
+
+
+ALLOWED_ROUTES = set(get_args(RouteType))
 
 
 @dataclass
@@ -65,6 +69,14 @@ def _validate_benchmark_inputs(iterations: int, min_nodes: int, max_nodes: int) 
         raise ValueError("min_nodes must be less than or equal to max_nodes")
 
 
+def _require_route_name(route: object) -> str:
+    if not isinstance(route, str) or not route:
+        raise ValueError("LaRA routing benchmark route must be a non-empty string")
+    if route not in ALLOWED_ROUTES:
+        raise ValueError(f"LaRA routing benchmark route is unsupported: {route}")
+    return route
+
+
 def run_benchmark(iterations: int, min_nodes: int, max_nodes: int) -> RoutingBenchmarkResult:
     _validate_benchmark_inputs(iterations, min_nodes, max_nodes)
 
@@ -83,8 +95,9 @@ def run_benchmark(iterations: int, min_nodes: int, max_nodes: int) -> RoutingBen
             supports_rlm=True,
         )
         elapsed = (time.perf_counter() - start) * 1000
+        route = _require_route_name(decision.route)
         result.times_ms.append(elapsed)
-        result.route_counts[decision.route] = result.route_counts.get(decision.route, 0) + 1
+        result.route_counts[route] = result.route_counts.get(route, 0) + 1
 
     return result
 

--- a/tests/scripts/test_bench_lara_routing.py
+++ b/tests/scripts/test_bench_lara_routing.py
@@ -54,7 +54,7 @@ def test_run_benchmark_records_one_route_per_iteration(monkeypatch: pytest.Monke
 
     class _Router:
         def route(self, *_args, **_kwargs):
-            return SimpleNamespace(route="mock-route")
+            return SimpleNamespace(route="semantic")
 
     monkeypatch.setattr(module, "LaRARouter", _Router)
 
@@ -62,4 +62,22 @@ def test_run_benchmark_records_one_route_per_iteration(monkeypatch: pytest.Monke
 
     assert result.iterations == 3
     assert len(result.times_ms) == 3
-    assert result.route_counts == {"mock-route": 3}
+    assert result.route_counts == {"semantic": 3}
+
+
+@pytest.mark.parametrize("route", [None, "", "mock-route"])
+def test_run_benchmark_rejects_invalid_route_labels(
+    route: object,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_module()
+
+    class _Router:
+        def route(self, *_args, **_kwargs):
+            return SimpleNamespace(route=route)
+
+    monkeypatch.setattr(module, "LaRARouter", _Router)
+
+    expected = "unsupported" if route == "mock-route" else "non-empty string"
+    with pytest.raises(ValueError, match=expected):
+        module.run_benchmark(1, 0, 0)


### PR DESCRIPTION
Summary: fail closed when the LaRA routing benchmark receives an empty or unsupported route label before adding it to the published route distribution. Validation: /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_bench_lara_routing.py; /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/benchmarks/bench_lara_routing.py tests/scripts/test_bench_lara_routing.py; git diff --check; bash scripts/automation_pr_preflight.sh origin/main HEAD.