### PR TITLE
feat(swarm): drain-mode decision core for the boss loop

### DIFF
--- a/aragora/swarm/drain_policy.py
+++ b/aragora/swarm/drain_policy.py
@@ -1,0 +1,110 @@
+"""Drain-mode decision core for the boss loop.
+
+When the open-PR queue is over its backpressure cap, the boss loop should DRAIN
+the queue instead of idling or generating more issues. This is the pure,
+deterministic heart of that behavior: given one open PR's observed state, decide
+whether to MERGE it, REPAIR it (dispatch a worker to fix a useful-but-red PR),
+CLOSE it (only if TRULY superseded), or LEAVE it alone. No I/O — the caller
+gathers PR state (gh/merge-packet) and performs the chosen action; the boss_loop
+wiring lands in a separate PR (boss_loop.py is large and drives the live loop).
+
+Encodes the operator's rule verbatim:
+- "Repair and merge useful work; close ONLY truly-entirely-superseded PRs."
+  -> CLOSE_SUPERSEDED requires has_changes is False OR an explicit superseded
+     flag. A merely-red PR is REPAIR, never CLOSE.
+- "Don't interfere with Factory." -> off_limits or owned_by_other_agent always
+  LEAVE — the drainer never touches a PR another fleet owns or one pinned
+  off-limits via the steering mailbox.
+- The merge-quorum gate stays the sole settlement authority: MERGE requires
+  green required checks + a supportive 2-family quorum + mergeable + a tier
+  within the autonomous-settle bound; anything above that bound LEAVEs for the
+  operator (never auto-merged).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+
+class DrainAction(Enum):
+    MERGE = "merge"  # green + quorum + mergeable + in-bound tier -> land via the gate
+    REPAIR = "repair"  # useful but red/near-green -> dispatch a repair worker
+    CLOSE_SUPERSEDED = "close_superseded"  # TRULY superseded (empty/dup/landed) -> close
+    LEAVE = "leave"  # owned/off-limits/over-tier/in-flight -> do not touch
+
+
+@dataclass(frozen=True)
+class DrainPolicy:
+    """Bounds for autonomous draining."""
+
+    auto_settle_max_tier: int = 2  # tiers 0..N may auto-merge; above -> LEAVE for human
+
+    def __post_init__(self) -> None:
+        if not 0 <= self.auto_settle_max_tier <= 4:
+            raise ValueError("auto_settle_max_tier must be in [0, 4]")
+
+
+@dataclass(frozen=True)
+class DrainCandidate:
+    """Observed state of one open PR at a drain decision point."""
+
+    pr: int
+    has_changes: bool = True  # changed_files > 0 (False => empty => superseded)
+    superseded: bool = False  # explicitly superseded (exact-dup / fully landed elsewhere)
+    off_limits: bool = False  # pinned off-limits (e.g. Factory's branch) -> never touch
+    owned_by_other_agent: bool = False  # a live owner is driving it -> never touch
+    required_checks_green: bool = False
+    quorum_satisfied: bool = False  # 2-family supportive, no unresolved dissent
+    mergeable: bool = False  # no conflicts; head matches
+    tier: int = 0  # merge tier (0-4)
+
+
+@dataclass(frozen=True)
+class DrainDecision:
+    action: DrainAction
+    reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"action": self.action.value, "reason": self.reason}
+
+
+def decide_drain_action(policy: DrainPolicy, cand: DrainCandidate) -> DrainDecision:
+    """Decide what to do with one open PR while draining. Pure; precedence matters.
+
+    Order: (1) ownership/off-limits -> LEAVE (never collide with another fleet);
+    (2) truly-superseded -> CLOSE_SUPERSEDED; (3) green+quorum+mergeable+in-bound
+    tier -> MERGE; (4) over the autonomous-settle tier -> LEAVE for the operator;
+    (5) otherwise it is useful but not landable -> REPAIR.
+    """
+    # (1) Never touch another fleet's / off-limits PR — the anti-collision guarantee.
+    if cand.off_limits:
+        return DrainDecision(DrainAction.LEAVE, "pinned off-limits (e.g. Factory) — not touched")
+    if cand.owned_by_other_agent:
+        return DrainDecision(DrainAction.LEAVE, "a live owner is driving it — not touched")
+
+    # (2) CLOSE only when TRULY superseded (empty or explicitly superseded). Never close
+    #     a merely-red PR — that is repairable, useful work.
+    if not cand.has_changes:
+        return DrainDecision(DrainAction.CLOSE_SUPERSEDED, "empty (no changes) — truly superseded")
+    if cand.superseded:
+        return DrainDecision(DrainAction.CLOSE_SUPERSEDED, "explicitly superseded (dup/landed)")
+
+    # (3) Land it only if fully gated AND within the autonomous-settle tier.
+    if (
+        cand.required_checks_green
+        and cand.quorum_satisfied
+        and cand.mergeable
+        and cand.tier <= policy.auto_settle_max_tier
+    ):
+        return DrainDecision(DrainAction.MERGE, "green + quorum + mergeable + in-bound tier")
+
+    # (4) Gated work above the autonomous tier is the operator's call — never auto-merge.
+    if cand.tier > policy.auto_settle_max_tier:
+        return DrainDecision(
+            DrainAction.LEAVE, f"tier {cand.tier} > auto_settle_max_tier — parks for operator"
+        )
+
+    # (5) Useful work that isn't landable yet -> repair it (don't discard it).
+    return DrainDecision(DrainAction.REPAIR, "useful but not green/mergeable — dispatch repair")

--- a/tests/swarm/test_drain_policy.py
+++ b/tests/swarm/test_drain_policy.py
@@ -1,0 +1,107 @@
+"""Tests for the drain-mode decision core (pure, deterministic)."""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.swarm.drain_policy import (
+    DrainAction,
+    DrainCandidate,
+    DrainDecision,
+    DrainPolicy,
+    decide_drain_action,
+)
+
+POL = DrainPolicy(auto_settle_max_tier=2)
+
+
+def _green(**kw: object) -> DrainCandidate:
+    base: dict[str, object] = {
+        "pr": 1,
+        "has_changes": True,
+        "required_checks_green": True,
+        "quorum_satisfied": True,
+        "mergeable": True,
+        "tier": 0,
+    }
+    base.update(kw)
+    return DrainCandidate(**base)  # type: ignore[arg-type]
+
+
+def test_fully_gated_in_bound_tier_merges() -> None:
+    assert decide_drain_action(POL, _green()).action is DrainAction.MERGE
+
+
+def test_off_limits_always_left_untouched() -> None:
+    # The anti-Factory-collision guarantee: off-limits wins over everything.
+    d = decide_drain_action(POL, _green(off_limits=True))
+    assert d.action is DrainAction.LEAVE and "off-limits" in d.reason
+
+
+def test_owned_by_other_agent_left() -> None:
+    assert decide_drain_action(POL, _green(owned_by_other_agent=True)).action is DrainAction.LEAVE
+
+
+def test_empty_pr_closed_superseded() -> None:
+    d = decide_drain_action(POL, DrainCandidate(pr=2, has_changes=False))
+    assert d.action is DrainAction.CLOSE_SUPERSEDED
+
+
+def test_explicitly_superseded_closed() -> None:
+    d = decide_drain_action(POL, DrainCandidate(pr=2, has_changes=True, superseded=True))
+    assert d.action is DrainAction.CLOSE_SUPERSEDED
+
+
+def test_red_useful_pr_is_repaired_never_closed() -> None:
+    # The operator's rule: a merely-red useful PR is REPAIR, NOT close.
+    d = decide_drain_action(
+        POL, DrainCandidate(pr=3, has_changes=True, required_checks_green=False)
+    )
+    assert d.action is DrainAction.REPAIR
+
+
+def test_green_but_no_quorum_is_repaired() -> None:
+    d = decide_drain_action(POL, _green(quorum_satisfied=False))
+    assert d.action is DrainAction.REPAIR
+
+
+def test_green_but_not_mergeable_is_repaired() -> None:
+    d = decide_drain_action(POL, _green(mergeable=False))
+    assert d.action is DrainAction.REPAIR
+
+
+def test_over_tier_left_for_operator_never_auto_merged() -> None:
+    # Tier 3 is fully gated but above the autonomous bound -> LEAVE, never MERGE.
+    d = decide_drain_action(POL, _green(tier=3))
+    assert d.action is DrainAction.LEAVE and "operator" in d.reason
+
+
+def test_off_limits_precedes_superseded() -> None:
+    # Even an empty PR that's off-limits is left alone (don't act on another fleet's PR).
+    d = decide_drain_action(POL, DrainCandidate(pr=4, has_changes=False, off_limits=True))
+    assert d.action is DrainAction.LEAVE
+
+
+def test_close_requires_truly_superseded_not_just_red() -> None:
+    # Guard against scope creep: nothing closes a PR that merely has failing checks.
+    red = DrainCandidate(pr=5, has_changes=True, required_checks_green=False, tier=0)
+    assert decide_drain_action(POL, red).action is not DrainAction.CLOSE_SUPERSEDED
+
+
+def test_action_vocabulary_is_fixed() -> None:
+    assert {a.value for a in DrainAction} == {"merge", "repair", "close_superseded", "leave"}
+
+
+def test_policy_validation() -> None:
+    with pytest.raises(ValueError, match="auto_settle_max_tier"):
+        DrainPolicy(auto_settle_max_tier=5)
+
+
+def test_to_dict() -> None:
+    d: DrainDecision = decide_drain_action(POL, _green())
+    assert d.to_dict() == {"action": "merge", "reason": d.reason}
+
+
+def test_deterministic() -> None:
+    c = _green(tier=3)
+    assert decide_drain_action(POL, c) == decide_drain_action(POL, c)


### PR DESCRIPTION
The pure decision heart of **boss-loop drain mode**: when the open-PR queue is over its backpressure cap, drain instead of idle/generate. UNWIRED — `boss_loop.py` wiring lands as a focused follow-up (5.3K-line file; safe to edit now that the loop is stopped).

**`aragora/swarm/drain_policy.py`** — `decide_drain_action(policy, candidate) → {MERGE, REPAIR, CLOSE_SUPERSEDED, LEAVE}`, encoding the operator's rule verbatim:
- **CLOSE_SUPERSEDED only when `has_changes` is False OR explicitly superseded** — a merely-red useful PR is **REPAIR**, never closed. (Tested invariant: nothing closes a red PR.)
- **`off_limits` / `owned_by_other_agent` → LEAVE** — the drainer never touches Factory's or another fleet's PR. *This is the anti-interference guarantee.*
- **MERGE only when** green required checks + supportive 2-family quorum + mergeable + `tier ≤ auto_settle_max_tier`; above the bound → **LEAVE for the operator** (never auto-merged). The merge-quorum gate stays sole authority.

**Tests:** 15 (merge/repair/close/leave paths, off-limits precedence, never-close-a-red-PR, over-tier-never-merges, vocabulary lock). mypy / ruff / typecheck clean.

Companion to the native-mission relay core ([#8466](https://github.com/synaptent/aragora/pull/8466)) — together they make the loop *useful when over cap* (drain) and *non-halting on blocked items* (relay). Part of fixing the boss loop's "idle + manufacture noise" failure mode (root cause: 166 open PRs vs 60 cap, all maintenance work withheld).

🤖 Generated with [Claude Code](https://claude.com/claude-code)