### PR TITLE
Extend stale owner reconciler to closed PRs

### DIFF
--- a/scripts/resolve_lane_conflicts.py
+++ b/scripts/resolve_lane_conflicts.py
@@ -48,6 +48,7 @@ ACTIVE_STATUSES = {
     "blocked",
 }
 INACTIVE_OWNER_STATUSES = {"released", "completed", "superseded"}
+TERMINAL_PR_STATES = {"MERGED", "CLOSED"}
 HEARTBEAT_TIMESTAMP_KEYS = ("last_heartbeat_at", "last_seen_at", "heartbeat_at")
 PID_KEYS = ("pid", "owner_pid")
 LOCAL_WORK_KEYS = ("worktree", "local_worktree", "local_work_path")
@@ -521,7 +522,7 @@ def _fetch_pr_state(*, pr: int, gh_bin: str) -> dict[str, Any]:
         "view",
         str(pr),
         "--json",
-        "number,state,headRefOid,mergedAt,mergeCommit,url",
+        "number,state,headRefOid,closedAt,mergedAt,mergeCommit,url",
     ]
     try:
         proc = subprocess.run(
@@ -568,6 +569,7 @@ def _fetch_pr_state(*, pr: int, gh_bin: str) -> dict[str, Any]:
         "number": _coerce_int(payload.get("number")),
         "state": str(payload.get("state") or "").upper(),
         "headRefOid": str(payload.get("headRefOid") or ""),
+        "closedAt": payload.get("closedAt"),
         "mergedAt": payload.get("mergedAt"),
         "mergeCommit": _merge_commit_oid(payload),
         "url": str(payload.get("url") or ""),
@@ -674,15 +676,42 @@ def _quote_shell_arg(value: Any) -> str:
     return "'" + text.replace("'", "'\"'\"'") + "'"
 
 
+def _terminal_pr_state(github_state: dict[str, Any]) -> str:
+    return str(github_state.get("state") or "").upper()
+
+
+def _terminal_pr_proof_matches(
+    *,
+    github_state: dict[str, Any],
+    expected_merge_commit: str | None,
+    expected_closed_at: str | None,
+) -> bool:
+    state = _terminal_pr_state(github_state)
+    if state == "MERGED":
+        expected = str(expected_merge_commit or "")
+        return bool(expected) and str(github_state.get("mergeCommit") or "") == expected
+    if state == "CLOSED":
+        expected = str(expected_closed_at or "")
+        return bool(expected) and str(github_state.get("closedAt") or "") == expected
+    return False
+
+
 def _steering_body(*, pr: int, github_state: dict[str, Any]) -> str:
     merge_commit = github_state.get("mergeCommit") or ""
     head = github_state.get("headRefOid") or ""
     merged_at = github_state.get("mergedAt") or ""
+    closed_at = github_state.get("closedAt") or ""
+    state = _terminal_pr_state(github_state)
+    if state == "CLOSED":
+        terminal = f"closed at {closed_at} from head {head}"
+        target = "already-closed target"
+    else:
+        terminal = f"merged at {merge_commit} from head {head} (merged_at={merged_at})"
+        target = "already-merged target"
     return (
-        f"PR #{pr} is already merged at {merge_commit} from head {head} "
-        f"(merged_at={merged_at}). Please mark this lane completed, released, "
-        "or superseded via claim_active_agent_lane.py; do not continue PR "
-        "mutation work on this already-merged target."
+        f"PR #{pr} is already {terminal}. Please mark this lane completed, released, "
+        "or superseded via claim_active_agent_lane.py; do not continue PR mutation work "
+        f"on this {target}."
     )
 
 
@@ -716,9 +745,10 @@ def _owner_release_commands(
     github_state: dict[str, Any],
 ) -> list[str]:
     merge_commit = github_state.get("mergeCommit") or ""
-    next_action = _quote_shell_arg(
-        f"superseded after PR #{pr} merged at {merge_commit}; no further PR mutation"
-    )
+    closed_at = github_state.get("closedAt") or ""
+    state = _terminal_pr_state(github_state)
+    terminal = f"closed at {closed_at}" if state == "CLOSED" else f"merged at {merge_commit}"
+    next_action = _quote_shell_arg(f"superseded after PR #{pr} {terminal}; no further PR mutation")
     commands: list[str] = []
     for finding in findings:
         lane_id = finding.get("lane_id")
@@ -740,14 +770,19 @@ def _operator_apply_command(
     registry_path: Path,
     receipt_dir: Path,
     expected_merge_commit: str,
+    expected_closed_at: str,
     heartbeat_path: Path,
     steering_inbox_root: Path,
     heartbeat_fresh_seconds: int,
 ) -> str:
-    commit_arg = expected_merge_commit or "<merge-commit-sha>"
+    terminal_guard = (
+        f"--expected-closed-at {expected_closed_at or '<closed-at>'}"
+        if expected_closed_at
+        else f"--expected-merge-commit {expected_merge_commit or '<merge-commit-sha>'}"
+    )
     return (
         "python3 scripts/resolve_lane_conflicts.py --merged-pr-lane-audit "
-        f"--pr {pr} --expected-merge-commit {commit_arg} --operator-authorized "
+        f"--pr {pr} {terminal_guard} --operator-authorized "
         f"--registry-path {registry_path} --receipt-dir {receipt_dir} "
         f"--heartbeat-path {_quote_shell_arg(heartbeat_path)} "
         f"--steering-inbox-root {_quote_shell_arg(steering_inbox_root)} "
@@ -763,6 +798,7 @@ def _base_merged_pr_audit_result(
     apply: bool,
     operator_authorized: bool,
     expected_merge_commit: str | None,
+    expected_closed_at: str | None,
     github_state: dict[str, Any],
     findings: list[dict[str, Any]],
     blocked_reason: str | None,
@@ -771,25 +807,34 @@ def _base_merged_pr_audit_result(
     heartbeat_fresh_seconds: int,
 ) -> dict[str, Any]:
     merge_commit = str(github_state.get("mergeCommit") or "")
+    closed_at = str(github_state.get("closedAt") or "")
     expected = str(expected_merge_commit or "")
+    expected_closed = str(expected_closed_at or "")
     unsafe_findings = [finding for finding in findings if finding.get("terminal_safety_blockers")]
     safe_findings = [finding for finding in findings if not finding.get("terminal_safety_blockers")]
     apply_eligible = (
         apply
         and operator_authorized
-        and bool(expected)
         and bool(safe_findings)
         and github_state.get("available") is True
-        and github_state.get("state") == "MERGED"
-        and merge_commit == expected
+        and _terminal_pr_state(github_state) in TERMINAL_PR_STATES
+        and _terminal_pr_proof_matches(
+            github_state=github_state,
+            expected_merge_commit=expected,
+            expected_closed_at=expected_closed,
+        )
     )
     operator_apply_command = ""
     if heartbeat_fresh_seconds >= 0:
+        terminal_state = _terminal_pr_state(github_state)
         operator_apply_command = _operator_apply_command(
             pr=pr,
             registry_path=registry_path,
             receipt_dir=receipt_dir,
             expected_merge_commit=merge_commit or expected,
+            expected_closed_at=(
+                closed_at or expected_closed or "<closed-at>" if terminal_state == "CLOSED" else ""
+            ),
             heartbeat_path=heartbeat_path,
             steering_inbox_root=steering_inbox_root,
             heartbeat_fresh_seconds=heartbeat_fresh_seconds,
@@ -817,6 +862,7 @@ def _base_merged_pr_audit_result(
         "requires_operator_authorization": True,
         "operator_authorized": operator_authorized,
         "expected_merge_commit": expected,
+        "expected_closed_at": expected_closed,
         "apply_eligible": apply_eligible,
         "blocked_reason": blocked_reason,
         "resolved_count": 0,
@@ -829,12 +875,14 @@ def _merged_pr_audit_blocked_reason(
     apply: bool,
     operator_authorized: bool,
     expected_merge_commit: str | None,
+    expected_closed_at: str | None,
     github_state: dict[str, Any],
     findings: list[dict[str, Any]],
 ) -> str | None:
     if github_state.get("available") is not True:
         return "github_state_unavailable"
-    if github_state.get("state") != "MERGED":
+    state = _terminal_pr_state(github_state)
+    if state not in TERMINAL_PR_STATES:
         return "pr_not_merged"
     if not findings:
         return "no_active_lanes_for_merged_pr"
@@ -842,11 +890,18 @@ def _merged_pr_audit_blocked_reason(
         return None
     if not operator_authorized:
         return "operator_authorization_required"
-    expected = str(expected_merge_commit or "")
-    if not expected:
-        return "expected_merge_commit_required"
-    if str(github_state.get("mergeCommit") or "") != expected:
-        return "merge_commit_mismatch"
+    if state == "MERGED":
+        expected = str(expected_merge_commit or "")
+        if not expected:
+            return "expected_merge_commit_required"
+        if str(github_state.get("mergeCommit") or "") != expected:
+            return "merge_commit_mismatch"
+    if state == "CLOSED":
+        expected = str(expected_closed_at or "")
+        if not expected:
+            return "expected_closed_at_required"
+        if str(github_state.get("closedAt") or "") != expected:
+            return "closed_at_mismatch"
     unsafe_findings = [finding for finding in findings if finding.get("terminal_safety_blockers")]
     safe_findings = [finding for finding in findings if not finding.get("terminal_safety_blockers")]
     if unsafe_findings and not safe_findings:
@@ -863,16 +918,16 @@ def audit_merged_pr_lanes(
     apply: bool = False,
     operator_authorized: bool = False,
     expected_merge_commit: str | None = None,
+    expected_closed_at: str | None = None,
     resolved_at: str | None = None,
     heartbeat_path: Path | None = None,
     steering_inbox_root: Path | None = None,
     heartbeat_fresh_seconds: int = HEARTBEAT_FRESH_SECONDS,
 ) -> dict[str, Any]:
-    """Audit active/blocked lane rows for an already-merged PR.
+    """Audit active/blocked lane rows for an already-terminal PR.
 
     Dry-run mode never mutates. Apply mode requires explicit operator
-    authorization and an exact merge-commit guard before superseding active
-    lifecycle rows.
+    authorization and exact terminal proof before superseding active lifecycle rows.
     """
 
     resolved_at = resolved_at or _utc_now_iso()
@@ -902,7 +957,10 @@ def audit_merged_pr_lanes(
         rows = _read_rows(registry_path)
         heartbeats, heartbeat_load_error = _read_rows_checked(heartbeat_path)
         findings: list[dict[str, Any]] = []
-        if github_state.get("available") is True and github_state.get("state") == "MERGED":
+        if (
+            github_state.get("available") is True
+            and _terminal_pr_state(github_state) in TERMINAL_PR_STATES
+        ):
             raw_findings = _active_pr_lane_findings(rows, pr=pr)
             if heartbeat_fresh_seconds < 0:
                 findings = []
@@ -927,6 +985,7 @@ def audit_merged_pr_lanes(
             apply=apply,
             operator_authorized=operator_authorized,
             expected_merge_commit=expected_merge_commit,
+            expected_closed_at=expected_closed_at,
             github_state=github_state,
             findings=findings,
         )
@@ -937,6 +996,7 @@ def audit_merged_pr_lanes(
             apply=apply,
             operator_authorized=operator_authorized,
             expected_merge_commit=expected_merge_commit,
+            expected_closed_at=expected_closed_at,
             github_state=github_state,
             findings=findings,
             blocked_reason=blocked_reason,
@@ -971,18 +1031,25 @@ def audit_merged_pr_lanes(
                 row["status"] = "superseded"
                 row["updated_at"] = resolved_at
                 row["last_steering_outcome"] = "superseded"
+                terminal_state = _terminal_pr_state(github_state)
                 receipt = {
                     "schema_version": MERGED_PR_RECEIPT_SCHEMA_VERSION,
                     "lane_id": row.get("lane_id"),
                     "owner_session": row.get("owner_session"),
                     "pr_number": pr,
                     "head_sha": github_state.get("headRefOid"),
+                    "terminal_state": terminal_state,
                     "merge_commit": github_state.get("mergeCommit"),
+                    "closed_at": github_state.get("closedAt"),
                     "merged_at": github_state.get("mergedAt"),
                     "old_status": old_status,
                     "new_status": "superseded",
                     "resolved_at_utc": resolved_at,
-                    "resolution": "merged_pr_has_active_lane_row",
+                    "resolution": (
+                        "closed_pr_has_active_lane_row"
+                        if terminal_state == "CLOSED"
+                        else "merged_pr_has_active_lane_row"
+                    ),
                     "terminal_safety_blockers": findings_by_key.get(row_key, {}).get(
                         "terminal_safety_blockers",
                         [],
@@ -1082,6 +1149,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Exact merge commit required for authorized merged-PR apply mode.",
     )
     parser.add_argument(
+        "--expected-closed-at",
+        default="",
+        help="Exact closedAt timestamp required for authorized closed-PR apply mode.",
+    )
+    parser.add_argument(
         "--operator-authorized",
         action="store_true",
         help="Required with --apply in merged-PR lane audit mode.",
@@ -1166,6 +1238,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             apply=bool(args.apply),
             operator_authorized=bool(args.operator_authorized),
             expected_merge_commit=args.expected_merge_commit,
+            expected_closed_at=args.expected_closed_at,
             heartbeat_path=args.heartbeat_path,
             steering_inbox_root=args.steering_inbox_root,
             heartbeat_fresh_seconds=args.heartbeat_fresh_seconds,

--- a/scripts/resolve_lane_conflicts.py
+++ b/scripts/resolve_lane_conflicts.py
@@ -685,14 +685,21 @@ def _terminal_pr_proof_matches(
     github_state: dict[str, Any],
     expected_merge_commit: str | None,
     expected_closed_at: str | None,
+    expected_head_sha: str | None,
 ) -> bool:
     state = _terminal_pr_state(github_state)
     if state == "MERGED":
         expected = str(expected_merge_commit or "")
         return bool(expected) and str(github_state.get("mergeCommit") or "") == expected
     if state == "CLOSED":
-        expected = str(expected_closed_at or "")
-        return bool(expected) and str(github_state.get("closedAt") or "") == expected
+        expected_closed = str(expected_closed_at or "")
+        expected_head = str(expected_head_sha or "")
+        return (
+            bool(expected_closed)
+            and bool(expected_head)
+            and str(github_state.get("closedAt") or "") == expected_closed
+            and str(github_state.get("headRefOid") or "") == expected_head
+        )
     return False
 
 
@@ -771,12 +778,16 @@ def _operator_apply_command(
     receipt_dir: Path,
     expected_merge_commit: str,
     expected_closed_at: str,
+    expected_head_sha: str,
     heartbeat_path: Path,
     steering_inbox_root: Path,
     heartbeat_fresh_seconds: int,
 ) -> str:
     terminal_guard = (
-        f"--expected-closed-at {expected_closed_at or '<closed-at>'}"
+        (
+            f"--expected-closed-at {expected_closed_at or '<closed-at>'} "
+            f"--expected-head-sha {expected_head_sha or '<head-sha>'}"
+        )
         if expected_closed_at
         else f"--expected-merge-commit {expected_merge_commit or '<merge-commit-sha>'}"
     )
@@ -799,6 +810,7 @@ def _base_merged_pr_audit_result(
     operator_authorized: bool,
     expected_merge_commit: str | None,
     expected_closed_at: str | None,
+    expected_head_sha: str | None,
     github_state: dict[str, Any],
     findings: list[dict[str, Any]],
     blocked_reason: str | None,
@@ -808,8 +820,10 @@ def _base_merged_pr_audit_result(
 ) -> dict[str, Any]:
     merge_commit = str(github_state.get("mergeCommit") or "")
     closed_at = str(github_state.get("closedAt") or "")
+    head_sha = str(github_state.get("headRefOid") or "")
     expected = str(expected_merge_commit or "")
     expected_closed = str(expected_closed_at or "")
+    expected_head = str(expected_head_sha or "")
     unsafe_findings = [finding for finding in findings if finding.get("terminal_safety_blockers")]
     safe_findings = [finding for finding in findings if not finding.get("terminal_safety_blockers")]
     apply_eligible = (
@@ -822,6 +836,7 @@ def _base_merged_pr_audit_result(
             github_state=github_state,
             expected_merge_commit=expected,
             expected_closed_at=expected_closed,
+            expected_head_sha=expected_head,
         )
     )
     operator_apply_command = ""
@@ -834,6 +849,9 @@ def _base_merged_pr_audit_result(
             expected_merge_commit=merge_commit or expected,
             expected_closed_at=(
                 closed_at or expected_closed or "<closed-at>" if terminal_state == "CLOSED" else ""
+            ),
+            expected_head_sha=(
+                head_sha or expected_head or "<head-sha>" if terminal_state == "CLOSED" else ""
             ),
             heartbeat_path=heartbeat_path,
             steering_inbox_root=steering_inbox_root,
@@ -863,6 +881,7 @@ def _base_merged_pr_audit_result(
         "operator_authorized": operator_authorized,
         "expected_merge_commit": expected,
         "expected_closed_at": expected_closed,
+        "expected_head_sha": expected_head,
         "apply_eligible": apply_eligible,
         "blocked_reason": blocked_reason,
         "resolved_count": 0,
@@ -876,6 +895,7 @@ def _merged_pr_audit_blocked_reason(
     operator_authorized: bool,
     expected_merge_commit: str | None,
     expected_closed_at: str | None,
+    expected_head_sha: str | None,
     github_state: dict[str, Any],
     findings: list[dict[str, Any]],
 ) -> str | None:
@@ -897,11 +917,16 @@ def _merged_pr_audit_blocked_reason(
         if str(github_state.get("mergeCommit") or "") != expected:
             return "merge_commit_mismatch"
     if state == "CLOSED":
-        expected = str(expected_closed_at or "")
-        if not expected:
+        expected_closed = str(expected_closed_at or "")
+        expected_head = str(expected_head_sha or "")
+        if not expected_closed:
             return "expected_closed_at_required"
-        if str(github_state.get("closedAt") or "") != expected:
+        if str(github_state.get("closedAt") or "") != expected_closed:
             return "closed_at_mismatch"
+        if not expected_head:
+            return "expected_head_sha_required"
+        if str(github_state.get("headRefOid") or "") != expected_head:
+            return "head_sha_mismatch"
     unsafe_findings = [finding for finding in findings if finding.get("terminal_safety_blockers")]
     safe_findings = [finding for finding in findings if not finding.get("terminal_safety_blockers")]
     if unsafe_findings and not safe_findings:
@@ -919,6 +944,7 @@ def audit_merged_pr_lanes(
     operator_authorized: bool = False,
     expected_merge_commit: str | None = None,
     expected_closed_at: str | None = None,
+    expected_head_sha: str | None = None,
     resolved_at: str | None = None,
     heartbeat_path: Path | None = None,
     steering_inbox_root: Path | None = None,
@@ -986,6 +1012,7 @@ def audit_merged_pr_lanes(
             operator_authorized=operator_authorized,
             expected_merge_commit=expected_merge_commit,
             expected_closed_at=expected_closed_at,
+            expected_head_sha=expected_head_sha,
             github_state=github_state,
             findings=findings,
         )
@@ -997,6 +1024,7 @@ def audit_merged_pr_lanes(
             operator_authorized=operator_authorized,
             expected_merge_commit=expected_merge_commit,
             expected_closed_at=expected_closed_at,
+            expected_head_sha=expected_head_sha,
             github_state=github_state,
             findings=findings,
             blocked_reason=blocked_reason,
@@ -1154,6 +1182,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Exact closedAt timestamp required for authorized closed-PR apply mode.",
     )
     parser.add_argument(
+        "--expected-head-sha",
+        default="",
+        help="Exact headRefOid required for authorized closed-PR apply mode.",
+    )
+    parser.add_argument(
         "--operator-authorized",
         action="store_true",
         help="Required with --apply in merged-PR lane audit mode.",
@@ -1239,6 +1272,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             operator_authorized=bool(args.operator_authorized),
             expected_merge_commit=args.expected_merge_commit,
             expected_closed_at=args.expected_closed_at,
+            expected_head_sha=args.expected_head_sha,
             heartbeat_path=args.heartbeat_path,
             steering_inbox_root=args.steering_inbox_root,
             heartbeat_fresh_seconds=args.heartbeat_fresh_seconds,

--- a/tests/scripts/test_resolve_lane_conflicts.py
+++ b/tests/scripts/test_resolve_lane_conflicts.py
@@ -80,13 +80,18 @@ def _merged_pr_gh(tmp_path: Path, *, merge_commit: str = "merge") -> Path:
     )
 
 
-def _closed_pr_gh(tmp_path: Path, *, closed_at: str = "2026-05-23T19:16:23Z") -> Path:
+def _closed_pr_gh(
+    tmp_path: Path,
+    *,
+    closed_at: str = "2026-05-23T19:16:23Z",
+    head_sha: str = "head",
+) -> Path:
     return _fake_gh(
         tmp_path,
         {
             "number": 7435,
             "state": "CLOSED",
-            "headRefOid": "head",
+            "headRefOid": head_sha,
             "closedAt": closed_at,
             "mergedAt": None,
             "mergeCommit": None,
@@ -704,6 +709,7 @@ def test_closed_pr_audit_reports_active_rows_without_mutating(tmp_path: Path) ->
     assert result["apply_eligible"] is False
     assert result["blocked_reason"] is None
     assert "--expected-closed-at 2026-05-23T19:16:23Z" in result["operator_apply_command"]
+    assert "--expected-head-sha head" in result["operator_apply_command"]
     assert json.loads(registry.read_text(encoding="utf-8"))[0]["status"] == "active"
 
 
@@ -737,6 +743,37 @@ def test_closed_pr_audit_apply_requires_expected_closed_at(tmp_path: Path) -> No
     assert json.loads(registry.read_text(encoding="utf-8"))[0]["status"] == "active"
 
 
+def test_closed_pr_audit_apply_requires_expected_head_sha(tmp_path: Path) -> None:
+    registry = tmp_path / "lanes.json"
+    _write_json(
+        registry,
+        [
+            {
+                "lane_id": "codex-closed",
+                "owner_session": "codex-owner",
+                "status": "active",
+                "pr_number": 7435,
+            }
+        ],
+    )
+
+    result = resolver.audit_merged_pr_lanes(
+        registry_path=registry,
+        receipt_dir=tmp_path / "receipts",
+        pr=7435,
+        gh_bin=str(_closed_pr_gh(tmp_path)),
+        apply=True,
+        operator_authorized=True,
+        expected_closed_at="2026-05-23T19:16:23Z",
+        heartbeat_path=tmp_path / "heartbeats.json",
+        steering_inbox_root=tmp_path / "operator-steering",
+    )
+
+    assert result["resolved_count"] == 0
+    assert result["blocked_reason"] == "expected_head_sha_required"
+    assert json.loads(registry.read_text(encoding="utf-8"))[0]["status"] == "active"
+
+
 def test_closed_pr_audit_apply_rejects_closed_at_mismatch(tmp_path: Path) -> None:
     registry = tmp_path / "lanes.json"
     _write_json(
@@ -759,12 +796,45 @@ def test_closed_pr_audit_apply_rejects_closed_at_mismatch(tmp_path: Path) -> Non
         apply=True,
         operator_authorized=True,
         expected_closed_at="2026-05-23T19:17:00Z",
+        expected_head_sha="head",
         heartbeat_path=tmp_path / "heartbeats.json",
         steering_inbox_root=tmp_path / "operator-steering",
     )
 
     assert result["resolved_count"] == 0
     assert result["blocked_reason"] == "closed_at_mismatch"
+    assert json.loads(registry.read_text(encoding="utf-8"))[0]["status"] == "active"
+
+
+def test_closed_pr_audit_apply_rejects_head_sha_mismatch(tmp_path: Path) -> None:
+    registry = tmp_path / "lanes.json"
+    _write_json(
+        registry,
+        [
+            {
+                "lane_id": "codex-closed",
+                "owner_session": "codex-owner",
+                "status": "active",
+                "pr_number": 7435,
+            }
+        ],
+    )
+
+    result = resolver.audit_merged_pr_lanes(
+        registry_path=registry,
+        receipt_dir=tmp_path / "receipts",
+        pr=7435,
+        gh_bin=str(_closed_pr_gh(tmp_path, head_sha="actual-head")),
+        apply=True,
+        operator_authorized=True,
+        expected_closed_at="2026-05-23T19:16:23Z",
+        expected_head_sha="expected-head",
+        heartbeat_path=tmp_path / "heartbeats.json",
+        steering_inbox_root=tmp_path / "operator-steering",
+    )
+
+    assert result["resolved_count"] == 0
+    assert result["blocked_reason"] == "head_sha_mismatch"
     assert json.loads(registry.read_text(encoding="utf-8"))[0]["status"] == "active"
 
 
@@ -793,6 +863,7 @@ def test_closed_pr_audit_apply_supersedes_safe_rows_with_closed_at_guard(
         apply=True,
         operator_authorized=True,
         expected_closed_at="2026-05-23T19:16:23Z",
+        expected_head_sha="head",
         heartbeat_path=tmp_path / "heartbeats.json",
         steering_inbox_root=tmp_path / "operator-steering",
         resolved_at="2026-05-23T19:20:00Z",

--- a/tests/scripts/test_resolve_lane_conflicts.py
+++ b/tests/scripts/test_resolve_lane_conflicts.py
@@ -80,6 +80,21 @@ def _merged_pr_gh(tmp_path: Path, *, merge_commit: str = "merge") -> Path:
     )
 
 
+def _closed_pr_gh(tmp_path: Path, *, closed_at: str = "2026-05-23T19:16:23Z") -> Path:
+    return _fake_gh(
+        tmp_path,
+        {
+            "number": 7435,
+            "state": "CLOSED",
+            "headRefOid": "head",
+            "closedAt": closed_at,
+            "mergedAt": None,
+            "mergeCommit": None,
+            "url": "https://github.com/synaptent/aragora/pull/7435",
+        },
+    )
+
+
 def _write_read_receipt(inbox: Path, *, message_filename: str, message_sha256: str = "") -> None:
     receipt_dir = inbox / "_read_receipts"
     receipt_dir.mkdir(parents=True, exist_ok=True)
@@ -632,30 +647,6 @@ def test_merged_pr_audit_ignores_open_and_unmerged_prs(tmp_path: Path) -> None:
     assert result["apply_eligible"] is False
     assert result["blocked_reason"] == "pr_not_merged"
 
-    gh_closed = _fake_gh(
-        tmp_path,
-        {
-            "number": 7441,
-            "state": "CLOSED",
-            "headRefOid": "abc",
-            "mergedAt": None,
-            "mergeCommit": None,
-            "url": "https://github.com/synaptent/aragora/pull/7441",
-        },
-    )
-
-    closed_result = resolver.audit_merged_pr_lanes(
-        registry_path=registry,
-        receipt_dir=tmp_path / "receipts",
-        pr=7441,
-        gh_bin=str(gh_closed),
-        apply=False,
-    )
-
-    assert closed_result["finding_count"] == 0
-    assert closed_result["github_state"]["state"] == "CLOSED"
-    assert closed_result["blocked_reason"] == "pr_not_merged"
-
 
 def test_merged_pr_audit_reports_github_state_unavailable(tmp_path: Path) -> None:
     registry = tmp_path / "lanes.json"
@@ -683,6 +674,139 @@ def test_merged_pr_audit_reports_github_state_unavailable(tmp_path: Path) -> Non
     assert result["finding_count"] == 0
     assert result["github_state"]["available"] is False
     assert result["blocked_reason"] == "github_state_unavailable"
+
+
+def test_closed_pr_audit_reports_active_rows_without_mutating(tmp_path: Path) -> None:
+    registry = tmp_path / "lanes.json"
+    _write_json(
+        registry,
+        [
+            {
+                "lane_id": "codex-closed",
+                "owner_session": "codex-owner",
+                "status": "active",
+                "pr_number": 7435,
+            }
+        ],
+    )
+
+    result = resolver.audit_merged_pr_lanes(
+        registry_path=registry,
+        receipt_dir=tmp_path / "receipts",
+        pr=7435,
+        gh_bin=str(_closed_pr_gh(tmp_path)),
+        apply=False,
+    )
+
+    assert result["github_state"]["state"] == "CLOSED"
+    assert result["github_state"]["closedAt"] == "2026-05-23T19:16:23Z"
+    assert result["finding_count"] == 1
+    assert result["apply_eligible"] is False
+    assert result["blocked_reason"] is None
+    assert "--expected-closed-at 2026-05-23T19:16:23Z" in result["operator_apply_command"]
+    assert json.loads(registry.read_text(encoding="utf-8"))[0]["status"] == "active"
+
+
+def test_closed_pr_audit_apply_requires_expected_closed_at(tmp_path: Path) -> None:
+    registry = tmp_path / "lanes.json"
+    _write_json(
+        registry,
+        [
+            {
+                "lane_id": "codex-closed",
+                "owner_session": "codex-owner",
+                "status": "active",
+                "pr_number": 7435,
+            }
+        ],
+    )
+
+    result = resolver.audit_merged_pr_lanes(
+        registry_path=registry,
+        receipt_dir=tmp_path / "receipts",
+        pr=7435,
+        gh_bin=str(_closed_pr_gh(tmp_path)),
+        apply=True,
+        operator_authorized=True,
+        heartbeat_path=tmp_path / "heartbeats.json",
+        steering_inbox_root=tmp_path / "operator-steering",
+    )
+
+    assert result["resolved_count"] == 0
+    assert result["blocked_reason"] == "expected_closed_at_required"
+    assert json.loads(registry.read_text(encoding="utf-8"))[0]["status"] == "active"
+
+
+def test_closed_pr_audit_apply_rejects_closed_at_mismatch(tmp_path: Path) -> None:
+    registry = tmp_path / "lanes.json"
+    _write_json(
+        registry,
+        [
+            {
+                "lane_id": "codex-closed",
+                "owner_session": "codex-owner",
+                "status": "active",
+                "pr_number": 7435,
+            }
+        ],
+    )
+
+    result = resolver.audit_merged_pr_lanes(
+        registry_path=registry,
+        receipt_dir=tmp_path / "receipts",
+        pr=7435,
+        gh_bin=str(_closed_pr_gh(tmp_path, closed_at="2026-05-23T19:16:23Z")),
+        apply=True,
+        operator_authorized=True,
+        expected_closed_at="2026-05-23T19:17:00Z",
+        heartbeat_path=tmp_path / "heartbeats.json",
+        steering_inbox_root=tmp_path / "operator-steering",
+    )
+
+    assert result["resolved_count"] == 0
+    assert result["blocked_reason"] == "closed_at_mismatch"
+    assert json.loads(registry.read_text(encoding="utf-8"))[0]["status"] == "active"
+
+
+def test_closed_pr_audit_apply_supersedes_safe_rows_with_closed_at_guard(
+    tmp_path: Path,
+) -> None:
+    registry = tmp_path / "lanes.json"
+    receipt_dir = tmp_path / "receipts"
+    _write_json(
+        registry,
+        [
+            {
+                "lane_id": "codex-closed",
+                "owner_session": "codex-owner",
+                "status": "active",
+                "pr_number": 7435,
+            }
+        ],
+    )
+
+    result = resolver.audit_merged_pr_lanes(
+        registry_path=registry,
+        receipt_dir=receipt_dir,
+        pr=7435,
+        gh_bin=str(_closed_pr_gh(tmp_path, closed_at="2026-05-23T19:16:23Z")),
+        apply=True,
+        operator_authorized=True,
+        expected_closed_at="2026-05-23T19:16:23Z",
+        heartbeat_path=tmp_path / "heartbeats.json",
+        steering_inbox_root=tmp_path / "operator-steering",
+        resolved_at="2026-05-23T19:20:00Z",
+    )
+
+    rows = json.loads(registry.read_text(encoding="utf-8"))
+    receipts = sorted(receipt_dir.glob("*.json"))
+    receipt = json.loads(receipts[0].read_text(encoding="utf-8"))
+    assert result["resolved_count"] == 1
+    assert result["blocked_reason"] is None
+    assert rows[0]["status"] == "superseded"
+    assert receipt["schema_version"] == "aragora-merged-pr-lane-audit/1.0"
+    assert receipt["closed_at"] == "2026-05-23T19:16:23Z"
+    assert receipt["terminal_state"] == "CLOSED"
 
 
 def test_merged_pr_audit_apply_requires_operator_authorization(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- extend `resolve_lane_conflicts.py --merged-pr-lane-audit` to treat closed PRs as terminal stale-owner reconciliation targets
- require exact `closedAt` proof via `--expected-closed-at` before guarded apply supersedes rows
- preserve existing merged-PR merge-commit guard behavior and append-only receipts

Refs #8561.

## Validation
- python3 -m pytest tests/scripts/test_resolve_lane_conflicts.py -q
- python3 scripts/report_code_quality.py --check
- git diff --check