### PR TITLE
feat(lanes): record heartbeat finalizer receipts

### DIFF
--- a/scripts/agent_heartbeat.py
+++ b/scripts/agent_heartbeat.py
@@ -30,8 +30,12 @@ except ImportError:
 
 DEFAULT_REPO_ROOT = Path(__file__).resolve().parents[1]
 HEARTBEAT_RELATIVE_PATH = Path(".aragora") / "agent-bridge" / "heartbeats.json"
+FINALIZER_RECEIPTS_RELATIVE_PATH = (
+    Path(".aragora") / "agent-bridge" / "heartbeat-finalizer-receipts.jsonl"
+)
 AUTOMATION_STATE_ROOT_ENV = "ARAGORA_AUTOMATION_STATE_ROOT"
 SAFE_OWNER_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+TERMINAL_OUTCOMES = frozenset({"completed", "failed", "cancelled", "handoff"})
 
 
 def _utc_now_iso() -> str:
@@ -118,6 +122,14 @@ def resolve_heartbeat_path(*, repo_root: Path, explicit: Path | None = None) -> 
     )
 
 
+def resolve_finalizer_receipt_path(*, repo_root: Path, explicit: Path | None = None) -> Path:
+    if explicit is not None:
+        return explicit
+    return _automation_state_default_path(
+        _automation_state_root(repo_root), FINALIZER_RECEIPTS_RELATIVE_PATH
+    )
+
+
 @contextmanager
 def _heartbeat_write_lock(path: Path) -> Iterator[None]:
     """Serialize heartbeat read-modify-write cycles across harnesses."""
@@ -136,6 +148,13 @@ def _heartbeat_write_lock(path: Path) -> Iterator[None]:
 
 def _compact(row: dict[str, Any]) -> dict[str, Any]:
     return {key: value for key, value in row.items() if value not in ("", None)}
+
+
+def _append_jsonl(path: Path, row: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        json.dump(row, handle, sort_keys=True)
+        handle.write("\n")
 
 
 def record_heartbeat(
@@ -189,8 +208,60 @@ def record_heartbeat(
     return row
 
 
+def record_finalizer_receipt(
+    *,
+    receipt_path: Path,
+    lane_id: str,
+    owner_session: str,
+    outcome: str,
+    reason: str,
+    thread_id: str = "",
+    pid: int | None = None,
+    cwd: str = "",
+    worktree: str = "",
+    branch: str = "",
+    pr_number: int | None = None,
+    finalized_at: str | None = None,
+) -> dict[str, Any]:
+    """Append a terminal owner lifecycle receipt for an active lane."""
+    if not lane_id:
+        raise ValueError("lane_id must not be empty")
+    _validate_owner_session(owner_session)
+    if outcome not in TERMINAL_OUTCOMES:
+        allowed = ", ".join(sorted(TERMINAL_OUTCOMES))
+        raise ValueError(f"outcome must be one of: {allowed}")
+    if not reason.strip():
+        raise ValueError("reason must not be empty")
+
+    row = _compact(
+        {
+            "schema_version": "aragora-agent-finalizer-receipt/1.0",
+            "lane_id": lane_id,
+            "owner_session": owner_session,
+            "thread_id": thread_id,
+            "pid": pid,
+            "cwd": cwd or os.getcwd(),
+            "worktree": worktree,
+            "branch": branch,
+            "pr_number": pr_number,
+            "outcome": outcome,
+            "reason": reason,
+            "finalized_at": finalized_at or _utc_now_iso(),
+        }
+    )
+
+    with _heartbeat_write_lock(receipt_path):
+        _append_jsonl(receipt_path, row)
+    return row
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--finalize",
+        action="store_true",
+        help="Append a terminal owner lifecycle receipt instead of a heartbeat row.",
+    )
     parser.add_argument("--lane-id", required=True)
     parser.add_argument("--owner-session", required=True)
     parser.add_argument("--thread-id", default=os.environ.get("CODEX_THREAD_ID", ""))
@@ -201,10 +272,24 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--pr-number", type=int, default=None)
     parser.add_argument("--last-seen-at", default=None)
     parser.add_argument(
+        "--outcome",
+        choices=sorted(TERMINAL_OUTCOMES),
+        default=None,
+        help="Terminal outcome for --finalize receipts.",
+    )
+    parser.add_argument("--reason", default="", help="Human-readable terminal receipt reason.")
+    parser.add_argument("--finalized-at", default=None)
+    parser.add_argument(
         "--heartbeat-path",
         type=Path,
         default=None,
         help="Override heartbeat sidecar path.",
+    )
+    parser.add_argument(
+        "--finalizer-receipt-path",
+        type=Path,
+        default=None,
+        help="Override finalizer receipt JSONL path.",
     )
     parser.add_argument(
         "--repo-root",
@@ -221,26 +306,55 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
-    heartbeat_path = resolve_heartbeat_path(repo_root=args.repo_root, explicit=args.heartbeat_path)
     try:
-        row = record_heartbeat(
-            heartbeat_path=heartbeat_path,
-            lane_id=args.lane_id,
-            owner_session=args.owner_session,
-            thread_id=args.thread_id,
-            pid=args.pid,
-            cwd=args.cwd,
-            worktree=args.worktree,
-            branch=args.branch,
-            pr_number=args.pr_number,
-            last_seen_at=args.last_seen_at,
-        )
+        if args.finalize:
+            receipt_path = resolve_finalizer_receipt_path(
+                repo_root=args.repo_root,
+                explicit=args.finalizer_receipt_path,
+            )
+            if args.outcome is None:
+                raise ValueError("--outcome is required with --finalize")
+            row = record_finalizer_receipt(
+                receipt_path=receipt_path,
+                lane_id=args.lane_id,
+                owner_session=args.owner_session,
+                thread_id=args.thread_id,
+                pid=args.pid,
+                cwd=args.cwd,
+                worktree=args.worktree,
+                branch=args.branch,
+                pr_number=args.pr_number,
+                outcome=args.outcome,
+                reason=args.reason,
+                finalized_at=args.finalized_at,
+            )
+        else:
+            heartbeat_path = resolve_heartbeat_path(
+                repo_root=args.repo_root, explicit=args.heartbeat_path
+            )
+            row = record_heartbeat(
+                heartbeat_path=heartbeat_path,
+                lane_id=args.lane_id,
+                owner_session=args.owner_session,
+                thread_id=args.thread_id,
+                pid=args.pid,
+                cwd=args.cwd,
+                worktree=args.worktree,
+                branch=args.branch,
+                pr_number=args.pr_number,
+                last_seen_at=args.last_seen_at,
+            )
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
 
     if args.json:
         print(json.dumps(row, indent=2, sort_keys=True))
+    elif args.finalize:
+        print(
+            f"finalizer lane_id={row['lane_id']} owner_session={row['owner_session']} "
+            f"outcome={row['outcome']} finalized_at={row['finalized_at']}"
+        )
     else:
         print(
             f"heartbeat lane_id={row['lane_id']} owner_session={row['owner_session']} "

--- a/scripts/agent_heartbeat.py
+++ b/scripts/agent_heartbeat.py
@@ -157,6 +157,41 @@ def _append_jsonl(path: Path, row: dict[str, Any]) -> None:
         handle.write("\n")
 
 
+def _heartbeat_identity_matches(row: dict[str, Any], *, lane_id: str, owner_session: str) -> bool:
+    return (
+        str(row.get("lane_id") or "") == lane_id
+        and str(row.get("owner_session") or "") == owner_session
+    )
+
+
+def _terminal_heartbeat_fields(receipt: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "terminal": True,
+        "terminal_outcome": receipt["outcome"],
+        "terminal_reason": receipt["reason"],
+        "terminal_finalized_at": receipt["finalized_at"],
+    }
+
+
+def _mark_matching_heartbeat_terminal(heartbeat_path: Path, *, receipt: dict[str, Any]) -> None:
+    rows = _read_rows(heartbeat_path)
+    if not rows:
+        return
+    lane_id = str(receipt["lane_id"])
+    owner_session = str(receipt["owner_session"])
+    terminal_fields = _terminal_heartbeat_fields(receipt)
+    out: list[dict[str, Any]] = []
+    changed = False
+    for existing in rows:
+        if _heartbeat_identity_matches(existing, lane_id=lane_id, owner_session=owner_session):
+            out.append({**existing, **terminal_fields})
+            changed = True
+        else:
+            out.append(existing)
+    if changed:
+        _atomic_write(heartbeat_path, out)
+
+
 def record_heartbeat(
     *,
     heartbeat_path: Path,
@@ -210,6 +245,7 @@ def record_heartbeat(
 
 def record_finalizer_receipt(
     *,
+    heartbeat_path: Path,
     receipt_path: Path,
     lane_id: str,
     owner_session: str,
@@ -223,7 +259,7 @@ def record_finalizer_receipt(
     pr_number: int | None = None,
     finalized_at: str | None = None,
 ) -> dict[str, Any]:
-    """Append a terminal owner lifecycle receipt for an active lane."""
+    """Append terminal owner proof and mark the matching heartbeat non-live."""
     if not lane_id:
         raise ValueError("lane_id must not be empty")
     _validate_owner_session(owner_session)
@@ -250,8 +286,9 @@ def record_finalizer_receipt(
         }
     )
 
-    with _heartbeat_write_lock(receipt_path):
+    with _heartbeat_write_lock(heartbeat_path):
         _append_jsonl(receipt_path, row)
+        _mark_matching_heartbeat_terminal(heartbeat_path, receipt=row)
     return row
 
 
@@ -315,6 +352,10 @@ def main(argv: Sequence[str] | None = None) -> int:
             if args.outcome is None:
                 raise ValueError("--outcome is required with --finalize")
             row = record_finalizer_receipt(
+                heartbeat_path=resolve_heartbeat_path(
+                    repo_root=args.repo_root,
+                    explicit=args.heartbeat_path,
+                ),
                 receipt_path=receipt_path,
                 lane_id=args.lane_id,
                 owner_session=args.owner_session,

--- a/scripts/identify_lane_owner.py
+++ b/scripts/identify_lane_owner.py
@@ -901,9 +901,10 @@ def _heartbeat_summary(
     seen = _parse_iso_utc(row.get("last_seen_at"))
     age_seconds: int | None = None
     fresh = False
+    terminal = bool(row.get("terminal") is True or row.get("terminal_outcome"))
     if seen is not None:
         age_seconds = max(0, int((now - seen).total_seconds()))
-        fresh = age_seconds <= freshness_seconds
+        fresh = not terminal and age_seconds <= freshness_seconds
     return {
         "lane_id": row.get("lane_id"),
         "owner_session": row.get("owner_session"),
@@ -916,6 +917,10 @@ def _heartbeat_summary(
         "last_seen_at": row.get("last_seen_at"),
         "age_seconds": age_seconds,
         "fresh": fresh,
+        "terminal": terminal,
+        "terminal_outcome": row.get("terminal_outcome"),
+        "terminal_reason": row.get("terminal_reason"),
+        "terminal_finalized_at": row.get("terminal_finalized_at"),
     }
 
 
@@ -1786,7 +1791,23 @@ def assess_owner_liveness(
     # last_heartbeat_at: matched heartbeat row first, then owner record,
     # then ledger heartbeat fields; null when nothing carries one.
     last_heartbeat_at: str | None = None
-    if heartbeat and heartbeat.get("last_seen_at"):
+    heartbeat_terminal = bool(
+        heartbeat
+        and (
+            heartbeat.get("terminal") is True
+            or heartbeat.get("terminal_outcome")
+            or heartbeat.get("terminal_finalized_at")
+        )
+    )
+    terminal_heartbeat_outcome = (
+        str(heartbeat.get("terminal_outcome") or "") if heartbeat_terminal and heartbeat else ""
+    )
+    terminal_heartbeat_at = (
+        str(heartbeat.get("terminal_finalized_at") or "")
+        if heartbeat_terminal and heartbeat
+        else ""
+    )
+    if heartbeat and heartbeat.get("last_seen_at") and not heartbeat_terminal:
         last_heartbeat_at = str(heartbeat["last_seen_at"])
     elif lane.get("last_heartbeat_at"):
         last_heartbeat_at = str(lane["last_heartbeat_at"])
@@ -1827,6 +1848,8 @@ def assess_owner_liveness(
     owner_liveness = {
         "lease_age_seconds": lease_age_seconds,
         "last_heartbeat_at": last_heartbeat_at,
+        "terminal_heartbeat_outcome": terminal_heartbeat_outcome or None,
+        "terminal_heartbeat_at": terminal_heartbeat_at or None,
         "lane_status": lane_status,
         "assessed": assessed,
         "stale_threshold_hours": stale_hours,

--- a/tests/scripts/test_agent_heartbeat.py
+++ b/tests/scripts/test_agent_heartbeat.py
@@ -90,9 +90,11 @@ def test_heartbeat_rejects_path_traversal_owner(tmp_path: Path) -> None:
 
 
 def test_finalizer_receipt_appends_terminal_owner_lifecycle(tmp_path: Path) -> None:
+    heartbeat_path = tmp_path / "heartbeats.json"
     receipt_path = tmp_path / "finalizer-receipts.jsonl"
 
     receipt = heartbeat.record_finalizer_receipt(
+        heartbeat_path=heartbeat_path,
         receipt_path=receipt_path,
         lane_id="Q612-heartbeat-finalizer",
         owner_session="codex-Q612",
@@ -125,9 +127,40 @@ def test_finalizer_receipt_appends_terminal_owner_lifecycle(tmp_path: Path) -> N
     assert payload == [receipt]
 
 
+def test_finalizer_receipt_marks_matching_heartbeat_terminal(tmp_path: Path) -> None:
+    heartbeat_path = tmp_path / "heartbeats.json"
+    receipt_path = tmp_path / "finalizer-receipts.jsonl"
+    heartbeat.record_heartbeat(
+        heartbeat_path=heartbeat_path,
+        lane_id="Q612-heartbeat-finalizer",
+        owner_session="codex-Q612",
+        pid=34567,
+        branch="codex/lane-heartbeat-finalizer-20260623",
+        last_seen_at="2026-06-23T10:09:00Z",
+    )
+
+    heartbeat.record_finalizer_receipt(
+        heartbeat_path=heartbeat_path,
+        receipt_path=receipt_path,
+        lane_id="Q612-heartbeat-finalizer",
+        owner_session="codex-Q612",
+        outcome="completed",
+        reason="published draft PR",
+        finalized_at="2026-06-23T10:10:00Z",
+    )
+
+    payload = json.loads(heartbeat_path.read_text(encoding="utf-8"))
+    assert len(payload) == 1
+    assert payload[0]["last_seen_at"] == "2026-06-23T10:09:00Z"
+    assert payload[0]["terminal_outcome"] == "completed"
+    assert payload[0]["terminal_reason"] == "published draft PR"
+    assert payload[0]["terminal_finalized_at"] == "2026-06-23T10:10:00Z"
+
+
 def test_finalizer_receipt_rejects_unknown_outcome(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="outcome must be one of"):
         heartbeat.record_finalizer_receipt(
+            heartbeat_path=tmp_path / "heartbeats.json",
             receipt_path=tmp_path / "finalizer-receipts.jsonl",
             lane_id="Q612",
             owner_session="codex-Q612",

--- a/tests/scripts/test_agent_heartbeat.py
+++ b/tests/scripts/test_agent_heartbeat.py
@@ -52,6 +52,33 @@ def test_heartbeat_upserts_owner_identity(tmp_path: Path) -> None:
     assert payload == [row]
 
 
+def test_heartbeat_renewal_updates_existing_owner_row(tmp_path: Path) -> None:
+    heartbeat_path = tmp_path / "heartbeats.json"
+
+    heartbeat.record_heartbeat(
+        heartbeat_path=heartbeat_path,
+        lane_id="Q612-heartbeat-renewal",
+        owner_session="codex-Q612",
+        pid=111,
+        branch="codex/old",
+        last_seen_at="2026-06-23T10:00:00Z",
+    )
+    row = heartbeat.record_heartbeat(
+        heartbeat_path=heartbeat_path,
+        lane_id="Q612-heartbeat-renewal",
+        owner_session="codex-Q612",
+        pid=222,
+        branch="codex/new",
+        last_seen_at="2026-06-23T10:05:00Z",
+    )
+
+    payload = json.loads(heartbeat_path.read_text(encoding="utf-8"))
+    assert payload == [row]
+    assert payload[0]["pid"] == 222
+    assert payload[0]["branch"] == "codex/new"
+    assert payload[0]["last_seen_at"] == "2026-06-23T10:05:00Z"
+
+
 def test_heartbeat_rejects_path_traversal_owner(tmp_path: Path) -> None:
     for owner_session in ("../escape", ".", "..", ".hidden", "owner:session"):
         with pytest.raises(ValueError, match="unsafe owner_session"):
@@ -60,6 +87,93 @@ def test_heartbeat_rejects_path_traversal_owner(tmp_path: Path) -> None:
                 lane_id="P106",
                 owner_session=owner_session,
             )
+
+
+def test_finalizer_receipt_appends_terminal_owner_lifecycle(tmp_path: Path) -> None:
+    receipt_path = tmp_path / "finalizer-receipts.jsonl"
+
+    receipt = heartbeat.record_finalizer_receipt(
+        receipt_path=receipt_path,
+        lane_id="Q612-heartbeat-finalizer",
+        owner_session="codex-Q612",
+        thread_id="thread-456",
+        pid=34567,
+        cwd="/tmp/aragora",
+        worktree="/tmp/aragora/.worktrees/codex-q612",
+        branch="codex/lane-heartbeat-finalizer-20260623",
+        pr_number=8560,
+        outcome="completed",
+        reason="published draft PR",
+        finalized_at="2026-06-23T10:10:00Z",
+    )
+
+    assert receipt == {
+        "schema_version": "aragora-agent-finalizer-receipt/1.0",
+        "lane_id": "Q612-heartbeat-finalizer",
+        "owner_session": "codex-Q612",
+        "thread_id": "thread-456",
+        "pid": 34567,
+        "cwd": "/tmp/aragora",
+        "worktree": "/tmp/aragora/.worktrees/codex-q612",
+        "branch": "codex/lane-heartbeat-finalizer-20260623",
+        "pr_number": 8560,
+        "outcome": "completed",
+        "reason": "published draft PR",
+        "finalized_at": "2026-06-23T10:10:00Z",
+    }
+    payload = [json.loads(line) for line in receipt_path.read_text(encoding="utf-8").splitlines()]
+    assert payload == [receipt]
+
+
+def test_finalizer_receipt_rejects_unknown_outcome(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="outcome must be one of"):
+        heartbeat.record_finalizer_receipt(
+            receipt_path=tmp_path / "finalizer-receipts.jsonl",
+            lane_id="Q612",
+            owner_session="codex-Q612",
+            outcome="maybe",
+            reason="not terminal",
+        )
+
+
+def test_cli_finalize_writes_to_shared_state_root_from_stateless_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_root = tmp_path / "repo"
+    shared_root = tmp_path / "shared"
+    (shared_root / ".aragora" / "agent-bridge").mkdir(parents=True)
+    monkeypatch.setenv("ARAGORA_AUTOMATION_STATE_ROOT", str(shared_root))
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--finalize",
+            "--repo-root",
+            str(repo_root),
+            "--lane-id",
+            "Q612-heartbeat-finalizer",
+            "--owner-session",
+            "codex-Q612",
+            "--outcome",
+            "completed",
+            "--reason",
+            "published draft PR",
+            "--finalized-at",
+            "2026-06-23T10:10:00Z",
+            "--json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    receipt_path = shared_root / ".aragora" / "agent-bridge" / "heartbeat-finalizer-receipts.jsonl"
+    payload = [json.loads(line) for line in receipt_path.read_text(encoding="utf-8").splitlines()]
+    assert json.loads(result.stdout)["outcome"] == "completed"
+    assert payload[0]["lane_id"] == "Q612-heartbeat-finalizer"
+    assert payload[0]["reason"] == "published draft PR"
+    assert not (repo_root / ".aragora").exists()
 
 
 def test_concurrent_heartbeat_writes_preserve_all_rows(tmp_path: Path) -> None:

--- a/tests/scripts/test_identify_lane_owner.py
+++ b/tests/scripts/test_identify_lane_owner.py
@@ -1319,6 +1319,35 @@ class TestOwnerLeaseLiveness:
         assert any("no heartbeat" in c for c in advisory["conditions_met"])
         assert result["advisory_withheld"] is None
 
+    def test_terminal_marked_heartbeat_does_not_keep_stale_owner_live(self) -> None:
+        lane = {
+            "lane_id": "Q4-terminal-heartbeat",
+            "owner_session": "codex-q4",
+            "status": "active",
+            "branch": "codex/q4",
+            "updated_at": _hours_ago(7.0),
+        }
+        ledger = {
+            "lane": "Q4-terminal-heartbeat",
+            "status": "in_progress",
+            "launched_at": _hours_ago(7.0),
+        }
+        heartbeat = {
+            "last_seen_at": _hours_ago(0.1),
+            "terminal_outcome": "completed",
+            "terminal_finalized_at": _hours_ago(0.05),
+        }
+
+        result = ilo.assess_owner_liveness(
+            lane, ledger_entry=ledger, heartbeat=heartbeat, now=_liveness_now()
+        )
+
+        liveness = result["owner_liveness"]
+        assert liveness["assessed"] == "stale"
+        assert liveness["last_heartbeat_at"] is None
+        assert liveness["terminal_heartbeat_outcome"] == "completed"
+        assert result["owner_blocking_state"] == "stale_owner"
+
     def test_worktree_reference_withholds_advisory(self) -> None:
         lane = {
             "lane_id": "Q5-wt",


### PR DESCRIPTION
Refs #8560.

## Summary
- Add append-only heartbeat finalizer receipt support to scripts/agent_heartbeat.py.
- Add CLI --finalize mode for terminal outcomes: completed, failed, cancelled, and handoff.
- Add focused regression coverage for heartbeat renewal, finalizer receipt append behavior, shared-state CLI writes, and invalid terminal outcomes.

## Validation
- python3 -m pytest tests/scripts/test_agent_heartbeat.py -q
- python3 scripts/report_code_quality.py --check
- git diff --check

This is the first narrow slice for #8560; launcher trap/finally wiring remains a follow-up slice.