### PR TITLE
feat(arbiter): env-gated funnel autopilot wiring (ready-triage + scan-window + backlog-gate)

### DIFF
--- a/scripts/run_merge_arbiter.sh
+++ b/scripts/run_merge_arbiter.sh
@@ -12,6 +12,31 @@ PYTHON_BIN="$(resolve_aragora_python 'import pydantic; import aragora.cli.comman
 
 cd "${REPO_ROOT}"
 
+# Opt-in funnel autopilot: draft-to-ready promotion (throughput lever 0).
+# Runs BEFORE the auto-evidence step so freshly-promoted PRs get evidenced the
+# same pass. Best-effort: a triage failure must never abort the arbiter.
+# Default off until the operator flips ARAGORA_READY_TRIAGE=1 (mirrors the
+# ARAGORA_AUTO_EVIDENCE pattern below). Honors the wrapper's cwd convention
+# (cd REPO_ROOT above), so pr_ready_triage resolves the repo from gh defaults
+# exactly like auto_evidence_cycle does.
+if [[ "${ARAGORA_READY_TRIAGE:-0}" == "1" ]]; then
+    echo "Running bounded draft-to-ready triage (apply mode)..."
+    "${PYTHON_BIN}" scripts/pr_ready_triage.py --apply \
+        || echo "Ready-triage reported failures (non-fatal for the arbiter)." >&2
+fi
+
+# Opt-in backlog backpressure refresh (throughput lever 2). When enabled,
+# refreshes .aragora/backpressure.json each pass so writer lanes can consult
+# the latest generate/shepherd signal. The gate is read-only except for its
+# own signal file (no --apply flag exists; it writes the signal by default).
+# Best-effort: never blocks the arbiter. Default off until the operator flips
+# ARAGORA_BACKLOG_GATE=1.
+if [[ "${ARAGORA_BACKLOG_GATE:-0}" == "1" ]]; then
+    echo "Refreshing backlog backpressure signal..."
+    "${PYTHON_BIN}" scripts/backlog_gate.py --quiet \
+        || echo "Backlog gate reported failures (non-fatal for the arbiter)." >&2
+fi
+
 # Opt-in bounded auto-evidence cycle (throughput lever 1, run-20260610 c07b).
 # Produces lint-validated two-family model-review evidence for ready Tier 0-2
 # PRs missing counted evidence, then re-runs stale quorum checks. Best-effort:
@@ -40,7 +65,9 @@ if [[ "${ARAGORA_AUTO_EVIDENCE:-0}" == "1" ]]; then
             fi
             unset tok
         fi
-        exec "${PYTHON_BIN}" scripts/auto_evidence_cycle.py --apply
+        # --max-scan 40 mitigates scan starvation (harmless even after the
+        # #8316 fix lands; it only widens the per-pass probe window).
+        exec "${PYTHON_BIN}" scripts/auto_evidence_cycle.py --apply --max-scan 40
     ) || echo "Auto-evidence cycle reported failures (non-fatal for the arbiter)." >&2
 fi
 


### PR DESCRIPTION
## What

Wires the funnel-transport scripts (merged in #8312) into the merge-arbiter wrapper, **env-gated and default-off**, mirroring the existing `ARAGORA_AUTO_EVIDENCE` block. The wrapper becomes *capable* of running the funnel autopilot; the operator activates by setting the env var(s) and reloading the daemon. With the env vars unset, arbiter behavior is **byte-identical** to before.

`scripts/run_merge_arbiter.sh` (+28/−1):

1. **`ARAGORA_READY_TRIAGE=1`** → runs `pr_ready_triage.py --apply` once per pass, **before** auto-evidence (so freshly-promoted drafts get evidenced the same pass). Non-fatal.
2. **`--max-scan 40`** added to the existing `auto_evidence_cycle.py --apply` call (scan-window mitigation; complementary to the #8316 fix). Only active inside the already-gated `ARAGORA_AUTO_EVIDENCE` block.
3. **`ARAGORA_BACKLOG_GATE=1`** → runs `backlog_gate.py --quiet` to refresh `.aragora/backpressure.json` each pass for writer-lane admission. Non-fatal. (Note: `backlog_gate.py` is read-only except its signal file — it has no `--apply`, so `--quiet` is correct.)

`stale_pr_janitor.py` deliberately **not** wired into the hot loop — better as a separate scheduled job.

## Operator activation (after merge + `git pull`)

Set the desired lever(s) in the arbiter daemon's environment and reload it:
- `ARAGORA_READY_TRIAGE=1` — promote eligible drafts each pass
- `ARAGORA_AUTO_EVIDENCE=1` (already exists) — now scans 40 deep
- `ARAGORA_BACKLOG_GATE=1` — refresh the backpressure signal

All three are independent and best-effort (failure logs to stderr, never aborts the arbiter).

## Validation

- `bash -n scripts/run_merge_arbiter.sh` → OK. shellcheck unavailable in the build env; conformed manually to the existing block's quoting/non-fatal idioms.
- Default-off contract verified: both new blocks guard on `[[ "${VAR:-0}" == "1" ]]`; unset → short-circuit → byte-identical behavior.

Tier ≤2 (local automation wrapper; not a workflow, not review_queue.py, not a protected file). Part of the conveyor-hardening epic #8344.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jfJj5gb9VoLs6VBMnzhrP

---
_Generated by [Claude Code](https://claude.ai/code/session_018jfJj5gb9VoLs6VBMnzhrP)_