### PR TITLE
fix(lanes): enforce dispatch lease conflicts

### DIFF
--- a/aragora/swarm/lane_conductor.py
+++ b/aragora/swarm/lane_conductor.py
@@ -184,11 +184,6 @@ def plan_pass(
 # ---------------------------------------------------------------------------
 
 
-# Owner-liveness assessments (from identify_lane_owner) that mean the lane is
-# NOT actively held, so a stale row holding it may be released and reclaimed.
-_RECLAIMABLE_ASSESSMENTS = {"stale", "terminal", "absent", "reclaimable"}
-
-
 def _run_lane_claim(work_order: WorkOrderSpec, root: Path) -> subprocess.CompletedProcess | None:
     """Run one PLAIN lane claim (no --force). None on spawn/timeout failure."""
     try:
@@ -220,88 +215,20 @@ def _run_lane_claim(work_order: WorkOrderSpec, root: Path) -> subprocess.Complet
         return None
 
 
-def _release_stale_conflict(pr: int, root: Path) -> bool:
-    """Release PR #``pr``'s current lane owner IFF it is assessed reclaimable.
-
-    claim_lane's conflict check is status-based, not heartbeat-based, so a
-    stale-but-still-``active`` row blocks a plain claim. We clear it only when
-    identify_lane_owner assesses the owner stale/terminal/absent -- NEVER a live
-    owner -- so a competing live worker is never displaced (the blind---force
-    clobber race is avoided). Returns True if a stale owner was released.
-    """
-    try:
-        probe = subprocess.run(
-            [
-                "python3",
-                str(root / "scripts" / "identify_lane_owner.py"),
-                "--pr",
-                str(pr),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=30,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return False
-    if probe.returncode != 0 or not probe.stdout.strip():
-        return False
-    try:
-        data = json.loads(probe.stdout)
-    except json.JSONDecodeError:
-        return False
-    owner = str(data.get("owner_session") or "").strip()
-    liveness = data.get("owner_liveness")
-    assessed = (
-        str((liveness.get("assessed") if isinstance(liveness, dict) else "") or "").strip().lower()
-    )
-    if not owner or assessed not in _RECLAIMABLE_ASSESSMENTS:
-        return False  # no owner, or owner is LIVE -> never release / never displace
-    try:
-        rel = subprocess.run(
-            [
-                "python3",
-                str(root / "scripts" / "claim_active_agent_lane.py"),
-                "--release-stale",
-                "--owner-session",
-                owner,
-                "--pr-number",
-                str(pr),
-                "--ttl-minutes",
-                "0",
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=30,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return False
-    return rel.returncode == 0
-
-
 def default_claim(work_order: WorkOrderSpec, *, repo_root: Path | None = None) -> bool:
     """Claim the lane via scripts/claim_active_agent_lane.py.
 
-    Plain claim first (no --force): claim_lane's identity-conflict check then
-    provides mutual exclusion, so a competing LIVE claim makes this fail and we
-    never double-dispatch. If it fails because a STALE row holds the resource,
-    release that stale row (only when its owner is assessed reclaimable) and retry
-    once. This reclaims stale lanes without the blind-force clobber race that
-    could overwrite a newly-live owner.
+    Plain claim only (no --force and no stale-owner release): claim_lane's
+    identity-conflict check provides mutual exclusion. If a stale or ambiguous
+    row still holds the PR, dispatch fails closed until an explicit release or
+    conservative reconciler receipt has already changed that row to a
+    non-blocking terminal status.
     """
     root = repo_root or Path.cwd()
     proc = _run_lane_claim(work_order, root)
     if proc is None:
         return False
-    if proc.returncode == 0:
-        return True
-    # Claim refused -- if a stale row is holding this PR, clear it and retry once.
-    if _release_stale_conflict(work_order.pr, root):
-        retry = _run_lane_claim(work_order, root)
-        return retry is not None and retry.returncode == 0
-    return False
+    return proc.returncode == 0
 
 
 def default_dispatch(work_order: WorkOrderSpec, *, repo_root: Path | None = None) -> str:

--- a/aragora/swarm/lane_dispatcher.py
+++ b/aragora/swarm/lane_dispatcher.py
@@ -58,6 +58,8 @@ Assigned lane: PR #{pr} (branch {branch}) in {repo} ONLY.
 --owner-session {session_id} \
 --pr-number {pr} --branch {branch} --source {target_agent} --status active \
 --next-action "advance #{pr}"
+   If the claim command exits non-zero, print "yielding: claim blocked" and \
+STOP -- do not work this PR.
 
 2. GROUND from live state for #{pr} ONLY (gh pr view/checks; \
 review-queue merge-packet --pr {pr} --json). Trust live state, never memory.

--- a/scripts/claim_active_agent_lane.py
+++ b/scripts/claim_active_agent_lane.py
@@ -43,9 +43,9 @@ bootstraps and from any agent):
 - A mutating active claim is also rejected when a different blocking owner
   already claims the same ``pr_number``, ``branch``, or ``worktree``. Blocking
   rows include live/active statuses, conflict rows, and unknown statuses.
-  Terminal rows such as ``released``, ``completed``, and ``superseded`` do not
-  block. Different lane IDs cannot silently duplicate work on the same PR or
-  branch. Read-only observers can opt into report-only claim creation with
+  Terminal rows such as ``released``, ``completed``, ``expired``, and
+  ``superseded`` do not block. Different lane IDs cannot silently duplicate work
+  on the same PR or branch. Read-only observers can opt into report-only claim creation with
   ``--allow-resource-conflicts``.
 - Never deletes rows. Never writes a lane row with a missing
   ``lane_id`` or empty ``owner_session``.
@@ -108,6 +108,7 @@ ALLOWED_STATUSES = (
     "blocked",
     "released",
     "completed",
+    "expired",
     "superseded",
     "conflict",
 )
@@ -154,7 +155,7 @@ ACTIVE_STATUSES = {
     "working",
     "blocked",
 }
-TERMINAL_NON_BLOCKING_STATUSES = {"released", "completed", "superseded"}
+TERMINAL_NON_BLOCKING_STATUSES = {"released", "completed", "expired", "superseded"}
 
 DEFAULT_ACTIVE_NEXT_ACTION = "unspecified active lane action"
 DEFAULT_STEERING_OUTCOME = "unknown"

--- a/scripts/claim_active_agent_lane.py
+++ b/scripts/claim_active_agent_lane.py
@@ -40,10 +40,12 @@ bootstraps and from any agent):
   same ``lane_id`` from a *different* ``owner_session`` is rejected
   unless ``--force`` is supplied; the helper exits 2 and prints a
   conflict hint so the caller can pick a different lane name or wait.
-- A mutating active claim is also rejected when a different active owner
-  already claims the same ``pr_number``, ``branch``, or ``worktree``.
-  Different lane IDs cannot silently duplicate work on the same PR or branch.
-  Read-only observers can opt into report-only claim creation with
+- A mutating active claim is also rejected when a different blocking owner
+  already claims the same ``pr_number``, ``branch``, or ``worktree``. Blocking
+  rows include live/active statuses, conflict rows, and unknown statuses.
+  Terminal rows such as ``released``, ``completed``, and ``superseded`` do not
+  block. Different lane IDs cannot silently duplicate work on the same PR or
+  branch. Read-only observers can opt into report-only claim creation with
   ``--allow-resource-conflicts``.
 - Never deletes rows. Never writes a lane row with a missing
   ``lane_id`` or empty ``owner_session``.
@@ -152,6 +154,7 @@ ACTIVE_STATUSES = {
     "working",
     "blocked",
 }
+TERMINAL_NON_BLOCKING_STATUSES = {"released", "completed", "superseded"}
 
 DEFAULT_ACTIVE_NEXT_ACTION = "unspecified active lane action"
 DEFAULT_STEERING_OUTCOME = "unknown"
@@ -294,7 +297,8 @@ def _active_identity_conflict(
     if not requested or str(normalized.get("status") or "") not in ACTIVE_STATUSES:
         return None
     for existing in rows:
-        if str(existing.get("status") or "") not in ACTIVE_STATUSES:
+        existing_status = str(existing.get("status") or "").strip()
+        if existing_status in TERMINAL_NON_BLOCKING_STATUSES:
             continue
         existing_owner = str(existing.get("owner_session") or "")
         if not existing_owner or existing_owner == owner_session:
@@ -557,7 +561,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--allow-resource-conflicts",
         action="store_true",
         help=(
-            "Allow a claim even if another active owner claims the same "
+            "Allow a claim even if another blocking owner claims the same "
             "pr_number, branch, or worktree. Default is fail-closed for "
             "mutating lane ownership."
         ),

--- a/scripts/identify_lane_owner.py
+++ b/scripts/identify_lane_owner.py
@@ -150,7 +150,7 @@ ACTIVE_STATUSES = {
     "blocked",
 }
 CONFLICT_STATUSES = {"conflict", "conflicting"}
-COMPLETED_STATUSES = {"completed", "released", "superseded"}
+COMPLETED_STATUSES = {"completed", "released", "superseded", "expired"}
 
 # Subprocess timeout for ``agent_bridge operator-snapshot``.
 SNAPSHOT_TIMEOUT_SECONDS = 30
@@ -1211,8 +1211,8 @@ def build_owner_info(
 STALE_HOURS_DEFAULT = 6.0
 LANE_RUNS_GLOB_DEFAULT = str(STATE_ROOT_DEFAULT / "run-*" / "lanes")
 
-# Lane-ledger statuses meaning the owning lane can no longer be working.
-TERMINAL_LANE_STATUSES = {"completed", "failed", "cancelled", "dead"}
+# Lane-ledger/status rows meaning the owning lane can no longer be working.
+TERMINAL_LANE_STATUSES = COMPLETED_STATUSES | {"failed", "cancelled", "dead"}
 
 STALE_CLAIM_PROTOCOL = "stale-claim-override"
 ADVISORY_WITHHELD_UNPUSHED = "possible_unpushed_work"
@@ -1824,10 +1824,15 @@ def assess_owner_liveness(
     now_dt = now or datetime.now(timezone.utc)
     threshold_seconds = max(0.0, stale_hours) * 3600.0
 
-    # lane_status: the lane ledger's view of the owning lane.
+    # lane_status: the lane ledger's view of the owning lane. When no ledger
+    # exists, a terminal registry status is still enough to avoid treating the
+    # row as an active owner lease.
     lane_status = "unknown"
+    registry_status = str(lane.get("status") or "").strip().lower()
     if ledger_entry is not None:
         lane_status = str(ledger_entry.get("status") or "").strip().lower() or "unknown"
+    elif registry_status in COMPLETED_STATUSES:
+        lane_status = registry_status
 
     # last_heartbeat_at: matched heartbeat row first, then owner record,
     # then ledger heartbeat fields; null when nothing carries one.

--- a/scripts/lane_conductor.py
+++ b/scripts/lane_conductor.py
@@ -53,10 +53,15 @@ from scripts.lane_supervisor import _worker_launcher_launch  # noqa: E402
 # mergeStateStatus values that mean "open and waiting on checks/quorum/settlement"
 # -- i.e. a candidate the swarm can usefully advance. CLEAN/DIRTY/DRAFT excluded.
 _BLOCKED_STATES = {"BLOCKED", "UNSTABLE"}
-# Owner-liveness assessments that mean the lane is NOT actively held, so it is
-# reassignable. Anything else (including unknown) is treated as live -- the
+# Owner blocking-state values that mean the lane is NOT actively held, so it is
+# reassignable. Anything else (including stale/unknown) is treated as live -- the
 # fail-safe direction is to avoid double-dispatching a possibly-live lane.
-_RECLAIMABLE_ASSESSMENTS = {"stale", "terminal", "absent", "reclaimable"}
+_RECLAIMABLE_OWNER_BLOCKING_STATES = {"stale_terminal_owner", "absent", "reclaimable"}
+
+# Compatibility for older identify_lane_owner output that predates
+# owner_blocking_state. Plain "stale" remains blocking until a reconciler/sweeper
+# has made the row terminal.
+_RECLAIMABLE_LEGACY_ASSESSMENTS = {"terminal", "absent", "reclaimable"}
 _UNKNOWN_OWNER = "owner-liveness-unavailable"
 # Per-probe timeout kept short: a single slow identify_lane_owner must not stall
 # the whole pass. Probes run concurrently across candidates (one slow probe no
@@ -178,11 +183,17 @@ def _resolve_owner(pr: int) -> tuple[int, str | None]:
     owner = str(data.get("owner_session") or "").strip()
     if not owner:
         return pr, None
+    owner_blocking_state = str(data.get("owner_blocking_state") or "").strip().lower()
+    if owner_blocking_state in _RECLAIMABLE_OWNER_BLOCKING_STATES:
+        return pr, None
+    if owner_blocking_state:
+        return pr, owner
+
     liveness = data.get("owner_liveness")
     assessment = (
         str((liveness.get("assessed") if isinstance(liveness, dict) else "") or "").strip().lower()
     )
-    if assessment in _RECLAIMABLE_ASSESSMENTS:
+    if assessment in _RECLAIMABLE_LEGACY_ASSESSMENTS:
         return pr, None
     return pr, owner
 

--- a/tests/scripts/test_claim_active_agent_lane.py
+++ b/tests/scripts/test_claim_active_agent_lane.py
@@ -188,6 +188,56 @@ def test_different_lane_same_branch_is_rejected_by_default(tmp_registry: Path) -
     assert "branch='worktree-codex-insights' already claimed" in str(excinfo.value)
 
 
+def test_different_lane_same_branch_with_conflict_status_is_rejected(
+    tmp_registry: Path,
+) -> None:
+    claim_module.claim_lane(
+        registry_path=tmp_registry,
+        lane_id="lane-a",
+        owner_session="codex-A",
+        status="conflict",
+        branch="worktree-codex-insights",
+    )
+
+    with pytest.raises(claim_module.ClaimError) as excinfo:
+        claim_module.claim_lane(
+            registry_path=tmp_registry,
+            lane_id="lane-b",
+            owner_session="codex-B",
+            branch="worktree-codex-insights",
+        )
+
+    assert "branch='worktree-codex-insights' already claimed" in str(excinfo.value)
+
+
+def test_different_lane_same_branch_with_unknown_status_is_rejected(
+    tmp_registry: Path,
+) -> None:
+    tmp_registry.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "lane-a",
+                    "owner_session": "codex-A",
+                    "status": "mystery",
+                    "branch": "worktree-codex-insights",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(claim_module.ClaimError) as excinfo:
+        claim_module.claim_lane(
+            registry_path=tmp_registry,
+            lane_id="lane-b",
+            owner_session="codex-B",
+            branch="worktree-codex-insights",
+        )
+
+    assert "branch='worktree-codex-insights' already claimed" in str(excinfo.value)
+
+
 def test_different_lane_same_worktree_is_rejected_by_default(
     tmp_registry: Path,
 ) -> None:
@@ -245,6 +295,30 @@ def test_released_lane_identity_does_not_block_new_owner(tmp_registry: Path) -> 
 
     payload = json.loads(tmp_registry.read_text(encoding="utf-8"))
     assert len(payload) == 2
+
+
+def test_superseded_lane_identity_does_not_block_new_owner_after_reconciliation(
+    tmp_registry: Path,
+) -> None:
+    claim_module.claim_lane(
+        registry_path=tmp_registry,
+        lane_id="lane-a",
+        owner_session="codex-A",
+        status="superseded",
+        pr_number=7245,
+        branch="codex/pr7245",
+    )
+    claim_module.claim_lane(
+        registry_path=tmp_registry,
+        lane_id="lane-b",
+        owner_session="codex-B",
+        pr_number=7245,
+        branch="codex/pr7245",
+    )
+
+    payload = {row["lane_id"]: row for row in json.loads(tmp_registry.read_text())}
+    assert payload["lane-a"]["status"] == "superseded"
+    assert payload["lane-b"]["status"] == "active"
 
 
 def test_other_lanes_are_preserved_during_claim(tmp_registry: Path) -> None:

--- a/tests/scripts/test_claim_active_agent_lane.py
+++ b/tests/scripts/test_claim_active_agent_lane.py
@@ -297,6 +297,30 @@ def test_released_lane_identity_does_not_block_new_owner(tmp_registry: Path) -> 
     assert len(payload) == 2
 
 
+def test_expired_lane_identity_does_not_block_new_owner_after_sweep(
+    tmp_registry: Path,
+) -> None:
+    claim_module.claim_lane(
+        registry_path=tmp_registry,
+        lane_id="lane-a",
+        owner_session="codex-A",
+        status="expired",
+        pr_number=7245,
+        branch="codex/pr7245",
+    )
+    claim_module.claim_lane(
+        registry_path=tmp_registry,
+        lane_id="lane-b",
+        owner_session="codex-B",
+        pr_number=7245,
+        branch="codex/pr7245",
+    )
+
+    payload = {row["lane_id"]: row for row in json.loads(tmp_registry.read_text())}
+    assert payload["lane-a"]["status"] == "expired"
+    assert payload["lane-b"]["status"] == "active"
+
+
 def test_superseded_lane_identity_does_not_block_new_owner_after_reconciliation(
     tmp_registry: Path,
 ) -> None:

--- a/tests/scripts/test_identify_lane_owner.py
+++ b/tests/scripts/test_identify_lane_owner.py
@@ -223,6 +223,27 @@ class TestLoadAndFind:
         assert r is not None
         assert r["lane_id"] == "newer-released"
 
+    def test_find_by_pr_treats_expired_as_historical(self) -> None:
+        lanes = [
+            {
+                "lane_id": "older-released",
+                "owner_session": "codex-old",
+                "status": "released",
+                "pr_number": 7292,
+                "updated_at": "2026-05-18T04:00:00Z",
+            },
+            {
+                "lane_id": "newer-expired",
+                "owner_session": "codex-expired",
+                "status": "expired",
+                "pr_number": 7292,
+                "updated_at": "2026-05-18T05:00:00Z",
+            },
+        ]
+        r = ilo.find_lane(lanes, pr=7292)
+        assert r is not None
+        assert r["lane_id"] == "newer-expired"
+
 
 class TestHeartbeatSummary:
     def test_build_owner_info_includes_fresh_heartbeat(self, tmp_path: Path) -> None:
@@ -1003,6 +1024,34 @@ class TestBuildOwnerInfo:
             "treat as historical; run fresh cleanup inspection before any deletion"
         )
 
+    def test_owner_state_marks_expired_lane_as_stale_historical(self, tmp_path: Path) -> None:
+        bg = tmp_path / "factory_bg.json"
+        bg.write_text("[]", encoding="utf-8")
+        lane = {
+            "lane_id": "expired-lane",
+            "owner_session": "codex-expired",
+            "status": "expired",
+            "worktree": "/tmp/expired-worktree",
+        }
+
+        info = ilo.build_owner_info(
+            lane,
+            snapshot_provider=lambda: fake_snapshot_records([]),
+            sessions_root=tmp_path / "codex_sessions",
+            projects_root=tmp_path / "claude_projects",
+            bg_path=bg,
+            steering_inbox_root=tmp_path / "steering",
+        )
+
+        assert info.owner_state == "stale"
+        assert info.liveness_state == "missing_heartbeat"
+        assert info.cleanup_state == "historical_requires_cleanup_inspect"
+        assert info.dispatchable is False
+        assert (
+            info.dispatch_blocker == "lane status is expired; claim an active lane before steering"
+        )
+        assert info.owner_state_reason == "lane status is expired"
+
 
 # ---------------------------------------------------------------------------
 # main() CLI
@@ -1333,6 +1382,27 @@ class TestOwnerLeaseLiveness:
             "overriding lane must write an override entry naming the stale lane id"
         )
         assert any("terminal" in c for c in advisory["conditions_met"])
+        assert result["advisory_withheld"] is None
+
+    def test_expired_registry_status_without_ledger_yields_terminal_advisory(self) -> None:
+        lane = {
+            "lane_id": "Q2-expired",
+            "owner_session": "codex-q2",
+            "status": "expired",
+            "branch": "codex/q2-expired",
+            "updated_at": _hours_ago(1.0),
+        }
+        result = ilo.assess_owner_liveness(
+            lane, ledger_entry=None, heartbeat=None, now=_liveness_now()
+        )
+
+        assert result["owner_liveness"]["assessed"] == "terminal"
+        assert result["owner_liveness"]["lane_status"] == "expired"
+        assert result["owner_blocking_state"] == "stale_terminal_owner"
+        advisory = result["stale_claim_advisory"]
+        assert advisory is not None
+        assert advisory["available"] is True
+        assert any("lane_status=expired" in c for c in advisory["conditions_met"])
         assert result["advisory_withheld"] is None
 
     @pytest.mark.parametrize("status", ["failed", "cancelled"])
@@ -2046,6 +2116,49 @@ class TestLivenessCLI:
         assert data["owner_blocking_state"] == "stale_owner"
         assert data["stale_claim_advisory"]["available"] is True
         assert data["stale_claim_advisory"]["protocol"] == "stale-claim-override"
+        assert data["advisory_withheld"] is None
+
+    def test_json_marks_expired_registry_row_as_stale_terminal_owner(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        registry = write_lane_registry(
+            tmp_path,
+            [
+                {
+                    "lane_id": "Q-expired-owner",
+                    "owner_session": "codex-expired",
+                    "source": "codex",
+                    "status": "expired",
+                    "branch": "codex/expired",
+                    "pr_number": 7826,
+                    "updated_at": _hours_ago(1.0),
+                }
+            ],
+        )
+
+        rc = ilo.main(
+            [
+                "--pr",
+                "7826",
+                "--json",
+                "--runs-glob",
+                str(tmp_path / "missing" / "lanes"),
+                "--now",
+                LIVENESS_NOW,
+                *self._cli_args(registry, tmp_path),
+            ]
+        )
+
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["dispatchable"] is False
+        assert data["dispatch_blocker"] == (
+            "lane status is expired; claim an active lane before steering"
+        )
+        assert data["owner_liveness"]["assessed"] == "terminal"
+        assert data["owner_liveness"]["lane_status"] == "expired"
+        assert data["owner_blocking_state"] == "stale_terminal_owner"
+        assert data["stale_claim_advisory"]["available"] is True
         assert data["advisory_withheld"] is None
 
     def test_custom_stale_hours_flag_keeps_owner_live(

--- a/tests/swarm/test_lane_conductor.py
+++ b/tests/swarm/test_lane_conductor.py
@@ -516,11 +516,33 @@ def test_fetch_live_claims_treats_empty_liveness_as_live(monkeypatch: Any) -> No
     assert cli.fetch_live_claims("synaptent/aragora", [_cand(1)]) == {1: "owner-a"}
 
 
-def test_fetch_live_claims_reclaims_explicit_stale_owner(monkeypatch: Any) -> None:
-    payload = {"owner_session": "owner-a", "owner_liveness": {"assessed": "stale"}}
+def test_fetch_live_claims_blocks_explicit_stale_owner(monkeypatch: Any) -> None:
+    payload = {
+        "owner_session": "owner-a",
+        "owner_liveness": {"assessed": "stale"},
+        "owner_blocking_state": "stale_owner",
+    }
+    monkeypatch.setattr(cli.subprocess, "run", lambda *args, **kwargs: _proc(json.dumps(payload)))
+
+    assert cli.fetch_live_claims("synaptent/aragora", [_cand(1)]) == {1: "owner-a"}
+
+
+def test_fetch_live_claims_reclaims_stale_terminal_owner(monkeypatch: Any) -> None:
+    payload = {
+        "owner_session": "owner-a",
+        "owner_liveness": {"assessed": "terminal"},
+        "owner_blocking_state": "stale_terminal_owner",
+    }
     monkeypatch.setattr(cli.subprocess, "run", lambda *args, **kwargs: _proc(json.dumps(payload)))
 
     assert cli.fetch_live_claims("synaptent/aragora", [_cand(1)]) == {}
+
+
+def test_fetch_live_claims_legacy_stale_owner_fails_closed(monkeypatch: Any) -> None:
+    payload = {"owner_session": "owner-a", "owner_liveness": {"assessed": "stale"}}
+    monkeypatch.setattr(cli.subprocess, "run", lambda *args, **kwargs: _proc(json.dumps(payload)))
+
+    assert cli.fetch_live_claims("synaptent/aragora", [_cand(1)]) == {1: "owner-a"}
 
 
 def test_fetch_live_claims_allows_explicit_absent_owner(monkeypatch: Any) -> None:

--- a/tests/swarm/test_lane_conductor.py
+++ b/tests/swarm/test_lane_conductor.py
@@ -276,62 +276,38 @@ def test_default_claim_is_plain_no_force(tmp_path: Path, monkeypatch: Any) -> No
     assert "--allow-resource-conflicts" not in cmd
 
 
-def test_default_claim_releases_stale_then_retries(tmp_path: Path, monkeypatch: Any) -> None:
-    # Claim refused (stale-but-active row holds the resource). The probe assesses
-    # the owner stale, so we release it and retry -- without --force.
+def test_default_claim_does_not_release_stale_owner(tmp_path: Path, monkeypatch: Any) -> None:
+    # Claim refused (stale-but-active row holds the resource). Dispatch must not
+    # clear it itself; stale owners become reassignable only after explicit
+    # release or conservative reconciler supersession.
     wo = _wo_42()
-    seq: list[str] = []
     calls: list[list[str]] = []
 
     def fake_run(cmd: list[str], **kwargs: Any) -> Any:
         calls.append(cmd)
-        script = next((c for c in cmd if c.endswith(".py")), "")
-        if script.endswith("identify_lane_owner.py"):
-            seq.append("probe")
-            return SimpleNamespace(
-                returncode=0,
-                stdout=json.dumps(
-                    {"owner_session": "stale-owner", "owner_liveness": {"assessed": "stale"}}
-                ),
-                stderr="",
-            )
-        if "--release-stale" in cmd:
-            seq.append("release")
-            return SimpleNamespace(returncode=0, stdout="", stderr="")
-        # plain claim: fail first, succeed on retry
-        seq.append("claim")
-        return SimpleNamespace(returncode=0 if seq.count("claim") > 1 else 2, stdout="", stderr="x")
+        return SimpleNamespace(returncode=2, stdout="", stderr="stale conflict")
 
     monkeypatch.setattr(lc.subprocess, "run", fake_run)
-    assert lc.default_claim(wo, repo_root=tmp_path) is True
-    assert seq == ["claim", "probe", "release", "claim"]
-    release_cmd = next(cmd for cmd in calls if "--release-stale" in cmd)
-    assert release_cmd[release_cmd.index("--pr-number") + 1] == str(wo.pr)
+    assert lc.default_claim(wo, repo_root=tmp_path) is False
+    assert len(calls) == 1
+    assert all("--release-stale" not in cmd for cmd in calls)
+    assert all(not any(part.endswith("identify_lane_owner.py") for part in cmd) for cmd in calls)
 
 
 def test_default_claim_does_not_release_live_owner(tmp_path: Path, monkeypatch: Any) -> None:
     # Claim refused and the owner is LIVE -> never release/displace; claim fails.
     wo = _wo_42()
-    released: list[str] = []
+    calls: list[list[str]] = []
 
     def fake_run(cmd: list[str], **kwargs: Any) -> Any:
-        script = next((c for c in cmd if c.endswith(".py")), "")
-        if script.endswith("identify_lane_owner.py"):
-            return SimpleNamespace(
-                returncode=0,
-                stdout=json.dumps(
-                    {"owner_session": "live-owner", "owner_liveness": {"assessed": "live"}}
-                ),
-                stderr="",
-            )
-        if "--release-stale" in cmd:
-            released.append("released")
-            return SimpleNamespace(returncode=0, stdout="", stderr="")
-        return SimpleNamespace(returncode=2, stdout="", stderr="conflict")  # claim always refused
+        calls.append(cmd)
+        return SimpleNamespace(returncode=2, stdout="", stderr="conflict")
 
     monkeypatch.setattr(lc.subprocess, "run", fake_run)
     assert lc.default_claim(wo, repo_root=tmp_path) is False
-    assert released == []  # a live owner is never released
+    assert len(calls) == 1
+    assert all("--release-stale" not in cmd for cmd in calls)
+    assert all(not any(part.endswith("identify_lane_owner.py") for part in cmd) for cmd in calls)
 
 
 def test_run_pass_releases_lane_when_dispatch_fails() -> None:

--- a/tests/swarm/test_lane_dispatcher.py
+++ b/tests/swarm/test_lane_dispatcher.py
@@ -137,6 +137,8 @@ def test_worker_prompt_is_claim_first_and_scoped() -> None:
     assert "claim_active_agent_lane.py" in prompt
     assert "--lane-id lane-42-sess-42" in prompt
     assert "--release-stale" not in prompt
+    assert "claim command exits non-zero" in prompt
+    assert "yielding: claim blocked" in prompt
     assert "CLAIM-OR-YIELD" in prompt
     assert "#42" in prompt
     assert "codex/lane-42" in prompt


### PR DESCRIPTION
## Summary

Implements the dispatch-time enforcement slice for #8563 by making lane dispatch fail closed on blocking ownership rows instead of releasing stale active owners during claim recovery.

- Treats active, conflict, and unknown-status owner rows as blocking when another lane claims the same PR, branch, or worktree.
- Leaves explicit terminal rows (`released`, `completed`, `superseded`) non-blocking so reconciler-superseded ownership can be reassigned.
- Removes dispatch-time automatic stale-owner release; workers now yield on claim failure unless an explicit release or conservative reconciler receipt has already cleared the row.

Closes #8563.

## Validation

- `python3 -m pytest tests/scripts/test_claim_active_agent_lane.py tests/swarm/test_lane_conductor.py tests/swarm/test_lane_dispatcher.py -q` (91 passed)
- `python3 -m pytest tests/scripts/test_resolve_lane_conflicts.py tests/scripts/test_identify_lane_owner.py -q` (111 passed)
- `python3 scripts/report_code_quality.py --check` (PASS)
- `git diff --check`
- commit/push hooks: ruff, ruff format, mypy, gitleaks, portability guard
