### PR TITLE
feat(automation): PR funnel transport — ready promoter, stale janitor, backpressure gate, funnel telemetry + inventory hang fix

### DIFF
--- a/scripts/backlog_gate.py
+++ b/scripts/backlog_gate.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""Closure-first backpressure gate for the autonomous PR pipeline (READ-ONLY).
+
+Writer lanes keep admitting new work regardless of how much WIP is already in
+flight ("admission outruns settlement"): drafts and outbox handoffs pile up
+faster than the merge arbiter can settle them. This gate computes a single
+closure-first signal that writer-lane wrappers consult before generating:
+
+- ``generate``  -- backlog is under both thresholds; writer lanes may create
+  new work.
+- ``shepherd``  -- backlog is at/over a threshold (or the gate itself failed);
+  writer lanes should rebase/fix/evidence EXISTING PRs instead of creating
+  new work.
+
+Inputs (read-only, one ``gh`` call per run):
+
+1. One ``gh pr list`` call (open PRs, ``--limit 300``) counted against the
+   automation branch prefixes (default ``codex/``, repeatable
+   ``--branch-prefix``).
+2. Outbox depth: the number of ``*.json`` files directly in ``--outbox-dir``
+   (default ``.aragora/automation-outbox``). A missing directory counts as 0
+   with an annotation -- not an error.
+
+Output: one JSON object on stdout (suppressed by ``--quiet``)::
+
+    {mode, reasons[], open_prs, drafts, ready, outbox_depth, thresholds,
+     generated_at, annotations[]}
+
+and the same JSON atomically written to ``--signal-file`` (default
+``.aragora/backpressure.json``; temp file + ``os.replace`` so readers never
+observe a partial signal).
+
+Exit codes (documented so shell wrappers can branch on ``$?``):
+
+- 0 -- mode ``generate``
+- 3 -- mode ``shepherd``
+- 1 -- gate failure (gh error etc.). Fail closed: the signal file is still
+  written with mode ``shepherd`` and reason ``gate_failure:<detail>`` before
+  exiting 1, so a broken gate never green-lights more generation.
+
+Safety model (mirrors ``pr_ready_triage.py`` / ``stale_pr_janitor.py``):
+read-only against GitHub, no mutations of any kind; the only file this script
+writes is its own signal file. Stdlib-only by design so it can run anywhere
+``gh`` is authenticated.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+DEFAULT_REPO = "synaptent/aragora"
+DEFAULT_BRANCH_PREFIXES = ("codex/",)
+DEFAULT_OUTBOX_DIR = os.path.join(".aragora", "automation-outbox")
+DEFAULT_SIGNAL_FILE = os.path.join(".aragora", "backpressure.json")
+DEFAULT_MAX_OPEN_PRS = 60
+DEFAULT_MAX_OUTBOX = 50
+GH_TIMEOUT_SECONDS = 120
+GH_LIST_LIMIT = 300
+
+EXIT_GENERATE = 0
+EXIT_FAILURE = 1
+EXIT_SHEPHERD = 3
+
+MODE_GENERATE = "generate"
+MODE_SHEPHERD = "shepherd"
+
+_GH_LIST_FIELDS = "number,headRefName,isDraft,createdAt"
+
+
+# --- Inputs (read-only) -------------------------------------------------------------
+
+
+def default_list_open_prs(repo: str) -> list[dict[str, Any]]:
+    """One ``gh pr list`` call for open PRs (read-only, capped at 300)."""
+    command = [
+        "gh",
+        "pr",
+        "list",
+        "--repo",
+        repo,
+        "--state",
+        "open",
+        "--json",
+        _GH_LIST_FIELDS,
+        "--limit",
+        str(GH_LIST_LIMIT),
+    ]
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        timeout=GH_TIMEOUT_SECONDS,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"gh pr list failed (exit {result.returncode}): {result.stderr.strip()}")
+    payload = json.loads(result.stdout or "[]")
+    if not isinstance(payload, list):
+        raise RuntimeError("gh pr list returned unexpected payload (expected a list)")
+    return payload
+
+
+def count_outbox_depth(outbox_dir: str) -> tuple[int, bool]:
+    """Count ``*.json`` files directly in the outbox dir.
+
+    A missing directory is (0, True) -- annotated, never an error.
+    """
+    if not os.path.isdir(outbox_dir):
+        return 0, True
+    depth = 0
+    with os.scandir(outbox_dir) as entries:
+        for entry in entries:
+            if entry.is_file() and entry.name.endswith(".json"):
+                depth += 1
+    return depth, False
+
+
+# --- Signal file ---------------------------------------------------------------------
+
+
+def atomic_write_json(path: str, payload: dict[str, Any]) -> None:
+    """Write temp + ``os.replace`` so readers never observe a partial file."""
+    directory = os.path.dirname(path) or "."
+    os.makedirs(directory, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=f".{os.path.basename(path)}.", dir=directory)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh, indent=2, sort_keys=True)
+            fh.write("\n")
+        os.replace(tmp, path)
+    finally:
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+
+
+# --- Gate ------------------------------------------------------------------------------
+
+
+def run_gate(
+    *,
+    list_prs: Callable[[], list[dict[str, Any]]],
+    branch_prefixes: tuple[str, ...] = DEFAULT_BRANCH_PREFIXES,
+    outbox_dir: str = DEFAULT_OUTBOX_DIR,
+    max_open_prs: int = DEFAULT_MAX_OPEN_PRS,
+    max_outbox: int = DEFAULT_MAX_OUTBOX,
+    signal_file: str = DEFAULT_SIGNAL_FILE,
+    quiet: bool = False,
+    now: datetime | None = None,
+    log: Callable[[str], None] = print,
+) -> int:
+    """Compute the gate decision, write the signal file, return the exit code.
+
+    Fail closed: any failure (gh error, unreadable outbox) still writes the
+    signal file with mode ``shepherd`` and reason ``gate_failure:<detail>``
+    before returning 1, so a broken gate never green-lights more generation.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+    generated_at = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+    thresholds = {"max_open_prs": max_open_prs, "max_outbox": max_outbox}
+
+    def emit(payload: dict[str, Any]) -> None:
+        if not quiet:
+            log(json.dumps(payload, sort_keys=True))
+
+    try:
+        prs = [
+            pr
+            for pr in list_prs()
+            if isinstance(pr, dict)
+            and any(
+                str(pr.get("headRefName") or "").startswith(prefix) for prefix in branch_prefixes
+            )
+        ]
+        depth, outbox_missing = count_outbox_depth(outbox_dir)
+    except (RuntimeError, OSError, ValueError, subprocess.SubprocessError) as exc:
+        detail = str(exc)[:300]
+        payload = {
+            "mode": MODE_SHEPHERD,
+            "reasons": [f"gate_failure:{detail}"],
+            "open_prs": None,
+            "drafts": None,
+            "ready": None,
+            "outbox_depth": None,
+            "thresholds": thresholds,
+            "generated_at": generated_at,
+            "annotations": [],
+        }
+        try:
+            atomic_write_json(signal_file, payload)
+        except OSError as write_exc:
+            print(
+                json.dumps({"action": "signal_write_failed", "error": str(write_exc)[:300]}),
+                file=sys.stderr,
+            )
+        emit(payload)
+        print(json.dumps({"action": "gate_failure", "error": detail}), file=sys.stderr)
+        return EXIT_FAILURE
+
+    open_count = len(prs)
+    drafts = sum(1 for pr in prs if bool(pr.get("isDraft")))
+    ready = open_count - drafts
+
+    reasons: list[str] = []
+    if open_count >= max_open_prs:
+        reasons.append(f"open_prs:{open_count}>=max_open_prs:{max_open_prs}")
+    if depth >= max_outbox:
+        reasons.append(f"outbox_depth:{depth}>=max_outbox:{max_outbox}")
+
+    annotations: list[str] = []
+    if outbox_missing:
+        annotations.append(f"outbox_dir_missing:{outbox_dir}")
+
+    mode = MODE_SHEPHERD if reasons else MODE_GENERATE
+    payload = {
+        "mode": mode,
+        "reasons": reasons,
+        "open_prs": open_count,
+        "drafts": drafts,
+        "ready": ready,
+        "outbox_depth": depth,
+        "thresholds": thresholds,
+        "generated_at": generated_at,
+        "annotations": annotations,
+    }
+
+    try:
+        atomic_write_json(signal_file, payload)
+    except OSError as exc:
+        # The signal file is the gate's contract with writer lanes; failing to
+        # write it is a gate failure (non-zero never green-lights generation).
+        emit(payload)
+        print(
+            json.dumps({"action": "signal_write_failed", "error": str(exc)[:300]}),
+            file=sys.stderr,
+        )
+        return EXIT_FAILURE
+
+    emit(payload)
+    return EXIT_GENERATE if mode == MODE_GENERATE else EXIT_SHEPHERD
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Closure-first backpressure gate: exits 0 (generate) when the "
+            "automation PR backlog and outbox are both under threshold, "
+            "3 (shepherd) otherwise, 1 on gate failure (fail closed: the "
+            "signal file is still written with mode shepherd). Read-only "
+            "except its own --signal-file."
+        )
+    )
+    parser.add_argument("--repo", default=DEFAULT_REPO, help="GitHub repo (owner/name)")
+    parser.add_argument(
+        "--branch-prefix",
+        action="append",
+        default=None,
+        help=f"Head-branch prefix to count; repeatable (default: {list(DEFAULT_BRANCH_PREFIXES)})",
+    )
+    parser.add_argument(
+        "--outbox-dir",
+        default=DEFAULT_OUTBOX_DIR,
+        help=f"Outbox directory whose direct *.json files are counted "
+        f"(default {DEFAULT_OUTBOX_DIR}; missing dir counts as 0)",
+    )
+    parser.add_argument(
+        "--max-open-prs",
+        type=int,
+        default=DEFAULT_MAX_OPEN_PRS,
+        help=f"Open automation PR threshold (default {DEFAULT_MAX_OPEN_PRS}); "
+        f"at/over this the gate says shepherd",
+    )
+    parser.add_argument(
+        "--max-outbox",
+        type=int,
+        default=DEFAULT_MAX_OUTBOX,
+        help=f"Outbox depth threshold (default {DEFAULT_MAX_OUTBOX}); "
+        f"at/over this the gate says shepherd",
+    )
+    parser.add_argument(
+        "--signal-file",
+        default=DEFAULT_SIGNAL_FILE,
+        help=f"Path for the atomically-written signal JSON (default {DEFAULT_SIGNAL_FILE})",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        default=False,
+        help="Suppress stdout JSON (signal file only)",
+    )
+    args = parser.parse_args(argv)
+
+    prefixes = tuple(args.branch_prefix) if args.branch_prefix else DEFAULT_BRANCH_PREFIXES
+
+    return run_gate(
+        list_prs=lambda: default_list_open_prs(args.repo),
+        branch_prefixes=prefixes,
+        outbox_dir=args.outbox_dir,
+        max_open_prs=args.max_open_prs,
+        max_outbox=args.max_outbox,
+        signal_file=args.signal_file,
+        quiet=args.quiet,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/backlog_gate.py
+++ b/scripts/backlog_gate.py
@@ -49,6 +49,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -173,9 +174,10 @@ def run_gate(
             log(json.dumps(payload, sort_keys=True))
 
     try:
+        raw_prs = list_prs()
         prs = [
             pr
-            for pr in list_prs()
+            for pr in raw_prs
             if isinstance(pr, dict)
             and any(
                 str(pr.get("headRefName") or "").startswith(prefix) for prefix in branch_prefixes
@@ -219,6 +221,14 @@ def run_gate(
     annotations: list[str] = []
     if outbox_missing:
         annotations.append(f"outbox_dir_missing:{outbox_dir}")
+    # Fail closed on a truncated listing: ``gh pr list`` truncates BEFORE the
+    # branch-prefix filter, so when the raw payload hits the list limit the
+    # counts above are floors and in-scope PRs may have been silently dropped.
+    # A gate that cannot see the whole backlog must never green-light more
+    # generation, regardless of how small the visible counts look.
+    if len(raw_prs) >= GH_LIST_LIMIT:
+        reasons.append(f"list_truncated:>={GH_LIST_LIMIT}")
+        annotations.append(f"list_truncated:>={GH_LIST_LIMIT}")
 
     mode = MODE_SHEPHERD if reasons else MODE_GENERATE
     payload = {
@@ -249,6 +259,16 @@ def run_gate(
     return EXIT_GENERATE if mode == MODE_GENERATE else EXIT_SHEPHERD
 
 
+_REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+
+
+def repo_arg(value: str) -> str:
+    """Argparse type: validate ``owner/name`` at parse time, before any gh call."""
+    if not _REPO_RE.match(value):
+        raise argparse.ArgumentTypeError(f"--repo must look like owner/name, got {value!r}")
+    return value
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description=(
@@ -259,7 +279,9 @@ def main(argv: list[str] | None = None) -> int:
             "except its own --signal-file."
         )
     )
-    parser.add_argument("--repo", default=DEFAULT_REPO, help="GitHub repo (owner/name)")
+    parser.add_argument(
+        "--repo", default=DEFAULT_REPO, type=repo_arg, help="GitHub repo (owner/name)"
+    )
     parser.add_argument(
         "--branch-prefix",
         action="append",

--- a/scripts/backlog_gate.py
+++ b/scripts/backlog_gate.py
@@ -139,7 +139,7 @@ def atomic_write_json(path: str, payload: dict[str, Any]) -> None:
     finally:
         try:
             os.unlink(tmp)
-        except FileNotFoundError:
+        except OSError:  # never mask the primary error with a cleanup failure
             pass
 
 

--- a/scripts/codex_worktree_value_inventory.py
+++ b/scripts/codex_worktree_value_inventory.py
@@ -18,6 +18,7 @@ import hashlib
 import json
 import os
 import re
+import signal
 import subprocess
 import sys
 import tempfile
@@ -42,6 +43,14 @@ from audit_codex_branch_backlog import (  # noqa: E402
 )
 
 SCHEMA = "aragora-worktree-harvest/1.0"
+# Every git/gh subprocess in this module must carry an explicit timeout so a
+# wedged candidate repo (e.g. `git status` blocked on an fsmonitor daemon or
+# hook) can never hang the whole inventory. Overridable per-run via
+# --git-timeout-seconds (alias of the long-standing --git-timeout flag).
+GIT_TIMEOUT_SECONDS = 30
+# Substring run_cmd embeds in stderr on timeout; classify_candidate uses it to
+# annotate timed-out candidates as inspect_timeout (always protected).
+_TIMEOUT_ERROR_MARKER = "timed out after"
 DEFAULT_LEGACY_ROOT = Path.home() / ".codex" / "worktrees"
 DEFAULT_CANONICAL_REL_ROOT = Path(".worktrees") / "codex-auto"
 DEFAULT_ROOT = DEFAULT_LEGACY_ROOT  # kept for backward compatibility
@@ -138,6 +147,7 @@ class GitInfo:
     patch_equivalent_to_base: bool = False
     smart_merge_equivalent_to_base: bool = False
     lookup_failed: bool = False
+    inspect_timeout: bool = False
     lookup_errors: list[str] = field(default_factory=list)
 
 
@@ -198,24 +208,63 @@ def utc_now() -> datetime:
     return datetime.now(UTC).replace(microsecond=0)
 
 
+def _kill_process_tree(proc: subprocess.Popen) -> None:
+    """Kill the child and its whole session, then drain pipes boundedly.
+
+    ``subprocess.run(timeout=...)`` kills only the direct child and then
+    drains its pipes with no timeout; a descendant process (git hook,
+    fsmonitor daemon) that inherited the pipe FDs keeps them open and the
+    drain blocks forever -- the observed "hung inside candidate git status"
+    failure. Killing the whole session and bounding the drain guarantees
+    run_cmd always returns.
+    """
+    try:
+        os.killpg(proc.pid, signal.SIGKILL)
+    except (OSError, AttributeError):
+        proc.kill()
+    try:
+        proc.communicate(timeout=5)
+    except (subprocess.TimeoutExpired, OSError, ValueError):
+        # Last resort: abandon the pipes rather than block the inventory.
+        for stream in (proc.stdout, proc.stderr):
+            if stream is not None:
+                try:
+                    stream.close()
+                except OSError:
+                    pass
+
+
 def run_cmd(args: list[str], cwd: Path, *, timeout: int) -> subprocess.CompletedProcess[str]:
     try:
-        return subprocess.run(
+        proc = subprocess.Popen(
             args,
             cwd=cwd,
             text=True,
-            capture_output=True,
-            check=False,
-            timeout=timeout,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
         )
-    except (OSError, subprocess.TimeoutExpired) as exc:
-        stderr = str(exc)
-        if isinstance(exc, subprocess.TimeoutExpired):
-            stderr = f"command timed out after {timeout}s: {' '.join(args)}"
-        return subprocess.CompletedProcess(args=args, returncode=124, stdout="", stderr=stderr)
+    except OSError as exc:
+        return subprocess.CompletedProcess(args=args, returncode=124, stdout="", stderr=str(exc))
+    try:
+        stdout, stderr = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        _kill_process_tree(proc)
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=124,
+            stdout="",
+            stderr=f"command timed out after {timeout}s: {' '.join(args)}",
+        )
+    return subprocess.CompletedProcess(
+        args=args, returncode=proc.returncode, stdout=stdout or "", stderr=stderr or ""
+    )
 
 
-def run_git(args: list[str], cwd: Path, *, timeout: int = 30) -> subprocess.CompletedProcess[str]:
+def run_git(
+    args: list[str], cwd: Path, *, timeout: int = GIT_TIMEOUT_SECONDS
+) -> subprocess.CompletedProcess[str]:
     return run_cmd(["git", *args], cwd, timeout=timeout)
 
 
@@ -943,6 +992,14 @@ def classify_candidate(
         classification = "unregistered_git_residue"
         proof.append("git checkout is not registered in git worktree list")
 
+    if any(_TIMEOUT_ERROR_MARKER in error for error in git.lookup_errors):
+        # A timed-out lookup is never authoritative: the candidate is already
+        # routed to a protected class (active_or_dirty via the fail-dirty
+        # status path, or lookup_failed), so it can never be safe-to-clean.
+        # Annotate it so operators and the summary can count timeouts.
+        git.inspect_timeout = True
+        proof.append("inspect_timeout: a git/GitHub lookup timed out; candidate is protected")
+
     return build_candidate(
         candidate_root,
         repo_path,
@@ -1123,16 +1180,11 @@ def candidate_roots(root: Path, limit: int | None = None) -> list[Path]:
 
 def _git_common_dir(repo: Path) -> Path | None:
     """Return the git common dir for ``repo`` without raising on non-repos."""
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(repo), "rev-parse", "--path-format=absolute", "--git-common-dir"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-            check=False,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
+    result = run_cmd(
+        ["git", "-C", str(repo), "rev-parse", "--path-format=absolute", "--git-common-dir"],
+        Path("."),
+        timeout=5,
+    )
     if result.returncode != 0:
         return None
     raw = result.stdout.strip()
@@ -1247,6 +1299,7 @@ def build_summary(candidates: list[WorktreeCandidate]) -> dict[str, Any]:
         "bytes_by_class": bytes_by_class,
         "known_size_bytes": known_bytes,
         "size_lookup_failures": size_lookup_failures,
+        "inspect_timeouts": sum(1 for candidate in candidates if candidate.git.inspect_timeout),
         "inventory_coverage": (
             1.0 if not candidates else (len(candidates) - size_lookup_failures) / len(candidates)
         ),
@@ -1432,7 +1485,15 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--limit", type=int)
     parser.add_argument("--size-mode", choices=("du", "stat", "none"), default="du")
     parser.add_argument("--size-timeout", type=int, default=300)
-    parser.add_argument("--git-timeout", type=int, default=30)
+    parser.add_argument(
+        "--git-timeout",
+        "--git-timeout-seconds",
+        dest="git_timeout",
+        type=int,
+        default=GIT_TIMEOUT_SECONDS,
+        help=f"Timeout for each git subprocess (default {GIT_TIMEOUT_SECONDS}s; "
+        "a timed-out candidate is annotated inspect_timeout and preserved)",
+    )
     parser.add_argument("--gh-timeout", type=int, default=30)
     parser.add_argument("--patch-timeout", type=int, default=45)
     parser.add_argument("--skip-gh", action="store_true")

--- a/scripts/codex_worktree_value_inventory.py
+++ b/scripts/codex_worktree_value_inventory.py
@@ -217,6 +217,9 @@ def _kill_process_tree(proc: subprocess.Popen) -> None:
     drain blocks forever -- the observed "hung inside candidate git status"
     failure. Killing the whole session and bounding the drain guarantees
     run_cmd always returns.
+
+    ``os.killpg``/``start_new_session`` are POSIX-only; on platforms without
+    them the AttributeError/OSError fallback kills the direct child only.
     """
     try:
         os.killpg(proc.pid, signal.SIGKILL)
@@ -232,6 +235,10 @@ def _kill_process_tree(proc: subprocess.Popen) -> None:
                     stream.close()
                 except OSError:
                     pass
+        try:
+            proc.wait(timeout=5)  # reap; SIGKILL was already sent above
+        except (subprocess.TimeoutExpired, OSError):
+            pass
 
 
 def run_cmd(args: list[str], cwd: Path, *, timeout: int) -> subprocess.CompletedProcess[str]:
@@ -1180,6 +1187,9 @@ def candidate_roots(root: Path, limit: int | None = None) -> list[Path]:
 
 def _git_common_dir(repo: Path) -> Path | None:
     """Return the git common dir for ``repo`` without raising on non-repos."""
+    # cwd="." is deliberate: ``repo`` may be a deleted/broken worktree path,
+    # and Popen(cwd=<missing dir>) raises before git can answer; ``git -C``
+    # reports the failure gracefully instead.
     result = run_cmd(
         ["git", "-C", str(repo), "rev-parse", "--path-format=absolute", "--git-common-dir"],
         Path("."),

--- a/scripts/funnel_stage_metrics.py
+++ b/scripts/funnel_stage_metrics.py
@@ -43,6 +43,7 @@ import argparse
 import json
 import math
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -244,15 +245,20 @@ def run_snapshot(
     annotations: list[str] = []
 
     try:
+        raw_open = list_open_prs()
         open_prs = [
-            pr
-            for pr in list_open_prs()
-            if isinstance(pr, dict) and _matches_prefix(pr, branch_prefixes)
+            pr for pr in raw_open if isinstance(pr, dict) and _matches_prefix(pr, branch_prefixes)
         ]
         outbox_depth, outbox_missing = count_outbox_depth(outbox_dir)
     except (RuntimeError, OSError, ValueError, subprocess.SubprocessError) as exc:
         print(json.dumps({"action": "error", "error": str(exc)[:500]}), file=sys.stderr)
         return EXIT_FAILURE
+
+    # ``gh pr list`` truncates BEFORE the prefix filter, so a raw payload at
+    # the limit makes every count derived from it a floor, not a total.
+    open_truncated = len(raw_open) >= OPEN_LIST_LIMIT
+    if open_truncated:
+        annotations.append(f"list_truncated_open:>={OPEN_LIST_LIMIT}")
 
     if outbox_missing:
         annotations.append(f"outbox_dir_missing:{outbox_dir}")
@@ -262,13 +268,20 @@ def run_snapshot(
     merged_24h: int | None
     try:
         merged = list_merged_prs(since)
-        merged_24h = 0
-        for pr in merged:
-            if not isinstance(pr, dict) or not _matches_prefix(pr, branch_prefixes):
-                continue
-            merged_at = _parse_iso(pr.get("mergedAt"))
-            if merged_at is not None and merged_at >= since:
-                merged_24h += 1
+        if len(merged) >= MERGED_LIST_LIMIT:
+            # Truncation happens before the prefix filter, so the filtered
+            # count would be a misleading undercount; degrade to null like
+            # the failed-search path instead of reporting it.
+            merged_24h = None
+            annotations.append(f"list_truncated_merged:>={MERGED_LIST_LIMIT}")
+        else:
+            merged_24h = 0
+            for pr in merged:
+                if not isinstance(pr, dict) or not _matches_prefix(pr, branch_prefixes):
+                    continue
+                merged_at = _parse_iso(pr.get("mergedAt"))
+                if merged_at is not None and merged_at >= since:
+                    merged_24h += 1
     except (RuntimeError, OSError, ValueError, subprocess.SubprocessError) as exc:
         merged_24h = None
         annotations.append(f"merged_search_failed:{str(exc)[:200]}")
@@ -308,6 +321,11 @@ def run_snapshot(
         )
     if stale_tail > max_stale_tail:
         thresholds_breached.append(f"stale_tail:{stale_tail}>max_stale_tail:{max_stale_tail}")
+    if open_truncated:
+        # Stage counts and stale_tail are unreliable floors when the open
+        # listing is truncated; the snapshot exists to surface breaches, and
+        # unknown-because-truncated is breach-worthy.
+        thresholds_breached.append("open_list_truncated")
 
     payload = {
         "generated_at": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -339,6 +357,16 @@ def run_snapshot(
     return EXIT_BREACH if thresholds_breached else EXIT_OK
 
 
+_REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+
+
+def repo_arg(value: str) -> str:
+    """Argparse type: validate ``owner/name`` at parse time, before any gh call."""
+    if not _REPO_RE.match(value):
+        raise argparse.ArgumentTypeError(f"--repo must look like owner/name, got {value!r}")
+    return value
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description=(
@@ -347,7 +375,9 @@ def main(argv: list[str] | None = None) -> int:
             "tail. Exits 0 normally, 3 if a threshold is breached, 1 on failure."
         )
     )
-    parser.add_argument("--repo", default=DEFAULT_REPO, help="GitHub repo (owner/name)")
+    parser.add_argument(
+        "--repo", default=DEFAULT_REPO, type=repo_arg, help="GitHub repo (owner/name)"
+    )
     parser.add_argument(
         "--branch-prefix",
         action="append",

--- a/scripts/funnel_stage_metrics.py
+++ b/scripts/funnel_stage_metrics.py
@@ -214,7 +214,7 @@ def atomic_write_json(path: str, payload: dict[str, Any]) -> None:
     finally:
         try:
             os.unlink(tmp)
-        except FileNotFoundError:
+        except OSError:  # never mask the primary error with a cleanup failure
             pass
 
 

--- a/scripts/funnel_stage_metrics.py
+++ b/scripts/funnel_stage_metrics.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""Funnel telemetry snapshot for the autonomous PR pipeline (READ-ONLY).
+
+The pipeline (writer lanes -> outbox publisher -> draft PRs -> ready ->
+evidence -> quorum -> arbiter merge) has no time-in-state measurement per
+funnel stage, so pileups go unnoticed until they are hundreds of units deep.
+This script takes one read-only snapshot per run:
+
+1. One ``gh pr list`` call for open automation PRs (draft + ready stages,
+   ``--limit 300``), filtered by ``--branch-prefix`` (default ``codex/``,
+   repeatable).
+2. One ``gh pr list --state merged --search "merged:>=<ISO 24h ago>"`` call
+   (``--limit 100``). If the search variant fails, the snapshot degrades
+   gracefully to ``merged_24h: null`` with an annotation rather than failing.
+3. Outbox depth: count of ``*.json`` files directly in ``--outbox-dir``
+   (default ``.aragora/automation-outbox``; missing dir = 0 with an
+   annotation).
+
+Emits JSON to stdout (and atomically to ``--out`` when given)::
+
+    {generated_at, outbox_depth,
+     stages: {draft: {count, age_hours: {p50, p90, max}},
+              ready: {count, age_hours: {p50, p90, max}}},
+     merged_24h, stale_tail, thresholds, thresholds_breached[], annotations[]}
+
+``stale_tail`` counts open automation PRs older than ``--stale-days``
+(default 4). ``thresholds_breached`` records a breach when the draft-stage
+age p90 exceeds ``--max-draft-age-hours`` (default 72) or ``stale_tail``
+exceeds ``--max-stale-tail`` (default 20).
+
+Exit codes (sentinel-friendly): 0 normal, 3 if any threshold breached,
+1 on failure.
+
+Safety model (mirrors ``backlog_gate.py`` / ``pr_ready_triage.py``):
+read-only against GitHub, no mutations; the only file this script can write
+is the optional ``--out`` snapshot (temp file + ``os.replace``). Stdlib-only
+by design so it can run anywhere ``gh`` is authenticated.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable
+
+DEFAULT_REPO = "synaptent/aragora"
+DEFAULT_BRANCH_PREFIXES = ("codex/",)
+DEFAULT_OUTBOX_DIR = os.path.join(".aragora", "automation-outbox")
+DEFAULT_STALE_DAYS = 4
+DEFAULT_MAX_DRAFT_AGE_HOURS = 72.0
+DEFAULT_MAX_STALE_TAIL = 20
+GH_TIMEOUT_SECONDS = 120
+OPEN_LIST_LIMIT = 300
+MERGED_LIST_LIMIT = 100
+
+EXIT_OK = 0
+EXIT_FAILURE = 1
+EXIT_BREACH = 3
+
+_GH_OPEN_FIELDS = "number,headRefName,isDraft,createdAt,updatedAt,labels"
+_GH_MERGED_FIELDS = "number,headRefName,mergedAt,createdAt"
+
+
+# --- Parsing / math helpers ----------------------------------------------------------
+
+
+def _parse_iso(ts: Any) -> datetime | None:
+    if not ts:
+        return None
+    try:
+        dt = datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def percentile(values: list[float], pct: float) -> float | None:
+    """Linear-interpolated percentile of ``values``; None for an empty list."""
+    if not values:
+        return None
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    rank = (len(ordered) - 1) * (pct / 100.0)
+    lower = math.floor(rank)
+    upper = math.ceil(rank)
+    if lower == upper:
+        return ordered[int(rank)]
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * (rank - lower)
+
+
+def _round(value: float | None) -> float | None:
+    return None if value is None else round(value, 2)
+
+
+def age_stats(ages_hours: list[float]) -> dict[str, float | None]:
+    return {
+        "p50": _round(percentile(ages_hours, 50)),
+        "p90": _round(percentile(ages_hours, 90)),
+        "max": _round(max(ages_hours)) if ages_hours else None,
+    }
+
+
+# --- Inputs (read-only) -------------------------------------------------------------
+
+
+def default_list_open_prs(repo: str) -> list[dict[str, Any]]:
+    """One ``gh pr list`` call for open PRs (read-only, capped at 300)."""
+    command = [
+        "gh",
+        "pr",
+        "list",
+        "--repo",
+        repo,
+        "--state",
+        "open",
+        "--json",
+        _GH_OPEN_FIELDS,
+        "--limit",
+        str(OPEN_LIST_LIMIT),
+    ]
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        timeout=GH_TIMEOUT_SECONDS,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"gh pr list failed (exit {result.returncode}): {result.stderr.strip()}")
+    payload = json.loads(result.stdout or "[]")
+    if not isinstance(payload, list):
+        raise RuntimeError("gh pr list returned unexpected payload (expected a list)")
+    return payload
+
+
+def default_list_merged_prs(repo: str, since: datetime) -> list[dict[str, Any]]:
+    """One ``gh pr list --state merged --search`` call (read-only, capped at 100).
+
+    Raises on any failure; the caller degrades gracefully to
+    ``merged_24h: null`` with an annotation rather than failing the snapshot.
+    """
+    command = [
+        "gh",
+        "pr",
+        "list",
+        "--repo",
+        repo,
+        "--state",
+        "merged",
+        "--json",
+        _GH_MERGED_FIELDS,
+        "--limit",
+        str(MERGED_LIST_LIMIT),
+        "--search",
+        f"merged:>={since.strftime('%Y-%m-%dT%H:%M:%SZ')}",
+    ]
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        timeout=GH_TIMEOUT_SECONDS,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"gh pr list (merged search) failed (exit {result.returncode}): {result.stderr.strip()}"
+        )
+    payload = json.loads(result.stdout or "[]")
+    if not isinstance(payload, list):
+        raise RuntimeError("gh pr list (merged search) returned unexpected payload")
+    return payload
+
+
+def count_outbox_depth(outbox_dir: str) -> tuple[int, bool]:
+    """Count ``*.json`` files directly in the outbox dir.
+
+    A missing directory is (0, True) -- annotated, never an error.
+    (Deliberately duplicated from ``backlog_gate.py``: these scripts are
+    freestanding stdlib files by design.)
+    """
+    if not os.path.isdir(outbox_dir):
+        return 0, True
+    depth = 0
+    with os.scandir(outbox_dir) as entries:
+        for entry in entries:
+            if entry.is_file() and entry.name.endswith(".json"):
+                depth += 1
+    return depth, False
+
+
+# --- Output ----------------------------------------------------------------------------
+
+
+def atomic_write_json(path: str, payload: dict[str, Any]) -> None:
+    """Write temp + ``os.replace`` so readers never observe a partial file."""
+    directory = os.path.dirname(path) or "."
+    os.makedirs(directory, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=f".{os.path.basename(path)}.", dir=directory)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh, indent=2, sort_keys=True)
+            fh.write("\n")
+        os.replace(tmp, path)
+    finally:
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+
+
+# --- Snapshot ---------------------------------------------------------------------------
+
+
+def _matches_prefix(pr: dict[str, Any], branch_prefixes: tuple[str, ...]) -> bool:
+    head = str(pr.get("headRefName") or "")
+    return any(head.startswith(prefix) for prefix in branch_prefixes)
+
+
+def run_snapshot(
+    *,
+    list_open_prs: Callable[[], list[dict[str, Any]]],
+    list_merged_prs: Callable[[datetime], list[dict[str, Any]]],
+    branch_prefixes: tuple[str, ...] = DEFAULT_BRANCH_PREFIXES,
+    outbox_dir: str = DEFAULT_OUTBOX_DIR,
+    stale_days: int = DEFAULT_STALE_DAYS,
+    max_draft_age_hours: float = DEFAULT_MAX_DRAFT_AGE_HOURS,
+    max_stale_tail: int = DEFAULT_MAX_STALE_TAIL,
+    out_file: str | None = None,
+    now: datetime | None = None,
+    log: Callable[[str], None] = print,
+) -> int:
+    """Build one funnel snapshot; return 0 / 3 (threshold breach) / 1 (failure)."""
+    if now is None:
+        now = datetime.now(timezone.utc)
+    annotations: list[str] = []
+
+    try:
+        open_prs = [
+            pr
+            for pr in list_open_prs()
+            if isinstance(pr, dict) and _matches_prefix(pr, branch_prefixes)
+        ]
+        outbox_depth, outbox_missing = count_outbox_depth(outbox_dir)
+    except (RuntimeError, OSError, ValueError, subprocess.SubprocessError) as exc:
+        print(json.dumps({"action": "error", "error": str(exc)[:500]}), file=sys.stderr)
+        return EXIT_FAILURE
+
+    if outbox_missing:
+        annotations.append(f"outbox_dir_missing:{outbox_dir}")
+
+    # Merged-in-24h, degrading gracefully when the search variant fails.
+    since = now - timedelta(hours=24)
+    merged_24h: int | None
+    try:
+        merged = list_merged_prs(since)
+        merged_24h = 0
+        for pr in merged:
+            if not isinstance(pr, dict) or not _matches_prefix(pr, branch_prefixes):
+                continue
+            merged_at = _parse_iso(pr.get("mergedAt"))
+            if merged_at is not None and merged_at >= since:
+                merged_24h += 1
+    except (RuntimeError, OSError, ValueError, subprocess.SubprocessError) as exc:
+        merged_24h = None
+        annotations.append(f"merged_search_failed:{str(exc)[:200]}")
+
+    # Stage ages: unparseable createdAt is excluded from age math (and the
+    # stale tail) but still counted in the stage count.
+    draft_ages: list[float] = []
+    ready_ages: list[float] = []
+    draft_count = 0
+    ready_count = 0
+    stale_tail = 0
+    stale_cutoff = timedelta(days=max(0, stale_days))
+    for pr in open_prs:
+        is_draft = bool(pr.get("isDraft"))
+        if is_draft:
+            draft_count += 1
+        else:
+            ready_count += 1
+        created = _parse_iso(pr.get("createdAt"))
+        if created is None:
+            continue
+        age_hours = (now - created).total_seconds() / 3600.0
+        (draft_ages if is_draft else ready_ages).append(age_hours)
+        if now - created > stale_cutoff:
+            stale_tail += 1
+
+    stages = {
+        "draft": {"count": draft_count, "age_hours": age_stats(draft_ages)},
+        "ready": {"count": ready_count, "age_hours": age_stats(ready_ages)},
+    }
+
+    thresholds_breached: list[str] = []
+    draft_p90 = stages["draft"]["age_hours"]["p90"]
+    if draft_p90 is not None and draft_p90 > max_draft_age_hours:
+        thresholds_breached.append(
+            f"draft_age_p90:{draft_p90}>max_draft_age_hours:{max_draft_age_hours}"
+        )
+    if stale_tail > max_stale_tail:
+        thresholds_breached.append(f"stale_tail:{stale_tail}>max_stale_tail:{max_stale_tail}")
+
+    payload = {
+        "generated_at": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "outbox_depth": outbox_depth,
+        "stages": stages,
+        "merged_24h": merged_24h,
+        "stale_tail": stale_tail,
+        "thresholds": {
+            "max_draft_age_hours": max_draft_age_hours,
+            "max_stale_tail": max_stale_tail,
+            "stale_days": stale_days,
+        },
+        "thresholds_breached": thresholds_breached,
+        "annotations": annotations,
+    }
+
+    log(json.dumps(payload, sort_keys=True))
+
+    if out_file:
+        try:
+            atomic_write_json(out_file, payload)
+        except OSError as exc:
+            print(
+                json.dumps({"action": "out_write_failed", "error": str(exc)[:300]}),
+                file=sys.stderr,
+            )
+            return EXIT_FAILURE
+
+    return EXIT_BREACH if thresholds_breached else EXIT_OK
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Read-only funnel telemetry snapshot for automation PRs: per-stage "
+            "counts and age percentiles, merged-in-24h, outbox depth, stale "
+            "tail. Exits 0 normally, 3 if a threshold is breached, 1 on failure."
+        )
+    )
+    parser.add_argument("--repo", default=DEFAULT_REPO, help="GitHub repo (owner/name)")
+    parser.add_argument(
+        "--branch-prefix",
+        action="append",
+        default=None,
+        help=f"Head-branch prefix to count; repeatable (default: {list(DEFAULT_BRANCH_PREFIXES)})",
+    )
+    parser.add_argument(
+        "--outbox-dir",
+        default=DEFAULT_OUTBOX_DIR,
+        help=f"Outbox directory whose direct *.json files are counted "
+        f"(default {DEFAULT_OUTBOX_DIR}; missing dir counts as 0)",
+    )
+    parser.add_argument(
+        "--stale-days",
+        type=int,
+        default=DEFAULT_STALE_DAYS,
+        help=f"Open PRs older than this many days count toward the stale tail "
+        f"(default {DEFAULT_STALE_DAYS})",
+    )
+    parser.add_argument(
+        "--max-draft-age-hours",
+        type=float,
+        default=DEFAULT_MAX_DRAFT_AGE_HOURS,
+        help=f"Breach when draft-stage age p90 exceeds this "
+        f"(default {DEFAULT_MAX_DRAFT_AGE_HOURS})",
+    )
+    parser.add_argument(
+        "--max-stale-tail",
+        type=int,
+        default=DEFAULT_MAX_STALE_TAIL,
+        help=f"Breach when the stale tail exceeds this (default {DEFAULT_MAX_STALE_TAIL})",
+    )
+    parser.add_argument(
+        "--out",
+        default=None,
+        help="Optional path to atomically write the snapshot JSON",
+    )
+    args = parser.parse_args(argv)
+
+    prefixes = tuple(args.branch_prefix) if args.branch_prefix else DEFAULT_BRANCH_PREFIXES
+
+    return run_snapshot(
+        list_open_prs=lambda: default_list_open_prs(args.repo),
+        list_merged_prs=lambda since: default_list_merged_prs(args.repo, since),
+        branch_prefixes=prefixes,
+        outbox_dir=args.outbox_dir,
+        stale_days=args.stale_days,
+        max_draft_age_hours=args.max_draft_age_hours,
+        max_stale_tail=args.max_stale_tail,
+        out_file=args.out,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pr_ready_triage.py
+++ b/scripts/pr_ready_triage.py
@@ -1,0 +1,522 @@
+#!/usr/bin/env python3
+"""Bounded draft→ready promoter for writer-agent PRs (pipeline gap fix).
+
+Writer agents produce ``codex/`` branches and the publisher opens DRAFT PRs,
+but nothing in the pipeline promotes those drafts to ready — so the downstream
+machinery (``scripts/auto_evidence_cycle.py`` evidence minting,
+``scripts/quorum_rerun_reconciler.py`` quorum reruns,
+``scripts/auto_merge_bucket_a.py`` merges) starves. This script closes that
+gap autonomously and *boundedly*: it selects qualifying draft PRs and runs
+``gh pr ready`` on at most ``--max-promotions`` of them per invocation.
+
+Probe (cheapest reliable, two stages — mirrors ``auto_evidence_cycle.py``):
+
+1. One ``gh pr list --draft`` call prunes obviously unpromotable drafts:
+   wrong branch prefix, failing/errored checks, not MERGEABLE, blocking
+   labels (``merge:manual``, ``do-not-promote``, ``held``), draft-by-design
+   governance markers in title/body (hard never-promote, see below), and PRs
+   younger than ``--min-age-minutes`` (lets draft CI finish).
+2. Each survivor (up to ``--max-scan``) is confirmed against the gate's own
+   ground truth: ``review-queue merge-packet --pr N --json``. Only Tier 0-2
+   entries with no ``requires_human_risk_settlement`` and
+   ``unresolved_dissent`` false qualify. A missing/unknown tier is a REJECT
+   (fail closed) — the same rule ``auto_evidence_cycle.needs_evidence``
+   applies.
+
+Hard never-promote: governance PRs that are draft by design — Tier 4
+settlements, operator-settlement-required changes, anything mentioning the
+Scarmani escalation track — must NEVER be marked ready by automation. Any PR
+whose title or body matches (case-insensitive)
+``tier\\s*4 | draft by design | do not mark ready | operator settlement
+required | scarmani`` is excluded in stage 1 before any packet probe.
+
+Safety model (mirrors ``boss_pr_janitor.py`` / ``auto_evidence_cycle.py``):
+
+- Dry-run by default: the plan is printed as JSON lines, nothing mutates.
+  ``--apply`` gates ALL mutations (the only mutation is ``gh pr ready``).
+- Per-invocation caps: ``--max-promotions`` (default 5), ``--max-scan``
+  packet probes (default 15).
+- Identical-error breaker: 3 consecutive identical promotion failures abort
+  the run (exit 2) — a systemic fault (gh auth broken) must not burn the cap.
+- Fail-closed exits: 0 clean (including empty plan), 1 any failure,
+  2 breaker tripped.
+
+Downstream: promoted PRs are picked up by ``scripts/auto_evidence_cycle.py``
+on the next arbiter pass; this script takes no further action after ``gh pr
+ready``.
+
+Stdlib-only by design so it can run anywhere ``gh`` is authenticated.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable
+
+DEFAULT_REPO = "synaptent/aragora"
+DEFAULT_BRANCH_PREFIXES = ("codex/",)
+DEFAULT_MIN_AGE_MINUTES = 30
+DEFAULT_MAX_SCAN = 15
+DEFAULT_MAX_PROMOTIONS = 5
+DEFAULT_BREAKER_THRESHOLD = 3
+GH_TIMEOUT_SECONDS = 120
+PACKET_TIMEOUT_SECONDS = 300
+
+EXIT_OK = 0
+EXIT_FAILURES = 1
+EXIT_BREAKER = 2
+
+# Merge-packet tiers eligible for autonomous promotion. Same band as
+# auto_evidence_cycle.AUTO_POSTABLE_TIERS; missing/unknown tier always rejects.
+PROMOTABLE_TIERS = frozenset({0, 1, 2})
+
+# Labels that veto promotion outright (stage 1).
+BLOCKING_LABELS = frozenset({"merge:manual", "do-not-promote", "held"})
+
+# Draft-by-design governance markers (title or body, case-insensitive).
+# These PRs are draft on purpose — Tier 4 settlements, operator-settlement
+# flows, the Scarmani escalation track — and must NEVER be promoted.
+NEVER_PROMOTE_RE = re.compile(
+    r"tier\s*4|draft by design|do not mark ready|operator settlement required|scarmani",
+    re.IGNORECASE,
+)
+
+# Check states/conclusions that disqualify a draft (same set as
+# boss_pr_janitor._FAILING_STATES).
+_FAILING_STATES = frozenset(
+    {
+        "FAILURE",
+        "ERROR",
+        "CANCELLED",
+        "TIMED_OUT",
+        "ACTION_REQUIRED",
+        "STARTUP_FAILURE",
+    }
+)
+
+_GH_LIST_FIELDS = (
+    "number,headRefName,title,body,labels,statusCheckRollup,mergeable,createdAt,updatedAt"
+)
+
+
+# --- Stage 1: cheap pruning ------------------------------------------------------
+
+
+def _labels(pr: dict[str, Any]) -> set[str]:
+    raw = pr.get("labels") or []
+    out: set[str] = set()
+    if not isinstance(raw, list):
+        return out
+    for item in raw:
+        name = str(item.get("name") or "") if isinstance(item, dict) else str(item)
+        if name:
+            out.add(name)
+    return out
+
+
+def has_failing_checks(pr: dict[str, Any]) -> bool:
+    rollup = pr.get("statusCheckRollup") or []
+    if not isinstance(rollup, list):
+        return False
+    for check in rollup:
+        if not isinstance(check, dict):
+            continue
+        state = str(check.get("state") or "").upper()
+        conclusion = str(check.get("conclusion") or "").upper()
+        if state in _FAILING_STATES or conclusion in _FAILING_STATES:
+            return True
+    return False
+
+
+def is_draft_by_design(pr: dict[str, Any]) -> bool:
+    """Hard never-promote: governance markers in title or body."""
+    text = f"{pr.get('title') or ''}\n{pr.get('body') or ''}"
+    return NEVER_PROMOTE_RE.search(text) is not None
+
+
+def _parse_iso(ts: Any) -> datetime | None:
+    if not ts:
+        return None
+    try:
+        dt = datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _too_young(pr: dict[str, Any], *, min_age_minutes: int, now: datetime) -> bool:
+    """Fail closed: an unparseable/missing createdAt counts as too young."""
+    created = _parse_iso(pr.get("createdAt"))
+    if created is None:
+        return True
+    return now - created < timedelta(minutes=max(0, min_age_minutes))
+
+
+def stage1_blocker(
+    pr: dict[str, Any],
+    *,
+    branch_prefixes: tuple[str, ...],
+    min_age_minutes: int,
+    now: datetime,
+) -> str | None:
+    """Return the stage-1 prune reason, or None if the draft survives."""
+    head = str(pr.get("headRefName") or "")
+    if not any(head.startswith(prefix) for prefix in branch_prefixes):
+        return f"branch prefix not in {list(branch_prefixes)}"
+    if is_draft_by_design(pr):
+        return "draft-by-design governance marker (hard never-promote)"
+    blocked = sorted(_labels(pr) & BLOCKING_LABELS)
+    if blocked:
+        return f"blocking label ({blocked[0]})"
+    if has_failing_checks(pr):
+        return "failing/errored check in rollup"
+    mergeable = str(pr.get("mergeable") or "")
+    if mergeable != "MERGEABLE":
+        return f"mergeable={mergeable or '(unknown)'} (requires MERGEABLE)"
+    if _too_young(pr, min_age_minutes=min_age_minutes, now=now):
+        return f"younger than {min_age_minutes}m (draft CI may still be running)"
+    return None
+
+
+def stage1_candidates(
+    prs: list[dict[str, Any]],
+    *,
+    branch_prefixes: tuple[str, ...],
+    min_age_minutes: int,
+    now: datetime,
+) -> list[dict[str, Any]]:
+    """Drafts surviving the cheap prune, oldest PR number first."""
+    survivors: list[dict[str, Any]] = []
+    for pr in prs:
+        if not isinstance(pr, dict):
+            continue
+        try:
+            int(pr["number"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        blocker = stage1_blocker(
+            pr, branch_prefixes=branch_prefixes, min_age_minutes=min_age_minutes, now=now
+        )
+        if blocker is None:
+            survivors.append(pr)
+    return sorted(survivors, key=lambda pr: int(pr["number"]))
+
+
+# --- Stage 2: merge-packet ground truth -------------------------------------------
+#
+# Field names come from the canonical merge-packet entries that
+# auto_evidence_cycle.needs_evidence reads: ``tier``,
+# ``requires_human_risk_settlement``, ``unresolved_dissent`` (and ``pr_number``
+# for entry matching in default_fetch_packet). Do not invent new keys.
+
+
+def packet_blocker(entry: dict[str, Any]) -> str | None:
+    """Return the stage-2 reject reason, or None when promotion is allowed.
+
+    Fail closed: an empty packet or a missing/unparseable tier always rejects.
+    """
+    if not entry:
+        return "empty merge packet (fail closed)"
+    raw_tier = entry.get("tier")
+    if not isinstance(raw_tier, (int, str)):
+        return f"unknown tier {raw_tier!r} (fail closed)"
+    try:
+        tier = int(raw_tier)
+    except (TypeError, ValueError):
+        return f"unknown tier {raw_tier!r} (fail closed)"
+    if tier not in PROMOTABLE_TIERS:
+        return f"tier {tier} outside promotable band {sorted(PROMOTABLE_TIERS)}"
+    if entry.get("requires_human_risk_settlement"):
+        return "requires_human_risk_settlement"
+    if entry.get("unresolved_dissent"):
+        return "unresolved_dissent"
+    return None
+
+
+# --- Default (real) I/O callables --------------------------------------------------
+
+
+def default_list_draft_prs(repo: str) -> list[dict[str, Any]]:
+    """One cheap ``gh pr list --draft`` call (read-only)."""
+    command = [
+        "gh",
+        "pr",
+        "list",
+        "--repo",
+        repo,
+        "--state",
+        "open",
+        "--draft",
+        "--json",
+        _GH_LIST_FIELDS,
+        "--limit",
+        "200",
+    ]
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        timeout=GH_TIMEOUT_SECONDS,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"gh pr list failed (exit {result.returncode}): {result.stderr.strip()}")
+    payload = json.loads(result.stdout or "[]")
+    if not isinstance(payload, list):
+        raise RuntimeError("gh pr list returned unexpected payload (expected a list)")
+    return payload
+
+
+def default_fetch_packet(repo: str, pr: int) -> dict[str, Any]:
+    """Canonical per-PR probe: ``review-queue merge-packet --pr N --json``.
+
+    Same entry-unwrapping logic as ``auto_evidence_cycle.default_fetch_packet``.
+    Returns ``{}`` on any failure (which stage 2 rejects, fail closed).
+    """
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "aragora.cli.main",
+                "review-queue",
+                "merge-packet",
+                "--pr",
+                str(pr),
+                "--repo",
+                repo,
+                "--json",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=PACKET_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return {}
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return {}
+    try:
+        payload = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return {}
+    if isinstance(payload, dict):
+        entries = payload.get("entries")
+        entries = entries if isinstance(entries, list) else [payload]
+    elif isinstance(payload, list):
+        entries = payload
+    else:
+        return {}
+    for entry in entries:
+        if isinstance(entry, dict) and str(entry.get("pr_number")) == str(pr):
+            return entry
+    return {}
+
+
+def default_mark_ready(repo: str, pr: int) -> tuple[bool, str]:
+    """The only mutation: ``gh pr ready N``. Returns (ok, error)."""
+    command = ["gh", "pr", "ready", str(pr), "--repo", repo]
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=GH_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return False, f"{type(exc).__name__}"
+    if result.returncode != 0:
+        return False, result.stderr.strip()[:300] or f"gh pr ready exited {result.returncode}"
+    return True, ""
+
+
+# --- Orchestrator -------------------------------------------------------------------
+
+
+def run_triage(
+    *,
+    list_prs: Callable[[], list[dict[str, Any]]],
+    fetch_packet: Callable[[int], dict[str, Any]],
+    mark_ready: Callable[[int], tuple[bool, str]],
+    apply: bool,
+    branch_prefixes: tuple[str, ...] = DEFAULT_BRANCH_PREFIXES,
+    min_age_minutes: int = DEFAULT_MIN_AGE_MINUTES,
+    max_scan: int = DEFAULT_MAX_SCAN,
+    max_promotions: int = DEFAULT_MAX_PROMOTIONS,
+    breaker_threshold: int = DEFAULT_BREAKER_THRESHOLD,
+    now: datetime | None = None,
+    log: Callable[[str], None] = print,
+) -> dict[str, Any]:
+    """Plan and (with ``apply``) execute one bounded promotion pass."""
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    summary: dict[str, Any] = {
+        "mode": "apply" if apply else "dry-run",
+        "plan": [],
+        "rejected": [],
+        "promoted": [],
+        "failed": [],
+        "breaker_tripped": False,
+        "exit_code": EXIT_OK,
+    }
+
+    survivors = stage1_candidates(
+        list_prs(),
+        branch_prefixes=branch_prefixes,
+        min_age_minutes=min_age_minutes,
+        now=now,
+    )
+
+    probes = 0
+    for pr in survivors:
+        if len(summary["plan"]) >= max_promotions or probes >= max_scan:
+            break
+        probes += 1
+        number = int(pr["number"])
+        entry = fetch_packet(number)
+        blocker = packet_blocker(entry)
+        if blocker is not None:
+            summary["rejected"].append({"pr": number, "reason": blocker})
+            log(json.dumps({"action": "reject", "pr": number, "reason": blocker}))
+            continue
+        item = {
+            "action": "promote",
+            "pr": number,
+            "head_ref": pr.get("headRefName"),
+            "title": str(pr.get("title") or "")[:80],
+            "tier": entry.get("tier"),
+        }
+        summary["plan"].append(item)
+        log(json.dumps({**item, "dry_run": not apply}))
+
+    if apply:
+        identical_errors = 0
+        last_error: str | None = None
+        for item in summary["plan"]:
+            ok, error = mark_ready(item["pr"])
+            if ok:
+                summary["promoted"].append(item["pr"])
+                identical_errors = 0
+                last_error = None
+                log(json.dumps({"action": "promoted", "pr": item["pr"]}))
+                continue
+            summary["failed"].append(item["pr"])
+            log(json.dumps({"action": "promote_failed", "pr": item["pr"], "error": error[:300]}))
+            identical_errors = identical_errors + 1 if error == last_error else 1
+            last_error = error
+            if identical_errors >= breaker_threshold:
+                summary["breaker_tripped"] = True
+                log(
+                    json.dumps(
+                        {
+                            "action": "breaker_tripped",
+                            "identical_errors": identical_errors,
+                            "error": error[:300],
+                        }
+                    )
+                )
+                break
+
+    if summary["breaker_tripped"]:
+        summary["exit_code"] = EXIT_BREAKER
+    elif summary["failed"]:
+        summary["exit_code"] = EXIT_FAILURES
+
+    log(
+        json.dumps(
+            {
+                "action": "summary",
+                "mode": summary["mode"],
+                "stage1_survivors": len(survivors),
+                "packet_probes": probes,
+                "planned_promotions": len(summary["plan"]),
+                "rejected": len(summary["rejected"]),
+                "promoted": summary["promoted"],
+                "failed": summary["failed"],
+                "breaker_tripped": summary["breaker_tripped"],
+                "downstream": (
+                    "promoted PRs are picked up by scripts/auto_evidence_cycle.py "
+                    "on the next arbiter pass; no further action here"
+                ),
+            }
+        )
+    )
+    return summary
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Bounded draft-to-ready promoter for writer-agent PRs. Dry-run by "
+            "default; --apply gates the only mutation (gh pr ready)."
+        )
+    )
+    parser.add_argument("--repo", default=DEFAULT_REPO, help="GitHub repo (owner/name)")
+    parser.add_argument(
+        "--branch-prefix",
+        action="append",
+        default=None,
+        help=f"Head-branch prefix to consider; repeatable (default: {list(DEFAULT_BRANCH_PREFIXES)})",
+    )
+    parser.add_argument(
+        "--min-age-minutes",
+        type=int,
+        default=DEFAULT_MIN_AGE_MINUTES,
+        help=f"Skip drafts younger than this, letting draft CI finish (default {DEFAULT_MIN_AGE_MINUTES})",
+    )
+    parser.add_argument(
+        "--max-scan",
+        type=int,
+        default=DEFAULT_MAX_SCAN,
+        help=f"Maximum merge-packet probes per run (default {DEFAULT_MAX_SCAN})",
+    )
+    parser.add_argument(
+        "--max-promotions",
+        type=int,
+        default=DEFAULT_MAX_PROMOTIONS,
+        help=f"Maximum PRs promoted per run (default {DEFAULT_MAX_PROMOTIONS})",
+    )
+    parser.add_argument(
+        "--breaker-threshold",
+        type=int,
+        default=DEFAULT_BREAKER_THRESHOLD,
+        help=f"Consecutive identical promotion failures that abort the run (default {DEFAULT_BREAKER_THRESHOLD})",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        default=False,
+        help="Actually run gh pr ready (default: dry-run, read-only)",
+    )
+    args = parser.parse_args(argv)
+
+    prefixes = tuple(args.branch_prefix) if args.branch_prefix else DEFAULT_BRANCH_PREFIXES
+
+    try:
+        summary = run_triage(
+            list_prs=lambda: default_list_draft_prs(args.repo),
+            fetch_packet=lambda pr: default_fetch_packet(args.repo, pr),
+            mark_ready=lambda pr: default_mark_ready(args.repo, pr),
+            apply=args.apply,
+            branch_prefixes=prefixes,
+            min_age_minutes=args.min_age_minutes,
+            max_scan=max(0, args.max_scan),
+            max_promotions=max(0, args.max_promotions),
+            breaker_threshold=max(1, args.breaker_threshold),
+        )
+    except (RuntimeError, json.JSONDecodeError, OSError, subprocess.SubprocessError) as exc:
+        print(json.dumps({"action": "error", "error": str(exc)[:500]}), file=sys.stderr)
+        return EXIT_FAILURES
+    return int(summary["exit_code"])
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pr_ready_triage.py
+++ b/scripts/pr_ready_triage.py
@@ -89,10 +89,14 @@ NEVER_PROMOTE_RE = re.compile(
 
 # Zero-width characters stripped before the never-promote match so markers
 # can't be split invisibly (ZWSP, ZWNJ, ZWJ, BOM/ZWNBSP, word joiner).
-_ZERO_WIDTH_RE = re.compile(
-    "[\N{ZERO WIDTH SPACE}\N{ZERO WIDTH NON-JOINER}\N{ZERO WIDTH JOINER}"
-    "\N{ZERO WIDTH NO-BREAK SPACE}\N{WORD JOINER}]"
+# All Unicode format chars (category Cf: zero-widths, soft hyphen, BOM, ...)
+# are stripped, and every separator (category Zs, incl. the one space NFKC
+# does not fold, U+1680 OGHAM SPACE MARK) maps to a plain ASCII space.
+_FORMAT_CHARS_RE = re.compile(
+    r"[\u00ad\u0600-\u0605\u061c\u06dd\u070f\u08e2\u180e\u200b-\u200f\u202a-\u202e\u2060-\u2064\u2066-\u206f\ufeff\ufff9-\ufffb]"
 )
+_SPACE_SEPARATORS_RE = re.compile(r"[\u1680\u2000-\u200a\u202f\u205f\u3000\u00a0]")
+_MULTI_SPACE_RE = re.compile(r"[ \t]+")
 
 # Check states/conclusions that disqualify a draft (same set as
 # boss_pr_janitor._FAILING_STATES).
@@ -144,11 +148,20 @@ def has_failing_checks(pr: dict[str, Any]) -> bool:
 def _normalize_marker_text(text: str) -> str:
     """Normalize against Unicode evasion before the never-promote match.
 
-    NFKC folds fullwidth/compatibility forms (``Ｔｉｅｒ ４`` -> ``Tier 4``),
-    zero-width characters are stripped so markers can't be split invisibly,
-    and ``casefold`` handles aggressive case mappings beyond IGNORECASE.
+    NFKC folds fullwidth/compatibility forms (``Ｔｉｅｒ ４`` -> ``Tier 4``)
+    and most exotic spaces; format characters (zero-widths, soft hyphen) are
+    stripped so markers can't be split invisibly; remaining separators map to
+    ASCII space and runs collapse so literal-space markers still match; and
+    ``casefold`` handles aggressive case mappings beyond IGNORECASE.
+
+    This guard is best-effort by nature (an intra-word split like
+    ``settle ment`` still evades it); the merge-packet tier check in
+    ``packet_blocker`` is the sole authority — this layer only adds friction.
     """
-    return _ZERO_WIDTH_RE.sub("", unicodedata.normalize("NFKC", text)).casefold()
+    text = unicodedata.normalize("NFKC", text)
+    text = _FORMAT_CHARS_RE.sub("", text)
+    text = _SPACE_SEPARATORS_RE.sub(" ", text)
+    return _MULTI_SPACE_RE.sub(" ", text).casefold()
 
 
 def is_draft_by_design(pr: dict[str, Any]) -> bool:

--- a/scripts/pr_ready_triage.py
+++ b/scripts/pr_ready_triage.py
@@ -55,6 +55,7 @@ import json
 import re
 import subprocess
 import sys
+import unicodedata
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable
 
@@ -84,6 +85,13 @@ BLOCKING_LABELS = frozenset({"merge:manual", "do-not-promote", "held"})
 NEVER_PROMOTE_RE = re.compile(
     r"tier\s*4|draft by design|do not mark ready|operator settlement required|scarmani",
     re.IGNORECASE,
+)
+
+# Zero-width characters stripped before the never-promote match so markers
+# can't be split invisibly (ZWSP, ZWNJ, ZWJ, BOM/ZWNBSP, word joiner).
+_ZERO_WIDTH_RE = re.compile(
+    "[\N{ZERO WIDTH SPACE}\N{ZERO WIDTH NON-JOINER}\N{ZERO WIDTH JOINER}"
+    "\N{ZERO WIDTH NO-BREAK SPACE}\N{WORD JOINER}]"
 )
 
 # Check states/conclusions that disqualify a draft (same set as
@@ -133,9 +141,19 @@ def has_failing_checks(pr: dict[str, Any]) -> bool:
     return False
 
 
+def _normalize_marker_text(text: str) -> str:
+    """Normalize against Unicode evasion before the never-promote match.
+
+    NFKC folds fullwidth/compatibility forms (``Ｔｉｅｒ ４`` -> ``Tier 4``),
+    zero-width characters are stripped so markers can't be split invisibly,
+    and ``casefold`` handles aggressive case mappings beyond IGNORECASE.
+    """
+    return _ZERO_WIDTH_RE.sub("", unicodedata.normalize("NFKC", text)).casefold()
+
+
 def is_draft_by_design(pr: dict[str, Any]) -> bool:
     """Hard never-promote: governance markers in title or body."""
-    text = f"{pr.get('title') or ''}\n{pr.get('body') or ''}"
+    text = _normalize_marker_text(f"{pr.get('title') or ''}\n{pr.get('body') or ''}")
     return NEVER_PROMOTE_RE.search(text) is not None
 
 
@@ -224,6 +242,9 @@ def packet_blocker(entry: dict[str, Any]) -> str | None:
     """
     if not entry:
         return "empty merge packet (fail closed)"
+    # AUTHORITATIVE gate: the merge-packet tier decides promotability. The
+    # stage-1 NEVER_PROMOTE_RE text match is advisory defense-in-depth only —
+    # do not weaken this check on the assumption that the regex backstops it.
     raw_tier = entry.get("tier")
     if not isinstance(raw_tier, (int, str)):
         return f"unknown tier {raw_tier!r} (fail closed)"
@@ -452,6 +473,16 @@ def run_triage(
     return summary
 
 
+_REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+
+
+def repo_arg(value: str) -> str:
+    """Argparse type: validate ``owner/name`` at parse time, before any gh call."""
+    if not _REPO_RE.match(value):
+        raise argparse.ArgumentTypeError(f"--repo must look like owner/name, got {value!r}")
+    return value
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description=(
@@ -459,7 +490,9 @@ def main(argv: list[str] | None = None) -> int:
             "default; --apply gates the only mutation (gh pr ready)."
         )
     )
-    parser.add_argument("--repo", default=DEFAULT_REPO, help="GitHub repo (owner/name)")
+    parser.add_argument(
+        "--repo", default=DEFAULT_REPO, type=repo_arg, help="GitHub repo (owner/name)"
+    )
     parser.add_argument(
         "--branch-prefix",
         action="append",

--- a/scripts/stale_pr_janitor.py
+++ b/scripts/stale_pr_janitor.py
@@ -1,0 +1,582 @@
+#!/usr/bin/env python3
+"""Stale-tail classifier + restack queue for codex/ PRs (NON-DESTRUCTIVE).
+
+The autonomous PR pipeline accumulates a tail of old open ``codex/`` PRs that
+nothing manages: some merely need a restack (merge conflicts), some are
+blocked on red CI, some are promotable and just need
+``scripts/pr_ready_triage.py`` to pick them up. This janitor classifies that
+tail and queues restack work — it NEVER closes PRs, NEVER deletes branches,
+NEVER pushes. The only GitHub mutation it can perform (gated behind
+``--apply``) is posting one idempotent explanatory comment per PR.
+
+Selection: open PRs (draft or ready) whose head branch matches
+``--branch-prefix`` (default ``codex/``), created at least ``--stale-days``
+ago (default 4).
+
+Classification (per selected PR):
+
+- ``active``      — updated within ``--inactive-days`` (default 2): skip.
+- ``promotable``  — MERGEABLE with green (non-failing, non-pending) checks:
+  emit a recommendation to run ``scripts/pr_ready_triage.py``; no queue entry,
+  no comment.
+- ``restack``     — ``mergeable == CONFLICTING``: queue entry (+ comment with
+  ``--apply``).
+- ``blocked``     — failing checks: queue entry naming the failing checks
+  (+ comment with ``--apply``).
+- ``indeterminate`` — pending checks / unknown mergeability: skip (fail safe).
+
+Restack queue: ``.aragora/restack-queue.json`` holds a list of
+``{pr, head_ref, classification, reason, detected_at}``. The janitor merges
+with the existing file, dedupes by PR number (this run's classification wins
+for PRs it classified), and never drops entries it did not classify this run.
+A corrupt existing queue file is an error (exit 1) — it is never overwritten.
+The queue file is the janitor's local work product and is written in both
+modes; ``--apply`` gates only the GitHub comment mutation.
+
+Idempotent comments: each janitor comment embeds the marker
+``<!-- stale-pr-janitor -->``. If any existing comment on the PR already
+contains the marker, the janitor skips posting (checked via
+``gh pr view N --json comments``, read-only). ``--max-comments`` (default 10)
+caps posts per run.
+
+Safety model (mirrors ``boss_pr_janitor.py`` / ``auto_evidence_cycle.py``):
+dry-run by default printing a JSON-lines plan; ``--apply`` gates mutations;
+3 consecutive identical comment failures trip the breaker (exit 2); any
+failed mutation fails closed (exit 1); clean runs exit 0.
+
+Stdlib-only by design so it can run anywhere ``gh`` is authenticated.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable
+
+DEFAULT_REPO = "synaptent/aragora"
+DEFAULT_BRANCH_PREFIX = "codex/"
+DEFAULT_STALE_DAYS = 4
+DEFAULT_INACTIVE_DAYS = 2
+DEFAULT_MAX_COMMENTS = 10
+DEFAULT_BREAKER_THRESHOLD = 3
+DEFAULT_QUEUE_FILE = os.path.join(".aragora", "restack-queue.json")
+GH_TIMEOUT_SECONDS = 120
+
+COMMENT_MARKER = "<!-- stale-pr-janitor -->"
+
+EXIT_OK = 0
+EXIT_FAILURES = 1
+EXIT_BREAKER = 2
+
+CLASS_ACTIVE = "active"
+CLASS_PROMOTABLE = "promotable"
+CLASS_RESTACK = "restack"
+CLASS_BLOCKED = "blocked"
+CLASS_INDETERMINATE = "indeterminate"
+
+# Classifications that produce a queue entry (and, with --apply, a comment).
+QUEUED_CLASSIFICATIONS = frozenset({CLASS_RESTACK, CLASS_BLOCKED})
+
+# Check states/conclusions treated as failing (same set as boss_pr_janitor).
+_FAILING_STATES = frozenset(
+    {
+        "FAILURE",
+        "ERROR",
+        "CANCELLED",
+        "TIMED_OUT",
+        "ACTION_REQUIRED",
+        "STARTUP_FAILURE",
+    }
+)
+
+_PENDING_STATUSES = frozenset({"IN_PROGRESS", "QUEUED", "PENDING", "WAITING", "REQUESTED"})
+
+_GH_LIST_FIELDS = "number,headRefName,isDraft,title,mergeable,createdAt,updatedAt,statusCheckRollup"
+
+
+# --- Classification ---------------------------------------------------------------
+
+
+def _parse_iso(ts: Any) -> datetime | None:
+    if not ts:
+        return None
+    try:
+        dt = datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def failing_check_names(pr: dict[str, Any]) -> list[str]:
+    rollup = pr.get("statusCheckRollup") or []
+    if not isinstance(rollup, list):
+        return []
+    names: list[str] = []
+    for check in rollup:
+        if not isinstance(check, dict):
+            continue
+        state = str(check.get("state") or "").upper()
+        conclusion = str(check.get("conclusion") or "").upper()
+        if state in _FAILING_STATES or conclusion in _FAILING_STATES:
+            names.append(str(check.get("name") or check.get("context") or "(unnamed check)"))
+    return names
+
+
+def _has_pending_checks(pr: dict[str, Any]) -> bool:
+    rollup = pr.get("statusCheckRollup") or []
+    if not isinstance(rollup, list):
+        return False
+    for check in rollup:
+        if not isinstance(check, dict):
+            continue
+        status = str(check.get("status") or "").upper()
+        state = str(check.get("state") or "").upper()
+        if status in _PENDING_STATUSES or state in _PENDING_STATUSES:
+            return True
+    return False
+
+
+def is_stale(pr: dict[str, Any], *, stale_days: int, now: datetime) -> bool:
+    """Fail safe: an unparseable/missing createdAt is never selected."""
+    created = _parse_iso(pr.get("createdAt"))
+    if created is None:
+        return False
+    return now - created >= timedelta(days=max(0, stale_days))
+
+
+def classify(pr: dict[str, Any], *, inactive_days: int, now: datetime) -> dict[str, Any]:
+    """Classify one stale PR. Pure function; never touches the network."""
+    number = int(pr.get("number") or 0)
+    head_ref = str(pr.get("headRefName") or "")
+    updated = _parse_iso(pr.get("updatedAt"))
+    # Fail safe: unparseable updatedAt counts as recent activity (skip).
+    if updated is None or now - updated < timedelta(days=max(0, inactive_days)):
+        return {
+            "pr": number,
+            "head_ref": head_ref,
+            "classification": CLASS_ACTIVE,
+            "reason": f"updated within {inactive_days}d (recent human/agent activity)",
+        }
+    mergeable = str(pr.get("mergeable") or "").upper()
+    if mergeable == "CONFLICTING":
+        return {
+            "pr": number,
+            "head_ref": head_ref,
+            "classification": CLASS_RESTACK,
+            "reason": "mergeable=CONFLICTING; needs restack onto main",
+        }
+    failing = failing_check_names(pr)
+    if failing:
+        return {
+            "pr": number,
+            "head_ref": head_ref,
+            "classification": CLASS_BLOCKED,
+            "reason": f"failing checks: {', '.join(sorted(failing)[:5])}",
+            "failing_checks": sorted(failing),
+        }
+    if mergeable == "MERGEABLE" and not _has_pending_checks(pr):
+        return {
+            "pr": number,
+            "head_ref": head_ref,
+            "classification": CLASS_PROMOTABLE,
+            "reason": ("mergeable with green checks; run scripts/pr_ready_triage.py to promote"),
+        }
+    return {
+        "pr": number,
+        "head_ref": head_ref,
+        "classification": CLASS_INDETERMINATE,
+        "reason": f"checks pending or mergeable={mergeable or '(unknown)'}; skipping (fail safe)",
+    }
+
+
+# --- Restack queue ------------------------------------------------------------------
+
+
+def load_queue(path: str) -> list[dict[str, Any]]:
+    """Load the existing queue. A corrupt file raises (never overwritten)."""
+    if not os.path.exists(path):
+        return []
+    with open(path, encoding="utf-8") as fh:
+        raw = fh.read()
+    if not raw.strip():
+        return []
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"corrupt restack queue {path}: {exc}") from exc
+    if not isinstance(payload, list):
+        raise RuntimeError(f"corrupt restack queue {path}: expected a JSON list")
+    return payload
+
+
+def merge_queue(
+    existing: list[dict[str, Any]], new_entries: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Merge new entries into the queue, deduped by PR number.
+
+    Entries this run classified replace any prior entry for the same PR;
+    entries it did not classify are never dropped. Unrecognizable existing
+    entries (no integer ``pr``) are preserved verbatim, first.
+    """
+    preserved_opaque: list[dict[str, Any]] = []
+    by_pr: dict[int, dict[str, Any]] = {}
+    for entry in existing:
+        if not isinstance(entry, dict):
+            continue
+        try:
+            number = int(entry["pr"])
+        except (KeyError, TypeError, ValueError):
+            preserved_opaque.append(entry)
+            continue
+        by_pr[number] = entry
+    for entry in new_entries:
+        by_pr[int(entry["pr"])] = entry
+    return preserved_opaque + [by_pr[number] for number in sorted(by_pr)]
+
+
+def write_queue(path: str, entries: list[dict[str, Any]]) -> None:
+    directory = os.path.dirname(path)
+    if directory:
+        os.makedirs(directory, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(entries, fh, indent=2, sort_keys=True)
+        fh.write("\n")
+
+
+# --- Comments -------------------------------------------------------------------------
+
+
+def comment_body(entry: dict[str, Any]) -> str:
+    return (
+        f"{COMMENT_MARKER}\n"
+        f"stale-pr-janitor classified this PR as **{entry['classification']}** "
+        f"({entry['reason']}).\n\n"
+        "It has been queued in `.aragora/restack-queue.json` for a restack pass. "
+        "This janitor is non-destructive: it never closes PRs, never deletes "
+        "branches, and never pushes. Rebase or update the branch to clear the "
+        "classification."
+    )
+
+
+def has_janitor_comment(comments: list[str]) -> bool:
+    return any(COMMENT_MARKER in body for body in comments)
+
+
+# --- Default (real) I/O callables -----------------------------------------------------
+
+
+def default_list_prs(repo: str) -> list[dict[str, Any]]:
+    """One ``gh pr list`` call covering drafts and ready PRs (read-only)."""
+    command = [
+        "gh",
+        "pr",
+        "list",
+        "--repo",
+        repo,
+        "--state",
+        "open",
+        "--json",
+        _GH_LIST_FIELDS,
+        "--limit",
+        "200",
+    ]
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        timeout=GH_TIMEOUT_SECONDS,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"gh pr list failed (exit {result.returncode}): {result.stderr.strip()}")
+    payload = json.loads(result.stdout or "[]")
+    if not isinstance(payload, list):
+        raise RuntimeError("gh pr list returned unexpected payload (expected a list)")
+    return payload
+
+
+def default_fetch_comments(repo: str, pr: int) -> list[str]:
+    """Existing comment bodies via ``gh pr view`` (read-only). Raises on failure
+    so the caller fails closed (no post when idempotency cannot be verified)."""
+    command = ["gh", "pr", "view", str(pr), "--repo", repo, "--json", "comments"]
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        timeout=GH_TIMEOUT_SECONDS,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"gh pr view {pr} failed (exit {result.returncode})")
+    payload = json.loads(result.stdout or "{}")
+    comments = payload.get("comments") if isinstance(payload, dict) else None
+    if not isinstance(comments, list):
+        return []
+    return [str(c.get("body") or "") for c in comments if isinstance(c, dict)]
+
+
+def default_post_comment(repo: str, pr: int, body: str) -> tuple[bool, str]:
+    """The only GitHub mutation: ``gh pr comment``. Returns (ok, error)."""
+    command = ["gh", "pr", "comment", str(pr), "--repo", repo, "--body", body]
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=GH_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return False, f"{type(exc).__name__}"
+    if result.returncode != 0:
+        return False, result.stderr.strip()[:300] or f"gh pr comment exited {result.returncode}"
+    return True, ""
+
+
+# --- Orchestrator ----------------------------------------------------------------------
+
+
+def run_janitor(
+    *,
+    list_prs: Callable[[], list[dict[str, Any]]],
+    fetch_comments: Callable[[int], list[str]],
+    post_comment: Callable[[int, str], tuple[bool, str]],
+    apply: bool,
+    queue_file: str = DEFAULT_QUEUE_FILE,
+    branch_prefix: str = DEFAULT_BRANCH_PREFIX,
+    stale_days: int = DEFAULT_STALE_DAYS,
+    inactive_days: int = DEFAULT_INACTIVE_DAYS,
+    max_comments: int = DEFAULT_MAX_COMMENTS,
+    breaker_threshold: int = DEFAULT_BREAKER_THRESHOLD,
+    now: datetime | None = None,
+    log: Callable[[str], None] = print,
+) -> dict[str, Any]:
+    """Classify the stale tail, update the restack queue, optionally comment.
+
+    Non-destructive by construction: the only actions this function can emit
+    are queue-file writes, recommendations, and (with ``apply``) idempotent
+    PR comments. There is no code path that closes, deletes, or pushes.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    summary: dict[str, Any] = {
+        "mode": "apply" if apply else "dry-run",
+        "classified": [],
+        "queued": [],
+        "recommendations": [],
+        "comments_posted": [],
+        "comments_skipped_existing": [],
+        "failed": [],
+        "queue_file": queue_file,
+        "breaker_tripped": False,
+        "exit_code": EXIT_OK,
+    }
+
+    selected = [
+        pr
+        for pr in list_prs()
+        if isinstance(pr, dict)
+        and str(pr.get("headRefName") or "").startswith(branch_prefix)
+        and is_stale(pr, stale_days=stale_days, now=now)
+    ]
+    selected.sort(key=lambda pr: int(pr.get("number") or 0))
+
+    detected_at = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+    queue_entries: list[dict[str, Any]] = []
+    for pr in selected:
+        entry = classify(pr, inactive_days=inactive_days, now=now)
+        summary["classified"].append(entry)
+        log(json.dumps({"action": "classify", **entry, "dry_run": not apply}))
+        if entry["classification"] == CLASS_PROMOTABLE:
+            summary["recommendations"].append(
+                {
+                    "pr": entry["pr"],
+                    "recommendation": "run scripts/pr_ready_triage.py (no action taken here)",
+                }
+            )
+        if entry["classification"] in QUEUED_CLASSIFICATIONS:
+            queue_entries.append(
+                {
+                    "pr": entry["pr"],
+                    "head_ref": entry["head_ref"],
+                    "classification": entry["classification"],
+                    "reason": entry["reason"],
+                    "detected_at": detected_at,
+                }
+            )
+
+    for rec in summary["recommendations"]:
+        log(json.dumps({"action": "recommend_promote", **rec}))
+
+    if queue_entries:
+        try:
+            existing = load_queue(queue_file)
+            merged = merge_queue(existing, queue_entries)
+            write_queue(queue_file, merged)
+        except (RuntimeError, OSError) as exc:
+            summary["exit_code"] = EXIT_FAILURES
+            log(json.dumps({"action": "queue_error", "error": str(exc)[:300]}))
+            _log_summary(summary, log)
+            return summary
+        summary["queued"] = [entry["pr"] for entry in queue_entries]
+        log(json.dumps({"action": "queue_written", "path": queue_file, "entries": len(merged)}))
+
+    identical_errors = 0
+    last_error: str | None = None
+    comment_candidates = queue_entries[: max(0, max_comments)]
+    for entry in comment_candidates:
+        number = entry["pr"]
+        try:
+            existing_comments = fetch_comments(number)
+        except (RuntimeError, json.JSONDecodeError, OSError, subprocess.SubprocessError) as exc:
+            # Fail closed: never post when idempotency cannot be verified.
+            summary["failed"].append(number)
+            error = f"comment check failed: {str(exc)[:200]}"
+            log(json.dumps({"action": "comment_failed", "pr": number, "error": error}))
+            identical_errors = identical_errors + 1 if error == last_error else 1
+            last_error = error
+            if identical_errors >= breaker_threshold:
+                summary["breaker_tripped"] = True
+                break
+            continue
+        if has_janitor_comment(existing_comments):
+            summary["comments_skipped_existing"].append(number)
+            log(json.dumps({"action": "comment_skipped", "pr": number, "reason": "marker exists"}))
+            continue
+        if not apply:
+            log(json.dumps({"action": "comment", "pr": number, "dry_run": True}))
+            continue
+        ok, error = post_comment(number, comment_body(entry))
+        if ok:
+            summary["comments_posted"].append(number)
+            identical_errors = 0
+            last_error = None
+            log(json.dumps({"action": "comment", "pr": number, "dry_run": False}))
+            continue
+        summary["failed"].append(number)
+        log(json.dumps({"action": "comment_failed", "pr": number, "error": error[:300]}))
+        identical_errors = identical_errors + 1 if error == last_error else 1
+        last_error = error
+        if identical_errors >= breaker_threshold:
+            summary["breaker_tripped"] = True
+            log(
+                json.dumps(
+                    {
+                        "action": "breaker_tripped",
+                        "identical_errors": identical_errors,
+                        "error": error[:300],
+                    }
+                )
+            )
+            break
+
+    if summary["breaker_tripped"]:
+        summary["exit_code"] = EXIT_BREAKER
+    elif summary["failed"]:
+        summary["exit_code"] = EXIT_FAILURES
+
+    _log_summary(summary, log)
+    return summary
+
+
+def _log_summary(summary: dict[str, Any], log: Callable[[str], None]) -> None:
+    log(
+        json.dumps(
+            {
+                "action": "summary",
+                "mode": summary["mode"],
+                "classified": len(summary["classified"]),
+                "queued": summary["queued"],
+                "recommendations": [rec["pr"] for rec in summary["recommendations"]],
+                "comments_posted": summary["comments_posted"],
+                "comments_skipped_existing": summary["comments_skipped_existing"],
+                "failed": summary["failed"],
+                "breaker_tripped": summary["breaker_tripped"],
+                "non_destructive": "never closes PRs, never deletes branches, never pushes",
+            }
+        )
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Stale-tail classifier + restack queue for codex/ PRs. "
+            "Non-destructive; dry-run by default; --apply gates the only "
+            "mutation (one idempotent PR comment per classified PR)."
+        )
+    )
+    parser.add_argument("--repo", default=DEFAULT_REPO, help="GitHub repo (owner/name)")
+    parser.add_argument(
+        "--branch-prefix",
+        default=DEFAULT_BRANCH_PREFIX,
+        help=f"Head-branch prefix to consider (default {DEFAULT_BRANCH_PREFIX!r})",
+    )
+    parser.add_argument(
+        "--stale-days",
+        type=int,
+        default=DEFAULT_STALE_DAYS,
+        help=f"Only consider PRs at least this many days old (default {DEFAULT_STALE_DAYS})",
+    )
+    parser.add_argument(
+        "--inactive-days",
+        type=int,
+        default=DEFAULT_INACTIVE_DAYS,
+        help=f"PRs updated within this many days are 'active' and skipped "
+        f"(default {DEFAULT_INACTIVE_DAYS})",
+    )
+    parser.add_argument(
+        "--max-comments",
+        type=int,
+        default=DEFAULT_MAX_COMMENTS,
+        help=f"Maximum PR comments per run (default {DEFAULT_MAX_COMMENTS})",
+    )
+    parser.add_argument(
+        "--queue-file",
+        default=DEFAULT_QUEUE_FILE,
+        help=f"Restack queue path (default {DEFAULT_QUEUE_FILE})",
+    )
+    parser.add_argument(
+        "--breaker-threshold",
+        type=int,
+        default=DEFAULT_BREAKER_THRESHOLD,
+        help=f"Consecutive identical comment failures that abort the run "
+        f"(default {DEFAULT_BREAKER_THRESHOLD})",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        default=False,
+        help="Actually post idempotent PR comments (default: dry-run; the local "
+        "restack queue file is written in both modes)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        summary = run_janitor(
+            list_prs=lambda: default_list_prs(args.repo),
+            fetch_comments=lambda pr: default_fetch_comments(args.repo, pr),
+            post_comment=lambda pr, body: default_post_comment(args.repo, pr, body),
+            apply=args.apply,
+            queue_file=args.queue_file,
+            branch_prefix=args.branch_prefix,
+            stale_days=args.stale_days,
+            inactive_days=args.inactive_days,
+            max_comments=args.max_comments,
+            breaker_threshold=max(1, args.breaker_threshold),
+        )
+    except (RuntimeError, json.JSONDecodeError, OSError, subprocess.SubprocessError) as exc:
+        print(json.dumps({"action": "error", "error": str(exc)[:500]}), file=sys.stderr)
+        return EXIT_FAILURES
+    return int(summary["exit_code"])
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_backlog_gate.py
+++ b/tests/scripts/test_backlog_gate.py
@@ -246,6 +246,34 @@ def test_gh_failure_with_unwritable_signal_still_exits_one(
 
 
 # ---------------------------------------------------------------------------
+# Fail closed: truncated listing forces shepherd
+# ---------------------------------------------------------------------------
+
+
+def test_truncated_listing_forces_shepherd_even_with_small_counts(tmp_path: Path) -> None:
+    # gh truncates BEFORE the prefix filter: a limit-sized payload with few
+    # matching branches means in-scope PRs may have been silently dropped.
+    prs = [_pr(n, head="other/branch") for n in range(gate.GH_LIST_LIMIT - 1)] + [_pr(999)]
+    exit_code, payload, _ = _run(tmp_path, prs)
+    assert exit_code == 3
+    assert payload is not None
+    assert payload["mode"] == "shepherd"
+    assert payload["open_prs"] == 1, "visible in-scope count stays small"
+    assert f"list_truncated:>={gate.GH_LIST_LIMIT}" in payload["reasons"]
+    assert f"list_truncated:>={gate.GH_LIST_LIMIT}" in payload["annotations"]
+
+
+def test_listing_just_below_limit_is_unaffected(tmp_path: Path) -> None:
+    prs = [_pr(n, head="other/branch") for n in range(gate.GH_LIST_LIMIT - 2)] + [_pr(999)]
+    exit_code, payload, _ = _run(tmp_path, prs)
+    assert exit_code == 0
+    assert payload is not None
+    assert payload["mode"] == "generate"
+    assert not any("list_truncated" in r for r in payload["reasons"])
+    assert not any("list_truncated" in a for a in payload["annotations"])
+
+
+# ---------------------------------------------------------------------------
 # Atomic signal writes
 # ---------------------------------------------------------------------------
 
@@ -384,6 +412,17 @@ def test_main_dry_by_default_invokes_no_subprocess_with_mocked_listing(
         )
         == 0
     )
+
+
+@pytest.mark.parametrize("repo", ["not-a-repo", "owner/name/extra", "owner/", "owner/na me"])
+def test_malformed_repo_rejected_at_parse_time(repo: str) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        gate.main(["--repo", repo, "--quiet"])
+    assert excinfo.value.code == 2, "argparse must reject before any gh call"
+
+
+def test_well_formed_repo_accepted_by_validator() -> None:
+    assert gate.repo_arg("synaptent/aragora") == "synaptent/aragora"
 
 
 def test_exit_code_constants_documented_contract() -> None:

--- a/tests/scripts/test_backlog_gate.py
+++ b/tests/scripts/test_backlog_gate.py
@@ -1,0 +1,396 @@
+"""Tests for ``scripts/backlog_gate.py`` (closure-first backpressure gate).
+
+All boundaries (the single ``gh pr list`` call) are injected; no test touches
+the network. Style mirrors ``tests/scripts/test_pr_ready_triage.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _load_module(script_name: str) -> Any:
+    here = Path(__file__).resolve()
+    script_path = here.parents[2] / "scripts" / script_name
+    spec = importlib.util.spec_from_file_location(f"{script_name}_under_test", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load spec for {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+gate = _load_module("backlog_gate.py")
+
+NOW = datetime(2026, 6, 12, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _pr(number: int, *, head: str = "codex/feature", draft: bool = True) -> dict[str, Any]:
+    return {
+        "number": number,
+        "headRefName": head,
+        "isDraft": draft,
+        "createdAt": "2026-06-11T12:00:00Z",
+    }
+
+
+def _outbox(tmp_path: Path, json_files: int = 0, *, other_files: int = 0) -> Path:
+    outbox = tmp_path / "outbox"
+    outbox.mkdir()
+    for i in range(json_files):
+        (outbox / f"item-{i}.json").write_text("{}", encoding="utf-8")
+    for i in range(other_files):
+        (outbox / f"noise-{i}.txt").write_text("x", encoding="utf-8")
+    return outbox
+
+
+def _run(
+    tmp_path: Path,
+    prs: list[dict[str, Any]] | Exception,
+    *,
+    outbox_dir: Path | None = None,
+    max_open_prs: int = 60,
+    max_outbox: int = 50,
+    quiet: bool = False,
+    branch_prefixes: tuple[str, ...] = ("codex/",),
+) -> tuple[int, dict[str, Any] | None, list[str]]:
+    """Run the gate with injected listing; return (exit, signal payload, stdout lines)."""
+    signal_file = tmp_path / "signals" / "backpressure.json"
+    lines: list[str] = []
+
+    def list_prs() -> list[dict[str, Any]]:
+        if isinstance(prs, Exception):
+            raise prs
+        return prs
+
+    exit_code = gate.run_gate(
+        list_prs=list_prs,
+        branch_prefixes=branch_prefixes,
+        outbox_dir=str(outbox_dir if outbox_dir is not None else tmp_path / "outbox"),
+        max_open_prs=max_open_prs,
+        max_outbox=max_outbox,
+        signal_file=str(signal_file),
+        quiet=quiet,
+        now=NOW,
+        log=lines.append,
+    )
+    payload = json.loads(signal_file.read_text(encoding="utf-8")) if signal_file.exists() else None
+    return exit_code, payload, lines
+
+
+# ---------------------------------------------------------------------------
+# Decision + exit codes
+# ---------------------------------------------------------------------------
+
+
+def test_under_both_thresholds_generates_exit_zero(tmp_path: Path) -> None:
+    outbox = _outbox(tmp_path, json_files=3)
+    exit_code, payload, lines = _run(tmp_path, [_pr(1), _pr(2, draft=False)], outbox_dir=outbox)
+    assert exit_code == 0
+    assert payload is not None
+    assert payload["mode"] == "generate"
+    assert payload["reasons"] == []
+    assert payload["open_prs"] == 2
+    assert payload["drafts"] == 1
+    assert payload["ready"] == 1
+    assert payload["outbox_depth"] == 3
+    assert payload["thresholds"] == {"max_open_prs": 60, "max_outbox": 50}
+    assert payload["generated_at"] == "2026-06-12T12:00:00Z"
+    # stdout JSON matches the signal file
+    assert json.loads(lines[-1]) == payload
+
+
+def test_open_prs_at_threshold_is_shepherd_exit_three(tmp_path: Path) -> None:
+    prs = [_pr(n) for n in range(5)]
+    exit_code, payload, _ = _run(tmp_path, prs, max_open_prs=5)
+    assert exit_code == 3
+    assert payload is not None
+    assert payload["mode"] == "shepherd"
+    assert payload["reasons"] == ["open_prs:5>=max_open_prs:5"]
+
+
+def test_open_prs_just_under_threshold_generates(tmp_path: Path) -> None:
+    prs = [_pr(n) for n in range(4)]
+    exit_code, payload, _ = _run(tmp_path, prs, max_open_prs=5)
+    assert exit_code == 0
+    assert payload is not None
+    assert payload["mode"] == "generate"
+
+
+def test_outbox_at_threshold_is_shepherd(tmp_path: Path) -> None:
+    outbox = _outbox(tmp_path, json_files=4)
+    exit_code, payload, _ = _run(tmp_path, [_pr(1)], outbox_dir=outbox, max_outbox=4)
+    assert exit_code == 3
+    assert payload is not None
+    assert payload["reasons"] == ["outbox_depth:4>=max_outbox:4"]
+
+
+def test_outbox_just_under_threshold_generates(tmp_path: Path) -> None:
+    outbox = _outbox(tmp_path, json_files=3)
+    exit_code, payload, _ = _run(tmp_path, [_pr(1)], outbox_dir=outbox, max_outbox=4)
+    assert exit_code == 0
+    assert payload is not None
+    assert payload["mode"] == "generate"
+
+
+def test_both_over_threshold_lists_both_reasons(tmp_path: Path) -> None:
+    outbox = _outbox(tmp_path, json_files=9)
+    exit_code, payload, _ = _run(
+        tmp_path, [_pr(n) for n in range(7)], outbox_dir=outbox, max_open_prs=2, max_outbox=2
+    )
+    assert exit_code == 3
+    assert payload is not None
+    assert payload["reasons"] == [
+        "open_prs:7>=max_open_prs:2",
+        "outbox_depth:9>=max_outbox:2",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# PR counting: prefixes, drafts/ready
+# ---------------------------------------------------------------------------
+
+
+def test_non_automation_branches_not_counted(tmp_path: Path) -> None:
+    prs = [_pr(1), _pr(2, head="feature/manual"), _pr(3, head="main-fix")]
+    exit_code, payload, _ = _run(tmp_path, prs, max_open_prs=2)
+    assert exit_code == 0
+    assert payload is not None
+    assert payload["open_prs"] == 1
+
+
+def test_repeatable_branch_prefixes(tmp_path: Path) -> None:
+    prs = [_pr(1), _pr(2, head="elves/run-1"), _pr(3, head="feature/x")]
+    _, payload, _ = _run(tmp_path, prs, branch_prefixes=("codex/", "elves/"))
+    assert payload is not None
+    assert payload["open_prs"] == 2
+
+
+def test_draft_and_ready_split(tmp_path: Path) -> None:
+    prs = [_pr(1, draft=True), _pr(2, draft=True), _pr(3, draft=False)]
+    _, payload, _ = _run(tmp_path, prs)
+    assert payload is not None
+    assert payload["drafts"] == 2
+    assert payload["ready"] == 1
+
+
+def test_malformed_pr_entries_ignored(tmp_path: Path) -> None:
+    prs: list[Any] = ["garbage", None, {"headRefName": None}, _pr(1)]
+    _, payload, _ = _run(tmp_path, prs)
+    assert payload is not None
+    assert payload["open_prs"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Outbox depth
+# ---------------------------------------------------------------------------
+
+
+def test_missing_outbox_dir_is_zero_with_annotation_not_error(tmp_path: Path) -> None:
+    missing = tmp_path / "does-not-exist"
+    exit_code, payload, _ = _run(tmp_path, [_pr(1)], outbox_dir=missing)
+    assert exit_code == 0
+    assert payload is not None
+    assert payload["outbox_depth"] == 0
+    assert payload["annotations"] == [f"outbox_dir_missing:{missing}"]
+
+
+def test_only_direct_json_files_counted(tmp_path: Path) -> None:
+    outbox = _outbox(tmp_path, json_files=2, other_files=3)
+    nested = outbox / "nested"
+    nested.mkdir()
+    (nested / "deep.json").write_text("{}", encoding="utf-8")
+    depth, missing = gate.count_outbox_depth(str(outbox))
+    assert depth == 2
+    assert missing is False
+
+
+# ---------------------------------------------------------------------------
+# Fail closed: gh failure writes a shepherd signal then exits 1
+# ---------------------------------------------------------------------------
+
+
+def test_gh_failure_writes_shepherd_signal_and_exits_one(tmp_path: Path) -> None:
+    exit_code, payload, _ = _run(tmp_path, RuntimeError("gh pr list failed (exit 4): boom"))
+    assert exit_code == 1
+    assert payload is not None, "the fail-closed signal file must still be written"
+    assert payload["mode"] == "shepherd"
+    assert payload["reasons"] == ["gate_failure:gh pr list failed (exit 4): boom"]
+    assert payload["open_prs"] is None
+    assert payload["outbox_depth"] is None
+
+
+def test_gh_failure_with_unwritable_signal_still_exits_one(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    signal_file = tmp_path / "blocked" / "signal.json"
+    (tmp_path / "blocked").write_text("a file, not a dir", encoding="utf-8")
+    exit_code = gate.run_gate(
+        list_prs=lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+        outbox_dir=str(tmp_path / "outbox"),
+        signal_file=str(signal_file),
+        now=NOW,
+        log=lambda line: None,
+    )
+    assert exit_code == 1
+    assert "signal_write_failed" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# Atomic signal writes
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_no_partial_file_on_simulated_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    outbox = _outbox(tmp_path, json_files=1)
+    signal_dir = tmp_path / "signals"
+    signal_file = signal_dir / "backpressure.json"
+
+    def broken_replace(src: str, dst: str) -> None:
+        raise OSError("simulated replace failure")
+
+    monkeypatch.setattr(gate.os, "replace", broken_replace)
+    exit_code = gate.run_gate(
+        list_prs=lambda: [_pr(1)],
+        outbox_dir=str(outbox),
+        signal_file=str(signal_file),
+        now=NOW,
+        log=lambda line: None,
+    )
+    assert exit_code == 1, "an unwritable signal file must never exit 0"
+    assert not signal_file.exists(), "no partial signal file may be left behind"
+    leftovers = [p.name for p in signal_dir.iterdir()]
+    assert leftovers == [], f"temp files must be cleaned up: {leftovers}"
+
+
+def test_atomic_write_replaces_existing_signal(tmp_path: Path) -> None:
+    target = tmp_path / "sig.json"
+    target.write_text('{"mode": "stale"}', encoding="utf-8")
+    gate.atomic_write_json(str(target), {"mode": "generate"})
+    assert json.loads(target.read_text(encoding="utf-8")) == {"mode": "generate"}
+    assert [p.name for p in tmp_path.iterdir()] == ["sig.json"]
+
+
+# ---------------------------------------------------------------------------
+# --quiet and main()
+# ---------------------------------------------------------------------------
+
+
+def test_quiet_suppresses_stdout_but_writes_signal(tmp_path: Path) -> None:
+    exit_code, payload, lines = _run(tmp_path, [_pr(1)], quiet=True)
+    assert exit_code == 0
+    assert lines == []
+    assert payload is not None
+    assert payload["mode"] == "generate"
+
+
+def test_quiet_suppresses_stdout_on_failure_too(tmp_path: Path) -> None:
+    exit_code, payload, lines = _run(tmp_path, RuntimeError("boom"), quiet=True)
+    assert exit_code == 1
+    assert lines == []
+    assert payload is not None
+    assert payload["mode"] == "shepherd"
+
+
+def test_main_generate_exit_zero(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(gate, "default_list_open_prs", lambda repo: [_pr(1)])
+    signal_file = tmp_path / "sig.json"
+    assert (
+        gate.main(
+            [
+                "--outbox-dir",
+                str(tmp_path / "outbox"),
+                "--signal-file",
+                str(signal_file),
+                "--quiet",
+            ]
+        )
+        == 0
+    )
+    assert json.loads(signal_file.read_text(encoding="utf-8"))["mode"] == "generate"
+
+
+def test_main_shepherd_exit_three(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(gate, "default_list_open_prs", lambda repo: [_pr(n) for n in range(3)])
+    assert (
+        gate.main(
+            [
+                "--max-open-prs",
+                "3",
+                "--outbox-dir",
+                str(tmp_path / "outbox"),
+                "--signal-file",
+                str(tmp_path / "sig.json"),
+                "--quiet",
+            ]
+        )
+        == 3
+    )
+
+
+def test_main_gh_failure_exit_one_with_shepherd_signal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def boom(repo: str) -> list[dict[str, Any]]:
+        raise RuntimeError("gh exploded")
+
+    monkeypatch.setattr(gate, "default_list_open_prs", boom)
+    signal_file = tmp_path / "sig.json"
+    assert (
+        gate.main(
+            [
+                "--outbox-dir",
+                str(tmp_path / "outbox"),
+                "--signal-file",
+                str(signal_file),
+                "--quiet",
+            ]
+        )
+        == 1
+    )
+    payload = json.loads(signal_file.read_text(encoding="utf-8"))
+    assert payload["mode"] == "shepherd"
+    assert payload["reasons"][0].startswith("gate_failure:")
+
+
+def test_main_dry_by_default_invokes_no_subprocess_with_mocked_listing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def forbidden_run(command: list[str], **kwargs: Any) -> Any:
+        raise AssertionError(f"subprocess must not run with mocked listing: {command}")
+
+    monkeypatch.setattr(gate, "default_list_open_prs", lambda repo: [])
+    monkeypatch.setattr(gate.subprocess, "run", forbidden_run)
+    assert (
+        gate.main(
+            [
+                "--outbox-dir",
+                str(tmp_path / "outbox"),
+                "--signal-file",
+                str(tmp_path / "sig.json"),
+                "--quiet",
+            ]
+        )
+        == 0
+    )
+
+
+def test_exit_code_constants_documented_contract() -> None:
+    assert gate.EXIT_GENERATE == 0
+    assert gate.EXIT_FAILURE == 1
+    assert gate.EXIT_SHEPHERD == 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/scripts/test_codex_worktree_value_inventory.py
+++ b/tests/scripts/test_codex_worktree_value_inventory.py
@@ -1005,3 +1005,139 @@ def test_classify_candidate_marks_open_pr_when_cache_hit(
     assert candidate.links["open_prs"] == [
         {"number": 999, "title": "Open PR for feat/x", "url": "https://example.test/pr/999"}
     ]
+
+
+# ---------------------------------------------------------------------------
+# Git-timeout hardening: a hung `git status` (or any git lookup) must never
+# hang the inventory, and a timed-out candidate must stay protected.
+# ---------------------------------------------------------------------------
+
+
+def test_run_cmd_timeout_returns_124_and_never_hangs(tmp_path: Path) -> None:
+    """A child that would outlive the timeout is killed (whole session) and
+    run_cmd returns promptly with the timeout annotation in stderr."""
+    import subprocess as subprocess_mod
+    import time
+
+    import codex_worktree_value_inventory as mod
+
+    started = time.monotonic()
+    # The backgrounded grandchild inherits the pipes; with plain
+    # subprocess.run(timeout=...) the post-kill drain would block on it.
+    proc = mod.run_cmd(
+        ["/bin/sh", "-c", "sleep 30 & exec sleep 30"],
+        tmp_path,
+        timeout=1,
+    )
+    elapsed = time.monotonic() - started
+
+    assert isinstance(proc, subprocess_mod.CompletedProcess)
+    assert proc.returncode == 124
+    assert "timed out after 1s" in proc.stderr
+    assert elapsed < 15, f"run_cmd must return promptly after a timeout, took {elapsed:.1f}s"
+
+
+def test_run_cmd_missing_binary_still_returns_completed_process(tmp_path: Path) -> None:
+    import codex_worktree_value_inventory as mod
+
+    proc = mod.run_cmd(["/nonexistent-binary-for-test"], tmp_path, timeout=1)
+
+    assert proc.returncode == 124
+    assert proc.stdout == ""
+
+
+def test_timeout_raising_runner_marks_candidate_inspect_timeout_protected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A fake Popen whose communicate raises subprocess.TimeoutExpired: the
+    candidate is annotated inspect_timeout and treated as protected (never
+    safe-to-clean), and classification completes instead of crashing."""
+    import subprocess as subprocess_mod
+
+    import codex_worktree_value_inventory as mod
+
+    root = _candidate(tmp_path)
+
+    class FakeHungPopen:
+        def __init__(self, args: list[str], **_kwargs: Any) -> None:
+            self.args = args
+            self.pid = 999_999_999  # killpg on this raises and falls back to kill()
+            self.returncode: int | None = None
+            self.stdout = None
+            self.stderr = None
+            self._calls = 0
+
+        def communicate(self, timeout: float | None = None) -> tuple[str, str]:
+            self._calls += 1
+            if self._calls == 1:
+                raise subprocess_mod.TimeoutExpired(self.args, timeout or 0)
+            return "", ""
+
+        def kill(self) -> None:
+            self.returncode = -9
+
+    monkeypatch.setattr(mod.subprocess, "Popen", FakeHungPopen)
+
+    candidate = mod.classify_candidate(
+        root,
+        context=_context(tmp_path),
+        size_bytes=1024,
+        size_lookup_failed=False,
+    )
+
+    assert candidate.git.inspect_timeout is True
+    assert any("inspect_timeout" in item for item in candidate.proof)
+    assert candidate.classification in mod.PROTECTED_CLASSES
+    assert candidate.cleanup_candidate is False
+    assert candidate.decision == "preserve"
+    assert candidate.cleanup_safety.safe_to_delete is False
+    assert candidate.cleanup_safety.preserve is True
+
+
+def test_status_timeout_protects_candidate_and_run_continues(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A candidate whose `git status` timed out is protected; remaining
+    candidates are still classified normally and the summary counts the
+    timeout."""
+    import codex_worktree_value_inventory as mod
+
+    hung_root = _candidate(tmp_path, "hung")
+    clean_root = _candidate(tmp_path, "clean")
+    _stub_clean_git(monkeypatch, ahead=0)
+
+    def fake_status(repo_path: Path, *, timeout: int) -> tuple[bool, bool, str | None]:
+        if "hung" in str(repo_path):
+            return True, True, f"command timed out after {timeout}s: git status --porcelain"
+        return False, False, None
+
+    monkeypatch.setattr(mod, "git_status_dirty", fake_status)
+
+    hung = mod.classify_candidate(
+        hung_root, context=_context(tmp_path), size_bytes=1024, size_lookup_failed=False
+    )
+    clean = mod.classify_candidate(
+        clean_root, context=_context(tmp_path), size_bytes=1024, size_lookup_failed=False
+    )
+
+    assert hung.git.inspect_timeout is True
+    assert hung.classification in mod.PROTECTED_CLASSES
+    assert hung.cleanup_candidate is False
+    assert hung.cleanup_safety.safe_to_delete is False
+    # The run continued: the clean candidate is unaffected.
+    assert clean.git.inspect_timeout is False
+    assert clean.classification == "unregistered_git_residue"
+
+    summary = mod.build_summary([hung, clean])
+    assert summary["inspect_timeouts"] == 1
+
+
+def test_build_parser_git_timeout_seconds_alias() -> None:
+    import codex_worktree_value_inventory as mod
+
+    parser = mod.build_parser()
+
+    assert mod.GIT_TIMEOUT_SECONDS == 30
+    assert parser.parse_args([]).git_timeout == mod.GIT_TIMEOUT_SECONDS
+    assert parser.parse_args(["--git-timeout-seconds", "7"]).git_timeout == 7
+    assert parser.parse_args(["--git-timeout", "9"]).git_timeout == 9

--- a/tests/scripts/test_funnel_stage_metrics.py
+++ b/tests/scripts/test_funnel_stage_metrics.py
@@ -1,0 +1,388 @@
+"""Tests for ``scripts/funnel_stage_metrics.py`` (funnel telemetry snapshot).
+
+All boundaries (the two ``gh pr list`` calls) are injected; no test touches
+the network. Style mirrors ``tests/scripts/test_backlog_gate.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _load_module(script_name: str) -> Any:
+    here = Path(__file__).resolve()
+    script_path = here.parents[2] / "scripts" / script_name
+    spec = importlib.util.spec_from_file_location(f"{script_name}_under_test", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load spec for {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+metrics = _load_module("funnel_stage_metrics.py")
+
+NOW = datetime(2026, 6, 12, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _open_pr(
+    number: int,
+    *,
+    head: str = "codex/feature",
+    draft: bool = True,
+    age_hours: float = 1.0,
+    created: str | None = None,
+) -> dict[str, Any]:
+    created_at = created if created is not None else _iso(NOW - timedelta(hours=age_hours))
+    return {
+        "number": number,
+        "headRefName": head,
+        "isDraft": draft,
+        "createdAt": created_at,
+        "updatedAt": created_at,
+        "labels": [],
+    }
+
+
+def _merged_pr(
+    number: int, *, head: str = "codex/done", merged_hours_ago: float = 2.0
+) -> dict[str, Any]:
+    return {
+        "number": number,
+        "headRefName": head,
+        "mergedAt": _iso(NOW - timedelta(hours=merged_hours_ago)),
+        "createdAt": _iso(NOW - timedelta(hours=merged_hours_ago + 24)),
+    }
+
+
+def _run(
+    tmp_path: Path,
+    open_prs: list[dict[str, Any]] | Exception,
+    merged_prs: list[dict[str, Any]] | Exception | None = None,
+    *,
+    outbox_dir: Path | None = None,
+    stale_days: int = 4,
+    max_draft_age_hours: float = 72.0,
+    max_stale_tail: int = 20,
+    out_file: str | None = None,
+    branch_prefixes: tuple[str, ...] = ("codex/",),
+) -> tuple[int, dict[str, Any] | None, list[datetime]]:
+    """Run a snapshot with injected runners; return (exit, payload, merged since args)."""
+    lines: list[str] = []
+    since_calls: list[datetime] = []
+
+    def list_open() -> list[dict[str, Any]]:
+        if isinstance(open_prs, Exception):
+            raise open_prs
+        return open_prs
+
+    def list_merged(since: datetime) -> list[dict[str, Any]]:
+        since_calls.append(since)
+        if isinstance(merged_prs, Exception):
+            raise merged_prs
+        return merged_prs or []
+
+    exit_code = metrics.run_snapshot(
+        list_open_prs=list_open,
+        list_merged_prs=list_merged,
+        branch_prefixes=branch_prefixes,
+        outbox_dir=str(outbox_dir if outbox_dir is not None else tmp_path / "outbox"),
+        stale_days=stale_days,
+        max_draft_age_hours=max_draft_age_hours,
+        max_stale_tail=max_stale_tail,
+        out_file=out_file,
+        now=NOW,
+        log=lines.append,
+    )
+    payload = json.loads(lines[-1]) if lines else None
+    return exit_code, payload, since_calls
+
+
+# ---------------------------------------------------------------------------
+# Percentile math
+# ---------------------------------------------------------------------------
+
+
+def test_percentile_empty_is_none() -> None:
+    assert metrics.percentile([], 50) is None
+
+
+def test_percentile_single_value() -> None:
+    assert metrics.percentile([7.0], 50) == 7.0
+    assert metrics.percentile([7.0], 90) == 7.0
+
+
+def test_percentile_linear_interpolation() -> None:
+    values = [10.0, 20.0, 30.0, 40.0]
+    assert metrics.percentile(values, 50) == pytest.approx(25.0)
+    assert metrics.percentile(values, 90) == pytest.approx(37.0)
+    assert metrics.percentile(values, 0) == 10.0
+    assert metrics.percentile(values, 100) == 40.0
+
+
+def test_percentile_order_independent() -> None:
+    assert metrics.percentile([40.0, 10.0, 30.0, 20.0], 50) == pytest.approx(25.0)
+
+
+def test_stage_age_percentiles_in_payload(tmp_path: Path) -> None:
+    drafts = [_open_pr(n, age_hours=h) for n, h in enumerate([10, 20, 30, 40], start=1)]
+    ready = [_open_pr(50, draft=False, age_hours=5)]
+    exit_code, payload, _ = _run(tmp_path, drafts + ready)
+    assert exit_code == 0
+    assert payload is not None
+    assert payload["stages"]["draft"]["count"] == 4
+    assert payload["stages"]["draft"]["age_hours"] == {"p50": 25.0, "p90": 37.0, "max": 40.0}
+    assert payload["stages"]["ready"]["count"] == 1
+    assert payload["stages"]["ready"]["age_hours"] == {"p50": 5.0, "p90": 5.0, "max": 5.0}
+
+
+def test_empty_stage_has_null_age_stats(tmp_path: Path) -> None:
+    _, payload, _ = _run(tmp_path, [])
+    assert payload is not None
+    assert payload["stages"]["draft"] == {
+        "count": 0,
+        "age_hours": {"p50": None, "p90": None, "max": None},
+    }
+    assert payload["stages"]["ready"]["count"] == 0
+
+
+def test_unparseable_created_at_counted_but_excluded_from_ages(tmp_path: Path) -> None:
+    prs = [_open_pr(1, created="not-a-date"), _open_pr(2, age_hours=8)]
+    _, payload, _ = _run(tmp_path, prs)
+    assert payload is not None
+    assert payload["stages"]["draft"]["count"] == 2
+    assert payload["stages"]["draft"]["age_hours"]["max"] == 8.0
+
+
+# ---------------------------------------------------------------------------
+# Branch prefix filtering
+# ---------------------------------------------------------------------------
+
+
+def test_non_automation_branches_excluded(tmp_path: Path) -> None:
+    prs = [_open_pr(1), _open_pr(2, head="feature/manual"), _open_pr(3, head="main")]
+    _, payload, _ = _run(tmp_path, prs)
+    assert payload is not None
+    assert payload["stages"]["draft"]["count"] == 1
+
+
+def test_repeatable_branch_prefixes(tmp_path: Path) -> None:
+    prs = [_open_pr(1), _open_pr(2, head="elves/run"), _open_pr(3, head="feature/x")]
+    _, payload, _ = _run(tmp_path, prs, branch_prefixes=("codex/", "elves/"))
+    assert payload is not None
+    assert payload["stages"]["draft"]["count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# merged_24h with graceful degradation
+# ---------------------------------------------------------------------------
+
+
+def test_merged_24h_counts_prefix_matches_within_window(tmp_path: Path) -> None:
+    merged = [
+        _merged_pr(1, merged_hours_ago=2),
+        _merged_pr(2, merged_hours_ago=23),
+        _merged_pr(3, head="feature/manual", merged_hours_ago=2),  # wrong prefix
+        _merged_pr(4, merged_hours_ago=30),  # outside the 24h window
+    ]
+    exit_code, payload, since_calls = _run(tmp_path, [], merged)
+    assert exit_code == 0
+    assert payload is not None
+    assert payload["merged_24h"] == 2
+    assert since_calls == [NOW - timedelta(hours=24)]
+
+
+def test_merged_search_failure_degrades_to_null_with_annotation(tmp_path: Path) -> None:
+    exit_code, payload, _ = _run(
+        tmp_path,
+        [_open_pr(1)],
+        RuntimeError("gh pr list (merged search) failed (exit 1): bad search"),
+    )
+    assert exit_code == 0, "a merged-search failure must not fail the snapshot"
+    assert payload is not None
+    assert payload["merged_24h"] is None
+    assert any(a.startswith("merged_search_failed:") for a in payload["annotations"])
+
+
+# ---------------------------------------------------------------------------
+# Outbox depth
+# ---------------------------------------------------------------------------
+
+
+def test_outbox_depth_counts_direct_json_files(tmp_path: Path) -> None:
+    outbox = tmp_path / "outbox"
+    outbox.mkdir()
+    (outbox / "a.json").write_text("{}", encoding="utf-8")
+    (outbox / "b.json").write_text("{}", encoding="utf-8")
+    (outbox / "c.txt").write_text("x", encoding="utf-8")
+    (outbox / "nested").mkdir()
+    (outbox / "nested" / "d.json").write_text("{}", encoding="utf-8")
+    _, payload, _ = _run(tmp_path, [], outbox_dir=outbox)
+    assert payload is not None
+    assert payload["outbox_depth"] == 2
+
+
+def test_missing_outbox_dir_is_zero_with_annotation(tmp_path: Path) -> None:
+    missing = tmp_path / "nope"
+    exit_code, payload, _ = _run(tmp_path, [], outbox_dir=missing)
+    assert exit_code == 0
+    assert payload is not None
+    assert payload["outbox_depth"] == 0
+    assert f"outbox_dir_missing:{missing}" in payload["annotations"]
+
+
+# ---------------------------------------------------------------------------
+# Stale tail + threshold breaches (exit 3)
+# ---------------------------------------------------------------------------
+
+
+def test_stale_tail_counts_open_prs_older_than_stale_days(tmp_path: Path) -> None:
+    prs = [
+        _open_pr(1, age_hours=24 * 5),  # 5 days: stale
+        _open_pr(2, draft=False, age_hours=24 * 4 + 1),  # just over 4 days: stale
+        _open_pr(3, age_hours=24 * 3),  # 3 days: not stale
+    ]
+    _, payload, _ = _run(tmp_path, prs, stale_days=4)
+    assert payload is not None
+    assert payload["stale_tail"] == 2
+
+
+def test_draft_p90_breach_exits_three(tmp_path: Path) -> None:
+    prs = [_open_pr(n, age_hours=100) for n in range(5)]
+    exit_code, payload, _ = _run(tmp_path, prs, max_draft_age_hours=72.0, max_stale_tail=99)
+    assert exit_code == 3
+    assert payload is not None
+    assert payload["thresholds_breached"] == ["draft_age_p90:100.0>max_draft_age_hours:72.0"]
+
+
+def test_draft_p90_at_threshold_is_not_breach(tmp_path: Path) -> None:
+    prs = [_open_pr(n, age_hours=72) for n in range(3)]
+    exit_code, payload, _ = _run(tmp_path, prs, max_draft_age_hours=72.0)
+    assert exit_code == 0
+    assert payload is not None
+    assert payload["thresholds_breached"] == []
+
+
+def test_stale_tail_breach_exits_three(tmp_path: Path) -> None:
+    prs = [_open_pr(n, age_hours=24 * 10) for n in range(3)]
+    exit_code, payload, _ = _run(tmp_path, prs, max_stale_tail=2, max_draft_age_hours=10_000.0)
+    assert exit_code == 3
+    assert payload is not None
+    assert payload["thresholds_breached"] == ["stale_tail:3>max_stale_tail:2"]
+
+
+def test_ready_age_does_not_trigger_draft_threshold(tmp_path: Path) -> None:
+    prs = [_open_pr(n, draft=False, age_hours=100) for n in range(3)]
+    exit_code, payload, _ = _run(
+        tmp_path, prs, max_draft_age_hours=72.0, max_stale_tail=99, stale_days=30
+    )
+    assert exit_code == 0
+    assert payload is not None
+    assert payload["thresholds_breached"] == []
+
+
+# ---------------------------------------------------------------------------
+# Failure path (exit 1) and --out atomic writes
+# ---------------------------------------------------------------------------
+
+
+def test_open_listing_failure_exits_one(tmp_path: Path) -> None:
+    exit_code, payload, _ = _run(tmp_path, RuntimeError("gh pr list failed"))
+    assert exit_code == 1
+    assert payload is None
+
+
+def test_out_file_written_atomically(tmp_path: Path) -> None:
+    out = tmp_path / "snapshots" / "funnel.json"
+    exit_code, payload, _ = _run(tmp_path, [_open_pr(1)], out_file=str(out))
+    assert exit_code == 0
+    assert payload is not None
+    assert json.loads(out.read_text(encoding="utf-8")) == payload
+    assert [p.name for p in out.parent.iterdir()] == ["funnel.json"]
+
+
+def test_out_write_failure_leaves_no_partial_file_and_exits_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    out_dir = tmp_path / "snapshots"
+    out = out_dir / "funnel.json"
+
+    def broken_replace(src: str, dst: str) -> None:
+        raise OSError("simulated replace failure")
+
+    monkeypatch.setattr(metrics.os, "replace", broken_replace)
+    exit_code, _, _ = _run(tmp_path, [_open_pr(1)], out_file=str(out))
+    assert exit_code == 1
+    assert not out.exists(), "no partial out file may be left behind"
+    assert [p.name for p in out_dir.iterdir()] == [], "temp files must be cleaned up"
+
+
+# ---------------------------------------------------------------------------
+# main()
+# ---------------------------------------------------------------------------
+
+
+def test_main_normal_exit_zero(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # main() uses the real clock, so timestamps must be relative to real now.
+    real_now = datetime.now(timezone.utc)
+    open_pr = dict(_open_pr(1), createdAt=_iso(real_now - timedelta(hours=1)))
+    merged_pr = dict(_merged_pr(2), mergedAt=_iso(real_now - timedelta(hours=2)))
+    monkeypatch.setattr(metrics, "default_list_open_prs", lambda repo: [open_pr])
+    monkeypatch.setattr(metrics, "default_list_merged_prs", lambda repo, since: [merged_pr])
+    out = tmp_path / "funnel.json"
+    assert metrics.main(["--outbox-dir", str(tmp_path / "outbox"), "--out", str(out)]) == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["merged_24h"] == 1
+    assert payload["stages"]["draft"]["count"] == 1
+
+
+def test_main_breach_exit_three(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    real_now = datetime.now(timezone.utc)
+    prs = [dict(_open_pr(n), createdAt=_iso(real_now - timedelta(hours=200))) for n in range(4)]
+    monkeypatch.setattr(metrics, "default_list_open_prs", lambda repo: prs)
+    monkeypatch.setattr(metrics, "default_list_merged_prs", lambda repo, since: [])
+    assert (
+        metrics.main(["--outbox-dir", str(tmp_path / "outbox"), "--max-draft-age-hours", "72"]) == 3
+    )
+
+
+def test_main_listing_failure_exit_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    def boom(repo: str) -> list[dict[str, Any]]:
+        raise RuntimeError("gh exploded")
+
+    monkeypatch.setattr(metrics, "default_list_open_prs", boom)
+    assert metrics.main([]) == 1
+
+
+def test_main_invokes_no_subprocess_with_mocked_runners(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def forbidden_run(command: list[str], **kwargs: Any) -> Any:
+        raise AssertionError(f"subprocess must not run with mocked runners: {command}")
+
+    monkeypatch.setattr(metrics, "default_list_open_prs", lambda repo: [])
+    monkeypatch.setattr(metrics, "default_list_merged_prs", lambda repo, since: [])
+    monkeypatch.setattr(metrics.subprocess, "run", forbidden_run)
+    assert metrics.main(["--outbox-dir", str(tmp_path / "outbox")]) == 0
+
+
+def test_exit_code_constants_documented_contract() -> None:
+    assert metrics.EXIT_OK == 0
+    assert metrics.EXIT_FAILURE == 1
+    assert metrics.EXIT_BREACH == 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/scripts/test_funnel_stage_metrics.py
+++ b/tests/scripts/test_funnel_stage_metrics.py
@@ -217,6 +217,51 @@ def test_merged_search_failure_degrades_to_null_with_annotation(tmp_path: Path) 
 
 
 # ---------------------------------------------------------------------------
+# Truncated listings: counts are floors, not totals
+# ---------------------------------------------------------------------------
+
+
+def test_open_list_truncation_annotated_and_breach(tmp_path: Path) -> None:
+    # gh truncates BEFORE the prefix filter, so a limit-sized payload makes
+    # every derived count an unreliable floor — that itself is a breach.
+    prs = [_open_pr(n, head="other/branch") for n in range(metrics.OPEN_LIST_LIMIT - 1)]
+    exit_code, payload, _ = _run(tmp_path, prs + [_open_pr(999)])
+    assert exit_code == 3
+    assert payload is not None
+    assert "open_list_truncated" in payload["thresholds_breached"]
+    assert f"list_truncated_open:>={metrics.OPEN_LIST_LIMIT}" in payload["annotations"]
+
+
+def test_open_list_just_below_limit_is_unaffected(tmp_path: Path) -> None:
+    prs = [_open_pr(n, head="other/branch") for n in range(metrics.OPEN_LIST_LIMIT - 2)]
+    exit_code, payload, _ = _run(tmp_path, prs + [_open_pr(999)])
+    assert exit_code == 0
+    assert payload is not None
+    assert payload["thresholds_breached"] == []
+    assert not any("list_truncated_open" in a for a in payload["annotations"])
+
+
+def test_merged_list_truncation_nulls_merged_24h_with_annotation(tmp_path: Path) -> None:
+    # A truncated merged list would yield a misleading prefix-filtered
+    # undercount; degrade to null like the failed-search path instead.
+    merged = [_merged_pr(n) for n in range(metrics.MERGED_LIST_LIMIT)]
+    exit_code, payload, _ = _run(tmp_path, [], merged)
+    assert exit_code == 0, "merged-list truncation must not breach or fail the snapshot"
+    assert payload is not None
+    assert payload["merged_24h"] is None
+    assert f"list_truncated_merged:>={metrics.MERGED_LIST_LIMIT}" in payload["annotations"]
+
+
+def test_merged_list_just_below_limit_counts_normally(tmp_path: Path) -> None:
+    merged = [_merged_pr(n) for n in range(metrics.MERGED_LIST_LIMIT - 1)]
+    exit_code, payload, _ = _run(tmp_path, [], merged)
+    assert exit_code == 0
+    assert payload is not None
+    assert payload["merged_24h"] == metrics.MERGED_LIST_LIMIT - 1
+    assert not any("list_truncated_merged" in a for a in payload["annotations"])
+
+
+# ---------------------------------------------------------------------------
 # Outbox depth
 # ---------------------------------------------------------------------------
 
@@ -376,6 +421,17 @@ def test_main_invokes_no_subprocess_with_mocked_runners(
     monkeypatch.setattr(metrics, "default_list_merged_prs", lambda repo, since: [])
     monkeypatch.setattr(metrics.subprocess, "run", forbidden_run)
     assert metrics.main(["--outbox-dir", str(tmp_path / "outbox")]) == 0
+
+
+@pytest.mark.parametrize("repo", ["not-a-repo", "owner/name/extra", "owner/", "owner/na me"])
+def test_malformed_repo_rejected_at_parse_time(repo: str) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        metrics.main(["--repo", repo])
+    assert excinfo.value.code == 2, "argparse must reject before any gh call"
+
+
+def test_well_formed_repo_accepted_by_validator() -> None:
+    assert metrics.repo_arg("synaptent/aragora") == "synaptent/aragora"
 
 
 def test_exit_code_constants_documented_contract() -> None:

--- a/tests/scripts/test_pr_ready_triage.py
+++ b/tests/scripts/test_pr_ready_triage.py
@@ -206,6 +206,49 @@ def test_never_promote_survives_perfect_packet() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Unicode evasion of the never-promote markers (NFKC + zero-width stripping)
+# ---------------------------------------------------------------------------
+
+
+def test_fullwidth_tier4_marker_blocked() -> None:
+    # NFKC folds fullwidth compatibility forms back to ASCII "Tier 4".
+    summary, ready, packet_calls = _run(
+        [_pr(1, body="Ｔｉｅｒ ４ settlement record.")],
+        {1: _entry(1)},
+        apply=True,
+    )
+    assert summary["plan"] == []
+    assert packet_calls == []
+    assert ready.calls == []
+
+
+def test_zero_width_split_tier4_marker_blocked() -> None:
+    summary, _, packet_calls = _run(
+        [_pr(1, body="context: tier\N{ZERO WIDTH SPACE}4 change")],
+        {1: _entry(1)},
+    )
+    assert summary["plan"] == []
+    assert packet_calls == []
+
+
+def test_zero_width_mixed_case_scarmani_blocked() -> None:
+    for zw in ("\N{ZERO WIDTH NON-JOINER}", "\N{ZERO WIDTH JOINER}", "\N{WORD JOINER}"):
+        summary, _, _ = _run(
+            [_pr(1, body=f"Escalated via SCAR{zw}MANI track.")],
+            {1: _entry(1)},
+        )
+        assert summary["plan"] == [], f"zero-width {zw!r} must not split the marker"
+
+
+def test_benign_text_passes_marker_normalization() -> None:
+    summary, _, _ = _run(
+        [_pr(1, title="codex: tidy cache tiers", body="Routine 4-step refactor of tiering.")],
+        {1: _entry(1)},
+    )
+    assert _planned(summary) == [1]
+
+
+# ---------------------------------------------------------------------------
 # Stage-1 pruning: checks, mergeability, prefix, age
 # ---------------------------------------------------------------------------
 
@@ -489,6 +532,17 @@ def test_main_listing_failure_fails_closed(monkeypatch: Any) -> None:
 
     monkeypatch.setattr(triage, "default_list_draft_prs", boom)
     assert triage.main(["--repo", "synaptent/aragora"]) == 1
+
+
+@pytest.mark.parametrize("repo", ["not-a-repo", "owner/name/extra", "owner/", "owner/na me"])
+def test_malformed_repo_rejected_at_parse_time(repo: str) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        triage.main(["--repo", repo])
+    assert excinfo.value.code == 2, "argparse must reject before any gh call"
+
+
+def test_well_formed_repo_accepted_by_validator() -> None:
+    assert triage.repo_arg("synaptent/aragora") == "synaptent/aragora"
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_pr_ready_triage.py
+++ b/tests/scripts/test_pr_ready_triage.py
@@ -1,0 +1,495 @@
+"""Tests for ``scripts/pr_ready_triage.py`` (bounded draft→ready promoter).
+
+All boundaries (draft listing, merge-packet probe, ``gh pr ready``) are
+injected; no test touches the network or spawns a subprocess. Style mirrors
+``tests/scripts/test_boss_pr_janitor.py`` and
+``tests/scripts/test_auto_evidence_cycle.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _load_module(script_name: str) -> Any:
+    here = Path(__file__).resolve()
+    script_path = here.parents[2] / "scripts" / script_name
+    spec = importlib.util.spec_from_file_location(f"{script_name}_under_test", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load spec for {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+triage = _load_module("pr_ready_triage.py")
+
+NOW = datetime(2026, 6, 12, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _pr(
+    number: int,
+    *,
+    head: str = "codex/feature-branch",
+    title: str = "codex: automated change",
+    body: str = "Routine automated change.",
+    labels: list[str] | None = None,
+    checks: list[dict[str, Any]] | None = None,
+    mergeable: str = "MERGEABLE",
+    created: str = "2026-06-12T10:00:00Z",  # 2h before NOW: old enough
+) -> dict[str, Any]:
+    return {
+        "number": number,
+        "headRefName": head,
+        "title": title,
+        "body": body,
+        "labels": [{"name": name} for name in (labels or [])],
+        "statusCheckRollup": checks if checks is not None else [],
+        "mergeable": mergeable,
+        "createdAt": created,
+        "updatedAt": created,
+    }
+
+
+def _entry(
+    pr: int,
+    *,
+    tier: Any = 1,
+    human: bool = False,
+    dissent: bool = False,
+) -> dict[str, Any]:
+    return {
+        "pr_number": pr,
+        "tier": tier,
+        "requires_human_risk_settlement": human,
+        "unresolved_dissent": dissent,
+    }
+
+
+class ReadyRecorder:
+    """Injected ``gh pr ready`` runner that records calls."""
+
+    def __init__(self, results: dict[int, tuple[bool, str]] | None = None) -> None:
+        self.calls: list[int] = []
+        self.results = results or {}
+
+    def __call__(self, pr: int) -> tuple[bool, str]:
+        self.calls.append(pr)
+        return self.results.get(pr, (True, ""))
+
+
+def _run(
+    prs: list[dict[str, Any]],
+    packets: dict[int, dict[str, Any]],
+    *,
+    apply: bool = False,
+    max_scan: int = 15,
+    max_promotions: int = 5,
+    min_age_minutes: int = 30,
+    branch_prefixes: tuple[str, ...] = ("codex/",),
+    breaker_threshold: int = 3,
+    mark_ready: ReadyRecorder | None = None,
+) -> tuple[dict[str, Any], ReadyRecorder, list[int]]:
+    mark_ready = mark_ready or ReadyRecorder()
+    packet_calls: list[int] = []
+
+    def fetch_packet(pr: int) -> dict[str, Any]:
+        packet_calls.append(pr)
+        return packets.get(pr, {})
+
+    summary = triage.run_triage(
+        list_prs=lambda: prs,
+        fetch_packet=fetch_packet,
+        mark_ready=mark_ready,
+        apply=apply,
+        branch_prefixes=branch_prefixes,
+        min_age_minutes=min_age_minutes,
+        max_scan=max_scan,
+        max_promotions=max_promotions,
+        breaker_threshold=breaker_threshold,
+        now=NOW,
+        log=lambda line: None,
+    )
+    return summary, mark_ready, packet_calls
+
+
+def _planned(summary: dict[str, Any]) -> list[int]:
+    return [item["pr"] for item in summary["plan"]]
+
+
+# ---------------------------------------------------------------------------
+# Draft-by-design governance PRs: hard never-promote
+# ---------------------------------------------------------------------------
+
+
+def test_tier4_marker_in_body_never_promoted() -> None:
+    summary, ready, packet_calls = _run(
+        [_pr(1, body="This is a Tier 4 settlement record."), _pr(2)],
+        {1: _entry(1), 2: _entry(2)},
+        apply=True,
+    )
+    assert _planned(summary) == [2]
+    assert 1 not in packet_calls, "never-promote PRs must be pruned before any packet probe"
+    assert ready.calls == [2]
+
+
+def test_tier4_marker_with_whitespace_variants_blocked() -> None:
+    for text in ("tier 4", "Tier4", "TIER   4", "tier\t4"):
+        summary, _, _ = _run([_pr(1, body=f"context: {text} change")], {1: _entry(1)})
+        assert summary["plan"] == [], f"marker {text!r} must block promotion"
+
+
+def test_scarmani_mention_never_promoted() -> None:
+    summary, ready, packet_calls = _run(
+        [_pr(1, body="Escalated via the Scarmani track.")],
+        {1: _entry(1)},
+        apply=True,
+    )
+    assert summary["plan"] == []
+    assert packet_calls == []
+    assert ready.calls == []
+
+
+def test_draft_by_design_in_title_never_promoted() -> None:
+    summary, _, _ = _run(
+        [_pr(1, title="governance: draft by design settlement")],
+        {1: _entry(1)},
+    )
+    assert summary["plan"] == []
+
+
+def test_do_not_mark_ready_marker_blocked() -> None:
+    summary, _, _ = _run(
+        [_pr(1, body="Reviewers: do NOT mark ready until ops signs off.")],
+        {1: _entry(1)},
+    )
+    assert summary["plan"] == []
+
+
+def test_operator_settlement_required_marker_blocked() -> None:
+    summary, _, _ = _run(
+        [_pr(1, body="Operator settlement required before merge.")],
+        {1: _entry(1)},
+    )
+    assert summary["plan"] == []
+
+
+@pytest.mark.parametrize("label", ["merge:manual", "do-not-promote", "held"])
+def test_blocking_labels_each_individually_block(label: str) -> None:
+    summary, ready, packet_calls = _run(
+        [_pr(1, labels=[label])],
+        {1: _entry(1)},
+        apply=True,
+    )
+    assert summary["plan"] == []
+    assert packet_calls == []
+    assert ready.calls == []
+
+
+def test_never_promote_survives_perfect_packet() -> None:
+    # Even a flawless Tier-0 packet must not rescue a draft-by-design PR.
+    summary, ready, _ = _run(
+        [_pr(1, body="draft by design", labels=[])],
+        {1: _entry(1, tier=0)},
+        apply=True,
+    )
+    assert summary["plan"] == []
+    assert ready.calls == []
+
+
+# ---------------------------------------------------------------------------
+# Stage-1 pruning: checks, mergeability, prefix, age
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("state", ["FAILURE", "ERROR", "CANCELLED", "TIMED_OUT"])
+def test_failing_or_errored_checks_pruned(state: str) -> None:
+    summary, _, packet_calls = _run(
+        [_pr(1, checks=[{"name": "ci", "state": state, "conclusion": state}]), _pr(2)],
+        {1: _entry(1), 2: _entry(2)},
+    )
+    assert _planned(summary) == [2]
+    assert packet_calls == [2]
+
+
+def test_pending_checks_do_not_prune() -> None:
+    summary, _, _ = _run(
+        [_pr(1, checks=[{"name": "ci", "status": "IN_PROGRESS"}])],
+        {1: _entry(1)},
+    )
+    assert _planned(summary) == [1]
+
+
+@pytest.mark.parametrize("mergeable", ["CONFLICTING", "UNKNOWN", ""])
+def test_not_mergeable_pruned(mergeable: str) -> None:
+    summary, _, _ = _run([_pr(1, mergeable=mergeable)], {1: _entry(1)})
+    assert summary["plan"] == []
+
+
+def test_wrong_branch_prefix_pruned() -> None:
+    summary, _, _ = _run(
+        [_pr(1, head="feature/manual-work"), _pr(2, head="codex/auto")],
+        {1: _entry(1), 2: _entry(2)},
+    )
+    assert _planned(summary) == [2]
+
+
+def test_repeatable_branch_prefixes() -> None:
+    summary, _, _ = _run(
+        [_pr(1, head="codex/auto"), _pr(2, head="elves/run-1"), _pr(3, head="feature/x")],
+        {1: _entry(1), 2: _entry(2), 3: _entry(3)},
+        branch_prefixes=("codex/", "elves/"),
+    )
+    assert _planned(summary) == [1, 2]
+
+
+def test_young_pr_pruned_until_min_age() -> None:
+    young = _pr(1, created="2026-06-12T11:45:00Z")  # 15m before NOW
+    summary, _, packet_calls = _run([young], {1: _entry(1)}, min_age_minutes=30)
+    assert summary["plan"] == []
+    assert packet_calls == []
+
+
+def test_unparseable_created_at_fails_closed_as_too_young() -> None:
+    summary, _, _ = _run([_pr(1, created="not-a-date")], {1: _entry(1)})
+    assert summary["plan"] == []
+
+
+# ---------------------------------------------------------------------------
+# Stage-2 merge-packet gate (fail closed)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("tier", [3, 4, None, "garbage"])
+def test_tier3_plus_and_unknown_tier_rejected(tier: Any) -> None:
+    summary, ready, _ = _run([_pr(1)], {1: _entry(1, tier=tier)}, apply=True)
+    assert summary["plan"] == []
+    assert [item["pr"] for item in summary["rejected"]] == [1]
+    assert ready.calls == []
+
+
+def test_missing_tier_key_rejected() -> None:
+    summary, _, _ = _run([_pr(1)], {1: {"pr_number": 1}})
+    assert summary["plan"] == []
+
+
+@pytest.mark.parametrize("tier", [0, 1, 2])
+def test_tier_0_1_2_accepted(tier: int) -> None:
+    summary, _, _ = _run([_pr(1)], {1: _entry(1, tier=tier)})
+    assert _planned(summary) == [1]
+
+
+def test_human_settlement_flag_rejected() -> None:
+    summary, _, _ = _run([_pr(1)], {1: _entry(1, human=True)})
+    assert summary["plan"] == []
+    assert "requires_human_risk_settlement" in summary["rejected"][0]["reason"]
+
+
+def test_unresolved_dissent_rejected() -> None:
+    summary, _, _ = _run([_pr(1)], {1: _entry(1, dissent=True)})
+    assert summary["plan"] == []
+    assert "unresolved_dissent" in summary["rejected"][0]["reason"]
+
+
+def test_empty_packet_rejected_fail_closed() -> None:
+    summary, _, _ = _run([_pr(1)], {1: {}})
+    assert summary["plan"] == []
+    assert [item["pr"] for item in summary["rejected"]] == [1]
+
+
+# ---------------------------------------------------------------------------
+# Caps
+# ---------------------------------------------------------------------------
+
+
+def test_max_promotions_caps_plan_and_probing() -> None:
+    prs = [_pr(n) for n in (1, 2, 3, 4, 5, 6)]
+    packets = {n: _entry(n) for n in (1, 2, 3, 4, 5, 6)}
+    summary, _, packet_calls = _run(prs, packets, max_promotions=2)
+    assert _planned(summary) == [1, 2]
+    assert packet_calls == [1, 2], "probing must stop once the plan is full"
+
+
+def test_max_scan_caps_packet_probes() -> None:
+    prs = [_pr(n) for n in range(1, 11)]
+    packets = {n: _entry(n, tier=3) for n in range(1, 11)}  # all rejected at stage 2
+    summary, _, packet_calls = _run(prs, packets, max_scan=4)
+    assert len(packet_calls) == 4
+    assert summary["plan"] == []
+
+
+def test_candidates_scanned_oldest_pr_first() -> None:
+    summary, _, packet_calls = _run(
+        [_pr(9), _pr(4), _pr(7)],
+        {4: _entry(4), 7: _entry(7), 9: _entry(9)},
+    )
+    assert packet_calls == [4, 7, 9]
+
+
+# ---------------------------------------------------------------------------
+# Dry-run purity
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_performs_zero_mutations_and_exits_zero() -> None:
+    summary, ready, _ = _run([_pr(1), _pr(2)], {1: _entry(1), 2: _entry(2)}, apply=False)
+    assert ready.calls == []
+    assert summary["promoted"] == []
+    assert summary["exit_code"] == 0
+    assert summary["mode"] == "dry-run"
+    assert _planned(summary) == [1, 2]
+
+
+def test_main_dry_run_invokes_no_subprocess_with_mocked_listing(
+    monkeypatch: Any, capsys: Any
+) -> None:
+    def forbidden_run(command: list[str], **kwargs: Any) -> Any:
+        raise AssertionError(f"subprocess must not run in dry-run with mocked I/O: {command}")
+
+    monkeypatch.setattr(triage, "default_list_draft_prs", lambda repo: [_pr(1)])
+    monkeypatch.setattr(triage, "default_fetch_packet", lambda repo, pr: _entry(pr))
+    monkeypatch.setattr(triage.subprocess, "run", forbidden_run)
+
+    exit_code = triage.main(["--repo", "synaptent/aragora"])
+
+    assert exit_code == 0
+    lines = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
+    promotes = [line for line in lines if line.get("action") == "promote"]
+    assert [p["pr"] for p in promotes] == [1]
+    assert all(p["dry_run"] is True for p in promotes)
+
+
+# ---------------------------------------------------------------------------
+# Apply path: promotion, fail-closed, breaker
+# ---------------------------------------------------------------------------
+
+
+def test_apply_promotes_planned_prs_and_exits_zero() -> None:
+    summary, ready, _ = _run([_pr(1), _pr(2)], {1: _entry(1), 2: _entry(2)}, apply=True)
+    assert ready.calls == [1, 2]
+    assert summary["promoted"] == [1, 2]
+    assert summary["exit_code"] == 0
+
+
+def test_apply_respects_max_promotions_cap() -> None:
+    prs = [_pr(n) for n in (1, 2, 3, 4)]
+    summary, ready, _ = _run(
+        prs, {n: _entry(n) for n in (1, 2, 3, 4)}, apply=True, max_promotions=2
+    )
+    assert ready.calls == [1, 2]
+    assert summary["promoted"] == [1, 2]
+
+
+def test_failed_promotion_fails_closed_exit_one() -> None:
+    ready = ReadyRecorder(results={1: (False, "boom")})
+    summary, _, _ = _run(
+        [_pr(1), _pr(2)], {1: _entry(1), 2: _entry(2)}, apply=True, mark_ready=ready
+    )
+    assert summary["failed"] == [1]
+    assert summary["promoted"] == [2]
+    assert summary["exit_code"] == 1
+
+
+def test_breaker_trips_on_three_identical_errors() -> None:
+    err = (False, "gh: HTTP 401 bad credentials")
+    ready = ReadyRecorder(results={1: err, 2: err, 3: err, 4: err})
+    summary, recorder, _ = _run(
+        [_pr(n) for n in (1, 2, 3, 4)],
+        {n: _entry(n) for n in (1, 2, 3, 4)},
+        apply=True,
+        mark_ready=ready,
+    )
+    assert recorder.calls == [1, 2, 3], "PR 4 must remain untouched after the breaker"
+    assert summary["breaker_tripped"] is True
+    assert summary["exit_code"] == 2
+
+
+def test_distinct_errors_do_not_trip_breaker() -> None:
+    ready = ReadyRecorder(
+        results={1: (False, "error A"), 2: (False, "error B"), 3: (False, "error A")}
+    )
+    summary, recorder, _ = _run(
+        [_pr(n) for n in (1, 2, 3)],
+        {n: _entry(n) for n in (1, 2, 3)},
+        apply=True,
+        mark_ready=ready,
+    )
+    assert len(recorder.calls) == 3
+    assert summary["breaker_tripped"] is False
+    assert summary["exit_code"] == 1
+
+
+def test_success_resets_breaker_counter() -> None:
+    err = (False, "same error")
+    ready = ReadyRecorder(results={1: err, 2: err})  # 3 and 4 succeed by default
+    summary, recorder, _ = _run(
+        [_pr(n) for n in (1, 2, 3, 4)],
+        {n: _entry(n) for n in (1, 2, 3, 4)},
+        apply=True,
+        mark_ready=ready,
+    )
+    assert recorder.calls == [1, 2, 3, 4]
+    assert summary["breaker_tripped"] is False
+
+
+# ---------------------------------------------------------------------------
+# Summary / downstream hand-off
+# ---------------------------------------------------------------------------
+
+
+def test_summary_names_auto_evidence_cycle_as_downstream() -> None:
+    lines: list[str] = []
+    triage.run_triage(
+        list_prs=lambda: [_pr(1)],
+        fetch_packet=lambda pr: _entry(pr),
+        mark_ready=ReadyRecorder(),
+        apply=True,
+        now=NOW,
+        log=lines.append,
+    )
+    summary_lines = [json.loads(line) for line in lines if '"summary"' in line]
+    assert summary_lines, "a summary line must always be printed"
+    assert "auto_evidence_cycle" in summary_lines[-1]["downstream"]
+
+
+def test_main_apply_runs_gh_pr_ready(monkeypatch: Any) -> None:
+    commands: list[list[str]] = []
+
+    def fake_run(command: list[str], **kwargs: Any) -> Any:
+        commands.append(list(command))
+
+        class _Result:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return _Result()
+
+    monkeypatch.setattr(triage, "default_list_draft_prs", lambda repo: [_pr(7)])
+    monkeypatch.setattr(triage, "default_fetch_packet", lambda repo, pr: _entry(pr))
+    monkeypatch.setattr(triage.subprocess, "run", fake_run)
+
+    assert triage.main(["--repo", "synaptent/aragora", "--apply"]) == 0
+    ready_commands = [c for c in commands if c[:3] == ["gh", "pr", "ready"]]
+    assert len(ready_commands) == 1
+    assert "7" in ready_commands[0]
+
+
+def test_main_listing_failure_fails_closed(monkeypatch: Any) -> None:
+    def boom(repo: str) -> list[dict[str, Any]]:
+        raise RuntimeError("gh pr list failed")
+
+    monkeypatch.setattr(triage, "default_list_draft_prs", boom)
+    assert triage.main(["--repo", "synaptent/aragora"]) == 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/scripts/test_pr_ready_triage.py
+++ b/tests/scripts/test_pr_ready_triage.py
@@ -240,6 +240,22 @@ def test_zero_width_mixed_case_scarmani_blocked() -> None:
         assert summary["plan"] == [], f"zero-width {zw!r} must not split the marker"
 
 
+def test_separator_and_format_char_evasions_blocked() -> None:
+    # Round-2 skeptical-review gaps: soft hyphen (Cf, not zero-width), OGHAM
+    # SPACE MARK (the one Zs char NFKC does not fold), and multi-space runs
+    # against the literal-space markers.
+    bodies = {
+        "soft-hyphen": "scar\u00admani settlement",
+        "ogham-space": "draft\u1680by\u1680design",
+        "nbsp": "draft\u00a0by\u00a0design",
+        "multi-space": "draft  by   design",
+    }
+    for name, body in bodies.items():
+        summary, _, packet_calls = _run([_pr(1, body=body)], {1: _entry(1)})
+        assert summary["plan"] == [], f"{name} evasion must be blocked"
+        assert packet_calls == []
+
+
 def test_benign_text_passes_marker_normalization() -> None:
     summary, _, _ = _run(
         [_pr(1, title="codex: tidy cache tiers", body="Routine 4-step refactor of tiering.")],

--- a/tests/scripts/test_stale_pr_janitor.py
+++ b/tests/scripts/test_stale_pr_janitor.py
@@ -1,0 +1,542 @@
+"""Tests for ``scripts/stale_pr_janitor.py`` (stale-tail classifier, NON-DESTRUCTIVE).
+
+All boundaries (PR listing, comment fetching, comment posting) are injected;
+no test touches the network or spawns a subprocess. Style mirrors
+``tests/scripts/test_boss_pr_janitor.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _load_module(script_name: str) -> Any:
+    here = Path(__file__).resolve()
+    script_path = here.parents[2] / "scripts" / script_name
+    spec = importlib.util.spec_from_file_location(f"{script_name}_under_test", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load spec for {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+janitor = _load_module("stale_pr_janitor.py")
+
+NOW = datetime(2026, 6, 12, 12, 0, 0, tzinfo=timezone.utc)
+
+OLD = "2026-06-01T00:00:00Z"  # 11 days before NOW: stale
+RECENT = "2026-06-11T12:00:00Z"  # 1 day before NOW: active
+
+
+def _pr(
+    number: int,
+    *,
+    head: str = "codex/feature-branch",
+    draft: bool = True,
+    mergeable: str = "MERGEABLE",
+    created: str = OLD,
+    updated: str = OLD,
+    checks: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "number": number,
+        "headRefName": head,
+        "isDraft": draft,
+        "title": f"codex: change {number}",
+        "mergeable": mergeable,
+        "createdAt": created,
+        "updatedAt": updated,
+        "statusCheckRollup": checks if checks is not None else [],
+    }
+
+
+def _failing_check(name: str = "pytest") -> dict[str, Any]:
+    return {"name": name, "state": "FAILURE", "conclusion": "FAILURE"}
+
+
+class CommentRecorder:
+    def __init__(self, results: dict[int, tuple[bool, str]] | None = None) -> None:
+        self.calls: list[tuple[int, str]] = []
+        self.results = results or {}
+
+    def __call__(self, pr: int, body: str) -> tuple[bool, str]:
+        self.calls.append((pr, body))
+        return self.results.get(pr, (True, ""))
+
+
+def _run(
+    prs: list[dict[str, Any]],
+    *,
+    queue_file: Path,
+    apply: bool = False,
+    existing_comments: dict[int, list[str]] | None = None,
+    post: CommentRecorder | None = None,
+    max_comments: int = 10,
+    stale_days: int = 4,
+    inactive_days: int = 2,
+    breaker_threshold: int = 3,
+    branch_prefix: str = "codex/",
+) -> tuple[dict[str, Any], CommentRecorder, list[int]]:
+    post = post or CommentRecorder()
+    comments = existing_comments or {}
+    fetch_calls: list[int] = []
+
+    def fetch_comments(pr: int) -> list[str]:
+        fetch_calls.append(pr)
+        return comments.get(pr, [])
+
+    summary = janitor.run_janitor(
+        list_prs=lambda: prs,
+        fetch_comments=fetch_comments,
+        post_comment=post,
+        apply=apply,
+        queue_file=str(queue_file),
+        branch_prefix=branch_prefix,
+        stale_days=stale_days,
+        inactive_days=inactive_days,
+        max_comments=max_comments,
+        breaker_threshold=breaker_threshold,
+        now=NOW,
+        log=lambda line: None,
+    )
+    return summary, post, fetch_calls
+
+
+def _read_queue(queue_file: Path) -> list[dict[str, Any]]:
+    return json.loads(queue_file.read_text(encoding="utf-8"))
+
+
+def _classifications(summary: dict[str, Any]) -> dict[int, str]:
+    return {entry["pr"]: entry["classification"] for entry in summary["classified"]}
+
+
+# ---------------------------------------------------------------------------
+# Selection: prefix + staleness
+# ---------------------------------------------------------------------------
+
+
+def test_young_pr_not_selected(tmp_path: Path) -> None:
+    young = _pr(1, created="2026-06-10T00:00:00Z")  # 2 days old < stale_days=4
+    summary, _, _ = _run([young], queue_file=tmp_path / "q.json")
+    assert summary["classified"] == []
+
+
+def test_non_codex_prefix_not_selected(tmp_path: Path) -> None:
+    summary, _, _ = _run(
+        [_pr(1, head="feature/manual"), _pr(2, head="codex/auto", mergeable="CONFLICTING")],
+        queue_file=tmp_path / "q.json",
+    )
+    assert list(_classifications(summary)) == [2]
+
+
+def test_ready_and_draft_prs_both_selected(tmp_path: Path) -> None:
+    summary, _, _ = _run(
+        [
+            _pr(1, draft=True, mergeable="CONFLICTING"),
+            _pr(2, draft=False, mergeable="CONFLICTING"),
+        ],
+        queue_file=tmp_path / "q.json",
+    )
+    assert sorted(_classifications(summary)) == [1, 2]
+
+
+def test_unparseable_created_at_skipped_fail_safe(tmp_path: Path) -> None:
+    summary, _, _ = _run(
+        [_pr(1, created="not-a-date", mergeable="CONFLICTING")],
+        queue_file=tmp_path / "q.json",
+    )
+    assert summary["classified"] == []
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+
+def test_recent_activity_classified_active_and_skipped(tmp_path: Path) -> None:
+    qf = tmp_path / "q.json"
+    summary, post, _ = _run(
+        [_pr(1, updated=RECENT, mergeable="CONFLICTING")],
+        queue_file=qf,
+        apply=True,
+    )
+    assert _classifications(summary) == {1: "active"}
+    assert summary["queued"] == []
+    assert post.calls == []
+    assert not qf.exists(), "active PRs must not touch the queue"
+
+
+def test_conflicting_classified_restack(tmp_path: Path) -> None:
+    summary, _, _ = _run(
+        [_pr(1, mergeable="CONFLICTING")],
+        queue_file=tmp_path / "q.json",
+    )
+    assert _classifications(summary) == {1: "restack"}
+    assert summary["queued"] == [1]
+
+
+def test_failing_checks_classified_blocked_with_check_names(tmp_path: Path) -> None:
+    summary, _, _ = _run(
+        [_pr(1, checks=[_failing_check("pytest"), _failing_check("ruff")])],
+        queue_file=tmp_path / "q.json",
+    )
+    entry = summary["classified"][0]
+    assert entry["classification"] == "blocked"
+    assert entry["failing_checks"] == ["pytest", "ruff"]
+    assert "pytest" in entry["reason"] and "ruff" in entry["reason"]
+    assert summary["queued"] == [1]
+
+
+def test_green_mergeable_classified_promotable_recommendation_only(tmp_path: Path) -> None:
+    qf = tmp_path / "q.json"
+    summary, post, _ = _run(
+        [_pr(1, checks=[{"name": "ci", "state": "SUCCESS", "conclusion": "SUCCESS"}])],
+        queue_file=qf,
+        apply=True,
+    )
+    assert _classifications(summary) == {1: "promotable"}
+    assert summary["recommendations"] == [
+        {"pr": 1, "recommendation": "run scripts/pr_ready_triage.py (no action taken here)"}
+    ]
+    assert summary["queued"] == []
+    assert post.calls == []
+    assert not qf.exists(), "promotable PRs must not be queued"
+
+
+def test_pending_checks_classified_indeterminate_and_skipped(tmp_path: Path) -> None:
+    qf = tmp_path / "q.json"
+    summary, post, _ = _run(
+        [_pr(1, checks=[{"name": "ci", "status": "IN_PROGRESS"}])],
+        queue_file=qf,
+        apply=True,
+    )
+    assert _classifications(summary) == {1: "indeterminate"}
+    assert summary["queued"] == []
+    assert post.calls == []
+    assert not qf.exists()
+
+
+# ---------------------------------------------------------------------------
+# Restack queue: write, merge, dedupe, never-drop, corruption
+# ---------------------------------------------------------------------------
+
+
+def test_queue_entries_have_required_fields(tmp_path: Path) -> None:
+    qf = tmp_path / "q.json"
+    _run([_pr(1, head="codex/conflicted", mergeable="CONFLICTING")], queue_file=qf)
+    entries = _read_queue(qf)
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["pr"] == 1
+    assert entry["head_ref"] == "codex/conflicted"
+    assert entry["classification"] == "restack"
+    assert entry["reason"]
+    assert entry["detected_at"] == "2026-06-12T12:00:00Z"
+
+
+def test_queue_merge_preserves_entries_not_classified_this_run(tmp_path: Path) -> None:
+    qf = tmp_path / "q.json"
+    pre_existing = [
+        {
+            "pr": 99,
+            "head_ref": "codex/old-thing",
+            "classification": "restack",
+            "reason": "previously detected",
+            "detected_at": "2026-06-01T00:00:00Z",
+        }
+    ]
+    qf.write_text(json.dumps(pre_existing), encoding="utf-8")
+
+    _run([_pr(1, mergeable="CONFLICTING")], queue_file=qf)
+
+    entries = _read_queue(qf)
+    assert {e["pr"] for e in entries} == {1, 99}
+    kept = next(e for e in entries if e["pr"] == 99)
+    assert kept == pre_existing[0], "entries from earlier runs must never be dropped or altered"
+
+
+def test_queue_dedupes_by_pr_number_current_run_wins(tmp_path: Path) -> None:
+    qf = tmp_path / "q.json"
+    qf.write_text(
+        json.dumps(
+            [
+                {
+                    "pr": 1,
+                    "head_ref": "codex/feature-branch",
+                    "classification": "blocked",
+                    "reason": "old reason",
+                    "detected_at": "2026-06-01T00:00:00Z",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    _run([_pr(1, mergeable="CONFLICTING")], queue_file=qf)
+
+    entries = _read_queue(qf)
+    assert len(entries) == 1, "dedupe by PR number"
+    assert entries[0]["classification"] == "restack"
+    assert entries[0]["detected_at"] == "2026-06-12T12:00:00Z"
+
+
+def test_opaque_existing_entries_preserved(tmp_path: Path) -> None:
+    qf = tmp_path / "q.json"
+    qf.write_text(json.dumps([{"note": "hand-written marker, no pr key"}]), encoding="utf-8")
+
+    _run([_pr(1, mergeable="CONFLICTING")], queue_file=qf)
+
+    entries = _read_queue(qf)
+    assert {"note": "hand-written marker, no pr key"} in entries
+    assert any(e.get("pr") == 1 for e in entries)
+
+
+def test_corrupt_queue_file_fails_closed_and_is_never_overwritten(tmp_path: Path) -> None:
+    qf = tmp_path / "q.json"
+    qf.write_text("{not json", encoding="utf-8")
+
+    summary, post, _ = _run([_pr(1, mergeable="CONFLICTING")], queue_file=qf, apply=True)
+
+    assert summary["exit_code"] == 1
+    assert qf.read_text(encoding="utf-8") == "{not json", "corrupt queue must not be overwritten"
+    assert post.calls == [], "no comments after a queue failure"
+
+
+# ---------------------------------------------------------------------------
+# Dry-run vs apply: comments
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_posts_no_comments_and_exits_zero(tmp_path: Path) -> None:
+    summary, post, _ = _run(
+        [_pr(1, mergeable="CONFLICTING"), _pr(2, checks=[_failing_check()])],
+        queue_file=tmp_path / "q.json",
+        apply=False,
+    )
+    assert post.calls == []
+    assert summary["comments_posted"] == []
+    assert summary["exit_code"] == 0
+    assert summary["mode"] == "dry-run"
+
+
+def test_apply_posts_one_marked_comment_per_queued_pr(tmp_path: Path) -> None:
+    summary, post, _ = _run(
+        [_pr(1, mergeable="CONFLICTING")],
+        queue_file=tmp_path / "q.json",
+        apply=True,
+    )
+    assert summary["comments_posted"] == [1]
+    assert len(post.calls) == 1
+    pr, body = post.calls[0]
+    assert pr == 1
+    assert janitor.COMMENT_MARKER in body
+    assert "never closes PRs" in body
+
+
+def test_existing_marker_comment_skips_posting_idempotent(tmp_path: Path) -> None:
+    summary, post, _ = _run(
+        [_pr(1, mergeable="CONFLICTING")],
+        queue_file=tmp_path / "q.json",
+        apply=True,
+        existing_comments={1: [f"earlier note\n{janitor.COMMENT_MARKER}\nclassified"]},
+    )
+    assert post.calls == []
+    assert summary["comments_skipped_existing"] == [1]
+    assert summary["comments_posted"] == []
+    assert summary["exit_code"] == 0
+
+
+def test_unrelated_existing_comments_do_not_block_posting(tmp_path: Path) -> None:
+    summary, post, _ = _run(
+        [_pr(1, mergeable="CONFLICTING")],
+        queue_file=tmp_path / "q.json",
+        apply=True,
+        existing_comments={1: ["LGTM", "please rebase"]},
+    )
+    assert summary["comments_posted"] == [1]
+    assert len(post.calls) == 1
+
+
+def test_max_comments_caps_posting(tmp_path: Path) -> None:
+    prs = [_pr(n, mergeable="CONFLICTING") for n in range(1, 6)]
+    summary, post, _ = _run(
+        prs,
+        queue_file=tmp_path / "q.json",
+        apply=True,
+        max_comments=2,
+    )
+    assert [pr for pr, _ in post.calls] == [1, 2]
+    assert summary["comments_posted"] == [1, 2]
+    # The queue still records ALL classified PRs, beyond the comment cap.
+    assert summary["queued"] == [1, 2, 3, 4, 5]
+
+
+def test_failed_comment_fails_closed_exit_one(tmp_path: Path) -> None:
+    post = CommentRecorder(results={1: (False, "boom")})
+    summary, _, _ = _run(
+        [_pr(1, mergeable="CONFLICTING"), _pr(2, mergeable="CONFLICTING")],
+        queue_file=tmp_path / "q.json",
+        apply=True,
+        post=post,
+    )
+    assert summary["failed"] == [1]
+    assert summary["comments_posted"] == [2]
+    assert summary["exit_code"] == 1
+
+
+def test_breaker_trips_on_three_identical_comment_errors(tmp_path: Path) -> None:
+    err = (False, "gh: HTTP 401 bad credentials")
+    post = CommentRecorder(results={1: err, 2: err, 3: err, 4: err})
+    summary, recorder, _ = _run(
+        [_pr(n, mergeable="CONFLICTING") for n in (1, 2, 3, 4)],
+        queue_file=tmp_path / "q.json",
+        apply=True,
+        post=post,
+    )
+    assert [pr for pr, _ in recorder.calls] == [1, 2, 3], "PR 4 untouched after the breaker"
+    assert summary["breaker_tripped"] is True
+    assert summary["exit_code"] == 2
+
+
+def test_distinct_comment_errors_do_not_trip_breaker(tmp_path: Path) -> None:
+    post = CommentRecorder(
+        results={1: (False, "error A"), 2: (False, "error B"), 3: (False, "error A")}
+    )
+    summary, recorder, _ = _run(
+        [_pr(n, mergeable="CONFLICTING") for n in (1, 2, 3)],
+        queue_file=tmp_path / "q.json",
+        apply=True,
+        post=post,
+    )
+    assert len(recorder.calls) == 3
+    assert summary["breaker_tripped"] is False
+    assert summary["exit_code"] == 1
+
+
+def test_comment_fetch_failure_fails_closed_without_posting(tmp_path: Path) -> None:
+    post = CommentRecorder()
+
+    def failing_fetch(pr: int) -> list[str]:
+        raise RuntimeError("gh pr view failed")
+
+    summary = janitor.run_janitor(
+        list_prs=lambda: [_pr(1, mergeable="CONFLICTING")],
+        fetch_comments=failing_fetch,
+        post_comment=post,
+        apply=True,
+        queue_file=str(tmp_path / "q.json"),
+        now=NOW,
+        log=lambda line: None,
+    )
+    assert post.calls == [], "never post when idempotency cannot be verified"
+    assert summary["failed"] == [1]
+    assert summary["exit_code"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Non-destructive guarantee: no close / delete / push, ever
+# ---------------------------------------------------------------------------
+
+
+def test_janitor_never_emits_close_delete_or_push(monkeypatch: Any, tmp_path: Path) -> None:
+    commands: list[list[str]] = []
+
+    def fake_run(command: list[str], **kwargs: Any) -> Any:
+        commands.append(list(command))
+
+        class _Result:
+            returncode = 0
+            stdout = "{}" if command[:3] == ["gh", "pr", "view"] else ""
+            stderr = ""
+
+        return _Result()
+
+    adversarial_mix = [
+        _pr(1, mergeable="CONFLICTING"),
+        _pr(2, checks=[_failing_check()]),
+        _pr(3, checks=[{"name": "ci", "state": "SUCCESS", "conclusion": "SUCCESS"}]),
+        _pr(4, updated=RECENT),
+        _pr(5, head="feature/other"),
+    ]
+    monkeypatch.setattr(janitor, "default_list_prs", lambda repo: adversarial_mix)
+    monkeypatch.setattr(janitor.subprocess, "run", fake_run)
+
+    exit_code = janitor.main(
+        ["--repo", "synaptent/aragora", "--apply", "--queue-file", str(tmp_path / "q.json")]
+    )
+
+    assert exit_code == 0
+    forbidden = {"close", "delete", "push", "--delete-branch", "merge"}
+    for command in commands:
+        assert not (set(command) & forbidden), f"destructive command emitted: {command}"
+    # Only read (view) and comment commands are permitted.
+    for command in commands:
+        assert command[:2] == ["gh", "pr"]
+        assert command[2] in {"view", "comment"}, command
+
+
+def test_plan_actions_limited_to_safe_vocabulary(tmp_path: Path) -> None:
+    lines: list[str] = []
+    janitor.run_janitor(
+        list_prs=lambda: [
+            _pr(1, mergeable="CONFLICTING"),
+            _pr(2, checks=[_failing_check()]),
+            _pr(3, checks=[{"name": "ci", "state": "SUCCESS", "conclusion": "SUCCESS"}]),
+        ],
+        fetch_comments=lambda pr: [],
+        post_comment=CommentRecorder(),
+        apply=True,
+        queue_file=str(tmp_path / "q.json"),
+        now=NOW,
+        log=lines.append,
+    )
+    allowed = {
+        "classify",
+        "recommend_promote",
+        "queue_written",
+        "queue_error",
+        "comment",
+        "comment_skipped",
+        "comment_failed",
+        "breaker_tripped",
+        "summary",
+    }
+    actions = {json.loads(line).get("action") for line in lines}
+    assert actions <= allowed, actions
+
+
+def test_main_dry_run_with_mocked_listing_only_reads(monkeypatch: Any, tmp_path: Path) -> None:
+    commands: list[list[str]] = []
+
+    def fake_run(command: list[str], **kwargs: Any) -> Any:
+        commands.append(list(command))
+
+        class _Result:
+            returncode = 0
+            stdout = "{}"
+            stderr = ""
+
+        return _Result()
+
+    monkeypatch.setattr(janitor, "default_list_prs", lambda repo: [_pr(1, mergeable="CONFLICTING")])
+    monkeypatch.setattr(janitor.subprocess, "run", fake_run)
+
+    exit_code = janitor.main(
+        ["--repo", "synaptent/aragora", "--queue-file", str(tmp_path / "q.json")]
+    )
+
+    assert exit_code == 0
+    assert all(c[:3] == ["gh", "pr", "view"] for c in commands), commands
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## Problem (funnel analysis, 2026-06-12)

The autonomous PR pipeline has transport gaps between stages: the publisher opens **draft** PRs but `auto_evidence_cycle.py` only feeds on **ready** PRs (130 drafts vs 8 ready at analysis time); nothing manages the stale tail (37 open codex/ PRs >4 days); writers generate regardless of backlog (~255 WIP vs ~15–20 merges/day); and no metric watches time-in-state, so pileups sit invisible. Separately, `codex_worktree_value_inventory.py` hung in production ("hung inside candidate git status", 2026-06-12 goal-loop).

## What this adds (new scripts + tests, plus one hang fix — Tier 2, no governance surfaces touched)

### Commit 1 — funnel transport
- **`scripts/pr_ready_triage.py`** — bounded draft→ready promoter. Stage 1: one `gh pr list --draft` prune (failing checks, non-MERGEABLE, blocking labels, min-age, **hard never-promote regex** for tier-4/draft-by-design/settlement/scarmani governance drafts — checked before any packet probe, so a perfect packet can never rescue a governance draft). Stage 2: `review-queue merge-packet` ground truth — tier ≤2 fail-closed, no human-settlement requirement, no unresolved dissent. Only mutation: `gh pr ready`, capped (default 5/run). Downstream pickup: `auto_evidence_cycle.py` on the next arbiter pass.
- **`scripts/stale_pr_janitor.py`** — non-destructive stale-tail classifier (`active`/`promotable`/`restack`/`blocked`/`indeterminate`); writes a merge-and-dedupe restack queue to `.aragora/restack-queue.json` for writer lanes; one idempotent marker comment per PR under `--apply`. **Never closes/deletes/pushes** (asserted by adversarial command-vocabulary tests).

### Commit 2 — backpressure + telemetry + hang fix
- **`scripts/backlog_gate.py`** — closure-first backpressure signal: open automation-PR count + outbox depth vs thresholds (60/50) → `generate`/`shepherd` mode, atomically written to `.aragora/backpressure.json`. **Fails closed**: any gate failure writes a `shepherd` signal before exiting 1 — a broken gate never green-lights generation. Exit 0/3/1 for shell wrappers.
- **`scripts/funnel_stage_metrics.py`** — per-stage telemetry: draft/ready counts with age p50/p90/max, stale tail, merged-24h, outbox depth; breach exit 3 (sentinel-friendly); merged-search failure degrades to `null` rather than failing the snapshot.
- **`scripts/codex_worktree_value_inventory.py` hang fix** — root cause: every subprocess already had a timeout, but `subprocess.run`'s post-timeout pipe drain blocks forever when a descendant (git hook / fsmonitor daemon) inherits the pipe FDs. `run_cmd` now uses `Popen(start_new_session=True)` + `killpg` on timeout + bounded 5s drain; timed-out candidates get `inspect_timeout` annotations and classify as PROTECTED (never cleanup candidates — never-delete posture preserved); the run completes and the summary reports `inspect_timeouts`. Includes a real grandchild-holds-pipes regression test.

## Tests / validation
- **169 tests passing** across the five test files (47 + 26 + 23 + 26 + 47 incl. 5 new inventory regression tests).
- `ruff check` + `ruff format` clean; `mypy` clean on the wave-1 scripts; `py_compile` on all.
- All scripts stdlib-only, dry-run/read-only by default, `--apply` gates mutations, injected runners for tests, identical-error breakers, fail-closed exits — mirroring `boss_pr_janitor.py` conventions.

## Deliberately out of scope
- Wiring into `run_merge_arbiter.sh` / boss loop (env-gated activation mirrors `ARAGORA_AUTO_EVIDENCE`) — follow-up by the operator's local session; keeps this PR off governance-adjacent surfaces.
- No edits to `review_queue.py`, workflows, settle scripts, or protected files.

## Rollout
Dry-run all four from the main checkout, review plans/signals, then enable promoter+janitor via the arbiter wrapper and point writer-lane admission at `.aragora/backpressure.json`. Caps intentionally conservative (promote 5/run, comment 10/run).

Related issues filed from the same analysis: #8315 (merge-packet GraphQL fallback, Tier 4), #8316 (settle_one_pr transport retry, Tier 4), #8317 (agent-bridge submit verification), #8318 (stale owner-lease TTL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jfJj5gb9VoLs6VBMnzhrP