### PR TITLE
docs: replace nonexistent pip extras and stale `serve --offline` flag

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -37,9 +37,9 @@ aragora serve --api-port 8080 --ws-port 8765
 |---------|-----------------|-------|
 | PostgreSQL | `pip install psycopg2-binary` | Production database |
 | Redis | `pip install redis` | Rate limiting, caching |
-| Monitoring | `pip install -e ".[monitoring]"` | Prometheus, Sentry |
-| Observability | `pip install -e ".[observability]"` | OpenTelemetry |
-| Broadcast | `pip install -e ".[broadcast]"` | TTS, audio features |
+| Monitoring | `pip install prometheus-client sentry-sdk` | Prometheus, Sentry |
+| Observability | `pip install opentelemetry-sdk opentelemetry-exporter-otlp` | OpenTelemetry |
+| Broadcast | `pip install edge-tts pydub` | TTS, audio features |
 
 ## Project Structure
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -35,7 +35,7 @@ aragora serve --api-port 8080 --ws-port 8765
 
 | Feature | Install Command | Notes |
 |---------|-----------------|-------|
-| PostgreSQL | `pip install psycopg2-binary` | Production database |
+| PostgreSQL | `pip install asyncpg` | Production database |
 | Redis | `pip install redis` | Rate limiting, caching |
 | Monitoring | `pip install prometheus-client sentry-sdk` | Prometheus, Sentry |
 | Observability | `pip install opentelemetry-sdk opentelemetry-exporter-otlp` | OpenTelemetry |

--- a/docs-site/docs/advanced/rlm-developer.md
+++ b/docs-site/docs/advanced/rlm-developer.md
@@ -328,7 +328,7 @@ async def test_my_function(mock_rlm):
 ```python
 rlm = get_rlm()
 if rlm is None:
-    # Check: Is `pip install aragora[rlm]` installed?
+    # Check: Is the `aragora` package installed (RLM ships with it)?
     # Check: Is ARAGORA_RLM_MODE set correctly?
     # Check: Are required API keys present?
     pass

--- a/docs-site/docs/advanced/rlm-developer.md
+++ b/docs-site/docs/advanced/rlm-developer.md
@@ -328,7 +328,7 @@ async def test_my_function(mock_rlm):
 ```python
 rlm = get_rlm()
 if rlm is None:
-    # Check: Is the `aragora` package installed (RLM ships with it)?
+    # Check: Is Aragora installed? (TRUE RLM also needs `pip install rlm`)
     # Check: Is ARAGORA_RLM_MODE set correctly?
     # Check: Are required API keys present?
     pass

--- a/docs-site/docs/advanced/rlm-user.md
+++ b/docs-site/docs/advanced/rlm-user.md
@@ -14,10 +14,10 @@ Aragora integrates Recursive Language Models (RLM) based on the paper ["Recursiv
 ## Installation
 
 ```bash
-# Install Aragora with RLM support
+# Install Aragora (includes the RLM compression fallback)
 pip install aragora
 
-# Or install the official RLM library directly
+# Add the official `rlm` package for TRUE RLM
 pip install rlm
 ```
 

--- a/docs-site/docs/advanced/rlm-user.md
+++ b/docs-site/docs/advanced/rlm-user.md
@@ -15,7 +15,7 @@ Aragora integrates Recursive Language Models (RLM) based on the paper ["Recursiv
 
 ```bash
 # Install Aragora with RLM support
-pip install aragora[rlm]
+pip install aragora
 
 # Or install the official RLM library directly
 pip install rlm

--- a/docs-site/docs/api/reference.md
+++ b/docs-site/docs/api/reference.md
@@ -2418,7 +2418,7 @@ Generate audio podcasts from debate traces.
 #### POST /api/debates/:id/broadcast
 Generate an MP3 podcast from a debate.
 
-**Rate limited**. Requires the broadcast module (`pip install aragora[broadcast]`).
+**Rate limited**. Requires TTS dependencies (`pip install edge-tts pydub`).
 
 **Response:**
 ```json

--- a/docs-site/docs/contributing/dependencies.md
+++ b/docs-site/docs/contributing/dependencies.md
@@ -20,21 +20,28 @@ pip install aragora[dev]
 pip install aragora[all]
 ```
 
-## Feature-to-Extras Mapping
+## Feature-to-Install Mapping
 
-| Feature | Extras | Size Impact |
-|---------|--------|-------------|
-| CLI debates | (none) | ~50MB |
-| Development/Testing | `dev` | +100MB |
-| Monitoring (Prometheus/Sentry) | `monitoring` | +20MB |
-| Distributed tracing (OpenTelemetry) | `observability` | +30MB |
-| Redis caching | `redis` | +5MB |
-| Database (Supabase/PostgreSQL) | `persistence,postgres` | +40MB |
-| PDF/DOCX processing | `documents` | +30MB |
-| Text-to-speech (basic) | `broadcast` | +50MB |
-| Text-to-speech (premium) | `broadcast-premium` | +500MB |
-| Web research | `research` | +20MB |
-| ML/Embeddings | `ml` | +2GB |
+Aragora's `pyproject.toml` defines these extras: `test`, `dev`, `gateway`,
+`enterprise`, `blockchain`, `connectors`, `experimental`, and `all`. Features
+without a dedicated extra install their optional packages directly.
+
+| Feature | Install | Size Impact |
+|---------|---------|-------------|
+| CLI debates | (base) `pip install aragora` | ~50MB |
+| Development/Testing | `pip install aragora[dev]` | +100MB |
+| Async gateway (FastAPI/uvicorn) | `pip install aragora[gateway]` | +20MB |
+| Database/SSO (asyncpg, Supabase, SAML) | `pip install aragora[enterprise]` | +40MB |
+| Streaming connectors (Kafka/RabbitMQ) | `pip install aragora[connectors]` | +15MB |
+| Blockchain (web3) | `pip install aragora[blockchain]` | +30MB |
+| Monitoring (Prometheus/Sentry) | `pip install prometheus-client sentry-sdk` | +20MB |
+| Distributed tracing (OpenTelemetry) | `pip install opentelemetry-sdk opentelemetry-exporter-otlp` | +30MB |
+| Redis caching | `pip install redis` | +5MB |
+| PDF/DOCX processing | `pip install pypdf python-docx` | +30MB |
+| Text-to-speech (basic) | `pip install edge-tts pydub` | +50MB |
+| Text-to-speech (premium) | `pip install elevenlabs` | +500MB |
+| Web research | `pip install duckduckgo-search beautifulsoup4` | +20MB |
+| ML/Embeddings | `pip install sentence-transformers scikit-learn` | +2GB |
 
 ## Installation Profiles
 
@@ -51,34 +58,34 @@ pip install aragora
 For running the REST/WebSocket server:
 
 ```bash
-pip install aragora[monitoring,observability]
+pip install aragora[gateway]
 ```
 
-**Includes**: Core + Prometheus metrics + OpenTelemetry tracing
+**Includes**: Core + FastAPI and uvicorn (REST/WebSocket server)
 
 ### Profile 3: Production Deployment
 For full production environment:
 
 ```bash
-pip install aragora[monitoring,observability,persistence,postgres,redis]
+pip install aragora[all]
 ```
 
-**Includes**: Core + metrics + tracing + Supabase + PostgreSQL + Redis caching
+**Includes**: Core + all extras (gateway, enterprise, connectors, blockchain, experimental). For metrics and Redis caching, also `pip install prometheus-client redis`.
 
 ### Profile 4: Development
 For contributing to Aragora:
 
 ```bash
-pip install aragora[dev,monitoring]
+pip install aragora[dev]
 ```
 
-**Includes**: Core + pytest + mypy + ruff + bandit + metrics
+**Includes**: Core + pytest + mypy + ruff + bandit
 
 ### Profile 5: Research/Evidence
 For debates with web research and evidence collection:
 
 ```bash
-pip install aragora[documents]
+pip install aragora duckduckgo-search beautifulsoup4 pypdf python-docx
 ```
 
 **Includes**: Core + DuckDuckGo search + PDF/DOCX parsing
@@ -88,19 +95,19 @@ For generating debate audio/video:
 
 ```bash
 # Basic TTS (free, edge-tts)
-pip install aragora[broadcast]
+pip install edge-tts pydub pyttsx3
 
-# Premium TTS (ElevenLabs, AWS Polly, Coqui XTTS)
-pip install aragora[broadcast-premium]
+# Premium TTS: ElevenLabs / AWS Polly / Coqui XTTS
+pip install elevenlabs   # or: boto3 (Polly), TTS (Coqui XTTS)
 ```
 
-**Note**: `broadcast-premium` requires ~500MB and includes PyTorch for XTTS
+**Note**: Coqui XTTS (`pip install TTS`) requires ~500MB and includes PyTorch
 
 ### Profile 7: ML/Semantic Search
 For semantic similarity and embeddings:
 
 ```bash
-pip install aragora[ml]
+pip install sentence-transformers scikit-learn numpy scipy
 ```
 
 **Warning**: This adds ~2GB for sentence-transformers and dependencies
@@ -122,6 +129,8 @@ pip install aragora[ml]
 | urllib3>=2.6.3 | HTTP utilities | CVE fix |
 
 ### Optional Dependencies
+
+The groups below describe related packages. Only `dev`, `test`, `gateway`, `enterprise`, `blockchain`, `connectors`, `experimental`, and `all` are installable as `pip install aragora[<extra>]`; the others are installed as the direct packages listed.
 
 #### `dev` - Development Tools
 ```
@@ -216,22 +225,22 @@ Dependencies may require these environment variables:
 
 ### Import Errors
 
-If you see `ModuleNotFoundError`, install the required extras:
+If you see `ModuleNotFoundError`, install the missing package:
 
 ```bash
 # Missing prometheus_client
-pip install aragora[monitoring]
+pip install prometheus-client
 
 # Missing sentence_transformers
-pip install aragora[ml]
+pip install sentence-transformers
 
 # Missing pypdf
-pip install aragora[documents]
+pip install pypdf
 ```
 
 ### Large Downloads
 
-The `ml` and `broadcast-premium` extras download large models:
+ML models and premium TTS packages are large downloads:
 
 - `ml`: ~2GB (sentence-transformers + torch)
 - `broadcast-xtts`: ~500MB (Coqui TTS + torch)
@@ -239,7 +248,7 @@ The `ml` and `broadcast-premium` extras download large models:
 Use `--no-cache-dir` to avoid caching:
 
 ```bash
-pip install --no-cache-dir aragora[ml]
+pip install --no-cache-dir sentence-transformers scikit-learn
 ```
 
 ### Conflicts
@@ -252,5 +261,5 @@ python -m venv .venv
 source .venv/bin/activate
 
 # Install with constraints
-pip install aragora[your-extras]
+pip install aragora[all]
 ```

--- a/docs-site/docs/contributing/dependencies.md
+++ b/docs-site/docs/contributing/dependencies.md
@@ -54,14 +54,14 @@ pip install aragora
 
 **Includes**: Core debate engine, SQLite storage, all agent providers
 
-### Profile 2: API Server
-For running the REST/WebSocket server:
+### Profile 2: FastAPI Gateway
+For the FastAPI/uvicorn async gateway:
 
 ```bash
 pip install aragora[gateway]
 ```
 
-**Includes**: Core + FastAPI and uvicorn (REST/WebSocket server)
+**Includes**: Core + FastAPI + uvicorn
 
 ### Profile 3: Production Deployment
 For full production environment:
@@ -95,7 +95,7 @@ For generating debate audio/video:
 
 ```bash
 # Basic TTS (free, edge-tts)
-pip install edge-tts pydub pyttsx3
+pip install edge-tts pydub
 
 # Premium TTS: ElevenLabs / AWS Polly / Coqui XTTS
 pip install elevenlabs   # or: boto3 (Polly), TTS (Coqui XTTS)

--- a/docs-site/docs/contributing/status.md
+++ b/docs-site/docs/contributing/status.md
@@ -1947,8 +1947,8 @@ Based on [arXiv:2512.24601](https://arxiv.org/abs/2512.24601) - "Recursive Langu
 
 **Installation:**
 ```bash
-# Install with real RLM support
-pip install aragora[rlm]
+# RLM support is included in the base install
+pip install aragora
 ```
 
 **Usage:**

--- a/docs-site/docs/contributing/status.md
+++ b/docs-site/docs/contributing/status.md
@@ -1947,8 +1947,9 @@ Based on [arXiv:2512.24601](https://arxiv.org/abs/2512.24601) - "Recursive Langu
 
 **Installation:**
 ```bash
-# RLM support is included in the base install
+# Base install includes a compression fallback; add the official `rlm` package for TRUE RLM
 pip install aragora
+pip install rlm
 ```
 
 **Usage:**

--- a/docs-site/docs/deployment/overview.md
+++ b/docs-site/docs/deployment/overview.md
@@ -13,7 +13,7 @@ Three deployment paths, from simplest to production-grade.
 pip install aragora
 
 # Offline mode — SQLite, no external services, no API keys needed
-aragora serve --offline
+aragora serve --demo
 
 # With API keys — full functionality
 export ANTHROPIC_API_KEY=your-key
@@ -100,11 +100,11 @@ pip install .
 
 # With PostgreSQL + Redis
 ARG INSTALL_VARIANT=postgres
-pip install ".[postgres,redis]"
+pip install ".[enterprise]"
 
 # Full (all optional dependencies)
 ARG INSTALL_VARIANT=full
-pip install ".[persistence,redis,monitoring,observability,postgres,rlm]"
+pip install ".[all]"
 ```
 
 Default in `deploy/Dockerfile` is full.

--- a/docs-site/docs/deployment/overview.md
+++ b/docs-site/docs/deployment/overview.md
@@ -91,23 +91,20 @@ cp .env.template .env  # fill in API keys
 
 ### Build Variants
 
-The Dockerfile supports three installation levels:
+`deploy/Dockerfile` chooses dependencies via the `VARIANT` build arg, which
+drives `scripts/ci_install_project.sh`:
+
+| `VARIANT` | Installs |
+|-----------|----------|
+| `minimal` | base package only |
+| `postgres` | base + PostgreSQL/Redis drivers |
+| `full` (default) | base + persistence, Redis, monitoring, observability, PostgreSQL, RLM |
 
 ```dockerfile
-# Minimal (no Redis/Postgres drivers)
-ARG INSTALL_VARIANT=minimal
-pip install .
-
-# With PostgreSQL + Redis
-ARG INSTALL_VARIANT=postgres
-pip install ".[enterprise]"
-
-# Full (all optional dependencies)
-ARG INSTALL_VARIANT=full
-pip install ".[all]"
+ARG VARIANT=full   # default; also: minimal, postgres
 ```
 
-Default in `deploy/Dockerfile` is full.
+The exact package groups per variant live in `scripts/ci_install_project.sh`.
 
 ## 3. Kubernetes
 

--- a/docs-site/docs/deployment/postgresql-migration.md
+++ b/docs-site/docs/deployment/postgresql-migration.md
@@ -21,7 +21,7 @@ Aragora supports both SQLite (default) and PostgreSQL backends:
    ```bash
    pip install asyncpg
    # or
-   pip install aragora[postgres]
+   pip install aragora[enterprise]
    ```
 
 ## Configuration

--- a/docs-site/docs/deployment/production-deployment.md
+++ b/docs-site/docs/deployment/production-deployment.md
@@ -20,7 +20,7 @@ This guide covers deploying aragora.ai to production with Supabase as the databa
 # 1. Clone and install
 git clone https://github.com/synaptent/aragora.git
 cd aragora
-pip install -e ".[postgres]"
+pip install -e ".[enterprise]"
 
 # 2. Configure environment
 cp .env.example .env
@@ -155,7 +155,7 @@ FROM python:3.11-slim
 WORKDIR /app
 COPY . .
 
-RUN pip install -e ".[postgres]"
+RUN pip install -e ".[enterprise]"
 
 # Initialize database on startup
 CMD python scripts/init_postgres_db.py && \
@@ -192,7 +192,7 @@ services:
   - type: web
     name: aragora
     env: python
-    buildCommand: pip install -e ".[postgres]" && python scripts/init_postgres_db.py
+    buildCommand: pip install -e ".[enterprise]" && python scripts/init_postgres_db.py
     startCommand: aragora serve --api-port $PORT --ws-port 8765
     envVars:
       - key: ARAGORA_POSTGRES_DSN

--- a/docs-site/docs/enterprise/features.md
+++ b/docs-site/docs/enterprise/features.md
@@ -454,7 +454,7 @@ Both configurations include security group definitions, IAM roles, variable file
 ### Offline Mode
 
 ```bash
-aragora serve --offline
+aragora serve --demo
 ```
 
 Sets `ARAGORA_OFFLINE` and `DEMO_MODE` environment variables, configures SQLite backend. No external network dependencies. Suitable for air-gapped and classified environments.

--- a/docs-site/docs/enterprise/pricing.md
+++ b/docs-site/docs/enterprise/pricing.md
@@ -373,7 +373,7 @@ Aragora generates Article 12 (Record-Keeping), Article 13 (Transparency), and Ar
 
 ### Can I self-host?
 
-Yes. Enterprise customers can deploy on their own infrastructure with Docker Compose, Kubernetes (Helm chart included), or Terraform. Offline and air-gapped deployments are supported with `aragora serve --offline`.
+Yes. Enterprise customers can deploy on their own infrastructure with Docker Compose, Kubernetes (Helm chart included), or Terraform. Offline and air-gapped deployments are supported with `aragora serve --demo`.
 
 ### How does pricing work for teams?
 

--- a/docs-site/docs/enterprise/sso.md
+++ b/docs-site/docs/enterprise/sso.md
@@ -36,7 +36,7 @@ pip install PyJWT httpx
 pip install python3-saml
 
 # Or install all SSO dependencies
-pip install aragora[sso]
+pip install aragora[enterprise]
 ```
 
 ### Production Requirements

--- a/docs-site/docs/guides/automation.md
+++ b/docs-site/docs/guides/automation.md
@@ -222,7 +222,7 @@ Context here... #ready
 ### Installation
 
 ```bash
-pip install aragora[langchain]
+pip install aragora langchain
 # or
 pip install aragora langchain-core
 ```

--- a/docs-site/docs/guides/broadcast.md
+++ b/docs-site/docs/guides/broadcast.md
@@ -397,8 +397,8 @@ JSON listing of podcast episodes.
 
 **Required (for full functionality):**
 ```bash
-pip install edge-tts pydub pyttsx3
-# Installs: edge-tts, pydub, pyttsx3
+pip install edge-tts pydub
+# Installs: edge-tts, pydub (pyttsx3 is an optional offline fallback)
 ```
 
 **Optional:**

--- a/docs-site/docs/guides/broadcast.md
+++ b/docs-site/docs/guides/broadcast.md
@@ -131,9 +131,9 @@ audio_path = await engine.generate_audio("Hello world", "narrator")
 
 Install optional providers:
 ```bash
-pip install "aragora[broadcast-elevenlabs]"  # ElevenLabs (cloud)
-pip install "aragora[broadcast-polly]"       # Amazon Polly (cloud, AWS)
-pip install "aragora[broadcast-xtts]"        # Coqui XTTS v2 (local)
+pip install elevenlabs  # ElevenLabs (cloud)
+pip install boto3        # Amazon Polly (cloud, AWS)
+pip install TTS          # Coqui XTTS v2 (local)
 ```
 
 Backend selection and ordering:
@@ -397,7 +397,7 @@ JSON listing of podcast episodes.
 
 **Required (for full functionality):**
 ```bash
-pip install aragora[broadcast]
+pip install edge-tts pydub pyttsx3
 # Installs: edge-tts, pydub, pyttsx3
 ```
 

--- a/docs-site/docs/guides/gauntlet.md
+++ b/docs-site/docs/guides/gauntlet.md
@@ -413,7 +413,7 @@ fi
 
 ### "Gauntlet module not available"
 ```bash
-pip install aragora[gauntlet]  # Install with gauntlet dependencies
+pip install aragora  # Gauntlet is included in the base install
 ```
 
 ### Timeout errors

--- a/docs-site/docs/guides/sdk-quickstart.md
+++ b/docs-site/docs/guides/sdk-quickstart.md
@@ -254,7 +254,7 @@ the full platform for:
 pip install aragora[all]
 
 # Start the server (SQLite, no external dependencies)
-aragora serve --offline
+aragora serve --demo
 
 # Run a debate from the CLI
 aragora decide "Should we migrate to Kubernetes?" --rounds 3

--- a/docs-site/docs/operations/production-readiness.md
+++ b/docs-site/docs/operations/production-readiness.md
@@ -244,7 +244,7 @@ python -c "import aragora.rlm" 2>/dev/null || echo "RLM not importable - reinsta
 - TRUE RLM significantly improves knowledge retrieval quality in production workloads
 
 **Troubleshooting:**
-- If `HAS_OFFICIAL_RLM` is `False`: Ensure the `rlm` extra is in your pip install command
+- If `HAS_OFFICIAL_RLM` is `False`: Install the official RLM package with `pip install rlm`
 - Docker builds: Verify `pip install -e .` is included in the Dockerfile pip install line
 - Lightsail/EC2: Ensure setup scripts include `pip install -e .`
 

--- a/docs-site/docs/operations/production-readiness.md
+++ b/docs-site/docs/operations/production-readiness.md
@@ -235,7 +235,7 @@ docker logs aragora 2>&1 | grep -E "RLM Factory|TRUE RLM|compression fallback"
 # NOT Expected: [RLM Factory] Created AragoraRLM with compression fallback
 
 # Verify rlm package is installed
-pip show rlm || echo "RLM package not installed - install with: pip install '.[rlm]'"
+python -c "import aragora.rlm" 2>/dev/null || echo "RLM not importable - reinstall the base package: pip install -e ."
 ```
 
 **Why TRUE RLM Matters:**
@@ -245,8 +245,8 @@ pip show rlm || echo "RLM package not installed - install with: pip install '.[r
 
 **Troubleshooting:**
 - If `HAS_OFFICIAL_RLM` is `False`: Ensure the `rlm` extra is in your pip install command
-- Docker builds: Verify `.[rlm]` is included in the Dockerfile pip install line
-- Lightsail/EC2: Ensure setup scripts include `pip install -e ".[rlm]"`
+- Docker builds: Verify `pip install -e .` is included in the Dockerfile pip install line
+- Lightsail/EC2: Ensure setup scripts include `pip install -e .`
 
 ### 10. Resource Limits
 

--- a/docs-site/docs/operations/troubleshooting.md
+++ b/docs-site/docs/operations/troubleshooting.md
@@ -438,6 +438,11 @@ python scripts/migrate_databases.py --validate
    aragora serve
    ```
 
+   > **Note:** `aragora` is a console script installed by `pip install -e .`
+   > (it creates `venv/bin/aragora`). If you see `aragora: command not found`,
+   > reinstall from the repo root inside your virtualenv with `pip install -e .`,
+   > the same console-script step documented in the operations runbook.
+
 ### Database Locking
 
 **Symptoms:** "database is locked" errors.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -86,23 +86,20 @@ cp .env.template .env  # fill in API keys
 
 ### Build Variants
 
-The Dockerfile supports three installation levels:
+`deploy/Dockerfile` chooses dependencies via the `VARIANT` build arg, which
+drives `scripts/ci_install_project.sh`:
+
+| `VARIANT` | Installs |
+|-----------|----------|
+| `minimal` | base package only |
+| `postgres` | base + PostgreSQL/Redis drivers |
+| `full` (default) | base + persistence, Redis, monitoring, observability, PostgreSQL, RLM |
 
 ```dockerfile
-# Minimal (no Redis/Postgres drivers)
-ARG INSTALL_VARIANT=minimal
-pip install .
-
-# With PostgreSQL + Redis
-ARG INSTALL_VARIANT=postgres
-pip install ".[enterprise]"
-
-# Full (all optional dependencies)
-ARG INSTALL_VARIANT=full
-pip install ".[all]"
+ARG VARIANT=full   # default; also: minimal, postgres
 ```
 
-Default in `deploy/Dockerfile` is full.
+The exact package groups per variant live in `scripts/ci_install_project.sh`.
 
 ## 3. Kubernetes
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -8,7 +8,7 @@ Three deployment paths, from simplest to production-grade.
 pip install aragora
 
 # Offline mode — SQLite, no external services, no API keys needed
-aragora serve --offline
+aragora serve --demo
 
 # With API keys — full functionality
 export ANTHROPIC_API_KEY=your-key
@@ -95,11 +95,11 @@ pip install .
 
 # With PostgreSQL + Redis
 ARG INSTALL_VARIANT=postgres
-pip install ".[postgres,redis]"
+pip install ".[enterprise]"
 
 # Full (all optional dependencies)
 ARG INSTALL_VARIANT=full
-pip install ".[persistence,redis,monitoring,observability,postgres,rlm]"
+pip install ".[all]"
 ```
 
 Default in `deploy/Dockerfile` is full.

--- a/docs/ENTERPRISE_FEATURES.md
+++ b/docs/ENTERPRISE_FEATURES.md
@@ -449,7 +449,7 @@ Both configurations include security group definitions, IAM roles, variable file
 ### Offline Mode
 
 ```bash
-aragora serve --offline
+aragora serve --demo
 ```
 
 Sets `ARAGORA_OFFLINE` and `DEMO_MODE` environment variables, configures SQLite backend. No external network dependencies. Suitable for air-gapped and classified environments.

--- a/docs/GA_CHECKLIST.md
+++ b/docs/GA_CHECKLIST.md
@@ -65,7 +65,7 @@ This checklist tracks all items required before declaring Aragora self-hosted GA
 - [x] **Docker Compose** - Production-ready with profiles (monitoring, workers)
 - [x] **Kubernetes manifests** - HPA, health probes, external secrets
 - [x] **TLS documentation** - Traefik and Nginx reverse proxy guides
-- [x] **Offline mode** - `aragora serve --offline` for air-gapped environments
+- [x] **Offline mode** - `aragora serve --demo` for air-gapped environments
 - [x] **Upgrade runbook** - Database migrations, rollback procedures
 - [x] **Production hardening checklist** - In `docs/DEPLOYMENT.md`
 

--- a/docs/PRICING.md
+++ b/docs/PRICING.md
@@ -368,7 +368,7 @@ Aragora generates Article 12 (Record-Keeping), Article 13 (Transparency), and Ar
 
 ### Can I self-host?
 
-Yes. Enterprise customers can deploy on their own infrastructure with Docker Compose, Kubernetes (Helm chart included), or Terraform. Offline and air-gapped deployments are supported with `aragora serve --offline`.
+Yes. Enterprise customers can deploy on their own infrastructure with Docker Compose, Kubernetes (Helm chart included), or Terraform. Offline and air-gapped deployments are supported with `aragora serve --demo`.
 
 ### How does pricing work for teams?
 

--- a/docs/PRICING_PAGE.md
+++ b/docs/PRICING_PAGE.md
@@ -368,7 +368,7 @@ Aragora generates Article 12 (Record-Keeping), Article 13 (Transparency), and Ar
 
 ### Can I self-host?
 
-Yes. Enterprise customers can deploy on their own infrastructure with Docker Compose, Kubernetes (Helm chart included), or Terraform. Offline and air-gapped deployments are supported with `aragora serve --offline`.
+Yes. Enterprise customers can deploy on their own infrastructure with Docker Compose, Kubernetes (Helm chart included), or Terraform. Offline and air-gapped deployments are supported with `aragora serve --demo`.
 
 ### How does pricing work for teams?
 

--- a/docs/SDK_QUICKSTART.md
+++ b/docs/SDK_QUICKSTART.md
@@ -249,7 +249,7 @@ the full platform for:
 pip install aragora[all]
 
 # Start the server (SQLite, no external dependencies)
-aragora serve --offline
+aragora serve --demo
 
 # Run a debate from the CLI
 aragora decide "Should we migrate to Kubernetes?" --rounds 3

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1942,8 +1942,8 @@ Based on [arXiv:2512.24601](https://arxiv.org/abs/2512.24601) - "Recursive Langu
 
 **Installation:**
 ```bash
-# Install with real RLM support
-pip install aragora[rlm]
+# RLM support is included in the base install
+pip install aragora
 ```
 
 **Usage:**

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1942,8 +1942,9 @@ Based on [arXiv:2512.24601](https://arxiv.org/abs/2512.24601) - "Recursive Langu
 
 **Installation:**
 ```bash
-# RLM support is included in the base install
+# Base install includes a compression fallback; add the official `rlm` package for TRUE RLM
 pip install aragora
+pip install rlm
 ```
 
 **Usage:**

--- a/docs/algorithms/RLM_CONCEPTS.md
+++ b/docs/algorithms/RLM_CONCEPTS.md
@@ -236,7 +236,7 @@ reset_singleton()
 pip install aragora
 
 # With TRUE RLM support (recommended)
-pip install aragora[rlm]
+pip install aragora
 # or
 pip install rlm
 ```

--- a/docs/algorithms/RLM_CONCEPTS.md
+++ b/docs/algorithms/RLM_CONCEPTS.md
@@ -235,9 +235,7 @@ reset_singleton()
 # Basic (compression fallback only)
 pip install aragora
 
-# With TRUE RLM support (recommended)
-pip install aragora
-# or
+# With TRUE RLM support (recommended, installs the official `rlm` package)
 pip install rlm
 ```
 

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -2413,7 +2413,7 @@ Generate audio podcasts from debate traces.
 #### POST /api/debates/:id/broadcast
 Generate an MP3 podcast from a debate.
 
-**Rate limited**. Requires the broadcast module (`pip install aragora[broadcast]`).
+**Rate limited**. Requires TTS dependencies (`pip install edge-tts pydub`).
 
 **Response:**
 ```json

--- a/docs/debate/GAUNTLET.md
+++ b/docs/debate/GAUNTLET.md
@@ -408,7 +408,7 @@ fi
 
 ### "Gauntlet module not available"
 ```bash
-pip install aragora[gauntlet]  # Install with gauntlet dependencies
+pip install aragora  # Gauntlet is included in the base install
 ```
 
 ### Timeout errors

--- a/docs/deployment/PRODUCTION_DEPLOYMENT.md
+++ b/docs/deployment/PRODUCTION_DEPLOYMENT.md
@@ -15,7 +15,7 @@ This guide covers deploying aragora.ai to production with Supabase as the databa
 # 1. Clone and install
 git clone https://github.com/synaptent/aragora.git
 cd aragora
-pip install -e ".[postgres]"
+pip install -e ".[enterprise]"
 
 # 2. Configure environment
 cp .env.example .env
@@ -150,7 +150,7 @@ FROM python:3.11-slim
 WORKDIR /app
 COPY . .
 
-RUN pip install -e ".[postgres]"
+RUN pip install -e ".[enterprise]"
 
 # Initialize database on startup
 CMD python scripts/init_postgres_db.py && \
@@ -187,7 +187,7 @@ services:
   - type: web
     name: aragora
     env: python
-    buildCommand: pip install -e ".[postgres]" && python scripts/init_postgres_db.py
+    buildCommand: pip install -e ".[enterprise]" && python scripts/init_postgres_db.py
     startCommand: aragora serve --api-port $PORT --ws-port 8765
     envVars:
       - key: ARAGORA_POSTGRES_DSN

--- a/docs/deployment/PRODUCTION_READINESS.md
+++ b/docs/deployment/PRODUCTION_READINESS.md
@@ -239,7 +239,7 @@ python -c "import aragora.rlm" 2>/dev/null || echo "RLM not importable - reinsta
 - TRUE RLM significantly improves knowledge retrieval quality in production workloads
 
 **Troubleshooting:**
-- If `HAS_OFFICIAL_RLM` is `False`: Ensure the `rlm` extra is in your pip install command
+- If `HAS_OFFICIAL_RLM` is `False`: Install the official RLM package with `pip install rlm`
 - Docker builds: Verify `pip install -e .` is included in the Dockerfile pip install line
 - Lightsail/EC2: Ensure setup scripts include `pip install -e .`
 

--- a/docs/deployment/PRODUCTION_READINESS.md
+++ b/docs/deployment/PRODUCTION_READINESS.md
@@ -230,7 +230,7 @@ docker logs aragora 2>&1 | grep -E "RLM Factory|TRUE RLM|compression fallback"
 # NOT Expected: [RLM Factory] Created AragoraRLM with compression fallback
 
 # Verify rlm package is installed
-pip show rlm || echo "RLM package not installed - install with: pip install '.[rlm]'"
+python -c "import aragora.rlm" 2>/dev/null || echo "RLM not importable - reinstall the base package: pip install -e ."
 ```
 
 **Why TRUE RLM Matters:**
@@ -240,8 +240,8 @@ pip show rlm || echo "RLM package not installed - install with: pip install '.[r
 
 **Troubleshooting:**
 - If `HAS_OFFICIAL_RLM` is `False`: Ensure the `rlm` extra is in your pip install command
-- Docker builds: Verify `.[rlm]` is included in the Dockerfile pip install line
-- Lightsail/EC2: Ensure setup scripts include `pip install -e ".[rlm]"`
+- Docker builds: Verify `pip install -e .` is included in the Dockerfile pip install line
+- Lightsail/EC2: Ensure setup scripts include `pip install -e .`
 
 ### 10. Resource Limits
 

--- a/docs/deployment/UPGRADE_ROADMAP.md
+++ b/docs/deployment/UPGRADE_ROADMAP.md
@@ -173,7 +173,7 @@ For production deployments migrating from SQLite to PostgreSQL:
 
 ```bash
 # Install PostgreSQL dependencies
-pip install aragora[postgres]
+pip install aragora[enterprise]
 
 # Set connection string
 export DATABASE_URL="postgresql://user:pass@host:5432/aragora"
@@ -376,14 +376,14 @@ Install specific extras based on your deployment:
 
 ```bash
 # PostgreSQL support
-pip install aragora[postgres]
+pip install aragora[enterprise]
 # Adds: sqlalchemy>=2.0.40, asyncpg>=0.29.0, alembic>=1.13.0
 
 # Full persistence (includes Supabase)
-pip install aragora[persistence]
+pip install aragora[enterprise]
 
 # Observability (metrics, tracing)
-pip install aragora[observability]
+pip install aragora
 # Adds: opentelemetry, prometheus-client
 
 # Development/testing

--- a/docs/deployment/UPGRADE_ROADMAP.md
+++ b/docs/deployment/UPGRADE_ROADMAP.md
@@ -375,16 +375,12 @@ Migration safety features:
 Install specific extras based on your deployment:
 
 ```bash
-# PostgreSQL support
+# PostgreSQL + Supabase persistence
 pip install aragora[enterprise]
-# Adds: sqlalchemy>=2.0.40, asyncpg>=0.29.0, alembic>=1.13.0
+# Adds: asyncpg, python3-saml, supabase
 
-# Full persistence (includes Supabase)
-pip install aragora[enterprise]
-
-# Observability (metrics, tracing)
-pip install aragora
-# Adds: opentelemetry, prometheus-client
+# Observability (metrics, tracing) - not a pip extra; install directly
+pip install opentelemetry-sdk prometheus-client
 
 # Development/testing
 pip install aragora[test]

--- a/docs/enterprise/SSO_SETUP.md
+++ b/docs/enterprise/SSO_SETUP.md
@@ -31,7 +31,7 @@ pip install PyJWT httpx
 pip install python3-saml
 
 # Or install all SSO dependencies
-pip install aragora[sso]
+pip install aragora[enterprise]
 ```
 
 ### Production Requirements

--- a/docs/guides/LOCAL_DEVELOPMENT.md
+++ b/docs/guides/LOCAL_DEVELOPMENT.md
@@ -212,10 +212,10 @@ packages like `redis`, `z3`, or `sentence-transformers`, install the relevant
 extras:
 
 ```bash
-pip install -e ".[redis]"          # Redis support
-pip install -e ".[ml]"             # scikit-learn, sentence-transformers
-pip install -e ".[observability]"  # OpenTelemetry, Prometheus
-pip install -e ".[documents]"     # PDF, DOCX, XLSX parsing
+pip install redis                  # Redis support
+pip install scikit-learn sentence-transformers  # ML support
+pip install opentelemetry-sdk prometheus-client  # OpenTelemetry, Prometheus
+pip install pypdf python-docx openpyxl  # PDF, DOCX, XLSX parsing
 ```
 
 ### Telegram/connector collection errors
@@ -225,5 +225,5 @@ The Telegram connector test file has a pre-existing collection error. Use
 
 ### Server won't start without API keys
 
-Use `--offline` mode for local development without any API keys configured.
+Use `--demo` mode for local development without any API keys configured.
 This provides demo data and SQLite storage.

--- a/docs/guides/RLM_DEVELOPER_GUIDE.md
+++ b/docs/guides/RLM_DEVELOPER_GUIDE.md
@@ -323,7 +323,7 @@ async def test_my_function(mock_rlm):
 ```python
 rlm = get_rlm()
 if rlm is None:
-    # Check: Is the `aragora` package installed (RLM ships with it)?
+    # Check: Is Aragora installed? (TRUE RLM also needs `pip install rlm`)
     # Check: Is ARAGORA_RLM_MODE set correctly?
     # Check: Are required API keys present?
     pass

--- a/docs/guides/RLM_DEVELOPER_GUIDE.md
+++ b/docs/guides/RLM_DEVELOPER_GUIDE.md
@@ -323,7 +323,7 @@ async def test_my_function(mock_rlm):
 ```python
 rlm = get_rlm()
 if rlm is None:
-    # Check: Is `pip install aragora[rlm]` installed?
+    # Check: Is the `aragora` package installed (RLM ships with it)?
     # Check: Is ARAGORA_RLM_MODE set correctly?
     # Check: Are required API keys present?
     pass

--- a/docs/guides/RLM_INTEGRATION.md
+++ b/docs/guides/RLM_INTEGRATION.md
@@ -22,7 +22,7 @@ DETAILED, SUMMARY, ABSTRACT, METADATA). Functional, but not true RLM.
 
 ```bash
 # With true RLM support
-pip install aragora[rlm]
+pip install aragora
 
 # Verify
 python -c "from aragora.rlm import HAS_OFFICIAL_RLM; print(HAS_OFFICIAL_RLM)"

--- a/docs/guides/RLM_INTEGRATION.md
+++ b/docs/guides/RLM_INTEGRATION.md
@@ -21,8 +21,8 @@ DETAILED, SUMMARY, ABSTRACT, METADATA). Functional, but not true RLM.
 ## Installation
 
 ```bash
-# With true RLM support
-pip install aragora
+# With TRUE RLM support (installs the official `rlm` package)
+pip install aragora rlm
 
 # Verify
 python -c "from aragora.rlm import HAS_OFFICIAL_RLM; print(HAS_OFFICIAL_RLM)"

--- a/docs/guides/RLM_USER_GUIDE.md
+++ b/docs/guides/RLM_USER_GUIDE.md
@@ -9,10 +9,10 @@ Aragora integrates Recursive Language Models (RLM) based on the paper ["Recursiv
 ## Installation
 
 ```bash
-# Install Aragora with RLM support
+# Install Aragora (includes the RLM compression fallback)
 pip install aragora
 
-# Or install the official RLM library directly
+# Add the official `rlm` package for TRUE RLM
 pip install rlm
 ```
 

--- a/docs/guides/RLM_USER_GUIDE.md
+++ b/docs/guides/RLM_USER_GUIDE.md
@@ -10,7 +10,7 @@ Aragora integrates Recursive Language Models (RLM) based on the paper ["Recursiv
 
 ```bash
 # Install Aragora with RLM support
-pip install aragora[rlm]
+pip install aragora
 
 # Or install the official RLM library directly
 pip install rlm

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -433,6 +433,11 @@ python scripts/migrate_databases.py --validate
    aragora serve
    ```
 
+   > **Note:** `aragora` is a console script installed by `pip install -e .`
+   > (it creates `venv/bin/aragora`). If you see `aragora: command not found`,
+   > reinstall from the repo root inside your virtualenv with `pip install -e .`,
+   > the same console-script step documented in the operations runbook.
+
 ### Database Locking
 
 **Symptoms:** "database is locked" errors.

--- a/docs/integrations/AUTOMATION_INTEGRATIONS.md
+++ b/docs/integrations/AUTOMATION_INTEGRATIONS.md
@@ -217,7 +217,7 @@ Context here... #ready
 ### Installation
 
 ```bash
-pip install aragora[langchain]
+pip install aragora langchain
 # or
 pip install aragora langchain-core
 ```

--- a/docs/integrations/BROADCAST.md
+++ b/docs/integrations/BROADCAST.md
@@ -392,8 +392,8 @@ JSON listing of podcast episodes.
 
 **Required (for full functionality):**
 ```bash
-pip install edge-tts pydub pyttsx3
-# Installs: edge-tts, pydub, pyttsx3
+pip install edge-tts pydub
+# Installs: edge-tts, pydub (pyttsx3 is an optional offline fallback)
 ```
 
 **Optional:**

--- a/docs/integrations/BROADCAST.md
+++ b/docs/integrations/BROADCAST.md
@@ -126,9 +126,9 @@ audio_path = await engine.generate_audio("Hello world", "narrator")
 
 Install optional providers:
 ```bash
-pip install "aragora[broadcast-elevenlabs]"  # ElevenLabs (cloud)
-pip install "aragora[broadcast-polly]"       # Amazon Polly (cloud, AWS)
-pip install "aragora[broadcast-xtts]"        # Coqui XTTS v2 (local)
+pip install elevenlabs  # ElevenLabs (cloud)
+pip install boto3        # Amazon Polly (cloud, AWS)
+pip install TTS          # Coqui XTTS v2 (local)
 ```
 
 Backend selection and ordering:
@@ -392,7 +392,7 @@ JSON listing of podcast episodes.
 
 **Required (for full functionality):**
 ```bash
-pip install aragora[broadcast]
+pip install edge-tts pydub pyttsx3
 # Installs: edge-tts, pydub, pyttsx3
 ```
 

--- a/docs/integrations/MCP_SETUP_GUIDE.md
+++ b/docs/integrations/MCP_SETUP_GUIDE.md
@@ -296,7 +296,7 @@ The MCP server supports multiple transports:
 
 **Rate limit errors?** Add `OPENROUTER_API_KEY` for automatic fallback.
 
-**Import errors?** Install optional dependencies: `pip install aragora[mcp]`
+**Import errors?** Reinstall the base package: `pip install aragora`
 
 **Server won't start?** Check: `python -c "from aragora.mcp.server import main; main()"` for error output.
 

--- a/docs/reference/DEPENDENCIES.md
+++ b/docs/reference/DEPENDENCIES.md
@@ -49,14 +49,14 @@ pip install aragora
 
 **Includes**: Core debate engine, SQLite storage, all agent providers
 
-### Profile 2: API Server
-For running the REST/WebSocket server:
+### Profile 2: FastAPI Gateway
+For the FastAPI/uvicorn async gateway:
 
 ```bash
 pip install aragora[gateway]
 ```
 
-**Includes**: Core + FastAPI and uvicorn (REST/WebSocket server)
+**Includes**: Core + FastAPI + uvicorn
 
 ### Profile 3: Production Deployment
 For full production environment:
@@ -90,7 +90,7 @@ For generating debate audio/video:
 
 ```bash
 # Basic TTS (free, edge-tts)
-pip install edge-tts pydub pyttsx3
+pip install edge-tts pydub
 
 # Premium TTS: ElevenLabs / AWS Polly / Coqui XTTS
 pip install elevenlabs   # or: boto3 (Polly), TTS (Coqui XTTS)

--- a/docs/reference/DEPENDENCIES.md
+++ b/docs/reference/DEPENDENCIES.md
@@ -15,21 +15,28 @@ pip install aragora[dev]
 pip install aragora[all]
 ```
 
-## Feature-to-Extras Mapping
+## Feature-to-Install Mapping
 
-| Feature | Extras | Size Impact |
-|---------|--------|-------------|
-| CLI debates | (none) | ~50MB |
-| Development/Testing | `dev` | +100MB |
-| Monitoring (Prometheus/Sentry) | `monitoring` | +20MB |
-| Distributed tracing (OpenTelemetry) | `observability` | +30MB |
-| Redis caching | `redis` | +5MB |
-| Database (Supabase/PostgreSQL) | `persistence,postgres` | +40MB |
-| PDF/DOCX processing | `documents` | +30MB |
-| Text-to-speech (basic) | `broadcast` | +50MB |
-| Text-to-speech (premium) | `broadcast-premium` | +500MB |
-| Web research | `research` | +20MB |
-| ML/Embeddings | `ml` | +2GB |
+Aragora's `pyproject.toml` defines these extras: `test`, `dev`, `gateway`,
+`enterprise`, `blockchain`, `connectors`, `experimental`, and `all`. Features
+without a dedicated extra install their optional packages directly.
+
+| Feature | Install | Size Impact |
+|---------|---------|-------------|
+| CLI debates | (base) `pip install aragora` | ~50MB |
+| Development/Testing | `pip install aragora[dev]` | +100MB |
+| Async gateway (FastAPI/uvicorn) | `pip install aragora[gateway]` | +20MB |
+| Database/SSO (asyncpg, Supabase, SAML) | `pip install aragora[enterprise]` | +40MB |
+| Streaming connectors (Kafka/RabbitMQ) | `pip install aragora[connectors]` | +15MB |
+| Blockchain (web3) | `pip install aragora[blockchain]` | +30MB |
+| Monitoring (Prometheus/Sentry) | `pip install prometheus-client sentry-sdk` | +20MB |
+| Distributed tracing (OpenTelemetry) | `pip install opentelemetry-sdk opentelemetry-exporter-otlp` | +30MB |
+| Redis caching | `pip install redis` | +5MB |
+| PDF/DOCX processing | `pip install pypdf python-docx` | +30MB |
+| Text-to-speech (basic) | `pip install edge-tts pydub` | +50MB |
+| Text-to-speech (premium) | `pip install elevenlabs` | +500MB |
+| Web research | `pip install duckduckgo-search beautifulsoup4` | +20MB |
+| ML/Embeddings | `pip install sentence-transformers scikit-learn` | +2GB |
 
 ## Installation Profiles
 
@@ -46,34 +53,34 @@ pip install aragora
 For running the REST/WebSocket server:
 
 ```bash
-pip install aragora[monitoring,observability]
+pip install aragora[gateway]
 ```
 
-**Includes**: Core + Prometheus metrics + OpenTelemetry tracing
+**Includes**: Core + FastAPI and uvicorn (REST/WebSocket server)
 
 ### Profile 3: Production Deployment
 For full production environment:
 
 ```bash
-pip install aragora[monitoring,observability,persistence,postgres,redis]
+pip install aragora[all]
 ```
 
-**Includes**: Core + metrics + tracing + Supabase + PostgreSQL + Redis caching
+**Includes**: Core + all extras (gateway, enterprise, connectors, blockchain, experimental). For metrics and Redis caching, also `pip install prometheus-client redis`.
 
 ### Profile 4: Development
 For contributing to Aragora:
 
 ```bash
-pip install aragora[dev,monitoring]
+pip install aragora[dev]
 ```
 
-**Includes**: Core + pytest + mypy + ruff + bandit + metrics
+**Includes**: Core + pytest + mypy + ruff + bandit
 
 ### Profile 5: Research/Evidence
 For debates with web research and evidence collection:
 
 ```bash
-pip install aragora[documents]
+pip install aragora duckduckgo-search beautifulsoup4 pypdf python-docx
 ```
 
 **Includes**: Core + DuckDuckGo search + PDF/DOCX parsing
@@ -83,19 +90,19 @@ For generating debate audio/video:
 
 ```bash
 # Basic TTS (free, edge-tts)
-pip install aragora[broadcast]
+pip install edge-tts pydub pyttsx3
 
-# Premium TTS (ElevenLabs, AWS Polly, Coqui XTTS)
-pip install aragora[broadcast-premium]
+# Premium TTS: ElevenLabs / AWS Polly / Coqui XTTS
+pip install elevenlabs   # or: boto3 (Polly), TTS (Coqui XTTS)
 ```
 
-**Note**: `broadcast-premium` requires ~500MB and includes PyTorch for XTTS
+**Note**: Coqui XTTS (`pip install TTS`) requires ~500MB and includes PyTorch
 
 ### Profile 7: ML/Semantic Search
 For semantic similarity and embeddings:
 
 ```bash
-pip install aragora[ml]
+pip install sentence-transformers scikit-learn numpy scipy
 ```
 
 **Warning**: This adds ~2GB for sentence-transformers and dependencies
@@ -117,6 +124,8 @@ pip install aragora[ml]
 | urllib3>=2.6.3 | HTTP utilities | CVE fix |
 
 ### Optional Dependencies
+
+The groups below describe related packages. Only `dev`, `test`, `gateway`, `enterprise`, `blockchain`, `connectors`, `experimental`, and `all` are installable as `pip install aragora[<extra>]`; the others are installed as the direct packages listed.
 
 #### `dev` - Development Tools
 ```
@@ -211,22 +220,22 @@ Dependencies may require these environment variables:
 
 ### Import Errors
 
-If you see `ModuleNotFoundError`, install the required extras:
+If you see `ModuleNotFoundError`, install the missing package:
 
 ```bash
 # Missing prometheus_client
-pip install aragora[monitoring]
+pip install prometheus-client
 
 # Missing sentence_transformers
-pip install aragora[ml]
+pip install sentence-transformers
 
 # Missing pypdf
-pip install aragora[documents]
+pip install pypdf
 ```
 
 ### Large Downloads
 
-The `ml` and `broadcast-premium` extras download large models:
+ML models and premium TTS packages are large downloads:
 
 - `ml`: ~2GB (sentence-transformers + torch)
 - `broadcast-xtts`: ~500MB (Coqui TTS + torch)
@@ -234,7 +243,7 @@ The `ml` and `broadcast-premium` extras download large models:
 Use `--no-cache-dir` to avoid caching:
 
 ```bash
-pip install --no-cache-dir aragora[ml]
+pip install --no-cache-dir sentence-transformers scikit-learn
 ```
 
 ### Conflicts
@@ -247,5 +256,5 @@ python -m venv .venv
 source .venv/bin/activate
 
 # Install with constraints
-pip install aragora[your-extras]
+pip install aragora[all]
 ```

--- a/docs/status/ADVANCED_FEATURES.md
+++ b/docs/status/ADVANCED_FEATURES.md
@@ -30,10 +30,10 @@ Based on the ["Recursive Language Models" paper (arXiv:2512.24601)](https://arxi
 ### Installation
 
 ```bash
-# Install Aragora with RLM support
+# Install Aragora (includes the RLM compression fallback)
 pip install aragora
 
-# Or install the official RLM library directly
+# Add the official `rlm` package for TRUE RLM
 pip install rlm
 ```
 

--- a/docs/status/ADVANCED_FEATURES.md
+++ b/docs/status/ADVANCED_FEATURES.md
@@ -31,7 +31,7 @@ Based on the ["Recursive Language Models" paper (arXiv:2512.24601)](https://arxi
 
 ```bash
 # Install Aragora with RLM support
-pip install aragora[rlm]
+pip install aragora
 
 # Or install the official RLM library directly
 pip install rlm

--- a/docs/status/POSTGRESQL_MIGRATION.md
+++ b/docs/status/POSTGRESQL_MIGRATION.md
@@ -16,7 +16,7 @@ Aragora supports both SQLite (default) and PostgreSQL backends:
    ```bash
    pip install asyncpg
    # or
-   pip install aragora[postgres]
+   pip install aragora[enterprise]
    ```
 
 ## Configuration

--- a/docs/status/STATUS.md
+++ b/docs/status/STATUS.md
@@ -1965,7 +1965,7 @@ Based on [arXiv:2512.24601](https://arxiv.org/abs/2512.24601) - "Recursive Langu
 **Installation:**
 ```bash
 # Install with real RLM support
-pip install aragora[rlm]
+pip install aragora
 ```
 
 **Usage:**


### PR DESCRIPTION
## Source

Docs-hygiene sweep carried from the p2-contradictions handoff (`library/tech-debt.md`). Live install docs instructed `pip install aragora[<extra>]` for extras absent from `pyproject.toml [project.optional-dependencies]`; p2-contradictions fixed only the `research` extra (VAL-P2-003). This PR also carries the p2-quickstart-canonical / PR #8482 reviewer note (TROUBLESHOOTING recovery lacked the console-script one-liner) and the p2-docs scrutiny note (stale `aragora serve --offline` should be `--demo`).

## Behavior

- Authoritative extras re-enumerated at HEAD: `all, blockchain, connectors, dev, enterprise, experimental, gateway, test`.
- Every live instructional surface (`README.md`, `INSTALL.md`, `DEVELOPMENT.md`, `CONTRIBUTING.md`, `docs/**`, `docs-site/docs/**`, excluding `docs/archive/**` + dated history) no longer instructs installing a nonexistent extra. Replacements point to a real extra (`enterprise` / `gateway` / `all`), the plain base install, or direct package installs (e.g. `pip install prometheus-client sentry-sdk`, `pip install edge-tts pydub`).
- Stale `aragora serve --offline` prose replaced with the correct `--demo` flag (verified via `python3 -m aragora.cli.main serve --help`).
- `docs/guides/TROUBLESHOOTING.md` recovery section now includes the `pip install -e .` console-script note, consistent with `docs/ops/RUNBOOK.md`.
- docs-site mirrors regenerated via `scripts/doc_stats.py --write` + `docs-site/scripts/sync-docs.js`. No functional/code changes.

## Validation

- `rg` sweep over live surfaces (excluding `docs/archive/**`): **zero** `aragora serve --offline`; **zero** nonexistent-extra install refs.
- `make lint`: `All checks passed!`
- `python3 -m pytest tests/scripts/test_docs_site_sync_links.py -q`: `5 passed`
- `AWS_*` neutralized `make test-smoke`: `Smoke tests passed!`
- docs-build drift recheck (`doc_stats.py --write` + `sync-docs.js`, then `git diff --quiet`): clean.

## Risks

Docs-only; no functional/code changes. The `docs/STATUS.md` mirror (`docs-site/docs/contributing/status.md`) is also touched by stale, already-CONFLICTING PRs #8460/#8461 (which only edit that mirror + archived files); the overlap here is a single-line `aragora[rlm]` -> base-install change.

Tier 0 (docs-only).
