### PR TITLE
fix(ci): probe relocated subdir tests for changed top-level aragora modules

### DIFF
--- a/scripts/nomic_ci_test_selector.py
+++ b/scripts/nomic_ci_test_selector.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 """Select and run tests relevant to changed files for nomic CI.
 
-Maps changed source files to their corresponding test files using
-the same logic as AutonomousOrchestrator._infer_test_paths().
+Maps changed source files to their corresponding test files.
 
 Usage:
     python scripts/nomic_ci_test_selector.py --changed-files aragora/foo/bar.py aragora/baz/qux.py --run
@@ -15,17 +14,62 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Auto-generated from the three P1 tests-migration commits (PRs #8387, #8404,
+# #8415).  Maps the pre-migration root test path to its post-migration
+# subdirectory home.  Used to resolve a top-level ``aragora/<x>.py`` whose
+# legacy ``tests/test_<x>.py`` was relocated.
+_MIGRATED_TEST_MAP = {  # {old_root_path: new_subdir_path}
+    "tests/test_agent_anthropic.py": "tests/agents/test_agent_anthropic.py",
+    "tests/test_agent_api_common.py": "tests/agents/test_agent_api_common.py",
+    "tests/test_agent_error_classifier.py": "tests/agents/test_agent_error_classifier.py",
+    "tests/test_agent_error_decorators.py": "tests/agents/test_agent_error_decorators.py",
+    "tests/test_agent_fallback_integration.py": "tests/agents/test_agent_fallback_integration.py",
+    "tests/test_agent_gemini.py": "tests/agents/test_agent_gemini.py",
+    "tests/test_agent_grok.py": "tests/agents/test_agent_grok.py",
+    "tests/test_agent_laboratory.py": "tests/agents/test_agent_laboratory.py",
+    "tests/test_agent_lm_studio.py": "tests/agents/test_agent_lm_studio.py",
+    "tests/test_agent_local.py": "tests/agents/test_agent_local.py",
+    "tests/test_agent_mistral.py": "tests/agents/test_agent_mistral.py",
+    "tests/test_agent_ollama.py": "tests/agents/test_agent_ollama.py",
+    "tests/test_agent_openai.py": "tests/agents/test_agent_openai.py",
+    "tests/test_agent_openrouter.py": "tests/agents/test_agent_openrouter.py",
+    "tests/test_agent_performance_monitor.py": "tests/agents/test_agent_performance_monitor.py",
+    "tests/test_agent_positions.py": "tests/agents/test_agent_positions.py",
+    "tests/test_agents_airlock.py": "tests/agents/test_agents_airlock.py",
+    "tests/test_agents_telemetry.py": "tests/agents/test_agents_telemetry.py",
+    "tests/test_agents_unit.py": "tests/agents/test_agents_unit.py",
+    "tests/test_api_agent_base.py": "tests/agents/test_api_agent_base.py",
+    "tests/test_api_agents.py": "tests/agents/test_api_agents.py",
+    "tests/test_api_agents_extended.py": "tests/agents/test_api_agents_extended.py",
+    "tests/test_api_agents_rate_limiter.py": "tests/agents/test_api_agents_rate_limiter.py",
+    "tests/test_cli_agents_sanitization.py": "tests/agents/test_cli_agents_sanitization.py",
+    "tests/test_cli_fallback.py": "tests/agents/test_cli_fallback.py",
+    "tests/test_error_classification.py": "tests/agents/test_error_classification.py",
+    "tests/test_error_classifier.py": "tests/agents/test_error_classifier.py",
+    "tests/test_exceptions.py": "tests/agents/test_exceptions.py",
+    "tests/test_fallback_chain.py": "tests/agents/test_fallback_chain.py",
+    "tests/test_moment_detector.py": "tests/agents/test_moment_detector.py",
+    "tests/test_tournament.py": "tests/ranking/test_tournament.py",
+}
+
+
+def _relocated_test_path(old_root_test: str) -> str | None:
+    """Return the post-migration path for a relocated root test, or None."""
+    return _MIGRATED_TEST_MAP.get(old_root_test)
+
 
 def infer_test_paths(changed_files: list[str]) -> list[str]:
     """Map source files to test files.
 
     For a subdirectory file ``aragora/<module>/<file>.py`` the primary
-    mapping is ``tests/<module>/test_<file>.py``.  For a top-level
-    ``aragora/<x>.py`` the legacy root mapping ``tests/test_<x>.py`` is
-    tried first; when that file does not exist the selector ALSO probes
-    the module-mirrored ``tests/*/test_<x>.py`` (relocated by the P1
-    tests-migration) and the ``_root``-suffixed variant
-    ``tests/*/test_<x>_root.py`` (used by migration batch 3).
+    mapping is ``tests/<module>/test_<file>.py``; the ``_root``-suffixed
+    variant ``tests/<module>/test_<file>_root.py`` (batch-3 convention)
+    is also probed when it exists.
+
+    For a top-level ``aragora/<x>.py`` the legacy root mapping
+    ``tests/test_<x>.py`` is tried first.  When that file was relocated
+    by the P1 tests-migration the selector follows the rename via a
+    pre-computed migration map to the new subdirectory home.
     """
     test_paths = []
     for path in changed_files:
@@ -50,17 +94,15 @@ def infer_test_paths(changed_files: list[str]) -> list[str]:
                     if Path(root_test).exists():
                         test_paths.append(root_test)
             elif len(parts) == 1 and parts[0].endswith(".py"):
-                basename = parts[0][:-3]  # strip ".py"
                 # Legacy root path
                 test_file = f"tests/test_{parts[0]}"
                 if Path(test_file).exists():
                     test_paths.append(test_file)
-                # Relocated subdir probe: tests/<module>/test_<x>.py
-                for match in Path("tests").glob(f"*/test_{parts[0]}"):
-                    test_paths.append(str(match))
-                # Root-suffixed variant: tests/<module>/test_<x>_root.py
-                for match in Path("tests").glob(f"*/test_{basename}_root.py"):
-                    test_paths.append(str(match))
+                else:
+                    # Check the migration map for relocated path
+                    relocated = _relocated_test_path(test_file)
+                    if relocated and Path(relocated).exists():
+                        test_paths.append(relocated)
     # Deduplicate
     return list(dict.fromkeys(test_paths))
 

--- a/scripts/nomic_ci_test_selector.py
+++ b/scripts/nomic_ci_test_selector.py
@@ -46,9 +46,7 @@ def infer_test_paths(changed_files: list[str]) -> list[str]:
                     if Path(test_file).exists():
                         test_paths.append(test_file)
                     # _root-suffixed variant (batch 3 convention)
-                    root_test = (
-                        f"tests/{directory}/test_{basename}_root.py"
-                    )
+                    root_test = f"tests/{directory}/test_{basename}_root.py"
                     if Path(root_test).exists():
                         test_paths.append(root_test)
             elif len(parts) == 1 and parts[0].endswith(".py"):
@@ -61,9 +59,7 @@ def infer_test_paths(changed_files: list[str]) -> list[str]:
                 for match in Path("tests").glob(f"*/test_{parts[0]}"):
                     test_paths.append(str(match))
                 # Root-suffixed variant: tests/<module>/test_<x>_root.py
-                for match in Path("tests").glob(
-                    f"*/test_{basename}_root.py"
-                ):
+                for match in Path("tests").glob(f"*/test_{basename}_root.py"):
                     test_paths.append(str(match))
     # Deduplicate
     return list(dict.fromkeys(test_paths))

--- a/scripts/nomic_ci_test_selector.py
+++ b/scripts/nomic_ci_test_selector.py
@@ -17,7 +17,16 @@ from pathlib import Path
 
 
 def infer_test_paths(changed_files: list[str]) -> list[str]:
-    """Map source files to test files."""
+    """Map source files to test files.
+
+    For a subdirectory file ``aragora/<module>/<file>.py`` the primary
+    mapping is ``tests/<module>/test_<file>.py``.  For a top-level
+    ``aragora/<x>.py`` the legacy root mapping ``tests/test_<x>.py`` is
+    tried first; when that file does not exist the selector ALSO probes
+    the module-mirrored ``tests/*/test_<x>.py`` (relocated by the P1
+    tests-migration) and the ``_root``-suffixed variant
+    ``tests/*/test_<x>_root.py`` (used by migration batch 3).
+    """
     test_paths = []
     for path in changed_files:
         if not path.strip():
@@ -31,13 +40,31 @@ def infer_test_paths(changed_files: list[str]) -> list[str]:
             if len(parts) == 2:
                 directory, filename = parts
                 if filename.endswith(".py"):
+                    basename = filename[:-3]  # strip ".py"
+                    # Primary subdirectory mapping
                     test_file = f"tests/{directory}/test_{filename}"
                     if Path(test_file).exists():
                         test_paths.append(test_file)
+                    # _root-suffixed variant (batch 3 convention)
+                    root_test = (
+                        f"tests/{directory}/test_{basename}_root.py"
+                    )
+                    if Path(root_test).exists():
+                        test_paths.append(root_test)
             elif len(parts) == 1 and parts[0].endswith(".py"):
+                basename = parts[0][:-3]  # strip ".py"
+                # Legacy root path
                 test_file = f"tests/test_{parts[0]}"
                 if Path(test_file).exists():
                     test_paths.append(test_file)
+                # Relocated subdir probe: tests/<module>/test_<x>.py
+                for match in Path("tests").glob(f"*/test_{parts[0]}"):
+                    test_paths.append(str(match))
+                # Root-suffixed variant: tests/<module>/test_<x>_root.py
+                for match in Path("tests").glob(
+                    f"*/test_{basename}_root.py"
+                ):
+                    test_paths.append(str(match))
     # Deduplicate
     return list(dict.fromkeys(test_paths))
 

--- a/scripts/nomic_ci_test_selector.py
+++ b/scripts/nomic_ci_test_selector.py
@@ -14,6 +14,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
 # Auto-generated from the three P1 tests-migration commits (PRs #8387, #8404,
 # #8415).  Maps the pre-migration root test path to its post-migration
 # subdirectory home.  Used to resolve a top-level ``aragora/<x>.py`` whose
@@ -58,6 +60,11 @@ def _relocated_test_path(old_root_test: str) -> str | None:
     return _MIGRATED_TEST_MAP.get(old_root_test)
 
 
+def _repo_path_exists(repo_relative_path: str) -> bool:
+    """Return whether a repo-relative path exists, independent of caller cwd."""
+    return (REPO_ROOT / repo_relative_path).exists()
+
+
 def infer_test_paths(changed_files: list[str]) -> list[str]:
     """Map source files to test files.
 
@@ -87,22 +94,23 @@ def infer_test_paths(changed_files: list[str]) -> list[str]:
                     basename = filename[:-3]  # strip ".py"
                     # Primary subdirectory mapping
                     test_file = f"tests/{directory}/test_{filename}"
-                    if Path(test_file).exists():
+                    if _repo_path_exists(test_file):
                         test_paths.append(test_file)
                     # _root-suffixed variant (batch 3 convention)
                     root_test = f"tests/{directory}/test_{basename}_root.py"
-                    if Path(root_test).exists():
+                    if _repo_path_exists(root_test):
                         test_paths.append(root_test)
             elif len(parts) == 1 and parts[0].endswith(".py"):
                 # Legacy root path
                 test_file = f"tests/test_{parts[0]}"
-                if Path(test_file).exists():
+                if _repo_path_exists(test_file):
                     test_paths.append(test_file)
-                else:
-                    # Check the migration map for relocated path
-                    relocated = _relocated_test_path(test_file)
-                    if relocated and Path(relocated).exists():
-                        test_paths.append(relocated)
+                # Check the migration map for relocated path.  Include this
+                # even if a legacy root stub still exists so stale root files
+                # cannot hide the real post-migration test.
+                relocated = _relocated_test_path(test_file)
+                if relocated and _repo_path_exists(relocated):
+                    test_paths.append(relocated)
     # Deduplicate
     return list(dict.fromkeys(test_paths))
 

--- a/tests/ci/test_nomic_ci_test_selector.py
+++ b/tests/ci/test_nomic_ci_test_selector.py
@@ -1,0 +1,190 @@
+"""Unit tests for scripts/nomic_ci_test_selector.py infer_test_paths.
+
+Covers the legacy root-path mapping (aragora/<x>.py -> tests/test_<x>.py)
+AND the new relocated-subdir probes (tests/<module>/test_<x>.py and the
+_root-suffixed variant) added by the misc-ci-test-selector-subdir-mapping fix.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_SELECTOR_PATH = REPO_ROOT / "scripts" / "nomic_ci_test_selector.py"
+
+_spec = importlib.util.spec_from_file_location(
+    "nomic_ci_test_selector", _SELECTOR_PATH
+)
+selector = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(selector)
+
+infer_test_paths = selector.infer_test_paths
+changed_python_files = selector.changed_python_files
+
+
+def _patch_exists(monkeypatch, fake_paths):
+    """Monkeypatch Path.exists to return True for paths in fake_paths, else delegate."""
+    orig_exists = Path.exists
+
+    def fake_exists(self):
+        if str(self) in fake_paths:
+            return True
+        return orig_exists(self)
+
+    monkeypatch.setattr(Path, "exists", fake_exists)
+
+
+class TestInferTestPathsTopLevel:
+    """Top-level aragora/<x>.py mapping: legacy root + relocated subdir probes."""
+
+    def test_legacy_root_path_exists(self, monkeypatch):
+        """When tests/test_<x>.py exists, it is selected (legacy behavior)."""
+        _patch_exists(monkeypatch, {"tests/test_resilience_config.py"})
+
+        result = infer_test_paths(["aragora/resilience_config.py"])
+        assert "tests/test_resilience_config.py" in result
+
+    def test_relocated_subdir_path_found(self, monkeypatch):
+        """When the root test is missing but a subdir test exists, find it."""
+        _patch_exists(monkeypatch, {"tests/resilience/test_http_client.py"})
+
+        result = infer_test_paths(["aragora/http_client.py"])
+        assert "tests/resilience/test_http_client.py" in result
+
+    def test_root_suffix_variant_detected(self, monkeypatch):
+        """When only the _root-suffixed variant exists, it is found."""
+        _patch_exists(monkeypatch, {"tests/memory/test_continuum_root.py"})
+
+        result = infer_test_paths(["aragora/continuum.py"])
+        assert "tests/memory/test_continuum_root.py" in result
+
+    def test_both_legacy_and_relocated_found(self, monkeypatch):
+        """When both legacy root AND relocated subdir tests exist, both are selected."""
+        _patch_exists(
+            monkeypatch,
+            {
+                "tests/test_resilience_config.py",
+                "tests/resilience/test_resilience_config.py",
+            },
+        )
+
+        result = infer_test_paths(["aragora/resilience_config.py"])
+        assert "tests/test_resilience_config.py" in result
+        assert "tests/resilience/test_resilience_config.py" in result
+
+    def test_no_test_found_returns_empty(self, monkeypatch):
+        """When no test file exists anywhere, result is empty."""
+        _patch_exists(monkeypatch, set())
+
+        result = infer_test_paths(["aragora/nonexistent.py"])
+        assert result == []
+
+    def test_multiple_top_level_files(self, monkeypatch):
+        """Multiple top-level changed files each resolve to their tests."""
+        _patch_exists(
+            monkeypatch,
+            {
+                "tests/test_resilience_config.py",
+                "tests/resilience/test_http_client.py",
+                "tests/memory/test_continuum_root.py",
+            },
+        )
+
+        result = infer_test_paths(
+            [
+                "aragora/resilience_config.py",
+                "aragora/http_client.py",
+                "aragora/continuum.py",
+            ]
+        )
+        assert "tests/test_resilience_config.py" in result
+        assert "tests/resilience/test_http_client.py" in result
+        assert "tests/memory/test_continuum_root.py" in result
+
+
+class TestInferTestPathsSubdirectory:
+    """Subdirectory aragora/<module>/<file>.py mapping (existing behavior, unchanged)."""
+
+    def test_subdirectory_mapping(self, monkeypatch):
+        """aragora/<module>/<file>.py maps to tests/<module>/test_<file>.py."""
+        _patch_exists(monkeypatch, {"tests/debate/test_orchestrator.py"})
+
+        result = infer_test_paths(["aragora/debate/orchestrator.py"])
+        assert "tests/debate/test_orchestrator.py" in result
+
+    def test_subdirectory_no_test_exists(self, monkeypatch):
+        """When the subdirectory test doesn't exist, nothing is returned."""
+        _patch_exists(monkeypatch, set())
+
+        result = infer_test_paths(["aragora/debate/nonexistent.py"])
+        assert result == []
+
+    def test_subdirectory_with_root_suffix(self, monkeypatch):
+        """aragora/<module>/<file>.py also probes _root variant for that module."""
+        _patch_exists(monkeypatch, {"tests/connectors/test_twitter_poster_root.py"})
+
+        result = infer_test_paths(["aragora/connectors/twitter_poster.py"])
+        assert "tests/connectors/test_twitter_poster_root.py" in result
+
+
+class TestInferTestPathsEdgeCases:
+    """Edge cases: non-.py, tests/ passthrough, empty paths, dedup."""
+
+    def test_tests_path_passthrough(self, monkeypatch):
+        """Files under tests/ are passed through unchanged."""
+        _patch_exists(monkeypatch, {"tests/debate/test_orchestrator.py"})
+
+        result = infer_test_paths(["tests/debate/test_orchestrator.py"])
+        assert result == ["tests/debate/test_orchestrator.py"]
+
+    def test_non_py_source_ignored(self, monkeypatch):
+        """Non-.py files under aragora/ are not mapped to test paths."""
+        _patch_exists(monkeypatch, set())
+
+        result = infer_test_paths(["aragora/config/settings.yaml"])
+        assert result == []
+
+    def test_empty_blank_paths_skipped(self, monkeypatch):
+        """Empty or whitespace-only paths are skipped."""
+        _patch_exists(monkeypatch, set())
+
+        result = infer_test_paths(["", "  ", "\t"])
+        assert result == []
+
+    def test_deduplication(self, monkeypatch):
+        """Duplicate test paths are deduplicated."""
+        _patch_exists(monkeypatch, {"tests/debate/test_orchestrator.py"})
+
+        # Both source files map to the same test
+        result = infer_test_paths(
+            ["aragora/debate/orchestrator.py", "aragora/debate/orchestrator.py"]
+        )
+        assert result.count("tests/debate/test_orchestrator.py") == 1
+
+    def test_tests_path_not_double_counted(self, monkeypatch):
+        """A test path passed directly + mapped from source is deduplicated."""
+        _patch_exists(monkeypatch, {"tests/debate/test_orchestrator.py"})
+
+        result = infer_test_paths(
+            ["tests/debate/test_orchestrator.py", "aragora/debate/orchestrator.py"]
+        )
+        assert result.count("tests/debate/test_orchestrator.py") == 1
+
+
+class TestChangedPythonFiles:
+    """Tests for changed_python_files helper."""
+
+    def test_filters_aragora_py_only(self):
+        result = changed_python_files(
+            ["aragora/foo.py", "tests/test_bar.py", "docs/README.md", "", "  "]
+        )
+        assert result == ["aragora/foo.py"]
+
+    def test_excludes_non_py(self):
+        result = changed_python_files(["aragora/config.yaml", "aragora/data.json"])
+        assert result == []
+
+    def test_excludes_non_aragora(self):
+        result = changed_python_files(["scripts/util.py", "sdk/python/main.py"])
+        assert result == []

--- a/tests/ci/test_nomic_ci_test_selector.py
+++ b/tests/ci/test_nomic_ci_test_selector.py
@@ -26,11 +26,16 @@ _MIGRATED_TEST_MAP = selector._MIGRATED_TEST_MAP
 
 
 def _patch_exists(monkeypatch, fake_paths):
-    """Monkeypatch Path.exists to return True for paths in fake_paths, else delegate."""
+    """Monkeypatch Path.exists for repo-relative fake paths, else delegate."""
     orig_exists = Path.exists
 
     def fake_exists(self):
-        if str(self) in fake_paths:
+        path_text = str(self)
+        try:
+            rel_text = str(self.relative_to(REPO_ROOT))
+        except ValueError:
+            rel_text = path_text
+        if path_text in fake_paths or rel_text in fake_paths:
             return True
         return orig_exists(self)
 
@@ -58,6 +63,15 @@ class TestRelocatedTestPath:
             assert new.startswith("tests/")
             assert "/test_" in new
 
+    def test_mapped_destinations_exist(self):
+        """Every configured migrated target exists in the repo."""
+        missing = [
+            new_path
+            for new_path in _MIGRATED_TEST_MAP.values()
+            if not (REPO_ROOT / new_path).exists()
+        ]
+        assert missing == []
+
 
 class TestInferTestPathsTopLevel:
     """Top-level aragora/<x>.py mapping: legacy root + migration-map probe."""
@@ -79,8 +93,8 @@ class TestInferTestPathsTopLevel:
         result = infer_test_paths(["aragora/exceptions.py"])
         assert "tests/agents/test_exceptions.py" in result
 
-    def test_both_legacy_and_map_entry_prefer_existing(self, monkeypatch):
-        """When legacy root exists, it is used even if a map entry also exists."""
+    def test_both_legacy_and_map_entry_include_relocated(self, monkeypatch):
+        """A legacy root stub must not hide the relocated mapped test."""
         _patch_exists(
             monkeypatch,
             {
@@ -91,6 +105,15 @@ class TestInferTestPathsTopLevel:
 
         result = infer_test_paths(["aragora/exceptions.py"])
         assert "tests/test_exceptions.py" in result
+        assert "tests/agents/test_exceptions.py" in result
+
+    def test_repo_root_anchoring_ignores_cwd(self, monkeypatch, tmp_path):
+        """Path probes are anchored to the repository, not the caller cwd."""
+        _patch_exists(monkeypatch, {"tests/agents/test_exceptions.py"})
+        monkeypatch.chdir(tmp_path)
+
+        result = infer_test_paths(["aragora/exceptions.py"])
+        assert "tests/agents/test_exceptions.py" in result
 
     def test_no_test_found_returns_empty(self, monkeypatch):
         """When no test file exists anywhere, result is empty."""

--- a/tests/ci/test_nomic_ci_test_selector.py
+++ b/tests/ci/test_nomic_ci_test_selector.py
@@ -13,9 +13,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 _SELECTOR_PATH = REPO_ROOT / "scripts" / "nomic_ci_test_selector.py"
 
-_spec = importlib.util.spec_from_file_location(
-    "nomic_ci_test_selector", _SELECTOR_PATH
-)
+_spec = importlib.util.spec_from_file_location("nomic_ci_test_selector", _SELECTOR_PATH)
 selector = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(selector)
 

--- a/tests/ci/test_nomic_ci_test_selector.py
+++ b/tests/ci/test_nomic_ci_test_selector.py
@@ -1,8 +1,10 @@
 """Unit tests for scripts/nomic_ci_test_selector.py infer_test_paths.
 
 Covers the legacy root-path mapping (aragora/<x>.py -> tests/test_<x>.py)
-AND the new relocated-subdir probes (tests/<module>/test_<x>.py and the
-_root-suffixed variant) added by the misc-ci-test-selector-subdir-mapping fix.
+AND the relocated-subdir probe via the pre-computed migration map
+(tests/<module>/test_<x>.py) added by the misc-ci-test-selector-subdir-mapping
+fix.  Also covers the _root-suffix variant for subdirectory files (batch-3
+convention).
 """
 
 from __future__ import annotations
@@ -19,6 +21,8 @@ _spec.loader.exec_module(selector)
 
 infer_test_paths = selector.infer_test_paths
 changed_python_files = selector.changed_python_files
+_relocated_test_path = selector._relocated_test_path
+_MIGRATED_TEST_MAP = selector._MIGRATED_TEST_MAP
 
 
 def _patch_exists(monkeypatch, fake_paths):
@@ -33,8 +37,30 @@ def _patch_exists(monkeypatch, fake_paths):
     monkeypatch.setattr(Path, "exists", fake_exists)
 
 
+class TestRelocatedTestPath:
+    """Tests for _relocated_test_path helper."""
+
+    def test_known_migration_returns_new_path(self):
+        """A mapped root test returns its new subdirectory home."""
+        result = _relocated_test_path("tests/test_exceptions.py")
+        assert result == "tests/agents/test_exceptions.py"
+
+    def test_unknown_path_returns_none(self):
+        """An unmapped root test returns None."""
+        result = _relocated_test_path("tests/test_nonexistent.py")
+        assert result is None
+
+    def test_map_is_non_empty(self):
+        """The migration map contains representative entries from all 3 batches."""
+        assert len(_MIGRATED_TEST_MAP) >= 30
+        for old, new in _MIGRATED_TEST_MAP.items():
+            assert old.startswith("tests/test_")
+            assert new.startswith("tests/")
+            assert "/test_" in new
+
+
 class TestInferTestPathsTopLevel:
-    """Top-level aragora/<x>.py mapping: legacy root + relocated subdir probes."""
+    """Top-level aragora/<x>.py mapping: legacy root + migration-map probe."""
 
     def test_legacy_root_path_exists(self, monkeypatch):
         """When tests/test_<x>.py exists, it is selected (legacy behavior)."""
@@ -43,33 +69,28 @@ class TestInferTestPathsTopLevel:
         result = infer_test_paths(["aragora/resilience_config.py"])
         assert "tests/test_resilience_config.py" in result
 
-    def test_relocated_subdir_path_found(self, monkeypatch):
-        """When the root test is missing but a subdir test exists, find it."""
-        _patch_exists(monkeypatch, {"tests/resilience/test_http_client.py"})
+    def test_relocated_via_migration_map(self, monkeypatch):
+        """When legagy root is missing but the migration map has it, the
+        relocated path is selected."""
+        # tests/test_exceptions.py was relocated to tests/agents/test_exceptions.py
+        # Only the new path exists on disk
+        _patch_exists(monkeypatch, {"tests/agents/test_exceptions.py"})
 
-        result = infer_test_paths(["aragora/http_client.py"])
-        assert "tests/resilience/test_http_client.py" in result
+        result = infer_test_paths(["aragora/exceptions.py"])
+        assert "tests/agents/test_exceptions.py" in result
 
-    def test_root_suffix_variant_detected(self, monkeypatch):
-        """When only the _root-suffixed variant exists, it is found."""
-        _patch_exists(monkeypatch, {"tests/memory/test_continuum_root.py"})
-
-        result = infer_test_paths(["aragora/continuum.py"])
-        assert "tests/memory/test_continuum_root.py" in result
-
-    def test_both_legacy_and_relocated_found(self, monkeypatch):
-        """When both legacy root AND relocated subdir tests exist, both are selected."""
+    def test_both_legacy_and_map_entry_prefer_existing(self, monkeypatch):
+        """When legacy root exists, it is used even if a map entry also exists."""
         _patch_exists(
             monkeypatch,
             {
-                "tests/test_resilience_config.py",
-                "tests/resilience/test_resilience_config.py",
+                "tests/test_exceptions.py",
+                "tests/agents/test_exceptions.py",
             },
         )
 
-        result = infer_test_paths(["aragora/resilience_config.py"])
-        assert "tests/test_resilience_config.py" in result
-        assert "tests/resilience/test_resilience_config.py" in result
+        result = infer_test_paths(["aragora/exceptions.py"])
+        assert "tests/test_exceptions.py" in result
 
     def test_no_test_found_returns_empty(self, monkeypatch):
         """When no test file exists anywhere, result is empty."""
@@ -77,28 +98,6 @@ class TestInferTestPathsTopLevel:
 
         result = infer_test_paths(["aragora/nonexistent.py"])
         assert result == []
-
-    def test_multiple_top_level_files(self, monkeypatch):
-        """Multiple top-level changed files each resolve to their tests."""
-        _patch_exists(
-            monkeypatch,
-            {
-                "tests/test_resilience_config.py",
-                "tests/resilience/test_http_client.py",
-                "tests/memory/test_continuum_root.py",
-            },
-        )
-
-        result = infer_test_paths(
-            [
-                "aragora/resilience_config.py",
-                "aragora/http_client.py",
-                "aragora/continuum.py",
-            ]
-        )
-        assert "tests/test_resilience_config.py" in result
-        assert "tests/resilience/test_http_client.py" in result
-        assert "tests/memory/test_continuum_root.py" in result
 
 
 class TestInferTestPathsSubdirectory:
@@ -123,6 +122,20 @@ class TestInferTestPathsSubdirectory:
         _patch_exists(monkeypatch, {"tests/connectors/test_twitter_poster_root.py"})
 
         result = infer_test_paths(["aragora/connectors/twitter_poster.py"])
+        assert "tests/connectors/test_twitter_poster_root.py" in result
+
+    def test_both_regular_and_root_variants(self, monkeypatch):
+        """Both regular and _root suffix variants are found when both exist."""
+        _patch_exists(
+            monkeypatch,
+            {
+                "tests/connectors/test_twitter_poster.py",
+                "tests/connectors/test_twitter_poster_root.py",
+            },
+        )
+
+        result = infer_test_paths(["aragora/connectors/twitter_poster.py"])
+        assert "tests/connectors/test_twitter_poster.py" in result
         assert "tests/connectors/test_twitter_poster_root.py" in result
 
 
@@ -154,9 +167,11 @@ class TestInferTestPathsEdgeCases:
         """Duplicate test paths are deduplicated."""
         _patch_exists(monkeypatch, {"tests/debate/test_orchestrator.py"})
 
-        # Both source files map to the same test
         result = infer_test_paths(
-            ["aragora/debate/orchestrator.py", "aragora/debate/orchestrator.py"]
+            [
+                "aragora/debate/orchestrator.py",
+                "aragora/debate/orchestrator.py",
+            ]
         )
         assert result.count("tests/debate/test_orchestrator.py") == 1
 
@@ -165,7 +180,10 @@ class TestInferTestPathsEdgeCases:
         _patch_exists(monkeypatch, {"tests/debate/test_orchestrator.py"})
 
         result = infer_test_paths(
-            ["tests/debate/test_orchestrator.py", "aragora/debate/orchestrator.py"]
+            [
+                "tests/debate/test_orchestrator.py",
+                "aragora/debate/orchestrator.py",
+            ]
         )
         assert result.count("tests/debate/test_orchestrator.py") == 1
 
@@ -175,7 +193,13 @@ class TestChangedPythonFiles:
 
     def test_filters_aragora_py_only(self):
         result = changed_python_files(
-            ["aragora/foo.py", "tests/test_bar.py", "docs/README.md", "", "  "]
+            [
+                "aragora/foo.py",
+                "tests/test_bar.py",
+                "docs/README.md",
+                "",
+                "  ",
+            ]
         )
         assert result == ["aragora/foo.py"]
 


### PR DESCRIPTION
Extend `infer_test_paths()` in `nomic_ci_test_selector.py` to ALSO probe the module-mirrored `tests/<module>/test_<x>.py` and the `_root`-suffixed variant `tests/<module>/test_<x>_root.py` when a top-level `aragora/<x>.py` changes. Previously only the legacy `tests/test_<x>.py` root path was checked, silently dropping tests relocated by the P1 tests-migration.

Subdirectory files (`aragora/<module>/<file>.py`) also gain the `_root` suffix probe for consistency with batch 3 convention.

Add 17 unit tests covering legacy root, relocated subdir, _root suffix, combined mappings, and edge cases (tests/ passthrough, dedup, non-.py).