### PR TITLE
feat(review): per-PR convergence budget that survives head drift (Phase 0+1a)

### DIFF
--- a/aragora/swarm/convergence_ledger.py
+++ b/aragora/swarm/convergence_ledger.py
@@ -1,0 +1,246 @@
+"""ConvergenceLedger — a per-PR round budget that survives head drift.
+
+The merge-quorum gate already bounds reruns per *head* (``max_reruns_per_head`` in
+:func:`aragora.swarm.merge_quorum_reconcile.plan_rerun`). But every repair commit
+creates a *new head*, so that budget resets each round and never bites — which is
+why a churning PR can accumulate dozens of "fix" commits with zero merges and zero
+posted evidence. The unit of churn is the *repair round* (dissent → repair → new
+head → dissent), and it is keyed by the PR, not by any single head.
+
+This ledger bounds rounds **per PR, across head drift**. When the budget is spent,
+the loop must stop re-running and instead reach a *decision* (net-value
+adjudication: merge-as-is / one bounded round / close / restructure) rather than
+churning forever. It also keeps a per-PR head + verdict history so a later
+trajectory/churn detector and the net-value adjudicator have the cross-round memory
+the stateless gate lacks.
+
+Pure data plus atomic, file-locked persistence. No model calls, no network — the
+intelligence layers consume this; this module only remembers.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import tempfile
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from types import ModuleType
+from typing import cast
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_LEDGER_PATH = Path.home() / ".aragora" / "pr_convergence_ledger.json"
+DEFAULT_ROUND_BUDGET = 6  # repair rounds across head drift before adjudication
+MAX_TRACKED_PRS = 500  # prune oldest beyond this (by last_round_at)
+
+# POSIX-only file lock; the module imports fine without it (mutations raise a clear
+# error rather than corrupting on a platform without flock).
+fcntl: ModuleType | None
+try:
+    import fcntl as _fcntl
+
+    fcntl = _fcntl
+except ImportError:  # pragma: no cover - non-POSIX
+    fcntl = None
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass
+class PRConvergence:
+    """One PR's cross-round convergence record.
+
+    ``rounds`` is the count of *distinct heads* this PR has put through review — the
+    churn metric. ``verdicts`` is the per-round verdict history (it may exceed
+    ``len(heads)`` if the same head is re-reviewed). ``adjudication`` is set once a
+    net-value decision has been recorded for the PR.
+    """
+
+    pr_number: int
+    heads: list[str] = field(default_factory=list)
+    verdicts: list[str] = field(default_factory=list)
+    first_seen: str = ""
+    last_round_at: str = ""
+    adjudication: dict | None = None
+
+    @property
+    def rounds(self) -> int:
+        return len(self.heads)
+
+    def budget_remaining(self, budget: int) -> int:
+        return max(0, budget - self.rounds)
+
+    def is_exhausted(self, budget: int) -> bool:
+        return budget > 0 and self.rounds >= budget
+
+
+class ConvergenceLedger:
+    """Atomic, file-locked per-PR convergence store.
+
+    Mutations take an exclusive lock, reload, mutate, persist, release — so
+    concurrent agents hitting the same ledger can't clobber each other's rounds.
+    Reads are lock-free (the atomic ``os.replace`` on write means a reader never
+    sees a torn file).
+    """
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        self.path = Path(path) if path is not None else DEFAULT_LEDGER_PATH
+        self.lock_path = self.path.with_suffix(self.path.suffix + ".lock")
+
+    # ---- mutations (locked) --------------------------------------------------
+
+    def record_round(
+        self, pr_number: int, head_sha: str, *, verdict: str = "", now: str | None = None
+    ) -> int:
+        """Record that ``pr_number`` has been through a review round at ``head_sha``.
+
+        A *new* head increments the round count (a repair round); re-reviewing the
+        same head does not (it is not new churn), but the verdict is still appended
+        to the history. Returns the PR's round count after recording.
+        """
+        stamp = now or _utcnow_iso()
+        with self._locked():
+            data = self._load()
+            rec = data.get(pr_number) or PRConvergence(pr_number=pr_number, first_seen=stamp)
+            if head_sha and head_sha not in rec.heads:
+                rec.heads.append(head_sha)
+            if verdict:
+                rec.verdicts.append(verdict)
+            rec.last_round_at = stamp
+            data[pr_number] = rec
+            self._prune(data)
+            self._save(data)
+            return rec.rounds
+
+    def record_adjudication(
+        self,
+        pr_number: int,
+        *,
+        verdict: str,
+        rationale: str = "",
+        now: str | None = None,
+    ) -> None:
+        """Record a net-value adjudication outcome for ``pr_number`` (audit trail)."""
+        stamp = now or _utcnow_iso()
+        with self._locked():
+            data = self._load()
+            rec = data.get(pr_number) or PRConvergence(pr_number=pr_number, first_seen=stamp)
+            rec.adjudication = {"verdict": verdict, "rationale": rationale, "at": stamp}
+            data[pr_number] = rec
+            self._save(data)
+
+    # ---- reads (lock-free) ---------------------------------------------------
+
+    def get(self, pr_number: int) -> PRConvergence | None:
+        return self._load().get(pr_number)
+
+    def rounds(self, pr_number: int) -> int:
+        rec = self.get(pr_number)
+        return rec.rounds if rec else 0
+
+    def budget_remaining(self, pr_number: int, budget: int = DEFAULT_ROUND_BUDGET) -> int:
+        return max(0, budget - self.rounds(pr_number))
+
+    def is_exhausted(self, pr_number: int, budget: int = DEFAULT_ROUND_BUDGET) -> bool:
+        rec = self.get(pr_number)
+        return rec.is_exhausted(budget) if rec else False
+
+    def verdict_history(self, pr_number: int) -> list[str]:
+        rec = self.get(pr_number)
+        return list(rec.verdicts) if rec else []
+
+    def summarize(self, budget: int = DEFAULT_ROUND_BUDGET) -> list[dict]:
+        """Compact per-PR rows for a status reader (most-churned first)."""
+        rows = [
+            {
+                "pr": rec.pr_number,
+                "rounds": rec.rounds,
+                "budget_remaining": rec.budget_remaining(budget),
+                "exhausted": rec.is_exhausted(budget),
+                "last_verdict": rec.verdicts[-1] if rec.verdicts else "",
+                "adjudicated": rec.adjudication is not None,
+                "last_round_at": rec.last_round_at,
+            }
+            for rec in self._load().values()
+        ]
+        rows.sort(key=lambda r: cast(int, r["rounds"]), reverse=True)
+        return rows
+
+    # ---- persistence (atomic) ------------------------------------------------
+
+    def _prune(self, data: dict[int, PRConvergence]) -> None:
+        if len(data) <= MAX_TRACKED_PRS:
+            return
+        # Drop the oldest by last_round_at (un-adjudicated first is not worth the
+        # complexity; recency is a fine eviction key for a bounded cache).
+        ordered = sorted(data.values(), key=lambda r: r.last_round_at)
+        for rec in ordered[: len(data) - MAX_TRACKED_PRS]:
+            del data[rec.pr_number]
+
+    @contextlib.contextmanager
+    def _locked(self):
+        if fcntl is None:  # pragma: no cover - non-POSIX
+            raise RuntimeError(
+                "ConvergenceLedger mutation requires POSIX fcntl file locking "
+                "(not available on this platform)"
+            )
+        self.lock_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.lock_path.open("w") as lf:
+            fcntl.flock(lf.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(lf.fileno(), fcntl.LOCK_UN)
+
+    def _load(self) -> dict[int, PRConvergence]:
+        if not self.path.exists():
+            return {}
+        try:
+            raw = json.loads(self.path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            logger.warning("convergence ledger unreadable at %s; starting empty", self.path)
+            return {}
+        out: dict[int, PRConvergence] = {}
+        for key, val in raw.items():
+            try:
+                pr = int(key)
+            except (TypeError, ValueError):
+                continue
+            out[pr] = PRConvergence(
+                pr_number=pr,
+                heads=list(val.get("heads", [])),
+                verdicts=list(val.get("verdicts", [])),
+                first_seen=val.get("first_seen", ""),
+                last_round_at=val.get("last_round_at", ""),
+                adjudication=val.get("adjudication"),
+            )
+        return out
+
+    def _save(self, data: dict[int, PRConvergence]) -> None:
+        payload = {str(pr): _record_to_dict(rec) for pr, rec in data.items()}
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(
+            dir=str(self.path.parent), prefix=f".{self.path.name}.", suffix=".tmp"
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump(payload, fh, indent=2, sort_keys=True)
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp, self.path)
+        except BaseException:
+            with contextlib.suppress(FileNotFoundError):
+                os.unlink(tmp)
+            raise
+
+
+def _record_to_dict(rec: PRConvergence) -> dict:
+    d = asdict(rec)
+    d.pop("pr_number", None)  # the dict is already keyed by PR number
+    return d

--- a/aragora/swarm/merge_quorum_reconcile.py
+++ b/aragora/swarm/merge_quorum_reconcile.py
@@ -187,11 +187,20 @@ def plan_rerun(
     cooldown_seconds: int = 600,
     max_reruns_per_head: int = 3,
     has_real_required_failure: bool = False,
+    pr_rounds_consumed: int = 0,
+    pr_round_budget: int = 0,
 ) -> RerunDecision:
     """Decide whether to re-run the gate so it re-reads current-head evidence.
 
     All checks fail safe (a ``False`` decision) when an input is missing or
     ambiguous. See module docstring for the safety invariants.
+
+    ``pr_round_budget`` is the per-PR convergence budget that survives head drift
+    (``max_reruns_per_head`` resets every new head, so it never bounds a churning
+    PR — see :mod:`aragora.swarm.convergence_ledger`). When ``pr_rounds_consumed``
+    reaches it, this stops re-running and signals that the PR needs a *decision*
+    (net-value adjudication), not another round. ``pr_round_budget=0`` disables the
+    check, so existing callers are unaffected until they opt in.
     """
 
     def decide(should: bool, reason: str) -> RerunDecision:
@@ -221,6 +230,12 @@ def plan_rerun(
     if not (run_created < newest):
         return decide(False, "quorum run already postdates the newest countable evidence")
 
+    if pr_round_budget and pr_rounds_consumed >= pr_round_budget:
+        return decide(
+            False,
+            f"PR round budget exhausted ({pr_rounds_consumed}/{pr_round_budget} repair "
+            "rounds across head drift); net-value adjudication required, not another rerun",
+        )
     if reruns_this_head >= max_reruns_per_head:
         return decide(False, f"max reruns reached for this head ({max_reruns_per_head})")
     if last_rerun_at is not None:

--- a/docs/plans/2026-06-26-pr-convergence-system.md
+++ b/docs/plans/2026-06-26-pr-convergence-system.md
@@ -1,0 +1,143 @@
+# PR Convergence System — Anti-Churn Budget, Scope Contract, and Net-Value Adjudication
+
+**Status:** Proposed (design / Tier-4 pre-approval artifact)
+**Author:** Claude (Opus 4.8), with Armand (scarmani)
+**Date:** 2026-06-26
+
+## 1. Problem
+
+The merge-quorum gate keeps PRs from regressing `main`, and that part works. But the
+surrounding loop does not *converge*. Empirically (measured 2026-06-26):
+
+| PR | commits | span | surface | merges | posted evidence |
+|----|---------|------|---------|--------|-----------------|
+| #8595 | 42 | 36h | classifier gates | 0 | 0 |
+| #8575 | 11 | 53h | evidence-timeout | 0 | 0 |
+| #8627 | 9 | 7h | lane-lease | 0 | 0 |
+| #8628 | 16 | 6.5h | swarm-lease | 0 | 0 |
+
+`#8595` alone produced **16 near-duplicate "fail closed on <uncertain X>" commits in
+under two hours.** Across these four PRs: 78 commits, 0 merges, 0 posted evidence. The
+loop converts compute into commits and recursive prompts, not landed value.
+
+## 2. Root cause
+
+The gate optimizes **"are there findings?"** (a defect-absolute, per-round, memoryless
+filter) when the merge decision should be **"is landing this now net-positive versus
+another round?"** (a value-relative, trajectory-aware judgment).
+
+Two facts make this fatal:
+
+1. **Adversarial review never returns empty.** A frontier model asked "what's wrong with
+   this code?" always finds *something* in any non-trivial diff. "Drive findings to zero"
+   optimizes toward an unreachable target over an unbounded space — it cannot terminate.
+2. **The repair agent's objective is "make findings disappear," not "maximize value."**
+   Generator (reviewer) that always produces + follower (repairer) that always chases +
+   no cost per round + no cross-round memory = a divergent loop.
+
+This is exactly why FunSearch/AlphaEvolve *converge* (their evaluator is a fixed fitness
+function with a target) and this does not (its evaluator is an open-ended critique).
+
+**The reshaping implementation finding:** the gate *already* has a budget —
+`max_reruns_per_head=3` in `plan_rerun()` ([merge_quorum_reconcile.py:188]) — but it is
+**keyed by head SHA.** Every repair commit is a new head, so the cap resets every round
+and never bites. **The budget must be keyed by PR, not head**, to survive head drift.
+That single change is the highest-leverage fix in this document.
+
+## 3. Principle
+
+> **Defect-absolute gating diverges; value-relative gating converges.**
+
+Every component below injects *value* and *cost* into a process that today has only
+*defect detection*. The merge bar changes from *"zero findings"* (unreachable) to
+*"no BLOCKING-in-scope findings, within a bounded budget"* (reachable).
+
+## 4. Architecture — three layers
+
+- **Layer C — Gas + forced-choice adjudication (the spine).** A depleting per-PR round
+  budget. When it depletes, the loop *cannot silently continue*: it emits a decision
+  verdict, and (later) a frontier panel forces one of `MERGE_AS_IS / ONE_BOUNDED_ROUND /
+  CLOSE / RESTRUCTURE`. This alone converts divergent → bounded.
+- **Layer A — Finding triage + scope contract (the quality multiplier).** Each finding is
+  judged `BLOCKING_IN_SCOPE / DEFER_OUT_OF_SCOPE / NITPICK / RESTRUCTURE_SIGNAL` against a
+  machine-readable scope contract set at PR creation. Out-of-scope `[P2]`s stop blocking.
+- **Layer B — Trajectory / churn memory (the detector).** Per-PR, per-surface finding
+  history. Same surface flagged N rounds → `RESTRUCTURE_SIGNAL`. Mechanizes the #8511
+  lesson ("reviewer flagging the same area N rounds = fix the abstraction").
+
+## 5. Grounded integration seams
+
+| Concern | Seam | Notes |
+|---|---|---|
+| "Rerun vs stop" chokepoint | `plan_rerun()` — `aragora/swarm/merge_quorum_reconcile.py:178` | pure; caller supplies state |
+| Per-PR durable state | `~/.aragora/merge_quorum_reconcile_state.json` | atomic write, pruned 500, **keyed by head** |
+| Verdict builder | `_build_model_review_quorum()` — `aragora/cli/commands/review_queue.py:3101` | 8-verdict elif cascade; add `net_value_adjudication_required` |
+| Severity split | `would_count` (lint) blocks `[P2]` regardless of flag; `dissenting` (`quorum_evidence.py:427`) honors flag | **triage judge plugs into `dissenting`, narrowing `dissenting_views` — never the lint** |
+| Scope contract | `SpecBundle` — `aragora/pipeline/backbone_contracts.py:217` | add `non_goals`, `deferred_surfaces`; PR template + parser |
+| Tier/surface classify | `_classify_model_review_tier` / `_subsystem_for` — `review_queue.py` | reusable by triage |
+| Judge infra | `LLMJudge` (`aragora/evaluation/llm_judge.py:533`), `default_reviewer_runner` (`quorum_evidence.py:1006`), `_reviewer_verdict` parser, `PartialConsensus`, `cost_tracker` | reuse for both judges |
+
+## 6. Phased plan (smallest-first, dependency-ordered)
+
+Each phase is one small landable PR, dogfooded through the merge gate under the same
+2-round discipline it encodes.
+
+| # | Phase | Lands | Tier | Depends | Model calls |
+|---|---|---|---|---|---|
+| 0 | Per-PR convergence ledger + budget logic | visibility + the data model | **2** | — | no |
+| 1a | `plan_rerun()` per-PR budget hard-stop | loop cannot exceed N rounds | **2** | 0 | no |
+| 1b | `net_value_adjudication_required` verdict | gate surfaces "decide" instead of looping | **4** | 1a | no |
+| 2 | Scope contract (`SpecBundle` + PR template + parser) | PRs declare goals/non-goals | 3 | — (parallel) | no |
+| 3 | Finding-triage judge → narrows `dissenting_views` | out-of-scope `[P2]`s stop blocking | **4** | 2 | yes |
+| 4 | Churn detector (per-surface trajectory) | auto `RESTRUCTURE_SIGNAL` | 2 | 0 | no |
+| 5 | Net-value adjudicator (panel + forced choice + signed receipt) | automated MERGE/ROUND/CLOSE/RESTRUCTURE | **4** | 1,3,4 | yes |
+| 6 | Real gas (token-cost budget via `cost_tracker`) | budget = cost, not round count | 2 | 5 | — |
+
+**Phases 0 + 1a ship with zero model calls and no Tier-4 surface** — they convert
+divergent → bounded *deterministically*. The frontier judges (3, 5) only improve
+*decision quality* on top of an already-bounded loop. The dangerous, expensive, Tier-4
+parts come last, after the cheap fix has already stopped the bleeding.
+
+## 7. Design decisions (locked)
+
+- **Budget keyed by PR, not head** — defeats head-drift; the core fix.
+- **Default-off / additive** — new `plan_rerun` params default to a disabled budget so
+  existing callers/tests are byte-for-byte unaffected until a caller opts in.
+- **Triage narrows `dissenting`, never the `would_count` lint** — the lint is flag-blind;
+  only the dissent layer can be made value-relative.
+- **Forced choice, budget-decrementing** — the adjudicator returns one enum value (parsed
+  via the proven `_reviewer_verdict` pattern), its own invocation decrements the budget,
+  and `ONE_BOUNDED_ROUND` is choosable at most once before the next call must pick
+  MERGE/CLOSE/RESTRUCTURE. No "let me think about it" continuation.
+- **RESTRUCTURE inherits a lower budget** — the system cannot infinitely restructure.
+- **Scope is immutable to the repairer** — set at PR creation from `SpecBundle`; otherwise
+  an agent dodges findings by declaring everything out of scope.
+- **Every adjudication is a signed receipt** — reuse the gauntlet receipt store; auditable,
+  and the policy is tunable from outcomes. Humans can always override.
+
+## 8. Anti-gaming / failure modes
+
+- *A free-text "is this good?" judge waffles and churns* → forced choice + budget
+  decrement + panel majority (cut variance via `PartialConsensus`).
+- *Restructure can loop too* → must change scope/abstraction (smaller surface) and inherit
+  a lower budget.
+- *Self-declared scope is a loophole* → scope set at creation, immutable to the repairer.
+- *Building the anti-churn system could itself churn* → build it under its own rule: one
+  small PR per phase, 2-round cap, land before the next. Once 1a lands, run the remaining
+  phases' PRs *through the budget they create.*
+
+## 9. Rollout
+
+1. Land Phase 0 + 1a (this PR) — Tier 2, deterministic. The loop becomes bounded.
+2. Wire the live reconcile script (`scripts/reconcile_merge_quorum.py`) to read the ledger
+   and pass `pr_rounds_consumed` / `pr_round_budget` into `plan_rerun()` — tight follow-up.
+3. Land 1b (Tier 4) — the gate emits the decision verdict.
+4. Build 2, then 3/4, then 5 — each small, each dogfooded.
+5. The system governs its own construction from Phase 2 onward.
+
+## 10. Out of scope (non-goals for the first PR)
+
+- No frontier-model calls (Phases 0/1a are pure).
+- No change to `review_queue.py` verdict logic (that is 1b, separate Tier-4 PR).
+- No live reconcile-script wiring (separate follow-up).
+- No public API / interface changes.

--- a/tests/swarm/test_convergence_ledger.py
+++ b/tests/swarm/test_convergence_ledger.py
@@ -1,0 +1,119 @@
+"""Tests for the per-PR ConvergenceLedger — the round budget that survives head drift.
+
+The load-bearing test is ``test_distinct_heads_count_as_rounds_not_rereviews``: the
+churn metric is *distinct heads put through review*, so a repair (new head) counts
+and a re-review of the same head does not — that is exactly what the per-head gate
+budget cannot see.
+"""
+
+from __future__ import annotations
+
+from aragora.swarm.convergence_ledger import (
+    DEFAULT_ROUND_BUDGET,
+    MAX_TRACKED_PRS,
+    ConvergenceLedger,
+    PRConvergence,
+)
+
+
+def _ledger(tmp_path):
+    return ConvergenceLedger(tmp_path / "conv.json")
+
+
+def test_record_round_returns_count_and_persists(tmp_path):
+    led = _ledger(tmp_path)
+    assert led.record_round(8628, "head-a", verdict="changes_requested", now="t0") == 1
+    assert led.record_round(8628, "head-b", verdict="changes_requested", now="t1") == 2
+    # A fresh instance reads the same persisted state.
+    assert ConvergenceLedger(tmp_path / "conv.json").rounds(8628) == 2
+
+
+def test_distinct_heads_count_as_rounds_not_rereviews(tmp_path):
+    led = _ledger(tmp_path)
+    led.record_round(8595, "h1", verdict="changes_requested", now="t0")
+    led.record_round(8595, "h1", verdict="changes_requested", now="t1")  # same head re-review
+    led.record_round(8595, "h2", verdict="changes_requested", now="t2")  # a repair → new head
+    rec = led.get(8595)
+    assert rec.rounds == 2  # two distinct heads, not three records
+    assert rec.verdicts == ["changes_requested"] * 3  # full verdict history retained
+
+
+def test_budget_disabled_when_zero(tmp_path):
+    led = _ledger(tmp_path)
+    led.record_round(1, "h1", now="t0")
+    assert led.is_exhausted(1, budget=0) is False  # 0 = disabled
+
+
+def test_budget_exhaustion_and_remaining(tmp_path):
+    led = _ledger(tmp_path)
+    for i in range(6):
+        led.record_round(8628, f"h{i}", now=f"t{i}")
+    assert led.rounds(8628) == 6
+    assert led.budget_remaining(8628, budget=6) == 0
+    assert led.is_exhausted(8628, budget=6) is True
+    assert led.is_exhausted(8628, budget=8) is False
+
+
+def test_unknown_pr_is_zero_not_exhausted(tmp_path):
+    led = _ledger(tmp_path)
+    assert led.rounds(404) == 0
+    assert led.is_exhausted(404, budget=6) is False
+    assert led.budget_remaining(404, budget=6) == 6
+
+
+def test_record_adjudication_audit_trail(tmp_path):
+    led = _ledger(tmp_path)
+    led.record_round(8628, "h1", now="t0")
+    led.record_adjudication(
+        8628, verdict="CLOSE", rationale="superseded; churned 7 rounds", now="t9"
+    )
+    rec = ConvergenceLedger(tmp_path / "conv.json").get(8628)
+    assert rec.adjudication == {
+        "verdict": "CLOSE",
+        "rationale": "superseded; churned 7 rounds",
+        "at": "t9",
+    }
+
+
+def test_summarize_orders_by_rounds_desc(tmp_path):
+    led = _ledger(tmp_path)
+    led.record_round(100, "a", verdict="pass", now="t0")
+    for i in range(4):
+        led.record_round(200, f"h{i}", verdict="changes_requested", now=f"t{i}")
+    rows = led.summarize(budget=6)
+    assert [r["pr"] for r in rows] == [200, 100]  # most-churned first
+    top = rows[0]
+    assert top["rounds"] == 4 and top["budget_remaining"] == 2
+    assert top["last_verdict"] == "changes_requested" and top["adjudicated"] is False
+
+
+def test_default_budget_constant_is_sane(tmp_path):
+    assert DEFAULT_ROUND_BUDGET >= 3  # enough for real polishing, bounded against churn
+
+
+def test_prune_caps_tracked_prs(tmp_path):
+    led = _ledger(tmp_path)
+    # Record MAX_TRACKED_PRS + 5; oldest-by-last_round_at evicted.
+    for i in range(MAX_TRACKED_PRS + 5):
+        led.record_round(i, "h", now=f"{i:06d}")
+    data = led._load()
+    assert len(data) == MAX_TRACKED_PRS
+    assert 0 not in data and 4 not in data  # five oldest evicted
+    assert (MAX_TRACKED_PRS + 4) in data  # newest retained
+
+
+def test_corrupt_ledger_degrades_to_empty(tmp_path):
+    p = tmp_path / "conv.json"
+    p.write_text("{ this is not json", encoding="utf-8")
+    led = ConvergenceLedger(p)
+    assert led.rounds(1) == 0  # unreadable → empty, not a crash
+    # ...and a subsequent write recovers cleanly.
+    led.record_round(1, "h1", now="t0")
+    assert ConvergenceLedger(p).rounds(1) == 1
+
+
+def test_record_dataclass_round_property():
+    rec = PRConvergence(pr_number=1, heads=["a", "b", "c"])
+    assert rec.rounds == 3
+    assert rec.is_exhausted(3) is True
+    assert rec.budget_remaining(5) == 2

--- a/tests/swarm/test_merge_quorum_reconcile.py
+++ b/tests/swarm/test_merge_quorum_reconcile.py
@@ -140,6 +140,30 @@ class TestPlanRerun:
         assert decision.should_rerun is False
         assert "max reruns" in decision.reason
 
+    def test_pr_budget_disabled_by_default(self) -> None:
+        # pr_round_budget defaults to 0 (disabled); a high consumed count is ignored.
+        decision = self._call(pr_rounds_consumed=99)
+        assert decision.should_rerun is True
+
+    def test_pr_budget_under_limit_allows(self) -> None:
+        decision = self._call(pr_rounds_consumed=2, pr_round_budget=6)
+        assert decision.should_rerun is True
+
+    def test_pr_budget_exhausted_demands_adjudication(self) -> None:
+        decision = self._call(pr_rounds_consumed=6, pr_round_budget=6)
+        assert decision.should_rerun is False
+        assert "round budget exhausted" in decision.reason
+        assert "net-value adjudication" in decision.reason
+
+    def test_pr_budget_bites_even_when_per_head_cap_is_fresh(self) -> None:
+        # THE fix: a repair push creates a new head, so the per-head cap resets
+        # (reruns_this_head=0). The per-PR budget must still bite across that drift.
+        decision = self._call(
+            reruns_this_head=0, max_reruns_per_head=3, pr_rounds_consumed=6, pr_round_budget=6
+        )
+        assert decision.should_rerun is False
+        assert "round budget exhausted" in decision.reason
+
     def test_within_cooldown(self) -> None:
         decision = self._call(last_rerun_at=NOW - timedelta(seconds=120), cooldown_seconds=600)
         assert decision.should_rerun is False


### PR DESCRIPTION
## Summary

Root-cause fix for the merge-quorum **churn** documented in
`docs/plans/2026-06-26-pr-convergence-system.md`. The gate already bounds reruns
per **head** (`max_reruns_per_head` in `plan_rerun`), but every repair commit is a
new head, so that cap resets each round and never bites — which is how a churning
PR reached **42 commits with 0 merges and 0 posted evidence**. The budget must be
keyed by **PR, not head**.

This is **Phase 0 + 1a**: Tier 2, deterministic, **zero model calls**, and
**default-off** so it changes no existing behavior until a caller opts in.

- `aragora/swarm/convergence_ledger.py` — per-PR `ConvergenceLedger`: counts
  *distinct heads* as repair rounds (the churn metric the per-head cap can't see),
  tracks verdict history, records adjudication outcomes. Atomic + `fcntl`-locked.
- `plan_rerun()` gains additive `pr_rounds_consumed` / `pr_round_budget` params
  (default `0` = disabled). When the per-PR budget is spent it stops re-running and
  signals a net-value **decision** is required, not another round.

## Scope Contract

**Goals (in scope)**
- Per-PR round ledger + budget logic (durable, survives head drift).
- `plan_rerun()` per-PR budget hard-stop, default-off.

**Non-goals (explicitly deferred to later PRs — see design doc §6)**
- `net_value_adjudication_required` verdict in `review_queue.py` (Tier 4).
- Live `reconcile_merge_quorum.py` wiring to read the ledger.
- Scope-contract `SpecBundle` fields + PR-template parser (Phase 2).
- Finding-triage judge + net-value adjudicator (Phases 3, 5 — the model calls).

Findings about any non-goal above are out-of-scope for this PR by design.

## Test plan
- `pytest tests/swarm/test_convergence_ledger.py tests/swarm/test_merge_quorum_reconcile.py` — **55 pass** (15 new).
- Key test: `test_pr_budget_bites_even_when_per_head_cap_is_fresh` — the budget bites across head drift even when `reruns_this_head=0`.
- mypy clean; ruff clean; zero `type:ignore`.

## Dogfood note
Once this lands it becomes the **first PR the budget governs** — the system starts
bounding its own construction from the next phase onward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
