### PR TITLE
feat(structex): add repo-root allowlist doc + CI checker (HEALTH-1 #8258)

### DIFF
--- a/docs/reference/ROOT_ALLOWLIST.md
+++ b/docs/reference/ROOT_ALLOWLIST.md
@@ -1,0 +1,75 @@
+# Repo-root allowlist
+
+The repository root must stay curated: only the files listed below may be tracked
+directly at the root of `synaptent/aragora`. Everything else belongs in a
+subdirectory. The list is enforced by `scripts/ci/check_root_allowlist.py`, which
+exits non-zero (naming the offender) when a tracked root file is not listed here.
+
+This guard was introduced with the P1 repo-root hygiene cleanup (HEALTH-1 #8258),
+which untracked stale clutter (marketing screenshots, a stale generated
+`openapi.json` whose canonical copy lives at `docs/api/openapi.json`, an
+inbox-triage dump, and two stray root test files). The only binary assets that
+remain at the root are the brand images `aragora_logo.png` and `favicon.png`.
+
+## How to update
+
+When you legitimately need a new root-level file, add its exact name between the
+markers below (keep the list sorted). To remove clutter instead, run
+`git rm --cached <file>` and add a matching pattern to `.gitignore`. Regenerate
+the candidate set with `git ls-files | grep -v /`.
+
+## Allowed root files
+
+<!-- ROOT_ALLOWLIST_BEGIN -->
+```text
+.dockerignore
+.env.example
+.env.production.example
+.gitattributes
+.gitguardian.yaml
+.gitignore
+.gitleaks.toml
+.importlinter
+.mypy-baseline
+.pre-commit-config.yaml
+.trivy.yaml
+.trivyignore
+AGENTS.md
+CHANGELOG.md
+CLAUDE.md
+CODE_OF_CONDUCT.md
+CONTRIBUTING.md
+DEVELOPMENT.md
+Dockerfile
+INSTALL.md
+Idea-to-Execution-Pipeline-Research.md
+LICENSE
+MANIFEST.in
+Makefile
+NEXT_STEPS.md
+README.md
+ROADMAP.md
+SECURITY.md
+SECURITY_AUDIT_INPUT_VALIDATION.md
+THIRD_PARTY_LICENSES.md
+TROUBLESHOOTING.md
+action.yml
+alembic.ini
+aragora_logo.png
+docker-compose.dev.yml
+docker-compose.production.yml
+docker-compose.quickstart.yml
+docker-compose.simple.yml
+docker-compose.sme.yml
+docker-compose.yml
+favicon.png
+github-app-manifest.json
+k8s
+pyproject.toml
+requirements.txt
+run_staging.py
+sitecustomize.py
+trivy.yaml
+uv.lock
+```
+<!-- ROOT_ALLOWLIST_END -->

--- a/scripts/ci/check_root_allowlist.py
+++ b/scripts/ci/check_root_allowlist.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Fail when a tracked repo-root file is not in docs/reference/ROOT_ALLOWLIST.md.
+
+Repo-root hygiene guard (HEALTH-1 #8258): the repository root should hold only a
+curated allowlist of files. Any tracked file living directly at the repo root
+that is not listed in ``docs/reference/ROOT_ALLOWLIST.md`` trips this check,
+naming the offender. Files in subdirectories are out of scope.
+
+Usage::
+
+    python3 scripts/ci/check_root_allowlist.py            # exit 0 when root is clean
+    python3 scripts/ci/check_root_allowlist.py            # exit 1 naming any newcomer
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ALLOWLIST_REL = "docs/reference/ROOT_ALLOWLIST.md"
+BEGIN_MARKER = "<!-- ROOT_ALLOWLIST_BEGIN -->"
+END_MARKER = "<!-- ROOT_ALLOWLIST_END -->"
+
+
+def parse_allowlist(text: str) -> set[str]:
+    """Extract allowlisted root filenames from the markdown allowlist doc.
+
+    Entries are the non-empty lines between the BEGIN/END HTML-comment markers.
+    Code-fence lines, comment lines, surrounding backticks, and any token
+    containing ``/`` (i.e. not repo-root scope) are ignored.
+    """
+    entries: set[str] = set()
+    capturing = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped == BEGIN_MARKER:
+            capturing = True
+            continue
+        if stripped == END_MARKER:
+            break
+        if not capturing:
+            continue
+        if not stripped or stripped.startswith("#") or stripped.startswith("```"):
+            continue
+        token = stripped.strip("`").strip()
+        if not token or "/" in token:
+            continue
+        entries.add(token)
+    return entries
+
+
+def find_offenders(tracked_root_files: list[str], allowlist: set[str]) -> list[str]:
+    """Tracked repo-root files that are not covered by the allowlist."""
+    return sorted(f for f in tracked_root_files if f not in allowlist)
+
+
+def list_tracked_root_files() -> list[str]:
+    """Tracked entries living directly at the repo root (no path separator)."""
+    out = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    return sorted(p for p in out.split("\0") if p and "/" not in p)
+
+
+def main() -> int:
+    doc = REPO_ROOT / ALLOWLIST_REL
+    if not doc.is_file():
+        print(f"check_root_allowlist: FAIL missing allowlist doc {ALLOWLIST_REL}")
+        return 2
+
+    allowlist = parse_allowlist(doc.read_text(encoding="utf-8"))
+    if not allowlist:
+        print(f"check_root_allowlist: FAIL empty allowlist in {ALLOWLIST_REL}")
+        return 2
+
+    tracked = list_tracked_root_files()
+    offenders = find_offenders(tracked, allowlist)
+    if offenders:
+        print("check_root_allowlist: FAIL non-allowlisted tracked repo-root file(s):")
+        for offender in offenders:
+            print(f"  {offender}")
+        print(
+            f"Add a legitimate entry to {ALLOWLIST_REL}, or untrack clutter with "
+            "'git rm --cached <file>'."
+        )
+        return 1
+
+    print(f"check_root_allowlist: OK all {len(tracked)} tracked repo-root files are allowlisted.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ci/test_check_root_allowlist.py
+++ b/tests/ci/test_check_root_allowlist.py
@@ -1,0 +1,117 @@
+"""Unit tests for scripts/ci/check_root_allowlist.py.
+
+Exercises the pure parse/offender logic and the ``main`` CLI wiring against a
+fake checkout (``REPO_ROOT`` and ``list_tracked_root_files`` are monkeypatched)
+so the tests stay fast and never depend on the live repo root. The end-to-end
+behavior on real origin/main (green on a clean tree, a tamper file trips it,
+restore greens again) is covered by the VAL-P1-005 acceptance check.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_CHECKER_PATH = REPO_ROOT / "scripts" / "ci" / "check_root_allowlist.py"
+
+_spec = importlib.util.spec_from_file_location("check_root_allowlist", _CHECKER_PATH)
+cra = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(cra)
+
+
+SAMPLE_DOC = """# Root allowlist
+
+Some intro prose mentioning docs/reference paths that must be ignored.
+
+<!-- ROOT_ALLOWLIST_BEGIN -->
+```text
+README.md
+aragora_logo.png
+favicon.png
+.gitignore
+# a comment inside the block is ignored
+docs/should_be_ignored.md
+```
+<!-- ROOT_ALLOWLIST_END -->
+
+zz_outside_block.txt
+"""
+
+
+# --- pure logic -------------------------------------------------------------
+
+
+def test_parse_allowlist_extracts_block_entries():
+    assert cra.parse_allowlist(SAMPLE_DOC) == {
+        "README.md",
+        "aragora_logo.png",
+        "favicon.png",
+        ".gitignore",
+    }
+
+
+def test_parse_allowlist_ignores_tokens_outside_block_and_paths():
+    parsed = cra.parse_allowlist(SAMPLE_DOC)
+    assert "zz_outside_block.txt" not in parsed  # outside the markers
+    assert "docs/should_be_ignored.md" not in parsed  # contains '/'
+    assert "text" not in parsed  # the ```text fence info string
+
+
+def test_find_offenders_flags_unlisted():
+    tracked = ["README.md", "aragora_logo.png", "zz_val_tamper.xyz"]
+    allowlist = {"README.md", "aragora_logo.png"}
+    assert cra.find_offenders(tracked, allowlist) == ["zz_val_tamper.xyz"]
+
+
+def test_find_offenders_clean_returns_empty():
+    tracked = ["README.md", "favicon.png"]
+    allowlist = {"README.md", "favicon.png", "extra"}
+    assert cra.find_offenders(tracked, allowlist) == []
+
+
+# --- main CLI wiring --------------------------------------------------------
+
+
+def _write_doc(root: Path, body: str = SAMPLE_DOC) -> None:
+    doc = root / "docs" / "reference" / "ROOT_ALLOWLIST.md"
+    doc.parent.mkdir(parents=True, exist_ok=True)
+    doc.write_text(body, encoding="utf-8")
+
+
+def test_main_green_on_clean_tree(tmp_path, monkeypatch):
+    _write_doc(tmp_path)
+    monkeypatch.setattr(cra, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(
+        cra,
+        "list_tracked_root_files",
+        lambda: ["README.md", "aragora_logo.png", "favicon.png", ".gitignore"],
+    )
+    assert cra.main() == 0
+
+
+def test_main_flags_tamper_and_names_offender(tmp_path, monkeypatch, capsys):
+    _write_doc(tmp_path)
+    monkeypatch.setattr(cra, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(
+        cra,
+        "list_tracked_root_files",
+        lambda: ["README.md", "zz_val_tamper.xyz"],
+    )
+    assert cra.main() == 1
+    assert "zz_val_tamper.xyz" in capsys.readouterr().out
+
+
+def test_main_missing_doc_returns_2(tmp_path, monkeypatch):
+    monkeypatch.setattr(cra, "REPO_ROOT", tmp_path)  # no doc written
+    assert cra.main() == 2
+
+
+def test_main_empty_allowlist_returns_2(tmp_path, monkeypatch):
+    _write_doc(
+        tmp_path,
+        "# empty\n<!-- ROOT_ALLOWLIST_BEGIN -->\n<!-- ROOT_ALLOWLIST_END -->\n",
+    )
+    monkeypatch.setattr(cra, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(cra, "list_tracked_root_files", lambda: ["README.md"])
+    assert cra.main() == 2


### PR DESCRIPTION
## Summary

P1 repo-root hygiene tooling (HEALTH-1 #8258, part of Structural Excellence epic #8257).

Adds a curated repo-root allowlist and a CI guard so cleaned clutter cannot creep back:
- `docs/reference/ROOT_ALLOWLIST.md` enumerates every file permitted directly at the
  repository root (49 entries, including the only remaining root binaries
  `aragora_logo.png` and `favicon.png`).
- `scripts/ci/check_root_allowlist.py` lists tracked root files via `git ls-files`,
  parses the allowlist doc, and exits non-zero (naming the offender) on any
  non-allowlisted tracked root file. Subdirectory files are out of scope.
- `tests/ci/test_check_root_allowlist.py` covers the parse/offender logic and the
  `main` CLI (green on a clean tree, tamper trips and names the file, missing/empty
  doc fails).

## Validation
- `pytest tests/ci/test_check_root_allowlist.py` -> 8 passed.
- `ruff check` clean on the checker and its tests.
- End-to-end in a throwaway repo seeded with the 49 root files: clean exit 0; a
  tampered `zz_val_tamper.xyz` exits 1 naming it; restore exits 0.

Fulfills VAL-P1-005 (and supports VAL-P1-001's allowlist clause). Tier 2.