### PR TITLE
fix(handlers): restore handler shard contracts

### DIFF
--- a/aragora/server/handlers/agents/agents.py
+++ b/aragora/server/handlers/agents/agents.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import logging
 import os
 import re
+from collections.abc import Awaitable
 
 from aragora.events.handler_events import emit_handler_event, QUERIED
 from typing import TYPE_CHECKING, Any
@@ -223,10 +224,15 @@ class AgentsHandler(  # type: ignore[misc]
             return True
         return any(path.startswith(p) for p in self._PUBLIC_PREFIXES)
 
-    async def handle(
+    def handle(
         self, path: str, query_params: dict[str, Any], handler: HTTPRequestHandler
-    ) -> HandlerResult | None:
-        """Route agent requests with RBAC."""
+    ) -> HandlerResult | Awaitable[HandlerResult | None] | None:
+        """Route agent requests.
+
+        Public read-only agent endpoints stay synchronous for legacy direct
+        handler callers; protected paths return an awaitable auth path for the
+        router to await when needed.
+        """
         # Rate limit check
         client_ip = get_client_ip(handler)
         if not _agent_limiter.is_allowed(client_ip):
@@ -236,17 +242,28 @@ class AgentsHandler(  # type: ignore[misc]
         normalized_path = strip_version_prefix(path)
         is_public = self._is_public_path(normalized_path)
 
-        # RBAC: Skip auth for public read-only endpoints, require for mutations
-        if not is_public:
-            try:
-                auth_context = await self.get_auth_context(handler, require_auth=True)
-                self.check_permission(auth_context, AGENT_PERMISSION)
-            except UnauthorizedError:
-                return error_response("Authentication required to access agent data", 401)
-            except ForbiddenError as e:
-                logger.warning("Agent access denied: %s", e)
-                return error_response("Permission denied", 403)
+        if is_public:
+            return self._handle_agent_request(path, query_params)
+        return self._handle_authenticated_agent_request(path, query_params, handler)
 
+    async def _handle_authenticated_agent_request(
+        self, path: str, query_params: dict[str, Any], handler: HTTPRequestHandler
+    ) -> HandlerResult | None:
+        """Authenticate protected agent paths before dispatching."""
+        try:
+            auth_context = await self.get_auth_context(handler, require_auth=True)
+            self.check_permission(auth_context, AGENT_PERMISSION)
+        except UnauthorizedError:
+            return error_response("Authentication required to access agent data", 401)
+        except ForbiddenError as e:
+            logger.warning("Agent access denied: %s", e)
+            return error_response("Permission denied", 403)
+        return self._handle_agent_request(path, query_params)
+
+    def _handle_agent_request(
+        self, path: str, query_params: dict[str, Any]
+    ) -> HandlerResult | None:
+        """Dispatch an already-authorized or public agent request."""
         path = strip_version_prefix(path)
         if path.startswith("/api/agents/") and not path.startswith(
             (

--- a/aragora/server/handlers/belief.py
+++ b/aragora/server/handlers/belief.py
@@ -222,7 +222,17 @@ class BeliefHandler(BaseHandler):
         roles_header = ""
         if hasattr(handler, "headers"):
             roles_header = handler.headers.get("X-User-Roles", "")
-        roles = set(roles_header.split(",")) if roles_header else {"member"}
+        if isinstance(roles_header, str) and roles_header:
+            roles = {role.strip() for role in roles_header.split(",") if role.strip()}
+        else:
+            user_roles = getattr(user, "roles", None)
+            if isinstance(user_roles, str):
+                roles = {user_roles}
+            elif isinstance(user_roles, (list, tuple, set, frozenset)):
+                roles = {str(role) for role in user_roles if str(role)}
+            else:
+                role = getattr(user, "role", None)
+                roles = {str(role)} if role else {"member"}
 
         context = AuthorizationContext(
             user_id=str(user_id),
@@ -242,11 +252,17 @@ class BeliefHandler(BaseHandler):
     def handle(self, path: str, query_params: dict, handler: Any) -> HandlerResult | None:
         """Route belief network requests to appropriate methods."""
         normalized = strip_version_prefix(path)
+        if not self.can_handle(normalized):
+            return None
+
         # Rate limit check
         client_ip = get_client_ip(handler)
         if not _belief_limiter.is_allowed(client_ip):
             logger.warning("Rate limit exceeded for belief endpoint: %s", client_ip)
             return error_response("Rate limit exceeded. Please try again later.", 429)
+
+        if self._is_belief_network_route(normalized) and not BELIEF_NETWORK_AVAILABLE:
+            return error_response("Belief network not available", 503)
 
         # Require authentication for belief network endpoints
         try:
@@ -327,6 +343,18 @@ class BeliefHandler(BaseHandler):
             return self._get_crux_analysis(nomic_dir, debate_id, limit)
 
         return None
+
+    @staticmethod
+    def _is_belief_network_route(normalized_path: str) -> bool:
+        """Return True for routes backed by the optional belief-network package."""
+        return (
+            normalized_path.startswith("/api/belief-network/")
+            or (
+                normalized_path.startswith("/api/debate/")
+                and normalized_path.endswith("/graph-stats")
+            )
+            or (normalized_path.startswith("/api/debates/") and normalized_path.endswith("/cruxes"))
+        )
 
     def _extract_debate_id(self, path: str, segment_index: int) -> str | None:
         """Extract and validate debate ID from path."""

--- a/aragora/server/handlers/webhooks.py
+++ b/aragora/server/handlers/webhooks.py
@@ -20,9 +20,10 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import importlib
 import logging
 import time
-from typing import Any
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 from aragora.server.handlers.base import (
     SAFE_ID_PATTERN,
@@ -38,14 +39,19 @@ from aragora.server.handlers.utils.url_security import validate_webhook_url
 from aragora.server.validation.query_params import safe_query_int
 
 # RBAC imports - graceful fallback if not available
-try:
-    from aragora.rbac import AuthorizationContext, check_permission
+if TYPE_CHECKING:
+    from aragora.rbac import AuthorizationContext
 
+_rbac_module: Any
+try:
+    _rbac_module = importlib.import_module("aragora.rbac")
     RBAC_AVAILABLE = True
 except ImportError:
+    _rbac_module = None
     RBAC_AVAILABLE = False
-    AuthorizationContext: Any = None
-    check_permission = None
+
+_AuthorizationContext: Any = getattr(_rbac_module, "AuthorizationContext", None)
+check_permission: Any = getattr(_rbac_module, "check_permission", None)
 
 from aragora.server.handlers.utils.rbac_guard import rbac_fail_closed
 
@@ -80,7 +86,7 @@ _list_limiter = RateLimiter(requests_per_minute=WEBHOOK_LIST_RPM)
 
 # Backward compatibility alias - the old WebhookStore interface is now provided
 # by WebhookConfigStoreBackend from aragora.storage.webhook_config_store
-WebhookStore = WebhookConfigStoreBackend
+WebhookStore: TypeAlias = WebhookConfigStoreBackend
 
 
 def get_webhook_store() -> WebhookConfigStoreBackend:
@@ -204,7 +210,7 @@ class WebhookHandler(SecureHandler):
 
     def _get_auth_context(self, handler) -> AuthorizationContext | None:
         """Build RBAC authorization context from request."""
-        if not RBAC_AVAILABLE or AuthorizationContext is None:
+        if not RBAC_AVAILABLE or _AuthorizationContext is None:
             return None
 
         user = self.get_current_user(handler)
@@ -212,7 +218,7 @@ class WebhookHandler(SecureHandler):
             return None
 
         # User context has user_id and potentially role info
-        return AuthorizationContext(
+        return _AuthorizationContext(
             user_id=user.user_id,
             roles=set([user.role]) if hasattr(user, "role") and user.role else set(),
             org_id=getattr(user, "org_id", None),

--- a/aragora/server/handlers/webhooks.py
+++ b/aragora/server/handlers/webhooks.py
@@ -702,6 +702,8 @@ The webhook secret is only returned once on creation - save it securely.""",
         if rbac_error:
             return rbac_error
 
+        if "url" not in body:
+            return error_response("URL is required", 400)
         raw_url = body.get("url", "")
         if not isinstance(raw_url, str):
             return error_response("URL must be a non-empty string", 400)

--- a/tests/handlers/test_handlers.py
+++ b/tests/handlers/test_handlers.py
@@ -427,7 +427,9 @@ class TestHandlerRouting:
         """Test unified server registers all handlers."""
         from aragora.server.unified_server import UnifiedHandler
 
-        # Check handler class variables exist
+        UnifiedHandler._init_handlers()
+
+        # Check handler class variables exist after lazy initialization
         assert hasattr(UnifiedHandler, "_consensus_handler")
         assert hasattr(UnifiedHandler, "_belief_handler")
 
@@ -699,17 +701,17 @@ class TestSystemHandler:
         }
         return SystemHandler(ctx)
 
-    def test_can_handle_health(self, handler):
-        """Test can_handle for health endpoint."""
-        assert handler.can_handle("/api/v1/health") is True
+    def test_does_not_handle_dedicated_health(self, handler):
+        """Health endpoints are owned by HealthHandler."""
+        assert handler.can_handle("/api/v1/health") is False
 
-    def test_can_handle_nomic_state(self, handler):
-        """Test can_handle for nomic state endpoint."""
-        assert handler.can_handle("/api/v1/nomic/state") is True
+    def test_does_not_handle_dedicated_nomic_state(self, handler):
+        """Nomic endpoints are owned by NomicHandler."""
+        assert handler.can_handle("/api/v1/nomic/state") is False
 
-    def test_can_handle_modes(self, handler):
-        """Test can_handle for modes endpoint."""
-        assert handler.can_handle("/api/v1/modes") is True
+    def test_does_not_handle_dedicated_modes(self, handler):
+        """Mode endpoints are owned by NomicHandler."""
+        assert handler.can_handle("/api/v1/modes") is False
 
     def test_can_handle_history(self, handler):
         """Test can_handle for history endpoints."""

--- a/tests/handlers/test_handlers_base.py
+++ b/tests/handlers/test_handlers_base.py
@@ -809,6 +809,7 @@ class TestBaseHandler:
 
     # === Authentication ===
 
+    @pytest.mark.no_auto_auth
     def test_get_current_user_authenticated(self, handler):
         """Test get_current_user when authenticated."""
         mock_user = MockUserContext()
@@ -820,6 +821,7 @@ class TestBaseHandler:
 
         assert result == mock_user
 
+    @pytest.mark.no_auto_auth
     def test_get_current_user_not_authenticated(self, handler):
         """Test get_current_user returns None when not authenticated."""
         mock_user = MockUserContext(is_authenticated=False)
@@ -831,6 +833,7 @@ class TestBaseHandler:
 
         assert result is None
 
+    @pytest.mark.no_auto_auth
     def test_require_auth_or_error_authenticated(self, handler):
         """Test require_auth_or_error when authenticated."""
         mock_user = MockUserContext()
@@ -843,6 +846,7 @@ class TestBaseHandler:
         assert user == mock_user
         assert err is None
 
+    @pytest.mark.no_auto_auth
     def test_require_auth_or_error_not_authenticated(self, handler):
         """Test require_auth_or_error when not authenticated."""
         mock_user = MockUserContext(is_authenticated=False)
@@ -867,6 +871,7 @@ class TestBaseHandler:
         """Test reading empty body."""
         mock_h = MagicMock()
         mock_h.headers = {"Content-Length": "0"}
+        mock_h.rfile = io.BytesIO(b"")
         result = handler.read_json_body(mock_h)
         assert result == {}
 
@@ -1053,6 +1058,7 @@ class TestBaseHandlerIntegration:
         assert parsed["limit"] == 5
         assert parsed["has_more"] is True
 
+    @pytest.mark.no_auto_auth
     def test_handler_with_auth_and_body(self, server_context):
         """Test handler with authentication and JSON body."""
 

--- a/tests/handlers/test_handlers_webhooks.py
+++ b/tests/handlers/test_handlers_webhooks.py
@@ -679,8 +679,8 @@ class TestGetWebhook:
             response_body = get_response_body(result)
             status = result.status_code
 
-            assert status == 403
-            assert "access denied" in response_body.lower()
+            assert status == 404
+            assert "not found" in response_body.lower()
 
 
 # ============================================================================
@@ -717,7 +717,7 @@ class TestDeleteWebhook:
             result = webhook_handler._handle_delete_webhook(sample_webhook.id, mock_http_handler)
             status = result.status_code
 
-            assert status == 403
+            assert status == 404
 
 
 # ============================================================================
@@ -797,7 +797,7 @@ class TestUpdateWebhook:
             )
             status = result.status_code
 
-            assert status == 403
+            assert status == 404
 
 
 # ============================================================================
@@ -853,7 +853,7 @@ class TestTestWebhook:
             result = webhook_handler._handle_test_webhook(sample_webhook.id, mock_http_handler)
             status = result.status_code
 
-            assert status == 403
+            assert status == 404
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- restore synchronous public AgentsHandler dispatch while preserving async auth handling for protected paths
- harden BeliefHandler ownership/auth/availability routing for handler-unit contexts
- align webhook/system/base handler tests with current route ownership, fail-closed access hiding, and explicit auth-test opt-outs

## Validation
- PYTHONDONTWRITEBYTECODE=1 /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/handlers/test_handlers.py tests/handlers/test_handlers_base.py tests/handlers/test_handlers_webhooks.py -q -p no:cacheprovider
- python3 -m mypy --ignore-missing-imports --follow-imports=skip --show-error-codes aragora/server/handlers/webhooks.py
- python3 -m ruff check aragora/server/handlers/agents/agents.py aragora/server/handlers/belief.py aragora/server/handlers/webhooks.py tests/handlers/test_handlers.py tests/handlers/test_handlers_base.py tests/handlers/test_handlers_webhooks.py
- python3 -m ruff format --check aragora/server/handlers/agents/agents.py aragora/server/handlers/belief.py aragora/server/handlers/webhooks.py tests/handlers/test_handlers.py tests/handlers/test_handlers_base.py tests/handlers/test_handlers_webhooks.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD

## Notes
- PR #8543 also touches aragora/server/handlers/belief.py, but its diff is a separate route-ownership cleanup and does not cover the auth/header/availability repair here.