### PR TITLE
harden(quorum): reviewer prompt omits empty priority levels (kills "[P1] None:" at source)

### DIFF
--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -716,8 +716,10 @@ def build_review_prompt(
         f"Review ONLY the changes below for PR #{pr} in {repo} at head {short}. "
         "Look hard for correctness, security, and regression risks. "
         "Begin your reply with 'Verdict: PASS' or 'Verdict: CHANGES-REQUESTED', then a terse "
-        "bullet list of concrete findings each tagged [P1]/[P2]/[P3] with a location, or state "
-        "explicitly that there are no blocking issues. Be concise.\n\n"
+        "bullet list of concrete findings, each tagged [P1]/[P2]/[P3] with a location. Include "
+        "ONLY priority levels that have a real finding: if a level has none, OMIT it entirely "
+        "-- never write a '[P1] None', '[P2] N/A', or similar no-finding line (it is misread as "
+        "a blocking finding). If there are no findings at all, write 'No findings.' Be concise.\n\n"
         f"=== CHANGED FILES (complete list, {file_count} file(s)) ===\n{file_list}\n\n"
         f"{body_header}\n{bounded}\n"
     )

--- a/tests/swarm/test_review_prompt.py
+++ b/tests/swarm/test_review_prompt.py
@@ -1,0 +1,45 @@
+"""The reviewer prompt must not induce '[P1] None:' no-finding lines.
+
+#8508 fixed the gate scanner to ignore explicit no-finding heads, but that relies
+on a fixed list of phrasings. The deeper fix is at the source: tell the reviewer
+to OMIT priority levels with no finding instead of writing '[P1] None'. This
+hardens against no-finding phrasings the scanner's list doesn't enumerate.
+"""
+
+from __future__ import annotations
+
+from aragora.swarm.quorum_evidence import build_review_prompt
+
+
+def _prompt() -> str:
+    return build_review_prompt(
+        repo="owner/repo",
+        pr=1,
+        head_sha="a" * 40,
+        diff_text="diff --git a/x.py b/x.py\n+print('x')\n",
+    )
+
+
+def test_prompt_instructs_omitting_empty_priority_levels():
+    low = _prompt().lower()
+    assert "omit" in low
+    # explicitly tells the reviewer not to emit a no-finding [Pn] line
+    assert "never write" in low
+    assert "none" in low  # references the "[Pn] None" anti-pattern it forbids
+
+
+def test_prompt_gives_a_no_findings_path():
+    assert "no findings" in _prompt().lower()
+
+
+def test_prompt_still_requires_verdict_and_tag_format():
+    p = _prompt()
+    assert "Verdict: PASS" in p
+    assert "Verdict: CHANGES-REQUESTED" in p
+    assert "[P1]" in p  # real findings are still tagged
+
+
+def test_prompt_drops_old_state_explicitly_phrasing():
+    # The old "or state explicitly that there are no blocking issues" wording is
+    # what models turned into "[P1] None:" -- it must be gone.
+    assert "state explicitly that there are no blocking issues" not in _prompt().lower()


### PR DESCRIPTION
Defense-in-depth at the **source** for the reviewer-counting problem, complementing #8508 (which fixed the gate scanner).

**Why:** the reviewer prompt told models to tag findings `[P1]/[P2]/[P3]` *"or state explicitly that there are no blocking issues"* — and models turned that into `[P1] None:` lines, which the gate's verdict scanner mis-read as blocking and **de-counted a genuine PASS**. #8508 fixed the *scanner* for a fixed list of no-finding heads (`none`, `n/a`, …). This fixes it at the **source** and covers no-finding phrasings the scanner's list doesn't enumerate.

**Change:** `build_review_prompt` now instructs the reviewer to include ONLY priority levels that have a real finding, **omit** empty levels entirely, **never write** a `[P1] None`/`[P2] N/A` line, and write `No findings.` when there are none.

**Verification:** 4 new tests (`tests/swarm/test_review_prompt.py`); the 8 existing prompt-related tests are unaffected; ruff + mypy clean. No behavior change to real-finding reviews.

**Coordination:** touches `quorum_evidence.py` (Tier-4) in a *different region* (`build_review_prompt`) than the in-flight tiering PR's `has_supportive_quorum` edit — low conflict risk, but sequence the Tier-4 settlements.