### PR TITLE
fix(ci): install anthropic sdk for control-plane tests

### DIFF
--- a/scripts/ci_install_project.sh
+++ b/scripts/ci_install_project.sh
@@ -67,6 +67,7 @@ LEGACY_CONTROL_PLANE_TEST_EXTRA_DEPS=(
   "redis>=5.0.0,<8.0"
   "asyncpg>=0.31.0,<1.0"             # aligned to pyproject [enterprise]/[all]
   "yt-dlp>=2024.1,<2027.0"
+  "anthropic>=0.111,<1.0"
   "openai>=2.0,<3.0"
   "twilio>=8.0,<10.0"
   "langchain>=1.0,<2.0"

--- a/tests/ci/test_release_gates.py
+++ b/tests/ci/test_release_gates.py
@@ -20,6 +20,7 @@ import textwrap
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from packaging.requirements import Requirement
 import pytest
 import yaml
 
@@ -49,6 +50,23 @@ def _get_triggers(data: dict) -> dict:
     if True in data:
         return data[True]
     raise KeyError("Workflow has no 'on' trigger key")
+
+
+def _shell_array_values(script: str, name: str) -> set[str]:
+    """Return quoted values from a simple bash array assignment."""
+    array_match = re.search(
+        rf"^(?:readonly\s+)?{re.escape(name)}=\((?P<body>[^\n]*)\)",
+        script,
+        re.MULTILINE,
+    )
+    if array_match is None:
+        array_match = re.search(
+            rf"^(?:readonly\s+)?{re.escape(name)}=\(\n(?P<body>.*?)^\)",
+            script,
+            re.MULTILINE | re.DOTALL,
+        )
+    assert array_match is not None
+    return set(re.findall(r'"([^"]+)"', array_match.group("body")))
 
 
 # ---------------------------------------------------------------------------
@@ -178,25 +196,17 @@ class TestSharedCiInstaller:
 
     def test_control_plane_root_names_include_renamed_package(self):
         script = (PROJECT_ROOT / "scripts" / "ci_install_project.sh").read_text()
-        names_match = re.search(
-            r"LEGACY_CONTROL_PLANE_PACKAGE_NAMES=\((?P<names>[^)]*)\)",
-            script,
-        )
-        assert names_match is not None
-        names = set(re.findall(r'"([^"]+)"', names_match.group("names")))
+        names = _shell_array_values(script, "LEGACY_CONTROL_PLANE_PACKAGE_NAMES")
         assert {"aragora-debate", "aragora"} <= names
         assert 'LEGACY_CONTROL_PLANE_MARKER_PATH="aragora/server"' in script
 
     def test_control_plane_test_deps_install_real_anthropic_sdk(self):
         script = (PROJECT_ROOT / "scripts" / "ci_install_project.sh").read_text()
-        test_deps_match = re.search(
-            r"LEGACY_CONTROL_PLANE_TEST_EXTRA_DEPS=\((?P<deps>.*?)\n\)",
-            script,
-            re.DOTALL,
+        deps = _shell_array_values(script, "LEGACY_CONTROL_PLANE_TEST_EXTRA_DEPS")
+        anthropic_dep = next(
+            Requirement(dep) for dep in deps if Requirement(dep).name == "anthropic"
         )
-        assert test_deps_match is not None
-        deps = set(re.findall(r'"([^"]+)"', test_deps_match.group("deps")))
-        assert "anthropic>=0.111,<1.0" in deps
+        assert str(anthropic_dep.specifier) == "<1.0,>=0.111"
 
 
 class TestAragoraReviewGateWorkflow:

--- a/tests/ci/test_release_gates.py
+++ b/tests/ci/test_release_gates.py
@@ -187,6 +187,17 @@ class TestSharedCiInstaller:
         assert {"aragora-debate", "aragora"} <= names
         assert 'LEGACY_CONTROL_PLANE_MARKER_PATH="aragora/server"' in script
 
+    def test_control_plane_test_deps_install_real_anthropic_sdk(self):
+        script = (PROJECT_ROOT / "scripts" / "ci_install_project.sh").read_text()
+        test_deps_match = re.search(
+            r"LEGACY_CONTROL_PLANE_TEST_EXTRA_DEPS=\((?P<deps>.*?)\n\)",
+            script,
+            re.DOTALL,
+        )
+        assert test_deps_match is not None
+        deps = set(re.findall(r'"([^"]+)"', test_deps_match.group("deps")))
+        assert "anthropic>=0.111,<1.0" in deps
+
 
 class TestAragoraReviewGateWorkflow:
     """Validate Aragora PR review gate structure."""


### PR DESCRIPTION
## Summary
- Add the real `anthropic` SDK to the shared control-plane CI test dependency set.
- Add a release-gate regression test so future packaging changes keep the dependency installed.

## Why
After #8517 merged the root package as the full `aragora` distribution, smoke tests hit `AttributeError: <module 'anthropic'> has no attribute 'Anthropic'` in the API mock autouse fixture. The fixture tolerates `ImportError`, but not a partial `anthropic` module without the SDK client classes. Installing the real SDK in the test dependency closure fixes that class of CI failure.

## Validation
- `bash -n scripts/ci_install_project.sh`
- `python3 -m pytest tests/ci/test_release_gates.py::TestSharedCiInstaller tests/debate/test_summarizer.py::TestDebateSummarizer::test_summarize_basic_result -q`
- `pre-commit run --files scripts/ci_install_project.sh tests/ci/test_release_gates.py`

## Notes
- Draft follow-up to the #8517 packaging merge.
- No branch protection, workflow, or settlement changes.
