### PR TITLE
fix(status): guard TW03 render against stale source

### DIFF
--- a/scripts/render_rescue_productization_status.py
+++ b/scripts/render_rescue_productization_status.py
@@ -4,13 +4,16 @@
 from __future__ import annotations
 
 import argparse
+import datetime as dt
 import json
+import re
 from pathlib import Path
 from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_REPORT_ROOT = REPO_ROOT / "docs" / "status" / "generated" / "rescue_productization"
 DEFAULT_OUTPUT = REPO_ROOT / "docs" / "status" / "TW03_RESCUE_PRODUCTIZATION_STATUS.md"
+_LAST_UPDATED_PATTERN = re.compile(r"^\s*Last\s+updated\s*:\s*(?P<value>\S+)\s*$")
 
 
 def _repo_stable_path(path: Path) -> str:
@@ -26,6 +29,50 @@ def _load_json(path: Path) -> dict[str, Any]:
     if not isinstance(payload, dict):
         raise ValueError(f"JSON payload at {path} must be an object")
     return payload
+
+
+def _coerce_utc_timestamp(raw: str) -> dt.datetime:
+    value = raw.strip()
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    parsed = dt.datetime.fromisoformat(value)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.timezone.utc)
+    return parsed.astimezone(dt.timezone.utc)
+
+
+def _existing_last_updated(path: Path) -> str | None:
+    if not path.exists():
+        return None
+    for line in path.read_text(encoding="utf-8").splitlines():
+        match = _LAST_UPDATED_PATTERN.match(line)
+        if match:
+            return match.group("value").strip()
+    return None
+
+
+def _ensure_report_not_older_than_existing_status(
+    *,
+    report_path: Path,
+    output_path: Path,
+    payload: dict[str, Any],
+) -> None:
+    generated_at = str(payload.get("generated_at") or "").strip()
+    existing_last_updated = _existing_last_updated(output_path)
+    if not generated_at or not existing_last_updated:
+        return
+
+    report_updated = _coerce_utc_timestamp(generated_at)
+    status_updated = _coerce_utc_timestamp(existing_last_updated)
+    if report_updated >= status_updated:
+        return
+
+    raise SystemExit(
+        "refusing to render stale rescue productization report: "
+        f"{_repo_stable_path(report_path)} generated_at={generated_at} is older than "
+        f"{_repo_stable_path(output_path)} Last updated={existing_last_updated}; "
+        "refresh docs/status/generated/rescue_productization/latest.json before rendering"
+    )
 
 
 def _format_value(value: Any) -> str:
@@ -181,7 +228,13 @@ def main(argv: list[str] | None = None) -> int:
     if not report_path.exists():
         raise SystemExit(f"rescue productization report not found: {report_path}")
 
-    content = render_status_markdown(report_path=report_path, payload=_load_json(report_path))
+    payload = _load_json(report_path)
+    _ensure_report_not_older_than_existing_status(
+        report_path=report_path,
+        output_path=output_path,
+        payload=payload,
+    )
+    content = render_status_markdown(report_path=report_path, payload=payload)
     written = write_output(output_path, content)
     print(str(written))
     return 0

--- a/tests/scripts/test_render_rescue_productization_status.py
+++ b/tests/scripts/test_render_rescue_productization_status.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 _scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
 if _scripts_dir not in sys.path:
     sys.path.insert(0, _scripts_dir)
@@ -131,3 +133,47 @@ def test_main_writes_output_from_latest_report(tmp_path: Path) -> None:
     rendered = output_path.read_text(encoding="utf-8")
     assert "No repeated rescue classes found in the current ledger window." in rendered
     assert "Last updated: 2026-04-14T18:42:00Z" in rendered
+
+
+def test_main_refuses_to_downgrade_existing_status_from_stale_report(tmp_path: Path) -> None:
+    report_root = tmp_path / "generated" / "rescue_productization"
+    report_root.mkdir(parents=True)
+    latest_path = report_root / "latest.json"
+    latest_path.write_text(
+        """{
+  "generated_at": "2026-06-04T13:31:36Z",
+  "ledger_path": "/Users/test/.aragora/rescue_events.jsonl",
+  "productization_map_path": "docs/benchmarks/rescue_productization.json",
+  "summary": {
+    "repeated_class_count": 0,
+    "linked_fixture_count": 0,
+    "linked_issue_count": 0,
+    "linked_other_count": 0,
+    "unlinked_repeated_class_count": 0,
+    "one_off_class_count": 0,
+    "below_threshold_class_count": 0
+  },
+  "repeated_classes": [],
+  "issue_linkage_results": [],
+  "issue_drafts": [],
+  "one_off_classes": [],
+  "below_threshold_classes": []
+}
+""",
+        encoding="utf-8",
+    )
+    output_path = tmp_path / "TW03_RESCUE_PRODUCTIZATION_STATUS.md"
+    original = "# TW-03 Rescue Productization Status\n\nLast updated: 2026-06-14T03:48:49Z\n"
+    output_path.write_text(original, encoding="utf-8")
+
+    with pytest.raises(SystemExit, match="refusing to render stale rescue productization report"):
+        mod.main(
+            [
+                "--report-root",
+                str(report_root),
+                "--output",
+                str(output_path),
+            ]
+        )
+
+    assert output_path.read_text(encoding="utf-8") == original


### PR DESCRIPTION
## Summary
- prevent TW03 status rendering from silently downgrading a newer committed status doc from stale rescue-productization latest.json
- add a focused regression test proving stale report data leaves the existing status untouched

## Validation
- PATH=/Users/armand/.pyenv/versions/3.11.11/bin:$PATH python3 -m pytest tests/scripts/test_render_rescue_productization_status.py tests/scripts/test_refresh_proof_surfaces.py -q
- PATH=/Users/armand/.pyenv/versions/3.11.11/bin:$PATH python3 scripts/render_rescue_productization_status.py (expected stale-source failure on current main data)
- git diff --check origin/main HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD