### PR TITLE
fix(settle-one): fall back on exact-head required checks

### DIFF
--- a/scripts/settle_one_pr.py
+++ b/scripts/settle_one_pr.py
@@ -31,6 +31,7 @@ CONVERGENCE_SENTENCE = (
 
 VERSION = "settle_one_steward.v1"
 MERGE_QUORUM = "aragora-merge-quorum"
+GITHUB_ACTIONS_APP_ID = 15368
 HUMAN_RISK_EXCLUDES = {7407, 7425, 7438, 7439, 7443}
 BROAD_PACKET_NEAR_SELECTED_LOOKAHEAD = 8
 PYTHON_EXECUTABLE = sys.executable or "python3"
@@ -931,10 +932,76 @@ def _check_runs_from_payload(payload: Any) -> list[dict[str, Any]]:
     return [item for item in check_runs if isinstance(item, dict)]
 
 
+def _github_actions_check_run(item: dict[str, Any]) -> bool:
+    app = item.get("app")
+    if isinstance(app, dict):
+        slug = str(app.get("slug") or "").strip().lower()
+        if slug == "github-actions":
+            return True
+        app_id = _coerce_int(app.get("id") or app.get("databaseId"))
+        if app_id == GITHUB_ACTIONS_APP_ID:
+            return True
+    return _coerce_int(item.get("app_id") or item.get("appId")) == GITHUB_ACTIONS_APP_ID
+
+
+def _fallback_required_check_source_report(
+    required_checks: Any,
+    check_runs_payload: Any,
+) -> dict[str, Any]:
+    if not isinstance(required_checks, list):
+        return {
+            "status": "unknown",
+            "blockers": ["required checks JSON unavailable"],
+            "suggestions": ["rerun gh pr checks --required before settlement"],
+        }
+
+    required_contexts = [
+        str(check.get("name") or check.get("context") or "").strip()
+        for check in required_checks
+        if isinstance(check, dict)
+    ]
+    required_contexts = [context for context in required_contexts if context]
+    if not required_contexts:
+        return {
+            "status": "unknown",
+            "blockers": ["required checks JSON empty"],
+            "suggestions": ["rerun gh pr checks --required before settlement"],
+        }
+
+    check_report = required_check_report(required_checks)
+    if check_report["blockers"]:
+        return check_report
+
+    check_runs = _check_runs_from_payload(check_runs_payload)
+    blockers: list[str] = []
+    for context in required_contexts:
+        matching_success = [
+            item
+            for item in check_runs
+            if _rollup_name(item) == context
+            and _rollup_success(item)
+            and _github_actions_check_run(item)
+        ]
+        if not matching_success:
+            blockers.append(
+                f"{context} lacks a matching successful exact-head GitHub Actions CheckRun"
+            )
+
+    if blockers:
+        return {
+            "status": "blocked",
+            "blockers": blockers,
+            "suggestions": ["rerun or inspect the missing app-sourced required check"],
+        }
+
+    return {"status": "pass", "blockers": [], "suggestions": []}
+
+
 def required_check_source_report(
     protection: Any,
     pr_view: Any,
     check_runs_payload: Any = None,
+    required_checks: Any = None,
 ) -> dict[str, Any]:
     """Fail closed when an app-pinned required check is only a manual status.
 
@@ -945,6 +1012,8 @@ def required_check_source_report(
     an executor tries to merge.
     """
     if not isinstance(protection, dict):
+        if required_checks is not None:
+            return _fallback_required_check_source_report(required_checks, check_runs_payload)
         return {
             "status": "unknown",
             "blockers": ["branch protection required_status_checks JSON unavailable"],
@@ -1573,7 +1642,9 @@ def build_report(
         blockers.extend(check_report["blockers"])
         report["suggested_commands"].extend(check_report["suggestions"])
 
-        source_report = required_check_source_report(protection, pr_view, check_runs_payload)
+        source_report = required_check_source_report(
+            protection, pr_view, check_runs_payload, required_checks
+        )
         report["checks"]["required_sources"] = source_report
         blockers.extend(source_report["blockers"])
         report["suggested_commands"].extend(source_report.get("suggestions") or [])

--- a/tests/scripts/test_settle_one_pr.py
+++ b/tests/scripts/test_settle_one_pr.py
@@ -1852,6 +1852,87 @@ def test_required_check_source_report_fails_closed_without_protection_json() -> 
     ]
 
 
+def test_required_check_source_report_falls_back_to_required_checks_and_check_runs() -> None:
+    report = required_check_source_report(
+        None,
+        {"statusCheckRollup": []},
+        {
+            "check_runs": [
+                {
+                    "name": "aragora-merge-quorum",
+                    "conclusion": "success",
+                    "app": {"id": 15368, "slug": "github-actions"},
+                }
+            ]
+        },
+        [{"name": "aragora-merge-quorum", "state": "SUCCESS"}],
+    )
+
+    assert report == {"status": "pass", "blockers": [], "suggestions": []}
+
+
+def test_required_check_source_report_fallback_blocks_empty_required_checks() -> None:
+    report = required_check_source_report(
+        None,
+        {"statusCheckRollup": []},
+        {
+            "check_runs": [
+                {
+                    "name": "aragora-merge-quorum",
+                    "conclusion": "success",
+                    "app": {"id": 15368, "slug": "github-actions"},
+                }
+            ]
+        },
+        [],
+    )
+
+    assert report["status"] == "unknown"
+    assert report["blockers"] == ["required checks JSON empty"]
+
+
+def test_required_check_source_report_fallback_blocks_non_green_required_check() -> None:
+    report = required_check_source_report(
+        None,
+        {"statusCheckRollup": []},
+        {
+            "check_runs": [
+                {
+                    "name": "aragora-merge-quorum",
+                    "conclusion": "success",
+                    "app": {"id": 15368, "slug": "github-actions"},
+                }
+            ]
+        },
+        [{"name": "aragora-merge-quorum", "state": "FAILURE"}],
+    )
+
+    assert report["status"] == "blocked"
+    assert report["blockers"] == ["aragora-merge-quorum is FAILURE"]
+
+
+def test_required_check_source_report_fallback_blocks_status_only_required_check() -> None:
+    report = required_check_source_report(
+        None,
+        {
+            "statusCheckRollup": [
+                {
+                    "__typename": "StatusContext",
+                    "context": "aragora-merge-quorum",
+                    "state": "SUCCESS",
+                }
+            ]
+        },
+        {"check_runs": []},
+        [{"name": "aragora-merge-quorum", "state": "SUCCESS"}],
+    )
+
+    assert report["status"] == "blocked"
+    assert report["blockers"] == [
+        "aragora-merge-quorum lacks a matching successful exact-head GitHub Actions CheckRun"
+    ]
+
+
 def test_build_report_reads_required_checks_from_pr_base_branch(monkeypatch) -> None:
     commands: list[list[str]] = []
 
@@ -2001,7 +2082,81 @@ def test_build_report_fails_closed_when_required_check_sources_unreadable(monkey
     )
 
     assert report["status"] == "blocked"
-    assert "branch protection required_status_checks JSON unavailable" in report["blockers"]
+    assert (
+        "aragora-merge-quorum lacks a matching successful exact-head GitHub Actions CheckRun"
+        in report["blockers"]
+    )
+
+
+def test_build_report_falls_back_when_required_checks_and_check_runs_are_green(
+    monkeypatch,
+) -> None:
+    def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
+        del cwd, timeout
+        if args[:3] == ["gh", "pr", "list"]:
+            return [], {"command": "metadata", "returncode": 0}
+        if args[:3] == OPERATOR_SNAPSHOT_PREFIX:
+            return {"lanes": []}, {"command": "snapshot", "returncode": 0}
+        if args[:3] == OWNER_PREFIX:
+            return {"status": "completed"}, {"command": "owner", "returncode": 0}
+        if args[:3] == STEERING_PREFIX:
+            return {"message_count": 0}, {"command": "mailbox", "returncode": 0}
+        if args[:3] == ["gh", "pr", "view"]:
+            return (
+                {
+                    "headRefOid": "0000000000000000000000000000000000001010",
+                    "baseRefName": "main",
+                    "isDraft": False,
+                    "mergeable": "MERGEABLE",
+                    "mergeStateStatus": "CLEAN",
+                    "statusCheckRollup": [],
+                },
+                {"command": "view", "returncode": 0},
+            )
+        if args[:2] == ["gh", "api"] and args[2].endswith("/required_status_checks"):
+            return None, {"command": "protection", "returncode": 404}
+        if args[:2] == ["gh", "api"] and args[2].endswith("/check-runs?per_page=100"):
+            return (
+                {
+                    "check_runs": [
+                        {
+                            "name": "aragora-merge-quorum",
+                            "conclusion": "success",
+                            "app": {"id": 15368, "slug": "github-actions"},
+                        }
+                    ]
+                },
+                {"command": "check-runs", "returncode": 0},
+            )
+        if args[:3] == ["gh", "pr", "checks"]:
+            return (
+                [{"name": "aragora-merge-quorum", "state": "SUCCESS"}],
+                {"command": "checks", "returncode": 0},
+            )
+        raise AssertionError(args)
+
+    monkeypatch.setattr(settle_one_pr, "_run_json", fake_run_json)
+
+    report = build_report(
+        _packet(
+            _entry(
+                1010,
+                status="satisfied",
+                verdict="admin_squash_allowed",
+                admin_squash_allowed=True,
+                reasons=["bounded internal code surface"],
+            ),
+            admin_order=[1010],
+        ),
+        cwd=Path.cwd(),
+        state_root=Path.cwd(),
+        explicit_pr=1010,
+        exclude_prs=set(),
+        live=True,
+        validate=False,
+    )
+
+    assert report["status"] == "packet_authorized_dry_run"
 
 
 def test_recursive_prompt_always_contains_convergence_sentence() -> None:


### PR DESCRIPTION
## Summary
- let settle_one_pr fall back to gh pr checks --required plus exact-head GitHub Actions check-runs when the legacy required_status_checks REST endpoint returns unavailable
- preserve fail-closed behavior for unavailable, empty, non-green, status-only, or non-GitHub-Actions required contexts
- add focused tests for the fallback and fail-closed cases

## Validation
- PATH=/Users/armand/.pyenv/versions/3.11.11/bin:$PATH python3 -m pytest tests/scripts/test_settle_one_pr.py
- PATH=/Users/armand/.pyenv/versions/3.11.11/bin:$PATH python3 scripts/settle_one_pr.py --json --pr 8366
- git diff --check origin/main HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD

No evidence was collected, and no workflows were rerun.