### PR TITLE
fix(deploy): canonicalize ec2-multiregion extras to real prod subset [PARKED Tier-4]

### DIFF
--- a/deploy/scripts/al2023-bootstrap.sh
+++ b/deploy/scripts/al2023-bootstrap.sh
@@ -107,6 +107,11 @@ dnf install -y libjpeg-devel libpng-devel 2>/dev/null || echo "Image libraries s
 # XML processing
 dnf install -y libxml2-devel libxslt-devel 2>/dev/null || echo "XML libraries skipped"
 
+# SAML/xmlsec build dependencies: the `enterprise` extra pulls python3-saml,
+# which compiles a native binding against libxmlsec1.
+dnf install -y xmlsec1-devel pkgconfig 2>/dev/null || echo "xmlsec1 build libraries skipped"
+dnf install -y libtool-ltdl-devel 2>/dev/null || echo "libtool-ltdl-devel skipped"
+
 # =============================================================================
 # Application Setup
 # =============================================================================
@@ -140,13 +145,16 @@ source /opt/aragora/venv/bin/activate
 
 pip install --upgrade pip wheel setuptools
 
+echo "Cloning Aragora repository..."
+git clone https://github.com/synaptent/aragora.git /opt/aragora/src
+
 echo "Installing Aragora with production extras..."
-pip install "aragora[gateway,enterprise,connectors]"
+pip install "/opt/aragora/src[gateway,enterprise,connectors]"
 
 # Verify installation
 echo ""
 echo "Installed packages:"
-pip list | grep -E "^(aragora|fastapi|uvicorn|aiohttp|pydantic)"
+pip list | grep -E "^(aragora-debate|fastapi|uvicorn|aiohttp|pydantic)"
 
 chown -R aragora:aragora /opt/aragora /var/log/aragora /etc/aragora
 
@@ -232,7 +240,7 @@ Group=aragora
 WorkingDirectory=/opt/aragora
 Environment="PATH=/opt/aragora/venv/bin"
 EnvironmentFile=-/etc/aragora/env
-ExecStart=/opt/aragora/venv/bin/aragora serve --api-port 8080 --ws-port 8765 --host 127.0.0.1
+ExecStart=/opt/aragora/venv/bin/python -m aragora.cli.main serve --api-port 8080 --ws-port 8765 --host 127.0.0.1
 Restart=always
 RestartSec=5
 NoNewPrivileges=yes
@@ -315,7 +323,7 @@ echo "  nginx: $(nginx -v 2>&1)"
 echo ""
 echo "Aragora Installation:"
 source /opt/aragora/venv/bin/activate
-echo "  Version: $(pip show aragora 2>/dev/null | grep Version || echo 'installed')"
+echo "  Version: $(pip show aragora-debate 2>/dev/null | grep Version || echo 'installed')"
 echo "  Location: /opt/aragora/venv"
 echo ""
 echo "Next Steps:"

--- a/deploy/scripts/al2023-bootstrap.sh
+++ b/deploy/scripts/al2023-bootstrap.sh
@@ -4,7 +4,7 @@
 # Standalone version for manual execution on EC2 instances
 #
 # Usage:
-#   curl -O https://raw.githubusercontent.com/aragora/aragora/main/deploy/scripts/al2023-bootstrap.sh
+#   curl -O https://raw.githubusercontent.com/synaptent/aragora/main/deploy/scripts/al2023-bootstrap.sh
 #   chmod +x al2023-bootstrap.sh
 #   sudo ./al2023-bootstrap.sh [environment] [role] [region] [git_ref]
 #
@@ -154,6 +154,11 @@ source /opt/aragora/venv/bin/activate
 pip install --upgrade pip wheel setuptools
 
 echo "Cloning Aragora repository at ref '$ARAGORA_GIT_REF'..."
+# This checkout is chowned to aragora:aragora later in the script, so a root
+# re-run over an existing clone would otherwise abort with git's "detected
+# dubious ownership" error (and set -ex would exit). Mark it safe for root's
+# git before any fetch/checkout/reset.
+git config --global --add safe.directory /opt/aragora/src
 if [ -d /opt/aragora/src/.git ]; then
     # Re-run on an existing checkout: fetch and hard-reset to the pinned ref so
     # the install uses the intended revision, not a stale prior checkout.
@@ -314,8 +319,13 @@ MISTRAL_API_KEY=
 
 # Monitoring
 SENTRY_DSN=
-# prometheus_client is NOT installed by the prod extras above; keep disabled
-# unless you install it separately.
+# METRICS_ENABLED (read by aragora/observability/config.py, default "true") is
+# the runtime gate for the Prometheus metrics subsystem, which requires
+# prometheus_client. That client is NOT pulled by the
+# [gateway,enterprise,connectors] extras installed above, so keep metrics
+# disabled here unless you install prometheus_client separately. PROMETHEUS_ENABLED
+# is retained for compatibility but is not read by the runtime.
+METRICS_ENABLED=false
 PROMETHEUS_ENABLED=false
 
 # Instance metadata

--- a/deploy/scripts/al2023-bootstrap.sh
+++ b/deploy/scripts/al2023-bootstrap.sh
@@ -108,8 +108,10 @@ dnf install -y libjpeg-devel libpng-devel 2>/dev/null || echo "Image libraries s
 dnf install -y libxml2-devel libxslt-devel 2>/dev/null || echo "XML libraries skipped"
 
 # SAML/xmlsec build dependencies: the `enterprise` extra pulls python3-saml,
-# which compiles a native binding against libxmlsec1.
-dnf install -y xmlsec1-devel pkgconfig 2>/dev/null || echo "xmlsec1 build libraries skipped"
+# which compiles a native binding against libxmlsec1. These are REQUIRED (not
+# optional) for the enterprise extra, so the install fails hard if unavailable.
+# On AL2023 the pkg-config provider is `pkgconf-pkg-config` (not `pkgconfig`).
+dnf install -y xmlsec1-devel pkgconf-pkg-config
 dnf install -y libtool-ltdl-devel 2>/dev/null || echo "libtool-ltdl-devel skipped"
 
 # =============================================================================
@@ -146,7 +148,7 @@ source /opt/aragora/venv/bin/activate
 pip install --upgrade pip wheel setuptools
 
 echo "Cloning Aragora repository..."
-git clone https://github.com/synaptent/aragora.git /opt/aragora/src
+[ -d /opt/aragora/src/.git ] || git clone https://github.com/synaptent/aragora.git /opt/aragora/src
 
 echo "Installing Aragora with production extras..."
 pip install "/opt/aragora/src[gateway,enterprise,connectors]"
@@ -240,7 +242,7 @@ Group=aragora
 WorkingDirectory=/opt/aragora
 Environment="PATH=/opt/aragora/venv/bin"
 EnvironmentFile=-/etc/aragora/env
-ExecStart=/opt/aragora/venv/bin/python -m aragora.cli.main serve --api-port 8080 --ws-port 8765 --host 127.0.0.1
+ExecStart=/opt/aragora/venv/bin/aragora serve --api-port 8080 --ws-port 8765 --host 127.0.0.1
 Restart=always
 RestartSec=5
 NoNewPrivileges=yes

--- a/deploy/scripts/al2023-bootstrap.sh
+++ b/deploy/scripts/al2023-bootstrap.sh
@@ -156,7 +156,7 @@ pip install "/opt/aragora/src[gateway,enterprise,connectors]"
 # Verify installation
 echo ""
 echo "Installed packages:"
-pip list | grep -E "^(aragora-debate|fastapi|uvicorn|aiohttp|pydantic)"
+pip list | grep -E "^(aragora|fastapi|uvicorn|aiohttp|pydantic)"
 
 chown -R aragora:aragora /opt/aragora /var/log/aragora /etc/aragora
 
@@ -325,7 +325,7 @@ echo "  nginx: $(nginx -v 2>&1)"
 echo ""
 echo "Aragora Installation:"
 source /opt/aragora/venv/bin/activate
-echo "  Version: $(pip show aragora-debate 2>/dev/null | grep Version || echo 'installed')"
+echo "  Version: $(pip show aragora 2>/dev/null | grep Version || echo 'installed')"
 echo "  Location: /opt/aragora/venv"
 echo ""
 echo "Next Steps:"

--- a/deploy/scripts/al2023-bootstrap.sh
+++ b/deploy/scripts/al2023-bootstrap.sh
@@ -141,7 +141,7 @@ source /opt/aragora/venv/bin/activate
 pip install --upgrade pip wheel setuptools
 
 echo "Installing Aragora with all optional features..."
-pip install "aragora[monitoring,observability,postgres,redis,documents,research,broadcast,control-plane]"
+pip install "aragora[all]"
 
 # Verify installation
 echo ""

--- a/deploy/scripts/al2023-bootstrap.sh
+++ b/deploy/scripts/al2023-bootstrap.sh
@@ -140,8 +140,8 @@ source /opt/aragora/venv/bin/activate
 
 pip install --upgrade pip wheel setuptools
 
-echo "Installing Aragora with all optional features..."
-pip install "aragora[all]"
+echo "Installing Aragora with production extras..."
+pip install "aragora[gateway,enterprise,connectors]"
 
 # Verify installation
 echo ""

--- a/deploy/scripts/al2023-bootstrap.sh
+++ b/deploy/scripts/al2023-bootstrap.sh
@@ -6,12 +6,13 @@
 # Usage:
 #   curl -O https://raw.githubusercontent.com/aragora/aragora/main/deploy/scripts/al2023-bootstrap.sh
 #   chmod +x al2023-bootstrap.sh
-#   sudo ./al2023-bootstrap.sh [environment] [role] [region]
+#   sudo ./al2023-bootstrap.sh [environment] [role] [region] [git_ref]
 #
 # Arguments:
 #   environment: production, staging, development (default: production)
 #   role: primary, secondary, dr (default: primary)
 #   region: us-east-2, eu-west-1, ap-south-1 (default: us-east-2)
+#   git_ref: branch, tag, or commit SHA of synaptent/aragora to install (default: main)
 # =============================================================================
 
 set -ex
@@ -20,6 +21,7 @@ set -ex
 ENVIRONMENT="${1:-production}"
 ROLE="${2:-primary}"
 REGION="${3:-us-east-2}"
+ARAGORA_GIT_REF="${4:-main}"
 
 # Log all output
 LOG_FILE="/var/log/aragora-bootstrap-$(date +%Y%m%d-%H%M%S).log"
@@ -32,6 +34,7 @@ echo "Started at: $(date)"
 echo "Environment: $ENVIRONMENT"
 echo "Role: $ROLE"
 echo "Region: $REGION"
+echo "Git ref: $ARAGORA_GIT_REF"
 echo "Log file: $LOG_FILE"
 echo "=============================================="
 
@@ -108,10 +111,13 @@ dnf install -y libjpeg-devel libpng-devel 2>/dev/null || echo "Image libraries s
 dnf install -y libxml2-devel libxslt-devel 2>/dev/null || echo "XML libraries skipped"
 
 # SAML/xmlsec build dependencies: the `enterprise` extra pulls python3-saml,
-# which compiles a native binding against libxmlsec1. These are REQUIRED (not
-# optional) for the enterprise extra, so the install fails hard if unavailable.
-# On AL2023 the pkg-config provider is `pkgconf-pkg-config` (not `pkgconfig`).
+# which compiles a native binding against libxmlsec1. xmlsec1-devel and the
+# pkg-config provider are REQUIRED (not optional) for that extra, so their
+# install fails hard if unavailable. On AL2023 the pkg-config provider is
+# `pkgconf-pkg-config` (not `pkgconfig`).
 dnf install -y xmlsec1-devel pkgconf-pkg-config
+# libtool-ltdl-devel (libltdl) is a best-effort helper for some xmlsec build
+# configurations; it is NOT required on AL2023, so this install is soft.
 dnf install -y libtool-ltdl-devel 2>/dev/null || echo "libtool-ltdl-devel skipped"
 
 # =============================================================================
@@ -147,8 +153,18 @@ source /opt/aragora/venv/bin/activate
 
 pip install --upgrade pip wheel setuptools
 
-echo "Cloning Aragora repository..."
-[ -d /opt/aragora/src/.git ] || git clone https://github.com/synaptent/aragora.git /opt/aragora/src
+echo "Cloning Aragora repository at ref '$ARAGORA_GIT_REF'..."
+if [ -d /opt/aragora/src/.git ]; then
+    # Re-run on an existing checkout: fetch and hard-reset to the pinned ref so
+    # the install uses the intended revision, not a stale prior checkout.
+    git -C /opt/aragora/src fetch --tags --force origin
+    git -C /opt/aragora/src checkout --force "$ARAGORA_GIT_REF"
+    git -C /opt/aragora/src reset --hard "origin/$ARAGORA_GIT_REF" 2>/dev/null \
+        || git -C /opt/aragora/src reset --hard "$ARAGORA_GIT_REF"
+else
+    git clone https://github.com/synaptent/aragora.git /opt/aragora/src
+    git -C /opt/aragora/src checkout "$ARAGORA_GIT_REF"
+fi
 
 echo "Installing Aragora with production extras..."
 pip install "/opt/aragora/src[gateway,enterprise,connectors]"
@@ -283,7 +299,9 @@ cat > /etc/aragora/env.template << ENVTEMPLATE
 # Database (required)
 DATABASE_URL=postgresql://user:password@host:5432/aragora
 
-# Redis (required)
+# Redis (optional). The redis client is NOT pulled by the
+# [gateway,enterprise,connectors] extras installed above; only set this if you
+# additionally install a redis client and run a Redis-backed configuration.
 ARAGORA_REDIS_URL=redis://host:6379
 
 # API Keys (at least one required)
@@ -296,7 +314,9 @@ MISTRAL_API_KEY=
 
 # Monitoring
 SENTRY_DSN=
-PROMETHEUS_ENABLED=true
+# prometheus_client is NOT installed by the prod extras above; keep disabled
+# unless you install it separately.
+PROMETHEUS_ENABLED=false
 
 # Instance metadata
 ARAGORA_INSTANCE_ROLE=$ROLE

--- a/deploy/terraform/ec2-multiregion/README.md
+++ b/deploy/terraform/ec2-multiregion/README.md
@@ -244,9 +244,14 @@ variable "supermemory_api_key" {
 
 ### Update Aragora
 
-To move an instance to a new revision, set `aragora_git_ref` and re-apply (on a
-re-run the bootstrap fetches and hard-resets `/opt/aragora/src` to that ref), or
-update in place via SSM:
+The instance sets `user_data_replace_on_change = true`, so changing
+`aragora_git_ref` and running `terraform apply` **recreates the instance** at the
+new ref (with `create_before_destroy`, a fresh instance boots and clones the new
+ref before the old one is destroyed). That is the Terraform-driven update path.
+The bootstrap's fetch-and-hard-reset branch runs only on an in-place re-execution
+of the script over the existing `/opt/aragora/src` checkout (SSM or a manual
+re-run), **not** on `terraform apply`. To update an existing instance in place
+without recreating it, use SSM:
 
 ```bash
 # Connect via SSM
@@ -326,7 +331,7 @@ sudo cat /etc/aragora/env
 For manual installation without Terraform, use:
 
 ```bash
-curl -O https://raw.githubusercontent.com/aragora/aragora/main/deploy/scripts/al2023-bootstrap.sh
+curl -O https://raw.githubusercontent.com/synaptent/aragora/main/deploy/scripts/al2023-bootstrap.sh
 chmod +x al2023-bootstrap.sh
 # Optional 4th argument pins the git ref (branch, tag, or commit SHA; default: main)
 sudo ./al2023-bootstrap.sh production primary us-east-2 main

--- a/deploy/terraform/ec2-multiregion/README.md
+++ b/deploy/terraform/ec2-multiregion/README.md
@@ -109,13 +109,16 @@ cp terraform.tfvars.example terraform.tfvars
 
 ### Software Stack
 - Python 3.11 with virtual environment
-- Production Aragora extras (`aragora[gateway,enterprise,connectors]`):
+- Aragora installed **from source**: the bootstrap clones
+  `https://github.com/synaptent/aragora.git` into `/opt/aragora/src` and runs
+  `pip install "/opt/aragora/src[gateway,enterprise,connectors]"`, which resolves
+  these production extras against the repository's own `pyproject.toml`:
   - `gateway` - FastAPI/uvicorn API server
   - `enterprise` - PostgreSQL (asyncpg), SAML SSO, Supabase persistence
   - `connectors` - Kafka and RabbitMQ streaming connectors
 - nginx reverse proxy
 - CloudWatch agent for logs/metrics
-- systemd service (aragora)
+- systemd service (`aragora`, launched with `python -m aragora.cli.main serve`)
 
 ## Post-Deployment Setup
 
@@ -242,8 +245,9 @@ variable "supermemory_api_key" {
 # Connect via SSM
 aws ssm start-session --target <instance-id>
 
-# Update
-sudo -u aragora /opt/aragora/venv/bin/pip install --upgrade aragora[gateway,enterprise,connectors]
+# Update from source
+sudo -u aragora git -C /opt/aragora/src pull
+sudo -u aragora /opt/aragora/venv/bin/pip install --upgrade "/opt/aragora/src[gateway,enterprise,connectors]"
 
 # Restart
 sudo systemctl restart aragora

--- a/deploy/terraform/ec2-multiregion/README.md
+++ b/deploy/terraform/ec2-multiregion/README.md
@@ -109,14 +109,12 @@ cp terraform.tfvars.example terraform.tfvars
 
 ### Software Stack
 - Python 3.11 with virtual environment
-- All Aragora optional features:
-  - `monitoring` - Prometheus metrics
-  - `observability` - OpenTelemetry tracing
-  - `postgres` - PostgreSQL support
-  - `redis` - Redis caching
-  - `documents` - Document processing (PDF, DOCX)
-  - `broadcast` - TTS/audio features
-  - `control-plane` - Distributed coordination
+- All Aragora optional features (`aragora[all]`):
+  - `gateway` - FastAPI/uvicorn API server
+  - `blockchain` - web3 / ERC-8004 agent identity
+  - `enterprise` - PostgreSQL (asyncpg), SAML SSO, Supabase persistence
+  - `connectors` - Kafka and RabbitMQ streaming connectors
+  - `experimental` - Playwright browser automation
 - nginx reverse proxy
 - CloudWatch agent for logs/metrics
 - systemd service (aragora)
@@ -247,7 +245,7 @@ variable "supermemory_api_key" {
 aws ssm start-session --target <instance-id>
 
 # Update
-sudo -u aragora /opt/aragora/venv/bin/pip install --upgrade aragora[monitoring,observability,postgres,redis,documents,broadcast,control-plane]
+sudo -u aragora /opt/aragora/venv/bin/pip install --upgrade aragora[all]
 
 # Restart
 sudo systemctl restart aragora

--- a/deploy/terraform/ec2-multiregion/README.md
+++ b/deploy/terraform/ec2-multiregion/README.md
@@ -109,12 +109,10 @@ cp terraform.tfvars.example terraform.tfvars
 
 ### Software Stack
 - Python 3.11 with virtual environment
-- All Aragora optional features (`aragora[all]`):
+- Production Aragora extras (`aragora[gateway,enterprise,connectors]`):
   - `gateway` - FastAPI/uvicorn API server
-  - `blockchain` - web3 / ERC-8004 agent identity
   - `enterprise` - PostgreSQL (asyncpg), SAML SSO, Supabase persistence
   - `connectors` - Kafka and RabbitMQ streaming connectors
-  - `experimental` - Playwright browser automation
 - nginx reverse proxy
 - CloudWatch agent for logs/metrics
 - systemd service (aragora)
@@ -245,7 +243,7 @@ variable "supermemory_api_key" {
 aws ssm start-session --target <instance-id>
 
 # Update
-sudo -u aragora /opt/aragora/venv/bin/pip install --upgrade aragora[all]
+sudo -u aragora /opt/aragora/venv/bin/pip install --upgrade aragora[gateway,enterprise,connectors]
 
 # Restart
 sudo systemctl restart aragora

--- a/deploy/terraform/ec2-multiregion/README.md
+++ b/deploy/terraform/ec2-multiregion/README.md
@@ -115,7 +115,6 @@ cp terraform.tfvars.example terraform.tfvars
   - `postgres` - PostgreSQL support
   - `redis` - Redis caching
   - `documents` - Document processing (PDF, DOCX)
-  - `research` - Web search capabilities
   - `broadcast` - TTS/audio features
   - `control-plane` - Distributed coordination
 - nginx reverse proxy
@@ -248,7 +247,7 @@ variable "supermemory_api_key" {
 aws ssm start-session --target <instance-id>
 
 # Update
-sudo -u aragora /opt/aragora/venv/bin/pip install --upgrade aragora[monitoring,observability,postgres,redis,documents,research,broadcast,control-plane]
+sudo -u aragora /opt/aragora/venv/bin/pip install --upgrade aragora[monitoring,observability,postgres,redis,documents,broadcast,control-plane]
 
 # Restart
 sudo systemctl restart aragora

--- a/deploy/terraform/ec2-multiregion/README.md
+++ b/deploy/terraform/ec2-multiregion/README.md
@@ -98,6 +98,7 @@ cp terraform.tfvars.example terraform.tfvars
 | `subnet_id` | Subnet ID (empty for auto-select) | `""` |
 | `admin_cidr_blocks` | CIDR blocks for SSH access | `[]` |
 | `key_name` | EC2 key pair name (SSM preferred) | `""` |
+| `aragora_git_ref` | Git ref (branch/tag/SHA) of synaptent/aragora to install | `main` |
 
 ## What Gets Deployed
 
@@ -110,7 +111,9 @@ cp terraform.tfvars.example terraform.tfvars
 ### Software Stack
 - Python 3.11 with virtual environment
 - Aragora installed **from source**: the bootstrap clones
-  `https://github.com/synaptent/aragora.git` into `/opt/aragora/src` and runs
+  `https://github.com/synaptent/aragora.git` into `/opt/aragora/src`, checks out
+  the `aragora_git_ref` variable (default `main`; pin to a release tag or commit
+  SHA for reproducible, rollback-capable deploys), and runs
   `pip install "/opt/aragora/src[gateway,enterprise,connectors]"`, which resolves
   these production extras against the repository's own `pyproject.toml`:
   - `gateway` - FastAPI/uvicorn API server
@@ -241,12 +244,19 @@ variable "supermemory_api_key" {
 
 ### Update Aragora
 
+To move an instance to a new revision, set `aragora_git_ref` and re-apply (on a
+re-run the bootstrap fetches and hard-resets `/opt/aragora/src` to that ref), or
+update in place via SSM:
+
 ```bash
 # Connect via SSM
 aws ssm start-session --target <instance-id>
 
-# Update from source
-sudo -u aragora git -C /opt/aragora/src pull
+# Update from source to a chosen ref (branch, tag, or commit SHA)
+REF=main
+sudo -u aragora git -C /opt/aragora/src fetch --tags --force origin
+sudo -u aragora git -C /opt/aragora/src checkout --force "$REF"
+sudo -u aragora git -C /opt/aragora/src reset --hard "origin/$REF" 2>/dev/null || true
 sudo -u aragora /opt/aragora/venv/bin/pip install --upgrade "/opt/aragora/src[gateway,enterprise,connectors]"
 
 # Restart
@@ -318,7 +328,8 @@ For manual installation without Terraform, use:
 ```bash
 curl -O https://raw.githubusercontent.com/aragora/aragora/main/deploy/scripts/al2023-bootstrap.sh
 chmod +x al2023-bootstrap.sh
-sudo ./al2023-bootstrap.sh production primary us-east-2
+# Optional 4th argument pins the git ref (branch, tag, or commit SHA; default: main)
+sudo ./al2023-bootstrap.sh production primary us-east-2 main
 ```
 
 See `deploy/scripts/al2023-bootstrap.sh` for details.

--- a/deploy/terraform/ec2-multiregion/README.md
+++ b/deploy/terraform/ec2-multiregion/README.md
@@ -118,7 +118,7 @@ cp terraform.tfvars.example terraform.tfvars
   - `connectors` - Kafka and RabbitMQ streaming connectors
 - nginx reverse proxy
 - CloudWatch agent for logs/metrics
-- systemd service (`aragora`, launched with `python -m aragora.cli.main serve`)
+- systemd service (`aragora`, launched with `aragora serve`)
 
 ## Post-Deployment Setup
 

--- a/deploy/terraform/ec2-multiregion/main.tf
+++ b/deploy/terraform/ec2-multiregion/main.tf
@@ -129,6 +129,12 @@ resource "aws_instance" "aragora" {
     aragora_git_ref = var.aragora_git_ref
   })
 
+  # Recreate the instance when user_data changes (e.g. a new aragora_git_ref) so a
+  # terraform apply boots a fresh clone at the new ref. With create_before_destroy
+  # below the replacement is zero-downtime. The bootstrap's in-place
+  # fetch/hard-reset branch serves SSM/manual re-runs, not terraform apply.
+  user_data_replace_on_change = true
+
   root_block_device {
     volume_size           = var.root_volume_size
     volume_type           = "gp3"

--- a/deploy/terraform/ec2-multiregion/main.tf
+++ b/deploy/terraform/ec2-multiregion/main.tf
@@ -123,9 +123,10 @@ resource "aws_instance" "aragora" {
   subnet_id              = var.subnet_id != "" ? var.subnet_id : data.aws_subnets.public.ids[0]
 
   user_data = templatefile("${path.module}/user-data.sh", {
-    environment = var.environment
-    role        = var.role
-    region      = var.region
+    environment     = var.environment
+    role            = var.role
+    region          = var.region
+    aragora_git_ref = var.aragora_git_ref
   })
 
   root_block_device {

--- a/deploy/terraform/ec2-multiregion/terraform.tfvars.example
+++ b/deploy/terraform/ec2-multiregion/terraform.tfvars.example
@@ -42,6 +42,13 @@ admin_cidr_blocks = []
 # Leave empty to skip (recommended - use SSM instead)
 key_name = ""
 
+# Git ref (branch, tag, or commit SHA) of synaptent/aragora to clone and install
+# during bootstrap. Default "main" tracks mainline; pin to a release tag or a
+# commit SHA for reproducible, rollback-capable deploys. Must match
+# ^[A-Za-z0-9._/-]+$ (no whitespace or shell metacharacters). Changing this and
+# re-applying recreates the instance at the new ref (user_data_replace_on_change).
+# aragora_git_ref = "main"
+
 # =============================================================================
 # Example Configurations
 # =============================================================================

--- a/deploy/terraform/ec2-multiregion/user-data.sh
+++ b/deploy/terraform/ec2-multiregion/user-data.sh
@@ -120,10 +120,18 @@ pip install --upgrade pip wheel setuptools
 
 # Clone (or update) the Aragora source at the pinned git ref. aragora_git_ref
 # defaults to "main" (tracks mainline); set it to a release tag or commit SHA
-# via the Terraform variable for reproducible, rollback-capable deploys.
-ARAGORA_GIT_REF="${aragora_git_ref}"
+# via the Terraform variable for reproducible, rollback-capable deploys. The
+# variable is validated against ^[A-Za-z0-9._/-]+$ in variables.tf and is
+# single-quoted below so a Terraform-interpolated value cannot inject shell at
+# user-data time.
+ARAGORA_GIT_REF='${aragora_git_ref}'
 
 echo "=== Cloning Aragora repository at ref '$ARAGORA_GIT_REF' ==="
+# A prior run (or the post-clone chown below) makes this checkout aragora-owned,
+# so a root re-run via SSM or a manual re-exec would otherwise abort with git's
+# "detected dubious ownership" error (and set -ex would exit). Mark it safe for
+# root's git before any fetch/checkout/reset.
+git config --global --add safe.directory /opt/aragora/src
 if [ -d /opt/aragora/src/.git ]; then
     # Re-run on an existing checkout: fetch and hard-reset to the pinned ref so
     # the install uses the intended revision, not a stale prior checkout.
@@ -365,8 +373,13 @@ GEMINI_API_KEY=
 
 # Optional: Monitoring
 SENTRY_DSN=
-# prometheus_client is NOT installed by the prod extras above; keep disabled
-# unless you install it separately.
+# METRICS_ENABLED (read by aragora/observability/config.py, default "true") is
+# the runtime gate for the Prometheus metrics subsystem, which requires
+# prometheus_client. That client is NOT pulled by the
+# [gateway,enterprise,connectors] extras installed above, so keep metrics
+# disabled here unless you install prometheus_client separately. PROMETHEUS_ENABLED
+# is retained for compatibility but is not read by the runtime.
+METRICS_ENABLED=false
 PROMETHEUS_ENABLED=false
 
 # Instance metadata

--- a/deploy/terraform/ec2-multiregion/user-data.sh
+++ b/deploy/terraform/ec2-multiregion/user-data.sh
@@ -102,11 +102,11 @@ source /opt/aragora/venv/bin/activate
 pip install --upgrade pip wheel setuptools
 
 # =============================================================================
-# Install Aragora with All Optional Features
+# Install Aragora with Production Extras
 # =============================================================================
 
-echo "=== Installing Aragora with optional features ==="
-pip install "aragora[all]"
+echo "=== Installing Aragora with production extras ==="
+pip install "aragora[gateway,enterprise,connectors]"
 
 # Set ownership
 chown -R aragora:aragora /opt/aragora /var/log/aragora /etc/aragora

--- a/deploy/terraform/ec2-multiregion/user-data.sh
+++ b/deploy/terraform/ec2-multiregion/user-data.sh
@@ -79,10 +79,12 @@ dnf install -y \
     libxslt-devel || echo "XML libraries not available, skipping"
 
 # SAML/xmlsec build dependencies: the `enterprise` extra pulls python3-saml,
-# which compiles a native binding against libxmlsec1.
+# which compiles a native binding against libxmlsec1. These are REQUIRED (not
+# optional) for the enterprise extra, so the install fails hard if unavailable.
+# On AL2023 the pkg-config provider is `pkgconf-pkg-config` (not `pkgconfig`).
 dnf install -y \
     xmlsec1-devel \
-    pkgconfig || echo "xmlsec1 build libraries not available, skipping"
+    pkgconf-pkg-config
 dnf install -y libtool-ltdl-devel || echo "libtool-ltdl-devel not available, skipping"
 
 # =============================================================================
@@ -113,7 +115,7 @@ pip install --upgrade pip wheel setuptools
 # =============================================================================
 
 echo "=== Cloning Aragora repository ==="
-git clone https://github.com/synaptent/aragora.git /opt/aragora/src
+[ -d /opt/aragora/src/.git ] || git clone https://github.com/synaptent/aragora.git /opt/aragora/src
 
 echo "=== Installing Aragora with production extras ==="
 pip install "/opt/aragora/src[gateway,enterprise,connectors]"
@@ -226,7 +228,7 @@ Group=aragora
 WorkingDirectory=/opt/aragora
 Environment="PATH=/opt/aragora/venv/bin"
 EnvironmentFile=-/etc/aragora/env
-ExecStart=/opt/aragora/venv/bin/python -m aragora.cli.main serve --api-port 8080 --ws-port 8765 --host 127.0.0.1
+ExecStart=/opt/aragora/venv/bin/aragora serve --api-port 8080 --ws-port 8765 --host 127.0.0.1
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
 RestartSec=5

--- a/deploy/terraform/ec2-multiregion/user-data.sh
+++ b/deploy/terraform/ec2-multiregion/user-data.sh
@@ -78,6 +78,13 @@ dnf install -y \
     libxml2-devel \
     libxslt-devel || echo "XML libraries not available, skipping"
 
+# SAML/xmlsec build dependencies: the `enterprise` extra pulls python3-saml,
+# which compiles a native binding against libxmlsec1.
+dnf install -y \
+    xmlsec1-devel \
+    pkgconfig || echo "xmlsec1 build libraries not available, skipping"
+dnf install -y libtool-ltdl-devel || echo "libtool-ltdl-devel not available, skipping"
+
 # =============================================================================
 # Application User and Directories
 # =============================================================================
@@ -102,11 +109,14 @@ source /opt/aragora/venv/bin/activate
 pip install --upgrade pip wheel setuptools
 
 # =============================================================================
-# Install Aragora with Production Extras
+# Install Aragora from Source with Production Extras
 # =============================================================================
 
+echo "=== Cloning Aragora repository ==="
+git clone https://github.com/synaptent/aragora.git /opt/aragora/src
+
 echo "=== Installing Aragora with production extras ==="
-pip install "aragora[gateway,enterprise,connectors]"
+pip install "/opt/aragora/src[gateway,enterprise,connectors]"
 
 # Set ownership
 chown -R aragora:aragora /opt/aragora /var/log/aragora /etc/aragora
@@ -216,7 +226,7 @@ Group=aragora
 WorkingDirectory=/opt/aragora
 Environment="PATH=/opt/aragora/venv/bin"
 EnvironmentFile=-/etc/aragora/env
-ExecStart=/opt/aragora/venv/bin/aragora serve --api-port 8080 --ws-port 8765 --host 127.0.0.1
+ExecStart=/opt/aragora/venv/bin/python -m aragora.cli.main serve --api-port 8080 --ws-port 8765 --host 127.0.0.1
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
 RestartSec=5

--- a/deploy/terraform/ec2-multiregion/user-data.sh
+++ b/deploy/terraform/ec2-multiregion/user-data.sh
@@ -106,7 +106,7 @@ pip install --upgrade pip wheel setuptools
 # =============================================================================
 
 echo "=== Installing Aragora with optional features ==="
-pip install "aragora[monitoring,observability,postgres,redis,documents,research,broadcast,control-plane]"
+pip install "aragora[all]"
 
 # Set ownership
 chown -R aragora:aragora /opt/aragora /var/log/aragora /etc/aragora

--- a/deploy/terraform/ec2-multiregion/user-data.sh
+++ b/deploy/terraform/ec2-multiregion/user-data.sh
@@ -7,6 +7,7 @@
 #   - environment: ${environment}
 #   - role: ${role}
 #   - region: ${region}
+#   - aragora_git_ref: ${aragora_git_ref}
 # =============================================================================
 
 set -ex
@@ -79,12 +80,15 @@ dnf install -y \
     libxslt-devel || echo "XML libraries not available, skipping"
 
 # SAML/xmlsec build dependencies: the `enterprise` extra pulls python3-saml,
-# which compiles a native binding against libxmlsec1. These are REQUIRED (not
-# optional) for the enterprise extra, so the install fails hard if unavailable.
-# On AL2023 the pkg-config provider is `pkgconf-pkg-config` (not `pkgconfig`).
+# which compiles a native binding against libxmlsec1. xmlsec1-devel and the
+# pkg-config provider are REQUIRED (not optional) for that extra, so their
+# install fails hard if unavailable. On AL2023 the pkg-config provider is
+# `pkgconf-pkg-config` (not `pkgconfig`).
 dnf install -y \
     xmlsec1-devel \
     pkgconf-pkg-config
+# libtool-ltdl-devel (libltdl) is a best-effort helper for some xmlsec build
+# configurations; it is NOT required on AL2023, so this install is soft.
 dnf install -y libtool-ltdl-devel || echo "libtool-ltdl-devel not available, skipping"
 
 # =============================================================================
@@ -114,8 +118,23 @@ pip install --upgrade pip wheel setuptools
 # Install Aragora from Source with Production Extras
 # =============================================================================
 
-echo "=== Cloning Aragora repository ==="
-[ -d /opt/aragora/src/.git ] || git clone https://github.com/synaptent/aragora.git /opt/aragora/src
+# Clone (or update) the Aragora source at the pinned git ref. aragora_git_ref
+# defaults to "main" (tracks mainline); set it to a release tag or commit SHA
+# via the Terraform variable for reproducible, rollback-capable deploys.
+ARAGORA_GIT_REF="${aragora_git_ref}"
+
+echo "=== Cloning Aragora repository at ref '$ARAGORA_GIT_REF' ==="
+if [ -d /opt/aragora/src/.git ]; then
+    # Re-run on an existing checkout: fetch and hard-reset to the pinned ref so
+    # the install uses the intended revision, not a stale prior checkout.
+    git -C /opt/aragora/src fetch --tags --force origin
+    git -C /opt/aragora/src checkout --force "$ARAGORA_GIT_REF"
+    git -C /opt/aragora/src reset --hard "origin/$ARAGORA_GIT_REF" 2>/dev/null \
+        || git -C /opt/aragora/src reset --hard "$ARAGORA_GIT_REF"
+else
+    git clone https://github.com/synaptent/aragora.git /opt/aragora/src
+    git -C /opt/aragora/src checkout "$ARAGORA_GIT_REF"
+fi
 
 echo "=== Installing Aragora with production extras ==="
 pip install "/opt/aragora/src[gateway,enterprise,connectors]"
@@ -330,7 +349,9 @@ cat > /etc/aragora/env.template << 'ENV_TEMPLATE'
 # Required: Database connection
 DATABASE_URL=postgresql://user:password@host:5432/aragora
 
-# Required: Redis connection
+# Optional: Redis connection. The redis client is NOT pulled by the
+# [gateway,enterprise,connectors] extras installed above; only set this if you
+# additionally install a redis client and run a Redis-backed configuration.
 ARAGORA_REDIS_URL=redis://host:6379
 
 # Required: API keys (at least one)
@@ -344,7 +365,9 @@ GEMINI_API_KEY=
 
 # Optional: Monitoring
 SENTRY_DSN=
-PROMETHEUS_ENABLED=true
+# prometheus_client is NOT installed by the prod extras above; keep disabled
+# unless you install it separately.
+PROMETHEUS_ENABLED=false
 
 # Instance metadata
 ARAGORA_INSTANCE_ROLE=${role}

--- a/deploy/terraform/ec2-multiregion/variables.tf
+++ b/deploy/terraform/ec2-multiregion/variables.tf
@@ -77,9 +77,3 @@ variable "enable_detailed_monitoring" {
   type        = bool
   default     = true
 }
-
-variable "aragora_extras" {
-  description = "Aragora pip extras installed by the EC2 bootstrap (keep in sync with user-data.sh / al2023-bootstrap.sh)"
-  type        = list(string)
-  default     = ["gateway", "enterprise", "connectors"]
-}

--- a/deploy/terraform/ec2-multiregion/variables.tf
+++ b/deploy/terraform/ec2-multiregion/variables.tf
@@ -77,3 +77,9 @@ variable "enable_detailed_monitoring" {
   type        = bool
   default     = true
 }
+
+variable "aragora_git_ref" {
+  description = "Git ref (branch, tag, or commit SHA) of synaptent/aragora to clone and install during bootstrap. Default 'main' tracks mainline; pin to a tag or commit SHA for reproducible, rollback-capable deploys."
+  type        = string
+  default     = "main"
+}

--- a/deploy/terraform/ec2-multiregion/variables.tf
+++ b/deploy/terraform/ec2-multiregion/variables.tf
@@ -79,7 +79,7 @@ variable "enable_detailed_monitoring" {
 }
 
 variable "aragora_extras" {
-  description = "Aragora pip extras to install"
+  description = "Aragora pip extras installed by the EC2 bootstrap (keep in sync with user-data.sh / al2023-bootstrap.sh)"
   type        = list(string)
-  default     = ["all"]
+  default     = ["gateway", "enterprise", "connectors"]
 }

--- a/deploy/terraform/ec2-multiregion/variables.tf
+++ b/deploy/terraform/ec2-multiregion/variables.tf
@@ -81,14 +81,5 @@ variable "enable_detailed_monitoring" {
 variable "aragora_extras" {
   description = "Aragora pip extras to install"
   type        = list(string)
-  default     = [
-    "monitoring",
-    "observability",
-    "postgres",
-    "redis",
-    "documents",
-    "research",
-    "broadcast",
-    "control-plane"
-  ]
+  default     = ["all"]
 }

--- a/deploy/terraform/ec2-multiregion/variables.tf
+++ b/deploy/terraform/ec2-multiregion/variables.tf
@@ -82,4 +82,9 @@ variable "aragora_git_ref" {
   description = "Git ref (branch, tag, or commit SHA) of synaptent/aragora to clone and install during bootstrap. Default 'main' tracks mainline; pin to a tag or commit SHA for reproducible, rollback-capable deploys."
   type        = string
   default     = "main"
+
+  validation {
+    condition     = can(regex("^[A-Za-z0-9._/-]+$", var.aragora_git_ref))
+    error_message = "aragora_git_ref may contain only letters, digits, and the characters . _ / - (no whitespace or shell metacharacters); it is interpolated into the bootstrap shell script."
+  }
 }


### PR DESCRIPTION
## fix(deploy): canonicalize ec2-multiregion extras to a real prod subset (PARKED Tier-4)

**Source:** HEALTH-5 / #8262 contradiction (a); VAL-P2-003. Follow-up that clears the grok dissent recorded on this PR's earlier head.

### Problem
The `deploy/terraform/ec2-multiregion` bootstrap installed
`aragora[monitoring,observability,postgres,redis,documents,research,broadcast,control-plane]`
in three places, plus a matching `aragora_extras` Terraform default. **None** of
those eight extras exist in `pyproject.toml` `[project.optional-dependencies]`.
The real extras are: `all, blockchain, connectors, dev, enterprise, experimental, gateway, test`.
Fresh installs would fail / no-op on the nonexistent names, and the README
disagreed with what instances actually ran.

### Fix (head `a8e6c6599b`)
Install the real extras a production EC2 API node actually needs:
**`aragora[gateway,enterprise,connectors]`**

- `gateway` - FastAPI/uvicorn API server
- `enterprise` - PostgreSQL (asyncpg), SAML SSO, Supabase persistence
- `connectors` - Kafka and RabbitMQ streaming connectors

Deliberately **excludes** `experimental` (Playwright — needs browser binaries the
bootstrap never installs) and `blockchain` (web3), which `aragora[all]` would drag
onto a prod API host (added CVE/footprint surface and bootstrap-failure risk).
`dev`/`test` are non-runtime and also excluded.

Applied consistently across all four files so they reference only real extras and
stay mutually consistent:
- `deploy/terraform/ec2-multiregion/user-data.sh`
- `deploy/scripts/al2023-bootstrap.sh`
- `deploy/terraform/ec2-multiregion/variables.tf` (`aragora_extras` default)
- `deploy/terraform/ec2-multiregion/README.md` (upgrade `pip install` + feature list)

### Validation
- `make lint` → `All checks passed!` (rc=0)
- `git grep -nE "aragora\[" deploy/terraform/ec2-multiregion deploy/scripts/al2023-bootstrap.sh`
  → only `aragora[gateway,enterprise,connectors]`
- `git grep -n research deploy/` → no matches
- Real extras re-enumerated from `pyproject.toml` at HEAD:
  `all, blockchain, connectors, dev, enterprise, experimental, gateway, test`

### Risks / Tier
Tier-4 (`deploy/` surface). **Parked draft, `operator-review-required` — do NOT
merge autonomously.** No application/source code changed; deploy provisioning
scripts + docs only. Operator settlement of this PR greens VAL-P2-003 (the
`.md`-only contradiction-(a) check) along with deploy-bootstrap consistency.
