### PR TITLE
docs(ci): reconcile import graph docstring and fix invalid noqa directives

### DIFF
--- a/scripts/ci/measure_import_graph.py
+++ b/scripts/ci/measure_import_graph.py
@@ -22,13 +22,15 @@ Two deliberate measurement choices
    under an ``if TYPE_CHECKING:`` guard are type-only: they never execute, so
    they cannot create a real runtime circular import. Counting them would
    conflate type annotations with runtime coupling and would perversely reward
-   deleting type hints. With them excluded the package has 139 mutual cycles;
-   including them inflates the count to 183. We pin the honest (excluded) value.
+   deleting type hints. With them excluded the package has 140 mutual cycles
+   (representing 140 cycles across 4,154 modules currently, drifting from
+   the audit-time 139 cycles across 4,152 modules); including them inflates
+   the count to 183. We pin the honest (excluded) value (140).
 
 2. **The checkout root is forced onto ``sys.path[0]`` before building the
    graph.** Otherwise grimp resolves the SDK namespace package
    ``sdk/python/aragora`` (2 modules) instead of the real ``aragora`` package
-   (~4,152 modules). Verified on PR #8311 (see mission library/environment.md).
+   (~4,154 modules, or 4,152 at audit-time). Verified on PR #8311 (see mission library/environment.md).
 
 Usage
 -----
@@ -73,7 +75,7 @@ class MeasureError(RuntimeError):
 
 def _force_repo_root_on_syspath() -> None:
     """Put the checkout root at ``sys.path[0]`` so grimp resolves the real
-    ``aragora`` package (~4,152 modules), not the SDK namespace package."""
+    ``aragora`` package (~4,154 modules), not the SDK namespace package."""
     root = str(REPO_ROOT)
     while root in sys.path:
         sys.path.remove(root)

--- a/tests/agents/test_fallback.py
+++ b/tests/agents/test_fallback.py
@@ -1140,7 +1140,7 @@ class TestMultiProviderFallbackStream:
 
         async def failing_stream(*args, **kwargs):
             raise RuntimeError("Rate limit")
-            yield  # noqa: unreachable - makes this an async generator
+            yield  # makes this an async generator
 
         async def successful_stream(*args, **kwargs):
             for token in ["Hello", " world"]:
@@ -1182,7 +1182,7 @@ class TestMultiProviderFallbackStream:
 
         async def policy_error_stream(*args, **kwargs):
             raise RuntimeError("Blocked by content policy filter")
-            yield  # noqa: unreachable - makes this an async generator
+            yield  # makes this an async generator
 
         async def successful_stream(*args, **kwargs):
             for token in ["Hello"]:

--- a/tests/handlers/billing/test_core_reporting.py
+++ b/tests/handlers/billing/test_core_reporting.py
@@ -724,7 +724,7 @@ class TestUsageExportCSV:
         @contextmanager
         def failing_transaction():
             raise sqlite3.Error("Database locked")
-            yield  # noqa: unreachable
+            yield  # needed for generator syntax
 
         user_store._transaction = failing_transaction
         h = BillingHandler(ctx={"user_store": user_store})
@@ -738,7 +738,7 @@ class TestUsageExportCSV:
         @contextmanager
         def failing_transaction():
             raise OSError("Disk full")
-            yield  # noqa: unreachable
+            yield  # needed for generator syntax
 
         user_store._transaction = failing_transaction
         h = BillingHandler(ctx={"user_store": user_store})
@@ -752,7 +752,7 @@ class TestUsageExportCSV:
         @contextmanager
         def failing_transaction():
             raise ValueError("Invalid data")
-            yield  # noqa: unreachable
+            yield  # needed for generator syntax
 
         user_store._transaction = failing_transaction
         h = BillingHandler(ctx={"user_store": user_store})

--- a/tests/handlers/features/test_cloud_storage.py
+++ b/tests/handlers/features/test_cloud_storage.py
@@ -708,7 +708,7 @@ class TestListFiles:
 
         async def list_files_gen(path):
             raise ConnectionError("network failure")
-            yield  # noqa: unreachable
+            yield
 
         mock_connector.list_files = list_files_gen
         del mock_connector.list_folders

--- a/tests/resilience/test_handler_resilience.py
+++ b/tests/resilience/test_handler_resilience.py
@@ -157,7 +157,7 @@ class TestSlackResilience:
         @asynccontextmanager
         async def _raise(*a, **kw):
             raise aiohttp.ClientError("Connection refused")
-            yield  # noqa: unreachable - needed for generator syntax
+            yield  # needed for generator syntax
 
         mock_session = MagicMock()
         mock_session.closed = False
@@ -180,7 +180,7 @@ class TestSlackResilience:
         @asynccontextmanager
         async def _raise(*a, **kw):
             raise aiohttp.ClientError("Connection refused")
-            yield  # noqa: unreachable
+            yield  # needed for generator syntax
 
         mock_session = MagicMock()
         mock_session.closed = False
@@ -281,7 +281,7 @@ class TestDiscordResilience:
         @asynccontextmanager
         async def _raise(*a, **kw):
             raise asyncio.TimeoutError()
-            yield  # noqa: unreachable
+            yield  # needed for generator syntax
 
         mock_session = MagicMock()
         mock_session.closed = False
@@ -392,7 +392,7 @@ class TestTeamsResilience:
         @asynccontextmanager
         async def _raise(*a, **kw):
             raise aiohttp.ClientError("Connection refused")
-            yield  # noqa: unreachable
+            yield  # needed for generator syntax
 
         mock_session = MagicMock()
         mock_session.closed = False


### PR DESCRIPTION
## Source Issue
Fulfills misc-p0-tooling-docs-noqa feature requirements.

## Behavior Summary
1. Reconciles the docstring in `scripts/ci/measure_import_graph.py` which cited 139 mutual cycles and 4,152 modules at audit-time with the current pinned baseline of 140 mutual cycles and 4,154 modules, noting the audit-time vs current drift explicitly.
2. Sweeps and resolves all 10 malformed/invalid `# noqa` directives in test files warned by the ruff linter, keeping clean explanatory comments where helpful.

This PR is strictly docs/test-only (Tier 0).

## Validation Performed
- Ran `make lint` which now passes with 0 warnings or errors (including no invalid-noqa warnings).
- Ran `python3 -m pytest tests/agents/test_fallback.py tests/resilience/test_handler_resilience.py tests/handlers/billing/test_core_reporting.py tests/handlers/features/test_cloud_storage.py` inside our worktree: 374 passed.
- Ran `make test-smoke` inside our worktree: all core/server/memory imports and startup checks passed successfully.

## Risks
None. These are non-functional documentation and test comment cleanups with no production code changes.