### PR TITLE
[DIC-15] CruxSet arena-path bridge — CruxFinderResult → CruxSet

### DIFF
--- a/aragora/reasoning/cruxset_emission.py
+++ b/aragora/reasoning/cruxset_emission.py
@@ -127,9 +127,65 @@ def maybe_emit_cruxset(
         return None
 
 
+def maybe_emit_cruxset_from_finder_result(
+    result: Any,
+    *,
+    receipt_id: str = "",
+    extra_provenance: dict[str, Any] | None = None,
+) -> CruxSet | None:
+    """Arena-path bridge for DIC-15: CruxFinderResult → CruxSet.
+
+    Converts the output of a ``consensus="crux_finder"`` debate run into the
+    DIC-15 :class:`~aragora.reasoning.cruxset.CruxSet` contract. Returns
+    ``None`` when emission is disabled (the default).
+
+    Call this after :func:`~aragora.debate.crux_mode.build_crux_finder_result`
+    to obtain the ranked, signed CruxSet that downstream receipt ingestion
+    (DIC-16) and the follow-up bridge (DIC-17) consume.
+
+    ``decision`` is always ``None`` — a crux-finder run never produces a
+    verdict by design. Provenance is seeded from ``result.debate_id`` and
+    can be extended via ``extra_provenance``.
+
+    Flag: ``ARAGORA_CRUXSET_EMISSION_ENABLED`` (default ``False``).
+    Live queue effect: none.
+    """
+    if not cruxset_emission_enabled():
+        return None
+
+    from aragora.debate.crux_mode import CruxFinderResult  # lazy — avoids import cycle
+
+    if not isinstance(result, CruxFinderResult):
+        logger.warning(
+            "maybe_emit_cruxset_from_finder_result: expected CruxFinderResult, got %s",
+            type(result).__name__,
+        )
+        return None
+
+    provenance: dict[str, Any] = {
+        "debate_id": result.debate_id,
+        "mode": "crux_finder",
+        "approach": result.metadata.get("approach", "A"),
+        "rounds": result.rounds,
+        "agents": list(result.agents),
+    }
+    if extra_provenance:
+        provenance.update(extra_provenance)
+
+    return maybe_emit_cruxset(
+        question=result.question,
+        analysis_payload=result.analysis.to_dict(),
+        decision=None,  # crux_finder never produces a verdict by design
+        receipt_id=receipt_id,
+        provenance=provenance,
+        top_k=len(result.analysis.cruxes) or 5,
+    )
+
+
 __all__ = [
     "CRUXSET_EMISSION_ENV_VAR",
     "cruxset_emission_enabled",
     "enable_cruxset_emission",
     "maybe_emit_cruxset",
+    "maybe_emit_cruxset_from_finder_result",
 ]

--- a/aragora/reasoning/cruxset_emission.py
+++ b/aragora/reasoning/cruxset_emission.py
@@ -153,7 +153,13 @@ def maybe_emit_cruxset_from_finder_result(
     if not cruxset_emission_enabled():
         return None
 
-    from aragora.debate.crux_mode import CruxFinderResult  # lazy — avoids import cycle
+    try:
+        from aragora.debate.crux_mode import CruxFinderResult  # lazy — avoids import cycle
+    except Exception as exc:  # noqa: BLE001 - degrade gracefully like the rest of this function
+        logger.warning(
+            "maybe_emit_cruxset_from_finder_result: could not import CruxFinderResult: %s", exc
+        )
+        return None
 
     if not isinstance(result, CruxFinderResult):
         logger.warning(
@@ -170,6 +176,7 @@ def maybe_emit_cruxset_from_finder_result(
         "agents": list(result.agents),
     }
     if extra_provenance:
+        # extra_provenance intentionally overwrites base keys — caller's responsibility
         provenance.update(extra_provenance)
 
     return maybe_emit_cruxset(
@@ -178,7 +185,7 @@ def maybe_emit_cruxset_from_finder_result(
         decision=None,  # crux_finder never produces a verdict by design
         receipt_id=receipt_id,
         provenance=provenance,
-        top_k=len(result.analysis.cruxes) or 5,
+        top_k=max(len(result.analysis.cruxes), 1),
     )
 
 

--- a/aragora/reasoning/cruxset_emission.py
+++ b/aragora/reasoning/cruxset_emission.py
@@ -168,24 +168,36 @@ def maybe_emit_cruxset_from_finder_result(
         )
         return None
 
-    provenance: dict[str, Any] = {
-        "debate_id": result.debate_id,
-        "mode": "crux_finder",
-        "approach": result.metadata.get("approach", "A"),
-        "rounds": result.rounds,
-        "agents": list(result.agents),
-    }
+    try:
+        metadata = result.metadata or {}
+        analysis = result.analysis
+        analysis_payload = analysis.to_dict()
+        cruxes = list(analysis.cruxes)
+        counterfactuals = list(result.counterfactuals or [])
+        provenance: dict[str, Any] = {
+            "debate_id": result.debate_id,
+            "mode": "crux_finder",
+            "approach": metadata.get("approach", "A"),
+            "rounds": result.rounds,
+            "agents": list(result.agents),
+        }
+    except Exception as exc:  # noqa: BLE001 - malformed finder output must fail closed
+        logger.warning("maybe_emit_cruxset_from_finder_result: malformed CruxFinderResult: %s", exc)
+        return None
+
+    if counterfactuals:
+        provenance["counterfactuals"] = counterfactuals
     if extra_provenance:
         # extra_provenance intentionally overwrites base keys — caller's responsibility
         provenance.update(extra_provenance)
 
     return maybe_emit_cruxset(
         question=result.question,
-        analysis_payload=result.analysis.to_dict(),
+        analysis_payload=analysis_payload,
         decision=None,  # crux_finder never produces a verdict by design
         receipt_id=receipt_id,
         provenance=provenance,
-        top_k=max(len(result.analysis.cruxes), 1),
+        top_k=max(len(cruxes), 1),
     )
 
 

--- a/aragora/reasoning/cruxset_emission.py
+++ b/aragora/reasoning/cruxset_emission.py
@@ -155,7 +155,7 @@ def maybe_emit_cruxset_from_finder_result(
 
     try:
         from aragora.debate.crux_mode import CruxFinderResult  # lazy — avoids import cycle
-    except Exception as exc:  # noqa: BLE001 - degrade gracefully like the rest of this function
+    except BaseException as exc:  # noqa: BLE001 - pyo3_runtime.PanicException is not an Exception
         logger.warning(
             "maybe_emit_cruxset_from_finder_result: could not import CruxFinderResult: %s", exc
         )

--- a/tests/reasoning/test_dic15_cruxset_arena_bridge.py
+++ b/tests/reasoning/test_dic15_cruxset_arena_bridge.py
@@ -171,7 +171,9 @@ def test_cruxes_sorted_by_load_bearing_score_desc(monkeypatch) -> None:
 
 def test_provenance_carries_debate_id_and_mode(monkeypatch) -> None:
     monkeypatch.setenv(mod.CRUXSET_EMISSION_ENV_VAR, "1")
-    cs = mod.maybe_emit_cruxset_from_finder_result(_result(_analysis(_claim("c1", "S", 0.7)), debate_id="debate-xyz-42"))
+    cs = mod.maybe_emit_cruxset_from_finder_result(
+        _result(_analysis(_claim("c1", "S", 0.7)), debate_id="debate-xyz-42")
+    )
     assert cs is not None
     assert cs.provenance.get("debate_id") == "debate-xyz-42"
     assert cs.provenance.get("mode") == "crux_finder"
@@ -222,8 +224,12 @@ def test_checksum_valid_and_schema_version_set(monkeypatch) -> None:
 def test_returns_none_when_analysis_has_no_cruxes(monkeypatch) -> None:
     monkeypatch.setenv(mod.CRUXSET_EMISSION_ENV_VAR, "1")
     empty = CruxAnalysisResult(
-        cruxes=[], total_claims=0, total_disagreements=0,
-        average_uncertainty=0.0, convergence_barrier=0.0, recommended_focus=[],
+        cruxes=[],
+        total_claims=0,
+        total_disagreements=0,
+        average_uncertainty=0.0,
+        convergence_barrier=0.0,
+        recommended_focus=[],
     )
     assert mod.maybe_emit_cruxset_from_finder_result(_result(empty)) is None
 

--- a/tests/reasoning/test_dic15_cruxset_arena_bridge.py
+++ b/tests/reasoning/test_dic15_cruxset_arena_bridge.py
@@ -1,0 +1,243 @@
+"""DIC-15 (#6025): Arena-path bridge tests — CruxFinderResult → CruxSet.
+
+Verifies :func:`~aragora.reasoning.cruxset_emission.maybe_emit_cruxset_from_finder_result`:
+
+DIC-15 acceptance criteria exercised here:
+- Flag-gated (default off, no live queue effect)
+- Ranked by load_bearing_score desc (same ordering as CruxSet.build)
+- ``decision`` is always None (crux_finder never produces a verdict)
+- Provenance links back to the source debate and accepts extra_provenance
+- Checksum valid and receipt_id threaded through
+
+All tests use deterministic mocked inputs (no Arena or API calls).
+
+Note: ``aragora.debate.*`` imports are blocked by a broken Rust/cffi
+``cryptography`` backend in this container.  We inject a lightweight stub
+into ``sys.modules`` so the lazy import inside the function under test
+resolves to our ``_CruxFinderResult`` dataclass.  In CI the real class is
+used and the same tests pass.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass, field
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+from aragora.reasoning import cruxset_emission as mod
+from aragora.reasoning.crux_detector import CruxAnalysisResult, CruxClaim
+from aragora.reasoning.cruxset import CRUXSET_SCHEMA_VERSION, CruxSet
+
+
+# ---------------------------------------------------------------------------
+# Stub for CruxFinderResult (mirrors fields read by the bridge function)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _CruxFinderResult:
+    """Lightweight stand-in for aragora.debate.crux_mode.CruxFinderResult."""
+
+    debate_id: str
+    question: str
+    analysis: Any
+    agents: list[str] = field(default_factory=list)
+    rounds: int = 0
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@pytest.fixture(autouse=True)
+def _inject_crux_mode_stub(monkeypatch):
+    """Pre-populate sys.modules with a stub module so the lazy import in
+    maybe_emit_cruxset_from_finder_result resolves to _CruxFinderResult.
+    """
+    stub = ModuleType("aragora.debate.crux_mode")
+    stub.CruxFinderResult = _CruxFinderResult  # type: ignore[attr-defined]
+    if "aragora.debate" not in sys.modules:
+        monkeypatch.setitem(sys.modules, "aragora.debate", ModuleType("aragora.debate"))
+    monkeypatch.setitem(sys.modules, "aragora.debate.crux_mode", stub)
+
+
+@pytest.fixture(autouse=True)
+def _reset_emission_flag(monkeypatch):
+    monkeypatch.delenv(mod.CRUXSET_EMISSION_ENV_VAR, raising=False)
+    yield
+    monkeypatch.delenv(mod.CRUXSET_EMISSION_ENV_VAR, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _claim(claim_id: str, statement: str, score: float) -> CruxClaim:
+    return CruxClaim(
+        claim_id=claim_id,
+        statement=statement,
+        author="agent-alpha",
+        crux_score=score,
+        influence_score=score * 0.9,
+        disagreement_score=score * 0.8,
+        uncertainty_score=score * 0.5,
+        centrality_score=score * 0.7,
+        affected_claims=[],
+        contesting_agents=["agent-beta"] if score > 0.5 else [],
+        resolution_impact=score * 0.4,
+    )
+
+
+def _analysis(*claims: CruxClaim, barrier: float = 0.5) -> CruxAnalysisResult:
+    return CruxAnalysisResult(
+        cruxes=list(claims),
+        total_claims=len(claims) + 2,
+        total_disagreements=len(claims),
+        average_uncertainty=0.45,
+        convergence_barrier=barrier,
+        recommended_focus=[c.claim_id for c in claims],
+    )
+
+
+def _result(
+    analysis: CruxAnalysisResult,
+    *,
+    debate_id: str = "debate-test-001",
+    question: str = "Should we adopt X?",
+    agents: list[str] | None = None,
+    rounds: int = 3,
+) -> _CruxFinderResult:
+    return _CruxFinderResult(
+        debate_id=debate_id,
+        question=question,
+        analysis=analysis,
+        agents=list(agents or ["agent-alpha", "agent-beta"]),
+        rounds=rounds,
+        metadata={"mode": "crux_finder", "approach": "A"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Feature flag
+# ---------------------------------------------------------------------------
+
+
+def test_returns_none_when_disabled() -> None:
+    cs = mod.maybe_emit_cruxset_from_finder_result(_result(_analysis(_claim("c1", "S", 0.8))))
+    assert cs is None
+
+
+def test_returns_cruxset_when_enabled(monkeypatch) -> None:
+    monkeypatch.setenv(mod.CRUXSET_EMISSION_ENV_VAR, "1")
+    cs = mod.maybe_emit_cruxset_from_finder_result(
+        _result(_analysis(_claim("c1", "X load-bearing", 0.8), _claim("c2", "Y dep X", 0.5)))
+    )
+    assert isinstance(cs, CruxSet)
+
+
+# ---------------------------------------------------------------------------
+# 2. No-verdict invariant (DIC-15 core guardrail)
+# ---------------------------------------------------------------------------
+
+
+def test_decision_is_always_none(monkeypatch) -> None:
+    """crux_finder never produces a verdict; decision must be None."""
+    monkeypatch.setenv(mod.CRUXSET_EMISSION_ENV_VAR, "1")
+    cs = mod.maybe_emit_cruxset_from_finder_result(_result(_analysis(_claim("c1", "S", 0.9))))
+    assert cs is not None
+    assert cs.decision is None
+
+
+# ---------------------------------------------------------------------------
+# 3. Ranking
+# ---------------------------------------------------------------------------
+
+
+def test_cruxes_sorted_by_load_bearing_score_desc(monkeypatch) -> None:
+    monkeypatch.setenv(mod.CRUXSET_EMISSION_ENV_VAR, "1")
+    a = _analysis(_claim("c1", "Low", 0.3), _claim("c2", "High", 0.9), _claim("c3", "Mid", 0.6))
+    cs = mod.maybe_emit_cruxset_from_finder_result(_result(a))
+    assert cs is not None
+    scores = [c.load_bearing_score for c in cs.cruxes]
+    assert scores == sorted(scores, reverse=True)
+    assert cs.cruxes[0].crux_id == "c2"
+
+
+# ---------------------------------------------------------------------------
+# 4. Provenance links
+# ---------------------------------------------------------------------------
+
+
+def test_provenance_carries_debate_id_and_mode(monkeypatch) -> None:
+    monkeypatch.setenv(mod.CRUXSET_EMISSION_ENV_VAR, "1")
+    cs = mod.maybe_emit_cruxset_from_finder_result(_result(_analysis(_claim("c1", "S", 0.7)), debate_id="debate-xyz-42"))
+    assert cs is not None
+    assert cs.provenance.get("debate_id") == "debate-xyz-42"
+    assert cs.provenance.get("mode") == "crux_finder"
+    assert cs.provenance.get("approach") == "A"
+
+
+def test_extra_provenance_merged(monkeypatch) -> None:
+    monkeypatch.setenv(mod.CRUXSET_EMISSION_ENV_VAR, "1")
+    cs = mod.maybe_emit_cruxset_from_finder_result(
+        _result(_analysis(_claim("c1", "S", 0.7))),
+        extra_provenance={"pipeline": "nightly-audit", "corpus_rev": 6},
+    )
+    assert cs is not None
+    assert cs.provenance.get("pipeline") == "nightly-audit"
+    assert cs.provenance.get("corpus_rev") == 6
+    assert cs.provenance.get("debate_id") is not None  # base provenance preserved
+
+
+def test_receipt_id_threaded_through(monkeypatch) -> None:
+    monkeypatch.setenv(mod.CRUXSET_EMISSION_ENV_VAR, "1")
+    cs = mod.maybe_emit_cruxset_from_finder_result(
+        _result(_analysis(_claim("c1", "S", 0.7))), receipt_id="rcpt_abc123"
+    )
+    assert cs is not None
+    assert cs.receipt_id == "rcpt_abc123"
+
+
+# ---------------------------------------------------------------------------
+# 5. Checksum and schema
+# ---------------------------------------------------------------------------
+
+
+def test_checksum_valid_and_schema_version_set(monkeypatch) -> None:
+    monkeypatch.setenv(mod.CRUXSET_EMISSION_ENV_VAR, "1")
+    cs = mod.maybe_emit_cruxset_from_finder_result(
+        _result(_analysis(_claim("c1", "Load-bearing", 0.8), _claim("c2", "Secondary", 0.4)))
+    )
+    assert cs is not None
+    assert cs.verify_checksum() is True
+    assert cs.schema_version == CRUXSET_SCHEMA_VERSION
+
+
+# ---------------------------------------------------------------------------
+# 6. Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_returns_none_when_analysis_has_no_cruxes(monkeypatch) -> None:
+    monkeypatch.setenv(mod.CRUXSET_EMISSION_ENV_VAR, "1")
+    empty = CruxAnalysisResult(
+        cruxes=[], total_claims=0, total_disagreements=0,
+        average_uncertainty=0.0, convergence_barrier=0.0, recommended_focus=[],
+    )
+    assert mod.maybe_emit_cruxset_from_finder_result(_result(empty)) is None
+
+
+def test_returns_none_for_wrong_type(monkeypatch) -> None:
+    monkeypatch.setenv(mod.CRUXSET_EMISSION_ENV_VAR, "1")
+    assert mod.maybe_emit_cruxset_from_finder_result("not-a-result") is None  # type: ignore[arg-type]
+
+
+def test_convergence_barrier_in_counterfactual_notes(monkeypatch) -> None:
+    """build_cruxset_from_analysis must embed the convergence_barrier signal."""
+    monkeypatch.setenv(mod.CRUXSET_EMISSION_ENV_VAR, "1")
+    cs = mod.maybe_emit_cruxset_from_finder_result(
+        _result(_analysis(_claim("c1", "Key assumption", 0.75), barrier=0.66))
+    )
+    assert cs is not None
+    assert any("convergence_barrier=0.66" in n for n in cs.counterfactual_notes)

--- a/tests/reasoning/test_dic15_cruxset_arena_bridge.py
+++ b/tests/reasoning/test_dic15_cruxset_arena_bridge.py
@@ -108,10 +108,11 @@ def _analysis(*claims: CruxClaim, barrier: float = 0.5) -> CruxAnalysisResult:
 
 
 def _result(
-    analysis: CruxAnalysisResult,
+    analysis: Any,
     *,
     debate_id: str = "debate-test-001",
     question: str = "Should we adopt X?",
+    counterfactuals: list[dict[str, Any]] | None = None,
     agents: list[str] | None = None,
     rounds: int = 3,
 ) -> Any:
@@ -119,7 +120,7 @@ def _result(
         debate_id=debate_id,
         question=question,
         analysis=analysis,
-        counterfactuals=[],
+        counterfactuals=list(counterfactuals or []),
         agents=list(agents or ["agent-alpha", "agent-beta"]),
         rounds=rounds,
         raw_claims=[],
@@ -201,6 +202,22 @@ def test_extra_provenance_merged(monkeypatch) -> None:
     assert cs.provenance.get("debate_id") is not None  # base provenance preserved
 
 
+def test_counterfactuals_preserved_in_provenance(monkeypatch) -> None:
+    monkeypatch.setenv(mod.CRUXSET_EMISSION_ENV_VAR, "1")
+    counterfactuals = [
+        {
+            "claim_id": "c1",
+            "assumption": "X is false",
+            "would_flip": True,
+        }
+    ]
+    cs = mod.maybe_emit_cruxset_from_finder_result(
+        _result(_analysis(_claim("c1", "S", 0.7)), counterfactuals=counterfactuals)
+    )
+    assert cs is not None
+    assert cs.provenance.get("counterfactuals") == counterfactuals
+
+
 def test_receipt_id_threaded_through(monkeypatch) -> None:
     monkeypatch.setenv(mod.CRUXSET_EMISSION_ENV_VAR, "1")
     cs = mod.maybe_emit_cruxset_from_finder_result(
@@ -246,6 +263,24 @@ def test_returns_none_when_analysis_has_no_cruxes(monkeypatch) -> None:
 def test_returns_none_for_wrong_type(monkeypatch) -> None:
     monkeypatch.setenv(mod.CRUXSET_EMISSION_ENV_VAR, "1")
     assert mod.maybe_emit_cruxset_from_finder_result("not-a-result") is None  # type: ignore[arg-type]
+
+
+def test_malformed_finder_analysis_fails_closed(monkeypatch) -> None:
+    monkeypatch.setenv(mod.CRUXSET_EMISSION_ENV_VAR, "1")
+    malformed = _result(_analysis(_claim("c1", "S", 0.7)))
+    malformed.analysis = None
+    assert mod.maybe_emit_cruxset_from_finder_result(malformed) is None
+
+
+def test_analysis_conversion_failure_fails_closed(monkeypatch) -> None:
+    class BrokenAnalysis:
+        cruxes = [_claim("c1", "S", 0.7)]
+
+        def to_dict(self) -> dict[str, Any]:
+            raise ValueError("bad analysis payload")
+
+    monkeypatch.setenv(mod.CRUXSET_EMISSION_ENV_VAR, "1")
+    assert mod.maybe_emit_cruxset_from_finder_result(_result(BrokenAnalysis())) is None
 
 
 def test_convergence_barrier_in_counterfactual_notes(monkeypatch) -> None:

--- a/tests/reasoning/test_dic15_cruxset_arena_bridge.py
+++ b/tests/reasoning/test_dic15_cruxset_arena_bridge.py
@@ -11,11 +11,10 @@ DIC-15 acceptance criteria exercised here:
 
 All tests use deterministic mocked inputs (no Arena or API calls).
 
-Note: ``aragora.debate.*`` imports are blocked by a broken Rust/cffi
-``cryptography`` backend in this container.  We inject a lightweight stub
-into ``sys.modules`` so the lazy import inside the function under test
-resolves to our ``_CruxFinderResult`` dataclass.  In CI the real class is
-used and the same tests pass.
+Note: ``aragora.debate.*`` imports may be blocked by a broken Rust/cffi
+``cryptography`` backend in some containers.  We try the real import first;
+only when it fails do we inject a lightweight stub into ``sys.modules`` so
+the lazy import inside the function under test can resolve.
 """
 
 from __future__ import annotations
@@ -33,29 +32,37 @@ from aragora.reasoning.cruxset import CRUXSET_SCHEMA_VERSION, CruxSet
 
 
 # ---------------------------------------------------------------------------
-# Stub for CruxFinderResult (mirrors fields read by the bridge function)
+# Real import or stub — prefer real when available
 # ---------------------------------------------------------------------------
 
+try:
+    from aragora.debate.crux_mode import CruxFinderResult as _ResultClass  # type: ignore[assignment]
 
-@dataclass
-class _CruxFinderResult:
-    """Lightweight stand-in for aragora.debate.crux_mode.CruxFinderResult."""
+    _USE_STUB = False
+except BaseException:  # noqa: BLE001 - pyo3_runtime.PanicException is not a subclass of Exception
+    _USE_STUB = True
 
-    debate_id: str
-    question: str
-    analysis: Any
-    agents: list[str] = field(default_factory=list)
-    rounds: int = 0
-    metadata: dict[str, Any] = field(default_factory=dict)
+    @dataclass  # type: ignore[no-redef]
+    class _ResultClass:  # type: ignore[no-redef]
+        """Lightweight stand-in for aragora.debate.crux_mode.CruxFinderResult."""
+
+        debate_id: str
+        question: str
+        analysis: Any
+        counterfactuals: list[dict[str, Any]] = field(default_factory=list)
+        agents: list[str] = field(default_factory=list)
+        rounds: int = 0
+        raw_claims: list[dict[str, Any]] = field(default_factory=list)
+        metadata: dict[str, Any] = field(default_factory=dict)
 
 
 @pytest.fixture(autouse=True)
 def _inject_crux_mode_stub(monkeypatch):
-    """Pre-populate sys.modules with a stub module so the lazy import in
-    maybe_emit_cruxset_from_finder_result resolves to _CruxFinderResult.
-    """
+    """Inject stub only when the real import failed (broken cryptography backend)."""
+    if not _USE_STUB:
+        return
     stub = ModuleType("aragora.debate.crux_mode")
-    stub.CruxFinderResult = _CruxFinderResult  # type: ignore[attr-defined]
+    stub.CruxFinderResult = _ResultClass  # type: ignore[attr-defined]
     if "aragora.debate" not in sys.modules:
         monkeypatch.setitem(sys.modules, "aragora.debate", ModuleType("aragora.debate"))
     monkeypatch.setitem(sys.modules, "aragora.debate.crux_mode", stub)
@@ -107,13 +114,15 @@ def _result(
     question: str = "Should we adopt X?",
     agents: list[str] | None = None,
     rounds: int = 3,
-) -> _CruxFinderResult:
-    return _CruxFinderResult(
+) -> Any:
+    return _ResultClass(
         debate_id=debate_id,
         question=question,
         analysis=analysis,
+        counterfactuals=[],
         agents=list(agents or ["agent-alpha", "agent-beta"]),
         rounds=rounds,
+        raw_claims=[],
         metadata={"mode": "crux_finder", "approach": "A"},
     )
 


### PR DESCRIPTION
## Slice

Adds `maybe_emit_cruxset_from_finder_result()` to `aragora/reasoning/cruxset_emission.py` — the missing direct bridge from a completed `CruxFinderResult` (Arena output) to the DIC-15 `CruxSet` contract. The `CruxSet` dataclass, `maybe_emit_cruxset`, and `consensus="crux_finder"` registration were already on `main`; what was absent was a single call-site for Arena callers that hold a `CruxFinderResult` and want the signed, ranked `CruxSet` output.

## Gating

- Default: **OFF** (flag: `ARAGORA_CRUXSET_EMISSION_ENABLED`)
- Live queue effect: **none**
- Advances issue: #6025

## Tests

- `test_returns_none_when_disabled` — flag off → function exits before any debate import
- `test_returns_cruxset_when_enabled` — flag on, result with cruxes → `isinstance(cs, CruxSet)`
- `test_decision_is_always_none` — crux-finder never produces a verdict; `cs.decision is None`
- `test_cruxes_sorted_by_load_bearing_score_desc` — ranking preserved from analyser output
- `test_provenance_carries_debate_id_and_mode` — provenance links `debate_id`, `mode="crux_finder"`, `approach="A"`
- `test_extra_provenance_merged` — `extra_provenance` kwarg merged without losing base provenance
- `test_receipt_id_threaded_through` — `receipt_id` kwarg passes through to `CruxSet.receipt_id`
- `test_checksum_valid_and_schema_version_set` — `cs.verify_checksum()` is True; schema version correct
- `test_returns_none_when_analysis_has_no_cruxes` — empty crux list → None (not a ValueError)
- `test_returns_none_for_wrong_type` — isinstance guard fires for non-`CruxFinderResult` inputs
- `test_convergence_barrier_in_counterfactual_notes` — `build_cruxset_from_analysis` embeds the barrier signal

## Validation

- `pytest tests/reasoning/test_dic15_cruxset_arena_bridge.py --noconftest` — **11 passed**
- `ruff check aragora/reasoning/cruxset_emission.py tests/reasoning/test_dic15_cruxset_arena_bridge.py` — **clean**
- `mypy aragora/reasoning/cruxset_emission.py --ignore-missing-imports` — **clean**

## Out of scope

- Wiring the bridge into the Arena's consensus phase (that's a follow-up once DIC-16 receipt persistence lands)
- Persisting the returned `CruxSet` to the receipt or KM stores (DIC-16 / #6026)
- Testing `DebateProtocol(consensus="crux_finder")` mode registration (already covered by `tests/debate/test_crux_mode.py::test_crux_finder_literal_accepted` on main)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CXKiLCA2iiLhAepPtPktWk)_