### PR TITLE
feat(nomic): relay-with-timeout decision core for native mission (PR #3 core)

### DIFF
--- a/aragora/nomic/mission_relay.py
+++ b/aragora/nomic/mission_relay.py
@@ -1,0 +1,109 @@
+"""Relay-with-timeout decision core for the native mission orchestrator.
+
+The piece that stops a blocked item from halting the whole mission (and the
+operator from becoming a 3-minute relay). Pure and deterministic: given a
+policy + the observed state of one work item, it decides whether to keep going,
+**park the item and notify** (so the mission continues OTHER items), or stop the
+whole mission. No I/O, no notifications sent here — the actual Slack/email send
+and the boss_loop wiring land in a separate quiet-window PR (boss_loop.py drives
+the live loop and must not be edited while it is running).
+
+Hard invariant: the only outcomes are CONTINUE, PARK_AND_NOTIFY, or STOP_MISSION.
+There is NO outcome that merges, settles, or marks-ready anything — parking sets
+an item aside for the operator; the merge-quorum gate stays the sole authority.
+STOP_MISSION is reserved for genuine global limits (budget/time), never for a
+single blocked item.
+
+PR #3 of docs/plans/2026-06-16-native-mission-orchestrator.md (pure core only).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+
+class RelayAction(Enum):
+    CONTINUE = "continue"  # item healthy / transient — keep working it
+    PARK_AND_NOTIFY = (
+        "park_and_notify"  # set item aside + notify operator; mission continues others
+    )
+    STOP_MISSION = "stop_mission"  # global limit hit (budget/time) — wind the whole mission down
+
+
+@dataclass(frozen=True)
+class RelayPolicy:
+    """How tolerant the mission is before parking an item or stopping."""
+
+    max_item_failures: int = 3  # consecutive failures on one item -> park it
+    item_timeout_seconds: float | None = None  # per-item wall-clock cap -> park (None = no cap)
+    relay_channel: str = "none"  # where PARK notifications go: none|slack|email
+
+    def __post_init__(self) -> None:
+        if self.max_item_failures < 1:
+            raise ValueError("max_item_failures must be >= 1")
+        if self.item_timeout_seconds is not None and self.item_timeout_seconds <= 0:
+            raise ValueError("item_timeout_seconds must be positive or None")
+        if self.relay_channel not in {"none", "slack", "email"}:
+            raise ValueError("relay_channel must be one of none|slack|email")
+
+
+@dataclass(frozen=True)
+class RelayContext:
+    """Observed state for one work item at a decision point."""
+
+    item_id: str
+    consecutive_failures: int = 0
+    needs_human: bool = False
+    elapsed_seconds: float = 0.0
+    budget_exhausted: bool = False
+    max_hours_exceeded: bool = False
+
+
+@dataclass(frozen=True)
+class RelayDecision:
+    action: RelayAction
+    reason: str
+    notify: bool  # emit a relay notification (only meaningful when channel != "none")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"action": self.action.value, "reason": self.reason, "notify": self.notify}
+
+
+def decide_relay_action(policy: RelayPolicy, ctx: RelayContext) -> RelayDecision:
+    """Decide the relay action for one item. Pure; global limits take precedence.
+
+    Order: (1) global budget/time limits -> STOP_MISSION; (2) per-item
+    needs-human / repeated-failure / timeout -> PARK_AND_NOTIFY (mission keeps
+    running other items); (3) otherwise CONTINUE. A PARK notifies only when a
+    real channel is configured.
+    """
+    # (1) Global limits stop the whole mission — these are the only STOP causes.
+    if ctx.budget_exhausted:
+        return RelayDecision(RelayAction.STOP_MISSION, "budget exhausted", notify=True)
+    if ctx.max_hours_exceeded:
+        return RelayDecision(RelayAction.STOP_MISSION, "max_hours exceeded", notify=True)
+
+    # (2) Per-item blocks PARK the item (never STOP the mission, never merge/settle).
+    notify = policy.relay_channel != "none"
+    if ctx.needs_human:
+        return RelayDecision(RelayAction.PARK_AND_NOTIFY, "item needs human", notify=notify)
+    if ctx.consecutive_failures >= policy.max_item_failures:
+        return RelayDecision(
+            RelayAction.PARK_AND_NOTIFY,
+            f"item hit {ctx.consecutive_failures} consecutive failures (>= {policy.max_item_failures})",
+            notify=notify,
+        )
+    if (
+        policy.item_timeout_seconds is not None
+        and ctx.elapsed_seconds >= policy.item_timeout_seconds
+    ):
+        return RelayDecision(
+            RelayAction.PARK_AND_NOTIFY,
+            f"item exceeded timeout {policy.item_timeout_seconds}s",
+            notify=notify,
+        )
+
+    # (3) Healthy / transient — keep working it.
+    return RelayDecision(RelayAction.CONTINUE, "item healthy", notify=False)

--- a/tests/nomic/test_mission_relay.py
+++ b/tests/nomic/test_mission_relay.py
@@ -1,0 +1,108 @@
+"""Tests for the relay-with-timeout decision core (pure, deterministic)."""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.nomic.mission_relay import (
+    RelayAction,
+    RelayContext,
+    RelayDecision,
+    RelayPolicy,
+    decide_relay_action,
+)
+
+
+def test_healthy_item_continues() -> None:
+    d = decide_relay_action(RelayPolicy(), RelayContext(item_id="a"))
+    assert d.action is RelayAction.CONTINUE
+    assert d.notify is False
+
+
+def test_needs_human_parks_not_stops() -> None:
+    # The core behavior: a blocked item PARKS (mission continues others), never STOPS.
+    d = decide_relay_action(
+        RelayPolicy(relay_channel="slack"), RelayContext(item_id="a", needs_human=True)
+    )
+    assert d.action is RelayAction.PARK_AND_NOTIFY
+    assert d.notify is True
+
+
+def test_park_notify_false_when_channel_none() -> None:
+    d = decide_relay_action(
+        RelayPolicy(relay_channel="none"), RelayContext(item_id="a", needs_human=True)
+    )
+    assert d.action is RelayAction.PARK_AND_NOTIFY
+    assert d.notify is False  # parked, but nowhere to notify
+
+
+def test_failures_threshold_parks() -> None:
+    pol = RelayPolicy(max_item_failures=3, relay_channel="email")
+    assert (
+        decide_relay_action(pol, RelayContext(item_id="a", consecutive_failures=2)).action
+        is RelayAction.CONTINUE
+    )
+    d = decide_relay_action(pol, RelayContext(item_id="a", consecutive_failures=3))
+    assert d.action is RelayAction.PARK_AND_NOTIFY and d.notify is True
+
+
+def test_item_timeout_parks() -> None:
+    pol = RelayPolicy(item_timeout_seconds=120.0)
+    assert (
+        decide_relay_action(pol, RelayContext(item_id="a", elapsed_seconds=119.0)).action
+        is RelayAction.CONTINUE
+    )
+    assert (
+        decide_relay_action(pol, RelayContext(item_id="a", elapsed_seconds=120.0)).action
+        is RelayAction.PARK_AND_NOTIFY
+    )
+
+
+def test_no_timeout_when_unset() -> None:
+    d = decide_relay_action(
+        RelayPolicy(item_timeout_seconds=None), RelayContext(item_id="a", elapsed_seconds=1e9)
+    )
+    assert d.action is RelayAction.CONTINUE
+
+
+def test_budget_exhausted_stops_mission() -> None:
+    d = decide_relay_action(RelayPolicy(), RelayContext(item_id="a", budget_exhausted=True))
+    assert d.action is RelayAction.STOP_MISSION
+
+
+def test_max_hours_exceeded_stops_mission() -> None:
+    d = decide_relay_action(RelayPolicy(), RelayContext(item_id="a", max_hours_exceeded=True))
+    assert d.action is RelayAction.STOP_MISSION
+
+
+def test_global_limit_precedes_item_block() -> None:
+    # Budget exhaustion wins even if the item also needs a human.
+    d = decide_relay_action(
+        RelayPolicy(), RelayContext(item_id="a", needs_human=True, budget_exhausted=True)
+    )
+    assert d.action is RelayAction.STOP_MISSION
+
+
+def test_no_action_ever_merges_or_settles() -> None:
+    # Invariant: the action vocabulary is exactly {continue, park, stop} — nothing
+    # that could merge/settle/mark-ready. Guards against future scope creep.
+    assert {a.value for a in RelayAction} == {"continue", "park_and_notify", "stop_mission"}
+
+
+def test_policy_validation() -> None:
+    with pytest.raises(ValueError, match="max_item_failures"):
+        RelayPolicy(max_item_failures=0)
+    with pytest.raises(ValueError, match="item_timeout_seconds"):
+        RelayPolicy(item_timeout_seconds=0.0)
+    with pytest.raises(ValueError, match="relay_channel"):
+        RelayPolicy(relay_channel="fax")
+
+
+def test_decision_to_dict() -> None:
+    d: RelayDecision = decide_relay_action(RelayPolicy(), RelayContext(item_id="a"))
+    assert d.to_dict() == {"action": "continue", "reason": "item healthy", "notify": False}
+
+
+def test_deterministic() -> None:
+    pol, ctx = RelayPolicy(relay_channel="slack"), RelayContext(item_id="a", needs_human=True)
+    assert decide_relay_action(pol, ctx) == decide_relay_action(pol, ctx)


### PR DESCRIPTION
**PR #3 (pure core) of the native mission orchestrator** (plan: [#8463](https://github.com/synaptent/aragora/pull/8463)). The piece that ends the 3-minute relay: a blocked item **parks and notifies** instead of halting the whole mission.

- **`aragora/nomic/mission_relay.py`**: `RelayPolicy` (`max_item_failures`, `item_timeout_seconds`, `relay_channel`) + `RelayContext` + `decide_relay_action() → RelayDecision`.
  - Global **budget/time** limits → `STOP_MISSION`.
  - Per-item **needs-human / repeated-failure / timeout** → `PARK_AND_NOTIFY` — **mission continues other items**; operator gets an async notification, no blocking wait.
  - Else → `CONTINUE`.
- **Hard invariant (tested):** the action vocabulary is exactly `{continue, park_and_notify, stop_mission}` — **no outcome can merge / settle / mark-ready.** Parking sets an item aside for the operator; the merge-quorum gate stays the sole authority. `STOP_MISSION` is reserved for global limits, never a single blocked item.

**Pure, deterministic, UNWIRED.** Does **not** touch `boss_loop.py` — that drives your live loop (running right now) and per the Factory-mission precedent its edits need a quiet window. The wiring (this core + the actual Slack/email send into the loop) is a separate quiet-window PR.

**Tests:** 13 (continue/park/stop paths, precedence, channel gating, policy validation, the no-merge invariant). mypy / ruff / typecheck-changed clean. Branches independently from main.

Companion to PR #1 contracts ([#8465](https://github.com/synaptent/aragora/pull/8465)). Next: `aragora mission` CLI (#4, stacks on #8465) + durable resume (#5); boss_loop wiring deferred to a quiet window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)