### PR TITLE
fix(ci): harden import-contract checker private API, layer-count, baseline union

### DIFF
--- a/scripts/ci/check_import_contracts.py
+++ b/scripts/ci/check_import_contracts.py
@@ -33,12 +33,23 @@ Usage
     python3 scripts/ci/check_import_contracts.py --freeze         # shrink baseline
     python3 scripts/ci/check_import_contracts.py --freeze --adopt # initial/grow freeze
 
+Requirements
+------------
+Verified against ``import-linter==2.11`` + ``grimp==3.14``. The checker uses one
+private import-linter symbol (``use_cases._register_contract_types``); access is
+guarded by ``_resolve_register_contract_types`` so a version that renames or
+removes it raises a clear CheckerError (exit 2) instead of an AttributeError. If
+that error appears, pin import-linter to the verified version
+(``python3 -m pip install 'import-linter==2.11'``).
+
 Exit codes
 ----------
     0 -- no new violations (clean, or only resolved violations).
     1 -- one or more NEW violations (fail-on-new).
     2 -- a usage/environment error (missing config, missing baseline, import-linter
-         not installed, or a shrink-only violation on --freeze).
+         not installed, an import-linter API/version mismatch, a layer-count
+         mismatch between .importlinter and LAYER_ORDER, or a shrink-only
+         violation on --freeze).
 """
 
 from __future__ import annotations
@@ -49,6 +60,7 @@ import datetime as dt
 import json
 import subprocess
 import sys
+from collections.abc import Callable
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -82,7 +94,9 @@ def parse_layer_membership(config_path: Path) -> dict[str, str]:
     Returns a dict keyed by BOTH the fully-qualified module name
     (``aragora.config``) and its tail (``config``), each mapping to one of
     LAYER_ORDER. Layer lines are read in declaration order and zipped against
-    LAYER_ORDER positionally.
+    LAYER_ORDER positionally; the number of declared layer lines MUST equal
+    len(LAYER_ORDER) or a CheckerError is raised (a mismatch would silently
+    misalign the positional mapping and drop the extra layers).
     """
     parser = configparser.ConfigParser()
     # Section names contain colons (e.g. [importlinter:contract:aragora-layers]);
@@ -101,11 +115,17 @@ def parse_layer_membership(config_path: Path) -> dict[str, str]:
     if layers_raw is None:
         raise CheckerError(f"No 'layers' contract found in {config_path}")
 
-    membership: dict[str, str] = {}
     layer_lines = [ln.strip() for ln in layers_raw.splitlines() if ln.strip()]
+    if len(layer_lines) != len(LAYER_ORDER):
+        raise CheckerError(
+            f"{config_path} declares {len(layer_lines)} layer line(s) but the checker's "
+            f"LAYER_ORDER expects exactly {len(LAYER_ORDER)} "
+            f"({', '.join(LAYER_ORDER)}). The positional layer -> LAYER_ORDER mapping "
+            "would be misaligned; update LAYER_ORDER and .importlinter together."
+        )
+
+    membership: dict[str, str] = {}
     for index, line in enumerate(layer_lines):
-        if index >= len(LAYER_ORDER):
-            break
         layer_name = LAYER_ORDER[index]
         delimiter = ":" if ":" in line else "|"
         for raw_tail in line.split(delimiter):
@@ -127,6 +147,27 @@ def layer_of(module_full: str, membership: dict[str, str]) -> str | None:
 
 
 # --- Running import-linter --------------------------------------------------
+
+# Verified against this import-linter version (see module docstring "Requirements").
+_VERIFIED_IMPORT_LINTER = "2.11"
+
+
+def _resolve_register_contract_types(use_cases_module: object) -> Callable[..., None]:
+    """Return import-linter's contract-type registrar, or raise on a version mismatch.
+
+    ``_register_contract_types`` is a private import-linter symbol. Accessing it
+    through this guard converts a future-version AttributeError into a clear,
+    actionable CheckerError instead of an opaque crash.
+    """
+    register = getattr(use_cases_module, "_register_contract_types", None)
+    if not callable(register):
+        raise CheckerError(
+            "import-linter API mismatch: 'use_cases._register_contract_types' is "
+            f"unavailable. This checker is verified against import-linter=={_VERIFIED_IMPORT_LINTER}; "
+            f"pin it (python3 -m pip install 'import-linter=={_VERIFIED_IMPORT_LINTER}') or update "
+            "scripts/ci/check_import_contracts.py for the installed import-linter version."
+        )
+    return register
 
 
 def compute_current_violations(config_path: Path) -> dict[str, set[str]]:
@@ -150,7 +191,7 @@ def compute_current_violations(config_path: Path) -> dict[str, set[str]]:
         ) from exc
 
     user_options = use_cases.read_user_options(config_filename=str(config_path))
-    use_cases._register_contract_types(user_options)
+    _resolve_register_contract_types(use_cases)(user_options)
     report = use_cases.create_report(user_options, cache_dir=None)
 
     if report.could_not_run or report.invalid_contract_options:
@@ -226,10 +267,17 @@ def write_baseline(path: Path, violations: dict[str, set[str]], config_path: Pat
 def diff_against_baseline(
     current: dict[str, set[str]], baseline: dict[str, set[str]]
 ) -> tuple[dict[str, set[str]], dict[str, set[str]]]:
-    """Return (new_violations, resolved_violations) per contract."""
+    """Return (new_violations, resolved_violations) per contract.
+
+    Iterates the UNION of current and baseline contract names so a contract that
+    is present in the baseline but absent from ``current`` (e.g. renamed) still
+    has its baselined violations accounted for as resolved rather than silently
+    dropped.
+    """
     new: dict[str, set[str]] = {}
     resolved: dict[str, set[str]] = {}
-    for name, cur in current.items():
+    for name in current.keys() | baseline.keys():
+        cur = current.get(name, set())
         base = baseline.get(name, set())
         new[name] = cur - base
         resolved[name] = base - cur

--- a/tests/ci/test_check_import_contracts.py
+++ b/tests/ci/test_check_import_contracts.py
@@ -33,6 +33,23 @@ def _write_baseline(path: Path, violations: set[str], contract: str = CONTRACT) 
     )
 
 
+def _write_importlinter(path: Path, layer_lines: list[str]) -> None:
+    """Write a minimal .importlinter whose layers contract has the given layer lines."""
+    body = "\n".join(f"    {line}" for line in layer_lines)
+    path.write_text(
+        "[importlinter]\n"
+        "root_package = aragora\n\n"
+        "[importlinter:contract:aragora-layers]\n"
+        "name = test layers\n"
+        "type = layers\n"
+        "containers =\n"
+        "    aragora\n"
+        "layers =\n"
+        f"{body}\n",
+        encoding="utf-8",
+    )
+
+
 # --- config parsing ---------------------------------------------------------
 
 
@@ -44,6 +61,40 @@ def test_parse_layer_membership_real_config():
     assert membership["aragora.config"] == "foundation"
     # tail keys resolve too
     assert membership["config"] == "foundation"
+
+
+def test_parse_layer_membership_real_config_has_exact_layer_count(tmp_path):
+    # Sanity guard for the positional mapping: the real .importlinter must declare
+    # exactly len(LAYER_ORDER) layer lines, otherwise parse_layer_membership raises.
+    membership = cic.parse_layer_membership(_REAL_CONFIG)
+    assert membership  # non-empty, i.e. the real config matches LAYER_ORDER's length
+
+
+def test_parse_layer_membership_rejects_too_few_layers(tmp_path):
+    cfg = tmp_path / ".importlinter"
+    _write_importlinter(cfg, ["server", "workflow", "debate"])  # 3 != len(LAYER_ORDER)
+    with pytest.raises(cic.CheckerError) as excinfo:
+        cic.parse_layer_membership(cfg)
+    assert "layer" in str(excinfo.value).lower()
+
+
+def test_parse_layer_membership_rejects_too_many_layers(tmp_path):
+    cfg = tmp_path / ".importlinter"
+    # 6 layer lines: an extra line would be silently truncated by the old code.
+    _write_importlinter(cfg, ["server", "workflow", "debate", "storage", "config", "extra"])
+    with pytest.raises(cic.CheckerError) as excinfo:
+        cic.parse_layer_membership(cfg)
+    assert "layer" in str(excinfo.value).lower()
+
+
+def test_parse_layer_membership_exact_count_succeeds(tmp_path):
+    cfg = tmp_path / ".importlinter"
+    _write_importlinter(
+        cfg, ["server", "workflow", "debate", "storage", "config"]
+    )  # exactly len(LAYER_ORDER)
+    membership = cic.parse_layer_membership(cfg)
+    assert membership["aragora.server"] == "interface"
+    assert membership["aragora.config"] == "foundation"
 
 
 def test_layer_of_full_and_tail():
@@ -61,6 +112,27 @@ def test_parse_layers_arg_valid_and_invalid():
         cic._parse_layers_arg("foundation,bogus")
 
 
+# --- import-linter private-API guard ----------------------------------------
+
+
+def test_resolve_register_contract_types_returns_callable_when_present():
+    import types
+
+    fake = types.SimpleNamespace(_register_contract_types=lambda user_options: None)
+    resolved = cic._resolve_register_contract_types(fake)
+    assert callable(resolved)
+
+
+def test_resolve_register_contract_types_raises_clear_error_on_version_mismatch():
+    import types
+
+    # A future import-linter that renamed/removed the private symbol.
+    fake = types.SimpleNamespace()
+    with pytest.raises(cic.CheckerError) as excinfo:
+        cic._resolve_register_contract_types(fake)
+    assert "import-linter" in str(excinfo.value).lower()
+
+
 # --- diff / filter ----------------------------------------------------------
 
 
@@ -70,6 +142,19 @@ def test_diff_against_baseline_new_and_resolved():
     new, resolved = cic.diff_against_baseline(current, baseline)
     assert new[CONTRACT] == {"c -> d"}
     assert resolved[CONTRACT] == {"e -> f"}
+
+
+def test_diff_against_baseline_keeps_baseline_only_contract():
+    # A contract present in the baseline but absent from current (e.g. renamed)
+    # must still be accounted for via the union of keys: its violations surface
+    # as RESOLVED rather than being silently dropped.
+    current = {"new-name": {"a -> b"}}
+    baseline = {"old-name": {"a -> b", "c -> d"}}
+    new, resolved = cic.diff_against_baseline(current, baseline)
+    assert resolved["old-name"] == {"a -> b", "c -> d"}
+    assert new["new-name"] == {"a -> b"}
+    # the baseline-only contract introduces no new violations
+    assert new.get("old-name", set()) == set()
 
 
 def test_filter_by_layers_keeps_only_selected_importer_layer():


### PR DESCRIPTION
## Source

Hardens `scripts/ci/check_import_contracts.py` per the three claude review
findings on PR #8311 (the P0 import-contract checker), shipped as one bounded
Tier-2 PR.

## Changes

1. **Unguarded private import-linter API.** The checker calls
   `use_cases._register_contract_types`, a private import-linter symbol. Access
   is now routed through `_resolve_register_contract_types()`, which raises a
   clear, actionable `CheckerError` (exit 2) on a version that renames/removes
   the symbol instead of an opaque `AttributeError`. The verified version
   (`import-linter==2.11` + `grimp==3.14`) is documented in a new module
   docstring "Requirements" section.

2. **Silent layer-count truncation.** `parse_layer_membership()` mapped
   `.importlinter` layer lines to `LAYER_ORDER` positionally and silently
   `break`-truncated extras. It now asserts
   `len(layer_lines) == len(LAYER_ORDER)` and raises `CheckerError` (exit 2) on
   any mismatch, so a drifted `.importlinter` fails loudly rather than
   misaligning the layer map.

3. **Dropped baselined contracts on rename.** `diff_against_baseline()` iterated
   only `current.items()`, dropping a baselined contract that disappeared from
   `current` (e.g. renamed). It now iterates `current.keys() | baseline.keys()`,
   so a baseline-only contract's violations are still accounted for as resolved.

`tests/ci/test_check_import_contracts.py` gains 7 cases (version-mismatch guard
present/absent, too-few/too-many/exact layer counts, real-config exact count,
baseline-only-contract union). Exit-code semantics (0/1/2) are unchanged.

## Validation (worktree, fresh main `ab62d96e0d`)

- `python3 -m pytest tests/ci/test_check_import_contracts.py -q` -> **22 passed**
  (15 existing + 7 new; the 5 behavior-specific new cases were red-first).
- `python3 scripts/ci/check_import_contracts.py` -> **exit 0**, "no new
  import-linter layer violations. baseline holds 106 grandfathered violation(s)."
  (VAL-P0-002 green.)
- Tamper (`aragora.config` -> `aragora.server`): **exit 1** naming the offender;
  restore: **exit 0** (VAL-P0-003 green). Bad layer-count config: **exit 2**.
- `make lint` -> All checks passed!  ·  targeted mypy on the changed file ->
  Success.  ·  typecheck differential -> PASS (`new=62 <= drift=66`).
- `make test-smoke` -> Smoke tests passed!  ·  smoke tier -> passed.

## Risks

Low. Pure hardening of a standalone CI checker script + its unit tests; no module
structure change (no METRICS/module_tiers regen), no public API, no workflow
edits. The checker stays green on clean main with identical exit-code semantics.

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>
