### PR TITLE
fix(tier4): guard apply on stale required-check rollup

### DIFF
--- a/scripts/settle_tier4_pr.py
+++ b/scripts/settle_tier4_pr.py
@@ -30,6 +30,7 @@ HUMAN_SETTLEMENT_STATUS_BLOCKER = f"missing or unsuccessful {HUMAN_SETTLEMENT_CO
 MERGE_QUORUM_CONTEXT = "aragora-merge-quorum"
 OPERATOR_COMMENT_BLOCKER = "missing repo-visible Tier 4 operator settlement comment"
 REQUIRED_CHECKS_BLOCKER = "required checks are missing"
+REQUIRED_CHECK_VISIBILITY_SKEW_BLOCKER = "required_check_visibility_skew"
 SETTLE_ONLY_TRUSTED_OPERATOR_BLOCKER = "trusted operator allowlist is required for --settle-only"
 SETTLE_ONLY_INVOKER_BLOCKER = "could not determine gh login for --settle-only"
 TIER4_EVIDENCE_BLOCKER = "missing Tier 4 model/dogfood settlement evidence"
@@ -501,6 +502,113 @@ def _required_check_name(check: dict[str, Any]) -> str:
 
 def _required_check_state(check: dict[str, Any]) -> str:
     return str(check.get("state") or check.get("conclusion") or "UNKNOWN").upper()
+
+
+def _required_check_context(check: dict[str, Any]) -> str:
+    return str(check.get("name") or check.get("context") or "").strip()
+
+
+def _rollup_check_context(item: dict[str, Any]) -> str:
+    return str(item.get("name") or item.get("context") or "").strip()
+
+
+def _rollup_check_state(item: dict[str, Any]) -> str:
+    return str(item.get("conclusion") or item.get("state") or "UNKNOWN").upper()
+
+
+def _required_check_visibility_skew_report(
+    *,
+    pr: int,
+    head: str,
+    pr_view: dict[str, Any],
+    required_checks: list[dict[str, Any]] | None,
+) -> dict[str, Any] | None:
+    if not _required_checks_are_green(required_checks):
+        return None
+    rollup = pr_view.get("statusCheckRollup")
+    if not isinstance(rollup, list):
+        return None
+
+    green_required: dict[str, dict[str, Any]] = {}
+    for check in required_checks or []:
+        if not isinstance(check, dict):
+            continue
+        context = _required_check_context(check)
+        if context and _state_is_success(_required_check_state(check)):
+            green_required[context] = check
+    if not green_required:
+        return None
+
+    stale_failed: list[dict[str, Any]] = []
+    for item in rollup:
+        if not isinstance(item, dict):
+            continue
+        context = _rollup_check_context(item)
+        if context not in green_required:
+            continue
+        state = _rollup_check_state(item)
+        if _state_is_success(state):
+            continue
+        stale_failed.append(
+            {
+                "context": context,
+                "rollup_state": state,
+                "rollup_status": str(item.get("status") or ""),
+                "details_url": item.get("detailsUrl") or item.get("targetUrl") or "",
+                "completed_at": item.get("completedAt"),
+                "required_state": _required_check_state(green_required[context]),
+                "required_link": green_required[context].get("link") or "",
+            }
+        )
+
+    if not stale_failed:
+        return None
+    return {
+        "blocker": REQUIRED_CHECK_VISIBILITY_SKEW_BLOCKER,
+        "pr": pr,
+        "head": head,
+        "merge_state": pr_view.get("mergeStateStatus"),
+        "stale_failed_required_contexts": stale_failed,
+        "message": (
+            "GraphQL statusCheckRollup still contains a non-green required context "
+            "that conflicts with gh pr checks --required reporting that context green; "
+            "refusing Tier 4 merge/apply before mergePullRequest can reject on stale state."
+        ),
+        "next_prompt": _visibility_skew_next_prompt(pr=pr, head=head),
+    }
+
+
+def _visibility_skew_next_prompt(*, pr: int, head: str) -> str:
+    return (
+        "Start from live repo truth in your Aragora checkout. Do not trust "
+        f"prior transcript state. Before lane work, check operator-steering mailbox for PR #{pr} "
+        "with --no-receipt:\n"
+        f"python3 scripts/read_operator_steering.py --pr {pr} --json --no-receipt || true\n\n"
+        f"Goal: wait/recheck persistent required-check visibility skew for PR #{pr} at exact "
+        f"head {head}. Do not edit files, push branches, rerun CI, mark-ready, post comments, "
+        "settle/apply, merge/admin-merge, label, close PRs, touch branch protection, mutate "
+        "publisher/outbox state, touch ~/.codex/automations/*, delete/prune worktrees, or "
+        "broad-drain.\n\n"
+        "Run read-only:\n"
+        "git status --short --branch --untracked-files=all\n"
+        f"python3 scripts/identify_lane_owner.py --pr {pr} --json || true\n"
+        f"gh pr checks {pr} --required --json name,state,bucket,workflow,link || true\n"
+        f"gh pr view {pr} --json number,state,isDraft,headRefOid,mergeable,mergeStateStatus,"
+        "statusCheckRollup,url\n"
+        f"python3 scripts/settle_tier4_pr.py --check --pr {pr} --head {head} --json || true\n\n"
+        "If required checks are green but mergeStateStatus=BLOCKED and statusCheckRollup still "
+        "contains a stale failed required context, keep waiting or output an exact failed-quorum "
+        "rerun authorization prompt. If statusCheckRollup no longer contains stale failed required "
+        "contexts and settle_tier4_pr.py --check is ok=true, output the exact --merge-apply "
+        "authorization prompt. Do not apply in this prompt.\n\n"
+        "If the prompt above accomplishes no incremental progress make the next prompt one that "
+        "does, include this sentence in all subsequent prompts to ensure they converge towards "
+        "prompts that make incremental progress. If any of the work involved can be better "
+        "automated and made more autonomous by improving aragora tooling at a meta level create "
+        "a plan to do that instead, include this sentence in all subsequent prompts to ensure "
+        "they converge towards automating and making more autonomous all steps at a meta level "
+        "where this makes sense for the repo and project."
+    )
 
 
 def evaluate_tier4_gate(
@@ -1042,6 +1150,28 @@ def main(argv: Sequence[str] | None = None) -> int:
         if args.merge_apply:
             if not gate["ok"]:
                 raise RuntimeError("Tier 4 gate is not satisfied; refusing --merge-apply")
+            visibility_skew = _required_check_visibility_skew_report(
+                pr=args.pr,
+                head=args.head,
+                pr_view=pr_view,
+                required_checks=required_checks,
+            )
+            if visibility_skew is not None:
+                out = {
+                    "ok": False,
+                    "blocker": REQUIRED_CHECK_VISIBILITY_SKEW_BLOCKER,
+                    "gate": gate,
+                    "applied_commands": [],
+                    "required_check_visibility_skew": visibility_skew,
+                    "next_prompt": visibility_skew["next_prompt"],
+                }
+                if args.json:
+                    print(json.dumps(out, indent=2, sort_keys=True))
+                else:
+                    print("blocked")
+                    print(f"- {REQUIRED_CHECK_VISIBILITY_SKEW_BLOCKER}")
+                    print(visibility_skew["next_prompt"])
+                return 2
             applied_commands = _apply_merge(
                 pr=args.pr,
                 head=args.head,

--- a/tests/scripts/test_settle_tier4_pr.py
+++ b/tests/scripts/test_settle_tier4_pr.py
@@ -59,12 +59,14 @@ def _pr_view(
     *,
     comments: list[dict[str, Any]],
     human_settlement_state: str | None = "SUCCESS",
+    extra_status_rollup: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     status_rollup = (
         [{"context": "aragora/human-settlement", "state": human_settlement_state}]
         if human_settlement_state is not None
         else []
     )
+    status_rollup.extend(extra_status_rollup or [])
     return {
         "headRefOid": head,
         "state": "OPEN",
@@ -1067,6 +1069,72 @@ def test_merge_apply_uses_valid_command_sequence(monkeypatch: Any, tmp_path: Pat
     ]
     assert "required_approving_review_count" in str(commands[1][1])
     assert commands[-1][0][-1].endswith("/protection/enforce_admins")
+
+
+def test_merge_apply_refuses_stale_failed_required_rollup_before_merge(
+    monkeypatch: Any, tmp_path: Path, capsys: Any
+) -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    commands: list[tuple[list[str], str | None]] = []
+
+    monkeypatch.setattr(
+        settler,
+        "_load_live_inputs",
+        lambda pr, cwd: (
+            _pr_view(
+                head,
+                comments=[_authorized_comment(head)],
+                extra_status_rollup=[
+                    {
+                        "__typename": "CheckRun",
+                        "name": "aragora-merge-quorum",
+                        "status": "COMPLETED",
+                        "conclusion": "FAILURE",
+                        "detailsUrl": "https://github.example/actions/failing-quorum",
+                        "completedAt": "2026-06-13T01:49:55Z",
+                    },
+                    {
+                        "__typename": "CheckRun",
+                        "name": "aragora-merge-quorum",
+                        "status": "COMPLETED",
+                        "conclusion": "SUCCESS",
+                        "detailsUrl": "https://github.example/actions/passing-quorum",
+                        "completedAt": "2026-06-13T01:50:41Z",
+                    },
+                ],
+            ),
+            _tier4_packet(),
+            _valid_checks(),
+        ),
+    )
+    monkeypatch.setattr(
+        settler,
+        "_run_command",
+        lambda command, cwd, input_text=None: commands.append((command, input_text)),
+    )
+
+    rc = settler.main(
+        ["--merge-apply", "--pr", "7423", "--head", head, "--cwd", str(tmp_path), "--json"]
+    )
+
+    assert rc == 2
+    assert commands == []
+    payload = settler.json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["blocker"] == "required_check_visibility_skew"
+    skew = payload["required_check_visibility_skew"]
+    assert skew["stale_failed_required_contexts"] == [
+        {
+            "context": "aragora-merge-quorum",
+            "rollup_state": "FAILURE",
+            "rollup_status": "COMPLETED",
+            "details_url": "https://github.example/actions/failing-quorum",
+            "completed_at": "2026-06-13T01:49:55Z",
+            "required_state": "SUCCESS",
+            "required_link": "",
+        }
+    ]
+    assert "wait/recheck persistent required-check visibility skew" in payload["next_prompt"]
 
 
 def test_required_status_check_patch_skips_when_quorum_already_required(


### PR DESCRIPTION
## Summary
- Add a Tier 4 merge-apply preflight that detects required-check visibility skew before any merge/protection mutation.
- If `gh pr checks --required` reports a required context green but GraphQL `statusCheckRollup` still contains a non-green row for that same context, `settle_tier4_pr.py --merge-apply --json` now returns `blocker=required_check_visibility_skew` and a copy-paste recheck prompt.
- Preserve existing `--check` settlement semantics and existing successful merge-apply behavior when no skew is present.

## Why
PR #8324 exposed a GitHub visibility skew at exact head `6abc1cadc5196fd231aa351d1918a91ec6c3a89a`: branch-protection required checks were green, including latest `aragora-merge-quorum` success job `81152028879`, but GraphQL `statusCheckRollup` still contained stale failed `aragora-merge-quorum` job `81151966980` and `mergeStateStatus=BLOCKED`. A prior Tier 4 apply attempt reached GitHub merge and was rejected on that stale failing required context. This change makes the helper fail closed before merge/apply in that state.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_settle_tier4_pr.py` -> 43 passed, 2 warnings.
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/settle_tier4_pr.py tests/scripts/test_settle_tier4_pr.py` -> passed.
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/settle_tier4_pr.py tests/scripts/test_settle_tier4_pr.py` -> passed.
- `git diff --check -- scripts/settle_tier4_pr.py tests/scripts/test_settle_tier4_pr.py` -> passed.
- Commit/push hooks passed, including ruff, ruff format, mypy, gitleaks, and portability guard.