### PR TITLE
Tighten pidless heartbeat finalizer matching

### DIFF
--- a/scripts/agent_heartbeat.py
+++ b/scripts/agent_heartbeat.py
@@ -250,6 +250,32 @@ def _same_finalizer_identity(existing: dict[str, Any], receipt: dict[str, Any]) 
     return comparable
 
 
+def _has_finalizer_identity_delta(existing: dict[str, Any], receipt: dict[str, Any]) -> bool:
+    for key in ("worktree", "branch", "pr_number"):
+        existing_value = existing.get(key)
+        receipt_value = receipt.get(key)
+        if existing_value is None or receipt_value is None:
+            continue
+        if isinstance(existing_value, str) and not existing_value:
+            continue
+        if isinstance(receipt_value, str) and not receipt_value:
+            continue
+        if existing_value != receipt_value:
+            return True
+    return False
+
+
+def _same_pidless_finalizer_identity(
+    existing: dict[str, Any],
+    receipt: dict[str, Any],
+) -> bool:
+    if _has_finalizer_identity_delta(existing, receipt):
+        return False
+    existing_worktree = str(existing.get("worktree") or "").strip()
+    receipt_worktree = str(receipt.get("worktree") or "").strip()
+    return bool(existing_worktree and existing_worktree == receipt_worktree)
+
+
 def _terminal_heartbeat_fields(
     receipt: dict[str, Any],
     *,
@@ -340,6 +366,7 @@ def _finalizer_matches_heartbeat(existing: dict[str, Any], *, receipt: dict[str,
         return False
     if existing_thread and receipt_thread and existing_thread != receipt_thread:
         return False
+    same_thread_identity = bool(existing_thread and receipt_thread)
     if existing_thread and not receipt_thread:
         return _same_finalizer_identity(existing, receipt)
     if receipt_thread and not existing_thread:
@@ -348,7 +375,9 @@ def _finalizer_matches_heartbeat(existing: dict[str, Any], *, receipt: dict[str,
     existing_pid = existing.get("pid")
     receipt_pid = receipt.get("pid")
     if existing_pid is not None and receipt_pid is None:
-        return _same_finalizer_identity(existing, receipt)
+        if same_thread_identity:
+            return not _has_finalizer_identity_delta(existing, receipt)
+        return _same_pidless_finalizer_identity(existing, receipt)
     if existing_pid is None and receipt_pid is not None:
         return _same_finalizer_identity(existing, receipt)
     if existing_pid is not None and receipt_pid is not None and existing_pid != receipt_pid:

--- a/tests/scripts/test_agent_heartbeat.py
+++ b/tests/scripts/test_agent_heartbeat.py
@@ -154,6 +154,7 @@ def test_finalizer_receipt_marks_matching_heartbeat_terminal(tmp_path: Path) -> 
         receipt_path=receipt_path,
         lane_id="Q612-heartbeat-finalizer",
         owner_session="codex-Q612",
+        pid=34567,
         branch="codex/lane-heartbeat-finalizer-20260623",
         outcome="completed",
         reason="published draft PR",
@@ -180,6 +181,7 @@ def test_finalizer_receipt_matches_stable_identity_despite_different_cwd(
         owner_session="codex-Q612",
         pid=34567,
         cwd="/tmp/launcher-cwd",
+        worktree="/tmp/aragora/.worktrees/q612",
         branch="codex/lane-heartbeat-finalizer-20260623",
         last_seen_at="2026-06-23T10:09:00Z",
     )
@@ -190,6 +192,7 @@ def test_finalizer_receipt_matches_stable_identity_despite_different_cwd(
         lane_id="Q612-heartbeat-finalizer",
         owner_session="codex-Q612",
         cwd="/tmp/manual-finalizer-cwd",
+        worktree="/tmp/aragora/.worktrees/q612",
         branch="codex/lane-heartbeat-finalizer-20260623",
         outcome="completed",
         reason="published draft PR",
@@ -200,6 +203,69 @@ def test_finalizer_receipt_matches_stable_identity_despite_different_cwd(
     assert payload[0]["terminal"] is True
     assert payload[0]["terminal_outcome"] == "completed"
     assert payload[0]["terminal_receipt_recorded"] is True
+
+
+def test_pidless_finalizer_with_matching_thread_marks_pid_bearing_heartbeat_terminal(
+    tmp_path: Path,
+) -> None:
+    heartbeat_path = tmp_path / "heartbeats.json"
+    receipt_path = tmp_path / "finalizer-receipts.jsonl"
+    heartbeat.record_heartbeat(
+        heartbeat_path=heartbeat_path,
+        lane_id="Q612-heartbeat-finalizer",
+        owner_session="codex-Q612",
+        thread_id="wrapper-run-1",
+        pid=34567,
+        branch="codex/lane-heartbeat-finalizer-20260623",
+        last_seen_at="2026-06-23T10:09:00Z",
+    )
+
+    heartbeat.record_finalizer_receipt(
+        heartbeat_path=heartbeat_path,
+        receipt_path=receipt_path,
+        lane_id="Q612-heartbeat-finalizer",
+        owner_session="codex-Q612",
+        thread_id="wrapper-run-1",
+        outcome="completed",
+        reason="wrapper-run-1 completed",
+        finalized_at="2026-06-23T10:10:00Z",
+    )
+
+    payload = json.loads(heartbeat_path.read_text(encoding="utf-8"))
+    assert payload[0]["terminal"] is True
+    assert payload[0]["terminal_outcome"] == "completed"
+    assert payload[0]["terminal_receipt_recorded"] is True
+
+
+def test_pidless_finalizer_with_branch_only_keeps_pid_bearing_heartbeat_live(
+    tmp_path: Path,
+) -> None:
+    heartbeat_path = tmp_path / "heartbeats.json"
+    receipt_path = tmp_path / "finalizer-receipts.jsonl"
+    heartbeat.record_heartbeat(
+        heartbeat_path=heartbeat_path,
+        lane_id="Q612-heartbeat-finalizer",
+        owner_session="codex-Q612",
+        pid=34567,
+        branch="codex/lane-heartbeat-finalizer-20260623",
+        last_seen_at="2026-06-23T10:09:00Z",
+    )
+
+    heartbeat.record_finalizer_receipt(
+        heartbeat_path=heartbeat_path,
+        receipt_path=receipt_path,
+        lane_id="Q612-heartbeat-finalizer",
+        owner_session="codex-Q612",
+        branch="codex/lane-heartbeat-finalizer-20260623",
+        outcome="completed",
+        reason="branch-only finalizer is not run identity",
+        finalized_at="2026-06-23T10:10:00Z",
+    )
+
+    payload = json.loads(heartbeat_path.read_text(encoding="utf-8"))
+    assert payload[0]["pid"] == 34567
+    assert "terminal" not in payload[0]
+    assert "terminal_outcome" not in payload[0]
 
 
 def test_finalizer_receipt_rejects_conflicting_stable_identity(


### PR DESCRIPTION
## Summary
- tighten heartbeat finalizer matching so pidless finalizers only terminalize PID-bearing heartbeat rows when another stable run identity matches
- preserve same-thread finalizer behavior and require worktree identity for pidless legacy finalizers without thread identity
- add regressions for same-thread acceptance and branch-only rejection

Follow-up to PR #8610 / leased-lane heartbeat finalizer receipts.

## Validation
- python3 -m pytest tests/scripts/test_agent_heartbeat.py -q
- python3 -m pytest tests/scripts/test_tmux_transport_scripts.py -q
- python3 scripts/report_code_quality.py --check
- git diff --check