### PR TITLE
fix(tier4): preflight merge credentials during check

### DIFF
--- a/docs-site/docs/contributing/claude.md
+++ b/docs-site/docs/contributing/claude.md
@@ -192,7 +192,7 @@ Legacy `.gt` stores are supported for backwards compatibility when present.
 
 ## Project Overview
 
-Aragora is the **Decision Integrity Platform** -- orchestrating 43 agent types to adversarially vet decisions against your organization's knowledge, then delivering audit-ready decision receipts to any channel. It implements self-improvement through the **Nomic Loop** -- an autonomous cycle where agents debate improvements, design solutions, implement code, and verify changes.
+Aragora is the **Decision Integrity Platform** -- orchestrating 46 agent types to adversarially vet decisions against your organization's knowledge, then delivering audit-ready decision receipts to any channel. It implements self-improvement through the **Nomic Loop** -- an autonomous cycle where agents debate improvements, design solutions, implement code, and verify changes.
 
 **Five Pillars:** (1) SMB-ready with enterprise-grade security, (2) leading-edge memory and context processing, (3) extensible/modular with broad connectors and SDKs, (4) multi-agent robustness via heterogeneous model consensus, (5) self-healing and self-extending via the Nomic Loop.
 

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -16,7 +16,7 @@
 | Python lines of code under aragora/ | `1967148` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `143` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
 | Test files (test_*.py under tests/) | `5386` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `221972` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| Test functions (class + module level) | `221977` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
 | @pytest.mark.parametrize decorators | `789` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `83` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2870` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |

--- a/scripts/settle_tier4_pr.py
+++ b/scripts/settle_tier4_pr.py
@@ -13,7 +13,7 @@ import os
 import shlex
 import subprocess
 import sys
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Collection, Sequence
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote
@@ -61,6 +61,7 @@ OPERATOR_COMMENT_BLOCKER = "missing repo-visible Tier 4 operator settlement comm
 REQUIRED_CHECKS_BLOCKER = "required checks are missing"
 REQUIRED_CHECK_VISIBILITY_SKEW_BLOCKER = "required_check_visibility_skew"
 REQUIRED_CHECK_REST_VISIBILITY_CONTEXT = "required check REST visibility"
+BRANCH_PROTECTION_PREFLIGHT_BLOCKER = "branch protection preflight failed"
 MERGE_QUORUM_SETTLEMENT_PROOF_BLOCKER = (
     "aragora-merge-quorum failure is not proven to be missing human settlement"
 )
@@ -1669,6 +1670,38 @@ def _preflight_branch_protection_reconcile(*, repo: str, cwd: Path) -> None:
             ) from exc
 
 
+def _branch_protection_preflight_report(
+    *,
+    repo: str,
+    cwd: Path,
+    authorized_actions: Collection[str],
+) -> dict[str, Any]:
+    """Run the merge-apply branch-protection capability probe without mutating."""
+
+    if "branch_protection" not in authorized_actions:
+        return {
+            "required": False,
+            "ok": True,
+            "skipped_reason": "branch_protection_reconcile was not authorized",
+        }
+    try:
+        _preflight_branch_protection_reconcile(repo=repo, cwd=cwd)
+    except Tier4ApplyError as exc:
+        return {
+            "required": True,
+            "ok": False,
+            "error": str(exc),
+            **exc.to_payload(),
+        }
+    return {
+        "required": True,
+        "ok": True,
+        "phase": "preflight",
+        "mutation_occurred": False,
+        "completed_commands": 0,
+    }
+
+
 def _branch_protection_snapshot(*, repo: str, cwd: Path) -> dict[str, Any]:
     base = f"repos/{repo}/branches/main/protection"
     snapshot: dict[str, Any] = {}
@@ -2023,6 +2056,23 @@ def main(argv: Sequence[str] | None = None) -> int:
                 cwd=args.cwd,
                 trusted_operator_logins=args.trusted_operator_login,
             )
+            if args.check and gate["ok"]:
+                branch_protection_preflight = _branch_protection_preflight_report(
+                    repo=args.repo,
+                    cwd=args.cwd,
+                    authorized_actions=set(gate.get("authorized_actions") or []),
+                )
+                gate["branch_protection_preflight"] = branch_protection_preflight
+                preflight_required = bool(branch_protection_preflight.get("required"))
+                preflight_ok = bool(branch_protection_preflight.get("ok"))
+                if preflight_required and not preflight_ok:
+                    error = str(branch_protection_preflight.get("error") or "").strip()
+                    blocker = BRANCH_PROTECTION_PREFLIGHT_BLOCKER
+                    if error:
+                        blocker = f"{blocker}: {error}"
+                    gate["blockers"].append(blocker)
+                    gate["settle_eligible"] = False
+                    gate["ok"] = False
         if args.merge_apply:
             if not gate["ok"]:
                 raise RuntimeError("Tier 4 gate is not satisfied; refusing --merge-apply")

--- a/scripts/settle_tier4_pr.py
+++ b/scripts/settle_tier4_pr.py
@@ -1561,7 +1561,7 @@ def _load_live_inputs(
 
 def _required_status_check_patch(*, repo: str, cwd: Path) -> tuple[list[str], str] | None:
     endpoint = f"repos/{repo}/branches/main/protection/required_status_checks"
-    current = _run_json(["gh", "api", endpoint], cwd=cwd)
+    current = _run_json(["gh", "api", endpoint], cwd=cwd, write_op=True)
     contexts = current.get("contexts")
     if not isinstance(contexts, list):
         checks = current.get("checks")
@@ -1636,7 +1636,7 @@ def _preflight_branch_protection_reconcile(*, repo: str, cwd: Path) -> None:
 
     base = f"repos/{repo}/branches/main/protection"
     try:
-        top_level = _run_json(["gh", "api", base], cwd=cwd)
+        top_level = _run_json(["gh", "api", base], cwd=cwd, write_op=True)
     except RuntimeError as exc:
         raise Tier4ApplyError(
             f"Tier 4 branch-protection preflight failed before merge mutation: {base}: {exc}",
@@ -1655,7 +1655,7 @@ def _preflight_branch_protection_reconcile(*, repo: str, cwd: Path) -> None:
         ("enforce_admins", f"{base}/enforce_admins"),
     ):
         try:
-            _run_json(["gh", "api", endpoint], cwd=cwd)
+            _run_json(["gh", "api", endpoint], cwd=cwd, write_op=True)
         except RuntimeError as exc:
             if _is_not_found_error(exc) and _top_level_rule_absent(top_level, key):
                 continue
@@ -1708,7 +1708,7 @@ def _branch_protection_snapshot(*, repo: str, cwd: Path) -> dict[str, Any]:
     base = f"repos/{repo}/branches/main/protection"
     snapshot: dict[str, Any] = {}
     try:
-        top_level = _run_json(["gh", "api", base], cwd=cwd)
+        top_level = _run_json(["gh", "api", base], cwd=cwd, write_op=True)
     except RuntimeError as exc:
         snapshot["branch_protection"] = {"snapshot_error": str(exc)}
         return snapshot
@@ -1719,7 +1719,7 @@ def _branch_protection_snapshot(*, repo: str, cwd: Path) -> dict[str, Any]:
         "enforce_admins": f"{base}/enforce_admins",
     }.items():
         try:
-            snapshot[key] = _run_json(["gh", "api", endpoint], cwd=cwd)
+            snapshot[key] = _run_json(["gh", "api", endpoint], cwd=cwd, write_op=True)
         except RuntimeError as exc:
             if _is_not_found_error(exc) and _top_level_rule_absent(top_level, key):
                 snapshot[key] = None

--- a/scripts/settle_tier4_pr.py
+++ b/scripts/settle_tier4_pr.py
@@ -1624,8 +1624,22 @@ def _top_level_rule_absent(top_level: dict[str, Any], key: str) -> bool:
 
 
 def _preflight_branch_protection_reconcile(*, repo: str, cwd: Path) -> None:
-    login = _current_gh_login(cwd=cwd)
-    if not _login_has_admin_permission(login, repo, cwd):
+    try:
+        login = _current_gh_login(cwd=cwd)
+        has_admin_permission = _login_has_admin_permission(login, repo, cwd)
+    except RuntimeError as exc:
+        raise Tier4ApplyError(
+            f"Tier 4 branch-protection preflight failed before merge mutation: "
+            f"could not probe gh admin permission: {exc}",
+            phase="preflight",
+            mutation_occurred=False,
+            completed_commands=0,
+            recovery_action=(
+                "verify gh auth is available and the eventual merge applier has "
+                "branch-protection admin access, then rerun --merge-apply"
+            ),
+        ) from exc
+    if not has_admin_permission:
         raise Tier4ApplyError(
             f"Tier 4 branch-protection preflight failed: gh login {login} lacks admin permission",
             phase="preflight",
@@ -1672,6 +1686,19 @@ def _preflight_branch_protection_reconcile(*, repo: str, cwd: Path) -> None:
             ) from exc
 
 
+def _branch_protection_preflight_is_observational_permission_probe(
+    exc: Tier4ApplyError,
+) -> bool:
+    """Return whether ``--check`` only proved the current observer lacks admin."""
+
+    return (
+        exc.phase == "preflight"
+        and exc.mutation_occurred is False
+        and exc.completed_commands == 0
+        and "lacks admin permission" in str(exc)
+    )
+
+
 def _branch_protection_preflight_report(
     *,
     repo: str,
@@ -1689,11 +1716,24 @@ def _branch_protection_preflight_report(
     try:
         _preflight_branch_protection_reconcile(repo=repo, cwd=cwd)
     except Tier4ApplyError as exc:
+        payload = exc.to_payload()
+        if _branch_protection_preflight_is_observational_permission_probe(exc):
+            return {
+                **payload,
+                "required": True,
+                "ok": True,
+                "advisory": True,
+                "error": str(exc),
+                "non_blocking_reason": (
+                    "current gh login lacks admin permission; --check is observational "
+                    "and the eventual --merge-apply operator may use a different trusted login"
+                ),
+            }
         return {
+            **payload,
             "required": True,
             "ok": False,
             "error": str(exc),
-            **exc.to_payload(),
         }
     return {
         "required": True,

--- a/scripts/settle_tier4_pr.py
+++ b/scripts/settle_tier4_pr.py
@@ -13,7 +13,7 @@ import os
 import shlex
 import subprocess
 import sys
-from collections.abc import Callable, Collection, Sequence
+from collections.abc import Callable, Collection, Mapping, Sequence
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote
@@ -34,7 +34,7 @@ except Exception:  # pragma: no cover - script must still run in partial checkou
     gh_subprocess_run = None  # type: ignore[assignment]
 
     def github_cli_env(
-        base_env: dict[str, str] | None = None,
+        base_env: Mapping[str, str] | None = None,
         *,
         prefer_app: bool = True,
     ) -> dict[str, str]:
@@ -574,6 +574,8 @@ def _packet_marks_tier4_settlement_surface(merge_packet: dict[str, Any], *, pr: 
     if isinstance(required, list) and str(pr) in {str(item) for item in required}:
         return True
     tier = entry.get("tier")
+    if not isinstance(tier, str | int | float):
+        return False
     try:
         return int(tier) >= 4
     except (TypeError, ValueError):

--- a/tests/scripts/test_settle_tier4_pr.py
+++ b/tests/scripts/test_settle_tier4_pr.py
@@ -2419,11 +2419,12 @@ def test_merge_apply_branch_protection_preflight_failure_prevents_merge(
     )
     monkeypatch.setattr(settler, "_current_gh_login", lambda cwd: "admin-user")
     monkeypatch.setattr(settler, "_login_has_admin_permission", lambda login, repo, cwd: True)
-    monkeypatch.setattr(
-        settler,
-        "_run_json",
-        lambda command, cwd: (_ for _ in ()).throw(RuntimeError("gh: Not Found (HTTP 404)")),
-    )
+
+    def fail_run_json(command: list[str], cwd: Path, *, write_op: bool = False) -> dict[str, Any]:
+        assert write_op is True
+        raise RuntimeError("gh: Not Found (HTTP 404)")
+
+    monkeypatch.setattr(settler, "_run_json", fail_run_json)
     monkeypatch.setattr(
         settler,
         "_run_command",
@@ -2448,7 +2449,7 @@ def test_merge_apply_branch_protection_preflight_failure_prevents_merge(
 def test_branch_protection_preflight_reads_all_privileged_endpoints(
     monkeypatch: Any, tmp_path: Path
 ) -> None:
-    commands: list[list[str]] = []
+    commands: list[tuple[list[str], bool]] = []
 
     monkeypatch.setattr(settler, "_current_gh_login", lambda cwd: "admin-user")
     monkeypatch.setattr(
@@ -2457,34 +2458,35 @@ def test_branch_protection_preflight_reads_all_privileged_endpoints(
         lambda login, repo, cwd: login == "admin-user",
     )
 
-    def fake_run_json(command: list[str], cwd: Path) -> dict[str, Any]:
-        commands.append(command)
+    def fake_run_json(command: list[str], cwd: Path, *, write_op: bool = False) -> dict[str, Any]:
+        commands.append((command, write_op))
         return {"ok": True}
 
     monkeypatch.setattr(settler, "_run_json", fake_run_json)
 
     settler._preflight_branch_protection_reconcile(repo="owner/repo", cwd=tmp_path)
 
-    endpoints = [command[-1] for command in commands]
+    endpoints = [command[-1] for command, _write_op in commands]
     assert endpoints == [
         "repos/owner/repo/branches/main/protection",
         "repos/owner/repo/branches/main/protection/required_pull_request_reviews",
         "repos/owner/repo/branches/main/protection/required_status_checks",
         "repos/owner/repo/branches/main/protection/enforce_admins",
     ]
+    assert [write_op for _command, write_op in commands] == [True, True, True, True]
 
 
 def test_branch_protection_preflight_allows_absent_optional_subresource_404(
     monkeypatch: Any, tmp_path: Path
 ) -> None:
-    commands: list[str] = []
+    commands: list[tuple[str, bool]] = []
 
     monkeypatch.setattr(settler, "_current_gh_login", lambda cwd: "admin-user")
     monkeypatch.setattr(settler, "_login_has_admin_permission", lambda login, repo, cwd: True)
 
-    def fake_run_json(command: list[str], cwd: Path) -> dict[str, Any]:
+    def fake_run_json(command: list[str], cwd: Path, *, write_op: bool = False) -> dict[str, Any]:
         endpoint = command[-1]
-        commands.append(endpoint)
+        commands.append((endpoint, write_op))
         if endpoint.endswith("/protection"):
             return {
                 "required_pull_request_reviews": None,
@@ -2502,10 +2504,10 @@ def test_branch_protection_preflight_allows_absent_optional_subresource_404(
     settler._preflight_branch_protection_reconcile(repo="owner/repo", cwd=tmp_path)
 
     assert commands == [
-        "repos/owner/repo/branches/main/protection",
-        "repos/owner/repo/branches/main/protection/required_pull_request_reviews",
-        "repos/owner/repo/branches/main/protection/required_status_checks",
-        "repos/owner/repo/branches/main/protection/enforce_admins",
+        ("repos/owner/repo/branches/main/protection", True),
+        ("repos/owner/repo/branches/main/protection/required_pull_request_reviews", True),
+        ("repos/owner/repo/branches/main/protection/required_status_checks", True),
+        ("repos/owner/repo/branches/main/protection/enforce_admins", True),
     ]
 
 
@@ -2515,7 +2517,8 @@ def test_branch_protection_preflight_blocks_present_optional_subresource_404(
     monkeypatch.setattr(settler, "_current_gh_login", lambda cwd: "admin-user")
     monkeypatch.setattr(settler, "_login_has_admin_permission", lambda login, repo, cwd: True)
 
-    def fake_run_json(command: list[str], cwd: Path) -> dict[str, Any]:
+    def fake_run_json(command: list[str], cwd: Path, *, write_op: bool = False) -> dict[str, Any]:
+        assert write_op is True
         endpoint = command[-1]
         if endpoint.endswith("/protection"):
             return {
@@ -2545,7 +2548,9 @@ def test_branch_protection_preflight_blocks_non_admin_invoker(
     monkeypatch.setattr(
         settler,
         "_run_json",
-        lambda command, cwd: pytest.fail("branch-protection endpoints should not be read"),
+        lambda command, cwd, **kwargs: pytest.fail(
+            "branch-protection endpoints should not be read"
+        ),
     )
 
     with pytest.raises(settler.Tier4ApplyError) as exc:
@@ -2560,7 +2565,10 @@ def test_branch_protection_preflight_blocks_non_admin_invoker(
 def test_branch_protection_snapshot_records_absent_optional_subresource_404(
     monkeypatch: Any, tmp_path: Path
 ) -> None:
-    def fake_run_json(command: list[str], cwd: Path) -> dict[str, Any]:
+    commands: list[bool] = []
+
+    def fake_run_json(command: list[str], cwd: Path, *, write_op: bool = False) -> dict[str, Any]:
+        commands.append(write_op)
         endpoint = command[-1]
         if endpoint.endswith("/protection"):
             return {
@@ -2582,6 +2590,7 @@ def test_branch_protection_snapshot_records_absent_optional_subresource_404(
     assert snapshot["required_status_checks"] is None
     assert snapshot["enforce_admins"] == {"enabled": True}
     assert settler._branch_protection_snapshot_errors(snapshot) == []
+    assert commands == [True, True, True, True]
 
 
 def test_branch_protection_top_level_snapshot_failure_prevents_merge(
@@ -2849,14 +2858,14 @@ def test_merge_apply_refuses_stale_failed_required_rollup_before_merge(
 def test_required_status_check_patch_skips_when_quorum_already_required(
     monkeypatch: Any, tmp_path: Path
 ) -> None:
-    monkeypatch.setattr(
-        settler,
-        "_run_json",
-        lambda command, cwd: {
+    def fake_run_json(command: list[str], cwd: Path, *, write_op: bool = False) -> dict[str, Any]:
+        assert write_op is True
+        return {
             "strict": False,
             "contexts": ["Generate & Validate", "aragora-merge-quorum", "lint"],
-        },
-    )
+        }
+
+    monkeypatch.setattr(settler, "_run_json", fake_run_json)
 
     patch = settler._required_status_check_patch(repo="owner/repo", cwd=tmp_path)
 
@@ -2866,17 +2875,17 @@ def test_required_status_check_patch_skips_when_quorum_already_required(
 def test_required_status_check_patch_adds_missing_quorum_from_checks(
     monkeypatch: Any, tmp_path: Path
 ) -> None:
-    monkeypatch.setattr(
-        settler,
-        "_run_json",
-        lambda command, cwd: {
+    def fake_run_json(command: list[str], cwd: Path, *, write_op: bool = False) -> dict[str, Any]:
+        assert write_op is True
+        return {
             "strict": False,
             "checks": [
                 {"context": "Generate & Validate", "app_id": 15368},
                 {"context": "lint", "app_id": 15368},
             ],
-        },
-    )
+        }
+
+    monkeypatch.setattr(settler, "_run_json", fake_run_json)
 
     command, payload = settler._required_status_check_patch(repo="owner/repo", cwd=tmp_path)
 

--- a/tests/scripts/test_settle_tier4_pr.py
+++ b/tests/scripts/test_settle_tier4_pr.py
@@ -1868,6 +1868,107 @@ def test_check_json_blocks_on_branch_protection_preflight_failure(
     assert "HTTP 403" in preflight["error"]
 
 
+def test_check_json_does_not_block_on_observational_non_admin_preflight(
+    monkeypatch: Any, tmp_path: Path, capsys: Any
+) -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+
+    monkeypatch.setattr(
+        settler,
+        "_load_live_inputs",
+        lambda pr, cwd, repo=settler.DEFAULT_REPO: (
+            _pr_view(head, comments=[_authorized_comment(head)]),
+            _tier4_packet(),
+            _valid_checks(),
+        ),
+    )
+    monkeypatch.setattr(settler, "_current_gh_login", lambda cwd: "reviewer-user")
+    monkeypatch.setattr(settler, "_login_has_admin_permission", lambda login, repo, cwd: False)
+    monkeypatch.setattr(
+        settler,
+        "_run_json",
+        lambda command, cwd, **kwargs: pytest.fail(
+            "observational non-admin checks should not read branch-protection endpoints"
+        ),
+    )
+
+    rc = settler.main(["--check", "--pr", "7423", "--head", head, "--cwd", str(tmp_path), "--json"])
+
+    assert rc == 0
+    gate = settler.json.loads(capsys.readouterr().out)["gate"]
+    assert gate["ok"] is True
+    assert gate["settle_eligible"] is True
+    preflight = gate["branch_protection_preflight"]
+    assert preflight["required"] is True
+    assert preflight["ok"] is True
+    assert preflight["advisory"] is True
+    assert "lacks admin permission" in preflight["error"]
+    assert "eventual --merge-apply operator" in preflight["non_blocking_reason"]
+
+
+def test_branch_protection_preflight_report_failure_keys_fail_closed(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    def fail_preflight(*, repo: str, cwd: Path) -> None:
+        raise settler.Tier4ApplyError(
+            "real preflight failure",
+            phase="preflight",
+            mutation_occurred=False,
+            completed_commands=0,
+            recovery_action="recover",
+        )
+
+    def conflicting_payload(self: Any) -> dict[str, Any]:
+        return {
+            "required": False,
+            "ok": True,
+            "error": "payload override",
+            "phase": self.phase,
+            "mutation_occurred": self.mutation_occurred,
+            "completed_commands": self.completed_commands,
+            "rollback_errors": self.rollback_errors,
+            "recovery_action": self.recovery_action,
+        }
+
+    monkeypatch.setattr(settler, "_preflight_branch_protection_reconcile", fail_preflight)
+    monkeypatch.setattr(settler.Tier4ApplyError, "to_payload", conflicting_payload)
+
+    preflight = settler._branch_protection_preflight_report(
+        repo="owner/repo",
+        cwd=tmp_path,
+        authorized_actions={"branch_protection"},
+    )
+
+    assert preflight["required"] is True
+    assert preflight["ok"] is False
+    assert preflight["error"] == "real preflight failure"
+    assert preflight["phase"] == "preflight"
+
+
+def test_branch_protection_preflight_report_wraps_auth_probe_runtime_error(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        settler,
+        "_current_gh_login",
+        lambda cwd: (_ for _ in ()).throw(RuntimeError("gh auth unavailable")),
+    )
+
+    preflight = settler._branch_protection_preflight_report(
+        repo="owner/repo",
+        cwd=tmp_path,
+        authorized_actions={"branch_protection"},
+    )
+
+    assert preflight["required"] is True
+    assert preflight["ok"] is False
+    assert preflight["phase"] == "preflight"
+    assert preflight["mutation_occurred"] is False
+    assert preflight["completed_commands"] == 0
+    assert "could not probe gh admin permission" in preflight["error"]
+    assert "gh auth unavailable" in preflight["error"]
+
+
 def test_check_skips_branch_protection_preflight_for_merge_only_authorization(
     monkeypatch: Any, tmp_path: Path, capsys: Any
 ) -> None:

--- a/tests/scripts/test_settle_tier4_pr.py
+++ b/tests/scripts/test_settle_tier4_pr.py
@@ -1390,6 +1390,11 @@ def test_cli_trusted_operator_login_authorizes_member_comment(
         "_login_has_admin_permission",
         lambda login, repo, cwd: login == "trusted-member",
     )
+    monkeypatch.setattr(
+        settler,
+        "_preflight_branch_protection_reconcile",
+        lambda repo, cwd: None,
+    )
 
     rc = settler.main(
         [
@@ -1813,6 +1818,91 @@ def test_check_json_includes_authorization_diagnostics(
     assert gate["authorization_diagnostics"][0]["rejection_reasons"] == [
         "MEMBER login owner-user is not in trusted operator allowlist"
     ]
+
+
+def test_check_json_blocks_on_branch_protection_preflight_failure(
+    monkeypatch: Any, tmp_path: Path, capsys: Any
+) -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+
+    monkeypatch.setattr(
+        settler,
+        "_load_live_inputs",
+        lambda pr, cwd, repo=settler.DEFAULT_REPO: (
+            _pr_view(head, comments=[_authorized_comment(head)]),
+            _tier4_packet(),
+            _valid_checks(),
+        ),
+    )
+
+    def fail_preflight(*, repo: str, cwd: Path) -> None:
+        raise settler.Tier4ApplyError(
+            "Tier 4 branch-protection preflight failed before merge mutation: "
+            "repos/owner/repo/branches/main/protection: gh: Resource not accessible "
+            "by integration (HTTP 403)",
+            phase="preflight",
+            mutation_occurred=False,
+            completed_commands=0,
+            recovery_action="verify the active gh identity has branch-protection admin access",
+        )
+
+    monkeypatch.setattr(settler, "_preflight_branch_protection_reconcile", fail_preflight)
+
+    rc = settler.main(["--check", "--pr", "7423", "--head", head, "--cwd", str(tmp_path), "--json"])
+
+    assert rc == 1
+    payload = settler.json.loads(capsys.readouterr().out)
+    gate = payload["gate"]
+    assert gate["ok"] is False
+    assert gate["settle_eligible"] is False
+    assert any(
+        blocker.startswith(settler.BRANCH_PROTECTION_PREFLIGHT_BLOCKER)
+        for blocker in gate["blockers"]
+    )
+    preflight = gate["branch_protection_preflight"]
+    assert preflight["required"] is True
+    assert preflight["ok"] is False
+    assert preflight["phase"] == "preflight"
+    assert preflight["mutation_occurred"] is False
+    assert preflight["completed_commands"] == 0
+    assert "HTTP 403" in preflight["error"]
+
+
+def test_check_skips_branch_protection_preflight_for_merge_only_authorization(
+    monkeypatch: Any, tmp_path: Path, capsys: Any
+) -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+
+    monkeypatch.setattr(
+        settler,
+        "_load_live_inputs",
+        lambda pr, cwd, repo=settler.DEFAULT_REPO: (
+            _pr_view(
+                head,
+                comments=[
+                    _authorized_comment(
+                        head,
+                        include_branch_protection=False,
+                    )
+                ],
+            ),
+            _tier4_packet(),
+            _valid_checks(),
+        ),
+    )
+    monkeypatch.setattr(
+        settler,
+        "_preflight_branch_protection_reconcile",
+        lambda repo, cwd: pytest.fail("merge-only authorization should not preflight"),
+    )
+
+    rc = settler.main(["--check", "--pr", "7423", "--head", head, "--cwd", str(tmp_path), "--json"])
+
+    assert rc == 0
+    gate = settler.json.loads(capsys.readouterr().out)["gate"]
+    assert gate["ok"] is True
+    assert gate["authorized_actions"] == ["merge"]
+    assert gate["branch_protection_preflight"]["required"] is False
 
 
 def test_settle_only_posts_comment_and_status_without_merge(


### PR DESCRIPTION
## Summary
- make `settle_tier4_pr.py --check` run the same branch-protection capability preflight needed by `--merge-apply` once the Tier 4 gate is otherwise satisfied
- surface branch-protection credential failures as structured `branch_protection_preflight` JSON with `mutation_occurred=false` before merge-apply
- keep merge-only authorizations from running branch-protection probes and tighten touched helper typing

## Validation
- `pytest tests/scripts/test_settle_tier4_pr.py -q`
- `python3 -m ruff check scripts/settle_tier4_pr.py tests/scripts/test_settle_tier4_pr.py`
- `python3 -m mypy scripts/settle_tier4_pr.py`
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- live #8452 check with this branch now blocks before merge-apply with `branch_protection_preflight.ok=false`, `mutation_occurred=false`, and the HTTP 403 credential error
