### PR TITLE
ci(structex): docs-link + onboarding-smoke checkers (HEALTH-5 #8262)

### DIFF
--- a/docs/ARAGORA_BUSINESS_SUMMARY.md
+++ b/docs/ARAGORA_BUSINESS_SUMMARY.md
@@ -9,13 +9,13 @@
 |---|---|
 | **Category claim** (Decision Integrity Platform) | [WHY_ARAGORA.md](WHY_ARAGORA.md) |
 | **Current commercial positioning** (what's sellable now, current gate, what not to claim yet) | [COMMERCIAL_OVERVIEW.md](COMMERCIAL_OVERVIEW.md) |
-| **Canonical metrics** (modules, tests, API operations, adapters, agent types) | [CANONICAL_GOALS.md — Canonical Metrics](CANONICAL_GOALS.md#canonical-metrics-march-2026-baseline) |
+| **Canonical metrics** (modules, tests, API operations, adapters, agent types) | [CANONICAL_GOALS.md — Canonical Metrics](CANONICAL_GOALS.md#canonical-metrics) |
 | **Feature inventory** (platform capabilities, scale) | [FEATURE_DISCOVERY.md](FEATURE_DISCOVERY.md) |
 | **Use cases and verticals** (software, healthcare, financial, legal, government, compliance) | [verticals/](verticals/) directory |
 | **Enterprise capabilities** (SSO, MFA, SCIM, RBAC, multi-tenancy, compliance frameworks) | [enterprise/ENTERPRISE_FEATURES.md](enterprise/ENTERPRISE_FEATURES.md) |
 | **GTM strategy and phased adoption** | [strategy/MARKET_TIMING_AND_EXPANSION.md](strategy/MARKET_TIMING_AND_EXPANSION.md) |
 | **Positioning against competitors** | [strategy/POSITIONING_AND_MESSAGING.md — Part 4](strategy/POSITIONING_AND_MESSAGING.md) |
-| **Pricing tiers, revenue projections, BYOK economics** | These are commercial-planning artifacts that are intentionally lower-traffic than the canonical positioning docs. The February 2026 projections are in the archived snapshot below. Current pricing and margin targets are summarized in [CANONICAL_GOALS.md — Canonical Metrics](CANONICAL_GOALS.md#canonical-metrics-march-2026-baseline). |
+| **Pricing tiers, revenue projections, BYOK economics** | These are commercial-planning artifacts that are intentionally lower-traffic than the canonical positioning docs. The February 2026 projections are in the archived snapshot below. Current pricing and margin targets are summarized in [CANONICAL_GOALS.md — Canonical Metrics](CANONICAL_GOALS.md#canonical-metrics). |
 | **February 2026 snapshot** (if you specifically need the historical document, including the revenue-projection tables) | [archive/2026-02-ARAGORA_BUSINESS_SUMMARY_v2.8.0.md](archive/2026-02-ARAGORA_BUSINESS_SUMMARY_v2.8.0.md) |
 
 The archived snapshot is kept as-is for historical reference and is not a current source of truth. Numeric counts (tests, adapters, etc.) and Phase-completion claims there should be treated as a February 2026 snapshot; defer to [CANONICAL_GOALS.md](CANONICAL_GOALS.md) for current baseline metrics and to [FEATURE_GAP_LIST.md](FEATURE_GAP_LIST.md) + [status/NEXT_STEPS_CANONICAL.md](status/NEXT_STEPS_CANONICAL.md) for current execution truth.

--- a/scripts/ci/check_docs_links.py
+++ b/scripts/ci/check_docs_links.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Internal markdown link + anchor checker (standard library only).
+
+Docs onboarding guard (HEALTH-5 #8262): after the P2 docs restructure every
+internal link must still resolve. This checker scans ``README.md`` and
+``docs/**/*.md`` and fails, naming each offender, when:
+
+* a relative link points at a file that does not exist, or
+* an in-document anchor (``target.md#section`` / ``#section``) points at a
+  heading that does not exist in the target markdown file.
+
+External URLs (``http:``, ``mailto:`` ...), images, and links into
+``docs/archive/`` are out of scope. The anchor matching mirrors the proven
+``scripts/check_docs_consistency.py`` logic so the two checkers agree on a
+clean tree.
+
+Usage::
+
+    python3 scripts/ci/check_docs_links.py            # exit 0 when links resolve
+    python3 scripts/ci/check_docs_links.py            # exit 1 naming any offender
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import unquote
+
+LINK_RE = re.compile(r"(?<!!)\[[^\]\n]+\]\(([^)\n]+)\)")
+INLINE_CODE_RE = re.compile(r"`[^`\n]*`")
+HEADING_RE = re.compile(r"^\s{0,3}#{1,6}\s+(.+?)\s*#*\s*$")
+HTML_ID_RE = re.compile(r"""<a\s+[^>]*id=["']([^"']+)["']""", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class LinkIssue:
+    location: str
+    message: str
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def iter_markdown_files(root: Path) -> list[Path]:
+    """README.md plus every tracked markdown file under docs/.
+
+    Falls back to a filesystem walk when ``git ls-files`` is unavailable (e.g.
+    a temporary fixture tree that is not a git checkout).
+    """
+    result = subprocess.run(
+        ["git", "-C", str(root), "ls-files", "-z", "--", "README.md", "docs"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode == 0 and result.stdout:
+        tracked = [root / p for p in result.stdout.split("\0") if p.endswith(".md")]
+        if tracked:
+            return tracked
+
+    files: list[Path] = []
+    readme = root / "README.md"
+    if readme.is_file():
+        files.append(readme)
+    docs = root / "docs"
+    if docs.is_dir():
+        files.extend(sorted(docs.rglob("*.md")))
+    return files
+
+
+def is_url(target: str) -> bool:
+    return bool(re.match(r"^[a-z][a-z0-9+.-]*:", target, re.IGNORECASE)) or target.startswith("//")
+
+
+def strip_link_title(raw: str) -> str:
+    target = raw.strip()
+    if target.startswith("<") and ">" in target:
+        return target[1 : target.index(">")]
+    return target.split()[0] if target.split() else target
+
+
+def split_target(target: str) -> tuple[str, str]:
+    no_title = strip_link_title(target)
+    path_part, sep, anchor = no_title.partition("#")
+    path_part = unquote(path_part.split("?", 1)[0])
+    return path_part, unquote(anchor) if sep else ""
+
+
+def resolve_link(root: Path, source: Path, path_part: str) -> Path:
+    if not path_part:
+        return source
+    if path_part.startswith("/"):
+        return root / path_part.lstrip("/")
+    return (source.parent / path_part).resolve()
+
+
+def normalize_anchor(value: str) -> str:
+    value = unquote(value).lower()
+    value = re.sub(r"`([^`]+)`", r"\1", value)
+    value = re.sub(r"\[[^\]]+\]\(([^)]+)\)", r"\1", value)
+    value = re.sub(r"<[^>]+>", "", value)
+    value = re.sub(r"[^a-z0-9]+", " ", value)
+    return " ".join(value.split())
+
+
+def github_slug(value: str) -> str:
+    return normalize_anchor(value).replace(" ", "-")
+
+
+def headings_for(path: Path) -> set[str]:
+    anchors: set[str] = set()
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return anchors
+    for line in text.splitlines():
+        heading = HEADING_RE.match(line)
+        titles = ([heading.group(1).strip()] if heading else []) + HTML_ID_RE.findall(line)
+        for title in titles:
+            anchors.add(normalize_anchor(title))
+            anchors.add(github_slug(title))
+            anchors.add(normalize_anchor(title).replace(" ", ""))
+    return anchors
+
+
+def anchor_exists(path: Path, anchor: str) -> bool:
+    wanted = normalize_anchor(anchor)
+    compact = wanted.replace(" ", "")
+    for existing in headings_for(path):
+        normalized = normalize_anchor(existing)
+        if normalized == wanted or existing == github_slug(anchor):
+            return True
+        if wanted and normalized.startswith(f"{wanted} "):
+            return True
+        if compact and normalized.replace(" ", "").startswith(compact):
+            return True
+    return False
+
+
+def extract_links(path: Path) -> list[tuple[int, str, str]]:
+    """Return (line_number, raw_target, raw_link_markdown) outside code spans."""
+    links: list[tuple[int, str, str]] = []
+    in_fence = False
+    for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        fence = line.lstrip().startswith("```")
+        if fence:
+            in_fence = not in_fence
+        if fence or in_fence:
+            continue
+        searchable = INLINE_CODE_RE.sub("", line)
+        for match in LINK_RE.finditer(searchable):
+            links.append((line_no, match.group(1).strip(), match.group(0)))
+    return links
+
+
+def find_broken_links(root: Path, files: list[Path] | None = None) -> list[LinkIssue]:
+    root = root.resolve()
+    docs_archive = root / "docs" / "archive"
+    sources = files if files is not None else iter_markdown_files(root)
+    issues: list[LinkIssue] = []
+    for source in sources:
+        try:
+            source.relative_to(docs_archive)
+            continue
+        except ValueError:
+            pass
+        rel_source = _rel(source, root)
+        for line_no, target, link in extract_links(source):
+            if is_url(strip_link_title(target)):
+                continue
+            path_part, anchor = split_target(target)
+            target_path = resolve_link(root, source, path_part)
+            try:
+                target_path.relative_to(docs_archive)
+                continue
+            except ValueError:
+                pass
+            location = f"{rel_source}:{line_no}"
+            if not target_path.exists():
+                issues.append(LinkIssue(location, f"missing link target {link} -> {target}"))
+                continue
+            if (
+                anchor
+                and target_path.suffix.lower() == ".md"
+                and not anchor_exists(target_path, anchor)
+            ):
+                issues.append(LinkIssue(location, f"missing anchor {link} -> {target}"))
+    return issues
+
+
+def _rel(path: Path, root: Path) -> str:
+    try:
+        return path.resolve().relative_to(root).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=repo_root(), help="Repository root")
+    args = parser.parse_args(argv)
+
+    issues = find_broken_links(args.root.resolve())
+    if issues:
+        print(f"check_docs_links: FAIL {len(issues)} broken internal link(s)/anchor(s):")
+        for issue in issues:
+            print(f"  {issue.location}: {issue.message}")
+        print(
+            "Fix the link target, update the anchor, or move the file back; "
+            "external URLs and docs/archive/ are out of scope."
+        )
+        return 1
+
+    print("check_docs_links: OK all internal markdown links and anchors resolve.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/onboarding_smoke.sh
+++ b/scripts/ci/onboarding_smoke.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Onboarding smoke (HEALTH-5 #8262, P2 docs): prove a new contributor can go
+# from a fresh checkout to a working CLI. From a throwaway /tmp virtualenv,
+# install the package from the local checkout and exercise the documented
+# zero-key aragora CLI surface (`--help` then the offline `demo`). Exits 0 only
+# when the whole path works end to end. Run from anywhere inside a checkout.
+set -euo pipefail
+
+# AWS neutralization (library/environment.md): importing aragora.* can otherwise
+# block on a botocore MFA getpass prompt (EOFError) in non-interactive runs.
+export AWS_CONFIG_FILE=/dev/null
+export AWS_SHARED_CREDENTIALS_FILE=/dev/null
+export AWS_EC2_METADATA_DISABLED=true
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SMOKE_VENV="/tmp/aragora-onboarding-smoke-$$"
+SMOKE_WORKDIR="/tmp/aragora-onboarding-smoke-work-$$"
+
+cleanup() {
+    rm -rf "$SMOKE_VENV" "$SMOKE_WORKDIR"
+}
+trap cleanup EXIT
+
+rm -rf "$SMOKE_VENV" "$SMOKE_WORKDIR"
+mkdir -p "$SMOKE_WORKDIR"
+
+# 1. Fresh virtualenv under /tmp (never inside the repo checkout).
+python3 -m venv /tmp/aragora-onboarding-smoke-$$
+VENV_PY="$SMOKE_VENV/bin/python"
+"$VENV_PY" -m pip install --upgrade pip setuptools wheel --quiet
+
+# 2. Install from the local checkout (the documented `pip install` path).
+cd "$REPO_ROOT"
+"$VENV_PY" -m pip install -e ".[test]" --quiet
+# Runtime deps the CLI imports at startup that the pre-P3 root distribution does
+# not yet declare in [project.dependencies]; P3 packaging folds these in.
+"$VENV_PY" -m pip install --quiet httpx aiohttp websockets
+
+# 3. Exercise the documented CLI surface from a scratch dir (keeps repo clean).
+cd "$SMOKE_WORKDIR"
+echo "== aragora --help =="
+"$VENV_PY" -m aragora.cli.main --help >/dev/null
+echo "== aragora demo (zero-key offline debate) =="
+"$VENV_PY" -m aragora.cli.main demo
+
+echo "onboarding smoke: OK (checkout -> venv -> install -> CLI demo)"

--- a/tests/ci/test_check_docs_links.py
+++ b/tests/ci/test_check_docs_links.py
@@ -1,0 +1,139 @@
+"""Unit tests for scripts/ci/check_docs_links.py.
+
+Exercises the pure link/anchor logic and the ``main`` CLI wiring against fake
+checkouts built under ``tmp_path`` (not a git repo, so the checker's filesystem
+fallback discovers the markdown files). The end-to-end behavior on real
+origin/main (green on a clean tree, a README tamper trips it, restore greens
+again) is covered by the VAL-P2-011 acceptance check.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_CHECKER_PATH = REPO_ROOT / "scripts" / "ci" / "check_docs_links.py"
+
+_spec = importlib.util.spec_from_file_location("check_docs_links", _CHECKER_PATH)
+cdl = importlib.util.module_from_spec(_spec)
+# Register before exec so the frozen-annotation dataclass can resolve its module.
+sys.modules["check_docs_links"] = cdl
+_spec.loader.exec_module(cdl)
+
+
+def _write(root: Path, rel: str, body: str) -> Path:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+# --- pure logic -------------------------------------------------------------
+
+
+def test_is_url_distinguishes_schemes():
+    assert cdl.is_url("https://example.com")
+    assert cdl.is_url("mailto:x@example.com")
+    assert cdl.is_url("//cdn.example.com/x")
+    assert not cdl.is_url("docs/guide.md")
+    assert not cdl.is_url("#section")
+
+
+def test_split_target_separates_path_and_anchor():
+    assert cdl.split_target("guide.md#intro") == ("guide.md", "intro")
+    assert cdl.split_target("guide.md") == ("guide.md", "")
+    assert cdl.split_target("#intro") == ("", "intro")
+    assert cdl.split_target('guide.md "Title"') == ("guide.md", "")
+    assert cdl.split_target("<a path.md>") == ("a path.md", "")
+
+
+def test_github_slug_matches_github_heading_rules():
+    assert cdl.github_slug("Canonical Metrics (March 2026 Baseline)") == (
+        "canonical-metrics-march-2026-baseline"
+    )
+    assert cdl.github_slug("`code` & symbols!") == "code-symbols"
+
+
+def test_anchor_exists_matches_heading(tmp_path):
+    target = _write(tmp_path, "doc.md", "# Title\n\n## Canonical Metrics\n\nbody\n")
+    assert cdl.anchor_exists(target, "canonical-metrics")
+    assert cdl.anchor_exists(target, "Canonical Metrics")
+    assert not cdl.anchor_exists(target, "nonexistent-heading")
+
+
+# --- find_broken_links ------------------------------------------------------
+
+
+def test_clean_tree_has_no_issues(tmp_path):
+    _write(tmp_path, "docs/guide.md", "# Guide\n\n## Setup\n\ndetails\n")
+    readme = _write(
+        tmp_path,
+        "README.md",
+        "# Project\n\nSee [the guide](docs/guide.md#setup) and [guide](docs/guide.md).\n",
+    )
+    assert cdl.find_broken_links(tmp_path, files=[readme]) == []
+
+
+def test_missing_file_target_is_reported(tmp_path):
+    readme = _write(tmp_path, "README.md", "# P\n\nbroken [x](docs/does_not_exist.md)\n")
+    issues = cdl.find_broken_links(tmp_path, files=[readme])
+    assert len(issues) == 1
+    assert "docs/does_not_exist.md" in issues[0].message
+    assert issues[0].location == "README.md:3"
+
+
+def test_missing_anchor_is_reported(tmp_path):
+    _write(tmp_path, "docs/guide.md", "# Guide\n\n## Setup\n")
+    readme = _write(tmp_path, "README.md", "# P\n\n[bad](docs/guide.md#teardown)\n")
+    issues = cdl.find_broken_links(tmp_path, files=[readme])
+    assert len(issues) == 1
+    assert "missing anchor" in issues[0].message
+
+
+def test_external_urls_and_images_are_ignored(tmp_path):
+    readme = _write(
+        tmp_path,
+        "README.md",
+        "# P\n\n[site](https://example.com/missing)\n\n![logo](docs/missing.png)\n",
+    )
+    assert cdl.find_broken_links(tmp_path, files=[readme]) == []
+
+
+def test_fenced_code_links_are_ignored(tmp_path):
+    readme = _write(
+        tmp_path,
+        "README.md",
+        "# P\n\n```\n[x](docs/missing.md)\n```\n",
+    )
+    assert cdl.find_broken_links(tmp_path, files=[readme]) == []
+
+
+def test_archive_source_and_target_are_excluded(tmp_path):
+    archived = _write(tmp_path, "docs/archive/old.md", "# Old\n\n[gone](missing.md)\n")
+    readme = _write(tmp_path, "README.md", "# P\n\n[hist](docs/archive/whatever.md)\n")
+    assert cdl.find_broken_links(tmp_path, files=[archived, readme]) == []
+
+
+# --- main CLI wiring --------------------------------------------------------
+
+
+def test_main_green_on_clean_tree(tmp_path, capsys):
+    _write(tmp_path, "docs/guide.md", "# Guide\n\n## Setup\n")
+    _write(tmp_path, "README.md", "# P\n\n[guide](docs/guide.md#setup)\n")
+    assert cdl.main(["--root", str(tmp_path)]) == 0
+    assert "OK" in capsys.readouterr().out
+
+
+def test_main_flags_tamper_and_names_offender(tmp_path, capsys):
+    _write(tmp_path, "docs/guide.md", "# Guide\n\n## Setup\n")
+    _write(
+        tmp_path,
+        "README.md",
+        "# P\n\n[guide](docs/guide.md#setup)\n\nbroken [x](docs/__val_no_such_file__.md)\n",
+    )
+    assert cdl.main(["--root", str(tmp_path)]) == 1
+    out = capsys.readouterr().out
+    assert "docs/__val_no_such_file__.md" in out
+    assert "README.md" in out


### PR DESCRIPTION
## What

Land the docs onboarding CI tooling in-repo (HEALTH-5 #8262, Epic #8257
Structural Excellence, milestone p2-docs). Scripts only; the matching
`.github/workflows/` entries are parked separately as a Tier-4 operator-review
draft.

- **`scripts/ci/check_docs_links.py`** — standard-library-only internal
  markdown link + anchor checker. Scans `README.md` and `docs/**/*.md`; fails
  (exit 1) naming each offender when a relative link points at a missing file
  or an in-document anchor points at a missing heading. External URLs, images,
  and `docs/archive/` are out of scope. Anchor matching mirrors the proven
  `scripts/check_docs_consistency.py` logic, but the scope is broader: it also
  covers depth-1 docs (e.g. `docs/quickstart.md`) that the existing checker's
  `docs/**/*.md` git-pathspec silently skips.
- **`scripts/ci/onboarding_smoke.sh`** — from a throwaway `/tmp` virtualenv,
  installs the package from the local checkout (`pip install -e .`) and
  exercises the documented zero-key CLI surface (`aragora --help` then the
  offline `demo`). Exits 0 only when the full checkout→venv→install→CLI path
  works. Runs with AWS neutralization exported (botocore MFA getpass guard).
- **`tests/ci/test_check_docs_links.py`** — 12 unit cases (green on a clean
  tree, missing-file + missing-anchor detection naming the offender, external
  URLs/images/fenced-code/`archive/` exclusion, and `main` clean+tamper).
- **`docs/ARAGORA_BUSINESS_SUMMARY.md`** — fixes 2 genuinely stale anchors
  (`CANONICAL_GOALS.md#canonical-metrics-march-2026-baseline` →
  `#canonical-metrics`; the heading was renamed to `## Canonical Metrics`)
  surfaced by the new checker. Needed for the checker to be green on main.

## Validation

```
$ python3 scripts/ci/check_docs_links.py        # clean main
check_docs_links: OK all internal markdown links and anchors resolve.   # exit 0
# append a broken [x](docs/__val_no_such_file__.md) to README.md
$ python3 scripts/ci/check_docs_links.py         # exit 1, names README.md offender
$ git checkout -- README.md && python3 scripts/ci/check_docs_links.py    # exit 0
$ bash scripts/ci/onboarding_smoke.sh           # exit 0, prints DECISION RECEIPT
$ python3 scripts/check_docs_consistency.py     # still exit 0
$ python3 -m pytest tests/ci/test_check_docs_links.py -q   # 12 passed
```

`make lint` clean; differential typecheck PASS (new script mypy-clean).

## Risk

Low. Additive `scripts/ci/` + `tests/ci/` plus a 2-line stale-anchor doc fix.
No runtime/package/import surface touched. The link checker is advisory tooling
(wired into CI only via the parked Tier-4 workflow). The onboarding smoke
installs into a disposable `/tmp` venv and cleans up after itself.
