### PR TITLE
fix(settle-one): bound broad steward scan

### DIFF
--- a/scripts/settle_one_pr.py
+++ b/scripts/settle_one_pr.py
@@ -56,6 +56,9 @@ OPERATOR_SNAPSHOT_TIMEOUT_SECONDS = _env_timeout_seconds(
 )
 BROAD_PACKET_TIMEOUT_SECONDS = _env_timeout_seconds("SETTLE_ONE_BROAD_PACKET_TIMEOUT_SECONDS", 90)
 SINGLE_PACKET_TIMEOUT_SECONDS = _env_timeout_seconds("SETTLE_ONE_SINGLE_PACKET_TIMEOUT_SECONDS", 90)
+BROAD_PACKET_TARGET_ATTEMPT_LIMIT = _env_timeout_seconds(
+    "SETTLE_ONE_BROAD_PACKET_TARGET_ATTEMPT_LIMIT", 8
+)
 COMMAND_OUTPUT_REPORT_LIMIT = 4096
 OPEN_PR_LIGHT_FIELDS = (
     "number,title,url,headRefName,headRefOid,isDraft,mergeable,mergeStateStatus,"
@@ -66,6 +69,7 @@ SURFACE_EXCLUDE_REASON = (
     "security/auth/RBAC/secrets/deploy/workflow/legal/compliance/destructive/"
     "migration/public-API surface"
 )
+DRAFT_EXCLUDE_REASON = "draft/readiness"
 
 
 def _repo_root() -> Path:
@@ -233,6 +237,14 @@ def _coerce_int(value: Any) -> int | None:
         return int(str(value))
     except (TypeError, ValueError):
         return None
+
+
+def _coerce_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    return str(value).strip().lower() in {"1", "true", "yes", "y"}
 
 
 def _is_green_summary(summary: str) -> bool:
@@ -430,6 +442,26 @@ def policy_exclusion_reasons(
     return list(dict.fromkeys(reasons))
 
 
+def broad_light_exclusion_reasons(
+    entry: dict[str, Any],
+    *,
+    exclude_prs: set[int] | None = None,
+    active_owned_prs: set[int] | None = None,
+    policy_metadata: dict[int, dict[str, Any]] | None = None,
+) -> list[str]:
+    """Cheap broad-mode exclusions before spending targeted packet calls."""
+    reasons = policy_exclusion_reasons(
+        entry,
+        exclude_prs=exclude_prs,
+        active_owned_prs=active_owned_prs,
+        policy_metadata=policy_metadata,
+    )
+    metadata = _metadata_for_entry(entry, policy_metadata)
+    if _coerce_bool(metadata.get("isDraft", entry.get("isDraft"))):
+        reasons.append(DRAFT_EXCLUDE_REASON)
+    return list(dict.fromkeys(reasons))
+
+
 def _exclusion_record(entry: dict[str, Any], reasons: list[str]) -> dict[str, Any]:
     return {
         "pr_number": _entry_pr(entry),
@@ -565,6 +597,7 @@ def no_candidate_diagnostics(
         "top_check_blocked_candidate": check_blocked[0] if check_blocked else None,
         "top_repair_first_candidate": repair_first[0] if repair_first else None,
         "top_conflict_candidate": _first_by_reason(policy_exclusions, "dirty/conflicting PR"),
+        "top_draft_candidate": _first_by_reason(policy_exclusions, DRAFT_EXCLUDE_REASON),
         "top_human_risk_candidate": top_human_risk,
         "top_evidence_blocked_candidate": evidence_not_green[0] if evidence_not_green else None,
         "top_satisfied_not_selected_candidate": (
@@ -612,6 +645,20 @@ def no_candidate_next_action(diagnostics: dict[str, Any]) -> dict[str, Any]:
             "operator_action": (
                 f"Repair conflicts for PR #{pr_number} in a clean disposable worktree, run focused "
                 "tests, push the branch only if validation passes. Do not merge."
+            ),
+        }
+
+    draft = diagnostics.get("top_draft_candidate")
+    if isinstance(draft, dict) and draft.get("pr_number"):
+        pr_number = draft["pr_number"]
+        return {
+            "kind": "wait_for_readiness",
+            "pr_number": pr_number,
+            "reason": "nearest otherwise-light-eligible PR is still draft/not ready",
+            "operator_action": (
+                f"Re-check PR #{pr_number} exact head, readiness, required checks, and "
+                "merge-packet; only collect evidence, mark ready, or merge if a later prompt "
+                "explicitly authorizes that exact action."
             ),
         }
 
@@ -1413,6 +1460,10 @@ def build_report(
                 return_exclusions=True,
             ),
         )
+    packet_policy_exclusions = [
+        item for item in packet.get("light_policy_exclusions") or [] if isinstance(item, dict)
+    ]
+    policy_exclusions = _merge_exclusions(packet_policy_exclusions, policy_exclusions)
     has_preselection_blockers = bool(preselection_blockers)
     selection_blockers = _dedupe_strings([*preselection_blockers, *selection_blockers])
     report: dict[str, Any] = {
@@ -1709,20 +1760,17 @@ def _light_entry_from_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
 
 
 def load_broad_packet_lazily(*, cwd: Path, limit: int, repo: str | None) -> dict[str, Any]:
-    try:
-        return _load_broad_packet_bulk(cwd=cwd, limit=limit, repo=repo)
-    except RuntimeError as bulk_error:
-        load_warnings = [f"bulk merge-packet failed; using fallback: {bulk_error}"]
-        metadata: dict[int, dict[str, Any]] = {}
-        metadata, command = load_open_pr_metadata(cwd, limit=limit, repo=repo)
-        if command.get("returncode") != 0:
-            packet = _empty_packet()
-            packet["load_blockers"] = [
-                str(bulk_error),
-                command.get("stderr") or command.get("stdout") or "gh pr list failed",
-            ]
-            packet["load_warnings"] = load_warnings
-            return packet
+    load_warnings = [
+        "bulk merge-packet skipped; using bounded light metadata scan for broad settle-one"
+    ]
+    metadata, command = load_open_pr_metadata(cwd, limit=limit, repo=repo)
+    if command.get("returncode") != 0:
+        packet = _empty_packet()
+        packet["load_blockers"] = [
+            command.get("stderr") or command.get("stdout") or "gh pr list failed"
+        ]
+        packet["load_warnings"] = load_warnings
+        return packet
 
     active_owned_prs, active_owned_command = load_active_owned_prs(cwd)
     snapshot_blocker = active_owned_snapshot_blocker(active_owned_command)
@@ -1733,28 +1781,31 @@ def load_broad_packet_lazily(*, cwd: Path, limit: int, repo: str | None) -> dict
         return packet
     packets: list[dict[str, Any]] = []
     packet_failures: list[str] = []
+    light_policy_exclusions: list[dict[str, Any]] = []
     packet_attempts = 0
-    selected_seen = False
-    packets_after_selected = 0
     for pr_number, item in metadata.items():
-        light_reasons = policy_exclusion_reasons(
-            _light_entry_from_metadata(item),
+        light_entry = _light_entry_from_metadata(item)
+        light_reasons = broad_light_exclusion_reasons(
+            light_entry,
             exclude_prs=HUMAN_RISK_EXCLUDES,
             active_owned_prs=active_owned_prs,
             policy_metadata=metadata,
         )
         if light_reasons:
+            light_policy_exclusions.append(_exclusion_record(light_entry, light_reasons))
             continue
+        if packet_attempts >= BROAD_PACKET_TARGET_ATTEMPT_LIMIT:
+            load_warnings.append(
+                "bounded broad packet window exhausted after "
+                f"{packet_attempts} targeted merge-packet queries "
+                f"(light candidates={len(metadata)}, limit={limit})"
+            )
+            break
         packet_attempts += 1
         try:
             packets.append(_load_single_pr_packet(cwd=cwd, pr=pr_number, repo=repo))
         except RuntimeError as exc:
             packet_failures.append(f"merge-packet for #{pr_number} failed: {exc}")
-            continue
-        if selected_seen:
-            packets_after_selected += 1
-            if packets_after_selected >= BROAD_PACKET_NEAR_SELECTED_LOOKAHEAD:
-                break
             continue
         selected, _blockers, _exclusions = cast(
             SelectionResultWithExclusions,
@@ -1768,14 +1819,20 @@ def load_broad_packet_lazily(*, cwd: Path, limit: int, repo: str | None) -> dict
             ),
         )
         if selected is not None:
-            selected_seen = True
+            break
     packet = _combine_packets(packets) if packets else _empty_packet()
-    if packet_attempts > BROAD_PACKET_NEAR_SELECTED_LOOKAHEAD:
+    if packet_attempts:
         load_warnings.append(
-            "fallback per-PR merge-packet queries: "
+            "bounded per-PR merge-packet queries: "
             f"{packet_attempts} (light candidates={len(metadata)}, limit={limit})"
         )
+    else:
+        load_warnings.append(
+            f"no targeted merge-packet queries after light exclusions (limit={limit})"
+        )
     packet["load_warnings"] = load_warnings
+    if light_policy_exclusions:
+        packet["light_policy_exclusions"] = light_policy_exclusions
     if packet_failures:
         packet["load_blockers"] = packet_failures
     return packet

--- a/tests/scripts/test_settle_one_pr.py
+++ b/tests/scripts/test_settle_one_pr.py
@@ -630,40 +630,16 @@ def test_open_pr_metadata_uses_light_list_fields(monkeypatch) -> None:
     assert "statusCheckRollup" not in fields
 
 
-def test_broad_packet_lazy_loader_uses_single_bulk_packet(monkeypatch) -> None:
-    commands: list[list[str]] = []
-
-    def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
-        del cwd, timeout
-        commands.append(args)
-        if args[:5] == MERGE_PACKET_PREFIX:
-            assert "--limit" in args
-            assert "--pr" not in args
-            return _packet(_entry(7376), _entry(7449)), {"command": "packet", "returncode": 0}
-        raise AssertionError(args)
-
-    monkeypatch.setattr(settle_one_pr, "_run_json", fake_run_json)
-
-    packet = load_broad_packet_lazily(cwd=Path.cwd(), limit=100, repo=None)
-
-    assert [entry["pr_number"] for entry in packet["entries"]] == [7376, 7449]
-    assert len(commands) == 1
-
-
-def test_broad_packet_lazy_loader_falls_back_when_bulk_packet_fails(
+def test_broad_packet_lazy_loader_uses_light_metadata_before_targeted_packets(
     monkeypatch,
 ) -> None:
     commands: list[list[str]] = []
-    bulk_calls = 0
 
     def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
-        nonlocal bulk_calls
         del cwd, timeout
         commands.append(args)
         if args[:5] == MERGE_PACKET_PREFIX:
-            if "--limit" in args:
-                bulk_calls += 1
-                return None, {"command": "bulk-packet", "returncode": 1, "stderr": "HTTP 504"}
+            assert "--limit" not in args
             pr_number = int(args[args.index("--pr") + 1])
             return _packet(_entry(pr_number)), {"command": "packet", "returncode": 0}
         if args[:3] == ["gh", "pr", "list"]:
@@ -671,13 +647,21 @@ def test_broad_packet_lazy_loader_falls_back_when_bulk_packet_fails(
                 [
                     {
                         "number": 7376,
+                        "title": "fix: draft candidate",
+                        "headRefName": "codex/draft",
+                        "isDraft": True,
+                    },
+                    {
+                        "number": 7377,
                         "title": "docs(governance): ADC follow-on deepening packet",
                         "headRefName": "adc-follow-on",
+                        "isDraft": False,
                     },
                     {
                         "number": 7449,
                         "title": "fix(settlement): exclude unsafe PR surfaces",
                         "headRefName": "codex/settle-one-policy-exclusions-20260523",
+                        "isDraft": False,
                     },
                 ],
                 {"command": "metadata", "returncode": 0},
@@ -690,36 +674,105 @@ def test_broad_packet_lazy_loader_falls_back_when_bulk_packet_fails(
 
     packet = load_broad_packet_lazily(cwd=Path.cwd(), limit=100, repo=None)
 
+    assert commands[0][:3] == ["gh", "pr", "list"]
     assert [entry["pr_number"] for entry in packet["entries"]] == [7449]
-    assert packet["load_warnings"] == ["bulk merge-packet failed; using fallback: HTTP 504"]
-    assert bulk_calls == 1
+    assert [
+        command
+        for command in commands
+        if command[:5] == MERGE_PACKET_PREFIX and "--limit" in command
+    ] == []
     targeted = [command for command in commands if "--pr" in command]
     assert len(targeted) == 1
     assert targeted[0][targeted[0].index("--pr") + 1] == "7449"
+    assert packet["light_policy_exclusions"] == [
+        {
+            "pr_number": 7376,
+            "title": "fix: draft candidate",
+            "head_sha": None,
+            "reasons": ["draft/readiness"],
+        },
+        {
+            "pr_number": 7377,
+            "title": "docs(governance): ADC follow-on deepening packet",
+            "head_sha": None,
+            "reasons": ["ADC PR"],
+        },
+    ]
 
 
-def test_broad_packet_lazy_loader_falls_back_when_bulk_packet_times_out(
-    monkeypatch,
-) -> None:
+def test_broad_packet_lazy_loader_caps_targeted_packet_window(monkeypatch) -> None:
+    commands: list[list[str]] = []
+
     def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
         del cwd, timeout
+        commands.append(args)
         if args[:5] == MERGE_PACKET_PREFIX:
-            if "--limit" in args:
-                return None, {
-                    "command": "bulk-packet",
-                    "returncode": 124,
-                    "stderr": "command timed out after 90s and was terminated",
-                    "timed_out": True,
-                }
             pr_number = int(args[args.index("--pr") + 1])
-            return _packet(_entry(pr_number)), {"command": "packet", "returncode": 0}
+            return (
+                _packet(
+                    _entry(
+                        pr_number,
+                        checks_summary="1/2 failing",
+                        reasons=["docs/tests/status-only"],
+                    )
+                ),
+                {"command": "packet", "returncode": 0},
+            )
+        if args[:3] == ["gh", "pr", "list"]:
+            return (
+                [
+                    {
+                        "number": number,
+                        "title": f"fix {number}",
+                        "headRefName": f"codex/{number}",
+                        "isDraft": False,
+                    }
+                    for number in range(7449, 7459)
+                ],
+                {"command": "metadata", "returncode": 0},
+            )
+        if args[:3] == OPERATOR_SNAPSHOT_PREFIX:
+            return {"lanes": []}, {"command": "snapshot", "returncode": 0}
+        raise AssertionError(args)
+
+    monkeypatch.setattr(settle_one_pr, "_run_json", fake_run_json)
+    monkeypatch.setattr(settle_one_pr, "BROAD_PACKET_TARGET_ATTEMPT_LIMIT", 3)
+
+    packet = load_broad_packet_lazily(cwd=Path.cwd(), limit=100, repo=None)
+
+    assert [entry["pr_number"] for entry in packet["entries"]] == [7449, 7450, 7451]
+    targeted = [command for command in commands if "--pr" in command]
+    assert len(targeted) == 3
+    assert any(
+        "bounded broad packet window exhausted after 3" in warning
+        for warning in packet["load_warnings"]
+    )
+
+
+def test_broad_packet_lazy_loader_skips_all_drafts_without_targeted_packets(
+    monkeypatch,
+) -> None:
+    commands: list[list[str]] = []
+
+    def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
+        del cwd, timeout
+        commands.append(args)
+        if args[:5] == MERGE_PACKET_PREFIX:
+            raise AssertionError("draft-only broad scan should not call merge-packet")
         if args[:3] == ["gh", "pr", "list"]:
             return (
                 [
                     {
                         "number": 7449,
-                        "title": "fix(settlement): exclude unsafe PR surfaces",
-                        "headRefName": "codex/settle-one-policy-exclusions-20260523",
+                        "title": "draft 7449",
+                        "headRefName": "codex/7449",
+                        "isDraft": True,
+                    },
+                    {
+                        "number": 7450,
+                        "title": "draft 7450",
+                        "headRefName": "codex/7450",
+                        "isDraft": True,
                     },
                 ],
                 {"command": "metadata", "returncode": 0},
@@ -732,19 +785,21 @@ def test_broad_packet_lazy_loader_falls_back_when_bulk_packet_times_out(
 
     packet = load_broad_packet_lazily(cwd=Path.cwd(), limit=100, repo=None)
 
-    assert [entry["pr_number"] for entry in packet["entries"]] == [7449]
-    assert packet["load_warnings"] == [
-        "bulk merge-packet failed; using fallback: command timed out after 90s and was terminated"
-    ]
+    assert packet["entries"] == []
+    assert [item["pr_number"] for item in packet["light_policy_exclusions"]] == [7449, 7450]
+    assert [command for command in commands if "--pr" in command] == []
+    assert packet["load_warnings"][-1] == (
+        "no targeted merge-packet queries after light exclusions (limit=100)"
+    )
 
 
-def test_broad_packet_lazy_loader_returns_empty_when_bulk_and_light_metadata_fail(
+def test_broad_packet_lazy_loader_returns_empty_when_light_metadata_fails(
     monkeypatch,
 ) -> None:
     def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
         del cwd, timeout
         if args[:5] == MERGE_PACKET_PREFIX:
-            return None, {"command": "bulk-packet", "returncode": 1, "stderr": "HTTP 504"}
+            raise AssertionError("light metadata failure should not call merge-packet")
         if args[:3] == ["gh", "pr", "list"]:
             return None, {"command": "metadata", "returncode": 1, "stderr": "HTTP 504"}
         raise AssertionError(args)
@@ -754,7 +809,7 @@ def test_broad_packet_lazy_loader_returns_empty_when_bulk_and_light_metadata_fai
     packet = load_broad_packet_lazily(cwd=Path.cwd(), limit=100, repo=None)
 
     assert packet["entries"] == []
-    assert packet["load_blockers"] == ["HTTP 504", "HTTP 504"]
+    assert packet["load_blockers"] == ["HTTP 504"]
 
 
 def test_broad_packet_lazy_loader_surfaces_targeted_packet_failures(
@@ -763,8 +818,6 @@ def test_broad_packet_lazy_loader_surfaces_targeted_packet_failures(
     def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
         del cwd, timeout
         if args[:5] == MERGE_PACKET_PREFIX:
-            if "--limit" in args:
-                return None, {"command": "bulk-packet", "returncode": 1, "stderr": "HTTP 504"}
             pr_number = args[args.index("--pr") + 1]
             return None, {
                 "command": f"packet {pr_number}",
@@ -791,7 +844,10 @@ def test_broad_packet_lazy_loader_surfaces_targeted_packet_failures(
     packet = load_broad_packet_lazily(cwd=Path.cwd(), limit=100, repo=None)
 
     assert packet["entries"] == []
-    assert packet["load_warnings"] == ["bulk merge-packet failed; using fallback: HTTP 504"]
+    assert packet["load_warnings"] == [
+        "bulk merge-packet skipped; using bounded light metadata scan for broad settle-one",
+        "bounded per-PR merge-packet queries: 1 (light candidates=1, limit=100)",
+    ]
     assert packet["load_blockers"] == ["merge-packet for #7449 failed: GraphQL timeout"]
 
 
@@ -801,8 +857,6 @@ def test_broad_packet_lazy_loader_surfaces_targeted_packet_timeout(
     def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
         del cwd, timeout
         if args[:5] == MERGE_PACKET_PREFIX:
-            if "--limit" in args:
-                return None, {"command": "bulk-packet", "returncode": 1, "stderr": "HTTP 504"}
             return None, {
                 "command": "packet",
                 "returncode": 124,
@@ -829,18 +883,19 @@ def test_broad_packet_lazy_loader_surfaces_targeted_packet_timeout(
     packet = load_broad_packet_lazily(cwd=Path.cwd(), limit=100, repo=None)
 
     assert packet["entries"] == []
-    assert packet["load_warnings"] == ["bulk merge-packet failed; using fallback: HTTP 504"]
+    assert packet["load_warnings"] == [
+        "bulk merge-packet skipped; using bounded light metadata scan for broad settle-one",
+        "bounded per-PR merge-packet queries: 1 (light candidates=1, limit=100)",
+    ]
     assert packet["load_blockers"] == [
         "merge-packet for #7449 failed: command timed out after 90s and was terminated"
     ]
 
 
-def test_broad_packet_lazy_loader_warns_on_large_fallback_fanout(monkeypatch) -> None:
+def test_broad_packet_lazy_loader_warns_on_bounded_packet_queries(monkeypatch) -> None:
     def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
         del cwd, timeout
         if args[:5] == MERGE_PACKET_PREFIX:
-            if "--limit" in args:
-                return None, {"command": "bulk-packet", "returncode": 1, "stderr": "HTTP 504"}
             pr_number = int(args[args.index("--pr") + 1])
             return (
                 _packet(
@@ -855,7 +910,12 @@ def test_broad_packet_lazy_loader_warns_on_large_fallback_fanout(monkeypatch) ->
         if args[:3] == ["gh", "pr", "list"]:
             return (
                 [
-                    {"number": number, "title": f"fix {number}", "headRefName": f"codex/{number}"}
+                    {
+                        "number": number,
+                        "title": f"fix {number}",
+                        "headRefName": f"codex/{number}",
+                        "isDraft": False,
+                    }
                     for number in range(7449, 7460)
                 ],
                 {"command": "metadata", "returncode": 0},
@@ -869,7 +929,7 @@ def test_broad_packet_lazy_loader_warns_on_large_fallback_fanout(monkeypatch) ->
     packet = load_broad_packet_lazily(cwd=Path.cwd(), limit=100, repo=None)
 
     assert any(
-        warning.startswith("fallback per-PR merge-packet queries:")
+        warning.startswith("bounded per-PR merge-packet queries:")
         for warning in packet["load_warnings"]
     )
 
@@ -878,17 +938,32 @@ def test_combine_packets_preserves_source_packet_timestamps(monkeypatch) -> None
     def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
         del cwd, timeout
         if args[:5] == MERGE_PACKET_PREFIX:
-            if "--limit" in args:
-                return None, {"command": "bulk-packet", "returncode": 1, "stderr": "HTTP 504"}
             pr_number = int(args[args.index("--pr") + 1])
-            packet = _packet(_entry(pr_number))
+            entry = _entry(pr_number)
+            if pr_number == 7449:
+                entry = _entry(
+                    pr_number,
+                    checks_summary="1/2 failing",
+                    reasons=["docs/tests/status-only"],
+                )
+            packet = _packet(entry)
             packet["generated_at"] = f"packet-{pr_number}-generated-at"
             return packet, {"command": "packet", "returncode": 0}
         if args[:3] == ["gh", "pr", "list"]:
             return (
                 [
-                    {"number": 7449, "title": "fix(settlement)", "headRefName": "codex/settle"},
-                    {"number": 7450, "title": "fix(next)", "headRefName": "codex/next"},
+                    {
+                        "number": 7449,
+                        "title": "fix(settlement)",
+                        "headRefName": "codex/settle",
+                        "isDraft": False,
+                    },
+                    {
+                        "number": 7450,
+                        "title": "fix(next)",
+                        "headRefName": "codex/next",
+                        "isDraft": False,
+                    },
                 ],
                 {"command": "metadata", "returncode": 0},
             )


### PR DESCRIPTION
## Summary
- make broad `scripts/settle_one_pr.py --json` start from light PR metadata instead of bulk merge-packet loading
- skip draft and autonomous-ineligible candidates before targeted packet calls
- cap targeted per-PR packet attempts and return bounded no-candidate diagnostics when the window is exhausted or GitHub GraphQL is unavailable

## Validation
- `PATH=/Users/armand/.pyenv/versions/3.11.11/bin:$PATH python3 -m pytest tests/scripts/test_settle_one_pr.py`
- `python3 -m py_compile scripts/settle_one_pr.py`
- `PATH=/Users/armand/.pyenv/versions/3.11.11/bin:$PATH python3 scripts/settle_one_pr.py --json --limit 1` completed bounded under current GitHub GraphQL rate-limit exhaustion
- `PATH=/Users/armand/.pyenv/versions/3.11.11/bin:$PATH python3 scripts/settle_one_pr.py --json` completed bounded under current GitHub GraphQL rate-limit exhaustion
- `git diff --check origin/main HEAD`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Notes
- Draft only; no evidence collection, ready transition, merge, CI rerun, outbox/receipt, label, branch protection, queue settlement, or human-risk state mutation.
