### PR TITLE
feat(connectors): lazy __getattr__ imports so base install runs aragora ask

### DIFF
--- a/aragora/_lazy_imports.py
+++ b/aragora/_lazy_imports.py
@@ -1,0 +1,47 @@
+"""Lazy module import helpers for the CLI.
+
+The CLI parser eagerly imports every command module so it can register the
+full set of subparsers. Some command modules only need an optional
+third-party dependency (e.g. ``httpx``) at *runtime* — when the command is
+actually executed against a server — not at import time.
+
+``lazy_module`` returns a tiny proxy that defers the real import until the
+first attribute access. This keeps the parser (and therefore the headline
+``aragora ask`` command) importable on a base install that does not have the
+optional dependency installed, while leaving every ``module.attr`` call site
+unchanged. If the dependency really is missing, the original
+``ModuleNotFoundError`` is raised on first use, pointing the user at the
+extra they need to install.
+"""
+
+from __future__ import annotations
+
+import importlib
+from types import ModuleType
+from typing import Any
+
+
+class _LazyModule:
+    """Proxy that imports the backing module on first attribute access."""
+
+    __slots__ = ("_lazy_name", "_lazy_mod")
+
+    def __init__(self, name: str) -> None:
+        object.__setattr__(self, "_lazy_name", name)
+        object.__setattr__(self, "_lazy_mod", None)
+
+    def _load(self) -> ModuleType:
+        mod = object.__getattribute__(self, "_lazy_mod")
+        if mod is None:
+            name = object.__getattribute__(self, "_lazy_name")
+            mod = importlib.import_module(name)
+            object.__setattr__(self, "_lazy_mod", mod)
+        return mod
+
+    def __getattr__(self, attr: str) -> Any:
+        return getattr(self._load(), attr)
+
+
+def lazy_module(name: str) -> Any:
+    """Return a lazy proxy for the importable module ``name``."""
+    return _LazyModule(name)

--- a/aragora/cli/batch.py
+++ b/aragora/cli/batch.py
@@ -16,10 +16,6 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-import httpx
-
-from aragora.security.safe_http import safe_get, safe_post
-
 if TYPE_CHECKING:
     from aragora.core import DebateResult
 
@@ -156,6 +152,13 @@ def _read_input_file(input_path: Path) -> list[dict[str, Any]]:
 
 def _batch_via_server(items: list[dict[str, Any]], args: argparse.Namespace) -> None:
     """Submit batch to server API."""
+    # Deferred imports: httpx (and the safe_http wrapper) are optional runtime
+    # deps. Importing them lazily keeps the batch subparser registrable on a
+    # base install that lacks httpx.
+    import httpx
+
+    from aragora.security.safe_http import safe_post
+
     server_url = args.url.rstrip("/")
 
     print(f"\nSubmitting to {server_url}/api/debates/batch...")
@@ -205,6 +208,8 @@ def _batch_via_server(items: list[dict[str, Any]], args: argparse.Namespace) -> 
 
 def _poll_batch_status(server_url: str, batch_id: str, token: str | None = None) -> None:
     """Poll batch status until completion."""
+    from aragora.security.safe_http import safe_get
+
     poll_interval = 5  # seconds
     max_polls = 360  # 30 minutes max
 

--- a/aragora/cli/commands/billing_ops.py
+++ b/aragora/cli/commands/billing_ops.py
@@ -15,9 +15,17 @@ import asyncio
 import json
 import logging
 from datetime import datetime, timedelta, timezone
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-import httpx
+from aragora._lazy_imports import lazy_module
+
+# Optional runtime dep: imported lazily so the parser can register this
+# command on a base install that lacks httpx (httpx is only needed when a
+# command actually issues an HTTP request).
+if TYPE_CHECKING:  # pragma: no cover - import only for type checkers
+    import httpx
+else:
+    httpx = lazy_module("httpx")
 
 from aragora.config.settings import get_settings
 

--- a/aragora/cli/commands/computer_use.py
+++ b/aragora/cli/commands/computer_use.py
@@ -14,9 +14,17 @@ import argparse
 import asyncio
 import json
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-import httpx
+from aragora._lazy_imports import lazy_module
+
+# Optional runtime dep: imported lazily so the parser can register this
+# command on a base install that lacks httpx (httpx is only needed when a
+# command actually issues an HTTP request).
+if TYPE_CHECKING:  # pragma: no cover - import only for type checkers
+    import httpx
+else:
+    httpx = lazy_module("httpx")
 
 from aragora.config.settings import get_settings
 

--- a/aragora/cli/commands/connectors.py
+++ b/aragora/cli/commands/connectors.py
@@ -14,9 +14,17 @@ import argparse
 import asyncio
 import json
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-import httpx
+from aragora._lazy_imports import lazy_module
+
+# Optional runtime dep: imported lazily so the parser can register this
+# command on a base install that lacks httpx (httpx is only needed when a
+# command actually issues an HTTP request).
+if TYPE_CHECKING:  # pragma: no cover - import only for type checkers
+    import httpx
+else:
+    httpx = lazy_module("httpx")
 
 from aragora.config.settings import get_settings
 

--- a/aragora/cli/commands/delegated.py
+++ b/aragora/cli/commands/delegated.py
@@ -8,10 +8,18 @@ can be imported from a single location.
 
 import argparse
 import os
+from typing import TYPE_CHECKING
 
-import httpx
+from aragora._lazy_imports import lazy_module
 
-from aragora.security.safe_http import safe_get
+# Optional runtime dep: imported lazily so the parser can register this
+# command on a base install that lacks httpx (httpx — and the safe_http
+# wrapper that imports it — are only needed when a command actually issues
+# an HTTP request to a running server).
+if TYPE_CHECKING:  # pragma: no cover - import only for type checkers
+    import httpx
+else:
+    httpx = lazy_module("httpx")
 
 # Default API URL from environment or localhost fallback
 DEFAULT_API_URL = os.environ.get("ARAGORA_API_URL", "http://localhost:8080")
@@ -26,6 +34,8 @@ def cmd_agents(args: argparse.Namespace) -> None:
 
 def cmd_control_plane(args: argparse.Namespace) -> None:
     """Handle 'control-plane' command - show control plane status and management."""
+    from aragora.security.safe_http import safe_get
+
     server_url = getattr(args, "server", DEFAULT_API_URL)
     subcommand = getattr(args, "subcommand", "status")
 

--- a/aragora/cli/commands/knowledge.py
+++ b/aragora/cli/commands/knowledge.py
@@ -14,9 +14,17 @@ import argparse
 import asyncio
 import json
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-import httpx
+from aragora._lazy_imports import lazy_module
+
+# Optional runtime dep: imported lazily so the parser can register this
+# command on a base install that lacks httpx (httpx is only needed when a
+# command actually issues an HTTP request).
+if TYPE_CHECKING:  # pragma: no cover - import only for type checkers
+    import httpx
+else:
+    httpx = lazy_module("httpx")
 
 from aragora.config.settings import get_settings
 

--- a/aragora/cli/commands/memory_ops.py
+++ b/aragora/cli/commands/memory_ops.py
@@ -15,9 +15,17 @@ import argparse
 import asyncio
 import json
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-import httpx
+from aragora._lazy_imports import lazy_module
+
+# Optional runtime dep: imported lazily so the parser can register this
+# command on a base install that lacks httpx (httpx is only needed when a
+# command actually issues an HTTP request).
+if TYPE_CHECKING:  # pragma: no cover - import only for type checkers
+    import httpx
+else:
+    httpx = lazy_module("httpx")
 
 from aragora.config.settings import get_settings
 

--- a/aragora/cli/commands/skills.py
+++ b/aragora/cli/commands/skills.py
@@ -18,9 +18,17 @@ import asyncio
 import json
 import logging
 import os
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-import httpx
+from aragora._lazy_imports import lazy_module
+
+# Optional runtime dep: imported lazily so the parser can register this
+# command on a base install that lacks httpx (httpx is only needed when a
+# command actually issues an HTTP request).
+if TYPE_CHECKING:  # pragma: no cover - import only for type checkers
+    import httpx
+else:
+    httpx = lazy_module("httpx")
 
 logger = logging.getLogger(__name__)
 

--- a/aragora/cli/config.py
+++ b/aragora/cli/config.py
@@ -10,8 +10,6 @@ import os
 from pathlib import Path
 from typing import Any
 
-import yaml
-
 CONFIG_FILE = ".aragora.yaml"
 ENV_KEYS = [
     "ANTHROPIC_API_KEY",
@@ -36,6 +34,8 @@ def find_config() -> Path | None:
 
 def load_config(config_path: Path | None = None) -> dict:
     """Load configuration from file."""
+    import yaml  # optional dep (PyYAML); deferred so the parser imports clean
+
     if config_path is None:
         config_path = find_config()
 
@@ -52,6 +52,8 @@ def load_config(config_path: Path | None = None) -> dict:
 
 def save_config(config: dict, config_path: Path | None = None) -> bool:
     """Save configuration to file."""
+    import yaml  # optional dep (PyYAML); deferred so the parser imports clean
+
     if config_path is None:
         config_path = find_config()
 
@@ -110,6 +112,8 @@ def cmd_config(args) -> None:
 
 def _show_config(args) -> None:
     """Show all configuration."""
+    import yaml  # optional dep (PyYAML); deferred so the parser imports clean
+
     config_path = find_config()
 
     if config_path is None:

--- a/aragora/cli/documents.py
+++ b/aragora/cli/documents.py
@@ -16,8 +16,6 @@ import json
 from pathlib import Path
 from typing import Any
 
-import yaml
-
 
 def create_documents_parser(subparsers: Any) -> None:
     """Create the documents subcommand parser."""
@@ -159,6 +157,8 @@ def cmd_upload(args: argparse.Namespace) -> int:
 
 async def _upload_async(args: argparse.Namespace) -> int:
     """Async upload implementation."""
+    import yaml  # optional dep (PyYAML); deferred so the parser imports clean
+
     from aragora.documents.folder import (
         FolderScanner,
         FolderUploadConfig,

--- a/aragora/cli/tenant.py
+++ b/aragora/cli/tenant.py
@@ -24,10 +24,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-import httpx
-
-from aragora.security.safe_http import safe_request
-
 DEFAULT_API_URL = os.environ.get("ARAGORA_API_URL", "http://localhost:8080")
 
 
@@ -43,6 +39,14 @@ def api_request(
     server_url: str = DEFAULT_API_URL,
 ) -> dict[str, Any]:
     """Make authenticated API request."""
+    # Deferred imports: httpx (and the safe_http wrapper that imports it) are
+    # optional runtime deps. Importing them lazily keeps the tenant subparser
+    # registrable on a base install that lacks httpx — only actually issuing a
+    # request requires it.
+    import httpx
+
+    from aragora.security.safe_http import safe_request
+
     url = f"{server_url.rstrip('/')}{path}"
     token = get_api_token()
 

--- a/aragora/connectors/__init__.py
+++ b/aragora/connectors/__init__.py
@@ -19,145 +19,196 @@ with the provenance system for traceability:
 
 All connectors record evidence through ProvenanceManager
 with proper source typing and confidence scoring.
+
+Imports are lazy (PEP 562 ``__getattr__``): importing
+``aragora.connectors`` (or any lightweight submodule such as
+``aragora.connectors.base``) does NOT eagerly pull in every connector's
+optional third-party dependencies. A name is only resolved — and its
+backing submodule imported — on first attribute access. This keeps the
+base install able to run the debate engine (which only needs
+``Evidence`` / ``BaseConnector``) without requiring optional deps like
+``defusedxml`` (arxiv), ``feedparser``, database drivers, etc.
 """
 
-from aragora.connectors.arxiv import ARXIV_CATEGORIES, ArXivConnector
-from aragora.connectors.base import BaseConnector, Evidence
-from aragora.connectors.whisper import (
-    WhisperConnector,
-    TranscriptionResult,
-    TranscriptionSegment,
-    is_supported_audio,
-    is_supported_video,
-    is_supported_media,
-    get_supported_formats as get_whisper_formats,
-)
-from aragora.connectors.exceptions import (
-    ConnectorAPIError,
-    ConnectorAuthError,
-    ConnectorError,
-    ConnectorNetworkError,
-    ConnectorNotFoundError,
-    ConnectorParseError,
-    ConnectorQuotaError,
-    ConnectorRateLimitError,
-    ConnectorTimeoutError,
-    ConnectorValidationError,
-    classify_exception,
-    connector_error_handler,
-    get_retry_delay,
-    is_retryable_error,
-)
-from aragora.connectors.recovery import (
-    RecoveryAction,
-    RecoveryConfig,
-    RecoveryStrategy,
-    create_recovery_chain,
-    with_recovery,
-)
-from aragora.connectors.credentials import (
-    AWSSecretsManagerProvider,
-    CachedCredentialProvider,
-    ChainedCredentialProvider,
-    CredentialProvider,
-    EnvCredentialProvider,
-    get_credential_provider,
-)
-from aragora.connectors.github import GitHubConnector
-from aragora.connectors.hackernews import HackerNewsConnector
-from aragora.connectors.local_docs import LocalDocsConnector
-from aragora.connectors.newsapi import (
-    HIGH_CREDIBILITY_SOURCES,
-    MEDIUM_CREDIBILITY_SOURCES,
-    NewsAPIConnector,
-)
-from aragora.connectors.courtlistener import CourtListenerConnector
-from aragora.connectors.govinfo import GovInfoConnector
-from aragora.connectors.nice_guidance import NICEGuidanceConnector
-from aragora.connectors.pubmed import PubMedConnector
-from aragora.connectors.semantic_scholar import SemanticScholarConnector
-from aragora.connectors.crossref import CrossRefConnector
-from aragora.connectors.clinical_tables import ClinicalTablesConnector
-from aragora.connectors.rxnav import RxNavConnector
-from aragora.connectors.reddit import RedditConnector
-from aragora.connectors.sec import FORM_TYPES, SECConnector
-from aragora.connectors.sql import SQLConnector, SQLQueryResult
-from aragora.connectors.twitter import TwitterConnector
-from aragora.connectors.web import WebConnector
-from aragora.connectors.wikipedia import WikipediaConnector
-from aragora.connectors.repository_crawler import (
-    RepositoryCrawler,
-    CrawlConfig,
-    CrawlResult,
-    CrawlState,
-    CrawledFile,
-    FileSymbol,
-    FileDependency,
-    FileType,
-    crawl_repository,
-)
+from __future__ import annotations
 
-# Legal connectors
-from aragora.connectors.legal import (
-    DocuSignConnector,
-    DocuSignCredentials,
-    DocuSignEnvironment,
-    Envelope,
-    EnvelopeCreateRequest,
-    EnvelopeStatus,
-    Recipient,
-    RecipientType,
-    Document,
-    SignatureTab,
-    WestlawConnector,
-    LexisConnector,
-)
-from aragora.connectors.accounting.gaap import FASBConnector
-from aragora.connectors.accounting.irs import IRSConnector
-from aragora.connectors.tax import GenericTaxConnector, TaxConnectorRegistry, resolve_tax_connector
+import importlib
+from typing import Any
 
-# DevOps connectors
-from aragora.connectors.devops import (
-    PagerDutyConnector,
-    PagerDutyCredentials,
-    PagerDutyError,
-    Incident,
-    IncidentCreateRequest,
-    IncidentNote,
-    IncidentPriority,
-    IncidentStatus,
-    IncidentUrgency,
-    OnCallSchedule,
-    Service,
-    ServiceStatus,
-    User,
-    WebhookPayload,
-)
+# Map every public name to the connectors submodule that defines it.
+# Submodules that live in subpackages use dotted suffixes
+# (e.g. "accounting.gaap" -> aragora.connectors.accounting.gaap).
+_NAME_TO_MODULE: dict[str, str] = {
+    # arxiv
+    "ARXIV_CATEGORIES": "arxiv",
+    "ArXivConnector": "arxiv",
+    # base
+    "BaseConnector": "base",
+    "Evidence": "base",
+    # whisper
+    "WhisperConnector": "whisper",
+    "TranscriptionResult": "whisper",
+    "TranscriptionSegment": "whisper",
+    "is_supported_audio": "whisper",
+    "is_supported_video": "whisper",
+    "is_supported_media": "whisper",
+    "get_whisper_formats": "whisper",  # exported as get_supported_formats in submodule
+    # exceptions
+    "ConnectorAPIError": "exceptions",
+    "ConnectorAuthError": "exceptions",
+    "ConnectorError": "exceptions",
+    "ConnectorNetworkError": "exceptions",
+    "ConnectorNotFoundError": "exceptions",
+    "ConnectorParseError": "exceptions",
+    "ConnectorQuotaError": "exceptions",
+    "ConnectorRateLimitError": "exceptions",
+    "ConnectorTimeoutError": "exceptions",
+    "ConnectorValidationError": "exceptions",
+    "classify_exception": "exceptions",
+    "connector_error_handler": "exceptions",
+    "get_retry_delay": "exceptions",
+    "is_retryable_error": "exceptions",
+    # recovery
+    "RecoveryAction": "recovery",
+    "RecoveryConfig": "recovery",
+    "RecoveryStrategy": "recovery",
+    "create_recovery_chain": "recovery",
+    "with_recovery": "recovery",
+    # credentials
+    "AWSSecretsManagerProvider": "credentials",
+    "CachedCredentialProvider": "credentials",
+    "ChainedCredentialProvider": "credentials",
+    "CredentialProvider": "credentials",
+    "EnvCredentialProvider": "credentials",
+    "get_credential_provider": "credentials",
+    # github
+    "GitHubConnector": "github",
+    # hackernews
+    "HackerNewsConnector": "hackernews",
+    # local_docs
+    "LocalDocsConnector": "local_docs",
+    # newsapi
+    "HIGH_CREDIBILITY_SOURCES": "newsapi",
+    "MEDIUM_CREDIBILITY_SOURCES": "newsapi",
+    "NewsAPIConnector": "newsapi",
+    # courtlistener
+    "CourtListenerConnector": "courtlistener",
+    # govinfo
+    "GovInfoConnector": "govinfo",
+    # nice_guidance
+    "NICEGuidanceConnector": "nice_guidance",
+    # pubmed
+    "PubMedConnector": "pubmed",
+    # semantic_scholar
+    "SemanticScholarConnector": "semantic_scholar",
+    # crossref
+    "CrossRefConnector": "crossref",
+    # clinical_tables
+    "ClinicalTablesConnector": "clinical_tables",
+    # rxnav
+    "RxNavConnector": "rxnav",
+    # reddit
+    "RedditConnector": "reddit",
+    # sec
+    "FORM_TYPES": "sec",
+    "SECConnector": "sec",
+    # sql
+    "SQLConnector": "sql",
+    "SQLQueryResult": "sql",
+    # twitter
+    "TwitterConnector": "twitter",
+    # web
+    "WebConnector": "web",
+    # wikipedia
+    "WikipediaConnector": "wikipedia",
+    # repository_crawler
+    "RepositoryCrawler": "repository_crawler",
+    "CrawlConfig": "repository_crawler",
+    "CrawlResult": "repository_crawler",
+    "CrawlState": "repository_crawler",
+    "CrawledFile": "repository_crawler",
+    "FileSymbol": "repository_crawler",
+    "FileDependency": "repository_crawler",
+    "FileType": "repository_crawler",
+    "crawl_repository": "repository_crawler",
+    # legal
+    "DocuSignConnector": "legal",
+    "DocuSignCredentials": "legal",
+    "DocuSignEnvironment": "legal",
+    "Envelope": "legal",
+    "EnvelopeCreateRequest": "legal",
+    "EnvelopeStatus": "legal",
+    "Recipient": "legal",
+    "RecipientType": "legal",
+    "Document": "legal",
+    "SignatureTab": "legal",
+    "WestlawConnector": "legal",
+    "LexisConnector": "legal",
+    # accounting
+    "FASBConnector": "accounting.gaap",
+    "IRSConnector": "accounting.irs",
+    # tax
+    "GenericTaxConnector": "tax",
+    "TaxConnectorRegistry": "tax",
+    "resolve_tax_connector": "tax",
+    # devops
+    "PagerDutyConnector": "devops",
+    "PagerDutyCredentials": "devops",
+    "PagerDutyError": "devops",
+    "Incident": "devops",
+    "IncidentCreateRequest": "devops",
+    "IncidentNote": "devops",
+    "IncidentPriority": "devops",
+    "IncidentStatus": "devops",
+    "IncidentUrgency": "devops",
+    "OnCallSchedule": "devops",
+    "Service": "devops",
+    "ServiceStatus": "devops",
+    "User": "devops",
+    "WebhookPayload": "devops",
+    # blockchain
+    "ERC8004Connector": "blockchain",
+    "BlockchainCredentials": "blockchain",
+    "BlockchainEvidence": "blockchain",
+    "BlockchainSearchResult": "blockchain",
+    # knowledge
+    "ObsidianConnector": "knowledge",
+    "ObsidianConfig": "knowledge",
+    "ObsidianNote": "knowledge",
+    "NoteType": "knowledge",
+    "create_obsidian_connector": "knowledge",
+    # memory
+    "ClaudeMemConnector": "memory",
+    "ClaudeMemConfig": "memory",
+    # conversation_ingestor
+    "ConversationIngestorConnector": "conversation_ingestor",
+    "Conversation": "conversation_ingestor",
+    "ConversationMessage": "conversation_ingestor",
+    "ConversationExport": "conversation_ingestor",
+    "ClaimExtraction": "conversation_ingestor",
+}
 
-# Blockchain connectors (ERC-8004)
-from aragora.connectors.blockchain import (
-    ERC8004Connector,
-    BlockchainCredentials,
-    BlockchainEvidence,
-    BlockchainSearchResult,
-)
+# A few names are re-exported under a different alias than the attribute
+# defined in the backing submodule. Map public name -> source attribute.
+_NAME_ALIASES: dict[str, str] = {
+    "get_whisper_formats": "get_supported_formats",
+}
 
-# Knowledge connectors
-from aragora.connectors.knowledge import (
-    ObsidianConnector,
-    ObsidianConfig,
-    ObsidianNote,
-    NoteType,
-    create_obsidian_connector,
-)
-from aragora.connectors.memory import ClaudeMemConnector, ClaudeMemConfig
-from aragora.connectors.conversation_ingestor import (
-    ConversationIngestorConnector,
-    Conversation,
-    ConversationMessage,
-    ConversationExport,
-    ClaimExtraction,
-)
+
+def __getattr__(name: str) -> Any:
+    mod = _NAME_TO_MODULE.get(name)
+    if mod is None:
+        raise AttributeError(f"module 'aragora.connectors' has no attribute {name!r}")
+    submod = importlib.import_module(f"aragora.connectors.{mod}")
+    source_attr = _NAME_ALIASES.get(name, name)
+    value = getattr(submod, source_attr)
+    globals()[name] = value  # cache so repeat access is fast and stable
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)
+
 
 __all__ = [
     # Base classes

--- a/aragora/core/embeddings/backends/gemini.py
+++ b/aragora/core/embeddings/backends/gemini.py
@@ -2,7 +2,12 @@
 
 import asyncio
 import logging
-import aiohttp
+from aragora._lazy_imports import lazy_module
+
+# Optional runtime dep: imported lazily so the embeddings package can be
+# imported on a base install that lacks aiohttp. aiohttp is only needed when
+# this backend actually issues an HTTP request to the embedding provider.
+aiohttp = lazy_module("aiohttp")
 
 from aragora.config.secrets import get_secret
 from aragora.core.embeddings.backends import EmbeddingBackend

--- a/aragora/core/embeddings/backends/ollama.py
+++ b/aragora/core/embeddings/backends/ollama.py
@@ -5,7 +5,12 @@ import logging
 import os
 import socket
 
-import aiohttp
+from aragora._lazy_imports import lazy_module
+
+# Optional runtime dep: imported lazily so the embeddings package can be
+# imported on a base install that lacks aiohttp. aiohttp is only needed when
+# this backend actually issues an HTTP request to the embedding provider.
+aiohttp = lazy_module("aiohttp")
 
 from aragora.core.embeddings.backends import EmbeddingBackend
 from aragora.core.embeddings.types import (

--- a/aragora/core/embeddings/backends/openai.py
+++ b/aragora/core/embeddings/backends/openai.py
@@ -2,7 +2,12 @@
 
 import asyncio
 import logging
-import aiohttp
+from aragora._lazy_imports import lazy_module
+
+# Optional runtime dep: imported lazily so the embeddings package can be
+# imported on a base install that lacks aiohttp. aiohttp is only needed when
+# this backend actually issues an HTTP request to the embedding provider.
+aiohttp = lazy_module("aiohttp")
 
 from aragora.config.secrets import get_secret
 from aragora.core.embeddings.backends import EmbeddingBackend

--- a/aragora/knowledge/mound/api/query.py
+++ b/aragora/knowledge/mound/api/query.py
@@ -17,7 +17,6 @@ comments suppress mypy warnings that are expected for this mixin pattern.
 
 from __future__ import annotations
 
-import aiohttp
 import asyncio
 import logging
 import time
@@ -25,6 +24,26 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Protocol
 from collections.abc import Sequence
+
+
+def _aiohttp_client_error() -> type[BaseException]:
+    """Return ``aiohttp.ClientError`` if aiohttp is installed, else a sentinel.
+
+    aiohttp is an optional dependency used only to widen a fallback ``except``
+    clause. Resolving it lazily lets the debate engine import this module on a
+    base install that lacks aiohttp; when aiohttp is absent the returned
+    sentinel class is never raised, so the surrounding ``except`` is a no-op
+    for it.
+    """
+    try:
+        import aiohttp
+    except ImportError:
+
+        class _MissingAiohttpClientError(Exception):
+            pass
+
+        return _MissingAiohttpClientError
+    return aiohttp.ClientError
 
 
 # Distributed tracing support
@@ -53,7 +72,7 @@ def _mock_trace_context(
 # Pre-declare trace_context for optional import
 trace_context: Any = _mock_trace_context
 try:
-    from aragora.server.middleware.tracing import trace_context
+    from aragora.server.middleware.tracing import trace_context  # type: ignore[no-redef]
 
     TRACING_AVAILABLE = True
 except ImportError:
@@ -469,10 +488,10 @@ class QueryOperationsMixin(_QueryMixinBase):
 
         # Query the meta store for recent nodes
         if hasattr(self._meta_store, "get_recent_nodes_async"):
-            return await self._meta_store.get_recent_nodes_async(ws_id, limit)
+            return await self._meta_store.get_recent_nodes_async(ws_id, limit)  # type: ignore[union-attr]
         else:
             # SQLite fallback - query nodes ordered by updated_at
-            nodes = self._meta_store.query_nodes(
+            nodes = self._meta_store.query_nodes(  # type: ignore[union-attr]
                 workspace_id=ws_id,
                 limit=limit,
             )
@@ -527,7 +546,7 @@ class QueryOperationsMixin(_QueryMixinBase):
                     if node:
                         items.append(node)
                 return items
-            except (RuntimeError, ValueError, OSError, aiohttp.ClientError) as e:
+            except (RuntimeError, ValueError, OSError, _aiohttp_client_error()) as e:
                 logger.debug("Semantic store search failed (falling back to keyword): %s", e)
 
         if not allow_fallback:
@@ -609,7 +628,7 @@ class QueryOperationsMixin(_QueryMixinBase):
                     return None
                 source = getattr(item, "source", None) or getattr(item, "source_type", None)
                 source_str = (
-                    source.value
+                    source.value  # type: ignore[union-attr]
                     if hasattr(source, "value")
                     else str(source)
                     if source
@@ -792,7 +811,7 @@ class QueryOperationsMixin(_QueryMixinBase):
                     node_ids.add(node.id)
                     source = getattr(node, "source", None) or getattr(node, "source_type", None)
                     source_str = (
-                        source.value
+                        source.value  # type: ignore[union-attr]
                         if hasattr(source, "value")
                         else str(source)
                         if source
@@ -814,7 +833,7 @@ class QueryOperationsMixin(_QueryMixinBase):
                     edge, "relationship_type", None
                 )
                 rel_type_str = (
-                    rel_type.value
+                    rel_type.value  # type: ignore[union-attr]
                     if hasattr(rel_type, "value")
                     else str(rel_type)
                     if rel_type
@@ -837,7 +856,7 @@ class QueryOperationsMixin(_QueryMixinBase):
                 node_ids.add(item.id)
                 source = getattr(item, "source", None) or getattr(item, "source_type", None)
                 source_str = (
-                    source.value
+                    source.value  # type: ignore[union-attr]
                     if hasattr(source, "value")
                     else str(source)
                     if source
@@ -868,7 +887,7 @@ class QueryOperationsMixin(_QueryMixinBase):
                             rel, "relationship_type", None
                         )
                         rel_type_str = (
-                            rel_type.value
+                            rel_type.value  # type: ignore[union-attr]
                             if hasattr(rel_type, "value")
                             else str(rel_type)
                             if rel_type
@@ -1137,8 +1156,8 @@ class QueryOperationsMixin(_QueryMixinBase):
 
         # If the postgres store has the method, use it
         if hasattr(self._meta_store, "get_grants_for_grantee_async"):
-            grants = await self._meta_store.get_grants_for_grantee_async(actor_id)
-            workspace_grants = await self._meta_store.get_grants_for_grantee_async(
+            grants = await self._meta_store.get_grants_for_grantee_async(actor_id)  # type: ignore[union-attr]
+            workspace_grants = await self._meta_store.get_grants_for_grantee_async(  # type: ignore[union-attr]
                 actor_workspace_id, grantee_type="workspace"
             )
 

--- a/aragora/memory/embeddings.py
+++ b/aragora/memory/embeddings.py
@@ -31,7 +31,13 @@ import os
 import struct
 from pathlib import Path
 
-import aiohttp
+from aragora._lazy_imports import lazy_module
+
+# Optional runtime dep: imported lazily so the debate engine can import this
+# module on a base install that lacks aiohttp. aiohttp is only touched when an
+# embedding is actually fetched from a remote API; the offline/hash fallback
+# path never needs it.
+aiohttp = lazy_module("aiohttp")
 
 from aragora.config import CACHE_TTL_EMBEDDINGS, get_api_key
 from aragora.exceptions import ExternalServiceError, REDIS_CONNECTION_ERRORS
@@ -61,8 +67,17 @@ def _get_embedding_cache() -> EmbeddingCache:
     return _embedding_cache
 
 
-# Default API timeout
-_API_TIMEOUT = aiohttp.ClientTimeout(total=30)
+# Default API timeout (built lazily so importing this module does not force
+# the optional aiohttp dependency to be present).
+_API_TIMEOUT_CACHE: Any = None
+
+
+def _api_timeout() -> Any:
+    global _API_TIMEOUT_CACHE
+    if _API_TIMEOUT_CACHE is None:
+        _API_TIMEOUT_CACHE = aiohttp.ClientTimeout(total=30)
+    return _API_TIMEOUT_CACHE
+
 
 # Track registration status
 _embedding_cache_registered = False
@@ -203,7 +218,7 @@ class OpenAIEmbedding(EmbeddingProvider):
             return cached
 
         async def _call() -> list[float]:
-            async with aiohttp.ClientSession(timeout=_API_TIMEOUT) as session:
+            async with aiohttp.ClientSession(timeout=_api_timeout()) as session:
                 async with session.post(
                     "https://api.openai.com/v1/embeddings",
                     headers={
@@ -234,7 +249,7 @@ class OpenAIEmbedding(EmbeddingProvider):
 
     async def embed_batch(self, texts: list[str]) -> list[list[float]]:
         async def _call() -> list[list[float]]:
-            async with aiohttp.ClientSession(timeout=_API_TIMEOUT) as session:
+            async with aiohttp.ClientSession(timeout=_api_timeout()) as session:
                 async with session.post(
                     "https://api.openai.com/v1/embeddings",
                     headers={
@@ -281,7 +296,7 @@ class GeminiEmbedding(EmbeddingProvider):
         url = f"https://generativelanguage.googleapis.com/v1beta/models/{self.model}:embedContent"
 
         async def _call() -> list[float]:
-            async with aiohttp.ClientSession(timeout=_API_TIMEOUT) as session:
+            async with aiohttp.ClientSession(timeout=_api_timeout()) as session:
                 async with session.post(
                     url,
                     headers={"x-goog-api-key": self.api_key, "Content-Type": "application/json"},
@@ -317,7 +332,7 @@ class OllamaEmbedding(EmbeddingProvider):
         self.dimension = 768  # nomic-embed-text
 
     async def embed(self, text: str) -> list[float]:
-        async with aiohttp.ClientSession(timeout=_API_TIMEOUT) as session:
+        async with aiohttp.ClientSession(timeout=_api_timeout()) as session:
             try:
                 async with session.post(
                     f"{self.base_url}/api/embeddings",
@@ -358,7 +373,7 @@ class SemanticRetriever:
     def __init__(
         self,
         db_path: str,
-        provider: EmbeddingProvider = None,
+        provider: EmbeddingProvider | None = None,
     ):
         self.db_path = Path(db_path)
         self.db = MemoryDatabase(db_path)


### PR DESCRIPTION
## Problem (confirmed)

A live `aragora ask` run on a base install crashes at import time:

```
aragora/connectors/arxiv.py:18  import defusedxml.ElementTree as ET
ModuleNotFoundError: No module named 'defusedxml'
```

## Root cause — eager package `__init__`

`aragora/connectors/__init__.py` eagerly imported all ~30 connector submodules at package load. The debate engine only needs `aragora.connectors.base.Evidence`, but importing **any** connectors submodule executes the package `__init__`, which drags in `arxiv → defusedxml` and every other connector's optional 3rd-party deps.

Import chain:
`debate.orchestrator → orchestrator_delegates → knowledge.mound → … → connectors.base → connectors/__init__ (EAGER) → arxiv → defusedxml`

The same eager-optional-import pattern blocked the headline command in several other modules once the connectors crash was removed.

## Fix — PEP 562 lazy `__getattr__` + deferred optional imports

Convert the eager imports to lazy loading (the same module-level `__getattr__` pattern already used by `aragora/__init__.py` and the CLI heavy modes). You only pay for an optional dependency when you actually use that connector/path.

### Files converted

| File | Change |
|------|--------|
| `aragora/connectors/__init__.py` | Full PEP 562 `__getattr__` over a `_NAME_TO_MODULE` map covering **all 114 `__all__` names** (derived by parsing the original import block, not hand-typed). `__all__` unchanged (public contract). `get_whisper_formats` alias preserved via `_NAME_ALIASES`. Resolved names cached in `globals()`. `__dir__` returns `sorted(__all__)`. |
| `aragora/_lazy_imports.py` *(new)* | Tiny dependency-free `lazy_module()` proxy — imports a module on first attribute access, so call sites like `httpx.HTTPError` / `aiohttp.ClientError` stay unchanged at runtime. |
| `aragora/cli/tenant.py`, `batch.py`, `config.py`, `documents.py` | Defer `httpx` / `PyYAML` into the functions that use them (these modules are imported eagerly only to register subparsers). |
| `aragora/cli/commands/{billing_ops,computer_use,connectors,delegated,knowledge,memory_ops,skills}.py` | Replace eager `import httpx` with the lazy proxy, under `if TYPE_CHECKING: import httpx` so type annotations / `except httpx.X` clauses stay typed for mypy. |
| `aragora/knowledge/mound/api/query.py` | `aiohttp` was used only to widen one fallback `except` tuple → resolved via a guarded `_aiohttp_client_error()` helper (sentinel when aiohttp absent). |
| `aragora/memory/embeddings.py` | Lazy `aiohttp` proxy; `_API_TIMEOUT` built lazily via `_api_timeout()`. |
| `aragora/core/embeddings/backends/{openai,gemini,ollama}.py` | Lazy `aiohttp` proxy. |

**No `pyproject.toml` / dependency changes** — distribution packaging is gated separately in #8517. This PR is purely the lazy-import refactor.

Also fixes a few pre-existing mypy errors in the two engine files that had to be touched (`query.py` `trace_context` no-redef + hasattr-guarded `union-attr`; `embeddings.py` implicit-Optional default) so the changed-file typecheck gate stays green. No runtime behavior change.

## Verification evidence (5 gates)

**Gate 1 — lean import is clean.** Lean venv = `pip install -e .` (base only, no extras); `defusedxml` not installed (`pip show defusedxml` → "Package(s) not found"):
```
$ python -c "import aragora.connectors; print('OK')"
OK            # defusedxml crash is gone
```

**Gate 2 — public API preserved.** All 114 `__all__` names resolve via the lazy `__getattr__` (test venv, with connector deps present); `__dir__` matches `__all__`; access is cached/stable:
```
total names: 114; failed to resolve: 0
__dir__ matches __all__: True
caching ok (Evidence stable): True
```
Lightweight names work on the lean install; `ArXivConnector` correctly requires `defusedxml` only when accessed (pay-for-what-you-use).

**Gate 3 — headline command survives imports.** Minimal-runtime venv = base + `pydantic`/`pydantic-settings`/`PyYAML` only, with **none** of `defusedxml`/`aiohttp`/`httpx`/`feedparser`/`requests`:
```
$ python -m aragora ask "Should we adopt feature flags?" --demo
FINAL ANSWER:
...
Receipt saved: ~/.aragora/receipts/....json     # EXIT 0 — runs end-to-end

$ python -m aragora ask "test" --local --rounds 1   # no API keys
No usable AI provider credential was discovered.    # stops on creds, NOT ImportError
```
The headline command now **runs**; with no credentials it stops on the expected non-import failure.

**Gate 4 — tests green.** `pytest tests/connectors/` (ignoring `chat/test_telegram.py`): **10,309 passed**, 41 skipped. The 28 remaining failures are **pre-existing** — verified identical on `main` with the changes stashed (version-sensitive datetime parsing, mock/version assertions across unrelated connectors). The 21 errors are a missing `pytest-benchmark` fixture (`test_chat_benchmarks.py`), unrelated to this change. Directly-affected modules (`test_recovery`, `test_whisper` [exercises the `get_whisper_formats` alias], `test_github`, `test_arxiv`) all pass (144 passed).

**Gate 5 — lint/type clean.** `ruff check` + `ruff format --check` clean on all touched files; hook-style `mypy --ignore-missing-imports --follow-imports=skip` clean on all 18 touched files (pre-push typecheck gate **Passed**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
