### PR TITLE
ci(structex): park docs-link-check + onboarding-smoke workflows [Tier-4, operator-review-required] (HEALTH-5 #8262)

### DIFF
--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -1,0 +1,42 @@
+# Tier-4 parked workflow (operator-review-required). Wires the in-repo
+# stdlib link checker scripts/ci/check_docs_links.py into CI so a docs move
+# that breaks an internal link/anchor fails the PR. Not merged by the mission;
+# operator reviews and lands it. Modeled on docs-consistency.yml.
+name: Docs Link Check
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "README.md"
+      - "scripts/ci/check_docs_links.py"
+      - ".github/workflows/docs-link-check.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "README.md"
+      - "scripts/ci/check_docs_links.py"
+      - ".github/workflows/docs-link-check.yml"
+
+concurrency:
+  group: docs-link-check-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docs-link-check:
+    name: Docs Link Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Check internal docs links and anchors
+        run: python3 scripts/ci/check_docs_links.py

--- a/.github/workflows/onboarding-smoke.yml
+++ b/.github/workflows/onboarding-smoke.yml
@@ -1,0 +1,45 @@
+# Tier-4 parked workflow (operator-review-required). Wires the in-repo
+# onboarding smoke scripts/ci/onboarding_smoke.sh into CI: a fresh /tmp venv
+# installs the package from the checkout and runs the zero-key aragora CLI
+# demo, proving a new contributor can go checkout -> working CLI. Not merged by
+# the mission; operator reviews and lands it. Modeled on docs-consistency.yml.
+name: Onboarding Smoke
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "pyproject.toml"
+      - "aragora/cli/**"
+      - "scripts/ci/onboarding_smoke.sh"
+      - ".github/workflows/onboarding-smoke.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "pyproject.toml"
+      - "aragora/cli/**"
+      - "scripts/ci/onboarding_smoke.sh"
+      - ".github/workflows/onboarding-smoke.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: onboarding-smoke-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  onboarding-smoke:
+    name: Onboarding Smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run onboarding smoke (fresh venv -> install -> CLI demo)
+        run: bash scripts/ci/onboarding_smoke.sh


### PR DESCRIPTION
## ⚠️ Tier-4 — PARKED draft (operator-review-required). Do NOT auto-merge.

This PR only adds `.github/workflows/` entries, which is a **Tier-4** surface.
Per the Structural Excellence operating contract it is parked as a labeled
draft for the operator to review and land; the mission does **not** merge it.

## What

Wire the two docs-onboarding checkers (already merged to main in #8490) into CI:

- **`.github/workflows/docs-link-check.yml`** — runs
  `python3 scripts/ci/check_docs_links.py` on PRs/pushes touching `docs/**`,
  `README.md`, or the checker. Fails the PR when a docs move breaks an internal
  link or anchor.
- **`.github/workflows/onboarding-smoke.yml`** — runs
  `bash scripts/ci/onboarding_smoke.sh` (fresh `/tmp` venv → install from the
  checkout → zero-key `aragora` CLI demo) on PRs/pushes touching
  `pyproject.toml`, `aragora/cli/**`, or the script; plus `workflow_dispatch`.

Both are modeled on the existing `docs-consistency.yml` (checkout →
setup-python → run). Small, additive, no edits to existing workflows.

## Validation (scripts already green on main #8490)

```
$ python3 scripts/ci/check_docs_links.py        # exit 0 on main
check_docs_links: OK all internal markdown links and anchors resolve.
$ bash scripts/ci/onboarding_smoke.sh            # exit 0, prints DECISION RECEIPT
```

The workflows are not exercised by this PR's own CI (they trigger on their
declared paths); they will run once the operator merges this and a matching
path changes.

## Risk

Tier-4 (CI workflow surface). Parked draft, labeled `operator-review-required`,
never merged by the mission. Both referenced scripts are already on main.
