### PR TITLE
test(cli): align batch mocks with safe HTTP wrappers

### DIFF
--- a/aragora/cli/billing.py
+++ b/aragora/cli/billing.py
@@ -131,7 +131,7 @@ def cmd_status_local(args: argparse.Namespace) -> int:
 
         return 0
 
-    except (OSError, RuntimeError, ValueError) as e:
+    except (ImportError, OSError, RuntimeError, ValueError) as e:
         print(f"\nError reading local usage: {e}")
         return 1
 

--- a/aragora/cli/billing.py
+++ b/aragora/cli/billing.py
@@ -235,7 +235,7 @@ def cmd_usage_local(args: argparse.Namespace, period_start: datetime, period_end
 
         return 0
 
-    except (OSError, RuntimeError, ValueError) as e:
+    except (ImportError, OSError, RuntimeError, ValueError) as e:
         print(f"\nError reading local usage: {e}")
         return 1
 

--- a/tests/cli/test_batch.py
+++ b/tests/cli/test_batch.py
@@ -295,7 +295,7 @@ class TestBatchViaServer:
             "status_url": "http://localhost:8080/status/batch-123",
         }
 
-        with patch("aragora.cli.batch.httpx.post", return_value=mock_response):
+        with patch("aragora.security.safe_http.safe_post", return_value=mock_response):
             _batch_via_server(items, args)
 
         captured = capsys.readouterr()
@@ -323,7 +323,7 @@ class TestBatchViaServer:
         mock_response.raise_for_status.side_effect = mock_error
         mock_response.text = "Server Error"
 
-        with patch("aragora.cli.batch.httpx.post", return_value=mock_response):
+        with patch("aragora.security.safe_http.safe_post", return_value=mock_response):
             with pytest.raises(SystemExit) as exc_info:
                 _batch_via_server(items, args)
 
@@ -347,7 +347,7 @@ class TestBatchViaServer:
         request = httpx.Request("POST", "http://localhost:8080/api/debates/batch")
         mock_error = httpx.RequestError("Connection refused", request=request)
 
-        with patch("aragora.cli.batch.httpx.post", side_effect=mock_error):
+        with patch("aragora.security.safe_http.safe_post", side_effect=mock_error):
             with pytest.raises(SystemExit) as exc_info:
                 _batch_via_server(items, args)
 
@@ -371,7 +371,7 @@ class TestBatchViaServer:
         mock_response.raise_for_status = MagicMock()
         mock_response.json.return_value = {"success": True, "batch_id": "batch-123"}
 
-        with patch("aragora.cli.batch.httpx.post", return_value=mock_response) as mock_post:
+        with patch("aragora.security.safe_http.safe_post", return_value=mock_response) as mock_post:
             _batch_via_server(items, args)
 
         # Check that webhook was included in request
@@ -532,7 +532,7 @@ class TestPollBatchStatus:
             mock_resp.raise_for_status = MagicMock()
             return mock_resp
 
-        with patch("aragora.cli.batch.httpx.get", side_effect=mock_get):
+        with patch("aragora.security.safe_http.safe_get", side_effect=mock_get):
             with patch("aragora.cli.batch.time.sleep"):  # Skip actual sleeping
                 _poll_batch_status("http://localhost:8080", "batch-123", None)
 
@@ -553,7 +553,7 @@ class TestPollBatchStatus:
         }
         mock_resp.raise_for_status = MagicMock()
 
-        with patch("aragora.cli.batch.httpx.get", return_value=mock_resp):
+        with patch("aragora.security.safe_http.safe_get", return_value=mock_resp):
             with patch("aragora.cli.batch.time.sleep"):
                 _poll_batch_status("http://localhost:8080", "batch-123", None)
 
@@ -574,7 +574,7 @@ class TestPollBatchStatus:
         }
         mock_resp.raise_for_status = MagicMock()
 
-        with patch("aragora.cli.batch.httpx.get", return_value=mock_resp):
+        with patch("aragora.security.safe_http.safe_get", return_value=mock_resp):
             with patch("aragora.cli.batch.time.sleep"):
                 _poll_batch_status("http://localhost:8080", "batch-123", None)
 

--- a/tests/cli/test_cli_batch.py
+++ b/tests/cli/test_cli_batch.py
@@ -244,16 +244,17 @@ class TestCmdBatch:
 class TestBatchViaServer:
     """Tests for _batch_via_server function."""
 
-    @patch("urllib.request.urlopen")
-    def test_submits_batch(self, mock_urlopen, sample_items, mock_args, capsys):
+    @patch("aragora.security.safe_http.safe_post")
+    def test_submits_batch(self, mock_safe_post, sample_items, mock_args, capsys):
         """Submit batch to server."""
         mock_response = MagicMock()
-        mock_response.read.return_value = json.dumps(
-            {"success": True, "batch_id": "batch-123", "items_queued": 3}
-        ).encode()
-        mock_response.__enter__ = MagicMock(return_value=mock_response)
-        mock_response.__exit__ = MagicMock(return_value=False)
-        mock_urlopen.return_value = mock_response
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {
+            "success": True,
+            "batch_id": "batch-123",
+            "items_queued": 3,
+        }
+        mock_safe_post.return_value = mock_response
 
         _batch_via_server(sample_items, mock_args)
 
@@ -261,46 +262,47 @@ class TestBatchViaServer:
         assert "Batch submitted successfully" in captured.out
         assert "batch-123" in captured.out
 
-    @patch("urllib.request.urlopen")
-    def test_includes_webhook(self, mock_urlopen, sample_items, mock_args):
+    @patch("aragora.security.safe_http.safe_post")
+    def test_includes_webhook(self, mock_safe_post, sample_items, mock_args):
         """Include webhook URL in request."""
         mock_args.webhook = "http://webhook.example.com"
         mock_response = MagicMock()
-        mock_response.read.return_value = json.dumps(
-            {"success": True, "batch_id": "batch-123"}
-        ).encode()
-        mock_response.__enter__ = MagicMock(return_value=mock_response)
-        mock_response.__exit__ = MagicMock(return_value=False)
-        mock_urlopen.return_value = mock_response
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {"success": True, "batch_id": "batch-123"}
+        mock_safe_post.return_value = mock_response
 
         _batch_via_server(sample_items, mock_args)
 
         # Verify webhook was included in request
-        call_args = mock_urlopen.call_args
-        request = call_args[0][0]
-        data = json.loads(request.data.decode())
-        assert data["webhook_url"] == "http://webhook.example.com"
-
-    @patch("urllib.request.urlopen")
-    def test_server_error(self, mock_urlopen, sample_items, mock_args, capsys):
-        """Handle server error."""
-        import urllib.error
-
-        mock_urlopen.side_effect = urllib.error.HTTPError(
-            "http://test", 500, "Server Error", {}, None
+        assert (
+            mock_safe_post.call_args.kwargs["json"]["webhook_url"] == "http://webhook.example.com"
         )
+
+    @patch("aragora.security.safe_http.safe_post")
+    def test_server_error(self, mock_safe_post, sample_items, mock_args, capsys):
+        """Handle server error."""
+        import httpx
+
+        request = httpx.Request("POST", "http://localhost:8080/api/debates/batch")
+        response = httpx.Response(500, request=request, text="Server Error")
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "Server Error", request=request, response=response
+        )
+        mock_safe_post.return_value = mock_response
 
         with pytest.raises(SystemExit) as exc_info:
             _batch_via_server(sample_items, mock_args)
 
         assert exc_info.value.code == 1
 
-    @patch("urllib.request.urlopen")
-    def test_connection_error(self, mock_urlopen, sample_items, mock_args, capsys):
+    @patch("aragora.security.safe_http.safe_post")
+    def test_connection_error(self, mock_safe_post, sample_items, mock_args, capsys):
         """Handle connection error."""
-        import urllib.error
+        import httpx
 
-        mock_urlopen.side_effect = urllib.error.URLError("Connection refused")
+        request = httpx.Request("POST", "http://localhost:8080/api/debates/batch")
+        mock_safe_post.side_effect = httpx.RequestError("Connection refused", request=request)
 
         with pytest.raises(SystemExit) as exc_info:
             _batch_via_server(sample_items, mock_args)
@@ -392,9 +394,9 @@ class TestBatchLocal:
 class TestPollBatchStatus:
     """Tests for _poll_batch_status function."""
 
-    @patch("urllib.request.urlopen")
+    @patch("aragora.security.safe_http.safe_get")
     @patch("time.sleep")
-    def test_polls_until_complete(self, mock_sleep, mock_urlopen, capsys):
+    def test_polls_until_complete(self, mock_sleep, mock_safe_get, capsys):
         """Poll until batch completes."""
         responses = [
             {
@@ -413,83 +415,72 @@ class TestPollBatchStatus:
             },
         ]
 
-        mock_response = MagicMock()
-        mock_response.__enter__ = MagicMock(return_value=mock_response)
-        mock_response.__exit__ = MagicMock(return_value=False)
-
         call_count = [0]
 
         def side_effect(*args, **kwargs):
             response_data = responses[min(call_count[0], len(responses) - 1)]
-            mock_response.read.return_value = json.dumps(response_data).encode()
             call_count[0] += 1
+            mock_response = MagicMock()
+            mock_response.raise_for_status = MagicMock()
+            mock_response.json.return_value = response_data
             return mock_response
 
-        mock_urlopen.side_effect = side_effect
+        mock_safe_get.side_effect = side_effect
 
         _poll_batch_status("http://localhost:8080", "batch-123")
 
         captured = capsys.readouterr()
         assert "Batch completed successfully" in captured.out
 
-    @patch("urllib.request.urlopen")
+    @patch("aragora.security.safe_http.safe_get")
     @patch("time.sleep")
-    def test_handles_partial_completion(self, mock_sleep, mock_urlopen, capsys):
+    def test_handles_partial_completion(self, mock_sleep, mock_safe_get, capsys):
         """Handle partial batch completion."""
         mock_response = MagicMock()
-        mock_response.read.return_value = json.dumps(
-            {
-                "status": "partial",
-                "progress_percent": 100,
-                "completed": 2,
-                "failed": 1,
-                "total_items": 3,
-            }
-        ).encode()
-        mock_response.__enter__ = MagicMock(return_value=mock_response)
-        mock_response.__exit__ = MagicMock(return_value=False)
-        mock_urlopen.return_value = mock_response
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {
+            "status": "partial",
+            "progress_percent": 100,
+            "completed": 2,
+            "failed": 1,
+            "total_items": 3,
+        }
+        mock_safe_get.return_value = mock_response
 
         _poll_batch_status("http://localhost:8080", "batch-123")
 
         captured = capsys.readouterr()
         assert "partially completed" in captured.out
 
-    @patch("urllib.request.urlopen")
+    @patch("aragora.security.safe_http.safe_get")
     @patch("time.sleep")
-    def test_handles_failure(self, mock_sleep, mock_urlopen, capsys):
+    def test_handles_failure(self, mock_sleep, mock_safe_get, capsys):
         """Handle batch failure."""
         mock_response = MagicMock()
-        mock_response.read.return_value = json.dumps(
-            {
-                "status": "failed",
-                "progress_percent": 50,
-                "completed": 1,
-                "failed": 2,
-                "total_items": 3,
-            }
-        ).encode()
-        mock_response.__enter__ = MagicMock(return_value=mock_response)
-        mock_response.__exit__ = MagicMock(return_value=False)
-        mock_urlopen.return_value = mock_response
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {
+            "status": "failed",
+            "progress_percent": 50,
+            "completed": 1,
+            "failed": 2,
+            "total_items": 3,
+        }
+        mock_safe_get.return_value = mock_response
 
         _poll_batch_status("http://localhost:8080", "batch-123")
 
         captured = capsys.readouterr()
         assert "Batch failed" in captured.out
 
-    @patch("urllib.request.urlopen")
+    @patch("aragora.security.safe_http.safe_get")
     @patch("time.sleep")
-    def test_includes_auth_token(self, mock_sleep, mock_urlopen):
+    def test_includes_auth_token(self, mock_sleep, mock_safe_get):
         """Include auth token in poll requests."""
         mock_response = MagicMock()
-        mock_response.read.return_value = json.dumps({"status": "completed"}).encode()
-        mock_response.__enter__ = MagicMock(return_value=mock_response)
-        mock_response.__exit__ = MagicMock(return_value=False)
-        mock_urlopen.return_value = mock_response
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {"status": "completed"}
+        mock_safe_get.return_value = mock_response
 
         _poll_batch_status("http://localhost:8080", "batch-123", token="secret-token")
 
-        call_args = mock_urlopen.call_args
-        request = call_args[0][0]
-        assert request.get_header("Authorization") == "Bearer secret-token"
+        assert mock_safe_get.call_args.kwargs["headers"]["Authorization"] == "Bearer secret-token"

--- a/tests/cli/test_cli_billing.py
+++ b/tests/cli/test_cli_billing.py
@@ -263,11 +263,11 @@ class TestCmdStatusLocal:
     def test_handles_import_error(self, mock_args, capsys):
         """Handle missing billing module."""
         with patch.dict("sys.modules", {"aragora.billing.usage": None}):
-            # Force import to fail
-            with patch("builtins.__import__", side_effect=ImportError("No module")):
-                result = cmd_status_local(mock_args)
+            result = cmd_status_local(mock_args)
 
         assert result == 1
+        captured = capsys.readouterr()
+        assert "Error reading local usage" in captured.out
 
 
 class TestCmdUsage:
@@ -345,12 +345,11 @@ class TestCmdUsage:
     def test_local_usage_handles_import_error(self, mock_args, capsys):
         """Handle missing local usage tracker dependencies."""
         with patch.dict("sys.modules", {"aragora.billing.usage": None}):
-            with patch("builtins.__import__", side_effect=ImportError("No module")):
-                result = cmd_usage_local(
-                    mock_args,
-                    datetime(2026, 1, 1),
-                    datetime(2026, 2, 1),
-                )
+            result = cmd_usage_local(
+                mock_args,
+                datetime(2026, 1, 1),
+                datetime(2026, 2, 1),
+            )
 
         assert result == 1
         captured = capsys.readouterr()

--- a/tests/cli/test_cli_billing.py
+++ b/tests/cli/test_cli_billing.py
@@ -342,6 +342,20 @@ class TestCmdUsage:
         assert "Debates by day:" in captured.out
         assert "2026-01-15:" in captured.out
 
+    def test_local_usage_handles_import_error(self, mock_args, capsys):
+        """Handle missing local usage tracker dependencies."""
+        with patch.dict("sys.modules", {"aragora.billing.usage": None}):
+            with patch("builtins.__import__", side_effect=ImportError("No module")):
+                result = cmd_usage_local(
+                    mock_args,
+                    datetime(2026, 1, 1),
+                    datetime(2026, 2, 1),
+                )
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "Error reading local usage" in captured.out
+
 
 class TestCmdSubscribe:
     """Tests for cmd_subscribe function."""


### PR DESCRIPTION
## Summary
- align CLI batch tests with the `safe_http.safe_post` / `safe_http.safe_get` wrappers now used by `aragora.cli.batch`
- update CLI batch response mocks from urllib-style `.read()` context managers to httpx-style `raise_for_status()` / `.json()` responses
- make local billing status tolerate import-time optional dependency failures as an error path, matching the existing test contract

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/cli/test_batch.py tests/cli/test_cli_batch.py tests/cli/test_cli_billing.py -q -p no:cacheprovider`
- `python3 -m ruff check aragora/cli/batch.py aragora/cli/billing.py tests/cli/test_batch.py tests/cli/test_cli_batch.py tests/cli/test_cli_billing.py`
- `python3 -m ruff format --check aragora/cli/batch.py aragora/cli/billing.py tests/cli/test_batch.py tests/cli/test_cli_batch.py tests/cli/test_cli_billing.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Context
This is a current-main repair for the CLI test-contract drift exposed while watching #8575. After this lands, #8575 should be rechecked at its live head before any evidence, settlement, rerun, or merge action.
