### PR TITLE
fix(lanes): suppress finalized heartbeat fallback freshness

### DIFF
--- a/scripts/identify_lane_owner.py
+++ b/scripts/identify_lane_owner.py
@@ -1807,7 +1807,9 @@ def assess_owner_liveness(
         if heartbeat_terminal and heartbeat
         else ""
     )
-    if heartbeat and heartbeat.get("last_seen_at") and not heartbeat_terminal:
+    if heartbeat_terminal:
+        last_heartbeat_at = None
+    elif heartbeat and heartbeat.get("last_seen_at"):
         last_heartbeat_at = str(heartbeat["last_seen_at"])
     elif lane.get("last_heartbeat_at"):
         last_heartbeat_at = str(lane["last_heartbeat_at"])
@@ -1820,11 +1822,24 @@ def assess_owner_liveness(
     # Lease anchor: the most recent timestamp across the owner record,
     # the matched heartbeat, and the ledger entry. Conservative — any
     # recent signal keeps the owner "live".
-    candidates = [_updated_at_timestamp(lane.get(key)) for key in _OWNER_RECORD_TIMESTAMP_KEYS]
+    owner_timestamp_keys = _OWNER_RECORD_TIMESTAMP_KEYS
+    ledger_timestamp_keys = _LEDGER_TIMESTAMP_KEYS
+    if heartbeat_terminal:
+        owner_timestamp_keys = tuple(
+            key for key in _OWNER_RECORD_TIMESTAMP_KEYS if key != "last_heartbeat_at"
+        )
+        ledger_timestamp_keys = tuple(
+            key
+            for key in _LEDGER_TIMESTAMP_KEYS
+            if key not in {"heartbeat_at", "last_heartbeat_at"}
+        )
+    candidates = [_updated_at_timestamp(lane.get(key)) for key in owner_timestamp_keys]
     if last_heartbeat_at:
         candidates.append(_updated_at_timestamp(last_heartbeat_at))
     if ledger_entry is not None:
-        candidates.append(_ledger_entry_timestamp(ledger_entry))
+        candidates.append(
+            max(_updated_at_timestamp(ledger_entry.get(key)) for key in ledger_timestamp_keys)
+        )
     anchor_ts = max(candidates)
 
     lease_age_seconds: int | None = None

--- a/tests/scripts/test_identify_lane_owner.py
+++ b/tests/scripts/test_identify_lane_owner.py
@@ -1326,11 +1326,13 @@ class TestOwnerLeaseLiveness:
             "status": "active",
             "branch": "codex/q4",
             "updated_at": _hours_ago(7.0),
+            "last_heartbeat_at": _hours_ago(0.1),
         }
         ledger = {
             "lane": "Q4-terminal-heartbeat",
             "status": "in_progress",
             "launched_at": _hours_ago(7.0),
+            "last_heartbeat_at": _hours_ago(0.1),
         }
         heartbeat = {
             "last_seen_at": _hours_ago(0.1),


### PR DESCRIPTION
Refs #8560.

## Summary
- Prevent terminal-marked heartbeat rows from falling back to copied lane/ledger heartbeat timestamps.
- Keep terminal finalized owners from being assessed live through stale duplicated heartbeat metadata.
- Add a focused regression for fresh lane and ledger heartbeat fallbacks alongside a terminal heartbeat row.

## Validation
- python3 -m pytest tests/scripts/test_agent_heartbeat.py tests/scripts/test_identify_lane_owner.py -q
- python3 scripts/report_code_quality.py --check
- git diff --check

Follow-up to #8576; this contains only the post-merge liveness repair.