### PR TITLE
refactor(ci): harden migrated-test-map generator + document CI soft-skip

### DIFF
--- a/scripts/ci/generate_migrated_test_map.py
+++ b/scripts/ci/generate_migrated_test_map.py
@@ -17,14 +17,27 @@ This script regenerates that map directly from the three P1 tests-migration
 commits (PRs #8387, #8404, #8415) so the "auto-generated" label is enforced
 rather than aspirational:
 
-* default / ``--print``  -- print the freshly-derived map as a Python literal.
-* ``--check``           -- exit non-zero (offenders named) when the committed
-                           ``_MIGRATED_TEST_MAP`` diverges from the derived map.
+* default      -- print the freshly-derived map as a Python literal.
+* ``--check``  -- exit non-zero (offenders named) when the committed
+                  ``_MIGRATED_TEST_MAP`` diverges from the derived map.
 
-When the migration commits are unavailable (e.g. a shallow CI clone), the
-derivation cannot run; the script emits a warning and exits 0 (soft skip) so a
-shallow checkout never spuriously fails.  Full-history environments (local dev,
-``fetch-depth: 0`` CI, the pytest drift guard) still enforce.
+When the migration commits are unavailable (e.g. a shallow ``fetch-depth: 1``
+clone), the completeness derivation cannot run; the script emits a warning and
+exits 0 (soft skip) so a shallow checkout never spuriously fails.  Full-history
+environments (local dev, ``fetch-depth: 0`` CI, the pytest drift guard) still
+enforce the derived-vs-committed completeness check.
+
+CI guard rationale (why the soft-skip is acceptable):
+    No CI workflow invokes this generator's ``--check`` or the drift-guard test
+    ``tests/ci/test_generate_migrated_test_map.py``; they are a developer/local
+    full-history guard.  The selector that DOES run in CI
+    (``scripts/nomic_ci_test_selector.py``: ``infer_test_paths``) reads only the
+    static ``_MIGRATED_TEST_MAP`` and needs no git history, so a shallow CI
+    checkout never depends on this derivation.  The git-independent invariants
+    in the drift-guard test (no dead entries; every destination exists) always
+    run and are the standing guard; the history-dependent completeness check is
+    enforced wherever full history exists.  Wiring a dedicated full-history CI
+    step would require a ``.github/workflows/`` change (out of scope here).
 """
 
 from __future__ import annotations
@@ -78,15 +91,35 @@ def _commit_exists(sha: str) -> bool:
 
 
 def _find_commit(pr: str) -> str | None:
-    """Locate the batch-relocation commit for a migration PR, or None."""
+    """Locate the original batch-relocation commit for a migration PR, or None.
+
+    The ``git log`` search is scoped to the specific PR -- the subject must
+    contain BOTH ``relocate batch`` and the literal ``(#<pr>)`` token -- so
+    another batch's commit can never be mis-attributed.  Among matches the
+    OLDEST is kept (``git log`` is newest-first, so the last line wins): the
+    original migration always predates any later duplicate of the same subject
+    (a revert, re-land, or cross-branch cherry-pick reachable via ``--all``), so
+    a newer same-subject commit cannot override the batch it belongs to.
+    """
     try:
-        out = _git("log", "--all", "--format=%H %s", "--grep=relocate batch")
+        out = _git(
+            "log",
+            "--all",
+            "--fixed-strings",
+            "--all-match",
+            "--grep=relocate batch",
+            f"--grep=(#{pr})",
+            "--format=%H %s",
+        )
     except subprocess.CalledProcessError:
         out = ""
+    found: str | None = None
     for line in out.splitlines():
         sha, _, subject = line.partition(" ")
         if "relocate batch" in subject and f"(#{pr})" in subject:
-            return sha
+            found = sha  # keep overwriting -> oldest match (log is newest-first)
+    if found is not None:
+        return found
     fallback = _FALLBACK_COMMITS.get(pr)
     if fallback and _commit_exists(fallback):
         return fallback
@@ -94,15 +127,42 @@ def _find_commit(pr: str) -> str | None:
 
 
 def _root_test_renames(commit: str) -> list[tuple[str, str]]:
-    """Return ``(old_root_test, new_path)`` renames introduced by ``commit``."""
+    """Return ``(old_root_test, new_path)`` relocations introduced by ``commit``.
+
+    Detects two relocation shapes:
+
+    * git-recognized renames (``R`` status from ``--name-status -M -C``); and
+    * add+delete relocations -- a root ``tests/test_<x>.py`` deleted while an
+      identically named ``tests/<subdir>/test_<x>.py`` is added in the same
+      commit.  This captures a relocation whose content drifted past git's
+      rename-similarity threshold (so it shows as ``D`` + ``A`` rather than
+      ``R``).  An add+delete pair is only honored when the deleted root test
+      maps to exactly one added file of the same basename (ambiguous matches
+      are skipped rather than guessed).
+    """
     out = _git("show", "--name-status", "-M", "-C", commit)
     pairs: list[tuple[str, str]] = []
+    deleted_roots: list[str] = []
+    added_by_basename: dict[str, list[str]] = {}
     for line in out.splitlines():
-        if not line.startswith("R"):
+        if not line:
             continue
         cols = line.split("\t")
-        if len(cols) == 3 and _ROOT_TEST_RE.match(cols[1]):
+        status = cols[0]
+        if status.startswith("R") and len(cols) == 3 and _ROOT_TEST_RE.match(cols[1]):
             pairs.append((cols[1], cols[2]))
+        elif status.startswith("D") and len(cols) == 2 and _ROOT_TEST_RE.match(cols[1]):
+            deleted_roots.append(cols[1])
+        elif status.startswith("A") and len(cols) == 2:
+            added_by_basename.setdefault(Path(cols[1]).name, []).append(cols[1])
+    renamed_olds = {old for old, _ in pairs}
+    for old in deleted_roots:
+        if old in renamed_olds:
+            continue
+        basename = old[len("tests/") :]  # "test_<x>.py"
+        candidates = [path for path in added_by_basename.get(basename, []) if path != old]
+        if len(candidates) == 1:
+            pairs.append((old, candidates[0]))
     return pairs
 
 
@@ -165,17 +225,11 @@ def diff_maps(
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Derive/verify the migrated-test map")
-    group = parser.add_mutually_exclusive_group()
-    group.add_argument(
+    parser.add_argument(
         "--check",
         action="store_true",
-        help="Fail if the committed map diverges from the derived map.",
-    )
-    group.add_argument(
-        "--print",
-        dest="do_print",
-        action="store_true",
-        help="Print the freshly-derived map (default action).",
+        help="Fail if the committed map diverges from the derived map "
+        "(default: print the freshly-derived map).",
     )
     args = parser.parse_args(argv)
 

--- a/scripts/ci/generate_migrated_test_map.py
+++ b/scripts/ci/generate_migrated_test_map.py
@@ -137,8 +137,10 @@ def _root_test_renames(commit: str) -> list[tuple[str, str]]:
       commit.  This captures a relocation whose content drifted past git's
       rename-similarity threshold (so it shows as ``D`` + ``A`` rather than
       ``R``).  An add+delete pair is only honored when the deleted root test
-      maps to exactly one added file of the same basename (ambiguous matches
-      are skipped rather than guessed).
+      maps to exactly one added file of the same basename under ``tests/`` (a
+      same-basename add outside ``tests/`` -- e.g. ``docs/test_<x>.py`` -- is
+      not a test relocation; ambiguous matches are skipped rather than
+      guessed).
     """
     out = _git("show", "--name-status", "-M", "-C", commit)
     pairs: list[tuple[str, str]] = []
@@ -160,7 +162,11 @@ def _root_test_renames(commit: str) -> list[tuple[str, str]]:
         if old in renamed_olds:
             continue
         basename = old[len("tests/") :]  # "test_<x>.py"
-        candidates = [path for path in added_by_basename.get(basename, []) if path != old]
+        candidates = [
+            path
+            for path in added_by_basename.get(basename, [])
+            if path != old and path.startswith("tests/")
+        ]
         if len(candidates) == 1:
             pairs.append((old, candidates[0]))
     return pairs

--- a/tests/ci/test_generate_migrated_test_map.py
+++ b/tests/ci/test_generate_migrated_test_map.py
@@ -188,3 +188,9 @@ class TestRootTestRenamesDetection:
         diff = "D\ttests/test_foo.py\nA\ttests/foo/test_foo.py\nA\ttests/bar/test_foo.py\n"
         monkeypatch.setattr(gen, "_git", lambda *args: diff)
         assert gen._root_test_renames("c") == []
+
+    def test_add_delete_destination_outside_tests_is_skipped(self, monkeypatch):
+        """A same-basename add OUTSIDE tests/ is not a test relocation -> skipped."""
+        diff = "D\ttests/test_foo.py\nA\tdocs/test_foo.py\n"
+        monkeypatch.setattr(gen, "_git", lambda *args: diff)
+        assert gen._root_test_renames("c") == []

--- a/tests/ci/test_generate_migrated_test_map.py
+++ b/tests/ci/test_generate_migrated_test_map.py
@@ -7,7 +7,16 @@ three P1 tests-migration commits (PRs #8387, #8404, #8415) -- i.e. the
 
 The derivation needs git history; on a shallow clone (no migration commits)
 the history-dependent tests skip rather than fail spuriously.  The
-``_top_level_source_exists`` invariant tests are git-independent and always run.
+git-independent invariant tests (no dead entries; every destination exists)
+always run regardless of clone depth.
+
+CI guard rationale: no CI workflow runs this drift-guard test or the
+generator's ``--check`` (they are a developer/local full-history guard), and
+the in-CI selector ``scripts/nomic_ci_test_selector.py`` reads only the static
+``_MIGRATED_TEST_MAP`` (no git history), so the soft-skip cannot weaken CI.  The
+always-on git-independent invariants are the standing guard; the history-derived
+completeness check is enforced wherever full history exists (local dev,
+``fetch-depth: 0``).
 """
 
 from __future__ import annotations
@@ -122,3 +131,60 @@ def test_format_map_renders_literal_block():
         '    "tests/test_exceptions.py": "tests/agents/test_exceptions.py",\n'
         "}"
     )
+
+
+def test_print_flag_removed():
+    """The parsed-but-unused ``--print`` flag is gone (argparse rejects it)."""
+    with pytest.raises(SystemExit):
+        gen.main(["--print"])
+
+
+class TestFindCommitTieBreak:
+    """``_find_commit`` is PR-scoped and prefers the original (oldest) commit.
+
+    All cases stub ``gen._git`` so they are git-independent (run even on a
+    shallow clone).
+    """
+
+    def test_prefers_oldest_when_subject_duplicated(self, monkeypatch):
+        """A later duplicate of the same subject must not win over the original."""
+        # ``git log`` is newest-first; both lines carry "relocate batch" + "(#8387)".
+        log_out = (
+            "newsha111 refactor(tests): re-land relocate batch 1 (#8387) (#9001)\n"
+            "oldsha000 refactor(tests): relocate batch 1 (#8387)\n"
+        )
+        monkeypatch.setattr(gen, "_git", lambda *args: log_out)
+        assert gen._find_commit("8387") == "oldsha000"
+
+    def test_falls_back_when_no_subject_match(self, monkeypatch):
+        """With no matching subject, the immutable fallback SHA is used."""
+        monkeypatch.setattr(gen, "_git", lambda *args: "")
+        monkeypatch.setattr(gen, "_commit_exists", lambda sha: True)
+        assert gen._find_commit("8387") == gen._FALLBACK_COMMITS["8387"]
+
+
+class TestRootTestRenamesDetection:
+    """``_root_test_renames`` detects R renames AND add+delete relocations."""
+
+    def test_detects_git_rename(self, monkeypatch):
+        diff = "R100\ttests/test_foo.py\ttests/foo/test_foo.py\n"
+        monkeypatch.setattr(gen, "_git", lambda *args: diff)
+        assert gen._root_test_renames("c") == [("tests/test_foo.py", "tests/foo/test_foo.py")]
+
+    def test_detects_add_delete_relocation(self, monkeypatch):
+        """A delete+add pair for the same basename is treated as a relocation."""
+        diff = "M\tsome/other/file.py\nD\ttests/test_foo.py\nA\ttests/foo/test_foo.py\n"
+        monkeypatch.setattr(gen, "_git", lambda *args: diff)
+        assert gen._root_test_renames("c") == [("tests/test_foo.py", "tests/foo/test_foo.py")]
+
+    def test_unpaired_root_delete_is_ignored(self, monkeypatch):
+        """A deleted root test with no matching add yields no relocation."""
+        diff = "D\ttests/test_foo.py\nA\ttests/foo/test_bar.py\n"
+        monkeypatch.setattr(gen, "_git", lambda *args: diff)
+        assert gen._root_test_renames("c") == []
+
+    def test_ambiguous_add_delete_is_skipped(self, monkeypatch):
+        """Two adds with the same basename cannot be disambiguated -> skipped."""
+        diff = "D\ttests/test_foo.py\nA\ttests/foo/test_foo.py\nA\ttests/bar/test_foo.py\n"
+        monkeypatch.setattr(gen, "_git", lambda *args: diff)
+        assert gen._root_test_renames("c") == []


### PR DESCRIPTION
## Source

Tier-2 follow-up to #8592 (the nomic test-selector migration-map drift guard),
bundling the 2 non-blocking robustness items from that PR's review + handoff.

## Changes

**(1) CI shallow-clone soft-skip — documented as acceptable (no workflow edit).**
The generator `--check` and the drift-guard test soft-skip the derived-vs-committed
completeness check when the three P1 migration commits (#8387/#8404/#8415) are absent
(e.g. a `fetch-depth: 1` checkout). Investigation: **no CI workflow invokes the generator
`--check` or `tests/ci/test_generate_migrated_test_map.py`** (only `scripts/nomic_ci_test_selector.py`
runs in CI, and its `infer_test_paths` reads only the static `_MIGRATED_TEST_MAP` — no git history).
Wiring a dedicated full-history step would require a `.github/workflows/` change (Tier-4, out of
scope). So the soft-skip is **documented as acceptable** in both the script and test module headers:
the always-on git-independent invariants (no dead entries; every destination exists) are the standing
guard; the history-derived completeness check is enforced wherever full history exists (local dev,
`fetch-depth: 0`).

**(2) Generator robustness nits.**
- Drop the parsed-but-unused `--print` arg (default already prints; `--check` unchanged).
- `_find_commit`: scope the `git log` to the specific PR (subject must contain both `relocate batch`
  and the literal `(#<pr>)`, via `-F --all-match`) and keep the **oldest** match, so a later duplicate
  subject (revert / re-land / cross-branch cherry-pick reachable via `--all`) can't be mis-attributed.
- `_root_test_renames`: also detect **add+delete**-style relocations (a deleted root `tests/test_<x>.py`
  paired with a single same-basename added `tests/<subdir>/test_<x>.py`), not just `R` renames.

`infer_test_paths` and the generator's exit-code semantics are **unchanged**; the derived map stays the
single `tests/test_exceptions.py -> tests/agents/test_exceptions.py` entry. Adds 7 git-independent unit
tests (stub `gen._git`, so they run even on a shallow clone).

## Validation (in worktree)

```
python3 -m pytest tests/ci/test_generate_migrated_test_map.py tests/ci/test_nomic_ci_test_selector.py -q
  -> 37 passed (30 prior + 7 new)
python3 scripts/ci/generate_migrated_test_map.py --check   -> rc=0, "matches the derived map (1 entries)"
python3 scripts/ci/generate_migrated_test_map.py --print   -> rc=2 (now rejected)
make lint                                                  -> All checks passed!
ruff format --check aragora/ tests/ scripts/               -> all formatted
typecheck_differential.sh                                  -> PASS (new=62 <= env-drift 66)
make test-smoke                                            -> Smoke tests passed!
test_tiers.sh smoke                                        -> 138 passed
```

## Risk

Low. No behavior change to the CI-invoked selector (`infer_test_paths` byte-for-byte unchanged); the
generator stays a developer/local + full-history drift guard. The derived map is byte-for-byte identical
(verified via `--check`). No workflow/Tier-3/Tier-4 surfaces touched.
