### PR TITLE
Use file-backed Claude MCP config for evidence reviews

### DIFF
--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -969,27 +969,43 @@ def default_reviewer_runner(family: str, prompt: str) -> ReviewerResult:
     return result
 
 
-def _claude_reviewer_command() -> list[str]:
+@contextmanager
+def _claude_empty_mcp_config_file() -> Iterator[Path]:
+    """Write Claude's empty MCP config to a real file for CLI compatibility."""
+
+    fd, path_text = tempfile.mkstemp(prefix="aragora-claude-mcp-", suffix=".json")
+    path = Path(path_text)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump({"mcpServers": {}}, handle)
+            handle.write("\n")
+        yield path
+    finally:
+        path.unlink(missing_ok=True)
+
+
+def _claude_reviewer_command(mcp_config_path: Path) -> list[str]:
     """Argv for the merge-gate claude reviewer with MCP servers disabled.
 
     The reviewer only reads a diff to emit a verdict, so it needs no MCP
     servers. Disabling them avoids claude's startup MCP handshake, which blocks
     until the full timeout when a local MCP server is wedged.
     """
-    return ["claude", "-p", "--strict-mcp-config", "--mcp-config", '{"mcpServers":{}}']
+    return ["claude", "-p", "--strict-mcp-config", "--mcp-config", str(mcp_config_path)]
 
 
 def _run_claude_cli(prompt: str) -> ReviewerResult:
     timeout = _timeout_seconds(_CLAUDE_TIMEOUT_ENV, _CLAUDE_TIMEOUT)
     try:
-        proc = subprocess.run(
-            _claude_reviewer_command(),
-            input=prompt,
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-            check=False,
-        )
+        with _claude_empty_mcp_config_file() as mcp_config_path:
+            proc = subprocess.run(
+                _claude_reviewer_command(mcp_config_path),
+                input=prompt,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                check=False,
+            )
     except FileNotFoundError:
         return ReviewerResult("claude", "", False, "claude CLI not found on PATH")
     except subprocess.TimeoutExpired:

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -318,9 +318,13 @@ def test_run_claude_cli_uses_env_timeout(monkeypatch: pytest.MonkeyPatch) -> Non
 
     result = qe._run_claude_cli("review prompt")
 
-    assert seen["args"] == (
-        ["claude", "-p", "--strict-mcp-config", "--mcp-config", '{"mcpServers":{}}'],
-    )
+    argv = seen["args"][0]
+    assert argv[:2] == ["claude", "-p"]
+    assert "--strict-mcp-config" in argv
+    assert "--mcp-config" in argv
+    mcp_config = Path(argv[argv.index("--mcp-config") + 1])
+    assert mcp_config.name.endswith(".json")
+    assert str(mcp_config) != '{"mcpServers":{}}'
     assert seen["timeout"] == 7.0
     assert result == ReviewerResult(
         "claude",
@@ -330,12 +334,34 @@ def test_run_claude_cli_uses_env_timeout(monkeypatch: pytest.MonkeyPatch) -> Non
     )
 
 
+def test_run_claude_cli_uses_file_backed_mcp_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, object] = {}
+
+    def fake_run(args, **_kwargs):
+        config_arg = args[args.index("--mcp-config") + 1]
+        config_path = Path(config_arg)
+        seen["config_arg"] = config_arg
+        seen["exists_during_run"] = config_path.exists()
+        seen["config_payload"] = json.loads(config_path.read_text(encoding="utf-8"))
+        return subprocess.CompletedProcess(args, 0, stdout="Verdict: PASS\n", stderr="")
+
+    monkeypatch.setattr(qe.subprocess, "run", fake_run)
+
+    result = qe._run_claude_cli("review prompt")
+
+    config_path = Path(str(seen["config_arg"]))
+    assert seen["exists_during_run"] is True
+    assert seen["config_payload"] == {"mcpServers": {}}
+    assert not config_path.exists()
+    assert result == ReviewerResult("claude", "Verdict: PASS", True)
+
+
 def test_claude_reviewer_command_disables_mcp() -> None:
-    cmd = qe._claude_reviewer_command()
+    cmd = qe._claude_reviewer_command(Path("/tmp/empty-mcp.json"))
 
     assert cmd[:2] == ["claude", "-p"]
     assert "--mcp-config" in cmd
-    assert cmd[cmd.index("--mcp-config") + 1] == '{"mcpServers":{}}'
+    assert cmd[cmd.index("--mcp-config") + 1] == "/tmp/empty-mcp.json"
     assert "--strict-mcp-config" in cmd
 
 


### PR DESCRIPTION
## Summary
- Write the empty Claude MCP config to a temporary JSON file before invoking the Claude evidence reviewer.
- Pass that file path to `claude --mcp-config` instead of inline JSON.
- Keep strict MCP disabling and clean up the temporary config after the reviewer process returns.

## Root cause
Claude Code `2.1.186` can hang on the inline JSON form used by the evidence helper:

```sh
claude -p --strict-mcp-config --mcp-config '{"mcpServers":{}}'
```

A file-backed config path avoids that inline-config parser/startup path while preserving the same empty MCP config intent.

## Validation
- `python3 -m pytest tests/swarm/test_quorum_evidence.py -q` (`161 passed`)
- `python3 scripts/report_code_quality.py --check`
- `git diff --check`

## Note
The local Claude CLI still showed intermittent timeout behavior during manual smoke probes, so this removes the confirmed inline JSON trigger but does not claim the local Claude runtime is globally healthy.
