### PR TITLE
test(structex): align stale tests/mcp assertions to current source behavior

### DIFF
--- a/tests/mcp/test_mcp_integration.py
+++ b/tests/mcp/test_mcp_integration.py
@@ -285,7 +285,7 @@ class TestMCPToolValidation:
 
             # Should fail on agent creation
             assert "error" in result
-            assert "No valid agents" in result["error"]
+            assert "Invalid agent selection" in result["error"]
 
 
 class TestMCPAsyncFunctions:

--- a/tests/mcp/test_mcp_server.py
+++ b/tests/mcp/test_mcp_server.py
@@ -311,16 +311,16 @@ class TestMCPToolExecution:
             assert result["count"] == 3
 
     @pytest.mark.asyncio
-    async def test_list_agents_fallback_on_error(self, server):
-        """Test list_agents returns fallback on error."""
+    async def test_list_agents_empty_on_error(self, server):
+        """Test list_agents fails closed with an empty list and error when the registry errors."""
         with patch("aragora.agents.base.list_available_agents") as mock_list:
             mock_list.side_effect = Exception("Registry unavailable")
 
             result = await server._list_agents()
 
             assert "agents" in result
-            assert len(result["agents"]) >= 5  # Fallback list
-            assert "note" in result
+            assert result["agents"] == []
+            assert "error" in result
 
     @pytest.mark.asyncio
     async def test_get_debate_from_cache(self, server):
@@ -346,8 +346,10 @@ class TestMCPToolExecution:
     @pytest.mark.asyncio
     async def test_get_debate_not_found(self, server):
         """Test get_debate returns error for non-existent debate."""
+        storage_db = MagicMock()
+        storage_db.get.return_value = None
         with patch("aragora.server.storage.get_debates_db") as mock_db:
-            mock_db.return_value = None
+            mock_db.return_value = storage_db
 
             result = await server._get_debate({"debate_id": "nonexistent"})
 
@@ -364,7 +366,7 @@ class TestMCPToolExecution:
 
     @pytest.mark.asyncio
     async def test_run_debate_no_valid_agents(self, server):
-        """Test run_debate with no valid agents returns error."""
+        """Test run_debate returns an error when a requested agent can't be created."""
         with patch("aragora.agents.base.create_agent") as mock_create:
             mock_create.side_effect = Exception("No API key")
 
@@ -376,7 +378,7 @@ class TestMCPToolExecution:
             )
 
             assert "error" in result
-            assert "No valid agents" in result["error"]
+            assert "Invalid agent selection" in result["error"]
 
     @pytest.mark.asyncio
     async def test_run_gauntlet_missing_content(self, server):
@@ -409,21 +411,21 @@ class TestMCPToolCallHandler:
 
     @pytest.mark.asyncio
     async def test_call_tool_handles_exceptions(self, server):
-        """Test tool call handler catches exceptions and uses fallback."""
+        """Test tool call handler catches exceptions and fails closed."""
         # Mock list_available_agents to raise an exception
-        # This tests that the tool properly catches errors and returns fallback
+        # This tests that the tool properly catches errors and returns an error result
         with patch(
             "aragora.agents.base.list_available_agents",
             side_effect=RuntimeError("Test error"),
         ):
             result = await _call_tool(server, "list_agents", {})
 
-            # When list_available_agents fails, list_agents_tool returns fallback
+            # When list_available_agents fails, list_agents_tool returns an empty list + error
             assert len(result) == 1
             parsed = json.loads(result[0].text)
-            # Fallback returns a list of agents with a note
             assert "agents" in parsed
-            assert "note" in parsed  # Fallback includes a note about unavailability
+            assert parsed["agents"] == []
+            assert "error" in parsed
 
     @pytest.mark.asyncio
     async def test_call_tool_returns_text_content(self, server):

--- a/tests/mcp/test_mcp_tools_root.py
+++ b/tests/mcp/test_mcp_tools_root.py
@@ -178,11 +178,11 @@ class TestRunDebateTool:
             )
 
             assert "error" in result
-            assert "No valid agents" in result["error"]
+            assert "Invalid agent selection" in result["error"]
 
     @pytest.mark.asyncio
     async def test_partial_agent_creation(self):
-        """Test debate runs with partial agent creation."""
+        """Test explicit selection is rejected when any requested agent can't be created."""
         mock_result = MagicMock()
         mock_result.final_answer = "Partial answer"
         mock_result.consensus_reached = False
@@ -213,8 +213,8 @@ class TestRunDebateTool:
                 agents="working,fake",
             )
 
-            assert "debate_id" in result
-            assert result["final_answer"] == "Partial answer"
+            assert "error" in result
+            assert "Invalid agent selection" in result["error"]
 
     @pytest.mark.asyncio
     async def test_successful_debate_returns_full_result(self):
@@ -518,8 +518,8 @@ class TestListAgentsTool:
             assert "openai-api" in result["agents"]
 
     @pytest.mark.asyncio
-    async def test_fallback_on_registry_error(self):
-        """Test fallback list when registry fails."""
+    async def test_empty_on_registry_error(self):
+        """Test list_agents fails closed with an empty list and error when the registry fails."""
         with patch(
             "aragora.agents.base.list_available_agents", side_effect=ImportError("Not found")
         ):
@@ -528,20 +528,21 @@ class TestListAgentsTool:
             result = await list_agents_tool()
 
             assert "agents" in result
-            assert result["count"] >= 5  # Fallback has at least 5
-            assert "note" in result
-            assert "Fallback" in result["note"]
+            assert result["count"] == 0
+            assert result["agents"] == []
+            assert "error" in result
 
     @pytest.mark.asyncio
-    async def test_fallback_includes_common_agents(self):
-        """Test fallback list includes common agent types."""
+    async def test_no_fallback_agents_on_error(self):
+        """Test no hardcoded fallback agents are returned when the registry fails."""
         with patch("aragora.agents.base.list_available_agents", side_effect=Exception("Any error")):
             from aragora.mcp.tools import list_agents_tool
 
             result = await list_agents_tool()
 
-            assert "anthropic-api" in result["agents"]
-            assert "openai-api" in result["agents"]
+            assert result["agents"] == []
+            assert "error" in result
+            assert "Could not list agents" in result["error"]
 
 
 class TestGetDebateTool:
@@ -615,7 +616,7 @@ class TestGetDebateTool:
             result = await mcp_tools.get_debate_tool(debate_id="any_id")
 
             assert "error" in result
-            assert "not found" in result["error"]
+            assert "Storage not available" in result["error"]
 
     @pytest.mark.asyncio
     async def test_no_db_returns_error(self):

--- a/tests/mcp/tools_module/test_agent_tools.py
+++ b/tests/mcp/tools_module/test_agent_tools.py
@@ -35,18 +35,18 @@ class TestListAgentsTool:
         assert "note" not in result
 
     @pytest.mark.asyncio
-    async def test_list_fallback_on_error(self):
-        """Test fallback list when error occurs."""
+    async def test_list_empty_on_error(self):
+        """Test list_agents fails closed with an empty list and error when an error occurs."""
         with patch(
             "aragora.agents.base.list_available_agents",
             side_effect=Exception("Import error"),
         ):
             result = await list_agents_tool()
 
-        assert result["count"] == 5
-        assert "anthropic-api" in result["agents"]
-        assert "note" in result
-        assert "fallback" in result["note"].lower()
+        assert result["count"] == 0
+        assert result["agents"] == []
+        assert "error" in result
+        assert "Could not list agents" in result["error"]
 
 
 class TestGetAgentHistoryTool:


### PR DESCRIPTION
## Source issue

P1 test-health (HEALTH-1, milestone p1-hygiene): 11 pre-existing stale-test
failures in the **nightly-only** `tests/mcp` dir, surfaced by the batch-3
tests-migration (#8415). All 11 reproduce on a clean `origin/main` worktree
(genuine pre-existing assertion drift, not a migration regression). They are
NOT in the PR `test-fast` shards — they surface only via targeted
`python3 -m pytest tests/mcp` or nightly `coverage.yml`.

## Behavior summary (Tier 0, tests-only)

No source behavior changed; no assertions weakened/deleted. Each stale
expectation was aligned to the **current** source message/shape (confirmed in
`aragora/mcp/tools_module/{debate,agent}.py` and `aragora/mcp/server.py`):

- **run_debate error drift** (`"No valid agents"` -> `"Invalid agent
  selection"`): `run_debate_tool` checks `explicit_agents and failed_agents`
  *before* the empty-list check, so any explicitly requested agent that can't
  be created now returns `"Invalid agent selection: could not create <name>"`.
  `"No valid agents could be created."` is now reached only for the
  default-agents (non-explicit) all-fail path. Updated 4 tests, incl.
  `test_partial_agent_creation` (an explicit selection with one uncreatable
  agent is now rejected rather than running a partial debate).
- **get_debate storage-exception drift** (`"not found"` -> `"Storage not
  available"`): a storage exception / missing db now yields `"Storage not
  available"`; `"Debate <id> not found"` is reserved for a present db whose
  `.get()` returns None.
- **list_agents fail-closed** (empty fallback list): on a registry error
  `list_agents_tool` now returns `{"agents": [], "count": 0, "error": "Could
  not list agents"}` (no hardcoded fallback agent list, no `"note"`). Updated
  the list-agents error tests across the server, root, and tools_module suites
  to assert the current fail-closed shape; renamed the now-misleading
  `*_fallback_*` tests (no in-repo refs).
- **`test_get_debate_not_found`**: its mock returned `None` for the db, which
  now lands in the `"Storage not available"` branch; fixed the mock (truthy db,
  `.get()` -> None) so it exercises the real not-found path it is named for
  (mirrors the sibling passing `test_not_found_returns_error`).

## Validation

```
python3 -m pytest tests/mcp -p no:randomly -q   # 647 passed (was 11 failed)
python3 -m pytest tests/mcp -q                  # 647 passed (random order, x2)
make lint                                       # All checks passed!
make test-smoke                                 # Smoke tests passed!
PYTEST_BIN="python3 -m pytest" bash scripts/test_tiers.sh smoke   # 138 passed
```

## Risks

Minimal. Tests-only diff (36 insertions / 33 deletions across 4 `tests/mcp`
files), no `aragora/` source touched, so the required changed-file `typecheck`
and `sdk-parity` contexts are out of scope. Relocating these files in the
migration already flipped the nightly-only mcp coverage red; this greens it.
