### PR TITLE
chore(structex): pin tests_collect_total pre-migration floor (VAL-P1-009) (#8258)

### DIFF
--- a/docs/audits/2026-06-12-codebase-health-audit.md
+++ b/docs/audits/2026-06-12-codebase-health-audit.md
@@ -64,12 +64,13 @@ Every headline number is reproducible: the exact command for each lives in the b
 
 ## Finding 4 — Tests: substance with a depth caveat
 
-**No issue (healthy).** | **Baseline keys:** `test_fns`, `test_files_py`, `mock_test_files`
+**No issue (healthy).** | **Baseline keys:** `test_fns`, `test_files_py`, `mock_test_files`, `tests_collect_total`
 
 - `docs/METRICS.md` claims verified within 0.2% (220,821 measured test functions; metrics pipeline is auto-generated, CI-checked by `metrics-drift.yml`, with anti-self-reference invariant tests).
 - Skip/xfail density ~1% of files. Flaky-retry plugin explicitly disabled (`-p no:rerunfailures`) — an anti-flake-masking choice.
 - Sampled tests assert real semantics: `tests/server/test_route_collisions.py` enumerates the live handler registry with a frozen shrink-only baseline; `tests/debate/test_consensus.py` asserts exact computed values; `tests/gauntlet/test_crux_receipt.py` asserts checksum stability and single-field mutation sensitivity.
 - Caveats: ~73% of test files are mock-reliant; only ~750 parametrize decorators across 220K functions — the headline count overstates depth.
+- **Collection floor pinned (P1):** `tests_collect_total` = 228385 (`PYTHONPATH=.:aragora-debate/src python3 -m pytest --collect-only -q tests/`, measured on origin/main `f9e49d9336`, rc=0, no collection errors) records the pre-migration pytest collection total under the update-BOTH rule. The P1 tests-root→subdir migration is rename-only, so the collect-only total must never drop below this floor (VAL-P1-009 path B).
 
 ## Finding 5 — CI: real governance, real weight, one real bug
 

--- a/docs/audits/2026-06-12-codebase-health-baseline.json
+++ b/docs/audits/2026-06-12-codebase-health-baseline.json
@@ -174,6 +174,14 @@
       "command": "python3 scripts/ci/measure_import_graph.py | jq .handlers_flat_root",
       "issue": 8259,
       "note": "Python files directly in the aragora/server/handlers/ root; equals 'ls aragora/server/handlers/*.py | wc -l'. Pinned by scripts/ci/measure_import_graph.py. Target <20 (P4b)."
+    },
+    {
+      "key": "tests_collect_total",
+      "value": 228385,
+      "direction": "grow",
+      "command": "PYTHONPATH=.:aragora-debate/src python3 -m pytest --collect-only -q tests/",
+      "issue": 8258,
+      "note": "Pre-migration pytest collection total, pinned BEFORE the P1 tests-root->subdir migration (VAL-P1-009 path B floor). The migration is rename-only (git mv loose tests/*.py into shard-referenced mirrored subdirs), so the post-migration collect-only total must never drop below this value. Measured on origin/main f9e49d9336 (pytest 9.0.2, rc=0, no collection errors)."
     }
   ]
 }


### PR DESCRIPTION
## Source

HEALTH-1 #8258 (epic #8257, Structural Excellence). Prereq for the P1 tests-root→subdir migration and for validation assertion **VAL-P1-009** (path B reads this pinned value).

## Behavior

Pins the pre-migration pytest collection total as a new baseline metric `tests_collect_total` under the **update-BOTH** rule (machine-readable baseline JSON + narrative audit md). This is the rename-only migration's losslessness floor: the collect-only total must never drop below it.

- `docs/audits/2026-06-12-codebase-health-baseline.json`: new metric `tests_collect_total` = **228385**, `direction: grow`, `issue: 8258`, command pinned.
- `docs/audits/2026-06-12-codebase-health-audit.md`: Finding 4 baseline-keys updated + "Collection floor pinned (P1)" bullet.

No code, test, or module-structure changes. Docs-only.

## Validation

Measured on origin/main `f9e49d9336` (pytest 9.0.2):

```
$ PYTHONPATH=.:aragora-debate/src python3 -m pytest --collect-only -q tests/
228385 tests collected in 264.54s (0:04:24)   # rc=0, no collection errors
```

VAL-P1-009 path B reader (baseline JSON):

```
$ python3 -c 'import json; ms=json.load(open("docs/audits/2026-06-12-codebase-health-baseline.json"))["metrics"]; \
  h=[m for m in ms if "collect-only" in m.get("command","")]; print(h[0]["key"], h[0]["value"], type(h[0]["value"]).__name__)'
tests_collect_total 228385 int
```

## Risks

Tier 0, docs-only. `make lint` green; preflight "docs-only diff detected / ok". No runtime, API, or CI-behavior surface touched.
