### PR TITLE
feat(automation): enforce ODR value backpressure admission

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -36,6 +36,10 @@ from aragora.swarm.boss_worker_lifecycle import (
 from aragora.swarm.debate_gate import DebateGate, DebateGateConfig, DebateGateRequest
 from aragora.swarm.dispatch_contract_gate import dispatch_contract_gate  # noqa: F401
 from aragora.swarm.env_utils import git_safe_env
+from aragora.swarm.pr_value import (
+    classify_value_record,
+    read_backpressure_withheld_classes,
+)
 from aragora.swarm.proof_first_queue import filter_noncanonical_boss_ready_issues
 from aragora.swarm.roadmap_priority import extract_roadmap_codes, load_roadmap_priority_policy
 from aragora.swarm.task_sanitizer import SanitizationOutcome, TaskSanitizer  # noqa: F401
@@ -580,6 +584,7 @@ class BossLoopConfig:
     use_focused_verification: bool = True
 
     use_value_ranking: bool = True
+    backpressure_signal_path: str | None = ".aragora/backpressure.json"
 
     avoid_open_pr_scope_conflicts: bool = True
 
@@ -945,6 +950,7 @@ class BossLoop:
         self._pending_handoff_prompts: dict[int, tuple[str, str | None]] = {}
         self._stop_reason: str | None = None
         self._last_sanitation_summary: list[str] = []
+        self._last_backpressure_summary: list[str] = []
         # Decomposition guardrails
         self._total_sub_issues_created: int = 0
         self._ticks_spent_on_decomposed_issues: int = 0
@@ -1479,6 +1485,50 @@ class BossLoop:
         else:
             self._last_sanitation_summary = []
 
+    def _filter_backpressure_withheld_issues(
+        self,
+        issues: list[GitHubIssue],
+        *,
+        pending_issue_numbers: set[int] | None = None,
+    ) -> list[GitHubIssue]:
+        """Drop feed-driven issues withheld by explicit backpressure admission.
+
+        Legacy shepherd-mode signals without ``admission.withhold_classes`` are
+        advisory-only. Pending handoff prompts are exempt because they represent
+        drain/follow-through on existing work rather than fresh generation.
+        """
+        withheld = read_backpressure_withheld_classes(self.config.backpressure_signal_path)
+        if not withheld:
+            self._last_backpressure_summary = []
+            return issues
+
+        pending = set(pending_issue_numbers or set())
+        kept: list[GitHubIssue] = []
+        skipped_by_class: dict[str, list[int]] = {}
+        for issue in issues:
+            if issue.number in pending:
+                kept.append(issue)
+                continue
+            value_class = classify_value_record(issue.to_dict())
+            if value_class in withheld:
+                skipped_by_class.setdefault(value_class, []).append(issue.number)
+                continue
+            kept.append(issue)
+
+        summaries: list[str] = []
+        for value_class, numbers in sorted(skipped_by_class.items()):
+            issue_refs = ", ".join(f"#{number}" for number in numbers[:3])
+            if len(numbers) > 3:
+                issue_refs = f"{issue_refs}, +{len(numbers) - 3} more"
+            summaries.append(f"{value_class} ({len(numbers)}: {issue_refs})")
+        self._last_backpressure_summary = summaries
+        if summaries:
+            logger.info(
+                "Boss loop skipped by backpressure admission: %s",
+                "; ".join(summaries),
+            )
+        return kept
+
     def _no_suitable_issue_guidance(
         self,
         *,
@@ -1502,6 +1552,12 @@ class BossLoop:
             sanitation_summary = "Skipped by sanitation: " + "; ".join(sanitation)
             needs_human_reasons.append(sanitation_summary)
             next_actions.append(sanitation_summary)
+        if self._last_backpressure_summary:
+            backpressure_summary = "Skipped by backpressure admission: " + "; ".join(
+                self._last_backpressure_summary
+            )
+            needs_human_reasons.append(backpressure_summary)
+            next_actions.append(backpressure_summary)
         for blocker_summary in self._session_blocker_summaries(already_maxed):
             needs_human_reasons.append(blocker_summary)
         return needs_human_reasons, next_actions
@@ -4304,6 +4360,10 @@ class BossLoop:
             i for i in issues if i.number in pending_issue_numbers or i.number not in already_maxed
         ]
         candidate_issues = self._filter_issues_with_active_claims(candidate_issues)
+        candidate_issues = self._filter_backpressure_withheld_issues(
+            candidate_issues,
+            pending_issue_numbers=pending_issue_numbers,
+        )
         eligibility_report = build_issue_eligibility_report(
             candidate_issues,
             skip_labels=self.config.skip_labels,
@@ -4566,6 +4626,10 @@ class BossLoop:
             i for i in issues if i.number in pending_issue_numbers or i.number not in already_maxed
         ]
         candidate_issues = self._filter_issues_with_active_claims(candidate_issues)
+        candidate_issues = self._filter_backpressure_withheld_issues(
+            candidate_issues,
+            pending_issue_numbers=pending_issue_numbers,
+        )
         eligibility_report = build_issue_eligibility_report(
             candidate_issues,
             skip_labels=self.config.skip_labels,

--- a/aragora/swarm/pr_value.py
+++ b/aragora/swarm/pr_value.py
@@ -1,0 +1,221 @@
+"""PR and issue value-composition classification for automation admission.
+
+The classifier is deliberately heuristic: it reads titles and labels to decide
+whether a PR/issue looks like loop self-maintenance, product work, infra, or
+unknown. Use it as a composition signal, not a per-item authority.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+DEFAULT_STALE_DAYS = 4
+DEFAULT_MAX_MAINTENANCE_RATIO = 0.5
+SAMPLE_PER_CLASS = 5
+
+MAINTENANCE_LABEL = "codex-automation"
+FEATURE_LABEL = "feature"
+
+CLASS_MAINTENANCE = "maintenance"
+CLASS_PRODUCT = "product"
+CLASS_INFRA = "infra"
+CLASS_UNKNOWN = "unknown"
+CLASS_ORDER = (CLASS_MAINTENANCE, CLASS_PRODUCT, CLASS_INFRA, CLASS_UNKNOWN)
+
+MAINTENANCE_TITLE_PATTERNS = (
+    r"outbox-harvest",
+    r"refresh generated",
+    r"regenerate",
+    r"resync",
+    r"module_tiers",
+    r"metrics drift",
+    r"stale[- ]quorum",
+    r"salvage",
+    r"\brepair\b",
+    r"drift",
+    r"preflight",
+    r"reconcile",
+    r"janitor",
+    r"backpressure",
+    r"sentinel",
+    r"lane",
+    r"gate",
+    r"quorum",
+)
+
+PRODUCT_TITLE_PATTERNS = (
+    r"ODR",
+    r"crux",
+    r"calibration",
+    r"receipt",
+    r"vertical",
+    r"\bAPI\b",
+    r"\bSDK\b",
+    r"handler",
+    r"endpoint",
+    r"debate",
+    r"consensus",
+)
+
+INFRA_TITLE_PATTERNS = (
+    r"test",
+    r"mypy",
+    r"lint",
+    r"ruff",
+    r"ci",
+    r"packaging",
+    r"docs",
+    r"import",
+)
+
+
+def _compile(patterns: tuple[str, ...]) -> tuple[re.Pattern[str], ...]:
+    return tuple(re.compile(pattern, re.IGNORECASE) for pattern in patterns)
+
+
+_MAINTENANCE_RE = _compile(MAINTENANCE_TITLE_PATTERNS)
+_PRODUCT_RE = _compile(PRODUCT_TITLE_PATTERNS)
+_INFRA_RE = _compile(INFRA_TITLE_PATTERNS)
+
+
+def parse_iso_datetime(value: Any) -> datetime | None:
+    """Parse GitHub ISO timestamps; return ``None`` for absent/bad values."""
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def label_names(record: dict[str, Any]) -> set[str]:
+    """Return lower-cased label names from GitHub-style dicts or strings."""
+    labels = record.get("labels") or []
+    names: set[str] = set()
+    if not isinstance(labels, list):
+        return names
+    for label in labels:
+        if isinstance(label, dict):
+            name = label.get("name")
+        else:
+            name = label
+        if name:
+            names.add(str(name).lower())
+    return names
+
+
+def _any_match(title: str, patterns: tuple[re.Pattern[str], ...]) -> bool:
+    return any(pattern.search(title) for pattern in patterns)
+
+
+def classify_value_record(record: dict[str, Any]) -> str:
+    """Classify one PR/issue-like record into one value-composition class.
+
+    Precedence is fixed and first-match-wins:
+    maintenance label/title, product label/title, infra title, unknown.
+    """
+    labels = label_names(record)
+    title = str(record.get("title") or "")
+
+    if MAINTENANCE_LABEL in labels or _any_match(title, _MAINTENANCE_RE):
+        return CLASS_MAINTENANCE
+    if FEATURE_LABEL in labels or _any_match(title, _PRODUCT_RE):
+        return CLASS_PRODUCT
+    if _any_match(title, _INFRA_RE):
+        return CLASS_INFRA
+    return CLASS_UNKNOWN
+
+
+def ratio(part: int, total: int) -> float:
+    return 0.0 if total <= 0 else round(part / total, 4)
+
+
+def build_value_report(
+    records: list[dict[str, Any]],
+    *,
+    stale_days: int = DEFAULT_STALE_DAYS,
+    max_maintenance_ratio: float = DEFAULT_MAX_MAINTENANCE_RATIO,
+    now: datetime,
+    annotations: list[str] | None = None,
+) -> dict[str, Any]:
+    """Build a pure value-composition report from PR/issue-like records."""
+    by_class = dict.fromkeys(CLASS_ORDER, 0)
+    sample: dict[str, list[dict[str, Any]]] = {name: [] for name in CLASS_ORDER}
+    drafts = 0
+    stale_count = 0
+    stale_cutoff = timedelta(days=max(0, stale_days))
+
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        value_class = classify_value_record(record)
+        by_class[value_class] += 1
+        if len(sample[value_class]) < SAMPLE_PER_CLASS:
+            sample[value_class].append(
+                {"number": record.get("number"), "title": str(record.get("title") or "")}
+            )
+        if bool(record.get("isDraft")):
+            drafts += 1
+        created = parse_iso_datetime(record.get("createdAt") or record.get("created_at"))
+        if created is not None and now - created > stale_cutoff:
+            stale_count += 1
+
+    total = sum(by_class.values())
+    return {
+        "total": total,
+        "by_class": by_class,
+        "maintenance_ratio": ratio(by_class[CLASS_MAINTENANCE], total),
+        "product_ratio": ratio(by_class[CLASS_PRODUCT], total),
+        "drafts": drafts,
+        "stale_count": stale_count,
+        "threshold": {
+            "max_maintenance_ratio": max_maintenance_ratio,
+            "stale_days": stale_days,
+        },
+        "annotations": list(annotations or []),
+        "sample": sample,
+    }
+
+
+def summary_line(report: dict[str, Any]) -> str:
+    by_class = report["by_class"]
+    return (
+        f"PR value: total={report['total']} "
+        f"maint={by_class[CLASS_MAINTENANCE]}({report['maintenance_ratio']:.0%}) "
+        f"product={by_class[CLASS_PRODUCT]}({report['product_ratio']:.0%}) "
+        f"infra={by_class[CLASS_INFRA]} unknown={by_class[CLASS_UNKNOWN]} "
+        f"drafts={report['drafts']} stale={report['stale_count']}"
+    )
+
+
+def read_backpressure_withheld_classes(path: str | Path | None) -> set[str]:
+    """Read explicit backpressure admission withholding classes.
+
+    Legacy ``mode: shepherd`` signals without an ``admission`` block stay
+    advisory-only. Missing, malformed, or non-object files fail open because
+    the binding policy must be explicit.
+    """
+    if not path:
+        return set()
+    try:
+        payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, TypeError, ValueError):
+        return set()
+    if not isinstance(payload, dict):
+        return set()
+    admission = payload.get("admission")
+    if not isinstance(admission, dict):
+        return set()
+    raw = admission.get("withhold_classes")
+    if not isinstance(raw, list):
+        return set()
+    return {
+        str(item).strip().lower() for item in raw if str(item).strip().lower() in set(CLASS_ORDER)
+    }

--- a/scripts/backlog_gate.py
+++ b/scripts/backlog_gate.py
@@ -54,7 +54,18 @@ import subprocess
 import sys
 import tempfile
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Callable
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from aragora.swarm.pr_value import (  # noqa: E402
+    CLASS_MAINTENANCE,
+    DEFAULT_MAX_MAINTENANCE_RATIO,
+    DEFAULT_STALE_DAYS,
+    build_value_report,
+)
 
 DEFAULT_REPO = "synaptent/aragora"
 DEFAULT_BRANCH_PREFIXES = ("codex/",)
@@ -62,6 +73,7 @@ DEFAULT_OUTBOX_DIR = os.path.join(".aragora", "automation-outbox")
 DEFAULT_SIGNAL_FILE = os.path.join(".aragora", "backpressure.json")
 DEFAULT_MAX_OPEN_PRS = 60
 DEFAULT_MAX_OUTBOX = 50
+DEFAULT_WITHHELD_CLASSES = (CLASS_MAINTENANCE,)
 GH_TIMEOUT_SECONDS = 120
 GH_LIST_LIMIT = 300
 
@@ -72,7 +84,7 @@ EXIT_SHEPHERD = 3
 MODE_GENERATE = "generate"
 MODE_SHEPHERD = "shepherd"
 
-_GH_LIST_FIELDS = "number,headRefName,isDraft,createdAt"
+_GH_LIST_FIELDS = "number,headRefName,title,labels,isDraft,createdAt,updatedAt"
 
 
 # --- Inputs (read-only) -------------------------------------------------------------
@@ -153,6 +165,8 @@ def run_gate(
     outbox_dir: str = DEFAULT_OUTBOX_DIR,
     max_open_prs: int = DEFAULT_MAX_OPEN_PRS,
     max_outbox: int = DEFAULT_MAX_OUTBOX,
+    max_maintenance_ratio: float = DEFAULT_MAX_MAINTENANCE_RATIO,
+    stale_days: int = DEFAULT_STALE_DAYS,
     signal_file: str = DEFAULT_SIGNAL_FILE,
     quiet: bool = False,
     now: datetime | None = None,
@@ -167,7 +181,11 @@ def run_gate(
     if now is None:
         now = datetime.now(timezone.utc)
     generated_at = now.strftime("%Y-%m-%dT%H:%M:%SZ")
-    thresholds = {"max_open_prs": max_open_prs, "max_outbox": max_outbox}
+    thresholds = {
+        "max_open_prs": max_open_prs,
+        "max_outbox": max_outbox,
+        "max_maintenance_ratio": max_maintenance_ratio,
+    }
 
     def emit(payload: dict[str, Any]) -> None:
         if not quiet:
@@ -194,6 +212,7 @@ def run_gate(
             "ready": None,
             "outbox_depth": None,
             "thresholds": thresholds,
+            "value_composition": None,
             "generated_at": generated_at,
             "annotations": [],
         }
@@ -211,12 +230,24 @@ def run_gate(
     open_count = len(prs)
     drafts = sum(1 for pr in prs if bool(pr.get("isDraft")))
     ready = open_count - drafts
+    value_report = build_value_report(
+        prs,
+        stale_days=stale_days,
+        max_maintenance_ratio=max_maintenance_ratio,
+        now=now,
+        annotations=[],
+    )
 
     reasons: list[str] = []
     if open_count >= max_open_prs:
         reasons.append(f"open_prs:{open_count}>=max_open_prs:{max_open_prs}")
     if depth >= max_outbox:
         reasons.append(f"outbox_depth:{depth}>=max_outbox:{max_outbox}")
+    if value_report["maintenance_ratio"] > max_maintenance_ratio:
+        reasons.append(
+            "maintenance_ratio:"
+            f"{value_report['maintenance_ratio']}>max_maintenance_ratio:{max_maintenance_ratio}"
+        )
 
     annotations: list[str] = []
     if outbox_missing:
@@ -229,6 +260,7 @@ def run_gate(
     if len(raw_prs) >= GH_LIST_LIMIT:
         reasons.append(f"list_truncated:>={GH_LIST_LIMIT}")
         annotations.append(f"list_truncated:>={GH_LIST_LIMIT}")
+        value_report["annotations"].append(f"list_truncated:>={GH_LIST_LIMIT}")
 
     mode = MODE_SHEPHERD if reasons else MODE_GENERATE
     payload = {
@@ -239,9 +271,15 @@ def run_gate(
         "ready": ready,
         "outbox_depth": depth,
         "thresholds": thresholds,
+        "value_composition": value_report,
         "generated_at": generated_at,
         "annotations": annotations,
     }
+    if reasons:
+        payload["admission"] = {
+            "withhold_classes": list(DEFAULT_WITHHELD_CLASSES),
+            "source": "backlog_gate",
+        }
 
     try:
         atomic_write_json(signal_file, payload)
@@ -309,6 +347,19 @@ def main(argv: list[str] | None = None) -> int:
         f"at/over this the gate says shepherd",
     )
     parser.add_argument(
+        "--max-maintenance-ratio",
+        type=float,
+        default=DEFAULT_MAX_MAINTENANCE_RATIO,
+        help=f"Maintenance-ratio threshold (default {DEFAULT_MAX_MAINTENANCE_RATIO}); "
+        "above this the gate says shepherd",
+    )
+    parser.add_argument(
+        "--stale-days",
+        type=int,
+        default=DEFAULT_STALE_DAYS,
+        help=f"Open PRs older than this many days count as stale (default {DEFAULT_STALE_DAYS})",
+    )
+    parser.add_argument(
         "--signal-file",
         default=DEFAULT_SIGNAL_FILE,
         help=f"Path for the atomically-written signal JSON (default {DEFAULT_SIGNAL_FILE})",
@@ -329,6 +380,8 @@ def main(argv: list[str] | None = None) -> int:
         outbox_dir=args.outbox_dir,
         max_open_prs=args.max_open_prs,
         max_outbox=args.max_outbox,
+        max_maintenance_ratio=args.max_maintenance_ratio,
+        stale_days=args.stale_days,
         signal_file=args.signal_file,
         quiet=args.quiet,
     )

--- a/scripts/generate_boss_issues.py
+++ b/scripts/generate_boss_issues.py
@@ -30,6 +30,10 @@ sys.path.insert(0, str(REPO_ROOT))
 from aragora.swarm.decomposition_bridge import DecompositionBridge  # noqa: E402
 from aragora.swarm.issue_scanner import BossIssueCandidate, scan_all  # noqa: E402
 from aragora.swarm.issue_upgrader import upgrade_issue_heuristic  # noqa: E402
+from aragora.swarm.pr_value import (  # noqa: E402
+    CLASS_MAINTENANCE,
+    read_backpressure_withheld_classes,
+)
 from aragora.swarm.proof_first_queue import classify_proof_first_queue_issue  # noqa: E402
 from aragora.swarm.roadmap_priority import load_roadmap_priority_policy  # noqa: E402
 
@@ -46,6 +50,7 @@ _OPEN_PR_PAGE_SIZE = 100
 _OPEN_PR_MAX_PAGES = 10
 _OPEN_PR_FILES_PAGE_SIZE = 100
 _OPEN_PR_FILES_MAX_PAGES = 10
+DEFAULT_BACKPRESSURE_SIGNAL_FILE = REPO_ROOT / ".aragora" / "backpressure.json"
 _UPGRADEABLE_CATEGORIES = frozenset(
     {"test_coverage", "broad_exception", "silent_exception", "type_annotation"}
 )
@@ -586,6 +591,15 @@ def main() -> None:
         ),
     )
     parser.add_argument(
+        "--backpressure-signal-file",
+        default=str(DEFAULT_BACKPRESSURE_SIGNAL_FILE),
+        help=(
+            "Read explicit admission.withhold_classes from this backpressure signal. "
+            "When maintenance is withheld, substrate candidate generation is disabled. "
+            "Missing or legacy files without admission are advisory-only."
+        ),
+    )
+    parser.add_argument(
         "--created-7d",
         type=int,
         default=None,
@@ -729,12 +743,17 @@ def main() -> None:
     )
 
     # 5. Trim to max, capping the substrate-surface share (Sprint 3 goal 2)
+    effective_substrate_cap = args.substrate_cap
+    withheld_classes = read_backpressure_withheld_classes(args.backpressure_signal_file)
+    if CLASS_MAINTENANCE in withheld_classes:
+        effective_substrate_cap = 0.0
+        print("  Backpressure admission withheld maintenance: substrate candidate cap forced to 0%")
     to_create, substrate_skipped = select_with_substrate_cap(
-        filtered, args.max_issues, args.substrate_cap
+        filtered, args.max_issues, effective_substrate_cap
     )
     if substrate_skipped:
         print(
-            f"  Substrate cap {args.substrate_cap:.0%}: skipped "
+            f"  Substrate cap {effective_substrate_cap:.0%}: skipped "
             f"{substrate_skipped} substrate-surface candidates "
             f"(substrate_skipped={substrate_skipped})"
         )
@@ -766,7 +785,7 @@ def main() -> None:
         if allowed < len(to_create):
             # Re-apply the substrate cap at the throttled budget so the
             # cap's composition is preserved while the total shrinks.
-            to_create, _ = select_with_substrate_cap(to_create, allowed, args.substrate_cap)
+            to_create, _ = select_with_substrate_cap(to_create, allowed, effective_substrate_cap)
 
     # 6. Create or dry-run
     if args.dry_run:

--- a/scripts/pr_value_classifier.py
+++ b/scripts/pr_value_classifier.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""PR value-composition classifier for the autonomous PR pipeline (READ-ONLY).
+
+This script makes self-maintenance drift visible by classifying open PRs as
+``maintenance``, ``product``, ``infra``, or ``unknown`` using the shared
+``aragora.swarm.pr_value`` heuristic. It never mutates GitHub; the only optional
+write is the ``--out`` JSON snapshot.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from aragora.swarm.pr_value import (  # noqa: E402
+    DEFAULT_MAX_MAINTENANCE_RATIO,
+    DEFAULT_STALE_DAYS,
+    build_value_report,
+    classify_value_record,
+    summary_line,
+)
+
+DEFAULT_REPO = "synaptent/aragora"
+DEFAULT_LIMIT = 300
+GH_TIMEOUT_SECONDS = 120
+
+EXIT_OK = 0
+EXIT_FAILURE = 1
+EXIT_BREACH = 3
+
+_GH_FIELDS = "number,title,labels,isDraft,createdAt,updatedAt"
+
+
+def classify_pr(pr: dict[str, Any]) -> str:
+    """Backward-compatible script-level alias for tests and ad-hoc callers."""
+    return classify_value_record(pr)
+
+
+def default_list_prs(repo: str, limit: int) -> list[dict[str, Any]]:
+    """One ``gh pr list`` call for open PRs (read-only, capped at ``limit``)."""
+    command = [
+        "gh",
+        "pr",
+        "list",
+        "--repo",
+        repo,
+        "--state",
+        "open",
+        "--json",
+        _GH_FIELDS,
+        "--limit",
+        str(limit),
+    ]
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        timeout=GH_TIMEOUT_SECONDS,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"gh pr list failed (exit {result.returncode}): {result.stderr.strip()}")
+    payload = json.loads(result.stdout or "[]")
+    if not isinstance(payload, list):
+        raise RuntimeError("gh pr list returned unexpected payload (expected a list)")
+    return payload
+
+
+def atomic_write_json(path: str, payload: dict[str, Any]) -> None:
+    """Write temp + ``os.replace`` so readers never observe a partial file."""
+    directory = os.path.dirname(path) or "."
+    os.makedirs(directory, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=f".{os.path.basename(path)}.", dir=directory)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh, indent=2, sort_keys=True)
+            fh.write("\n")
+        os.replace(tmp, path)
+    finally:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+
+
+def run_classifier(
+    *,
+    list_prs: Callable[[], list[dict[str, Any]]],
+    limit: int = DEFAULT_LIMIT,
+    stale_days: int = DEFAULT_STALE_DAYS,
+    max_maintenance_ratio: float = DEFAULT_MAX_MAINTENANCE_RATIO,
+    out_file: str | None = None,
+    summary: bool = False,
+    now: datetime | None = None,
+    log: Callable[[str], None] = print,
+) -> int:
+    """Build one value-composition report; return 0 / 3 (breach) / 1."""
+    if now is None:
+        now = datetime.now(timezone.utc)
+    annotations: list[str] = []
+
+    try:
+        raw = list_prs()
+        if not isinstance(raw, list):
+            raise RuntimeError("list_prs returned unexpected payload (expected a list)")
+        prs = [pr for pr in raw if isinstance(pr, dict)]
+    except (RuntimeError, OSError, ValueError, subprocess.SubprocessError) as exc:
+        print(json.dumps({"action": "error", "error": str(exc)[:500]}), file=sys.stderr)
+        return EXIT_FAILURE
+
+    if len(prs) >= limit:
+        annotations.append(f"list_truncated:>={limit}")
+
+    report = {
+        "generated_at": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        **build_value_report(
+            prs,
+            stale_days=stale_days,
+            max_maintenance_ratio=max_maintenance_ratio,
+            now=now,
+            annotations=annotations,
+        ),
+    }
+
+    log(summary_line(report) if summary else json.dumps(report, sort_keys=True))
+
+    if out_file:
+        try:
+            atomic_write_json(out_file, report)
+        except OSError as exc:
+            print(
+                json.dumps({"action": "out_write_failed", "error": str(exc)[:300]}),
+                file=sys.stderr,
+            )
+            return EXIT_FAILURE
+
+    if report["maintenance_ratio"] > max_maintenance_ratio:
+        return EXIT_BREACH
+    return EXIT_OK
+
+
+_REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+
+
+def repo_arg(value: str) -> str:
+    """Argparse type: validate ``owner/name`` at parse time."""
+    if not _REPO_RE.match(value):
+        raise argparse.ArgumentTypeError(f"--repo must look like owner/name, got {value!r}")
+    return value
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Read-only PR value-composition classifier. Exits 0 normally, "
+            "3 when maintenance_ratio exceeds the threshold, 1 on failure."
+        )
+    )
+    parser.add_argument(
+        "--repo", default=DEFAULT_REPO, type=repo_arg, help="GitHub repo (owner/name)"
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=DEFAULT_LIMIT,
+        help=f"Per-run cap on open PRs fetched (default {DEFAULT_LIMIT})",
+    )
+    parser.add_argument(
+        "--stale-days",
+        type=int,
+        default=DEFAULT_STALE_DAYS,
+        help=f"Open PRs older than this many days count as stale (default {DEFAULT_STALE_DAYS})",
+    )
+    parser.add_argument(
+        "--max-maintenance-ratio",
+        type=float,
+        default=DEFAULT_MAX_MAINTENANCE_RATIO,
+        help=f"Breach (exit 3) when maintenance_ratio exceeds this "
+        f"(default {DEFAULT_MAX_MAINTENANCE_RATIO})",
+    )
+    parser.add_argument("--summary", action="store_true", help="Emit one summary line")
+    parser.add_argument("--out", default=None, help="Optional atomic JSON output path")
+    args = parser.parse_args(argv)
+
+    return run_classifier(
+        list_prs=lambda: default_list_prs(args.repo, args.limit),
+        limit=args.limit,
+        stale_days=args.stale_days,
+        max_maintenance_ratio=args.max_maintenance_ratio,
+        out_file=args.out,
+        summary=args.summary,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_backlog_gate.py
+++ b/tests/scripts/test_backlog_gate.py
@@ -34,12 +34,22 @@ gate = _load_module("backlog_gate.py")
 NOW = datetime(2026, 6, 12, 12, 0, 0, tzinfo=timezone.utc)
 
 
-def _pr(number: int, *, head: str = "codex/feature", draft: bool = True) -> dict[str, Any]:
+def _pr(
+    number: int,
+    *,
+    head: str = "codex/feature",
+    title: str = "",
+    labels: list[str] | None = None,
+    draft: bool = True,
+) -> dict[str, Any]:
     return {
         "number": number,
         "headRefName": head,
+        "title": title,
+        "labels": [{"name": label} for label in (labels or [])],
         "isDraft": draft,
         "createdAt": "2026-06-11T12:00:00Z",
+        "updatedAt": "2026-06-11T12:00:00Z",
     }
 
 
@@ -60,6 +70,7 @@ def _run(
     outbox_dir: Path | None = None,
     max_open_prs: int = 60,
     max_outbox: int = 50,
+    max_maintenance_ratio: float = 0.5,
     quiet: bool = False,
     branch_prefixes: tuple[str, ...] = ("codex/",),
 ) -> tuple[int, dict[str, Any] | None, list[str]]:
@@ -78,6 +89,7 @@ def _run(
         outbox_dir=str(outbox_dir if outbox_dir is not None else tmp_path / "outbox"),
         max_open_prs=max_open_prs,
         max_outbox=max_outbox,
+        max_maintenance_ratio=max_maintenance_ratio,
         signal_file=str(signal_file),
         quiet=quiet,
         now=NOW,
@@ -103,7 +115,14 @@ def test_under_both_thresholds_generates_exit_zero(tmp_path: Path) -> None:
     assert payload["drafts"] == 1
     assert payload["ready"] == 1
     assert payload["outbox_depth"] == 3
-    assert payload["thresholds"] == {"max_open_prs": 60, "max_outbox": 50}
+    assert payload["thresholds"] == {
+        "max_open_prs": 60,
+        "max_outbox": 50,
+        "max_maintenance_ratio": 0.5,
+    }
+    assert payload["value_composition"]["total"] == 2
+    assert payload["value_composition"]["maintenance_ratio"] == 0.0
+    assert "admission" not in payload
     assert payload["generated_at"] == "2026-06-12T12:00:00Z"
     # stdout JSON matches the signal file
     assert json.loads(lines[-1]) == payload
@@ -116,6 +135,10 @@ def test_open_prs_at_threshold_is_shepherd_exit_three(tmp_path: Path) -> None:
     assert payload is not None
     assert payload["mode"] == "shepherd"
     assert payload["reasons"] == ["open_prs:5>=max_open_prs:5"]
+    assert payload["admission"] == {
+        "withhold_classes": ["maintenance"],
+        "source": "backlog_gate",
+    }
 
 
 def test_open_prs_just_under_threshold_generates(tmp_path: Path) -> None:
@@ -153,6 +176,35 @@ def test_both_over_threshold_lists_both_reasons(tmp_path: Path) -> None:
         "open_prs:7>=max_open_prs:2",
         "outbox_depth:9>=max_outbox:2",
     ]
+
+
+def test_maintenance_ratio_breach_is_shepherd_with_admission(tmp_path: Path) -> None:
+    prs = [
+        _pr(1, title="drift repair", labels=["codex-automation"]),
+        _pr(2, title="reconcile lane"),
+        _pr(3, title="new ODR receipt endpoint"),
+    ]
+    exit_code, payload, _ = _run(tmp_path, prs, max_maintenance_ratio=0.5)
+    assert exit_code == 3
+    assert payload is not None
+    assert payload["mode"] == "shepherd"
+    assert "maintenance_ratio:0.6667>max_maintenance_ratio:0.5" in payload["reasons"]
+    assert payload["value_composition"]["by_class"]["maintenance"] == 2
+    assert payload["value_composition"]["by_class"]["product"] == 1
+    assert payload["admission"] == {
+        "withhold_classes": ["maintenance"],
+        "source": "backlog_gate",
+    }
+
+
+def test_legacy_shepherd_shape_without_admission_is_not_emitted_for_generate(
+    tmp_path: Path,
+) -> None:
+    exit_code, payload, _ = _run(tmp_path, [_pr(1, title="new ODR endpoint")])
+    assert exit_code == 0
+    assert payload is not None
+    assert payload["mode"] == "generate"
+    assert "admission" not in payload
 
 
 # ---------------------------------------------------------------------------
@@ -227,6 +279,8 @@ def test_gh_failure_writes_shepherd_signal_and_exits_one(tmp_path: Path) -> None
     assert payload["reasons"] == ["gate_failure:gh pr list failed (exit 4): boom"]
     assert payload["open_prs"] is None
     assert payload["outbox_depth"] is None
+    assert payload["value_composition"] is None
+    assert "admission" not in payload
 
 
 def test_gh_failure_with_unwritable_signal_still_exits_one(
@@ -261,6 +315,7 @@ def test_truncated_listing_forces_shepherd_even_with_small_counts(tmp_path: Path
     assert payload["open_prs"] == 1, "visible in-scope count stays small"
     assert f"list_truncated:>={gate.GH_LIST_LIMIT}" in payload["reasons"]
     assert f"list_truncated:>={gate.GH_LIST_LIMIT}" in payload["annotations"]
+    assert payload["admission"]["withhold_classes"] == ["maintenance"]
 
 
 def test_listing_just_below_limit_is_unaffected(tmp_path: Path) -> None:

--- a/tests/scripts/test_generate_boss_issues.py
+++ b/tests/scripts/test_generate_boss_issues.py
@@ -922,6 +922,103 @@ def test_main_omits_extra_labels_when_disabled(monkeypatch, capsys) -> None:
     assert created[0][4] == []
 
 
+def test_main_backpressure_signal_blocks_substrate_refill(
+    monkeypatch, capsys, tmp_path: Path
+) -> None:
+    substrate = _candidate("substrate_module", file_scope=["scripts/substrate_tool.py"])
+    product = _candidate("product_module", file_scope=["aragora/server/product_module.py"])
+    signal_file = tmp_path / "backpressure.json"
+    signal_file.write_text(
+        json.dumps(
+            {
+                "mode": "shepherd",
+                "admission": {
+                    "withhold_classes": ["maintenance"],
+                    "source": "backlog_gate",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        mod,
+        "scan_all",
+        lambda repo_root, categories=None, min_success_rate=0.3: [substrate, product],
+    )
+    monkeypatch.setattr(mod, "fetch_existing_boss_issues", lambda repo: [])
+    monkeypatch.setattr(mod, "fetch_open_pr_files", lambda repo: set())
+    monkeypatch.setattr(mod, "validate_body", lambda body: (True, ""))
+    monkeypatch.setattr(mod, "load_roadmap_priority_policy", lambda repo_root: None)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate_boss_issues.py",
+            "--repo",
+            "org/repo",
+            "--dry-run",
+            "--max-issues",
+            "5",
+            "--label",
+            "lane:test",
+            "--backpressure-signal-file",
+            str(signal_file),
+        ],
+    )
+
+    mod.main()
+
+    out = capsys.readouterr().out
+    assert "Backpressure admission withheld maintenance" in out
+    assert "DRY RUN — would create 1 issues" in out
+    assert product.title in out
+    assert substrate.title not in out
+
+
+def test_main_legacy_shepherd_signal_does_not_block_refill(
+    monkeypatch, capsys, tmp_path: Path
+) -> None:
+    substrate = _candidate("substrate_module", file_scope=["scripts/substrate_tool.py"])
+    signal_file = tmp_path / "backpressure.json"
+    signal_file.write_text(json.dumps({"mode": "shepherd"}), encoding="utf-8")
+
+    monkeypatch.setattr(
+        mod,
+        "scan_all",
+        lambda repo_root, categories=None, min_success_rate=0.3: [substrate],
+    )
+    monkeypatch.setattr(mod, "fetch_existing_boss_issues", lambda repo: [])
+    monkeypatch.setattr(mod, "fetch_open_pr_files", lambda repo: set())
+    monkeypatch.setattr(mod, "validate_body", lambda body: (True, ""))
+    monkeypatch.setattr(mod, "load_roadmap_priority_policy", lambda repo_root: None)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate_boss_issues.py",
+            "--repo",
+            "org/repo",
+            "--dry-run",
+            "--max-issues",
+            "5",
+            "--label",
+            "lane:test",
+            "--substrate-cap",
+            "1",
+            "--backpressure-signal-file",
+            str(signal_file),
+        ],
+    )
+
+    mod.main()
+
+    out = capsys.readouterr().out
+    assert "Backpressure admission withheld maintenance" not in out
+    assert "DRY RUN — would create 1 issues" in out
+    assert substrate.title in out
+
+
 class TestSelectWithSubstrateCap:
     """Substrate cap on issue creation (FOCUS.md Sprint 3 goal 2)."""
 

--- a/tests/scripts/test_pr_value_classifier.py
+++ b/tests/scripts/test_pr_value_classifier.py
@@ -1,0 +1,264 @@
+"""Tests for ``scripts/pr_value_classifier.py``.
+
+The ``gh pr list`` boundary is injected; no test touches the network.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _load_module(script_name: str) -> Any:
+    here = Path(__file__).resolve()
+    script_path = here.parents[2] / "scripts" / script_name
+    spec = importlib.util.spec_from_file_location(f"{script_name}_under_test", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load spec for {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+clf = _load_module("pr_value_classifier.py")
+
+NOW = datetime(2026, 6, 13, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _pr(
+    number: int,
+    title: str,
+    *,
+    labels: list[str] | None = None,
+    is_draft: bool = False,
+    created: datetime | None = None,
+) -> dict[str, Any]:
+    return {
+        "number": number,
+        "title": title,
+        "labels": [{"name": name} for name in (labels or [])],
+        "isDraft": is_draft,
+        "createdAt": _iso(created or NOW),
+        "updatedAt": _iso(created or NOW),
+    }
+
+
+def _runner(prs: list[dict[str, Any]]):
+    return lambda: list(prs)
+
+
+def test_classify_maintenance_by_label() -> None:
+    assert clf.classify_pr(_pr(1, "anything", labels=["codex-automation"])) == "maintenance"
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "outbox-harvest sweep",
+        "Refresh generated module_tiers",
+        "regenerate fixtures",
+        "resync convoy store",
+        "metrics drift report",
+        "stale-quorum cleanup",
+        "salvage queue drain",
+        "repair broken lane",
+        "drift sentinel update",
+        "preflight gate check",
+        "reconcile leases",
+        "boss janitor pass",
+        "backpressure tuning",
+        "quorum gate adjust",
+    ],
+)
+def test_classify_maintenance_by_title(title: str) -> None:
+    assert clf.classify_pr(_pr(1, title)) == "maintenance"
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "Add ODR workflow",
+        "crux extraction",
+        "calibration tracker",
+        "decision receipt store",
+        "healthcare vertical",
+        "new API endpoint",
+        "Python SDK client",
+        "fix handler bug",
+        "debate orchestrator",
+        "consensus proof",
+    ],
+)
+def test_classify_product_by_title(title: str) -> None:
+    assert clf.classify_pr(_pr(1, title)) == "product"
+
+
+def test_classify_product_by_feature_label() -> None:
+    assert clf.classify_pr(_pr(1, "opaque title", labels=["feature"])) == "product"
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "add tests for foo",
+        "mypy fixes",
+        "lint cleanup",
+        "ruff autofix",
+        "ci pipeline tweak",
+        "packaging metadata",
+        "docs update",
+        "fix import order",
+    ],
+)
+def test_classify_infra_by_title(title: str) -> None:
+    assert clf.classify_pr(_pr(1, title)) == "infra"
+
+
+def test_classify_unknown() -> None:
+    assert clf.classify_pr(_pr(1, "wibble wobble flooble")) == "unknown"
+
+
+def test_precedence_label_beats_product_title() -> None:
+    pr = _pr(1, "feat(api): new endpoint", labels=["codex-automation"])
+    assert clf.classify_pr(pr) == "maintenance"
+
+
+def test_precedence_maintenance_title_beats_product_title() -> None:
+    assert clf.classify_pr(_pr(1, "API gate refactor")) == "maintenance"
+
+
+def test_precedence_product_beats_infra() -> None:
+    assert clf.classify_pr(_pr(1, "add test for new API endpoint")) == "product"
+
+
+def test_maintenance_ratio_and_breach_exit3(capsys: pytest.CaptureFixture[str]) -> None:
+    prs = [
+        _pr(1, "drift repair", labels=["codex-automation"]),
+        _pr(2, "reconcile leases"),
+        _pr(3, "new API endpoint"),
+    ]
+    rc = clf.run_classifier(list_prs=_runner(prs), now=NOW, max_maintenance_ratio=0.5)
+    out = json.loads(capsys.readouterr().out)
+    assert out["generated_at"] == "2026-06-13T12:00:00Z"
+    assert out["total"] == 3
+    assert out["by_class"]["maintenance"] == 2
+    assert out["by_class"]["product"] == 1
+    assert out["maintenance_ratio"] == pytest.approx(0.6667, abs=1e-3)
+    assert out["product_ratio"] == pytest.approx(0.3333, abs=1e-3)
+    assert rc == clf.EXIT_BREACH
+
+
+def test_no_breach_at_threshold_boundary(capsys: pytest.CaptureFixture[str]) -> None:
+    prs = [_pr(1, "reconcile leases"), _pr(2, "new API endpoint")]
+    rc = clf.run_classifier(list_prs=_runner(prs), now=NOW, max_maintenance_ratio=0.5)
+    out = json.loads(capsys.readouterr().out)
+    assert out["maintenance_ratio"] == 0.5
+    assert rc == clf.EXIT_OK
+
+
+def test_stale_and_drafts_counted(capsys: pytest.CaptureFixture[str]) -> None:
+    old = NOW - timedelta(days=10)
+    fresh = NOW - timedelta(hours=2)
+    prs = [
+        _pr(1, "new API endpoint", is_draft=True, created=old),
+        _pr(2, "another API endpoint", created=fresh),
+        _pr(3, "third API endpoint", created=old),
+    ]
+    clf.run_classifier(list_prs=_runner(prs), now=NOW, stale_days=4)
+    out = json.loads(capsys.readouterr().out)
+    assert out["drafts"] == 1
+    assert out["stale_count"] == 2
+
+
+def test_empty_list_zero_ratios_exit0(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = clf.run_classifier(list_prs=_runner([]), now=NOW)
+    out = json.loads(capsys.readouterr().out)
+    assert out["total"] == 0
+    assert out["maintenance_ratio"] == 0.0
+    assert out["product_ratio"] == 0.0
+    assert rc == clf.EXIT_OK
+
+
+def test_sample_capped_at_five(capsys: pytest.CaptureFixture[str]) -> None:
+    prs = [_pr(i, "new API endpoint") for i in range(1, 9)]
+    clf.run_classifier(list_prs=_runner(prs), now=NOW)
+    out = json.loads(capsys.readouterr().out)
+    assert len(out["sample"]["product"]) == 5
+    assert out["by_class"]["product"] == 8
+
+
+def test_summary_one_line(capsys: pytest.CaptureFixture[str]) -> None:
+    clf.run_classifier(
+        list_prs=_runner([_pr(1, "drift"), _pr(2, "new API endpoint")]), now=NOW, summary=True
+    )
+    out = capsys.readouterr().out.strip()
+    assert "\n" not in out
+    assert out.startswith("PR value:")
+    assert "maint=1" in out
+    assert "product=1" in out
+
+
+@pytest.mark.parametrize("bad", ["not-a-repo", "owner/", "/name", "a/b/c", "owner name"])
+def test_repo_arg_rejects_malformed(bad: str) -> None:
+    import argparse
+
+    with pytest.raises(argparse.ArgumentTypeError):
+        clf.repo_arg(bad)
+
+
+def test_atomic_write_no_temp_left_on_success(tmp_path: Path) -> None:
+    out = tmp_path / "report.json"
+    rc = clf.run_classifier(
+        list_prs=_runner([_pr(1, "new API endpoint")]),
+        now=NOW,
+        out_file=str(out),
+    )
+    assert rc == clf.EXIT_OK
+    assert json.loads(out.read_text(encoding="utf-8"))["total"] == 1
+    assert [path.name for path in tmp_path.iterdir() if path.name != "report.json"] == []
+
+
+def test_atomic_write_failure_leaves_no_temp(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    out = tmp_path / "report.json"
+
+    def boom(src: str, dst: str) -> None:
+        raise OSError("simulated replace failure")
+
+    monkeypatch.setattr(clf.os, "replace", boom)
+    rc = clf.run_classifier(
+        list_prs=_runner([_pr(1, "new API endpoint")]),
+        now=NOW,
+        out_file=str(out),
+    )
+    assert rc == clf.EXIT_FAILURE
+    assert not out.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_runner_failure_exits_1(capsys: pytest.CaptureFixture[str]) -> None:
+    def boom() -> list[dict[str, Any]]:
+        raise RuntimeError("gh exploded")
+
+    rc = clf.run_classifier(list_prs=boom, now=NOW)
+    assert rc == clf.EXIT_FAILURE
+    assert "gh exploded" in capsys.readouterr().err
+
+
+def test_truncation_annotation(capsys: pytest.CaptureFixture[str]) -> None:
+    prs = [_pr(i, "new API endpoint") for i in range(1, 4)]
+    clf.run_classifier(list_prs=_runner(prs), now=NOW, limit=3)
+    out = json.loads(capsys.readouterr().out)
+    assert "list_truncated:>=3" in out["annotations"]

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -1601,6 +1601,111 @@ class TestBossLoop:
         assert len(result.issues_attempted) == 0
         assert "No suitable open issue" in result.needs_human_reasons[0]
 
+    @pytest.mark.asyncio
+    async def test_backpressure_admission_skips_maintenance_issue_but_dispatches_product(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        signal_file = tmp_path / "backpressure.json"
+        signal_file.write_text(
+            json.dumps(
+                {
+                    "mode": "shepherd",
+                    "admission": {
+                        "withhold_classes": ["maintenance"],
+                        "source": "backlog_gate",
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        maintenance = _make_issue(2801, "repair lane gate")
+        product = _make_issue(
+            2802,
+            "Add ODR receipt endpoint",
+        )
+        feed = MagicMock(spec=GitHubIssueFeed)
+        feed.fetch.return_value = [maintenance, product]
+        loop = BossLoop(
+            config=_boss_config(max_iterations=1, backpressure_signal_path=str(signal_file)),
+            issue_feed=feed,
+            freshness_checker=lambda **kw: _fresh_result(fresh=True),
+        )
+        loop._existing_open_pr_skip_status = lambda **kwargs: None
+        loop._dispatch_issue = AsyncMock(return_value={"status": "completed"})
+
+        status = await loop._run_iteration(1)
+
+        assert status.worker_status == "completed"
+        assert status.selected_issue["number"] == product.number
+        loop._dispatch_issue.assert_awaited_once_with(product, ANY)
+
+    @pytest.mark.asyncio
+    async def test_legacy_backpressure_shepherd_without_admission_is_advisory_only(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        signal_file = tmp_path / "backpressure.json"
+        signal_file.write_text(json.dumps({"mode": "shepherd"}), encoding="utf-8")
+        issue = _make_issue(2803, "repair lane gate")
+        feed = MagicMock(spec=GitHubIssueFeed)
+        feed.fetch.return_value = [issue]
+        loop = BossLoop(
+            config=_boss_config(max_iterations=1, backpressure_signal_path=str(signal_file)),
+            issue_feed=feed,
+            freshness_checker=lambda **kw: _fresh_result(fresh=True),
+        )
+        loop._existing_open_pr_skip_status = lambda **kwargs: None
+        loop._dispatch_issue = AsyncMock(return_value={"status": "completed"})
+
+        status = await loop._run_iteration(1)
+
+        assert status.worker_status == "completed"
+        assert status.selected_issue["number"] == issue.number
+        loop._dispatch_issue.assert_awaited_once_with(issue, ANY)
+
+    @pytest.mark.asyncio
+    async def test_backpressure_admission_allows_pending_handoff_followthrough(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        signal_file = tmp_path / "backpressure.json"
+        signal_file.write_text(
+            json.dumps(
+                {
+                    "mode": "shepherd",
+                    "admission": {
+                        "withhold_classes": ["maintenance"],
+                        "source": "backlog_gate",
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        issue = _make_issue(2804, "repair lane gate")
+        feed = MagicMock(spec=GitHubIssueFeed)
+        feed.fetch.return_value = [issue]
+        loop = BossLoop(
+            config=_boss_config(max_iterations=1, backpressure_signal_path=str(signal_file)),
+            issue_feed=feed,
+            freshness_checker=lambda **kw: _fresh_result(fresh=True),
+        )
+        loop._pending_handoff_prompts[issue.number] = ("handoff prompt", "codex")
+        loop._existing_open_pr_skip_status = lambda **kwargs: None
+        loop._dispatch_issue = AsyncMock(return_value={"status": "completed"})
+
+        status = await loop._run_iteration(1)
+
+        assert status.worker_status == "completed"
+        assert status.selected_issue["number"] == issue.number
+        loop._dispatch_issue.assert_awaited_once_with(issue, ANY)
+
     def test_no_suitable_issue_keepalive_continues_until_max_iterations(self):
         """With keepalive on, empty queues should not terminate the run."""
         feed = MagicMock(spec=GitHubIssueFeed)


### PR DESCRIPTION
## Summary
- Salvages the PR value classifier payload from #8371 without the doc churn, and moves the shared heuristic/reporting logic into `aragora/swarm/pr_value.py`.
- Extends `scripts/backlog_gate.py` to include value composition in `.aragora/backpressure.json` and emit explicit `admission.withhold_classes=["maintenance"]` only for measured pressure breaches.
- Wires explicit admission withholding into boss-loop selection and `scripts/generate_boss_issues.py`, preserving product/ODR candidates and pending handoff follow-through.

Supersedes #8371. Builds on merged mission #8372. Refs #8344.

## Validation
- `python3 -m pytest -q tests/scripts/test_pr_value_classifier.py tests/scripts/test_backlog_gate.py` → 85 passed
- `python3 -m pytest -q tests/scripts/test_generate_boss_issues.py` → 45 passed
- `python3 -m pytest -q tests/swarm/test_boss_loop.py -k "backpressure or no_suitable_issue"` → 9 passed, 218 deselected
- `ruff check scripts/pr_value_classifier.py scripts/backlog_gate.py scripts/generate_boss_issues.py aragora/swarm/pr_value.py aragora/swarm/boss_loop.py` → passed
- `python3 -m py_compile scripts/pr_value_classifier.py scripts/backlog_gate.py scripts/generate_boss_issues.py` → passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` → passed
- Live classifier smoke: one pre-push attempt returned exit 3 with `total=202 maint=133(66%) product=11(5%) infra=15 unknown=43 drafts=176 stale=68`; final repeat was blocked by GitHub GraphQL rate limit.