### PR TITLE
fix(owner): discount absent preserved worktree refs

### DIFF
--- a/scripts/identify_lane_owner.py
+++ b/scripts/identify_lane_owner.py
@@ -1245,6 +1245,36 @@ _LOCAL_WORK_CLAIM_KEYS = (
     "dirty",
 )
 
+_SHA_RE = re.compile(r"\b[0-9a-f]{40}\b")
+_PRESERVATION_GIT_TIMEOUT_SECONDS = 10.0
+_PRESERVATION_GH_TIMEOUT_SECONDS = 20.0
+_SAFE_WORKTREE_INSPECT_TIMEOUT_SECONDS = 30.0
+_PRESERVATION_OUTBOX_DIRS = ("automation-outbox", "automation-receipts")
+_PRESERVATION_SHA_KEYS = (
+    "desired_head_sha",
+    "head_sha",
+    "headRefOid",
+    "merge_head_sha",
+    "commit_sha",
+)
+
+CommandRunner = Callable[[list[str], Path, float], subprocess.CompletedProcess[str]]
+
+
+def _run_preservation_command(
+    cmd: list[str],
+    cwd: Path,
+    timeout: float,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        cwd=cwd,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=timeout,
+    )
+
 
 def _ledger_entry_timestamp(entry: dict[str, Any]) -> float:
     """Most recent parseable timestamp on a lane-ledger entry (0.0 if none)."""
@@ -1293,21 +1323,430 @@ def find_lane_ledger_entry(
     return best
 
 
-def _local_work_indication(lane: dict[str, Any], ledger_entry: dict[str, Any] | None) -> str | None:
-    """Reason to suspect local (possibly unpushed/uncommitted) work, or None.
+def _normal_state_root(path: Path) -> Path:
+    return path if path.name == ".aragora" else path / ".aragora"
 
-    Fail closed: a worktree reference alone is enough — metadata cannot
-    prove that work in a worktree was pushed.
-    """
 
-    if lane.get("worktree"):
-        return "owner record references a worktree path"
+def _local_work_claim_indication(
+    lane: dict[str, Any], ledger_entry: dict[str, Any] | None
+) -> str | None:
     for source_name, record in (("owner record", lane), ("lane ledger", ledger_entry or {})):
         for key in _LOCAL_WORK_CLAIM_KEYS:
             if record.get(key):
                 return f"{source_name} claims local work ({key})"
-    if (ledger_entry or {}).get("worktree"):
-        return "lane ledger references a worktree path"
+    return None
+
+
+def _worktree_reference_paths(
+    lane: dict[str, Any], ledger_entry: dict[str, Any] | None
+) -> list[tuple[str, str]]:
+    paths: list[tuple[str, str]] = []
+    for source_name, record in (("owner record", lane), ("lane ledger", ledger_entry or {})):
+        worktree = str(record.get("worktree") or "").strip()
+        if worktree:
+            paths.append((source_name, worktree))
+    return paths
+
+
+def _proof_covers_worktree_paths(
+    proof: dict[str, Any] | None,
+    paths: list[tuple[str, str]],
+) -> bool:
+    if not proof or proof.get("available") is not True:
+        return False
+    proven_paths = {str(path) for path in proof.get("worktree_paths") or []}
+    return all(path in proven_paths for _, path in paths)
+
+
+def _json_payload(stdout: str) -> Any:
+    try:
+        return json.loads(stdout or "null")
+    except json.JSONDecodeError:
+        return None
+
+
+def _safe_worktree_absent_noop_proof(
+    path: str,
+    *,
+    repo_root: Path,
+    runner: CommandRunner,
+) -> dict[str, Any]:
+    cmd = [
+        sys.executable,
+        str(REPO_ROOT / "scripts" / "safe_worktree_cleanup.py"),
+        "inspect",
+        path,
+        "--json",
+    ]
+    try:
+        proc = runner(cmd, repo_root, _SAFE_WORKTREE_INSPECT_TIMEOUT_SECONDS)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {"path": path, "absent_noop": False, "reason": f"inspect_failed: {exc}"}
+
+    payload = _json_payload(proc.stdout)
+    if not isinstance(payload, dict):
+        return {
+            "path": path,
+            "absent_noop": False,
+            "reason": "safe_worktree_inspect_json_unavailable",
+        }
+
+    safety = payload.get("cleanup_safety")
+    classification = safety.get("classification") if isinstance(safety, dict) else None
+    blockers = payload.get("blockers") if isinstance(payload.get("blockers"), list) else []
+    absent_noop = (
+        payload.get("exists") is False
+        and payload.get("dirty") is not True
+        and payload.get("active_session") is not True
+        and "missing_path" in blockers
+        and classification == "absent_noop"
+    )
+    if absent_noop:
+        return {
+            "path": path,
+            "absent_noop": True,
+            "source": "safe_worktree_cleanup.inspect",
+            "classification": classification,
+        }
+    return {
+        "path": path,
+        "absent_noop": False,
+        "reason": "worktree_not_absent_noop",
+        "exists": payload.get("exists"),
+        "classification": classification,
+        "blockers": blockers,
+    }
+
+
+def _record_matches_lane(record: dict[str, Any], *, lane_id: str, branch: str) -> bool:
+    for candidate in (record, record.get("metadata"), record.get("payload")):
+        if not isinstance(candidate, dict):
+            continue
+        if lane_id and str(candidate.get("lane_id") or "") == lane_id:
+            return True
+        if branch and str(candidate.get("branch") or "") == branch:
+            return True
+    return False
+
+
+def _matching_state_records(
+    *,
+    lane_id: str,
+    branch: str,
+    state_root: Path,
+) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    root = _normal_state_root(state_root)
+    for dirname in _PRESERVATION_OUTBOX_DIRS:
+        directory = root / dirname
+        if not directory.is_dir():
+            continue
+        for path in sorted(directory.glob("*.json")):
+            try:
+                payload = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if isinstance(payload, dict) and _record_matches_lane(
+                payload, lane_id=lane_id, branch=branch
+            ):
+                payload = dict(payload)
+                payload["_source_path"] = str(path)
+                records.append(payload)
+    return records
+
+
+def _first_sha_from_record(record: dict[str, Any] | None) -> str | None:
+    if not isinstance(record, dict):
+        return None
+    for key in _PRESERVATION_SHA_KEYS:
+        value = record.get(key)
+        if isinstance(value, str) and _SHA_RE.fullmatch(value.strip()):
+            return value.strip()
+    for key in ("metadata", "payload", "details", "handoff"):
+        nested = record.get(key)
+        if isinstance(nested, dict):
+            value = _first_sha_from_record(nested)
+            if value:
+                return value
+    return None
+
+
+def _desired_head_for_preservation(
+    lane: dict[str, Any],
+    ledger_entry: dict[str, Any] | None,
+    *,
+    state_root: Path,
+) -> tuple[str | None, dict[str, Any] | None]:
+    branch = str(lane.get("branch") or (ledger_entry or {}).get("branch") or "")
+    lane_id = str(lane.get("lane_id") or (ledger_entry or {}).get("lane") or "")
+    records: list[dict[str, Any]] = [lane]
+    if ledger_entry is not None:
+        records.append(ledger_entry)
+    records.extend(_matching_state_records(lane_id=lane_id, branch=branch, state_root=state_root))
+
+    for record in records:
+        sha = _first_sha_from_record(record)
+        if sha:
+            return sha, record
+    return None, None
+
+
+def _remote_branch_head(
+    branch: str,
+    *,
+    repo_root: Path,
+    runner: CommandRunner,
+) -> dict[str, Any]:
+    try:
+        proc = runner(
+            ["git", "ls-remote", "origin", f"refs/heads/{branch}"],
+            repo_root,
+            _PRESERVATION_GIT_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {"status": "lookup_failed", "reason": str(exc)}
+    if proc.returncode != 0:
+        return {"status": "lookup_failed", "reason": proc.stderr.strip()}
+    line = (proc.stdout or "").strip().splitlines()
+    if not line:
+        return {"status": "missing"}
+    head = line[0].split()[0] if line[0].split() else ""
+    if not _SHA_RE.fullmatch(head):
+        return {"status": "lookup_failed", "reason": "unexpected ls-remote output"}
+    return {"status": "exists", "head_sha": head}
+
+
+def _repo_slug_from_origin(repo_root: Path, *, runner: CommandRunner) -> str | None:
+    try:
+        proc = runner(
+            ["git", "remote", "get-url", "origin"], repo_root, _PRESERVATION_GIT_TIMEOUT_SECONDS
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if proc.returncode != 0:
+        return None
+    url = proc.stdout.strip()
+    if url.endswith(".git"):
+        url = url[:-4]
+    if url.startswith("git@github.com:"):
+        return url.removeprefix("git@github.com:")
+    marker = "github.com/"
+    if marker in url:
+        return url.split(marker, 1)[1].strip("/")
+    return None
+
+
+def _gh_api_json(
+    api_path: str,
+    *,
+    repo_root: Path,
+    runner: CommandRunner,
+) -> Any:
+    try:
+        proc = runner(
+            ["gh", "api", "-H", "Accept: application/vnd.github+json", api_path],
+            repo_root,
+            _PRESERVATION_GH_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if proc.returncode != 0:
+        return None
+    return _json_payload(proc.stdout)
+
+
+def _merged_pr_commit_list_proof(
+    desired_head: str,
+    *,
+    repo_root: Path,
+    runner: CommandRunner,
+) -> dict[str, Any]:
+    repo_slug = _repo_slug_from_origin(repo_root, runner=runner)
+    if not repo_slug:
+        return {
+            "proven": False,
+            "method": "merged_pr_commit_list",
+            "reason": "repo_slug_unavailable",
+        }
+
+    pulls = _gh_api_json(
+        f"repos/{repo_slug}/commits/{desired_head}/pulls", repo_root=repo_root, runner=runner
+    )
+    if not isinstance(pulls, list):
+        return {
+            "proven": False,
+            "method": "merged_pr_commit_list",
+            "reason": "commit_pulls_unavailable",
+        }
+
+    for pull in pulls:
+        if not isinstance(pull, dict) or not pull.get("merged_at"):
+            continue
+        number = pull.get("number")
+        if not isinstance(number, int):
+            continue
+        commits = _gh_api_json(
+            f"repos/{repo_slug}/pulls/{number}/commits?per_page=100",
+            repo_root=repo_root,
+            runner=runner,
+        )
+        if not isinstance(commits, list):
+            continue
+        if any(isinstance(item, dict) and item.get("sha") == desired_head for item in commits):
+            return {
+                "proven": True,
+                "method": "merged_pr_commit_list",
+                "pr_number": number,
+                "repo": repo_slug,
+            }
+    return {
+        "proven": False,
+        "method": "merged_pr_commit_list",
+        "reason": "no_merged_pr_commit_contains_desired_head",
+    }
+
+
+def build_worktree_reference_preservation_proof(
+    lane: dict[str, Any],
+    *,
+    ledger_entry: dict[str, Any] | None = None,
+    repo_root: Path = REPO_ROOT,
+    state_root: Path = STATE_ROOT_DEFAULT,
+    runner: CommandRunner = _run_preservation_command,
+) -> dict[str, Any] | None:
+    """Prove a bare worktree reference is not evidence of local-only work.
+
+    Fail closed unless the recorded worktree is absent/noop by
+    ``safe_worktree_cleanup.py inspect`` and the desired head is
+    preserved upstream by an exact remote branch or merged PR commit
+    list. Dirty/local-work markers are never discounted.
+    """
+
+    paths = _worktree_reference_paths(lane, ledger_entry)
+    if not paths:
+        return None
+
+    local_claim = _local_work_claim_indication(lane, ledger_entry)
+    if local_claim:
+        return {
+            "available": False,
+            "reason": "local_work_claim_present",
+            "detail": local_claim,
+            "worktree_paths": [path for _, path in paths],
+        }
+
+    inspections = [
+        _safe_worktree_absent_noop_proof(path, repo_root=repo_root, runner=runner)
+        for _, path in paths
+    ]
+    if not all(item.get("absent_noop") is True for item in inspections):
+        return {
+            "available": False,
+            "reason": "worktree_not_absent_noop",
+            "worktree_paths": [path for _, path in paths],
+            "worktree_inspections": inspections,
+        }
+
+    branch = str(lane.get("branch") or (ledger_entry or {}).get("branch") or "").strip()
+    desired_head, source_record = _desired_head_for_preservation(
+        lane, ledger_entry, state_root=state_root
+    )
+    if not branch:
+        return {
+            "available": False,
+            "reason": "branch_unavailable",
+            "worktree_paths": [path for _, path in paths],
+            "worktree_inspections": inspections,
+        }
+    if not desired_head:
+        return {
+            "available": False,
+            "reason": "desired_head_unavailable",
+            "branch": branch,
+            "worktree_paths": [path for _, path in paths],
+            "worktree_inspections": inspections,
+        }
+
+    remote = _remote_branch_head(branch, repo_root=repo_root, runner=runner)
+    if remote.get("status") == "exists":
+        if remote.get("head_sha") == desired_head:
+            return {
+                "available": True,
+                "branch": branch,
+                "desired_head_sha": desired_head,
+                "desired_head_source": (source_record or {}).get("_source_path", "lane_or_ledger"),
+                "worktree_paths": [path for _, path in paths],
+                "worktree_inspections": inspections,
+                "upstream_preservation": {
+                    "proven": True,
+                    "method": "remote_branch_exact_head",
+                    "remote_head_sha": remote.get("head_sha"),
+                },
+            }
+        return {
+            "available": False,
+            "reason": "remote_branch_head_mismatch",
+            "branch": branch,
+            "desired_head_sha": desired_head,
+            "remote": remote,
+            "worktree_paths": [path for _, path in paths],
+            "worktree_inspections": inspections,
+        }
+    if remote.get("status") != "missing":
+        return {
+            "available": False,
+            "reason": "remote_branch_lookup_failed",
+            "branch": branch,
+            "desired_head_sha": desired_head,
+            "remote": remote,
+            "worktree_paths": [path for _, path in paths],
+            "worktree_inspections": inspections,
+        }
+
+    merged_pr = _merged_pr_commit_list_proof(desired_head, repo_root=repo_root, runner=runner)
+    if merged_pr.get("proven") is True:
+        return {
+            "available": True,
+            "branch": branch,
+            "desired_head_sha": desired_head,
+            "desired_head_source": (source_record or {}).get("_source_path", "lane_or_ledger"),
+            "worktree_paths": [path for _, path in paths],
+            "worktree_inspections": inspections,
+            "upstream_preservation": merged_pr,
+        }
+    return {
+        "available": False,
+        "reason": "upstream_preservation_unproven",
+        "branch": branch,
+        "desired_head_sha": desired_head,
+        "remote": remote,
+        "merged_pr": merged_pr,
+        "worktree_paths": [path for _, path in paths],
+        "worktree_inspections": inspections,
+    }
+
+
+def _local_work_indication(
+    lane: dict[str, Any],
+    ledger_entry: dict[str, Any] | None,
+    *,
+    local_work_preservation: dict[str, Any] | None = None,
+) -> str | None:
+    """Reason to suspect local (possibly unpushed/uncommitted) work, or None.
+
+    Fail closed: a worktree reference alone is enough — metadata cannot
+    prove that work in a worktree was pushed. The only exception is an
+    explicit preservation proof for a bare worktree reference.
+    """
+
+    local_claim = _local_work_claim_indication(lane, ledger_entry)
+    if local_claim:
+        return local_claim
+    worktree_paths = _worktree_reference_paths(lane, ledger_entry)
+    if worktree_paths:
+        if _proof_covers_worktree_paths(local_work_preservation, worktree_paths):
+            return None
+        return f"{worktree_paths[0][0]} references a worktree path"
     return None
 
 
@@ -1318,6 +1757,7 @@ def assess_owner_liveness(
     heartbeat: dict[str, Any] | None = None,
     now: datetime | None = None,
     stale_hours: float = STALE_HOURS_DEFAULT,
+    local_work_preservation: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Advisory-only owner-lease liveness assessment (issue #8318).
 
@@ -1389,7 +1829,11 @@ def assess_owner_liveness(
     advisory: dict[str, Any] | None = None
     advisory_withheld: str | None = None
     if assessed in ("stale", "terminal"):
-        indication = _local_work_indication(lane, ledger_entry)
+        indication = _local_work_indication(
+            lane,
+            ledger_entry,
+            local_work_preservation=local_work_preservation,
+        )
         if indication is not None:
             # Fail closed: possible unpushed/uncommitted work → no
             # advisory; escalate to an operator instead.
@@ -1404,7 +1848,16 @@ def assess_owner_liveness(
                     f"of {stale_hours}h"
                 )
                 conditions.append("no heartbeat newer than the stale window")
-            conditions.append("no worktree or local-work claim on the owner record")
+            if _worktree_reference_paths(lane, ledger_entry):
+                method = (
+                    (local_work_preservation or {}).get("upstream_preservation", {}).get("method")
+                )
+                conditions.append(
+                    "recorded worktree reference is absent/noop and preserved upstream"
+                    + (f" via {method}" if method else "")
+                )
+            else:
+                conditions.append("no worktree or local-work claim on the owner record")
             advisory = {
                 "available": True,
                 "protocol": STALE_CLAIM_PROTOCOL,
@@ -1416,6 +1869,7 @@ def assess_owner_liveness(
         "owner_liveness": owner_liveness,
         "stale_claim_advisory": advisory,
         "advisory_withheld": advisory_withheld,
+        "local_work_preservation": local_work_preservation,
     }
 
 
@@ -1637,13 +2091,30 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     liveness_payload: dict[str, Any] | None = None
     if args.liveness:
+        ledger_entry = find_lane_ledger_entry(lane, runs_glob=args.runs_glob)
         liveness_payload = assess_owner_liveness(
             lane,
-            ledger_entry=find_lane_ledger_entry(lane, runs_glob=args.runs_glob),
+            ledger_entry=ledger_entry,
             heartbeat=info.latest_heartbeat,
             now=_parse_iso_utc(args.now) if args.now else None,
             stale_hours=args.stale_hours,
         )
+        if liveness_payload.get("advisory_withheld") == ADVISORY_WITHHELD_UNPUSHED:
+            local_work_preservation = build_worktree_reference_preservation_proof(
+                lane,
+                ledger_entry=ledger_entry,
+                repo_root=REPO_ROOT,
+                state_root=STATE_ROOT_DEFAULT,
+            )
+            if local_work_preservation is not None:
+                liveness_payload = assess_owner_liveness(
+                    lane,
+                    ledger_entry=ledger_entry,
+                    heartbeat=info.latest_heartbeat,
+                    now=_parse_iso_utc(args.now) if args.now else None,
+                    stale_hours=args.stale_hours,
+                    local_work_preservation=local_work_preservation,
+                )
 
     if args.json:
         payload = dataclasses.asdict(info)

--- a/tests/scripts/test_identify_lane_owner.py
+++ b/tests/scripts/test_identify_lane_owner.py
@@ -1168,6 +1168,52 @@ def write_lane_ledger(tmp_path: Path, entries: list[dict[str, Any]]) -> str:
     return str(tmp_path / ".aragora" / "run-*" / "lanes")
 
 
+def write_preservation_outbox(
+    tmp_path: Path,
+    *,
+    lane_id: str,
+    branch: str,
+    desired_head_sha: str,
+) -> Path:
+    outbox = tmp_path / ".aragora" / "automation-outbox"
+    outbox.mkdir(parents=True, exist_ok=True)
+    path = outbox / f"open-pr-{branch.replace('/', '-')}-{desired_head_sha[:8]}.json"
+    path.write_text(
+        json.dumps(
+            {
+                "lane_id": lane_id,
+                "branch": branch,
+                "desired_head_sha": desired_head_sha,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def completed(
+    cmd: list[str], *, stdout: str = "", returncode: int = 0
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(cmd, returncode, stdout=stdout, stderr="")
+
+
+def safe_inspect_payload(*, exists: bool) -> str:
+    blockers = [] if exists else ["missing_path"]
+    return json.dumps(
+        {
+            "exists": exists,
+            "tracked_worktree": exists,
+            "active_session": False,
+            "dirty": False,
+            "blockers": blockers,
+            "cleanup_safety": {
+                "classification": "cleanup_candidate" if exists else "absent_noop",
+                "decision": "cleanup_candidate" if exists else "noop",
+            },
+        }
+    )
+
+
 class TestOwnerLeaseLiveness:
     def test_live_owner_no_advisory(self) -> None:
         lane = {
@@ -1346,6 +1392,261 @@ class TestOwnerLeaseLiveness:
     def test_find_lane_ledger_entry_missing_returns_none(self, tmp_path: Path) -> None:
         runs_glob = write_lane_ledger(tmp_path, [])
         assert ilo.find_lane_ledger_entry({"lane_id": "nope"}, runs_glob=runs_glob) is None
+
+
+class TestWorktreeReferencePreservationProof:
+    def test_q467_absent_worktree_remote_branch_exact_head_yields_advisory(
+        self, tmp_path: Path
+    ) -> None:
+        desired_sha = "4966b95bec51fac1ae102443d5e7a2974e03065d"
+        branch = "codex/measure-work-loss-pending-outbox-primary-20260610"
+        lane = {
+            "lane_id": "Q467-primary-measure-work-loss-pending-outbox",
+            "owner_session": "codex-q467",
+            "branch": branch,
+            "worktree": str(tmp_path / "absent-q467"),
+            "updated_at": _hours_ago(7.0),
+        }
+        ledger = {
+            "lane": lane["lane_id"],
+            "branch": branch,
+            "status": "in_progress",
+            "launched_at": _hours_ago(7.0),
+        }
+        write_preservation_outbox(
+            tmp_path,
+            lane_id=lane["lane_id"],
+            branch=branch,
+            desired_head_sha=desired_sha,
+        )
+        calls: list[list[str]] = []
+
+        def runner(cmd: list[str], cwd: Path, timeout: float) -> subprocess.CompletedProcess[str]:
+            calls.append(cmd)
+            if "safe_worktree_cleanup.py" in " ".join(cmd):
+                return completed(cmd, stdout=safe_inspect_payload(exists=False), returncode=1)
+            if cmd[:3] == ["git", "ls-remote", "origin"]:
+                return completed(cmd, stdout=f"{desired_sha}\trefs/heads/{branch}\n")
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        proof = ilo.build_worktree_reference_preservation_proof(
+            lane,
+            ledger_entry=ledger,
+            repo_root=tmp_path,
+            state_root=tmp_path / ".aragora",
+            runner=runner,
+        )
+        assert proof["available"] is True
+        assert proof["upstream_preservation"]["method"] == "remote_branch_exact_head"
+        assert not any(cmd[:2] == ["gh", "api"] for cmd in calls)
+
+        result = ilo.assess_owner_liveness(
+            lane,
+            ledger_entry=ledger,
+            heartbeat=None,
+            now=_liveness_now(),
+            local_work_preservation=proof,
+        )
+        assert result["stale_claim_advisory"]["available"] is True
+        assert result["advisory_withheld"] is None
+
+    def test_q379_absent_worktree_merged_pr_commit_yields_advisory_when_remote_gone(
+        self, tmp_path: Path
+    ) -> None:
+        desired_sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        branch = "codex/salvage-collect-evidence-quorum-rerun-20260606"
+        lane = {
+            "lane_id": "Q379-primary-salvage",
+            "owner_session": "codex-q379",
+            "branch": branch,
+            "worktree": str(tmp_path / "absent-q379"),
+            "updated_at": _hours_ago(7.0),
+        }
+        ledger = {
+            "lane": lane["lane_id"],
+            "branch": branch,
+            "status": "completed",
+            "launched_at": _hours_ago(7.0),
+        }
+        write_preservation_outbox(
+            tmp_path,
+            lane_id=lane["lane_id"],
+            branch=branch,
+            desired_head_sha=desired_sha,
+        )
+
+        def runner(cmd: list[str], cwd: Path, timeout: float) -> subprocess.CompletedProcess[str]:
+            if "safe_worktree_cleanup.py" in " ".join(cmd):
+                return completed(cmd, stdout=safe_inspect_payload(exists=False), returncode=1)
+            if cmd[:3] == ["git", "ls-remote", "origin"]:
+                return completed(cmd, stdout="")
+            if cmd == ["git", "remote", "get-url", "origin"]:
+                return completed(cmd, stdout="https://github.com/synaptent/aragora.git\n")
+            if cmd[:2] == ["gh", "api"] and f"commits/{desired_sha}/pulls" in cmd[-1]:
+                return completed(
+                    cmd, stdout=json.dumps([{"number": 8396, "merged_at": LIVENESS_NOW}])
+                )
+            if cmd[:2] == ["gh", "api"] and "pulls/8396/commits" in cmd[-1]:
+                return completed(cmd, stdout=json.dumps([{"sha": desired_sha}]))
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        proof = ilo.build_worktree_reference_preservation_proof(
+            lane,
+            ledger_entry=ledger,
+            repo_root=tmp_path,
+            state_root=tmp_path / ".aragora",
+            runner=runner,
+        )
+        assert proof["available"] is True
+        assert proof["upstream_preservation"]["method"] == "merged_pr_commit_list"
+
+        result = ilo.assess_owner_liveness(
+            lane,
+            ledger_entry=ledger,
+            heartbeat=None,
+            now=_liveness_now(),
+            local_work_preservation=proof,
+        )
+        assert result["stale_claim_advisory"]["available"] is True
+        assert result["advisory_withheld"] is None
+
+    def test_present_worktree_still_withholds_possible_unpushed_work(self, tmp_path: Path) -> None:
+        desired_sha = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        branch = "codex/present-worktree"
+        lane = {
+            "lane_id": "Q-present",
+            "owner_session": "codex-present",
+            "branch": branch,
+            "worktree": str(tmp_path / "present-worktree"),
+            "updated_at": _hours_ago(7.0),
+        }
+        ledger = {
+            "lane": lane["lane_id"],
+            "branch": branch,
+            "status": "in_progress",
+            "launched_at": _hours_ago(7.0),
+        }
+        write_preservation_outbox(
+            tmp_path,
+            lane_id=lane["lane_id"],
+            branch=branch,
+            desired_head_sha=desired_sha,
+        )
+
+        def runner(cmd: list[str], cwd: Path, timeout: float) -> subprocess.CompletedProcess[str]:
+            if "safe_worktree_cleanup.py" in " ".join(cmd):
+                return completed(cmd, stdout=safe_inspect_payload(exists=True))
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        proof = ilo.build_worktree_reference_preservation_proof(
+            lane,
+            ledger_entry=ledger,
+            repo_root=tmp_path,
+            state_root=tmp_path / ".aragora",
+            runner=runner,
+        )
+        result = ilo.assess_owner_liveness(
+            lane,
+            ledger_entry=ledger,
+            heartbeat=None,
+            now=_liveness_now(),
+            local_work_preservation=proof,
+        )
+        assert proof["available"] is False
+        assert result["stale_claim_advisory"] is None
+        assert result["advisory_withheld"] == "possible_unpushed_work"
+
+    def test_absent_worktree_without_upstream_proof_still_withholds(self, tmp_path: Path) -> None:
+        desired_sha = "cccccccccccccccccccccccccccccccccccccccc"
+        branch = "codex/no-upstream-proof"
+        lane = {
+            "lane_id": "Q-no-proof",
+            "owner_session": "codex-no-proof",
+            "branch": branch,
+            "worktree": str(tmp_path / "absent-no-proof"),
+            "updated_at": _hours_ago(7.0),
+        }
+        ledger = {
+            "lane": lane["lane_id"],
+            "branch": branch,
+            "status": "in_progress",
+            "launched_at": _hours_ago(7.0),
+        }
+        write_preservation_outbox(
+            tmp_path,
+            lane_id=lane["lane_id"],
+            branch=branch,
+            desired_head_sha=desired_sha,
+        )
+
+        def runner(cmd: list[str], cwd: Path, timeout: float) -> subprocess.CompletedProcess[str]:
+            if "safe_worktree_cleanup.py" in " ".join(cmd):
+                return completed(cmd, stdout=safe_inspect_payload(exists=False), returncode=1)
+            if cmd[:3] == ["git", "ls-remote", "origin"]:
+                return completed(cmd, stdout="")
+            if cmd == ["git", "remote", "get-url", "origin"]:
+                return completed(cmd, stdout="https://github.com/synaptent/aragora.git\n")
+            if cmd[:2] == ["gh", "api"] and f"commits/{desired_sha}/pulls" in cmd[-1]:
+                return completed(cmd, stdout="[]")
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        proof = ilo.build_worktree_reference_preservation_proof(
+            lane,
+            ledger_entry=ledger,
+            repo_root=tmp_path,
+            state_root=tmp_path / ".aragora",
+            runner=runner,
+        )
+        result = ilo.assess_owner_liveness(
+            lane,
+            ledger_entry=ledger,
+            heartbeat=None,
+            now=_liveness_now(),
+            local_work_preservation=proof,
+        )
+        assert proof["available"] is False
+        assert proof["reason"] == "upstream_preservation_unproven"
+        assert result["stale_claim_advisory"] is None
+        assert result["advisory_withheld"] == "possible_unpushed_work"
+
+    def test_dirty_marker_set_still_withholds_possible_unpushed_work(self, tmp_path: Path) -> None:
+        branch = "codex/dirty-marker"
+        lane = {
+            "lane_id": "Q-dirty-marker",
+            "owner_session": "codex-dirty-marker",
+            "branch": branch,
+            "worktree": str(tmp_path / "absent-dirty"),
+            "local_work": True,
+            "updated_at": _hours_ago(7.0),
+        }
+        ledger = {
+            "lane": lane["lane_id"],
+            "branch": branch,
+            "status": "in_progress",
+            "launched_at": _hours_ago(7.0),
+        }
+
+        def runner(cmd: list[str], cwd: Path, timeout: float) -> subprocess.CompletedProcess[str]:
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        proof = ilo.build_worktree_reference_preservation_proof(
+            lane,
+            ledger_entry=ledger,
+            repo_root=tmp_path,
+            state_root=tmp_path / ".aragora",
+            runner=runner,
+        )
+        result = ilo.assess_owner_liveness(
+            lane,
+            ledger_entry=ledger,
+            heartbeat=None,
+            now=_liveness_now(),
+            local_work_preservation=proof,
+        )
+        assert proof["available"] is False
+        assert proof["reason"] == "local_work_claim_present"
+        assert result["stale_claim_advisory"] is None
+        assert result["advisory_withheld"] == "possible_unpushed_work"
 
 
 class TestLivenessCLI:


### PR DESCRIPTION
## Summary
- Adds a proof-gated liveness discount for bare recorded worktree references in `scripts/identify_lane_owner.py`.
- Preserves fail-closed behavior for present worktrees, missing upstream preservation proof, and any dirty/local-work marker.
- Emits `local_work_preservation` diagnostics naming the selected proof source and reason when proof fails.

## Evidence
- Q467 live smoke: `identify_lane_owner.py --branch codex/measure-work-loss-pending-outbox-primary-20260610 --liveness --json` now reports `advisory_withheld=null`, `stale_claim_advisory.available=true`, `safe_worktree_cleanup.inspect` classification `absent_noop`, and remote branch `codex/measure-work-loss-pending-outbox-primary-20260610` at exact desired head `4966b95bec51fac1ae102443d5e7a2974e03065d`.
- Q379 shape: regression coverage proves the remote-branch-gone path only discounts when the desired SHA is present in a merged PR commit list.
- Safety guardrails: present worktree, absent worktree without upstream proof, and dirty/local-work markers all continue to withhold with `possible_unpushed_work`.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_identify_lane_owner.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/identify_lane_owner.py tests/scripts/test_identify_lane_owner.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/identify_lane_owner.py tests/scripts/test_identify_lane_owner.py`

No Q379/Q467 release, outbox archive, or settlement-helper changes are included.