### PR TITLE
fix(preflight): suggest benchmark truth renderer validation

### DIFF
--- a/scripts/automation_pr_preflight.sh
+++ b/scripts/automation_pr_preflight.sh
@@ -61,6 +61,7 @@ def lines(name: str) -> list[str]:
     return [line for line in os.environ.get(name, "").splitlines() if line]
 
 
+changed_paths = set(lines("PREFLIGHT_CHANGED_FILES"))
 source_changes = lines("PREFLIGHT_SOURCE_CHANGES")
 test_changes = lines("PREFLIGHT_TEST_CHANGES")
 publisher_startup_changes = lines("PREFLIGHT_PUBLISHER_STARTUP_CHANGES")
@@ -75,6 +76,14 @@ if python_sources:
 if test_changes:
     quoted_tests = " ".join(shlex.quote(path) for path in test_changes)
     suggested_commands.append(f"python3 -m pytest {quoted_tests} -q")
+if changed_paths & {
+    "scripts/render_benchmark_truth_status.py",
+    "tests/scripts/test_render_benchmark_truth_status.py",
+}:
+    suggested_commands.append("python3 -m py_compile scripts/render_benchmark_truth_status.py")
+    pytest_command = "python3 -m pytest tests/scripts/test_render_benchmark_truth_status.py -q"
+    if pytest_command not in suggested_commands:
+        suggested_commands.append(pytest_command)
 if publisher_startup_changes:
     startup_modules = (
         "scripts.cache_codex_automation_github_status",


### PR DESCRIPTION
## Summary
- Teaches `scripts/automation_pr_preflight.sh` to suggest the focused benchmark-truth renderer validation when the renderer or its test changes.

## Harvest evidence
- Branch: `codex/swarm-01659fc4-micro-5`
- Head: `2f2a1f682c90e27d7406a491cc367ebe4e8d180f`
- Source worktree: `/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-01659fc4-micro-5`
- Inventory class before publish: `unique_unharvested`
- Owner: unowned; no operator-steering lane matched
- Prior representation: no existing PR, no outbox/receipt hit for branch/head
- Merge-tree against current `origin/main`: clean

## Validation
- `bash -n scripts/automation_pr_preflight.sh`
- `git diff --check origin/main...HEAD -- scripts/automation_pr_preflight.sh`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- Pre-push hooks passed on branch publish.

## Governance note
This touches the PR preflight/gate helper. Draft harvest only: keep parked for human review; do not mark ready or merge in the harvest cycle.
