### PR TITLE
refactor(storage): rehome debate sharing models out of server handler (VAL-P4A-003)

### DIFF
--- a/aragora/server/handlers/social/sharing.py
+++ b/aragora/server/handlers/social/sharing.py
@@ -20,11 +20,11 @@ import secrets
 import threading
 import time
 from dataclasses import dataclass, field
-from enum import Enum
 from typing import Any
 
 from aragora.rbac.decorators import require_permission
 from aragora.server.validation.schema import SHARE_UPDATE_SCHEMA, validate_against_schema
+from aragora.storage.share_models import DebateVisibility, ShareSettings
 
 from ..base import (
     BaseHandler,
@@ -40,73 +40,6 @@ logger = logging.getLogger(__name__)
 
 # Rate limiter for social share APIs (60 requests per minute)
 _share_limiter = RateLimiter(requests_per_minute=60)
-
-
-class DebateVisibility(str, Enum):
-    """Visibility level for a debate."""
-
-    PRIVATE = "private"  # Only creator can access
-    TEAM = "team"  # Organization members can access
-    PUBLIC = "public"  # Anyone with link can access
-
-
-@dataclass
-class ShareSettings:
-    """Sharing settings for a debate."""
-
-    debate_id: str
-    visibility: DebateVisibility = DebateVisibility.PRIVATE
-    share_token: str | None = None
-    created_at: float = field(default_factory=time.time)
-    expires_at: float | None = None  # None = no expiration
-    allow_comments: bool = False
-    allow_forking: bool = False
-    view_count: int = 0
-    owner_id: str | None = None
-    org_id: str | None = None
-
-    def to_dict(self) -> dict[str, Any]:
-        """Convert to JSON-serializable dict."""
-        return {
-            "debate_id": self.debate_id,
-            "visibility": self.visibility.value,
-            "share_token": self.share_token,
-            "share_url": self._get_share_url() if self.share_token else None,
-            "created_at": self.created_at,
-            "expires_at": self.expires_at,
-            "is_expired": self.is_expired,
-            "allow_comments": self.allow_comments,
-            "allow_forking": self.allow_forking,
-            "view_count": self.view_count,
-        }
-
-    def _get_share_url(self) -> str:
-        """Generate the share URL."""
-        # This would be configured via settings in production
-        return f"/api/v1/shared/{self.share_token}"
-
-    @property
-    def is_expired(self) -> bool:
-        """Check if the share link has expired."""
-        if self.expires_at is None:
-            return False
-        return time.time() > self.expires_at
-
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> ShareSettings:
-        """Create from dictionary."""
-        return cls(
-            debate_id=data["debate_id"],
-            visibility=DebateVisibility(data.get("visibility", "private")),
-            share_token=data.get("share_token"),
-            created_at=data.get("created_at", time.time()),
-            expires_at=data.get("expires_at"),
-            allow_comments=data.get("allow_comments", False),
-            allow_forking=data.get("allow_forking", False),
-            view_count=data.get("view_count", 0),
-            owner_id=data.get("owner_id"),
-            org_id=data.get("org_id"),
-        )
 
 
 MAX_SHARE_SETTINGS = 10000  # Prevent unbounded memory growth
@@ -463,7 +396,7 @@ class SharingHandler(BaseHandler):
 
         db_user = self._resolve_social_user(handler, user)
         org_id = getattr(db_user, "org_id", "") or ""
-        shared_by = getattr(db_user, "id", None) or getattr(db_user, "user_id", "")
+        shared_by = getattr(db_user, "id", None) or getattr(db_user, "user_id", "") or ""
 
         share = SocialShare(
             id=secrets.token_urlsafe(8),

--- a/aragora/storage/share_models.py
+++ b/aragora/storage/share_models.py
@@ -1,0 +1,88 @@
+"""Debate sharing data models.
+
+These models live in the storage layer so that lower-layer modules (e.g.
+``aragora.storage.share_store``) can reference them without importing
+``aragora.server``. The server-side sharing handler
+(``aragora.server.handlers.social.sharing``) re-exports them for backward
+compatibility.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class DebateVisibility(str, Enum):
+    """Visibility level for a debate."""
+
+    PRIVATE = "private"  # Only creator can access
+    TEAM = "team"  # Organization members can access
+    PUBLIC = "public"  # Anyone with link can access
+
+
+@dataclass
+class ShareSettings:
+    """Sharing settings for a debate."""
+
+    debate_id: str
+    visibility: DebateVisibility = DebateVisibility.PRIVATE
+    share_token: str | None = None
+    created_at: float = field(default_factory=time.time)
+    expires_at: float | None = None  # None = no expiration
+    allow_comments: bool = False
+    allow_forking: bool = False
+    view_count: int = 0
+    owner_id: str | None = None
+    org_id: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to JSON-serializable dict."""
+        return {
+            "debate_id": self.debate_id,
+            "visibility": self.visibility.value,
+            "share_token": self.share_token,
+            "share_url": self._get_share_url() if self.share_token else None,
+            "created_at": self.created_at,
+            "expires_at": self.expires_at,
+            "is_expired": self.is_expired,
+            "allow_comments": self.allow_comments,
+            "allow_forking": self.allow_forking,
+            "view_count": self.view_count,
+        }
+
+    def _get_share_url(self) -> str:
+        """Generate the share URL."""
+        # This would be configured via settings in production
+        return f"/api/v1/shared/{self.share_token}"
+
+    @property
+    def is_expired(self) -> bool:
+        """Check if the share link has expired."""
+        if self.expires_at is None:
+            return False
+        return time.time() > self.expires_at
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ShareSettings:
+        """Create from dictionary."""
+        return cls(
+            debate_id=data["debate_id"],
+            visibility=DebateVisibility(data.get("visibility", "private")),
+            share_token=data.get("share_token"),
+            created_at=data.get("created_at", time.time()),
+            expires_at=data.get("expires_at"),
+            allow_comments=data.get("allow_comments", False),
+            allow_forking=data.get("allow_forking", False),
+            view_count=data.get("view_count", 0),
+            owner_id=data.get("owner_id"),
+            org_id=data.get("org_id"),
+        )
+
+
+__all__ = [
+    "DebateVisibility",
+    "ShareSettings",
+]

--- a/aragora/storage/share_store.py
+++ b/aragora/storage/share_store.py
@@ -18,7 +18,6 @@ import os
 import secrets
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 from aragora.storage.backends import (
     POSTGRESQL_AVAILABLE,
@@ -26,9 +25,7 @@ from aragora.storage.backends import (
     PostgreSQLBackend,
 )
 from aragora.storage.base_store import SQLiteStore
-
-if TYPE_CHECKING:
-    from aragora.server.handlers.social.sharing import ShareSettings
+from aragora.storage.share_models import DebateVisibility, ShareSettings
 
 logger = logging.getLogger(__name__)
 
@@ -474,9 +471,6 @@ class ShareLinkStore(SQLiteStore):
 
     def _row_to_settings(self, row: tuple) -> ShareSettings:
         """Convert a database row to ShareSettings object."""
-        # Import here to avoid circular dependency
-        from aragora.server.handlers.social.sharing import DebateVisibility, ShareSettings
-
         return ShareSettings(
             debate_id=row[1],
             visibility=DebateVisibility(row[2]),


### PR DESCRIPTION
## Source
HEALTH-2 #8259 (P4a layering) — VAL-P4A-003 (share_store, the first of the three named files; decision_router merged in #8622, redis_cache is operator-owned in #8616).

## Behavior
`aragora.storage.share_store` reached UP into `aragora.server.handlers.social.sharing`
(a lazy in-function import at the old line 478, plus a `TYPE_CHECKING` import) to get
`DebateVisibility` / `ShareSettings` — a storage→server upward import the layer contract
forbids.

This relocates both data models DOWN to a new **stdlib-only** module
`aragora/storage/share_models.py`. `share_store` now imports them intra-package (no
upward edge). The server sharing handler and the `aragora.server.handlers.social`
package **re-export** them from the new home, so every pre-existing import path keeps
working with **identity-equal** objects.

Because the new home imports nothing from `aragora`, the original "Import here to avoid
circular dependency" lazy import is gone — `share_store` imports the models at module
scope with no cycle.

Also coerces a **pre-existing** untyped `shared_by` fallback in `sharing.py` to `str`
(the value could previously be `None` while `SocialShare.shared_by` is typed `str`) so
the changed-file mypy pre-push hook stays clean. This is the identical error mypy already
reports on `origin/main` (it only surfaces now because `sharing.py` is a changed file).

## No shims-ledger entry (by design)
This is a **transparent symbol relocation**, not a module-home move: no module path
changed and `aragora.server.handlers.social.sharing` still exports both symbols
(re-exported, identity-equal). There is no broken/deprecated import path to shim, so no
`shims.md` bullet applies (a bullet would fail VAL-CROSS-004 two-sided check, since a
living handler module must not emit a module-import DeprecationWarning).

## Validation
- `python3 /tmp/p4val/t1.py aragora/storage/share_store.py aragora.server` → **PASS** (was `FAIL [(478, 'aragora.server.handlers.social.sharing')]`)
- `python3 -c "import aragora.storage.share_store, aragora.utils.redis_cache, aragora.core.decision_router; print('ok')"` → ok
- Identity-equal across the re-export chain: `share_models` ← `sharing` ← `social` package ← `share_store`.
- Consumer suites green: `tests/storage/test_share_store.py` + `test_share_store_root.py` + `tests/handlers/test_handlers_sharing.py` = **106 passed**.
- `ruff check` + `ruff format --check` pass; typecheck differential PASS (new=64 ≤ 66); `module_tiers --check` no drift; `make test-smoke` + smoke tier (138) pass.
- import-contracts: baseline-neutral — the only NEW edge it reports (`aragora.swarm -> aragora.cli`) is pre-existing on clean `origin/main` and unrelated to these files.

## Tier
Tier-3 (touches `aragora/server/handlers/`). Prepare-only: this PR is brought green +
quorum-complete and left for operator settlement.

## Risks
Low. Pure data-model relocation with full transparent re-export; no behavior change
except the `shared_by` None→"" hardening (strictly safer).
