### PR TITLE
feat(swarm): wip_budget — count-based open-PR WIP cap (stop the queue refilling)

### DIFF
--- a/aragora/swarm/wip_budget.py
+++ b/aragora/swarm/wip_budget.py
@@ -43,6 +43,10 @@ from typing import Any
 POLICY_RELPATH = Path(".aragora") / "wip_budgets.json"
 ENV_FLEET_DEFAULT = "ARAGORA_WIP_OPEN_PR_CAP"
 
+# resolve_wip_budget source_status values (human-readable; classify_wip derives
+# its verdict from the data, not from this advisory label -- see classify_wip).
+WIP_OK = "ok"
+
 # classify_wip verdicts.
 WIP_WITHIN_CAP = "within_cap"
 WIP_OVER_CAP = "over_cap"
@@ -148,7 +152,15 @@ def resolve_wip_budget(
     policy: WipPolicy,
     fleet_id: str,
 ) -> dict[str, Any]:
-    """Compose one fleet's raw ``wip`` dict for :func:`classify_wip`."""
+    """Compose one fleet's raw ``wip`` dict for :func:`classify_wip`.
+
+    Unlike :mod:`loop_budget` -- which reads a persisted spend snapshot and tracks
+    its mtime freshness -- the open-PR count here is supplied live by the caller
+    (e.g. a just-run ``gh pr list``), so there is no freshness/age field: ensuring
+    the count is current is the caller's responsibility at the decision point. A
+    caller wiring this into a generation lane must measure the count immediately
+    before gating, not reuse a stale cached value.
+    """
     cap, cap_source = policy.cap_for(fleet_id)
     count = _as_count(open_pr_count)
 
@@ -181,7 +193,7 @@ def resolve_wip_budget(
         }
     return {
         "source": f"{cap_source} + count:supplied",
-        "source_status": "ok",
+        "source_status": WIP_OK,
         "open_pr_count": count,
         "ceiling": cap,
         "remaining": cap - count,
@@ -191,15 +203,18 @@ def resolve_wip_budget(
 def classify_wip(wip: dict[str, Any]) -> WipDecision:
     """Classify a ``wip`` dict into a :class:`WipDecision`.
 
-    Only the ``ok`` status (real ceiling + real count) can produce ``over_cap``
-    and withhold generation; every other status keeps ``allow_generation`` True.
+    The verdict is derived from the *data itself* (parsed count + ceiling), NOT
+    from the advisory ``source_status`` label, so a caller cannot bypass the
+    fail-safe by mislabelling a dict ``source_status="ok"`` with a missing or
+    untrusted count. Only a real ceiling AND a real count can produce ``over_cap``
+    and withhold generation; every other shape keeps ``allow_generation`` True
+    (``cap=0`` is the deliberate "freeze" case: count >= 0 is always over_cap).
     """
-    status = str(wip.get("source_status", WIP_UNAVAILABLE))
     count = _as_count(wip.get("open_pr_count"))
     ceiling = _as_count(wip.get("ceiling"))
     source = str(wip.get("source", "none"))
 
-    if status == "ok" and count is not None and ceiling is not None:
+    if count is not None and ceiling is not None:
         over = count >= ceiling
         return WipDecision(
             verdict=WIP_OVER_CAP if over else WIP_WITHIN_CAP,
@@ -209,10 +224,7 @@ def classify_wip(wip: dict[str, Any]) -> WipDecision:
             remaining=ceiling - count,
             source=source,
         )
-    if status == "unavailable":
-        verdict = WIP_UNAVAILABLE
-    else:
-        verdict = WIP_DEGRADED
+    verdict = WIP_UNAVAILABLE if (count is None and ceiling is None) else WIP_DEGRADED
     return WipDecision(
         verdict=verdict,
         allow_generation=True,

--- a/aragora/swarm/wip_budget.py
+++ b/aragora/swarm/wip_budget.py
@@ -1,0 +1,223 @@
+"""Loop Control Plane v2 -- count-based open-PR WIP ceilings.
+
+Companion to :mod:`aragora.swarm.loop_budget` (dollar ceilings). Where the dollar
+budget governs a *running* loop's spend, the WIP cap governs whether a generation
+lane should create *another* PR given how many it already has open -- the queue-
+pressure control that stops one fleet out-generating the merge gate (the
+"backlog never drains because generation == settlement" failure mode).
+
+Two honest pieces, mirroring loop_budget:
+
+* **Policy** (``.aragora/wip_budgets.json``, operator-owned): per-fleet open-PR
+  ceilings with an optional fleet default. ``ARAGORA_WIP_OPEN_PR_CAP`` is the
+  lowest-precedence fleet default.
+* **Live count**: the current open-PR count for a fleet, supplied by the caller
+  (e.g. from ``gh pr list``). The control plane only ever *reads* a count it is
+  handed; it never fabricates one.
+
+:func:`resolve_wip_budget` composes them into a raw ``wip`` dict; :func:`classify_wip`
+turns that into a :class:`WipDecision`:
+
+* ceiling + real count   -> ``within_cap`` | ``over_cap`` (the only gating states)
+* ceiling, unknown count -> ``degraded``  (visible, never blocks -- fail safe)
+* count, no ceiling      -> ``degraded``  (visible count, nothing to gate on)
+* neither                -> ``unavailable``
+
+A fabricated/unknown count NEVER classifies ``over_cap``: blocking a legitimate
+fleet on a number we cannot trust is exactly the fabricated-alarm class the
+control plane exists to avoid (mirrors loop_budget's "never halt on stale spend").
+
+This module provides the rails, not the retirement: a generation lane adopts
+:func:`classify_wip` at its create-PR decision point; nothing here mutates a loop.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+POLICY_RELPATH = Path(".aragora") / "wip_budgets.json"
+ENV_FLEET_DEFAULT = "ARAGORA_WIP_OPEN_PR_CAP"
+
+# classify_wip verdicts.
+WIP_WITHIN_CAP = "within_cap"
+WIP_OVER_CAP = "over_cap"
+WIP_DEGRADED = "degraded"
+WIP_UNAVAILABLE = "unavailable"
+
+
+def _as_count(value: Any) -> int | None:
+    """Parse a finite, non-negative integer count; everything else is ``None``.
+
+    Rejects bools, NaN/inf, negatives, and non-integral floats (a count of
+    ``3.7`` open PRs is meaningless). A rejected value reads as "unknown", which
+    fails safe (never ``over_cap``) rather than fabricating a gate.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if value >= 0 else None
+    if isinstance(value, float):
+        if not math.isfinite(value) or value < 0 or value != int(value):
+            return None
+        return int(value)
+    if isinstance(value, str):
+        try:
+            parsed = int(value.strip())
+        except ValueError:
+            return None
+        return parsed if parsed >= 0 else None
+    return None
+
+
+@dataclass
+class WipPolicy:
+    """Operator-owned per-fleet open-PR ceilings."""
+
+    default_cap: int | None = None
+    per_fleet_cap: dict[str, int] = field(default_factory=dict)
+    source: str = "none"
+
+    @classmethod
+    def load(cls, repo_root: Path | str) -> "WipPolicy":
+        """Read the policy file, falling back to the env fleet default.
+
+        Missing or unreadable policy degrades to the env fallback (or an empty
+        policy) instead of raising; like loop_budget, the WIP surface must never
+        take the fleet inventory down.
+        """
+        path = Path(repo_root) / POLICY_RELPATH
+        payload: dict[str, Any] | None = None
+        try:
+            with path.open(encoding="utf-8") as handle:
+                loaded = json.load(handle)
+            payload = loaded if isinstance(loaded, dict) else None
+        except (OSError, json.JSONDecodeError, ValueError):
+            payload = None
+
+        env_default = _as_count(os.environ.get(ENV_FLEET_DEFAULT))
+        if payload is None:
+            if env_default is not None:
+                return cls(default_cap=env_default, source=f"env:{ENV_FLEET_DEFAULT}")
+            return cls()
+
+        per_fleet: dict[str, int] = {}
+        raw_fleets = payload.get("fleets")
+        if isinstance(raw_fleets, dict):
+            for fleet_id, entry in raw_fleets.items():
+                cap = _as_count(entry.get("cap")) if isinstance(entry, dict) else None
+                if cap is not None:
+                    per_fleet[str(fleet_id)] = cap
+
+        default_cap = _as_count(payload.get("default_cap"))
+        source = f"policy:{POLICY_RELPATH}"
+        if default_cap is None and env_default is not None:
+            default_cap = env_default
+            source = f"policy:{POLICY_RELPATH}+env:{ENV_FLEET_DEFAULT}"
+
+        return cls(default_cap=default_cap, per_fleet_cap=per_fleet, source=source)
+
+    def cap_for(self, fleet_id: str) -> tuple[int | None, str]:
+        """Return ``(cap, source)`` for one fleet (per-fleet beats default)."""
+        if fleet_id in self.per_fleet_cap:
+            return self.per_fleet_cap[fleet_id], f"{self.source}#fleets.{fleet_id}"
+        if self.default_cap is not None:
+            return self.default_cap, f"{self.source}#default"
+        return None, "none"
+
+
+@dataclass(frozen=True)
+class WipDecision:
+    """Pure output of :func:`classify_wip`. ``allow_generation`` is the answer to
+    'may this lane create another PR right now?' -- ``False`` only on ``over_cap``."""
+
+    verdict: str
+    allow_generation: bool
+    open_pr_count: int | None
+    ceiling: int | None
+    remaining: int | None
+    source: str
+
+
+def resolve_wip_budget(
+    open_pr_count: int | None,
+    policy: WipPolicy,
+    fleet_id: str,
+) -> dict[str, Any]:
+    """Compose one fleet's raw ``wip`` dict for :func:`classify_wip`."""
+    cap, cap_source = policy.cap_for(fleet_id)
+    count = _as_count(open_pr_count)
+
+    if count is None and cap is None:
+        return {
+            "source": "none",
+            "source_status": WIP_UNAVAILABLE,
+            "open_pr_count": None,
+            "ceiling": None,
+            "remaining": None,
+        }
+    if cap is None:
+        # Visible count, nothing to gate on.
+        return {
+            "source": "count:supplied",
+            "source_status": WIP_DEGRADED,
+            "open_pr_count": count,
+            "ceiling": None,
+            "remaining": None,
+        }
+    if count is None:
+        # A ceiling with an unknown count is visible but never blocks: blocking
+        # on a number we cannot trust is the fabricated-alarm class to avoid.
+        return {
+            "source": cap_source,
+            "source_status": WIP_DEGRADED,
+            "open_pr_count": None,
+            "ceiling": cap,
+            "remaining": None,
+        }
+    return {
+        "source": f"{cap_source} + count:supplied",
+        "source_status": "ok",
+        "open_pr_count": count,
+        "ceiling": cap,
+        "remaining": cap - count,
+    }
+
+
+def classify_wip(wip: dict[str, Any]) -> WipDecision:
+    """Classify a ``wip`` dict into a :class:`WipDecision`.
+
+    Only the ``ok`` status (real ceiling + real count) can produce ``over_cap``
+    and withhold generation; every other status keeps ``allow_generation`` True.
+    """
+    status = str(wip.get("source_status", WIP_UNAVAILABLE))
+    count = _as_count(wip.get("open_pr_count"))
+    ceiling = _as_count(wip.get("ceiling"))
+    source = str(wip.get("source", "none"))
+
+    if status == "ok" and count is not None and ceiling is not None:
+        over = count >= ceiling
+        return WipDecision(
+            verdict=WIP_OVER_CAP if over else WIP_WITHIN_CAP,
+            allow_generation=not over,
+            open_pr_count=count,
+            ceiling=ceiling,
+            remaining=ceiling - count,
+            source=source,
+        )
+    if status == "unavailable":
+        verdict = WIP_UNAVAILABLE
+    else:
+        verdict = WIP_DEGRADED
+    return WipDecision(
+        verdict=verdict,
+        allow_generation=True,
+        open_pr_count=count,
+        ceiling=ceiling,
+        remaining=None,
+        source=source,
+    )

--- a/tests/swarm/test_wip_budget.py
+++ b/tests/swarm/test_wip_budget.py
@@ -1,0 +1,137 @@
+"""Tests for the count-based open-PR WIP cap (Loop Control Plane v2 companion).
+
+``wip_budget`` mirrors ``loop_budget`` (dollar ceilings) but governs a different
+decision: whether a generation lane should create *another* PR given how many it
+already has open. The fail-safe direction matches loop_budget's philosophy -- a
+fabricated/unknown count must NEVER classify ``over_cap`` and block a legitimate
+fleet; blocking on a number we cannot trust is exactly the fabricated-alarm class
+the control plane exists to avoid.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from aragora.swarm.wip_budget import (
+    WIP_DEGRADED,
+    WIP_OVER_CAP,
+    WIP_UNAVAILABLE,
+    WIP_WITHIN_CAP,
+    WipPolicy,
+    classify_wip,
+    resolve_wip_budget,
+)
+
+
+# --- policy load -----------------------------------------------------------
+
+
+def _write_policy(root: Path, payload: dict) -> None:
+    d = root / ".aragora"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "wip_budgets.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_policy_load_per_fleet_and_default(tmp_path):
+    _write_policy(tmp_path, {"default_cap": 40, "fleets": {"an0mium": {"cap": 20}}})
+    policy = WipPolicy.load(tmp_path)
+    assert policy.cap_for("an0mium")[0] == 20
+    assert policy.cap_for("other")[0] == 40  # falls to default
+
+
+def test_policy_load_missing_file_is_empty_not_raising(tmp_path):
+    policy = WipPolicy.load(tmp_path)  # no .aragora/wip_budgets.json
+    assert policy.cap_for("any") == (None, "none")
+
+
+def test_policy_load_unreadable_json_degrades_to_empty(tmp_path):
+    d = tmp_path / ".aragora"
+    d.mkdir()
+    (d / "wip_budgets.json").write_text("{not json", encoding="utf-8")
+    policy = WipPolicy.load(tmp_path)
+    assert policy.cap_for("any")[0] is None
+
+
+def test_policy_env_fleet_default_fallback(tmp_path, monkeypatch):
+    monkeypatch.setenv("ARAGORA_WIP_OPEN_PR_CAP", "15")
+    policy = WipPolicy.load(tmp_path)  # no policy file -> env default
+    cap, source = policy.cap_for("an0mium")
+    assert cap == 15
+    assert "ARAGORA_WIP_OPEN_PR_CAP" in source
+
+
+def test_policy_rejects_negative_and_nonint_caps(tmp_path):
+    _write_policy(tmp_path, {"default_cap": -5, "fleets": {"x": {"cap": 3.7}}})
+    policy = WipPolicy.load(tmp_path)
+    assert policy.cap_for("x")[0] is None  # 3.7 not an integer cap
+    assert policy.cap_for("y")[0] is None  # -5 rejected
+
+
+# --- resolve quadrants -----------------------------------------------------
+
+
+def test_resolve_ceiling_plus_count_is_ok(tmp_path):
+    _write_policy(tmp_path, {"fleets": {"an0mium": {"cap": 20}}})
+    wip = resolve_wip_budget(12, WipPolicy.load(tmp_path), "an0mium")
+    assert wip["source_status"] == "ok"
+    assert wip["ceiling"] == 20
+    assert wip["open_pr_count"] == 12
+    assert wip["remaining"] == 8
+
+
+def test_resolve_ceiling_unknown_count_is_degraded(tmp_path):
+    _write_policy(tmp_path, {"fleets": {"an0mium": {"cap": 20}}})
+    wip = resolve_wip_budget(None, WipPolicy.load(tmp_path), "an0mium")
+    assert wip["source_status"] == "degraded"
+    assert wip["ceiling"] == 20
+    assert wip["open_pr_count"] is None
+    assert wip["remaining"] is None
+
+
+def test_resolve_count_no_ceiling_is_degraded(tmp_path):
+    wip = resolve_wip_budget(50, WipPolicy.load(tmp_path), "an0mium")
+    assert wip["source_status"] == "degraded"
+    assert wip["ceiling"] is None
+    assert wip["open_pr_count"] == 50
+
+
+def test_resolve_neither_is_unavailable(tmp_path):
+    wip = resolve_wip_budget(None, WipPolicy.load(tmp_path), "an0mium")
+    assert wip["source_status"] == "unavailable"
+
+
+# --- classify_wip ----------------------------------------------------------
+
+
+def test_classify_within_cap_allows_generation(tmp_path):
+    _write_policy(tmp_path, {"fleets": {"f": {"cap": 20}}})
+    decision = classify_wip(resolve_wip_budget(12, WipPolicy.load(tmp_path), "f"))
+    assert decision.verdict == WIP_WITHIN_CAP
+    assert decision.allow_generation is True
+
+
+def test_classify_over_cap_blocks_generation_at_boundary(tmp_path):
+    _write_policy(tmp_path, {"fleets": {"f": {"cap": 20}}})
+    pol = WipPolicy.load(tmp_path)
+    at = classify_wip(resolve_wip_budget(20, pol, "f"))  # count == cap -> over
+    assert at.verdict == WIP_OVER_CAP
+    assert at.allow_generation is False
+    under = classify_wip(resolve_wip_budget(19, pol, "f"))  # cap-1 -> within
+    assert under.verdict == WIP_WITHIN_CAP
+    assert under.allow_generation is True
+
+
+def test_classify_unknown_count_fails_safe_never_over_cap(tmp_path):
+    # The fail-safe contract: a ceiling with an unknown count must DEGRADE and
+    # keep allowing generation, never fabricate an over_cap halt.
+    _write_policy(tmp_path, {"fleets": {"f": {"cap": 20}}})
+    decision = classify_wip(resolve_wip_budget(None, WipPolicy.load(tmp_path), "f"))
+    assert decision.verdict == WIP_DEGRADED
+    assert decision.allow_generation is True
+
+
+def test_classify_unavailable_allows_generation(tmp_path):
+    decision = classify_wip(resolve_wip_budget(None, WipPolicy.load(tmp_path), "f"))
+    assert decision.verdict == WIP_UNAVAILABLE
+    assert decision.allow_generation is True

--- a/tests/swarm/test_wip_budget.py
+++ b/tests/swarm/test_wip_budget.py
@@ -13,15 +13,26 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from aragora.swarm.wip_budget import (
     WIP_DEGRADED,
     WIP_OVER_CAP,
     WIP_UNAVAILABLE,
     WIP_WITHIN_CAP,
     WipPolicy,
+    _as_count,
     classify_wip,
     resolve_wip_budget,
 )
+
+
+@pytest.fixture(autouse=True)
+def _clear_wip_env(monkeypatch):
+    # The env fleet-default would flip the no-ceiling / no-count assertions
+    # (missing-file -> a cap; count-only -> ok). Mirror test_loop_budget's
+    # delenv discipline so these tests are environment-independent.
+    monkeypatch.delenv("ARAGORA_WIP_OPEN_PR_CAP", raising=False)
 
 
 # --- policy load -----------------------------------------------------------
@@ -135,3 +146,37 @@ def test_classify_unavailable_allows_generation(tmp_path):
     decision = classify_wip(resolve_wip_budget(None, WipPolicy.load(tmp_path), "f"))
     assert decision.verdict == WIP_UNAVAILABLE
     assert decision.allow_generation is True
+
+
+def test_classify_self_derives_and_ignores_misleading_status():
+    # A caller cannot bypass the fail-safe by mislabelling status="ok" with a
+    # missing count: classify derives the verdict from the data, not the label.
+    degraded = classify_wip({"source_status": "ok", "open_pr_count": None, "ceiling": 20})
+    assert degraded.verdict == WIP_DEGRADED
+    assert degraded.allow_generation is True
+    # ...and an honest ok dict still gates correctly.
+    over = classify_wip({"source_status": "ok", "open_pr_count": 25, "ceiling": 20})
+    assert over.verdict == WIP_OVER_CAP
+
+
+def test_cap_zero_freezes_generation(tmp_path):
+    # cap=0 is the deliberate "freeze" knob: 0 open PRs already >= 0 -> over_cap.
+    _write_policy(tmp_path, {"fleets": {"frozen": {"cap": 0}}})
+    decision = classify_wip(resolve_wip_budget(0, WipPolicy.load(tmp_path), "frozen"))
+    assert decision.verdict == WIP_OVER_CAP
+    assert decision.allow_generation is False
+
+
+def test_as_count_rejects_untrusted_values():
+    # Parity with loop_budget._as_float regression guards: anything that isn't a
+    # clean non-negative integer reads as "unknown" (None) and so fails safe.
+    assert _as_count(True) is None  # bool is not a count
+    assert _as_count(False) is None
+    assert _as_count(-3) is None
+    assert _as_count(3.7) is None  # non-integral float
+    assert _as_count(float("nan")) is None
+    assert _as_count(float("inf")) is None
+    assert _as_count("not-an-int") is None
+    assert _as_count(3.0) == 3  # integral float ok
+    assert _as_count("12") == 12
+    assert _as_count(0) == 0


### PR DESCRIPTION
## What

A **count-based open-PR WIP ceiling** — the missing queue-pressure control. The backlog doesn't drain because one fleet **out-generates the merge gate** (generation ≈ settlement). This adds the cap as a companion to `loop_budget.py`:

- `loop_budget.py` (existing) governs a *running* loop's **dollar spend**.
- `wip_budget.py` (new) governs whether a generation lane should create **another PR** given how many it already has open.

## Design (mirrors the proven dollar-budget pattern)

- `WipPolicy` — operator-owned per-fleet ceilings from `.aragora/wip_budgets.json` (+ `ARAGORA_WIP_OPEN_PR_CAP` fleet-default env fallback), loaded **fail-open** exactly like `BudgetPolicy`.
- `resolve_wip_budget` / `classify_wip` — pure, unit-tested decision. **Only a real ceiling + real count can produce `over_cap`** (`allow_generation=False`). An unknown/fabricated count **degrades and keeps allowing generation** — blocking a legitimate fleet on a number we can't trust is precisely the fabricated-alarm class the control plane exists to avoid (matches loop_budget's "never halt on stale spend").

## Scope / safety

**Provides the rails, not the retirement.** A generation lane adopts `classify_wip` at its create-PR decision point. `boss_loop.py` is a hot god-file (under #8257 P5) and a live-loop file, so it is **deliberately not edited here** — wiring is a documented follow-up seam. Net-new files only; no hot or merge-authority surfaces touched → Tier-2.

## Why this matters

Every fleet's own diagnosis converges here: settlement throughput is necessary but insufficient while generation refills the queue. This is the lever that lets the backlog actually trend down.

## Verification

13 unit tests (policy precedence + fail-open load, `_as_count` edge cases, all 4 resolve quadrants, classify within/over/degraded/unavailable + the fail-safe "unknown count never over_cap" contract), ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)