### PR TITLE
fix(review-queue): ignore quoted parser examples

### DIFF
--- a/aragora/cli/commands/review_queue_comment_verdicts.py
+++ b/aragora/cli/commands/review_queue_comment_verdicts.py
@@ -178,6 +178,30 @@ def _normalize_value(text: str) -> str:
     return re.sub(r"\s+", " ", text.strip().strip("*_").strip().lower())
 
 
+_FENCE_LINE = re.compile(r"^\s*(?:```|~~~)")
+
+
+def _semantic_review_lines(body: str) -> list[str]:
+    """Lines that should participate in verdict/finding classification.
+
+    Reviewers often quote the gate syntax itself while reviewing parser changes,
+    e.g. fenced examples of ``Verdict: CHANGES-REQUESTED`` or blockquoted
+    ``[P2]`` snippets. Those are not the reviewer's live verdict/finding lines
+    and must not become blocking dissent. Normal bullet/list findings are kept.
+    """
+    lines: list[str] = []
+    in_fence = False
+    for raw_line in str(body or "").splitlines():
+        stripped = raw_line.strip()
+        if _FENCE_LINE.match(stripped):
+            in_fence = not in_fence
+            continue
+        if in_fence or stripped.startswith(">"):
+            continue
+        lines.append(stripped)
+    return lines
+
+
 def _priority_finding_severity(stripped: str) -> str | None:
     """Return ``"P0"``/``"P1"`` if ``stripped`` is a *real* `[P0]`/`[P1]` finding
     line (head-before-colon NOT in :data:`_NO_FINDING_HEADS`), else ``None``.
@@ -230,7 +254,7 @@ def _populated_blocker_label(stripped: str, follow_lines: list[str]) -> bool:
 
 def has_blocking_or_negative_verdict(body: str) -> bool:
     """Return True for explicit evidence comments that report blockers."""
-    lines = [raw_line.strip() for raw_line in str(body or "").splitlines()]
+    lines = _semantic_review_lines(body)
     for idx, stripped in enumerate(lines):
         if not stripped:
             continue
@@ -280,8 +304,7 @@ def highest_blocking_severity(body: str) -> str | None:
     ``"P1"`` when both are present.
     """
     best: str | None = None
-    for raw_line in str(body or "").splitlines():
-        stripped = raw_line.strip()
+    for stripped in _semantic_review_lines(body):
         if not stripped:
             continue
         severity = _priority_finding_severity(stripped)
@@ -302,7 +325,7 @@ def has_blocking_finding_or_label(body: str) -> bool:
     ``CHANGES-REQUESTED`` comment promotes a *blocking* dissent only when it is
     backed by a real `[P0]`/`[P1]` finding or a populated Blocker label.
     """
-    lines = [raw_line.strip() for raw_line in str(body or "").splitlines()]
+    lines = _semantic_review_lines(body)
     for idx, stripped in enumerate(lines):
         if not stripped:
             continue

--- a/aragora/cli/commands/review_queue_comment_verdicts.py
+++ b/aragora/cli/commands/review_queue_comment_verdicts.py
@@ -178,7 +178,27 @@ def _normalize_value(text: str) -> str:
     return re.sub(r"\s+", " ", text.strip().strip("*_").strip().lower())
 
 
-_FENCE_LINE = re.compile(r"^\s*(?:```|~~~)")
+_FENCE_LINE = re.compile(r"^\s*(?:`{3,}|~{3,})(?:[\w.+-]+)?\s*$")
+_INDENTED_CODE_LINE = re.compile(r"^(?: {4,}|\t)")
+
+
+def _strip_blockquote_prefix(line: str) -> str:
+    return re.sub(r"^\s*>\s?", "", line).strip()
+
+
+def _blockquote_group_is_example(lines: list[str]) -> bool:
+    combined = " ".join(_normalize_value(line) for line in lines)
+    return bool(
+        re.search(r"\b(?:quoted|example|sample|demonstrat(?:e|ion)|not a live finding)\b", combined)
+    )
+
+
+def _flush_blockquote_group(lines: list[str], blockquote_group: list[str]) -> None:
+    if not blockquote_group:
+        return
+    if not _blockquote_group_is_example(blockquote_group):
+        lines.extend(blockquote_group)
+    blockquote_group.clear()
 
 
 def _semantic_review_lines(body: str) -> list[str]:
@@ -191,14 +211,31 @@ def _semantic_review_lines(body: str) -> list[str]:
     """
     lines: list[str] = []
     in_fence = False
+    fence_buffer: list[str] = []
+    blockquote_group: list[str] = []
     for raw_line in str(body or "").splitlines():
         stripped = raw_line.strip()
         if _FENCE_LINE.match(stripped):
+            _flush_blockquote_group(lines, blockquote_group)
             in_fence = not in_fence
+            if not in_fence:
+                fence_buffer.clear()
             continue
-        if in_fence or stripped.startswith(">"):
+        if in_fence:
+            fence_buffer.append(stripped)
+            continue
+        if stripped.startswith(">"):
+            blockquote_group.append(_strip_blockquote_prefix(raw_line))
+            continue
+        _flush_blockquote_group(lines, blockquote_group)
+        if _INDENTED_CODE_LINE.match(raw_line):
             continue
         lines.append(stripped)
+    _flush_blockquote_group(lines, blockquote_group)
+    if in_fence:
+        # Fail closed for malformed evidence: if a reviewer opens a fence and never closes it,
+        # do not silently discard the rest of the comment.
+        lines.extend(fence_buffer)
     return lines
 
 

--- a/tests/cli/commands/test_review_queue_comment_verdicts.py
+++ b/tests/cli/commands/test_review_queue_comment_verdicts.py
@@ -100,6 +100,49 @@ def test_negative_verdict_line_still_blocks():
     assert has_blocking_or_negative_verdict("Verdict: CHANGES-REQUESTED")
 
 
+def test_fenced_parser_examples_do_not_block():
+    body = (
+        "Verdict: PASS\n\n"
+        "The parser needs to understand examples like:\n"
+        "```markdown\n"
+        "Verdict: CHANGES-REQUESTED\n"
+        "[P2] This is quoted gate syntax, not a live finding.\n"
+        "Blockers: no authentication on admin endpoint\n"
+        "```\n"
+        "The implementation is otherwise safe."
+    )
+    assert has_blocking_or_negative_verdict(body) is False
+    assert has_blocking_finding_or_label(body) is False
+    assert highest_blocking_severity(body) is None
+
+
+def test_blockquoted_parser_examples_do_not_block():
+    body = (
+        "Verdict: PASS\n\n"
+        "> Verdict: CHANGES-REQUESTED\n"
+        "> [P1] Quoted example text, not a live finding.\n"
+        "> Blockers: no validation\n"
+        "\n"
+        "No live blockers."
+    )
+    assert has_blocking_or_negative_verdict(body) is False
+    assert has_blocking_finding_or_label(body) is False
+    assert highest_blocking_severity(body) is None
+
+
+def test_real_finding_after_fenced_example_still_blocks():
+    body = (
+        "Verdict: PASS\n"
+        "```\n"
+        "[P1] quoted example ignored\n"
+        "```\n"
+        "- [P1] live settlement gate bypass remains"
+    )
+    assert has_blocking_or_negative_verdict(body) is True
+    assert has_blocking_finding_or_label(body) is True
+    assert highest_blocking_severity(body) == "P1"
+
+
 # --- Blocker-label path: bare "no" finding bypass (openai #8574 P1) --------
 #
 # `_NON_BLOCKING_PREFIXES` used to include a bare "no", so a populated Blocker

--- a/tests/cli/commands/test_review_queue_comment_verdicts.py
+++ b/tests/cli/commands/test_review_queue_comment_verdicts.py
@@ -130,6 +130,56 @@ def test_blockquoted_parser_examples_do_not_block():
     assert highest_blocking_severity(body) is None
 
 
+def test_live_blockquoted_finding_still_blocks():
+    body = "Verdict: PASS\n\n> [P1] settlement gate bypass remains live reviewer output\n"
+    assert has_blocking_or_negative_verdict(body) is True
+    assert has_blocking_finding_or_label(body) is True
+    assert highest_blocking_severity(body) == "P1"
+
+
+def test_prose_starting_with_backticks_does_not_open_fence():
+    body = (
+        "Verdict: PASS\n"
+        "``` is used for code examples in markdown prose.\n"
+        "- [P1] live settlement gate bypass remains\n"
+    )
+    assert has_blocking_or_negative_verdict(body) is True
+    assert has_blocking_finding_or_label(body) is True
+    assert highest_blocking_severity(body) == "P1"
+
+
+def test_single_line_code_span_does_not_open_fence():
+    body = (
+        "Verdict: PASS\n"
+        "```[P1] quoted inline example```\n"
+        "- [P1] live settlement gate bypass remains\n"
+    )
+    assert has_blocking_or_negative_verdict(body) is True
+    assert has_blocking_finding_or_label(body) is True
+    assert highest_blocking_severity(body) == "P1"
+
+
+def test_unclosed_fence_fails_closed_for_priority_finding():
+    body = (
+        "Verdict: PASS\n```markdown\n- [P1] unclosed quoted finding cannot be silently discarded\n"
+    )
+    assert has_blocking_or_negative_verdict(body) is True
+    assert has_blocking_finding_or_label(body) is True
+    assert highest_blocking_severity(body) == "P1"
+
+
+def test_indented_parser_example_does_not_block():
+    body = (
+        "Verdict: PASS\n\n"
+        "    Verdict: CHANGES-REQUESTED\n"
+        "    [P1] indented parser example, not a live finding\n"
+        "No live blockers.\n"
+    )
+    assert has_blocking_or_negative_verdict(body) is False
+    assert has_blocking_finding_or_label(body) is False
+    assert highest_blocking_severity(body) is None
+
+
 def test_real_finding_after_fenced_example_still_blocks():
     body = (
         "Verdict: PASS\n"


### PR DESCRIPTION
## Summary
- Ignore fenced code blocks and blockquoted example lines when classifying review verdict/severity markers.
- Preserve normal live finding detection for `[P2]` default blocking and `[P0]`/`[P1]` severity blocking.
- Add regression coverage for fenced examples, blockquoted examples, and real findings after examples.

## Validation
- `timeout 120 python3 -m pytest tests/cli/commands/test_review_queue_comment_verdicts.py tests/governance/test_finding_severity_gate.py -q`
- `timeout 180 pre-commit run --files aragora/cli/commands/review_queue_comment_verdicts.py tests/cli/commands/test_review_queue_comment_verdicts.py`
- Push hook: pre-commit + mypy passed

Draft because this touches merge/evidence classification behavior and should go through normal governance review.
