### PR TITLE
fix(quorum): stop "[P1] None:" non-findings from de-counting a PASS vote

### DIFF
--- a/aragora/cli/commands/review_queue_comment_verdicts.py
+++ b/aragora/cli/commands/review_queue_comment_verdicts.py
@@ -4,6 +4,42 @@ from __future__ import annotations
 
 import re
 
+# Explicit "no Pn finding" heads. A `[P0]`/`[P1]` line is blocking UNLESS the text
+# before its first colon is EXACTLY one of these — models emit `"[P1] None:"`,
+# `"[P1] N/A"`, `"[P1] no issues: ..."` to declare the absence of a finding. Matched
+# exactly (not as a prefix) so a real finding that merely starts with "none"/"no"
+# (e.g. "[P1] None of the inputs are validated") still blocks.
+_NO_FINDING_HEADS = frozenset(
+    {
+        "none",
+        "none found",
+        "none identified",
+        "none noted",
+        "none here",
+        "n/a",
+        "na",
+        "nil",
+        "0",
+        "zero",
+        "false",
+        "[]",
+        "not applicable",
+        "no issues",
+        "no issue",
+        "no findings",
+        "no finding",
+        "no blockers",
+        "no blocker",
+        "no blocking",
+        "no blocking findings",
+        "no concerns",
+        "no concern",
+        "no critical issues",
+        "no critical issue",
+        "no critical findings",
+    }
+)
+
 
 def has_blocking_or_negative_verdict(body: str) -> bool:
     """Return True for explicit evidence comments that report blockers."""
@@ -58,7 +94,14 @@ def has_blocking_or_negative_verdict(body: str) -> bool:
         if re.match(
             r"^(?:\*\*)?\[(?:p0|p1)\](?:\*\*)?(?:\s|$|[:.;—–-])", priority_marker_line, re.I
         ):
-            return True
+            rest = re.sub(
+                r"^(?:\*\*)?\[(?:p0|p1)\](?:\*\*)?\s*", "", priority_marker_line, flags=re.I
+            )
+            head = _normalize_value(rest).split(":", 1)[0].strip(" .;—–-")
+            if head not in _NO_FINDING_HEADS:
+                return True
+            # explicit "[Pn] None:/N/A/no issues" non-finding -> keep scanning
+            continue
         line = _strip_decoration(stripped).replace("**", "").replace("__", "")
         match = re.match(r"^(?P<label>[^:—–-]+?)\s*(?::|—|–|-)\s*(?P<value>.*)$", line)
         if not match:

--- a/tests/cli/commands/test_review_queue_comment_verdicts.py
+++ b/tests/cli/commands/test_review_queue_comment_verdicts.py
@@ -1,0 +1,88 @@
+"""Tests for the [P0]/[P1] non-finding false-positive in the verdict scanner.
+
+`has_blocking_or_negative_verdict` is the blocking-language scan used at BOTH
+collect-time and gate-time to decide whether a reviewer's evidence counts. It
+treated ANY line starting with `[P0]`/`[P1]` as a blocking finding — including
+`"[P1] None:"` / `"[P1] N/A"`, which low-cost models (and claude/codex) emit to
+say "no P0/P1 issues". That silently de-counted a PASS vote.
+
+The fix must be conservative: a real finding that merely *starts with* "none"/"no"
+(e.g. `[P1] None of the inputs are validated`, `[P1] no auth check`) MUST still
+block. Only an explicit no-finding *head* (the text before any colon being exactly
+"none", "n/a", "no issues", ...) is treated as non-blocking.
+"""
+
+from __future__ import annotations
+
+from aragora.cli.commands.review_queue_comment_verdicts import (
+    has_blocking_or_negative_verdict,
+)
+
+
+# --- the bug: explicit no-finding heads must NOT block --------------------
+
+
+def test_p1_none_colon_is_not_blocking():
+    # The exact qwen/claude pattern that was de-counting PASS votes.
+    assert not has_blocking_or_negative_verdict("- [P1] None: defense-in-depth is solid")
+
+
+def test_p1_bare_none_is_not_blocking():
+    assert not has_blocking_or_negative_verdict("- [P1] none")
+
+
+def test_p0_no_issues_colon_is_not_blocking():
+    assert not has_blocking_or_negative_verdict("- [P0] No issues: clean implementation")
+
+
+def test_p1_na_is_not_blocking():
+    assert not has_blocking_or_negative_verdict("- [P1] N/A")
+
+
+def test_p1_none_found_is_not_blocking():
+    assert not has_blocking_or_negative_verdict("- [P1] none found")
+
+
+def test_p1_no_blocking_findings_is_not_blocking():
+    assert not has_blocking_or_negative_verdict("- [P1] no blocking findings")
+
+
+def test_full_pass_body_with_p1_none_lines_counts():
+    body = (
+        "## Qwen independent model review\n\n"
+        "Model family: qwen\n\n"
+        "Verdict: PASS\n"
+        "- [P1] None: comprehensive guard conditions\n"
+        "- [P2] None: tests cover the mismatch path\n\n"
+        "dogfood: yes\n"
+    )
+    assert not has_blocking_or_negative_verdict(body)
+
+
+# --- adversarial integrity: real findings MUST still block ----------------
+
+
+def test_real_p1_finding_starting_with_none_still_blocks():
+    # "None of the inputs..." is a REAL finding that happens to start with "none".
+    assert has_blocking_or_negative_verdict("- [P1] None of the inputs are validated")
+
+
+def test_real_p1_finding_starting_with_no_still_blocks():
+    assert has_blocking_or_negative_verdict("- [P1] no authentication on the admin endpoint")
+
+
+def test_real_p1_finding_still_blocks():
+    assert has_blocking_or_negative_verdict("- [P1] settlement gate can be bypassed")
+
+
+def test_bare_p1_tag_blocks_conservatively():
+    # A bare "[P1]" with no text is ambiguous; default to blocking.
+    assert has_blocking_or_negative_verdict("[P1]")
+
+
+def test_p0_real_finding_still_blocks():
+    assert has_blocking_or_negative_verdict("[P0] settlement gate bypass")
+
+
+def test_negative_verdict_line_still_blocks():
+    assert has_blocking_or_negative_verdict("Verdict: CHANGES-REQUESTED")


### PR DESCRIPTION
## The bug (root-cause of "qwen PASS but doesn't count")

`has_blocking_or_negative_verdict` (`aragora/cli/commands/review_queue_comment_verdicts.py`) is the blocking-language scan used at **both** collect-time (`_lint_evidence_comment` → whether evidence is posted) **and** gate-time (`_model_review_signals_from_comments` → whether posted evidence counts toward the merge quorum). It matched **any** line starting with `[P0]`/`[P1]` and returned "blocking" **without reading the text after the tag**.

Models following the `[P1]/[P2]/[P3]` prompt format emit `"[P1] None:"`, `"[P1] N/A"`, `"[P1] no issues: ..."` to say *"no Pn findings"*. The scanner mistook these for real blockers → `negative_verdict=True` → `counted_reviewer_ids=[]` → `would_count=False` → a genuine **PASS vote silently dropped** from the quorum. This affects **every** reviewer family (qwen, claude, codex), so it can stall even a single-signal tiered gate.

## The fix (conservative — adversarial integrity preserved)

A `[P0]`/`[P1]` line is blocking **unless** the text before its first colon is **exactly** a no-finding head (`none`, `n/a`, `no issues`, `no blocking findings`, …). Matched **exactly, never as a prefix**, so a real finding that merely *starts with* "none"/"no" still blocks:
- `[P1] None of the inputs are validated` → **blocks** ✓
- `[P1] no auth check on the admin endpoint` → **blocks** ✓
- `[P1] None:` / `[P1] N/A` / `[P1] no issues: clean` → **counts** (non-finding) ✓

## Verification
- New dedicated test file (13 tests) covering both the non-finding cases and the real-finding-preservation cases.
- The **23 existing verdict tests stay green** (real `[P0]`/`[P1]` findings still block; `[P2]` still non-blocking).
- ruff + mypy clean.

Complementary to the gate-tiering and slug-default fixes in flight: tiering reduces the *number* of required signals; this makes each signal actually *count* when the reviewer PASSes.