### PR TITLE
fix(agent-bridge): classify benchmark truth renderer process

### DIFF
--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -1117,6 +1117,8 @@ def _classify_agent_process(command: str) -> str | None:
         return None
     if "codex_worktree_value_inventory.py" in lowered:
         return "worktree_inventory"
+    if "scripts/render_benchmark_truth_status.py" in lowered:
+        return "benchmark_truth"
     if "run_boss_cycle.sh" in lowered:
         return "boss_cycle"
     if (
@@ -1146,6 +1148,7 @@ def _classify_agent_process(command: str) -> str | None:
 
 def _process_summary_for_role(role: str) -> str:
     summaries = {
+        "benchmark_truth": "benchmark-truth status and latest-pointer guard process",
         "boss_cycle": "boss-loop control process",
         "claude_code": "Claude Code local session process",
         "codex_app_server": "Codex Desktop app server process",

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -1647,22 +1647,28 @@ def test_collect_agent_process_census_redacts_commands_and_counts_roles() -> Non
             " 102 00:03:04 python3 scripts/codex_worktree_value_inventory.py --write-ledger",
             " 103 00:00:05 node /opt/homebrew/bin/codex --yolo",
             " 104 00:00:01 python3 scripts/agent_bridge.py processes --json",
+            " 105 00:00:07 python3 scripts/render_benchmark_truth_status.py --output /tmp/status.md",
             "bad-line",
         ]
     )
 
     assert payload["ok"] is True
-    assert payload["total"] == 3
+    assert payload["total"] == 4
     assert payload["by_role"] == {
+        "benchmark_truth": 1,
         "boss_cycle": 1,
         "codex_cli": 1,
         "worktree_inventory": 1,
     }
     assert [record["role"] for record in payload["records"]] == [
+        "benchmark_truth",
         "boss_cycle",
         "codex_cli",
         "worktree_inventory",
     ]
+    assert payload["records"][0]["summary"] == (
+        "benchmark-truth status and latest-pointer guard process"
+    )
     assert all("command" not in record for record in payload["records"])
     assert "sk-secret" not in json.dumps(payload)
 


### PR DESCRIPTION
## Summary
- classify render_benchmark_truth_status.py processes as benchmark_truth in agent_bridge
- cover the process census role count, redacted records, and summary text

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/scripts/test_agent_bridge.py::test_collect_agent_process_census_redacts_commands_and_counts_roles -q
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/scripts/test_agent_bridge.py -q
- python3 -m py_compile scripts/agent_bridge.py tests/scripts/test_agent_bridge.py
- python3 -m ruff check scripts/agent_bridge.py tests/scripts/test_agent_bridge.py
- python3 -m ruff format --check scripts/agent_bridge.py tests/scripts/test_agent_bridge.py
- git diff --check && git diff --check origin/main...HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD