### PR TITLE
fix(boss-loop): route aux-step gh reads through GitHub App token

### DIFF
--- a/scripts/run_boss_cycle.sh
+++ b/scripts/run_boss_cycle.sh
@@ -34,6 +34,43 @@ PYTHON_BIN="$(resolve_aragora_python 'import pydantic; import aragora.cli.comman
 
 cd "${REPO_ROOT}"
 
+# Opt-in GitHub App auth for this cycle's shell-level `gh` calls
+# (ARAGORA_GH_APP_AUTH=1, default off; mirrors run_merge_arbiter.sh and
+# run_codex_automation_publisher.sh). The App installation token carries its
+# OWN GraphQL budget, separate from the operator PAT whose budget is
+# chronically exhausted by the poller fleet. Mint it ONCE here and share it
+# across the read-heavy aux steps below (quorum reconciler + post-loop issue
+# refill), both of which shell out via raw `subprocess.run(["gh", ...])` and
+# therefore inherit the operator PAT rather than self-minting via
+# aragora.swarm.github_app_auth like the boss-loop's own Python reads do.
+# The substrate-cap scan in generate_boss_issues.py (gh pr list + per-PR
+# files) is the heaviest GraphQL read draining the PAT each cycle.
+#
+# Each consumer applies the token inside its OWN subshell so it does not leak
+# into the boss-loop Python process invoked above (which self-manages App auth
+# per call and must keep the PAT for write ops). Fail-safe: gh_app_env.py
+# prints nothing when App config is absent or the mint fails, so each block
+# degrades to the existing gh auth byte-for-byte. The token value is never
+# echoed. ARAGORA_GITHUB_AUTH_SOURCE tags the token so write ops can drop it.
+BOSS_GH_APP_TOKEN=""
+if [[ "${ARAGORA_GH_APP_AUTH:-0}" == "1" ]]; then
+    BOSS_GH_APP_TOKEN="$("${PYTHON_BIN}" scripts/gh_app_env.py --print-token --quiet 2>/dev/null || true)"
+    if [[ -n "${BOSS_GH_APP_TOKEN}" ]]; then
+        echo "Boss cycle gh auth: GitHub App installation token (per-pass mint)."
+    fi
+fi
+
+# Export the shared per-pass App token into the calling (sub)shell's gh env.
+# No-op when the token is empty (App auth off or App config absent), so the
+# default gh auth path is preserved byte-for-byte.
+apply_boss_gh_app_token() {
+    if [[ -n "${BOSS_GH_APP_TOKEN}" ]]; then
+        export GH_TOKEN="${BOSS_GH_APP_TOKEN}"
+        export GITHUB_TOKEN="${BOSS_GH_APP_TOKEN}"
+        export ARAGORA_GITHUB_AUTH_SOURCE="github_app_installation"
+    fi
+}
+
 echo "Starting boss-loop cycle for ${boss_repo} (label=${boss_label})..."
 echo "Using Python interpreter: ${PYTHON_BIN}"
 set +e
@@ -47,8 +84,14 @@ echo "Boss loop exited with status ${boss_status}."
 # fails the cycle. Default off until the operator flips ARAGORA_QUORUM_RECONCILER=1.
 if [[ "${ARAGORA_QUORUM_RECONCILER:-0}" == "1" ]]; then
     echo "Running quorum-rerun reconciler (apply mode)..."
-    "${PYTHON_BIN}" scripts/quorum_rerun_reconciler.py --repo "${boss_repo}" --apply \
-        || echo "Quorum reconciler reported failures (non-fatal for the cycle)." >&2
+    # Subshell so the shared per-pass App token (when minted) backs the
+    # reconciler's gh check-run reads + `gh run rerun` calls without leaking
+    # into the boss-loop Python process. Degrades to existing gh auth when the
+    # token is empty.
+    (
+        apply_boss_gh_app_token
+        exec "${PYTHON_BIN}" scripts/quorum_rerun_reconciler.py --repo "${boss_repo}" --apply
+    ) || echo "Quorum reconciler reported failures (non-fatal for the cycle)." >&2
 fi
 
 if [[ "${POST_LOOP_ISSUE_REFILL}" != "1" ]]; then
@@ -80,4 +123,12 @@ if [[ "${POST_LOOP_DRY_RUN}" == "1" ]]; then
 fi
 
 echo "Running post-loop issue refill: ${refill_cmd[*]}"
-"${refill_cmd[@]}"
+# Subshell so the shared per-pass App token (when minted) backs the heaviest
+# read consumer in this cycle — generate_boss_issues.py's substrate-cap scan
+# (gh pr list + per-PR files). Degrades to existing gh auth when the token is
+# empty, preserving the default path byte-for-byte. The subshell propagates
+# the refill's exit status to the (set -e) parent exactly as the bare call did.
+(
+    apply_boss_gh_app_token
+    exec "${refill_cmd[@]}"
+)


### PR DESCRIPTION
## Problem

GraphQL secondary-rate-limit exhaustion on the operator PAT keeps stalling both the codex fleet and the Factory mission workers — and it also collides with operator admin merges (e.g. `gh pr merge … --admin` returning *"GraphQL: API rate limit already exceeded for user ID 33477136"*). The root cause is that the GraphQL budget is a **single per-user bucket** shared by the entire poller fleet.

The GitHub App installation token carries its **own separate** GraphQL budget. That bucket-separation idiom is already proven and running in `run_merge_arbiter.sh` and `run_codex_automation_publisher.sh`, but it had **not** propagated to the boss-loop launcher — one of the largest standing read consumers.

## What this changes

`scripts/run_boss_cycle.sh` shells out to two aux scripts that issue read-heavy `gh` calls via **raw `subprocess.run(["gh", ...])`**, so they inherit the operator PAT instead of self-minting an App token the way the boss-loop's own Python reads do via `aragora.swarm.github_app_auth`:

- `quorum_rerun_reconciler.py` — check-run reads + `gh run rerun`
- `generate_boss_issues.py` — **substrate-cap scan** (`gh pr list` + per-PR files), the heaviest GraphQL read each cycle

This PR mints **one per-pass App token** (gated on `ARAGORA_GH_APP_AUTH=1`, **default off**) and applies it inside subshells for exactly those two aux steps — byte-for-byte the arbiter idiom.

## Safety / scope

- **No merge-authority surface touched** (no changes to `review_queue.py`, the quorum workflow, evidence parsers, or settlement helpers).
- The boss-loop Python process itself is **left untouched** — it self-manages App auth per call and correctly keeps the PAT for write ops. The one-shot token is isolated inside each aux subshell so it never leaks into that process.
- **Fail-safe:** when the token is empty (App auth off, the default — or App config absent / mint fails), every block degrades to the existing `gh` auth path byte-for-byte.
- The token value is never echoed; `ARAGORA_GITHUB_AUTH_SOURCE` tags it so write ops can drop it.

## Verification

- `bash -n scripts/run_boss_cycle.sh` passes.
- Confirmed both aux scripts use raw `gh` subprocess (do not route through `gh_subprocess_run`), and that `gh_app_env.py --print-token --quiet` are the same flags the arbiter relies on.

## Follow-ups (not in this PR)

- The Factory mission pollers hit the same wall and should adopt App-token reads for their poll loops.
- Keep an0mium reserved solely for admin merges (the App token 403s on classic branch-protection `required_status_checks`).

https://claude.ai/code/session_018jfJj5gb9VoLs6VBMnzhrP

---
_Generated by [Claude Code](https://claude.ai/code/session_018jfJj5gb9VoLs6VBMnzhrP)_