### PR TITLE
feat(coordination): owner-lease liveness + fail-closed stale-claim advisory (#8318)

### DIFF
--- a/scripts/identify_lane_owner.py
+++ b/scripts/identify_lane_owner.py
@@ -38,6 +38,17 @@ Lookup sources (read-only, in this precedence):
      steering-message inbox count (Phase B-built dir; Phase A only
      reads).
 
+Owner-lease liveness (issue #8318): when ``--liveness`` is enabled
+(default), the JSON output is additionally enriched with an
+``owner_liveness`` object (lease age, last heartbeat, lane-ledger
+status, assessment) and — only for stale/terminal owners with no
+indication of local unpushed work — a machine-readable
+``stale_claim_advisory`` codifying the manual stale-claim override
+protocol exercised on #8125. This is VISIBILITY + ADVISORY only: it
+never changes a go/no-go decision by itself, and it fails closed
+(``advisory_withheld: "possible_unpushed_work"``) whenever
+uncommitted/unpushed work might exist.
+
 Pure stdlib. No ``aragora.*`` imports. Read-only — never mutates
 GitHub state, lane registry, mailboxes, or any other on-disk file.
 """
@@ -46,6 +57,7 @@ from __future__ import annotations
 
 import argparse
 import dataclasses
+import glob
 import json
 import os
 import re
@@ -1182,6 +1194,253 @@ def build_owner_info(
 
 
 # ---------------------------------------------------------------------------
+# Owner-lease liveness + stale-claim advisory (issue #8318)
+# ---------------------------------------------------------------------------
+#
+# Advisory-only by design. Nothing in this section changes a go/no-go
+# decision; it only makes a dead owner lock *visible* and codifies the
+# manual stale-claim protocol (exercised successfully on #8125) as
+# machine-readable output for the operator / conveyor to act on.
+
+STALE_HOURS_DEFAULT = 6.0
+LANE_RUNS_GLOB_DEFAULT = str(STATE_ROOT_DEFAULT / "run-*" / "lanes")
+
+# Lane-ledger statuses meaning the owning lane can no longer be working.
+TERMINAL_LANE_STATUSES = {"completed", "failed", "cancelled", "dead"}
+
+STALE_CLAIM_PROTOCOL = "stale-claim-override"
+ADVISORY_WITHHELD_UNPUSHED = "possible_unpushed_work"
+REQUIRED_LEDGER_RECORD = "overriding lane must write an override entry naming the stale lane id"
+
+# Timestamp fields on the owner (lane-registry) record; newest wins.
+_OWNER_RECORD_TIMESTAMP_KEYS = (
+    "updated_at",
+    "claimed_at",
+    "created_at",
+    "last_heartbeat_at",
+    "last_mailbox_check_at",
+    "last_delivery_at",
+    "last_ack_at",
+)
+
+# Timestamp fields on a lane-ledger entry (.aragora/run-*/lanes/*.json).
+_LEDGER_TIMESTAMP_KEYS = (
+    "updated_at",
+    "launched_at",
+    "detected_at",
+    "completed_at",
+    "finished_at",
+    "heartbeat_at",
+    "last_heartbeat_at",
+)
+
+# Boolean-ish owner/ledger fields that claim local (possibly unpushed) work.
+_LOCAL_WORK_CLAIM_KEYS = (
+    "uncommitted_changes",
+    "has_uncommitted_changes",
+    "uncommitted",
+    "unpushed_commits",
+    "local_changes",
+    "local_work",
+    "dirty",
+)
+
+
+def _ledger_entry_timestamp(entry: dict[str, Any]) -> float:
+    """Most recent parseable timestamp on a lane-ledger entry (0.0 if none)."""
+
+    return max(_updated_at_timestamp(entry.get(key)) for key in _LEDGER_TIMESTAMP_KEYS)
+
+
+def find_lane_ledger_entry(
+    lane: dict[str, Any],
+    *,
+    runs_glob: str = LANE_RUNS_GLOB_DEFAULT,
+) -> dict[str, Any] | None:
+    """Newest lane-ledger entry matching this lane by lane id or branch.
+
+    Lane ledgers live at ``<runs_glob>/*.json`` (the same layout
+    ``scripts/lane_janitor.py`` consumes): one JSON object per lane
+    with ``lane``, ``branch``, ``status``, ``launched_at`` and, when
+    the janitor has acted, ``detected_at``.
+    """
+
+    lane_id = str(lane.get("lane_id") or "")
+    branch = str(lane.get("branch") or "")
+    if not lane_id and not branch:
+        return None
+
+    best: dict[str, Any] | None = None
+    best_ts = float("-inf")
+    for lanes_dir in sorted(glob.glob(runs_glob)):
+        lanes_path = Path(lanes_dir)
+        if not lanes_path.is_dir():
+            continue
+        for ledger_file in sorted(lanes_path.glob("*.json")):
+            try:
+                entry = json.loads(ledger_file.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if not isinstance(entry, dict):
+                continue
+            entry_lane = str(entry.get("lane") or entry.get("lane_id") or "")
+            entry_branch = str(entry.get("branch") or "")
+            if not ((lane_id and entry_lane == lane_id) or (branch and entry_branch == branch)):
+                continue
+            ts = _ledger_entry_timestamp(entry)
+            if ts > best_ts:
+                best, best_ts = entry, ts
+    return best
+
+
+def _local_work_indication(lane: dict[str, Any], ledger_entry: dict[str, Any] | None) -> str | None:
+    """Reason to suspect local (possibly unpushed/uncommitted) work, or None.
+
+    Fail closed: a worktree reference alone is enough — metadata cannot
+    prove that work in a worktree was pushed.
+    """
+
+    if lane.get("worktree"):
+        return "owner record references a worktree path"
+    for source_name, record in (("owner record", lane), ("lane ledger", ledger_entry or {})):
+        for key in _LOCAL_WORK_CLAIM_KEYS:
+            if record.get(key):
+                return f"{source_name} claims local work ({key})"
+    if (ledger_entry or {}).get("worktree"):
+        return "lane ledger references a worktree path"
+    return None
+
+
+def assess_owner_liveness(
+    lane: dict[str, Any],
+    *,
+    ledger_entry: dict[str, Any] | None = None,
+    heartbeat: dict[str, Any] | None = None,
+    now: datetime | None = None,
+    stale_hours: float = STALE_HOURS_DEFAULT,
+) -> dict[str, Any]:
+    """Advisory-only owner-lease liveness assessment (issue #8318).
+
+    Returns a dict with ``owner_liveness``, ``stale_claim_advisory``
+    and ``advisory_withheld`` keys, merged additively into the JSON
+    output. Pure visibility: this never changes a go/no-go decision
+    by itself. ``assessed == "unknown"`` NEVER produces an advisory,
+    and any hint of local work withholds it
+    (``advisory_withheld: "possible_unpushed_work"``).
+    """
+
+    now_dt = now or datetime.now(timezone.utc)
+    threshold_seconds = max(0.0, stale_hours) * 3600.0
+
+    # lane_status: the lane ledger's view of the owning lane.
+    lane_status = "unknown"
+    if ledger_entry is not None:
+        lane_status = str(ledger_entry.get("status") or "").strip().lower() or "unknown"
+
+    # last_heartbeat_at: matched heartbeat row first, then owner record,
+    # then ledger heartbeat fields; null when nothing carries one.
+    last_heartbeat_at: str | None = None
+    if heartbeat and heartbeat.get("last_seen_at"):
+        last_heartbeat_at = str(heartbeat["last_seen_at"])
+    elif lane.get("last_heartbeat_at"):
+        last_heartbeat_at = str(lane["last_heartbeat_at"])
+    elif ledger_entry is not None:
+        for key in ("heartbeat_at", "last_heartbeat_at"):
+            if ledger_entry.get(key):
+                last_heartbeat_at = str(ledger_entry[key])
+                break
+
+    # Lease anchor: the most recent timestamp across the owner record,
+    # the matched heartbeat, and the ledger entry. Conservative — any
+    # recent signal keeps the owner "live".
+    candidates = [_updated_at_timestamp(lane.get(key)) for key in _OWNER_RECORD_TIMESTAMP_KEYS]
+    if last_heartbeat_at:
+        candidates.append(_updated_at_timestamp(last_heartbeat_at))
+    if ledger_entry is not None:
+        candidates.append(_ledger_entry_timestamp(ledger_entry))
+    anchor_ts = max(candidates)
+
+    lease_age_seconds: int | None = None
+    if anchor_ts > 0.0:
+        lease_age_seconds = max(0, int(now_dt.timestamp() - anchor_ts))
+
+    heartbeat_recent = False
+    heartbeat_ts = _updated_at_timestamp(last_heartbeat_at) if last_heartbeat_at else 0.0
+    if heartbeat_ts > 0.0:
+        heartbeat_recent = (now_dt.timestamp() - heartbeat_ts) <= threshold_seconds
+
+    if lane_status in TERMINAL_LANE_STATUSES:
+        assessed = "terminal"
+    elif lease_age_seconds is None:
+        assessed = "unknown"
+    elif lease_age_seconds <= threshold_seconds or heartbeat_recent:
+        assessed = "live"
+    else:
+        assessed = "stale"
+
+    owner_liveness = {
+        "lease_age_seconds": lease_age_seconds,
+        "last_heartbeat_at": last_heartbeat_at,
+        "lane_status": lane_status,
+        "assessed": assessed,
+        "stale_threshold_hours": stale_hours,
+    }
+
+    advisory: dict[str, Any] | None = None
+    advisory_withheld: str | None = None
+    if assessed in ("stale", "terminal"):
+        indication = _local_work_indication(lane, ledger_entry)
+        if indication is not None:
+            # Fail closed: possible unpushed/uncommitted work → no
+            # advisory; escalate to an operator instead.
+            advisory_withheld = ADVISORY_WITHHELD_UNPUSHED
+        else:
+            conditions: list[str] = []
+            if assessed == "terminal":
+                conditions.append(f"lane_status={lane_status} is terminal in the lane ledger")
+            else:
+                conditions.append(
+                    f"lease_age_seconds={lease_age_seconds} exceeds stale threshold "
+                    f"of {stale_hours}h"
+                )
+                conditions.append("no heartbeat newer than the stale window")
+            conditions.append("no worktree or local-work claim on the owner record")
+            advisory = {
+                "available": True,
+                "protocol": STALE_CLAIM_PROTOCOL,
+                "conditions_met": conditions,
+                "required_ledger_record": REQUIRED_LEDGER_RECORD,
+            }
+
+    return {
+        "owner_liveness": owner_liveness,
+        "stale_claim_advisory": advisory,
+        "advisory_withheld": advisory_withheld,
+    }
+
+
+def _print_liveness_summary(payload: dict[str, Any]) -> None:
+    """Single plain-text summary line for the liveness assessment."""
+
+    liveness = payload["owner_liveness"]
+    if payload.get("stale_claim_advisory"):
+        advisory = "available"
+    elif payload.get("advisory_withheld"):
+        advisory = f"withheld ({payload['advisory_withheld']})"
+    else:
+        advisory = "none"
+    lease = liveness["lease_age_seconds"]
+    print(
+        "owner_liveness: "
+        f"assessed={liveness['assessed']} "
+        f"lease_age_seconds={lease if lease is not None else '-'} "
+        f"lane_status={liveness['lane_status']} "
+        f"last_heartbeat_at={liveness['last_heartbeat_at'] or '-'} "
+        f"stale_claim_advisory={advisory}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
@@ -1293,6 +1552,38 @@ def _build_parser() -> argparse.ArgumentParser:
         default=HEARTBEATS_DEFAULT,
         help="Override path to .aragora/agent-bridge/heartbeats.json (used by tests).",
     )
+    p.add_argument(
+        "--stale-hours",
+        type=float,
+        default=STALE_HOURS_DEFAULT,
+        help=(
+            "Owner-lease age (hours) beyond which a lane with no fresher "
+            f"heartbeat is assessed stale (default {STALE_HOURS_DEFAULT})."
+        ),
+    )
+    p.add_argument(
+        "--liveness",
+        dest="liveness",
+        action="store_true",
+        default=True,
+        help="Include the advisory-only owner_liveness assessment (default).",
+    )
+    p.add_argument(
+        "--no-liveness",
+        dest="liveness",
+        action="store_false",
+        help="Suppress the owner_liveness assessment; output is byte-identical to pre-#8318.",
+    )
+    p.add_argument(
+        "--runs-glob",
+        default=LANE_RUNS_GLOB_DEFAULT,
+        help="Glob for lane-ledger directories (.aragora/run-*/lanes; used by tests).",
+    )
+    p.add_argument(
+        "--now",
+        default=None,
+        help="ISO-8601 'now' override for the liveness assessment (tests/replays).",
+    )
     return p
 
 
@@ -1344,10 +1635,25 @@ def main(argv: Sequence[str] | None = None) -> int:
         heartbeat_path=args.heartbeat_path,
     )
 
+    liveness_payload: dict[str, Any] | None = None
+    if args.liveness:
+        liveness_payload = assess_owner_liveness(
+            lane,
+            ledger_entry=find_lane_ledger_entry(lane, runs_glob=args.runs_glob),
+            heartbeat=info.latest_heartbeat,
+            now=_parse_iso_utc(args.now) if args.now else None,
+            stale_hours=args.stale_hours,
+        )
+
     if args.json:
-        print(json.dumps(dataclasses.asdict(info), indent=2, sort_keys=True))
+        payload = dataclasses.asdict(info)
+        if liveness_payload is not None:
+            payload.update(liveness_payload)
+        print(json.dumps(payload, indent=2, sort_keys=True))
     else:
         _print_human(info)
+        if liveness_payload is not None:
+            _print_liveness_summary(liveness_payload)
 
     return 0
 

--- a/tests/scripts/test_identify_lane_owner.py
+++ b/tests/scripts/test_identify_lane_owner.py
@@ -1137,3 +1137,388 @@ class TestEncodeCwdForClaude:
 
     def test_no_leading_slash_gets_dash(self) -> None:
         assert ilo._encode_cwd_for_claude("rel/path") == "-rel-path"
+
+
+# ---------------------------------------------------------------------------
+# Owner-lease liveness + stale-claim advisory (issue #8318)
+# ---------------------------------------------------------------------------
+
+
+LIVENESS_NOW = "2026-06-13T12:00:00Z"
+
+
+def _liveness_now() -> Any:
+    return ilo._parse_iso_utc(LIVENESS_NOW)
+
+
+def _hours_ago(hours: float) -> str:
+    from datetime import timedelta
+
+    return (_liveness_now() - timedelta(hours=hours)).strftime("%Y-%m-%dT%H:%M:%S") + "Z"
+
+
+def write_lane_ledger(tmp_path: Path, entries: list[dict[str, Any]]) -> str:
+    """Write lane-ledger fixtures in the lane_janitor layout; return runs glob."""
+
+    lanes_dir = tmp_path / ".aragora" / "run-20260613-liveness" / "lanes"
+    lanes_dir.mkdir(parents=True, exist_ok=True)
+    for i, entry in enumerate(entries):
+        name = str(entry.get("lane") or f"lane-{i}")
+        (lanes_dir / f"{name}.json").write_text(json.dumps(entry), encoding="utf-8")
+    return str(tmp_path / ".aragora" / "run-*" / "lanes")
+
+
+class TestOwnerLeaseLiveness:
+    def test_live_owner_no_advisory(self) -> None:
+        lane = {
+            "lane_id": "Q1-live",
+            "owner_session": "codex-q1",
+            "status": "active",
+            "branch": "codex/q1",
+            "updated_at": _hours_ago(1.0),
+        }
+        ledger = {"lane": "Q1-live", "status": "in_progress", "launched_at": _hours_ago(1.0)}
+        result = ilo.assess_owner_liveness(
+            lane, ledger_entry=ledger, heartbeat=None, now=_liveness_now()
+        )
+        liveness = result["owner_liveness"]
+        assert liveness["assessed"] == "live"
+        assert liveness["lane_status"] == "in_progress"
+        assert liveness["lease_age_seconds"] == 3600
+        assert liveness["last_heartbeat_at"] is None
+        assert result["stale_claim_advisory"] is None
+        assert result["advisory_withheld"] is None
+
+    def test_terminal_completed_lane_yields_advisory(self) -> None:
+        lane = {
+            "lane_id": "Q2-done",
+            "owner_session": "codex-q2",
+            "status": "active",
+            "branch": "codex/q2",
+            "updated_at": _hours_ago(7.0),
+        }
+        ledger = {"lane": "Q2-done", "status": "completed", "launched_at": _hours_ago(7.0)}
+        result = ilo.assess_owner_liveness(
+            lane, ledger_entry=ledger, heartbeat=None, now=_liveness_now()
+        )
+        assert result["owner_liveness"]["assessed"] == "terminal"
+        assert result["owner_liveness"]["lane_status"] == "completed"
+        advisory = result["stale_claim_advisory"]
+        assert advisory is not None
+        assert advisory["available"] is True
+        assert advisory["protocol"] == "stale-claim-override"
+        assert advisory["required_ledger_record"] == (
+            "overriding lane must write an override entry naming the stale lane id"
+        )
+        assert any("terminal" in c for c in advisory["conditions_met"])
+        assert result["advisory_withheld"] is None
+
+    @pytest.mark.parametrize("status", ["failed", "cancelled"])
+    def test_failed_and_cancelled_ledger_statuses_are_terminal(self, status: str) -> None:
+        lane = {"lane_id": "Q3", "owner_session": "x", "updated_at": _hours_ago(7.0)}
+        ledger = {"lane": "Q3", "status": status, "launched_at": _hours_ago(7.0)}
+        result = ilo.assess_owner_liveness(
+            lane, ledger_entry=ledger, heartbeat=None, now=_liveness_now()
+        )
+        assert result["owner_liveness"]["assessed"] == "terminal"
+        assert result["stale_claim_advisory"] is not None
+
+    def test_stale_in_progress_without_heartbeat_yields_advisory(self) -> None:
+        lane = {
+            "lane_id": "Q4-stale",
+            "owner_session": "codex-q4",
+            "status": "active",
+            "branch": "codex/q4",
+            "updated_at": _hours_ago(7.0),
+        }
+        ledger = {"lane": "Q4-stale", "status": "in_progress", "launched_at": _hours_ago(7.0)}
+        result = ilo.assess_owner_liveness(
+            lane, ledger_entry=ledger, heartbeat=None, now=_liveness_now()
+        )
+        liveness = result["owner_liveness"]
+        assert liveness["assessed"] == "stale"
+        assert liveness["lane_status"] == "in_progress"
+        assert liveness["lease_age_seconds"] == 7 * 3600
+        advisory = result["stale_claim_advisory"]
+        assert advisory is not None
+        assert advisory["available"] is True
+        assert any("lease_age_seconds" in c for c in advisory["conditions_met"])
+        assert any("no heartbeat" in c for c in advisory["conditions_met"])
+        assert result["advisory_withheld"] is None
+
+    def test_worktree_reference_withholds_advisory(self) -> None:
+        lane = {
+            "lane_id": "Q5-wt",
+            "owner_session": "codex-q5",
+            "status": "active",
+            "worktree": "/private/tmp/q5-worktree",
+            "updated_at": _hours_ago(7.0),
+        }
+        ledger = {"lane": "Q5-wt", "status": "in_progress", "launched_at": _hours_ago(7.0)}
+        result = ilo.assess_owner_liveness(
+            lane, ledger_entry=ledger, heartbeat=None, now=_liveness_now()
+        )
+        assert result["owner_liveness"]["assessed"] == "stale"
+        assert result["stale_claim_advisory"] is None
+        assert result["advisory_withheld"] == "possible_unpushed_work"
+
+    def test_uncommitted_work_claim_withholds_advisory(self) -> None:
+        lane = {"lane_id": "Q6-dirty", "owner_session": "codex-q6", "updated_at": _hours_ago(7.0)}
+        ledger = {
+            "lane": "Q6-dirty",
+            "status": "completed",
+            "launched_at": _hours_ago(7.0),
+            "uncommitted_changes": True,
+        }
+        result = ilo.assess_owner_liveness(
+            lane, ledger_entry=ledger, heartbeat=None, now=_liveness_now()
+        )
+        assert result["owner_liveness"]["assessed"] == "terminal"
+        assert result["stale_claim_advisory"] is None
+        assert result["advisory_withheld"] == "possible_unpushed_work"
+
+    def test_unknown_timestamps_never_produce_advisory(self) -> None:
+        lane = {"lane_id": "Q7-unknown", "owner_session": "codex-q7", "status": "active"}
+        result = ilo.assess_owner_liveness(
+            lane, ledger_entry=None, heartbeat=None, now=_liveness_now()
+        )
+        liveness = result["owner_liveness"]
+        assert liveness["assessed"] == "unknown"
+        assert liveness["lease_age_seconds"] is None
+        assert liveness["lane_status"] == "unknown"
+        assert liveness["last_heartbeat_at"] is None
+        assert result["stale_claim_advisory"] is None
+        assert result["advisory_withheld"] is None
+
+    def test_lease_just_under_stale_hours_is_live(self) -> None:
+        # 1 minute inside the default 6h window → live, no advisory.
+        from datetime import timedelta
+
+        updated = (_liveness_now() - timedelta(hours=6) + timedelta(minutes=1)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        lane = {"lane_id": "Q8-boundary", "owner_session": "codex-q8", "updated_at": updated}
+        ledger = {"lane": "Q8-boundary", "status": "in_progress", "launched_at": updated}
+        result = ilo.assess_owner_liveness(
+            lane, ledger_entry=ledger, heartbeat=None, now=_liveness_now()
+        )
+        assert result["owner_liveness"]["assessed"] == "live"
+        assert result["stale_claim_advisory"] is None
+        assert result["advisory_withheld"] is None
+
+    def test_fresh_heartbeat_keeps_old_lease_live(self) -> None:
+        lane = {"lane_id": "Q9-hb", "owner_session": "codex-q9", "updated_at": _hours_ago(7.0)}
+        heartbeat = {"last_seen_at": _hours_ago(0.1)}
+        result = ilo.assess_owner_liveness(
+            lane, ledger_entry=None, heartbeat=heartbeat, now=_liveness_now()
+        )
+        liveness = result["owner_liveness"]
+        assert liveness["assessed"] == "live"
+        assert liveness["last_heartbeat_at"] == _hours_ago(0.1)
+        assert result["stale_claim_advisory"] is None
+
+    def test_find_lane_ledger_entry_matches_by_branch_and_picks_newest(
+        self, tmp_path: Path
+    ) -> None:
+        runs_glob = write_lane_ledger(
+            tmp_path,
+            [
+                {
+                    "lane": "older-attempt",
+                    "branch": "codex/shared",
+                    "status": "dead",
+                    "launched_at": _hours_ago(30.0),
+                },
+                {
+                    "lane": "newer-attempt",
+                    "branch": "codex/shared",
+                    "status": "in_progress",
+                    "launched_at": _hours_ago(2.0),
+                },
+            ],
+        )
+        lane = {"lane_id": "not-in-ledger", "branch": "codex/shared"}
+        entry = ilo.find_lane_ledger_entry(lane, runs_glob=runs_glob)
+        assert entry is not None
+        assert entry["lane"] == "newer-attempt"
+        assert entry["status"] == "in_progress"
+
+    def test_find_lane_ledger_entry_missing_returns_none(self, tmp_path: Path) -> None:
+        runs_glob = write_lane_ledger(tmp_path, [])
+        assert ilo.find_lane_ledger_entry({"lane_id": "nope"}, runs_glob=runs_glob) is None
+
+
+class TestLivenessCLI:
+    def _cli_args(self, registry: Path, tmp_path: Path) -> list[str]:
+        return [
+            "--registry-path",
+            str(registry),
+            "--codex-sessions-root",
+            str(tmp_path / "no_codex"),
+            "--claude-projects-root",
+            str(tmp_path / "no_claude"),
+            "--factory-bg-path",
+            str(tmp_path / "no_factory.json"),
+            "--steering-inbox-root",
+            str(tmp_path / "no_steering"),
+            "--heartbeat-path",
+            str(tmp_path / "no_heartbeats.json"),
+        ]
+
+    def _stale_fixture(self, tmp_path: Path) -> tuple[Path, str]:
+        registry = write_lane_registry(
+            tmp_path,
+            [
+                {
+                    "lane_id": "Q379-stale-owner",
+                    "owner_session": "codex-q379",
+                    "source": "codex",
+                    "status": "active",
+                    "branch": "codex/q379",
+                    "pr_number": 7825,
+                    "updated_at": _hours_ago(7.0),
+                }
+            ],
+        )
+        runs_glob = write_lane_ledger(
+            tmp_path,
+            [
+                {
+                    "lane": "Q379-stale-owner",
+                    "branch": "codex/q379",
+                    "status": "in_progress",
+                    "launched_at": _hours_ago(7.0),
+                }
+            ],
+        )
+        return registry, runs_glob
+
+    def test_json_includes_owner_liveness_and_advisory(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        registry, runs_glob = self._stale_fixture(tmp_path)
+        rc = ilo.main(
+            [
+                "--lane-id",
+                "Q379-stale-owner",
+                "--json",
+                "--runs-glob",
+                runs_glob,
+                "--now",
+                LIVENESS_NOW,
+                *self._cli_args(registry, tmp_path),
+            ]
+        )
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        # Existing fields still present and unchanged.
+        assert data["lane_id"] == "Q379-stale-owner"
+        assert data["owner_session"] == "codex-q379"
+        assert data["pr_number"] == 7825
+        # New advisory-only enrichment.
+        assert data["owner_liveness"]["assessed"] == "stale"
+        assert data["owner_liveness"]["lane_status"] == "in_progress"
+        assert data["owner_liveness"]["lease_age_seconds"] == 7 * 3600
+        assert data["stale_claim_advisory"]["available"] is True
+        assert data["stale_claim_advisory"]["protocol"] == "stale-claim-override"
+        assert data["advisory_withheld"] is None
+
+    def test_custom_stale_hours_flag_keeps_owner_live(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        registry, runs_glob = self._stale_fixture(tmp_path)
+        rc = ilo.main(
+            [
+                "--lane-id",
+                "Q379-stale-owner",
+                "--json",
+                "--runs-glob",
+                runs_glob,
+                "--now",
+                LIVENESS_NOW,
+                "--stale-hours",
+                "8",
+                *self._cli_args(registry, tmp_path),
+            ]
+        )
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["owner_liveness"]["assessed"] == "live"
+        assert data["stale_claim_advisory"] is None
+
+    def test_no_liveness_output_is_byte_identical_to_legacy_schema(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        import dataclasses as _dataclasses
+
+        registry, runs_glob = self._stale_fixture(tmp_path)
+        rc = ilo.main(
+            [
+                "--lane-id",
+                "Q379-stale-owner",
+                "--json",
+                "--no-liveness",
+                "--runs-glob",
+                runs_glob,
+                "--now",
+                LIVENESS_NOW,
+                *self._cli_args(registry, tmp_path),
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        legacy_fields = {f.name for f in _dataclasses.fields(ilo.LaneOwnerInfo)}
+        assert set(data.keys()) == legacy_fields
+        # Byte-identical to the pre-#8318 serialization of the same info.
+        lane = ilo.find_lane(ilo.load_lane_records(registry), lane_id="Q379-stale-owner")
+        assert lane is not None
+        info = ilo.build_owner_info(
+            lane,
+            sessions_root=tmp_path / "no_codex",
+            projects_root=tmp_path / "no_claude",
+            bg_path=tmp_path / "no_factory.json",
+            steering_inbox_root=tmp_path / "no_steering",
+            heartbeat_path=tmp_path / "no_heartbeats.json",
+        )
+        expected = json.dumps(_dataclasses.asdict(info), indent=2, sort_keys=True) + "\n"
+        assert out == expected
+
+    def test_human_output_gains_single_summary_line(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        registry, runs_glob = self._stale_fixture(tmp_path)
+        rc = ilo.main(
+            [
+                "--lane-id",
+                "Q379-stale-owner",
+                "--runs-glob",
+                runs_glob,
+                "--now",
+                LIVENESS_NOW,
+                *self._cli_args(registry, tmp_path),
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        summary_lines = [line for line in out.splitlines() if line.startswith("owner_liveness: ")]
+        assert len(summary_lines) == 1
+        assert "assessed=stale" in summary_lines[0]
+        assert "stale_claim_advisory=available" in summary_lines[0]
+
+    def test_human_output_omits_summary_with_no_liveness(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        registry, runs_glob = self._stale_fixture(tmp_path)
+        rc = ilo.main(
+            [
+                "--lane-id",
+                "Q379-stale-owner",
+                "--no-liveness",
+                "--runs-glob",
+                runs_glob,
+                *self._cli_args(registry, tmp_path),
+            ]
+        )
+        assert rc == 0
+        assert "owner_liveness: " not in capsys.readouterr().out


### PR DESCRIPTION
## Problem (issue #8318 — ghost owners freeze exact-gated merges)

Owner locks have no liveness or TTL semantics: PR #7825 sat fully exact-gated (Tier 2, quorum satisfied, 63/63 green, `admin_squash_allowed=true`, `settle_one_pr` blockers `[]`) for many hours across multiple goal-loop cycles because `active_owner=true` pointed at lane `Q379-…` with no live process and no heartbeat. The conveyor correctly refuses to merge over an owner — but a dead owner becomes a permanent veto. The manual stale-claim protocol was exercised successfully on #8125 (June 11); this codifies it as machine-readable output.

**Conservative by design: visibility + advisory only.** Nothing in this PR changes a go/no-go decision by itself, and the advisory is withheld whenever unpushed work might exist.

## What this adds (all additive to `scripts/identify_lane_owner.py`; existing fields unchanged)

- **`owner_liveness`** in `--json` output: `lease_age_seconds`, `last_heartbeat_at`, `lane_status`, `assessed: live|stale|terminal|unknown`, `stale_threshold_hours`. Lease anchor is the **max** across the owner record's timestamps (`updated_at`, `last_heartbeat_at`, `last_mailbox_check_at`, `last_delivery_at`, `last_ack_at`, …), the matched `agent-bridge/heartbeats.json` entry, and the lane-ledger entry (`.aragora/run-*/lanes/*.json`) — conservative: any recent signal → `live`.
- **`stale_claim_advisory`** — present only when assessed `stale` (lease age > `--stale-hours`, default 6, no fresh heartbeat) or `terminal` (ledger status completed/failed/cancelled/dead) **and** there is zero indication of local work: any `worktree` reference or local-work claim field in the owner record withholds the advisory with `advisory_withheld: "possible_unpushed_work"` (fail closed to operator escalation). `unknown` **never** advises. When it fires, it carries `protocol: "stale-claim-override"`, the conditions met, and `required_ledger_record` — the overriding lane must write an override entry naming the stale lane id (the #8125 protocol, machine-readable).
- New flags: `--stale-hours`, `--liveness`/`--no-liveness` (default on; `--no-liveness` output is **byte-identical** to the pre-change schema — pinned by a serialized-bytes test), `--runs-glob`, `--now` (replay/test override). Plain-text output gains exactly one `owner_liveness:` summary line.

## What this enables downstream

Conveyor prompts can move from "owner present → skip forever" to "owner present → consult `owner_liveness`; if advisory available, record the override in the ledger and proceed" — with the override decision still belonging to the consuming lane/operator, never to this lookup. `scripts/agent_bridge.py` deliberately untouched (other PRs own it).

## Validation

- Tests: baseline 59 passed → **76 passed** (17 new: live/terminal/failed/cancelled/stale assessments; worktree-reference and uncommitted-claim withholding; unknown-never-advises; just-under-threshold boundary; fresh-heartbeat rescue; ledger lookups; CLI tests incl. byte-identical `--no-liveness` and the single text summary line).
- `ruff check` + `ruff format --check` clean at the CI-pinned ruff version; end-to-end CLI smoke with a stale `in_progress` fixture produces the expected assessment + advisory.

Fixes #8318

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jfJj5gb9VoLs6VBMnzhrP

---
_Generated by [Claude Code](https://claude.ai/code/session_018jfJj5gb9VoLs6VBMnzhrP)_