### PR TITLE
fix(cleanup): report untracked residue purge truthfully

### DIFF
--- a/scripts/safe_worktree_cleanup.py
+++ b/scripts/safe_worktree_cleanup.py
@@ -605,7 +605,16 @@ def remove_worktree(
         if purge_error:
             result["purge_error"] = purge_error
         if result["path_purged"]:
-            result["removed"] = True
+            if result["git_remove_failed"]:
+                result["status"] = "remove_failed_path_purged"
+                result["removed"] = False
+                result["recovery_action"] = (
+                    "filesystem path was purged, but git worktree remove failed; "
+                    "rerun inspect and reconcile git worktree metadata before deleting "
+                    "the branch or treating cleanup as complete"
+                )
+            else:
+                result["removed"] = True
         else:
             if result["git_remove_failed"]:
                 result["status"] = "remove_failed_purge_incomplete"
@@ -624,8 +633,6 @@ def remove_worktree(
         result["status"] = "partial"
     elif result.get("status") == "untracked_path" and result["removed"]:
         result["status"] = "purged"
-    elif result.get("status") == "remove_failed" and result["path_purged"]:
-        result["status"] = "purged_after_failed_remove"
 
     return result
 
@@ -659,6 +666,7 @@ def cmd_remove(args: argparse.Namespace) -> int:
     if status in {
         "blocked",
         "remove_failed",
+        "remove_failed_path_purged",
         "remove_failed_purge_incomplete",
         "untracked_path",
         "partial",

--- a/scripts/safe_worktree_cleanup.py
+++ b/scripts/safe_worktree_cleanup.py
@@ -547,6 +547,7 @@ def remove_worktree(
         "path_purged": False,
         "requires_purge_path": False,
         "git_remove_failed": False,
+        "git_worktree_removed": False,
         "recovery_action": None,
         "residual_paths": [],
         "purge_error": None,
@@ -570,7 +571,11 @@ def remove_worktree(
             )
         except subprocess.TimeoutExpired as exc:
             result["status"] = "remove_failed"
+            result["git_remove_failed"] = True
             result["stderr"] = f"git worktree remove timed out after {exc.timeout}s"
+            result["recovery_action"] = (
+                "git worktree remove timed out; rerun inspect before retrying cleanup"
+            )
             return result
         if proc.returncode != 0:
             result["status"] = "remove_failed"
@@ -581,6 +586,7 @@ def remove_worktree(
         else:
             result["removed"] = True
             result["status"] = "removed"
+            result["git_worktree_removed"] = True
     else:
         result["status"] = "untracked_path"
         if not purge_path:

--- a/scripts/safe_worktree_cleanup.py
+++ b/scripts/safe_worktree_cleanup.py
@@ -479,6 +479,46 @@ def _delete_branch(repo_root: Path, branch: str) -> bool:
     return proc.returncode == 0
 
 
+def _path_still_exists(path: Path) -> bool:
+    return path.exists() or path.is_symlink()
+
+
+def _residual_paths(path: Path, *, limit: int = 50) -> list[str]:
+    """Return a bounded list of residual entries under a failed purge path."""
+
+    if not _path_still_exists(path):
+        return []
+    if path.is_file() or path.is_symlink():
+        return ["."]
+    residuals: list[str] = []
+    try:
+        for entry in sorted(path.rglob("*"), key=lambda item: str(item.relative_to(path))):
+            residuals.append(str(entry.relative_to(path)))
+            if len(residuals) >= limit:
+                residuals.append("...")
+                break
+    except OSError:
+        return ["<lookup_failed>"]
+    return residuals or ["."]
+
+
+def _purge_residual_path(path: Path) -> tuple[bool, str | None, list[str]]:
+    """Delete an untracked residue path and report truthfully if anything remains."""
+
+    if not _path_still_exists(path):
+        return True, None, []
+    purge_error: str | None = None
+    try:
+        if path.is_file() or path.is_symlink():
+            path.unlink()
+        else:
+            shutil.rmtree(path)
+    except OSError as exc:
+        purge_error = str(exc)
+    residuals = _residual_paths(path)
+    return not _path_still_exists(path), purge_error, residuals
+
+
 def remove_worktree(
     repo_root: Path,
     inspection: WorktreeInspection,
@@ -493,6 +533,10 @@ def remove_worktree(
         "removed": False,
         "branch_deleted": False,
         "path_purged": False,
+        "requires_purge_path": False,
+        "recovery_action": None,
+        "residual_paths": [],
+        "purge_error": None,
         "blockers": list(inspection.blockers),
         "cleanup_safety": cleanup_safety(inspection),
     }
@@ -526,13 +570,28 @@ def remove_worktree(
     else:
         result["status"] = "untracked_path"
         if not purge_path:
+            result["requires_purge_path"] = True
+            result["recovery_action"] = (
+                "rerun remove with --purge-path only after a fresh inspect returns "
+                "removable=true, blockers=[], dirty=false, active_session=false, "
+                "and open_prs=[] for this exact path"
+            )
             return result
 
-    if path.exists() and purge_path:
-        shutil.rmtree(path, ignore_errors=True)
-        result["path_purged"] = not path.exists()
+    if _path_still_exists(path) and purge_path:
+        path_purged, purge_error, residuals = _purge_residual_path(path)
+        result["path_purged"] = path_purged
+        result["residual_paths"] = residuals
+        if purge_error:
+            result["purge_error"] = purge_error
         if result["path_purged"]:
             result["removed"] = True
+        else:
+            result["status"] = "purge_incomplete"
+            result["recovery_action"] = (
+                "path was not fully removed; inspect residual_paths and rerun cleanup "
+                "only after the remaining files are proven disposable"
+            )
 
     if delete_branch and inspection.branch:
         result["branch_deleted"] = _delete_branch(repo_root, inspection.branch)
@@ -573,7 +632,7 @@ def cmd_remove(args: argparse.Namespace) -> int:
     else:
         print(json.dumps(result, indent=2))
     status = str(result.get("status", ""))
-    if status in {"blocked", "remove_failed", "untracked_path", "partial"}:
+    if status in {"blocked", "remove_failed", "untracked_path", "partial", "purge_incomplete"}:
         return 1
     return 0
 
@@ -608,7 +667,10 @@ def _build_parser() -> argparse.ArgumentParser:
     remove_parser.add_argument(
         "--purge-path",
         action="store_true",
-        help="Delete a residual path if git worktree removal leaves files behind",
+        help=(
+            "Delete the filesystem path after safety gates pass; required for untracked "
+            "residue and verified after removal"
+        ),
     )
     remove_parser.add_argument(
         "--force", action="store_true", help="Bypass active-session/open-PR blockers"

--- a/scripts/safe_worktree_cleanup.py
+++ b/scripts/safe_worktree_cleanup.py
@@ -525,7 +525,10 @@ def _purge_residual_path(path: Path) -> tuple[bool, str | None, list[str]]:
     except OSError as exc:
         purge_error = str(exc)
     residuals = _residual_paths(path)
-    return not _path_still_exists(path), purge_error, residuals
+    path_purged = not _path_still_exists(path)
+    if path_purged:
+        purge_error = None
+    return path_purged, purge_error, residuals
 
 
 def remove_worktree(
@@ -543,6 +546,7 @@ def remove_worktree(
         "branch_deleted": False,
         "path_purged": False,
         "requires_purge_path": False,
+        "git_remove_failed": False,
         "recovery_action": None,
         "residual_paths": [],
         "purge_error": None,
@@ -570,6 +574,7 @@ def remove_worktree(
             return result
         if proc.returncode != 0:
             result["status"] = "remove_failed"
+            result["git_remove_failed"] = True
             result["stderr"] = proc.stderr.strip()
             if not purge_path:
                 return result
@@ -596,14 +601,17 @@ def remove_worktree(
         if result["path_purged"]:
             result["removed"] = True
         else:
+            if result["git_remove_failed"]:
+                result["status"] = "remove_failed_purge_incomplete"
+            else:
+                result["status"] = "purge_incomplete"
             result["removed"] = False
-            result["status"] = "purge_incomplete"
             result["recovery_action"] = (
                 "path was not fully removed; inspect residual_paths and rerun cleanup "
                 "only after the remaining files are proven disposable"
             )
 
-    if delete_branch and inspection.branch:
+    if delete_branch and inspection.branch and result.get("removed"):
         result["branch_deleted"] = _delete_branch(repo_root, inspection.branch)
 
     if result.get("status") in {"removed", "untracked_path"} and not result["removed"]:
@@ -642,7 +650,14 @@ def cmd_remove(args: argparse.Namespace) -> int:
     else:
         print(json.dumps(result, indent=2))
     status = str(result.get("status", ""))
-    if status in {"blocked", "remove_failed", "untracked_path", "partial", "purge_incomplete"}:
+    if status in {
+        "blocked",
+        "remove_failed",
+        "remove_failed_purge_incomplete",
+        "untracked_path",
+        "partial",
+        "purge_incomplete",
+    }:
         return 1
     return 0
 

--- a/scripts/safe_worktree_cleanup.py
+++ b/scripts/safe_worktree_cleanup.py
@@ -489,7 +489,7 @@ def _residual_paths(path: Path, *, limit: int = 50) -> list[str]:
     if not _path_still_exists(path):
         return []
     if path.is_file() or path.is_symlink():
-        return ["."]
+        return [path.name]
     residuals: list[str] = []
     pending = [path]
     while pending:
@@ -581,6 +581,9 @@ def remove_worktree(
             result["status"] = "remove_failed"
             result["git_remove_failed"] = True
             result["stderr"] = proc.stderr.strip()
+            result["recovery_action"] = (
+                "git worktree remove failed; rerun inspect before retrying cleanup"
+            )
             if not purge_path:
                 return result
         else:

--- a/scripts/safe_worktree_cleanup.py
+++ b/scripts/safe_worktree_cleanup.py
@@ -491,14 +491,23 @@ def _residual_paths(path: Path, *, limit: int = 50) -> list[str]:
     if path.is_file() or path.is_symlink():
         return ["."]
     residuals: list[str] = []
-    try:
-        for entry in sorted(path.rglob("*"), key=lambda item: str(item.relative_to(path))):
-            residuals.append(str(entry.relative_to(path)))
-            if len(residuals) >= limit:
-                residuals.append("...")
-                break
-    except OSError:
-        return ["<lookup_failed>"]
+    pending = [path]
+    while pending:
+        current = pending.pop()
+        try:
+            entries = current.iterdir()
+            for entry in entries:
+                residuals.append(str(entry.relative_to(path)))
+                if entry.is_dir() and not entry.is_symlink():
+                    pending.append(entry)
+                if len(residuals) >= limit:
+                    residuals.append("...")
+                    return residuals
+        except OSError:
+            if residuals:
+                residuals.append("<lookup_failed>")
+                return residuals
+            return ["<lookup_failed>"]
     return residuals or ["."]
 
 
@@ -587,6 +596,7 @@ def remove_worktree(
         if result["path_purged"]:
             result["removed"] = True
         else:
+            result["removed"] = False
             result["status"] = "purge_incomplete"
             result["recovery_action"] = (
                 "path was not fully removed; inspect residual_paths and rerun cleanup "

--- a/tests/scripts/test_safe_worktree_cleanup.py
+++ b/tests/scripts/test_safe_worktree_cleanup.py
@@ -436,6 +436,165 @@ def test_tracked_remove_purge_failure_reports_not_removed(
     assert "not fully removed" in result["recovery_action"]
 
 
+def test_failed_git_remove_and_failed_purge_preserve_both_signals(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import safe_worktree_cleanup as mod
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    worktree = tmp_path / "tracked-residue"
+    worktree.mkdir()
+    (worktree / "leftover.txt").write_text("residue\n")
+
+    inspection = mod.WorktreeInspection(
+        path=str(worktree),
+        exists=True,
+        tracked_worktree=True,
+        branch="codex/test",
+        active_session=False,
+        lock_files=[],
+        dirty=False,
+        unique_commits_ahead=0,
+        ahead_lookup_failed=False,
+        patch_equivalent_to_origin_main=False,
+        patch_equivalence_lookup_failed=False,
+        open_prs=[],
+        pr_lookup_failed=False,
+        blockers=[],
+    )
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=args[0],
+            returncode=255,
+            stdout="",
+            stderr="Directory not empty",
+        )
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+    monkeypatch.setattr(mod.shutil, "rmtree", lambda *_args, **_kwargs: None)
+
+    result = mod.remove_worktree(
+        repo_root,
+        inspection,
+        delete_branch=False,
+        purge_path=True,
+        force=False,
+    )
+
+    assert result["status"] == "remove_failed_purge_incomplete"
+    assert result["git_remove_failed"] is True
+    assert result["stderr"] == "Directory not empty"
+    assert result["removed"] is False
+    assert result["path_purged"] is False
+    assert result["residual_paths"] == ["leftover.txt"]
+
+
+def test_purge_race_success_clears_stale_purge_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import safe_worktree_cleanup as mod
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    worktree = tmp_path / "anchor-residue"
+    worktree.mkdir()
+
+    inspection = mod.WorktreeInspection(
+        path=str(worktree),
+        exists=True,
+        tracked_worktree=False,
+        branch=None,
+        active_session=False,
+        lock_files=[],
+        dirty=False,
+        unique_commits_ahead=0,
+        ahead_lookup_failed=False,
+        patch_equivalent_to_origin_main=False,
+        patch_equivalence_lookup_failed=False,
+        open_prs=[],
+        pr_lookup_failed=False,
+        blockers=[],
+    )
+
+    def race_remove(path: Path) -> None:
+        path.rmdir()
+        raise OSError("path disappeared during purge")
+
+    monkeypatch.setattr(mod.shutil, "rmtree", race_remove)
+
+    result = mod.remove_worktree(
+        repo_root,
+        inspection,
+        delete_branch=False,
+        purge_path=True,
+        force=False,
+    )
+
+    assert result["status"] == "purged"
+    assert result["path_purged"] is True
+    assert result["purge_error"] is None
+    assert result["residual_paths"] == []
+
+
+def test_purge_incomplete_does_not_delete_branch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import safe_worktree_cleanup as mod
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    worktree = tmp_path / "tracked-residue"
+    worktree.mkdir()
+    (worktree / "leftover.txt").write_text("residue\n")
+
+    inspection = mod.WorktreeInspection(
+        path=str(worktree),
+        exists=True,
+        tracked_worktree=True,
+        branch="codex/test",
+        active_session=False,
+        lock_files=[],
+        dirty=False,
+        unique_commits_ahead=0,
+        ahead_lookup_failed=False,
+        patch_equivalent_to_origin_main=False,
+        patch_equivalence_lookup_failed=False,
+        open_prs=[],
+        pr_lookup_failed=False,
+        blockers=[],
+    )
+    branch_delete_calls: list[list[str]] = []
+
+    def fake_run(*args, **kwargs):
+        command = list(args[0])
+        if command[:3] == ["git", "branch", "-D"]:
+            branch_delete_calls.append(command)
+        return subprocess.CompletedProcess(
+            args=command,
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+    monkeypatch.setattr(mod.autopilot, "_branch_exists", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(mod.shutil, "rmtree", lambda *_args, **_kwargs: None)
+
+    result = mod.remove_worktree(
+        repo_root,
+        inspection,
+        delete_branch=True,
+        purge_path=True,
+        force=False,
+    )
+
+    assert result["status"] == "purge_incomplete"
+    assert result["branch_deleted"] is False
+    assert branch_delete_calls == []
+
+
 def test_residual_paths_are_bounded_without_rglob(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/scripts/test_safe_worktree_cleanup.py
+++ b/tests/scripts/test_safe_worktree_cleanup.py
@@ -245,9 +245,11 @@ def test_remove_purges_residual_path_after_failed_git_remove(
         force=False,
     )
 
-    assert result["status"] == "purged_after_failed_remove"
+    assert result["status"] == "remove_failed_path_purged"
+    assert result["removed"] is False
     assert result["path_purged"] is True
     assert result["git_remove_failed"] is True
+    assert "git worktree remove failed" in result["recovery_action"]
     assert worktree.exists() is False
 
 
@@ -490,6 +492,129 @@ def test_failed_git_remove_and_failed_purge_preserve_both_signals(
     assert result["removed"] is False
     assert result["path_purged"] is False
     assert result["residual_paths"] == ["leftover.txt"]
+
+
+def test_cmd_remove_reports_failed_git_remove_even_after_path_purge(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import safe_worktree_cleanup as mod
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    worktree = tmp_path / "tracked-residue"
+    worktree.mkdir()
+    (worktree / "leftover.txt").write_text("residue\n")
+
+    inspection = mod.WorktreeInspection(
+        path=str(worktree),
+        exists=True,
+        tracked_worktree=True,
+        branch="codex/test",
+        active_session=False,
+        lock_files=[],
+        dirty=False,
+        unique_commits_ahead=0,
+        ahead_lookup_failed=False,
+        patch_equivalent_to_origin_main=False,
+        patch_equivalence_lookup_failed=False,
+        open_prs=[],
+        pr_lookup_failed=False,
+        blockers=[],
+    )
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=args[0],
+            returncode=255,
+            stdout="",
+            stderr="Directory not empty",
+        )
+
+    monkeypatch.setattr(mod, "inspect_worktree", lambda *_args, **_kwargs: inspection)
+    monkeypatch.setattr(mod.autopilot, "_repo_root_from", lambda _path: repo_root)
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    args = argparse.Namespace(
+        repo=".",
+        path=str(worktree),
+        branch=None,
+        delete_branch=True,
+        purge_path=True,
+        force=False,
+        json=True,
+    )
+
+    rc = mod.cmd_remove(args)
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 1
+    assert payload["status"] == "remove_failed_path_purged"
+    assert payload["git_remove_failed"] is True
+    assert payload["path_purged"] is True
+    assert payload["removed"] is False
+    assert payload["branch_deleted"] is False
+
+
+def test_cmd_remove_returns_nonzero_for_tracked_residue_purge_incomplete(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import safe_worktree_cleanup as mod
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    worktree = tmp_path / "tracked-residue"
+    residual = worktree / "build" / "cache"
+    residual.mkdir(parents=True)
+    (residual / "leftover.txt").write_text("residue\n")
+
+    inspection = mod.WorktreeInspection(
+        path=str(worktree),
+        exists=True,
+        tracked_worktree=True,
+        branch="codex/test",
+        active_session=False,
+        lock_files=[],
+        dirty=False,
+        unique_commits_ahead=0,
+        ahead_lookup_failed=False,
+        patch_equivalent_to_origin_main=False,
+        patch_equivalence_lookup_failed=False,
+        open_prs=[],
+        pr_lookup_failed=False,
+        blockers=[],
+    )
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=args[0],
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+
+    monkeypatch.setattr(mod, "inspect_worktree", lambda *_args, **_kwargs: inspection)
+    monkeypatch.setattr(mod.autopilot, "_repo_root_from", lambda _path: repo_root)
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+    monkeypatch.setattr(mod.shutil, "rmtree", lambda *_args, **_kwargs: None)
+
+    args = argparse.Namespace(
+        repo=".",
+        path=str(worktree),
+        branch=None,
+        delete_branch=False,
+        purge_path=True,
+        force=False,
+        json=True,
+    )
+
+    rc = mod.cmd_remove(args)
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 1
+    assert payload["status"] == "purge_incomplete"
+    assert payload["git_worktree_removed"] is True
+    assert payload["path_purged"] is False
+    assert payload["removed"] is False
 
 
 def test_git_remove_timeout_sets_failure_flag_and_recovery_action(

--- a/tests/scripts/test_safe_worktree_cleanup.py
+++ b/tests/scripts/test_safe_worktree_cleanup.py
@@ -489,9 +489,60 @@ def test_failed_git_remove_and_failed_purge_preserve_both_signals(
     assert result["status"] == "remove_failed_purge_incomplete"
     assert result["git_remove_failed"] is True
     assert result["stderr"] == "Directory not empty"
+    assert "not fully removed" in result["recovery_action"]
     assert result["removed"] is False
     assert result["path_purged"] is False
     assert result["residual_paths"] == ["leftover.txt"]
+
+
+def test_failed_git_remove_without_purge_has_recovery_action(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import safe_worktree_cleanup as mod
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    worktree = tmp_path / "tracked-residue"
+    worktree.mkdir()
+
+    inspection = mod.WorktreeInspection(
+        path=str(worktree),
+        exists=True,
+        tracked_worktree=True,
+        branch="codex/test",
+        active_session=False,
+        lock_files=[],
+        dirty=False,
+        unique_commits_ahead=0,
+        ahead_lookup_failed=False,
+        patch_equivalent_to_origin_main=False,
+        patch_equivalence_lookup_failed=False,
+        open_prs=[],
+        pr_lookup_failed=False,
+        blockers=[],
+    )
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=args[0],
+            returncode=255,
+            stdout="",
+            stderr="Directory not empty",
+        )
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    result = mod.remove_worktree(
+        repo_root,
+        inspection,
+        delete_branch=False,
+        purge_path=False,
+        force=False,
+    )
+
+    assert result["status"] == "remove_failed"
+    assert result["git_remove_failed"] is True
+    assert "rerun inspect" in result["recovery_action"]
 
 
 def test_cmd_remove_reports_failed_git_remove_even_after_path_purge(
@@ -787,6 +838,15 @@ def test_residual_paths_are_bounded_without_rglob(
 
     assert len(residuals) == 51
     assert residuals[-1] == "..."
+
+
+def test_residual_paths_name_file_targets(tmp_path: Path) -> None:
+    import safe_worktree_cleanup as mod
+
+    residue = tmp_path / "leftover.log"
+    residue.write_text("residue\n")
+
+    assert mod._residual_paths(residue) == ["leftover.log"]
 
 
 def test_remove_deletes_branch_when_requested(

--- a/tests/scripts/test_safe_worktree_cleanup.py
+++ b/tests/scripts/test_safe_worktree_cleanup.py
@@ -225,16 +225,15 @@ def test_remove_purges_residual_path_after_failed_git_remove(
         blockers=[],
     )
 
-    monkeypatch.setattr(
-        mod.autopilot,
-        "_run_git",
-        lambda *_args, **_kwargs: subprocess.CompletedProcess(
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(
             args=["git", "worktree", "remove"],
             returncode=255,
             stdout="",
             stderr="Directory not empty",
-        ),
-    )
+        )
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
     monkeypatch.setattr(mod.autopilot, "_branch_exists", lambda *_args, **_kwargs: True)
     monkeypatch.setattr(mod.autopilot, "_repo_root_from", lambda _path: repo_root)
 
@@ -248,6 +247,7 @@ def test_remove_purges_residual_path_after_failed_git_remove(
 
     assert result["status"] == "purged_after_failed_remove"
     assert result["path_purged"] is True
+    assert result["git_remove_failed"] is True
     assert worktree.exists() is False
 
 
@@ -431,6 +431,7 @@ def test_tracked_remove_purge_failure_reports_not_removed(
 
     assert result["status"] == "purge_incomplete"
     assert result["removed"] is False
+    assert result["git_worktree_removed"] is True
     assert result["path_purged"] is False
     assert "build" in result["residual_paths"]
     assert "not fully removed" in result["recovery_action"]
@@ -489,6 +490,53 @@ def test_failed_git_remove_and_failed_purge_preserve_both_signals(
     assert result["removed"] is False
     assert result["path_purged"] is False
     assert result["residual_paths"] == ["leftover.txt"]
+
+
+def test_git_remove_timeout_sets_failure_flag_and_recovery_action(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import safe_worktree_cleanup as mod
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    worktree = tmp_path / "tracked-timeout"
+    worktree.mkdir()
+
+    inspection = mod.WorktreeInspection(
+        path=str(worktree),
+        exists=True,
+        tracked_worktree=True,
+        branch="codex/test",
+        active_session=False,
+        lock_files=[],
+        dirty=False,
+        unique_commits_ahead=0,
+        ahead_lookup_failed=False,
+        patch_equivalent_to_origin_main=False,
+        patch_equivalence_lookup_failed=False,
+        open_prs=[],
+        pr_lookup_failed=False,
+        blockers=[],
+    )
+
+    def timeout_run(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs.get("timeout"))
+
+    monkeypatch.setattr(mod.subprocess, "run", timeout_run)
+
+    result = mod.remove_worktree(
+        repo_root,
+        inspection,
+        delete_branch=False,
+        purge_path=True,
+        force=False,
+    )
+
+    assert result["status"] == "remove_failed"
+    assert result["git_remove_failed"] is True
+    assert result["git_worktree_removed"] is False
+    assert "timed out" in result["stderr"]
+    assert "rerun inspect" in result["recovery_action"]
 
 
 def test_purge_race_success_clears_stale_purge_error(

--- a/tests/scripts/test_safe_worktree_cleanup.py
+++ b/tests/scripts/test_safe_worktree_cleanup.py
@@ -381,6 +381,82 @@ def test_remove_purge_path_reports_incomplete_when_anchor_residue_survives(
     assert worktree.exists() is True
 
 
+def test_tracked_remove_purge_failure_reports_not_removed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import safe_worktree_cleanup as mod
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    worktree = tmp_path / "tracked-residue"
+    residual = worktree / "build" / "cache"
+    residual.mkdir(parents=True)
+    (residual / "leftover.txt").write_text("residue\n")
+
+    inspection = mod.WorktreeInspection(
+        path=str(worktree),
+        exists=True,
+        tracked_worktree=True,
+        branch="codex/test",
+        active_session=False,
+        lock_files=[],
+        dirty=False,
+        unique_commits_ahead=0,
+        ahead_lookup_failed=False,
+        patch_equivalent_to_origin_main=False,
+        patch_equivalence_lookup_failed=False,
+        open_prs=[],
+        pr_lookup_failed=False,
+        blockers=[],
+    )
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=args[0],
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+    monkeypatch.setattr(mod.shutil, "rmtree", lambda *_args, **_kwargs: None)
+
+    result = mod.remove_worktree(
+        repo_root,
+        inspection,
+        delete_branch=False,
+        purge_path=True,
+        force=False,
+    )
+
+    assert result["status"] == "purge_incomplete"
+    assert result["removed"] is False
+    assert result["path_purged"] is False
+    assert "build" in result["residual_paths"]
+    assert "not fully removed" in result["recovery_action"]
+
+
+def test_residual_paths_are_bounded_without_rglob(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import safe_worktree_cleanup as mod
+
+    residue = tmp_path / "large-residue"
+    residue.mkdir()
+    for index in range(60):
+        (residue / f"leftover-{index:02d}.txt").write_text("x")
+
+    def fail_rglob(*_args, **_kwargs):
+        raise AssertionError("residual lookup must not traverse with rglob")
+
+    monkeypatch.setattr(Path, "rglob", fail_rglob)
+
+    residuals = mod._residual_paths(residue, limit=50)
+
+    assert len(residuals) == 51
+    assert residuals[-1] == "..."
+
+
 def test_remove_deletes_branch_when_requested(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/scripts/test_safe_worktree_cleanup.py
+++ b/tests/scripts/test_safe_worktree_cleanup.py
@@ -251,6 +251,136 @@ def test_remove_purges_residual_path_after_failed_git_remove(
     assert worktree.exists() is False
 
 
+def test_remove_refuses_untracked_residue_without_purge_path_with_recovery(
+    tmp_path: Path,
+) -> None:
+    import safe_worktree_cleanup as mod
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    worktree = tmp_path / "anchor-residue"
+    worktree.mkdir()
+    (worktree / ".claude-session-anchor").write_text("session anchor\n")
+
+    inspection = mod.WorktreeInspection(
+        path=str(worktree),
+        exists=True,
+        tracked_worktree=False,
+        branch=None,
+        active_session=False,
+        lock_files=[],
+        dirty=False,
+        unique_commits_ahead=0,
+        ahead_lookup_failed=False,
+        patch_equivalent_to_origin_main=False,
+        patch_equivalence_lookup_failed=False,
+        open_prs=[],
+        pr_lookup_failed=False,
+        blockers=[],
+    )
+
+    result = mod.remove_worktree(
+        repo_root,
+        inspection,
+        delete_branch=False,
+        purge_path=False,
+        force=False,
+    )
+
+    assert result["status"] == "untracked_path"
+    assert result["removed"] is False
+    assert result["path_purged"] is False
+    assert result["requires_purge_path"] is True
+    assert "--purge-path" in result["recovery_action"]
+    assert worktree.exists() is True
+
+
+def test_remove_purge_path_deletes_anchor_only_untracked_residue(tmp_path: Path) -> None:
+    import safe_worktree_cleanup as mod
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    worktree = tmp_path / "anchor-residue"
+    worktree.mkdir()
+    (worktree / ".claude-session-anchor").write_text("session anchor\n")
+
+    inspection = mod.WorktreeInspection(
+        path=str(worktree),
+        exists=True,
+        tracked_worktree=False,
+        branch=None,
+        active_session=False,
+        lock_files=[],
+        dirty=False,
+        unique_commits_ahead=0,
+        ahead_lookup_failed=False,
+        patch_equivalent_to_origin_main=False,
+        patch_equivalence_lookup_failed=False,
+        open_prs=[],
+        pr_lookup_failed=False,
+        blockers=[],
+    )
+
+    result = mod.remove_worktree(
+        repo_root,
+        inspection,
+        delete_branch=False,
+        purge_path=True,
+        force=False,
+    )
+
+    assert result["status"] == "purged"
+    assert result["removed"] is True
+    assert result["path_purged"] is True
+    assert result["residual_paths"] == []
+    assert worktree.exists() is False
+
+
+def test_remove_purge_path_reports_incomplete_when_anchor_residue_survives(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import safe_worktree_cleanup as mod
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    worktree = tmp_path / "anchor-residue"
+    worktree.mkdir()
+    (worktree / ".claude-session-anchor").write_text("session anchor\n")
+
+    inspection = mod.WorktreeInspection(
+        path=str(worktree),
+        exists=True,
+        tracked_worktree=False,
+        branch=None,
+        active_session=False,
+        lock_files=[],
+        dirty=False,
+        unique_commits_ahead=0,
+        ahead_lookup_failed=False,
+        patch_equivalent_to_origin_main=False,
+        patch_equivalence_lookup_failed=False,
+        open_prs=[],
+        pr_lookup_failed=False,
+        blockers=[],
+    )
+    monkeypatch.setattr(mod.shutil, "rmtree", lambda *_args, **_kwargs: None)
+
+    result = mod.remove_worktree(
+        repo_root,
+        inspection,
+        delete_branch=False,
+        purge_path=True,
+        force=False,
+    )
+
+    assert result["status"] == "purge_incomplete"
+    assert result["removed"] is False
+    assert result["path_purged"] is False
+    assert result["residual_paths"] == [".claude-session-anchor"]
+    assert "not fully removed" in result["recovery_action"]
+    assert worktree.exists() is True
+
+
 def test_remove_deletes_branch_when_requested(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- make untracked residue removal without --purge-path return explicit recovery guidance
- make --purge-path report residual paths and purge_incomplete instead of generic partial when files remain
- cover anchor-only .claude-session-anchor residue success and incomplete-purge behavior

## Validation
- python3 -m pytest tests/scripts/test_safe_worktree_cleanup.py -q
- pre-commit run --files scripts/safe_worktree_cleanup.py tests/scripts/test_safe_worktree_cleanup.py

Draft only; do not merge in this cycle.