### PR TITLE
test(pipeline): isolate aragora.swarm.tranche_submit from sys.modules pollution

### DIFF
--- a/tests/pipeline/conftest.py
+++ b/tests/pipeline/conftest.py
@@ -1,0 +1,37 @@
+"""Shared fixtures for the pipeline test suite.
+
+``aragora/swarm/__init__.py`` defines a PEP 562 module ``__getattr__`` that only
+serves names in its ``_EXPORTS`` allowlist. ``tranche_submit`` is a submodule,
+not an export, so it is reachable as ``aragora.swarm.tranche_submit`` only after
+it has been imported and bound onto the package namespace. Several pipeline
+tests patch ``sys.modules`` (``patch.dict``) to simulate missing optional
+dependencies; under ``pytest-randomly`` an ordering can leave the
+``aragora.swarm`` package or the submodule unbound, after which
+``monkeypatch.setattr("aragora.swarm.tranche_submit.submit_intake_bundle", ...)``
+in ``test_stage_transitions.py`` raises ``AttributeError`` from that
+``__getattr__``. Snapshot the clean module objects at import time and restore the
+binding before every test so the suite is order-independent without touching
+source behavior.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+import aragora
+import aragora.swarm
+import aragora.swarm.tranche_submit
+
+_SWARM_PACKAGE = sys.modules["aragora.swarm"]
+_TRANCHE_SUBMIT = sys.modules["aragora.swarm.tranche_submit"]
+
+
+@pytest.fixture(autouse=True)
+def _restore_swarm_tranche_submit_binding():
+    sys.modules["aragora.swarm"] = _SWARM_PACKAGE
+    sys.modules["aragora.swarm.tranche_submit"] = _TRANCHE_SUBMIT
+    aragora.swarm = _SWARM_PACKAGE
+    _SWARM_PACKAGE.tranche_submit = _TRANCHE_SUBMIT
+    yield


### PR DESCRIPTION
## Source issue

`tests/pipeline/test_stage_transitions.py::TestInteractiveTransitions::test_approvals_and_swarm_submission_update_transition_and_nodes`
fails under `pytest-randomly` (no pinned seed in CI / nightly) with:

```
AttributeError: module 'aragora.swarm' has no attribute 'tranche_submit'
  aragora/swarm/__init__.py:108  (PEP 562 module __getattr__)
```

This is a pre-existing, latent **order-dependent** flake surfaced during
post-merge green-verification of the six nightly-only dirs (sibling PR #8439).
Both `test_stage_transitions.py` and `aragora/swarm/tranche_submit.py` predate
this work; the failure reproduces on a clean `origin/main` worktree (e.g.
`tests/pipeline -p randomly --randomly-seed=100` → 1 failed) and **passes in
isolation** (`-p no:randomly`), confirming cross-file pollution rather than a
source regression.

## Root cause

`aragora/swarm/__init__.py` defines a PEP 562 module `__getattr__` that only
serves names in its `_EXPORTS` allowlist. `tranche_submit` is a submodule (not
an export), so `aragora.swarm.tranche_submit` is reachable as an attribute only
after the submodule has been imported and bound onto the package namespace.
Several pipeline tests patch `sys.modules` (`patch.dict`) to simulate missing
optional dependencies; under certain random orderings the `aragora.swarm`
package or the submodule is left unbound, after which the victim's
`monkeypatch.setattr("aragora.swarm.tranche_submit.submit_intake_bundle", ...)`
(raising=True) fails resolving the attribute via that `__getattr__`.

## Fix

Add `tests/pipeline/conftest.py` with an autouse fixture that snapshots the
clean `aragora.swarm` package and `aragora.swarm.tranche_submit` submodule
objects at import time and restores the `sys.modules` entries + attribute
binding before every test. This is the prescribed snapshot+restore pattern for
a lazily-populated registry. **No source behavior changed; no assertions
weakened.**

## Validation

```
python3 -m pytest tests/pipeline -p randomly --randomly-seed=100 -q
# before: 1 failed, 1903 passed   after: 1904 passed
```

Verified green across seeds 100, 1, 42, 12345, 99999, 7, 2024 (1904 passed
each). Local gates: `make lint` PASS, typecheck differential PASS
(`new=51 <= 55`), `make test-smoke` PASS, smoke tier PASS (138 passed).

## Risks

None. Tests-only; mypy/lint scopes are unaffected by a new test conftest. The
required CI `typecheck` (changed-file `aragora/`-scoped) skip-passes since no
`aragora/` files are touched.
