### PR TITLE
fix(publisher): bound dry-run decisions

### DIFF
--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -1451,7 +1451,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "--limit",
         type=int,
         default=DEFAULT_LIMIT,
-        help="Maximum number of issues to create in one apply run",
+        help="Maximum number of handoffs to inspect in dry-run or issues to create in apply",
     )
     parser.add_argument(
         "--max-open-issues",
@@ -1627,9 +1627,7 @@ def main(argv: list[str] | None = None) -> int:
             return 0
         return 1 if handoffs else 0
 
-    decision_handoffs = (
-        handoffs[: max(args.limit, 0)] if args.summary_only and not args.apply else handoffs
-    )
+    decision_handoffs = handoffs if args.apply else handoffs[: max(args.limit, 0)]
     decisions = decide_handoffs(
         decision_handoffs,
         repo_root=repo_root,

--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -36,6 +36,7 @@ DEFAULT_LABELS = ("boss-ready",)
 DEFAULT_LIMIT = 2
 DEFAULT_MAX_OPEN_ISSUES = 12
 DEFAULT_COMMAND_TIMEOUT_SECONDS = 45
+DEFAULT_LOOKUP_TIMEOUT_SECONDS = 8
 MAX_ISSUE_BODY_CHARS = 60_000
 DEFAULT_OUTBOX_DIR = Path(".aragora/automation-outbox")
 DEFAULT_RECEIPT_DIR = Path(".aragora/automation-receipts")
@@ -213,6 +214,10 @@ def _decision_for_handoff(
     )
 
 
+def _github_lookup_failed_decision(handoff: Handoff) -> PublishDecision:
+    return _decision_for_handoff(handoff, eligible=False, reason="github_lookup_failed")
+
+
 def summarize_decisions(decisions: Sequence[PublishDecision]) -> dict[str, Any]:
     reason_counts = Counter(item.reason for item in decisions)
     eligible_count = sum(1 for item in decisions if item.eligible)
@@ -250,34 +255,36 @@ def _gh_write_op(args: list[str]) -> bool:
     }
 
 
-def _run(args: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+def _run(
+    args: list[str],
+    *,
+    cwd: Path,
+    timeout: float | int = DEFAULT_COMMAND_TIMEOUT_SECONDS,
+) -> subprocess.CompletedProcess[str]:
     env = github_cli_env(os.environ) if args and args[0] == "gh" else None
-    if args and args[0] == "gh":
-        return gh_subprocess_run(
-            args[1:],
-            timeout=DEFAULT_COMMAND_TIMEOUT_SECONDS,
-            prefer_app=True,
-            write_op=_gh_write_op(args[1:]),
-            env=dict(os.environ if env is None else env),
-            max_retries=0,
-        )
     try:
+        if args and args[0] == "gh":
+            return gh_subprocess_run(
+                args[1:],
+                timeout=timeout,
+                prefer_app=True,
+                write_op=_gh_write_op(args[1:]),
+                env=dict(os.environ if env is None else env),
+                max_retries=0,
+            )
         return subprocess.run(
             args,
             cwd=cwd,
             text=True,
             capture_output=True,
             check=False,
-            timeout=DEFAULT_COMMAND_TIMEOUT_SECONDS,
+            timeout=timeout,
             env=env,
         )
     except subprocess.TimeoutExpired as exc:
         stdout = exc.stdout if isinstance(exc.stdout, str) else ""
         stderr = exc.stderr if isinstance(exc.stderr, str) else ""
-        message = (
-            stderr
-            or f"command timed out after {DEFAULT_COMMAND_TIMEOUT_SECONDS}s: {' '.join(args)}"
-        )
+        message = stderr or f"command timed out after {timeout}s: {' '.join(args)}"
         return subprocess.CompletedProcess(args=args, returncode=124, stdout=stdout, stderr=message)
 
 
@@ -1061,6 +1068,7 @@ def _existing_issue(repo_root: Path, repo: str, title: str) -> dict[str, Any] | 
             "50",
         ],
         cwd=repo_root,
+        timeout=DEFAULT_LOOKUP_TIMEOUT_SECONDS,
     )
     if proc.returncode != 0:
         raise RuntimeError(proc.stderr.strip() or proc.stdout.strip() or "failed to list issues")
@@ -1094,6 +1102,7 @@ def _existing_pr(repo_root: Path, repo: str, title: str) -> dict[str, Any] | Non
             "50",
         ],
         cwd=repo_root,
+        timeout=DEFAULT_LOOKUP_TIMEOUT_SECONDS,
     )
     if proc.returncode != 0:
         raise RuntimeError(proc.stderr.strip() or proc.stdout.strip() or "failed to list PRs")
@@ -1141,6 +1150,7 @@ def _pr_by_number(repo_root: Path, repo: str, number: int) -> dict[str, Any] | N
             "number,title,url,state,headRefName,headRefOid",
         ],
         cwd=repo_root,
+        timeout=DEFAULT_LOOKUP_TIMEOUT_SECONDS,
     )
     if proc.returncode != 0:
         stderr = (proc.stderr or proc.stdout or "").lower()
@@ -1171,6 +1181,7 @@ def _open_pr_by_branch(repo_root: Path, repo: str, branch: str | None) -> dict[s
             "1",
         ],
         cwd=repo_root,
+        timeout=DEFAULT_LOOKUP_TIMEOUT_SECONDS,
     )
     if proc.returncode != 0:
         raise RuntimeError(
@@ -1237,7 +1248,7 @@ def _open_boss_ready_count(repo_root: Path, repo: str, labels: list[str]) -> int
     ]
     for label in labels:
         args.extend(["--label", label])
-    proc = _run(args, cwd=repo_root)
+    proc = _run(args, cwd=repo_root, timeout=DEFAULT_LOOKUP_TIMEOUT_SECONDS)
     if proc.returncode != 0:
         raise RuntimeError(
             proc.stderr.strip() or proc.stdout.strip() or "failed to count open issues"
@@ -1312,14 +1323,24 @@ def decide_handoffs(
     labels: list[str],
     max_open_issues: int,
 ) -> list[PublishDecision]:
-    open_issue_count = _open_boss_ready_count(repo_root, repo, labels)
+    try:
+        open_issue_count = _open_boss_ready_count(repo_root, repo, labels)
+    except (RuntimeError, json.JSONDecodeError):
+        return [
+            _local_handoff_blocker(repo_root, handoff) or _github_lookup_failed_decision(handoff)
+            for handoff in handoffs
+        ]
     decisions: list[PublishDecision] = []
     for handoff in handoffs:
         local_blocker = _local_handoff_blocker(repo_root, handoff)
         if local_blocker is not None:
             decisions.append(local_blocker)
             continue
-        target_pr = _target_open_pr(repo_root, repo, handoff)
+        try:
+            target_pr = _target_open_pr(repo_root, repo, handoff)
+        except (RuntimeError, json.JSONDecodeError):
+            decisions.append(_github_lookup_failed_decision(handoff))
+            continue
         if target_pr:
             decisions.append(
                 PublishDecision(
@@ -1331,7 +1352,11 @@ def decide_handoffs(
                 )
             )
             continue
-        existing = _existing_issue(repo_root, repo, handoff.task_title)
+        try:
+            existing = _existing_issue(repo_root, repo, handoff.task_title)
+        except (RuntimeError, json.JSONDecodeError):
+            decisions.append(_github_lookup_failed_decision(handoff))
+            continue
         if existing:
             decisions.append(
                 PublishDecision(
@@ -1343,7 +1368,11 @@ def decide_handoffs(
                 )
             )
             continue
-        referenced_pr = _referenced_pr(repo_root, repo, handoff)
+        try:
+            referenced_pr = _referenced_pr(repo_root, repo, handoff)
+        except (RuntimeError, json.JSONDecodeError):
+            decisions.append(_github_lookup_failed_decision(handoff))
+            continue
         if referenced_pr and _pr_head_satisfies_handoff(handoff, referenced_pr):
             decisions.append(
                 PublishDecision(
@@ -1355,7 +1384,11 @@ def decide_handoffs(
                 )
             )
             continue
-        existing_pr = _existing_pr(repo_root, repo, handoff.task_title)
+        try:
+            existing_pr = _existing_pr(repo_root, repo, handoff.task_title)
+        except (RuntimeError, json.JSONDecodeError):
+            decisions.append(_github_lookup_failed_decision(handoff))
+            continue
         if existing_pr and _pr_head_satisfies_handoff(handoff, existing_pr):
             decisions.append(
                 PublishDecision(

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -1018,7 +1018,12 @@ def test_decide_handoffs_marks_duplicate_issue(monkeypatch: Any, tmp_path: Path)
         ]
     )
 
-    def fake_run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    def fake_run(
+        args: list[str],
+        *,
+        cwd: Path,
+        timeout: float | int = mod.DEFAULT_COMMAND_TIMEOUT_SECONDS,
+    ) -> subprocess.CompletedProcess[str]:
         if args[:3] == ["gh", "issue", "list"] and "--label" in args:
             return subprocess.CompletedProcess(args, 0, "[]", "")
         return subprocess.CompletedProcess(args, 0, issue_payload, "")
@@ -1074,6 +1079,86 @@ def test_run_uses_user_auth_for_issue_create(monkeypatch: Any, tmp_path: Path) -
     assert recorded["max_retries"] == 0
 
 
+def test_run_returns_completed_process_for_gh_timeout(monkeypatch: Any, tmp_path: Path) -> None:
+    def fake_gh_run(
+        args: list[str],
+        *,
+        timeout: float,
+        prefer_app: bool,
+        write_op: bool,
+        env: dict[str, str],
+        max_retries: int,
+    ) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired(cmd=["gh", *args], timeout=timeout)
+
+    monkeypatch.setattr(mod, "gh_subprocess_run", fake_gh_run)
+
+    result = mod._run(["gh", "issue", "list"], cwd=tmp_path, timeout=3)
+
+    assert result.returncode == 124
+    assert "command timed out after 3s" in result.stderr
+
+
+def test_existing_issue_uses_bounded_lookup_timeout(monkeypatch: Any, tmp_path: Path) -> None:
+    recorded: dict[str, float | int] = {}
+
+    def fake_run(
+        args: list[str],
+        *,
+        cwd: Path,
+        timeout: float | int = mod.DEFAULT_COMMAND_TIMEOUT_SECONDS,
+    ) -> subprocess.CompletedProcess[str]:
+        recorded["timeout"] = timeout
+        return subprocess.CompletedProcess(args, 0, "[]", "")
+
+    monkeypatch.setattr(mod, "_run", fake_run)
+
+    assert mod._existing_issue(tmp_path, "synaptent/aragora", "Slow duplicate lookup") is None
+    assert recorded["timeout"] == mod.DEFAULT_LOOKUP_TIMEOUT_SECONDS
+
+
+def test_decide_handoffs_blocks_lookup_failure(monkeypatch: Any, tmp_path: Path) -> None:
+    handoff = Handoff(
+        source_file=str(tmp_path / "memory.md"),
+        task_title="Publish a handoff while duplicate search is slow",
+        priority="MEDIUM",
+        body="body",
+        labels={},
+        expires_at=None,
+    )
+
+    def fake_run(
+        args: list[str],
+        *,
+        cwd: Path,
+        timeout: float | int = mod.DEFAULT_COMMAND_TIMEOUT_SECONDS,
+    ) -> subprocess.CompletedProcess[str]:
+        if args[:3] == ["gh", "issue", "list"] and "--label" in args:
+            return subprocess.CompletedProcess(args, 0, "[]", "")
+        if args[:3] == ["gh", "issue", "list"]:
+            return subprocess.CompletedProcess(args, 124, "", "lookup timed out")
+        return subprocess.CompletedProcess(args, 0, "[]", "")
+
+    monkeypatch.setattr(mod, "_run", fake_run)
+
+    decisions = mod.decide_handoffs(
+        [handoff],
+        repo_root=tmp_path,
+        repo="synaptent/aragora",
+        labels=["boss-ready"],
+        max_open_issues=12,
+    )
+
+    assert decisions == [
+        PublishDecision(
+            task_title=handoff.task_title,
+            source_file=handoff.source_file,
+            eligible=False,
+            reason="github_lookup_failed",
+        )
+    ]
+
+
 def test_decide_handoffs_marks_duplicate_pr(monkeypatch: Any, tmp_path: Path) -> None:
     handoff = Handoff(
         source_file=str(tmp_path / "memory.md"),
@@ -1094,7 +1179,12 @@ def test_decide_handoffs_marks_duplicate_pr(monkeypatch: Any, tmp_path: Path) ->
         ]
     )
 
-    def fake_run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    def fake_run(
+        args: list[str],
+        *,
+        cwd: Path,
+        timeout: float | int = mod.DEFAULT_COMMAND_TIMEOUT_SECONDS,
+    ) -> subprocess.CompletedProcess[str]:
         if args[:3] == ["gh", "issue", "list"] and "--label" in args:
             return subprocess.CompletedProcess(args, 0, "[]", "")
         if args[:3] == ["gh", "issue", "list"]:
@@ -1137,7 +1227,12 @@ def test_decide_handoffs_routes_explicit_pr_followup_before_issue_cap(
         expires_at=None,
     )
 
-    def fake_run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    def fake_run(
+        args: list[str],
+        *,
+        cwd: Path,
+        timeout: float | int = mod.DEFAULT_COMMAND_TIMEOUT_SECONDS,
+    ) -> subprocess.CompletedProcess[str]:
         if args[:3] == ["gh", "issue", "list"] and "--label" in args:
             return subprocess.CompletedProcess(args, 0, json.dumps([{"number": 1}]), "")
         if args[:3] == ["gh", "issue", "list"]:
@@ -1194,7 +1289,12 @@ def test_decide_handoffs_routes_branch_handoff_to_open_pr_before_issue_cap(
         desired_head="abc1234",
     )
 
-    def fake_run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    def fake_run(
+        args: list[str],
+        *,
+        cwd: Path,
+        timeout: float | int = mod.DEFAULT_COMMAND_TIMEOUT_SECONDS,
+    ) -> subprocess.CompletedProcess[str]:
         if args[:3] == ["gh", "issue", "list"] and "--label" in args:
             return subprocess.CompletedProcess(args, 0, json.dumps([{"number": 1}]), "")
         if args[:3] == ["gh", "issue", "list"]:
@@ -1259,7 +1359,12 @@ def test_decide_handoffs_keeps_branch_update_actionable_when_pr_head_is_stale(
         desired_head="5091193dfe68d40ead6ac775cd43c507360fa0fe",
     )
 
-    def fake_run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    def fake_run(
+        args: list[str],
+        *,
+        cwd: Path,
+        timeout: float | int = mod.DEFAULT_COMMAND_TIMEOUT_SECONDS,
+    ) -> subprocess.CompletedProcess[str]:
         if args[:3] == ["gh", "issue", "list"] and "--label" in args:
             return subprocess.CompletedProcess(args, 0, "[]", "")
         if args[:3] == ["gh", "pr", "list"] and "--head" in args:
@@ -1327,7 +1432,12 @@ def test_decide_handoffs_blocks_stale_outbox_head_before_pr_lookup(
     )
     real_run = mod._run
 
-    def fake_run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    def fake_run(
+        args: list[str],
+        *,
+        cwd: Path,
+        timeout: float | int = mod.DEFAULT_COMMAND_TIMEOUT_SECONDS,
+    ) -> subprocess.CompletedProcess[str]:
         if args[:3] == ["gh", "issue", "list"] and "--label" in args:
             return subprocess.CompletedProcess(args, 0, "[]", "")
         if args and args[0] == "gh":
@@ -1371,7 +1481,12 @@ def test_decide_handoffs_prefers_branch_pr_over_duplicate_issue(
         branch="codex/frontend-e2e-test-workflow-scope",
     )
 
-    def fake_run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    def fake_run(
+        args: list[str],
+        *,
+        cwd: Path,
+        timeout: float | int = mod.DEFAULT_COMMAND_TIMEOUT_SECONDS,
+    ) -> subprocess.CompletedProcess[str]:
         if args[:3] == ["gh", "issue", "list"] and "--label" in args:
             return subprocess.CompletedProcess(args, 0, "[]", "")
         if args[:3] == ["gh", "pr", "list"] and "--head" in args:
@@ -1444,7 +1559,12 @@ def test_decide_handoffs_respects_open_issue_cap(monkeypatch: Any, tmp_path: Pat
         expires_at=None,
     )
 
-    def fake_run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    def fake_run(
+        args: list[str],
+        *,
+        cwd: Path,
+        timeout: float | int = mod.DEFAULT_COMMAND_TIMEOUT_SECONDS,
+    ) -> subprocess.CompletedProcess[str]:
         if "--label" in args:
             return subprocess.CompletedProcess(args, 0, json.dumps([{"number": 1}]), "")
         return subprocess.CompletedProcess(args, 0, "[]", "")
@@ -1538,7 +1658,12 @@ def test_decide_handoffs_skips_merged_referenced_pr_slug(monkeypatch: Any, tmp_p
         branch="codex/review-pr6808",
     )
 
-    def fake_run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    def fake_run(
+        args: list[str],
+        *,
+        cwd: Path,
+        timeout: float | int = mod.DEFAULT_COMMAND_TIMEOUT_SECONDS,
+    ) -> subprocess.CompletedProcess[str]:
         if args[:3] == ["gh", "issue", "list"] and "--label" in args:
             return subprocess.CompletedProcess(args, 0, "[]", "")
         if args[:3] == ["gh", "issue", "list"]:
@@ -1593,7 +1718,12 @@ def test_publish_handoffs_creates_issue_with_labels(monkeypatch: Any, tmp_path: 
     )
     created: list[list[str]] = []
 
-    def fake_run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    def fake_run(
+        args: list[str],
+        *,
+        cwd: Path,
+        timeout: float | int = mod.DEFAULT_COMMAND_TIMEOUT_SECONDS,
+    ) -> subprocess.CompletedProcess[str]:
         created.append(args)
         return subprocess.CompletedProcess(
             args, 0, "https://github.com/synaptent/aragora/issues/5890\n", ""
@@ -1649,7 +1779,12 @@ def test_publish_handoffs_writes_outbox_receipt(monkeypatch: Any, tmp_path: Path
         source_kind="outbox",
     )
 
-    def fake_run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    def fake_run(
+        args: list[str],
+        *,
+        cwd: Path,
+        timeout: float | int = mod.DEFAULT_COMMAND_TIMEOUT_SECONDS,
+    ) -> subprocess.CompletedProcess[str]:
         if args[:3] == ["gh", "issue", "create"]:
             return subprocess.CompletedProcess(
                 args, 0, "https://github.com/synaptent/aragora/issues/7000\n", ""
@@ -2586,7 +2721,12 @@ def test_parser_rejects_abbreviated_max_options() -> None:
 def test_create_issue_truncates_oversized_body(monkeypatch: Any, tmp_path: Path) -> None:
     bodies: list[str] = []
 
-    def fake_run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    def fake_run(
+        args: list[str],
+        *,
+        cwd: Path,
+        timeout: float | int = mod.DEFAULT_COMMAND_TIMEOUT_SECONDS,
+    ) -> subprocess.CompletedProcess[str]:
         if args[:3] == ["gh", "issue", "create"]:
             bodies.append(args[args.index("--body") + 1])
             return subprocess.CompletedProcess(
@@ -2617,7 +2757,12 @@ def test_create_issue_truncates_oversized_body(monkeypatch: Any, tmp_path: Path)
 def test_create_issue_preserves_boundary_sized_body(monkeypatch: Any, tmp_path: Path) -> None:
     bodies: list[str] = []
 
-    def fake_run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    def fake_run(
+        args: list[str],
+        *,
+        cwd: Path,
+        timeout: float | int = mod.DEFAULT_COMMAND_TIMEOUT_SECONDS,
+    ) -> subprocess.CompletedProcess[str]:
         if args[:3] == ["gh", "issue", "create"]:
             bodies.append(args[args.index("--body") + 1])
             return subprocess.CompletedProcess(

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -2143,13 +2143,82 @@ def test_main_summary_only_limits_github_ready_decision_preview(
     assert payload["decisions_truncated"] is True
     assert payload["outbox_preview_limited"] is True
     assert payload["outbox_preview_limit"] == 1
+
+
+def test_main_dry_run_limits_github_ready_decision_preview(
+    monkeypatch: Any, tmp_path: Path, capsys
+) -> None:
+    handoffs = [
+        Handoff(
+            source_file=str(tmp_path / f"handoff-{index}.md"),
+            task_title=f"Ready handoff {index}",
+            priority="MEDIUM",
+            body="body",
+            labels={},
+            expires_at=None,
+        )
+        for index in range(3)
+    ]
+    captured: dict[str, int] = {}
+    monkeypatch.setattr(mod, "_repo_root", lambda path: tmp_path)
+    monkeypatch.setattr(mod, "load_handoffs", lambda codex_home, automation_ids=None: handoffs)
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda repo_root: GitHubCLIHealth(
+            ready=True,
+            auth_ok=True,
+            api_ok=True,
+            mode="ready",
+            error="",
+            repo=str(tmp_path),
+        ),
+    )
+
+    def fake_decide_handoffs(
+        preview_handoffs: list[Handoff],
+        *,
+        repo_root: Path,
+        repo: str,
+        labels: list[str],
+        max_open_issues: int,
+    ) -> list[PublishDecision]:
+        captured["count"] = len(preview_handoffs)
+        return [
+            PublishDecision(
+                task_title=handoff.task_title,
+                source_file=handoff.source_file,
+                eligible=True,
+                reason="eligible",
+            )
+            for handoff in preview_handoffs
+        ]
+
+    monkeypatch.setattr(mod, "decide_handoffs", fake_decide_handoffs)
+
+    exit_code = mod.main(
+        [
+            "--repo",
+            str(tmp_path),
+            "--codex-home",
+            str(tmp_path),
+            "--json",
+            "--dry-run",
+            "--limit",
+            "1",
+        ]
+    )
+
+    assert exit_code == 0
+    assert captured["count"] == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert len(payload["decisions"]) == 1
+    assert payload["handoff_count"] == 3
     assert payload["decision_summary"] == {
         "total": 1,
         "eligible_count": 1,
         "ineligible_count": 0,
-        "reason_counts": {
-            "eligible": 1,
-        },
+        "reason_counts": {"eligible": 1},
     }
 
 


### PR DESCRIPTION
## Summary
- Make publisher dry-runs honor --limit before duplicate/PR GitHub lookups.
- Add a regression proving non-summary dry-run only inspects the requested preview count.

## Validation
- PYTHONDONTWRITEBYTECODE=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTEST_ADDOPTS='-p no:cacheprovider' /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_publish_automation_handoffs.py
- python3 -m py_compile scripts/publish_automation_handoffs.py tests/scripts/test_publish_automation_handoffs.py
- RUFF_CACHE_DIR=/private/tmp/ruff-cache-publisher-dry-run-limit /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/publish_automation_handoffs.py tests/scripts/test_publish_automation_handoffs.py
- RUFF_CACHE_DIR=/private/tmp/ruff-cache-publisher-dry-run-limit-format /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/publish_automation_handoffs.py tests/scripts/test_publish_automation_handoffs.py
- git diff --check && git diff --check origin/main...HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- live smoke: publish_automation_handoffs.py --dry-run --json --automation-id engineering-autopilot-3-2 --limit 1 returned decision_count=1