### PR TITLE
ci(merge-gate): enable tiered merge gate for Tier 1-2

### DIFF
--- a/.github/workflows/aragora-merge-quorum.yml
+++ b/.github/workflows/aragora-merge-quorum.yml
@@ -113,6 +113,14 @@ jobs:
           # code + the disclosed bare-"no" Blocker security fix are already on main; this only sets
           # the live (CI) side of the min(prepared, live) flag — the prepare side is set in operator env.
           ARAGORA_ENABLE_SEVERITY_GATED_DISSENT: "1"
+          # Activate the tiered merge gate (operator Option A 2026-06-26, library/operator-approvals.md;
+          # spec docs/specs/TIERED_MERGE_GATE_QUORUM_POLICY.md, enablement note
+          # docs/governance/TIERED_MERGE_GATE_ENABLEMENT.md). With this ON, a Tier 1-2 PR settles on ONE
+          # western-frontier signal (claude/openai) instead of two distinct families, which unblocks the
+          # structurally-unreachable structural-refactor shim/move quorum. Tier 0 (already 1 signal) and
+          # Tier 3-4 are UNAFFECTED: Tier 3-4 still require two Western families plus human settlement. The
+          # gate reads this flag live; reverting is a single env flip back OFF (another Tier-4 edit).
+          ARAGORA_ENABLE_TIERED_MERGE_GATE: "1"
         shell: bash
         run: |
           set -euo pipefail

--- a/aragora/swarm/merge_quorum_reconcile.py
+++ b/aragora/swarm/merge_quorum_reconcile.py
@@ -46,6 +46,10 @@ from typing import Final
 # import. Drift from the policy is prevented by test_tiered_merge_gate_quorum_policy::
 # test_reconcile_diagnostic_matches_policy, which asserts equality against
 # tier_quorum_rule(tier, tiered_gate=False) (claude/Codex #8507 single-source).
+# NOTE: summarize_settlement sources the LIVE signal *count* (and the western-frontier
+# constraint) from the flag-aware tier_quorum_rule so the diagnostic mirrors the gate
+# under ARAGORA_ENABLE_TIERED_MERGE_GATE; this table supplies only the flag-independent
+# dogfood/human-settlement requirements and serves as the strict-regime pin.
 TIER_REQUIREMENTS: Final[dict[int, tuple[int, bool, bool]]] = {
     0: (1, False, False),
     1: (2, True, False),
@@ -390,26 +394,51 @@ def summarize_settlement(
     ids = counted_reviewer_ids(comments)
     has_dogfood = any(c.would_count and c.is_dogfood for c in comments)
 
-    required_signals, requires_dogfood, requires_human = TIER_REQUIREMENTS.get(
+    # requires_dogfood / requires_human are tier-derived and flag-independent (dogfood for
+    # Tier 1+, human settlement for Tier 3+); only the signal *count* and the
+    # western-frontier constraint change with the tiered merge gate, so source those two
+    # from the strict TIER_REQUIREMENTS projection and the signal bar from the flag-aware
+    # rule below.
+    _, requires_dogfood, requires_human = TIER_REQUIREMENTS.get(
         tier if tier is not None else -1, (2, True, True)
     )
-    # Apply the canonical jurisdiction rules so this diagnostic cannot tell an
-    # operator "settle-ready" for a pair the live gate would block (e.g. a
-    # claude+deepseek Tier 3-4 PR, where deepseek is advisory-only). The reconcile
-    # table is the strict/default-OFF projection, so evaluate the rule with
-    # tiered_gate=False to match that regime. Function-level import avoids a
-    # circular import (quorum_evidence imports this module via merge_quorum_io).
-    from aragora.swarm.quorum_evidence import WESTERN_FAMILIES, tier_quorum_rule
+    # Mirror the LIVE merge gate exactly: read the tiered-gate flag via the same accessor
+    # the gate uses (tiered_merge_gate_enabled) rather than hardcoding the strict regime, so
+    # when the flag is ON this diagnostic reports the relaxed Tier 1-2 bar (one
+    # western-frontier signal) and when OFF the strict bar — it never tells an operator a
+    # different requirement than what CI would actually enforce. Deriving from the same
+    # tier_quorum_rule means it can only ever match or be stricter than the gate, so it can
+    # never falsely green-light. Function-level import avoids a circular import
+    # (quorum_evidence imports this module via merge_quorum_io).
+    from aragora.swarm.quorum_evidence import (
+        WESTERN_FAMILIES,
+        WESTERN_FRONTIER_FAMILIES,
+        tier_quorum_rule,
+        tiered_merge_gate_enabled,
+    )
 
-    rule = tier_quorum_rule(tier, tiered_gate=False)
+    rule = tier_quorum_rule(tier, tiered_gate=tiered_merge_gate_enabled())
+    required_signals = rule.required_signals
     # Jurisdiction-eligible count: drops Chinese-routed families at Tier 3-4. This
     # is what actually drives the gate's quorum decision, not the raw id count.
     counted = rule.counted_families(ids)
     advisory_only = bool(set(ids) - counted)
+    # Tiered gate ON: a Tier 1-2 PR settles on ONE western-frontier signal (claude/openai),
+    # so a lone non-frontier signal must not be reported as sufficient (mirrors the gate's
+    # western_frontier_satisfied check).
+    needs_western_frontier = rule.requires_western_frontier and not (
+        counted & WESTERN_FRONTIER_FAMILIES
+    )
     needs_western = rule.requires_at_least_one_western and not (counted & WESTERN_FAMILIES)
 
     if quorum_conclusion.upper() == _SUCCESS:
         next_action = "none — quorum check is green; PR is ready to merge"
+    elif needs_western_frontier:
+        next_action = (
+            "collect one western-frontier model signal (claude/openai) on the current "
+            "head; under the tiered merge gate a Tier 1-2 PR settles on a single "
+            "western-frontier signal, which the counted families do not yet include"
+        )
     elif len(counted) < required_signals:
         missing = required_signals - len(counted)
         if advisory_only:

--- a/docs/governance/TIERED_MERGE_GATE_ENABLEMENT.md
+++ b/docs/governance/TIERED_MERGE_GATE_ENABLEMENT.md
@@ -1,0 +1,66 @@
+# Tiered Merge Gate Enablement
+
+This note records that the **tiered merge gate** is enabled in CI and describes its
+effect. It complements the design in
+[`docs/specs/TIERED_MERGE_GATE_QUORUM_POLICY.md`](../specs/TIERED_MERGE_GATE_QUORUM_POLICY.md)
+and the jurisdiction rules in
+[`docs/REVIEW_AUTHORITY_PRINCIPLES.md`](../REVIEW_AUTHORITY_PRINCIPLES.md).
+
+## What is enabled
+
+The `Evaluate merge quorum` step of
+[`.github/workflows/aragora-merge-quorum.yml`](../../.github/workflows/aragora-merge-quorum.yml)
+sets, alongside the existing `ARAGORA_ENABLE_SEVERITY_GATED_DISSENT: "1"`:
+
+```yaml
+ARAGORA_ENABLE_TIERED_MERGE_GATE: "1"
+```
+
+The flag is read live by `tier_quorum_rule(...)` in
+`aragora/swarm/quorum_evidence.py` (see `tiered_merge_gate_enabled`), which is the single
+source of truth for the live merge gate, the auto-settle collector, and the reconcile
+diagnostic. No gate logic changed; this enablement only sets the input flag.
+
+## Effect (Tier 1-2 only)
+
+| Tier | Flag OFF (default)                                   | Flag ON (this enablement)                              |
+|------|-----------------------------------------------------|--------------------------------------------------------|
+| 1    | 2 distinct counting families (any family)           | **1 western-frontier signal** (`claude`/`openai`)      |
+| 2    | 2 distinct families, at least one Western           | **1 western-frontier signal** (`claude`/`openai`)      |
+
+The "western-frontier" set is the strict subset `{claude, openai}` of the Western family
+set, so a cheaper model can never solo-authorize a merge.
+
+## What is NOT affected
+
+Tier 0, Tier 3, and Tier 4 are **unchanged** by this flag:
+
+- **Tier 0** already requires one signal of any family; unchanged.
+- **Tier 3-4** continue to require two distinct **Western** families (Western-only counted
+  quorum) **plus** human settlement. The flag's relaxation branch is bounded to tiers 1-2;
+  tiers 3-4 fall through to the Western-only fail-safe rule. The Tier 2 "at least one
+  Western" and Tier 3-4 "Western-only counted" jurisdiction tightenings are applied
+  unconditionally regardless of this flag.
+
+Concretely, P4b/P5 server-handler PRs (Tier 3) still require per-PR operator human
+settlement; this enablement does not change that.
+
+## Why it is enabled
+
+The P4a structural-refactor shim/move PRs hit a structurally unreachable Tier-1 model
+quorum: the repo-grounded western-frontier reviewer (`claude`) PASSes with `would_count=true`
+plus dogfood, but the only sanctioned second families decline illegitimately on the
+intentional deprecation shims (an out-of-scope `[P2]` "migrate consumers off the shim", a
+provably-false `[P1]` on byte-identical verbatim-moved code, or a non-converging hardening
+loop). Severity-gated dissent does not help when those verdicts are `CHANGES-REQUESTED`, and
+a human settlement is inert at Tier-1 `needs_model_review_quorum`. The operator chose
+**Option A (enable the tiered merge gate)** on 2026-06-26 to let Tier 1-2 settle on the
+genuine lone western-frontier signal. Full analysis: the mission's
+`research/tier1-shim-gate-mechanism.md`.
+
+## Reversibility
+
+Default is OFF. The global flag is the revocation control: flipping the workflow env back to
+OFF (or removing the line) restores the two-distinct-family bar for Tier 1-2 everywhere, with
+no code change. Both enabling and reverting are Tier-4 merge-authority edits to the protected
+workflow file and require operator settlement.

--- a/tests/governance/test_tiered_merge_gate_quorum_policy.py
+++ b/tests/governance/test_tiered_merge_gate_quorum_policy.py
@@ -144,6 +144,81 @@ def test_reconcile_diagnostic_matches_policy():
         assert requires_human == (tier >= 3)
 
 
+@pytest.mark.parametrize("tier", [1, 2])
+def test_reconcile_diagnostic_is_flag_aware_under_tiered_gate(tier, monkeypatch):
+    # The reconcile diagnostic must read the SAME tiered-gate flag the live gate reads
+    # (tiered_merge_gate_enabled), not hardcode the strict default-OFF regime. Under the
+    # flag a Tier 1-2 PR settles on one western-frontier signal, so a lone claude signal
+    # (+ dogfood) must NOT be reported as short of quorum; with the flag OFF the same lone
+    # signal IS one short of the strict two-family bar.
+    from aragora.swarm.merge_quorum_reconcile import EvidenceComment, summarize_settlement
+
+    lone_frontier = [
+        EvidenceComment(
+            created_at="2026-06-26T00:00:00Z",
+            would_count=True,
+            reviewer_id="claude",
+            is_dogfood=True,
+        )
+    ]
+
+    monkeypatch.setenv("ARAGORA_ENABLE_TIERED_MERGE_GATE", "1")
+    on = summarize_settlement(
+        pr_number=1,
+        head_sha="deadbeef",
+        tier=tier,
+        comments=lone_frontier,
+        human_settlement_present=False,
+        quorum_conclusion="FAILURE",
+    )
+    # Mirrors the live gate, which accepts a lone western-frontier signal under the flag.
+    assert tier_quorum_rule(tier, tiered_gate=True).is_satisfied_by(["claude"]) is True
+    assert "more distinct model signal" not in on.next_action
+    assert "western-frontier" not in on.next_action  # claude already satisfies the frontier
+
+    monkeypatch.delenv("ARAGORA_ENABLE_TIERED_MERGE_GATE", raising=False)
+    off = summarize_settlement(
+        pr_number=1,
+        head_sha="deadbeef",
+        tier=tier,
+        comments=lone_frontier,
+        human_settlement_present=False,
+        quorum_conclusion="FAILURE",
+    )
+    # Strict (flag OFF) bar: the same lone signal is one short of the two-family quorum.
+    assert tier_quorum_rule(tier, tiered_gate=False).is_satisfied_by(["claude"]) is False
+    assert "collect 1 more distinct model signal" in off.next_action
+
+
+@pytest.mark.parametrize("tier", [1, 2])
+def test_reconcile_diagnostic_never_green_lights_non_frontier_under_tiered_gate(tier, monkeypatch):
+    # NEVER falsely green-light: grok is Western but NOT western-frontier, so under the flag
+    # a lone grok signal does not settle a Tier 1-2 PR. The diagnostic must surface the
+    # missing western-frontier signal (mirroring the gate's western_frontier check) instead
+    # of reporting the lone non-frontier signal as sufficient.
+    from aragora.swarm.merge_quorum_reconcile import EvidenceComment, summarize_settlement
+
+    monkeypatch.setenv("ARAGORA_ENABLE_TIERED_MERGE_GATE", "1")
+    lone_grok = [
+        EvidenceComment(
+            created_at="2026-06-26T00:00:00Z",
+            would_count=True,
+            reviewer_id="grok",
+            is_dogfood=True,
+        )
+    ]
+    status = summarize_settlement(
+        pr_number=1,
+        head_sha="deadbeef",
+        tier=tier,
+        comments=lone_grok,
+        human_settlement_present=False,
+        quorum_conclusion="FAILURE",
+    )
+    assert tier_quorum_rule(tier, tiered_gate=True).is_satisfied_by(["grok"]) is False
+    assert "western-frontier" in status.next_action
+
+
 def test_review_queue_reexports_canonical_jurisdiction_sets():
     # The gate references the *same* frozenset objects as the policy (no duplicate
     # allowlist to drift).

--- a/tests/governance/test_tiered_merge_gate_quorum_policy.py
+++ b/tests/governance/test_tiered_merge_gate_quorum_policy.py
@@ -97,12 +97,21 @@ def test_tier1_counts_any_two_distinct_families():
 
 @pytest.mark.parametrize("tier", [1, 2])
 def test_tiered_gate_relaxation_requires_western_frontier(tier):
+    # Flag ON (ARAGORA_ENABLE_TIERED_MERGE_GATE=1): a Tier 1-2 PR settles on a
+    # single western-frontier signal (claude/openai).
     rule = tier_quorum_rule(tier, tiered_gate=True)
     assert rule.required_signals == 1
     assert rule.requires_western_frontier is True
     assert rule.is_satisfied_by({"claude"}) is True  # frontier solo-settles
     assert rule.is_satisfied_by({"grok"}) is False  # Western but not frontier
     assert rule.is_satisfied_by({"deepseek"}) is False  # cheap cannot solo-settle
+
+    # Flag OFF (contrast): without the gate, Tier 1-2 require two distinct
+    # families, so a lone western-frontier signal no longer satisfies the quorum.
+    off = tier_quorum_rule(tier, tiered_gate=False)
+    assert off.required_signals == 2
+    assert off.requires_western_frontier is False
+    assert off.is_satisfied_by({"claude"}) is False  # one signal is insufficient
 
 
 # --- G3: single source of truth across all three surfaces --------------------


### PR DESCRIPTION
## Summary

**Tier-4 PARKED DRAFT — PREPARE ONLY. Do not ready, do not merge autonomously. Operator settles via `scripts/settle_tier4_pr.py` + head-bound `--squash --match-head-commit`.**

Enables the **tiered merge gate** by adding one env line to the `Evaluate merge quorum` step of `.github/workflows/aragora-merge-quorum.yml`, alongside the existing `ARAGORA_ENABLE_SEVERITY_GATED_DISSENT: "1"`:

```yaml
ARAGORA_ENABLE_TIERED_MERGE_GATE: "1"
```

No gate logic is touched. The gate reads this flag live in `tier_quorum_rule(...)` (`aragora/swarm/quorum_evidence.py`).

## Why

Operator chose **Option A on 2026-06-26** (`library/operator-approvals.md`) to unblock the structurally-unreachable Tier-1 shim/move model quorum for the P4a structural-refactor phase: the repo-grounded western-frontier reviewer (`claude`) PASSes with `would_count=true` + dogfood, but the only sanctioned second families decline illegitimately on the intentional deprecation shims (out-of-scope `[P2]` "migrate consumers off the shim", a provably-false `[P1]` on byte-identical verbatim-moved code, or a non-converging hardening loop). Severity-gated dissent does not help (both are `CHANGES-REQUESTED`), and human settlement is inert at Tier-1 `needs_model_review_quorum`. Full code-level analysis in the mission's `research/tier1-shim-gate-mechanism.md`.

## Effect (verified in code)

| Tier | Flag OFF (default) | Flag ON (this PR) |
|------|--------------------|-------------------|
| 1 | 2 distinct families | **1 western-frontier signal** (claude/openai) |
| 2 | 2 distinct, >=1 Western | **1 western-frontier signal** (claude/openai) |

- **Tier 0** (already 1 signal) and **Tier 3-4** are **UNAFFECTED**: Tier 3-4 still require two distinct Western families plus human settlement, so P4b/P5 server-handler PRs keep their per-PR operator settlement.
- **Reversible:** flip the env back OFF (another Tier-4 edit) at phase end.

## Changes

- `.github/workflows/aragora-merge-quorum.yml` — the one env line (+ a documenting comment matching the neighboring flag's convention).
- `tests/governance/test_tiered_merge_gate_quorum_policy.py` — extended `test_tiered_gate_relaxation_requires_western_frontier` (already parametrized over tiers [1,2]) with the **flag-OFF contrast**: `tier_quorum_rule(tier, tiered_gate=False).required_signals == 2`, `requires_western_frontier is False`, and a lone `{claude}` no longer satisfies the quorum.
- `docs/governance/TIERED_MERGE_GATE_ENABLEMENT.md` — brief enablement note describing the flag's effect, that Tier 0/3/4 are unaffected, and reversibility. (`docs/governance/*` is not a `sync-docs.js` mirror source, so no docs-site regen.)

## Validation (run in an isolated worktree off fresh origin/main)

```
make lint                                            -> All checks passed!
ruff format --check aragora/ tests/ scripts/         -> 10531 files already formatted
python3 -m pytest tests/governance/test_tiered_merge_gate_quorum_policy.py \
        tests/workflows/test_aragora_merge_quorum_workflow.py -q   -> 17 passed
make test-smoke (import canary)                      -> Smoke tests passed!
PYTEST_BIN="python3 -m pytest" bash scripts/test_tiers.sh smoke    -> 138 passed
```

## Risks

- **Blast radius is global to Tier 1-2** (the flag is tier-keyed, not "is-shim"-scoped). For this mission that is the structural-refactor shim/move class plus a few Tier-1/2 features, all carrying the independent-VAL + all-other-CI-green safety net. Integrity preserved: every counted signal stays a genuine reviewer verdict; no manufactured signals, no `--admin`, head-bound merges only.
- This file is under `.github/workflows/`, so the PR is **Tier 4** (merge-authority self-modification). It must be settled by the operator, never merged autonomously.
