### PR TITLE
fix(metrics): use registry for adapter count

### DIFF
--- a/scripts/update_docs_metrics.py
+++ b/scripts/update_docs_metrics.py
@@ -1,46 +1,51 @@
-import os
 import re
+from pathlib import Path
 
 
-def update_adapter_count():
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+def get_adapter_count() -> int:
+    """Return the product's canonical Knowledge Mound adapter count."""
+    from aragora.knowledge.mound.adapters.factory import ADAPTER_SPECS
+
+    return len(ADAPTER_SPECS)
+
+
+def _replace_adapter_count(content: str, adapter_count: int) -> str | None:
+    pattern = r"(<!-- adpt-count -->)\d+(<!-- /adpt-count -->)"
+    new_text = rf"\g<1>{adapter_count}\g<2>"
+    if not re.search(pattern, content):
+        return None
+    return re.sub(pattern, new_text, content)
+
+
+def update_adapter_count(
+    *,
+    project_root: Path = PROJECT_ROOT,
+    adapter_count: int | None = None,
+) -> None:
     """
-    Counts the number of adapters in the knowledge mound and updates the README.md.
+    Counts canonical Knowledge Mound adapters and updates the README.md.
     """
-    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-    adapters_dir = os.path.join(project_root, "aragora", "knowledge", "mound", "adapters")
-    readme_path = os.path.join(project_root, "README.md")
+    readme_path = project_root / "README.md"
+    adapter_count = get_adapter_count() if adapter_count is None else adapter_count
 
     try:
-        # Count the number of files in the adapters directory
-        adapter_files = os.listdir(adapters_dir)
-        # Filter out any hidden files like .DS_Store
-        adapter_count = len([f for f in adapter_files if not f.startswith(".")])
-    except FileNotFoundError:
-        print(f"Error: Adapters directory not found at {adapters_dir}")
-        return
-
-    try:
-        with open(readme_path, "r") as f:
-            content = f.read()
+        content = readme_path.read_text(encoding="utf-8")
     except FileNotFoundError:
         print(f"Error: README.md not found at {readme_path}")
         return
 
-    # Use a regex to find and replace the adapter count within the HTML comments
-    pattern = r"(<!-- adpt-count -->)\d+(<!-- /adpt-count -->)"
-    new_text = rf"\g<1>{adapter_count}\g<2>"
-
-    if re.search(pattern, content):
-        updated_content = re.sub(pattern, new_text, content)
-    else:
+    updated_content = _replace_adapter_count(content, adapter_count)
+    if updated_content is None:
         print("Error: Could not find the adapter count placeholder in README.md")
         print("Please add '<!-- adpt-count -->...<!-- /adpt-count -->' to the README.")
         return
 
     if content != updated_content:
         try:
-            with open(readme_path, "w") as f:
-                f.write(updated_content)
+            readme_path.write_text(updated_content, encoding="utf-8")
             print(f"Successfully updated README.md with adapter count: {adapter_count}")
         except IOError as e:
             print(f"Error writing to README.md: {e}")

--- a/tests/scripts/test_update_docs_metrics.py
+++ b/tests/scripts/test_update_docs_metrics.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
+if _scripts_dir not in sys.path:
+    sys.path.insert(0, _scripts_dir)
+
+import update_docs_metrics as mod  # noqa: E402
+
+
+def test_replace_adapter_count_updates_readme_placeholder() -> None:
+    content = "Knowledge Mound (<!-- adpt-count -->0<!-- /adpt-count --> adapters)"
+
+    updated = mod._replace_adapter_count(content, 42)
+
+    assert updated == "Knowledge Mound (<!-- adpt-count -->42<!-- /adpt-count --> adapters)"
+
+
+def test_update_adapter_count_uses_registry_count_not_directory_noise(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text("KM: <!-- adpt-count -->999<!-- /adpt-count --> adapters\n", encoding="utf-8")
+
+    noisy_adapters = tmp_path / "aragora" / "knowledge" / "mound" / "adapters"
+    noisy_adapters.mkdir(parents=True)
+    (noisy_adapters / "CLAUDE.md").write_text("not an adapter registry entry\n", encoding="utf-8")
+    (noisy_adapters / "_base.py").write_text("not counted directly\n", encoding="utf-8")
+    (noisy_adapters / "performance").mkdir()
+
+    monkeypatch.setattr(mod, "get_adapter_count", lambda: 42)
+
+    mod.update_adapter_count(project_root=tmp_path)
+
+    assert readme.read_text(encoding="utf-8") == (
+        "KM: <!-- adpt-count -->42<!-- /adpt-count --> adapters\n"
+    )
+    captured = capsys.readouterr()
+    assert "Successfully updated README.md with adapter count: 42" in captured.out


### PR DESCRIPTION
Summary:
- Make update_docs_metrics use the canonical Knowledge Mound ADAPTER_SPECS registry count instead of counting adapter directory entries.
- Add focused regression coverage proving directory noise does not change the README adapter metric.

Validation:
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_update_docs_metrics.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/update_docs_metrics.py tests/scripts/test_update_docs_metrics.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python scripts/update_docs_metrics.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD