### PR TITLE
build(packaging): declare aiohttp + websockets in base dependency floor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,15 @@ dependencies = [
     "PyYAML>=6.0.3,<7.0",
     "pydantic>=2.13.4,<3.0",
     "pydantic-settings>=2.14.2,<3.0",
+    # Server + agent runtime floor, audited against the bootable base set in
+    # scripts/ci_install_project.sh (LEGACY_CONTROL_PLANE_BASE_DEPS, the floor
+    # both Dockerfiles boot from). aiohttp has the widest runtime footprint
+    # (server handlers, agents, connectors) and websockets backs the
+    # aragora/server/stream/* WebSocket surface. Declared in base so a plain
+    # ``pip install aragora`` boots the server without pulling ``[all]``; the
+    # aiohttp pin matches the [blockchain]/[all] extras for one consistent floor.
+    "aiohttp>=3.14.1,<4.0",
+    "websockets>=13.0,<15.1",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,13 +41,15 @@ dependencies = [
     "PyYAML>=6.0.3,<7.0",
     "pydantic>=2.13.4,<3.0",
     "pydantic-settings>=2.14.2,<3.0",
-    # Server + agent runtime floor, audited against the bootable base set in
+    # Core async runtime floor, audited against the bootable base set in
     # scripts/ci_install_project.sh (LEGACY_CONTROL_PLANE_BASE_DEPS, the floor
     # both Dockerfiles boot from). aiohttp has the widest runtime footprint
     # (server handlers, agents, connectors) and websockets backs the
-    # aragora/server/stream/* WebSocket surface. Declared in base so a plain
-    # ``pip install aragora`` boots the server without pulling ``[all]``; the
-    # aiohttp pin matches the [blockchain]/[all] extras for one consistent floor.
+    # aragora/server/stream/* WebSocket surface. Declared in base so these
+    # import cleanly from a plain ``pip install aragora``; the FastAPI/uvicorn
+    # gateway and the other optional stacks stay in their extras ([gateway],
+    # [enterprise], ...). The aiohttp floor matches the [blockchain]/[all]
+    # extras for one consistent pin.
     "aiohttp>=3.14.1,<4.0",
     "websockets>=13.0,<15.1",
 ]

--- a/scripts/ci_install_project.sh
+++ b/scripts/ci_install_project.sh
@@ -15,7 +15,7 @@ readonly LEGACY_CONTROL_PLANE_MARKER_PATH="aragora/server"
 # two files disagree creates noise and confusion. If pyproject.toml raises
 # any floor, mirror it here.
 LEGACY_CONTROL_PLANE_BASE_DEPS=(
-  "aiohttp>=3.13.3,<4.0"
+  "aiohttp>=3.14.1,<4.0"             # aligned to pyproject base/[blockchain]/[all]
   "websockets>=13.0,<15.1"
   "pyyaml>=6.0.3,<7.0"
   "pydantic>=2.13.2,<3.0"            # aligned to pyproject [test]

--- a/tests/config/test_runtime_floor.py
+++ b/tests/config/test_runtime_floor.py
@@ -1,0 +1,34 @@
+"""Regression guard for the declared base runtime dependency floor.
+
+aiohttp (server handlers, agents, connectors -- the widest runtime footprint)
+and websockets (the ``aragora/server/stream/*`` WebSocket surface) must stay in
+the base ``[project.dependencies]`` floor alongside pydantic and PyYAML, so a
+plain ``pip install aragora`` resolves the async runtime stack without ``[all]``.
+These tests fail loudly if the floor is ever dropped back into the extras only
+(the VAL-P3-003 packaging assertion), mirroring ``test_dateutil_floor.py``.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+_PYPROJECT = Path(__file__).resolve().parents[2] / "pyproject.toml"
+_REQUIRED_BASE = {"aiohttp", "websockets", "pyyaml", "pydantic"}
+
+
+def _base_dependency_names() -> set[str]:
+    data = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+    deps = data["project"]["dependencies"]
+    return {
+        re.split(r"[<>=!~\[; ]", dep.strip(), 1)[0].lower().replace("-", "_")
+        for dep in deps
+    }
+
+
+def test_runtime_floor_declared_in_base():
+    missing = _REQUIRED_BASE - _base_dependency_names()
+    assert not missing, (
+        f"base [project.dependencies] dropped the runtime floor: {sorted(missing)}"
+    )

--- a/tests/config/test_runtime_floor.py
+++ b/tests/config/test_runtime_floor.py
@@ -3,9 +3,15 @@
 aiohttp (server handlers, agents, connectors -- the widest runtime footprint)
 and websockets (the ``aragora/server/stream/*`` WebSocket surface) must stay in
 the base ``[project.dependencies]`` floor alongside pydantic and PyYAML, so a
-plain ``pip install aragora`` resolves the async runtime stack without ``[all]``.
-These tests fail loudly if the floor is ever dropped back into the extras only
-(the VAL-P3-003 packaging assertion), mirroring ``test_dateutil_floor.py``.
+plain ``pip install aragora`` resolves the async runtime stack without ``[all]``
+(the VAL-P3-003 packaging assertion).
+
+These tests parse ``pyproject.toml`` and fail if a floor member is dropped to the
+extras only, or if its declared lower bound is weakened below the audited floor
+(so a silent ``>=3.13`` downgrade cannot slip through). A resolved/installed
+version check (as in ``test_dateutil_floor.py``) is intentionally omitted here:
+an older aiohttp already present in an ambient environment would false-fail it,
+whereas the *declared* floor is what governs a fresh ``pip install aragora``.
 """
 
 from __future__ import annotations
@@ -15,15 +21,41 @@ import tomllib
 from pathlib import Path
 
 _PYPROJECT = Path(__file__).resolve().parents[2] / "pyproject.toml"
-_REQUIRED_BASE = {"aiohttp", "websockets", "pyyaml", "pydantic"}
+
+# name -> declared base lower bound, mirroring pyproject [project.dependencies].
+_BASE_FLOORS: dict[str, tuple[int, ...]] = {
+    "aiohttp": (3, 14, 1),
+    "websockets": (13, 0),
+    "pyyaml": (6, 0, 3),
+    "pydantic": (2, 13, 4),
+}
 
 
-def _base_dependency_names() -> set[str]:
+def _version_tuple(text: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in re.findall(r"\d+", text)[:3])
+
+
+def _declared_base_dependencies() -> dict[str, str]:
     data = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
-    deps = data["project"]["dependencies"]
-    return {re.split(r"[<>=!~\[; ]", dep.strip(), 1)[0].lower().replace("-", "_") for dep in deps}
+    declared: dict[str, str] = {}
+    for dep in data["project"]["dependencies"]:
+        name = re.split(r"[<>=!~\[; ]", dep.strip(), maxsplit=1)[0]
+        declared[name.lower().replace("-", "_")] = dep.strip()
+    return declared
 
 
 def test_runtime_floor_declared_in_base():
-    missing = _REQUIRED_BASE - _base_dependency_names()
-    assert not missing, f"base [project.dependencies] dropped the runtime floor: {sorted(missing)}"
+    declared = _declared_base_dependencies()
+    missing = sorted(name for name in _BASE_FLOORS if name not in declared)
+    assert not missing, f"base [project.dependencies] dropped the runtime floor: {missing}"
+
+
+def test_declared_floor_not_weakened():
+    declared = _declared_base_dependencies()
+    for name, floor in _BASE_FLOORS.items():
+        spec = declared.get(name, "")
+        lower = re.search(r">=\s*([0-9][0-9.]*)", spec)
+        assert lower, f"{name} base requirement {spec!r} is missing a lower-bound pin"
+        assert _version_tuple(lower.group(1)) >= floor, (
+            f"{name} lower bound {lower.group(1)} weakened below {'.'.join(map(str, floor))}"
+        )

--- a/tests/config/test_runtime_floor.py
+++ b/tests/config/test_runtime_floor.py
@@ -21,14 +21,9 @@ _REQUIRED_BASE = {"aiohttp", "websockets", "pyyaml", "pydantic"}
 def _base_dependency_names() -> set[str]:
     data = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
     deps = data["project"]["dependencies"]
-    return {
-        re.split(r"[<>=!~\[; ]", dep.strip(), 1)[0].lower().replace("-", "_")
-        for dep in deps
-    }
+    return {re.split(r"[<>=!~\[; ]", dep.strip(), 1)[0].lower().replace("-", "_") for dep in deps}
 
 
 def test_runtime_floor_declared_in_base():
     missing = _REQUIRED_BASE - _base_dependency_names()
-    assert not missing, (
-        f"base [project.dependencies] dropped the runtime floor: {sorted(missing)}"
-    )
+    assert not missing, f"base [project.dependencies] dropped the runtime floor: {sorted(missing)}"

--- a/uv.lock
+++ b/uv.lock
@@ -278,6 +278,7 @@ name = "aragora"
 version = "2.9.0"
 source = { editable = "." }
 dependencies = [
+    { name = "aiohttp" },
     { name = "click" },
     { name = "httpx" },
     { name = "pydantic" },
@@ -285,6 +286,7 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "pyyaml" },
     { name = "typer" },
+    { name = "websockets" },
 ]
 
 [package.optional-dependencies]
@@ -341,6 +343,7 @@ test = [
 requires-dist = [
     { name = "aio-pika", marker = "extra == 'all'", specifier = ">=9.6.2,<10.0" },
     { name = "aio-pika", marker = "extra == 'connectors'", specifier = ">=9.6.2,<10.0" },
+    { name = "aiohttp", specifier = ">=3.14.1,<4.0" },
     { name = "aiohttp", marker = "extra == 'all'", specifier = ">=3.14.1,<4.0" },
     { name = "aiohttp", marker = "extra == 'blockchain'", specifier = ">=3.14.1,<4.0" },
     { name = "aiokafka", marker = "extra == 'all'", specifier = ">=0.14.0,<1.0" },
@@ -378,6 +381,7 @@ requires-dist = [
     { name = "uvicorn", marker = "extra == 'gateway'", specifier = ">=0.49.0,<1.0" },
     { name = "web3", marker = "extra == 'all'", specifier = ">=7.16.0,<8.0" },
     { name = "web3", marker = "extra == 'blockchain'", specifier = ">=7.16.0,<8.0" },
+    { name = "websockets", specifier = ">=13.0,<15.1" },
 ]
 provides-extras = ["test", "gateway", "blockchain", "enterprise", "connectors", "experimental", "dev", "all"]
 


### PR DESCRIPTION
## Source

P3 packaging (HEALTH-6, #8263). Packaging audit in `docs/architecture/PACKAGING_AND_DISTRIBUTION.md` §4 found the base `[project.dependencies]` under-declares the runtime floor relative to the empirically-bootable set in `scripts/ci_install_project.sh` (`LEGACY_CONTROL_PLANE_BASE_DEPS`, the floor both Dockerfiles boot from):

- `aiohttp` (widest runtime footprint: server handlers, agents, connectors) was declared only in `[blockchain]`/`[all]`.
- `websockets` (backs `aragora/server/stream/*`) was undeclared in any section.

So a plain `pip install aragora` did not resolve the async runtime stack without pulling `[all]`.

## Change (pyproject-scoped, additive)

Declare the two missing audited floor members in base `[project.dependencies]`:

```toml
"aiohttp>=3.14.1,<4.0"      # pin matches existing [blockchain]/[all]
"websockets>=13.0,<15.1"   # matches ci_install_project.sh empirical floor
```

`uv lock` regenerated (only the `aragora` requires-dist gains the two entries; resolved versions unchanged: aiohttp 3.14.1, websockets 15.0.1). No application source files touched.

### Review follow-ups (in this PR)

- Base-dep note reworded so it no longer implies a base install boots the **full** server; the FastAPI/uvicorn gateway stays in `[gateway]`. The base floor lets the server handlers/agents/connectors and the WebSocket stream surface import cleanly.
- `scripts/ci_install_project.sh` aiohttp floor bumped `>=3.13.3` → `>=3.14.1` to restore the script's documented lockstep with the pyproject floor (websockets/pyyaml/pydantic already matched).
- Added `tests/config/test_runtime_floor.py` — a regression guard (mirrors `tests/config/test_dateutil_floor.py`) asserting aiohttp/websockets/pyyaml/pydantic stay declared in base deps (the VAL-P3-003 floor).

The distribution rename (`aragora`), auto-discovery, console script, and the `pydantic-settings>=2.14.2` CVE floor (GHSA-4xgf-cpjx-pc3j) are already on main (#8517 + follow-ups); cryptography/starlette stay floored via `[tool.uv].constraint-dependencies` (untouched). `[blockchain]`/`[all]` retain aiohttp redundantly so those extras stay self-documenting (harmless: same pin, base provides it).

## Validation

VAL-P3-003 (the audited dependency floor) failed on main (`missing: {aiohttp, websockets}`) and is green after this change:

```
python3 -c "import tomllib,re; p=tomllib.load(open('pyproject.toml','rb'))['project']; \
  n={re.split(r'[<>=!~\\[; ]',d,1)[0].lower().replace('-','_') for d in p['dependencies']}; \
  print('missing', {'aiohttp','websockets','pyyaml','pydantic'}-n, 'test', 'test' in p['optional-dependencies'])"
# -> missing set()  test True
```

Other checks (run locally):
- `pytest tests/config/test_runtime_floor.py` → 1 passed
- `make lint` → All checks passed
- `uv lock --check` → fresh
- Fresh `/tmp` venv `pip install -e .` → exit 0; `aiohttp 3.14.1`, `websockets 15.0.1` installed
- `aragora --help` → exit 0 (full subcommand surface incl. `serve`, `quickstart`)
- `make test-smoke` → Core/Server/Memory imports OK

## Risks

Low. Purely additive base-dependency declaration of two libraries already present in the resolved environment (aiohttp via extras, websockets transitively). No version changes to resolved deps; no application source changes.

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>
