### PR TITLE
docs(packaging): P3 packaging design + dogfood decision receipt (#8263)

### DIFF
--- a/docs/architecture/PACKAGING_AND_DISTRIBUTION.md
+++ b/docs/architecture/PACKAGING_AND_DISTRIBUTION.md
@@ -1,0 +1,131 @@
+# Packaging and Distribution Design (P3)
+
+Authoritative design record for the P3 packaging milestone (HEALTH-6,
+[#8263](https://github.com/synaptent/aragora/issues/8263)). This is a
+**post-hoc** design doc: the decision-gated rename already shipped on `main` via
+PR #8517, so this records what shipped, why, the traced dependency audit, and
+the remaining packaging follow-ups. The decision receipt for the dogfood gate is
+[`../audits/2026-06-22-p3-packaging-decision-receipt.md`](../audits/2026-06-22-p3-packaging-decision-receipt.md).
+
+## 1. Decision summary
+
+The root distribution is **Option A** from #8263: one `aragora` distribution
+shipping the full package and the console entry points, while keeping the
+standalone wedges (`aragora-debate/`, and ODR-3's `aragora-verify`) separable.
+See the decision receipt for the dogfood debate that gated this (verdict PASS,
+heterogeneous quorum grok/mistral-api/deepseek).
+
+## 2. Distribution rename: `aragora-debate` → `aragora`
+
+| Aspect | Before (baseline `a5cf5fc70b`) | After (shipped, #8517) |
+|---|---|---|
+| `[project].name` | `aragora-debate` | `aragora` |
+| Console scripts | none | `aragora = aragora.cli.main:main` |
+| Packaged modules | `aragora`, `aragora.core`, `aragora.debate` (3) | full tree via `include = ["aragora*"]` |
+| Wedge | `aragora-debate/` standalone | unchanged standalone wedge |
+
+The single name resolves the prior three-name contradiction (`aragora-debate`
+build / `aragora` README badge / `aragora-sdk` SDK) called out in #8263.
+
+## 3. Package list strategy: auto-discovery
+
+The build uses setuptools **auto-discovery**, not an explicit list:
+
+```toml
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["aragora*"]
+exclude = ["aragora-debate*", "tests*", "docs*"]
+```
+
+Rationale: the tree has ~141 top-level subpackages (`aragora/*/__init__.py`);
+an explicit list rots on every new subpackage. `include = ["aragora*"]` captures
+`aragora.cli` and `aragora.server` (excluded before, which is precisely why the
+documented `aragora serve` path was impossible pre-P3). The `exclude` keeps the
+`aragora-debate/` wedge, `tests/`, and `docs/` out of the wheel.
+
+## 4. Dependency audit (traced from actual imports)
+
+Method: count distinct files under `aragora/` that import each module
+(`rg -l 'import|from <mod>' aragora/`), cross-referenced against the empirically
+bootable runtime list in `scripts/ci_install_project.sh`
+(`LEGACY_CONTROL_PLANE_BASE_DEPS`, the floor both Dockerfiles boot from).
+
+| Dependency | Import sites under `aragora/` | Genuinely needed by | In base `[project.dependencies]`? | Status |
+|---|---:|---|---|---|
+| `pydantic` | 33 | config, core, server, cli | yes (`>=2.13.4,<3.0`) | floor ✓ |
+| `PyYAML` (`yaml`) | 49 | config, hooks, templates | yes (`>=6.0.3,<7.0`) | floor ✓ |
+| `aiohttp` | 102 | server handlers, agents, connectors | **no** (only `[blockchain]`,`[all]`) | floor GAP ⚠ |
+| `websockets` | 7 | `aragora/server/stream/*` | **no** (undeclared anywhere) | floor GAP ⚠ |
+| `pydantic-settings` | 1 | config | yes (`>=2.14.2,<3.0`) | floor ✓ + CVE floor |
+| `click` / `typer` / `httpx` / `python-dateutil` | n/a | cli entry surface | yes | CLI floor ✓ |
+
+**Audited floor = {aiohttp, websockets, pyyaml, pydantic}** plus the CLI
+essentials (click, typer, httpx, python-dateutil) and `pydantic-settings`.
+
+### Finding (coordination, not fixed here)
+
+Base `[project.dependencies]` under-declares the real runtime floor relative to
+the bootable `LEGACY_CONTROL_PLANE_BASE_DEPS` set. Most importantly:
+
+- `aiohttp` (102 import sites) is present only in `[blockchain]`/`[all]`, not the base floor.
+- `websockets` (7 import sites, server streaming) is not declared in any section.
+
+Recommendation for the pyproject-owning P3 follow-ups (`p3-verification-suite` /
+`p3-deploy-finalize`): fold `aiohttp` + `websockets` (and the rest of the
+empirical base set: bcrypt, cryptography, jinja2, numpy, boto3, PyJWT,
+python-multipart, mcp, fastapi, uvicorn) into the base floor or a dedicated
+`[server]` extra, so a documented install is bootable without pulling `[all]`.
+This also brings the declared floor in line with the VAL-P3-003 expectation
+(aiohttp + websockets + pyyaml + pydantic in the declared dependencies).
+
+> This design doc does not edit `pyproject.toml` — that file is owned by other
+> P3 features and is path-frozen by several open PRs.
+
+## 5. Extras layout (shipped)
+
+| Extra | Purpose | Key members |
+|---|---|---|
+| `test` | acceptance install | build, pytest, pytest-asyncio, twine, pydantic(-settings), PyYAML |
+| `gateway` | HTTP/API surface | fastapi, uvicorn |
+| `blockchain` | ERC-8004 identity | aiohttp, web3 |
+| `enterprise` | SSO / managed PG | asyncpg, python3-saml, supabase |
+| `connectors` | streaming ingest | aiokafka, aio-pika |
+| `experimental` | browser automation | playwright |
+| `dev` | type/lint tooling | mypy, mypy-baseline, types-*, bandit |
+| `all` | union of runtime extras | gateway ∪ blockchain ∪ enterprise ∪ connectors ∪ experimental |
+
+## 6. Console entry point
+
+```toml
+[project.scripts]
+aragora = "aragora.cli.main:main"
+```
+
+After `pip install -e ".[test]"`, `aragora --help` exposes the full subcommand
+surface (`ask`, `serve`, `quickstart`, `gauntlet`, `receipt`, ...).
+
+## 7. Wedges and ODR-3 coordination
+
+- **`aragora-debate/`** — unchanged standalone wedge; its `[project].name`
+  stays `aragora-debate`. The name collision is resolved by renaming only the
+  root distribution.
+- **`aragora-verify` (ODR-3, #8226)** — a separate near-zero-dependency PyPI
+  package (`packages/aragora-verify/`) for offline receipt verification. The
+  root `aragora` distribution must **not** absorb it: the verifier's value is
+  that it is trustworthy *outside* an Aragora install. ODR-3 leads on
+  receipt-surface naming. The dependency audit above is shared on #8226.
+
+## 8. Security floors (already on main)
+
+- `pydantic-settings>=2.14.2` closes **GHSA-4xgf-cpjx-pc3j** (the sole open CVE;
+  vulnerable code path has 0 in-tree usages). Declared in base + `[test]`.
+- `cryptography>=48.0.1` and `starlette>=1.3.1` are floored via
+  `[tool.uv].constraint-dependencies`. Already remediated — do not re-fix.
+
+## 9. Definition of done (from #8263) — status
+
+- [x] Decision receipt attached (dogfood gate) — see the receipt doc.
+- [x] Option implemented — Option A shipped via #8517.
+- [ ] Clean-machine `pip install` → CLI → zero-key receipt (owned by `p3-verification-suite`).
+- [ ] `INSTALL.md`/README/quickstart agree with reality (HEALTH-5 / P2 + P3 follow-ups).

--- a/docs/audits/2026-06-22-p3-packaging-decision-receipt.md
+++ b/docs/audits/2026-06-22-p3-packaging-decision-receipt.md
@@ -1,0 +1,107 @@
+# P3 Packaging Decision Receipt (#8263)
+
+Dogfood decision receipt for the decision-gated packaging issue
+[#8263](https://github.com/synaptent/aragora/issues/8263) ("one installable
+story — unify PyPI naming + console entry points"). The decision gate required
+running an Aragora debate on the packaging split question and attaching the
+resulting **decision receipt** before implementing. This document records that
+receipt; it is a post-hoc record because the chosen option already shipped on
+`main` (see "Outcome" below).
+
+Companion design doc:
+[`../architecture/PACKAGING_AND_DISTRIBUTION.md`](../architecture/PACKAGING_AND_DISTRIBUTION.md)
+(full package strategy + traced dependency audit table).
+
+## The decision question (verbatim framing from #8263)
+
+- **Option A** — one name (`aragora`) ships the full package including the CLI
+  and server console entry points (`aragora = aragora.cli.main:main`), keeping
+  `aragora-debate/` as a separate standalone wedge.
+- **Option B** — a minimal wedge package (receipts + offline verifier, aligned
+  with ODR-3 #8226) plus a full meta-package depending on it.
+
+Selection criterion: which option best delivers a single clean documented
+`pip install` → CLI → zero-key decision-receipt path while honoring ODR-3
+([#8226](https://github.com/synaptent/aragora/issues/8226)), which ships a
+separate standalone `aragora-verify` offline receipt verifier.
+
+## Dogfood debate
+
+The decision was stress-tested with Aragora's own debate engine
+(`python3 -m aragora.cli.main ask ... --consensus judge`), heterogeneous
+model quorum, judge consensus.
+
+| Field | Value |
+|---|---|
+| receipt_id | `debate-9ea6b178-a438-4964-9836-3ba84230bd03` |
+| debate_id | `9ea6b178-a438-4964-9836-3ba84230bd03` |
+| timestamp | `2026-06-22T22:11:52Z` |
+| agents (heterogeneous) | `grok`, `mistral-api`, `deepseek` |
+| agents_failed | none |
+| rounds_used | 1 |
+| consensus | judge; `consensus_reached = true` |
+| winning position | `grok` |
+| dissenting_views | 0 |
+| verdict | **PASS** |
+| confidence | 0.80 |
+| robustness_score | 0.80 |
+| input_hash | `05e1b2f374b5708e925f11c05ec1f00bd230aa3b0b5af350fb26f70a85904fc8` |
+| content_hash | `275a182b60fc8e1c` |
+| artifact_hash / checksum | `b665b43f8af31673911b3676a115182c3f3e971b0d6012970433b3a7a8559655` |
+| schema_version | 1.1 |
+| receipt sha256 | `5fa4f45c10e4925df8ff7b95757ba861beccb62772d1072da53ec2a7fea0e6b1` |
+
+### Synthesis (winning position, abridged)
+
+The judge synthesis favored the **unified path**: "A single encompassing
+approach carries clear strengths ... this unity reduces the cognitive load" of
+moving from intent to a tangible result, while "the presence of more focused
+companions for those who already know their precise need preserves autonomy
+without forcing the majority through extra thresholds." The modular alternative
+was recognized as valid where needs genuinely diverge ("a solitary walker may
+prefer a simple staff rather than an entire traveler's kit"), but it "risks
+introducing hesitation at the very moment when momentum toward purpose matters
+most." The debate explicitly respected the concern that a unified offering must
+**not entangle the independent core verifier** — i.e. ODR-3's standalone
+`aragora-verify` must stay separable.
+
+The receipt JSON is reproducible from the loop and verifiable offline:
+
+```
+aragora receipt verify <path>/9ea6b178-a438-4964-9836-3ba84230bd03_275a182b60fc8e1c.json
+```
+
+## Decision
+
+**Option A (unified `aragora` distribution), with standalone wedges preserved.**
+
+This is effectively a synthesis that keeps Option A's single clean install story
+while retaining the separable wedges that Option B and ODR-3 care about:
+
+1. The root distribution is renamed `aragora-debate` → `aragora` and ships the
+   full package (auto-discovery `include = ["aragora*"]`) with a console entry
+   point `aragora = aragora.cli.main:main`.
+2. `aragora-debate/` remains an unchanged standalone wedge.
+3. ODR-3's `aragora-verify` stays a **separate** near-zero-dependency package;
+   the root `aragora` distribution does not absorb the offline verifier, so the
+   "receipt is trustworthy outside Aragora" property is preserved. ODR-3 leads
+   on receipt-surface naming.
+
+## Outcome (already shipped on main)
+
+The chosen Option A landed via **#8517** (merged on `main`, commit `4cf2fd74db`,
+"feat(packaging): root distribution becomes installable `aragora` (P3)"). This
+receipt is therefore a post-hoc record of the decision gate, not a
+pre-implementation hold. Verified on `origin/main`:
+
+- `[project].name == "aragora"`
+- `[project.scripts].aragora == "aragora.cli.main:main"`
+- `[tool.setuptools.packages.find].include == ["aragora*"]`
+- `aragora-debate/pyproject.toml` `[project].name == "aragora-debate"` (wedge intact)
+
+## Cross-references
+
+- Issue: #8263 (decision-gated packaging) — this receipt satisfies its decision gate.
+- ODR-3 coordination: #8226 (standalone `aragora-verify`) — dependency audit shared there.
+- Source audit baseline: [`2026-06-12-codebase-health-audit.md`](2026-06-12-codebase-health-audit.md).
+- Implementation: PR #8517 (root distribution rename, merged).


### PR DESCRIPTION
## Source
HEALTH-6 #8263 (decision-gated packaging) + ODR-3 coordination #8226. Part of epic #8257 (P3 packaging milestone).

## What
Two docs-only artifacts (no `pyproject.toml` edits — that file is path-frozen and owned by other P3 features):

1. `docs/architecture/PACKAGING_AND_DISTRIBUTION.md` — post-hoc P3 packaging design recording what **#8517** shipped (root distribution `aragora-debate` → `aragora`, auto-discovery `include = ["aragora*"]`, console script `aragora = aragora.cli.main:main`, `aragora-debate/` wedge preserved), with a **traced dependency audit table** (import-site counts: aiohttp 102, websockets 7, pyyaml 49, pydantic 33) and the aiohttp/websockets base-floor gap finding for the pyproject-owning follow-ups.
2. `docs/audits/2026-06-22-p3-packaging-decision-receipt.md` — the **dogfood decision receipt** for the decision-gated #8263, produced by Aragora's own debate engine (`aragora ask ... --consensus judge`): verdict **PASS**, heterogeneous quorum grok/mistral-api/deepseek, content_hash `275a182b60fc8e1c`.

## Decision
Option A (one `aragora` distribution shipping CLI/server entry points) with the standalone wedges (`aragora-debate/`, ODR-3 `aragora-verify`) kept separable. Already shipped on main via #8517; this PR records the design + receipt post-hoc.

## Validation (exact commands + results)
- `python3 scripts/ci/check_docs_links.py` → exit 0 (all internal links/anchors resolve)
- `python3 scripts/check_docs_consistency.py` → exit 0 (No findings)
- `python3 scripts/check_version_alignment.py` → exit 0 (All versions aligned)
- `make lint` → exit 0
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` → exit 0 (docs-only diff)

## Risks
None material: docs-only, non-mirrored paths (no docs-site regen), no protected/Tier-4 surfaces, no pyproject edits.
