### PR TITLE
docs(plans): medium-term design specs — event substrate, mission schema, review_queue decomposition plan (#8344)

### DIFF
--- a/docs/superpowers/plans/2026-06-13-event-substrate-design.md
+++ b/docs/superpowers/plans/2026-06-13-event-substrate-design.md
@@ -1,0 +1,249 @@
+# Event Substrate over Polling — Design Spec
+
+Status: design spec (medium-term item 1 of epic [#8344](https://github.com/synaptent/aragora/issues/8344),
+§5.1 of `docs/superpowers/plans/2026-06-13-conveyor-hardening-program.md`).
+Written 2026-06-13. Implementable; names the components, the data flow, and a
+phased rollout. Tier of the eventual build: per-component (mostly Tier 2; the
+witness/credential pieces inherit the Tier-2 build / Tier-4 identity split from
+`docs/specs/TAMPER_EVIDENT_TRAIL.md`).
+
+## 1. Problem: polling is the quota-starvation root cause
+
+This retires **failure class E** (quota starvation as architecture) at the
+root. The program doc and epic frame it precisely: one GitHub identity serves N
+concurrent pollers, each re-verifying full PR state every cycle. The "do not
+trust transcript state" doctrine is correct, but applied per-lane it multiplies
+GraphQL reads by fleet size and exhausts the 5,000-pts/hr budget mid-hour while
+REST sits healthy.
+
+Three layers already ameliorate this without removing the polls:
+
+- `scripts/pr_state_cache.py` (#8339): ONE budgeted REST-only poller maintains
+  `.aragora/pr-state-cache.json`; lanes read the cache and spend exactly one
+  targeted REST `verify` call immediately before any mutation (the binding
+  **reader contract** documented in that module's header).
+- ETag/conditional requests (#8339/#8324): 304s are free, so the single poller
+  re-lists cheaply.
+- App-token routing (operator runbook): the GitHub App installation token has
+  its own rate budget, separate from `an0mium`.
+
+These shrink the cost of polling. They do **not** remove the structural fact
+that state is *pulled* on a clock. The event substrate inverts that: GitHub
+**pushes** state changes to a local collector, which updates the same
+`.aragora/pr-state-cache.json` that #8339 already ships. The single poller
+degrades from "the source of truth" to "a periodic reconcile backstop."
+
+## 2. Architecture: webhook → collector → shared cache
+
+```
+   GitHub org/repo                  local collector                lanes
+   ┌───────────────┐   webhook   ┌──────────────────────┐  reads  ┌─────────┐
+   │ pull_request  │──POST────▶  │ event-cache-collector │◀────────│ lane A  │
+   │ check_run     │  (HMAC)     │  (append-only ingest) │  read   │ lane B  │
+   │ issue_comment │             │   ↓ atomic write      │◀────────│ lane C  │
+   │ status        │             │ .aragora/pr-state-    │  read   │  ...    │
+   └───────────────┘             │   cache.json          │         └─────────┘
+          │                      │ .aragora/trail/       │              │
+          │  (also)              │   webhook-events.jsonl│ verify(1 REST│ before
+          ▼                      └──────────────────────┘  exact head) │ mutate
+   external witness                                                     ▼
+   (TET intent reconciliation)                                      GitHub API
+```
+
+The cache file format and reader contract are **unchanged** from #8339 — that
+is the whole point. Lanes already speak `pr_state_cache.py read` / `verify`;
+the substrate only changes *who writes the cache* (pushed events instead of a
+clock-driven poll), not how lanes consume it. This is what makes the migration
+low-risk: the consumer side never moves.
+
+## 3. Webhook events to subscribe
+
+Org-level webhook (or repo-level for `synaptent/aragora` first), delivering to
+the collector endpoint. Subscribe to exactly the event types that move the
+funnel state the cache tracks:
+
+| Event | Why the cache needs it | Cache field updated |
+|---|---|---|
+| `pull_request` | open/close/reopen, ready-for-review, head-SHA moves (`synchronize`), merge | PR entry create/retire, `state`, `head_sha`, `draft`, `merged` |
+| `check_run` | per-check conclusion/status transitions (the funnel's quorum-green signal) | per-PR `{check_name: conclusion-or-status}`, `checks_fetched_at` |
+| `status` | commit-status contexts incl. `aragora/human-settlement` and `aragora-merge-quorum` | status contexts on the head SHA |
+| `issue_comment` | operator steering comments, Tier-4 human-preapproval comments, supersession hints | comment-derived steering/settlement hints |
+
+Deliberately **not** subscribed (out of cache scope, and `check_suite` would
+duplicate `check_run`): `push` to non-PR refs, `workflow_run` internals,
+`deployment`. The witness role (§6) widens coverage separately via the
+Enterprise audit stream, which sees admin events webhooks never expose.
+
+Delivery hardening:
+
+- HMAC-SHA256 signature verification (`X-Hub-Signature-256`) on every POST; the
+  shared secret lives only in the collector's environment.
+- `X-GitHub-Delivery` id recorded per event for dedup and replay.
+- Per-event ordering is not assumed — the collector reconciles by
+  `(pr_number, head_sha, event timestamp)` and never lets an older event
+  overwrite a newer head (monotonic-by-timestamp merge).
+
+## 4. The local collector (append-only)
+
+New script: `scripts/event_cache_collector.py`. Stdlib-only by design (mirrors
+`pr_state_cache.py`), so it runs anywhere the receiving host can reach. Two
+responsibilities, cleanly separated:
+
+1. **Ingest (append-only).** Every verified webhook is appended verbatim to
+   `.aragora/trail/webhook-events.jsonl` (one JSON object per line, with the
+   delivery id, received-at, and HMAC-verified flag). This file is never
+   rewritten — it is the local working copy of the event log and the seed of
+   the witness role (§6).
+2. **Project (cache write).** From each event, project the relevant fields onto
+   the in-memory cache and write `.aragora/pr-state-cache.json` atomically
+   (mkstemp + `os.replace`, never a partial file — identical discipline to
+   `pr_state_cache.py`). The projection is monotonic: an event whose
+   `head_sha`/timestamp is older than the cached entry annotates and is
+   skipped, never regresses the cache.
+
+The cache schema carries `generated_at` and per-PR `checks_fetched_at` already;
+the collector additionally stamps `source: "webhook"` and `last_delivery_id`
+per entry so a reader (or the reconciler) can tell webhook-fresh entries from
+poll-refreshed ones. `SCHEMA_VERSION` bumps by one and `pr_state_cache.py read`
+tolerates both `source` values.
+
+Transport mechanics (pick at build time, both documented):
+
+- **Receiver**: a tiny HTTP endpoint. Cheapest viable form is a single-file
+  cloud function (CF worker / Lambda) that verifies HMAC and appends to a
+  durable queue; the local collector drains the queue and writes the cache. For
+  a single-host fleet, the receiver can be a localhost listener behind a tunnel
+  (cloudflared/ngrok) — acceptable for the dogfood phase, not for the witness
+  role.
+- **Decoupling**: the receiver's only job is verify-and-enqueue; the projection
+  into the cache happens in the local collector loop. This keeps the
+  agent-reachable host out of the credential path (§7).
+
+## 5. How lanes consume it (unchanged reader contract)
+
+No lane code changes between the polling world and the event world. Lanes:
+
+1. `pr_state_cache.py read <pr>` for routine state (cheap, local, free).
+2. exactly one `pr_state_cache.py verify <pr>` REST call for the exact head
+   immediately before any mutation.
+3. never treat the cache as authority for settlement/merge gates —
+   `review-queue merge-packet` for the exact head SHA remains the gate
+   authority (see `docs/REVIEW_AUTHORITY_PRINCIPLES.md`).
+
+The substrate makes step 1 *fresher* (push latency, not poll cadence) and makes
+step 2's `verify` almost always confirm what the cache already said — but the
+`verify` stays mandatory: a single live REST call before mutation is the
+fail-closed guarantee that survives a missed or delayed webhook (§8). The epic's
+near-term item "wire `pr_state_cache read/verify` into lane recursive-prompt
+preambles" is the prerequisite; the substrate inherits it for free.
+
+## 6. Dual role: the tamper-evident-trail external witness
+
+The collector is also Variant A of the external witness in
+`docs/specs/TAMPER_EVIDENT_TRAIL.md` (Component 1, "org webhook → collector").
+That spec already decided Variant B (Enterprise audit-log streaming → S3
+Object-Lock) is **primary** and Variant A is the documented fallback / defense
+in depth — so this substrate's witness role is explicitly the *secondary*
+witness, valuable because:
+
+- It runs even on plan downgrade or for a second org/repo without Enterprise.
+- It provides redundancy during the highest-assurance period.
+- Its `webhook-events.jsonl` feeds the same **intent reconciliation** detector:
+  the `trail_reconcile` sentinel diffs witness events against pre-registered,
+  externally-anchored intent records (TET Component 2/3), and an unmatched
+  witness event is a breach.
+
+To serve the witness role honestly, the append path must be **append-only with
+external anchoring** — the local `.jsonl` is the working copy, but the witness
+root is a bucket whose write credential the laptop never holds (TET §"witness
+root", `AragoraTrailWitnessWrite` role). The webhook collector's coverage is
+narrower than the audit stream (it cannot see token/deploy-key/App creation),
+which is exactly why TET keeps Variant B primary. This design does not
+re-litigate that decision; it implements the fallback collector so the cache
+update and the witness ingest share one component instead of two.
+
+## 7. Security note: collector credentials never touch agent-reachable disk
+
+Two distinct credentials, neither on a lane-reachable host:
+
+- **Webhook secret** (HMAC shared secret): lives only in the receiver's
+  environment (cloud-function secret store). Agents read the *cache*, never the
+  secret; possessing the cache grants no ability to forge events.
+- **Witness write credential** (`AragoraTrailWitnessWrite`, the bucket
+  Object-Lock writer): assumable ONLY by the collector function, never present
+  in any agent keyring/env — identical posture to TET. The threat model is
+  TET's: even an adversary who controls the laptop and every credential on it
+  cannot rewrite the witness, because the write credential isn't there.
+
+The collector's *cache projection* (what lanes consume) is intentionally
+low-privilege: it only writes `.aragora/pr-state-cache.json`, a non-authoritative
+read cache. The high-privilege append (witness root) is isolated in the
+cloud-function half. This split is the load-bearing security property — do not
+collapse the two halves onto one agent-reachable host during implementation.
+
+## 8. Failure modes and backstops
+
+| Failure | Detection | Backstop |
+|---|---|---|
+| Missed/dropped webhook | cache entry's `generated_at`/`checks_fetched_at` ages past `--max-age-seconds`; `read` returns `stale` (exit 3) | the periodic reconcile poll (§9) re-lists via REST+ETag and repairs the entry; the mandatory pre-mutation `verify` catches a stale head in the moment |
+| Collector outage (blind window) | sentinel watches collector liveness (TET notes this exact failure mode for Variant A) | reconcile poll keeps the cache usable; sentinel raises a blind-period incident ("silence is never success") |
+| Out-of-order delivery | monotonic-by-timestamp/head merge in the projector | older event annotated and skipped, never regresses the cache |
+| Forged/replayed event | HMAC verify + `X-GitHub-Delivery` dedup | unverified/duplicate events dropped before projection; witness records the drop |
+| Webhook coverage gap (admin events) | known-by-design (webhooks don't expose token/App changes) | TET Variant B audit stream covers it; this collector never claims to |
+
+The reconcile poll is the safety net that lets the substrate fail open *toward
+correctness*: if events stop, the system degrades to exactly today's polling
+behavior (one budgeted REST poller), not to blindness.
+
+## 9. Migration path (phased, run-alongside-first)
+
+Strictly additive at every step; polling is retired only after the substrate
+proves itself against it.
+
+- **Phase 0 — collector alongside poll (shadow).** Deploy
+  `event_cache_collector.py` writing to a *separate* cache file
+  (`.aragora/pr-state-cache.webhook.json`). The existing `pr_state_cache.py poll`
+  keeps writing the canonical cache. A small comparator
+  (`scripts/event_cache_collector.py compare`) diffs the two each cycle and
+  reports divergence. No lane reads the webhook cache yet. Tier 2.
+- **Phase 1 — collector writes the canonical cache; poll demoted to
+  reconcile.** Once Phase 0 shows webhook freshness matches/beats poll freshness
+  with bounded divergence, the collector writes the canonical
+  `.aragora/pr-state-cache.json`. The poller drops to a *reconcile* cadence
+  (e.g. every 5–10 min instead of every cycle) whose only job is repairing
+  missed-webhook gaps. Most GraphQL/REST list traffic disappears here — this is
+  where the quota win lands. Tier 2.
+- **Phase 2 — witness wiring.** Point the collector's append at the witness root
+  per TET (Variant A fallback) and wire `webhook-events.jsonl` into
+  `trail_reconcile`. Tier 2 build; the credential-isolation steps inherit TET's
+  Tier-4 identity discipline.
+- **Phase 3 — retire residual polling.** When Phase 1 has run for a sustained
+  window with zero missed-webhook-caused stale reads (measured: reconcile poll
+  finds no deltas the webhook missed), reduce the reconcile poll to a low-cadence
+  backstop only. Never remove it entirely — it is the §8 backstop. Tier 2.
+
+Exit metric (falsifiable, mirrors TET's discipline): after Phase 1, fleet
+GraphQL consumption per hour drops by the bulk of the polling fan-out, *and* the
+reconcile poll reports a near-empty delta set (webhooks were carrying the state).
+If the reconcile poll keeps finding deltas the webhooks missed, the subscription
+set or the projector is wrong — fix it before advancing, do not retire polling.
+
+## 10. Components named (for the executing lane)
+
+| Component | Path | Tier | Status |
+|---|---|---|---|
+| Webhook receiver (HMAC verify + enqueue) | cloud function (CF worker / Lambda) | 2 (build) / operator (deploy) | new |
+| Local collector (ingest + project) | `scripts/event_cache_collector.py` | 2 | new |
+| Shared cache (reader contract) | `.aragora/pr-state-cache.json` via `scripts/pr_state_cache.py` | — | exists (#8339) |
+| Webhook event log (witness working copy) | `.aragora/trail/webhook-events.jsonl` | 2 | new |
+| Reconcile poller (backstop) | `scripts/pr_state_cache.py poll` (demoted cadence) | — | exists (#8339) |
+| Witness root + write role | S3 Object-Lock + `AragoraTrailWitnessWrite` | 4 (identity) | per TET |
+| Reconciler check | `trail_reconcile` sentinel | 2 | per TET |
+
+## Cross-references
+
+- Program: `docs/superpowers/plans/2026-06-13-conveyor-hardening-program.md` (§2 class E, §3 tamper evidence, §5.1).
+- Epic: [#8344](https://github.com/synaptent/aragora/issues/8344) (medium-term phase 1; near-term cache wiring).
+- Witness/reconciliation: `docs/specs/TAMPER_EVIDENT_TRAIL.md` (Component 1 Variant A, Components 2–3).
+- Shared cache + reader contract: #8339; REST fallback + ETag: #8324; quota class root: #8315/#8316.
+- Gate authority that the cache must never substitute for: `docs/REVIEW_AUTHORITY_PRINCIPLES.md`.

--- a/docs/superpowers/plans/2026-06-13-mission-schema-design.md
+++ b/docs/superpowers/plans/2026-06-13-mission-schema-design.md
@@ -1,0 +1,270 @@
+# Mission Schema — Design Spec
+
+Status: design spec (medium-term item 2 of epic [#8344](https://github.com/synaptent/aragora/issues/8344),
+§5.2 of `docs/superpowers/plans/2026-06-13-conveyor-hardening-program.md`).
+Written 2026-06-13. Implementable; proposes a concrete schema, a loader/executor
+contract, and how validation contracts and readiness probes plug in.
+
+## 1. Why this exists: the orchestrator must be swappable
+
+The program doc states the load-bearing principle plainly: **no load-bearing
+component should assume a specific model.** The 2026-06-12 Fable-5 suspension
+made it concrete — the heterogeneous merge quorum sailed through unaffected,
+because heterogeneity is built into its construction, while anything *pinned to a
+single model* (a mission orchestrator) was exposed and stalled.
+
+Today `docs/superpowers/plans/*` mission files are prose. They are excellent for
+humans and for a model that happens to be running, but they are not
+*machine-loadable*: a Claude Code session, a Codex goal-loop, and a Factory
+mission each re-interpret the same prose differently, and each re-researches the
+repo's merge gate from scratch (the program's harness-comparison table calls
+this out as Factory's weakness — "had to re-research the repo's merge gate from
+scratch"). A machine-readable mission schema turns the prose into an artifact any
+harness can load and execute identically. The orchestrator becomes a swappable
+runtime, not a single point of model failure.
+
+This is the program's "absorb into aragora as repo artifacts" item #3 (mission
+schema) composed with #1 (validation contracts) and #2 (readiness probes).
+
+## 2. Prior art: the Factory mission structure
+
+Factory missions are the explicit prior art (harness-comparison table:
+"readiness probes, validation contracts, milestone gates, pointed clarifying
+questions"). A Factory mission already carries, in spirit:
+
+- a **goal** and decomposition into **phases / milestones**,
+- **gates** between milestones (don't advance until the gate passes),
+- **validation contracts** (machine-checkable acceptance per goal),
+- a **readiness probe** (a dependency check before spending budget),
+- **clarifying questions** surfaced before execution.
+
+The Aragora loop's complementary superpower is the *governed merge transport*:
+tiers, quorum, receipts, 24/7 operation. The mission schema's job is to make a
+mission file carry **both** — Factory's planning discipline and Aragora's
+tiering/yield/budget governance — in one portable document. The existing
+`docs/superpowers/plans/*` files (e.g. this program doc, the codebase-health
+program, the steering-leverage plans) are the corpus the schema must be able to
+represent without losing information.
+
+## 3. Format: YAML front-matter + Markdown body
+
+A mission file stays a readable Markdown document with a **YAML front-matter
+block** carrying the machine-readable contract. This keeps the human narrative
+(which is where the *why* lives) while making the executable fields parseable
+with zero new file types. The front-matter validates against a published
+JSON-schema (`docs/superpowers/schema/mission.schema.json`). Rationale for
+front-matter over a separate `.json`: the prose and the contract drift apart if
+they live in two files; co-locating them keeps the spec and its rationale in one
+reviewable diff (the same discipline the codebase already applies to receipts).
+
+```markdown
+---
+mission_schema_version: 1
+id: conveyor-event-substrate
+title: Event substrate over polling
+goal: >
+  Retire most PR-state polling by pushing GitHub events to a local collector
+  that maintains the shared PR-state cache; double the collector as the TET
+  external witness.
+tier: 2                      # max tier any phase reaches; per-phase tier may differ
+budgets:
+  wall_clock_minutes: 240
+  model_calls: 400
+  usd: 5.00
+readiness_probe: mission-readiness/event-substrate   # see §6
+yield_rules:                  # ODR / path-freeze behavior
+  path_freeze:
+    - "scripts/pr_state_cache.py"      # reader contract is frozen; do not edit
+  odr_yield:                  # owner-declared-region yield: steer via comments, do not edit
+    - surface: "review_queue*"
+      owner: scarmani
+phases:
+  - id: p0-shadow
+    name: Collector alongside poll (shadow)
+    tier: 2
+    human_checkpoint: false
+    acceptance:                # validation contract refs (§5)
+      - contract: webhook-cache-divergence-bounded
+      - contract: no-lane-reads-webhook-cache-yet
+  - id: p1-canonical
+    name: Collector writes canonical cache; poll demoted
+    tier: 2
+    human_checkpoint: false
+    depends_on: [p0-shadow]
+    acceptance:
+      - contract: graphql-consumption-dropped
+      - contract: reconcile-delta-near-empty
+  - id: p2-witness
+    name: Witness wiring
+    tier: 4                    # inherits TET identity discipline
+    human_checkpoint: true     # scarmani settlement / operator preapproval
+    depends_on: [p1-canonical]
+    acceptance:
+      - contract: trail-reconcile-breaches-on-unmatched
+validation_contracts: docs/superpowers/contracts/event-substrate/
+references:
+  - "#8344"
+  - "#8339"
+  - "docs/specs/TAMPER_EVIDENT_TRAIL.md"
+---
+
+# Event substrate over polling
+
+(human narrative — the design doc body, unchanged prose...)
+```
+
+## 4. Required fields (the schema contract)
+
+The JSON-schema (`mission.schema.json`) requires:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `mission_schema_version` | int | schema version for forward compat |
+| `id` | string (slug) | stable mission id; matches a lane ledger entry |
+| `title` | string | human title |
+| `goal` | string | one-paragraph north star |
+| `tier` | int 0–4 | max tier reached by any phase (`docs/REVIEW_AUTHORITY_PRINCIPLES.md`) |
+| `budgets` | object | at minimum `wall_clock_minutes`; optionally `model_calls`, `usd` |
+| `phases` | array | ordered phases, each with the phase contract below |
+| `yield_rules` | object | `path_freeze` (paths no lane may edit) + `odr_yield` (owner-declared regions; steer via comments) |
+| `validation_contracts` | path | directory/file of machine-checkable acceptance assertions (§5) |
+| `readiness_probe` | string | id of the pre-launch probe to run (§6) |
+| `references` | array | issues/docs this mission threads (e.g. `#8344`) |
+
+Each **phase** requires:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `id` | string | phase slug |
+| `name` | string | human name |
+| `tier` | int 0–4 | this phase's tier (may exceed mission `tier` only if mission `tier` is raised to match) |
+| `human_checkpoint` | bool | if true, the harness MUST pause for explicit operator authorization before/after the phase (Tier 3–4 phases are always `true`) |
+| `acceptance` | array of `{contract: <id>}` | the validation contracts that must pass for the phase to count as done |
+| `depends_on` | array of phase ids (optional) | DAG ordering |
+
+The schema is intentionally a superset-compatible *extension* of the Factory
+mission shape: goal, phases-with-gates, validation contracts, readiness probe,
+checkpoints. The aragora-specific additions are `tier`, `budgets`, and
+`yield_rules` — the governance fields that make the mission honor this repo's
+merge authority and claim-discipline rules.
+
+## 5. Validation contracts (machine-checkable acceptance)
+
+A validation contract is the program's absorb-item #1: a *machine-checkable
+acceptance assertion per goal, evaluated before a lane's work counts as done*.
+Each contract is a small, harness-agnostic, executable check living under
+`docs/superpowers/contracts/<mission-id>/<contract-id>.{sh,py,yaml}` with a
+declared verdict protocol:
+
+- exit 0 = satisfied; nonzero = not satisfied; the check prints a one-line
+  human-readable verdict and a machine `{"contract": id, "pass": bool,
+  "evidence": ...}` line.
+- contracts are **read-only and deterministic** where possible (they assert over
+  repo state, CI status, cache files, metrics) — they never mutate.
+- a phase's `acceptance` list is ANDed: every referenced contract must pass for
+  the phase to advance.
+
+Example contract ids from the event-substrate mission above:
+`graphql-consumption-dropped` (asserts measured GraphQL pts/hr fell below a
+threshold after Phase 1), `reconcile-delta-near-empty` (asserts the reconcile
+poll found ≤N deltas the webhooks missed), `trail-reconcile-breaches-on-unmatched`
+(asserts the reconciler raises a breach on a simulated unmatched witness event —
+the TET T5 replay test). These are exactly the *falsifiable exit metrics* the
+TET spec and the event-substrate spec already write in prose; the schema makes
+them executable and binding.
+
+Why this matters: today a lane self-reports "done" from its transcript, and the
+"do not trust transcript state" doctrine then forces re-verification by polling.
+A validation contract moves the done-judgment out of the transcript into a
+deterministic check any harness (or the sentinel, or the operator) can re-run —
+it is the planning-side analog of the merge quorum's evidence-first discipline.
+
+## 6. Pre-launch readiness probe
+
+The program's absorb-item #2: a **5-minute dependency check before any lane
+spends budget** (3 of the run's silent deaths were probe-preventable — failure
+class A). A probe is referenced by id from the mission and lives under
+`docs/superpowers/probes/<probe-id>.{sh,py}`. It asserts the mission's
+preconditions and refuses to launch on failure:
+
+- **auth**: `gh auth status` healthy; the *right identity* (App token vs
+  `an0mium`) is active for this mission's traffic class.
+- **keys**: required provider keys present for the heterogeneity this mission
+  needs (and explicitly NOT assuming a single model — if the configured
+  orchestrator model is unavailable, the probe must confirm a fallback exists,
+  not fail the mission; this is the Fable-5 lesson encoded).
+- **CLI surfaces**: the commands the mission invokes resolve (e.g.
+  `review-queue merge-packet --help`, `pr_state_cache.py read --help`).
+- **worktree**: an isolated worktree exists and is clean (per CLAUDE.md
+  worktree-isolation rule).
+- **gate context**: the merge gate is reachable and its tier rules are loadable
+  — so the harness does not "re-research the repo's merge gate from scratch."
+
+Probe verdict protocol mirrors validation contracts: exit 0 / nonzero + a
+machine line. The harness MUST run the probe and gate launch on it; a failed
+probe parks the mission (does not disclose-and-proceed — program operating
+lesson: "tier escalations park by default").
+
+## 7. How a harness loads and executes a mission
+
+The contract any harness implements (Claude Code, Codex, Factory). Reference
+loader/runner: `scripts/mission_run.py` (stdlib + the schema validator),
+deliberately thin so each harness can re-implement it natively if preferred:
+
+1. **Parse + validate** front-matter against `mission.schema.json`. Invalid →
+   refuse, print the schema error. (No execution on an unvalidated mission.)
+2. **Readiness probe**: run `readiness_probe`; park on failure (§6).
+3. **For each phase in DAG order** (`depends_on`):
+   a. If `human_checkpoint` or `tier >= 3`: pause for explicit operator
+      authorization (any channel — program lesson 6: "a human must decide ≠ a
+      human must type"; unforgeability comes from credential isolation, not
+      ceremony). For Tier 4, the authorization is the scarmani-settled
+      preapproval per `docs/REVIEW_AUTHORITY_PRINCIPLES.md`.
+   b. Enforce `yield_rules`: never edit `path_freeze` paths; in `odr_yield`
+      surfaces, steer via comments to the declared owner rather than editing.
+   c. Track budget consumption against `budgets`; on breach, park and report
+      (never silently overrun — backpressure at admission, program §1).
+   d. Do the work (harness-native).
+   e. Run the phase's `acceptance` validation contracts (§5). All must pass to
+      mark the phase done. A failing contract parks the phase with the contract's
+      evidence — it does NOT advance on a self-reported done.
+4. **Mission done** only when all phases are contract-satisfied. Emit a mission
+   receipt (binds to the contracts that passed and their evidence), suitable for
+   the lane ledger and — for Tier 3+/witnessed missions — the TET intent chain.
+
+The harness is swappable because every decision point is data in the schema
+(tiers, checkpoints, budgets, yield rules) or an external executable (probe,
+contracts), not a model judgment baked into one orchestrator. Swap the model
+running step 3d and the governance still holds.
+
+## 8. Migration / rollout
+
+- **Phase A — schema + validator, no enforcement.** Publish
+  `mission.schema.json` and `scripts/mission_run.py validate`. Add front-matter
+  to ONE existing plan (this event-substrate spec is the natural first subject,
+  since its phases and exit metrics are already written). Tier 1 (additive).
+- **Phase B — probes + contracts for that one mission.** Author the
+  readiness probe and the validation contracts referenced by the front-matter;
+  prove `mission_run.py` parks correctly on a failing probe and on a failing
+  contract. Tier 2.
+- **Phase C — backfill the corpus.** Add front-matter to the other active
+  `docs/superpowers/plans/*` missions; the schema must round-trip them without
+  information loss (if a real mission can't be expressed, the schema is wrong —
+  extend it). Tier 1–2.
+- **Phase D — harness adoption.** Document the loader contract (§7) so Codex and
+  Factory runs consume the same missions; the orchestrator is then demonstrably
+  swappable. Tier 2.
+
+Exit metric (falsifiable): the same mission file, executed by two different
+harnesses/models, reaches the same per-phase contract verdicts. If they diverge,
+a decision that should be data is still living in a model's head — find it and
+move it into the schema, a probe, or a contract.
+
+## Cross-references
+
+- Program: `docs/superpowers/plans/2026-06-13-conveyor-hardening-program.md` (§4 harness comparison + absorb items; §5.2).
+- Epic: [#8344](https://github.com/synaptent/aragora/issues/8344) (medium-term phase 2; phase 3 validation contracts + readiness probes).
+- Tier classification + checkpoint semantics: `docs/REVIEW_AUTHORITY_PRINCIPLES.md`.
+- Witness/receipt anchoring for Tier 3+ missions: `docs/specs/TAMPER_EVIDENT_TRAIL.md`.
+- First subject mission: `docs/superpowers/plans/2026-06-13-event-substrate-design.md`.
+- Related blocked work this discipline protects: #8315, #8316, #8343.

--- a/docs/superpowers/plans/2026-06-13-review-queue-decomposition-plan.md
+++ b/docs/superpowers/plans/2026-06-13-review-queue-decomposition-plan.md
@@ -1,0 +1,201 @@
+# review_queue.py Decomposition — Tier-4 Preapproval Artifact
+
+Status: **preapproval artifact** for a Tier-4 merge-authority self-modification
+(medium-term item 3 of epic [#8344](https://github.com/synaptent/aragora/issues/8344),
+§5.3 of `docs/superpowers/plans/2026-06-13-conveyor-hardening-program.md`).
+Written 2026-06-13.
+
+> **THIS IS A PLAN, NOT AN IMPLEMENTATION.** Per `docs/REVIEW_AUTHORITY_PRINCIPLES.md`,
+> any change to `aragora/cli/commands/review_queue.py` is **Tier 4** because the
+> model-quorum logic that gates the change *is* the code being changed — the
+> artifact under review would otherwise be its own arbiter. Tier 4 requires
+> **human preapproval before implementation AND human settlement (scarmani) on
+> each PR before merge.** This document is the preapproval artifact the operator
+> reviews to authorize the work. **No lane may begin implementation until this
+> plan is operator-approved, and each sub-PR below requires its own scarmani
+> settlement.** Do NOT propose or perform this unattended.
+
+## 1. Why decompose: the Tier-4 bottleneck
+
+`aragora/cli/commands/review_queue.py` is ~5,293 LOC (measured 2026-06-13)
+against a lint ratchet. It is the single Tier-4 merge-authority module, and
+three pieces of near-term work all queue behind its size and its
+self-arbitration property:
+
+- **#8315** — GraphQL→REST fallback for the merge-authority read path.
+- **#8316** — `settle_one` retry + `auto_evidence` `transport_blocked_prs`
+  surfacing (failure class B; "after the review_queue split or via extraction"
+  in the epic's own checklist).
+- **#8343** — `collect-evidence` CLI registration (Tier 4, checkpoint flow).
+
+Every edit to this file is a full Tier-4 ceremony, and the file's size makes
+each edit's blast radius large and its diff hard to settle. Decomposing it into
+cohesive submodules **does not loosen the gate** — it makes each future Tier-4
+change small, legible, and surface-pinned, so the operator can settle it
+honestly. The CODEOWNERS pin must follow the surface via a glob (`review_queue*`,
+per program §3 and the #8324 thread), so modularization never moves
+merge-authority code out from under scarmani's pin.
+
+## 2. Precedent / template (#8324)
+
+The decomposition is not novel — it is the continuation of an established
+pattern. Already extracted and present on `main`:
+
+- `review_queue_transport.py` (~7.8 KB) — `gh` CLI transport helpers,
+  transport-error classification (`transport_blocked`, the GitHub-transport
+  markers), JSON-with-retries. (Established by the #8324 line of work.)
+- `review_queue_parsers.py` (~5.3 KB) — argparse subparser registration helpers.
+- `review_queue_conductor.py` (~54.6 KB) — the owner-aware, read-only conductor
+  packet builder, which already imports back from `review_queue` and
+  `review_queue_transport` via the re-export discipline below.
+
+The #8324 `review_queue_rest_fallback.py` extraction is **not yet on main** (it
+is the in-flight Tier-4 template). This plan sequences the remaining splits the
+same way #8324 did its REST-fallback extraction: extract a cohesive unit, leave
+a re-export shim in `review_queue.py`, migrate the unit's tests, settle as its
+own Tier-4 PR.
+
+## 3. Proposed module boundaries
+
+The thin facade `review_queue.py` retains the public CLI surface (parser wiring
++ `cmd_*` dispatch) and re-exports every symbol other modules or tests import,
+so no public import path breaks. Cohesive units extracted:
+
+| Module | Responsibility | Representative symbols (from current `review_queue.py`) | Status |
+|---|---|---|---|
+| `review_queue_transport.py` | `gh` transport + transport-error classification | `_gh_json`, `_gh_json_with_transport_retries`, `_gh_error_kind`, `_is_github_transport_error` | **exists** |
+| `review_queue_parsers.py` | argparse subparser registration | `add_*_parser` helpers | **exists** |
+| `review_queue_conductor.py` | read-only owner-aware conductor packet | `QUEUE_CONDUCTOR_*`, conductor builder | **exists** |
+| `review_queue_rest_fallback.py` | GraphQL→REST fallback for the check/status read path | `_fetch_direct_commit_check_runs`, `_latest_direct_check_runs_by_name`, `_direct_check_run_*`, `_fetch_required_status_check_protection` | **planned in #8324** (this plan sequences after it) |
+| `review_queue_checks.py` | required-check surface summarization + rollup diagnostics | `_fetch_required_pr_check_surface`, `_summarize_required_pr_checks`, `_required_pr_check_bucket`, `_rollup_*`, `_build_check_surface_diagnostics`, `_status_check_*` | new |
+| `review_queue_packet.py` | merge-authorization packet building | `_build_packet`, `_build_merge_authorization_packet`, `_explicit_merged_pr_merge_packet_entry`, `_tier_requirement` | new |
+| `review_queue_quorum.py` | model-review quorum + tier classification (the gate core) | `_build_model_review_quorum`, `_classify_model_review_tier`, `_reviewer_signals_from_protocol`, `_infer_model_reviewer_from_text`, `ModelReviewIdentity` | new |
+| `review_queue_evidence_lint.py` | evidence-lint command logic | `_cmd_evidence_lint` and its helpers | new |
+| `review_queue_settlement.py` | settlement-creator pin + settlement receipts | `_post_human_settlement_status`, `_has_recorded_*_settlement`, `_has_tier_four_human_preapproval_comment`, `SettlementReceipt`, `RecordedSettlementResult`, `_resolve_settlement_repo_slug` | new |
+| `review_queue.py` (facade) | CLI parser wiring, `cmd_*` dispatch, re-export shims | `add_review_queue_parser`, `cmd_review_queue`, `_cmd_*` | **thin facade** |
+
+Boundary rationale:
+
+- **`review_queue_quorum.py` is the most sensitive unit** — it is literally the
+  merge-authority gate (quorum counting, tier classification, the family
+  recognizer `_infer_model_reviewer_from_text` whose change
+  `docs/REVIEW_AUTHORITY_PRINCIPLES.md` already names as Tier 4). It is extracted
+  *last* and most carefully; its PR is the one where self-arbitration risk is
+  highest, so its scarmani settlement scrutiny is highest.
+- **`review_queue_settlement.py`** carries the H2 settlement-creator pin logic
+  (`creator.login == scarmani`); it must land only after #8274's pins are in
+  place (§7), so the extraction moves code that is already pin-protected.
+- **`review_queue_checks.py` / `review_queue_packet.py`** are mechanical,
+  read-only surfaces with the largest LOC win and lowest semantic risk — they go
+  early to relieve the lint ratchet for #8315/#8316/#8343.
+
+## 4. Re-export-shim discipline (public symbols)
+
+The pattern already in use (`review_queue_conductor.py` imports
+`_build_merge_authorization_packet`, `_fetch_required_pr_check_surface`, etc.
+back from `review_queue`). Discipline for every extraction:
+
+1. Move the implementation to the new module.
+2. In `review_queue.py`, add `from aragora.cli.commands.review_queue_<unit> import (...)`
+   re-exporting **every** symbol that any other module or test referenced from
+   `review_queue` — so existing import paths keep working unchanged. The facade
+   becomes the stable public surface; the units are the implementation.
+3. Avoid import cycles: shared low-level helpers (transport, identity dataclasses)
+   live in the leaf modules; the facade and conductor import *from* the units,
+   never the reverse for anything load-bearing. Where the current conductor
+   imports back from `review_queue`, redirect those imports to the new units once
+   the units exist (a follow-up cleanup PR, not a blocker).
+4. Each shim PR is verified by: full import of `aragora.cli.commands.review_queue`
+   succeeds; every previously-importable symbol still resolves (a characterization
+   test enumerates the public symbol set and asserts it is unchanged across the
+   extraction — this is the safety net against accidentally narrowing the gate).
+
+## 5. Test-migration plan
+
+- Before any extraction: add a **characterization test** that pins the current
+  public symbol set of `review_queue` and the current gate verdicts on a corpus
+  of representative packets (Tier 0–4). This is the inversion-proof: the
+  decomposition must not change a single gate verdict. (Pattern named in
+  `docs/REVIEW_AUTHORITY_PRINCIPLES.md`: governance tests in `tests/governance/`
+  that characterize current gate behavior.)
+- Per extraction: move the unit's tests alongside the unit
+  (`tests/.../test_review_queue_<unit>.py`), keep a thin re-import test ensuring
+  the facade still exposes the moved symbols, and re-run the characterization
+  test — green characterization is the per-PR acceptance gate.
+- The `review_queue_quorum.py` extraction additionally re-runs the
+  `tests/governance/` suite that pins family-eligibility-by-tier (the payload of
+  `docs/REVIEW_AUTHORITY_PRINCIPLES.md` §"Model family eligibility") to prove the
+  gate's counting rules are byte-for-byte preserved.
+
+## 6. What stays in the thin facade
+
+`review_queue.py` keeps only: `add_review_queue_parser` (parser wiring,
+delegating to `review_queue_parsers`), `cmd_review_queue` dispatch, the `_cmd_*`
+handlers (which orchestrate the extracted units), the public dataclasses kept
+for back-compat re-export, and the re-export block. Target: a facade well under
+the lint ratchet, with each future Tier-4 change touching one cohesive unit.
+
+## 7. Sequencing — AFTER #8274 (scarmani pins)
+
+This work is sequenced **after #8274 lands** (the 4-commit scarmani sitting: H1
+CODEOWNERS pin incl. the `review_queue*` glob, H2 settlement-creator pin). Two
+reasons, both load-bearing:
+
+1. The `review_queue*` **glob pin must exist first** so that as code moves into
+   `review_queue_*.py` modules, it stays under scarmani's CODEOWNERS authority
+   (program §3: "pins must follow surfaces ... because modularization otherwise
+   moves merge-authority code out from under the pin"). Decomposing before the
+   glob pin would briefly orphan merge-authority code from its owner.
+2. `review_queue_settlement.py` extracts the H2 settlement-creator-pin logic;
+   that logic should already be the pinned, settled behavior before it is moved.
+
+Also requires the operator to have completed the epic's near-term item: "check
+existing broad `@an0mium` CODEOWNERS rules won't freeze automation" (an author
+cannot approve their own PR; broad rules would freeze the pipeline) before
+require-code-owner-review is enabled.
+
+## 8. Exact sub-PR sequence (each Tier 4, each scarmani-settled)
+
+Each PR below is its own Tier-4 merge-authority PR requiring operator preapproval
+(this artifact) plus a per-PR scarmani settlement. They are ordered
+lowest-risk-first to relieve the lint ratchet early and defer the gate core last.
+
+| # | PR | Extract | Risk | Unblocks |
+|---|---|---|---|---|
+| 0 | **prerequisite** | #8274 scarmani pins land; #8324 `review_queue_rest_fallback.py` lands | — | the glob pin + the template |
+| 1 | char-test | `tests/governance/` characterization test pinning public symbols + Tier 0–4 verdicts | low | the safety net for all that follow |
+| 2 | checks | `review_queue_checks.py` (required-check surface + rollup diagnostics) | low (read-only) | LOC relief for #8315/#8316/#8343 |
+| 3 | packet | `review_queue_packet.py` (merge-authorization packet building) | medium (read-only, gate-adjacent) | #8315 (REST fallback in packet path), #8316 |
+| 4 | evidence-lint | `review_queue_evidence_lint.py` | low | #8343 collect-evidence registration |
+| 5 | settlement | `review_queue_settlement.py` (incl. H2 creator-pin logic) | medium-high (settlement semantics) | clean settlement surface; AFTER #8274 |
+| 6 | quorum | `review_queue_quorum.py` (model quorum + tier classification — the gate core) | **highest** (self-arbitration) | the legibility win on the most sensitive code |
+| 7 | shim cleanup | redirect conductor's back-imports to the new units; tighten facade | low | final facade < lint ratchet |
+
+Each PR: characterization test green (no gate-verdict change), full
+`review_queue` import resolves, public symbol set unchanged, then scarmani
+settlement. If any PR's characterization test changes a verdict, that PR is
+**not a refactor** — it is a gate behavior change and must be split out and
+settled as such (or rejected).
+
+## 9. Explicit Tier-4 guardrails (restated)
+
+- This plan is the **preapproval artifact**; implementation begins only after the
+  operator approves it.
+- Each of PRs 1–7 requires its own **scarmani settlement** (the
+  `aragora/human-settlement` status, creator `scarmani`, per
+  `docs/REVIEW_AUTHORITY_PRINCIPLES.md` and the H2 pin).
+- A lane may **prepare** the diffs and characterization tests, but MUST park at
+  the settlement boundary and MUST NOT self-merge — "tier escalations park by
+  default; disclose-and-proceed races the operator" (program operating lesson 4).
+- Pure refactor only: zero gate-verdict changes. Any behavior change (incl.
+  touching `_infer_model_reviewer_from_text` family eligibility) is a separate,
+  separately-preapproved Tier-4 change with its own `docs/specs/` artifact, per
+  the family-additive governance rule in `docs/REVIEW_AUTHORITY_PRINCIPLES.md`.
+
+## Cross-references
+
+- Program: `docs/superpowers/plans/2026-06-13-conveyor-hardening-program.md` (§3 identity/pins-follow-surfaces, §5.3).
+- Epic: [#8344](https://github.com/synaptent/aragora/issues/8344) (medium-term phase 5; near-term #8274 sitting).
+- Tier-4 / merge-authority self-modification rule + family eligibility: `docs/REVIEW_AUTHORITY_PRINCIPLES.md`.
+- Pins: #8274 (scarmani H1/H2, `review_queue*` glob). Template: #8324 (`review_queue_rest_fallback.py`).
+- Unblocked work: #8315 (GraphQL→REST fallback), #8316 (settle_one retry / transport surfacing), #8343 (collect-evidence registration).


### PR DESCRIPTION
## What

Three reviewable design specs turning the conveyor-hardening epic's (#8344) medium-term direction into executable plans. **Docs-only, Tier ≤1** — no implementation; the review_queue item is explicitly a Tier-4 preapproval artifact, not code.

`docs/superpowers/plans/`:

1. **`2026-06-13-event-substrate-design.md`** — GitHub webhook (`pull_request`/`check_run`/`status`/`issue_comment`) → new `scripts/event_cache_collector.py` (append-only) → the existing `.aragora/pr-state-cache.json` (#8339), lane reader contract unchanged. Retires most PR-state polling (the GraphQL-starvation root cause, failure class E). Doubles as the tamper-evident-trail external witness; 4-phase run-alongside-then-retire rollout with a reconcile-poll backstop; collector write-credentials isolated from agent-reachable disk.
2. **`2026-06-13-mission-schema-design.md`** — YAML front-matter + `mission.schema.json` formalizing `docs/superpowers/plans/*` into a harness-agnostic contract (goal, phases, tier, budgets, human checkpoints, path-freeze/ODR yield rules), with pluggable validation contracts + a pre-launch readiness probe. Framed against the Fable-5 suspension as the orchestrator-swappability fix; Factory missions as prior art.
3. **`2026-06-13-review-queue-decomposition-plan.md`** — **Tier-4 preapproval artifact** (not implementation): 7 cohesive submodules, re-export-shim discipline, characterization-test-gated migration, an exact lowest-risk-first sub-PR sequence each requiring scarmani settlement, sequenced **after #8274**. Restates the guardrails forbidding unattended execution or any gate-verdict change. Unblocks #8315/#8316/#8343 once executed.

## Validation

- Docs-only, 720 insertions across 3 files. Code fences balanced; cross-refs to #8344/#8315/#8316/#8343/#8274, the program doc, `TAMPER_EVIDENT_TRAIL.md`, `REVIEW_AUTHORITY_PRINCIPLES.md` in place.
- Ran `doc_stats.py --write` (no tracked diff — metrics already match main) and `sync-docs.js` (these plans are outside its curated mirror, so no mirror output) — keeps the `build`/docs-sync check green.

Part of epic #8344.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jfJj5gb9VoLs6VBMnzhrP

---
_Generated by [Claude Code](https://claude.ai/code/session_018jfJj5gb9VoLs6VBMnzhrP)_