### PR TITLE
fix(quorum): add REST fallback for evidence metadata

### DIFF
--- a/aragora/cli/commands/review_queue_rest_fallback.py
+++ b/aragora/cli/commands/review_queue_rest_fallback.py
@@ -220,6 +220,10 @@ def _hydrate_pr_with_rest_fallback(
     )
     reviews = _rest_list(f"repos/{repo_slug}/pulls/{number}/reviews?per_page=100", gh_json=gh_json)
     commits = _rest_list(f"repos/{repo_slug}/pulls/{number}/commits?per_page=100", gh_json=gh_json)
+    direct_check_runs = _fetch_direct_commit_check_runs(repo_slug, head_sha, gh_json=gh_json)
+    required_status_checks = _fetch_required_status_check_protection(
+        repo_slug, str(base.get("ref") or "").strip(), gh_json=gh_json
+    )
 
     return {
         "number": int(rest_pr.get("number") or number),
@@ -259,6 +263,8 @@ def _hydrate_pr_with_rest_fallback(
         "reviews": [_normalize_rest_review(review) for review in reviews],
         "commits": [_normalize_rest_commit(commit) for commit in commits],
         "commitStatuses": _fetch_direct_commit_statuses(repo_slug, head_sha, gh_json=gh_json),
+        "directCheckRuns": direct_check_runs,
+        "requiredStatusChecks": required_status_checks,
         "_rest_fallback": {
             "enabled": True,
             "repo": repo_slug,

--- a/aragora/swarm/merge_quorum_io.py
+++ b/aragora/swarm/merge_quorum_io.py
@@ -136,45 +136,137 @@ def list_open_prs(repo: str, *, limit: int, author: str | None) -> list[int]:
     return numbers
 
 
-def fetch_pr_context(repo: str, pr: int) -> dict[str, Any]:
-    """Head SHA, head committedDate, quorum conclusion, and real-failure flag."""
-    data = run_json(
-        [
-            "gh",
-            "pr",
-            "view",
-            str(pr),
-            "--repo",
-            repo,
-            "--json",
-            "headRefOid,commits,statusCheckRollup",
-        ],
-        env=_read_env(),
+def _gh_json_for_rest_fallback(args: list[str]) -> Any:
+    """Adapter for review-queue REST helpers that preserves read-token routing."""
+    from aragora.cli.commands.review_queue_transport import _GhError
+
+    try:
+        return run_json(["gh", *args], env=_read_env())
+    except RuntimeError as exc:
+        raise _GhError(str(exc)) from exc
+
+
+def _fetch_pr_context_with_rest_fallback(repo: str, pr: int, source_error: str) -> dict[str, Any]:
+    """Fallback to REST PR/check metadata after GraphQL-backed ``gh pr view`` fails."""
+    from aragora.cli.commands.review_queue_rest_fallback import _hydrate_pr_with_rest_fallback
+
+    return _hydrate_pr_with_rest_fallback(
+        number=pr,
+        repo_slug=repo,
+        source_error=source_error,
+        gh_json=_gh_json_for_rest_fallback,
     )
-    head_sha = str(data.get("headRefOid") or "").strip()
+
+
+def _head_committed_at(data: dict[str, Any], head_sha: str, repo: str) -> str:
     commits = data.get("commits") or []
-    head_committed_at = ""
     for entry in commits:
         if isinstance(entry, dict) and str(entry.get("oid") or "") == head_sha:
-            head_committed_at = str(entry.get("committedDate") or "")
-            break
-    if not head_committed_at and head_sha:
-        # The head may be beyond the returned commit slice; fetch its date
-        # directly rather than guessing from the last listed commit.
-        try:
-            commit = (
-                run_json(["gh", "api", f"repos/{repo}/commits/{head_sha}"], env=_read_env()) or {}
+            return str(entry.get("committedDate") or "")
+    if not head_sha:
+        return ""
+    # The head may be beyond the returned commit slice; fetch its date directly
+    # rather than guessing from the last listed commit.
+    try:
+        commit = run_json(["gh", "api", f"repos/{repo}/commits/{head_sha}"], env=_read_env()) or {}
+    except RuntimeError:
+        commit = {}
+    committer = (commit.get("commit") or {}).get("committer") or {}
+    return str(committer.get("date") or "")
+
+
+def _latest_by_name(items: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    latest: dict[str, tuple[str, int, dict[str, Any]]] = {}
+    for index, item in enumerate(items):
+        name = str(item.get("name") or item.get("context") or "").strip()
+        if not name:
+            continue
+        timestamp = str(
+            item.get("completed_at")
+            or item.get("started_at")
+            or item.get("updatedAt")
+            or item.get("updated_at")
+            or item.get("created_at")
+            or item.get("createdAt")
+            or ""
+        )
+        previous = latest.get(name)
+        if (
+            previous is None
+            or timestamp > previous[0]
+            or (timestamp == previous[0] and index < previous[1])
+        ):
+            latest[name] = (timestamp, index, item)
+    return {name: row[2] for name, row in latest.items()}
+
+
+def _direct_check_rollup(data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Build a conservative rollup from REST direct checks when PR rollup is absent."""
+    rollup = data.get("statusCheckRollup") or []
+    if rollup:
+        return [item for item in rollup if isinstance(item, dict)]
+
+    direct_runs = [item for item in data.get("directCheckRuns") or [] if isinstance(item, dict)]
+    commit_statuses = [item for item in data.get("commitStatuses") or [] if isinstance(item, dict)]
+    required_payload = data.get("requiredStatusChecks")
+    required_checks = []
+    if isinstance(required_payload, dict):
+        required_checks = [
+            item for item in required_payload.get("checks") or [] if isinstance(item, dict)
+        ]
+
+    direct_by_name = _latest_by_name(direct_runs)
+    status_by_name = _latest_by_name(commit_statuses)
+    synthetic: list[dict[str, Any]] = []
+
+    for required in required_checks:
+        context = str(required.get("context") or "").strip()
+        if not context:
+            continue
+        run = direct_by_name.get(context)
+        if run is not None:
+            synthetic.append(
+                {
+                    "name": context,
+                    "conclusion": str(run.get("conclusion") or "").upper(),
+                    "state": str(run.get("status") or "").upper(),
+                    "isRequired": True,
+                }
             )
-        except RuntimeError:
-            commit = {}
-        committer = (commit.get("commit") or {}).get("committer") or {}
-        head_committed_at = str(committer.get("date") or "")
+            continue
+        status = status_by_name.get(context)
+        if status is not None:
+            synthetic.append(
+                {
+                    "context": context,
+                    "state": str(status.get("state") or "").upper(),
+                    "isRequired": True,
+                }
+            )
+
+    if QUORUM_CHECK_NAME in direct_by_name and all(
+        str(item.get("name") or item.get("context") or "") != QUORUM_CHECK_NAME
+        for item in synthetic
+    ):
+        run = direct_by_name[QUORUM_CHECK_NAME]
+        synthetic.append(
+            {
+                "name": QUORUM_CHECK_NAME,
+                "conclusion": str(run.get("conclusion") or "").upper(),
+                "state": str(run.get("status") or "").upper(),
+                "isRequired": False,
+            }
+        )
+    return synthetic
+
+
+def _context_from_pr_payload(repo: str, data: dict[str, Any]) -> dict[str, Any]:
+    head_sha = str(data.get("headRefOid") or "").strip()
+    head_committed_at = _head_committed_at(data, head_sha, repo)
 
     real_failure = False
     quorum_conclusion = ""
-    for check in data.get("statusCheckRollup") or []:
-        if not isinstance(check, dict):
-            continue
+    for check in _direct_check_rollup(data):
         name = str(check.get("name") or check.get("context") or "")
         conclusion = str(check.get("conclusion") or check.get("state") or "").upper()
         if name == QUORUM_CHECK_NAME:
@@ -192,7 +284,44 @@ def fetch_pr_context(repo: str, pr: int) -> dict[str, Any]:
         "head_committed_at": head_committed_at,
         "quorum_conclusion": quorum_conclusion,
         "has_real_required_failure": real_failure,
+        "rest_fallback": data.get("_rest_fallback") or {},
     }
+
+
+def fetch_pr_context(repo: str, pr: int) -> dict[str, Any]:
+    """Head SHA, head committedDate, quorum conclusion, and real-failure flag."""
+    try:
+        data = run_json(
+            [
+                "gh",
+                "pr",
+                "view",
+                str(pr),
+                "--repo",
+                repo,
+                "--json",
+                "headRefOid,commits,statusCheckRollup",
+            ],
+            env=_read_env(),
+        )
+    except RuntimeError as exc:
+        data = _fetch_pr_context_with_rest_fallback(repo, pr, str(exc))
+    if not isinstance(data, dict):
+        data = {}
+    return _context_from_pr_payload(repo, data)
+
+
+def fetch_pr_head_sha(repo: str, pr: int) -> str:
+    """Resolve a PR head SHA, using REST fallback when ``gh pr view`` is blocked."""
+    try:
+        data = run_json(
+            ["gh", "pr", "view", str(pr), "--repo", repo, "--json", "headRefOid"],
+            env=_read_env(),
+        )
+        return str((data or {}).get("headRefOid") or "").strip()
+    except RuntimeError as exc:
+        data = _fetch_pr_context_with_rest_fallback(repo, pr, str(exc))
+    return str(data.get("headRefOid") or "").strip()
 
 
 def fetch_latest_quorum_run(repo: str, head_sha: str) -> QuorumRun | None:

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -1294,6 +1294,8 @@ def default_prompt_builder(repo: str, pr: int, ctx: dict[str, Any]) -> str:
     # rather than silently skipping the check and grounding on a stale head.
     live_head = (live.stdout or "").strip()
     if live.returncode != 0 or not live_head:
+        live_head = merge_quorum_io.fetch_pr_head_sha(repo, pr)
+    if not live_head:
         raise RuntimeError(f"could not re-resolve head for PR #{pr} to pin the diff")
     if head_sha and live_head and live_head != head_sha:
         raise RuntimeError(

--- a/tests/swarm/test_merge_quorum_io.py
+++ b/tests/swarm/test_merge_quorum_io.py
@@ -57,6 +57,101 @@ def test_fetch_pr_context_routes_reads_through_app_token(monkeypatch) -> None:
     assert captured_envs[0].get("ARAGORA_GITHUB_AUTH_SOURCE") == "github_app_installation"
 
 
+def test_fetch_pr_context_uses_rest_fallback_after_pr_view_transport(monkeypatch) -> None:
+    calls: list[list[str]] = []
+    head = "f" * 40
+
+    def fake_run(args, *, env=None, timeout=m._GH_TIMEOUT):
+        del env, timeout
+        calls.append(args)
+        if args[:4] == ["gh", "pr", "view", "8532"]:
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=1,
+                stdout="",
+                stderr="error connecting to api.github.com",
+            )
+        if args == ["gh", "api", "repos/o/r/pulls/8532"]:
+            return _proc(
+                json.dumps(
+                    {
+                        "number": 8532,
+                        "title": "deps",
+                        "html_url": "https://github.com/o/r/pull/8532",
+                        "head": {"sha": head, "ref": "dependabot/sdk"},
+                        "base": {"sha": "b" * 40, "ref": "main"},
+                        "state": "open",
+                        "draft": False,
+                        "mergeable": True,
+                        "mergeable_state": "blocked",
+                        "user": {"login": "dependabot[bot]"},
+                    }
+                )
+            )
+        if args == ["gh", "api", "repos/o/r/pulls/8532/files?per_page=100"]:
+            return _proc(json.dumps([{"filename": "sdk/typescript/package.json"}]))
+        if args == ["gh", "api", "repos/o/r/issues/8532/comments?per_page=100"]:
+            return _proc(json.dumps([]))
+        if args == ["gh", "api", "repos/o/r/pulls/8532/reviews?per_page=100"]:
+            return _proc(json.dumps([]))
+        if args == ["gh", "api", "repos/o/r/pulls/8532/commits?per_page=100"]:
+            return _proc(
+                json.dumps(
+                    [
+                        {
+                            "sha": head,
+                            "commit": {"author": {"date": "2026-06-23T01:02:03Z"}},
+                        }
+                    ]
+                )
+            )
+        if args == ["gh", "api", f"repos/o/r/commits/{head}/statuses?per_page=100"]:
+            return _proc(json.dumps([]))
+        if args == ["gh", "api", f"repos/o/r/commits/{head}/status"]:
+            return _proc(json.dumps({"statuses": []}))
+        if args == ["gh", "api", f"repos/o/r/commits/{head}/check-runs?per_page=100"]:
+            return _proc(
+                json.dumps(
+                    {
+                        "total_count": 2,
+                        "check_runs": [
+                            {
+                                "name": "lint",
+                                "status": "completed",
+                                "conclusion": "success",
+                                "completed_at": "2026-06-23T01:04:00Z",
+                            },
+                            {
+                                "name": "aragora-merge-quorum",
+                                "status": "completed",
+                                "conclusion": "failure",
+                                "completed_at": "2026-06-23T01:05:00Z",
+                            },
+                        ],
+                    }
+                )
+            )
+        if args == [
+            "gh",
+            "api",
+            "repos/o/r/branches/main/protection/required_status_checks",
+        ]:
+            return _proc(json.dumps({"strict": False, "checks": [{"context": "lint"}]}))
+        raise AssertionError(args)
+
+    monkeypatch.setattr(m, "run", fake_run)
+
+    ctx = m.fetch_pr_context("o/r", 8532)
+
+    assert ctx["head_sha"] == head
+    assert ctx["head_committed_at"] == "2026-06-23T01:02:03Z"
+    assert ctx["quorum_conclusion"] == "FAILURE"
+    assert ctx["has_real_required_failure"] is False
+    assert ctx["rest_fallback"]["enabled"] is True
+    assert any(call[:4] == ["gh", "pr", "view", "8532"] for call in calls)
+    assert any(call[:3] == ["gh", "api", "repos/o/r/pulls/8532"] for call in calls)
+
+
 def test_fetch_pr_tier_reads_nested_entries(monkeypatch) -> None:
     payload = {
         "version": "merge_authorization_packet.v1",

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -2264,6 +2264,35 @@ def test_default_prompt_builder_tolerates_name_status_fetch_failure(monkeypatch)
         assert path in header
 
 
+def test_default_prompt_builder_uses_head_pin_fallback_when_pr_view_fails(
+    monkeypatch,
+) -> None:
+    diff = (
+        "diff --git a/aragora/x.py b/aragora/x.py\n"
+        "--- a/aragora/x.py\n+++ b/aragora/x.py\n@@ -1 +1 @@\n-old\n+new\n"
+    )
+
+    def fake_run(args, *, env=None, timeout=None):
+        del env, timeout
+        if args[:3] == ["gh", "pr", "diff"]:
+            if "--name-status" in args:
+                return SimpleNamespace(returncode=0, stdout="M\taragora/x.py\n", stderr="")
+            return SimpleNamespace(returncode=0, stdout=diff, stderr="")
+        if args[:3] == ["gh", "pr", "view"]:
+            return SimpleNamespace(
+                returncode=1, stdout="", stderr="error connecting to api.github.com"
+            )
+        raise AssertionError(f"unexpected args: {args}")
+
+    monkeypatch.setattr(qe.merge_quorum_io, "run", fake_run)
+    monkeypatch.setattr(qe.merge_quorum_io, "fetch_pr_head_sha", lambda repo, pr: HEAD)
+
+    prompt = qe.default_prompt_builder("o/r", 8532, {"head_sha": HEAD})
+
+    assert "aragora/x.py" in prompt
+    assert HEAD[:7] in prompt
+
+
 def test_default_prompt_builder_empty_diff_still_raises(monkeypatch) -> None:
     # Builder exit/return semantics unchanged: an empty diff is still a hard error.
     monkeypatch.setattr(qe.merge_quorum_io, "run", _prompt_builder_run_stub("   \n", "D\tx\n"))


### PR DESCRIPTION
## Summary
- add REST fallback hydration for collect-evidence PR metadata when GraphQL-backed gh pr view transport fails
- reuse review-queue REST fallback surfaces for PR head, commit date, direct checks, and required contexts
- keep the diff scoped to quorum evidence metadata and focused tests

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/swarm/test_merge_quorum_io.py tests/swarm/test_quorum_evidence.py -q -p no:cacheprovider
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check aragora/swarm/merge_quorum_io.py aragora/swarm/quorum_evidence.py aragora/cli/commands/review_queue_rest_fallback.py tests/swarm/test_merge_quorum_io.py tests/swarm/test_quorum_evidence.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check aragora/swarm/merge_quorum_io.py aragora/swarm/quorum_evidence.py aragora/cli/commands/review_queue_rest_fallback.py tests/swarm/test_merge_quorum_io.py tests/swarm/test_quorum_evidence.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD

Outbox handoff: open-pr-codex-collect-evidence-rest-fallback-20260623-d9d49c24
Published from exact head 69220c1bc460839c58e50f853fcaddaf352bec5a.