### PR TITLE
fix(settle-tier4): accept admin collaborator settlements

### DIFF
--- a/scripts/settle_tier4_pr.py
+++ b/scripts/settle_tier4_pr.py
@@ -22,7 +22,9 @@ AUTHORIZED_MARKER = "Tier-4 Human Settlement Authorization"
 AUTHORIZED_MERGE_TOKENS = ("admin_squash_merge", "admin squash")
 AUTHORIZED_PROTECTION_TOKENS = ("branch_protection_reconcile", "branch protection reconcile")
 TRUSTED_OPERATOR_AUTHOR_ASSOCIATIONS = {"OWNER"}
-TRUSTED_OPERATOR_MEMBER_ASSOCIATIONS = {"COLLABORATOR", "MEMBER"}
+# GitHub reports some repo admins as COLLABORATOR rather than MEMBER. These
+# associations are trusted only after a live repo-admin permission check.
+TRUSTED_OPERATOR_PERMISSION_CHECKED_ASSOCIATIONS = {"COLLABORATOR", "MEMBER"}
 TRUSTED_OPERATOR_LOGINS_ENV = "ARAGORA_TIER4_TRUSTED_OPERATORS"
 PermissionChecker = Callable[[str], bool]
 HUMAN_SETTLEMENT_CONTEXT = "aragora/human-settlement"
@@ -188,13 +190,13 @@ def _is_trusted_operator_author(
     )
 
 
-def _trusted_member_requires_permission_check(
+def _trusted_operator_requires_permission_check(
     item: dict[str, Any],
     *,
     trusted_operator_logins: frozenset[str],
 ) -> bool:
     association = str(item.get("authorAssociation") or "").upper()
-    if association not in TRUSTED_OPERATOR_MEMBER_ASSOCIATIONS:
+    if association not in TRUSTED_OPERATOR_PERMISSION_CHECKED_ASSOCIATIONS:
         return False
     login = _author_login(item)
     if not login:
@@ -212,7 +214,7 @@ def _operator_author_rejection_reason(
     association = str(item.get("authorAssociation") or "").upper()
     if association in TRUSTED_OPERATOR_AUTHOR_ASSOCIATIONS:
         return ""
-    if association not in TRUSTED_OPERATOR_MEMBER_ASSOCIATIONS:
+    if association not in TRUSTED_OPERATOR_PERMISSION_CHECKED_ASSOCIATIONS:
         return f"authorAssociation {association or '<missing>'} is not trusted"
     login = _author_login(item)
     if not login:
@@ -222,7 +224,7 @@ def _operator_author_rejection_reason(
     if not evaluate_member_permissions:
         return ""
     if not permission_checker(login):
-        return f"trusted member {login or '<missing>'} lacks admin permission"
+        return f"trusted operator {login or '<missing>'} lacks admin permission"
     return ""
 
 
@@ -257,7 +259,7 @@ def _authorization_diagnostic(
         permission_checker=permission_checker,
         evaluate_member_permissions=evaluate_member_permissions,
     )
-    admin_permission_required = _trusted_member_requires_permission_check(
+    admin_permission_required = _trusted_operator_requires_permission_check(
         item,
         trusted_operator_logins=trusted_operator_logins,
     )
@@ -276,7 +278,7 @@ def _authorization_diagnostic(
         rejection_reasons.append(author_rejection)
     if admin_permission_required and not evaluate_member_permissions:
         rejection_reasons.append(
-            "trusted member admin permission was not evaluated because earlier gate blockers are present"
+            "trusted operator admin permission was not evaluated because earlier gate blockers are present"
         )
     if not fresh_after_head_commit:
         rejection_reasons.append("authorization is older than head commit")

--- a/scripts/settle_tier4_pr.py
+++ b/scripts/settle_tier4_pr.py
@@ -22,7 +22,7 @@ AUTHORIZED_MARKER = "Tier-4 Human Settlement Authorization"
 AUTHORIZED_MERGE_TOKENS = ("admin_squash_merge", "admin squash")
 AUTHORIZED_PROTECTION_TOKENS = ("branch_protection_reconcile", "branch protection reconcile")
 TRUSTED_OPERATOR_AUTHOR_ASSOCIATIONS = {"OWNER"}
-TRUSTED_OPERATOR_MEMBER_ASSOCIATIONS = {"MEMBER"}
+TRUSTED_OPERATOR_MEMBER_ASSOCIATIONS = {"COLLABORATOR", "MEMBER"}
 TRUSTED_OPERATOR_LOGINS_ENV = "ARAGORA_TIER4_TRUSTED_OPERATORS"
 PermissionChecker = Callable[[str], bool]
 HUMAN_SETTLEMENT_CONTEXT = "aragora/human-settlement"
@@ -1255,9 +1255,9 @@ def build_parser() -> argparse.ArgumentParser:
         action="append",
         default=[],
         help=(
-            "Restrict repo-visible MEMBER authorization comments to this admin "
+            "Restrict repo-visible MEMBER/COLLABORATOR authorization comments to this admin "
             "login. Repeatable; also reads comma-separated "
-            f"{TRUSTED_OPERATOR_LOGINS_ENV}. If omitted, any live admin MEMBER "
+            f"{TRUSTED_OPERATOR_LOGINS_ENV}. If omitted, any live admin MEMBER/COLLABORATOR "
             f"may authorize when {HUMAN_SETTLEMENT_CONTEXT} is success. "
             "--settle-only additionally requires the invoking gh login to be "
             "present in this allowlist and have admin/OWNER authority."

--- a/tests/scripts/test_settle_tier4_pr.py
+++ b/tests/scripts/test_settle_tier4_pr.py
@@ -338,6 +338,31 @@ def test_configured_trusted_member_comment_authorizes(monkeypatch: Any) -> None:
     assert result["blockers"] == []
 
 
+def test_configured_trusted_collaborator_comment_authorizes(monkeypatch: Any) -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    monkeypatch.setenv("ARAGORA_TIER4_TRUSTED_OPERATORS", "trusted-admin")
+    result = settler.evaluate_tier4_gate(
+        pr=7423,
+        expected_head=head,
+        pr_view=_pr_view(
+            head,
+            comments=[
+                _authorized_comment(
+                    head,
+                    association="COLLABORATOR",
+                    author="trusted-admin",
+                )
+            ],
+        ),
+        merge_packet=_tier4_packet(),
+        required_checks=_valid_checks(),
+        permission_checker=lambda login: login == "trusted-admin",
+    )
+
+    assert result["ok"] is True
+    assert result["blockers"] == []
+
+
 def test_configured_trusted_member_permission_check_runs_once(monkeypatch: Any) -> None:
     head = "57c740022e3c432718462efa12ca79f1df4f674d"
     checked_logins: list[str] = []
@@ -382,6 +407,31 @@ def test_trusted_member_comment_requires_admin_permission(monkeypatch: Any) -> N
     assert "missing repo-visible Tier 4 operator settlement comment" in result["blockers"]
 
 
+def test_trusted_collaborator_comment_requires_admin_permission(monkeypatch: Any) -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    monkeypatch.setenv("ARAGORA_TIER4_TRUSTED_OPERATORS", "trusted-collaborator")
+    result = settler.evaluate_tier4_gate(
+        pr=7423,
+        expected_head=head,
+        pr_view=_pr_view(
+            head,
+            comments=[
+                _authorized_comment(
+                    head,
+                    association="COLLABORATOR",
+                    author="trusted-collaborator",
+                )
+            ],
+        ),
+        merge_packet=_tier4_packet(),
+        required_checks=_valid_checks(),
+        permission_checker=lambda login: False,
+    )
+
+    assert result["ok"] is False
+    assert "missing repo-visible Tier 4 operator settlement comment" in result["blockers"]
+
+
 def test_admin_member_comment_does_not_require_explicit_allowlist() -> None:
     head = "57c740022e3c432718462efa12ca79f1df4f674d"
     result = settler.evaluate_tier4_gate(
@@ -398,6 +448,47 @@ def test_admin_member_comment_does_not_require_explicit_allowlist() -> None:
 
     assert result["ok"] is True
     assert result["blockers"] == []
+
+
+def test_settle_only_trusted_admin_collaborator_matches_check_rule() -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    precondition = settler.evaluate_tier4_settlement_preconditions(
+        pr=7423,
+        expected_head=head,
+        pr_view=_pr_view(head, comments=[], human_settlement_state=None),
+        merge_packet=_tier4_packet(),
+        required_checks=[
+            {"name": "lint", "state": "SUCCESS"},
+            {"name": "aragora-merge-quorum", "state": "FAILURE"},
+        ],
+        trusted_operator_logins=["trusted-admin"],
+        invoker_login="trusted-admin",
+        invoker_has_admin_permission=True,
+        require_trusted_invoker=True,
+        require_invoker_admin_permission=True,
+    )
+    check = settler.evaluate_tier4_gate(
+        pr=7423,
+        expected_head=head,
+        pr_view=_pr_view(
+            head,
+            comments=[
+                _authorized_comment(
+                    head,
+                    association="COLLABORATOR",
+                    author="trusted-admin",
+                )
+            ],
+        ),
+        merge_packet=_tier4_packet(),
+        required_checks=_valid_checks(),
+        trusted_operator_logins=["trusted-admin"],
+        permission_checker=lambda login: login == "trusted-admin",
+    )
+
+    assert precondition["ok"] is True
+    assert check["ok"] is True
+    assert check["blockers"] == []
 
 
 def test_cli_trusted_operator_login_authorizes_member_comment(

--- a/tests/scripts/test_settle_tier4_pr.py
+++ b/tests/scripts/test_settle_tier4_pr.py
@@ -450,6 +450,24 @@ def test_admin_member_comment_does_not_require_explicit_allowlist() -> None:
     assert result["blockers"] == []
 
 
+def test_admin_collaborator_comment_does_not_require_explicit_allowlist() -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    result = settler.evaluate_tier4_gate(
+        pr=7423,
+        expected_head=head,
+        pr_view=_pr_view(
+            head,
+            comments=[_authorized_comment(head, association="COLLABORATOR", author="an0mium")],
+        ),
+        merge_packet=_tier4_packet(),
+        required_checks=_valid_checks(),
+        permission_checker=lambda login: login == "an0mium",
+    )
+
+    assert result["ok"] is True
+    assert result["blockers"] == []
+
+
 def test_settle_only_trusted_admin_collaborator_matches_check_rule() -> None:
     head = "57c740022e3c432718462efa12ca79f1df4f674d"
     precondition = settler.evaluate_tier4_settlement_preconditions(
@@ -623,7 +641,7 @@ def test_head_mismatch_skips_member_permission_check(monkeypatch: Any) -> None:
     assert diagnostic["admin_permission_required"] is True
     assert diagnostic["admin_permission_evaluated"] is False
     assert (
-        "trusted member admin permission was not evaluated because earlier gate blockers are present"
+        "trusted operator admin permission was not evaluated because earlier gate blockers are present"
         in diagnostic["rejection_reasons"]
     )
 
@@ -679,7 +697,7 @@ def test_failed_required_check_skips_member_permission_check(monkeypatch: Any) -
     assert diagnostic["admin_permission_required"] is True
     assert diagnostic["admin_permission_evaluated"] is False
     assert (
-        "trusted member admin permission was not evaluated because earlier gate blockers are present"
+        "trusted operator admin permission was not evaluated because earlier gate blockers are present"
         in diagnostic["rejection_reasons"]
     )
 
@@ -769,7 +787,7 @@ def test_unexpected_packet_blocker_does_not_report_missing_trusted_member_commen
     assert diagnostic["admin_permission_required"] is True
     assert diagnostic["admin_permission_evaluated"] is False
     assert (
-        "trusted member admin permission was not evaluated because earlier gate blockers are present"
+        "trusted operator admin permission was not evaluated because earlier gate blockers are present"
         in diagnostic["rejection_reasons"]
     )
 


### PR DESCRIPTION
## Summary
- Treat trusted `COLLABORATOR` settlement comments like `MEMBER` comments when live repo admin permission verifies the login.
- Keep non-admin collaborators rejected.
- Add regression coverage for admin collaborator acceptance, non-admin collaborator rejection, and settle-only/check trust consistency.

## Validation
- `python3 -m pytest tests/scripts/test_settle_tier4_pr.py`
- `git diff --check`

## Notes
- Does not merge or mutate PR #8392.
- Root cause observed: GitHub reports trusted/admin settlement comments as `COLLABORATOR`, while `settle_tier4_pr.py --check` only treated `OWNER` and admin `MEMBER` as trusted.