### PR TITLE
fix(review-queue): reject stale head citations in evidence

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -4350,7 +4350,11 @@ def _is_review_grounded_on_head(
         if commit_oid:
             if commit_oid == head_sha:
                 return True
+            if _body_cites_different_head_sha(body, head_sha):
+                return False
             return bool(head_short and head_short in body)
+    if _body_cites_different_head_sha(body, head_sha):
+        return False
     if head_short and head_short in body:
         return True
     if not head_committed_at:
@@ -4399,6 +4403,8 @@ def _is_comment_grounded_on_head(
         return True
     body = str(comment.get("body", "") or "")
     head_short = head_sha[:7]
+    if _body_cites_different_head_sha(body, head_sha):
+        return False
     if head_short and head_short in body:
         return True
     created = str(comment.get("createdAt", "") or "")
@@ -4409,6 +4415,29 @@ def _is_comment_grounded_on_head(
         # seen this head, so the comment is treated as stale.
         return False
     return created >= head_committed_at
+
+
+def _body_cites_different_head_sha(body: str, head_sha: str) -> bool:
+    """Return True when a comment labels some other SHA as the reviewed head.
+
+    Timestamp recency is a useful fallback for terse comments, but it must not
+    override an explicit ``Head SHA: <old-sha>`` style citation copied from a
+    superseded prompt.
+    """
+    normalized_head = str(head_sha or "").strip().lower()
+    if len(normalized_head) < 7:
+        return False
+    for match in re.finditer(
+        r"\b(?:current\s+head|exact\s+head|head\s+sha|head|commit(?:\s+sha)?)\b"
+        r"[^\n]{0,80}?([0-9a-f]{7,40})\b",
+        str(body or "").lower(),
+        flags=re.IGNORECASE,
+    ):
+        cited = match.group(1).lower()
+        if normalized_head.startswith(cited) or cited.startswith(normalized_head):
+            continue
+        return True
+    return False
 
 
 def _first_nonempty_line(text: str) -> str:

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -4418,12 +4418,7 @@ def _is_comment_grounded_on_head(
 
 
 def _body_cites_different_head_sha(body: str, head_sha: str) -> bool:
-    """Return True when a comment labels some other SHA as the reviewed head.
-
-    Timestamp recency is a useful fallback for terse comments, but it must not
-    override an explicit ``Head SHA: <old-sha>`` style citation copied from a
-    superseded prompt.
-    """
+    """Return True when a comment labels another SHA as the reviewed head."""
     normalized_head = str(head_sha or "").strip().lower()
     if len(normalized_head) < 7:
         return False

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -1456,6 +1456,38 @@ class TestModelReviewQuorum:
         assert quorum["counted_reviewer_ids"] == ["grok", "openai"]
         assert quorum["status"] == "satisfied"
 
+    def test_fresh_comment_citing_different_head_sha_is_excluded(self) -> None:
+        """Timestamp freshness must not rescue evidence pasted for an older head."""
+        head_sha = "abcdef1234567890abcdef1234567890abcdef12"
+        previous_head = "1234567890abcdef1234567890abcdef12345678"
+        pr = _make_pr(files=["aragora/cli/commands/swarm.py"])
+        pr["headRefOid"] = head_sha
+        pr["commits"] = [
+            {"oid": head_sha, "committedDate": "2026-04-28T20:00:00Z"},
+        ]
+        pr["comments"] = [
+            {
+                "author": {"login": "an0mium"},
+                "body": _codex_openai_body(
+                    body=(
+                        f"Head SHA: {previous_head}\nFocused adversarial dogfood found no blockers."
+                    )
+                ),
+                "createdAt": "2026-04-28T20:05:00Z",
+            },
+        ]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=["aragora/cli/commands/swarm.py"],
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+        )
+        assert quorum["counted_reviewer_ids"] == []
+        assert quorum["dogfood_evidence"] == []
+        assert quorum["status"] == "needs_model_review_quorum"
+
     def test_stale_comment_with_head_sha_citation_still_counts(self) -> None:
         """A reviewer who explicitly cites the current head SHA in
         their body counts even if their createdAt predates the head."""


### PR DESCRIPTION
## Summary
- Reject model-evidence comments/reviews that explicitly cite a different reviewed head SHA before timestamp recency or generic SHA-prefix fallback can count them.
- Add a regression proving fresh evidence pasted for an older head is excluded from model quorum and dogfood evidence.

## Motivation
Live #8527 drift exposed a merge-packet/evidence-lint disagreement: a fresh OpenAI evidence comment body cited old head `1bbb9f4c3cd6b684f63442e6d5e6fd7d7f756a90`, while the PR had already moved to `6dd317a385741f1d02c3001f7259baee64b16a95`. Evidence-lint correctly rejected the body for the new exact head, but merge-packet could still count it through timestamp fallback.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/cli/commands/test_review_queue.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py`

Draft until CI/evidence gates are collected.