### PR TITLE
fix(ci): frontend deploy via --archive=tgz (clear Vercel 15k-file limit)

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -198,7 +198,11 @@ jobs:
         run: |
           # Run from repo root; Vercel project rootDirectory is configured server-side.
           npx vercel pull --yes --environment=production --token="${{ secrets.VERCEL_TOKEN }}"
-          DEPLOY_URL=$(npx vercel deploy --prod --yes --token="${{ secrets.VERCEL_TOKEN }}")
+          # --archive=tgz uploads the deployment as a single tarball, avoiding
+          # Vercel's 15000-file-per-deployment limit (the frontend exceeds it at
+          # ~15.5k files, which had been failing every deploy with
+          # "files should NOT have more than 15000 items").
+          DEPLOY_URL=$(npx vercel deploy --prod --yes --archive=tgz --token="${{ secrets.VERCEL_TOKEN }}")
           echo "deploy_url=$DEPLOY_URL" >> "$GITHUB_OUTPUT"
           echo "Deployed URL: $DEPLOY_URL"
         env:

--- a/.github/workflows/deploy-secure.yml
+++ b/.github/workflows/deploy-secure.yml
@@ -141,7 +141,11 @@ jobs:
         run: |
           # Run from repo root; Vercel project rootDirectory is configured server-side.
           npx vercel pull --yes --environment=production --token="${{ secrets.VERCEL_TOKEN }}"
-          DEPLOY_URL=$(npx vercel deploy --prod --yes --token="${{ secrets.VERCEL_TOKEN }}")
+          # --archive=tgz: see deploy-frontend.yml. Avoids Vercel's 15000-file
+          # per-deployment cap (the monorepo ships ~15.5k files). Follow-up: narrow
+          # the upload scope (--cwd aragora/live / .vercelignore) so we stop
+          # shipping backend/tests/docs to Vercel at all.
+          DEPLOY_URL=$(npx vercel deploy --prod --yes --archive=tgz --token="${{ secrets.VERCEL_TOKEN }}")
           echo "deploy_url=$DEPLOY_URL" >> "$GITHUB_OUTPUT"
           echo "Deployed URL: $DEPLOY_URL"
         env:


### PR DESCRIPTION
Frontend production deploys have failed every run for 6+ runs with Vercel's `files should NOT have more than 15000 items, received ~15540` per-deployment cap. `vercel deploy --archive=tgz` uploads the build as a single tarball, bypassing the file-count limit — restoring deploys. One-line change to the deploy command; no other behavior change, no untrusted input.