### PR TITLE
fix(tests): resolve handle_post contradiction — pin the no-op hook contract, un-red Release Readiness (#8325)

### DIFF
--- a/tests/handlers/admin/test_system.py
+++ b/tests/handlers/admin/test_system.py
@@ -695,9 +695,15 @@ class TestRemovedLegacyRoutes:
         assert handler.can_handle("/metrics") is False
         assert "/metrics" not in handler.ROUTES
 
-    def test_no_post_handler_remains(self):
-        """SystemHandler defines no handle_post after revoke removal."""
-        assert "handle_post" not in SystemHandler.__dict__
+    def test_post_handler_is_noop_compat_hook(self):
+        """handle_post remains as a deliberate no-op after the revoke move.
+
+        It anchors OpenAPI placeholder-method inference (see
+        tests/server/test_route_ownership.py pins and issue #8325) and must
+        never claim a route.
+        """
+        assert "handle_post" in SystemHandler.__dict__
+        assert SystemHandler(ctx={}).handle_post("/api/auth/revoke", {}, None) is None
 
     def test_metrics_dispatch_returns_none(self, handler, mock_http):
         """handle() no longer dispatches /metrics (falls through to None)."""

--- a/tests/test_handlers_system.py
+++ b/tests/test_handlers_system.py
@@ -1651,11 +1651,19 @@ class TestNomicHealthEdgeCases:
 
 
 class TestPostHandler:
-    """SystemHandler no longer defines POST routes.
+    """SystemHandler claims no POST routes.
 
-    Its only POST endpoint (/api/auth/revoke) moved to AuthHandler — see
-    tests/server/test_route_ownership.py for the ownership pin.
+    Its only real POST endpoint (/api/auth/revoke) moved to AuthHandler — see
+    tests/server/test_route_ownership.py for the ownership pin. A no-op
+    ``handle_post`` deliberately REMAINS on SystemHandler so OpenAPI
+    placeholder-method inference keeps emitting POST placeholders for its
+    path-only ROUTES (pinned by
+    test_system_openapi_placeholder_methods_do_not_drift_when_revoke_moves);
+    the hook must never claim a route. See issue #8325.
     """
 
-    def test_no_handle_post_defined(self):
-        assert "handle_post" not in SystemHandler.__dict__
+    def test_handle_post_is_noop_compat_hook(self):
+        assert "handle_post" in SystemHandler.__dict__
+        handler = SystemHandler(ctx={})
+        assert handler.handle_post("/api/auth/revoke", {}, None) is None
+        assert handler.handle_post("/api/system/maintenance", {}, None) is None


### PR DESCRIPTION
## Problem (issue #8325 — ambient main-red since ~08:23 CT)

`Release Readiness` fails repo-wide on `tests/test_handlers_system.py::TestPostHandler::test_no_handle_post_defined`, demoting otherwise-green PRs out of auto-merge Bucket A and polluting merge-packet failure counts. Root cause: main carries **both directions** of the `SystemHandler.handle_post` question simultaneously:

- `tests/server/test_route_ownership.py` **requires the hook to exist** — it anchors OpenAPI placeholder-method inference (`test_system_openapi_placeholder_methods_do_not_drift_when_revoke_moves`) and pins that it never reclaims routes (`test_system_handler_post_compat_hook_does_not_reclaim_removed_routes`).
- Two absence tests (added by #8163) assert the method must **not exist at all**: `test_no_handle_post_defined` and `tests/handlers/admin/test_system.py::test_no_post_handler_remains`.

The hook on main is a pure no-op (`return None` for every path; docstring: "Preserve legacy POST placeholder inference without claiming POST routes") — so the `/api/auth/revoke` ownership move to `AuthHandler` is unaffected by its existence. The absence tests over-pinned the intent.

## Fix (direction (b), operator-authorized on #8325)

Keep the hook; invert the two absence tests into **hook-contract tests**: the hook must exist (placeholder anchor) and must never claim a route (asserted against `/api/auth/revoke` and `/api/system/maintenance`). Both tests now cross-reference the route-ownership pins and #8325, so the repo states one coherent invariant instead of two contradictory ones.

Test-only change; no production code touched. Tier ≤2.

## Why not remove the hook instead (direction (a))

Removing it flips generated OpenAPI placeholder methods POST→GET (`openapi_impl._infer_methods()`), which is exactly the regression grok flagged on #8290 and which `test_system_openapi_placeholder_methods_do_not_drift_when_revoke_moves` exists to block. Note: **draft #8320 currently implements direction (a)** (removes the hook) without running the route-ownership suite — see coordination comment there; its explainability half is unaffected by this PR (zero file overlap).

## Validation

- `tests/test_handlers_system.py` + `tests/server/test_route_ownership.py` → **85 passed, 1 skipped** (the previously-failing test now passes, and the placeholder-drift pins still hold)
- `tests/handlers/admin/test_system.py` + `TestPostHandler` → **114 passed**
- `ruff check` + `ruff format --check` clean

Fixes #8325

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jfJj5gb9VoLs6VBMnzhrP

---
_Generated by [Claude Code](https://claude.ai/code/session_018jfJj5gb9VoLs6VBMnzhrP)_