### PR TITLE
feat(nomic): native mission contracts — MissionSpec + WorkItem front-door (PR #1)

### DIFF
--- a/aragora/config/feature_flags.py
+++ b/aragora/config/feature_flags.py
@@ -442,6 +442,20 @@ class FeatureFlagRegistry:
 
     def _register_builtin_flags(self) -> None:
         """Register all built-in feature flags."""
+        # Native mission orchestrator (set-a-goal, walk-away; see
+        # docs/plans/2026-06-16-native-mission-orchestrator.md). Default OFF and
+        # EXPERIMENTAL: gates the long-running engine wiring that lands in later
+        # PRs. The MissionSpec/WorkItem contracts (aragora/nomic/mission.py) are
+        # inert data until this is enabled.
+        self.register(
+            "enable_native_mission",
+            bool,
+            False,
+            "Enable the native mission orchestrator (nomic goal-intake -> boss_loop engine)",
+            FlagCategory.EXPERIMENTAL,
+            FlagStatus.BETA,
+            env_var="ARAGORA_ENABLE_NATIVE_MISSION",
+        )
         # OpenRouter Fusion (multi-model council+judge). All default OFF: Fusion
         # is ~4-5x cost and must be an explicit opt-in. Downstream phases
         # (planning/verify/quorum tie-break) gate on their own flags so each can

--- a/aragora/nomic/mission.py
+++ b/aragora/nomic/mission.py
@@ -1,0 +1,153 @@
+"""Native mission contracts — the front door for "set a goal, walk away".
+
+Pure data + a pure adapter, intentionally UNWIRED. This is PR #1 of the native
+mission orchestrator (docs/plans/2026-06-16-native-mission-orchestrator.md):
+the typed ``MissionSpec`` front-door plus the ``WorkItem`` queue shape and a
+deterministic adapter from nomic's decomposition output. No execution, no I/O,
+no model calls here — the long-running engine (boss_loop tick loop), the
+relay-with-timeout, and the model transport land in later PRs and gate on the
+``enable_native_mission`` flag (default OFF). Nothing imports this yet, so it
+cannot change any behavior.
+
+Design intent (recorded so later PRs hold the line):
+- Runs on SUBSCRIPTIONS by default (``MissionTransport.CLI`` = 1 Claude Max +
+  1 Codex Max, MCP-disabled). ``MissionTransport.API`` is an optional scale
+  lever, not a prerequisite.
+- ``auto_settle_max_tier`` bounds what the mission may settle autonomously on a
+  passing model quorum; higher-tier items PARK for the operator. The
+  merge-quorum gate remains the sole settlement authority — the mission never
+  bypasses it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+
+class MissionTransport(Enum):
+    """How the mission drives models. CLI (subscriptions) is the default."""
+
+    CLI = "cli"  # subscription CLIs: claude -p (MCP-disabled) + codex exec, 1 sub/provider
+    API = "api"  # optional scale lever: api_agents via Secrets Manager
+
+
+class WorkItemStatus(Enum):
+    PENDING = "pending"
+    RUNNING = "running"
+    DONE = "done"
+    PARKED = "parked"  # blocked/needs-human; mission continues OTHER items
+    FAILED = "failed"
+
+
+_RELAY_CHANNELS = frozenset({"none", "slack", "email"})
+
+
+@dataclass(frozen=True)
+class MissionSpec:
+    """A high-level goal plus the bounds under which the mission may pursue it."""
+
+    goal: str
+    mission_id: str
+    acceptance_criteria: tuple[str, ...] = ()
+    budget_usd: float | None = None
+    max_hours: float | None = None
+    transport: MissionTransport = MissionTransport.CLI
+    relay: str = "none"
+    auto_settle_max_tier: int = 2
+
+    def __post_init__(self) -> None:
+        if not self.goal.strip():
+            raise ValueError("goal must be non-empty")
+        if not self.mission_id.strip():
+            raise ValueError("mission_id must be non-empty")
+        if self.budget_usd is not None and self.budget_usd < 0:
+            raise ValueError("budget_usd must be non-negative or None")
+        if self.max_hours is not None and self.max_hours <= 0:
+            raise ValueError("max_hours must be positive or None")
+        if self.relay not in _RELAY_CHANNELS:
+            raise ValueError(f"relay must be one of {sorted(_RELAY_CHANNELS)}")
+        if not 0 <= self.auto_settle_max_tier <= 4:
+            raise ValueError("auto_settle_max_tier must be in [0, 4]")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "goal": self.goal,
+            "mission_id": self.mission_id,
+            "acceptance_criteria": list(self.acceptance_criteria),
+            "budget_usd": self.budget_usd,
+            "max_hours": self.max_hours,
+            "transport": self.transport.value,
+            "relay": self.relay,
+            "auto_settle_max_tier": self.auto_settle_max_tier,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "MissionSpec":
+        raw_criteria = payload.get("acceptance_criteria", [])
+        criteria = tuple(str(c) for c in raw_criteria) if isinstance(raw_criteria, list) else ()
+        transport_raw = payload.get("transport", MissionTransport.CLI.value)
+        return cls(
+            goal=str(payload["goal"]),
+            mission_id=str(payload["mission_id"]),
+            acceptance_criteria=criteria,
+            budget_usd=payload.get("budget_usd"),
+            max_hours=payload.get("max_hours"),
+            transport=MissionTransport(transport_raw),
+            relay=str(payload.get("relay", "none")),
+            auto_settle_max_tier=int(payload.get("auto_settle_max_tier", 2)),
+        )
+
+
+@dataclass(frozen=True)
+class WorkItem:
+    """One unit of mission work. The internal queue replaces the GitHub-issue gate."""
+
+    item_id: str
+    description: str
+    status: WorkItemStatus = WorkItemStatus.PENDING
+    complexity: str = "low"  # low|medium|high, from decomposition (NOT the merge tier)
+    file_scope: tuple[str, ...] = ()
+    dependencies: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "item_id": self.item_id,
+            "description": self.description,
+            "status": self.status.value,
+            "complexity": self.complexity,
+            "file_scope": list(self.file_scope),
+            "dependencies": list(self.dependencies),
+        }
+
+
+def work_items_from_subtasks(subtasks: Iterable[Any]) -> tuple[WorkItem, ...]:
+    """Adapt nomic decomposition output into a PENDING work-item queue.
+
+    Accepts ``SubTask`` (``aragora.nomic.task_decomposer``) or any structurally
+    compatible object exposing ``id``, ``title``/``description``,
+    ``estimated_complexity``, ``file_scope``, ``dependencies``. Pure and
+    deterministic — order preserved, no I/O. Items with no usable id are skipped
+    rather than raising, so a malformed decomposition can't crash the front door.
+    """
+    items: list[WorkItem] = []
+    for st in subtasks:
+        item_id = str(getattr(st, "id", "") or "")
+        if not item_id:
+            continue
+        description = str(getattr(st, "description", "") or getattr(st, "title", "") or "")
+        complexity = str(getattr(st, "estimated_complexity", "low") or "low")
+        file_scope = tuple(str(f) for f in (getattr(st, "file_scope", ()) or ()))
+        dependencies = tuple(str(d) for d in (getattr(st, "dependencies", ()) or ()))
+        items.append(
+            WorkItem(
+                item_id=item_id,
+                description=description,
+                complexity=complexity,
+                file_scope=file_scope,
+                dependencies=dependencies,
+            )
+        )
+    return tuple(items)

--- a/tests/nomic/test_mission.py
+++ b/tests/nomic/test_mission.py
@@ -1,0 +1,141 @@
+"""Tests for the native mission contracts (pure data + adapter)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from aragora.config.feature_flags import FeatureFlagRegistry
+from aragora.nomic.mission import (
+    MissionSpec,
+    MissionTransport,
+    WorkItem,
+    WorkItemStatus,
+    work_items_from_subtasks,
+)
+
+
+def _spec(**kw: object) -> MissionSpec:
+    base: dict[str, object] = {"goal": "improve X", "mission_id": "m1"}
+    base.update(kw)
+    return MissionSpec(**base)  # type: ignore[arg-type]
+
+
+def test_minimal_spec_defaults() -> None:
+    s = _spec()
+    assert s.transport is MissionTransport.CLI  # subscriptions by default
+    assert s.relay == "none"
+    assert s.auto_settle_max_tier == 2
+    assert s.budget_usd is None and s.max_hours is None
+
+
+def test_spec_frozen() -> None:
+    s = _spec()
+    with pytest.raises(Exception):
+        s.goal = "other"  # type: ignore[misc]
+
+
+def test_empty_goal_and_id_rejected() -> None:
+    with pytest.raises(ValueError, match="goal"):
+        _spec(goal="   ")
+    with pytest.raises(ValueError, match="mission_id"):
+        _spec(mission_id="")
+
+
+@pytest.mark.parametrize("bad", [-1.0])
+def test_negative_budget_rejected(bad: float) -> None:
+    with pytest.raises(ValueError, match="budget_usd"):
+        _spec(budget_usd=bad)
+    assert _spec(budget_usd=0.0).budget_usd == 0.0
+
+
+def test_nonpositive_max_hours_rejected() -> None:
+    with pytest.raises(ValueError, match="max_hours"):
+        _spec(max_hours=0.0)
+    assert _spec(max_hours=7.0).max_hours == 7.0
+
+
+def test_invalid_relay_rejected() -> None:
+    with pytest.raises(ValueError, match="relay"):
+        _spec(relay="carrier-pigeon")
+    for ok in ("none", "slack", "email"):
+        assert _spec(relay=ok).relay == ok
+
+
+@pytest.mark.parametrize("bad", [-1, 5])
+def test_auto_settle_tier_range(bad: int) -> None:
+    with pytest.raises(ValueError, match="auto_settle_max_tier"):
+        _spec(auto_settle_max_tier=bad)
+
+
+def test_spec_dict_roundtrip() -> None:
+    s = _spec(
+        acceptance_criteria=("tests green", "wheel builds"),
+        budget_usd=12.5,
+        max_hours=6.0,
+        transport=MissionTransport.API,
+        relay="slack",
+        auto_settle_max_tier=1,
+    )
+    restored = MissionSpec.from_dict(s.to_dict())
+    assert restored == s
+
+
+def test_from_dict_tolerates_missing_optionals() -> None:
+    s = MissionSpec.from_dict({"goal": "g", "mission_id": "m"})
+    assert s.transport is MissionTransport.CLI and s.auto_settle_max_tier == 2
+
+
+@dataclass
+class _FakeSubTask:
+    id: str
+    title: str = ""
+    description: str = ""
+    estimated_complexity: str = "low"
+    file_scope: tuple[str, ...] = ()
+    dependencies: tuple[str, ...] = ()
+
+
+def test_work_items_from_subtasks_maps_fields_and_preserves_order() -> None:
+    subs = [
+        _FakeSubTask(
+            id="a",
+            description="do A",
+            estimated_complexity="high",
+            file_scope=("x.py",),
+            dependencies=(),
+        ),
+        _FakeSubTask(id="b", title="B title", estimated_complexity="medium", dependencies=("a",)),
+    ]
+    items = work_items_from_subtasks(subs)
+    assert [i.item_id for i in items] == ["a", "b"]
+    assert items[0].description == "do A" and items[0].complexity == "high"
+    assert items[0].file_scope == ("x.py",)
+    assert items[1].description == "B title"  # falls back to title
+    assert items[1].dependencies == ("a",)
+    assert all(i.status is WorkItemStatus.PENDING for i in items)
+
+
+def test_work_items_skips_idless_without_raising() -> None:
+    items = work_items_from_subtasks([_FakeSubTask(id=""), _FakeSubTask(id="ok")])
+    assert [i.item_id for i in items] == ["ok"]
+
+
+def test_work_item_to_dict_shape() -> None:
+    d = WorkItem(item_id="a", description="x").to_dict()
+    assert set(d) == {
+        "item_id",
+        "description",
+        "status",
+        "complexity",
+        "file_scope",
+        "dependencies",
+    }
+    assert d["status"] == "pending"
+
+
+def test_flag_registered_default_off(monkeypatch) -> None:
+    monkeypatch.delenv("ARAGORA_ENABLE_NATIVE_MISSION", raising=False)
+    reg = FeatureFlagRegistry()
+    assert reg.is_enabled("enable_native_mission") is False


### PR DESCRIPTION
**PR #1 of the native mission orchestrator** (plan: [#8463](https://github.com/synaptent/aragora/pull/8463), `docs/plans/2026-06-16-native-mission-orchestrator.md`). Pure data + a pure adapter, **intentionally UNWIRED** — nothing imports it yet, so **zero behavior change**.

- **`aragora/nomic/mission.py`**:
  - `MissionSpec` — the typed front door (goal / acceptance_criteria / budget_usd / max_hours / transport / relay / auto_settle_max_tier) with range validation + dict round-trip.
  - `WorkItem` + `WorkItemStatus` — the internal work-item queue shape that replaces the GitHub-issue gate (`PARKED` = blocked-needs-human; mission continues other items).
  - `work_items_from_subtasks()` — deterministic, duck-typed adapter from nomic `SubTask` decomposition → `PENDING` work items (order-preserving; skips id-less rather than raising).
- **`MissionTransport.CLI` is the default** — subscriptions (1 Claude Max `claude -p` MCP-disabled + 1 Codex Max `codex exec`). `API` is the optional scale lever, **not** a prerequisite (per the corrected halt analysis: subs run for hours; the wall was the outer harness).
- `auto_settle_max_tier` bounds autonomous settlement; **the merge-quorum gate stays the sole authority** — the mission never bypasses it.
- **`enable_native_mission` flag, default OFF / EXPERIMENTAL** — gates the engine wiring that lands in later PRs.

**Tests:** 14 (validation, dict round-trip, adapter mapping/fallback/skip, flag default-OFF). mypy / ruff / typecheck-changed clean.

Next on the critical path: PR #3 relay-with-timeout, PR #4 `aragora mission` CLI, PR #5 durable resume. (PR #2 API transport is optional.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)