### PR TITLE
fix(automation): add local harvest reporting

### DIFF
--- a/scripts/codex_automation_harvest_report.py
+++ b/scripts/codex_automation_harvest_report.py
@@ -379,7 +379,8 @@ def write_latest_report(report: Mapping[str, Any], *, state_root: Path) -> Path:
 
 
 def print_markdown(report: Mapping[str, Any]) -> None:
-    counts = report.get("counts") if isinstance(report.get("counts"), Mapping) else {}
+    raw_counts = report.get("counts")
+    counts: Mapping[str, Any] = raw_counts if isinstance(raw_counts, Mapping) else {}
     print("# Codex Automation Harvest Report\n")
     print(f"- Repo: `{report.get('repo')}`")
     print(f"- State root: `{report.get('state_root')}`")

--- a/scripts/codex_automation_harvest_report.py
+++ b/scripts/codex_automation_harvest_report.py
@@ -1,0 +1,475 @@
+#!/usr/bin/env python3
+"""Local-only harvest report for sandboxed Codex automation output."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from collections import Counter
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.publish_automation_handoffs import (  # noqa: E402
+    DEFAULT_OUTBOX_DIR,
+    DEFAULT_RECEIPT_DIR,
+    TERMINAL_RECEIPT_STATUSES,
+    Handoff,
+    load_outbox_handoffs,
+)
+
+UTC = timezone.utc
+SCHEMA_VERSION = 1
+DEFAULT_PUBLISHER_CACHE = Path(".aragora/automation-github-status/latest.json")
+DEFAULT_WORKTREE_HARVEST = Path(".aragora/worktree-harvest/latest.json")
+PRODUCT_PROOF_TOKENS = (
+    "aavt",
+    "aft",
+    "ask",
+    "benchmark",
+    "doctor",
+    "dogfood",
+    "eu ai",
+    "external",
+    "grok",
+    "provider",
+    "receipt",
+    "validate-env",
+)
+META_TOOLING_TOKENS = (
+    "agent_bridge",
+    "automation",
+    "handoff",
+    "harvest",
+    "merge",
+    "outbox",
+    "publisher",
+    "queue",
+    "settle",
+    "steward",
+)
+CLASSIFICATION_ORDER = {
+    "product_proof_candidate": 0,
+    "ready_for_pr": 1,
+    "needs_review": 2,
+    "meta_tooling_candidate": 3,
+    "issue_only": 4,
+    "needs_rebase": 5,
+    "protected_active_work": 6,
+    "superseded_candidate": 7,
+}
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _run(
+    args: list[str],
+    *,
+    cwd: Path,
+    timeout: int = 10,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            args,
+            cwd=cwd,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout if isinstance(exc.stdout, str) else ""
+        stderr = exc.stderr if isinstance(exc.stderr, str) else ""
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=124,
+            stdout=stdout,
+            stderr=stderr or f"command timed out after {timeout}s: {' '.join(args)}",
+        )
+
+
+def repo_root(path: Path) -> Path:
+    proc = _run(["git", "rev-parse", "--show-toplevel"], cwd=path)
+    if proc.returncode != 0:
+        raise SystemExit(proc.stderr.strip() or "not a git repository")
+    return Path(proc.stdout.strip()).resolve()
+
+
+def _same_git_origin(left: Path, right: Path) -> bool:
+    left_proc = _run(["git", "config", "--get", "remote.origin.url"], cwd=left)
+    right_proc = _run(["git", "config", "--get", "remote.origin.url"], cwd=right)
+    return (
+        left_proc.returncode == 0
+        and right_proc.returncode == 0
+        and bool(left_proc.stdout.strip())
+        and left_proc.stdout.strip() == right_proc.stdout.strip()
+    )
+
+
+def automation_state_root(root: Path, explicit: Path | None = None) -> Path:
+    if explicit is not None:
+        resolved = explicit.expanduser().resolve()
+        return resolved if resolved.name == ".aragora" else resolved / ".aragora"
+    if (root / ".aragora").is_dir():
+        return root / ".aragora"
+
+    configured = os.environ.get("ARAGORA_AUTOMATION_STATE_ROOT")
+    candidates = [Path(configured).expanduser()] if configured else []
+    candidates.append(Path.home() / "Development" / "aragora")
+    for candidate in candidates:
+        resolved = candidate.resolve()
+        if resolved.name == ".aragora" and resolved.is_dir():
+            return resolved
+        if (resolved / ".aragora").is_dir() and _same_git_origin(root, resolved):
+            return resolved / ".aragora"
+    return root / ".aragora"
+
+
+def _state_path(state_root: Path, explicit: Path | None, default: Path) -> Path:
+    if explicit is not None:
+        expanded = explicit.expanduser()
+        return expanded.resolve() if expanded.is_absolute() else (state_root / expanded).resolve()
+    if default.parts[:1] == (".aragora",):
+        return state_root.joinpath(*default.parts[1:]).resolve()
+    return (state_root / default).resolve()
+
+
+def _json_files(path: Path) -> list[Path]:
+    if not path.exists():
+        return []
+    return sorted(item for item in path.iterdir() if item.is_file() and item.suffix == ".json")
+
+
+def _load_json(path: Path) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _terminal_receipt_count(receipt_dir: Path) -> int:
+    count = 0
+    for path in _json_files(receipt_dir):
+        payload = _load_json(path)
+        if payload is None:
+            continue
+        if str(payload.get("status") or "").strip().lower() in TERMINAL_RECEIPT_STATUSES:
+            count += 1
+    return count
+
+
+def _branch_exists(root: Path, branch: str | None) -> bool:
+    if not branch:
+        return False
+    proc = _run(["git", "rev-parse", "--verify", branch], cwd=root)
+    return proc.returncode == 0
+
+
+def _text_blob(handoff: Handoff) -> str:
+    # The rendered body contains generic words such as "proof" and "receipt" for
+    # most handoffs. Classify from durable intent fields to avoid over-ranking
+    # routine meta-tooling as product-proof work.
+    return f"{handoff.task_title}\n{handoff.branch or ''}\n{handoff.priority}".lower()
+
+
+def _contains_signal(text: str, tokens: tuple[str, ...]) -> bool:
+    for token in tokens:
+        if " " in token or "-" in token or "_" in token:
+            if token in text:
+                return True
+            continue
+        if re.search(rf"(?<![a-z0-9]){re.escape(token)}(?![a-z0-9])", text):
+            return True
+    return False
+
+
+def classify_handoff(root: Path, handoff: Handoff) -> str:
+    """Return one harvest classification for a handoff."""
+
+    if handoff.source_kind != "outbox":
+        return "needs_review"
+    if not handoff.branch:
+        return "issue_only"
+    if not _branch_exists(root, handoff.branch):
+        return "needs_rebase"
+
+    text = _text_blob(handoff)
+    if _contains_signal(text, PRODUCT_PROOF_TOKENS):
+        return "product_proof_candidate"
+    if _contains_signal(text, META_TOOLING_TOKENS):
+        return "meta_tooling_candidate"
+    return "ready_for_pr"
+
+
+def _handoff_record(root: Path, handoff: Handoff) -> dict[str, Any]:
+    classification = classify_handoff(root, handoff)
+    return {
+        "task": handoff.task_title,
+        "source_file": handoff.source_file,
+        "source_kind": handoff.source_kind,
+        "branch": handoff.branch,
+        "desired_head": handoff.desired_head,
+        "priority": handoff.priority,
+        "idempotency_key": handoff.idempotency_key,
+        "classification": classification,
+        "rank": CLASSIFICATION_ORDER.get(classification, 99),
+    }
+
+
+def _load_optional_json(path: Path | None) -> dict[str, Any]:
+    if path is None:
+        return {}
+    return _load_json(path) or {}
+
+
+def _run_json(args: list[str], *, cwd: Path, timeout: int) -> dict[str, Any]:
+    proc = _run(args, cwd=cwd, timeout=timeout)
+    if proc.returncode != 0:
+        return {
+            "error": proc.stderr.strip() or proc.stdout.strip() or "command failed",
+            "returncode": proc.returncode,
+        }
+    try:
+        payload = json.loads(proc.stdout or "{}")
+    except json.JSONDecodeError:
+        return {"error": "invalid json", "returncode": proc.returncode}
+    return payload if isinstance(payload, dict) else {"payload": payload}
+
+
+def _local_branch_count(root: Path, prefix: str = "codex/") -> int:
+    proc = _run(
+        ["git", "for-each-ref", "--format=%(refname:short)", f"refs/heads/{prefix}"],
+        cwd=root,
+    )
+    if proc.returncode != 0:
+        return 0
+    return sum(1 for line in proc.stdout.splitlines() if line.strip())
+
+
+def _int_from_mapping(value: Any, key: str) -> int:
+    if not isinstance(value, Mapping):
+        return 0
+    raw = value.get(key)
+    return raw if isinstance(raw, int) else 0
+
+
+def _coordination_counts(operator_snapshot: Mapping[str, Any]) -> dict[str, int]:
+    pending = operator_snapshot.get("pending_steering_messages")
+    heartbeats = operator_snapshot.get("agent_heartbeats")
+    return {
+        "pending_steering_messages": _int_from_mapping(pending, "count"),
+        "unread_steering_messages": _int_from_mapping(pending, "unread_message_count"),
+        "fresh_agent_heartbeats": _int_from_mapping(heartbeats, "fresh_count"),
+        "stale_agent_heartbeats": _int_from_mapping(heartbeats, "stale_count"),
+    }
+
+
+def _compact_publisher_cache(payload: Mapping[str, Any]) -> dict[str, Any]:
+    local_queue = payload.get("local_queue")
+    github_health = payload.get("github_health")
+    return {
+        "generated_at": payload.get("generated_at"),
+        "local_queue": dict(local_queue) if isinstance(local_queue, Mapping) else {},
+        "github_health": dict(github_health) if isinstance(github_health, Mapping) else {},
+    }
+
+
+def _compact_operator_snapshot(payload: Mapping[str, Any]) -> dict[str, Any]:
+    pending = payload.get("pending_steering_messages")
+    heartbeats = payload.get("agent_heartbeats")
+    health = payload.get("health")
+    summary = payload.get("summary")
+    conflicts = payload.get("lane_conflicts")
+    return {
+        "health": dict(health) if isinstance(health, Mapping) else {},
+        "lane_conflict_count": len(conflicts) if isinstance(conflicts, list) else 0,
+        "pending_steering_messages": {
+            "count": _int_from_mapping(pending, "count"),
+            "unread_message_count": _int_from_mapping(pending, "unread_message_count"),
+        },
+        "agent_heartbeats": {
+            "fresh_count": _int_from_mapping(heartbeats, "fresh_count"),
+            "stale_count": _int_from_mapping(heartbeats, "stale_count"),
+        },
+        "summary": dict(summary) if isinstance(summary, Mapping) else {},
+    }
+
+
+def _compact_worktree_harvest(payload: Mapping[str, Any]) -> dict[str, Any]:
+    summary = payload.get("summary")
+    return {
+        "schema": payload.get("schema"),
+        "generated_at": payload.get("generated_at"),
+        "summary": dict(summary) if isinstance(summary, Mapping) else {},
+    }
+
+
+def build_report(
+    *,
+    repo_root: Path,
+    state_root: Path,
+    outbox_dir: Path | None = None,
+    receipt_dir: Path | None = None,
+    publisher_cache: Mapping[str, Any] | None = None,
+    operator_snapshot: Mapping[str, Any] | None = None,
+    worktree_harvest: Mapping[str, Any] | None = None,
+    top_limit: int = 20,
+) -> dict[str, Any]:
+    repo_root = repo_root.resolve()
+    state_root = state_root.resolve()
+    outbox_root = _state_path(state_root, outbox_dir, DEFAULT_OUTBOX_DIR)
+    receipt_root = _state_path(state_root, receipt_dir, DEFAULT_RECEIPT_DIR)
+    handoffs = load_outbox_handoffs(
+        repo_root,
+        outbox_dir=outbox_root,
+        receipt_dir=receipt_root,
+    )
+    records = [_handoff_record(repo_root, handoff) for handoff in handoffs]
+    records.sort(key=lambda item: (item["rank"], item["task"], item["source_file"]))
+    class_counts = Counter(str(item["classification"]) for item in records)
+    coordination = _coordination_counts(operator_snapshot or {})
+    counts = {
+        "outbox_total_count": len(_json_files(outbox_root)),
+        "active_handoff_count": len(handoffs),
+        "terminal_receipt_count": _terminal_receipt_count(receipt_root),
+        "local_codex_branch_count": _local_branch_count(repo_root),
+        **coordination,
+    }
+    recommended = records[0] if records else None
+    return {
+        "automation_harvest_schema_version": SCHEMA_VERSION,
+        "generated_at": _now_iso(),
+        "repo": str(repo_root),
+        "state_root": str(state_root),
+        "outbox_dir": str(outbox_root),
+        "receipt_dir": str(receipt_root),
+        "counts": counts,
+        "classification_counts": dict(sorted(class_counts.items())),
+        "recommended_next_target": recommended,
+        "top_next_handoffs": records[: max(top_limit, 0)],
+        "publisher_cache": _compact_publisher_cache(publisher_cache or {}),
+        "operator_snapshot_summary": _compact_operator_snapshot(operator_snapshot or {}),
+        "worktree_harvest_summary": _compact_worktree_harvest(worktree_harvest or {}),
+    }
+
+
+def write_latest_report(report: Mapping[str, Any], *, state_root: Path) -> Path:
+    state_root = state_root.expanduser().resolve()
+    if state_root.name != ".aragora":
+        state_root = state_root / ".aragora"
+    output_dir = state_root / "automation-harvest"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / "latest.json"
+    output_path.write_text(
+        json.dumps(dict(report), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return output_path
+
+
+def print_markdown(report: Mapping[str, Any]) -> None:
+    counts = report.get("counts") if isinstance(report.get("counts"), Mapping) else {}
+    print("# Codex Automation Harvest Report\n")
+    print(f"- Repo: `{report.get('repo')}`")
+    print(f"- State root: `{report.get('state_root')}`")
+    print(f"- Active handoffs: `{counts.get('active_handoff_count', 0)}`")
+    print(f"- Total outbox files: `{counts.get('outbox_total_count', 0)}`")
+    print(f"- Terminal receipts: `{counts.get('terminal_receipt_count', 0)}`")
+    print(f"- Local codex branches: `{counts.get('local_codex_branch_count', 0)}`")
+    print(f"- Pending steering messages: `{counts.get('pending_steering_messages', 0)}`")
+    print(f"- Fresh agent heartbeats: `{counts.get('fresh_agent_heartbeats', 0)}`")
+    target = report.get("recommended_next_target")
+    if isinstance(target, Mapping):
+        print("\n## Recommended Next Target\n")
+        print(f"- Task: `{target.get('task')}`")
+        print(f"- Classification: `{target.get('classification')}`")
+        print(f"- Branch: `{target.get('branch')}`")
+        print(f"- Source: `{target.get('source_file')}`")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=".", help="Path inside the repository")
+    parser.add_argument(
+        "--state-root",
+        type=Path,
+        default=None,
+        help="Automation state root, either repo root or .aragora directory.",
+    )
+    parser.add_argument("--outbox-dir", type=Path, default=None)
+    parser.add_argument("--receipt-dir", type=Path, default=None)
+    parser.add_argument("--publisher-cache", type=Path, default=None)
+    parser.add_argument("--operator-snapshot-json", type=Path, default=None)
+    parser.add_argument("--worktree-harvest-json", type=Path, default=None)
+    parser.add_argument("--top-limit", type=int, default=20)
+    parser.add_argument("--json", action="store_true", help="Emit JSON")
+    parser.add_argument("--markdown", action="store_true", help="Emit Markdown")
+    parser.add_argument(
+        "--write-latest",
+        action="store_true",
+        help="Write .aragora/automation-harvest/latest.json",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    root = repo_root(Path(args.repo))
+    state_root = automation_state_root(root, args.state_root)
+    publisher_cache_path = _state_path(
+        state_root,
+        args.publisher_cache,
+        DEFAULT_PUBLISHER_CACHE,
+    )
+    operator_snapshot = (
+        _load_optional_json(args.operator_snapshot_json)
+        if args.operator_snapshot_json
+        else _run_json(
+            [
+                "python3",
+                "scripts/agent_bridge.py",
+                "operator-snapshot",
+                "--json",
+                "--summary-only",
+            ],
+            cwd=root,
+            timeout=15,
+        )
+    )
+    worktree_harvest_path = _state_path(
+        state_root,
+        args.worktree_harvest_json,
+        DEFAULT_WORKTREE_HARVEST,
+    )
+    report = build_report(
+        repo_root=root,
+        state_root=state_root,
+        outbox_dir=args.outbox_dir,
+        receipt_dir=args.receipt_dir,
+        publisher_cache=_load_optional_json(publisher_cache_path),
+        operator_snapshot=operator_snapshot,
+        worktree_harvest=_load_optional_json(worktree_harvest_path),
+        top_limit=args.top_limit,
+    )
+    if args.write_latest:
+        report["latest_path"] = str(write_latest_report(report, state_root=state_root))
+    if args.markdown and not args.json:
+        print_markdown(report)
+    else:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -1510,6 +1510,15 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="With --json, omit per-handoff decisions and print compact counts only.",
     )
+    parser.add_argument(
+        "--local-only",
+        "--no-github",
+        action="store_true",
+        help=(
+            "Build a bounded local preview without probing GitHub or running "
+            "issue/PR duplicate lookups. Safe for sandboxed automations."
+        ),
+    )
     return parser
 
 
@@ -1571,6 +1580,47 @@ def main(argv: list[str] | None = None) -> int:
         key=lambda item: (_source_mtime(item.source_file), item.priority),
         reverse=True,
     )
+    if args.local_only:
+        decision_handoffs = handoffs[: max(args.limit, 0)]
+        decisions = [
+            _local_handoff_blocker(repo_root, handoff)
+            or PublishDecision(
+                task_title=handoff.task_title,
+                source_file=handoff.source_file,
+                eligible=False,
+                reason="local_only_preview",
+            )
+            for handoff in decision_handoffs
+        ]
+        payload = {
+            "repo": str(repo_root),
+            "codex_home": str(codex_home),
+            "github_repo": args.github_repo,
+            "labels": labels,
+            "automation_ids": sorted(automation_ids),
+            "outbox_dir": str(outbox_dir),
+            "receipt_dir": str(receipt_dir),
+            "memory_handoff_count": len(memory_handoffs),
+            "outbox_handoff_count": len(outbox_handoffs),
+            "handoff_count": len(handoffs),
+            "github_health": {
+                "ready": False,
+                "auth_ok": False,
+                "api_ok": False,
+                "mode": "local_only",
+                "error": "GitHub probing intentionally skipped",
+                "repo": str(repo_root),
+            },
+            "decisions": [asdict(item) for item in decisions],
+            "decision_summary": summarize_decisions(decisions),
+        }
+        if args.json:
+            output_payload = summary_only_payload(payload) if args.summary_only else payload
+            print(json.dumps(output_payload, indent=2))
+        else:
+            print(f"local_only: {len(handoffs)} handoffs loaded; GitHub probing skipped")
+        return 0
+
     github_health = check_github_cli_health(repo_root)
     if not github_health.ready:
         decision_handoffs = handoffs[: max(args.limit, 0)]

--- a/scripts/run_codex_automation_publisher.sh
+++ b/scripts/run_codex_automation_publisher.sh
@@ -30,12 +30,31 @@ fi
 HANDOFF_OUTBOX_DIR="${ARAGORA_AUTOMATION_OUTBOX_DIR:-${AUTOMATION_STATE_ROOT}/.aragora/automation-outbox}"
 HANDOFF_RECEIPT_DIR="${ARAGORA_AUTOMATION_RECEIPT_DIR:-${AUTOMATION_STATE_ROOT}/.aragora/automation-receipts}"
 GITHUB_STATUS_CACHE="${ARAGORA_AUTOMATION_GITHUB_STATUS_CACHE:-${AUTOMATION_STATE_ROOT}/.aragora/automation-github-status/latest.json}"
+HARVEST_REPORT_PATH="${AUTOMATION_STATE_ROOT}/.aragora/automation-harvest/latest.json"
 STAMP() {
   date -u +"%Y-%m-%dT%H:%M:%SZ"
 }
 
 repo_root_available() {
   [[ -d "${REPO_ROOT}" && ( -d "${REPO_ROOT}/.git" || -f "${REPO_ROOT}/.git" ) ]]
+}
+
+write_harvest_report() {
+  if ! repo_root_available; then
+    return 0
+  fi
+  if python3 scripts/codex_automation_harvest_report.py \
+    --repo "${REPO_ROOT}" \
+    --state-root "${AUTOMATION_STATE_ROOT}/.aragora" \
+    --outbox-dir "${HANDOFF_OUTBOX_DIR}" \
+    --receipt-dir "${HANDOFF_RECEIPT_DIR}" \
+    --publisher-cache "${GITHUB_STATUS_CACHE}" \
+    --write-latest \
+    --json >/dev/null; then
+    echo "$(STAMP) [codex-automation-publisher] wrote local harvest summary: ${HARVEST_REPORT_PATH}"
+  else
+    echo "$(STAMP) [codex-automation-publisher] local harvest summary failed; continuing"
+  fi
 }
 
 if ! mkdir "$LOCK_DIR" 2>/dev/null; then
@@ -87,6 +106,7 @@ if python3 scripts/cache_codex_automation_github_status.py \
 else
   echo "$(STAMP) [codex-automation-publisher] GitHub queue status cache failed; continuing"
 fi
+write_harvest_report
 HEALTH_READY="$(
   printf '%s' "${HEALTH_JSON}" \
     | python3 -c 'import json,sys; print("true" if json.load(sys.stdin).get("ready") else "false")' \
@@ -192,5 +212,6 @@ if python3 scripts/publish_automation_handoffs.py \
 else
   echo "$(STAMP) [codex-automation-publisher] handoff publish pass failed; continuing"
 fi
+write_harvest_report
 
 echo "$(STAMP) [codex-automation-publisher] publish pass complete"

--- a/tests/scripts/test_codex_automation_harvest_report.py
+++ b/tests/scripts/test_codex_automation_harvest_report.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import scripts.codex_automation_harvest_report as mod
+
+
+def _git_repo(path: Path) -> None:
+    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "checkout", "-b", "main"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "codex@example.com"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Codex"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    (path / "README.md").write_text("base\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "add", "README.md"], cwd=path, check=True, capture_output=True, text=True
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "base"], cwd=path, check=True, capture_output=True, text=True
+    )
+    subprocess.run(
+        ["git", "checkout", "-b", "codex/provider-proof"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    (path / "README.md").write_text("base\nproof\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "commit", "-am", "proof"], cwd=path, check=True, capture_output=True, text=True
+    )
+    subprocess.run(
+        ["git", "checkout", "main"], cwd=path, check=True, capture_output=True, text=True
+    )
+
+
+def _outbox_payload(**overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "task": "Provider dogfood proof receipt",
+        "requires_github": True,
+        "requested_action": "open_pr",
+        "repo": "synaptent/aragora",
+        "local_evidence": {"branch": "codex/provider-proof", "head": "abc123"},
+        "validation": ["pytest tests/provider.py -q"],
+        "idempotency_key": "open-pr-codex-provider-proof-abc123",
+        "created_at": "2026-05-27T12:00:00+00:00",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_build_report_classifies_and_ranks_unharvested_handoffs(tmp_path: Path) -> None:
+    _git_repo(tmp_path)
+    state_root = tmp_path / ".aragora"
+    outbox = state_root / "automation-outbox"
+    receipts = state_root / "automation-receipts"
+    cache = state_root / "automation-github-status"
+    outbox.mkdir(parents=True)
+    receipts.mkdir(parents=True)
+    cache.mkdir(parents=True)
+    (outbox / "proof.json").write_text(json.dumps(_outbox_payload()), encoding="utf-8")
+    (outbox / "issue-only.json").write_text(
+        json.dumps(
+            _outbox_payload(
+                task="Investigate stale coordination note",
+                local_evidence={},
+                idempotency_key="issue-codex-stale-coordination-abc123",
+            )
+        ),
+        encoding="utf-8",
+    )
+    (receipts / "completed.json").write_text(
+        json.dumps({"idempotency_key": "completed", "status": "completed"}),
+        encoding="utf-8",
+    )
+    (cache / "latest.json").write_text(
+        json.dumps({"local_queue": {"outbox_count": 2}, "github_health": {"mode": "ready"}}),
+        encoding="utf-8",
+    )
+
+    report = mod.build_report(
+        repo_root=tmp_path,
+        state_root=state_root,
+        operator_snapshot={
+            "pending_steering_messages": {"count": 2, "unread_message_count": 1},
+            "agent_heartbeats": {"fresh_count": 0, "stale_count": 4},
+        },
+        worktree_harvest={"generated_at": "2026-05-27T12:00:00Z", "summary": {"x": 1}},
+    )
+
+    assert report["automation_harvest_schema_version"] == 1
+    assert report["counts"]["outbox_total_count"] == 2
+    assert report["counts"]["terminal_receipt_count"] == 1
+    assert report["counts"]["pending_steering_messages"] == 2
+    assert report["counts"]["fresh_agent_heartbeats"] == 0
+    assert report["classification_counts"] == {
+        "issue_only": 1,
+        "product_proof_candidate": 1,
+    }
+    assert report["top_next_handoffs"][0]["classification"] == "product_proof_candidate"
+    assert report["recommended_next_target"]["task"] == "Provider dogfood proof receipt"
+
+
+def test_write_latest_report_uses_stable_schema_path(tmp_path: Path) -> None:
+    report = {
+        "automation_harvest_schema_version": 1,
+        "generated_at": "2026-05-27T12:00:00Z",
+        "counts": {},
+    }
+
+    path = mod.write_latest_report(report, state_root=tmp_path / ".aragora")
+
+    assert path == tmp_path / ".aragora" / "automation-harvest" / "latest.json"
+    assert json.loads(path.read_text(encoding="utf-8"))["automation_harvest_schema_version"] == 1

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -1768,7 +1768,7 @@ def test_main_preview_does_not_write_outbox_receipt(
     monkeypatch.setattr(
         mod,
         "_load_outbox_handoffs_with_skip_reasons",
-        lambda repo_root, outbox_dir=None, receipt_dir=None: ([handoff], Counter()),
+        lambda repo_root, **kwargs: ([handoff], Counter()),
     )
     monkeypatch.setattr(
         mod,
@@ -1839,7 +1839,7 @@ def test_main_accepts_explicit_dry_run_alias(monkeypatch: Any, tmp_path: Path, c
     monkeypatch.setattr(
         mod,
         "_load_outbox_handoffs_with_skip_reasons",
-        lambda repo_root, outbox_dir=None, receipt_dir=None: ([handoff], Counter()),
+        lambda repo_root, **kwargs: ([handoff], Counter()),
     )
     monkeypatch.setattr(
         mod,
@@ -2346,8 +2346,8 @@ def test_main_local_only_summary_never_probes_github(
     monkeypatch.setattr(mod, "load_handoffs", lambda codex_home, automation_ids=None: [])
     monkeypatch.setattr(
         mod,
-        "load_outbox_handoffs",
-        lambda repo_root, outbox_dir=None, receipt_dir=None: [handoff],
+        "_load_outbox_handoffs_with_skip_reasons",
+        lambda repo_root, **kwargs: ([handoff], Counter()),
     )
     monkeypatch.setattr(
         mod,

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -2328,6 +2328,65 @@ def test_main_summary_only_limits_outbox_loading(monkeypatch: Any, tmp_path: Pat
     assert payload["outbox_preview_limit"] == 1
 
 
+def test_main_local_only_summary_never_probes_github(
+    monkeypatch: Any, tmp_path: Path, capsys
+) -> None:
+    handoff = Handoff(
+        source_file=str(tmp_path / ".aragora" / "automation-outbox" / "example.json"),
+        task_title="Publish provider dogfood proof branch",
+        priority="HIGH",
+        body="body",
+        labels={},
+        expires_at=None,
+        idempotency_key="open-pr-codex-provider-proof-abc123",
+        source_kind="outbox",
+        branch="codex/provider-proof",
+    )
+    monkeypatch.setattr(mod, "_repo_root", lambda path: tmp_path)
+    monkeypatch.setattr(mod, "load_handoffs", lambda codex_home, automation_ids=None: [])
+    monkeypatch.setattr(
+        mod,
+        "load_outbox_handoffs",
+        lambda repo_root, outbox_dir=None, receipt_dir=None: [handoff],
+    )
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda repo_root: (_ for _ in ()).throw(AssertionError("GitHub probe forbidden")),
+    )
+    monkeypatch.setattr(
+        mod,
+        "decide_handoffs",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("GitHub decisions forbidden")),
+    )
+
+    exit_code = mod.main(
+        [
+            "--repo",
+            str(tmp_path),
+            "--codex-home",
+            str(tmp_path),
+            "--json",
+            "--summary-only",
+            "--local-only",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["github_health"]["mode"] == "local_only"
+    assert payload["handoff_count"] == 1
+    assert payload["decision_count"] == 1
+    assert payload["decision_summary"] == {
+        "total": 1,
+        "eligible_count": 0,
+        "ineligible_count": 1,
+        "reason_counts": {
+            "local_only_preview": 1,
+        },
+    }
+
+
 def test_main_summary_only_reports_outbox_files_skipped_before_publish(
     monkeypatch: Any, tmp_path: Path, capsys
 ) -> None:

--- a/tests/scripts/test_run_codex_automation_publisher.py
+++ b/tests/scripts/test_run_codex_automation_publisher.py
@@ -55,6 +55,16 @@ def test_publisher_wrapper_handles_missing_gh_as_unavailable() -> None:
     assert "GitHub unavailable; leaving automations in handoff-only mode" in script
 
 
+def test_publisher_wrapper_writes_stable_harvest_summary() -> None:
+    script = (REPO_ROOT / "scripts" / "run_codex_automation_publisher.sh").read_text(
+        encoding="utf-8"
+    )
+
+    assert "scripts/codex_automation_harvest_report.py" in script
+    assert "--write-latest" in script
+    assert "automation-harvest/latest.json" in script
+
+
 def test_launchd_installer_prefers_canonical_git_worktree_root() -> None:
     script = (REPO_ROOT / "scripts" / "install_codex_automation_publisher_launchd.sh").read_text(
         encoding="utf-8"


### PR DESCRIPTION
## Summary
- Restacks and publishes the local automation harvest reporting work from `codex/automation-harvest-reliability-20260527`.
- Adds `scripts/codex_automation_harvest_report.py` for local harvest/backlog reporting.
- Extends the automation handoff publisher local-only summary path and publisher wrapper coverage.

## Harvest provenance
- Source branch: `codex/automation-harvest-reliability-20260527`
- Source commits: `93d4e37487`, `ac00ec2f88`
- Owner/overlap checks before restack found no active lane and no open PR for the touched script/test surfaces.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/scripts/test_codex_automation_harvest_report.py tests/scripts/test_publish_automation_handoffs.py tests/scripts/test_run_codex_automation_publisher.py -q -p no:cacheprovider`
- `python3 -m ruff check scripts/codex_automation_harvest_report.py scripts/publish_automation_handoffs.py tests/scripts/test_codex_automation_harvest_report.py tests/scripts/test_publish_automation_handoffs.py tests/scripts/test_run_codex_automation_publisher.py`
- `python3 -m ruff format --check scripts/codex_automation_harvest_report.py scripts/publish_automation_handoffs.py tests/scripts/test_codex_automation_harvest_report.py tests/scripts/test_publish_automation_handoffs.py tests/scripts/test_run_codex_automation_publisher.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Notes
- Draft until CI and queue gates settle.
- No merge, ready transition, CI rerun, settlement, handoff archive, or branch-protection mutation is authorized by this PR.
