### PR TITLE
Suggest agent bridge preflight smoke

### DIFF
--- a/scripts/automation_pr_preflight.sh
+++ b/scripts/automation_pr_preflight.sh
@@ -72,6 +72,8 @@ if python_sources:
         f"python3 scripts/nomic_ci_test_selector.py --changed-files {quoted} --dry-run"
     )
     suggested_commands.append(f"python3 -m ruff check {quoted}")
+if "scripts/agent_bridge.py" in source_changes:
+    suggested_commands.append("python3 scripts/agent_bridge.py operator-snapshot --json --summary-only")
 if test_changes:
     quoted_tests = " ".join(shlex.quote(path) for path in test_changes)
     suggested_commands.append(f"python3 -m pytest {quoted_tests} -q")

--- a/tests/scripts/test_automation_pr_preflight.py
+++ b/tests/scripts/test_automation_pr_preflight.py
@@ -144,6 +144,31 @@ def test_automation_pr_preflight_json_suggests_publisher_startup_smoke(
     assert "'scripts.github_cli_health'" in startup_command
 
 
+def test_automation_pr_preflight_json_suggests_agent_bridge_smoke(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _run(["git", "switch", "-c", "codex/agent-bridge-json"], cwd=repo)
+    source = repo / "scripts" / "agent_bridge.py"
+    source.parent.mkdir()
+    source.write_text("print('bridge')\n", encoding="utf-8")
+    _run(["git", "add", "scripts/agent_bridge.py"], cwd=repo)
+    _run(["git", "commit", "-m", "fix: update agent bridge"], cwd=repo)
+
+    proc = _run(["bash", str(SCRIPT), "--json", "origin/main", "HEAD"], cwd=repo)
+
+    assert proc.returncode == 0
+    payload = json.loads(proc.stdout)
+    assert payload["status"] == "ok"
+    assert payload["docs_only"] is False
+    assert payload["source_without_tests"] is True
+    assert payload["suggested_validation_commands"] == [
+        "python3 scripts/nomic_ci_test_selector.py --changed-files scripts/agent_bridge.py --dry-run",
+        "python3 -m ruff check scripts/agent_bridge.py",
+        "python3 scripts/agent_bridge.py operator-snapshot --json --summary-only",
+    ]
+
+
 def test_automation_pr_preflight_rejects_synthetic_preflight_commit_subject(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Restacks the unowned outbox handoff open-pr-codex-salvage-preflight-agent-bridge-smoke-20260610-5c4b8e32 onto current origin/main without rewriting the pushed source branch. The old branch codex/salvage-preflight-agent-bridge-smoke-20260610 conflicted with current tests/scripts/test_automation_pr_preflight.py; this r2 branch keeps the existing publisher startup smoke test and adds the agent_bridge smoke suggestion coverage.\n\nValidation:\n- git diff --check origin/main...HEAD\n- bash -n scripts/automation_pr_preflight.sh\n- PYTHONDONTWRITEBYTECODE=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_automation_pr_preflight.py -q -p no:cacheprovider: 18 passed\n- /Users/armand/.pyenv/versions/3.11.11/bin/python -m py_compile tests/scripts/test_automation_pr_preflight.py\n- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check tests/scripts/test_automation_pr_preflight.py\n- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check tests/scripts/test_automation_pr_preflight.py\n- git merge-tree --write-tree origin/main HEAD\n- bash scripts/automation_pr_preflight.sh origin/main HEAD\n- git push pre-push hooks passed\n\nNo outbox handoff was archived and no CI was rerun.