### PR TITLE
feat(swarm): unattended Tier 0-2 auto-merge on green quorum

### DIFF
--- a/aragora/swarm/auto_merge_green.py
+++ b/aragora/swarm/auto_merge_green.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Pure decision core for unattended Tier 0-2 auto-merge on green quorum.
+
+When a Tier 0-2 PR's merge-packet reaches ``status=satisfied`` the merge-quorum
+gate already authorizes an admin squash ("Model quorum satisfied; Tier 0-2
+settlement authorized" -- see ``.github/workflows/aragora-merge-quorum.yml``).
+Today a human still types ``gh pr merge`` for those. This module decides --
+purely, from already-fetched state -- whether to *execute* that
+already-authorized merge without a human in the loop.
+
+It deliberately makes NO new risk judgment. It re-checks, defense-in-depth, the
+exact conditions the existing ``auto_merge_bucket_a`` admin-squash exception
+requires (``scripts/auto_merge_bucket_a.py::_merge_packet_allows_blocked_state``)
+plus the live check predicate from ``boss_drain_pass._proxy_authorized``
+(merge-quorum green + every required check green + mergeable). Tier 3-4 PRs
+(which require human risk settlement) are never eligible here -- they continue
+to flow through ``scripts/settle_tier4_pr.py`` unchanged.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+# The branch-protection required checks (mirrors boss_drain_pass._REQUIRED).
+REQUIRED_CHECKS: frozenset[str] = frozenset(
+    {"lint", "typecheck", "sdk-parity", "Generate & Validate", "TypeScript SDK Type Check"}
+)
+
+# The merge-quorum status check that encodes heterogeneous model-family consensus.
+QUORUM_CHECK = "aragora-merge-quorum"
+
+# Tiers 0-2 settle without human risk acceptance; 3-4 always need a human.
+MAX_AUTO_MERGE_TIER = 2
+
+# Merge states from which an authorized admin squash is safe. BLOCKED is allowed
+# only because a satisfied merge-packet is what substitutes for the missing
+# review approval under branch protection; every other non-CLEAN state (DIRTY,
+# BEHIND, UNSTABLE, UNKNOWN) is refused.
+_SAFE_MERGE_STATES = frozenset({"CLEAN", "BLOCKED"})
+
+
+@dataclass(frozen=True)
+class PRMergeContext:
+    """Already-fetched state for one open PR. Pure input to the decision."""
+
+    number: int
+    head_sha: str
+    tier: int | None
+    packet_status: str
+    packet_verdict: str
+    requires_human_risk_settlement: bool
+    unresolved_dissent: bool
+    admin_squash_allowed: bool
+    is_draft: bool
+    mergeable: str
+    merge_state_status: str
+    check_states: dict[str, str]
+
+
+@dataclass(frozen=True)
+class MergeDecision:
+    """Verdict for one PR: whether to merge unattended, and why not if not."""
+
+    number: int
+    head_sha: str
+    should_merge: bool
+    blockers: tuple[str, ...]
+
+
+def decide_auto_merge(
+    ctx: PRMergeContext,
+    *,
+    max_tier: int = MAX_AUTO_MERGE_TIER,
+    required_checks: frozenset[str] = REQUIRED_CHECKS,
+) -> MergeDecision:
+    """Decide whether ``ctx`` may be merged unattended; collect *every* blocker.
+
+    Returns ``should_merge=True`` only when none of the guards trip. All blockers
+    are accumulated (not short-circuited) so an operator sees the full picture.
+    """
+    blockers: list[str] = []
+
+    if ctx.is_draft:
+        blockers.append("draft")
+
+    if ctx.tier is None:
+        blockers.append("tier unknown (merge-packet did not classify)")
+    elif ctx.tier > max_tier:
+        blockers.append(f"tier {ctx.tier} > {max_tier}: needs human risk settlement (Tier 3-4)")
+
+    if ctx.requires_human_risk_settlement:
+        blockers.append("requires human risk settlement")
+
+    if ctx.packet_status != "satisfied":
+        blockers.append(f"merge-packet status not satisfied ({ctx.packet_status or 'unknown'})")
+
+    if ctx.packet_verdict != "admin_squash_allowed":
+        blockers.append(
+            f"merge-packet verdict not admin_squash_allowed ({ctx.packet_verdict or 'unknown'})"
+        )
+
+    if not ctx.admin_squash_allowed:
+        blockers.append("admin squash not allowed by merge-packet")
+
+    if ctx.unresolved_dissent:
+        blockers.append("unresolved dissent present")
+
+    if ctx.mergeable != "MERGEABLE":
+        blockers.append(f"not mergeable (mergeable={ctx.mergeable or 'unknown'})")
+
+    if ctx.merge_state_status not in _SAFE_MERGE_STATES:
+        blockers.append(
+            f"merge state not safe (mergeStateStatus={ctx.merge_state_status or 'unknown'})"
+        )
+
+    quorum_state = ctx.check_states.get(QUORUM_CHECK)
+    if quorum_state != "SUCCESS":
+        blockers.append(f"merge-quorum not green ({QUORUM_CHECK}={quorum_state or 'absent'})")
+
+    for name in sorted(required_checks):
+        state = ctx.check_states.get(name)
+        if state != "SUCCESS":
+            blockers.append(f"required check not green: {name}={state or 'absent'}")
+
+    return MergeDecision(
+        number=ctx.number,
+        head_sha=ctx.head_sha,
+        should_merge=not blockers,
+        blockers=tuple(blockers),
+    )
+
+
+def context_from_gh(view: dict[str, Any], packet_entry: dict[str, Any] | None) -> PRMergeContext:
+    """Build a :class:`PRMergeContext` from a ``gh pr view`` payload + packet entry.
+
+    ``statusCheckRollup`` mixes two shapes: check *runs* expose ``name`` +
+    ``conclusion``; commit *statuses* expose ``context`` + ``state``. Both are
+    normalised into ``check_states`` so the decision core sees one flat map.
+    A missing ``packet_entry`` leaves ``tier=None`` (which always blocks).
+    """
+    check_states: dict[str, str] = {}
+    for item in view.get("statusCheckRollup") or []:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("name") or item.get("context")
+        if not name:
+            continue
+        state = item.get("conclusion") or item.get("state") or item.get("status")
+        check_states[str(name)] = str(state or "")
+
+    packet = packet_entry or {}
+    tier_raw = packet.get("tier")
+    try:
+        tier = int(tier_raw) if tier_raw is not None else None
+    except (TypeError, ValueError):
+        tier = None
+
+    return PRMergeContext(
+        number=int(view.get("number") or 0),
+        head_sha=str(view.get("headRefOid") or ""),
+        tier=tier,
+        packet_status=str(packet.get("status") or ""),
+        packet_verdict=str(packet.get("verdict") or ""),
+        requires_human_risk_settlement=bool(packet.get("requires_human_risk_settlement")),
+        unresolved_dissent=bool(packet.get("unresolved_dissent")),
+        admin_squash_allowed=bool(packet.get("admin_squash_allowed")),
+        is_draft=bool(view.get("isDraft")),
+        mergeable=str(view.get("mergeable") or ""),
+        merge_state_status=str(view.get("mergeStateStatus") or ""),
+        check_states=check_states,
+    )
+
+
+def merge_eligible(
+    contexts: list[PRMergeContext],
+    *,
+    max_tier: int = MAX_AUTO_MERGE_TIER,
+) -> list[MergeDecision]:
+    """Decide a batch of contexts (preserves order)."""
+    return [decide_auto_merge(ctx, max_tier=max_tier) for ctx in contexts]
+
+
+def apply_merges(
+    decisions: list[MergeDecision],
+    *,
+    merge_fn: Callable[[int, str], tuple[bool, str]],
+    max_merges: int | None = None,
+    dry_run: bool = True,
+) -> list[dict[str, Any]]:
+    """Bounded apply loop. The merge side-effect is injected for testability.
+
+    - Non-eligible decisions are reported as ``skip`` and never merged.
+    - ``dry_run`` (default) calls ``merge_fn`` for nothing; it reports
+      ``would-merge`` and still honours ``max_merges`` so the plan is accurate.
+    - A failed merge does NOT consume a ``max_merges`` slot.
+    """
+    results: list[dict[str, Any]] = []
+    merged = 0
+    for decision in decisions:
+        record: dict[str, Any] = {"pr": decision.number, "head": decision.head_sha}
+        if not decision.should_merge:
+            record["action"] = "skip"
+            record["blockers"] = list(decision.blockers)
+            results.append(record)
+            continue
+        if max_merges is not None and merged >= max_merges:
+            record["action"] = "deferred (max-merges reached)"
+            results.append(record)
+            continue
+        if dry_run:
+            record["action"] = "would-merge"
+            results.append(record)
+            merged += 1
+            continue
+        ok, detail = merge_fn(decision.number, decision.head_sha)
+        record["action"] = "merged" if ok else "merge-failed"
+        record["detail"] = detail
+        results.append(record)
+        if ok:
+            merged += 1
+    return results

--- a/aragora/swarm/auto_merge_green.py
+++ b/aragora/swarm/auto_merge_green.py
@@ -47,6 +47,7 @@ class PRMergeContext:
 
     number: int
     head_sha: str
+    packet_head_sha: str
     tier: int | None
     packet_status: str
     packet_verdict: str
@@ -87,8 +88,11 @@ def decide_auto_merge(
 
     if ctx.tier is None:
         blockers.append("tier unknown (merge-packet did not classify)")
-    elif ctx.tier > max_tier:
-        blockers.append(f"tier {ctx.tier} > {max_tier}: needs human risk settlement (Tier 3-4)")
+    elif ctx.tier < 0 or ctx.tier > max_tier:
+        blockers.append(
+            f"tier {ctx.tier} outside auto-merge range 0-{max_tier} "
+            "(Tier 3-4 need human settlement; <0 is invalid)"
+        )
 
     if ctx.requires_human_risk_settlement:
         blockers.append("requires human risk settlement")
@@ -106,6 +110,14 @@ def decide_auto_merge(
 
     if ctx.unresolved_dissent:
         blockers.append("unresolved dissent present")
+
+    # The merge-packet is a separate subprocess from the gh view; if the head
+    # moved between the two fetches we'd be deciding on mismatched data. Only
+    # flag when the packet actually disclosed a head (else tier=None blocks).
+    if ctx.packet_head_sha and ctx.packet_head_sha != ctx.head_sha:
+        blockers.append(
+            f"packet head mismatch (packet={ctx.packet_head_sha[:7]} view={ctx.head_sha[:7]})"
+        )
 
     if ctx.mergeable != "MERGEABLE":
         blockers.append(f"not mergeable (mergeable={ctx.mergeable or 'unknown'})")
@@ -160,6 +172,7 @@ def context_from_gh(view: dict[str, Any], packet_entry: dict[str, Any] | None) -
     return PRMergeContext(
         number=int(view.get("number") or 0),
         head_sha=str(view.get("headRefOid") or ""),
+        packet_head_sha=str(packet.get("head_sha") or ""),
         tier=tier,
         packet_status=str(packet.get("status") or ""),
         packet_verdict=str(packet.get("verdict") or ""),

--- a/aragora/swarm/auto_merge_green.py
+++ b/aragora/swarm/auto_merge_green.py
@@ -40,6 +40,16 @@ MAX_AUTO_MERGE_TIER = 2
 # BEHIND, UNSTABLE, UNKNOWN) is refused.
 _SAFE_MERGE_STATES = frozenset({"CLEAN", "BLOCKED"})
 
+# Any check ending in one of these conclusions blocks the merge -- even a
+# *non-required* one. The target population is ~always mergeStateStatus=BLOCKED
+# (review approval substituted by the packet), so a failing non-required check
+# would not show up as UNSTABLE; without this guard it would pass every other
+# check and be --admin-merged. This also closes the REQUIRED_CHECKS drift hazard
+# (a newly-required check failing is caught here regardless of the static list).
+_FAILING_CHECK_STATES = frozenset(
+    {"FAILURE", "ERROR", "CANCELLED", "TIMED_OUT", "STARTUP_FAILURE", "ACTION_REQUIRED"}
+)
+
 
 @dataclass(frozen=True)
 class PRMergeContext:
@@ -136,12 +146,31 @@ def decide_auto_merge(
         if state != "SUCCESS":
             blockers.append(f"required check not green: {name}={state or 'absent'}")
 
+    failing = sorted(n for n, s in ctx.check_states.items() if s in _FAILING_CHECK_STATES)
+    if failing:
+        shown = ", ".join(failing[:3])
+        blockers.append(
+            f"failing checks present (incl. non-required): {shown}{', …' if len(failing) > 3 else ''}"
+        )
+
     return MergeDecision(
         number=ctx.number,
         head_sha=ctx.head_sha,
         should_merge=not blockers,
         blockers=tuple(blockers),
     )
+
+
+def first_error_line(stderr: str, stdout: str) -> str:
+    """First non-empty line of a failed merge's output, or a safe default.
+
+    Guards the whitespace-only case: ``"\\n".strip().splitlines()[0]`` would
+    raise ``IndexError`` and crash a whole pass mid-merge. Prefer stderr.
+    """
+    text = (stderr or stdout or "").strip()
+    if not text:
+        return "merge failed"
+    return text.splitlines()[0]
 
 
 def context_from_gh(view: dict[str, Any], packet_entry: dict[str, Any] | None) -> PRMergeContext:
@@ -176,8 +205,11 @@ def context_from_gh(view: dict[str, Any], packet_entry: dict[str, Any] | None) -
         tier=tier,
         packet_status=str(packet.get("status") or ""),
         packet_verdict=str(packet.get("verdict") or ""),
-        requires_human_risk_settlement=bool(packet.get("requires_human_risk_settlement")),
-        unresolved_dissent=bool(packet.get("unresolved_dissent")),
+        # Fail CLOSED on these safety flags: an absent/renamed key -> treat as
+        # "settlement required" / "dissent present" so a schema drift blocks the
+        # merge rather than silently permitting it.
+        requires_human_risk_settlement=packet.get("requires_human_risk_settlement") is not False,
+        unresolved_dissent=packet.get("unresolved_dissent") is not False,
         admin_squash_allowed=bool(packet.get("admin_squash_allowed")),
         is_draft=bool(view.get("isDraft")),
         mergeable=str(view.get("mergeable") or ""),

--- a/scripts/auto_merge_quorum_green.py
+++ b/scripts/auto_merge_quorum_green.py
@@ -42,6 +42,10 @@ from aragora.swarm.auto_merge_green import (
 
 _VIEW_FIELDS = "number,headRefOid,isDraft,mergeable,mergeStateStatus,statusCheckRollup"
 
+# Conservative default cap for a single unattended pass. Unbounded auto-merge is
+# intentionally not the default; raise --max-merges for larger batches.
+DEFAULT_MAX_MERGES = 10
+
 
 def _gh_json(args: list[str], timeout: int = 60) -> Any:
     try:
@@ -187,7 +191,12 @@ def main(argv: list[str] | None = None) -> int:
         "--pr", type=int, action="append", help="specific PR(s); default scans open PRs"
     )
     parser.add_argument("--limit", type=int, default=300, help="max open PRs to scan")
-    parser.add_argument("--max-merges", type=int, default=None, help="cap merges in this pass")
+    parser.add_argument(
+        "--max-merges",
+        type=int,
+        default=DEFAULT_MAX_MERGES,
+        help=f"cap merges in this pass (default {DEFAULT_MAX_MERGES}; raise N for larger batches)",
+    )
     parser.add_argument("--apply", action="store_true", help="actually merge (default: dry-run)")
     parser.add_argument("--json", action="store_true", help="emit JSON summary")
     args = parser.parse_args(argv)

--- a/scripts/auto_merge_quorum_green.py
+++ b/scripts/auto_merge_quorum_green.py
@@ -37,6 +37,7 @@ from aragora.swarm.auto_merge_green import (
     QUORUM_CHECK,
     apply_merges,
     context_from_gh,
+    first_error_line,
     merge_eligible,
 )
 
@@ -172,12 +173,7 @@ def _make_merge_fn(repo: str):
             return (False, f"merge invocation failed: {exc}")
         if out.returncode == 0:
             return (True, "merged")
-        return (
-            False,
-            (out.stderr or out.stdout or "merge failed").strip().splitlines()[0]
-            if (out.stderr or out.stdout)
-            else "merge failed",
-        )
+        return (False, first_error_line(out.stderr, out.stdout))
 
     return merge_fn
 

--- a/scripts/auto_merge_quorum_green.py
+++ b/scripts/auto_merge_quorum_green.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Unattended Tier 0-2 auto-merge on green quorum. Dry-run by default.
+
+Merges open PRs that the merge-quorum gate has ALREADY authorized for Tier 0-2
+settlement (merge-packet ``status=satisfied`` / ``verdict=admin_squash_allowed``)
+and whose live checks are all green -- without a human typing ``gh pr merge``.
+This is the unattended *execution* of an already-authorized merge, not a new
+risk judgment. The authority remains the merge-packet + the
+``aragora-merge-quorum`` check.
+
+Tier 3-4 PRs (which require human risk settlement) are NEVER touched here; they
+continue to flow through ``scripts/settle_tier4_pr.py`` unchanged.
+
+Composes after evidence collection: run ``scripts/auto_evidence_cycle.py --apply``
+to drive Tier 0-2 PRs to green, then this to merge the green ones.
+
+Safety:
+- ``--dry-run`` (DEFAULT) merges NOTHING; it prints the plan. ``--apply`` is required.
+- Every merge uses ``--match-head-commit`` so a push between decision and merge
+  aborts rather than squashing a tree nobody reviewed (race-safe).
+- ``--max-merges`` bounds a single pass.
+- A cheap gh pre-filter (non-draft + mergeable + quorum green) decides whether
+  to spend a merge-packet subprocess, so a full-queue scan stays affordable.
+- The decision core (:mod:`aragora.swarm.auto_merge_green`) re-checks every gate
+  defense-in-depth; this script only supplies I/O.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from typing import Any
+
+from aragora.swarm.auto_merge_green import (
+    QUORUM_CHECK,
+    apply_merges,
+    context_from_gh,
+    merge_eligible,
+)
+
+_VIEW_FIELDS = "number,headRefOid,isDraft,mergeable,mergeStateStatus,statusCheckRollup"
+
+
+def _gh_json(args: list[str], timeout: int = 60) -> Any:
+    try:
+        out = subprocess.run(["gh", *args], capture_output=True, text=True, timeout=timeout)
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if out.returncode != 0 or not out.stdout.strip():
+        return None
+    try:
+        return json.loads(out.stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+def list_open_pr_numbers(repo: str, limit: int) -> list[int]:
+    data = _gh_json(
+        [
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--limit",
+            str(limit),
+            "--json",
+            "number,isDraft",
+        ]
+    )
+    if not isinstance(data, list):
+        return []
+    numbers: list[int] = []
+    for pr in data:
+        if isinstance(pr, dict) and not pr.get("isDraft") and pr.get("number") is not None:
+            numbers.append(int(pr["number"]))
+    return numbers
+
+
+def fetch_view(repo: str, pr: int) -> dict[str, Any] | None:
+    view = _gh_json(["pr", "view", str(pr), "--repo", repo, "--json", _VIEW_FIELDS])
+    return view if isinstance(view, dict) else None
+
+
+def fetch_packet_entry(repo: str, pr: int, *, timeout: int = 120) -> dict[str, Any] | None:
+    """Run ``review-queue merge-packet`` and return the entry for ``pr``."""
+    try:
+        out = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "aragora.cli.main",
+                "review-queue",
+                "merge-packet",
+                "--pr",
+                str(pr),
+                "--repo",
+                repo,
+                "--json",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if out.returncode != 0 or not out.stdout.strip():
+        return None
+    try:
+        payload = json.loads(out.stdout)
+    except json.JSONDecodeError:
+        return None
+    if isinstance(payload, dict):
+        entries = payload.get("entries")
+        entries = entries if isinstance(entries, list) else [payload]
+    elif isinstance(payload, list):
+        entries = payload
+    else:
+        return None
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        try:
+            if int(entry.get("pr_number") or 0) == pr:
+                return entry
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def _cheaply_promising(view: dict[str, Any]) -> bool:
+    """True if the cheap gh signals justify an (expensive) merge-packet fetch."""
+    if view.get("isDraft") or view.get("mergeable") != "MERGEABLE":
+        return False
+    for item in view.get("statusCheckRollup") or []:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("name") or item.get("context")
+        if name == QUORUM_CHECK:
+            return (item.get("conclusion") or item.get("state") or item.get("status")) == "SUCCESS"
+    return False
+
+
+def _make_merge_fn(repo: str):
+    def merge_fn(pr: int, head: str) -> tuple[bool, str]:
+        try:
+            out = subprocess.run(
+                [
+                    "gh",
+                    "pr",
+                    "merge",
+                    str(pr),
+                    "--repo",
+                    repo,
+                    "--squash",
+                    "--admin",
+                    "--match-head-commit",
+                    head,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+        except (subprocess.TimeoutExpired, OSError) as exc:
+            return (False, f"merge invocation failed: {exc}")
+        if out.returncode == 0:
+            return (True, "merged")
+        return (
+            False,
+            (out.stderr or out.stdout or "merge failed").strip().splitlines()[0]
+            if (out.stderr or out.stdout)
+            else "merge failed",
+        )
+
+    return merge_fn
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Unattended Tier 0-2 auto-merge on green quorum (dry-run by default)"
+    )
+    parser.add_argument("--repo", required=True, help="owner/name")
+    parser.add_argument(
+        "--pr", type=int, action="append", help="specific PR(s); default scans open PRs"
+    )
+    parser.add_argument("--limit", type=int, default=300, help="max open PRs to scan")
+    parser.add_argument("--max-merges", type=int, default=None, help="cap merges in this pass")
+    parser.add_argument("--apply", action="store_true", help="actually merge (default: dry-run)")
+    parser.add_argument("--json", action="store_true", help="emit JSON summary")
+    args = parser.parse_args(argv)
+
+    prs = args.pr if args.pr else list_open_pr_numbers(args.repo, args.limit)
+    contexts = []
+    for pr in prs:
+        view = fetch_view(args.repo, pr)
+        if view is None:
+            continue
+        packet = fetch_packet_entry(args.repo, pr) if _cheaply_promising(view) else None
+        contexts.append(context_from_gh(view, packet))
+
+    decisions = merge_eligible(contexts)
+    results = apply_merges(
+        decisions,
+        merge_fn=_make_merge_fn(args.repo),
+        max_merges=args.max_merges,
+        dry_run=not args.apply,
+    )
+
+    summary = {
+        "repo": args.repo,
+        "mode": "apply" if args.apply else "dry-run",
+        "scanned": len(contexts),
+        "eligible": sum(1 for d in decisions if d.should_merge),
+        "results": results,
+    }
+    if args.json:
+        print(json.dumps(summary, indent=2))
+    else:
+        print(
+            f"[auto-merge-green] {summary['mode']}: scanned {summary['scanned']}, {summary['eligible']} eligible"
+        )
+        for record in results:
+            line = f"  #{record['pr']}: {record['action']}"
+            blockers = record.get("blockers") or []
+            if blockers:
+                shown = "; ".join(blockers[:2])
+                line += f"  ({shown}{'; …' if len(blockers) > 2 else ''})"
+            elif record.get("detail"):
+                line += f"  ({record['detail']})"
+            print(line)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/swarm/test_auto_merge_green.py
+++ b/tests/swarm/test_auto_merge_green.py
@@ -22,6 +22,7 @@ from aragora.swarm.auto_merge_green import (
     REQUIRED_CHECKS,
     PRMergeContext,
     decide_auto_merge,
+    first_error_line,
 )
 
 
@@ -227,3 +228,38 @@ def test_context_is_immutable():
     ctx = _authorized_context()
     with pytest.raises(dataclasses.FrozenInstanceError):
         ctx.tier = 4  # type: ignore[misc]
+
+
+def test_failing_non_required_check_blocks_even_when_blocked():
+    # The target population is ~always mergeStateStatus=BLOCKED, so a failing
+    # *non-required* check would otherwise pass every guard and get --admin
+    # merged. Any failing check in the rollup must block.
+    states = _green_checks()
+    states["Baseline Determinism"] = "FAILURE"  # non-required, failing
+    decision = decide_auto_merge(
+        _authorized_context(check_states=states, merge_state_status="BLOCKED")
+    )
+    assert decision.should_merge is False
+    assert any(
+        "baseline determinism" in b.lower() or "failing" in b.lower() for b in decision.blockers
+    )
+
+
+def test_cancelled_check_blocks():
+    states = _green_checks()
+    states["some-check"] = "CANCELLED"
+    decision = decide_auto_merge(_authorized_context(check_states=states))
+    assert decision.should_merge is False
+
+
+def test_first_error_line_whitespace_only_is_safe():
+    # Regression: "\n".strip().splitlines()[0] used to raise IndexError mid-pass.
+    assert first_error_line("\n", "") == "merge failed"
+    assert first_error_line("", "") == "merge failed"
+    assert first_error_line("   ", "  ") == "merge failed"
+
+
+def test_first_error_line_returns_first_line():
+    assert first_error_line("boom\nmore detail", "") == "boom"
+    assert first_error_line("", "stdout only") == "stdout only"
+    assert first_error_line("stderr wins", "stdout loses") == "stderr wins"

--- a/tests/swarm/test_auto_merge_green.py
+++ b/tests/swarm/test_auto_merge_green.py
@@ -1,0 +1,206 @@
+"""Tests for the unattended Tier 0-2 auto-merge decision core.
+
+The decision core (:func:`aragora.swarm.auto_merge_green.decide_auto_merge`) is
+pure: it takes an already-fetched PR context and returns whether the PR may be
+merged unattended, plus the blockers that prevented it. It encodes the *same*
+authorization the merge-quorum gate already grants for Tier 0-2 PRs whose
+merge-packet reaches ``status=satisfied`` -- it never makes a new risk judgment,
+it only decides whether to *execute* an already-authorized merge without a human.
+
+Safety is the whole point, so every guard that keeps a not-fully-authorized PR
+from auto-merging gets its own test asserting the specific blocker.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from aragora.swarm.auto_merge_green import (
+    MAX_AUTO_MERGE_TIER,
+    REQUIRED_CHECKS,
+    PRMergeContext,
+    decide_auto_merge,
+)
+
+
+def _green_checks() -> dict[str, str]:
+    states = dict.fromkeys(REQUIRED_CHECKS, "SUCCESS")
+    states["aragora-merge-quorum"] = "SUCCESS"
+    return states
+
+
+def _authorized_context(**overrides) -> PRMergeContext:
+    """A fully-authorized Tier-2 PR: every guard passes unless overridden."""
+    base = dict(
+        number=8447,
+        head_sha="a" * 40,
+        tier=2,
+        packet_status="satisfied",
+        packet_verdict="admin_squash_allowed",
+        requires_human_risk_settlement=False,
+        unresolved_dissent=False,
+        admin_squash_allowed=True,
+        is_draft=False,
+        mergeable="MERGEABLE",
+        merge_state_status="BLOCKED",
+        check_states=_green_checks(),
+    )
+    base.update(overrides)
+    return PRMergeContext(**base)
+
+
+def test_fully_authorized_tier2_pr_is_merged():
+    decision = decide_auto_merge(_authorized_context())
+    assert decision.should_merge is True
+    assert decision.blockers == ()
+    assert decision.number == 8447
+    assert decision.head_sha == "a" * 40
+
+
+def test_clean_merge_state_is_also_mergeable():
+    # A Tier-0 docs PR can reach CLEAN (no branch-protection block); still merge.
+    decision = decide_auto_merge(_authorized_context(tier=0, merge_state_status="CLEAN"))
+    assert decision.should_merge is True
+    assert decision.blockers == ()
+
+
+def test_tier_three_is_blocked_for_human_settlement():
+    decision = decide_auto_merge(_authorized_context(tier=3))
+    assert decision.should_merge is False
+    assert any("tier" in b.lower() for b in decision.blockers)
+
+
+def test_tier_four_is_blocked():
+    decision = decide_auto_merge(_authorized_context(tier=4))
+    assert decision.should_merge is False
+    assert any("tier" in b.lower() for b in decision.blockers)
+
+
+def test_unknown_tier_is_blocked():
+    decision = decide_auto_merge(_authorized_context(tier=None))
+    assert decision.should_merge is False
+    assert any("tier" in b.lower() for b in decision.blockers)
+
+
+def test_requires_human_risk_settlement_is_blocked():
+    decision = decide_auto_merge(_authorized_context(requires_human_risk_settlement=True))
+    assert decision.should_merge is False
+    assert any("human" in b.lower() for b in decision.blockers)
+
+
+def test_packet_status_not_satisfied_is_blocked():
+    decision = decide_auto_merge(_authorized_context(packet_status="needs_model_review_quorum"))
+    assert decision.should_merge is False
+    assert any("satisfied" in b.lower() for b in decision.blockers)
+
+
+def test_packet_verdict_not_admin_squash_is_blocked():
+    decision = decide_auto_merge(
+        _authorized_context(packet_verdict="collect_model_quorum_before_merge")
+    )
+    assert decision.should_merge is False
+    assert any("verdict" in b.lower() for b in decision.blockers)
+
+
+def test_admin_squash_not_allowed_is_blocked():
+    decision = decide_auto_merge(_authorized_context(admin_squash_allowed=False))
+    assert decision.should_merge is False
+    assert any("admin squash" in b.lower() for b in decision.blockers)
+
+
+def test_unresolved_dissent_is_blocked():
+    decision = decide_auto_merge(_authorized_context(unresolved_dissent=True))
+    assert decision.should_merge is False
+    assert any("dissent" in b.lower() for b in decision.blockers)
+
+
+def test_draft_is_blocked():
+    decision = decide_auto_merge(_authorized_context(is_draft=True))
+    assert decision.should_merge is False
+    assert any("draft" in b.lower() for b in decision.blockers)
+
+
+def test_conflicting_is_blocked():
+    decision = decide_auto_merge(_authorized_context(mergeable="CONFLICTING"))
+    assert decision.should_merge is False
+    assert any("mergeable" in b.lower() for b in decision.blockers)
+
+
+def test_unknown_mergeability_is_blocked():
+    decision = decide_auto_merge(_authorized_context(mergeable="UNKNOWN"))
+    assert decision.should_merge is False
+    assert any("mergeable" in b.lower() for b in decision.blockers)
+
+
+def test_dirty_merge_state_is_blocked():
+    decision = decide_auto_merge(_authorized_context(merge_state_status="DIRTY"))
+    assert decision.should_merge is False
+    assert any("merge state" in b.lower() for b in decision.blockers)
+
+
+def test_unstable_merge_state_is_blocked():
+    # UNSTABLE = a non-required check is failing; skip rather than risk it.
+    decision = decide_auto_merge(_authorized_context(merge_state_status="UNSTABLE"))
+    assert decision.should_merge is False
+    assert any("merge state" in b.lower() for b in decision.blockers)
+
+
+def test_quorum_not_green_is_blocked():
+    states = _green_checks()
+    states["aragora-merge-quorum"] = "FAILURE"
+    decision = decide_auto_merge(_authorized_context(check_states=states))
+    assert decision.should_merge is False
+    assert any("quorum" in b.lower() for b in decision.blockers)
+
+
+def test_quorum_missing_is_blocked():
+    states = _green_checks()
+    del states["aragora-merge-quorum"]
+    decision = decide_auto_merge(_authorized_context(check_states=states))
+    assert decision.should_merge is False
+    assert any("quorum" in b.lower() for b in decision.blockers)
+
+
+def test_any_failing_required_check_is_blocked():
+    states = _green_checks()
+    states["lint"] = "FAILURE"
+    decision = decide_auto_merge(_authorized_context(check_states=states))
+    assert decision.should_merge is False
+    assert any("lint" in b for b in decision.blockers)
+
+
+def test_pending_required_check_is_blocked():
+    states = _green_checks()
+    states["typecheck"] = "PENDING"
+    decision = decide_auto_merge(_authorized_context(check_states=states))
+    assert decision.should_merge is False
+    assert any("typecheck" in b for b in decision.blockers)
+
+
+def test_missing_required_check_is_blocked():
+    states = _green_checks()
+    del states["sdk-parity"]
+    decision = decide_auto_merge(_authorized_context(check_states=states))
+    assert decision.should_merge is False
+    assert any("sdk-parity" in b for b in decision.blockers)
+
+
+def test_multiple_blockers_are_all_reported():
+    decision = decide_auto_merge(
+        _authorized_context(tier=4, is_draft=True, mergeable="CONFLICTING")
+    )
+    assert decision.should_merge is False
+    # all three independent problems surface, not just the first
+    assert len(decision.blockers) >= 3
+
+
+def test_max_tier_is_two_by_default():
+    assert MAX_AUTO_MERGE_TIER == 2
+
+
+def test_context_is_immutable():
+    ctx = _authorized_context()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        ctx.tier = 4  # type: ignore[misc]

--- a/tests/swarm/test_auto_merge_green.py
+++ b/tests/swarm/test_auto_merge_green.py
@@ -36,6 +36,7 @@ def _authorized_context(**overrides) -> PRMergeContext:
     base = dict(
         number=8447,
         head_sha="a" * 40,
+        packet_head_sha="a" * 40,
         tier=2,
         packet_status="satisfied",
         packet_verdict="admin_squash_allowed",
@@ -57,6 +58,28 @@ def test_fully_authorized_tier2_pr_is_merged():
     assert decision.blockers == ()
     assert decision.number == 8447
     assert decision.head_sha == "a" * 40
+
+
+def test_packet_head_mismatch_is_blocked():
+    # The merge-packet is fetched in a separate subprocess from the gh view; if
+    # the head moved between them we'd be deciding on mismatched data.
+    decision = decide_auto_merge(_authorized_context(packet_head_sha="f" * 40))
+    assert decision.should_merge is False
+    assert any("head" in b.lower() for b in decision.blockers)
+
+
+def test_absent_packet_head_does_not_add_mismatch_blocker():
+    # packet=None -> packet_head_sha="" -> tier=None already blocks; no spurious
+    # head-mismatch blocker should pile on.
+    decision = decide_auto_merge(_authorized_context(packet_head_sha="", tier=None))
+    assert decision.should_merge is False
+    assert not any("head" in b.lower() and "mismatch" in b.lower() for b in decision.blockers)
+
+
+def test_negative_tier_is_blocked():
+    decision = decide_auto_merge(_authorized_context(tier=-1))
+    assert decision.should_merge is False
+    assert any("tier" in b.lower() for b in decision.blockers)
 
 
 def test_clean_merge_state_is_also_mergeable():

--- a/tests/swarm/test_auto_merge_green_cli.py
+++ b/tests/swarm/test_auto_merge_green_cli.py
@@ -47,6 +47,7 @@ def _packet(**overrides) -> dict:
         requires_human_risk_settlement=False,
         unresolved_dissent=False,
         admin_squash_allowed=True,
+        head_sha="b" * 40,  # matches _view() headRefOid
     )
     base.update(overrides)
     return base
@@ -85,6 +86,19 @@ def test_context_from_gh_carries_human_settlement_flag():
     ctx = context_from_gh(_view(), _packet(tier=4, requires_human_risk_settlement=True))
     assert ctx.requires_human_risk_settlement is True
     assert decide_auto_merge(ctx).should_merge is False
+
+
+def test_context_from_gh_extracts_packet_head():
+    ctx = context_from_gh(_view(headRefOid="e" * 40), _packet(head_sha="e" * 40))
+    assert ctx.packet_head_sha == "e" * 40
+    assert ctx.head_sha == "e" * 40
+
+
+def test_context_from_gh_packet_head_mismatch_blocks_merge():
+    # packet computed against a different head than the view -> must not merge.
+    ctx = context_from_gh(_view(headRefOid="1" * 40), _packet(head_sha="2" * 40))
+    assert decide_auto_merge(ctx).should_merge is False
+    assert any("head" in b.lower() for b in decide_auto_merge(ctx).blockers)
 
 
 # --- merge_eligible --------------------------------------------------------

--- a/tests/swarm/test_auto_merge_green_cli.py
+++ b/tests/swarm/test_auto_merge_green_cli.py
@@ -101,6 +101,24 @@ def test_context_from_gh_packet_head_mismatch_blocks_merge():
     assert any("head" in b.lower() for b in decide_auto_merge(ctx).blockers)
 
 
+def test_context_fail_closed_on_missing_settlement_flag():
+    # A safety-critical auto-merge must fail CLOSED if the packet omits the
+    # human-settlement flag (e.g. a schema rename), not silently permit.
+    pkt = _packet()
+    del pkt["requires_human_risk_settlement"]
+    ctx = context_from_gh(_view(), pkt)
+    assert ctx.requires_human_risk_settlement is True
+    assert decide_auto_merge(ctx).should_merge is False
+
+
+def test_context_fail_closed_on_missing_dissent_flag():
+    pkt = _packet()
+    del pkt["unresolved_dissent"]
+    ctx = context_from_gh(_view(), pkt)
+    assert ctx.unresolved_dissent is True
+    assert decide_auto_merge(ctx).should_merge is False
+
+
 # --- merge_eligible --------------------------------------------------------
 
 

--- a/tests/swarm/test_auto_merge_green_cli.py
+++ b/tests/swarm/test_auto_merge_green_cli.py
@@ -1,0 +1,178 @@
+"""Tests for the glue layer of unattended Tier 0-2 auto-merge.
+
+These cover the impure-but-injectable pieces around the pure decision core:
+- ``context_from_gh``: map a ``gh pr view`` payload + merge-packet entry into a
+  :class:`PRMergeContext` (parses the heterogeneous statusCheckRollup shape).
+- ``merge_eligible``: decide a batch of contexts.
+- ``apply_merges``: the bounded apply loop, with the merge side-effect injected
+  so we test orchestration (dry-run, cap, failure handling) without touching gh.
+"""
+
+from __future__ import annotations
+
+from aragora.swarm.auto_merge_green import (
+    REQUIRED_CHECKS,
+    MergeDecision,
+    apply_merges,
+    context_from_gh,
+    decide_auto_merge,
+    merge_eligible,
+)
+
+
+def _rollup_all_green() -> list[dict]:
+    rollup = [{"name": name, "conclusion": "SUCCESS"} for name in REQUIRED_CHECKS]
+    rollup.append({"name": "aragora-merge-quorum", "conclusion": "SUCCESS"})
+    return rollup
+
+
+def _view(**overrides) -> dict:
+    base = dict(
+        number=8447,
+        headRefOid="b" * 40,
+        isDraft=False,
+        mergeable="MERGEABLE",
+        mergeStateStatus="BLOCKED",
+        statusCheckRollup=_rollup_all_green(),
+    )
+    base.update(overrides)
+    return base
+
+
+def _packet(**overrides) -> dict:
+    base = dict(
+        tier=2,
+        status="satisfied",
+        verdict="admin_squash_allowed",
+        requires_human_risk_settlement=False,
+        unresolved_dissent=False,
+        admin_squash_allowed=True,
+    )
+    base.update(overrides)
+    return base
+
+
+# --- context_from_gh -------------------------------------------------------
+
+
+def test_context_from_gh_authorized_pr_decides_merge():
+    ctx = context_from_gh(_view(), _packet())
+    assert decide_auto_merge(ctx).should_merge is True
+
+
+def test_context_from_gh_extracts_head_and_number():
+    ctx = context_from_gh(_view(number=99, headRefOid="c" * 40), _packet())
+    assert ctx.number == 99
+    assert ctx.head_sha == "c" * 40
+
+
+def test_context_from_gh_parses_status_style_rollup_entry():
+    # Commit *statuses* (vs check *runs*) use "context"+"state", not "name"+"conclusion".
+    rollup = _rollup_all_green()
+    rollup.append({"context": "legacy-status", "state": "SUCCESS"})
+    ctx = context_from_gh(_view(statusCheckRollup=rollup), _packet())
+    assert ctx.check_states["legacy-status"] == "SUCCESS"
+    assert ctx.check_states["aragora-merge-quorum"] == "SUCCESS"
+
+
+def test_context_from_gh_missing_packet_yields_unknown_tier():
+    ctx = context_from_gh(_view(), None)
+    assert ctx.tier is None
+    assert decide_auto_merge(ctx).should_merge is False
+
+
+def test_context_from_gh_carries_human_settlement_flag():
+    ctx = context_from_gh(_view(), _packet(tier=4, requires_human_risk_settlement=True))
+    assert ctx.requires_human_risk_settlement is True
+    assert decide_auto_merge(ctx).should_merge is False
+
+
+# --- merge_eligible --------------------------------------------------------
+
+
+def test_merge_eligible_decides_each_context():
+    good = context_from_gh(_view(number=1), _packet())
+    bad = context_from_gh(_view(number=2), _packet(tier=4))
+    decisions = merge_eligible([good, bad])
+    by_pr = {d.number: d for d in decisions}
+    assert by_pr[1].should_merge is True
+    assert by_pr[2].should_merge is False
+
+
+# --- apply_merges ----------------------------------------------------------
+
+
+def _decision(number: int, should_merge: bool) -> MergeDecision:
+    return MergeDecision(
+        number=number,
+        head_sha="d" * 40,
+        should_merge=should_merge,
+        blockers=() if should_merge else ("blocked for test",),
+    )
+
+
+def test_apply_merges_dry_run_never_calls_merger():
+    calls: list[tuple[int, str]] = []
+
+    def merger(pr, head):  # pragma: no cover - must NOT be invoked
+        calls.append((pr, head))
+        return (True, "ok")
+
+    results = apply_merges([_decision(1, True)], merge_fn=merger, dry_run=True)
+    assert calls == []
+    assert results[0]["pr"] == 1
+    assert results[0]["action"] == "would-merge"
+
+
+def test_apply_merges_applies_only_eligible():
+    calls: list[int] = []
+
+    def merger(pr, head):
+        calls.append(pr)
+        return (True, "merged")
+
+    results = apply_merges(
+        [_decision(1, True), _decision(2, False)], merge_fn=merger, dry_run=False
+    )
+    assert calls == [1]
+    actions = {r["pr"]: r["action"] for r in results}
+    assert actions[1] == "merged"
+    assert actions[2] == "skip"
+
+
+def test_apply_merges_respects_max_merges():
+    calls: list[int] = []
+
+    def merger(pr, head):
+        calls.append(pr)
+        return (True, "merged")
+
+    results = apply_merges(
+        [_decision(1, True), _decision(2, True), _decision(3, True)],
+        merge_fn=merger,
+        dry_run=False,
+        max_merges=1,
+    )
+    assert calls == [1]
+    actions = {r["pr"]: r["action"] for r in results}
+    assert actions[1] == "merged"
+    assert "deferred" in actions[2]
+    assert "deferred" in actions[3]
+
+
+def test_apply_merges_failed_merge_does_not_consume_cap():
+    def merger(pr, head):
+        if pr == 1:
+            return (False, "gh rejected")
+        return (True, "merged")
+
+    results = apply_merges(
+        [_decision(1, True), _decision(2, True)],
+        merge_fn=merger,
+        dry_run=False,
+        max_merges=1,
+    )
+    actions = {r["pr"]: r["action"] for r in results}
+    assert actions[1] == "merge-failed"
+    # the failed one must not have eaten the single merge slot
+    assert actions[2] == "merged"


### PR DESCRIPTION
## What & why

Adds an **unattended path that merges PRs the merge-quorum gate has *already* authorized** for Tier 0-2 settlement — without a human typing `gh pr merge`. This takes the operator out of the per-PR settlement loop for low-tier PRs, which is the throughput unlock: more review lanes only out-throughput the backlog once *merging* is unattended (otherwise lanes just grow WIP behind a serialized human gate).

It makes **no new risk judgment** — it executes a merge the gate already labels *"Model quorum satisfied; Tier 0-2 settlement authorized."* **Tier 3-4 (human risk settlement) PRs are never touched** and continue through `scripts/settle_tier4_pr.py` unchanged.

## How it's safe

The decision core re-checks, defense-in-depth, the exact conditions that already gate an admin squash today:
- merge-packet `status=satisfied`, `verdict=admin_squash_allowed`, `admin_squash_allowed=true`, `requires_human_risk_settlement=false`, `unresolved_dissent=false`, `tier ≤ 2` (mirrors `auto_merge_bucket_a._merge_packet_allows_blocked_state`)
- `aragora-merge-quorum` green **and** every required check green **and** `mergeable` (mirrors `boss_drain_pass._proxy_authorized`)
- **dry-run by default**; `--apply` required; **`--match-head-commit`** so a push between decision and merge aborts rather than squashing an unreviewed tree; `--max-merges` bounds a pass.

## Files
- `aragora/swarm/auto_merge_green.py` — pure decision core + injectable apply loop
- `scripts/auto_merge_quorum_green.py` — thin `gh` I/O CLI (cheap pre-filter gates the merge-packet subprocess)
- `tests/swarm/test_auto_merge_green*.py` — 33 tests (decision core + dependency-injected merge fn)

## Verification
- 33 tests pass; ruff + mypy clean.
- Live dry-run against 5 open PRs: 0 merged, all correctly skipped with specific blockers.
- Live packet→context→decision chain validated against a real PR (every merge-packet field name confirmed).

## Dogfood
This PR touches only `aragora/swarm/`, `scripts/`, `tests/` — all Tier ≤ 2 — so it lands through the very Tier 0-2 path it creates.

## Usage
```bash
# dry-run plan
python scripts/auto_merge_quorum_green.py --repo synaptent/aragora
# act, bounded
python scripts/auto_merge_quorum_green.py --repo synaptent/aragora --apply --max-merges 5
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)