### PR TITLE
feat(swarm): bounded drain-pass orchestrator (boss-loop drain wiring core)

### DIFF
--- a/aragora/swarm/drain_pass.py
+++ b/aragora/swarm/drain_pass.py
@@ -1,0 +1,154 @@
+"""Bounded drain-pass orchestrator for the boss loop.
+
+When the boss loop is over the open-PR cap (backpressure on), it should DRAIN the
+existing queue instead of idling or generating new work. This module is the pure
+orchestration core of that pass: given a batch of observed open-PR candidates, it
+applies :func:`aragora.swarm.drain_policy.decide_drain_action` to each, then
+executes the actionable decisions **under per-type caps and a priority order**,
+via an injected ``execute_fn`` (so the core stays pure and unit-testable; the
+boss_loop hook supplies the real gh merge/close/dispatch).
+
+Two properties matter for safety and for not making things worse:
+- **REPAIR is tightly bounded** (``max_repairs_per_pass``, default 2): a REPAIR
+  dispatches a worker, so 263 red PRs must NOT trigger 263 workers. Excess
+  actionable items are deferred to the next pass, so the queue drains gradually.
+- **LEAVE is never executed.** Off-limits (e.g. Factory's ``structex/*``),
+  other-agent-owned, and over-tier PRs are preserved untouched — the
+  anti-collision guarantee is enforced at the candidate level (``off_limits`` /
+  ``owned_by_other_agent``) and honored here by simply never acting on LEAVE.
+
+Priority when capped: MERGE first (lands work + drains), then CLOSE_SUPERSEDED
+(drains cheaply), then REPAIR (creates load — most bounded).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from collections.abc import Iterable
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Any
+
+from aragora.swarm.drain_policy import DrainAction
+from aragora.swarm.drain_policy import DrainCandidate
+from aragora.swarm.drain_policy import DrainPolicy
+from aragora.swarm.drain_policy import decide_drain_action
+
+# execute_fn(pr_number, action) -> True on success. Injected by the boss_loop hook.
+ExecuteFn = Callable[[int, DrainAction], bool]
+
+# Priority order when caps force a choice (earlier = preferred).
+_PRIORITY = (DrainAction.MERGE, DrainAction.CLOSE_SUPERSEDED, DrainAction.REPAIR)
+
+
+@dataclass(frozen=True)
+class DrainPassPolicy:
+    """Per-pass bounds. Wraps the per-candidate ``DrainPolicy``."""
+
+    drain: DrainPolicy = field(default_factory=DrainPolicy)
+    max_merges_per_pass: int = 5
+    max_closes_per_pass: int = 10
+    max_repairs_per_pass: int = 2  # worker dispatch — keep small to avoid a repair storm
+
+    def __post_init__(self) -> None:
+        for name in ("max_merges_per_pass", "max_closes_per_pass", "max_repairs_per_pass"):
+            if getattr(self, name) < 0:
+                raise ValueError(f"{name} must be >= 0")
+
+    def cap_for(self, action: DrainAction) -> int:
+        return {
+            DrainAction.MERGE: self.max_merges_per_pass,
+            DrainAction.CLOSE_SUPERSEDED: self.max_closes_per_pass,
+            DrainAction.REPAIR: self.max_repairs_per_pass,
+        }.get(action, 0)
+
+
+@dataclass(frozen=True)
+class PlannedAction:
+    pr: int
+    action: DrainAction
+    reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"pr": self.pr, "action": self.action.value, "reason": self.reason}
+
+
+@dataclass(frozen=True)
+class DrainPassResult:
+    planned: tuple[PlannedAction, ...]  # selected for action this pass (within caps)
+    deferred: tuple[PlannedAction, ...]  # actionable but cap-exceeded -> next pass
+    left: tuple[PlannedAction, ...]  # LEAVE decisions (off-limits/owned/over-tier)
+    executed: tuple[int, ...]
+    failed: tuple[int, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "planned": [p.to_dict() for p in self.planned],
+            "deferred": [p.to_dict() for p in self.deferred],
+            "left": [p.to_dict() for p in self.left],
+            "executed": list(self.executed),
+            "failed": list(self.failed),
+            "counts": {
+                "planned": len(self.planned),
+                "deferred": len(self.deferred),
+                "left": len(self.left),
+                "executed": len(self.executed),
+                "failed": len(self.failed),
+            },
+        }
+
+
+def plan_drain_pass(
+    policy: DrainPassPolicy, candidates: Iterable[DrainCandidate]
+) -> tuple[list[PlannedAction], list[PlannedAction], list[PlannedAction]]:
+    """Decide + bound, without executing. Returns ``(planned, deferred, left)``.
+
+    Deterministic: candidate order is preserved within each action bucket, and
+    per-type caps are applied in priority order. ``planned`` are the actions to
+    take this pass; ``deferred`` are actionable items that exceeded a cap (try
+    next pass); ``left`` are LEAVE decisions (never executed).
+    """
+    buckets: dict[DrainAction, list[PlannedAction]] = {a: [] for a in DrainAction}
+    for cand in candidates:
+        decision = decide_drain_action(policy.drain, cand)
+        buckets[decision.action].append(
+            PlannedAction(pr=cand.pr, action=decision.action, reason=decision.reason)
+        )
+
+    planned: list[PlannedAction] = []
+    deferred: list[PlannedAction] = []
+    for action in _PRIORITY:
+        cap = policy.cap_for(action)
+        items = buckets[action]
+        planned.extend(items[:cap])
+        deferred.extend(items[cap:])
+    left = list(buckets[DrainAction.LEAVE])
+    return planned, deferred, left
+
+
+def run_drain_pass(
+    policy: DrainPassPolicy,
+    candidates: Iterable[DrainCandidate],
+    execute_fn: ExecuteFn,
+) -> DrainPassResult:
+    """Plan then execute the planned actions via ``execute_fn``. LEAVE is never executed.
+
+    ``execute_fn`` returning falsy (or raising) marks that PR failed; one failure
+    never aborts the pass (the queue keeps draining).
+    """
+    planned, deferred, left = plan_drain_pass(policy, candidates)
+    executed: list[int] = []
+    failed: list[int] = []
+    for item in planned:
+        try:
+            ok = execute_fn(item.pr, item.action)
+        except Exception:  # noqa: BLE001 - injected callback; one bad PR must not abort the drain
+            ok = False
+        (executed if ok else failed).append(item.pr)
+    return DrainPassResult(
+        planned=tuple(planned),
+        deferred=tuple(deferred),
+        left=tuple(left),
+        executed=tuple(executed),
+        failed=tuple(failed),
+    )

--- a/tests/swarm/test_drain_pass.py
+++ b/tests/swarm/test_drain_pass.py
@@ -1,0 +1,143 @@
+"""Tests for the bounded drain-pass orchestrator (pure; injected execution)."""
+
+from __future__ import annotations
+
+from aragora.swarm.drain_pass import (
+    DrainPassPolicy,
+    plan_drain_pass,
+    run_drain_pass,
+)
+from aragora.swarm.drain_policy import DrainAction, DrainCandidate, DrainPolicy
+
+
+def _mergeable(pr: int, tier: int = 0) -> DrainCandidate:
+    return DrainCandidate(
+        pr=pr,
+        has_changes=True,
+        required_checks_green=True,
+        quorum_satisfied=True,
+        mergeable=True,
+        tier=tier,
+    )
+
+
+def _repairable(pr: int) -> DrainCandidate:
+    return DrainCandidate(pr=pr, has_changes=True, required_checks_green=False, mergeable=False)
+
+
+def test_leave_is_never_executed() -> None:
+    cands = [
+        DrainCandidate(pr=1, off_limits=True, has_changes=True),  # Factory branch
+        DrainCandidate(pr=2, owned_by_other_agent=True, has_changes=True),
+        _mergeable(3, tier=4),  # over auto_settle tier -> LEAVE
+    ]
+    calls: list[int] = []
+    res = run_drain_pass(DrainPassPolicy(), cands, lambda pr, a: calls.append(pr) or True)
+    assert calls == []  # nothing executed
+    assert {p.pr for p in res.left} == {1, 2, 3}
+
+
+def test_off_limits_factory_pr_left_even_if_green() -> None:
+    # A green, mergeable PR that is pinned off-limits must still be LEFT.
+    factory_pr = DrainCandidate(
+        pr=1,
+        off_limits=True,
+        has_changes=True,
+        required_checks_green=True,
+        quorum_satisfied=True,
+        mergeable=True,
+    )
+    res = run_drain_pass(DrainPassPolicy(), [factory_pr], lambda pr, a: True)
+    assert res.executed == ()
+    assert res.left[0].action is DrainAction.LEAVE
+
+
+def test_merge_close_repair_routed_and_executed() -> None:
+    cands = [
+        _mergeable(10),  # MERGE
+        DrainCandidate(pr=11, has_changes=False),  # empty -> CLOSE_SUPERSEDED
+        DrainCandidate(pr=12, has_changes=True, superseded=True),  # CLOSE_SUPERSEDED
+        _repairable(13),  # REPAIR
+    ]
+    seen: dict[int, DrainAction] = {}
+    res = run_drain_pass(DrainPassPolicy(), cands, lambda pr, a: seen.__setitem__(pr, a) or True)
+    assert seen[10] is DrainAction.MERGE
+    assert seen[11] is DrainAction.CLOSE_SUPERSEDED
+    assert seen[12] is DrainAction.CLOSE_SUPERSEDED
+    assert seen[13] is DrainAction.REPAIR
+    assert set(res.executed) == {10, 11, 12, 13}
+
+
+def test_repair_is_tightly_capped_no_storm() -> None:
+    # 50 repairable PRs, cap repairs at 2 -> only 2 planned, 48 deferred.
+    cands = [_repairable(100 + i) for i in range(50)]
+    policy = DrainPassPolicy(max_repairs_per_pass=2)
+    planned, deferred, left = plan_drain_pass(policy, cands)
+    assert len(planned) == 2
+    assert len(deferred) == 48
+    assert all(p.action is DrainAction.REPAIR for p in planned)
+
+
+def test_merge_cap_and_deferral() -> None:
+    cands = [_mergeable(200 + i) for i in range(9)]
+    policy = DrainPassPolicy(max_merges_per_pass=5)
+    planned, deferred, _ = plan_drain_pass(policy, cands)
+    assert len(planned) == 5
+    assert len(deferred) == 4
+
+
+def test_priority_order_merge_before_close_before_repair() -> None:
+    # Mixed batch; verify planned ordering follows MERGE -> CLOSE -> REPAIR.
+    cands = [
+        _repairable(1),
+        DrainCandidate(pr=2, has_changes=False),  # CLOSE
+        _mergeable(3),
+    ]
+    planned, _, _ = plan_drain_pass(DrainPassPolicy(), cands)
+    actions = [p.action for p in planned]
+    assert actions == [DrainAction.MERGE, DrainAction.CLOSE_SUPERSEDED, DrainAction.REPAIR]
+
+
+def test_execute_failure_does_not_abort_pass() -> None:
+    cands = [_mergeable(1), _mergeable(2), _mergeable(3)]
+
+    def flaky(pr: int, a: DrainAction) -> bool:
+        return pr != 2  # #2 "fails"
+
+    res = run_drain_pass(DrainPassPolicy(), cands, flaky)
+    assert set(res.executed) == {1, 3}
+    assert res.failed == (2,)
+
+
+def test_execute_exception_is_caught_as_failure() -> None:
+    def boom(pr: int, a: DrainAction) -> bool:
+        raise RuntimeError("gh down")
+
+    res = run_drain_pass(DrainPassPolicy(), [_mergeable(1)], boom)
+    assert res.failed == (1,)
+    assert res.executed == ()
+
+
+def test_tier_bound_respects_drain_policy() -> None:
+    # tier 3 with default auto_settle_max_tier=2 -> LEAVE (parks for operator).
+    res = run_drain_pass(
+        DrainPassPolicy(drain=DrainPolicy(auto_settle_max_tier=2)),
+        [_mergeable(1, tier=3)],
+        lambda pr, a: True,
+    )
+    assert res.executed == ()
+    assert res.left[0].pr == 1
+
+
+def test_negative_cap_rejected() -> None:
+    import pytest
+
+    with pytest.raises(ValueError, match="max_repairs_per_pass"):
+        DrainPassPolicy(max_repairs_per_pass=-1)
+
+
+def test_to_dict_shape() -> None:
+    res = run_drain_pass(DrainPassPolicy(), [_mergeable(1)], lambda pr, a: True)
+    d = res.to_dict()
+    assert set(d) == {"planned", "deferred", "left", "executed", "failed", "counts"}
+    assert d["counts"]["executed"] == 1


### PR DESCRIPTION
Pure orchestration core for the boss-loop **drain mode** you asked for — sits between the per-PR decision (`drain_policy.decide_drain_action`, #8468) and the `boss_loop` hook (next PR).

`run_drain_pass(policy, candidates, execute_fn)`:
- Routes each open-PR candidate via `decide_drain_action`, then executes under **per-type caps + priority MERGE > CLOSE_SUPERSEDED > REPAIR**.
- **REPAIR tightly bounded** (`max_repairs_per_pass`, default 2) → a 263-PR red backlog cannot trigger a worker storm; excess actionable items **defer to the next pass** (gradual drain).
- **LEAVE is never executed** → off-limits (Factory `structex/*`), other-agent-owned, and over-tier PRs preserved untouched (the anti-collision guarantee).
- One `execute_fn` failure/exception never aborts the pass.
- Pure + injected execution → fully unit-testable (11 tests); no gh/I-O here.

Next: the minimal `boss_loop.py` hook (builds candidates from gh, supplies the real execute_fn = gate-merge / `gh pr close` / `dispatch_bounded_spec`) — landed with the loop stopped. Part of `docs/plans/2026-06-16-native-mission-orchestrator.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)