### PR TITLE
ci: enable severity-gated dissent in merge quorum

### DIFF
--- a/.github/workflows/aragora-merge-quorum.yml
+++ b/.github/workflows/aragora-merge-quorum.yml
@@ -108,8 +108,8 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
           IS_DRAFT: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft || 'false' }}
           # Activate the merged severity-gated dissent policy for the required gate:
-          # [P2]/[P3]-only findings are advisory, while P0/P1 and changes-requested
-          # findings remain blocking.
+          # [P2]/[P3]-only or finding-free CHANGES-REQUESTED reviews are advisory,
+          # while P0/P1 findings and populated Blocker labels remain blocking.
           ARAGORA_ENABLE_SEVERITY_GATED_DISSENT: "1"
         shell: bash
         run: |

--- a/.github/workflows/aragora-merge-quorum.yml
+++ b/.github/workflows/aragora-merge-quorum.yml
@@ -107,6 +107,10 @@ jobs:
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
           IS_DRAFT: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft || 'false' }}
+          # Activate the merged severity-gated dissent policy for the required gate:
+          # [P2]/[P3]-only findings are advisory, while P0/P1 and changes-requested
+          # findings remain blocking.
+          ARAGORA_ENABLE_SEVERITY_GATED_DISSENT: "1"
         shell: bash
         run: |
           set -euo pipefail

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3412,13 +3412,15 @@ def _tier_requirement(tier: int) -> dict[str, Any]:
     # design (claude #8507 P1; full rationale in docs/specs/TIERED_MERGE_GATE_QUORUM_POLICY.md):
     #   * This live merge gate is evaluated fresh on every CI run against the PR's
     #     current evidence, so there is no prepare→apply staleness window to reconcile.
-    #     It reads the live flag directly. The activated default is ON, and the
-    #     operator's explicit opt-out flag is the revocation control (set it falsey
-    #     to restore strict behavior everywhere).
+    #     It reads the live tiered-merge flag directly. That flag remains default
+    #     OFF, and enabling it is itself the operator's deliberate, Tier-4-gated
+    #     audit point — the global flag is the revocation control (flip OFF to
+    #     revoke the one-western-frontier Tier 1-2 relaxation everywhere).
     #   * The auto-settle apply path stores a prepared artifact with a real time gap
     #     between prepare and apply, so it additionally reconciles via min(prepared,
     #     live) to stop a flag flip from retroactively relaxing a stale artifact.
-    # Only the apply path needs the extra reconciliation because only it has stored,
+    # Both paths are strict unless the tiered-merge flag is explicitly enabled; only
+    # the apply path needs the extra reconciliation because only it has stored,
     # deferrable state.
     rule = tier_quorum_rule(tier, tiered_gate=tiered_merge_gate_enabled())
     return {

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3412,14 +3412,14 @@ def _tier_requirement(tier: int) -> dict[str, Any]:
     # design (claude #8507 P1; full rationale in docs/specs/TIERED_MERGE_GATE_QUORUM_POLICY.md):
     #   * This live merge gate is evaluated fresh on every CI run against the PR's
     #     current evidence, so there is no prepare→apply staleness window to reconcile.
-    #     It reads the live flag directly. The flag is default OFF, and enabling it is
-    #     itself the operator's deliberate, Tier-4-gated audit point — the global flag
-    #     *is* the revocation control (flip OFF to revoke everywhere).
+    #     It reads the live flag directly. The activated default is ON, and the
+    #     operator's explicit opt-out flag is the revocation control (set it falsey
+    #     to restore strict behavior everywhere).
     #   * The auto-settle apply path stores a prepared artifact with a real time gap
     #     between prepare and apply, so it additionally reconciles via min(prepared,
     #     live) to stop a flag flip from retroactively relaxing a stale artifact.
-    # Both are strict-by-default; only the apply path needs the extra reconciliation
-    # because only it has stored, deferrable state.
+    # Only the apply path needs the extra reconciliation because only it has stored,
+    # deferrable state.
     rule = tier_quorum_rule(tier, tiered_gate=tiered_merge_gate_enabled())
     return {
         "required_model_signals": rule.required_signals,
@@ -4207,18 +4207,18 @@ def _dissenting_views_from_comments(
 ) -> list[dict[str, Any]]:
     """Extract exact-head model-review comments that visibly request changes.
 
-    When ``ARAGORA_ENABLE_SEVERITY_GATED_DISSENT`` is OFF (default) a comment that
-    ``_has_blocking_or_negative_verdict`` — a real ``[P0]``/``[P1]`` finding, a
-    populated Blocker label, OR a bare negative ``Verdict:`` line — promotes a
-    blocking dissent, byte-identical to historical behavior.
-
-    When the flag is ON, only a comment backed by a real ``[P0]``/``[P1]`` finding
+    By default, only a comment backed by a real ``[P0]``/``[P1]`` finding
     or a populated Blocker label (``_has_blocking_finding_or_label``) promotes a
     blocking dissent. A ``[P2]``/``[P3]``-only or finding-free CHANGES-REQUESTED is
     downgraded to *advisory*: non-blocking, and — because it is excluded from the
     returned blocking-dissent list and never marked supportive — non-counting. The
     downgraded comment is still recorded (in ``advisory_views`` when provided) so the
     review quality stays visible on the PR / in the audit packet.
+
+    When ``ARAGORA_ENABLE_SEVERITY_GATED_DISSENT=0`` (or another explicit falsey
+    value), a comment that ``_has_blocking_or_negative_verdict`` — a real ``[P0]`` /
+    ``[P1]`` finding, a populated Blocker label, OR a bare negative ``Verdict:`` line
+    — promotes a blocking dissent, byte-identical to legacy strict behavior.
     """
     markers = (
         "dogfood",
@@ -4244,9 +4244,10 @@ def _dissenting_views_from_comments(
         lower = body.lower()
         if not any(token in lower for token in markers):
             continue
-        # Flag OFF: a bare negative Verdict line still blocks (historical behavior).
-        # Flag ON: only a real [P0]/[P1] finding or a populated Blocker label blocks;
-        # a [P2]/[P3]-only or finding-free CHANGES-REQUESTED becomes advisory.
+        # Severity-gated ON: only a real [P0]/[P1] finding or a populated Blocker
+        # label blocks; a [P2]/[P3]-only or finding-free CHANGES-REQUESTED becomes
+        # advisory. Explicit OFF preserves legacy strict behavior, where a bare
+        # negative Verdict line still blocks.
         blocks = (
             _has_blocking_finding_or_label(body)
             if severity_gated

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -44,6 +44,7 @@ from aragora.cli.commands.review_queue_parsers import (
 from aragora.cli.commands.review_queue_comment_verdicts import (
     has_blocking_finding_or_label as _has_blocking_finding_or_label,
     has_blocking_or_negative_verdict as _has_blocking_or_negative_verdict,
+    has_negative_verdict_line as _has_negative_verdict_line,
     highest_blocking_severity as _highest_blocking_severity,
 )
 from aragora.cli.commands.review_queue_transport import (
@@ -4288,10 +4289,11 @@ def _build_advisory_view(comment: dict[str, Any], body: str) -> dict[str, Any] |
     comment that, under the severity gate, carries only ``[P2]``/``[P3]`` (or no)
     findings. Returns ``None`` if the reviewer identity is unrecognized.
     """
-    # The comment WOULD have blocked under the strict (flag-OFF) regime: it is a
-    # genuine negative verdict, just not backed by a real [P0]/[P1] finding or a
-    # populated Blocker label. Recording it preserves the reviewer's signal.
-    if not _has_blocking_or_negative_verdict(body):
+    # The comment WOULD have blocked under the strict (explicit-OFF) regime because
+    # it is a genuine negative verdict, just not backed by a real [P0]/[P1] finding
+    # or a populated Blocker label. A PASS body that merely includes [P2] follow-ups
+    # should remain a PASS, not an advisory changes-requested record.
+    if not _has_negative_verdict_line(body):
         return None
     identity = _resolve_model_review_identity(body)
     if identity.surface_reviewer_id == "unknown_model_reviewer":

--- a/aragora/cli/commands/review_queue_comment_verdicts.py
+++ b/aragora/cli/commands/review_queue_comment_verdicts.py
@@ -271,6 +271,26 @@ def has_blocking_or_negative_verdict(body: str) -> bool:
     return False
 
 
+def has_negative_verdict_line(body: str) -> bool:
+    """Return True when ``body`` has a negative Verdict/Decision/Recommendation line."""
+    for raw_line in str(body or "").splitlines():
+        stripped = raw_line.strip()
+        if not stripped:
+            continue
+        line = _strip_decoration(stripped).replace("**", "").replace("__", "")
+        match = re.match(r"^(?P<label>[^:—–-]+?)\s*(?::|—|–|-)\s*(?P<value>.*)$", line)
+        if not match:
+            continue
+        normalized_label = re.sub(r"\s+", " ", match.group("label").strip().lower())
+        normalized_label = normalized_label.strip("*_ ")
+        if normalized_label not in {"verdict", "decision", "recommendation"}:
+            continue
+        normalized_value = _normalize_value(match.group("value"))
+        if _starts_with_phrase(normalized_value, _NEGATIVE_VERDICT_PREFIXES):
+            return True
+    return False
+
+
 def highest_blocking_severity(body: str) -> str | None:
     """Return ``"P0"``/``"P1"`` if ``body`` carries a real (non-:data:`_NO_FINDING_HEADS`)
     `[P0]`/`[P1]` finding line, else ``None``.

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -118,33 +118,40 @@ def tiered_merge_gate_enabled(env: dict[str, str] | None = None) -> bool:
     return str(source.get(_TIERED_GATE_ENV, "")).strip().lower() in _TIERED_GATE_TRUE
 
 
-# Opt-in flag for severity-gated dissent. When OFF (default), a reviewer
-# ``Verdict: CHANGES-REQUESTED`` line promotes a *blocking* dissent regardless of
-# finding severity — even a `[P2]`/`[P3]`-only or finding-free comment blocks the
-# merge as hard as a `[P0]` defect (today's behavior). When ON, a CHANGES-REQUESTED
+# Activation flag for severity-gated dissent. By default, a CHANGES-REQUESTED
 # comment promotes a blocking dissent ONLY when it carries a real `[P0]`/`[P1]`
 # finding or a populated Blocker label; a `[P2]`/`[P3]`-only or finding-free
 # CHANGES-REQUESTED becomes *advisory* — non-blocking AND non-counting (it still
 # posts and stays visible on the PR; it just no longer blocks). `[P0]`/`[P1]`
-# findings and populated Blocker labels ALWAYS block, flag ON or OFF.
+# findings and populated Blocker labels ALWAYS block. Operators can explicitly
+# opt out to the legacy strict behavior with ARAGORA_ENABLE_SEVERITY_GATED_DISSENT=0.
 #
-# Gating this behind the flag keeps it revertible WITHOUT a code change and is the
-# in-tree audit point for the operator's approval. See
+# Keeping an explicit opt-out keeps the policy revertible WITHOUT a code change after
+# the operator-approved activation. See
 # docs/specs/FINDING_SEVERITY_GATE.md and
 # docs/REVIEW_AUTHORITY_PRINCIPLES.md::Family-additive change governance.
 _SEVERITY_GATED_DISSENT_ENV = "ARAGORA_ENABLE_SEVERITY_GATED_DISSENT"
 _SEVERITY_GATED_DISSENT_TRUE = frozenset(("1", "true", "yes", "on"))
+_SEVERITY_GATED_DISSENT_FALSE = frozenset(("0", "false", "no", "off"))
 
 
 def severity_gated_dissent_enabled(env: dict[str, str] | None = None) -> bool:
-    """Whether the opt-in severity-gated dissent gate is active. Default OFF; a
-    `[P2]`/`[P3]`-only CHANGES-REQUESTED only becomes advisory (non-blocking,
-    non-counting) when this is ON. See :data:`_SEVERITY_GATED_DISSENT_ENV`."""
+    """Whether the severity-gated dissent gate is active.
+
+    Default ON after the operator-approved activation; explicit falsey values opt out
+    to the legacy strict behavior. Unknown non-empty values fail strict.
+    See :data:`_SEVERITY_GATED_DISSENT_ENV`.
+    """
     source = os.environ if env is None else env
-    return (
-        str(source.get(_SEVERITY_GATED_DISSENT_ENV, "")).strip().lower()
-        in _SEVERITY_GATED_DISSENT_TRUE
-    )
+    raw = source.get(_SEVERITY_GATED_DISSENT_ENV)
+    if raw is None or str(raw).strip() == "":
+        return True
+    value = str(raw).strip().lower()
+    if value in _SEVERITY_GATED_DISSENT_TRUE:
+        return True
+    if value in _SEVERITY_GATED_DISSENT_FALSE:
+        return False
+    return False
 
 
 def _coerce_relaxed_flag(value: Any) -> bool:

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -435,16 +435,16 @@ class EvidenceItem:
         if self.verdict != "changes_requested":
             return False
         if not self.severity_gated:
-            # Default (flag OFF): any changes_requested is a blocking dissent —
-            # byte-identical to historical behavior.
+            # Explicit strict opt-out: any changes_requested is a blocking dissent,
+            # byte-identical to legacy behavior.
             return True
-        # Flag ON: a changes_requested is dissenting (blocks / trips prepare-only)
-        # ONLY when backed by a real [P0]/[P1] finding OR a populated Blocker label
-        # (``has_blocking_finding_or_label`` — the SAME helper the review-queue gate
-        # half consults, so the two halves stay in lockstep and Blocker labels always
-        # block per the invariant). A [P2]/[P3]-only or finding-free changes_requested
-        # is advisory — non-blocking, and (because ``supportive`` is unchanged) still
-        # non-counting.
+        # Default active policy: a changes_requested is dissenting (blocks / trips
+        # prepare-only) ONLY when backed by a real [P0]/[P1] finding OR a populated
+        # Blocker label (``has_blocking_finding_or_label`` — the SAME helper the
+        # review-queue gate half consults, so the two halves stay in lockstep and
+        # Blocker labels always block per the invariant). A [P2]/[P3]-only or
+        # finding-free changes_requested is advisory — non-blocking, and (because
+        # ``supportive`` is unchanged) still non-counting.
         return has_blocking_finding_or_label(self.body)
 
 

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -1796,6 +1796,7 @@ def collect_evidence(
         tier=tier,
         action=action,
         action_reason=action_reason,
+        tiered_gate=tiered_merge_gate_enabled(env),
     )
 
     prompt = prompt_builder(repo, pr, ctx)
@@ -1865,6 +1866,7 @@ def collect_evidence(
                 verdict=_reviewer_verdict(result.text),
                 counted_reviewer_ids=list(lint.get("counted_reviewer_ids") or []),
                 problems=list(lint.get("problems") or []),
+                severity_gated=severity_gated_dissent_enabled(env),
             )
         )
 
@@ -2050,12 +2052,12 @@ def apply_prepared_evidence(
     # live (itself the Tier-4-gated decision). Anyone who can forge the artifact JSON
     # can also forge reviewer bodies, so artifact integrity is the caller's trust
     # boundary — this field grants no authority beyond what the live flag already does.
-    live_gate = tiered_merge_gate_enabled()
+    live_gate = tiered_merge_gate_enabled(env)
     effective_tiered_gate = bool(prepared.tiered_gate) and live_gate
     # Reconcile the severity-gate regime the same way: a relaxed-prepared artifact
     # only stays relaxed when the live flag also relaxes; otherwise dissent is
     # re-evaluated under the strict regime. Mirrors effective_tiered_gate.
-    live_severity_gated = severity_gated_dissent_enabled()
+    live_severity_gated = severity_gated_dissent_enabled(env)
 
     tier = tier_fetcher(repo, pr)
     action, action_reason = decide_action(tier, apply)

--- a/docs/specs/FINDING_SEVERITY_GATE.md
+++ b/docs/specs/FINDING_SEVERITY_GATE.md
@@ -39,9 +39,9 @@ treadmill: the reviewer keeps re-raising the same low-severity nits against each
 head, and the PR can never settle. The negative *word* — not the finding *severity*
 — is what blocks.
 
-## Proposed behavior (opt-in)
+## Proposed behavior (active by default, explicit opt-out)
 
-Behind `ARAGORA_ENABLE_SEVERITY_GATED_DISSENT` (default OFF), a CHANGES-REQUESTED
+With `ARAGORA_ENABLE_SEVERITY_GATED_DISSENT` unset or truthy, a CHANGES-REQUESTED
 comment promotes a **blocking** dissent only when it carries a real `[P0]`/`[P1]`
 finding **or** a populated Blocker label. A `[P2]`/`[P3]`-only or finding-free
 CHANGES-REQUESTED becomes **advisory**:
@@ -60,11 +60,13 @@ of a low-severity dissent is removed.
 
 ## Invariants
 
-1. **Flag OFF = zero severity-gating behavior change, plus one disclosed security
-   fix.** With the flag unset/falsey the severity-gating semantics are byte-identical
-   to today — the existing review_queue / quorum_evidence suites stay green and the
-   flag-OFF characterization tests in `tests/governance/test_finding_severity_gate.py`
-   pin it. The **one** deliberate flag-independent change is a security fix to the
+1. **Explicit flag OFF = legacy strict behavior, plus one disclosed security
+   fix.** With the flag explicitly falsey (`0`, `false`, `no`, `off`) the
+   severity-gating semantics are byte-identical to legacy strict behavior — the
+   existing review_queue / quorum_evidence suites stay green and the flag-OFF
+   characterization tests in `tests/governance/test_finding_severity_gate.py`
+   pin it. Unknown non-empty values also fail strict. The **one** deliberate
+   flag-independent change is a security fix to the
    pre-existing Blocker-label scanner: a populated Blocker label whose finding text
    begins with a bare "no" (e.g. `Blockers: no authentication on admin endpoint`)
    previously matched the non-blocking prefix `"no"` and was silently demoted to
@@ -92,7 +94,9 @@ Four changes; flag OFF ⇒ identical behavior:
 1. **Flag** `ARAGORA_ENABLE_SEVERITY_GATED_DISSENT` + helper
    `severity_gated_dissent_enabled(env=None)` in
    `aragora/swarm/quorum_evidence.py`, mirroring `tiered_merge_gate_enabled`
-   exactly (same truthy set `{1, true, yes, on}`, default OFF).
+   for truthy values `{1, true, yes, on}` and adding explicit opt-out values
+   `{0, false, no, off}`. The default is ON after activation; unknown non-empty
+   values fail strict.
 2. **Shared helpers** in `aragora/cli/commands/review_queue_comment_verdicts.py`:
    - `highest_blocking_severity(body) -> "P0" | "P1" | None` — reuses the exact
      `[P0]`/`[P1]` detection (and `_NO_FINDING_HEADS`) that
@@ -127,6 +131,6 @@ Four changes; flag OFF ⇒ identical behavior:
 
 ## Rollout
 
-Phase 1 of the nitpick-vs-real plan: land the opt-in flag (default OFF) plus
-pre-approval artifacts, so the operator can enable it per the governance contract.
-No CI default is changed by this PR.
+Phase 1 of the nitpick-vs-real plan landed the flag and pre-approval artifacts.
+The activation PR turns the policy on by default across CI and local/operator
+probes, while preserving an explicit environment opt-out for fast rollback.

--- a/docs/specs/FINDING_SEVERITY_GATE.md
+++ b/docs/specs/FINDING_SEVERITY_GATE.md
@@ -8,7 +8,8 @@ required by
 (a change to *what blocks a merge at a given Tier* is a Tier 4 self-modification by
 the same rule that governs which family counts at which Tier).
 
-**Enforcement is opt-in and default-OFF.** With the flag OFF the gate behaves
+**Enforcement is active by default after activation, with explicit opt-out.** With the
+flag explicitly OFF the gate behaves
 byte-identically to today (proven by the flag-OFF characterization tests). The
 behavior is revertible WITHOUT a code change — unset the environment flag. The flag
 is the in-tree audit point for the operator's approval.
@@ -89,7 +90,7 @@ of a low-severity dissent is removed.
 
 ## Implementation
 
-Four changes; flag OFF ⇒ identical behavior:
+Four changes; explicit flag OFF ⇒ legacy strict behavior:
 
 1. **Flag** `ARAGORA_ENABLE_SEVERITY_GATED_DISSENT` + helper
    `severity_gated_dissent_enabled(env=None)` in

--- a/docs/specs/FINDING_SEVERITY_GATE.md
+++ b/docs/specs/FINDING_SEVERITY_GATE.md
@@ -114,21 +114,22 @@ Four changes; explicit flag OFF ⇒ legacy strict behavior:
      never by the negative-verdict check, so positive verdicts like `Verdict: no
      concerns` are not promoted to blocking dissents.
 3. **`_dissenting_views_from_comments`** (review_queue) consults
-   `has_blocking_finding_or_label` when the flag is ON (dropping the bare-negative-
-   verdict trigger) and `has_blocking_or_negative_verdict` when OFF. Downgraded
-   comments are recorded in `advisory_views` and surfaced as a non-blocking
-   `reasons` note.
+   `has_blocking_finding_or_label` in the default active regime (dropping the
+   bare-negative-verdict trigger) and `has_blocking_or_negative_verdict` only under
+   explicit strict opt-out. Downgraded negative-verdict comments are recorded in
+   `advisory_views` and surfaced as a non-blocking `reasons` note.
 4. **`EvidenceItem.dissenting`** (quorum_evidence) is `dissenting` only when
-   `verdict == "changes_requested" AND has_blocking_finding_or_label(body)` while the
-   flag is ON — i.e. a real `[P0]`/`[P1]` finding OR a populated Blocker label (the
-   latter blocks even without a `[P0]`/`[P1]` marker, matching the review-queue half;
-   this is strictly broader than `highest_blocking_severity(body) is not None`, which
-   only detects `[P0]`/`[P1]`). OFF ⇒ `dissenting = (verdict == "changes_requested")`
-   as today. The flag is captured once at construction (`severity_gated` field) and —
-   like `CollectOutcome.tiered_gate` — is serialized into prepared artifacts and
-   reconciled `effective = prepared AND live` at apply, so a gate decision stays
-   deterministic and cannot be relaxed by flipping the env between prepare and apply.
-   `supportive` is unchanged.
+   `verdict == "changes_requested" AND has_blocking_finding_or_label(body)` in the
+   default active regime — i.e. a real `[P0]`/`[P1]` finding OR a populated Blocker
+   label (the latter blocks even without a `[P0]`/`[P1]` marker, matching the
+   review-queue half; this is strictly broader than
+   `highest_blocking_severity(body) is not None`, which only detects `[P0]`/`[P1]`).
+   Explicit strict opt-out makes every `changes_requested` verdict dissenting, as
+   legacy behavior did. The flag is captured once at construction (`severity_gated`
+   field) and — like `CollectOutcome.tiered_gate` — is serialized into prepared
+   artifacts and reconciled `effective = prepared AND live` at apply, so a gate
+   decision stays deterministic and cannot be relaxed by flipping the env between
+   prepare and apply. `supportive` is unchanged.
 
 ## Rollout
 

--- a/docs/specs/FINDING_SEVERITY_GATE.md
+++ b/docs/specs/FINDING_SEVERITY_GATE.md
@@ -1,18 +1,18 @@
-# Finding-Severity Dissent Gate (Tier 4 Pre-Approval)
+# Finding-Severity Dissent Gate
 
-**Status:** design doc / pre-approval artifact for a Tier 4 merge-authority
+**Status:** activation spec and rollback contract for a Tier 4 merge-authority
 self-modification. This file and
-`tests/governance/test_finding_severity_gate.py` are the pre-approval artifact
-required by
-`docs/REVIEW_AUTHORITY_PRINCIPLES.md::Family-additive change governance`
-(a change to *what blocks a merge at a given Tier* is a Tier 4 self-modification by
-the same rule that governs which family counts at which Tier).
+`tests/governance/test_finding_severity_gate.py` remain the audit artifact required
+by `docs/REVIEW_AUTHORITY_PRINCIPLES.md::Family-additive change governance` (a
+change to *what blocks a merge at a given Tier* is a Tier 4 self-modification by the
+same rule that governs which family counts at which Tier).
 
 **Enforcement is active by default after activation, with explicit opt-out.** With the
 flag explicitly OFF the gate behaves
 byte-identically to today (proven by the flag-OFF characterization tests). The
-behavior is revertible WITHOUT a code change — unset the environment flag. The flag
-is the in-tree audit point for the operator's approval.
+behavior is revertible WITHOUT a code change by setting
+`ARAGORA_ENABLE_SEVERITY_GATED_DISSENT=0` (or `false`, `no`, `off`). Unset/empty
+means active. The flag is the in-tree audit point for the operator's approval.
 
 ## Problem Statement
 

--- a/scripts/aragora_runtime.sh
+++ b/scripts/aragora_runtime.sh
@@ -9,6 +9,10 @@
 # systemd service. Installers must call this at launch time (via a wrapper),
 # never bake an absolute interpreter path into the generated unit.
 
+# Align long-running local governance loops with the required merge-quorum gate.
+# Operators can still opt out explicitly by exporting the flag as 0/false/off.
+export ARAGORA_ENABLE_SEVERITY_GATED_DISSENT="${ARAGORA_ENABLE_SEVERITY_GATED_DISSENT:-1}"
+
 # Determine the repository root. Honors ARAGORA_REPO_ROOT, otherwise derives it
 # from this file's location (scripts/.. == repo root) regardless of the caller.
 aragora_repo_root() {

--- a/scripts/run_codex_automation_publisher.sh
+++ b/scripts/run_codex_automation_publisher.sh
@@ -5,6 +5,9 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 LOCK_DIR="${TMPDIR:-/tmp}/com.aragora.codex-automation-publisher.lock"
 export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 export CODEX_HOME="${CODEX_HOME:-${HOME}/.codex}"
+# Align publisher value-drain / settlement probes with the required merge-quorum
+# gate while preserving an explicit operator opt-out.
+export ARAGORA_ENABLE_SEVERITY_GATED_DISSENT="${ARAGORA_ENABLE_SEVERITY_GATED_DISSENT:-1}"
 PYTHON_BIN="${ARAGORA_AUTOMATION_PYTHON:-python3}"
 HANDOFF_LIMIT="${ARAGORA_AUTOMATION_HANDOFF_LIMIT:-2}"
 MAX_OPEN_ISSUES="${ARAGORA_AUTOMATION_MAX_OPEN_ISSUES:-16}"

--- a/tests/governance/test_finding_severity_gate.py
+++ b/tests/governance/test_finding_severity_gate.py
@@ -198,11 +198,11 @@ def test_p1_none_head_still_no_finding_after_fix():
 
 
 class TestFlagOnBlockerLabelSecurityBypass:
-    """Flag ON: a security-phrased populated Blocker label promotes a BLOCKING
+    """Default/flag ON: a security-phrased populated Blocker label promotes a BLOCKING
     dissent (not advisory). Regression for openai #8574 [P1]."""
 
     def test_no_auth_blocker_label_still_blocks_dissent(self, monkeypatch):
-        monkeypatch.setenv(_FLAG, "1")
+        monkeypatch.delenv(_FLAG, raising=False)
         advisory: list[dict] = []
         dissent = _dissenting_views_from_comments(
             [_comment(_BLOCKER_LABEL_NO_AUTH_CHANGES_REQUESTED)],
@@ -216,7 +216,7 @@ class TestFlagOnBlockerLabelSecurityBypass:
 
     @pytest.mark.parametrize("value", _BLOCKER_LABEL_NO_FINDING_SECURITY_PHRASINGS)
     def test_security_phrasings_are_blocking_dissent(self, monkeypatch, value):
-        monkeypatch.setenv(_FLAG, "1")
+        monkeypatch.delenv(_FLAG, raising=False)
         body = (
             "## Claude independent model review\n"
             f"Current head: {_HEAD}\n"
@@ -268,17 +268,18 @@ class TestFlagOffStrict:
             has_pending=False,
             has_failures=False,
         )
-        # The [P2]-only dissent blocks (flag OFF): unresolved_dissent is set and no
-        # advisory downgrade occurs. (``status`` may report a different incomplete
-        # cause first when this synthetic packet's quorum is itself unsatisfied; the
-        # gate-governing signal is ``unresolved_dissent``.)
+        # The [P2]-only dissent blocks under explicit strict opt-out:
+        # unresolved_dissent is set and no advisory downgrade occurs. (``status`` may
+        # report a different incomplete cause first when this synthetic packet's
+        # quorum is itself unsatisfied; the gate-governing signal is
+        # ``unresolved_dissent``.)
         assert quorum["unresolved_dissent"] is True
         assert "unresolved model dissent is present" in quorum["reasons"]
         assert quorum["advisory_views"] == []
 
 
 # --------------------------------------------------------------------------- #
-# Flag ON — severity-gated
+# Default / flag ON — severity-gated
 # --------------------------------------------------------------------------- #
 
 

--- a/tests/governance/test_finding_severity_gate.py
+++ b/tests/governance/test_finding_severity_gate.py
@@ -63,6 +63,12 @@ _BLOCKER_LABEL_CHANGES_REQUESTED = (
 _NO_FINDING_CHANGES_REQUESTED = (
     f"## Claude independent model review\nCurrent head: {_HEAD}\nVerdict: CHANGES-REQUESTED"
 )
+_P2_PASS_REVIEW = (
+    "## Claude independent model review\n"
+    f"Current head: {_HEAD}\n"
+    "Verdict: PASS\n"
+    "[P2] Prefer a constant over the magic number on line 40.\n"
+)
 # A populated Blocker label whose finding text starts with bare "no" — common
 # security phrasing ("no authentication", "no validation", "no authorization").
 # This MUST block: a populated Blocker label always blocks (the stated invariant).
@@ -312,6 +318,16 @@ class TestFlagOnSeverityGated:
         assert dissent == []
         assert len(advisory) == 1
         assert _evidence(_NO_FINDING_CHANGES_REQUESTED).dissenting is False
+
+    def test_pass_with_p2_followup_is_not_advisory_changes_requested(self, monkeypatch):
+        monkeypatch.delenv(_FLAG, raising=False)
+        advisory: list[dict] = []
+        dissent = _dissenting_views_from_comments(
+            [_comment(_P2_PASS_REVIEW)], head_sha=_HEAD, advisory_views=advisory
+        )
+
+        assert dissent == []
+        assert advisory == []
 
     def test_p1_finding_still_blocks(self, monkeypatch):
         monkeypatch.setenv(_FLAG, "1")

--- a/tests/governance/test_finding_severity_gate.py
+++ b/tests/governance/test_finding_severity_gate.py
@@ -6,14 +6,14 @@ These tests are the pre-approval regression target for the design in
 to *what blocks a merge at a given Tier* is a Tier 4 merge-authority
 self-modification).
 
-They pin BOTH regimes of the opt-in ``ARAGORA_ENABLE_SEVERITY_GATED_DISSENT`` flag:
+They pin BOTH regimes of the ``ARAGORA_ENABLE_SEVERITY_GATED_DISSENT`` activation flag:
 
-* **Flag OFF (default / strict)** — byte-identical to today: a
+* **Default / flag ON** — a CHANGES-REQUESTED comment with only ``[P2]``/``[P3]``
+  (or no finding) is *advisory*: non-blocking AND non-counting; a real ``[P1]``
+  finding or a populated Blocker label STILL blocks; a clean PASS still counts.
+* **Flag OFF (explicit strict opt-out)** — byte-identical to legacy strict behavior: a
   ``Verdict: CHANGES-REQUESTED`` comment blocks regardless of finding severity, even
   one that lists only ``[P2]``; ``[P0]``/``[P1]`` blocks; a clean PASS counts.
-* **Flag ON** — a CHANGES-REQUESTED comment with only ``[P2]``/``[P3]`` (or no
-  finding) is *advisory*: non-blocking AND non-counting; a real ``[P1]`` finding or a
-  populated Blocker label STILL blocks; a clean PASS still counts.
 
 The two gate halves — ``review_queue._dissenting_views_from_comments`` and
 ``quorum_evidence.EvidenceItem.dissenting`` — are asserted to AGREE for the same body
@@ -134,15 +134,21 @@ def _evidence(body: str, *, verdict: str = "changes_requested") -> EvidenceItem:
 # --------------------------------------------------------------------------- #
 
 
-def test_flag_defaults_off(monkeypatch):
+def test_flag_defaults_on(monkeypatch):
     monkeypatch.delenv(_FLAG, raising=False)
-    assert severity_gated_dissent_enabled() is False
+    assert severity_gated_dissent_enabled() is True
 
 
 @pytest.mark.parametrize("value", ["1", "true", "yes", "on", "TRUE", "On"])
 def test_flag_truthy_values(monkeypatch, value):
     monkeypatch.setenv(_FLAG, value)
     assert severity_gated_dissent_enabled() is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off", "FALSE", "Off", "bogus"])
+def test_flag_falsey_and_unknown_values_fail_strict(monkeypatch, value):
+    monkeypatch.setenv(_FLAG, value)
+    assert severity_gated_dissent_enabled() is False
 
 
 def test_highest_blocking_severity_pins_finding_recognition():
@@ -220,13 +226,13 @@ class TestFlagOnBlockerLabelSecurityBypass:
 
 
 # --------------------------------------------------------------------------- #
-# Flag OFF (default / strict) — pins TODAY's behavior
+# Explicit flag OFF / strict opt-out — pins legacy strict behavior
 # --------------------------------------------------------------------------- #
 
 
 class TestFlagOffStrict:
     def test_p2_only_changes_requested_still_blocks(self, monkeypatch):
-        monkeypatch.delenv(_FLAG, raising=False)
+        monkeypatch.setenv(_FLAG, "0")
         dissent = _dissenting_views_from_comments(
             [_comment(_P2_ONLY_CHANGES_REQUESTED)], head_sha=_HEAD
         )
@@ -236,7 +242,7 @@ class TestFlagOffStrict:
         assert _evidence(_P2_ONLY_CHANGES_REQUESTED).dissenting is True
 
     def test_p1_changes_requested_blocks(self, monkeypatch):
-        monkeypatch.delenv(_FLAG, raising=False)
+        monkeypatch.setenv(_FLAG, "0")
         assert (
             len(_dissenting_views_from_comments([_comment(_P1_CHANGES_REQUESTED)], head_sha=_HEAD))
             == 1
@@ -252,7 +258,7 @@ class TestFlagOffStrict:
         assert item.supportive is True
 
     def test_integration_p2_only_blocks_quorum(self, monkeypatch):
-        monkeypatch.delenv(_FLAG, raising=False)
+        monkeypatch.setenv(_FLAG, "0")
         pr = _grounded_pr([*_supporting_comments(), _comment(_P2_ONLY_CHANGES_REQUESTED)])
         quorum = _build_model_review_quorum(
             pr=pr,
@@ -384,7 +390,7 @@ class TestFlagOnSeverityGated:
 )
 def test_both_gate_halves_agree(monkeypatch, body, off_blocks, on_blocks):
     # Flag OFF
-    monkeypatch.delenv(_FLAG, raising=False)
+    monkeypatch.setenv(_FLAG, "0")
     rq_off = bool(_dissenting_views_from_comments([_comment(body)], head_sha=_HEAD))
     qe_off = _evidence(body).dissenting
     assert rq_off == qe_off == off_blocks

--- a/tests/governance/test_finding_severity_gate.py
+++ b/tests/governance/test_finding_severity_gate.py
@@ -340,7 +340,7 @@ class TestFlagOnSeverityGated:
         assert item.supportive is True
 
     def test_integration_p2_only_does_not_block_clean_packet(self, monkeypatch):
-        monkeypatch.setenv(_FLAG, "1")
+        monkeypatch.delenv(_FLAG, raising=False)
         pr = _grounded_pr([*_supporting_comments(), _comment(_P2_ONLY_CHANGES_REQUESTED)])
         quorum = _build_model_review_quorum(
             pr=pr,

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -2005,7 +2005,10 @@ def test_apply_relaxed_artifact_posts_when_both_regimes_relaxed(tmp_path, monkey
     assert posted == [_prepared_body("claude")]
 
 
-def test_apply_prepared_evidence_rederives_verdict_from_body(tmp_path) -> None:
+def test_apply_prepared_evidence_rederives_verdict_from_body(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ARAGORA_ENABLE_SEVERITY_GATED_DISSENT", "0")
     prepared = _prepared_outcome_file(
         tmp_path,
         items=[

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -1190,6 +1190,42 @@ def test_collect_severity_gated_finding_free_changes_requested_is_advisory(
     assert all("changes-requested" not in body.lower() for _repo, body in posted)
 
 
+def test_collect_uses_caller_env_for_severity_gate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ARAGORA_ENABLE_SEVERITY_GATED_DISSENT", "1")
+    fakes, posted = _fakes(tier=1)
+
+    def reviewer_runner(family: str, prompt: str) -> ReviewerResult:
+        if family == "grok":
+            return ReviewerResult(
+                "grok",
+                "Verdict: CHANGES-REQUESTED\n- [P2] Add a follow-up smoke test.",
+                True,
+            )
+        return ReviewerResult(family, f"Verdict: PASS from {family}", True)
+
+    fakes["reviewer_runner"] = reviewer_runner
+    outcome = collect_evidence(
+        repo="o/r",
+        pr=1,
+        families=["claude", "openai", "grok"],
+        author="me",
+        apply=True,
+        env={
+            "ARAGORA_ENABLE_TIERED_MERGE_GATE": "1",
+            "ARAGORA_ENABLE_SEVERITY_GATED_DISSENT": "0",
+        },
+        **fakes,
+    )
+
+    assert outcome.tiered_gate is True
+    assert {item.family: item.severity_gated for item in outcome.items}["grok"] is False
+    assert outcome.action == "prepare"
+    assert outcome.dissenting_families == ["grok"]
+    assert posted == []
+
+
 def test_evidence_item_dissenting_uses_captured_outcome_policy(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -2050,6 +2086,108 @@ def test_apply_prepared_evidence_rederives_verdict_from_body(
     assert outcome.dissenting_families == ["claude"]
     assert "reviewer dissent present" in outcome.action_reason
     assert outcome.posted == []
+    assert posted == []
+
+
+def test_apply_prepared_evidence_default_severity_gate_makes_p2_advisory(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("ARAGORA_ENABLE_SEVERITY_GATED_DISSENT", raising=False)
+    prepared = _prepared_outcome_file(
+        tmp_path,
+        items=[
+            EvidenceItem(
+                "grok",
+                _prepared_body("grok", "CHANGES-REQUESTED")
+                + "- [P2] Add a follow-up smoke test.\n",
+                True,
+                ["grok"],
+                [],
+                "changes_requested",
+                severity_gated=True,
+            ),
+            EvidenceItem("claude", _prepared_body("claude"), True, ["claude"], [], "pass"),
+        ],
+    )
+    posted: list[tuple[str, str]] = []
+
+    def linter(pr, head_sha, head_committed_at, author, body, env) -> dict:
+        family = "claude" if "claude body" in body else "grok"
+        return {
+            "would_count": True,
+            "counted_reviewer_ids": [family],
+            "problems": [],
+        }
+
+    outcome = qe.apply_prepared_evidence(
+        repo="o/r",
+        pr=1,
+        prepared_json=prepared,
+        author="me",
+        apply=True,
+        families=["grok", "claude"],
+        context_fetcher=lambda repo, pr: {"head_sha": HEAD, "head_committed_at": COMMITTED},
+        tier_fetcher=lambda repo, pr: 1,
+        linter=linter,
+        poster=lambda repo, pr, body: posted.append((repo, body)),
+    )
+
+    assert outcome.action == "post"
+    assert outcome.dissenting_families == []
+    assert outcome.posted == ["claude"]
+    assert posted == [("o/r", _prepared_body("claude"))]
+
+
+def test_apply_prepared_evidence_uses_caller_env_for_live_severity_gate(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ARAGORA_ENABLE_SEVERITY_GATED_DISSENT", "1")
+    prepared = _prepared_outcome_file(
+        tmp_path,
+        items=[
+            EvidenceItem(
+                "grok",
+                _prepared_body("grok", "CHANGES-REQUESTED")
+                + "- [P2] Add a follow-up smoke test.\n",
+                True,
+                ["grok"],
+                [],
+                "changes_requested",
+                severity_gated=True,
+            ),
+            EvidenceItem("claude", _prepared_body("claude"), True, ["claude"], [], "pass"),
+        ],
+    )
+    posted: list[tuple[str, str]] = []
+
+    def linter(pr, head_sha, head_committed_at, author, body, env) -> dict:
+        family = "claude" if "claude body" in body else "grok"
+        return {
+            "would_count": True,
+            "counted_reviewer_ids": [family],
+            "problems": [],
+        }
+
+    outcome = qe.apply_prepared_evidence(
+        repo="o/r",
+        pr=1,
+        prepared_json=prepared,
+        author="me",
+        apply=True,
+        families=["grok", "claude"],
+        context_fetcher=lambda repo, pr: {"head_sha": HEAD, "head_committed_at": COMMITTED},
+        tier_fetcher=lambda repo, pr: 1,
+        linter=linter,
+        poster=lambda repo, pr, body: posted.append((repo, body)),
+        env={
+            "ARAGORA_ENABLE_TIERED_MERGE_GATE": "1",
+            "ARAGORA_ENABLE_SEVERITY_GATED_DISSENT": "0",
+        },
+    )
+
+    assert outcome.action == "prepare"
+    assert outcome.items[0].severity_gated is False
+    assert outcome.dissenting_families == ["grok"]
     assert posted == []
 
 


### PR DESCRIPTION
## Summary
- enables the merged severity-gated dissent policy in the required merge-quorum evaluator
- makes severity-gated dissent the code default so raw local merge-packet probes, CI, and long-running governance launchers agree
- preserves explicit rollback with `ARAGORA_ENABLE_SEVERITY_GATED_DISSENT=0/false/no/off`
- keeps P0/P1 findings and populated Blocker labels blocking while P2/P3-only or finding-free CHANGES-REQUESTED reviews become advisory/non-counting

## Governance
This edits `.github/workflows/aragora-merge-quorum.yml` and merge-authority/evidence behavior, so it is Tier 4 merge-authority substrate. Do not merge without the repo's exact-head model quorum and human settlement gate.

## Validation
- `git diff --check`
- `bash -n scripts/aragora_runtime.sh scripts/run_codex_automation_publisher.sh scripts/run_boss_cycle.sh scripts/run_merge_arbiter.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/aragora-merge-quorum.yml")'`
- `python3 -m pytest tests/governance/test_finding_severity_gate.py tests/swarm/test_quorum_evidence.py tests/cli/commands/test_review_queue.py -q`
- `pre-commit run --files .github/workflows/aragora-merge-quorum.yml scripts/aragora_runtime.sh scripts/run_codex_automation_publisher.sh aragora/swarm/quorum_evidence.py aragora/cli/commands/review_queue.py tests/governance/test_finding_severity_gate.py tests/swarm/test_quorum_evidence.py docs/specs/FINDING_SEVERITY_GATE.md`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
