### PR TITLE
Harden fleet sentinel resolver inputs

### DIFF
--- a/scripts/fleet_sentinel.py
+++ b/scripts/fleet_sentinel.py
@@ -190,36 +190,6 @@ def _git_toplevel(path: Path) -> Path | None:
     return Path(proc.stdout.strip()).resolve()
 
 
-def _git_head_oid(path: Path) -> str:
-    proc = subprocess.run(
-        ["git", "-C", str(path), "rev-parse", "HEAD"],
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        check=False,
-    )
-    if proc.returncode != 0:
-        return ""
-    return proc.stdout.strip()
-
-
-def _git_has_object(path: Path, oid: str) -> bool:
-    if not oid:
-        return False
-    proc = subprocess.run(
-        ["git", "-C", str(path), "cat-file", "-e", f"{oid}^{{commit}}"],
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        check=False,
-    )
-    return proc.returncode == 0
-
-
-def _shares_repo_head_object(repo_root: Path, candidate_root: Path) -> bool:
-    return _git_has_object(candidate_root, _git_head_oid(repo_root))
-
-
 def _registered_worktree_roots(repo_root: Path) -> set[Path]:
     roots: set[Path] = set()
     toplevel = _git_toplevel(repo_root)
@@ -255,10 +225,7 @@ def _is_same_origin_state_root(state_root: Path, repo_root: Path) -> bool:
     candidate_root = _git_toplevel(candidate)
     if candidate_root is None or candidate.resolve() != candidate_root:
         return False
-    registered_roots = _registered_worktree_roots(repo_root)
-    registered_worktree = candidate_root in registered_roots
-    shared_repo_object = _shares_repo_head_object(repo_root, candidate_root)
-    if not registered_worktree and not shared_repo_object:
+    if candidate_root not in _registered_worktree_roots(repo_root):
         return False
     return _same_git_origin(repo_root, candidate_root)
 

--- a/scripts/fleet_sentinel.py
+++ b/scripts/fleet_sentinel.py
@@ -1923,23 +1923,30 @@ def run_checks(args: argparse.Namespace, now: datetime) -> list[CheckResult]:
                 )
             elif name == "stale_terminal_owner":
                 default_paths = getattr(args, "_automation_state_root_default_paths", {})
-                using_fallback_defaults = bool(
-                    getattr(args, "_automation_state_root_error", "")
-                    and str(Path(args.agent_bridge_lanes))
-                    == default_paths.get("agent_bridge_lanes")
-                    and str(Path(args.agent_heartbeats)) == default_paths.get("agent_heartbeats")
-                    and str(Path(args.operator_steering_root))
-                    == default_paths.get("operator_steering_root")
-                    and str(Path(args.stale_terminal_owner_receipt_dir))
-                    == default_paths.get("stale_terminal_owner_receipt_dir")
+                fallback_path_values = {
+                    "agent_bridge_lanes": str(Path(args.agent_bridge_lanes)),
+                    "agent_heartbeats": str(Path(args.agent_heartbeats)),
+                    "operator_steering_root": str(Path(args.operator_steering_root)),
+                    "stale_terminal_owner_receipt_dir": str(
+                        Path(args.stale_terminal_owner_receipt_dir)
+                    ),
+                }
+                unsafe_fallback_paths = [
+                    name
+                    for name, value in fallback_path_values.items()
+                    if value == default_paths.get(name)
+                ]
+                using_unsafe_fallback_defaults = bool(
+                    getattr(args, "_automation_state_root_error", "") and unsafe_fallback_paths
                 )
-                if using_fallback_defaults:
+                if using_unsafe_fallback_defaults:
                     results.append(
                         _result(
                             "stale_terminal_owner",
                             "unknown",
                             "invalid automation state root: "
-                            f"{args._automation_state_root_error}; provide explicit state paths",
+                            f"{args._automation_state_root_error}; provide explicit state paths "
+                            f"for: {', '.join(unsafe_fallback_paths)}",
                         )
                     )
                 else:

--- a/scripts/fleet_sentinel.py
+++ b/scripts/fleet_sentinel.py
@@ -44,6 +44,8 @@ from pathlib import Path
 from typing import Any, Callable
 
 CheckResult = dict[str, Any]
+SCRIPTS_DIR = Path(__file__).resolve().parent
+DEFAULT_REPO_ROOT = SCRIPTS_DIR.parent
 
 ALL_CHECKS = (
     "publisher_status",
@@ -58,6 +60,17 @@ ALL_CHECKS = (
     "stale_terminal_owner",
     "github_api_health",
     "trail_reconcile",
+)
+REPO_SLUG_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,99}/[A-Za-z0-9][A-Za-z0-9_.-]{0,99}$")
+RESOLVER_REQUIRED_ATTRS = (
+    "ACTIVE_STATUSES",
+    "_annotate_terminal_safety",
+    "_active_pr_lane_findings",
+    "_base_merged_pr_audit_result",
+    "_merged_pr_audit_blocked_reason",
+    "_parse_timestamp",
+    "_read_rows_checked",
+    "_utc_now_iso",
 )
 
 # Branch namespaces owned by autonomous lanes; only these are eligible for the
@@ -100,12 +113,81 @@ def _canonical_repo_root(path: Path) -> Path:
     return path.resolve()
 
 
+def _git_common_state_root(path: Path) -> Path | None:
+    common_dir_proc = subprocess.run(
+        ["git", "-C", str(path), "rev-parse", "--path-format=absolute", "--git-common-dir"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if common_dir_proc.returncode != 0 or not common_dir_proc.stdout.strip():
+        return None
+    common_dir = Path(common_dir_proc.stdout.strip()).resolve()
+    if common_dir.name == ".git":
+        return common_dir.parent / ".aragora"
+    for parent in common_dir.parents:
+        if parent.name == ".git":
+            return parent.parent / ".aragora"
+    return None
+
+
+def _trusted_automation_state_roots(repo_root: Path) -> set[Path]:
+    roots = {
+        (_canonical_repo_root(repo_root) / ".aragora").resolve(),
+        (DEFAULT_REPO_ROOT / ".aragora").resolve(),
+    }
+    common_state_root = _git_common_state_root(repo_root)
+    if common_state_root is not None:
+        roots.add(common_state_root.resolve())
+    return roots
+
+
+def _normalize_automation_state_root(path: str) -> Path:
+    root = Path(path).expanduser()
+    root = root if root.name == ".aragora" else root / ".aragora"
+    return root.resolve()
+
+
 def _automation_state_root(repo_root: Path) -> Path:
     configured = os.environ.get("ARAGORA_AUTOMATION_STATE_ROOT")
     if configured:
-        root = Path(configured).expanduser()
-        return root if root.name == ".aragora" else root / ".aragora"
-    return _canonical_repo_root(repo_root) / ".aragora"
+        root = _normalize_automation_state_root(configured)
+        trusted_roots = _trusted_automation_state_roots(repo_root)
+        if root not in trusted_roots:
+            allowed = ", ".join(str(item) for item in sorted(trusted_roots))
+            raise ValueError(
+                f"untrusted ARAGORA_AUTOMATION_STATE_ROOT {root}; expected one of: {allowed}"
+            )
+        return root
+    return (_canonical_repo_root(repo_root) / ".aragora").resolve()
+
+
+def _validate_repo_slug(repo_slug: str) -> str:
+    slug = repo_slug.strip()
+    if slug != repo_slug or not REPO_SLUG_RE.fullmatch(slug):
+        raise ValueError("repo_slug must be a single GitHub owner/repo slug")
+    owner, repo = slug.split("/", 1)
+    if owner in {".", ".."} or repo in {".", ".."} or owner.startswith("-") or repo.startswith("-"):
+        raise ValueError("repo_slug contains an unsafe owner or repository segment")
+    return slug
+
+
+def _validate_gh_bin(gh_bin: str) -> str:
+    value = str(gh_bin)
+    if value != value.strip() or any(char.isspace() for char in value) or "\0" in value:
+        raise ValueError("gh_bin must be one executable token")
+    if value == "gh":
+        return value
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        raise ValueError("gh_bin must be 'gh' or an absolute path to gh")
+    resolved = path.resolve()
+    if resolved.name != "gh":
+        raise ValueError("gh_bin absolute path must point to an executable named gh")
+    if not resolved.is_file() or not os.access(resolved, os.X_OK):
+        raise ValueError("gh_bin absolute path must be an executable file")
+    return str(resolved)
 
 
 def parse_iso(value: str) -> datetime:
@@ -626,13 +708,24 @@ def _default_pr_state_fetcher(
     gh_bin: str,
     timeout_seconds: float = 30.0,
 ) -> dict[str, Any]:
+    try:
+        safe_gh_bin = _validate_gh_bin(gh_bin)
+        safe_repo_slug = _validate_repo_slug(repo_slug)
+    except ValueError as exc:
+        return {
+            "available": False,
+            "number": pr,
+            "state": "UNKNOWN",
+            "error": f"invalid GitHub CLI configuration: {exc}",
+            "command": [],
+        }
     cmd = [
-        gh_bin,
+        safe_gh_bin,
         "pr",
         "view",
         str(pr),
         "--repo",
-        repo_slug,
+        safe_repo_slug,
         "--json",
         "number,state,closed,closedAt,mergedAt,mergeCommit,headRefName,headRefOid,url",
     ]
@@ -683,11 +776,37 @@ def _default_pr_state_fetcher(
     }
 
 
+def _trusted_resolver_path() -> Path:
+    script_path = SCRIPTS_DIR / "resolve_lane_conflicts.py"
+    try:
+        resolved = script_path.resolve(strict=True)
+        trusted_scripts_dir = SCRIPTS_DIR.resolve(strict=True)
+    except OSError as exc:
+        raise RuntimeError(f"could not resolve trusted resolver path: {exc}") from exc
+    expected_scripts_dir = (_canonical_repo_root(DEFAULT_REPO_ROOT) / "scripts").resolve()
+    if trusted_scripts_dir != expected_scripts_dir:
+        raise RuntimeError(
+            "fleet sentinel scripts directory does not match canonical repo scripts directory: "
+            f"{trusted_scripts_dir} != {expected_scripts_dir}"
+        )
+    if resolved.parent != trusted_scripts_dir or resolved.name != "resolve_lane_conflicts.py":
+        raise RuntimeError(f"untrusted resolver module path: {resolved}")
+    return resolved
+
+
+def _validate_resolver_module(module: Any, script_path: Path) -> None:
+    missing = [name for name in RESOLVER_REQUIRED_ATTRS if not hasattr(module, name)]
+    if missing:
+        raise RuntimeError(
+            f"resolver module at {script_path} is missing required attrs: {', '.join(missing)}"
+        )
+
+
 def _load_resolver_module() -> Any:
     global _RESOLVER_MODULE
     if _RESOLVER_MODULE is not None:
         return _RESOLVER_MODULE
-    script_path = Path(__file__).with_name("resolve_lane_conflicts.py")
+    script_path = _trusted_resolver_path()
     spec = importlib.util.spec_from_file_location(
         "resolve_lane_conflicts_for_sentinel", script_path
     )
@@ -695,6 +814,7 @@ def _load_resolver_module() -> Any:
         raise RuntimeError(f"could not load resolver module at {script_path}")
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
+    _validate_resolver_module(module, script_path)
     _RESOLVER_MODULE = module
     return module
 
@@ -836,6 +956,12 @@ def check_stale_terminal_owner(
     exact merge commit is available.
     """
     name = "stale_terminal_owner"
+    try:
+        repo_slug = _validate_repo_slug(repo_slug)
+        gh_bin = _validate_gh_bin(gh_bin)
+    except ValueError as exc:
+        return _result(name, "unknown", f"invalid GitHub CLI configuration: {exc}")
+
     rows, load_error = _read_json_list(registry_path)
     if load_error:
         if load_error == "missing":
@@ -1741,7 +1867,7 @@ def run_checks(args: argparse.Namespace, now: datetime) -> list[CheckResult]:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
-    repo_root = Path(__file__).resolve().parents[1]
+    repo_root = DEFAULT_REPO_ROOT
     automation_state_root = _automation_state_root(repo_root)
     parser.add_argument("--repo-root", default=str(repo_root))
     parser.add_argument(

--- a/scripts/fleet_sentinel.py
+++ b/scripts/fleet_sentinel.py
@@ -190,6 +190,36 @@ def _git_toplevel(path: Path) -> Path | None:
     return Path(proc.stdout.strip()).resolve()
 
 
+def _git_head_oid(path: Path) -> str:
+    proc = subprocess.run(
+        ["git", "-C", str(path), "rev-parse", "HEAD"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return ""
+    return proc.stdout.strip()
+
+
+def _git_has_object(path: Path, oid: str) -> bool:
+    if not oid:
+        return False
+    proc = subprocess.run(
+        ["git", "-C", str(path), "cat-file", "-e", f"{oid}^{{commit}}"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    return proc.returncode == 0
+
+
+def _shares_repo_head_object(repo_root: Path, candidate_root: Path) -> bool:
+    return _git_has_object(candidate_root, _git_head_oid(repo_root))
+
+
 def _registered_worktree_roots(repo_root: Path) -> set[Path]:
     roots: set[Path] = set()
     toplevel = _git_toplevel(repo_root)
@@ -225,7 +255,10 @@ def _is_same_origin_state_root(state_root: Path, repo_root: Path) -> bool:
     candidate_root = _git_toplevel(candidate)
     if candidate_root is None or candidate.resolve() != candidate_root:
         return False
-    if candidate_root not in _registered_worktree_roots(repo_root):
+    registered_roots = _registered_worktree_roots(repo_root)
+    registered_worktree = candidate_root in registered_roots
+    shared_repo_object = _shares_repo_head_object(repo_root, candidate_root)
+    if not registered_worktree and not shared_repo_object:
         return False
     return _same_git_origin(repo_root, candidate_root)
 
@@ -295,8 +328,6 @@ def _validate_gh_bin(gh_bin: str) -> str:
         resolved = path.resolve()
     except OSError as exc:
         raise ValueError(f"gh_bin absolute path could not be resolved: {exc}") from exc
-    if resolved.name != "gh":
-        raise ValueError("gh_bin absolute path must point to a gh executable")
     if not resolved.is_file() or not os.access(resolved, os.X_OK):
         raise ValueError("gh_bin absolute path must be an executable file")
     return str(resolved)

--- a/scripts/fleet_sentinel.py
+++ b/scripts/fleet_sentinel.py
@@ -132,6 +132,32 @@ def _git_common_state_root(path: Path) -> Path | None:
     return None
 
 
+def _git_origin(path: Path) -> str:
+    proc = subprocess.run(
+        ["git", "-C", str(path), "config", "--get", "remote.origin.url"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return ""
+    return proc.stdout.strip()
+
+
+def _same_git_origin(left: Path, right: Path) -> bool:
+    left_origin = _git_origin(left)
+    return bool(left_origin) and left_origin == _git_origin(right)
+
+
+def _state_root_repo_candidate(state_root: Path) -> Path:
+    return state_root.parent if state_root.name == ".aragora" else state_root
+
+
+def _is_same_origin_state_root(state_root: Path, repo_root: Path) -> bool:
+    return _same_git_origin(repo_root, _state_root_repo_candidate(state_root))
+
+
 def _trusted_automation_state_roots(repo_root: Path) -> set[Path]:
     roots = {
         (_canonical_repo_root(repo_root) / ".aragora").resolve(),
@@ -154,13 +180,24 @@ def _automation_state_root(repo_root: Path) -> Path:
     if configured:
         root = _normalize_automation_state_root(configured)
         trusted_roots = _trusted_automation_state_roots(repo_root)
-        if root not in trusted_roots:
+        if root not in trusted_roots and not _is_same_origin_state_root(root, repo_root):
             allowed = ", ".join(str(item) for item in sorted(trusted_roots))
             raise ValueError(
-                f"untrusted ARAGORA_AUTOMATION_STATE_ROOT {root}; expected one of: {allowed}"
+                f"untrusted ARAGORA_AUTOMATION_STATE_ROOT {root}; expected one of: "
+                f"{allowed}, or a same-origin checkout's .aragora"
             )
         return root
     return (_canonical_repo_root(repo_root) / ".aragora").resolve()
+
+
+def _automation_state_root_for_defaults(repo_root: Path) -> tuple[Path, str | None]:
+    try:
+        return _automation_state_root(repo_root), None
+    except ValueError as exc:
+        # Parser construction must not crash before explicit path overrides can
+        # be parsed. The stale_terminal_owner check fails closed if these
+        # fallback defaults are actually used.
+        return (_canonical_repo_root(repo_root) / ".aragora").resolve(), str(exc)
 
 
 def _validate_repo_slug(repo_slug: str) -> str:
@@ -181,10 +218,8 @@ def _validate_gh_bin(gh_bin: str) -> str:
         return value
     path = Path(value).expanduser()
     if not path.is_absolute():
-        raise ValueError("gh_bin must be 'gh' or an absolute path to gh")
+        raise ValueError("gh_bin must be 'gh' or an absolute executable path")
     resolved = path.resolve()
-    if resolved.name != "gh":
-        raise ValueError("gh_bin absolute path must point to an executable named gh")
     if not resolved.is_file() or not os.access(resolved, os.X_OK):
         raise ValueError("gh_bin absolute path must be an executable file")
     return str(resolved)
@@ -783,7 +818,7 @@ def _trusted_resolver_path() -> Path:
         trusted_scripts_dir = SCRIPTS_DIR.resolve(strict=True)
     except OSError as exc:
         raise RuntimeError(f"could not resolve trusted resolver path: {exc}") from exc
-    expected_scripts_dir = (_canonical_repo_root(DEFAULT_REPO_ROOT) / "scripts").resolve()
+    expected_scripts_dir = (DEFAULT_REPO_ROOT / "scripts").resolve()
     if trusted_scripts_dir != expected_scripts_dir:
         raise RuntimeError(
             "fleet sentinel scripts directory does not match canonical repo scripts directory: "
@@ -1639,7 +1674,8 @@ def _github_witness_events(
     operator phase T0) replaces this as the witness root once enabled; this
     fetcher then becomes the liveness cross-check.
     """
-    raw = json.loads(capture(["gh", "api", f"repos/{repo_slug}/events?per_page=100"]))
+    safe_repo_slug = _validate_repo_slug(repo_slug)
+    raw = json.loads(capture(["gh", "api", f"repos/{safe_repo_slug}/events?per_page=100"]))
     events: list[dict[str, Any]] = []
     for item in raw:
         etype = item.get("type", "")
@@ -1809,20 +1845,41 @@ def run_checks(args: argparse.Namespace, now: datetime) -> list[CheckResult]:
                     )
                 )
             elif name == "stale_terminal_owner":
-                results.append(
-                    check_stale_terminal_owner(
-                        Path(args.agent_bridge_lanes),
-                        receipt_dir=Path(args.stale_terminal_owner_receipt_dir),
-                        heartbeat_path=Path(args.agent_heartbeats),
-                        steering_inbox_root=Path(args.operator_steering_root),
-                        min_age_hours=args.stale_terminal_owner_age_hours,
-                        now=now,
-                        repo_slug=args.github_repo,
-                        gh_bin=args.gh_bin,
-                        heartbeat_fresh_seconds=args.stale_terminal_owner_heartbeat_fresh_seconds,
-                        gh_timeout_seconds=args.stale_terminal_owner_gh_timeout_seconds,
-                    )
+                default_paths = getattr(args, "_automation_state_root_default_paths", {})
+                using_fallback_defaults = bool(
+                    getattr(args, "_automation_state_root_error", "")
+                    and str(Path(args.agent_bridge_lanes))
+                    == default_paths.get("agent_bridge_lanes")
+                    and str(Path(args.agent_heartbeats)) == default_paths.get("agent_heartbeats")
+                    and str(Path(args.operator_steering_root))
+                    == default_paths.get("operator_steering_root")
+                    and str(Path(args.stale_terminal_owner_receipt_dir))
+                    == default_paths.get("stale_terminal_owner_receipt_dir")
                 )
+                if using_fallback_defaults:
+                    results.append(
+                        _result(
+                            "stale_terminal_owner",
+                            "unknown",
+                            "invalid automation state root: "
+                            f"{args._automation_state_root_error}; provide explicit state paths",
+                        )
+                    )
+                else:
+                    results.append(
+                        check_stale_terminal_owner(
+                            Path(args.agent_bridge_lanes),
+                            receipt_dir=Path(args.stale_terminal_owner_receipt_dir),
+                            heartbeat_path=Path(args.agent_heartbeats),
+                            steering_inbox_root=Path(args.operator_steering_root),
+                            min_age_hours=args.stale_terminal_owner_age_hours,
+                            now=now,
+                            repo_slug=args.github_repo,
+                            gh_bin=args.gh_bin,
+                            heartbeat_fresh_seconds=args.stale_terminal_owner_heartbeat_fresh_seconds,
+                            gh_timeout_seconds=args.stale_terminal_owner_gh_timeout_seconds,
+                        )
+                    )
             elif name == "github_api_health":
                 results.append(
                     check_github_api_health(
@@ -1868,7 +1925,21 @@ def run_checks(args: argparse.Namespace, now: datetime) -> list[CheckResult]:
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     repo_root = DEFAULT_REPO_ROOT
-    automation_state_root = _automation_state_root(repo_root)
+    automation_state_root, automation_state_root_error = _automation_state_root_for_defaults(
+        repo_root
+    )
+    automation_default_paths = {
+        "agent_bridge_lanes": str(automation_state_root / "agent-bridge" / "lanes.json"),
+        "agent_heartbeats": str(automation_state_root / "agent-bridge" / "heartbeats.json"),
+        "operator_steering_root": str(automation_state_root / "operator-steering"),
+        "stale_terminal_owner_receipt_dir": str(
+            automation_state_root / "agent-bridge" / "conflict-resolution-receipts"
+        ),
+    }
+    parser.set_defaults(
+        _automation_state_root_error=automation_state_root_error,
+        _automation_state_root_default_paths=automation_default_paths,
+    )
     parser.add_argument("--repo-root", default=str(repo_root))
     parser.add_argument(
         "--publisher-status",
@@ -1910,17 +1981,17 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--orphan-branch-age-hours", type=float, default=24.0)
     parser.add_argument(
         "--agent-bridge-lanes",
-        default=str(automation_state_root / "agent-bridge" / "lanes.json"),
+        default=automation_default_paths["agent_bridge_lanes"],
         help="lane owner registry used by stale_terminal_owner",
     )
     parser.add_argument(
         "--agent-heartbeats",
-        default=str(automation_state_root / "agent-bridge" / "heartbeats.json"),
+        default=automation_default_paths["agent_heartbeats"],
         help="heartbeat registry used by stale_terminal_owner safety checks",
     )
     parser.add_argument(
         "--operator-steering-root",
-        default=str(automation_state_root / "operator-steering"),
+        default=automation_default_paths["operator_steering_root"],
         help="operator-steering inbox root used by stale_terminal_owner safety checks",
     )
     parser.add_argument(
@@ -1931,7 +2002,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--stale-terminal-owner-receipt-dir",
-        default=str(automation_state_root / "agent-bridge" / "conflict-resolution-receipts"),
+        default=automation_default_paths["stale_terminal_owner_receipt_dir"],
         help="receipt directory to print in guarded resolve_lane_conflicts commands",
     )
     parser.add_argument(

--- a/scripts/fleet_sentinel.py
+++ b/scripts/fleet_sentinel.py
@@ -42,6 +42,7 @@ from datetime import datetime, timezone
 from fnmatch import fnmatch
 from pathlib import Path
 from typing import Any, Callable
+from urllib.parse import urlparse
 
 CheckResult = dict[str, Any]
 SCRIPTS_DIR = Path(__file__).resolve().parent
@@ -140,14 +141,79 @@ def _git_origin(path: Path) -> str:
         stderr=subprocess.PIPE,
         check=False,
     )
+    if proc.returncode == 0 and proc.stdout.strip():
+        return proc.stdout.strip()
+    proc = subprocess.run(
+        ["git", "-C", str(path), "config", "--get-regexp", r"^remote\..*\.url$"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
     if proc.returncode != 0:
         return ""
-    return proc.stdout.strip()
+    for line in proc.stdout.splitlines():
+        _key, _sep, value = line.partition(" ")
+        if value.strip():
+            return value.strip()
+    return ""
+
+
+def _canonical_git_url(url: str) -> str:
+    value = url.strip().rstrip("/")
+    if not value:
+        return ""
+    if "://" not in value and ":" in value and "@" in value.split(":", 1)[0]:
+        host_part, path_part = value.split(":", 1)
+        host = host_part.rsplit("@", 1)[-1]
+        path = path_part
+    else:
+        parsed = urlparse(value)
+        host = parsed.hostname or ""
+        path = parsed.path.lstrip("/") if parsed.scheme else value
+    path = path.rstrip("/")
+    if path.endswith(".git"):
+        path = path[:-4]
+    return f"{host.lower()}/{path.lower()}" if host else path.lower()
+
+
+def _git_toplevel(path: Path) -> Path | None:
+    proc = subprocess.run(
+        ["git", "-C", str(path), "rev-parse", "--show-toplevel"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return None
+    return Path(proc.stdout.strip()).resolve()
+
+
+def _registered_worktree_roots(repo_root: Path) -> set[Path]:
+    roots: set[Path] = set()
+    toplevel = _git_toplevel(repo_root)
+    if toplevel is not None:
+        roots.add(toplevel)
+    proc = subprocess.run(
+        ["git", "-C", str(repo_root), "worktree", "list", "--porcelain"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return roots
+    for line in proc.stdout.splitlines():
+        if line.startswith("worktree "):
+            roots.add(Path(line.removeprefix("worktree ")).resolve())
+    return roots
 
 
 def _same_git_origin(left: Path, right: Path) -> bool:
-    left_origin = _git_origin(left)
-    return bool(left_origin) and left_origin == _git_origin(right)
+    left_origin = _canonical_git_url(_git_origin(left))
+    right_origin = _canonical_git_url(_git_origin(right))
+    return bool(left_origin) and left_origin == right_origin
 
 
 def _state_root_repo_candidate(state_root: Path) -> Path:
@@ -155,7 +221,13 @@ def _state_root_repo_candidate(state_root: Path) -> Path:
 
 
 def _is_same_origin_state_root(state_root: Path, repo_root: Path) -> bool:
-    return _same_git_origin(repo_root, _state_root_repo_candidate(state_root))
+    candidate = _state_root_repo_candidate(state_root)
+    candidate_root = _git_toplevel(candidate)
+    if candidate_root is None or candidate.resolve() != candidate_root:
+        return False
+    if candidate_root not in _registered_worktree_roots(repo_root):
+        return False
+    return _same_git_origin(repo_root, candidate_root)
 
 
 def _trusted_automation_state_roots(repo_root: Path) -> set[Path]:
@@ -219,7 +291,12 @@ def _validate_gh_bin(gh_bin: str) -> str:
     path = Path(value).expanduser()
     if not path.is_absolute():
         raise ValueError("gh_bin must be 'gh' or an absolute executable path")
-    resolved = path.resolve()
+    try:
+        resolved = path.resolve()
+    except OSError as exc:
+        raise ValueError(f"gh_bin absolute path could not be resolved: {exc}") from exc
+    if resolved.name != "gh":
+        raise ValueError("gh_bin absolute path must point to a gh executable")
     if not resolved.is_file() or not os.access(resolved, os.X_OK):
         raise ValueError("gh_bin absolute path must be an executable file")
     return str(resolved)

--- a/scripts/fleet_sentinel.py
+++ b/scripts/fleet_sentinel.py
@@ -225,8 +225,6 @@ def _is_same_origin_state_root(state_root: Path, repo_root: Path) -> bool:
     candidate_root = _git_toplevel(candidate)
     if candidate_root is None or candidate.resolve() != candidate_root:
         return False
-    if candidate_root not in _registered_worktree_roots(repo_root):
-        return False
     return _same_git_origin(repo_root, candidate_root)
 
 

--- a/scripts/fleet_sentinel.py
+++ b/scripts/fleet_sentinel.py
@@ -42,7 +42,6 @@ from datetime import datetime, timezone
 from fnmatch import fnmatch
 from pathlib import Path
 from typing import Any, Callable
-from urllib.parse import urlparse
 
 CheckResult = dict[str, Any]
 SCRIPTS_DIR = Path(__file__).resolve().parent
@@ -63,6 +62,12 @@ ALL_CHECKS = (
     "trail_reconcile",
 )
 REPO_SLUG_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,99}/[A-Za-z0-9][A-Za-z0-9_.-]{0,99}$")
+STATE_PATH_ARGS = {
+    "--agent-bridge-lanes": "agent_bridge_lanes",
+    "--agent-heartbeats": "agent_heartbeats",
+    "--operator-steering-root": "operator_steering_root",
+    "--stale-terminal-owner-receipt-dir": "stale_terminal_owner_receipt_dir",
+}
 RESOLVER_REQUIRED_ATTRS = (
     "ACTIVE_STATUSES",
     "_annotate_terminal_safety",
@@ -133,50 +138,6 @@ def _git_common_state_root(path: Path) -> Path | None:
     return None
 
 
-def _git_origin(path: Path) -> str:
-    proc = subprocess.run(
-        ["git", "-C", str(path), "config", "--get", "remote.origin.url"],
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        check=False,
-    )
-    if proc.returncode == 0 and proc.stdout.strip():
-        return proc.stdout.strip()
-    proc = subprocess.run(
-        ["git", "-C", str(path), "config", "--get-regexp", r"^remote\..*\.url$"],
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        check=False,
-    )
-    if proc.returncode != 0:
-        return ""
-    for line in proc.stdout.splitlines():
-        _key, _sep, value = line.partition(" ")
-        if value.strip():
-            return value.strip()
-    return ""
-
-
-def _canonical_git_url(url: str) -> str:
-    value = url.strip().rstrip("/")
-    if not value:
-        return ""
-    if "://" not in value and ":" in value and "@" in value.split(":", 1)[0]:
-        host_part, path_part = value.split(":", 1)
-        host = host_part.rsplit("@", 1)[-1]
-        path = path_part
-    else:
-        parsed = urlparse(value)
-        host = parsed.hostname or ""
-        path = parsed.path.lstrip("/") if parsed.scheme else value
-    path = path.rstrip("/")
-    if path.endswith(".git"):
-        path = path[:-4]
-    return f"{host.lower()}/{path.lower()}" if host else path.lower()
-
-
 def _git_toplevel(path: Path) -> Path | None:
     proc = subprocess.run(
         ["git", "-C", str(path), "rev-parse", "--show-toplevel"],
@@ -210,22 +171,16 @@ def _registered_worktree_roots(repo_root: Path) -> set[Path]:
     return roots
 
 
-def _same_git_origin(left: Path, right: Path) -> bool:
-    left_origin = _canonical_git_url(_git_origin(left))
-    right_origin = _canonical_git_url(_git_origin(right))
-    return bool(left_origin) and left_origin == right_origin
-
-
 def _state_root_repo_candidate(state_root: Path) -> Path:
     return state_root.parent if state_root.name == ".aragora" else state_root
 
 
-def _is_same_origin_state_root(state_root: Path, repo_root: Path) -> bool:
+def _is_registered_worktree_state_root(state_root: Path, repo_root: Path) -> bool:
     candidate = _state_root_repo_candidate(state_root)
     candidate_root = _git_toplevel(candidate)
     if candidate_root is None or candidate.resolve() != candidate_root:
         return False
-    return _same_git_origin(repo_root, candidate_root)
+    return candidate_root in _registered_worktree_roots(repo_root)
 
 
 def _trusted_automation_state_roots(repo_root: Path) -> set[Path]:
@@ -250,11 +205,11 @@ def _automation_state_root(repo_root: Path) -> Path:
     if configured:
         root = _normalize_automation_state_root(configured)
         trusted_roots = _trusted_automation_state_roots(repo_root)
-        if root not in trusted_roots and not _is_same_origin_state_root(root, repo_root):
+        if root not in trusted_roots and not _is_registered_worktree_state_root(root, repo_root):
             allowed = ", ".join(str(item) for item in sorted(trusted_roots))
             raise ValueError(
                 f"untrusted ARAGORA_AUTOMATION_STATE_ROOT {root}; expected one of: "
-                f"{allowed}, or a same-origin checkout's .aragora"
+                f"{allowed}, or a registered worktree's .aragora"
             )
         return root
     return (_canonical_repo_root(repo_root) / ".aragora").resolve()
@@ -268,6 +223,15 @@ def _automation_state_root_for_defaults(repo_root: Path) -> tuple[Path, str | No
         # be parsed. The stale_terminal_owner check fails closed if these
         # fallback defaults are actually used.
         return (_canonical_repo_root(repo_root) / ".aragora").resolve(), str(exc)
+
+
+def _explicit_state_path_args(argv: list[str]) -> set[str]:
+    explicit: set[str] = set()
+    for token in argv:
+        for flag, dest in STATE_PATH_ARGS.items():
+            if token == flag or token.startswith(f"{flag}="):
+                explicit.add(dest)
+    return explicit
 
 
 def _validate_repo_slug(repo_slug: str) -> str:
@@ -1919,6 +1883,7 @@ def run_checks(args: argparse.Namespace, now: datetime) -> list[CheckResult]:
                 )
             elif name == "stale_terminal_owner":
                 default_paths = getattr(args, "_automation_state_root_default_paths", {})
+                explicit_paths = set(getattr(args, "_explicit_state_path_args", set()))
                 fallback_path_values = {
                     "agent_bridge_lanes": str(Path(args.agent_bridge_lanes)),
                     "agent_heartbeats": str(Path(args.agent_heartbeats)),
@@ -1930,7 +1895,7 @@ def run_checks(args: argparse.Namespace, now: datetime) -> list[CheckResult]:
                 unsafe_fallback_paths = [
                     name
                     for name, value in fallback_path_values.items()
-                    if value == default_paths.get(name)
+                    if name not in explicit_paths and value == default_paths.get(name)
                 ]
                 using_unsafe_fallback_defaults = bool(
                     getattr(args, "_automation_state_root_error", "") and unsafe_fallback_paths
@@ -2154,7 +2119,9 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
-    args = build_parser().parse_args(argv)
+    raw_argv = list(sys.argv[1:] if argv is None else argv)
+    args = build_parser().parse_args(raw_argv)
+    args._explicit_state_path_args = _explicit_state_path_args(raw_argv)
     now = parse_iso(args.now) if args.now else datetime.now(timezone.utc)
     checks = run_checks(args, now)
     breaches = sum(1 for c in checks if c["status"] == "breach")

--- a/scripts/post_merge_lane_audit.py
+++ b/scripts/post_merge_lane_audit.py
@@ -16,6 +16,7 @@ from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 Runner = Callable[[list[str]], subprocess.CompletedProcess[str]]
+DRY_RUN_ZERO_EXIT_BLOCKERS = {"invalid_automation_state_root"}
 
 
 def _run_command(
@@ -162,7 +163,7 @@ def run_post_merge_lane_audit(
             proc=dry_proc,
             error=message,
         )
-    if dry_payload.get("blocked_reason"):
+    if dry_payload.get("blocked_reason") in DRY_RUN_ZERO_EXIT_BLOCKERS:
         message = str(dry_payload.get("blocked_reason") or "audit blocked")
         return _merge_helper_metadata(
             dry_payload,

--- a/scripts/post_merge_lane_audit.py
+++ b/scripts/post_merge_lane_audit.py
@@ -162,6 +162,17 @@ def run_post_merge_lane_audit(
             proc=dry_proc,
             error=message,
         )
+    if dry_payload.get("blocked_reason"):
+        message = str(dry_payload.get("blocked_reason") or "audit blocked")
+        return _merge_helper_metadata(
+            dry_payload,
+            audit_ok=False,
+            audit_applied=False,
+            apply_requested=apply,
+            command=dry_command,
+            proc=dry_proc,
+            error=message,
+        )
 
     dry_result = _merge_helper_metadata(
         dry_payload,

--- a/scripts/resolve_lane_conflicts.py
+++ b/scripts/resolve_lane_conflicts.py
@@ -155,6 +155,36 @@ def _git_toplevel(path: Path) -> Path | None:
     return Path(proc.stdout.strip()).resolve()
 
 
+def _git_head_oid(path: Path) -> str:
+    proc = subprocess.run(
+        ["git", "-C", str(path), "rev-parse", "HEAD"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return ""
+    return proc.stdout.strip()
+
+
+def _git_has_object(path: Path, oid: str) -> bool:
+    if not oid:
+        return False
+    proc = subprocess.run(
+        ["git", "-C", str(path), "cat-file", "-e", f"{oid}^{{commit}}"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    return proc.returncode == 0
+
+
+def _shares_repo_head_object(repo_root: Path, candidate_root: Path) -> bool:
+    return _git_has_object(candidate_root, _git_head_oid(repo_root))
+
+
 def _registered_worktree_roots(repo_root: Path) -> set[Path]:
     roots: set[Path] = set()
     toplevel = _git_toplevel(repo_root)
@@ -190,7 +220,10 @@ def _is_same_origin_state_root(state_root: Path, repo_root: Path) -> bool:
     candidate_root = _git_toplevel(candidate)
     if candidate_root is None or candidate.resolve() != candidate_root:
         return False
-    if candidate_root not in _registered_worktree_roots(repo_root):
+    registered_roots = _registered_worktree_roots(repo_root)
+    registered_worktree = candidate_root in registered_roots
+    shared_repo_object = _shares_repo_head_object(repo_root, candidate_root)
+    if not registered_worktree and not shared_repo_object:
         return False
     return _same_git_origin(repo_root, candidate_root)
 
@@ -240,8 +273,6 @@ def _validate_gh_bin(gh_bin: str) -> str:
         resolved = path.resolve()
     except OSError as exc:
         raise ValueError(f"gh_bin absolute path could not be resolved: {exc}") from exc
-    if resolved.name != "gh":
-        raise ValueError("gh_bin absolute path must point to a gh executable")
     if not resolved.is_file() or not os.access(resolved, os.X_OK):
         raise ValueError("gh_bin absolute path must be an executable file")
     return str(resolved)

--- a/scripts/resolve_lane_conflicts.py
+++ b/scripts/resolve_lane_conflicts.py
@@ -21,7 +21,6 @@ from collections.abc import Sequence
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
 
 _fcntl: Any
 try:
@@ -98,50 +97,6 @@ def _git_common_state_root(path: Path = DEFAULT_REPO_ROOT) -> Path | None:
     return None
 
 
-def _git_origin(path: Path) -> str:
-    proc = subprocess.run(
-        ["git", "-C", str(path), "config", "--get", "remote.origin.url"],
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        check=False,
-    )
-    if proc.returncode == 0 and proc.stdout.strip():
-        return proc.stdout.strip()
-    proc = subprocess.run(
-        ["git", "-C", str(path), "config", "--get-regexp", r"^remote\..*\.url$"],
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        check=False,
-    )
-    if proc.returncode != 0:
-        return ""
-    for line in proc.stdout.splitlines():
-        _key, _sep, value = line.partition(" ")
-        if value.strip():
-            return value.strip()
-    return ""
-
-
-def _canonical_git_url(url: str) -> str:
-    value = url.strip().rstrip("/")
-    if not value:
-        return ""
-    if "://" not in value and ":" in value and "@" in value.split(":", 1)[0]:
-        host_part, path_part = value.split(":", 1)
-        host = host_part.rsplit("@", 1)[-1]
-        path = path_part
-    else:
-        parsed = urlparse(value)
-        host = parsed.hostname or ""
-        path = parsed.path.lstrip("/") if parsed.scheme else value
-    path = path.rstrip("/")
-    if path.endswith(".git"):
-        path = path[:-4]
-    return f"{host.lower()}/{path.lower()}" if host else path.lower()
-
-
 def _git_toplevel(path: Path) -> Path | None:
     proc = subprocess.run(
         ["git", "-C", str(path), "rev-parse", "--show-toplevel"],
@@ -175,22 +130,16 @@ def _registered_worktree_roots(repo_root: Path) -> set[Path]:
     return roots
 
 
-def _same_git_origin(left: Path, right: Path) -> bool:
-    left_origin = _canonical_git_url(_git_origin(left))
-    right_origin = _canonical_git_url(_git_origin(right))
-    return bool(left_origin) and left_origin == right_origin
-
-
 def _state_root_repo_candidate(state_root: Path) -> Path:
     return state_root.parent if state_root.name == ".aragora" else state_root
 
 
-def _is_same_origin_state_root(state_root: Path, repo_root: Path) -> bool:
+def _is_registered_worktree_state_root(state_root: Path, repo_root: Path) -> bool:
     candidate = _state_root_repo_candidate(state_root)
     candidate_root = _git_toplevel(candidate)
     if candidate_root is None or candidate.resolve() != candidate_root:
         return False
-    return _same_git_origin(repo_root, candidate_root)
+    return candidate_root in _registered_worktree_roots(repo_root)
 
 
 def _trusted_automation_state_roots(repo_root: Path = DEFAULT_REPO_ROOT) -> set[Path]:
@@ -215,11 +164,11 @@ def _automation_state_root(repo_root: Path = DEFAULT_REPO_ROOT) -> Path:
     if configured:
         root = _normalize_automation_state_root(configured)
         trusted_roots = _trusted_automation_state_roots(repo_root)
-        if root not in trusted_roots and not _is_same_origin_state_root(root, repo_root):
+        if root not in trusted_roots and not _is_registered_worktree_state_root(root, repo_root):
             allowed = ", ".join(str(item) for item in sorted(trusted_roots))
             raise ValueError(
                 f"untrusted ARAGORA_AUTOMATION_STATE_ROOT {root}; expected one of: "
-                f"{allowed}, or a same-origin checkout's .aragora"
+                f"{allowed}, or a registered worktree's .aragora"
             )
         return root
     return (_canonical_repo_root(repo_root) / ".aragora").resolve()

--- a/scripts/resolve_lane_conflicts.py
+++ b/scripts/resolve_lane_conflicts.py
@@ -97,6 +97,32 @@ def _git_common_state_root(path: Path = DEFAULT_REPO_ROOT) -> Path | None:
     return None
 
 
+def _git_origin(path: Path) -> str:
+    proc = subprocess.run(
+        ["git", "-C", str(path), "config", "--get", "remote.origin.url"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return ""
+    return proc.stdout.strip()
+
+
+def _same_git_origin(left: Path, right: Path) -> bool:
+    left_origin = _git_origin(left)
+    return bool(left_origin) and left_origin == _git_origin(right)
+
+
+def _state_root_repo_candidate(state_root: Path) -> Path:
+    return state_root.parent if state_root.name == ".aragora" else state_root
+
+
+def _is_same_origin_state_root(state_root: Path, repo_root: Path) -> bool:
+    return _same_git_origin(repo_root, _state_root_repo_candidate(state_root))
+
+
 def _trusted_automation_state_roots(repo_root: Path = DEFAULT_REPO_ROOT) -> set[Path]:
     roots = {
         (_canonical_repo_root(repo_root) / ".aragora").resolve(),
@@ -119,10 +145,11 @@ def _automation_state_root(repo_root: Path = DEFAULT_REPO_ROOT) -> Path:
     if configured:
         root = _normalize_automation_state_root(configured)
         trusted_roots = _trusted_automation_state_roots(repo_root)
-        if root not in trusted_roots:
+        if root not in trusted_roots and not _is_same_origin_state_root(root, repo_root):
             allowed = ", ".join(str(item) for item in sorted(trusted_roots))
             raise ValueError(
-                f"untrusted ARAGORA_AUTOMATION_STATE_ROOT {root}; expected one of: {allowed}"
+                f"untrusted ARAGORA_AUTOMATION_STATE_ROOT {root}; expected one of: "
+                f"{allowed}, or a same-origin checkout's .aragora"
             )
         return root
     return (_canonical_repo_root(repo_root) / ".aragora").resolve()
@@ -136,10 +163,8 @@ def _validate_gh_bin(gh_bin: str) -> str:
         return value
     path = Path(value).expanduser()
     if not path.is_absolute():
-        raise ValueError("gh_bin must be 'gh' or an absolute path to gh")
+        raise ValueError("gh_bin must be 'gh' or an absolute executable path")
     resolved = path.resolve()
-    if resolved.name != "gh":
-        raise ValueError("gh_bin absolute path must point to an executable named gh")
     if not resolved.is_file() or not os.access(resolved, os.X_OK):
         raise ValueError("gh_bin absolute path must be an executable file")
     return str(resolved)

--- a/scripts/resolve_lane_conflicts.py
+++ b/scripts/resolve_lane_conflicts.py
@@ -155,36 +155,6 @@ def _git_toplevel(path: Path) -> Path | None:
     return Path(proc.stdout.strip()).resolve()
 
 
-def _git_head_oid(path: Path) -> str:
-    proc = subprocess.run(
-        ["git", "-C", str(path), "rev-parse", "HEAD"],
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        check=False,
-    )
-    if proc.returncode != 0:
-        return ""
-    return proc.stdout.strip()
-
-
-def _git_has_object(path: Path, oid: str) -> bool:
-    if not oid:
-        return False
-    proc = subprocess.run(
-        ["git", "-C", str(path), "cat-file", "-e", f"{oid}^{{commit}}"],
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        check=False,
-    )
-    return proc.returncode == 0
-
-
-def _shares_repo_head_object(repo_root: Path, candidate_root: Path) -> bool:
-    return _git_has_object(candidate_root, _git_head_oid(repo_root))
-
-
 def _registered_worktree_roots(repo_root: Path) -> set[Path]:
     roots: set[Path] = set()
     toplevel = _git_toplevel(repo_root)
@@ -220,10 +190,7 @@ def _is_same_origin_state_root(state_root: Path, repo_root: Path) -> bool:
     candidate_root = _git_toplevel(candidate)
     if candidate_root is None or candidate.resolve() != candidate_root:
         return False
-    registered_roots = _registered_worktree_roots(repo_root)
-    registered_worktree = candidate_root in registered_roots
-    shared_repo_object = _shares_repo_head_object(repo_root, candidate_root)
-    if not registered_worktree and not shared_repo_object:
+    if candidate_root not in _registered_worktree_roots(repo_root):
         return False
     return _same_git_origin(repo_root, candidate_root)
 

--- a/scripts/resolve_lane_conflicts.py
+++ b/scripts/resolve_lane_conflicts.py
@@ -78,12 +78,71 @@ def _canonical_repo_root(path: Path = DEFAULT_REPO_ROOT) -> Path:
     return path.resolve()
 
 
+def _git_common_state_root(path: Path = DEFAULT_REPO_ROOT) -> Path | None:
+    common_dir_proc = subprocess.run(
+        ["git", "-C", str(path), "rev-parse", "--path-format=absolute", "--git-common-dir"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if common_dir_proc.returncode != 0 or not common_dir_proc.stdout.strip():
+        return None
+    common_dir = Path(common_dir_proc.stdout.strip()).resolve()
+    if common_dir.name == ".git":
+        return common_dir.parent / ".aragora"
+    for parent in common_dir.parents:
+        if parent.name == ".git":
+            return parent.parent / ".aragora"
+    return None
+
+
+def _trusted_automation_state_roots(repo_root: Path = DEFAULT_REPO_ROOT) -> set[Path]:
+    roots = {
+        (_canonical_repo_root(repo_root) / ".aragora").resolve(),
+        (DEFAULT_REPO_ROOT / ".aragora").resolve(),
+    }
+    common_state_root = _git_common_state_root(repo_root)
+    if common_state_root is not None:
+        roots.add(common_state_root.resolve())
+    return roots
+
+
+def _normalize_automation_state_root(path: str) -> Path:
+    root = Path(path).expanduser()
+    root = root if root.name == ".aragora" else root / ".aragora"
+    return root.resolve()
+
+
 def _automation_state_root(repo_root: Path = DEFAULT_REPO_ROOT) -> Path:
     configured = os.environ.get("ARAGORA_AUTOMATION_STATE_ROOT")
     if configured:
-        root = Path(configured).expanduser()
-        return root if root.name == ".aragora" else root / ".aragora"
-    return _canonical_repo_root(repo_root) / ".aragora"
+        root = _normalize_automation_state_root(configured)
+        trusted_roots = _trusted_automation_state_roots(repo_root)
+        if root not in trusted_roots:
+            allowed = ", ".join(str(item) for item in sorted(trusted_roots))
+            raise ValueError(
+                f"untrusted ARAGORA_AUTOMATION_STATE_ROOT {root}; expected one of: {allowed}"
+            )
+        return root
+    return (_canonical_repo_root(repo_root) / ".aragora").resolve()
+
+
+def _validate_gh_bin(gh_bin: str) -> str:
+    value = str(gh_bin)
+    if value != value.strip() or any(char.isspace() for char in value) or "\0" in value:
+        raise ValueError("gh_bin must be one executable token")
+    if value == "gh":
+        return value
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        raise ValueError("gh_bin must be 'gh' or an absolute path to gh")
+    resolved = path.resolve()
+    if resolved.name != "gh":
+        raise ValueError("gh_bin absolute path must point to an executable named gh")
+    if not resolved.is_file() or not os.access(resolved, os.X_OK):
+        raise ValueError("gh_bin absolute path must be an executable file")
+    return str(resolved)
 
 
 def _default_registry_path() -> Path:
@@ -400,8 +459,17 @@ def _merge_commit_oid(payload: dict[str, Any]) -> str:
 
 
 def _fetch_pr_state(*, pr: int, gh_bin: str) -> dict[str, Any]:
+    try:
+        safe_gh_bin = _validate_gh_bin(gh_bin)
+    except ValueError as exc:
+        return {
+            "available": False,
+            "state": None,
+            "error": f"invalid GitHub CLI configuration: {exc}",
+            "command": [],
+        }
     cmd = [
-        gh_bin,
+        safe_gh_bin,
         "pr",
         "view",
         str(pr),

--- a/scripts/resolve_lane_conflicts.py
+++ b/scripts/resolve_lane_conflicts.py
@@ -21,6 +21,7 @@ from collections.abc import Sequence
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 _fcntl: Any
 try:
@@ -105,14 +106,79 @@ def _git_origin(path: Path) -> str:
         stderr=subprocess.PIPE,
         check=False,
     )
+    if proc.returncode == 0 and proc.stdout.strip():
+        return proc.stdout.strip()
+    proc = subprocess.run(
+        ["git", "-C", str(path), "config", "--get-regexp", r"^remote\..*\.url$"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
     if proc.returncode != 0:
         return ""
-    return proc.stdout.strip()
+    for line in proc.stdout.splitlines():
+        _key, _sep, value = line.partition(" ")
+        if value.strip():
+            return value.strip()
+    return ""
+
+
+def _canonical_git_url(url: str) -> str:
+    value = url.strip().rstrip("/")
+    if not value:
+        return ""
+    if "://" not in value and ":" in value and "@" in value.split(":", 1)[0]:
+        host_part, path_part = value.split(":", 1)
+        host = host_part.rsplit("@", 1)[-1]
+        path = path_part
+    else:
+        parsed = urlparse(value)
+        host = parsed.hostname or ""
+        path = parsed.path.lstrip("/") if parsed.scheme else value
+    path = path.rstrip("/")
+    if path.endswith(".git"):
+        path = path[:-4]
+    return f"{host.lower()}/{path.lower()}" if host else path.lower()
+
+
+def _git_toplevel(path: Path) -> Path | None:
+    proc = subprocess.run(
+        ["git", "-C", str(path), "rev-parse", "--show-toplevel"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return None
+    return Path(proc.stdout.strip()).resolve()
+
+
+def _registered_worktree_roots(repo_root: Path) -> set[Path]:
+    roots: set[Path] = set()
+    toplevel = _git_toplevel(repo_root)
+    if toplevel is not None:
+        roots.add(toplevel)
+    proc = subprocess.run(
+        ["git", "-C", str(repo_root), "worktree", "list", "--porcelain"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return roots
+    for line in proc.stdout.splitlines():
+        if line.startswith("worktree "):
+            roots.add(Path(line.removeprefix("worktree ")).resolve())
+    return roots
 
 
 def _same_git_origin(left: Path, right: Path) -> bool:
-    left_origin = _git_origin(left)
-    return bool(left_origin) and left_origin == _git_origin(right)
+    left_origin = _canonical_git_url(_git_origin(left))
+    right_origin = _canonical_git_url(_git_origin(right))
+    return bool(left_origin) and left_origin == right_origin
 
 
 def _state_root_repo_candidate(state_root: Path) -> Path:
@@ -120,7 +186,13 @@ def _state_root_repo_candidate(state_root: Path) -> Path:
 
 
 def _is_same_origin_state_root(state_root: Path, repo_root: Path) -> bool:
-    return _same_git_origin(repo_root, _state_root_repo_candidate(state_root))
+    candidate = _state_root_repo_candidate(state_root)
+    candidate_root = _git_toplevel(candidate)
+    if candidate_root is None or candidate.resolve() != candidate_root:
+        return False
+    if candidate_root not in _registered_worktree_roots(repo_root):
+        return False
+    return _same_git_origin(repo_root, candidate_root)
 
 
 def _trusted_automation_state_roots(repo_root: Path = DEFAULT_REPO_ROOT) -> set[Path]:
@@ -164,7 +236,12 @@ def _validate_gh_bin(gh_bin: str) -> str:
     path = Path(value).expanduser()
     if not path.is_absolute():
         raise ValueError("gh_bin must be 'gh' or an absolute executable path")
-    resolved = path.resolve()
+    try:
+        resolved = path.resolve()
+    except OSError as exc:
+        raise ValueError(f"gh_bin absolute path could not be resolved: {exc}") from exc
+    if resolved.name != "gh":
+        raise ValueError("gh_bin absolute path must point to a gh executable")
     if not resolved.is_file() or not os.access(resolved, os.X_OK):
         raise ValueError("gh_bin absolute path must be an executable file")
     return str(resolved)
@@ -1088,8 +1165,23 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
-    registry_path = args.registry_path or _default_registry_path()
-    receipt_dir = args.receipt_dir or _default_receipt_dir()
+    try:
+        registry_path = args.registry_path or _default_registry_path()
+        receipt_dir = args.receipt_dir or _default_receipt_dir()
+    except ValueError as exc:
+        result = {
+            "blocked_reason": "invalid_automation_state_root",
+            "candidate_count": 0,
+            "error": str(exc),
+            "receipt_dir": None,
+            "registry_path": None,
+            "resolved_count": 0,
+        }
+        if args.json:
+            print(json.dumps(result, indent=2, sort_keys=True))
+        else:
+            print(f"blocked=invalid_automation_state_root: {exc}")
+        return 2
     if args.merged_pr_lane_audit:
         if args.pr is None:
             result = {

--- a/scripts/resolve_lane_conflicts.py
+++ b/scripts/resolve_lane_conflicts.py
@@ -190,8 +190,6 @@ def _is_same_origin_state_root(state_root: Path, repo_root: Path) -> bool:
     candidate_root = _git_toplevel(candidate)
     if candidate_root is None or candidate.resolve() != candidate_root:
         return False
-    if candidate_root not in _registered_worktree_roots(repo_root):
-        return False
     return _same_git_origin(repo_root, candidate_root)
 
 
@@ -1237,6 +1235,8 @@ def main(argv: Sequence[str] | None = None) -> int:
                     print(command)
             if result.get("operator_apply_command"):
                 print(result["operator_apply_command"])
+        if result.get("blocked_reason") == "invalid_automation_state_root":
+            return 2
         if args.apply and result.get("resolved_count", 0) == 0:
             return 2
         return 0

--- a/scripts/resolve_lane_conflicts.py
+++ b/scripts/resolve_lane_conflicts.py
@@ -931,8 +931,26 @@ def audit_merged_pr_lanes(
     """
 
     resolved_at = resolved_at or _utc_now_iso()
-    heartbeat_path = heartbeat_path or _default_heartbeat_path()
-    steering_inbox_root = steering_inbox_root or _default_steering_inbox_root()
+    try:
+        heartbeat_path = heartbeat_path or _default_heartbeat_path()
+        steering_inbox_root = steering_inbox_root or _default_steering_inbox_root()
+    except ValueError as exc:
+        return {
+            "mode": "merged_pr_lane_audit",
+            "apply": bool(apply),
+            "apply_eligible": False,
+            "blocked_reason": "invalid_automation_state_root",
+            "error": str(exc),
+            "finding_count": 0,
+            "findings": [],
+            "github_state": {"available": False, "error": str(exc)},
+            "heartbeat_load_error": None,
+            "owner_release_commands": [],
+            "owner_steering_commands": [],
+            "owner_steering_text": "",
+            "receipt_paths": [],
+            "resolved_count": 0,
+        }
     now_ts = _parse_timestamp(resolved_at) or dt.datetime.now(dt.UTC).timestamp()
     github_state = _fetch_pr_state(pr=pr, gh_bin=gh_bin)
     with _registry_write_lock(registry_path):

--- a/tests/scripts/test_fleet_sentinel.py
+++ b/tests/scripts/test_fleet_sentinel.py
@@ -225,22 +225,6 @@ def test_automation_state_root_rejects_unregistered_same_origin_checkout(
         raise AssertionError("unregistered same-origin automation state root was accepted")
 
 
-def test_automation_state_root_accepts_same_origin_checkout_with_shared_head_object(
-    tmp_path: Path,
-    monkeypatch: Any,
-) -> None:
-    repo = tmp_path / "repo"
-    shared = tmp_path / "shared-checkout"
-    _init_repo_with_origin(repo)
-    _init_repo_with_origin(shared, "git@github.com:synaptent/aragora.git")
-    (shared / ".aragora").mkdir()
-    monkeypatch.setenv("ARAGORA_AUTOMATION_STATE_ROOT", str(shared))
-    monkeypatch.setattr(sentinel, "_registered_worktree_roots", lambda repo_root: {repo.resolve()})
-    monkeypatch.setattr(sentinel, "_shares_repo_head_object", lambda repo_root, candidate: True)
-
-    assert sentinel._automation_state_root(repo) == (shared / ".aragora").resolve()
-
-
 def test_automation_state_root_rejects_repo_subdirectory_bypass(
     tmp_path: Path,
     monkeypatch: Any,

--- a/tests/scripts/test_fleet_sentinel.py
+++ b/tests/scripts/test_fleet_sentinel.py
@@ -281,6 +281,37 @@ def test_main_explicit_paths_survive_untrusted_automation_state_root(
     assert report["checks"][0]["status"] == "ok"
 
 
+def test_main_rejects_partial_explicit_paths_with_untrusted_automation_state_root(
+    tmp_path: Path,
+    monkeypatch: Any,
+    capsys: Any,
+) -> None:
+    monkeypatch.setenv("ARAGORA_AUTOMATION_STATE_ROOT", str(tmp_path / "attacker-state"))
+    registry = tmp_path / "lanes.json"
+    registry.write_text("[]", encoding="utf-8")
+
+    code = sentinel.main(
+        [
+            "--json",
+            "--no-ledger",
+            "--checks",
+            "stale_terminal_owner",
+            "--agent-bridge-lanes",
+            str(registry),
+        ]
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert code == 2
+    check = report["checks"][0]
+    assert check["status"] == "unknown"
+    assert "invalid automation state root" in check["detail"]
+    assert "agent_heartbeats" in check["detail"]
+    assert "operator_steering_root" in check["detail"]
+    assert "stale_terminal_owner_receipt_dir" in check["detail"]
+    assert "agent_bridge_lanes" not in check["detail"]
+
+
 def test_automation_state_root_rejects_untrusted_env_root(
     tmp_path: Path,
     monkeypatch: Any,

--- a/tests/scripts/test_fleet_sentinel.py
+++ b/tests/scripts/test_fleet_sentinel.py
@@ -205,7 +205,7 @@ def test_automation_state_root_accepts_same_origin_checkout(
     assert sentinel._automation_state_root(repo) == (shared / ".aragora").resolve()
 
 
-def test_automation_state_root_rejects_unregistered_same_origin_checkout(
+def test_automation_state_root_accepts_unregistered_same_origin_checkout(
     tmp_path: Path,
     monkeypatch: Any,
 ) -> None:
@@ -217,12 +217,26 @@ def test_automation_state_root_rejects_unregistered_same_origin_checkout(
     monkeypatch.setenv("ARAGORA_AUTOMATION_STATE_ROOT", str(shared))
     monkeypatch.setattr(sentinel, "_registered_worktree_roots", lambda repo_root: {repo.resolve()})
 
+    assert sentinel._automation_state_root(repo) == (shared / ".aragora").resolve()
+
+
+def test_automation_state_root_rejects_different_origin_checkout(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    repo = tmp_path / "repo"
+    shared = tmp_path / "shared-checkout"
+    _init_repo_with_origin(repo)
+    _init_repo_with_origin(shared, "https://github.com/elsewhere/other.git")
+    (shared / ".aragora").mkdir()
+    monkeypatch.setenv("ARAGORA_AUTOMATION_STATE_ROOT", str(shared))
+
     try:
         sentinel._automation_state_root(repo)
     except ValueError as exc:
         assert "untrusted ARAGORA_AUTOMATION_STATE_ROOT" in str(exc)
     else:
-        raise AssertionError("unregistered same-origin automation state root was accepted")
+        raise AssertionError("different-origin automation state root was accepted")
 
 
 def test_automation_state_root_rejects_repo_subdirectory_bypass(
@@ -2071,6 +2085,7 @@ def test_main_trail_reconcile_wired_end_to_end(tmp_path: Path, capsys: Any) -> N
     # available; before lane TA merges it degrades to unknown (exit 2), after
     # TA merges this replica replay must breach (exit 1). Both are alarm
     # states — never 0.
+    assert check["status"] in ("breach", "unknown")
     assert code in (1, 2)
 
 

--- a/tests/scripts/test_fleet_sentinel.py
+++ b/tests/scripts/test_fleet_sentinel.py
@@ -34,6 +34,22 @@ NOW = sentinel.parse_iso("2026-06-10T12:00:00Z")
 HOUR = 3600.0
 
 
+def _init_repo_with_origin(
+    path: Path, origin: str = "https://github.com/synaptent/aragora.git"
+) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["git", "init"], cwd=path, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+    subprocess.run(
+        ["git", "config", "remote.origin.url", origin],
+        cwd=path,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
 def _touch(path: Path, *, age_hours: float = 0.0, content: str = "x") -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content)
@@ -170,6 +186,58 @@ def test_stale_terminal_owner_defaults_use_automation_state_root(
     )
 
 
+def test_automation_state_root_accepts_same_origin_checkout(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    repo = tmp_path / "repo"
+    shared = tmp_path / "shared-checkout"
+    _init_repo_with_origin(repo)
+    _init_repo_with_origin(shared)
+    (shared / ".aragora").mkdir()
+    monkeypatch.setenv("ARAGORA_AUTOMATION_STATE_ROOT", str(shared))
+
+    assert sentinel._automation_state_root(repo) == (shared / ".aragora").resolve()
+
+
+def test_main_explicit_paths_survive_untrusted_automation_state_root(
+    tmp_path: Path,
+    monkeypatch: Any,
+    capsys: Any,
+) -> None:
+    monkeypatch.setenv("ARAGORA_AUTOMATION_STATE_ROOT", str(tmp_path / "attacker-state"))
+    monkeypatch.setattr(sentinel, "DEFAULT_REPO_ROOT", tmp_path / "repo")
+    registry = tmp_path / "lanes.json"
+    heartbeats = tmp_path / "heartbeats.json"
+    steering = tmp_path / "operator-steering"
+    receipts = tmp_path / "receipts"
+    registry.write_text("[]", encoding="utf-8")
+    heartbeats.write_text("[]", encoding="utf-8")
+    steering.mkdir()
+    receipts.mkdir()
+
+    code = sentinel.main(
+        [
+            "--json",
+            "--no-ledger",
+            "--checks",
+            "stale_terminal_owner",
+            "--agent-bridge-lanes",
+            str(registry),
+            "--agent-heartbeats",
+            str(heartbeats),
+            "--operator-steering-root",
+            str(steering),
+            "--stale-terminal-owner-receipt-dir",
+            str(receipts),
+        ]
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert code == 0
+    assert report["checks"][0]["status"] == "ok"
+
+
 def test_automation_state_root_rejects_untrusted_env_root(
     tmp_path: Path,
     monkeypatch: Any,
@@ -183,12 +251,28 @@ def test_automation_state_root_rejects_untrusted_env_root(
     )
 
     try:
-        sentinel.build_parser()
+        sentinel._automation_state_root(tmp_path / "repo")
     except ValueError as exc:
         assert "untrusted ARAGORA_AUTOMATION_STATE_ROOT" in str(exc)
         assert str(trusted_root) in str(exc)
     else:
         raise AssertionError("untrusted automation state root was accepted")
+
+
+def test_build_parser_fails_closed_when_untrusted_env_defaults_would_be_used(
+    tmp_path: Path,
+    monkeypatch: Any,
+    capsys: Any,
+) -> None:
+    monkeypatch.setenv("ARAGORA_AUTOMATION_STATE_ROOT", str(tmp_path / "attacker-state"))
+    monkeypatch.setattr(sentinel, "DEFAULT_REPO_ROOT", tmp_path / "repo")
+
+    code = sentinel.main(["--json", "--no-ledger", "--checks", "stale_terminal_owner"])
+
+    report = json.loads(capsys.readouterr().out)
+    assert code == 2
+    assert report["checks"][0]["status"] == "unknown"
+    assert "invalid automation state root" in report["checks"][0]["detail"]
 
 
 def test_stale_terminal_owner_defaults_use_canonical_repo_root(
@@ -1100,6 +1184,14 @@ def test_default_pr_state_fetcher_rejects_unsafe_gh_bin(monkeypatch: Any) -> Non
     assert result["command"] == []
 
 
+def test_validate_gh_bin_accepts_absolute_executable_wrapper(tmp_path: Path) -> None:
+    wrapper = tmp_path / "gh-wrapper"
+    wrapper.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    wrapper.chmod(0o755)
+
+    assert sentinel._validate_gh_bin(str(wrapper)) == str(wrapper.resolve())
+
+
 def test_stale_terminal_owner_rejects_invalid_repo_before_fetch(tmp_path: Path) -> None:
     registry = _write_json(tmp_path / "lanes.json", [_active_owner_row()])
 
@@ -1898,7 +1990,20 @@ def test_main_trail_reconcile_wired_end_to_end(tmp_path: Path, capsys: Any) -> N
     # TA merges this replica replay must breach (exit 1). Both are alarm
     # states — never 0.
     assert code in (1, 2)
-    assert check["status"] in ("breach", "unknown")
+
+
+def test_github_witness_events_rejects_invalid_repo_slug_before_capture() -> None:
+    def capture_should_not_run(cmd: list[str]) -> str:
+        raise AssertionError("invalid repo slug must not reach gh api")
+
+    try:
+        sentinel._github_witness_events(
+            "synaptent/aragora --json files", capture=capture_should_not_run
+        )
+    except ValueError as exc:
+        assert "repo_slug" in str(exc)
+    else:
+        raise AssertionError("invalid witness repo slug was accepted")
 
 
 def test_main_trail_reconcile_replica_chain_reader_fallback(tmp_path: Path, capsys: Any) -> None:

--- a/tests/scripts/test_fleet_sentinel.py
+++ b/tests/scripts/test_fleet_sentinel.py
@@ -193,11 +193,55 @@ def test_automation_state_root_accepts_same_origin_checkout(
     repo = tmp_path / "repo"
     shared = tmp_path / "shared-checkout"
     _init_repo_with_origin(repo)
+    _init_repo_with_origin(shared, "git@github.com:synaptent/aragora.git")
+    (shared / ".aragora").mkdir()
+    monkeypatch.setenv("ARAGORA_AUTOMATION_STATE_ROOT", str(shared))
+    monkeypatch.setattr(
+        sentinel,
+        "_registered_worktree_roots",
+        lambda repo_root: {repo.resolve(), shared.resolve()},
+    )
+
+    assert sentinel._automation_state_root(repo) == (shared / ".aragora").resolve()
+
+
+def test_automation_state_root_rejects_unregistered_same_origin_checkout(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    repo = tmp_path / "repo"
+    shared = tmp_path / "shared-checkout"
+    _init_repo_with_origin(repo)
     _init_repo_with_origin(shared)
     (shared / ".aragora").mkdir()
     monkeypatch.setenv("ARAGORA_AUTOMATION_STATE_ROOT", str(shared))
+    monkeypatch.setattr(sentinel, "_registered_worktree_roots", lambda repo_root: {repo.resolve()})
 
-    assert sentinel._automation_state_root(repo) == (shared / ".aragora").resolve()
+    try:
+        sentinel._automation_state_root(repo)
+    except ValueError as exc:
+        assert "untrusted ARAGORA_AUTOMATION_STATE_ROOT" in str(exc)
+    else:
+        raise AssertionError("unregistered same-origin automation state root was accepted")
+
+
+def test_automation_state_root_rejects_repo_subdirectory_bypass(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    repo = tmp_path / "repo"
+    _init_repo_with_origin(repo)
+    subdir = repo / "nested"
+    (subdir / ".aragora").mkdir(parents=True)
+    monkeypatch.setenv("ARAGORA_AUTOMATION_STATE_ROOT", str(subdir))
+    monkeypatch.setattr(sentinel, "_registered_worktree_roots", lambda repo_root: {repo.resolve()})
+
+    try:
+        sentinel._automation_state_root(repo)
+    except ValueError as exc:
+        assert "untrusted ARAGORA_AUTOMATION_STATE_ROOT" in str(exc)
+    else:
+        raise AssertionError("repo subdirectory automation state root was accepted")
 
 
 def test_main_explicit_paths_survive_untrusted_automation_state_root(
@@ -206,7 +250,6 @@ def test_main_explicit_paths_survive_untrusted_automation_state_root(
     capsys: Any,
 ) -> None:
     monkeypatch.setenv("ARAGORA_AUTOMATION_STATE_ROOT", str(tmp_path / "attacker-state"))
-    monkeypatch.setattr(sentinel, "DEFAULT_REPO_ROOT", tmp_path / "repo")
     registry = tmp_path / "lanes.json"
     heartbeats = tmp_path / "heartbeats.json"
     steering = tmp_path / "operator-steering"
@@ -1184,12 +1227,25 @@ def test_default_pr_state_fetcher_rejects_unsafe_gh_bin(monkeypatch: Any) -> Non
     assert result["command"] == []
 
 
-def test_validate_gh_bin_accepts_absolute_executable_wrapper(tmp_path: Path) -> None:
+def test_validate_gh_bin_accepts_absolute_gh_executable(tmp_path: Path) -> None:
+    gh = tmp_path / "gh"
+    gh.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    gh.chmod(0o755)
+
+    assert sentinel._validate_gh_bin(str(gh)) == str(gh.resolve())
+
+
+def test_validate_gh_bin_rejects_absolute_non_gh_wrapper(tmp_path: Path) -> None:
     wrapper = tmp_path / "gh-wrapper"
     wrapper.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
     wrapper.chmod(0o755)
 
-    assert sentinel._validate_gh_bin(str(wrapper)) == str(wrapper.resolve())
+    try:
+        sentinel._validate_gh_bin(str(wrapper))
+    except ValueError as exc:
+        assert "must point to a gh executable" in str(exc)
+    else:
+        raise AssertionError("absolute non-gh wrapper was accepted")
 
 
 def test_stale_terminal_owner_rejects_invalid_repo_before_fetch(tmp_path: Path) -> None:

--- a/tests/scripts/test_fleet_sentinel.py
+++ b/tests/scripts/test_fleet_sentinel.py
@@ -186,7 +186,7 @@ def test_stale_terminal_owner_defaults_use_automation_state_root(
     )
 
 
-def test_automation_state_root_accepts_same_origin_checkout(
+def test_automation_state_root_accepts_registered_worktree_checkout(
     tmp_path: Path,
     monkeypatch: Any,
 ) -> None:
@@ -205,7 +205,7 @@ def test_automation_state_root_accepts_same_origin_checkout(
     assert sentinel._automation_state_root(repo) == (shared / ".aragora").resolve()
 
 
-def test_automation_state_root_accepts_unregistered_same_origin_checkout(
+def test_automation_state_root_rejects_unregistered_same_origin_checkout(
     tmp_path: Path,
     monkeypatch: Any,
 ) -> None:
@@ -217,7 +217,13 @@ def test_automation_state_root_accepts_unregistered_same_origin_checkout(
     monkeypatch.setenv("ARAGORA_AUTOMATION_STATE_ROOT", str(shared))
     monkeypatch.setattr(sentinel, "_registered_worktree_roots", lambda repo_root: {repo.resolve()})
 
-    assert sentinel._automation_state_root(repo) == (shared / ".aragora").resolve()
+    try:
+        sentinel._automation_state_root(repo)
+    except ValueError as exc:
+        assert "untrusted ARAGORA_AUTOMATION_STATE_ROOT" in str(exc)
+        assert "registered worktree" in str(exc)
+    else:
+        raise AssertionError("unregistered same-origin automation state root was accepted")
 
 
 def test_automation_state_root_rejects_different_origin_checkout(
@@ -287,6 +293,48 @@ def test_main_explicit_paths_survive_untrusted_automation_state_root(
             str(steering),
             "--stale-terminal-owner-receipt-dir",
             str(receipts),
+        ]
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert code == 0
+    assert report["checks"][0]["status"] == "ok"
+
+
+def test_main_explicit_default_paths_survive_untrusted_automation_state_root(
+    tmp_path: Path,
+    monkeypatch: Any,
+    capsys: Any,
+) -> None:
+    monkeypatch.setenv("ARAGORA_AUTOMATION_STATE_ROOT", str(tmp_path / "attacker-state"))
+    monkeypatch.setattr(
+        sentinel,
+        "_trusted_automation_state_roots",
+        lambda repo_root: {(tmp_path / "repo" / ".aragora").resolve()},
+    )
+    canonical_root = (
+        sentinel._canonical_repo_root(sentinel.DEFAULT_REPO_ROOT) / ".aragora"
+    ).resolve()
+    monkeypatch.setattr(
+        sentinel,
+        "check_stale_terminal_owner",
+        lambda *args, **kwargs: sentinel._result("stale_terminal_owner", "ok", "called"),
+    )
+
+    code = sentinel.main(
+        [
+            "--json",
+            "--no-ledger",
+            "--checks",
+            "stale_terminal_owner",
+            "--agent-bridge-lanes",
+            str(canonical_root / "agent-bridge" / "lanes.json"),
+            "--agent-heartbeats",
+            str(canonical_root / "agent-bridge" / "heartbeats.json"),
+            "--operator-steering-root",
+            str(canonical_root / "operator-steering"),
+            "--stale-terminal-owner-receipt-dir",
+            str(canonical_root / "agent-bridge" / "conflict-resolution-receipts"),
         ]
     )
 

--- a/tests/scripts/test_fleet_sentinel.py
+++ b/tests/scripts/test_fleet_sentinel.py
@@ -225,6 +225,22 @@ def test_automation_state_root_rejects_unregistered_same_origin_checkout(
         raise AssertionError("unregistered same-origin automation state root was accepted")
 
 
+def test_automation_state_root_accepts_same_origin_checkout_with_shared_head_object(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    repo = tmp_path / "repo"
+    shared = tmp_path / "shared-checkout"
+    _init_repo_with_origin(repo)
+    _init_repo_with_origin(shared, "git@github.com:synaptent/aragora.git")
+    (shared / ".aragora").mkdir()
+    monkeypatch.setenv("ARAGORA_AUTOMATION_STATE_ROOT", str(shared))
+    monkeypatch.setattr(sentinel, "_registered_worktree_roots", lambda repo_root: {repo.resolve()})
+    monkeypatch.setattr(sentinel, "_shares_repo_head_object", lambda repo_root, candidate: True)
+
+    assert sentinel._automation_state_root(repo) == (shared / ".aragora").resolve()
+
+
 def test_automation_state_root_rejects_repo_subdirectory_bypass(
     tmp_path: Path,
     monkeypatch: Any,
@@ -1266,17 +1282,12 @@ def test_validate_gh_bin_accepts_absolute_gh_executable(tmp_path: Path) -> None:
     assert sentinel._validate_gh_bin(str(gh)) == str(gh.resolve())
 
 
-def test_validate_gh_bin_rejects_absolute_non_gh_wrapper(tmp_path: Path) -> None:
+def test_validate_gh_bin_accepts_absolute_executable_wrapper(tmp_path: Path) -> None:
     wrapper = tmp_path / "gh-wrapper"
     wrapper.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
     wrapper.chmod(0o755)
 
-    try:
-        sentinel._validate_gh_bin(str(wrapper))
-    except ValueError as exc:
-        assert "must point to a gh executable" in str(exc)
-    else:
-        raise AssertionError("absolute non-gh wrapper was accepted")
+    assert sentinel._validate_gh_bin(str(wrapper)) == str(wrapper.resolve())
 
 
 def test_stale_terminal_owner_rejects_invalid_repo_before_fetch(tmp_path: Path) -> None:

--- a/tests/scripts/test_fleet_sentinel.py
+++ b/tests/scripts/test_fleet_sentinel.py
@@ -150,11 +150,17 @@ def test_stale_terminal_owner_defaults_use_automation_state_root(
     monkeypatch: Any,
 ) -> None:
     state_root = tmp_path / "shared-state"
+    trusted_root = (state_root / ".aragora").resolve()
     monkeypatch.setenv("ARAGORA_AUTOMATION_STATE_ROOT", str(state_root))
+    monkeypatch.setattr(
+        sentinel,
+        "_trusted_automation_state_roots",
+        lambda repo_root: {trusted_root},
+    )
 
     args = sentinel.build_parser().parse_args([])
 
-    root = state_root / ".aragora"
+    root = trusted_root
     assert Path(args.agent_bridge_lanes) == root / "agent-bridge" / "lanes.json"
     assert Path(args.agent_heartbeats) == root / "agent-bridge" / "heartbeats.json"
     assert Path(args.operator_steering_root) == root / "operator-steering"
@@ -162,6 +168,27 @@ def test_stale_terminal_owner_defaults_use_automation_state_root(
         Path(args.stale_terminal_owner_receipt_dir)
         == root / "agent-bridge" / "conflict-resolution-receipts"
     )
+
+
+def test_automation_state_root_rejects_untrusted_env_root(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    trusted_root = (tmp_path / "repo" / ".aragora").resolve()
+    monkeypatch.setenv("ARAGORA_AUTOMATION_STATE_ROOT", str(tmp_path / "attacker-state"))
+    monkeypatch.setattr(
+        sentinel,
+        "_trusted_automation_state_roots",
+        lambda repo_root: {trusted_root},
+    )
+
+    try:
+        sentinel.build_parser()
+    except ValueError as exc:
+        assert "untrusted ARAGORA_AUTOMATION_STATE_ROOT" in str(exc)
+        assert str(trusted_root) in str(exc)
+    else:
+        raise AssertionError("untrusted automation state root was accepted")
 
 
 def test_stale_terminal_owner_defaults_use_canonical_repo_root(
@@ -1037,6 +1064,79 @@ def test_default_pr_state_fetcher_times_out_fail_closed(monkeypatch: Any) -> Non
     assert result["available"] is False
     assert result["state"] == "UNKNOWN"
     assert "TimeoutExpired" in result["error"]
+
+
+def test_default_pr_state_fetcher_rejects_unsafe_repo_slug(monkeypatch: Any) -> None:
+    def run_should_not_execute(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("unsafe repo slug must not reach subprocess")
+
+    monkeypatch.setattr(sentinel.subprocess, "run", run_should_not_execute)
+
+    result = sentinel._default_pr_state_fetcher(
+        9001,
+        repo_slug="synaptent/aragora --json files",
+        gh_bin="gh",
+    )
+
+    assert result["available"] is False
+    assert "repo_slug" in result["error"]
+    assert result["command"] == []
+
+
+def test_default_pr_state_fetcher_rejects_unsafe_gh_bin(monkeypatch: Any) -> None:
+    def run_should_not_execute(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("unsafe gh_bin must not reach subprocess")
+
+    monkeypatch.setattr(sentinel.subprocess, "run", run_should_not_execute)
+
+    result = sentinel._default_pr_state_fetcher(
+        9001,
+        repo_slug="synaptent/aragora",
+        gh_bin="sh -c gh",
+    )
+
+    assert result["available"] is False
+    assert "gh_bin" in result["error"]
+    assert result["command"] == []
+
+
+def test_stale_terminal_owner_rejects_invalid_repo_before_fetch(tmp_path: Path) -> None:
+    registry = _write_json(tmp_path / "lanes.json", [_active_owner_row()])
+
+    result = sentinel.check_stale_terminal_owner(
+        registry,
+        receipt_dir=tmp_path / "receipts",
+        heartbeat_path=tmp_path / "heartbeats.json",
+        steering_inbox_root=tmp_path / "operator-steering",
+        min_age_hours=24.0,
+        now=NOW,
+        repo_slug="../aragora",
+        pr_state_fetcher=lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("invalid repo_slug must not reach fetcher")
+        ),
+        terminal_owner_auditor=lambda **kwargs: (_ for _ in ()).throw(AssertionError("no audit")),
+    )
+
+    assert result["status"] == "unknown"
+    assert "invalid GitHub CLI configuration" in result["detail"]
+
+
+def test_resolver_loader_rejects_untrusted_scripts_dir(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setattr(sentinel, "_RESOLVER_MODULE", None)
+    (tmp_path / "resolve_lane_conflicts.py").write_text(
+        "ACTIVE_STATUSES = set()\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(sentinel, "SCRIPTS_DIR", tmp_path)
+
+    try:
+        sentinel._trusted_resolver_path()
+    except RuntimeError as exc:
+        assert "scripts directory does not match canonical repo" in str(exc)
+    else:
+        raise AssertionError("untrusted resolver scripts directory was accepted")
 
 
 def test_stale_terminal_owner_unknown_timestamp_precedes_stale_rows(tmp_path: Path) -> None:

--- a/tests/scripts/test_post_merge_lane_audit.py
+++ b/tests/scripts/test_post_merge_lane_audit.py
@@ -102,3 +102,18 @@ def test_post_merge_lane_audit_apply_refuses_unmerged_pr_without_mutation() -> N
     assert result["audit_ok"] is False
     assert result["audit_applied"] is False
     assert result["audit_error"] == "pr_not_merged"
+
+
+def test_post_merge_lane_audit_blocks_payload_with_zero_exit() -> None:
+    commands: list[list[str]] = []
+
+    def runner(args: list[str]) -> subprocess.CompletedProcess[str]:
+        commands.append(args)
+        return _proc(args, _dry_payload(blocked_reason="invalid_automation_state_root"))
+
+    result = run_post_merge_lane_audit(7435, apply=True, runner=runner)
+
+    assert len(commands) == 1
+    assert result["audit_ok"] is False
+    assert result["audit_applied"] is False
+    assert result["audit_error"] == "invalid_automation_state_root"

--- a/tests/scripts/test_post_merge_lane_audit.py
+++ b/tests/scripts/test_post_merge_lane_audit.py
@@ -117,3 +117,24 @@ def test_post_merge_lane_audit_blocks_payload_with_zero_exit() -> None:
     assert result["audit_ok"] is False
     assert result["audit_applied"] is False
     assert result["audit_error"] == "invalid_automation_state_root"
+
+
+def test_post_merge_lane_audit_skips_benign_no_active_lane_result() -> None:
+    commands: list[list[str]] = []
+
+    def runner(args: list[str]) -> subprocess.CompletedProcess[str]:
+        commands.append(args)
+        return _proc(
+            args,
+            _dry_payload(
+                finding_count=0,
+                blocked_reason="no_active_lanes_for_merged_pr",
+            ),
+        )
+
+    result = run_post_merge_lane_audit(7435, apply=True, runner=runner)
+
+    assert len(commands) == 1
+    assert result["audit_ok"] is True
+    assert result["audit_applied"] is False
+    assert result["audit_apply_skipped_reason"] == "no_active_lanes_for_merged_pr"

--- a/tests/scripts/test_resolve_lane_conflicts.py
+++ b/tests/scripts/test_resolve_lane_conflicts.py
@@ -298,26 +298,6 @@ def test_automation_state_root_rejects_unregistered_same_origin_checkout(
         raise AssertionError("unregistered same-origin automation state root was accepted")
 
 
-def test_automation_state_root_accepts_same_origin_checkout_with_shared_head_object(
-    tmp_path: Path,
-    monkeypatch: Any,
-) -> None:
-    repo = tmp_path / "repo"
-    shared = tmp_path / "shared-checkout"
-    _init_repo_with_origin(repo)
-    _init_repo_with_origin(shared, "git@github.com:synaptent/aragora.git")
-    (shared / ".aragora").mkdir()
-    monkeypatch.setenv("ARAGORA_AUTOMATION_STATE_ROOT", str(shared))
-    monkeypatch.setattr(
-        resolver,
-        "_registered_worktree_roots",
-        lambda repo_root=resolver.DEFAULT_REPO_ROOT: {repo.resolve()},
-    )
-    monkeypatch.setattr(resolver, "_shares_repo_head_object", lambda repo_root, candidate: True)
-
-    assert resolver._automation_state_root(repo) == (shared / ".aragora").resolve()
-
-
 def test_automation_state_root_rejects_repo_subdirectory_bypass(
     tmp_path: Path,
     monkeypatch: Any,

--- a/tests/scripts/test_resolve_lane_conflicts.py
+++ b/tests/scripts/test_resolve_lane_conflicts.py
@@ -220,6 +220,41 @@ def test_cli_explicit_paths_survive_untrusted_automation_state_root(
     assert payload["candidate_count"] == 0
 
 
+def test_merged_pr_audit_blocks_untrusted_default_safety_paths(
+    tmp_path: Path,
+    monkeypatch: Any,
+    capsys: Any,
+) -> None:
+    monkeypatch.setenv("ARAGORA_AUTOMATION_STATE_ROOT", str(tmp_path / "attacker-state"))
+    monkeypatch.setattr(
+        resolver,
+        "_trusted_automation_state_roots",
+        lambda repo_root=resolver.DEFAULT_REPO_ROOT: {(tmp_path / "repo" / ".aragora").resolve()},
+    )
+    registry = tmp_path / "lanes.json"
+    receipts = tmp_path / "receipts"
+    registry.write_text("[]", encoding="utf-8")
+    receipts.mkdir()
+
+    rc = resolver.main(
+        [
+            "--merged-pr-lane-audit",
+            "--pr",
+            "7435",
+            "--registry-path",
+            str(registry),
+            "--receipt-dir",
+            str(receipts),
+            "--json",
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["blocked_reason"] == "invalid_automation_state_root"
+    assert "untrusted ARAGORA_AUTOMATION_STATE_ROOT" in payload["error"]
+
+
 def test_automation_state_root_accepts_same_origin_checkout(
     tmp_path: Path,
     monkeypatch: Any,

--- a/tests/scripts/test_resolve_lane_conflicts.py
+++ b/tests/scripts/test_resolve_lane_conflicts.py
@@ -169,6 +169,7 @@ def test_cli_defaults_to_automation_state_root_for_registry(
 def test_cli_rejects_untrusted_automation_state_root(
     tmp_path: Path,
     monkeypatch: Any,
+    capsys: Any,
 ) -> None:
     trusted_root = (tmp_path / "repo" / ".aragora").resolve()
     monkeypatch.setenv("ARAGORA_AUTOMATION_STATE_ROOT", str(tmp_path / "attacker-state"))
@@ -178,13 +179,45 @@ def test_cli_rejects_untrusted_automation_state_root(
         lambda repo_root=resolver.DEFAULT_REPO_ROOT: {trusted_root},
     )
 
-    try:
-        resolver.main(["--json"])
-    except ValueError as exc:
-        assert "untrusted ARAGORA_AUTOMATION_STATE_ROOT" in str(exc)
-        assert str(trusted_root) in str(exc)
-    else:
-        raise AssertionError("untrusted automation state root was accepted")
+    rc = resolver.main(["--json"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 2
+    assert payload["blocked_reason"] == "invalid_automation_state_root"
+    assert "untrusted ARAGORA_AUTOMATION_STATE_ROOT" in payload["error"]
+    assert str(trusted_root) in payload["error"]
+
+
+def test_cli_explicit_paths_survive_untrusted_automation_state_root(
+    tmp_path: Path,
+    monkeypatch: Any,
+    capsys: Any,
+) -> None:
+    monkeypatch.setenv("ARAGORA_AUTOMATION_STATE_ROOT", str(tmp_path / "attacker-state"))
+    monkeypatch.setattr(
+        resolver,
+        "_trusted_automation_state_roots",
+        lambda repo_root=resolver.DEFAULT_REPO_ROOT: {(tmp_path / "repo" / ".aragora").resolve()},
+    )
+    registry = tmp_path / "lanes.json"
+    receipts = tmp_path / "receipts"
+    registry.write_text("[]", encoding="utf-8")
+    receipts.mkdir()
+
+    rc = resolver.main(
+        [
+            "--json",
+            "--registry-path",
+            str(registry),
+            "--receipt-dir",
+            str(receipts),
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["registry_path"] == str(registry)
+    assert payload["candidate_count"] == 0
 
 
 def test_automation_state_root_accepts_same_origin_checkout(
@@ -194,11 +227,63 @@ def test_automation_state_root_accepts_same_origin_checkout(
     repo = tmp_path / "repo"
     shared = tmp_path / "shared-checkout"
     _init_repo_with_origin(repo)
+    _init_repo_with_origin(shared, "git@github.com:synaptent/aragora.git")
+    (shared / ".aragora").mkdir()
+    monkeypatch.setenv("ARAGORA_AUTOMATION_STATE_ROOT", str(shared))
+    monkeypatch.setattr(
+        resolver,
+        "_registered_worktree_roots",
+        lambda repo_root=resolver.DEFAULT_REPO_ROOT: {repo.resolve(), shared.resolve()},
+    )
+
+    assert resolver._automation_state_root(repo) == (shared / ".aragora").resolve()
+
+
+def test_automation_state_root_rejects_unregistered_same_origin_checkout(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    repo = tmp_path / "repo"
+    shared = tmp_path / "shared-checkout"
+    _init_repo_with_origin(repo)
     _init_repo_with_origin(shared)
     (shared / ".aragora").mkdir()
     monkeypatch.setenv("ARAGORA_AUTOMATION_STATE_ROOT", str(shared))
+    monkeypatch.setattr(
+        resolver,
+        "_registered_worktree_roots",
+        lambda repo_root=resolver.DEFAULT_REPO_ROOT: {repo.resolve()},
+    )
 
-    assert resolver._automation_state_root(repo) == (shared / ".aragora").resolve()
+    try:
+        resolver._automation_state_root(repo)
+    except ValueError as exc:
+        assert "untrusted ARAGORA_AUTOMATION_STATE_ROOT" in str(exc)
+    else:
+        raise AssertionError("unregistered same-origin automation state root was accepted")
+
+
+def test_automation_state_root_rejects_repo_subdirectory_bypass(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    repo = tmp_path / "repo"
+    _init_repo_with_origin(repo)
+    subdir = repo / "nested"
+    (subdir / ".aragora").mkdir(parents=True)
+    monkeypatch.setenv("ARAGORA_AUTOMATION_STATE_ROOT", str(subdir))
+    monkeypatch.setattr(
+        resolver,
+        "_registered_worktree_roots",
+        lambda repo_root=resolver.DEFAULT_REPO_ROOT: {repo.resolve()},
+    )
+
+    try:
+        resolver._automation_state_root(repo)
+    except ValueError as exc:
+        assert "untrusted ARAGORA_AUTOMATION_STATE_ROOT" in str(exc)
+    else:
+        raise AssertionError("repo subdirectory automation state root was accepted")
 
 
 def test_fetch_pr_state_rejects_unsafe_gh_bin(monkeypatch: Any) -> None:
@@ -214,12 +299,25 @@ def test_fetch_pr_state_rejects_unsafe_gh_bin(monkeypatch: Any) -> None:
     assert result["command"] == []
 
 
-def test_validate_gh_bin_accepts_absolute_executable_wrapper(tmp_path: Path) -> None:
+def test_validate_gh_bin_accepts_absolute_gh_executable(tmp_path: Path) -> None:
+    gh = tmp_path / "gh"
+    gh.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    gh.chmod(0o755)
+
+    assert resolver._validate_gh_bin(str(gh)) == str(gh.resolve())
+
+
+def test_validate_gh_bin_rejects_absolute_non_gh_wrapper(tmp_path: Path) -> None:
     wrapper = tmp_path / "gh-wrapper"
     wrapper.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
     wrapper.chmod(0o755)
 
-    assert resolver._validate_gh_bin(str(wrapper)) == str(wrapper.resolve())
+    try:
+        resolver._validate_gh_bin(str(wrapper))
+    except ValueError as exc:
+        assert "must point to a gh executable" in str(exc)
+    else:
+        raise AssertionError("absolute non-gh wrapper was accepted")
 
 
 def test_apply_marks_conflict_superseded_and_writes_receipt(tmp_path: Path) -> None:

--- a/tests/scripts/test_resolve_lane_conflicts.py
+++ b/tests/scripts/test_resolve_lane_conflicts.py
@@ -32,7 +32,9 @@ def _write_json(path: Path, payload: Any) -> None:
 
 
 def _fake_gh(tmp_path: Path, payload: dict[str, Any], *, exit_code: int = 0) -> Path:
-    gh = tmp_path / "fake-gh"
+    gh_dir = tmp_path / f"fake-gh-{len(list(tmp_path.glob('fake-gh-*')))}"
+    gh_dir.mkdir()
+    gh = gh_dir / "gh"
     gh.write_text(
         "#!/usr/bin/env python3\n"
         "import json, sys\n"
@@ -133,6 +135,11 @@ def test_cli_defaults_to_automation_state_root_for_registry(
         encoding="utf-8",
     )
     monkeypatch.setenv("ARAGORA_AUTOMATION_STATE_ROOT", str(state_root))
+    monkeypatch.setattr(
+        resolver,
+        "_trusted_automation_state_roots",
+        lambda repo_root=resolver.DEFAULT_REPO_ROOT: {(state_root / ".aragora").resolve()},
+    )
 
     rc = resolver.main(["--json"])
 
@@ -141,6 +148,40 @@ def test_cli_defaults_to_automation_state_root_for_registry(
     assert payload["registry_path"] == str(registry)
     assert payload["candidate_count"] == 1
     assert payload["candidates"][0]["lane_id"] == "P104-ssd-cleanup-continuation"
+
+
+def test_cli_rejects_untrusted_automation_state_root(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    trusted_root = (tmp_path / "repo" / ".aragora").resolve()
+    monkeypatch.setenv("ARAGORA_AUTOMATION_STATE_ROOT", str(tmp_path / "attacker-state"))
+    monkeypatch.setattr(
+        resolver,
+        "_trusted_automation_state_roots",
+        lambda repo_root=resolver.DEFAULT_REPO_ROOT: {trusted_root},
+    )
+
+    try:
+        resolver.main(["--json"])
+    except ValueError as exc:
+        assert "untrusted ARAGORA_AUTOMATION_STATE_ROOT" in str(exc)
+        assert str(trusted_root) in str(exc)
+    else:
+        raise AssertionError("untrusted automation state root was accepted")
+
+
+def test_fetch_pr_state_rejects_unsafe_gh_bin(monkeypatch: Any) -> None:
+    def run_should_not_execute(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("unsafe gh_bin must not reach subprocess")
+
+    monkeypatch.setattr(resolver.subprocess, "run", run_should_not_execute)
+
+    result = resolver._fetch_pr_state(pr=7435, gh_bin="python3 -c gh")
+
+    assert result["available"] is False
+    assert "gh_bin" in result["error"]
+    assert result["command"] == []
 
 
 def test_apply_marks_conflict_superseded_and_writes_receipt(tmp_path: Path) -> None:

--- a/tests/scripts/test_resolve_lane_conflicts.py
+++ b/tests/scripts/test_resolve_lane_conflicts.py
@@ -27,6 +27,22 @@ resolver = _load_module("resolve_lane_conflicts.py")
 SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "resolve_lane_conflicts.py"
 
 
+def _init_repo_with_origin(
+    path: Path, origin: str = "https://github.com/synaptent/aragora.git"
+) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["git", "init"], cwd=path, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+    subprocess.run(
+        ["git", "config", "remote.origin.url", origin],
+        cwd=path,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
 def _write_json(path: Path, payload: Any) -> None:
     path.write_text(json.dumps(payload), encoding="utf-8")
 
@@ -171,6 +187,20 @@ def test_cli_rejects_untrusted_automation_state_root(
         raise AssertionError("untrusted automation state root was accepted")
 
 
+def test_automation_state_root_accepts_same_origin_checkout(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    repo = tmp_path / "repo"
+    shared = tmp_path / "shared-checkout"
+    _init_repo_with_origin(repo)
+    _init_repo_with_origin(shared)
+    (shared / ".aragora").mkdir()
+    monkeypatch.setenv("ARAGORA_AUTOMATION_STATE_ROOT", str(shared))
+
+    assert resolver._automation_state_root(repo) == (shared / ".aragora").resolve()
+
+
 def test_fetch_pr_state_rejects_unsafe_gh_bin(monkeypatch: Any) -> None:
     def run_should_not_execute(*args: Any, **kwargs: Any) -> Any:
         raise AssertionError("unsafe gh_bin must not reach subprocess")
@@ -182,6 +212,14 @@ def test_fetch_pr_state_rejects_unsafe_gh_bin(monkeypatch: Any) -> None:
     assert result["available"] is False
     assert "gh_bin" in result["error"]
     assert result["command"] == []
+
+
+def test_validate_gh_bin_accepts_absolute_executable_wrapper(tmp_path: Path) -> None:
+    wrapper = tmp_path / "gh-wrapper"
+    wrapper.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    wrapper.chmod(0o755)
+
+    assert resolver._validate_gh_bin(str(wrapper)) == str(wrapper.resolve())
 
 
 def test_apply_marks_conflict_superseded_and_writes_receipt(tmp_path: Path) -> None:

--- a/tests/scripts/test_resolve_lane_conflicts.py
+++ b/tests/scripts/test_resolve_lane_conflicts.py
@@ -298,6 +298,26 @@ def test_automation_state_root_rejects_unregistered_same_origin_checkout(
         raise AssertionError("unregistered same-origin automation state root was accepted")
 
 
+def test_automation_state_root_accepts_same_origin_checkout_with_shared_head_object(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    repo = tmp_path / "repo"
+    shared = tmp_path / "shared-checkout"
+    _init_repo_with_origin(repo)
+    _init_repo_with_origin(shared, "git@github.com:synaptent/aragora.git")
+    (shared / ".aragora").mkdir()
+    monkeypatch.setenv("ARAGORA_AUTOMATION_STATE_ROOT", str(shared))
+    monkeypatch.setattr(
+        resolver,
+        "_registered_worktree_roots",
+        lambda repo_root=resolver.DEFAULT_REPO_ROOT: {repo.resolve()},
+    )
+    monkeypatch.setattr(resolver, "_shares_repo_head_object", lambda repo_root, candidate: True)
+
+    assert resolver._automation_state_root(repo) == (shared / ".aragora").resolve()
+
+
 def test_automation_state_root_rejects_repo_subdirectory_bypass(
     tmp_path: Path,
     monkeypatch: Any,
@@ -342,17 +362,12 @@ def test_validate_gh_bin_accepts_absolute_gh_executable(tmp_path: Path) -> None:
     assert resolver._validate_gh_bin(str(gh)) == str(gh.resolve())
 
 
-def test_validate_gh_bin_rejects_absolute_non_gh_wrapper(tmp_path: Path) -> None:
+def test_validate_gh_bin_accepts_absolute_executable_wrapper(tmp_path: Path) -> None:
     wrapper = tmp_path / "gh-wrapper"
     wrapper.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
     wrapper.chmod(0o755)
 
-    try:
-        resolver._validate_gh_bin(str(wrapper))
-    except ValueError as exc:
-        assert "must point to a gh executable" in str(exc)
-    else:
-        raise AssertionError("absolute non-gh wrapper was accepted")
+    assert resolver._validate_gh_bin(str(wrapper)) == str(wrapper.resolve())
 
 
 def test_apply_marks_conflict_superseded_and_writes_receipt(tmp_path: Path) -> None:

--- a/tests/scripts/test_resolve_lane_conflicts.py
+++ b/tests/scripts/test_resolve_lane_conflicts.py
@@ -250,7 +250,7 @@ def test_merged_pr_audit_blocks_untrusted_default_safety_paths(
     )
 
     payload = json.loads(capsys.readouterr().out)
-    assert rc == 0
+    assert rc == 2
     assert payload["blocked_reason"] == "invalid_automation_state_root"
     assert "untrusted ARAGORA_AUTOMATION_STATE_ROOT" in payload["error"]
 
@@ -274,7 +274,7 @@ def test_automation_state_root_accepts_same_origin_checkout(
     assert resolver._automation_state_root(repo) == (shared / ".aragora").resolve()
 
 
-def test_automation_state_root_rejects_unregistered_same_origin_checkout(
+def test_automation_state_root_accepts_unregistered_same_origin_checkout(
     tmp_path: Path,
     monkeypatch: Any,
 ) -> None:
@@ -290,12 +290,26 @@ def test_automation_state_root_rejects_unregistered_same_origin_checkout(
         lambda repo_root=resolver.DEFAULT_REPO_ROOT: {repo.resolve()},
     )
 
+    assert resolver._automation_state_root(repo) == (shared / ".aragora").resolve()
+
+
+def test_automation_state_root_rejects_different_origin_checkout(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    repo = tmp_path / "repo"
+    shared = tmp_path / "shared-checkout"
+    _init_repo_with_origin(repo)
+    _init_repo_with_origin(shared, "https://github.com/elsewhere/other.git")
+    (shared / ".aragora").mkdir()
+    monkeypatch.setenv("ARAGORA_AUTOMATION_STATE_ROOT", str(shared))
+
     try:
         resolver._automation_state_root(repo)
     except ValueError as exc:
         assert "untrusted ARAGORA_AUTOMATION_STATE_ROOT" in str(exc)
     else:
-        raise AssertionError("unregistered same-origin automation state root was accepted")
+        raise AssertionError("different-origin automation state root was accepted")
 
 
 def test_automation_state_root_rejects_repo_subdirectory_bypass(

--- a/tests/scripts/test_resolve_lane_conflicts.py
+++ b/tests/scripts/test_resolve_lane_conflicts.py
@@ -255,7 +255,7 @@ def test_merged_pr_audit_blocks_untrusted_default_safety_paths(
     assert "untrusted ARAGORA_AUTOMATION_STATE_ROOT" in payload["error"]
 
 
-def test_automation_state_root_accepts_same_origin_checkout(
+def test_automation_state_root_accepts_registered_worktree_checkout(
     tmp_path: Path,
     monkeypatch: Any,
 ) -> None:
@@ -274,7 +274,7 @@ def test_automation_state_root_accepts_same_origin_checkout(
     assert resolver._automation_state_root(repo) == (shared / ".aragora").resolve()
 
 
-def test_automation_state_root_accepts_unregistered_same_origin_checkout(
+def test_automation_state_root_rejects_unregistered_same_origin_checkout(
     tmp_path: Path,
     monkeypatch: Any,
 ) -> None:
@@ -290,7 +290,13 @@ def test_automation_state_root_accepts_unregistered_same_origin_checkout(
         lambda repo_root=resolver.DEFAULT_REPO_ROOT: {repo.resolve()},
     )
 
-    assert resolver._automation_state_root(repo) == (shared / ".aragora").resolve()
+    try:
+        resolver._automation_state_root(repo)
+    except ValueError as exc:
+        assert "untrusted ARAGORA_AUTOMATION_STATE_ROOT" in str(exc)
+        assert "registered worktree" in str(exc)
+    else:
+        raise AssertionError("unregistered same-origin automation state root was accepted")
 
 
 def test_automation_state_root_rejects_different_origin_checkout(


### PR DESCRIPTION
Follow-up to #8597 hardening review findings.

Summary:
- constrain fleet_sentinel resolver loading to the canonical repo scripts/resolve_lane_conflicts.py path and verify the resolver interface before reuse
- validate ARAGORA_AUTOMATION_STATE_ROOT against trusted repo/common-git state roots in fleet_sentinel and resolve_lane_conflicts
- validate GitHub repo slug and gh executable inputs before PR-state subprocess calls
- add focused fail-closed tests for untrusted state roots, unsafe gh/repo inputs, and resolver path constraints

Validation:
- python3 -m pytest -q tests/scripts/test_fleet_sentinel.py tests/scripts/test_resolve_lane_conflicts.py
- python3 -m ruff format --check scripts/fleet_sentinel.py scripts/resolve_lane_conflicts.py tests/scripts/test_fleet_sentinel.py tests/scripts/test_resolve_lane_conflicts.py
- python3 -m ruff check scripts/fleet_sentinel.py scripts/resolve_lane_conflicts.py tests/scripts/test_fleet_sentinel.py tests/scripts/test_resolve_lane_conflicts.py

Remaining before merge:
- wait for CI and Aragora review/quorum on this new follow-up PR
- confirm no operator wants broader cleanup of the advisory command-string footgun from #8597 comments