### PR TITLE
feat(automation): shared PR-state cache — budgeted REST poller with ETag conditional requests (#8315)

### DIFF
--- a/scripts/pr_state_cache.py
+++ b/scripts/pr_state_cache.py
@@ -1,0 +1,608 @@
+#!/usr/bin/env python3
+"""Shared PR-state cache: ONE budgeted REST-only poller, many cheap readers (#8315).
+
+The automation fleet shares a single GitHub identity. N concurrent lanes each
+re-polling identical PR state via GraphQL-backed ``gh pr view`` / ``gh pr list``
+exhausts the 5,000-point/hour GraphQL budget. This module replaces that fan-out
+with a single REST-only poller that maintains an atomically-written JSON cache;
+lanes read the cache and spend exactly one targeted REST call to verify the
+exact head immediately before any mutation.
+
+READER CONTRACT (explicit, binding for every lane):
+
+  Lanes MUST: (1) read from cache for routine state, (2) call ``verify`` for
+  the exact head immediately before any mutation, (3) never treat cache as
+  authority for settlement/merge gates — merge-packet remains the gate
+  authority.
+
+Subcommands:
+
+- ``poll``   — list pass + delta detail pass. Dry-run by default: prints the
+  would-write cache JSON to stdout and touches nothing; ``--apply`` writes
+  ``--cache-file`` atomically (mkstemp + os.replace, never a partial file).
+- ``read``   — cheap lane path: prints the cached entry plus a freshness
+  verdict (``fresh``/``stale``/``missing``); exit 3 when stale or missing.
+  Every read is self-describing: the cache carries ``generated_at`` and a
+  per-PR ``checks_fetched_at``. Staleness policy is the READER's job, bounded
+  here by ``--max-age-seconds``.
+- ``verify`` — the only always-live command: exactly ONE REST call
+  (``gh api repos/{repo}/pulls/N``) returning current head/state for the
+  just-before-mutation check.
+
+List pass (REST, conditional requests):
+
+- ``gh api -i "repos/{repo}/pulls?state=open&per_page=100"`` — ``-i`` captures
+  the HTTP status line and headers, so the ETag can be stored per endpoint and
+  replayed via ``-H "If-None-Match: <etag>"`` on subsequent polls. ``gh``
+  exits nonzero on a 304, so the status is parsed from the captured ``-i``
+  output rather than trusted from the exit code: a parsed 304 means
+  "unchanged, zero rate-limit cost" and terminates the list pass reusing
+  cached data. Pagination follows pages until a short page or ``--max-pages``.
+
+Delta detail pass:
+
+- Only PRs whose head moved since the cached entry (or with no cached checks)
+  cost a ``repos/{repo}/commits/{sha}/check-runs?per_page=100`` call; the
+  latest run per check name (by completed/started timestamp) is stored as
+  ``{name: conclusion-or-status}``. At most ``--max-detail`` fetches per run;
+  over-cap PRs are annotated ``detail_deferred:<n>``.
+
+Safety model (mirrors scripts/auto_evidence_cycle.py):
+
+- ``--max-requests`` per poll run (default 30); exceeding it stops the run,
+  annotates ``budget_exhausted``, exit 3.
+- Identical-error breaker: 3 consecutive identical gh failures abort, exit 2,
+  nothing written.
+- A gh transport/HTTP failure on the list pass keeps the previous cache file
+  byte-for-byte intact, annotates, exit 1 — a partial or empty cache is never
+  written over a good one.
+- Fail-closed exits: 0 clean, 1 failure, 2 breaker, 3 budget/stale/missing.
+
+Stdlib-only by design so it can run anywhere ``gh`` is authenticated. All I/O
+boundaries (the gh runner, the clock) are injectable for tests.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+DEFAULT_REPO = "synaptent/aragora"
+DEFAULT_CACHE_FILE = os.path.join(".aragora", "pr-state-cache.json")
+DEFAULT_MAX_PAGES = 5
+DEFAULT_MAX_DETAIL = 10
+DEFAULT_MAX_REQUESTS = 30
+DEFAULT_MAX_AGE_SECONDS = 300
+BREAKER_THRESHOLD = 3
+PER_PAGE = 100
+SCHEMA_VERSION = 1
+GH_TIMEOUT_SECONDS = 60
+
+EXIT_OK = 0
+EXIT_FAILURES = 1
+EXIT_BREAKER = 2
+EXIT_STALE = 3  # also: budget exhausted (bounded-cap outcome, not a fault)
+
+# Same owner/name shape every repo-taking automation script here validates.
+_REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+_STATUS_LINE_RE = re.compile(r"^HTTP/[0-9.]+\s+(\d{3})")
+
+GhRunner = Callable[[list[str]], tuple[int, str, str]]
+
+
+# --- gh transport ----------------------------------------------------------------
+
+
+def default_run_gh(args: list[str]) -> tuple[int, str, str]:
+    """Run ``gh <args>``; returns (returncode, stdout, stderr). Never raises."""
+    try:
+        proc = subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            timeout=GH_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return 127, "", f"{type(exc).__name__}: {exc}"
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+@dataclass
+class GhResponse:
+    """Parsed ``gh api -i`` output: HTTP status, headers, body."""
+
+    status: int | None
+    headers: dict[str, str] = field(default_factory=dict)
+    body: str = ""
+    error: str = ""
+
+
+def parse_gh_api_response(returncode: int, stdout: str, stderr: str) -> GhResponse:
+    """Parse ``gh api -i`` output into status/headers/body.
+
+    ``gh api`` exits nonzero for any non-2xx status — including 304 Not
+    Modified, which for conditional requests is the *success* path (unchanged,
+    zero rate-limit cost). So the exit code is never trusted directly: the
+    status line is parsed out of the captured ``-i`` output, and only output
+    with no parseable HTTP status at all is a transport failure.
+    """
+    text = stdout or ""
+    match = _STATUS_LINE_RE.match(text)
+    if match is None:
+        detail = (stderr or stdout or "").strip()[:300]
+        return GhResponse(
+            status=None,
+            error=detail or f"gh exited {returncode} with no HTTP status line",
+        )
+    status = int(match.group(1))
+    head, sep, body = text.partition("\r\n\r\n")
+    if not sep:
+        head, _, body = text.partition("\n\n")
+    headers: dict[str, str] = {}
+    for line in head.splitlines()[1:]:
+        name, colon, value = line.partition(":")
+        if colon:
+            headers[name.strip().lower()] = value.strip()
+    return GhResponse(status=status, headers=headers, body=body.strip())
+
+
+# --- cache I/O -------------------------------------------------------------------
+
+
+def atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write JSON atomically: mkstemp in the target dir, then os.replace.
+
+    A failure mid-write can never leave a partial cache at ``path``; the
+    temp file is always cleaned up.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        os.replace(tmp, path)
+    finally:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass  # already replaced into place (common case) or never created
+
+
+def load_cache(path: str) -> dict[str, Any] | None:
+    """Load the cache file; None when missing, unreadable, or malformed."""
+    try:
+        with open(path, encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _iso(timestamp: float) -> str:
+    return datetime.fromtimestamp(timestamp, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_iso(value: Any) -> float | None:
+    try:
+        parsed = datetime.strptime(str(value), "%Y-%m-%dT%H:%M:%SZ")
+    except (TypeError, ValueError):
+        return None
+    return parsed.replace(tzinfo=timezone.utc).timestamp()
+
+
+# --- normalization ---------------------------------------------------------------
+
+
+def list_endpoint(repo: str, page: int) -> str:
+    base = f"repos/{repo}/pulls?state=open&per_page={PER_PAGE}"
+    return base if page <= 1 else f"{base}&page={page}"
+
+
+def check_runs_endpoint(repo: str, sha: str) -> str:
+    return f"repos/{repo}/commits/{sha}/check-runs?per_page={PER_PAGE}"
+
+
+def normalize_pr(row: dict[str, Any]) -> dict[str, Any] | None:
+    """Normalize one REST pulls-list row into the cache PR schema."""
+    try:
+        number = int(row["number"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    head = row.get("head") if isinstance(row.get("head"), dict) else {}
+    base = row.get("base") if isinstance(row.get("base"), dict) else {}
+    labels = [
+        str(label.get("name"))
+        for label in (row.get("labels") or [])
+        if isinstance(label, dict) and label.get("name")
+    ]
+    return {
+        "number": number,
+        "head_sha": str(head.get("sha") or ""),
+        "head_ref": str(head.get("ref") or ""),
+        "base_ref": str(base.get("ref") or ""),
+        "draft": bool(row.get("draft")),
+        "state": str(row.get("state") or ""),
+        "updated_at": str(row.get("updated_at") or ""),
+        "labels": labels,
+        "checks": None,
+        "checks_fetched_at": None,
+    }
+
+
+def extract_checks(payload: dict[str, Any]) -> dict[str, str]:
+    """Latest check-run per name: ``{name: conclusion-or-status}``.
+
+    GitHub returns every attempt; only the most recent run per check name (by
+    completed/started timestamp, ISO-sortable) reflects current state.
+    """
+    latest: dict[str, tuple[str, str]] = {}  # name -> (timestamp_key, value)
+    for run in payload.get("check_runs") or []:
+        if not isinstance(run, dict):
+            continue
+        name = str(run.get("name") or "")
+        if not name:
+            continue
+        key = str(run.get("completed_at") or run.get("started_at") or "")
+        value = str(run.get("conclusion") or run.get("status") or "")
+        if name not in latest or key >= latest[name][0]:
+            latest[name] = (key, value)
+    return {name: value for name, (_, value) in sorted(latest.items())}
+
+
+# --- poll ------------------------------------------------------------------------
+
+
+def run_poll(
+    *,
+    repo: str,
+    previous: dict[str, Any] | None,
+    run_gh: GhRunner,
+    max_pages: int = DEFAULT_MAX_PAGES,
+    max_detail: int = DEFAULT_MAX_DETAIL,
+    max_requests: int = DEFAULT_MAX_REQUESTS,
+    breaker_threshold: int = BREAKER_THRESHOLD,
+    clock: Callable[[], float] = time.time,
+) -> dict[str, Any]:
+    """One bounded poll: list pass, merge, delta detail pass.
+
+    Returns ``{"cache": dict | None, "exit_code": int, "annotations": [...],
+    "requests_used": int}``. ``cache`` is None exactly when nothing may be
+    written (list failure → exit 1, breaker → exit 2, budget exhausted before
+    the list completed → exit 3): the previous cache file must stay intact.
+    """
+    annotations: list[str] = []
+    requests_used = 0
+    prev = previous if isinstance(previous, dict) else {}
+    prev_endpoints = prev.get("endpoints") if isinstance(prev.get("endpoints"), dict) else {}
+    prev_prs = prev.get("prs") if isinstance(prev.get("prs"), dict) else {}
+
+    def summary(cache: dict[str, Any] | None, exit_code: int) -> dict[str, Any]:
+        return {
+            "cache": cache,
+            "exit_code": exit_code,
+            "annotations": annotations,
+            "requests_used": requests_used,
+        }
+
+    # --- LIST PASS (conditional REST; any failure keeps the previous cache) ---
+    endpoints: dict[str, Any] = {}
+    fetched: dict[str, dict[str, Any]] = {}
+    saw_304 = False
+    for page in range(1, max(1, max_pages) + 1):
+        if requests_used >= max_requests:
+            annotations.append("budget_exhausted")
+            return summary(None, EXIT_STALE)
+        endpoint = list_endpoint(repo, page)
+        prev_meta = prev_endpoints.get(endpoint)
+        etag = str(prev_meta.get("etag") or "") if isinstance(prev_meta, dict) else ""
+        args = ["api", "-i", endpoint]
+        if etag:
+            args += ["-H", f"If-None-Match: {etag}"]
+        requests_used += 1
+        response = parse_gh_api_response(*run_gh(args))
+        now_iso = _iso(clock())
+        if response.status == 304:
+            # Unchanged, zero rate-limit cost: reuse cached data from here on.
+            saw_304 = True
+            endpoints[endpoint] = {"etag": etag, "last_status": 304, "fetched_at": now_iso}
+            break
+        if response.status != 200:
+            reason = response.error or f"http {response.status}"
+            annotations.append(f"list_fetch_failed:{endpoint}:{reason[:160]}")
+            return summary(None, EXIT_FAILURES)
+        try:
+            rows = json.loads(response.body or "[]")
+        except json.JSONDecodeError:
+            annotations.append(f"list_fetch_failed:{endpoint}:unparseable body")
+            return summary(None, EXIT_FAILURES)
+        if not isinstance(rows, list):
+            annotations.append(f"list_fetch_failed:{endpoint}:expected a list")
+            return summary(None, EXIT_FAILURES)
+        endpoints[endpoint] = {
+            "etag": response.headers.get("etag") or etag or None,
+            "last_status": 200,
+            "fetched_at": now_iso,
+        }
+        for row in rows:
+            entry = normalize_pr(row) if isinstance(row, dict) else None
+            if entry is not None:
+                fetched[str(entry["number"])] = entry
+        if len(rows) < PER_PAGE:
+            break
+    else:
+        annotations.append(f"pages_capped:{max_pages}")
+
+    # --- MERGE: carry checks forward for unchanged heads -----------------------
+    prs: dict[str, dict[str, Any]] = {}
+    if saw_304:
+        # Cannot enumerate closed PRs without a fresh full listing; keep all.
+        prs.update({num: dict(entry) for num, entry in prev_prs.items()})
+    for num, entry in fetched.items():
+        old = prev_prs.get(num)
+        if isinstance(old, dict) and old.get("head_sha") == entry["head_sha"]:
+            entry["checks"] = old.get("checks")
+            entry["checks_fetched_at"] = old.get("checks_fetched_at")
+        prs[num] = entry
+
+    # --- DELTA DETAIL PASS: only moved heads / missing checks cost a request ---
+    budget_exhausted = False
+    detail_done = 0
+    identical_errors = 0
+    last_error: str | None = None
+    for num in sorted(prs, key=int):
+        entry = prs[num]
+        if entry.get("checks") is not None or not entry.get("head_sha"):
+            continue
+        if detail_done >= max_detail or requests_used >= max_requests:
+            if requests_used >= max_requests:
+                budget_exhausted = True
+            annotations.append(f"detail_deferred:{num}")
+            continue
+        requests_used += 1
+        returncode, stdout, stderr = run_gh(
+            ["api", check_runs_endpoint(repo, str(entry["head_sha"]))]
+        )
+        error = ""
+        if returncode != 0:
+            error = (stderr or stdout).strip()[:200] or f"gh exited {returncode}"
+        else:
+            try:
+                payload = json.loads(stdout or "{}")
+                if not isinstance(payload, dict):
+                    raise ValueError("non-object payload")
+            except (json.JSONDecodeError, ValueError):
+                error = "unparseable check-runs body"
+            else:
+                entry["checks"] = extract_checks(payload)
+                entry["checks_fetched_at"] = _iso(clock())
+                detail_done += 1
+                identical_errors = 0
+                last_error = None
+                continue
+        annotations.append(f"detail_failed:{num}:{error[:160]}")
+        identical_errors = identical_errors + 1 if error == last_error else 1
+        last_error = error
+        if identical_errors >= breaker_threshold:
+            annotations.append("breaker_tripped")
+            return summary(None, EXIT_BREAKER)
+
+    if budget_exhausted:
+        annotations.append("budget_exhausted")
+
+    cache = {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": _iso(clock()),
+        "repo": repo,
+        "endpoints": {**prev_endpoints, **endpoints},
+        "prs": prs,
+        "annotations": annotations,
+    }
+    return summary(cache, EXIT_STALE if budget_exhausted else EXIT_OK)
+
+
+# --- read (lanes' cheap path) ------------------------------------------------------
+
+
+def run_read(
+    cache: dict[str, Any] | None,
+    pr: int,
+    *,
+    max_age_seconds: float = DEFAULT_MAX_AGE_SECONDS,
+    clock: Callable[[], float] = time.time,
+) -> tuple[dict[str, Any], int]:
+    """Freshness-verdicted cache read; never touches the network.
+
+    Verdicts: ``fresh`` (exit 0), ``stale`` / ``missing`` (exit 3 — the lane
+    must wait for the poller or escalate to ``verify``).
+    """
+    entry = None
+    if isinstance(cache, dict):
+        prs = cache.get("prs")
+        if isinstance(prs, dict):
+            entry = prs.get(str(pr))
+    if entry is None:
+        return {"pr": pr, "verdict": "missing", "entry": None}, EXIT_STALE
+    generated = _parse_iso(cache.get("generated_at")) if isinstance(cache, dict) else None
+    age = clock() - generated if generated is not None else None
+    report = {
+        "pr": pr,
+        "generated_at": cache.get("generated_at") if isinstance(cache, dict) else None,
+        "age_seconds": round(age, 1) if age is not None else None,
+        "max_age_seconds": max_age_seconds,
+        "checks_fetched_at": entry.get("checks_fetched_at"),
+        "entry": entry,
+    }
+    if age is None or age > max_age_seconds:
+        report["verdict"] = "stale"
+        return report, EXIT_STALE
+    report["verdict"] = "fresh"
+    return report, EXIT_OK
+
+
+# --- verify (the only always-live command) -----------------------------------------
+
+
+def run_verify(repo: str, pr: int, run_gh: GhRunner) -> tuple[dict[str, Any], int]:
+    """Exactly ONE live REST call returning current head/state for PR ``pr``.
+
+    This is the lane's just-before-mutation check; it is deliberately the only
+    code path here that always spends a request.
+    """
+    returncode, stdout, stderr = run_gh(["api", f"repos/{repo}/pulls/{pr}"])
+    if returncode != 0:
+        error = (stderr or stdout).strip()[:300] or f"gh exited {returncode}"
+        return {"pr": pr, "error": error}, EXIT_FAILURES
+    try:
+        payload = json.loads(stdout or "{}")
+        if not isinstance(payload, dict):
+            raise ValueError("non-object payload")
+    except (json.JSONDecodeError, ValueError):
+        return {"pr": pr, "error": "unparseable gh api body"}, EXIT_FAILURES
+    head = payload.get("head") if isinstance(payload.get("head"), dict) else {}
+    base = payload.get("base") if isinstance(payload.get("base"), dict) else {}
+    return {
+        "pr": pr,
+        "number": payload.get("number"),
+        "head_sha": str(head.get("sha") or ""),
+        "head_ref": str(head.get("ref") or ""),
+        "base_ref": str(base.get("ref") or ""),
+        "state": str(payload.get("state") or ""),
+        "draft": bool(payload.get("draft")),
+        "merged": bool(payload.get("merged")),
+        "mergeable": payload.get("mergeable"),
+        "updated_at": str(payload.get("updated_at") or ""),
+        "live": True,
+    }, EXIT_OK
+
+
+# --- CLI ---------------------------------------------------------------------------
+
+
+def _repo_type(value: str) -> str:
+    if not _REPO_RE.match(value):
+        raise argparse.ArgumentTypeError(f"malformed repo {value!r} (expected owner/name)")
+    return value
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--repo", type=_repo_type, default=DEFAULT_REPO, help="owner/name")
+    parser.add_argument(
+        "--cache-file",
+        default=DEFAULT_CACHE_FILE,
+        help=f"cache file path (default: {DEFAULT_CACHE_FILE})",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    poll = sub.add_parser("poll", help="budgeted REST list + delta detail pass")
+    poll.add_argument(
+        "--apply",
+        action="store_true",
+        help="write the cache file (default: dry-run, print would-write JSON)",
+    )
+    poll.add_argument("--max-pages", type=int, default=DEFAULT_MAX_PAGES)
+    poll.add_argument("--max-detail", type=int, default=DEFAULT_MAX_DETAIL)
+    poll.add_argument("--max-requests", type=int, default=DEFAULT_MAX_REQUESTS)
+
+    read = sub.add_parser("read", help="cached entry + freshness verdict (no network)")
+    read.add_argument("--pr", type=int, required=True)
+    read.add_argument("--max-age-seconds", type=float, default=DEFAULT_MAX_AGE_SECONDS)
+
+    verify = sub.add_parser("verify", help="ONE live REST call for the exact current head")
+    verify.add_argument("--pr", type=int, required=True)
+
+    return parser
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    run_gh: GhRunner = default_run_gh,
+    clock: Callable[[], float] = time.time,
+) -> int:
+    args = build_parser().parse_args(argv)
+
+    if args.command == "poll":
+        previous = load_cache(args.cache_file)
+        summary = run_poll(
+            repo=args.repo,
+            previous=previous,
+            run_gh=run_gh,
+            max_pages=max(1, args.max_pages),
+            max_detail=max(0, args.max_detail),
+            max_requests=max(0, args.max_requests),
+            clock=clock,
+        )
+        cache = summary["cache"]
+        if cache is None:
+            print(
+                json.dumps(
+                    {
+                        "action": "poll",
+                        "wrote": False,
+                        "annotations": summary["annotations"],
+                        "requests_used": summary["requests_used"],
+                        "exit_code": summary["exit_code"],
+                    }
+                ),
+                file=sys.stderr,
+            )
+            return int(summary["exit_code"])
+        if not args.apply:
+            print(json.dumps(cache, indent=2, sort_keys=True))
+            return int(summary["exit_code"])
+        try:
+            atomic_write_json(Path(args.cache_file), cache)
+        except OSError as exc:
+            print(
+                json.dumps({"action": "poll", "wrote": False, "error": str(exc)[:300]}),
+                file=sys.stderr,
+            )
+            return EXIT_FAILURES
+        print(
+            json.dumps(
+                {
+                    "action": "poll",
+                    "wrote": True,
+                    "cache_file": args.cache_file,
+                    "prs": len(cache["prs"]),
+                    "annotations": summary["annotations"],
+                    "requests_used": summary["requests_used"],
+                    "exit_code": summary["exit_code"],
+                }
+            )
+        )
+        return int(summary["exit_code"])
+
+    if args.command == "read":
+        report, exit_code = run_read(
+            load_cache(args.cache_file),
+            args.pr,
+            max_age_seconds=args.max_age_seconds,
+            clock=clock,
+        )
+        print(json.dumps(report, indent=2, sort_keys=True))
+        return exit_code
+
+    # verify
+    report, exit_code = run_verify(args.repo, args.pr, run_gh)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_pr_state_cache.py
+++ b/tests/scripts/test_pr_state_cache.py
@@ -1,0 +1,544 @@
+"""Tests for ``scripts/pr_state_cache.py`` (shared PR-state cache, #8315).
+
+All boundaries (the gh runner, the clock) are injected; no test touches the
+network or spawns a subprocess. The fake gh runner returns canned ``-i``
+responses including the status line and headers, so the 304 / ETag handling
+is exercised exactly as ``gh api -i`` produces it (nonzero exit on 304).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _load_module(script_name: str) -> Any:
+    here = Path(__file__).resolve()
+    script_path = here.parents[2] / "scripts" / script_name
+    spec = importlib.util.spec_from_file_location(f"{script_name}_under_test", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load spec for {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+psc = _load_module("pr_state_cache.py")
+
+REPO = "synaptent/aragora"
+
+
+def _http(status: int, body: str = "", etag: str | None = None) -> tuple[int, str, str]:
+    """Build a canned ``gh api -i`` response: status line + headers + body.
+
+    Mirrors real gh behavior: nonzero exit code for any non-2xx status,
+    including 304 (where the captured output still carries the status line).
+    """
+    reasons = {200: "OK", 304: "Not Modified", 404: "Not Found", 500: "Internal Server Error"}
+    lines = [
+        f"HTTP/2.0 {status} {reasons.get(status, '')}".rstrip(),
+        "Content-Type: application/json; charset=utf-8",
+    ]
+    if etag is not None:
+        lines.append(f"Etag: {etag}")
+    text = "\r\n".join(lines) + "\r\n\r\n" + body
+    returncode = 0 if 200 <= status < 300 else 1
+    return returncode, text, "" if returncode == 0 else f"gh: HTTP {status}"
+
+
+def _pr_row(number: int, *, sha: str = "a" * 8, draft: bool = False) -> dict[str, Any]:
+    return {
+        "number": number,
+        "head": {"sha": sha, "ref": f"feature/{number}"},
+        "base": {"ref": "main"},
+        "draft": draft,
+        "state": "open",
+        "updated_at": "2026-06-13T10:00:00Z",
+        "labels": [{"name": "automation"}],
+    }
+
+
+def _check_runs_body(name: str = "ci", conclusion: str = "success") -> str:
+    return json.dumps(
+        {
+            "total_count": 1,
+            "check_runs": [
+                {
+                    "name": name,
+                    "status": "completed",
+                    "conclusion": conclusion,
+                    "completed_at": "2026-06-13T10:05:00Z",
+                },
+            ],
+        }
+    )
+
+
+class FakeGh:
+    """Injected gh runner: queued canned responses keyed by endpoint."""
+
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+        self.queues: dict[str, list[tuple[int, str, str]]] = {}
+        self.fallback: tuple[int, str, str] = (1, "", "gh: unexpected endpoint")
+
+    def queue(self, endpoint: str, *responses: tuple[int, str, str]) -> None:
+        self.queues.setdefault(endpoint, []).extend(responses)
+
+    @staticmethod
+    def endpoint_of(args: list[str]) -> str:
+        skip_next = False
+        for arg in args:
+            if skip_next:
+                skip_next = False
+                continue
+            if arg == "-H":
+                skip_next = True
+                continue
+            if arg in ("api", "-i"):
+                continue
+            return arg
+        return ""
+
+    def header_of(self, args: list[str], name: str) -> str | None:
+        for index, arg in enumerate(args):
+            if arg == "-H" and index + 1 < len(args):
+                header = args[index + 1]
+                if header.lower().startswith(f"{name.lower()}:"):
+                    return header.partition(":")[2].strip()
+        return None
+
+    def __call__(self, args: list[str]) -> tuple[int, str, str]:
+        self.calls.append(list(args))
+        queue = self.queues.get(self.endpoint_of(args))
+        if queue:
+            return queue.pop(0)
+        return self.fallback
+
+
+LIST_EP = psc.list_endpoint(REPO, 1)
+
+
+def _poll(gh: FakeGh, previous: dict[str, Any] | None = None, **kwargs: Any) -> dict[str, Any]:
+    return psc.run_poll(repo=REPO, previous=previous, run_gh=gh, clock=lambda: 1000.0, **kwargs)
+
+
+def _fresh_cache_via_poll(gh: FakeGh | None = None) -> dict[str, Any]:
+    """One-PR baseline cache built through a real (fake-backed) poll."""
+    gh = gh or FakeGh()
+    gh.queue(LIST_EP, _http(200, json.dumps([_pr_row(7, sha="abc123")]), etag='W/"e1"'))
+    gh.queue(psc.check_runs_endpoint(REPO, "abc123"), (0, _check_runs_body(), ""))
+    summary = _poll(gh)
+    assert summary["exit_code"] == 0
+    return summary["cache"]
+
+
+# --- gh api -i parsing -------------------------------------------------------------
+
+
+def test_parse_response_200_extracts_status_headers_body() -> None:
+    response = psc.parse_gh_api_response(*_http(200, "[]", etag='W/"x"'))
+    assert response.status == 200
+    assert response.headers["etag"] == 'W/"x"'
+    assert response.body == "[]"
+
+
+def test_parse_response_304_despite_nonzero_exit() -> None:
+    returncode, stdout, stderr = _http(304)
+    assert returncode != 0  # gh exits nonzero on 304
+    response = psc.parse_gh_api_response(returncode, stdout, stderr)
+    assert response.status == 304
+    assert response.error == ""
+
+
+def test_parse_response_header_names_case_insensitive() -> None:
+    stdout = 'HTTP/2.0 200 OK\r\nETAG: W/"y"\r\n\r\n[]'
+    response = psc.parse_gh_api_response(0, stdout, "")
+    assert response.headers["etag"] == 'W/"y"'
+
+
+def test_parse_response_no_status_line_is_transport_error() -> None:
+    response = psc.parse_gh_api_response(127, "", "OSError: gh not found")
+    assert response.status is None
+    assert "gh not found" in response.error
+
+
+# --- poll: list pass, ETag, 304 ----------------------------------------------------
+
+
+def test_first_poll_stores_prs_and_etag() -> None:
+    cache = _fresh_cache_via_poll()
+    assert cache["schema_version"] == 1
+    assert cache["repo"] == REPO
+    assert cache["prs"]["7"]["head_sha"] == "abc123"
+    assert cache["prs"]["7"]["checks"] == {"ci": "success"}
+    assert cache["endpoints"][LIST_EP]["etag"] == 'W/"e1"'
+    assert cache["endpoints"][LIST_EP]["last_status"] == 200
+
+
+def test_etag_sent_on_second_poll() -> None:
+    cache = _fresh_cache_via_poll()
+    gh = FakeGh()
+    gh.queue(LIST_EP, _http(304))
+    _poll(gh, previous=cache)
+    list_call = gh.calls[0]
+    assert gh.header_of(list_call, "If-None-Match") == 'W/"e1"'
+
+
+def test_no_etag_header_on_first_poll() -> None:
+    gh = FakeGh()
+    gh.queue(LIST_EP, _http(200, "[]"))
+    _poll(gh)
+    assert gh.header_of(gh.calls[0], "If-None-Match") is None
+
+
+def test_304_reuses_cached_prs() -> None:
+    cache = _fresh_cache_via_poll()
+    gh = FakeGh()
+    gh.queue(LIST_EP, _http(304))
+    summary = _poll(gh, previous=cache)
+    assert summary["exit_code"] == 0
+    assert summary["cache"]["prs"]["7"]["head_sha"] == "abc123"
+    assert summary["cache"]["prs"]["7"]["checks"] == {"ci": "success"}
+    assert summary["cache"]["endpoints"][LIST_EP]["last_status"] == 304
+    # ETag survives the 304 for the next conditional poll.
+    assert summary["cache"]["endpoints"][LIST_EP]["etag"] == 'W/"e1"'
+
+
+def test_304_costs_no_detail_fetches() -> None:
+    cache = _fresh_cache_via_poll()
+    gh = FakeGh()
+    gh.queue(LIST_EP, _http(304))
+    summary = _poll(gh, previous=cache)
+    assert len(gh.calls) == 1  # the conditional list call only
+    assert summary["requests_used"] == 1
+
+
+# --- poll: delta detail pass -------------------------------------------------------
+
+
+def test_head_change_triggers_detail_fetch() -> None:
+    cache = _fresh_cache_via_poll()
+    gh = FakeGh()
+    gh.queue(LIST_EP, _http(200, json.dumps([_pr_row(7, sha="def456")]), etag='W/"e2"'))
+    gh.queue(psc.check_runs_endpoint(REPO, "def456"), (0, _check_runs_body("ci", "failure"), ""))
+    summary = _poll(gh, previous=cache)
+    entry = summary["cache"]["prs"]["7"]
+    assert entry["head_sha"] == "def456"
+    assert entry["checks"] == {"ci": "failure"}
+    assert any("check-runs" in FakeGh.endpoint_of(call) for call in gh.calls)
+
+
+def test_unchanged_head_skips_detail_fetch() -> None:
+    cache = _fresh_cache_via_poll()
+    gh = FakeGh()
+    gh.queue(LIST_EP, _http(200, json.dumps([_pr_row(7, sha="abc123")]), etag='W/"e2"'))
+    summary = _poll(gh, previous=cache)
+    assert len(gh.calls) == 1  # list only; cached checks carried forward
+    assert summary["cache"]["prs"]["7"]["checks"] == {"ci": "success"}
+    assert summary["cache"]["prs"]["7"]["checks_fetched_at"] is not None
+
+
+def test_missing_cached_checks_triggers_detail_even_with_same_head() -> None:
+    cache = _fresh_cache_via_poll()
+    cache["prs"]["7"]["checks"] = None  # e.g. deferred on a previous run
+    gh = FakeGh()
+    gh.queue(LIST_EP, _http(200, json.dumps([_pr_row(7, sha="abc123")]), etag='W/"e2"'))
+    gh.queue(psc.check_runs_endpoint(REPO, "abc123"), (0, _check_runs_body(), ""))
+    summary = _poll(gh, previous=cache)
+    assert summary["cache"]["prs"]["7"]["checks"] == {"ci": "success"}
+
+
+def test_max_detail_cap_annotates_detail_deferred() -> None:
+    rows = [_pr_row(n, sha=f"sha{n}") for n in (1, 2, 3)]
+    gh = FakeGh()
+    gh.queue(LIST_EP, _http(200, json.dumps(rows), etag='W/"e1"'))
+    gh.queue(psc.check_runs_endpoint(REPO, "sha1"), (0, _check_runs_body(), ""))
+    summary = _poll(gh, max_detail=1)
+    assert summary["exit_code"] == 0
+    assert "detail_deferred:2" in summary["annotations"]
+    assert "detail_deferred:3" in summary["annotations"]
+    assert summary["cache"]["prs"]["1"]["checks"] == {"ci": "success"}
+    assert summary["cache"]["prs"]["2"]["checks"] is None
+
+
+def test_extract_checks_keeps_latest_run_per_name() -> None:
+    payload = {
+        "check_runs": [
+            {"name": "ci", "conclusion": "failure", "completed_at": "2026-06-13T09:00:00Z"},
+            {"name": "ci", "conclusion": "success", "completed_at": "2026-06-13T11:00:00Z"},
+            {"name": "lint", "status": "in_progress", "started_at": "2026-06-13T10:00:00Z"},
+        ]
+    }
+    assert psc.extract_checks(payload) == {"ci": "success", "lint": "in_progress"}
+
+
+# --- poll: budget guard and breaker -------------------------------------------------
+
+
+def test_budget_guard_during_detail_exit_3_with_annotation() -> None:
+    rows = [_pr_row(n, sha=f"sha{n}") for n in (1, 2, 3)]
+    gh = FakeGh()
+    gh.queue(LIST_EP, _http(200, json.dumps(rows), etag='W/"e1"'))
+    gh.queue(psc.check_runs_endpoint(REPO, "sha1"), (0, _check_runs_body(), ""))
+    summary = _poll(gh, max_requests=2)  # 1 list + 1 detail, then exhausted
+    assert summary["exit_code"] == 3
+    assert "budget_exhausted" in summary["annotations"]
+    assert summary["cache"] is not None  # list data is complete and writable
+    assert "detail_deferred:2" in summary["annotations"]
+
+
+def test_budget_guard_before_list_exit_3_no_cache() -> None:
+    gh = FakeGh()
+    summary = _poll(gh, max_requests=0)
+    assert summary["exit_code"] == 3
+    assert summary["cache"] is None  # never write a partial cache
+    assert "budget_exhausted" in summary["annotations"]
+    assert gh.calls == []
+
+
+def test_breaker_three_identical_detail_errors_exit_2() -> None:
+    rows = [_pr_row(n, sha=f"sha{n}") for n in (1, 2, 3)]
+    gh = FakeGh()
+    gh.queue(LIST_EP, _http(200, json.dumps(rows), etag='W/"e1"'))
+    gh.fallback = (1, "", "gh: HTTP 502 Bad Gateway")  # identical every time
+    summary = _poll(gh)
+    assert summary["exit_code"] == 2
+    assert "breaker_tripped" in summary["annotations"]
+    assert summary["cache"] is None
+
+
+def test_breaker_not_tripped_on_varied_errors() -> None:
+    rows = [_pr_row(n, sha=f"sha{n}") for n in (1, 2, 3)]
+    gh = FakeGh()
+    gh.queue(LIST_EP, _http(200, json.dumps(rows), etag='W/"e1"'))
+    for n in (1, 2, 3):
+        gh.queue(psc.check_runs_endpoint(REPO, f"sha{n}"), (1, "", f"gh: error {n}"))
+    summary = _poll(gh)
+    assert summary["exit_code"] == 0  # failures annotated, no systemic fault
+    assert "breaker_tripped" not in summary["annotations"]
+    assert sum(1 for a in summary["annotations"] if a.startswith("detail_failed:")) == 3
+
+
+# --- poll: list-pass failures preserve the previous cache ---------------------------
+
+
+def test_list_transport_failure_returns_no_cache_exit_1() -> None:
+    gh = FakeGh()
+    gh.queue(LIST_EP, (127, "", "OSError: gh not found"))
+    summary = _poll(gh, previous=_fresh_cache_via_poll())
+    assert summary["exit_code"] == 1
+    assert summary["cache"] is None
+    assert any(a.startswith("list_fetch_failed:") for a in summary["annotations"])
+
+
+def test_list_http_500_returns_no_cache_exit_1() -> None:
+    gh = FakeGh()
+    gh.queue(LIST_EP, _http(500, '{"message": "boom"}'))
+    summary = _poll(gh)
+    assert summary["exit_code"] == 1
+    assert summary["cache"] is None
+
+
+def test_transport_failure_preserves_prior_cache_file_bytes(tmp_path: Path) -> None:
+    cache_file = tmp_path / "cache.json"
+    psc.atomic_write_json(cache_file, _fresh_cache_via_poll())
+    before = cache_file.read_bytes()
+    gh = FakeGh()
+    gh.queue(LIST_EP, (127, "", "OSError: gh not found"))
+    exit_code = main_with(gh, ["--cache-file", str(cache_file), "poll", "--apply"])
+    assert exit_code == 1
+    assert cache_file.read_bytes() == before
+
+
+# --- pagination ----------------------------------------------------------------------
+
+
+def _full_page(start: int) -> str:
+    return json.dumps([_pr_row(n, sha=f"sha{n}") for n in range(start, start + psc.PER_PAGE)])
+
+
+def test_pagination_follows_until_short_page() -> None:
+    gh = FakeGh()
+    gh.queue(psc.list_endpoint(REPO, 1), _http(200, _full_page(1), etag='W/"p1"'))
+    gh.queue(psc.list_endpoint(REPO, 2), _http(200, json.dumps([_pr_row(500)]), etag='W/"p2"'))
+    summary = _poll(gh, max_detail=0)
+    assert summary["exit_code"] == 0
+    assert len(summary["cache"]["prs"]) == psc.PER_PAGE + 1
+    endpoints = [FakeGh.endpoint_of(call) for call in gh.calls]
+    assert endpoints == [psc.list_endpoint(REPO, 1), psc.list_endpoint(REPO, 2)]
+
+
+def test_pagination_caps_at_max_pages() -> None:
+    gh = FakeGh()
+    gh.queue(psc.list_endpoint(REPO, 1), _http(200, _full_page(1), etag='W/"p1"'))
+    gh.queue(psc.list_endpoint(REPO, 2), _http(200, _full_page(200), etag='W/"p2"'))
+    summary = _poll(gh, max_pages=2, max_detail=0)
+    assert len(gh.calls) == 2
+    assert "pages_capped:2" in summary["annotations"]
+
+
+def test_pagination_stores_etag_per_endpoint() -> None:
+    gh = FakeGh()
+    gh.queue(psc.list_endpoint(REPO, 1), _http(200, _full_page(1), etag='W/"p1"'))
+    gh.queue(psc.list_endpoint(REPO, 2), _http(200, "[]", etag='W/"p2"'))
+    summary = _poll(gh, max_detail=0)
+    endpoints = summary["cache"]["endpoints"]
+    assert endpoints[psc.list_endpoint(REPO, 1)]["etag"] == 'W/"p1"'
+    assert endpoints[psc.list_endpoint(REPO, 2)]["etag"] == 'W/"p2"'
+
+
+def test_full_refresh_drops_closed_prs() -> None:
+    cache = _fresh_cache_via_poll()  # has PR 7
+    gh = FakeGh()
+    gh.queue(LIST_EP, _http(200, json.dumps([_pr_row(8, sha="sha8")]), etag='W/"e2"'))
+    gh.queue(psc.check_runs_endpoint(REPO, "sha8"), (0, _check_runs_body(), ""))
+    summary = _poll(gh, previous=cache)
+    assert set(summary["cache"]["prs"]) == {"8"}
+
+
+# --- atomic writes -------------------------------------------------------------------
+
+
+def test_atomic_write_produces_valid_json_and_no_temp(tmp_path: Path) -> None:
+    target = tmp_path / "nested" / "cache.json"
+    psc.atomic_write_json(target, {"schema_version": 1})
+    assert json.loads(target.read_text()) == {"schema_version": 1}
+    assert [p.name for p in target.parent.iterdir()] == ["cache.json"]
+
+
+def test_atomic_write_failure_leaves_no_temp_and_keeps_original(tmp_path: Path) -> None:
+    target = tmp_path / "cache.json"
+    psc.atomic_write_json(target, {"ok": True})
+    before = target.read_bytes()
+    with pytest.raises(TypeError):
+        psc.atomic_write_json(target, {"bad": object()})  # not JSON-serializable
+    assert target.read_bytes() == before
+    assert [p.name for p in tmp_path.iterdir()] == ["cache.json"]
+
+
+# --- read (freshness verdicts) --------------------------------------------------------
+
+
+def test_read_fresh_exit_0() -> None:
+    cache = _fresh_cache_via_poll()  # generated_at at clock=1000.0
+    report, exit_code = psc.run_read(cache, 7, max_age_seconds=300, clock=lambda: 1100.0)
+    assert exit_code == 0
+    assert report["verdict"] == "fresh"
+    assert report["entry"]["head_sha"] == "abc123"
+    assert report["checks_fetched_at"] is not None  # self-describing read
+
+
+def test_read_stale_exit_3() -> None:
+    cache = _fresh_cache_via_poll()
+    report, exit_code = psc.run_read(cache, 7, max_age_seconds=300, clock=lambda: 2000.0)
+    assert exit_code == 3
+    assert report["verdict"] == "stale"
+
+
+def test_read_missing_pr_exit_3() -> None:
+    report, exit_code = psc.run_read(_fresh_cache_via_poll(), 999, clock=lambda: 1000.0)
+    assert exit_code == 3
+    assert report["verdict"] == "missing"
+
+
+def test_read_missing_cache_exit_3() -> None:
+    report, exit_code = psc.run_read(None, 7, clock=lambda: 1000.0)
+    assert exit_code == 3
+    assert report["verdict"] == "missing"
+
+
+# --- verify (the only always-live command) --------------------------------------------
+
+
+def test_verify_makes_exactly_one_live_call() -> None:
+    gh = FakeGh()
+    body = json.dumps(
+        {
+            "number": 7,
+            "head": {"sha": "abc123", "ref": "feature/7"},
+            "base": {"ref": "main"},
+            "state": "open",
+            "draft": False,
+            "merged": False,
+            "mergeable": True,
+            "updated_at": "2026-06-13T10:00:00Z",
+        }
+    )
+    gh.queue(f"repos/{REPO}/pulls/7", (0, body, ""))
+    report, exit_code = psc.run_verify(REPO, 7, gh)
+    assert exit_code == 0
+    assert len(gh.calls) == 1
+    assert gh.calls[0] == ["api", f"repos/{REPO}/pulls/7"]
+    assert report["head_sha"] == "abc123"
+    assert report["live"] is True
+
+
+def test_verify_failure_exit_1() -> None:
+    gh = FakeGh()
+    gh.queue(f"repos/{REPO}/pulls/7", (1, "", "gh: HTTP 404"))
+    report, exit_code = psc.run_verify(REPO, 7, gh)
+    assert exit_code == 1
+    assert "404" in report["error"]
+
+
+# --- CLI ------------------------------------------------------------------------------
+
+
+def main_with(gh: FakeGh, argv: list[str]) -> int:
+    return psc.main(argv, run_gh=gh, clock=lambda: 1000.0)
+
+
+def test_malformed_repo_rejected_at_parse(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        psc.main(["--repo", "not a repo!", "poll"], run_gh=FakeGh())
+    assert excinfo.value.code == 2
+    assert "malformed repo" in capsys.readouterr().err
+
+
+def test_poll_dry_run_prints_would_write_and_writes_nothing(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    cache_file = tmp_path / "cache.json"
+    gh = FakeGh()
+    gh.queue(LIST_EP, _http(200, json.dumps([_pr_row(7, sha="abc123")]), etag='W/"e1"'))
+    gh.queue(psc.check_runs_endpoint(REPO, "abc123"), (0, _check_runs_body(), ""))
+    exit_code = main_with(gh, ["--cache-file", str(cache_file), "poll"])
+    assert exit_code == 0
+    assert not cache_file.exists()
+    printed = json.loads(capsys.readouterr().out)
+    assert printed["prs"]["7"]["head_sha"] == "abc123"
+
+
+def test_poll_apply_writes_cache_file(tmp_path: Path) -> None:
+    cache_file = tmp_path / "cache.json"
+    gh = FakeGh()
+    gh.queue(LIST_EP, _http(200, json.dumps([_pr_row(7, sha="abc123")]), etag='W/"e1"'))
+    gh.queue(psc.check_runs_endpoint(REPO, "abc123"), (0, _check_runs_body(), ""))
+    exit_code = main_with(gh, ["--cache-file", str(cache_file), "poll", "--apply"])
+    assert exit_code == 0
+    written = json.loads(cache_file.read_text())
+    assert written["prs"]["7"]["checks"] == {"ci": "success"}
+
+
+def test_read_cli_round_trip(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    cache_file = tmp_path / "cache.json"
+    psc.atomic_write_json(cache_file, _fresh_cache_via_poll())
+    exit_code = main_with(
+        FakeGh(), ["--cache-file", str(cache_file), "read", "--pr", "7", "--max-age-seconds", "60"]
+    )
+    assert exit_code == 0
+    assert json.loads(capsys.readouterr().out)["verdict"] == "fresh"
+
+
+def test_read_cli_missing_file_exit_3(tmp_path: Path) -> None:
+    exit_code = main_with(
+        FakeGh(), ["--cache-file", str(tmp_path / "absent.json"), "read", "--pr", "7"]
+    )
+    assert exit_code == 3


### PR DESCRIPTION
## Problem (issue #8315, layer 3 — the architectural half)

The fleet shares one GitHub identity, and every lane independently re-polls near-identical PR state via GraphQL-backed `gh pr view/list` every cycle ("do not trust transcript state" × N concurrent lanes). Result, observed all evening of 2026-06-12: the 5,000-point/hour GraphQL budget exhausts mid-hour, `merge-packet` fails closed to `transport_blocked`, and entire codex goal-loops stall until the hourly reset. Quota exhaustion is the symptom; **N lanes buying the same data** is the disease.

## What this adds — `scripts/pr_state_cache.py` (new file, Tier 2)

One budgeted REST-only poller maintains a shared cache; lanes read the cache and spend exactly **one** targeted live call before any mutation.

- **`poll`** — `gh api -i "repos/{repo}/pulls?state=open"` with **ETag conditional requests**: a 304 reuses the entire cached set at the cost of 1 request and zero quota-priced body. (`gh api` exits nonzero on 304, so the HTTP status line is parsed from `-i` output rather than trusting exit codes; "no parseable status line" is the only transport-failure condition.) Delta detail pass: check-runs are fetched **only for PRs whose head moved** since the cache, capped by `--max-detail` (10, over-cap annotated `detail_deferred`). Per-run `--max-requests` budget (30), identical-error breaker, dry-run default with `--apply` gating the write.
- **Write-safety matrix**: list-pass transport failure (exit 1) and breaker (exit 2) never touch the prior cache file (test asserts byte-identical preservation); budget exhaustion during the detail pass still writes complete list data with annotations; before the list completes, writes nothing. Atomic mkstemp+`os.replace` with `except OSError` cleanup.
- **`read --pr N --max-age-seconds 300`** — the lanes' cheap path: cached entry + self-describing freshness verdict (`generated_at`, `checks_fetched_at`), exit 3 on stale/missing.
- **`verify --pr N`** — the one always-live call (`gh api repos/{repo}/pulls/N`, test-asserted single request) for the exact-head check immediately before mutating.
- **Reader contract** (verbatim in the module docstring): cache for routine reads; `verify` before any mutation; **merge-packet remains the sole gate authority** — the cache is never settlement evidence.

## What this enables

Lane recursive-prompt preambles replace ~8–12 GraphQL reads per cycle with `read` (free) + one `verify` (1 REST request) — a ~10× read reduction fleet-wide while *strengthening* the exact-head-before-mutation invariant. Pairs with #8324 (REST fallback inside merge-packet) and the App-token routing for the remaining direct calls.

## Validation

- 38 tests (injected fake `gh` runner with canned `-i` responses): ETag sent on second poll; 304 reuses cache with zero detail fetches; head-change triggers detail, unchanged head doesn't; caps/budget/breaker exits 0/1/2/3; prior-cache preservation on failure; no temp residue on simulated `os.replace` failure; pagination; `verify` single-call; `read` freshness verdicts; malformed `--repo` rejected at parse time.
- `ruff check` + `ruff format` clean; stdlib-only; mirrors `boss_pr_janitor.py` conventions.

Part of #8315 (the Tier-4 merge-packet REST fallback is #8324; this is the lane-side substrate and needs no governance surfaces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jfJj5gb9VoLs6VBMnzhrP

---
_Generated by [Claude Code](https://claude.ai/code/session_018jfJj5gb9VoLs6VBMnzhrP)_