### PR TITLE
docs(open-pr): clarify no-draft usage

### DIFF
--- a/scripts/open_pr.sh
+++ b/scripts/open_pr.sh
@@ -16,6 +16,7 @@ Behavior:
   - Fails when working tree is dirty.
   - Pushes current branch to origin.
   - Creates a draft PR with gh using --fill (unless one already exists).
+  - Pass --no-draft only when the branch is ready for live review.
 EOF
 }
 


### PR DESCRIPTION
## Summary
- Clarifies `scripts/open_pr.sh --no-draft` help text so operators only use it when a branch is ready for live review.

## Harvest evidence
- Branch: `codex/swarm-01659fc4-micro-1`
- Head: `299b30d45850ad615976503ef194ab1aaa5f5b26`
- Source worktree: `/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-01659fc4-micro-1`
- Inventory class before publish: `unique_unharvested`
- Owner: unowned; no operator-steering lane matched
- Prior representation: no existing PR, no outbox/receipt hit for branch/head
- Merge-tree against current `origin/main`: clean

## Validation
- `bash -n scripts/open_pr.sh`
- `git diff --check origin/main...HEAD -- scripts/open_pr.sh`
- `python3 -m pytest tests/scripts/test_open_pr.py` (4 passed)

Draft harvest only. Do not mark ready or merge in the harvest cycle.
