### PR TITLE
feat(routing): syftr-pattern Pareto search over debate-workflow configs

### DIFF
--- a/aragora/routing/debate_config_search.py
+++ b/aragora/routing/debate_config_search.py
@@ -1,0 +1,163 @@
+"""Pareto-optimal debate-workflow search (syftr-pattern).
+
+Where :mod:`aragora.routing.cost_quality_optimizer` picks the cost/quality-optimal
+*provider* from observed metrics, this module searches over debate **workflow
+configurations** — number of rounds, consensus mode, and the reviewing model
+family set — to surface the configs on the cost / quality / latency Pareto
+frontier.
+
+Inspired by DataRobot's syftr (Pareto-optimized agentic workflows) but deliberately
+dependency-free: instead of pulling in Optuna/MOTPE we use a *bounded* enumeration
+of the (small, discrete) debate config space plus multi-objective non-domination.
+The objective is pluggable — in production an evaluator runs a real debate and
+reads cost from ``billing.cost_tracker``, quality from ``evaluation.llm_judge``, and
+wall-clock latency; in tests it is a pure function. This keeps the expensive,
+credential-bound part (actually running debates) out of the searchable core so the
+search logic is fully unit-testable offline.
+
+Cost note: a search runs one debate per trial, so it spends real money. Trials are
+bounded by ``max_trials`` (default small) and the whole point is to *find* the cheap
+configs — run a search once, then reuse the recommended config.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from typing import Optional
+
+__all__ = [
+    "DebateConfig",
+    "ConfigEvaluation",
+    "DebateSearchSpace",
+    "SearchResult",
+    "pareto_optimal",
+    "search_pareto_configs",
+]
+
+
+@dataclass(frozen=True)
+class DebateConfig:
+    """One point in the debate-workflow search space."""
+
+    rounds: int
+    consensus: str
+    families: tuple[str, ...]
+
+    def label(self) -> str:
+        return f"r{self.rounds}/{self.consensus}/{'+'.join(self.families)}"
+
+
+@dataclass(frozen=True)
+class ConfigEvaluation:
+    """A config scored on the three objectives: cost ↓, quality ↑, latency ↓."""
+
+    config: DebateConfig
+    cost_usd: float
+    quality: float  # normalized 0..1, higher is better
+    latency_s: float
+
+    def dominates(self, other: "ConfigEvaluation") -> bool:
+        """True if this evaluation Pareto-dominates ``other``.
+
+        Dominates ≡ no worse on every objective AND strictly better on ≥1.
+        """
+        no_worse = (
+            self.cost_usd <= other.cost_usd
+            and self.quality >= other.quality
+            and self.latency_s <= other.latency_s
+        )
+        strictly_better = (
+            self.cost_usd < other.cost_usd
+            or self.quality > other.quality
+            or self.latency_s < other.latency_s
+        )
+        return no_worse and strictly_better
+
+
+@dataclass(frozen=True)
+class DebateSearchSpace:
+    """The discrete grid of debate configs to search.
+
+    Defaults stay small and cheap-leaning (DeepSeek pairing first) so an
+    unconfigured search doesn't fan out into an expensive combinatorial sweep.
+    """
+
+    rounds: tuple[int, ...] = (1, 2, 3)
+    consensus_modes: tuple[str, ...] = ("majority", "unanimous", "prover_estimator")
+    family_sets: tuple[tuple[str, ...], ...] = (
+        ("claude", "deepseek"),
+        ("claude", "openai"),
+        ("claude", "openai", "grok"),
+    )
+
+    def enumerate(self) -> list[DebateConfig]:
+        """All configs in the grid, deterministically ordered (cheapest-leaning first)."""
+        configs: list[DebateConfig] = []
+        for families in self.family_sets:
+            for rounds in self.rounds:
+                for consensus in self.consensus_modes:
+                    configs.append(
+                        DebateConfig(rounds=rounds, consensus=consensus, families=families)
+                    )
+        return configs
+
+
+def pareto_optimal(evaluations: Sequence[ConfigEvaluation]) -> list[ConfigEvaluation]:
+    """Return the non-dominated set, sorted by ascending cost then descending quality."""
+    frontier: list[ConfigEvaluation] = []
+    for candidate in evaluations:
+        if not any(other.dominates(candidate) for other in evaluations if other is not candidate):
+            frontier.append(candidate)
+    frontier.sort(key=lambda e: (e.cost_usd, -e.quality, e.latency_s))
+    return frontier
+
+
+@dataclass
+class SearchResult:
+    frontier: list[ConfigEvaluation]
+    all_evaluations: list[ConfigEvaluation] = field(default_factory=list)
+
+    def recommend(
+        self,
+        *,
+        max_cost_usd: float | None = None,
+        min_quality: float | None = None,
+    ) -> Optional[ConfigEvaluation]:
+        """Pick a frontier config under the given constraints.
+
+        Returns the cheapest frontier point meeting ``max_cost_usd``/``min_quality``;
+        if none qualifies, returns the highest-quality frontier point (so a caller
+        always gets a usable answer), or None if the frontier is empty.
+        """
+        if not self.frontier:
+            return None
+        eligible = [
+            e
+            for e in self.frontier
+            if (max_cost_usd is None or e.cost_usd <= max_cost_usd)
+            and (min_quality is None or e.quality >= min_quality)
+        ]
+        if eligible:
+            return min(eligible, key=lambda e: e.cost_usd)
+        return max(self.frontier, key=lambda e: e.quality)
+
+
+def search_pareto_configs(
+    space: DebateSearchSpace,
+    evaluator: Callable[[DebateConfig], ConfigEvaluation],
+    *,
+    max_trials: int = 6,
+) -> SearchResult:
+    """Evaluate up to ``max_trials`` configs and return the Pareto frontier.
+
+    ``evaluator`` runs/scores a single config — kept injectable so the costly,
+    credential-bound debate execution lives outside this searchable core. Trials
+    are bounded (each is a real debate = real spend); configs are taken in the
+    space's deterministic, cheapest-leaning order.
+    """
+    if max_trials <= 0:
+        raise ValueError("max_trials must be positive")
+    configs = space.enumerate()[:max_trials]
+    evaluations = [evaluator(config) for config in configs]
+    return SearchResult(frontier=pareto_optimal(evaluations), all_evaluations=evaluations)

--- a/tests/routing/test_debate_config_search.py
+++ b/tests/routing/test_debate_config_search.py
@@ -1,0 +1,91 @@
+"""Tests for the syftr-pattern debate-config Pareto search."""
+
+from __future__ import annotations
+
+from aragora.routing.debate_config_search import (
+    ConfigEvaluation,
+    DebateConfig,
+    DebateSearchSpace,
+    pareto_optimal,
+    search_pareto_configs,
+)
+
+
+def _ev(cost: float, quality: float, latency: float, label: str = "x") -> ConfigEvaluation:
+    return ConfigEvaluation(
+        config=DebateConfig(rounds=1, consensus=label, families=("claude",)),
+        cost_usd=cost,
+        quality=quality,
+        latency_s=latency,
+    )
+
+
+def test_domination_three_objectives() -> None:
+    cheap_good_fast = _ev(0.1, 0.9, 1.0)
+    pricey_worse = _ev(0.5, 0.8, 2.0)
+    assert cheap_good_fast.dominates(pricey_worse)
+    assert not pricey_worse.dominates(cheap_good_fast)
+
+
+def test_no_domination_on_tradeoff() -> None:
+    cheap_lowq = _ev(0.1, 0.7, 1.0)
+    pricey_highq = _ev(0.5, 0.95, 1.0)
+    # Neither dominates: one wins cost, the other wins quality.
+    assert not cheap_lowq.dominates(pricey_highq)
+    assert not pricey_highq.dominates(cheap_lowq)
+
+
+def test_pareto_optimal_drops_dominated_keeps_tradeoffs() -> None:
+    cheap = _ev(0.1, 0.7, 1.0, "cheap")
+    balanced = _ev(0.3, 0.85, 1.0, "balanced")
+    premium = _ev(0.5, 0.95, 1.0, "premium")
+    dominated = _ev(0.6, 0.6, 3.0, "dominated")  # worse than all on every axis
+    frontier = pareto_optimal([cheap, balanced, premium, dominated])
+    labels = {e.config.consensus for e in frontier}
+    assert labels == {"cheap", "balanced", "premium"}
+    assert frontier[0].config.consensus == "cheap"  # sorted by ascending cost
+
+
+def test_search_space_enumeration_is_deterministic_and_cheap_first() -> None:
+    space = DebateSearchSpace()
+    configs = space.enumerate()
+    assert len(configs) == 3 * 3 * 3
+    # cheapest-leaning family set (claude+deepseek) is enumerated first
+    assert configs[0].families == ("claude", "deepseek")
+
+
+def test_search_bounds_trials_and_returns_frontier() -> None:
+    space = DebateSearchSpace()
+    seen: list[str] = []
+
+    def evaluator(config: DebateConfig) -> ConfigEvaluation:
+        seen.append(config.label())
+        # cheaper as rounds drop; quality rises with rounds — a real tradeoff.
+        return ConfigEvaluation(
+            config=config,
+            cost_usd=0.05 * config.rounds * len(config.families),
+            quality=0.6 + 0.1 * config.rounds,
+            latency_s=float(config.rounds),
+        )
+
+    result = search_pareto_configs(space, evaluator, max_trials=4)
+    assert len(seen) == 4  # bounded
+    assert result.frontier  # non-empty
+    assert all(isinstance(e, ConfigEvaluation) for e in result.frontier)
+
+
+def test_recommend_honors_constraints_then_falls_back() -> None:
+    result = search_pareto_configs(
+        DebateSearchSpace(),
+        lambda c: ConfigEvaluation(
+            c, cost_usd=0.1 * c.rounds, quality=0.6 + 0.1 * c.rounds, latency_s=1.0
+        ),
+        max_trials=3,
+    )
+    # With a cost cap, pick cheapest eligible.
+    cheap = result.recommend(max_cost_usd=0.15)
+    assert cheap is not None and cheap.cost_usd <= 0.15
+    # Impossible quality floor → fall back to highest-quality frontier point.
+    best = result.recommend(min_quality=99.0)
+    assert best is not None
+    assert best.quality == max(e.quality for e in result.frontier)


### PR DESCRIPTION
## What
A dependency-free, syftr-inspired Pareto search over **debate-workflow configurations** (rounds × consensus mode × reviewing model-family set), complementing the existing provider-level `pareto_frontier` in `cost_quality_optimizer`.

## Why
Directly serves the predictable-cost mandate: surfaces the cost/quality/latency-optimal debate configs so the cheap path (e.g. `claude + deepseek`, 1 round, majority) is used when it suffices and premium configs are reserved for high-stakes decisions.

## Design
- **No new deps** — bounded enumeration of the small discrete config space + 3-objective non-domination, instead of Optuna/MOTPE (syftr's approach).
- **Injectable objective** — `evaluator: DebateConfig -> ConfigEvaluation` keeps the costly, credential-bound debate execution *outside* the searchable core, so search/frontier/recommend logic is fully unit-testable offline.
- **Cost-aware** — trials are bounded (`max_trials`, default 6); each trial is a real debate = real spend. Run once, reuse the recommended config.

## Follow-up (separate PR)
A live `evaluator` that runs a real debate and reads cost from `billing.cost_tracker`, quality from `evaluation.llm_judge`, latency from wall-clock — wiring the search to production (needs credentials).

## Tests
6 passing: domination, tradeoff non-domination, frontier extraction, bounded trials, constraint-aware recommend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)