### PR TITLE
fix(steering): mark successful reads as ok

### DIFF
--- a/scripts/read_operator_steering.py
+++ b/scripts/read_operator_steering.py
@@ -300,6 +300,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
 
     out = {
+        "ok": True,
         "owner_session": owner_session,
         "resolved_via": resolved_via,
         "lane_id": lane.get("lane_id") if isinstance(lane, dict) else None,


### PR DESCRIPTION
## Summary
- Adds `ok: true` to successful JSON output from `scripts/read_operator_steering.py`.
- This makes success and selector-miss/error responses machine-distinguishable with a stable `ok` field.

## Harvest evidence
- Branch: `codex/swarm-01659fc4-micro-4`
- Head: `78fe2386fdd148c7cb6b213d6a981cbd5fb2fdbf`
- Source worktree: `/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-01659fc4-micro-4`
- Inventory class before publish: `unique_unharvested`
- Owner: unowned; no operator-steering lane matched
- Prior representation: no existing PR, no outbox/receipt hit for branch/head
- Merge-tree against current `origin/main`: clean

## Validation
- `python3 -m py_compile scripts/read_operator_steering.py`
- `git diff --check origin/main...HEAD -- scripts/read_operator_steering.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- `python3 -m pytest tests/scripts/test_read_operator_steering.py` (7 passed)
- Success-path smoke confirmed `ok: true` in JSON output.

Note: a broader steering group run included pre-existing expectation drift in `tests/scripts/test_agent_bridge_steering.py` around unresolved-message keys; the dedicated reader surface above is green.

Draft harvest only. Do not mark ready or merge in the harvest cycle.
