### PR TITLE
fix(work): surface outbox lane owners

### DIFF
--- a/aragora/work/sources.py
+++ b/aragora/work/sources.py
@@ -14,6 +14,7 @@ from aragora.work.models import WorkItem
 from aragora.work.scoring import is_current_status, stale_factor
 
 _ACTIVE_LANE_STATUSES = {"active", "claimed", "in_progress", "in-progress", "running"}
+_OWNER_PROTECTED_LANE_STATUSES = _ACTIVE_LANE_STATUSES | {"blocked"}
 _OUTBOX_READY_METADATA_KEYS = (
     "objective",
     "context",
@@ -179,9 +180,13 @@ def _lane_is_active(row: dict[str, Any]) -> bool:
     return str(row.get("status") or "").strip().lower() in _ACTIVE_LANE_STATUSES
 
 
+def _lane_is_owner_protected(row: dict[str, Any]) -> bool:
+    return str(row.get("status") or "").strip().lower() in _OWNER_PROTECTED_LANE_STATUSES
+
+
 def _lane_sort_key(row: dict[str, Any]) -> tuple[int, str, str]:
     return (
-        1 if _lane_is_active(row) else 0,
+        2 if _lane_is_active(row) else 1 if _lane_is_owner_protected(row) else 0,
         str(row.get("updated_at") or ""),
         str(row.get("lane_id") or ""),
     )
@@ -203,9 +208,11 @@ def _lane_lookup_value(row: dict[str, Any], key: str) -> str | None:
 
 def _apply_lane_metadata(item: WorkItem, lane: dict[str, Any]) -> None:
     active = _lane_is_active(lane)
+    owner_protected = _lane_is_owner_protected(lane)
     owner_session = _lane_lookup_value(lane, "owner_session")
     metadata = {
         "active_lane": active,
+        "lane_owner_protected": owner_protected,
         "lane_id": _lane_lookup_value(lane, "lane_id"),
         "owner_session": owner_session,
         "lane_worktree": _lane_lookup_value(lane, "worktree"),
@@ -213,14 +220,14 @@ def _apply_lane_metadata(item: WorkItem, lane: dict[str, Any]) -> None:
         "lane_updated_at": _lane_lookup_value(lane, "updated_at"),
     }
     item.metadata.update({key: value for key, value in metadata.items() if value is not None})
-    if active and owner_session and item.owner is None:
+    if owner_protected and owner_session and item.owner is None:
         item.owner = owner_session
 
 
 def enrich_with_agent_bridge_lanes(
     repo_root: Path, items: list[WorkItem]
 ) -> tuple[list[WorkItem], dict[str, Any]]:
-    """Attach active/recent lane ownership to PR work items from repo-local lanes.json."""
+    """Attach active/recent lane ownership to branch-backed work items."""
     rows, health = _read_agent_bridge_lane_rows(repo_root)
     if not rows:
         return items, health
@@ -240,7 +247,7 @@ def enrich_with_agent_bridge_lanes(
     enriched = 0
     active = 0
     for item in items:
-        if item.source != "github_pr":
+        if item.source not in {"github_pr", "automation_outbox"}:
             continue
         number = item.metadata.get("number")
         candidates: list[dict[str, Any]] = []

--- a/tests/cli/test_work_board.py
+++ b/tests/cli/test_work_board.py
@@ -448,6 +448,53 @@ def test_work_show_preserves_assignee_when_lane_is_released(
     assert item["metadata"]["lane_status"] == "released"
 
 
+def test_work_show_enriches_outbox_handoff_with_blocked_lane_owner(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setattr("aragora.work.sources.shutil.which", lambda name: None)
+    outbox = tmp_path / ".aragora" / "automation-outbox"
+    outbox.mkdir(parents=True)
+    (outbox / "handoff.json").write_text(
+        json.dumps(
+            {
+                "task": "Open PR for branch publisher telemetry",
+                "branch": "codex/branch-publisher-cache-unavailable-primary-r2-20260604",
+            }
+        ),
+        encoding="utf-8",
+    )
+    registry = tmp_path / ".aragora" / "agent-bridge" / "lanes.json"
+    registry.parent.mkdir(parents=True)
+    registry.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "Q312-primary-branch-publisher-cache-unavailable-r2",
+                    "owner_session": "primary-owner",
+                    "status": "blocked",
+                    "branch": "codex/branch-publisher-cache-unavailable-primary-r2-20260604",
+                    "worktree": "/repo/.worktrees/branch-publisher-cache",
+                    "updated_at": "2026-06-04T06:19:35Z",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert cmd_work_show(_args(tmp_path, work_id="automation-outbox:handoff")) == 0
+    payload = _capture_json(capsys)
+    item = payload["item"]
+
+    assert item["owner"] == "primary-owner"
+    assert item["metadata"]["active_lane"] is False
+    assert item["metadata"]["lane_owner_protected"] is True
+    assert item["metadata"]["lane_id"] == "Q312-primary-branch-publisher-cache-unavailable-r2"
+    assert item["metadata"]["owner_session"] == "primary-owner"
+    assert item["metadata"]["lane_worktree"] == "/repo/.worktrees/branch-publisher-cache"
+    assert item["metadata"]["lane_status"] == "blocked"
+    assert item["metadata"]["lane_updated_at"] == "2026-06-04T06:19:35Z"
+
+
 def test_work_robot_degrades_safely_on_malformed_lane_registry(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
 ) -> None:


### PR DESCRIPTION
## Summary
- Surface owner-protected lane ownership on automation-outbox work items whose branch matches an agent-bridge lane.
- Preserve blocked lane protection without marking those rows as active work.
- Keep released lane rows from overriding explicit handoff ownership.

## Validation
- PYTHONDONTWRITEBYTECODE=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTEST_ADDOPTS="-p no:cacheprovider" /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/cli/test_work_board.py: 27 passed, 2 existing pytest config warnings.
- python3 -m ruff check aragora/work/sources.py tests/cli/test_work_board.py: All checks passed.
- python3 -m ruff format --check aragora/work/sources.py tests/cli/test_work_board.py: 2 files already formatted.
- git diff --check origin/main...HEAD: passed.
- git merge-tree --write-tree origin/main HEAD: 6162f0eb19d8901daca98c69ea13e4a59eb85777.
- bash scripts/automation_pr_preflight.sh origin/main HEAD: preflight ok.

## Context
This publishes the existing validated outbox handoff `open-pr-codex-work-outbox-lane-owner-improver-20260605-5f88cccc`, which directly addresses the work-robot owner mismatch observed during harvest. This PR was opened from the existing remote branch without changing branch contents.