### PR TITLE
Fix fleet sentinel hardening review gaps

### DIFF
--- a/scripts/fleet_sentinel.py
+++ b/scripts/fleet_sentinel.py
@@ -251,15 +251,41 @@ def _validate_gh_bin(gh_bin: str) -> str:
     if value == "gh":
         return value
     path = Path(value).expanduser()
-    if not path.is_absolute():
-        raise ValueError("gh_bin must be 'gh' or an absolute executable path")
+    if not path.is_absolute() and not any(sep in value for sep in ("/", os.sep)):
+        raise ValueError("gh_bin must be 'gh' or an executable path")
     try:
         resolved = path.resolve()
     except OSError as exc:
-        raise ValueError(f"gh_bin absolute path could not be resolved: {exc}") from exc
+        raise ValueError(f"gh_bin path could not be resolved: {exc}") from exc
     if not resolved.is_file() or not os.access(resolved, os.X_OK):
-        raise ValueError("gh_bin absolute path must be an executable file")
+        raise ValueError("gh_bin path must be an executable file")
     return str(resolved)
+
+
+def _split_operator_command(command: str, *, option_name: str) -> list[str]:
+    try:
+        tokens = shlex.split(command)
+    except ValueError as exc:
+        raise ValueError(f"{option_name} is not a valid argv template: {exc}") from exc
+    if not tokens:
+        raise ValueError(f"{option_name} must not be empty")
+    executable = tokens[0]
+    if (
+        executable.startswith("-")
+        or "\0" in executable
+        or any(char.isspace() for char in executable)
+    ):
+        raise ValueError(f"{option_name} executable must be one safe argv token")
+    if any(sep in executable for sep in ("/", os.sep)):
+        path = Path(executable).expanduser()
+        try:
+            resolved = path.resolve()
+        except OSError as exc:
+            raise ValueError(f"{option_name} executable path could not be resolved: {exc}") from exc
+        if not resolved.is_file() or not os.access(resolved, os.X_OK):
+            raise ValueError(f"{option_name} executable path must be an executable file")
+        tokens[0] = str(resolved)
+    return tokens
 
 
 def parse_iso(value: str) -> datetime:
@@ -1787,20 +1813,21 @@ def breach_summary(checks: list[CheckResult]) -> str:
 
 
 def notify(notify_cmd: str, summary: str, *, runner: Callable[[list[str]], int]) -> None:
-    tokens = shlex.split(notify_cmd)
-    if any("{summary}" in t for t in tokens):
-        # A bare "{summary}" token becomes its own argv element — safe to pass
-        # the text through verbatim.  A placeholder embedded in a larger token
-        # lands inside another language's string literal (e.g. the installer's
-        # default AppleScript "display notification" command), so neutralize
-        # quote/backslash injection before substituting.
-        embedded_safe = summary.replace("\\", "/").replace('"', "'")
-        tokens = [
-            summary if t == "{summary}" else t.replace("{summary}", embedded_safe) for t in tokens
-        ]
-    else:
-        tokens.append(summary)
     try:
+        tokens = _split_operator_command(notify_cmd, option_name="--notify-cmd")
+        if any("{summary}" in t for t in tokens):
+            # A bare "{summary}" token becomes its own argv element — safe to pass
+            # the text through verbatim.  A placeholder embedded in a larger token
+            # lands inside another language's string literal (e.g. the installer's
+            # default AppleScript "display notification" command), so neutralize
+            # quote/backslash injection before substituting.
+            embedded_safe = summary.replace("\\", "/").replace('"', "'")
+            tokens = [
+                summary if t == "{summary}" else t.replace("{summary}", embedded_safe)
+                for t in tokens
+            ]
+        else:
+            tokens.append(summary)
         runner(tokens)
     except Exception as exc:  # noqa: BLE001 - notification failure must not mask the report
         print(f"fleet-sentinel: notify-cmd failed: {exc}", file=sys.stderr)
@@ -1838,7 +1865,10 @@ def run_checks(args: argparse.Namespace, now: datetime) -> list[CheckResult]:
                 results.append(check_launchd_plists(Path(args.launch_agents_dir)))
             elif name == "gh_auth":
                 results.append(
-                    check_gh_auth(runner=_default_command_runner, cmd=shlex.split(args.gh_auth_cmd))
+                    check_gh_auth(
+                        runner=_default_command_runner,
+                        cmd=_split_operator_command(args.gh_auth_cmd, option_name="--gh-auth-cmd"),
+                    )
                 )
             elif name == "checkout_invariant":
                 results.append(
@@ -1892,6 +1922,12 @@ def run_checks(args: argparse.Namespace, now: datetime) -> list[CheckResult]:
                         Path(args.stale_terminal_owner_receipt_dir)
                     ),
                 }
+                if not hasattr(args, "_explicit_state_path_args"):
+                    explicit_paths = {
+                        name
+                        for name, value in fallback_path_values.items()
+                        if value != default_paths.get(name)
+                    }
                 unsafe_fallback_paths = [
                     name
                     for name, value in fallback_path_values.items()
@@ -1932,7 +1968,9 @@ def run_checks(args: argparse.Namespace, now: datetime) -> list[CheckResult]:
                         persist_threshold=args.persist_threshold,
                         tail_lines=args.publisher_log_tail_lines,
                         probe_runner=_default_command_runner,
-                        probe_cmd=shlex.split(args.rate_limit_cmd),
+                        probe_cmd=_split_operator_command(
+                            args.rate_limit_cmd, option_name="--rate-limit-cmd"
+                        ),
                     )
                 )
             elif name == "trail_reconcile":

--- a/scripts/post_merge_lane_audit.py
+++ b/scripts/post_merge_lane_audit.py
@@ -16,7 +16,7 @@ from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 Runner = Callable[[list[str]], subprocess.CompletedProcess[str]]
-DRY_RUN_ZERO_EXIT_BLOCKERS = {"invalid_automation_state_root"}
+BENIGN_DRY_RUN_BLOCKERS = {"no_active_lanes_for_merged_pr"}
 
 
 def _run_command(
@@ -163,7 +163,12 @@ def run_post_merge_lane_audit(
             proc=dry_proc,
             error=message,
         )
-    if dry_payload.get("blocked_reason") in DRY_RUN_ZERO_EXIT_BLOCKERS:
+    blocked_reason = dry_payload.get("blocked_reason")
+    benign_blocker = (
+        blocked_reason in BENIGN_DRY_RUN_BLOCKERS
+        and int(dry_payload.get("finding_count") or 0) == 0
+    )
+    if blocked_reason and not benign_blocker:
         message = str(dry_payload.get("blocked_reason") or "audit blocked")
         return _merge_helper_metadata(
             dry_payload,

--- a/scripts/resolve_lane_conflicts.py
+++ b/scripts/resolve_lane_conflicts.py
@@ -181,14 +181,14 @@ def _validate_gh_bin(gh_bin: str) -> str:
     if value == "gh":
         return value
     path = Path(value).expanduser()
-    if not path.is_absolute():
-        raise ValueError("gh_bin must be 'gh' or an absolute executable path")
+    if not path.is_absolute() and not any(sep in value for sep in ("/", os.sep)):
+        raise ValueError("gh_bin must be 'gh' or an executable path")
     try:
         resolved = path.resolve()
     except OSError as exc:
-        raise ValueError(f"gh_bin absolute path could not be resolved: {exc}") from exc
+        raise ValueError(f"gh_bin path could not be resolved: {exc}") from exc
     if not resolved.is_file() or not os.access(resolved, os.X_OK):
-        raise ValueError("gh_bin absolute path must be an executable file")
+        raise ValueError("gh_bin path must be an executable file")
     return str(resolved)
 
 

--- a/tests/scripts/test_fleet_sentinel.py
+++ b/tests/scripts/test_fleet_sentinel.py
@@ -343,6 +343,38 @@ def test_main_explicit_default_paths_survive_untrusted_automation_state_root(
     assert report["checks"][0]["status"] == "ok"
 
 
+def test_run_checks_infers_direct_namespace_explicit_paths(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    args = sentinel.build_parser().parse_args(["--checks", "stale_terminal_owner"])
+    args.agent_bridge_lanes = str(tmp_path / "lanes.json")
+    args.agent_heartbeats = str(tmp_path / "heartbeats.json")
+    args.operator_steering_root = str(tmp_path / "operator-steering")
+    args.stale_terminal_owner_receipt_dir = str(tmp_path / "receipts")
+    args._automation_state_root_error = "untrusted state root"
+    args._automation_state_root_default_paths = {
+        "agent_bridge_lanes": "/attacker/.aragora/agent-bridge/lanes.json",
+        "agent_heartbeats": "/attacker/.aragora/agent-bridge/heartbeats.json",
+        "operator_steering_root": "/attacker/.aragora/operator-steering",
+        "stale_terminal_owner_receipt_dir": (
+            "/attacker/.aragora/agent-bridge/conflict-resolution-receipts"
+        ),
+    }
+    called: dict[str, bool] = {}
+
+    def fake_check(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        called["yes"] = True
+        return sentinel._result("stale_terminal_owner", "ok", "called")
+
+    monkeypatch.setattr(sentinel, "check_stale_terminal_owner", fake_check)
+
+    checks = sentinel.run_checks(args, NOW)
+
+    assert called == {"yes": True}
+    assert checks == [sentinel._result("stale_terminal_owner", "ok", "called")]
+
+
 def test_main_rejects_partial_explicit_paths_with_untrusted_automation_state_root(
     tmp_path: Path,
     monkeypatch: Any,
@@ -1336,6 +1368,31 @@ def test_validate_gh_bin_accepts_absolute_executable_wrapper(tmp_path: Path) -> 
     assert sentinel._validate_gh_bin(str(wrapper)) == str(wrapper.resolve())
 
 
+def test_validate_gh_bin_accepts_relative_executable_wrapper(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    tools = tmp_path / "tools"
+    tools.mkdir()
+    wrapper = tools / "gh"
+    wrapper.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    wrapper.chmod(0o755)
+    monkeypatch.chdir(tmp_path)
+
+    assert sentinel._validate_gh_bin("./tools/gh") == str(wrapper.resolve())
+
+
+def test_split_operator_command_rejects_malformed_template() -> None:
+    try:
+        sentinel._split_operator_command(
+            'gh auth status "unterminated', option_name="--gh-auth-cmd"
+        )
+    except ValueError as exc:
+        assert "--gh-auth-cmd" in str(exc)
+    else:
+        raise AssertionError("malformed command template was accepted")
+
+
 def test_stale_terminal_owner_rejects_invalid_repo_before_fetch(tmp_path: Path) -> None:
     registry = _write_json(tmp_path / "lanes.json", [_active_owner_row()])
 
@@ -2149,6 +2206,34 @@ def test_github_witness_events_rejects_invalid_repo_slug_before_capture() -> Non
         assert "repo_slug" in str(exc)
     else:
         raise AssertionError("invalid witness repo slug was accepted")
+
+
+def test_main_trail_reconcile_invalid_repo_slug_is_structured_unknown(
+    tmp_path: Path,
+    capsys: Any,
+) -> None:
+    code = sentinel.main(
+        [
+            "--json",
+            "--no-ledger",
+            "--now",
+            "2026-06-10T12:00:00Z",
+            "--checks",
+            "trail_reconcile",
+            "--trail-witness-repo",
+            "synaptent/aragora --json files",
+            "--trail-chain",
+            str(tmp_path / "intent-chain.jsonl"),
+        ]
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert code == 2
+    check = report["checks"][0]
+    assert check["status"] == "unknown"
+    assert "witness unreadable" in check["detail"]
+    assert "repo_slug" in check["detail"]
+    assert "check crashed" not in check["detail"]
 
 
 def test_main_trail_reconcile_replica_chain_reader_fallback(tmp_path: Path, capsys: Any) -> None:

--- a/tests/scripts/test_post_merge_lane_audit.py
+++ b/tests/scripts/test_post_merge_lane_audit.py
@@ -119,6 +119,21 @@ def test_post_merge_lane_audit_blocks_payload_with_zero_exit() -> None:
     assert result["audit_error"] == "invalid_automation_state_root"
 
 
+def test_post_merge_lane_audit_blocks_unknown_zero_exit_blocker() -> None:
+    commands: list[list[str]] = []
+
+    def runner(args: list[str]) -> subprocess.CompletedProcess[str]:
+        commands.append(args)
+        return _proc(args, _dry_payload(blocked_reason="future_blocker"))
+
+    result = run_post_merge_lane_audit(7435, apply=True, runner=runner)
+
+    assert len(commands) == 1
+    assert result["audit_ok"] is False
+    assert result["audit_applied"] is False
+    assert result["audit_error"] == "future_blocker"
+
+
 def test_post_merge_lane_audit_skips_benign_no_active_lane_result() -> None:
     commands: list[list[str]] = []
 

--- a/tests/scripts/test_resolve_lane_conflicts.py
+++ b/tests/scripts/test_resolve_lane_conflicts.py
@@ -370,6 +370,20 @@ def test_validate_gh_bin_accepts_absolute_executable_wrapper(tmp_path: Path) -> 
     assert resolver._validate_gh_bin(str(wrapper)) == str(wrapper.resolve())
 
 
+def test_validate_gh_bin_accepts_relative_executable_wrapper(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    tools = tmp_path / "tools"
+    tools.mkdir()
+    wrapper = tools / "gh"
+    wrapper.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    wrapper.chmod(0o755)
+    monkeypatch.chdir(tmp_path)
+
+    assert resolver._validate_gh_bin("./tools/gh") == str(wrapper.resolve())
+
+
 def test_apply_marks_conflict_superseded_and_writes_receipt(tmp_path: Path) -> None:
     registry = tmp_path / "lanes.json"
     receipt_dir = tmp_path / "receipts"


### PR DESCRIPTION
## Summary

Follow-up repair for the valid OpenAI/Grok dry-run dissent on merged PR #8617.

- validate operator command templates before spawning subprocesses
- preserve executable relative `gh` wrappers while rejecting unsafe bare tokens
- infer explicit state paths for direct `run_checks()` callers
- treat any zero-exit post-merge audit `blocked_reason` as blocked except the existing benign no-active-lanes case
- add structured invalid witness slug coverage and focused regression tests

## Validation

- `python3 -m pytest tests/scripts/test_fleet_sentinel.py tests/scripts/test_resolve_lane_conflicts.py tests/scripts/test_post_merge_lane_audit.py -q`
- `python3 -m ruff check scripts/fleet_sentinel.py scripts/resolve_lane_conflicts.py scripts/post_merge_lane_audit.py tests/scripts/test_fleet_sentinel.py tests/scripts/test_resolve_lane_conflicts.py tests/scripts/test_post_merge_lane_audit.py`
- `git diff --check`
- `python3 scripts/check_portability.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

No model evidence posted; this PR should go through the normal exact-head evidence path after CI settles.
