### PR TITLE
docs(status): align hygiene-register six-week-plan prose with live 2026-03-05 plan

### DIFF
--- a/docs-site/docs/contributing/documentation-hygiene-and-gap-register.md
+++ b/docs-site/docs/contributing/documentation-hygiene-and-gap-register.md
@@ -57,7 +57,7 @@ The live execution backlog now tracks in [ACTIVE_EXECUTION_ISSUES.md](./active-e
 
 - Closed-loop backbone, inbox trust wedge, swarm supervision, provider routing phase 1, Comms Hub completion, and OpenClaw core-loop delivery are treated as shipped in `docs/status/STATUS.md`.
 - Canonical execution priorities are now linked directly to the GitHub backlog: truthfulness/backlog canonicalization is complete on `main` through `#809`, the first kernel bridge tranche `#810` is complete, and the active M1 kernel work is now `#811` and `#812` in `docs/status/NEXT_STEPS_CANONICAL.md` and `docs/status/ACTIVE_EXECUTION_ISSUES.md`.
-- The active six-week plan is wedge/PMF-focused: first receipt quickly, parity hard-close, reliability cleanup, surface simplification, and status consolidation in the live six-week execution plan (`docs/status/EXECUTION_NEXT_6_WEEKS_2026-03-05.md`).
+- The active six-week plan is wedge/PMF-focused: closing the default product loop on `main`, making the proof surfaces truthful by default, finishing the bounded execution operator contract, running design-partner PMF loops on the real wedges, and expanding one truthful workbench slice before a PMF decision gate, per the live six-week execution plan (`docs/status/EXECUTION_NEXT_6_WEEKS_2026-03-05.md`).
 
 ### Near-Term Goals (Q2 2026)
 

--- a/docs/status/DOCUMENTATION_HYGIENE_AND_GAP_REGISTER.md
+++ b/docs/status/DOCUMENTATION_HYGIENE_AND_GAP_REGISTER.md
@@ -52,7 +52,7 @@ The live execution backlog now tracks in [ACTIVE_EXECUTION_ISSUES.md](ACTIVE_EXE
 
 - Closed-loop backbone, inbox trust wedge, swarm supervision, provider routing phase 1, Comms Hub completion, and OpenClaw core-loop delivery are treated as shipped in `docs/status/STATUS.md`.
 - Canonical execution priorities are now linked directly to the GitHub backlog: truthfulness/backlog canonicalization is complete on `main` through `#809`, the first kernel bridge tranche `#810` is complete, and the active M1 kernel work is now `#811` and `#812` in `docs/status/NEXT_STEPS_CANONICAL.md` and `docs/status/ACTIVE_EXECUTION_ISSUES.md`.
-- The active six-week plan is wedge/PMF-focused: first receipt quickly, parity hard-close, reliability cleanup, surface simplification, and status consolidation in the live six-week execution plan (`docs/status/EXECUTION_NEXT_6_WEEKS_2026-03-05.md`).
+- The active six-week plan is wedge/PMF-focused: closing the default product loop on `main`, making the proof surfaces truthful by default, finishing the bounded execution operator contract, running design-partner PMF loops on the real wedges, and expanding one truthful workbench slice before a PMF decision gate, per the live six-week execution plan (`docs/status/EXECUTION_NEXT_6_WEEKS_2026-03-05.md`).
 
 ### Near-Term Goals (Q2 2026)
 


### PR DESCRIPTION
## Source

grok's single in-scope `[P2]` finding from the PR #8516 model review (handoff `2026-06-21T16-44-55-832Z__p2-docs-active-plan-link-fix...json`, discoveredIssues[0]), deferred from that link-only-scoped PR and tracked as mission feature `misc-grok-hygiene-register-prose`. (grok's other 3 findings were git-verified non-defects: misread / pre-existing / redundant-test.)

## Change

The "Current Focus (March 2026)" bullet in `docs/status/DOCUMENTATION_HYGIENE_AND_GAP_REGISTER.md` summarized the active six-week plan with stale OLD-plan framing — *"first receipt quickly, parity hard-close, reliability cleanup, surface simplification, and status consolidation"* — none of which appears in the live plan (`docs/status/EXECUTION_NEXT_6_WEEKS_2026-03-05.md`).

Rewrote the bullet to the live plan's actual priority order: closing the default product loop on `main`, making proof surfaces truthful by default, finishing the bounded execution operator contract, running design-partner PMF loops on the real wedges, and expanding one truthful workbench slice before a PMF decision gate. The doc's link already points at the live plan (landed in #8516); only the framing prose was stale.

The docs-site mirror (`docs-site/docs/contributing/documentation-hygiene-and-gap-register.md`) was regenerated via `node docs-site/scripts/sync-docs.js` (not hand-edited). `docs/archive/**` untouched.

## Validation (worktree)

- `python3 scripts/check_docs_consistency.py` -> all checks PASS (rc=0)
- `python3 scripts/ci/check_docs_links.py` -> `OK all internal markdown links and anchors resolve` (rc=0)
- `python3 -m pytest tests/scripts/test_docs_site_sync_links.py -q` -> 5 passed
- `make lint` -> All checks passed! ; `make test-smoke` -> Smoke tests passed!
- `scripts/automation_pr_preflight.sh origin/main HEAD` -> ok (docs-only, 2 files)

## Risk / Tier

Docs-only, no code or public-API surface; the mirror is deterministic `sync-docs.js` output. Because the diff regenerates a `docs-site/docs/**` mirror, the merge gate classifies this **Tier-1** (`tier_1_additive_internal`), not Tier-0 — budgeted for a 2-family model quorum (grok + claude).
