### PR TITLE
fix(automation): fall back to REST for publisher PR lookup

### DIFF
--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -866,11 +866,16 @@ def _open_codex_prs_from_status_cache(
 def _flatten_rest_pages(payload: Any) -> list[dict[str, Any]]:
     if not isinstance(payload, list):
         raise RuntimeError("REST PR lookup returned unexpected JSON shape")
-    if payload and all(isinstance(item, list) for item in payload):
-        return [
-            pr for page in payload if isinstance(page, list) for pr in page if isinstance(pr, dict)
-        ]
-    return [item for item in payload if isinstance(item, dict)]
+    flattened: list[dict[str, Any]] = []
+    for item in payload:
+        if isinstance(item, dict):
+            flattened.append(item)
+            continue
+        if isinstance(item, list):
+            flattened.extend(_flatten_rest_pages(item))
+            continue
+        raise RuntimeError("REST PR lookup returned unexpected JSON shape")
+    return flattened
 
 
 def _open_codex_prs_from_rest(repo_root: Path, repo: str) -> list[dict[str, Any]]:
@@ -895,9 +900,15 @@ def _open_codex_prs_from_rest(repo_root: Path, repo: str) -> list[dict[str, Any]
     for item in _flatten_rest_pages(payload):
         head = item.get("head")
         if not isinstance(head, Mapping):
-            continue
+            number = item.get("number")
+            suffix = f" for PR #{number}" if number is not None else ""
+            raise RuntimeError(f"REST PR lookup missing head metadata{suffix}")
         branch = head.get("ref")
-        if not isinstance(branch, str) or not branch.startswith(CODEX_BRANCH_PREFIX):
+        if not isinstance(branch, str):
+            number = item.get("number")
+            suffix = f" for PR #{number}" if number is not None else ""
+            raise RuntimeError(f"REST PR lookup missing head ref{suffix}")
+        if not branch.startswith(CODEX_BRANCH_PREFIX):
             continue
         prs.append(
             {
@@ -940,6 +951,8 @@ def _open_codex_prs_with_cache_fallback(
                 "source": "rest",
                 "status": "ok",
                 "fallback_error": live_error,
+                "lookup_degraded": True,
+                "rest_result_count": len(rest_prs),
             }
             lookup_meta.update(cache_meta)
             return rest_prs, lookup_meta
@@ -1822,6 +1835,20 @@ def main(argv: list[str] | None = None) -> int:
             )
     unhealthy_open_pr_count = len(unhealthy_open_prs)
     all_open_prs_unhealthy = bool(open_codex_prs) and unhealthy_open_pr_count == len(open_codex_prs)
+    if (
+        open_pr_lookup.get("source") == "rest"
+        and open_pr_lookup.get("lookup_degraded") is True
+        and not open_codex_prs
+    ):
+        unhealthy_open_pr_count = max(unhealthy_open_pr_count, 1)
+        all_open_prs_unhealthy = True
+        unhealthy_open_prs = [
+            {
+                "reasons": [
+                    "lookup_degraded_queue_health_unknown",
+                ]
+            }
+        ]
     cache_queue_health = open_pr_lookup.get("cache_queue_health")
     if open_pr_lookup.get("source") == "cache" and isinstance(cache_queue_health, Mapping):
         cached_merge_state_counts = cache_queue_health.get("merge_state_counts")

--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -863,6 +863,58 @@ def _open_codex_prs_from_status_cache(
     return prs, meta
 
 
+def _flatten_rest_pages(payload: Any) -> list[dict[str, Any]]:
+    if not isinstance(payload, list):
+        return []
+    if payload and all(isinstance(item, list) for item in payload):
+        return [
+            pr for page in payload if isinstance(page, list) for pr in page if isinstance(pr, dict)
+        ]
+    return [item for item in payload if isinstance(item, dict)]
+
+
+def _open_codex_prs_from_rest(repo_root: Path, repo: str) -> list[dict[str, Any]]:
+    proc = _run(
+        [
+            "gh",
+            "api",
+            "--paginate",
+            "--slurp",
+            f"repos/{repo}/pulls?state=open&per_page=100",
+        ],
+        cwd=repo_root,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.strip() or proc.stdout.strip() or "failed to list REST PRs")
+    try:
+        payload = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("REST PR lookup returned invalid JSON") from exc
+
+    prs: list[dict[str, Any]] = []
+    for item in _flatten_rest_pages(payload):
+        head = item.get("head")
+        if not isinstance(head, Mapping):
+            continue
+        branch = head.get("ref")
+        if not isinstance(branch, str) or not branch.startswith(CODEX_BRANCH_PREFIX):
+            continue
+        prs.append(
+            {
+                "number": item.get("number"),
+                "title": item.get("title"),
+                "headRefName": branch,
+                "isDraft": item.get("draft"),
+                "mergeStateStatus": str(item.get("mergeable_state") or "UNKNOWN").upper(),
+                "reviewDecision": None,
+                "statusCheckRollup": [],
+                "lookup_degraded": True,
+                "lookup_source": "rest",
+            }
+        )
+    return prs
+
+
 def _open_codex_prs_with_cache_fallback(
     repo_root: Path,
     repo: str,
@@ -876,7 +928,18 @@ def _open_codex_prs_with_cache_fallback(
         live_error = str(exc)
         cached_prs, cache_meta = _open_codex_prs_from_status_cache(repo_root, repo)
         if cached_prs is None:
-            raise OpenCodexPrLookupError(live_error, cache_meta) from exc
+            try:
+                rest_prs = _open_codex_prs_from_rest(repo_root, repo)
+            except RuntimeError as rest_exc:
+                cache_meta["rest_error"] = str(rest_exc)
+                raise OpenCodexPrLookupError(live_error, cache_meta) from exc
+            lookup_meta = {
+                "source": "rest",
+                "status": "ok",
+                "fallback_error": live_error,
+            }
+            lookup_meta.update(cache_meta)
+            return rest_prs, lookup_meta
         lookup_meta = {
             "source": "cache",
             "status": "ok",

--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -900,14 +900,10 @@ def _open_codex_prs_from_rest(repo_root: Path, repo: str) -> list[dict[str, Any]
     for item in _flatten_rest_pages(payload):
         head = item.get("head")
         if not isinstance(head, Mapping):
-            number = item.get("number")
-            suffix = f" for PR #{number}" if number is not None else ""
-            raise RuntimeError(f"REST PR lookup missing head metadata{suffix}")
+            continue
         branch = head.get("ref")
         if not isinstance(branch, str):
-            number = item.get("number")
-            suffix = f" for PR #{number}" if number is not None else ""
-            raise RuntimeError(f"REST PR lookup missing head ref{suffix}")
+            continue
         if not branch.startswith(CODEX_BRANCH_PREFIX):
             continue
         prs.append(
@@ -1782,22 +1778,34 @@ def main(argv: list[str] | None = None) -> int:
     open_pr_heads = {
         item["headRefName"] for item in open_codex_prs if isinstance(item.get("headRefName"), str)
     }
+    open_pr_lookup_degraded = open_pr_lookup.get("lookup_degraded") is True
     duplicate_open_pr_patch_lookup = _duplicate_open_pr_patch_branches(
         repo_root,
         args.base,
         hydrated_branches,
         open_codex_prs,
     )
-    historical_pr_branches = _branches_with_pr_history(
-        repo_root,
-        args.github_repo,
-        [branch.branch for branch in hydrated_branches if branch.branch not in open_pr_heads],
-    )
-    resolved_related_branches = _branches_with_resolved_related_work(
-        repo_root,
-        args.github_repo,
-        [branch for branch in hydrated_branches if branch.branch not in historical_pr_branches],
-    )
+    historical_pr_lookup_skipped = False
+    related_work_lookup_skipped = False
+    if open_pr_lookup_degraded:
+        # A degraded open-PR lookup means GraphQL-backed follow-up searches may
+        # still be unavailable. Keep read visibility, but do not run further
+        # networked dedupe searches or publish from an incomplete queue view.
+        historical_pr_lookup_skipped = True
+        related_work_lookup_skipped = True
+        historical_pr_branches = set()
+        resolved_related_branches = set()
+    else:
+        historical_pr_branches = _branches_with_pr_history(
+            repo_root,
+            args.github_repo,
+            [branch.branch for branch in hydrated_branches if branch.branch not in open_pr_heads],
+        )
+        resolved_related_branches = _branches_with_resolved_related_work(
+            repo_root,
+            args.github_repo,
+            [branch for branch in hydrated_branches if branch.branch not in historical_pr_branches],
+        )
     decisions = select_publishable_branches(
         hydrated_branches,
         worktrees,
@@ -1896,6 +1904,8 @@ def main(argv: list[str] | None = None) -> int:
         "open_pr_lookup": {
             key: value for key, value in open_pr_lookup.items() if key != "cache_queue_health"
         },
+        "historical_pr_lookup_skipped": historical_pr_lookup_skipped,
+        "related_work_lookup_skipped": related_work_lookup_skipped,
         "automation_guardrails": asdict(guardrail_report),
         "github_health": github_health.to_dict(),
         "decisions": [asdict(decision) for decision in decisions],
@@ -1908,6 +1918,9 @@ def main(argv: list[str] | None = None) -> int:
         elif all_open_prs_unhealthy and not args.allow_unhealthy_queue_publish:
             payload["published"] = []
             payload["publish_paused_reason"] = "open_pr_queue_unhealthy"
+        elif open_pr_lookup_degraded:
+            payload["published"] = []
+            payload["publish_paused_reason"] = "open_pr_lookup_degraded"
         else:
             if all_open_prs_unhealthy and args.allow_unhealthy_queue_publish:
                 payload["publish_override_reason"] = "allow_unhealthy_queue_publish"

--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -933,6 +933,9 @@ def _open_codex_prs_with_cache_fallback(
             except RuntimeError as rest_exc:
                 cache_meta["rest_error"] = str(rest_exc)
                 raise OpenCodexPrLookupError(live_error, cache_meta) from exc
+            for item in rest_prs:
+                item.setdefault("lookup_degraded", True)
+                item.setdefault("lookup_source", "rest")
             lookup_meta = {
                 "source": "rest",
                 "status": "ok",
@@ -1009,6 +1012,9 @@ def _unhealthy_check_rollup_items(check_rollup: Any) -> list[dict[str, Any]]:
 
 
 def _open_codex_pr_unhealthy_reasons(item: dict[str, Any]) -> list[str]:
+    if item.get("lookup_degraded") is True:
+        return ["lookup_degraded_queue_health_unknown"]
+
     merge_state = str(item.get("mergeStateStatus") or "UNKNOWN").upper()
     if merge_state == "DIRTY":
         return ["merge_state=DIRTY"]

--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -878,7 +878,12 @@ def _flatten_rest_pages(payload: Any) -> list[dict[str, Any]]:
     return flattened
 
 
-def _open_codex_prs_from_rest(repo_root: Path, repo: str) -> list[dict[str, Any]]:
+def _open_codex_prs_from_rest(
+    repo_root: Path,
+    repo: str,
+    *,
+    meta: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
     proc = _run(
         [
             "gh",
@@ -896,15 +901,24 @@ def _open_codex_prs_from_rest(repo_root: Path, repo: str) -> list[dict[str, Any]
     except json.JSONDecodeError as exc:
         raise RuntimeError("REST PR lookup returned invalid JSON") from exc
 
+    flattened = _flatten_rest_pages(payload)
+    if meta is not None:
+        meta["rest_payload_count"] = len(flattened)
     prs: list[dict[str, Any]] = []
-    for item in _flatten_rest_pages(payload):
+    skipped_missing_head = 0
+    skipped_missing_head_ref = 0
+    skipped_non_codex_head = 0
+    for item in flattened:
         head = item.get("head")
         if not isinstance(head, Mapping):
+            skipped_missing_head += 1
             continue
         branch = head.get("ref")
         if not isinstance(branch, str):
+            skipped_missing_head_ref += 1
             continue
         if not branch.startswith(CODEX_BRANCH_PREFIX):
+            skipped_non_codex_head += 1
             continue
         prs.append(
             {
@@ -918,6 +932,13 @@ def _open_codex_prs_from_rest(repo_root: Path, repo: str) -> list[dict[str, Any]
                 "lookup_degraded": True,
                 "lookup_source": "rest",
             }
+        )
+    if meta is not None:
+        meta["rest_skipped_missing_head_count"] = skipped_missing_head
+        meta["rest_skipped_missing_head_ref_count"] = skipped_missing_head_ref
+        meta["rest_skipped_non_codex_head_count"] = skipped_non_codex_head
+        meta["rest_skipped_total_count"] = (
+            skipped_missing_head + skipped_missing_head_ref + skipped_non_codex_head
         )
     return prs
 
@@ -936,7 +957,8 @@ def _open_codex_prs_with_cache_fallback(
         cached_prs, cache_meta = _open_codex_prs_from_status_cache(repo_root, repo)
         if cached_prs is None:
             try:
-                rest_prs = _open_codex_prs_from_rest(repo_root, repo)
+                rest_meta: dict[str, Any] = {}
+                rest_prs = _open_codex_prs_from_rest(repo_root, repo, meta=rest_meta)
             except RuntimeError as rest_exc:
                 cache_meta["rest_error"] = str(rest_exc)
                 raise OpenCodexPrLookupError(live_error, cache_meta) from exc
@@ -951,6 +973,7 @@ def _open_codex_prs_with_cache_fallback(
                 "rest_result_count": len(rest_prs),
             }
             lookup_meta.update(cache_meta)
+            lookup_meta.update(rest_meta)
             return rest_prs, lookup_meta
         lookup_meta = {
             "source": "cache",
@@ -1783,23 +1806,27 @@ def main(argv: list[str] | None = None) -> int:
         item["headRefName"] for item in open_codex_prs if isinstance(item.get("headRefName"), str)
     }
     open_pr_lookup_degraded = open_pr_lookup.get("lookup_degraded") is True
-    duplicate_open_pr_patch_lookup = _duplicate_open_pr_patch_branches(
-        repo_root,
-        args.base,
-        hydrated_branches,
-        open_codex_prs,
-    )
+    duplicate_open_pr_patch_lookup_skipped = False
     historical_pr_lookup_skipped = False
     related_work_lookup_skipped = False
     if open_pr_lookup_degraded:
         # A degraded open-PR lookup means GraphQL-backed follow-up searches may
-        # still be unavailable. Keep read visibility, but do not run further
-        # networked dedupe searches or publish from an incomplete queue view.
+        # still be unavailable and the REST snapshot may be incomplete. Keep
+        # read visibility, but do not run further dedupe searches or publish
+        # from an incomplete queue view.
+        duplicate_open_pr_patch_lookup_skipped = True
+        duplicate_open_pr_patch_lookup = set()
         historical_pr_lookup_skipped = True
         related_work_lookup_skipped = True
         historical_pr_branches = set()
         resolved_related_branches = set()
     else:
+        duplicate_open_pr_patch_lookup = _duplicate_open_pr_patch_branches(
+            repo_root,
+            args.base,
+            hydrated_branches,
+            open_codex_prs,
+        )
         historical_pr_branches = _branches_with_pr_history(
             repo_root,
             args.github_repo,
@@ -1921,6 +1948,7 @@ def main(argv: list[str] | None = None) -> int:
         "open_pr_lookup": {
             key: value for key, value in open_pr_lookup.items() if key != "cache_queue_health"
         },
+        "duplicate_open_pr_patch_lookup_skipped": duplicate_open_pr_patch_lookup_skipped,
         "historical_pr_lookup_skipped": historical_pr_lookup_skipped,
         "related_work_lookup_skipped": related_work_lookup_skipped,
         "automation_guardrails": asdict(guardrail_report),
@@ -1954,6 +1982,8 @@ def main(argv: list[str] | None = None) -> int:
                 draft=args.draft,
             )
             payload["published"] = published
+    elif open_pr_lookup_degraded and open_pr_lookup_degraded_publishable_decision_count:
+        payload["publish_paused_reason"] = "open_pr_lookup_degraded"
 
     if args.summary_only:
         payload = summary_only_payload(payload)
@@ -1975,8 +2005,7 @@ def main(argv: list[str] | None = None) -> int:
                         print(f"  - {item['branch']} -> PR #{item['pr_number']}")
 
     if (
-        args.apply
-        and payload.get("publish_paused_reason") == "open_pr_lookup_degraded"
+        payload.get("publish_paused_reason") == "open_pr_lookup_degraded"
         and open_pr_lookup_degraded_publishable_decision_count
     ):
         return 1

--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -1828,6 +1828,14 @@ def main(argv: list[str] | None = None) -> int:
         superseded_outbox_branches=superseded_outbox_lookup,
         duplicate_open_pr_patch_branches=duplicate_open_pr_patch_lookup,
     )
+    open_pr_lookup_degraded_publishable_decision_count = 0
+    if open_pr_lookup_degraded:
+        open_pr_lookup_degraded_publishable_decision_count = sum(
+            1 for decision in decisions if decision.eligible
+        )
+        open_pr_lookup["publishable_decision_count"] = (
+            open_pr_lookup_degraded_publishable_decision_count
+        )
     if open_pr_lookup_degraded:
         decisions = _mark_github_unavailable(
             decisions,
@@ -1966,7 +1974,11 @@ def main(argv: list[str] | None = None) -> int:
                     else:
                         print(f"  - {item['branch']} -> PR #{item['pr_number']}")
 
-    if args.apply and payload.get("publish_paused_reason") == "open_pr_lookup_degraded":
+    if (
+        args.apply
+        and payload.get("publish_paused_reason") == "open_pr_lookup_degraded"
+        and open_pr_lookup_degraded_publishable_decision_count
+    ):
         return 1
     return 0
 

--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -1277,7 +1277,11 @@ def select_publishable_branches(
     return decisions
 
 
-def _mark_github_unavailable(decisions: list[PublishDecision]) -> list[PublishDecision]:
+def _mark_github_unavailable(
+    decisions: list[PublishDecision],
+    *,
+    reason: str = "github_unavailable",
+) -> list[PublishDecision]:
     unavailable: list[PublishDecision] = []
     for decision in decisions:
         if not decision.eligible:
@@ -1287,7 +1291,7 @@ def _mark_github_unavailable(decisions: list[PublishDecision]) -> list[PublishDe
             PublishDecision(
                 branch=decision.branch,
                 eligible=False,
-                reason="github_unavailable",
+                reason=reason,
                 subject=decision.subject,
                 head_sha=decision.head_sha,
                 unique_commit_count=decision.unique_commit_count,
@@ -1824,6 +1828,11 @@ def main(argv: list[str] | None = None) -> int:
         superseded_outbox_branches=superseded_outbox_lookup,
         duplicate_open_pr_patch_branches=duplicate_open_pr_patch_lookup,
     )
+    if open_pr_lookup_degraded:
+        decisions = _mark_github_unavailable(
+            decisions,
+            reason="open_pr_lookup_degraded",
+        )
     merge_state_counts: dict[str, int] = {}
     unhealthy_open_prs: list[dict[str, Any]] = []
     for item in open_codex_prs:

--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -945,7 +945,7 @@ def _open_codex_prs_with_cache_fallback(
                 item.setdefault("lookup_source", "rest")
             lookup_meta = {
                 "source": "rest",
-                "status": "ok",
+                "status": "degraded",
                 "fallback_error": live_error,
                 "lookup_degraded": True,
                 "rest_result_count": len(rest_prs),
@@ -1924,12 +1924,12 @@ def main(argv: list[str] | None = None) -> int:
         if not guardrail_report.ok:
             payload["published"] = []
             payload["publish_paused_reason"] = "automation_guardrail"
-        elif all_open_prs_unhealthy and not args.allow_unhealthy_queue_publish:
-            payload["published"] = []
-            payload["publish_paused_reason"] = "open_pr_queue_unhealthy"
         elif open_pr_lookup_degraded:
             payload["published"] = []
             payload["publish_paused_reason"] = "open_pr_lookup_degraded"
+        elif all_open_prs_unhealthy and not args.allow_unhealthy_queue_publish:
+            payload["published"] = []
+            payload["publish_paused_reason"] = "open_pr_queue_unhealthy"
         else:
             if all_open_prs_unhealthy and args.allow_unhealthy_queue_publish:
                 payload["publish_override_reason"] = "allow_unhealthy_queue_publish"
@@ -1966,6 +1966,8 @@ def main(argv: list[str] | None = None) -> int:
                     else:
                         print(f"  - {item['branch']} -> PR #{item['pr_number']}")
 
+    if args.apply and payload.get("publish_paused_reason") == "open_pr_lookup_degraded":
+        return 1
     return 0
 
 

--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -865,7 +865,7 @@ def _open_codex_prs_from_status_cache(
 
 def _flatten_rest_pages(payload: Any) -> list[dict[str, Any]]:
     if not isinstance(payload, list):
-        return []
+        raise RuntimeError("REST PR lookup returned unexpected JSON shape")
     if payload and all(isinstance(item, list) for item in payload):
         return [
             pr for page in payload if isinstance(page, list) for pr in page if isinstance(pr, dict)

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -732,7 +732,7 @@ def test_open_codex_prs_from_rest_rejects_unexpected_json_shape(
         raise AssertionError("expected REST shape failure")
 
 
-def test_open_codex_prs_from_rest_rejects_missing_head_metadata(
+def test_open_codex_prs_from_rest_skips_missing_head_metadata(
     monkeypatch: Any, tmp_path: Path
 ) -> None:
     monkeypatch.setattr(
@@ -746,12 +746,7 @@ def test_open_codex_prs_from_rest_rejects_missing_head_metadata(
         ),
     )
 
-    try:
-        mod._open_codex_prs_from_rest(tmp_path, "synaptent/aragora")
-    except RuntimeError as exc:
-        assert "missing head metadata for PR #7001" in str(exc)
-    else:  # pragma: no cover - assertion clarity
-        raise AssertionError("expected malformed REST PR failure")
+    assert mod._open_codex_prs_from_rest(tmp_path, "synaptent/aragora") == []
 
 
 def test_open_codex_prs_falls_back_to_rest_when_graphql_and_cache_fail(
@@ -801,6 +796,48 @@ def test_rest_fallback_prs_are_unhealthy_for_queue_health() -> None:
             "lookup_degraded": True,
         }
     ) == ["lookup_degraded_queue_health_unknown"]
+
+
+def test_rest_fallback_skips_malformed_pr_entries(monkeypatch: Any, tmp_path: Path) -> None:
+    payload = [
+        [
+            {"number": 1, "head": None},
+            {"number": 2, "head": {"ref": None}},
+            {"number": 3, "head": {"ref": "feature/not-codex"}},
+            {
+                "number": 4,
+                "title": "valid codex PR",
+                "draft": False,
+                "mergeable_state": "clean",
+                "head": {"ref": "codex/valid"},
+            },
+        ]
+    ]
+
+    monkeypatch.setattr(
+        mod,
+        "_run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args=args[0],
+            returncode=0,
+            stdout=json.dumps(payload),
+            stderr="",
+        ),
+    )
+
+    assert mod._open_codex_prs_from_rest(tmp_path, "synaptent/aragora") == [
+        {
+            "number": 4,
+            "title": "valid codex PR",
+            "headRefName": "codex/valid",
+            "isDraft": False,
+            "mergeStateStatus": "CLEAN",
+            "reviewDecision": None,
+            "statusCheckRollup": [],
+            "lookup_degraded": True,
+            "lookup_source": "rest",
+        }
+    ]
 
 
 def test_open_codex_prs_reports_rest_error_when_all_lookups_fail(
@@ -1800,6 +1837,95 @@ def test_main_pauses_apply_when_rest_fallback_returns_no_codex_prs(
         "lookup_degraded_queue_health_unknown"
     ]
     assert payload["publish_paused_reason"] == "open_pr_queue_unhealthy"
+
+
+def test_main_degraded_rest_lookup_blocks_override_and_skips_history_search(
+    monkeypatch: Any, tmp_path: Path, capsys: Any
+) -> None:
+    branch = BranchSnapshot(
+        branch="codex/rest-empty",
+        upstream=None,
+        head_sha="abc1234",
+        committed_at=datetime.now(UTC),
+        subject="rest empty branch",
+        unique_commit_count=1,
+    )
+
+    monkeypatch.setattr(mod, "_repo_root", lambda path: tmp_path)
+    monkeypatch.setattr(mod, "_local_codex_branches", lambda repo_root: [branch])
+    monkeypatch.setattr(mod, "_list_worktrees", lambda repo_root, branch_filter=None: [])
+
+    def fail_history(*args: Any, **kwargs: Any) -> set[str]:
+        raise AssertionError("history lookup should be skipped for degraded open-PR lookup")
+
+    monkeypatch.setattr(mod, "_branches_with_pr_history", fail_history)
+    monkeypatch.setattr(mod, "_branches_with_resolved_related_work", fail_history)
+    monkeypatch.setattr(
+        mod,
+        "_open_codex_prs",
+        lambda repo_root, repo: (_ for _ in ()).throw(RuntimeError("GraphQL 504")),
+    )
+    monkeypatch.setattr(
+        mod,
+        "_open_codex_prs_from_status_cache",
+        lambda repo_root, repo: (None, {"cache_reason": "cache_stale"}),
+    )
+    monkeypatch.setattr(mod, "_open_codex_prs_from_rest", lambda repo_root, repo: [])
+    monkeypatch.setattr(mod, "_branch_is_merged", lambda repo_root, base, branch: False)
+    monkeypatch.setattr(
+        mod, "_branch_patch_equivalent_to_base", lambda repo_root, base, branch: False
+    )
+    monkeypatch.setattr(mod, "_branch_has_pr_diff", lambda repo_root, base, branch: True)
+    monkeypatch.setattr(mod, "_branch_unique_commit_count", lambda repo_root, base, branch: 1)
+    monkeypatch.setattr(mod, "outbox_superseded_branches", lambda repo_root, outbox_dir=None: set())
+    monkeypatch.setattr(mod, "_branch_remote_head", lambda repo_root, branch: None)
+    monkeypatch.setattr(
+        mod,
+        "evaluate_automation_guardrails",
+        lambda repo_root, open_pr_count, max_open_prs: mod.AutomationGuardrailReport(
+            ok=True,
+            blockers=[],
+            metrics={},
+        ),
+    )
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda repo_root: GitHubCLIHealth(
+            ready=True,
+            auth_ok=True,
+            api_ok=True,
+            mode="ready",
+            error="",
+            repo=str(tmp_path),
+        ),
+    )
+    publish_called = False
+
+    def fake_publish(*args: Any, **kwargs: Any) -> list[dict[str, Any]]:
+        nonlocal publish_called
+        publish_called = True
+        return []
+
+    monkeypatch.setattr(mod, "_publish_decisions", fake_publish)
+
+    exit_code = mod.main(
+        [
+            "--repo",
+            str(tmp_path),
+            "--apply",
+            "--json",
+            "--allow-unhealthy-queue-publish",
+        ]
+    )
+
+    assert exit_code == 0
+    assert publish_called is False
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["open_pr_lookup"]["source"] == "rest"
+    assert payload["historical_pr_lookup_skipped"] is True
+    assert payload["related_work_lookup_skipped"] is True
+    assert payload["publish_paused_reason"] == "open_pr_lookup_degraded"
 
 
 def test_main_reports_open_pr_lookup_failure_when_cache_is_unusable(

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -765,7 +765,7 @@ def test_open_codex_prs_falls_back_to_rest_when_graphql_and_cache_fail(
     monkeypatch.setattr(
         mod,
         "_open_codex_prs_from_rest",
-        lambda repo_root, repo: [{"headRefName": "codex/fix-one"}],
+        lambda repo_root, repo, **kwargs: [{"headRefName": "codex/fix-one"}],
     )
 
     prs, meta = mod._open_codex_prs_with_cache_fallback(tmp_path, "synaptent/aragora")
@@ -825,7 +825,9 @@ def test_rest_fallback_skips_malformed_pr_entries(monkeypatch: Any, tmp_path: Pa
         ),
     )
 
-    assert mod._open_codex_prs_from_rest(tmp_path, "synaptent/aragora") == [
+    meta: dict[str, Any] = {}
+
+    assert mod._open_codex_prs_from_rest(tmp_path, "synaptent/aragora", meta=meta) == [
         {
             "number": 4,
             "title": "valid codex PR",
@@ -838,6 +840,11 @@ def test_rest_fallback_skips_malformed_pr_entries(monkeypatch: Any, tmp_path: Pa
             "lookup_source": "rest",
         }
     ]
+    assert meta["rest_payload_count"] == 4
+    assert meta["rest_skipped_missing_head_count"] == 1
+    assert meta["rest_skipped_missing_head_ref_count"] == 1
+    assert meta["rest_skipped_non_codex_head_count"] == 1
+    assert meta["rest_skipped_total_count"] == 3
 
 
 def test_open_codex_prs_reports_rest_error_when_all_lookups_fail(
@@ -856,7 +863,7 @@ def test_open_codex_prs_reports_rest_error_when_all_lookups_fail(
     monkeypatch.setattr(
         mod,
         "_open_codex_prs_from_rest",
-        lambda repo_root, repo: (_ for _ in ()).throw(RuntimeError("REST 502")),
+        lambda repo_root, repo, **kwargs: (_ for _ in ()).throw(RuntimeError("REST 502")),
     )
 
     try:
@@ -1601,7 +1608,7 @@ def test_main_falls_back_to_cached_open_pr_heads_when_live_listing_504s(
     monkeypatch.setattr(
         mod,
         "_open_codex_prs_from_rest",
-        lambda repo_root, repo: (_ for _ in ()).throw(RuntimeError("REST 502")),
+        lambda repo_root, repo, **kwargs: (_ for _ in ()).throw(RuntimeError("REST 502")),
     )
     monkeypatch.setattr(mod, "_branch_is_merged", lambda repo_root, base, branch: False)
     monkeypatch.setattr(
@@ -1668,7 +1675,7 @@ def test_main_falls_back_to_rest_but_pauses_apply_for_unknown_queue_health(
     monkeypatch.setattr(
         mod,
         "_open_codex_prs_from_rest",
-        lambda repo_root, repo: [
+        lambda repo_root, repo, **kwargs: [
             {
                 "number": 9001,
                 "title": "REST open branch",
@@ -1784,7 +1791,7 @@ def test_main_pauses_apply_when_rest_fallback_returns_no_codex_prs(
         "_open_codex_prs_from_status_cache",
         lambda repo_root, repo: (None, {"cache_reason": "cache_stale"}),
     )
-    monkeypatch.setattr(mod, "_open_codex_prs_from_rest", lambda repo_root, repo: [])
+    monkeypatch.setattr(mod, "_open_codex_prs_from_rest", lambda repo_root, repo, **kwargs: [])
     monkeypatch.setattr(mod, "_branch_is_merged", lambda repo_root, base, branch: False)
     monkeypatch.setattr(
         mod, "_branch_patch_equivalent_to_base", lambda repo_root, base, branch: False
@@ -1860,6 +1867,10 @@ def test_main_degraded_rest_lookup_blocks_override_and_skips_history_search(
     def fail_history(*args: Any, **kwargs: Any) -> set[str]:
         raise AssertionError("history lookup should be skipped for degraded open-PR lookup")
 
+    def fail_duplicate(*args: Any, **kwargs: Any) -> set[str]:
+        raise AssertionError("duplicate lookup should be skipped for degraded open-PR lookup")
+
+    monkeypatch.setattr(mod, "_duplicate_open_pr_patch_branches", fail_duplicate)
     monkeypatch.setattr(mod, "_branches_with_pr_history", fail_history)
     monkeypatch.setattr(mod, "_branches_with_resolved_related_work", fail_history)
     monkeypatch.setattr(
@@ -1872,7 +1883,7 @@ def test_main_degraded_rest_lookup_blocks_override_and_skips_history_search(
         "_open_codex_prs_from_status_cache",
         lambda repo_root, repo: (None, {"cache_reason": "cache_stale"}),
     )
-    monkeypatch.setattr(mod, "_open_codex_prs_from_rest", lambda repo_root, repo: [])
+    monkeypatch.setattr(mod, "_open_codex_prs_from_rest", lambda repo_root, repo, **kwargs: [])
     monkeypatch.setattr(mod, "_branch_is_merged", lambda repo_root, base, branch: False)
     monkeypatch.setattr(
         mod, "_branch_patch_equivalent_to_base", lambda repo_root, base, branch: False
@@ -1926,9 +1937,84 @@ def test_main_degraded_rest_lookup_blocks_override_and_skips_history_search(
     payload = json.loads(capsys.readouterr().out)
     assert payload["open_pr_lookup"]["source"] == "rest"
     assert payload["open_pr_lookup"]["publishable_decision_count"] == 1
+    assert payload["duplicate_open_pr_patch_lookup_skipped"] is True
     assert payload["historical_pr_lookup_skipped"] is True
     assert payload["related_work_lookup_skipped"] is True
     assert payload["decisions"][0]["eligible"] is False
+    assert payload["decisions"][0]["reason"] == "open_pr_lookup_degraded"
+    assert payload["publish_paused_reason"] == "open_pr_lookup_degraded"
+
+
+def test_main_degraded_rest_lookup_dry_run_exits_nonzero_when_publishable_work_exists(
+    monkeypatch: Any, tmp_path: Path, capsys: Any
+) -> None:
+    branch = BranchSnapshot(
+        branch="codex/rest-empty",
+        upstream=None,
+        head_sha="abc1234",
+        committed_at=datetime.now(UTC),
+        subject="rest empty branch",
+        unique_commit_count=1,
+    )
+
+    monkeypatch.setattr(mod, "_repo_root", lambda path: tmp_path)
+    monkeypatch.setattr(mod, "_local_codex_branches", lambda repo_root: [branch])
+    monkeypatch.setattr(mod, "_list_worktrees", lambda repo_root, branch_filter=None: [])
+
+    def fail_degraded_lookup(*args: Any, **kwargs: Any) -> set[str]:
+        raise AssertionError("degraded mode should not run follow-up GitHub dedupe lookups")
+
+    monkeypatch.setattr(mod, "_duplicate_open_pr_patch_branches", fail_degraded_lookup)
+    monkeypatch.setattr(mod, "_branches_with_pr_history", fail_degraded_lookup)
+    monkeypatch.setattr(mod, "_branches_with_resolved_related_work", fail_degraded_lookup)
+    monkeypatch.setattr(
+        mod,
+        "_open_codex_prs",
+        lambda repo_root, repo: (_ for _ in ()).throw(RuntimeError("GraphQL 504")),
+    )
+    monkeypatch.setattr(
+        mod,
+        "_open_codex_prs_from_status_cache",
+        lambda repo_root, repo: (None, {"cache_reason": "cache_stale"}),
+    )
+    monkeypatch.setattr(mod, "_open_codex_prs_from_rest", lambda repo_root, repo, **kwargs: [])
+    monkeypatch.setattr(mod, "_branch_is_merged", lambda repo_root, base, branch: False)
+    monkeypatch.setattr(
+        mod, "_branch_patch_equivalent_to_base", lambda repo_root, base, branch: False
+    )
+    monkeypatch.setattr(mod, "_branch_has_pr_diff", lambda repo_root, base, branch: True)
+    monkeypatch.setattr(mod, "_branch_unique_commit_count", lambda repo_root, base, branch: 1)
+    monkeypatch.setattr(mod, "outbox_superseded_branches", lambda repo_root, outbox_dir=None: set())
+    monkeypatch.setattr(mod, "_branch_remote_head", lambda repo_root, branch: None)
+    monkeypatch.setattr(
+        mod,
+        "evaluate_automation_guardrails",
+        lambda repo_root, open_pr_count, max_open_prs: mod.AutomationGuardrailReport(
+            ok=True,
+            blockers=[],
+            metrics={},
+        ),
+    )
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda repo_root: GitHubCLIHealth(
+            ready=True,
+            auth_ok=True,
+            api_ok=True,
+            mode="ready",
+            error="",
+            repo=str(tmp_path),
+        ),
+    )
+
+    exit_code = mod.main(["--repo", str(tmp_path), "--json"])
+
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["open_pr_lookup"]["source"] == "rest"
+    assert payload["open_pr_lookup"]["publishable_decision_count"] == 1
+    assert payload["duplicate_open_pr_patch_lookup_skipped"] is True
     assert payload["decisions"][0]["reason"] == "open_pr_lookup_degraded"
     assert payload["publish_paused_reason"] == "open_pr_lookup_degraded"
 
@@ -1956,7 +2042,7 @@ def test_main_reports_open_pr_lookup_failure_when_cache_is_unusable(
     monkeypatch.setattr(
         mod,
         "_open_codex_prs_from_rest",
-        lambda repo_root, repo: (_ for _ in ()).throw(RuntimeError("REST 502")),
+        lambda repo_root, repo, **kwargs: (_ for _ in ()).throw(RuntimeError("REST 502")),
     )
     monkeypatch.setattr(mod, "_branch_is_merged", lambda repo_root, base, branch: False)
     monkeypatch.setattr(

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -778,7 +778,7 @@ def test_open_codex_prs_falls_back_to_rest_when_graphql_and_cache_fail(
         }
     ]
     assert meta["source"] == "rest"
-    assert meta["status"] == "ok"
+    assert meta["status"] == "degraded"
     assert meta["fallback_error"] == "GraphQL 504"
     assert meta["cache_reason"] == "cache_stale"
     assert meta["lookup_degraded"] is True
@@ -1733,7 +1733,7 @@ def test_main_falls_back_to_rest_but_pauses_apply_for_unknown_queue_health(
 
     exit_code = mod.main(["--repo", str(tmp_path), "--apply", "--json"])
 
-    assert exit_code == 0
+    assert exit_code == 1
     assert publish_called is False
     payload = json.loads(capsys.readouterr().out)
     assert payload["open_pr_lookup"]["source"] == "rest"
@@ -1744,7 +1744,7 @@ def test_main_falls_back_to_rest_but_pauses_apply_for_unknown_queue_health(
     assert payload["queue_health"]["unhealthy_open_prs"][0]["reasons"] == [
         "lookup_degraded_queue_health_unknown"
     ]
-    assert payload["publish_paused_reason"] == "open_pr_queue_unhealthy"
+    assert payload["publish_paused_reason"] == "open_pr_lookup_degraded"
 
 
 def test_main_pauses_apply_when_rest_fallback_returns_no_codex_prs(
@@ -1824,7 +1824,7 @@ def test_main_pauses_apply_when_rest_fallback_returns_no_codex_prs(
 
     exit_code = mod.main(["--repo", str(tmp_path), "--apply", "--json"])
 
-    assert exit_code == 0
+    assert exit_code == 1
     assert publish_called is False
     payload = json.loads(capsys.readouterr().out)
     assert payload["open_pr_lookup"]["source"] == "rest"
@@ -1836,7 +1836,7 @@ def test_main_pauses_apply_when_rest_fallback_returns_no_codex_prs(
     assert payload["queue_health"]["unhealthy_open_prs"][0]["reasons"] == [
         "lookup_degraded_queue_health_unknown"
     ]
-    assert payload["publish_paused_reason"] == "open_pr_queue_unhealthy"
+    assert payload["publish_paused_reason"] == "open_pr_lookup_degraded"
 
 
 def test_main_degraded_rest_lookup_blocks_override_and_skips_history_search(
@@ -1919,7 +1919,7 @@ def test_main_degraded_rest_lookup_blocks_override_and_skips_history_search(
         ]
     )
 
-    assert exit_code == 0
+    assert exit_code == 1
     assert publish_called is False
     payload = json.loads(capsys.readouterr().out)
     assert payload["open_pr_lookup"]["source"] == "rest"

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -63,6 +63,18 @@ def _worktree(
     )
 
 
+def _allow_automation_guardrails(monkeypatch: Any) -> None:
+    monkeypatch.setattr(
+        mod,
+        "evaluate_automation_guardrails",
+        lambda repo_root, open_pr_count, max_open_prs: mod.AutomationGuardrailReport(
+            ok=True,
+            blockers=[],
+            metrics={},
+        ),
+    )
+
+
 def test_duplicate_patch_branches_skips_older_candidate(tmp_path: Path) -> None:
     _git(tmp_path, "init", "-b", "main")
     _git(tmp_path, "config", "user.email", "codex@example.invalid")
@@ -1264,6 +1276,7 @@ def test_main_pauses_apply_when_open_codex_queue_is_unhealthy(
         mod, "_branch_patch_equivalent_to_base", lambda repo_root, base, branch: False
     )
     monkeypatch.setattr(mod, "_branch_remote_head", lambda repo_root, branch: None)
+    _allow_automation_guardrails(monkeypatch)
     monkeypatch.setattr(
         mod,
         "check_github_cli_health",
@@ -1331,6 +1344,7 @@ def test_main_can_override_unhealthy_queue_pause_for_preflighted_branch(
     monkeypatch.setattr(mod, "_branch_unique_commit_count", lambda repo_root, base, branch: 1)
     monkeypatch.setattr(mod, "outbox_superseded_branches", lambda repo_root, outbox_dir=None: set())
     monkeypatch.setattr(mod, "_branch_remote_head", lambda repo_root, branch: None)
+    _allow_automation_guardrails(monkeypatch)
     monkeypatch.setattr(
         mod,
         "check_github_cli_health",
@@ -1410,6 +1424,7 @@ def test_main_does_not_pause_for_green_review_required_codex_pr(
         mod, "_branch_patch_equivalent_to_base", lambda repo_root, base, branch: False
     )
     monkeypatch.setattr(mod, "_branch_remote_head", lambda repo_root, branch: None)
+    _allow_automation_guardrails(monkeypatch)
     monkeypatch.setattr(
         mod,
         "check_github_cli_health",

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -682,11 +682,30 @@ def test_open_codex_prs_falls_back_to_rest_when_graphql_and_cache_fail(
 
     prs, meta = mod._open_codex_prs_with_cache_fallback(tmp_path, "synaptent/aragora")
 
-    assert prs == [{"headRefName": "codex/fix-one"}]
+    assert prs == [
+        {
+            "headRefName": "codex/fix-one",
+            "lookup_degraded": True,
+            "lookup_source": "rest",
+        }
+    ]
     assert meta["source"] == "rest"
     assert meta["status"] == "ok"
     assert meta["fallback_error"] == "GraphQL 504"
     assert meta["cache_reason"] == "cache_stale"
+    assert prs[0]["lookup_degraded"] is True
+
+
+def test_rest_fallback_prs_are_unhealthy_for_queue_health() -> None:
+    assert mod._open_codex_pr_unhealthy_reasons(
+        {
+            "headRefName": "codex/rest-only",
+            "mergeStateStatus": "UNKNOWN",
+            "reviewDecision": None,
+            "statusCheckRollup": [],
+            "lookup_degraded": True,
+        }
+    ) == ["lookup_degraded_queue_health_unknown"]
 
 
 def test_open_codex_prs_reports_rest_error_when_all_lookups_fail(
@@ -1478,6 +1497,119 @@ def test_main_falls_back_to_cached_open_pr_heads_when_live_listing_504s(
     assert '"fallback_error": "HTTP 504"' in out
     assert '"open_pr_exists"' in out
     assert '"open_pr_count": 1' in out
+
+
+def test_main_falls_back_to_rest_but_pauses_apply_for_unknown_queue_health(
+    monkeypatch: Any, tmp_path: Path, capsys: Any
+) -> None:
+    branch = BranchSnapshot(
+        branch="codex/rest-open",
+        upstream=None,
+        head_sha="abc1234",
+        committed_at=datetime.now(UTC),
+        subject="rest open branch",
+        unique_commit_count=1,
+    )
+
+    monkeypatch.setattr(mod, "_repo_root", lambda path: tmp_path)
+    monkeypatch.setattr(mod, "_local_codex_branches", lambda repo_root: [branch])
+    monkeypatch.setattr(mod, "_list_worktrees", lambda repo_root, branch_filter=None: [])
+    monkeypatch.setattr(mod, "_branches_with_pr_history", lambda repo_root, repo, branches: set())
+    monkeypatch.setattr(
+        mod,
+        "_branches_with_resolved_related_work",
+        lambda repo_root, repo, branches: set(),
+    )
+    monkeypatch.setattr(
+        mod,
+        "_duplicate_open_pr_patch_branches",
+        lambda repo_root, base, branches, open_codex_prs: set(),
+    )
+    monkeypatch.setattr(
+        mod,
+        "_open_codex_prs",
+        lambda repo_root, repo: (_ for _ in ()).throw(RuntimeError("GraphQL 504")),
+    )
+    monkeypatch.setattr(
+        mod,
+        "_open_codex_prs_from_rest",
+        lambda repo_root, repo: [
+            {
+                "number": 9001,
+                "title": "REST open branch",
+                "headRefName": "codex/rest-open",
+                "isDraft": False,
+                "mergeStateStatus": "UNKNOWN",
+                "reviewDecision": None,
+                "statusCheckRollup": [],
+                "lookup_degraded": True,
+                "lookup_source": "rest",
+            },
+            {
+                "number": 9002,
+                "title": "REST sibling branch",
+                "headRefName": "codex/rest-sibling",
+                "isDraft": False,
+                "mergeStateStatus": "UNKNOWN",
+                "reviewDecision": None,
+                "statusCheckRollup": [],
+                "lookup_degraded": True,
+                "lookup_source": "rest",
+            },
+        ],
+    )
+    monkeypatch.setattr(mod, "_branch_is_merged", lambda repo_root, base, branch: False)
+    monkeypatch.setattr(
+        mod, "_branch_patch_equivalent_to_base", lambda repo_root, base, branch: False
+    )
+    monkeypatch.setattr(mod, "_branch_has_pr_diff", lambda repo_root, base, branch: True)
+    monkeypatch.setattr(mod, "_branch_unique_commit_count", lambda repo_root, base, branch: 1)
+    monkeypatch.setattr(mod, "outbox_superseded_branches", lambda repo_root, outbox_dir=None: set())
+    monkeypatch.setattr(mod, "_branch_remote_head", lambda repo_root, branch: None)
+    monkeypatch.setattr(
+        mod,
+        "evaluate_automation_guardrails",
+        lambda repo_root, open_pr_count, max_open_prs: mod.AutomationGuardrailReport(
+            ok=True,
+            blockers=[],
+            metrics={},
+        ),
+    )
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda repo_root: GitHubCLIHealth(
+            ready=True,
+            auth_ok=True,
+            api_ok=True,
+            mode="ready",
+            error="",
+            repo=str(tmp_path),
+        ),
+    )
+    publish_called = False
+
+    def fake_publish(*args: Any, **kwargs: Any) -> list[dict[str, Any]]:
+        nonlocal publish_called
+        publish_called = True
+        return []
+
+    monkeypatch.setattr(mod, "_publish_decisions", fake_publish)
+
+    exit_code = mod.main(["--repo", str(tmp_path), "--apply", "--json"])
+
+    assert exit_code == 0
+    assert publish_called is False
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["open_pr_lookup"]["source"] == "rest"
+    assert payload["open_pr_lookup"]["fallback_error"] == "GraphQL 504"
+    assert payload["decisions"][0]["reason"] == "open_pr_exists"
+    assert payload["queue_health"]["unhealthy_open_pr_count"] == 2
+    assert payload["queue_health"]["all_open_prs_unhealthy"] is True
+    assert payload["queue_health"]["unhealthy_open_prs"][0]["reasons"] == [
+        "lookup_degraded_queue_health_unknown"
+    ]
+    assert payload["publish_paused_reason"] == "open_pr_queue_unhealthy"
 
 
 def test_main_reports_open_pr_lookup_failure_when_cache_is_unusable(

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -661,6 +661,28 @@ def test_open_codex_prs_from_rest_filters_codex_branches(monkeypatch: Any, tmp_p
     assert all(pr["lookup_source"] == "rest" for pr in prs)
 
 
+def test_open_codex_prs_from_rest_rejects_unexpected_json_shape(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        mod,
+        "_run",
+        lambda args, cwd, check=False: subprocess.CompletedProcess(
+            args=args,
+            returncode=0,
+            stdout=json.dumps({"not": "a pull request list"}),
+            stderr="",
+        ),
+    )
+
+    try:
+        mod._open_codex_prs_from_rest(tmp_path, "synaptent/aragora")
+    except RuntimeError as exc:
+        assert "unexpected JSON shape" in str(exc)
+    else:  # pragma: no cover - assertion clarity
+        raise AssertionError("expected REST shape failure")
+
+
 def test_open_codex_prs_falls_back_to_rest_when_graphql_and_cache_fail(
     monkeypatch: Any, tmp_path: Path
 ) -> None:

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -606,6 +606,118 @@ def test_open_pr_heads_counts_only_codex_branches(monkeypatch: Any, tmp_path: Pa
     }
 
 
+def test_open_codex_prs_from_rest_filters_codex_branches(monkeypatch: Any, tmp_path: Path) -> None:
+    payload = json.dumps(
+        [
+            [
+                {
+                    "number": 7001,
+                    "title": "Automation fix",
+                    "head": {"ref": "codex/fix-one"},
+                    "draft": True,
+                    "mergeable_state": "clean",
+                },
+                {
+                    "number": 7002,
+                    "title": "Manual fix",
+                    "head": {"ref": "feature/manual"},
+                    "draft": False,
+                    "mergeable_state": "clean",
+                },
+            ],
+            [
+                {
+                    "number": 7003,
+                    "title": "Dependabot fix",
+                    "head": {"ref": "dependabot/npm/package"},
+                    "draft": False,
+                    "mergeable_state": "clean",
+                },
+                {
+                    "number": 7004,
+                    "title": "Automation repair",
+                    "head": {"ref": "codex/fix-two"},
+                    "draft": False,
+                },
+            ],
+        ]
+    )
+
+    monkeypatch.setattr(
+        mod,
+        "_run",
+        lambda args, cwd, check=False: subprocess.CompletedProcess(
+            args=args, returncode=0, stdout=payload, stderr=""
+        ),
+    )
+
+    prs = mod._open_codex_prs_from_rest(tmp_path, "synaptent/aragora")
+
+    assert [pr["headRefName"] for pr in prs] == ["codex/fix-one", "codex/fix-two"]
+    assert prs[0]["number"] == 7001
+    assert prs[0]["isDraft"] is True
+    assert prs[0]["mergeStateStatus"] == "CLEAN"
+    assert prs[1]["mergeStateStatus"] == "UNKNOWN"
+    assert all(pr["lookup_source"] == "rest" for pr in prs)
+
+
+def test_open_codex_prs_falls_back_to_rest_when_graphql_and_cache_fail(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        mod,
+        "_open_codex_prs",
+        lambda repo_root, repo: (_ for _ in ()).throw(RuntimeError("GraphQL 504")),
+    )
+    monkeypatch.setattr(
+        mod,
+        "_open_codex_prs_from_status_cache",
+        lambda repo_root, repo: (None, {"cache_reason": "cache_stale"}),
+    )
+    monkeypatch.setattr(
+        mod,
+        "_open_codex_prs_from_rest",
+        lambda repo_root, repo: [{"headRefName": "codex/fix-one"}],
+    )
+
+    prs, meta = mod._open_codex_prs_with_cache_fallback(tmp_path, "synaptent/aragora")
+
+    assert prs == [{"headRefName": "codex/fix-one"}]
+    assert meta["source"] == "rest"
+    assert meta["status"] == "ok"
+    assert meta["fallback_error"] == "GraphQL 504"
+    assert meta["cache_reason"] == "cache_stale"
+
+
+def test_open_codex_prs_reports_rest_error_when_all_lookups_fail(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        mod,
+        "_open_codex_prs",
+        lambda repo_root, repo: (_ for _ in ()).throw(RuntimeError("GraphQL 504")),
+    )
+    monkeypatch.setattr(
+        mod,
+        "_open_codex_prs_from_status_cache",
+        lambda repo_root, repo: (None, {"cache_reason": "cache_stale"}),
+    )
+    monkeypatch.setattr(
+        mod,
+        "_open_codex_prs_from_rest",
+        lambda repo_root, repo: (_ for _ in ()).throw(RuntimeError("REST 502")),
+    )
+
+    try:
+        mod._open_codex_prs_with_cache_fallback(tmp_path, "synaptent/aragora")
+    except mod.OpenCodexPrLookupError as exc:
+        assert exc.error == "GraphQL 504"
+        assert exc.cache_meta["cache_reason"] == "cache_stale"
+        assert exc.cache_meta["rest_error"] == "REST 502"
+    else:  # pragma: no cover - assertion helper
+        raise AssertionError("expected OpenCodexPrLookupError")
+
+
 def test_run_uses_env_overrides_for_git_timeout(monkeypatch: Any, tmp_path: Path) -> None:
     recorded: dict[str, Any] = {}
 
@@ -1332,6 +1444,11 @@ def test_main_falls_back_to_cached_open_pr_heads_when_live_listing_504s(
         "_open_codex_prs",
         lambda repo_root, repo: (_ for _ in ()).throw(RuntimeError("HTTP 504")),
     )
+    monkeypatch.setattr(
+        mod,
+        "_open_codex_prs_from_rest",
+        lambda repo_root, repo: (_ for _ in ()).throw(RuntimeError("REST 502")),
+    )
     monkeypatch.setattr(mod, "_branch_is_merged", lambda repo_root, base, branch: False)
     monkeypatch.setattr(
         mod, "_branch_patch_equivalent_to_base", lambda repo_root, base, branch: False
@@ -1383,6 +1500,11 @@ def test_main_reports_open_pr_lookup_failure_when_cache_is_unusable(
         "_open_codex_prs",
         lambda repo_root, repo: (_ for _ in ()).throw(RuntimeError("HTTP 504")),
     )
+    monkeypatch.setattr(
+        mod,
+        "_open_codex_prs_from_rest",
+        lambda repo_root, repo: (_ for _ in ()).throw(RuntimeError("REST 502")),
+    )
     monkeypatch.setattr(mod, "_branch_is_merged", lambda repo_root, base, branch: False)
     monkeypatch.setattr(
         mod, "_branch_patch_equivalent_to_base", lambda repo_root, base, branch: False
@@ -1410,6 +1532,7 @@ def test_main_reports_open_pr_lookup_failure_when_cache_is_unusable(
     assert '"status": "failed"' in out
     assert '"error": "HTTP 504"' in out
     assert '"cache_usable": false' in out
+    assert '"rest_error": "REST 502"' in out
     assert '"decisions": []' in out
 
 

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -673,6 +673,43 @@ def test_open_codex_prs_from_rest_filters_codex_branches(monkeypatch: Any, tmp_p
     assert all(pr["lookup_source"] == "rest" for pr in prs)
 
 
+def test_open_codex_prs_from_rest_flattens_mixed_rest_pages(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    payload = json.dumps(
+        [
+            {
+                "number": 7001,
+                "title": "Flat automation fix",
+                "head": {"ref": "codex/flat-fix"},
+                "draft": False,
+                "mergeable_state": "clean",
+            },
+            [
+                {
+                    "number": 7002,
+                    "title": "Nested automation fix",
+                    "head": {"ref": "codex/nested-fix"},
+                    "draft": True,
+                    "mergeable_state": "blocked",
+                }
+            ],
+        ]
+    )
+
+    monkeypatch.setattr(
+        mod,
+        "_run",
+        lambda args, cwd, check=False: subprocess.CompletedProcess(
+            args=args, returncode=0, stdout=payload, stderr=""
+        ),
+    )
+
+    prs = mod._open_codex_prs_from_rest(tmp_path, "synaptent/aragora")
+
+    assert [pr["headRefName"] for pr in prs] == ["codex/flat-fix", "codex/nested-fix"]
+
+
 def test_open_codex_prs_from_rest_rejects_unexpected_json_shape(
     monkeypatch: Any, tmp_path: Path
 ) -> None:
@@ -693,6 +730,28 @@ def test_open_codex_prs_from_rest_rejects_unexpected_json_shape(
         assert "unexpected JSON shape" in str(exc)
     else:  # pragma: no cover - assertion clarity
         raise AssertionError("expected REST shape failure")
+
+
+def test_open_codex_prs_from_rest_rejects_missing_head_metadata(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        mod,
+        "_run",
+        lambda args, cwd, check=False: subprocess.CompletedProcess(
+            args=args,
+            returncode=0,
+            stdout=json.dumps([[{"number": 7001, "title": "Malformed PR"}]]),
+            stderr="",
+        ),
+    )
+
+    try:
+        mod._open_codex_prs_from_rest(tmp_path, "synaptent/aragora")
+    except RuntimeError as exc:
+        assert "missing head metadata for PR #7001" in str(exc)
+    else:  # pragma: no cover - assertion clarity
+        raise AssertionError("expected malformed REST PR failure")
 
 
 def test_open_codex_prs_falls_back_to_rest_when_graphql_and_cache_fail(
@@ -727,6 +786,8 @@ def test_open_codex_prs_falls_back_to_rest_when_graphql_and_cache_fail(
     assert meta["status"] == "ok"
     assert meta["fallback_error"] == "GraphQL 504"
     assert meta["cache_reason"] == "cache_stale"
+    assert meta["lookup_degraded"] is True
+    assert meta["rest_result_count"] == 1
     assert prs[0]["lookup_degraded"] is True
 
 
@@ -1642,6 +1703,98 @@ def test_main_falls_back_to_rest_but_pauses_apply_for_unknown_queue_health(
     assert payload["open_pr_lookup"]["fallback_error"] == "GraphQL 504"
     assert payload["decisions"][0]["reason"] == "open_pr_exists"
     assert payload["queue_health"]["unhealthy_open_pr_count"] == 2
+    assert payload["queue_health"]["all_open_prs_unhealthy"] is True
+    assert payload["queue_health"]["unhealthy_open_prs"][0]["reasons"] == [
+        "lookup_degraded_queue_health_unknown"
+    ]
+    assert payload["publish_paused_reason"] == "open_pr_queue_unhealthy"
+
+
+def test_main_pauses_apply_when_rest_fallback_returns_no_codex_prs(
+    monkeypatch: Any, tmp_path: Path, capsys: Any
+) -> None:
+    branch = BranchSnapshot(
+        branch="codex/rest-empty",
+        upstream=None,
+        head_sha="abc1234",
+        committed_at=datetime.now(UTC),
+        subject="rest empty branch",
+        unique_commit_count=1,
+    )
+
+    monkeypatch.setattr(mod, "_repo_root", lambda path: tmp_path)
+    monkeypatch.setattr(mod, "_local_codex_branches", lambda repo_root: [branch])
+    monkeypatch.setattr(mod, "_list_worktrees", lambda repo_root, branch_filter=None: [])
+    monkeypatch.setattr(mod, "_branches_with_pr_history", lambda repo_root, repo, branches: set())
+    monkeypatch.setattr(
+        mod,
+        "_branches_with_resolved_related_work",
+        lambda repo_root, repo, branches: set(),
+    )
+    monkeypatch.setattr(
+        mod,
+        "_duplicate_open_pr_patch_branches",
+        lambda repo_root, base, branches, open_codex_prs: set(),
+    )
+    monkeypatch.setattr(
+        mod,
+        "_open_codex_prs",
+        lambda repo_root, repo: (_ for _ in ()).throw(RuntimeError("GraphQL 504")),
+    )
+    monkeypatch.setattr(
+        mod,
+        "_open_codex_prs_from_status_cache",
+        lambda repo_root, repo: (None, {"cache_reason": "cache_stale"}),
+    )
+    monkeypatch.setattr(mod, "_open_codex_prs_from_rest", lambda repo_root, repo: [])
+    monkeypatch.setattr(mod, "_branch_is_merged", lambda repo_root, base, branch: False)
+    monkeypatch.setattr(
+        mod, "_branch_patch_equivalent_to_base", lambda repo_root, base, branch: False
+    )
+    monkeypatch.setattr(mod, "_branch_has_pr_diff", lambda repo_root, base, branch: True)
+    monkeypatch.setattr(mod, "_branch_unique_commit_count", lambda repo_root, base, branch: 1)
+    monkeypatch.setattr(mod, "outbox_superseded_branches", lambda repo_root, outbox_dir=None: set())
+    monkeypatch.setattr(mod, "_branch_remote_head", lambda repo_root, branch: None)
+    monkeypatch.setattr(
+        mod,
+        "evaluate_automation_guardrails",
+        lambda repo_root, open_pr_count, max_open_prs: mod.AutomationGuardrailReport(
+            ok=True,
+            blockers=[],
+            metrics={},
+        ),
+    )
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda repo_root: GitHubCLIHealth(
+            ready=True,
+            auth_ok=True,
+            api_ok=True,
+            mode="ready",
+            error="",
+            repo=str(tmp_path),
+        ),
+    )
+    publish_called = False
+
+    def fake_publish(*args: Any, **kwargs: Any) -> list[dict[str, Any]]:
+        nonlocal publish_called
+        publish_called = True
+        return []
+
+    monkeypatch.setattr(mod, "_publish_decisions", fake_publish)
+
+    exit_code = mod.main(["--repo", str(tmp_path), "--apply", "--json"])
+
+    assert exit_code == 0
+    assert publish_called is False
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["open_pr_lookup"]["source"] == "rest"
+    assert payload["open_pr_lookup"]["lookup_degraded"] is True
+    assert payload["open_pr_lookup"]["rest_result_count"] == 0
+    assert payload["queue_health"]["open_codex_pr_count"] == 0
+    assert payload["queue_health"]["unhealthy_open_pr_count"] == 1
     assert payload["queue_health"]["all_open_prs_unhealthy"] is True
     assert payload["queue_health"]["unhealthy_open_prs"][0]["reasons"] == [
         "lookup_degraded_queue_health_unknown"

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -1925,6 +1925,8 @@ def test_main_degraded_rest_lookup_blocks_override_and_skips_history_search(
     assert payload["open_pr_lookup"]["source"] == "rest"
     assert payload["historical_pr_lookup_skipped"] is True
     assert payload["related_work_lookup_skipped"] is True
+    assert payload["decisions"][0]["eligible"] is False
+    assert payload["decisions"][0]["reason"] == "open_pr_lookup_degraded"
     assert payload["publish_paused_reason"] == "open_pr_lookup_degraded"
 
 

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -1733,11 +1733,12 @@ def test_main_falls_back_to_rest_but_pauses_apply_for_unknown_queue_health(
 
     exit_code = mod.main(["--repo", str(tmp_path), "--apply", "--json"])
 
-    assert exit_code == 1
+    assert exit_code == 0
     assert publish_called is False
     payload = json.loads(capsys.readouterr().out)
     assert payload["open_pr_lookup"]["source"] == "rest"
     assert payload["open_pr_lookup"]["fallback_error"] == "GraphQL 504"
+    assert payload["open_pr_lookup"]["publishable_decision_count"] == 0
     assert payload["decisions"][0]["reason"] == "open_pr_exists"
     assert payload["queue_health"]["unhealthy_open_pr_count"] == 2
     assert payload["queue_health"]["all_open_prs_unhealthy"] is True
@@ -1830,6 +1831,7 @@ def test_main_pauses_apply_when_rest_fallback_returns_no_codex_prs(
     assert payload["open_pr_lookup"]["source"] == "rest"
     assert payload["open_pr_lookup"]["lookup_degraded"] is True
     assert payload["open_pr_lookup"]["rest_result_count"] == 0
+    assert payload["open_pr_lookup"]["publishable_decision_count"] == 1
     assert payload["queue_health"]["open_codex_pr_count"] == 0
     assert payload["queue_health"]["unhealthy_open_pr_count"] == 1
     assert payload["queue_health"]["all_open_prs_unhealthy"] is True
@@ -1923,6 +1925,7 @@ def test_main_degraded_rest_lookup_blocks_override_and_skips_history_search(
     assert publish_called is False
     payload = json.loads(capsys.readouterr().out)
     assert payload["open_pr_lookup"]["source"] == "rest"
+    assert payload["open_pr_lookup"]["publishable_decision_count"] == 1
     assert payload["historical_pr_lookup_skipped"] is True
     assert payload["related_work_lookup_skipped"] is True
     assert payload["decisions"][0]["eligible"] is False


### PR DESCRIPTION
## Summary
- add a REST open-PR listing fallback for codex automation branch publishing when broad GraphQL listing fails and cache is stale
- keep dry-run/default behavior fail-closed when GraphQL, cache, and REST all fail
- preserve open PR caps and duplicate-head detection from live PR head data

## Validation
- ARAGORA_AUTOMATION_MIN_FREE_GIB=0 python3 -m pytest tests/scripts/test_publish_codex_automation_branches.py -q
- pre-commit run --files scripts/publish_codex_automation_branches.py tests/scripts/test_publish_codex_automation_branches.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- live dry-run for codex/agent-bridge-broker-pipe-improver-20260614 now reaches source=rest and reports policy blockers instead of transport failure