### PR TITLE
feat(structex): import-graph metrics tool + shrink-only cycle ratchet (epic #8257)

### DIFF
--- a/docs/audits/2026-06-12-codebase-health-audit.md
+++ b/docs/audits/2026-06-12-codebase-health-audit.md
@@ -29,12 +29,13 @@ Every headline number is reproducible: the exact command for each lives in the b
 
 ## Finding 1 — Layering: the delivery layer is a de facto shared library
 
-**Issue:** #8259 (Wave 1) | **Baseline keys:** `server_import_outside`, `type_checking_files`, `circular_mention_files`, `loc_server`
+**Issue:** #8259 (Wave 1) | **Baseline keys:** `server_import_outside`, `type_checking_files`, `circular_mention_files`, `loc_server`, `mutual_import_cycles`, `server_imported_by`, `handlers_flat_root`
 
 - `aragora/server/` is 475,621 LOC, 24.4% of the package (1,031 files).
 - **180 files outside `server/` import `aragora.server`.** Worst case is top-level in the core engine: `aragora/debate/orchestrator.py:40` does `from aragora.server.metrics import ACTIVE_DEBATES`.
 - `aragora/core/decision_router.py` lazily imports `aragora.server.documents` and `aragora.server.decision_integrity_utils` inside functions as an explicit circular workaround.
 - 910 files (~22%) need `if TYPE_CHECKING:` guards; 155 files carry circular-import mentions. There is no enforced layering: the intended core → debate → delivery direction is violated and nothing stops new violations.
+- **Graph metrics now pinned (P0):** `scripts/ci/measure_import_graph.py` (grimp, with TYPE_CHECKING-guarded imports excluded — they are type-only and not runtime cycles) pins the three previously-unmeasured numbers into the baseline JSON under the update-BOTH rule: mutual import cycles (140; 183 if TYPE_CHECKING imports are included), distinct top-level packages importing `aragora.server` (48), and flat handler files in `aragora/server/handlers/` (187, cross-checked against `ls aragora/server/handlers/*.py | wc -l`). The cycle count is ratcheted shrink-only via `measure_import_graph.py --check` against `scripts/baselines/import_cycles_baseline.json` (any growth fails). Targets: cycles <30, `server` imported-by <=5, handlers flat-root <20 (P4b).
 
 **Remediation:** freeze the offender list as a shrink-only CI baseline (the `tests/server/test_route_collisions.py` pattern: new entries fail, resolved-but-not-removed entries fail). First substantive shrink: move `ACTIVE_DEBATES` and sibling metrics to `aragora/observability/`, re-export from `server.metrics` for compat.
 

--- a/docs/audits/2026-06-12-codebase-health-baseline.json
+++ b/docs/audits/2026-06-12-codebase-health-baseline.json
@@ -150,6 +150,30 @@
       "direction": "grow",
       "command": "per-package BLE001/G004 carve-outs from [tool.ruff.lint.per-file-ignores] introduced by #8261",
       "issue": 8261
+    },
+    {
+      "key": "mutual_import_cycles",
+      "value": 140,
+      "direction": "shrink",
+      "command": "python3 scripts/ci/measure_import_graph.py | jq .mutual_import_cycles",
+      "issue": 8259,
+      "note": "Unordered pairs of aragora modules that directly import each other (mutual 2-cycles), with TYPE_CHECKING-guarded imports EXCLUDED (type-only imports are not runtime cycles; including them inflates the count to 183). Pinned by scripts/ci/measure_import_graph.py and ratcheted shrink-only via its --check mode against scripts/baselines/import_cycles_baseline.json. Target <30 (P4b)."
+    },
+    {
+      "key": "server_imported_by",
+      "value": 48,
+      "direction": "shrink",
+      "command": "python3 scripts/ci/measure_import_graph.py | jq .server_imported_by",
+      "issue": 8259,
+      "note": "Distinct top-level aragora packages outside aragora.server that directly import the aragora.server subtree (grimp). Pinned by scripts/ci/measure_import_graph.py. Target <=5 (P4b)."
+    },
+    {
+      "key": "handlers_flat_root",
+      "value": 187,
+      "direction": "shrink",
+      "command": "python3 scripts/ci/measure_import_graph.py | jq .handlers_flat_root",
+      "issue": 8259,
+      "note": "Python files directly in the aragora/server/handlers/ root; equals 'ls aragora/server/handlers/*.py | wc -l'. Pinned by scripts/ci/measure_import_graph.py. Target <20 (P4b)."
     }
   ]
 }

--- a/scripts/baselines/import_cycles_baseline.json
+++ b/scripts/baselines/import_cycles_baseline.json
@@ -1,0 +1,8 @@
+{
+  "_comment": "Shrink-only baseline for mutual import cycles measured by scripts/ci/measure_import_graph.py with TYPE_CHECKING-guarded imports excluded. 'measure_import_graph.py --check' fails on ANY growth above this value (a single new mutual cycle trips it); this value may only shrink as cycles are removed (then re-freeze).",
+  "metric": "mutual_import_cycles",
+  "exclude_type_checking_imports": true,
+  "value": 140,
+  "frozen_from_ref": "cecfc96c61c30999938f69cddd710ebeeb20aae9",
+  "frozen_at": "2026-06-13T00:21:30Z"
+}

--- a/scripts/ci/measure_import_graph.py
+++ b/scripts/ci/measure_import_graph.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""Measure the aragora import graph and ratchet its mutual-cycle count.
+
+Emits three machine-parsable integers used by the codebase-health baseline
+(epic #8257):
+
+  * ``mutual_import_cycles`` -- number of unordered pairs of aragora modules
+    that directly import each other (a mutual 2-cycle). This is the macro-
+    coupling number P4b drives down and the ``--check`` ratchet protects.
+  * ``server_imported_by``   -- number of distinct top-level ``aragora.<pkg>``
+    packages OUTSIDE ``aragora.server`` that import any module in the
+    ``aragora.server`` subtree. The "delivery layer used as a shared library"
+    metric (target <=5).
+  * ``handlers_flat_root``   -- number of ``*.py`` files directly in
+    ``aragora/server/handlers/`` (cross-checks exactly with
+    ``ls aragora/server/handlers/*.py | wc -l``).
+
+Two deliberate measurement choices
+----------------------------------
+1. **TYPE_CHECKING-guarded imports are EXCLUDED**
+   (``grimp.build_graph(..., exclude_type_checking_imports=True)``). Imports
+   under an ``if TYPE_CHECKING:`` guard are type-only: they never execute, so
+   they cannot create a real runtime circular import. Counting them would
+   conflate type annotations with runtime coupling and would perversely reward
+   deleting type hints. With them excluded the package has 139 mutual cycles;
+   including them inflates the count to 183. We pin the honest (excluded) value.
+
+2. **The checkout root is forced onto ``sys.path[0]`` before building the
+   graph.** Otherwise grimp resolves the SDK namespace package
+   ``sdk/python/aragora`` (2 modules) instead of the real ``aragora`` package
+   (~4,152 modules). Verified on PR #8311 (see mission library/environment.md).
+
+Usage
+-----
+    python3 scripts/ci/measure_import_graph.py            # JSON: the 3 metrics
+    python3 scripts/ci/measure_import_graph.py --json     # (same; explicit)
+    python3 scripts/ci/measure_import_graph.py --check    # cycles ratchet
+    python3 scripts/ci/measure_import_graph.py --freeze --adopt   # write baseline
+    python3 scripts/ci/measure_import_graph.py --freeze   # shrink-only re-freeze
+
+Exit codes
+----------
+    0 -- measurement succeeded, or ``--check`` found no cycle growth.
+    1 -- ``--check`` detected cycle growth above the recorded baseline
+         (fail-on-growth; a single new mutual cycle trips it).
+    2 -- a usage/environment error (grimp missing, baseline missing, or a
+         shrink-only violation on --freeze).
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+# NOTE: the literal "import_cycles_baseline" below is greppable on purpose
+# (it wires --check/--freeze to the recorded baseline file).
+CYCLES_BASELINE_PATH = REPO_ROOT / "scripts" / "baselines" / "import_cycles_baseline.json"
+ROOT_PACKAGE = "aragora"
+SERVER_PACKAGE = "aragora.server"
+HANDLERS_DIR = REPO_ROOT / "aragora" / "server" / "handlers"
+
+
+class MeasureError(RuntimeError):
+    """Raised for usage/environment errors that map to exit code 2."""
+
+
+# --- Graph construction -----------------------------------------------------
+
+
+def _force_repo_root_on_syspath() -> None:
+    """Put the checkout root at ``sys.path[0]`` so grimp resolves the real
+    ``aragora`` package (~4,152 modules), not the SDK namespace package."""
+    root = str(REPO_ROOT)
+    while root in sys.path:
+        sys.path.remove(root)
+    sys.path.insert(0, root)
+
+
+def build_aragora_graph(exclude_type_checking: bool = True):
+    """Build the grimp import graph for the ``aragora`` package.
+
+    Caching is disabled (``cache_dir=None``) so the measurement always reflects
+    the current tree and never writes a ``.grimp_cache`` artifact into the repo.
+    """
+    _force_repo_root_on_syspath()
+    try:
+        import grimp
+    except ImportError as exc:  # pragma: no cover - exercised via validator install path
+        raise MeasureError(
+            "grimp not installed; run: python3 -m pip install grimp import-linter"
+        ) from exc
+    return grimp.build_graph(
+        ROOT_PACKAGE,
+        exclude_type_checking_imports=exclude_type_checking,
+        cache_dir=None,
+    )
+
+
+# --- Pure metric functions --------------------------------------------------
+
+
+def count_mutual_cycles(graph) -> int:
+    """Unordered pairs of modules that directly import each other."""
+    edges: set[tuple[str, str]] = set()
+    for module in graph.modules:
+        for imported in graph.find_modules_directly_imported_by(module):
+            if module != imported:
+                edges.add((module, imported))
+    pairs = {tuple(sorted((a, b))) for (a, b) in edges if (b, a) in edges}
+    return len(pairs)
+
+
+def count_server_imported_by(graph, server_package: str = SERVER_PACKAGE) -> int:
+    """Distinct top-level ``aragora.<pkg>`` packages outside the server subtree
+    that directly import any module in the server subtree."""
+    prefix = server_package + "."
+    subtree = {m for m in graph.modules if m == server_package or m.startswith(prefix)}
+    importer_tops: set[str] = set()
+    for server_module in subtree:
+        for importer in graph.find_modules_that_directly_import(server_module):
+            if importer == server_package or importer.startswith(prefix):
+                continue  # internal to the server subtree
+            parts = importer.split(".")
+            importer_tops.add(parts[1] if len(parts) >= 2 else importer)
+    return len(importer_tops)
+
+
+def count_handlers_flat_root(handlers_dir: Path = HANDLERS_DIR) -> int:
+    """Count ``*.py`` files directly in ``handlers_dir`` (non-recursive),
+    matching ``ls <dir>/*.py | wc -l`` exactly."""
+    return sum(1 for _ in handlers_dir.glob("*.py"))
+
+
+def evaluate_cycle_growth(current: int, baseline: int) -> bool:
+    """Return True if ``current`` exceeds the recorded ``baseline`` (growth)."""
+    return current > baseline
+
+
+def measure_all(exclude_type_checking: bool = True) -> dict[str, object]:
+    graph = build_aragora_graph(exclude_type_checking)
+    return {
+        "mutual_import_cycles": count_mutual_cycles(graph),
+        "server_imported_by": count_server_imported_by(graph),
+        "handlers_flat_root": count_handlers_flat_root(),
+        "exclude_type_checking_imports": exclude_type_checking,
+        "total_modules": len(graph.modules),
+        "generated_at": dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+
+
+# --- Cycle ratchet baseline I/O --------------------------------------------
+
+
+def load_cycle_baseline(path: Path = CYCLES_BASELINE_PATH) -> int:
+    if not path.exists():
+        raise MeasureError(
+            f"cycles baseline not found: {path}. Create it with "
+            "'python3 scripts/ci/measure_import_graph.py --freeze --adopt'."
+        )
+    data = json.loads(path.read_text(encoding="utf-8"))
+    value = data.get("value")
+    if not isinstance(value, int):
+        raise MeasureError(f"malformed cycles baseline (expected int '.value'): {path}")
+    return value
+
+
+def write_cycle_baseline(path: Path, value: int) -> None:
+    payload = {
+        "_comment": (
+            "Shrink-only baseline for mutual import cycles measured by "
+            "scripts/ci/measure_import_graph.py with TYPE_CHECKING-guarded "
+            "imports excluded. 'measure_import_graph.py --check' fails on ANY "
+            "growth above this value (a single new mutual cycle trips it); this "
+            "value may only shrink as cycles are removed (then re-freeze)."
+        ),
+        "metric": "mutual_import_cycles",
+        "exclude_type_checking_imports": True,
+        "value": value,
+        "frozen_from_ref": _git_head(),
+        "frozen_at": dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _git_head() -> str:
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+    except (subprocess.CalledProcessError, OSError):
+        return "unknown"
+
+
+# --- CLI --------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Measure the aragora import graph (mutual cycles, server imported-by, "
+            "handlers flat-root) with TYPE_CHECKING imports excluded, and ratchet "
+            "the mutual-cycle count against scripts/baselines/import_cycles_baseline.json."
+        ),
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help=(
+            "Cycle ratchet: re-measure mutual cycles and exit non-zero if the "
+            "count grew above the recorded baseline (fail-on-growth)."
+        ),
+    )
+    parser.add_argument(
+        "--freeze",
+        action="store_true",
+        help=(
+            "Write the current mutual-cycle count to the baseline. Refuses to "
+            "RAISE an existing baseline unless --adopt is given (shrink-only)."
+        ),
+    )
+    parser.add_argument(
+        "--adopt",
+        action="store_true",
+        help="With --freeze, permit the baseline value to grow (initial adoption only).",
+    )
+    parser.add_argument(
+        "--baseline",
+        type=Path,
+        default=CYCLES_BASELINE_PATH,
+        help=(
+            "Path to import_cycles_baseline.json "
+            "(default: scripts/baselines/import_cycles_baseline.json)."
+        ),
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a machine-readable JSON summary (the default output is already JSON).",
+    )
+    return parser
+
+
+def _run_check(args: argparse.Namespace) -> int:
+    baseline = load_cycle_baseline(args.baseline)
+    current = count_mutual_cycles(build_aragora_graph())
+    grew = evaluate_cycle_growth(current, baseline)
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "metric": "mutual_import_cycles",
+                    "baseline": baseline,
+                    "current": current,
+                    "ok": not grew,
+                },
+                indent=2,
+            )
+        )
+    elif grew:
+        print(
+            f"FAIL: mutual import cycles grew {baseline} -> {current} "
+            f"(+{current - baseline}). Remove the new mutual import(s); the cycle "
+            "ratchet is shrink-only."
+        )
+    else:
+        print(f"OK: mutual import cycles {current} <= baseline {baseline}.")
+    return 1 if grew else 0
+
+
+def _run_freeze(args: argparse.Namespace) -> int:
+    current = count_mutual_cycles(build_aragora_graph())
+    if args.baseline.exists() and not args.adopt:
+        existing = load_cycle_baseline(args.baseline)
+        if current > existing:
+            raise MeasureError(
+                f"--freeze would RAISE the cycles baseline {existing} -> {current} "
+                "(shrink-only). Remove the new cycle(s), or pass --adopt for an "
+                "intentional re-adoption."
+            )
+    write_cycle_baseline(args.baseline, current)
+    print(f"Froze mutual import cycles baseline = {current} -> {args.baseline}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.freeze:
+            return _run_freeze(args)
+        if args.check:
+            return _run_check(args)
+        print(json.dumps(measure_all(), indent=2))
+    except MeasureError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ci/test_measure_import_graph.py
+++ b/tests/ci/test_measure_import_graph.py
@@ -1,0 +1,134 @@
+"""Unit tests for scripts/ci/measure_import_graph.py.
+
+The metric functions are exercised against a tiny in-memory grimp graph and the
+``--check``/``--freeze`` ratchet logic against monkeypatched measurements, so the
+tests are fast and never build the real ~4,100-module graph. End-to-end behavior
+against the real ``aragora`` package (three extractable integers, handlers
+cross-check, anchors) is covered by the VAL-P0-007 acceptance check.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import grimp
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_TOOL_PATH = REPO_ROOT / "scripts" / "ci" / "measure_import_graph.py"
+
+_spec = importlib.util.spec_from_file_location("measure_import_graph", _TOOL_PATH)
+mig = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mig)
+
+
+def _synthetic_graph() -> "grimp.ImportGraph":
+    """a<->b is a mutual cycle; a and c.sub import the server subtree."""
+    graph = grimp.ImportGraph()
+    for module in (
+        "aragora",
+        "aragora.a",
+        "aragora.b",
+        "aragora.c",
+        "aragora.c.sub",
+        "aragora.server",
+        "aragora.server.x",
+    ):
+        graph.add_module(module)
+    graph.add_import(importer="aragora.a", imported="aragora.b")
+    graph.add_import(importer="aragora.b", imported="aragora.a")  # mutual cycle
+    graph.add_import(importer="aragora.a", imported="aragora.server.x")
+    graph.add_import(importer="aragora.c.sub", imported="aragora.server")
+    return graph
+
+
+# --- pure metric functions --------------------------------------------------
+
+
+def test_count_mutual_cycles():
+    assert mig.count_mutual_cycles(_synthetic_graph()) == 1
+
+
+def test_count_server_imported_by_counts_distinct_top_level_outside_server():
+    # importers of the server subtree: aragora.a and aragora.c.sub -> tops {a, c}
+    assert mig.count_server_imported_by(_synthetic_graph()) == 2
+
+
+def test_count_handlers_flat_root_is_non_recursive(tmp_path):
+    (tmp_path / "a.py").write_text("x = 1\n", encoding="utf-8")
+    (tmp_path / "b.py").write_text("x = 2\n", encoding="utf-8")
+    (tmp_path / "__init__.py").write_text("", encoding="utf-8")
+    (tmp_path / "notpy.txt").write_text("nope\n", encoding="utf-8")
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "c.py").write_text("x = 3\n", encoding="utf-8")  # nested: must NOT count
+    assert mig.count_handlers_flat_root(tmp_path) == 3
+
+
+def test_evaluate_cycle_growth():
+    assert mig.evaluate_cycle_growth(141, 140) is True
+    assert mig.evaluate_cycle_growth(140, 140) is False
+    assert mig.evaluate_cycle_growth(139, 140) is False
+
+
+# --- CLI: --check ratchet ---------------------------------------------------
+
+
+def test_check_exits_nonzero_on_plus_one_growth(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(mig, "build_aragora_graph", lambda *a, **k: _synthetic_graph())
+    baseline = tmp_path / "cyc.json"
+    baseline.write_text(json.dumps({"value": 0}), encoding="utf-8")  # current=1 -> +1 growth
+    assert mig.main(["--check", "--baseline", str(baseline)]) == 1
+    assert "grew" in capsys.readouterr().out
+
+
+def test_check_ok_when_not_grown(tmp_path, monkeypatch):
+    monkeypatch.setattr(mig, "build_aragora_graph", lambda *a, **k: _synthetic_graph())
+    baseline = tmp_path / "cyc.json"
+    baseline.write_text(json.dumps({"value": 1}), encoding="utf-8")  # current=1 == baseline
+    assert mig.main(["--check", "--baseline", str(baseline)]) == 0
+
+
+def test_check_ok_when_cycles_shrank(tmp_path, monkeypatch):
+    monkeypatch.setattr(mig, "build_aragora_graph", lambda *a, **k: _synthetic_graph())
+    baseline = tmp_path / "cyc.json"
+    baseline.write_text(json.dumps({"value": 9}), encoding="utf-8")  # current=1 < baseline
+    assert mig.main(["--check", "--baseline", str(baseline)]) == 0
+
+
+def test_check_missing_baseline_is_usage_error(tmp_path, monkeypatch):
+    monkeypatch.setattr(mig, "build_aragora_graph", lambda *a, **k: _synthetic_graph())
+    assert mig.main(["--check", "--baseline", str(tmp_path / "nope.json")]) == 2
+
+
+# --- CLI: --freeze (shrink-only) -------------------------------------------
+
+
+def test_freeze_refuses_to_raise_without_adopt(tmp_path, monkeypatch):
+    monkeypatch.setattr(mig, "build_aragora_graph", lambda *a, **k: _synthetic_graph())
+    baseline = tmp_path / "cyc.json"
+    baseline.write_text(json.dumps({"value": 0}), encoding="utf-8")  # current=1 > 0
+    assert mig.main(["--freeze", "--baseline", str(baseline)]) == 2
+    assert json.loads(baseline.read_text())["value"] == 0  # unchanged
+
+
+def test_freeze_adopt_writes_current_value(tmp_path, monkeypatch):
+    monkeypatch.setattr(mig, "build_aragora_graph", lambda *a, **k: _synthetic_graph())
+    baseline = tmp_path / "cyc.json"
+    assert mig.main(["--freeze", "--adopt", "--baseline", str(baseline)]) == 0
+    written = json.loads(baseline.read_text())
+    assert written["value"] == 1
+    assert written["exclude_type_checking_imports"] is True
+
+
+def test_default_output_has_three_integer_metrics(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(mig, "build_aragora_graph", lambda *a, **k: _synthetic_graph())
+    monkeypatch.setattr(mig, "count_handlers_flat_root", lambda *a, **k: 187)
+    assert mig.main([]) == 0
+    out = json.loads(capsys.readouterr().out)
+    assert isinstance(out["mutual_import_cycles"], int)
+    assert isinstance(out["server_imported_by"], int)
+    assert out["handlers_flat_root"] == 187
+    assert out["exclude_type_checking_imports"] is True


### PR DESCRIPTION
## Summary

Part of the Structural Excellence mission (epic #8257), P0 ratchets milestone. Adds the import-graph measurement tool and pins the three previously-unmeasured graph metrics into the canonical baseline (update-BOTH rule).

### What lands

1. **`scripts/ci/measure_import_graph.py`** — emits three machine-parsable integers via `grimp`:
   - `mutual_import_cycles` = **140** (unordered pairs of `aragora` modules that directly import each other), with **TYPE_CHECKING-guarded imports EXCLUDED** (`exclude_type_checking_imports=True`). Type-only imports never execute, so they are not runtime cycles; including them inflates the count to 183. The honest (excluded) value is pinned. This choice is documented in the module docstring and the audit.
   - `server_imported_by` = **48** (distinct top-level `aragora.<pkg>` packages outside `aragora.server` that import the server subtree).
   - `handlers_flat_root` = **187** (`*.py` files directly in `aragora/server/handlers/`; equals `ls aragora/server/handlers/*.py | wc -l`).
   - **sys.path[0] fix:** the checkout root is forced to the front of `sys.path` before building the graph, so grimp resolves the real `aragora` package (~4,150 modules) instead of the `sdk/python/aragora` namespace package (2 modules). This was the regression observed on PR #8311.
2. **Shrink-only mutual-cycle ratchet** — `scripts/baselines/import_cycles_baseline.json` records the count; `measure_import_graph.py --check` exits non-zero on **any** growth (a single new mutual cycle trips it). Needed by the later P4b cycle-reduction work.
3. **Update-BOTH** — the three metrics are pinned into `docs/audits/2026-06-12-codebase-health-baseline.json` (each with an integer value + a `measure_import_graph` command) and the tool is referenced in `docs/audits/2026-06-12-codebase-health-audit.md` (Finding 1).

### Verification

- `python3 scripts/ci/measure_import_graph.py` → exits 0, emits the three integers; handlers cross-check `187 == ls aragora/server/handlers/*.py | wc -l`; anchors hold (cycles ∈ [100,400], imported-by ∈ [30,100]).
- Cycle ratchet: `--check` green at baseline; a synthetic `+1` (139→140) exits 1; a shrink case exits 0.
- `tests/ci/test_measure_import_graph.py` — 11 unit tests (metric functions on a synthetic grimp graph + ratchet/freeze CLI).
- Local gates: `make lint` clean, `tests/ci` 129 passed, import canary OK, smoke tier 138 passed.

Fulfills **VAL-P0-007**, **VAL-P0-008**.
