### PR TITLE
Add fleet sentinel stale terminal owner check

### DIFF
--- a/scripts/fleet_sentinel.py
+++ b/scripts/fleet_sentinel.py
@@ -63,17 +63,6 @@ ALL_CHECKS = (
 # ledger-less orphan-branch sweep (failure class A, 2026-06-10/11: coordinator
 # lanes died at setup leaving empty elves/run-* branches nobody noticed).
 ORPHAN_BRANCH_PATTERNS = ("elves/*", "aragora/boss*")
-ACTIVE_LANE_STATUSES = {
-    "active",
-    "running",
-    "pending",
-    "queued",
-    "claimed",
-    "waiting_for_steering",
-    "acknowledged",
-    "working",
-    "blocked",
-}
 LANE_TIMESTAMP_KEYS = (
     "updated_at",
     "last_heartbeat_at",
@@ -82,6 +71,7 @@ LANE_TIMESTAMP_KEYS = (
     "created_at",
 )
 LIVE_OWNER_BLOCKERS = frozenset({"fresh_heartbeat", "live_process"})
+_RESOLVER_MODULE: Any | None = None
 
 
 def parse_iso(value: str) -> datetime:
@@ -600,6 +590,7 @@ def _default_pr_state_fetcher(
     *,
     repo_slug: str,
     gh_bin: str,
+    timeout_seconds: float = 30.0,
 ) -> dict[str, Any]:
     cmd = [
         gh_bin,
@@ -611,7 +602,22 @@ def _default_pr_state_fetcher(
         "--json",
         "number,state,closed,closedAt,mergedAt,mergeCommit,headRefName,headRefOid,url",
     ]
-    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)  # noqa: S603
+    try:
+        proc = subprocess.run(  # noqa: S603
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return {
+            "available": False,
+            "number": pr,
+            "state": "UNKNOWN",
+            "error": f"{exc.__class__.__name__}: {exc}",
+            "command": cmd,
+        }
     if proc.returncode != 0:
         return {
             "available": False,
@@ -644,6 +650,9 @@ def _default_pr_state_fetcher(
 
 
 def _load_resolver_module() -> Any:
+    global _RESOLVER_MODULE
+    if _RESOLVER_MODULE is not None:
+        return _RESOLVER_MODULE
     script_path = Path(__file__).with_name("resolve_lane_conflicts.py")
     spec = importlib.util.spec_from_file_location(
         "resolve_lane_conflicts_for_sentinel", script_path
@@ -652,7 +661,12 @@ def _load_resolver_module() -> Any:
         raise RuntimeError(f"could not load resolver module at {script_path}")
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
+    _RESOLVER_MODULE = module
     return module
+
+
+def _active_lane_statuses() -> set[str]:
+    return set(getattr(_load_resolver_module(), "ACTIVE_STATUSES"))
 
 
 def _default_terminal_owner_auditor(
@@ -666,13 +680,54 @@ def _default_terminal_owner_auditor(
     heartbeat_fresh_seconds: int,
 ) -> dict[str, Any]:
     resolver = _load_resolver_module()
-    return resolver.audit_merged_pr_lanes(
+    resolved_at = resolver._utc_now_iso()
+    now_ts = resolver._parse_timestamp(resolved_at)
+    github_state = resolver._fetch_pr_state(pr=pr, gh_bin=gh_bin)
+    rows, row_load_error = resolver._read_rows_checked(registry_path)
+    heartbeats, heartbeat_load_error = resolver._read_rows_checked(heartbeat_path)
+    findings: list[dict[str, Any]] = []
+    blocked_reason = ""
+    if row_load_error:
+        blocked_reason = f"lane_registry_unreadable:{row_load_error}"
+    elif github_state.get("available") is True and github_state.get("state") == "MERGED":
+        raw_findings = resolver._active_pr_lane_findings(rows, pr=pr)
+        if heartbeat_fresh_seconds < 0:
+            findings = []
+            for finding in raw_findings:
+                finding = dict(finding)
+                finding["terminal_safety_blockers"] = ["invalid_heartbeat_fresh_seconds"]
+                finding["terminal_safety_details"] = {
+                    "heartbeat_fresh_seconds": heartbeat_fresh_seconds
+                }
+                finding["apply_safe"] = False
+                findings.append(finding)
+        else:
+            findings = resolver._annotate_terminal_safety(
+                raw_findings,
+                heartbeats=heartbeats,
+                heartbeat_load_error=heartbeat_load_error,
+                steering_inbox_root=steering_inbox_root,
+                now_ts=now_ts,
+                heartbeat_fresh_seconds=heartbeat_fresh_seconds,
+            )
+    if not blocked_reason:
+        blocked_reason = resolver._merged_pr_audit_blocked_reason(
+            apply=False,
+            operator_authorized=False,
+            expected_merge_commit=None,
+            github_state=github_state,
+            findings=findings,
+        )
+    return resolver._base_merged_pr_audit_result(
         registry_path=registry_path,
         receipt_dir=receipt_dir,
         pr=pr,
-        gh_bin=gh_bin,
         apply=False,
         operator_authorized=False,
+        expected_merge_commit=None,
+        github_state=github_state,
+        findings=findings,
+        blocked_reason=blocked_reason,
         heartbeat_path=heartbeat_path,
         steering_inbox_root=steering_inbox_root,
         heartbeat_fresh_seconds=heartbeat_fresh_seconds,
@@ -732,24 +787,27 @@ def check_stale_terminal_owner(
     repo_slug: str,
     gh_bin: str = "gh",
     heartbeat_fresh_seconds: int = 15 * 60,
+    gh_timeout_seconds: float = 30.0,
     pr_state_fetcher: Callable[..., dict[str, Any]] | None = None,
     terminal_owner_auditor: Callable[..., dict[str, Any]] | None = None,
 ) -> CheckResult:
     """Report stale owner rows that still block merged/closed PRs.
 
-    This check is intentionally read-only.  It detects and routes; the only
-    mutation path it prints is the guarded ``resolve_lane_conflicts.py`` apply
-    command, and only for merged PRs where an exact merge commit is available.
+    This check is intentionally read-only and avoids resolver write locks.  It
+    detects and routes; the only mutation path it prints is the guarded
+    ``resolve_lane_conflicts.py`` apply command, and only for merged PRs where an
+    exact merge commit is available.
     """
     name = "stale_terminal_owner"
     rows, load_error = _read_json_list(registry_path)
     if load_error:
         return _result(name, "unknown", f"lane registry unreadable: {load_error}")
 
+    active_lane_statuses = _active_lane_statuses()
     stale_rows: list[dict[str, Any]] = []
     unknown_age_rows: list[dict[str, Any]] = []
     for row in rows:
-        if str(row.get("status") or "") not in ACTIVE_LANE_STATUSES:
+        if str(row.get("status") or "") not in active_lane_statuses:
             continue
         pr = _coerce_int(row.get("pr_number"))
         if pr is None:
@@ -764,20 +822,32 @@ def check_stale_terminal_owner(
             stale["_stale_age_hours"] = age_hours
             stale_rows.append(stale)
 
-    if not stale_rows and unknown_age_rows:
+    unknown_age_detail = ""
+    if unknown_age_rows:
         sample = ", ".join(
             str(row.get("lane_id") or row.get("owner_session") or row.get("pr_number"))
             for row in unknown_age_rows[:5]
         )
-        return _result(
-            name,
-            "unknown",
-            f"{len(unknown_age_rows)} active PR owner row(s) have no comparable timestamp: {sample}",
+        unknown_age_detail = (
+            f"{len(unknown_age_rows)} active PR owner row(s) have no comparable timestamp: {sample}"
         )
     if not stale_rows:
+        if unknown_age_detail:
+            return _result(name, "unknown", unknown_age_detail)
         return _result(name, "ok", "no stale active PR owner rows over threshold")
 
-    fetch_state = pr_state_fetcher or _default_pr_state_fetcher
+    if pr_state_fetcher is None:
+
+        def fetch_state(pr: int, *, repo_slug: str, gh_bin: str) -> dict[str, Any]:
+            return _default_pr_state_fetcher(
+                pr,
+                repo_slug=repo_slug,
+                gh_bin=gh_bin,
+                timeout_seconds=gh_timeout_seconds,
+            )
+
+    else:
+        fetch_state = pr_state_fetcher
     audit_terminal = terminal_owner_auditor or _default_terminal_owner_auditor
     by_pr: dict[int, list[dict[str, Any]]] = {}
     for row in stale_rows:
@@ -787,7 +857,7 @@ def check_stale_terminal_owner(
 
     candidates: list[dict[str, Any]] = []
     live_suppressed: list[dict[str, Any]] = []
-    unknowns: list[str] = []
+    unknowns: list[str] = [unknown_age_detail] if unknown_age_detail else []
     for pr, pr_rows in sorted(by_pr.items()):
         state = fetch_state(pr, repo_slug=repo_slug, gh_bin=gh_bin)
         if state.get("available") is not True:
@@ -826,9 +896,16 @@ def check_stale_terminal_owner(
 
         for row in pr_rows:
             key = (str(row.get("lane_id") or ""), str(row.get("owner_session") or ""))
-            finding = findings_by_key.get(key, {})
-            blockers = list(finding.get("terminal_safety_blockers") or [])
-            details = dict(finding.get("terminal_safety_details") or {})
+            finding = findings_by_key.get(key)
+            if terminal_state == "MERGED" and finding is None:
+                blockers = ["missing_reconciler_finding"]
+                details = {
+                    "reason": "read-only resolver audit did not return a matching active owner row"
+                }
+            else:
+                finding = finding or {}
+                blockers = list(finding.get("terminal_safety_blockers") or [])
+                details = dict(finding.get("terminal_safety_details") or {})
             if terminal_state == "CLOSED":
                 blockers = ["closed_pr_manual_review"]
                 details = {
@@ -1573,6 +1650,7 @@ def run_checks(args: argparse.Namespace, now: datetime) -> list[CheckResult]:
                         repo_slug=args.github_repo,
                         gh_bin=args.gh_bin,
                         heartbeat_fresh_seconds=args.stale_terminal_owner_heartbeat_fresh_seconds,
+                        gh_timeout_seconds=args.stale_terminal_owner_gh_timeout_seconds,
                     )
                 )
             elif name == "github_api_health":
@@ -1690,6 +1768,12 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         default=15 * 60,
         help="fresh-heartbeat TTL passed through to resolve_lane_conflicts",
+    )
+    parser.add_argument(
+        "--stale-terminal-owner-gh-timeout-seconds",
+        type=float,
+        default=30.0,
+        help="timeout for stale_terminal_owner GitHub CLI PR-state probes",
     )
     parser.add_argument("--github-repo", default="synaptent/aragora")
     parser.add_argument("--gh-bin", default="gh")

--- a/scripts/fleet_sentinel.py
+++ b/scripts/fleet_sentinel.py
@@ -566,7 +566,7 @@ def _read_json_list(path: Path) -> tuple[list[dict[str, Any]], str | None]:
     try:
         payload = json.loads(path.read_text())
     except FileNotFoundError:
-        return [], None
+        return [], "missing"
     except (OSError, json.JSONDecodeError) as exc:
         return [], f"{exc.__class__.__name__}: {exc}"
     if not isinstance(payload, list):

--- a/scripts/fleet_sentinel.py
+++ b/scripts/fleet_sentinel.py
@@ -31,6 +31,7 @@ import glob as glob_module
 import hashlib
 import importlib.util
 import json
+import os
 import plistlib
 import re
 import shlex
@@ -72,6 +73,14 @@ LANE_TIMESTAMP_KEYS = (
 )
 LIVE_OWNER_BLOCKERS = frozenset({"fresh_heartbeat", "live_process"})
 _RESOLVER_MODULE: Any | None = None
+
+
+def _automation_state_root(repo_root: Path) -> Path:
+    configured = os.environ.get("ARAGORA_AUTOMATION_STATE_ROOT")
+    if configured:
+        root = Path(configured).expanduser()
+        return root if root.name == ".aragora" else root / ".aragora"
+    return repo_root / ".aragora"
 
 
 def parse_iso(value: str) -> datetime:
@@ -672,6 +681,7 @@ def _active_lane_statuses() -> set[str]:
 def _default_terminal_owner_auditor(
     *,
     pr: int,
+    github_state: dict[str, Any],
     registry_path: Path,
     receipt_dir: Path,
     gh_bin: str,
@@ -682,7 +692,9 @@ def _default_terminal_owner_auditor(
     resolver = _load_resolver_module()
     resolved_at = resolver._utc_now_iso()
     now_ts = resolver._parse_timestamp(resolved_at)
-    github_state = resolver._fetch_pr_state(pr=pr, gh_bin=gh_bin)
+    github_state = dict(github_state)
+    if "mergeCommit" not in github_state and github_state.get("merge_commit"):
+        github_state["mergeCommit"] = github_state["merge_commit"]
     rows, row_load_error = resolver._read_rows_checked(registry_path)
     heartbeats, heartbeat_load_error = resolver._read_rows_checked(heartbeat_path)
     findings: list[dict[str, Any]] = []
@@ -872,6 +884,7 @@ def check_stale_terminal_owner(
         if terminal_state == "MERGED":
             audit = audit_terminal(
                 pr=pr,
+                github_state=state,
                 registry_path=registry_path,
                 receipt_dir=receipt_dir,
                 gh_bin=gh_bin,
@@ -1698,6 +1711,7 @@ def run_checks(args: argparse.Namespace, now: datetime) -> list[CheckResult]:
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     repo_root = Path(__file__).resolve().parents[1]
+    automation_state_root = _automation_state_root(repo_root)
     parser.add_argument("--repo-root", default=str(repo_root))
     parser.add_argument(
         "--publisher-status",
@@ -1739,17 +1753,17 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--orphan-branch-age-hours", type=float, default=24.0)
     parser.add_argument(
         "--agent-bridge-lanes",
-        default=str(repo_root / ".aragora" / "agent-bridge" / "lanes.json"),
+        default=str(automation_state_root / "agent-bridge" / "lanes.json"),
         help="lane owner registry used by stale_terminal_owner",
     )
     parser.add_argument(
         "--agent-heartbeats",
-        default=str(repo_root / ".aragora" / "agent-bridge" / "heartbeats.json"),
+        default=str(automation_state_root / "agent-bridge" / "heartbeats.json"),
         help="heartbeat registry used by stale_terminal_owner safety checks",
     )
     parser.add_argument(
         "--operator-steering-root",
-        default=str(repo_root / ".aragora" / "operator-steering"),
+        default=str(automation_state_root / "operator-steering"),
         help="operator-steering inbox root used by stale_terminal_owner safety checks",
     )
     parser.add_argument(
@@ -1760,7 +1774,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--stale-terminal-owner-receipt-dir",
-        default=str(repo_root / ".aragora" / "agent-bridge" / "conflict-resolution-receipts"),
+        default=str(automation_state_root / "agent-bridge" / "conflict-resolution-receipts"),
         help="receipt directory to print in guarded resolve_lane_conflicts commands",
     )
     parser.add_argument(

--- a/scripts/fleet_sentinel.py
+++ b/scripts/fleet_sentinel.py
@@ -838,6 +838,12 @@ def check_stale_terminal_owner(
     name = "stale_terminal_owner"
     rows, load_error = _read_json_list(registry_path)
     if load_error:
+        if load_error == "missing":
+            return _result(
+                name,
+                "ok",
+                f"lane registry missing: {registry_path} — agent-bridge state absent; check skipped",
+            )
         return _result(name, "unknown", f"lane registry unreadable: {load_error}")
 
     active_lane_statuses = _active_lane_statuses()

--- a/scripts/fleet_sentinel.py
+++ b/scripts/fleet_sentinel.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import argparse
 import glob as glob_module
 import hashlib
+import importlib.util
 import json
 import plistlib
 import re
@@ -53,6 +54,7 @@ ALL_CHECKS = (
     "outbox_drain_progress",
     "disk_free",
     "lane_liveness",
+    "stale_terminal_owner",
     "github_api_health",
     "trail_reconcile",
 )
@@ -61,6 +63,25 @@ ALL_CHECKS = (
 # ledger-less orphan-branch sweep (failure class A, 2026-06-10/11: coordinator
 # lanes died at setup leaving empty elves/run-* branches nobody noticed).
 ORPHAN_BRANCH_PATTERNS = ("elves/*", "aragora/boss*")
+ACTIVE_LANE_STATUSES = {
+    "active",
+    "running",
+    "pending",
+    "queued",
+    "claimed",
+    "waiting_for_steering",
+    "acknowledged",
+    "working",
+    "blocked",
+}
+LANE_TIMESTAMP_KEYS = (
+    "updated_at",
+    "last_heartbeat_at",
+    "last_seen_at",
+    "claimed_at",
+    "created_at",
+)
+LIVE_OWNER_BLOCKERS = frozenset({"fresh_heartbeat", "live_process"})
 
 
 def parse_iso(value: str) -> datetime:
@@ -77,6 +98,15 @@ def _result(check: str, status: str, detail: str) -> CheckResult:
 
 def _age_hours(path: Path, now: datetime) -> float:
     return (now.timestamp() - path.stat().st_mtime) / 3600.0
+
+
+def _coerce_int(value: Any) -> int | None:
+    try:
+        if value is None or value == "":
+            return None
+        return int(value)
+    except (TypeError, ValueError):
+        return None
 
 
 # ---------------------------------------------------------------------------
@@ -526,6 +556,351 @@ def check_lane_liveness(
         f"{in_progress} in_progress lane(s) live; "
         f"{pattern_branches} lane-pattern branch(es) on origin, no orphans",
     )
+
+
+# ---------------------------------------------------------------------------
+# stale_terminal_owner (#8562 — stale lane owners blocking terminal PRs)
+# ---------------------------------------------------------------------------
+
+
+def _read_json_list(path: Path) -> tuple[list[dict[str, Any]], str | None]:
+    try:
+        payload = json.loads(path.read_text())
+    except FileNotFoundError:
+        return [], None
+    except (OSError, json.JSONDecodeError) as exc:
+        return [], f"{exc.__class__.__name__}: {exc}"
+    if not isinstance(payload, list):
+        return [], "invalid_shape:not_list"
+    return [row for row in payload if isinstance(row, dict)], None
+
+
+def _latest_lane_timestamp(row: dict[str, Any]) -> datetime | None:
+    parsed: list[datetime] = []
+    for key in LANE_TIMESTAMP_KEYS:
+        raw = str(row.get(key) or "").strip()
+        if not raw:
+            continue
+        try:
+            parsed.append(parse_iso(raw))
+        except ValueError:
+            continue
+    return max(parsed) if parsed else None
+
+
+def _merge_commit_oid(payload: dict[str, Any]) -> str:
+    value = payload.get("mergeCommit") or payload.get("merge_commit")
+    if isinstance(value, dict):
+        return str(value.get("oid") or value.get("sha") or "")
+    return str(value or "")
+
+
+def _default_pr_state_fetcher(
+    pr: int,
+    *,
+    repo_slug: str,
+    gh_bin: str,
+) -> dict[str, Any]:
+    cmd = [
+        gh_bin,
+        "pr",
+        "view",
+        str(pr),
+        "--repo",
+        repo_slug,
+        "--json",
+        "number,state,closed,closedAt,mergedAt,mergeCommit,headRefName,headRefOid,url",
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)  # noqa: S603
+    if proc.returncode != 0:
+        return {
+            "available": False,
+            "number": pr,
+            "state": "UNKNOWN",
+            "error": proc.stderr.strip() or proc.stdout.strip(),
+            "command": cmd,
+        }
+    try:
+        payload = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        return {
+            "available": False,
+            "number": pr,
+            "state": "UNKNOWN",
+            "error": f"invalid gh json: {exc}",
+            "command": cmd,
+        }
+    return {
+        "available": True,
+        "number": _coerce_int(payload.get("number")) or pr,
+        "state": str(payload.get("state") or "").upper(),
+        "closed_at": payload.get("closedAt"),
+        "merged_at": payload.get("mergedAt"),
+        "merge_commit": _merge_commit_oid(payload),
+        "head_sha": str(payload.get("headRefOid") or ""),
+        "branch": str(payload.get("headRefName") or ""),
+        "url": str(payload.get("url") or ""),
+    }
+
+
+def _load_resolver_module() -> Any:
+    script_path = Path(__file__).with_name("resolve_lane_conflicts.py")
+    spec = importlib.util.spec_from_file_location(
+        "resolve_lane_conflicts_for_sentinel", script_path
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load resolver module at {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _default_terminal_owner_auditor(
+    *,
+    pr: int,
+    registry_path: Path,
+    receipt_dir: Path,
+    gh_bin: str,
+    heartbeat_path: Path,
+    steering_inbox_root: Path,
+    heartbeat_fresh_seconds: int,
+) -> dict[str, Any]:
+    resolver = _load_resolver_module()
+    return resolver.audit_merged_pr_lanes(
+        registry_path=registry_path,
+        receipt_dir=receipt_dir,
+        pr=pr,
+        gh_bin=gh_bin,
+        apply=False,
+        operator_authorized=False,
+        heartbeat_path=heartbeat_path,
+        steering_inbox_root=steering_inbox_root,
+        heartbeat_fresh_seconds=heartbeat_fresh_seconds,
+    )
+
+
+def _reconciler_dry_run_command(
+    *,
+    pr: int,
+    registry_path: Path,
+    receipt_dir: Path,
+    heartbeat_path: Path,
+    steering_inbox_root: Path,
+    heartbeat_fresh_seconds: int,
+) -> str:
+    return (
+        "python3 scripts/resolve_lane_conflicts.py --merged-pr-lane-audit "
+        f"--pr {pr} "
+        f"--registry-path {shlex.quote(str(registry_path))} "
+        f"--receipt-dir {shlex.quote(str(receipt_dir))} "
+        f"--heartbeat-path {shlex.quote(str(heartbeat_path))} "
+        f"--steering-inbox-root {shlex.quote(str(steering_inbox_root))} "
+        f"--heartbeat-fresh-seconds {heartbeat_fresh_seconds} --json"
+    )
+
+
+def _reconciler_apply_command(
+    *,
+    pr: int,
+    merge_commit: str,
+    registry_path: Path,
+    receipt_dir: Path,
+    heartbeat_path: Path,
+    steering_inbox_root: Path,
+    heartbeat_fresh_seconds: int,
+) -> str:
+    return (
+        "python3 scripts/resolve_lane_conflicts.py --merged-pr-lane-audit "
+        f"--pr {pr} --expected-merge-commit {shlex.quote(merge_commit)} "
+        "--operator-authorized "
+        f"--registry-path {shlex.quote(str(registry_path))} "
+        f"--receipt-dir {shlex.quote(str(receipt_dir))} "
+        f"--heartbeat-path {shlex.quote(str(heartbeat_path))} "
+        f"--steering-inbox-root {shlex.quote(str(steering_inbox_root))} "
+        f"--heartbeat-fresh-seconds {heartbeat_fresh_seconds} --apply --json"
+    )
+
+
+def check_stale_terminal_owner(
+    registry_path: Path,
+    *,
+    receipt_dir: Path,
+    heartbeat_path: Path,
+    steering_inbox_root: Path,
+    min_age_hours: float,
+    now: datetime,
+    repo_slug: str,
+    gh_bin: str = "gh",
+    heartbeat_fresh_seconds: int = 15 * 60,
+    pr_state_fetcher: Callable[..., dict[str, Any]] | None = None,
+    terminal_owner_auditor: Callable[..., dict[str, Any]] | None = None,
+) -> CheckResult:
+    """Report stale owner rows that still block merged/closed PRs.
+
+    This check is intentionally read-only.  It detects and routes; the only
+    mutation path it prints is the guarded ``resolve_lane_conflicts.py`` apply
+    command, and only for merged PRs where an exact merge commit is available.
+    """
+    name = "stale_terminal_owner"
+    rows, load_error = _read_json_list(registry_path)
+    if load_error:
+        return _result(name, "unknown", f"lane registry unreadable: {load_error}")
+
+    stale_rows: list[dict[str, Any]] = []
+    unknown_age_rows: list[dict[str, Any]] = []
+    for row in rows:
+        if str(row.get("status") or "") not in ACTIVE_LANE_STATUSES:
+            continue
+        pr = _coerce_int(row.get("pr_number"))
+        if pr is None:
+            continue
+        latest = _latest_lane_timestamp(row)
+        if latest is None:
+            unknown_age_rows.append(row)
+            continue
+        age_hours = (now - latest).total_seconds() / 3600.0
+        if age_hours >= min_age_hours:
+            stale = dict(row)
+            stale["_stale_age_hours"] = age_hours
+            stale_rows.append(stale)
+
+    if not stale_rows and unknown_age_rows:
+        sample = ", ".join(
+            str(row.get("lane_id") or row.get("owner_session") or row.get("pr_number"))
+            for row in unknown_age_rows[:5]
+        )
+        return _result(
+            name,
+            "unknown",
+            f"{len(unknown_age_rows)} active PR owner row(s) have no comparable timestamp: {sample}",
+        )
+    if not stale_rows:
+        return _result(name, "ok", "no stale active PR owner rows over threshold")
+
+    fetch_state = pr_state_fetcher or _default_pr_state_fetcher
+    audit_terminal = terminal_owner_auditor or _default_terminal_owner_auditor
+    by_pr: dict[int, list[dict[str, Any]]] = {}
+    for row in stale_rows:
+        pr = _coerce_int(row.get("pr_number"))
+        if pr is not None:
+            by_pr.setdefault(pr, []).append(row)
+
+    candidates: list[dict[str, Any]] = []
+    live_suppressed: list[dict[str, Any]] = []
+    unknowns: list[str] = []
+    for pr, pr_rows in sorted(by_pr.items()):
+        state = fetch_state(pr, repo_slug=repo_slug, gh_bin=gh_bin)
+        if state.get("available") is not True:
+            unknowns.append(f"PR #{pr}: {state.get('error') or 'state unavailable'}")
+            continue
+        terminal_state = str(state.get("state") or "").upper()
+        if terminal_state not in {"MERGED", "CLOSED"}:
+            continue
+
+        audit: dict[str, Any] = {}
+        findings_by_key: dict[tuple[str, str], dict[str, Any]] = {}
+        if terminal_state == "MERGED":
+            audit = audit_terminal(
+                pr=pr,
+                registry_path=registry_path,
+                receipt_dir=receipt_dir,
+                gh_bin=gh_bin,
+                heartbeat_path=heartbeat_path,
+                steering_inbox_root=steering_inbox_root,
+                heartbeat_fresh_seconds=heartbeat_fresh_seconds,
+            )
+            if audit.get("github_state", {}).get("available") is not True:
+                unknowns.append(
+                    f"PR #{pr}: reconciler audit unavailable: "
+                    f"{audit.get('github_state', {}).get('error') or audit.get('blocked_reason')}"
+                )
+                continue
+            findings_by_key = {
+                (
+                    str(finding.get("lane_id") or ""),
+                    str(finding.get("owner_session") or ""),
+                ): finding
+                for finding in audit.get("findings", [])
+                if isinstance(finding, dict)
+            }
+
+        for row in pr_rows:
+            key = (str(row.get("lane_id") or ""), str(row.get("owner_session") or ""))
+            finding = findings_by_key.get(key, {})
+            blockers = list(finding.get("terminal_safety_blockers") or [])
+            details = dict(finding.get("terminal_safety_details") or {})
+            if terminal_state == "CLOSED":
+                blockers = ["closed_pr_manual_review"]
+                details = {
+                    "reason": "closed-unmerged PRs are terminal but have no merge-commit guard"
+                }
+            candidate = {
+                "lane_id": row.get("lane_id"),
+                "pr_number": pr,
+                "branch": row.get("branch") or state.get("branch"),
+                "owner_session": row.get("owner_session"),
+                "age_hours": round(float(row["_stale_age_hours"]), 2),
+                "terminal_state": terminal_state,
+                "terminal_url": state.get("url"),
+                "merge_commit": state.get("merge_commit") or "",
+                "terminal_safety_blockers": blockers,
+                "terminal_safety_details": details,
+                "reconciler_dry_run_command": _reconciler_dry_run_command(
+                    pr=pr,
+                    registry_path=registry_path,
+                    receipt_dir=receipt_dir,
+                    heartbeat_path=heartbeat_path,
+                    steering_inbox_root=steering_inbox_root,
+                    heartbeat_fresh_seconds=heartbeat_fresh_seconds,
+                ),
+                "reconciler_apply_command": "",
+            }
+            merge_commit = str(state.get("merge_commit") or "")
+            if terminal_state == "MERGED" and not blockers and merge_commit:
+                candidate["reconciler_apply_command"] = _reconciler_apply_command(
+                    pr=pr,
+                    merge_commit=merge_commit,
+                    registry_path=registry_path,
+                    receipt_dir=receipt_dir,
+                    heartbeat_path=heartbeat_path,
+                    steering_inbox_root=steering_inbox_root,
+                    heartbeat_fresh_seconds=heartbeat_fresh_seconds,
+                )
+            if LIVE_OWNER_BLOCKERS.intersection(blockers):
+                live_suppressed.append(candidate)
+            else:
+                candidates.append(candidate)
+
+    if unknowns:
+        return {
+            **_result(name, "unknown", "terminal PR state unknown: " + "; ".join(unknowns)),
+            "candidates": candidates,
+            "live_suppressed": live_suppressed,
+        }
+    if candidates:
+        detail = "; ".join(
+            f"lane {item.get('lane_id')} PR #{item['pr_number']} "
+            f"{item['terminal_state']} owner={item.get('owner_session')} "
+            f"age={item['age_hours']:.1f}h"
+            for item in candidates[:5]
+        )
+        return {
+            **_result(name, "breach", detail),
+            "candidates": candidates,
+            "live_suppressed": live_suppressed,
+        }
+    if live_suppressed:
+        return {
+            **_result(
+                name,
+                "ok",
+                f"{len(live_suppressed)} terminal PR owner row(s) have live-owner signal; "
+                "no stale terminal owner rows",
+            ),
+            "candidates": [],
+            "live_suppressed": live_suppressed,
+        }
+    return _result(name, "ok", "no stale terminal owner rows for merged/closed PRs")
 
 
 # ---------------------------------------------------------------------------
@@ -1186,6 +1561,20 @@ def run_checks(args: argparse.Namespace, now: datetime) -> list[CheckResult]:
                         commit_dater=_default_commit_dater(repo),
                     )
                 )
+            elif name == "stale_terminal_owner":
+                results.append(
+                    check_stale_terminal_owner(
+                        Path(args.agent_bridge_lanes),
+                        receipt_dir=Path(args.stale_terminal_owner_receipt_dir),
+                        heartbeat_path=Path(args.agent_heartbeats),
+                        steering_inbox_root=Path(args.operator_steering_root),
+                        min_age_hours=args.stale_terminal_owner_age_hours,
+                        now=now,
+                        repo_slug=args.github_repo,
+                        gh_bin=args.gh_bin,
+                        heartbeat_fresh_seconds=args.stale_terminal_owner_heartbeat_fresh_seconds,
+                    )
+                )
             elif name == "github_api_health":
                 results.append(
                     check_github_api_health(
@@ -1270,6 +1659,40 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--lane-max-age-hours", type=float, default=3.0)
     parser.add_argument("--orphan-branch-age-hours", type=float, default=24.0)
+    parser.add_argument(
+        "--agent-bridge-lanes",
+        default=str(repo_root / ".aragora" / "agent-bridge" / "lanes.json"),
+        help="lane owner registry used by stale_terminal_owner",
+    )
+    parser.add_argument(
+        "--agent-heartbeats",
+        default=str(repo_root / ".aragora" / "agent-bridge" / "heartbeats.json"),
+        help="heartbeat registry used by stale_terminal_owner safety checks",
+    )
+    parser.add_argument(
+        "--operator-steering-root",
+        default=str(repo_root / ".aragora" / "operator-steering"),
+        help="operator-steering inbox root used by stale_terminal_owner safety checks",
+    )
+    parser.add_argument(
+        "--stale-terminal-owner-age-hours",
+        type=float,
+        default=24.0,
+        help="minimum owner-row age before stale_terminal_owner evaluates terminal PR state",
+    )
+    parser.add_argument(
+        "--stale-terminal-owner-receipt-dir",
+        default=str(repo_root / ".aragora" / "agent-bridge" / "conflict-resolution-receipts"),
+        help="receipt directory to print in guarded resolve_lane_conflicts commands",
+    )
+    parser.add_argument(
+        "--stale-terminal-owner-heartbeat-fresh-seconds",
+        type=int,
+        default=15 * 60,
+        help="fresh-heartbeat TTL passed through to resolve_lane_conflicts",
+    )
+    parser.add_argument("--github-repo", default="synaptent/aragora")
+    parser.add_argument("--gh-bin", default="gh")
     parser.add_argument(
         "--publisher-log",
         default=str(repo_root / ".aragora" / "overnight" / "codex-automation-publisher.log"),

--- a/scripts/fleet_sentinel.py
+++ b/scripts/fleet_sentinel.py
@@ -75,12 +75,37 @@ LIVE_OWNER_BLOCKERS = frozenset({"fresh_heartbeat", "live_process"})
 _RESOLVER_MODULE: Any | None = None
 
 
+def _canonical_repo_root(path: Path) -> Path:
+    common_dir_proc = subprocess.run(
+        ["git", "-C", str(path), "rev-parse", "--path-format=absolute", "--git-common-dir"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if common_dir_proc.returncode == 0:
+        common_dir = common_dir_proc.stdout.strip()
+        if common_dir.endswith("/.git"):
+            return Path(common_dir).resolve().parent
+
+    root_proc = subprocess.run(
+        ["git", "-C", str(path), "rev-parse", "--show-toplevel"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if root_proc.returncode == 0 and root_proc.stdout.strip():
+        return Path(root_proc.stdout.strip()).resolve()
+    return path.resolve()
+
+
 def _automation_state_root(repo_root: Path) -> Path:
     configured = os.environ.get("ARAGORA_AUTOMATION_STATE_ROOT")
     if configured:
         root = Path(configured).expanduser()
         return root if root.name == ".aragora" else root / ".aragora"
-    return repo_root / ".aragora"
+    return _canonical_repo_root(repo_root) / ".aragora"
 
 
 def parse_iso(value: str) -> datetime:

--- a/tests/scripts/test_fleet_sentinel.py
+++ b/tests/scripts/test_fleet_sentinel.py
@@ -787,7 +787,7 @@ def _active_owner_row(**overrides: Any) -> dict[str, Any]:
     return row
 
 
-def test_stale_terminal_owner_missing_registry_is_unknown(tmp_path: Path) -> None:
+def test_stale_terminal_owner_missing_registry_is_ok_skipped(tmp_path: Path) -> None:
     result = sentinel.check_stale_terminal_owner(
         tmp_path / "missing-lanes.json",
         receipt_dir=tmp_path / "receipts",
@@ -802,8 +802,30 @@ def test_stale_terminal_owner_missing_registry_is_unknown(tmp_path: Path) -> Non
         terminal_owner_auditor=lambda **kwargs: (_ for _ in ()).throw(AssertionError("no audit")),
     )
 
+    assert result["status"] == "ok"
+    assert "agent-bridge state absent" in result["detail"]
+
+
+def test_stale_terminal_owner_invalid_registry_stays_unknown(tmp_path: Path) -> None:
+    registry = tmp_path / "lanes.json"
+    registry.write_text("{not json", encoding="utf-8")
+
+    result = sentinel.check_stale_terminal_owner(
+        registry,
+        receipt_dir=tmp_path / "receipts",
+        heartbeat_path=tmp_path / "heartbeats.json",
+        steering_inbox_root=tmp_path / "operator-steering",
+        min_age_hours=24.0,
+        now=NOW,
+        repo_slug="synaptent/aragora",
+        pr_state_fetcher=lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("no PR state fetch")
+        ),
+        terminal_owner_auditor=lambda **kwargs: (_ for _ in ()).throw(AssertionError("no audit")),
+    )
+
     assert result["status"] == "unknown"
-    assert "lane registry unreadable: missing" in result["detail"]
+    assert "lane registry unreadable" in result["detail"]
 
 
 def test_stale_terminal_owner_reports_safe_merged_pr_with_guarded_commands(
@@ -1172,6 +1194,42 @@ def test_default_terminal_owner_auditor_uses_no_lock_read_only_path(
     assert result["github_state"]["state"] == "MERGED"
     assert result["github_state"]["mergeCommit"] == "abc123"
     assert result["findings"][0]["terminal_safety_blockers"] == []
+
+
+def test_stale_terminal_owner_default_auditor_uses_real_resolver_module(
+    tmp_path: Path,
+) -> None:
+    sentinel._RESOLVER_MODULE = None
+    registry = _write_json(tmp_path / "lanes.json", [_active_owner_row()])
+
+    def fetch_state(pr: int, *, repo_slug: str, gh_bin: str) -> dict[str, Any]:
+        assert pr == 9001
+        assert repo_slug == "synaptent/aragora"
+        assert gh_bin == "gh"
+        return {
+            "available": True,
+            "number": pr,
+            "state": "MERGED",
+            "merge_commit": "real-resolver-merge",
+            "url": "https://github.test/pr/9001",
+        }
+
+    result = sentinel.check_stale_terminal_owner(
+        registry,
+        receipt_dir=tmp_path / "receipts",
+        heartbeat_path=tmp_path / "heartbeats.json",
+        steering_inbox_root=tmp_path / "operator-steering",
+        min_age_hours=24.0,
+        now=NOW,
+        repo_slug="synaptent/aragora",
+        pr_state_fetcher=fetch_state,
+    )
+
+    assert result["status"] == "breach"
+    candidate = result["candidates"][0]
+    assert candidate["lane_id"] == "Q900-stale-terminal"
+    assert candidate["terminal_safety_blockers"] == []
+    assert "--expected-merge-commit real-resolver-merge" in candidate["reconciler_apply_command"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scripts/test_fleet_sentinel.py
+++ b/tests/scripts/test_fleet_sentinel.py
@@ -164,6 +164,26 @@ def test_stale_terminal_owner_defaults_use_automation_state_root(
     )
 
 
+def test_stale_terminal_owner_defaults_use_canonical_repo_root(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    canonical_root = tmp_path / "canonical-repo"
+    monkeypatch.delenv("ARAGORA_AUTOMATION_STATE_ROOT", raising=False)
+    monkeypatch.setattr(sentinel, "_canonical_repo_root", lambda path: canonical_root)
+
+    args = sentinel.build_parser().parse_args([])
+
+    root = canonical_root / ".aragora"
+    assert Path(args.agent_bridge_lanes) == root / "agent-bridge" / "lanes.json"
+    assert Path(args.agent_heartbeats) == root / "agent-bridge" / "heartbeats.json"
+    assert Path(args.operator_steering_root) == root / "operator-steering"
+    assert (
+        Path(args.stale_terminal_owner_receipt_dir)
+        == root / "agent-bridge" / "conflict-resolution-receipts"
+    )
+
+
 # ---------------------------------------------------------------------------
 # boss_metrics_heartbeat
 # ---------------------------------------------------------------------------

--- a/tests/scripts/test_fleet_sentinel.py
+++ b/tests/scripts/test_fleet_sentinel.py
@@ -890,6 +890,179 @@ def test_stale_terminal_owner_reports_closed_pr_without_apply_command(tmp_path: 
     assert result["candidates"][0]["reconciler_apply_command"] == ""
 
 
+def test_default_pr_state_fetcher_times_out_fail_closed(monkeypatch: Any) -> None:
+    def run_timeout(*args: Any, **kwargs: Any) -> Any:
+        raise subprocess.TimeoutExpired(cmd=kwargs.get("args", ["gh"]), timeout=0.01)
+
+    monkeypatch.setattr(sentinel.subprocess, "run", run_timeout)
+
+    result = sentinel._default_pr_state_fetcher(
+        9001,
+        repo_slug="synaptent/aragora",
+        gh_bin="gh",
+        timeout_seconds=0.01,
+    )
+
+    assert result["available"] is False
+    assert result["state"] == "UNKNOWN"
+    assert "TimeoutExpired" in result["error"]
+
+
+def test_stale_terminal_owner_unknown_timestamp_precedes_stale_rows(tmp_path: Path) -> None:
+    result, audit_calls = _stale_owner_result(
+        tmp_path,
+        [
+            _active_owner_row(lane_id="Q-stale", owner_session="owner-stale"),
+            _active_owner_row(
+                lane_id="Q-no-time",
+                owner_session="owner-no-time",
+                updated_at="",
+            ),
+        ],
+        pr_state={"state": "CLOSED", "merge_commit": "", "url": "https://github.test/pr/9001"},
+    )
+
+    assert audit_calls == []
+    assert result["status"] == "unknown"
+    assert "no comparable timestamp" in result["detail"]
+    assert result["candidates"][0]["lane_id"] == "Q-stale"
+
+
+def test_stale_terminal_owner_missing_audit_finding_blocks_apply(tmp_path: Path) -> None:
+    result, audit_calls = _stale_owner_result(
+        tmp_path,
+        [_active_owner_row()],
+        pr_state={
+            "state": "MERGED",
+            "merge_commit": "abc123",
+            "url": "https://github.test/pr/9001",
+        },
+        findings=[],
+    )
+
+    assert audit_calls == [9001]
+    assert result["status"] == "breach"
+    assert result["candidates"][0]["terminal_safety_blockers"] == ["missing_reconciler_finding"]
+    assert result["candidates"][0]["reconciler_apply_command"] == ""
+
+
+def test_stale_terminal_owner_uses_resolver_active_statuses(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    class FakeResolver:
+        ACTIVE_STATUSES = {"leased"}
+
+    monkeypatch.setattr(sentinel, "_load_resolver_module", lambda: FakeResolver())
+    registry = _write_json(
+        tmp_path / "lanes.json",
+        [_active_owner_row(status="leased")],
+    )
+
+    def fetch_state(pr: int, *, repo_slug: str, gh_bin: str) -> dict[str, Any]:
+        return {
+            "available": True,
+            "number": pr,
+            "state": "CLOSED",
+            "merge_commit": "",
+            "url": "https://github.test/pr/9001",
+        }
+
+    result = sentinel.check_stale_terminal_owner(
+        registry,
+        receipt_dir=tmp_path / "receipts",
+        heartbeat_path=tmp_path / "heartbeats.json",
+        steering_inbox_root=tmp_path / "operator-steering",
+        min_age_hours=24.0,
+        now=NOW,
+        repo_slug="synaptent/aragora",
+        pr_state_fetcher=fetch_state,
+        terminal_owner_auditor=lambda **kwargs: (_ for _ in ()).throw(AssertionError("no audit")),
+    )
+
+    assert result["status"] == "breach"
+    assert result["candidates"][0]["terminal_safety_blockers"] == ["closed_pr_manual_review"]
+
+
+def test_default_terminal_owner_auditor_uses_no_lock_read_only_path(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    class FakeResolver:
+        ACTIVE_STATUSES = {"active"}
+
+        def _utc_now_iso(self) -> str:
+            return "2026-06-10T12:00:00Z"
+
+        def _parse_timestamp(self, value: str) -> float:
+            return NOW.timestamp()
+
+        def _fetch_pr_state(self, *, pr: int, gh_bin: str) -> dict[str, Any]:
+            return {"available": True, "state": "MERGED", "mergeCommit": "abc123"}
+
+        def _read_rows_checked(self, path: Path) -> tuple[list[dict[str, Any]], str | None]:
+            if path.name == "lanes.json":
+                return [_active_owner_row()], None
+            return [], None
+
+        def _active_pr_lane_findings(
+            self,
+            rows: list[dict[str, Any]],
+            *,
+            pr: int,
+        ) -> list[dict[str, Any]]:
+            return [
+                {
+                    "lane_id": "Q900-stale-terminal",
+                    "owner_session": "codex-owner",
+                }
+            ]
+
+        def _annotate_terminal_safety(
+            self,
+            findings: list[dict[str, Any]],
+            **kwargs: Any,
+        ) -> list[dict[str, Any]]:
+            return [
+                {
+                    **finding,
+                    "terminal_safety_blockers": [],
+                    "terminal_safety_details": {},
+                    "apply_safe": True,
+                }
+                for finding in findings
+            ]
+
+        def _merged_pr_audit_blocked_reason(self, **kwargs: Any) -> str:
+            return ""
+
+        def _base_merged_pr_audit_result(self, **kwargs: Any) -> dict[str, Any]:
+            return {
+                "github_state": kwargs["github_state"],
+                "findings": kwargs["findings"],
+                "blocked_reason": kwargs["blocked_reason"],
+                "apply_eligible": False,
+            }
+
+        def audit_merged_pr_lanes(self, **kwargs: Any) -> dict[str, Any]:
+            raise AssertionError("sentinel must not enter resolver write-lock audit")
+
+    monkeypatch.setattr(sentinel, "_load_resolver_module", lambda: FakeResolver())
+
+    result = sentinel._default_terminal_owner_auditor(
+        pr=9001,
+        registry_path=tmp_path / "lanes.json",
+        receipt_dir=tmp_path / "receipts",
+        gh_bin="gh",
+        heartbeat_path=tmp_path / "heartbeats.json",
+        steering_inbox_root=tmp_path / "operator-steering",
+        heartbeat_fresh_seconds=900,
+    )
+
+    assert result["github_state"]["state"] == "MERGED"
+    assert result["findings"][0]["terminal_safety_blockers"] == []
+
+
 # ---------------------------------------------------------------------------
 # github_api_health  (failure class B: GraphQL 502/504 streaks of 2026-06-10/11
 # stalled the publisher; the cached github_health flipped auth_ok:false so the

--- a/tests/scripts/test_fleet_sentinel.py
+++ b/tests/scripts/test_fleet_sentinel.py
@@ -767,6 +767,25 @@ def _active_owner_row(**overrides: Any) -> dict[str, Any]:
     return row
 
 
+def test_stale_terminal_owner_missing_registry_is_unknown(tmp_path: Path) -> None:
+    result = sentinel.check_stale_terminal_owner(
+        tmp_path / "missing-lanes.json",
+        receipt_dir=tmp_path / "receipts",
+        heartbeat_path=tmp_path / "heartbeats.json",
+        steering_inbox_root=tmp_path / "operator-steering",
+        min_age_hours=24.0,
+        now=NOW,
+        repo_slug="synaptent/aragora",
+        pr_state_fetcher=lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("no PR state fetch")
+        ),
+        terminal_owner_auditor=lambda **kwargs: (_ for _ in ()).throw(AssertionError("no audit")),
+    )
+
+    assert result["status"] == "unknown"
+    assert "lane registry unreadable: missing" in result["detail"]
+
+
 def test_stale_terminal_owner_reports_safe_merged_pr_with_guarded_commands(
     tmp_path: Path,
 ) -> None:

--- a/tests/scripts/test_fleet_sentinel.py
+++ b/tests/scripts/test_fleet_sentinel.py
@@ -145,6 +145,25 @@ def test_publisher_status_default_is_live_cache_path() -> None:
     assert default.parts[-3:] == (".aragora", "automation-github-status", "latest.json")
 
 
+def test_stale_terminal_owner_defaults_use_automation_state_root(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    state_root = tmp_path / "shared-state"
+    monkeypatch.setenv("ARAGORA_AUTOMATION_STATE_ROOT", str(state_root))
+
+    args = sentinel.build_parser().parse_args([])
+
+    root = state_root / ".aragora"
+    assert Path(args.agent_bridge_lanes) == root / "agent-bridge" / "lanes.json"
+    assert Path(args.agent_heartbeats) == root / "agent-bridge" / "heartbeats.json"
+    assert Path(args.operator_steering_root) == root / "operator-steering"
+    assert (
+        Path(args.stale_terminal_owner_receipt_dir)
+        == root / "agent-bridge" / "conflict-resolution-receipts"
+    )
+
+
 # ---------------------------------------------------------------------------
 # boss_metrics_heartbeat
 # ---------------------------------------------------------------------------
@@ -794,6 +813,57 @@ def test_stale_terminal_owner_reports_safe_merged_pr_with_guarded_commands(
     assert "--apply --json" in result["candidates"][0]["reconciler_apply_command"]
 
 
+def test_stale_terminal_owner_passes_repo_scoped_state_to_terminal_auditor(
+    tmp_path: Path,
+) -> None:
+    registry = _write_json(tmp_path / "lanes.json", [_active_owner_row()])
+    seen_state: dict[str, Any] = {}
+
+    def fetch_state(pr: int, *, repo_slug: str, gh_bin: str) -> dict[str, Any]:
+        assert repo_slug == "synaptent/aragora"
+        assert gh_bin == "gh"
+        return {
+            "available": True,
+            "number": pr,
+            "state": "MERGED",
+            "merge_commit": "repo-scoped-merge",
+            "url": "https://github.test/pr/9001",
+        }
+
+    def audit_terminal(**kwargs: Any) -> dict[str, Any]:
+        seen_state.update(kwargs["github_state"])
+        return {
+            "github_state": kwargs["github_state"],
+            "findings": [
+                {
+                    "lane_id": "Q900-stale-terminal",
+                    "owner_session": "codex-owner",
+                    "terminal_safety_blockers": [],
+                    "terminal_safety_details": {},
+                }
+            ],
+        }
+
+    result = sentinel.check_stale_terminal_owner(
+        registry,
+        receipt_dir=tmp_path / "receipts",
+        heartbeat_path=tmp_path / "heartbeats.json",
+        steering_inbox_root=tmp_path / "operator-steering",
+        min_age_hours=24.0,
+        now=NOW,
+        repo_slug="synaptent/aragora",
+        pr_state_fetcher=fetch_state,
+        terminal_owner_auditor=audit_terminal,
+    )
+
+    assert seen_state["merge_commit"] == "repo-scoped-merge"
+    assert result["status"] == "breach"
+    assert (
+        "--expected-merge-commit repo-scoped-merge"
+        in result["candidates"][0]["reconciler_apply_command"]
+    )
+
+
 def test_stale_terminal_owner_suppresses_fresh_heartbeat_rows(tmp_path: Path) -> None:
     result, audit_calls = _stale_owner_result(
         tmp_path,
@@ -998,7 +1068,7 @@ def test_default_terminal_owner_auditor_uses_no_lock_read_only_path(
             return NOW.timestamp()
 
         def _fetch_pr_state(self, *, pr: int, gh_bin: str) -> dict[str, Any]:
-            return {"available": True, "state": "MERGED", "mergeCommit": "abc123"}
+            raise AssertionError("sentinel must reuse its repo-scoped PR state")
 
         def _read_rows_checked(self, path: Path) -> tuple[list[dict[str, Any]], str | None]:
             if path.name == "lanes.json":
@@ -1051,6 +1121,7 @@ def test_default_terminal_owner_auditor_uses_no_lock_read_only_path(
 
     result = sentinel._default_terminal_owner_auditor(
         pr=9001,
+        github_state={"available": True, "state": "MERGED", "merge_commit": "abc123"},
         registry_path=tmp_path / "lanes.json",
         receipt_dir=tmp_path / "receipts",
         gh_bin="gh",
@@ -1060,6 +1131,7 @@ def test_default_terminal_owner_auditor_uses_no_lock_read_only_path(
     )
 
     assert result["github_state"]["state"] == "MERGED"
+    assert result["github_state"]["mergeCommit"] == "abc123"
     assert result["findings"][0]["terminal_safety_blockers"] == []
 
 

--- a/tests/scripts/test_fleet_sentinel.py
+++ b/tests/scripts/test_fleet_sentinel.py
@@ -688,6 +688,209 @@ def test_breach_replay_jun10_silent_lane_death(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# stale_terminal_owner (#8562: stale owners blocking terminal PRs)
+# ---------------------------------------------------------------------------
+
+
+def _write_json(path: Path, payload: Any) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _stale_owner_result(
+    tmp_path: Path,
+    rows: list[dict[str, Any]],
+    *,
+    pr_state: dict[str, Any],
+    findings: list[dict[str, Any]] | None = None,
+    min_age_hours: float = 24.0,
+) -> Any:
+    registry = _write_json(tmp_path / "lanes.json", rows)
+    audit_calls: list[int] = []
+
+    def fetch_state(pr: int, *, repo_slug: str, gh_bin: str) -> dict[str, Any]:
+        assert repo_slug == "synaptent/aragora"
+        assert gh_bin == "gh"
+        return {"available": True, "number": pr, **pr_state}
+
+    def audit_terminal(**kwargs: Any) -> dict[str, Any]:
+        audit_calls.append(kwargs["pr"])
+        return {
+            "github_state": {"available": True, "state": "MERGED"},
+            "findings": findings if findings is not None else [],
+        }
+
+    result = sentinel.check_stale_terminal_owner(
+        registry,
+        receipt_dir=tmp_path / "receipts",
+        heartbeat_path=tmp_path / "heartbeats.json",
+        steering_inbox_root=tmp_path / "operator-steering",
+        min_age_hours=min_age_hours,
+        now=NOW,
+        repo_slug="synaptent/aragora",
+        pr_state_fetcher=fetch_state,
+        terminal_owner_auditor=audit_terminal,
+    )
+    return result, audit_calls
+
+
+def _active_owner_row(**overrides: Any) -> dict[str, Any]:
+    row = {
+        "lane_id": "Q900-stale-terminal",
+        "owner_session": "codex-owner",
+        "status": "active",
+        "pr_number": 9001,
+        "branch": "codex/stale-terminal-demo",
+        "updated_at": "2026-06-08T12:00:00Z",
+    }
+    row.update(overrides)
+    return row
+
+
+def test_stale_terminal_owner_reports_safe_merged_pr_with_guarded_commands(
+    tmp_path: Path,
+) -> None:
+    result, audit_calls = _stale_owner_result(
+        tmp_path,
+        [_active_owner_row()],
+        pr_state={
+            "state": "MERGED",
+            "merge_commit": "abc123",
+            "url": "https://github.test/pr/9001",
+        },
+        findings=[
+            {
+                "lane_id": "Q900-stale-terminal",
+                "owner_session": "codex-owner",
+                "terminal_safety_blockers": [],
+                "terminal_safety_details": {},
+            }
+        ],
+    )
+
+    assert result["status"] == "breach"
+    assert audit_calls == [9001]
+    assert result["candidates"][0] == {
+        "lane_id": "Q900-stale-terminal",
+        "pr_number": 9001,
+        "branch": "codex/stale-terminal-demo",
+        "owner_session": "codex-owner",
+        "age_hours": 48.0,
+        "terminal_state": "MERGED",
+        "terminal_url": "https://github.test/pr/9001",
+        "merge_commit": "abc123",
+        "terminal_safety_blockers": [],
+        "terminal_safety_details": {},
+        "reconciler_dry_run_command": result["candidates"][0]["reconciler_dry_run_command"],
+        "reconciler_apply_command": result["candidates"][0]["reconciler_apply_command"],
+    }
+    assert (
+        "resolve_lane_conflicts.py --merged-pr-lane-audit"
+        in result["candidates"][0]["reconciler_dry_run_command"]
+    )
+    assert "--expected-merge-commit abc123" in result["candidates"][0]["reconciler_apply_command"]
+    assert "--operator-authorized" in result["candidates"][0]["reconciler_apply_command"]
+    assert "--apply --json" in result["candidates"][0]["reconciler_apply_command"]
+
+
+def test_stale_terminal_owner_suppresses_fresh_heartbeat_rows(tmp_path: Path) -> None:
+    result, audit_calls = _stale_owner_result(
+        tmp_path,
+        [_active_owner_row()],
+        pr_state={"state": "MERGED", "merge_commit": "abc123"},
+        findings=[
+            {
+                "lane_id": "Q900-stale-terminal",
+                "owner_session": "codex-owner",
+                "terminal_safety_blockers": ["fresh_heartbeat"],
+                "terminal_safety_details": {"fresh_heartbeat_timestamps": ["2026-06-10T11:59:00Z"]},
+            }
+        ],
+    )
+
+    assert audit_calls == [9001]
+    assert result["status"] == "ok"
+    assert result["candidates"] == []
+    assert result["live_suppressed"][0]["terminal_safety_blockers"] == ["fresh_heartbeat"]
+
+
+def test_stale_terminal_owner_reports_api_unknown_as_unknown(tmp_path: Path) -> None:
+    registry = _write_json(tmp_path / "lanes.json", [_active_owner_row()])
+
+    def fetch_state(pr: int, *, repo_slug: str, gh_bin: str) -> dict[str, Any]:
+        return {"available": False, "number": pr, "state": "UNKNOWN", "error": "HTTP 502"}
+
+    result = sentinel.check_stale_terminal_owner(
+        registry,
+        receipt_dir=tmp_path / "receipts",
+        heartbeat_path=tmp_path / "heartbeats.json",
+        steering_inbox_root=tmp_path / "operator-steering",
+        min_age_hours=24.0,
+        now=NOW,
+        repo_slug="synaptent/aragora",
+        pr_state_fetcher=fetch_state,
+        terminal_owner_auditor=lambda **kwargs: (_ for _ in ()).throw(AssertionError("no audit")),
+    )
+
+    assert result["status"] == "unknown"
+    assert "HTTP 502" in result["detail"]
+
+
+def test_stale_terminal_owner_reports_unsafe_mailbox_and_local_work_blockers(
+    tmp_path: Path,
+) -> None:
+    result, _ = _stale_owner_result(
+        tmp_path,
+        [
+            _active_owner_row(lane_id="Q-mailbox", owner_session="owner-mailbox"),
+            _active_owner_row(lane_id="Q-local-work", owner_session="owner-local-work"),
+        ],
+        pr_state={"state": "MERGED", "merge_commit": "abc123"},
+        findings=[
+            {
+                "lane_id": "Q-mailbox",
+                "owner_session": "owner-mailbox",
+                "terminal_safety_blockers": ["unread_mailbox"],
+                "terminal_safety_details": {"pending_mailbox_messages": ["message.json"]},
+            },
+            {
+                "lane_id": "Q-local-work",
+                "owner_session": "owner-local-work",
+                "terminal_safety_blockers": ["local_work_claim"],
+                "terminal_safety_details": {"local_work_claims": ["/tmp/work"]},
+            },
+        ],
+    )
+
+    assert result["status"] == "breach"
+    blockers = {
+        candidate["lane_id"]: candidate["terminal_safety_blockers"]
+        for candidate in result["candidates"]
+    }
+    assert blockers == {
+        "Q-mailbox": ["unread_mailbox"],
+        "Q-local-work": ["local_work_claim"],
+    }
+    assert all(not candidate["reconciler_apply_command"] for candidate in result["candidates"])
+
+
+def test_stale_terminal_owner_reports_closed_pr_without_apply_command(tmp_path: Path) -> None:
+    result, audit_calls = _stale_owner_result(
+        tmp_path,
+        [_active_owner_row()],
+        pr_state={"state": "CLOSED", "merge_commit": "", "url": "https://github.test/pr/9001"},
+    )
+
+    assert audit_calls == []
+    assert result["status"] == "breach"
+    assert result["candidates"][0]["terminal_state"] == "CLOSED"
+    assert result["candidates"][0]["terminal_safety_blockers"] == ["closed_pr_manual_review"]
+    assert result["candidates"][0]["reconciler_dry_run_command"]
+    assert result["candidates"][0]["reconciler_apply_command"] == ""
+
+
+# ---------------------------------------------------------------------------
 # github_api_health  (failure class B: GraphQL 502/504 streaks of 2026-06-10/11
 # stalled the publisher; the cached github_health flipped auth_ok:false so the
 # sentinel breached without distinguishing transient from persistent)


### PR DESCRIPTION
## Summary
- add a read-only `stale_terminal_owner` fleet sentinel check for stale active lane owner rows on terminal PRs
- reuse the existing lane-conflict reconciler dry-run audit for merged PR safety gates
- report guarded dry-run/apply commands only when terminal proof is strong, while leaving closed/unknown/unsafe cases non-mutating

## Validation
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_resolve_lane_conflicts.py tests/scripts/test_fleet_sentinel.py -q`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python scripts/report_code_quality.py --check`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/fleet_sentinel.py tests/scripts/test_fleet_sentinel.py`
- `git diff --check`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python scripts/fleet_sentinel.py --checks stale_terminal_owner --json --no-ledger`

Closes #8562
