### PR TITLE
feat(orchestrator): pure foundation — TaskRoutingContext + OperationalModeSelector

### DIFF
--- a/aragora/modes/selector.py
+++ b/aragora/modes/selector.py
@@ -1,0 +1,165 @@
+"""Execution-pattern selection for the hybrid orchestrator.
+
+Picks *how* a unit of work should be executed -- which of three orchestration
+patterns best fits -- distinct from aragora's operational :class:`~aragora.modes.base.Mode`
+(Architect/Coder/RedTeam/...), which shapes *what* an agent may do.
+
+The three patterns map to existing executors:
+
+* ``DYNAMIC_WORKFLOW`` -> ``aragora/workflow/engine.py`` -- adaptive, decomposable,
+  deterministic multi-step work; the lowest-overhead default.
+* ``GOAL_ANCHORED``    -> ``aragora/nomic/autonomous_orchestrator.py`` -- abstract,
+  open-ended goals ("improve X") needing decomposition + parallel tracks.
+* ``AGENT_TEAMS``      -> ``aragora/debate/orchestrator.py`` (Arena) -- decisions
+  needing adversarial consensus; reserved for risk/consensus/contested work
+  because it is the most expensive executor.
+
+This module is **pure and deterministic** -- no I/O, no model calls -- so it is
+unit-testable and safe to ship unwired. ``goal_abstractness`` and
+``complexity_score`` are inputs the caller supplies (e.g. from ``DomainDetector``);
+``estimate_goal_abstractness`` offers a keyword fallback. Per the project's "use
+real intelligence, not regex" principle the heuristic is the *fallback*: an
+opt-in LLM-as-judge path is the intended steady state (a follow-on), and the
+heuristic exists so the feature ships and degrades safely.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class OrchestrationPattern(Enum):
+    """How a unit of work is executed. (Distinct from ``workflow.types.ExecutionPattern``.)"""
+
+    DYNAMIC_WORKFLOW = "dynamic_workflow"
+    GOAL_ANCHORED = "goal_anchored"
+    AGENT_TEAMS = "agent_teams"
+
+
+# Informational map pattern -> executor module (no import; documentation/telemetry only).
+EXECUTOR_MODULES: dict[OrchestrationPattern, str] = {
+    OrchestrationPattern.DYNAMIC_WORKFLOW: "aragora.workflow.engine",
+    OrchestrationPattern.GOAL_ANCHORED: "aragora.nomic.autonomous_orchestrator",
+    OrchestrationPattern.AGENT_TEAMS: "aragora.debate.orchestrator",
+}
+
+_ABSTRACT_GOAL_MARKERS = (
+    "maximize",
+    "minimize",
+    "improve",
+    "optimize",
+    "enhance",
+    "make better",
+    "increase",
+    "reduce",
+)
+
+
+def estimate_goal_abstractness(task_text: str) -> float:
+    """Heuristic 0-1 abstractness for a task description (fallback only).
+
+    Open-ended optimization verbs without a concrete deliverable read as
+    abstract; an imperative with a concrete object reads as concrete. This is a
+    deliberate keyword fallback -- the intended steady state is an LLM judge.
+    """
+    text = (task_text or "").strip().lower()
+    if not text:
+        return 0.0
+    return 0.7 if any(marker in text for marker in _ABSTRACT_GOAL_MARKERS) else 0.0
+
+
+@dataclass(frozen=True)
+class ModeDecisionContext:
+    """Inputs to pattern selection. All optional with safe defaults for testing.
+
+    ``risk_tier`` 0-4 (PR/goal classification). ``complexity_score`` 0-10.
+    ``goal_abstractness`` 0-1. The booleans are cheap structural signals the
+    caller already has from intake/classification.
+    """
+
+    task_text: str = ""
+    risk_tier: int = 0
+    consensus_required: bool = False
+    complexity_score: float = 0.0
+    goal_abstractness: float = 0.0
+    is_code_change: bool = False
+    is_design: bool = False
+    involves_error: bool = False
+    domain: str = "general"
+    prior_pattern: OrchestrationPattern | None = None
+
+    def __post_init__(self) -> None:
+        if not 0 <= self.risk_tier <= 4:
+            raise ValueError("risk_tier must be in [0, 4]")
+        if not 0.0 <= self.complexity_score <= 10.0:
+            raise ValueError("complexity_score must be in [0, 10]")
+        if not 0.0 <= self.goal_abstractness <= 1.0:
+            raise ValueError("goal_abstractness must be in [0, 1]")
+
+
+@dataclass(frozen=True)
+class PatternDecision:
+    """Result of pattern selection."""
+
+    pattern: OrchestrationPattern
+    confidence: float
+    rationale: str
+
+    @property
+    def executor_module(self) -> str:
+        return EXECUTOR_MODULES[self.pattern]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "pattern": self.pattern.value,
+            "confidence": self.confidence,
+            "rationale": self.rationale,
+            "executor_module": self.executor_module,
+        }
+
+
+class OperationalModeSelector:
+    """Deterministic execution-pattern selector.
+
+    Ordering reserves the expensive ``AGENT_TEAMS`` pattern for work that
+    genuinely needs adversarial vetting (risk/consensus/contested/design/error/
+    very-complex) and defaults everything else to the lowest-overhead
+    ``DYNAMIC_WORKFLOW`` -- so an unclassified medium task never silently lands
+    on the most expensive executor.
+    """
+
+    def select_pattern(self, ctx: ModeDecisionContext) -> PatternDecision:
+        # 1. Hard safety override: high-risk or explicitly contested -> teams.
+        if ctx.risk_tier >= 3 or ctx.consensus_required:
+            return PatternDecision(
+                OrchestrationPattern.AGENT_TEAMS, 0.95, "risk/consensus gate -> adversarial teams"
+            )
+
+        # 2. Genuine decisions / design / error-diagnosis / very complex -> teams.
+        if ctx.is_design or ctx.involves_error or ctx.complexity_score >= 8.0:
+            return PatternDecision(
+                OrchestrationPattern.AGENT_TEAMS,
+                0.8,
+                "contested correctness -> adversarial vetting",
+            )
+
+        # 3. Abstract, open-ended, non-code goals -> goal-anchored decomposition.
+        if ctx.goal_abstractness >= 0.6 and not ctx.is_code_change:
+            return PatternDecision(
+                OrchestrationPattern.GOAL_ANCHORED, 0.8, "abstract goal needs decomposition"
+            )
+
+        # 4. Structured, decomposable, deterministic multi-step -> dynamic workflow.
+        if 3.0 <= ctx.complexity_score <= 7.0:
+            return PatternDecision(
+                OrchestrationPattern.DYNAMIC_WORKFLOW, 0.7, "structured multi-step task"
+            )
+
+        # 5. Default: lowest-overhead pattern (never default to the costly teams path).
+        #    A prior successful pattern (KM hint) breaks ties when present.
+        if ctx.prior_pattern is not None:
+            return PatternDecision(ctx.prior_pattern, 0.55, "default with prior-outcome tiebreaker")
+        return PatternDecision(
+            OrchestrationPattern.DYNAMIC_WORKFLOW, 0.6, "default: lowest-overhead pattern"
+        )

--- a/aragora/routing/config.py
+++ b/aragora/routing/config.py
@@ -54,6 +54,58 @@ class GatewayRoutingConfig:
         )
 
 
+@dataclass(frozen=True)
+class TaskRoutingContext:
+    """Per-unit-of-work routing inputs for the hybrid orchestrator.
+
+    Carries the signals the Pareto model-router and mode-selector both need so a
+    single unit of work can be (a) assigned an execution pattern and (b) routed
+    to a cost/quality/latency-optimal model. Pure data -- no behavior, no I/O.
+
+    Fields:
+      - ``complexity_score``: 0-10, typically from ``DomainDetector`` complexity
+        estimation; higher means more reasoning-heavy.
+      - ``budget_usd``: optional per-unit spend cap; ``None`` means uncapped.
+      - ``latency_ms_sla``: optional soft latency target; ``None`` means none.
+      - ``quality_floor``: 0-1 minimum acceptable quality for candidate models.
+      - ``diversity_preference``: 0-1 weight favoring heterogeneous model sets
+        (matters for multi-agent/team patterns; ignored for single-model work).
+    """
+
+    task_id: str
+    domain: str
+    complexity_score: float = 0.0
+    budget_usd: float | None = None
+    latency_ms_sla: float | None = None
+    quality_floor: float = 0.0
+    diversity_preference: float = 0.0
+
+    def __post_init__(self) -> None:
+        if not self.task_id:
+            raise ValueError("task_id must be non-empty")
+        if not 0.0 <= self.complexity_score <= 10.0:
+            raise ValueError("complexity_score must be in [0, 10]")
+        if not 0.0 <= self.quality_floor <= 1.0:
+            raise ValueError("quality_floor must be in [0, 1]")
+        if not 0.0 <= self.diversity_preference <= 1.0:
+            raise ValueError("diversity_preference must be in [0, 1]")
+        if self.budget_usd is not None and self.budget_usd < 0:
+            raise ValueError("budget_usd must be non-negative or None")
+        if self.latency_ms_sla is not None and self.latency_ms_sla <= 0:
+            raise ValueError("latency_ms_sla must be positive or None")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "task_id": self.task_id,
+            "domain": self.domain,
+            "complexity_score": self.complexity_score,
+            "budget_usd": self.budget_usd,
+            "latency_ms_sla": self.latency_ms_sla,
+            "quality_floor": self.quality_floor,
+            "diversity_preference": self.diversity_preference,
+        }
+
+
 def _parse_csv(value: str | None) -> set[str]:
     if not value:
         return set()
@@ -118,13 +170,16 @@ def load_gateway_routing_config() -> GatewayRoutingConfig:
         300,
     )
 
+    # Pass parsed sets directly: __post_init__ applies defaults for an empty set
+    # exactly as it does for None (``self.x or set(_DEF)``), so this is
+    # behavior-preserving and keeps the arg type ``set[str]`` (not ``set[str] | None``).
     return GatewayRoutingConfig(
         financial_threshold=financial_threshold,
-        risk_levels=risk_levels or None,
-        compliance_flags=compliance_flags or None,
+        risk_levels=risk_levels,
+        compliance_flags=compliance_flags,
         stakeholder_threshold=stakeholder_threshold,
-        require_debate_keywords=require_debate_keywords or None,
-        require_execute_keywords=require_execute_keywords or None,
+        require_debate_keywords=require_debate_keywords,
+        require_execute_keywords=require_execute_keywords,
         time_sensitive_threshold_seconds=time_sensitive_threshold_seconds,
         confidence_threshold=confidence_threshold,
         cache_ttl_seconds=cache_ttl_seconds,

--- a/tests/modes/test_selector.py
+++ b/tests/modes/test_selector.py
@@ -1,0 +1,120 @@
+"""Tests for the execution-pattern selector (pure, deterministic)."""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.modes.selector import (
+    EXECUTOR_MODULES,
+    ModeDecisionContext,
+    OperationalModeSelector,
+    OrchestrationPattern,
+    PatternDecision,
+    estimate_goal_abstractness,
+)
+
+SELECTOR = OperationalModeSelector()
+
+
+def _pick(**kwargs: object) -> PatternDecision:
+    return SELECTOR.select_pattern(ModeDecisionContext(**kwargs))  # type: ignore[arg-type]
+
+
+def test_high_risk_forces_agent_teams() -> None:
+    d = _pick(risk_tier=3, complexity_score=1.0)
+    assert d.pattern is OrchestrationPattern.AGENT_TEAMS
+    assert d.confidence >= 0.9
+
+
+def test_consensus_required_forces_agent_teams() -> None:
+    d = _pick(consensus_required=True, complexity_score=1.0)
+    assert d.pattern is OrchestrationPattern.AGENT_TEAMS
+
+
+def test_design_routes_to_agent_teams() -> None:
+    assert _pick(is_design=True, complexity_score=2.0).pattern is OrchestrationPattern.AGENT_TEAMS
+
+
+def test_error_diagnosis_routes_to_agent_teams() -> None:
+    assert _pick(involves_error=True).pattern is OrchestrationPattern.AGENT_TEAMS
+
+
+def test_very_high_complexity_routes_to_agent_teams() -> None:
+    assert _pick(complexity_score=9.0).pattern is OrchestrationPattern.AGENT_TEAMS
+
+
+def test_abstract_noncode_goal_routes_to_goal_anchored() -> None:
+    d = _pick(goal_abstractness=0.7, is_code_change=False, complexity_score=2.0)
+    assert d.pattern is OrchestrationPattern.GOAL_ANCHORED
+
+
+def test_abstract_but_code_change_does_not_take_goal_anchored() -> None:
+    # Abstract phrasing on a concrete code change should not become goal_anchored.
+    d = _pick(goal_abstractness=0.7, is_code_change=True, complexity_score=1.0)
+    assert d.pattern is not OrchestrationPattern.GOAL_ANCHORED
+
+
+def test_structured_medium_complexity_routes_to_dynamic_workflow() -> None:
+    assert _pick(complexity_score=5.0).pattern is OrchestrationPattern.DYNAMIC_WORKFLOW
+
+
+def test_default_is_dynamic_workflow_not_agent_teams() -> None:
+    # Critique fix: an unclassified low-complexity task must NOT default to the
+    # most expensive executor.
+    d = _pick(complexity_score=1.0)
+    assert d.pattern is OrchestrationPattern.DYNAMIC_WORKFLOW
+
+
+def test_prior_pattern_breaks_tie_in_default_branch() -> None:
+    d = _pick(complexity_score=1.0, prior_pattern=OrchestrationPattern.GOAL_ANCHORED)
+    assert d.pattern is OrchestrationPattern.GOAL_ANCHORED
+    assert "prior" in d.rationale.lower()
+
+
+def test_risk_gate_precedes_prior_pattern() -> None:
+    # Safety override wins even if a prior pattern hint is present.
+    d = _pick(risk_tier=4, prior_pattern=OrchestrationPattern.DYNAMIC_WORKFLOW)
+    assert d.pattern is OrchestrationPattern.AGENT_TEAMS
+
+
+def test_decision_is_deterministic() -> None:
+    ctx = ModeDecisionContext(complexity_score=5.0, domain="software")
+    assert SELECTOR.select_pattern(ctx).pattern is SELECTOR.select_pattern(ctx).pattern
+
+
+def test_executor_module_mapping_complete() -> None:
+    for pattern in OrchestrationPattern:
+        assert pattern in EXECUTOR_MODULES
+    d = _pick(complexity_score=5.0)
+    assert d.executor_module == EXECUTOR_MODULES[OrchestrationPattern.DYNAMIC_WORKFLOW]
+
+
+def test_to_dict_shape() -> None:
+    d = _pick(complexity_score=5.0).to_dict()
+    assert set(d) == {"pattern", "confidence", "rationale", "executor_module"}
+    assert d["pattern"] == "dynamic_workflow"
+
+
+@pytest.mark.parametrize(
+    "text,expected_high",
+    [
+        ("maximize SME utility", True),
+        ("optimize the cache", True),
+        ("add a login button", False),
+        ("", False),
+    ],
+)
+def test_estimate_goal_abstractness(text: str, expected_high: bool) -> None:
+    score = estimate_goal_abstractness(text)
+    assert (score >= 0.6) is expected_high
+
+
+@pytest.mark.parametrize("bad", [-1, 5])
+def test_invalid_risk_tier_rejected(bad: int) -> None:
+    with pytest.raises(ValueError, match="risk_tier"):
+        ModeDecisionContext(risk_tier=bad)
+
+
+def test_invalid_complexity_rejected() -> None:
+    with pytest.raises(ValueError, match="complexity_score"):
+        ModeDecisionContext(complexity_score=11.0)

--- a/tests/routing/test_task_routing_context.py
+++ b/tests/routing/test_task_routing_context.py
@@ -1,0 +1,81 @@
+"""Tests for TaskRoutingContext (pure routing-input dataclass)."""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.routing.config import TaskRoutingContext
+
+
+def test_minimal_construction_and_defaults() -> None:
+    ctx = TaskRoutingContext(task_id="t1", domain="software")
+    assert ctx.task_id == "t1"
+    assert ctx.domain == "software"
+    assert ctx.complexity_score == 0.0
+    assert ctx.budget_usd is None
+    assert ctx.latency_ms_sla is None
+    assert ctx.quality_floor == 0.0
+    assert ctx.diversity_preference == 0.0
+
+
+def test_frozen_is_immutable() -> None:
+    ctx = TaskRoutingContext(task_id="t1", domain="software")
+    with pytest.raises(Exception):
+        ctx.task_id = "other"  # type: ignore[misc]
+
+
+def test_to_dict_roundtrip_shape() -> None:
+    ctx = TaskRoutingContext(
+        task_id="t1",
+        domain="legal",
+        complexity_score=6.5,
+        budget_usd=1.25,
+        latency_ms_sla=2000.0,
+        quality_floor=0.7,
+        diversity_preference=0.4,
+    )
+    d = ctx.to_dict()
+    assert d == {
+        "task_id": "t1",
+        "domain": "legal",
+        "complexity_score": 6.5,
+        "budget_usd": 1.25,
+        "latency_ms_sla": 2000.0,
+        "quality_floor": 0.7,
+        "diversity_preference": 0.4,
+    }
+
+
+def test_empty_task_id_rejected() -> None:
+    with pytest.raises(ValueError, match="task_id"):
+        TaskRoutingContext(task_id="", domain="software")
+
+
+@pytest.mark.parametrize("bad", [-0.1, 10.1, 99.0])
+def test_complexity_out_of_range_rejected(bad: float) -> None:
+    with pytest.raises(ValueError, match="complexity_score"):
+        TaskRoutingContext(task_id="t1", domain="d", complexity_score=bad)
+
+
+@pytest.mark.parametrize("bad", [-0.01, 1.01])
+def test_quality_floor_out_of_range_rejected(bad: float) -> None:
+    with pytest.raises(ValueError, match="quality_floor"):
+        TaskRoutingContext(task_id="t1", domain="d", quality_floor=bad)
+
+
+def test_diversity_out_of_range_rejected() -> None:
+    with pytest.raises(ValueError, match="diversity_preference"):
+        TaskRoutingContext(task_id="t1", domain="d", diversity_preference=2.0)
+
+
+def test_negative_budget_rejected_but_none_ok() -> None:
+    with pytest.raises(ValueError, match="budget_usd"):
+        TaskRoutingContext(task_id="t1", domain="d", budget_usd=-5.0)
+    assert TaskRoutingContext(task_id="t1", domain="d", budget_usd=None).budget_usd is None
+    assert TaskRoutingContext(task_id="t1", domain="d", budget_usd=0.0).budget_usd == 0.0
+
+
+def test_nonpositive_latency_rejected_but_none_ok() -> None:
+    with pytest.raises(ValueError, match="latency_ms_sla"):
+        TaskRoutingContext(task_id="t1", domain="d", latency_ms_sla=0.0)
+    assert TaskRoutingContext(task_id="t1", domain="d", latency_ms_sla=None).latency_ms_sla is None


### PR DESCRIPTION
First two PRs of the hybrid-orchestrator program (plan: [#8458](https://github.com/synaptent/aragora/pull/8458), `docs/plans/2026-06-15-hybrid-orchestrator.md`). Both **pure, deterministic, and UNWIRED** — no caller imports them, so zero behavior risk.

- **`routing/config.py` → `TaskRoutingContext`**: per-unit routing inputs (domain, complexity 0-10, `budget_usd`, latency SLA, `quality_floor` 0-1, diversity) with range validation + `to_dict`.
- **`modes/selector.py` → `OperationalModeSelector`**: deterministic pick of an `OrchestrationPattern` (`dynamic_workflow` / `goal_anchored` / `agent_teams`). Named `OrchestrationPattern` to avoid colliding with `workflow.types.ExecutionPattern`. **Per the design critique:** defaults to the lowest-overhead `dynamic_workflow` and reserves the expensive `agent_teams` for explicit risk/consensus/contested/design/error/very-complex triggers — no silent default to the costly executor.

Also fixes 4 **pre-existing latent** `set[str] | None` arg-type errors in `load_gateway_routing_config` that this PR's touch surfaced to the changed-file typecheck (behavior-preserving: `__post_init__` treats an empty set identically to `None`).

**Tests:** 33 new (validation + every decision branch + determinism), config behavior preserved (14 pass). mypy / ruff / typecheck-changed all clean.

Next in the program: #1 Fusion slug+pricing verify (needs OPENROUTER_API_KEY), then the wiring PRs (#13 orchestrator seam behind `enable_hybrid_routing`, OFF).

🤖 Generated with [Claude Code](https://claude.com/claude-code)