### PR TITLE
test(structex): repair migration-surfaced stale tests in agents/knowledge/reasoning shards

### DIFF
--- a/tests/agents/conftest.py
+++ b/tests/agents/conftest.py
@@ -1,0 +1,48 @@
+"""Shared fixtures for agent tests."""
+
+import pytest
+
+from aragora.agents.registry import AgentRegistry, register_all_agents
+from aragora.resilience import reset_all_v2_circuit_breakers
+
+# Populate the lazily-built agent registry once, before any test can clear it,
+# and snapshot the full set of registered specs. register_all_agents() only
+# triggers the @register decorators via module imports, so after a clear() the
+# already-cached modules are not re-imported and the registry cannot be rebuilt
+# for the rest of the process. Capturing the populated state here lets the
+# autouse fixture below restore a complete registry between tests.
+register_all_agents()
+_AGENT_REGISTRY_GOLDEN = dict(AgentRegistry._registry)
+
+
+@pytest.fixture(autouse=True)
+def _restore_agent_registry():
+    """Restore the shared ``AgentRegistry`` after every agent test.
+
+    Registry tests call ``AgentRegistry.clear()``/``register()`` on the shared
+    class-level ``_registry``. Because population is lazy and import-based, a
+    cleared registry cannot be rebuilt via ``register_all_agents()`` within the
+    same process, so a clear() in one test file otherwise leaves
+    ``create_agent()`` broken (e.g. "Unknown agent type: demo") for every later
+    test file. Restoring the captured registry after each test keeps it intact
+    across files regardless of execution order.
+    """
+    yield
+    AgentRegistry._registry.clear()
+    AgentRegistry._registry.update(_AGENT_REGISTRY_GOLDEN)
+
+
+@pytest.fixture(autouse=True)
+def _reset_agent_circuit_breakers():
+    """Reset the agent circuit-breaker registry around every agent test.
+
+    Agents acquire breakers from the shared ``get_v2_circuit_breaker`` registry
+    keyed by agent name, so a breaker tripped in one test (e.g. ollama/lm-studio
+    connection-failure cases) stays open for later tests and raises an
+    order-dependent ``AgentCircuitOpenError``. The suite-wide autouse reset only
+    clears the v1 registry, which is a distinct dict, so the v2 registry must be
+    reset separately here.
+    """
+    reset_all_v2_circuit_breakers()
+    yield
+    reset_all_v2_circuit_breakers()

--- a/tests/agents/test_agent_lm_studio.py
+++ b/tests/agents/test_agent_lm_studio.py
@@ -381,7 +381,8 @@ class TestLMStudioGenerateStream:
 
         mock_response = AsyncMock()
         mock_response.status = 200
-        mock_response.content = mock_content_iter()
+        mock_response.content = MagicMock()
+        mock_response.content.iter_any.return_value = mock_content_iter()
         mock_response.__aenter__ = AsyncMock(return_value=mock_response)
         mock_response.__aexit__ = AsyncMock(return_value=None)
 
@@ -415,7 +416,8 @@ class TestLMStudioGenerateStream:
 
         mock_response = AsyncMock()
         mock_response.status = 200
-        mock_response.content = mock_content_iter()
+        mock_response.content = MagicMock()
+        mock_response.content.iter_any.return_value = mock_content_iter()
         mock_response.__aenter__ = AsyncMock(return_value=mock_response)
         mock_response.__aexit__ = AsyncMock(return_value=None)
 

--- a/tests/evidence/test_evidence_collector.py
+++ b/tests/evidence/test_evidence_collector.py
@@ -788,7 +788,7 @@ class TestURLConsentGate:
 
     def test_consent_callback_error_blocks_url(self):
         """Should block URL if consent callback raises exception."""
-        callback = Mock(side_effect=Exception("Consent service unavailable"))
+        callback = Mock(side_effect=ValueError("Consent service unavailable"))
         collector = EvidenceCollector(
             require_url_consent=True,
             url_consent_callback=callback,
@@ -836,7 +836,7 @@ class TestURLConsentGate:
 
     def test_audit_callback_error_handled_gracefully(self):
         """Should handle audit callback errors gracefully."""
-        audit_callback = Mock(side_effect=Exception("Audit service down"))
+        audit_callback = Mock(side_effect=RuntimeError("Audit service down"))
         collector = EvidenceCollector(audit_callback=audit_callback)
 
         # Should not raise

--- a/tests/memory/test_debate_memory_manager.py
+++ b/tests/memory/test_debate_memory_manager.py
@@ -328,7 +328,7 @@ class TestStoreDebateOutcome:
 
     def test_store_outcome_handles_exception(self, mock_continuum_memory, mock_debate_result):
         """Test exception handling in store_debate_outcome."""
-        mock_continuum_memory.add.side_effect = Exception("Storage error")
+        mock_continuum_memory.add.side_effect = RuntimeError("Storage error")
 
         manager = MemoryManager(continuum_memory=mock_continuum_memory)
         # Should not raise
@@ -844,6 +844,6 @@ class TestNotifySpectator:
 
     def test_notify_spectator_handles_exception(self, memory_manager, mock_spectator):
         """Test notification handles exceptions."""
-        mock_spectator.emit.side_effect = Exception("Emit error")
+        mock_spectator.emit.side_effect = RuntimeError("Emit error")
         # Should not raise
         memory_manager._notify_spectator("test_event", "test details")

--- a/tests/reasoning/test_belief_analysis.py
+++ b/tests/reasoning/test_belief_analysis.py
@@ -208,7 +208,7 @@ class TestDebateBeliefAnalyzer:
         """Handles errors during belief propagation."""
         mock_network = MagicMock()
         mock_network.nodes = {"node1": {}}
-        mock_network.propagate.side_effect = ValueError("Propagation failed")
+        mock_network.propagate.side_effect = RuntimeError("Propagation failed")
 
         mock_BN = MagicMock(return_value=mock_network)
         mock_load.return_value = (mock_BN, MagicMock())
@@ -219,7 +219,7 @@ class TestDebateBeliefAnalyzer:
         result = analyzer.analyze_messages(messages)
 
         assert result.analysis_error is not None
-        assert "Propagation failed" in result.analysis_error
+        assert "Belief analysis failed" in result.analysis_error
 
     @patch("aragora.debate.phases.belief_analysis._load_belief_classes")
     def test_handles_analyzer_error(self, mock_load):
@@ -236,4 +236,4 @@ class TestDebateBeliefAnalyzer:
         result = analyzer.analyze_claims(claims)
 
         assert result.analysis_error is not None
-        assert "Analysis failed" in result.analysis_error
+        assert "Belief analysis failed" in result.analysis_error

--- a/tests/reasoning/test_nomic_integration_extended.py
+++ b/tests/reasoning/test_nomic_integration_extended.py
@@ -295,7 +295,7 @@ class TestAgentProbingExtended:
         integration.prober = MagicMock()
         integration.prober.probe_agent = AsyncMock(return_value=mock_report)
 
-        weights = await integration.probe_agents([mock_agent])
+        weights = await integration.probe_agents([mock_agent], run_agent_fn=AsyncMock())
 
         # Weight should be 1.0 - 0.2 = 0.8
         assert weights[mock_agent.name] == pytest.approx(0.8, rel=0.01)
@@ -315,7 +315,7 @@ class TestAgentProbingExtended:
         integration.prober = MagicMock()
         integration.prober.probe_agent = AsyncMock(return_value=mock_report)
 
-        weights = await integration.probe_agents([mock_agent])
+        weights = await integration.probe_agents([mock_agent], run_agent_fn=AsyncMock())
 
         # Weight = (1.0 - 0.1) * 0.5 = 0.45
         assert weights[mock_agent.name] == pytest.approx(0.45, rel=0.01)
@@ -351,7 +351,7 @@ class TestAgentProbingExtended:
         integration.prober = MagicMock()
         integration.prober.probe_agent = AsyncMock(side_effect=RuntimeError("Probe failed"))
 
-        weights = await integration.probe_agents([mock_agent])
+        weights = await integration.probe_agents([mock_agent], run_agent_fn=AsyncMock())
 
         # Should get fallback weight of 0.75
         assert weights[mock_agent.name] == 0.75
@@ -371,7 +371,7 @@ class TestAgentProbingExtended:
         integration.prober = MagicMock()
         integration.prober.probe_agent = AsyncMock(return_value=mock_report)
 
-        await integration.probe_agents([mock_agent])
+        await integration.probe_agents([mock_agent], run_agent_fn=AsyncMock())
 
         assert integration._agent_weights[mock_agent.name] == pytest.approx(0.9, rel=0.01)
 
@@ -679,7 +679,9 @@ class TestErrorHandling:
 
         # Mock counterfactual orchestrator
         integration_no_checkpoint.counterfactual = MagicMock()
-        integration_no_checkpoint.counterfactual.create_branches = AsyncMock(return_value=[])
+        integration_no_checkpoint.counterfactual.create_and_run_branches = AsyncMock(
+            return_value=[]
+        )
 
         # Patch PivotClaim to handle the incorrect kwargs in the implementation
         with patch("aragora.nomic.integration.PivotClaim") as MockPivotClaim:

--- a/tests/reasoning/test_provenance_enhanced.py
+++ b/tests/reasoning/test_provenance_enhanced.py
@@ -482,7 +482,7 @@ class TestGitProvenanceTracker:
     def test_run_git_exception(self):
         """Test _run_git handles exceptions."""
         tracker = GitProvenanceTracker(repo_path="/repo")
-        with patch("subprocess.run", side_effect=Exception("Command failed")):
+        with patch("subprocess.run", side_effect=OSError("Command failed")):
             success, output = tracker._run_git(["status"])
             assert success is False
             assert "Command failed" in output
@@ -784,7 +784,7 @@ class TestWebProvenanceTracker:
             )
 
             mock_pool, session_ctx = _mock_http_pool_response()
-            session_ctx.__aenter__.side_effect = RuntimeError("Network error")
+            session_ctx.__aenter__.side_effect = OSError("Network error")
 
             with patch("aragora.server.http_client_pool.get_http_pool", return_value=mock_pool):
                 check = await tracker.check_staleness(source_info)


### PR DESCRIPTION
## Source

The tests-migration (batches 1-3) relocated loose root tests into per-dir `tests/`
mirrors, placing them into the per-dir `test-fast` CI shards for the first time.
This surfaced PRE-EXISTING stale-test debt (the SOURCE is correct; the TESTS were
stale), reddening the previously-green `agents`, `knowledge`
(tests/knowledge+evidence+memory), and `reasoning` (tests/rlm+reasoning) shards.
Each failure below was confirmed to reproduce identically at the test's location
on clean `origin/main` before fixing.

## What this fixes (tests-only — no source-behavior changes, no assertion weakening)

**agents shard**
- **(aiohttp API drift)** `tests/agents/test_agent_lm_studio.py`: streaming tests
  used the removed `async_generator.iter_any`; updated to the current `aiohttp`
  streaming API (mock `content` exposes `iter_any`).
- **(circuit-breaker isolation)** `tests/agents/conftest.py` (new): autouse fixture
  resets the shared **v2** `get_v2_circuit_breaker` registry around every test. The
  suite-wide autouse reset only cleared the v1 registry, so a breaker tripped by an
  ollama/lm-studio connection-failure test stayed open and raised order-dependent
  `AgentCircuitOpenError` in later files.
- **(AgentRegistry isolation)** `tests/agents/conftest.py`: populates the
  lazily-built `AgentRegistry` once at import and restores it after every test.
  Registry tests call `AgentRegistry.clear()`; because population is lazy and
  import-based, a cleared registry cannot be rebuilt via `register_all_agents()`
  in-process, so a clear() in one file left `create_agent("demo")` raising
  `ValueError: Unknown agent type: demo` for every later file (e.g. `test_base.py`)
  under random ordering.

**knowledge shard (error-handling tests asserting outdated exception behavior)**
- `tests/evidence/test_evidence_collector.py`: consent stimulus `Exception`->`ValueError`,
  audit `Exception`->`RuntimeError` (match the source's deliberately-narrowed catch;
  graceful-handling assertions preserved).
- `tests/memory/test_debate_memory_manager.py`: store + notify stimulus
  `Exception`->`RuntimeError`.

**reasoning shard (signature / format / exception drift)**
- `tests/reasoning/test_nomic_integration_extended.py`: `probe_agents` now requires
  `run_agent_fn` (added `run_agent_fn=AsyncMock()` x4); deadlock test
  `create_branches`->`create_and_run_branches`.
- `tests/reasoning/test_belief_analysis.py`: propagation/analyzer error tests
  `ValueError`->`RuntimeError` + assertion text `"Belief analysis failed"`.
- `tests/reasoning/test_provenance_enhanced.py`: git/staleness exception stimulus
  ->`OSError` (within the source's caught tuple).

## Validation (this branch)

- `make lint` -> All checks passed!
- `typecheck_differential.sh` -> PASS (new=50 <= env drift 50; tests-only, no mission-file regressions)
- Targeted (random order): the 6 edited test files + the isolation-repro pairs
  (`test_agent_ollama`/`test_agent_local`, `test_agent_registry`/`test_registry`/`test_base`)
  -> **504 passed**
- Full shards (CI marker filter, random order): `tests/rlm tests/reasoning` -> 2300 passed;
  `tests/knowledge tests/evidence tests/memory` -> 9382 passed, 2 skipped;
  `tests/agents` -> 5505 passed, 11 failed. The 11 are exclusively the
  model-name/persona-count assertions in the 5 files owned by open PR #8420
  (`fix(agents): align current shard contracts`) and are out of scope here.
- `make test-smoke` -> Smoke tests passed!; smoke tier (`scripts/test_tiers.sh smoke`) -> 138 passed.

## Risks

Tests-only; no source changes; no assertions weakened or deleted; no skips added
(`tests/.skip_baseline` unchanged). The two new autouse conftest fixtures only reset
shared global state (v2 breaker registry + `AgentRegistry`) between tests, increasing
isolation. The agents shard remains red solely on PR #8420's files until that PR merges.
