### PR TITLE
fix(steering): mark successful mailbox reads

### DIFF
--- a/scripts/read_operator_steering.py
+++ b/scripts/read_operator_steering.py
@@ -300,6 +300,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
 
     out = {
+        "ok": True,
         "owner_session": owner_session,
         "resolved_via": resolved_via,
         "lane_id": lane.get("lane_id") if isinstance(lane, dict) else None,

--- a/tests/scripts/test_read_operator_steering.py
+++ b/tests/scripts/test_read_operator_steering.py
@@ -71,6 +71,7 @@ def test_reads_only_selected_owner_and_writes_bound_receipt(tmp_path: Path, caps
 
     assert rc == 0
     out = json.loads(capsys.readouterr().out)
+    assert out["ok"] is True
     assert out["owner_session"] == "codex-selected"
     assert out["message_count"] == 1
     assert out["receipt_count"] == 1
@@ -197,6 +198,7 @@ def test_resolves_owner_by_lane_id(tmp_path: Path, capsys: Any) -> None:
 
     assert rc == 0
     out = json.loads(capsys.readouterr().out)
+    assert out["ok"] is True
     assert out["owner_session"] == "codex-lane-owner"
     assert out["resolved_via"] == "lane-id"
     assert out["message_count"] == 1


### PR DESCRIPTION
Adds ok=true to successful read_operator_steering.py JSON responses so automation callers can treat success and selector misses symmetrically.\n\nValidation:\n- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_read_operator_steering.py -q\n- /Users/armand/.pyenv/versions/3.11.11/bin/python -m py_compile scripts/read_operator_steering.py tests/scripts/test_read_operator_steering.py\n- ruff check scripts/read_operator_steering.py tests/scripts/test_read_operator_steering.py\n- ruff format --check scripts/read_operator_steering.py tests/scripts/test_read_operator_steering.py\n- bash scripts/automation_pr_preflight.sh origin/main HEAD\n- dogfood: python scripts/read_operator_steering.py --lane-id Q496-primary-read-steering-success-ok --no-receipt --json emitted ok=true