### PR TITLE
[codex] fix Tier 4 settle-only quorum proof

### DIFF
--- a/scripts/settle_tier4_pr.py
+++ b/scripts/settle_tier4_pr.py
@@ -44,6 +44,9 @@ OPERATOR_COMMENT_BLOCKER = "missing repo-visible Tier 4 operator settlement comm
 REQUIRED_CHECKS_BLOCKER = "required checks are missing"
 REQUIRED_CHECK_VISIBILITY_SKEW_BLOCKER = "required_check_visibility_skew"
 REQUIRED_CHECK_REST_VISIBILITY_CONTEXT = "required check REST visibility"
+MERGE_QUORUM_SETTLEMENT_PROOF_BLOCKER = (
+    "aragora-merge-quorum failure is not proven to be missing human settlement"
+)
 SETTLE_ONLY_TRUSTED_OPERATOR_BLOCKER = "trusted operator allowlist is required for --settle-only"
 SETTLE_ONLY_INVOKER_BLOCKER = "could not determine gh login for --settle-only"
 SETTLE_ONLY_ADMIN_PERMISSION_BLOCKER = "admin/OWNER permission required for --settle-only"
@@ -582,6 +585,94 @@ def _required_check_context(check: dict[str, Any]) -> str:
     return str(check.get("name") or check.get("context") or "").strip()
 
 
+def _required_check_is_merge_quorum(check: dict[str, Any]) -> bool:
+    return _required_check_context(check) == MERGE_QUORUM_CONTEXT
+
+
+def _required_quorum_only_failure(required_checks: list[dict[str, Any]] | None) -> bool:
+    if not required_checks:
+        return False
+    saw_quorum_failure = False
+    for check in required_checks:
+        if not isinstance(check, dict):
+            continue
+        state = _required_check_state(check)
+        if _state_is_success(state):
+            continue
+        if _required_check_is_merge_quorum(check):
+            saw_quorum_failure = True
+            continue
+        return False
+    return saw_quorum_failure
+
+
+def _packet_proves_quorum_missing_settlement(merge_packet: dict[str, Any], *, pr: int) -> bool:
+    entry = _entry_for_pr(merge_packet, pr=pr)
+    if not entry:
+        return False
+    if bool(entry.get("unresolved_dissent")):
+        return False
+    return _packet_marks_tier4_human_settlement(merge_packet, pr=pr)
+
+
+def _check_link(check: dict[str, Any]) -> str:
+    for key in ("link", "detailsUrl", "details_url", "target_url", "targetUrl", "url"):
+        value = str(check.get(key) or "").strip()
+        if value:
+            return value
+    return ""
+
+
+def _github_actions_job_id_from_url(url: str) -> str:
+    if "/job/" not in url:
+        return ""
+    tail = url.split("/job/", 1)[1]
+    candidate = tail.split("?", 1)[0].split("#", 1)[0].split("/", 1)[0]
+    return candidate if candidate.isdigit() else ""
+
+
+def _quorum_failure_log_proves_missing_settlement(
+    required_checks: list[dict[str, Any]] | None,
+    *,
+    repo: str,
+    cwd: Path,
+    head: str,
+) -> bool:
+    if not _required_quorum_only_failure(required_checks):
+        return False
+    quorum_check = next(
+        (
+            check
+            for check in required_checks or []
+            if isinstance(check, dict)
+            and _required_check_is_merge_quorum(check)
+            and not _state_is_success(_required_check_state(check))
+        ),
+        None,
+    )
+    if quorum_check is None:
+        return False
+    job_id = _github_actions_job_id_from_url(_check_link(quorum_check))
+    if not job_id:
+        return False
+    try:
+        log = _run_text_command(
+            ["gh", "run", "view", "--repo", repo, "--job", job_id, "--log-failed"],
+            cwd=cwd,
+        )
+    except (OSError, RuntimeError, subprocess.SubprocessError):
+        return False
+    lowered = log.lower()
+    head_prefix = str(head or "").strip().lower()[:12]
+    if len(head_prefix) < 12:
+        return False
+    return (
+        "no human settlement signal is recorded" in lowered
+        and HUMAN_SETTLEMENT_CONTEXT.lower() in lowered
+        and head_prefix in lowered
+    )
+
+
 def _rollup_check_context(item: dict[str, Any]) -> str:
     return str(item.get("name") or item.get("context") or "").strip()
 
@@ -788,6 +879,7 @@ def evaluate_tier4_settlement_preconditions(
     pr_view: dict[str, Any],
     merge_packet: dict[str, Any],
     required_checks: list[dict[str, Any]] | None = None,
+    quorum_missing_settlement_proof: bool = False,
     trusted_operator_logins: Sequence[str] | None = None,
     invoker_login: str | None = None,
     invoker_has_admin_permission: bool | None = None,
@@ -808,12 +900,27 @@ def evaluate_tier4_settlement_preconditions(
     if not required_checks:
         blockers.append(REQUIRED_CHECKS_BLOCKER)
     else:
+        packet_missing_settlement_proof = _packet_proves_quorum_missing_settlement(
+            merge_packet, pr=pr
+        )
+        has_quorum_missing_settlement_proof = (
+            packet_missing_settlement_proof or quorum_missing_settlement_proof
+        )
+        quorum_only_failure = _required_quorum_only_failure(required_checks)
         for check in required_checks:
             name = _required_check_name(check)
             state = _required_check_state(check)
-            if _state_is_success(state) or name == "aragora-merge-quorum":
+            if _state_is_success(state):
+                continue
+            if (
+                _required_check_is_merge_quorum(check)
+                and quorum_only_failure
+                and has_quorum_missing_settlement_proof
+            ):
                 continue
             blockers.append(f"required check {name} is {state}")
+        if quorum_only_failure and not has_quorum_missing_settlement_proof:
+            blockers.append(MERGE_QUORUM_SETTLEMENT_PROOF_BLOCKER)
 
     not_ready = merge_packet.get("not_ready")
     if isinstance(not_ready, list):
@@ -1551,12 +1658,23 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         applied_commands: list[list[str]] = []
         if args.settle_only:
+            quorum_missing_settlement_proof = False
+            if _required_quorum_only_failure(
+                required_checks
+            ) and not _packet_proves_quorum_missing_settlement(merge_packet, pr=args.pr):
+                quorum_missing_settlement_proof = _quorum_failure_log_proves_missing_settlement(
+                    required_checks,
+                    repo=args.repo,
+                    cwd=args.cwd,
+                    head=args.head,
+                )
             gate = evaluate_tier4_settlement_preconditions(
                 pr=args.pr,
                 expected_head=args.head,
                 pr_view=pr_view,
                 merge_packet=merge_packet,
                 required_checks=required_checks,
+                quorum_missing_settlement_proof=quorum_missing_settlement_proof,
                 trusted_operator_logins=args.trusted_operator_login,
             )
             if not gate["ok"]:
@@ -1576,6 +1694,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 pr_view=pr_view,
                 merge_packet=merge_packet,
                 required_checks=required_checks,
+                quorum_missing_settlement_proof=quorum_missing_settlement_proof,
                 trusted_operator_logins=args.trusted_operator_login,
                 invoker_login=invoker_login,
                 invoker_has_admin_permission=invoker_has_admin_permission,

--- a/tests/scripts/test_settle_tier4_pr.py
+++ b/tests/scripts/test_settle_tier4_pr.py
@@ -108,6 +108,19 @@ def _tier4_packet(
     }
 
 
+def _tier4_repair_packet_missing_settlement(pr: int = 7423) -> dict[str, Any]:
+    packet = _tier4_packet(pr=pr)
+    packet["not_ready"] = [pr]
+    packet["entries"][0]["status"] = "repair_or_wait"
+    packet["entries"][0]["verdict"] = "not_ready_for_settlement"
+    packet["entries"][0]["requires_human_risk_settlement"] = True
+    packet["entries"][0]["reasons"] = [
+        "workflow/deploy/destructive surface touched",
+        "checks are failing; repair before settlement",
+    ]
+    return packet
+
+
 def _valid_checks() -> list[dict[str, str]]:
     return [
         {"name": "lint", "state": "SUCCESS"},
@@ -1531,6 +1544,155 @@ def test_settle_only_posts_comment_and_status_without_merge(
             None,
         )
     ]
+
+
+def test_settle_only_requires_proof_for_quorum_only_repair_packet() -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+
+    result = settler.evaluate_tier4_settlement_preconditions(
+        pr=7423,
+        expected_head=head,
+        pr_view=_pr_view(head, comments=[], human_settlement_state=None),
+        merge_packet=_tier4_repair_packet_missing_settlement(),
+        required_checks=[
+            {"name": "lint", "state": "SUCCESS"},
+            {"name": "aragora-merge-quorum", "state": "FAILURE"},
+        ],
+    )
+
+    assert result["ok"] is False
+    assert (
+        "aragora-merge-quorum failure is not proven to be missing human settlement"
+        in result["blockers"]
+    )
+
+
+def test_settle_only_allows_quorum_only_repair_packet_with_log_proof(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    text_commands: list[tuple[list[str], str | None]] = []
+    commands: list[tuple[list[str], str | None]] = []
+    proof_calls: list[tuple[list[dict[str, str]], str]] = []
+    required_checks = [
+        {"name": "lint", "state": "SUCCESS"},
+        {
+            "name": "aragora-merge-quorum",
+            "state": "FAILURE",
+            "link": "https://github.example/synaptent/aragora/actions/runs/123/job/456",
+        },
+    ]
+
+    monkeypatch.setattr(
+        settler,
+        "_load_live_inputs",
+        lambda pr, *, cwd, repo=settler.DEFAULT_REPO: (
+            _pr_view(head, comments=[], human_settlement_state=None),
+            _tier4_repair_packet_missing_settlement(),
+            required_checks,
+        ),
+    )
+
+    def fake_quorum_proof(checks: list[dict[str, str]], *, repo: str, cwd: Path, head: str) -> bool:
+        proof_calls.append((checks, head))
+        return True
+
+    monkeypatch.setattr(settler, "_quorum_failure_log_proves_missing_settlement", fake_quorum_proof)
+    monkeypatch.setattr(
+        settler,
+        "_run_text_command",
+        lambda command, cwd, input_text=None: (
+            text_commands.append((command, input_text))
+            or "https://github.example/pr/7423#issuecomment-1\n"
+        ),
+    )
+    monkeypatch.setattr(
+        settler,
+        "_run_command",
+        lambda command, cwd, input_text=None: commands.append((command, input_text)),
+    )
+    monkeypatch.setattr(settler, "_current_gh_login", lambda cwd: "trusted-member")
+    monkeypatch.setattr(
+        settler,
+        "_login_has_admin_permission",
+        lambda login, repo, cwd: login == "trusted-member",
+    )
+
+    rc = settler.main(
+        [
+            "--settle-only",
+            "--pr",
+            "7423",
+            "--head",
+            head,
+            "--trusted-operator-login",
+            "trusted-member",
+            "--cwd",
+            str(tmp_path),
+        ]
+    )
+
+    assert rc == 0
+    assert proof_calls == [(required_checks, head)]
+    assert text_commands[0][0][:3] == ["gh", "pr", "comment"]
+    assert commands[0][0][:3] == ["gh", "api", "--method"]
+
+
+def test_quorum_failure_log_proves_missing_human_settlement(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    calls: list[list[str]] = []
+
+    def fake_run_text_command(
+        command: list[str], *, cwd: Path, input_text: str | None = None
+    ) -> str:
+        calls.append(command)
+        return (
+            "Tier 4: model quorum prepared the risk packet, but no human "
+            f"settlement signal is recorded for head {head[:12]}. "
+            "The operator must record settlement and set the "
+            "'Aragora/Human-Settlement' commit status."
+        )
+
+    monkeypatch.setattr(settler, "_run_text_command", fake_run_text_command)
+
+    assert (
+        settler._quorum_failure_log_proves_missing_settlement(
+            [
+                {"name": "lint", "state": "SUCCESS"},
+                {
+                    "name": "aragora-merge-quorum",
+                    "state": "FAILURE",
+                    "link": "https://github.example/synaptent/aragora/actions/runs/123/job/456",
+                },
+            ],
+            repo="synaptent/aragora",
+            cwd=tmp_path,
+            head=head,
+        )
+        is True
+    )
+    assert calls == [
+        ["gh", "run", "view", "--repo", "synaptent/aragora", "--job", "456", "--log-failed"]
+    ]
+
+    assert (
+        settler._quorum_failure_log_proves_missing_settlement(
+            [
+                {"name": "lint", "state": "SUCCESS"},
+                {
+                    "name": "aragora-merge-quorum",
+                    "state": "FAILURE",
+                    "link": "https://github.example/synaptent/aragora/actions/runs/123/job/456",
+                },
+            ],
+            repo="synaptent/aragora",
+            cwd=tmp_path,
+            head="short",
+        )
+        is False
+    )
 
 
 def test_settle_only_rejects_untrusted_invoking_login(


### PR DESCRIPTION
## Summary
- require explicit packet/log proof before `--settle-only` ignores a failed `aragora-merge-quorum` required check
- read the failed quorum job log to recognize the exact missing `aragora/human-settlement` settlement sentinel
- add focused regression coverage for quorum-only repair packets with and without proof

## Test Plan
- `pytest tests/scripts/test_settle_tier4_pr.py -q`
- `python3 -m ruff check scripts/settle_tier4_pr.py tests/scripts/test_settle_tier4_pr.py`
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Scope
This is a separate tooling repair for the #8397 settlement-only ordering issue. It does not merge, settle, rerun, or mutate #8397.