### PR TITLE
fix(dogfood): bootstrap score CLI imports

### DIFF
--- a/scripts/dogfood_score.py
+++ b/scripts/dogfood_score.py
@@ -5,16 +5,14 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
-from aragora.debate.output_quality import (
-    OutputContract,
-    compute_duplicate_existing_create_ratio,
-    validate_output_against_contract,
-)
-from aragora.debate.repo_grounding import assess_repo_grounding
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 
 TIMEOUT_PREFIX = "ARAGORA_TIMEOUT_JSON="
@@ -106,6 +104,13 @@ def _score_run(
     timeout_report_path: Path | None,
     repo_root: Path,
 ) -> RunMetrics:
+    from aragora.debate.output_quality import (
+        OutputContract,
+        compute_duplicate_existing_create_ratio,
+        validate_output_against_contract,
+    )
+    from aragora.debate.repo_grounding import assess_repo_grounding
+
     stdout_text = _read_text(stdout_path)
     timeout_payload = _load_timeout_payload(timeout_report_path, stdout_text)
     final_answer = _extract_final_answer(stdout_text)

--- a/tests/scripts/test_dogfood_score.py
+++ b/tests/scripts/test_dogfood_score.py
@@ -1,0 +1,31 @@
+"""Tests for scripts/dogfood_score.py CLI behavior."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "dogfood_score.py"
+
+
+def test_help_runs_without_pythonpath() -> None:
+    env = dict(os.environ)
+    env.pop("PYTHONPATH", None)
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--help"],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=20,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "--baseline-stdout" in result.stdout
+    assert "--enhanced-stdout" in result.stdout


### PR DESCRIPTION
## Summary
- harvests the dogfood score CLI import fix from codex/dogfood-score-cli-import-improver-20260615
- bootstraps the repo root on direct script invocation without PYTHONPATH
- adds a focused regression for direct no-PYTHONPATH help execution

## Validation
- PYTHONDONTWRITEBYTECODE=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_dogfood_score.py -p no:rerunfailures -p no:cacheprovider
- env -u PYTHONPATH /Users/armand/.pyenv/versions/3.11.11/bin/python scripts/dogfood_score.py --help
- ruff check scripts/dogfood_score.py tests/scripts/test_dogfood_score.py
- ruff format --check scripts/dogfood_score.py tests/scripts/test_dogfood_score.py
- git diff --check origin/main...HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD

## Harvest Evidence
- source branch: codex/dogfood-score-cli-import-improver-20260615
- source head: db1ef9cec12e6a8ecb392eb148d7b132f44cfd27
- harvest head: 8ffee1c0c7
- note: system python3 help smoke was killed with exit 137 in this environment; pyenv Python 3.11.11 passed.