### PR TITLE
fix(publisher): fail closed on degraded PR lookup

### DIFF
--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -911,14 +911,10 @@ def _open_codex_prs_from_rest(
     for item in flattened:
         head = item.get("head")
         if not isinstance(head, Mapping):
-            number = item.get("number")
-            suffix = f" for PR #{number}" if number is not None else ""
-            raise RuntimeError(f"REST PR lookup missing head metadata{suffix}")
+            continue
         branch = head.get("ref")
         if not isinstance(branch, str):
-            number = item.get("number")
-            suffix = f" for PR #{number}" if number is not None else ""
-            raise RuntimeError(f"REST PR lookup missing head ref{suffix}")
+            continue
         if not branch.startswith(CODEX_BRANCH_PREFIX):
             skipped_non_codex_head += 1
             continue
@@ -1968,6 +1964,9 @@ def main(argv: list[str] | None = None) -> int:
         elif all_open_prs_unhealthy and not args.allow_unhealthy_queue_publish:
             payload["published"] = []
             payload["publish_paused_reason"] = "open_pr_queue_unhealthy"
+        elif open_pr_lookup_degraded:
+            payload["published"] = []
+            payload["publish_paused_reason"] = "open_pr_lookup_degraded"
         else:
             if all_open_prs_unhealthy and args.allow_unhealthy_queue_publish:
                 payload["publish_override_reason"] = "allow_unhealthy_queue_publish"

--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -1964,9 +1964,6 @@ def main(argv: list[str] | None = None) -> int:
         elif all_open_prs_unhealthy and not args.allow_unhealthy_queue_publish:
             payload["published"] = []
             payload["publish_paused_reason"] = "open_pr_queue_unhealthy"
-        elif open_pr_lookup_degraded:
-            payload["published"] = []
-            payload["publish_paused_reason"] = "open_pr_lookup_degraded"
         else:
             if all_open_prs_unhealthy and args.allow_unhealthy_queue_publish:
                 payload["publish_override_reason"] = "allow_unhealthy_queue_publish"

--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -911,12 +911,14 @@ def _open_codex_prs_from_rest(
     for item in flattened:
         head = item.get("head")
         if not isinstance(head, Mapping):
-            skipped_missing_head += 1
-            continue
+            number = item.get("number")
+            suffix = f" for PR #{number}" if number is not None else ""
+            raise RuntimeError(f"REST PR lookup missing head metadata{suffix}")
         branch = head.get("ref")
         if not isinstance(branch, str):
-            skipped_missing_head_ref += 1
-            continue
+            number = item.get("number")
+            suffix = f" for PR #{number}" if number is not None else ""
+            raise RuntimeError(f"REST PR lookup missing head ref{suffix}")
         if not branch.startswith(CODEX_BRANCH_PREFIX):
             skipped_non_codex_head += 1
             continue

--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -911,10 +911,14 @@ def _open_codex_prs_from_rest(
     for item in flattened:
         head = item.get("head")
         if not isinstance(head, Mapping):
-            continue
+            number = item.get("number")
+            suffix = f" for PR #{number}" if number is not None else ""
+            raise RuntimeError(f"REST PR lookup missing head metadata{suffix}")
         branch = head.get("ref")
         if not isinstance(branch, str):
-            continue
+            number = item.get("number")
+            suffix = f" for PR #{number}" if number is not None else ""
+            raise RuntimeError(f"REST PR lookup missing head ref{suffix}")
         if not branch.startswith(CODEX_BRANCH_PREFIX):
             skipped_non_codex_head += 1
             continue

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -1726,7 +1726,7 @@ def test_main_falls_back_to_rest_but_pauses_apply_for_unknown_queue_health(
 
     exit_code = mod.main(["--repo", str(tmp_path), "--apply", "--json"])
 
-    assert exit_code == 0
+    assert exit_code == 1
     assert publish_called is False
     payload = json.loads(capsys.readouterr().out)
     assert payload["open_pr_lookup"]["source"] == "rest"

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -732,7 +732,7 @@ def test_open_codex_prs_from_rest_rejects_unexpected_json_shape(
         raise AssertionError("expected REST shape failure")
 
 
-def test_open_codex_prs_from_rest_skips_missing_head_metadata(
+def test_open_codex_prs_from_rest_rejects_missing_head_metadata(
     monkeypatch: Any, tmp_path: Path
 ) -> None:
     monkeypatch.setattr(
@@ -746,7 +746,12 @@ def test_open_codex_prs_from_rest_skips_missing_head_metadata(
         ),
     )
 
-    assert mod._open_codex_prs_from_rest(tmp_path, "synaptent/aragora") == []
+    try:
+        mod._open_codex_prs_from_rest(tmp_path, "synaptent/aragora")
+    except RuntimeError as exc:
+        assert "missing head metadata for PR #7001" in str(exc)
+    else:  # pragma: no cover - assertion clarity
+        raise AssertionError("expected missing head metadata failure")
 
 
 def test_open_codex_prs_falls_back_to_rest_when_graphql_and_cache_fail(

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -732,7 +732,7 @@ def test_open_codex_prs_from_rest_rejects_unexpected_json_shape(
         raise AssertionError("expected REST shape failure")
 
 
-def test_open_codex_prs_from_rest_rejects_missing_head_metadata(
+def test_open_codex_prs_from_rest_skips_missing_head_metadata(
     monkeypatch: Any, tmp_path: Path
 ) -> None:
     monkeypatch.setattr(
@@ -746,12 +746,7 @@ def test_open_codex_prs_from_rest_rejects_missing_head_metadata(
         ),
     )
 
-    try:
-        mod._open_codex_prs_from_rest(tmp_path, "synaptent/aragora")
-    except RuntimeError as exc:
-        assert "missing head metadata for PR #7001" in str(exc)
-    else:  # pragma: no cover - assertion clarity
-        raise AssertionError("expected malformed REST PR failure")
+    assert mod._open_codex_prs_from_rest(tmp_path, "synaptent/aragora") == []
 
 
 def test_open_codex_prs_falls_back_to_rest_when_graphql_and_cache_fail(
@@ -803,7 +798,7 @@ def test_rest_fallback_prs_are_unhealthy_for_queue_health() -> None:
     ) == ["lookup_degraded_queue_health_unknown"]
 
 
-def test_rest_fallback_skips_malformed_pr_entries(monkeypatch: Any, tmp_path: Path) -> None:
+def test_rest_fallback_rejects_malformed_pr_entries(monkeypatch: Any, tmp_path: Path) -> None:
     payload = [
         [
             {"number": 1, "head": None},
@@ -830,26 +825,12 @@ def test_rest_fallback_skips_malformed_pr_entries(monkeypatch: Any, tmp_path: Pa
         ),
     )
 
-    meta: dict[str, Any] = {}
-
-    assert mod._open_codex_prs_from_rest(tmp_path, "synaptent/aragora", meta=meta) == [
-        {
-            "number": 4,
-            "title": "valid codex PR",
-            "headRefName": "codex/valid",
-            "isDraft": False,
-            "mergeStateStatus": "CLEAN",
-            "reviewDecision": None,
-            "statusCheckRollup": [],
-            "lookup_degraded": True,
-            "lookup_source": "rest",
-        }
-    ]
-    assert meta["rest_payload_count"] == 4
-    assert meta["rest_skipped_missing_head_count"] == 1
-    assert meta["rest_skipped_missing_head_ref_count"] == 1
-    assert meta["rest_skipped_non_codex_head_count"] == 1
-    assert meta["rest_skipped_total_count"] == 3
+    try:
+        mod._open_codex_prs_from_rest(tmp_path, "synaptent/aragora")
+    except RuntimeError as exc:
+        assert "missing head metadata for PR #1" in str(exc)
+    else:  # pragma: no cover - assertion clarity
+        raise AssertionError("expected malformed REST PR failure")
 
 
 def test_open_codex_prs_reports_rest_error_when_all_lookups_fail(

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -1726,7 +1726,7 @@ def test_main_falls_back_to_rest_but_pauses_apply_for_unknown_queue_health(
 
     exit_code = mod.main(["--repo", str(tmp_path), "--apply", "--json"])
 
-    assert exit_code == 1
+    assert exit_code == 0
     assert publish_called is False
     payload = json.loads(capsys.readouterr().out)
     assert payload["open_pr_lookup"]["source"] == "rest"

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -732,7 +732,7 @@ def test_open_codex_prs_from_rest_rejects_unexpected_json_shape(
         raise AssertionError("expected REST shape failure")
 
 
-def test_open_codex_prs_from_rest_skips_missing_head_metadata(
+def test_open_codex_prs_from_rest_rejects_missing_head_metadata(
     monkeypatch: Any, tmp_path: Path
 ) -> None:
     monkeypatch.setattr(
@@ -746,7 +746,12 @@ def test_open_codex_prs_from_rest_skips_missing_head_metadata(
         ),
     )
 
-    assert mod._open_codex_prs_from_rest(tmp_path, "synaptent/aragora") == []
+    try:
+        mod._open_codex_prs_from_rest(tmp_path, "synaptent/aragora")
+    except RuntimeError as exc:
+        assert "missing head metadata for PR #7001" in str(exc)
+    else:  # pragma: no cover - assertion clarity
+        raise AssertionError("expected malformed REST PR failure")
 
 
 def test_open_codex_prs_falls_back_to_rest_when_graphql_and_cache_fail(


### PR DESCRIPTION
## Summary

Harvested and restacked the valuable publisher fallback work from local branch `codex/pr8527-publisher-fallback-followup-20260623` at source head `6dd317a385`.

This makes publisher open-PR lookup fail closed under degraded or malformed GitHub REST responses instead of silently treating incomplete PR metadata as publishable/absent state. It also preserves the intended degraded no-op apply behavior when there is no publishable work.

## Safety / Coordination

- Owner/steering checks for the source branch found no active lane.
- No existing open/all PR was found for `codex/publisher-degraded-pr-lookup-failclosed-20260626` before publication.
- Scope is limited to:
  - `scripts/publish_codex_automation_branches.py`
  - `tests/scripts/test_publish_codex_automation_branches.py`

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/scripts/test_publish_codex_automation_branches.py -q -p no:cacheprovider` -> 58 passed
- `python3 -m ruff check scripts/publish_codex_automation_branches.py tests/scripts/test_publish_codex_automation_branches.py` -> passed
- `python3 -m ruff format --check scripts/publish_codex_automation_branches.py tests/scripts/test_publish_codex_automation_branches.py` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> passed
