### PR TITLE
feat: implement Native Mission CLI (PR-4)

### DIFF
--- a/aragora/cli/_mission_parser.py
+++ b/aragora/cli/_mission_parser.py
@@ -1,0 +1,41 @@
+"""Argument-parser registration for the ``mission`` subcommand.
+
+Extracted from :mod:`aragora.cli.parser` to keep that module under its LOC
+ratchet. This is pure ``argparse`` wiring with no heavy imports; the command
+handler stays lazy-loaded via the injected ``lazy`` factory so CLI startup
+remains fast.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+
+def add_mission_parser(subparsers: Any, lazy: Callable[[str, str], Callable[..., Any]]) -> None:
+    """Add the ``mission`` subcommand parser."""
+    mission_parser = subparsers.add_parser(
+        "mission",
+        help="Run or manage native missions",
+        description="Ingest a free-text goal, decompose it, and register it to the mission loop.",
+    )
+    mission_parser.add_argument("goal", help="The high-level goal description")
+    mission_parser.add_argument("--budget", type=float, help="The USD budget limit for the mission")
+    mission_parser.add_argument("--max-hours", type=float, help="The maximum run time in hours")
+    mission_parser.add_argument(
+        "--relay",
+        choices=["none", "slack", "email"],
+        default="none",
+        help="The notification relay channel for hard-halt/park actions",
+    )
+    mission_parser.add_argument(
+        "--auto-settle-max-tier",
+        type=int,
+        default=2,
+        choices=[0, 1, 2, 3, 4],
+        help="The maximum merge-quorum evidence quality tier to settle autonomously",
+    )
+    mission_parser.add_argument(
+        "--tracks", help="Comma-separated focus tracks (e.g. sme,qa,billing)"
+    )
+    mission_parser.set_defaults(func=lazy("aragora.cli.commands.mission", "cmd_mission"))

--- a/aragora/cli/_mission_parser.py
+++ b/aragora/cli/_mission_parser.py
@@ -32,8 +32,12 @@ def add_mission_parser(subparsers: Any, lazy: Callable[[str, str], Callable[...,
         "--auto-settle-max-tier",
         type=int,
         default=2,
-        choices=[0, 1, 2, 3, 4],
-        help="The maximum merge-quorum evidence quality tier to settle autonomously",
+        choices=[0, 1, 2],
+        help=(
+            "Highest merge-quorum tier the mission may settle autonomously (0-2). "
+            "Tier-3+ always parks for human risk acceptance — the gate, not the "
+            "mission, is the sole authority for Tier-3/4 settlement."
+        ),
     )
     mission_parser.add_argument(
         "--tracks", help="Comma-separated focus tracks (e.g. sme,qa,billing)"

--- a/aragora/cli/commands/mission.py
+++ b/aragora/cli/commands/mission.py
@@ -1,0 +1,68 @@
+"""Native Mission CLI commands."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+import uuid
+
+from aragora.nomic.mission import MissionSpec, NativeMissionRunner
+
+
+def cmd_mission(args: argparse.Namespace) -> int:
+    """Execute the 'mission' command."""
+    return asyncio.run(_cmd_mission_async(args))
+
+
+async def _cmd_mission_async(args: argparse.Namespace) -> int:
+    # 1. Parse tracks if provided
+    tracks = None
+    if getattr(args, "tracks", None):
+        tracks = [t.strip() for t in args.tracks.split(",") if t.strip()]
+
+    # 2. Generate mission_id
+    mission_id = f"mission-{uuid.uuid4().hex[:12]}"
+
+    # 3. Construct MissionSpec
+    try:
+        spec = MissionSpec(
+            goal=args.goal,
+            mission_id=mission_id,
+            budget_usd=args.budget,
+            max_hours=args.max_hours,
+            relay=args.relay,
+            auto_settle_max_tier=args.auto_settle_max_tier,
+        )
+    except ValueError as e:
+        print(f"Validation error: {e}", file=sys.stderr)
+        return 1
+
+    # 4. Instantiate NativeMissionRunner
+    try:
+        runner = NativeMissionRunner()
+        print(f"Ingesting mission '{mission_id}'...")
+        print(f"Goal: {spec.goal!r}")
+        if spec.budget_usd is not None:
+            print(f"Budget: ${spec.budget_usd:.2f} USD")
+        if spec.max_hours is not None:
+            print(f"Max hours: {spec.max_hours}h")
+        print(f"Relay: {spec.relay}")
+        print(f"Auto-settle max tier: {spec.auto_settle_max_tier}")
+        if tracks:
+            print(f"Tracks: {', '.join(tracks)}")
+
+        work_items = await runner.ingest_mission(spec, tracks=tracks)
+
+        print(f"Success: Mission '{mission_id}' ingested.")
+        print(f"Decomposed into {len(work_items)} work items:")
+        for item in work_items:
+            print(f"  - [{item.item_id}] ({item.complexity}) {item.description}")
+        return 0
+    except RuntimeError as e:
+        # This will catch the RuntimeError if enable_native_mission is OFF
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    except Exception as e:
+        print(f"Unexpected error: {e}", file=sys.stderr)
+        return 1

--- a/aragora/cli/commands/mission.py
+++ b/aragora/cli/commands/mission.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import logging
 import sys
 import uuid
 
 from aragora.nomic.mission import MissionSpec, NativeMissionRunner
+
+logger = logging.getLogger(__name__)
 
 
 def cmd_mission(args: argparse.Namespace) -> int:
@@ -38,31 +41,33 @@ async def _cmd_mission_async(args: argparse.Namespace) -> int:
         print(f"Validation error: {e}", file=sys.stderr)
         return 1
 
-    # 4. Instantiate NativeMissionRunner
+    # 4. Instantiate NativeMissionRunner and ingest. Defer the spec preamble
+    #    until ingest succeeds so a failure (e.g. enable_native_mission OFF)
+    #    doesn't print an accepted-looking summary right before an error.
     try:
         runner = NativeMissionRunner()
         print(f"Ingesting mission '{mission_id}'...")
-        print(f"Goal: {spec.goal!r}")
-        if spec.budget_usd is not None:
-            print(f"Budget: ${spec.budget_usd:.2f} USD")
-        if spec.max_hours is not None:
-            print(f"Max hours: {spec.max_hours}h")
-        print(f"Relay: {spec.relay}")
-        print(f"Auto-settle max tier: {spec.auto_settle_max_tier}")
-        if tracks:
-            print(f"Tracks: {', '.join(tracks)}")
-
         work_items = await runner.ingest_mission(spec, tracks=tracks)
-
-        print(f"Success: Mission '{mission_id}' ingested.")
-        print(f"Decomposed into {len(work_items)} work items:")
-        for item in work_items:
-            print(f"  - [{item.item_id}] ({item.complexity}) {item.description}")
-        return 0
     except RuntimeError as e:
-        # This will catch the RuntimeError if enable_native_mission is OFF
+        # Raised when enable_native_mission is OFF (or runner preconditions fail).
         print(f"Error: {e}", file=sys.stderr)
         return 1
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - CLI boundary: report cleanly, keep the traceback in logs
+        logger.exception("Unexpected error ingesting mission %s", mission_id)
         print(f"Unexpected error: {e}", file=sys.stderr)
         return 1
+
+    print(f"Success: Mission '{mission_id}' ingested.")
+    print(f"Goal: {spec.goal!r}")
+    if spec.budget_usd is not None:
+        print(f"Budget: ${spec.budget_usd:.2f} USD")
+    if spec.max_hours is not None:
+        print(f"Max hours: {spec.max_hours}h")
+    print(f"Relay: {spec.relay}")
+    print(f"Auto-settle max tier: {spec.auto_settle_max_tier}")
+    if tracks:
+        print(f"Tracks: {', '.join(tracks)}")
+    print(f"Decomposed into {len(work_items)} work items:")
+    for item in work_items:
+        print(f"  - [{item.item_id}] ({item.complexity}) {item.description}")
+    return 0

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -163,6 +163,7 @@ Examples:
     _add_mcp_parser(subparsers)
     _add_marketplace_parser(subparsers)
     _add_skills_parser(subparsers)
+    _add_mission_parser(subparsers)
     _add_nomic_parser(subparsers)
     _add_workflow_parser(subparsers)
     _add_deploy_parser(subparsers)
@@ -5370,3 +5371,32 @@ def _add_essay_parser(subparsers) -> None:
         help="Comma-separated model identifiers; first model is used as judge",
     )
     score_parser.set_defaults(func=_lazy("aragora.cli.commands.essay", "essay_command"))
+
+
+def _add_mission_parser(subparsers) -> None:
+    """Add the 'mission' subcommand parser."""
+    mission_parser = subparsers.add_parser(
+        "mission",
+        help="Run or manage native missions",
+        description="Ingest a free-text goal, decompose it, and register it to the mission loop.",
+    )
+    mission_parser.add_argument("goal", help="The high-level goal description")
+    mission_parser.add_argument("--budget", type=float, help="The USD budget limit for the mission")
+    mission_parser.add_argument("--max-hours", type=float, help="The maximum run time in hours")
+    mission_parser.add_argument(
+        "--relay",
+        choices=["none", "slack", "email"],
+        default="none",
+        help="The notification relay channel for hard-halt/park actions",
+    )
+    mission_parser.add_argument(
+        "--auto-settle-max-tier",
+        type=int,
+        default=2,
+        choices=[0, 1, 2, 3, 4],
+        help="The maximum merge-quorum evidence quality tier to settle autonomously",
+    )
+    mission_parser.add_argument(
+        "--tracks", help="Comma-separated focus tracks (e.g. sme,qa,billing)"
+    )
+    mission_parser.set_defaults(func=_lazy("aragora.cli.commands.mission", "cmd_mission"))

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -8,6 +8,7 @@ Separated from command implementations for clarity and maintainability.
 import argparse
 import os
 
+from aragora.cli._mission_parser import add_mission_parser
 from aragora.config import DEFAULT_AGENTS, DEFAULT_CONSENSUS, DEFAULT_ROUNDS
 
 DEFAULT_CAMPAIGN_MANIFEST = ".aragora/campaign_manifest.yaml"
@@ -163,7 +164,7 @@ Examples:
     _add_mcp_parser(subparsers)
     _add_marketplace_parser(subparsers)
     _add_skills_parser(subparsers)
-    _add_mission_parser(subparsers)
+    add_mission_parser(subparsers, _lazy)
     _add_nomic_parser(subparsers)
     _add_workflow_parser(subparsers)
     _add_deploy_parser(subparsers)
@@ -5371,32 +5372,3 @@ def _add_essay_parser(subparsers) -> None:
         help="Comma-separated model identifiers; first model is used as judge",
     )
     score_parser.set_defaults(func=_lazy("aragora.cli.commands.essay", "essay_command"))
-
-
-def _add_mission_parser(subparsers) -> None:
-    """Add the 'mission' subcommand parser."""
-    mission_parser = subparsers.add_parser(
-        "mission",
-        help="Run or manage native missions",
-        description="Ingest a free-text goal, decompose it, and register it to the mission loop.",
-    )
-    mission_parser.add_argument("goal", help="The high-level goal description")
-    mission_parser.add_argument("--budget", type=float, help="The USD budget limit for the mission")
-    mission_parser.add_argument("--max-hours", type=float, help="The maximum run time in hours")
-    mission_parser.add_argument(
-        "--relay",
-        choices=["none", "slack", "email"],
-        default="none",
-        help="The notification relay channel for hard-halt/park actions",
-    )
-    mission_parser.add_argument(
-        "--auto-settle-max-tier",
-        type=int,
-        default=2,
-        choices=[0, 1, 2, 3, 4],
-        help="The maximum merge-quorum evidence quality tier to settle autonomously",
-    )
-    mission_parser.add_argument(
-        "--tracks", help="Comma-separated focus tracks (e.g. sme,qa,billing)"
-    )
-    mission_parser.set_defaults(func=_lazy("aragora.cli.commands.mission", "cmd_mission"))

--- a/aragora/nomic/mission.py
+++ b/aragora/nomic/mission.py
@@ -76,8 +76,11 @@ class MissionSpec:
             raise ValueError("max_hours must be positive or None")
         if self.relay not in _RELAY_CHANNELS:
             raise ValueError(f"relay must be one of {sorted(_RELAY_CHANNELS)}")
-        if not 0 <= self.auto_settle_max_tier <= 4:
-            raise ValueError("auto_settle_max_tier must be in [0, 4]")
+        if not 0 <= self.auto_settle_max_tier <= 2:
+            # Binding guardrail: the mission/relay can never auto-settle Tier-3+;
+            # those park for human risk acceptance and the merge-quorum gate stays
+            # the sole settlement authority. See the native-mission plan doc.
+            raise ValueError("auto_settle_max_tier must be in [0, 2] (Tier-3+ parks for human)")
 
     def to_dict(self) -> dict[str, Any]:
         return {

--- a/tests/cli/test_mission_cli.py
+++ b/tests/cli/test_mission_cli.py
@@ -1,0 +1,152 @@
+"""Tests for the native mission CLI commands."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aragora.cli.parser import build_parser
+from aragora.cli.commands.mission import cmd_mission
+from aragora.nomic.mission import MissionSpec, WorkItem, WorkItemStatus
+
+
+def test_mission_parser_args() -> None:
+    """Test that the mission subcommand parser parses arguments correctly."""
+    parser = build_parser()
+
+    # 1. Parsing with all options
+    args = parser.parse_args(
+        [
+            "mission",
+            "Refactor auth",
+            "--budget",
+            "150.50",
+            "--max-hours",
+            "6.5",
+            "--relay",
+            "slack",
+            "--auto-settle-max-tier",
+            "1",
+            "--tracks",
+            "sme,qa",
+        ]
+    )
+
+    assert args.command == "mission"
+    assert args.goal == "Refactor auth"
+    assert args.budget == 150.50
+    assert args.max_hours == 6.5
+    assert args.relay == "slack"
+    assert args.auto_settle_max_tier == 1
+    assert args.tracks == "sme,qa"
+
+    # 2. Parsing with defaults
+    args_default = parser.parse_args(["mission", "Do something"])
+    assert args_default.command == "mission"
+    assert args_default.goal == "Do something"
+    assert args_default.budget is None
+    assert args_default.max_hours is None
+    assert args_default.relay == "none"
+    assert args_default.auto_settle_max_tier == 2
+    assert args_default.tracks is None
+
+
+def test_mission_parser_invalid_relay() -> None:
+    """Test that the parser rejects invalid relay choices."""
+    parser = build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["mission", "goal", "--relay", "invalid-relay"])
+
+
+def test_cmd_mission_success(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test cmd_mission executes successfully when the feature flag is enabled."""
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "mission",
+            "Refactor auth",
+            "--budget",
+            "50",
+            "--relay",
+            "email",
+            "--tracks",
+            "sme",
+        ]
+    )
+
+    dummy_items = (
+        WorkItem(
+            item_id="wi-1",
+            description="Refactor auth",
+            status=WorkItemStatus.PENDING,
+            complexity="medium",
+        ),
+    )
+
+    # Mock NativeMissionRunner
+    mock_runner_instance = MagicMock()
+    mock_runner_instance.ingest_mission = AsyncMock(return_value=dummy_items)
+
+    with patch(
+        "aragora.cli.commands.mission.NativeMissionRunner", return_value=mock_runner_instance
+    ):
+        exit_code = cmd_mission(args)
+
+        assert exit_code == 0
+
+        captured = capsys.readouterr()
+        assert "Ingesting mission" in captured.out
+        assert "Refactor auth" in captured.out
+        assert "Success: Mission" in captured.out
+        assert "Decomposed into 1 work items" in captured.out
+        assert "wi-1" in captured.out
+        assert "medium" in captured.out
+
+        # Verify runner was called correctly
+        mock_runner_instance.ingest_mission.assert_called_once()
+        called_spec = mock_runner_instance.ingest_mission.call_args[0][0]
+        assert isinstance(called_spec, MissionSpec)
+        assert called_spec.goal == "Refactor auth"
+        assert called_spec.budget_usd == 50.0
+        assert called_spec.relay == "email"
+        assert mock_runner_instance.ingest_mission.call_args[1]["tracks"] == ["sme"]
+
+
+def test_cmd_mission_disabled_flag(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test cmd_mission handles RuntimeError when the feature flag is disabled."""
+    parser = build_parser()
+    args = parser.parse_args(["mission", "Refactor auth"])
+
+    # Mock NativeMissionRunner to raise RuntimeError (matching disabled flag behavior)
+    mock_runner_instance = MagicMock()
+    mock_runner_instance.ingest_mission = AsyncMock(
+        side_effect=RuntimeError("Native mission orchestrator is disabled")
+    )
+
+    with patch(
+        "aragora.cli.commands.mission.NativeMissionRunner", return_value=mock_runner_instance
+    ):
+        exit_code = cmd_mission(args)
+
+        assert exit_code == 1
+
+        captured = capsys.readouterr()
+        assert "Error: Native mission orchestrator is disabled" in captured.err
+
+
+def test_cmd_mission_validation_error(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test cmd_mission handles MissionSpec validation errors gracefully."""
+    parser = build_parser()
+    # Let's parse valid CLI arguments, but trigger a value error at Spec validation,
+    # e.g., by passing a negative budget (which is allowed by parser float type but rejected by MissionSpec)
+    args = parser.parse_args(["mission", "Goal", "--budget", "-10"])
+
+    exit_code = cmd_mission(args)
+    assert exit_code == 1
+
+    captured = capsys.readouterr()
+    assert "Validation error: budget_usd must be non-negative" in captured.err

--- a/tests/nomic/test_mission.py
+++ b/tests/nomic/test_mission.py
@@ -68,10 +68,17 @@ def test_invalid_relay_rejected() -> None:
         assert _spec(relay=ok).relay == ok
 
 
-@pytest.mark.parametrize("bad", [-1, 5])
-def test_auto_settle_tier_range(bad: int) -> None:
+@pytest.mark.parametrize("bad", [-1, 3, 4, 5])
+def test_auto_settle_tier_rejects_out_of_range(bad: int) -> None:
+    # Binding guardrail: the mission may never auto-settle Tier-3+; those park
+    # for human risk acceptance. Tiers 3 and 4 must be rejected, not just <0/>4.
     with pytest.raises(ValueError, match="auto_settle_max_tier"):
         _spec(auto_settle_max_tier=bad)
+
+
+@pytest.mark.parametrize("ok", [0, 1, 2])
+def test_auto_settle_tier_allows_zero_through_two(ok: int) -> None:
+    assert _spec(auto_settle_max_tier=ok).auto_settle_max_tier == ok
 
 
 def test_spec_dict_roundtrip() -> None:


### PR DESCRIPTION
Implements PR-4 of the native mission orchestrator (#8463) per docs/plans/2026-06-16-native-mission-orchestrator.md. Adds the aragora mission CLI command in aragora/cli/commands/mission.py, subparser registration in aragora/cli/parser.py, and comprehensive unit tests in tests/cli/test_mission_cli.py.