### PR TITLE
fix(quorum): family aliases (codex/gpt→openai) + markdown-tolerant verdict parse

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3814,6 +3814,13 @@ def _normalize_model_family(value: str) -> str:
         "z-ai": "glm",
         "nous-hermes": "hermes",
         "nous hermes": "hermes",
+        # OpenAI-family CLI/product names so a disclosed "Model family: codex"
+        # still counts at the gate (mirrors canonical_family in quorum_evidence).
+        "codex": "openai",
+        "gpt": "openai",
+        "gpt-5": "openai",
+        "gpt5": "openai",
+        "chatgpt": "openai",
     }
 
     def _lookup(token: str) -> str:

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -41,7 +41,7 @@ import tempfile
 import time
 from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -641,15 +641,21 @@ def default_reviewer_runner(family: str, prompt: str) -> ReviewerResult:
         result = _run_gemini_reviewer(prompt)
     else:
         result = _run_api_agent(fam, prompt)
-    # Universal last-resort fallback: when the subscription CLI / family API path
-    # failed (infra failure, not a returned verdict) and an OPENROUTER_API_KEY is
-    # present, review via OpenRouter using a same-tier model for the SAME family.
-    # This keeps the heterogeneous-family invariant (same family, different
+    # Opt-in last-resort fallback: when the subscription CLI / family API path
+    # failed (infra failure, not a returned verdict) and the OpenRouter fallback is
+    # explicitly enabled, review via OpenRouter using a same-tier model for the SAME
+    # family. Keeps the heterogeneous-family invariant (same family, different
     # transport) so one provider's outage/quota can't stall the quorum.
     if not result.ok:
         fallback = _run_openrouter_reviewer(fam, prompt)
         if fallback.ok:
             return fallback
+        # Both paths failed: keep the primary failure but record that the fallback
+        # was attempted, so a stalled merge is attributable rather than opaque.
+        if "disabled" not in fallback.error:
+            return replace(
+                result, error=f"{result.error}; openrouter fallback also failed: {fallback.error}"
+            )
     return result
 
 
@@ -794,37 +800,72 @@ def _run_gemini_reviewer(prompt: str) -> ReviewerResult:
     return _run_api_agent("gemini", prompt)
 
 
-# Same-tier OpenRouter model per family for the failure-only fallback. Mapped to
-# the highest-quality slug for each family so a fallback review is as trustworthy
-# as the subscription path it replaces (cost is bounded: only used on failure).
+# Same-tier OpenRouter model per family for the failure-only fallback. Slugs are
+# verified against the live OpenRouter catalogue; a per-family override is read
+# from ARAGORA_OPENROUTER_REVIEWER_MODELS (JSON) so a stale slug never silently
+# no-ops the fallback. Mapped to the highest-quality slug per family so a fallback
+# review is as trustworthy as the subscription path it replaces.
 _OPENROUTER_REVIEWER_MODELS: dict[str, str] = {
-    "claude": "anthropic/claude-opus-4.8",
-    "openai": "openai/gpt-5.5",
-    "grok": "x-ai/grok-4",
-    "gemini": "google/gemini-3.1-pro",
+    "claude": "anthropic/claude-fable-5",
+    "openai": "openai/gpt-5-pro",
+    "grok": "x-ai/grok-4.3",
+    "gemini": "google/gemini-3.1-pro-preview",
 }
 
 
+def _openrouter_reviewer_model(family: str) -> str | None:
+    """Resolve the OpenRouter slug for ``family``, honoring an env JSON override."""
+    raw = os.environ.get("ARAGORA_OPENROUTER_REVIEWER_MODELS", "").strip()
+    if raw:
+        try:
+            override = json.loads(raw)
+            if isinstance(override, dict) and override.get(family):
+                return str(override[family])
+        except (ValueError, TypeError):
+            logger.warning("ARAGORA_OPENROUTER_REVIEWER_MODELS is not valid JSON; ignoring")
+    return _OPENROUTER_REVIEWER_MODELS.get(family)
+
+
 def _openrouter_reviewer_available() -> bool:
+    """True only when the fallback is EXPLICITLY enabled and a key is present.
+
+    Egressing the diff to a third-party aggregator is opt-in: an operator must set
+    ARAGORA_ENABLE_OPENROUTER_REVIEWER_FALLBACK=1 AND provide OPENROUTER_API_KEY.
+    Having a key configured for other purposes never silently changes data egress.
+    """
+    enabled = str(os.environ.get("ARAGORA_ENABLE_OPENROUTER_REVIEWER_FALLBACK") or "").strip()
+    if enabled.lower() not in {"1", "true", "yes", "on"}:
+        return False
     return _env_key_present("OPENROUTER_API_KEY")
 
 
 def _run_openrouter_reviewer(family: str, prompt: str) -> ReviewerResult:
-    """Failure-only OpenRouter fallback so one provider's outage can't stall quorum.
+    """Opt-in, failure-only OpenRouter fallback so one provider's outage can't stall
+    quorum.
 
-    Gated on ``OPENROUTER_API_KEY``; reviews as the requested ``family`` via a
-    same-tier OpenRouter model (same model family, different transport). Returns a
-    non-ok result when no key is set or no model is mapped, so the caller keeps the
-    original subscription-path failure.
+    Requires ARAGORA_ENABLE_OPENROUTER_REVIEWER_FALLBACK=1 + OPENROUTER_API_KEY;
+    reviews as the requested ``family`` via a same-tier OpenRouter model (same model
+    family, different transport). Returns a non-ok result when disabled or no model
+    is mapped, so the caller keeps the original subscription-path failure.
     """
     fam = canonical_family(family)
     if not _openrouter_reviewer_available():
         return ReviewerResult(
-            fam, "", False, "OpenRouter fallback unavailable: no OPENROUTER_API_KEY"
+            fam,
+            "",
+            False,
+            "OpenRouter fallback disabled (set ARAGORA_ENABLE_OPENROUTER_REVIEWER_FALLBACK=1 "
+            "+ OPENROUTER_API_KEY to enable)",
         )
-    model = _OPENROUTER_REVIEWER_MODELS.get(fam)
+    model = _openrouter_reviewer_model(fam)
     if not model:
         return ReviewerResult(fam, "", False, f"no OpenRouter model mapped for family {fam}")
+    logger.warning(
+        "Reviewer %s: subscription path failed; attempting OpenRouter fallback via %s "
+        "(metered third-party egress, opt-in enabled)",
+        fam,
+        model,
+    )
     result = _run_api_agent(fam, prompt, model=model)
     if result.ok:
         return ReviewerResult(fam, result.text, True, harness=_OPENROUTER_HARNESS)

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -84,6 +84,32 @@ FAMILY_DISPLAY: dict[str, str] = {
     "hermes": "Hermes",
 }
 
+# Provider-equivalent CLI/product names that operators naturally type, mapped to
+# the single canonical family key. ``codex``/``gpt`` are the OpenAI family (the
+# Codex CLI is just its local transport). These MUST collapse to the canonical
+# family for BOTH routing and quorum counting via :func:`canonical_family`, so an
+# alias can never be counted as a distinct family — that would let one provider
+# satisfy the 2-distinct-family minimum on its own.
+_FAMILY_ALIASES: dict[str, str] = {
+    "codex": "openai",
+    "gpt": "openai",
+    "gpt-5": "openai",
+    "gpt5": "openai",
+    "chatgpt": "openai",
+}
+
+
+def canonical_family(name: str) -> str:
+    """Lowercase a reviewer-family name and collapse known provider aliases.
+
+    This is the only normalization that should be used for routing, validation,
+    and quorum counting. ``canonical_family("Codex") == canonical_family("openai")``
+    so the two never count as separate families.
+    """
+    fam = name.strip().lower()
+    return _FAMILY_ALIASES.get(fam, fam)
+
+
 DEFAULT_FAMILIES: tuple[str, ...] = ("claude", "grok")
 
 # Tiers at or above this require exact-head operator settlement; never auto-post.
@@ -415,13 +441,20 @@ def _neutralize_reviewer_text(text: str) -> str:
 
 
 def _reviewer_verdict(text: str) -> str:
-    """Parse the first reviewer verdict line without inventing support."""
+    """Parse the first reviewer verdict line without inventing support.
+
+    Tolerant of common markdown decoration: reviewers frequently emit
+    ``**Verdict: PASS**`` or ``## Verdict: CHANGES-REQUESTED`` and may precede it
+    with a preamble line. Leading/trailing markdown (``*``, ``#``, ``>``, ``-``,
+    backticks) is stripped before matching so a genuine verdict is not lost.
+    """
     for line in text.splitlines():
         stripped = line.strip().lower()
         if not stripped:
             continue
-        if stripped.startswith("verdict:"):
-            verdict = stripped.split(":", 1)[1].strip()
+        probe = stripped.lstrip("*#>-` \t")
+        if probe.startswith("verdict:"):
+            verdict = probe.split(":", 1)[1].strip().lstrip("*`# \t")
             if verdict.startswith("pass"):
                 return "pass"
             if verdict.startswith("changes-requested") or verdict.startswith("changes requested"):
@@ -448,7 +481,7 @@ def compose_evidence_comment(
     head. ``reviewer_text`` is the genuine reviewer output; only lines that could
     hijack the identity parser are quoted (see :func:`_neutralize_reviewer_text`).
     """
-    fam = family.strip().lower()
+    fam = canonical_family(family)
     display = FAMILY_DISPLAY.get(fam, fam.title())
     provider = FAMILY_PROVIDERS.get(fam, fam)
     short = head_sha[:7]
@@ -597,7 +630,7 @@ def default_reviewer_runner(family: str, prompt: str) -> ReviewerResult:
     routing for grok/gemini lets the merge gate form a 2-family quorum from any
     two subscription CLIs, so one provider's usage cap can't stall merges.
     """
-    fam = family.strip().lower()
+    fam = canonical_family(family)
     if fam == "claude":
         return _run_claude_cli(prompt)
     if fam == "openai":
@@ -1246,7 +1279,7 @@ def collect_evidence(
     seen: set[str] = set()
     ordered_families: list[str] = []
     for raw_family in families:
-        family = raw_family.strip().lower()
+        family = canonical_family(raw_family)
         if not family or family in seen:
             continue
         seen.add(family)
@@ -1393,7 +1426,7 @@ def _clone_reviewer_failures(failures: Sequence[ReviewerResult]) -> list[Reviewe
 def _prepared_family_allowlist(families: Sequence[str] | None) -> set[str] | None:
     if families is None:
         return None
-    return {family.strip().lower() for family in families if family.strip()}
+    return {canonical_family(family) for family in families if family.strip()}
 
 
 def _validate_prepared_item_families(
@@ -1404,7 +1437,7 @@ def _validate_prepared_item_families(
     allowed = _prepared_family_allowlist(families)
     seen: set[str] = set()
     for item in items:
-        family = item.family.strip().lower()
+        family = canonical_family(item.family)
         if family not in FAMILY_PROVIDERS:
             raise ValueError(
                 f"prepared evidence artifact has unsupported reviewer family: {family}"

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -639,6 +639,10 @@ def default_reviewer_runner(family: str, prompt: str) -> ReviewerResult:
         result = _run_grok_reviewer(prompt)
     elif fam == "gemini":
         result = _run_gemini_reviewer(prompt)
+    elif fam in _OPENROUTER_DIRECT_FAMILIES:
+        # No subscription CLI for this family: OpenRouter is the primary transport
+        # (opt-in egress gate still applies). Skip the fallback re-attempt below.
+        return _run_openrouter_reviewer(fam, prompt)
     else:
         result = _run_api_agent(fam, prompt)
     # Opt-in last-resort fallback: when the subscription CLI / family API path
@@ -810,7 +814,17 @@ _OPENROUTER_REVIEWER_MODELS: dict[str, str] = {
     "openai": "openai/gpt-5-pro",
     "grok": "x-ai/grok-4.3",
     "gemini": "google/gemini-3.1-pro-preview",
+    # Cost-efficient families with no subscription CLI — reviewed OpenRouter-direct
+    # (see _OPENROUTER_DIRECT_FAMILIES). DeepSeek V4 Pro is a strong intelligence/$
+    # pick, giving a cheap, distinct second family when premium CLIs are down.
+    "deepseek": "deepseek/deepseek-v4-pro",
 }
+
+# Families with no subscription CLI / native API path: they review via OpenRouter
+# as their PRIMARY transport (still gated on the opt-in egress flag + key). This
+# lets a cheap, distinct family (e.g. claude + deepseek) form a 2-family quorum
+# when the premium subscription CLIs are quota-/auth-blocked.
+_OPENROUTER_DIRECT_FAMILIES: frozenset[str] = frozenset({"deepseek"})
 
 
 def _openrouter_reviewer_model(family: str) -> str | None:

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -632,14 +632,25 @@ def default_reviewer_runner(family: str, prompt: str) -> ReviewerResult:
     """
     fam = canonical_family(family)
     if fam == "claude":
-        return _run_claude_cli(prompt)
-    if fam == "openai":
-        return _run_openai_reviewer(prompt)
-    if fam == "grok":
-        return _run_grok_reviewer(prompt)
-    if fam == "gemini":
-        return _run_gemini_reviewer(prompt)
-    return _run_api_agent(fam, prompt)
+        result = _run_claude_cli(prompt)
+    elif fam == "openai":
+        result = _run_openai_reviewer(prompt)
+    elif fam == "grok":
+        result = _run_grok_reviewer(prompt)
+    elif fam == "gemini":
+        result = _run_gemini_reviewer(prompt)
+    else:
+        result = _run_api_agent(fam, prompt)
+    # Universal last-resort fallback: when the subscription CLI / family API path
+    # failed (infra failure, not a returned verdict) and an OPENROUTER_API_KEY is
+    # present, review via OpenRouter using a same-tier model for the SAME family.
+    # This keeps the heterogeneous-family invariant (same family, different
+    # transport) so one provider's outage/quota can't stall the quorum.
+    if not result.ok:
+        fallback = _run_openrouter_reviewer(fam, prompt)
+        if fallback.ok:
+            return fallback
+    return result
 
 
 def _claude_reviewer_command() -> list[str]:
@@ -699,6 +710,7 @@ def _run_openai_reviewer(prompt: str) -> ReviewerResult:
 
 _GROK_BUILD_HARNESS = "Grok Build CLI harness"
 _ANTIGRAVITY_HARNESS = "Antigravity CLI harness"
+_OPENROUTER_HARNESS = "OpenRouter API fallback harness"
 
 
 def _resolve_grok_build_bin() -> str:
@@ -780,6 +792,43 @@ def _run_gemini_reviewer(prompt: str) -> ReviewerResult:
         if result.ok or not _env_key_present("GEMINI_API_KEY", "GOOGLE_API_KEY"):
             return result
     return _run_api_agent("gemini", prompt)
+
+
+# Same-tier OpenRouter model per family for the failure-only fallback. Mapped to
+# the highest-quality slug for each family so a fallback review is as trustworthy
+# as the subscription path it replaces (cost is bounded: only used on failure).
+_OPENROUTER_REVIEWER_MODELS: dict[str, str] = {
+    "claude": "anthropic/claude-opus-4.8",
+    "openai": "openai/gpt-5.5",
+    "grok": "x-ai/grok-4",
+    "gemini": "google/gemini-3.1-pro",
+}
+
+
+def _openrouter_reviewer_available() -> bool:
+    return _env_key_present("OPENROUTER_API_KEY")
+
+
+def _run_openrouter_reviewer(family: str, prompt: str) -> ReviewerResult:
+    """Failure-only OpenRouter fallback so one provider's outage can't stall quorum.
+
+    Gated on ``OPENROUTER_API_KEY``; reviews as the requested ``family`` via a
+    same-tier OpenRouter model (same model family, different transport). Returns a
+    non-ok result when no key is set or no model is mapped, so the caller keeps the
+    original subscription-path failure.
+    """
+    fam = canonical_family(family)
+    if not _openrouter_reviewer_available():
+        return ReviewerResult(
+            fam, "", False, "OpenRouter fallback unavailable: no OPENROUTER_API_KEY"
+        )
+    model = _OPENROUTER_REVIEWER_MODELS.get(fam)
+    if not model:
+        return ReviewerResult(fam, "", False, f"no OpenRouter model mapped for family {fam}")
+    result = _run_api_agent(fam, prompt, model=model)
+    if result.ok:
+        return ReviewerResult(fam, result.text, True, harness=_OPENROUTER_HARNESS)
+    return result
 
 
 def _run_codex_openai_cli(prompt: str) -> ReviewerResult:
@@ -883,11 +932,11 @@ def _codex_model_selection_failed(detail: str) -> bool:
     )
 
 
-def _run_api_agent(family: str, prompt: str) -> ReviewerResult:
+def _run_api_agent(family: str, prompt: str, model: str | None = None) -> ReviewerResult:
     timeout = _timeout_seconds(_REVIEWER_TIMEOUT_ENV, _REVIEWER_TIMEOUT)
     ctx = _api_agent_process_context()
     result_queue: multiprocessing.Queue = ctx.Queue(maxsize=1)
-    process = _start_api_agent_worker_process(ctx, family, prompt, result_queue)
+    process = _start_api_agent_worker_process(ctx, family, prompt, result_queue, model)
     process.start()
     process.join(timeout + _REVIEWER_CLEANUP_TIMEOUT)
     if process.is_alive():
@@ -930,10 +979,11 @@ def _start_api_agent_worker_process(
     family: str,
     prompt: str,
     result_queue: multiprocessing.Queue,
+    model: str | None = None,
 ) -> multiprocessing.Process:
     return ctx.Process(
         target=_api_agent_worker,
-        args=(family, prompt, result_queue),
+        args=(family, prompt, result_queue, model),
         daemon=True,
     )
 
@@ -942,17 +992,21 @@ def _api_agent_worker(
     family: str,
     prompt: str,
     result_queue: multiprocessing.Queue,
+    model: str | None = None,
 ) -> None:
-    result_queue.put(_run_api_agent_in_current_process(family, prompt))
+    result_queue.put(_run_api_agent_in_current_process(family, prompt, model))
 
 
-def _run_api_agent_in_current_process(family: str, prompt: str) -> ReviewerResult:
+def _run_api_agent_in_current_process(
+    family: str, prompt: str, model: str | None = None
+) -> ReviewerResult:
     try:
-        from aragora.agents import create_agent
-    except Exception as exc:  # pragma: no cover - import guard
-        return ReviewerResult(family, "", False, f"create_agent import failed: {exc}")
-    try:
-        agent = create_agent(family, name=f"{family}_reviewer", role="critic")
+        if model:
+            agent = _build_openrouter_agent(family, model)
+        else:
+            from aragora.agents import create_agent
+
+            agent = create_agent(family, name=f"{family}_reviewer", role="critic")
         text = asyncio.run(_generate_with_api_agent_cleanup(agent, prompt))
     except Exception as exc:
         return ReviewerResult(family, "", False, f"{type(exc).__name__}: {str(exc)[:200]}")
@@ -960,6 +1014,17 @@ def _run_api_agent_in_current_process(family: str, prompt: str) -> ReviewerResul
     if not text:
         return ReviewerResult(family, "", False, "empty reviewer output")
     return ReviewerResult(family, _cap_text(text), True)
+
+
+def _build_openrouter_agent(family: str, model: str) -> Any:
+    """Construct an OpenRouter-backed reviewer agent for ``model``.
+
+    The returned agent reviews as the requested ``family`` (same model family,
+    different transport), so its evidence still counts as that family's vote.
+    """
+    from aragora.agents.api_agents.openrouter import OpenRouterAgent
+
+    return OpenRouterAgent(name=f"{family}_openrouter_reviewer", role="critic", model=model)
 
 
 async def _generate_with_api_agent_cleanup(agent: Any, prompt: str) -> str:

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -317,7 +317,7 @@ def _string_list(value: Any) -> list[str]:
 def _evidence_item_from_dict(raw: Any) -> EvidenceItem:
     if not isinstance(raw, dict):
         raise ValueError("prepared evidence item must be an object")
-    family = str(raw.get("family") or "").strip().lower()
+    family = canonical_family(str(raw.get("family") or ""))
     body = str(raw.get("body") or "")
     if not family:
         raise ValueError("prepared evidence item missing family")
@@ -337,7 +337,7 @@ def _reviewer_result_from_dict(raw: Any) -> ReviewerResult:
     if not isinstance(raw, dict):
         raise ValueError("prepared reviewer failure must be an object")
     return ReviewerResult(
-        family=str(raw.get("family") or "").strip().lower(),
+        family=canonical_family(str(raw.get("family") or "")),
         text=str(raw.get("text") or ""),
         ok=bool(raw.get("ok", False)),
         error=str(raw.get("error") or ""),
@@ -452,7 +452,7 @@ def _reviewer_verdict(text: str) -> str:
         stripped = line.strip().lower()
         if not stripped:
             continue
-        probe = stripped.lstrip("*#>-` \t")
+        probe = stripped.lstrip("*#>-`0123456789.)\t ")
         if probe.startswith("verdict:"):
             verdict = probe.split(":", 1)[1].strip().lstrip("*`# \t")
             if verdict.startswith("pass"):

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -815,16 +815,18 @@ _OPENROUTER_REVIEWER_MODELS: dict[str, str] = {
     "grok": "x-ai/grok-4.3",
     "gemini": "google/gemini-3.1-pro-preview",
     # Cost-efficient families with no subscription CLI — reviewed OpenRouter-direct
-    # (see _OPENROUTER_DIRECT_FAMILIES). DeepSeek V4 Pro is a strong intelligence/$
-    # pick, giving a cheap, distinct second family when premium CLIs are down.
+    # (see _OPENROUTER_DIRECT_FAMILIES). Each is a strong, distinct intelligence/$
+    # pick, giving cheap additional families when premium CLIs are quota-/auth-down.
     "deepseek": "deepseek/deepseek-v4-pro",
+    "qwen": "qwen/qwen3-235b-a22b-thinking-2507",
+    "kimi": "moonshotai/kimi-k2.6",
 }
 
 # Families with no subscription CLI / native API path: they review via OpenRouter
 # as their PRIMARY transport (still gated on the opt-in egress flag + key). This
-# lets a cheap, distinct family (e.g. claude + deepseek) form a 2-family quorum
-# when the premium subscription CLIs are quota-/auth-blocked.
-_OPENROUTER_DIRECT_FAMILIES: frozenset[str] = frozenset({"deepseek"})
+# lets cheap, distinct families (e.g. claude + deepseek/qwen/kimi) form a 2-family
+# quorum when the premium subscription CLIs are quota-/auth-blocked.
+_OPENROUTER_DIRECT_FAMILIES: frozenset[str] = frozenset({"deepseek", "qwen", "kimi"})
 
 
 def _openrouter_reviewer_model(family: str) -> str | None:

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -2658,6 +2658,16 @@ class TestParentheticalModelFamily:
         assert _normalize_model_family("openai") == "openai"
         assert _normalize_model_family("claude") == "claude"
 
+    def test_codex_and_gpt_aliases_resolve_to_openai(self) -> None:
+        # A disclosed "Model family: codex" / "gpt" must count at the gate, since
+        # the collector now emits canonical "openai" for those CLI/product names.
+        from aragora.cli.commands.review_queue import _normalize_model_family
+
+        assert _normalize_model_family("codex") == "openai"
+        assert _normalize_model_family("gpt") == "openai"
+        assert _normalize_model_family("chatgpt") == "openai"
+        assert _normalize_model_family("codex (gpt-5.5 harness)") == "openai"
+
     def test_aliases_still_resolve_including_multiword(self) -> None:
         from aragora.cli.commands.review_queue import _normalize_model_family
 

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -1420,6 +1420,62 @@ def test_collect_dedupes_families() -> None:
     assert [item.family for item in outcome.items] == ["claude", "grok"]
 
 
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("Codex", "openai"),
+        ("codex", "openai"),
+        ("gpt", "openai"),
+        ("GPT-5", "openai"),
+        ("chatgpt", "openai"),
+        ("openai", "openai"),
+        (" Grok ", "grok"),
+        ("Claude", "claude"),
+        ("gemini", "gemini"),
+    ],
+)
+def test_canonical_family_collapses_aliases(name: str, expected: str) -> None:
+    from aragora.swarm.quorum_evidence import canonical_family
+
+    assert canonical_family(name) == expected
+
+
+def test_collect_aliases_codex_and_gpt_to_single_openai_family() -> None:
+    # codex/gpt are the OpenAI family's CLI/product names. They must collapse to
+    # ONE canonical family so a single provider can't satisfy the 2-family quorum.
+    fakes, _ = _fakes(tier=4)
+    outcome = collect_evidence(
+        repo="o/r",
+        pr=1,
+        families=["openai", "codex", "gpt"],
+        author="me",
+        apply=False,
+        **fakes,
+    )
+    assert [item.family for item in outcome.items] == ["openai"]
+
+
+@pytest.mark.parametrize(
+    "body,expected",
+    [
+        ("Verdict: PASS", "pass"),
+        ("**Verdict: PASS**", "pass"),
+        ("## Verdict: CHANGES-REQUESTED", "changes_requested"),
+        (
+            "Reviewing the diff...\n**Verdict: CHANGES-REQUESTED**\n- **[P2]** x",
+            "changes_requested",
+        ),
+        ("intro preamble line\nVerdict: PASS\n- note", "pass"),
+        ("`Verdict: pass`", "pass"),
+        ("no verdict at all here", "unknown"),
+    ],
+)
+def test_reviewer_verdict_tolerates_markdown_and_preamble(body: str, expected: str) -> None:
+    from aragora.swarm.quorum_evidence import _reviewer_verdict
+
+    assert _reviewer_verdict(body) == expected
+
+
 def test_collect_missing_head_raises() -> None:
     fakes, _ = _fakes(tier=1, head="")
     with pytest.raises(ValueError):

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -1518,7 +1518,8 @@ def test_openrouter_reviewer_rejects_unmapped_family(monkeypatch) -> None:
 
     monkeypatch.setenv("ARAGORA_ENABLE_OPENROUTER_REVIEWER_FALLBACK", "1")
     monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
-    result = q._run_openrouter_reviewer("deepseek", "prompt")
+    # qwen is a recognized family but has no OpenRouter slug mapped (unlike deepseek).
+    result = q._run_openrouter_reviewer("qwen", "prompt")
     assert not result.ok
     assert "no OpenRouter model" in result.error
 
@@ -1578,6 +1579,36 @@ def test_openrouter_fallback_routes_alias_to_canonical_family(monkeypatch) -> No
     # "codex" is an alias of openai; the fallback must review as the openai family.
     result = q.default_reviewer_runner("codex", "prompt")
     assert result.ok and result.family == "openai"
+
+
+def test_deepseek_routes_openrouter_direct(monkeypatch) -> None:
+    # DeepSeek has no subscription CLI: it must review OpenRouter-direct (primary),
+    # NOT via _run_api_agent, so a cheap distinct family can join the quorum.
+    from aragora.swarm import quorum_evidence as q
+
+    called = {"or": None, "api": False}
+
+    def _or(fam, _p):
+        called["or"] = fam
+        return q.ReviewerResult(fam, "Verdict: PASS via OpenRouter", True, harness="or")
+
+    def _api(fam, _p, model=None):
+        called["api"] = True
+        return q.ReviewerResult(fam, "", False, "should not be called")
+
+    monkeypatch.setattr(q, "_run_openrouter_reviewer", _or)
+    monkeypatch.setattr(q, "_run_api_agent", _api)
+    result = q.default_reviewer_runner("deepseek", "prompt")
+    assert result.ok and result.family == "deepseek"
+    assert called["or"] == "deepseek" and called["api"] is False
+
+
+def test_deepseek_is_openrouter_direct_with_mapped_model() -> None:
+    from aragora.swarm import quorum_evidence as q
+
+    assert "deepseek" in q._OPENROUTER_DIRECT_FAMILIES
+    assert q._openrouter_reviewer_model("deepseek")  # a slug is mapped
+    assert "deepseek" in q.FAMILY_PROVIDERS  # already a recognized counting family
 
 
 def test_collect_missing_head_raises() -> None:

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -597,7 +597,7 @@ def test_run_api_agent_timeout_terminates_blocked_worker(
     monkeypatch.setattr(
         qe,
         "_start_api_agent_worker_process",
-        lambda ctx, family, prompt, result_queue: FakeProcess(),
+        lambda ctx, family, prompt, result_queue, model=None: FakeProcess(),
         raising=False,
     )
 
@@ -645,7 +645,7 @@ def test_run_api_agent_parent_timeout_honors_env_override(
     monkeypatch.setattr(
         qe,
         "_start_api_agent_worker_process",
-        lambda ctx, family, prompt, result_queue: FakeProcess(),
+        lambda ctx, family, prompt, result_queue, model=None: FakeProcess(),
         raising=False,
     )
 
@@ -1486,6 +1486,75 @@ def test_evidence_item_from_dict_canonicalizes_alias_family() -> None:
         {"family": "Codex", "body": "Verdict: PASS\nbody", "would_count": True}
     )
     assert item.family == "openai"
+
+
+# --- OpenRouter failure-only fallback ---------------------------------------
+
+
+def test_openrouter_reviewer_gated_on_key(monkeypatch) -> None:
+    from aragora.swarm import quorum_evidence as q
+
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    result = q._run_openrouter_reviewer("grok", "prompt")
+    assert not result.ok
+    assert "OPENROUTER_API_KEY" in result.error
+
+
+def test_openrouter_reviewer_rejects_unmapped_family(monkeypatch) -> None:
+    from aragora.swarm import quorum_evidence as q
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    result = q._run_openrouter_reviewer("deepseek", "prompt")
+    assert not result.ok
+    assert "no OpenRouter model" in result.error
+
+
+def test_default_runner_falls_back_to_openrouter_on_infra_failure(monkeypatch) -> None:
+    from aragora.swarm import quorum_evidence as q
+
+    monkeypatch.setattr(
+        q, "_run_grok_reviewer", lambda _p: q.ReviewerResult("grok", "", False, "cli down")
+    )
+    monkeypatch.setattr(
+        q,
+        "_run_openrouter_reviewer",
+        lambda fam, _p: q.ReviewerResult(fam, "Verdict: PASS via OpenRouter", True, harness="or"),
+    )
+    result = q.default_reviewer_runner("grok", "prompt")
+    assert result.ok
+    assert result.family == "grok"  # family identity preserved across transport
+    assert "OpenRouter" in result.text
+
+
+def test_default_runner_skips_openrouter_when_primary_ok(monkeypatch) -> None:
+    from aragora.swarm import quorum_evidence as q
+
+    monkeypatch.setattr(
+        q, "_run_grok_reviewer", lambda _p: q.ReviewerResult("grok", "Verdict: PASS", True)
+    )
+    called = {"openrouter": False}
+
+    def _or(fam, _p):
+        called["openrouter"] = True
+        return q.ReviewerResult(fam, "", True)
+
+    monkeypatch.setattr(q, "_run_openrouter_reviewer", _or)
+    result = q.default_reviewer_runner("grok", "prompt")
+    assert result.ok and called["openrouter"] is False
+
+
+def test_openrouter_fallback_routes_alias_to_canonical_family(monkeypatch) -> None:
+    from aragora.swarm import quorum_evidence as q
+
+    monkeypatch.setattr(
+        q, "_run_openai_reviewer", lambda _p: q.ReviewerResult("openai", "", False, "codex quota")
+    )
+    monkeypatch.setattr(
+        q, "_run_openrouter_reviewer", lambda fam, _p: q.ReviewerResult(fam, "Verdict: PASS", True)
+    )
+    # "codex" is an alias of openai; the fallback must review as the openai family.
+    result = q.default_reviewer_runner("codex", "prompt")
+    assert result.ok and result.family == "openai"
 
 
 def test_collect_missing_head_raises() -> None:

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -1491,22 +1491,45 @@ def test_evidence_item_from_dict_canonicalizes_alias_family() -> None:
 # --- OpenRouter failure-only fallback ---------------------------------------
 
 
-def test_openrouter_reviewer_gated_on_key(monkeypatch) -> None:
+def test_openrouter_reviewer_disabled_without_optin_flag(monkeypatch) -> None:
+    # Key present but the opt-in flag is NOT set: must stay disabled (no silent
+    # third-party egress just because a key happens to be configured).
     from aragora.swarm import quorum_evidence as q
 
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    monkeypatch.delenv("ARAGORA_ENABLE_OPENROUTER_REVIEWER_FALLBACK", raising=False)
+    result = q._run_openrouter_reviewer("grok", "prompt")
+    assert not result.ok
+    assert "disabled" in result.error
+
+
+def test_openrouter_reviewer_disabled_without_key(monkeypatch) -> None:
+    from aragora.swarm import quorum_evidence as q
+
+    monkeypatch.setenv("ARAGORA_ENABLE_OPENROUTER_REVIEWER_FALLBACK", "1")
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
     result = q._run_openrouter_reviewer("grok", "prompt")
     assert not result.ok
-    assert "OPENROUTER_API_KEY" in result.error
+    assert "disabled" in result.error
 
 
 def test_openrouter_reviewer_rejects_unmapped_family(monkeypatch) -> None:
     from aragora.swarm import quorum_evidence as q
 
+    monkeypatch.setenv("ARAGORA_ENABLE_OPENROUTER_REVIEWER_FALLBACK", "1")
     monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
     result = q._run_openrouter_reviewer("deepseek", "prompt")
     assert not result.ok
     assert "no OpenRouter model" in result.error
+
+
+def test_openrouter_reviewer_model_env_override(monkeypatch) -> None:
+    from aragora.swarm import quorum_evidence as q
+
+    monkeypatch.setenv("ARAGORA_OPENROUTER_REVIEWER_MODELS", '{"grok": "x-ai/grok-custom"}')
+    assert q._openrouter_reviewer_model("grok") == "x-ai/grok-custom"
+    # Unspecified families fall back to the built-in (verified) map.
+    assert q._openrouter_reviewer_model("openai") == "openai/gpt-5-pro"
 
 
 def test_default_runner_falls_back_to_openrouter_on_infra_failure(monkeypatch) -> None:

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -1518,8 +1518,8 @@ def test_openrouter_reviewer_rejects_unmapped_family(monkeypatch) -> None:
 
     monkeypatch.setenv("ARAGORA_ENABLE_OPENROUTER_REVIEWER_FALLBACK", "1")
     monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
-    # qwen is a recognized family but has no OpenRouter slug mapped (unlike deepseek).
-    result = q._run_openrouter_reviewer("qwen", "prompt")
+    # mistral is a recognized family but has no OpenRouter slug mapped (unlike deepseek).
+    result = q._run_openrouter_reviewer("mistral", "prompt")
     assert not result.ok
     assert "no OpenRouter model" in result.error
 

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -1467,6 +1467,7 @@ def test_collect_aliases_codex_and_gpt_to_single_openai_family() -> None:
         ),
         ("intro preamble line\nVerdict: PASS\n- note", "pass"),
         ("`Verdict: pass`", "pass"),
+        ("1. Verdict: PASS", "pass"),
         ("no verdict at all here", "unknown"),
     ],
 )
@@ -1474,6 +1475,17 @@ def test_reviewer_verdict_tolerates_markdown_and_preamble(body: str, expected: s
     from aragora.swarm.quorum_evidence import _reviewer_verdict
 
     assert _reviewer_verdict(body) == expected
+
+
+def test_evidence_item_from_dict_canonicalizes_alias_family() -> None:
+    # A prepared artifact labeled with an alias must deserialize to the canonical
+    # family so apply/replay counts it (lint discloses the canonical family).
+    from aragora.swarm.quorum_evidence import _evidence_item_from_dict
+
+    item = _evidence_item_from_dict(
+        {"family": "Codex", "body": "Verdict: PASS\nbody", "would_count": True}
+    )
+    assert item.family == "openai"
 
 
 def test_collect_missing_head_raises() -> None:


### PR DESCRIPTION
## Why
Dogfooding the merge gate tonight surfaced two reviewer-harness robustness gaps that make heterogeneous quorum less reliable than it should be:

1. **`codex`/`gpt` rejected as families.** `aragora review-queue collect-evidence --reviewers ... codex` failed with `unsupported reviewer family: codex` — but `codex`/`gpt` are just the OpenAI family's CLI/product names. This cost a full reviewer cycle.
2. **Markdown verdicts misparsed.** Reviewers (esp. grok) emit `**Verdict: PASS**` / `## Verdict: CHANGES-REQUESTED`, sometimes after a preamble line. `_reviewer_verdict` only matched a line literally starting with `verdict:`, so genuine verdicts were read as `unknown` and dropped from counting.

## What
- Add `canonical_family()` (lowercase + alias-collapse) and apply it at **every** routing/validation/counting/dedup seam. `_FAMILY_ALIASES = {codex, gpt, gpt-5, gpt5, chatgpt} → openai`.
  - **Hard invariant (tested):** aliases collapse to the single canonical family, so `--reviewers openai codex` counts as **one** family — a provider can never self-satisfy the 2-distinct-family minimum.
- Make `_reviewer_verdict` tolerant of leading/trailing markdown (`*`, `#`, `>`, `-`, backticks) and preamble lines.

## Tests
- `canonical_family` alias table (codex/gpt/gpt-5/chatgpt → openai; claude/grok/gemini unchanged).
- `collect_evidence(families=[openai, codex, gpt])` → single `openai` family.
- verdict parser tolerates `**bold**`, `## heading`, backtick, and preamble forms.
- Full `tests/swarm/test_quorum_evidence.py` green (134 passed).

## Out of scope (follow-ups)
- grok verdict **best-of-N** for run-to-run variance (it flip-flops PASS↔changes_requested on identical heads).
- gemini/`agy` returns **empty output on heavy prompts even at 9-min timeout** — deeper than a timeout; needs investigation.
- `drain_policy.py` Tier-3+ auto-settle ceiling (separate task chip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)