### PR TITLE
docs(metrics): regenerate docs/METRICS.md to absorb workflow-count drift 88->89

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -12,12 +12,12 @@
 
 | Metric | Value | Source | Command |
 |---|---|---|---|
-| Python files under aragora/ | `4201` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1966457` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python files under aragora/ | `4204` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
+| Python lines of code under aragora/ | `1967148` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `143` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5379` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `221895` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
-| @pytest.mark.parametrize decorators | `788` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
+| Test files (test_*.py under tests/) | `5386` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `221972` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| @pytest.mark.parametrize decorators | `789` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `83` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2870` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
 | OpenAPI operations (HTTP verbs) | `3297` | `docs/api/openapi.json` | `python -c "import json; spec=json.load(open('docs/api/openapi.json')); print(sum(1 for p in spec['paths'].values() for m in p if m.lower() in {'get','post','put','delete','patch','head','options'}))"` |
@@ -28,8 +28,8 @@
 | Allowlisted agent types | `35` | `aragora/config/settings.py` | `grep -A 50 'ALLOWED_AGENT_TYPES' aragora/config/settings.py \| grep -oE "'[a-z-]+'" \| sort -u \| wc -l` |
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `46` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |
-| Markdown files under docs/ | `1007` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
-| GitHub Actions workflows | `88` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
+| Markdown files under docs/ | `1008` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
+| GitHub Actions workflows | `89` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
 | Mypy baseline errors (grandfathered) | `3115` | `.mypy-baseline` | `wc -l .mypy-baseline` |
 
 ## Notes on counting methodology


### PR DESCRIPTION
## Source

VAL-CROSS-008 (METRICS.md drift gate) is RED on fresh `origin/main`: a foreign GitHub Actions workflow landed after the prior metrics regen (PR #8510), so `docs/METRICS.md` is stale at **88** workflows while the tree now has **89**. `python3 scripts/regenerate_metrics.py --check` exits 1.

Authorized under the standing operator Tier-0 exception (`library/operator-approvals.md` Decision 2026-06-17 Option B, reaffirmed 2026-06-21): a SINGLE-FILE `docs/METRICS.md` regeneration. The `docs/METRICS.md` path-freeze is lifted for this one file only.

## Behavior summary

Ran the bare regenerator (`python3 scripts/regenerate_metrics.py`), which rewrites `docs/METRICS.md` from ground truth. Binding change: **GitHub Actions workflows 88 -> 89**. Other refreshed cells are sub-0.5%-threshold ambient ground-truth (Python files 4201->4204, LOC 1966457->1967148, test files 5379->5386, test functions 221895->221972, `@pytest.mark.parametrize` 788->789, docs md 1007->1008).

Zero mission code contribution. `docs/METRICS.md` is the **only** changed file (no `module_tiers.yaml`, no other path).

## Validation (fresh origin/main worktree)

```
$ python3 scripts/regenerate_metrics.py --check     # BEFORE
Metrics drifted:
  DRIFT: GitHub Actions workflows 88 -> 89 (1.1%)
exit=1

$ python3 scripts/regenerate_metrics.py             # writes docs/METRICS.md
$ git status --porcelain                            # exactly one path
 M docs/METRICS.md

$ python3 scripts/regenerate_metrics.py --check     # AFTER
No drift beyond 0.5% threshold.
exit=0

$ make lint
All checks passed!  (exit 0)
```

## Risks

Minimal. Docs-only (Tier 0). The 6 open foreign PRs that also touch `docs/METRICS.md` will resolve their own conflicts after this merges (accepted cost per Option B); this PR does not edit, rebase, or comment on them.
