### PR TITLE
test(billing): realign stale PROFESSIONAL tier limit expectations to source (1000)

### DIFF
--- a/tests/billing/test_billing_models_root.py
+++ b/tests/billing/test_billing_models_root.py
@@ -193,14 +193,14 @@ class TestOrganization:
         limits = org.limits
 
         assert limits == TIER_LIMITS[SubscriptionTier.PROFESSIONAL]
-        assert limits.debates_per_month == 200
+        assert limits.debates_per_month == 1000
 
     def test_organization_debates_remaining(self):
         """Should calculate remaining debates correctly."""
         org = Organization(tier=SubscriptionTier.PROFESSIONAL)
         org.debates_used_this_month = 50
 
-        assert org.debates_remaining == 150  # 200 - 50
+        assert org.debates_remaining == 950  # 1000 - 50
 
     def test_organization_debates_remaining_at_limit(self):
         """Debates remaining should be 0 when at limit."""


### PR DESCRIPTION
## Summary

Fixes the two pre-existing main-red failures in `tests/billing/test_billing_models_root.py`:
- `TestOrganization::test_organization_limits_property`
- `TestOrganization::test_organization_debates_remaining`

The source `TIER_LIMITS[PROFESSIONAL].debates_per_month` is now **1000** ([aragora/billing/models.py:108](aragora/billing/models.py#L108)), but two assertions still expected the old value of `200`. The test was internally inconsistent — `test_organization_to_dict` already expected `debates_remaining == 950` (1000 − 50).

## Changes
- `test_organization_limits_property`: `debates_per_month == 200` → `1000`
- `test_organization_debates_remaining`: `debates_remaining == 150` → `950` (1000 − 50)

Test-only realignment to current source behavior — no production code touched. Mirrors the recent stale-test cleanups in #8439 / #8441.

## Verification
```
pytest tests/billing/test_billing_models_root.py -q
69 passed in 5.97s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)