### PR TITLE
feat(automation): Tier-4 merge-train to serialize contention-surface PRs

### DIFF
--- a/scripts/automation_pr_preflight.sh
+++ b/scripts/automation_pr_preflight.sh
@@ -229,4 +229,33 @@ fi
 
 echo "preflight: changed files"
 printf '%s\n' "${changed_files}" | sed 's/^/  - /'
+
+# Opt-in Tier-4 merge-train guard (default off; flip ARAGORA_TIER4_MERGE_TRAIN=1).
+# Refuses to add an (N+1)th concurrent open PR to a serialized Tier-4 surface
+# (e.g. scripts/settle_tier4_pr.py), which is what creates the settlement
+# pile-up + re-conflict churn. Best-effort: a transport/tooling failure warns
+# and does NOT block (only a clean queue decision, exit 2, fails the preflight).
+# Reads open-PR state via the App token, so it never burns the operator PAT.
+if [[ "${ARAGORA_TIER4_MERGE_TRAIN:-0}" == "1" ]]; then
+    changed_csv="$(printf '%s\n' "${changed_files}" | sed '/^$/d' | paste -sd, -)"
+    train_args=(--check --changed-files "${changed_csv}" --repo "${ARAGORA_TIER4_MERGE_TRAIN_REPO:-synaptent/aragora}")
+    if [[ -n "${ARAGORA_TIER4_MERGE_TRAIN_PR:-}" ]]; then
+        train_args+=(--candidate-pr "${ARAGORA_TIER4_MERGE_TRAIN_PR}")
+    fi
+    if [[ -n "${ARAGORA_TIER4_MERGE_TRAIN_CAP:-}" ]]; then
+        train_args+=(--cap "${ARAGORA_TIER4_MERGE_TRAIN_CAP}")
+    fi
+    set +e
+    train_out="$(python3 scripts/tier4_merge_train.py "${train_args[@]}" 2>&1)"
+    train_rc=$?
+    set -e
+    if [[ "${train_rc}" -eq 2 ]]; then
+        fail_preflight 2 "tier-4 merge-train lane full: ${train_out}"
+    elif [[ "${train_rc}" -ne 0 ]]; then
+        echo "preflight: tier-4 merge-train check skipped (non-fatal): ${train_out}" >&2
+    else
+        echo "preflight: tier-4 merge-train lane has room"
+    fi
+fi
+
 echo "preflight: ok"

--- a/scripts/tier4_merge_train.py
+++ b/scripts/tier4_merge_train.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""Serialize concurrent PRs that touch a Tier-4 merge-authority surface.
+
+Problem this solves
+--------------------
+When many open PRs edit the same Tier-4 file (``scripts/settle_tier4_pr.py``
+is the worst offender), every one of them must run the full human-settlement
+dance *and* re-conflicts the others on merge. The fleet ends up generating the
+very settlement toil the gate exists to prevent — a six-way pile-up where each
+landing forces a rebase of all the rest.
+
+The merge-train fixes the *class*: it treats each Tier-4 contention surface as
+a single-lane track. At most ``cap`` open PRs (default 1) may touch a given
+surface at once; the rest are *queued* in a deterministic order behind the
+head-of-train. A pre-open check (``--check``) refuses to add an (N+1)th PR to a
+full lane, and ``--status`` shows the current train per surface so the operator
+can land them head-first, rebasing each on the prior.
+
+Design
+------
+The core (``evaluate_merge_train`` / ``build_train`` / ``serialized_paths_for``)
+is pure: it takes an explicit list of open PRs and a candidate's changed files
+and returns a decision. All GitHub I/O lives at the edges (``fetch_open_prs``)
+and is App-token-routed via ``scripts/gh_app_env.py`` so the check never burns
+the operator PAT's GraphQL budget. This keeps the module import-clean (stdlib
+only) and unit-testable without a live ``gh``.
+
+The serialized-surface list mirrors ``review_queue.TIER_4_PREFIXES`` — the
+canonical Tier-4 classifier. It is vendored here (not imported) to keep this
+module dependency-light; ``tests/scripts/test_tier4_merge_train.py`` carries a
+drift guard that fails if the two ever diverge.
+
+Usage
+-----
+    # Would opening this PR overflow a Tier-4 lane?
+    python3 scripts/tier4_merge_train.py --check --changed-files scripts/settle_tier4_pr.py
+    python3 scripts/tier4_merge_train.py --check --base origin/main --head HEAD --repo synaptent/aragora
+
+    # Show the current train (which PR is head, which are queued) per surface.
+    python3 scripts/tier4_merge_train.py --status --repo synaptent/aragora --json
+
+Exit codes: 0 = allowed (lane has room), 2 = queued (lane full), 1 = usage/error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Callable, Iterable, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_REPO = "synaptent/aragora"
+DEFAULT_CAP = 1
+GH_TIMEOUT_SECONDS = 30
+
+# Mirror of ``aragora.cli.commands.review_queue.TIER_4_PREFIXES`` — the canonical
+# Tier-4 (human-preapproval / merge-authority) classifier. Vendored to keep this
+# module stdlib-only; the drift guard in the focused test fails if it diverges.
+SERIALIZED_TIER4_PREFIXES: tuple[str, ...] = (
+    ".github/workflows/",
+    "deploy/",
+    "docker/",
+    "k8s/",
+    "aragora/cli/commands/review_queue.py",
+    "aragora/cli/parser.py",
+    "scripts/settle_tier4_pr.py",
+    "scripts/settle_one_pr.py",
+    "scripts/merge_codex_automation_prs.py",
+)
+
+ALLOW = "allow"
+QUEUE = "queue"
+
+
+def matches_serialized_path(path: str) -> str | None:
+    """Return the serialized Tier-4 prefix ``path`` falls under, or ``None``.
+
+    A directory prefix (``.github/workflows/``) matches any file beneath it; an
+    exact file entry matches only that file.
+    """
+    candidate = str(path or "").strip()
+    if not candidate:
+        return None
+    for prefix in SERIALIZED_TIER4_PREFIXES:
+        if prefix.endswith("/"):
+            if candidate.startswith(prefix):
+                return prefix
+        elif candidate == prefix:
+            return prefix
+    return None
+
+
+def serialized_paths_for(files: Iterable[str]) -> set[str]:
+    """The set of serialized Tier-4 surfaces touched by ``files``."""
+    touched: set[str] = set()
+    for path in files:
+        prefix = matches_serialized_path(path)
+        if prefix is not None:
+            touched.add(prefix)
+    return touched
+
+
+def _pr_sort_key(pr: dict[str, Any]) -> tuple[str, int]:
+    """Deterministic train order: oldest PR first, ties broken by number.
+
+    ``createdAt`` is an ISO-8601 string which sorts lexicographically; a missing
+    value sorts first (treated as oldest) so it still yields a stable order.
+    """
+    created = str(pr.get("createdAt") or pr.get("created_at") or "")
+    try:
+        number = int(pr.get("number"))
+    except (TypeError, ValueError):
+        number = 0
+    return (created, number)
+
+
+def _pr_number(pr: dict[str, Any]) -> int | None:
+    try:
+        return int(pr.get("number"))
+    except (TypeError, ValueError):
+        return None
+
+
+def _pr_files(pr: dict[str, Any]) -> list[str]:
+    raw = pr.get("files")
+    files: list[str] = []
+    if isinstance(raw, list):
+        for entry in raw:
+            if isinstance(entry, dict):
+                name = entry.get("path") or entry.get("filename")
+                if name:
+                    files.append(str(name))
+            elif isinstance(entry, str):
+                files.append(entry)
+    return files
+
+
+def build_train(
+    open_prs: Sequence[dict[str, Any]],
+) -> dict[str, list[dict[str, Any]]]:
+    """Per serialized surface, the ordered list of open PRs occupying it.
+
+    The first element of each list is the head-of-train (should land next); the
+    rest are queued behind it.
+    """
+    lanes: dict[str, list[dict[str, Any]]] = {}
+    for pr in sorted(open_prs, key=_pr_sort_key):
+        for prefix in serialized_paths_for(_pr_files(pr)):
+            lanes.setdefault(prefix, []).append(
+                {
+                    "number": _pr_number(pr),
+                    "title": str(pr.get("title") or "").strip(),
+                    "createdAt": str(pr.get("createdAt") or pr.get("created_at") or ""),
+                }
+            )
+    return lanes
+
+
+def evaluate_merge_train(
+    candidate_files: Iterable[str],
+    open_prs: Sequence[dict[str, Any]],
+    *,
+    cap: int = DEFAULT_CAP,
+    candidate_pr: int | None = None,
+) -> dict[str, Any]:
+    """Decide whether a candidate PR may occupy the Tier-4 lanes it touches.
+
+    ``cap`` is the max number of *other* open PRs allowed on a surface before a
+    new one must queue. The candidate itself is excluded from the count (so
+    re-evaluating an already-open PR does not block on itself).
+    """
+    cap = max(1, int(cap))
+    candidate_surfaces = sorted(serialized_paths_for(candidate_files))
+    train = build_train(open_prs)
+
+    contended: dict[str, Any] = {}
+    blocking: set[int] = set()
+    for prefix in candidate_surfaces:
+        occupants = [
+            entry
+            for entry in train.get(prefix, [])
+            if entry["number"] is not None and entry["number"] != candidate_pr
+        ]
+        lane_full = len(occupants) >= cap
+        if lane_full:
+            for entry in occupants:
+                blocking.add(int(entry["number"]))
+        contended[prefix] = {
+            "open_pr_numbers": [entry["number"] for entry in occupants],
+            "head_pr": occupants[0]["number"] if occupants else None,
+            "lane_full": lane_full,
+        }
+
+    decision = QUEUE if blocking else ALLOW
+    if not candidate_surfaces:
+        reason = "candidate touches no serialized Tier-4 surface"
+    elif decision == ALLOW:
+        reason = "all touched Tier-4 lanes have room within cap"
+    else:
+        joined = ", ".join(str(n) for n in sorted(blocking))
+        reason = (
+            f"Tier-4 lane already occupied by open PR(s) {joined}; queue behind the "
+            "head-of-train and rebase on it once it lands"
+        )
+
+    return {
+        "decision": decision,
+        "ok": decision == ALLOW,
+        "cap": cap,
+        "candidate_pr": candidate_pr,
+        "candidate_surfaces": candidate_surfaces,
+        "contended_surfaces": contended,
+        "blocking_prs": sorted(blocking),
+        "reason": reason,
+    }
+
+
+# ---------------------------------------------------------------------------
+# GitHub I/O shell (App-token-routed, injectable for tests)
+# ---------------------------------------------------------------------------
+
+
+def _app_token_env() -> dict[str, str]:
+    """Best-effort App-installation token env for read-only gh calls.
+
+    Mirrors the shell wrappers: mint via ``scripts/gh_app_env.py --print-token``
+    so the lane check never spends the operator PAT's GraphQL budget. Returns an
+    empty dict (degrade to ambient gh auth) when the App config is absent.
+    """
+    try:
+        result = subprocess.run(  # noqa: S603 - controlled gh_app_env invocation
+            [
+                sys.executable,
+                str(REPO_ROOT / "scripts" / "gh_app_env.py"),
+                "--print-token",
+                "--quiet",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=GH_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return {}
+    token = (result.stdout or "").strip()
+    if not token:
+        return {}
+    return {
+        "GH_TOKEN": token,
+        "GITHUB_TOKEN": token,
+        "ARAGORA_GITHUB_AUTH_SOURCE": "github_app_installation",
+    }
+
+
+def fetch_open_prs(repo: str, *, limit: int = 200) -> list[dict[str, Any]]:
+    """List open PRs with their changed files via App-token-routed ``gh``."""
+    import os
+
+    env = {**os.environ, **_app_token_env()}
+    result = subprocess.run(  # noqa: S603 - controlled gh invocation
+        [
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--limit",
+            str(limit),
+            "--json",
+            "number,title,createdAt,files",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=GH_TIMEOUT_SECONDS,
+        env=env,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"gh pr list failed: {(result.stderr or '').strip()}")
+    try:
+        payload = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"could not parse gh pr list output: {exc}") from None
+    return payload if isinstance(payload, list) else []
+
+
+def _changed_files_from_git(base: str, head: str) -> list[str]:
+    result = subprocess.run(  # noqa: S603 - controlled git invocation
+        ["git", "diff", "--name-only", f"{base}...{head}"],
+        capture_output=True,
+        text=True,
+        timeout=GH_TIMEOUT_SECONDS,
+        cwd=str(REPO_ROOT),
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"git diff failed: {(result.stderr or '').strip()}")
+    return [line.strip() for line in (result.stdout or "").splitlines() if line.strip()]
+
+
+def _load_open_prs_arg(value: str) -> list[dict[str, Any]]:
+    text = sys.stdin.read() if value == "-" else Path(value).read_text(encoding="utf-8")
+    payload = json.loads(text or "[]")
+    return payload if isinstance(payload, list) else []
+
+
+def _split_csv(values: Sequence[str]) -> list[str]:
+    out: list[str] = []
+    for value in values:
+        out.extend(part.strip() for part in value.split(",") if part.strip())
+    return out
+
+
+def _resolve_candidate_files(args: argparse.Namespace) -> list[str]:
+    if args.changed_files:
+        return _split_csv(args.changed_files)
+    return _changed_files_from_git(args.base, args.head)
+
+
+def _resolve_open_prs(args: argparse.Namespace) -> list[dict[str, Any]]:
+    if args.open_prs_json:
+        return _load_open_prs_arg(args.open_prs_json)
+    return fetch_open_prs(args.repo)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check", action="store_true", help="evaluate whether a candidate may occupy its lanes"
+    )
+    parser.add_argument(
+        "--status", action="store_true", help="print the current train per serialized surface"
+    )
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument(
+        "--cap", type=int, default=DEFAULT_CAP, help="max concurrent open PRs per surface"
+    )
+    parser.add_argument(
+        "--candidate-pr", type=int, default=None, help="exclude this PR from the lane count"
+    )
+    parser.add_argument(
+        "--changed-files",
+        action="append",
+        default=[],
+        help="comma-separated candidate paths; repeatable. Omit to diff --base..--head.",
+    )
+    parser.add_argument("--base", default="origin/main")
+    parser.add_argument("--head", default="HEAD")
+    parser.add_argument(
+        "--open-prs-json",
+        default=None,
+        help="path to a JSON list of open PRs (or '-' for stdin); omit to fetch live",
+    )
+    parser.add_argument("--json", action="store_true", help="emit JSON")
+    return parser
+
+
+def _emit(payload: dict[str, Any], *, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def main(argv: Sequence[str] | None = None, *, fetcher: Callable[..., Any] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.status == args.check:  # both or neither
+        print("error: pass exactly one of --check or --status", file=sys.stderr)
+        return 1
+
+    try:
+        open_prs = _resolve_open_prs(args)
+    except (RuntimeError, OSError, ValueError) as exc:
+        print(f"error: could not resolve open PRs: {exc}", file=sys.stderr)
+        return 1
+
+    if args.status:
+        train = build_train(open_prs)
+        if args.json:
+            _emit({"cap": max(1, args.cap), "train": train}, as_json=True)
+        else:
+            if not train:
+                print("merge-train: no open PR occupies any serialized Tier-4 surface")
+            for prefix, lane in sorted(train.items()):
+                print(f"merge-train: {prefix} (cap={max(1, args.cap)})")
+                for position, entry in enumerate(lane):
+                    marker = "HEAD" if position == 0 else f"queued #{position}"
+                    print(f"  [{marker}] PR #{entry['number']} {entry['title']}")
+        return 0
+
+    try:
+        candidate_files = _resolve_candidate_files(args)
+    except (RuntimeError, OSError) as exc:
+        print(f"error: could not resolve candidate files: {exc}", file=sys.stderr)
+        return 1
+
+    result = evaluate_merge_train(
+        candidate_files,
+        open_prs,
+        cap=args.cap,
+        candidate_pr=args.candidate_pr,
+    )
+    if args.json:
+        _emit(result, as_json=True)
+    elif result["decision"] == ALLOW:
+        print(f"merge-train: allow — {result['reason']}")
+    else:
+        print(f"merge-train: queue — {result['reason']}", file=sys.stderr)
+        for prefix in result["candidate_surfaces"]:
+            lane = result["contended_surfaces"].get(prefix, {})
+            if lane.get("lane_full"):
+                print(f"  {prefix}: head-of-train PR #{lane.get('head_pr')}", file=sys.stderr)
+    return 0 if result["ok"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_tier4_merge_train.py
+++ b/tests/scripts/test_tier4_merge_train.py
@@ -1,0 +1,238 @@
+"""Tests for ``scripts/tier4_merge_train.py`` — Tier-4 contention serializer.
+
+Pure-core, fixture-driven: the lane decision is exercised against explicit
+open-PR lists, so no ``gh`` subprocess is ever invoked. A drift guard asserts
+the vendored serialized-surface list stays in sync with the canonical
+``review_queue.TIER_4_PREFIXES`` (skipped when that import's heavy dependency
+closure is unavailable, e.g. in a minimal sandbox).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _load_module() -> Any:
+    here = Path(__file__).resolve()
+    script_path = here.parents[2] / "scripts" / "tier4_merge_train.py"
+    spec = importlib.util.spec_from_file_location("tier4_merge_train_under_test", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load spec for {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+train = _load_module()
+
+
+def _pr(number: int, files: list[str], *, created: str = "", title: str = "") -> dict[str, Any]:
+    return {
+        "number": number,
+        "title": title or f"PR {number}",
+        "createdAt": created,
+        "files": [{"path": f} for f in files],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Path classification
+# ---------------------------------------------------------------------------
+
+
+def test_matches_exact_file_surface() -> None:
+    assert (
+        train.matches_serialized_path("scripts/settle_tier4_pr.py") == "scripts/settle_tier4_pr.py"
+    )
+
+
+def test_matches_directory_prefix_surface() -> None:
+    assert (
+        train.matches_serialized_path(".github/workflows/aragora-merge-quorum.yml")
+        == ".github/workflows/"
+    )
+
+
+def test_non_serialized_path_returns_none() -> None:
+    assert train.matches_serialized_path("scripts/run_boss_cycle.sh") is None
+    assert train.matches_serialized_path("aragora/debate/orchestrator.py") is None
+
+
+def test_serialized_paths_for_dedupes_by_surface() -> None:
+    touched = train.serialized_paths_for(
+        ["scripts/settle_tier4_pr.py", "tests/scripts/test_settle_tier4_pr.py", "README.md"]
+    )
+    assert touched == {"scripts/settle_tier4_pr.py"}
+
+
+# ---------------------------------------------------------------------------
+# Lane decision
+# ---------------------------------------------------------------------------
+
+
+def test_empty_lane_allows_candidate() -> None:
+    result = train.evaluate_merge_train(
+        ["scripts/settle_tier4_pr.py"],
+        open_prs=[],
+        cap=1,
+    )
+    assert result["ok"] is True
+    assert result["decision"] == train.ALLOW
+    assert result["blocking_prs"] == []
+
+
+def test_full_lane_queues_candidate() -> None:
+    open_prs = [_pr(8405, ["scripts/settle_tier4_pr.py"], created="2026-06-14T04:00:00Z")]
+    result = train.evaluate_merge_train(
+        ["scripts/settle_tier4_pr.py", "tests/scripts/test_settle_tier4_pr.py"],
+        open_prs=open_prs,
+        cap=1,
+    )
+    assert result["ok"] is False
+    assert result["decision"] == train.QUEUE
+    assert result["blocking_prs"] == [8405]
+    assert result["contended_surfaces"]["scripts/settle_tier4_pr.py"]["head_pr"] == 8405
+    assert result["contended_surfaces"]["scripts/settle_tier4_pr.py"]["lane_full"] is True
+
+
+def test_cap_two_allows_second_pr() -> None:
+    open_prs = [_pr(8405, ["scripts/settle_tier4_pr.py"], created="2026-06-14T04:00:00Z")]
+    result = train.evaluate_merge_train(
+        ["scripts/settle_tier4_pr.py"],
+        open_prs=open_prs,
+        cap=2,
+    )
+    assert result["ok"] is True
+
+
+def test_candidate_excluded_from_its_own_lane_count() -> None:
+    # Re-evaluating an already-open PR must not block on itself.
+    open_prs = [_pr(8408, ["scripts/settle_tier4_pr.py"], created="2026-06-14T05:00:00Z")]
+    result = train.evaluate_merge_train(
+        ["scripts/settle_tier4_pr.py"],
+        open_prs=open_prs,
+        cap=1,
+        candidate_pr=8408,
+    )
+    assert result["ok"] is True
+    assert result["blocking_prs"] == []
+
+
+def test_non_serialized_candidate_always_allowed() -> None:
+    open_prs = [_pr(8405, ["scripts/settle_tier4_pr.py"])]
+    result = train.evaluate_merge_train(
+        ["aragora/debate/orchestrator.py", "README.md"],
+        open_prs=open_prs,
+        cap=1,
+    )
+    assert result["ok"] is True
+    assert result["candidate_surfaces"] == []
+    assert "no serialized Tier-4 surface" in result["reason"]
+
+
+def test_distinct_surfaces_do_not_cross_block() -> None:
+    # An open PR on settle_one_pr.py must not block a candidate on review_queue.py.
+    open_prs = [_pr(8396, ["scripts/settle_one_pr.py"])]
+    result = train.evaluate_merge_train(
+        ["aragora/cli/commands/review_queue.py"],
+        open_prs=open_prs,
+        cap=1,
+    )
+    assert result["ok"] is True
+
+
+def test_train_ordered_oldest_first_then_number() -> None:
+    open_prs = [
+        _pr(8412, ["scripts/settle_tier4_pr.py"], created="2026-06-14T07:39:00Z"),
+        _pr(8405, ["scripts/settle_tier4_pr.py"], created="2026-06-14T04:56:00Z"),
+        _pr(8408, ["scripts/settle_tier4_pr.py"], created="2026-06-14T05:32:00Z"),
+    ]
+    lanes = train.build_train(open_prs)
+    order = [entry["number"] for entry in lanes["scripts/settle_tier4_pr.py"]]
+    assert order == [8405, 8408, 8412]
+
+
+def test_blocking_prs_unions_across_surfaces() -> None:
+    open_prs = [
+        _pr(8405, ["scripts/settle_tier4_pr.py"], created="2026-06-14T04:00:00Z"),
+        _pr(8396, ["scripts/settle_one_pr.py"], created="2026-06-14T03:00:00Z"),
+    ]
+    result = train.evaluate_merge_train(
+        ["scripts/settle_tier4_pr.py", "scripts/settle_one_pr.py"],
+        open_prs=open_prs,
+        cap=1,
+    )
+    assert result["ok"] is False
+    assert result["blocking_prs"] == [8396, 8405]
+
+
+# ---------------------------------------------------------------------------
+# CLI exit codes (pure path via injected open-PR JSON)
+# ---------------------------------------------------------------------------
+
+
+def test_cli_check_allow_exit_zero(tmp_path: Path, capsys: Any) -> None:
+    prs = tmp_path / "open.json"
+    prs.write_text("[]", encoding="utf-8")
+    code = train.main(
+        [
+            "--check",
+            "--changed-files",
+            "scripts/settle_tier4_pr.py",
+            "--open-prs-json",
+            str(prs),
+            "--json",
+        ]
+    )
+    assert code == 0
+
+
+def test_cli_check_queue_exit_two(tmp_path: Path) -> None:
+    prs = tmp_path / "open.json"
+    prs.write_text(
+        '[{"number": 8405, "title": "x", "createdAt": "2026-06-14T04:00:00Z",'
+        ' "files": [{"path": "scripts/settle_tier4_pr.py"}]}]',
+        encoding="utf-8",
+    )
+    code = train.main(
+        [
+            "--check",
+            "--changed-files",
+            "scripts/settle_tier4_pr.py",
+            "--open-prs-json",
+            str(prs),
+            "--json",
+        ]
+    )
+    assert code == 2
+
+
+def test_cli_requires_exactly_one_mode(tmp_path: Path) -> None:
+    prs = tmp_path / "open.json"
+    prs.write_text("[]", encoding="utf-8")
+    # neither --check nor --status
+    assert train.main(["--open-prs-json", str(prs)]) == 1
+    # both
+    assert train.main(["--check", "--status", "--open-prs-json", str(prs)]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Drift guard: vendored list must match the canonical classifier
+# ---------------------------------------------------------------------------
+
+
+def test_serialized_prefixes_match_canonical_tier4() -> None:
+    review_queue = pytest.importorskip(
+        "aragora.cli.commands.review_queue",
+        reason="review_queue import closure unavailable in this environment",
+    )
+    assert set(train.SERIALIZED_TIER4_PREFIXES) == set(review_queue.TIER_4_PREFIXES), (
+        "scripts/tier4_merge_train.py SERIALIZED_TIER4_PREFIXES has drifted from "
+        "review_queue.TIER_4_PREFIXES — re-sync the vendored copy."
+    )


### PR DESCRIPTION
## Problem

When many open PRs edit the same Tier-4 merge-authority file, each must run the full human-settlement dance **and** re-conflicts the others on merge. The fleet ends up generating the very settlement toil the gate exists to prevent. Live example from today: **six** concurrent open PRs all editing `scripts/settle_tier4_pr.py` (#8382, #8405, #8406, #8408→closed-dup, #8410, #8412) — every landing forces a rebase of all the rest, and the identical pattern produced a duplicate fix (#8408 vs #8412).

## What this adds

`scripts/tier4_merge_train.py` — a single-lane serializer for PRs touching a Tier-4 surface:

- At most `cap` open PRs (default **1**) may occupy a serialized surface; the rest are **queued** in a deterministic oldest-first order behind the head-of-train.
- **`--check`** → exit `2` when a lane is full (so a pre-open hook can refuse the (N+1)th PR), exit `0` when there's room.
- **`--status`** → prints the current train per surface (HEAD + queued), so PRs land head-first, each rebased on the prior.

Run against today's live cluster it reconstructs the train exactly:
```
merge-train: scripts/settle_tier4_pr.py (cap=1)
  [HEAD] PR #8405
  [queued #1] PR #8406
  [queued #2] PR #8412
```

## Design

- **Pure core** (`evaluate_merge_train` / `build_train` / `serialized_paths_for`) is stdlib-only and unit-tested without a live `gh`. All GitHub I/O is at the edges (`fetch_open_prs`) and **App-token-routed** via `scripts/gh_app_env.py`, so the check never burns the operator PAT's GraphQL budget.
- The serialized-surface list **mirrors `review_queue.TIER_4_PREFIXES`** (the canonical Tier-4 classifier). It's vendored to keep the module dependency-light; a **drift-guard test** fails if the two diverge (and currently confirms they match exactly).

## Integration (opt-in, default OFF)

`automation_pr_preflight.sh` gains a block gated on `ARAGORA_TIER4_MERGE_TRAIN=1` that runs the check before `preflight: ok`. **Best-effort:** a transport/tooling failure warns and does **not** block; only a clean queue decision (exit 2) fails the preflight. Mirrors the existing `ARAGORA_GH_APP_AUTH` / `ARAGORA_QUORUM_RECONCILER` opt-in pattern.

**Does not touch `settle_tier4_pr.py`, `settle_one_pr.py`, or `review_queue.py`** — no merge-authority surface is modified; this is a new standalone guard.

## Validation

- `pytest tests/scripts/test_tier4_merge_train.py` → **16 passed** (incl. the drift guard, which imported `review_queue.TIER_4_PREFIXES` and matched).
- `ruff check` + `ruff format --check` clean on both files.
- `bash -n scripts/automation_pr_preflight.sh` OK; default-off path emits zero merge-train lines (behavior unchanged until opted in).

## Why this is the high-leverage fix

This addresses the *class* — it would have prevented today's six-PR `settle_tier4_pr.py` pile-up and the #8408/#8412 duplicate — rather than any single PR landing. Tier classification: this PR itself touches only a new script + a Tier-2 automation shell (`automation_pr_preflight.sh`), not a Tier-4 surface, so it should settle normally.

https://claude.ai/code/session_018jfJj5gb9VoLs6VBMnzhrP

---
_Generated by [Claude Code](https://claude.ai/code/session_018jfJj5gb9VoLs6VBMnzhrP)_