### PR TITLE
harden(proof): consolidate proof/benchmark-truth input-validation guards (harvest of #8052/#8057/#8064/#7995/#8044)

### DIFF
--- a/scripts/capability_gap_report.py
+++ b/scripts/capability_gap_report.py
@@ -64,11 +64,16 @@ class SurfaceCoverage:
 
 def _load_yaml(path: Path) -> dict[str, Any]:
     if not path.exists():
-        return {}
+        raise FileNotFoundError(f"Capability report YAML source missing: {path}")
     with path.open("r", encoding="utf-8") as handle:
-        data = yaml.safe_load(handle) or {}
+        try:
+            data = yaml.safe_load(handle)
+        except yaml.YAMLError as exc:
+            raise ValueError(f"Malformed capability report YAML source {path}: {exc}") from exc
+    if data is None:
+        raise ValueError(f"Capability report YAML source {path} is empty")
     if not isinstance(data, dict):
-        return {}
+        raise ValueError(f"Capability report YAML source {path} must be a mapping")
     return data
 
 

--- a/scripts/capability_matrix_delta.py
+++ b/scripts/capability_matrix_delta.py
@@ -6,11 +6,16 @@ from __future__ import annotations
 import argparse
 import re
 import subprocess
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 MATRIX_PATH = Path("docs/CAPABILITY_MATRIX.md")
+
+
+class BaseMatrixUnavailableError(RuntimeError):
+    """Raised when an explicitly requested base matrix cannot be read."""
 
 
 def _extract(pattern: str, text: str) -> tuple[int, ...] | None:
@@ -43,7 +48,7 @@ def _load_text(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
-def _load_base_text(repo_root: Path, base_ref: str) -> str | None:
+def _load_base_text(repo_root: Path, base_ref: str) -> str:
     target = f"{base_ref}:{MATRIX_PATH.as_posix()}"
     proc = subprocess.run(
         ["git", "show", target],
@@ -53,7 +58,8 @@ def _load_base_text(repo_root: Path, base_ref: str) -> str | None:
         capture_output=True,
     )
     if proc.returncode != 0:
-        return None
+        detail = proc.stderr.strip() or proc.stdout.strip() or f"git show exited {proc.returncode}"
+        raise BaseMatrixUnavailableError(f"Base matrix unavailable for ref {base_ref!r}: {detail}")
     return proc.stdout
 
 
@@ -70,7 +76,7 @@ def _metric_line(name: str, head: int, base: int | None) -> str:
     return f"| {name} | {base_val} | {head} | {_delta(head, base)} |"
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Generate capability matrix delta summary")
     parser.add_argument("--root", default=str(REPO_ROOT), help="Repo root")
     parser.add_argument("--base-ref", help="Git ref to compare against (e.g. origin/main)")
@@ -79,7 +85,7 @@ def main() -> int:
         default="/tmp/capability-matrix-summary.md",
         help="Output markdown file",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     repo_root = Path(args.root).resolve()
     current_path = repo_root / MATRIX_PATH
@@ -89,16 +95,13 @@ def main() -> int:
     current = _parse_matrix(current_text)
 
     base: dict[str, tuple[int, ...]] | None = None
-    base_note = ""
 
     if args.base_ref:
-        base_text = _load_base_text(repo_root, args.base_ref)
-        if base_text:
-            base = _parse_matrix(base_text)
-        else:
-            base_note = (
-                f"Base matrix unavailable for ref `{args.base_ref}`; showing head snapshot only."
-            )
+        try:
+            base = _parse_matrix(_load_base_text(repo_root, args.base_ref))
+        except BaseMatrixUnavailableError as exc:
+            print(str(exc), file=sys.stderr)
+            return 2
 
     now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%SZ")
     lines: list[str] = []
@@ -108,9 +111,6 @@ def main() -> int:
     lines.append(f"Source: `{MATRIX_PATH.as_posix()}`")
     if args.base_ref:
         lines.append(f"Base ref: `{args.base_ref}`")
-    if base_note:
-        lines.append("")
-        lines.append(f"> {base_note}")
     lines.append("")
 
     lines.append("| Metric | Base | Head | Delta |")

--- a/scripts/measure_b0_scorecard.py
+++ b/scripts/measure_b0_scorecard.py
@@ -432,11 +432,20 @@ def load_metrics(path: Path, window: int | None = None) -> list[dict[str, Any]]:
         return []
     rows: list[dict[str, Any]] = []
     try:
-        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
-            try:
-                rows.append(json.loads(line))
-            except json.JSONDecodeError:
+        for line_number, line in enumerate(
+            path.read_text(encoding="utf-8", errors="replace").splitlines(),
+            start=1,
+        ):
+            raw = line.strip()
+            if not raw:
                 continue
+            try:
+                payload = json.loads(raw)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"malformed JSONL row at {path}:{line_number}: {exc.msg}") from exc
+            if not isinstance(payload, dict):
+                raise ValueError(f"JSONL row at {path}:{line_number} must be an object")
+            rows.append(payload)
     except OSError:
         return []
     if window and window > 0:

--- a/scripts/render_benchmark_truth_status.py
+++ b/scripts/render_benchmark_truth_status.py
@@ -56,11 +56,28 @@ def _load_json(path: Path) -> dict[str, Any]:
     return payload
 
 
+def _positive_revision(value: Any, *, path: Path) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"Corpus at {path} must contain a positive integer revision")
+    try:
+        revision = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Corpus at {path} must contain a positive integer revision") from exc
+    if revision <= 0:
+        raise ValueError(f"Corpus at {path} must contain a positive integer revision")
+    return revision
+
+
 def load_corpus(path: Path) -> dict[str, Any]:
     payload = _load_json(path)
     issues = payload.get("issues")
     if not isinstance(issues, list) or not issues:
         raise ValueError(f"Corpus at {path} must contain a non-empty 'issues' list")
+    corpus_id = str(payload.get("corpus_id") or "").strip()
+    if not corpus_id:
+        raise ValueError(f"Corpus at {path} must contain a non-empty corpus_id")
+    payload["corpus_id"] = corpus_id
+    payload["revision"] = _positive_revision(payload.get("revision"), path=path)
     return payload
 
 

--- a/scripts/render_benchmark_truth_status.py
+++ b/scripts/render_benchmark_truth_status.py
@@ -283,18 +283,49 @@ def _render_issue_drafts(drafts: list[dict[str, Any]]) -> list[str]:
     ] or ["- none"]
 
 
+def _proxy_count(value: Any, *, field: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"proxy metric `{field}` must be an integer count")
+    if value < 0:
+        raise ValueError(f"proxy metric `{field}` must be non-negative")
+    return value
+
+
 def _normalize_proxy_metrics(payload: dict[str, Any]) -> dict[str, Any]:
     proxy_metrics = dict(payload)
     terminal_class_distribution = dict(proxy_metrics.get("terminal_class_distribution") or {})
 
-    if "unique_issues_neutral" not in proxy_metrics:
-        attempted = proxy_metrics.get("unique_issues_attempted")
-        succeeded = proxy_metrics.get("unique_issues_succeeded")
-        failed = proxy_metrics.get("unique_issues_failed")
-        if all(isinstance(value, (int, float)) for value in (attempted, succeeded, failed)):
-            proxy_metrics["unique_issues_neutral"] = max(
-                int(attempted) - int(succeeded) - int(failed),
-                0,
+    attempted = _proxy_count(
+        proxy_metrics.get("unique_issues_attempted"),
+        field="unique_issues_attempted",
+    )
+    succeeded = _proxy_count(
+        proxy_metrics.get("unique_issues_succeeded"),
+        field="unique_issues_succeeded",
+    )
+    failed = _proxy_count(
+        proxy_metrics.get("unique_issues_failed"),
+        field="unique_issues_failed",
+    )
+    if attempted is not None and succeeded is not None and failed is not None:
+        neutral = _proxy_count(
+            proxy_metrics.get("unique_issues_neutral"),
+            field="unique_issues_neutral",
+        )
+        expected_neutral = attempted - succeeded - failed
+        if expected_neutral < 0:
+            raise ValueError(
+                "proxy metrics inconsistent: unique_issues_succeeded + "
+                "unique_issues_failed exceeds unique_issues_attempted"
+            )
+        if neutral is None:
+            proxy_metrics["unique_issues_neutral"] = expected_neutral
+        elif neutral != expected_neutral:
+            raise ValueError(
+                "proxy metrics inconsistent: unique_issues_neutral must equal "
+                "unique_issues_attempted - unique_issues_succeeded - unique_issues_failed"
             )
 
     if "neutral_classes" not in proxy_metrics and terminal_class_distribution:

--- a/tests/scripts/test_capability_gap_report.py
+++ b/tests/scripts/test_capability_gap_report.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import scripts.capability_gap_report as gap_report
+
+
+def _write(path: Path, body: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _write_minimal_sources(repo_root: Path) -> None:
+    _write(
+        repo_root / "aragora" / "capabilities.yaml",
+        """
+capabilities:
+  inbox_triage:
+    name: Inbox triage
+    category: workflow
+    status: active
+""",
+    )
+    _write(
+        repo_root / "aragora" / "capability_surfaces.yaml",
+        """
+capabilities:
+  inbox_triage:
+    cli:
+      - aragora inbox triage
+    sdk:
+      python:
+        - aragora_sdk.inbox
+""",
+    )
+
+
+def test_build_report_counts_valid_capability_sources(tmp_path: Path) -> None:
+    _write_minimal_sources(tmp_path)
+
+    report = gap_report.build_report(tmp_path)
+
+    assert report["total_capabilities"] == 1
+    assert report["mapped_capabilities"] == 1
+    assert report["items"]["inbox_triage"]["name"] == "Inbox triage"
+    assert report["gaps"]["api"] == ["inbox_triage"]
+    assert report["gaps"]["sdk"] == []
+
+
+def test_load_yaml_rejects_missing_source(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="Capability report YAML source missing"):
+        gap_report._load_yaml(tmp_path / "missing.yaml")
+
+
+def test_load_yaml_rejects_empty_source(tmp_path: Path) -> None:
+    source = _write(tmp_path / "empty.yaml", "")
+
+    with pytest.raises(ValueError, match="is empty"):
+        gap_report._load_yaml(source)
+
+
+def test_load_yaml_rejects_malformed_source(tmp_path: Path) -> None:
+    source = _write(tmp_path / "bad.yaml", "capabilities:\n  - [")
+
+    with pytest.raises(ValueError, match="Malformed capability report YAML source"):
+        gap_report._load_yaml(source)
+
+
+def test_load_yaml_rejects_non_mapping_source(tmp_path: Path) -> None:
+    source = _write(tmp_path / "list.yaml", "- inbox_triage\n")
+
+    with pytest.raises(ValueError, match="must be a mapping"):
+        gap_report._load_yaml(source)
+
+
+def test_build_report_rejects_missing_catalog_before_empty_report(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "aragora" / "capability_surfaces.yaml",
+        """
+capabilities:
+  inbox_triage:
+    cli:
+      - aragora inbox triage
+""",
+    )
+
+    with pytest.raises(FileNotFoundError, match="capabilities.yaml"):
+        gap_report.build_report(tmp_path)

--- a/tests/scripts/test_capability_matrix_delta.py
+++ b/tests/scripts/test_capability_matrix_delta.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import scripts.capability_matrix_delta as capability_matrix_delta
+
+
+HEAD_MATRIX = """# Capability Matrix
+
+| Surface | Coverage |
+|---|---:|
+| **HTTP API** | 10 paths / 20 operations |
+| **CLI** | 3 commands |
+| **SDK (Python)** | 4 namespaces |
+| **SDK (TypeScript)** | 5 namespaces |
+| **Capability Catalog** | 6/7 mapped |
+"""
+
+BASE_MATRIX = """# Capability Matrix
+
+| Surface | Coverage |
+|---|---:|
+| **HTTP API** | 8 paths / 17 operations |
+| **CLI** | 2 commands |
+| **SDK (Python)** | 4 namespaces |
+| **SDK (TypeScript)** | 3 namespaces |
+| **Capability Catalog** | 5/7 mapped |
+"""
+
+
+def _write_head_matrix(repo_root: Path) -> None:
+    matrix_path = repo_root / "docs" / "CAPABILITY_MATRIX.md"
+    matrix_path.parent.mkdir(parents=True)
+    matrix_path.write_text(HEAD_MATRIX, encoding="utf-8")
+
+
+def test_main_without_base_ref_writes_head_snapshot(tmp_path: Path) -> None:
+    _write_head_matrix(tmp_path)
+    out_path = tmp_path / "summary.md"
+
+    rc = capability_matrix_delta.main(["--root", str(tmp_path), "--out", str(out_path)])
+
+    assert rc == 0
+    body = out_path.read_text(encoding="utf-8")
+    assert "| HTTP paths | n/a | 10 | n/a |" in body
+    assert "| Total capabilities | n/a | 7 | n/a |" in body
+    assert "Coverage: 85.7%" in body
+
+
+def test_main_with_base_ref_writes_measured_deltas(tmp_path: Path, monkeypatch) -> None:
+    _write_head_matrix(tmp_path)
+    out_path = tmp_path / "summary.md"
+
+    def fake_load_base_text(repo_root: Path, base_ref: str) -> str:
+        assert repo_root == tmp_path.resolve()
+        assert base_ref == "origin/main"
+        return BASE_MATRIX
+
+    monkeypatch.setattr(capability_matrix_delta, "_load_base_text", fake_load_base_text)
+
+    rc = capability_matrix_delta.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--base-ref",
+            "origin/main",
+            "--out",
+            str(out_path),
+        ]
+    )
+
+    assert rc == 0
+    body = out_path.read_text(encoding="utf-8")
+    assert "Base ref: `origin/main`" in body
+    assert "| HTTP paths | 8 | 10 | +2 |" in body
+    assert "| HTTP operations | 17 | 20 | +3 |" in body
+    assert "| TypeScript SDK namespaces | 3 | 5 | +2 |" in body
+    assert "Coverage: 71.4% -> 85.7% (+14.3pp)" in body
+
+
+def test_main_with_unavailable_base_ref_fails_closed(tmp_path: Path, monkeypatch, capsys) -> None:
+    _write_head_matrix(tmp_path)
+    out_path = tmp_path / "summary.md"
+
+    def fake_load_base_text(repo_root: Path, base_ref: str) -> str:
+        raise capability_matrix_delta.BaseMatrixUnavailableError(
+            "Base matrix unavailable for ref 'missing': fatal: bad revision"
+        )
+
+    monkeypatch.setattr(capability_matrix_delta, "_load_base_text", fake_load_base_text)
+
+    rc = capability_matrix_delta.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--base-ref",
+            "missing",
+            "--out",
+            str(out_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert not out_path.exists()
+    assert "Base matrix unavailable for ref 'missing'" in captured.err

--- a/tests/scripts/test_measure_b0_scorecard.py
+++ b/tests/scripts/test_measure_b0_scorecard.py
@@ -4,6 +4,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 _scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
 if _scripts_dir not in sys.path:
     sys.path.insert(0, _scripts_dir)
@@ -93,6 +95,30 @@ def test_main_json_mode_keeps_json_output(tmp_path: Path, capsys) -> None:
     assert payload["status"] == "active"
     assert payload["no_rescue_success_rate"] == 1.0
     assert payload["unique_issues_attempted"] == 1
+
+
+def test_load_metrics_rejects_malformed_jsonl_row(tmp_path: Path) -> None:
+    metrics_path = tmp_path / "boss_metrics.jsonl"
+    metrics_path.write_text(
+        "\n".join(
+            [
+                json.dumps({"issue_number": 1001, "terminal_class": "deliverable_pr_created"}),
+                "{not json}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=r"malformed JSONL row at .*boss_metrics\.jsonl:2"):
+        mod.load_metrics(metrics_path)
+
+
+def test_load_metrics_rejects_non_object_jsonl_row(tmp_path: Path) -> None:
+    metrics_path = tmp_path / "boss_metrics.jsonl"
+    metrics_path.write_text(json.dumps([{"issue_number": 1001}]), encoding="utf-8")
+
+    with pytest.raises(ValueError, match=r"JSONL row at .*boss_metrics\.jsonl:1 must be an object"):
+        mod.load_metrics(metrics_path)
 
 
 def test_main_uses_resolved_metrics_path_for_default_metrics(

--- a/tests/scripts/test_render_benchmark_truth_status.py
+++ b/tests/scripts/test_render_benchmark_truth_status.py
@@ -383,6 +383,85 @@ def test_render_status_markdown_backfills_legacy_proxy_neutral_fields(tmp_path: 
     assert "`issue_already_resolved`: 4" in markdown
 
 
+def test_render_status_markdown_rejects_proxy_neutral_count_mismatch(
+    tmp_path: Path,
+) -> None:
+    corpus_path = _write_json(
+        tmp_path / "corpus.json",
+        {
+            "corpus_id": "tw-01-bounded-execution-v1",
+            "revision": 1,
+            "recorded_on": "2026-04-14",
+            "success_contract": "mergeable_pr_or_merged_pr",
+            "issues": [{"issue_id": 1064, "title": "Issue A"}],
+        },
+    )
+    latest_paths = mod.resolve_latest_paths(
+        corpus_path=corpus_path,
+        truth_root=tmp_path / "truth",
+        scorecard_root=tmp_path / "scorecards",
+    )
+
+    with pytest.raises(ValueError, match="unique_issues_neutral"):
+        mod.render_status_markdown(
+            corpus_path=corpus_path,
+            truth_path=latest_paths["truth_corpus_latest"],
+            scorecard_path=latest_paths["scorecard_corpus_latest"],
+            latest_paths=latest_paths,
+            truth_payload=_truth_payload(revision=1),
+            scorecard_payload={
+                **_scorecard_payload(revision=1),
+                "proxy_metrics": {
+                    "no_rescue_success_rate": 0.0,
+                    "unique_issues_attempted": 5,
+                    "unique_issues_succeeded": 1,
+                    "unique_issues_failed": 1,
+                    "unique_issues_neutral": 9,
+                    "total_ticks": 5,
+                },
+            },
+        )
+
+
+def test_render_status_markdown_rejects_proxy_success_failure_overflow(
+    tmp_path: Path,
+) -> None:
+    corpus_path = _write_json(
+        tmp_path / "corpus.json",
+        {
+            "corpus_id": "tw-01-bounded-execution-v1",
+            "revision": 1,
+            "recorded_on": "2026-04-14",
+            "success_contract": "mergeable_pr_or_merged_pr",
+            "issues": [{"issue_id": 1064, "title": "Issue A"}],
+        },
+    )
+    latest_paths = mod.resolve_latest_paths(
+        corpus_path=corpus_path,
+        truth_root=tmp_path / "truth",
+        scorecard_root=tmp_path / "scorecards",
+    )
+
+    with pytest.raises(ValueError, match="exceeds unique_issues_attempted"):
+        mod.render_status_markdown(
+            corpus_path=corpus_path,
+            truth_path=latest_paths["truth_corpus_latest"],
+            scorecard_path=latest_paths["scorecard_corpus_latest"],
+            latest_paths=latest_paths,
+            truth_payload=_truth_payload(revision=1),
+            scorecard_payload={
+                **_scorecard_payload(revision=1),
+                "proxy_metrics": {
+                    "no_rescue_success_rate": 0.0,
+                    "unique_issues_attempted": 1,
+                    "unique_issues_succeeded": 1,
+                    "unique_issues_failed": 1,
+                    "total_ticks": 2,
+                },
+            },
+        )
+
+
 def test_render_status_markdown_surfaces_stale_closed_corpus_issues(tmp_path: Path) -> None:
     corpus_path = _write_json(
         tmp_path / "corpus.json",

--- a/tests/scripts/test_render_benchmark_truth_status.py
+++ b/tests/scripts/test_render_benchmark_truth_status.py
@@ -183,6 +183,35 @@ def test_render_status_markdown_includes_metrics_and_paths(tmp_path: Path) -> No
     )
 
 
+def test_load_corpus_rejects_blank_corpus_id(tmp_path: Path) -> None:
+    corpus_path = _write_json(
+        tmp_path / "corpus.json",
+        {
+            "corpus_id": " ",
+            "revision": 1,
+            "issues": [{"issue_id": 1064, "title": "Issue A"}],
+        },
+    )
+
+    with pytest.raises(ValueError, match="non-empty corpus_id"):
+        mod.load_corpus(corpus_path)
+
+
+@pytest.mark.parametrize("revision", [0, -1, True, "not-a-number", None])
+def test_load_corpus_rejects_invalid_revision(tmp_path: Path, revision: object) -> None:
+    corpus_path = _write_json(
+        tmp_path / "corpus.json",
+        {
+            "corpus_id": "tw-01-bounded-execution-v1",
+            "revision": revision,
+            "issues": [{"issue_id": 1064, "title": "Issue A"}],
+        },
+    )
+
+    with pytest.raises(ValueError, match="positive integer revision"):
+        mod.load_corpus(corpus_path)
+
+
 def test_render_status_markdown_headlines_verified_rate_and_in_flight_metrics(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## What
Consolidates the genuinely-valuable proof-integrity / benchmark-truth input-validation guards harvested from 5 stale single-commit drafts that were closed during the open-PR backlog drain (branches preserved). One clean PR instead of 5 stale ones.

Harvested commits (fail-closed on malformed/inconsistent inputs to proof & benchmark-truth tooling):
- `measure_b0_scorecard.py` — fail closed on malformed scorecard metrics (#8052)
- `capability_gap_report.py` — fail closed on invalid capability gap sources (#8057)
- `capability_matrix_delta.py` — fail closed on missing capability matrix base (#8064)
- `render_benchmark_truth_status.py` — reject inconsistent proxy counts (#7995) + validate status corpus identity (#8044)

## Why
These guard the proof-first / benchmark-truth surfaces against silently accepting malformed input — real robustness on surfaces the operator cares about. Drained the 5-PR noise; harvested the value into `main`.

## Tests
52 passing across the 4 affected `tests/scripts/` modules. (The pre-existing `agent_bridge_steering` + `capability_matrix` CLI-count failures on main are unrelated and not touched here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)