### PR TITLE
fix(audit): report worktree base freshness

### DIFF
--- a/scripts/audit_codex_branch_backlog.py
+++ b/scripts/audit_codex_branch_backlog.py
@@ -858,6 +858,59 @@ def branch_divergence(root: Path, base: str, branch: str) -> tuple[int, int] | N
         return None
 
 
+def worktree_base_status(
+    root: Path,
+    base: str,
+    *,
+    head_sha: str | None = None,
+    base_sha: str | None = None,
+) -> dict[str, Any]:
+    """Classify the launcher worktree's HEAD against the branch-audit base."""
+
+    head_sha = head_sha if head_sha is not None else git_revision(root, "HEAD")
+    base_sha = base_sha if base_sha is not None else git_revision(root, base)
+    if not head_sha or not base_sha:
+        return {
+            "worktree_head_matches_base": None,
+            "worktree_base_relation": "unknown",
+            "worktree_base_ahead_count": None,
+            "worktree_base_behind_count": None,
+        }
+
+    if head_sha == base_sha:
+        return {
+            "worktree_head_matches_base": True,
+            "worktree_base_relation": "up_to_date",
+            "worktree_base_ahead_count": 0,
+            "worktree_base_behind_count": 0,
+        }
+
+    divergence = branch_divergence(root, base, "HEAD")
+    if divergence is None:
+        return {
+            "worktree_head_matches_base": False,
+            "worktree_base_relation": "unknown",
+            "worktree_base_ahead_count": None,
+            "worktree_base_behind_count": None,
+        }
+
+    ahead_count, behind_count = divergence
+    if ahead_count == 0 and behind_count == 0:
+        relation = "up_to_date"
+    elif ahead_count == 0:
+        relation = "behind_base"
+    elif behind_count == 0:
+        relation = "ahead_of_base"
+    else:
+        relation = "diverged_from_base"
+    return {
+        "worktree_head_matches_base": relation == "up_to_date",
+        "worktree_base_relation": relation,
+        "worktree_base_ahead_count": ahead_count,
+        "worktree_base_behind_count": behind_count,
+    }
+
+
 def branch_divergence_map(
     root: Path,
     base: str,
@@ -1445,11 +1498,20 @@ def audit(
     skipped_counts = Counter(
         record.category for record in records if record.patch_equivalence_skipped
     )
+    worktree_head_sha = git_revision(root, "HEAD")
+    base_sha = git_revision(root, base)
+    worktree_status = worktree_base_status(
+        root,
+        base,
+        head_sha=worktree_head_sha,
+        base_sha=base_sha,
+    )
     return {
         "repo": str(root),
-        "worktree_head_sha": git_revision(root, "HEAD"),
+        "worktree_head_sha": worktree_head_sha,
         "base": base,
-        "base_sha": git_revision(root, base),
+        "base_sha": base_sha,
+        **worktree_status,
         "prefix": prefix,
         "recent_hours": recent_hours,
         "publisher_backlog_limit": publisher_backlog_limit,
@@ -1479,6 +1541,7 @@ def audit(
                 unresolved_handoff_outbox_refs_outside_audit
             ),
             "patch_equivalent_handoff_outbox_branches": (patch_equivalent_handoff_outbox_branches),
+            **worktree_status,
             "writer_should_pause_for_branch_backlog": (
                 publishable_branch_backlog >= publisher_backlog_limit
             ),
@@ -1553,6 +1616,13 @@ def print_markdown(payload: dict[str, Any], *, examples: int) -> None:
     print(f"- Worktree HEAD: `{payload.get('worktree_head_sha')}`")
     print(f"- Base: `{payload['base']}`")
     print(f"- Base SHA: `{payload.get('base_sha')}`")
+    if "worktree_base_relation" in summary:
+        print(
+            "- Worktree/base relation: "
+            f"`{summary['worktree_base_relation']}` "
+            f"(ahead `{summary.get('worktree_base_ahead_count')}`, "
+            f"behind `{summary.get('worktree_base_behind_count')}`)"
+        )
     print(f"- Branches audited: `{payload['branch_count']}`")
     print(f"- Safe cleanup candidates: `{summary['safe_cleanup_candidates']}`")
     print(f"- Salvage candidates: `{summary['salvage_candidates']}`")

--- a/tests/scripts/test_audit_codex_branch_backlog.py
+++ b/tests/scripts/test_audit_codex_branch_backlog.py
@@ -379,6 +379,9 @@ def test_print_markdown_includes_revision_metadata(tmp_path: Path, capsys: Any) 
             "diverged_salvage_candidates": 0,
             "handoff_receipted_branches": 0,
             "handoff_outbox_branches": 0,
+            "worktree_base_relation": "behind_base",
+            "worktree_base_ahead_count": 0,
+            "worktree_base_behind_count": 1,
             "writer_should_pause_for_branch_backlog": False,
             "protected": 0,
             "by_category": {},
@@ -391,6 +394,7 @@ def test_print_markdown_includes_revision_metadata(tmp_path: Path, capsys: Any) 
 
     assert "- Worktree HEAD: `1111111111111111111111111111111111111111`" in out
     assert "- Base SHA: `2222222222222222222222222222222222222222`" in out
+    assert "- Worktree/base relation: `behind_base` (ahead `0`, behind `1`)" in out
 
 
 def test_audit_skips_open_pr_lookup_when_github_health_degraded(
@@ -663,6 +667,11 @@ def test_audit_reports_worktree_and_base_revisions(tmp_path: Path, monkeypatch: 
             "origin/main": "2222222222222222222222222222222222222222",
         }[ref],
     )
+    monkeypatch.setattr(
+        mod,
+        "branch_divergence",
+        lambda _root, _base, branch: (0, 5) if branch == "HEAD" else None,
+    )
 
     payload = mod.audit(
         root=tmp_path,
@@ -677,6 +686,59 @@ def test_audit_reports_worktree_and_base_revisions(tmp_path: Path, monkeypatch: 
 
     assert payload["worktree_head_sha"] == "1111111111111111111111111111111111111111"
     assert payload["base_sha"] == "2222222222222222222222222222222222222222"
+    assert payload["worktree_head_matches_base"] is False
+    assert payload["worktree_base_relation"] == "behind_base"
+    assert payload["worktree_base_ahead_count"] == 0
+    assert payload["worktree_base_behind_count"] == 5
+    assert payload["summary"]["worktree_head_matches_base"] is False
+    assert payload["summary"]["worktree_base_relation"] == "behind_base"
+    assert payload["summary"]["worktree_base_ahead_count"] == 0
+    assert payload["summary"]["worktree_base_behind_count"] == 5
+
+
+def test_worktree_base_status_reports_up_to_date_without_rev_list(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    def fail_branch_divergence(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("matching revisions should not need rev-list")
+
+    monkeypatch.setattr(mod, "branch_divergence", fail_branch_divergence)
+
+    status = mod.worktree_base_status(
+        tmp_path,
+        "origin/main",
+        head_sha="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        base_sha="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    )
+
+    assert status == {
+        "worktree_head_matches_base": True,
+        "worktree_base_relation": "up_to_date",
+        "worktree_base_ahead_count": 0,
+        "worktree_base_behind_count": 0,
+    }
+
+
+def test_worktree_base_status_reports_diverged(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setattr(mod, "branch_divergence", lambda *_args, **_kwargs: (2, 3))
+
+    status = mod.worktree_base_status(
+        tmp_path,
+        "origin/main",
+        head_sha="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        base_sha="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    )
+
+    assert status == {
+        "worktree_head_matches_base": False,
+        "worktree_base_relation": "diverged_from_base",
+        "worktree_base_ahead_count": 2,
+        "worktree_base_behind_count": 3,
+    }
 
 
 def test_audit_uses_batched_divergence_before_fallback(tmp_path: Path, monkeypatch: Any) -> None:


### PR DESCRIPTION
Expose whether the audit launcher worktree is up to date, behind, ahead, diverged, or unknown relative to the configured base. Include the classification and ahead/behind counts in summary-only JSON and markdown so automation lanes can notice stale checkout evidence directly.

Co-authored-by: codex[bot] <codex[bot]@users.noreply.github.com>
