### PR TITLE
fix(outbox): require current base for merged-pr proof

### DIFF
--- a/scripts/reconcile_automation_outbox.py
+++ b/scripts/reconcile_automation_outbox.py
@@ -352,6 +352,11 @@ def _requested_base_from_payload(payload: Mapping[str, Any]) -> str:
     return ""
 
 
+def _handoff_base_matches_reconciler(payload: Mapping[str, Any], base: str) -> bool:
+    expected_base = _requested_base_from_payload(payload) or base
+    return _normalize_base_ref(expected_base) == _normalize_base_ref(base)
+
+
 def _upstream_base_matches(upstream: Mapping[str, Any], expected_base: str) -> bool:
     expected = _normalize_base_ref(expected_base)
     for key in ("base_ref", "base_ref_name", "baseRefName", "base"):
@@ -396,7 +401,7 @@ def _merged_pr_commit_preservation_proof(
     if not _is_pr_publication_request(payload):
         return None
     expected_base = _requested_base_from_payload(payload) or base
-    if _normalize_base_ref(expected_base) != _normalize_base_ref(base):
+    if not _handoff_base_matches_reconciler(payload, base):
         # Archive authority is scoped to the reconciler base. Integration-branch
         # handoffs must be reconciled with their matching --base instead of
         # being archived from an origin/main pass.
@@ -1588,7 +1593,9 @@ def main(argv: list[str] | None = None) -> int:
                 if args.apply:
                     shutil.move(str(path), str(archive_dir / path.name))
                 continue
-            if _branch_has_landed_on_main(root, args.base, branch):
+            if _handoff_base_matches_reconciler(payload, args.base) and _branch_has_landed_on_main(
+                root, args.base, branch
+            ):
                 counts["satisfied_by_landed_on_main"] += 1
                 actions.append(
                     {
@@ -1737,7 +1744,9 @@ def main(argv: list[str] | None = None) -> int:
                 shutil.move(str(path), str(archive_dir / path.name))
             continue
 
-        if _branch_has_landed_on_main(root, args.base, branch):
+        if _handoff_base_matches_reconciler(payload, args.base) and _branch_has_landed_on_main(
+            root, args.base, branch
+        ):
             counts["satisfied_by_landed_on_main"] += 1
             actions.append(
                 {

--- a/scripts/reconcile_automation_outbox.py
+++ b/scripts/reconcile_automation_outbox.py
@@ -396,6 +396,8 @@ def _merged_pr_commit_preservation_proof(
     if not _is_pr_publication_request(payload):
         return None
     expected_base = _requested_base_from_payload(payload) or base
+    if _normalize_base_ref(expected_base) != _normalize_base_ref(base):
+        return None
     records = _lane_records_from_payload(payload, branch)
     if not records:
         return None
@@ -476,6 +478,8 @@ def _merged_pr_commit_preservation_proof(
         if not isinstance(upstream, Mapping):
             return None
         if not _upstream_base_matches(upstream, expected_base):
+            return None
+        if not _desired_head_landed_on_base(root, base, record_branch, desired_head):
             return None
         if common_upstream is None:
             common_upstream = upstream

--- a/scripts/reconcile_automation_outbox.py
+++ b/scripts/reconcile_automation_outbox.py
@@ -1066,6 +1066,13 @@ def _receipt_handoff_keep_reason(
         return None
     receipt_label = f"{reason} receipt"
 
+    requested_base = _requested_base_from_payload(payload) or base
+    if not _handoff_base_matches_reconciler(payload, base):
+        return (
+            f"{receipt_label} targets base {requested_base or 'unknown'}, "
+            f"not reconciler base {base}"
+        )
+
     handled, keep_reason = _merged_target_pr_receipt_resolution(
         root, repo_name, payload, receipt, base, branch
     )

--- a/scripts/reconcile_automation_outbox.py
+++ b/scripts/reconcile_automation_outbox.py
@@ -726,11 +726,14 @@ def _merged_target_pr_receipt_resolution(
     repo_name: str,
     payload: dict[str, Any],
     receipt: Mapping[str, Any],
+    base: str,
+    branch: str,
 ) -> tuple[bool, str | None]:
     """Resolve target-PR receipts whose referenced PR is already merged.
 
     Returns (handled, keep_reason). When handled is True and keep_reason is None,
-    the receipt satisfies the handoff without needing any branch ref checks.
+    the receipt satisfies the handoff because the merged PR head is also proven
+    preserved on the reconciler base.
     """
 
     status = str(receipt.get("status") or "").strip().lower()
@@ -749,12 +752,24 @@ def _merged_target_pr_receipt_resolution(
 
     target_pr_head = str((target_pr_state or {}).get("headRefOid") or "").strip()
     target_pr_number = str((target_pr_state or {}).get("number") or "").strip()
-    if _heads_match(desired_head, target_pr_head):
-        return True, None
-    return True, (
-        f"{receipt_label} points to merged PR #{target_pr_number} at "
-        f"{target_pr_head[:12] or 'unknown'}, not desired head {desired_head[:12]}"
-    )
+    if not _heads_match(desired_head, target_pr_head):
+        return True, (
+            f"{receipt_label} points to merged PR #{target_pr_number} at "
+            f"{target_pr_head[:12] or 'unknown'}, not desired head {desired_head[:12]}"
+        )
+
+    requested_base = _requested_base_from_payload(payload) or base
+    if not _handoff_base_matches_reconciler(payload, base):
+        return True, (
+            f"{receipt_label} targets base {requested_base or 'unknown'}, "
+            f"not reconciler base {base}"
+        )
+    if not _desired_head_landed_on_base(root, base, branch, desired_head):
+        return True, (
+            f"{receipt_label} points to merged PR #{target_pr_number} at desired head "
+            f"{desired_head[:12]}, but that head is not preserved on {base}"
+        )
+    return True, None
 
 
 def _receipt_has_issue_reference(receipt: Mapping[str, Any]) -> bool:
@@ -1037,6 +1052,7 @@ def _receipt_handoff_keep_reason(
     payload: dict[str, Any],
     receipt: Mapping[str, Any],
     branch: str,
+    base: str,
 ) -> str | None:
     """Return why a terminal receipt is not enough to archive this handoff."""
 
@@ -1050,7 +1066,9 @@ def _receipt_handoff_keep_reason(
         return None
     receipt_label = f"{reason} receipt"
 
-    handled, keep_reason = _merged_target_pr_receipt_resolution(root, repo_name, payload, receipt)
+    handled, keep_reason = _merged_target_pr_receipt_resolution(
+        root, repo_name, payload, receipt, base, branch
+    )
     if handled:
         return keep_reason
 
@@ -1534,7 +1552,7 @@ def main(argv: list[str] | None = None) -> int:
                 )
                 continue
             target_pr_handled, target_pr_keep_reason = _merged_target_pr_receipt_resolution(
-                root, args.repo_name, payload, receipt
+                root, args.repo_name, payload, receipt, args.base, branch
             )
             if target_pr_handled:
                 if target_pr_keep_reason is not None:
@@ -1565,7 +1583,7 @@ def main(argv: list[str] | None = None) -> int:
                 continue
             if str(receipt.get("reason") or "").strip().lower() == "existing_pr":
                 keep_reason = _receipt_handoff_keep_reason(
-                    root, args.repo_name, payload, receipt, branch
+                    root, args.repo_name, payload, receipt, branch, args.base
                 )
                 if keep_reason is not None:
                     counts["blocked_receipt_pr_head_mismatch"] += 1
@@ -1610,7 +1628,7 @@ def main(argv: list[str] | None = None) -> int:
                     shutil.move(str(path), str(archive_dir / path.name))
                 continue
             keep_reason = _receipt_handoff_keep_reason(
-                root, args.repo_name, payload, receipt, branch
+                root, args.repo_name, payload, receipt, branch, args.base
             )
             if keep_reason is not None:
                 counts["blocked_receipt_pr_head_mismatch"] += 1

--- a/scripts/reconcile_automation_outbox.py
+++ b/scripts/reconcile_automation_outbox.py
@@ -397,6 +397,9 @@ def _merged_pr_commit_preservation_proof(
         return None
     expected_base = _requested_base_from_payload(payload) or base
     if _normalize_base_ref(expected_base) != _normalize_base_ref(base):
+        # Archive authority is scoped to the reconciler base. Integration-branch
+        # handoffs must be reconciled with their matching --base instead of
+        # being archived from an origin/main pass.
         return None
     records = _lane_records_from_payload(payload, branch)
     if not records:
@@ -480,6 +483,9 @@ def _merged_pr_commit_preservation_proof(
         if not _upstream_base_matches(upstream, expected_base):
             return None
         if not _desired_head_landed_on_base(root, base, record_branch, desired_head):
+            # A merged PR commit-list proves history membership, not current-base
+            # preservation. Prefer stale-outbox noise over archiving work whose
+            # squash tip was reverted or is not patch-equivalent on this base.
             return None
         if common_upstream is None:
             common_upstream = upstream

--- a/tests/scripts/test_reconcile_automation_outbox.py
+++ b/tests/scripts/test_reconcile_automation_outbox.py
@@ -1155,8 +1155,11 @@ def test_reconcile_archives_target_pr_receipt_when_pr_merged_at_desired_head(
     monkeypatch.setattr(
         mod,
         "run_git",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(
-            AssertionError("git ref checks should not run for merged target PR receipts")
+        lambda args, _root, **_kwargs: subprocess.CompletedProcess(
+            args=args,
+            returncode=0,
+            stdout=f"{desired_head}\n" if args[:2] == ["rev-parse", "--verify"] else "",
+            stderr="",
         ),
     )
     monkeypatch.setattr(
@@ -1177,6 +1180,152 @@ def test_reconcile_archives_target_pr_receipt_when_pr_merged_at_desired_head(
     assert payload["actions"][0]["reason"] == "matching receipt exists"
     assert handoff.exists()
     assert not (tmp_path / ".aragora" / "automation-outbox-archive").exists()
+
+
+def test_reconcile_keeps_target_pr_receipt_when_requested_base_differs_from_reconciler_base(
+    tmp_path: Path,
+    monkeypatch: Any,
+    capsys: Any,
+) -> None:
+    outbox_dir = tmp_path / ".aragora" / "automation-outbox"
+    receipt_dir = tmp_path / ".aragora" / "automation-receipts"
+    key = "open-pr-codex-target-pr-merged-feature-base"
+    branch = "codex/target-pr-merged-feature-base"
+    desired_head = "abcdef1234567890abcdef1234567890abcdef12"
+    handoff = _write_outbox_handoff(
+        outbox_dir,
+        branch=branch,
+        key=key,
+        local_evidence={
+            "branch": branch,
+            "desired_head_sha": desired_head,
+        },
+    )
+    payload = json.loads(handoff.read_text(encoding="utf-8"))
+    payload["requested_action"] = {
+        "type": "open_pr",
+        "branch": branch,
+        "base": "codex/integration",
+        "desired_head_sha": desired_head,
+    }
+    handoff.write_text(json.dumps(payload), encoding="utf-8")
+    receipt_dir.mkdir(parents=True)
+    (receipt_dir / f"{key}.json").write_text(
+        json.dumps(
+            {
+                "idempotency_key": key,
+                "status": "already_satisfied",
+                "reason": "target_open_pr",
+                "existing_pr_url": "https://github.com/synaptent/aragora/pull/7105",
+                "repo": "synaptent/aragora",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        mod,
+        "_target_pr_state",
+        lambda *_args: {
+            "number": 7105,
+            "state": "MERGED",
+            "headRefOid": desired_head,
+        },
+    )
+    monkeypatch.setattr(
+        mod,
+        "run_git",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("base-mismatched target PR receipt should not inspect git refs")
+        ),
+    )
+    monkeypatch.setattr(mod, "open_pr_heads", lambda *_args: {})
+
+    assert mod.main(["--repo", str(tmp_path), "--base", "origin/main", "--json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["counts"]["satisfied_by_existing_receipt"] == 0
+    assert payload["counts"]["blocked_receipt_pr_head_mismatch"] == 1
+    assert payload["counts"]["still_protecting_active_work"] == 1
+    assert payload["actions"][0]["decision"] == "keep"
+    assert "not reconciler base origin/main" in payload["actions"][0]["reason"]
+    assert handoff.exists()
+
+
+def test_reconcile_keeps_target_pr_receipt_when_desired_head_not_on_reconciler_base(
+    tmp_path: Path,
+    monkeypatch: Any,
+    capsys: Any,
+) -> None:
+    outbox_dir = tmp_path / ".aragora" / "automation-outbox"
+    receipt_dir = tmp_path / ".aragora" / "automation-receipts"
+    key = "open-pr-codex-target-pr-merged-reverted"
+    branch = "codex/target-pr-merged-reverted"
+    desired_head = "abcdef1234567890abcdef1234567890abcdef12"
+    handoff = _write_outbox_handoff(
+        outbox_dir,
+        branch=branch,
+        key=key,
+        local_evidence={
+            "branch": branch,
+            "desired_head_sha": desired_head,
+        },
+    )
+    receipt_dir.mkdir(parents=True)
+    (receipt_dir / f"{key}.json").write_text(
+        json.dumps(
+            {
+                "idempotency_key": key,
+                "status": "already_satisfied",
+                "reason": "target_open_pr",
+                "existing_pr_url": "https://github.com/synaptent/aragora/pull/7105",
+                "repo": "synaptent/aragora",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        mod,
+        "_target_pr_state",
+        lambda *_args: {
+            "number": 7105,
+            "state": "MERGED",
+            "headRefOid": desired_head,
+        },
+    )
+
+    def fake_run_git(
+        args: list[str],
+        _root: Path,
+        *,
+        timeout: int = 60,
+    ) -> subprocess.CompletedProcess[str]:
+        if args[:2] == ["rev-parse", "--verify"]:
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout=f"{desired_head}\n")
+        if args[:2] == ["merge-base", "--is-ancestor"]:
+            return subprocess.CompletedProcess(args=args, returncode=1, stdout="", stderr="")
+        if args[0] == "cherry":
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=0,
+                stdout=f"+ {desired_head}\n",
+                stderr="",
+            )
+        raise AssertionError(f"unexpected git call: {args}")
+
+    monkeypatch.setattr(mod, "run_git", fake_run_git)
+    monkeypatch.setattr(mod, "open_pr_heads", lambda *_args: {})
+
+    assert mod.main(["--repo", str(tmp_path), "--base", "origin/main", "--json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["counts"]["satisfied_by_existing_receipt"] == 0
+    assert payload["counts"]["blocked_receipt_pr_head_mismatch"] == 1
+    assert payload["counts"]["still_protecting_active_work"] == 1
+    assert payload["actions"][0]["decision"] == "keep"
+    assert "not preserved on origin/main" in payload["actions"][0]["reason"]
+    assert handoff.exists()
 
 
 def test_reconcile_keeps_target_pr_receipt_when_merged_pr_head_differs(

--- a/tests/scripts/test_reconcile_automation_outbox.py
+++ b/tests/scripts/test_reconcile_automation_outbox.py
@@ -885,6 +885,90 @@ def test_reconcile_archives_issue_only_pr_handoff_when_merged_pr_proves_head_pre
     )
 
 
+def test_reconcile_keeps_handoff_when_merged_pr_head_is_not_on_current_base(
+    tmp_path: Path,
+    monkeypatch: Any,
+    capsys: Any,
+) -> None:
+    outbox_dir = tmp_path / ".aragora" / "automation-outbox"
+    key = "open-pr-codex-reverted-merged-pr-proof-abc123"
+    branch = "codex/reverted-merged-pr-proof"
+    desired_head = "abcdef1234567890abcdef1234567890abcdef12"
+    handoff = _write_outbox_handoff(
+        outbox_dir,
+        branch=branch,
+        key=key,
+        local_evidence={
+            "branch": branch,
+            "desired_head_sha": desired_head,
+            "worktree": str(tmp_path / "missing-worktree"),
+        },
+    )
+    payload = json.loads(handoff.read_text(encoding="utf-8"))
+    payload["requested_action"] = {
+        "type": "open_or_update_pr",
+        "base": "main",
+        "branch": branch,
+        "desired_head_sha": desired_head,
+    }
+    handoff.write_text(json.dumps(payload), encoding="utf-8")
+
+    monkeypatch.setattr(
+        mod,
+        "build_worktree_reference_preservation_proof",
+        lambda *_args, **_kwargs: {
+            "available": True,
+            "branch": branch,
+            "desired_head_sha": desired_head,
+            "worktree_paths": [str(tmp_path / "missing-worktree")],
+            "worktree_inspections": [
+                {
+                    "path": str(tmp_path / "missing-worktree"),
+                    "absent_noop": True,
+                    "source": "safe_worktree_cleanup.inspect",
+                    "classification": "absent_noop",
+                }
+            ],
+            "upstream_preservation": {
+                "proven": True,
+                "method": "merged_pr_commit_list",
+                "pr_number": 8583,
+                "repo": "synaptent/aragora",
+                "base_ref": "main",
+            },
+        },
+    )
+
+    def fake_run_git(
+        args: list[str],
+        _root: Path,
+        *,
+        timeout: int = 60,
+    ) -> subprocess.CompletedProcess[str]:
+        if args[:2] == ["rev-parse", "--verify"]:
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout=f"{desired_head}\n")
+        if args[:2] == ["merge-base", "--is-ancestor"]:
+            return subprocess.CompletedProcess(args=args, returncode=1, stdout="", stderr="")
+        if args[0] == "cherry":
+            return subprocess.CompletedProcess(
+                args=args, returncode=0, stdout=f"+ {desired_head}\n"
+            )
+        raise AssertionError(f"unexpected git call: {args}")
+
+    monkeypatch.setattr(mod, "run_git", fake_run_git)
+    monkeypatch.setattr(mod, "check_github_cli_health", lambda _root: _ready_github())
+    monkeypatch.setattr(mod, "open_pr_heads", lambda *_args: {})
+
+    assert mod.main(["--repo", str(tmp_path), "--json"]) == 0
+
+    result = json.loads(capsys.readouterr().out)
+    assert result["counts"]["satisfied_by_merged_pr_commit_proof"] == 0
+    assert result["counts"]["still_protecting_active_work"] == 1
+    assert result["actions"][0]["decision"] == "keep"
+    assert "actively protecting" in result["actions"][0]["reason"]
+    assert handoff.exists()
+
+
 def test_reconcile_keeps_target_pr_receipt_when_desired_head_not_published(
     tmp_path: Path,
     monkeypatch: Any,

--- a/tests/scripts/test_reconcile_automation_outbox.py
+++ b/tests/scripts/test_reconcile_automation_outbox.py
@@ -1111,6 +1111,69 @@ def test_reconcile_keeps_existing_pr_receipt_when_desired_head_not_published(
     assert not (tmp_path / ".aragora" / "automation-outbox-archive").exists()
 
 
+def test_reconcile_keeps_existing_pr_receipt_when_requested_base_differs_from_reconciler_base(
+    tmp_path: Path,
+    monkeypatch: Any,
+    capsys: Any,
+) -> None:
+    outbox_dir = tmp_path / ".aragora" / "automation-outbox"
+    receipt_dir = tmp_path / ".aragora" / "automation-receipts"
+    key = "open-pr-codex-existing-pr-feature-base"
+    branch = "codex/existing-pr-feature-base"
+    desired_head = "abcdef1234567890abcdef1234567890abcdef12"
+    handoff = _write_outbox_handoff(
+        outbox_dir,
+        branch=branch,
+        key=key,
+        local_evidence={
+            "branch": branch,
+            "desired_head_sha": desired_head,
+        },
+    )
+    payload = json.loads(handoff.read_text(encoding="utf-8"))
+    payload["requested_action"] = {
+        "type": "open_pr",
+        "branch": branch,
+        "base": "codex/integration",
+        "desired_head_sha": desired_head,
+    }
+    handoff.write_text(json.dumps(payload), encoding="utf-8")
+    receipt_dir.mkdir(parents=True)
+    (receipt_dir / f"{key}.json").write_text(
+        json.dumps(
+            {
+                "idempotency_key": key,
+                "status": "already_satisfied",
+                "reason": "existing_pr",
+                "existing_pr_url": "https://github.com/synaptent/aragora/pull/7475",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(mod, "_target_pr_state", lambda *_args: None)
+    monkeypatch.setattr(
+        mod,
+        "run_git",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("base-mismatched existing PR receipt should not inspect git refs")
+        ),
+    )
+    monkeypatch.setattr(mod, "open_pr_heads", lambda *_args: {})
+
+    assert mod.main(["--repo", str(tmp_path), "--base", "origin/main", "--json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["counts"]["blocked_receipt_pr_head_mismatch"] == 1
+    assert payload["counts"]["satisfied_by_existing_receipt"] == 0
+    assert payload["counts"]["still_protecting_active_work"] == 1
+    assert payload["actions"][0]["decision"] == "keep"
+    assert "existing_pr receipt targets base codex/integration" in payload["actions"][0]["reason"]
+    assert "not reconciler base origin/main" in payload["actions"][0]["reason"]
+    assert handoff.exists()
+    assert not (tmp_path / ".aragora" / "automation-outbox-archive").exists()
+
+
 def test_reconcile_archives_target_pr_receipt_when_pr_merged_at_desired_head(
     tmp_path: Path,
     monkeypatch: Any,

--- a/tests/scripts/test_reconcile_automation_outbox.py
+++ b/tests/scripts/test_reconcile_automation_outbox.py
@@ -2021,6 +2021,49 @@ def test_landed_branch_archives_without_github_lookup(
     )
 
 
+def test_landed_branch_keeps_when_requested_base_differs_from_reconciler_base(
+    tmp_path: Path,
+    monkeypatch: Any,
+    capsys: Any,
+) -> None:
+    outbox_dir = tmp_path / ".aragora" / "automation-outbox"
+    key = "open-pr-codex-feature-base-landed-abc123"
+    branch = "codex/feature-base-landed"
+    handoff = _write_outbox_handoff(outbox_dir, branch=branch, key=key)
+    payload = json.loads(handoff.read_text(encoding="utf-8"))
+    payload["requested_action"] = {
+        "type": "open_pr",
+        "branch": branch,
+        "base": "codex/feature-integration",
+    }
+    handoff.write_text(json.dumps(payload), encoding="utf-8")
+
+    def fake_run_git(
+        args: list[str],
+        _root: Path,
+        *,
+        timeout: int = 60,
+    ) -> subprocess.CompletedProcess[str]:
+        if args[:2] == ["rev-parse", "--verify"]:
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout="abc123\n")
+        if args[:2] == ["merge-base", "--is-ancestor"]:
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+        raise AssertionError(f"unexpected git call: {args}")
+
+    monkeypatch.setattr(mod, "run_git", fake_run_git)
+    monkeypatch.setattr(mod, "check_github_cli_health", lambda _root: _ready_github())
+    monkeypatch.setattr(mod, "open_pr_heads", lambda *_args: {})
+
+    assert mod.main(["--repo", str(tmp_path), "--json"]) == 0
+
+    result = json.loads(capsys.readouterr().out)
+    assert result["counts"]["satisfied_by_landed_on_main"] == 0
+    assert result["counts"]["still_protecting_active_work"] == 1
+    assert result["actions"][0]["decision"] == "keep"
+    assert "actively protecting" in result["actions"][0]["reason"]
+    assert handoff.exists()
+
+
 def test_patch_equivalent_target_pr_receipt_archives_before_remote_check(
     tmp_path: Path,
     monkeypatch: Any,

--- a/tests/scripts/test_reconcile_automation_outbox.py
+++ b/tests/scripts/test_reconcile_automation_outbox.py
@@ -1341,11 +1341,14 @@ def test_unique_branch_archives_when_desired_head_is_patch_equivalent_to_main(
     ) -> subprocess.CompletedProcess[str]:
         if args == ["rev-parse", "--verify", branch]:
             return subprocess.CompletedProcess(args=args, returncode=0, stdout=f"{desired_head}\n")
+        if args == ["rev-parse", "--verify", desired_head]:
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout=f"{desired_head}\n")
         if args[:2] == ["merge-base", "--is-ancestor"]:
             return subprocess.CompletedProcess(args=args, returncode=1, stdout="", stderr="")
         if args[0] == "cherry":
+            status = "-" if args[2] == desired_head else "+"
             return subprocess.CompletedProcess(
-                args=args, returncode=0, stdout=f"- {desired_head}\n"
+                args=args, returncode=0, stdout=f"{status} {desired_head}\n"
             )
         raise AssertionError(f"unexpected git call: {args}")
 
@@ -1382,12 +1385,10 @@ def test_unique_branch_archives_when_desired_head_is_patch_equivalent_to_main(
     assert mod.main(["--repo", str(tmp_path), "--json"]) == 0
 
     payload = json.loads(capsys.readouterr().out)
-    assert payload["counts"]["satisfied_by_landed_on_main"] == 1
+    assert payload["counts"]["satisfied_by_merged_pr_commit_proof"] == 1
     assert payload["counts"]["still_protecting_active_work"] == 0
     assert payload["actions"][0]["decision"] == "archive"
-    assert (
-        payload["actions"][0]["reason"] == "branch work landed on main (merge or patch-equivalent)"
-    )
+    assert "merged PR commit list (PR #8583)" in payload["actions"][0]["reason"]
 
 
 def test_unique_branch_keeps_when_preservation_proof_is_remote_branch_only(
@@ -1506,6 +1507,106 @@ def test_merged_pr_preservation_proof_rejects_non_base_pr(
     assert proof is None
 
 
+def test_merged_pr_preservation_proof_rejects_reverted_desired_head(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    branch = "codex/reverted-merged-proof"
+    desired_head = "abcdef1234567890abcdef1234567890abcdef12"
+    payload = {
+        "requested_action": {"type": "open_pr", "branch": branch, "base": "main"},
+        "local_evidence": {
+            "branch": branch,
+            "desired_head_sha": desired_head,
+            "worktree": str(tmp_path / "missing-worktree"),
+        },
+    }
+
+    def fake_run_git(
+        args: list[str],
+        _root: Path,
+        *,
+        timeout: int = 60,
+    ) -> subprocess.CompletedProcess[str]:
+        if args[:2] == ["rev-parse", "--verify"]:
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout=f"{desired_head}\n")
+        if args[:2] == ["merge-base", "--is-ancestor"]:
+            return subprocess.CompletedProcess(args=args, returncode=1, stdout="", stderr="")
+        if args[0] == "cherry":
+            return subprocess.CompletedProcess(
+                args=args, returncode=0, stdout=f"+ {desired_head}\n"
+            )
+        raise AssertionError(f"unexpected git call: {args}")
+
+    monkeypatch.setattr(mod, "run_git", fake_run_git)
+    monkeypatch.setattr(
+        mod,
+        "build_worktree_reference_preservation_proof",
+        lambda *_args, **_kwargs: {
+            "available": True,
+            "branch": branch,
+            "desired_head_sha": desired_head,
+            "worktree_paths": [str(tmp_path / "missing-worktree")],
+            "upstream_preservation": {
+                "proven": True,
+                "method": "merged_pr_commit_list",
+                "pr_number": 8583,
+                "repo": "synaptent/aragora",
+                "base_ref": "main",
+            },
+        },
+    )
+
+    proof = mod._merged_pr_commit_preservation_proof(
+        root=tmp_path,
+        state_root=tmp_path,
+        payload=payload,
+        branch=branch,
+        repo_name="synaptent/aragora",
+        base="origin/main",
+    )
+
+    assert proof is None
+
+
+def test_merged_pr_preservation_proof_rejects_head_only_base_mismatch(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    branch = "codex/head-only-feature-base"
+    desired_head = "abcdef1234567890abcdef1234567890abcdef12"
+    payload = {
+        "requested_action": {
+            "type": "open_pr",
+            "branch": branch,
+            "base": "codex/feature-integration",
+        },
+        "local_evidence": {
+            "branch": branch,
+            "desired_head_sha": desired_head,
+        },
+    }
+
+    monkeypatch.setattr(
+        mod,
+        "build_worktree_reference_preservation_proof",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("base mismatch should fail before worktree proof")
+        ),
+    )
+
+    proof = mod._merged_pr_commit_preservation_proof(
+        root=tmp_path,
+        state_root=tmp_path,
+        payload=payload,
+        branch=branch,
+        repo_name="synaptent/aragora",
+        base="origin/main",
+    )
+
+    assert proof is None
+
+
 def test_merged_pr_preservation_proof_checks_all_local_evidence_worktrees(
     tmp_path: Path,
     monkeypatch: Any,
@@ -1608,11 +1709,14 @@ def test_unique_branch_archives_when_merged_pr_proof_is_squash_merged(
     ) -> subprocess.CompletedProcess[str]:
         if args == ["rev-parse", "--verify", branch]:
             return subprocess.CompletedProcess(args=args, returncode=0, stdout=f"{desired_head}\n")
+        if args == ["rev-parse", "--verify", desired_head]:
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout=f"{desired_head}\n")
         if args[:2] == ["merge-base", "--is-ancestor"]:
             return subprocess.CompletedProcess(args=args, returncode=1, stdout="", stderr="")
         if args[0] == "cherry":
+            status = "-" if args[2] == desired_head else "+"
             return subprocess.CompletedProcess(
-                args=args, returncode=0, stdout=f"+ {desired_head}\n"
+                args=args, returncode=0, stdout=f"{status} {desired_head}\n"
             )
         raise AssertionError(f"unexpected git call: {args}")
 


### PR DESCRIPTION
## Summary
- fail closed when an outbox handoff requests a base different from the reconciler base
- require merged-PR preservation proofs to show the desired head is still present or patch-equivalent on the current base before archiving
- add regressions for reverted desired heads and head-only base mismatches

## Validation
- `python3 -m pytest tests/scripts/test_reconcile_automation_outbox.py tests/scripts/test_identify_lane_owner.py -q`
- `pre-commit run --files scripts/reconcile_automation_outbox.py tests/scripts/test_reconcile_automation_outbox.py`
