### PR TITLE
fix(ci): isolate safety dependency scan

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -695,8 +695,8 @@ jobs:
 
       - name: Install security tools
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install bandit safety
+          python -m pip install --upgrade pip setuptools
+          python -m pip install bandit
 
       - name: Run Bandit security scan
         run: |
@@ -708,9 +708,34 @@ jobs:
       - name: Check dependencies for vulnerabilities
         run: |
           python -m pip install -e .
+          safety_requirements="${RUNNER_TEMP:-/tmp}/aragora-safety-requirements.txt"
+          safety_venv="${RUNNER_TEMP:-/tmp}/aragora-safety-venv"
+          python - <<'PY' > "$safety_requirements"
+          import json
+          import subprocess
+          import sys
+
+          packages = json.loads(
+              subprocess.check_output(
+                  [sys.executable, "-m", "pip", "list", "--format=json"],
+                  text=True,
+              )
+          )
+          for package in packages:
+              name = package.get("name")
+              version = package.get("version")
+              if name and version:
+                  print(f"{name}=={version}")
+          PY
+          python -m venv "$safety_venv"
+          "$safety_venv/bin/python" -m pip install --upgrade pip
+          "$safety_venv/bin/python" -m pip install safety
           # Blocking: fail on HIGH/CRITICAL vulnerabilities.
           # --ignore 70612: Known false positive / accepted risk.
-          safety check --full-report --ignore 70612
+          "$safety_venv/bin/safety" check \
+            --full-report \
+            --ignore 70612 \
+            -r "$safety_requirements"
 
   secrets:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- keep Safety out of the Aragora project environment so the Lint security job no longer crashes on Safety 3.8.1 vs Typer 0.26.7
- scan the installed project dependency inventory from a separate Safety virtualenv, preserving fail-closed dependency vulnerability behavior
- upgrade setuptools before inventory generation so the scan reports real project dependency risk instead of the bootstrap setuptools CVEs from a fresh venv

## Context
Repairs current main Lint workflow security job failure from run 27963273285 / job 82750237660 at main head d438761ca1ef599a694490180aa921125a70520f.

## Validation
- Python 3.11.11 focused security validation: bandit -r aragora/ -lll -ii completed with High: 0
- Python 3.11.11 isolated Safety validation: generated installed-package requirements from the project env, ran Safety 3.8.1 from a separate venv, scanned 29 packages, 0 vulnerabilities
- pre-commit run --files .github/workflows/lint.yml
- pre-commit run --hook-stage pre-push --from-ref origin/main --to-ref HEAD
- git diff --check origin/main HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD

Note: local generated git hooks point at /Users/armand/Development/aragora/.venv/bin/python, which currently lacks pre_commit, so the equivalent pre-commit stages were run explicitly through the working pre-commit 3.8.0 binary before committing/pushing.