### PR TITLE
fix(settle-tier4): preflight branch protection before merge apply

### DIFF
--- a/scripts/settle_tier4_pr.py
+++ b/scripts/settle_tier4_pr.py
@@ -46,6 +46,36 @@ ALLOWED_TIER4_ENTRY_STATUSES = {
 }
 
 
+class Tier4ApplyError(RuntimeError):
+    """Structured failure for Tier 4 merge/apply phases."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        phase: str,
+        mutation_occurred: bool,
+        completed_commands: int,
+        recovery_action: str,
+        rollback_errors: Sequence[str] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.phase = phase
+        self.mutation_occurred = mutation_occurred
+        self.completed_commands = completed_commands
+        self.recovery_action = recovery_action
+        self.rollback_errors = list(rollback_errors or [])
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "phase": self.phase,
+            "mutation_occurred": self.mutation_occurred,
+            "completed_commands": self.completed_commands,
+            "rollback_errors": self.rollback_errors,
+            "recovery_action": self.recovery_action,
+        }
+
+
 def _text_items(pr_view: dict[str, Any]) -> list[dict[str, Any]]:
     items: list[dict[str, Any]] = []
     for key in ("comments", "reviews"):
@@ -887,6 +917,40 @@ def _run_text_command(command: list[str], *, cwd: Path, input_text: str | None =
     return result.stdout.strip()
 
 
+def _preflight_branch_protection_reconcile(*, repo: str, cwd: Path) -> None:
+    login = _current_gh_login(cwd=cwd)
+    if not _login_has_admin_permission(login, repo, cwd):
+        raise Tier4ApplyError(
+            f"Tier 4 branch-protection preflight failed: gh login {login} lacks admin permission",
+            phase="preflight",
+            mutation_occurred=False,
+            completed_commands=0,
+            recovery_action="switch gh auth to an admin/OWNER identity and rerun --merge-apply",
+        )
+
+    base = f"repos/{repo}/branches/main/protection"
+    for endpoint in (
+        base,
+        f"{base}/required_pull_request_reviews",
+        f"{base}/required_status_checks",
+        f"{base}/enforce_admins",
+    ):
+        try:
+            _run_json(["gh", "api", endpoint], cwd=cwd)
+        except RuntimeError as exc:
+            raise Tier4ApplyError(
+                "Tier 4 branch-protection preflight failed before merge mutation: "
+                f"{endpoint}: {exc}",
+                phase="preflight",
+                mutation_occurred=False,
+                completed_commands=0,
+                recovery_action=(
+                    "verify the active gh identity has branch-protection admin access, "
+                    "then rerun --merge-apply"
+                ),
+            ) from exc
+
+
 def _branch_protection_snapshot(*, repo: str, cwd: Path) -> dict[str, Any]:
     base = f"repos/{repo}/branches/main/protection"
     snapshot: dict[str, Any] = {}
@@ -993,6 +1057,8 @@ def _apply_merge(
     reconcile_branch_protection: bool = False,
 ) -> list[list[str]]:
     commands: list[list[str]] = []
+    if reconcile_branch_protection:
+        _preflight_branch_protection_reconcile(repo=repo, cwd=cwd)
     snapshot = (
         _branch_protection_snapshot(repo=repo, cwd=cwd) if reconcile_branch_protection else {}
     )
@@ -1049,11 +1115,23 @@ def _apply_merge(
         ]
         _run_command(enforce_command, cwd=cwd)
         commands.append(enforce_command)
-    except (OSError, subprocess.SubprocessError) as exc:
+    except Tier4ApplyError:
+        raise
+    except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
         rollback_errors = _restore_branch_protection(repo=repo, cwd=cwd, snapshot=snapshot)
-        raise RuntimeError(
-            "Tier 4 apply failed after partial execution; "
-            f"completed_commands={len(commands)} rollback_errors={rollback_errors}: {exc}"
+        phase = "merge" if not commands else "branch_protection_restore"
+        recovery_action = (
+            "rerun live verification before any retry; if mutation_occurred=true, "
+            "inspect PR state and branch protection before rerunning --merge-apply"
+        )
+        raise Tier4ApplyError(
+            "Tier 4 apply failed after partial execution: "
+            f"completed_commands={len(commands)} rollback_errors={rollback_errors}: {exc}",
+            phase=phase,
+            mutation_occurred=bool(commands),
+            completed_commands=len(commands),
+            rollback_errors=rollback_errors,
+            recovery_action=recovery_action,
         ) from exc
     return commands
 
@@ -1181,6 +1259,18 @@ def main(argv: Sequence[str] | None = None) -> int:
                 in set(gate.get("authorized_actions") or []),
             )
         out = {"gate": gate, "applied_commands": applied_commands}
+    except Tier4ApplyError as exc:
+        if args.json:
+            print(
+                json.dumps(
+                    {"ok": False, "error": str(exc), **exc.to_payload()},
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+        else:
+            print(f"error: {exc}", file=sys.stderr)
+        return 2
     except RuntimeError as exc:
         if args.json:
             print(json.dumps({"ok": False, "error": str(exc)}, indent=2, sort_keys=True))

--- a/scripts/settle_tier4_pr.py
+++ b/scripts/settle_tier4_pr.py
@@ -917,6 +917,15 @@ def _run_text_command(command: list[str], *, cwd: Path, input_text: str | None =
     return result.stdout.strip()
 
 
+def _is_not_found_error(exc: BaseException) -> bool:
+    text = str(exc)
+    return "HTTP 404" in text or "Not Found" in text
+
+
+def _top_level_rule_absent(top_level: dict[str, Any], key: str) -> bool:
+    return top_level.get(key) is None
+
+
 def _preflight_branch_protection_reconcile(*, repo: str, cwd: Path) -> None:
     login = _current_gh_login(cwd=cwd)
     if not _login_has_admin_permission(login, repo, cwd):
@@ -929,15 +938,30 @@ def _preflight_branch_protection_reconcile(*, repo: str, cwd: Path) -> None:
         )
 
     base = f"repos/{repo}/branches/main/protection"
-    for endpoint in (
-        base,
-        f"{base}/required_pull_request_reviews",
-        f"{base}/required_status_checks",
-        f"{base}/enforce_admins",
+    try:
+        top_level = _run_json(["gh", "api", base], cwd=cwd)
+    except RuntimeError as exc:
+        raise Tier4ApplyError(
+            f"Tier 4 branch-protection preflight failed before merge mutation: {base}: {exc}",
+            phase="preflight",
+            mutation_occurred=False,
+            completed_commands=0,
+            recovery_action=(
+                "verify the active gh identity has branch-protection admin access, "
+                "then rerun --merge-apply"
+            ),
+        ) from exc
+
+    for key, endpoint in (
+        ("required_pull_request_reviews", f"{base}/required_pull_request_reviews"),
+        ("required_status_checks", f"{base}/required_status_checks"),
+        ("enforce_admins", f"{base}/enforce_admins"),
     ):
         try:
             _run_json(["gh", "api", endpoint], cwd=cwd)
         except RuntimeError as exc:
+            if _is_not_found_error(exc) and _top_level_rule_absent(top_level, key):
+                continue
             raise Tier4ApplyError(
                 "Tier 4 branch-protection preflight failed before merge mutation: "
                 f"{endpoint}: {exc}",
@@ -954,6 +978,12 @@ def _preflight_branch_protection_reconcile(*, repo: str, cwd: Path) -> None:
 def _branch_protection_snapshot(*, repo: str, cwd: Path) -> dict[str, Any]:
     base = f"repos/{repo}/branches/main/protection"
     snapshot: dict[str, Any] = {}
+    try:
+        top_level = _run_json(["gh", "api", base], cwd=cwd)
+    except RuntimeError as exc:
+        snapshot["branch_protection"] = {"snapshot_error": str(exc)}
+        return snapshot
+    snapshot["branch_protection"] = top_level
     for key, endpoint in {
         "required_pull_request_reviews": f"{base}/required_pull_request_reviews",
         "required_status_checks": f"{base}/required_status_checks",
@@ -962,14 +992,27 @@ def _branch_protection_snapshot(*, repo: str, cwd: Path) -> dict[str, Any]:
         try:
             snapshot[key] = _run_json(["gh", "api", endpoint], cwd=cwd)
         except RuntimeError as exc:
+            if _is_not_found_error(exc) and _top_level_rule_absent(top_level, key):
+                snapshot[key] = None
+                continue
             snapshot[key] = {"snapshot_error": str(exc)}
     return snapshot
 
 
 def _branch_protection_snapshot_errors(snapshot: dict[str, Any]) -> list[str]:
     errors: list[str] = []
+    top_level = snapshot.get("branch_protection")
+    if not isinstance(top_level, dict):
+        errors.append("branch_protection: missing snapshot")
+        top_level = {}
+    else:
+        snapshot_error = top_level.get("snapshot_error")
+        if snapshot_error:
+            errors.append(f"branch_protection: {snapshot_error}")
     for key in ("required_pull_request_reviews", "required_status_checks", "enforce_admins"):
         value = snapshot.get(key)
+        if value is None and _top_level_rule_absent(top_level, key):
+            continue
         if not isinstance(value, dict):
             errors.append(f"{key}: missing snapshot")
             continue
@@ -977,6 +1020,11 @@ def _branch_protection_snapshot_errors(snapshot: dict[str, Any]) -> list[str]:
         if snapshot_error:
             errors.append(f"{key}: {snapshot_error}")
     return errors
+
+
+def _snapshot_subresource_available(snapshot: dict[str, Any], key: str) -> bool:
+    value = snapshot.get(key)
+    return isinstance(value, dict) and "snapshot_error" not in value
 
 
 def _restore_branch_protection(*, repo: str, cwd: Path, snapshot: dict[str, Any]) -> list[str]:
@@ -1109,42 +1157,45 @@ def _apply_merge(
         if not reconcile_branch_protection:
             return commands
 
-        reviews_command = [
-            "gh",
-            "api",
-            "--method",
-            "PATCH",
-            f"repos/{repo}/branches/main/protection/required_pull_request_reviews",
-            "--input",
-            "-",
-        ]
-        _run_command(
-            reviews_command,
-            cwd=cwd,
-            input_text=json.dumps(
-                {
-                    "required_approving_review_count": 0,
-                    "require_code_owner_reviews": False,
-                }
-            ),
-        )
-        commands.append(reviews_command)
+        if _snapshot_subresource_available(snapshot, "required_pull_request_reviews"):
+            reviews_command = [
+                "gh",
+                "api",
+                "--method",
+                "PATCH",
+                f"repos/{repo}/branches/main/protection/required_pull_request_reviews",
+                "--input",
+                "-",
+            ]
+            _run_command(
+                reviews_command,
+                cwd=cwd,
+                input_text=json.dumps(
+                    {
+                        "required_approving_review_count": 0,
+                        "require_code_owner_reviews": False,
+                    }
+                ),
+            )
+            commands.append(reviews_command)
 
-        checks_patch = _required_status_check_patch(repo=repo, cwd=cwd)
-        if checks_patch is not None:
-            checks_command, checks_payload = checks_patch
-            _run_command(checks_command, cwd=cwd, input_text=checks_payload)
-            commands.append(checks_command)
+        if _snapshot_subresource_available(snapshot, "required_status_checks"):
+            checks_patch = _required_status_check_patch(repo=repo, cwd=cwd)
+            if checks_patch is not None:
+                checks_command, checks_payload = checks_patch
+                _run_command(checks_command, cwd=cwd, input_text=checks_payload)
+                commands.append(checks_command)
 
-        enforce_command = [
-            "gh",
-            "api",
-            "--method",
-            "POST",
-            f"repos/{repo}/branches/main/protection/enforce_admins",
-        ]
-        _run_command(enforce_command, cwd=cwd)
-        commands.append(enforce_command)
+        if _snapshot_subresource_available(snapshot, "enforce_admins"):
+            enforce_command = [
+                "gh",
+                "api",
+                "--method",
+                "POST",
+                f"repos/{repo}/branches/main/protection/enforce_admins",
+            ]
+            _run_command(enforce_command, cwd=cwd)
+            commands.append(enforce_command)
     except Tier4ApplyError:
         raise
     except (OSError, RuntimeError, subprocess.SubprocessError) as exc:

--- a/scripts/settle_tier4_pr.py
+++ b/scripts/settle_tier4_pr.py
@@ -1100,7 +1100,9 @@ def _apply_merge(
         "--match-head-commit",
         head,
     ]
+    merge_invoked = False
     try:
+        merge_invoked = True
         _run_command(merge_command, cwd=cwd)
         commands.append(merge_command)
 
@@ -1148,15 +1150,17 @@ def _apply_merge(
     except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
         rollback_errors = _restore_branch_protection(repo=repo, cwd=cwd, snapshot=snapshot)
         phase = "merge" if not commands else "branch_protection_restore"
+        mutation_occurred = bool(commands) or merge_invoked
         recovery_action = (
             "rerun live verification before any retry; if mutation_occurred=true, "
             "inspect PR state and branch protection before rerunning --merge-apply"
         )
         raise Tier4ApplyError(
             "Tier 4 apply failed after partial execution: "
-            f"completed_commands={len(commands)} rollback_errors={rollback_errors}: {exc}",
+            f"completed_commands={len(commands)} merge_invoked={merge_invoked} "
+            f"rollback_errors={rollback_errors}: {exc}",
             phase=phase,
-            mutation_occurred=bool(commands),
+            mutation_occurred=mutation_occurred,
             completed_commands=len(commands),
             rollback_errors=rollback_errors,
             recovery_action=recovery_action,

--- a/scripts/settle_tier4_pr.py
+++ b/scripts/settle_tier4_pr.py
@@ -966,6 +966,19 @@ def _branch_protection_snapshot(*, repo: str, cwd: Path) -> dict[str, Any]:
     return snapshot
 
 
+def _branch_protection_snapshot_errors(snapshot: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for key in ("required_pull_request_reviews", "required_status_checks", "enforce_admins"):
+        value = snapshot.get(key)
+        if not isinstance(value, dict):
+            errors.append(f"{key}: missing snapshot")
+            continue
+        snapshot_error = value.get("snapshot_error")
+        if snapshot_error:
+            errors.append(f"{key}: {snapshot_error}")
+    return errors
+
+
 def _restore_branch_protection(*, repo: str, cwd: Path, snapshot: dict[str, Any]) -> list[str]:
     base = f"repos/{repo}/branches/main/protection"
     errors: list[str] = []
@@ -1062,6 +1075,21 @@ def _apply_merge(
     snapshot = (
         _branch_protection_snapshot(repo=repo, cwd=cwd) if reconcile_branch_protection else {}
     )
+    snapshot_errors = (
+        _branch_protection_snapshot_errors(snapshot) if reconcile_branch_protection else []
+    )
+    if snapshot_errors:
+        raise Tier4ApplyError(
+            "Tier 4 branch-protection snapshot failed before merge mutation: "
+            + "; ".join(snapshot_errors),
+            phase="branch_protection_snapshot",
+            mutation_occurred=False,
+            completed_commands=0,
+            recovery_action=(
+                "verify branch-protection read access and retry --merge-apply before "
+                "any merge mutation"
+            ),
+        )
     merge_command = [
         "gh",
         "pr",

--- a/tests/scripts/test_settle_tier4_pr.py
+++ b/tests/scripts/test_settle_tier4_pr.py
@@ -113,6 +113,17 @@ def _valid_checks() -> list[dict[str, str]]:
     ]
 
 
+def _valid_branch_protection_snapshot() -> dict[str, dict[str, Any]]:
+    return {
+        "required_pull_request_reviews": {
+            "required_approving_review_count": 0,
+            "require_code_owner_reviews": False,
+        },
+        "required_status_checks": {"strict": False, "contexts": ["lint"]},
+        "enforce_admins": {"enabled": True},
+    }
+
+
 def test_missing_operator_comment_blocks_settlement() -> None:
     head = "57c740022e3c432718462efa12ca79f1df4f674d"
     result = settler.evaluate_tier4_gate(
@@ -1054,7 +1065,7 @@ def test_merge_apply_uses_valid_command_sequence(monkeypatch: Any, tmp_path: Pat
     monkeypatch.setattr(
         settler,
         "_branch_protection_snapshot",
-        lambda repo, cwd: {},
+        lambda repo, cwd: _valid_branch_protection_snapshot(),
     )
     monkeypatch.setattr(
         settler,
@@ -1172,6 +1183,55 @@ def test_branch_protection_preflight_blocks_non_admin_invoker(
     assert "lacks admin permission" in str(exc.value)
 
 
+def test_merge_apply_branch_protection_snapshot_failure_prevents_merge(
+    monkeypatch: Any, tmp_path: Path, capsys: Any
+) -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    commands: list[tuple[list[str], str | None]] = []
+
+    monkeypatch.setattr(
+        settler,
+        "_load_live_inputs",
+        lambda pr, cwd: (
+            _pr_view(head, comments=[_authorized_comment(head)]),
+            _tier4_packet(),
+            _valid_checks(),
+        ),
+    )
+    monkeypatch.setattr(
+        settler,
+        "_preflight_branch_protection_reconcile",
+        lambda repo, cwd: None,
+    )
+    monkeypatch.setattr(
+        settler,
+        "_branch_protection_snapshot",
+        lambda repo, cwd: {
+            "required_pull_request_reviews": {"snapshot_error": "gh: Not Found (HTTP 404)"},
+            "required_status_checks": {"strict": False, "contexts": ["lint"]},
+            "enforce_admins": {"enabled": True},
+        },
+    )
+    monkeypatch.setattr(
+        settler,
+        "_run_command",
+        lambda command, cwd, input_text=None: commands.append((command, input_text)),
+    )
+
+    rc = settler.main(
+        ["--merge-apply", "--pr", "7423", "--head", head, "--cwd", str(tmp_path), "--json"]
+    )
+
+    assert rc == 2
+    assert commands == []
+    payload = settler.json.loads(capsys.readouterr().out)
+    assert payload["phase"] == "branch_protection_snapshot"
+    assert payload["mutation_occurred"] is False
+    assert payload["completed_commands"] == 0
+    assert "required_pull_request_reviews" in payload["error"]
+    assert "before any merge mutation" in payload["recovery_action"]
+
+
 def test_merge_apply_branch_protection_failure_reports_partial_mutation(
     monkeypatch: Any, tmp_path: Path, capsys: Any
 ) -> None:
@@ -1195,7 +1255,7 @@ def test_merge_apply_branch_protection_failure_reports_partial_mutation(
     monkeypatch.setattr(
         settler,
         "_branch_protection_snapshot",
-        lambda repo, cwd: {},
+        lambda repo, cwd: _valid_branch_protection_snapshot(),
     )
 
     def fake_run_command(command: list[str], cwd: Path, input_text: str | None = None) -> None:
@@ -1361,7 +1421,7 @@ def test_merge_apply_skips_required_status_check_patch_when_quorum_already_requi
     monkeypatch.setattr(
         settler,
         "_branch_protection_snapshot",
-        lambda repo, cwd: {},
+        lambda repo, cwd: _valid_branch_protection_snapshot(),
     )
     monkeypatch.setattr(
         settler,

--- a/tests/scripts/test_settle_tier4_pr.py
+++ b/tests/scripts/test_settle_tier4_pr.py
@@ -115,6 +115,11 @@ def _valid_checks() -> list[dict[str, str]]:
 
 def _valid_branch_protection_snapshot() -> dict[str, dict[str, Any]]:
     return {
+        "branch_protection": {
+            "required_pull_request_reviews": {"url": "https://github.example/reviews"},
+            "required_status_checks": {"url": "https://github.example/checks"},
+            "enforce_admins": {"enabled": True},
+        },
         "required_pull_request_reviews": {
             "required_approving_review_count": 0,
             "require_code_owner_reviews": False,
@@ -1163,6 +1168,69 @@ def test_branch_protection_preflight_reads_all_privileged_endpoints(
     ]
 
 
+def test_branch_protection_preflight_allows_absent_optional_subresource_404(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    commands: list[str] = []
+
+    monkeypatch.setattr(settler, "_current_gh_login", lambda cwd: "admin-user")
+    monkeypatch.setattr(settler, "_login_has_admin_permission", lambda login, repo, cwd: True)
+
+    def fake_run_json(command: list[str], cwd: Path) -> dict[str, Any]:
+        endpoint = command[-1]
+        commands.append(endpoint)
+        if endpoint.endswith("/protection"):
+            return {
+                "required_pull_request_reviews": None,
+                "required_status_checks": None,
+                "enforce_admins": {"enabled": True},
+            }
+        if endpoint.endswith("/required_pull_request_reviews") or endpoint.endswith(
+            "/required_status_checks"
+        ):
+            raise RuntimeError("gh: Not Found (HTTP 404)")
+        return {"enabled": True}
+
+    monkeypatch.setattr(settler, "_run_json", fake_run_json)
+
+    settler._preflight_branch_protection_reconcile(repo="owner/repo", cwd=tmp_path)
+
+    assert commands == [
+        "repos/owner/repo/branches/main/protection",
+        "repos/owner/repo/branches/main/protection/required_pull_request_reviews",
+        "repos/owner/repo/branches/main/protection/required_status_checks",
+        "repos/owner/repo/branches/main/protection/enforce_admins",
+    ]
+
+
+def test_branch_protection_preflight_blocks_present_optional_subresource_404(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(settler, "_current_gh_login", lambda cwd: "admin-user")
+    monkeypatch.setattr(settler, "_login_has_admin_permission", lambda login, repo, cwd: True)
+
+    def fake_run_json(command: list[str], cwd: Path) -> dict[str, Any]:
+        endpoint = command[-1]
+        if endpoint.endswith("/protection"):
+            return {
+                "required_pull_request_reviews": {"url": "https://github.example/reviews"},
+                "required_status_checks": None,
+                "enforce_admins": {"enabled": True},
+            }
+        if endpoint.endswith("/required_pull_request_reviews"):
+            raise RuntimeError("gh: Not Found (HTTP 404)")
+        return {"ok": True}
+
+    monkeypatch.setattr(settler, "_run_json", fake_run_json)
+
+    with pytest.raises(settler.Tier4ApplyError) as exc:
+        settler._preflight_branch_protection_reconcile(repo="owner/repo", cwd=tmp_path)
+
+    assert exc.value.phase == "preflight"
+    assert exc.value.mutation_occurred is False
+    assert "required_pull_request_reviews" in str(exc.value)
+
+
 def test_branch_protection_preflight_blocks_non_admin_invoker(
     monkeypatch: Any, tmp_path: Path
 ) -> None:
@@ -1181,6 +1249,77 @@ def test_branch_protection_preflight_blocks_non_admin_invoker(
     assert exc.value.mutation_occurred is False
     assert exc.value.completed_commands == 0
     assert "lacks admin permission" in str(exc.value)
+
+
+def test_branch_protection_snapshot_records_absent_optional_subresource_404(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    def fake_run_json(command: list[str], cwd: Path) -> dict[str, Any]:
+        endpoint = command[-1]
+        if endpoint.endswith("/protection"):
+            return {
+                "required_pull_request_reviews": None,
+                "required_status_checks": None,
+                "enforce_admins": {"enabled": True},
+            }
+        if endpoint.endswith("/required_pull_request_reviews") or endpoint.endswith(
+            "/required_status_checks"
+        ):
+            raise RuntimeError("gh: Not Found (HTTP 404)")
+        return {"enabled": True}
+
+    monkeypatch.setattr(settler, "_run_json", fake_run_json)
+
+    snapshot = settler._branch_protection_snapshot(repo="owner/repo", cwd=tmp_path)
+
+    assert snapshot["required_pull_request_reviews"] is None
+    assert snapshot["required_status_checks"] is None
+    assert snapshot["enforce_admins"] == {"enabled": True}
+    assert settler._branch_protection_snapshot_errors(snapshot) == []
+
+
+def test_branch_protection_top_level_snapshot_failure_prevents_merge(
+    monkeypatch: Any, tmp_path: Path, capsys: Any
+) -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    commands: list[tuple[list[str], str | None]] = []
+
+    monkeypatch.setattr(
+        settler,
+        "_load_live_inputs",
+        lambda pr, cwd: (
+            _pr_view(head, comments=[_authorized_comment(head)]),
+            _tier4_packet(),
+            _valid_checks(),
+        ),
+    )
+    monkeypatch.setattr(
+        settler,
+        "_preflight_branch_protection_reconcile",
+        lambda repo, cwd: None,
+    )
+    monkeypatch.setattr(
+        settler,
+        "_branch_protection_snapshot",
+        lambda repo, cwd: {"branch_protection": {"snapshot_error": "gh: Not Found (HTTP 404)"}},
+    )
+    monkeypatch.setattr(
+        settler,
+        "_run_command",
+        lambda command, cwd, input_text=None: commands.append((command, input_text)),
+    )
+
+    rc = settler.main(
+        ["--merge-apply", "--pr", "7423", "--head", head, "--cwd", str(tmp_path), "--json"]
+    )
+
+    assert rc == 2
+    assert commands == []
+    payload = settler.json.loads(capsys.readouterr().out)
+    assert payload["phase"] == "branch_protection_snapshot"
+    assert payload["mutation_occurred"] is False
+    assert payload["completed_commands"] == 0
+    assert "branch_protection" in payload["error"]
 
 
 def test_merge_apply_branch_protection_snapshot_failure_prevents_merge(
@@ -1207,6 +1346,11 @@ def test_merge_apply_branch_protection_snapshot_failure_prevents_merge(
         settler,
         "_branch_protection_snapshot",
         lambda repo, cwd: {
+            "branch_protection": {
+                "required_pull_request_reviews": {"url": "https://github.example/reviews"},
+                "required_status_checks": {"url": "https://github.example/checks"},
+                "enforce_admins": {"enabled": True},
+            },
             "required_pull_request_reviews": {"snapshot_error": "gh: Not Found (HTTP 404)"},
             "required_status_checks": {"strict": False, "contexts": ["lint"]},
             "enforce_admins": {"enabled": True},

--- a/tests/scripts/test_settle_tier4_pr.py
+++ b/tests/scripts/test_settle_tier4_pr.py
@@ -1028,6 +1028,7 @@ def test_ambiguous_apply_mode_is_rejected() -> None:
 def test_merge_apply_uses_valid_command_sequence(monkeypatch: Any, tmp_path: Path) -> None:
     head = "57c740022e3c432718462efa12ca79f1df4f674d"
     commands: list[tuple[list[str], str | None]] = []
+    events: list[str] = []
 
     monkeypatch.setattr(
         settler,
@@ -1041,7 +1042,9 @@ def test_merge_apply_uses_valid_command_sequence(monkeypatch: Any, tmp_path: Pat
     monkeypatch.setattr(
         settler,
         "_run_command",
-        lambda command, cwd, input_text=None: commands.append((command, input_text)),
+        lambda command, cwd, input_text=None: (
+            events.append("command") or commands.append((command, input_text))
+        ),
     )
     monkeypatch.setattr(
         settler,
@@ -1053,10 +1056,16 @@ def test_merge_apply_uses_valid_command_sequence(monkeypatch: Any, tmp_path: Pat
         "_branch_protection_snapshot",
         lambda repo, cwd: {},
     )
+    monkeypatch.setattr(
+        settler,
+        "_preflight_branch_protection_reconcile",
+        lambda repo, cwd: events.append("preflight"),
+    )
 
     rc = settler.main(["--merge-apply", "--pr", "7423", "--head", head, "--cwd", str(tmp_path)])
 
     assert rc == 0
+    assert events[0] == "preflight"
     assert commands[0][0] == [
         "gh",
         "pr",
@@ -1069,6 +1078,144 @@ def test_merge_apply_uses_valid_command_sequence(monkeypatch: Any, tmp_path: Pat
     ]
     assert "required_approving_review_count" in str(commands[1][1])
     assert commands[-1][0][-1].endswith("/protection/enforce_admins")
+
+
+def test_merge_apply_branch_protection_preflight_failure_prevents_merge(
+    monkeypatch: Any, tmp_path: Path, capsys: Any
+) -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    commands: list[tuple[list[str], str | None]] = []
+
+    monkeypatch.setattr(
+        settler,
+        "_load_live_inputs",
+        lambda pr, cwd: (
+            _pr_view(head, comments=[_authorized_comment(head)]),
+            _tier4_packet(),
+            _valid_checks(),
+        ),
+    )
+    monkeypatch.setattr(settler, "_current_gh_login", lambda cwd: "admin-user")
+    monkeypatch.setattr(settler, "_login_has_admin_permission", lambda login, repo, cwd: True)
+    monkeypatch.setattr(
+        settler,
+        "_run_json",
+        lambda command, cwd: (_ for _ in ()).throw(RuntimeError("gh: Not Found (HTTP 404)")),
+    )
+    monkeypatch.setattr(
+        settler,
+        "_run_command",
+        lambda command, cwd, input_text=None: commands.append((command, input_text)),
+    )
+
+    rc = settler.main(
+        ["--merge-apply", "--pr", "7423", "--head", head, "--cwd", str(tmp_path), "--json"]
+    )
+
+    assert rc == 2
+    assert commands == []
+    payload = settler.json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["phase"] == "preflight"
+    assert payload["mutation_occurred"] is False
+    assert payload["completed_commands"] == 0
+    assert "Not Found" in payload["error"]
+    assert "verify the active gh identity" in payload["recovery_action"]
+
+
+def test_branch_protection_preflight_reads_all_privileged_endpoints(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    commands: list[list[str]] = []
+
+    monkeypatch.setattr(settler, "_current_gh_login", lambda cwd: "admin-user")
+    monkeypatch.setattr(
+        settler,
+        "_login_has_admin_permission",
+        lambda login, repo, cwd: login == "admin-user",
+    )
+
+    def fake_run_json(command: list[str], cwd: Path) -> dict[str, Any]:
+        commands.append(command)
+        return {"ok": True}
+
+    monkeypatch.setattr(settler, "_run_json", fake_run_json)
+
+    settler._preflight_branch_protection_reconcile(repo="owner/repo", cwd=tmp_path)
+
+    endpoints = [command[-1] for command in commands]
+    assert endpoints == [
+        "repos/owner/repo/branches/main/protection",
+        "repos/owner/repo/branches/main/protection/required_pull_request_reviews",
+        "repos/owner/repo/branches/main/protection/required_status_checks",
+        "repos/owner/repo/branches/main/protection/enforce_admins",
+    ]
+
+
+def test_branch_protection_preflight_blocks_non_admin_invoker(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(settler, "_current_gh_login", lambda cwd: "member-user")
+    monkeypatch.setattr(settler, "_login_has_admin_permission", lambda login, repo, cwd: False)
+    monkeypatch.setattr(
+        settler,
+        "_run_json",
+        lambda command, cwd: pytest.fail("branch-protection endpoints should not be read"),
+    )
+
+    with pytest.raises(settler.Tier4ApplyError) as exc:
+        settler._preflight_branch_protection_reconcile(repo="owner/repo", cwd=tmp_path)
+
+    assert exc.value.phase == "preflight"
+    assert exc.value.mutation_occurred is False
+    assert exc.value.completed_commands == 0
+    assert "lacks admin permission" in str(exc.value)
+
+
+def test_merge_apply_branch_protection_failure_reports_partial_mutation(
+    monkeypatch: Any, tmp_path: Path, capsys: Any
+) -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    commands: list[tuple[list[str], str | None]] = []
+
+    monkeypatch.setattr(
+        settler,
+        "_load_live_inputs",
+        lambda pr, cwd: (
+            _pr_view(head, comments=[_authorized_comment(head)]),
+            _tier4_packet(),
+            _valid_checks(),
+        ),
+    )
+    monkeypatch.setattr(
+        settler,
+        "_preflight_branch_protection_reconcile",
+        lambda repo, cwd: None,
+    )
+    monkeypatch.setattr(
+        settler,
+        "_branch_protection_snapshot",
+        lambda repo, cwd: {},
+    )
+
+    def fake_run_command(command: list[str], cwd: Path, input_text: str | None = None) -> None:
+        commands.append((command, input_text))
+        if "required_pull_request_reviews" in " ".join(command):
+            raise subprocess.CalledProcessError(1, command, stderr="Not Found")
+
+    monkeypatch.setattr(settler, "_run_command", fake_run_command)
+
+    rc = settler.main(
+        ["--merge-apply", "--pr", "7423", "--head", head, "--cwd", str(tmp_path), "--json"]
+    )
+
+    assert rc == 2
+    assert commands[0][0][:3] == ["gh", "pr", "merge"]
+    payload = settler.json.loads(capsys.readouterr().out)
+    assert payload["phase"] == "branch_protection_restore"
+    assert payload["mutation_occurred"] is True
+    assert payload["completed_commands"] == 1
+    assert "inspect PR state and branch protection" in payload["recovery_action"]
 
 
 def test_merge_apply_refuses_stale_failed_required_rollup_before_merge(
@@ -1215,6 +1362,11 @@ def test_merge_apply_skips_required_status_check_patch_when_quorum_already_requi
         settler,
         "_branch_protection_snapshot",
         lambda repo, cwd: {},
+    )
+    monkeypatch.setattr(
+        settler,
+        "_preflight_branch_protection_reconcile",
+        lambda repo, cwd: None,
     )
 
     rc = settler.main(["--merge-apply", "--pr", "7423", "--head", head, "--cwd", str(tmp_path)])

--- a/tests/scripts/test_settle_tier4_pr.py
+++ b/tests/scripts/test_settle_tier4_pr.py
@@ -1232,6 +1232,58 @@ def test_merge_apply_branch_protection_snapshot_failure_prevents_merge(
     assert "before any merge mutation" in payload["recovery_action"]
 
 
+def test_merge_apply_merge_command_failure_reports_possible_mutation(
+    monkeypatch: Any, tmp_path: Path, capsys: Any
+) -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    commands: list[tuple[list[str], str | None]] = []
+
+    monkeypatch.setattr(
+        settler,
+        "_load_live_inputs",
+        lambda pr, cwd: (
+            _pr_view(head, comments=[_authorized_comment(head)]),
+            _tier4_packet(),
+            _valid_checks(),
+        ),
+    )
+    monkeypatch.setattr(
+        settler,
+        "_preflight_branch_protection_reconcile",
+        lambda repo, cwd: None,
+    )
+    monkeypatch.setattr(
+        settler,
+        "_branch_protection_snapshot",
+        lambda repo, cwd: _valid_branch_protection_snapshot(),
+    )
+    monkeypatch.setattr(
+        settler,
+        "_restore_branch_protection",
+        lambda repo, cwd, snapshot: ["restore skipped in test"],
+    )
+
+    def fake_run_command(command: list[str], cwd: Path, input_text: str | None = None) -> None:
+        commands.append((command, input_text))
+        if command[:3] == ["gh", "pr", "merge"]:
+            raise subprocess.CalledProcessError(1, command, stderr="transport lost")
+
+    monkeypatch.setattr(settler, "_run_command", fake_run_command)
+
+    rc = settler.main(
+        ["--merge-apply", "--pr", "7423", "--head", head, "--cwd", str(tmp_path), "--json"]
+    )
+
+    assert rc == 2
+    assert commands[0][0][:3] == ["gh", "pr", "merge"]
+    payload = settler.json.loads(capsys.readouterr().out)
+    assert payload["phase"] == "merge"
+    assert payload["mutation_occurred"] is True
+    assert payload["completed_commands"] == 0
+    assert "merge_invoked=True" in payload["error"]
+    assert "inspect PR state and branch protection" in payload["recovery_action"]
+
+
 def test_merge_apply_branch_protection_failure_reports_partial_mutation(
     monkeypatch: Any, tmp_path: Path, capsys: Any
 ) -> None:


### PR DESCRIPTION
## Summary
- preflight active gh admin permission and branch-protection read access before Tier 4 `--merge-apply` can run a merge mutation
- fail closed before merge when branch-protection reconcile would be inaccessible
- return structured JSON diagnostics for preflight and partial post-merge branch-protection failures

## Context
This is a bounded repair for the #8290 helper failure shape: the helper merged the exact head, then returned `ok=false` after a branch-protection PATCH 404. This patch prevents the no-mutation case from reaching the merge command when privileged branch-protection access is not available, while preserving existing exact-head, model-quorum, settlement creator-pin, and OWNER/admin authorization gates.

## Validation
- `python3 -m pytest tests/scripts/test_settle_tier4_pr.py` — 47 passed
- `pre-commit run --files scripts/settle_tier4_pr.py tests/scripts/test_settle_tier4_pr.py` — passed
- pre-push hook — passed, including mypy

Draft only. Do not merge without the normal Tier-4 settlement path.
