### PR TITLE
feat(swarm): raise SwarmCommander parallelism defaults ~1.8-2x (driving function)

### DIFF
--- a/aragora/swarm/config.py
+++ b/aragora/swarm/config.py
@@ -132,7 +132,12 @@ class SwarmCommanderConfig:
     """Configuration for the SwarmCommander."""
 
     interrogator: InterrogatorConfig = field(default_factory=InterrogatorConfig)
-    budget_limit_usd: float | None = 50.0
+    # Parallelism/throughput defaults raised ~1.8-2x (2026-06-14): the swarm is a
+    # *driving function* for more concurrent lanes/agents, not a throttle. Budget
+    # scales with the parallelism so it does not become the new bottleneck. The
+    # exact-head merge gate + lease coordination remain the safety layer, so wider
+    # fan-out does not relax any settlement guarantee.
+    budget_limit_usd: float | None = 90.0
     require_approval: bool = False
     use_worktree_isolation: bool = True
     enable_meta_planning: bool = True
@@ -140,10 +145,10 @@ class SwarmCommanderConfig:
     enable_mode_enforcement: bool = True
     generate_receipts: bool = True
     spectate_stream: bool = True
-    max_parallel_tasks: int = 20
-    max_cycles: int = 5
-    max_subtasks: int = 15
-    max_parallel_branches: int = 16
+    max_parallel_tasks: int = 40
+    max_cycles: int = 9
+    max_subtasks: int = 28
+    max_parallel_branches: int = 32
     iterative_mode: bool = True
     user_profile: UserProfile = UserProfile.CEO
 

--- a/tests/swarm/test_commander.py
+++ b/tests/swarm/test_commander.py
@@ -486,11 +486,11 @@ class TestSwarmCommanderConfig:
 
     def test_default_budget(self):
         config = SwarmCommanderConfig()
-        assert config.budget_limit_usd == 50.0
+        assert config.budget_limit_usd == 90.0
 
     def test_default_max_parallel(self):
         config = SwarmCommanderConfig()
-        assert config.max_parallel_tasks == 20
+        assert config.max_parallel_tasks == 40
 
     def test_iterative_mode_default(self):
         config = SwarmCommanderConfig()


### PR DESCRIPTION
## What

Treats the swarm as a **driving function for more parallelism**, not a throttle. Raises the `SwarmCommanderConfig` throughput defaults ~1.8-2x:

| Knob | Before | After | × |
|---|---|---|---|
| `max_parallel_tasks` | 20 | **40** | 2.0 |
| `max_parallel_branches` | 16 | **32** | 2.0 |
| `max_subtasks` | 15 | **28** | ~1.9 |
| `max_cycles` | 5 | **9** | 1.8 |
| `budget_limit_usd` | 50.0 | **90.0** | 1.8 |

Budget is scaled with the parallelism so it doesn't become the *new* bottleneck under doubled fan-out. The exact-head merge gate + lease-based worker coordination remain the safety layer — **wider fan-out relaxes no settlement guarantee** (more agents do more *work*; merge authority is unchanged).

Updated the two default-value assertions in `tests/swarm/test_commander.py` (`test_default_budget` → 90.0, `test_default_max_parallel` → 40) to match the new defaults.

## Verification

- `SwarmCommanderConfig()` imports and reports the new defaults (`tasks 40 / branches 32 / subtasks 28 / cycles 9 / budget 90`).
- `ruff check` + `ruff format --check` clean.
- The `tests/swarm/test_commander.py` module needs the full swarm import stack (commander → reconciler → supervisor) to execute, which isn't available in the cloud sandbox — CI runs it in the full stack. The two assertion updates are correct-by-construction against the new defaults.

## Deliberately NOT changed here (left to the operator)

The **real fleet lane count** — boss-loop `configured_max_parallel_dispatches` — defaults to `1` but is **pinned to `1` by ~8 tests in `test_boss_loop.py`** and is set operationally via launch args (the CLI already defaults `--boss-max-parallel-dispatches` to **3**, and `tranche_queue` `max_parallel_lanes` is operator-supplied). So raising real lane concurrency is a **launch/launchd-arg change**, not a code-default change — doing it in code would break the pinned tests without changing how the daemon actually launches.

**Recommended operator follow-ups (the paired bottleneck):** raise `--boss-max-parallel-dispatches` / `--max-parallel-lanes` in the boss-loop launchd args, **and** add GraphQL capacity (App token / second identity / REST fallbacks) so the wider fan-out doesn't starve the shared token — the chronic `graphql remaining=0` is the current ceiling on throughput.

Part of the ongoing bottleneck-removal work for higher-throughput autonomous orchestration.

---
_Generated by [Claude Code](https://claude.ai/code/session_018jfJj5gb9VoLs6VBMnzhrP)_