### PR TITLE
refactor(debate): lazify server.metrics import in orchestrator_runner (VAL-P4A-004)

### DIFF
--- a/aragora/debate/orchestrator_runner.py
+++ b/aragora/debate/orchestrator_runner.py
@@ -30,10 +30,6 @@ from aragora.debate.context import DebateContext
 from aragora.logging_config import LogContext, get_logger as get_structured_logger
 from aragora.observability.tracing import add_span_attributes
 from aragora.pipeline.execution_mode import ExecutionMode as SafetyMode
-from aragora.server.metrics import (
-    ACTIVE_DEBATES,
-    track_debate_outcome,
-)
 from aragora.observability.metrics.debate_slo import (
     record_debate_completion_slo,
     update_debate_success_rate,
@@ -1257,6 +1253,8 @@ def record_debate_metrics(
         state: The debate execution state
         span: OpenTelemetry span for tracing
     """
+    from aragora.server.metrics import ACTIVE_DEBATES, track_debate_outcome
+
     ACTIVE_DEBATES.dec()
     duration = time.perf_counter() - state.debate_start_time
     ctx = state.ctx

--- a/tests/debate/test_orchestrator_runner.py
+++ b/tests/debate/test_orchestrator_runner.py
@@ -747,7 +747,7 @@ class TestRecordDebateMetrics:
 
     def test_decrements_active_debates(self, mock_arena, execution_state, mock_span):
         """Test that ACTIVE_DEBATES counter is decremented."""
-        with patch("aragora.debate.orchestrator_runner.ACTIVE_DEBATES") as mock_counter:
+        with patch("aragora.server.metrics.ACTIVE_DEBATES") as mock_counter:
             record_debate_metrics(mock_arena, execution_state, mock_span)
 
             mock_counter.dec.assert_called_once()
@@ -757,9 +757,9 @@ class TestRecordDebateMetrics:
         execution_state.debate_start_time = time.perf_counter() - 10.0
 
         with (
-            patch("aragora.debate.orchestrator_runner.ACTIVE_DEBATES"),
+            patch("aragora.server.metrics.ACTIVE_DEBATES"),
             patch("aragora.debate.orchestrator_runner.add_span_attributes") as mock_add_attrs,
-            patch("aragora.debate.orchestrator_runner.track_debate_outcome"),
+            patch("aragora.server.metrics.track_debate_outcome"),
         ):
             record_debate_metrics(mock_arena, execution_state, mock_span)
 
@@ -774,9 +774,9 @@ class TestRecordDebateMetrics:
         execution_state.ctx.result.messages = [MagicMock(), MagicMock(), MagicMock()]
 
         with (
-            patch("aragora.debate.orchestrator_runner.ACTIVE_DEBATES"),
+            patch("aragora.server.metrics.ACTIVE_DEBATES"),
             patch("aragora.debate.orchestrator_runner.add_span_attributes") as mock_add_attrs,
-            patch("aragora.debate.orchestrator_runner.track_debate_outcome"),
+            patch("aragora.server.metrics.track_debate_outcome"),
         ):
             record_debate_metrics(mock_arena, execution_state, mock_span)
 
@@ -797,9 +797,9 @@ class TestRecordDebateMetrics:
         execution_state.ctx.result.confidence = 0.8
 
         with (
-            patch("aragora.debate.orchestrator_runner.ACTIVE_DEBATES"),
+            patch("aragora.server.metrics.ACTIVE_DEBATES"),
             patch("aragora.debate.orchestrator_runner.add_span_attributes"),
-            patch("aragora.debate.orchestrator_runner.track_debate_outcome") as mock_track,
+            patch("aragora.server.metrics.track_debate_outcome") as mock_track,
         ):
             record_debate_metrics(mock_arena, execution_state, mock_span)
 
@@ -813,9 +813,9 @@ class TestRecordDebateMetrics:
     def test_tracks_circuit_breaker_metrics(self, mock_arena, execution_state, mock_span):
         """Test that circuit breaker metrics are tracked."""
         with (
-            patch("aragora.debate.orchestrator_runner.ACTIVE_DEBATES"),
+            patch("aragora.server.metrics.ACTIVE_DEBATES"),
             patch("aragora.debate.orchestrator_runner.add_span_attributes"),
-            patch("aragora.debate.orchestrator_runner.track_debate_outcome"),
+            patch("aragora.server.metrics.track_debate_outcome"),
         ):
             record_debate_metrics(mock_arena, execution_state, mock_span)
 
@@ -826,9 +826,9 @@ class TestRecordDebateMetrics:
         execution_state.ctx.result = None
 
         with (
-            patch("aragora.debate.orchestrator_runner.ACTIVE_DEBATES"),
+            patch("aragora.server.metrics.ACTIVE_DEBATES"),
             patch("aragora.debate.orchestrator_runner.add_span_attributes") as mock_add_attrs,
-            patch("aragora.debate.orchestrator_runner.track_debate_outcome"),
+            patch("aragora.server.metrics.track_debate_outcome"),
         ):
             # Should not raise
             record_debate_metrics(mock_arena, execution_state, mock_span)
@@ -1609,9 +1609,9 @@ class TestErrorHandlingAndRecovery:
         execution_state.ctx.result.confidence = 0.3
 
         with (
-            patch("aragora.debate.orchestrator_runner.ACTIVE_DEBATES"),
+            patch("aragora.server.metrics.ACTIVE_DEBATES"),
             patch("aragora.debate.orchestrator_runner.add_span_attributes"),
-            patch("aragora.debate.orchestrator_runner.track_debate_outcome") as mock_track,
+            patch("aragora.server.metrics.track_debate_outcome") as mock_track,
         ):
             record_debate_metrics(mock_arena, execution_state, mock_span)
 

--- a/tests/integration/test_chaos_scenarios.py
+++ b/tests/integration/test_chaos_scenarios.py
@@ -654,7 +654,7 @@ class TestInfrastructureFailures:
         # Replace metrics functions with silent no-ops to simulate
         # a metrics backend that is offline but not erroring
         with patch(
-            "aragora.debate.orchestrator_runner.track_debate_outcome",
+            "aragora.server.metrics.track_debate_outcome",
             return_value=None,
         ):
             with patch(


### PR DESCRIPTION
## Source
HEALTH-2 #8259 (P4a layering foundation). Fulfills VAL-P4A-004.

## Change
`aragora/debate/orchestrator_runner.py` carried a module-scope
`from aragora.server.metrics import ACTIVE_DEBATES, track_debate_outcome`
(debate domain importing the interface layer eagerly). That import is moved
into `record_debate_metrics` (its only consumer), so the module carries no
module-scope `aragora.server` import. Behavior is unchanged: the same
`aragora.server.metrics` objects are used, just imported lazily (there is
already a precedent lazy `server.metrics` import in this file). The 7
`record_debate_metrics` tests now patch the symbols at their
`aragora.server.metrics` source, where the lazy import resolves them.

## Validation
- `python3 /tmp/p4val/t2.py aragora/debate/orchestrator_runner.py aragora.server` -> `PASS` (was `FAIL [(33, 'aragora.server.metrics')]`)
- functional: `python3 -c "import aragora.debate.orchestrator_runner; print('ok')"` -> `ok`
- `python3 -m pytest tests/debate/test_orchestrator_runner.py` -> 89 passed
- `make test-smoke` -> Smoke tests passed; smoke tier -> 138 passed
- ruff check + `ruff format --check` clean; typecheck differential -> PASS

## Risk
Low. Import-location-only change; no symbol moved, no module-structure change,
so no shim / baseline / METRICS / module_tiers updates are required.
