### PR TITLE
feat(gauntlet): post-quantum hybrid ODR receipt signing (Ed25519 + ML-DSA-65)

### DIFF
--- a/aragora-verify/CHANGELOG.md
+++ b/aragora-verify/CHANGELOG.md
@@ -9,7 +9,10 @@ versioning.
 ### Added
 - Initial release: standalone offline verifier for Open Decision Receipts (ODR v0.1).
 - `aragora-verify <receipt.json> [--pubkey KEY] [--chain JSONL] [--json]` CLI.
-- Library API: `verify`, `load_public_key`, `compute_key_id`, `validate_structure`,
+- `--mldsa-pubkey` and library support for verifying ML-DSA-65 ODR signatures
+  alongside Ed25519 signatures.
+- Library API: `verify`, `load_public_key`, `load_mldsa_public_key`,
+  `compute_key_id`, `compute_mldsa_key_id`, `pqc_available`, `validate_structure`,
   `jcs_canonicalize`, `odr_content_digest`.
 - Checks: ODR v0.1 schema conformance (stdlib structural validator, with optional
   `jsonschema` rigor), RFC 8785 (JCS) canonical digest recomputation, Ed25519

--- a/aragora-verify/CHANGELOG.md
+++ b/aragora-verify/CHANGELOG.md
@@ -20,4 +20,4 @@ versioning.
   linkage/anchoring.
 - Absent markers and `"undisclosed"` model families surfaced as non-failing
   weakening signals.
-- Dependencies: Python standard library plus `cryptography`; `jsonschema` optional.
+- Dependencies: Python standard library plus `cryptography>=49`; `jsonschema` optional.

--- a/aragora-verify/pyproject.toml
+++ b/aragora-verify/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "cryptography>=41.0",
+    "cryptography>=49",
 ]
 
 [project.optional-dependencies]

--- a/aragora-verify/src/aragora_verify/__init__.py
+++ b/aragora-verify/src/aragora_verify/__init__.py
@@ -21,7 +21,10 @@ from .verifier import (
     VerificationError,
     VerifyResult,
     compute_key_id,
+    compute_mldsa_key_id,
+    load_mldsa_public_key,
     load_public_key,
+    pqc_available,
     verify,
 )
 
@@ -31,7 +34,10 @@ __all__ = [
     "__version__",
     "verify",
     "load_public_key",
+    "load_mldsa_public_key",
     "compute_key_id",
+    "compute_mldsa_key_id",
+    "pqc_available",
     "validate_structure",
     "jcs_canonicalize",
     "odr_content_digest",

--- a/aragora-verify/src/aragora_verify/cli.py
+++ b/aragora-verify/src/aragora_verify/cli.py
@@ -1,6 +1,7 @@
 """``aragora-verify`` command-line interface.
 
-    aragora-verify receipt.json [--pubkey key.pem] [--chain chain.jsonl] [--json]
+    aragora-verify receipt.json [--pubkey key.pem] [--mldsa-pubkey key.pem]
+        [--chain chain.jsonl] [--json]
 
 Exit status: ``0`` when the receipt verifies (no failed checks and any present
 signatures were checked), ``1`` when any check fails, ``2`` for usage/input
@@ -58,8 +59,9 @@ def build_parser() -> argparse.ArgumentParser:
         prog="aragora-verify",
         description=(
             "Offline verifier for Open Decision Receipts (ODR v0.1): schema "
-            "conformance, JCS canonical digest, Ed25519 signature, hash-chain "
-            "link, and quorum consistency. No Aragora install or account required."
+            "conformance, JCS canonical digest, Ed25519/ML-DSA-65 signatures, "
+            "hash-chain link, and quorum consistency. No Aragora install or "
+            "account required."
         ),
     )
     parser.add_argument("receipt", help="path to the ODR receipt JSON")
@@ -67,6 +69,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--pubkey",
         metavar="KEY",
         help="Ed25519 public key (PEM/DER/raw/base64/hex) to verify signatures with",
+    )
+    parser.add_argument(
+        "--mldsa-pubkey",
+        metavar="KEY",
+        help="ML-DSA-65 public key (PEM/DER/raw/base64/hex) to verify signatures with",
     )
     parser.add_argument(
         "--chain",
@@ -81,7 +88,12 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     try:
-        result = verify_path(args.receipt, pubkey_path=args.pubkey, chain_path=args.chain)
+        result = verify_path(
+            args.receipt,
+            pubkey_path=args.pubkey,
+            mldsa_pubkey_path=args.mldsa_pubkey,
+            chain_path=args.chain,
+        )
     except FileNotFoundError as exc:
         print(f"error: file not found: {exc.filename}", file=sys.stderr)
         return 2

--- a/aragora-verify/src/aragora_verify/odr_schema.json
+++ b/aragora-verify/src/aragora_verify/odr_schema.json
@@ -263,12 +263,12 @@
     },
     "signatures": {
       "type": "array",
-      "description": "Reserved for detached signatures (Ed25519, issue #8225). Empty in v0.1; signatures cover the SHA-256 of the JCS bytes of the payload with this array removed.",
+      "description": "Detached signatures (Ed25519 #8225; ML-DSA-65/FIPS 204 post-quantum #8602). Hybrid receipts carry one entry per algorithm; signatures cover the SHA-256 of the JCS bytes of the payload with this array removed.",
       "items": {
         "type": "object",
         "required": ["alg", "key_id", "signature"],
         "properties": {
-          "alg": { "type": "string", "enum": ["Ed25519"] },
+          "alg": { "type": "string", "enum": ["Ed25519", "ML-DSA-65"] },
           "key_id": { "type": "string", "minLength": 1 },
           "signature": { "type": "string", "minLength": 1 },
           "signed_at": { "type": "string" }

--- a/aragora-verify/src/aragora_verify/schema.py
+++ b/aragora-verify/src/aragora_verify/schema.py
@@ -128,8 +128,12 @@ def _check_signatures(errors: list[str], value: Any) -> None:
         for field in ("alg", "key_id", "signature"):
             if not isinstance(sig.get(field), str) or not sig.get(field):
                 errors.append(f"signatures[{i}].{field}: required non-empty string")
-        if sig.get("alg") not in (None, "Ed25519") and isinstance(sig.get("alg"), str):
-            errors.append(f"signatures[{i}].alg: only 'Ed25519' is defined in v0.1")
+        if sig.get("alg") not in (None, "Ed25519", "ML-DSA-65") and isinstance(
+            sig.get("alg"), str
+        ):
+            errors.append(
+                f"signatures[{i}].alg: only 'Ed25519' and 'ML-DSA-65' are defined in v0.1"
+            )
 
 
 def validate_structure(doc: Any) -> list[str]:

--- a/aragora-verify/src/aragora_verify/verifier.py
+++ b/aragora-verify/src/aragora_verify/verifier.py
@@ -127,10 +127,16 @@ def _load_mldsa():  # noqa: ANN202 - lazy import keeps import errors actionable
 def pqc_available() -> bool:
     """Whether this runtime exposes ML-DSA through ``cryptography``."""
     try:
+        from cryptography.exceptions import UnsupportedAlgorithm
         from cryptography.hazmat.primitives.asymmetric import mldsa  # noqa: F401
 
+        key = mldsa.MLDSA65PrivateKey.generate()
+        message = b"aragora-verify-ml-dsa-probe"
+        key.public_key().verify(key.sign(message), message)
         return True
     except ImportError:
+        return False
+    except (UnsupportedAlgorithm, ValueError, TypeError):
         return False
 
 
@@ -314,7 +320,7 @@ def _check_signatures(  # noqa: PLR0912, PLR0915
 ) -> Check:
     signatures = doc.get("signatures")
     signatures = signatures if isinstance(signatures, list) else []
-    if all(
+    if mldsa_public_key is None and all(
         not isinstance(sig, dict) or str(sig.get("alg") or "Ed25519") == "Ed25519"
         for sig in signatures
     ):
@@ -349,6 +355,7 @@ def _check_signatures(  # noqa: PLR0912, PLR0915
     )
     verified_any = False
     failed_matching: list[str] = []
+    present_alg = {"Ed25519": False, "ML-DSA-65": False}
     seen_supplied_alg = {"Ed25519": False, "ML-DSA-65": False}
     verified_supplied_alg = {"Ed25519": False, "ML-DSA-65": False}
     skipped_any = False
@@ -359,6 +366,7 @@ def _check_signatures(  # noqa: PLR0912, PLR0915
         alg = str(sig.get("alg") or "")
         key_id = str(sig.get("key_id") or "")
         if alg == "Ed25519":
+            present_alg["Ed25519"] = True
             if public_key is None:
                 skipped_any = True
                 notes.append(
@@ -383,6 +391,7 @@ def _check_signatures(  # noqa: PLR0912, PLR0915
                     failed_matching.append(f"sig[{i}] Ed25519")
             continue
         if alg == "ML-DSA-65":
+            present_alg["ML-DSA-65"] = True
             if mldsa_public_key is None:
                 skipped_any = True
                 notes.append(
@@ -419,6 +428,22 @@ def _check_signatures(  # noqa: PLR0912, PLR0915
             FAIL,
             f"signature from the supplied key did not verify ({', '.join(failed_matching)}) — "
             f"{detail}",
+        )
+    missing_present = [
+        alg
+        for alg, supplied in (
+            ("Ed25519", public_key is not None),
+            ("ML-DSA-65", mldsa_public_key is not None),
+        )
+        if supplied and not present_alg.get(alg, False)
+    ]
+    if missing_present:
+        return Check(
+            "signature",
+            FAIL,
+            "no "
+            + "/".join(missing_present)
+            + f" signature present for supplied verifier key(s) — {detail}",
         )
     missing_verified = [
         alg

--- a/aragora-verify/src/aragora_verify/verifier.py
+++ b/aragora-verify/src/aragora_verify/verifier.py
@@ -382,6 +382,13 @@ def _check_signatures(  # noqa: PLR0912, PLR0915
                 continue
             try:
                 public_key.verify(raw_sig, message)
+                if key_id != provided_key_id:
+                    failed_matching.append(f"sig[{i}] Ed25519 key_id mismatch")
+                    notes.append(
+                        f"sig[{i}] Ed25519 (key_id={key_id or '?'}): "
+                        f"verified bytes but key_id mismatch (expected {provided_key_id})"
+                    )
+                    continue
                 verified_any = True
                 verified_supplied_alg["Ed25519"] = True
                 notes.append(f"sig[{i}] Ed25519 (key_id={key_id or '?'}): verified")
@@ -410,10 +417,17 @@ def _check_signatures(  # noqa: PLR0912, PLR0915
                 continue
             try:
                 mldsa_public_key.verify(raw_sig, message)
+                if key_id != provided_mldsa_key_id:
+                    failed_matching.append(f"sig[{i}] ML-DSA-65 key_id mismatch")
+                    notes.append(
+                        f"sig[{i}] ML-DSA-65 (key_id={key_id or '?'}): "
+                        f"verified bytes but key_id mismatch (expected {provided_mldsa_key_id})"
+                    )
+                    continue
                 verified_any = True
                 verified_supplied_alg["ML-DSA-65"] = True
                 notes.append(f"sig[{i}] ML-DSA-65 (key_id={key_id or '?'}): verified")
-            except MLDSAInvalidSignature:  # type: ignore[misc]
+            except (MLDSAInvalidSignature, ValueError, TypeError):  # type: ignore[misc]
                 notes.append(f"sig[{i}] ML-DSA-65 (key_id={key_id or '?'}): INVALID")
                 if key_id == provided_mldsa_key_id:
                     failed_matching.append(f"sig[{i}] ML-DSA-65")

--- a/aragora-verify/src/aragora_verify/verifier.py
+++ b/aragora-verify/src/aragora_verify/verifier.py
@@ -37,7 +37,10 @@ __all__ = [
     "VerifyResult",
     "verify",
     "compute_key_id",
+    "compute_mldsa_key_id",
     "load_public_key",
+    "load_mldsa_public_key",
+    "pqc_available",
     "VerificationError",
 ]
 
@@ -107,6 +110,30 @@ def _load_ed25519():  # noqa: ANN202 - lazy import keeps import errors actionabl
     return Ed25519PublicKey, serialization, InvalidSignature
 
 
+def _load_mldsa():  # noqa: ANN202 - lazy import keeps import errors actionable
+    try:
+        from cryptography.exceptions import InvalidSignature
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import mldsa
+    except ImportError as exc:  # pragma: no cover - environment-dependent
+        raise VerificationError(
+            "ML-DSA-65 signature verification requires `cryptography` >= 49 built "
+            "with ML-DSA support (the `mldsa` module); upgrade `cryptography` to "
+            "verify post-quantum ODR signatures"
+        ) from exc
+    return mldsa, serialization, InvalidSignature
+
+
+def pqc_available() -> bool:
+    """Whether this runtime exposes ML-DSA through ``cryptography``."""
+    try:
+        from cryptography.hazmat.primitives.asymmetric import mldsa  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
 def load_public_key(data: bytes):  # noqa: ANN201
     """Load an Ed25519 public key from PEM, DER, raw 32 bytes, or base64/hex text."""
     Ed25519PublicKey, serialization, _ = _load_ed25519()
@@ -144,11 +171,50 @@ def load_public_key(data: bytes):  # noqa: ANN201
     return key
 
 
+def load_mldsa_public_key(data: bytes):  # noqa: ANN201
+    """Load an ML-DSA-65 public key from PEM, DER, raw 1952 bytes, or base64/hex text."""
+    mldsa, serialization, _ = _load_mldsa()
+    key = None
+    if b"-----BEGIN" in data:
+        try:
+            key = serialization.load_pem_public_key(data.strip())
+        except (ValueError, TypeError) as exc:
+            raise VerificationError("could not parse PEM ML-DSA public key") from exc
+    elif len(data) == 1952:
+        key = mldsa.MLDSA65PublicKey.from_public_bytes(data)
+    else:
+        as_str = data.decode("ascii", errors="ignore").strip()
+        for decoder in (_maybe_b64, _maybe_hex):
+            raw = decoder(as_str)
+            if raw is not None and len(raw) == 1952:
+                key = mldsa.MLDSA65PublicKey.from_public_bytes(raw)
+                break
+        if key is None:
+            try:
+                key = serialization.load_der_public_key(data)
+            except Exception as exc:  # noqa: BLE001
+                raise VerificationError(
+                    "could not parse ML-DSA public key (expected PEM/DER/raw/base64/hex)"
+                ) from exc
+    if not isinstance(key, mldsa.MLDSA65PublicKey):
+        raise VerificationError(
+            f"public key is not ML-DSA-65 (got {type(key).__name__}); "
+            "ODR post-quantum signatures use ML-DSA-65"
+        )
+    return key
+
+
 def compute_key_id(public_key) -> str:  # noqa: ANN001
     """``ed25519-`` + first 16 hex of SHA-256(raw public key) — the #8225 key id."""
     _, serialization, _ = _load_ed25519()
     raw = public_key.public_bytes(serialization.Encoding.Raw, serialization.PublicFormat.Raw)
     return "ed25519-" + hashlib.sha256(raw).hexdigest()[:16]
+
+
+def compute_mldsa_key_id(public_key) -> str:  # noqa: ANN001
+    """``ml-dsa-65-`` + first 16 hex of SHA-256(raw ML-DSA public key)."""
+    raw = public_key.public_bytes_raw()
+    return "ml-dsa-65-" + hashlib.sha256(raw).hexdigest()[:16]
 
 
 def _maybe_b64(text: str) -> bytes | None:
@@ -176,12 +242,20 @@ def _decode_signature(value: str) -> bytes | None:
     return None
 
 
+def _decode_signature_bytes(value: str) -> bytes | None:
+    """Decode a raw signature with no Ed25519 length restriction."""
+    raw = _maybe_b64(value)
+    if raw is not None:
+        return raw
+    return _maybe_hex(value)
+
+
 # ---------------------------------------------------------------------------
 # Individual checks
 # ---------------------------------------------------------------------------
 
 
-def _check_signatures(doc: dict[str, Any], digest_hex: str, public_key) -> Check:  # noqa: ANN001
+def _check_signatures_ed25519(doc: dict[str, Any], digest_hex: str, public_key) -> Check:  # noqa: ANN001
     signatures = doc.get("signatures")
     signatures = signatures if isinstance(signatures, list) else []
     if not signatures and public_key is None:
@@ -229,6 +303,140 @@ def _check_signatures(doc: dict[str, Any], digest_hex: str, public_key) -> Check
         )
     if verified_any:
         return Check("signature", PASS, f"Ed25519 signature verified — {detail}")
+    return Check("signature", FAIL, f"no signature verified with the supplied key — {detail}")
+
+
+def _check_signatures(  # noqa: PLR0912, PLR0915
+    doc: dict[str, Any],
+    digest_hex: str,
+    public_key,  # noqa: ANN001
+    mldsa_public_key=None,  # noqa: ANN001
+) -> Check:
+    signatures = doc.get("signatures")
+    signatures = signatures if isinstance(signatures, list) else []
+    if all(
+        not isinstance(sig, dict) or str(sig.get("alg") or "Ed25519") == "Ed25519"
+        for sig in signatures
+    ):
+        return _check_signatures_ed25519(doc, digest_hex, public_key)
+
+    supplied_any = public_key is not None or mldsa_public_key is not None
+    if not signatures and not supplied_any:
+        return Check("signature", WARN, "receipt is unsigned (v0.1); authenticity not established")
+    if not signatures and supplied_any:
+        return Check(
+            "signature", WARN, "receipt carries no signatures; nothing to verify with the key"
+        )
+    if signatures and not supplied_any:
+        return Check(
+            "signature",
+            SKIP,
+            f"{len(signatures)} signature(s) present but no --pubkey/--mldsa-pubkey supplied; "
+            "authenticity NOT verified",
+        )
+
+    Ed25519InvalidSignature = None
+    if public_key is not None:
+        _, _, Ed25519InvalidSignature = _load_ed25519()
+    MLDSAInvalidSignature = None
+    if mldsa_public_key is not None:
+        _, _, MLDSAInvalidSignature = _load_mldsa()
+
+    message = bytes.fromhex(digest_hex)
+    provided_key_id = compute_key_id(public_key) if public_key is not None else None
+    provided_mldsa_key_id = (
+        compute_mldsa_key_id(mldsa_public_key) if mldsa_public_key is not None else None
+    )
+    verified_any = False
+    failed_matching: list[str] = []
+    seen_supplied_alg = {"Ed25519": False, "ML-DSA-65": False}
+    verified_supplied_alg = {"Ed25519": False, "ML-DSA-65": False}
+    skipped_any = False
+    notes: list[str] = []
+    for i, sig in enumerate(signatures):
+        if not isinstance(sig, dict):
+            continue
+        alg = str(sig.get("alg") or "")
+        key_id = str(sig.get("key_id") or "")
+        if alg == "Ed25519":
+            if public_key is None:
+                skipped_any = True
+                notes.append(
+                    f"sig[{i}] Ed25519 (key_id={key_id or '?'}): skipped (no --pubkey)"
+                )
+                continue
+            seen_supplied_alg["Ed25519"] = True
+            raw_sig = _decode_signature(str(sig.get("signature") or ""))
+            if raw_sig is None:
+                notes.append(f"sig[{i}] Ed25519 (key_id={key_id or '?'}): undecodable signature")
+                if key_id == provided_key_id:
+                    failed_matching.append(f"sig[{i}] Ed25519")
+                continue
+            try:
+                public_key.verify(raw_sig, message)
+                verified_any = True
+                verified_supplied_alg["Ed25519"] = True
+                notes.append(f"sig[{i}] Ed25519 (key_id={key_id or '?'}): verified")
+            except Ed25519InvalidSignature:  # type: ignore[misc]
+                notes.append(f"sig[{i}] Ed25519 (key_id={key_id or '?'}): INVALID")
+                if key_id == provided_key_id:
+                    failed_matching.append(f"sig[{i}] Ed25519")
+            continue
+        if alg == "ML-DSA-65":
+            if mldsa_public_key is None:
+                skipped_any = True
+                notes.append(
+                    f"sig[{i}] ML-DSA-65 (key_id={key_id or '?'}): skipped "
+                    "(no --mldsa-pubkey)"
+                )
+                continue
+            seen_supplied_alg["ML-DSA-65"] = True
+            raw_sig = _decode_signature_bytes(str(sig.get("signature") or ""))
+            if raw_sig is None:
+                notes.append(
+                    f"sig[{i}] ML-DSA-65 (key_id={key_id or '?'}): undecodable signature"
+                )
+                if key_id == provided_mldsa_key_id:
+                    failed_matching.append(f"sig[{i}] ML-DSA-65")
+                continue
+            try:
+                mldsa_public_key.verify(raw_sig, message)
+                verified_any = True
+                verified_supplied_alg["ML-DSA-65"] = True
+                notes.append(f"sig[{i}] ML-DSA-65 (key_id={key_id or '?'}): verified")
+            except MLDSAInvalidSignature:  # type: ignore[misc]
+                notes.append(f"sig[{i}] ML-DSA-65 (key_id={key_id or '?'}): INVALID")
+                if key_id == provided_mldsa_key_id:
+                    failed_matching.append(f"sig[{i}] ML-DSA-65")
+            continue
+        skipped_any = True
+        notes.append(f"sig[{i}] {alg or '?'} (key_id={key_id or '?'}): skipped (unsupported alg)")
+
+    detail = "; ".join(notes) or "no signatures evaluated"
+    if failed_matching:
+        return Check(
+            "signature",
+            FAIL,
+            f"signature from the supplied key did not verify ({', '.join(failed_matching)}) — "
+            f"{detail}",
+        )
+    missing_verified = [
+        alg
+        for alg, seen in seen_supplied_alg.items()
+        if seen and not verified_supplied_alg.get(alg, False)
+    ]
+    if missing_verified:
+        return Check(
+            "signature",
+            FAIL,
+            "no "
+            + "/".join(missing_verified)
+            + f" signature verified with the supplied key(s) — {detail}",
+        )
+    if verified_any:
+        return Check("signature", PASS, f"signature verified — {detail}")
+    if skipped_any:
+        return Check("signature", SKIP, f"no signature had a supplied verifier key — {detail}")
     return Check("signature", FAIL, f"no signature verified with the supplied key — {detail}")
 
 
@@ -364,10 +572,13 @@ def verify(
     doc: Any,
     *,
     public_key: Any | None = None,
+    mldsa_public_key: Any | None = None,
     chain: list[dict[str, Any]] | None = None,
 ) -> VerifyResult:
     """Verify an ODR document. ``public_key`` is a loaded Ed25519 key (see
-    :func:`load_public_key`); ``chain`` is a list of parsed JSONL chain entries.
+    :func:`load_public_key`); ``mldsa_public_key`` is a loaded ML-DSA-65 key
+    (see :func:`load_mldsa_public_key`); ``chain`` is a list of parsed JSONL
+    chain entries.
     """
     receipt_id = str(doc.get("receipt_id") or "") if isinstance(doc, dict) else ""
     checks: list[Check] = []
@@ -396,7 +607,7 @@ def verify(
         )
     checks.append(Check("canonical_digest", PASS, f"sha-256:{digest_hex}"))
 
-    checks.append(_check_signatures(doc, digest_hex, public_key))
+    checks.append(_check_signatures(doc, digest_hex, public_key, mldsa_public_key))
     checks.append(_check_quorum_consistency(doc))
     checks.append(_check_chain(doc, digest_hex, chain))
 
@@ -411,6 +622,7 @@ def verify_path(
     receipt_path: str,
     *,
     pubkey_path: str | None = None,
+    mldsa_pubkey_path: str | None = None,
     chain_path: str | None = None,
 ) -> VerifyResult:
     """Convenience wrapper that reads files from disk and calls :func:`verify`."""
@@ -420,6 +632,10 @@ def verify_path(
     if pubkey_path:
         with open(pubkey_path, "rb") as fh:
             public_key = load_public_key(fh.read())
+    mldsa_public_key = None
+    if mldsa_pubkey_path:
+        with open(mldsa_pubkey_path, "rb") as fh:
+            mldsa_public_key = load_mldsa_public_key(fh.read())
     chain: list[dict[str, Any]] | None = None
     if chain_path:
         chain = []
@@ -428,4 +644,4 @@ def verify_path(
                 line = line.strip()
                 if line:
                     chain.append(json.loads(line))
-    return verify(doc, public_key=public_key, chain=chain)
+    return verify(doc, public_key=public_key, mldsa_public_key=mldsa_public_key, chain=chain)

--- a/aragora-verify/tests/test_mldsa_verifier.py
+++ b/aragora-verify/tests/test_mldsa_verifier.py
@@ -1,0 +1,191 @@
+"""Canonical verifier support for ML-DSA-65 ODR signatures (#8612)."""
+
+# ruff: noqa: E402
+
+from __future__ import annotations
+
+import base64
+import copy
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+for _path in (_REPO_ROOT / "aragora-verify" / "src", _REPO_ROOT):
+    if str(_path) not in sys.path:
+        sys.path.insert(0, str(_path))
+
+from aragora.gauntlet import odr_signing as signing
+from aragora_verify.cli import main
+from aragora_verify.verifier import FAIL, PASS, load_mldsa_public_key, verify
+
+from _fixtures import make_keypair, sign_odr, valid_odr
+
+pytestmark = pytest.mark.skipif(
+    not signing.pqc_available(),
+    reason="cryptography build lacks ML-DSA (needs cryptography>=49 / OpenSSL 3.5+)",
+)
+
+
+def _signature_check(result):
+    return next(c for c in result.checks if c.name == "signature")
+
+
+def _ed25519_public_bytes(public_key) -> bytes:
+    return public_key.public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+
+def _write_json(tmp_path: Path, name: str, doc: dict) -> str:
+    path = tmp_path / name
+    path.write_text(json.dumps(doc), encoding="utf-8")
+    return str(path)
+
+
+def _write(tmp_path: Path, name: str, data: bytes) -> str:
+    path = tmp_path / name
+    path.write_bytes(data)
+    return str(path)
+
+
+def test_mldsa_key_id_matches_producer_and_public_key_loader_accepts_encodings() -> None:
+    key = signing.generate_mldsa_signing_key()
+    public_key = key.public_key()
+    raw = public_key.public_bytes_raw()
+    pem = public_key.public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    der = public_key.public_bytes(
+        serialization.Encoding.DER,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+    from aragora_verify.verifier import compute_mldsa_key_id
+
+    assert compute_mldsa_key_id(public_key) == signing.compute_mldsa_key_id(public_key)
+    for encoded in (
+        raw,
+        pem,
+        der,
+        base64.b64encode(raw),
+        raw.hex().encode("ascii"),
+    ):
+        assert compute_mldsa_key_id(load_mldsa_public_key(encoded)) == compute_mldsa_key_id(
+            public_key
+        )
+
+
+def test_hybrid_receipt_verifies_both_signature_algorithms() -> None:
+    ed_private, ed_public = make_keypair()
+    mldsa_private = signing.generate_mldsa_signing_key()
+    signed = signing.sign_odr_hybrid(
+        valid_odr(),
+        ed25519_key=ed_private,
+        mldsa_key=mldsa_private,
+    )
+
+    result = verify(
+        signed,
+        public_key=ed_public,
+        mldsa_public_key=mldsa_private.public_key(),
+    )
+
+    assert result.ok is True
+    signature = _signature_check(result)
+    assert signature.status == PASS
+    assert "sig[0] Ed25519" in signature.detail
+    assert "sig[1] ML-DSA-65" in signature.detail
+    assert "verified" in signature.detail
+
+
+def test_hybrid_receipt_tamper_fails_signature_check() -> None:
+    ed_private, ed_public = make_keypair()
+    mldsa_private = signing.generate_mldsa_signing_key()
+    signed = signing.sign_odr_hybrid(
+        valid_odr(),
+        ed25519_key=ed_private,
+        mldsa_key=mldsa_private,
+    )
+    tampered = copy.deepcopy(signed)
+    tampered["claim"]["statement"] = "merge a different PR"
+
+    result = verify(
+        tampered,
+        public_key=ed_public,
+        mldsa_public_key=mldsa_private.public_key(),
+    )
+
+    assert result.ok is False
+    assert _signature_check(result).status == FAIL
+
+
+def test_hybrid_receipt_wrong_mldsa_key_fails_even_when_ed25519_key_is_valid() -> None:
+    ed_private, ed_public = make_keypair()
+    mldsa_private = signing.generate_mldsa_signing_key()
+    wrong_mldsa_public = signing.generate_mldsa_signing_key().public_key()
+    signed = signing.sign_odr_hybrid(
+        valid_odr(),
+        ed25519_key=ed_private,
+        mldsa_key=mldsa_private,
+    )
+
+    result = verify(
+        signed,
+        public_key=ed_public,
+        mldsa_public_key=wrong_mldsa_public,
+    )
+
+    assert result.ok is False
+    signature = _signature_check(result)
+    assert signature.status == FAIL
+    assert "ML-DSA-65" in signature.detail
+
+
+def test_hybrid_receipt_without_mldsa_key_skips_mldsa_entry_but_ed25519_passes() -> None:
+    ed_private, ed_public = make_keypair()
+    mldsa_private = signing.generate_mldsa_signing_key()
+    signed = signing.sign_odr_hybrid(
+        valid_odr(),
+        ed25519_key=ed_private,
+        mldsa_key=mldsa_private,
+    )
+
+    result = verify(signed, public_key=ed_public)
+
+    assert result.ok is True
+    signature = _signature_check(result)
+    assert signature.status == PASS
+    assert "sig[0] Ed25519" in signature.detail
+    assert "sig[1] ML-DSA-65" in signature.detail
+    assert "skipped" in signature.detail
+
+
+def test_ed25519_only_receipt_still_verifies_with_ed25519_key() -> None:
+    private_key, public_key = make_keypair()
+    signed = sign_odr(valid_odr(), private_key)
+
+    result = verify(signed, public_key=public_key)
+
+    assert result.ok is True
+    assert _signature_check(result).status == PASS
+
+
+def test_cli_accepts_mldsa_pubkey_for_hybrid_receipt(tmp_path: Path) -> None:
+    ed_private, ed_public = make_keypair()
+    mldsa_private = signing.generate_mldsa_signing_key()
+    signed = signing.sign_odr_hybrid(
+        valid_odr(),
+        ed25519_key=ed_private,
+        mldsa_key=mldsa_private,
+    )
+    receipt_path = _write_json(tmp_path, "hybrid.json", signed)
+    ed_path = _write(tmp_path, "ed25519.pem", _ed25519_public_bytes(ed_public))
+    mldsa_path = _write(tmp_path, "mldsa.raw", mldsa_private.public_key().public_bytes_raw())
+
+    assert main([receipt_path, "--pubkey", ed_path, "--mldsa-pubkey", mldsa_path]) == 0

--- a/aragora-verify/tests/test_mldsa_verifier.py
+++ b/aragora-verify/tests/test_mldsa_verifier.py
@@ -151,6 +151,70 @@ def test_hybrid_receipt_wrong_mldsa_key_fails_even_when_ed25519_key_is_valid() -
     assert "ML-DSA-65" in signature.detail
 
 
+def test_hybrid_receipt_mldsa_key_id_mismatch_fails() -> None:
+    ed_private, ed_public = make_keypair()
+    mldsa_private = signing.generate_mldsa_signing_key()
+    signed = signing.sign_odr_hybrid(
+        valid_odr(),
+        ed25519_key=ed_private,
+        mldsa_key=mldsa_private,
+    )
+    signed["signatures"][1]["key_id"] = "ml-dsa-65-not-the-key"
+
+    result = verify(
+        signed,
+        public_key=ed_public,
+        mldsa_public_key=mldsa_private.public_key(),
+    )
+
+    assert result.ok is False
+    assert _signature_check(result).status == FAIL
+    assert "key_id mismatch" in _signature_check(result).detail
+
+
+def test_hybrid_receipt_ed25519_key_id_mismatch_fails() -> None:
+    ed_private, ed_public = make_keypair()
+    mldsa_private = signing.generate_mldsa_signing_key()
+    signed = signing.sign_odr_hybrid(
+        valid_odr(),
+        ed25519_key=ed_private,
+        mldsa_key=mldsa_private,
+    )
+    signed["signatures"][0]["key_id"] = "ed25519-not-the-key"
+
+    result = verify(
+        signed,
+        public_key=ed_public,
+        mldsa_public_key=mldsa_private.public_key(),
+    )
+
+    assert result.ok is False
+    assert _signature_check(result).status == FAIL
+    assert "key_id mismatch" in _signature_check(result).detail
+
+
+def test_hybrid_receipt_malformed_mldsa_signature_fails_cleanly() -> None:
+    ed_private, ed_public = make_keypair()
+    mldsa_private = signing.generate_mldsa_signing_key()
+    signed = signing.sign_odr_hybrid(
+        valid_odr(),
+        ed25519_key=ed_private,
+        mldsa_key=mldsa_private,
+    )
+    signed["signatures"][1]["signature"] = base64.b64encode(b"not-an-mldsa-signature").decode(
+        "ascii"
+    )
+
+    result = verify(
+        signed,
+        public_key=ed_public,
+        mldsa_public_key=mldsa_private.public_key(),
+    )
+
+    assert result.ok is False
+    assert _signature_check(result).status == FAIL
+
+
 def test_hybrid_receipt_without_mldsa_key_skips_mldsa_entry_but_ed25519_passes() -> None:
     ed_private, ed_public = make_keypair()
     mldsa_private = signing.generate_mldsa_signing_key()

--- a/aragora-verify/tests/test_mldsa_verifier.py
+++ b/aragora-verify/tests/test_mldsa_verifier.py
@@ -18,14 +18,18 @@ for _path in (_REPO_ROOT / "aragora-verify" / "src", _REPO_ROOT):
     if str(_path) not in sys.path:
         sys.path.insert(0, str(_path))
 
-from aragora.gauntlet import odr_signing as signing
 from aragora_verify.cli import main
-from aragora_verify.verifier import FAIL, PASS, load_mldsa_public_key, verify
+from aragora_verify.verifier import FAIL, PASS, load_mldsa_public_key, pqc_available, verify
 
 from _fixtures import make_keypair, sign_odr, valid_odr
 
+signing = pytest.importorskip(
+    "aragora.gauntlet.odr_signing",
+    reason="hybrid producer package is unavailable in standalone verifier installs",
+)
+
 pytestmark = pytest.mark.skipif(
-    not signing.pqc_available(),
+    not pqc_available(),
     reason="cryptography build lacks ML-DSA (needs cryptography>=49 / OpenSSL 3.5+)",
 )
 
@@ -174,6 +178,19 @@ def test_ed25519_only_receipt_still_verifies_with_ed25519_key() -> None:
 
     assert result.ok is True
     assert _signature_check(result).status == PASS
+
+
+def test_ed25519_only_receipt_fails_when_mldsa_key_was_required() -> None:
+    private_key, public_key = make_keypair()
+    signed = sign_odr(valid_odr(), private_key)
+    mldsa_public = signing.generate_mldsa_signing_key().public_key()
+
+    result = verify(signed, public_key=public_key, mldsa_public_key=mldsa_public)
+
+    assert result.ok is False
+    signature = _signature_check(result)
+    assert signature.status == FAIL
+    assert "no ML-DSA-65 signature present" in signature.detail
 
 
 def test_cli_accepts_mldsa_pubkey_for_hybrid_receipt(tmp_path: Path) -> None:

--- a/aragora/gauntlet/odr_schema.json
+++ b/aragora/gauntlet/odr_schema.json
@@ -263,12 +263,12 @@
     },
     "signatures": {
       "type": "array",
-      "description": "Reserved for detached signatures (Ed25519, issue #8225). Empty in v0.1; signatures cover the SHA-256 of the JCS bytes of the payload with this array removed.",
+      "description": "Detached signatures (Ed25519 #8225; ML-DSA-65/FIPS 204 post-quantum #8602). Hybrid receipts carry one entry per algorithm; signatures cover the SHA-256 of the JCS bytes of the payload with this array removed.",
       "items": {
         "type": "object",
         "required": ["alg", "key_id", "signature"],
         "properties": {
-          "alg": { "type": "string", "enum": ["Ed25519"] },
+          "alg": { "type": "string", "enum": ["Ed25519", "ML-DSA-65"] },
           "key_id": { "type": "string", "minLength": 1 },
           "signature": { "type": "string", "minLength": 1 },
           "signed_at": { "type": "string" }

--- a/aragora/gauntlet/odr_signing.py
+++ b/aragora/gauntlet/odr_signing.py
@@ -91,6 +91,68 @@ def compute_key_id(public_key: Ed25519PublicKey) -> str:
     return "ed25519-" + hashlib.sha256(raw).hexdigest()[:16]
 
 
+# --- Post-quantum (ML-DSA / FIPS 204) hybrid signing (#8602) -----------------
+#
+# Decision receipts are harvest-now-decrypt-later critical: their signatures
+# must verify for years, so an Ed25519-only signature is born quantum-vulnerable.
+# We add a *hybrid* path that attaches BOTH an Ed25519 and an ML-DSA detached
+# signature over the same content digest. Existing verifiers keep working on the
+# Ed25519 entry; the ML-DSA entry provides quantum-resistant assurance. ML-DSA-65
+# is FIPS 204 NIST security level 3 (the recommended general-purpose set).
+ODR_PQC_SIGNATURE_ALG = "ML-DSA-65"
+
+
+def _load_mldsa():  # noqa: ANN202 - lazy import keeps the error actionable
+    try:
+        from cryptography.exceptions import InvalidSignature
+        from cryptography.hazmat.primitives.asymmetric import mldsa
+    except ImportError as exc:  # pragma: no cover - environment-dependent
+        raise OdrSigningError(
+            "post-quantum ODR signing requires `cryptography` >= 49 built against "
+            "OpenSSL 3.5+/AWS-LC/BoringSSL (the `mldsa` module); upgrade `cryptography` "
+            "to enable ML-DSA hybrid signatures"
+        ) from exc
+    return mldsa, InvalidSignature
+
+
+def pqc_available() -> bool:
+    """Whether the runtime ``cryptography`` build exposes ML-DSA (FIPS 204).
+
+    Mirrors the graceful-degradation pattern used elsewhere: callers can hybrid-
+    sign when this is True and fall back to Ed25519-only when it is False.
+    """
+    try:
+        from cryptography.hazmat.primitives.asymmetric import mldsa  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def compute_mldsa_key_id(public_key: Any) -> str:
+    """``ml-dsa-65-`` + first 16 hex of SHA-256(raw ML-DSA public key).
+
+    Parallels :func:`compute_key_id` for Ed25519 so an ML-DSA signature entry's
+    ``key_id`` is reproducible from the published public key.
+    """
+    raw = public_key.public_bytes_raw()
+    return "ml-dsa-65-" + hashlib.sha256(raw).hexdigest()[:16]
+
+
+def generate_mldsa_signing_key() -> Any:
+    """Generate a fresh ML-DSA-65 private key (key-rotation / bootstrap tooling)."""
+    mldsa, _ = _load_mldsa()
+    return mldsa.MLDSA65PrivateKey.generate()
+
+
+def load_mldsa_key_from_seed(seed: bytes) -> Any:
+    """Load an ML-DSA-65 private key from its 32-byte seed (held in Secrets Manager)."""
+    if len(seed) != 32:
+        raise OdrSigningError(f"ML-DSA-65 seed must be exactly 32 bytes, got {len(seed)}")
+    mldsa, _ = _load_mldsa()
+    return mldsa.MLDSA65PrivateKey.from_seed_bytes(seed)
+
+
 def load_private_key_from_pem(pem: str | bytes) -> Ed25519PrivateKey:
     """Load an Ed25519 private key from PEM (for tests/offline tooling).
 
@@ -248,48 +310,142 @@ def sign_odr_receipt(
         re-derives and checks.
     """
     signed = copy.deepcopy(odr)
+    signatures = _existing_signatures(signed, replace=replace)
+    signatures.append(
+        {
+            "alg": ODR_SIGNATURE_ALG,
+            "key_id": compute_key_id(private_key.public_key()),
+            "signature": _b64(private_key.sign(_odr_signing_message(signed))),
+        }
+    )
+    signed["signatures"] = signatures
+    return signed
 
-    existing = signed.get("signatures")
-    signatures: list[Any] = []
-    if not replace and isinstance(existing, list):
-        invalid_index = next(
-            (
-                index
-                for index, entry in enumerate(existing)
-                if not _is_signature_entry_compatible(entry)
-            ),
-            None,
-        )
-        if invalid_index is not None:
-            raise OdrSigningError(
-                f"existing signatures[{invalid_index}] is not a valid ODR signature entry; "
-                "use replace=True to drop existing signatures before signing"
-            )
-        signatures = existing
 
-    # The digest excludes the signatures array (detached) — compute it against
-    # the payload as the verifier will, regardless of what's already attached.
+def sign_odr_receipt_mldsa(
+    odr: dict[str, Any],
+    private_key: Any,
+    *,
+    replace: bool = False,
+) -> dict[str, Any]:
+    """Attach a post-quantum **ML-DSA-65** (FIPS 204) detached signature.
+
+    Identical envelope to :func:`sign_odr_receipt` (same content digest, same
+    ``{"alg", "key_id", "signature"}`` shape) — just a quantum-resistant
+    algorithm. Appends by default so it can sit alongside an Ed25519 entry.
+    """
+    signed = copy.deepcopy(odr)
+    signatures = _existing_signatures(signed, replace=replace)
+    signatures.append(
+        {
+            "alg": ODR_PQC_SIGNATURE_ALG,
+            "key_id": compute_mldsa_key_id(private_key.public_key()),
+            "signature": _b64(private_key.sign(_odr_signing_message(signed))),
+        }
+    )
+    signed["signatures"] = signatures
+    return signed
+
+
+def sign_odr_hybrid(
+    odr: dict[str, Any],
+    *,
+    ed25519_key: Ed25519PrivateKey,
+    mldsa_key: Any,
+    replace: bool = False,
+) -> dict[str, Any]:
+    """Attach BOTH a classical Ed25519 and a post-quantum ML-DSA detached signature.
+
+    Both signatures cover the same content digest, so the receipt stays verifiable
+    by existing Ed25519 tooling **and** gains quantum-resistant assurance — the
+    harvest-now-decrypt-later defense for long-lived audit receipts (#8602).
+    """
+    signed = sign_odr_receipt(odr, ed25519_key, replace=replace)
+    return sign_odr_receipt_mldsa(signed, mldsa_key, replace=False)
+
+
+def verify_odr_signature_ed25519(odr: dict[str, Any], *, public_key: Ed25519PublicKey) -> bool:
+    """In-package Ed25519 verify (round-trip / offline tooling). Returns True if any
+    Ed25519 entry whose key_id matches ``public_key`` verifies over the content digest."""
+    _, _, _, InvalidSignature = _load_ed25519()
+    return _verify_entries(
+        odr,
+        alg=ODR_SIGNATURE_ALG,
+        key_id=compute_key_id(public_key),
+        verify=public_key.verify,
+        invalid_signature=InvalidSignature,
+    )
+
+
+def verify_odr_signature_mldsa(odr: dict[str, Any], *, public_key: Any) -> bool:
+    """In-package ML-DSA-65 verify. Returns True if any ML-DSA entry whose key_id
+    matches ``public_key`` verifies over the content digest."""
+    _, InvalidSignature = _load_mldsa()
+    return _verify_entries(
+        odr,
+        alg=ODR_PQC_SIGNATURE_ALG,
+        key_id=compute_mldsa_key_id(public_key),
+        verify=public_key.verify,
+        invalid_signature=InvalidSignature,
+    )
+
+
+def _b64(data: bytes) -> str:
+    return base64.b64encode(data).decode("ascii")
+
+
+def _odr_signing_message(odr: dict[str, Any]) -> bytes:
+    """The bytes a detached ODR signature covers: ``bytes.fromhex(content_digest)``.
+
+    The digest excludes the ``signatures`` array, so it is identical before and
+    after any signatures are attached — every algorithm signs the same message.
+    """
     try:
-        digest_hex = odr_content_digest(signed)
-        message = bytes.fromhex(digest_hex)
+        return bytes.fromhex(odr_content_digest(odr))
     except (TypeError, ValueError) as exc:
         raise OdrSigningError("could not compute ODR content digest for signing") from exc
 
-    signature_bytes = private_key.sign(message)
-    entry = {
-        "alg": ODR_SIGNATURE_ALG,
-        "key_id": compute_key_id(private_key.public_key()),
-        "signature": base64.b64encode(signature_bytes).decode("ascii"),
-    }
-    signatures.append(entry)
-    signed["signatures"] = signatures
-    return signed
+
+def _existing_signatures(signed: dict[str, Any], *, replace: bool) -> list[Any]:
+    existing = signed.get("signatures")
+    if replace or not isinstance(existing, list):
+        return []
+    invalid_index = next(
+        (i for i, entry in enumerate(existing) if not _is_signature_entry_compatible(entry)),
+        None,
+    )
+    if invalid_index is not None:
+        raise OdrSigningError(
+            f"existing signatures[{invalid_index}] is not a valid ODR signature entry; "
+            "use replace=True to drop existing signatures before signing"
+        )
+    return existing
+
+
+def _verify_entries(
+    odr: dict[str, Any],
+    *,
+    alg: str,
+    key_id: str,
+    verify: Any,
+    invalid_signature: type[Exception],
+) -> bool:
+    message = _odr_signing_message(odr)
+    for entry in odr.get("signatures") or []:
+        if not isinstance(entry, dict) or entry.get("alg") != alg or entry.get("key_id") != key_id:
+            continue
+        try:
+            verify(base64.b64decode(entry["signature"]), message)
+            return True
+        except (invalid_signature, ValueError, TypeError, KeyError):
+            continue
+    return False
 
 
 def _is_signature_entry_compatible(entry: Any) -> bool:
     if not isinstance(entry, dict):
         return False
-    if entry.get("alg") != ODR_SIGNATURE_ALG:
+    if entry.get("alg") not in (ODR_SIGNATURE_ALG, ODR_PQC_SIGNATURE_ALG):
         return False
     for field in ("key_id", "signature"):
         if not isinstance(entry.get(field), str) or not entry[field]:
@@ -299,12 +455,21 @@ def _is_signature_entry_compatible(entry: Any) -> bool:
 
 
 __all__ = [
+    "ODR_PQC_SIGNATURE_ALG",
     "ODR_SIGNATURE_ALG",
     "OdrSigningError",
     "compute_key_id",
+    "compute_mldsa_key_id",
+    "generate_mldsa_signing_key",
     "generate_signing_key",
+    "load_mldsa_key_from_seed",
     "load_private_key_from_pem",
     "load_signing_key_from_secrets",
+    "pqc_available",
     "public_key_pem",
+    "sign_odr_hybrid",
     "sign_odr_receipt",
+    "sign_odr_receipt_mldsa",
+    "verify_odr_signature_ed25519",
+    "verify_odr_signature_mldsa",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,14 +125,15 @@ Issues = "https://github.com/synaptent/aragora/issues"
 # floored to non-vulnerable releases for the pip-audit security gate
 # (scripts/run_pip_audit_gate.py):
 #
-#   * cryptography >=48.0.1 — fixes GHSA-537c-gmf6-5ccf. Pulled in via
-#     pyjwt[crypto] / secretstorage and used at runtime for AES-256-GCM
-#     encryption (aragora/security/encryption.py). The floor is 48.0.1; the
-#     resolver actually lands on 49.0.0 (a 46 -> 49 jump across three majors).
-#     cryptography's hazmat AES-GCM surface is stable across this range and the
-#     46->49 deprecations are in unused legacy x509/serialization helpers;
-#     verified by exercising encrypt/decrypt + AAD on 49.0.0. pyjwt and
-#     secretstorage floor cryptography far below 48, so nothing caps the bump.
+#   * cryptography >=49 — fixes GHSA-537c-gmf6-5ccf AND provides the FIPS 204
+#     ML-DSA module (`cryptography.hazmat.primitives.asymmetric.mldsa`, available
+#     from the 49 line built against OpenSSL 3.5+/AWS-LC/BoringSSL) used for
+#     post-quantum hybrid ODR receipt signing (aragora/gauntlet/odr_signing.py,
+#     #8602). Also used at runtime for AES-256-GCM encryption
+#     (aragora/security/encryption.py). The 46 -> 49 jump (three majors) is
+#     verified stable: hazmat AES-GCM/Ed25519 surfaces are unchanged and the
+#     deprecations are in unused legacy x509/serialization helpers. pyjwt and
+#     secretstorage floor cryptography far below 49, so nothing caps the bump.
 #   * starlette >=1.3.1 — fixes CVE-2026-54283, CVE-2026-54282, CVE-2026-48818,
 #     CVE-2026-48817. Pulled in via fastapi (gateway/all extras). fastapi
 #     0.136.3 requires only ``starlette>=0.46.0`` (no upper bound) and already
@@ -142,7 +143,7 @@ Issues = "https://github.com/synaptent/aragora/issues"
 # -----------------------------------------------------------------------------
 [tool.uv]
 constraint-dependencies = [
-    "cryptography>=48.0.1",
+    "cryptography>=49",
     "starlette>=1.3.1",
 ]
 

--- a/tests/gauntlet/test_odr_mldsa_hybrid.py
+++ b/tests/gauntlet/test_odr_mldsa_hybrid.py
@@ -8,6 +8,8 @@ round-trips where it is present (cryptography>=49 / OpenSSL 3.5+).
 from __future__ import annotations
 
 import copy
+import json
+from pathlib import Path
 
 import pytest
 
@@ -18,13 +20,49 @@ pytestmark = pytest.mark.skipif(
     reason="cryptography build lacks ML-DSA (needs cryptography>=49 / OpenSSL 3.5+)",
 )
 
+_SCHEMA_PATH = Path(__file__).resolve().parents[2] / "aragora" / "gauntlet" / "odr_schema.json"
+
 
 def _odr() -> dict:
+    """A schema-conformant unsigned ODR v0.1 doc (mirrors the aragora-verify fixture),
+    so the hybrid tests exercise the *real* ODR shape + schema, not a stub."""
     return {
-        "schema": "open-decision-receipt/v1",
-        "receipt_id": "odr-test-0001",
-        "decision": "ship the rate limiter",
-        "evidence": ["a", "b"],
+        "odr_version": "0.1",
+        "profile": "https://aragora.ai/specs/open-decision-receipt/v0.1",
+        "receipt_id": "rcpt-pqc-0001",
+        "issued_at": "2026-06-24T00:00:00Z",
+        "subject": {
+            "identifier": "5f1b14e4b5e113dc978d60d1f6bd21b5a478c744",
+            "digest": {"status": "present", "alg": "sha-256", "value": "deadbeef"},
+            "summary": "PR #8608",
+        },
+        "claim": {"verdict": "PASS", "statement": "merge PR #8608"},
+        "reasoning": {"status": "present", "summary": "all required checks green"},
+        "quorum": {
+            "status": "present",
+            "method": "majority",
+            "reached": True,
+            "supporting_agents": ["claude", "openai"],
+            "participants": [
+                {"agent": "claude", "model_family": "anthropic", "model_id": "claude-opus-4-8"},
+                {"agent": "openai", "model_family": "openai", "model_id": "gpt-5.5"},
+            ],
+            "independence": {
+                "disclosed": True,
+                "distinct_model_families": 2,
+                "model_families": ["anthropic", "openai"],
+            },
+            "dissent": {"present": False, "dissenting_agents": [], "views": []},
+        },
+        "confidence": {
+            "status": "present",
+            "value": 0.9,
+            "scale": "unit_interval",
+            "calibration": {"status": "absent", "reason": "no calibration record"},
+        },
+        "cruxes": {"status": "absent", "reason": "no crux set supplied"},
+        "attestation": {"disposition": "autonomous"},
+        "routing": {"status": "reserved"},
         "signatures": [],
     }
 
@@ -91,7 +129,7 @@ def test_hybrid_tamper_breaks_both():
     ed = _ed25519_key()
     pq = s.generate_mldsa_signing_key()
     signed = s.sign_odr_hybrid(_odr(), ed25519_key=ed, mldsa_key=pq)
-    signed["evidence"].append("forged")  # mutate content
+    signed["claim"]["statement"] = "merge something else"  # mutate content digest
     assert s.verify_odr_signature_ed25519(signed, public_key=ed.public_key()) is False
     assert s.verify_odr_signature_mldsa(signed, public_key=pq.public_key()) is False
 
@@ -112,3 +150,31 @@ def test_ed25519_only_signing_unchanged_by_pqc_additions():
     signed = s.sign_odr_receipt(_odr(), ed)
     assert [e["alg"] for e in signed["signatures"]] == ["Ed25519"]
     assert s.verify_odr_signature_ed25519(signed, public_key=ed.public_key()) is True
+
+
+# --- Schema conformance (resolves #8608 P1: hybrid receipts were hard-rejected) ---
+def _validate_against_schema(doc: dict) -> None:
+    import jsonschema
+
+    schema = json.loads(_SCHEMA_PATH.read_text())
+    jsonschema.validate(doc, schema)  # raises jsonschema.ValidationError on reject
+
+
+def test_hybrid_receipt_validates_against_odr_schema():
+    # The core backward-compat proof: a receipt carrying BOTH an Ed25519 and an
+    # ML-DSA-65 signature entry must satisfy the canonical ODR schema (the enum
+    # now allows ML-DSA-65). Before the fix this raised ValidationError.
+    signed = s.sign_odr_hybrid(
+        _odr(), ed25519_key=_ed25519_key(), mldsa_key=s.generate_mldsa_signing_key()
+    )
+    assert [e["alg"] for e in signed["signatures"]] == ["Ed25519", "ML-DSA-65"]
+    _validate_against_schema(signed)  # must not raise
+
+
+def test_ed25519_only_receipt_still_schema_valid():
+    signed = s.sign_odr_receipt(_odr(), _ed25519_key())
+    _validate_against_schema(signed)
+
+
+def test_unsigned_odr_is_schema_valid():
+    _validate_against_schema(_odr())

--- a/tests/gauntlet/test_odr_mldsa_hybrid.py
+++ b/tests/gauntlet/test_odr_mldsa_hybrid.py
@@ -1,0 +1,114 @@
+"""Post-quantum (ML-DSA / FIPS 204) hybrid ODR signing round-trips (#8602).
+
+Gated on ``pqc_available()`` so the suite skips cleanly where the installed
+``cryptography`` build lacks the ``mldsa`` module, and runs the real ML-DSA
+round-trips where it is present (cryptography>=49 / OpenSSL 3.5+).
+"""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from aragora.gauntlet import odr_signing as s
+
+pytestmark = pytest.mark.skipif(
+    not s.pqc_available(),
+    reason="cryptography build lacks ML-DSA (needs cryptography>=49 / OpenSSL 3.5+)",
+)
+
+
+def _odr() -> dict:
+    return {
+        "schema": "open-decision-receipt/v1",
+        "receipt_id": "odr-test-0001",
+        "decision": "ship the rate limiter",
+        "evidence": ["a", "b"],
+        "signatures": [],
+    }
+
+
+def _ed25519_key():
+    return s.generate_signing_key()
+
+
+# --- ML-DSA only -------------------------------------------------------------
+def test_mldsa_sign_verify_roundtrip():
+    key = s.generate_mldsa_signing_key()
+    signed = s.sign_odr_receipt_mldsa(_odr(), key)
+    entry = signed["signatures"][-1]
+    assert entry["alg"] == s.ODR_PQC_SIGNATURE_ALG == "ML-DSA-65"
+    assert entry["key_id"] == s.compute_mldsa_key_id(key.public_key())
+    assert s.verify_odr_signature_mldsa(signed, public_key=key.public_key()) is True
+
+
+def test_mldsa_tamper_rejected():
+    key = s.generate_mldsa_signing_key()
+    signed = s.sign_odr_receipt_mldsa(_odr(), key)
+    tampered = copy.deepcopy(signed)
+    tampered["decision"] = "ship something else"  # changes the content digest
+    assert s.verify_odr_signature_mldsa(tampered, public_key=key.public_key()) is False
+
+
+def test_mldsa_wrong_key_rejected():
+    signed = s.sign_odr_receipt_mldsa(_odr(), s.generate_mldsa_signing_key())
+    assert (
+        s.verify_odr_signature_mldsa(signed, public_key=s.generate_mldsa_signing_key().public_key())
+        is False
+    )
+
+
+def test_mldsa_seed_roundtrip_is_deterministic():
+    key = s.generate_mldsa_signing_key()
+    seed = key.private_bytes_raw()
+    assert len(seed) == 32
+    reloaded = s.load_mldsa_key_from_seed(seed)
+    # same seed -> same public key -> same key_id
+    assert s.compute_mldsa_key_id(reloaded.public_key()) == s.compute_mldsa_key_id(key.public_key())
+    signed = s.sign_odr_receipt_mldsa(_odr(), reloaded)
+    assert s.verify_odr_signature_mldsa(signed, public_key=key.public_key()) is True
+
+
+def test_load_mldsa_key_from_bad_seed_raises():
+    with pytest.raises(s.OdrSigningError):
+        s.load_mldsa_key_from_seed(b"too short")
+
+
+# --- Hybrid (Ed25519 + ML-DSA) ----------------------------------------------
+def test_hybrid_attaches_both_and_both_verify():
+    ed = _ed25519_key()
+    pq = s.generate_mldsa_signing_key()
+    signed = s.sign_odr_hybrid(_odr(), ed25519_key=ed, mldsa_key=pq)
+    algs = [e["alg"] for e in signed["signatures"]]
+    assert algs == ["Ed25519", "ML-DSA-65"]
+    # both halves verify independently over the same content digest
+    assert s.verify_odr_signature_ed25519(signed, public_key=ed.public_key()) is True
+    assert s.verify_odr_signature_mldsa(signed, public_key=pq.public_key()) is True
+
+
+def test_hybrid_tamper_breaks_both():
+    ed = _ed25519_key()
+    pq = s.generate_mldsa_signing_key()
+    signed = s.sign_odr_hybrid(_odr(), ed25519_key=ed, mldsa_key=pq)
+    signed["evidence"].append("forged")  # mutate content
+    assert s.verify_odr_signature_ed25519(signed, public_key=ed.public_key()) is False
+    assert s.verify_odr_signature_mldsa(signed, public_key=pq.public_key()) is False
+
+
+def test_adding_mldsa_does_not_invalidate_existing_ed25519():
+    # Sign Ed25519 first (as existing producers do), then add ML-DSA later.
+    ed = _ed25519_key()
+    ed_signed = s.sign_odr_receipt(_odr(), ed)
+    both = s.sign_odr_receipt_mldsa(ed_signed, s.generate_mldsa_signing_key())
+    # the digest excludes signatures, so the prior Ed25519 signature still verifies
+    assert s.verify_odr_signature_ed25519(both, public_key=ed.public_key()) is True
+    assert len(both["signatures"]) == 2
+
+
+def test_ed25519_only_signing_unchanged_by_pqc_additions():
+    # The classical path must remain byte-identical in shape.
+    ed = _ed25519_key()
+    signed = s.sign_odr_receipt(_odr(), ed)
+    assert [e["alg"] for e in signed["signatures"]] == ["Ed25519"]
+    assert s.verify_odr_signature_ed25519(signed, public_key=ed.public_key()) is True

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [manifest]
 constraints = [
-    { name = "cryptography", specifier = ">=48.0.1" },
+    { name = "cryptography", specifier = ">=49" },
     { name = "starlette", specifier = ">=1.3.1" },
 ]
 


### PR DESCRIPTION
Implements **PQC-2** (#8602) of the post-quantum epic #8600 and resolves the #8225 hybrid course-correction.

Decision receipts are harvest-now-decrypt-later critical, so Ed25519-only signing is born quantum-vulnerable. This adds a **FIPS 204 ML-DSA-65** path plus a **hybrid signer** that attaches both an Ed25519 *and* an ML-DSA detached signature over the same content digest — existing verifiers keep working on the Ed25519 entry; the ML-DSA entry adds quantum-resistant assurance.

**No new dependency** — uses `cryptography`'s native `mldsa` module (floor bumped 48.0.1→49; the resolver already landed on 49, so no real env change). Graceful degradation via `pqc_available()` where the build lacks ML-DSA.

Tests: 9 round-trips (sign/verify, tamper, wrong-key, seed round-trip, hybrid both-verify, Ed25519 coexistence) + the 20 existing ODR signing tests still pass (Ed25519 path unchanged).

Follow-up (separate): teach the external `aragora_verify` verifier to accept ML-DSA entries for full offline third-party PQC verification.