### PR TITLE
test(structex): align stale tests/core FormatDebateData + decision-routing to current source

### DIFF
--- a/tests/core/test_decision.py
+++ b/tests/core/test_decision.py
@@ -1127,7 +1127,7 @@ class TestDecisionRouterRouteMethods:
 
     @pytest.mark.asyncio
     async def test_route_to_debate_executes_decision_integrity(self, monkeypatch):
-        """Decision integrity execution triggers plan executor when enabled."""
+        """Decision integrity execution is fail-closed when intake is untrusted."""
         from types import SimpleNamespace
         from unittest.mock import AsyncMock
 
@@ -1229,10 +1229,17 @@ class TestDecisionRouterRouteMethods:
         ) as mock_execute:
             result = await router.route(request)
 
-        assert mock_execute.called is True
         assert result.success is True
         assert result.decision_integrity is not None
-        assert result.decision_integrity["execution"]["status"] == "completed"
+        # The route builds the plan and requests execution, but the backbone
+        # gate is fail-closed: the intake trust tier produced by this path
+        # ("authenticated-user"/"service-authored") is not in the auto-execution
+        # allowlist, so the plan is blocked before the executor is invoked.
+        assert result.decision_integrity["plan_id"]
+        execution = result.decision_integrity["execution"]
+        assert execution["status"] == "failed"
+        assert "untrusted_intake_tier" in execution["error"]
+        assert mock_execute.called is False
 
 
 # ===========================================================================

--- a/tests/core/test_decision.py
+++ b/tests/core/test_decision.py
@@ -1126,7 +1126,7 @@ class TestDecisionRouterRouteMethods:
         assert result.decision_integrity == package_payload
 
     @pytest.mark.asyncio
-    async def test_route_to_debate_executes_decision_integrity(self, monkeypatch):
+    async def test_route_to_debate_blocks_untrusted_intake_execution(self, monkeypatch):
         """Decision integrity execution is fail-closed when intake is untrusted."""
         from types import SimpleNamespace
         from unittest.mock import AsyncMock

--- a/tests/core/test_integration_base.py
+++ b/tests/core/test_integration_base.py
@@ -62,13 +62,9 @@ def sample_debate_result():
         rounds_used=3,
         winner="claude",
         confidence=0.85,
+        participants=["claude", "gpt-4", "gemini"],
     )
     result.debate_id = "test-debate-123"
-    result.question = "What is the best programming language?"
-    result.answer = "Python is widely considered excellent."
-    result.total_rounds = 3
-    result.consensus_confidence = 0.85
-    result.participating_agents = ["claude", "gpt-4", "gemini"]
     return result
 
 
@@ -251,7 +247,7 @@ class TestFormatDebateData:
 
         assert isinstance(data, FormattedDebateData)
         assert data.debate_id == "test-debate-123"
-        assert data.question == sample_debate_result.question
+        assert data.question == sample_debate_result.task
         assert data.total_rounds == 3
         assert data.confidence == 0.85
         assert data.confidence_percent == "85%"
@@ -259,7 +255,7 @@ class TestFormatDebateData:
 
     def test_question_truncation(self, integration, sample_debate_result):
         """Test question is truncated to limit."""
-        sample_debate_result.question = "A" * 300
+        sample_debate_result.task = "A" * 300
         data = integration.format_debate_data(sample_debate_result, question_limit=100)
 
         assert len(data.question_truncated) == 100
@@ -267,7 +263,7 @@ class TestFormatDebateData:
 
     def test_answer_truncation(self, integration, sample_debate_result):
         """Test answer is truncated to limit."""
-        sample_debate_result.answer = "B" * 600
+        sample_debate_result.final_answer = "B" * 600
         data = integration.format_debate_data(sample_debate_result, answer_limit=200)
 
         assert len(data.answer_truncated) == 200
@@ -282,7 +278,7 @@ class TestFormatDebateData:
 
     def test_agents_truncation(self, integration, sample_debate_result):
         """Test agents list is truncated."""
-        sample_debate_result.participating_agents = ["a1", "a2", "a3", "a4", "a5", "a6"]
+        sample_debate_result.participants = ["a1", "a2", "a3", "a4", "a5", "a6"]
         data = integration.format_debate_data(sample_debate_result, agents_limit=3)
 
         assert "+3 more" in data.agents_display
@@ -302,7 +298,7 @@ class TestFormatDebateData:
 
     def test_no_answer(self, integration, sample_debate_result):
         """Test handling when answer is None."""
-        sample_debate_result.answer = None
+        sample_debate_result.final_answer = None
         data = integration.format_debate_data(sample_debate_result)
 
         assert data.answer is None
@@ -310,7 +306,7 @@ class TestFormatDebateData:
 
     def test_no_confidence(self, integration, sample_debate_result):
         """Test handling when confidence is None."""
-        sample_debate_result.consensus_confidence = None
+        sample_debate_result.confidence = None
         data = integration.format_debate_data(sample_debate_result)
 
         assert data.confidence is None


### PR DESCRIPTION
## Summary

Tier-0 tests-only repair of 9 pre-existing stale-test failures in `tests/core`
surfaced by the tests-migration (nightly-only / targeted-run dir, not in the PR
`test-fast` shards). All 9 were confirmed reproducing on clean `origin/main`
before fixing; the source behavior is current and correct — only the tests were
stale (contract drift). No source-behavior changes; no assertions weakened.

## Failures fixed (9)

**`tests/core/test_integration_base.py::TestFormatDebateData` (8)** — the fixture
set attribute aliases (`question`, `answer`, `total_rounds`,
`consensus_confidence`, `participating_agents`) that `BaseIntegration.format_debate_data`
(`aragora/integrations/base.py`) no longer reads. The current source reads the
canonical `DebateResult` fields `task`, `final_answer`, `rounds_used`,
`confidence`, `participants` (`aragora/core_types.py`). Updated the fixture to set
`participants` in the constructor and the tests to mutate the canonical fields.

**`tests/core/test_decision.py::TestDecisionRouterRouteMethods::test_route_to_debate_executes_decision_integrity` (1)**
— the test expected `PlanExecutor.execute` to run and `execution.status == "completed"`.
The current route path (`aragora/core/decision_router.py` →
`aragora/server/decision_integrity_utils.py:build_decision_integrity_payload`) is
fail-closed: the backbone execution gate
(`aragora/pipeline/receipt_gate.py:evaluate_plan_execution_gate`) only allows
auto-execution for trust tiers `{operator-authored, internal-retrieved}`. This
route always produces `authenticated-user`/`service-authored` intake, so the plan
is blocked (`untrusted_intake_tier`) before the executor runs. Updated the test to
assert the current fail-closed contract (plan built, execution requested, status
`failed` with the gate reason, executor not invoked).

## Validation

```
python3 -m pytest tests/core -q                  # 1057 passed (random order, pytest-randomly)
python3 -m pytest tests/core -q -p no:randomly   # 1057 passed (deterministic)
make lint                                         # All checks passed!
make test-smoke                                   # Smoke tests passed!
PYTEST_BIN="python3 -m pytest" bash scripts/test_tiers.sh smoke   # 138 passed
```

All 9 target tests fail on clean `origin/main` and pass after this change.

## Risk

Minimal: tests-only diff (2 files, +17/-14). No `aragora/` source touched, so the
changed-file-scoped required `typecheck` and `sdk-parity` checks are out of scope.
