### PR TITLE
docs(agents): document fusion registry entry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Aragora is the control plane for multi-agent vetted decisionmaking across organi
 > freely; never break main / public API / release flow / CI" rule, and main-red
 > incident mode. That contract governs *how* agents execute against the repo. This
 > document describes *what* agents are registered as runtime debate participants
-> (the 44-agent registry).
+> (the 46-agent registry).
 
 ## Worktree Autopilot (High-Churn Sessions)
 
@@ -90,7 +90,7 @@ commit") from the v12/v13 lessons; soft-reset and re-commit instead.
 
 ## Agent Types
 
-Aragora currently registers 44 agent types across CLI, direct API, OpenRouter, local inference, and external framework proxies. Use `list_available_agents()` to see the full registry at runtime. Server-side validation uses the allowlist in `aragora/config/settings.py` (`ALLOWED_AGENT_TYPES`, 35 types as of 2026-06-06). Entries marked **opt-in** are registered but not allowlisted by default.
+Aragora currently registers 46 agent types across CLI, direct API, OpenRouter, local inference, and external framework proxies. Use `list_available_agents()` to see the full registry at runtime. Server-side validation uses the allowlist in `aragora/config/settings.py` (`ALLOWED_AGENT_TYPES`, 35 types as of 2026-06-06). Entries marked **opt-in** are registered but not allowlisted by default.
 
 ### CLI-Based Agents (allowlisted)
 
@@ -101,6 +101,8 @@ Aragora currently registers 44 agent types across CLI, direct API, OpenRouter, l
 | `openai` | `openai` | gpt-4.1 | GPT-4.1, 1M context |
 | `gemini-cli` | `gemini` | gemini-3.1-pro-preview | Gemini 3.1 Pro, 1M context |
 | `grok-cli` | `grok` | grok-4-latest | Grok 4, 256K context |
+| `grok-build` | `grok` (Grok Build CLI) | grok-build | Opt-in subscription CLI; resolves `~/.grok/bin/grok` or `ARAGORA_GROK_BUILD_BIN` |
+| `antigravity` | `agy` | gemini-3.5-flash | Opt-in subscription CLI; resolves `~/.antigravity/bin/agy` or `ARAGORA_ANTIGRAVITY_BIN` |
 | `qwen-cli` | `qwen` | qwen3-coder | |
 | `deepseek-cli` | `deepseek` | deepseek-v4-pro | Requires `DEEPSEEK_API_KEY` |
 | `kilocode` | `kilocode` | provider-specific | Defaults to `openrouter/google/gemini-3.1-pro-preview` via `provider_id` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Aragora is the control plane for multi-agent vetted decisionmaking across organi
 > freely; never break main / public API / release flow / CI" rule, and main-red
 > incident mode. That contract governs *how* agents execute against the repo. This
 > document describes *what* agents are registered as runtime debate participants
-> (the 43-agent registry).
+> (the 44-agent registry).
 
 ## Worktree Autopilot (High-Churn Sessions)
 
@@ -90,7 +90,7 @@ commit") from the v12/v13 lessons; soft-reset and re-commit instead.
 
 ## Agent Types
 
-Aragora currently registers 43 agent types across CLI, direct API, OpenRouter, local inference, and external framework proxies. Use `list_available_agents()` to see the full registry at runtime. Server-side validation uses the allowlist in `aragora/config/settings.py` (`ALLOWED_AGENT_TYPES`, 35 types as of 2026-06-06). Entries marked **opt-in** are registered but not allowlisted by default.
+Aragora currently registers 44 agent types across CLI, direct API, OpenRouter, local inference, and external framework proxies. Use `list_available_agents()` to see the full registry at runtime. Server-side validation uses the allowlist in `aragora/config/settings.py` (`ALLOWED_AGENT_TYPES`, 35 types as of 2026-06-06). Entries marked **opt-in** are registered but not allowlisted by default.
 
 ### CLI-Based Agents (allowlisted)
 
@@ -145,6 +145,7 @@ All OpenRouter agents require `OPENROUTER_API_KEY`.
 | `sonar` | perplexity/sonar-reasoning | Sonar (reasoning + web search) |
 | `command-r` | cohere/command-r-plus | Command R+ (RAG-optimized) |
 | `jamba` | ai21/jamba-1.6-large | Jamba (SSM-Transformer hybrid) |
+| `fusion` | openrouter/fusion | OpenRouter Fusion multi-model council+judge endpoint (opt-in, not a quorum family) |
 | `openrouter` | deepseek/deepseek-v4-pro | Generic OpenRouter default |
 
 ### External Framework Proxies

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,7 +187,7 @@ Legacy `.gt` stores are supported for backwards compatibility when present.
 
 ## Project Overview
 
-Aragora is the **Decision Integrity Platform** -- orchestrating 43 agent types to adversarially vet decisions against your organization's knowledge, then delivering audit-ready decision receipts to any channel. It implements self-improvement through the **Nomic Loop** -- an autonomous cycle where agents debate improvements, design solutions, implement code, and verify changes.
+Aragora is the **Decision Integrity Platform** -- orchestrating 44 agent types to adversarially vet decisions against your organization's knowledge, then delivering audit-ready decision receipts to any channel. It implements self-improvement through the **Nomic Loop** -- an autonomous cycle where agents debate improvements, design solutions, implement code, and verify changes.
 
 **Five Pillars:** (1) SMB-ready with enterprise-grade security, (2) leading-edge memory and context processing, (3) extensible/modular with broad connectors and SDKs, (4) multi-agent robustness via heterogeneous model consensus, (5) self-healing and self-extending via the Nomic Loop.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,7 +187,7 @@ Legacy `.gt` stores are supported for backwards compatibility when present.
 
 ## Project Overview
 
-Aragora is the **Decision Integrity Platform** -- orchestrating 44 agent types to adversarially vet decisions against your organization's knowledge, then delivering audit-ready decision receipts to any channel. It implements self-improvement through the **Nomic Loop** -- an autonomous cycle where agents debate improvements, design solutions, implement code, and verify changes.
+Aragora is the **Decision Integrity Platform** -- orchestrating 46 agent types to adversarially vet decisions against your organization's knowledge, then delivering audit-ready decision receipts to any channel. It implements self-improvement through the **Nomic Loop** -- an autonomous cycle where agents debate improvements, design solutions, implement code, and verify changes.
 
 **Five Pillars:** (1) SMB-ready with enterprise-grade security, (2) leading-edge memory and context processing, (3) extensible/modular with broad connectors and SDKs, (4) multi-agent robustness via heterogeneous model consensus, (5) self-healing and self-extending via the Nomic Loop.
 

--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ aragora/
 │   ├── consensus.py      # Consensus detection and proofs
 │   ├── convergence.py    # Semantic similarity detection
 │   └── phases/           # Propose, critique, revise, vote, judge
-├── agents/         # 44 registered agent types (CLI, direct API, OpenRouter, local)
+├── agents/         # 46 registered agent types (CLI, direct API, OpenRouter, local)
 │   ├── api_agents/       # Anthropic, OpenAI, Gemini, Grok, Mistral, OpenRouter
 │   ├── cli_agents.py     # Claude Code, Codex, Gemini CLI, Grok CLI
 │   └── fallback.py       # OpenRouter fallback on quota errors

--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ aragora/
 │   ├── consensus.py      # Consensus detection and proofs
 │   ├── convergence.py    # Semantic similarity detection
 │   └── phases/           # Propose, critique, revise, vote, judge
-├── agents/         # 43 registered agent types (CLI, direct API, OpenRouter, local)
+├── agents/         # 44 registered agent types (CLI, direct API, OpenRouter, local)
 │   ├── api_agents/       # Anthropic, OpenAI, Gemini, Grok, Mistral, OpenRouter
 │   ├── cli_agents.py     # Claude Code, Codex, Gemini CLI, Grok CLI
 │   └── fallback.py       # OpenRouter fallback on quota errors


### PR DESCRIPTION
## Summary
- update documented registered-agent counts from 43 to 44
- add the opt-in OpenRouter fusion agent to AGENTS.md
- keep README.md and CLAUDE.md count references aligned with runtime registry

## Validation
- PATH=/Users/armand/.pyenv/versions/3.11.11/bin:/Users/armand/.local/bin:/Library/Frameworks/Python.framework/Versions/3.13/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/armand/.codex/tmp/arg0/codex-arg0iVm8sI:/Users/armand/.local/bin:/Users/armand/.grok/bin:/Users/armand/.antigravity/antigravity/bin:/Users/armand/.bun/bin:/Users/armand/.nebius/bin:/Users/armand/.pyenv/shims:/Users/armand/miniforge3/bin:/Users/armand/miniforge3/condabin:/Library/Frameworks/Python.framework/Versions/3.13/bin:/Users/armand/.cargo/bin:/Applications/Codex.app/Contents/Resources python3 scripts/check_agent_registry_sync.py
- PATH=/Users/armand/.pyenv/versions/3.11.11/bin:/Users/armand/.local/bin:/Library/Frameworks/Python.framework/Versions/3.13/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/armand/.codex/tmp/arg0/codex-arg0iVm8sI:/Users/armand/.local/bin:/Users/armand/.grok/bin:/Users/armand/.antigravity/antigravity/bin:/Users/armand/.bun/bin:/Users/armand/.nebius/bin:/Users/armand/.pyenv/shims:/Users/armand/miniforge3/bin:/Users/armand/miniforge3/condabin:/Library/Frameworks/Python.framework/Versions/3.13/bin:/Users/armand/.cargo/bin:/Applications/Codex.app/Contents/Resources python3 scripts/check_agent_registry_drift.py
- git diff --check origin/main HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD