### PR TITLE
feat(agent-bridge): local Codex observe + advisory steer-back channel

### DIFF
--- a/aragora/config/feature_flags.py
+++ b/aragora/config/feature_flags.py
@@ -469,6 +469,21 @@ class FeatureFlagRegistry:
             "[scaffolding; enforcement lands in the nomic-integration PR] Monthly USD cap across all Fusion calls",
             FlagCategory.BILLING,
         )
+        # Codex agent bridge (cross-agent observation + advisory steering). Default
+        # OFF: reading a one-shot digest needs no flag (it touches nothing), but any
+        # orchestration use -- auto-ingesting sibling Codex state or writing advisory
+        # steering -- is an explicit opt-in. The steering channel is advisory and
+        # monotonic-restrictive: it can only ever add caution, never grant a gate
+        # bypass, so the merge-quorum gate stays the sole merge authority.
+        self.register(
+            "enable_codex_bridge",
+            bool,
+            False,
+            "Enable cross-agent ingest of local Codex session/automation state and advisory steer-back",
+            FlagCategory.EXPERIMENTAL,
+            FlagStatus.BETA,
+            env_var="ARAGORA_ENABLE_CODEX_BRIDGE",
+        )
         # Knowledge Mound flags
         self.register(
             "enable_knowledge_retrieval",

--- a/aragora/swarm/agent_bridge/codex_source.py
+++ b/aragora/swarm/agent_bridge/codex_source.py
@@ -1,0 +1,400 @@
+"""Read-only ingest of Codex (Desktop / CLI) on-disk session state.
+
+The Codex app persists everything we need to *observe* a sibling agent locally,
+with no network and no API:
+
+* ``<codex_home>/sessions/YYYY/MM/DD/rollout-*.jsonl`` -- one append-only
+  transcript per session. ``session_meta`` carries ``cwd`` (which repo/worktree
+  the session is operating on) and ``originator``; ``event_msg`` lines of type
+  ``agent_message`` carry the human-visible narration.
+* ``<codex_home>/session_index.jsonl`` -- ``{id, thread_name, updated_at}`` per
+  thread; the cheap recency cursor + human-readable thread names.
+* ``<codex_home>/automations/<name>/ledger.jsonl`` -- already-structured
+  steering records emitted by Codex's headless loops: ``action.target``
+  (pr/head/branch), ``forbidden_actions``, ``git.head``/``origin_main``,
+  ``summary`` (open PR count, runner blockers).
+
+This module turns those into typed summaries so an operator (or the boss loop)
+can cross-check a sibling agent's claimed state against live ``git``/``gh``
+without copy-pasting transcripts. It is strictly read-only and defensive: a
+malformed line is skipped, never raised, so a half-written file (Codex is
+appending concurrently) can never crash the digest.
+
+The ingest is inert unless pointed at a Codex home; the ``enable_codex_bridge``
+feature flag (default OFF) gates any *orchestration* use. Reading for a one-shot
+digest needs no flag -- it touches nothing.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Iterator
+from dataclasses import dataclass
+from dataclasses import field
+from datetime import UTC
+from datetime import datetime
+from datetime import timedelta
+from pathlib import Path
+from typing import Any
+
+# A rollout filename embeds the session UUID after the local timestamp, e.g.
+# ``rollout-2026-06-15T15-40-37-019ecd03-c60c-7bc1-8b9c-6477893310f6.jsonl``.
+_ROLLOUT_PREFIX = "rollout-"
+_ROLLOUT_SUFFIX = ".jsonl"
+
+
+def default_codex_home() -> Path:
+    """Codex home directory. Override with ``ARAGORA_CODEX_HOME`` (operator-specific)."""
+    override = os.environ.get("ARAGORA_CODEX_HOME")
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".codex"
+
+
+def _parse_iso(value: Any) -> datetime | None:
+    """Parse an ISO-8601 timestamp defensively; naive values are treated as UTC.
+
+    Returns ``None`` for anything unparseable so callers can skip rather than
+    crash on a malformed or partially-written record.
+    """
+    if not isinstance(value, str) or not value.strip():
+        return None
+    text = value.strip().replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _iter_jsonl(path: Path) -> Iterator[dict[str, Any]]:
+    """Yield JSON objects from a JSONL file, skipping blank/malformed lines."""
+    try:
+        handle = path.open("r", encoding="utf-8")
+    except OSError:
+        return
+    with handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                payload = json.loads(line)
+            except (ValueError, json.JSONDecodeError):
+                continue
+            if isinstance(payload, dict):
+                yield payload
+
+
+@dataclass(slots=True)
+class CodexSessionSummary:
+    """A compact, human-readable view of one Codex session rollout."""
+
+    session_id: str
+    rollout_path: str
+    cwd: str | None
+    originator: str | None
+    model_provider: str | None
+    started_at: str | None
+    updated_at: str | None
+    agent_message_count: int
+    last_agent_message: str | None
+    thread_name: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "session_id": self.session_id,
+            "rollout_path": self.rollout_path,
+            "cwd": self.cwd,
+            "originator": self.originator,
+            "model_provider": self.model_provider,
+            "started_at": self.started_at,
+            "updated_at": self.updated_at,
+            "agent_message_count": self.agent_message_count,
+            "last_agent_message": self.last_agent_message,
+            "thread_name": self.thread_name,
+        }
+
+
+@dataclass(slots=True)
+class CodexLedgerEntry:
+    """One structured steering record from an automation ledger."""
+
+    automation: str
+    ledger_path: str
+    kind: str | None
+    reason: str | None
+    pr: int | None
+    head: str | None
+    branch: str | None
+    url: str | None
+    forbidden_actions: list[str] = field(default_factory=list)
+    git_head: str | None = None
+    git_origin_main: str | None = None
+    git_status_ok: bool | None = None
+    open_pr_count: int | None = None
+    runner_blockers: list[str] = field(default_factory=list)
+    generated_at: str | None = None
+    repo_root: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "automation": self.automation,
+            "ledger_path": self.ledger_path,
+            "kind": self.kind,
+            "reason": self.reason,
+            "pr": self.pr,
+            "head": self.head,
+            "branch": self.branch,
+            "url": self.url,
+            "forbidden_actions": list(self.forbidden_actions),
+            "git_head": self.git_head,
+            "git_origin_main": self.git_origin_main,
+            "git_status_ok": self.git_status_ok,
+            "open_pr_count": self.open_pr_count,
+            "runner_blockers": list(self.runner_blockers),
+            "generated_at": self.generated_at,
+            "repo_root": self.repo_root,
+        }
+
+
+def read_session_index(home: Path | None = None) -> dict[str, dict[str, Any]]:
+    """Return ``{session_id: {thread_name, updated_at}}`` from ``session_index.jsonl``.
+
+    Later lines win, matching the append-only "last write is current" semantics.
+    """
+    home = home or default_codex_home()
+    index: dict[str, dict[str, Any]] = {}
+    for entry in _iter_jsonl(home / "session_index.jsonl"):
+        session_id = entry.get("id")
+        if isinstance(session_id, str) and session_id:
+            index[session_id] = entry
+    return index
+
+
+def summarize_rollout(path: Path) -> CodexSessionSummary | None:
+    """Summarize one rollout file. ``None`` if it has no usable ``session_meta``."""
+    session_id: str | None = None
+    cwd: str | None = None
+    originator: str | None = None
+    model_provider: str | None = None
+    started_at: str | None = None
+    updated_at: str | None = None
+    agent_message_count = 0
+    last_agent_message: str | None = None
+
+    for record in _iter_jsonl(path):
+        ts = record.get("timestamp")
+        if isinstance(ts, str) and ts:
+            updated_at = ts
+        rtype = record.get("type")
+        payload = record.get("payload")
+        if not isinstance(payload, dict):
+            continue
+        if rtype == "session_meta":
+            sid = payload.get("id")
+            session_id = sid if isinstance(sid, str) else session_id
+            cwd = payload.get("cwd") if isinstance(payload.get("cwd"), str) else cwd
+            originator = (
+                payload.get("originator")
+                if isinstance(payload.get("originator"), str)
+                else originator
+            )
+            model_provider = (
+                payload.get("model_provider")
+                if isinstance(payload.get("model_provider"), str)
+                else model_provider
+            )
+            meta_ts = payload.get("timestamp")
+            if isinstance(meta_ts, str) and meta_ts:
+                started_at = meta_ts
+        elif rtype == "event_msg" and payload.get("type") == "agent_message":
+            message = payload.get("message")
+            if isinstance(message, str) and message.strip():
+                agent_message_count += 1
+                last_agent_message = message.strip()
+
+    if session_id is None:
+        # Fall back to the timestamp+UUID portion of the filename so a rollout
+        # without a readable meta line is still uniquely identifiable.
+        stem = path.name
+        if stem.startswith(_ROLLOUT_PREFIX) and stem.endswith(_ROLLOUT_SUFFIX):
+            session_id = stem[len(_ROLLOUT_PREFIX) : -len(_ROLLOUT_SUFFIX)]
+        else:
+            return None
+
+    return CodexSessionSummary(
+        session_id=session_id,
+        rollout_path=str(path),
+        cwd=cwd,
+        originator=originator,
+        model_provider=model_provider,
+        started_at=started_at,
+        updated_at=updated_at,
+        agent_message_count=agent_message_count,
+        last_agent_message=last_agent_message,
+    )
+
+
+def _session_date_dirs(home: Path) -> Iterator[tuple[datetime, Path]]:
+    """Yield ``(date, dir)`` for each ``sessions/YYYY/MM/DD`` directory."""
+    sessions_root = home / "sessions"
+    if not sessions_root.is_dir():
+        return
+    for year_dir in sessions_root.iterdir():
+        if not year_dir.is_dir():
+            continue
+        for month_dir in year_dir.iterdir():
+            if not month_dir.is_dir():
+                continue
+            for day_dir in month_dir.iterdir():
+                if not day_dir.is_dir():
+                    continue
+                try:
+                    day = datetime(
+                        int(year_dir.name), int(month_dir.name), int(day_dir.name), tzinfo=UTC
+                    )
+                except ValueError:
+                    continue
+                yield day, day_dir
+
+
+def recent_sessions(
+    home: Path | None = None,
+    *,
+    hours: float | None = 24.0,
+    limit: int | None = 50,
+    now: datetime | None = None,
+) -> list[CodexSessionSummary]:
+    """Summaries of recently-updated Codex sessions, newest first.
+
+    ``hours`` filters on each rollout's last record timestamp (``None`` = no
+    time filter). Date directories are pre-filtered with a one-day margin so we
+    only read files that can plausibly be in range. ``thread_name`` is joined in
+    from ``session_index.jsonl`` when available.
+    """
+    home = home or default_codex_home()
+    now = now or datetime.now(UTC)
+    cutoff = None if hours is None else now - timedelta(hours=hours)
+    # Pre-filter date dirs (cheap) before reading any file content.
+    dir_cutoff = None if cutoff is None else (cutoff - timedelta(days=1))
+    index = read_session_index(home)
+
+    summaries: list[tuple[datetime, CodexSessionSummary]] = []
+    for day, day_dir in _session_date_dirs(home):
+        if dir_cutoff is not None and day < dir_cutoff:
+            continue
+        for rollout in day_dir.glob(f"{_ROLLOUT_PREFIX}*{_ROLLOUT_SUFFIX}"):
+            summary = summarize_rollout(rollout)
+            if summary is None:
+                continue
+            updated = _parse_iso(summary.updated_at) or _parse_iso(summary.started_at)
+            if cutoff is not None and (updated is None or updated < cutoff):
+                continue
+            meta = index.get(summary.session_id)
+            if meta is not None:
+                thread_name = meta.get("thread_name")
+                if isinstance(thread_name, str):
+                    summary.thread_name = thread_name
+            sort_key = updated or datetime.min.replace(tzinfo=UTC)
+            summaries.append((sort_key, summary))
+
+    summaries.sort(key=lambda item: item[0], reverse=True)
+    ordered = [summary for _, summary in summaries]
+    if limit is not None:
+        ordered = ordered[:limit]
+    return ordered
+
+
+def _coerce_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    return None
+
+
+def _coerce_str_list(value: Any) -> list[str]:
+    if isinstance(value, list):
+        return [item for item in value if isinstance(item, str)]
+    return []
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    """Return ``value`` if it is a mapping, else an empty dict (type-narrowing helper)."""
+    return value if isinstance(value, dict) else {}
+
+
+def _str_or_none(value: Any) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _bool_or_none(value: Any) -> bool | None:
+    return value if isinstance(value, bool) else None
+
+
+def _ledger_entry_from_record(
+    record: dict[str, Any], *, automation: str, ledger_path: Path
+) -> CodexLedgerEntry:
+    action = _as_dict(record.get("action"))
+    target = _as_dict(action.get("target"))
+    git = _as_dict(record.get("git"))
+    summary = _as_dict(record.get("summary"))
+
+    return CodexLedgerEntry(
+        automation=automation,
+        ledger_path=str(ledger_path),
+        kind=_str_or_none(action.get("kind")),
+        reason=_str_or_none(action.get("reason")),
+        pr=_coerce_int(target.get("pr")),
+        head=_str_or_none(target.get("head")),
+        branch=_str_or_none(target.get("branch")),
+        url=_str_or_none(target.get("url")),
+        forbidden_actions=_coerce_str_list(record.get("forbidden_actions")),
+        git_head=_str_or_none(git.get("head")),
+        git_origin_main=_str_or_none(git.get("origin_main")),
+        git_status_ok=_bool_or_none(git.get("status_ok")),
+        open_pr_count=_coerce_int(summary.get("open_pr_count")),
+        runner_blockers=_coerce_str_list(summary.get("runner_blockers")),
+        generated_at=_str_or_none(record.get("generated_at")),
+        repo_root=_str_or_none(record.get("repo_root")),
+    )
+
+
+def read_ledgers(
+    home: Path | None = None,
+    *,
+    hours: float | None = 24.0,
+    now: datetime | None = None,
+) -> list[CodexLedgerEntry]:
+    """Structured steering records from ``automations/*/ledger.jsonl``, newest first.
+
+    ``hours`` filters on each record's ``generated_at`` (``None`` = no filter).
+    """
+    home = home or default_codex_home()
+    now = now or datetime.now(UTC)
+    cutoff = None if hours is None else now - timedelta(hours=hours)
+    automations_root = home / "automations"
+    if not automations_root.is_dir():
+        return []
+
+    entries: list[tuple[datetime, CodexLedgerEntry]] = []
+    for automation_dir in automations_root.iterdir():
+        ledger_path = automation_dir / "ledger.jsonl"
+        if not ledger_path.is_file():
+            continue
+        for record in _iter_jsonl(ledger_path):
+            generated = _parse_iso(record.get("generated_at"))
+            if cutoff is not None and (generated is None or generated < cutoff):
+                continue
+            entry = _ledger_entry_from_record(
+                record, automation=automation_dir.name, ledger_path=ledger_path
+            )
+            sort_key = generated or datetime.min.replace(tzinfo=UTC)
+            entries.append((sort_key, entry))
+
+    entries.sort(key=lambda item: item[0], reverse=True)
+    return [entry for _, entry in entries]

--- a/aragora/swarm/agent_bridge/codex_source.py
+++ b/aragora/swarm/agent_bridge/codex_source.py
@@ -83,7 +83,7 @@ def _iter_jsonl(path: Path) -> Iterator[dict[str, Any]]:
                 continue
             try:
                 payload = json.loads(line)
-            except (ValueError, json.JSONDecodeError):
+            except ValueError:  # JSONDecodeError subclasses ValueError
                 continue
             if isinstance(payload, dict):
                 yield payload

--- a/aragora/swarm/agent_bridge/codex_steer.py
+++ b/aragora/swarm/agent_bridge/codex_steer.py
@@ -1,0 +1,229 @@
+"""Advisory, monotonic-restrictive steer-back channel for a sibling Codex agent.
+
+The companion to ``codex_source`` (observation). Where that module *reads* what
+Codex did, this module lets the operator/boss-loop *advise* what Codex should
+avoid next -- without ever being able to loosen a gate.
+
+The hard safety invariant, enforced in code rather than by convention: a
+steering directive can only ever **add caution**.
+
+* It may append to the *forbidden actions* set (only from a fixed, known-
+  restrictive vocabulary -- :data:`STEERABLE_FORBIDDEN_ACTIONS`).
+* It may pin specific PRs *off-limits*.
+* It may carry an advisory note.
+
+There is deliberately **no field** by which a directive can grant a permission,
+remove a forbidden action, authorize a merge / ``--admin`` / Tier-4 settlement,
+or relax branch protection. :func:`effective_forbidden_actions` returns a
+*superset* of the caller's baseline by construction (set union), so even a
+malformed or hostile write to the mailbox can only make Codex more conservative.
+The merge-quorum gate remains the sole merge authority.
+
+The mailbox is a local append-only JSONL file (default under the Codex home);
+the Codex automation's Phase-0 reads it via :func:`render_phase0_block` and folds
+the directives into its own ``forbidden_actions`` before acting.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from dataclasses import field
+from datetime import UTC
+from datetime import datetime
+from datetime import timedelta
+from pathlib import Path
+from typing import Any
+
+from .codex_source import _iter_jsonl
+from .codex_source import _parse_iso
+from .codex_source import default_codex_home
+
+# The complete vocabulary a directive may add to a forbidden-actions set. These
+# mirror the actions the Codex automation ledgers already gate on; a directive
+# referencing anything outside this set is rejected, so the channel cannot be
+# used to smuggle in an unknown (and possibly permissive) token.
+STEERABLE_FORBIDDEN_ACTIONS: frozenset[str] = frozenset(
+    {
+        "merge",
+        "mark_ready",
+        "rerun_required_ci",
+        "record_tier4_settlement",
+        "mutate_branch_protection",
+        "mutate_dirty_root_source_files",
+        "create_pr",
+        "mutate_pr_branch",
+        "touch_shared_root",
+    }
+)
+
+
+class SteeringValidationError(ValueError):
+    """Raised when a directive would do anything other than add caution."""
+
+
+def default_mailbox_path(home: Path | None = None) -> Path:
+    """Steering mailbox path. Override with ``ARAGORA_CODEX_STEER_MAILBOX``."""
+    override = os.environ.get("ARAGORA_CODEX_STEER_MAILBOX")
+    if override:
+        return Path(override).expanduser()
+    home = home or default_codex_home()
+    return home / "aragora_steering" / "mailbox.jsonl"
+
+
+@dataclass(slots=True)
+class SteeringDirective:
+    """One advisory directive. Every field can only *add* caution.
+
+    ``target_pr`` of ``None`` means the directive applies globally; otherwise it
+    applies only when Codex is acting on that PR. ``off_limits_prs`` lists PRs
+    Codex must not touch at all.
+    """
+
+    issued_by: str
+    issued_at: str
+    add_forbidden_actions: list[str] = field(default_factory=list)
+    off_limits_prs: list[int] = field(default_factory=list)
+    target_pr: int | None = None
+    note: str | None = None
+
+    def __post_init__(self) -> None:
+        unknown = sorted(set(self.add_forbidden_actions) - STEERABLE_FORBIDDEN_ACTIONS)
+        if unknown:
+            raise SteeringValidationError(
+                f"add_forbidden_actions contains non-steerable tokens: {unknown}; "
+                f"the channel may only add caution from {sorted(STEERABLE_FORBIDDEN_ACTIONS)}"
+            )
+        if any(pr <= 0 for pr in self.off_limits_prs):
+            raise SteeringValidationError("off_limits_prs must be positive PR numbers")
+        if self.target_pr is not None and self.target_pr <= 0:
+            raise SteeringValidationError("target_pr must be a positive PR number or null")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "issued_by": self.issued_by,
+            "issued_at": self.issued_at,
+            "add_forbidden_actions": sorted(set(self.add_forbidden_actions)),
+            "off_limits_prs": sorted(set(self.off_limits_prs)),
+            "target_pr": self.target_pr,
+            "note": self.note,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "SteeringDirective":
+        issued_by = payload.get("issued_by")
+        issued_at = payload.get("issued_at")
+        if not isinstance(issued_by, str) or not isinstance(issued_at, str):
+            raise SteeringValidationError("issued_by and issued_at must be strings")
+        raw_actions = payload.get("add_forbidden_actions", [])
+        if not isinstance(raw_actions, list):
+            raise SteeringValidationError("add_forbidden_actions must be a list")
+        raw_prs = payload.get("off_limits_prs", [])
+        if not isinstance(raw_prs, list):
+            raise SteeringValidationError("off_limits_prs must be a list")
+        target_pr = payload.get("target_pr")
+        if target_pr is not None and not isinstance(target_pr, int):
+            raise SteeringValidationError("target_pr must be an int or null")
+        note = payload.get("note")
+        if note is not None and not isinstance(note, str):
+            raise SteeringValidationError("note must be a string or null")
+        return cls(
+            issued_by=issued_by,
+            issued_at=issued_at,
+            add_forbidden_actions=[a for a in raw_actions if isinstance(a, str)],
+            off_limits_prs=[p for p in raw_prs if isinstance(p, int) and not isinstance(p, bool)],
+            target_pr=target_pr,
+            note=note,
+        )
+
+
+def write_directive(directive: SteeringDirective, *, mailbox_path: Path | None = None) -> Path:
+    """Append a directive to the mailbox (creating it if needed). Returns the path."""
+    path = mailbox_path or default_mailbox_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(directive.to_dict(), sort_keys=True) + "\n")
+    return path
+
+
+def read_directives(
+    *,
+    mailbox_path: Path | None = None,
+    hours: float | None = 24.0,
+    now: datetime | None = None,
+) -> list[SteeringDirective]:
+    """Read directives from the mailbox, oldest first; malformed lines are skipped."""
+    path = mailbox_path or default_mailbox_path()
+    if not path.is_file():
+        return []
+    now = now or datetime.now(UTC)
+    cutoff = None if hours is None else now - timedelta(hours=hours)
+    directives: list[SteeringDirective] = []
+    for record in _iter_jsonl(path):
+        issued = _parse_iso(record.get("issued_at"))
+        if cutoff is not None and (issued is None or issued < cutoff):
+            continue
+        try:
+            directives.append(SteeringDirective.from_dict(record))
+        except SteeringValidationError:
+            # A malformed/hostile directive is dropped entirely. Because the only
+            # effect a valid directive can have is additive caution, dropping one
+            # can never *loosen* the effective posture.
+            continue
+    return directives
+
+
+def effective_forbidden_actions(
+    base_forbidden_actions: list[str],
+    directives: list[SteeringDirective],
+    *,
+    pr: int | None = None,
+) -> list[str]:
+    """The caller's baseline forbidden set, UNIONed with applicable directives.
+
+    Guaranteed superset of ``base_forbidden_actions`` -- this function can only
+    grow the set, never shrink it. A directive applies when it is global
+    (``target_pr is None``) or its ``target_pr`` matches ``pr``. A PR on any
+    directive's ``off_limits_prs`` gets the whole steerable set added.
+    """
+    effective: set[str] = set(base_forbidden_actions)
+    for directive in directives:
+        if directive.target_pr is None or directive.target_pr == pr:
+            effective.update(directive.add_forbidden_actions)
+        if pr is not None and pr in directive.off_limits_prs:
+            effective.update(STEERABLE_FORBIDDEN_ACTIONS)
+    return sorted(effective)
+
+
+def off_limits_prs(directives: list[SteeringDirective]) -> list[int]:
+    """All PRs pinned off-limits across the given directives."""
+    pinned: set[int] = set()
+    for directive in directives:
+        pinned.update(directive.off_limits_prs)
+    return sorted(pinned)
+
+
+def render_phase0_block(directives: list[SteeringDirective], *, pr: int | None = None) -> str:
+    """Human-readable steering block for a Codex automation prompt's Phase-0.
+
+    Returns ``""`` when there are no applicable directives so the caller can
+    omit the section entirely.
+    """
+    if not directives:
+        return ""
+    pinned = off_limits_prs(directives)
+    added = effective_forbidden_actions([], directives, pr=pr)
+    notes = [d.note for d in directives if d.note]
+    lines = ["## Operator steering (advisory; additive caution only)"]
+    if pinned:
+        lines.append(f"- PRs OFF-LIMITS (do not touch): {pinned}")
+    if added:
+        lines.append(f"- Additional forbidden actions this cycle: {added}")
+    for note in notes:
+        lines.append(f"- Note: {note}")
+    lines.append(
+        "- These directives can only ADD caution; the merge-quorum gate remains the "
+        "sole merge authority. They never authorize merge, --admin, or Tier-4 settlement."
+    )
+    return "\n".join(lines)

--- a/aragora/swarm/agent_bridge/codex_steer.py
+++ b/aragora/swarm/agent_bridge/codex_steer.py
@@ -139,7 +139,12 @@ class SteeringDirective:
 
 
 def write_directive(directive: SteeringDirective, *, mailbox_path: Path | None = None) -> Path:
-    """Append a directive to the mailbox (creating it if needed). Returns the path."""
+    """Append a directive to the mailbox (creating it if needed). Returns the path.
+
+    A directive serializes to well under ``PIPE_BUF`` (4 KB on macOS/Linux), so a
+    single ``O_APPEND`` write is atomic and concurrent writers cannot interleave;
+    no explicit lock is needed at these sizes.
+    """
     path = mailbox_path or default_mailbox_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a", encoding="utf-8") as handle:
@@ -153,25 +158,32 @@ def read_directives(
     hours: float | None = 24.0,
     now: datetime | None = None,
 ) -> list[SteeringDirective]:
-    """Read directives from the mailbox, oldest first; malformed lines are skipped."""
+    """Read directives from the mailbox, oldest first; malformed lines are skipped.
+
+    Sorted by ``issued_at`` so "oldest first" holds even if a shared mailbox is
+    appended to by multiple writers with skewed clocks (unparseable timestamps
+    sort first, as the most conservative position).
+    """
     path = mailbox_path or default_mailbox_path()
     if not path.is_file():
         return []
     now = now or datetime.now(UTC)
     cutoff = None if hours is None else now - timedelta(hours=hours)
-    directives: list[SteeringDirective] = []
+    _epoch = datetime.min.replace(tzinfo=UTC)
+    dated: list[tuple[datetime, SteeringDirective]] = []
     for record in _iter_jsonl(path):
         issued = _parse_iso(record.get("issued_at"))
         if cutoff is not None and (issued is None or issued < cutoff):
             continue
         try:
-            directives.append(SteeringDirective.from_dict(record))
+            dated.append((issued or _epoch, SteeringDirective.from_dict(record)))
         except SteeringValidationError:
             # A malformed/hostile directive is dropped entirely. Because the only
             # effect a valid directive can have is additive caution, dropping one
             # can never *loosen* the effective posture.
             continue
-    return directives
+    dated.sort(key=lambda item: item[0])
+    return [directive for _, directive in dated]
 
 
 def effective_forbidden_actions(

--- a/scripts/codex_bridge_digest.py
+++ b/scripts/codex_bridge_digest.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Read-only digest of what sibling Codex sessions/automations did recently.
+
+Replaces hand copy-pasting Codex transcripts: reads the local Codex on-disk
+state (``aragora.swarm.agent_bridge.codex_source``) and prints a compact,
+cross-checkable summary -- recent sessions (what each was doing + where) and
+automation ledger steering records (target PR/head, forbidden actions, blockers).
+
+Strictly observational. Touches no repo files and makes no mutations. With
+``--live`` it additionally runs read-only ``gh pr view`` to flag when a Codex
+prompt is grounded on a stale head or a PR that already merged/closed.
+
+Examples::
+
+    python scripts/codex_bridge_digest.py --hours 12
+    python scripts/codex_bridge_digest.py --hours 6 --live --repo synaptent/aragora
+    python scripts/codex_bridge_digest.py --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# Allow running as a bare script from anywhere in the repo.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from aragora.swarm.agent_bridge.codex_source import (  # noqa: E402
+    CodexLedgerEntry,
+    CodexSessionSummary,
+    default_codex_home,
+    read_ledgers,
+    recent_sessions,
+)
+
+_TRUNC = 160
+
+
+def _default_shared_root() -> str | None:
+    """The main repo worktree -- a Codex session here is editing shared dirt.
+
+    Resolved portably: ``ARAGORA_SHARED_ROOT`` if set, else the parent of git's
+    common dir (the primary worktree even when run from a linked worktree).
+    """
+    override = os.environ.get("ARAGORA_SHARED_ROOT")
+    if override:
+        return str(Path(override).expanduser().resolve())
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    return str(Path(result.stdout.strip()).parent.resolve())
+
+
+def _truncate(text: str | None, length: int = _TRUNC) -> str:
+    if not text:
+        return ""
+    collapsed = " ".join(text.split())
+    return collapsed if len(collapsed) <= length else collapsed[: length - 1] + "…"
+
+
+def _gh_pr_view(pr: int, repo: str) -> dict | None:
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "view",
+                str(pr),
+                "--repo",
+                repo,
+                "--json",
+                "state,headRefOid,isDraft,title",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        payload = json.loads(result.stdout)
+    except (ValueError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _session_flags(
+    sessions: list[CodexSessionSummary], shared_root: str | None
+) -> dict[str, list[str]]:
+    """Compute per-session watchlist flags keyed by rollout path."""
+    flags: dict[str, list[str]] = {}
+    cwd_counts: dict[str, int] = {}
+    for session in sessions:
+        if session.cwd:
+            cwd_counts[session.cwd] = cwd_counts.get(session.cwd, 0) + 1
+    for session in sessions:
+        session_flags: list[str] = []
+        if shared_root and session.cwd == shared_root:
+            session_flags.append("operating directly on SHARED ROOT (dirt risk)")
+        if session.cwd and cwd_counts.get(session.cwd, 0) > 1:
+            session_flags.append(f"shares cwd with {cwd_counts[session.cwd] - 1} other session(s)")
+        if session_flags:
+            flags[session.rollout_path] = session_flags
+    return flags
+
+
+def _live_ledger_flags(entries: list[CodexLedgerEntry], repo: str) -> dict[int, list[str]]:
+    """For distinct target PRs, flag stale-head / already-merged prompts via gh."""
+    flags: dict[int, list[str]] = {}
+    seen: set[int] = set()
+    for entry in entries:
+        if entry.pr is None or entry.pr in seen:
+            continue
+        seen.add(entry.pr)
+        view = _gh_pr_view(entry.pr, repo)
+        if view is None:
+            continue
+        pr_flags: list[str] = []
+        state = view.get("state")
+        if isinstance(state, str) and state.upper() in {"MERGED", "CLOSED"}:
+            pr_flags.append(f"PR already {state.upper()} (prompt is stale)")
+        live_head = view.get("headRefOid")
+        if entry.head and isinstance(live_head, str) and live_head != entry.head:
+            pr_flags.append(
+                f"head moved {entry.head[:12]} -> {live_head[:12]} (Codex grounded on stale head)"
+            )
+        if pr_flags:
+            flags[entry.pr] = pr_flags
+    return flags
+
+
+def _render_text(
+    *,
+    home: Path,
+    hours: float | None,
+    sessions: list[CodexSessionSummary],
+    ledgers: list[CodexLedgerEntry],
+    session_flags: dict[str, list[str]],
+    ledger_flags: dict[int, list[str]],
+) -> str:
+    out: list[str] = []
+    window = "all time" if hours is None else f"last {hours:g}h"
+    out.append(f"# Codex bridge digest  (home={home}, window={window})")
+    out.append("")
+
+    out.append(f"## Sessions ({len(sessions)})")
+    if not sessions:
+        out.append("  (none in window)")
+    for session in sessions:
+        name = session.thread_name or session.session_id[:12]
+        origin = session.originator or "?"
+        out.append(f"- {name}  [{origin}]  updated={session.updated_at or '?'}")
+        out.append(f"    cwd: {session.cwd or '?'}")
+        out.append(
+            f"    msgs={session.agent_message_count}  last: {_truncate(session.last_agent_message)}"
+        )
+        for flag in session_flags.get(session.rollout_path, []):
+            out.append(f"    ⚠ {flag}")
+    out.append("")
+
+    out.append(f"## Automation ledgers ({len(ledgers)})")
+    if not ledgers:
+        out.append("  (none in window)")
+    for entry in ledgers:
+        target = f"PR #{entry.pr}" if entry.pr is not None else "(no PR target)"
+        head = f" @ {entry.head[:12]}" if entry.head else ""
+        out.append(f"- [{entry.automation}] {entry.kind or '?'} -> {target}{head}")
+        if entry.reason:
+            out.append(f"    reason: {_truncate(entry.reason)}")
+        if entry.git_head and entry.git_origin_main and entry.git_head != entry.git_origin_main:
+            out.append(
+                f"    ⚠ git.head {entry.git_head[:12]} != origin/main {entry.git_origin_main[:12]}"
+            )
+        if entry.runner_blockers:
+            out.append(f"    ⚠ runner_blockers: {entry.runner_blockers}")
+        if entry.forbidden_actions:
+            out.append(f"    forbidden: {', '.join(entry.forbidden_actions)}")
+        for flag in ledger_flags.get(entry.pr, []) if entry.pr is not None else []:
+            out.append(f"    ⚠ {flag}")
+    out.append("")
+
+    return "\n".join(out)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--codex-home",
+        type=Path,
+        default=None,
+        help="Codex home (default: $ARAGORA_CODEX_HOME or ~/.codex)",
+    )
+    parser.add_argument(
+        "--hours", type=float, default=24.0, help="Recency window in hours (0 = all)"
+    )
+    parser.add_argument("--limit", type=int, default=50, help="Max sessions to show")
+    parser.add_argument(
+        "--live", action="store_true", help="Cross-check target PRs against gh (read-only)"
+    )
+    parser.add_argument("--repo", default="synaptent/aragora", help="Repo for --live gh checks")
+    parser.add_argument(
+        "--shared-root",
+        default=None,
+        help="Main worktree path to flag as dirt-risk (default: $ARAGORA_SHARED_ROOT or git common dir)",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of text")
+    args = parser.parse_args(argv)
+
+    home = args.codex_home or default_codex_home()
+    hours = None if args.hours == 0 else args.hours
+    shared_root = args.shared_root or _default_shared_root()
+
+    sessions = recent_sessions(home, hours=hours, limit=args.limit)
+    ledgers = read_ledgers(home, hours=hours)
+    session_flags = _session_flags(sessions, shared_root)
+    ledger_flags = _live_ledger_flags(ledgers, args.repo) if args.live else {}
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "codex_home": str(home),
+                    "hours": hours,
+                    "sessions": [s.to_dict() for s in sessions],
+                    "ledgers": [entry.to_dict() for entry in ledgers],
+                    "session_flags": session_flags,
+                    "ledger_flags": {str(k): v for k, v in ledger_flags.items()},
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(
+            _render_text(
+                home=home,
+                hours=hours,
+                sessions=sessions,
+                ledgers=ledgers,
+                session_flags=session_flags,
+                ledger_flags=ledger_flags,
+            )
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/wire_codex_steering.py
+++ b/scripts/wire_codex_steering.py
@@ -32,7 +32,10 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from aragora.swarm.agent_bridge.codex_source import default_codex_home  # noqa: E402
 from aragora.swarm.agent_bridge.codex_steer import default_mailbox_path  # noqa: E402
 
-_MARKER = "aragora_steering"  # presence => already wired (idempotency anchor)
+# Idempotency anchor: a deliberate token always present in the injected clause,
+# independent of the (configurable) mailbox path -- so a custom --mailbox without
+# "aragora_steering" in it still can't cause a re-append on re-run.
+_MARKER = "OPERATOR STEERING (Phase-0)"
 
 
 def _steering_clause(mailbox: Path) -> str:
@@ -110,7 +113,8 @@ def main(argv: list[str] | None = None) -> int:
         if args.dry_run:
             print(f"  WOULD wire  {automation_dir.name}")
         else:
-            backup = toml_path.with_suffix(f".toml.bak-{int(time.time())}")
+            # Nanosecond suffix so two runs within the same second don't clobber backups.
+            backup = toml_path.with_suffix(f".toml.bak-{time.time_ns()}")
             backup.write_text(toml_path.read_text(encoding="utf-8"), encoding="utf-8")
             toml_path.write_text(tomli_w.dumps(cfg), encoding="utf-8")
             print(f"  wired {automation_dir.name}  (backup: {backup.name})")

--- a/scripts/wire_codex_steering.py
+++ b/scripts/wire_codex_steering.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Wire local Codex automations to honor the Aragora steering mailbox at Phase-0.
+
+Appends one idempotent clause to each qualifying ``automation.toml`` prompt
+instructing the automation to read the advisory steering mailbox
+(:func:`aragora.swarm.agent_bridge.codex_steer.default_mailbox_path`) before
+acting, and to treat any directive there as ADDITIONAL caution for that cycle.
+
+The mailbox is monotonic-restrictive by construction (see ``codex_steer``), so a
+wired automation can only ever become *more* conservative -- it never gains a
+way to merge, mark-ready, rerun CI, or settle Tier-4. The merge-quorum gate
+stays the sole merge authority.
+
+Safe to re-run: each file is skipped if already wired, and every modified file
+is backed up to ``automation.toml.bak-<epoch>`` first. Use ``--dry-run`` to
+preview. Defaults target ACTIVE automations whose cwd is an Aragora checkout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+import tomllib
+from pathlib import Path
+
+import tomli_w
+
+# Allow running as a bare script from anywhere in the repo.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from aragora.swarm.agent_bridge.codex_source import default_codex_home  # noqa: E402
+from aragora.swarm.agent_bridge.codex_steer import default_mailbox_path  # noqa: E402
+
+_MARKER = "aragora_steering"  # presence => already wired (idempotency anchor)
+
+
+def _steering_clause(mailbox: Path) -> str:
+    return (
+        " ADDITIONAL OPERATOR STEERING (Phase-0): Before selecting or acting on anything, "
+        f"read the operator steering mailbox at {mailbox} (JSONL; ignore if absent or empty). "
+        "Treat every directive there as ADDITIONAL caution for THIS cycle only: add its "
+        "add_forbidden_actions to your forbidden actions, treat its off_limits_prs as PRs you "
+        "must not touch, and honor its note. These directives can ONLY restrict -- they never "
+        "authorize a merge, --admin, mark-ready, CI rerun, or Tier 4 settlement; the "
+        "merge-quorum gate remains the sole merge authority."
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--automations-dir",
+        type=Path,
+        default=default_codex_home() / "automations",
+        help="Codex automations directory (default: <codex_home>/automations)",
+    )
+    parser.add_argument(
+        "--mailbox", type=Path, default=default_mailbox_path(), help="Steering mailbox path"
+    )
+    parser.add_argument(
+        "--filter-cwd",
+        default="Development/aragora",
+        help="Only wire automations whose cwd contains this substring",
+    )
+    parser.add_argument(
+        "--include-inactive", action="store_true", help="Also wire non-ACTIVE automations"
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Preview without writing")
+    args = parser.parse_args(argv)
+
+    clause = _steering_clause(args.mailbox)
+    if not args.automations_dir.is_dir():
+        print(f"no automations dir: {args.automations_dir}")
+        return 1
+
+    wired = skipped = 0
+    for automation_dir in sorted(args.automations_dir.iterdir()):
+        toml_path = automation_dir / "automation.toml"
+        if not toml_path.is_file():
+            continue
+        try:
+            cfg = tomllib.loads(toml_path.read_text(encoding="utf-8"))
+        except (OSError, tomllib.TOMLDecodeError) as exc:
+            print(f"  [parse-error] {automation_dir.name}: {exc}")
+            continue
+
+        prompt = cfg.get("prompt")
+        if not isinstance(prompt, str):
+            continue
+        status = cfg.get("status")
+        cwds = cfg.get("cwds", [])
+        matches_cwd = any(args.filter_cwd in str(c) for c in cwds)
+        active = status == "ACTIVE"
+
+        reason = None
+        if _MARKER in prompt:
+            reason = "already wired"
+        elif not matches_cwd:
+            reason = f"cwd !~ {args.filter_cwd!r}"
+        elif not active and not args.include_inactive:
+            reason = f"status={status}"
+        if reason is not None:
+            print(f"  skip  {automation_dir.name:42s} ({reason})")
+            skipped += 1
+            continue
+
+        cfg["prompt"] = prompt + clause
+        cfg["updated_at"] = int(time.time() * 1000)
+        if args.dry_run:
+            print(f"  WOULD wire  {automation_dir.name}")
+        else:
+            backup = toml_path.with_suffix(f".toml.bak-{int(time.time())}")
+            backup.write_text(toml_path.read_text(encoding="utf-8"), encoding="utf-8")
+            toml_path.write_text(tomli_w.dumps(cfg), encoding="utf-8")
+            print(f"  wired {automation_dir.name}  (backup: {backup.name})")
+        wired += 1
+
+    verb = "would wire" if args.dry_run else "wired"
+    print(f"\n{verb} {wired}, skipped {skipped}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/swarm/agent_bridge/test_codex_source.py
+++ b/tests/swarm/agent_bridge/test_codex_source.py
@@ -1,0 +1,225 @@
+"""Tests for read-only Codex session/automation ingest (codex_source).
+
+Synthetic temp Codex homes only -- no dependency on a real ~/.codex. Verifies
+parsing, recency filtering, thread-name join, ledger extraction, and the
+defensive contract that malformed lines never raise.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC
+from datetime import datetime
+from pathlib import Path
+
+from aragora.swarm.agent_bridge import codex_source as cs
+
+NOW = datetime(2026, 6, 15, 21, 0, 0, tzinfo=UTC)
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8")
+
+
+def _rollout(home: Path, *, day: str, ts: str, session_id: str, records: list[dict]) -> Path:
+    year, month, dd = day.split("-")
+    path = home / "sessions" / year / month / dd / f"rollout-{ts}-{session_id}.jsonl"
+    _write_jsonl(path, records)
+    return path
+
+
+def test_summarize_rollout_extracts_meta_and_last_message(tmp_path: Path) -> None:
+    home = tmp_path / ".codex"
+    path = _rollout(
+        home,
+        day="2026-06-15",
+        ts="2026-06-15T15-40-37",
+        session_id="019ecd03-aaaa",
+        records=[
+            {
+                "timestamp": "2026-06-15T20:40:46.911Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": "019ecd03-aaaa",
+                    "cwd": "/work/.codex/worktrees/d48e/aragora",
+                    "originator": "Codex Desktop",
+                    "model_provider": "openai",
+                    "timestamp": "2026-06-15T20:40:37.152Z",
+                },
+            },
+            {
+                "timestamp": "2026-06-15T20:41:00Z",
+                "type": "event_msg",
+                "payload": {"type": "agent_message", "message": "first thing"},
+            },
+            {
+                "timestamp": "2026-06-15T20:42:00Z",
+                "type": "event_msg",
+                "payload": {"type": "agent_message", "message": "  last thing  "},
+            },
+        ],
+    )
+    summary = cs.summarize_rollout(path)
+    assert summary is not None
+    assert summary.session_id == "019ecd03-aaaa"
+    assert summary.cwd == "/work/.codex/worktrees/d48e/aragora"
+    assert summary.originator == "Codex Desktop"
+    assert summary.model_provider == "openai"
+    assert summary.agent_message_count == 2
+    assert summary.last_agent_message == "last thing"
+    assert summary.updated_at == "2026-06-15T20:42:00Z"
+
+
+def test_recent_sessions_filters_by_window_and_joins_thread_name(tmp_path: Path) -> None:
+    home = tmp_path / ".codex"
+    _rollout(
+        home,
+        day="2026-06-15",
+        ts="2026-06-15T20-40-00",
+        session_id="recent-1",
+        records=[
+            {
+                "timestamp": "2026-06-15T20:50:00Z",
+                "type": "session_meta",
+                "payload": {"id": "recent-1", "cwd": "/repo", "originator": "Codex Desktop"},
+            }
+        ],
+    )
+    _rollout(
+        home,
+        day="2026-06-13",
+        ts="2026-06-13T01-00-00",
+        session_id="old-1",
+        records=[
+            {
+                "timestamp": "2026-06-13T01:00:00Z",
+                "type": "session_meta",
+                "payload": {"id": "old-1", "cwd": "/repo"},
+            }
+        ],
+    )
+    _write_jsonl(
+        home / "session_index.jsonl",
+        [{"id": "recent-1", "thread_name": "Repo hygiene", "updated_at": "2026-06-15T20:50:00Z"}],
+    )
+
+    out = cs.recent_sessions(home, hours=6.0, now=NOW)
+    ids = [s.session_id for s in out]
+    assert ids == ["recent-1"]  # old-1 is outside the 6h window
+    assert out[0].thread_name == "Repo hygiene"
+
+
+def test_recent_sessions_no_window_returns_all(tmp_path: Path) -> None:
+    home = tmp_path / ".codex"
+    _rollout(
+        home,
+        day="2026-06-13",
+        ts="2026-06-13T01-00-00",
+        session_id="old-1",
+        records=[
+            {
+                "timestamp": "2026-06-13T01:00:00Z",
+                "type": "session_meta",
+                "payload": {"id": "old-1", "cwd": "/repo"},
+            }
+        ],
+    )
+    out = cs.recent_sessions(home, hours=None, now=NOW)
+    assert [s.session_id for s in out] == ["old-1"]
+
+
+def test_malformed_lines_are_skipped_not_raised(tmp_path: Path) -> None:
+    home = tmp_path / ".codex"
+    path = home / "sessions" / "2026" / "06" / "15" / "rollout-2026-06-15T20-40-00-bad.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "not json at all\n"
+        + json.dumps(
+            {
+                "timestamp": "2026-06-15T20:50:00Z",
+                "type": "session_meta",
+                "payload": {"id": "bad", "cwd": "/repo"},
+            }
+        )
+        + "\n{ truncated half-written line",
+        encoding="utf-8",
+    )
+    summary = cs.summarize_rollout(path)
+    assert summary is not None
+    assert summary.session_id == "bad"
+
+
+def test_rollout_without_meta_falls_back_to_filename_id(tmp_path: Path) -> None:
+    home = tmp_path / ".codex"
+    path = _rollout(
+        home,
+        day="2026-06-15",
+        ts="2026-06-15T20-40-00",
+        session_id="from-filename",
+        records=[{"timestamp": "2026-06-15T20:50:00Z", "type": "event_msg", "payload": {}}],
+    )
+    summary = cs.summarize_rollout(path)
+    assert summary is not None
+    # No session_meta -> id falls back to the filename stem (timestamp+uuid),
+    # which still uniquely identifies the rollout.
+    assert summary.session_id == "2026-06-15T20-40-00-from-filename"
+
+
+def test_read_ledgers_extracts_structured_fields(tmp_path: Path) -> None:
+    home = tmp_path / ".codex"
+    _write_jsonl(
+        home / "automations" / "overnight-conductor" / "ledger.jsonl",
+        [
+            {
+                "action": {
+                    "kind": "merge_ready_prompt",
+                    "reason": "first mergeable non-draft PR",
+                    "target": {
+                        "pr": 8436,
+                        "head": "bd238556853d8d7afa8c19cea1e599d0730d5984",
+                        "branch": "dependabot/x",
+                        "url": "https://github.com/synaptent/aragora/pull/8436",
+                    },
+                },
+                "forbidden_actions": ["merge", "mark_ready"],
+                "git": {"head": "abc", "origin_main": "abc", "status_ok": True},
+                "summary": {"open_pr_count": 10, "runner_blockers": []},
+                "generated_at": "2026-06-15T20:14:49+00:00",
+                "repo_root": "/tmp/cycle/aragora",
+            }
+        ],
+    )
+    out = cs.read_ledgers(home, hours=24.0, now=NOW)
+    assert len(out) == 1
+    entry = out[0]
+    assert entry.automation == "overnight-conductor"
+    assert entry.pr == 8436
+    assert entry.head.startswith("bd23855")
+    assert entry.forbidden_actions == ["merge", "mark_ready"]
+    assert entry.open_pr_count == 10
+    assert entry.git_status_ok is True
+
+
+def test_read_ledgers_window_filters_old_records(tmp_path: Path) -> None:
+    home = tmp_path / ".codex"
+    _write_jsonl(
+        home / "automations" / "stale" / "ledger.jsonl",
+        [{"action": {"kind": "x"}, "generated_at": "2026-06-10T00:00:00Z"}],
+    )
+    assert cs.read_ledgers(home, hours=12.0, now=NOW) == []
+
+
+def test_parse_iso_handles_z_naive_and_garbage() -> None:
+    assert cs._parse_iso("2026-06-15T20:40:46.911Z") is not None
+    naive = cs._parse_iso("2026-06-15T20:40:46")
+    assert naive is not None and naive.tzinfo is UTC
+    assert cs._parse_iso("not a date") is None
+    assert cs._parse_iso(None) is None
+
+
+def test_missing_codex_home_returns_empty(tmp_path: Path) -> None:
+    home = tmp_path / "does-not-exist"
+    assert cs.recent_sessions(home, now=NOW) == []
+    assert cs.read_ledgers(home, now=NOW) == []
+    assert cs.read_session_index(home) == {}

--- a/tests/swarm/agent_bridge/test_codex_steer.py
+++ b/tests/swarm/agent_bridge/test_codex_steer.py
@@ -1,0 +1,133 @@
+"""Tests for the advisory, monotonic-restrictive Codex steer-back channel.
+
+The central property under test: a steering directive can only ever ADD caution.
+``effective_forbidden_actions`` is always a superset of the caller's baseline,
+non-steerable tokens are rejected, and a malformed directive on disk is dropped
+(which can never loosen the posture).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from aragora.swarm.agent_bridge import codex_steer as st
+
+NOW = datetime(2026, 6, 15, 21, 0, 0, tzinfo=UTC)
+
+
+def _directive(**kwargs) -> st.SteeringDirective:
+    base = {"issued_by": "claude", "issued_at": "2026-06-15T20:55:00Z"}
+    base.update(kwargs)
+    return st.SteeringDirective(**base)
+
+
+def test_write_then_read_roundtrip(tmp_path: Path) -> None:
+    mailbox = tmp_path / "mailbox.jsonl"
+    st.write_directive(
+        _directive(add_forbidden_actions=["merge"], note="hold off"), mailbox_path=mailbox
+    )
+    out = st.read_directives(mailbox_path=mailbox, hours=24.0, now=NOW)
+    assert len(out) == 1
+    assert out[0].add_forbidden_actions == ["merge"]
+    assert out[0].note == "hold off"
+
+
+def test_non_steerable_action_is_rejected() -> None:
+    with pytest.raises(st.SteeringValidationError):
+        _directive(add_forbidden_actions=["grant_admin"])  # not in the vocabulary
+
+
+def test_effective_forbidden_actions_is_always_a_superset() -> None:
+    base = ["merge"]
+    directives = [_directive(add_forbidden_actions=["mark_ready", "rerun_required_ci"])]
+    effective = st.effective_forbidden_actions(base, directives)
+    assert set(base).issubset(set(effective))
+    assert "mark_ready" in effective and "rerun_required_ci" in effective
+
+
+def test_effective_forbidden_actions_cannot_remove_baseline() -> None:
+    # Even with no directives, the baseline is preserved exactly (no shrink path).
+    base = ["merge", "mutate_branch_protection"]
+    assert set(base).issubset(set(st.effective_forbidden_actions(base, [])))
+
+
+def test_target_pr_scopes_the_directive() -> None:
+    directives = [_directive(add_forbidden_actions=["merge"], target_pr=8444)]
+    # Applies to the matching PR...
+    assert "merge" in st.effective_forbidden_actions([], directives, pr=8444)
+    # ...but not to a different PR.
+    assert "merge" not in st.effective_forbidden_actions([], directives, pr=8405)
+
+
+def test_global_directive_applies_to_every_pr() -> None:
+    directives = [_directive(add_forbidden_actions=["merge"], target_pr=None)]
+    assert "merge" in st.effective_forbidden_actions([], directives, pr=999)
+    assert "merge" in st.effective_forbidden_actions([], directives, pr=None)
+
+
+def test_off_limits_pr_gets_full_steerable_set() -> None:
+    directives = [_directive(off_limits_prs=[8446])]
+    effective = st.effective_forbidden_actions([], directives, pr=8446)
+    assert st.STEERABLE_FORBIDDEN_ACTIONS.issubset(set(effective))
+    # A non-pinned PR is unaffected.
+    assert st.effective_forbidden_actions([], directives, pr=1) == []
+
+
+def test_malformed_directive_on_disk_is_dropped_not_loosening(tmp_path: Path) -> None:
+    mailbox = tmp_path / "mailbox.jsonl"
+    mailbox.write_text(
+        "garbage line\n"
+        + json.dumps(
+            {
+                "issued_by": "x",
+                "issued_at": "2026-06-15T20:55:00Z",
+                "add_forbidden_actions": ["unknown_token"],
+            }
+        )  # invalid -> dropped
+        + "\n"
+        + json.dumps(
+            {
+                "issued_by": "claude",
+                "issued_at": "2026-06-15T20:56:00Z",
+                "add_forbidden_actions": ["merge"],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    out = st.read_directives(mailbox_path=mailbox, hours=24.0, now=NOW)
+    assert len(out) == 1
+    assert out[0].add_forbidden_actions == ["merge"]
+
+
+def test_read_directives_window_filters_old(tmp_path: Path) -> None:
+    mailbox = tmp_path / "mailbox.jsonl"
+    st.write_directive(
+        _directive(add_forbidden_actions=["merge"], issued_at="2026-06-10T00:00:00Z"),
+        mailbox_path=mailbox,
+    )
+    assert st.read_directives(mailbox_path=mailbox, hours=12.0, now=NOW) == []
+
+
+def test_render_phase0_block_empty_without_directives() -> None:
+    assert st.render_phase0_block([]) == ""
+
+
+def test_render_phase0_block_includes_pins_actions_and_note() -> None:
+    directives = [
+        _directive(add_forbidden_actions=["merge"], off_limits_prs=[8446], note="fusion lane"),
+    ]
+    block = st.render_phase0_block(directives, pr=8446)
+    assert "OFF-LIMITS" in block and "8446" in block
+    assert "fusion lane" in block
+    assert "sole merge authority" in block
+
+
+def test_off_limits_prs_rejects_nonpositive() -> None:
+    with pytest.raises(st.SteeringValidationError):
+        _directive(off_limits_prs=[0])


### PR DESCRIPTION
## What

A local, repo-clean bridge to **observe** a sibling Codex (Desktop/CLI) agent and **advise** it — without copy-pasting transcripts and without ever being able to loosen a gate.

- **Ingest (read-only):** `aragora/swarm/agent_bridge/codex_source.py` parses `~/.codex` `sessions/`, `session_index.jsonl`, and `automations/*/ledger.jsonl` into typed summaries. Defensive — malformed/half-written lines are skipped, never raised (Codex appends concurrently).
- **Steer-back (advisory):** `aragora/swarm/agent_bridge/codex_steer.py` — a mailbox the Codex automations read at Phase-0. **Monotonic-restrictive, enforced in code:** `effective_forbidden_actions()` returns a *superset* of the caller's baseline by construction, the action vocabulary is a fixed restrictive set, and there is **no field** that can grant a permission / authorize merge / `--admin` / Tier-4 settlement. A malformed or hostile mailbox write can only add caution. The merge-quorum gate stays the sole merge authority.
- **Digest CLI:** `scripts/codex_bridge_digest.py --hours 8 --live` — what each Codex session did + where, ledger steering records, and watchlist flags; `--live` cross-checks target PRs against `gh` to flag stale-head / already-merged steering prompts.
- **Gate:** `enable_codex_bridge` feature flag, **default OFF**, gates orchestration use. The one-shot digest needs no flag — it touches nothing.

## Repo stays useful to others

Generic + opt-in: inert without Codex installed. Paths via `ARAGORA_CODEX_HOME` / `ARAGORA_SHARED_ROOT` / `ARAGORA_CODEX_STEER_MAILBOX`; shared-root dirt-risk path derived portably (env or git common dir). Operator-specific glue (launchd, real paths) stays out of the repo.

## Verified live

Run against a real `~/.codex`, the digest surfaced 8 active Codex sessions, flagged two operating directly on the shared root, and `--live` caught conductor prompts targeting already-merged PRs (#8436/#8424).

## Tests

21 focused tests (synthetic temp homes only; no real `~/.codex` dependency). `mypy`, `ruff`, portability guard all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)