### PR TITLE
chore(tiers): regenerate module_tiers.yaml — un-red the check gate repo-wide

### DIFF
--- a/aragora/module_tiers.yaml
+++ b/aragora/module_tiers.yaml
@@ -26,9 +26,9 @@ thresholds:
 summary:
   core: 21
   integrated: 90
-  experimental: 28
+  experimental: 29
   deprecated: 2
-  total: 141
+  total: 142
 
 modules:
   # --- core (21) ---
@@ -36,7 +36,7 @@ modules:
     tier: core
     py_files: 83
     importer_count: 184
-    test_file_count: 163
+    test_file_count: 164
     override_reason: "Agent factory, 43 registered types"
   - name: billing
     tier: core
@@ -45,9 +45,9 @@ modules:
     test_file_count: 118
   - name: cli
     tier: core
-    py_files: 114
+    py_files: 117
     importer_count: 6
-    test_file_count: 140
+    test_file_count: 144
     override_reason: "aragora CLI — primary developer surface"
   - name: config
     tier: core
@@ -81,13 +81,13 @@ modules:
   - name: events
     tier: core
     py_files: 32
-    importer_count: 124
+    importer_count: 123
     test_file_count: 51
   - name: gauntlet
     tier: core
-    py_files: 36
-    importer_count: 65
-    test_file_count: 102
+    py_files: 37
+    importer_count: 66
+    test_file_count: 103
   - name: knowledge
     tier: core
     py_files: 177
@@ -134,12 +134,12 @@ modules:
     tier: core
     py_files: 13
     importer_count: 154
-    test_file_count: 96
+    test_file_count: 97
   - name: server
     tier: core
     py_files: 1115
     importer_count: 180
-    test_file_count: 1881
+    test_file_count: 1886
     override_reason: "FastAPI server + 3K+ API operations"
   - name: storage
     tier: core
@@ -484,7 +484,7 @@ modules:
     tier: integrated
     py_files: 31
     importer_count: 39
-    test_file_count: 40
+    test_file_count: 41
   - name: routing
     tier: integrated
     py_files: 13
@@ -537,9 +537,9 @@ modules:
     test_file_count: 5
   - name: swarm
     tier: integrated
-    py_files: 105
+    py_files: 108
     importer_count: 32
-    test_file_count: 166
+    test_file_count: 172
   - name: templates
     tier: integrated
     py_files: 1
@@ -601,7 +601,7 @@ modules:
     importer_count: 16
     test_file_count: 11
 
-  # --- experimental (28) ---
+  # --- experimental (29) ---
   - name: advocates
     tier: experimental
     py_files: 2
@@ -722,6 +722,11 @@ modules:
     py_files: 3
     importer_count: 1
     test_file_count: 3
+  - name: trail
+    tier: experimental
+    py_files: 3
+    importer_count: 0
+    test_file_count: 4
   - name: transcription
     tier: experimental
     py_files: 3


### PR DESCRIPTION
## Problem (fourth ambient main-red drift)

The `check` job runs `python3 scripts/regenerate_module_tiers.py` and fails on any resulting diff. `aragora/module_tiers.yaml` drifted stale on main — the structural-excellence batch (#8311 and siblings) added modules without regenerating it — so `check` was failing **repo-wide on every PR** (observed on #8338, whose own diff only touches `scripts/agent_bridge.py` and cannot affect module tiers). Same generated-artifact-guard class as #8330 (handle_post), #8348 (docs-site), and #8342.

## Fix

Commit the canonical regeneration output: `python3 scripts/regenerate_module_tiers.py` → 142 modules, +20/−15. No source/code change; this only refreshes the tracked generated file to match the tree.

## Validation

- Re-running `regenerate_module_tiers.py` after this commit produces no further diff (the check's success condition).
- Diff is confined to `aragora/module_tiers.yaml`.

Tier ≤2, generated-artifact only, no governance surfaces. Clears `check` for all open PRs once on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jfJj5gb9VoLs6VBMnzhrP

---
_Generated by [Claude Code](https://claude.ai/code/session_018jfJj5gb9VoLs6VBMnzhrP)_