### PR TITLE
test: realign stale nightly-only tests to current source behavior

### DIFF
--- a/tests/audit/conftest.py
+++ b/tests/audit/conftest.py
@@ -1,0 +1,30 @@
+"""Shared fixtures for the audit test suite."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_audit_registry():
+    # ``AuditRegistry`` is a process-wide singleton exposed as the module-global
+    # ``audit_registry``. Some tests mutate it in place (register/clear/discover)
+    # without restoring it, so under pytest-randomly an auditor left registered by
+    # one test leaks into a later test that assumes a clean registry. Snapshot the
+    # registry before each test and restore it afterwards so registrations never
+    # cross test boundaries.
+    from aragora.audit.registry import audit_registry
+
+    snapshot = {
+        "_auditors": dict(audit_registry._auditors),
+        "_auditor_classes": dict(audit_registry._auditor_classes),
+        "_presets": dict(audit_registry._presets),
+        "_legacy_auditors": dict(audit_registry._legacy_auditors),
+    }
+    try:
+        yield
+    finally:
+        for attr, saved in snapshot.items():
+            current = getattr(audit_registry, attr)
+            current.clear()
+            current.update(saved)

--- a/tests/audit/test_audit_log.py
+++ b/tests/audit/test_audit_log.py
@@ -864,7 +864,9 @@ class TestAuditLogEdgeCases:
 
         events = audit_log.query(AuditQuery())
         assert len(events) == 1
-        assert "O'Brien" in str(events[0].details)
+        # details round-trips as a dict; check the stored field value directly
+        # (str(dict) would escape the apostrophe in its repr).
+        assert "O'Brien" in events[0].details["query"]
 
     def test_event_with_unicode(self, audit_log):
         """Test event with unicode characters."""

--- a/tests/export/test_export_artifact.py
+++ b/tests/export/test_export_artifact.py
@@ -829,15 +829,18 @@ class TestArtifactBuilder:
         mock_result.final_answer = "Answer that is longer than twenty characters"
         mock_result.consensus_reached = True
         mock_result.confidence = 0.9
+        # Vote breakdown is computed against the winning choice; an explicit
+        # winner attribute takes priority over the most-common-vote fallback.
+        mock_result.winner = "Answer that is longe"
 
-        # Create votes - choice matches first 20 chars of final_answer
+        # Create votes - agent1's choice matches the winner, agent2's does not
         vote1 = MagicMock()
         vote1.agent = "agent1"
-        vote1.choice = "Answer that is longe"  # Matches first 20
+        vote1.choice = "Answer that is longe"  # Matches winner -> agreed
 
         vote2 = MagicMock()
         vote2.agent = "agent2"
-        vote2.choice = "Different answer"  # Doesn't match
+        vote2.choice = "Different answer"  # Doesn't match winner -> disagreed
 
         mock_result.votes = [vote1, vote2]
 

--- a/tests/modes/test_modes_prober.py
+++ b/tests/modes/test_modes_prober.py
@@ -951,7 +951,7 @@ class TestCapabilityProber:
         """Should handle agent errors gracefully."""
 
         async def mock_run_agent(agent, prompt):
-            raise Exception("Agent failed")
+            raise RuntimeError("Agent failed")
 
         from aragora.modes.probes import ProbeType
 

--- a/tests/pipeline/backbone_entrypoints_inventory.py
+++ b/tests/pipeline/backbone_entrypoints_inventory.py
@@ -251,6 +251,14 @@ ENTRYPOINT_INVENTORY: Final[tuple[BackboneEntrypoint, ...]] = (
         wiring_mode="canonical_queue",
         signals=("execute_decision_plan_with_backbone",),
     ),
+    BackboneEntrypoint(
+        file_path="aragora/swarm/boss_worker_lifecycle.py",
+        qualname="dispatch_issue",
+        lifecycle="mixed",
+        coverage="green",
+        wiring_mode="manual_run",
+        signals=("run_ledger_create",),
+    ),
 )
 
 INTERNAL_BACKBONE_HELPERS: Final[dict[str, str]] = {

--- a/tests/routing/test_domain_matcher_root.py
+++ b/tests/routing/test_domain_matcher_root.py
@@ -8,6 +8,7 @@ import time
 from unittest.mock import MagicMock, patch
 
 import pytest
+from anthropic.types import TextBlock
 
 from aragora.routing.domain_matcher import (
     DOMAIN_KEYWORDS,
@@ -301,7 +302,7 @@ class TestDomainDetectorLLM:
         mock_client = MagicMock()
         mock_response = MagicMock()
         mock_response.content = [
-            MagicMock(text='{"domains": [{"name": "security", "confidence": 0.95}]}')
+            TextBlock(type="text", text='{"domains": [{"name": "security", "confidence": 0.95}]}')
         ]
         mock_client.messages.create.return_value = mock_response
 
@@ -317,7 +318,9 @@ class TestDomainDetectorLLM:
         mock_client = MagicMock()
         mock_response = MagicMock()
         mock_response.content = [
-            MagicMock(text='```json\n{"domains": [{"name": "api", "confidence": 0.9}]}\n```')
+            TextBlock(
+                type="text", text='```json\n{"domains": [{"name": "api", "confidence": 0.9}]}\n```'
+            )
         ]
         mock_client.messages.create.return_value = mock_response
 
@@ -347,7 +350,7 @@ class TestDomainDetectorLLM:
     def test_llm_detection_failure_fallback(self):
         """Test that LLM failure falls back to keywords."""
         mock_client = MagicMock()
-        mock_client.messages.create.side_effect = Exception("API Error")
+        mock_client.messages.create.side_effect = ConnectionError("API Error")
 
         with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test_key"}):
             detector = DomainDetector(use_llm=True, client=mock_client, use_cache=False)
@@ -362,7 +365,7 @@ class TestDomainDetectorLLM:
         mock_client = MagicMock()
         mock_response = MagicMock()
         mock_response.content = [
-            MagicMock(text='{"domains": [{"name": "security", "confidence": 0.9}]}')
+            TextBlock(type="text", text='{"domains": [{"name": "security", "confidence": 0.9}]}')
         ]
         mock_client.messages.create.return_value = mock_response
 

--- a/tests/verification/test_verification.py
+++ b/tests/verification/test_verification.py
@@ -19,6 +19,7 @@ from aragora.verification.proofs import (
     SAFE_BUILTINS,
     EXEC_TIMEOUT_SECONDS,
     _exec_with_timeout,
+    VerificationError,
     ProofType,
     ProofStatus,
     VerificationProof,
@@ -108,17 +109,17 @@ class TestExecWithTimeout:
     def test_safe_builtins_enforced(self):
         """Unsafe builtins should not be available."""
         namespace = {}
-        # Code validation catches dangerous patterns early (RuntimeError)
-        # or execution fails with NameError if pattern slips through
-        with pytest.raises((NameError, RuntimeError)):
+        # Code-safety validation rejects dangerous patterns (e.g. open() ) with
+        # a VerificationError before the code is executed.
+        with pytest.raises(VerificationError):
             _exec_with_timeout("result = open('/etc/passwd')", namespace)
 
     def test_import_blocked(self):
         """Import should be blocked."""
         namespace = {}
-        # Code validation catches import early (RuntimeError)
-        # or execution fails with ImportError/NameError
-        with pytest.raises((NameError, ImportError, RuntimeError)):
+        # Code-safety validation rejects import statements with a
+        # VerificationError before the code is executed.
+        with pytest.raises(VerificationError):
             _exec_with_timeout("import os", namespace)
 
 


### PR DESCRIPTION
## Source issue

Pre-existing stale-test debt surfaced by the tests-migration in six
nightly-only module dirs (`tests/routing`, `tests/verification`,
`tests/export`, `tests/modes`, `tests/audit`, `tests/pipeline`). These are
**not** in the PR `test-fast` shards; they surface only via targeted
`python3 -m pytest tests/<dir>` or the nightly `coverage.yml`. Every failure
was re-confirmed reproducing on a fresh clean `origin/main` worktree
(`6b66a19af5`), i.e. genuine pre-existing debt, not migration regressions.

Tier 0, tests-only: **no source behavior changed, no assertions weakened**
(several are tightened to the precise current behavior).

## Behavior summary

| Dir | Stale test | Current source behavior it now matches |
|-----|-----------|----------------------------------------|
| routing | `TestDomainDetectorLLM` (×4) | `DomainDetector` only parses the LLM JSON when `response.content[0]` is an `anthropic.types.TextBlock`; a `MagicMock(text=...)` fell through to keyword detection (confidence 1.0). Now uses real `TextBlock`; fallback test raises a catchable `ConnectionError`. |
| verification | `TestExecWithTimeout` (×2) | `_exec_with_timeout` raises `VerificationError` from code-safety validation (not a `NameError`/`RuntimeError` subclass). Tests now expect `VerificationError`. |
| export | `test_from_result_vote_breakdown` | vote breakdown is computed against the winning choice; an unset `MagicMock().winner` is auto-truthy. Test now sets an explicit `winner`. |
| modes | `test_probe_agent_handles_errors` | `probe_agent` catches only `RuntimeError`; test now raises `RuntimeError`. |
| audit | `test_event_with_special_characters` | `details` round-trips as a dict; `str(dict)` escapes the apostrophe in its repr. Test now checks the stored field value directly. |
| pipeline | `test_backbone_entrypoint_inventory_matches_repo_scan` | repo scan discovers `aragora/swarm/boss_worker_lifecycle.py::dispatch_issue`; added to the inventory. Verified the full inventory matches the scan on `origin/main` `6b66a19af5`. |

Additionally, `tests/audit/conftest.py` adds an autouse fixture that
snapshots and restores the process-wide `audit_registry` singleton between
tests. Under `pytest-randomly` (no pinned seed) a polluter
(`test_audit_domain_packs.py::TestAuditorRegistry`) left `software` registered
on the global singleton, so the victim
(`test_software.py::...::test_register_software_auditor`) hit
`ValueError: Auditor 'software' is already registered`. Deterministically
reproduced via the polluter+victim pair under `-p no:randomly`, confirmed on
fresh `origin/main`, and fixed with snapshot+restore (never weakening
assertions, never changing source).

## Validation

```
python3 -m pytest tests/routing tests/verification tests/export tests/modes tests/audit tests/pipeline -q
# -> 5493 passed, 3 skipped (pre-existing skips/warnings)
```

`tests/audit` also verified green across `-p no:randomly` and four explicit
`pytest-randomly` seeds (1, 42, 12345, 99999): 1163 passed each.

## Risks

None. Tests-only; mypy/lint scopes exclude the changed paths. The required CI
`typecheck` (changed-file `aragora/`-scoped) skip-passes since no `aragora/`
files are touched.
