### PR TITLE
fix(automation): honor CODEX_HOME in desktop check

### DIFF
--- a/scripts/check_codex_desktop_automations.py
+++ b/scripts/check_codex_desktop_automations.py
@@ -26,6 +26,13 @@ PROMPT_WORDS_BY_ROLE = {
 }
 
 
+def _default_automation_root() -> Path:
+    configured = os.environ.get("CODEX_HOME")
+    if configured:
+        return Path(configured).expanduser() / "automations"
+    return Path.home() / ".codex" / "automations"
+
+
 @dataclass(frozen=True)
 class AutomationRecord:
     id: str
@@ -289,8 +296,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--root",
         type=Path,
-        default=Path.home() / ".codex" / "automations",
-        help="Codex Desktop automation directory",
+        default=_default_automation_root(),
+        help="Codex Desktop automation directory (default: $CODEX_HOME/automations or ~/.codex/automations)",
     )
     parser.add_argument("--json", action="store_true")
     parser.add_argument(

--- a/tests/scripts/test_check_codex_desktop_automations.py
+++ b/tests/scripts/test_check_codex_desktop_automations.py
@@ -252,6 +252,31 @@ def test_summary_only_payload_omits_core_writer_prompts(tmp_path: Path) -> None:
     )
 
 
+def test_main_defaults_root_from_codex_home_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import check_codex_desktop_automations as mod
+
+    codex_home = tmp_path / "custom-codex-home"
+    automation_root = codex_home / "automations"
+    prompt = "Read memory, repair one branch, validate locally, run preflight, then refresh outbox."
+    for automation_id, minute in mod.CORE_WRITERS.items():
+        _write_automation(
+            automation_root,
+            automation_id,
+            name=f"{automation_id} Writer",
+            prompt=prompt,
+            byminute=minute,
+        )
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    assert mod.main(["--json", "--summary-only"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["root"] == str(automation_root)
+    assert payload["summary"] == {"active_count": 4, "error_count": 0, "warning_count": 0}
+
+
 def test_main_summary_only_json_omits_prompts(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
## Summary
- make check_codex_desktop_automations.py default to $CODEX_HOME/automations when CODEX_HOME is set
- add a CLI regression test covering the env-derived root

## Validation
- PYTHONDONTWRITEBYTECODE=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/scripts/test_check_codex_desktop_automations.py -p no:rerunfailures -p no:cacheprovider
- python3 -m py_compile scripts/check_codex_desktop_automations.py
- python3 -m ruff check scripts/check_codex_desktop_automations.py tests/scripts/test_check_codex_desktop_automations.py
- python3 -m ruff format --check scripts/check_codex_desktop_automations.py tests/scripts/test_check_codex_desktop_automations.py
- CODEX_HOME=/Users/armand/.codex python3 scripts/check_codex_desktop_automations.py --json --summary-only
- bash scripts/automation_pr_preflight.sh origin/main HEAD

Co-authored-by: codex[bot] <codex[bot]@users.noreply.github.com>