### PR TITLE
ci(merge-gate): activate severity-gated dissent (set live flag)

### DIFF
--- a/.github/workflows/aragora-merge-quorum.yml
+++ b/.github/workflows/aragora-merge-quorum.yml
@@ -107,6 +107,12 @@ jobs:
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
           IS_DRAFT: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft || 'false' }}
+          # Activate severity-gated dissent (FIPS #8574 / spec docs/specs/FINDING_SEVERITY_GATE.md):
+          # a [P2]/[P3]-only or finding-free CHANGES-REQUESTED becomes advisory (non-blocking,
+          # non-counting); [P0]/[P1] and populated Blocker labels still ALWAYS block. The gate-logic
+          # code + the disclosed bare-"no" Blocker security fix are already on main; this only sets
+          # the live (CI) side of the min(prepared, live) flag — the prepare side is set in operator env.
+          ARAGORA_ENABLE_SEVERITY_GATED_DISSENT: "1"
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Activate severity-gated dissent (live flag)

Sets `ARAGORA_ENABLE_SEVERITY_GATED_DISSENT=1` in the `aragora-merge-quorum` workflow so a `[P2]`/`[P3]`-only or finding-free `CHANGES-REQUESTED` becomes **advisory** (non-blocking, non-counting). `[P0]`/`[P1]` and populated Blocker labels still **ALWAYS** block.

### Why this is operator-settled (not normal quorum)
The merge-gate workflow checks out `main` and runs main's classifier to evaluate every PR. Any honest model review of *severity-gating* necessarily mentions the dissent markers (`[P2]`, `Verdict: CHANGES-REQUESTED`) that the **strict** gate blocks on — so a change that activates severity-gating cannot pass the gate it is trying to relax (verified: grok PASSED #8596 but raised two real `[P2]` tags → blocked under strict). With `enforce_admins: true`, `--admin` cannot bypass either. This is the legitimate operator escape-hatch per `docs/REVIEW_AUTHORITY_PRINCIPLES.md`: a change the gate is structurally incapable of evaluating.

### Safety
- The gate-logic code + the disclosed bare-`"no"` Blocker **security fix** are already on `main` (#8574 lineage). This only sets the live (CI) side of the `min(prepared, live)` flag.
- Default-OFF design; reversible by reverting this one line.
- `[P0]`/`[P1]`/Blocker-label dissents are unaffected.
