### PR TITLE
fix(review-queue): fail closed on collect-evidence timeouts

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -729,6 +729,18 @@ def add_review_queue_parser(subparsers: argparse._SubParsersAction) -> None:
     collect_evidence_arg(
         "--apply", action="store_true", help="Post Tier 0-2 evidence; Tier 3-4 prepare only."
     )
+    collect_evidence_arg(
+        "--reviewer-timeout",
+        type=float,
+        default=None,
+        help="Per-reviewer timeout in seconds for this invocation.",
+    )
+    collect_evidence_arg(
+        "--overall-timeout",
+        type=float,
+        default=None,
+        help="Overall reviewer orchestration timeout in seconds; fail-closed on expiry.",
+    )
     collect_evidence_arg("--json", dest="json_output", action="store_true", help="Output as JSON")
 
     lint_comment_p = sub.add_parser(
@@ -1364,6 +1376,8 @@ def _cmd_collect_evidence(args: argparse.Namespace) -> int:
         author=getattr(args, "author", None),
         apply=bool(getattr(args, "apply", False)),
         json_output=json_output,
+        reviewer_timeout=getattr(args, "reviewer_timeout", None),
+        overall_timeout=getattr(args, "overall_timeout", None),
     )
 
 

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -739,7 +739,10 @@ def add_review_queue_parser(subparsers: argparse._SubParsersAction) -> None:
         "--overall-timeout",
         type=float,
         default=None,
-        help="Overall reviewer orchestration timeout in seconds; fail-closed on expiry.",
+        help=(
+            "Overall reviewer orchestration timeout in seconds; fail-closed on expiry. "
+            "When omitted, use a bounded default derived from reviewer timeout and retry budget."
+        ),
     )
     collect_evidence_arg("--json", dest="json_output", action="store_true", help="Output as JSON")
 

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -2354,6 +2354,18 @@ def _add_review_queue_parser(subparsers) -> None:
         help="Post evidence for Tier 0-2 PRs (Tier 3-4 always prepare-only).",
     )
     collect_evidence_parser.add_argument(
+        "--reviewer-timeout",
+        type=float,
+        default=None,
+        help="Per-reviewer timeout in seconds for this invocation.",
+    )
+    collect_evidence_parser.add_argument(
+        "--overall-timeout",
+        type=float,
+        default=None,
+        help="Overall reviewer orchestration timeout in seconds; fail-closed on expiry.",
+    )
+    collect_evidence_parser.add_argument(
         "--json", dest="json_output", action="store_true", help="Output as JSON"
     )
     collect_evidence_parser.set_defaults(

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -2363,7 +2363,10 @@ def _add_review_queue_parser(subparsers) -> None:
         "--overall-timeout",
         type=float,
         default=None,
-        help="Overall reviewer orchestration timeout in seconds; fail-closed on expiry.",
+        help=(
+            "Overall reviewer orchestration timeout in seconds; fail-closed on expiry. "
+            "When omitted, use a bounded default derived from reviewer timeout and retry budget."
+        ),
     )
     collect_evidence_parser.add_argument(
         "--json", dest="json_output", action="store_true", help="Output as JSON"

--- a/aragora/swarm/merge_quorum_io.py
+++ b/aragora/swarm/merge_quorum_io.py
@@ -35,6 +35,29 @@ _EVIDENCE_LINT_TIMEOUT = 90
 _GH_TIMEOUT = 60
 _GITHUB_ACTIONS_AUTHOR = "github-actions[bot]"
 _MIN_EVIDENCE_BODY = 40
+_GITHUB_TRANSPORT_ERROR_MARKERS = (
+    "api rate limit already exceeded",
+    "check your internet connection",
+    "client.timeout exceeded",
+    "connection refused",
+    "connection reset",
+    "connection timed out",
+    "context deadline exceeded",
+    "could not resolve host",
+    "error connecting",
+    "failed to start",
+    "http 502",
+    "http 503",
+    "http 504",
+    "i/o timeout",
+    "net/http",
+    "no such host",
+    "operation timed out",
+    "rate limit exceeded",
+    "temporary failure in name resolution",
+    "timeout awaiting response headers",
+    "tls handshake timeout",
+)
 
 
 def _could_count(author: str, body: str) -> bool:
@@ -104,6 +127,24 @@ def run_json(
     return json.loads(proc.stdout or "null")
 
 
+def _is_github_transport_error(error: object) -> bool:
+    text = str(error or "").lower()
+    return any(marker in text for marker in _GITHUB_TRANSPORT_ERROR_MARKERS)
+
+
+def _read_json_with_operator_fallback(args: list[str], *, timeout: int = _GH_TIMEOUT) -> Any:
+    """Read through the App token first; fall back to operator auth on transport only."""
+    read_env = _read_env()
+    try:
+        return run_json(args, env=read_env, timeout=timeout)
+    except RuntimeError as exc:
+        if read_env.get(
+            "ARAGORA_GITHUB_AUTH_SOURCE"
+        ) != "github_app_installation" or not _is_github_transport_error(exc):
+            raise
+        return run_json(args, env=aragora_env(), timeout=timeout)
+
+
 def list_open_prs(repo: str, *, limit: int, author: str | None) -> list[int]:
     rows = (
         run_json(
@@ -138,7 +179,7 @@ def list_open_prs(repo: str, *, limit: int, author: str | None) -> list[int]:
 
 def fetch_pr_context(repo: str, pr: int) -> dict[str, Any]:
     """Head SHA, head committedDate, quorum conclusion, and real-failure flag."""
-    data = run_json(
+    data = _read_json_with_operator_fallback(
         [
             "gh",
             "pr",
@@ -149,7 +190,6 @@ def fetch_pr_context(repo: str, pr: int) -> dict[str, Any]:
             "--json",
             "headRefOid,commits,statusCheckRollup",
         ],
-        env=_read_env(),
     )
     head_sha = str(data.get("headRefOid") or "").strip()
     commits = data.get("commits") or []

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -1696,10 +1696,16 @@ def collect_evidence(
     poster: Callable[[str, int, str], None] = default_poster,
     quorum_reconciler: Callable[[str, int], dict[str, Any] | None] | None = None,
     env: dict[str, str] | None = None,
+    reviewer_timeout: float | None = None,
     overall_timeout: float | None = None,
 ) -> CollectOutcome:
     """Run reviewers, validate evidence, and post only when tier-gating allows."""
     overall_timeout = _validate_positive_timeout(overall_timeout, "overall_timeout")
+    reviewer_timeout = _validate_positive_timeout(reviewer_timeout, "reviewer_timeout")
+    if overall_timeout is not None and (
+        reviewer_timeout is None or reviewer_timeout > overall_timeout
+    ):
+        reviewer_timeout = overall_timeout
     ctx = context_fetcher(repo, pr)
     head_sha = str(ctx.get("head_sha") or "").strip()
     head_committed_at = str(ctx.get("head_committed_at") or "")
@@ -1742,48 +1748,45 @@ def collect_evidence(
     reviews: dict[str, ReviewerResult] = {}
     if supported:
         max_workers = min(len(supported), _MAX_REVIEWER_WORKERS)
-        pool = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
-        future_to_family = {
-            pool.submit(_run_reviewer_with_infra_retry, reviewer_runner, family, prompt): family
-            for family in supported
-        }
-        try:
-            done, pending = concurrent.futures.wait(
-                future_to_family,
-                timeout=overall_timeout,
-                return_when=concurrent.futures.ALL_COMPLETED,
-            )
-            for future in done:
-                family = future_to_family[future]
-                try:
-                    reviews[family] = future.result()
-                except Exception as exc:  # noqa: BLE001 - one bad reviewer must not abort the run
-                    reviews[family] = ReviewerResult(
-                        family, "", False, f"{type(exc).__name__}: {str(exc)[:200]}"
-                    )
-            if pending:
-                outcome.orchestration_timed_out = True
-                timed_out = [
-                    family
-                    for family in ordered_families
-                    if any(future_to_family[future] == family for future in pending)
-                ]
-                outcome.timed_out_families = timed_out
-                timeout_text = _format_seconds(overall_timeout or 0)
-                for future in pending:
-                    future.cancel()
+        with _scoped_reviewer_timeout_env(reviewer_timeout):
+            with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
+                future_to_family = {
+                    pool.submit(
+                        _run_reviewer_with_infra_retry, reviewer_runner, family, prompt
+                    ): family
+                    for family in supported
+                }
+                done, pending = concurrent.futures.wait(
+                    future_to_family,
+                    timeout=overall_timeout,
+                    return_when=concurrent.futures.ALL_COMPLETED,
+                )
+                for future in done:
                     family = future_to_family[future]
-                    reviews[family] = ReviewerResult(
-                        family,
-                        "",
-                        False,
-                        f"overall collect-evidence timeout after {timeout_text}s",
-                    )
-        finally:
-            # Do not wait here: each built-in reviewer has its own timeout/process
-            # boundary, and this outer deadline exists specifically so orchestration
-            # can return fail-closed JSON instead of hanging in future collection.
-            pool.shutdown(wait=False, cancel_futures=True)
+                    try:
+                        reviews[family] = future.result()
+                    except Exception as exc:  # noqa: BLE001 - one bad reviewer must not abort the run
+                        reviews[family] = ReviewerResult(
+                            family, "", False, f"{type(exc).__name__}: {str(exc)[:200]}"
+                        )
+                if pending:
+                    outcome.orchestration_timed_out = True
+                    timed_out = [
+                        family
+                        for family in ordered_families
+                        if any(future_to_family[future] == family for future in pending)
+                    ]
+                    outcome.timed_out_families = timed_out
+                    timeout_text = _format_seconds(overall_timeout or 0)
+                    for future in pending:
+                        future.cancel()
+                        family = future_to_family[future]
+                        reviews[family] = ReviewerResult(
+                            family,
+                            "",
+                            False,
+                            f"overall collect-evidence timeout after {timeout_text}s",
+                        )
 
     for family in ordered_families:
         if family not in FAMILY_PROVIDERS:
@@ -2032,6 +2035,8 @@ def apply_prepared_evidence(
         action_reason=action_reason,
         items=_clone_prepared_items(prepared.items),
         failures=_clone_reviewer_failures(prepared.failures),
+        orchestration_timed_out=prepared.orchestration_timed_out,
+        timed_out_families=list(prepared.timed_out_families),
         tiered_gate=effective_tiered_gate,
     )
 
@@ -2040,6 +2045,13 @@ def apply_prepared_evidence(
         outcome.action_reason = (
             f"prepared head {prepared.head_sha[:7]} does not match current head "
             f"{head_sha[:7]}; prepared evidence only"
+        )
+        return outcome
+
+    if outcome.orchestration_timed_out:
+        outcome.action = "prepare"
+        outcome.action_reason = (
+            "prepared collect-evidence artifact timed out; refusing to post partial evidence"
         )
         return outcome
 
@@ -2199,6 +2211,7 @@ def run_collect_cli(
                     apply=apply,
                     env=merge_quorum_io.aragora_env(),
                     quorum_reconciler=default_quorum_reconciler if apply else None,
+                    reviewer_timeout=validated_reviewer_timeout,
                     overall_timeout=validated_overall_timeout,
                 )
             else:
@@ -2223,4 +2236,4 @@ def run_collect_cli(
         printer(json.dumps(outcome.to_dict(), indent=2))
     else:
         printer(_render_outcome(outcome))
-    return 0 if outcome.has_supportive_quorum else 1
+    return 0 if outcome.has_supportive_quorum and not outcome.orchestration_timed_out else 1

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -37,6 +37,7 @@ import os
 import queue
 import re
 import secrets
+import signal
 import subprocess
 import tempfile
 import time
@@ -329,10 +330,45 @@ def _reviewer_process_entry(
     prompt: str,
 ) -> None:
     try:
-        result = _run_reviewer_with_infra_retry(runner, family, prompt, retries=0)
+        if hasattr(os, "setsid"):
+            os.setsid()
+        result = _run_reviewer_with_infra_retry(runner, family, prompt)
     except Exception as exc:  # noqa: BLE001 - child failures become reviewer failures.
         result = ReviewerResult(family, "", False, f"{type(exc).__name__}: {str(exc)[:200]}")
     result_queue.put(result)
+
+
+def _terminate_reviewer_process(process: Any) -> None:
+    """Terminate a reviewer process, preferring its process group when isolated."""
+    if not process.is_alive():
+        process.join(timeout=0)
+        return
+    pgid: int | None = None
+    if hasattr(os, "getpgid") and hasattr(os, "killpg"):
+        try:
+            candidate = os.getpgid(process.pid)
+        except OSError:
+            candidate = None
+        if candidate == process.pid:
+            pgid = candidate
+    if pgid is not None:
+        try:
+            os.killpg(pgid, signal.SIGTERM)
+        except OSError:
+            pass
+    else:
+        process.terminate()
+    process.join(timeout=_REVIEWER_CLEANUP_TIMEOUT)
+    if not process.is_alive():
+        return
+    if pgid is not None:
+        try:
+            os.killpg(pgid, signal.SIGKILL)
+        except OSError:
+            pass
+    else:
+        process.kill()
+    process.join(timeout=_REVIEWER_CLEANUP_TIMEOUT)
 
 
 def _run_reviewers_with_process_timeout(
@@ -344,34 +380,52 @@ def _run_reviewers_with_process_timeout(
 ) -> tuple[dict[str, ReviewerResult], list[str]]:
     """Run reviewers in killable child processes for hard overall deadlines."""
     start_methods = multiprocessing.get_all_start_methods()
-    ctx = multiprocessing.get_context("fork" if "fork" in start_methods else None)
+    if "fork" not in start_methods:
+        message = (
+            "overall-timeout process isolation requires a fork-capable runtime; "
+            "no reviewers were run"
+        )
+        return (
+            {family: ReviewerResult(family, "", False, message) for family in families},
+            list(families),
+        )
+    ctx = multiprocessing.get_context("fork")
     result_queue = ctx.Queue()
     processes: dict[str, Any] = {}
-    for family in families:
-        process = ctx.Process(
-            target=_reviewer_process_entry,
-            args=(result_queue, reviewer_runner, family, prompt),
-            daemon=True,
-        )
-        process.start()
-        processes[family] = process
-
-    deadline = time.monotonic() + overall_timeout
-    pending = set(families)
+    queued = list(families)
+    max_workers = min(len(queued), _MAX_REVIEWER_WORKERS)
     reviews: dict[str, ReviewerResult] = {}
-    while pending:
-        remaining = deadline - time.monotonic()
-        if remaining <= 0:
-            break
-        try:
-            result = result_queue.get(timeout=min(remaining, 0.1))
-        except queue.Empty:
-            result = None
-        if result is not None:
-            reviews[result.family] = result
-            pending.discard(result.family)
-        for family in list(pending):
-            process = processes[family]
+
+    def launch_ready() -> None:
+        while queued and len(processes) < max_workers:
+            family = queued.pop(0)
+            process = ctx.Process(
+                target=_reviewer_process_entry,
+                args=(result_queue, reviewer_runner, family, prompt),
+                daemon=True,
+            )
+            process.start()
+            processes[family] = process
+
+    def record_result(result: ReviewerResult) -> None:
+        reviews[result.family] = result
+        process = processes.pop(result.family, None)
+        if process is not None:
+            process.join(timeout=0)
+
+    def drain_results() -> None:
+        while True:
+            try:
+                result = result_queue.get_nowait()
+            except queue.Empty:
+                break
+            record_result(result)
+
+    launch_ready()
+    deadline = time.monotonic() + overall_timeout
+    while processes or queued:
+        drain_results()
+        for family, process in list(processes.items()):
             if process.exitcode is not None:
                 process.join(timeout=0)
                 reviews.setdefault(
@@ -383,23 +437,53 @@ def _run_reviewers_with_process_timeout(
                         f"reviewer process exited with code {process.exitcode} without result",
                     ),
                 )
-                pending.discard(family)
+                processes.pop(family, None)
+        launch_ready()
+        if not processes and not queued:
+            break
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        try:
+            result = result_queue.get(timeout=min(remaining, 0.1))
+        except queue.Empty:
+            continue
+        record_result(result)
 
-    timed_out = [family for family in families if family in pending]
+    # A result may have been enqueued just before the deadline. Drain once more
+    # before classifying anything as timed out so finished reviewers are not
+    # reported as missing.
+    drain_results()
+    for family, process in list(processes.items()):
+        if process.exitcode is not None:
+            process.join(timeout=0)
+            reviews.setdefault(
+                family,
+                ReviewerResult(
+                    family,
+                    "",
+                    False,
+                    f"reviewer process exited with code {process.exitcode} without result",
+                ),
+            )
+            processes.pop(family, None)
+
+    timed_out = list(processes) + queued
     timeout_text = _format_seconds(overall_timeout)
-    for family in timed_out:
-        process = processes[family]
-        if process.is_alive():
-            process.terminate()
-            process.join(timeout=_REVIEWER_CLEANUP_TIMEOUT)
-        if process.is_alive():
-            process.kill()
-            process.join(timeout=_REVIEWER_CLEANUP_TIMEOUT)
+    for family, process in list(processes.items()):
+        _terminate_reviewer_process(process)
         reviews[family] = ReviewerResult(
             family,
             "",
             False,
             f"overall collect-evidence timeout after {timeout_text}s",
+        )
+    for family in queued:
+        reviews[family] = ReviewerResult(
+            family,
+            "",
+            False,
+            f"overall collect-evidence timeout before reviewer started after {timeout_text}s",
         )
 
     for process in processes.values():

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -322,6 +322,93 @@ def _run_reviewer_with_infra_retry(
     return result
 
 
+def _reviewer_process_entry(
+    result_queue: Any,
+    runner: Callable[[str, str], ReviewerResult],
+    family: str,
+    prompt: str,
+) -> None:
+    try:
+        result = _run_reviewer_with_infra_retry(runner, family, prompt, retries=0)
+    except Exception as exc:  # noqa: BLE001 - child failures become reviewer failures.
+        result = ReviewerResult(family, "", False, f"{type(exc).__name__}: {str(exc)[:200]}")
+    result_queue.put(result)
+
+
+def _run_reviewers_with_process_timeout(
+    *,
+    families: Sequence[str],
+    prompt: str,
+    reviewer_runner: Callable[[str, str], ReviewerResult],
+    overall_timeout: float,
+) -> tuple[dict[str, ReviewerResult], list[str]]:
+    """Run reviewers in killable child processes for hard overall deadlines."""
+    start_methods = multiprocessing.get_all_start_methods()
+    ctx = multiprocessing.get_context("fork" if "fork" in start_methods else None)
+    result_queue = ctx.Queue()
+    processes: dict[str, multiprocessing.Process] = {}
+    for family in families:
+        process = ctx.Process(
+            target=_reviewer_process_entry,
+            args=(result_queue, reviewer_runner, family, prompt),
+            daemon=True,
+        )
+        process.start()
+        processes[family] = process
+
+    deadline = time.monotonic() + overall_timeout
+    pending = set(families)
+    reviews: dict[str, ReviewerResult] = {}
+    while pending:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        try:
+            result = result_queue.get(timeout=min(remaining, 0.1))
+        except queue.Empty:
+            result = None
+        if result is not None:
+            reviews[result.family] = result
+            pending.discard(result.family)
+        for family in list(pending):
+            process = processes[family]
+            if process.exitcode is not None:
+                process.join(timeout=0)
+                reviews.setdefault(
+                    family,
+                    ReviewerResult(
+                        family,
+                        "",
+                        False,
+                        f"reviewer process exited with code {process.exitcode} without result",
+                    ),
+                )
+                pending.discard(family)
+
+    timed_out = [family for family in families if family in pending]
+    timeout_text = _format_seconds(overall_timeout)
+    for family in timed_out:
+        process = processes[family]
+        if process.is_alive():
+            process.terminate()
+            process.join(timeout=_REVIEWER_CLEANUP_TIMEOUT)
+        if process.is_alive():
+            process.kill()
+            process.join(timeout=_REVIEWER_CLEANUP_TIMEOUT)
+        reviews[family] = ReviewerResult(
+            family,
+            "",
+            False,
+            f"overall collect-evidence timeout after {timeout_text}s",
+        )
+
+    for process in processes.values():
+        process.join(timeout=0)
+    result_queue.close()
+    result_queue.join_thread()
+    return reviews, timed_out
+
+
 def _cap_text(text: str) -> str:
     text = text.strip()
     if len(text) > _MAX_REVIEWER_CHARS:
@@ -432,6 +519,8 @@ class CollectOutcome:
         otherwise needs two distinct families incl. ≥1 Western; Tier 3-4 (and any
         unknown/None tier, fail-safe) need two distinct WESTERN families.
         """
+        if self.orchestration_timed_out:
+            return False
         rule = tier_quorum_rule(self.tier, tiered_gate=self.tiered_gate)
         return rule.is_satisfied_by(self.supportive_families)
 
@@ -443,6 +532,12 @@ class CollectOutcome:
         (western-frontier / Western-only / at-least-one-Western / signal count)
         rather than a misleading ``(n/2)`` distinct-family denominator.
         """
+        if self.orchestration_timed_out:
+            timed_out = ", ".join(self.timed_out_families) or "unknown"
+            return (
+                f"collect-evidence timed out before all reviewers completed "
+                f"({timed_out}); prepared evidence only"
+            )
         rule = tier_quorum_rule(self.tier, tiered_gate=self.tiered_gate)
         supportive = {str(f).strip().lower() for f in self.supportive_families}
         counted = rule.counted_families(supportive)
@@ -1747,46 +1842,36 @@ def collect_evidence(
     supported = [family for family in ordered_families if family in FAMILY_PROVIDERS]
     reviews: dict[str, ReviewerResult] = {}
     if supported:
-        max_workers = min(len(supported), _MAX_REVIEWER_WORKERS)
         with _scoped_reviewer_timeout_env(reviewer_timeout):
-            with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
-                future_to_family = {
-                    pool.submit(
-                        _run_reviewer_with_infra_retry, reviewer_runner, family, prompt
-                    ): family
-                    for family in supported
-                }
-                done, pending = concurrent.futures.wait(
-                    future_to_family,
-                    timeout=overall_timeout,
-                    return_when=concurrent.futures.ALL_COMPLETED,
+            if overall_timeout is not None:
+                reviews, timed_out = _run_reviewers_with_process_timeout(
+                    families=supported,
+                    prompt=prompt,
+                    reviewer_runner=reviewer_runner,
+                    overall_timeout=overall_timeout,
                 )
-                for future in done:
-                    family = future_to_family[future]
-                    try:
-                        reviews[family] = future.result()
-                    except Exception as exc:  # noqa: BLE001 - one bad reviewer must not abort the run
-                        reviews[family] = ReviewerResult(
-                            family, "", False, f"{type(exc).__name__}: {str(exc)[:200]}"
-                        )
-                if pending:
+                if timed_out:
                     outcome.orchestration_timed_out = True
-                    timed_out = [
-                        family
-                        for family in ordered_families
-                        if any(future_to_family[future] == family for future in pending)
+                    outcome.timed_out_families = [
+                        family for family in ordered_families if family in set(timed_out)
                     ]
-                    outcome.timed_out_families = timed_out
-                    timeout_text = _format_seconds(overall_timeout or 0)
-                    for future in pending:
-                        future.cancel()
+            else:
+                max_workers = min(len(supported), _MAX_REVIEWER_WORKERS)
+                with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
+                    future_to_family = {
+                        pool.submit(
+                            _run_reviewer_with_infra_retry, reviewer_runner, family, prompt
+                        ): family
+                        for family in supported
+                    }
+                    for future in concurrent.futures.as_completed(future_to_family):
                         family = future_to_family[future]
-                        reviews[family] = ReviewerResult(
-                            family,
-                            "",
-                            False,
-                            f"overall collect-evidence timeout after {timeout_text}s",
-                        )
+                        try:
+                            reviews[family] = future.result()
+                        except Exception as exc:  # noqa: BLE001 - one bad reviewer must not abort the run
+                            reviews[family] = ReviewerResult(
+                                family, "", False, f"{type(exc).__name__}: {str(exc)[:200]}"
+                            )
 
     for family in ordered_families:
         if family not in FAMILY_PROVIDERS:
@@ -2148,6 +2233,9 @@ def _render_outcome(outcome: CollectOutcome) -> str:
         lines.append(f"  posted: {', '.join(outcome.posted)}")
     if outcome.post_errors:
         lines.append(f"  post errors: {'; '.join(outcome.post_errors)}")
+    if outcome.orchestration_timed_out:
+        timed_out = ", ".join(outcome.timed_out_families) or "unknown"
+        lines.append(f"  orchestration timeout: {timed_out}")
     if outcome.quorum_rerun:
         rerun = outcome.quorum_rerun
         action = "applied" if rerun.get("applied") else "not applied"
@@ -2183,11 +2271,12 @@ def run_collect_cli(
 ) -> int:
     """Shared entry point for the script and ``review-queue collect-evidence``.
 
-    Returns 0 when >=2 reviewers produced counting evidence, else 1. Note that a
-    non-zero exit does not imply nothing was posted: with ``--apply`` on a
-    low-tier PR a single genuine reviewer can post one counting comment and still
-    return 1 (quorum is enforced as N-of-M elsewhere). Inspect ``posted_families``
-    in the JSON output rather than treating exit-code 1 as "nothing posted".
+    Returns 0 when the completed reviewers satisfy quorum and no orchestration
+    timeout occurred, else 1. Note that a non-zero exit does not imply nothing was
+    posted: with ``--apply`` on a low-tier PR a single genuine reviewer can post one
+    counting comment and still return 1 (quorum is enforced as N-of-M elsewhere).
+    Inspect ``posted_families`` and ``orchestration_timed_out`` in JSON output rather
+    than treating exit-code 1 as "nothing posted".
     """
     fams = tuple(families) if families else DEFAULT_FAMILIES
     resolved_author = author or resolve_author()

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -342,6 +342,18 @@ def _timeout_seconds(env_name: str, default: int) -> float:
     return value
 
 
+def _validate_positive_timeout(value: float | None, name: str) -> float | None:
+    if value is None:
+        return None
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a positive number of seconds") from exc
+    if not math.isfinite(seconds) or seconds <= 0:
+        raise ValueError(f"{name} must be a positive number of seconds")
+    return seconds
+
+
 def _format_seconds(seconds: float) -> str:
     return f"{seconds:g}"
 
@@ -391,6 +403,8 @@ class CollectOutcome:
     posted: list[str] = field(default_factory=list)
     post_errors: list[str] = field(default_factory=list)
     quorum_rerun: dict[str, Any] | None = None
+    orchestration_timed_out: bool = False
+    timed_out_families: list[str] = field(default_factory=list)
     # Captured ONCE at construction (not re-read from os.environ per property
     # access) so a security-relevant gate decision stays deterministic within a
     # single settlement flow even if the process env mutates mid-run.
@@ -473,6 +487,8 @@ class CollectOutcome:
             "posted_families": list(self.posted),
             "post_errors": list(self.post_errors),
             "quorum_rerun": self.quorum_rerun,
+            "orchestration_timed_out": self.orchestration_timed_out,
+            "timed_out_families": list(self.timed_out_families),
             "items": [
                 {
                     "family": item.family,
@@ -576,6 +592,8 @@ def collect_outcome_from_dict(data: dict[str, Any]) -> CollectOutcome:
         quorum_rerun=data.get("quorum_rerun")
         if isinstance(data.get("quorum_rerun"), dict)
         else None,
+        orchestration_timed_out=bool(data.get("orchestration_timed_out", False)),
+        timed_out_families=_string_list(data.get("timed_out_families")),
         **gate_kwargs,
     )
 
@@ -1678,8 +1696,10 @@ def collect_evidence(
     poster: Callable[[str, int, str], None] = default_poster,
     quorum_reconciler: Callable[[str, int], dict[str, Any] | None] | None = None,
     env: dict[str, str] | None = None,
+    overall_timeout: float | None = None,
 ) -> CollectOutcome:
     """Run reviewers, validate evidence, and post only when tier-gating allows."""
+    overall_timeout = _validate_positive_timeout(overall_timeout, "overall_timeout")
     ctx = context_fetcher(repo, pr)
     head_sha = str(ctx.get("head_sha") or "").strip()
     head_committed_at = str(ctx.get("head_committed_at") or "")
@@ -1722,12 +1742,18 @@ def collect_evidence(
     reviews: dict[str, ReviewerResult] = {}
     if supported:
         max_workers = min(len(supported), _MAX_REVIEWER_WORKERS)
-        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
-            future_to_family = {
-                pool.submit(_run_reviewer_with_infra_retry, reviewer_runner, family, prompt): family
-                for family in supported
-            }
-            for future in concurrent.futures.as_completed(future_to_family):
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
+        future_to_family = {
+            pool.submit(_run_reviewer_with_infra_retry, reviewer_runner, family, prompt): family
+            for family in supported
+        }
+        try:
+            done, pending = concurrent.futures.wait(
+                future_to_family,
+                timeout=overall_timeout,
+                return_when=concurrent.futures.ALL_COMPLETED,
+            )
+            for future in done:
                 family = future_to_family[future]
                 try:
                     reviews[family] = future.result()
@@ -1735,6 +1761,29 @@ def collect_evidence(
                     reviews[family] = ReviewerResult(
                         family, "", False, f"{type(exc).__name__}: {str(exc)[:200]}"
                     )
+            if pending:
+                outcome.orchestration_timed_out = True
+                timed_out = [
+                    family
+                    for family in ordered_families
+                    if any(future_to_family[future] == family for future in pending)
+                ]
+                outcome.timed_out_families = timed_out
+                timeout_text = _format_seconds(overall_timeout or 0)
+                for future in pending:
+                    future.cancel()
+                    family = future_to_family[future]
+                    reviews[family] = ReviewerResult(
+                        family,
+                        "",
+                        False,
+                        f"overall collect-evidence timeout after {timeout_text}s",
+                    )
+        finally:
+            # Do not wait here: each built-in reviewer has its own timeout/process
+            # boundary, and this outer deadline exists specifically so orchestration
+            # can return fail-closed JSON instead of hanging in future collection.
+            pool.shutdown(wait=False, cancel_futures=True)
 
     for family in ordered_families:
         if family not in FAMILY_PROVIDERS:
@@ -1768,6 +1817,14 @@ def collect_evidence(
                 problems=list(lint.get("problems") or []),
             )
         )
+
+    if outcome.orchestration_timed_out:
+        outcome.action = "prepare"
+        outcome.action_reason = (
+            "overall collect-evidence timeout "
+            f"after {_format_seconds(overall_timeout or 0)}s; prepared evidence only"
+        )
+        return outcome
 
     if action == "post":
         if outcome.dissenting_families:
@@ -1846,6 +1903,27 @@ def _clone_reviewer_failures(failures: Sequence[ReviewerResult]) -> list[Reviewe
         )
         for failure in failures
     ]
+
+
+@contextmanager
+def _scoped_reviewer_timeout_env(reviewer_timeout: float | None) -> Iterator[None]:
+    seconds = _validate_positive_timeout(reviewer_timeout, "reviewer_timeout")
+    if seconds is None:
+        yield
+        return
+    value = _format_seconds(seconds)
+    env_names = (_CLAUDE_TIMEOUT_ENV, _REVIEWER_TIMEOUT_ENV, _CODEX_TIMEOUT_ENV)
+    old_values = {name: os.environ.get(name) for name in env_names}
+    try:
+        for name in env_names:
+            os.environ[name] = value
+        yield
+    finally:
+        for name, old_value in old_values.items():
+            if old_value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = old_value
 
 
 def _prepared_family_allowlist(families: Sequence[str] | None) -> set[str] | None:
@@ -2087,6 +2165,8 @@ def run_collect_cli(
     apply: bool,
     json_output: bool,
     prepared_json: Path | None = None,
+    reviewer_timeout: float | None = None,
+    overall_timeout: float | None = None,
     printer: Callable[[str], None] = print,
 ) -> int:
     """Shared entry point for the script and ``review-queue collect-evidence``.
@@ -2100,27 +2180,38 @@ def run_collect_cli(
     fams = tuple(families) if families else DEFAULT_FAMILIES
     resolved_author = author or resolve_author()
     try:
-        if prepared_json is None:
-            outcome = collect_evidence(
-                repo=repo,
-                pr=pr,
-                families=fams,
-                author=resolved_author,
-                apply=apply,
-                env=merge_quorum_io.aragora_env(),
-                quorum_reconciler=default_quorum_reconciler if apply else None,
-            )
-        else:
-            outcome = apply_prepared_evidence(
-                repo=repo,
-                pr=pr,
-                prepared_json=prepared_json,
-                author=resolved_author,
-                apply=apply,
-                families=fams,
-                env=merge_quorum_io.aragora_env(),
-                quorum_reconciler=default_quorum_reconciler if apply else None,
-            )
+        validated_overall_timeout = _validate_positive_timeout(overall_timeout, "overall_timeout")
+        validated_reviewer_timeout = _validate_positive_timeout(
+            reviewer_timeout, "reviewer_timeout"
+        )
+        if validated_overall_timeout is not None and (
+            validated_reviewer_timeout is None
+            or validated_reviewer_timeout > validated_overall_timeout
+        ):
+            validated_reviewer_timeout = validated_overall_timeout
+        with _scoped_reviewer_timeout_env(validated_reviewer_timeout):
+            if prepared_json is None:
+                outcome = collect_evidence(
+                    repo=repo,
+                    pr=pr,
+                    families=fams,
+                    author=resolved_author,
+                    apply=apply,
+                    env=merge_quorum_io.aragora_env(),
+                    quorum_reconciler=default_quorum_reconciler if apply else None,
+                    overall_timeout=validated_overall_timeout,
+                )
+            else:
+                outcome = apply_prepared_evidence(
+                    repo=repo,
+                    pr=pr,
+                    prepared_json=prepared_json,
+                    author=resolved_author,
+                    apply=apply,
+                    families=fams,
+                    env=merge_quorum_io.aragora_env(),
+                    quorum_reconciler=default_quorum_reconciler if apply else None,
+                )
     except (ValueError, RuntimeError, OSError, subprocess.SubprocessError) as exc:
         if json_output:
             printer(json.dumps({"mode": "collect_evidence", "error": str(exc)}, indent=2))

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -34,6 +34,7 @@ import logging
 import math
 import multiprocessing
 import os
+import pickle
 import queue
 import re
 import secrets
@@ -376,20 +377,39 @@ def _reviewer_process_context(
 ) -> Any | None:
     """Return the safest killable process context for reviewer orchestration.
 
-    Production collection uses the top-level ``default_reviewer_runner``, which is
-    spawn-pickleable and should avoid forking a potentially threaded parent. Tests
-    and custom callers often pass local closures; those need ``fork`` when
-    available. If neither safe path exists, callers should fall back to the
-    ordinary per-reviewer timeout path instead of failing every family without
-    attempting review.
+    Prefer ``spawn`` for any runner that can cross the spawn pickling boundary,
+    avoiding fork-from-threaded-parent hazards in production. Tests and custom
+    callers often pass local closures; those need ``fork`` when available. If no
+    killable context can enforce the requested overall timeout, callers must fail
+    closed rather than silently falling back to an unbounded thread wait.
     """
     start_methods = multiprocessing.get_all_start_methods()
-    runner_name = getattr(reviewer_runner, "__name__", "")
-    if runner_name == "default_reviewer_runner" and "spawn" in start_methods:
-        return multiprocessing.get_context("spawn")
+    if "spawn" in start_methods:
+        try:
+            pickle.dumps(reviewer_runner)
+        except (AttributeError, TypeError, pickle.PicklingError):
+            pass
+        else:
+            return multiprocessing.get_context("spawn")
     if "fork" in start_methods:
         return multiprocessing.get_context("fork")
     return None
+
+
+def _process_isolation_unavailable(
+    families: Sequence[str], reason: str
+) -> tuple[dict[str, ReviewerResult], list[str]]:
+    message = f"overall-timeout process isolation unavailable; {reason}; no reviewers were run"
+    return {family: ReviewerResult(family, "", False, message) for family in families}, list(
+        families
+    )
+
+
+def _safe_process_context_get_queue(ctx: Any, families: Sequence[str]) -> Any:
+    try:
+        return ctx.Queue()
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise RuntimeError(f"could not create reviewer result queue: {exc}") from exc
 
 
 def _run_reviewers_threaded(
@@ -427,10 +447,13 @@ def _run_reviewers_with_process_timeout(
     """Run reviewers in killable child processes for hard overall deadlines."""
     ctx = _reviewer_process_context(reviewer_runner)
     if ctx is None:
-        return _run_reviewers_threaded(
-            families=families, prompt=prompt, reviewer_runner=reviewer_runner
-        ), []
-    result_queue = ctx.Queue()
+        return _process_isolation_unavailable(
+            families, "no spawn-pickleable runner and no fork-capable runtime"
+        )
+    try:
+        result_queue = _safe_process_context_get_queue(ctx, families)
+    except RuntimeError as exc:
+        return _process_isolation_unavailable(families, str(exc))
     processes: dict[str, Any] = {}
     queued = list(families)
     max_workers = min(len(queued), _MAX_REVIEWER_WORKERS)
@@ -439,11 +462,17 @@ def _run_reviewers_with_process_timeout(
     def launch_ready() -> None:
         while queued and len(processes) < max_workers:
             family = queued.pop(0)
-            process = ctx.Process(
-                target=_reviewer_process_entry,
-                args=(result_queue, reviewer_runner, family, prompt),
-            )
-            process.start()
+            try:
+                process = ctx.Process(
+                    target=_reviewer_process_entry,
+                    args=(result_queue, reviewer_runner, family, prompt),
+                )
+                process.start()
+            except (OSError, RuntimeError, ValueError) as exc:
+                reviews[family] = ReviewerResult(
+                    family, "", False, f"could not start reviewer process: {exc}"
+                )
+                continue
             processes[family] = process
 
     def record_result(result: ReviewerResult) -> None:

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -371,6 +371,52 @@ def _terminate_reviewer_process(process: Any) -> None:
     process.join(timeout=_REVIEWER_CLEANUP_TIMEOUT)
 
 
+def _reviewer_process_context(
+    reviewer_runner: Callable[[str, str], ReviewerResult],
+) -> Any | None:
+    """Return the safest killable process context for reviewer orchestration.
+
+    Production collection uses the top-level ``default_reviewer_runner``, which is
+    spawn-pickleable and should avoid forking a potentially threaded parent. Tests
+    and custom callers often pass local closures; those need ``fork`` when
+    available. If neither safe path exists, callers should fall back to the
+    ordinary per-reviewer timeout path instead of failing every family without
+    attempting review.
+    """
+    start_methods = multiprocessing.get_all_start_methods()
+    runner_name = getattr(reviewer_runner, "__name__", "")
+    if runner_name == "default_reviewer_runner" and "spawn" in start_methods:
+        return multiprocessing.get_context("spawn")
+    if "fork" in start_methods:
+        return multiprocessing.get_context("fork")
+    return None
+
+
+def _run_reviewers_threaded(
+    *,
+    families: Sequence[str],
+    prompt: str,
+    reviewer_runner: Callable[[str, str], ReviewerResult],
+) -> dict[str, ReviewerResult]:
+    """Run reviewers through the legacy bounded-per-reviewer thread fanout."""
+    max_workers = min(len(families), _MAX_REVIEWER_WORKERS)
+    reviews: dict[str, ReviewerResult] = {}
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
+        future_to_family = {
+            pool.submit(_run_reviewer_with_infra_retry, reviewer_runner, family, prompt): family
+            for family in families
+        }
+        for future in concurrent.futures.as_completed(future_to_family):
+            family = future_to_family[future]
+            try:
+                reviews[family] = future.result()
+            except Exception as exc:  # noqa: BLE001 - one bad reviewer must not abort the run
+                reviews[family] = ReviewerResult(
+                    family, "", False, f"{type(exc).__name__}: {str(exc)[:200]}"
+                )
+    return reviews
+
+
 def _run_reviewers_with_process_timeout(
     *,
     families: Sequence[str],
@@ -379,17 +425,11 @@ def _run_reviewers_with_process_timeout(
     overall_timeout: float,
 ) -> tuple[dict[str, ReviewerResult], list[str]]:
     """Run reviewers in killable child processes for hard overall deadlines."""
-    start_methods = multiprocessing.get_all_start_methods()
-    if "fork" not in start_methods:
-        message = (
-            "overall-timeout process isolation requires a fork-capable runtime; "
-            "no reviewers were run"
-        )
-        return (
-            {family: ReviewerResult(family, "", False, message) for family in families},
-            list(families),
-        )
-    ctx = multiprocessing.get_context("fork")
+    ctx = _reviewer_process_context(reviewer_runner)
+    if ctx is None:
+        return _run_reviewers_threaded(
+            families=families, prompt=prompt, reviewer_runner=reviewer_runner
+        ), []
     result_queue = ctx.Queue()
     processes: dict[str, Any] = {}
     queued = list(families)
@@ -467,10 +507,16 @@ def _run_reviewers_with_process_timeout(
             )
             processes.pop(family, None)
 
-    timed_out = list(processes) + queued
     timeout_text = _format_seconds(overall_timeout)
     for family, process in list(processes.items()):
         _terminate_reviewer_process(process)
+    # A reviewer can put a result at the deadline boundary, after the last drain
+    # but before termination cleanup observes it. Drain again before assigning
+    # timeout failures so a real completed review is never discarded.
+    drain_results()
+
+    timed_out = list(processes) + queued
+    for family, process in list(processes.items()):
         reviews[family] = ReviewerResult(
             family,
             "",
@@ -680,6 +726,22 @@ class CollectOutcome:
             ],
             "failures": [{"family": f.family, "error": f.error} for f in self.failures],
         }
+
+
+def _timeout_failure_present(outcome: CollectOutcome) -> bool:
+    """Whether a prepared artifact carries any timeout marker.
+
+    Older artifacts may omit ``orchestration_timed_out`` while still carrying
+    ``timed_out_families`` or timeout-shaped reviewer failures. Treat those as
+    fail-closed during apply so partial low-tier quorum cannot post.
+    """
+    if outcome.orchestration_timed_out or outcome.timed_out_families:
+        return True
+    return any(
+        "overall collect-evidence timeout" in failure.error.lower()
+        or "timeout before reviewer started" in failure.error.lower()
+        for failure in outcome.failures
+    )
 
 
 def _string_list(value: Any) -> list[str]:
@@ -1939,22 +2001,11 @@ def collect_evidence(
                         family for family in ordered_families if family in set(timed_out)
                     ]
             else:
-                max_workers = min(len(supported), _MAX_REVIEWER_WORKERS)
-                with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
-                    future_to_family = {
-                        pool.submit(
-                            _run_reviewer_with_infra_retry, reviewer_runner, family, prompt
-                        ): family
-                        for family in supported
-                    }
-                    for future in concurrent.futures.as_completed(future_to_family):
-                        family = future_to_family[future]
-                        try:
-                            reviews[family] = future.result()
-                        except Exception as exc:  # noqa: BLE001 - one bad reviewer must not abort the run
-                            reviews[family] = ReviewerResult(
-                                family, "", False, f"{type(exc).__name__}: {str(exc)[:200]}"
-                            )
+                reviews = _run_reviewers_threaded(
+                    families=supported,
+                    prompt=prompt,
+                    reviewer_runner=reviewer_runner,
+                )
 
     for family in ordered_families:
         if family not in FAMILY_PROVIDERS:
@@ -2216,7 +2267,10 @@ def apply_prepared_evidence(
         )
         return outcome
 
-    if outcome.orchestration_timed_out:
+    if _timeout_failure_present(outcome):
+        outcome.orchestration_timed_out = True
+        if not outcome.timed_out_families:
+            outcome.timed_out_families = [failure.family for failure in outcome.failures]
         outcome.action = "prepare"
         outcome.action_reason = (
             "prepared collect-evidence artifact timed out; refusing to post partial evidence"

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -346,7 +346,7 @@ def _run_reviewers_with_process_timeout(
     start_methods = multiprocessing.get_all_start_methods()
     ctx = multiprocessing.get_context("fork" if "fork" in start_methods else None)
     result_queue = ctx.Queue()
-    processes: dict[str, multiprocessing.Process] = {}
+    processes: dict[str, Any] = {}
     for family in families:
         process = ctx.Process(
             target=_reviewer_process_entry,

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -492,6 +492,8 @@ def _run_reviewers_with_process_timeout(
     launch_ready()
     deadline = time.monotonic() + overall_timeout
     while processes or queued:
+        if time.monotonic() >= deadline:
+            break
         drain_results()
         for family, process in list(processes.items()):
             if process.exitcode is not None:
@@ -516,33 +518,33 @@ def _run_reviewers_with_process_timeout(
             result = result_queue.get(timeout=min(remaining, 0.1))
         except queue.Empty:
             continue
+        if time.monotonic() >= deadline:
+            break
         record_result(result)
 
-    # A result may have been enqueued just before the deadline. Drain once more
-    # before classifying anything as timed out so finished reviewers are not
-    # reported as missing.
-    drain_results()
-    for family, process in list(processes.items()):
-        if process.exitcode is not None:
-            process.join(timeout=0)
-            reviews.setdefault(
-                family,
-                ReviewerResult(
+    if time.monotonic() < deadline:
+        # A result may have been enqueued just before the deadline. Drain once more
+        # before classifying anything as timed out so finished reviewers are not
+        # reported as missing. After the deadline, ignore late results and fail
+        # closed instead of letting post-timeout quorum sneak through.
+        drain_results()
+        for family, process in list(processes.items()):
+            if process.exitcode is not None:
+                process.join(timeout=0)
+                reviews.setdefault(
                     family,
-                    "",
-                    False,
-                    f"reviewer process exited with code {process.exitcode} without result",
-                ),
-            )
-            processes.pop(family, None)
+                    ReviewerResult(
+                        family,
+                        "",
+                        False,
+                        f"reviewer process exited with code {process.exitcode} without result",
+                    ),
+                )
+                processes.pop(family, None)
 
     timeout_text = _format_seconds(overall_timeout)
     for family, process in list(processes.items()):
         _terminate_reviewer_process(process)
-    # A reviewer can put a result at the deadline boundary, after the last drain
-    # but before termination cleanup observes it. Drain again before assigning
-    # timeout failures so a real completed review is never discarded.
-    drain_results()
 
     timed_out = list(processes) + queued
     for family, process in list(processes.items()):
@@ -1327,7 +1329,7 @@ def _resolve_grok_build_bin() -> str:
 
 
 def _run_argv_cli_reviewer(
-    family: str, argv: list[str], harness: str, timeout: float = _REVIEWER_TIMEOUT
+    family: str, argv: list[str], harness: str, timeout: float | None = None
 ) -> ReviewerResult:
     """Run a headless single-prompt CLI reviewer (prompt passed as an argv value).
 
@@ -1336,6 +1338,9 @@ def _run_argv_cli_reviewer(
     the review body. Same exact-head composition + evidence-lint as every other
     reviewer decides whether the result can count.
     """
+    timeout = (
+        _timeout_seconds(_REVIEWER_TIMEOUT_ENV, _REVIEWER_TIMEOUT) if timeout is None else timeout
+    )
     try:
         proc = subprocess.run(argv, capture_output=True, text=True, timeout=timeout, check=False)
     except FileNotFoundError:

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -402,7 +402,6 @@ def _run_reviewers_with_process_timeout(
             process = ctx.Process(
                 target=_reviewer_process_entry,
                 args=(result_queue, reviewer_runner, family, prompt),
-                daemon=True,
             )
             process.start()
             processes[family] = process

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -268,6 +268,7 @@ _CODEX_TIMEOUT = 300
 _REVIEWER_TIMEOUT = 300
 _CLAUDE_TIMEOUT_ENV = "ARAGORA_COLLECT_EVIDENCE_CLAUDE_TIMEOUT_SECONDS"
 _CODEX_TIMEOUT_ENV = "ARAGORA_COLLECT_EVIDENCE_CODEX_TIMEOUT_SECONDS"
+_OVERALL_TIMEOUT_ENV = "ARAGORA_COLLECT_EVIDENCE_OVERALL_TIMEOUT_SECONDS"
 _CODEX_MODEL_ENV = "ARAGORA_COLLECT_EVIDENCE_CODEX_MODEL"
 _CODEX_MODELS_ENV = "ARAGORA_COLLECT_EVIDENCE_CODEX_MODELS"
 _CODEX_DEFAULT_MODELS = ("gpt-5.5", "gpt-5")
@@ -300,6 +301,13 @@ def _reviewer_infra_retries() -> int:
         return max(0, int(raw))
     except ValueError:
         return _REVIEWER_INFRA_RETRIES_DEFAULT
+
+
+def _default_overall_timeout_seconds(reviewer_timeout: float) -> float:
+    default = math.ceil(
+        float(reviewer_timeout) * (_reviewer_infra_retries() + 1) + _REVIEWER_CLEANUP_TIMEOUT
+    )
+    return _timeout_seconds(_OVERALL_TIMEOUT_ENV, default)
 
 
 def _run_reviewer_with_infra_retry(
@@ -2456,6 +2464,12 @@ def run_collect_cli(
         validated_reviewer_timeout = _validate_positive_timeout(
             reviewer_timeout, "reviewer_timeout"
         )
+        if prepared_json is None and validated_overall_timeout is None:
+            if validated_reviewer_timeout is None:
+                validated_reviewer_timeout = _timeout_seconds(
+                    _REVIEWER_TIMEOUT_ENV, _REVIEWER_TIMEOUT
+                )
+            validated_overall_timeout = _default_overall_timeout_seconds(validated_reviewer_timeout)
         if validated_overall_timeout is not None and (
             validated_reviewer_timeout is None
             or validated_reviewer_timeout > validated_overall_timeout

--- a/scripts/collect_quorum_evidence.py
+++ b/scripts/collect_quorum_evidence.py
@@ -75,7 +75,10 @@ def main(argv: list[str] | None = None) -> int:
         "--overall-timeout",
         type=float,
         default=None,
-        help="Overall reviewer orchestration timeout in seconds; fail-closed on expiry.",
+        help=(
+            "Overall reviewer orchestration timeout in seconds; fail-closed on expiry. "
+            "When omitted, use a bounded default derived from reviewer timeout and retry budget."
+        ),
     )
     parser.add_argument("--json", dest="json_output", action="store_true", help="Output as JSON")
     args = parser.parse_args(argv)

--- a/scripts/collect_quorum_evidence.py
+++ b/scripts/collect_quorum_evidence.py
@@ -65,6 +65,18 @@ def main(argv: list[str] | None = None) -> int:
             "re-running reviewers."
         ),
     )
+    parser.add_argument(
+        "--reviewer-timeout",
+        type=float,
+        default=None,
+        help="Per-reviewer timeout in seconds for this invocation.",
+    )
+    parser.add_argument(
+        "--overall-timeout",
+        type=float,
+        default=None,
+        help="Overall reviewer orchestration timeout in seconds; fail-closed on expiry.",
+    )
     parser.add_argument("--json", dest="json_output", action="store_true", help="Output as JSON")
     args = parser.parse_args(argv)
 
@@ -76,6 +88,8 @@ def main(argv: list[str] | None = None) -> int:
         apply=args.apply,
         json_output=args.json_output,
         prepared_json=args.prepared_json,
+        reviewer_timeout=args.reviewer_timeout,
+        overall_timeout=args.overall_timeout,
     )
 
 

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -5595,6 +5595,10 @@ class TestCommandDispatch:
                 "openai",
                 "--author",
                 "an0mium",
+                "--reviewer-timeout",
+                "90",
+                "--overall-timeout",
+                "150",
                 "--json",
             ]
         )
@@ -5603,6 +5607,8 @@ class TestCommandDispatch:
         assert ns_collect.pr == 6280
         assert ns_collect.reviewers == ["claude", "openai"]
         assert ns_collect.author == "an0mium"
+        assert ns_collect.reviewer_timeout == 90.0
+        assert ns_collect.overall_timeout == 150.0
         assert ns_collect.apply is False
         assert ns_collect.json_output is True
         # run invocation parses

--- a/tests/cli/test_cli_training.py
+++ b/tests/cli/test_cli_training.py
@@ -26,7 +26,7 @@ def runner():
 class TestExportSft:
     """Tests for export-sft command."""
 
-    @patch("aragora.cli.training.SFTExporter")
+    @patch("aragora.training.exporters.SFTExporter")
     def test_export_sft_basic(self, mock_exporter_class, runner, tmp_path):
         """export-sft creates output file."""
         mock_exporter = MagicMock()
@@ -42,7 +42,7 @@ class TestExportSft:
         assert "100" in result.output
         assert "SFT" in result.output
 
-    @patch("aragora.cli.training.SFTExporter")
+    @patch("aragora.training.exporters.SFTExporter")
     def test_export_sft_with_options(self, mock_exporter_class, runner, tmp_path):
         """export-sft respects options."""
         mock_exporter = MagicMock()
@@ -75,7 +75,7 @@ class TestExportSft:
 class TestExportDpo:
     """Tests for export-dpo command."""
 
-    @patch("aragora.cli.training.DPOExporter")
+    @patch("aragora.training.exporters.DPOExporter")
     def test_export_dpo_basic(self, mock_exporter_class, runner, tmp_path):
         """export-dpo creates output file."""
         mock_exporter = MagicMock()
@@ -91,7 +91,7 @@ class TestExportDpo:
         assert "75" in result.output
         assert "DPO" in result.output
 
-    @patch("aragora.cli.training.DPOExporter")
+    @patch("aragora.training.exporters.DPOExporter")
     def test_export_dpo_with_elo_diff(self, mock_exporter_class, runner, tmp_path):
         """export-dpo respects min-elo-diff option."""
         mock_exporter = MagicMock()
@@ -117,7 +117,7 @@ class TestExportDpo:
 class TestExportGauntlet:
     """Tests for export-gauntlet command."""
 
-    @patch("aragora.cli.training.GauntletExporter")
+    @patch("aragora.training.exporters.GauntletExporter")
     def test_export_gauntlet_basic(self, mock_exporter_class, runner, tmp_path):
         """export-gauntlet creates output file."""
         mock_exporter = MagicMock()
@@ -137,9 +137,9 @@ class TestExportGauntlet:
 class TestExportAll:
     """Tests for export-all command."""
 
-    @patch("aragora.cli.training.GauntletExporter")
-    @patch("aragora.cli.training.DPOExporter")
-    @patch("aragora.cli.training.SFTExporter")
+    @patch("aragora.training.exporters.GauntletExporter")
+    @patch("aragora.training.exporters.DPOExporter")
+    @patch("aragora.training.exporters.SFTExporter")
     def test_export_all_creates_multiple_files(
         self, mock_sft, mock_dpo, mock_gauntlet, runner, tmp_path
     ):
@@ -173,7 +173,7 @@ class TestTestConnection:
         assert "TINKER_API_KEY" in result.output
 
     @patch("aragora.cli.training.asyncio.run")
-    @patch("aragora.cli.training.TinkerClient")
+    @patch("aragora.training.tinker_client.TinkerClient")
     @patch.dict("os.environ", {"TINKER_API_KEY": "test-key"})
     def test_connection_success(self, mock_client_class, mock_run, runner):
         """test-connection succeeds with valid key."""
@@ -192,7 +192,7 @@ class TestTrainSft:
     """Tests for train-sft command."""
 
     @patch("aragora.cli.training.asyncio.run")
-    @patch("aragora.cli.training.TrainingScheduler")
+    @patch("aragora.training.TrainingScheduler")
     def test_train_sft_schedules_job(self, mock_scheduler_class, mock_run, runner):
         """train-sft schedules a training job."""
         mock_scheduler = AsyncMock()
@@ -222,7 +222,7 @@ class TestTrainDpo:
     """Tests for train-dpo command."""
 
     @patch("aragora.cli.training.asyncio.run")
-    @patch("aragora.cli.training.TrainingScheduler")
+    @patch("aragora.training.TrainingScheduler")
     def test_train_dpo_schedules_job(self, mock_scheduler_class, mock_run, runner):
         """train-dpo schedules a DPO training job."""
         mock_scheduler = AsyncMock()
@@ -240,7 +240,7 @@ class TestListModels:
     """Tests for list-models command."""
 
     @patch("aragora.cli.training.asyncio.run")
-    @patch("aragora.cli.training.TinkerClient")
+    @patch("aragora.training.tinker_client.TinkerClient")
     def test_list_models_empty(self, mock_client_class, mock_run, runner):
         """list-models shows message when no models."""
         mock_run.return_value = None
@@ -255,7 +255,7 @@ class TestSample:
     """Tests for sample command."""
 
     @patch("aragora.cli.training.asyncio.run")
-    @patch("aragora.cli.training.TinkerClient")
+    @patch("aragora.training.tinker_client.TinkerClient")
     def test_sample_generates_text(self, mock_client_class, mock_run, runner):
         """sample command generates text."""
         mock_client = AsyncMock()
@@ -275,8 +275,8 @@ class TestSample:
 class TestStats:
     """Tests for stats command."""
 
-    @patch("aragora.cli.training.EloSystem")
-    @patch("aragora.cli.training.CritiqueStore")
+    @patch("aragora.ranking.elo.EloSystem")
+    @patch("aragora.memory.store.CritiqueStore")
     def test_stats_shows_data(self, mock_critique, mock_elo, runner):
         """stats command shows training data statistics."""
         mock_critique_instance = MagicMock()

--- a/tests/gauntlet/conftest.py
+++ b/tests/gauntlet/conftest.py
@@ -48,7 +48,13 @@ def _mock_gauntlet_runner_external_calls(monkeypatch):
     from aragora.gauntlet.result import AttackSummary, ProbeSummary, ScenarioSummary
     from aragora.gauntlet.runner import GauntletRunner
 
+    original_run_red_team = GauntletRunner._run_red_team
+
     async def _mock_run_red_team(self, input_content, context, result, report_progress):
+        if self.run_agent_fn is not None:
+            return await original_run_red_team(
+                self, input_content, context, result, report_progress
+            )
         return AttackSummary()
 
     async def _mock_run_probes(self, input_content, context, result, report_progress):

--- a/tests/swarm/test_merge_quorum_io.py
+++ b/tests/swarm/test_merge_quorum_io.py
@@ -48,12 +48,87 @@ def test_fetch_pr_context_routes_reads_through_app_token(monkeypatch) -> None:
 
     def capture_run(args, *, env=None, timeout=m._GH_TIMEOUT):
         captured_envs.append(env or {})
-        return _proc(json.dumps({"headRefOid": "abc", "commits": [], "statusCheckRollup": []}))
+        return _proc(
+            json.dumps(
+                {
+                    "headRefOid": "abc",
+                    "commits": [{"oid": "abc", "committedDate": "2026-06-28T00:00:00Z"}],
+                    "statusCheckRollup": [],
+                }
+            )
+        )
 
     monkeypatch.setattr(m, "run", capture_run)
     m.fetch_pr_context("o/r", 1)
     assert captured_envs, "expected fetch_pr_context to shell out to gh"
     assert captured_envs[0].get("GH_TOKEN") == "fake-app-token"
+    assert captured_envs[0].get("ARAGORA_GITHUB_AUTH_SOURCE") == "github_app_installation"
+
+
+def test_fetch_pr_context_falls_back_to_operator_auth_on_app_transport_error(
+    monkeypatch,
+) -> None:
+    from aragora.swarm import github_app_auth
+
+    monkeypatch.setattr(
+        github_app_auth, "get_github_app_installation_token", lambda env=None: "fake-app-token"
+    )
+    captured_envs: list[dict] = []
+
+    def capture_run(args, *, env=None, timeout=m._GH_TIMEOUT):
+        captured_envs.append(env or {})
+        if (env or {}).get("ARAGORA_GITHUB_AUTH_SOURCE") == "github_app_installation":
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=1,
+                stdout="",
+                stderr="error connecting to api.github.com\ncheck your internet connection",
+            )
+        return _proc(
+            json.dumps(
+                {
+                    "headRefOid": "abc",
+                    "commits": [{"oid": "abc", "committedDate": "2026-06-28T00:00:00Z"}],
+                    "statusCheckRollup": [],
+                }
+            )
+        )
+
+    monkeypatch.setattr(m, "run", capture_run)
+    ctx = m.fetch_pr_context("o/r", 1)
+
+    assert ctx["head_sha"] == "abc"
+    assert len(captured_envs) == 2
+    assert captured_envs[0].get("ARAGORA_GITHUB_AUTH_SOURCE") == "github_app_installation"
+    assert captured_envs[1].get("ARAGORA_GITHUB_AUTH_SOURCE") != "github_app_installation"
+
+
+def test_fetch_pr_context_does_not_fallback_on_non_transport_app_error(monkeypatch) -> None:
+    from aragora.swarm import github_app_auth
+
+    monkeypatch.setattr(
+        github_app_auth, "get_github_app_installation_token", lambda env=None: "fake-app-token"
+    )
+    captured_envs: list[dict] = []
+
+    def capture_run(args, *, env=None, timeout=m._GH_TIMEOUT):
+        captured_envs.append(env or {})
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=1,
+            stdout="",
+            stderr="GraphQL: Resource not accessible by integration",
+        )
+
+    monkeypatch.setattr(m, "run", capture_run)
+    try:
+        m.fetch_pr_context("o/r", 1)
+    except RuntimeError as exc:
+        assert "Resource not accessible by integration" in str(exc)
+    else:  # pragma: no cover - explicit assertion for readability.
+        raise AssertionError("expected non-transport app error to fail closed")
+
+    assert len(captured_envs) == 1
     assert captured_envs[0].get("ARAGORA_GITHUB_AUTH_SOURCE") == "github_app_installation"
 
 

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -1286,7 +1286,7 @@ def test_collect_overall_timeout_process_path_runs_queued_reviewers(tmp_path, mo
 
 def test_collect_overall_timeout_process_path_allows_nested_reviewer_process() -> None:
     if "fork" not in multiprocessing.get_all_start_methods():
-        pytest.skip("overall-timeout reviewer isolation requires fork")
+        return
     fakes, _ = _fakes(tier=2)
     fakes["reviewer_runner"] = _process_spawning_reviewer_runner
 

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -1168,10 +1168,10 @@ def test_collect_overall_timeout_path_preserves_infra_retry(tmp_path, monkeypatc
     assert attempts_file.read_text(encoding="utf-8").count("grok\n") == 2
 
 
-def test_collect_overall_timeout_fails_closed_without_fork(monkeypatch) -> None:
+def test_collect_overall_timeout_falls_back_without_process_context(monkeypatch) -> None:
     fakes, _ = _fakes(tier=0)
     called: list[str] = []
-    monkeypatch.setattr(qe.multiprocessing, "get_all_start_methods", lambda: ["spawn"])
+    monkeypatch.setattr(qe.multiprocessing, "get_all_start_methods", lambda: [])
 
     def reviewer_runner(family: str, prompt: str) -> ReviewerResult:
         called.append(family)
@@ -1188,12 +1188,11 @@ def test_collect_overall_timeout_fails_closed_without_fork(monkeypatch) -> None:
         **fakes,
     )
 
-    assert called == []
-    assert outcome.orchestration_timed_out is True
-    assert outcome.timed_out_families == ["claude", "grok"]
-    assert outcome.items == []
-    assert [failure.family for failure in outcome.failures] == ["claude", "grok"]
-    assert all("fork-capable runtime" in failure.error for failure in outcome.failures)
+    assert called == ["claude", "grok"]
+    assert outcome.orchestration_timed_out is False
+    assert outcome.timed_out_families == []
+    assert [item.family for item in outcome.items] == ["claude", "grok"]
+    assert outcome.failures == []
 
 
 def test_collect_overall_timeout_process_path_runs_queued_reviewers(tmp_path, monkeypatch) -> None:
@@ -1980,6 +1979,50 @@ def test_apply_prepared_evidence_refuses_timed_out_artifact(tmp_path) -> None:
         timed_out_families=["grok"],
     )
     prepared = tmp_path / "timed_out_prepared.json"
+    prepared.write_text(json.dumps(outcome.to_dict()), encoding="utf-8")
+    posted: list[str] = []
+
+    applied = qe.apply_prepared_evidence(
+        repo="o/r",
+        pr=1,
+        prepared_json=prepared,
+        author="me",
+        apply=True,
+        families=["claude", "grok"],
+        context_fetcher=lambda r, p: {"head_sha": HEAD, "head_committed_at": COMMITTED},
+        tier_fetcher=lambda r, p: 0,
+        linter=lambda *a, **k: {
+            "would_count": True,
+            "counted_reviewer_ids": ["claude"],
+            "problems": [],
+        },
+        poster=lambda r, p, b: posted.append(b),
+    )
+
+    assert applied.action == "prepare"
+    assert applied.orchestration_timed_out is True
+    assert applied.timed_out_families == ["grok"]
+    assert "timed out" in applied.action_reason
+    assert applied.has_supportive_quorum is False
+    assert applied.posted == []
+    assert posted == []
+
+
+def test_apply_prepared_evidence_refuses_timeout_markers_without_flag(tmp_path) -> None:
+    outcome = CollectOutcome(
+        repo="o/r",
+        pr=1,
+        head_sha=HEAD,
+        head_committed_at=COMMITTED,
+        tier=0,
+        action="prepare",
+        action_reason="legacy timeout artifact",
+        items=[EvidenceItem("claude", _prepared_body("claude"), True, ["claude"], [], "pass")],
+        failures=[ReviewerResult("grok", "", False, "overall collect-evidence timeout")],
+        orchestration_timed_out=False,
+        timed_out_families=[],
+    )
+    prepared = tmp_path / "legacy_timeout_prepared.json"
     prepared.write_text(json.dumps(outcome.to_dict()), encoding="utf-8")
     posted: list[str] = []
 

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -1168,7 +1168,7 @@ def test_collect_overall_timeout_path_preserves_infra_retry(tmp_path, monkeypatc
     assert attempts_file.read_text(encoding="utf-8").count("grok\n") == 2
 
 
-def test_collect_overall_timeout_falls_back_without_process_context(monkeypatch) -> None:
+def test_collect_overall_timeout_fails_closed_without_process_context(monkeypatch) -> None:
     fakes, _ = _fakes(tier=0)
     called: list[str] = []
     monkeypatch.setattr(qe.multiprocessing, "get_all_start_methods", lambda: [])
@@ -1188,11 +1188,47 @@ def test_collect_overall_timeout_falls_back_without_process_context(monkeypatch)
         **fakes,
     )
 
-    assert called == ["claude", "grok"]
-    assert outcome.orchestration_timed_out is False
-    assert outcome.timed_out_families == []
-    assert [item.family for item in outcome.items] == ["claude", "grok"]
-    assert outcome.failures == []
+    assert called == []
+    assert outcome.orchestration_timed_out is True
+    assert outcome.timed_out_families == ["claude", "grok"]
+    assert outcome.items == []
+    assert [failure.family for failure in outcome.failures] == ["claude", "grok"]
+    assert all("process isolation unavailable" in failure.error for failure in outcome.failures)
+
+
+def test_collect_overall_timeout_prefers_spawn_for_pickleable_runner(monkeypatch) -> None:
+    seen: list[str] = []
+
+    def fake_get_context(method: str):
+        seen.append(method)
+        return SimpleNamespace(method=method)
+
+    monkeypatch.setattr(qe.multiprocessing, "get_all_start_methods", lambda: ["spawn", "fork"])
+    monkeypatch.setattr(qe.multiprocessing, "get_context", fake_get_context)
+
+    ctx = qe._reviewer_process_context(qe.default_reviewer_runner)
+
+    assert ctx == SimpleNamespace(method="spawn")
+    assert seen == ["spawn"]
+
+
+def test_collect_overall_timeout_queue_setup_failure_fails_closed(monkeypatch) -> None:
+    class BadContext:
+        def Queue(self):  # noqa: N802 - mirrors multiprocessing API
+            raise OSError("queue denied")
+
+    monkeypatch.setattr(qe, "_reviewer_process_context", lambda runner: BadContext())
+
+    reviews, timed_out = qe._run_reviewers_with_process_timeout(
+        families=["claude", "grok"],
+        prompt="p",
+        reviewer_runner=lambda family, prompt: ReviewerResult(family, "", True),
+        overall_timeout=5.0,
+    )
+
+    assert timed_out == ["claude", "grok"]
+    assert set(reviews) == {"claude", "grok"}
+    assert all("process isolation unavailable" in result.error for result in reviews.values())
 
 
 def test_collect_overall_timeout_process_path_runs_queued_reviewers(tmp_path, monkeypatch) -> None:

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -1080,21 +1080,22 @@ def test_collect_overall_timeout_fails_closed_without_partial_post() -> None:
     assert outcome.to_dict()["timed_out_families"] == ["grok"]
 
 
-def test_collect_overall_timeout_waits_for_bounded_reviewer_before_env_restore(
-    monkeypatch,
-) -> None:
+def test_collect_overall_timeout_terminates_slow_reviewer(tmp_path, monkeypatch) -> None:
     fakes, _ = _fakes(tier=0)
-    runner_done = threading.Event()
+    started = tmp_path / "started"
+    finished = tmp_path / "finished"
     monkeypatch.delenv(qe._REVIEWER_TIMEOUT_ENV, raising=False)
 
     def slow_runner(family: str, prompt: str) -> ReviewerResult:
         if family == "grok":
             assert os.environ.get(qe._REVIEWER_TIMEOUT_ENV) == "0.05"
-            time.sleep(0.2)
-            runner_done.set()
+            started.write_text("yes", encoding="utf-8")
+            time.sleep(2.0)
+            finished.write_text("yes", encoding="utf-8")
         return ReviewerResult(family, f"Verdict: PASS from {family}", True)
 
     fakes["reviewer_runner"] = slow_runner
+    started_at = time.monotonic()
     outcome = collect_evidence(
         repo="o/r",
         pr=1,
@@ -1104,9 +1105,13 @@ def test_collect_overall_timeout_waits_for_bounded_reviewer_before_env_restore(
         overall_timeout=0.05,
         **fakes,
     )
+    elapsed = time.monotonic() - started_at
 
     assert outcome.orchestration_timed_out is True
-    assert runner_done.is_set()
+    assert elapsed < 1.0
+    assert started.exists()
+    time.sleep(0.1)
+    assert not finished.exists()
     assert os.environ.get(qe._REVIEWER_TIMEOUT_ENV) is None
 
 
@@ -1870,7 +1875,7 @@ def test_apply_prepared_evidence_refuses_timed_out_artifact(tmp_path) -> None:
     assert applied.orchestration_timed_out is True
     assert applied.timed_out_families == ["grok"]
     assert "timed out" in applied.action_reason
-    assert applied.has_supportive_quorum is True
+    assert applied.has_supportive_quorum is False
     assert applied.posted == []
     assert posted == []
 

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -2676,6 +2676,58 @@ def test_run_collect_cli_scopes_reviewer_timeout_env_and_forwards_overall(
     assert "collect_evidence" in capsys.readouterr().out
 
 
+def test_run_collect_cli_defaults_to_bounded_overall_timeout(monkeypatch) -> None:
+    seen: dict[str, object] = {}
+    monkeypatch.setenv(qe._REVIEWER_TIMEOUT_ENV, "8")
+    monkeypatch.setenv(qe._OVERALL_TIMEOUT_ENV, "25")
+    monkeypatch.delenv(qe._CLAUDE_TIMEOUT_ENV, raising=False)
+    monkeypatch.delenv(qe._CODEX_TIMEOUT_ENV, raising=False)
+
+    def fake_collect(**kwargs) -> CollectOutcome:
+        seen["reviewer_timeout"] = kwargs.get("reviewer_timeout")
+        seen["overall_timeout"] = kwargs.get("overall_timeout")
+        seen["claude_timeout_env"] = os.environ.get(qe._CLAUDE_TIMEOUT_ENV)
+        seen["reviewer_timeout_env"] = os.environ.get(qe._REVIEWER_TIMEOUT_ENV)
+        seen["codex_timeout_env"] = os.environ.get(qe._CODEX_TIMEOUT_ENV)
+        return CollectOutcome(
+            repo="o/r",
+            pr=1,
+            head_sha=HEAD,
+            head_committed_at=COMMITTED,
+            tier=1,
+            action="prepare",
+            action_reason="dry-run",
+            items=[
+                EvidenceItem("claude", "body", True, ["claude"], [], "pass"),
+                EvidenceItem("grok", "body", True, ["grok"], [], "pass"),
+            ],
+        )
+
+    monkeypatch.setattr(qe, "collect_evidence", fake_collect)
+    monkeypatch.setattr(qe, "resolve_author", lambda default="local": "me")
+
+    rc = qe.run_collect_cli(
+        repo="o/r",
+        pr=1,
+        families=["claude", "grok"],
+        author=None,
+        apply=False,
+        json_output=False,
+    )
+
+    assert rc == 0
+    assert seen == {
+        "reviewer_timeout": 8.0,
+        "overall_timeout": 25.0,
+        "claude_timeout_env": "8",
+        "reviewer_timeout_env": "8",
+        "codex_timeout_env": "8",
+    }
+    assert os.environ.get(qe._REVIEWER_TIMEOUT_ENV) == "8"
+    assert os.environ.get(qe._CLAUDE_TIMEOUT_ENV) is None
+    assert os.environ.get(qe._CODEX_TIMEOUT_ENV) is None
+
+
 def test_run_collect_cli_overall_timeout_caps_default_reviewer_env(monkeypatch) -> None:
     seen: dict[str, object] = {}
     monkeypatch.delenv(qe._CLAUDE_TIMEOUT_ENV, raising=False)

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -1140,6 +1140,32 @@ def test_collect_overall_timeout_terminates_slow_reviewer(tmp_path, monkeypatch)
     assert os.environ.get(qe._REVIEWER_TIMEOUT_ENV) is None
 
 
+def test_collect_overall_timeout_rejects_results_after_deadline(monkeypatch) -> None:
+    fakes, _ = _fakes(tier=0)
+    monkeypatch.delenv(qe._REVIEWER_TIMEOUT_ENV, raising=False)
+
+    def just_late_runner(family: str, prompt: str) -> ReviewerResult:
+        time.sleep(0.08)
+        return ReviewerResult(family, f"Verdict: PASS from {family}", True)
+
+    fakes["reviewer_runner"] = just_late_runner
+    outcome = collect_evidence(
+        repo="o/r",
+        pr=1,
+        families=["claude", "grok"],
+        author="me",
+        apply=True,
+        overall_timeout=0.05,
+        **fakes,
+    )
+
+    assert outcome.orchestration_timed_out is True
+    assert outcome.timed_out_families == ["claude", "grok"]
+    assert outcome.items == []
+    assert [failure.family for failure in outcome.failures] == ["claude", "grok"]
+    assert outcome.posted == []
+
+
 def test_collect_overall_timeout_path_preserves_infra_retry(tmp_path, monkeypatch) -> None:
     fakes, _ = _fakes(tier=0)
     attempts_file = tmp_path / "attempts.txt"
@@ -2921,6 +2947,25 @@ def test_grok_reviewer_prefers_sandboxed_cli_when_installed(monkeypatch) -> None
     assert seen["argv"][0].endswith(".grok/bin/grok")
 
 
+def test_grok_reviewer_cli_honors_reviewer_timeout_env(monkeypatch) -> None:
+    _force_grok_bin(monkeypatch, True)
+    monkeypatch.setenv(qe._REVIEWER_TIMEOUT_ENV, "12.5")
+    seen: dict = {}
+
+    def fake_run(argv, *, capture_output, text, timeout, check):
+        seen["timeout"] = timeout
+        return SimpleNamespace(returncode=0, stdout="Verdict: PASS\nNo findings.", stderr="")
+
+    monkeypatch.setattr(qe.subprocess, "run", fake_run)
+    monkeypatch.setattr(qe, "_run_api_agent", lambda f, p: pytest.fail("should not hit API"))
+
+    res = qe._run_grok_reviewer("review prompt")
+
+    assert res.family == "grok"
+    assert res.ok is True
+    assert seen["timeout"] == 12.5
+
+
 def test_grok_build_bin_override(monkeypatch) -> None:
     monkeypatch.setenv("ARAGORA_GROK_BUILD_BIN", "/custom/grok")
     assert qe._resolve_grok_build_bin() == "/custom/grok"
@@ -2962,6 +3007,27 @@ def test_gemini_reviewer_prefers_resolved_sandboxed_agy(monkeypatch) -> None:
     assert res.family == "gemini"
     # resolved path (not bare "agy") + sandbox.
     assert seen["argv"] == ["/usr/local/bin/agy", "--sandbox", "-p", "review prompt"]
+
+
+def test_gemini_reviewer_cli_honors_reviewer_timeout_env(monkeypatch) -> None:
+    import shutil as _sh
+
+    monkeypatch.setenv(qe._REVIEWER_TIMEOUT_ENV, "9")
+    monkeypatch.setattr(_sh, "which", lambda name: "/usr/local/bin/agy" if name == "agy" else None)
+    seen: dict = {}
+
+    def fake_run(argv, *, capture_output, text, timeout, check):
+        seen["timeout"] = timeout
+        return SimpleNamespace(returncode=0, stdout="Verdict: PASS\nNo findings.", stderr="")
+
+    monkeypatch.setattr(qe.subprocess, "run", fake_run)
+    monkeypatch.setattr(qe, "_run_api_agent", lambda f, p: pytest.fail("should not hit API"))
+
+    res = qe._run_gemini_reviewer("review prompt")
+
+    assert res.family == "gemini"
+    assert res.ok is True
+    assert seen["timeout"] == 9.0
 
 
 def test_gemini_reviewer_falls_back_to_api_without_agy(monkeypatch) -> None:

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -1046,6 +1046,43 @@ def test_collect_records_raising_reviewer_as_failure() -> None:
     assert "reviewer boom" in outcome.failures[0].error
 
 
+def test_collect_overall_timeout_fails_closed_without_partial_post() -> None:
+    # Tier 0 would be satisfied by the fast claude result alone, but an
+    # orchestration timeout means the evidence set is incomplete. It must fail
+    # closed to prepare-only and never post a partial quorum.
+    fakes, posted = _fakes(tier=0)
+
+    def slow_grok_runner(family: str, prompt: str) -> ReviewerResult:
+        if family == "grok":
+            time.sleep(0.2)
+        return ReviewerResult(family, f"Verdict: PASS from {family}", True)
+
+    fakes["reviewer_runner"] = slow_grok_runner
+    started = time.monotonic()
+    outcome = collect_evidence(
+        repo="o/r",
+        pr=1,
+        families=["claude", "grok"],
+        author="me",
+        apply=True,
+        overall_timeout=0.05,
+        **fakes,
+    )
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 0.18
+    assert outcome.orchestration_timed_out is True
+    assert outcome.timed_out_families == ["grok"]
+    assert [f.family for f in outcome.failures] == ["grok"]
+    assert "overall collect-evidence timeout" in outcome.failures[0].error
+    assert outcome.action == "prepare"
+    assert "overall collect-evidence timeout" in outcome.action_reason
+    assert outcome.posted == []
+    assert posted == []
+    assert outcome.to_dict()["orchestration_timed_out"] is True
+    assert outcome.to_dict()["timed_out_families"] == ["grok"]
+
+
 def test_collect_low_tier_apply_triggers_same_pr_quorum_reconciler_after_posts() -> None:
     fakes, posted = _fakes(tier=1)
     calls: list[tuple[str, int, int]] = []
@@ -2244,6 +2281,109 @@ def test_run_collect_cli_catches_runtime_error(monkeypatch, capsys) -> None:
     )
     assert rc == 1
     assert "empty diff" in capsys.readouterr().out
+
+
+def test_run_collect_cli_scopes_reviewer_timeout_env_and_forwards_overall(
+    monkeypatch, capsys
+) -> None:
+    seen: dict[str, object] = {}
+    monkeypatch.setenv(qe._CLAUDE_TIMEOUT_ENV, "old-claude")
+    monkeypatch.delenv(qe._REVIEWER_TIMEOUT_ENV, raising=False)
+    monkeypatch.setenv(qe._CODEX_TIMEOUT_ENV, "old-codex")
+
+    def fake_collect(**kwargs) -> CollectOutcome:
+        seen.update(kwargs)
+        seen["claude_timeout_env"] = os.environ.get(qe._CLAUDE_TIMEOUT_ENV)
+        seen["reviewer_timeout_env"] = os.environ.get(qe._REVIEWER_TIMEOUT_ENV)
+        seen["codex_timeout_env"] = os.environ.get(qe._CODEX_TIMEOUT_ENV)
+        return CollectOutcome(
+            repo="o/r",
+            pr=1,
+            head_sha=HEAD,
+            head_committed_at=COMMITTED,
+            tier=1,
+            action="prepare",
+            action_reason="dry-run",
+            items=[
+                EvidenceItem("claude", "body", True, ["claude"], [], "pass"),
+                EvidenceItem("grok", "body", True, ["grok"], [], "pass"),
+            ],
+        )
+
+    monkeypatch.setattr(qe, "collect_evidence", fake_collect)
+    monkeypatch.setattr(qe, "resolve_author", lambda default="local": "me")
+
+    rc = qe.run_collect_cli(
+        repo="o/r",
+        pr=1,
+        families=["claude", "grok"],
+        author=None,
+        apply=False,
+        json_output=True,
+        reviewer_timeout=12.5,
+        overall_timeout=45.0,
+    )
+
+    assert rc == 0
+    assert seen["overall_timeout"] == 45.0
+    assert seen["claude_timeout_env"] == "12.5"
+    assert seen["reviewer_timeout_env"] == "12.5"
+    assert seen["codex_timeout_env"] == "12.5"
+    assert os.environ.get(qe._CLAUDE_TIMEOUT_ENV) == "old-claude"
+    assert os.environ.get(qe._REVIEWER_TIMEOUT_ENV) is None
+    assert os.environ.get(qe._CODEX_TIMEOUT_ENV) == "old-codex"
+    assert "collect_evidence" in capsys.readouterr().out
+
+
+def test_run_collect_cli_overall_timeout_caps_default_reviewer_env(monkeypatch) -> None:
+    seen: dict[str, object] = {}
+    monkeypatch.delenv(qe._CLAUDE_TIMEOUT_ENV, raising=False)
+    monkeypatch.delenv(qe._REVIEWER_TIMEOUT_ENV, raising=False)
+    monkeypatch.delenv(qe._CODEX_TIMEOUT_ENV, raising=False)
+
+    def fake_collect(**kwargs) -> CollectOutcome:
+        seen["overall_timeout"] = kwargs.get("overall_timeout")
+        seen["claude_timeout_env"] = os.environ.get(qe._CLAUDE_TIMEOUT_ENV)
+        seen["reviewer_timeout_env"] = os.environ.get(qe._REVIEWER_TIMEOUT_ENV)
+        seen["codex_timeout_env"] = os.environ.get(qe._CODEX_TIMEOUT_ENV)
+        return CollectOutcome(
+            repo="o/r",
+            pr=1,
+            head_sha=HEAD,
+            head_committed_at=COMMITTED,
+            tier=4,
+            action="prepare",
+            action_reason="settlement",
+            items=[
+                EvidenceItem("claude", "body", True, ["claude"], [], "pass"),
+                EvidenceItem("grok", "body", True, ["grok"], [], "pass"),
+            ],
+        )
+
+    monkeypatch.setattr(qe, "collect_evidence", fake_collect)
+    monkeypatch.setattr(qe, "resolve_author", lambda default="local": "me")
+
+    rc = qe.run_collect_cli(
+        repo="o/r",
+        pr=1,
+        families=["claude", "grok"],
+        author=None,
+        apply=False,
+        json_output=False,
+        reviewer_timeout=None,
+        overall_timeout=30.0,
+    )
+
+    assert rc == 0
+    assert seen == {
+        "overall_timeout": 30.0,
+        "claude_timeout_env": "30",
+        "reviewer_timeout_env": "30",
+        "codex_timeout_env": "30",
+    }
+    assert os.environ.get(qe._CLAUDE_TIMEOUT_ENV) is None
+    assert os.environ.get(qe._REVIEWER_TIMEOUT_ENV) is None
+    assert os.environ.get(qe._CODEX_TIMEOUT_ENV) is None
 
 
 # --- build_review_prompt: complete file list + fair per-file body bounding ---

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -1058,7 +1058,6 @@ def test_collect_overall_timeout_fails_closed_without_partial_post() -> None:
         return ReviewerResult(family, f"Verdict: PASS from {family}", True)
 
     fakes["reviewer_runner"] = slow_grok_runner
-    started = time.monotonic()
     outcome = collect_evidence(
         repo="o/r",
         pr=1,
@@ -1068,9 +1067,7 @@ def test_collect_overall_timeout_fails_closed_without_partial_post() -> None:
         overall_timeout=0.05,
         **fakes,
     )
-    elapsed = time.monotonic() - started
 
-    assert elapsed < 0.18
     assert outcome.orchestration_timed_out is True
     assert outcome.timed_out_families == ["grok"]
     assert [f.family for f in outcome.failures] == ["grok"]
@@ -1081,6 +1078,36 @@ def test_collect_overall_timeout_fails_closed_without_partial_post() -> None:
     assert posted == []
     assert outcome.to_dict()["orchestration_timed_out"] is True
     assert outcome.to_dict()["timed_out_families"] == ["grok"]
+
+
+def test_collect_overall_timeout_waits_for_bounded_reviewer_before_env_restore(
+    monkeypatch,
+) -> None:
+    fakes, _ = _fakes(tier=0)
+    runner_done = threading.Event()
+    monkeypatch.delenv(qe._REVIEWER_TIMEOUT_ENV, raising=False)
+
+    def slow_runner(family: str, prompt: str) -> ReviewerResult:
+        if family == "grok":
+            assert os.environ.get(qe._REVIEWER_TIMEOUT_ENV) == "0.05"
+            time.sleep(0.2)
+            runner_done.set()
+        return ReviewerResult(family, f"Verdict: PASS from {family}", True)
+
+    fakes["reviewer_runner"] = slow_runner
+    outcome = collect_evidence(
+        repo="o/r",
+        pr=1,
+        families=["claude", "grok"],
+        author="me",
+        apply=True,
+        overall_timeout=0.05,
+        **fakes,
+    )
+
+    assert outcome.orchestration_timed_out is True
+    assert runner_done.is_set()
+    assert os.environ.get(qe._REVIEWER_TIMEOUT_ENV) is None
 
 
 def test_collect_low_tier_apply_triggers_same_pr_quorum_reconciler_after_posts() -> None:
@@ -1804,6 +1831,50 @@ def test_apply_prepared_evidence_posts_without_rerunning_reviewers(tmp_path) -> 
     assert posted == [("o/r", _prepared_body("claude")), ("o/r", _prepared_body("grok"))]
 
 
+def test_apply_prepared_evidence_refuses_timed_out_artifact(tmp_path) -> None:
+    outcome = CollectOutcome(
+        repo="o/r",
+        pr=1,
+        head_sha=HEAD,
+        head_committed_at=COMMITTED,
+        tier=0,
+        action="prepare",
+        action_reason="overall collect-evidence timeout after 0.05s; prepared evidence only",
+        items=[EvidenceItem("claude", _prepared_body("claude"), True, ["claude"], [], "pass")],
+        failures=[ReviewerResult("grok", "", False, "overall collect-evidence timeout")],
+        orchestration_timed_out=True,
+        timed_out_families=["grok"],
+    )
+    prepared = tmp_path / "timed_out_prepared.json"
+    prepared.write_text(json.dumps(outcome.to_dict()), encoding="utf-8")
+    posted: list[str] = []
+
+    applied = qe.apply_prepared_evidence(
+        repo="o/r",
+        pr=1,
+        prepared_json=prepared,
+        author="me",
+        apply=True,
+        families=["claude", "grok"],
+        context_fetcher=lambda r, p: {"head_sha": HEAD, "head_committed_at": COMMITTED},
+        tier_fetcher=lambda r, p: 0,
+        linter=lambda *a, **k: {
+            "would_count": True,
+            "counted_reviewer_ids": ["claude"],
+            "problems": [],
+        },
+        poster=lambda r, p, b: posted.append(b),
+    )
+
+    assert applied.action == "prepare"
+    assert applied.orchestration_timed_out is True
+    assert applied.timed_out_families == ["grok"]
+    assert "timed out" in applied.action_reason
+    assert applied.has_supportive_quorum is True
+    assert applied.posted == []
+    assert posted == []
+
+
 def test_collect_outcome_tiered_gate_roundtrips() -> None:
     # The gate regime an artifact was prepared under must survive serialization so
     # the settlement bar cannot silently change between prepare and apply (#8507 P1).
@@ -2254,6 +2325,37 @@ def test_run_collect_cli_exit_code_quorum_incomplete(monkeypatch) -> None:
     rc = qe.run_collect_cli(
         repo="o/r", pr=1, families=None, author=None, apply=False, json_output=False
     )
+    assert rc == 1
+
+
+def test_run_collect_cli_timeout_exit_code_fails_even_with_partial_quorum(monkeypatch) -> None:
+    def fake_collect(**kwargs) -> CollectOutcome:
+        return CollectOutcome(
+            repo="o/r",
+            pr=1,
+            head_sha=HEAD,
+            head_committed_at=COMMITTED,
+            tier=0,
+            action="prepare",
+            action_reason="overall collect-evidence timeout after 0.05s; prepared evidence only",
+            items=[EvidenceItem("claude", "body", True, ["claude"], [], "pass")],
+            failures=[ReviewerResult("grok", "", False, "overall collect-evidence timeout")],
+            orchestration_timed_out=True,
+            timed_out_families=["grok"],
+        )
+
+    monkeypatch.setattr(qe, "collect_evidence", fake_collect)
+    monkeypatch.setattr(qe, "resolve_author", lambda default="local": "me")
+
+    rc = qe.run_collect_cli(
+        repo="o/r",
+        pr=1,
+        families=["claude", "grok"],
+        author=None,
+        apply=True,
+        json_output=True,
+    )
+
     assert rc == 1
 
 

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import multiprocessing
 import os
 import subprocess
 import threading
@@ -35,6 +36,30 @@ from aragora.swarm.quorum_evidence import (
 
 HEAD = "49a979d587f910aaad4fb0f0bed708dd48c97c35"
 COMMITTED = "2026-06-04T09:57:49-05:00"
+
+
+def _nested_reviewer_child() -> None:
+    return
+
+
+def _process_spawning_reviewer_runner(family: str, prompt: str) -> ReviewerResult:
+    del prompt
+    ctx = multiprocessing.get_context("fork")
+    process = ctx.Process(target=_nested_reviewer_child)
+    process.start()
+    process.join(timeout=2.0)
+    if process.is_alive():
+        process.terminate()
+        process.join(timeout=1.0)
+        return ReviewerResult(family, "", False, "nested reviewer child timed out")
+    if process.exitcode != 0:
+        return ReviewerResult(
+            family,
+            "",
+            False,
+            f"nested reviewer child exited with code {process.exitcode}",
+        )
+    return ReviewerResult(family, f"Verdict: PASS from {family}", True)
 
 
 @pytest.fixture(autouse=True)
@@ -1195,6 +1220,27 @@ def test_collect_overall_timeout_process_path_runs_queued_reviewers(tmp_path, mo
     assert outcome.orchestration_timed_out is False
     assert calls_file.read_text(encoding="utf-8").splitlines() == ["claude", "grok", "openai"]
     assert [item.family for item in outcome.items] == ["claude", "grok", "openai"]
+    assert outcome.failures == []
+
+
+def test_collect_overall_timeout_process_path_allows_nested_reviewer_process() -> None:
+    if "fork" not in multiprocessing.get_all_start_methods():
+        pytest.skip("overall-timeout reviewer isolation requires fork")
+    fakes, _ = _fakes(tier=2)
+    fakes["reviewer_runner"] = _process_spawning_reviewer_runner
+
+    outcome = collect_evidence(
+        repo="o/r",
+        pr=1,
+        families=["openai", "grok"],
+        author="me",
+        apply=False,
+        overall_timeout=5.0,
+        **fakes,
+    )
+
+    assert outcome.orchestration_timed_out is False
+    assert [item.family for item in outcome.items] == ["openai", "grok"]
     assert outcome.failures == []
 
 

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -1115,6 +1115,89 @@ def test_collect_overall_timeout_terminates_slow_reviewer(tmp_path, monkeypatch)
     assert os.environ.get(qe._REVIEWER_TIMEOUT_ENV) is None
 
 
+def test_collect_overall_timeout_path_preserves_infra_retry(tmp_path, monkeypatch) -> None:
+    fakes, _ = _fakes(tier=0)
+    attempts_file = tmp_path / "attempts.txt"
+    monkeypatch.setenv(qe._REVIEWER_INFRA_RETRIES_ENV, "1")
+
+    def flaky_runner(family: str, prompt: str) -> ReviewerResult:
+        attempts = attempts_file.read_text(encoding="utf-8") if attempts_file.exists() else ""
+        attempts_file.write_text(attempts + family + "\n", encoding="utf-8")
+        if family == "grok" and "grok" not in attempts:
+            return ReviewerResult(family, "", False, "transient cli timeout")
+        return ReviewerResult(family, f"Verdict: PASS from {family}", True)
+
+    fakes["reviewer_runner"] = flaky_runner
+    outcome = collect_evidence(
+        repo="o/r",
+        pr=1,
+        families=["claude", "grok"],
+        author="me",
+        apply=False,
+        overall_timeout=5.0,
+        **fakes,
+    )
+
+    assert outcome.orchestration_timed_out is False
+    assert [item.family for item in outcome.items] == ["claude", "grok"]
+    assert attempts_file.read_text(encoding="utf-8").count("grok\n") == 2
+
+
+def test_collect_overall_timeout_fails_closed_without_fork(monkeypatch) -> None:
+    fakes, _ = _fakes(tier=0)
+    called: list[str] = []
+    monkeypatch.setattr(qe.multiprocessing, "get_all_start_methods", lambda: ["spawn"])
+
+    def reviewer_runner(family: str, prompt: str) -> ReviewerResult:
+        called.append(family)
+        return ReviewerResult(family, f"Verdict: PASS from {family}", True)
+
+    fakes["reviewer_runner"] = reviewer_runner
+    outcome = collect_evidence(
+        repo="o/r",
+        pr=1,
+        families=["claude", "grok"],
+        author="me",
+        apply=False,
+        overall_timeout=5.0,
+        **fakes,
+    )
+
+    assert called == []
+    assert outcome.orchestration_timed_out is True
+    assert outcome.timed_out_families == ["claude", "grok"]
+    assert outcome.items == []
+    assert [failure.family for failure in outcome.failures] == ["claude", "grok"]
+    assert all("fork-capable runtime" in failure.error for failure in outcome.failures)
+
+
+def test_collect_overall_timeout_process_path_runs_queued_reviewers(tmp_path, monkeypatch) -> None:
+    fakes, _ = _fakes(tier=2)
+    calls_file = tmp_path / "calls.txt"
+    monkeypatch.setattr(qe, "_MAX_REVIEWER_WORKERS", 1)
+
+    def reviewer_runner(family: str, prompt: str) -> ReviewerResult:
+        previous = calls_file.read_text(encoding="utf-8") if calls_file.exists() else ""
+        calls_file.write_text(previous + family + "\n", encoding="utf-8")
+        return ReviewerResult(family, f"Verdict: PASS from {family}", True)
+
+    fakes["reviewer_runner"] = reviewer_runner
+    outcome = collect_evidence(
+        repo="o/r",
+        pr=1,
+        families=["claude", "grok", "openai"],
+        author="me",
+        apply=False,
+        overall_timeout=5.0,
+        **fakes,
+    )
+
+    assert outcome.orchestration_timed_out is False
+    assert calls_file.read_text(encoding="utf-8").splitlines() == ["claude", "grok", "openai"]
+    assert [item.family for item in outcome.items] == ["claude", "grok", "openai"]
+    assert outcome.failures == []
+
+
 def test_collect_low_tier_apply_triggers_same_pr_quorum_reconciler_after_posts() -> None:
     fakes, posted = _fakes(tier=1)
     calls: list[tuple[str, int, int]] = []


### PR DESCRIPTION
## Summary
- add --reviewer-timeout and --overall-timeout to review-queue collect-evidence and the script wrapper
- fail closed with JSON timeout diagnostics instead of hanging around reviewer futures
- prevent partial quorum posting when overall reviewer orchestration times out

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 timeout 240 /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/swarm/test_quorum_evidence.py tests/cli/commands/test_review_queue.py -q
- timeout 240 pre-commit run --files scripts/collect_quorum_evidence.py aragora/swarm/quorum_evidence.py aragora/cli/commands/review_queue.py aragora/cli/parser.py tests/swarm/test_quorum_evidence.py tests/cli/commands/test_review_queue.py

Draft only; do not merge in this cycle.