### PR TITLE
[Tier-4 parked] ci: wire import-contract + file-size + cycle ratchets into lint + pre-commit

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -190,6 +190,50 @@ jobs:
           fi
           echo "Lint passed (or skipped — no Python-relevant changes)"
 
+  structural-ratchets:
+    # PARKED Tier-4 staging (epic #8257, P0): advisory wiring of the three
+    # structural-excellence ratchets so the operator can review and optionally
+    # promote them to a required check (branch protection) or fold the steps
+    # into lint-run. Each ratchet is shrink-only against a frozen baseline and
+    # fails ONLY on a NEW layer violation, a NEW >2,000-line aragora file, or a
+    # NEW mutual import cycle.
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    name: Structural Excellence Ratchets
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: ./.github/actions/setup-python-safe
+        with:
+          python-version: "3.11"
+
+      - name: Install ratchet dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install import-linter grimp
+
+      - name: Import-linter layer contracts (shrink-only baseline)
+        run: python3 scripts/ci/check_import_contracts.py
+
+      - name: Max-file-size ratchet (no new >2,000-line aragora file)
+        run: python3 scripts/ci/check_file_sizes.py
+
+      - name: Mutual import-cycle ratchet (shrink-only)
+        run: python3 scripts/ci/measure_import_graph.py --check
+
+      - name: Ratchet repro hint
+        if: failure()
+        run: |
+          echo "Reproduce locally:"
+          echo "  python3 scripts/ci/check_import_contracts.py"
+          echo "  python3 scripts/ci/check_file_sizes.py"
+          echo "  python3 scripts/ci/measure_import_graph.py --check"
+
   connector-exception-hygiene:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -190,6 +190,41 @@ repos:
         # Run on manual stage to avoid slowing down commits
         stages: [manual]
 
+  # Structural-excellence ratchets (epic #8257, P0). Shrink-only baselines: a
+  # NEW layer violation, a NEW >2,000-line aragora file, or a NEW mutual import
+  # cycle fails the hook. Scoped to aragora/**.py changes and run on pre-push
+  # (they build the full import graph, too slow for every commit). PARKED Tier-4
+  # staging: the operator reviews this draft before it merges.
+  - repo: local
+    hooks:
+      - id: import-contracts-ratchet
+        name: Import-linter layer contracts (shrink-only baseline)
+        entry: python scripts/ci/check_import_contracts.py
+        language: python
+        additional_dependencies:
+          - import-linter
+          - grimp
+        pass_filenames: false
+        files: ^aragora/.*\.py$
+        stages: [pre-push]
+      - id: import-cycles-ratchet
+        name: Mutual import-cycle ratchet (shrink-only)
+        entry: python scripts/ci/measure_import_graph.py --check
+        language: python
+        additional_dependencies:
+          - import-linter
+          - grimp
+        pass_filenames: false
+        files: ^aragora/.*\.py$
+        stages: [pre-push]
+      - id: file-size-ratchet
+        name: Max-file-size ratchet (no new >2,000-line aragora file)
+        entry: python3 scripts/ci/check_file_sizes.py
+        language: system
+        pass_filenames: false
+        files: ^aragora/.*\.py$
+        stages: [pre-push]
+
 # CI-only configuration
 # These checks run in CI but are too slow for every commit
 ci:


### PR DESCRIPTION
## PARKED Tier-4 draft — do not merge autonomously (operator settlement required)

**Source:** epic #8257 (Structural Excellence), milestone **P0 ratchets**, assertion **VAL-P0-009**.
**Tier:** 4 (touches `.github/workflows/`). This is a **parked draft**: it stays a draft, is labeled `operator-review-required`, and is **never** flipped ready or merged by automation. The operator reviews and settles it.

## What this wires

Wires the three already-merged P0 checker scripts (which live on `main` and run standalone today) into CI so the operator can enforce them:

| Ratchet | Script | Model |
|---|---|---|
| Import-linter layer contracts | `scripts/ci/check_import_contracts.py` | shrink-only baseline, fail-on-new |
| Max-file-size (>2,000 lines) | `scripts/ci/check_file_sizes.py` | shrink-only baseline, fail-on-new |
| Mutual import cycles | `scripts/ci/measure_import_graph.py --check` | shrink-only baseline, fail-on-growth |

> VAL-P0-009 requires only `check_import_contracts` + `check_file_sizes`; the mutual-cycles ratchet is additive (all three P0 checks staged together).

## Changes (2 files, 79 insertions)

- **`.github/workflows/lint.yml`** — new advisory `structural-ratchets` job (`ubuntu-latest`, gated on `needs.changes.outputs.python == 'true'`, mirroring `lint-run`). Installs `import-linter grimp`, then runs all three ratchets.
- **`.pre-commit-config.yaml`** — three `pre-push` local hooks scoped to `^aragora/.*\.py$` for the same ratchets (import/cycle hooks use isolated `language: python` envs with `import-linter`/`grimp`; the file-size hook is stdlib-only `language: system`).

Each ratchet is **shrink-only** against a frozen baseline: it fails ONLY on a NEW layer violation, a NEW >2,000-line file, or a NEW mutual cycle — never on the grandfathered baseline.

## Operator notes

- The new `structural-ratchets` job is **advisory** (not in branch protection). To enforce it, the operator adds it to the required-checks list (branch protection) or folds the steps into the required `lint-run` job.
- Self-hosted checkout-integrity policy does not apply (job runs on `ubuntu-latest`); workflow `pip install` policy is satisfied (`python3 -m pip install`).

## Validation performed locally (in an isolated worktree off `origin/main`)

```
python3 -c "import yaml; ... assert 'structural-ratchets' in jobs"        # lint.yml parses; job present (runs-on: ubuntu-latest)
python3 -c "import yaml; ... ratchet hook ids present"                     # .pre-commit-config.yaml parses; 3 hooks present
python3 scripts/check_workflow_pip_install_policy.py --repo-root .         # -> Workflow pip policy check passed (exit 0)
python3 scripts/check_workflow_checkout_integrity_policy.py --repo-root .  # -> checkout-integrity policy check passed (exit 0)
make lint                                                                  # -> All checks passed! (exit 0)
bash scripts/automation_pr_preflight.sh origin/main HEAD                   # -> preflight: ok (exit 0)
```

## Risks

Low. Additive CI wiring only; no Python/source behavior changes. The job is advisory until the operator promotes it, so merging cannot break the required gate. Branch base is a clean ancestor of `origin/main` (2-file diff).

This PR is exempt from the normal merge flow: no evidence collection, no ready flip.
