### PR TITLE
feat(swarm): settle_pr — operator-driven, tier-aware PR settlement orchestrator

### DIFF
--- a/aragora/swarm/settle_plan.py
+++ b/aragora/swarm/settle_plan.py
@@ -45,6 +45,7 @@ def plan_settlement(
     tier: int | None,
     quorum_satisfied: bool,
     supportive_families: Sequence[str],
+    head_sha: str | None = None,
     unresolved_dissent: bool = False,
     operator_login_provided: bool = False,
 ) -> SettlementPlan:
@@ -83,6 +84,12 @@ def plan_settlement(
             f"Tier {tier} requires a human risk settlement: pass --operator-login <gh-login>"
         )
 
+    # The Tier 3-4 settle commands are head-bound (settle_tier4_pr --head <sha>);
+    # without a resolved head they would render as runnable-looking but doomed
+    # `--head <head>` placeholders. Refuse to call that route ready.
+    if route == ROUTE_OPERATOR_TIER4 and not (head_sha and str(head_sha).strip()):
+        blockers.append("head_sha unresolved (cannot emit head-bound Tier 3-4 settle commands)")
+
     ready_to_mutate = not blockers and route != ROUTE_BLOCKED
     return SettlementPlan(
         tier=tier,
@@ -119,6 +126,8 @@ def summarize_collect(payload: Mapping[str, Any]) -> dict[str, Any]:
             "tier": None,
             "head_sha": payload.get("head_sha"),
             "quorum_satisfied": False,
+            "action": payload.get("action"),
+            "action_reason": payload.get("action_reason"),
             "supportive_families": [],
             "dissenting_families": [],
             "items": [],
@@ -140,6 +149,12 @@ def summarize_collect(payload: Mapping[str, Any]) -> dict[str, Any]:
         "tier": payload.get("tier"),
         "head_sha": payload.get("head_sha"),
         "quorum_satisfied": bool(payload.get("has_supportive_quorum")),
+        # collect's OWN authority signal: "post" means it classified the PR as
+        # auto-postable (Tier 0-2); "prepare" means it refused to post (Tier >=3
+        # or a recheck tier-promotion). The CLI uses this as a cross-check so a
+        # stale top-level ``tier`` cannot misroute an auto-merge (see settle_pr).
+        "action": payload.get("action"),
+        "action_reason": payload.get("action_reason"),
         "supportive_families": list(payload.get("supportive_families") or []),
         "dissenting_families": list(payload.get("dissenting_families") or []),
         "items": items,

--- a/aragora/swarm/settle_plan.py
+++ b/aragora/swarm/settle_plan.py
@@ -50,7 +50,7 @@ def plan_settlement(
     head_sha: str | None = None,
     unresolved_dissent: bool = False,
     operator_login_provided: bool = False,
-    authority_prepare_only: bool = False,
+    collect_refused_to_post: bool = False,
 ) -> SettlementPlan:
     """Decide the settlement route and whether it is safe to proceed.
 
@@ -80,13 +80,19 @@ def plan_settlement(
     else:
         route = ROUTE_OPERATOR_TIER4
 
-    # The evidence authority's own posted-vs-refused signal overrides a stale tier.
-    # If collect refused to post (action="prepare") yet the merge-packet tier still
-    # reads <=2 -- e.g. a pre-post recheck promoted the tier to 3+ -- trust the
-    # stricter signal and route to operator settlement. Without this the CLI would
-    # withhold auto-merge AND never surface the Tier 3-4 path: an operator dead-end.
-    if authority_prepare_only and route == ROUTE_AUTO_MERGE:
-        route = ROUTE_OPERATOR_TIER4
+    # Genuine tier escalation is handled by tier-based routing above (collect's
+    # reported tier >2 -> operator). A "prepare" verdict is NOT a reliable tier
+    # signal: collect also prepares when the head moved (tier 2->2), a recheck is
+    # pending, or a transient gh error hit -- so we never re-route an auto-merge to
+    # the operator path on it (that would surface Tier-4 commands bound to a
+    # superseded head). Instead: never auto-merge OVER a refusal-to-post. Block and
+    # tell the operator to re-run collect on the current head.
+    if collect_refused_to_post and route == ROUTE_AUTO_MERGE:
+        blockers.append(
+            "collect refused to post evidence despite a satisfied quorum "
+            "(head moved / recheck pending / tier promotion) -- re-run collect on "
+            "the current head rather than auto-merging over a refusal-to-post"
+        )
 
     # Dissent blocks every route, not just auto-merge: Tier 0-2 cannot auto-merge
     # over a dissent, and settle_tier4_pr hard-fails on unresolved_dissent too, so
@@ -98,8 +104,9 @@ def plan_settlement(
 
     requires_operator_login = route == ROUTE_OPERATOR_TIER4
     if requires_operator_login and not operator_login_provided:
-        why = "evidence authority (prepare-only)" if authority_prepare_only else f"Tier {tier}"
-        blockers.append(f"{why} requires a human risk settlement: pass --operator-login <gh-login>")
+        blockers.append(
+            f"Tier {tier} requires a human risk settlement: pass --operator-login <gh-login>"
+        )
 
     # The Tier 3-4 settle commands are head-bound (settle_tier4_pr --head <sha>);
     # without a resolved head they would render as runnable-looking but doomed

--- a/aragora/swarm/settle_plan.py
+++ b/aragora/swarm/settle_plan.py
@@ -15,6 +15,7 @@ and refuses to proceed when the model quorum is not genuinely satisfied.
 
 from __future__ import annotations
 
+import math
 import shlex
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
@@ -67,6 +68,13 @@ def plan_settlement(
     if tier is None:
         route = ROUTE_BLOCKED
         blockers.append("tier unknown (merge-packet did not classify the PR)")
+    elif tier < 0:
+        # A negative tier is malformed; `tier <= 2` would pick the LESS conservative
+        # auto-merge path. Fail safe -- the composed tools also treat <0 as invalid.
+        route = ROUTE_BLOCKED
+        blockers.append(
+            f"invalid tier {tier} (negative -- merge-packet classification is malformed)"
+        )
     elif tier <= AUTO_MERGE_MAX_TIER:
         route = ROUTE_AUTO_MERGE
     else:
@@ -131,24 +139,32 @@ def tier4_settle_commands(
 
 
 def _coerce_tier(value: Any) -> int | None:
-    """Coerce a merge-packet ``tier`` to ``int`` (or ``None`` if malformed).
+    """Coerce a merge-packet ``tier`` to a non-negative ``int`` (else ``None``).
 
     ``plan_settlement`` does ``tier <= AUTO_MERGE_MAX_TIER``; a non-int tier from a
-    malformed payload would raise ``TypeError`` there. Coercing here (a bool, NaN,
-    or unparseable value becomes ``None`` -> fail-safe ``ROUTE_BLOCKED``) keeps the
-    planner total."""
+    malformed payload would raise ``TypeError`` there. Coercing here keeps the
+    planner total: a bool, a non-finite/non-integral/negative float, an
+    unparseable string, or a negative int all become ``None`` -> fail-safe
+    ``ROUTE_BLOCKED``. ``json.loads`` accepts ``NaN``/``Infinity`` by default, so
+    finiteness is checked BEFORE ``int(value)`` (which would otherwise raise
+    ``ValueError``/``OverflowError`` on them)."""
     if isinstance(value, bool):
         return None
+    coerced: int | None
     if isinstance(value, int):
-        return value
-    if isinstance(value, float):
-        return int(value) if value == int(value) else None
-    if isinstance(value, str):
+        coerced = value
+    elif isinstance(value, float):
+        coerced = int(value) if (math.isfinite(value) and value == int(value)) else None
+    elif isinstance(value, str):
         try:
-            return int(value.strip())
+            coerced = int(value.strip())
         except ValueError:
-            return None
-    return None
+            coerced = None
+    else:
+        coerced = None
+    if coerced is not None and coerced < 0:
+        return None
+    return coerced
 
 
 def summarize_collect(payload: Mapping[str, Any]) -> dict[str, Any]:
@@ -170,6 +186,10 @@ def summarize_collect(payload: Mapping[str, Any]) -> dict[str, Any]:
         }
     items = []
     for it in payload.get("items") or []:
+        if not isinstance(it, dict):
+            # A malformed (non-dict) item must not crash the flatten the way the
+            # top-level error envelope is already guarded against -- skip it.
+            continue
         items.append(
             {
                 "family": it.get("family"),

--- a/aragora/swarm/settle_plan.py
+++ b/aragora/swarm/settle_plan.py
@@ -15,6 +15,7 @@ and refuses to proceed when the model quorum is not genuinely satisfied.
 
 from __future__ import annotations
 
+import shlex
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
@@ -48,6 +49,7 @@ def plan_settlement(
     head_sha: str | None = None,
     unresolved_dissent: bool = False,
     operator_login_provided: bool = False,
+    authority_prepare_only: bool = False,
 ) -> SettlementPlan:
     """Decide the settlement route and whether it is safe to proceed.
 
@@ -70,6 +72,14 @@ def plan_settlement(
     else:
         route = ROUTE_OPERATOR_TIER4
 
+    # The evidence authority's own posted-vs-refused signal overrides a stale tier.
+    # If collect refused to post (action="prepare") yet the merge-packet tier still
+    # reads <=2 -- e.g. a pre-post recheck promoted the tier to 3+ -- trust the
+    # stricter signal and route to operator settlement. Without this the CLI would
+    # withhold auto-merge AND never surface the Tier 3-4 path: an operator dead-end.
+    if authority_prepare_only and route == ROUTE_AUTO_MERGE:
+        route = ROUTE_OPERATOR_TIER4
+
     # Dissent blocks every route, not just auto-merge: Tier 0-2 cannot auto-merge
     # over a dissent, and settle_tier4_pr hard-fails on unresolved_dissent too, so
     # a Tier 3-4 plan that ignored it would surface commands doomed to fail.
@@ -80,9 +90,8 @@ def plan_settlement(
 
     requires_operator_login = route == ROUTE_OPERATOR_TIER4
     if requires_operator_login and not operator_login_provided:
-        blockers.append(
-            f"Tier {tier} requires a human risk settlement: pass --operator-login <gh-login>"
-        )
+        why = "evidence authority (prepare-only)" if authority_prepare_only else f"Tier {tier}"
+        blockers.append(f"{why} requires a human risk settlement: pass --operator-login <gh-login>")
 
     # The Tier 3-4 settle commands are head-bound (settle_tier4_pr --head <sha>);
     # without a resolved head they would render as runnable-looking but doomed
@@ -107,13 +116,39 @@ def tier4_settle_commands(
     """The exact, head-bound ``settle_tier4_pr.py`` commands a trusted operator runs
     to record the human risk settlement and merge. The CLI surfaces these rather
     than executing them: the Tier-4 human settlement must be a deliberate operator
-    act, never an automated one."""
+    act, never an automated one.
+
+    Every interpolated value is ``shlex.quote``d: these strings are surfaced for
+    copy-paste into a shell, so an unquoted ``repo``/``head``/``operator_login``
+    bearing shell metacharacters would be a command-injection vector. ``pr`` is
+    coerced to ``int`` for the same reason."""
     base = (
-        f"python3 scripts/settle_tier4_pr.py --pr {pr} --head {head} "
-        f"--trusted-operator-login {operator_login} --repo {repo}"
+        f"python3 scripts/settle_tier4_pr.py --pr {int(pr)} --head {shlex.quote(str(head))} "
+        f"--trusted-operator-login {shlex.quote(str(operator_login))} --repo {shlex.quote(str(repo))}"
     )
     prefix = "ARAGORA_DISABLE_GITHUB_APP_TOKEN=1 " if no_app_token else ""
     return [f"{base} --check", f"{base} --settle-only", f"{prefix}{base} --merge-apply"]
+
+
+def _coerce_tier(value: Any) -> int | None:
+    """Coerce a merge-packet ``tier`` to ``int`` (or ``None`` if malformed).
+
+    ``plan_settlement`` does ``tier <= AUTO_MERGE_MAX_TIER``; a non-int tier from a
+    malformed payload would raise ``TypeError`` there. Coercing here (a bool, NaN,
+    or unparseable value becomes ``None`` -> fail-safe ``ROUTE_BLOCKED``) keeps the
+    planner total."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value) if value == int(value) else None
+    if isinstance(value, str):
+        try:
+            return int(value.strip())
+        except ValueError:
+            return None
+    return None
 
 
 def summarize_collect(payload: Mapping[str, Any]) -> dict[str, Any]:
@@ -146,7 +181,7 @@ def summarize_collect(payload: Mapping[str, Any]) -> dict[str, Any]:
         )
     return {
         "error": None,
-        "tier": payload.get("tier"),
+        "tier": _coerce_tier(payload.get("tier")),
         "head_sha": payload.get("head_sha"),
         "quorum_satisfied": bool(payload.get("has_supportive_quorum")),
         # collect's OWN authority signal: "post" means it classified the PR as

--- a/aragora/swarm/settle_plan.py
+++ b/aragora/swarm/settle_plan.py
@@ -1,0 +1,141 @@
+"""Pure routing/gating decision for the operator-driven PR settlement CLI.
+
+``scripts/settle_pr.py`` orchestrates the end-to-end settlement runbook by
+*composing* the existing tools (``collect_quorum_evidence.py`` for evidence,
+``auto_merge_quorum_green.py`` for Tier 0-2 merges, ``settle_tier4_pr.py`` for
+Tier 3-4 human settlement). This module is its single decision brain: given an
+already-fetched quorum/tier state it decides whether settlement can proceed and
+by which route, accumulating every blocker. It performs **no I/O**, so the
+routing/gating logic stays deterministic and unit-testable.
+
+The actual merge gate is never reimplemented here -- the composed tools remain
+authoritative and enforce it. This module only decides *which* of them to invoke
+and refuses to proceed when the model quorum is not genuinely satisfied.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+# Tier 0-2 can settle unattended on a green model quorum (auto-merge path);
+# Tier 3-4 require a head-bound human risk settlement by a trusted operator.
+AUTO_MERGE_MAX_TIER = 2
+
+ROUTE_AUTO_MERGE = "auto_merge_green"
+ROUTE_OPERATOR_TIER4 = "operator_human_settlement"
+ROUTE_BLOCKED = "blocked"
+
+
+@dataclass(frozen=True)
+class SettlementPlan:
+    """The decided route + readiness for one PR. Pure output of :func:`plan_settlement`."""
+
+    tier: int | None
+    route: str
+    quorum_satisfied: bool
+    requires_operator_login: bool
+    ready_to_mutate: bool
+    blockers: tuple[str, ...]
+
+
+def plan_settlement(
+    *,
+    tier: int | None,
+    quorum_satisfied: bool,
+    supportive_families: Sequence[str],
+    unresolved_dissent: bool = False,
+    operator_login_provided: bool = False,
+) -> SettlementPlan:
+    """Decide the settlement route and whether it is safe to proceed.
+
+    ``ready_to_mutate`` is True only when the model quorum is satisfied, the tier
+    is classified, and any route-specific precondition is met (Tier 3-4 needs an
+    operator login). Every reason a mutation is refused is collected in
+    ``blockers`` so the CLI can surface all of them at once.
+    """
+    blockers: list[str] = []
+    supportive = sorted({str(f) for f in supportive_families})
+
+    if not quorum_satisfied:
+        blockers.append(f"model quorum not satisfied (supportive families: {supportive or 'none'})")
+
+    if tier is None:
+        route = ROUTE_BLOCKED
+        blockers.append("tier unknown (merge-packet did not classify the PR)")
+    elif tier <= AUTO_MERGE_MAX_TIER:
+        route = ROUTE_AUTO_MERGE
+        if unresolved_dissent:
+            blockers.append("unresolved model dissent (Tier 0-2 cannot auto-merge over a dissent)")
+    else:
+        route = ROUTE_OPERATOR_TIER4
+
+    requires_operator_login = route == ROUTE_OPERATOR_TIER4
+    if requires_operator_login and not operator_login_provided:
+        blockers.append(
+            f"Tier {tier} requires a human risk settlement: pass --operator-login <gh-login>"
+        )
+
+    ready_to_mutate = not blockers and route != ROUTE_BLOCKED
+    return SettlementPlan(
+        tier=tier,
+        route=route,
+        quorum_satisfied=quorum_satisfied,
+        requires_operator_login=requires_operator_login,
+        ready_to_mutate=ready_to_mutate,
+        blockers=tuple(blockers),
+    )
+
+
+def tier4_settle_commands(
+    *, repo: str, pr: int, head: str, operator_login: str, no_app_token: bool = False
+) -> list[str]:
+    """The exact, head-bound ``settle_tier4_pr.py`` commands a trusted operator runs
+    to record the human risk settlement and merge. The CLI surfaces these rather
+    than executing them: the Tier-4 human settlement must be a deliberate operator
+    act, never an automated one."""
+    base = (
+        f"python3 scripts/settle_tier4_pr.py --pr {pr} --head {head} "
+        f"--trusted-operator-login {operator_login} --repo {repo}"
+    )
+    prefix = "ARAGORA_DISABLE_GITHUB_APP_TOKEN=1 " if no_app_token else ""
+    return [f"{base} --check", f"{base} --settle-only", f"{prefix}{base} --merge-apply"]
+
+
+def summarize_collect(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Flatten a ``collect_quorum_evidence --json`` payload into the fields the
+    planner and diagnostics need. Tolerates the error envelope (``{"error": ...}``)
+    by reporting an unsatisfied quorum with no tier."""
+    if payload.get("error"):
+        return {
+            "error": str(payload["error"]),
+            "tier": None,
+            "head_sha": payload.get("head_sha"),
+            "quorum_satisfied": False,
+            "supportive_families": [],
+            "dissenting_families": [],
+            "items": [],
+            "failures": list(payload.get("failures") or []),
+        }
+    items = []
+    for it in payload.get("items") or []:
+        items.append(
+            {
+                "family": it.get("family"),
+                "verdict": it.get("verdict"),
+                "would_count": bool(it.get("would_count")),
+                "counted_reviewer_ids": list(it.get("counted_reviewer_ids") or []),
+                "problems": list(it.get("problems") or []),
+            }
+        )
+    return {
+        "error": None,
+        "tier": payload.get("tier"),
+        "head_sha": payload.get("head_sha"),
+        "quorum_satisfied": bool(payload.get("has_supportive_quorum")),
+        "supportive_families": list(payload.get("supportive_families") or []),
+        "dissenting_families": list(payload.get("dissenting_families") or []),
+        "items": items,
+        "failures": list(payload.get("failures") or []),
+    }

--- a/aragora/swarm/settle_plan.py
+++ b/aragora/swarm/settle_plan.py
@@ -119,7 +119,13 @@ def plan_settlement(
 
 
 def tier4_settle_commands(
-    *, repo: str, pr: int, head: str, operator_login: str, no_app_token: bool = False
+    *,
+    repo: str,
+    pr: int,
+    head: str,
+    operator_login: str,
+    no_app_token: bool = False,
+    repo_root: str | None = None,
 ) -> list[str]:
     """The exact, head-bound ``settle_tier4_pr.py`` commands a trusted operator runs
     to record the human risk settlement and merge. The CLI surfaces these rather
@@ -129,13 +135,20 @@ def tier4_settle_commands(
     Every interpolated value is ``shlex.quote``d: these strings are surfaced for
     copy-paste into a shell, so an unquoted ``repo``/``head``/``operator_login``
     bearing shell metacharacters would be a command-injection vector. ``pr`` is
-    coerced to ``int`` for the same reason."""
-    base = (
+    coerced to ``int`` for the same reason. ``repo_root``, when given, prepends a
+    ``cd <root> &&`` guard so the cwd-relative ``scripts/...`` path resolves even
+    when the operator pastes from outside the repo root."""
+    cmd = (
         f"python3 scripts/settle_tier4_pr.py --pr {int(pr)} --head {shlex.quote(str(head))} "
         f"--trusted-operator-login {shlex.quote(str(operator_login))} --repo {shlex.quote(str(repo))}"
     )
-    prefix = "ARAGORA_DISABLE_GITHUB_APP_TOKEN=1 " if no_app_token else ""
-    return [f"{base} --check", f"{base} --settle-only", f"{prefix}{base} --merge-apply"]
+    cd_prefix = f"cd {shlex.quote(str(repo_root))} && " if repo_root else ""
+    env_prefix = "ARAGORA_DISABLE_GITHUB_APP_TOKEN=1 " if no_app_token else ""
+    return [
+        f"{cd_prefix}{cmd} --check",
+        f"{cd_prefix}{cmd} --settle-only",
+        f"{cd_prefix}{env_prefix}{cmd} --merge-apply",
+    ]
 
 
 def _coerce_tier(value: Any) -> int | None:

--- a/aragora/swarm/settle_plan.py
+++ b/aragora/swarm/settle_plan.py
@@ -66,10 +66,16 @@ def plan_settlement(
         blockers.append("tier unknown (merge-packet did not classify the PR)")
     elif tier <= AUTO_MERGE_MAX_TIER:
         route = ROUTE_AUTO_MERGE
-        if unresolved_dissent:
-            blockers.append("unresolved model dissent (Tier 0-2 cannot auto-merge over a dissent)")
     else:
         route = ROUTE_OPERATOR_TIER4
+
+    # Dissent blocks every route, not just auto-merge: Tier 0-2 cannot auto-merge
+    # over a dissent, and settle_tier4_pr hard-fails on unresolved_dissent too, so
+    # a Tier 3-4 plan that ignored it would surface commands doomed to fail.
+    if unresolved_dissent and route != ROUTE_BLOCKED:
+        blockers.append(
+            "unresolved model dissent (auto-merge and Tier 3-4 settlement both refuse it)"
+        )
 
     requires_operator_login = route == ROUTE_OPERATOR_TIER4
     if requires_operator_login and not operator_login_provided:

--- a/scripts/settle_pr.py
+++ b/scripts/settle_pr.py
@@ -87,21 +87,6 @@ def _collect(repo: str, pr: int, reviewers: list[str], *, apply: bool) -> dict[s
     return {"mode": "collect_evidence", "error": detail[:500]}
 
 
-def _post_supportive_evidence(repo: str, pr: int, payload: dict[str, Any]) -> list[str]:
-    """Post each countable item's evidence body as a PR comment. Returns the URLs."""
-    posted: list[str] = []
-    for item in payload.get("items") or []:
-        if not item.get("would_count"):
-            continue
-        body = item.get("body") or ""
-        if not body.strip():
-            continue
-        out = _run(["gh", "pr", "comment", str(pr), "--repo", repo, "--body", body])
-        if out.returncode == 0 and out.stdout.strip():
-            posted.append(out.stdout.strip())
-    return posted
-
-
 def _auto_merge(repo: str, pr: int) -> subprocess.CompletedProcess[str]:
     script = _REPO_ROOT / "scripts" / "auto_merge_quorum_green.py"
     return _run([sys.executable, str(script), "--repo", repo, "--pr", str(pr), "--apply"])
@@ -156,7 +141,12 @@ def main(argv: list[str] | None = None) -> int:
         print("error: could not resolve repo (pass --repo owner/name)", file=sys.stderr)
         return 2
 
-    payload = _collect(repo, args.pr, args.reviewers, apply=False)
+    # ONE collect. For Tier 0-2 + --apply, collect itself posts evidence AND runs
+    # the quorum reconciler (the authority's own posting path -- we never re-post).
+    # For Tier 3-4, collect treats --apply as prepare-only and refuses to post; we
+    # honor that invariant and NEVER post Tier 3-4 evidence ourselves -- the human
+    # settlement is surfaced, not automated.
+    payload = _collect(repo, args.pr, args.reviewers, apply=args.apply)
     summary = summarize_collect(payload)
     plan = plan_settlement(
         tier=summary["tier"],
@@ -168,32 +158,19 @@ def main(argv: list[str] | None = None) -> int:
 
     next_steps: list[str] = []
     actions: list[str] = []
+    mutate_ok = True  # set False only if an attempted auto-merge actually fails
 
-    if args.apply and plan.ready_to_mutate:
-        if plan.route == ROUTE_AUTO_MERGE:
-            # Re-collect with --apply so Tier 0-2 evidence is posted, then auto-merge.
-            _collect(repo, args.pr, args.reviewers, apply=True)
-            am = _auto_merge(repo, args.pr)
-            actions.append(
-                "auto_merge_quorum_green: " + (am.stdout.strip() or am.stderr.strip())[:300]
-            )
-        elif plan.route == ROUTE_OPERATOR_TIER4:
-            # Prepare + post supportive evidence; surface (never auto-run) the settle path.
-            prepared = _collect(repo, args.pr, args.reviewers, apply=True)
-            posted = _post_supportive_evidence(repo, args.pr, prepared)
-            actions.append(f"posted {len(posted)} supportive evidence comment(s)")
-            head = (
-                summarize_collect(prepared).get("head_sha") or summary.get("head_sha") or "<head>"
-            )
-            next_steps = tier4_settle_commands(
-                repo=repo,
-                pr=args.pr,
-                head=str(head),
-                operator_login=args.operator_login or "<gh-login>",
-                no_app_token=args.no_app_token,
-            )
-    elif plan.route == ROUTE_OPERATOR_TIER4 and not plan.blockers:
-        # Dry-run informational: show the operator path even without --apply.
+    if args.apply and plan.ready_to_mutate and plan.route == ROUTE_AUTO_MERGE:
+        # collect --apply already posted + reconciled the Tier 0-2 evidence; merge.
+        am = _auto_merge(repo, args.pr)
+        mutate_ok = am.returncode == 0
+        actions.append(
+            f"auto_merge_quorum_green (rc={am.returncode}): "
+            + (am.stdout.strip() or am.stderr.strip())[:300]
+        )
+
+    if plan.route == ROUTE_OPERATOR_TIER4 and not plan.blockers:
+        # Tier 3-4: surface the operator settle commands; never post/settle here.
         next_steps = tier4_settle_commands(
             repo=repo,
             pr=args.pr,
@@ -201,6 +178,11 @@ def main(argv: list[str] | None = None) -> int:
             operator_login=args.operator_login or "<gh-login>",
             no_app_token=args.no_app_token,
         )
+        if args.apply:
+            actions.append(
+                "Tier 3-4: evidence prepared (collect refuses to auto-post it); "
+                "run the surfaced commands to settle -- never automated here."
+            )
 
     if args.json:
         print(
@@ -213,6 +195,7 @@ def main(argv: list[str] | None = None) -> int:
                     "quorum_satisfied": plan.quorum_satisfied,
                     "ready_to_mutate": plan.ready_to_mutate,
                     "applied": bool(args.apply),
+                    "mutate_ok": mutate_ok,
                     "blockers": list(plan.blockers),
                     "actions": actions,
                     "next_steps": next_steps,
@@ -232,8 +215,9 @@ def main(argv: list[str] | None = None) -> int:
             for s in next_steps:
                 print(f"    {s}")
 
-    # Exit 0 if ready (or already applied), 1 if blocked.
-    return 0 if plan.ready_to_mutate else 1
+    # Exit nonzero when blocked, or when an attempted auto-merge failed -- so an
+    # automation wrapper can distinguish a real settlement from a no-op/failure.
+    return 0 if (plan.ready_to_mutate and mutate_ok) else 1
 
 
 if __name__ == "__main__":

--- a/scripts/settle_pr.py
+++ b/scripts/settle_pr.py
@@ -148,6 +148,13 @@ def main(argv: list[str] | None = None) -> int:
     # settlement is surfaced, not automated.
     payload = _collect(repo, args.pr, args.reviewers, apply=args.apply)
     summary = summarize_collect(payload)
+    # Authority cross-check: under --apply, collect posts (action="post") only for
+    # the tiers it deems auto-settleable; "prepare" means it refused to post (Tier
+    # >=3, including a recheck tier-promotion the top-level `tier` did not reflect).
+    # plan_settlement re-routes such a PR to the operator path so it is never an
+    # auto-merge-withheld dead-end.
+    collect_prepared_only = str(summary.get("action") or "") == "prepare"
+
     plan = plan_settlement(
         tier=summary["tier"],
         quorum_satisfied=summary["quorum_satisfied"],
@@ -155,34 +162,21 @@ def main(argv: list[str] | None = None) -> int:
         head_sha=summary.get("head_sha"),
         unresolved_dissent=bool(summary["dissenting_families"]),
         operator_login_provided=bool(args.operator_login),
+        authority_prepare_only=collect_prepared_only,
     )
 
     next_steps: list[str] = []
     actions: list[str] = []
     mutate_ok = True  # set False only if an attempted auto-merge actually fails
 
-    # Authority cross-check: under --apply, collect posts (action="post") only for
-    # the tiers it deems auto-settleable; "prepare" means it refused to post (Tier
-    # >=3, including a recheck tier-promotion the top-level `tier` -- and so the
-    # plan's route -- did not reflect). Never auto-merge over that disagreement.
-    collect_prepared_only = str(summary.get("action") or "") == "prepare"
-
     if args.apply and plan.ready_to_mutate and plan.route == ROUTE_AUTO_MERGE:
-        if collect_prepared_only:
-            mutate_ok = False
-            actions.append(
-                "auto-merge withheld: collect classified prepare-only "
-                f"(action_reason={summary.get('action_reason')!r}) -- the evidence "
-                "authority puts this above the auto-merge tier; operator must settle."
-            )
-        else:
-            # collect --apply already posted + reconciled the Tier 0-2 evidence; merge.
-            am = _auto_merge(repo, args.pr)
-            mutate_ok = am.returncode == 0
-            actions.append(
-                f"auto_merge_quorum_green (rc={am.returncode}): "
-                + (am.stdout.strip() or am.stderr.strip())[:300]
-            )
+        # collect --apply already posted + reconciled the Tier 0-2 evidence; merge.
+        am = _auto_merge(repo, args.pr)
+        mutate_ok = am.returncode == 0
+        actions.append(
+            f"auto_merge_quorum_green (rc={am.returncode}): "
+            + (am.stdout.strip() or am.stderr.strip())[:300]
+        )
 
     if plan.route == ROUTE_OPERATOR_TIER4 and not plan.blockers:
         # Tier 3-4: surface the operator settle commands; never post/settle here.
@@ -193,6 +187,12 @@ def main(argv: list[str] | None = None) -> int:
             operator_login=args.operator_login or "<gh-login>",
             no_app_token=args.no_app_token,
         )
+        if collect_prepared_only:
+            actions.append(
+                "routed to operator settlement: collect classified prepare-only "
+                f"(action_reason={summary.get('action_reason')!r}) -- the evidence "
+                "authority puts this above the auto-merge tier despite the packet tier."
+            )
         if args.apply:
             actions.append(
                 "Tier 3-4: evidence prepared (collect refuses to auto-post it); "

--- a/scripts/settle_pr.py
+++ b/scripts/settle_pr.py
@@ -152,6 +152,7 @@ def main(argv: list[str] | None = None) -> int:
         tier=summary["tier"],
         quorum_satisfied=summary["quorum_satisfied"],
         supportive_families=summary["supportive_families"],
+        head_sha=summary.get("head_sha"),
         unresolved_dissent=bool(summary["dissenting_families"]),
         operator_login_provided=bool(args.operator_login),
     )
@@ -160,14 +161,28 @@ def main(argv: list[str] | None = None) -> int:
     actions: list[str] = []
     mutate_ok = True  # set False only if an attempted auto-merge actually fails
 
+    # Authority cross-check: under --apply, collect posts (action="post") only for
+    # the tiers it deems auto-settleable; "prepare" means it refused to post (Tier
+    # >=3, including a recheck tier-promotion the top-level `tier` -- and so the
+    # plan's route -- did not reflect). Never auto-merge over that disagreement.
+    collect_prepared_only = str(summary.get("action") or "") == "prepare"
+
     if args.apply and plan.ready_to_mutate and plan.route == ROUTE_AUTO_MERGE:
-        # collect --apply already posted + reconciled the Tier 0-2 evidence; merge.
-        am = _auto_merge(repo, args.pr)
-        mutate_ok = am.returncode == 0
-        actions.append(
-            f"auto_merge_quorum_green (rc={am.returncode}): "
-            + (am.stdout.strip() or am.stderr.strip())[:300]
-        )
+        if collect_prepared_only:
+            mutate_ok = False
+            actions.append(
+                "auto-merge withheld: collect classified prepare-only "
+                f"(action_reason={summary.get('action_reason')!r}) -- the evidence "
+                "authority puts this above the auto-merge tier; operator must settle."
+            )
+        else:
+            # collect --apply already posted + reconciled the Tier 0-2 evidence; merge.
+            am = _auto_merge(repo, args.pr)
+            mutate_ok = am.returncode == 0
+            actions.append(
+                f"auto_merge_quorum_green (rc={am.returncode}): "
+                + (am.stdout.strip() or am.stderr.strip())[:300]
+            )
 
     if plan.route == ROUTE_OPERATOR_TIER4 and not plan.blockers:
         # Tier 3-4: surface the operator settle commands; never post/settle here.
@@ -215,8 +230,15 @@ def main(argv: list[str] | None = None) -> int:
             for s in next_steps:
                 print(f"    {s}")
 
-    # Exit nonzero when blocked, or when an attempted auto-merge failed -- so an
-    # automation wrapper can distinguish a real settlement from a no-op/failure.
+    # Exit codes (so an automation wrapper can tell settlement from a no-op):
+    #   3  --apply on a Tier 3-4 route: the settle commands were SURFACED, not run.
+    #      Operator action is still required -- this is NOT a completed settlement,
+    #      so a wrapper must not advance past the human settle_tier4_pr steps.
+    #   1  blocked, or an attempted Tier 0-2 auto-merge actually failed.
+    #   0  actionable: a dry-run with a ready plan, or a Tier 0-2 auto-merge that
+    #      succeeded.
+    if args.apply and plan.route == ROUTE_OPERATOR_TIER4 and plan.ready_to_mutate:
+        return 3
     return 0 if (plan.ready_to_mutate and mutate_ok) else 1
 
 

--- a/scripts/settle_pr.py
+++ b/scripts/settle_pr.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Operator-driven PR settlement: collect -> verify quorum -> post -> tier-aware settle.
+
+COMPOSES the existing tools instead of reimplementing the merge gate:
+  - scripts/collect_quorum_evidence.py   model-quorum evidence (the authority)
+  - scripts/auto_merge_quorum_green.py   Tier 0-2 unattended merge on green quorum
+  - scripts/settle_tier4_pr.py           Tier 3-4 head-bound human settlement
+
+The routing/gating decision is the pure, unit-tested
+``aragora.swarm.settle_plan.plan_settlement`` -- this CLI only does I/O (gh /
+subprocess) and surfaces the plan. Dry-run by default; ``--apply`` mutates.
+
+It is AUTH-AGNOSTIC: it assumes the shell is already authenticated however the
+operator does it (env keys / Secrets Manager / Vault). It needs ``gh`` plus the
+reviewer keys present in the environment; it never reads, stores, or prints raw
+secrets.
+
+Tier-aware behavior under ``--apply``:
+  - Tier 0-2: posts evidence (via collect --apply) then runs the existing
+    auto-merge-on-green tool. Fully unattended.
+  - Tier 3-4: posts the supportive evidence, then SURFACES the exact
+    ``settle_tier4_pr.py`` commands for the operator to run. The Tier-4 human
+    risk settlement is a deliberate operator act and is never automated here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from aragora.swarm.settle_plan import (  # noqa: E402
+    ROUTE_AUTO_MERGE,
+    ROUTE_OPERATOR_TIER4,
+    plan_settlement,
+    summarize_collect,
+    tier4_settle_commands,
+)
+
+
+def _run(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+
+def _resolve_repo(repo: str | None) -> str | None:
+    if repo:
+        return repo
+    out = _run(["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"])
+    return out.stdout.strip() or None
+
+
+def _collect(repo: str, pr: int, reviewers: list[str], *, apply: bool) -> dict[str, Any]:
+    """Run collect_quorum_evidence and return its JSON payload.
+
+    collect exits non-zero when the quorum is not met but still prints the full
+    JSON, so we parse stdout regardless of the return code. A genuinely empty /
+    unparseable stdout becomes an error envelope.
+    """
+    script = _REPO_ROOT / "scripts" / "collect_quorum_evidence.py"
+    cmd = [
+        sys.executable,
+        str(script),
+        "--repo",
+        repo,
+        "--pr",
+        str(pr),
+        "--reviewers",
+        *reviewers,
+        "--json",
+    ]
+    if apply:
+        cmd.append("--apply")
+    out = _run(cmd)
+    try:
+        payload = json.loads(out.stdout)
+        if isinstance(payload, dict):
+            return payload
+    except (json.JSONDecodeError, ValueError):
+        pass
+    detail = (out.stderr or out.stdout or "collect produced no JSON").strip()
+    return {"mode": "collect_evidence", "error": detail[:500]}
+
+
+def _post_supportive_evidence(repo: str, pr: int, payload: dict[str, Any]) -> list[str]:
+    """Post each countable item's evidence body as a PR comment. Returns the URLs."""
+    posted: list[str] = []
+    for item in payload.get("items") or []:
+        if not item.get("would_count"):
+            continue
+        body = item.get("body") or ""
+        if not body.strip():
+            continue
+        out = _run(["gh", "pr", "comment", str(pr), "--repo", repo, "--body", body])
+        if out.returncode == 0 and out.stdout.strip():
+            posted.append(out.stdout.strip())
+    return posted
+
+
+def _auto_merge(repo: str, pr: int) -> subprocess.CompletedProcess[str]:
+    script = _REPO_ROOT / "scripts" / "auto_merge_quorum_green.py"
+    return _run([sys.executable, str(script), "--repo", repo, "--pr", str(pr), "--apply"])
+
+
+def _render_human(summary: dict[str, Any], plan: Any) -> None:
+    print(f"\nPR settlement plan  (tier={summary['tier']}  route={plan.route})")
+    print(f"  head:                  {summary.get('head_sha')}")
+    print(f"  supportive_families:   {summary['supportive_families']}")
+    print(f"  dissenting_families:   {summary['dissenting_families']}")
+    print(f"  has_supportive_quorum: {summary['quorum_satisfied']}")
+    if summary.get("failures"):
+        print(f"  reviewer failures:     {summary['failures']}")
+    for it in summary["items"]:
+        print(
+            f"  - {str(it['family']):8} verdict={str(it['verdict']):18} "
+            f"would_count={it['would_count']} problems={it['problems']}"
+        )
+    print(f"  ready_to_mutate:       {plan.ready_to_mutate}")
+    for b in plan.blockers:
+        print(f"    blocker: {b}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Collect quorum -> verify -> tier-aware settle a PR.")
+    ap.add_argument("--pr", type=int, required=True, help="PR number")
+    ap.add_argument("--repo", help="owner/name (default: current gh repo)")
+    ap.add_argument(
+        "--reviewers",
+        nargs="+",
+        default=["claude", "grok"],
+        help="reviewer model families (default: claude grok)",
+    )
+    ap.add_argument(
+        "--operator-login",
+        help="trusted operator GitHub login (required to surface the Tier 3-4 settle path)",
+    )
+    ap.add_argument(
+        "--apply", action="store_true", help="post evidence + settle (default: dry-run)"
+    )
+    ap.add_argument(
+        "--no-app-token",
+        action="store_true",
+        help="surface Tier-4 merge-apply with ARAGORA_DISABLE_GITHUB_APP_TOKEN=1 "
+        "(branch-protection preflight workaround)",
+    )
+    ap.add_argument("--json", action="store_true", help="emit a JSON summary instead of text")
+    args = ap.parse_args(argv)
+
+    repo = _resolve_repo(args.repo)
+    if not repo:
+        print("error: could not resolve repo (pass --repo owner/name)", file=sys.stderr)
+        return 2
+
+    payload = _collect(repo, args.pr, args.reviewers, apply=False)
+    summary = summarize_collect(payload)
+    plan = plan_settlement(
+        tier=summary["tier"],
+        quorum_satisfied=summary["quorum_satisfied"],
+        supportive_families=summary["supportive_families"],
+        unresolved_dissent=bool(summary["dissenting_families"]),
+        operator_login_provided=bool(args.operator_login),
+    )
+
+    next_steps: list[str] = []
+    actions: list[str] = []
+
+    if args.apply and plan.ready_to_mutate:
+        if plan.route == ROUTE_AUTO_MERGE:
+            # Re-collect with --apply so Tier 0-2 evidence is posted, then auto-merge.
+            _collect(repo, args.pr, args.reviewers, apply=True)
+            am = _auto_merge(repo, args.pr)
+            actions.append(
+                "auto_merge_quorum_green: " + (am.stdout.strip() or am.stderr.strip())[:300]
+            )
+        elif plan.route == ROUTE_OPERATOR_TIER4:
+            # Prepare + post supportive evidence; surface (never auto-run) the settle path.
+            prepared = _collect(repo, args.pr, args.reviewers, apply=True)
+            posted = _post_supportive_evidence(repo, args.pr, prepared)
+            actions.append(f"posted {len(posted)} supportive evidence comment(s)")
+            head = (
+                summarize_collect(prepared).get("head_sha") or summary.get("head_sha") or "<head>"
+            )
+            next_steps = tier4_settle_commands(
+                repo=repo,
+                pr=args.pr,
+                head=str(head),
+                operator_login=args.operator_login or "<gh-login>",
+                no_app_token=args.no_app_token,
+            )
+    elif plan.route == ROUTE_OPERATOR_TIER4 and not plan.blockers:
+        # Dry-run informational: show the operator path even without --apply.
+        next_steps = tier4_settle_commands(
+            repo=repo,
+            pr=args.pr,
+            head=str(summary.get("head_sha") or "<head>"),
+            operator_login=args.operator_login or "<gh-login>",
+            no_app_token=args.no_app_token,
+        )
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "repo": repo,
+                    "pr": args.pr,
+                    "route": plan.route,
+                    "tier": plan.tier,
+                    "quorum_satisfied": plan.quorum_satisfied,
+                    "ready_to_mutate": plan.ready_to_mutate,
+                    "applied": bool(args.apply),
+                    "blockers": list(plan.blockers),
+                    "actions": actions,
+                    "next_steps": next_steps,
+                    "summary": summary,
+                },
+                indent=2,
+            )
+        )
+    else:
+        _render_human(summary, plan)
+        if not args.apply:
+            print("\n  DRY RUN — nothing mutated. Re-run with --apply to act.")
+        for a in actions:
+            print(f"  action: {a}")
+        if next_steps:
+            print("\n  Tier 3-4 operator settle path (run these yourself):")
+            for s in next_steps:
+                print(f"    {s}")
+
+    # Exit 0 if ready (or already applied), 1 if blocked.
+    return 0 if plan.ready_to_mutate else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/settle_pr.py
+++ b/scripts/settle_pr.py
@@ -18,9 +18,10 @@ secrets.
 Tier-aware behavior under ``--apply``:
   - Tier 0-2: posts evidence (via collect --apply) then runs the existing
     auto-merge-on-green tool. Fully unattended.
-  - Tier 3-4: posts the supportive evidence, then SURFACES the exact
-    ``settle_tier4_pr.py`` commands for the operator to run. The Tier-4 human
-    risk settlement is a deliberate operator act and is never automated here.
+  - Tier 3-4: collect treats --apply as prepare-only and never posts; this CLI
+    honors that invariant and only SURFACES the exact ``settle_tier4_pr.py``
+    commands for the operator to run. The Tier-4 human risk settlement is a
+    deliberate operator act and is never posted or automated here.
 """
 
 from __future__ import annotations
@@ -43,15 +44,41 @@ from aragora.swarm.settle_plan import (  # noqa: E402
     tier4_settle_commands,
 )
 
+# Bounded so a hung `gh` or a stuck reviewer collect can never stall the CLI
+# indefinitely. Collect runs real model reviewers, so its ceiling is generous.
+_GH_TIMEOUT = 60.0
+_MERGE_TIMEOUT = 300.0
+_COLLECT_TIMEOUT = 1800.0
 
-def _run(cmd: list[str]) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+def _run(cmd: list[str], *, timeout: float | None = None) -> subprocess.CompletedProcess[str]:
+    """Run a subprocess, never raising on a timeout: a timed-out call returns a
+    synthetic rc=124 result (stdout/stderr preserved) so callers stay total."""
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True, check=False, timeout=timeout)
+    except subprocess.TimeoutExpired as exc:
+        out = (
+            exc.stdout
+            if isinstance(exc.stdout, str)
+            else (exc.stdout or b"").decode(errors="replace")
+        )
+        err = (
+            exc.stderr
+            if isinstance(exc.stderr, str)
+            else (exc.stderr or b"").decode(errors="replace")
+        )
+        return subprocess.CompletedProcess(
+            cmd, returncode=124, stdout=out, stderr=f"{err}\n[timed out after {timeout}s]".strip()
+        )
 
 
 def _resolve_repo(repo: str | None) -> str | None:
     if repo:
         return repo
-    out = _run(["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"])
+    out = _run(
+        ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
+        timeout=_GH_TIMEOUT,
+    )
     return out.stdout.strip() or None
 
 
@@ -76,7 +103,7 @@ def _collect(repo: str, pr: int, reviewers: list[str], *, apply: bool) -> dict[s
     ]
     if apply:
         cmd.append("--apply")
-    out = _run(cmd)
+    out = _run(cmd, timeout=_COLLECT_TIMEOUT)
     try:
         payload = json.loads(out.stdout)
         if isinstance(payload, dict):
@@ -89,11 +116,18 @@ def _collect(repo: str, pr: int, reviewers: list[str], *, apply: bool) -> dict[s
 
 def _auto_merge(repo: str, pr: int) -> subprocess.CompletedProcess[str]:
     script = _REPO_ROOT / "scripts" / "auto_merge_quorum_green.py"
-    return _run([sys.executable, str(script), "--repo", repo, "--pr", str(pr), "--apply"])
+    return _run(
+        [sys.executable, str(script), "--repo", repo, "--pr", str(pr), "--apply"],
+        timeout=_MERGE_TIMEOUT,
+    )
 
 
 def _render_human(summary: dict[str, Any], plan: Any) -> None:
     print(f"\nPR settlement plan  (tier={summary['tier']}  route={plan.route})")
+    if summary.get("error"):
+        # Surface collect's root cause (exception text / "no JSON") in the default
+        # text path too -- not just --json -- so a failed collect is diagnosable.
+        print(f"  collect error:         {summary['error']}")
     print(f"  head:                  {summary.get('head_sha')}")
     print(f"  supportive_families:   {summary['supportive_families']}")
     print(f"  dissenting_families:   {summary['dissenting_families']}")
@@ -178,7 +212,12 @@ def main(argv: list[str] | None = None) -> int:
             + (am.stdout.strip() or am.stderr.strip())[:300]
         )
 
-    if plan.route == ROUTE_OPERATOR_TIER4 and not plan.blockers:
+    # Surface the Tier 3-4 commands when the route is ready (no blockers), OR as a
+    # PREVIEW during a dry-run even if blocked (e.g. no --operator-login yet) so the
+    # operator can see the exact runbook before resolving blockers. Never surfaced
+    # under --apply unless genuinely ready -- a preview must not look actionable.
+    tier4_preview = plan.route == ROUTE_OPERATOR_TIER4 and bool(plan.blockers) and not args.apply
+    if plan.route == ROUTE_OPERATOR_TIER4 and (not plan.blockers or tier4_preview):
         # Tier 3-4: surface the operator settle commands; never post/settle here.
         next_steps = tier4_settle_commands(
             repo=repo,
@@ -214,6 +253,7 @@ def main(argv: list[str] | None = None) -> int:
                     "blockers": list(plan.blockers),
                     "actions": actions,
                     "next_steps": next_steps,
+                    "next_steps_preview": bool(next_steps) and bool(plan.blockers),
                     "summary": summary,
                 },
                 indent=2,
@@ -226,7 +266,12 @@ def main(argv: list[str] | None = None) -> int:
         for a in actions:
             print(f"  action: {a}")
         if next_steps:
-            print("\n  Tier 3-4 operator settle path (run these yourself):")
+            label = (
+                "Tier 3-4 operator settle path PREVIEW (resolve blockers above first):"
+                if plan.blockers
+                else "Tier 3-4 operator settle path (run these yourself):"
+            )
+            print(f"\n  {label}")
             for s in next_steps:
                 print(f"    {s}")
 

--- a/scripts/settle_pr.py
+++ b/scripts/settle_pr.py
@@ -128,6 +128,9 @@ def _render_human(summary: dict[str, Any], plan: Any) -> None:
         # Surface collect's root cause (exception text / "no JSON") in the default
         # text path too -- not just --json -- so a failed collect is diagnosable.
         print(f"  collect error:         {summary['error']}")
+    if summary.get("action"):
+        reason = summary.get("action_reason")
+        print(f"  collect action:        {summary['action']}" + (f" ({reason})" if reason else ""))
     print(f"  head:                  {summary.get('head_sha')}")
     print(f"  supportive_families:   {summary['supportive_families']}")
     print(f"  dissenting_families:   {summary['dissenting_families']}")
@@ -182,16 +185,15 @@ def main(argv: list[str] | None = None) -> int:
     # settlement is surfaced, not automated.
     payload = _collect(repo, args.pr, args.reviewers, apply=args.apply)
     summary = summarize_collect(payload)
-    # Authority cross-check. collect emits action="prepare" whenever it does NOT
-    # post -- which on a dry-run is ALWAYS (it never posts), and under --apply can
-    # mean several things (quorum incomplete, dissent, OR a genuine Tier >=3
-    # classification incl. a recheck tier-promotion the packet `tier` missed). Only
-    # the last is a tier-authority override. So honor it as one ONLY under --apply
-    # AND when the quorum is satisfied with no dissent -- then the one remaining
-    # reason collect refused to post is a higher tier, and re-routing to the
-    # operator path avoids an auto-merge-withheld dead-end. (Without this gate a
-    # dry-run would misroute every eligible Tier 0-2 PR to operator settlement.)
-    collect_prepared_only = (
+    # collect emits action="prepare" whenever it does NOT post -- which on a dry-run
+    # is ALWAYS (it never posts), and under --apply can mean several things (quorum
+    # incomplete, dissent, head moved, recheck pending, transient gh error, OR a
+    # genuine Tier >=3). "prepare" is NOT a reliable tier signal, so we do NOT try
+    # to infer escalation from it (tier-based routing already escalates a reported
+    # tier >2). We only flag the surprising case -- collect refused to post under
+    # --apply despite a satisfied quorum and no dissent -- so the planner can block
+    # the auto-merge (never merge OVER a refusal-to-post) and ask for a re-collect.
+    collect_refused_to_post = (
         bool(args.apply)
         and str(summary.get("action") or "") == "prepare"
         and bool(summary["quorum_satisfied"])
@@ -205,7 +207,7 @@ def main(argv: list[str] | None = None) -> int:
         head_sha=summary.get("head_sha"),
         unresolved_dissent=bool(summary["dissenting_families"]),
         operator_login_provided=bool(args.operator_login),
-        authority_prepare_only=collect_prepared_only,
+        collect_refused_to_post=collect_refused_to_post,
     )
 
     next_steps: list[str] = []
@@ -236,12 +238,6 @@ def main(argv: list[str] | None = None) -> int:
             no_app_token=args.no_app_token,
             repo_root=str(_REPO_ROOT),
         )
-        if collect_prepared_only:
-            actions.append(
-                "routed to operator settlement: collect classified prepare-only "
-                f"(action_reason={summary.get('action_reason')!r}) -- the evidence "
-                "authority puts this above the auto-merge tier despite the packet tier."
-            )
         if args.apply:
             actions.append(
                 "Tier 3-4: evidence prepared (collect refuses to auto-post it); "

--- a/scripts/settle_pr.py
+++ b/scripts/settle_pr.py
@@ -182,12 +182,21 @@ def main(argv: list[str] | None = None) -> int:
     # settlement is surfaced, not automated.
     payload = _collect(repo, args.pr, args.reviewers, apply=args.apply)
     summary = summarize_collect(payload)
-    # Authority cross-check: under --apply, collect posts (action="post") only for
-    # the tiers it deems auto-settleable; "prepare" means it refused to post (Tier
-    # >=3, including a recheck tier-promotion the top-level `tier` did not reflect).
-    # plan_settlement re-routes such a PR to the operator path so it is never an
-    # auto-merge-withheld dead-end.
-    collect_prepared_only = str(summary.get("action") or "") == "prepare"
+    # Authority cross-check. collect emits action="prepare" whenever it does NOT
+    # post -- which on a dry-run is ALWAYS (it never posts), and under --apply can
+    # mean several things (quorum incomplete, dissent, OR a genuine Tier >=3
+    # classification incl. a recheck tier-promotion the packet `tier` missed). Only
+    # the last is a tier-authority override. So honor it as one ONLY under --apply
+    # AND when the quorum is satisfied with no dissent -- then the one remaining
+    # reason collect refused to post is a higher tier, and re-routing to the
+    # operator path avoids an auto-merge-withheld dead-end. (Without this gate a
+    # dry-run would misroute every eligible Tier 0-2 PR to operator settlement.)
+    collect_prepared_only = (
+        bool(args.apply)
+        and str(summary.get("action") or "") == "prepare"
+        and bool(summary["quorum_satisfied"])
+        and not summary["dissenting_families"]
+    )
 
     plan = plan_settlement(
         tier=summary["tier"],
@@ -225,6 +234,7 @@ def main(argv: list[str] | None = None) -> int:
             head=str(summary.get("head_sha") or "<head>"),
             operator_login=args.operator_login or "<gh-login>",
             no_app_token=args.no_app_token,
+            repo_root=str(_REPO_ROOT),
         )
         if collect_prepared_only:
             actions.append(

--- a/tests/swarm/test_settle_plan.py
+++ b/tests/swarm/test_settle_plan.py
@@ -15,6 +15,7 @@ from aragora.swarm.settle_plan import (
     ROUTE_AUTO_MERGE,
     ROUTE_BLOCKED,
     ROUTE_OPERATOR_TIER4,
+    _coerce_tier,
     plan_settlement,
     summarize_collect,
     tier4_settle_commands,
@@ -130,6 +131,43 @@ def test_authority_prepare_only_reroutes_stale_tier_to_operator():
     assert blocked.route == ROUTE_OPERATOR_TIER4
     assert blocked.ready_to_mutate is False
     assert any("--operator-login" in b and "Tier 2" not in b for b in blocked.blockers)
+
+
+def test_negative_tier_is_blocked_not_auto_merged():
+    # A negative tier must NOT take `tier <= 2` into the less-conservative
+    # auto-merge path; it is malformed -> fail-safe ROUTE_BLOCKED.
+    plan = plan_settlement(tier=-1, quorum_satisfied=True, supportive_families=["claude", "grok"])
+    assert plan.route == ROUTE_BLOCKED
+    assert plan.ready_to_mutate is False
+    assert any("negative" in b for b in plan.blockers)
+
+
+def test_coerce_tier_is_total_on_nonfinite_and_negative():
+    # The helper must never propagate: json.loads yields NaN/Infinity floats, and
+    # int(NaN)/int(inf) raise -- finiteness is checked first. Negatives -> None.
+    assert _coerce_tier(float("nan")) is None
+    assert _coerce_tier(float("inf")) is None
+    assert _coerce_tier(float("-inf")) is None
+    assert _coerce_tier(2.7) is None  # non-integral
+    assert _coerce_tier(-1) is None  # negative int
+    assert _coerce_tier("-3") is None  # negative string
+    assert _coerce_tier(True) is None  # bool is not a tier
+    assert _coerce_tier(2.0) == 2  # integral float ok
+    assert _coerce_tier("3") == 3
+    assert _coerce_tier(0) == 0
+
+
+def test_summarize_collect_skips_malformed_items():
+    # A non-dict item must not crash the flatten (parity with the error envelope).
+    s = summarize_collect(
+        {
+            "tier": 2,
+            "has_supportive_quorum": True,
+            "items": [{"family": "claude", "verdict": "pass"}, "garbage", None, 42],
+        }
+    )
+    assert len(s["items"]) == 1
+    assert s["items"][0]["family"] == "claude"
 
 
 def test_unknown_tier_is_blocked_fail_safe():

--- a/tests/swarm/test_settle_plan.py
+++ b/tests/swarm/test_settle_plan.py
@@ -9,6 +9,8 @@ JSON payload into the fields the planner + diagnostics need.
 
 from __future__ import annotations
 
+from shlex import quote as shlex_quote
+
 from aragora.swarm.settle_plan import (
     ROUTE_AUTO_MERGE,
     ROUTE_BLOCKED,
@@ -103,6 +105,33 @@ def test_tier_four_with_operator_login_is_ready():
     assert plan.blockers == ()
 
 
+def test_authority_prepare_only_reroutes_stale_tier_to_operator():
+    # collect refused to post (action="prepare") but the packet tier still reads 2
+    # (a pre-post recheck promotion): trust the stricter authority and route to the
+    # operator path -- never auto-merge-withhold into a dead-end with no Tier-4 path.
+    plan = plan_settlement(
+        tier=2,
+        quorum_satisfied=True,
+        supportive_families=["claude", "grok"],
+        head_sha="abc123",
+        operator_login_provided=True,
+        authority_prepare_only=True,
+    )
+    assert plan.route == ROUTE_OPERATOR_TIER4
+    assert plan.ready_to_mutate is True  # login + head present -> surfaceable
+    # ...and without a login it blocks with a guiding message (no stale "Tier 2").
+    blocked = plan_settlement(
+        tier=2,
+        quorum_satisfied=True,
+        supportive_families=["claude", "grok"],
+        head_sha="abc123",
+        authority_prepare_only=True,
+    )
+    assert blocked.route == ROUTE_OPERATOR_TIER4
+    assert blocked.ready_to_mutate is False
+    assert any("--operator-login" in b and "Tier 2" not in b for b in blocked.blockers)
+
+
 def test_unknown_tier_is_blocked_fail_safe():
     plan = plan_settlement(tier=None, quorum_satisfied=True, supportive_families=["claude", "grok"])
     assert plan.route == ROUTE_BLOCKED
@@ -161,6 +190,36 @@ def test_summarize_collect_preserves_action_authority_signal():
     )
     assert s["action"] == "prepare"
     assert s["action_reason"] == "tier promoted to 3 on pre-post recheck"
+
+
+def test_summarize_collect_coerces_malformed_tier_to_none():
+    # A non-int tier from a malformed payload must not reach `tier <= 2` (TypeError);
+    # it coerces to None -> fail-safe ROUTE_BLOCKED.
+    s = summarize_collect({"tier": "not-a-tier", "has_supportive_quorum": True, "items": []})
+    assert s["tier"] is None
+    plan = plan_settlement(
+        tier=s["tier"], quorum_satisfied=True, supportive_families=["claude", "grok"]
+    )
+    assert plan.route == ROUTE_BLOCKED
+    # An integral string tier still parses.
+    assert summarize_collect({"tier": "3", "items": []})["tier"] == 3
+
+
+def test_tier4_settle_commands_quote_shell_metacharacters():
+    # Surfaced for copy-paste -> metacharacters in repo/head/login must be quoted,
+    # never an injection vector.
+    cmds = tier4_settle_commands(
+        repo="owner/repo;rm -rf /",
+        pr=42,
+        head="$(whoami)",
+        operator_login="alice`id`",
+    )
+    joined = "\n".join(cmds)
+    assert "rm -rf /" not in joined.replace("'owner/repo;rm -rf /'", "")
+    assert "$(whoami)" not in joined.replace("'$(whoami)'", "")
+    # the dangerous substrings only survive inside single-quotes
+    for raw in ("owner/repo;rm -rf /", "$(whoami)", "alice`id`"):
+        assert shlex_quote(raw) in joined
 
 
 def test_summarize_collect_handles_error_envelope():

--- a/tests/swarm/test_settle_plan.py
+++ b/tests/swarm/test_settle_plan.py
@@ -283,6 +283,26 @@ def test_tier4_settle_commands_are_head_bound_and_ordered():
     assert not cmds[2].startswith("ARAGORA_DISABLE_GITHUB_APP_TOKEN=1")
 
 
+def test_tier4_settle_commands_cd_guard_when_repo_root_given():
+    # repo_root prepends a `cd <root> &&` guard so the cwd-relative scripts/ path
+    # resolves from anywhere; the env override still applies to python3, not cd.
+    cmds = tier4_settle_commands(
+        repo="owner/repo",
+        pr=42,
+        head="abc123",
+        operator_login="alice",
+        no_app_token=True,
+        repo_root="/path/to repo",
+    )
+    for c in cmds:
+        assert c.startswith("cd '/path/to repo' && ")  # quoted (has a space)
+    # env override sits after the cd, before python3 (so it applies to python3)
+    assert "&& ARAGORA_DISABLE_GITHUB_APP_TOKEN=1 python3 " in cmds[2]
+    # ...and without repo_root there is no cd prefix (back-compat).
+    plain = tier4_settle_commands(repo="owner/repo", pr=42, head="abc123", operator_login="alice")
+    assert not any(c.startswith("cd ") for c in plain)
+
+
 def test_tier4_settle_commands_no_app_token_prefixes_merge_only():
     cmds = tier4_settle_commands(
         repo="owner/repo", pr=42, head="abc123", operator_login="alice", no_app_token=True

--- a/tests/swarm/test_settle_plan.py
+++ b/tests/swarm/test_settle_plan.py
@@ -54,6 +54,21 @@ def test_tier_four_requires_operator_login():
     assert any("--operator-login" in b for b in plan.blockers)
 
 
+def test_tier_four_unresolved_dissent_blocks_even_with_login():
+    # settle_tier4_pr hard-fails on unresolved dissent, so a Tier 3-4 plan must
+    # also block on it (not just Tier 0-2) -- else it surfaces doomed commands.
+    plan = plan_settlement(
+        tier=4,
+        quorum_satisfied=True,
+        supportive_families=["claude", "grok"],
+        unresolved_dissent=True,
+        operator_login_provided=True,
+    )
+    assert plan.route == ROUTE_OPERATOR_TIER4
+    assert plan.ready_to_mutate is False
+    assert any("dissent" in b for b in plan.blockers)
+
+
 def test_tier_four_with_operator_login_is_ready():
     plan = plan_settlement(
         tier=3,

--- a/tests/swarm/test_settle_plan.py
+++ b/tests/swarm/test_settle_plan.py
@@ -106,31 +106,31 @@ def test_tier_four_with_operator_login_is_ready():
     assert plan.blockers == ()
 
 
-def test_authority_prepare_only_reroutes_stale_tier_to_operator():
-    # collect refused to post (action="prepare") but the packet tier still reads 2
-    # (a pre-post recheck promotion): trust the stricter authority and route to the
-    # operator path -- never auto-merge-withhold into a dead-end with no Tier-4 path.
+def test_collect_refused_to_post_blocks_auto_merge_without_rerouting():
+    # collect refused to post (action="prepare") on a Tier 0-2 PR despite a clean
+    # quorum -- head moved / recheck pending / transient. "prepare" is NOT a tier
+    # signal, so we do NOT re-route to operator (that would surface Tier-4 commands
+    # bound to a superseded head). The route stays auto-merge but is BLOCKED: never
+    # auto-merge over a refusal-to-post; re-run collect.
     plan = plan_settlement(
         tier=2,
         quorum_satisfied=True,
         supportive_families=["claude", "grok"],
         head_sha="abc123",
-        operator_login_provided=True,
-        authority_prepare_only=True,
+        collect_refused_to_post=True,
     )
-    assert plan.route == ROUTE_OPERATOR_TIER4
-    assert plan.ready_to_mutate is True  # login + head present -> surfaceable
-    # ...and without a login it blocks with a guiding message (no stale "Tier 2").
-    blocked = plan_settlement(
-        tier=2,
+    assert plan.route == ROUTE_AUTO_MERGE  # NOT escalated to operator
+    assert plan.ready_to_mutate is False
+    assert any("refused to post" in b for b in plan.blockers)
+    # Genuine escalation still comes from the reported tier, not the prepare flag.
+    tier4 = plan_settlement(
+        tier=3,
         quorum_satisfied=True,
         supportive_families=["claude", "grok"],
         head_sha="abc123",
-        authority_prepare_only=True,
+        operator_login_provided=True,
     )
-    assert blocked.route == ROUTE_OPERATOR_TIER4
-    assert blocked.ready_to_mutate is False
-    assert any("--operator-login" in b and "Tier 2" not in b for b in blocked.blockers)
+    assert tier4.route == ROUTE_OPERATOR_TIER4
 
 
 def test_negative_tier_is_blocked_not_auto_merged():

--- a/tests/swarm/test_settle_plan.py
+++ b/tests/swarm/test_settle_plan.py
@@ -47,11 +47,31 @@ def test_tier_two_unresolved_dissent_blocks_auto_merge():
 
 def test_tier_four_requires_operator_login():
     # Without --operator-login the Tier-4 human settlement cannot proceed.
-    plan = plan_settlement(tier=4, quorum_satisfied=True, supportive_families=["claude", "grok"])
+    plan = plan_settlement(
+        tier=4,
+        quorum_satisfied=True,
+        supportive_families=["claude", "grok"],
+        head_sha="abc123",
+    )
     assert plan.route == ROUTE_OPERATOR_TIER4
     assert plan.requires_operator_login is True
     assert plan.ready_to_mutate is False
     assert any("--operator-login" in b for b in plan.blockers)
+
+
+def test_tier_four_missing_head_blocks_doomed_commands():
+    # Tier 3-4 commands embed `--head <sha>`; an unresolved head must block so the
+    # CLI never surfaces runnable-looking but doomed `--head <head>` placeholders.
+    plan = plan_settlement(
+        tier=4,
+        quorum_satisfied=True,
+        supportive_families=["claude", "grok"],
+        operator_login_provided=True,
+        head_sha=None,
+    )
+    assert plan.route == ROUTE_OPERATOR_TIER4
+    assert plan.ready_to_mutate is False
+    assert any("head_sha unresolved" in b for b in plan.blockers)
 
 
 def test_tier_four_unresolved_dissent_blocks_even_with_login():
@@ -61,6 +81,7 @@ def test_tier_four_unresolved_dissent_blocks_even_with_login():
         tier=4,
         quorum_satisfied=True,
         supportive_families=["claude", "grok"],
+        head_sha="abc123",
         unresolved_dissent=True,
         operator_login_provided=True,
     )
@@ -74,6 +95,7 @@ def test_tier_four_with_operator_login_is_ready():
         tier=3,
         quorum_satisfied=True,
         supportive_families=["claude", "grok"],
+        head_sha="abc123",
         operator_login_provided=True,
     )
     assert plan.route == ROUTE_OPERATOR_TIER4
@@ -120,6 +142,25 @@ def test_summarize_collect_flattens_payload():
     assert s["dissenting_families"] == []
     assert len(s["items"]) == 2
     assert s["failures"] == []
+
+
+def test_summarize_collect_preserves_action_authority_signal():
+    # collect's action/action_reason are the authority's own posted-vs-refused
+    # signal; the CLI cross-checks them against the route, so they must survive
+    # the flatten (a recheck tier-promotion shows action="prepare" here).
+    s = summarize_collect(
+        {
+            "tier": 2,
+            "head_sha": "abc123",
+            "has_supportive_quorum": True,
+            "action": "prepare",
+            "action_reason": "tier promoted to 3 on pre-post recheck",
+            "supportive_families": ["claude", "grok"],
+            "items": [],
+        }
+    )
+    assert s["action"] == "prepare"
+    assert s["action_reason"] == "tier promoted to 3 on pre-post recheck"
 
 
 def test_summarize_collect_handles_error_envelope():

--- a/tests/swarm/test_settle_plan.py
+++ b/tests/swarm/test_settle_plan.py
@@ -1,0 +1,140 @@
+"""Tests for the pure settlement routing/gating decision (settle_pr.py's brain).
+
+`plan_settlement` decides, from already-fetched quorum/tier state, whether a PR
+can be driven to settlement and by which route (auto-merge for Tier 0-2, operator
+human-settlement for Tier 3-4) -- accumulating every blocker. It performs no I/O,
+so it is fully unit-testable here. `summarize_collect` flattens a collect-evidence
+JSON payload into the fields the planner + diagnostics need.
+"""
+
+from __future__ import annotations
+
+from aragora.swarm.settle_plan import (
+    ROUTE_AUTO_MERGE,
+    ROUTE_BLOCKED,
+    ROUTE_OPERATOR_TIER4,
+    plan_settlement,
+    summarize_collect,
+    tier4_settle_commands,
+)
+
+
+def test_tier_two_satisfied_routes_to_auto_merge():
+    plan = plan_settlement(tier=2, quorum_satisfied=True, supportive_families=["claude", "grok"])
+    assert plan.route == ROUTE_AUTO_MERGE
+    assert plan.ready_to_mutate is True
+    assert plan.requires_operator_login is False
+    assert plan.blockers == ()
+
+
+def test_quorum_unsatisfied_blocks_and_is_not_ready():
+    plan = plan_settlement(tier=2, quorum_satisfied=False, supportive_families=["grok"])
+    assert plan.ready_to_mutate is False
+    assert any("quorum not satisfied" in b for b in plan.blockers)
+
+
+def test_tier_two_unresolved_dissent_blocks_auto_merge():
+    plan = plan_settlement(
+        tier=1,
+        quorum_satisfied=True,
+        supportive_families=["claude", "grok"],
+        unresolved_dissent=True,
+    )
+    assert plan.route == ROUTE_AUTO_MERGE
+    assert plan.ready_to_mutate is False
+    assert any("dissent" in b for b in plan.blockers)
+
+
+def test_tier_four_requires_operator_login():
+    # Without --operator-login the Tier-4 human settlement cannot proceed.
+    plan = plan_settlement(tier=4, quorum_satisfied=True, supportive_families=["claude", "grok"])
+    assert plan.route == ROUTE_OPERATOR_TIER4
+    assert plan.requires_operator_login is True
+    assert plan.ready_to_mutate is False
+    assert any("--operator-login" in b for b in plan.blockers)
+
+
+def test_tier_four_with_operator_login_is_ready():
+    plan = plan_settlement(
+        tier=3,
+        quorum_satisfied=True,
+        supportive_families=["claude", "grok"],
+        operator_login_provided=True,
+    )
+    assert plan.route == ROUTE_OPERATOR_TIER4
+    assert plan.ready_to_mutate is True
+    assert plan.blockers == ()
+
+
+def test_unknown_tier_is_blocked_fail_safe():
+    plan = plan_settlement(tier=None, quorum_satisfied=True, supportive_families=["claude", "grok"])
+    assert plan.route == ROUTE_BLOCKED
+    assert plan.ready_to_mutate is False
+    assert any("tier unknown" in b for b in plan.blockers)
+
+
+def test_summarize_collect_flattens_payload():
+    payload = {
+        "tier": 2,
+        "head_sha": "abc123",
+        "has_supportive_quorum": True,
+        "supportive_families": ["claude", "grok"],
+        "dissenting_families": [],
+        "items": [
+            {
+                "family": "claude",
+                "verdict": "pass",
+                "would_count": True,
+                "counted_reviewer_ids": ["claude"],
+                "problems": [],
+            },
+            {
+                "family": "grok",
+                "verdict": "pass",
+                "would_count": True,
+                "counted_reviewer_ids": ["grok"],
+                "problems": [],
+            },
+        ],
+        "failures": [],
+    }
+    s = summarize_collect(payload)
+    assert s["tier"] == 2
+    assert s["quorum_satisfied"] is True
+    assert s["supportive_families"] == ["claude", "grok"]
+    assert s["dissenting_families"] == []
+    assert len(s["items"]) == 2
+    assert s["failures"] == []
+
+
+def test_summarize_collect_handles_error_envelope():
+    s = summarize_collect({"mode": "collect_evidence", "error": "boom"})
+    assert s["error"] == "boom"
+    assert s["quorum_satisfied"] is False
+    assert s["tier"] is None
+
+
+def test_tier4_settle_commands_are_head_bound_and_ordered():
+    cmds = tier4_settle_commands(repo="owner/repo", pr=42, head="abc123", operator_login="alice")
+    assert len(cmds) == 3
+    # check -> settle-only -> merge-apply, every command head-bound + operator-pinned.
+    assert cmds[0].endswith("--check")
+    assert cmds[1].endswith("--settle-only")
+    assert cmds[2].endswith("--merge-apply")
+    for c in cmds:
+        assert "--pr 42" in c
+        assert "--head abc123" in c
+        assert "--trusted-operator-login alice" in c
+        assert "--repo owner/repo" in c
+    # no app-token prefix unless requested
+    assert not cmds[2].startswith("ARAGORA_DISABLE_GITHUB_APP_TOKEN=1")
+
+
+def test_tier4_settle_commands_no_app_token_prefixes_merge_only():
+    cmds = tier4_settle_commands(
+        repo="owner/repo", pr=42, head="abc123", operator_login="alice", no_app_token=True
+    )
+    assert cmds[2].startswith("ARAGORA_DISABLE_GITHUB_APP_TOKEN=1 ")
+    # only the irreversible merge-apply step carries the override
+    assert not cmds[0].startswith("ARAGORA_DISABLE_GITHUB_APP_TOKEN=1")
+    assert not cmds[1].startswith("ARAGORA_DISABLE_GITHUB_APP_TOKEN=1")

--- a/tests/swarm/test_settle_pr_cli.py
+++ b/tests/swarm/test_settle_pr_cli.py
@@ -93,20 +93,28 @@ def test_tier4_apply_surfaces_commands_and_exits_3(cli, monkeypatch):
     assert calls["auto_merge"] == 0  # never auto-merges a Tier-4 PR
 
 
-def test_prepare_only_reroutes_to_operator_not_dead_end(cli, monkeypatch):
-    # collect refused to post (action="prepare") with a stale tier=2: must re-route
-    # to the operator path (exit 3 under --apply with a login), never silently
-    # withhold auto-merge with no surfaced settle path.
+def test_apply_prepare_clean_quorum_blocks_and_recollects(cli, monkeypatch, capsys):
+    # collect refused to post under --apply despite a clean quorum (head moved /
+    # recheck pending). "prepare" is NOT a tier signal: the PR must NOT be re-routed
+    # to operator settlement (no Tier-4 commands bound to a superseded head); it
+    # stays on auto_merge_green, BLOCKED with a re-collect instruction, exit 1, and
+    # is never auto-merged over the refusal.
     monkeypatch.setattr(
         cli,
         "_collect",
-        lambda *a, **k: _payload(action="prepare", action_reason="tier promoted on recheck"),
+        lambda *a, **k: _payload(action="prepare", action_reason="head moved since classification"),
     )
     auto = {"n": 0}
     monkeypatch.setattr(cli, "_auto_merge", lambda *a, **k: auto.__setitem__("n", auto["n"] + 1))
-    rc = cli.main(["--repo", "owner/repo", "--pr", "8511", "--apply", "--operator-login", "alice"])
-    assert rc == 3
-    assert auto["n"] == 0  # prepare-only never auto-merges
+    rc = cli.main(
+        ["--repo", "owner/repo", "--pr", "8511", "--apply", "--operator-login", "alice", "--json"]
+    )
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 1
+    assert auto["n"] == 0  # never auto-merges over a refusal-to-post
+    assert out["route"] == "auto_merge_green"  # NOT re-routed to operator
+    assert out["next_steps"] == []  # no Tier-4 commands surfaced
+    assert any("refused to post" in b for b in out["blockers"])
 
 
 def test_dry_run_ready_exits_0_without_mutating(cli, monkeypatch):

--- a/tests/swarm/test_settle_pr_cli.py
+++ b/tests/swarm/test_settle_pr_cli.py
@@ -8,6 +8,7 @@ test_settle_plan.py; this guards the glue.
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -109,12 +110,45 @@ def test_prepare_only_reroutes_to_operator_not_dead_end(cli, monkeypatch):
 
 
 def test_dry_run_ready_exits_0_without_mutating(cli, monkeypatch):
-    monkeypatch.setattr(cli, "_collect", lambda *a, **k: _payload())
+    # Real collect emits action="prepare" on a dry-run (it never posts). That must
+    # NOT be read as a tier-authority override -- an eligible Tier 0-2 dry-run must
+    # stay on the auto-merge route and exit 0, not misroute to operator settlement.
+    monkeypatch.setattr(cli, "_collect", lambda *a, **k: _payload(action="prepare"))
     auto = {"n": 0}
     monkeypatch.setattr(cli, "_auto_merge", lambda *a, **k: auto.__setitem__("n", auto["n"] + 1))
     rc = cli.main(["--repo", "owner/repo", "--pr", "8512"])  # no --apply
     assert rc == 0
     assert auto["n"] == 0  # dry-run never calls auto-merge
+
+
+def test_apply_prepare_with_unsatisfied_quorum_stays_auto_merge_route(cli, monkeypatch, capsys):
+    # Under --apply, action="prepare" caused by an INCOMPLETE quorum (not a tier
+    # promotion) must not be mislabeled as operator settlement: the route stays
+    # auto_merge_green (it is genuinely Tier 2), blocked on the quorum.
+    monkeypatch.setattr(
+        cli,
+        "_collect",
+        lambda *a, **k: _payload(
+            action="prepare", has_supportive_quorum=False, supportive_families=["claude"]
+        ),
+    )
+    rc = cli.main(["--repo", "owner/repo", "--pr", "8512", "--apply", "--json"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert json.loads(out)["route"] == "auto_merge_green"
+
+
+def test_apply_prepare_with_dissent_stays_auto_merge_route(cli, monkeypatch, capsys):
+    # Same for a dissent-caused prepare: not a tier override.
+    monkeypatch.setattr(
+        cli,
+        "_collect",
+        lambda *a, **k: _payload(action="prepare", dissenting_families=["grok"]),
+    )
+    rc = cli.main(["--repo", "owner/repo", "--pr", "8512", "--apply", "--json"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert json.loads(out)["route"] == "auto_merge_green"
 
 
 def test_tier4_dry_run_previews_runbook_without_login(cli, monkeypatch, capsys):

--- a/tests/swarm/test_settle_pr_cli.py
+++ b/tests/swarm/test_settle_pr_cli.py
@@ -115,3 +115,27 @@ def test_dry_run_ready_exits_0_without_mutating(cli, monkeypatch):
     rc = cli.main(["--repo", "owner/repo", "--pr", "8512"])  # no --apply
     assert rc == 0
     assert auto["n"] == 0  # dry-run never calls auto-merge
+
+
+def test_tier4_dry_run_previews_runbook_without_login(cli, monkeypatch, capsys):
+    # A Tier-4 dry-run with no --operator-login is blocked (exit 1) but still
+    # PREVIEWS the settle runbook so the operator sees it before resolving blockers.
+    monkeypatch.setattr(cli, "_collect", lambda *a, **k: _payload(tier=4))
+    rc = cli.main(["--repo", "owner/repo", "--pr", "8382"])  # dry-run, no login
+    out = capsys.readouterr().out
+    assert rc == 1  # blocked (no login) -> not ready
+    assert "PREVIEW" in out
+    assert "settle_tier4_pr.py" in out
+    assert "<gh-login>" in out  # placeholder for the missing login
+
+
+def test_collect_error_is_surfaced_in_text_output(cli, monkeypatch, capsys):
+    # collect's root-cause error must appear in the default text path, not only --json.
+    monkeypatch.setattr(
+        cli, "_collect", lambda *a, **k: {"mode": "collect_evidence", "error": "boom: no JSON"}
+    )
+    rc = cli.main(["--repo", "owner/repo", "--pr", "8512"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "collect error" in out
+    assert "boom: no JSON" in out

--- a/tests/swarm/test_settle_pr_cli.py
+++ b/tests/swarm/test_settle_pr_cli.py
@@ -1,0 +1,117 @@
+"""Orchestration tests for scripts/settle_pr.py (the I/O wrapper around the pure
+`settle_plan` brain). These exercise the collect->plan->apply wiring and the
+exit-code contract that automation wrappers depend on, with `_collect`/`_auto_merge`
+stubbed (no real `gh`/subprocess). The routing logic itself is covered by
+test_settle_plan.py; this guards the glue.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SETTLE_PR = _REPO_ROOT / "scripts" / "settle_pr.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("settle_pr_cli_under_test", _SETTLE_PR)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def cli(monkeypatch):
+    mod = _load_module()
+    # Never touch the network: --repo is always passed so _resolve_repo is a no-op,
+    # but stub it defensively anyway.
+    monkeypatch.setattr(mod, "_resolve_repo", lambda repo: repo or "owner/repo")
+    return mod
+
+
+def _payload(**over):
+    base = {
+        "tier": 2,
+        "head_sha": "abc123",
+        "has_supportive_quorum": True,
+        "action": "post",
+        "supportive_families": ["claude", "grok"],
+        "dissenting_families": [],
+        "items": [],
+        "failures": [],
+    }
+    base.update(over)
+    return base
+
+
+def test_tier2_apply_auto_merge_success_exits_0(cli, monkeypatch):
+    monkeypatch.setattr(cli, "_collect", lambda *a, **k: _payload())
+    monkeypatch.setattr(
+        cli,
+        "_auto_merge",
+        lambda *a, **k: SimpleNamespace(returncode=0, stdout="merged", stderr=""),
+    )
+    rc = cli.main(["--repo", "owner/repo", "--pr", "8512", "--apply"])
+    assert rc == 0
+
+
+def test_tier2_apply_auto_merge_failure_exits_1(cli, monkeypatch):
+    monkeypatch.setattr(cli, "_collect", lambda *a, **k: _payload())
+    monkeypatch.setattr(
+        cli, "_auto_merge", lambda *a, **k: SimpleNamespace(returncode=1, stdout="", stderr="boom")
+    )
+    rc = cli.main(["--repo", "owner/repo", "--pr", "8512", "--apply"])
+    assert rc == 1
+
+
+def test_quorum_unsatisfied_exits_1(cli, monkeypatch):
+    monkeypatch.setattr(
+        cli,
+        "_collect",
+        lambda *a, **k: _payload(has_supportive_quorum=False, supportive_families=["claude"]),
+    )
+    rc = cli.main(["--repo", "owner/repo", "--pr", "8512", "--apply"])
+    assert rc == 1
+
+
+def test_tier4_apply_surfaces_commands_and_exits_3(cli, monkeypatch):
+    # Tier 3-4 --apply: commands are SURFACED, not run -> exit 3 (operator action
+    # still required), never 0.
+    monkeypatch.setattr(cli, "_collect", lambda *a, **k: _payload(tier=4))
+    calls = {"auto_merge": 0}
+    monkeypatch.setattr(
+        cli, "_auto_merge", lambda *a, **k: calls.__setitem__("auto_merge", calls["auto_merge"] + 1)
+    )
+    rc = cli.main(["--repo", "owner/repo", "--pr", "8382", "--apply", "--operator-login", "alice"])
+    assert rc == 3
+    assert calls["auto_merge"] == 0  # never auto-merges a Tier-4 PR
+
+
+def test_prepare_only_reroutes_to_operator_not_dead_end(cli, monkeypatch):
+    # collect refused to post (action="prepare") with a stale tier=2: must re-route
+    # to the operator path (exit 3 under --apply with a login), never silently
+    # withhold auto-merge with no surfaced settle path.
+    monkeypatch.setattr(
+        cli,
+        "_collect",
+        lambda *a, **k: _payload(action="prepare", action_reason="tier promoted on recheck"),
+    )
+    auto = {"n": 0}
+    monkeypatch.setattr(cli, "_auto_merge", lambda *a, **k: auto.__setitem__("n", auto["n"] + 1))
+    rc = cli.main(["--repo", "owner/repo", "--pr", "8511", "--apply", "--operator-login", "alice"])
+    assert rc == 3
+    assert auto["n"] == 0  # prepare-only never auto-merges
+
+
+def test_dry_run_ready_exits_0_without_mutating(cli, monkeypatch):
+    monkeypatch.setattr(cli, "_collect", lambda *a, **k: _payload())
+    auto = {"n": 0}
+    monkeypatch.setattr(cli, "_auto_merge", lambda *a, **k: auto.__setitem__("n", auto["n"] + 1))
+    rc = cli.main(["--repo", "owner/repo", "--pr", "8512"])  # no --apply
+    assert rc == 0
+    assert auto["n"] == 0  # dry-run never calls auto-merge


### PR DESCRIPTION
## What

A single **auth-agnostic** CLI (`scripts/settle_pr.py`) that drives a PR through the full settlement runbook by **composing the existing tools** — it does not reimplement the merge gate:

`collect_quorum_evidence` (evidence = the authority) → verify the quorum is genuinely satisfied → post → **tier-aware** settle:
- **Tier 0-2** → runs the existing `auto_merge_quorum_green` (unattended).
- **Tier 3-4** → posts supportive evidence, then **surfaces** the exact `settle_tier4_pr` commands for the operator. The Tier-4 human risk settlement is a deliberate operator act and is **never auto-run** here.

## Design

- `aragora/swarm/settle_plan.py` — the pure, unit-tested **decision brain** (`plan_settlement` routing/gating, `summarize_collect`, `tier4_settle_commands`). No I/O; every refusal reason is accumulated in `blockers`.
- `scripts/settle_pr.py` — a **thin** CLI doing only `gh`/subprocess I/O. **Dry-run by default**; `--apply` mutates. Auth-agnostic (uses whatever the shell already provides — env keys / Secrets Manager / Vault); never reads, stores, or prints raw secrets.

## Why

The end-to-end "collect → verify real quorum → post → settle" runbook was tribal knowledge scattered across ad-hoc commands. This captures it as a tested, documented tool that refuses to post/settle unless the model quorum is genuinely satisfied.

## Verification

- 10 unit tests (routing matrix, error-envelope tolerance, head-bound/ordered Tier-4 commands), ruff + mypy clean, standalone `--help` works.
- **Net-new files only** (no merge-authority surfaces touched) → Tier-2; lands through the same quorum gate it helps drive (dogfood).

🤖 Generated with [Claude Code](https://claude.com/claude-code)