### PR TITLE
fix(swarm): disable MCP for the merge-gate claude reviewer

### DIFF
--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -473,11 +473,21 @@ def default_reviewer_runner(family: str, prompt: str) -> ReviewerResult:
     return _run_api_agent(fam, prompt)
 
 
+def _claude_reviewer_command() -> list[str]:
+    """Argv for the merge-gate claude reviewer with MCP servers disabled.
+
+    The reviewer only reads a diff to emit a verdict, so it needs no MCP
+    servers. Disabling them avoids claude's startup MCP handshake, which blocks
+    until the full timeout when a local MCP server is wedged.
+    """
+    return ["claude", "-p", "--strict-mcp-config", "--mcp-config", '{"mcpServers":{}}']
+
+
 def _run_claude_cli(prompt: str) -> ReviewerResult:
     timeout = _timeout_seconds(_CLAUDE_TIMEOUT_ENV, _CLAUDE_TIMEOUT)
     try:
         proc = subprocess.run(
-            ["claude", "-p"],
+            _claude_reviewer_command(),
             input=prompt,
             capture_output=True,
             text=True,

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -240,7 +240,9 @@ def test_run_claude_cli_uses_env_timeout(monkeypatch: pytest.MonkeyPatch) -> Non
 
     result = qe._run_claude_cli("review prompt")
 
-    assert seen["args"] == (["claude", "-p"],)
+    assert seen["args"] == (
+        ["claude", "-p", "--strict-mcp-config", "--mcp-config", '{"mcpServers":{}}'],
+    )
     assert seen["timeout"] == 7.0
     assert result == ReviewerResult(
         "claude",
@@ -248,6 +250,15 @@ def test_run_claude_cli_uses_env_timeout(monkeypatch: pytest.MonkeyPatch) -> Non
         False,
         "claude CLI timed out after 7s",
     )
+
+
+def test_claude_reviewer_command_disables_mcp() -> None:
+    cmd = qe._claude_reviewer_command()
+
+    assert cmd[:2] == ["claude", "-p"]
+    assert "--mcp-config" in cmd
+    assert cmd[cmd.index("--mcp-config") + 1] == '{"mcpServers":{}}'
+    assert "--strict-mcp-config" in cmd
 
 
 # --- OpenAI reviewer fallback ----------------------------------------------


### PR DESCRIPTION
## What

Make the merge-gate `claude` CLI reviewer immune to a wedged local MCP server.

`_run_claude_cli` in `aragora/swarm/quorum_evidence.py` spawned plain
`["claude", "-p"]`, which blocks on claude's MCP handshake at startup. When a
local MCP server is CPU-pegged/wedged (observed: claude-mem's `chroma-mcp` at
~90% CPU), that handshake never completes, so every reviewer call hangs to the
300s `_CLAUDE_TIMEOUT`, drops the claude signal to 0, and blocks every merge
(repeatedly stalled p1-conftest-split / PR #8416). The reviewer only reads a
diff to emit a verdict and needs no MCP servers.

## Change (scope: `_run_claude_cli` + new helper only)

- New `_claude_reviewer_command()` returns
  `["claude", "-p", "--strict-mcp-config", "--mcp-config", '{"mcpServers":{}}']`.
- `_run_claude_cli` calls the helper instead of the inline `["claude", "-p"]`.
- Everything else is byte-for-byte unchanged: stdin prompt, timeout via
  `_CLAUDE_TIMEOUT(_ENV)`, `capture_output`, `text`, `check=False`, the
  `FileNotFoundError` / `TimeoutExpired` / `OSError|SubprocessError` handling,
  and the `returncode != 0` or empty-text failure path.
- `build_claude_command` (the debate-agent path in `aragora/agents/cli_agents.py`)
  is intentionally NOT touched.

## Flag compatibility

`claude --help | grep -i mcp` on the installed claude (2.1.177) confirms BOTH
`--strict-mcp-config` and `--mcp-config <configs...>` are accepted, so both are
kept (`--strict-mcp-config` forces "only use MCP servers from --mcp-config",
i.e. an empty set). No flag was omitted.

## Tests

- Red-first `test_claude_reviewer_command_disables_mcp` asserts the reviewer
  argv contains `--mcp-config '{"mcpServers":{}}'` (and the strict flag) without
  spawning claude. Failed before the fix (`AttributeError`), passes after.
- `test_run_claude_cli_uses_env_timeout` updated to assert the spawned argv is
  the MCP-disabled command (timeout/error semantics unchanged).
- No change to verdict/quorum semantics.

## Validation

- `python3 -m pytest tests/swarm/test_quorum_evidence.py -q` -> `92 passed`
  (the 2 target tests fail before the fix, pass after).
- `make lint` -> `All checks passed!`
- `bash $MISSION/scripts/typecheck_differential.sh` -> `TYPECHECK PASS
  (differential: new=50 <= recorded env drift=50)` (0 new errors from this PR).
- `make test-smoke` -> `Smoke tests passed!`
- `PYTEST_BIN="python3 -m pytest" bash scripts/test_tiers.sh smoke` -> `138 passed`.

## Risk

Pure isolation change in one CLI-spawn helper; tier 2 (`aragora/swarm/`). No
public API, workflow, or release-flow surface touched.
