### PR TITLE
Classify terminal stale lane owners

### DIFF
--- a/scripts/build_next_prompt.py
+++ b/scripts/build_next_prompt.py
@@ -860,6 +860,8 @@ def _owner_lookup_packet(
 def _is_stale_mailbox_only_owner(owner_state: Any) -> bool:
     if not isinstance(owner_state, dict):
         return False
+    if str(owner_state.get("owner_blocking_state") or "") == "stale_terminal_owner":
+        return False
     if str(owner_state.get("status") or "") not in ACTIVE_STATUSES:
         return False
     live_process = owner_state.get("live_process")

--- a/scripts/identify_lane_owner.py
+++ b/scripts/identify_lane_owner.py
@@ -41,13 +41,14 @@ Lookup sources (read-only, in this precedence):
 Owner-lease liveness (issue #8318): when ``--liveness`` is enabled
 (default), the JSON output is additionally enriched with an
 ``owner_liveness`` object (lease age, last heartbeat, lane-ledger
-status, assessment) and — only for stale/terminal owners with no
-indication of local unpushed work — a machine-readable
-``stale_claim_advisory`` codifying the manual stale-claim override
-protocol exercised on #8125. This is VISIBILITY + ADVISORY only: it
-never changes a go/no-go decision by itself, and it fails closed
-(``advisory_withheld: "possible_unpushed_work"``) whenever
-uncommitted/unpushed work might exist.
+status, assessment), a consumer-facing ``owner_blocking_state``, and
+— only for stale/terminal owners with no indication of local unpushed
+work — a machine-readable ``stale_claim_advisory`` codifying the
+manual stale-claim override protocol exercised on #8125. This is
+VISIBILITY + ADVISORY only: it never changes a go/no-go decision by
+itself, and it fails closed (``advisory_withheld:
+"possible_unpushed_work"``) whenever uncommitted/unpushed work might
+exist.
 
 Pure stdlib. No ``aragora.*`` imports. Read-only — never mutates
 GitHub state, lane registry, mailboxes, or any other on-disk file.
@@ -1212,6 +1213,11 @@ STALE_CLAIM_PROTOCOL = "stale-claim-override"
 ADVISORY_WITHHELD_UNPUSHED = "possible_unpushed_work"
 REQUIRED_LEDGER_RECORD = "overriding lane must write an override entry naming the stale lane id"
 
+OWNER_BLOCKING_LIVE = "live_owner"
+OWNER_BLOCKING_UNKNOWN = "unknown_owner"
+OWNER_BLOCKING_STALE = "stale_owner"
+OWNER_BLOCKING_STALE_TERMINAL = "stale_terminal_owner"
+
 # Timestamp fields on the owner (lane-registry) record; newest wins.
 _OWNER_RECORD_TIMESTAMP_KEYS = (
     "updated_at",
@@ -1865,8 +1871,36 @@ def assess_owner_liveness(
                 "required_ledger_record": REQUIRED_LEDGER_RECORD,
             }
 
+    if assessed == "live":
+        owner_blocking_state = OWNER_BLOCKING_LIVE
+        owner_blocking_state_reason = "owner has current lease or heartbeat evidence"
+    elif assessed == "unknown":
+        owner_blocking_state = OWNER_BLOCKING_UNKNOWN
+        owner_blocking_state_reason = "owner lease age could not be established"
+    elif (
+        assessed == "terminal"
+        and advisory is not None
+        and advisory.get("available") is True
+        and advisory_withheld is None
+    ):
+        owner_blocking_state = OWNER_BLOCKING_STALE_TERMINAL
+        owner_blocking_state_reason = (
+            "terminal stale owner has no local-work claim and is eligible for guarded "
+            "stale-claim handling"
+        )
+    else:
+        owner_blocking_state = OWNER_BLOCKING_STALE
+        if advisory_withheld:
+            owner_blocking_state_reason = (
+                f"stale owner remains blocking because advisory is withheld: {advisory_withheld}"
+            )
+        else:
+            owner_blocking_state_reason = "stale owner is not proven terminal-safe"
+
     return {
         "owner_liveness": owner_liveness,
+        "owner_blocking_state": owner_blocking_state,
+        "owner_blocking_state_reason": owner_blocking_state_reason,
         "stale_claim_advisory": advisory,
         "advisory_withheld": advisory_withheld,
         "local_work_preservation": local_work_preservation,
@@ -1887,6 +1921,7 @@ def _print_liveness_summary(payload: dict[str, Any]) -> None:
     print(
         "owner_liveness: "
         f"assessed={liveness['assessed']} "
+        f"owner_blocking_state={payload['owner_blocking_state']} "
         f"lease_age_seconds={lease if lease is not None else '-'} "
         f"lane_status={liveness['lane_status']} "
         f"last_heartbeat_at={liveness['last_heartbeat_at'] or '-'} "

--- a/tests/scripts/test_build_next_prompt.py
+++ b/tests/scripts/test_build_next_prompt.py
@@ -1042,6 +1042,20 @@ def test_main_routes_stale_mailbox_only_owner_to_steering_prompt(
     assert "last heartbeat is 2026-06-04T14:45:34Z" in out
 
 
+def test_stale_terminal_owner_does_not_route_to_mailbox_steering() -> None:
+    owner_state = {
+        "status": "blocked",
+        "owner_blocking_state": "stale_terminal_owner",
+        "pending_message_count": 1,
+        "unread_message_count": 1,
+        "harness_confidence": "mailbox_only_fuzzy_thread",
+        "live_prompt_dispatchable": False,
+        "live_process": {"found": False},
+    }
+
+    assert prompt_builder._is_stale_mailbox_only_owner(owner_state) is False
+
+
 def test_main_guards_unresolved_operator_choice_placeholders(
     tmp_path: Path,
     monkeypatch: Any,

--- a/tests/scripts/test_identify_lane_owner.py
+++ b/tests/scripts/test_identify_lane_owner.py
@@ -1256,6 +1256,7 @@ class TestOwnerLeaseLiveness:
         assert liveness["lane_status"] == "in_progress"
         assert liveness["lease_age_seconds"] == 3600
         assert liveness["last_heartbeat_at"] is None
+        assert result["owner_blocking_state"] == "live_owner"
         assert result["stale_claim_advisory"] is None
         assert result["advisory_withheld"] is None
 
@@ -1273,6 +1274,7 @@ class TestOwnerLeaseLiveness:
         )
         assert result["owner_liveness"]["assessed"] == "terminal"
         assert result["owner_liveness"]["lane_status"] == "completed"
+        assert result["owner_blocking_state"] == "stale_terminal_owner"
         advisory = result["stale_claim_advisory"]
         assert advisory is not None
         assert advisory["available"] is True
@@ -1309,6 +1311,7 @@ class TestOwnerLeaseLiveness:
         assert liveness["assessed"] == "stale"
         assert liveness["lane_status"] == "in_progress"
         assert liveness["lease_age_seconds"] == 7 * 3600
+        assert result["owner_blocking_state"] == "stale_owner"
         advisory = result["stale_claim_advisory"]
         assert advisory is not None
         assert advisory["available"] is True
@@ -1329,6 +1332,7 @@ class TestOwnerLeaseLiveness:
             lane, ledger_entry=ledger, heartbeat=None, now=_liveness_now()
         )
         assert result["owner_liveness"]["assessed"] == "stale"
+        assert result["owner_blocking_state"] == "stale_owner"
         assert result["stale_claim_advisory"] is None
         assert result["advisory_withheld"] == "possible_unpushed_work"
 
@@ -1555,6 +1559,7 @@ class TestOwnerLeaseLiveness:
             lane, ledger_entry=ledger, heartbeat=None, now=_liveness_now()
         )
         assert result["owner_liveness"]["assessed"] == "terminal"
+        assert result["owner_blocking_state"] == "stale_owner"
         assert result["stale_claim_advisory"] is None
         assert result["advisory_withheld"] == "possible_unpushed_work"
 
@@ -1568,6 +1573,7 @@ class TestOwnerLeaseLiveness:
         assert liveness["lease_age_seconds"] is None
         assert liveness["lane_status"] == "unknown"
         assert liveness["last_heartbeat_at"] is None
+        assert result["owner_blocking_state"] == "unknown_owner"
         assert result["stale_claim_advisory"] is None
         assert result["advisory_withheld"] is None
 
@@ -1584,6 +1590,7 @@ class TestOwnerLeaseLiveness:
             lane, ledger_entry=ledger, heartbeat=None, now=_liveness_now()
         )
         assert result["owner_liveness"]["assessed"] == "live"
+        assert result["owner_blocking_state"] == "live_owner"
         assert result["stale_claim_advisory"] is None
         assert result["advisory_withheld"] is None
 
@@ -1955,6 +1962,7 @@ class TestLivenessCLI:
         assert data["owner_liveness"]["assessed"] == "stale"
         assert data["owner_liveness"]["lane_status"] == "in_progress"
         assert data["owner_liveness"]["lease_age_seconds"] == 7 * 3600
+        assert data["owner_blocking_state"] == "stale_owner"
         assert data["stale_claim_advisory"]["available"] is True
         assert data["stale_claim_advisory"]["protocol"] == "stale-claim-override"
         assert data["advisory_withheld"] is None
@@ -2040,6 +2048,7 @@ class TestLivenessCLI:
         summary_lines = [line for line in out.splitlines() if line.startswith("owner_liveness: ")]
         assert len(summary_lines) == 1
         assert "assessed=stale" in summary_lines[0]
+        assert "owner_blocking_state=stale_owner" in summary_lines[0]
         assert "stale_claim_advisory=available" in summary_lines[0]
 
     def test_human_output_omits_summary_with_no_liveness(


### PR DESCRIPTION
## Summary
- Add an additive `owner_blocking_state` / reason to `identify_lane_owner.py` liveness output.
- Classify terminal stale owners with safe stale-claim advisory as `stale_terminal_owner` while keeping live, unknown, and unsafe stale owners blocking.
- Teach `build_next_prompt.py` not to route `stale_terminal_owner` rows as active stale mailbox-only blockers.

## Validation
- `python3 -m pytest tests/scripts/test_identify_lane_owner.py tests/scripts/test_build_next_prompt.py -q` (`125 passed`)
- `python3 scripts/report_code_quality.py --check`
- `git diff --check`

Refs #8559
