### PR TITLE
refactor(ci): prune dead nomic test-selector map entries; enforce auto-generation

### DIFF
--- a/scripts/ci/generate_migrated_test_map.py
+++ b/scripts/ci/generate_migrated_test_map.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Derive (and verify) the nomic CI test-selector migration map.
+
+``scripts/nomic_ci_test_selector.py`` keeps a ``_MIGRATED_TEST_MAP`` that lets
+the selector follow a relocated root test (``tests/test_<x>.py`` ->
+``tests/<module>/test_<x>.py``) when a CHANGED top-level ``aragora/<x>.py``
+module's legacy root test was moved during the P1 tests-migration.
+
+That map is only ever consulted in ``infer_test_paths`` for a genuinely
+top-level ``aragora/<x>.py`` (the ``len(parts) == 1`` branch); a source under a
+subdirectory takes the ``len(parts) == 2`` branch and never reads the map.  So
+the ONLY entries that can affect resolution are relocations whose top-level
+source ``aragora/<x>.py`` still exists.  Every other relocated root test (the
+overwhelming majority) is dead weight in the map.
+
+This script regenerates that map directly from the three P1 tests-migration
+commits (PRs #8387, #8404, #8415) so the "auto-generated" label is enforced
+rather than aspirational:
+
+* default / ``--print``  -- print the freshly-derived map as a Python literal.
+* ``--check``           -- exit non-zero (offenders named) when the committed
+                           ``_MIGRATED_TEST_MAP`` diverges from the derived map.
+
+When the migration commits are unavailable (e.g. a shallow CI clone), the
+derivation cannot run; the script emits a warning and exits 0 (soft skip) so a
+shallow checkout never spuriously fails.  Full-history environments (local dev,
+``fetch-depth: 0`` CI, the pytest drift guard) still enforce.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SELECTOR_REL = "scripts/nomic_ci_test_selector.py"
+GENERATOR_REL = "scripts/ci/generate_migrated_test_map.py"
+
+# The three P1 tests-migration PRs whose merge commits relocated loose root
+# tests into mirrored subdirectories.
+MIGRATION_PRS = ("8387", "8404", "8415")
+
+# Immutable fallback SHAs for the three relocation commits, used only if the
+# local clone's commit subjects no longer match the grep (grep-by-PR wins).
+_FALLBACK_COMMITS = {
+    "8387": "4d5188c81cde57e8361453ab9e29653684d6c0e9",
+    "8404": "d6ef78d62b6a016f741e461cdf022dadfb646eff",
+    "8415": "5e2218542821f1741a982958fc783db0b387d705",
+}
+
+# A pre-migration root test: ``tests/test_<x>.py`` with no further subdirectory.
+_ROOT_TEST_RE = re.compile(r"^tests/test_[^/]+\.py$")
+
+
+class HistoryUnavailable(RuntimeError):
+    """Raised when a migration commit is not present in this clone."""
+
+
+def _git(*args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(REPO_ROOT), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+
+
+def _commit_exists(sha: str) -> bool:
+    try:
+        _git("cat-file", "-e", f"{sha}^{{commit}}")
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def _find_commit(pr: str) -> str | None:
+    """Locate the batch-relocation commit for a migration PR, or None."""
+    try:
+        out = _git("log", "--all", "--format=%H %s", "--grep=relocate batch")
+    except subprocess.CalledProcessError:
+        out = ""
+    for line in out.splitlines():
+        sha, _, subject = line.partition(" ")
+        if "relocate batch" in subject and f"(#{pr})" in subject:
+            return sha
+    fallback = _FALLBACK_COMMITS.get(pr)
+    if fallback and _commit_exists(fallback):
+        return fallback
+    return None
+
+
+def _root_test_renames(commit: str) -> list[tuple[str, str]]:
+    """Return ``(old_root_test, new_path)`` renames introduced by ``commit``."""
+    out = _git("show", "--name-status", "-M", "-C", commit)
+    pairs: list[tuple[str, str]] = []
+    for line in out.splitlines():
+        if not line.startswith("R"):
+            continue
+        cols = line.split("\t")
+        if len(cols) == 3 and _ROOT_TEST_RE.match(cols[1]):
+            pairs.append((cols[1], cols[2]))
+    return pairs
+
+
+def _top_level_source_exists(old_root_test: str) -> bool:
+    """Whether the top-level module implied by ``tests/test_<x>.py`` exists."""
+    module = old_root_test[len("tests/test_") :]  # "<x>.py"
+    return (REPO_ROOT / "aragora" / module).exists()
+
+
+def derive_map() -> dict[str, str]:
+    """Derive the reachable migration map from the three migration commits.
+
+    Only relocations whose top-level source ``aragora/<x>.py`` still exists are
+    kept -- those are exactly the entries ``infer_test_paths`` can consult.
+
+    Raises ``HistoryUnavailable`` if any migration commit is missing locally.
+    """
+    derived: dict[str, str] = {}
+    for pr in MIGRATION_PRS:
+        commit = _find_commit(pr)
+        if commit is None:
+            raise HistoryUnavailable(
+                f"migration commit for PR #{pr} not found (shallow clone? re-run with full history)"
+            )
+        for old, new in _root_test_renames(commit):
+            if _top_level_source_exists(old):
+                derived[old] = new
+    return dict(sorted(derived.items()))
+
+
+def committed_map() -> dict[str, str]:
+    """Load ``_MIGRATED_TEST_MAP`` from the committed selector module."""
+    selector_path = REPO_ROOT / SELECTOR_REL
+    spec = importlib.util.spec_from_file_location("nomic_ci_test_selector", selector_path)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"cannot load {SELECTOR_REL}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return dict(module._MIGRATED_TEST_MAP)
+
+
+def format_map(mapping: dict[str, str]) -> str:
+    """Render a mapping as the ``_MIGRATED_TEST_MAP`` Python literal block."""
+    lines = ["_MIGRATED_TEST_MAP = {  # {old_root_path: new_subdir_path}"]
+    for old, new in sorted(mapping.items()):
+        lines.append(f'    "{old}": "{new}",')
+    lines.append("}")
+    return "\n".join(lines)
+
+
+def diff_maps(
+    committed: dict[str, str], derived: dict[str, str]
+) -> tuple[list[str], list[str], list[str]]:
+    """Return ``(extra, missing, changed)`` keys between committed and derived."""
+    extra = sorted(set(committed) - set(derived))
+    missing = sorted(set(derived) - set(committed))
+    changed = sorted(k for k in set(committed) & set(derived) if committed[k] != derived[k])
+    return extra, missing, changed
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Derive/verify the migrated-test map")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--check",
+        action="store_true",
+        help="Fail if the committed map diverges from the derived map.",
+    )
+    group.add_argument(
+        "--print",
+        dest="do_print",
+        action="store_true",
+        help="Print the freshly-derived map (default action).",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        derived = derive_map()
+    except HistoryUnavailable as exc:
+        print(f"::warning::cannot derive migration map: {exc}")
+        return 0
+
+    if not args.check:
+        print(format_map(derived))
+        return 0
+
+    committed = committed_map()
+    if committed == derived:
+        print(f"OK: committed _MIGRATED_TEST_MAP matches the derived map ({len(derived)} entries).")
+        return 0
+
+    extra, missing, changed = diff_maps(committed, derived)
+    print("ERROR: committed _MIGRATED_TEST_MAP diverges from the P1 migration commits:")
+    for key in extra:
+        print(
+            f"  ::error::dead entry (no top-level aragora source / not a migration rename): {key}"
+        )
+    for key in missing:
+        print(f"  ::error::missing reachable entry: {key} -> {derived[key]}")
+    for key in changed:
+        print(
+            f"  ::error::wrong destination for {key}: committed={committed[key]} derived={derived[key]}"
+        )
+    print(f"\nUpdate _MIGRATED_TEST_MAP in {SELECTOR_REL} to match (regenerate with")
+    print(f"`python3 {GENERATOR_REL}`).\n\nExpected map:")
+    print(format_map(derived))
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/nomic_ci_test_selector.py
+++ b/scripts/nomic_ci_test_selector.py
@@ -16,42 +16,18 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
-# Auto-generated from the three P1 tests-migration commits (PRs #8387, #8404,
-# #8415).  Maps the pre-migration root test path to its post-migration
-# subdirectory home.  Used to resolve a top-level ``aragora/<x>.py`` whose
-# legacy ``tests/test_<x>.py`` was relocated.
+# Derived from the three P1 tests-migration commits (PRs #8387, #8404, #8415)
+# by ``scripts/ci/generate_migrated_test_map.py`` and guarded against drift by
+# ``tests/ci/test_generate_migrated_test_map.py``.  Maps a pre-migration root
+# test path to its post-migration subdirectory home, but ONLY for relocations
+# whose top-level source ``aragora/<x>.py`` still exists -- those are the only
+# entries ``infer_test_paths`` can ever consult, because a subdirectory source
+# takes the ``len(parts) == 2`` branch and never reads this map.  Every other
+# relocated root test (the bulk of the migration) resolves via that branch, so
+# listing it here would be dead weight.  Regenerate with
+# ``python3 scripts/ci/generate_migrated_test_map.py``.
 _MIGRATED_TEST_MAP = {  # {old_root_path: new_subdir_path}
-    "tests/test_agent_anthropic.py": "tests/agents/test_agent_anthropic.py",
-    "tests/test_agent_api_common.py": "tests/agents/test_agent_api_common.py",
-    "tests/test_agent_error_classifier.py": "tests/agents/test_agent_error_classifier.py",
-    "tests/test_agent_error_decorators.py": "tests/agents/test_agent_error_decorators.py",
-    "tests/test_agent_fallback_integration.py": "tests/agents/test_agent_fallback_integration.py",
-    "tests/test_agent_gemini.py": "tests/agents/test_agent_gemini.py",
-    "tests/test_agent_grok.py": "tests/agents/test_agent_grok.py",
-    "tests/test_agent_laboratory.py": "tests/agents/test_agent_laboratory.py",
-    "tests/test_agent_lm_studio.py": "tests/agents/test_agent_lm_studio.py",
-    "tests/test_agent_local.py": "tests/agents/test_agent_local.py",
-    "tests/test_agent_mistral.py": "tests/agents/test_agent_mistral.py",
-    "tests/test_agent_ollama.py": "tests/agents/test_agent_ollama.py",
-    "tests/test_agent_openai.py": "tests/agents/test_agent_openai.py",
-    "tests/test_agent_openrouter.py": "tests/agents/test_agent_openrouter.py",
-    "tests/test_agent_performance_monitor.py": "tests/agents/test_agent_performance_monitor.py",
-    "tests/test_agent_positions.py": "tests/agents/test_agent_positions.py",
-    "tests/test_agents_airlock.py": "tests/agents/test_agents_airlock.py",
-    "tests/test_agents_telemetry.py": "tests/agents/test_agents_telemetry.py",
-    "tests/test_agents_unit.py": "tests/agents/test_agents_unit.py",
-    "tests/test_api_agent_base.py": "tests/agents/test_api_agent_base.py",
-    "tests/test_api_agents.py": "tests/agents/test_api_agents.py",
-    "tests/test_api_agents_extended.py": "tests/agents/test_api_agents_extended.py",
-    "tests/test_api_agents_rate_limiter.py": "tests/agents/test_api_agents_rate_limiter.py",
-    "tests/test_cli_agents_sanitization.py": "tests/agents/test_cli_agents_sanitization.py",
-    "tests/test_cli_fallback.py": "tests/agents/test_cli_fallback.py",
-    "tests/test_error_classification.py": "tests/agents/test_error_classification.py",
-    "tests/test_error_classifier.py": "tests/agents/test_error_classifier.py",
     "tests/test_exceptions.py": "tests/agents/test_exceptions.py",
-    "tests/test_fallback_chain.py": "tests/agents/test_fallback_chain.py",
-    "tests/test_moment_detector.py": "tests/agents/test_moment_detector.py",
-    "tests/test_tournament.py": "tests/ranking/test_tournament.py",
 }
 
 

--- a/tests/ci/test_generate_migrated_test_map.py
+++ b/tests/ci/test_generate_migrated_test_map.py
@@ -1,0 +1,124 @@
+"""Drift guard for scripts/ci/generate_migrated_test_map.py.
+
+Enforces that the committed ``_MIGRATED_TEST_MAP`` in
+``scripts/nomic_ci_test_selector.py`` matches the map freshly derived from the
+three P1 tests-migration commits (PRs #8387, #8404, #8415) -- i.e. the
+"auto-generated" label is real, not aspirational.
+
+The derivation needs git history; on a shallow clone (no migration commits)
+the history-dependent tests skip rather than fail spuriously.  The
+``_top_level_source_exists`` invariant tests are git-independent and always run.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_GEN_PATH = REPO_ROOT / "scripts" / "ci" / "generate_migrated_test_map.py"
+
+_spec = importlib.util.spec_from_file_location("generate_migrated_test_map", _GEN_PATH)
+gen = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gen)
+
+
+def _derive_or_skip() -> dict[str, str]:
+    try:
+        return gen.derive_map()
+    except gen.HistoryUnavailable as exc:  # shallow clone -- nothing to enforce
+        pytest.skip(str(exc))
+
+
+class TestDerivedMap:
+    """The derivation produces exactly the reachable (top-level) entries."""
+
+    def test_only_top_level_reachable_relocation_is_exceptions(self):
+        """aragora/exceptions.py is the sole relocated top-level module."""
+        derived = _derive_or_skip()
+        assert derived == {"tests/test_exceptions.py": "tests/agents/test_exceptions.py"}
+
+    def test_committed_map_matches_derived(self):
+        """The committed _MIGRATED_TEST_MAP equals the freshly-derived map."""
+        derived = _derive_or_skip()
+        assert gen.committed_map() == derived
+
+    def test_check_passes_on_clean_tree(self):
+        """`--check` exits 0 when committed and derived agree."""
+        _derive_or_skip()  # ensures history is present, else skip
+        assert gen.main(["--check"]) == 0
+
+
+class TestCommittedMapInvariants:
+    """Git-independent invariants -- always enforced, even on a shallow clone."""
+
+    def test_every_committed_entry_is_top_level_reachable(self):
+        """No dead entries: every key maps from an existing top-level module."""
+        committed = gen.committed_map()
+        assert committed, "the migration map should not be empty"
+        for old in committed:
+            assert old.startswith("tests/test_")
+            assert "/" not in old[len("tests/") :], f"{old} is not a root-form key"
+            assert gen._top_level_source_exists(old), (
+                f"dead entry {old}: no top-level aragora source"
+            )
+
+    def test_every_committed_destination_exists(self):
+        """Every migrated target still exists on disk (catches re-relocation)."""
+        committed = gen.committed_map()
+        missing = [new for new in committed.values() if not (REPO_ROOT / new).exists()]
+        assert missing == []
+
+
+class TestCheckDetectsDrift:
+    """`--check` fails (non-zero, offender named) on a tampered committed map."""
+
+    def test_dead_entry_fails_check(self, monkeypatch, capsys):
+        _derive_or_skip()
+        polluted = dict(gen.committed_map())
+        polluted["tests/test_agent_grok.py"] = "tests/agents/test_agent_grok.py"
+        monkeypatch.setattr(gen, "committed_map", lambda: polluted)
+
+        rc = gen.main(["--check"])
+
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert "tests/test_agent_grok.py" in out
+        assert "dead entry" in out
+
+    def test_missing_entry_fails_check(self, monkeypatch, capsys):
+        _derive_or_skip()
+        monkeypatch.setattr(gen, "committed_map", lambda: {})
+
+        rc = gen.main(["--check"])
+
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert "missing reachable entry" in out
+        assert "tests/test_exceptions.py" in out
+
+    def test_wrong_destination_fails_check(self, monkeypatch, capsys):
+        _derive_or_skip()
+        monkeypatch.setattr(
+            gen,
+            "committed_map",
+            lambda: {"tests/test_exceptions.py": "tests/wrong/test_exceptions.py"},
+        )
+
+        rc = gen.main(["--check"])
+
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert "wrong destination" in out
+
+
+def test_format_map_renders_literal_block():
+    """format_map renders the canonical _MIGRATED_TEST_MAP literal block."""
+    rendered = gen.format_map({"tests/test_exceptions.py": "tests/agents/test_exceptions.py"})
+    assert rendered == (
+        "_MIGRATED_TEST_MAP = {  # {old_root_path: new_subdir_path}\n"
+        '    "tests/test_exceptions.py": "tests/agents/test_exceptions.py",\n'
+        "}"
+    )

--- a/tests/ci/test_nomic_ci_test_selector.py
+++ b/tests/ci/test_nomic_ci_test_selector.py
@@ -56,8 +56,8 @@ class TestRelocatedTestPath:
         assert result is None
 
     def test_map_is_non_empty(self):
-        """The migration map contains representative entries from all 3 batches."""
-        assert len(_MIGRATED_TEST_MAP) >= 30
+        """Every map entry is a well-formed root -> subdirectory relocation."""
+        assert _MIGRATED_TEST_MAP
         for old, new in _MIGRATED_TEST_MAP.items():
             assert old.startswith("tests/test_")
             assert new.startswith("tests/")
@@ -84,7 +84,7 @@ class TestInferTestPathsTopLevel:
         assert "tests/test_resilience_config.py" in result
 
     def test_relocated_via_migration_map(self, monkeypatch):
-        """When legagy root is missing but the migration map has it, the
+        """When legacy root is missing but the migration map has it, the
         relocated path is selected."""
         # tests/test_exceptions.py was relocated to tests/agents/test_exceptions.py
         # Only the new path exists on disk


### PR DESCRIPTION
## Source

Tier-2 hygiene cleanup bundling the 3 non-blocking #8540 review-quorum items (claude/grok) for the test-selector migration map (`scripts/nomic_ci_test_selector.py` + `tests/ci/test_nomic_ci_test_selector.py`).

## What changed

1. **[claude P3] Remove dead `_MIGRATED_TEST_MAP` entries.** `infer_test_paths` only consults the map for a top-level `aragora/<x>.py` (the `len(parts) == 1` branch); a subdirectory source takes the `len(parts) == 2` branch and never reads the map. Of the 31 committed entries, 30 mapped from sources that live under `aragora/<...>/` (the `agent_*`/`api_agent*`/`cli_*` family, and also `tournament` whose real source is `aragora/tournaments/tournament.py`, `error_classifier`, etc.), so they were dead weight. Across all **599** root-test renames in the three P1 migration commits, `aragora/exceptions.py` is the **only** relocated top-level module, so the map is now the single reachable entry `tests/test_exceptions.py -> tests/agents/test_exceptions.py`.

2. **[grok P2] Enforce the "auto-generated" label.** New `scripts/ci/generate_migrated_test_map.py` derives the map directly from the migration-commit git diffs (PRs #8387/#8404/#8415), filtered to top-level-reachable relocations; `--check` exits non-zero (naming offenders) when the committed map diverges. New `tests/ci/test_generate_migrated_test_map.py` is the drift guard: the git-independent "no dead entries" + "destinations still exist" invariants always run, while the full git-derivation check skips gracefully on a shallow clone.

3. **[claude P3] Typo fix** `legagy` -> `legacy` in the `test_relocated_via_migration_map` docstring.

## Behavior unchanged

`infer_test_paths` + exit-code semantics are byte-for-byte unchanged (only the map literal + its comment change). The three #8540 dry-run probes resolve identically old vs new:

| probe | resolution (old == new) |
|---|---|
| `aragora/exceptions.py` | `["tests/agents/test_exceptions.py"]` |
| `aragora/resilience_config.py` | `["tests/test_resilience_config.py"]` |
| `aragora/connectors/twitter_poster.py` | `["tests/connectors/test_twitter_poster.py", "tests/connectors/test_twitter_poster_root.py"]` |

Removing dead entries cannot change real-world resolution: the map is only consulted for an existing top-level `aragora/<x>.py`, and every removed entry's source does not exist as a top-level module.

## Validation

- `python3 scripts/ci/generate_migrated_test_map.py --check` -> `OK: committed _MIGRATED_TEST_MAP matches the derived map (1 entries).`
- `python3 -m pytest tests/ci/test_generate_migrated_test_map.py tests/ci/test_nomic_ci_test_selector.py` -> 30 passed (red-first: 3 failed before the prune)
- `make lint` green; `ruff format --check` green; typecheck differential `new=62 <= env-drift 66`; `make test-smoke` OK; smoke tier 138 passed; multi-seed sweep (seeds 1/42/100/2024) green.

## Risk

Low; internal-cleanliness only. No workflow files touched (stays Tier-2). The selector's public behavior and the nomic CI dry-run output are unchanged.
