### PR TITLE
fix(swarm): require leases for autonomous Codex tmux lanes

### DIFF
--- a/scripts/tmux_session_launcher.sh
+++ b/scripts/tmux_session_launcher.sh
@@ -6,7 +6,7 @@
 #   ./scripts/tmux_session_launcher.sh --name claude-worker --agent claude --autonomous --prompt "Fix tests"
 #   ./scripts/tmux_session_launcher.sh --name factory-review --agent droid --prompt "Review PR #6811"
 #   ./scripts/tmux_session_launcher.sh --name factory-review --agent factory --cwd /tmp/pr-review --prompt "Review PR #6811"
-#   ./scripts/tmux_session_launcher.sh --name codex-qa --agent codex --autonomous --prompt "Fix the tests"
+#   ./scripts/tmux_session_launcher.sh --name codex-qa --agent codex --autonomous --task-id Q123 --claimed-path tests/foo.py --prompt "Fix the tests"
 #   ./scripts/tmux_session_launcher.sh --list
 #   ./scripts/tmux_session_launcher.sh --kill codex-conductor
 #
@@ -14,6 +14,9 @@
 #   --autonomous   Grant full permissions (Claude: --dangerously-skip-permissions,
 #                  Codex: codex exec --dangerously-bypass-approvals-and-sandbox)
 #                  Required for agents to run Bash, edit files, etc. in tmux lanes.
+#                  Autonomous Codex launches must carry a dev-coordination
+#                  lease assignment (--task-id plus scope/test flags), unless
+#                  --allow-unleased-codex is passed explicitly for manual debug.
 #
 # Each session gets:
 #   - a dedicated tmux window in the "aragora" session
@@ -148,6 +151,14 @@ PROMPT_FILE=""
 ACTION="launch"
 AUTONOMOUS="0"
 WORKDIR=""
+TASK_ID=""
+LEASE_TITLE=""
+LEASE_TTL_HOURS="${CODEX_WORK_LEASE_TTL_HOURS:-8}"
+ALLOW_LEASE_OVERLAP="0"
+ALLOW_UNLEASED_CODEX="0"
+WRITE_SCOPES=()
+CLAIMED_PATHS=()
+TEST_COMMANDS=()
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -157,6 +168,14 @@ while [[ $# -gt 0 ]]; do
         --prompt)   PROMPT="$2"; shift 2 ;;
         --prompt-file) PROMPT_FILE="$2"; shift 2 ;;
         --autonomous) AUTONOMOUS="1"; shift ;;
+        --task-id)  TASK_ID="$2"; shift 2 ;;
+        --title|--goal) LEASE_TITLE="$2"; shift 2 ;;
+        --lease-ttl-hours) LEASE_TTL_HOURS="$2"; shift 2 ;;
+        --write-scope) WRITE_SCOPES+=("$2"); shift 2 ;;
+        --claimed-path) CLAIMED_PATHS+=("$2"); shift 2 ;;
+        --test) TEST_COMMANDS+=("$2"); shift 2 ;;
+        --allow-overlap) ALLOW_LEASE_OVERLAP="1"; shift ;;
+        --allow-unleased-codex) ALLOW_UNLEASED_CODEX="1"; shift ;;
         --list)     ACTION="list"; shift ;;
         --kill)     ACTION="kill"; NAME="$2"; shift 2 ;;
         --status)   ACTION="status"; shift ;;
@@ -249,6 +268,24 @@ if [[ -n "${PROMPT}" ]]; then
     HAS_PROMPT="yes"
 fi
 
+LEASE_CONFIGURED="0"
+if [[ -n "${TASK_ID}" || -n "${LEASE_TITLE}" || ${#WRITE_SCOPES[@]} -gt 0 || ${#CLAIMED_PATHS[@]} -gt 0 || ${#TEST_COMMANDS[@]} -gt 0 ]]; then
+    LEASE_CONFIGURED="1"
+fi
+
+if [[ "${AGENT}" == "codex" && "${AUTONOMOUS}" == "1" && "${ALLOW_UNLEASED_CODEX}" != "1" && "${LEASE_CONFIGURED}" != "1" ]]; then
+    cat >&2 <<'EOF'
+Refusing unleased autonomous Codex launch.
+
+Autonomous Codex workers must be assigned by the conductor/dispatcher instead
+of free-picking the queue. Pass an explicit dev-coordination lease, for example:
+  --task-id Q123 --title "repair PR #123" --claimed-path scripts/foo.py
+
+For one-off manual debugging only, pass --allow-unleased-codex.
+EOF
+    exit 2
+fi
+
 # Build the launch command
 # When --autonomous is set:
 #   - Claude gets ARAGORA_ADMIN_APPROVED=1 → --dangerously-skip-permissions (can run Bash)
@@ -257,6 +294,32 @@ fi
 #   - Droid/Factory prompted work always uses `droid exec --auto high`; use
 #     ARAGORA_DROID_AUTO_LEVEL=low|medium|high to lower the level explicitly.
 if [[ "${AGENT}" == "codex" ]]; then
+    CODEX_SESSION_ARGS=(--agent "${NAME}" --base main)
+    if [[ "${AUTONOMOUS}" == "1" ]]; then
+        CODEX_SESSION_ARGS+=(--yolo)
+    fi
+    if [[ -n "${TASK_ID}" ]]; then
+        CODEX_SESSION_ARGS+=(--task-id "${TASK_ID}")
+    fi
+    if [[ -n "${LEASE_TITLE}" ]]; then
+        CODEX_SESSION_ARGS+=(--title "${LEASE_TITLE}")
+    fi
+    if [[ -n "${LEASE_TTL_HOURS}" ]]; then
+        CODEX_SESSION_ARGS+=(--lease-ttl-hours "${LEASE_TTL_HOURS}")
+    fi
+    for scope in "${WRITE_SCOPES[@]}"; do
+        CODEX_SESSION_ARGS+=(--write-scope "${scope}")
+    done
+    for path in "${CLAIMED_PATHS[@]}"; do
+        CODEX_SESSION_ARGS+=(--claimed-path "${path}")
+    done
+    for test_cmd in "${TEST_COMMANDS[@]}"; do
+        CODEX_SESSION_ARGS+=(--test "${test_cmd}")
+    done
+    if [[ "${ALLOW_LEASE_OVERLAP}" == "1" ]]; then
+        CODEX_SESSION_ARGS+=(--allow-overlap)
+    fi
+    CODEX_SESSION_ARGS_TEXT="$(python3 -c 'import shlex, sys; print(" ".join(shlex.quote(a) for a in sys.argv[1:]))' "${CODEX_SESSION_ARGS[@]}")"
     if [[ "${AUTONOMOUS}" == "1" ]]; then
         if [[ -n "${PROMPT}" ]]; then
             CODEX_EXEC_PROMPT_FILE="${PROMPT_FILE}"
@@ -273,7 +336,8 @@ import shlex
 import sys
 from pathlib import Path
 
-launch_file, workdir, name, prompt_file = sys.argv[1:5]
+launch_file, workdir, prompt_file = sys.argv[1:4]
+session_args = sys.argv[4:]
 body = "\n".join(
     [
         "#!/usr/bin/env bash",
@@ -281,7 +345,8 @@ body = "\n".join(
         f"cd {shlex.quote(workdir)}",
         (
             "./scripts/codex_session.sh "
-            f"--agent {shlex.quote(name)} --base main --yolo -- "
+            + " ".join(shlex.quote(arg) for arg in session_args)
+            + " -- "
             "codex exec --dangerously-bypass-approvals-and-sandbox "
             f"- < {shlex.quote(prompt_file)}"
         ),
@@ -291,16 +356,16 @@ body = "\n".join(
 path = Path(launch_file)
 path.write_text(body, encoding="utf-8")
 os.chmod(path, 0o700)
-' "${CODEX_EXEC_LAUNCH_FILE}" "${WORKDIR}" "${NAME}" "${CODEX_EXEC_PROMPT_FILE}"
+' "${CODEX_EXEC_LAUNCH_FILE}" "${WORKDIR}" "${CODEX_EXEC_PROMPT_FILE}" "${CODEX_SESSION_ARGS[@]}"
             LAUNCH_CMD="bash '${CODEX_EXEC_LAUNCH_FILE}'"
             # `codex exec` consumes the prompt directly; do not also paste it
             # into an interactive pane.
             PROMPT=""
         else
-            LAUNCH_CMD="cd '${WORKDIR}' && ./scripts/codex_session.sh --agent '${NAME}' --base main --yolo"
+            LAUNCH_CMD="cd '${WORKDIR}' && ./scripts/codex_session.sh ${CODEX_SESSION_ARGS_TEXT}"
         fi
     else
-        LAUNCH_CMD="cd '${WORKDIR}' && ./scripts/codex_session.sh --agent '${NAME}' --base main"
+        LAUNCH_CMD="cd '${WORKDIR}' && ./scripts/codex_session.sh ${CODEX_SESSION_ARGS_TEXT}"
     fi
 elif [[ "${AGENT}" == "claude" ]]; then
     if [[ "${AUTONOMOUS}" == "1" ]]; then

--- a/scripts/tmux_session_launcher.sh
+++ b/scripts/tmux_session_launcher.sh
@@ -268,8 +268,13 @@ if [[ -n "${PROMPT}" ]]; then
     HAS_PROMPT="yes"
 fi
 
+LEASE_SCOPE_CONFIGURED="0"
+if [[ ${#WRITE_SCOPES[@]} -gt 0 || ${#CLAIMED_PATHS[@]} -gt 0 || ${#TEST_COMMANDS[@]} -gt 0 ]]; then
+    LEASE_SCOPE_CONFIGURED="1"
+fi
+
 LEASE_CONFIGURED="0"
-if [[ -n "${TASK_ID}" || -n "${LEASE_TITLE}" || ${#WRITE_SCOPES[@]} -gt 0 || ${#CLAIMED_PATHS[@]} -gt 0 || ${#TEST_COMMANDS[@]} -gt 0 ]]; then
+if [[ -n "${TASK_ID}" && "${LEASE_SCOPE_CONFIGURED}" == "1" ]]; then
     LEASE_CONFIGURED="1"
 fi
 
@@ -280,6 +285,9 @@ Refusing unleased autonomous Codex launch.
 Autonomous Codex workers must be assigned by the conductor/dispatcher instead
 of free-picking the queue. Pass an explicit dev-coordination lease, for example:
   --task-id Q123 --title "repair PR #123" --claimed-path scripts/foo.py
+
+A valid autonomous Codex lease requires --task-id plus at least one concrete
+scope signal: --claimed-path, --write-scope, or --test.
 
 For one-off manual debugging only, pass --allow-unleased-codex.
 EOF

--- a/tests/scripts/test_tmux_transport_scripts.py
+++ b/tests/scripts/test_tmux_transport_scripts.py
@@ -145,7 +145,8 @@ def test_tmux_session_launcher_waits_for_readiness_marker_before_prompt_send(
     assert any(
         call[:2] == ["send-keys", "-t"]
         and call[2] == "@17"
-        and "./scripts/codex_session.sh --agent 'testpane'" in call[3]
+        and "./scripts/codex_session.sh" in call[3]
+        and "--agent testpane" in call[3]
         for call in calls
     )
     registry_payload = json.loads(
@@ -172,6 +173,10 @@ def test_tmux_session_launcher_autonomous_codex_prompt_uses_exec(
             "--agent",
             "codex",
             "--autonomous",
+            "--task-id",
+            "Q123",
+            "--claimed-path",
+            "scripts/tmux_session_launcher.sh",
             "--prompt",
             "report git status only",
         ],
@@ -194,6 +199,8 @@ def test_tmux_session_launcher_autonomous_codex_prompt_uses_exec(
     )
     launch_script = Path(env["HOME"]) / ".aragora" / "tmux-sessions" / "codex-auto.launch.sh"
     launch_body = launch_script.read_text(encoding="utf-8")
+    assert "--task-id Q123" in launch_body
+    assert "--claimed-path scripts/tmux_session_launcher.sh" in launch_body
     assert "codex exec --dangerously-bypass-approvals-and-sandbox - <" in launch_body
     assert "--ask-for-approval" not in launch_body
     assert "--full-auto" not in launch_body
@@ -208,6 +215,138 @@ def test_tmux_session_launcher_autonomous_codex_prompt_uses_exec(
     )
     assert meta["has_prompt"] is True
     assert meta["prompt_file"].endswith("codex-auto.prompt.md")
+
+
+def test_tmux_session_launcher_rejects_autonomous_codex_without_lease(
+    tmp_path: Path,
+) -> None:
+    _write_fake_tmux(tmp_path)
+    env = _fake_tmux_env(tmp_path)
+    env["ARAGORA_TMUX_REGISTRY_REPO_ROOT"] = str(tmp_path)
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(REPO_ROOT / "scripts" / "tmux_session_launcher.sh"),
+            "--name",
+            "codex-auto",
+            "--agent",
+            "codex",
+            "--autonomous",
+            "--prompt",
+            "report git status only",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "Refusing unleased autonomous Codex launch." in result.stderr
+
+
+def test_tmux_session_launcher_rejects_autonomous_codex_with_title_only(
+    tmp_path: Path,
+) -> None:
+    _write_fake_tmux(tmp_path)
+    env = _fake_tmux_env(tmp_path)
+    env["ARAGORA_TMUX_REGISTRY_REPO_ROOT"] = str(tmp_path)
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(REPO_ROOT / "scripts" / "tmux_session_launcher.sh"),
+            "--name",
+            "codex-auto",
+            "--agent",
+            "codex",
+            "--autonomous",
+            "--title",
+            "descriptive goal only",
+            "--prompt",
+            "report git status only",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "requires --task-id plus at least one concrete" in result.stderr
+
+
+def test_tmux_session_launcher_rejects_autonomous_codex_with_task_id_only(
+    tmp_path: Path,
+) -> None:
+    _write_fake_tmux(tmp_path)
+    env = _fake_tmux_env(tmp_path)
+    env["ARAGORA_TMUX_REGISTRY_REPO_ROOT"] = str(tmp_path)
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(REPO_ROOT / "scripts" / "tmux_session_launcher.sh"),
+            "--name",
+            "codex-auto",
+            "--agent",
+            "codex",
+            "--autonomous",
+            "--task-id",
+            "Q123",
+            "--prompt",
+            "report git status only",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "requires --task-id plus at least one concrete" in result.stderr
+
+
+def test_tmux_session_launcher_accepts_autonomous_codex_with_task_id_and_scope(
+    tmp_path: Path,
+) -> None:
+    _write_fake_tmux(tmp_path)
+    env = _fake_tmux_env(tmp_path)
+    env["ARAGORA_TMUX_INIT_WAIT_SECONDS"] = "1"
+    env["ARAGORA_TMUX_REGISTRY_REPO_ROOT"] = str(tmp_path)
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(REPO_ROOT / "scripts" / "tmux_session_launcher.sh"),
+            "--name",
+            "codex-auto",
+            "--agent",
+            "codex",
+            "--autonomous",
+            "--task-id",
+            "Q123",
+            "--claimed-path",
+            "scripts/tmux_session_launcher.sh",
+            "--prompt",
+            "report git status only",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert "Refusing unleased autonomous Codex launch." not in result.stderr
+    launch_script = Path(env["HOME"]) / ".aragora" / "tmux-sessions" / "codex-auto.launch.sh"
+    launch_body = launch_script.read_text(encoding="utf-8")
+    assert "--task-id Q123" in launch_body
+    assert "--claimed-path scripts/tmux_session_launcher.sh" in launch_body
 
 
 def test_tmux_session_launcher_accepts_new_codex_readiness_markers(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Require autonomous Codex tmux launches to carry an explicit dev-coordination lease assignment.
- Pass lease metadata through to `scripts/codex_session.sh` so existing lease/claim machinery owns the worker's scope.
- Add an explicit `--allow-unleased-codex` escape hatch for manual debugging.

## Why
Unassigned autonomous Codex panes can free-pick the queue and collide with other sessions. This routes conductor-launched Codex workers through the existing lease primitive instead of building a new dispatcher.

## Validation
- `bash -n scripts/tmux_session_launcher.sh`
- `./scripts/tmux_session_launcher.sh --name lease-guard-test --agent codex --autonomous --prompt 'do work'` exits `2` before tmux setup with the expected refusal message.
- `pre-commit run --files scripts/tmux_session_launcher.sh`
