### PR TITLE
fix(swarm): give quorum reviewers the complete changed-file list

### DIFF
--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -95,6 +95,10 @@ QUORUM_STATE_LOCK_STALE_SECONDS = 15 * 60
 _REVIEWER_RESULT_QUEUE_TIMEOUT = 1.0
 # Cap the diff fed to reviewers so a huge PR cannot blow the model context.
 _MAX_DIFF_CHARS = 60_000
+# Marker left in place of a changed file's omitted hunk once the per-file diff
+# budget is exhausted. The complete changed-file list always precedes the body,
+# so a reviewer can still confirm every file is present.
+_PER_FILE_TRUNCATION_MARKER = "\n[hunk truncated; full changed-file list is above]\n"
 # Cap reviewer output so a runaway model cannot exceed GitHub's per-comment limit.
 _MAX_REVIEWER_CHARS = 32_000
 _CLAUDE_TIMEOUT = 300
@@ -340,22 +344,119 @@ def compose_evidence_comment(
     )
 
 
-def build_review_prompt(*, repo: str, pr: int | str, head_sha: str, diff_text: str) -> str:
-    """Adversarial review prompt grounded on the exact head; diff is bounded."""
+def _split_unified_diff(diff: str) -> list[str]:
+    """Split a unified diff into one segment per file on ``diff --git`` headers.
+
+    Any preamble before the first ``diff --git`` is returned as a leading segment
+    so no bytes are lost. Each segment keeps its own ``diff --git`` header so a
+    reviewer can still identify the file even when the segment is later truncated.
+    """
+    segments: list[str] = []
+    current: list[str] = []
+    for line in diff.splitlines(keepends=True):
+        if line.startswith("diff --git ") and current:
+            segments.append("".join(current))
+            current = [line]
+        else:
+            current.append(line)
+    if current:
+        segments.append("".join(current))
+    return segments
+
+
+def _bound_diff_body(diff: str, max_chars: int) -> tuple[str, bool]:
+    """Bound a unified diff to ``max_chars`` without dropping whole files.
+
+    A naive ``diff[:max_chars]`` keeps only the files that sort before the budget
+    runs out, so a large deletion that sorts before later additions can hide
+    those additions entirely and let a reviewer wrongly report the added files as
+    absent. Instead the budget is shared across files (smallest first, each
+    file's unused budget flowing to the rest) so every changed file contributes
+    at least a hunk. Returns ``(text, truncated)``.
+    """
+    if len(diff) <= max_chars:
+        return diff, False
+    segments = _split_unified_diff(diff)
+    if len(segments) <= 1:
+        return diff[:max_chars].rstrip() + _PER_FILE_TRUNCATION_MARKER, True
+    allocations = [0] * len(segments)
+    remaining_budget = max_chars
+    remaining_files = len(segments)
+    for index in sorted(range(len(segments)), key=lambda i: len(segments[i])):
+        share = remaining_budget // remaining_files if remaining_files else 0
+        take = min(len(segments[index]), share)
+        allocations[index] = take
+        remaining_budget -= take
+        remaining_files -= 1
+    truncated = False
+    parts: list[str] = []
+    for segment, budget in zip(segments, allocations):
+        if budget >= len(segment):
+            parts.append(segment)
+        else:
+            truncated = True
+            parts.append(segment[:budget].rstrip() + _PER_FILE_TRUNCATION_MARKER)
+    return "".join(parts), truncated
+
+
+def _file_list_from_diff(diff: str) -> str:
+    """Best-effort changed-file list parsed from a unified diff's headers.
+
+    Fallback for when ``gh pr diff --name-status`` could not be fetched, so the
+    prompt's changed-file section stays complete and a reviewer can never call a
+    listed file absent.
+    """
+    paths: list[str] = []
+    seen: set[str] = set()
+    for line in diff.splitlines():
+        if not line.startswith("diff --git "):
+            continue
+        rest = line[len("diff --git ") :].strip()
+        marker = rest.rfind(" b/")
+        path = rest[marker + len(" b/") :].strip() if marker != -1 else rest
+        if path and path not in seen:
+            seen.add(path)
+            paths.append(path)
+    return "\n".join(paths)
+
+
+def build_review_prompt(
+    *,
+    repo: str,
+    pr: int | str,
+    head_sha: str,
+    diff_text: str,
+    name_status: str = "",
+) -> str:
+    """Adversarial review prompt grounded on the exact head.
+
+    The complete changed-file list (from ``gh pr diff --name-status`` or, as a
+    fallback, the file headers parsed from the diff) is always included in full
+    so a reviewer can never falsely report a file/module as absent. Only the
+    unified-diff body is bounded, and it is bounded per-file (so a large deletion
+    that sorts before later additions can no longer hide them) rather than by a
+    blind first-N-bytes slice.
+    """
     diff = diff_text.strip()
-    truncated = ""
-    if len(diff) > _MAX_DIFF_CHARS:
-        diff = diff[:_MAX_DIFF_CHARS]
-        truncated = "\n\n[diff truncated for length]"
+    file_list = name_status.strip() or _file_list_from_diff(diff)
+    file_count = sum(1 for line in file_list.splitlines() if line.strip())
+    bounded, truncated = _bound_diff_body(diff, _MAX_DIFF_CHARS)
     short = head_sha[:7]
+    body_header = f"=== DIFF (head {short}) ==="
+    if truncated:
+        body_header = (
+            f"=== DIFF (head {short}; some hunks omitted for length - the CHANGED FILES "
+            "list above is complete, so treat every listed path as present) ==="
+        )
     return (
         "You are an adversarial senior reviewer giving an independent model review. "
-        f"Review ONLY the diff below for PR #{pr} in {repo} at head {short}. "
+        f"Review ONLY the changes below for PR #{pr} in {repo} at head {short}. "
         "Look hard for correctness, security, and regression risks. "
         "Begin your reply with 'Verdict: PASS' or 'Verdict: CHANGES-REQUESTED', then a terse "
         "bullet list of concrete findings each tagged [P1]/[P2]/[P3] with a location, or state "
         "explicitly that there are no blocking issues. Be concise.\n\n"
-        f"=== DIFF (head {short}) ===\n{diff}{truncated}\n"
+        f"=== CHANGED FILES (complete list, {file_count} file(s)) ===\n{file_list}\n\n"
+        f"{body_header}\n{bounded}\n"
     )
 
 
@@ -637,6 +738,26 @@ async def _close_api_agent_resources(agent: Any) -> None:
         logger.debug("collect-evidence shared connector close failed: %s", exc)
 
 
+def _fetch_name_status(repo: str, pr: int) -> str:
+    """Best-effort complete changed-file list via ``gh pr diff --name-status``.
+
+    Supplementary to the (bounded) diff body, so a failure here must never change
+    the builder's raise/return semantics: ``build_review_prompt`` falls back to
+    parsing file headers from the diff when this is empty.
+    """
+    try:
+        proc = merge_quorum_io.run(
+            ["gh", "pr", "diff", str(pr), "--repo", repo, "--name-status"],
+            env=merge_quorum_io.aragora_env(),
+            timeout=120,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    if proc.returncode != 0:
+        return ""
+    return proc.stdout or ""
+
+
 def default_prompt_builder(repo: str, pr: int, ctx: dict[str, Any]) -> str:
     head_sha = str(ctx.get("head_sha") or "")
     proc = merge_quorum_io.run(
@@ -654,6 +775,9 @@ def default_prompt_builder(repo: str, pr: int, ctx: dict[str, Any]) -> str:
     diff_text = proc.stdout or ""
     if not diff_text.strip():
         raise RuntimeError(f"PR #{pr} has an empty diff; nothing to review")
+    # Best-effort complete changed-file list so the reviewer always sees every
+    # path even when the diff body is bounded; never alters the raise/return below.
+    name_status = _fetch_name_status(repo, pr)
     # Pin the diff to the resolved head: `gh pr diff` returns whatever the head
     # is at call time, so if it moved between context resolution and now the
     # reviewer would see a different diff than the comment claims to ground on.
@@ -682,7 +806,9 @@ def default_prompt_builder(repo: str, pr: int, ctx: dict[str, Any]) -> str:
         raise RuntimeError(
             f"head moved during diff fetch for PR #{pr} ({head_sha[:7]} -> {live_head[:7]}); retry"
         )
-    return build_review_prompt(repo=repo, pr=pr, head_sha=head_sha, diff_text=diff_text)
+    return build_review_prompt(
+        repo=repo, pr=pr, head_sha=head_sha, diff_text=diff_text, name_status=name_status
+    )
 
 
 def default_linter(

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -1431,3 +1431,181 @@ def test_run_collect_cli_catches_runtime_error(monkeypatch, capsys) -> None:
     )
     assert rc == 1
     assert "empty diff" in capsys.readouterr().out
+
+
+# --- build_review_prompt: complete file list + fair per-file body bounding ---
+
+
+def _diff_with_deletion_before_additions() -> tuple[str, str, list[str]]:
+    """A unified diff whose large DELETION sorts (alphabetically) before its
+    ADDITIONS, mirroring PR #8416 (``tests/conftest.py`` deleted before
+    ``tests/fixtures/*`` added). A blind ``diff[:N]`` slice would drop the
+    additions entirely. Returns ``(diff, name_status, added_paths)``.
+    """
+    deleted = "tests/conftest.py"
+    added = ["tests/fixtures/alpha.py", "tests/fixtures/beta.py"]
+    big_body = "\n".join(f"-old conftest line {i} " + "x" * 60 for i in range(2000))
+    deletion = (
+        f"diff --git a/{deleted} b/{deleted}\n"
+        "deleted file mode 100644\n"
+        f"--- a/{deleted}\n+++ /dev/null\n@@ -1,2000 +0,0 @@\n{big_body}\n"
+    )
+    additions = ""
+    for path in added:
+        body = "\n".join(f"+fixture {path} line {i}" for i in range(40))
+        additions += (
+            f"diff --git a/{path} b/{path}\n"
+            "new file mode 100644\n"
+            f"--- /dev/null\n+++ b/{path}\n@@ -0,0 +1,40 @@\n{body}\n"
+        )
+    diff = deletion + additions
+    name_status = f"D\t{deleted}\n" + "".join(f"A\t{p}\n" for p in added)
+    return diff, name_status, added
+
+
+def test_build_review_prompt_keeps_all_added_paths_when_deletion_sorts_first() -> None:
+    diff, name_status, added = _diff_with_deletion_before_additions()
+    assert len(diff) > qe._MAX_DIFF_CHARS  # body alone forces bounding
+    prompt = qe.build_review_prompt(
+        repo="o/r", pr=8416, head_sha=HEAD, diff_text=diff, name_status=name_status
+    )
+    # Every added path survives even though the diff body had to be bounded.
+    for path in added:
+        assert path in prompt
+
+
+def test_build_review_prompt_never_truncates_complete_file_list_header() -> None:
+    diff, name_status, added = _diff_with_deletion_before_additions()
+    prompt = qe.build_review_prompt(
+        repo="o/r", pr=8416, head_sha=HEAD, diff_text=diff, name_status=name_status
+    )
+    header = prompt[: prompt.index("=== DIFF")]
+    # The file-list header is placed before the (bounded) body and is complete.
+    assert "=== CHANGED FILES" in header
+    assert "tests/conftest.py" in header
+    for path in added:
+        assert path in header
+    # The body really was bounded (per-file marker present), proving the header
+    # survived truncation rather than the diff simply being small.
+    assert qe._PER_FILE_TRUNCATION_MARKER.strip() in prompt
+
+
+def test_build_review_prompt_derives_file_list_when_name_status_absent() -> None:
+    diff, _name_status, added = _diff_with_deletion_before_additions()
+    # No name_status supplied: the file list is recovered from the diff headers,
+    # so a reviewer still cannot claim an added file is absent.
+    prompt = qe.build_review_prompt(repo="o/r", pr=8416, head_sha=HEAD, diff_text=diff)
+    header = prompt[: prompt.index("=== DIFF")]
+    assert "tests/conftest.py" in header
+    for path in added:
+        assert path in header
+
+
+def test_build_review_prompt_small_diff_is_not_truncated() -> None:
+    diff = (
+        "diff --git a/aragora/x.py b/aragora/x.py\n"
+        "--- a/aragora/x.py\n+++ b/aragora/x.py\n@@ -1 +1 @@\n-old\n+new\n"
+    )
+    prompt = qe.build_review_prompt(
+        repo="o/r", pr=42, head_sha=HEAD, diff_text=diff, name_status="M\taragora/x.py\n"
+    )
+    # Shape semantics unchanged: a str grounded on the short head, carrying the
+    # verdict instruction and the changed file; nothing truncated.
+    assert isinstance(prompt, str)
+    assert HEAD[:7] in prompt
+    assert "Verdict: PASS" in prompt
+    assert "Verdict: CHANGES-REQUESTED" in prompt
+    assert "aragora/x.py" in prompt
+    assert "truncated" not in prompt
+
+
+# --- _bound_diff_body: fair per-file water-filling --------------------------
+
+
+def test_bound_diff_body_returns_input_unchanged_when_within_cap() -> None:
+    diff = "diff --git a/a b/a\n+hello\n"
+    bounded, truncated = qe._bound_diff_body(diff, 30_000)
+    assert truncated is False
+    assert bounded == diff
+
+
+def test_bound_diff_body_gives_every_file_a_hunk() -> None:
+    seg_a = "diff --git a/a b/a\n" + "A" * 50_000 + "\n"
+    seg_b = "diff --git a/b b/b\n" + "B" * 50_000 + "\n"
+    seg_c = "diff --git a/c b/c\n" + "C" * 50_000 + "\n"
+    bounded, truncated = qe._bound_diff_body(seg_a + seg_b + seg_c, 30_000)
+    assert truncated is True
+    # No single file may consume the whole budget: each file's header (and some
+    # content) survives, unlike a blind first-N-bytes slice.
+    assert "diff --git a/a b/a" in bounded
+    assert "diff --git a/b b/b" in bounded
+    assert "diff --git a/c b/c" in bounded
+    assert "B" in bounded and "C" in bounded
+    marker_overhead = 3 * len(qe._PER_FILE_TRUNCATION_MARKER)
+    assert len(bounded) <= 30_000 + marker_overhead + 8
+
+
+def test_bound_diff_body_single_file_falls_back_to_head_slice() -> None:
+    diff = "diff --git a/a b/a\n" + "A" * 100_000
+    bounded, truncated = qe._bound_diff_body(diff, 30_000)
+    assert truncated is True
+    assert bounded.startswith("diff --git a/a b/a")
+    assert len(bounded) <= 30_000 + len(qe._PER_FILE_TRUNCATION_MARKER) + 8
+
+
+def test_bound_diff_body_small_addition_kept_whole_when_deletion_huge() -> None:
+    # The fairness property that fixes #8416: a small addition that sorts AFTER a
+    # huge deletion is kept in full and never dropped.
+    deletion = "diff --git a/del b/del\n" + "D" * 200_000 + "\n"
+    addition = "diff --git a/add b/add\n+only forty chars of new content here\n"
+    bounded, truncated = qe._bound_diff_body(deletion + addition, 60_000)
+    assert truncated is True
+    assert "only forty chars of new content here" in bounded
+
+
+# --- default_prompt_builder: name-status pass-through + graceful fallback ----
+
+
+def _prompt_builder_run_stub(diff: str, name_status: str | None):
+    """Build a fake ``merge_quorum_io.run`` serving diff / name-status / head."""
+
+    def fake_run(args, *, env=None, timeout=None):
+        if args[:3] == ["gh", "pr", "diff"]:
+            if "--name-status" in args:
+                if name_status is None:
+                    return SimpleNamespace(returncode=1, stdout="", stderr="boom")
+                return SimpleNamespace(returncode=0, stdout=name_status, stderr="")
+            return SimpleNamespace(returncode=0, stdout=diff, stderr="")
+        if args[:3] == ["gh", "pr", "view"]:
+            return SimpleNamespace(returncode=0, stdout=HEAD + "\n", stderr="")
+        raise AssertionError(f"unexpected args: {args}")
+
+    return fake_run
+
+
+def test_default_prompt_builder_prepends_name_status(monkeypatch) -> None:
+    diff, name_status, added = _diff_with_deletion_before_additions()
+    monkeypatch.setattr(qe.merge_quorum_io, "run", _prompt_builder_run_stub(diff, name_status))
+    prompt = qe.default_prompt_builder("o/r", 8416, {"head_sha": HEAD})
+    header = prompt[: prompt.index("=== DIFF")]
+    assert "tests/conftest.py" in header
+    for path in added:
+        assert path in header
+
+
+def test_default_prompt_builder_tolerates_name_status_fetch_failure(monkeypatch) -> None:
+    diff, _name_status, added = _diff_with_deletion_before_additions()
+    # name-status fetch fails: the builder must NOT raise and must still produce a
+    # complete file list (recovered from the diff) -- return semantics unchanged.
+    monkeypatch.setattr(qe.merge_quorum_io, "run", _prompt_builder_run_stub(diff, None))
+    prompt = qe.default_prompt_builder("o/r", 8416, {"head_sha": HEAD})
+    header = prompt[: prompt.index("=== DIFF")]
+    for path in added:
+        assert path in header
+
+
+def test_default_prompt_builder_empty_diff_still_raises(monkeypatch) -> None:
+    # Builder exit/return semantics unchanged: an empty diff is still a hard error.
+    monkeypatch.setattr(qe.merge_quorum_io, "run", _prompt_builder_run_stub("   \n", "D\tx\n"))
+    with pytest.raises(RuntimeError, match="empty diff"):
+        qe.default_prompt_builder("o/r", 8416, {"head_sha": HEAD})


### PR DESCRIPTION
## Summary

Fixes the deterministic reviewer diff-truncation false-positive in the
`aragora-merge-quorum` gate (P1 hygiene, HEALTH-1 / #8258; unblocks #8416).

`aragora/swarm/quorum_evidence.py` built the collect-evidence reviewer prompt by
slicing the first `_MAX_DIFF_CHARS=60_000` chars of alphabetical `gh pr diff`
output. When a PR's large DELETION sorts alphabetically before its ADDITIONS
(e.g. `tests/conftest.py` deleted before `tests/fixtures/*` added in #8416), the
additions were cut off entirely, so the API reviewer (grok) saw only deletions
and emitted a confident-but-FALSE `Verdict: CHANGES-REQUESTED` ("modules do not
exist / fixtures deleted"), failing the quorum even though the PR was correct
(the CLI reviewer claude, which inspects the repo directly, PASSED).

## Change (gate-correctness PRESERVING)

- `build_review_prompt` now ALWAYS prepends the complete changed-file list
  (`gh pr diff --name-status`, fetched best-effort by `default_prompt_builder`;
  falls back to file headers parsed from the diff when that fetch fails) BEFORE
  the unified-diff body, so a reviewer can never falsely claim a file/module is
  absent.
- The diff body is bounded **per file** (water-filling, smallest first) instead
  of a blind first-N-bytes slice, so every changed file contributes at least a
  hunk; a small addition that sorts after a huge deletion is now kept in full.
- No quorum thresholds, reviewer counts, or builder exit-code/return semantics
  change. The name-status fetch is best-effort and never adds a new raise path.

## Tests (`tests/swarm/test_quorum_evidence.py`)

- a synthetic diff whose DELETION sorts before its ADDITIONS yields a prompt
  containing every added file's path;
- the complete file-list header is never truncated even when the body is;
- the file list is derived from the diff when name-status is absent;
- `_bound_diff_body` water-filling gives every file a hunk and keeps small
  additions whole when a deletion is huge;
- `default_prompt_builder` prepends name-status, tolerates a name-status fetch
  failure, and still raises on an empty diff (return/exit semantics unchanged).

## Validation (local, all green)

- `make lint` -> All checks passed!
- `bash $MISSION/scripts/typecheck_differential.sh` -> TYPECHECK PASS (new=48 <= env-drift 50; `quorum_evidence.py` mypy-clean)
- `python3 -m pytest tests/swarm/test_quorum_evidence.py -q` -> 91 passed (red-first: 10 of the new cases failed before the fix)
- `make test-smoke` -> Smoke tests passed!
- `PYTEST_BIN="python3 -m pytest" bash scripts/test_tiers.sh smoke` -> 138 passed

## Risks

Low. Tier 2 (`aragora/swarm/`), additive and behavior-neutral for normal PRs
(small diffs are emitted unchanged aside from the always-present complete
file-list header). This STRENGTHENS review accuracy; it does not weaken the gate.

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>
