### PR TITLE
harden(quorum): retry reviewers only on infra failure, never a verdict (Tier-4, preapproved)

### DIFF
--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -121,6 +121,48 @@ _REVIEWER_CLEANUP_TIMEOUT = 10
 # (e.g. 2x300s). Run them concurrently instead; this cap bounds the fan-out.
 _MAX_REVIEWER_WORKERS = 4
 
+# Retry a reviewer ONLY on infra failure (ok=False: timeout / CLI-not-found /
+# nonzero-exit / empty output) — transport flakiness, not a review. A returned
+# verdict (ok=True), INCLUDING changes_requested, is never retried: that is a
+# real adversarial review and must stand. This does not touch counting rules
+# (FAMILY_PROVIDERS, the 2-distinct-family minimum, Fusion-exclusion) — it only
+# stops a transient CLI timeout from masquerading as a missing/ dissenting family
+# and forcing a manual re-roll. Default 1 retry; 0 disables (env-overridable).
+_REVIEWER_INFRA_RETRIES_ENV = "ARAGORA_COLLECT_EVIDENCE_INFRA_RETRIES"
+_REVIEWER_INFRA_RETRIES_DEFAULT = 1
+
+
+def _reviewer_infra_retries() -> int:
+    raw = os.environ.get(_REVIEWER_INFRA_RETRIES_ENV, "").strip()
+    if not raw:
+        return _REVIEWER_INFRA_RETRIES_DEFAULT
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        return _REVIEWER_INFRA_RETRIES_DEFAULT
+
+
+def _run_reviewer_with_infra_retry(
+    runner: Callable[[str, str], ReviewerResult],
+    family: str,
+    prompt: str,
+    *,
+    retries: int | None = None,
+) -> ReviewerResult:
+    """Invoke ``runner(family, prompt)``, retrying ONLY transport failures.
+
+    Re-runs while the result is an infra failure (``ok is False``) up to
+    ``retries`` extra attempts. A result that returned a verdict (``ok is True``)
+    — pass OR changes_requested — is returned immediately and never retried, so a
+    genuine dissent can never be "retried away". Counting/settlement are unchanged.
+    """
+    attempts_left = _reviewer_infra_retries() if retries is None else max(0, retries)
+    result = runner(family, prompt)
+    while not result.ok and attempts_left > 0:
+        attempts_left -= 1
+        result = runner(family, prompt)
+    return result
+
 
 def _cap_text(text: str) -> str:
     text = text.strip()
@@ -1221,7 +1263,8 @@ def collect_evidence(
         max_workers = min(len(supported), _MAX_REVIEWER_WORKERS)
         with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
             future_to_family = {
-                pool.submit(reviewer_runner, family, prompt): family for family in supported
+                pool.submit(_run_reviewer_with_infra_retry, reviewer_runner, family, prompt): family
+                for family in supported
             }
             for future in concurrent.futures.as_completed(future_to_family):
                 family = future_to_family[future]

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -2111,3 +2111,64 @@ def test_cross_provider_does_not_change_counting_rules() -> None:
     assert "fusion" not in qe.FAMILY_PROVIDERS  # blend must never count as a family
     assert qe.FAMILY_PROVIDERS["grok"] == "xai"
     assert qe.FAMILY_PROVIDERS["gemini"] == "google"
+
+
+# --- Reviewer infra-retry hardening (Tier-4, operator-preapproved 2026-06-16) ---
+from aragora.swarm.quorum_evidence import (  # noqa: E402
+    ReviewerResult as _RR,
+    _run_reviewer_with_infra_retry as _retry,
+)
+
+
+def _seq_runner(results):
+    state = {"n": 0}
+
+    def run(family, prompt):
+        r = results[min(state["n"], len(results) - 1)]
+        state["n"] += 1
+        return r
+
+    run.state = state
+    return run
+
+
+def test_infra_retry_recovers_transient_failure(monkeypatch):
+    monkeypatch.delenv("ARAGORA_COLLECT_EVIDENCE_INFRA_RETRIES", raising=False)
+    runner = _seq_runner([_RR("grok", "", False, "timeout"), _RR("grok", "Verdict: pass", True)])
+    res = _retry(runner, "grok", "p")
+    assert res.ok is True  # second attempt's verdict used
+    assert runner.state["n"] == 2  # retried exactly once
+
+
+def test_infra_retry_never_retries_a_real_verdict(monkeypatch):
+    monkeypatch.delenv("ARAGORA_COLLECT_EVIDENCE_INFRA_RETRIES", raising=False)
+    # A returned changes_requested (ok=True) is a real review — must NOT be retried away.
+    runner = _seq_runner(
+        [_RR("claude", "Verdict: changes-requested", True), _RR("claude", "Verdict: pass", True)]
+    )
+    res = _retry(runner, "claude", "p")
+    assert res.ok is True
+    assert res.text.lower().startswith("verdict: changes")
+    assert runner.state["n"] == 1  # dissent stands; no re-roll
+
+
+def test_infra_retry_exhausts_and_returns_failure(monkeypatch):
+    monkeypatch.setenv("ARAGORA_COLLECT_EVIDENCE_INFRA_RETRIES", "1")
+    runner = _seq_runner([_RR("grok", "", False, "timeout")])  # always fails
+    res = _retry(runner, "grok", "p")
+    assert res.ok is False
+    assert runner.state["n"] == 2  # 1 initial + 1 retry
+
+
+def test_infra_retry_zero_disables(monkeypatch):
+    monkeypatch.setenv("ARAGORA_COLLECT_EVIDENCE_INFRA_RETRIES", "0")
+    runner = _seq_runner([_RR("grok", "", False, "x")])
+    _retry(runner, "grok", "p")
+    assert runner.state["n"] == 1  # no retry when disabled
+
+
+def test_infra_retry_env_count_respected(monkeypatch):
+    monkeypatch.setenv("ARAGORA_COLLECT_EVIDENCE_INFRA_RETRIES", "2")
+    runner = _seq_runner([_RR("grok", "", False, "x")])  # always fails
+    _retry(runner, "grok", "p")
+    assert runner.state["n"] == 3  # 1 initial + 2 retries


### PR DESCRIPTION
## What (Tier-4, operator-preapproved 2026-06-16)

The merge gate's own **reviewer transport** is the dominant conveyor friction observed this session: the CLI reviewers intermittently **time out** (gemini, 300s) or **error** (grok, `unknown`), which is recorded as a failed/non-counting family and forces a **manual quorum re-roll** — even when the code is fine and another family already returned PASS.

This wraps each reviewer dispatch in `_run_reviewer_with_infra_retry`: re-run **only** while the result is an **infra failure** (`ok=False`: timeout / CLI-not-found / nonzero-exit / empty). A result that **returned a verdict** (`ok=True`) — PASS *or* `changes_requested` — is returned immediately and **never retried**, so a genuine adversarial dissent can never be "retried away." Default 1 retry; env-tunable via `ARAGORA_COLLECT_EVIDENCE_INFRA_RETRIES` (0 disables).

## Not a gate weakening

Counting/settlement rules are **untouched**: `FAMILY_PROVIDERS`, the 2-distinct-family minimum, Fusion-exclusion, and `settle_one_pr` authority are all unchanged. The retry only distinguishes *transport flakiness* (`ok=False`) from a *real review* (`ok=True`), and only ever re-runs the former.

## Why Tier-4

`aragora/swarm/quorum_evidence.py` is a merge-authority surface (it composes/validates the evidence the gate counts). Per `docs/REVIEW_AUTHORITY_PRINCIPLES.md` this is a merge-authority self-modification → operator preapproval (granted 2026-06-16) + head-bound operator settlement to merge.

## Tests / gates

5 new tests pin the behavior (retry-recovers-transient, **never-retry-real-verdict**, exhaust-returns-failure, zero-disables, env-count); 117 quorum_evidence tests green; ruff + mypy clean.
