### PR TITLE
fix(review-queue): classify crypto dependency signing changes as Tier 4

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -271,6 +271,39 @@ TIER_4_PREFIXES: tuple[str, ...] = (
     "scripts/settle_one_pr.py",
     "scripts/merge_codex_automation_prs.py",
 )
+TIER_4_CRYPTO_PATH_MARKERS: tuple[str, ...] = (
+    "crypto",
+    "cryptography",
+    "mldsa",
+    "ml_dsa",
+    "odr_signing",
+    "signature",
+    "signing",
+)
+TIER_4_CRYPTO_METADATA_MARKERS: tuple[str, ...] = (
+    "cryptography",
+    "ed25519",
+    "fips 204",
+    "mldsa",
+    "ml-dsa",
+    "ml_dsa",
+    "post-quantum",
+    "pqc",
+    "quantum",
+    "receipt signing",
+    "signature",
+    "signing",
+)
+TIER_4_DEPENDENCY_BUMP_MARKERS: tuple[str, ...] = (
+    "dependency",
+    "dep bump",
+    "floor bump",
+    "floor bumped",
+    "floor raised",
+    "major bump",
+    "major-version",
+    "upgrade",
+)
 PARKED_LABELS: tuple[str, ...] = ("stale", "do-not-merge", "wip", "blocked")
 MERGE_QUORUM_CHECK_NAME = "aragora-merge-quorum"
 MERGE_QUORUM_WORKFLOW_NAME = "Aragora Merge Quorum"
@@ -3377,10 +3410,21 @@ def _classify_model_review_tier(
 ) -> tuple[int, str, str]:
     normalized = [path.strip() for path in files if path.strip()]
     title = str((pr or {}).get("title", "") or "").lower()
+    body = str((pr or {}).get("body", "") or "").lower()
     if not normalized:
         return (1, "tier_1_additive_internal", "no changed files reported; defaulting to Tier 1")
     if any(_matches_prefix(path, TIER_4_PREFIXES) for path in normalized):
         return (4, "tier_4_preapproval_required", "workflow/deploy/destructive surface touched")
+    if _touches_approval_required_crypto_or_dependency_surface(
+        normalized,
+        title=title,
+        body=body,
+    ):
+        return (
+            4,
+            "tier_4_preapproval_required",
+            "approval-required dependency or cryptographic signing surface touched",
+        )
     if any(_matches_prefix(path, TIER_3_PREFIXES) for path in normalized) or any(
         keyword in title for keyword in TIER_3_TITLE_KEYWORDS
     ):
@@ -3400,6 +3444,37 @@ def _classify_model_review_tier(
             "live automation, CLI, observability, retry, or cache surface touched",
         )
     return (1, "tier_1_additive_internal", "bounded internal code surface")
+
+
+def _touches_approval_required_crypto_or_dependency_surface(
+    files: list[str],
+    *,
+    title: str,
+    body: str,
+) -> bool:
+    """Fail closed on approval-required crypto/signing and major dependency signals.
+
+    The merge-packet path has PR metadata and changed-file paths, not a full diff.
+    This therefore only classifies surfaces it can prove from those inputs: source
+    paths that are themselves crypto/signing surfaces, and dependency files paired
+    with explicit PR title/body metadata naming a crypto or major-version bump.
+    """
+
+    source_paths = [
+        path.lower()
+        for path in files
+        if not _is_docs_tests_or_status_path(path) and path.lower() != "pyproject.toml"
+    ]
+    if any(marker in path for path in source_paths for marker in TIER_4_CRYPTO_PATH_MARKERS):
+        return True
+
+    metadata = f"{title}\n{body}"
+    touches_dependency_manifest = any(path.lower() == "pyproject.toml" for path in files)
+    if not touches_dependency_manifest:
+        return False
+    if any(marker in metadata for marker in TIER_4_CRYPTO_METADATA_MARKERS):
+        return True
+    return any(marker in metadata for marker in TIER_4_DEPENDENCY_BUMP_MARKERS)
 
 
 def _tier_requirement(tier: int) -> dict[str, Any]:

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -1085,6 +1085,43 @@ class TestModelReviewQuorum:
         assert tier == 3
         assert "semantic" in reason
 
+    def test_crypto_receipt_signing_surface_requires_tier_four(self) -> None:
+        files = [
+            "aragora/gauntlet/odr_signing.py",
+            "pyproject.toml",
+            "tests/gauntlet/test_odr_mldsa_hybrid.py",
+        ]
+        pr = _make_pr(
+            title="feat(gauntlet): post-quantum hybrid ODR receipt signing",
+            files=files,
+            body="Raises cryptography floor to >=49 for FIPS 204 ML-DSA-65 signing.",
+        )
+        tier, tier_name, reason = _classify_model_review_tier(files, pr=pr)
+        assert tier == 4
+        assert tier_name == "tier_4_preapproval_required"
+        assert "cryptographic signing" in reason
+
+    def test_pyproject_crypto_dependency_floor_requires_tier_four(self) -> None:
+        files = ["pyproject.toml"]
+        pr = _make_pr(
+            title="chore(deps): raise cryptography floor",
+            files=files,
+            body="Floor bumped from 48.0.1 to 49 for ML-DSA support.",
+        )
+        tier, _, reason = _classify_model_review_tier(files, pr=pr)
+        assert tier == 4
+        assert "dependency" in reason
+
+    def test_non_security_additive_internal_code_remains_tier_one(self) -> None:
+        files = ["aragora/agents/router.py"]
+        tier, tier_name, reason = _classify_model_review_tier(
+            files,
+            pr=_make_pr(title="feat(router): add internal helper", files=files),
+        )
+        assert tier == 1
+        assert tier_name == "tier_1_additive_internal"
+        assert "bounded internal" in reason
+
     def test_tier_zero_satisfied_by_one_dogfood_note(self) -> None:
         pr = _make_pr(files=["docs/status/report.md"])
         pr["comments"] = [_dogfood_comment()]
@@ -1784,6 +1821,32 @@ class TestModelReviewQuorum:
         assert quorum["status"] == "human_risk_settlement_required"
         assert quorum["admin_squash_allowed"] is False
         assert quorum["requires_human_risk_settlement"] is True
+
+    def test_crypto_dependency_quorum_requires_human_risk_settlement(self) -> None:
+        files = [
+            "aragora/gauntlet/odr_signing.py",
+            "pyproject.toml",
+            "tests/gauntlet/test_odr_mldsa_hybrid.py",
+        ]
+        pr = _make_pr(
+            title="feat(gauntlet): post-quantum hybrid ODR receipt signing",
+            files=files,
+            body="Raises cryptography floor to >=49 for FIPS 204 ML-DSA-65 signing.",
+        )
+        pr["comments"] = [_dogfood_comment()]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=files,
+            protocol=_executed_protocol(),
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+        )
+        assert quorum["tier"] == 4
+        assert quorum["status"] == "human_preapproval_required"
+        assert quorum["admin_squash_allowed"] is False
+        assert quorum["requires_human_risk_settlement"] is True
+        assert quorum["requires_human_preapproval"] is True
 
     def test_tier_three_human_risk_settlement_allows_admin_squash(self) -> None:
         pr = _make_pr(files=["aragora/reputation/store.py"])


### PR DESCRIPTION
## Summary

Fail closed on approval-required crypto/signing and dependency-bump surfaces in the review-queue tier classifier.

This repairs the live #8608 shape where merge-packet/settle_one previously classified a PR as Tier 1 even though it:
- raises the `cryptography` dependency floor to `>=49`
- adds long-lived ODR receipt signing crypto (`Ed25519` + `ML-DSA-65`)
- therefore falls under the operating-contract approval-required surface for major dependency bumps and security/crypto signing work

## Scope

Changed only:
- `aragora/cli/commands/review_queue.py`
- `tests/cli/commands/test_review_queue.py`

The classifier now marks as Tier 4 when PR metadata/file paths prove one of these surfaces:
- crypto/signing source path, excluding tests/docs-only paths
- `pyproject.toml` paired with explicit crypto/security/signing or dependency-bump metadata in title/body

It preserves Tier 0-2 behavior for ordinary non-security internal code.

## Live Reproduction

Before this repair, live #8608 at head `ff30732c4232f24e035c44238f7143a3732302ce` reported:
- `tier=1`
- `requires_human_risk_settlement=false`
- blocker only missing model evidence/quorum

With this branch, live #8608 rechecks classify the current head as:
- `tier=4`
- `tier_name=tier_4_preapproval_required`
- `requires_human_risk_settlement=true`
- `requires_human_preapproval=true`
- reason: `approval-required dependency or cryptographic signing surface touched`

#8608 head moved during the recheck, but the patched classifier still produced the Tier 4 result against the new live head.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/cli/commands/test_review_queue.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

