### PR TITLE
docs(sdk): drop removed aragora-js reference from typescript README [PARKED Tier-3]

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -3,7 +3,7 @@
 Official TypeScript SDK for the Aragora multi-agent debate platform.
 
 Need a smaller, `/api/v1`-only client or minimal dependencies? Use
-`@aragora/client` for legacy compatibility (see `aragora-js/README.md`).
+`@aragora/client` for legacy compatibility.
 
 ## Package Comparison
 


### PR DESCRIPTION
## PARKED — Tier 3 (human settlement) + sdk-parity in-scope

This is a **parked draft**. The change sits under `sdk/` (Tier-3 surface), so settlement is human (worker does not self-settle). It is also **sdk-parity in-scope**, and repo sdk-parity debt currently exceeds the decaying budget, so the required `sdk-parity` check has **no autonomous green path** right now. It is the residual offender for **VAL-P2-004** that the Tier-0 PR (#8475) could not include.

## Source

HEALTH-5 #8262 (part 2), contradiction (b) — removed `aragora-js/` path references on live surfaces. Mission feature `p2-contradictions`.

## What changed (documentation only)

`sdk/typescript/README.md` line 6: removed the dangling `(see \`aragora-js/README.md\`)` pointer. The `aragora-js/` directory no longer exists.

## Validation

After this lands, VAL-P2-004's sweep returns zero offending matches:
```
git grep -n "aragora-js/" origin/main -- README.md DEVELOPMENT.md CONTRIBUTING.md INSTALL.md CLAUDE.md AGENTS.md 'docs/guides/**' 'docs/getting-started/**' 'docs/reference/**' 'sdk/**/*.md'
```

## Operator settlement (when sdk-parity greens on main)

1. `gh run rerun <sdk-parity-run-id>` on this branch once parity greens on main (rerun recomputes the merge ref; no push).
2. `gh pr ready <N>`; collect evidence (`review-queue collect-evidence --pr <N> --reviewers claude grok` — Tier-3 is prepare-only, post via `gh pr comment`).
3. Tier-3 settlement: `review-queue record-settlement <N> --head-sha <HEAD_SHA> --action approve --reason "..." --post-github-status`, then `gh pr merge <N> --squash --match-head-commit <HEAD_SHA>`.

## Risks

Documentation-only, behavior-neutral. No code or SDK runtime changes.
