### PR TITLE
fix(reports): validate capability gap maps

### DIFF
--- a/scripts/capability_gap_report.py
+++ b/scripts/capability_gap_report.py
@@ -68,8 +68,21 @@ def _load_yaml(path: Path) -> dict[str, Any]:
     with path.open("r", encoding="utf-8") as handle:
         data = yaml.safe_load(handle) or {}
     if not isinstance(data, dict):
-        return {}
+        raise ValueError(f"{path} must contain a YAML mapping")
     return data
+
+
+def _require_mapping(value: Any, *, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be a mapping")
+    return value
+
+
+def _optional_mapping(container: dict[str, Any], key: str, *, label: str) -> dict[str, Any]:
+    value = container.get(key)
+    if value is None:
+        return {}
+    return _require_mapping(value, label=label)
 
 
 def _as_list(value: Any) -> list[str]:
@@ -83,9 +96,9 @@ def _as_list(value: Any) -> list[str]:
 
 
 def _parse_surface_entry(entry: dict[str, Any]) -> SurfaceCoverage:
+    entry = _require_mapping(entry, label="capability surface entry")
     sdk = entry.get("sdk") or {}
-    if not isinstance(sdk, dict):
-        sdk = {}
+    sdk = _require_mapping(sdk, label="capability surface sdk entry")
     return SurfaceCoverage(
         cli=_as_list(entry.get("cli")),
         api=_as_list(entry.get("api")),
@@ -103,20 +116,23 @@ def build_report(repo_root: Path, *, include_unmapped: bool = True) -> dict[str,
     base_data = _load_yaml(base_path)
     surface_data = _load_yaml(surfaces_path)
 
-    base_caps = base_data.get("capabilities") or {}
-    if not isinstance(base_caps, dict):
-        base_caps = {}
+    base_caps = _optional_mapping(
+        base_data,
+        "capabilities",
+        label="capabilities catalog",
+    )
 
-    surface_caps = surface_data.get("capabilities") or {}
-    if not isinstance(surface_caps, dict):
-        surface_caps = {}
+    surface_caps = _optional_mapping(
+        surface_data,
+        "capabilities",
+        label="capability surface map",
+    )
 
     report_items: dict[str, Any] = {}
     unmapped: list[str] = []
 
     for key, payload in base_caps.items():
-        if not isinstance(payload, dict):
-            payload = {}
+        payload = _require_mapping(payload, label=f"capability catalog entry {key}")
         name = payload.get("name", key)
         category = payload.get("category", "unknown")
         status = payload.get("status", "unknown")

--- a/tests/scripts/test_capability_gap_report.py
+++ b/tests/scripts/test_capability_gap_report.py
@@ -1,0 +1,152 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = ROOT / "scripts" / "capability_gap_report.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("capability_gap_report", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_yaml(root: Path, *, capabilities: str, surfaces: str) -> None:
+    aragora_dir = root / "aragora"
+    aragora_dir.mkdir()
+    (aragora_dir / "capabilities.yaml").write_text(capabilities, encoding="utf-8")
+    (aragora_dir / "capability_surfaces.yaml").write_text(surfaces, encoding="utf-8")
+
+
+def test_build_report_accepts_minimal_capability_maps(tmp_path: Path) -> None:
+    module = _load_module()
+    _write_yaml(
+        tmp_path,
+        capabilities="""
+capabilities:
+  example:
+    name: Example Capability
+    category: proof
+    status: stable
+""",
+        surfaces="""
+capabilities:
+  example:
+    cli:
+      - aragora example
+    api: []
+    sdk:
+      python: []
+      typescript: []
+    ui: []
+    channels: []
+""",
+    )
+
+    report = module.build_report(tmp_path)
+
+    assert report["total_capabilities"] == 1
+    assert report["mapped_capabilities"] == 1
+    assert report["items"]["example"]["name"] == "Example Capability"
+
+
+def test_build_report_rejects_non_mapping_yaml_root(tmp_path: Path) -> None:
+    module = _load_module()
+    _write_yaml(
+        tmp_path,
+        capabilities="- not-a-map\n",
+        surfaces="capabilities: {}\n",
+    )
+
+    with pytest.raises(ValueError, match="capabilities.yaml must contain a YAML mapping"):
+        module.build_report(tmp_path)
+
+
+def test_build_report_rejects_non_mapping_capability_catalog(tmp_path: Path) -> None:
+    module = _load_module()
+    _write_yaml(
+        tmp_path,
+        capabilities="capabilities: []\n",
+        surfaces="capabilities: {}\n",
+    )
+
+    with pytest.raises(ValueError, match="capabilities catalog must be a mapping"):
+        module.build_report(tmp_path)
+
+
+def test_build_report_rejects_non_mapping_capability_entry(tmp_path: Path) -> None:
+    module = _load_module()
+    _write_yaml(
+        tmp_path,
+        capabilities="""
+capabilities:
+  example: stable
+""",
+        surfaces="capabilities: {}\n",
+    )
+
+    with pytest.raises(ValueError, match="capability catalog entry example must be a mapping"):
+        module.build_report(tmp_path)
+
+
+def test_build_report_rejects_non_mapping_surface_map(tmp_path: Path) -> None:
+    module = _load_module()
+    _write_yaml(
+        tmp_path,
+        capabilities="""
+capabilities:
+  example:
+    name: Example
+""",
+        surfaces="capabilities: []\n",
+    )
+
+    with pytest.raises(ValueError, match="capability surface map must be a mapping"):
+        module.build_report(tmp_path)
+
+
+def test_build_report_rejects_non_mapping_surface_entry(tmp_path: Path) -> None:
+    module = _load_module()
+    _write_yaml(
+        tmp_path,
+        capabilities="""
+capabilities:
+  example:
+    name: Example
+""",
+        surfaces="""
+capabilities:
+  example: exposed
+""",
+    )
+
+    with pytest.raises(ValueError, match="capability surface entry must be a mapping"):
+        module.build_report(tmp_path)
+
+
+def test_build_report_rejects_non_mapping_surface_sdk_entry(tmp_path: Path) -> None:
+    module = _load_module()
+    _write_yaml(
+        tmp_path,
+        capabilities="""
+capabilities:
+  example:
+    name: Example
+""",
+        surfaces="""
+capabilities:
+  example:
+    sdk: python-client
+""",
+    )
+
+    with pytest.raises(ValueError, match="capability surface sdk entry must be a mapping"):
+        module.build_report(tmp_path)


### PR DESCRIPTION
Summary: fail closed when the capability gap report receives malformed capability catalog or surface map shapes instead of silently publishing empty data or crashing unclearly. Validation: /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_capability_gap_report.py; /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/capability_gap_report.py tests/scripts/test_capability_gap_report.py; /Users/armand/.pyenv/versions/3.11.11/bin/python scripts/capability_gap_report.py --format json; git diff --check; bash scripts/automation_pr_preflight.sh origin/main HEAD.