### PR TITLE
[DIC-28] crux-garden --write: persist gardening report to docs/status/generated/gardening_reports/

### DIFF
--- a/aragora/cli/commands/dic28_crux_garden.py
+++ b/aragora/cli/commands/dic28_crux_garden.py
@@ -25,6 +25,7 @@ from aragora.epistemic.gardening import GardeningConfig, GardeningReport, run_ga
 
 _FLAG = "ARAGORA_CRUX_GARDENING_ENABLED"
 _TRUTHY = frozenset({"1", "true", "yes", "on"})
+_DEFAULT_OUTPUT_DIR = "docs/status/generated/gardening_reports"
 
 
 def _flag_enabled() -> bool:
@@ -104,6 +105,18 @@ def _format_text(report: GardeningReport) -> str:
     return "\n".join(lines)
 
 
+def _write_report(report: GardeningReport, output_dir: Path) -> Path:
+    """Persist *report* as a timestamped JSON file under *output_dir*.
+
+    Creates the directory tree if absent.  Returns the path written.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    safe_ts = report.generated_at[:19].replace(":", "").replace("-", "").replace("T", "_")
+    dest = output_dir / f"gardening_report_{safe_ts}.json"
+    dest.write_text(report.to_json(), encoding="utf-8")
+    return dest
+
+
 def cmd_crux_garden(args: argparse.Namespace) -> int:
     if not _flag_enabled():
         print(f"error: {_FLAG} is not set; crux gardening is disabled", file=sys.stderr)
@@ -113,5 +126,13 @@ def cmd_crux_garden(args: argparse.Namespace) -> int:
         print(f"error: {result}", file=sys.stderr)
         return 1
     report = run_gardening_pass(result, [], config=GardeningConfig(enabled=True))
+
+    do_write: bool = getattr(args, "write", False)
+    if do_write:
+        raw_dir = getattr(args, "output_dir", None) or _DEFAULT_OUTPUT_DIR
+        dest = _write_report(report, Path(raw_dir).expanduser())
+        print(f"gardening report written: {dest}")
+        return 0
+
     print(report.to_json() if args.json else _format_text(report))
     return 0

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -878,6 +878,22 @@ def _add_crux_garden_parser(subparsers) -> None:
         help="Path to a JSONL or JSON-array file of CruxReceipt dicts.",
     )
     p.add_argument("--json", action="store_true", help="Emit report as JSON.")
+    p.add_argument(
+        "--write",
+        action="store_true",
+        default=False,
+        help="Persist the gardening report to --output-dir as a timestamped JSON file.",
+    )
+    p.add_argument(
+        "--output-dir",
+        default=None,
+        dest="output_dir",
+        help=(
+            "Directory for persisted reports "
+            "(default: docs/status/generated/gardening_reports). "
+            "Only used when --write is passed."
+        ),
+    )
     p.set_defaults(func=_lazy("aragora.cli.commands.dic28_crux_garden", "cmd_crux_garden"))
 
 

--- a/tests/cli/test_dic28_crux_garden.py
+++ b/tests/cli/test_dic28_crux_garden.py
@@ -64,9 +64,7 @@ def _ns(
     write: bool = False,
     output_dir: str | None = None,
 ) -> argparse.Namespace:
-    return argparse.Namespace(
-        input=input_path, json=json_out, write=write, output_dir=output_dir
-    )
+    return argparse.Namespace(input=input_path, json=json_out, write=write, output_dir=output_dir)
 
 
 # ---------------------------------------------------------------------------
@@ -224,9 +222,7 @@ def test_write_flag_creates_report_file(
     assert len(files) == 1
 
 
-def test_write_flag_report_json_is_valid(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_write_flag_report_json_is_valid(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv(_FLAG, "1")
     f = tmp_path / "r.json"
     f.write_text(json.dumps([_RECEIPT]))
@@ -254,9 +250,7 @@ def test_write_flag_creates_output_dir_if_absent(
     assert any(nested.glob("gardening_report_*.json"))
 
 
-def test_write_flag_off_leaves_no_file(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_write_flag_off_leaves_no_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv(_FLAG, "1")
     f = tmp_path / "r.json"
     f.write_text(json.dumps([_RECEIPT]))

--- a/tests/cli/test_dic28_crux_garden.py
+++ b/tests/cli/test_dic28_crux_garden.py
@@ -6,6 +6,18 @@ All receipt inputs are synthetic dicts.
 
 from __future__ import annotations
 
+import sys
+import types
+
+# yaml stub — pyyaml is absent in the hermetic uv-tool pytest venv used for
+# vision-layer CI.  Provides the subset of yaml needed by transitive imports
+# from aragora.epistemic (only yaml.safe_load is called at import time).
+if "yaml" not in sys.modules:
+    _yaml_stub = types.ModuleType("yaml")
+    _yaml_stub.safe_load = lambda stream: {}  # type: ignore[attr-defined]
+    _yaml_stub.dump = lambda data, **kw: ""  # type: ignore[attr-defined]
+    sys.modules["yaml"] = _yaml_stub
+
 import argparse
 import json
 from pathlib import Path
@@ -45,8 +57,16 @@ _RECEIPT: dict = {
 }
 
 
-def _ns(*, input_path: str, json_out: bool = False) -> argparse.Namespace:
-    return argparse.Namespace(input=input_path, json=json_out)
+def _ns(
+    *,
+    input_path: str,
+    json_out: bool = False,
+    write: bool = False,
+    output_dir: str | None = None,
+) -> argparse.Namespace:
+    return argparse.Namespace(
+        input=input_path, json=json_out, write=write, output_dir=output_dir
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -184,3 +204,63 @@ def test_jsonl_non_object_line_exits_1(
     f.write_text("1\n")
     assert cmd_crux_garden(_ns(input_path=str(f))) == 1
     assert "line 1" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# --write flag: persist report to output directory
+# ---------------------------------------------------------------------------
+
+
+def test_write_flag_creates_report_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    f = tmp_path / "r.json"
+    f.write_text(json.dumps([_RECEIPT]))
+    out_dir = tmp_path / "reports"
+    rc = cmd_crux_garden(_ns(input_path=str(f), write=True, output_dir=str(out_dir)))
+    assert rc == 0
+    files = list(out_dir.glob("gardening_report_*.json"))
+    assert len(files) == 1
+
+
+def test_write_flag_report_json_is_valid(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    f = tmp_path / "r.json"
+    f.write_text(json.dumps([_RECEIPT]))
+    out_dir = tmp_path / "reports"
+    cmd_crux_garden(_ns(input_path=str(f), write=True, output_dir=str(out_dir)))
+    files = list(out_dir.glob("gardening_report_*.json"))
+    data = json.loads(files[0].read_text(encoding="utf-8"))
+    assert "generated_at" in data
+    assert "resolved_results" in data
+    assert "outstanding_results" in data
+    assert "schema_version" in data
+
+
+def test_write_flag_creates_output_dir_if_absent(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    f = tmp_path / "r.json"
+    f.write_text(json.dumps([_RECEIPT]))
+    nested = tmp_path / "a" / "b" / "c"
+    assert not nested.exists()
+    rc = cmd_crux_garden(_ns(input_path=str(f), write=True, output_dir=str(nested)))
+    assert rc == 0
+    assert nested.exists()
+    assert any(nested.glob("gardening_report_*.json"))
+
+
+def test_write_flag_off_leaves_no_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    f = tmp_path / "r.json"
+    f.write_text(json.dumps([_RECEIPT]))
+    out_dir = tmp_path / "reports"
+    rc = cmd_crux_garden(_ns(input_path=str(f), write=False, output_dir=str(out_dir)))
+    assert rc == 0
+    assert not out_dir.exists()


### PR DESCRIPTION
## Slice

Adds `--write` and `--output-dir` flags to the `aragora crux-garden` CLI so the `GardeningReport` is persisted as a timestamped JSON file under `docs/status/generated/gardening_reports/` (or a caller-supplied directory), satisfying the acceptance criterion in issue #6222 that was unmet by the stdout-only implementation. Mirrors the DIC-26 `--write` slice pattern (DIC-26 PR #8288 explicitly deferred DIC-28 persistence as a separate slice in its "Out of scope" section).

## Gating

- Default: **OFF** (flag: `ARAGORA_CRUX_GARDENING_ENABLED=1` required; `--write` must be passed explicitly)
- Live queue effect: **none** — purely additive file-write on the read-only report path; no debates started, no queue writes
- Advances issue: #6222 (DIC-28 Proactive Crux Gardening)

## Tests

New in `tests/cli/test_dic28_crux_garden.py` (4 new; 14 pre-existing = **18 passed** total):

| Test | What it verifies |
|---|---|
| `test_write_flag_creates_report_file` | `--write` produces exactly one `gardening_report_*.json` in the output dir |
| `test_write_flag_report_json_is_valid` | written file is valid JSON with `generated_at`, `resolved_results`, `outstanding_results`, `schema_version` |
| `test_write_flag_creates_output_dir_if_absent` | `--write` creates the full directory tree when absent (3-level nested path) |
| `test_write_flag_off_leaves_no_file` | without `--write`, no report file is created; output dir untouched |

Also adds a `yaml` stub at the top of the test file (same pattern as DIC-21/23/25) so tests run cleanly in the hermetic uv-tool pytest venv where pyyaml is absent.

## Validation

- `pytest tests/cli/test_dic28_crux_garden.py --noconftest` — **18 passed** in 0.16 s
- `ruff check aragora/cli/commands/dic28_crux_garden.py tests/cli/test_dic28_crux_garden.py` — **clean**
- `mypy aragora/cli/commands/dic28_crux_garden.py --ignore-missing-imports` — **Success: no issues found**
- Net diff: **119 LOC** across 3 files (21 command, 16 parser, 82 test)

## Out of scope

- Writing to the default `docs/status/generated/gardening_reports/` path on CI (operator trigger decision, not a code gate)
- DIC-17 follow-up bridge wiring from the `--write` output path (tracked separately)
- Automated scheduling of periodic gardening runs (DIC-28 scheduling concern, separate slice)
- DIC-25 fragility-delta integration into gardening results (the `GardeningConfig.fragility_shift_threshold` hook exists; wiring it to a live DIC-25 catalog requires the Foreman gate to open)

## Gate status

Per `docs/status/NEXT_STEPS_CANONICAL.md`, `DIC-13..22` (and by extension DIC-23..28) are in the **Delay** track. The proof-first Foreman gate has **not** opened. This PR is planning truth and flag-gated operator tooling only; no `boss-ready` label applied. Kept as draft.

---
_Generated by [Claude Code](https://claude.ai/code/session_017c3yxV3z2oDgfrV2mXhxae)_