### PR TITLE
feat: implement Native Mission Orchestrator PR-1

### DIFF
--- a/aragora/nomic/autonomous_orchestrator.py
+++ b/aragora/nomic/autonomous_orchestrator.py
@@ -628,7 +628,7 @@ class AutonomousOrchestrator:
             if self.enable_metrics and self._metrics_collector is not None:
                 try:
                     # Scope metrics to the files touched by all subtasks
-                    file_scope = []
+                    file_scope: list[str] = []
                     for a in assignments:
                         file_scope.extend(a.subtask.file_scope or [])
                     _metrics_baseline = await self._metrics_collector.collect_baseline(
@@ -838,6 +838,14 @@ class AutonomousOrchestrator:
                 success=False,
                 error=f"Orchestration failed: {type(e).__name__}",
             )
+
+    async def decompose_goal(
+        self,
+        goal: str,
+        tracks: list[str] | None = None,
+    ) -> TaskDecomposition:
+        """Decompose a high-level goal into subtasks."""
+        return await self._decompose_goal(goal, tracks)
 
     async def _decompose_goal(
         self,

--- a/aragora/nomic/mission.py
+++ b/aragora/nomic/mission.py
@@ -22,6 +22,8 @@ Design intent (recorded so later PRs hold the line):
 from __future__ import annotations
 
 import json
+import os
+import tempfile
 from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import Enum
@@ -198,9 +200,24 @@ class MissionStore:
             "items": [item.to_dict() for item in items],
         }
         dest = self.path_for(spec.mission_id)
-        tmp = dest.with_suffix(".json.tmp")
-        tmp.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
-        tmp.replace(dest)
+        payload = json.dumps(data, indent=2) + "\n"
+        # Unique temp name in the destination dir so two concurrent writers for
+        # the same mission_id cannot clobber each other's in-flight file; the
+        # final os.replace is atomic on POSIX.
+        fd, tmp_name = tempfile.mkstemp(
+            dir=self.state_dir, prefix=f"{dest.stem}.", suffix=".json.tmp"
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                fh.write(payload)
+            os.replace(tmp_name, dest)
+        finally:
+            # On success os.replace consumed tmp_name; on failure clean the orphan.
+            if os.path.exists(tmp_name):
+                try:
+                    os.unlink(tmp_name)
+                except OSError:
+                    pass
         return dest
 
     def load_mission(self, mission_id: str) -> tuple[MissionSpec, tuple[WorkItem, ...]] | None:

--- a/aragora/nomic/mission.py
+++ b/aragora/nomic/mission.py
@@ -21,10 +21,15 @@ Design intent (recorded so later PRs hold the line):
 
 from __future__ import annotations
 
+import json
 from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import Enum
+from pathlib import Path
 from typing import Any
+
+from aragora.config.feature_flags import FeatureFlagRegistry
+from aragora.persistence.db_config import get_default_data_dir
 
 
 class MissionTransport(Enum):
@@ -122,6 +127,26 @@ class WorkItem:
             "dependencies": list(self.dependencies),
         }
 
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "WorkItem":
+        status_raw = payload.get("status", WorkItemStatus.PENDING.value)
+        file_scope_raw = payload.get("file_scope", [])
+        file_scope = (
+            tuple(str(f) for f in file_scope_raw) if isinstance(file_scope_raw, list) else ()
+        )
+        dependencies_raw = payload.get("dependencies", [])
+        dependencies = (
+            tuple(str(d) for d in dependencies_raw) if isinstance(dependencies_raw, list) else ()
+        )
+        return cls(
+            item_id=str(payload["item_id"]),
+            description=str(payload["description"]),
+            status=WorkItemStatus(status_raw),
+            complexity=str(payload.get("complexity", "low")),
+            file_scope=file_scope,
+            dependencies=dependencies,
+        )
+
 
 def work_items_from_subtasks(subtasks: Iterable[Any]) -> tuple[WorkItem, ...]:
     """Adapt nomic decomposition output into a PENDING work-item queue.
@@ -151,3 +176,81 @@ def work_items_from_subtasks(subtasks: Iterable[Any]) -> tuple[WorkItem, ...]:
             )
         )
     return tuple(items)
+
+
+class MissionStore:
+    """JSON-based store for native mission queues, rooted at get_default_data_dir() / 'missions'."""
+
+    def __init__(self, state_dir: Path | None = None) -> None:
+        self.state_dir = Path(state_dir or (get_default_data_dir() / "missions")).resolve()
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+
+    def path_for(self, mission_id: str) -> Path:
+        # Sanitize to prevent path traversal
+        clean_id = "".join(c for c in mission_id if c.isalnum() or c in "_-")
+        if not clean_id or clean_id != mission_id:
+            raise ValueError(f"Invalid mission ID: {mission_id}")
+        return self.state_dir / f"{clean_id}.json"
+
+    def save_mission(self, spec: MissionSpec, items: Iterable[WorkItem]) -> Path:
+        data = {
+            "spec": spec.to_dict(),
+            "items": [item.to_dict() for item in items],
+        }
+        dest = self.path_for(spec.mission_id)
+        tmp = dest.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+        tmp.replace(dest)
+        return dest
+
+    def load_mission(self, mission_id: str) -> tuple[MissionSpec, tuple[WorkItem, ...]] | None:
+        path = self.path_for(mission_id)
+        if not path.exists():
+            return None
+        data = json.loads(path.read_text(encoding="utf-8"))
+        spec = MissionSpec.from_dict(data["spec"])
+        items = tuple(WorkItem.from_dict(i) for i in data.get("items", []))
+        return spec, items
+
+    def list_missions(self) -> list[str]:
+        """List all active mission IDs based on files in the state directory."""
+        return [p.stem for p in sorted(self.state_dir.glob("*.json"))]
+
+
+class NativeMissionRunner:
+    """Intake coordinator for native missions: decompose and enqueue."""
+
+    def __init__(
+        self,
+        orchestrator: Any | None = None,
+        store: MissionStore | None = None,
+        feature_flags: FeatureFlagRegistry | None = None,
+    ) -> None:
+        self._orchestrator = orchestrator
+        self.store = store or MissionStore()
+        self.feature_flags = feature_flags or FeatureFlagRegistry()
+
+    @property
+    def orchestrator(self) -> Any:
+        if self._orchestrator is None:
+            from aragora.nomic.autonomous_orchestrator import AutonomousOrchestrator
+
+            self._orchestrator = AutonomousOrchestrator()
+        return self._orchestrator
+
+    async def ingest_mission(
+        self,
+        spec: MissionSpec,
+        tracks: list[str] | None = None,
+    ) -> tuple[WorkItem, ...]:
+        """Decompose the high-level goal, convert to WorkItems, and persist in the queue."""
+        if not self.feature_flags.is_enabled("enable_native_mission"):
+            raise RuntimeError(
+                "Native mission orchestrator is disabled (enable_native_mission flag is OFF)."
+            )
+
+        decomposition = await self.orchestrator.decompose_goal(spec.goal, tracks=tracks)
+        work_items = work_items_from_subtasks(decomposition.subtasks)
+
+        self.store.save_mission(spec, work_items)
+        return work_items

--- a/tests/nomic/test_mission.py
+++ b/tests/nomic/test_mission.py
@@ -6,6 +6,9 @@ from dataclasses import dataclass
 
 import pytest
 
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
 from aragora.config.feature_flags import FeatureFlagRegistry
 from aragora.nomic.mission import (
     MissionSpec,
@@ -13,6 +16,8 @@ from aragora.nomic.mission import (
     WorkItem,
     WorkItemStatus,
     work_items_from_subtasks,
+    MissionStore,
+    NativeMissionRunner,
 )
 
 
@@ -139,3 +144,126 @@ def test_flag_registered_default_off(monkeypatch) -> None:
     monkeypatch.delenv("ARAGORA_ENABLE_NATIVE_MISSION", raising=False)
     reg = FeatureFlagRegistry()
     assert reg.is_enabled("enable_native_mission") is False
+
+
+def test_work_item_from_dict_roundtrip() -> None:
+    wi = WorkItem(
+        item_id="wi-1",
+        description="Write tests",
+        status=WorkItemStatus.RUNNING,
+        complexity="high",
+        file_scope=("a.py", "b.py"),
+        dependencies=("wi-0",),
+    )
+    restored = WorkItem.from_dict(wi.to_dict())
+    assert restored == wi
+
+
+def test_work_item_from_dict_defaults() -> None:
+    wi = WorkItem.from_dict({"item_id": "wi-default", "description": "desc"})
+    assert wi.status is WorkItemStatus.PENDING
+    assert wi.complexity == "low"
+    assert wi.file_scope == ()
+    assert wi.dependencies == ()
+
+
+def test_mission_store_lifecycle(tmp_path: Path) -> None:
+    store = MissionStore(state_dir=tmp_path)
+    spec = _spec(mission_id="mission-test")
+    items = [
+        WorkItem(item_id="sub-1", description="Subtask 1"),
+        WorkItem(item_id="sub-2", description="Subtask 2"),
+    ]
+
+    # Save
+    p = store.save_mission(spec, items)
+    assert p.exists()
+    assert p.name == "mission-test.json"
+
+    # List
+    assert store.list_missions() == ["mission-test"]
+
+    # Load
+    loaded = store.load_mission("mission-test")
+    assert loaded is not None
+    loaded_spec, loaded_items = loaded
+    assert loaded_spec == spec
+    assert len(loaded_items) == 2
+    assert loaded_items[0].item_id == "sub-1"
+    assert loaded_items[1].item_id == "sub-2"
+
+
+def test_mission_store_path_sanitization(tmp_path: Path) -> None:
+    store = MissionStore(state_dir=tmp_path)
+    spec = _spec(mission_id="my-cool_mission-123")
+    p = store.save_mission(spec, [])
+    assert p.name == "my-cool_mission-123.json"
+
+    with pytest.raises(ValueError, match="Invalid mission ID"):
+        store.path_for("   ")
+
+    with pytest.raises(ValueError, match="Invalid mission ID"):
+        store.path_for("../../etc/passwd")
+
+
+def test_runner_raises_when_disabled(monkeypatch) -> None:
+    monkeypatch.setenv("ARAGORA_ENABLE_NATIVE_MISSION", "false")
+    runner = NativeMissionRunner()
+    spec = _spec()
+    with pytest.raises(RuntimeError, match="Native mission orchestrator is disabled"):
+        import asyncio
+
+        asyncio.run(runner.ingest_mission(spec))
+
+
+def test_runner_ingest_mission(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("ARAGORA_ENABLE_NATIVE_MISSION", "true")
+
+    mock_orch = MagicMock()
+    mock_orch.decompose_goal = AsyncMock()
+
+    dummy_subtasks = [
+        _FakeSubTask(id="sub-1", title="Task 1", estimated_complexity="medium"),
+        _FakeSubTask(id="sub-2", title="Task 2", estimated_complexity="low"),
+    ]
+    from aragora.nomic.task_decomposer import TaskDecomposition
+
+    dummy_decomp = TaskDecomposition(
+        original_task="Improve codebase",
+        complexity_score=50,
+        complexity_level="medium",
+        should_decompose=True,
+        subtasks=dummy_subtasks,
+    )
+    mock_orch.decompose_goal.return_value = dummy_decomp
+
+    store = MissionStore(state_dir=tmp_path)
+    runner = NativeMissionRunner(orchestrator=mock_orch, store=store)
+
+    spec = _spec(goal="Improve codebase", mission_id="runner-test-mission")
+
+    import asyncio
+
+    items = asyncio.run(runner.ingest_mission(spec))
+
+    mock_orch.decompose_goal.assert_called_once_with("Improve codebase", tracks=None)
+
+    assert len(items) == 2
+    assert items[0].item_id == "sub-1"
+    assert items[0].complexity == "medium"
+    assert items[1].item_id == "sub-2"
+    assert items[1].complexity == "low"
+
+    loaded = store.load_mission("runner-test-mission")
+    assert loaded is not None
+    loaded_spec, loaded_items = loaded
+    assert loaded_spec == spec
+    assert len(loaded_items) == 2
+    assert loaded_items[0].item_id == "sub-1"
+
+
+def test_runner_lazy_orchestrator(monkeypatch) -> None:
+    runner = NativeMissionRunner()
+    from aragora.nomic.autonomous_orchestrator import AutonomousOrchestrator
+
+    assert isinstance(runner.orchestrator, AutonomousOrchestrator)


### PR DESCRIPTION
Implements PR-1 of the native mission orchestrator (#8463) per docs/plans/2026-06-16-native-mission-orchestrator.md. Includes MissionSpec, MissionStore, AutonomousOrchestrator.decompose_goal seam, NativeMissionRunner, and comprehensive unit tests.