### PR TITLE
fix(publisher): bound outbox git probes

### DIFF
--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -36,6 +36,7 @@ DEFAULT_LABELS = ("boss-ready",)
 DEFAULT_LIMIT = 2
 DEFAULT_MAX_OPEN_ISSUES = 12
 DEFAULT_COMMAND_TIMEOUT_SECONDS = 45
+GIT_PROBE_TIMEOUT_SECONDS = 5
 MAX_ISSUE_BODY_CHARS = 60_000
 DEFAULT_OUTBOX_DIR = Path(".aragora/automation-outbox")
 DEFAULT_RECEIPT_DIR = Path(".aragora/automation-receipts")
@@ -676,23 +677,56 @@ def _outbox_desired_head(payload: dict[str, Any]) -> str | None:
     return None
 
 
+def _outbox_git_candidates(payload: dict[str, Any]) -> list[str]:
+    exact_refs = [
+        _outbox_evidence_value(payload, "head"),
+        _outbox_evidence_value(payload, "head_sha"),
+        _outbox_evidence_value(payload, "commit"),
+    ]
+    candidates = list(dict.fromkeys(item for item in exact_refs if item))
+    if not candidates:
+        branch = _outbox_evidence_value(payload, "branch")
+        if branch:
+            candidates.append(branch)
+    return candidates
+
+
+def _run_git_probe(repo_root: Path, args: list[str]) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            args,
+            cwd=repo_root,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=GIT_PROBE_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=124,
+            stdout=exc.stdout if isinstance(exc.stdout, str) else "",
+            stderr=exc.stderr if isinstance(exc.stderr, str) else "",
+        )
+
+
 def _git_is_ancestor(repo_root: Path, ancestor: str, descendant: str) -> bool:
-    proc = _run(["git", "merge-base", "--is-ancestor", ancestor, descendant], cwd=repo_root)
+    proc = _run_git_probe(
+        repo_root,
+        ["git", "merge-base", "--is-ancestor", ancestor, descendant],
+    )
     return proc.returncode == 0
 
 
 def _git_patch_equivalent(repo_root: Path, base: str, candidate: str) -> bool:
-    diff_proc = _run(["git", "diff", "--quiet", f"{base}...{candidate}"], cwd=repo_root)
-    if diff_proc.returncode == 0:
+    tree_proc = _run_git_probe(repo_root, ["git", "diff", "--quiet", base, candidate])
+    if tree_proc.returncode == 0:
         return True
-    if diff_proc.returncode != 1:
+    if tree_proc.returncode != 1:
         return False
 
-    proc = _run(["git", "cherry", base, candidate], cwd=repo_root)
-    if proc.returncode != 0:
-        return False
-    statuses = [line[:1] for line in proc.stdout.splitlines() if line.strip()]
-    return bool(statuses) and all(status == "-" for status in statuses)
+    diff_proc = _run_git_probe(repo_root, ["git", "diff", "--quiet", f"{base}...{candidate}"])
+    return diff_proc.returncode == 0
 
 
 def _outbox_branch_already_merged(repo_root: Path, payload: dict[str, Any]) -> bool:
@@ -703,13 +737,7 @@ def _outbox_branch_already_merged(repo_root: Path, payload: dict[str, Any]) -> b
     if not base_ref:
         return False
 
-    candidates = [
-        _outbox_evidence_value(payload, "head"),
-        _outbox_evidence_value(payload, "head_sha"),
-        _outbox_evidence_value(payload, "commit"),
-        _outbox_evidence_value(payload, "branch"),
-    ]
-    for candidate in dict.fromkeys(item for item in candidates if item):
+    for candidate in _outbox_git_candidates(payload):
         if _git_is_ancestor(repo_root, candidate, base_ref):
             return True
     return False
@@ -723,13 +751,7 @@ def _outbox_branch_patch_equivalent(repo_root: Path, payload: dict[str, Any]) ->
     if not base_ref:
         return False
 
-    candidates = [
-        _outbox_evidence_value(payload, "branch"),
-        _outbox_evidence_value(payload, "head"),
-        _outbox_evidence_value(payload, "head_sha"),
-        _outbox_evidence_value(payload, "commit"),
-    ]
-    for candidate in dict.fromkeys(item for item in candidates if item):
+    for candidate in _outbox_git_candidates(payload):
         if _git_patch_equivalent(repo_root, base_ref, candidate):
             return True
     return False

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -762,6 +762,57 @@ def test_load_outbox_handoffs_skips_already_merged_top_level_head(tmp_path: Path
     assert mod.load_outbox_handoffs(repo) == []
 
 
+def test_git_is_ancestor_times_out_as_not_merged(monkeypatch: Any, tmp_path: Path) -> None:
+    calls: list[tuple[list[str], float | None]] = []
+
+    def fake_run(
+        args: list[str],
+        *,
+        cwd: Path,
+        text: bool,
+        capture_output: bool,
+        check: bool,
+        timeout: float | None,
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append((args, timeout))
+        raise subprocess.TimeoutExpired(args, timeout)
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    assert mod._git_is_ancestor(tmp_path, "slow-ref", "origin/main") is False
+    assert calls == [
+        (
+            ["git", "merge-base", "--is-ancestor", "slow-ref", "origin/main"],
+            mod.GIT_PROBE_TIMEOUT_SECONDS,
+        )
+    ]
+
+
+def test_outbox_git_candidates_prefer_exact_head_over_branch() -> None:
+    payload = _outbox_payload(
+        branch="codex/example",
+        head_sha="0123456789abcdef0123456789abcdef01234567",
+    )
+
+    assert mod._outbox_git_candidates(payload) == ["0123456789abcdef0123456789abcdef01234567"]
+
+
+def test_git_patch_equivalent_does_not_run_cherry(monkeypatch: Any, tmp_path: Path) -> None:
+    calls: list[list[str]] = []
+
+    def fake_probe(repo_root: Path, args: list[str]) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        return subprocess.CompletedProcess(args, 1, "", "")
+
+    monkeypatch.setattr(mod, "_run_git_probe", fake_probe)
+
+    assert mod._git_patch_equivalent(tmp_path, "origin/main", "abc1234") is False
+    assert calls == [
+        ["git", "diff", "--quiet", "origin/main", "abc1234"],
+        ["git", "diff", "--quiet", "origin/main...abc1234"],
+    ]
+
+
 def test_load_outbox_handoffs_skips_patch_equivalent_branch(tmp_path: Path) -> None:
     repo, head = _repo_with_patch_equivalent_codex_branch(tmp_path)
     outbox = repo / ".aragora" / "automation-outbox"


### PR DESCRIPTION
## Summary
- bound publisher outbox ancestry and diff probes with a short local timeout
- prefer exact handoff head refs over mutable branch refs during already-merged/patch checks
- replace broad git cherry patch-equivalence scans with cheaper tree/diff checks

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_publish_automation_handoffs.py (67 passed)
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m py_compile scripts/publish_automation_handoffs.py tests/scripts/test_publish_automation_handoffs.py
- python3 -m ruff check scripts/publish_automation_handoffs.py tests/scripts/test_publish_automation_handoffs.py
- python3 -m ruff format --check scripts/publish_automation_handoffs.py tests/scripts/test_publish_automation_handoffs.py
- git diff --check && git diff --check origin/main...HEAD
- live outbox loader completed: 107 handoffs, 10 expired skips, about 12.08s
- publisher summary dry-run completed: decision_summary total=107 eligible=1 existing_issue=103 stale_outbox_head=1 target_open_pr=2
- bash scripts/automation_pr_preflight.sh origin/main HEAD
