### PR TITLE
fix(inventory): classify stale applied worktrees

### DIFF
--- a/scripts/codex_worktree_value_inventory.py
+++ b/scripts/codex_worktree_value_inventory.py
@@ -241,21 +241,32 @@ def _kill_process_tree(proc: subprocess.Popen) -> None:
             pass
 
 
-def run_cmd(args: list[str], cwd: Path, *, timeout: int) -> subprocess.CompletedProcess[str]:
+def run_cmd(
+    args: list[str],
+    cwd: Path,
+    *,
+    timeout: int,
+    env: dict[str, str] | None = None,
+    input_text: str | None = None,
+) -> subprocess.CompletedProcess[str]:
     try:
         proc = subprocess.Popen(
             args,
             cwd=cwd,
             text=True,
-            stdin=subprocess.DEVNULL,
+            stdin=subprocess.PIPE if input_text is not None else subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            env=env,
             start_new_session=True,
         )
     except OSError as exc:
         return subprocess.CompletedProcess(args=args, returncode=124, stdout="", stderr=str(exc))
     try:
-        stdout, stderr = proc.communicate(timeout=timeout)
+        if input_text is None:
+            stdout, stderr = proc.communicate(timeout=timeout)
+        else:
+            stdout, stderr = proc.communicate(input=input_text, timeout=timeout)
     except subprocess.TimeoutExpired:
         _kill_process_tree(proc)
         return subprocess.CompletedProcess(
@@ -431,7 +442,16 @@ def _terminal_path_receipt(payload: dict[str, Any]) -> bool:
     status = str(payload.get("status") or "").strip()
     if status in TERMINAL_RECEIPT_STATUSES:
         return True
-    decision = str(payload.get("decision") or "").strip()
+    decision_value = payload.get("decision")
+    if isinstance(decision_value, dict):
+        decision = str(
+            decision_value.get("outcome")
+            or decision_value.get("status")
+            or decision_value.get("decision")
+            or ""
+        ).strip()
+    else:
+        decision = str(decision_value or payload.get("outcome") or "").strip()
     if decision.startswith(TERMINAL_HARVEST_DECISION_PREFIXES):
         return True
     return False
@@ -677,6 +697,67 @@ def branch_subjects_match_recent_main(
         if commit_subject_matches_recent_main(subject, recent_main_subjects)
     ]
     return len(matched) == len(subjects), matched
+
+
+def branch_patches_present_on_base(
+    repo_path: Path,
+    base: str,
+    rev: str,
+    *,
+    timeout: int,
+) -> tuple[bool, list[str]]:
+    """Return true when every unique non-merge commit patch is already in base.
+
+    Some stale branches contain local commits whose changes were later merged
+    through a different PR/commit, while the stale branch's old tree still
+    differs from current main. Plain tree-diff or `git cherry` checks can leave
+    those as false `unique_unharvested` rows. Use a temporary index loaded with
+    `base` and verify each commit's reverse patch applies there. This is the
+    same safety property as "cherry-pick onto base would be empty", without
+    mutating the candidate worktree.
+    """
+
+    commits_proc = run_git(
+        ["rev-list", "--reverse", "--no-merges", f"{base}..{rev}"],
+        repo_path,
+        timeout=timeout,
+    )
+    if commits_proc.returncode != 0:
+        return False, []
+    commits = [line.strip() for line in commits_proc.stdout.splitlines() if line.strip()]
+    if not commits:
+        return False, []
+
+    fd, index_path = tempfile.mkstemp(prefix="aragora-inventory-index-")
+    os.close(fd)
+    try:
+        env = dict(os.environ)
+        env["GIT_INDEX_FILE"] = index_path
+        read_tree = run_cmd(["git", "read-tree", base], repo_path, timeout=timeout, env=env)
+        if read_tree.returncode != 0:
+            return False, []
+
+        verified: list[str] = []
+        for commit in commits:
+            patch = run_git(["show", "--format=", "--binary", commit], repo_path, timeout=timeout)
+            if patch.returncode != 0 or not patch.stdout.strip():
+                return False, verified
+            reverse_check = run_cmd(
+                ["git", "apply", "--cached", "--reverse", "--check", "--index", "-"],
+                repo_path,
+                timeout=timeout,
+                env=env,
+                input_text=patch.stdout,
+            )
+            if reverse_check.returncode != 0:
+                return False, verified
+            verified.append(commit)
+        return True, verified
+    finally:
+        try:
+            os.unlink(index_path)
+        except FileNotFoundError:
+            pass
 
 
 def prefetch_open_pr_heads(
@@ -987,8 +1068,20 @@ def classify_candidate(
                     )
                     links["smart_merge_matched_subjects"] = matched_subjects
                 else:
-                    classification = "unique_unharvested"
-                    proof.append("branch has unique commits or diff ahead of base")
+                    patches_present, matched_commits = branch_patches_present_on_base(
+                        repo_path,
+                        context.base,
+                        rev or "HEAD",
+                        timeout=context.patch_timeout,
+                    )
+                    git.smart_merge_equivalent_to_base = patches_present
+                    if patches_present:
+                        classification = "patch_equivalent_or_merged"
+                        proof.append("all unique commit patches are already present on base")
+                        links["smart_merge_matched_commits"] = matched_commits
+                    else:
+                        classification = "unique_unharvested"
+                        proof.append("branch has unique commits or diff ahead of base")
             else:
                 classification = "unique_unharvested"
                 proof.append("branch has unique commits or diff ahead of base")
@@ -1513,7 +1606,8 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Reclassify ahead branches as patch_equivalent_or_merged when every "
             "unique commit subject loosely matches a recent main squash-merge "
-            "subject. Default off to preserve legacy inventory behavior."
+            "subject, or when every unique commit patch is already present on "
+            "base. Default off to preserve legacy inventory behavior."
         ),
     )
     parser.add_argument(

--- a/scripts/codex_worktree_value_inventory.py
+++ b/scripts/codex_worktree_value_inventory.py
@@ -1150,9 +1150,11 @@ def classify_candidate(
                     classification = "patch_equivalent_or_merged"
                     proof.append("merging branch into base leaves base tree unchanged")
                     links["smart_merge_merge_tree"] = context.base
+                elif merge_tree_error:
+                    classification = "unique_unharvested"
+                    proof.append("merge-tree did not prove branch is already represented on base")
+                    links["smart_merge_merge_tree_error"] = merge_tree_error
                 else:
-                    if merge_tree_error:
-                        links["smart_merge_merge_tree_error"] = merge_tree_error
                     merge_commits, merge_error = branch_unique_merge_commits(
                         repo_path,
                         context.base,

--- a/scripts/codex_worktree_value_inventory.py
+++ b/scripts/codex_worktree_value_inventory.py
@@ -202,6 +202,7 @@ class InventoryContext:
     smart_merge_detection: bool = False
     smart_merge_main_subjects: list[str] = field(default_factory=list)
     open_pr_heads_cache: dict[str, list[dict[str, Any]]] | None = None
+    open_pr_records_cache: list[dict[str, Any]] | None = None
     terminal_receipt_path_heads: dict[str, set[str | None]] = field(default_factory=dict)
 
 
@@ -851,7 +852,7 @@ def branch_merge_tree_matches_base(
 
 def prefetch_open_pr_heads(
     repo: Path, *, timeout: int
-) -> tuple[dict[str, list[dict[str, Any]]], bool, str | None]:
+) -> tuple[dict[str, list[dict[str, Any]]], list[dict[str, Any]], bool, str | None]:
     proc = run_cmd(
         [
             "gh",
@@ -862,29 +863,33 @@ def prefetch_open_pr_heads(
             "--limit",
             "500",
             "--json",
-            "number,title,url,headRefName",
+            "number,title,url,headRefName,body",
         ],
         repo,
         timeout=timeout,
     )
     if proc.returncode != 0:
-        return {}, True, proc.stderr.strip() or "gh pr prefetch failed"
+        return {}, [], True, proc.stderr.strip() or "gh pr prefetch failed"
     try:
         payload = json.loads(proc.stdout or "[]")
     except json.JSONDecodeError as exc:
-        return {}, True, f"failed to parse gh pr prefetch output: {exc}"
+        return {}, [], True, f"failed to parse gh pr prefetch output: {exc}"
     if not isinstance(payload, list):
-        return {}, True, "gh pr prefetch output was not a list"
+        return {}, [], True, "gh pr prefetch output was not a list"
     cache: dict[str, list[dict[str, Any]]] = {}
+    records: list[dict[str, Any]] = []
     for item in payload:
         if not isinstance(item, dict):
             continue
         head = item.get("headRefName")
         if not isinstance(head, str) or not head:
             continue
-        record = {k: v for k, v in item.items() if k in ("number", "title", "url")}
+        record = {
+            k: v for k, v in item.items() if k in ("number", "title", "url", "headRefName", "body")
+        }
+        records.append(record)
         cache.setdefault(head, []).append(record)
-    return cache, False, None
+    return cache, records, False, None
 
 
 def lookup_open_prs(
@@ -915,6 +920,113 @@ def lookup_open_prs(
     if not isinstance(payload, list):
         return [], True, "gh pr output was not a list"
     return [item for item in payload if isinstance(item, dict)], False, None
+
+
+def lookup_branch_prs(
+    repo: Path,
+    branch: str | None,
+    *,
+    timeout: int,
+    skip_gh: bool,
+) -> tuple[list[dict[str, Any]], bool, str | None]:
+    """Return all GitHub PR records for a branch.
+
+    This is used only for preserve decisions: if a stale closed PR branch is
+    explicitly superseded by an open PR, inventory must not propose harvesting
+    that old branch again.
+    """
+
+    if not branch or skip_gh:
+        return [], False, None
+    proc = run_cmd(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--state",
+            "all",
+            "--head",
+            branch,
+            "--json",
+            "number,title,url,state,headRefName,headRefOid",
+        ],
+        repo,
+        timeout=timeout,
+    )
+    if proc.returncode != 0:
+        return [], True, proc.stderr.strip() or "gh pr branch lookup failed"
+    try:
+        payload = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        return [], True, f"failed to parse gh pr branch output: {exc}"
+    if not isinstance(payload, list):
+        return [], True, "gh pr branch output was not a list"
+    return [item for item in payload if isinstance(item, dict)], False, None
+
+
+_SUPERSESSION_TERMS = (
+    "supersede",
+    "supersedes",
+    "superseded",
+    "re-cut",
+    "recut",
+    "re cut",
+    "replaces",
+    "replacement",
+)
+
+
+def _open_pr_explicitly_supersedes(source_pr_number: int, open_pr: dict[str, Any]) -> bool:
+    text = f"{open_pr.get('title') or ''}\n{open_pr.get('body') or ''}".lower()
+    if not text:
+        return False
+    for match in re.finditer(rf"#\s*{source_pr_number}\b", text):
+        window = text[max(0, match.start() - 96) : min(len(text), match.end() + 96)]
+        if any(term in window for term in _SUPERSESSION_TERMS):
+            return True
+    return False
+
+
+def lookup_superseding_open_prs(
+    repo: Path,
+    branch: str | None,
+    *,
+    timeout: int,
+    skip_gh: bool,
+    open_pr_records: list[dict[str, Any]] | None,
+) -> tuple[list[dict[str, Any]], bool, str | None]:
+    if not branch or skip_gh or not open_pr_records:
+        return [], False, None
+
+    branch_prs, failed, error = lookup_branch_prs(
+        repo,
+        branch,
+        timeout=timeout,
+        skip_gh=skip_gh,
+    )
+    if failed:
+        return [], True, error
+
+    source_numbers: list[int] = []
+    for item in branch_prs:
+        state = str(item.get("state") or "").upper()
+        number = item.get("number")
+        if state == "OPEN" or not isinstance(number, int):
+            continue
+        source_numbers.append(number)
+
+    superseding: list[dict[str, Any]] = []
+    for source_number in source_numbers:
+        for open_pr in open_pr_records:
+            if _open_pr_explicitly_supersedes(source_number, open_pr):
+                record = {
+                    k: v
+                    for k, v in open_pr.items()
+                    if k in ("number", "title", "url", "headRefName")
+                }
+                record["supersedes_pr"] = source_number
+                superseding.append(record)
+    return superseding, False, None
 
 
 def measure_sizes(
@@ -980,6 +1092,7 @@ def classify_candidate(
     proof: list[str] = []
     links: dict[str, Any] = {
         "open_prs": [],
+        "superseding_open_prs": [],
         "outbox_files": [],
         "receipt_files": [],
     }
@@ -1123,104 +1236,125 @@ def classify_candidate(
         if path_receipt_protected:
             proof.append("terminal receipt references path/head")
     elif git.ahead and git.ahead > 0:
-        patch_equivalent = False
-        try:
-            patch_equivalent = is_patch_equivalent(
-                repo_path,
-                context.base,
-                rev or "HEAD",
-                timeout=context.patch_timeout,
-            )
-        except Exception as exc:
+        superseding_open_prs, superseding_failed, superseding_error = lookup_superseding_open_prs(
+            context.repo,
+            branch,
+            timeout=context.gh_timeout,
+            skip_gh=context.skip_gh,
+            open_pr_records=context.open_pr_records_cache,
+        )
+        links["superseding_open_prs"] = superseding_open_prs
+        if superseding_failed:
             git.lookup_failed = True
-            git.lookup_errors.append(f"patch equivalence failed: {exc}")
+            git.lookup_errors.append(superseding_error or "superseding open PR lookup failed")
             classification = "lookup_failed"
-            proof.append("patch equivalence lookup failed")
+            proof.append("superseding open PR lookup failed")
+        elif superseding_open_prs:
+            classification = "open_pr_or_outbox"
+            proof.append("open PR explicitly supersedes closed source PR for branch")
         else:
-            git.patch_equivalent_to_base = patch_equivalent
-            if patch_equivalent:
-                classification = "patch_equivalent_or_merged"
-                proof.append("branch is patch-equivalent to base")
-            elif context.smart_merge_detection:
-                merge_tree_matches, merge_tree_error = branch_merge_tree_matches_base(
+            patch_equivalent = False
+            try:
+                patch_equivalent = is_patch_equivalent(
                     repo_path,
                     context.base,
                     rev or "HEAD",
                     timeout=context.patch_timeout,
                 )
-                if merge_tree_matches is None and merge_tree_error:
-                    git.lookup_failed = True
-                    git.lookup_errors.append(
-                        f"smart merge merge-tree lookup failed: {merge_tree_error}"
-                    )
-                    classification = "lookup_failed"
-                    proof.append("smart merge lookup failed")
-                elif merge_tree_matches:
-                    git.smart_merge_equivalent_to_base = True
+            except Exception as exc:
+                git.lookup_failed = True
+                git.lookup_errors.append(f"patch equivalence failed: {exc}")
+                classification = "lookup_failed"
+                proof.append("patch equivalence lookup failed")
+            else:
+                git.patch_equivalent_to_base = patch_equivalent
+                if patch_equivalent:
                     classification = "patch_equivalent_or_merged"
-                    proof.append("merging branch into base leaves base tree unchanged")
-                    links["smart_merge_merge_tree"] = context.base
-                elif merge_tree_error:
-                    classification = "unique_unharvested"
-                    proof.append("merge-tree did not prove branch is already represented on base")
-                    links["smart_merge_merge_tree_error"] = merge_tree_error
-                else:
-                    merge_commits, merge_error = branch_unique_merge_commits(
+                    proof.append("branch is patch-equivalent to base")
+                elif context.smart_merge_detection:
+                    merge_tree_matches, merge_tree_error = branch_merge_tree_matches_base(
                         repo_path,
                         context.base,
                         rev or "HEAD",
                         timeout=context.patch_timeout,
                     )
-                    if merge_error:
+                    if merge_tree_matches is None and merge_tree_error:
                         git.lookup_failed = True
                         git.lookup_errors.append(
-                            f"smart merge merge-commit lookup failed: {merge_error}"
+                            f"smart merge merge-tree lookup failed: {merge_tree_error}"
                         )
                         classification = "lookup_failed"
                         proof.append("smart merge lookup failed")
-                    elif merge_commits:
+                    elif merge_tree_matches:
+                        git.smart_merge_equivalent_to_base = True
+                        classification = "patch_equivalent_or_merged"
+                        proof.append("merging branch into base leaves base tree unchanged")
+                        links["smart_merge_merge_tree"] = context.base
+                    elif merge_tree_error:
                         classification = "unique_unharvested"
                         proof.append(
-                            "smart merge detection skipped because branch contains merge commits"
+                            "merge-tree did not prove branch is already represented on base"
                         )
-                        links["smart_merge_merge_commits"] = merge_commits
+                        links["smart_merge_merge_tree_error"] = merge_tree_error
                     else:
-                        smart_equivalent, matched_subjects = branch_subjects_match_recent_main(
-                            repo_path,
-                            context.base,
-                            rev or "HEAD",
-                            context.smart_merge_main_subjects,
-                            timeout=context.patch_timeout,
-                        )
-                        if smart_equivalent:
-                            proof.append(
-                                "all unique commit subjects match recent main squash-merge subjects "
-                                "(advisory; patch proof still required)"
-                            )
-                            links["smart_merge_matched_subjects"] = matched_subjects
-                        error_count_before = len(git.lookup_errors)
-                        patches_present, matched_commits = branch_patches_present_on_base(
+                        merge_commits, merge_error = branch_unique_merge_commits(
                             repo_path,
                             context.base,
                             rev or "HEAD",
                             timeout=context.patch_timeout,
-                            lookup_errors=git.lookup_errors,
                         )
-                        git.smart_merge_equivalent_to_base = patches_present
-                        if patches_present:
-                            classification = "patch_equivalent_or_merged"
-                            proof.append("all unique commit patches are already present on base")
-                            links["smart_merge_matched_commits"] = matched_commits
-                        elif len(git.lookup_errors) > error_count_before:
+                        if merge_error:
                             git.lookup_failed = True
+                            git.lookup_errors.append(
+                                f"smart merge merge-commit lookup failed: {merge_error}"
+                            )
                             classification = "lookup_failed"
-                            proof.append("smart merge patch-present lookup failed")
-                        else:
+                            proof.append("smart merge lookup failed")
+                        elif merge_commits:
                             classification = "unique_unharvested"
-                            proof.append("branch has unique commits or diff ahead of base")
-            else:
-                classification = "unique_unharvested"
-                proof.append("branch has unique commits or diff ahead of base")
+                            proof.append(
+                                "smart merge detection skipped because branch contains merge commits"
+                            )
+                            links["smart_merge_merge_commits"] = merge_commits
+                        else:
+                            smart_equivalent, matched_subjects = branch_subjects_match_recent_main(
+                                repo_path,
+                                context.base,
+                                rev or "HEAD",
+                                context.smart_merge_main_subjects,
+                                timeout=context.patch_timeout,
+                            )
+                            if smart_equivalent:
+                                proof.append(
+                                    "all unique commit subjects match recent main squash-merge "
+                                    "subjects (advisory; patch proof still required)"
+                                )
+                                links["smart_merge_matched_subjects"] = matched_subjects
+                            error_count_before = len(git.lookup_errors)
+                            patches_present, matched_commits = branch_patches_present_on_base(
+                                repo_path,
+                                context.base,
+                                rev or "HEAD",
+                                timeout=context.patch_timeout,
+                                lookup_errors=git.lookup_errors,
+                            )
+                            git.smart_merge_equivalent_to_base = patches_present
+                            if patches_present:
+                                classification = "patch_equivalent_or_merged"
+                                proof.append(
+                                    "all unique commit patches are already present on base"
+                                )
+                                links["smart_merge_matched_commits"] = matched_commits
+                            elif len(git.lookup_errors) > error_count_before:
+                                git.lookup_failed = True
+                                classification = "lookup_failed"
+                                proof.append("smart merge patch-present lookup failed")
+                            else:
+                                classification = "unique_unharvested"
+                                proof.append("branch has unique commits or diff ahead of base")
+                else:
+                    classification = "unique_unharvested"
+                    proof.append("branch has unique commits or diff ahead of base")
     elif git.registered_worktree:
         classification = "patch_equivalent_or_merged"
         proof.append("registered git worktree has no unique commits ahead of base")
@@ -1584,10 +1718,12 @@ def inventory(
     candidate_paths = candidate_roots_from(roots, limit)
     sizes, size_failures = measure_sizes(candidate_paths, mode=size_mode, timeout=size_timeout)
     open_pr_heads_cache: dict[str, list[dict[str, Any]]] | None = None
+    open_pr_records_cache: list[dict[str, Any]] | None = None
     if include_pr_state:
-        cache, fetch_failed, _err = prefetch_open_pr_heads(repo, timeout=gh_timeout)
+        cache, records, fetch_failed, _err = prefetch_open_pr_heads(repo, timeout=gh_timeout)
         if not fetch_failed:
             open_pr_heads_cache = cache
+            open_pr_records_cache = records
     context = InventoryContext(
         repo=repo,
         base=base,
@@ -1624,6 +1760,7 @@ def inventory(
             else []
         ),
         open_pr_heads_cache=open_pr_heads_cache,
+        open_pr_records_cache=open_pr_records_cache,
     )
     candidates = [
         classify_candidate(

--- a/scripts/codex_worktree_value_inventory.py
+++ b/scripts/codex_worktree_value_inventory.py
@@ -805,6 +805,37 @@ def branch_unique_merge_commits(
     return [line.strip() for line in proc.stdout.splitlines() if line.strip()], None
 
 
+def branch_merge_tree_matches_base(
+    repo_path: Path,
+    base: str,
+    rev: str,
+    *,
+    timeout: int,
+) -> tuple[bool | None, str | None]:
+    """Return true when merging rev into base would leave base's tree unchanged."""
+
+    base_tree = run_git(["rev-parse", f"{base}^{{tree}}"], repo_path, timeout=timeout)
+    if base_tree.returncode != 0:
+        detail = (base_tree.stderr or base_tree.stdout or "").strip()
+        return None, detail or f"git rev-parse {base}^{{tree}} exited {base_tree.returncode}"
+    base_tree_sha = base_tree.stdout.strip().splitlines()[0] if base_tree.stdout.strip() else ""
+    if not base_tree_sha:
+        return None, "git rev-parse returned an empty tree id"
+
+    merge_tree = run_git(
+        ["merge-tree", "--write-tree", "--no-messages", base, rev],
+        repo_path,
+        timeout=timeout,
+    )
+    if merge_tree.returncode != 0:
+        detail = (merge_tree.stderr or merge_tree.stdout or "").strip()
+        return None, detail or f"git merge-tree exited {merge_tree.returncode}"
+    merged_tree_sha = merge_tree.stdout.strip().splitlines()[0] if merge_tree.stdout.strip() else ""
+    if not merged_tree_sha:
+        return None, "git merge-tree returned an empty tree id"
+    return merged_tree_sha == base_tree_sha, None
+
+
 def prefetch_open_pr_heads(
     repo: Path, *, timeout: int
 ) -> tuple[dict[str, list[dict[str, Any]]], bool, str | None]:
@@ -1098,61 +1129,82 @@ def classify_candidate(
                 classification = "patch_equivalent_or_merged"
                 proof.append("branch is patch-equivalent to base")
             elif context.smart_merge_detection:
-                merge_commits, merge_error = branch_unique_merge_commits(
+                merge_tree_matches, merge_tree_error = branch_merge_tree_matches_base(
                     repo_path,
                     context.base,
                     rev or "HEAD",
                     timeout=context.patch_timeout,
                 )
-                if merge_error:
+                if merge_tree_error:
                     git.lookup_failed = True
                     git.lookup_errors.append(
-                        f"smart merge merge-commit lookup failed: {merge_error}"
+                        f"smart merge merge-tree lookup failed: {merge_tree_error}"
                     )
                     classification = "lookup_failed"
                     proof.append("smart merge lookup failed")
-                elif merge_commits:
-                    classification = "unique_unharvested"
-                    proof.append(
-                        "smart merge detection skipped because branch contains merge commits"
-                    )
-                    links["smart_merge_merge_commits"] = merge_commits
+                elif merge_tree_matches:
+                    git.smart_merge_equivalent_to_base = True
+                    classification = "patch_equivalent_or_merged"
+                    proof.append("merging branch into base leaves base tree unchanged")
+                    links["smart_merge_merge_tree"] = context.base
                 else:
-                    smart_equivalent, matched_subjects = branch_subjects_match_recent_main(
+                    merge_commits, merge_error = branch_unique_merge_commits(
                         repo_path,
                         context.base,
                         rev or "HEAD",
-                        context.smart_merge_main_subjects,
                         timeout=context.patch_timeout,
                     )
-                    git.smart_merge_equivalent_to_base = smart_equivalent
-                    if smart_equivalent:
-                        classification = "patch_equivalent_or_merged"
-                        proof.append(
-                            "all unique commit subjects match recent main squash-merge subjects"
+                    if merge_error:
+                        git.lookup_failed = True
+                        git.lookup_errors.append(
+                            f"smart merge merge-commit lookup failed: {merge_error}"
                         )
-                        links["smart_merge_matched_subjects"] = matched_subjects
+                        classification = "lookup_failed"
+                        proof.append("smart merge lookup failed")
+                    elif merge_commits:
+                        classification = "unique_unharvested"
+                        proof.append(
+                            "smart merge detection skipped because branch contains merge commits"
+                        )
+                        links["smart_merge_merge_commits"] = merge_commits
                     else:
-                        error_count_before = len(git.lookup_errors)
-                        patches_present, matched_commits = branch_patches_present_on_base(
+                        smart_equivalent, matched_subjects = branch_subjects_match_recent_main(
                             repo_path,
                             context.base,
                             rev or "HEAD",
+                            context.smart_merge_main_subjects,
                             timeout=context.patch_timeout,
-                            lookup_errors=git.lookup_errors,
                         )
-                        git.smart_merge_equivalent_to_base = patches_present
-                        if patches_present:
+                        git.smart_merge_equivalent_to_base = smart_equivalent
+                        if smart_equivalent:
                             classification = "patch_equivalent_or_merged"
-                            proof.append("all unique commit patches are already present on base")
-                            links["smart_merge_matched_commits"] = matched_commits
-                        elif len(git.lookup_errors) > error_count_before:
-                            git.lookup_failed = True
-                            classification = "lookup_failed"
-                            proof.append("smart merge patch-present lookup failed")
+                            proof.append(
+                                "all unique commit subjects match recent main squash-merge subjects"
+                            )
+                            links["smart_merge_matched_subjects"] = matched_subjects
                         else:
-                            classification = "unique_unharvested"
-                            proof.append("branch has unique commits or diff ahead of base")
+                            error_count_before = len(git.lookup_errors)
+                            patches_present, matched_commits = branch_patches_present_on_base(
+                                repo_path,
+                                context.base,
+                                rev or "HEAD",
+                                timeout=context.patch_timeout,
+                                lookup_errors=git.lookup_errors,
+                            )
+                            git.smart_merge_equivalent_to_base = patches_present
+                            if patches_present:
+                                classification = "patch_equivalent_or_merged"
+                                proof.append(
+                                    "all unique commit patches are already present on base"
+                                )
+                                links["smart_merge_matched_commits"] = matched_commits
+                            elif len(git.lookup_errors) > error_count_before:
+                                git.lookup_failed = True
+                                classification = "lookup_failed"
+                                proof.append("smart merge patch-present lookup failed")
+                            else:
+                                classification = "unique_unharvested"
+                                proof.append("branch has unique commits or diff ahead of base")
             else:
                 classification = "unique_unharvested"
                 proof.append("branch has unique commits or diff ahead of base")

--- a/scripts/codex_worktree_value_inventory.py
+++ b/scripts/codex_worktree_value_inventory.py
@@ -452,6 +452,8 @@ def _terminal_path_receipt(payload: dict[str, Any]) -> bool:
         ).strip()
     else:
         decision = str(decision_value or payload.get("outcome") or "").strip()
+    if decision in TERMINAL_RECEIPT_STATUSES:
+        return True
     if decision.startswith(TERMINAL_HARVEST_DECISION_PREFIXES):
         return True
     return False
@@ -705,6 +707,7 @@ def branch_patches_present_on_base(
     rev: str,
     *,
     timeout: int,
+    lookup_errors: list[str] | None = None,
 ) -> tuple[bool, list[str]]:
     """Return true when every unique non-merge commit patch is already in base.
 
@@ -723,6 +726,11 @@ def branch_patches_present_on_base(
         timeout=timeout,
     )
     if commits_proc.returncode != 0:
+        if lookup_errors is not None:
+            detail = (commits_proc.stderr or commits_proc.stdout or "").strip()
+            lookup_errors.append(
+                f"patch-present rev-list failed: {detail or commits_proc.returncode}"
+            )
         return False, []
     commits = [line.strip() for line in commits_proc.stdout.splitlines() if line.strip()]
     if not commits:
@@ -735,12 +743,21 @@ def branch_patches_present_on_base(
         env["GIT_INDEX_FILE"] = index_path
         read_tree = run_cmd(["git", "read-tree", base], repo_path, timeout=timeout, env=env)
         if read_tree.returncode != 0:
+            if lookup_errors is not None:
+                detail = (read_tree.stderr or read_tree.stdout or "").strip()
+                lookup_errors.append(
+                    f"patch-present read-tree failed: {detail or read_tree.returncode}"
+                )
             return False, []
 
         verified: list[str] = []
         for commit in commits:
             patch = run_git(["show", "--format=", "--binary", commit], repo_path, timeout=timeout)
             if patch.returncode != 0 or not patch.stdout.strip():
+                if lookup_errors is not None:
+                    detail = (patch.stderr or patch.stdout or "").strip()
+                    reason = "empty patch" if patch.returncode == 0 else detail or patch.returncode
+                    lookup_errors.append(f"patch-present show failed for {commit}: {reason}")
                 return False, verified
             reverse_check = run_cmd(
                 ["git", "apply", "--cached", "--reverse", "--check", "--index", "-"],
@@ -750,6 +767,12 @@ def branch_patches_present_on_base(
                 input_text=patch.stdout,
             )
             if reverse_check.returncode != 0:
+                if lookup_errors is not None:
+                    detail = (reverse_check.stderr or reverse_check.stdout or "").strip()
+                    lookup_errors.append(
+                        f"patch-present reverse-check failed for {commit}: "
+                        f"{detail or reverse_check.returncode}"
+                    )
                 return False, verified
             verified.append(commit)
         return True, verified
@@ -758,6 +781,20 @@ def branch_patches_present_on_base(
             os.unlink(index_path)
         except FileNotFoundError:
             pass
+
+
+def branch_unique_merge_commits(
+    repo_path: Path,
+    base: str,
+    rev: str,
+    *,
+    timeout: int,
+) -> tuple[list[str] | None, str | None]:
+    proc = run_git(["rev-list", "--merges", f"{base}..{rev}"], repo_path, timeout=timeout)
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "").strip()
+        return None, detail or f"git rev-list --merges exited {proc.returncode}"
+    return [line.strip() for line in proc.stdout.splitlines() if line.strip()], None
 
 
 def prefetch_open_pr_heads(
@@ -1053,35 +1090,55 @@ def classify_candidate(
                 classification = "patch_equivalent_or_merged"
                 proof.append("branch is patch-equivalent to base")
             elif context.smart_merge_detection:
-                smart_equivalent, matched_subjects = branch_subjects_match_recent_main(
+                merge_commits, merge_error = branch_unique_merge_commits(
                     repo_path,
                     context.base,
                     rev or "HEAD",
-                    context.smart_merge_main_subjects,
                     timeout=context.patch_timeout,
                 )
-                git.smart_merge_equivalent_to_base = smart_equivalent
-                if smart_equivalent:
-                    classification = "patch_equivalent_or_merged"
-                    proof.append(
-                        "all unique commit subjects match recent main squash-merge subjects"
+                if merge_error:
+                    git.lookup_errors.append(
+                        f"smart merge merge-commit lookup failed: {merge_error}"
                     )
-                    links["smart_merge_matched_subjects"] = matched_subjects
+                    classification = "unique_unharvested"
+                    proof.append("branch has unique commits or diff ahead of base")
+                elif merge_commits:
+                    classification = "unique_unharvested"
+                    proof.append(
+                        "smart merge detection skipped because branch contains merge commits"
+                    )
+                    links["smart_merge_merge_commits"] = merge_commits
                 else:
-                    patches_present, matched_commits = branch_patches_present_on_base(
+                    smart_equivalent, matched_subjects = branch_subjects_match_recent_main(
                         repo_path,
                         context.base,
                         rev or "HEAD",
+                        context.smart_merge_main_subjects,
                         timeout=context.patch_timeout,
                     )
-                    git.smart_merge_equivalent_to_base = patches_present
-                    if patches_present:
+                    git.smart_merge_equivalent_to_base = smart_equivalent
+                    if smart_equivalent:
                         classification = "patch_equivalent_or_merged"
-                        proof.append("all unique commit patches are already present on base")
-                        links["smart_merge_matched_commits"] = matched_commits
+                        proof.append(
+                            "all unique commit subjects match recent main squash-merge subjects"
+                        )
+                        links["smart_merge_matched_subjects"] = matched_subjects
                     else:
-                        classification = "unique_unharvested"
-                        proof.append("branch has unique commits or diff ahead of base")
+                        patches_present, matched_commits = branch_patches_present_on_base(
+                            repo_path,
+                            context.base,
+                            rev or "HEAD",
+                            timeout=context.patch_timeout,
+                            lookup_errors=git.lookup_errors,
+                        )
+                        git.smart_merge_equivalent_to_base = patches_present
+                        if patches_present:
+                            classification = "patch_equivalent_or_merged"
+                            proof.append("all unique commit patches are already present on base")
+                            links["smart_merge_matched_commits"] = matched_commits
+                        else:
+                            classification = "unique_unharvested"
+                            proof.append("branch has unique commits or diff ahead of base")
             else:
                 classification = "unique_unharvested"
                 proof.append("branch has unique commits or diff ahead of base")

--- a/scripts/codex_worktree_value_inventory.py
+++ b/scripts/codex_worktree_value_inventory.py
@@ -48,6 +48,7 @@ SCHEMA = "aragora-worktree-harvest/1.0"
 # hook) can never hang the whole inventory. Overridable per-run via
 # --git-timeout-seconds (alias of the long-standing --git-timeout flag).
 GIT_TIMEOUT_SECONDS = 30
+MAX_SMART_MERGE_PATCH_COMMITS = 25
 # Substring run_cmd embeds in stderr on timeout; classify_candidate uses it to
 # annotate timed-out candidates as inspect_timeout (always protected).
 _TIMEOUT_ERROR_MARKER = "timed out after"
@@ -735,6 +736,13 @@ def branch_patches_present_on_base(
     commits = [line.strip() for line in commits_proc.stdout.splitlines() if line.strip()]
     if not commits:
         return False, []
+    if len(commits) > MAX_SMART_MERGE_PATCH_COMMITS:
+        if lookup_errors is not None:
+            lookup_errors.append(
+                "patch-present skipped: "
+                f"{len(commits)} commits exceeds budget {MAX_SMART_MERGE_PATCH_COMMITS}"
+            )
+        return False, []
 
     fd, index_path = tempfile.mkstemp(prefix="aragora-inventory-index-")
     os.close(fd)
@@ -767,7 +775,7 @@ def branch_patches_present_on_base(
                 input_text=patch.stdout,
             )
             if reverse_check.returncode != 0:
-                if lookup_errors is not None:
+                if lookup_errors is not None and reverse_check.returncode == 124:
                     detail = (reverse_check.stderr or reverse_check.stdout or "").strip()
                     lookup_errors.append(
                         f"patch-present reverse-check failed for {commit}: "
@@ -1097,11 +1105,12 @@ def classify_candidate(
                     timeout=context.patch_timeout,
                 )
                 if merge_error:
+                    git.lookup_failed = True
                     git.lookup_errors.append(
                         f"smart merge merge-commit lookup failed: {merge_error}"
                     )
-                    classification = "unique_unharvested"
-                    proof.append("branch has unique commits or diff ahead of base")
+                    classification = "lookup_failed"
+                    proof.append("smart merge lookup failed")
                 elif merge_commits:
                     classification = "unique_unharvested"
                     proof.append(
@@ -1124,6 +1133,7 @@ def classify_candidate(
                         )
                         links["smart_merge_matched_subjects"] = matched_subjects
                     else:
+                        error_count_before = len(git.lookup_errors)
                         patches_present, matched_commits = branch_patches_present_on_base(
                             repo_path,
                             context.base,
@@ -1136,6 +1146,10 @@ def classify_candidate(
                             classification = "patch_equivalent_or_merged"
                             proof.append("all unique commit patches are already present on base")
                             links["smart_merge_matched_commits"] = matched_commits
+                        elif len(git.lookup_errors) > error_count_before:
+                            git.lookup_failed = True
+                            classification = "lookup_failed"
+                            proof.append("smart merge patch-present lookup failed")
                         else:
                             classification = "unique_unharvested"
                             proof.append("branch has unique commits or diff ahead of base")

--- a/scripts/codex_worktree_value_inventory.py
+++ b/scripts/codex_worktree_value_inventory.py
@@ -860,7 +860,31 @@ def prefetch_open_pr_heads(
     bool,
     str | None,
 ]:
-    proc = run_cmd(
+    open_proc = run_cmd(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--state",
+            "open",
+            "--limit",
+            "500",
+            "--json",
+            "number,title,url,headRefName,body,state,headRefOid",
+        ],
+        repo,
+        timeout=timeout,
+    )
+    if open_proc.returncode != 0:
+        return {}, [], {}, True, open_proc.stderr.strip() or "gh pr open prefetch failed"
+    try:
+        open_payload = json.loads(open_proc.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        return {}, [], {}, True, f"failed to parse gh pr open prefetch output: {exc}"
+    if not isinstance(open_payload, list):
+        return {}, [], {}, True, "gh pr open prefetch output was not a list"
+
+    all_proc = run_cmd(
         [
             "gh",
             "pr",
@@ -875,18 +899,19 @@ def prefetch_open_pr_heads(
         repo,
         timeout=timeout,
     )
-    if proc.returncode != 0:
-        return {}, [], {}, True, proc.stderr.strip() or "gh pr prefetch failed"
+    if all_proc.returncode != 0:
+        return {}, [], {}, True, all_proc.stderr.strip() or "gh pr all-state prefetch failed"
     try:
-        payload = json.loads(proc.stdout or "[]")
+        all_payload = json.loads(all_proc.stdout or "[]")
     except json.JSONDecodeError as exc:
-        return {}, [], {}, True, f"failed to parse gh pr prefetch output: {exc}"
-    if not isinstance(payload, list):
-        return {}, [], {}, True, "gh pr prefetch output was not a list"
+        return {}, [], {}, True, f"failed to parse gh pr all-state prefetch output: {exc}"
+    if not isinstance(all_payload, list):
+        return {}, [], {}, True, "gh pr all-state prefetch output was not a list"
+
     cache: dict[str, list[dict[str, Any]]] = {}
     records: list[dict[str, Any]] = []
     branch_records: dict[str, list[dict[str, Any]]] = {}
-    for item in payload:
+    for item in all_payload:
         if not isinstance(item, dict):
             continue
         head = item.get("headRefName")
@@ -898,8 +923,19 @@ def prefetch_open_pr_heads(
             if k in ("number", "title", "url", "headRefName", "body", "state", "headRefOid")
         }
         branch_records.setdefault(head, []).append(record)
-        if str(item.get("state") or "").upper() != "OPEN":
+    for item in open_payload:
+        if not isinstance(item, dict):
             continue
+        head = item.get("headRefName")
+        if not isinstance(head, str) or not head:
+            continue
+        if str(item.get("state") or "OPEN").upper() != "OPEN":
+            continue
+        record = {
+            k: v
+            for k, v in item.items()
+            if k in ("number", "title", "url", "headRefName", "body", "state", "headRefOid")
+        }
         records.append(record)
         cache.setdefault(head, []).append(record)
     return cache, records, branch_records, False, None

--- a/scripts/codex_worktree_value_inventory.py
+++ b/scripts/codex_worktree_value_inventory.py
@@ -768,7 +768,7 @@ def branch_patches_present_on_base(
                     lookup_errors.append(f"patch-present show failed for {commit}: {reason}")
                 return False, verified
             reverse_check = run_cmd(
-                ["git", "apply", "--cached", "--reverse", "--check", "--index", "-"],
+                ["git", "apply", "--cached", "--reverse", "--check", "-"],
                 repo_path,
                 timeout=timeout,
                 env=env,

--- a/scripts/codex_worktree_value_inventory.py
+++ b/scripts/codex_worktree_value_inventory.py
@@ -203,6 +203,7 @@ class InventoryContext:
     smart_merge_main_subjects: list[str] = field(default_factory=list)
     open_pr_heads_cache: dict[str, list[dict[str, Any]]] | None = None
     open_pr_records_cache: list[dict[str, Any]] | None = None
+    branch_pr_records_cache: dict[str, list[dict[str, Any]]] | None = None
     terminal_receipt_path_heads: dict[str, set[str | None]] = field(default_factory=dict)
 
 
@@ -852,32 +853,39 @@ def branch_merge_tree_matches_base(
 
 def prefetch_open_pr_heads(
     repo: Path, *, timeout: int
-) -> tuple[dict[str, list[dict[str, Any]]], list[dict[str, Any]], bool, str | None]:
+) -> tuple[
+    dict[str, list[dict[str, Any]]],
+    list[dict[str, Any]],
+    dict[str, list[dict[str, Any]]],
+    bool,
+    str | None,
+]:
     proc = run_cmd(
         [
             "gh",
             "pr",
             "list",
             "--state",
-            "open",
+            "all",
             "--limit",
             "500",
             "--json",
-            "number,title,url,headRefName,body",
+            "number,title,url,headRefName,body,state,headRefOid",
         ],
         repo,
         timeout=timeout,
     )
     if proc.returncode != 0:
-        return {}, [], True, proc.stderr.strip() or "gh pr prefetch failed"
+        return {}, [], {}, True, proc.stderr.strip() or "gh pr prefetch failed"
     try:
         payload = json.loads(proc.stdout or "[]")
     except json.JSONDecodeError as exc:
-        return {}, [], True, f"failed to parse gh pr prefetch output: {exc}"
+        return {}, [], {}, True, f"failed to parse gh pr prefetch output: {exc}"
     if not isinstance(payload, list):
-        return {}, [], True, "gh pr prefetch output was not a list"
+        return {}, [], {}, True, "gh pr prefetch output was not a list"
     cache: dict[str, list[dict[str, Any]]] = {}
     records: list[dict[str, Any]] = []
+    branch_records: dict[str, list[dict[str, Any]]] = {}
     for item in payload:
         if not isinstance(item, dict):
             continue
@@ -885,11 +893,16 @@ def prefetch_open_pr_heads(
         if not isinstance(head, str) or not head:
             continue
         record = {
-            k: v for k, v in item.items() if k in ("number", "title", "url", "headRefName", "body")
+            k: v
+            for k, v in item.items()
+            if k in ("number", "title", "url", "headRefName", "body", "state", "headRefOid")
         }
+        branch_records.setdefault(head, []).append(record)
+        if str(item.get("state") or "").upper() != "OPEN":
+            continue
         records.append(record)
         cache.setdefault(head, []).append(record)
-    return cache, records, False, None
+    return cache, records, branch_records, False, None
 
 
 def lookup_open_prs(
@@ -928,6 +941,7 @@ def lookup_branch_prs(
     *,
     timeout: int,
     skip_gh: bool,
+    cached_branch_prs: dict[str, list[dict[str, Any]]] | None = None,
 ) -> tuple[list[dict[str, Any]], bool, str | None]:
     """Return all GitHub PR records for a branch.
 
@@ -938,6 +952,8 @@ def lookup_branch_prs(
 
     if not branch or skip_gh:
         return [], False, None
+    if cached_branch_prs is not None:
+        return list(cached_branch_prs.get(branch, [])), False, None
     proc = run_cmd(
         [
             "gh",
@@ -994,6 +1010,7 @@ def lookup_superseding_open_prs(
     timeout: int,
     skip_gh: bool,
     open_pr_records: list[dict[str, Any]] | None,
+    branch_pr_records: dict[str, list[dict[str, Any]]] | None,
 ) -> tuple[list[dict[str, Any]], bool, str | None]:
     if not branch or skip_gh or not open_pr_records:
         return [], False, None
@@ -1003,6 +1020,7 @@ def lookup_superseding_open_prs(
         branch,
         timeout=timeout,
         skip_gh=skip_gh,
+        cached_branch_prs=branch_pr_records,
     )
     if failed:
         return [], True, error
@@ -1242,6 +1260,7 @@ def classify_candidate(
             timeout=context.gh_timeout,
             skip_gh=context.skip_gh,
             open_pr_records=context.open_pr_records_cache,
+            branch_pr_records=context.branch_pr_records_cache,
         )
         links["superseding_open_prs"] = superseding_open_prs
         if superseding_failed:
@@ -1719,11 +1738,15 @@ def inventory(
     sizes, size_failures = measure_sizes(candidate_paths, mode=size_mode, timeout=size_timeout)
     open_pr_heads_cache: dict[str, list[dict[str, Any]]] | None = None
     open_pr_records_cache: list[dict[str, Any]] | None = None
+    branch_pr_records_cache: dict[str, list[dict[str, Any]]] | None = None
     if include_pr_state:
-        cache, records, fetch_failed, _err = prefetch_open_pr_heads(repo, timeout=gh_timeout)
+        cache, records, branch_records, fetch_failed, _err = prefetch_open_pr_heads(
+            repo, timeout=gh_timeout
+        )
         if not fetch_failed:
             open_pr_heads_cache = cache
             open_pr_records_cache = records
+            branch_pr_records_cache = branch_records
     context = InventoryContext(
         repo=repo,
         base=base,
@@ -1761,6 +1784,7 @@ def inventory(
         ),
         open_pr_heads_cache=open_pr_heads_cache,
         open_pr_records_cache=open_pr_records_cache,
+        branch_pr_records_cache=branch_pr_records_cache,
     )
     candidates = [
         classify_candidate(

--- a/scripts/codex_worktree_value_inventory.py
+++ b/scripts/codex_worktree_value_inventory.py
@@ -255,6 +255,8 @@ def run_cmd(
             args,
             cwd=cwd,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             stdin=subprocess.PIPE if input_text is not None else subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -275,6 +277,14 @@ def run_cmd(
             returncode=124,
             stdout="",
             stderr=f"command timed out after {timeout}s: {' '.join(args)}",
+        )
+    except (UnicodeError, OSError, ValueError) as exc:
+        _kill_process_tree(proc)
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=125,
+            stdout="",
+            stderr=f"command failed while reading output: {type(exc).__name__}: {exc}",
         )
     return subprocess.CompletedProcess(
         args=args, returncode=proc.returncode, stdout=stdout or "", stderr=stderr or ""

--- a/scripts/codex_worktree_value_inventory.py
+++ b/scripts/codex_worktree_value_inventory.py
@@ -829,7 +829,10 @@ def branch_merge_tree_matches_base(
     )
     if merge_tree.returncode != 0:
         detail = (merge_tree.stderr or merge_tree.stdout or "").strip()
-        return None, detail or f"git merge-tree exited {merge_tree.returncode}"
+        reason = detail or f"git merge-tree exited {merge_tree.returncode}"
+        if merge_tree.returncode == 124 or _TIMEOUT_ERROR_MARKER in reason:
+            return None, reason
+        return False, reason
     merged_tree_sha = merge_tree.stdout.strip().splitlines()[0] if merge_tree.stdout.strip() else ""
     if not merged_tree_sha:
         return None, "git merge-tree returned an empty tree id"
@@ -1135,7 +1138,7 @@ def classify_candidate(
                     rev or "HEAD",
                     timeout=context.patch_timeout,
                 )
-                if merge_tree_error:
+                if merge_tree_matches is None and merge_tree_error:
                     git.lookup_failed = True
                     git.lookup_errors.append(
                         f"smart merge merge-tree lookup failed: {merge_tree_error}"
@@ -1148,6 +1151,8 @@ def classify_candidate(
                     proof.append("merging branch into base leaves base tree unchanged")
                     links["smart_merge_merge_tree"] = context.base
                 else:
+                    if merge_tree_error:
+                        links["smart_merge_merge_tree_error"] = merge_tree_error
                     merge_commits, merge_error = branch_unique_merge_commits(
                         repo_path,
                         context.base,

--- a/scripts/codex_worktree_value_inventory.py
+++ b/scripts/codex_worktree_value_inventory.py
@@ -1192,36 +1192,32 @@ def classify_candidate(
                             context.smart_merge_main_subjects,
                             timeout=context.patch_timeout,
                         )
-                        git.smart_merge_equivalent_to_base = smart_equivalent
                         if smart_equivalent:
-                            classification = "patch_equivalent_or_merged"
                             proof.append(
-                                "all unique commit subjects match recent main squash-merge subjects"
+                                "all unique commit subjects match recent main squash-merge subjects "
+                                "(advisory; patch proof still required)"
                             )
                             links["smart_merge_matched_subjects"] = matched_subjects
+                        error_count_before = len(git.lookup_errors)
+                        patches_present, matched_commits = branch_patches_present_on_base(
+                            repo_path,
+                            context.base,
+                            rev or "HEAD",
+                            timeout=context.patch_timeout,
+                            lookup_errors=git.lookup_errors,
+                        )
+                        git.smart_merge_equivalent_to_base = patches_present
+                        if patches_present:
+                            classification = "patch_equivalent_or_merged"
+                            proof.append("all unique commit patches are already present on base")
+                            links["smart_merge_matched_commits"] = matched_commits
+                        elif len(git.lookup_errors) > error_count_before:
+                            git.lookup_failed = True
+                            classification = "lookup_failed"
+                            proof.append("smart merge patch-present lookup failed")
                         else:
-                            error_count_before = len(git.lookup_errors)
-                            patches_present, matched_commits = branch_patches_present_on_base(
-                                repo_path,
-                                context.base,
-                                rev or "HEAD",
-                                timeout=context.patch_timeout,
-                                lookup_errors=git.lookup_errors,
-                            )
-                            git.smart_merge_equivalent_to_base = patches_present
-                            if patches_present:
-                                classification = "patch_equivalent_or_merged"
-                                proof.append(
-                                    "all unique commit patches are already present on base"
-                                )
-                                links["smart_merge_matched_commits"] = matched_commits
-                            elif len(git.lookup_errors) > error_count_before:
-                                git.lookup_failed = True
-                                classification = "lookup_failed"
-                                proof.append("smart merge patch-present lookup failed")
-                            else:
-                                classification = "unique_unharvested"
-                                proof.append("branch has unique commits or diff ahead of base")
+                            classification = "unique_unharvested"
+                            proof.append("branch has unique commits or diff ahead of base")
             else:
                 classification = "unique_unharvested"
                 proof.append("branch has unique commits or diff ahead of base")
@@ -1744,10 +1740,10 @@ def build_parser() -> argparse.ArgumentParser:
         "--smart-merge-detection",
         action="store_true",
         help=(
-            "Reclassify ahead branches as patch_equivalent_or_merged when every "
-            "unique commit subject loosely matches a recent main squash-merge "
-            "subject, or when every unique commit patch is already present on "
-            "base. Default off to preserve legacy inventory behavior."
+            "Reclassify ahead branches as patch_equivalent_or_merged when merge-tree "
+            "or patch-presence proves the branch is already represented on base. "
+            "Loose recent-main subject matches are recorded only as advisory context. "
+            "Default off to preserve legacy inventory behavior."
         ),
     )
     parser.add_argument(

--- a/tests/scripts/test_codex_worktree_value_inventory.py
+++ b/tests/scripts/test_codex_worktree_value_inventory.py
@@ -707,7 +707,7 @@ def test_smart_merge_detection_reclassifies_noop_merge_tree(
     assert candidate.links["smart_merge_merge_tree"] == "origin/main"
 
 
-def test_smart_merge_detection_merge_tree_failure_is_protected(
+def test_smart_merge_detection_merge_tree_timeout_is_protected(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     import codex_worktree_value_inventory as mod
@@ -717,7 +717,7 @@ def test_smart_merge_detection_merge_tree_failure_is_protected(
     monkeypatch.setattr(
         mod,
         "branch_merge_tree_matches_base",
-        lambda *_args, **_kwargs: (None, "merge conflict"),
+        lambda *_args, **_kwargs: (None, "command timed out after 1s"),
     )
 
     candidate = mod.classify_candidate(
@@ -737,6 +737,46 @@ def test_smart_merge_detection_merge_tree_failure_is_protected(
     assert any(
         "smart merge merge-tree lookup failed" in item for item in candidate.git.lookup_errors
     )
+
+
+def test_smart_merge_detection_merge_tree_conflict_falls_through(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import codex_worktree_value_inventory as mod
+
+    root = _candidate(tmp_path)
+    _stub_clean_git(monkeypatch, ahead=3, patch_equivalent=False)
+    monkeypatch.setattr(
+        mod,
+        "branch_merge_tree_matches_base",
+        lambda *_args, **_kwargs: (False, "CONFLICT (content): tracked.txt"),
+    )
+    monkeypatch.setattr(
+        mod,
+        "branch_subjects_match_recent_main",
+        lambda *_args, **_kwargs: (False, []),
+    )
+    monkeypatch.setattr(
+        mod,
+        "branch_patches_present_on_base",
+        lambda *_args, **_kwargs: (False, []),
+    )
+
+    candidate = mod.classify_candidate(
+        root,
+        context=_context(
+            tmp_path,
+            smart_merge_detection=True,
+            smart_merge_main_subjects=[],
+        ),
+        size_bytes=1024,
+        size_lookup_failed=False,
+    )
+
+    assert candidate.classification == "unique_unharvested"
+    assert candidate.cleanup_candidate is False
+    assert candidate.git.lookup_failed is False
+    assert candidate.links["smart_merge_merge_tree_error"] == "CONFLICT (content): tracked.txt"
 
 
 def test_branch_patches_present_on_base_uses_temp_index_only(tmp_path: Path) -> None:

--- a/tests/scripts/test_codex_worktree_value_inventory.py
+++ b/tests/scripts/test_codex_worktree_value_inventory.py
@@ -91,6 +91,11 @@ def _stub_clean_git(
         ),
     )
     monkeypatch.setattr(mod, "is_patch_equivalent", lambda *_args, **_kwargs: patch_equivalent)
+    monkeypatch.setattr(
+        mod,
+        "branch_unique_merge_commits",
+        lambda *_args, **_kwargs: ([], None),
+    )
 
 
 def test_default_scan_preserves_foreign_repo_as_lookup_failed(
@@ -467,6 +472,32 @@ def test_terminal_receipt_path_heads_reads_object_decision_outcome(
     assert refs[str(root.resolve())] == {"abcdef123456"}
 
 
+def test_terminal_receipt_path_heads_reads_object_decision_status(
+    tmp_path: Path,
+) -> None:
+    import codex_worktree_value_inventory as mod
+
+    root = _candidate(tmp_path)
+    receipt_dir = tmp_path / ".aragora" / "worktree-harvest" / "harvest-receipts"
+    receipt_dir.mkdir(parents=True)
+    (receipt_dir / "completed.json").write_text(
+        json.dumps(
+            {
+                "decision": {"status": "completed"},
+                "selected_candidate": {
+                    "path": str(root),
+                    "head": "abcdef123456",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    refs = mod.terminal_receipt_path_heads([receipt_dir])
+
+    assert refs[str(root.resolve())] == {"abcdef123456"}
+
+
 def test_unique_unharvested_when_ahead_and_not_patch_equivalent(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -638,6 +669,87 @@ def test_smart_merge_detection_reclassifies_already_present_patches(
     assert candidate.git.smart_merge_equivalent_to_base is True
     assert "all unique commit patches are already present on base" in candidate.proof
     assert candidate.links["smart_merge_matched_commits"] == ["2f2a1f6", "b46d5c6"]
+
+
+def test_smart_merge_detection_preserves_branches_with_merge_commits(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import codex_worktree_value_inventory as mod
+
+    root = _candidate(tmp_path)
+    _stub_clean_git(monkeypatch, ahead=3, patch_equivalent=False)
+    monkeypatch.setattr(
+        mod,
+        "branch_unique_merge_commits",
+        lambda *_args, **_kwargs: (["merge-sha"], None),
+    )
+    monkeypatch.setattr(
+        mod,
+        "branch_subjects_match_recent_main",
+        lambda *_args, **_kwargs: (True, ["feat: already merged"]),
+    )
+    monkeypatch.setattr(
+        mod,
+        "branch_patches_present_on_base",
+        lambda *_args, **_kwargs: (True, ["commit-sha"]),
+    )
+
+    candidate = mod.classify_candidate(
+        root,
+        context=_context(
+            tmp_path,
+            smart_merge_detection=True,
+            smart_merge_main_subjects=["feat: already merged (#123)"],
+        ),
+        size_bytes=1024,
+        size_lookup_failed=False,
+    )
+
+    assert candidate.classification == "unique_unharvested"
+    assert candidate.cleanup_candidate is False
+    assert candidate.git.smart_merge_equivalent_to_base is False
+    assert "smart merge detection skipped because branch contains merge commits" in candidate.proof
+    assert candidate.links["smart_merge_merge_commits"] == ["merge-sha"]
+
+
+def test_smart_merge_patch_timeout_is_reported(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import codex_worktree_value_inventory as mod
+
+    root = _candidate(tmp_path)
+    _stub_clean_git(monkeypatch, ahead=2, patch_equivalent=False)
+    monkeypatch.setattr(
+        mod,
+        "branch_subjects_match_recent_main",
+        lambda *_args, **_kwargs: (False, []),
+    )
+
+    def fake_patches_present(
+        *_args: Any, lookup_errors: list[str] | None = None, **_kwargs: Any
+    ) -> tuple[bool, list[str]]:
+        if lookup_errors is not None:
+            lookup_errors.append("patch-present rev-list failed: command timed out after 1s")
+        return False, []
+
+    monkeypatch.setattr(mod, "branch_patches_present_on_base", fake_patches_present)
+
+    candidate = mod.classify_candidate(
+        root,
+        context=_context(
+            tmp_path,
+            smart_merge_detection=True,
+            smart_merge_main_subjects=[],
+        ),
+        size_bytes=1024,
+        size_lookup_failed=False,
+    )
+
+    assert candidate.classification == "unique_unharvested"
+    assert candidate.cleanup_candidate is False
+    assert candidate.git.inspect_timeout is True
+    assert any("patch-present rev-list failed" in item for item in candidate.git.lookup_errors)
+    assert any("inspect_timeout" in item for item in candidate.proof)
 
 
 def test_smart_merge_detection_keeps_unmatched_subjects_harvestable(

--- a/tests/scripts/test_codex_worktree_value_inventory.py
+++ b/tests/scripts/test_codex_worktree_value_inventory.py
@@ -600,7 +600,7 @@ def test_smart_merge_detection_default_off_preserves_unique_harvest(
     assert candidate.decision == "harvest_candidate"
 
 
-def test_smart_merge_detection_reclassifies_matching_subjects(
+def test_smart_merge_detection_keeps_matching_subjects_harvestable_without_patch_proof(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     import codex_worktree_value_inventory as mod
@@ -614,6 +614,11 @@ def test_smart_merge_detection_reclassifies_matching_subjects(
             "feat(scripts): list active sessions [lane: P42]",
             "docs(status): inventory receipt [lane: P42]",
         ],
+    )
+    monkeypatch.setattr(
+        mod,
+        "branch_patches_present_on_base",
+        lambda *_args, **_kwargs: (False, []),
     )
 
     candidate = mod.classify_candidate(
@@ -630,10 +635,13 @@ def test_smart_merge_detection_reclassifies_matching_subjects(
         size_lookup_failed=False,
     )
 
-    assert candidate.classification == "patch_equivalent_or_merged"
-    assert candidate.cleanup_candidate is True
-    assert candidate.git.smart_merge_equivalent_to_base is True
-    assert "all unique commit subjects match recent main squash-merge subjects" in candidate.proof
+    assert candidate.classification == "unique_unharvested"
+    assert candidate.cleanup_candidate is False
+    assert candidate.git.smart_merge_equivalent_to_base is False
+    assert (
+        "all unique commit subjects match recent main squash-merge subjects "
+        "(advisory; patch proof still required)"
+    ) in candidate.proof
     assert candidate.links["smart_merge_matched_subjects"] == [
         "feat(scripts): list active sessions [lane: P42]",
         "docs(status): inventory receipt [lane: P42]",

--- a/tests/scripts/test_codex_worktree_value_inventory.py
+++ b/tests/scripts/test_codex_worktree_value_inventory.py
@@ -745,11 +745,88 @@ def test_smart_merge_patch_timeout_is_reported(
         size_lookup_failed=False,
     )
 
-    assert candidate.classification == "unique_unharvested"
+    assert candidate.classification == "lookup_failed"
     assert candidate.cleanup_candidate is False
+    assert candidate.git.lookup_failed is True
     assert candidate.git.inspect_timeout is True
     assert any("patch-present rev-list failed" in item for item in candidate.git.lookup_errors)
     assert any("inspect_timeout" in item for item in candidate.proof)
+
+
+def test_smart_merge_merge_commit_lookup_failure_is_protected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import codex_worktree_value_inventory as mod
+
+    root = _candidate(tmp_path)
+    _stub_clean_git(monkeypatch, ahead=2, patch_equivalent=False)
+    monkeypatch.setattr(
+        mod,
+        "branch_unique_merge_commits",
+        lambda *_args, **_kwargs: (None, "command timed out after 1s"),
+    )
+
+    candidate = mod.classify_candidate(
+        root,
+        context=_context(
+            tmp_path,
+            smart_merge_detection=True,
+            smart_merge_main_subjects=[],
+        ),
+        size_bytes=1024,
+        size_lookup_failed=False,
+    )
+
+    assert candidate.classification == "lookup_failed"
+    assert candidate.cleanup_candidate is False
+    assert candidate.git.lookup_failed is True
+    assert candidate.git.inspect_timeout is True
+    assert any(
+        "smart merge merge-commit lookup failed" in item for item in candidate.git.lookup_errors
+    )
+
+
+def test_smart_merge_patch_commit_budget_is_protected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import subprocess
+
+    import codex_worktree_value_inventory as mod
+
+    root = _candidate(tmp_path)
+    _stub_clean_git(monkeypatch, ahead=100, patch_equivalent=False)
+    monkeypatch.setattr(
+        mod,
+        "branch_subjects_match_recent_main",
+        lambda *_args, **_kwargs: (False, []),
+    )
+
+    many_commits = "\n".join(f"{idx:040x}" for idx in range(mod.MAX_SMART_MERGE_PATCH_COMMITS + 1))
+
+    def fake_run_git(args: list[str], *_args: Any, **_kwargs: Any) -> Any:
+        if args[:3] == ["rev-list", "--reverse", "--no-merges"]:
+            return subprocess.CompletedProcess(
+                args=args, returncode=0, stdout=many_commits, stderr=""
+            )
+        raise AssertionError(f"unexpected git call: {args}")
+
+    monkeypatch.setattr(mod, "run_git", fake_run_git)
+
+    candidate = mod.classify_candidate(
+        root,
+        context=_context(
+            tmp_path,
+            smart_merge_detection=True,
+            smart_merge_main_subjects=[],
+        ),
+        size_bytes=1024,
+        size_lookup_failed=False,
+    )
+
+    assert candidate.classification == "lookup_failed"
+    assert candidate.cleanup_candidate is False
+    assert candidate.git.lookup_failed is True
+    assert any("commits exceeds budget" in item for item in candidate.git.lookup_errors)
 
 
 def test_smart_merge_detection_keeps_unmatched_subjects_harvestable(
@@ -766,6 +843,11 @@ def test_smart_merge_detection_keeps_unmatched_subjects_harvestable(
             "feat(scripts): list active sessions",
             "fix(swarm): new unmerged behavior",
         ],
+    )
+    monkeypatch.setattr(
+        mod,
+        "branch_patches_present_on_base",
+        lambda *_args, **_kwargs: (False, []),
     )
 
     candidate = mod.classify_candidate(
@@ -826,6 +908,11 @@ def test_smart_merge_detection_log_failure_keeps_candidate_harvestable(
     root = _candidate(tmp_path)
     _stub_clean_git(monkeypatch, ahead=2, patch_equivalent=False)
     monkeypatch.setattr(mod, "branch_unique_commit_subjects", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        mod,
+        "branch_patches_present_on_base",
+        lambda *_args, **_kwargs: (False, []),
+    )
 
     candidate = mod.classify_candidate(
         root,

--- a/tests/scripts/test_codex_worktree_value_inventory.py
+++ b/tests/scripts/test_codex_worktree_value_inventory.py
@@ -1516,6 +1516,108 @@ def test_classify_candidate_marks_open_pr_when_cache_hit(
     ]
 
 
+def test_classify_candidate_preserves_closed_pr_superseded_by_open_pr(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import codex_worktree_value_inventory as mod
+
+    root = _candidate(tmp_path)
+    _stub_clean_git(monkeypatch, branch="feat/stale", ahead=3, patch_equivalent=False)
+    monkeypatch.setattr(
+        mod,
+        "lookup_branch_prs",
+        lambda *_args, **_kwargs: (
+            [
+                {
+                    "number": 8255,
+                    "state": "CLOSED",
+                    "title": "stale source",
+                    "url": "https://example.test/pr/8255",
+                }
+            ],
+            False,
+            None,
+        ),
+    )
+
+    candidate = mod.classify_candidate(
+        root,
+        context=_context(
+            tmp_path,
+            open_pr_records_cache=[
+                {
+                    "number": 8543,
+                    "title": "feat: replacement",
+                    "body": "Re-cut fresh against current main; supersedes stale PR #8255.",
+                    "url": "https://example.test/pr/8543",
+                    "headRefName": "feat/recut",
+                }
+            ],
+        ),
+        size_bytes=1024,
+        size_lookup_failed=False,
+    )
+
+    assert candidate.classification == "open_pr_or_outbox"
+    assert candidate.decision == "preserve"
+    assert "open PR explicitly supersedes closed source PR for branch" in candidate.proof
+    assert candidate.links["superseding_open_prs"] == [
+        {
+            "number": 8543,
+            "title": "feat: replacement",
+            "url": "https://example.test/pr/8543",
+            "headRefName": "feat/recut",
+            "supersedes_pr": 8255,
+        }
+    ]
+
+
+def test_classify_candidate_keeps_generic_pr_reference_harvestable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import codex_worktree_value_inventory as mod
+
+    root = _candidate(tmp_path)
+    _stub_clean_git(monkeypatch, branch="feat/stale", ahead=3, patch_equivalent=False)
+    monkeypatch.setattr(
+        mod,
+        "lookup_branch_prs",
+        lambda *_args, **_kwargs: (
+            [
+                {
+                    "number": 8255,
+                    "state": "CLOSED",
+                    "title": "stale source",
+                    "url": "https://example.test/pr/8255",
+                }
+            ],
+            False,
+            None,
+        ),
+    )
+
+    candidate = mod.classify_candidate(
+        root,
+        context=_context(
+            tmp_path,
+            open_pr_records_cache=[
+                {
+                    "number": 8543,
+                    "title": "feat: related work",
+                    "body": "Refs #8255 for historical background.",
+                    "url": "https://example.test/pr/8543",
+                    "headRefName": "feat/related",
+                }
+            ],
+        ),
+        size_bytes=1024,
+        size_lookup_failed=False,
+    )
+
+    assert candidate.classification == "unique_unharvested"
+    assert candidate.links["superseding_open_prs"] == []
+
+
 # ---------------------------------------------------------------------------
 # Git-timeout hardening: a hung `git status` (or any git lookup) must never
 # hang the inventory, and a timed-out candidate must stay protected.

--- a/tests/scripts/test_codex_worktree_value_inventory.py
+++ b/tests/scripts/test_codex_worktree_value_inventory.py
@@ -801,7 +801,7 @@ def test_branch_patches_present_on_base_uses_temp_index_only(tmp_path: Path) -> 
         )
         return proc.stdout.strip()
 
-    git("init")
+    git("init", "-b", "master")
     git("config", "user.email", "test@example.test")
     git("config", "user.name", "Test User")
     (repo / "tracked.txt").write_text("old\n", encoding="utf-8")
@@ -849,7 +849,7 @@ def test_branch_merge_tree_matches_base_for_noop_merge_commit(tmp_path: Path) ->
         )
         return proc.stdout.strip()
 
-    git("init")
+    git("init", "-b", "master")
     git("config", "user.email", "test@example.test")
     git("config", "user.name", "Test User")
     (repo / "tracked.txt").write_text("base\n", encoding="utf-8")
@@ -1545,6 +1545,23 @@ def test_run_cmd_missing_binary_still_returns_completed_process(tmp_path: Path) 
 
     assert proc.returncode == 124
     assert proc.stdout == ""
+
+
+def test_run_cmd_replaces_invalid_utf8_output(tmp_path: Path) -> None:
+    import codex_worktree_value_inventory as mod
+
+    proc = mod.run_cmd(
+        [
+            sys.executable,
+            "-c",
+            "import sys; sys.stdout.buffer.write(b'patch\\xffpayload')",
+        ],
+        tmp_path,
+        timeout=5,
+    )
+
+    assert proc.returncode == 0
+    assert "patch\ufffdpayload" in proc.stdout
 
 
 def test_timeout_raising_runner_marks_candidate_inspect_timeout_protected(

--- a/tests/scripts/test_codex_worktree_value_inventory.py
+++ b/tests/scripts/test_codex_worktree_value_inventory.py
@@ -1523,27 +1523,26 @@ def test_classify_candidate_preserves_closed_pr_superseded_by_open_pr(
 
     root = _candidate(tmp_path)
     _stub_clean_git(monkeypatch, branch="feat/stale", ahead=3, patch_equivalent=False)
-    monkeypatch.setattr(
-        mod,
-        "lookup_branch_prs",
-        lambda *_args, **_kwargs: (
-            [
-                {
-                    "number": 8255,
-                    "state": "CLOSED",
-                    "title": "stale source",
-                    "url": "https://example.test/pr/8255",
-                }
-            ],
-            False,
-            None,
-        ),
-    )
+
+    def fail_if_called(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("cached branch PR records should avoid per-candidate gh calls")
+
+    monkeypatch.setattr(mod, "run_cmd", fail_if_called)
 
     candidate = mod.classify_candidate(
         root,
         context=_context(
             tmp_path,
+            branch_pr_records_cache={
+                "feat/stale": [
+                    {
+                        "number": 8255,
+                        "state": "CLOSED",
+                        "title": "stale source",
+                        "url": "https://example.test/pr/8255",
+                    }
+                ],
+            },
             open_pr_records_cache=[
                 {
                     "number": 8543,
@@ -1600,6 +1599,16 @@ def test_classify_candidate_keeps_generic_pr_reference_harvestable(
         root,
         context=_context(
             tmp_path,
+            branch_pr_records_cache={
+                "feat/stale": [
+                    {
+                        "number": 8255,
+                        "state": "CLOSED",
+                        "title": "stale source",
+                        "url": "https://example.test/pr/8255",
+                    }
+                ],
+            },
             open_pr_records_cache=[
                 {
                     "number": 8543,

--- a/tests/scripts/test_codex_worktree_value_inventory.py
+++ b/tests/scripts/test_codex_worktree_value_inventory.py
@@ -801,7 +801,7 @@ def test_branch_patches_present_on_base_uses_temp_index_only(tmp_path: Path) -> 
         )
         return proc.stdout.strip()
 
-    git("init", "-b", "master")
+    git("init")
     git("config", "user.email", "test@example.test")
     git("config", "user.name", "Test User")
     (repo / "tracked.txt").write_text("old\n", encoding="utf-8")
@@ -849,7 +849,7 @@ def test_branch_merge_tree_matches_base_for_noop_merge_commit(tmp_path: Path) ->
         )
         return proc.stdout.strip()
 
-    git("init", "-b", "master")
+    git("init")
     git("config", "user.email", "test@example.test")
     git("config", "user.name", "Test User")
     (repo / "tracked.txt").write_text("base\n", encoding="utf-8")

--- a/tests/scripts/test_codex_worktree_value_inventory.py
+++ b/tests/scripts/test_codex_worktree_value_inventory.py
@@ -754,12 +754,14 @@ def test_smart_merge_detection_merge_tree_conflict_falls_through(
     monkeypatch.setattr(
         mod,
         "branch_subjects_match_recent_main",
-        lambda *_args, **_kwargs: (False, []),
+        lambda *_args, **_kwargs: (True, ["feat: looks merged"]),
     )
     monkeypatch.setattr(
         mod,
         "branch_patches_present_on_base",
-        lambda *_args, **_kwargs: (False, []),
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("conflicts must not fall through to patch heuristics")
+        ),
     )
 
     candidate = mod.classify_candidate(
@@ -777,6 +779,7 @@ def test_smart_merge_detection_merge_tree_conflict_falls_through(
     assert candidate.cleanup_candidate is False
     assert candidate.git.lookup_failed is False
     assert candidate.links["smart_merge_merge_tree_error"] == "CONFLICT (content): tracked.txt"
+    assert "merge-tree did not prove branch is already represented on base" in candidate.proof
 
 
 def test_branch_patches_present_on_base_uses_temp_index_only(tmp_path: Path) -> None:

--- a/tests/scripts/test_codex_worktree_value_inventory.py
+++ b/tests/scripts/test_codex_worktree_value_inventory.py
@@ -671,6 +671,54 @@ def test_smart_merge_detection_reclassifies_already_present_patches(
     assert candidate.links["smart_merge_matched_commits"] == ["2f2a1f6", "b46d5c6"]
 
 
+def test_branch_patches_present_on_base_uses_temp_index_only(tmp_path: Path) -> None:
+    import subprocess
+
+    import codex_worktree_value_inventory as mod
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    def git(*args: str) -> str:
+        proc = subprocess.run(
+            ["git", *args],
+            cwd=repo,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        return proc.stdout.strip()
+
+    git("init")
+    git("config", "user.email", "test@example.test")
+    git("config", "user.name", "Test User")
+    (repo / "tracked.txt").write_text("old\n", encoding="utf-8")
+    git("add", "tracked.txt")
+    git("commit", "-m", "base")
+    base_commit = git("rev-parse", "HEAD")
+
+    git("checkout", "-b", "stale")
+    (repo / "tracked.txt").write_text("new\n", encoding="utf-8")
+    git("commit", "-am", "stale patch")
+    stale_commit = git("rev-parse", "HEAD")
+
+    git("checkout", "master")
+    (repo / "tracked.txt").write_text("new\n", encoding="utf-8")
+    git("commit", "-am", "main contains patch")
+    git("checkout", "-b", "unrelated-worktree", base_commit)
+
+    present, matched = mod.branch_patches_present_on_base(
+        repo,
+        "master",
+        "stale",
+        timeout=5,
+    )
+
+    assert present is True
+    assert matched == [stale_commit]
+
+
 def test_smart_merge_detection_preserves_branches_with_merge_commits(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/scripts/test_codex_worktree_value_inventory.py
+++ b/tests/scripts/test_codex_worktree_value_inventory.py
@@ -1478,6 +1478,85 @@ def test_lookup_open_prs_returns_empty_when_branch_not_in_cache(
     assert err is None
 
 
+def test_prefetch_open_pr_heads_uses_open_only_cache_for_open_heads(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import codex_worktree_value_inventory as mod
+
+    calls: list[list[str]] = []
+
+    def fake_run_cmd(args: list[str], *_args: Any, **_kwargs: Any) -> Any:
+        calls.append(args)
+        if "--state" in args and args[args.index("--state") + 1] == "open":
+            payload = [
+                {
+                    "number": 901,
+                    "title": "Older still-open PR",
+                    "url": "https://example.test/pr/901",
+                    "headRefName": "feat/older-open",
+                    "body": "",
+                    "state": "OPEN",
+                    "headRefOid": "older-head",
+                }
+            ]
+        else:
+            payload = [
+                {
+                    "number": 902,
+                    "title": "Recent closed PR",
+                    "url": "https://example.test/pr/902",
+                    "headRefName": "feat/recent-closed",
+                    "body": "",
+                    "state": "CLOSED",
+                    "headRefOid": "closed-head",
+                }
+            ]
+        return mod.subprocess.CompletedProcess(
+            args=args,
+            returncode=0,
+            stdout=json.dumps(payload),
+            stderr="",
+        )
+
+    monkeypatch.setattr(mod, "run_cmd", fake_run_cmd)
+
+    cache, records, branch_records, failed, err = mod.prefetch_open_pr_heads(
+        tmp_path,
+        timeout=1,
+    )
+
+    assert failed is False
+    assert err is None
+    assert [call[call.index("--state") + 1] for call in calls] == ["open", "all"]
+    assert cache == {
+        "feat/older-open": [
+            {
+                "number": 901,
+                "title": "Older still-open PR",
+                "url": "https://example.test/pr/901",
+                "headRefName": "feat/older-open",
+                "body": "",
+                "state": "OPEN",
+                "headRefOid": "older-head",
+            }
+        ]
+    }
+    assert records == cache["feat/older-open"]
+    assert branch_records == {
+        "feat/recent-closed": [
+            {
+                "number": 902,
+                "title": "Recent closed PR",
+                "url": "https://example.test/pr/902",
+                "headRefName": "feat/recent-closed",
+                "body": "",
+                "state": "CLOSED",
+                "headRefOid": "closed-head",
+            }
+        ]
+    }
+
+
 def test_classify_candidate_marks_open_pr_when_cache_hit(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/scripts/test_codex_worktree_value_inventory.py
+++ b/tests/scripts/test_codex_worktree_value_inventory.py
@@ -441,6 +441,32 @@ def test_terminal_receipt_path_heads_reads_harvest_receipt_source_candidate(
     assert refs[str(repo_path.resolve())] == {"abcdef123456"}
 
 
+def test_terminal_receipt_path_heads_reads_object_decision_outcome(
+    tmp_path: Path,
+) -> None:
+    import codex_worktree_value_inventory as mod
+
+    root = _candidate(tmp_path)
+    receipt_dir = tmp_path / ".aragora" / "worktree-harvest" / "harvest-receipts"
+    receipt_dir.mkdir(parents=True)
+    (receipt_dir / "preserve.json").write_text(
+        json.dumps(
+            {
+                "decision": {"outcome": "preserve_existing_merged_pr"},
+                "selected_candidate": {
+                    "path": str(root),
+                    "head": "abcdef123456",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    refs = mod.terminal_receipt_path_heads([receipt_dir])
+
+    assert refs[str(root.resolve())] == {"abcdef123456"}
+
+
 def test_unique_unharvested_when_ahead_and_not_patch_equivalent(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -578,6 +604,42 @@ def test_smart_merge_detection_reclassifies_matching_subjects(
     ]
 
 
+def test_smart_merge_detection_reclassifies_already_present_patches(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import codex_worktree_value_inventory as mod
+
+    root = _candidate(tmp_path)
+    _stub_clean_git(monkeypatch, ahead=2, patch_equivalent=False)
+    monkeypatch.setattr(
+        mod,
+        "branch_subjects_match_recent_main",
+        lambda *_args, **_kwargs: (False, []),
+    )
+    monkeypatch.setattr(
+        mod,
+        "branch_patches_present_on_base",
+        lambda *_args, **_kwargs: (True, ["2f2a1f6", "b46d5c6"]),
+    )
+
+    candidate = mod.classify_candidate(
+        root,
+        context=_context(
+            tmp_path,
+            smart_merge_detection=True,
+            smart_merge_main_subjects=[],
+        ),
+        size_bytes=1024,
+        size_lookup_failed=False,
+    )
+
+    assert candidate.classification == "patch_equivalent_or_merged"
+    assert candidate.cleanup_candidate is True
+    assert candidate.git.smart_merge_equivalent_to_base is True
+    assert "all unique commit patches are already present on base" in candidate.proof
+    assert candidate.links["smart_merge_matched_commits"] == ["2f2a1f6", "b46d5c6"]
+
+
 def test_smart_merge_detection_keeps_unmatched_subjects_harvestable(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -600,6 +662,40 @@ def test_smart_merge_detection_keeps_unmatched_subjects_harvestable(
             tmp_path,
             smart_merge_detection=True,
             smart_merge_main_subjects=["feat(scripts): list active sessions (#7260)"],
+        ),
+        size_bytes=1024,
+        size_lookup_failed=False,
+    )
+
+    assert candidate.classification == "unique_unharvested"
+    assert candidate.cleanup_candidate is False
+    assert candidate.git.smart_merge_equivalent_to_base is False
+
+
+def test_smart_merge_detection_keeps_unapplied_patches_harvestable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import codex_worktree_value_inventory as mod
+
+    root = _candidate(tmp_path)
+    _stub_clean_git(monkeypatch, ahead=2, patch_equivalent=False)
+    monkeypatch.setattr(
+        mod,
+        "branch_subjects_match_recent_main",
+        lambda *_args, **_kwargs: (False, []),
+    )
+    monkeypatch.setattr(
+        mod,
+        "branch_patches_present_on_base",
+        lambda *_args, **_kwargs: (False, ["2f2a1f6"]),
+    )
+
+    candidate = mod.classify_candidate(
+        root,
+        context=_context(
+            tmp_path,
+            smart_merge_detection=True,
+            smart_merge_main_subjects=[],
         ),
         size_bytes=1024,
         size_lookup_failed=False,

--- a/tests/scripts/test_codex_worktree_value_inventory.py
+++ b/tests/scripts/test_codex_worktree_value_inventory.py
@@ -96,6 +96,11 @@ def _stub_clean_git(
         "branch_unique_merge_commits",
         lambda *_args, **_kwargs: ([], None),
     )
+    monkeypatch.setattr(
+        mod,
+        "branch_merge_tree_matches_base",
+        lambda *_args, **_kwargs: (False, None),
+    )
 
 
 def test_default_scan_preserves_foreign_repo_as_lookup_failed(
@@ -671,6 +676,69 @@ def test_smart_merge_detection_reclassifies_already_present_patches(
     assert candidate.links["smart_merge_matched_commits"] == ["2f2a1f6", "b46d5c6"]
 
 
+def test_smart_merge_detection_reclassifies_noop_merge_tree(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import codex_worktree_value_inventory as mod
+
+    root = _candidate(tmp_path)
+    _stub_clean_git(monkeypatch, ahead=3, patch_equivalent=False)
+    monkeypatch.setattr(
+        mod,
+        "branch_merge_tree_matches_base",
+        lambda *_args, **_kwargs: (True, None),
+    )
+
+    candidate = mod.classify_candidate(
+        root,
+        context=_context(
+            tmp_path,
+            smart_merge_detection=True,
+            smart_merge_main_subjects=[],
+        ),
+        size_bytes=1024,
+        size_lookup_failed=False,
+    )
+
+    assert candidate.classification == "patch_equivalent_or_merged"
+    assert candidate.cleanup_candidate is True
+    assert candidate.git.smart_merge_equivalent_to_base is True
+    assert "merging branch into base leaves base tree unchanged" in candidate.proof
+    assert candidate.links["smart_merge_merge_tree"] == "origin/main"
+
+
+def test_smart_merge_detection_merge_tree_failure_is_protected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import codex_worktree_value_inventory as mod
+
+    root = _candidate(tmp_path)
+    _stub_clean_git(monkeypatch, ahead=3, patch_equivalent=False)
+    monkeypatch.setattr(
+        mod,
+        "branch_merge_tree_matches_base",
+        lambda *_args, **_kwargs: (None, "merge conflict"),
+    )
+
+    candidate = mod.classify_candidate(
+        root,
+        context=_context(
+            tmp_path,
+            smart_merge_detection=True,
+            smart_merge_main_subjects=[],
+        ),
+        size_bytes=1024,
+        size_lookup_failed=False,
+    )
+
+    assert candidate.classification == "lookup_failed"
+    assert candidate.cleanup_candidate is False
+    assert candidate.git.lookup_failed is True
+    assert any(
+        "smart merge merge-tree lookup failed" in item for item in candidate.git.lookup_errors
+    )
+
+
 def test_branch_patches_present_on_base_uses_temp_index_only(tmp_path: Path) -> None:
     import subprocess
 
@@ -717,6 +785,53 @@ def test_branch_patches_present_on_base_uses_temp_index_only(tmp_path: Path) -> 
 
     assert present is True
     assert matched == [stale_commit]
+
+
+def test_branch_merge_tree_matches_base_for_noop_merge_commit(tmp_path: Path) -> None:
+    import subprocess
+
+    import codex_worktree_value_inventory as mod
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    def git(*args: str) -> str:
+        proc = subprocess.run(
+            ["git", *args],
+            cwd=repo,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        return proc.stdout.strip()
+
+    git("init")
+    git("config", "user.email", "test@example.test")
+    git("config", "user.name", "Test User")
+    (repo / "tracked.txt").write_text("base\n", encoding="utf-8")
+    git("add", "tracked.txt")
+    git("commit", "-m", "base")
+
+    git("checkout", "-b", "stale")
+    (repo / "tracked.txt").write_text("base\nstale value\n", encoding="utf-8")
+    git("commit", "-am", "stale value")
+
+    git("checkout", "master")
+    (repo / "tracked.txt").write_text("base\nstale value\n", encoding="utf-8")
+    git("commit", "-am", "main already has stale value")
+    git("checkout", "stale")
+    git("merge", "--no-ff", "master", "-m", "merge main into stale")
+
+    matches, error = mod.branch_merge_tree_matches_base(
+        repo,
+        "master",
+        "stale",
+        timeout=5,
+    )
+
+    assert error is None
+    assert matches is True
 
 
 def test_smart_merge_detection_preserves_branches_with_merge_commits(

--- a/tests/scripts/test_codex_worktree_value_inventory.py
+++ b/tests/scripts/test_codex_worktree_value_inventory.py
@@ -801,7 +801,7 @@ def test_branch_patches_present_on_base_uses_temp_index_only(tmp_path: Path) -> 
         )
         return proc.stdout.strip()
 
-    git("init")
+    git("init", "-b", "master")
     git("config", "user.email", "test@example.test")
     git("config", "user.name", "Test User")
     (repo / "tracked.txt").write_text("old\n", encoding="utf-8")
@@ -849,7 +849,7 @@ def test_branch_merge_tree_matches_base_for_noop_merge_commit(tmp_path: Path) ->
         )
         return proc.stdout.strip()
 
-    git("init")
+    git("init", "-b", "master")
     git("config", "user.email", "test@example.test")
     git("config", "user.name", "Test User")
     (repo / "tracked.txt").write_text("base\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
- teach `codex_worktree_value_inventory.py --smart-merge-detection` to classify stale branches as `patch_equivalent_or_merged` when every unique commit patch is already present on base
- treat harvest preserve receipts with object-form `decision.outcome` as terminal path receipts
- add focused regressions for both false-unique cases

## Validation
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_codex_worktree_value_inventory.py -q`
- `pre-commit run --files scripts/codex_worktree_value_inventory.py tests/scripts/test_codex_worktree_value_inventory.py`
- live dry-run from this branch: `unique_unharvested` dropped from 2 to 0; closure-floor is `receipt_protected`; `codex/swarm-01659fc4-micro-6` is `patch_equivalent_or_merged`

## Notes
Draft only. This does not clean worktrees or mutate shared-root state.
