### PR TITLE
fix(settle-one): add REST required-check fallback

### DIFF
--- a/scripts/settle_one_pr.py
+++ b/scripts/settle_one_pr.py
@@ -1040,6 +1040,61 @@ def required_check_source_report(
     return {"status": status, "blockers": blockers, "suggestions": suggestions}
 
 
+def _required_check_source_fallback_from_entry(
+    entry: dict[str, Any],
+    check_report: dict[str, Any],
+    protection_cmd: dict[str, Any],
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """Recover required check metadata from merge-packet's exact-head gate.
+
+    This fallback is intentionally narrow: it only activates after the live
+    required checks surface is green, and only when merge-packet already carried
+    branch-protection required check metadata plus an exact-head check-run gate
+    proving those contexts are satisfied.
+    """
+    if check_report.get("status") != "pass":
+        return None, None
+    check_surfaces = entry.get("check_surfaces")
+    if not isinstance(check_surfaces, dict):
+        return None, None
+    direct = check_surfaces.get("direct_commit_check_runs")
+    if not isinstance(direct, dict):
+        return None, None
+    if not bool(direct.get("required_contexts_satisfied")):
+        return None, None
+    non_success = direct.get("non_success_required_contexts") or []
+    if isinstance(non_success, list) and non_success:
+        return None, None
+    required_checks = direct.get("required_checks")
+    if not isinstance(required_checks, list) or not required_checks:
+        return None, None
+
+    checks: list[dict[str, Any]] = []
+    for item in required_checks:
+        if not isinstance(item, dict):
+            continue
+        context = str(item.get("context") or item.get("name") or "").strip()
+        if not context:
+            continue
+        checks.append({"context": context, "app_id": item.get("app_id")})
+    if not checks:
+        return None, None
+
+    reason = (
+        protection_cmd.get("stderr")
+        or protection_cmd.get("json_error")
+        or protection_cmd.get("stdout")
+        or "branch protection required_status_checks unavailable"
+    )
+    diagnostic = {
+        "used": True,
+        "source": "merge_packet_direct_commit_check_runs.required_checks",
+        "reason": str(reason),
+        "contexts": [str(item["context"]) for item in checks],
+    }
+    return {"checks": checks, "source": diagnostic["source"]}, diagnostic
+
+
 def validation_report(
     entry: dict[str, Any], *, cwd: Path, run_validation: bool
 ) -> list[dict[str, Any]]:
@@ -1116,7 +1171,132 @@ def load_pr_policy_metadata(
     )
     if isinstance(payload, dict):
         return payload, command
+    rest_payload, rest_command = load_pr_policy_metadata_rest(cwd, pr_number, repo=repo)
+    if rest_payload:
+        rest_command["primary_command"] = command
+        rest_command["fallback_reason"] = (
+            command.get("stderr")
+            or command.get("json_error")
+            or command.get("stdout")
+            or "gh pr view policy metadata unavailable"
+        )
+        return rest_payload, rest_command
     return {}, command
+
+
+def _rest_mergeable(value: Any) -> str:
+    if value is True:
+        return "MERGEABLE"
+    if value is False:
+        return "CONFLICTING"
+    return ""
+
+
+def _rest_merge_state(value: Any) -> str:
+    state = str(value or "").upper()
+    if state == "UNKNOWN":
+        return ""
+    return state
+
+
+def _rest_file_item(item: Any) -> dict[str, Any] | None:
+    if not isinstance(item, dict):
+        return None
+    filename = str(item.get("filename") or item.get("path") or "").strip()
+    if not filename:
+        return None
+    return {
+        "path": filename,
+        "additions": item.get("additions"),
+        "deletions": item.get("deletions"),
+        "changeType": item.get("status") or item.get("changeType"),
+    }
+
+
+def load_pr_policy_metadata_rest(
+    cwd: Path, pr_number: int, *, repo: str | None = None
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Load the policy metadata subset through REST when GraphQL is unavailable."""
+    pull_payload, pull_cmd = _run_json(
+        _with_repo(["gh", "api", f"repos/{{owner}}/{{repo}}/pulls/{pr_number}"], repo),
+        cwd=cwd,
+        timeout=GH_METADATA_TIMEOUT_SECONDS,
+    )
+    if not isinstance(pull_payload, dict):
+        return (
+            {},
+            {
+                "command": f"REST fallback: gh api repos/{{owner}}/{{repo}}/pulls/{pr_number}",
+                "returncode": 1,
+                "stdout": "",
+                "stderr": str(
+                    pull_cmd.get("stderr")
+                    or pull_cmd.get("json_error")
+                    or pull_cmd.get("stdout")
+                    or "pull REST metadata unavailable"
+                ),
+                "rest_fallback": True,
+                "pull_command": pull_cmd,
+            },
+        )
+    files_payload, files_cmd = _run_json(
+        _with_repo(
+            [
+                "gh",
+                "api",
+                f"repos/{{owner}}/{{repo}}/pulls/{pr_number}/files",
+                "--paginate",
+            ],
+            repo,
+        ),
+        cwd=cwd,
+        timeout=GH_METADATA_TIMEOUT_SECONDS,
+    )
+    command: dict[str, Any] = {
+        "command": (
+            f"REST fallback: gh api repos/{{owner}}/{{repo}}/pulls/{pr_number}; "
+            f"gh api repos/{{owner}}/{{repo}}/pulls/{pr_number}/files --paginate"
+        ),
+        "returncode": 0
+        if isinstance(pull_payload, dict) and isinstance(files_payload, list)
+        else 1,
+        "stdout": "",
+        "stderr": "",
+        "rest_fallback": True,
+        "pull_command": pull_cmd,
+        "files_command": files_cmd,
+    }
+    if not isinstance(files_payload, list):
+        command["stderr"] = str(
+            files_cmd.get("stderr")
+            or files_cmd.get("json_error")
+            or files_cmd.get("stdout")
+            or "pull files REST metadata unavailable"
+        )
+        return {}, command
+
+    head = pull_payload.get("head") if isinstance(pull_payload.get("head"), dict) else {}
+    user = pull_payload.get("user") if isinstance(pull_payload.get("user"), dict) else {}
+    files = [file for item in files_payload if (file := _rest_file_item(item)) is not None]
+    metadata = {
+        "number": _coerce_int(pull_payload.get("number")) or pr_number,
+        "title": pull_payload.get("title"),
+        "headRefName": head.get("ref") if isinstance(head, dict) else "",
+        "author": {"login": user.get("login")} if isinstance(user, dict) else {},
+        "mergeable": _rest_mergeable(pull_payload.get("mergeable")),
+        "mergeStateStatus": _rest_merge_state(pull_payload.get("mergeable_state")),
+        "files": files,
+        "metadata_source": "rest_pull_files",
+    }
+    command["stdout"] = json.dumps(
+        {
+            "metadata_source": "rest_pull_files",
+            "number": metadata["number"],
+            "file_count": len(files),
+        },
+        sort_keys=True,
+    )
+    return metadata, command
 
 
 def _has_policy_file_scope(metadata: dict[str, Any]) -> bool:
@@ -1573,7 +1753,23 @@ def build_report(
         blockers.extend(check_report["blockers"])
         report["suggested_commands"].extend(check_report["suggestions"])
 
-        source_report = required_check_source_report(protection, pr_view, check_runs_payload)
+        required_source_fallback: dict[str, Any] | None = None
+        protection_for_source = protection
+        if not isinstance(protection_for_source, dict):
+            protection_for_source, required_source_fallback = (
+                _required_check_source_fallback_from_entry(
+                    selected,
+                    check_report,
+                    protection_cmd,
+                )
+            )
+        source_report = required_check_source_report(
+            protection_for_source, pr_view, check_runs_payload
+        )
+        if required_source_fallback is not None:
+            source_report["source"] = required_source_fallback["source"]
+            source_report["fallback_reason"] = required_source_fallback["reason"]
+            report["checks"]["required_source_fallback"] = required_source_fallback
         report["checks"]["required_sources"] = source_report
         blockers.extend(source_report["blockers"])
         report["suggested_commands"].extend(source_report.get("suggestions") or [])

--- a/tests/scripts/test_settle_one_pr.py
+++ b/tests/scripts/test_settle_one_pr.py
@@ -1261,6 +1261,8 @@ def test_lazy_policy_metadata_continues_past_failed_pr_view(monkeypatch) -> None
             return {"message_count": 0}, {"command": "mailbox", "returncode": 0}
         if args[:3] == ["gh", "pr", "view"] and args[3] == "7451":
             return None, {"command": "policy-view-7451", "returncode": 1, "stderr": "timeout"}
+        if args[:2] == ["gh", "api"] and args[2] == "repos/{owner}/{repo}/pulls/7451":
+            return None, {"command": "pull-rest-7451", "returncode": 404, "stderr": "not found"}
         if (
             args[:3] == ["gh", "pr", "view"]
             and args[3] == "7452"
@@ -1451,6 +1453,60 @@ def test_explicit_pr_reuses_preloaded_policy_file_scope(monkeypatch) -> None:
     assert report["policy_exclusions"] == []
 
 
+def test_pr_policy_metadata_uses_rest_fallback_when_graphql_unavailable(monkeypatch) -> None:
+    def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
+        del cwd, timeout
+        if args[:3] == ["gh", "pr", "view"] and args[3] == "7451":
+            return None, {
+                "command": "policy-view-7451",
+                "returncode": 1,
+                "stderr": "GraphQL: API rate limit already exceeded",
+            }
+        if args[:2] == ["gh", "api"] and args[2] == "repos/{owner}/{repo}/pulls/7451":
+            return (
+                {
+                    "number": 7451,
+                    "title": "docs: candidate",
+                    "head": {"ref": "codex/docs-candidate"},
+                    "user": {"login": "alice"},
+                    "mergeable": True,
+                    "mergeable_state": "clean",
+                },
+                {"command": "pull-rest", "returncode": 0},
+            )
+        if args[:2] == ["gh", "api"] and args[2] == "repos/{owner}/{repo}/pulls/7451/files":
+            return (
+                [{"filename": "docs/status/example.md", "additions": 2, "deletions": 1}],
+                {"command": "files-rest", "returncode": 0},
+            )
+        raise AssertionError(args)
+
+    monkeypatch.setattr(settle_one_pr, "_run_json", fake_run_json)
+
+    metadata, command = settle_one_pr.load_pr_policy_metadata(Path.cwd(), 7451)
+
+    assert metadata == {
+        "number": 7451,
+        "title": "docs: candidate",
+        "headRefName": "codex/docs-candidate",
+        "author": {"login": "alice"},
+        "mergeable": "MERGEABLE",
+        "mergeStateStatus": "CLEAN",
+        "files": [
+            {
+                "path": "docs/status/example.md",
+                "additions": 2,
+                "deletions": 1,
+                "changeType": None,
+            }
+        ],
+        "metadata_source": "rest_pull_files",
+    }
+    assert command["rest_fallback"] is True
+    assert command["primary_command"]["returncode"] == 1
+    assert command["fallback_reason"] == "GraphQL: API rate limit already exceeded"
+
+
 def test_build_report_fails_closed_when_selected_policy_metadata_unavailable(
     monkeypatch,
 ) -> None:
@@ -1471,6 +1527,8 @@ def test_build_report_fails_closed_when_selected_policy_metadata_unavailable(
             return {"lanes": []}, {"command": "snapshot", "returncode": 0}
         if args[:3] == ["gh", "pr", "view"] and args[3] == "7451":
             return None, {"command": "policy-view", "returncode": 1, "stderr": "timeout"}
+        if args[:2] == ["gh", "api"] and args[2] == "repos/{owner}/{repo}/pulls/7451":
+            return None, {"command": "pull-rest", "returncode": 404, "stderr": "not found"}
         raise AssertionError(args)
 
     monkeypatch.setattr(settle_one_pr, "_run_json", fake_run_json)
@@ -2002,6 +2060,218 @@ def test_build_report_fails_closed_when_required_check_sources_unreadable(monkey
 
     assert report["status"] == "blocked"
     assert "branch protection required_status_checks JSON unavailable" in report["blockers"]
+
+
+def test_build_report_uses_packet_required_check_metadata_when_app_token_cannot_read_protection(
+    monkeypatch,
+) -> None:
+    commands: list[list[str]] = []
+
+    def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
+        del cwd, timeout
+        commands.append(args)
+        if args[:3] == ["gh", "pr", "list"]:
+            return [], {"command": "metadata", "returncode": 0}
+        if args[:3] == OPERATOR_SNAPSHOT_PREFIX:
+            return {"lanes": []}, {"command": "snapshot", "returncode": 0}
+        if args[:3] == OWNER_PREFIX:
+            return {"status": "completed"}, {"command": "owner", "returncode": 0}
+        if args[:3] == STEERING_PREFIX:
+            return {"message_count": 0}, {"command": "mailbox", "returncode": 0}
+        if (
+            args[:3] == ["gh", "pr", "view"]
+            and args[3] == "8372"
+            and args[5] == settle_one_pr.PR_POLICY_FIELDS
+        ):
+            return (
+                {
+                    "number": 8372,
+                    "title": "docs: ODR mission",
+                    "headRefName": "claude/odr-completion-mission",
+                    "mergeable": "MERGEABLE",
+                    "mergeStateStatus": "CLEAN",
+                    "files": [{"path": "docs/superpowers/plans/odr.md"}],
+                },
+                {"command": "policy-view", "returncode": 0},
+            )
+        if (
+            args[:3] == ["gh", "pr", "view"]
+            and args[3] == "8372"
+            and "statusCheckRollup" in args[5]
+        ):
+            return (
+                {
+                    "headRefOid": "0000000000000000000000000000000000008372",
+                    "baseRefName": "main",
+                    "isDraft": False,
+                    "mergeable": "MERGEABLE",
+                    "mergeStateStatus": "CLEAN",
+                    "statusCheckRollup": [],
+                },
+                {"command": "view", "returncode": 0},
+            )
+        if args[:2] == ["gh", "api"] and args[2].endswith("/required_status_checks"):
+            return None, {
+                "command": "protection",
+                "returncode": 403,
+                "stderr": "Resource not accessible by integration",
+            }
+        if args[:2] == ["gh", "api"] and args[2].endswith("/check-runs?per_page=100"):
+            return (
+                {
+                    "check_runs": [
+                        {
+                            "name": "aragora-merge-quorum",
+                            "conclusion": "success",
+                            "app": {"id": 15368},
+                        }
+                    ]
+                },
+                {"command": "check-runs", "returncode": 0},
+            )
+        if args[:3] == ["gh", "pr", "checks"]:
+            return (
+                [{"name": "aragora-merge-quorum", "state": "SUCCESS"}],
+                {"command": "checks", "returncode": 0},
+            )
+        raise AssertionError(args)
+
+    monkeypatch.setattr(settle_one_pr, "_run_json", fake_run_json)
+
+    entry = _entry(
+        8372,
+        status="satisfied",
+        verdict="admin_squash_allowed",
+        admin_squash_allowed=True,
+        reasons=["bounded internal code surface"],
+    )
+    entry["check_surfaces"] = {
+        "direct_commit_check_runs": {
+            "required_contexts_satisfied": True,
+            "non_success_required_contexts": [],
+            "required_checks": [{"context": "aragora-merge-quorum", "app_id": 15368}],
+        }
+    }
+    report = build_report(
+        _packet(entry, admin_order=[8372]),
+        cwd=Path.cwd(),
+        state_root=Path.cwd(),
+        explicit_pr=8372,
+        exclude_prs=set(),
+        live=True,
+        validate=False,
+    )
+
+    assert report["status"] == "packet_authorized_dry_run"
+    assert report["blockers"] == []
+    assert report["checks"]["required_source_fallback"] == {
+        "used": True,
+        "source": "merge_packet_direct_commit_check_runs.required_checks",
+        "reason": "Resource not accessible by integration",
+        "contexts": ["aragora-merge-quorum"],
+    }
+    assert report["checks"]["required_sources"]["source"] == (
+        "merge_packet_direct_commit_check_runs.required_checks"
+    )
+    assert any(
+        cmd[:2] == ["gh", "api"] and cmd[2].endswith("/required_status_checks") for cmd in commands
+    )
+
+
+def test_build_report_still_fails_closed_when_required_contexts_are_unknown(monkeypatch) -> None:
+    def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
+        del cwd, timeout
+        if args[:3] == ["gh", "pr", "list"]:
+            return [], {"command": "metadata", "returncode": 0}
+        if args[:3] == OPERATOR_SNAPSHOT_PREFIX:
+            return {"lanes": []}, {"command": "snapshot", "returncode": 0}
+        if args[:3] == OWNER_PREFIX:
+            return {"status": "completed"}, {"command": "owner", "returncode": 0}
+        if args[:3] == STEERING_PREFIX:
+            return {"message_count": 0}, {"command": "mailbox", "returncode": 0}
+        if (
+            args[:3] == ["gh", "pr", "view"]
+            and args[3] == "8373"
+            and args[5] == settle_one_pr.PR_POLICY_FIELDS
+        ):
+            return (
+                {
+                    "number": 8373,
+                    "title": "docs: unknown required contexts",
+                    "headRefName": "codex/docs",
+                    "mergeable": "MERGEABLE",
+                    "mergeStateStatus": "CLEAN",
+                    "files": [{"path": "docs/status/example.md"}],
+                },
+                {"command": "policy-view", "returncode": 0},
+            )
+        if (
+            args[:3] == ["gh", "pr", "view"]
+            and args[3] == "8373"
+            and "statusCheckRollup" in args[5]
+        ):
+            return (
+                {
+                    "headRefOid": "0000000000000000000000000000000000008373",
+                    "baseRefName": "main",
+                    "isDraft": False,
+                    "mergeable": "MERGEABLE",
+                    "mergeStateStatus": "CLEAN",
+                    "statusCheckRollup": [],
+                },
+                {"command": "view", "returncode": 0},
+            )
+        if args[:2] == ["gh", "api"] and args[2].endswith("/required_status_checks"):
+            return None, {"command": "protection", "returncode": 403}
+        if args[:2] == ["gh", "api"] and args[2].endswith("/check-runs?per_page=100"):
+            return (
+                {
+                    "check_runs": [
+                        {
+                            "name": "aragora-merge-quorum",
+                            "conclusion": "success",
+                            "app": {"id": 15368},
+                        }
+                    ]
+                },
+                {"command": "check-runs", "returncode": 0},
+            )
+        if args[:3] == ["gh", "pr", "checks"]:
+            return (
+                [{"name": "aragora-merge-quorum", "state": "SUCCESS"}],
+                {"command": "checks", "returncode": 0},
+            )
+        raise AssertionError(args)
+
+    monkeypatch.setattr(settle_one_pr, "_run_json", fake_run_json)
+
+    entry = _entry(
+        8373,
+        status="satisfied",
+        verdict="admin_squash_allowed",
+        admin_squash_allowed=True,
+        reasons=["bounded internal code surface"],
+    )
+    entry["check_surfaces"] = {
+        "direct_commit_check_runs": {
+            "required_contexts_satisfied": True,
+            "non_success_required_contexts": [],
+            "required_checks": [],
+        }
+    }
+    report = build_report(
+        _packet(entry, admin_order=[8373]),
+        cwd=Path.cwd(),
+        state_root=Path.cwd(),
+        explicit_pr=8373,
+        exclude_prs=set(),
+        live=True,
+        validate=False,
+    )
+
+    assert report["status"] == "blocked"
+    assert "branch protection required_status_checks JSON unavailable" in report["blockers"]
+    assert "required_source_fallback" not in report["checks"]
 
 
 def test_recursive_prompt_always_contains_convergence_sentence() -> None:


### PR DESCRIPTION
## Summary

- Add a REST fallback for `scripts/settle_one_pr.py` selected-candidate policy metadata when `gh pr view` GraphQL is unavailable.
- Allow `settle_one_pr.py` to verify required-check source metadata from merge-packet's exact-head `direct_commit_check_runs.required_checks` only when live required checks are green and branch-protection `required_status_checks` is unavailable.
- Preserve fail-closed behavior when required contexts cannot be established by any supported source.

## Reproduction Context

#8372 exposed the failure shape before it was merged:

- Local PAT GraphQL was exhausted, so normal `gh pr view` metadata failed.
- GitHub App token could read PR/check GraphQL and selected #8372, but branch-protection `required_status_checks` returned `HTTP 403 Resource not accessible by integration`.
- Normal REST could read `repos/synaptent/aragora/branches/main/protection/required_status_checks` and returned the required contexts: `lint`, `typecheck`, `sdk-parity`, `Generate & Validate`, `TypeScript SDK Type Check`, and `aragora-merge-quorum`.
- Exact-head required check-runs for #8372 at `9b8876be4678d50fedf468218f353848058f4c4c` were green after the evidence-triggered quorum rerun.

#8372 has since merged as `fbf0b247e451c4f4bc4451b51c4ee5176ec49db0`, so this PR preserves the issue as regression coverage rather than continuing to operate on #8372.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_settle_one_pr.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/settle_one_pr.py tests/scripts/test_settle_one_pr.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/settle_one_pr.py tests/scripts/test_settle_one_pr.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
