### PR TITLE
feat(nomic): relay executor — park-and-notify (native mission PR#3 executor)

### DIFF
--- a/aragora/nomic/mission.py
+++ b/aragora/nomic/mission.py
@@ -25,7 +25,7 @@ import json
 import os
 import tempfile
 from collections.abc import Iterable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import Enum
 from pathlib import Path
 from typing import Any
@@ -232,6 +232,30 @@ class MissionStore:
     def list_missions(self) -> list[str]:
         """List all active mission IDs based on files in the state directory."""
         return [p.stem for p in sorted(self.state_dir.glob("*.json"))]
+
+    def set_item_status(self, mission_id: str, item_id: str, status: WorkItemStatus) -> bool:
+        """Update one work item's status in place and persist.
+
+        Returns True if the item was found and updated, False if the mission or
+        item does not exist. The whole mission is re-saved atomically (the only
+        write path), so a single item update can never corrupt the file.
+        """
+        loaded = self.load_mission(mission_id)
+        if loaded is None:
+            return False
+        spec, items = loaded
+        updated: list[WorkItem] = []
+        found = False
+        for item in items:
+            if item.item_id == item_id:
+                updated.append(replace(item, status=status))
+                found = True
+            else:
+                updated.append(item)
+        if not found:
+            return False
+        self.save_mission(spec, updated)
+        return True
 
 
 class NativeMissionRunner:

--- a/aragora/nomic/mission.py
+++ b/aragora/nomic/mission.py
@@ -239,6 +239,11 @@ class MissionStore:
         Returns True if the item was found and updated, False if the mission or
         item does not exist. The whole mission is re-saved atomically (the only
         write path), so a single item update can never corrupt the file.
+
+        Concurrency: load-modify-save with no lock — assumes a single writer per
+        mission (the single-tick boss_loop / NativeMissionRunner). If a mission
+        store is ever shared across concurrent writers, this needs a flock/CAS
+        (mirroring billing/budget_guard) to avoid lost updates.
         """
         loaded = self.load_mission(mission_id)
         if loaded is None:

--- a/aragora/nomic/mission_relay_executor.py
+++ b/aragora/nomic/mission_relay_executor.py
@@ -1,0 +1,125 @@
+"""Relay executor — the I/O half the pure decision core deferred.
+
+`mission_relay.decide_relay_action` is pure: it only *decides* CONTINUE /
+PARK_AND_NOTIFY / STOP_MISSION. This module turns that decision into real
+effects: PARK_AND_NOTIFY marks the work item ``PARKED`` in the ``MissionStore``
+and (when a relay channel is configured) sends an out-of-band notification;
+STOP_MISSION sends a wind-down notification; CONTINUE is a no-op.
+
+Hard invariant (inherited from the core): NOTHING here merges, settles, or
+marks-ready anything. The only state change is ``WorkItemStatus -> PARKED`` plus
+an advisory notification — the merge-quorum gate stays the sole authority, and a
+parked item is set aside for the operator, never auto-resolved.
+
+This is the executor half of PR #3 of
+``docs/plans/2026-06-16-native-mission-orchestrator.md``. The boss_loop wiring
+(calling ``evaluate_and_apply`` at the loop's per-item halt points) lands
+separately, behind ``enable_native_mission``, in a quiet window.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from aragora.nomic.mission import MissionStore, WorkItemStatus
+from aragora.nomic.mission_relay import (
+    RelayAction,
+    RelayContext,
+    RelayDecision,
+    RelayPolicy,
+    decide_relay_action,
+)
+from aragora.notifications.models import Notification, NotificationChannel
+
+# policy.relay_channel ("none"|"slack"|"email") -> concrete delivery channel.
+_CHANNEL_MAP: dict[str, NotificationChannel] = {
+    "slack": NotificationChannel.SLACK,
+    "email": NotificationChannel.EMAIL,
+}
+
+
+class _Notifier(Protocol):
+    """Minimal duck-typed surface of ``NotificationService`` the executor needs."""
+
+    async def notify(
+        self, notification: Notification, channels: list[NotificationChannel] | None = None
+    ) -> Any: ...
+
+
+@dataclass(frozen=True)
+class RelayOutcome:
+    """What the executor actually did for one item."""
+
+    action: RelayAction
+    reason: str
+    parked: bool = False
+    stopped: bool = False
+    notified: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "action": self.action.value,
+            "reason": self.reason,
+            "parked": self.parked,
+            "stopped": self.stopped,
+            "notified": self.notified,
+        }
+
+
+class MissionRelay:
+    """Applies relay decisions: parks blocked items + notifies; never merges/settles."""
+
+    def __init__(
+        self,
+        policy: RelayPolicy,
+        store: MissionStore,
+        *,
+        notifier: _Notifier | None = None,
+    ) -> None:
+        self.policy = policy
+        self.store = store
+        self.notifier = notifier
+
+    def evaluate(self, ctx: RelayContext) -> RelayDecision:
+        """Pure decision (delegates to the core); no effects."""
+        return decide_relay_action(self.policy, ctx)
+
+    async def apply(self, mission_id: str, item_id: str, decision: RelayDecision) -> RelayOutcome:
+        """Apply a decision: park the item (PARK) and/or notify; CONTINUE is a no-op.
+
+        STOP_MISSION does NOT park the triggering item (it is a global limit, not
+        an item fault) — it only signals the caller to wind the mission down.
+        """
+        if decision.action is RelayAction.PARK_AND_NOTIFY:
+            parked = self.store.set_item_status(mission_id, item_id, WorkItemStatus.PARKED)
+            notified = await self._maybe_notify(mission_id, item_id, decision)
+            return RelayOutcome(decision.action, decision.reason, parked=parked, notified=notified)
+        if decision.action is RelayAction.STOP_MISSION:
+            notified = await self._maybe_notify(mission_id, item_id, decision)
+            return RelayOutcome(decision.action, decision.reason, stopped=True, notified=notified)
+        return RelayOutcome(decision.action, decision.reason)
+
+    async def evaluate_and_apply(
+        self, mission_id: str, item_id: str, ctx: RelayContext
+    ) -> RelayOutcome:
+        """Convenience: decide for ``ctx`` then apply. The one call a loop needs."""
+        return await self.apply(mission_id, item_id, self.evaluate(ctx))
+
+    async def _maybe_notify(self, mission_id: str, item_id: str, decision: RelayDecision) -> bool:
+        if not decision.notify or self.notifier is None:
+            return False
+        channel = _CHANNEL_MAP.get(self.policy.relay_channel)
+        if channel is None:  # relay_channel == "none"
+            return False
+        severity = "warning" if decision.action is RelayAction.PARK_AND_NOTIFY else "error"
+        notification = Notification(
+            title=f"[mission {mission_id}] {decision.action.value}",
+            message=f"item {item_id}: {decision.reason}",
+            severity=severity,
+        )
+        await self.notifier.notify(notification, channels=[channel])
+        return True
+
+
+__all__ = ["MissionRelay", "RelayOutcome"]

--- a/aragora/nomic/mission_relay_executor.py
+++ b/aragora/nomic/mission_relay_executor.py
@@ -93,7 +93,10 @@ class MissionRelay:
         """
         if decision.action is RelayAction.PARK_AND_NOTIFY:
             parked = self.store.set_item_status(mission_id, item_id, WorkItemStatus.PARKED)
-            notified = await self._maybe_notify(mission_id, item_id, decision)
+            # Only notify when the park actually took. If the item/mission vanished
+            # (parked is False) there is nothing to set aside — sending a "parked"
+            # alert would misinform the operator. The caller still sees parked=False.
+            notified = await self._maybe_notify(mission_id, item_id, decision) if parked else False
             return RelayOutcome(decision.action, decision.reason, parked=parked, notified=notified)
         if decision.action is RelayAction.STOP_MISSION:
             notified = await self._maybe_notify(mission_id, item_id, decision)

--- a/tests/nomic/test_mission_relay_executor.py
+++ b/tests/nomic/test_mission_relay_executor.py
@@ -149,6 +149,19 @@ def test_no_crash_when_notifier_absent(tmp_path: Path) -> None:
     assert outcome.notified is False
 
 
+def test_park_failure_does_not_send_misleading_notify(tmp_path: Path) -> None:
+    """If the item/mission vanished, a PARK that didn't take must not notify."""
+    store = _store(tmp_path)
+    _seed(store)
+    notifier = FakeNotifier()
+    relay = MissionRelay(RelayPolicy(relay_channel="slack"), store, notifier=notifier)
+    decision = relay.evaluate(RelayContext(item_id="ghost", needs_human=True))
+    outcome = asyncio.run(relay.apply("m1", "ghost", decision))  # item not in mission
+    assert outcome.parked is False
+    assert outcome.notified is False
+    assert notifier.calls == []  # no "parked" alert about an item we didn't park
+
+
 def test_evaluate_and_apply_end_to_end(tmp_path: Path) -> None:
     store = _store(tmp_path)
     _seed(store)

--- a/tests/nomic/test_mission_relay_executor.py
+++ b/tests/nomic/test_mission_relay_executor.py
@@ -1,0 +1,173 @@
+"""Tests for the relay executor (park + notify) and MissionStore.set_item_status."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from aragora.nomic.mission import MissionSpec, MissionStore, WorkItem, WorkItemStatus
+from aragora.nomic.mission_relay import RelayAction, RelayContext, RelayPolicy
+from aragora.nomic.mission_relay_executor import MissionRelay, RelayOutcome
+
+
+def _store(tmp_path: Path) -> MissionStore:
+    return MissionStore(state_dir=tmp_path)
+
+
+def _seed(store: MissionStore, mission_id: str = "m1") -> None:
+    spec = MissionSpec(goal="ship it", mission_id=mission_id)
+    items = [
+        WorkItem(item_id="i1", description="first"),
+        WorkItem(item_id="i2", description="second"),
+    ]
+    store.save_mission(spec, items)
+
+
+class FakeNotifier:
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
+
+    async def notify(self, notification, channels=None):
+        self.calls.append((notification, channels))
+        return []
+
+
+# --- MissionStore.set_item_status ------------------------------------------
+
+
+def test_set_item_status_parks_one_item_leaves_others(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _seed(store)
+    assert store.set_item_status("m1", "i1", WorkItemStatus.PARKED) is True
+    _, items = store.load_mission("m1")
+    by_id = {i.item_id: i.status for i in items}
+    assert by_id["i1"] is WorkItemStatus.PARKED
+    assert by_id["i2"] is WorkItemStatus.PENDING  # untouched
+
+
+def test_set_item_status_missing_mission_returns_false(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    assert store.set_item_status("nope", "i1", WorkItemStatus.PARKED) is False
+
+
+def test_set_item_status_missing_item_returns_false(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _seed(store)
+    assert store.set_item_status("m1", "ghost", WorkItemStatus.PARKED) is False
+
+
+# --- MissionRelay.evaluate (pure delegation) -------------------------------
+
+
+def test_evaluate_delegates_to_core(tmp_path: Path) -> None:
+    relay = MissionRelay(RelayPolicy(), _store(tmp_path))
+    assert relay.evaluate(RelayContext(item_id="i1")).action is RelayAction.CONTINUE
+    needs_human = RelayContext(item_id="i1", needs_human=True)
+    assert relay.evaluate(needs_human).action is RelayAction.PARK_AND_NOTIFY
+
+
+# --- MissionRelay.apply ----------------------------------------------------
+
+
+def test_apply_park_marks_parked_and_notifies(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _seed(store)
+    notifier = FakeNotifier()
+    relay = MissionRelay(RelayPolicy(relay_channel="slack"), store, notifier=notifier)
+    decision = relay.evaluate(RelayContext(item_id="i1", needs_human=True))
+    outcome = asyncio.run(relay.apply("m1", "i1", decision))
+
+    assert isinstance(outcome, RelayOutcome)
+    assert outcome.action is RelayAction.PARK_AND_NOTIFY
+    assert outcome.parked is True
+    assert outcome.notified is True
+    assert outcome.stopped is False
+    # Persisted.
+    _, items = store.load_mission("m1")
+    assert {i.item_id: i.status for i in items}["i1"] is WorkItemStatus.PARKED
+    # Notified once, on the slack channel.
+    assert len(notifier.calls) == 1
+    _, channels = notifier.calls[0]
+    assert [c.value for c in channels] == ["slack"]
+
+
+def test_apply_stop_notifies_but_does_not_park(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _seed(store)
+    notifier = FakeNotifier()
+    relay = MissionRelay(RelayPolicy(relay_channel="email"), store, notifier=notifier)
+    decision = relay.evaluate(RelayContext(item_id="i1", budget_exhausted=True))
+    outcome = asyncio.run(relay.apply("m1", "i1", decision))
+
+    assert outcome.action is RelayAction.STOP_MISSION
+    assert outcome.stopped is True
+    assert outcome.parked is False
+    assert outcome.notified is True
+    # The triggering item is NOT parked (global limit, not an item fault).
+    _, items = store.load_mission("m1")
+    assert {i.item_id: i.status for i in items}["i1"] is WorkItemStatus.PENDING
+    assert len(notifier.calls) == 1
+
+
+def test_apply_continue_is_noop(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _seed(store)
+    notifier = FakeNotifier()
+    relay = MissionRelay(RelayPolicy(relay_channel="slack"), store, notifier=notifier)
+    decision = relay.evaluate(RelayContext(item_id="i1"))  # healthy
+    outcome = asyncio.run(relay.apply("m1", "i1", decision))
+
+    assert outcome.action is RelayAction.CONTINUE
+    assert (outcome.parked, outcome.stopped, outcome.notified) == (False, False, False)
+    assert notifier.calls == []
+    _, items = store.load_mission("m1")
+    assert {i.item_id: i.status for i in items}["i1"] is WorkItemStatus.PENDING
+
+
+def test_no_notify_when_channel_none(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _seed(store)
+    notifier = FakeNotifier()
+    # relay_channel="none" -> core sets notify=False -> executor must not notify.
+    relay = MissionRelay(RelayPolicy(relay_channel="none"), store, notifier=notifier)
+    decision = relay.evaluate(RelayContext(item_id="i1", needs_human=True))
+    outcome = asyncio.run(relay.apply("m1", "i1", decision))
+    assert outcome.parked is True  # still parks
+    assert outcome.notified is False
+    assert notifier.calls == []
+
+
+def test_no_crash_when_notifier_absent(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _seed(store)
+    relay = MissionRelay(RelayPolicy(relay_channel="slack"), store, notifier=None)
+    decision = relay.evaluate(RelayContext(item_id="i1", needs_human=True))
+    outcome = asyncio.run(relay.apply("m1", "i1", decision))
+    assert outcome.parked is True
+    assert outcome.notified is False
+
+
+def test_evaluate_and_apply_end_to_end(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _seed(store)
+    relay = MissionRelay(
+        RelayPolicy(max_item_failures=2, relay_channel="slack"), store, notifier=FakeNotifier()
+    )
+    ctx = RelayContext(item_id="i2", consecutive_failures=2)  # hits the failure cap -> park
+    outcome = asyncio.run(relay.evaluate_and_apply("m1", "i2", ctx))
+    assert outcome.action is RelayAction.PARK_AND_NOTIFY
+    assert outcome.parked is True
+    _, items = store.load_mission("m1")
+    assert {i.item_id: i.status for i in items}["i2"] is WorkItemStatus.PARKED
+
+
+def test_invariant_executor_never_merges_or_settles() -> None:
+    """The relay can park + notify only — never merge/settle/mark-ready (gate stays sole authority)."""
+    import aragora.nomic.mission_relay_executor as mod
+
+    src = Path(mod.__file__).read_text(encoding="utf-8").lower()
+    for forbidden in ("settle", "merge", "mark_ready", "--admin", "gh pr merge"):
+        # allow the word inside the module docstring's invariant statement, but not as a call.
+        assert f"{forbidden}(" not in src, f"executor must not invoke {forbidden}"


### PR DESCRIPTION
## What

PR #3 (executor half) of the native mission orchestrator (`docs/plans/2026-06-16-native-mission-orchestrator.md`). The pure relay decision core (`mission_relay.decide_relay_action`, #8466) only *decides*; this adds the deferred I/O half that turns a decision into real effects.

- **`MissionStore.set_item_status(mission_id, item_id, status) -> bool`** — update one work item in place (`dataclasses.replace` on the frozen `WorkItem`) and re-save atomically via the existing single write path. `False` if the mission/item is absent. Needed by the executor + future resume/status.
- **`MissionRelay`** (`aragora/nomic/mission_relay_executor.py`) — `evaluate()` delegates to the core; `apply()` turns a `RelayDecision` into effects: **PARK_AND_NOTIFY** marks the item `PARKED` + notifies (when a channel is configured), **STOP_MISSION** notifies a wind-down (does *not* park the trigger — it's a global limit, not an item fault), **CONTINUE** is a no-op. The notifier is duck-typed (`NotificationService.notify`); channel from `policy.relay_channel`.

## Invariant (test-pinned)

The executor **never merges, settles, or marks-ready** anything — the only state change is `WorkItemStatus -> PARKED` plus an advisory notification. The merge-quorum gate stays the sole settlement authority; a parked item waits for the operator. `test_invariant_executor_never_merges_or_settles` enforces this at the source level.

## Safety

- **Zero live-loop edits.** The `boss_loop.py` call site (`evaluate_and_apply` at the per-item halt points, behind `enable_native_mission`) lands separately in a quiet window.
- Default-OFF posture preserved: nothing wires this into a running loop yet.

## Tests / gates

11 new tests (`tests/nomic/test_mission_relay_executor.py`) + 21 existing mission tests green; mypy clean (2 files); ruff clean; import smoke OK.
