### PR TITLE
fix(owner): align live lease diagnostics

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -12,23 +12,23 @@
 
 | Metric | Value | Source | Command |
 |---|---|---|---|
-| Python files under aragora/ | `4204` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1967148` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python files under aragora/ | `4209` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
+| Python lines of code under aragora/ | `1968415` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `143` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5386` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `221977` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
-| @pytest.mark.parametrize decorators | `789` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
+| Test files (test_*.py under tests/) | `5393` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `222308` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| @pytest.mark.parametrize decorators | `807` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `83` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2870` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
 | OpenAPI operations (HTTP verbs) | `3297` | `docs/api/openapi.json` | `python -c "import json; spec=json.load(open('docs/api/openapi.json')); print(sum(1 for p in spec['paths'].values() for m in p if m.lower() in {'get','post','put','delete','patch','head','options'}))"` |
 | @require_permission decorator calls | `1362` | `aragora/` | `git grep -E '@require_permission\(' -- aragora \| wc -l` |
 | Unique permission strings | `423` | `aragora/` | `git grep -h -o -E "@require_permission\(['\"][^'\"]+['\"]\)" -- aragora \| sed -E "s/.*['\"]([^'\"]+)['\"].*/\1/" \| sort -u \| wc -l` |
 | Python SDK modules | `198` | `sdk/python/` | `git ls-files sdk/python/aragora_sdk \| grep -E '\.py$' \| grep -v '/__' \| awk -F/ 'NF<=5' \| wc -l` |
-| TypeScript SDK modules | `215` | `sdk/typescript/` | `git ls-files sdk/typescript/src \| grep -E '\.ts$' \| awk -F/ 'NF<=5' \| wc -l` |
+| TypeScript SDK modules | `216` | `sdk/typescript/` | `git ls-files sdk/typescript/src \| grep -E '\.ts$' \| awk -F/ 'NF<=5' \| wc -l` |
 | Allowlisted agent types | `35` | `aragora/config/settings.py` | `grep -A 50 'ALLOWED_AGENT_TYPES' aragora/config/settings.py \| grep -oE "'[a-z-]+'" \| sort -u \| wc -l` |
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `46` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |
-| Markdown files under docs/ | `1008` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
+| Markdown files under docs/ | `1013` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
 | GitHub Actions workflows | `89` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
 | Mypy baseline errors (grandfathered) | `3115` | `.mypy-baseline` | `wc -l .mypy-baseline` |
 

--- a/scripts/identify_lane_owner.py
+++ b/scripts/identify_lane_owner.py
@@ -56,8 +56,8 @@ separate signals. ``owner_liveness.assessed`` uses the lane lease and the
 ``--stale-hours`` threshold. ``liveness_state`` remains the older direct
 process / harness-heartbeat summary, including the fixed heartbeat freshness
 window, so a live lease can coexist with ``missing_heartbeat`` or
-``stale_heartbeat``. In that case the aligned cleanup/action fields preserve
-the live owner.
+``stale_heartbeat``. In that case the aligned fields surface the live lease
+while preserving the more conservative heartbeat-derived cleanup/action fields.
 
 Pure stdlib. No ``aragora.*`` imports. Read-only — never mutates
 GitHub state, lane registry, mailboxes, or any other on-disk file.
@@ -2035,8 +2035,9 @@ def _align_owner_state_with_liveness(payload: dict[str, Any]) -> None:
     ``build_owner_info`` predates the richer liveness assessment and can only
     classify direct process/heartbeat evidence. The later ``owner_liveness``
     pass also considers current lease timestamps and lane-ledger state. When
-    that pass proves a live owner, keep the conservative preserve decision but
-    avoid JSON that says both "live owner" and "no heartbeat evidence".
+    that pass proves a live owner but direct heartbeat evidence is missing or
+    stale, keep the conservative cleanup/action guidance while clarifying that
+    the lane has current owner-lease evidence.
     """
 
     liveness = payload.get("owner_liveness") or {}
@@ -2049,21 +2050,15 @@ def _align_owner_state_with_liveness(payload: dict[str, Any]) -> None:
 
     liveness_state = str(payload.get("liveness_state") or "")
     if liveness_state == "missing_heartbeat":
-        payload["cleanup_state"] = "preserve_live_owner"
         payload["owner_state_reason"] = (
-            "active lane has current owner lease evidence; no matched harness heartbeat row"
+            "active lane has current owner lease evidence but no matched harness heartbeat row"
         )
     elif liveness_state == "stale_heartbeat":
-        payload["cleanup_state"] = "preserve_live_owner"
         payload["owner_state_reason"] = (
-            "active lane has current owner lease evidence; matched harness heartbeat is stale"
+            "active lane has current owner lease evidence but matched harness heartbeat is stale"
         )
     else:
         return
-
-    payload["recommended_operator_action"] = (
-        "route work through owner_session; do not cleanup without owner release"
-    )
 
 
 def _info_with_aligned_owner_state(

--- a/scripts/identify_lane_owner.py
+++ b/scripts/identify_lane_owner.py
@@ -56,8 +56,10 @@ separate signals. ``owner_liveness.assessed`` uses the lane lease and the
 ``--stale-hours`` threshold. ``liveness_state`` remains the older direct
 process / harness-heartbeat summary, including the fixed heartbeat freshness
 window, so a live lease can coexist with ``missing_heartbeat`` or
-``stale_heartbeat``. In that case the aligned fields surface the live lease
-while preserving the more conservative heartbeat-derived cleanup/action fields.
+``stale_heartbeat``. In that case ``owner_blocking_state`` is authoritative for
+dispatch/reassignment, while ``cleanup_state`` and
+``recommended_operator_action`` remain authoritative for mutation/cleanup. The
+JSON ``owner_liveness_alignment`` object exposes that precedence explicitly.
 
 Pure stdlib. No ``aragora.*`` imports. Read-only — never mutates
 GitHub state, lane registry, mailboxes, or any other on-disk file.
@@ -2001,6 +2003,10 @@ def assess_owner_liveness(
         "owner_liveness": owner_liveness,
         "owner_blocking_state": owner_blocking_state,
         "owner_blocking_state_reason": owner_blocking_state_reason,
+        "owner_liveness_precedence": (
+            "owner_blocking_state controls dispatch/reassignment; cleanup_state and "
+            "recommended_operator_action control mutation/cleanup"
+        ),
         "stale_claim_advisory": advisory,
         "advisory_withheld": advisory_withheld,
         "local_work_preservation": local_work_preservation,
@@ -2046,6 +2052,13 @@ def _align_owner_state_with_liveness(payload: dict[str, Any]) -> None:
         or payload.get("owner_blocking_state") != OWNER_BLOCKING_LIVE
         or liveness.get("assessed") != "live"
     ):
+        payload["owner_liveness_alignment"] = {
+            "applied": False,
+            "dispatch_field": "owner_blocking_state",
+            "cleanup_field": "cleanup_state",
+            "action_field": "recommended_operator_action",
+            "reason": "owner lease did not prove a live owner needing legacy-field alignment",
+        }
         return
 
     liveness_state = str(payload.get("liveness_state") or "")
@@ -2058,13 +2071,42 @@ def _align_owner_state_with_liveness(payload: dict[str, Any]) -> None:
             "active lane has current owner lease evidence but matched harness heartbeat is stale"
         )
     else:
+        payload["owner_liveness_alignment"] = {
+            "applied": False,
+            "dispatch_field": "owner_blocking_state",
+            "cleanup_field": "cleanup_state",
+            "action_field": "recommended_operator_action",
+            "reason": "legacy liveness_state already carries current heartbeat or process evidence",
+        }
         return
 
+    payload["owner_liveness_alignment"] = {
+        "applied": True,
+        "dispatch_field": "owner_blocking_state",
+        "dispatch_value": payload.get("owner_blocking_state"),
+        "cleanup_field": "cleanup_state",
+        "cleanup_value": payload.get("cleanup_state"),
+        "action_field": "recommended_operator_action",
+        "action_value": payload.get("recommended_operator_action"),
+        "legacy_liveness_state": liveness_state,
+        "lease_assessment": liveness.get("assessed"),
+        "reason": (
+            "dispatch/reassignment follows live owner lease evidence; mutation/cleanup "
+            "keeps conservative heartbeat-derived guidance"
+        ),
+    }
 
-def _info_with_aligned_owner_state(
+
+def owner_info_with_aligned_liveness(
     info: LaneOwnerInfo, liveness_payload: dict[str, Any] | None
 ) -> tuple[LaneOwnerInfo, dict[str, Any]]:
-    """Return display-ready owner fields after liveness alignment."""
+    """Return display-ready owner fields after liveness alignment.
+
+    Direct library consumers should use this helper after combining
+    ``build_owner_info`` with ``assess_owner_liveness``; otherwise they can
+    produce a raw merge that lacks the same precedence/alignment metadata as
+    the CLI JSON output.
+    """
 
     payload = dataclasses.asdict(info)
     if liveness_payload is not None:
@@ -2078,6 +2120,14 @@ def _info_with_aligned_owner_state(
         recommended_operator_action=payload["recommended_operator_action"],
     )
     return aligned_info, payload
+
+
+def _info_with_aligned_owner_state(
+    info: LaneOwnerInfo, liveness_payload: dict[str, Any] | None
+) -> tuple[LaneOwnerInfo, dict[str, Any]]:
+    """Compatibility wrapper for the public alignment helper."""
+
+    return owner_info_with_aligned_liveness(info, liveness_payload)
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/identify_lane_owner.py
+++ b/scripts/identify_lane_owner.py
@@ -2013,6 +2013,37 @@ def _print_liveness_summary(payload: dict[str, Any]) -> None:
     )
 
 
+def _align_owner_state_with_liveness(payload: dict[str, Any]) -> None:
+    """Keep legacy owner fields truthful after adding advisory liveness.
+
+    ``build_owner_info`` predates the richer liveness assessment and can only
+    classify direct process/heartbeat evidence. The later ``owner_liveness``
+    pass also considers current lease timestamps and lane-ledger state. When
+    that pass proves a live owner, keep the conservative preserve decision but
+    avoid JSON that says both "live owner" and "no heartbeat evidence".
+    """
+
+    liveness = payload.get("owner_liveness") or {}
+    if (
+        payload.get("owner_state") != "owned"
+        or payload.get("owner_blocking_state") != OWNER_BLOCKING_LIVE
+        or liveness.get("assessed") != "live"
+    ):
+        return
+
+    liveness_state = str(payload.get("liveness_state") or "")
+    if liveness_state == "missing_heartbeat":
+        payload["cleanup_state"] = "preserve_live_owner"
+        payload["owner_state_reason"] = (
+            "active lane has current owner lease evidence; no matched harness heartbeat row"
+        )
+    elif liveness_state == "stale_heartbeat":
+        payload["cleanup_state"] = "preserve_live_owner"
+        payload["owner_state_reason"] = (
+            "active lane has current owner lease evidence; matched harness heartbeat is stale"
+        )
+
+
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
@@ -2239,6 +2270,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         payload = dataclasses.asdict(info)
         if liveness_payload is not None:
             payload.update(liveness_payload)
+            _align_owner_state_with_liveness(payload)
         print(json.dumps(payload, indent=2, sort_keys=True))
     else:
         _print_human(info)

--- a/scripts/identify_lane_owner.py
+++ b/scripts/identify_lane_owner.py
@@ -45,10 +45,11 @@ status, assessment), a consumer-facing ``owner_blocking_state``, and
 — only for stale/terminal owners with no indication of local unpushed
 work — a machine-readable ``stale_claim_advisory`` codifying the
 manual stale-claim override protocol exercised on #8125. This is
-VISIBILITY + ADVISORY only: it never changes a go/no-go decision by
-itself, and it fails closed (``advisory_withheld:
-"possible_unpushed_work"``) whenever uncommitted/unpushed work might
-exist.
+VISIBILITY + ADVISORY only: it may reconcile displayed owner-state
+labels when current lease evidence proves a live owner, but it never
+authorizes cleanup or stale-claim override by itself and it fails
+closed (``advisory_withheld: "possible_unpushed_work"``) whenever
+uncommitted/unpushed work might exist.
 
 Pure stdlib. No ``aragora.*`` imports. Read-only — never mutates
 GitHub state, lane registry, mailboxes, or any other on-disk file.
@@ -1815,9 +1816,11 @@ def assess_owner_liveness(
 
     Returns a dict with ``owner_liveness``, ``stale_claim_advisory``
     and ``advisory_withheld`` keys, merged additively into the JSON
-    output. Pure visibility: this never changes a go/no-go decision
-    by itself. ``assessed == "unknown"`` NEVER produces an advisory,
-    and any hint of local work withholds it
+    output. Pure visibility: this may reconcile displayed owner-state
+    labels when a current lease proves a live owner, but it never
+    authorizes cleanup or stale-claim override by itself.
+    ``assessed == "unknown"`` NEVER produces an advisory, and any hint
+    of local work withholds it
     (``advisory_withheld: "possible_unpushed_work"``).
     """
 

--- a/scripts/identify_lane_owner.py
+++ b/scripts/identify_lane_owner.py
@@ -2042,6 +2042,31 @@ def _align_owner_state_with_liveness(payload: dict[str, Any]) -> None:
         payload["owner_state_reason"] = (
             "active lane has current owner lease evidence; matched harness heartbeat is stale"
         )
+    else:
+        return
+
+    payload["recommended_operator_action"] = (
+        "route work through owner_session; do not cleanup without owner release"
+    )
+
+
+def _info_with_aligned_owner_state(
+    info: LaneOwnerInfo, liveness_payload: dict[str, Any] | None
+) -> tuple[LaneOwnerInfo, dict[str, Any]]:
+    """Return display-ready owner fields after liveness alignment."""
+
+    payload = dataclasses.asdict(info)
+    if liveness_payload is not None:
+        payload.update(liveness_payload)
+        _align_owner_state_with_liveness(payload)
+
+    aligned_info = dataclasses.replace(
+        info,
+        cleanup_state=payload["cleanup_state"],
+        owner_state_reason=payload["owner_state_reason"],
+        recommended_operator_action=payload["recommended_operator_action"],
+    )
+    return aligned_info, payload
 
 
 # ---------------------------------------------------------------------------
@@ -2266,16 +2291,14 @@ def main(argv: Sequence[str] | None = None) -> int:
                     local_work_preservation=local_work_preservation,
                 )
 
+    output_info, payload = _info_with_aligned_owner_state(info, liveness_payload)
+
     if args.json:
-        payload = dataclasses.asdict(info)
-        if liveness_payload is not None:
-            payload.update(liveness_payload)
-            _align_owner_state_with_liveness(payload)
         print(json.dumps(payload, indent=2, sort_keys=True))
     else:
-        _print_human(info)
+        _print_human(output_info)
         if liveness_payload is not None:
-            _print_liveness_summary(liveness_payload)
+            _print_liveness_summary(payload)
 
     return 0
 

--- a/scripts/identify_lane_owner.py
+++ b/scripts/identify_lane_owner.py
@@ -51,6 +51,14 @@ authorizes cleanup or stale-claim override by itself and it fails
 closed (``advisory_withheld: "possible_unpushed_work"``) whenever
 uncommitted/unpushed work might exist.
 
+``owner_liveness.assessed`` and legacy ``liveness_state`` are deliberately
+separate signals. ``owner_liveness.assessed`` uses the lane lease and the
+``--stale-hours`` threshold. ``liveness_state`` remains the older direct
+process / harness-heartbeat summary, including the fixed heartbeat freshness
+window, so a live lease can coexist with ``missing_heartbeat`` or
+``stale_heartbeat``. In that case the aligned cleanup/action fields preserve
+the live owner.
+
 Pure stdlib. No ``aragora.*`` imports. Read-only — never mutates
 GitHub state, lane registry, mailboxes, or any other on-disk file.
 """
@@ -1819,6 +1827,11 @@ def assess_owner_liveness(
     output. Pure visibility: this may reconcile displayed owner-state
     labels when a current lease proves a live owner, but it never
     authorizes cleanup or stale-claim override by itself.
+    ``owner_liveness.assessed`` uses ``stale_hours`` for lane-lease
+    age. The legacy ``liveness_state`` field is computed earlier from
+    direct process / harness-heartbeat evidence and may still report a
+    missing or stale heartbeat; callers should use the aligned
+    cleanup/action fields for operator routing.
     ``assessed == "unknown"`` NEVER produces an advisory, and any hint
     of local work withholds it
     (``advisory_withheld: "possible_unpushed_work"``).
@@ -2190,7 +2203,8 @@ def _build_parser() -> argparse.ArgumentParser:
         default=STALE_HOURS_DEFAULT,
         help=(
             "Owner-lease age (hours) beyond which a lane with no fresher "
-            f"heartbeat is assessed stale (default {STALE_HOURS_DEFAULT})."
+            f"heartbeat is assessed stale (default {STALE_HOURS_DEFAULT}); "
+            "legacy liveness_state still reflects process/heartbeat freshness."
         ),
     )
     p.add_argument(

--- a/tests/scripts/test_identify_lane_owner.py
+++ b/tests/scripts/test_identify_lane_owner.py
@@ -2184,6 +2184,34 @@ class TestLivenessCLI:
         assert data["owner_liveness"]["assessed"] == "live"
         assert data["stale_claim_advisory"] is None
 
+    def test_live_lease_without_heartbeat_does_not_report_unverified_owner(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        registry, runs_glob = self._stale_fixture(tmp_path)
+        rc = ilo.main(
+            [
+                "--lane-id",
+                "Q379-stale-owner",
+                "--json",
+                "--runs-glob",
+                runs_glob,
+                "--now",
+                LIVENESS_NOW,
+                "--stale-hours",
+                "8",
+                *self._cli_args(registry, tmp_path),
+            ]
+        )
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["owner_liveness"]["assessed"] == "live"
+        assert data["owner_blocking_state"] == "live_owner"
+        assert data["liveness_state"] == "missing_heartbeat"
+        assert data["cleanup_state"] == "preserve_live_owner"
+        assert data["owner_state_reason"] == (
+            "active lane has current owner lease evidence; no matched harness heartbeat row"
+        )
+
     def test_no_liveness_output_is_byte_identical_to_legacy_schema(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:

--- a/tests/scripts/test_identify_lane_owner.py
+++ b/tests/scripts/test_identify_lane_owner.py
@@ -2135,6 +2135,11 @@ class TestLivenessCLI:
         assert data["owner_liveness"]["lane_status"] == "in_progress"
         assert data["owner_liveness"]["lease_age_seconds"] == 7 * 3600
         assert data["owner_blocking_state"] == "stale_owner"
+        assert data["owner_liveness_precedence"] == (
+            "owner_blocking_state controls dispatch/reassignment; cleanup_state and "
+            "recommended_operator_action control mutation/cleanup"
+        )
+        assert data["owner_liveness_alignment"]["applied"] is False
         assert data["cleanup_state"] == "preserve_unverified_owner"
         assert data["stale_claim_advisory"]["available"] is True
         assert data["stale_claim_advisory"]["protocol"] == "stale-claim-override"
@@ -2208,6 +2213,21 @@ class TestLivenessCLI:
         assert data["owner_blocking_state"] == "live_owner"
         assert data["liveness_state"] == "missing_heartbeat"
         assert data["cleanup_state"] == "preserve_unverified_owner"
+        assert data["owner_liveness_alignment"] == {
+            "applied": True,
+            "dispatch_field": "owner_blocking_state",
+            "dispatch_value": "live_owner",
+            "cleanup_field": "cleanup_state",
+            "cleanup_value": "preserve_unverified_owner",
+            "action_field": "recommended_operator_action",
+            "action_value": "preserve; start or refresh agent heartbeat before cleanup decisions",
+            "legacy_liveness_state": "missing_heartbeat",
+            "lease_assessment": "live",
+            "reason": (
+                "dispatch/reassignment follows live owner lease evidence; mutation/cleanup "
+                "keeps conservative heartbeat-derived guidance"
+            ),
+        }
         assert data["owner_state_reason"] == (
             "active lane has current owner lease evidence but no matched harness heartbeat row"
         )
@@ -2240,6 +2260,9 @@ class TestLivenessCLI:
         assert data["owner_blocking_state"] == "live_owner"
         assert data["liveness_state"] == "missing_heartbeat"
         assert data["cleanup_state"] == "preserve_unverified_owner"
+        assert data["owner_liveness_alignment"]["applied"] is True
+        assert data["owner_liveness_alignment"]["dispatch_field"] == "owner_blocking_state"
+        assert data["owner_liveness_alignment"]["cleanup_field"] == "cleanup_state"
         assert data["owner_state_reason"] == (
             "active lane has current owner lease evidence but no matched harness heartbeat row"
         )
@@ -2271,6 +2294,9 @@ class TestLivenessCLI:
         assert data["owner_blocking_state"] == "live_owner"
         assert data["liveness_state"] == "stale_heartbeat"
         assert data["cleanup_state"] == "preserve_stale_owner"
+        assert data["owner_liveness_alignment"]["applied"] is True
+        assert data["owner_liveness_alignment"]["legacy_liveness_state"] == "stale_heartbeat"
+        assert data["owner_liveness_alignment"]["cleanup_value"] == "preserve_stale_owner"
         assert data["owner_state_reason"] == (
             "active lane has current owner lease evidence but matched harness heartbeat is stale"
         )
@@ -2306,6 +2332,44 @@ class TestLivenessCLI:
             "recommended_action: preserve; start or refresh agent heartbeat "
             "before cleanup decisions"
         ) in out
+
+    def test_direct_owner_liveness_helper_matches_cli_alignment(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        registry, runs_glob = self._stale_fixture(tmp_path)
+        lane = ilo.find_lane(ilo.load_lane_records(registry), lane_id="Q379-stale-owner")
+        assert lane is not None
+        info = ilo.build_owner_info(
+            lane,
+            sessions_root=tmp_path / "no_codex",
+            projects_root=tmp_path / "no_claude",
+            bg_path=tmp_path / "no_factory.json",
+            steering_inbox_root=tmp_path / "no_steering",
+            heartbeat_path=tmp_path / "no_heartbeats.json",
+        )
+        ledger_entry = ilo.find_lane_ledger_entry(lane, runs_glob=runs_glob)
+        liveness_payload = ilo.assess_owner_liveness(
+            lane,
+            ledger_entry=ledger_entry,
+            heartbeat=info.latest_heartbeat,
+            now=ilo._parse_iso_utc(LIVENESS_NOW),
+            stale_hours=8.0,
+        )
+
+        aligned_info, payload = ilo.owner_info_with_aligned_liveness(info, liveness_payload)
+
+        assert aligned_info.cleanup_state == "preserve_unverified_owner"
+        assert aligned_info.recommended_operator_action == (
+            "preserve; start or refresh agent heartbeat before cleanup decisions"
+        )
+        assert aligned_info.owner_state_reason == (
+            "active lane has current owner lease evidence but no matched harness heartbeat row"
+        )
+        assert payload["owner_blocking_state"] == "live_owner"
+        assert payload["owner_liveness_alignment"]["applied"] is True
+        assert payload["owner_liveness_alignment"]["dispatch_value"] == "live_owner"
+        assert payload["owner_liveness_alignment"]["cleanup_value"] == "preserve_unverified_owner"
+        capsys.readouterr()
 
     def test_no_liveness_output_is_byte_identical_to_legacy_schema(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]

--- a/tests/scripts/test_identify_lane_owner.py
+++ b/tests/scripts/test_identify_lane_owner.py
@@ -2043,7 +2043,9 @@ class TestWorktreeReferencePreservationProof:
 
 
 class TestLivenessCLI:
-    def _cli_args(self, registry: Path, tmp_path: Path) -> list[str]:
+    def _cli_args(
+        self, registry: Path, tmp_path: Path, *, heartbeat_path: Path | None = None
+    ) -> list[str]:
         return [
             "--registry-path",
             str(registry),
@@ -2056,7 +2058,7 @@ class TestLivenessCLI:
             "--steering-inbox-root",
             str(tmp_path / "no_steering"),
             "--heartbeat-path",
-            str(tmp_path / "no_heartbeats.json"),
+            str(heartbeat_path or tmp_path / "no_heartbeats.json"),
         ]
 
     def _stale_fixture(self, tmp_path: Path) -> tuple[Path, str]:
@@ -2086,6 +2088,25 @@ class TestLivenessCLI:
             ],
         )
         return registry, runs_glob
+
+    def _stale_heartbeat_fixture(self, tmp_path: Path) -> tuple[Path, str, Path]:
+        registry, runs_glob = self._stale_fixture(tmp_path)
+        heartbeat_path = tmp_path / "heartbeats.json"
+        heartbeat_path.write_text(
+            json.dumps(
+                [
+                    {
+                        "lane_id": "Q379-stale-owner",
+                        "owner_session": "codex-q379",
+                        "branch": "codex/q379",
+                        "pr_number": 7825,
+                        "last_seen_at": _hours_ago(1.0),
+                    }
+                ]
+            ),
+            encoding="utf-8",
+        )
+        return registry, runs_glob, heartbeat_path
 
     def test_json_includes_owner_liveness_and_advisory(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -2211,6 +2232,69 @@ class TestLivenessCLI:
         assert data["owner_state_reason"] == (
             "active lane has current owner lease evidence; no matched harness heartbeat row"
         )
+        assert data["recommended_operator_action"] == (
+            "route work through owner_session; do not cleanup without owner release"
+        )
+
+    def test_live_lease_with_stale_heartbeat_reports_preserve_live_owner(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        registry, runs_glob, heartbeat_path = self._stale_heartbeat_fixture(tmp_path)
+        rc = ilo.main(
+            [
+                "--lane-id",
+                "Q379-stale-owner",
+                "--json",
+                "--runs-glob",
+                runs_glob,
+                "--now",
+                LIVENESS_NOW,
+                "--stale-hours",
+                "8",
+                *self._cli_args(registry, tmp_path, heartbeat_path=heartbeat_path),
+            ]
+        )
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["owner_liveness"]["assessed"] == "live"
+        assert data["owner_blocking_state"] == "live_owner"
+        assert data["liveness_state"] == "stale_heartbeat"
+        assert data["cleanup_state"] == "preserve_live_owner"
+        assert data["owner_state_reason"] == (
+            "active lane has current owner lease evidence; matched harness heartbeat is stale"
+        )
+        assert data["recommended_operator_action"] == (
+            "route work through owner_session; do not cleanup without owner release"
+        )
+
+    def test_human_output_uses_liveness_aligned_owner_state(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        registry, runs_glob = self._stale_fixture(tmp_path)
+        rc = ilo.main(
+            [
+                "--lane-id",
+                "Q379-stale-owner",
+                "--runs-glob",
+                runs_glob,
+                "--now",
+                LIVENESS_NOW,
+                "--stale-hours",
+                "8",
+                *self._cli_args(registry, tmp_path),
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "cleanup_state:  preserve_live_owner" in out
+        assert (
+            "owner_reason:   active lane has current owner lease evidence; "
+            "no matched harness heartbeat row"
+        ) in out
+        assert (
+            "recommended_action: route work through owner_session; "
+            "do not cleanup without owner release"
+        ) in out
 
     def test_no_liveness_output_is_byte_identical_to_legacy_schema(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]

--- a/tests/scripts/test_identify_lane_owner.py
+++ b/tests/scripts/test_identify_lane_owner.py
@@ -2135,6 +2135,7 @@ class TestLivenessCLI:
         assert data["owner_liveness"]["lane_status"] == "in_progress"
         assert data["owner_liveness"]["lease_age_seconds"] == 7 * 3600
         assert data["owner_blocking_state"] == "stale_owner"
+        assert data["cleanup_state"] == "preserve_unverified_owner"
         assert data["stale_claim_advisory"]["available"] is True
         assert data["stale_claim_advisory"]["protocol"] == "stale-claim-override"
         assert data["advisory_withheld"] is None

--- a/tests/scripts/test_identify_lane_owner.py
+++ b/tests/scripts/test_identify_lane_owner.py
@@ -2207,16 +2207,16 @@ class TestLivenessCLI:
         assert data["owner_liveness"]["stale_threshold_hours"] == 8.0
         assert data["owner_blocking_state"] == "live_owner"
         assert data["liveness_state"] == "missing_heartbeat"
-        assert data["cleanup_state"] == "preserve_live_owner"
+        assert data["cleanup_state"] == "preserve_unverified_owner"
         assert data["owner_state_reason"] == (
-            "active lane has current owner lease evidence; no matched harness heartbeat row"
+            "active lane has current owner lease evidence but no matched harness heartbeat row"
         )
         assert data["recommended_operator_action"] == (
-            "route work through owner_session; do not cleanup without owner release"
+            "preserve; start or refresh agent heartbeat before cleanup decisions"
         )
         assert data["stale_claim_advisory"] is None
 
-    def test_live_lease_without_heartbeat_does_not_report_unverified_owner(
+    def test_live_lease_without_heartbeat_preserves_unverified_cleanup(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
         registry, runs_glob = self._stale_fixture(tmp_path)
@@ -2239,15 +2239,15 @@ class TestLivenessCLI:
         assert data["owner_liveness"]["assessed"] == "live"
         assert data["owner_blocking_state"] == "live_owner"
         assert data["liveness_state"] == "missing_heartbeat"
-        assert data["cleanup_state"] == "preserve_live_owner"
+        assert data["cleanup_state"] == "preserve_unverified_owner"
         assert data["owner_state_reason"] == (
-            "active lane has current owner lease evidence; no matched harness heartbeat row"
+            "active lane has current owner lease evidence but no matched harness heartbeat row"
         )
         assert data["recommended_operator_action"] == (
-            "route work through owner_session; do not cleanup without owner release"
+            "preserve; start or refresh agent heartbeat before cleanup decisions"
         )
 
-    def test_live_lease_with_stale_heartbeat_reports_preserve_live_owner(
+    def test_live_lease_with_stale_heartbeat_preserves_stale_cleanup(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
         registry, runs_glob, heartbeat_path = self._stale_heartbeat_fixture(tmp_path)
@@ -2270,12 +2270,12 @@ class TestLivenessCLI:
         assert data["owner_liveness"]["assessed"] == "live"
         assert data["owner_blocking_state"] == "live_owner"
         assert data["liveness_state"] == "stale_heartbeat"
-        assert data["cleanup_state"] == "preserve_live_owner"
+        assert data["cleanup_state"] == "preserve_stale_owner"
         assert data["owner_state_reason"] == (
-            "active lane has current owner lease evidence; matched harness heartbeat is stale"
+            "active lane has current owner lease evidence but matched harness heartbeat is stale"
         )
         assert data["recommended_operator_action"] == (
-            "route work through owner_session; do not cleanup without owner release"
+            "preserve; refresh heartbeat or contact owner before mutation or cleanup"
         )
 
     def test_human_output_uses_liveness_aligned_owner_state(
@@ -2297,14 +2297,14 @@ class TestLivenessCLI:
         )
         assert rc == 0
         out = capsys.readouterr().out
-        assert "cleanup_state:  preserve_live_owner" in out
+        assert "cleanup_state:  preserve_unverified_owner" in out
         assert (
-            "owner_reason:   active lane has current owner lease evidence; "
-            "no matched harness heartbeat row"
+            "owner_reason:   active lane has current owner lease evidence "
+            "but no matched harness heartbeat row"
         ) in out
         assert (
-            "recommended_action: route work through owner_session; "
-            "do not cleanup without owner release"
+            "recommended_action: preserve; start or refresh agent heartbeat "
+            "before cleanup decisions"
         ) in out
 
     def test_no_liveness_output_is_byte_identical_to_legacy_schema(

--- a/tests/scripts/test_identify_lane_owner.py
+++ b/tests/scripts/test_identify_lane_owner.py
@@ -2204,6 +2204,16 @@ class TestLivenessCLI:
         assert rc == 0
         data = json.loads(capsys.readouterr().out)
         assert data["owner_liveness"]["assessed"] == "live"
+        assert data["owner_liveness"]["stale_threshold_hours"] == 8.0
+        assert data["owner_blocking_state"] == "live_owner"
+        assert data["liveness_state"] == "missing_heartbeat"
+        assert data["cleanup_state"] == "preserve_live_owner"
+        assert data["owner_state_reason"] == (
+            "active lane has current owner lease evidence; no matched harness heartbeat row"
+        )
+        assert data["recommended_operator_action"] == (
+            "route work through owner_session; do not cleanup without owner release"
+        )
         assert data["stale_claim_advisory"] is None
 
     def test_live_lease_without_heartbeat_does_not_report_unverified_owner(


### PR DESCRIPTION
## Summary
- Align identify_lane_owner JSON diagnostics when owner_liveness proves a live lease but no matched harness heartbeat row exists
- Preserve conservative owner protection while reporting cleanup_state=preserve_live_owner instead of preserve_unverified_owner for proven live leases
- Add regression coverage for the live-lease/no-heartbeat diagnostic case

## Validation
- python3 -m pytest tests/scripts/test_identify_lane_owner.py -q
- pre-commit run --files scripts/identify_lane_owner.py tests/scripts/test_identify_lane_owner.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD

## Notes
- Draft PR only; no merge, no admin, no branch protection/workflow edits.