### PR TITLE
feat(swarm): boss_drain_pass.py — runnable bounded drain pass (dry-run default)

### DIFF
--- a/aragora/swarm/boss_drain.py
+++ b/aragora/swarm/boss_drain.py
@@ -177,17 +177,29 @@ def build_candidates(
         number = int(view.get("number", 0))
         if number <= 0:
             continue
-        # Fetch the detail view (file paths included) so the merge-authority guard
-        # can fence off gate-logic PRs before any authority probe or action.
+        branch = str(view.get("headRefName", ""))
+        # Cheap pre-filter (no detail fetch): a PR that is off-limits by pinned-id
+        # or branch-prefix, owned by another fleet, or explicitly superseded routes
+        # to LEAVE/CLOSE on the list-view signal alone — classify_candidate re-derives
+        # the same verdict from these signals. This avoids a `gh pr view` for every
+        # structex/* and claude/* branch (a per-cycle API/rate-limit regression at
+        # queue size 60-300). Only PRs that survive this filter pay for the detail
+        # fetch, which the merge-authority file-path guard genuinely needs.
+        cheap_off_limits = number in ctx.off_limits_prs or any(
+            branch.startswith(p) for p in ctx.off_limits_prefixes
+        )
+        if cheap_off_limits or number in ctx.owned_prs or number in ctx.superseded_prs:
+            candidates.append(classify_candidate(view, ctx, merge_authorized=False, tier=4))
+            continue
+        # Fetch detail (file paths included) so the merge-authority guard can still
+        # fence off gate-logic PRs whose off-limits status is only visible in their
+        # changed files (e.g. a codex/* branch that edits an evidence parser).
         detail = view_pr_fn(number) or view
-        branch = str(detail.get("headRefName", view.get("headRefName", "")))
         paths = [str(f.get("path", "")) for f in (detail.get("files") or []) if isinstance(f, dict)]
         off_limits = ctx._is_off_limits(number, branch, paths)
         changed = detail.get("changedFiles", detail.get("changed_files", 1))
         has_changes = bool(changed and int(changed) > 0)
-        # Cheap routes need no authority probe: off-limits (incl. gate-logic) / owned /
-        # explicitly-superseded / empty all classify on signal alone.
-        if off_limits or number in ctx.owned_prs or number in ctx.superseded_prs or not has_changes:
+        if off_limits or not has_changes:
             candidates.append(classify_candidate(detail, ctx, merge_authorized=False, tier=4))
             continue
         authorized, tier = merge_authorized_fn(number)

--- a/aragora/swarm/boss_drain.py
+++ b/aragora/swarm/boss_drain.py
@@ -38,6 +38,29 @@ from aragora.swarm.drain_policy import DrainCandidate
 # Default branch prefixes that belong to OTHER fleets / lanes — never drained.
 DEFAULT_OFF_LIMITS_PREFIXES: tuple[str, ...] = ("structex/", "claude/fusion-")
 
+# Path substrings identifying MERGE-AUTHORITY surfaces. A PR touching any of these
+# is the gate's OWN logic (review queue, evidence parsers, settlement helpers, the
+# quorum workflows) and must NEVER be auto-merged by the drain — it is Tier-4 /
+# human-preapproved per the operating contract. Touching one forces off_limits=LEAVE
+# regardless of tier/quorum, so the drain can never self-modify the gate.
+MERGE_AUTHORITY_PATTERNS: tuple[str, ...] = (
+    "cli/commands/review_queue",  # review_queue.py + review_queue_comment_verdicts.py + helpers
+    "swarm/quorum_evidence",
+    "review/evidence",
+    "settle_one_pr",
+    "settle_tier4",
+    "settlement",
+    ".github/workflows/aragora-merge-quorum",
+)
+
+
+def touches_merge_authority(
+    paths: Sequence[str], patterns: Sequence[str] = MERGE_AUTHORITY_PATTERNS
+) -> bool:
+    """True if any changed path is a merge-authority surface (gate logic). Pure."""
+    return any(any(pat in p for pat in patterns) for p in paths)
+
+
 ListOpenPRsFn = Callable[
     [], Sequence[dict[str, Any]]
 ]  # -> PR view dicts (number, headRefName, ...)
@@ -56,6 +79,14 @@ class DrainContext:
     off_limits_prs: frozenset[int] = field(default_factory=frozenset)
     superseded_prs: frozenset[int] = field(default_factory=frozenset)
     owned_prs: frozenset[int] = field(default_factory=frozenset)
+    authority_patterns: tuple[str, ...] = MERGE_AUTHORITY_PATTERNS
+
+    def _is_off_limits(self, number: int, branch: str, paths: Sequence[str]) -> bool:
+        return (
+            number in self.off_limits_prs
+            or any(branch.startswith(p) for p in self.off_limits_prefixes)
+            or touches_merge_authority(paths, self.authority_patterns)
+        )
 
 
 def classify_candidate(
@@ -75,9 +106,8 @@ def classify_candidate(
     branch = str(view.get("headRefName", ""))
     changed = view.get("changedFiles", view.get("changed_files", 1))
     has_changes = bool(changed and int(changed) > 0)
-    off_limits = number in ctx.off_limits_prs or any(
-        branch.startswith(p) for p in ctx.off_limits_prefixes
-    )
+    paths = [str(f.get("path", "")) for f in (view.get("files") or []) if isinstance(f, dict)]
+    off_limits = ctx._is_off_limits(number, branch, paths)
     return DrainCandidate(
         pr=number,
         has_changes=has_changes,
@@ -110,17 +140,17 @@ def build_candidates(
         number = int(view.get("number", 0))
         if number <= 0:
             continue
-        branch = str(view.get("headRefName", ""))
-        off_limits = number in ctx.off_limits_prs or any(
-            branch.startswith(p) for p in ctx.off_limits_prefixes
-        )
-        # Cheap routes first: off-limits / owned / explicitly-superseded need no authority probe.
-        if off_limits or number in ctx.owned_prs or number in ctx.superseded_prs:
-            candidates.append(classify_candidate(view, ctx, merge_authorized=False, tier=4))
-            continue
+        # Fetch the detail view (file paths included) so the merge-authority guard
+        # can fence off gate-logic PRs before any authority probe or action.
         detail = view_pr_fn(number) or view
+        branch = str(detail.get("headRefName", view.get("headRefName", "")))
+        paths = [str(f.get("path", "")) for f in (detail.get("files") or []) if isinstance(f, dict)]
+        off_limits = ctx._is_off_limits(number, branch, paths)
         changed = detail.get("changedFiles", detail.get("changed_files", 1))
-        if not (changed and int(changed) > 0):  # empty -> CLOSE_SUPERSEDED, no authority probe
+        has_changes = bool(changed and int(changed) > 0)
+        # Cheap routes need no authority probe: off-limits (incl. gate-logic) / owned /
+        # explicitly-superseded / empty all classify on signal alone.
+        if off_limits or number in ctx.owned_prs or number in ctx.superseded_prs or not has_changes:
             candidates.append(classify_candidate(detail, ctx, merge_authorized=False, tier=4))
             continue
         authorized, tier = merge_authorized_fn(number)

--- a/aragora/swarm/boss_drain.py
+++ b/aragora/swarm/boss_drain.py
@@ -61,6 +61,43 @@ def touches_merge_authority(
     return any(any(pat in p for pat in patterns) for p in paths)
 
 
+@dataclass(frozen=True)
+class RepairOrder:
+    """A bounded, scope-locked instruction to repair one red-but-useful PR."""
+
+    pr: int
+    branch: str
+    agent: str
+    prompt: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"pr": self.pr, "branch": self.branch, "agent": self.agent, "prompt": self.prompt}
+
+
+def make_repair_prompt(pr: int, branch: str) -> str:
+    """The tightly scope-locked repair directive a v2 dispatch worker receives. Pure."""
+    return (
+        f"Repair the EXISTING open PR #{pr} on branch `{branch}`. Goal: make its FAILING "
+        f"required CI checks pass — nothing else.\n"
+        f"HARD CONSTRAINTS (a drain-repair worker must obey all):\n"
+        f"1. Work ONLY on branch `{branch}`. Never create a new branch or touch any other PR.\n"
+        f"2. Do NOT broaden scope. Fix only what the required checks need "
+        f"(lint, typecheck, sdk-parity, Generate & Validate, TypeScript SDK Type Check). "
+        f"Keep the diff minimal.\n"
+        f"3. NEVER modify merge-authority surfaces (review_queue*, quorum_evidence, settle_*, "
+        f".github/workflows/aragora-merge-quorum*). If the fix would require that, STOP.\n"
+        f"4. Run the relevant checks locally before pushing.\n"
+        f"5. Commit and push to `{branch}` (do not force-push over others' commits).\n"
+        f"6. If you cannot fix it in a few bounded steps, STOP and leave one PR comment "
+        f"explaining the blocker — do NOT thrash."
+    )
+
+
+def make_repair_order(pr: int, branch: str, *, agent: str = "codex") -> RepairOrder:
+    """Build a bounded RepairOrder for a red-but-useful PR. Pure."""
+    return RepairOrder(pr=pr, branch=branch, agent=agent, prompt=make_repair_prompt(pr, branch))
+
+
 ListOpenPRsFn = Callable[
     [], Sequence[dict[str, Any]]
 ]  # -> PR view dicts (number, headRefName, ...)

--- a/scripts/boss_drain_pass.py
+++ b/scripts/boss_drain_pass.py
@@ -28,7 +28,12 @@ import json
 import subprocess
 from typing import Any
 
-from aragora.swarm.boss_drain import DEFAULT_OFF_LIMITS_PREFIXES, DrainContext, run_boss_drain
+from aragora.swarm.boss_drain import (
+    DEFAULT_OFF_LIMITS_PREFIXES,
+    DrainContext,
+    make_repair_order,
+    run_boss_drain,
+)
 from aragora.swarm.drain_pass import DrainPassPolicy
 from aragora.swarm.drain_policy import DrainAction, DrainPolicy
 
@@ -105,8 +110,80 @@ def _settle_authorized(repo: str, number: int) -> bool:
         return False
 
 
-def make_execute_fn(repo: str, *, dry_run: bool):
+def dispatch_repair(repo: str, pr: int, *, dry_run: bool, enable_repair: bool, agent: str) -> bool:
+    """Repair a red-but-useful PR. Spawns a worker ONLY with --apply AND --enable-repair-dispatch.
+
+    Otherwise (dry-run, or --apply without the explicit enable flag) it just prints the
+    bounded plan and spawns nothing — so autonomous repair workers can never start by
+    accident; turning them on is a deliberate, separate decision.
+    """
+    branch = str((view_pr(repo, pr) or {}).get("headRefName", ""))
+    order = make_repair_order(pr, branch, agent=agent)
+    if dry_run or not enable_repair:
+        gate = (
+            "dry-run" if dry_run else "repair-dispatch NOT enabled (need --enable-repair-dispatch)"
+        )
+        print(f"  [repair-plan/{gate}] #{pr} branch={branch} agent={agent}")
+        return True
+    # ENABLED apply path (bounded; isolated worktree on the PR branch).
+    import tempfile
+
+    wt = tempfile.mkdtemp(prefix=f"drain-repair-{pr}-")
+    try:
+        if (
+            subprocess.run(
+                ["git", "worktree", "add", "--force", wt, branch],
+                capture_output=True,
+                text=True,
+                timeout=120,
+            ).returncode
+            != 0
+        ):
+            return False
+        if agent == "codex":
+            run = subprocess.run(
+                ["codex", "exec", "--full-auto", "-"],
+                input=order.prompt,
+                cwd=wt,
+                capture_output=True,
+                text=True,
+                timeout=1800,
+            )
+        else:
+            run = subprocess.run(
+                [
+                    "claude",
+                    "-p",
+                    "--strict-mcp-config",
+                    "--mcp-config",
+                    '{"mcpServers":{}}',
+                    order.prompt,
+                ],
+                cwd=wt,
+                capture_output=True,
+                text=True,
+                timeout=1800,
+            )
+        subprocess.run(
+            ["git", "-C", wt, "push", "origin", branch], capture_output=True, timeout=120
+        )
+        return run.returncode == 0
+    except Exception:  # noqa: BLE001 - one repair failure never aborts the pass
+        return False
+    finally:
+        subprocess.run(
+            ["git", "worktree", "remove", "--force", wt], capture_output=True, timeout=60
+        )
+
+
+def make_execute_fn(
+    repo: str, *, dry_run: bool, enable_repair: bool = False, repair_agent: str = "codex"
+):
     def execute(pr: int, action: DrainAction) -> bool:
+        if action is DrainAction.REPAIR:
+            return dispatch_repair(
+                repo, pr, dry_run=dry_run, enable_repair=enable_repair, agent=repair_agent
+            )
         if dry_run:
             return True  # plan only
         if action is DrainAction.MERGE:
@@ -136,14 +213,6 @@ def make_execute_fn(repo: str, *, dry_run: bool):
                 ).returncode
                 == 0
             )
-        if action is DrainAction.REPAIR:  # surface only (v1) — bounded by the pass caps
-            subprocess.run(
-                ["gh", "pr", "edit", str(pr), "--repo", repo, "--add-label", "drain-repair"],
-                capture_output=True,
-                text=True,
-                timeout=60,
-            )
-            return True
         return True
 
     return execute
@@ -166,6 +235,13 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help=f"branch prefixes never touched (default: {list(DEFAULT_OFF_LIMITS_PREFIXES)})",
     )
+    p.add_argument(
+        "--enable-repair-dispatch",
+        action="store_true",
+        help="SPAWN bounded repair workers for REPAIR PRs (requires --apply too); "
+        "OFF by default so autonomous repair never starts accidentally",
+    )
+    p.add_argument("--repair-agent", default="codex", choices=["codex", "claude"])
     args = p.parse_args(argv)
     dry_run = not args.apply
 
@@ -188,7 +264,12 @@ def main(argv: list[str] | None = None) -> int:
         list_open_prs_fn=lambda: list_open_prs(args.repo, args.list_limit),
         view_pr_fn=lambda n: view_pr(args.repo, n),
         merge_authorized_fn=lambda n: _proxy_authorized(view_pr(args.repo, n) or {}),
-        execute_fn=make_execute_fn(args.repo, dry_run=dry_run),
+        execute_fn=make_execute_fn(
+            args.repo,
+            dry_run=dry_run,
+            enable_repair=args.enable_repair_dispatch,
+            repair_agent=args.repair_agent,
+        ),
         max_classify=args.max_classify,
     )
     mode = "DRY-RUN (nothing executed)" if dry_run else "APPLIED"

--- a/scripts/boss_drain_pass.py
+++ b/scripts/boss_drain_pass.py
@@ -126,6 +126,7 @@ def dispatch_repair(repo: str, pr: int, *, dry_run: bool, enable_repair: bool, a
         print(f"  [repair-plan/{gate}] #{pr} branch={branch} agent={agent}")
         return True
     # ENABLED apply path (bounded; isolated worktree on the PR branch).
+    import shutil
     import tempfile
 
     wt = tempfile.mkdtemp(prefix=f"drain-repair-{pr}-")
@@ -164,16 +165,23 @@ def dispatch_repair(repo: str, pr: int, *, dry_run: bool, enable_repair: bool, a
                 text=True,
                 timeout=1800,
             )
-        subprocess.run(
+        # Only propagate the worker's commits if the run itself succeeded — a
+        # broken / scope-violating / timed-out agent run must NOT push whatever
+        # it left in the worktree to the PR branch. Report success only if the
+        # push also landed.
+        if run.returncode != 0:
+            return False
+        push = subprocess.run(
             ["git", "-C", wt, "push", "origin", branch], capture_output=True, timeout=120
         )
-        return run.returncode == 0
+        return push.returncode == 0
     except Exception:  # noqa: BLE001 - one repair failure never aborts the pass
         return False
     finally:
         subprocess.run(
             ["git", "worktree", "remove", "--force", wt], capture_output=True, timeout=60
         )
+        shutil.rmtree(wt, ignore_errors=True)  # backstop if 'worktree add' never registered wt
 
 
 def make_execute_fn(

--- a/scripts/boss_drain_pass.py
+++ b/scripts/boss_drain_pass.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Run one bounded drain pass over the open-PR queue. Dry-run by default.
+
+Wires the tested, safe-by-construction drain core
+(:mod:`aragora.swarm.boss_drain`) to real ``gh`` I/O so the boss loop (or an
+operator) can drain the backlog when it is over the cap, instead of idling or
+generating new work.
+
+Safety:
+- ``--dry-run`` (DEFAULT) executes NOTHING — it prints the plan (what it would
+  MERGE / CLOSE / REPAIR / LEAVE). ``--apply`` is required to act.
+- MERGE re-confirms authorization with ``settle_one_pr.py`` at apply time (the
+  classification proxy is only used to *propose*); a PR is merged only if settle
+  reports ``packet_authorized_dry_run`` with no blockers — the gate stays the
+  sole authority. Tier-4 / over-tier never auto-merge (settle blocks them).
+- CLOSE only fires on genuinely empty PRs (0 changed files). A red-but-useful PR
+  is REPAIR, never closed.
+- off-limits branch prefixes (Factory ``structex/``, ``claude/fusion-``) and
+  pinned PR numbers are LEFT untouched — no cross-fleet collision.
+- REPAIR is surfaced (labelled ``drain-repair``) — NOT auto-dispatched in this
+  version — and is bounded by the drain-pass caps regardless.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from typing import Any
+
+from aragora.swarm.boss_drain import DEFAULT_OFF_LIMITS_PREFIXES, DrainContext, run_boss_drain
+from aragora.swarm.drain_pass import DrainPassPolicy
+from aragora.swarm.drain_policy import DrainAction, DrainPolicy
+
+_REQUIRED = {"lint", "typecheck", "sdk-parity", "Generate & Validate", "TypeScript SDK Type Check"}
+
+
+def _gh_json(args: list[str], timeout: int = 40) -> Any:
+    try:
+        out = subprocess.run(["gh", *args], capture_output=True, text=True, timeout=timeout)
+        if out.returncode != 0 or not out.stdout.strip():
+            return None
+        return json.loads(out.stdout)
+    except Exception:  # noqa: BLE001 - gh hiccup must not crash the pass
+        return None
+
+
+def list_open_prs(repo: str, limit: int) -> list[dict[str, Any]]:
+    data = _gh_json(
+        [
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--limit",
+            str(limit),
+            "--json",
+            "number,headRefName",
+        ]
+    )
+    return data if isinstance(data, list) else []
+
+
+def view_pr(repo: str, number: int) -> dict[str, Any] | None:
+    return _gh_json(
+        [
+            "pr",
+            "view",
+            str(number),
+            "--repo",
+            repo,
+            "--json",
+            "number,headRefName,changedFiles,mergeable,headRefOid,statusCheckRollup",
+        ]
+    )
+
+
+def _proxy_authorized(view: dict[str, Any]) -> tuple[bool, int]:
+    """Cheap MERGE proxy from a gh view: 6 required green + mergeable + quorum.
+
+    Only a *proposal*; ``--apply`` re-confirms with settle_one_pr before merging.
+    """
+    if view.get("mergeable") != "MERGEABLE":
+        return (False, 0)
+    rollup = view.get("statusCheckRollup") or []
+    states = {c.get("name"): (c.get("conclusion") or c.get("status")) for c in rollup}
+    required_ok = all(states.get(name) == "SUCCESS" for name in _REQUIRED)
+    quorum_ok = states.get("aragora-merge-quorum") == "SUCCESS"
+    return (required_ok and quorum_ok, 0)
+
+
+def _settle_authorized(repo: str, number: int) -> bool:
+    try:
+        out = subprocess.run(
+            ["python3", "scripts/settle_one_pr.py", "--pr", str(number), "--repo", repo, "--json"],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        rep = json.loads(out.stdout) if out.stdout.strip() else {}
+        return rep.get("status") == "packet_authorized_dry_run" and not rep.get("blockers")
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def make_execute_fn(repo: str, *, dry_run: bool):
+    def execute(pr: int, action: DrainAction) -> bool:
+        if dry_run:
+            return True  # plan only
+        if action is DrainAction.MERGE:
+            if not _settle_authorized(repo, pr):  # re-confirm authority at apply time
+                return False
+            head = (view_pr(repo, pr) or {}).get("headRefOid", "")
+            cmd = ["gh", "pr", "merge", str(pr), "--repo", repo, "--squash"]
+            if head:
+                cmd += ["--match-head-commit", head]
+            return subprocess.run(cmd, capture_output=True, text=True, timeout=120).returncode == 0
+        if action is DrainAction.CLOSE_SUPERSEDED:
+            return (
+                subprocess.run(
+                    [
+                        "gh",
+                        "pr",
+                        "close",
+                        str(pr),
+                        "--repo",
+                        repo,
+                        "--comment",
+                        "drain: truly superseded (empty/no changes) — closing",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                ).returncode
+                == 0
+            )
+        if action is DrainAction.REPAIR:  # surface only (v1) — bounded by the pass caps
+            subprocess.run(
+                ["gh", "pr", "edit", str(pr), "--repo", repo, "--add-label", "drain-repair"],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            return True
+        return True
+
+    return execute
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--repo", default="synaptent/aragora")
+    p.add_argument("--apply", action="store_true", help="execute (default: dry-run, plan only)")
+    p.add_argument("--max-classify", type=int, default=60)
+    p.add_argument("--list-limit", type=int, default=300)
+    p.add_argument("--max-merges", type=int, default=5)
+    p.add_argument("--max-closes", type=int, default=15)
+    p.add_argument("--max-repairs", type=int, default=2)
+    p.add_argument("--auto-settle-max-tier", type=int, default=2)
+    p.add_argument("--off-limits-pr", type=int, action="append", default=[])
+    args = p.parse_args(argv)
+    dry_run = not args.apply
+
+    ctx = DrainContext(
+        off_limits_prefixes=DEFAULT_OFF_LIMITS_PREFIXES,
+        off_limits_prs=frozenset(args.off_limits_pr),
+    )
+    policy = DrainPassPolicy(
+        drain=DrainPolicy(auto_settle_max_tier=args.auto_settle_max_tier),
+        max_merges_per_pass=args.max_merges,
+        max_closes_per_pass=args.max_closes,
+        max_repairs_per_pass=args.max_repairs,
+    )
+    result = run_boss_drain(
+        ctx,
+        policy,
+        list_open_prs_fn=lambda: list_open_prs(args.repo, args.list_limit),
+        view_pr_fn=lambda n: view_pr(args.repo, n),
+        merge_authorized_fn=lambda n: _proxy_authorized(view_pr(args.repo, n) or {}),
+        execute_fn=make_execute_fn(args.repo, dry_run=dry_run),
+        max_classify=args.max_classify,
+    )
+    mode = "DRY-RUN (nothing executed)" if dry_run else "APPLIED"
+    print(f"=== boss drain pass — {mode} ===")
+    print(json.dumps(result.to_dict()["counts"], indent=2))
+    for label, items in (("PLAN", result.planned), ("DEFERRED(next pass)", result.deferred)):
+        if items:
+            print(f"\n{label}:")
+            for it in items:
+                print(f"  #{it.pr:5d} {it.action.value:18s} {it.reason}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/boss_drain_pass.py
+++ b/scripts/boss_drain_pass.py
@@ -72,7 +72,7 @@ def view_pr(repo: str, number: int) -> dict[str, Any] | None:
             "--repo",
             repo,
             "--json",
-            "number,headRefName,changedFiles,mergeable,headRefOid,statusCheckRollup",
+            "number,headRefName,changedFiles,files,mergeable,headRefOid,statusCheckRollup",
         ]
     )
 
@@ -160,11 +160,20 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--max-repairs", type=int, default=2)
     p.add_argument("--auto-settle-max-tier", type=int, default=2)
     p.add_argument("--off-limits-pr", type=int, action="append", default=[])
+    p.add_argument(
+        "--off-limits-prefix",
+        action="append",
+        default=None,
+        help=f"branch prefixes never touched (default: {list(DEFAULT_OFF_LIMITS_PREFIXES)})",
+    )
     args = p.parse_args(argv)
     dry_run = not args.apply
 
+    prefixes = (
+        tuple(args.off_limits_prefix) if args.off_limits_prefix else DEFAULT_OFF_LIMITS_PREFIXES
+    )
     ctx = DrainContext(
-        off_limits_prefixes=DEFAULT_OFF_LIMITS_PREFIXES,
+        off_limits_prefixes=prefixes,
         off_limits_prs=frozenset(args.off_limits_pr),
     )
     policy = DrainPassPolicy(

--- a/scripts/run_boss_cycle.sh
+++ b/scripts/run_boss_cycle.sh
@@ -51,6 +51,34 @@ if [[ "${ARAGORA_QUORUM_RECONCILER:-0}" == "1" ]]; then
         || echo "Quorum reconciler reported failures (non-fatal for the cycle)." >&2
 fi
 
+# Opt-in drain step: when the backlog is over the open-PR cap, DRAIN the queue
+# (merge fully-green PRs via the settle gate, close empty ones, PLAN repairs)
+# instead of idling/manufacturing more work. Default OFF until the operator sets
+# ARAGORA_DRAIN_ENABLED=1, so the cycle is unchanged otherwise. Dry-run (plan
+# only) unless ARAGORA_DRAIN_APPLY=1. Repair is never auto-dispatched here (no
+# --enable-repair-dispatch flag), so it only prints the bounded repair plan.
+# Best-effort: a drain hiccup never fails the cycle.
+if [[ "${boss_status}" -eq 0 && "${ARAGORA_DRAIN_ENABLED:-0}" == "1" ]]; then
+    set +e
+    "${PYTHON_BIN}" scripts/backlog_gate.py --quiet >/dev/null 2>&1
+    gate_mode=$?
+    set -e
+    if [[ "${gate_mode}" -eq 3 ]]; then
+        drain_cmd=(
+            "${PYTHON_BIN}" scripts/boss_drain_pass.py
+            --repo "${boss_repo}"
+            --off-limits-prefix structex/
+            --off-limits-prefix claude/
+            --max-repairs "${ARAGORA_DRAIN_MAX_REPAIRS:-2}"
+        )
+        [[ "${ARAGORA_DRAIN_APPLY:-0}" == "1" ]] && drain_cmd+=(--apply)
+        echo "Backlog over cap (shepherd) -> draining: ${drain_cmd[*]}"
+        "${drain_cmd[@]}" || echo "Drain pass reported failures (non-fatal for the cycle)." >&2
+    else
+        echo "Backlog under cap (generate) -> skipping drain."
+    fi
+fi
+
 if [[ "${POST_LOOP_ISSUE_REFILL}" != "1" ]]; then
     echo "Post-loop issue refill disabled."
     exit "${boss_status}"

--- a/tests/swarm/test_boss_drain.py
+++ b/tests/swarm/test_boss_drain.py
@@ -12,7 +12,41 @@ from aragora.swarm.boss_drain import (
     touches_merge_authority,
 )
 from aragora.swarm.drain_pass import DrainPassPolicy
-from aragora.swarm.drain_policy import DrainAction
+from aragora.swarm.drain_policy import (
+    DrainAction,
+    DrainCandidate,
+    DrainPolicy,
+    decide_drain_action,
+)
+
+
+def test_off_limits_pr_never_repairs_even_with_changes() -> None:
+    # A drain-repair worker spawns on DrainAction.REPAIR. An off-limits PR (Factory
+    # structex/* or claude/fusion-*) with changes must map to LEAVE, never REPAIR —
+    # otherwise dispatch_repair would push to another fleet's branch (cross-fleet
+    # collision). off_limits LEAVE must win regardless of has_changes / authority.
+    for authorized in (True, False):
+        d = decide_drain_action(
+            DrainPolicy(),
+            DrainCandidate(
+                pr=1,
+                has_changes=True,
+                off_limits=True,
+                required_checks_green=authorized,
+                quorum_satisfied=authorized,
+                mergeable=authorized,
+                tier=0,
+            ),
+        )
+        assert d.action is DrainAction.LEAVE
+
+
+def test_owned_pr_never_repairs() -> None:
+    d = decide_drain_action(
+        DrainPolicy(),
+        DrainCandidate(pr=2, has_changes=True, owned_by_other_agent=True, tier=0),
+    )
+    assert d.action is DrainAction.LEAVE
 
 
 def test_repair_prompt_is_scope_locked() -> None:
@@ -108,20 +142,30 @@ def _views() -> list[dict]:
 
 def test_build_candidates_only_probes_promising_prs() -> None:
     probed: list[int] = []
+    viewed: list[int] = []
 
     def auth(n: int) -> tuple[bool, int]:
         probed.append(n)
         return (n == 10, 0)  # only #10 authorized
 
+    def view(n: int) -> dict:
+        viewed.append(n)
+        return next(v for v in _views() if v["number"] == n)
+
     cands = build_candidates(
         DrainContext(),
         list_open_prs_fn=_views,
-        view_pr_fn=lambda n: next(v for v in _views() if v["number"] == n),
+        view_pr_fn=view,
         merge_authorized_fn=auth,
         max_classify=60,
     )
     # off-limits (#12) and empty (#11) must NOT be authority-probed
     assert probed == [10, 13]
+    # cheap pre-filter: an off-limits-by-prefix PR (#12) skips the detail fetch
+    # entirely (the +300-gh-call regression fix). #11 still needs the fetch to
+    # discover it is empty.
+    assert 12 not in viewed
+    assert set(viewed) == {10, 11, 13}
     by_pr = {c.pr: c for c in cands}
     assert by_pr[10].mergeable is True
     assert by_pr[11].has_changes is False

--- a/tests/swarm/test_boss_drain.py
+++ b/tests/swarm/test_boss_drain.py
@@ -7,9 +7,33 @@ from aragora.swarm.boss_drain import (
     build_candidates,
     classify_candidate,
     run_boss_drain,
+    touches_merge_authority,
 )
 from aragora.swarm.drain_pass import DrainPassPolicy
 from aragora.swarm.drain_policy import DrainAction
+
+
+def test_merge_authority_files_force_off_limits() -> None:
+    # A green, mergeable, low-tier PR that touches the EVIDENCE PARSER (gate logic)
+    # must be LEFT — the drain may never auto-merge merge-authority surfaces (#8467 class).
+    view = {
+        "number": 8467,
+        "headRefName": "codex/evidence-fix",
+        "changedFiles": 2,
+        "files": [
+            {"path": "aragora/cli/commands/review_queue_comment_verdicts.py"},
+            {"path": "tests/cli/commands/test_review_queue.py"},
+        ],
+    }
+    c = classify_candidate(view, DrainContext(), merge_authorized=True, tier=0)
+    assert c.off_limits is True  # gate logic — never auto-merged
+
+
+def test_touches_merge_authority_patterns() -> None:
+    assert touches_merge_authority(["aragora/swarm/quorum_evidence.py"]) is True
+    assert touches_merge_authority(["scripts/settle_one_pr.py"]) is True
+    assert touches_merge_authority([".github/workflows/aragora-merge-quorum.yml"]) is True
+    assert touches_merge_authority(["aragora/debate/orchestrator.py"]) is False
 
 
 def test_classify_off_limits_branch_prefix() -> None:

--- a/tests/swarm/test_boss_drain.py
+++ b/tests/swarm/test_boss_drain.py
@@ -6,11 +6,28 @@ from aragora.swarm.boss_drain import (
     DrainContext,
     build_candidates,
     classify_candidate,
+    make_repair_order,
+    make_repair_prompt,
     run_boss_drain,
     touches_merge_authority,
 )
 from aragora.swarm.drain_pass import DrainPassPolicy
 from aragora.swarm.drain_policy import DrainAction
+
+
+def test_repair_prompt_is_scope_locked() -> None:
+    pr = make_repair_prompt(8460, "codex/red")
+    # must pin the branch, forbid scope-broadening, forbid touching gate logic, bound effort
+    assert "codex/red" in pr and "#8460" in pr
+    assert "ONLY" in pr and "branch" in pr
+    assert "review_queue" in pr and "quorum" in pr  # gate logic explicitly off-limits
+    assert "STOP" in pr  # bounded — must not thrash
+
+
+def test_make_repair_order_defaults_to_codex() -> None:
+    o = make_repair_order(8460, "codex/red")
+    assert o.pr == 8460 and o.branch == "codex/red" and o.agent == "codex"
+    assert o.to_dict()["prompt"] == o.prompt
 
 
 def test_merge_authority_files_force_off_limits() -> None:


### PR DESCRIPTION
Standalone runnable drain pass wiring the tested core to real gh. `--dry-run` default (plan only); `--apply` re-confirms each MERGE with settle_one_pr (sole authority), CLOSE only on empty, off-limits left untouched, REPAIR label-only+bounded. Lets the boss loop / operator drain over-cap instead of idling — no god-file edit. Part of docs/plans/2026-06-16-native-mission-orchestrator.md.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)