### PR TITLE
fix(review-queue): use codex for openai evidence fallback

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -690,33 +690,22 @@ def add_review_queue_parser(subparsers: argparse._SubParsersAction) -> None:
             "Defaults to a dry run that posts nothing."
         ),
     )
-    collect_evidence_p.add_argument(
-        "--pr", required=True, type=int, help="PR number to collect evidence for"
-    )
-    collect_evidence_p.add_argument(
-        "--repo",
-        default="",
-        help="owner/name of the target repo (default: current gh context)",
-    )
-    collect_evidence_p.add_argument(
+    collect_evidence_arg = collect_evidence_p.add_argument
+    collect_evidence_arg("--pr", required=True, type=int, help="PR number to collect evidence for")
+    collect_evidence_arg("--repo", default="", help="owner/name target repo (default: gh context)")
+    collect_evidence_arg(
         "--reviewers",
         nargs="+",
         default=None,
         help="reviewer model families to run (default: claude grok)",
     )
-    collect_evidence_p.add_argument(
-        "--author",
-        default=None,
-        help="GitHub login to simulate for evidence-lint (default: gh authenticated user)",
+    collect_evidence_arg(
+        "--author", default=None, help="GitHub login for evidence-lint (default: gh user)"
     )
-    collect_evidence_p.add_argument(
-        "--apply",
-        action="store_true",
-        help="Post evidence for Tier 0-2 PRs (Tier 3-4 always prepare-only).",
+    collect_evidence_arg(
+        "--apply", action="store_true", help="Post Tier 0-2 evidence; Tier 3-4 prepare only."
     )
-    collect_evidence_p.add_argument(
-        "--json", dest="json_output", action="store_true", help="Output as JSON"
-    )
+    collect_evidence_arg("--json", dest="json_output", action="store_true", help="Output as JSON")
 
     lint_comment_p = sub.add_parser(
         "lint-comment",

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -679,6 +679,45 @@ def add_review_queue_parser(subparsers: argparse._SubParsersAction) -> None:
     )
     evidence_lint_p.add_argument("--json", action="store_true", help="Output as JSON")
 
+    collect_evidence_p = sub.add_parser(
+        "collect-evidence",
+        help="Run genuine model reviewers, lint their evidence, post only if tier allows",
+        description=(
+            "Run >=2 genuine heterogeneous model reviewers against a PR's exact head, "
+            "compose evidence comments the quorum parsers recognize, and validate each "
+            "with evidence-lint before posting. Only Tier 0-2 PRs auto-post (with "
+            "--apply); Tier 3-4 always prepare evidence for operator settlement. "
+            "Defaults to a dry run that posts nothing."
+        ),
+    )
+    collect_evidence_p.add_argument(
+        "--pr", required=True, type=int, help="PR number to collect evidence for"
+    )
+    collect_evidence_p.add_argument(
+        "--repo",
+        default="",
+        help="owner/name of the target repo (default: current gh context)",
+    )
+    collect_evidence_p.add_argument(
+        "--reviewers",
+        nargs="+",
+        default=None,
+        help="reviewer model families to run (default: claude grok)",
+    )
+    collect_evidence_p.add_argument(
+        "--author",
+        default=None,
+        help="GitHub login to simulate for evidence-lint (default: gh authenticated user)",
+    )
+    collect_evidence_p.add_argument(
+        "--apply",
+        action="store_true",
+        help="Post evidence for Tier 0-2 PRs (Tier 3-4 always prepare-only).",
+    )
+    collect_evidence_p.add_argument(
+        "--json", dest="json_output", action="store_true", help="Output as JSON"
+    )
+
     lint_comment_p = sub.add_parser(
         "lint-comment",
         help="Dry-run whether a proposed reviewer comment will count before posting",

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -103,6 +103,7 @@ _REVIEWER_TIMEOUT = 300
 _CLAUDE_TIMEOUT_ENV = "ARAGORA_COLLECT_EVIDENCE_CLAUDE_TIMEOUT_SECONDS"
 _CODEX_TIMEOUT_ENV = "ARAGORA_COLLECT_EVIDENCE_CODEX_TIMEOUT_SECONDS"
 _CODEX_MODEL_ENV = "ARAGORA_COLLECT_EVIDENCE_CODEX_MODEL"
+_CODEX_DEFAULT_MODEL = "gpt-5.5"
 _REVIEWER_TIMEOUT_ENV = "ARAGORA_COLLECT_EVIDENCE_REVIEWER_TIMEOUT_SECONDS"
 _CODEX_OPENAI_HARNESS = "Codex CLI OpenAI harness"
 _REVIEWER_CLEANUP_TIMEOUT = 10
@@ -424,15 +425,14 @@ def _run_codex_openai_cli(prompt: str) -> ReviewerResult:
         cmd = [
             "codex",
             "exec",
+            "--ignore-user-config",
             "--sandbox",
             "read-only",
-            "--ask-for-approval",
-            "never",
             "--ephemeral",
             "--output-last-message",
             output_path,
         ]
-        model = os.environ.get(_CODEX_MODEL_ENV, "").strip()
+        model = os.environ.get(_CODEX_MODEL_ENV, "").strip() or _CODEX_DEFAULT_MODEL
         if model:
             cmd.extend(["--model", model])
         cmd.append("-")

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -33,6 +33,7 @@ import math
 import os
 import re
 import subprocess
+import tempfile
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from typing import Any
@@ -84,9 +85,13 @@ _MAX_DIFF_CHARS = 60_000
 # Cap reviewer output so a runaway model cannot exceed GitHub's per-comment limit.
 _MAX_REVIEWER_CHARS = 32_000
 _CLAUDE_TIMEOUT = 300
+_CODEX_TIMEOUT = 300
 _REVIEWER_TIMEOUT = 300
 _CLAUDE_TIMEOUT_ENV = "ARAGORA_COLLECT_EVIDENCE_CLAUDE_TIMEOUT_SECONDS"
+_CODEX_TIMEOUT_ENV = "ARAGORA_COLLECT_EVIDENCE_CODEX_TIMEOUT_SECONDS"
+_CODEX_MODEL_ENV = "ARAGORA_COLLECT_EVIDENCE_CODEX_MODEL"
 _REVIEWER_TIMEOUT_ENV = "ARAGORA_COLLECT_EVIDENCE_REVIEWER_TIMEOUT_SECONDS"
+_CODEX_OPENAI_HARNESS = "Codex CLI OpenAI harness"
 
 
 def _cap_text(text: str) -> str:
@@ -121,6 +126,7 @@ class ReviewerResult:
     text: str
     ok: bool
     error: str = ""
+    harness: str = ""
 
 
 @dataclass
@@ -300,6 +306,8 @@ def default_reviewer_runner(family: str, prompt: str) -> ReviewerResult:
     fam = family.strip().lower()
     if fam == "claude":
         return _run_claude_cli(prompt)
+    if fam == "openai":
+        return _run_openai_reviewer(prompt)
     return _run_api_agent(fam, prompt)
 
 
@@ -333,6 +341,79 @@ def _run_claude_cli(prompt: str) -> ReviewerResult:
             f"claude CLI exit {proc.returncode}: {(proc.stderr or '').strip()[:200]}",
         )
     return ReviewerResult("claude", _cap_text(text), True)
+
+
+def _run_openai_reviewer(prompt: str) -> ReviewerResult:
+    """Run OpenAI evidence via direct API when available, else Codex CLI.
+
+    Operator machines often have Codex subscription auth but no direct
+    ``OPENAI_API_KEY``. In that case Codex CLI is the local OpenAI-family
+    reviewer; the normal exact-head comment composition and lint-before-post
+    paths still decide whether the resulting evidence can count.
+    """
+    if os.environ.get("OPENAI_API_KEY", "").strip():
+        return _run_api_agent("openai", prompt)
+    return _run_codex_openai_cli(prompt)
+
+
+def _run_codex_openai_cli(prompt: str) -> ReviewerResult:
+    timeout = _timeout_seconds(_CODEX_TIMEOUT_ENV, _CODEX_TIMEOUT)
+    output_path = ""
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w", suffix=".md", prefix="aragora-codex-openai-review-", delete=False
+        ) as fh:
+            output_path = fh.name
+        cmd = [
+            "codex",
+            "exec",
+            "--sandbox",
+            "read-only",
+            "--ask-for-approval",
+            "never",
+            "--ephemeral",
+            "--output-last-message",
+            output_path,
+        ]
+        model = os.environ.get(_CODEX_MODEL_ENV, "").strip()
+        if model:
+            cmd.extend(["--model", model])
+        cmd.append("-")
+        proc = subprocess.run(
+            cmd,
+            input=prompt,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except FileNotFoundError:
+        return ReviewerResult("openai", "", False, "codex CLI not found on PATH")
+    except subprocess.TimeoutExpired:
+        return ReviewerResult(
+            "openai", "", False, f"codex CLI timed out after {_format_seconds(timeout)}s"
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return ReviewerResult("openai", "", False, f"{type(exc).__name__}: {str(exc)[:200]}")
+    try:
+        text = ""
+        if output_path and os.path.exists(output_path):
+            with open(output_path, encoding="utf-8") as fh:
+                text = fh.read().strip()
+        if not text:
+            text = (proc.stdout or "").strip()
+        if proc.returncode != 0 or not text:
+            detail = (proc.stderr or proc.stdout or "").strip()[:200]
+            return ReviewerResult(
+                "openai", "", False, f"codex CLI exit {proc.returncode}: {detail}"
+            )
+        return ReviewerResult("openai", _cap_text(text), True, harness=_CODEX_OPENAI_HARNESS)
+    finally:
+        if output_path:
+            try:
+                os.unlink(output_path)
+            except OSError:
+                pass
 
 
 def _run_api_agent(family: str, prompt: str) -> ReviewerResult:
@@ -550,6 +631,7 @@ def collect_evidence(
             head_committed_at=head_committed_at,
             pr=pr,
             reviewer_text=result.text,
+            harness=result.harness,
         )
         lint = linter(pr, head_sha, head_committed_at, author, body, env or {})
         outcome.items.append(

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -444,15 +444,6 @@ def _run_codex_openai_cli(prompt: str) -> ReviewerResult:
             timeout=timeout,
             check=False,
         )
-    except FileNotFoundError:
-        return ReviewerResult("openai", "", False, "codex CLI not found on PATH")
-    except subprocess.TimeoutExpired:
-        return ReviewerResult(
-            "openai", "", False, f"codex CLI timed out after {_format_seconds(timeout)}s"
-        )
-    except (OSError, subprocess.SubprocessError) as exc:
-        return ReviewerResult("openai", "", False, f"{type(exc).__name__}: {str(exc)[:200]}")
-    try:
         text = ""
         if output_path and os.path.exists(output_path):
             with open(output_path, encoding="utf-8") as fh:
@@ -465,6 +456,14 @@ def _run_codex_openai_cli(prompt: str) -> ReviewerResult:
                 "openai", "", False, f"codex CLI exit {proc.returncode}: {detail}"
             )
         return ReviewerResult("openai", _cap_text(text), True, harness=_CODEX_OPENAI_HARNESS)
+    except FileNotFoundError:
+        return ReviewerResult("openai", "", False, "codex CLI not found on PATH")
+    except subprocess.TimeoutExpired:
+        return ReviewerResult(
+            "openai", "", False, f"codex CLI timed out after {_format_seconds(timeout)}s"
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return ReviewerResult("openai", "", False, f"{type(exc).__name__}: {str(exc)[:200]}")
     finally:
         if output_path:
             try:

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -103,9 +103,12 @@ _REVIEWER_TIMEOUT = 300
 _CLAUDE_TIMEOUT_ENV = "ARAGORA_COLLECT_EVIDENCE_CLAUDE_TIMEOUT_SECONDS"
 _CODEX_TIMEOUT_ENV = "ARAGORA_COLLECT_EVIDENCE_CODEX_TIMEOUT_SECONDS"
 _CODEX_MODEL_ENV = "ARAGORA_COLLECT_EVIDENCE_CODEX_MODEL"
-_CODEX_DEFAULT_MODEL = "gpt-5.5"
+_CODEX_MODELS_ENV = "ARAGORA_COLLECT_EVIDENCE_CODEX_MODELS"
+_CODEX_DEFAULT_MODELS = ("gpt-5.5", "gpt-5")
+_CODEX_DEFAULT_MODEL = _CODEX_DEFAULT_MODELS[0]
 _REVIEWER_TIMEOUT_ENV = "ARAGORA_COLLECT_EVIDENCE_REVIEWER_TIMEOUT_SECONDS"
 _CODEX_OPENAI_HARNESS = "Codex CLI OpenAI harness"
+_CODEX_APPROVAL_POLICY_CONFIG = 'approval_policy="never"'
 _REVIEWER_CLEANUP_TIMEOUT = 10
 
 
@@ -416,60 +419,103 @@ def _run_openai_reviewer(prompt: str) -> ReviewerResult:
 
 def _run_codex_openai_cli(prompt: str) -> ReviewerResult:
     timeout = _timeout_seconds(_CODEX_TIMEOUT_ENV, _CODEX_TIMEOUT)
-    output_path = ""
-    try:
-        with tempfile.NamedTemporaryFile(
-            "w", suffix=".md", prefix="aragora-codex-openai-review-", delete=False
-        ) as fh:
-            output_path = fh.name
-        cmd = [
-            "codex",
-            "exec",
-            "--ignore-user-config",
-            "--sandbox",
-            "read-only",
-            "--ephemeral",
-            "--output-last-message",
-            output_path,
-        ]
-        model = os.environ.get(_CODEX_MODEL_ENV, "").strip() or _CODEX_DEFAULT_MODEL
-        if model:
-            cmd.extend(["--model", model])
-        cmd.append("-")
-        proc = subprocess.run(
-            cmd,
-            input=prompt,
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-            check=False,
-        )
-        text = ""
-        if output_path and os.path.exists(output_path):
-            with open(output_path, encoding="utf-8") as fh:
-                text = fh.read().strip()
-        if not text:
-            text = (proc.stdout or "").strip()
-        if proc.returncode != 0 or not text:
-            detail = (proc.stderr or proc.stdout or "").strip()[:200]
-            return ReviewerResult(
-                "openai", "", False, f"codex CLI exit {proc.returncode}: {detail}"
+    model_candidates = _codex_model_candidates()
+    model_errors: list[str] = []
+    for index, model in enumerate(model_candidates):
+        output_path = ""
+        try:
+            with tempfile.NamedTemporaryFile(
+                "w", suffix=".md", prefix="aragora-codex-openai-review-", delete=False
+            ) as fh:
+                output_path = fh.name
+            cmd = _codex_openai_command(output_path, model=model)
+            proc = subprocess.run(
+                cmd,
+                input=prompt,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                check=False,
             )
-        return ReviewerResult("openai", _cap_text(text), True, harness=_CODEX_OPENAI_HARNESS)
-    except FileNotFoundError:
-        return ReviewerResult("openai", "", False, "codex CLI not found on PATH")
-    except subprocess.TimeoutExpired:
-        return ReviewerResult(
-            "openai", "", False, f"codex CLI timed out after {_format_seconds(timeout)}s"
+            text = ""
+            if output_path and os.path.exists(output_path):
+                with open(output_path, encoding="utf-8") as fh:
+                    text = fh.read().strip()
+            if not text:
+                text = (proc.stdout or "").strip()
+            if proc.returncode != 0 or not text:
+                detail = (proc.stderr or proc.stdout or "").strip()[:200]
+                if index < len(model_candidates) - 1 and _codex_model_selection_failed(detail):
+                    model_errors.append(f"{model}: {detail}")
+                    continue
+                if model_errors:
+                    detail = (
+                        f"{detail}; previous model selection failures: {'; '.join(model_errors)}"
+                    )
+                return ReviewerResult(
+                    "openai", "", False, f"codex CLI exit {proc.returncode}: {detail}"
+                )
+            return ReviewerResult("openai", _cap_text(text), True, harness=_CODEX_OPENAI_HARNESS)
+        except FileNotFoundError:
+            return ReviewerResult("openai", "", False, "codex CLI not found on PATH")
+        except subprocess.TimeoutExpired:
+            return ReviewerResult(
+                "openai", "", False, f"codex CLI timed out after {_format_seconds(timeout)}s"
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            return ReviewerResult("openai", "", False, f"{type(exc).__name__}: {str(exc)[:200]}")
+        finally:
+            if output_path:
+                try:
+                    os.unlink(output_path)
+                except OSError:
+                    pass
+    return ReviewerResult("openai", "", False, "codex CLI has no configured model candidates")
+
+
+def _codex_model_candidates() -> list[str]:
+    pinned_model = os.environ.get(_CODEX_MODEL_ENV, "").strip()
+    if pinned_model:
+        return [pinned_model]
+    raw_models = os.environ.get(_CODEX_MODELS_ENV, "").strip()
+    candidates = re.split(r"[\s,]+", raw_models) if raw_models else list(_CODEX_DEFAULT_MODELS)
+    return list(dict.fromkeys(model.strip() for model in candidates if model.strip()))
+
+
+def _codex_openai_command(output_path: str, *, model: str) -> list[str]:
+    cmd = [
+        "codex",
+        "exec",
+        "--ignore-user-config",
+        "-c",
+        _CODEX_APPROVAL_POLICY_CONFIG,
+        "--sandbox",
+        "read-only",
+        "--ephemeral",
+        "--output-last-message",
+        output_path,
+    ]
+    if model:
+        cmd.extend(["--model", model])
+    cmd.append("-")
+    return cmd
+
+
+def _codex_model_selection_failed(detail: str) -> bool:
+    lower = detail.lower()
+    if "model" not in lower:
+        return False
+    return any(
+        marker in lower
+        for marker in (
+            "not supported",
+            "not available",
+            "unsupported",
+            "unknown",
+            "invalid",
+            "unrecognized",
         )
-    except (OSError, subprocess.SubprocessError) as exc:
-        return ReviewerResult("openai", "", False, f"{type(exc).__name__}: {str(exc)[:200]}")
-    finally:
-        if output_path:
-            try:
-                os.unlink(output_path)
-            except OSError:
-                pass
+    )
 
 
 def _run_api_agent(family: str, prompt: str) -> ReviewerResult:

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -4933,6 +4933,30 @@ class TestCommandDispatch:
         assert ns_evidence_lint.head_sha == "headsha123"
         assert ns_evidence_lint.body_file is None
         assert ns_evidence_lint.json is True
+        # collect-evidence invocation parses through the fast-path command parser
+        ns_collect = root.parse_args(
+            [
+                "review-queue",
+                "collect-evidence",
+                "--repo",
+                "synaptent/aragora",
+                "--pr",
+                "6280",
+                "--reviewers",
+                "claude",
+                "openai",
+                "--author",
+                "an0mium",
+                "--json",
+            ]
+        )
+        assert ns_collect.review_queue_command == "collect-evidence"
+        assert ns_collect.repo == "synaptent/aragora"
+        assert ns_collect.pr == 6280
+        assert ns_collect.reviewers == ["claude", "openai"]
+        assert ns_collect.author == "an0mium"
+        assert ns_collect.apply is False
+        assert ns_collect.json_output is True
         # run invocation parses
         ns_run = root.parse_args(["review-queue", "run", "--limit", "3", "--ready-only"])
         assert ns_run.review_queue_command == "run"

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -316,6 +316,8 @@ def test_run_openai_reviewer_without_api_key_uses_codex_cli(
         "codex",
         "exec",
         "--ignore-user-config",
+        "-c",
+        qe._CODEX_APPROVAL_POLICY_CONFIG,
         "--sandbox",
         "read-only",
         "--ephemeral",
@@ -332,6 +334,69 @@ def test_run_openai_reviewer_without_api_key_uses_codex_cli(
     assert seen["timeout"] == 11.0
     assert seen["check"] is False
     assert not Path(seen["output_path"]).exists()
+
+
+def test_run_openai_reviewer_retries_default_codex_model_selection_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list[str]] = []
+    output_paths: list[Path] = []
+
+    def fake_run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        output_paths.append(Path(cmd[cmd.index("--output-last-message") + 1]))
+        model = cmd[cmd.index("--model") + 1]
+        if model == qe._CODEX_DEFAULT_MODELS[0]:
+            return subprocess.CompletedProcess(
+                cmd,
+                1,
+                stdout="",
+                stderr=f"model {model} is not supported",
+            )
+        output_paths[-1].write_text("Verdict: PASS after fallback", encoding="utf-8")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv(qe._CODEX_MODEL_ENV, raising=False)
+    monkeypatch.delenv(qe._CODEX_MODELS_ENV, raising=False)
+    monkeypatch.setattr(qe.subprocess, "run", fake_run)
+
+    result = qe._run_openai_reviewer("review prompt")
+
+    assert result == ReviewerResult(
+        "openai",
+        "Verdict: PASS after fallback",
+        True,
+        harness=qe._CODEX_OPENAI_HARNESS,
+    )
+    assert [call[call.index("--model") + 1] for call in calls] == list(qe._CODEX_DEFAULT_MODELS)
+    assert all(not path.exists() for path in output_paths)
+
+
+def test_run_openai_reviewer_respects_pinned_codex_model_without_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        return subprocess.CompletedProcess(
+            cmd,
+            1,
+            stdout="",
+            stderr="model pinned-model is not supported",
+        )
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv(qe._CODEX_MODEL_ENV, "pinned-model")
+    monkeypatch.setattr(qe.subprocess, "run", fake_run)
+
+    result = qe._run_openai_reviewer("review prompt")
+
+    assert result.ok is False
+    assert "codex CLI exit 1: model pinned-model is not supported" in result.error
+    assert len(calls) == 1
+    assert calls[0][-3:] == ["--model", "pinned-model", "-"]
 
 
 def test_run_openai_reviewer_passes_optional_codex_model(

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -375,6 +375,44 @@ def test_run_openai_reviewer_codex_failure_never_fabricates(
     assert result.harness == ""
 
 
+@pytest.mark.parametrize(
+    ("exc", "expected_error"),
+    [
+        (
+            subprocess.TimeoutExpired(cmd=["codex"], timeout=3),
+            "codex CLI timed out after",
+        ),
+        (FileNotFoundError("missing codex"), "codex CLI not found on PATH"),
+        (OSError("disk full"), "OSError: disk full"),
+        (subprocess.SubprocessError("bad pipe"), "SubprocessError: bad pipe"),
+    ],
+)
+def test_run_openai_reviewer_cleans_codex_output_file_when_subprocess_raises(
+    monkeypatch: pytest.MonkeyPatch,
+    exc: Exception,
+    expected_error: str,
+) -> None:
+    seen: dict[str, Path] = {}
+
+    def fake_run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
+        output_path = Path(cmd[cmd.index("--output-last-message") + 1])
+        output_path.write_text("partial reviewer output", encoding="utf-8")
+        seen["output_path"] = output_path
+        raise exc
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(qe.subprocess, "run", fake_run)
+
+    result = qe._run_openai_reviewer("review prompt")
+
+    assert result.family == "openai"
+    assert result.text == ""
+    assert result.ok is False
+    assert expected_error in result.error
+    assert "output_path" in seen
+    assert not seen["output_path"].exists()
+
+
 # --- default API reviewer cleanup ------------------------------------------
 
 

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -12,6 +12,7 @@ The compose helper is checked against the *real* evidence parser
 from __future__ import annotations
 
 import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -242,6 +243,129 @@ def test_run_claude_cli_uses_env_timeout(monkeypatch: pytest.MonkeyPatch) -> Non
         False,
         "claude CLI timed out after 7s",
     )
+
+
+# --- OpenAI reviewer fallback ----------------------------------------------
+
+
+def test_run_openai_reviewer_uses_api_when_openai_key_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, str]] = []
+
+    def fake_api_agent(family: str, prompt: str) -> ReviewerResult:
+        calls.append((family, prompt))
+        return ReviewerResult(family, "Verdict: PASS from API", True)
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setattr(qe, "_run_api_agent", fake_api_agent)
+
+    result = qe._run_openai_reviewer("review prompt")
+
+    assert result == ReviewerResult("openai", "Verdict: PASS from API", True)
+    assert calls == [("openai", "review prompt")]
+
+
+def test_run_openai_reviewer_without_api_key_uses_codex_cli(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: dict[str, object] = {}
+
+    def fake_run(
+        cmd: list[str],
+        *,
+        input: str,
+        capture_output: bool,
+        text: bool,
+        timeout: float,
+        check: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        seen.update(
+            {
+                "cmd": cmd,
+                "input": input,
+                "capture_output": capture_output,
+                "text": text,
+                "timeout": timeout,
+                "check": check,
+            }
+        )
+        output_path = Path(cmd[cmd.index("--output-last-message") + 1])
+        output_path.write_text("Verdict: PASS via Codex\n", encoding="utf-8")
+        seen["output_path"] = output_path
+        return subprocess.CompletedProcess(cmd, 0, stdout="ignored stdout", stderr="")
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv(qe._CODEX_TIMEOUT_ENV, "11")
+    monkeypatch.setattr(qe.subprocess, "run", fake_run)
+
+    result = qe._run_openai_reviewer("review prompt")
+
+    assert result == ReviewerResult(
+        "openai",
+        "Verdict: PASS via Codex",
+        True,
+        harness=qe._CODEX_OPENAI_HARNESS,
+    )
+    assert seen["cmd"] == [
+        "codex",
+        "exec",
+        "--sandbox",
+        "read-only",
+        "--ask-for-approval",
+        "never",
+        "--ephemeral",
+        "--output-last-message",
+        str(seen["output_path"]),
+        "-",
+    ]
+    assert seen["input"] == "review prompt"
+    assert seen["capture_output"] is True
+    assert seen["text"] is True
+    assert seen["timeout"] == 11.0
+    assert seen["check"] is False
+    assert not Path(seen["output_path"]).exists()
+
+
+def test_run_openai_reviewer_passes_optional_codex_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: dict[str, object] = {}
+
+    def fake_run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
+        seen["cmd"] = cmd
+        Path(cmd[cmd.index("--output-last-message") + 1]).write_text(
+            "Verdict: PASS",
+            encoding="utf-8",
+        )
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv(qe._CODEX_MODEL_ENV, "gpt-5-codex")
+    monkeypatch.setattr(qe.subprocess, "run", fake_run)
+
+    result = qe._run_openai_reviewer("review prompt")
+
+    assert result.ok is True
+    assert seen["cmd"][-3:] == ["--model", "gpt-5-codex", "-"]
+
+
+def test_run_openai_reviewer_codex_failure_never_fabricates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="codex failed")
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(qe.subprocess, "run", fake_run)
+
+    result = qe._run_openai_reviewer("review prompt")
+
+    assert result.family == "openai"
+    assert result.text == ""
+    assert result.ok is False
+    assert "codex CLI exit 1: codex failed" in result.error
+    assert result.harness == ""
 
 
 # --- default API reviewer cleanup ------------------------------------------
@@ -546,6 +670,38 @@ def test_collect_dry_run_prepares_without_posting() -> None:
     assert outcome.action == "prepare"
     assert posted == []
     assert sorted(outcome.counting_families) == ["claude", "grok"]
+
+
+def test_collect_carries_reviewer_harness_into_comment() -> None:
+    fakes, posted = _fakes(tier=1)
+
+    def harness_runner(family: str, prompt: str) -> ReviewerResult:
+        return ReviewerResult(
+            family,
+            "Verdict: PASS via harness",
+            True,
+            harness=qe._CODEX_OPENAI_HARNESS,
+        )
+
+    def harness_linter(pr, head_sha, head_committed_at, author, body, env) -> dict:
+        assert qe._CODEX_OPENAI_HARNESS in body
+        return {
+            "would_count": True,
+            "counted_reviewer_ids": ["openai"],
+            "problems": [],
+        }
+
+    fakes["reviewer_runner"] = harness_runner
+    fakes["linter"] = harness_linter
+
+    outcome = collect_evidence(
+        repo="o/r", pr=1, families=["openai"], author="me", apply=False, **fakes
+    )
+
+    assert outcome.action == "prepare"
+    assert posted == []
+    assert outcome.counting_families == ["openai"]
+    assert qe._CODEX_OPENAI_HARNESS in outcome.items[0].body
 
 
 def test_collect_never_fabricates_on_reviewer_failure() -> None:

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -315,15 +315,17 @@ def test_run_openai_reviewer_without_api_key_uses_codex_cli(
     assert seen["cmd"] == [
         "codex",
         "exec",
+        "--ignore-user-config",
         "--sandbox",
         "read-only",
-        "--ask-for-approval",
-        "never",
         "--ephemeral",
         "--output-last-message",
         str(seen["output_path"]),
+        "--model",
+        qe._CODEX_DEFAULT_MODEL,
         "-",
     ]
+    assert "--ask-for-approval" not in seen["cmd"]
     assert seen["input"] == "review prompt"
     assert seen["capture_output"] is True
     assert seen["text"] is True


### PR DESCRIPTION
## Summary
- Adds a Codex CLI-backed OpenAI reviewer path for collect-evidence when OPENAI_API_KEY is absent.
- Preserves direct OpenAI API reviewer behavior when OPENAI_API_KEY is present.
- Carries reviewer harness metadata into composed evidence comments so existing lint-before-post and exact-head safeguards remain authoritative.
- Registers collect-evidence on the review-queue fast-path parser so the documented python3 -m aragora.cli.main review-queue collect-evidence command is reachable.

## Validation
- python3 -m pytest -q tests/swarm/test_quorum_evidence.py tests/cli/commands/test_review_queue.py::TestCommandDispatch::test_parser_registers_build_packet_run_and_act
- python3 -m aragora.cli.main review-queue collect-evidence --help
- python3 -m ruff check aragora/swarm/quorum_evidence.py aragora/cli/commands/review_queue.py tests/swarm/test_quorum_evidence.py tests/cli/commands/test_review_queue.py
- python3 -m ruff format --check aragora/swarm/quorum_evidence.py aragora/cli/commands/review_queue.py tests/swarm/test_quorum_evidence.py tests/cli/commands/test_review_queue.py
- git diff --check

Draft only; no merge or readiness mutation requested.