### PR TITLE
feat(swarm): Fusion merge-quorum tie-breaker (advisory, non-counting) — Fusion PR-3

### DIFF
--- a/aragora/config/feature_flags.py
+++ b/aragora/config/feature_flags.py
@@ -484,6 +484,15 @@ class FeatureFlagRegistry:
             FlagStatus.BETA,
             env_var="ARAGORA_ENABLE_CODEX_BRIDGE",
         )
+        self.register(
+            "enable_fusion_quorum_tiebreak",
+            bool,
+            False,
+            "Run an advisory, non-counting OpenRouter Fusion tie-breaker when merge-quorum reviewers split",
+            FlagCategory.EXPERIMENTAL,
+            FlagStatus.BETA,
+            env_var="ARAGORA_ENABLE_FUSION_QUORUM_TIEBREAK",
+        )
         # Knowledge Mound flags
         self.register(
             "enable_knowledge_retrieval",

--- a/aragora/swarm/fusion_tiebreak.py
+++ b/aragora/swarm/fusion_tiebreak.py
@@ -1,0 +1,124 @@
+"""Fusion tie-breaker for split merge-quorum reviews.
+
+When the heterogeneous model reviewers SPLIT -- at least one supportive PASS and
+at least one dissenting changes-requested, with no 2-family supportive quorum --
+an OpenRouter Fusion review can be run as a DISCLOSED, ADVISORY tie-breaker.
+
+HARD CONSTRAINT (mirrors aragora.swarm.quorum_evidence's exclusion of router
+surfaces): Fusion is a multi-model *blend*, so it is NEVER a counting quorum
+family -- counting it would double-count consensus. The tie-breaker comment is
+marked ``is_tie_breaker`` and states explicitly that it does NOT satisfy the
+2-family model-quorum minimum; it only advises the operator's settlement.
+
+Gated by the ``enable_fusion_quorum_tiebreak`` feature flag (default OFF), and by
+an injected ``fusion_review`` runner -- so this stays a pure decision module with
+no network/model dependency. The real runner (openrouter/fusion via the reviewer
+mechanism) is supplied by the caller once Fusion is runnable; until then the
+tie-breaker simply no-ops, never blocking or falsely resolving a quorum.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+
+TIEBREAKER_HEADING = "## OpenRouter Fusion tie-breaker (advisory, non-counting)"
+# A fusion_review runner returns the reviewer's raw text (or "" on failure).
+FusionReview = Callable[[], str]
+
+
+def should_run_tiebreaker(
+    *,
+    supportive_families: Sequence[str],
+    dissenting_families: Sequence[str],
+    has_supportive_quorum: bool,
+    flag_enabled: bool,
+) -> bool:
+    """True only for a genuine, flag-enabled split with no quorum yet.
+
+    A "split" needs at least one supportive PASS AND at least one dissenting
+    changes-requested. Unanimous-pass (already a quorum), unanimous-fail (nothing
+    to break -- the dissent is real and should be fixed, not overridden), and the
+    flag-off case all return False.
+    """
+    if not flag_enabled:
+        return False
+    if has_supportive_quorum:
+        return False  # already resolved; no tie to break
+    return bool(supportive_families) and bool(dissenting_families)
+
+
+def compose_tiebreaker_comment(
+    *,
+    verdict_text: str,
+    head_sha: str,
+    pr: int,
+    supportive_families: Sequence[str],
+    dissenting_families: Sequence[str],
+) -> str:
+    """Compose the disclosed, explicitly non-counting tie-breaker comment."""
+    return (
+        f"{TIEBREAKER_HEADING}\n\n"
+        f"Tie evaluated via the OpenRouter Fusion council (multi-model panel + judge), "
+        f"grounded on PR #{pr} head {head_sha[:12]}.\n"
+        f"Split: supportive={sorted(supportive_families)} "
+        f"dissenting={sorted(dissenting_families)}.\n\n"
+        f"{verdict_text.strip()}\n\n"
+        "NOTE: This is an ADVISORY tie-breaker. Fusion is a multi-model blend, so it does "
+        "NOT count as an independent quorum family and does NOT satisfy the 2-family "
+        "model-quorum requirement. It only advises the operator's settlement decision; the "
+        "dissenting reviewer's concern must still be resolved or explicitly accepted."
+    )
+
+
+@dataclass(frozen=True)
+class TiebreakerOutcome:
+    """Result of a tie-breaker attempt. ``comment`` is set only when ``ran``."""
+
+    ran: bool
+    reason: str
+    comment: str | None = None
+    is_tie_breaker: bool = True  # never a counting family signal
+
+
+def run_tiebreaker(
+    *,
+    supportive_families: Sequence[str],
+    dissenting_families: Sequence[str],
+    has_supportive_quorum: bool,
+    flag_enabled: bool,
+    head_sha: str,
+    pr: int,
+    fusion_review: FusionReview | None,
+) -> TiebreakerOutcome:
+    """Run the advisory tie-breaker if (and only if) the gates pass.
+
+    Returns a non-running outcome (never raises) when the flag is off, there is no
+    genuine split, no runner is supplied (Fusion not runnable here), or Fusion
+    returns nothing -- so a missing/blocked Fusion never blocks or falsely
+    resolves a quorum.
+    """
+    if not should_run_tiebreaker(
+        supportive_families=supportive_families,
+        dissenting_families=dissenting_families,
+        has_supportive_quorum=has_supportive_quorum,
+        flag_enabled=flag_enabled,
+    ):
+        return TiebreakerOutcome(ran=False, reason="no split, quorum already met, or flag off")
+    if fusion_review is None:
+        return TiebreakerOutcome(
+            ran=False, reason="no fusion_review runner supplied (Fusion not runnable here)"
+        )
+    text = fusion_review()
+    if not text or not text.strip():
+        return TiebreakerOutcome(ran=False, reason="fusion review returned empty")
+    comment = compose_tiebreaker_comment(
+        verdict_text=text,
+        head_sha=head_sha,
+        pr=pr,
+        supportive_families=supportive_families,
+        dissenting_families=dissenting_families,
+    )
+    return TiebreakerOutcome(
+        ran=True, reason="tie-breaker composed (advisory, non-counting)", comment=comment
+    )

--- a/aragora/swarm/fusion_tiebreak.py
+++ b/aragora/swarm/fusion_tiebreak.py
@@ -78,7 +78,7 @@ class TiebreakerOutcome:
     ran: bool
     reason: str
     comment: str | None = None
-    is_tie_breaker: bool = True  # never a counting family signal
+    is_tie_breaker: bool = False  # actual tie-breaker comments opt in below
 
 
 def run_tiebreaker(
@@ -112,7 +112,7 @@ def run_tiebreaker(
     try:
         text = fusion_review()
     except Exception as exc:
-        return TiebreakerOutcome(ran=False, reason=f"fusion review raised: {exc}")
+        return TiebreakerOutcome(ran=False, reason=f"fusion review raised {type(exc).__name__}")
     if not text or not text.strip():
         return TiebreakerOutcome(ran=False, reason="fusion review returned empty")
     comment = compose_tiebreaker_comment(
@@ -123,5 +123,8 @@ def run_tiebreaker(
         dissenting_families=dissenting_families,
     )
     return TiebreakerOutcome(
-        ran=True, reason="tie-breaker composed (advisory, non-counting)", comment=comment
+        ran=True,
+        reason="tie-breaker composed (advisory, non-counting)",
+        comment=comment,
+        is_tie_breaker=True,
     )

--- a/aragora/swarm/fusion_tiebreak.py
+++ b/aragora/swarm/fusion_tiebreak.py
@@ -109,7 +109,10 @@ def run_tiebreaker(
         return TiebreakerOutcome(
             ran=False, reason="no fusion_review runner supplied (Fusion not runnable here)"
         )
-    text = fusion_review()
+    try:
+        text = fusion_review()
+    except Exception as exc:
+        return TiebreakerOutcome(ran=False, reason=f"fusion review raised: {exc}")
     if not text or not text.strip():
         return TiebreakerOutcome(ran=False, reason="fusion review returned empty")
     comment = compose_tiebreaker_comment(

--- a/aragora/swarm/fusion_tiebreak.py
+++ b/aragora/swarm/fusion_tiebreak.py
@@ -23,6 +23,7 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 
 TIEBREAKER_HEADING = "## OpenRouter Fusion tie-breaker (advisory, non-counting)"
+MIN_DISPLAYABLE_HEAD_SHA_LENGTH = 7
 # A fusion_review runner returns the reviewer's raw text (or "" on failure).
 FusionReview = Callable[[], str]
 
@@ -56,11 +57,16 @@ def compose_tiebreaker_comment(
     supportive_families: Sequence[str],
     dissenting_families: Sequence[str],
 ) -> str:
-    """Compose the disclosed, explicitly non-counting tie-breaker comment."""
+    """Compose the disclosed, explicitly non-counting tie-breaker comment.
+
+    ``head_sha`` is required provenance. Empty or implausibly short values are
+    displayed as unknown, but ``None`` remains a caller contract violation.
+    """
+    short_head = _display_head_sha(head_sha)
     return (
         f"{TIEBREAKER_HEADING}\n\n"
         f"Tie evaluated via the OpenRouter Fusion council (multi-model panel + judge), "
-        f"grounded on PR #{pr} head {head_sha[:12]}.\n"
+        f"grounded on PR #{pr} head {short_head}.\n"
         f"Split: supportive={sorted(supportive_families)} "
         f"dissenting={sorted(dissenting_families)}.\n\n"
         f"{verdict_text.strip()}\n\n"
@@ -69,6 +75,15 @@ def compose_tiebreaker_comment(
         "model-quorum requirement. It only advises the operator's settlement decision; the "
         "dissenting reviewer's concern must still be resolved or explicitly accepted."
     )
+
+
+def _display_head_sha(head_sha: str) -> str:
+    if head_sha is None:
+        raise TypeError("head_sha must be a str, not None")
+    normalized = head_sha.strip()
+    if len(normalized) < MIN_DISPLAYABLE_HEAD_SHA_LENGTH:
+        return "unknown"
+    return normalized[:12]
 
 
 @dataclass(frozen=True)

--- a/tests/swarm/test_fusion_tiebreak.py
+++ b/tests/swarm/test_fusion_tiebreak.py
@@ -1,0 +1,122 @@
+"""Tests for the Fusion merge-quorum tie-breaker (aragora.swarm.fusion_tiebreak).
+
+Pure decision + comment composition; the Fusion call is injected, so no network
+or model dependency. Verifies the hard constraint: the tie-breaker is advisory
+and explicitly NON-counting (Fusion is a blend, never a quorum family).
+"""
+
+from __future__ import annotations
+
+from aragora.config.feature_flags import FeatureFlagRegistry
+from aragora.swarm import fusion_tiebreak as ft
+
+
+def test_should_run_only_on_genuine_split_when_enabled() -> None:
+    # Split: one PASS, one changes-requested, no quorum, flag on -> run.
+    assert ft.should_run_tiebreaker(
+        supportive_families=["claude"],
+        dissenting_families=["grok"],
+        has_supportive_quorum=False,
+        flag_enabled=True,
+    )
+
+
+def test_should_not_run_when_flag_off() -> None:
+    assert not ft.should_run_tiebreaker(
+        supportive_families=["claude"],
+        dissenting_families=["grok"],
+        has_supportive_quorum=False,
+        flag_enabled=False,
+    )
+
+
+def test_should_not_run_when_quorum_met() -> None:
+    assert not ft.should_run_tiebreaker(
+        supportive_families=["claude", "grok"],
+        dissenting_families=[],
+        has_supportive_quorum=True,
+        flag_enabled=True,
+    )
+
+
+def test_should_not_run_on_unanimous_fail() -> None:
+    # No supportive family => not a split; the dissent is real and must be fixed,
+    # not overridden by a tie-breaker.
+    assert not ft.should_run_tiebreaker(
+        supportive_families=[],
+        dissenting_families=["claude", "grok"],
+        has_supportive_quorum=False,
+        flag_enabled=True,
+    )
+
+
+def test_run_tiebreaker_composes_disclosed_noncounting_comment() -> None:
+    out = ft.run_tiebreaker(
+        supportive_families=["claude"],
+        dissenting_families=["grok"],
+        has_supportive_quorum=False,
+        flag_enabled=True,
+        head_sha="abcdef1234567890",
+        pr=8444,
+        fusion_review=lambda: "Verdict: lean-pass\nThe dissent is a non-blocking nit.",
+    )
+    assert out.ran is True
+    assert out.is_tie_breaker is True
+    assert out.comment is not None
+    # Disclosure + the hard non-counting constraint must be explicit.
+    assert ft.TIEBREAKER_HEADING in out.comment
+    assert "NOT count as an independent quorum family" in out.comment
+    assert "advisory" in out.comment.lower()
+    assert "abcdef123456" in out.comment  # head short-sha
+    assert "#8444" in out.comment
+
+
+def test_run_tiebreaker_noop_without_runner() -> None:
+    # Fusion not runnable here (no key/slug) -> graceful no-op, never blocks.
+    out = ft.run_tiebreaker(
+        supportive_families=["claude"],
+        dissenting_families=["grok"],
+        has_supportive_quorum=False,
+        flag_enabled=True,
+        head_sha="deadbeef",
+        pr=1,
+        fusion_review=None,
+    )
+    assert out.ran is False
+    assert "not runnable" in out.reason
+
+
+def test_run_tiebreaker_noop_on_empty_fusion_output() -> None:
+    out = ft.run_tiebreaker(
+        supportive_families=["claude"],
+        dissenting_families=["grok"],
+        has_supportive_quorum=False,
+        flag_enabled=True,
+        head_sha="deadbeef",
+        pr=1,
+        fusion_review=lambda: "   ",
+    )
+    assert out.ran is False
+    assert "empty" in out.reason
+
+
+def test_run_tiebreaker_noop_when_no_split() -> None:
+    # Quorum already met -> nothing to break, even with a runner present.
+    called = []
+    out = ft.run_tiebreaker(
+        supportive_families=["claude", "grok"],
+        dissenting_families=[],
+        has_supportive_quorum=True,
+        flag_enabled=True,
+        head_sha="deadbeef",
+        pr=1,
+        fusion_review=lambda: called.append(1) or "should not run",
+    )
+    assert out.ran is False
+    assert called == []  # runner must NOT be invoked when there's no tie
+
+
+def test_tiebreak_flag_registered_default_off(monkeypatch) -> None:
+    monkeypatch.delenv("ARAGORA_ENABLE_FUSION_QUORUM_TIEBREAK", raising=False)
+    reg = FeatureFlagRegistry()
+    assert reg.is_enabled("enable_fusion_quorum_tiebreak") is False

--- a/tests/swarm/test_fusion_tiebreak.py
+++ b/tests/swarm/test_fusion_tiebreak.py
@@ -7,6 +7,8 @@ and explicitly NON-counting (Fusion is a blend, never a quorum family).
 
 from __future__ import annotations
 
+import pytest
+
 from aragora.config.feature_flags import FeatureFlagRegistry
 from aragora.swarm import fusion_tiebreak as ft
 
@@ -69,6 +71,38 @@ def test_run_tiebreaker_composes_disclosed_noncounting_comment() -> None:
     assert "advisory" in out.comment.lower()
     assert "abcdef123456" in out.comment  # head short-sha
     assert "#8444" in out.comment
+
+
+@pytest.mark.parametrize("head_sha", ["", "   ", "abc123"])
+def test_run_tiebreaker_treats_empty_or_short_head_sha_as_unknown(head_sha: str) -> None:
+    out = ft.run_tiebreaker(
+        supportive_families=["claude"],
+        dissenting_families=["grok"],
+        has_supportive_quorum=False,
+        flag_enabled=True,
+        head_sha=head_sha,
+        pr=8444,
+        fusion_review=lambda: "Verdict: lean-pass",
+    )
+
+    assert out.ran is True
+    assert out.comment is not None
+    assert "head unknown" in out.comment
+    assert "head abc123" not in out.comment
+    assert "head ." not in out.comment
+
+
+def test_run_tiebreaker_keeps_none_head_sha_fail_loud() -> None:
+    with pytest.raises(TypeError, match="head_sha"):
+        ft.run_tiebreaker(
+            supportive_families=["claude"],
+            dissenting_families=["grok"],
+            has_supportive_quorum=False,
+            flag_enabled=True,
+            head_sha=None,  # type: ignore[arg-type]
+            pr=8444,
+            fusion_review=lambda: "Verdict: lean-pass",
+        )
 
 
 def test_run_tiebreaker_noop_without_runner() -> None:

--- a/tests/swarm/test_fusion_tiebreak.py
+++ b/tests/swarm/test_fusion_tiebreak.py
@@ -100,6 +100,26 @@ def test_run_tiebreaker_noop_on_empty_fusion_output() -> None:
     assert "empty" in out.reason
 
 
+def test_run_tiebreaker_noop_when_fusion_runner_raises() -> None:
+    def raises() -> str:
+        raise RuntimeError("fusion unavailable")
+
+    out = ft.run_tiebreaker(
+        supportive_families=["claude"],
+        dissenting_families=["grok"],
+        has_supportive_quorum=False,
+        flag_enabled=True,
+        head_sha="deadbeef",
+        pr=1,
+        fusion_review=raises,
+    )
+
+    assert out.ran is False
+    assert out.comment is None
+    assert "fusion review raised" in out.reason
+    assert "fusion unavailable" in out.reason
+
+
 def test_run_tiebreaker_noop_when_no_split() -> None:
     # Quorum already met -> nothing to break, even with a runner present.
     called = []

--- a/tests/swarm/test_fusion_tiebreak.py
+++ b/tests/swarm/test_fusion_tiebreak.py
@@ -83,6 +83,7 @@ def test_run_tiebreaker_noop_without_runner() -> None:
         fusion_review=None,
     )
     assert out.ran is False
+    assert out.is_tie_breaker is False
     assert "not runnable" in out.reason
 
 
@@ -97,6 +98,7 @@ def test_run_tiebreaker_noop_on_empty_fusion_output() -> None:
         fusion_review=lambda: "   ",
     )
     assert out.ran is False
+    assert out.is_tie_breaker is False
     assert "empty" in out.reason
 
 
@@ -116,8 +118,9 @@ def test_run_tiebreaker_noop_when_fusion_runner_raises() -> None:
 
     assert out.ran is False
     assert out.comment is None
-    assert "fusion review raised" in out.reason
-    assert "fusion unavailable" in out.reason
+    assert out.is_tie_breaker is False
+    assert out.reason == "fusion review raised RuntimeError"
+    assert "fusion unavailable" not in out.reason
 
 
 def test_run_tiebreaker_noop_when_no_split() -> None:
@@ -133,6 +136,7 @@ def test_run_tiebreaker_noop_when_no_split() -> None:
         fusion_review=lambda: called.append(1) or "should not run",
     )
     assert out.ran is False
+    assert out.is_tie_breaker is False
     assert called == []  # runner must NOT be invoked when there's no tie
 
 


### PR DESCRIPTION
## Fusion PR-3 — merge-quorum tie-breaker (advisory, non-counting)

Third PR of the Fusion arc. Directly targets the swarm's chronic pain: every PR needs a
2-family supportive quorum, and reviews frequently **split** (one family PASS, one
changes-requested) — stalling otherwise-good PRs. This adds an opt-in OpenRouter Fusion
**tie-breaker** to advise the operator when that happens.

**Default OFF.** Zero behavior change until `enable_fusion_quorum_tiebreak` is set.

### The hard constraint (same as PR-1)
Fusion is a multi-model **blend**, so it must **never** count as a quorum family
(`quorum_evidence.py` already excludes router surfaces for this reason). The tie-breaker is
**disclosed** (`is_tie_breaker`) and its comment states explicitly that it does **NOT**
satisfy the 2-family minimum — it only *advises* settlement; the dissent must still be
resolved or explicitly accepted. It can never flip a split into a false quorum.

### Changes
- **`aragora/swarm/fusion_tiebreak.py`** — pure, dependency-free:
  - `should_run_tiebreaker(...)` fires only on a **genuine split** (≥1 supportive + ≥1
    dissenting, no quorum, flag on). Never on unanimous-fail (the dissent is real),
    never when quorum is met, never flag-off.
  - `compose_tiebreaker_comment(...)` builds the disclosed, non-counting comment.
  - `run_tiebreaker(...)` takes an **injected** `fusion_review` runner, so the module has
    no network/model dependency and **no-ops gracefully** when Fusion isn't runnable
    (no key/unverified slug yet) — it never blocks or falsely resolves a quorum.
- **`config/feature_flags.py`** — `enable_fusion_quorum_tiebreak` (default False, EXPERIMENTAL/BETA).

### Scope note
Pure module + flag. The thin wiring into `collect_evidence` and the real `openrouter/fusion`
runner land once Fusion is **runtime-verified** (slug + `OPENROUTER_API_KEY`) — the same gate
PR-1 flagged. Until then this is correct, tested, inert-by-default scaffolding.

### Validation
`pytest tests/swarm/test_fusion_tiebreak.py` → 9 passed (split logic, disclosure/non-counting
language, graceful no-op without a runner / on empty output / when no split, flag default-OFF).
`ruff check`/`format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
