### PR TITLE
fix(agent-bridge): classify benchmark truth renderer processes

### DIFF
--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -1124,6 +1124,8 @@ def _classify_agent_process(command: str) -> str | None:
         or "run_codex_automation_publisher.py" in lowered
     ):
         return "publisher"
+    if "render_benchmark_truth_status.py" in lowered:
+        return "benchmark_truth"
     if "multi_agent_dialog.py" in lowered:
         return "multi_agent_dialog"
     if (
@@ -1147,6 +1149,7 @@ def _classify_agent_process(command: str) -> str | None:
 def _process_summary_for_role(role: str) -> str:
     summaries = {
         "boss_cycle": "boss-loop control process",
+        "benchmark_truth": "benchmark-truth status and latest-pointer guard process",
         "claude_code": "Claude Code local session process",
         "codex_app_server": "Codex Desktop app server process",
         "codex_cli": "Codex CLI process",


### PR DESCRIPTION
## Summary
- Classifies `render_benchmark_truth_status.py` processes as `benchmark_truth` in `agent_bridge.py` process summaries.
- Adds the corresponding human-readable process summary string.

## Harvest evidence
- Branch: `codex/swarm-01659fc4-micro-3`
- Head: `16b21d95ceeeb69f26ad5a641d39c7f3654bf443`
- Source worktree: `/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-01659fc4-micro-3`
- Inventory class before publish: `unique_unharvested`
- Owner: unowned; no operator-steering lane matched
- Prior representation: no existing PR, no outbox/receipt hit for branch/head
- Merge-tree against current `origin/main`: clean

## Validation
- `python3 -m py_compile scripts/agent_bridge.py`
- `git diff --check origin/main...HEAD -- scripts/agent_bridge.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- `python3 -m pytest tests/scripts/test_agent_bridge.py` (76 passed)

Draft harvest only. Do not mark ready or merge in the harvest cycle.
