### PR TITLE
fix(lanes): guard stale-owner reconciliation

### DIFF
--- a/scripts/resolve_lane_conflicts.py
+++ b/scripts/resolve_lane_conflicts.py
@@ -266,36 +266,6 @@ def _safe_steering_inbox(owner_session: str, *, steering_inbox_root: Path) -> Pa
     return inbox
 
 
-def _message_key(path: Path) -> tuple[str, str]:
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        data = {}
-    if not isinstance(data, dict):
-        data = {}
-    return (path.name, str(data.get("message_sha256") or ""))
-
-
-def _read_receipt_keys(inbox: Path) -> set[tuple[str, str]]:
-    receipt_dir = inbox / "_read_receipts"
-    if not receipt_dir.is_dir():
-        return set()
-    keys: set[tuple[str, str]] = set()
-    for receipt_path in receipt_dir.glob("*.json"):
-        if not receipt_path.is_file():
-            continue
-        try:
-            data = json.loads(receipt_path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            continue
-        if not isinstance(data, dict):
-            continue
-        message_filename = str(data.get("message_filename") or "")
-        if message_filename:
-            keys.add((message_filename, str(data.get("message_sha256") or "")))
-    return keys
-
-
 def _pending_mailbox_messages(
     owner_session: str, *, steering_inbox_root: Path
 ) -> tuple[list[str], str | None]:
@@ -304,14 +274,9 @@ def _pending_mailbox_messages(
         return [], "invalid_owner_session"
     if not inbox.is_dir():
         return [], None
-    read_keys = _read_receipt_keys(inbox)
-    pending: list[str] = []
-    for path in sorted(
-        (path for path in inbox.glob("*.json") if path.is_file()), key=lambda p: p.name
-    ):
-        if _message_key(path) not in read_keys:
-            pending.append(path.name)
-    return pending, None
+    # Read receipts are proof-of-read/outcome only; they are not an ack/move protocol.
+    # A top-level message file remains pending until a future explicit ack path moves it.
+    return sorted(path.name for path in inbox.glob("*.json") if path.is_file()), None
 
 
 def _atomic_write(path: Path, rows: list[dict[str, Any]]) -> None:

--- a/scripts/resolve_lane_conflicts.py
+++ b/scripts/resolve_lane_conflicts.py
@@ -126,6 +126,22 @@ def _read_rows(path: Path) -> list[dict[str, Any]]:
     return [row for row in payload if isinstance(row, dict)]
 
 
+def _read_rows_checked(path: Path) -> tuple[list[dict[str, Any]], str | None]:
+    if not path.exists():
+        return [], None
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [], f"read_failed:{type(exc).__name__}:{exc}"
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        return [], f"invalid_json:{exc.msg}"
+    if not isinstance(payload, list):
+        return [], "invalid_shape:not_list"
+    return [row for row in payload if isinstance(row, dict)], None
+
+
 def _parse_timestamp(value: Any) -> float | None:
     text = str(value or "").strip()
     if not text:
@@ -461,6 +477,7 @@ def _annotate_terminal_safety(
     findings: list[dict[str, Any]],
     *,
     heartbeats: list[dict[str, Any]],
+    heartbeat_load_error: str | None = None,
     steering_inbox_root: Path,
     now_ts: float,
     heartbeat_fresh_seconds: int,
@@ -492,6 +509,10 @@ def _annotate_terminal_safety(
         if fresh_heartbeats:
             blockers.append("fresh_heartbeat")
             details["fresh_heartbeat_timestamps"] = fresh_heartbeats
+
+        if heartbeat_load_error:
+            blockers.append("heartbeat_state_untrusted")
+            details["heartbeat_read_error"] = heartbeat_load_error
 
         pending_messages = _pending_mailbox_messages(
             owner_session,
@@ -584,12 +605,18 @@ def _operator_apply_command(
     registry_path: Path,
     receipt_dir: Path,
     expected_merge_commit: str,
+    heartbeat_path: Path,
+    steering_inbox_root: Path,
+    heartbeat_fresh_seconds: int,
 ) -> str:
     commit_arg = expected_merge_commit or "<merge-commit-sha>"
     return (
         "python3 scripts/resolve_lane_conflicts.py --merged-pr-lane-audit "
         f"--pr {pr} --expected-merge-commit {commit_arg} --operator-authorized "
-        f"--registry-path {registry_path} --receipt-dir {receipt_dir} --apply --json"
+        f"--registry-path {registry_path} --receipt-dir {receipt_dir} "
+        f"--heartbeat-path {_quote_shell_arg(heartbeat_path)} "
+        f"--steering-inbox-root {_quote_shell_arg(steering_inbox_root)} "
+        f"--heartbeat-fresh-seconds {heartbeat_fresh_seconds} --apply --json"
     )
 
 
@@ -604,6 +631,9 @@ def _base_merged_pr_audit_result(
     github_state: dict[str, Any],
     findings: list[dict[str, Any]],
     blocked_reason: str | None,
+    heartbeat_path: Path,
+    steering_inbox_root: Path,
+    heartbeat_fresh_seconds: int,
 ) -> dict[str, Any]:
     merge_commit = str(github_state.get("mergeCommit") or "")
     expected = str(expected_merge_commit or "")
@@ -642,6 +672,9 @@ def _base_merged_pr_audit_result(
             registry_path=registry_path,
             receipt_dir=receipt_dir,
             expected_merge_commit=merge_commit or expected,
+            heartbeat_path=heartbeat_path,
+            steering_inbox_root=steering_inbox_root,
+            heartbeat_fresh_seconds=heartbeat_fresh_seconds,
         ),
         "requires_operator_authorization": True,
         "operator_authorized": operator_authorized,
@@ -709,12 +742,13 @@ def audit_merged_pr_lanes(
     github_state = _fetch_pr_state(pr=pr, gh_bin=gh_bin)
     with _registry_write_lock(registry_path):
         rows = _read_rows(registry_path)
-        heartbeats = _read_rows(heartbeat_path)
+        heartbeats, heartbeat_load_error = _read_rows_checked(heartbeat_path)
         findings: list[dict[str, Any]] = []
         if github_state.get("available") is True and github_state.get("state") == "MERGED":
             findings = _annotate_terminal_safety(
                 _active_pr_lane_findings(rows, pr=pr),
                 heartbeats=heartbeats,
+                heartbeat_load_error=heartbeat_load_error,
                 steering_inbox_root=steering_inbox_root,
                 now_ts=now_ts,
                 heartbeat_fresh_seconds=heartbeat_fresh_seconds,
@@ -736,6 +770,9 @@ def audit_merged_pr_lanes(
             github_state=github_state,
             findings=findings,
             blocked_reason=blocked_reason,
+            heartbeat_path=heartbeat_path,
+            steering_inbox_root=steering_inbox_root,
+            heartbeat_fresh_seconds=heartbeat_fresh_seconds,
         )
         if not result["apply_eligible"]:
             return result

--- a/scripts/resolve_lane_conflicts.py
+++ b/scripts/resolve_lane_conflicts.py
@@ -33,6 +33,9 @@ REGISTRY_RELATIVE_PATH = Path(".aragora") / "agent-bridge" / "lanes.json"
 RECEIPT_RELATIVE_DIR = Path(".aragora") / "agent-bridge" / "conflict-resolution-receipts"
 RECEIPT_SCHEMA_VERSION = "aragora-lane-conflict-resolution/1.0"
 MERGED_PR_RECEIPT_SCHEMA_VERSION = "aragora-merged-pr-lane-audit/1.0"
+HEARTBEAT_RELATIVE_PATH = Path(".aragora") / "agent-bridge" / "heartbeats.json"
+STEERING_INBOX_RELATIVE_DIR = Path(".aragora") / "operator-steering"
+HEARTBEAT_FRESH_SECONDS = 15 * 60
 ACTIVE_STATUSES = {
     "active",
     "running",
@@ -45,6 +48,9 @@ ACTIVE_STATUSES = {
     "blocked",
 }
 INACTIVE_OWNER_STATUSES = {"released", "completed", "superseded"}
+HEARTBEAT_TIMESTAMP_KEYS = ("last_heartbeat_at", "last_seen_at", "heartbeat_at")
+PID_KEYS = ("pid", "owner_pid")
+LOCAL_WORK_KEYS = ("worktree", "local_worktree", "local_work_path")
 
 
 def _canonical_repo_root(path: Path = DEFAULT_REPO_ROOT) -> Path:
@@ -88,6 +94,22 @@ def _default_receipt_dir() -> Path:
     return _automation_state_root() / "agent-bridge" / "conflict-resolution-receipts"
 
 
+def _default_heartbeat_path() -> Path:
+    root = _automation_state_root()
+    if root.name == ".aragora":
+        return root.joinpath(*HEARTBEAT_RELATIVE_PATH.parts[1:])
+    return root / HEARTBEAT_RELATIVE_PATH
+
+
+def _default_steering_inbox_root() -> Path:
+    root = _automation_state_root()
+    return (
+        root.joinpath(*STEERING_INBOX_RELATIVE_DIR.parts[1:])
+        if root.name == ".aragora"
+        else root / STEERING_INBOX_RELATIVE_DIR
+    )
+
+
 def _utc_now_iso() -> str:
     return dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
@@ -102,6 +124,125 @@ def _read_rows(path: Path) -> list[dict[str, Any]]:
     if not isinstance(payload, list):
         return []
     return [row for row in payload if isinstance(row, dict)]
+
+
+def _parse_timestamp(value: Any) -> float | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = dt.datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.UTC)
+    return parsed.timestamp()
+
+
+def _matching_heartbeat_rows(
+    heartbeats: list[dict[str, Any]],
+    *,
+    lane_id: str,
+    owner_session: str,
+) -> list[dict[str, Any]]:
+    return [
+        row
+        for row in heartbeats
+        if str(row.get("lane_id") or "") == lane_id
+        and str(row.get("owner_session") or "") == owner_session
+    ]
+
+
+def _record_is_terminal(record: dict[str, Any]) -> bool:
+    return bool(record.get("terminal") or record.get("terminal_outcome"))
+
+
+def _fresh_heartbeat_timestamps(
+    records: Sequence[dict[str, Any]],
+    *,
+    now_ts: float,
+    freshness_seconds: int,
+) -> list[str]:
+    fresh: list[str] = []
+    cutoff = now_ts - freshness_seconds
+    for record in records:
+        if _record_is_terminal(record):
+            continue
+        for key in HEARTBEAT_TIMESTAMP_KEYS:
+            raw = record.get(key)
+            ts = _parse_timestamp(raw)
+            if ts is not None and ts >= cutoff:
+                fresh.append(str(raw))
+    return fresh
+
+
+def _process_is_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _live_pids(records: Sequence[dict[str, Any]]) -> list[int]:
+    live: list[int] = []
+    for record in records:
+        if _record_is_terminal(record):
+            continue
+        for key in PID_KEYS:
+            pid = _coerce_int(record.get(key))
+            if pid is not None and _process_is_alive(pid):
+                live.append(pid)
+    return live
+
+
+def _local_work_claims(records: Sequence[dict[str, Any]]) -> list[str]:
+    claims: list[str] = []
+    for record in records:
+        for key in LOCAL_WORK_KEYS:
+            value = str(record.get(key) or "").strip()
+            if value:
+                claims.append(value)
+        if record.get("possible_unpushed_work") or record.get("has_unpushed_work"):
+            claims.append("possible_unpushed_work")
+    return claims
+
+
+def _safe_steering_inbox(owner_session: str, *, steering_inbox_root: Path) -> Path | None:
+    if (
+        not owner_session
+        or owner_session != owner_session.strip()
+        or "/" in owner_session
+        or "\\" in owner_session
+    ):
+        return None
+    session_path = Path(owner_session)
+    if session_path.is_absolute() or owner_session in {".", ".."} or ".." in session_path.parts:
+        return None
+    root = steering_inbox_root.resolve(strict=False)
+    inbox = (root / owner_session).resolve(strict=False)
+    try:
+        inbox.relative_to(root)
+    except ValueError:
+        return None
+    return inbox
+
+
+def _pending_mailbox_messages(owner_session: str, *, steering_inbox_root: Path) -> list[str]:
+    inbox = _safe_steering_inbox(owner_session, steering_inbox_root=steering_inbox_root)
+    if inbox is None:
+        return ["unsafe_owner_session"]
+    if not inbox.is_dir():
+        return []
+    return sorted(path.name for path in inbox.glob("*.json") if path.is_file())
 
 
 def _atomic_write(path: Path, rows: list[dict[str, Any]]) -> None:
@@ -300,6 +441,12 @@ def _active_pr_lane_findings(rows: list[dict[str, Any]], *, pr: int) -> list[dic
                 "status": status,
                 "branch": row.get("branch"),
                 "worktree": row.get("worktree"),
+                "local_worktree": row.get("local_worktree"),
+                "local_work_path": row.get("local_work_path"),
+                "possible_unpushed_work": row.get("possible_unpushed_work"),
+                "has_unpushed_work": row.get("has_unpushed_work"),
+                "pid": row.get("pid"),
+                "owner_pid": row.get("owner_pid"),
                 "next_action": row.get("next_action"),
                 "updated_at": row.get("updated_at"),
                 "last_heartbeat_at": row.get("last_heartbeat_at"),
@@ -308,6 +455,62 @@ def _active_pr_lane_findings(rows: list[dict[str, Any]], *, pr: int) -> list[dic
             }
         )
     return findings
+
+
+def _annotate_terminal_safety(
+    findings: list[dict[str, Any]],
+    *,
+    heartbeats: list[dict[str, Any]],
+    steering_inbox_root: Path,
+    now_ts: float,
+    heartbeat_fresh_seconds: int,
+) -> list[dict[str, Any]]:
+    annotated: list[dict[str, Any]] = []
+    for finding in findings:
+        finding = dict(finding)
+        lane_id = str(finding.get("lane_id") or "")
+        owner_session = str(finding.get("owner_session") or "")
+        heartbeat_rows = _matching_heartbeat_rows(
+            heartbeats,
+            lane_id=lane_id,
+            owner_session=owner_session,
+        )
+        records = [finding, *heartbeat_rows]
+        blockers: list[str] = []
+        details: dict[str, Any] = {}
+
+        live_pids = sorted(set(_live_pids(records)))
+        if live_pids:
+            blockers.append("live_process")
+            details["live_pids"] = live_pids
+
+        fresh_heartbeats = _fresh_heartbeat_timestamps(
+            records,
+            now_ts=now_ts,
+            freshness_seconds=heartbeat_fresh_seconds,
+        )
+        if fresh_heartbeats:
+            blockers.append("fresh_heartbeat")
+            details["fresh_heartbeat_timestamps"] = fresh_heartbeats
+
+        pending_messages = _pending_mailbox_messages(
+            owner_session,
+            steering_inbox_root=steering_inbox_root,
+        )
+        if pending_messages:
+            blockers.append("unread_mailbox")
+            details["pending_mailbox_messages"] = pending_messages
+
+        local_work_claims = sorted(set(_local_work_claims(records)))
+        if local_work_claims:
+            blockers.append("local_work_claim")
+            details["local_work_claims"] = local_work_claims
+
+        finding["terminal_safety_blockers"] = blockers
+        finding["terminal_safety_details"] = details
+        finding["apply_safe"] = not blockers
+        annotated.append(finding)
+    return annotated
 
 
 def _quote_shell_arg(value: Any) -> str:
@@ -404,11 +607,13 @@ def _base_merged_pr_audit_result(
 ) -> dict[str, Any]:
     merge_commit = str(github_state.get("mergeCommit") or "")
     expected = str(expected_merge_commit or "")
+    unsafe_findings = [finding for finding in findings if finding.get("terminal_safety_blockers")]
     apply_eligible = (
         apply
         and operator_authorized
         and bool(expected)
         and bool(findings)
+        and not unsafe_findings
         and github_state.get("available") is True
         and github_state.get("state") == "MERGED"
         and merge_commit == expected
@@ -422,6 +627,8 @@ def _base_merged_pr_audit_result(
         "github_state": github_state,
         "finding_count": len(findings),
         "findings": findings,
+        "safe_finding_count": len(findings) - len(unsafe_findings),
+        "unsafe_finding_count": len(unsafe_findings),
         "owner_steering_text": "\n".join(
             _owner_steering_commands(findings=findings, pr=pr, github_state=github_state)
         ),
@@ -469,6 +676,8 @@ def _merged_pr_audit_blocked_reason(
         return "expected_merge_commit_required"
     if str(github_state.get("mergeCommit") or "") != expected:
         return "merge_commit_mismatch"
+    if any(finding.get("terminal_safety_blockers") for finding in findings):
+        return "unsafe_terminal_owner_gates"
     return None
 
 
@@ -482,6 +691,9 @@ def audit_merged_pr_lanes(
     operator_authorized: bool = False,
     expected_merge_commit: str | None = None,
     resolved_at: str | None = None,
+    heartbeat_path: Path | None = None,
+    steering_inbox_root: Path | None = None,
+    heartbeat_fresh_seconds: int = HEARTBEAT_FRESH_SECONDS,
 ) -> dict[str, Any]:
     """Audit active/blocked lane rows for an already-merged PR.
 
@@ -491,12 +703,22 @@ def audit_merged_pr_lanes(
     """
 
     resolved_at = resolved_at or _utc_now_iso()
+    heartbeat_path = heartbeat_path or _default_heartbeat_path()
+    steering_inbox_root = steering_inbox_root or _default_steering_inbox_root()
+    now_ts = _parse_timestamp(resolved_at) or dt.datetime.now(dt.UTC).timestamp()
     github_state = _fetch_pr_state(pr=pr, gh_bin=gh_bin)
     with _registry_write_lock(registry_path):
         rows = _read_rows(registry_path)
+        heartbeats = _read_rows(heartbeat_path)
         findings: list[dict[str, Any]] = []
         if github_state.get("available") is True and github_state.get("state") == "MERGED":
-            findings = _active_pr_lane_findings(rows, pr=pr)
+            findings = _annotate_terminal_safety(
+                _active_pr_lane_findings(rows, pr=pr),
+                heartbeats=heartbeats,
+                steering_inbox_root=steering_inbox_root,
+                now_ts=now_ts,
+                heartbeat_fresh_seconds=heartbeat_fresh_seconds,
+            )
         blocked_reason = _merged_pr_audit_blocked_reason(
             apply=apply,
             operator_authorized=operator_authorized,
@@ -522,6 +744,10 @@ def audit_merged_pr_lanes(
             (str(finding.get("lane_id") or ""), str(finding.get("owner_session") or ""))
             for finding in findings
         }
+        findings_by_key = {
+            (str(finding.get("lane_id") or ""), str(finding.get("owner_session") or "")): finding
+            for finding in findings
+        }
         receipt_paths: list[str] = []
         out_rows: list[dict[str, Any]] = []
         for row in rows:
@@ -545,6 +771,10 @@ def audit_merged_pr_lanes(
                     "new_status": "superseded",
                     "resolved_at_utc": resolved_at,
                     "resolution": "merged_pr_has_active_lane_row",
+                    "terminal_safety_blockers": findings_by_key.get(row_key, {}).get(
+                        "terminal_safety_blockers",
+                        [],
+                    ),
                 }
                 receipt_paths.append(str(_write_receipt(receipt_dir=receipt_dir, receipt=receipt)))
             out_rows.append(row)
@@ -662,6 +892,24 @@ def build_parser() -> argparse.ArgumentParser:
             "shared automation state root."
         ),
     )
+    parser.add_argument(
+        "--heartbeat-path",
+        type=Path,
+        default=None,
+        help="Override .aragora/agent-bridge/heartbeats.json for terminal safety checks.",
+    )
+    parser.add_argument(
+        "--steering-inbox-root",
+        type=Path,
+        default=None,
+        help="Override .aragora/operator-steering for unread mailbox checks.",
+    )
+    parser.add_argument(
+        "--heartbeat-fresh-seconds",
+        type=int,
+        default=HEARTBEAT_FRESH_SECONDS,
+        help="Fresh heartbeat TTL in seconds for merged-PR apply safety checks.",
+    )
     parser.add_argument("--json", action="store_true")
     return parser
 
@@ -691,6 +939,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             apply=bool(args.apply),
             operator_authorized=bool(args.operator_authorized),
             expected_merge_commit=args.expected_merge_commit,
+            heartbeat_path=args.heartbeat_path,
+            steering_inbox_root=args.steering_inbox_root,
+            heartbeat_fresh_seconds=args.heartbeat_fresh_seconds,
         )
         if args.json:
             print(json.dumps(result, indent=2, sort_keys=True))

--- a/scripts/resolve_lane_conflicts.py
+++ b/scripts/resolve_lane_conflicts.py
@@ -266,13 +266,52 @@ def _safe_steering_inbox(owner_session: str, *, steering_inbox_root: Path) -> Pa
     return inbox
 
 
-def _pending_mailbox_messages(owner_session: str, *, steering_inbox_root: Path) -> list[str]:
+def _message_key(path: Path) -> tuple[str, str]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        data = {}
+    if not isinstance(data, dict):
+        data = {}
+    return (path.name, str(data.get("message_sha256") or ""))
+
+
+def _read_receipt_keys(inbox: Path) -> set[tuple[str, str]]:
+    receipt_dir = inbox / "_read_receipts"
+    if not receipt_dir.is_dir():
+        return set()
+    keys: set[tuple[str, str]] = set()
+    for receipt_path in receipt_dir.glob("*.json"):
+        if not receipt_path.is_file():
+            continue
+        try:
+            data = json.loads(receipt_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        message_filename = str(data.get("message_filename") or "")
+        if message_filename:
+            keys.add((message_filename, str(data.get("message_sha256") or "")))
+    return keys
+
+
+def _pending_mailbox_messages(
+    owner_session: str, *, steering_inbox_root: Path
+) -> tuple[list[str], str | None]:
     inbox = _safe_steering_inbox(owner_session, steering_inbox_root=steering_inbox_root)
     if inbox is None:
-        return ["unsafe_owner_session"]
+        return [], "invalid_owner_session"
     if not inbox.is_dir():
-        return []
-    return sorted(path.name for path in inbox.glob("*.json") if path.is_file())
+        return [], None
+    read_keys = _read_receipt_keys(inbox)
+    pending: list[str] = []
+    for path in sorted(
+        (path for path in inbox.glob("*.json") if path.is_file()), key=lambda p: p.name
+    ):
+        if _message_key(path) not in read_keys:
+            pending.append(path.name)
+    return pending, None
 
 
 def _atomic_write(path: Path, rows: list[dict[str, Any]]) -> None:
@@ -528,11 +567,13 @@ def _annotate_terminal_safety(
             blockers.append("heartbeat_state_untrusted")
             details["heartbeat_read_error"] = heartbeat_load_error
 
-        pending_messages = _pending_mailbox_messages(
+        pending_messages, mailbox_blocker = _pending_mailbox_messages(
             owner_session,
             steering_inbox_root=steering_inbox_root,
         )
-        if pending_messages:
+        if mailbox_blocker:
+            blockers.append(mailbox_blocker)
+        elif pending_messages:
             blockers.append("unread_mailbox")
             details["pending_mailbox_messages"] = pending_messages
 
@@ -652,16 +693,27 @@ def _base_merged_pr_audit_result(
     merge_commit = str(github_state.get("mergeCommit") or "")
     expected = str(expected_merge_commit or "")
     unsafe_findings = [finding for finding in findings if finding.get("terminal_safety_blockers")]
+    safe_findings = [finding for finding in findings if not finding.get("terminal_safety_blockers")]
     apply_eligible = (
         apply
         and operator_authorized
         and bool(expected)
-        and bool(findings)
-        and not unsafe_findings
+        and bool(safe_findings)
         and github_state.get("available") is True
         and github_state.get("state") == "MERGED"
         and merge_commit == expected
     )
+    operator_apply_command = ""
+    if heartbeat_fresh_seconds >= 0:
+        operator_apply_command = _operator_apply_command(
+            pr=pr,
+            registry_path=registry_path,
+            receipt_dir=receipt_dir,
+            expected_merge_commit=merge_commit or expected,
+            heartbeat_path=heartbeat_path,
+            steering_inbox_root=steering_inbox_root,
+            heartbeat_fresh_seconds=heartbeat_fresh_seconds,
+        )
     return {
         "mode": "merged_pr_lane_audit",
         "registry_path": str(registry_path),
@@ -681,15 +733,7 @@ def _base_merged_pr_audit_result(
             pr=pr,
             github_state=github_state,
         ),
-        "operator_apply_command": _operator_apply_command(
-            pr=pr,
-            registry_path=registry_path,
-            receipt_dir=receipt_dir,
-            expected_merge_commit=merge_commit or expected,
-            heartbeat_path=heartbeat_path,
-            steering_inbox_root=steering_inbox_root,
-            heartbeat_fresh_seconds=heartbeat_fresh_seconds,
-        ),
+        "operator_apply_command": operator_apply_command,
         "requires_operator_authorization": True,
         "operator_authorized": operator_authorized,
         "expected_merge_commit": expected,
@@ -723,7 +767,9 @@ def _merged_pr_audit_blocked_reason(
         return "expected_merge_commit_required"
     if str(github_state.get("mergeCommit") or "") != expected:
         return "merge_commit_mismatch"
-    if any(finding.get("terminal_safety_blockers") for finding in findings):
+    unsafe_findings = [finding for finding in findings if finding.get("terminal_safety_blockers")]
+    safe_findings = [finding for finding in findings if not finding.get("terminal_safety_blockers")]
+    if unsafe_findings and not safe_findings:
         return "unsafe_terminal_owner_gates"
     return None
 
@@ -759,14 +805,26 @@ def audit_merged_pr_lanes(
         heartbeats, heartbeat_load_error = _read_rows_checked(heartbeat_path)
         findings: list[dict[str, Any]] = []
         if github_state.get("available") is True and github_state.get("state") == "MERGED":
-            findings = _annotate_terminal_safety(
-                _active_pr_lane_findings(rows, pr=pr),
-                heartbeats=heartbeats,
-                heartbeat_load_error=heartbeat_load_error,
-                steering_inbox_root=steering_inbox_root,
-                now_ts=now_ts,
-                heartbeat_fresh_seconds=heartbeat_fresh_seconds,
-            )
+            raw_findings = _active_pr_lane_findings(rows, pr=pr)
+            if heartbeat_fresh_seconds < 0:
+                findings = []
+                for finding in raw_findings:
+                    finding = dict(finding)
+                    finding["terminal_safety_blockers"] = ["invalid_heartbeat_fresh_seconds"]
+                    finding["terminal_safety_details"] = {
+                        "heartbeat_fresh_seconds": heartbeat_fresh_seconds
+                    }
+                    finding["apply_safe"] = False
+                    findings.append(finding)
+            else:
+                findings = _annotate_terminal_safety(
+                    raw_findings,
+                    heartbeats=heartbeats,
+                    heartbeat_load_error=heartbeat_load_error,
+                    steering_inbox_root=steering_inbox_root,
+                    now_ts=now_ts,
+                    heartbeat_fresh_seconds=heartbeat_fresh_seconds,
+                )
         blocked_reason = _merged_pr_audit_blocked_reason(
             apply=apply,
             operator_authorized=operator_authorized,
@@ -789,11 +847,16 @@ def audit_merged_pr_lanes(
             heartbeat_fresh_seconds=heartbeat_fresh_seconds,
         )
         if not result["apply_eligible"]:
+            if heartbeat_fresh_seconds < 0 and findings:
+                result["blocked_reason"] = "invalid_heartbeat_fresh_seconds"
             return result
 
+        safe_findings = [
+            finding for finding in findings if not finding.get("terminal_safety_blockers")
+        ]
         target_keys = {
             (str(finding.get("lane_id") or ""), str(finding.get("owner_session") or ""))
-            for finding in findings
+            for finding in safe_findings
         }
         findings_by_key = {
             (str(finding.get("lane_id") or ""), str(finding.get("owner_session") or "")): finding

--- a/scripts/resolve_lane_conflicts.py
+++ b/scripts/resolve_lane_conflicts.py
@@ -220,14 +220,28 @@ def _live_pids(records: Sequence[dict[str, Any]]) -> list[int]:
     return live
 
 
+def _truthy_flag(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    text = str(value or "").strip().lower()
+    return text in {"1", "true", "yes", "y", "on"}
+
+
 def _local_work_claims(records: Sequence[dict[str, Any]]) -> list[str]:
     claims: list[str] = []
     for record in records:
+        has_local_work_risk = _truthy_flag(record.get("possible_unpushed_work")) or _truthy_flag(
+            record.get("has_unpushed_work")
+        )
+        if not has_local_work_risk:
+            continue
         for key in LOCAL_WORK_KEYS:
             value = str(record.get(key) or "").strip()
             if value:
                 claims.append(value)
-        if record.get("possible_unpushed_work") or record.get("has_unpushed_work"):
+        if not any(str(record.get(key) or "").strip() for key in LOCAL_WORK_KEYS):
             claims.append("possible_unpushed_work")
     return claims
 

--- a/tests/scripts/test_resolve_lane_conflicts.py
+++ b/tests/scripts/test_resolve_lane_conflicts.py
@@ -786,6 +786,7 @@ def test_merged_pr_audit_apply_rejects_local_work_claim(tmp_path: Path) -> None:
                 "owner_session": "codex-owner",
                 "status": "active",
                 "worktree": "/tmp/active-worktree",
+                "possible_unpushed_work": True,
                 "pr_number": 7435,
             }
         ],
@@ -810,3 +811,40 @@ def test_merged_pr_audit_apply_rejects_local_work_claim(tmp_path: Path) -> None:
         "/tmp/active-worktree"
     ]
     assert json.loads(registry.read_text(encoding="utf-8"))[0]["status"] == "active"
+
+
+def test_merged_pr_audit_apply_allows_recorded_worktree_without_local_work_risk(
+    tmp_path: Path,
+) -> None:
+    registry = tmp_path / "lanes.json"
+    _write_json(
+        registry,
+        [
+            {
+                "lane_id": "codex-merged",
+                "owner_session": "codex-owner",
+                "status": "active",
+                "worktree": "/tmp/active-worktree",
+                "possible_unpushed_work": "false",
+                "has_unpushed_work": False,
+                "pr_number": 7435,
+            }
+        ],
+    )
+
+    result = resolver.audit_merged_pr_lanes(
+        registry_path=registry,
+        receipt_dir=tmp_path / "receipts",
+        pr=7435,
+        gh_bin=str(_merged_pr_gh(tmp_path)),
+        apply=True,
+        operator_authorized=True,
+        expected_merge_commit="merge",
+        heartbeat_path=tmp_path / "heartbeats.json",
+        steering_inbox_root=tmp_path / "operator-steering",
+    )
+
+    assert result["resolved_count"] == 1
+    assert result["blocked_reason"] is None
+    rows = json.loads(registry.read_text(encoding="utf-8"))
+    assert rows[0]["status"] == "superseded"

--- a/tests/scripts/test_resolve_lane_conflicts.py
+++ b/tests/scripts/test_resolve_lane_conflicts.py
@@ -631,6 +631,78 @@ def test_merged_pr_audit_apply_rejects_fresh_heartbeat(tmp_path: Path) -> None:
     assert json.loads(registry.read_text(encoding="utf-8"))[0]["status"] == "active"
 
 
+def test_merged_pr_audit_apply_rejects_untrusted_heartbeat_state(tmp_path: Path) -> None:
+    registry = tmp_path / "lanes.json"
+    heartbeats = tmp_path / "heartbeats.json"
+    _write_json(
+        registry,
+        [
+            {
+                "lane_id": "codex-merged",
+                "owner_session": "codex-owner",
+                "status": "active",
+                "pr_number": 7435,
+            }
+        ],
+    )
+    heartbeats.write_text("{not-json", encoding="utf-8")
+
+    result = resolver.audit_merged_pr_lanes(
+        registry_path=registry,
+        receipt_dir=tmp_path / "receipts",
+        pr=7435,
+        gh_bin=str(_merged_pr_gh(tmp_path)),
+        apply=True,
+        operator_authorized=True,
+        expected_merge_commit="merge",
+        heartbeat_path=heartbeats,
+        steering_inbox_root=tmp_path / "operator-steering",
+    )
+
+    assert result["resolved_count"] == 0
+    assert result["blocked_reason"] == "unsafe_terminal_owner_gates"
+    assert result["findings"][0]["terminal_safety_blockers"] == ["heartbeat_state_untrusted"]
+    assert result["findings"][0]["terminal_safety_details"]["heartbeat_read_error"].startswith(
+        "invalid_json:"
+    )
+    assert json.loads(registry.read_text(encoding="utf-8"))[0]["status"] == "active"
+
+
+def test_merged_pr_audit_apply_command_preserves_safety_overrides(tmp_path: Path) -> None:
+    registry = tmp_path / "lanes.json"
+    heartbeats = tmp_path / "heartbeats.json"
+    steering_root = tmp_path / "operator-steering"
+    _write_json(
+        registry,
+        [
+            {
+                "lane_id": "codex-merged",
+                "owner_session": "codex-owner",
+                "status": "active",
+                "pr_number": 7435,
+            }
+        ],
+    )
+    _write_json(heartbeats, [])
+
+    result = resolver.audit_merged_pr_lanes(
+        registry_path=registry,
+        receipt_dir=tmp_path / "receipts",
+        pr=7435,
+        gh_bin=str(_merged_pr_gh(tmp_path)),
+        heartbeat_path=heartbeats,
+        steering_inbox_root=steering_root,
+        heartbeat_fresh_seconds=123,
+    )
+
+    command = result["operator_apply_command"]
+    assert "--heartbeat-path" in command
+    assert str(heartbeats) in command
+    assert "--steering-inbox-root" in command
+    assert str(steering_root) in command
+    assert "--heartbeat-fresh-seconds 123" in command
+
+
 def test_merged_pr_audit_apply_rejects_unread_mailbox(tmp_path: Path) -> None:
     registry = tmp_path / "lanes.json"
     steering_root = tmp_path / "operator-steering"

--- a/tests/scripts/test_resolve_lane_conflicts.py
+++ b/tests/scripts/test_resolve_lane_conflicts.py
@@ -62,6 +62,21 @@ def _merged_pr_gh(tmp_path: Path, *, merge_commit: str = "merge") -> Path:
     )
 
 
+def _write_read_receipt(inbox: Path, *, message_filename: str, message_sha256: str = "") -> None:
+    receipt_dir = inbox / "_read_receipts"
+    receipt_dir.mkdir(parents=True, exist_ok=True)
+    _write_json(
+        receipt_dir / "receipt.json",
+        {
+            "schema_version": "aragora-operator-steering-read-receipt/1.0",
+            "message_filename": message_filename,
+            "message_sha256": message_sha256,
+            "outcome": "read",
+            "read_at_utc": "2026-05-23T19:20:00Z",
+        },
+    )
+
+
 def test_detects_completed_owner_conflict_without_mutating(tmp_path: Path) -> None:
     registry = tmp_path / "lanes.json"
     registry.write_text(
@@ -468,6 +483,10 @@ def test_merged_pr_audit_apply_requires_operator_authorization(tmp_path: Path) -
             str(registry),
             "--receipt-dir",
             str(tmp_path / "receipts"),
+            "--heartbeat-path",
+            str(tmp_path / "heartbeats.json"),
+            "--steering-inbox-root",
+            str(tmp_path / "operator-steering"),
             "--json",
         ],
         text=True,
@@ -530,6 +549,8 @@ def test_merged_pr_audit_apply_supersedes_only_target_pr_rows(tmp_path: Path) ->
         operator_authorized=True,
         expected_merge_commit="4e8b21e98a0ddbcb383d9c92e6c20b343e49d151",
         resolved_at="2026-05-23T19:20:00Z",
+        heartbeat_path=tmp_path / "heartbeats.json",
+        steering_inbox_root=tmp_path / "operator-steering",
     )
 
     rows = {row["lane_id"]: row for row in json.loads(registry.read_text(encoding="utf-8"))}
@@ -742,6 +763,76 @@ def test_merged_pr_audit_apply_rejects_unread_mailbox(tmp_path: Path) -> None:
     assert json.loads(registry.read_text(encoding="utf-8"))[0]["status"] == "active"
 
 
+def test_merged_pr_audit_apply_allows_read_mailbox_message(tmp_path: Path) -> None:
+    registry = tmp_path / "lanes.json"
+    steering_root = tmp_path / "operator-steering"
+    inbox = steering_root / "codex-owner"
+    inbox.mkdir(parents=True)
+    (inbox / "message.json").write_text("{}", encoding="utf-8")
+    _write_read_receipt(inbox, message_filename="message.json")
+    _write_json(
+        registry,
+        [
+            {
+                "lane_id": "codex-merged",
+                "owner_session": "codex-owner",
+                "status": "active",
+                "pr_number": 7435,
+            }
+        ],
+    )
+
+    result = resolver.audit_merged_pr_lanes(
+        registry_path=registry,
+        receipt_dir=tmp_path / "receipts",
+        pr=7435,
+        gh_bin=str(_merged_pr_gh(tmp_path)),
+        apply=True,
+        operator_authorized=True,
+        expected_merge_commit="merge",
+        heartbeat_path=tmp_path / "heartbeats.json",
+        steering_inbox_root=steering_root,
+    )
+
+    assert result["resolved_count"] == 1
+    assert result["blocked_reason"] is None
+    assert result["findings"][0]["terminal_safety_blockers"] == []
+    assert json.loads(registry.read_text(encoding="utf-8"))[0]["status"] == "superseded"
+
+
+def test_merged_pr_audit_apply_labels_invalid_owner_session_separately(tmp_path: Path) -> None:
+    registry = tmp_path / "lanes.json"
+    _write_json(
+        registry,
+        [
+            {
+                "lane_id": "codex-merged",
+                "owner_session": "../codex-owner",
+                "status": "active",
+                "pr_number": 7435,
+            }
+        ],
+    )
+
+    result = resolver.audit_merged_pr_lanes(
+        registry_path=registry,
+        receipt_dir=tmp_path / "receipts",
+        pr=7435,
+        gh_bin=str(_merged_pr_gh(tmp_path)),
+        apply=True,
+        operator_authorized=True,
+        expected_merge_commit="merge",
+        heartbeat_path=tmp_path / "heartbeats.json",
+        steering_inbox_root=tmp_path / "operator-steering",
+    )
+
+    assert result["resolved_count"] == 0
+    assert result["blocked_reason"] == "unsafe_terminal_owner_gates"
+    assert result["findings"][0]["terminal_safety_blockers"] == ["invalid_owner_session"]
+    assert "pending_mailbox_messages" not in result["findings"][0]["terminal_safety_details"]
+    assert json.loads(registry.read_text(encoding="utf-8"))[0]["status"] == "active"
+
+
 def test_merged_pr_audit_apply_rejects_live_owner_process(tmp_path: Path) -> None:
     registry = tmp_path / "lanes.json"
     _write_json(
@@ -848,3 +939,86 @@ def test_merged_pr_audit_apply_allows_recorded_worktree_without_local_work_risk(
     assert result["blocked_reason"] is None
     rows = json.loads(registry.read_text(encoding="utf-8"))
     assert rows[0]["status"] == "superseded"
+
+
+def test_merged_pr_audit_apply_supersedes_safe_rows_when_other_rows_are_unsafe(
+    tmp_path: Path,
+) -> None:
+    registry = tmp_path / "lanes.json"
+    steering_root = tmp_path / "operator-steering"
+    inbox = steering_root / "codex-blocked"
+    inbox.mkdir(parents=True)
+    (inbox / "message.json").write_text("{}", encoding="utf-8")
+    _write_json(
+        registry,
+        [
+            {
+                "lane_id": "codex-safe",
+                "owner_session": "codex-safe",
+                "status": "active",
+                "pr_number": 7435,
+            },
+            {
+                "lane_id": "codex-blocked",
+                "owner_session": "codex-blocked",
+                "status": "active",
+                "pr_number": 7435,
+            },
+        ],
+    )
+
+    result = resolver.audit_merged_pr_lanes(
+        registry_path=registry,
+        receipt_dir=tmp_path / "receipts",
+        pr=7435,
+        gh_bin=str(_merged_pr_gh(tmp_path)),
+        apply=True,
+        operator_authorized=True,
+        expected_merge_commit="merge",
+        heartbeat_path=tmp_path / "heartbeats.json",
+        steering_inbox_root=steering_root,
+    )
+
+    rows = {row["lane_id"]: row for row in json.loads(registry.read_text(encoding="utf-8"))}
+    assert result["resolved_count"] == 1
+    assert result["safe_finding_count"] == 1
+    assert result["unsafe_finding_count"] == 1
+    assert rows["codex-safe"]["status"] == "superseded"
+    assert rows["codex-blocked"]["status"] == "active"
+
+
+def test_merged_pr_audit_apply_rejects_negative_heartbeat_fresh_seconds(
+    tmp_path: Path,
+) -> None:
+    registry = tmp_path / "lanes.json"
+    _write_json(
+        registry,
+        [
+            {
+                "lane_id": "codex-merged",
+                "owner_session": "codex-owner",
+                "status": "active",
+                "pr_number": 7435,
+            }
+        ],
+    )
+
+    result = resolver.audit_merged_pr_lanes(
+        registry_path=registry,
+        receipt_dir=tmp_path / "receipts",
+        pr=7435,
+        gh_bin=str(_merged_pr_gh(tmp_path)),
+        apply=True,
+        operator_authorized=True,
+        expected_merge_commit="merge",
+        heartbeat_path=tmp_path / "heartbeats.json",
+        steering_inbox_root=tmp_path / "operator-steering",
+        heartbeat_fresh_seconds=-1,
+    )
+
+    assert result["resolved_count"] == 0
+    assert result["apply_eligible"] is False
+    assert result["blocked_reason"] == "invalid_heartbeat_fresh_seconds"
+    assert result["operator_apply_command"] == ""
+    assert result["findings"][0]["terminal_safety_blockers"] == ["invalid_heartbeat_fresh_seconds"]
+    assert json.loads(registry.read_text(encoding="utf-8"))[0]["status"] == "active"

--- a/tests/scripts/test_resolve_lane_conflicts.py
+++ b/tests/scripts/test_resolve_lane_conflicts.py
@@ -763,7 +763,9 @@ def test_merged_pr_audit_apply_rejects_unread_mailbox(tmp_path: Path) -> None:
     assert json.loads(registry.read_text(encoding="utf-8"))[0]["status"] == "active"
 
 
-def test_merged_pr_audit_apply_allows_read_mailbox_message(tmp_path: Path) -> None:
+def test_merged_pr_audit_apply_rejects_read_but_unacked_mailbox_message(
+    tmp_path: Path,
+) -> None:
     registry = tmp_path / "lanes.json"
     steering_root = tmp_path / "operator-steering"
     inbox = steering_root / "codex-owner"
@@ -794,10 +796,13 @@ def test_merged_pr_audit_apply_allows_read_mailbox_message(tmp_path: Path) -> No
         steering_inbox_root=steering_root,
     )
 
-    assert result["resolved_count"] == 1
-    assert result["blocked_reason"] is None
-    assert result["findings"][0]["terminal_safety_blockers"] == []
-    assert json.loads(registry.read_text(encoding="utf-8"))[0]["status"] == "superseded"
+    assert result["resolved_count"] == 0
+    assert result["blocked_reason"] == "unsafe_terminal_owner_gates"
+    assert result["findings"][0]["terminal_safety_blockers"] == ["unread_mailbox"]
+    assert result["findings"][0]["terminal_safety_details"]["pending_mailbox_messages"] == [
+        "message.json"
+    ]
+    assert json.loads(registry.read_text(encoding="utf-8"))[0]["status"] == "active"
 
 
 def test_merged_pr_audit_apply_labels_invalid_owner_session_separately(tmp_path: Path) -> None:

--- a/tests/scripts/test_resolve_lane_conflicts.py
+++ b/tests/scripts/test_resolve_lane_conflicts.py
@@ -48,6 +48,20 @@ def _fake_gh(tmp_path: Path, payload: dict[str, Any], *, exit_code: int = 0) -> 
     return gh
 
 
+def _merged_pr_gh(tmp_path: Path, *, merge_commit: str = "merge") -> Path:
+    return _fake_gh(
+        tmp_path,
+        {
+            "number": 7435,
+            "state": "MERGED",
+            "headRefOid": "head",
+            "mergedAt": "2026-05-23T19:16:23Z",
+            "mergeCommit": {"oid": merge_commit},
+            "url": "https://github.com/synaptent/aragora/pull/7435",
+        },
+    )
+
+
 def test_detects_completed_owner_conflict_without_mutating(tmp_path: Path) -> None:
     registry = tmp_path / "lanes.json"
     registry.write_text(
@@ -570,4 +584,157 @@ def test_merged_pr_audit_apply_rejects_merge_commit_mismatch(tmp_path: Path) -> 
 
     assert result["resolved_count"] == 0
     assert result["blocked_reason"] == "merge_commit_mismatch"
+    assert json.loads(registry.read_text(encoding="utf-8"))[0]["status"] == "active"
+
+
+def test_merged_pr_audit_apply_rejects_fresh_heartbeat(tmp_path: Path) -> None:
+    registry = tmp_path / "lanes.json"
+    heartbeats = tmp_path / "heartbeats.json"
+    _write_json(
+        registry,
+        [
+            {
+                "lane_id": "codex-merged",
+                "owner_session": "codex-owner",
+                "status": "active",
+                "pr_number": 7435,
+            }
+        ],
+    )
+    _write_json(
+        heartbeats,
+        [
+            {
+                "lane_id": "codex-merged",
+                "owner_session": "codex-owner",
+                "last_seen_at": "2026-05-23T19:19:30Z",
+            }
+        ],
+    )
+
+    result = resolver.audit_merged_pr_lanes(
+        registry_path=registry,
+        receipt_dir=tmp_path / "receipts",
+        pr=7435,
+        gh_bin=str(_merged_pr_gh(tmp_path)),
+        apply=True,
+        operator_authorized=True,
+        expected_merge_commit="merge",
+        resolved_at="2026-05-23T19:20:00Z",
+        heartbeat_path=heartbeats,
+        steering_inbox_root=tmp_path / "operator-steering",
+    )
+
+    assert result["resolved_count"] == 0
+    assert result["blocked_reason"] == "unsafe_terminal_owner_gates"
+    assert result["findings"][0]["terminal_safety_blockers"] == ["fresh_heartbeat"]
+    assert json.loads(registry.read_text(encoding="utf-8"))[0]["status"] == "active"
+
+
+def test_merged_pr_audit_apply_rejects_unread_mailbox(tmp_path: Path) -> None:
+    registry = tmp_path / "lanes.json"
+    steering_root = tmp_path / "operator-steering"
+    inbox = steering_root / "codex-owner"
+    inbox.mkdir(parents=True)
+    (inbox / "message.json").write_text("{}", encoding="utf-8")
+    _write_json(
+        registry,
+        [
+            {
+                "lane_id": "codex-merged",
+                "owner_session": "codex-owner",
+                "status": "active",
+                "pr_number": 7435,
+            }
+        ],
+    )
+
+    result = resolver.audit_merged_pr_lanes(
+        registry_path=registry,
+        receipt_dir=tmp_path / "receipts",
+        pr=7435,
+        gh_bin=str(_merged_pr_gh(tmp_path)),
+        apply=True,
+        operator_authorized=True,
+        expected_merge_commit="merge",
+        heartbeat_path=tmp_path / "heartbeats.json",
+        steering_inbox_root=steering_root,
+    )
+
+    assert result["resolved_count"] == 0
+    assert result["blocked_reason"] == "unsafe_terminal_owner_gates"
+    assert result["findings"][0]["terminal_safety_blockers"] == ["unread_mailbox"]
+    assert result["findings"][0]["terminal_safety_details"]["pending_mailbox_messages"] == [
+        "message.json"
+    ]
+    assert json.loads(registry.read_text(encoding="utf-8"))[0]["status"] == "active"
+
+
+def test_merged_pr_audit_apply_rejects_live_owner_process(tmp_path: Path) -> None:
+    registry = tmp_path / "lanes.json"
+    _write_json(
+        registry,
+        [
+            {
+                "lane_id": "codex-merged",
+                "owner_session": "codex-owner",
+                "status": "active",
+                "pid": os.getpid(),
+                "pr_number": 7435,
+            }
+        ],
+    )
+
+    result = resolver.audit_merged_pr_lanes(
+        registry_path=registry,
+        receipt_dir=tmp_path / "receipts",
+        pr=7435,
+        gh_bin=str(_merged_pr_gh(tmp_path)),
+        apply=True,
+        operator_authorized=True,
+        expected_merge_commit="merge",
+        heartbeat_path=tmp_path / "heartbeats.json",
+        steering_inbox_root=tmp_path / "operator-steering",
+    )
+
+    assert result["resolved_count"] == 0
+    assert result["blocked_reason"] == "unsafe_terminal_owner_gates"
+    assert result["findings"][0]["terminal_safety_blockers"] == ["live_process"]
+    assert result["findings"][0]["terminal_safety_details"]["live_pids"] == [os.getpid()]
+    assert json.loads(registry.read_text(encoding="utf-8"))[0]["status"] == "active"
+
+
+def test_merged_pr_audit_apply_rejects_local_work_claim(tmp_path: Path) -> None:
+    registry = tmp_path / "lanes.json"
+    _write_json(
+        registry,
+        [
+            {
+                "lane_id": "codex-merged",
+                "owner_session": "codex-owner",
+                "status": "active",
+                "worktree": "/tmp/active-worktree",
+                "pr_number": 7435,
+            }
+        ],
+    )
+
+    result = resolver.audit_merged_pr_lanes(
+        registry_path=registry,
+        receipt_dir=tmp_path / "receipts",
+        pr=7435,
+        gh_bin=str(_merged_pr_gh(tmp_path)),
+        apply=True,
+        operator_authorized=True,
+        expected_merge_commit="merge",
+        heartbeat_path=tmp_path / "heartbeats.json",
+        steering_inbox_root=tmp_path / "operator-steering",
+    )
+
+    assert result["resolved_count"] == 0
+    assert result["blocked_reason"] == "unsafe_terminal_owner_gates"
+    assert result["findings"][0]["terminal_safety_blockers"] == ["local_work_claim"]
+    assert result["findings"][0]["terminal_safety_details"]["local_work_claims"] == [
+        "/tmp/active-worktree"
+    ]
     assert json.loads(registry.read_text(encoding="utf-8"))[0]["status"] == "active"


### PR DESCRIPTION
## Summary

Implements the next #8561 stale-owner reconciler slice by making merged-PR lane supersession apply mode fail closed unless the terminal-owner gates are clean.

- Keeps dry-run observational while annotating findings with `terminal_safety_blockers` and details.
- Requires apply candidates to have no live process, no fresh heartbeat, no unread operator mailbox messages, and no local work/worktree claim.
- Preserves the existing exact merged-PR proof and expected merge commit guard, and still writes append-only receipts without deleting rows.

Closes part of #8561.

## Validation

- `python3 -m pytest tests/scripts/test_resolve_lane_conflicts.py tests/scripts/test_agent_heartbeat.py tests/scripts/test_identify_lane_owner.py -q` (116 passed)
- `python3 scripts/report_code_quality.py --check` (PASS)
- `git diff --check`
- push hooks: ruff, ruff format, mypy, gitleaks, portability guard
