### PR TITLE
fix(automation): auto-evidence selection — surface transport_blocked, end scan-window starvation (#8316)

### DIFF
--- a/scripts/auto_evidence_cycle.py
+++ b/scripts/auto_evidence_cycle.py
@@ -29,7 +29,8 @@ Safety model (mirrors ``quorum_rerun_reconciler.py``):
   (default 15), ``--budget-seconds`` wall clock (default 1800).
 - Identical-error breaker: 3 consecutive identical collect failures abort the
   cycle (exit 2) — a systemic fault (CLI missing, auth broken) must not burn
-  the whole budget.
+  the whole budget. A run of consecutive transport-blocked merge-packet probes
+  (GitHub/GraphQL down, auth broken) feeds the same breaker.
 - Never-post-on-lint-fail is enforced *inside* collect-evidence; this wrapper
   additionally requires >=2 posted families before counting a PR as done.
 - Tier gating is enforced twice: by this wrapper's selection and again by
@@ -38,8 +39,10 @@ Safety model (mirrors ``quorum_rerun_reconciler.py``):
   ``ARAGORA_SECRETS_STRICT=false`` and ``ARAGORA_USE_SECRETS_MANAGER=false``
   forced, because API reviewer construction under strict MFA-gated AWS dies on
   an interactive MFA prompt EOF (Lane V, run-20260609).
-- Fail-closed exits: 0 clean (including empty plan), 1 any failure,
-  2 breaker tripped.
+- Fail-closed exits: 0 clean (genuinely empty plan, no transport drops), 1 any
+  failure, 2 breaker tripped, 3 INDETERMINATE — candidates were dropped because
+  a merge-packet probe could not see them (transport_blocked / fetch failure)
+  and nothing was posted, so an empty plan does NOT mean the queue is clear.
 
 Opt-in wiring: ``scripts/run_merge_arbiter.sh`` runs this before the arbiter
 when ``ARAGORA_AUTO_EVIDENCE=1`` (default off, non-fatal for the arbiter).
@@ -96,6 +99,13 @@ def _load_dogfood_module() -> Any:
 EXIT_OK = 0
 EXIT_FAILURES = 1
 EXIT_BREAKER = 2
+EXIT_INDETERMINATE = 3
+
+# Sentinel status for a packet probe that could not see the PR (GitHub/GraphQL
+# transport hiccup, subprocess failure, timeout, or unparseable output). This is
+# INDETERMINATE — not "selectable" and not "genuinely clear" — so the operator
+# can tell "no work" from "couldn't see the work".
+TRANSPORT_BLOCKED_STATUS = "transport_blocked"
 
 
 def _sanitized_env() -> dict[str, str]:
@@ -135,7 +145,15 @@ def latest_quorum_conclusion(pr_row: dict[str, Any]) -> str:
 
 
 def stage1_candidates(prs: list[dict[str, Any]]) -> list[int]:
-    """Ready (non-draft) PRs whose latest quorum check is not SUCCESS, oldest first."""
+    """Ready (non-draft) PRs whose latest quorum check is not SUCCESS, newest first.
+
+    Newest-first (#8316): the oldest-first ordering meant the low-numbered tail
+    of permanently auto-INELIGIBLE PRs (Tier 3/4, human-settlement-required)
+    consumed the entire ``--max-scan`` probe budget every run, so fresh ready
+    Tier-0-2 PRs at the high end were never probed. Probing the freshest PRs
+    first guarantees they are always reached; stage 2 also no longer lets
+    ineligible candidates consume the eligible-scan budget.
+    """
     out: list[int] = []
     for pr in prs:
         if not isinstance(pr, dict) or pr.get("isDraft"):
@@ -147,29 +165,63 @@ def stage1_candidates(prs: list[dict[str, Any]]) -> list[int]:
         if latest_quorum_conclusion(pr) == "SUCCESS":
             continue
         out.append(number)
-    return sorted(out)
+    return sorted(out, reverse=True)
+
+
+def is_transport_blocked(entry: dict[str, Any]) -> bool:
+    """Whether a packet probe came back INDETERMINATE (could not see the PR).
+
+    A transport-blocked probe is neither selectable nor a clean "no work"
+    signal: the GitHub/GraphQL hop, the subprocess, or the parser failed, so the
+    PR's real selectability is unknown. ``default_fetch_packet`` synthesizes this
+    envelope for any fetch failure/exception so the caller never silently treats
+    a hiccup as an empty queue. The canonical CLI marks the same condition with
+    ``status="transport_blocked"`` / ``transport_blocked: true`` (see
+    ``aragora/cli/commands/review_queue_transport.py``).
+    """
+    if not entry:
+        return False
+    if entry.get("transport_blocked"):
+        return True
+    return str(entry.get("status") or "").strip().lower() == TRANSPORT_BLOCKED_STATUS
+
+
+def rejection_reason(entry: dict[str, Any]) -> str | None:
+    """Reason a packet entry is *not* selectable, or ``None`` if it is selectable.
+
+    Returns a stable, low-cardinality reason string so the cycle can surface
+    ``rejected_by_reason`` counts and distinguish an empty plan (everything
+    rejected) from an exhausted scan window (budget ran out before reaching a
+    selectable PR). Callers must treat transport-blocked entries as INDETERMINATE
+    *before* asking for a rejection reason; this function assumes a real packet.
+    """
+    if not entry:
+        return "empty_packet"
+    if str(entry.get("status") or "").strip().lower() != SELECTABLE_STATUS:
+        return "wrong_status"
+    try:
+        tier = int(entry.get("tier"))
+    except (TypeError, ValueError):
+        return "unknown_tier"  # fail safe, never auto-postable anyway
+    if tier not in AUTO_POSTABLE_TIERS:
+        return "wrong_tier"
+    if entry.get("requires_human_risk_settlement"):
+        return "human_settlement_required"
+    if entry.get("unresolved_dissent"):
+        return "unresolved_dissent"
+    families = entry.get("counted_model_families")
+    if families is None:
+        families = entry.get("counted_reviewer_ids") or []
+    if len(families) >= REQUIRED_FAMILIES:
+        return "quorum_satisfied"
+    return None
 
 
 def needs_evidence(entry: dict[str, Any]) -> bool:
     """Whether a merge-packet entry is selectable for bounded auto-evidence."""
-    if not entry:
+    if is_transport_blocked(entry):
         return False
-    if str(entry.get("status") or "").strip().lower() != SELECTABLE_STATUS:
-        return False
-    try:
-        tier = int(entry.get("tier"))
-    except (TypeError, ValueError):
-        return False  # unknown tier: fail safe, never auto-postable anyway
-    if tier not in AUTO_POSTABLE_TIERS:
-        return False
-    if entry.get("requires_human_risk_settlement"):
-        return False
-    if entry.get("unresolved_dissent"):
-        return False
-    families = entry.get("counted_model_families")
-    if families is None:
-        families = entry.get("counted_reviewer_ids") or []
-    return len(families) < REQUIRED_FAMILIES
+    return rejection_reason(entry) is None
 
 
 def needs_dogfood(entry: dict[str, Any]) -> bool:
@@ -401,8 +453,31 @@ def default_list_prs(repo: str) -> list[dict[str, Any]]:
     raise RuntimeError(f"gh pr list failed for {repo} (heavy and light listings)")
 
 
+def _transport_blocked_packet(pr: int, error: str) -> dict[str, Any]:
+    """Synthesize an INDETERMINATE packet for a probe that could not see the PR.
+
+    Any fetch failure (subprocess error, non-zero exit, timeout, unparseable
+    output, or an explicit transport-blocked CLI envelope) becomes this shape so
+    the cycle counts the PR in ``transport_blocked_prs`` rather than silently
+    treating the hiccup as a clean empty queue.
+    """
+    return {
+        "pr_number": pr,
+        "status": TRANSPORT_BLOCKED_STATUS,
+        "transport_blocked": True,
+        "error": str(error or "")[:300],
+    }
+
+
 def default_fetch_packet(repo: str, pr: int) -> dict[str, Any]:
-    """Canonical per-PR probe: ``review-queue merge-packet --pr N --json``."""
+    """Canonical per-PR probe: ``review-queue merge-packet --pr N --json``.
+
+    A clean structural "not selectable" packet is returned as-is (possibly
+    ``{}``). Any *failure* to see the PR — subprocess error, timeout, non-zero
+    exit, unparseable output, or an explicit ``transport_blocked`` envelope — is
+    surfaced as an INDETERMINATE transport-blocked packet, never as ``{}``; the
+    operator must be able to tell "no work" from "couldn't see the work".
+    """
     try:
         proc = subprocess.run(
             [
@@ -423,13 +498,27 @@ def default_fetch_packet(repo: str, pr: int) -> dict[str, Any]:
             env=_sanitized_env(),
         )
     except subprocess.TimeoutExpired:
-        return {}
+        return _transport_blocked_packet(
+            pr, f"merge-packet timed out after {PACKET_TIMEOUT_SECONDS}s"
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return _transport_blocked_packet(pr, f"merge-packet subprocess error: {exc}")
     if proc.returncode != 0 or not proc.stdout.strip():
-        return {}
+        return _transport_blocked_packet(
+            pr,
+            (proc.stderr or proc.stdout or f"merge-packet exit {proc.returncode}").strip(),
+        )
     try:
         payload = json.loads(proc.stdout)
     except json.JSONDecodeError:
-        return {}
+        return _transport_blocked_packet(pr, "unparseable merge-packet output")
+    # An explicit transport-blocked envelope carries no matching entry, so detect
+    # it at the envelope level before the per-PR entry scan drops it.
+    if isinstance(payload, dict) and (
+        payload.get("transport_blocked")
+        or str(payload.get("status") or "").strip().lower() == TRANSPORT_BLOCKED_STATUS
+    ):
+        return _transport_blocked_packet(pr, payload.get("error") or "transport blocked")
     if isinstance(payload, dict):
         entries = payload.get("entries")
         entries = entries if isinstance(entries, list) else [payload]
@@ -644,6 +733,10 @@ def run_cycle(
         "mode": "apply" if apply else "dry-run",
         "plan": [],
         "dogfood_plan": [],
+        "transport_blocked_prs": [],
+        "scanned": 0,
+        "rejected_by_reason": {},
+        "unprobed_candidates": 0,
         "posted_prs": [],
         "failed_prs": [],
         "dogfood_posted_prs": [],
@@ -658,19 +751,62 @@ def run_cycle(
     }
 
     candidates = stage1_candidates(list_prs())
-    probes = 0
+    # ``--max-scan`` now bounds ELIGIBLE-or-INDETERMINATE examinations, not raw
+    # probes (#8316): cleanly-ineligible candidates (wrong tier / wrong status /
+    # human-settlement-required / unresolved-dissent / already-satisfied) no
+    # longer consume the scan budget, so a low-numbered tail of permanently
+    # ineligible Tier-3/4 PRs can never starve a fresh eligible PR further down
+    # the list. ``scanned`` records the total candidates examined.
+    examined_budget = 0  # eligible-or-indeterminate examinations against max_scan
+    transport_streak = 0  # consecutive transport-blocked probes (breaker input)
     for number in candidates:
         scan_full = len(summary["plan"]) >= max_prs and (
             run_dogfood is None or len(summary["dogfood_plan"]) >= max_dogfood
         )
-        if scan_full or probes >= max_scan:
+        if scan_full or examined_budget >= max_scan:
             break
         if over_budget():
             summary["budget_exhausted"] = True
             break
-        probes += 1
+        summary["scanned"] += 1
         entry = fetch_packet(number)
-        if needs_evidence(entry) and len(summary["plan"]) < max_prs:
+
+        if is_transport_blocked(entry):
+            # INDETERMINATE: could not see the PR. Count it (so an empty plan is
+            # distinguishable from a hiccup), consume budget, but do not select.
+            summary["transport_blocked_prs"].append(number)
+            examined_budget += 1
+            transport_streak += 1
+            # A run of identical transport failures is a systemic fault (auth
+            # broken, GraphQL down) — feed it into the same breaker the apply
+            # loop uses so the cycle aborts (exit 2) instead of grinding the
+            # whole scan budget against a dead endpoint.
+            if transport_streak >= breaker_threshold:
+                summary["breaker_tripped"] = True
+                log(
+                    json.dumps(
+                        {
+                            "result": "breaker_tripped",
+                            "stage": "scan",
+                            "transport_blocked_streak": transport_streak,
+                        }
+                    )
+                )
+                break
+            continue
+        transport_streak = 0
+
+        selectable_quorum = needs_evidence(entry)
+        selectable_dogfood = run_dogfood is not None and needs_dogfood(entry)
+        if selectable_quorum or selectable_dogfood:
+            examined_budget += 1
+        else:
+            # Cleanly ineligible: record the reason, but do NOT consume the
+            # eligible-scan budget — keep probing past it to reach fresh PRs.
+            reason = rejection_reason(entry) or "ineligible"
+            summary["rejected_by_reason"][reason] = summary["rejected_by_reason"].get(reason, 0) + 1
+
+        if selectable_quorum and len(summary["plan"]) < max_prs:
             # NB: keep this local distinct from the ``families`` parameter
             # (requested reviewer families) used by routing records below.
             counted = entry.get("counted_model_families") or entry.get("counted_reviewer_ids") or []
@@ -682,11 +818,7 @@ def run_cycle(
                     "counted_families": list(counted),
                 }
             )
-        if (
-            run_dogfood is not None
-            and needs_dogfood(entry)
-            and len(summary["dogfood_plan"]) < max_dogfood
-        ):
+        if selectable_dogfood and len(summary["dogfood_plan"]) < max_dogfood:
             summary["dogfood_plan"].append(
                 {
                     "pr": number,
@@ -695,6 +827,9 @@ def run_cycle(
                     "requires_adversarial_dogfood": True,
                 }
             )
+    # Candidates the scan never reached (loop broke on cap/budget before the
+    # end). ``scanned`` counts every candidate examined, so this is exact.
+    summary["unprobed_candidates"] = max(0, len(candidates) - summary["scanned"])
 
     for item in summary["plan"]:
         log(json.dumps({**item, "mode": summary["mode"]}))
@@ -704,11 +839,19 @@ def run_cycle(
         log(json.dumps({"plan": "empty", "mode": summary["mode"]}))
 
     if not apply:
+        # Dry-run never posts, so "transport drops + nothing posted" reduces to
+        # "transport drops occurred": an empty plan that is INDETERMINATE, not
+        # genuinely clear. The scan-phase breaker still wins (exit 2).
+        if summary["breaker_tripped"]:
+            summary["exit_code"] = EXIT_BREAKER
+        elif summary["transport_blocked_prs"]:
+            summary["exit_code"] = EXIT_INDETERMINATE
         return summary
 
     identical_errors = 0
     last_error = None
-    for item in summary["plan"]:
+    collect_plan = [] if summary["breaker_tripped"] else summary["plan"]
+    for item in collect_plan:
         if over_budget():
             summary["budget_exhausted"] = True
             break
@@ -791,10 +934,16 @@ def run_cycle(
         summary["reconciler_exit"] = run_reconciler()
         log(json.dumps({"reconciler_exit": summary["reconciler_exit"]}))
 
+    posted_anything = bool(summary["posted_prs"] or summary["dogfood_posted_prs"])
     if summary["breaker_tripped"]:
         summary["exit_code"] = EXIT_BREAKER
     elif summary["failed_prs"] or (summary["reconciler_exit"] not in (None, 0)):
         summary["exit_code"] = EXIT_FAILURES
+    elif summary["transport_blocked_prs"] and not posted_anything:
+        # Candidates were dropped because we couldn't see them and nothing was
+        # posted: INDETERMINATE, not a clean empty queue. Exit 3 so the operator
+        # distinguishes "no work" from "couldn't see the work".
+        summary["exit_code"] = EXIT_INDETERMINATE
     return summary
 
 

--- a/tests/scripts/test_auto_evidence_cycle.py
+++ b/tests/scripts/test_auto_evidence_cycle.py
@@ -167,12 +167,14 @@ def test_pr_without_quorum_check_is_still_probed() -> None:
     assert [item["pr"] for item in summary["plan"]] == [3]
 
 
-def test_candidates_scanned_oldest_first() -> None:
+def test_candidates_scanned_newest_first() -> None:
+    # #8316: probe newest-first so a low-numbered tail of permanently ineligible
+    # PRs can never starve fresh ready PRs at the high end.
     summary, _, _ = _run(
         [_pr(9), _pr(4), _pr(7)],
         {4: _entry(4), 7: _entry(7), 9: _entry(9)},
     )
-    assert summary["_packet_calls"] == [4, 7, 9]
+    assert summary["_packet_calls"] == [9, 7, 4]
 
 
 # --- Stage-2 selection (canonical merge-packet probe) -------------------------
@@ -222,17 +224,38 @@ def test_max_prs_caps_the_plan() -> None:
     prs = [_pr(n) for n in (1, 2, 3, 4, 5)]
     packets = {n: _entry(n) for n in (1, 2, 3, 4, 5)}
     summary, _, _ = _run(prs, packets, max_prs=2)
-    assert [item["pr"] for item in summary["plan"]] == [1, 2]
+    # Newest-first (#8316): the two freshest PRs are planned, not the oldest.
+    assert [item["pr"] for item in summary["plan"]] == [5, 4]
     # Probing stops once the plan is full.
-    assert summary["_packet_calls"] == [1, 2]
+    assert summary["_packet_calls"] == [5, 4]
 
 
-def test_max_scan_caps_packet_probes() -> None:
+def test_max_scan_budget_is_eligible_or_indeterminate_not_raw_probes() -> None:
+    # #8316: cleanly-ineligible candidates (here: already-satisfied) no longer
+    # consume the --max-scan budget. A queue of 10 ineligible PRs is probed in
+    # full (none burns budget), the plan stays empty, and the rejections are
+    # surfaced by reason — distinguishable from an exhausted scan window.
     prs = [_pr(n) for n in range(1, 11)]
     packets = {n: _entry(n, status="satisfied", families=["claude", "grok"]) for n in range(1, 11)}
     summary, _, _ = _run(prs, packets, max_scan=4)
-    assert len(summary["_packet_calls"]) == 4
+    assert len(summary["_packet_calls"]) == 10
     assert summary["plan"] == []
+    assert summary["rejected_by_reason"]["wrong_status"] == 10
+    assert summary["unprobed_candidates"] == 0
+
+
+def test_max_scan_caps_eligible_examinations() -> None:
+    # The eligible-or-indeterminate budget still bounds work: with 10 eligible
+    # PRs and max_scan=4 (but max_prs high), only 4 are examined; the rest are
+    # surfaced as unprobed so an empty/short plan is distinguishable from an
+    # exhausted window.
+    prs = [_pr(n) for n in range(1, 11)]
+    packets = {n: _entry(n) for n in range(1, 11)}
+    summary, _, _ = _run(prs, packets, max_scan=4, max_prs=10)
+    assert len(summary["_packet_calls"]) == 4
+    assert len(summary["plan"]) == 4
+    assert summary["scanned"] == 4
+    assert summary["unprobed_candidates"] == 6
 
 
 def test_budget_exhaustion_stops_scanning() -> None:
@@ -268,7 +291,8 @@ def test_apply_runs_collect_with_apply_then_reconciler_once() -> None:
         {1: _entry(1), 2: _entry(2)},
         apply=True,
     )
-    assert collect.calls == [(1, True), (2, True)]
+    # Newest-first scan order (#8316): PR 2 is planned/collected before PR 1.
+    assert collect.calls == [(2, True), (1, True)]
     assert reconciler.calls == 1
     assert summary["exit_code"] == 0
     assert sorted(summary["posted_prs"]) == [1, 2]
@@ -688,7 +712,8 @@ def test_apply_writes_one_routing_record_per_collected_pr() -> None:
         apply=True,
         write_routing_record=writer,
     )
-    assert [r["pr"] for r in writer.records] == [1, 2]
+    # Newest-first scan order (#8316): records are written PR 2 then PR 1.
+    assert [r["pr"] for r in writer.records] == [2, 1]
     assert len(summary["routing_records"]) == 2
     assert summary["routing_record_errors"] == []
     assert summary["exit_code"] == 0
@@ -829,3 +854,195 @@ def test_parse_collect_output_missing_head_and_tier_are_absent_not_invented() ->
     result = cycle.parse_collect_output(1, _json.dumps(payload), "")
     assert result["head_sha"] == ""
     assert result["tier"] is None
+
+
+# --- #8316 DEFECT 1: transport/structural conflation -------------------------
+
+
+def _transport_packet(pr: int, *, error: str = "GraphQL 502") -> dict[str, Any]:
+    # Mirrors aragora/cli/commands/review_queue_transport.py: a probe that could
+    # not see the PR carries status=transport_blocked / transport_blocked=True.
+    return {
+        "pr_number": pr,
+        "status": "transport_blocked",
+        "transport_blocked": True,
+        "error": error,
+    }
+
+
+def test_transport_blocked_packet_is_indeterminate_not_silently_empty() -> None:
+    # A transport hiccup must NOT look like a clean empty queue: count it in
+    # transport_blocked_prs, leave the plan empty, and exit 3 (not 0).
+    summary, collect, recon = _run([_pr(1)], {1: _transport_packet(1)})
+    assert summary["transport_blocked_prs"] == [1]
+    assert summary["plan"] == []
+    assert summary["exit_code"] == cycle.EXIT_INDETERMINATE
+    assert collect.calls == []  # dry-run posts nothing
+
+
+def test_transport_blocked_via_status_only_is_detected() -> None:
+    # An envelope that carries status=transport_blocked but no boolean flag.
+    pkt = {"pr_number": 1, "status": "transport_blocked", "error": "504"}
+    summary, _, _ = _run([_pr(1)], {1: pkt})
+    assert summary["transport_blocked_prs"] == [1]
+    assert summary["exit_code"] == cycle.EXIT_INDETERMINATE
+
+
+def test_genuinely_empty_packet_still_exits_zero() -> None:
+    # A structural empty (PR seen, nothing selectable) is NOT transport-blocked:
+    # the queue is genuinely clear, so exit 0 with an empty plan.
+    summary, _, _ = _run([_pr(1)], {1: {}})
+    assert summary["transport_blocked_prs"] == []
+    assert summary["plan"] == []
+    assert summary["exit_code"] == cycle.EXIT_OK
+
+
+def test_transport_drop_with_a_real_post_does_not_force_exit_three() -> None:
+    # If something was actually posted, a transport drop elsewhere is not the
+    # whole story: the run did real work, so it is not INDETERMINATE.
+    summary, _, recon = _run(
+        [_pr(2), _pr(1)],
+        {2: _entry(2), 1: _transport_packet(1)},
+        apply=True,
+    )
+    assert summary["posted_prs"] == [2]
+    assert summary["transport_blocked_prs"] == [1]
+    assert summary["exit_code"] == cycle.EXIT_OK
+
+
+def test_default_fetch_packet_synthesizes_transport_on_failure(monkeypatch: Any) -> None:
+    # A non-zero merge-packet exit must surface as a transport-blocked packet,
+    # never as {} (which would be indistinguishable from a clean empty queue).
+    class _Proc:
+        returncode = 1
+        stdout = ""
+        stderr = "gh: API rate limit exceeded"
+
+    monkeypatch.setattr(cycle.subprocess, "run", lambda *a, **k: _Proc())
+    entry = cycle.default_fetch_packet("owner/repo", 42)
+    assert cycle.is_transport_blocked(entry) is True
+    assert entry["pr_number"] == 42
+
+
+def test_default_fetch_packet_timeout_is_transport_blocked(monkeypatch: Any) -> None:
+    def _boom(*a: Any, **k: Any) -> Any:
+        raise cycle.subprocess.TimeoutExpired(cmd="merge-packet", timeout=1)
+
+    monkeypatch.setattr(cycle.subprocess, "run", _boom)
+    entry = cycle.default_fetch_packet("owner/repo", 7)
+    assert cycle.is_transport_blocked(entry) is True
+
+
+def test_default_fetch_packet_transport_envelope_is_propagated(monkeypatch: Any) -> None:
+    import json as _json
+
+    class _Proc:
+        returncode = 0
+        stderr = ""
+        stdout = _json.dumps(
+            {
+                "version": "merge_authorization_packet.v1",
+                "status": "transport_blocked",
+                "entries": [],
+            }
+        )
+
+    monkeypatch.setattr(cycle.subprocess, "run", lambda *a, **k: _Proc())
+    entry = cycle.default_fetch_packet("owner/repo", 99)
+    assert cycle.is_transport_blocked(entry) is True
+
+
+def test_consecutive_transport_blocks_trip_the_breaker() -> None:
+    # A run of transport failures is a systemic fault: it feeds the same breaker
+    # the apply loop uses and aborts the cycle (exit 2).
+    prs = [_pr(n) for n in (5, 4, 3, 2, 1)]
+    packets = {n: _transport_packet(n) for n in (5, 4, 3, 2, 1)}
+    summary, _, _ = _run(prs, packets, breaker_threshold=3)
+    assert summary["breaker_tripped"] is True
+    assert summary["exit_code"] == cycle.EXIT_BREAKER
+    # Stopped at the breaker: only the first 3 were probed.
+    assert summary["transport_blocked_prs"] == [5, 4, 3]
+
+
+# The apply-loop identical-error breaker (3 identical real collect failures →
+# exit 2) is unchanged; its regression coverage lives in
+# ``test_identical_error_breaker_trips_after_threshold`` above.
+
+
+# --- #8316 DEFECT 2: scan-window starvation ----------------------------------
+
+
+def test_ineligible_tail_does_not_starve_a_fresh_eligible_pr() -> None:
+    # A tail of permanently-ineligible Tier-3 PRs (oldest, lowest numbers) plus
+    # one fresh eligible Tier-1 PR (highest number). With the OLD oldest-first +
+    # raw-probe-budget behavior the ineligible tail consumed --max-scan and the
+    # fresh PR was never reached; now it is probed and selected.
+    prs = [_pr(n) for n in (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20)]
+    packets = {n: _entry(n, tier=3) for n in range(1, 11)}
+    packets[20] = _entry(20, tier=1)  # the fresh eligible PR beyond --max-scan
+    summary, _, _ = _run(prs, packets, max_scan=3)
+    assert [item["pr"] for item in summary["plan"]] == [20]
+    # The ineligible PRs were probed but did not consume the eligible budget.
+    assert summary["rejected_by_reason"]["wrong_tier"] == 10
+    assert 20 in summary["_packet_calls"]
+
+
+def test_rejection_reasons_are_surfaced_with_counts() -> None:
+    prs = [_pr(n) for n in (1, 2, 3, 4)]
+    packets = {
+        1: _entry(1, tier=3),  # wrong_tier
+        2: _entry(2, human=True),  # human_settlement_required
+        3: _entry(3, dissent=True),  # unresolved_dissent
+        4: _entry(4, families=["claude", "grok"]),  # quorum_satisfied
+    }
+    summary, _, _ = _run(prs, packets)
+    assert summary["plan"] == []
+    assert summary["rejected_by_reason"] == {
+        "wrong_tier": 1,
+        "human_settlement_required": 1,
+        "unresolved_dissent": 1,
+        "quorum_satisfied": 1,
+    }
+    assert summary["scanned"] == 4
+    assert summary["unprobed_candidates"] == 0
+    # Genuinely clear queue (no transport drops): exit 0.
+    assert summary["exit_code"] == cycle.EXIT_OK
+
+
+def test_rejection_reason_classifier() -> None:
+    assert cycle.rejection_reason({}) == "empty_packet"
+    assert cycle.rejection_reason({"status": "satisfied", "tier": 1}) == "wrong_status"
+    assert (
+        cycle.rejection_reason({"status": "needs_model_review_quorum", "tier": 9}) == "wrong_tier"
+    )
+    assert (
+        cycle.rejection_reason({"status": "needs_model_review_quorum", "tier": "x"})
+        == "unknown_tier"
+    )
+    assert (
+        cycle.rejection_reason(
+            {
+                "status": "needs_model_review_quorum",
+                "tier": 1,
+                "requires_human_risk_settlement": True,
+            }
+        )
+        == "human_settlement_required"
+    )
+    assert (
+        cycle.rejection_reason(
+            {
+                "status": "needs_model_review_quorum",
+                "tier": 1,
+                "counted_model_families": ["claude", "grok"],
+            }
+        )
+        == "quorum_satisfied"
+    )
+    # Selectable entry returns None.
+    assert (
+        cycle.rejection_reason(
+            {"status": "needs_model_review_quorum", "tier": 1, "counted_model_families": ["claude"]}
+        )
+        is None
+    )


### PR DESCRIPTION
## Problem (issue #8316 — why tonight needed manual evidence loops)

`auto_evidence_cycle.py` is the daemon path that auto-collects model-review evidence so ready PRs reach quorum without a human running `collect-evidence`. Tonight it returned `{"plan": "empty"}` / exit 0 across many runs while ready Tier-0-2 PRs sat evidence-starved — forcing nine manual evidence loops. Root cause: two selection defects.

1. **Transport/structural conflation** — a per-PR merge-packet probe returning `transport_blocked` (GitHub/GraphQL hiccup) was silently treated as "not selectable," so a transient outage produced a clean empty plan indistinguishable from "queue genuinely clear."
2. **Scan-window starvation** — candidates were probed oldest-first, capped at `--max-scan` (15); the low-numbered tail is dominated by permanently auto-ineligible Tier-3/4 / human-settlement PRs that ate the entire probe budget every run, so fresh Tier-0-2 PRs at the high end were never reached.

## Fix

- **Indeterminate ≠ unselectable**: a probe that cannot *see* a PR (`transport_blocked` envelope, subprocess error, timeout, non-zero exit, unparseable output) is synthesized into a transport-blocked packet, counted in `transport_blocked_prs`, fed into the identical-error breaker (a run trips it → exit 2), and forces **exit 3** (not silent exit-0) when candidates were dropped and nothing posted. The operator can now distinguish "no work" from "couldn't see the work."
- **No starvation**: probe **newest-first**; cleanly-ineligible PRs (wrong tier/status, human-settlement-required, unresolved-dissent, already-satisfied) **no longer consume the `--max-scan` eligible-examination budget**, so a Tier-3/4 tail can never starve fresh PRs.
- **Observability**: `scanned`, `rejected_by_reason` (counts), and `unprobed_candidates` surfaced in the summary JSON — an empty plan is now distinguishable from an exhausted window. A genuinely-clear queue still exits 0.

## Validation

- Tests: baseline 51 → **63 passed** (11 new + corrected-semantics replacements): transport_blocked counted + exit 3; ineligible tail doesn't block a fresh PR beyond `--max-scan`; rejected-by-reason surfaced; breaker still trips on 3 identical real errors; genuinely-empty queue still exits 0.
- `ruff check` + `ruff format` clean; `py_compile` OK.

Tier ≤2 (script only — not `review_queue.py`, not a workflow, not the gate). **This is the change that ends manual evidence loops**: once merged and the arbiter is running (#8355 activation), the daemon self-evidences ready PRs.

Fixes #8316

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jfJj5gb9VoLs6VBMnzhrP

---
_Generated by [Claude Code](https://claude.ai/code/session_018jfJj5gb9VoLs6VBMnzhrP)_