### PR TITLE
[codex] fix review-queue quorum-only required check fallback

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -1883,6 +1883,19 @@ def _effective_required_pr_check_count(
     )
 
 
+def _effective_required_pr_checks(
+    checks: list[dict[str, Any]], *, ignore_quorum_check: bool = False
+) -> list[dict[str, Any]]:
+    """Return required PR checks after excluding current/self quorum rows."""
+    return [
+        check
+        for check in checks
+        if isinstance(check, dict)
+        and not _is_required_pr_check_current_merge_quorum_self_check(check)
+        and not (ignore_quorum_check and _is_merge_quorum_check(check))
+    ]
+
+
 def _status_check_display_name(check: dict[str, Any]) -> str:
     workflow = str(check.get("workflowName") or check.get("workflow") or "").strip()
     name = str(check.get("name") or check.get("context") or "").strip()
@@ -2522,6 +2535,26 @@ def _build_packet(
             if ignore_own_quorum_check
             else 0
         )
+        effective_required_checks = _effective_required_pr_checks(
+            required_pr_checks, ignore_quorum_check=ignore_own_quorum_check
+        )
+        required_failing_or_cancelled_checks = [
+            check
+            for check in effective_required_checks
+            if _required_pr_check_bucket(check) in {"fail", "cancel"}
+        ]
+        required_pending_checks = [
+            check
+            for check in effective_required_checks
+            if _required_pr_check_bucket(check) == "pending"
+        ]
+        required_quorum_only_failure = (
+            required_available
+            and effective_required_count > 0
+            and bool(required_failing_or_cancelled_checks)
+            and not required_pending_checks
+            and all(_is_merge_quorum_check(check) for check in required_failing_or_cancelled_checks)
+        )
         # _rollup_non_green_diagnostics reports the raw GitHub rollup counts/sample
         # and is intentionally not filtered by ignore_own_quorum_check. The flag's
         # effect on the rollup is limited to the summary text computed above; the
@@ -2567,18 +2600,12 @@ def _build_packet(
             "gate_blocked_reason": gate_blocked_reason,
             "failing_or_cancelled": [
                 str(check.get("name") or "").strip()
-                for check in required_pr_checks
-                if _required_pr_check_bucket(check) in {"fail", "cancel"}
-                and not _is_required_pr_check_current_merge_quorum_self_check(check)
-                and not (ignore_own_quorum_check and _is_merge_quorum_check(check))
+                for check in required_failing_or_cancelled_checks
             ][:CHECK_SURFACE_DIAGNOSTIC_LIMIT],
-            "pending": [
-                str(check.get("name") or "").strip()
-                for check in required_pr_checks
-                if _required_pr_check_bucket(check) == "pending"
-                and not _is_required_pr_check_current_merge_quorum_self_check(check)
-                and not (ignore_own_quorum_check and _is_merge_quorum_check(check))
-            ][:CHECK_SURFACE_DIAGNOSTIC_LIMIT],
+            "pending": [str(check.get("name") or "").strip() for check in required_pending_checks][
+                :CHECK_SURFACE_DIAGNOSTIC_LIMIT
+            ],
+            "quorum_only_failure": required_quorum_only_failure,
         }
         if required_surface.get("error"):
             check_surfaces["required_pr_checks"]["error"] = str(required_surface.get("error"))
@@ -2612,6 +2639,26 @@ def _build_packet(
             check_surfaces["remediation_prompt"] = (
                 "Continue gating on branch-protection required checks; keep "
                 "non-required shadow/advisory check failures visible but non-blocking."
+            )
+        elif required_quorum_only_failure:
+            check_surfaces["required_pr_checks"]["gate_selected"] = True
+            check_surfaces["required_pr_checks"]["gate_blocked_reason"] = ""
+            checks_summary = f"{required_summary} (required PR checks; only merge-quorum failing)"
+            has_pending = False
+            checks_unavailable = False
+            check_surfaces["effective_gate"] = {
+                "source": "required_pr_checks",
+                "summary": checks_summary,
+            }
+            check_surfaces["diagnosis"] = (
+                "The PR check rollup includes non-required non-green checks, "
+                "and GitHub reports every non-quorum branch-protection required "
+                "check green; merge-packet leaves aragora-merge-quorum to the "
+                "model quorum evidence gate."
+            )
+            check_surfaces["remediation_prompt"] = (
+                "Collect missing model quorum evidence or rerun aragora-merge-quorum "
+                "after evidence is counted; keep non-required rollup failures advisory."
             )
         elif gate_blocked_reason:
             check_surfaces["diagnosis"] = (
@@ -3076,6 +3123,19 @@ def _build_model_review_quorum(
     quorum_satisfied = (
         signal_count >= requirement["required_model_signals"] and has_required_dogfood
     )
+    required_pr_check_surface = (
+        check_surfaces.get("required_pr_checks") if isinstance(check_surfaces, dict) else {}
+    )
+    quorum_only_required_failure = bool(
+        isinstance(required_pr_check_surface, dict)
+        and required_pr_check_surface.get("quorum_only_failure")
+    )
+    missing_quorum_is_active_check_blocker = (
+        quorum_only_required_failure and not quorum_satisfied and not settlement_recorded
+    )
+    stale_quorum_check_after_satisfied_evidence = (
+        quorum_only_required_failure and quorum_satisfied and not settlement_recorded
+    )
     requires_human_preapproval = bool(requirement["requires_human_preapproval"])
     human_preapproval_recorded = (
         requires_human_preapproval
@@ -3107,8 +3167,12 @@ def _build_model_review_quorum(
         reasons.append(str(settlement_creator_pin["reason"]))
     elif human_risk_settlement_recorded:
         reasons.append("exact-head human risk settlement receipt recorded")
-    if has_failures and not settlement_recorded:
+    if has_failures and not settlement_recorded and not missing_quorum_is_active_check_blocker:
         reasons.append("checks are failing; repair before settlement")
+    elif missing_quorum_is_active_check_blocker:
+        reasons.append(
+            "required aragora-merge-quorum is failing because model quorum is incomplete"
+        )
     if checks_unavailable and not settlement_recorded:
         reasons.append("checks are unavailable; wait for GitHub check rollup before settlement")
         if isinstance(check_surfaces, dict) and (
@@ -3139,10 +3203,11 @@ def _build_model_review_quorum(
         verdict = "already_merged_settlement_recorded"
         requires_human_risk_settlement = False
     elif (
-        has_failures
+        (has_failures and not missing_quorum_is_active_check_blocker)
         or has_pending
         or checks_unavailable
-        or machine_recommendation == "repair_first"
+        or (machine_recommendation == "repair_first" and not missing_quorum_is_active_check_blocker)
+        or stale_quorum_check_after_satisfied_evidence
         or blocking_workflow_state
     ):
         status = "repair_or_wait"

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -3668,9 +3668,15 @@ class TestBuildQueueAndPacket:
         monkeypatch.setattr("aragora.cli.commands.review_queue._gh_json", fake_gh_json)
 
         packet = _build_packet("7465", repo_override=None)
+        required = packet.check_surfaces["required_pr_checks"]
         rollup = packet.check_surfaces["pr_rollup"]
 
-        assert "effective_gate" not in packet.check_surfaces
+        assert packet.check_surfaces["effective_gate"] == {
+            "source": "required_pr_checks",
+            "summary": "1 failing / 2 required (required PR checks; only merge-quorum failing)",
+        }
+        assert required["gate_selected"] is True
+        assert required["quorum_only_failure"] is True
         assert rollup["optional_runner_capacity_noise_count"] == 1
         assert rollup["long_queued_self_hosted_shadow_without_runner_metadata_count"] == 0
         assert packet.machine_recommendation == "repair_first"
@@ -3682,6 +3688,100 @@ class TestBuildQueueAndPacket:
         assert not any(
             "checks are pending" in reason for reason in packet.model_review_quorum["reasons"]
         )
+
+    def test_required_pr_checks_gate_routes_quorum_only_failure_to_model_quorum(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pr_payload = _make_pr(
+            number=8374,
+            files=["scripts/audit_test_skips.py", "tests/scripts/test_audit_test_skips.py"],
+            checks=[
+                {
+                    "name": "aragora-merge-quorum",
+                    "workflowName": "Aragora Merge Quorum",
+                    "status": "COMPLETED",
+                    "conclusion": "FAILURE",
+                },
+                {"name": "Version Alignment", "status": "COMPLETED", "conclusion": "FAILURE"},
+                {
+                    "name": "Status Doc Reconciliation",
+                    "status": "COMPLETED",
+                    "conclusion": "FAILURE",
+                },
+                {"name": "Generate & Validate", "status": "COMPLETED", "conclusion": "SUCCESS"},
+                {
+                    "name": "TypeScript SDK Type Check",
+                    "status": "COMPLETED",
+                    "conclusion": "SUCCESS",
+                },
+                {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
+                {"name": "sdk-parity", "status": "COMPLETED", "conclusion": "SUCCESS"},
+                {"name": "typecheck", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            ],
+        )
+
+        def fake_gh_json(args: list[str]) -> Any:
+            if args[:2] == ["pr", "view"]:
+                return pr_payload
+            if args[:2] == ["pr", "checks"]:
+                return [
+                    {
+                        "name": "aragora-merge-quorum",
+                        "state": "FAILURE",
+                        "bucket": "fail",
+                        "workflow": "Aragora Merge Quorum",
+                    },
+                    {
+                        "name": "Generate & Validate",
+                        "state": "SUCCESS",
+                        "bucket": "pass",
+                        "workflow": "OpenAPI Spec",
+                    },
+                    {
+                        "name": "TypeScript SDK Type Check",
+                        "state": "SUCCESS",
+                        "bucket": "pass",
+                        "workflow": "SDK Tests",
+                    },
+                    {"name": "lint", "state": "SUCCESS", "bucket": "pass", "workflow": "Lint"},
+                    {
+                        "name": "sdk-parity",
+                        "state": "SUCCESS",
+                        "bucket": "pass",
+                        "workflow": "SDK Parity Check",
+                    },
+                    {
+                        "name": "typecheck",
+                        "state": "SUCCESS",
+                        "bucket": "pass",
+                        "workflow": "Lint",
+                    },
+                ]
+            raise AssertionError(f"unexpected gh call: {args}")
+
+        monkeypatch.setattr("aragora.cli.commands.review_queue._gh_json", fake_gh_json)
+
+        packet = _build_packet("8374", repo_override=None)
+        required = packet.check_surfaces["required_pr_checks"]
+        rollup = packet.check_surfaces["pr_rollup"]
+        quorum = packet.model_review_quorum
+
+        assert required["available"] is True
+        assert required["failing_or_cancelled"] == ["aragora-merge-quorum"]
+        assert required["gate_selected"] is True
+        assert packet.check_surfaces["effective_gate"] == {
+            "source": "required_pr_checks",
+            "summary": "1 failing / 6 required (required PR checks; only merge-quorum failing)",
+        }
+        assert rollup["non_required_non_green_count"] == 2
+        assert rollup["non_required_non_green_sample"] == [
+            "Version Alignment",
+            "Status Doc Reconciliation",
+        ]
+        assert quorum["status"] == "needs_model_review_quorum"
+        assert quorum["verdict"] == "collect_model_quorum_before_merge"
+        assert "model quorum incomplete: 0/2 signal(s)" in quorum["reasons"]
+        assert "checks are failing; repair before settlement" not in quorum["reasons"]
 
     def test_required_pr_checks_gate_keeps_non_self_required_failure_blocking(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary
- route review-queue merge-packet quorum-only required check failures to the model-quorum blocker instead of generic repair
- keep non-required PR rollup failures visible as advisory check-surface noise when required PR checks are available
- add a regression for the #8374 shape: non-required rollup failures plus only aragora-merge-quorum required-failing from missing model evidence

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/cli/commands/test_review_queue.py::TestBuildQueueAndPacket -q
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/cli/commands/test_review_queue.py::TestIgnoreOwnQuorumCheck tests/cli/commands/test_review_queue.py::TestSummarizeChecks -q
- git diff --check
- bash scripts/automation_pr_preflight.sh origin/main HEAD

## Impact
This keeps #8374 from being classified as generic repair_or_wait when the PR-facing rollup has non-required failures but branch-protection required checks show only aragora-merge-quorum failing because model quorum evidence is missing.