### PR TITLE
Emit boss metrics for empty boss-loop cycles

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -1162,6 +1162,39 @@ class BossLoop:
             tests_passed=tests_passed,
         )
 
+    def _append_no_suitable_issue_metrics(
+        self,
+        *,
+        iteration: int,
+        elapsed_seconds: float,
+        needs_human_reasons: list[str],
+        next_actions: list[str],
+    ) -> None:
+        blocker_evidence = {
+            "stop_reason": BossStopReason.NO_SUITABLE_ISSUE.value,
+            "needs_human_reasons": list(needs_human_reasons),
+            "next_actions": list(next_actions),
+        }
+        self._append_iteration_metrics(
+            iteration=iteration,
+            issue_number=None,
+            worker_result={
+                "status": "blocked",
+                "outcome": "blocked",
+                "blocker_kind": BossStopReason.NO_SUITABLE_ISSUE.value,
+                "blocker_evidence": blocker_evidence,
+                "failure_reason": (
+                    str(needs_human_reasons[0]).strip()
+                    if needs_human_reasons
+                    else "No suitable open issue found in the GitHub feed."
+                ),
+                "reasons": list(needs_human_reasons),
+                "next_actions": list(next_actions),
+                "receipt_metadata": {"blocker_evidence": blocker_evidence},
+            },
+            elapsed_seconds=elapsed_seconds,
+        )
+
     def _normalized_model_rotation(self) -> list[str]:
         seen: set[str] = set()
         normalized: list[str] = []
@@ -4407,6 +4440,13 @@ class BossLoop:
                     already_maxed=already_maxed,
                     report=eligibility_report,
                 )
+            elapsed_seconds = time.monotonic() - iter_start
+            self._append_no_suitable_issue_metrics(
+                iteration=iteration,
+                elapsed_seconds=elapsed_seconds,
+                needs_human_reasons=needs_human_reasons,
+                next_actions=next_actions,
+            )
             return BossIterationStatus(
                 iteration=iteration,
                 run_id=self.run_id,
@@ -4417,7 +4457,7 @@ class BossLoop:
                 stop_reason=BossStopReason.NO_SUITABLE_ISSUE.value,
                 needs_human_reasons=needs_human_reasons,
                 next_actions=next_actions,
-                elapsed_seconds=time.monotonic() - iter_start,
+                elapsed_seconds=elapsed_seconds,
             )
 
         # Step 3: Check runner freshness only when there is eligible work to dispatch
@@ -4664,6 +4704,13 @@ class BossLoop:
                     already_maxed=already_maxed,
                     report=eligibility_report,
                 )
+            elapsed_seconds = time.monotonic() - iter_start
+            self._append_no_suitable_issue_metrics(
+                iteration=iteration,
+                elapsed_seconds=elapsed_seconds,
+                needs_human_reasons=needs_human_reasons,
+                next_actions=next_actions,
+            )
             return [
                 BossIterationStatus(
                     iteration=iteration,
@@ -4675,7 +4722,7 @@ class BossLoop:
                     stop_reason=BossStopReason.NO_SUITABLE_ISSUE.value,
                     needs_human_reasons=needs_human_reasons,
                     next_actions=next_actions,
-                    elapsed_seconds=time.monotonic() - iter_start,
+                    elapsed_seconds=elapsed_seconds,
                 )
             ]
 

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -110,6 +110,7 @@ def _boss_config(**overrides: Any) -> BossLoopConfig:
         "freshness_ttl_seconds": 3600.0,
         "max_consecutive_failures": 2,
         "max_retries_per_issue": 2,
+        "metrics_jsonl_path": None,
     }
     defaults.update(overrides)
     return BossLoopConfig(**defaults)
@@ -1600,6 +1601,62 @@ class TestBossLoop:
         assert result.iterations_completed == 1
         assert len(result.issues_attempted) == 0
         assert "No suitable open issue" in result.needs_human_reasons[0]
+
+    def test_no_suitable_issue_appends_metrics_heartbeat(self, tmp_path: Path):
+        from aragora.swarm.terminal_truth import TerminalClass
+
+        feed = MagicMock(spec=GitHubIssueFeed)
+        feed.fetch.return_value = []
+        metrics_path = tmp_path / "boss_metrics.jsonl"
+
+        config = _boss_config(
+            auto_refill_threshold=0,
+            metrics_jsonl_path=str(metrics_path),
+        )
+        loop = BossLoop(
+            config=config,
+            issue_feed=feed,
+            freshness_checker=lambda **kw: _fresh_result(fresh=True),
+        )
+
+        result = asyncio.run(loop.run())
+
+        assert result.stop_reason == BossStopReason.NO_SUITABLE_ISSUE.value
+        payload = json.loads(metrics_path.read_text(encoding="utf-8"))
+        assert payload["issue_number"] is None
+        assert payload["worker_status"] == "blocked"
+        assert payload["worker_outcome"] == "blocked"
+        assert payload["blocker_kind"] == BossStopReason.NO_SUITABLE_ISSUE.value
+        assert payload["failure_reason"].startswith("No suitable open issue")
+        assert payload["dispatch_skip_reason"] == "no_work_orders"
+        assert payload["terminal_class"] == TerminalClass.BLOCKED_NOT_DISPATCH_BOUNDED.value
+
+    def test_parallel_no_suitable_issue_appends_one_metrics_heartbeat(self, tmp_path: Path):
+        feed = MagicMock(spec=GitHubIssueFeed)
+        feed.fetch.return_value = []
+        metrics_path = tmp_path / "boss_metrics.jsonl"
+
+        config = _boss_config(
+            auto_refill_threshold=0,
+            max_parallel_dispatches=2,
+            metrics_jsonl_path=str(metrics_path),
+        )
+        loop = BossLoop(
+            config=config,
+            issue_feed=feed,
+            freshness_checker=lambda **kw: _fresh_result(fresh=True),
+        )
+
+        result = asyncio.run(loop.run())
+
+        assert result.stop_reason == BossStopReason.NO_SUITABLE_ISSUE.value
+        rows = [
+            json.loads(line)
+            for line in metrics_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        assert len(rows) == 1
+        assert rows[0]["blocker_kind"] == BossStopReason.NO_SUITABLE_ISSUE.value
 
     @pytest.mark.asyncio
     async def test_backpressure_admission_skips_maintenance_issue_but_dispatches_product(


### PR DESCRIPTION
## Summary
- Append a synthetic, classifier-safe boss metrics row when the boss loop stops with no_suitable_issue before dispatch.
- Cover both serial and parallel empty-selection paths.
- Default the test helper metrics path to None so tests do not write production .aragora/overnight/boss_metrics.jsonl unless they opt in with a temp path.

## Safety
- No production metrics file is mutated by tests.
- Existing worker-result metrics emission remains unchanged.
- Terminal classification goes through the existing metrics classifier and records blocked_not_dispatch_bounded.

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/swarm/test_boss_loop.py -k "no_suitable_issue_appends_metrics_heartbeat or parallel_no_suitable_issue_appends_one_metrics_heartbeat or no_suitable_issue_stops"
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m py_compile aragora/swarm/boss_loop.py tests/swarm/test_boss_loop.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check aragora/swarm/boss_loop.py tests/swarm/test_boss_loop.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check aragora/swarm/boss_loop.py tests/swarm/test_boss_loop.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD