### PR TITLE
fix(settle-tier4): route read probes through app auth

### DIFF
--- a/aragora/swarm/github_app_auth.py
+++ b/aragora/swarm/github_app_auth.py
@@ -362,6 +362,7 @@ def _bucket_for_args(args: Sequence[str], stderr: str) -> str:
 def gh_subprocess_run(
     args: Sequence[str],
     *,
+    cwd: Path | None = None,
     timeout: float = 30.0,
     prefer_app: bool = True,
     write_op: bool = False,
@@ -406,6 +407,7 @@ def gh_subprocess_run(
     while attempt <= max_retries:
         result = subprocess.run(  # noqa: S603 - controlled gh invocation
             ["gh", *list(args)],
+            cwd=cwd,
             capture_output=True,
             text=True,
             timeout=timeout,

--- a/scripts/settle_tier4_pr.py
+++ b/scripts/settle_tier4_pr.py
@@ -25,6 +25,23 @@ if str(REPO_ROOT) not in sys.path:
 from aragora.cli.commands import review_queue_rest_fallback as rest_fallback
 from aragora.cli.commands.review_queue_transport import _GhError
 
+try:
+    from aragora.swarm.github_app_auth import (
+        gh_subprocess_run,
+        github_cli_env,
+    )
+except Exception:  # pragma: no cover - script must still run in partial checkouts
+    gh_subprocess_run = None  # type: ignore[assignment]
+
+    def github_cli_env(
+        base_env: dict[str, str] | None = None,
+        *,
+        prefer_app: bool = True,
+    ) -> dict[str, str]:
+        del prefer_app
+        return dict(os.environ if base_env is None else base_env)
+
+
 DEFAULT_REPO = "synaptent/aragora"
 AUTHORIZED_MARKER = "Tier-4 Human Settlement Authorization"
 AUTHORIZED_MERGE_TOKENS = ("admin_squash_merge", "admin squash")
@@ -157,7 +174,9 @@ def _trusted_operator_logins(extra_logins: Sequence[str] | None = None) -> froze
 
 
 def _current_gh_login(*, cwd: Path) -> str:
-    payload = _run_json(["gh", "api", "user"], cwd=cwd)
+    # Identity is semantic for Tier-4 settlement. Do not let App-token fallback
+    # turn an operator identity check into a bot identity check.
+    payload = _run_json(["gh", "api", "user"], cwd=cwd, prefer_app=False)
     login = str(payload.get("login") or "").strip().lower()
     if not login:
         raise RuntimeError("gh api user did not return a login")
@@ -1007,14 +1026,65 @@ def evaluate_tier4_settlement_preconditions(
     }
 
 
-def _run_json(command: list[str], *, cwd: Path | None = None) -> dict[str, Any]:
+def _subprocess_env(*, prefer_app: bool, write_op: bool) -> dict[str, str]:
+    if write_op:
+        return github_cli_env(os.environ, prefer_app=False)
+    return github_cli_env(os.environ, prefer_app=prefer_app)
+
+
+def _run_process(
+    command: list[str],
+    *,
+    cwd: Path | None = None,
+    timeout: float = 120,
+    prefer_app: bool = True,
+    write_op: bool = False,
+    input_text: str | None = None,
+    check: bool = False,
+) -> subprocess.CompletedProcess[str]:
     try:
-        result = subprocess.run(command, cwd=cwd, capture_output=True, text=True, timeout=120)
+        if command and command[0] == "gh" and input_text is None and gh_subprocess_run is not None:
+            result = gh_subprocess_run(
+                command[1:],
+                cwd=cwd,
+                timeout=timeout,
+                prefer_app=prefer_app,
+                write_op=write_op,
+                env=os.environ,
+            )
+            if check and result.returncode != 0:
+                raise subprocess.CalledProcessError(
+                    result.returncode,
+                    command,
+                    output=result.stdout,
+                    stderr=result.stderr,
+                )
+            return result
+        return subprocess.run(
+            command,
+            cwd=cwd,
+            input=input_text,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=_subprocess_env(prefer_app=prefer_app, write_op=write_op),
+            check=check,
+        )
     except subprocess.TimeoutExpired as exc:
-        timeout = int(exc.timeout if exc.timeout is not None else 120)
-        raise RuntimeError(f"{shlex.join(command)} timed out after {timeout}s") from exc
+        timeout_value = int(exc.timeout if exc.timeout is not None else timeout)
+        raise RuntimeError(f"{shlex.join(command)} timed out after {timeout_value}s") from exc
     except OSError as exc:
         raise RuntimeError(f"{shlex.join(command)} failed to start: {exc}") from exc
+
+
+def _run_json(
+    command: list[str],
+    *,
+    cwd: Path | None = None,
+    prefer_app: bool = True,
+    write_op: bool = False,
+) -> dict[str, Any]:
+    result = _run_process(command, cwd=cwd, prefer_app=prefer_app, write_op=write_op)
     if result.returncode != 0:
         raise RuntimeError(f"{shlex.join(command)} failed: {_command_failure_detail(result)}")
     try:
@@ -1026,14 +1096,14 @@ def _run_json(command: list[str], *, cwd: Path | None = None) -> dict[str, Any]:
     return payload
 
 
-def _run_json_any(command: list[str], *, cwd: Path | None = None) -> Any:
-    try:
-        result = subprocess.run(command, cwd=cwd, capture_output=True, text=True, timeout=120)
-    except subprocess.TimeoutExpired as exc:
-        timeout = int(exc.timeout if exc.timeout is not None else 120)
-        raise RuntimeError(f"{shlex.join(command)} timed out after {timeout}s") from exc
-    except OSError as exc:
-        raise RuntimeError(f"{shlex.join(command)} failed to start: {exc}") from exc
+def _run_json_any(
+    command: list[str],
+    *,
+    cwd: Path | None = None,
+    prefer_app: bool = True,
+    write_op: bool = False,
+) -> Any:
+    result = _run_process(command, cwd=cwd, prefer_app=prefer_app, write_op=write_op)
     if result.returncode != 0:
         raise RuntimeError(f"{shlex.join(command)} failed: {_command_failure_detail(result)}")
     try:
@@ -1510,18 +1580,33 @@ def _required_status_check_patch(*, repo: str, cwd: Path) -> tuple[list[str], st
 
 
 def _run_command(command: list[str], *, cwd: Path, input_text: str | None = None) -> None:
-    subprocess.run(command, cwd=cwd, input=input_text, text=True, check=True, timeout=180)
+    result = _run_process(
+        command,
+        cwd=cwd,
+        input_text=input_text,
+        timeout=180,
+        prefer_app=True,
+        write_op=True,
+        check=True,
+    )
+    if result.returncode != 0:
+        raise subprocess.CalledProcessError(
+            result.returncode,
+            command,
+            output=result.stdout,
+            stderr=result.stderr,
+        )
 
 
 def _run_text_command(command: list[str], *, cwd: Path, input_text: str | None = None) -> str:
-    result = subprocess.run(
+    result = _run_process(
         command,
         cwd=cwd,
-        input=input_text,
-        capture_output=True,
-        text=True,
-        check=True,
+        input_text=input_text,
         timeout=180,
+        prefer_app=True,
+        write_op=True,
+        check=True,
     )
     return result.stdout.strip()
 

--- a/tests/scripts/test_settle_tier4_pr.py
+++ b/tests/scripts/test_settle_tier4_pr.py
@@ -121,6 +121,88 @@ def _tier4_repair_packet_missing_settlement(pr: int = 7423) -> dict[str, Any]:
     return packet
 
 
+def test_json_read_gh_probe_prefers_app_auth_and_preserves_cwd(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def fake_gh_subprocess_run(args: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        calls.append({"args": args, **kwargs})
+        return subprocess.CompletedProcess(["gh", *args], 0, '{"ok": true}', "")
+
+    monkeypatch.setattr(settler, "gh_subprocess_run", fake_gh_subprocess_run)
+
+    payload = settler._run_json(["gh", "pr", "view", "7423"], cwd=tmp_path)
+
+    assert payload == {"ok": True}
+    assert calls == [
+        {
+            "args": ["pr", "view", "7423"],
+            "cwd": tmp_path,
+            "timeout": 120,
+            "prefer_app": True,
+            "write_op": False,
+            "env": settler.os.environ,
+        }
+    ]
+
+
+def test_current_gh_login_uses_user_auth_not_app_auth(monkeypatch: Any, tmp_path: Path) -> None:
+    observed: list[dict[str, Any]] = []
+
+    def fake_run_json(
+        command: list[str],
+        *,
+        cwd: Path | None = None,
+        prefer_app: bool = True,
+        write_op: bool = False,
+    ) -> dict[str, Any]:
+        observed.append(
+            {
+                "command": command,
+                "cwd": cwd,
+                "prefer_app": prefer_app,
+                "write_op": write_op,
+            }
+        )
+        return {"login": "scarmani"}
+
+    monkeypatch.setattr(settler, "_run_json", fake_run_json)
+
+    assert settler._current_gh_login(cwd=tmp_path) == "scarmani"
+    assert observed == [
+        {
+            "command": ["gh", "api", "user"],
+            "cwd": tmp_path,
+            "prefer_app": False,
+            "write_op": False,
+        }
+    ]
+
+
+def test_write_command_uses_user_auth_not_app_auth(monkeypatch: Any, tmp_path: Path) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def fake_gh_subprocess_run(args: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        calls.append({"args": args, **kwargs})
+        return subprocess.CompletedProcess(["gh", *args], 0, "", "")
+
+    monkeypatch.setattr(settler, "gh_subprocess_run", fake_gh_subprocess_run)
+
+    settler._run_command(["gh", "pr", "comment", "7423", "--body", "settled"], cwd=tmp_path)
+
+    assert calls == [
+        {
+            "args": ["pr", "comment", "7423", "--body", "settled"],
+            "cwd": tmp_path,
+            "timeout": 180,
+            "prefer_app": True,
+            "write_op": True,
+            "env": settler.os.environ,
+        }
+    ]
+
+
 def _valid_checks() -> list[dict[str, str]]:
     return [
         {"name": "lint", "state": "SUCCESS"},
@@ -132,6 +214,7 @@ def test_run_json_timeout_reports_runtime_error(monkeypatch: pytest.MonkeyPatch)
     def fake_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
         raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs.get("timeout"))
 
+    monkeypatch.setattr(settler, "gh_subprocess_run", None)
     monkeypatch.setattr(settler.subprocess, "run", fake_run)
 
     with pytest.raises(RuntimeError, match=r"gh pr view 7423 timed out after 120s"):
@@ -142,6 +225,7 @@ def test_run_json_timeout_preserves_zero_timeout(monkeypatch: pytest.MonkeyPatch
     def fake_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
         raise subprocess.TimeoutExpired(cmd=args[0], timeout=0)
 
+    monkeypatch.setattr(settler, "gh_subprocess_run", None)
     monkeypatch.setattr(settler.subprocess, "run", fake_run)
 
     with pytest.raises(RuntimeError, match=r"gh pr view 7423 timed out after 0s"):
@@ -152,6 +236,7 @@ def test_run_json_any_timeout_preserves_zero_timeout(monkeypatch: pytest.MonkeyP
     def fake_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
         raise subprocess.TimeoutExpired(cmd=args[0], timeout=0)
 
+    monkeypatch.setattr(settler, "gh_subprocess_run", None)
     monkeypatch.setattr(settler.subprocess, "run", fake_run)
 
     with pytest.raises(RuntimeError, match=r"gh pr view 7423 timed out after 0s"):
@@ -192,6 +277,7 @@ def test_main_json_reports_live_probe_timeout(
     def fake_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
         raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs.get("timeout"))
 
+    monkeypatch.setattr(settler, "gh_subprocess_run", None)
     monkeypatch.setattr(settler.subprocess, "run", fake_run)
 
     exit_code = settler.main(

--- a/tests/swarm/test_github_app_auth.py
+++ b/tests/swarm/test_github_app_auth.py
@@ -249,6 +249,22 @@ def test_gh_subprocess_run_returns_success_immediately(monkeypatch) -> None:
     assert calls == [["gh", "pr", "list"]]
 
 
+def test_gh_subprocess_run_preserves_cwd(monkeypatch, tmp_path) -> None:
+    observed: dict[str, object] = {}
+
+    def fake_run(cmd, **kwargs):
+        observed.update(kwargs)
+        return subprocess.CompletedProcess(cmd, 0, '{"ok": true}', "")
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+    monkeypatch.setattr(mod, "github_cli_env", lambda *, prefer_app=True: {"GH_TOKEN": "x"})
+
+    result = mod.gh_subprocess_run(["pr", "list"], cwd=tmp_path)
+
+    assert result.returncode == 0
+    assert observed["cwd"] == tmp_path
+
+
 def test_gh_subprocess_run_does_not_retry_non_rate_limit_failures(monkeypatch) -> None:
     calls: list[list[str]] = []
 


### PR DESCRIPTION
## Summary
- Restacks the surviving non-overlapping piece from #8405 onto current `origin/main` after #8410, #8426, and #7894 landed.
- Routes read-only `scripts/settle_tier4_pr.py` GitHub probes through the App-token-aware `gh_subprocess_run`, while keeping `gh api user`, PR comments, commit statuses, and branch-protection writes on operator auth.
- Adds `cwd` passthrough to `gh_subprocess_run` and regression coverage for read auth, write auth, operator identity auth, and cwd preservation.

## Validation
- `python -m pytest tests/scripts/test_settle_tier4_pr.py tests/swarm/test_github_app_auth.py -q`
- `python -m ruff check aragora/swarm/github_app_auth.py scripts/settle_tier4_pr.py tests/scripts/test_settle_tier4_pr.py tests/swarm/test_github_app_auth.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- push hook: ruff, ruff format, mypy, gitleaks, portability guard

## Redundant PR closure plan
- #8410 is already merged into main; no closure action needed.
- #8405 should close as superseded after this PR is green; this PR preserves only the app-auth read-probe behavior and intentionally drops the token-doctor/tooling bundle.
- #8406 should close as superseded after this PR is green; #8410/#7894 already cover the settle-only quorum/direct-required-check fallback pieces, and the broad review-queue extraction/docs churn is not part of the smallest survivor.