### PR TITLE
docs(metrics): regenerate docs/METRICS.md to absorb ambient parametrize drift

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -12,12 +12,12 @@
 
 | Metric | Value | Source | Command |
 |---|---|---|---|
-| Python files under aragora/ | `4198` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1964974` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python files under aragora/ | `4201` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
+| Python lines of code under aragora/ | `1966457` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `143` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5371` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `221727` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
-| @pytest.mark.parametrize decorators | `776` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
+| Test files (test_*.py under tests/) | `5379` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `221895` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| @pytest.mark.parametrize decorators | `788` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `83` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2870` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
 | OpenAPI operations (HTTP verbs) | `3297` | `docs/api/openapi.json` | `python -c "import json; spec=json.load(open('docs/api/openapi.json')); print(sum(1 for p in spec['paths'].values() for m in p if m.lower() in {'get','post','put','delete','patch','head','options'}))"` |
@@ -28,7 +28,7 @@
 | Allowlisted agent types | `35` | `aragora/config/settings.py` | `grep -A 50 'ALLOWED_AGENT_TYPES' aragora/config/settings.py \| grep -oE "'[a-z-]+'" \| sort -u \| wc -l` |
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `46` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |
-| Markdown files under docs/ | `1006` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
+| Markdown files under docs/ | `1007` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
 | GitHub Actions workflows | `88` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
 | Mypy baseline errors (grandfathered) | `3115` | `.mypy-baseline` | `wc -l .mypy-baseline` |
 


### PR DESCRIPTION
## Source

End-of-P2 boundary gate **VAL-CROSS-008** (metrics drift gate green) and the
operator-authorized narrow Tier-0 exception recorded in
`library/operator-approvals.md` (Decision: VAL-CROSS-008 METRICS drift
resolution — Option B, 2026-06-17).

## Behavior summary

`python3 scripts/regenerate_metrics.py --check` was RED on `main`. The drift had
narrowed to a single ambient test count exceeding the 0.5% threshold
(`@pytest.mark.parametrize` 776 → 788, 1.5%), with **zero mission contribution**.
The bare regeneration also refreshes the other (sub-threshold) ambient counts in
the same file (`aragora/` py files 4198→4201, LOC, test files 5371→5379, test
functions, docs `.md` 1006→1007) — all ambient repo growth from concurrent
automation.

This is the contract's sanctioned **"first regenerating PR absorbs pre-existing
drift"** case. `docs/METRICS.md` is normally path-frozen (it appears in several
open foreign PRs), but the operator explicitly lifted the freeze for **this one
file only** so the mission can green the drift gate. This PR touches **only**
`docs/METRICS.md`; the foreign PRs resolve their own conflicts after this merges
and are not edited or rebased here.

## Validation

```
# before (on clean origin/main):
$ python3 scripts/regenerate_metrics.py --check
Metrics drifted:
  DRIFT: @pytest.mark.parametrize decorators 776 -> 788 (1.5%)
metrics_check_exit=1

# regenerate (bare invocation WRITES docs/METRICS.md):
$ python3 scripts/regenerate_metrics.py
Wrote .../docs/METRICS.md with 19 metrics.

# git status shows exactly one changed path:
$ git status --porcelain
 M docs/METRICS.md

# after:
$ python3 scripts/regenerate_metrics.py --check
No drift beyond 0.5% threshold.
metrics_check_exit=0
```

`make lint` → exit 0.

## Risks

Minimal. Single docs-only file; no code, no module structure, no
`module_tiers.yaml` change (confirmed `git status` shows only `docs/METRICS.md`).
Values are pure count refreshes regenerated deterministically by the repo's own
`scripts/regenerate_metrics.py`. Tier 0.
