### PR TITLE
feat(swarm): boss-loop drain driver (classify + bounded drain pass)

### DIFF
--- a/aragora/swarm/boss_drain.py
+++ b/aragora/swarm/boss_drain.py
@@ -1,0 +1,149 @@
+"""Boss-loop drain driver: classify open PRs and run a bounded drain pass.
+
+When the boss loop is over the open-PR cap, this turns the live PR queue into a
+batch of :class:`~aragora.swarm.drain_policy.DrainCandidate`, runs the bounded
+:func:`~aragora.swarm.drain_pass.run_drain_pass`, and executes the decisions.
+
+Safe by construction:
+- **MERGE never re-implements the gate.** A PR is only MERGE-eligible if an
+  injected ``merge_authorized_fn`` (wired to ``settle_one_pr`` in the boss loop)
+  says so — same authority, same tier/quorum/checks rules. Unknown-authority PRs
+  default to NOT mergeable, so nothing slips through.
+- **CLOSE only on truly-superseded** — empty (0 changed files) or an explicit
+  superseded list. A merely-red PR is REPAIR, never closed.
+- **off-limits is enforced** — branch-prefix matches (e.g. Factory's
+  ``structex/``, ``claude/fusion-``) and pinned PR numbers are marked
+  ``off_limits`` → LEAVE, never touched.
+- **REPAIR is bounded** by the drain-pass caps (default 2/pass) → no worker storm.
+
+All I/O is injected (``list_open_prs_fn``, ``view_pr_fn``, ``merge_authorized_fn``,
+``execute_fn``) so the driver is unit-testable; the boss-loop hook supplies the
+real gh-backed implementations.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from collections.abc import Sequence
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Any
+
+from aragora.swarm.drain_pass import DrainPassPolicy
+from aragora.swarm.drain_pass import DrainPassResult
+from aragora.swarm.drain_pass import run_drain_pass
+from aragora.swarm.drain_policy import DrainAction
+from aragora.swarm.drain_policy import DrainCandidate
+
+# Default branch prefixes that belong to OTHER fleets / lanes — never drained.
+DEFAULT_OFF_LIMITS_PREFIXES: tuple[str, ...] = ("structex/", "claude/fusion-")
+
+ListOpenPRsFn = Callable[
+    [], Sequence[dict[str, Any]]
+]  # -> PR view dicts (number, headRefName, ...)
+ViewPRFn = Callable[
+    [int], dict[str, Any] | None
+]  # -> detailed PR view (changedFiles, mergeable...)
+MergeAuthorizedFn = Callable[[int], tuple[bool, int]]  # (authorized, tier) — wired to settle_one_pr
+ExecuteFn = Callable[[int, DrainAction], bool]
+
+
+@dataclass(frozen=True)
+class DrainContext:
+    """Inputs that bound/guard a drain pass (off-limits + supersession)."""
+
+    off_limits_prefixes: tuple[str, ...] = DEFAULT_OFF_LIMITS_PREFIXES
+    off_limits_prs: frozenset[int] = field(default_factory=frozenset)
+    superseded_prs: frozenset[int] = field(default_factory=frozenset)
+    owned_prs: frozenset[int] = field(default_factory=frozenset)
+
+
+def classify_candidate(
+    view: dict[str, Any],
+    ctx: DrainContext,
+    *,
+    merge_authorized: bool,
+    tier: int,
+) -> DrainCandidate:
+    """Build a DrainCandidate from a gh PR view + an authority verdict. Pure.
+
+    ``merge_authorized``/``tier`` come from the gate (settle_one_pr) for PRs we
+    bothered to check; for the rest pass ``merge_authorized=False`` (and any
+    tier) so they route to REPAIR/LEAVE, never an unchecked MERGE.
+    """
+    number = int(view.get("number", 0))
+    branch = str(view.get("headRefName", ""))
+    changed = view.get("changedFiles", view.get("changed_files", 1))
+    has_changes = bool(changed and int(changed) > 0)
+    off_limits = number in ctx.off_limits_prs or any(
+        branch.startswith(p) for p in ctx.off_limits_prefixes
+    )
+    return DrainCandidate(
+        pr=number,
+        has_changes=has_changes,
+        superseded=number in ctx.superseded_prs,
+        off_limits=off_limits,
+        owned_by_other_agent=number in ctx.owned_prs,
+        required_checks_green=merge_authorized,  # authority bundles checks+quorum+mergeable
+        quorum_satisfied=merge_authorized,
+        mergeable=merge_authorized,
+        tier=tier,
+    )
+
+
+def build_candidates(
+    ctx: DrainContext,
+    *,
+    list_open_prs_fn: ListOpenPRsFn,
+    view_pr_fn: ViewPRFn,
+    merge_authorized_fn: MergeAuthorizedFn,
+    max_classify: int = 60,
+) -> list[DrainCandidate]:
+    """Classify up to ``max_classify`` open PRs into DrainCandidates (bounded I/O).
+
+    Off-limits / empty PRs are classified WITHOUT the (expensive) authority check
+    — they route to LEAVE/CLOSE on cheap signal alone. Only PRs that are
+    non-off-limits and have changes pay for a ``merge_authorized_fn`` call.
+    """
+    candidates: list[DrainCandidate] = []
+    for view in list(list_open_prs_fn())[:max_classify]:
+        number = int(view.get("number", 0))
+        if number <= 0:
+            continue
+        branch = str(view.get("headRefName", ""))
+        off_limits = number in ctx.off_limits_prs or any(
+            branch.startswith(p) for p in ctx.off_limits_prefixes
+        )
+        # Cheap routes first: off-limits / owned / explicitly-superseded need no authority probe.
+        if off_limits or number in ctx.owned_prs or number in ctx.superseded_prs:
+            candidates.append(classify_candidate(view, ctx, merge_authorized=False, tier=4))
+            continue
+        detail = view_pr_fn(number) or view
+        changed = detail.get("changedFiles", detail.get("changed_files", 1))
+        if not (changed and int(changed) > 0):  # empty -> CLOSE_SUPERSEDED, no authority probe
+            candidates.append(classify_candidate(detail, ctx, merge_authorized=False, tier=4))
+            continue
+        authorized, tier = merge_authorized_fn(number)
+        candidates.append(classify_candidate(detail, ctx, merge_authorized=authorized, tier=tier))
+    return candidates
+
+
+def run_boss_drain(
+    ctx: DrainContext,
+    pass_policy: DrainPassPolicy,
+    *,
+    list_open_prs_fn: ListOpenPRsFn,
+    view_pr_fn: ViewPRFn,
+    merge_authorized_fn: MergeAuthorizedFn,
+    execute_fn: ExecuteFn,
+    max_classify: int = 60,
+) -> DrainPassResult:
+    """End-to-end bounded drain pass over the live open-PR queue."""
+    candidates = build_candidates(
+        ctx,
+        list_open_prs_fn=list_open_prs_fn,
+        view_pr_fn=view_pr_fn,
+        merge_authorized_fn=merge_authorized_fn,
+        max_classify=max_classify,
+    )
+    return run_drain_pass(pass_policy, candidates, execute_fn)

--- a/tests/swarm/test_boss_drain.py
+++ b/tests/swarm/test_boss_drain.py
@@ -1,0 +1,138 @@
+"""Tests for the boss-loop drain driver (injected I/O; safe-by-construction)."""
+
+from __future__ import annotations
+
+from aragora.swarm.boss_drain import (
+    DrainContext,
+    build_candidates,
+    classify_candidate,
+    run_boss_drain,
+)
+from aragora.swarm.drain_pass import DrainPassPolicy
+from aragora.swarm.drain_policy import DrainAction
+
+
+def test_classify_off_limits_branch_prefix() -> None:
+    c = classify_candidate(
+        {"number": 1, "headRefName": "structex/p2-docs", "changedFiles": 3},
+        DrainContext(),
+        merge_authorized=True,
+        tier=0,
+    )
+    assert c.off_limits is True  # Factory branch — must never be touched
+
+
+def test_classify_off_limits_pinned_number() -> None:
+    c = classify_candidate(
+        {"number": 99, "headRefName": "codex/foo", "changedFiles": 3},
+        DrainContext(off_limits_prs=frozenset({99})),
+        merge_authorized=True,
+        tier=0,
+    )
+    assert c.off_limits is True
+
+
+def test_classify_empty_has_no_changes() -> None:
+    c = classify_candidate(
+        {"number": 2, "headRefName": "codex/x", "changedFiles": 0},
+        DrainContext(),
+        merge_authorized=False,
+        tier=4,
+    )
+    assert c.has_changes is False  # -> CLOSE_SUPERSEDED downstream
+
+
+def test_classify_authorized_sets_mergeable_bundle() -> None:
+    c = classify_candidate(
+        {"number": 3, "headRefName": "codex/x", "changedFiles": 5},
+        DrainContext(),
+        merge_authorized=True,
+        tier=1,
+    )
+    assert c.required_checks_green and c.quorum_satisfied and c.mergeable and c.tier == 1
+
+
+def _views() -> list[dict]:
+    return [
+        {"number": 10, "headRefName": "codex/green", "changedFiles": 4},  # -> authority probe
+        {"number": 11, "headRefName": "codex/empty", "changedFiles": 0},  # -> CLOSE (no probe)
+        {
+            "number": 12,
+            "headRefName": "structex/x",
+            "changedFiles": 9,
+        },  # -> off-limits LEAVE (no probe)
+        {"number": 13, "headRefName": "codex/red", "changedFiles": 7},  # -> REPAIR
+    ]
+
+
+def test_build_candidates_only_probes_promising_prs() -> None:
+    probed: list[int] = []
+
+    def auth(n: int) -> tuple[bool, int]:
+        probed.append(n)
+        return (n == 10, 0)  # only #10 authorized
+
+    cands = build_candidates(
+        DrainContext(),
+        list_open_prs_fn=_views,
+        view_pr_fn=lambda n: next(v for v in _views() if v["number"] == n),
+        merge_authorized_fn=auth,
+        max_classify=60,
+    )
+    # off-limits (#12) and empty (#11) must NOT be authority-probed
+    assert probed == [10, 13]
+    by_pr = {c.pr: c for c in cands}
+    assert by_pr[10].mergeable is True
+    assert by_pr[11].has_changes is False
+    assert by_pr[12].off_limits is True
+    assert by_pr[13].mergeable is False
+
+
+def test_build_candidates_respects_max_classify() -> None:
+    many = [{"number": 100 + i, "headRefName": "codex/x", "changedFiles": 2} for i in range(50)]
+    seen: list[int] = []
+    build_candidates(
+        DrainContext(),
+        list_open_prs_fn=lambda: many,
+        view_pr_fn=lambda n: {"number": n, "headRefName": "codex/x", "changedFiles": 2},
+        merge_authorized_fn=lambda n: (seen.append(n) or (False, 4)),
+        max_classify=5,
+    )
+    assert len(seen) == 5  # only first 5 classified/probed
+
+
+def test_run_boss_drain_routes_and_executes_safely() -> None:
+    executed: dict[int, DrainAction] = {}
+
+    def auth(n: int) -> tuple[bool, int]:
+        return (n == 10, 0)
+
+    res = run_boss_drain(
+        DrainContext(),
+        DrainPassPolicy(max_repairs_per_pass=5),
+        list_open_prs_fn=_views,
+        view_pr_fn=lambda n: next(v for v in _views() if v["number"] == n),
+        merge_authorized_fn=auth,
+        execute_fn=lambda pr, a: executed.__setitem__(pr, a) or True,
+        max_classify=60,
+    )
+    assert executed.get(10) is DrainAction.MERGE
+    assert executed.get(11) is DrainAction.CLOSE_SUPERSEDED
+    assert 12 not in executed  # off-limits LEFT, never executed
+    assert executed.get(13) is DrainAction.REPAIR
+    assert {c.pr for c in res.left} == {12}
+
+
+def test_unauthorized_pr_never_merges() -> None:
+    # Authority says NO for everything -> no MERGE, only REPAIR/CLOSE/LEAVE.
+    res = run_boss_drain(
+        DrainContext(),
+        DrainPassPolicy(),
+        list_open_prs_fn=lambda: [{"number": 5, "headRefName": "codex/x", "changedFiles": 3}],
+        view_pr_fn=lambda n: {"number": 5, "headRefName": "codex/x", "changedFiles": 3},
+        merge_authorized_fn=lambda n: (False, 0),
+        execute_fn=lambda pr, a: True,
+        max_classify=60,
+    )
+    actions = {p.action for p in res.planned}
+    assert DrainAction.MERGE not in actions


### PR DESCRIPTION
Driver that turns the live open-PR queue into a bounded drain pass. **Safe by construction:** MERGE defers to `settle_one_pr` authority (never re-implements the gate); CLOSE only on empty/explicitly-superseded; off-limits (Factory `structex/`, `claude/fusion-`, pinned PRs) → LEAVE untouched; REPAIR bounded (no worker storm). All I/O injected → 8 unit tests. The `boss_loop.py` hook (next PR) supplies real gh-backed fns and flag-gates it default-OFF. Part of docs/plans/2026-06-16-native-mission-orchestrator.md.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)