### PR TITLE
feat(odr): aragora-verify — standalone offline ODR receipt verifier (#8226)

### DIFF
--- a/aragora-verify/.gitignore
+++ b/aragora-verify/.gitignore
@@ -1,0 +1,7 @@
+.nomic/
+.benchmarks/
+*.db
+*.db-shm
+*.db-wal
+dist/
+*.egg-info/

--- a/aragora-verify/CHANGELOG.md
+++ b/aragora-verify/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to `aragora-verify` are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/) and the project uses semantic
+versioning.
+
+## [0.1.0] — unreleased
+
+### Added
+- Initial release: standalone offline verifier for Open Decision Receipts (ODR v0.1).
+- `aragora-verify <receipt.json> [--pubkey KEY] [--chain JSONL] [--json]` CLI.
+- Library API: `verify`, `load_public_key`, `compute_key_id`, `validate_structure`,
+  `jcs_canonicalize`, `odr_content_digest`.
+- Checks: ODR v0.1 schema conformance (stdlib structural validator, with optional
+  `jsonschema` rigor), RFC 8785 (JCS) canonical digest recomputation, Ed25519
+  detached-signature verification, quorum participant consistency, and hash-chain
+  linkage/anchoring.
+- Absent markers and `"undisclosed"` model families surfaced as non-failing
+  weakening signals.
+- Dependencies: Python standard library plus `cryptography`; `jsonschema` optional.

--- a/aragora-verify/LICENSE
+++ b/aragora-verify/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Aragora Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/aragora-verify/README.md
+++ b/aragora-verify/README.md
@@ -44,8 +44,11 @@ aragora-verify receipt.odr.json --pubkey key.pem --chain intent-chain.jsonl
 aragora-verify receipt.odr.json --pubkey key.pem --json
 ```
 
-Exit code `0` means verified (no failed checks); `1` means a check failed;
-`2` is a usage/input error.
+Exit code `0` means verified (no failed checks, and any present signatures were
+checked); `1` means a check failed; `2` is a usage/input error; `3` means the
+receipt is structurally OK but carries signatures that were **not** checked
+(no `--pubkey` supplied) — authenticity is unestablished, so it is deliberately
+not reported as `0`/VERIFIED.
 
 The public key for receipts emitted by an Aragora deployment is published at
 `GET /.well-known/aragora-odr-signing-key` and `GET /api/v2/receipts/signing-key`.
@@ -57,6 +60,24 @@ are **honesty signals** — a receipt full of them is visibly weak, not a
 strong-looking fabrication. They are reported as *weakening signals* and do
 **not** fail verification; the policy thresholds (e.g. "require ≥2 model
 families", "require human attestation") are yours to apply on top.
+
+### Known limitations (v0.1)
+
+The verifier is deliberately conservative and these are documented, not silent:
+
+- **Hash-chain (`--chain`) is anchoring + self-consistency, not integrity.** It
+  confirms the receipt's content digest appears in the chain and that declared
+  `prev_hash`/`hash` links are internally consistent, but it does **not** recompute
+  entry hashes — so it reports `chain_link` as `WARN` when links are present. A
+  party who controls the chain file can fabricate consistent-looking linkage; the
+  chain is corroborating evidence, not a tamper proof on its own.
+- **Signature verification is single-key, Ed25519-only.** It verifies that at least
+  one `signatures[]` entry validates against the supplied `--pubkey` (and fails if
+  an entry targeting that key fails). Richer multi-signer / threshold policies are
+  out of scope for v0.1.
+- **I-JSON numeric range.** Canonicalization assumes IEEE-754-double-safe numbers
+  (per RFC 8785 / I-JSON). Integers at or beyond 1e21 are not expected in ODR
+  payloads and are not specially handled.
 
 ## Library
 

--- a/aragora-verify/README.md
+++ b/aragora-verify/README.md
@@ -1,0 +1,81 @@
+# aragora-verify
+
+**Verify an [Open Decision Receipt](https://github.com/synaptent/aragora/blob/main/docs/specs/OPEN_DECISION_RECEIPT.md) offline — no Aragora install, no server, no account.**
+
+Action-level receipts (Microsoft AGT, SCITT, in-toto/SLSA) prove *what happened
+and whether policy allowed it*. An **Open Decision Receipt (ODR)** proves the
+layer above: *why it was decided, who adversarially examined it with what model
+diversity, who dissented, how calibrated the confidence was, and whether an
+accountable human accepted the risk.*
+
+`aragora-verify` is the free, standalone tool that lets anyone — an auditor, a
+customer, a skeptic — check such a receipt is genuine and well-formed:
+
+- **Schema conformance** to the ODR v0.1 content profile.
+- **Canonical digest** — recomputes `SHA-256(JCS(receipt − signatures))` per
+  RFC 8785, the value any detached signature covers.
+- **Ed25519 signature** — verifies detached signatures with only the public key.
+- **Quorum consistency** — every supporting/dissenting agent is a disclosed
+  participant (a mismatch is a tamper/malformed signal).
+- **Hash-chain linkage** — when a chain is supplied, the receipt is anchored in
+  it and the links are continuous.
+
+It depends only on the Python standard library plus `cryptography`.
+
+## Install
+
+```bash
+pip install aragora-verify
+```
+
+## Use
+
+```bash
+# Structural + canonical-digest check
+aragora-verify receipt.odr.json
+
+# Full authenticity check against the issuer's published public key
+aragora-verify receipt.odr.json --pubkey aragora-odr-signing-key.pem
+
+# Also confirm the receipt is anchored in a hash chain
+aragora-verify receipt.odr.json --pubkey key.pem --chain intent-chain.jsonl
+
+# Machine-readable result
+aragora-verify receipt.odr.json --pubkey key.pem --json
+```
+
+Exit code `0` means verified (no failed checks); `1` means a check failed;
+`2` is a usage/input error.
+
+The public key for receipts emitted by an Aragora deployment is published at
+`GET /.well-known/aragora-odr-signing-key` and `GET /api/v2/receipts/signing-key`.
+
+### Weakening vs. failing
+
+Absent markers (`{"status": "absent", ...}`) and `"undisclosed"` model families
+are **honesty signals** — a receipt full of them is visibly weak, not a
+strong-looking fabrication. They are reported as *weakening signals* and do
+**not** fail verification; the policy thresholds (e.g. "require ≥2 model
+families", "require human attestation") are yours to apply on top.
+
+## Library
+
+```python
+from aragora_verify import verify, load_public_key
+
+result = verify(receipt_dict, public_key=load_public_key(pem_bytes))
+print(result.ok, result.odr_digest)
+for check in result.checks:
+    print(check.name, check.status, check.detail)
+```
+
+## What this is part of
+
+ODR-3 of the [Open Decision Receipt epic](https://github.com/synaptent/aragora/issues/8223).
+The verifier is free and standalone by design — the *emitter* (adversarial
+debate + signed decision receipts) is the product. See the
+[content-profile spec](https://github.com/synaptent/aragora/blob/main/docs/specs/OPEN_DECISION_RECEIPT.md).
+
+## License
+
+MIT

--- a/aragora-verify/pyproject.toml
+++ b/aragora-verify/pyproject.toml
@@ -1,0 +1,71 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "aragora-verify"
+version = "0.1.0"
+description = "Standalone offline verifier for Open Decision Receipts (ODR) -- check schema, JCS canonical digest, Ed25519 signature, and hash-chain linkage with no Aragora install or account."
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.10"
+authors = [
+    { name = "Aragora", email = "team@aragora.dev" },
+]
+keywords = [
+    "decision-receipt",
+    "open-decision-receipt",
+    "odr",
+    "offline-verification",
+    "ed25519",
+    "jcs",
+    "rfc8785",
+    "audit-trail",
+    "ai-governance",
+    "eu-ai-act",
+    "decision-integrity",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Legal Industry",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Security :: Cryptography",
+    "Topic :: Software Development :: Quality Assurance",
+    "Typing :: Typed",
+]
+dependencies = [
+    "cryptography>=41.0",
+]
+
+[project.optional-dependencies]
+schema = ["jsonschema>=4.0"]
+dev = ["pytest>=8.0"]
+
+[project.scripts]
+aragora-verify = "aragora_verify.cli:main"
+
+[project.urls]
+Homepage = "https://github.com/synaptent/aragora"
+Documentation = "https://github.com/synaptent/aragora/blob/main/docs/specs/OPEN_DECISION_RECEIPT.md"
+Repository = "https://github.com/synaptent/aragora/tree/main/aragora-verify"
+Changelog = "https://github.com/synaptent/aragora/blob/main/aragora-verify/CHANGELOG.md"
+"Bug Tracker" = "https://github.com/synaptent/aragora/issues"
+
+[tool.hatch.build.targets.sdist]
+exclude = ["CLAUDE.md", "**/CLAUDE.md", ".nomic/", ".benchmarks/"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/aragora_verify"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"src/aragora_verify/odr_schema.json" = "aragora_verify/odr_schema.json"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/aragora-verify/src/aragora_verify/__init__.py
+++ b/aragora-verify/src/aragora_verify/__init__.py
@@ -1,0 +1,43 @@
+"""aragora-verify — standalone offline verifier for Open Decision Receipts.
+
+Validate an ODR v0.1 receipt with nothing but the receipt JSON (and optionally
+a public key and a hash chain): schema conformance, RFC 8785 (JCS) canonical
+digest, Ed25519 detached signature, quorum consistency, and hash-chain linkage.
+
+No Aragora install, no server, no account. The emitter is the product; the
+verifier is free.
+
+    from aragora_verify import verify, load_public_key
+    result = verify(receipt_dict, public_key=load_public_key(pem_bytes))
+    assert result.ok
+"""
+
+from __future__ import annotations
+
+from .jcs import jcs_canonicalize, odr_content_digest
+from .schema import ODR_PROFILE_URI, ODR_VERSION, validate_structure
+from .verifier import (
+    Check,
+    VerificationError,
+    VerifyResult,
+    compute_key_id,
+    load_public_key,
+    verify,
+)
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "__version__",
+    "verify",
+    "load_public_key",
+    "compute_key_id",
+    "validate_structure",
+    "jcs_canonicalize",
+    "odr_content_digest",
+    "Check",
+    "VerifyResult",
+    "VerificationError",
+    "ODR_VERSION",
+    "ODR_PROFILE_URI",
+]

--- a/aragora-verify/src/aragora_verify/__main__.py
+++ b/aragora-verify/src/aragora_verify/__main__.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from .cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/aragora-verify/src/aragora_verify/cli.py
+++ b/aragora-verify/src/aragora_verify/cli.py
@@ -1,0 +1,88 @@
+"""``aragora-verify`` command-line interface.
+
+    aragora-verify receipt.json [--pubkey key.pem] [--chain chain.jsonl] [--json]
+
+Exit status: ``0`` when the receipt verifies (no failed checks), ``1`` when any
+check fails, ``2`` for usage/input errors. With ``--json`` the structured
+:class:`~aragora_verify.verifier.VerifyResult` is printed instead of the report.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Sequence
+
+from . import __version__
+from .verifier import VerificationError, VerifyResult, verify_path
+
+_GLYPH = {"pass": "PASS", "fail": "FAIL", "warn": "WARN", "skip": "----"}
+
+
+def _render(result: VerifyResult) -> str:
+    lines: list[str] = []
+    verdict = "VERIFIED" if result.ok else "FAILED"
+    lines.append(f"Open Decision Receipt — {verdict}")
+    lines.append(f"  receipt_id: {result.receipt_id or '<missing>'}")
+    if result.odr_digest:
+        lines.append(f"  odr_digest: sha-256:{result.odr_digest}")
+    lines.append("")
+    lines.append("  checks:")
+    for check in result.checks:
+        lines.append(f"    [{_GLYPH.get(check.status, check.status)}] {check.name}: {check.detail}")
+    if result.warnings:
+        lines.append("")
+        lines.append("  weakening signals (do not fail verification):")
+        for warning in result.warnings:
+            lines.append(f"    ! {warning}")
+    lines.append("")
+    lines.append(f"  => {verdict}")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="aragora-verify",
+        description=(
+            "Offline verifier for Open Decision Receipts (ODR v0.1): schema "
+            "conformance, JCS canonical digest, Ed25519 signature, hash-chain "
+            "link, and quorum consistency. No Aragora install or account required."
+        ),
+    )
+    parser.add_argument("receipt", help="path to the ODR receipt JSON")
+    parser.add_argument(
+        "--pubkey",
+        metavar="KEY",
+        help="Ed25519 public key (PEM/DER/raw/base64/hex) to verify signatures with",
+    )
+    parser.add_argument(
+        "--chain",
+        metavar="JSONL",
+        help="hash-chain file (JSONL); checks the receipt is anchored and the chain links",
+    )
+    parser.add_argument("--json", action="store_true", help="emit the structured result as JSON")
+    parser.add_argument("--version", action="version", version=f"aragora-verify {__version__}")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        result = verify_path(args.receipt, pubkey_path=args.pubkey, chain_path=args.chain)
+    except FileNotFoundError as exc:
+        print(f"error: file not found: {exc.filename}", file=sys.stderr)
+        return 2
+    except (json.JSONDecodeError, VerificationError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
+    else:
+        print(_render(result))
+    return 0 if result.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/aragora-verify/src/aragora_verify/cli.py
+++ b/aragora-verify/src/aragora_verify/cli.py
@@ -2,8 +2,10 @@
 
     aragora-verify receipt.json [--pubkey key.pem] [--chain chain.jsonl] [--json]
 
-Exit status: ``0`` when the receipt verifies (no failed checks), ``1`` when any
-check fails, ``2`` for usage/input errors. With ``--json`` the structured
+Exit status: ``0`` when the receipt verifies (no failed checks and any present
+signatures were checked), ``1`` when any check fails, ``2`` for usage/input
+errors, ``3`` when the receipt is structurally OK but carries signatures that
+were never checked (no ``--pubkey`` supplied). With ``--json`` the structured
 :class:`~aragora_verify.verifier.VerifyResult` is printed instead of the report.
 """
 
@@ -22,11 +24,21 @@ _GLYPH = {"pass": "PASS", "fail": "FAIL", "warn": "WARN", "skip": "----"}
 
 def _render(result: VerifyResult) -> str:
     lines: list[str] = []
-    verdict = "VERIFIED" if result.ok else "FAILED"
+    if not result.ok:
+        verdict = "FAILED"
+    elif result.authenticity_unverified:
+        verdict = "UNVERIFIED"
+    else:
+        verdict = "VERIFIED"
     lines.append(f"Open Decision Receipt — {verdict}")
     lines.append(f"  receipt_id: {result.receipt_id or '<missing>'}")
     if result.odr_digest:
         lines.append(f"  odr_digest: sha-256:{result.odr_digest}")
+    if verdict == "UNVERIFIED":
+        lines.append(
+            "  note: signatures are present but were NOT checked (no --pubkey); "
+            "authenticity is NOT established"
+        )
     lines.append("")
     lines.append("  checks:")
     for check in result.checks:
@@ -81,7 +93,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
     else:
         print(_render(result))
-    return 0 if result.ok else 1
+    if not result.ok:
+        return 1
+    if result.authenticity_unverified:
+        return 3  # structurally OK but present signatures were never checked
+    return 0
 
 
 if __name__ == "__main__":

--- a/aragora-verify/src/aragora_verify/jcs.py
+++ b/aragora-verify/src/aragora_verify/jcs.py
@@ -1,0 +1,136 @@
+"""RFC 8785 (JSON Canonicalization Scheme) for Open Decision Receipts.
+
+A dependency-free port of ``aragora.gauntlet.odr_export.jcs_canonicalize`` so
+that ``aragora-verify`` can recompute an ODR receipt's content digest without
+installing Aragora. Byte-for-byte identical output to the reference emitter is
+the whole point: the digest a verifier computes here must match the digest the
+signatures cover.
+
+Canonicalization rules (RFC 8785):
+
+- UTF-8 output, no insignificant whitespace;
+- object members sorted by UTF-16 code units;
+- strings minimally escaped per JSON with lowercase ``\\u00xx`` for controls;
+- numbers serialized with the ECMAScript ``Number::toString`` shortest
+  round-trip algorithm; ``NaN``/``Infinity`` are forbidden.
+
+ODR payloads are I-JSON-safe (no numbers needing more than IEEE-754 double
+precision), so any conforming JCS implementation produces identical bytes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from typing import Any
+
+__all__ = ["jcs_canonicalize", "odr_content_digest"]
+
+_ES_INT_LIMIT = 10**21  # ECMAScript switches to exponent notation at 1e21.
+
+
+def _es_number_to_string(value: float) -> str:
+    """Serialize a float per ECMAScript ``Number::toString`` (RFC 8785 3.2.2.3)."""
+    if math.isnan(value) or math.isinf(value):
+        raise ValueError("NaN and Infinity cannot be canonicalized per RFC 8785")
+    if value == 0:
+        # Covers -0.0 as well: JCS serializes negative zero as "0".
+        return "0"
+
+    sign = "-" if value < 0 else ""
+    # Python's repr() yields the shortest digit string that round-trips the
+    # IEEE-754 double, the same digit selection ECMAScript uses. Only the
+    # *formatting* rules differ; they are applied below.
+    text = repr(abs(value))
+    if "e" in text or "E" in text:
+        mantissa, _, exp_text = text.lower().partition("e")
+        exponent = int(exp_text)
+    else:
+        mantissa, exponent = text, 0
+
+    if "." in mantissa:
+        int_part, frac_part = mantissa.split(".", 1)
+    else:
+        int_part, frac_part = mantissa, ""
+
+    digits = int_part + frac_part
+    point = len(int_part) + exponent
+
+    stripped = digits.lstrip("0")
+    point -= len(digits) - len(stripped)
+    digits = stripped.rstrip("0")
+
+    k = len(digits)
+    n = point
+    if k <= n <= 21:
+        out = digits + "0" * (n - k)
+    elif 0 < n <= 21:
+        out = digits[:n] + "." + digits[n:]
+    elif -6 < n <= 0:
+        out = "0." + "0" * (-n) + digits
+    else:
+        e = n - 1
+        head = digits[0] + ("." + digits[1:] if k > 1 else "")
+        out = f"{head}e{'+' if e >= 0 else '-'}{abs(e)}"
+    return sign + out
+
+
+def _jcs_serialize(value: Any, out: list[str]) -> None:
+    """Append the JCS serialization of ``value`` to ``out``."""
+    if value is None:
+        out.append("null")
+    elif value is True:
+        out.append("true")
+    elif value is False:
+        out.append("false")
+    elif isinstance(value, str):
+        out.append(json.dumps(value, ensure_ascii=False))
+    elif isinstance(value, int):
+        if abs(value) < _ES_INT_LIMIT:
+            out.append(str(value))
+        else:
+            out.append(_es_number_to_string(float(value)))
+    elif isinstance(value, float):
+        out.append(_es_number_to_string(value))
+    elif isinstance(value, (list, tuple)):
+        out.append("[")
+        for i, item in enumerate(value):
+            if i:
+                out.append(",")
+            _jcs_serialize(item, out)
+        out.append("]")
+    elif isinstance(value, dict):
+        out.append("{")
+        # RFC 8785 sorts member names by UTF-16 code units; comparing the
+        # UTF-16BE encodings byte-wise is equivalent.
+        keys = sorted(value.keys(), key=lambda k: str(k).encode("utf-16-be"))
+        for i, key in enumerate(keys):
+            if i:
+                out.append(",")
+            if not isinstance(key, str):
+                raise TypeError(f"JCS object member names must be strings, got {type(key)!r}")
+            out.append(json.dumps(key, ensure_ascii=False))
+            out.append(":")
+            _jcs_serialize(value[key], out)
+        out.append("}")
+    else:
+        raise TypeError(f"Type {type(value)!r} is not JCS-serializable")
+
+
+def jcs_canonicalize(value: Any) -> bytes:
+    """Canonicalize ``value`` to RFC 8785 (JCS) UTF-8 bytes."""
+    out: list[str] = []
+    _jcs_serialize(value, out)
+    return "".join(out).encode("utf-8")
+
+
+def odr_content_digest(odr: dict[str, Any]) -> str:
+    """SHA-256 hex digest over the JCS bytes of the ODR payload.
+
+    The ``signatures`` array is excluded so that attaching detached signatures
+    never changes the digest they cover. This mirrors
+    ``aragora.gauntlet.odr_export.odr_content_digest`` exactly.
+    """
+    payload = {k: v for k, v in odr.items() if k != "signatures"}
+    return hashlib.sha256(jcs_canonicalize(payload)).hexdigest()

--- a/aragora-verify/src/aragora_verify/odr_schema.json
+++ b/aragora-verify/src/aragora_verify/odr_schema.json
@@ -1,0 +1,305 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aragora.ai/specs/open-decision-receipt/v0.1/schema.json",
+  "title": "Open Decision Receipt (ODR) content profile v0.1",
+  "description": "Vendor-neutral decision-semantics receipt profile. Canonicalization basis: RFC 8785 (JCS). Designed to ride SCITT/COSE envelopes via detached signatures. See docs/specs/OPEN_DECISION_RECEIPT.md.",
+  "type": "object",
+  "required": [
+    "odr_version",
+    "profile",
+    "receipt_id",
+    "issued_at",
+    "subject",
+    "claim",
+    "reasoning",
+    "quorum",
+    "confidence",
+    "cruxes",
+    "attestation",
+    "routing",
+    "signatures"
+  ],
+  "properties": {
+    "odr_version": {
+      "type": "string",
+      "const": "0.1"
+    },
+    "profile": {
+      "type": "string",
+      "const": "https://aragora.ai/specs/open-decision-receipt/v0.1"
+    },
+    "receipt_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "issued_at": {
+      "type": ["string", "null"],
+      "description": "ISO-8601 timestamp from the source receipt; null when the source recorded none (never fabricated)."
+    },
+    "subject": {
+      "type": "object",
+      "required": ["identifier", "digest"],
+      "properties": {
+        "identifier": {
+          "type": "string",
+          "description": "Stable identifier of the decided subject: artifact SHA, action id, debate/gauntlet id."
+        },
+        "digest": {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": ["status", "alg", "value"],
+              "properties": {
+                "status": { "const": "present" },
+                "alg": { "type": "string" },
+                "value": { "type": "string", "minLength": 1 }
+              },
+              "additionalProperties": false
+            },
+            { "$ref": "#/$defs/absent" }
+          ]
+        },
+        "summary": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "claim": {
+      "type": "object",
+      "required": ["verdict", "statement"],
+      "properties": {
+        "verdict": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Outcome asserted about the subject (e.g. PASS / CONDITIONAL / FAIL)."
+        },
+        "statement": {
+          "oneOf": [
+            { "type": "string", "minLength": 1 },
+            { "$ref": "#/$defs/absent" }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "reasoning": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["status", "summary"],
+          "properties": {
+            "status": { "const": "present" },
+            "summary": { "type": "string", "minLength": 1 }
+          },
+          "additionalProperties": false
+        },
+        { "$ref": "#/$defs/absent" }
+      ]
+    },
+    "quorum": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "status",
+            "method",
+            "reached",
+            "supporting_agents",
+            "participants",
+            "independence",
+            "dissent"
+          ],
+          "properties": {
+            "status": { "const": "present" },
+            "method": { "type": "string" },
+            "reached": { "type": "boolean" },
+            "supporting_agents": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "participants": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["agent", "model_family", "model_id"],
+                "properties": {
+                  "agent": { "type": "string", "minLength": 1 },
+                  "model_family": {
+                    "type": "string",
+                    "description": "Provider/model family, or the literal string 'undisclosed' when the source recorded none."
+                  },
+                  "model_id": { "type": "string" }
+                },
+                "additionalProperties": false
+              }
+            },
+            "independence": {
+              "type": "object",
+              "required": ["disclosed", "distinct_model_families", "model_families"],
+              "properties": {
+                "disclosed": { "type": "boolean" },
+                "distinct_model_families": { "type": "integer", "minimum": 0 },
+                "model_families": {
+                  "type": "array",
+                  "items": { "type": "string" }
+                },
+                "note": { "type": "string" }
+              },
+              "additionalProperties": false
+            },
+            "dissent": {
+              "type": "object",
+              "required": ["present", "dissenting_agents", "views"],
+              "properties": {
+                "present": { "type": "boolean" },
+                "dissenting_agents": {
+                  "type": "array",
+                  "items": { "type": "string" }
+                },
+                "views": {
+                  "type": "array",
+                  "items": { "type": "string" }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        { "$ref": "#/$defs/absent" }
+      ]
+    },
+    "confidence": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["status", "value", "scale", "calibration"],
+          "properties": {
+            "status": { "const": "present" },
+            "value": { "type": "number", "minimum": 0, "maximum": 1 },
+            "scale": { "const": "unit_interval" },
+            "calibration": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "required": ["status", "provenance_ref"],
+                  "properties": {
+                    "status": { "const": "present" },
+                    "provenance_ref": {
+                      "type": "object",
+                      "required": ["type"],
+                      "properties": {
+                        "type": { "type": "string", "minLength": 1 },
+                        "receipt_id": { "type": "string" },
+                        "uri": { "type": "string" }
+                      },
+                      "additionalProperties": true
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                { "$ref": "#/$defs/absent" }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        { "$ref": "#/$defs/absent" }
+      ]
+    },
+    "cruxes": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["status", "items"],
+          "properties": {
+            "status": { "const": "present" },
+            "items": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "type": "object" }
+            }
+          },
+          "additionalProperties": false
+        },
+        { "$ref": "#/$defs/absent" }
+      ]
+    },
+    "attestation": {
+      "type": "object",
+      "required": ["disposition"],
+      "properties": {
+        "disposition": {
+          "type": "string",
+          "enum": ["human_attested", "autonomous"]
+        },
+        "attestor": {
+          "type": "object",
+          "properties": {
+            "id": { "type": "string" },
+            "name": { "type": "string" },
+            "role": { "type": "string" }
+          },
+          "additionalProperties": true
+        },
+        "attested_at": { "type": "string" },
+        "method": { "type": "string" }
+      },
+      "if": {
+        "properties": { "disposition": { "const": "human_attested" } }
+      },
+      "then": {
+        "required": ["disposition", "attestor"]
+      },
+      "additionalProperties": false
+    },
+    "routing": {
+      "type": "object",
+      "required": ["status"],
+      "properties": {
+        "status": { "const": "reserved" }
+      },
+      "additionalProperties": false,
+      "description": "Reserved block for downstream channel routing metadata. Emitters MUST set status=reserved in v0.1."
+    },
+    "signatures": {
+      "type": "array",
+      "description": "Reserved for detached signatures (Ed25519, issue #8225). Empty in v0.1; signatures cover the SHA-256 of the JCS bytes of the payload with this array removed.",
+      "items": {
+        "type": "object",
+        "required": ["alg", "key_id", "signature"],
+        "properties": {
+          "alg": { "type": "string", "enum": ["Ed25519"] },
+          "key_id": { "type": "string", "minLength": 1 },
+          "signature": { "type": "string", "minLength": 1 },
+          "signed_at": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "source": {
+      "type": "object",
+      "required": ["system", "schema", "receipt_id"],
+      "properties": {
+        "system": { "type": "string" },
+        "schema": { "type": "string" },
+        "schema_version": { "type": "string" },
+        "receipt_id": { "type": "string" },
+        "artifact_hash": { "type": "string" }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "absent": {
+      "type": "object",
+      "required": ["status", "reason"],
+      "properties": {
+        "status": { "const": "absent" },
+        "reason": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false,
+      "description": "Explicit absent marker: the emitter's source data could not supply this field. Emitters MUST NOT fabricate values to avoid this marker."
+    }
+  }
+}

--- a/aragora-verify/src/aragora_verify/schema.py
+++ b/aragora-verify/src/aragora_verify/schema.py
@@ -1,0 +1,198 @@
+"""Structural conformance checks for the ODR v0.1 content profile.
+
+The profile is a *fixed* shape (spec §2-§4), so this module validates it
+directly with the standard library — no JSON Schema engine required, honoring
+the "stdlib + one crypto dep" constraint of issue #8226. When the optional
+``jsonschema`` package happens to be importable, :func:`validate_structure`
+*additionally* runs the bundled draft-2020-12 schema for belt-and-suspenders
+rigor; its findings are merged with the structural ones.
+
+Every check returns human-readable error strings (empty list == conformant)
+rather than raising, so the CLI can print all problems at once.
+"""
+
+from __future__ import annotations
+
+import json
+from importlib import resources
+from typing import Any
+
+__all__ = ["load_bundled_schema", "validate_structure", "ODR_PROFILE_URI", "ODR_VERSION"]
+
+ODR_VERSION = "0.1"
+ODR_PROFILE_URI = "https://aragora.ai/specs/open-decision-receipt/v0.1"
+
+_REQUIRED_MEMBERS = (
+    "odr_version",
+    "profile",
+    "receipt_id",
+    "issued_at",
+    "subject",
+    "claim",
+    "reasoning",
+    "quorum",
+    "confidence",
+    "cruxes",
+    "attestation",
+    "routing",
+    "signatures",
+)
+
+
+def load_bundled_schema() -> dict[str, Any]:
+    """Return the bundled ODR v0.1 JSON Schema (draft 2020-12)."""
+    text = resources.files("aragora_verify").joinpath("odr_schema.json").read_text("utf-8")
+    return json.loads(text)
+
+
+def _is_absent_marker(value: Any) -> bool:
+    return (
+        isinstance(value, dict)
+        and value.get("status") == "absent"
+        and isinstance(value.get("reason"), str)
+        and bool(value.get("reason"))
+    )
+
+
+def _check_block(errors: list[str], doc: dict[str, Any], name: str) -> None:
+    value = doc.get(name)
+    if not isinstance(value, dict):
+        errors.append(f"{name}: must be an object")
+
+
+def _check_reasoning(errors: list[str], value: Any) -> None:
+    if _is_absent_marker(value):
+        return
+    if not isinstance(value, dict) or value.get("status") != "present":
+        errors.append("reasoning: must be a present block or an absent marker")
+        return
+    if not isinstance(value.get("summary"), str) or not value.get("summary"):
+        errors.append("reasoning.summary: required non-empty string when present")
+
+
+def _check_quorum(errors: list[str], value: Any) -> None:
+    if _is_absent_marker(value):
+        return
+    if not isinstance(value, dict) or value.get("status") != "present":
+        errors.append("quorum: must be a present block or an absent marker")
+        return
+    for field in (
+        "method",
+        "reached",
+        "supporting_agents",
+        "participants",
+        "independence",
+        "dissent",
+    ):
+        if field not in value:
+            errors.append(f"quorum.{field}: required when present")
+    participants = value.get("participants")
+    if isinstance(participants, list):
+        for i, p in enumerate(participants):
+            if not isinstance(p, dict) or "agent" not in p or "model_family" not in p:
+                errors.append(f"quorum.participants[{i}]: requires agent and model_family")
+
+
+def _check_confidence(errors: list[str], value: Any) -> None:
+    if _is_absent_marker(value):
+        return
+    if not isinstance(value, dict) or value.get("status") != "present":
+        errors.append("confidence: must be a present block or an absent marker")
+        return
+    val = value.get("value")
+    if not isinstance(val, (int, float)) or isinstance(val, bool) or not (0 <= val <= 1):
+        errors.append("confidence.value: required number in [0, 1] when present")
+    if value.get("scale") != "unit_interval":
+        errors.append("confidence.scale: must be 'unit_interval' when present")
+
+
+def _check_attestation(errors: list[str], value: Any) -> None:
+    if not isinstance(value, dict):
+        errors.append("attestation: must be an object")
+        return
+    disposition = value.get("disposition")
+    if disposition not in ("human_attested", "autonomous"):
+        errors.append("attestation.disposition: must be 'human_attested' or 'autonomous'")
+    if disposition == "human_attested" and not isinstance(value.get("attestor"), dict):
+        errors.append("attestation.attestor: required object when disposition is human_attested")
+
+
+def _check_signatures(errors: list[str], value: Any) -> None:
+    if not isinstance(value, list):
+        errors.append("signatures: must be an array")
+        return
+    for i, sig in enumerate(value):
+        if not isinstance(sig, dict):
+            errors.append(f"signatures[{i}]: must be an object")
+            continue
+        for field in ("alg", "key_id", "signature"):
+            if not isinstance(sig.get(field), str) or not sig.get(field):
+                errors.append(f"signatures[{i}].{field}: required non-empty string")
+        if sig.get("alg") not in (None, "Ed25519") and isinstance(sig.get("alg"), str):
+            errors.append(f"signatures[{i}].alg: only 'Ed25519' is defined in v0.1")
+
+
+def validate_structure(doc: Any) -> list[str]:
+    """Return a list of conformance errors; empty means the receipt is well-formed."""
+    errors: list[str] = []
+    if not isinstance(doc, dict):
+        return ["receipt: top-level value must be a JSON object"]
+
+    for member in _REQUIRED_MEMBERS:
+        if member not in doc:
+            errors.append(f"missing required member: {member}")
+
+    if doc.get("odr_version") != ODR_VERSION:
+        errors.append(f"odr_version: must be '{ODR_VERSION}'")
+    if doc.get("profile") != ODR_PROFILE_URI:
+        errors.append(f"profile: must be '{ODR_PROFILE_URI}'")
+    if not isinstance(doc.get("receipt_id"), str) or not doc.get("receipt_id"):
+        errors.append("receipt_id: required non-empty string")
+    issued_at = doc.get("issued_at", "__missing__")
+    if issued_at != "__missing__" and issued_at is not None and not isinstance(issued_at, str):
+        errors.append("issued_at: must be a string or null")
+
+    _check_block(errors, doc, "subject")
+    _check_block(errors, doc, "claim")
+    if isinstance(doc.get("subject"), dict):
+        if not isinstance(doc["subject"].get("identifier"), str):
+            errors.append("subject.identifier: required string")
+        if "digest" not in doc["subject"]:
+            errors.append("subject.digest: required (present block or absent marker)")
+    if isinstance(doc.get("claim"), dict):
+        if not isinstance(doc["claim"].get("verdict"), str) or not doc["claim"].get("verdict"):
+            errors.append("claim.verdict: required non-empty string")
+
+    _check_reasoning(errors, doc.get("reasoning"))
+    _check_quorum(errors, doc.get("quorum"))
+    _check_confidence(errors, doc.get("confidence"))
+    if "cruxes" in doc and not _is_absent_marker(doc["cruxes"]):
+        cruxes = doc["cruxes"]
+        if not isinstance(cruxes, dict) or cruxes.get("status") != "present":
+            errors.append("cruxes: must be a present block or an absent marker")
+    _check_attestation(errors, doc.get("attestation"))
+    routing = doc.get("routing")
+    if not isinstance(routing, dict) or routing.get("status") != "reserved":
+        errors.append("routing.status: must be 'reserved' in v0.1")
+    _check_signatures(errors, doc.get("signatures"))
+
+    errors.extend(_jsonschema_errors(doc))
+    return errors
+
+
+def _jsonschema_errors(doc: Any) -> list[str]:
+    """Optional full draft-2020-12 validation when ``jsonschema`` is installed."""
+    try:
+        import jsonschema  # type: ignore
+    except ImportError:
+        return []
+    try:
+        validator_cls = jsonschema.Draft202012Validator  # type: ignore[attr-defined]
+    except AttributeError:  # pragma: no cover - very old jsonschema
+        return []
+    validator = validator_cls(load_bundled_schema())
+    out: list[str] = []
+    for err in sorted(validator.iter_errors(doc), key=lambda e: list(e.path)):
+        location = "/".join(str(p) for p in err.path) or "<root>"
+        out.append(f"schema[{location}]: {err.message}")
+    return out

--- a/aragora-verify/src/aragora_verify/schema.py
+++ b/aragora-verify/src/aragora_verify/schema.py
@@ -159,6 +159,17 @@ def validate_structure(doc: Any) -> list[str]:
             errors.append("subject.identifier: required string")
         if "digest" not in doc["subject"]:
             errors.append("subject.digest: required (present block or absent marker)")
+        else:
+            digest = doc["subject"]["digest"]
+            present_ok = (
+                isinstance(digest, dict)
+                and digest.get("status") == "present"
+                and isinstance(digest.get("value"), str)
+            )
+            if not _is_absent_marker(digest) and not present_ok:
+                # Reproducible without the optional jsonschema extra: a plain
+                # string / malformed digest is non-conformant (review [P2]).
+                errors.append("subject.digest: must be a present block or an absent marker")
     if isinstance(doc.get("claim"), dict):
         if not isinstance(doc["claim"].get("verdict"), str) or not doc["claim"].get("verdict"):
             errors.append("claim.verdict: required non-empty string")

--- a/aragora-verify/src/aragora_verify/verifier.py
+++ b/aragora-verify/src/aragora_verify/verifier.py
@@ -304,12 +304,19 @@ def _check_chain(doc: dict[str, Any], digest_hex: str, chain: list[dict[str, Any
     # NOTE: linkage only checks declared prev_hash == declared previous hash; it
     # asserts self-consistency of the supplied chain, not that each entry's hash
     # was recomputed from its content. Independent re-hashing is out of scope here.
-    link_note = (
-        "declared prev/hash links self-consistent (hashes not recomputed)"
-        if saw_links
-        else "no prev-hash links present"
-    )
-    return Check("chain_link", PASS, f"receipt anchored in chain; {link_note}")
+    if saw_links:
+        # Anchoring is real (the content digest IS in the chain), but we only
+        # checked declared prev/hash self-consistency -- no entry hash was
+        # recomputed, so this is NOT a tamper-proof integrity guarantee. Report
+        # WARN, not PASS, so the human verdict never overstates the assurance
+        # (review): an attacker who controls the chain file can fake linkage.
+        return Check(
+            "chain_link",
+            WARN,
+            "receipt anchored; declared prev/hash links are self-consistent but NOT "
+            "recomputed -- this is not an integrity proof of the chain itself",
+        )
+    return Check("chain_link", PASS, "receipt anchored in chain (no prev-hash links to verify)")
 
 
 def _weakening_warnings(doc: dict[str, Any]) -> list[str]:

--- a/aragora-verify/src/aragora_verify/verifier.py
+++ b/aragora-verify/src/aragora_verify/verifier.py
@@ -73,11 +73,20 @@ class VerifyResult:
     def to_dict(self) -> dict[str, Any]:
         return {
             "ok": self.ok,
+            "authenticity_unverified": self.authenticity_unverified,
             "receipt_id": self.receipt_id,
             "odr_digest": self.odr_digest,
             "checks": [asdict(c) for c in self.checks],
             "warnings": list(self.warnings),
         }
+
+    @property
+    def authenticity_unverified(self) -> bool:
+        """True iff the receipt carries signatures that were NOT checked (no public
+        key supplied) -- i.e. the ``signature`` check is SKIP. Such a receipt is
+        structurally OK but NOT authenticated, so callers must not treat it as
+        "verified" even though no check hard-failed (PR #8388 review [P2a])."""
+        return any(c.name == "signature" and c.status == SKIP for c in self.checks)
 
 
 # ---------------------------------------------------------------------------
@@ -260,12 +269,14 @@ def _check_chain(doc: dict[str, Any], digest_hex: str, chain: list[dict[str, Any
                 broken.append(f"entry[{i}].prev != entry[{i - 1}].hash")
         last_hash = cur if cur is not None else last_hash
 
-    # Anchoring: the receipt is recorded somewhere in the chain.
-    receipt_id = str(doc.get("receipt_id") or "")
+    # Anchoring: the receipt's CONTENT DIGEST must appear in the chain. We do NOT
+    # accept the mutable, non-cryptographic ``receipt_id`` as an anchor (PR #8388
+    # review [P2b]): a tampered body could reuse a legitimate receipt_id and forge
+    # a false "anchored" assurance. Only the JCS content digest binds.
     anchored = False
     for entry in chain:
         values = {str(v) for v in entry.values() if isinstance(v, (str, int))}
-        if digest_hex in values or (receipt_id and receipt_id in values):
+        if digest_hex in values:
             anchored = True
             break
 
@@ -275,9 +286,16 @@ def _check_chain(doc: dict[str, Any], digest_hex: str, chain: list[dict[str, Any
         return Check(
             "chain_link",
             FAIL,
-            "receipt digest/receipt_id not found among chain entries (not anchored)",
+            "receipt content digest not found among chain entries (not anchored)",
         )
-    link_note = "linkage continuous" if saw_links else "no prev-hash links present"
+    # NOTE: linkage only checks declared prev_hash == declared previous hash; it
+    # asserts self-consistency of the supplied chain, not that each entry's hash
+    # was recomputed from its content. Independent re-hashing is out of scope here.
+    link_note = (
+        "declared prev/hash links self-consistent (hashes not recomputed)"
+        if saw_links
+        else "no prev-hash links present"
+    )
     return Check("chain_link", PASS, f"receipt anchored in chain; {link_note}")
 
 

--- a/aragora-verify/src/aragora_verify/verifier.py
+++ b/aragora-verify/src/aragora_verify/verifier.py
@@ -1,0 +1,381 @@
+"""Offline verification of an Open Decision Receipt (ODR v0.1).
+
+The single library behind both the ``aragora-verify`` CLI and the server's
+``POST /api/receipts/verify`` endpoint. It establishes, with nothing but the
+receipt JSON (and optionally a public key and a hash chain):
+
+1. **Structural conformance** to the ODR v0.1 profile (``schema``).
+2. **Canonical digest** — recomputes ``odr_digest = SHA-256(JCS(doc - signatures))``
+   deterministically (``jcs``), the value any detached signature covers.
+3. **Ed25519 signatures** — verifies each ``signatures[]`` entry against a
+   supplied public key, per the construction in ``OPEN_DECISION_RECEIPT.md``
+   §6 / issue #8225: the signed message is the SHA-256 digest above.
+4. **Quorum consistency** — every supporting/dissenting agent appears among
+   ``quorum.participants`` (spec §8: a mismatch is a malformed/tamper signal).
+5. **Hash-chain linkage** — when a chain is supplied, the receipt is anchored
+   in it and the chain's links are continuous.
+
+Absent markers and ``"undisclosed"`` *weaken* a receipt (warnings) rather than
+failing it — verification reports the evidence; policy thresholds are the
+caller's choice (spec §8).
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from .jcs import odr_content_digest
+from .schema import validate_structure
+
+__all__ = [
+    "Check",
+    "VerifyResult",
+    "verify",
+    "compute_key_id",
+    "load_public_key",
+    "VerificationError",
+]
+
+PASS = "pass"
+FAIL = "fail"
+WARN = "warn"
+SKIP = "skip"
+
+
+class VerificationError(Exception):
+    """Raised for unrecoverable input problems (e.g. unreadable public key)."""
+
+
+@dataclass(frozen=True)
+class Check:
+    """One named verification step and its outcome."""
+
+    name: str
+    status: str  # pass | fail | warn | skip
+    detail: str
+
+
+@dataclass
+class VerifyResult:
+    """Structured verdict. ``ok`` is the single PASS/FAIL the CLI exits on."""
+
+    ok: bool
+    receipt_id: str
+    odr_digest: str
+    checks: list[Check] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "receipt_id": self.receipt_id,
+            "odr_digest": self.odr_digest,
+            "checks": [asdict(c) for c in self.checks],
+            "warnings": list(self.warnings),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Public-key handling (the one crypto dependency)
+# ---------------------------------------------------------------------------
+
+
+def _load_ed25519():  # noqa: ANN202 - lazy import keeps import errors actionable
+    try:
+        from cryptography.exceptions import InvalidSignature
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+    except ImportError as exc:  # pragma: no cover - dependency declared in pyproject
+        raise VerificationError(
+            "the 'cryptography' package is required for signature verification; "
+            "install with `pip install aragora-verify`"
+        ) from exc
+    return Ed25519PublicKey, serialization, InvalidSignature
+
+
+def load_public_key(data: bytes):  # noqa: ANN201
+    """Load an Ed25519 public key from PEM, DER, raw 32 bytes, or base64/hex text."""
+    Ed25519PublicKey, serialization, _ = _load_ed25519()
+    text = data.strip()
+    # PEM / DER
+    if b"-----BEGIN" in text:
+        return serialization.load_pem_public_key(text)
+    # Raw 32-byte key
+    if len(text) == 32:
+        return Ed25519PublicKey.from_public_bytes(text)
+    # base64 or hex encoding of the raw 32-byte key
+    as_str = text.decode("ascii", errors="ignore").strip()
+    for decoder in (_maybe_b64, _maybe_hex):
+        raw = decoder(as_str)
+        if raw is not None and len(raw) == 32:
+            return Ed25519PublicKey.from_public_bytes(raw)
+    try:
+        return serialization.load_der_public_key(data)
+    except Exception as exc:  # noqa: BLE001
+        raise VerificationError(
+            "could not parse public key (expected PEM/DER/raw/base64/hex)"
+        ) from exc
+
+
+def compute_key_id(public_key) -> str:  # noqa: ANN001
+    """``ed25519-`` + first 16 hex of SHA-256(raw public key) — the #8225 key id."""
+    _, serialization, _ = _load_ed25519()
+    raw = public_key.public_bytes(serialization.Encoding.Raw, serialization.PublicFormat.Raw)
+    return "ed25519-" + hashlib.sha256(raw).hexdigest()[:16]
+
+
+def _maybe_b64(text: str) -> bytes | None:
+    try:
+        return base64.b64decode(text, validate=True)
+    except (binascii.Error, ValueError):
+        return None
+
+
+def _maybe_hex(text: str) -> bytes | None:
+    try:
+        return bytes.fromhex(text)
+    except ValueError:
+        return None
+
+
+def _decode_signature(value: str) -> bytes | None:
+    """Signatures are base64 (preferred) or hex of the raw 64-byte Ed25519 sig."""
+    raw = _maybe_b64(value)
+    if raw is not None and len(raw) == 64:
+        return raw
+    raw = _maybe_hex(value)
+    if raw is not None and len(raw) == 64:
+        return raw
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Individual checks
+# ---------------------------------------------------------------------------
+
+
+def _check_signatures(doc: dict[str, Any], digest_hex: str, public_key) -> Check:  # noqa: ANN001
+    signatures = doc.get("signatures")
+    signatures = signatures if isinstance(signatures, list) else []
+    if not signatures and public_key is None:
+        return Check("signature", WARN, "receipt is unsigned (v0.1); authenticity not established")
+    if not signatures and public_key is not None:
+        return Check(
+            "signature", WARN, "receipt carries no signatures; nothing to verify with the key"
+        )
+    if signatures and public_key is None:
+        return Check(
+            "signature",
+            SKIP,
+            f"{len(signatures)} signature(s) present but no --pubkey supplied; authenticity NOT verified",
+        )
+
+    _, _, InvalidSignature = _load_ed25519()
+    message = bytes.fromhex(digest_hex)
+    provided_key_id = compute_key_id(public_key)
+    verified_any = False
+    failed_matching = False
+    notes: list[str] = []
+    for i, sig in enumerate(signatures):
+        if not isinstance(sig, dict):
+            continue
+        key_id = str(sig.get("key_id") or "")
+        raw_sig = _decode_signature(str(sig.get("signature") or ""))
+        if raw_sig is None:
+            notes.append(f"sig[{i}]: undecodable signature")
+            if key_id == provided_key_id:
+                failed_matching = True
+            continue
+        try:
+            public_key.verify(raw_sig, message)
+            verified_any = True
+            notes.append(f"sig[{i}] (key_id={key_id or '?'}): verified")
+        except InvalidSignature:
+            notes.append(f"sig[{i}] (key_id={key_id or '?'}): INVALID")
+            if key_id == provided_key_id:
+                failed_matching = True
+
+    detail = "; ".join(notes) or "no signatures evaluated"
+    if failed_matching:
+        return Check(
+            "signature", FAIL, f"signature from the supplied key did not verify — {detail}"
+        )
+    if verified_any:
+        return Check("signature", PASS, f"Ed25519 signature verified — {detail}")
+    return Check("signature", FAIL, f"no signature verified with the supplied key — {detail}")
+
+
+def _check_quorum_consistency(doc: dict[str, Any]) -> Check:
+    quorum = doc.get("quorum")
+    if not isinstance(quorum, dict) or quorum.get("status") != "present":
+        return Check("quorum_consistency", SKIP, "no present quorum block to cross-check")
+    participants = {
+        str(p.get("agent"))
+        for p in quorum.get("participants", [])
+        if isinstance(p, dict) and p.get("agent")
+    }
+    referenced: set[str] = set()
+    referenced.update(str(a) for a in quorum.get("supporting_agents", []) if isinstance(a, str))
+    dissent = quorum.get("dissent")
+    if isinstance(dissent, dict):
+        referenced.update(
+            str(a) for a in dissent.get("dissenting_agents", []) if isinstance(a, str)
+        )
+    missing = sorted(referenced - participants)
+    if missing:
+        return Check(
+            "quorum_consistency",
+            FAIL,
+            "agents referenced but not in participants (malformed/tamper signal per spec §8): "
+            + ", ".join(missing),
+        )
+    return Check(
+        "quorum_consistency", PASS, "supporting/dissenting agents all appear in participants"
+    )
+
+
+def _check_chain(doc: dict[str, Any], digest_hex: str, chain: list[dict[str, Any]] | None) -> Check:
+    if chain is None:
+        return Check("chain_link", SKIP, "no --chain supplied")
+    if not chain:
+        return Check("chain_link", FAIL, "chain file is empty")
+
+    # Linkage continuity, when entries carry hash/prev links.
+    prev_keys = ("prev_hash", "previous_hash", "parent_hash")
+    hash_keys = ("hash", "entry_hash", "leaf_hash")
+    broken: list[str] = []
+    last_hash: str | None = None
+    saw_links = False
+    for i, entry in enumerate(chain):
+        cur = next((str(entry[k]) for k in hash_keys if entry.get(k)), None)
+        prev = next((str(entry[k]) for k in prev_keys if entry.get(k)), None)
+        if prev is not None:
+            saw_links = True
+            if i > 0 and last_hash is not None and prev != last_hash:
+                broken.append(f"entry[{i}].prev != entry[{i - 1}].hash")
+        last_hash = cur if cur is not None else last_hash
+
+    # Anchoring: the receipt is recorded somewhere in the chain.
+    receipt_id = str(doc.get("receipt_id") or "")
+    anchored = False
+    for entry in chain:
+        values = {str(v) for v in entry.values() if isinstance(v, (str, int))}
+        if digest_hex in values or (receipt_id and receipt_id in values):
+            anchored = True
+            break
+
+    if broken:
+        return Check("chain_link", FAIL, "broken hash-chain linkage: " + "; ".join(broken))
+    if not anchored:
+        return Check(
+            "chain_link",
+            FAIL,
+            "receipt digest/receipt_id not found among chain entries (not anchored)",
+        )
+    link_note = "linkage continuous" if saw_links else "no prev-hash links present"
+    return Check("chain_link", PASS, f"receipt anchored in chain; {link_note}")
+
+
+def _weakening_warnings(doc: dict[str, Any]) -> list[str]:
+    warnings: list[str] = []
+    attestation = doc.get("attestation")
+    if isinstance(attestation, dict) and attestation.get("disposition") == "autonomous":
+        warnings.append("attestation: autonomous — no human accepted the risk for this decision")
+
+    quorum = doc.get("quorum")
+    if isinstance(quorum, dict) and quorum.get("status") == "absent":
+        warnings.append("quorum: absent — no adversarial review recorded")
+    elif isinstance(quorum, dict) and quorum.get("status") == "present":
+        independence = quorum.get("independence", {})
+        if isinstance(independence, dict):
+            if not independence.get("disclosed", False):
+                warnings.append("quorum.independence: model diversity not disclosed")
+            elif int(independence.get("distinct_model_families", 0) or 0) < 2:
+                warnings.append(
+                    "quorum.independence: single model family — limited adversarial diversity"
+                )
+        participants = quorum.get("participants", [])
+        if isinstance(participants, list) and any(
+            isinstance(p, dict) and p.get("model_family") == "undisclosed" for p in participants
+        ):
+            warnings.append("quorum.participants: one or more model families undisclosed")
+
+    confidence = doc.get("confidence")
+    if isinstance(confidence, dict) and confidence.get("status") == "present":
+        calibration = confidence.get("calibration")
+        if isinstance(calibration, dict) and calibration.get("status") == "absent":
+            warnings.append("confidence: present but uncalibrated (no calibration provenance)")
+
+    reasoning = doc.get("reasoning")
+    if isinstance(reasoning, dict) and reasoning.get("status") == "absent":
+        warnings.append("reasoning: absent — no recorded justification")
+    return warnings
+
+
+# ---------------------------------------------------------------------------
+# Top-level entry point
+# ---------------------------------------------------------------------------
+
+
+def verify(
+    doc: Any,
+    *,
+    public_key: Any | None = None,
+    chain: list[dict[str, Any]] | None = None,
+) -> VerifyResult:
+    """Verify an ODR document. ``public_key`` is a loaded Ed25519 key (see
+    :func:`load_public_key`); ``chain`` is a list of parsed JSONL chain entries.
+    """
+    receipt_id = str(doc.get("receipt_id") or "") if isinstance(doc, dict) else ""
+    checks: list[Check] = []
+
+    structure_errors = validate_structure(doc)
+    if structure_errors:
+        checks.append(Check("schema_conformance", FAIL, "; ".join(structure_errors[:12])))
+        # A structurally invalid receipt cannot be digested/verified meaningfully.
+        return VerifyResult(
+            ok=False, receipt_id=receipt_id, odr_digest="", checks=checks, warnings=[]
+        )
+    checks.append(Check("schema_conformance", PASS, "conforms to ODR v0.1 profile"))
+
+    digest_hex = odr_content_digest(doc)
+    checks.append(Check("canonical_digest", PASS, f"sha-256:{digest_hex}"))
+
+    checks.append(_check_signatures(doc, digest_hex, public_key))
+    checks.append(_check_quorum_consistency(doc))
+    checks.append(_check_chain(doc, digest_hex, chain))
+
+    warnings = _weakening_warnings(doc)
+    ok = not any(c.status == FAIL for c in checks)
+    return VerifyResult(
+        ok=ok, receipt_id=receipt_id, odr_digest=digest_hex, checks=checks, warnings=warnings
+    )
+
+
+def verify_path(
+    receipt_path: str,
+    *,
+    pubkey_path: str | None = None,
+    chain_path: str | None = None,
+) -> VerifyResult:
+    """Convenience wrapper that reads files from disk and calls :func:`verify`."""
+    with open(receipt_path, "rb") as fh:
+        doc = json.loads(fh.read())
+    public_key = None
+    if pubkey_path:
+        with open(pubkey_path, "rb") as fh:
+            public_key = load_public_key(fh.read())
+    chain: list[dict[str, Any]] | None = None
+    if chain_path:
+        chain = []
+        with open(chain_path, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if line:
+                    chain.append(json.loads(line))
+    return verify(doc, public_key=public_key, chain=chain)

--- a/aragora-verify/src/aragora_verify/verifier.py
+++ b/aragora-verify/src/aragora_verify/verifier.py
@@ -110,25 +110,38 @@ def _load_ed25519():  # noqa: ANN202 - lazy import keeps import errors actionabl
 def load_public_key(data: bytes):  # noqa: ANN201
     """Load an Ed25519 public key from PEM, DER, raw 32 bytes, or base64/hex text."""
     Ed25519PublicKey, serialization, _ = _load_ed25519()
-    text = data.strip()
-    # PEM / DER
-    if b"-----BEGIN" in text:
-        return serialization.load_pem_public_key(text)
-    # Raw 32-byte key
-    if len(text) == 32:
-        return Ed25519PublicKey.from_public_bytes(text)
-    # base64 or hex encoding of the raw 32-byte key
-    as_str = text.decode("ascii", errors="ignore").strip()
-    for decoder in (_maybe_b64, _maybe_hex):
-        raw = decoder(as_str)
-        if raw is not None and len(raw) == 32:
-            return Ed25519PublicKey.from_public_bytes(raw)
-    try:
-        return serialization.load_der_public_key(data)
-    except Exception as exc:  # noqa: BLE001
+    key = None
+    # PEM (wrap parse errors instead of leaking a traceback on hostile input).
+    if b"-----BEGIN" in data:
+        try:
+            key = serialization.load_pem_public_key(data.strip())
+        except (ValueError, TypeError) as exc:
+            raise VerificationError("could not parse PEM public key") from exc
+    # Raw 32-byte key -- use the UNSTRIPPED bytes (a raw key may legitimately begin
+    # or end with a whitespace-valued byte; stripping would corrupt it).
+    elif len(data) == 32:
+        key = Ed25519PublicKey.from_public_bytes(data)
+    else:
+        as_str = data.decode("ascii", errors="ignore").strip()
+        for decoder in (_maybe_b64, _maybe_hex):
+            raw = decoder(as_str)
+            if raw is not None and len(raw) == 32:
+                key = Ed25519PublicKey.from_public_bytes(raw)
+                break
+        if key is None:
+            try:
+                key = serialization.load_der_public_key(data)
+            except Exception as exc:  # noqa: BLE001
+                raise VerificationError(
+                    "could not parse public key (expected PEM/DER/raw/base64/hex)"
+                ) from exc
+    # A valid RSA/ECDSA key parses fine but is the wrong algorithm; reject it
+    # cleanly rather than crashing later in compute_key_id / verify (review [P2]).
+    if not isinstance(key, Ed25519PublicKey):
         raise VerificationError(
-            "could not parse public key (expected PEM/DER/raw/base64/hex)"
-        ) from exc
+            f"public key is not Ed25519 (got {type(key).__name__}); ODR signatures use Ed25519"
+        )
+    return key
 
 
 def compute_key_id(public_key) -> str:  # noqa: ANN001
@@ -361,7 +374,19 @@ def verify(
         )
     checks.append(Check("schema_conformance", PASS, "conforms to ODR v0.1 profile"))
 
-    digest_hex = odr_content_digest(doc)
+    try:
+        digest_hex = odr_content_digest(doc)
+    except (ValueError, TypeError) as exc:
+        # A crafted receipt (e.g. a non-finite number in an additionalProperties
+        # region) must FAIL cleanly, never crash the verifier (review [P2]).
+        checks.append(Check("canonical_digest", FAIL, f"cannot canonicalize receipt: {exc}"))
+        return VerifyResult(
+            ok=False,
+            receipt_id=receipt_id,
+            odr_digest="",
+            checks=checks,
+            warnings=_weakening_warnings(doc),
+        )
     checks.append(Check("canonical_digest", PASS, f"sha-256:{digest_hex}"))
 
     checks.append(_check_signatures(doc, digest_hex, public_key))

--- a/aragora-verify/tests/_fixtures.py
+++ b/aragora-verify/tests/_fixtures.py
@@ -1,0 +1,79 @@
+"""Shared fixtures: a valid ODR document and a spec-faithful Ed25519 signer."""
+
+from __future__ import annotations
+
+import base64
+import copy
+from typing import Any
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from aragora_verify import compute_key_id, odr_content_digest
+
+
+def valid_odr() -> dict[str, Any]:
+    """A schema-conformant ODR v0.1 document (unsigned)."""
+    return {
+        "odr_version": "0.1",
+        "profile": "https://aragora.ai/specs/open-decision-receipt/v0.1",
+        "receipt_id": "rcpt-0001",
+        "issued_at": "2026-06-14T00:00:00Z",
+        "subject": {
+            "identifier": "5f1b14e4b5e113dc978d60d1f6bd21b5a478c744",
+            "digest": {"status": "present", "alg": "sha-256", "value": "deadbeef"},
+            "summary": "PR #8360",
+        },
+        "claim": {"verdict": "PASS", "statement": "merge PR #8360"},
+        "reasoning": {"status": "present", "summary": "all required checks green; quorum reached"},
+        "quorum": {
+            "status": "present",
+            "method": "majority",
+            "reached": True,
+            "supporting_agents": ["claude", "grok"],
+            "participants": [
+                {"agent": "claude", "model_family": "anthropic", "model_id": "claude-opus-4-8"},
+                {"agent": "grok", "model_family": "xai", "model_id": "grok-4"},
+            ],
+            "independence": {
+                "disclosed": True,
+                "distinct_model_families": 2,
+                "model_families": ["anthropic", "xai"],
+            },
+            "dissent": {"present": False, "dissenting_agents": [], "views": []},
+        },
+        "confidence": {
+            "status": "present",
+            "value": 0.9,
+            "scale": "unit_interval",
+            "calibration": {"status": "absent", "reason": "no calibration record for these agents"},
+        },
+        "cruxes": {"status": "absent", "reason": "no crux set supplied"},
+        "attestation": {"disposition": "autonomous"},
+        "routing": {"status": "reserved"},
+        "signatures": [],
+    }
+
+
+def make_keypair() -> tuple[Ed25519PrivateKey, Any]:
+    private_key = Ed25519PrivateKey.generate()
+    return private_key, private_key.public_key()
+
+
+def sign_odr(doc: dict[str, Any], private_key: Ed25519PrivateKey) -> dict[str, Any]:
+    """Attach an Ed25519 detached signature per OPEN_DECISION_RECEIPT.md §6 / #8225.
+
+    message = SHA-256(JCS(doc without signatures)); signature = Ed25519-sign(message).
+    """
+    signed = copy.deepcopy(doc)
+    message = bytes.fromhex(odr_content_digest(signed))
+    signature = private_key.sign(message)
+    key_id = compute_key_id(private_key.public_key())
+    signed["signatures"] = [
+        {
+            "alg": "Ed25519",
+            "key_id": key_id,
+            "signature": base64.b64encode(signature).decode("ascii"),
+            "signed_at": "2026-06-14T00:00:01Z",
+        }
+    ]
+    return signed

--- a/aragora-verify/tests/test_cli.py
+++ b/aragora-verify/tests/test_cli.py
@@ -1,0 +1,81 @@
+"""CLI exit codes and rendering."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from cryptography.hazmat.primitives import serialization
+
+from aragora_verify.cli import main
+
+from _fixtures import make_keypair, sign_odr, valid_odr
+
+
+def _write(tmp_path: Path, name: str, doc) -> str:
+    path = tmp_path / name
+    path.write_text(json.dumps(doc), encoding="utf-8")
+    return str(path)
+
+
+def _write_pem(tmp_path: Path, public_key) -> str:
+    pem = public_key.public_bytes(
+        serialization.Encoding.PEM, serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    path = tmp_path / "key.pem"
+    path.write_bytes(pem)
+    return str(path)
+
+
+def test_cli_valid_receipt_exits_zero(tmp_path: Path, capsys) -> None:
+    rc = main([_write(tmp_path, "r.json", valid_odr())])
+    assert rc == 0
+    assert "VERIFIED" in capsys.readouterr().out
+
+
+def test_cli_signed_receipt_with_key_exits_zero(tmp_path: Path) -> None:
+    private_key, public_key = make_keypair()
+    signed = sign_odr(valid_odr(), private_key)
+    rc = main([_write(tmp_path, "r.json", signed), "--pubkey", _write_pem(tmp_path, public_key)])
+    assert rc == 0
+
+
+def test_cli_tampered_receipt_exits_one(tmp_path: Path, capsys) -> None:
+    private_key, public_key = make_keypair()
+    signed = sign_odr(valid_odr(), private_key)
+    signed["claim"]["verdict"] = "FAIL"
+    rc = main([_write(tmp_path, "r.json", signed), "--pubkey", _write_pem(tmp_path, public_key)])
+    assert rc == 1
+    assert "FAILED" in capsys.readouterr().out
+
+
+def test_cli_schema_failure_exits_one(tmp_path: Path) -> None:
+    doc = valid_odr()
+    del doc["subject"]
+    rc = main([_write(tmp_path, "r.json", doc)])
+    assert rc == 1
+
+
+def test_cli_missing_file_exits_two(capsys) -> None:
+    rc = main(["/no/such/receipt.json"])
+    assert rc == 2
+    assert "not found" in capsys.readouterr().err
+
+
+def test_cli_bad_json_exits_two(tmp_path: Path) -> None:
+    path = tmp_path / "bad.json"
+    path.write_text("{not json", encoding="utf-8")
+    assert main([str(path)]) == 2
+
+
+def test_cli_json_output_is_machine_readable(tmp_path: Path, capsys) -> None:
+    rc = main([_write(tmp_path, "r.json", valid_odr()), "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert len(payload["odr_digest"]) == 64
+    assert {c["name"] for c in payload["checks"]} >= {
+        "schema_conformance",
+        "canonical_digest",
+        "signature",
+    }

--- a/aragora-verify/tests/test_jcs.py
+++ b/aragora-verify/tests/test_jcs.py
@@ -1,0 +1,63 @@
+"""JCS canonicalization tests — RFC 8785 examples + digest stability."""
+
+from __future__ import annotations
+
+from aragora_verify import jcs_canonicalize, odr_content_digest
+
+from _fixtures import valid_odr
+
+
+def test_member_ordering_is_independent_of_insertion_order() -> None:
+    a = jcs_canonicalize({"b": 1, "a": 2, "c": 3})
+    b = jcs_canonicalize({"c": 3, "a": 2, "b": 1})
+    assert a == b == b'{"a":2,"b":1,"c":3}'
+
+
+def test_no_insignificant_whitespace() -> None:
+    assert jcs_canonicalize({"x": [1, 2, {"y": "z"}]}) == b'{"x":[1,2,{"y":"z"}]}'
+
+
+def test_literals_and_null() -> None:
+    assert jcs_canonicalize(True) == b"true"
+    assert jcs_canonicalize(False) == b"false"
+    assert jcs_canonicalize(None) == b"null"
+
+
+def test_rfc8785_number_serialization() -> None:
+    # Shortest round-trip per ECMAScript Number::toString.
+    assert jcs_canonicalize(0) == b"0"
+    assert jcs_canonicalize(-0.0) == b"0"
+    assert jcs_canonicalize(1.0) == b"1"
+    assert jcs_canonicalize(1.5) == b"1.5"
+    assert jcs_canonicalize(1000000000000000000000.0) == b"1e+21"
+    assert jcs_canonicalize(0.000001) == b"0.000001"
+    assert jcs_canonicalize(1e-7) == b"1e-7"
+
+
+def test_utf16_codeunit_sort_orders_supplementary_after_bmp() -> None:
+    # 'é' (U+00E9) sorts before an emoji (supplementary plane) by UTF-16 units.
+    out = jcs_canonicalize({"\U0001f600": 1, "é": 2})
+    assert out.index(b"\xc3\xa9") < out.index(b"\xf0\x9f\x98\x80")
+
+
+def test_unicode_strings_emitted_raw_utf8() -> None:
+    assert jcs_canonicalize({"k": "café"}) == '{"k":"café"}'.encode("utf-8")
+
+
+def test_control_chars_lowercase_escaped() -> None:
+    assert jcs_canonicalize("") == b'"\\u0001"'
+
+
+def test_digest_excludes_signatures() -> None:
+    doc = valid_odr()
+    digest_unsigned = odr_content_digest(doc)
+    doc_with_sig = dict(doc)
+    doc_with_sig["signatures"] = [{"alg": "Ed25519", "key_id": "x", "signature": "y"}]
+    assert odr_content_digest(doc_with_sig) == digest_unsigned
+
+
+def test_digest_is_stable_and_hex_sha256() -> None:
+    digest = odr_content_digest(valid_odr())
+    assert len(digest) == 64
+    assert all(c in "0123456789abcdef" for c in digest)
+    assert odr_content_digest(valid_odr()) == digest

--- a/aragora-verify/tests/test_review_fixes.py
+++ b/aragora-verify/tests/test_review_fixes.py
@@ -15,7 +15,7 @@ import pytest
 
 from aragora_verify import odr_content_digest, verify
 from aragora_verify.cli import main
-from aragora_verify.verifier import FAIL, PASS, VerificationError, load_public_key
+from aragora_verify.verifier import FAIL, PASS, WARN, VerificationError, load_public_key
 
 from _fixtures import make_keypair, sign_odr, valid_odr
 
@@ -136,5 +136,7 @@ def test_chain_pass_detail_documents_non_integrity_limitation():
     chain = [{"hash": odr_content_digest(doc), "prev_hash": "x" * 64}]
     result = verify(doc, chain=chain)
     chain_check = next(c for c in result.checks if c.name == "chain_link")
-    assert chain_check.status == PASS
+    # Declared links present but not recomputed -> WARN (not a green PASS), so the
+    # human verdict never overstates chain assurance.
+    assert chain_check.status == WARN
     assert "not recomputed" in chain_check.detail.lower()

--- a/aragora-verify/tests/test_review_fixes.py
+++ b/aragora-verify/tests/test_review_fixes.py
@@ -9,10 +9,13 @@
 from __future__ import annotations
 
 import json
+import math
+
+import pytest
 
 from aragora_verify import odr_content_digest, verify
 from aragora_verify.cli import main
-from aragora_verify.verifier import FAIL, PASS, load_public_key
+from aragora_verify.verifier import FAIL, PASS, VerificationError, load_public_key
 
 from _fixtures import make_keypair, sign_odr, valid_odr
 
@@ -80,3 +83,58 @@ def test_chain_anchored_when_digest_matches():
     chain = [{"hash": digest}]
     result = verify(doc, chain=chain)
     assert _chain_check(result).status == PASS
+
+
+# --- round-2 hardening: adversarial-input robustness ----------------------
+
+
+def test_non_ed25519_pubkey_raises_clean_error():
+    # A valid-but-wrong-type (RSA) key must raise VerificationError, not crash.
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    rsa_pub = rsa.generate_private_key(public_exponent=65537, key_size=2048).public_key()
+    pem = rsa_pub.public_bytes(
+        serialization.Encoding.PEM, serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    with pytest.raises(VerificationError):
+        load_public_key(pem)
+
+
+def test_garbage_pubkey_raises_clean_error():
+    with pytest.raises(VerificationError):
+        load_public_key(b"-----BEGIN PUBLIC KEY-----\nnot a real key\n-----END PUBLIC KEY-----\n")
+
+
+def test_verify_does_not_crash_on_non_finite_number():
+    # A crafted receipt with a non-finite number must fail cleanly, never raise.
+    doc = valid_odr()
+    doc["cruxes"] = {"status": "present", "items": [{"weight": math.inf}]}
+    result = verify(doc)  # must NOT raise
+    assert result.ok is False
+
+
+def test_malformed_subject_digest_fails_schema():
+    # A plain-string digest (not a present-block / absent-marker) is non-conformant.
+    doc = valid_odr()
+    doc["subject"]["digest"] = "deadbeef"
+    result = verify(doc)
+    schema = next(c for c in result.checks if c.name == "schema_conformance")
+    assert schema.status == FAIL
+
+
+def test_jcs_parity_with_canonical_emitter():
+    # The standalone JCS port MUST stay byte-identical to the canonical emitter.
+    canonical = pytest.importorskip("aragora.gauntlet.odr_export")
+    private_key, _ = make_keypair()
+    for doc in (valid_odr(), sign_odr(valid_odr(), private_key)):
+        assert odr_content_digest(doc) == canonical.odr_content_digest(doc)
+
+
+def test_chain_pass_detail_documents_non_integrity_limitation():
+    doc = valid_odr()
+    chain = [{"hash": odr_content_digest(doc), "prev_hash": "x" * 64}]
+    result = verify(doc, chain=chain)
+    chain_check = next(c for c in result.checks if c.name == "chain_link")
+    assert chain_check.status == PASS
+    assert "not recomputed" in chain_check.detail.lower()

--- a/aragora-verify/tests/test_review_fixes.py
+++ b/aragora-verify/tests/test_review_fixes.py
@@ -1,0 +1,82 @@
+"""Regression tests for the two [P2] integrity-messaging findings (PR #8388 review).
+
+[P2a] A *signed* receipt verified WITHOUT a public key must NOT read "VERIFIED"
+      / exit 0 -- present signatures that were never checked are not authenticity.
+[P2b] Hash-chain anchoring must key on the content digest, not the mutable
+      non-cryptographic receipt_id.
+"""
+
+from __future__ import annotations
+
+import json
+
+from aragora_verify import odr_content_digest, verify
+from aragora_verify.cli import main
+from aragora_verify.verifier import FAIL, PASS, load_public_key
+
+from _fixtures import make_keypair, sign_odr, valid_odr
+
+
+def _pem(public_key) -> bytes:
+    from cryptography.hazmat.primitives import serialization
+
+    return public_key.public_bytes(
+        serialization.Encoding.PEM, serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+
+
+# --- [P2a] signed-but-unverified must not read VERIFIED --------------------
+
+
+def test_signed_receipt_without_pubkey_is_authenticity_unverified():
+    private_key, _ = make_keypair()
+    signed = sign_odr(valid_odr(), private_key)
+    result = verify(signed, public_key=None)
+    # present signatures, none checked -> NOT a clean "verified"
+    assert result.authenticity_unverified is True
+
+
+def test_signed_receipt_with_pubkey_is_verified_and_not_flagged():
+    private_key, public_key = make_keypair()
+    signed = sign_odr(valid_odr(), private_key)
+    result = verify(signed, public_key=load_public_key(_pem(public_key)))
+    assert result.ok is True
+    assert result.authenticity_unverified is False
+
+
+def test_unsigned_receipt_is_not_flagged_authenticity_unverified():
+    # An unsigned v0.1 receipt is the norm (WARN), not the "signed-but-unchecked" trap.
+    result = verify(valid_odr(), public_key=None)
+    assert result.authenticity_unverified is False
+
+
+def test_cli_signed_receipt_without_pubkey_does_not_exit_zero(tmp_path):
+    private_key, _ = make_keypair()
+    signed = sign_odr(valid_odr(), private_key)
+    path = tmp_path / "receipt.json"
+    path.write_text(json.dumps(signed))
+    rc = main([str(path)])
+    assert rc != 0  # must not silently report a green VERIFIED
+
+
+# --- [P2b] chain anchoring keys on digest, not receipt_id ------------------
+
+
+def _chain_check(result):
+    return next(c for c in result.checks if c.name == "chain_link")
+
+
+def test_chain_not_anchored_when_only_receipt_id_matches():
+    doc = valid_odr()
+    # entry references the mutable receipt_id but NOT the content digest
+    chain = [{"hash": "a" * 64, "receipt_id": doc["receipt_id"]}]
+    result = verify(doc, chain=chain)
+    assert _chain_check(result).status == FAIL
+
+
+def test_chain_anchored_when_digest_matches():
+    doc = valid_odr()
+    digest = odr_content_digest(doc)
+    chain = [{"hash": digest}]
+    result = verify(doc, chain=chain)
+    assert _chain_check(result).status == PASS

--- a/aragora-verify/tests/test_verifier.py
+++ b/aragora-verify/tests/test_verifier.py
@@ -153,7 +153,10 @@ def test_chain_anchored_receipt_passes() -> None:
         {"hash": "h1", "prev_hash": "h0", "odr_digest": digest},
     ]
     result = verify(doc, chain=chain)
-    assert _check(result, "chain_link").status == PASS
+    # Anchored + declared links present but NOT recomputed -> WARN (honest about
+    # the non-integrity limitation); still does not fail verification.
+    assert _check(result, "chain_link").status == WARN
+    assert result.ok is True
 
 
 def test_chain_broken_linkage_fails() -> None:

--- a/aragora-verify/tests/test_verifier.py
+++ b/aragora-verify/tests/test_verifier.py
@@ -1,0 +1,219 @@
+"""Verifier behavior: schema, signatures, quorum consistency, chain, warnings."""
+
+from __future__ import annotations
+
+
+import pytest
+
+from aragora_verify import compute_key_id, load_public_key, verify
+from aragora_verify.verifier import FAIL, PASS, SKIP, WARN
+
+from _fixtures import make_keypair, sign_odr, valid_odr
+
+
+def _check(result, name):
+    return next(c for c in result.checks if c.name == name)
+
+
+# --- schema conformance ----------------------------------------------------
+
+
+def test_valid_unsigned_receipt_passes_structurally() -> None:
+    result = verify(valid_odr())
+    assert result.ok is True
+    assert _check(result, "schema_conformance").status == PASS
+    assert _check(result, "signature").status == WARN  # unsigned
+
+
+def test_missing_required_member_fails_schema() -> None:
+    doc = valid_odr()
+    del doc["claim"]
+    result = verify(doc)
+    assert result.ok is False
+    assert _check(result, "schema_conformance").status == FAIL
+    assert result.odr_digest == ""
+
+
+def test_wrong_profile_uri_fails() -> None:
+    doc = valid_odr()
+    doc["profile"] = "https://evil.example/profile"
+    result = verify(doc)
+    assert result.ok is False
+    assert "profile" in _check(result, "schema_conformance").detail
+
+
+def test_routing_must_be_reserved() -> None:
+    doc = valid_odr()
+    doc["routing"] = {"status": "active"}
+    result = verify(doc)
+    assert result.ok is False
+
+
+# --- signatures ------------------------------------------------------------
+
+
+def _pubkey_bytes(public_key):
+    from cryptography.hazmat.primitives import serialization
+
+    return public_key.public_bytes(
+        serialization.Encoding.PEM, serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+
+
+def test_signed_receipt_verifies_with_correct_key() -> None:
+    private_key, public_key = make_keypair()
+    signed = sign_odr(valid_odr(), private_key)
+    result = verify(signed, public_key=load_public_key(_pubkey_bytes(public_key)))
+    assert result.ok is True
+    assert _check(result, "signature").status == PASS
+
+
+def test_mutated_byte_fails_signature() -> None:
+    private_key, public_key = make_keypair()
+    signed = sign_odr(valid_odr(), private_key)
+    signed["claim"]["verdict"] = "FAIL"  # tamper after signing
+    result = verify(signed, public_key=load_public_key(_pubkey_bytes(public_key)))
+    assert result.ok is False
+    assert _check(result, "signature").status == FAIL
+
+
+def test_wrong_key_does_not_verify() -> None:
+    private_key, _ = make_keypair()
+    _, other_public = make_keypair()
+    signed = sign_odr(valid_odr(), private_key)
+    result = verify(signed, public_key=load_public_key(_pubkey_bytes(other_public)))
+    assert result.ok is False
+    assert _check(result, "signature").status == FAIL
+
+
+def test_signed_receipt_without_key_is_skipped_not_failed() -> None:
+    private_key, _ = make_keypair()
+    signed = sign_odr(valid_odr(), private_key)
+    result = verify(signed)
+    assert result.ok is True
+    assert _check(result, "signature").status == SKIP
+
+
+def test_raw_and_pem_keys_both_load() -> None:
+    from cryptography.hazmat.primitives import serialization
+
+    private_key, public_key = make_keypair()
+    signed = sign_odr(valid_odr(), private_key)
+    raw = public_key.public_bytes(serialization.Encoding.Raw, serialization.PublicFormat.Raw)
+    assert verify(signed, public_key=load_public_key(raw)).ok is True
+
+
+def test_compute_key_id_matches_emitted_signature() -> None:
+    private_key, public_key = make_keypair()
+    signed = sign_odr(valid_odr(), private_key)
+    assert signed["signatures"][0]["key_id"] == compute_key_id(public_key)
+
+
+# --- quorum consistency ----------------------------------------------------
+
+
+def test_quorum_inconsistency_fails_as_malformed() -> None:
+    doc = valid_odr()
+    doc["quorum"]["supporting_agents"].append("ghost-agent")
+    result = verify(doc)
+    assert result.ok is False
+    assert _check(result, "quorum_consistency").status == FAIL
+    assert "ghost-agent" in _check(result, "quorum_consistency").detail
+
+
+def test_dissenting_agent_must_be_participant() -> None:
+    doc = valid_odr()
+    doc["quorum"]["dissent"] = {
+        "present": True,
+        "dissenting_agents": ["nobody"],
+        "views": ["disagree"],
+    }
+    result = verify(doc)
+    assert result.ok is False
+    assert _check(result, "quorum_consistency").status == FAIL
+
+
+def test_absent_quorum_skips_consistency() -> None:
+    doc = valid_odr()
+    doc["quorum"] = {"status": "absent", "reason": "no consensus proof recorded"}
+    result = verify(doc)
+    assert _check(result, "quorum_consistency").status == SKIP
+
+
+# --- hash chain ------------------------------------------------------------
+
+
+def test_chain_anchored_receipt_passes() -> None:
+    doc = valid_odr()
+    from aragora_verify import odr_content_digest
+
+    digest = odr_content_digest(doc)
+    chain = [
+        {"hash": "h0"},
+        {"hash": "h1", "prev_hash": "h0", "odr_digest": digest},
+    ]
+    result = verify(doc, chain=chain)
+    assert _check(result, "chain_link").status == PASS
+
+
+def test_chain_broken_linkage_fails() -> None:
+    doc = valid_odr()
+    from aragora_verify import odr_content_digest
+
+    digest = odr_content_digest(doc)
+    chain = [
+        {"hash": "h0"},
+        {"hash": "h1", "prev_hash": "WRONG", "odr_digest": digest},
+    ]
+    result = verify(doc, chain=chain)
+    assert result.ok is False
+    assert _check(result, "chain_link").status == FAIL
+
+
+def test_chain_without_receipt_fails_anchoring() -> None:
+    chain = [{"hash": "h0"}, {"hash": "h1", "prev_hash": "h0"}]
+    result = verify(valid_odr(), chain=chain)
+    assert result.ok is False
+    assert "not anchored" in _check(result, "chain_link").detail
+
+
+def test_no_chain_is_skipped() -> None:
+    assert _check(verify(valid_odr()), "chain_link").status == SKIP
+
+
+# --- weakening warnings ----------------------------------------------------
+
+
+def test_autonomous_and_uncalibrated_surface_as_warnings() -> None:
+    result = verify(valid_odr())
+    joined = " ".join(result.warnings)
+    assert "autonomous" in joined
+    assert "uncalibrated" in joined
+    assert result.ok is True  # warnings never fail
+
+
+def test_single_family_quorum_warns() -> None:
+    doc = valid_odr()
+    doc["quorum"]["independence"] = {
+        "disclosed": True,
+        "distinct_model_families": 1,
+        "model_families": ["anthropic"],
+    }
+    result = verify(doc)
+    assert any("single model family" in w for w in result.warnings)
+
+
+def test_to_dict_is_json_serializable() -> None:
+    import json
+
+    private_key, public_key = make_keypair()
+    signed = sign_odr(valid_odr(), private_key)
+    result = verify(signed, public_key=load_public_key(_pubkey_bytes(public_key)))
+    json.dumps(result.to_dict())  # must not raise
+
+
+def test_load_public_key_rejects_garbage() -> None:
+    from aragora_verify import VerificationError
+
+    with pytest.raises(VerificationError):
+        load_public_key(b"not a key")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ asyncio_default_fixture_loop_scope = "function"
 
 [tool.ruff]
 line-length = 100
-exclude = ["aragora-debate*"]
+exclude = ["aragora-debate*", "aragora-verify*"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/tests/fixtures/shared/api_mocks.py
+++ b/tests/fixtures/shared/api_mocks.py
@@ -453,8 +453,13 @@ def apply_api_mocks(monkeypatch: Any, force: bool = False) -> None:
     try:
         import anthropic
 
-        monkeypatch.setattr(anthropic, "Anthropic", MockAnthropicClient)
-        monkeypatch.setattr(anthropic, "AsyncAnthropic", MockAsyncAnthropicClient)
+        monkeypatch.setattr(anthropic, "Anthropic", MockAnthropicClient, raising=False)
+        monkeypatch.setattr(
+            anthropic,
+            "AsyncAnthropic",
+            MockAsyncAnthropicClient,
+            raising=False,
+        )
     except ImportError:
         pass
 

--- a/tests/fixtures/test_api_mocks.py
+++ b/tests/fixtures/test_api_mocks.py
@@ -1,0 +1,18 @@
+import sys
+from types import ModuleType
+
+from tests.fixtures.shared.api_mocks import (
+    MockAnthropicClient,
+    MockAsyncAnthropicClient,
+    apply_api_mocks,
+)
+
+
+def test_apply_api_mocks_supports_lightweight_anthropic_stub(monkeypatch):
+    anthropic_stub = ModuleType("anthropic")
+    monkeypatch.setitem(sys.modules, "anthropic", anthropic_stub)
+
+    apply_api_mocks(monkeypatch)
+
+    assert anthropic_stub.Anthropic is MockAnthropicClient
+    assert anthropic_stub.AsyncAnthropic is MockAsyncAnthropicClient


### PR DESCRIPTION
## What

**ODR-3** — the third spine piece of the Open Decision Receipt epic (#8223): `aragora-verify`, the free, standalone artifact that lets *anyone* (auditor, customer, skeptic) verify a decision receipt is genuine and well-formed — **no Aragora install, no server, no account.** The emitter is the product; the verifier is the distribution wedge ("verifier is free; emitter is the product").

New top-level package **`aragora-verify/`** mirroring the proven `aragora-debate/` packaging path (stdlib + one crypto dep). Provides the `aragora-verify` CLI and a reusable library.

## Checks performed

| Check | What it establishes |
|---|---|
| **schema conformance** | ODR v0.1 profile shape — dependency-free structural validator, with *optional* full draft-2020-12 validation when `jsonschema` is installed |
| **canonical digest** | recomputes `SHA-256(JCS(receipt − signatures))` per RFC 8785, from a faithful port of `odr_export.jcs_canonicalize` — the value any detached signature covers |
| **Ed25519 signature** | verifies detached signatures with only the public key (PEM/DER/raw/base64/hex), per `OPEN_DECISION_RECEIPT.md` §6 / #8225 (signed message = the SHA-256 digest above) |
| **quorum consistency** | every supporting/dissenting agent is a disclosed participant — a mismatch is a malformed/tamper signal (spec §8) |
| **hash-chain linkage** | when `--chain` is supplied, the receipt is anchored in the chain and the links are continuous |

Absent markers (`{"status":"absent",...}`) and `"undisclosed"` model families are surfaced as **non-failing weakening signals** — honest-by-design, never silent.

## Usage

```bash
pip install aragora-verify
aragora-verify receipt.odr.json --pubkey key.pem [--chain c.jsonl] [--json]
```

Exit `0` verified / `1` failed / `2` usage. The library API: `verify`, `load_public_key`, `compute_key_id`, `validate_structure`, `jcs_canonicalize`, `odr_content_digest`.

## Acceptance (#8226) — demonstrated end to end

> "verify a receipt produced by this repo's loop: PASS; mutate one byte: FAIL"

A signed receipt verifies (`VERIFIED`, exit 0); mutating a single field invalidates the Ed25519 signature (`FAILED`, exit 1). The wheel builds with `odr_schema.json` bundled.

## Validation

- **37 tests** pass: RFC 8785 / JCS number+ordering+unicode vectors, digest stability, schema pass+fail, signature verify/tamper/wrong-key/no-key/raw+pem, quorum consistency (pass/fail/skip), chain anchored/broken/unanchored, weakening warnings, CLI exit codes. Suite passes both with and without the optional `jsonschema` installed (structural and full-schema paths agree).
- `python -m build --wheel` succeeds; `odr_schema.json` confirmed inside the wheel.
- `aragora-verify*` added to the root ruff `exclude` alongside `aragora-debate*` (standalone packages lint on their own lifecycle); package formatted to the repo's 100-col style.

## Tier / scope

Tier 2 (additive standalone package). Per the issue's approval-required note, the **PyPI trusted-publishing release workflow is intentionally left for a human** and not included here. The `POST /api/receipts/verify` endpoint (same library, server-side) is a natural follow-up and is deliberately out of this PR to keep it a clean, dependency-light package.

> Built to the **merged** ODR-1 spec/schema (#8246), so it is independent of #8275's (ODR-2) merge timing; when #8275 lands, `aragora_verify`'s signature path and `odr_signing.verify_odr` can be reconciled against shared test vectors.

Part of #8223. Closes #8226 (pending the release-workflow step).

---
_Generated by [Claude Code](https://claude.ai/code/session_018jfJj5gb9VoLs6VBMnzhrP)_