### PR TITLE
fix(reconcile): archive merged-pr-preserved outbox heads

### DIFF
--- a/scripts/identify_lane_owner.py
+++ b/scripts/identify_lane_owner.py
@@ -68,7 +68,7 @@ import time
 from collections.abc import Callable, Sequence
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
 # ---------------------------------------------------------------------------
 # Paths (overridable for tests)
@@ -1566,6 +1566,45 @@ def _gh_api_json(
     return _json_payload(proc.stdout)
 
 
+def _gh_api_paginated_json_list(
+    api_path: str,
+    *,
+    repo_root: Path,
+    runner: CommandRunner,
+    per_page: int = 100,
+    max_pages: int = 20,
+) -> list[Any] | None:
+    """Fetch a small GitHub REST list endpoint without silently truncating it."""
+
+    values: list[Any] = []
+    separator = "&" if "?" in api_path else "?"
+    for page in range(1, max_pages + 1):
+        payload = _gh_api_json(
+            f"{api_path}{separator}per_page={per_page}&page={page}",
+            repo_root=repo_root,
+            runner=runner,
+        )
+        if not isinstance(payload, list):
+            return None
+        values.extend(payload)
+        if len(payload) < per_page:
+            return values
+    return None
+
+
+def _pull_base_ref(pull: Mapping[str, Any]) -> str:
+    base = pull.get("base")
+    if isinstance(base, Mapping):
+        ref = str(base.get("ref") or "").strip()
+        if ref:
+            return ref
+    for key in ("baseRefName", "base_ref_name", "base_ref"):
+        ref = str(pull.get(key) or "").strip()
+        if ref:
+            return ref
+    return ""
+
+
 def _merged_pr_commit_list_proof(
     desired_head: str,
     *,
@@ -1596,19 +1635,21 @@ def _merged_pr_commit_list_proof(
         number = pull.get("number")
         if not isinstance(number, int):
             continue
-        commits = _gh_api_json(
-            f"repos/{repo_slug}/pulls/{number}/commits?per_page=100",
+        commits = _gh_api_paginated_json_list(
+            f"repos/{repo_slug}/pulls/{number}/commits",
             repo_root=repo_root,
             runner=runner,
         )
         if not isinstance(commits, list):
             continue
         if any(isinstance(item, dict) and item.get("sha") == desired_head for item in commits):
+            base_ref = _pull_base_ref(pull)
             return {
                 "proven": True,
                 "method": "merged_pr_commit_list",
                 "pr_number": number,
                 "repo": repo_slug,
+                "base_ref": base_ref or None,
             }
     return {
         "proven": False,

--- a/scripts/reconcile_automation_outbox.py
+++ b/scripts/reconcile_automation_outbox.py
@@ -469,8 +469,6 @@ def _merged_pr_commit_preservation_proof(
             return None
         if not _upstream_base_matches(upstream, expected_base):
             return None
-        if not _desired_head_landed_on_base(root, base, record_branch, desired_head):
-            return None
         if common_upstream is None:
             common_upstream = upstream
         proofs.append(proof)

--- a/scripts/reconcile_automation_outbox.py
+++ b/scripts/reconcile_automation_outbox.py
@@ -116,19 +116,32 @@ def _resolve_path(repo_root: Path, value: Path | None, default: Path) -> Path:
     return (repo_root / expanded).resolve()
 
 
-def _branch_has_landed_on_main(root: Path, base: str, branch: str) -> bool:
-    """Return True if the branch's HEAD or a patch-equivalent commit is on main."""
-    proc = run_git(["rev-parse", "--verify", branch], root, timeout=15)
+def _normalize_base_ref(value: str) -> str:
+    text = str(value or "").strip()
+    for prefix in ("refs/remotes/origin/", "refs/heads/", "origin/"):
+        if text.startswith(prefix):
+            return text.removeprefix(prefix)
+    return text
+
+
+def _ref_has_landed_on_main(root: Path, base: str, ref: str) -> bool:
+    """Return True if ref or a patch-equivalent commit is on the selected base."""
+    proc = run_git(["rev-parse", "--verify", ref], root, timeout=15)
     if proc.returncode != 0:
         return False
-    proc = run_git(["merge-base", "--is-ancestor", branch, base], root, timeout=15)
+    proc = run_git(["merge-base", "--is-ancestor", ref, base], root, timeout=15)
     if proc.returncode == 0:
         return True
-    proc = run_git(["cherry", base, branch], root, timeout=120)
+    proc = run_git(["cherry", base, ref], root, timeout=120)
     if proc.returncode != 0:
         return False
     statuses = [line.split(" ", 1)[0] for line in proc.stdout.splitlines() if line.strip()]
     return bool(statuses) and all(status == "-" for status in statuses)
+
+
+def _branch_has_landed_on_main(root: Path, base: str, branch: str) -> bool:
+    """Return True if the branch's HEAD or a patch-equivalent commit is on main."""
+    return _ref_has_landed_on_main(root, base, branch)
 
 
 def _terminal_receipt_keys(receipt_dir: Path) -> set[str]:
@@ -246,41 +259,114 @@ def _desired_head_from_payload(payload: dict[str, Any]) -> str:
     return ""
 
 
-def _lane_record_from_payload(payload: Mapping[str, Any], branch: str) -> dict[str, Any]:
-    """Build the minimal lane-like record needed for preservation proof helpers."""
-    record: dict[str, Any] = {"branch": branch}
+def _copy_local_work_markers(record: dict[str, Any], source: Mapping[str, Any]) -> None:
+    for key in (
+        "uncommitted_changes",
+        "has_uncommitted_changes",
+        "uncommitted",
+        "unpushed_commits",
+        "local_changes",
+        "local_work",
+        "dirty",
+    ):
+        if source.get(key):
+            record[key] = source.get(key)
+
+
+def _lane_records_from_payload(payload: Mapping[str, Any], branch: str) -> list[dict[str, Any]]:
+    """Build lane-like records for every local evidence reference.
+
+    Older handoffs may contain multiple local_evidence records. Treating only
+    the last worktree as authoritative can hide still-active local work, so the
+    merged-PR proof path must prove every referenced worktree/head independently.
+    """
 
     desired_head = _desired_head_from_payload(dict(payload))
+    common: dict[str, Any] = {"branch": branch}
     if desired_head:
-        record["desired_head_sha"] = desired_head
-        record["head_sha"] = desired_head
+        common["desired_head_sha"] = desired_head
+        common["head_sha"] = desired_head
 
     lane = payload.get("lane")
     if isinstance(lane, Mapping):
         lane_id = str(lane.get("lane_id") or lane.get("lane") or "").strip()
         if lane_id:
-            record["lane_id"] = lane_id
+            common["lane_id"] = lane_id
 
+    records: list[dict[str, Any]] = []
     for local_evidence in _local_evidence_mappings(payload.get("local_evidence")):
+        record = dict(common)
+        local_branch = str(local_evidence.get("branch") or "").strip()
+        if local_branch:
+            record["branch"] = local_branch
+        local_head = str(
+            local_evidence.get("desired_head_sha")
+            or local_evidence.get("head_sha")
+            or local_evidence.get("head")
+            or local_evidence.get("commit")
+            or ""
+        ).strip()
+        if local_head:
+            record["desired_head_sha"] = local_head
+            record["head_sha"] = local_head
         worktree = str(local_evidence.get("worktree") or "").strip()
         if worktree:
             record["worktree"] = worktree
-        for key in (
-            "uncommitted_changes",
-            "has_uncommitted_changes",
-            "uncommitted",
-            "unpushed_commits",
-            "local_changes",
-            "local_work",
-            "dirty",
-        ):
-            if local_evidence.get(key):
-                record[key] = local_evidence.get(key)
+        _copy_local_work_markers(record, local_evidence)
+        records.append(record)
 
     worktree = str(payload.get("worktree") or "").strip()
-    if worktree and "worktree" not in record:
+    if worktree and not any(record.get("worktree") == worktree for record in records):
+        record = dict(common)
         record["worktree"] = worktree
-    return record
+        _copy_local_work_markers(record, payload)
+        records.append(record)
+
+    if not records:
+        records.append(dict(common))
+    return records
+
+
+def _lane_record_from_payload(payload: Mapping[str, Any], branch: str) -> dict[str, Any]:
+    """Build the first minimal lane-like record needed by legacy callers."""
+    return _lane_records_from_payload(payload, branch)[0]
+
+
+def _requested_base_from_payload(payload: Mapping[str, Any]) -> str:
+    requested_action = _mapping_from_action(payload.get("requested_action"))
+    if requested_action is not None:
+        for key in ("base", "base_ref", "base_ref_name", "target_base"):
+            base = str(requested_action.get(key) or "").strip()
+            if base:
+                return base
+    for key in ("base", "base_ref", "base_ref_name", "target_base"):
+        base = str(payload.get(key) or "").strip()
+        if base:
+            return base
+    return ""
+
+
+def _upstream_base_matches(upstream: Mapping[str, Any], expected_base: str) -> bool:
+    expected = _normalize_base_ref(expected_base)
+    for key in ("base_ref", "base_ref_name", "baseRefName", "base"):
+        actual = upstream.get(key)
+        if isinstance(actual, Mapping):
+            actual = actual.get("ref")
+        actual_ref = _normalize_base_ref(str(actual or "").strip())
+        if actual_ref:
+            return actual_ref == expected
+    return False
+
+
+def _desired_head_landed_on_base(root: Path, base: str, branch: str, desired_head: str) -> bool:
+    branch_head = _git_ref_head(root, branch) if branch else ""
+    if (
+        branch_head
+        and _heads_match(desired_head, branch_head)
+        and _ref_has_landed_on_main(root, base, branch)
+    ):
+        return True
+    return bool(desired_head) and _ref_has_landed_on_main(root, base, desired_head)
 
 
 def _merged_pr_commit_preservation_proof(
@@ -290,61 +376,124 @@ def _merged_pr_commit_preservation_proof(
     payload: dict[str, Any],
     branch: str,
     repo_name: str,
+    base: str,
 ) -> Mapping[str, Any] | None:
     """Return proof that an outbox head is already preserved by a merged PR.
 
     This intentionally accepts only the merged-PR commit-list proof. A remote
     branch at the exact desired head still represents unpublished PR-intent work,
-    so it must keep protecting the outbox handoff.
+    so it must keep protecting the outbox handoff. The merged PR must also target
+    the reconciler base, and the desired head must be present or patch-equivalent
+    on that base now; historical PR membership alone is not enough after reverts.
     """
 
     if not _is_pr_publication_request(payload):
         return None
-    record = _lane_record_from_payload(payload, branch)
-    if not record.get("worktree") or not record.get("desired_head_sha"):
+    expected_base = _requested_base_from_payload(payload) or base
+    records = _lane_records_from_payload(payload, branch)
+    if not records:
         return None
-    try:
-        proof = build_worktree_reference_preservation_proof(
-            record,
-            repo_root=root,
-            state_root=state_root,
-        )
-    except Exception:
-        return None
-    if not isinstance(proof, Mapping):
-        return None
-    if proof.get("available") is not True:
-        if proof.get("reason") != "upstream_preservation_unproven":
+
+    proofs: list[Mapping[str, Any]] = []
+    desired_heads: set[str] = set()
+    worktree_paths: list[str] = []
+    common_upstream: Mapping[str, Any] | None = None
+
+    for record in records:
+        desired_head = str(record.get("desired_head_sha") or "").strip()
+        if not desired_head:
             return None
-        if not _preservation_proof_has_absent_worktree(proof):
+        record_branch = str(record.get("branch") or branch).strip()
+        desired_heads.add(desired_head)
+
+        if not record.get("worktree"):
+            if not _desired_head_landed_on_base(root, base, record_branch, desired_head):
+                return None
+            proof = {
+                "available": True,
+                "branch": record_branch,
+                "desired_head_sha": desired_head,
+                "upstream_preservation": {
+                    "proven": True,
+                    "method": "current_base_contains_desired_head",
+                    "base": base,
+                },
+            }
+            proofs.append(proof)
+            continue
+
+        worktree_paths.append(str(record.get("worktree") or ""))
+        try:
+            proof = build_worktree_reference_preservation_proof(
+                record,
+                repo_root=root,
+                state_root=state_root,
+            )
+        except Exception:
             return None
-        desired_head = str(proof.get("desired_head_sha") or "").strip()
-        merged_pr = _merged_pr_commit_list_preservation(root, repo_name, desired_head)
-        if merged_pr.get("proven") is not True:
+        if not isinstance(proof, Mapping):
             return None
-        enriched = dict(proof)
-        enriched["available"] = True
-        enriched["upstream_preservation"] = merged_pr
-        enriched["upstream_preservation_fallback"] = "direct_paginated_merged_pr_lookup"
-        return enriched
-    upstream = proof.get("upstream_preservation")
-    if not isinstance(upstream, Mapping):
-        return None
-    if upstream.get("method") != "merged_pr_commit_list" or upstream.get("proven") is not True:
-        if not _preservation_proof_has_absent_worktree(proof):
+
+        upstream = proof.get("upstream_preservation")
+        if proof.get("available") is not True:
+            if proof.get("reason") != "upstream_preservation_unproven":
+                return None
+            if not _preservation_proof_has_absent_worktree(proof):
+                return None
+            upstream = _merged_pr_commit_list_preservation(root, repo_name, desired_head)
+            if upstream.get("proven") is not True:
+                return None
+            proof = {
+                **dict(proof),
+                "available": True,
+                "upstream_preservation": upstream,
+                "upstream_preservation_fallback": "direct_paginated_merged_pr_lookup",
+            }
+        elif not isinstance(upstream, Mapping) or not (
+            upstream.get("method") == "merged_pr_commit_list" and upstream.get("proven") is True
+        ):
+            if not _preservation_proof_has_absent_worktree(proof):
+                return None
+            upstream = _merged_pr_commit_list_preservation(root, repo_name, desired_head)
+            if upstream.get("proven") is not True:
+                return None
+            proof = {
+                **dict(proof),
+                "upstream_preservation": upstream,
+                "upstream_preservation_fallback": {
+                    "from": dict(proof.get("upstream_preservation") or {}),
+                    "method": "direct_paginated_merged_pr_lookup",
+                },
+            }
+        if not isinstance(upstream, Mapping):
             return None
-        desired_head = str(proof.get("desired_head_sha") or "").strip()
-        merged_pr = _merged_pr_commit_list_preservation(root, repo_name, desired_head)
-        if merged_pr.get("proven") is not True:
+        if not _upstream_base_matches(upstream, expected_base):
             return None
-        enriched = dict(proof)
-        enriched["upstream_preservation"] = merged_pr
-        enriched["upstream_preservation_fallback"] = {
-            "from": dict(upstream),
-            "method": "direct_paginated_merged_pr_lookup",
+        if not _desired_head_landed_on_base(root, base, record_branch, desired_head):
+            return None
+        if common_upstream is None:
+            common_upstream = upstream
+        proofs.append(proof)
+
+    if common_upstream is None:
+        common_upstream = {
+            "proven": True,
+            "method": "current_base_contains_desired_head",
+            "base": base,
         }
-        return enriched
-    return proof
+    if len(proofs) == 1:
+        single = dict(proofs[0])
+        single["upstream_preservation"] = dict(common_upstream)
+        return single
+    return {
+        "available": True,
+        "branch": branch,
+        "desired_head_sha": sorted(desired_heads)[0] if len(desired_heads) == 1 else None,
+        "desired_head_shas": sorted(desired_heads),
+        "worktree_paths": worktree_paths,
+        "worktree_proofs": proofs,
+        "upstream_preservation": dict(common_upstream),
+    }
 
 
 def _preservation_proof_has_absent_worktree(proof: Mapping[str, Any]) -> bool:
@@ -385,6 +534,19 @@ def _gh_api_paginated_items(root: Path, endpoint: str) -> list[Mapping[str, Any]
     return items
 
 
+def _pull_base_ref(pull: Mapping[str, Any]) -> str:
+    base = pull.get("base")
+    if isinstance(base, Mapping):
+        ref = str(base.get("ref") or "").strip()
+        if ref:
+            return ref
+    for key in ("baseRefName", "base_ref_name", "base_ref"):
+        ref = str(pull.get(key) or "").strip()
+        if ref:
+            return ref
+    return ""
+
+
 def _merged_pr_commit_list_preservation(
     root: Path,
     repo_name: str,
@@ -422,6 +584,7 @@ def _merged_pr_commit_list_preservation(
                 "pr_number": number,
                 "repo": repo_name,
                 "source": "gh_api_paginated",
+                "base_ref": _pull_base_ref(pull) or None,
             }
     return {
         "proven": False,
@@ -1308,6 +1471,7 @@ def main(argv: list[str] | None = None) -> int:
                     payload=payload,
                     branch=branch,
                     repo_name=args.repo_name,
+                    base=args.base,
                 )
                 if merged_pr_proof is not None:
                     upstream = merged_pr_proof.get("upstream_preservation") or {}
@@ -1599,6 +1763,7 @@ def main(argv: list[str] | None = None) -> int:
             payload=payload,
             branch=branch,
             repo_name=args.repo_name,
+            base=args.base,
         )
         if merged_pr_proof is not None:
             upstream = merged_pr_proof.get("upstream_preservation") or {}

--- a/scripts/reconcile_automation_outbox.py
+++ b/scripts/reconcile_automation_outbox.py
@@ -289,6 +289,7 @@ def _merged_pr_commit_preservation_proof(
     state_root: Path,
     payload: dict[str, Any],
     branch: str,
+    repo_name: str,
 ) -> Mapping[str, Any] | None:
     """Return proof that an outbox head is already preserved by a merged PR.
 
@@ -310,14 +311,123 @@ def _merged_pr_commit_preservation_proof(
         )
     except Exception:
         return None
-    if not isinstance(proof, Mapping) or proof.get("available") is not True:
+    if not isinstance(proof, Mapping):
         return None
+    if proof.get("available") is not True:
+        if proof.get("reason") != "upstream_preservation_unproven":
+            return None
+        if not _preservation_proof_has_absent_worktree(proof):
+            return None
+        desired_head = str(proof.get("desired_head_sha") or "").strip()
+        merged_pr = _merged_pr_commit_list_preservation(root, repo_name, desired_head)
+        if merged_pr.get("proven") is not True:
+            return None
+        enriched = dict(proof)
+        enriched["available"] = True
+        enriched["upstream_preservation"] = merged_pr
+        enriched["upstream_preservation_fallback"] = "direct_paginated_merged_pr_lookup"
+        return enriched
     upstream = proof.get("upstream_preservation")
     if not isinstance(upstream, Mapping):
         return None
     if upstream.get("method") != "merged_pr_commit_list" or upstream.get("proven") is not True:
-        return None
+        if not _preservation_proof_has_absent_worktree(proof):
+            return None
+        desired_head = str(proof.get("desired_head_sha") or "").strip()
+        merged_pr = _merged_pr_commit_list_preservation(root, repo_name, desired_head)
+        if merged_pr.get("proven") is not True:
+            return None
+        enriched = dict(proof)
+        enriched["upstream_preservation"] = merged_pr
+        enriched["upstream_preservation_fallback"] = {
+            "from": dict(upstream),
+            "method": "direct_paginated_merged_pr_lookup",
+        }
+        return enriched
     return proof
+
+
+def _preservation_proof_has_absent_worktree(proof: Mapping[str, Any]) -> bool:
+    inspections = proof.get("worktree_inspections")
+    if not isinstance(inspections, Sequence) or isinstance(inspections, (str, bytes, bytearray)):
+        return False
+    return bool(inspections) and all(
+        isinstance(item, Mapping) and item.get("absent_noop") is True for item in inspections
+    )
+
+
+def _gh_api_paginated_items(root: Path, endpoint: str) -> list[Mapping[str, Any]] | None:
+    try:
+        proc = subprocess.run(
+            ["gh", "api", "--paginate", "--slurp", endpoint],
+            cwd=root,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if proc.returncode != 0:
+        return None
+    try:
+        pages = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(pages, list):
+        return None
+    items: list[Mapping[str, Any]] = []
+    for page in pages:
+        if isinstance(page, list):
+            items.extend(item for item in page if isinstance(item, Mapping))
+        elif isinstance(page, Mapping):
+            items.append(page)
+    return items
+
+
+def _merged_pr_commit_list_preservation(
+    root: Path,
+    repo_name: str,
+    desired_head: str,
+) -> Mapping[str, Any]:
+    if not desired_head:
+        return {
+            "proven": False,
+            "method": "merged_pr_commit_list",
+            "reason": "desired_head_unavailable",
+        }
+    pulls = _gh_api_paginated_items(root, f"repos/{repo_name}/commits/{desired_head}/pulls")
+    if pulls is None:
+        return {
+            "proven": False,
+            "method": "merged_pr_commit_list",
+            "reason": "commit_pulls_unavailable",
+        }
+    for pull in pulls:
+        if not pull.get("merged_at"):
+            continue
+        number = pull.get("number")
+        if not isinstance(number, int):
+            continue
+        commits = _gh_api_paginated_items(
+            root,
+            f"repos/{repo_name}/pulls/{number}/commits?per_page=100",
+        )
+        if commits is None:
+            continue
+        if any(item.get("sha") == desired_head for item in commits):
+            return {
+                "proven": True,
+                "method": "merged_pr_commit_list",
+                "pr_number": number,
+                "repo": repo_name,
+                "source": "gh_api_paginated",
+            }
+    return {
+        "proven": False,
+        "method": "merged_pr_commit_list",
+        "reason": "no_merged_pr_commit_contains_desired_head",
+    }
 
 
 def _requested_action_type(payload: Mapping[str, Any]) -> str:
@@ -696,6 +806,25 @@ def _archive_with_terminal_disposition(
     """
     archived = {key: value for key, value in payload.items() if key != "__source_file"}
     archived["terminal_disposition"] = dict(terminal_info)
+    destination = archive_dir / path.name
+    destination.write_text(json.dumps(archived, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    path.unlink()
+    return destination
+
+
+def _archive_with_preservation_proof(
+    path: Path,
+    archive_dir: Path,
+    payload: Mapping[str, Any],
+    proof: Mapping[str, Any],
+    reason: str,
+) -> Path:
+    archived = {key: value for key, value in payload.items() if key != "__source_file"}
+    archived["terminal_disposition"] = {
+        "archived_by": "scripts/reconcile_automation_outbox.py",
+        "reason": reason,
+        "preservation_proof": dict(proof),
+    }
     destination = archive_dir / path.name
     destination.write_text(json.dumps(archived, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     path.unlink()
@@ -1178,6 +1307,7 @@ def main(argv: list[str] | None = None) -> int:
                     state_root=state_root,
                     payload=payload,
                     branch=branch,
+                    repo_name=args.repo_name,
                 )
                 if merged_pr_proof is not None:
                     upstream = merged_pr_proof.get("upstream_preservation") or {}
@@ -1197,7 +1327,9 @@ def main(argv: list[str] | None = None) -> int:
                         }
                     )
                     if args.apply:
-                        shutil.move(str(path), str(archive_dir / path.name))
+                        _archive_with_preservation_proof(
+                            path, archive_dir, payload, merged_pr_proof, reason
+                        )
                     continue
                 issue_only_kept_reason = (
                     issue_only_keep_reason
@@ -1466,6 +1598,7 @@ def main(argv: list[str] | None = None) -> int:
             state_root=state_root,
             payload=payload,
             branch=branch,
+            repo_name=args.repo_name,
         )
         if merged_pr_proof is not None:
             upstream = merged_pr_proof.get("upstream_preservation") or {}
@@ -1492,7 +1625,9 @@ def main(argv: list[str] | None = None) -> int:
                     pr_number=int(pr_number) if isinstance(pr_number, int) else None,
                     apply=True,
                 )
-                shutil.move(str(path), str(archive_dir / path.name))
+                _archive_with_preservation_proof(
+                    path, archive_dir, payload, merged_pr_proof, reason
+                )
             continue
 
         reason = (

--- a/scripts/reconcile_automation_outbox.py
+++ b/scripts/reconcile_automation_outbox.py
@@ -42,6 +42,7 @@ from audit_codex_branch_backlog import (  # noqa: E402
     run_git,
 )
 from github_cli_health import check_github_cli_health  # noqa: E402
+from identify_lane_owner import build_worktree_reference_preservation_proof  # noqa: E402
 
 UTC = timezone.utc
 DEFAULT_OUTBOX_DIR = Path(".aragora/automation-outbox")
@@ -243,6 +244,80 @@ def _desired_head_from_payload(payload: dict[str, Any]) -> str:
             if head:
                 return head
     return ""
+
+
+def _lane_record_from_payload(payload: Mapping[str, Any], branch: str) -> dict[str, Any]:
+    """Build the minimal lane-like record needed for preservation proof helpers."""
+    record: dict[str, Any] = {"branch": branch}
+
+    desired_head = _desired_head_from_payload(dict(payload))
+    if desired_head:
+        record["desired_head_sha"] = desired_head
+        record["head_sha"] = desired_head
+
+    lane = payload.get("lane")
+    if isinstance(lane, Mapping):
+        lane_id = str(lane.get("lane_id") or lane.get("lane") or "").strip()
+        if lane_id:
+            record["lane_id"] = lane_id
+
+    for local_evidence in _local_evidence_mappings(payload.get("local_evidence")):
+        worktree = str(local_evidence.get("worktree") or "").strip()
+        if worktree:
+            record["worktree"] = worktree
+        for key in (
+            "uncommitted_changes",
+            "has_uncommitted_changes",
+            "uncommitted",
+            "unpushed_commits",
+            "local_changes",
+            "local_work",
+            "dirty",
+        ):
+            if local_evidence.get(key):
+                record[key] = local_evidence.get(key)
+
+    worktree = str(payload.get("worktree") or "").strip()
+    if worktree and "worktree" not in record:
+        record["worktree"] = worktree
+    return record
+
+
+def _merged_pr_commit_preservation_proof(
+    *,
+    root: Path,
+    state_root: Path,
+    payload: dict[str, Any],
+    branch: str,
+) -> Mapping[str, Any] | None:
+    """Return proof that an outbox head is already preserved by a merged PR.
+
+    This intentionally accepts only the merged-PR commit-list proof. A remote
+    branch at the exact desired head still represents unpublished PR-intent work,
+    so it must keep protecting the outbox handoff.
+    """
+
+    if not _is_pr_publication_request(payload):
+        return None
+    record = _lane_record_from_payload(payload, branch)
+    if not record.get("worktree") or not record.get("desired_head_sha"):
+        return None
+    try:
+        proof = build_worktree_reference_preservation_proof(
+            record,
+            repo_root=root,
+            state_root=state_root,
+        )
+    except Exception:
+        return None
+    if not isinstance(proof, Mapping) or proof.get("available") is not True:
+        return None
+    upstream = proof.get("upstream_preservation")
+    if not isinstance(upstream, Mapping):
+        return None
+    if upstream.get("method") != "merged_pr_commit_list" or upstream.get("proven") is not True:
+        return None
+    return proof
 
 
 def _requested_action_type(payload: Mapping[str, Any]) -> str:
@@ -1040,6 +1115,7 @@ def main(argv: list[str] | None = None) -> int:
         "satisfied_by_superseded_handoff": 0,
         "satisfied_by_landed_on_main": 0,
         "satisfied_by_open_pr_merged": 0,  # placeholder; we only know open PRs
+        "satisfied_by_merged_pr_commit_proof": 0,
         "still_protecting_active_work": 0,
         "missing_branch": 0,
         "blocked_missing_branch_open_pr_unknown": 0,
@@ -1096,6 +1172,32 @@ def main(argv: list[str] | None = None) -> int:
                         _archive_with_terminal_disposition(
                             path, archive_dir, payload, terminal_info
                         )
+                    continue
+                merged_pr_proof = _merged_pr_commit_preservation_proof(
+                    root=root,
+                    state_root=state_root,
+                    payload=payload,
+                    branch=branch,
+                )
+                if merged_pr_proof is not None:
+                    upstream = merged_pr_proof.get("upstream_preservation") or {}
+                    pr_number = upstream.get("pr_number") if isinstance(upstream, Mapping) else None
+                    reason = "desired head preserved by merged PR commit list" + (
+                        f" (PR #{pr_number})" if pr_number is not None else ""
+                    )
+                    counts["satisfied_by_merged_pr_commit_proof"] += 1
+                    actions.append(
+                        {
+                            "path": str(path),
+                            "branch": branch,
+                            "decision": "archive",
+                            "reason": reason,
+                            "preservation_proof": merged_pr_proof,
+                            "synthetic_receipt": False,
+                        }
+                    )
+                    if args.apply:
+                        shutil.move(str(path), str(archive_dir / path.name))
                     continue
                 issue_only_kept_reason = (
                     issue_only_keep_reason
@@ -1357,6 +1459,40 @@ def main(argv: list[str] | None = None) -> int:
                     "synthetic_receipt": False,
                 }
             )
+            continue
+
+        merged_pr_proof = _merged_pr_commit_preservation_proof(
+            root=root,
+            state_root=state_root,
+            payload=payload,
+            branch=branch,
+        )
+        if merged_pr_proof is not None:
+            upstream = merged_pr_proof.get("upstream_preservation") or {}
+            pr_number = upstream.get("pr_number") if isinstance(upstream, Mapping) else None
+            reason = "desired head preserved by merged PR commit list" + (
+                f" (PR #{pr_number})" if pr_number is not None else ""
+            )
+            counts["satisfied_by_merged_pr_commit_proof"] += 1
+            actions.append(
+                {
+                    "path": str(path),
+                    "branch": branch,
+                    "decision": "archive",
+                    "reason": reason,
+                    "preservation_proof": merged_pr_proof,
+                    "synthetic_receipt": True,
+                }
+            )
+            if args.apply:
+                _write_synthetic_receipt(
+                    receipt_dir=receipt_dir,
+                    outbox_payload=payload,
+                    reason=reason,
+                    pr_number=int(pr_number) if isinstance(pr_number, int) else None,
+                    apply=True,
+                )
+                shutil.move(str(path), str(archive_dir / path.name))
             continue
 
         reason = (

--- a/scripts/reconcile_automation_outbox.py
+++ b/scripts/reconcile_automation_outbox.py
@@ -59,6 +59,15 @@ DEFAULT_ARCHIVE_DIR = Path(".aragora/automation-outbox-archive")
 DEFAULT_EXISTING_ISSUE_MIN_AGE_DAYS = 3.0
 DEFAULT_EXISTING_ISSUE_ARCHIVE_CAP = 20
 TERMINAL_DISPOSITION_EXISTING_ISSUE = "superseded_by_existing_issue"
+LOCAL_WORK_MARKER_KEYS = (
+    "uncommitted_changes",
+    "has_uncommitted_changes",
+    "uncommitted",
+    "unpushed_commits",
+    "local_changes",
+    "local_work",
+    "dirty",
+)
 
 
 def _mute_stdout_after_broken_pipe() -> None:
@@ -260,17 +269,13 @@ def _desired_head_from_payload(payload: dict[str, Any]) -> str:
 
 
 def _copy_local_work_markers(record: dict[str, Any], source: Mapping[str, Any]) -> None:
-    for key in (
-        "uncommitted_changes",
-        "has_uncommitted_changes",
-        "uncommitted",
-        "unpushed_commits",
-        "local_changes",
-        "local_work",
-        "dirty",
-    ):
+    for key in LOCAL_WORK_MARKER_KEYS:
         if source.get(key):
             record[key] = source.get(key)
+
+
+def _has_local_work_marker(record: Mapping[str, Any]) -> bool:
+    return any(bool(record.get(key)) for key in LOCAL_WORK_MARKER_KEYS)
 
 
 def _lane_records_from_payload(payload: Mapping[str, Any], branch: str) -> list[dict[str, Any]]:
@@ -286,6 +291,7 @@ def _lane_records_from_payload(payload: Mapping[str, Any], branch: str) -> list[
     if desired_head:
         common["desired_head_sha"] = desired_head
         common["head_sha"] = desired_head
+    _copy_local_work_markers(common, payload)
 
     lane = payload.get("lane")
     if isinstance(lane, Mapping):
@@ -407,6 +413,8 @@ def _merged_pr_commit_preservation_proof(
         desired_heads.add(desired_head)
 
         if not record.get("worktree"):
+            if _has_local_work_marker(record):
+                return None
             if not _desired_head_landed_on_base(root, base, record_branch, desired_head):
                 return None
             proof = {

--- a/tests/scripts/test_identify_lane_owner.py
+++ b/tests/scripts/test_identify_lane_owner.py
@@ -1238,6 +1238,56 @@ def safe_inspect_payload(*, exists: bool) -> str:
     )
 
 
+def test_absent_worktree_merged_pr_commit_list_paginates_commits(tmp_path: Path) -> None:
+    desired_head = "317b94232d3ba41c3a1e546a94010dfdf069f85f"
+    lane, ledger, _worktree = _stale_worktree_lane(
+        tmp_path,
+        branch="codex/large-merged-pr",
+        desired_head=desired_head,
+    )
+    calls: list[list[str]] = []
+
+    def runner(cmd: list[str], cwd: Path, timeout: float) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        if "safe_worktree_cleanup.py" in " ".join(cmd):
+            return completed(cmd, stdout=safe_inspect_payload(exists=False), returncode=1)
+        if cmd[:3] == ["git", "ls-remote", "origin"]:
+            return completed(cmd, stdout="")
+        if cmd == ["git", "remote", "get-url", "origin"]:
+            return completed(cmd, stdout="https://github.com/synaptent/aragora.git\n")
+        if cmd[:2] == ["gh", "api"] and f"commits/{desired_head}/pulls" in cmd[-1]:
+            return completed(
+                cmd,
+                stdout=json.dumps(
+                    [{"number": 7825, "merged_at": LIVENESS_NOW, "base": {"ref": "main"}}]
+                ),
+            )
+        if cmd[:2] == ["gh", "api"] and "pulls/7825/commits" in cmd[-1]:
+            if "&page=1" in cmd[-1]:
+                return completed(
+                    cmd,
+                    stdout=json.dumps([{"sha": f"{i:040x}"} for i in range(100)]),
+                )
+            if "&page=2" in cmd[-1]:
+                return completed(cmd, stdout=json.dumps([{"sha": desired_head}]))
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    proof = ilo.build_worktree_reference_preservation_proof(
+        lane,
+        ledger_entry=ledger,
+        repo_root=tmp_path,
+        state_root=tmp_path / ".aragora",
+        runner=runner,
+    )
+
+    assert proof["available"] is True
+    assert proof["upstream_preservation"]["method"] == "merged_pr_commit_list"
+    assert proof["upstream_preservation"]["base_ref"] == "main"
+    commit_page_calls = [cmd for cmd in calls if "pulls/7825/commits" in cmd[-1]]
+    assert any("&page=1" in cmd[-1] for cmd in commit_page_calls)
+    assert any("&page=2" in cmd[-1] for cmd in commit_page_calls)
+
+
 class TestOwnerLeaseLiveness:
     def test_live_owner_no_advisory(self) -> None:
         lane = {

--- a/tests/scripts/test_reconcile_automation_outbox.py
+++ b/tests/scripts/test_reconcile_automation_outbox.py
@@ -847,7 +847,7 @@ def test_reconcile_archives_issue_only_pr_handoff_when_merged_pr_proves_head_pre
         ),
     )
 
-    assert mod.main(["--repo", str(tmp_path), "--json"]) == 0
+    assert mod.main(["--repo", str(tmp_path), "--apply", "--json"]) == 0
 
     result = json.loads(capsys.readouterr().out)
     assert result["counts"]["satisfied_by_merged_pr_commit_proof"] == 1
@@ -856,7 +856,14 @@ def test_reconcile_archives_issue_only_pr_handoff_when_merged_pr_proves_head_pre
     assert result["actions"][0]["decision"] == "archive"
     assert result["actions"][0]["synthetic_receipt"] is False
     assert "merged PR commit list (PR #8583)" in result["actions"][0]["reason"]
-    assert handoff.exists()
+    assert not handoff.exists()
+    archived = tmp_path / ".aragora" / "automation-outbox-archive" / handoff.name
+    archive_payload = json.loads(archived.read_text(encoding="utf-8"))
+    disposition = archive_payload["terminal_disposition"]
+    assert disposition["reason"] == "desired head preserved by merged PR commit list (PR #8583)"
+    assert disposition["preservation_proof"]["upstream_preservation"]["method"] == (
+        "merged_pr_commit_list"
+    )
 
 
 def test_reconcile_keeps_target_pr_receipt_when_desired_head_not_published(
@@ -1326,6 +1333,7 @@ def test_unique_branch_archives_when_desired_head_preserved_by_merged_pr_commit_
     monkeypatch.setattr(mod, "run_git", fake_run_git)
     monkeypatch.setattr(mod, "check_github_cli_health", lambda _root: _ready_github())
     monkeypatch.setattr(mod, "open_pr_heads", lambda *_args: {})
+    monkeypatch.setattr(mod, "_gh_api_paginated_items", lambda *_args: [])
     monkeypatch.setattr(
         mod,
         "build_worktree_reference_preservation_proof",
@@ -1426,6 +1434,92 @@ def test_unique_branch_keeps_when_preservation_proof_is_remote_branch_only(
     assert payload["counts"]["still_protecting_active_work"] == 1
     assert payload["actions"][0]["decision"] == "keep"
     assert "actively protecting" in payload["actions"][0]["reason"]
+
+
+def test_unique_branch_archives_when_remote_branch_also_has_merged_pr_proof(
+    tmp_path: Path,
+    monkeypatch: Any,
+    capsys: Any,
+) -> None:
+    outbox_dir = tmp_path / ".aragora" / "automation-outbox"
+    key = "open-pr-codex-remote-and-merged-proof-abc123"
+    branch = "codex/remote-and-merged-proof"
+    desired_head = "abcdef1234567890abcdef1234567890abcdef12"
+    _write_outbox_handoff(
+        outbox_dir,
+        branch=branch,
+        key=key,
+        local_evidence={
+            "branch": branch,
+            "desired_head_sha": desired_head,
+            "worktree": str(tmp_path / "missing-worktree"),
+        },
+    )
+
+    def fake_run_git(
+        args: list[str],
+        _root: Path,
+        *,
+        timeout: int = 60,
+    ) -> subprocess.CompletedProcess[str]:
+        if args == ["rev-parse", "--verify", branch]:
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout=f"{desired_head}\n")
+        if args[:2] == ["merge-base", "--is-ancestor"]:
+            return subprocess.CompletedProcess(args=args, returncode=1, stdout="", stderr="")
+        if args[0] == "cherry":
+            return subprocess.CompletedProcess(
+                args=args, returncode=0, stdout=f"+ {desired_head}\n"
+            )
+        raise AssertionError(f"unexpected git call: {args}")
+
+    def fake_gh_items(_root: Path, endpoint: str) -> list[dict[str, Any]]:
+        if endpoint == f"repos/synaptent/aragora/commits/{desired_head}/pulls":
+            return [{"number": 8583, "merged_at": "2026-06-24T00:00:00Z"}]
+        if endpoint == "repos/synaptent/aragora/pulls/8583/commits?per_page=100":
+            return [
+                {"sha": "1111111111111111111111111111111111111111"},
+                {"sha": desired_head},
+            ]
+        raise AssertionError(f"unexpected gh endpoint: {endpoint}")
+
+    monkeypatch.setattr(mod, "run_git", fake_run_git)
+    monkeypatch.setattr(mod, "check_github_cli_health", lambda _root: _ready_github())
+    monkeypatch.setattr(mod, "open_pr_heads", lambda *_args: {})
+    monkeypatch.setattr(mod, "_gh_api_paginated_items", fake_gh_items)
+    monkeypatch.setattr(
+        mod,
+        "build_worktree_reference_preservation_proof",
+        lambda *_args, **_kwargs: {
+            "available": True,
+            "branch": branch,
+            "desired_head_sha": desired_head,
+            "worktree_paths": [str(tmp_path / "missing-worktree")],
+            "worktree_inspections": [
+                {
+                    "path": str(tmp_path / "missing-worktree"),
+                    "absent_noop": True,
+                    "source": "safe_worktree_cleanup.inspect",
+                    "classification": "absent_noop",
+                }
+            ],
+            "upstream_preservation": {
+                "proven": True,
+                "method": "remote_branch_exact_head",
+                "remote_head_sha": desired_head,
+            },
+        },
+    )
+
+    assert mod.main(["--repo", str(tmp_path), "--json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["counts"]["satisfied_by_merged_pr_commit_proof"] == 1
+    assert payload["counts"]["still_protecting_active_work"] == 0
+    assert payload["actions"][0]["decision"] == "archive"
+    assert "merged PR commit list (PR #8583)" in payload["actions"][0]["reason"]
+    proof = payload["actions"][0]["preservation_proof"]
+    assert proof["upstream_preservation"]["source"] == "gh_api_paginated"
+    assert proof["upstream_preservation_fallback"]["from"]["method"] == "remote_branch_exact_head"
 
 
 def test_unique_branch_keeps_when_preservation_proof_is_unavailable(

--- a/tests/scripts/test_reconcile_automation_outbox.py
+++ b/tests/scripts/test_reconcile_automation_outbox.py
@@ -1551,7 +1551,7 @@ def test_merged_pr_preservation_proof_checks_all_local_evidence_worktrees(
     assert len(proof["worktree_proofs"]) == 2
 
 
-def test_unique_branch_keeps_when_merged_pr_proof_is_not_on_current_base(
+def test_unique_branch_archives_when_merged_pr_proof_is_squash_merged(
     tmp_path: Path,
     monkeypatch: Any,
     capsys: Any,
@@ -1589,7 +1589,13 @@ def test_unique_branch_keeps_when_merged_pr_proof_is_not_on_current_base(
 
     def fake_gh_items(_root: Path, endpoint: str) -> list[dict[str, Any]]:
         if endpoint == f"repos/synaptent/aragora/commits/{desired_head}/pulls":
-            return [{"number": 8583, "merged_at": "2026-06-24T00:00:00Z"}]
+            return [
+                {
+                    "number": 8583,
+                    "merged_at": "2026-06-24T00:00:00Z",
+                    "base": {"ref": "main"},
+                }
+            ]
         if endpoint == "repos/synaptent/aragora/pulls/8583/commits?per_page=100":
             return [
                 {"sha": "1111111111111111111111111111111111111111"},
@@ -1628,10 +1634,10 @@ def test_unique_branch_keeps_when_merged_pr_proof_is_not_on_current_base(
     assert mod.main(["--repo", str(tmp_path), "--json"]) == 0
 
     payload = json.loads(capsys.readouterr().out)
-    assert payload["counts"]["satisfied_by_merged_pr_commit_proof"] == 0
-    assert payload["counts"]["still_protecting_active_work"] == 1
-    assert payload["actions"][0]["decision"] == "keep"
-    assert "actively protecting" in payload["actions"][0]["reason"]
+    assert payload["counts"]["satisfied_by_merged_pr_commit_proof"] == 1
+    assert payload["counts"]["still_protecting_active_work"] == 0
+    assert payload["actions"][0]["decision"] == "archive"
+    assert "merged PR commit list (PR #8583)" in payload["actions"][0]["reason"]
 
 
 def test_unique_branch_keeps_when_preservation_proof_is_unavailable(

--- a/tests/scripts/test_reconcile_automation_outbox.py
+++ b/tests/scripts/test_reconcile_automation_outbox.py
@@ -766,6 +766,99 @@ def test_reconcile_keeps_pr_handoff_with_issue_only_receipt(
     assert handoff.exists()
 
 
+def test_reconcile_archives_issue_only_pr_handoff_when_merged_pr_proves_head_preserved(
+    tmp_path: Path,
+    monkeypatch: Any,
+    capsys: Any,
+) -> None:
+    outbox_dir = tmp_path / ".aragora" / "automation-outbox"
+    receipt_dir = tmp_path / ".aragora" / "automation-receipts"
+    key = "open-pr-codex-issue-only-merged-pr-proof-abc123"
+    branch = "codex/issue-only-merged-pr-proof"
+    desired_head = "abcdef1234567890abcdef1234567890abcdef12"
+    handoff = _write_outbox_handoff(
+        outbox_dir,
+        branch=branch,
+        key=key,
+        local_evidence={
+            "branch": branch,
+            "desired_head_sha": desired_head,
+            "worktree": str(tmp_path / "missing-worktree"),
+        },
+    )
+    payload = json.loads(handoff.read_text(encoding="utf-8"))
+    payload["requested_action"] = {
+        "type": "open_or_update_pr",
+        "base": "main",
+        "branch": branch,
+        "desired_head_sha": desired_head,
+    }
+    handoff.write_text(json.dumps(payload), encoding="utf-8")
+    receipt_dir.mkdir(parents=True)
+    (receipt_dir / f"{key}.json").write_text(
+        json.dumps(
+            {
+                "idempotency_key": key,
+                "status": "published",
+                "reason": "published",
+                "created_issue_url": "https://github.com/synaptent/aragora/issues/8581",
+                "existing_pr_url": None,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        mod,
+        "build_worktree_reference_preservation_proof",
+        lambda *_args, **_kwargs: {
+            "available": True,
+            "branch": branch,
+            "desired_head_sha": desired_head,
+            "worktree_paths": [str(tmp_path / "missing-worktree")],
+            "worktree_inspections": [
+                {
+                    "path": str(tmp_path / "missing-worktree"),
+                    "absent_noop": True,
+                    "source": "safe_worktree_cleanup.inspect",
+                    "classification": "absent_noop",
+                }
+            ],
+            "upstream_preservation": {
+                "proven": True,
+                "method": "merged_pr_commit_list",
+                "pr_number": 8583,
+                "repo": "synaptent/aragora",
+            },
+        },
+    )
+    monkeypatch.setattr(
+        mod,
+        "run_git",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("git ref checks should not run once merged PR proof is available")
+        ),
+    )
+    monkeypatch.setattr(
+        mod,
+        "open_pr_heads",
+        lambda *_args: (_ for _ in ()).throw(
+            AssertionError("open PR fetch should not run once merged PR proof is available")
+        ),
+    )
+
+    assert mod.main(["--repo", str(tmp_path), "--json"]) == 0
+
+    result = json.loads(capsys.readouterr().out)
+    assert result["counts"]["satisfied_by_merged_pr_commit_proof"] == 1
+    assert result["counts"]["blocked_receipt_issue_only"] == 0
+    assert result["counts"]["still_protecting_active_work"] == 0
+    assert result["actions"][0]["decision"] == "archive"
+    assert result["actions"][0]["synthetic_receipt"] is False
+    assert "merged PR commit list (PR #8583)" in result["actions"][0]["reason"]
+    assert handoff.exists()
+
+
 def test_reconcile_keeps_target_pr_receipt_when_desired_head_not_published(
     tmp_path: Path,
     monkeypatch: Any,
@@ -1192,6 +1285,204 @@ def test_unique_non_codex_branch_is_protected_by_open_pr(
     assert payload["counts"]["still_protecting_active_work"] == 1
     assert payload["actions"][0]["decision"] == "keep"
     assert payload["actions"][0]["reason"] == "branch has open PR #8501"
+
+
+def test_unique_branch_archives_when_desired_head_preserved_by_merged_pr_commit_list(
+    tmp_path: Path,
+    monkeypatch: Any,
+    capsys: Any,
+) -> None:
+    outbox_dir = tmp_path / ".aragora" / "automation-outbox"
+    key = "open-pr-codex-merged-pr-proof-abc123"
+    branch = "codex/merged-pr-proof"
+    desired_head = "abcdef1234567890abcdef1234567890abcdef12"
+    _write_outbox_handoff(
+        outbox_dir,
+        branch=branch,
+        key=key,
+        local_evidence={
+            "branch": branch,
+            "desired_head_sha": desired_head,
+            "worktree": str(tmp_path / "missing-worktree"),
+        },
+    )
+
+    def fake_run_git(
+        args: list[str],
+        _root: Path,
+        *,
+        timeout: int = 60,
+    ) -> subprocess.CompletedProcess[str]:
+        if args == ["rev-parse", "--verify", branch]:
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout=f"{desired_head}\n")
+        if args[:2] == ["merge-base", "--is-ancestor"]:
+            return subprocess.CompletedProcess(args=args, returncode=1, stdout="", stderr="")
+        if args[0] == "cherry":
+            return subprocess.CompletedProcess(
+                args=args, returncode=0, stdout=f"+ {desired_head}\n"
+            )
+        raise AssertionError(f"unexpected git call: {args}")
+
+    monkeypatch.setattr(mod, "run_git", fake_run_git)
+    monkeypatch.setattr(mod, "check_github_cli_health", lambda _root: _ready_github())
+    monkeypatch.setattr(mod, "open_pr_heads", lambda *_args: {})
+    monkeypatch.setattr(
+        mod,
+        "build_worktree_reference_preservation_proof",
+        lambda *_args, **_kwargs: {
+            "available": True,
+            "branch": branch,
+            "desired_head_sha": desired_head,
+            "worktree_paths": [str(tmp_path / "missing-worktree")],
+            "worktree_inspections": [
+                {
+                    "path": str(tmp_path / "missing-worktree"),
+                    "absent_noop": True,
+                    "source": "safe_worktree_cleanup.inspect",
+                    "classification": "absent_noop",
+                }
+            ],
+            "upstream_preservation": {
+                "proven": True,
+                "method": "merged_pr_commit_list",
+                "pr_number": 8583,
+                "repo": "synaptent/aragora",
+            },
+        },
+    )
+
+    assert mod.main(["--repo", str(tmp_path), "--json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["counts"]["satisfied_by_merged_pr_commit_proof"] == 1
+    assert payload["counts"]["still_protecting_active_work"] == 0
+    assert payload["actions"][0]["decision"] == "archive"
+    assert "merged PR commit list (PR #8583)" in payload["actions"][0]["reason"]
+    assert (
+        payload["actions"][0]["preservation_proof"]["upstream_preservation"]["method"]
+        == "merged_pr_commit_list"
+    )
+
+
+def test_unique_branch_keeps_when_preservation_proof_is_remote_branch_only(
+    tmp_path: Path,
+    monkeypatch: Any,
+    capsys: Any,
+) -> None:
+    outbox_dir = tmp_path / ".aragora" / "automation-outbox"
+    key = "open-pr-codex-remote-only-proof-abc123"
+    branch = "codex/remote-only-proof"
+    desired_head = "abcdef1234567890abcdef1234567890abcdef12"
+    _write_outbox_handoff(
+        outbox_dir,
+        branch=branch,
+        key=key,
+        local_evidence={
+            "branch": branch,
+            "desired_head_sha": desired_head,
+            "worktree": str(tmp_path / "missing-worktree"),
+        },
+    )
+
+    def fake_run_git(
+        args: list[str],
+        _root: Path,
+        *,
+        timeout: int = 60,
+    ) -> subprocess.CompletedProcess[str]:
+        if args == ["rev-parse", "--verify", branch]:
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout=f"{desired_head}\n")
+        if args[:2] == ["merge-base", "--is-ancestor"]:
+            return subprocess.CompletedProcess(args=args, returncode=1, stdout="", stderr="")
+        if args[0] == "cherry":
+            return subprocess.CompletedProcess(
+                args=args, returncode=0, stdout=f"+ {desired_head}\n"
+            )
+        raise AssertionError(f"unexpected git call: {args}")
+
+    monkeypatch.setattr(mod, "run_git", fake_run_git)
+    monkeypatch.setattr(mod, "check_github_cli_health", lambda _root: _ready_github())
+    monkeypatch.setattr(mod, "open_pr_heads", lambda *_args: {})
+    monkeypatch.setattr(
+        mod,
+        "build_worktree_reference_preservation_proof",
+        lambda *_args, **_kwargs: {
+            "available": True,
+            "branch": branch,
+            "desired_head_sha": desired_head,
+            "worktree_paths": [str(tmp_path / "missing-worktree")],
+            "upstream_preservation": {
+                "proven": True,
+                "method": "remote_branch_exact_head",
+                "remote_head_sha": desired_head,
+            },
+        },
+    )
+
+    assert mod.main(["--repo", str(tmp_path), "--json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["counts"]["satisfied_by_merged_pr_commit_proof"] == 0
+    assert payload["counts"]["still_protecting_active_work"] == 1
+    assert payload["actions"][0]["decision"] == "keep"
+    assert "actively protecting" in payload["actions"][0]["reason"]
+
+
+def test_unique_branch_keeps_when_preservation_proof_is_unavailable(
+    tmp_path: Path,
+    monkeypatch: Any,
+    capsys: Any,
+) -> None:
+    outbox_dir = tmp_path / ".aragora" / "automation-outbox"
+    key = "open-pr-codex-proof-unavailable-abc123"
+    branch = "codex/proof-unavailable"
+    desired_head = "abcdef1234567890abcdef1234567890abcdef12"
+    _write_outbox_handoff(
+        outbox_dir,
+        branch=branch,
+        key=key,
+        local_evidence={
+            "branch": branch,
+            "desired_head_sha": desired_head,
+            "worktree": str(tmp_path / "missing-worktree"),
+        },
+    )
+
+    def fake_run_git(
+        args: list[str],
+        _root: Path,
+        *,
+        timeout: int = 60,
+    ) -> subprocess.CompletedProcess[str]:
+        if args == ["rev-parse", "--verify", branch]:
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout=f"{desired_head}\n")
+        if args[:2] == ["merge-base", "--is-ancestor"]:
+            return subprocess.CompletedProcess(args=args, returncode=1, stdout="", stderr="")
+        if args[0] == "cherry":
+            return subprocess.CompletedProcess(
+                args=args, returncode=0, stdout=f"+ {desired_head}\n"
+            )
+        raise AssertionError(f"unexpected git call: {args}")
+
+    monkeypatch.setattr(mod, "run_git", fake_run_git)
+    monkeypatch.setattr(mod, "check_github_cli_health", lambda _root: _ready_github())
+    monkeypatch.setattr(mod, "open_pr_heads", lambda *_args: {})
+    monkeypatch.setattr(
+        mod,
+        "build_worktree_reference_preservation_proof",
+        lambda *_args, **_kwargs: {
+            "available": False,
+            "reason": "upstream_preservation_unproven",
+        },
+    )
+
+    assert mod.main(["--repo", str(tmp_path), "--json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["counts"]["satisfied_by_merged_pr_commit_proof"] == 0
+    assert payload["counts"]["still_protecting_active_work"] == 1
+    assert payload["actions"][0]["decision"] == "keep"
+    assert "actively protecting" in payload["actions"][0]["reason"]
 
 
 def test_landed_branch_archives_without_github_lookup(

--- a/tests/scripts/test_reconcile_automation_outbox.py
+++ b/tests/scripts/test_reconcile_automation_outbox.py
@@ -829,16 +829,24 @@ def test_reconcile_archives_issue_only_pr_handoff_when_merged_pr_proves_head_pre
                 "method": "merged_pr_commit_list",
                 "pr_number": 8583,
                 "repo": "synaptent/aragora",
+                "base_ref": "main",
             },
         },
     )
-    monkeypatch.setattr(
-        mod,
-        "run_git",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(
-            AssertionError("git ref checks should not run once merged PR proof is available")
-        ),
-    )
+
+    def fake_run_git(
+        args: list[str],
+        _root: Path,
+        *,
+        timeout: int = 60,
+    ) -> subprocess.CompletedProcess[str]:
+        if args == ["rev-parse", "--verify", branch]:
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout=f"{desired_head}\n")
+        if args[:2] == ["merge-base", "--is-ancestor"]:
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+        raise AssertionError(f"unexpected git call: {args}")
+
+    monkeypatch.setattr(mod, "run_git", fake_run_git)
     monkeypatch.setattr(
         mod,
         "open_pr_heads",
@@ -1294,7 +1302,7 @@ def test_unique_non_codex_branch_is_protected_by_open_pr(
     assert payload["actions"][0]["reason"] == "branch has open PR #8501"
 
 
-def test_unique_branch_archives_when_desired_head_preserved_by_merged_pr_commit_list(
+def test_unique_branch_archives_when_desired_head_is_patch_equivalent_to_main(
     tmp_path: Path,
     monkeypatch: Any,
     capsys: Any,
@@ -1326,7 +1334,7 @@ def test_unique_branch_archives_when_desired_head_preserved_by_merged_pr_commit_
             return subprocess.CompletedProcess(args=args, returncode=1, stdout="", stderr="")
         if args[0] == "cherry":
             return subprocess.CompletedProcess(
-                args=args, returncode=0, stdout=f"+ {desired_head}\n"
+                args=args, returncode=0, stdout=f"- {desired_head}\n"
             )
         raise AssertionError(f"unexpected git call: {args}")
 
@@ -1355,6 +1363,7 @@ def test_unique_branch_archives_when_desired_head_preserved_by_merged_pr_commit_
                 "method": "merged_pr_commit_list",
                 "pr_number": 8583,
                 "repo": "synaptent/aragora",
+                "base_ref": "main",
             },
         },
     )
@@ -1362,13 +1371,11 @@ def test_unique_branch_archives_when_desired_head_preserved_by_merged_pr_commit_
     assert mod.main(["--repo", str(tmp_path), "--json"]) == 0
 
     payload = json.loads(capsys.readouterr().out)
-    assert payload["counts"]["satisfied_by_merged_pr_commit_proof"] == 1
+    assert payload["counts"]["satisfied_by_landed_on_main"] == 1
     assert payload["counts"]["still_protecting_active_work"] == 0
     assert payload["actions"][0]["decision"] == "archive"
-    assert "merged PR commit list (PR #8583)" in payload["actions"][0]["reason"]
     assert (
-        payload["actions"][0]["preservation_proof"]["upstream_preservation"]["method"]
-        == "merged_pr_commit_list"
+        payload["actions"][0]["reason"] == "branch work landed on main (merge or patch-equivalent)"
     )
 
 
@@ -1436,7 +1443,115 @@ def test_unique_branch_keeps_when_preservation_proof_is_remote_branch_only(
     assert "actively protecting" in payload["actions"][0]["reason"]
 
 
-def test_unique_branch_archives_when_remote_branch_also_has_merged_pr_proof(
+def test_merged_pr_preservation_proof_rejects_non_base_pr(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    branch = "codex/feature-base-proof"
+    desired_head = "abcdef1234567890abcdef1234567890abcdef12"
+    payload = {
+        "requested_action": {"type": "open_pr", "branch": branch, "base": "main"},
+        "local_evidence": {
+            "branch": branch,
+            "desired_head_sha": desired_head,
+            "worktree": str(tmp_path / "missing-worktree"),
+        },
+    }
+
+    monkeypatch.setattr(
+        mod,
+        "build_worktree_reference_preservation_proof",
+        lambda *_args, **_kwargs: {
+            "available": True,
+            "branch": branch,
+            "desired_head_sha": desired_head,
+            "worktree_paths": [str(tmp_path / "missing-worktree")],
+            "upstream_preservation": {
+                "proven": True,
+                "method": "merged_pr_commit_list",
+                "pr_number": 8583,
+                "repo": "synaptent/aragora",
+                "base_ref": "codex/feature-integration",
+            },
+        },
+    )
+
+    proof = mod._merged_pr_commit_preservation_proof(
+        root=tmp_path,
+        state_root=tmp_path,
+        payload=payload,
+        branch=branch,
+        repo_name="synaptent/aragora",
+        base="origin/main",
+    )
+
+    assert proof is None
+
+
+def test_merged_pr_preservation_proof_checks_all_local_evidence_worktrees(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    branch = "codex/multi-worktree-proof"
+    desired_head = "abcdef1234567890abcdef1234567890abcdef12"
+    worktrees = [tmp_path / "missing-worktree-a", tmp_path / "missing-worktree-b"]
+    payload = {
+        "requested_action": {"type": "open_pr", "branch": branch, "base": "main"},
+        "local_evidence": [
+            {"branch": branch, "desired_head_sha": desired_head, "worktree": str(worktrees[0])},
+            {"branch": branch, "desired_head_sha": desired_head, "worktree": str(worktrees[1])},
+        ],
+    }
+
+    def fake_run_git(
+        args: list[str],
+        _root: Path,
+        *,
+        timeout: int = 60,
+    ) -> subprocess.CompletedProcess[str]:
+        if args == ["rev-parse", "--verify", branch]:
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout=f"{desired_head}\n")
+        if args[:2] == ["merge-base", "--is-ancestor"]:
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+        raise AssertionError(f"unexpected git call: {args}")
+
+    seen_worktrees: list[str] = []
+
+    def fake_preservation_proof(record: dict[str, Any], **_kwargs: Any) -> dict[str, Any]:
+        worktree = str(record.get("worktree") or "")
+        seen_worktrees.append(worktree)
+        return {
+            "available": True,
+            "branch": branch,
+            "desired_head_sha": desired_head,
+            "worktree_paths": [worktree],
+            "upstream_preservation": {
+                "proven": True,
+                "method": "merged_pr_commit_list",
+                "pr_number": 8583,
+                "repo": "synaptent/aragora",
+                "base_ref": "main",
+            },
+        }
+
+    monkeypatch.setattr(mod, "run_git", fake_run_git)
+    monkeypatch.setattr(mod, "build_worktree_reference_preservation_proof", fake_preservation_proof)
+
+    proof = mod._merged_pr_commit_preservation_proof(
+        root=tmp_path,
+        state_root=tmp_path,
+        payload=payload,
+        branch=branch,
+        repo_name="synaptent/aragora",
+        base="origin/main",
+    )
+
+    assert sorted(seen_worktrees) == sorted(str(path) for path in worktrees)
+    assert proof is not None
+    assert len(proof["worktree_proofs"]) == 2
+
+
+def test_unique_branch_keeps_when_merged_pr_proof_is_not_on_current_base(
     tmp_path: Path,
     monkeypatch: Any,
     capsys: Any,
@@ -1513,13 +1628,10 @@ def test_unique_branch_archives_when_remote_branch_also_has_merged_pr_proof(
     assert mod.main(["--repo", str(tmp_path), "--json"]) == 0
 
     payload = json.loads(capsys.readouterr().out)
-    assert payload["counts"]["satisfied_by_merged_pr_commit_proof"] == 1
-    assert payload["counts"]["still_protecting_active_work"] == 0
-    assert payload["actions"][0]["decision"] == "archive"
-    assert "merged PR commit list (PR #8583)" in payload["actions"][0]["reason"]
-    proof = payload["actions"][0]["preservation_proof"]
-    assert proof["upstream_preservation"]["source"] == "gh_api_paginated"
-    assert proof["upstream_preservation_fallback"]["from"]["method"] == "remote_branch_exact_head"
+    assert payload["counts"]["satisfied_by_merged_pr_commit_proof"] == 0
+    assert payload["counts"]["still_protecting_active_work"] == 1
+    assert payload["actions"][0]["decision"] == "keep"
+    assert "actively protecting" in payload["actions"][0]["reason"]
 
 
 def test_unique_branch_keeps_when_preservation_proof_is_unavailable(

--- a/tests/scripts/test_reconcile_automation_outbox.py
+++ b/tests/scripts/test_reconcile_automation_outbox.py
@@ -842,8 +842,19 @@ def test_reconcile_archives_issue_only_pr_handoff_when_merged_pr_proves_head_pre
     ) -> subprocess.CompletedProcess[str]:
         if args == ["rev-parse", "--verify", branch]:
             return subprocess.CompletedProcess(args=args, returncode=0, stdout=f"{desired_head}\n")
+        if args == ["rev-parse", "--verify", desired_head]:
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout=f"{desired_head}\n")
         if args[:2] == ["merge-base", "--is-ancestor"]:
-            return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=0 if args[2] == desired_head else 1,
+                stdout="",
+                stderr="",
+            )
+        if args[0] == "cherry":
+            return subprocess.CompletedProcess(
+                args=args, returncode=0, stdout=f"+ {desired_head}\n"
+            )
         raise AssertionError(f"unexpected git call: {args}")
 
     monkeypatch.setattr(mod, "run_git", fake_run_git)
@@ -1407,8 +1418,15 @@ def test_unique_branch_keeps_when_preservation_proof_is_remote_branch_only(
     ) -> subprocess.CompletedProcess[str]:
         if args == ["rev-parse", "--verify", branch]:
             return subprocess.CompletedProcess(args=args, returncode=0, stdout=f"{desired_head}\n")
+        if args == ["rev-parse", "--verify", desired_head]:
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout=f"{desired_head}\n")
         if args[:2] == ["merge-base", "--is-ancestor"]:
-            return subprocess.CompletedProcess(args=args, returncode=1, stdout="", stderr="")
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=0 if args[2] == desired_head else 1,
+                stdout="",
+                stderr="",
+            )
         if args[0] == "cherry":
             return subprocess.CompletedProcess(
                 args=args, returncode=0, stdout=f"+ {desired_head}\n"
@@ -1511,8 +1529,19 @@ def test_merged_pr_preservation_proof_checks_all_local_evidence_worktrees(
     ) -> subprocess.CompletedProcess[str]:
         if args == ["rev-parse", "--verify", branch]:
             return subprocess.CompletedProcess(args=args, returncode=0, stdout=f"{desired_head}\n")
+        if args == ["rev-parse", "--verify", desired_head]:
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout=f"{desired_head}\n")
         if args[:2] == ["merge-base", "--is-ancestor"]:
-            return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=0 if args[2] == desired_head else 1,
+                stdout="",
+                stderr="",
+            )
+        if args[0] == "cherry":
+            return subprocess.CompletedProcess(
+                args=args, returncode=0, stdout=f"+ {desired_head}\n"
+            )
         raise AssertionError(f"unexpected git call: {args}")
 
     seen_worktrees: list[str] = []
@@ -1632,6 +1661,63 @@ def test_unique_branch_keeps_when_merged_pr_proof_is_not_on_current_base(
     assert payload["counts"]["still_protecting_active_work"] == 1
     assert payload["actions"][0]["decision"] == "keep"
     assert "actively protecting" in payload["actions"][0]["reason"]
+
+
+def test_unique_branch_keeps_head_only_handoff_with_top_level_local_work_marker(
+    tmp_path: Path,
+    monkeypatch: Any,
+    capsys: Any,
+) -> None:
+    outbox_dir = tmp_path / ".aragora" / "automation-outbox"
+    key = "open-pr-codex-head-only-dirty-abc123"
+    branch = "codex/head-only-dirty"
+    desired_head = "abcdef1234567890abcdef1234567890abcdef12"
+    handoff = _write_outbox_handoff(
+        outbox_dir,
+        branch=branch,
+        key=key,
+        local_evidence={
+            "branch": branch,
+            "desired_head_sha": desired_head,
+        },
+    )
+    payload = json.loads(handoff.read_text(encoding="utf-8"))
+    payload["dirty"] = True
+    handoff.write_text(json.dumps(payload), encoding="utf-8")
+
+    def fake_run_git(
+        args: list[str],
+        _root: Path,
+        *,
+        timeout: int = 60,
+    ) -> subprocess.CompletedProcess[str]:
+        if args == ["rev-parse", "--verify", branch]:
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout=f"{desired_head}\n")
+        if args[:2] == ["merge-base", "--is-ancestor"]:
+            return subprocess.CompletedProcess(args=args, returncode=1, stdout="", stderr="")
+        if args[0] == "cherry":
+            return subprocess.CompletedProcess(
+                args=args, returncode=0, stdout=f"+ {desired_head}\n"
+            )
+        raise AssertionError(f"unexpected git call: {args}")
+
+    monkeypatch.setattr(mod, "run_git", fake_run_git)
+    monkeypatch.setattr(mod, "check_github_cli_health", lambda _root: _ready_github())
+    monkeypatch.setattr(mod, "open_pr_heads", lambda *_args: {})
+    monkeypatch.setattr(
+        mod,
+        "build_worktree_reference_preservation_proof",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("dirty head-only handoff must fail before worktree proof")
+        ),
+    )
+
+    assert mod.main(["--repo", str(tmp_path), "--json"]) == 0
+
+    result = json.loads(capsys.readouterr().out)
+    assert result["counts"]["satisfied_by_merged_pr_commit_proof"] == 0
+    assert result["counts"]["still_protecting_active_work"] == 1
+    assert result["actions"][0]["decision"] == "keep"
 
 
 def test_unique_branch_keeps_when_preservation_proof_is_unavailable(


### PR DESCRIPTION
## Summary

- Add a reconcile-outbox archive path for PR-intended handoffs whose desired head is already preserved by a merged PR commit list.
- Reuse `identify_lane_owner.py`'s existing worktree-reference preservation proof so archival requires a recorded worktree to be absent/noop via `safe_worktree_cleanup.py inspect`.
- Preserve fail-closed behavior: exact remote branch preservation alone still keeps the handoff, missing/unavailable proof still keeps it, and existing issue-only receipts do not satisfy PR-intended handoffs unless this merged-PR proof is present.

## Live Q668 Reproduction

- Outbox: `.aragora/automation-outbox/open-pr-codex-audit-active-session-live-cwd-protection-442b3565.json`
- Branch: `codex/audit-active-session-live-cwd-protection`
- Desired head: `442b3565f9040d10e641526b7ea1b9628ca46062`
- Recorded worktree: `/Users/armand/.codex/worktrees/50ef/aragora`
- Current proof: worktree is absent/noop; merged PR `#8583` contains the desired head; remote branch is gone.

Before this branch, the live target dry-run kept the item as issue-only receipt noise. After this branch, the same targeted dry-run reports `decision=archive`, `satisfied_by_merged_pr_commit_proof=1`, and proof method `merged_pr_commit_list` for PR `#8583`.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_reconcile_automation_outbox.py` -> 51 passed
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/reconcile_automation_outbox.py tests/scripts/test_reconcile_automation_outbox.py` -> pass
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/reconcile_automation_outbox.py tests/scripts/test_reconcile_automation_outbox.py` -> pass
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> preflight ok
- Targeted live dry-run: `python3 scripts/reconcile_automation_outbox.py --repo /tmp/aragora-reconcile-q668-20260624091024-67492 --base origin/main --state-root /Users/armand/Development/aragora --outbox-file open-pr-codex-audit-active-session-live-cwd-protection-442b3565.json --dry-run --json` -> archives exactly the Q668 handoff in dry-run
