### PR TITLE
fix(secrets): never hang on interactive MFA prompt in headless processes

### DIFF
--- a/aragora/config/secrets.py
+++ b/aragora/config/secrets.py
@@ -438,7 +438,12 @@ class SecretManager:
                 },
             )
             client = self._build_client(boto3, region, config)
-            self._aws_clients[region] = client
+            # Don't cache a fail-closed None: a later retry (e.g. after credentials
+            # become available, or in a different process state) must be able to
+            # re-attempt Secrets Manager rather than be pinned to None for the
+            # SecretManager instance's lifetime.
+            if client is not None:
+                self._aws_clients[region] = client
             return client
         except ImportError:
             logger.debug("boto3 not installed, AWS Secrets Manager unavailable")

--- a/aragora/config/secrets.py
+++ b/aragora/config/secrets.py
@@ -36,11 +36,43 @@ from __future__ import annotations
 import json
 import logging
 import os
+import sys
 import threading
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any, cast
 
 logger = logging.getLogger(__name__)
+
+
+def _mfa_prompt_allowed(*, isatty: bool, env: Mapping[str, str] | None = None) -> bool:
+    """Whether an interactive AWS MFA prompt is permissible in this process.
+
+    A non-interactive process (cron automation, headless conductor, a background
+    evidence pass) must NEVER block on ``getpass`` for an MFA code — it hangs
+    forever with no TTY to answer it. This is the silent failure that wedged every
+    automated Secrets Manager load: the process appears to "run" but is stuck on an
+    invisible prompt. Allowed only when attached to a TTY, or when explicitly
+    overridden via ``ARAGORA_AWS_ALLOW_MFA_PROMPT`` (escape hatch for odd setups).
+    """
+    resolved: Mapping[str, str] = os.environ if env is None else env
+    override = str(resolved.get("ARAGORA_AWS_ALLOW_MFA_PROMPT", "")).strip().lower()
+    if override in ("1", "true", "yes"):
+        return True
+    return isatty
+
+
+def _fail_fast_mfa_prompter(prompt: str = "") -> str:
+    """Replaces botocore's interactive ``getpass`` MFA prompter in non-interactive
+    processes so AWS assume-role-with-MFA *fails fast* (caught → fall back to env /
+    .env secrets) instead of blocking forever on a TTY that isn't there."""
+    raise RuntimeError(
+        "AWS assume-role needs an interactive MFA code but this process has no TTY; "
+        "skipping Secrets Manager and falling back to environment/.env secrets. "
+        "Run interactively, pre-export an AWS session, or set "
+        "ARAGORA_USE_SECRETS_MANAGER=false to silence."
+    )
+
 
 # Import botocore exceptions for proper error handling
 # These are optional - if not installed, we use Exception as fallback
@@ -388,7 +420,7 @@ class SecretManager:
                     "mode": "standard",
                 },
             )
-            client = boto3.client("secretsmanager", region_name=region, config=config)
+            client = self._build_client(boto3, region, config)
             self._aws_clients[region] = client
             return client
         except ImportError:
@@ -406,6 +438,36 @@ class SecretManager:
                 "Failed to initialize AWS client (%s): %s: %s", region, type(e).__name__, e
             )
             return None
+
+    def _build_client(self, boto3: Any, region: str, config: Any) -> Any:
+        """Build the Secrets Manager client, neutering the interactive MFA prompt in
+        non-interactive processes.
+
+        A profile that requires assume-role-with-MFA (``AWS_PROFILE=aragora-secrets``)
+        otherwise blocks on ``getpass`` with no TTY to answer — the silent hang that
+        wedged every headless Secrets Manager load. Here, a non-interactive process
+        installs :func:`_fail_fast_mfa_prompter` so resolution fails fast and the
+        caller falls back to env/.env secrets. Interactive TTYs and MFA-free
+        credential paths (instance roles, OIDC) are unaffected.
+        """
+        try:
+            interactive = sys.stdin.isatty()
+        except (ValueError, OSError, AttributeError):
+            interactive = False
+        if _mfa_prompt_allowed(isatty=interactive):
+            return boto3.client("secretsmanager", region_name=region, config=config)
+        try:
+            import botocore.session  # type: ignore[import-untyped, import-not-found]
+
+            bsession = botocore.session.get_session()
+            provider = bsession.get_component("credential_provider").get_provider("assume-role")
+            provider._prompter = _fail_fast_mfa_prompter
+            return boto3.Session(botocore_session=bsession).client(
+                "secretsmanager", region_name=region, config=config
+            )
+        except Exception:  # noqa: BLE001 - botocore internals vary by version; degrade safely
+            logger.debug("non-interactive MFA guard unavailable; using default client")
+            return boto3.client("secretsmanager", region_name=region, config=config)
 
     def _load_from_aws(self) -> dict[str, str]:
         """Load secrets from AWS Secrets Manager."""

--- a/aragora/config/secrets.py
+++ b/aragora/config/secrets.py
@@ -457,14 +457,16 @@ class SecretManager:
         if _mfa_prompt_allowed(isatty=interactive):
             return boto3.client("secretsmanager", region_name=region, config=config)
         try:
-            import botocore.session  # type: ignore[import-untyped, import-not-found]
-
-            bsession = botocore.session.get_session()
-            provider = bsession.get_component("credential_provider").get_provider("assume-role")
-            provider._prompter = _fail_fast_mfa_prompter
-            return boto3.Session(botocore_session=bsession).client(
-                "secretsmanager", region_name=region, config=config
+            # Reach botocore's session via boto3's own wrapper (``_session``) rather
+            # than importing botocore.session directly — keeps this off the typed
+            # import surface (boto3 is already an untyped/Any import).
+            boto_session = boto3.Session()
+            botocore_session = boto_session._session
+            provider = botocore_session.get_component("credential_provider").get_provider(
+                "assume-role"
             )
+            provider._prompter = _fail_fast_mfa_prompter
+            return boto_session.client("secretsmanager", region_name=region, config=config)
         except Exception:  # noqa: BLE001 - botocore internals vary by version; degrade safely
             logger.debug("non-interactive MFA guard unavailable; using default client")
             return boto3.client("secretsmanager", region_name=region, config=config)

--- a/aragora/config/secrets.py
+++ b/aragora/config/secrets.py
@@ -36,7 +36,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-import sys
 import threading
 from collections.abc import Mapping
 from dataclasses import dataclass, field
@@ -72,6 +71,24 @@ def _fail_fast_mfa_prompter(prompt: str = "") -> str:
         "Run interactively, pre-export an AWS session, or set "
         "ARAGORA_USE_SECRETS_MANAGER=false to silence."
     )
+
+
+def _has_controlling_tty() -> bool:
+    """Whether a controlling terminal is reachable for an interactive prompt.
+
+    botocore's MFA prompt uses ``getpass``, which reads ``/dev/tty`` (the controlling
+    terminal), NOT stdin — so ``sys.stdin.isatty()`` is the wrong question: a process
+    with redirected stdin but a live terminal (``python app.py </dev/null`` in an SSH
+    shell) could still prompt successfully. Probe ``/dev/tty`` directly to match what
+    getpass will actually do, so we only fail-fast when there is genuinely no terminal
+    (cron, nohup, a detached daemon).
+    """
+    try:
+        fd = os.open("/dev/tty", os.O_RDWR)
+    except OSError:
+        return False
+    os.close(fd)
+    return True
 
 
 # Import botocore exceptions for proper error handling
@@ -450,11 +467,7 @@ class SecretManager:
         caller falls back to env/.env secrets. Interactive TTYs and MFA-free
         credential paths (instance roles, OIDC) are unaffected.
         """
-        try:
-            interactive = sys.stdin.isatty()
-        except (ValueError, OSError, AttributeError):
-            interactive = False
-        if _mfa_prompt_allowed(isatty=interactive):
+        if _mfa_prompt_allowed(isatty=_has_controlling_tty()):
             return boto3.client("secretsmanager", region_name=region, config=config)
         try:
             # Reach botocore's session via boto3's own wrapper (``_session``) rather
@@ -467,9 +480,18 @@ class SecretManager:
             )
             provider._prompter = _fail_fast_mfa_prompter
             return boto_session.client("secretsmanager", region_name=region, config=config)
-        except Exception:  # noqa: BLE001 - botocore internals vary by version; degrade safely
-            logger.debug("non-interactive MFA guard unavailable; using default client")
-            return boto3.client("secretsmanager", region_name=region, config=config)
+        except Exception:  # noqa: BLE001 - botocore internals vary by version
+            # Fail CLOSED, not back to the hang-prone default client: if the guard
+            # cannot be installed in a non-interactive process, returning
+            # boto3.client() here would re-enter the exact getpass MFA hang this
+            # exists to prevent. Returning None makes the caller fall back to
+            # env/.env secrets instead.
+            logger.warning(
+                "could not install non-interactive MFA guard for %s; refusing the "
+                "default client to avoid a getpass hang (using env/.env secrets)",
+                region,
+            )
+            return None
 
     def _load_from_aws(self) -> dict[str, str]:
         """Load secrets from AWS Secrets Manager."""

--- a/tests/config/test_secrets.py
+++ b/tests/config/test_secrets.py
@@ -29,6 +29,7 @@ from aragora.config.secrets import (
     SecretManager,
     SecretsConfig,
     _fail_fast_mfa_prompter,
+    _has_controlling_tty,
     _mfa_prompt_allowed,
     SecretNotFoundError,
     clear_secret_cache,
@@ -328,7 +329,7 @@ class TestSecretManagerAWS:
         # (the non-interactive MFA guard has its own dedicated tests).
         with (
             patch("boto3.client") as mock_boto,
-            patch("aragora.config.secrets.sys.stdin.isatty", return_value=True),
+            patch("aragora.config.secrets._has_controlling_tty", return_value=True),
         ):
             mock_boto.return_value = MagicMock()
             client = manager._get_aws_client(manager.config.aws_region)
@@ -862,7 +863,7 @@ class TestNonInteractiveMfaGuard:
         manager = SecretManager(SecretsConfig())
         fake_boto3 = MagicMock()
         with (
-            patch("aragora.config.secrets.sys.stdin.isatty", return_value=False),
+            patch("aragora.config.secrets._has_controlling_tty", return_value=False),
             patch.dict(os.environ, {}, clear=True),
         ):
             manager._build_client(fake_boto3, "us-east-1", MagicMock())
@@ -872,7 +873,7 @@ class TestNonInteractiveMfaGuard:
     def test_build_client_uses_default_when_interactive(self):
         manager = SecretManager(SecretsConfig())
         fake_boto3 = MagicMock()
-        with patch("aragora.config.secrets.sys.stdin.isatty", return_value=True):
+        with patch("aragora.config.secrets._has_controlling_tty", return_value=True):
             manager._build_client(fake_boto3, "us-east-1", MagicMock())
         fake_boto3.client.assert_called_once()  # normal interactive path
         fake_boto3.Session.assert_not_called()
@@ -895,12 +896,42 @@ class TestNonInteractiveMfaGuard:
         fake_boto3 = MagicMock()
         fake_boto3.Session = _FakeSession
         with (
-            patch("aragora.config.secrets.sys.stdin.isatty", return_value=False),
+            patch("aragora.config.secrets._has_controlling_tty", return_value=False),
             patch.dict(os.environ, {}, clear=True),
         ):
             manager._build_client(fake_boto3, "us-east-1", MagicMock())
 
+        # `get_session()` returns a fresh, isolated session per call, so this mutation
+        # does not leak into other tests.
         provider = real_botocore_session.get_component("credential_provider").get_provider(
             "assume-role"
         )
         assert provider._prompter is _fail_fast_mfa_prompter
+
+    def test_guard_install_failure_fails_closed_not_back_to_default(self):
+        """grok [P2]: if the MFA guard can't be installed in a headless process, we
+        must NOT fall back to the unguarded boto3.client() — that would re-enter the
+        exact getpass hang. Returns None so the caller uses env/.env secrets."""
+        manager = SecretManager(SecretsConfig())
+        fake_boto3 = MagicMock()
+        fake_boto3.Session.side_effect = RuntimeError("botocore internals changed")
+        with (
+            patch("aragora.config.secrets._has_controlling_tty", return_value=False),
+            patch.dict(os.environ, {}, clear=True),
+        ):
+            result = manager._build_client(fake_boto3, "us-east-1", MagicMock())
+        assert result is None  # fail closed
+        fake_boto3.client.assert_not_called()  # never the hang-prone default
+
+    def test_controlling_tty_probe_matches_dev_tty_openability(self):
+        """grok [P2]: the gate probes /dev/tty (what getpass uses), not stdin —
+        independent of the test runner's own terminal state."""
+        with patch("aragora.config.secrets.os.open", side_effect=OSError):
+            assert _has_controlling_tty() is False
+        with (
+            patch("aragora.config.secrets.os.open", return_value=7) as op,
+            patch("aragora.config.secrets.os.close") as cl,
+        ):
+            assert _has_controlling_tty() is True
+            op.assert_called_once()
+            cl.assert_called_once_with(7)  # fd is closed, not leaked

--- a/tests/config/test_secrets.py
+++ b/tests/config/test_secrets.py
@@ -879,25 +879,28 @@ class TestNonInteractiveMfaGuard:
 
     def test_real_botocore_prompter_is_failfast_when_headless(self):
         """End-to-end against real botocore: the assume-role provider's prompter is
-        replaced with the fail-fast one (so it can't getpass-hang)."""
-        manager = SecretManager(SecretsConfig())
-        captured: dict[str, object] = {}
+        replaced with the fail-fast one (so it can't getpass-hang). The guard reaches
+        the botocore session via boto3's ``_session`` wrapper."""
+        import botocore.session
 
-        class _CapturingSession:
-            def __init__(self, *, botocore_session):
-                captured["botocore_session"] = botocore_session
+        manager = SecretManager(SecretsConfig())
+        real_botocore_session = botocore.session.get_session()
+
+        class _FakeSession:
+            _session = real_botocore_session
 
             def client(self, **_kw):
                 return MagicMock()
 
         fake_boto3 = MagicMock()
-        fake_boto3.Session = _CapturingSession
+        fake_boto3.Session = _FakeSession
         with (
             patch("aragora.config.secrets.sys.stdin.isatty", return_value=False),
             patch.dict(os.environ, {}, clear=True),
         ):
             manager._build_client(fake_boto3, "us-east-1", MagicMock())
 
-        bsession = captured["botocore_session"]
-        provider = bsession.get_component("credential_provider").get_provider("assume-role")
+        provider = real_botocore_session.get_component("credential_provider").get_provider(
+            "assume-role"
+        )
         assert provider._prompter is _fail_fast_mfa_prompter

--- a/tests/config/test_secrets.py
+++ b/tests/config/test_secrets.py
@@ -28,6 +28,8 @@ from aragora.config.secrets import (
     SecretPresence,
     SecretManager,
     SecretsConfig,
+    _fail_fast_mfa_prompter,
+    _mfa_prompt_allowed,
     SecretNotFoundError,
     clear_secret_cache,
     get_required_secret,
@@ -322,7 +324,12 @@ class TestSecretManagerAWS:
 
         assert manager._aws_clients == {}
 
-        with patch("boto3.client") as mock_boto:
+        # Force the interactive path so this exercises default-client config plumbing
+        # (the non-interactive MFA guard has its own dedicated tests).
+        with (
+            patch("boto3.client") as mock_boto,
+            patch("aragora.config.secrets.sys.stdin.isatty", return_value=True),
+        ):
             mock_boto.return_value = MagicMock()
             client = manager._get_aws_client(manager.config.aws_region)
             assert client is not None
@@ -829,3 +836,68 @@ class TestStrictMode:
         """Module-level usability helper does not count placeholders."""
         with patch.dict(os.environ, {"OPENROUTER_API_KEY": "short"}, clear=True):
             assert is_secret_usable("OPENROUTER_API_KEY", strict=False) is False
+
+
+class TestNonInteractiveMfaGuard:
+    """The headless-hang fix: a non-interactive process must never block on an AWS
+    MFA getpass prompt — it must fail fast and fall back to env/.env secrets."""
+
+    def test_prompt_allowed_only_when_interactive(self):
+        assert _mfa_prompt_allowed(isatty=True, env={}) is True
+        assert _mfa_prompt_allowed(isatty=False, env={}) is False
+
+    def test_explicit_override_allows_prompt_even_headless(self):
+        for val in ("1", "true", "YES"):
+            assert (
+                _mfa_prompt_allowed(isatty=False, env={"ARAGORA_AWS_ALLOW_MFA_PROMPT": val}) is True
+            )
+
+    def test_fail_fast_prompter_raises_instead_of_blocking(self):
+        with pytest.raises(RuntimeError, match="no TTY"):
+            _fail_fast_mfa_prompter("Enter MFA code: ")
+
+    def test_build_client_uses_guarded_session_when_headless(self):
+        """Non-interactive => the assume-role MFA prompter is neutered via a custom
+        botocore session, never the default (hang-prone) client."""
+        manager = SecretManager(SecretsConfig())
+        fake_boto3 = MagicMock()
+        with (
+            patch("aragora.config.secrets.sys.stdin.isatty", return_value=False),
+            patch.dict(os.environ, {}, clear=True),
+        ):
+            manager._build_client(fake_boto3, "us-east-1", MagicMock())
+        fake_boto3.Session.assert_called_once()  # guarded session path
+        fake_boto3.client.assert_not_called()  # never the unguarded default
+
+    def test_build_client_uses_default_when_interactive(self):
+        manager = SecretManager(SecretsConfig())
+        fake_boto3 = MagicMock()
+        with patch("aragora.config.secrets.sys.stdin.isatty", return_value=True):
+            manager._build_client(fake_boto3, "us-east-1", MagicMock())
+        fake_boto3.client.assert_called_once()  # normal interactive path
+        fake_boto3.Session.assert_not_called()
+
+    def test_real_botocore_prompter_is_failfast_when_headless(self):
+        """End-to-end against real botocore: the assume-role provider's prompter is
+        replaced with the fail-fast one (so it can't getpass-hang)."""
+        manager = SecretManager(SecretsConfig())
+        captured: dict[str, object] = {}
+
+        class _CapturingSession:
+            def __init__(self, *, botocore_session):
+                captured["botocore_session"] = botocore_session
+
+            def client(self, **_kw):
+                return MagicMock()
+
+        fake_boto3 = MagicMock()
+        fake_boto3.Session = _CapturingSession
+        with (
+            patch("aragora.config.secrets.sys.stdin.isatty", return_value=False),
+            patch.dict(os.environ, {}, clear=True),
+        ):
+            manager._build_client(fake_boto3, "us-east-1", MagicMock())
+
+        bsession = captured["botocore_session"]
+        provider = bsession.get_component("credential_provider").get_provider("assume-role")
+        assert provider._prompter is _fail_fast_mfa_prompter


### PR DESCRIPTION
## Summary

**Root-cause fix for "the automations never landed anything."** `.env` sets
`ARAGORA_USE_SECRETS_MANAGER=true` + `AWS_PROFILE=aragora-secrets`. Any **headless**
process (cron automations, the overnight conductor, a background evidence pass) that
loads secrets then resolves AWS credentials through an assume-role profile requiring
**MFA** — and botocore calls `getpass()`, which **blocks forever** with no TTY to
answer it. The process looks alive but is wedged on an invisible prompt, so it can
never collect/post quorum evidence → never satisfies the gate → never merges.

Confirmed live: 3 background `collect-evidence` runs this session hung on
`Enter MFA code for ...armand-bootstrap-totp` until killed. The keys are already in
`.env` (XAI, OpenRouter) — the AWS detour was pure misconfiguration for headless use.

## Fix

In a non-interactive process, neuter botocore's assume-role MFA prompter so it
**fails fast → falls back to env/.env secrets** instead of hanging.
- `_mfa_prompt_allowed()` — interactive (TTY) or explicit `ARAGORA_AWS_ALLOW_MFA_PROMPT` only.
- `_fail_fast_mfa_prompter()` — raises a clear "no TTY" error instead of `getpass`.
- `SecretManager._build_client()` — installs the fail-fast prompter on a custom botocore session when non-interactive.

## Scope Contract

**Goals:** stop headless secret-loading from hanging on MFA; fall back to env keys.
**Non-goals:** changing the interactive path, the production (instance-role/OIDC) path, strict-mode policy, or which secrets are critical. No new secret sources.

## Test plan
- 81 secrets tests pass (5 new: TTY/override matrix, fail-fast prompter raises, guarded-session path headless, default path interactive, real-botocore prompter swap).
- mypy clean; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
