### PR TITLE
perf(swarm): concurrent quorum reviewers + App-token read routing

### DIFF
--- a/aragora/swarm/merge_quorum_io.py
+++ b/aragora/swarm/merge_quorum_io.py
@@ -17,6 +17,7 @@ import sys
 import tempfile
 from typing import Any
 
+from aragora.swarm import github_app_auth
 from aragora.swarm.merge_quorum_reconcile import (
     EvidenceComment,
     PacketClassification,
@@ -68,6 +69,19 @@ def aragora_env() -> dict[str, str]:
     return env
 
 
+def _read_env() -> dict[str, str]:
+    """Environment for *read-only* ``gh`` calls.
+
+    Prefer the GitHub App installation token so reads draw on the App's separate
+    API budget instead of starving the operator's shared per-user PAT quota (the
+    chronic GraphQL-exhaustion failure mode). Degrades transparently to the
+    ambient/operator auth when no App config is present. Read-only by design --
+    the App installation 403s on classic branch-protection writes, so write call
+    sites deliberately keep ``run()``'s default (PAT) env instead of this helper.
+    """
+    return github_app_auth.github_cli_env(aragora_env())
+
+
 def run(
     args: list[str], *, env: dict[str, str] | None = None, timeout: int | None = _GH_TIMEOUT
 ) -> subprocess.CompletedProcess:
@@ -105,7 +119,8 @@ def list_open_prs(repo: str, *, limit: int, author: str | None) -> list[int]:
                 str(limit),
                 "--json",
                 "number,isDraft,author",
-            ]
+            ],
+            env=_read_env(),
         )
         or []
     )
@@ -133,7 +148,8 @@ def fetch_pr_context(repo: str, pr: int) -> dict[str, Any]:
             repo,
             "--json",
             "headRefOid,commits,statusCheckRollup",
-        ]
+        ],
+        env=_read_env(),
     )
     head_sha = str(data.get("headRefOid") or "").strip()
     commits = data.get("commits") or []
@@ -146,7 +162,9 @@ def fetch_pr_context(repo: str, pr: int) -> dict[str, Any]:
         # The head may be beyond the returned commit slice; fetch its date
         # directly rather than guessing from the last listed commit.
         try:
-            commit = run_json(["gh", "api", f"repos/{repo}/commits/{head_sha}"]) or {}
+            commit = (
+                run_json(["gh", "api", f"repos/{repo}/commits/{head_sha}"], env=_read_env()) or {}
+            )
         except RuntimeError:
             commit = {}
         committer = (commit.get("commit") or {}).get("committer") or {}
@@ -185,7 +203,8 @@ def fetch_latest_quorum_run(repo: str, head_sha: str) -> QuorumRun | None:
             "gh",
             "api",
             f"repos/{repo}/actions/workflows/{QUORUM_WORKFLOW_FILE}/runs?head_sha={head_sha}&per_page=1",
-        ]
+        ],
+        env=_read_env(),
     )
     runs = (data or {}).get("workflow_runs") or []
     if not runs:
@@ -210,7 +229,10 @@ def fetch_human_settlement_present(repo: str, head_sha: str) -> bool:
     if not head_sha:
         return False
     try:
-        statuses = run_json(["gh", "api", f"repos/{repo}/commits/{head_sha}/statuses"]) or []
+        statuses = (
+            run_json(["gh", "api", f"repos/{repo}/commits/{head_sha}/statuses"], env=_read_env())
+            or []
+        )
     except RuntimeError:
         return False
     for status in statuses:
@@ -243,7 +265,7 @@ def fetch_merge_packet_classification(repo: str, pr: int) -> PacketClassificatio
                 repo,
                 "--json",
             ],
-            env=aragora_env(),
+            env=_read_env(),
             timeout=_MERGE_PACKET_TIMEOUT,
         )
     except subprocess.TimeoutExpired:

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -27,6 +27,7 @@ all network/process I/O is injected so the orchestrator
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import inspect
 import logging
 import math
@@ -101,6 +102,10 @@ _REVIEWER_TIMEOUT = 300
 _CLAUDE_TIMEOUT_ENV = "ARAGORA_COLLECT_EVIDENCE_CLAUDE_TIMEOUT_SECONDS"
 _REVIEWER_TIMEOUT_ENV = "ARAGORA_COLLECT_EVIDENCE_REVIEWER_TIMEOUT_SECONDS"
 _REVIEWER_CLEANUP_TIMEOUT = 10
+# Reviewers each block up to their own (timeout-guarded, process-isolated) run,
+# so running them serially made wall-time the *sum* of every reviewer's timeout
+# (e.g. 2x300s). Run them concurrently instead; this cap bounds the fan-out.
+_MAX_REVIEWER_WORKERS = 4
 
 
 def _cap_text(text: str) -> str:
@@ -757,12 +762,41 @@ def collect_evidence(
 
     prompt = prompt_builder(repo, pr, ctx)
 
+    # Resolve the ordered, de-duplicated family list up front so item/failure
+    # ordering stays deterministic and matches the caller's requested order,
+    # regardless of which reviewer finishes first.
     seen: set[str] = set()
+    ordered_families: list[str] = []
     for raw_family in families:
         family = raw_family.strip().lower()
         if not family or family in seen:
             continue
         seen.add(family)
+        ordered_families.append(family)
+
+    # Run the supported reviewers concurrently. Each runner already bounds itself
+    # with its own timeout and isolates its work in a child subprocess/process, so
+    # threads here only wait -- but they turn serial wall-time (sum of timeouts)
+    # into roughly the slowest single reviewer. One reviewer raising never aborts
+    # the run; it is recorded as a failure like any empty/non-ok result.
+    supported = [family for family in ordered_families if family in FAMILY_PROVIDERS]
+    reviews: dict[str, ReviewerResult] = {}
+    if supported:
+        max_workers = min(len(supported), _MAX_REVIEWER_WORKERS)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
+            future_to_family = {
+                pool.submit(reviewer_runner, family, prompt): family for family in supported
+            }
+            for future in concurrent.futures.as_completed(future_to_family):
+                family = future_to_family[future]
+                try:
+                    reviews[family] = future.result()
+                except Exception as exc:  # noqa: BLE001 - one bad reviewer must not abort the run
+                    reviews[family] = ReviewerResult(
+                        family, "", False, f"{type(exc).__name__}: {str(exc)[:200]}"
+                    )
+
+    for family in ordered_families:
         if family not in FAMILY_PROVIDERS:
             # Only direct families the quorum parser can count are supported;
             # reject anything else early instead of producing an uncountable
@@ -771,7 +805,7 @@ def collect_evidence(
                 ReviewerResult(family, "", False, f"unsupported reviewer family: {family}")
             )
             continue
-        result = reviewer_runner(family, prompt)
+        result = reviews[family]
         if not result.ok or not result.text.strip():
             outcome.failures.append(result)
             continue

--- a/tests/swarm/test_merge_quorum_io.py
+++ b/tests/swarm/test_merge_quorum_io.py
@@ -16,6 +16,47 @@ def _proc(stdout: str, returncode: int = 0) -> subprocess.CompletedProcess:
     return subprocess.CompletedProcess(args=["gh"], returncode=returncode, stdout=stdout, stderr="")
 
 
+def test_read_env_prefers_app_installation_token(monkeypatch) -> None:
+    from aragora.swarm import github_app_auth
+
+    monkeypatch.setattr(
+        github_app_auth, "get_github_app_installation_token", lambda env=None: "fake-app-token"
+    )
+    env = m._read_env()
+    assert env["GH_TOKEN"] == "fake-app-token"
+    assert env["GITHUB_TOKEN"] == "fake-app-token"
+    assert env["ARAGORA_GITHUB_AUTH_SOURCE"] == "github_app_installation"
+
+
+def test_read_env_degrades_to_ambient_auth_without_app_config(monkeypatch) -> None:
+    from aragora.swarm import github_app_auth
+
+    # No App config -> mint returns None -> read env carries no App-source tag, so
+    # gh falls back to the operator's ambient auth instead of crashing.
+    monkeypatch.setattr(github_app_auth, "get_github_app_installation_token", lambda env=None: None)
+    env = m._read_env()
+    assert env.get("ARAGORA_GITHUB_AUTH_SOURCE") != "github_app_installation"
+
+
+def test_fetch_pr_context_routes_reads_through_app_token(monkeypatch) -> None:
+    from aragora.swarm import github_app_auth
+
+    monkeypatch.setattr(
+        github_app_auth, "get_github_app_installation_token", lambda env=None: "fake-app-token"
+    )
+    captured_envs: list[dict] = []
+
+    def capture_run(args, *, env=None, timeout=m._GH_TIMEOUT):
+        captured_envs.append(env or {})
+        return _proc(json.dumps({"headRefOid": "abc", "commits": [], "statusCheckRollup": []}))
+
+    monkeypatch.setattr(m, "run", capture_run)
+    m.fetch_pr_context("o/r", 1)
+    assert captured_envs, "expected fetch_pr_context to shell out to gh"
+    assert captured_envs[0].get("GH_TOKEN") == "fake-app-token"
+    assert captured_envs[0].get("ARAGORA_GITHUB_AUTH_SOURCE") == "github_app_installation"
+
+
 def test_fetch_pr_tier_reads_nested_entries(monkeypatch) -> None:
     payload = {
         "version": "merge_authorization_packet.v1",

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import os
 import subprocess
+import threading
 import time
 from contextlib import contextmanager
 from types import SimpleNamespace
@@ -670,6 +671,62 @@ def test_collect_low_tier_apply_posts_both() -> None:
     assert outcome.action == "post"
     assert sorted(outcome.posted) == ["claude", "grok"]
     assert len(posted) == 2
+
+
+def test_collect_runs_reviewers_concurrently() -> None:
+    # Deterministic concurrency proof: a 2-party barrier only trips if both
+    # reviewers run at once. Serial execution would block the first runner on
+    # the barrier forever (until its 5s timeout -> BrokenBarrierError), which my
+    # runner would surface as a failure. Concurrent execution lets both pass.
+    fakes, _ = _fakes(tier=1)
+    barrier = threading.Barrier(2, timeout=5)
+
+    def barrier_runner(family: str, prompt: str) -> ReviewerResult:
+        barrier.wait()
+        return ReviewerResult(family, f"Verdict: PASS from {family}", True)
+
+    fakes["reviewer_runner"] = barrier_runner
+    outcome = collect_evidence(
+        repo="o/r", pr=1, families=["claude", "grok"], author="me", apply=False, **fakes
+    )
+    assert {item.family for item in outcome.items} == {"claude", "grok"}
+    assert outcome.failures == []
+
+
+def test_collect_preserves_family_order_despite_completion_order() -> None:
+    # The first-requested reviewer (claude) finishes last; items must still be
+    # ordered by the caller's requested family order, not by completion.
+    fakes, _ = _fakes(tier=1)
+
+    def ordered_runner(family: str, prompt: str) -> ReviewerResult:
+        if family == "claude":
+            time.sleep(0.2)  # ensure claude returns after grok
+        return ReviewerResult(family, f"Verdict: PASS from {family}", True)
+
+    fakes["reviewer_runner"] = ordered_runner
+    outcome = collect_evidence(
+        repo="o/r", pr=1, families=["claude", "grok"], author="me", apply=False, **fakes
+    )
+    assert [item.family for item in outcome.items] == ["claude", "grok"]
+
+
+def test_collect_records_raising_reviewer_as_failure() -> None:
+    # A reviewer that raises is recorded as a failure (it must not abort the run
+    # or crash the pool); the other reviewer's evidence is still collected.
+    fakes, _ = _fakes(tier=1)
+
+    def maybe_raise(family: str, prompt: str) -> ReviewerResult:
+        if family == "grok":
+            raise RuntimeError("reviewer boom")
+        return ReviewerResult(family, "Verdict: PASS from claude", True)
+
+    fakes["reviewer_runner"] = maybe_raise
+    outcome = collect_evidence(
+        repo="o/r", pr=1, families=["claude", "grok"], author="me", apply=False, **fakes
+    )
+    assert [item.family for item in outcome.items] == ["claude"]
+    assert [f.family for f in outcome.failures] == ["grok"]
+    assert "reviewer boom" in outcome.failures[0].error
 
 
 def test_collect_low_tier_apply_triggers_same_pr_quorum_reconciler_after_posts() -> None:


### PR DESCRIPTION
## Problem

Two issues jointly produced the recurring **"`collect_quorum_evidence` hangs / GraphQL starvation"** failure mode seen across the fleet:

1. **Reviewers ran serially.** `quorum_evidence.collect_evidence` looped over families one at a time, each `reviewer_runner` call blocking up to its own 300s timeout. Two reviewers made wall-time the **sum** of timeouts (~10 min) — long enough that the agentic loop interrupted before any timeout fired, *presenting as a hang* even though the timeout machinery was working.
2. **Reads drained the operator's per-user PAT quota.** `merge_quorum_io`'s `gh` calls shelled out with inherited (operator PAT) auth, so the high-traffic read path (PR view / tier / check-runs / open-PR list / merge-packet) competed for the same exhausted per-user GraphQL bucket as everything else.

## Change

**1. Concurrent reviewers** (`quorum_evidence.py`)
- Resolve the ordered, de-duplicated family list up front, run the supported reviewers concurrently in a bounded `ThreadPoolExecutor` (`_MAX_REVIEWER_WORKERS=4`), then process results in the caller's requested order.
- Each runner is *already* timeout-guarded and process-isolated (claude via subprocess; API agents via spawned process), so threads here only wait — turning serial wall-time (sum of timeouts) into roughly the slowest single reviewer.
- **Behavior-preserving:** item/failure ordering, dedup, unsupported-family handling, never-fabricate, and the dissent/quorum gating are all unchanged. A reviewer that *raises* is recorded as a failure instead of aborting the run.

**2. App-token read routing** (`merge_quorum_io.py`)
- Read-only `gh` calls (`fetch_pr_context`, `fetch_latest_quorum_run`, `fetch_human_settlement_present`, `list_open_prs`, and the merge-packet subprocess) now route through the GitHub App installation token via `github_app_auth.github_cli_env`, drawing on the App's **separate** API budget.
- **Read-only by design:** `run()`'s default (PAT) env is left untouched so write call sites are unaffected — the App installation 403s on classic branch-protection writes. Degrades transparently to ambient/operator auth when no App config is present (same silent-safe contract as `scripts/gh_app_env.py`, extending the #8407 pattern from shell wrappers into the Python read path).

## Validation
- `pytest tests/swarm/test_quorum_evidence.py tests/swarm/test_merge_quorum_io.py` → **87 passed** (69+3 and 12+3 new).
- New reviewer tests: deterministic barrier-based concurrency proof, completion-order vs requested-order preservation, raising-reviewer-recorded-as-failure.
- New routing tests: read-env prefers the App token, degrades to ambient auth without App config, and `fetch_pr_context` actually routes its `gh` calls through the App token.
- `ruff check` + `ruff format --check` clean on all four files.

## Tier
Touches `aragora/swarm/quorum_evidence.py` and `aragora/swarm/merge_quorum_io.py` — swarm/merge-gate-adjacent but **behavior-preserving for the evidence output** (same comments, same order, same lint results; only faster and on a different token bucket). No parser or gate semantics change.

---
_Generated by [Claude Code](https://claude.ai/code/session_018jfJj5gb9VoLs6VBMnzhrP)_