### PR TITLE
fix(structex): guard grimp import in measure_import_graph tests via importorskip (#8331 follow-up)

### DIFF
--- a/tests/ci/test_measure_import_graph.py
+++ b/tests/ci/test_measure_import_graph.py
@@ -13,8 +13,9 @@ import importlib.util
 import json
 from pathlib import Path
 
-import grimp
 import pytest
+
+grimp = pytest.importorskip("grimp")
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 _TOOL_PATH = REPO_ROOT / "scripts" / "ci" / "measure_import_graph.py"


### PR DESCRIPTION
## Source
Follow-up to #8331 (epic #8257, P0 ratchets).

## Problem
#8331 merged `tests/ci/test_measure_import_graph.py` with a top-level `import grimp`. `grimp` is a mission/CI-optional dependency (not in the baseline test deps). The "Baseline Determinism" job runs `pytest --collect-only tests/` with only baseline deps installed, so the top-level import raises `ModuleNotFoundError` at collection time, which errors the whole collection (`--maxfail 1`) on main and on every subsequent PR.

## Fix
Replace the top-level `import grimp` with `grimp = pytest.importorskip("grimp")`. When grimp is absent the module is cleanly skipped during collection (no error); when present (the mission env / lanes with grimp) the 11 tests run exactly as before. Matches the convention in `tests/ci/test_check_import_contracts.py`, which deliberately avoids importing grimp at collection time.

## Validation
- `pytest --collect-only` over a dir with an importorskip-missing module plus a normal test -> exit 0 (module skipped, no error), mirroring the determinism command.
- `python3 -m pytest tests/ci/test_measure_import_graph.py -q` -> 11 passed (grimp present).
- `make lint` PASS.

## Risks
Minimal. One-line guard in a single test file; no production code touched.