### PR TITLE
Add read-only handoff state classifier

### DIFF
--- a/docs/superpowers/specs/2026-06-26-reconcile-lane-design.md
+++ b/docs/superpowers/specs/2026-06-26-reconcile-lane-design.md
@@ -138,7 +138,7 @@ There is a confirmed bug: the publisher **never read its pause manifest** (`~/.a
 | Worktree cleanup + guardrails | `scripts/codex_worktree_autopilot.py` (`cleanup`), `scripts/safe_worktree_cleanup.py` | Stage 1 |
 | Worktree value inventory | `scripts/codex_worktree_value_inventory.py` (`classify_candidate`, value classes) | Stage 1/2 evidence |
 | Salvage classifier (discard / auto-PR-candidate / operator-review) | `scripts/harvest_salvage_branches.py` (`_is_trivial_diff`, `_matches_auto_pr_archetype`, `_diff_stat`, `_commit_log`) | Stages 2,4,5 classification only |
-| PR/outbox representation evidence | `scripts/codex_worktree_value_inventory.py --include-pr-state`, `scripts/reconcile_automation_outbox.py`, `scripts/identify_lane_owner.py` | PR-backing / representation evidence (guardrails) |
+| PR/outbox representation evidence | `scripts/classify_handoff_state.py`, `scripts/handoff_state.py`, `scripts/codex_worktree_value_inventory.py --include-pr-state`, `scripts/reconcile_automation_outbox.py`, `scripts/identify_lane_owner.py` | Read-only PR-backing / handoff / owner evidence (guardrails) |
 | Outbox reconcile | `scripts/reconcile_automation_outbox.py` (`--apply`) | settles satisfied handoffs before Cut |
 | Auto-merge decision core | `aragora/swarm/auto_merge_green.py` (`decide_auto_merge`, `apply_merges`), `scripts/auto_merge_quorum_green.py` | Stage 6 |
 | WIP / backpressure | `aragora/swarm/wip_budget.py` (`classify_wip`), `scripts/backlog_gate.py` | Stage 7 |
@@ -212,7 +212,7 @@ Crash safety is inherited from the spine: `MissionState.save` is atomic (`os.rep
 
 ## 8. Testing strategy
 
-- **Temp-repo fixtures with synthetic sprawl.** A fixture builds a throwaway git repo and fabricates the full taxonomy: merged-into-main, `[gone]`, empty-diff, dirty worktree, live-process worktree (sentinel lock file), PR-backing branch, retry-series duplicates, `trivial`/`tiny`/`substantive` branches, and a Tier-0..4 spread of open PRs. No network: `gh`, outbox/owner probes, and the model quorum are injected (the primitives already take injectable list/merge fns — `apply_merges(merge_fn=…)`, `backlog_gate.run_gate(list_prs=…)`, and the inventory/outbox scripts accept cached or fixture-backed data).
+- **Temp-repo fixtures with synthetic sprawl.** A fixture builds a throwaway git repo and fabricates the full taxonomy: merged-into-main, `[gone]`, empty-diff, dirty worktree, live-process worktree (sentinel lock file), PR-backing branch, retry-series duplicates, `trivial`/`tiny`/`substantive` branches, and a Tier-0..4 spread of open PRs. No network: `gh`, outbox/owner probes, and the model quorum are injected (the primitives already take injectable list/merge fns — `apply_merges(merge_fn=…)`, `backlog_gate.run_gate(list_prs=…)`, `classify_handoffs(github_client=…, owner_probe=…)`, and the inventory/outbox scripts accept cached or fixture-backed data).
 - **Dry-run vs apply parity.** For each stage, assert the dry-run **plan** exactly equals the set the `--apply` run mutates (same branches pruned/cut, same PRs merged) — the core safety property. A divergence is a bug.
 - **Guardrail tests.** Assert Prune/Cut **never** touch a dirty / live-process / active-session / PR-backing / preserved / protected-surface / unmerged-commit branch even when it otherwise classifies for removal.
 - **Exact-head deletion tests.** Advance a branch after dry-run/inspection but before apply; assert Prune/Cut skip deletion and emit `needs-human-at-<sha>` or `head_moved`, preserving both the old protected SHA and the new branch tip.

--- a/scripts/classify_handoff_state.py
+++ b/scripts/classify_handoff_state.py
@@ -82,8 +82,9 @@ def _build_parser() -> argparse.ArgumentParser:
         "--fail-on-unsafe-state",
         action="store_true",
         help=(
-            "Exit 2 when classification is unknown, GitHub evidence is unavailable, "
-            "or any item exposes an unsafe mutation candidate."
+            "Compatibility flag. Unsafe classifications now exit 2 by default when "
+            "classification is unknown, GitHub evidence is unavailable, or any item "
+            "exposes an unsafe mutation candidate."
         ),
     )
     return parser
@@ -124,7 +125,7 @@ def main(argv: list[str] | None = None) -> int:
     output = compact_summary(payload) if args.summary_only else payload
     if args.json:
         print(json.dumps(output, indent=2, sort_keys=True))
-        return 2 if args.fail_on_unsafe_state and _has_unsafe_state(payload) else 0
+        return 2 if _has_unsafe_state(payload) else 0
 
     print(f"schema_version: {output['schema_version']}")
     print(f"generated_at: {output['generated_at']}")
@@ -137,7 +138,7 @@ def main(argv: list[str] | None = None) -> int:
         print("items:")
         for item in output.get("items", []):
             print(f"  {item.get('outbox_file')}: {item.get('state')} ({item.get('reason')})")
-    return 2 if args.fail_on_unsafe_state and _has_unsafe_state(payload) else 0
+    return 2 if _has_unsafe_state(payload) else 0
 
 
 if __name__ == "__main__":

--- a/scripts/classify_handoff_state.py
+++ b/scripts/classify_handoff_state.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Classify active Aragora automation handoffs without mutating state."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from handoff_state import (  # noqa: E402
+    DEFAULT_REPO_ROOT,
+    classify_handoffs,
+    compact_summary,
+)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo",
+        type=Path,
+        default=DEFAULT_REPO_ROOT,
+        help="Repository root used for local state and gh cwd (default: current directory).",
+    )
+    parser.add_argument(
+        "--state-root",
+        type=Path,
+        default=None,
+        help=(
+            "Checkout or .aragora directory that owns shared automation state. "
+            "Defaults to --repo/.aragora."
+        ),
+    )
+    parser.add_argument(
+        "--github-repo",
+        default=None,
+        help="GitHub repository in owner/name form. Defaults to remote.origin.url.",
+    )
+    parser.add_argument(
+        "--outbox-file",
+        default=None,
+        help="Classify only this outbox JSON file. Relative names resolve inside automation-outbox.",
+    )
+    parser.add_argument(
+        "--no-github",
+        action="store_true",
+        help="Disable narrow GitHub REST/ref reads and classify from local state only.",
+    )
+    parser.add_argument(
+        "--owner-timeout-seconds",
+        type=int,
+        default=20,
+        help="Timeout for the read-only owner/liveness helper per branch (default: 20).",
+    )
+    parser.add_argument(
+        "--queue-cache-max-age-seconds",
+        type=int,
+        default=1800,
+        help=(
+            "Maximum age for using cached open-PR cap pressure decisions (default: 1800s = 30min)."
+        ),
+    )
+    parser.add_argument(
+        "--with-liveness-helper",
+        action="store_true",
+        help=(
+            "Use identify_lane_owner.py --liveness for each item. Default uses the "
+            "faster local lane registry to keep whole-outbox classification bounded."
+        ),
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON.")
+    parser.add_argument(
+        "--summary-only",
+        action="store_true",
+        help="With --json, omit per-item details and emit compact counts only.",
+    )
+    parser.add_argument(
+        "--fail-on-unsafe-state",
+        action="store_true",
+        help=(
+            "Exit 2 when classification is unknown, GitHub evidence is unavailable, "
+            "or any item exposes an unsafe mutation candidate."
+        ),
+    )
+    return parser
+
+
+def _has_unsafe_state(payload: dict) -> bool:
+    github = payload.get("github") if isinstance(payload.get("github"), dict) else {}
+    if github.get("mode") in {"disabled", "partial"}:
+        return True
+    for item in payload.get("items") or []:
+        if not isinstance(item, dict):
+            return True
+        if item.get("state") in {"unknown", "preserved_not_actionable"}:
+            return True
+        if (
+            item.get("state")
+            in {"represented_by_exact_open_pr", "represented_by_exact_remote_branch"}
+            and item.get("safe_to_mutate") is not True
+        ):
+            return True
+        if item.get("next_mutation_candidate") != "none" and item.get("safe_to_mutate") is not True:
+            return True
+    return False
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    payload = classify_handoffs(
+        repo_root=args.repo,
+        state_root=args.state_root,
+        github_repo=args.github_repo,
+        outbox_file=args.outbox_file,
+        no_github=args.no_github,
+        owner_timeout_seconds=args.owner_timeout_seconds,
+        with_liveness_helper=args.with_liveness_helper,
+        queue_cache_max_age_seconds=args.queue_cache_max_age_seconds,
+    )
+    output = compact_summary(payload) if args.summary_only else payload
+    if args.json:
+        print(json.dumps(output, indent=2, sort_keys=True))
+        return 2 if args.fail_on_unsafe_state and _has_unsafe_state(payload) else 0
+
+    print(f"schema_version: {output['schema_version']}")
+    print(f"generated_at: {output['generated_at']}")
+    print(f"repo: {output['repo']}")
+    print(f"outbox_count: {output['outbox_count']}")
+    print("counts:")
+    for state, count in sorted((output.get("counts") or {}).items()):
+        print(f"  {state}: {count}")
+    if not args.summary_only:
+        print("items:")
+        for item in output.get("items", []):
+            print(f"  {item.get('outbox_file')}: {item.get('state')} ({item.get('reason')})")
+    return 2 if args.fail_on_unsafe_state and _has_unsafe_state(payload) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/handoff_state.py
+++ b/scripts/handoff_state.py
@@ -467,7 +467,12 @@ class LaneRegistryOwnerProbe:
     def probe(self, branch: str) -> OwnerEvidence:
         candidates = [row for row in self.records if str(row.get("branch") or "") == branch]
         if not candidates:
-            return OwnerEvidence(available=True, matched=False, error="no lane matched")
+            return OwnerEvidence(
+                available=True,
+                matched=False,
+                error="no lane matched",
+                source="lane_registry",
+            )
         row = _best_lane_record(candidates)
         status = str(row.get("status") or "").strip().lower()
         blocking_state = str(row.get("owner_blocking_state") or "").strip() or None
@@ -476,6 +481,7 @@ class LaneRegistryOwnerProbe:
         elif blocking_state is None and status in ACTIVE_LANE_STATUSES:
             blocking_state = "unknown_owner"
         evidence = owner_evidence_from_payload(row)
+        evidence.source = evidence.source or "lane_registry"
         evidence.status = status or evidence.status
         evidence.owner_blocking_state = evidence.owner_blocking_state or blocking_state
         evidence.owner_blocking_state_reason = evidence.owner_blocking_state_reason or (
@@ -615,6 +621,7 @@ def classify_handoffs(
     )
     receipts = load_terminal_receipts(receipt_dir)
     outbox_files = _selected_outbox_files(outbox_dir, outbox_file)
+    steering_rows = _steering_message_rows(_state_path(state_root, DEFAULT_STEERING_ROOT))
     gh = github_client or NarrowGitHubClient(
         repo_root=repo_root,
         github_repo=github_repo or "",
@@ -657,6 +664,7 @@ def classify_handoffs(
             github_client=gh,
             owner_probe=owner,
             state_root=state_root,
+            steering_rows=steering_rows,
         )
         gh_error = item.evidence.get("github", {}).get("error")
         if isinstance(gh_error, str) and gh_error:
@@ -698,6 +706,7 @@ def classify_handoff_item(
     github_client: Any,
     owner_probe: Any,
     state_root: Path,
+    steering_rows: Sequence[Mapping[str, Any]] | None = None,
 ) -> HandoffClassification:
     idem = str(payload.get("idempotency_key") or path.stem).strip() or path.stem
     branch = branch_from_payload(payload)
@@ -753,6 +762,7 @@ def classify_handoff_item(
         branch=branch,
         owner_session=owner.owner_session,
         lane_id=owner.lane_id,
+        message_rows=steering_rows,
     )
     evidence["steering"] = dataclasses.asdict(steering)
     if not desired_head and github.open_prs:
@@ -821,6 +831,21 @@ def classify_handoff_item(
                 reason=f"branch has exact-head open PR #{number} but GitHub PR evidence is degraded",
                 evidence=evidence,
             )
+        mutation_guard = _exact_open_pr_mutation_guard(
+            github.exact_open_pr,
+            desired_head,
+            owner,
+        )
+        if mutation_guard:
+            return HandoffClassification(
+                outbox_file=path.name,
+                idempotency_key=idem,
+                branch=branch,
+                desired_head_sha=desired_head or None,
+                state=HandoffState.REPRESENTED_BY_EXACT_OPEN_PR,
+                reason=f"branch has exact-head open PR #{number} but {mutation_guard}",
+                evidence=evidence,
+            )
         return HandoffClassification(
             outbox_file=path.name,
             idempotency_key=idem,
@@ -834,6 +859,7 @@ def classify_handoff_item(
         )
 
     remote_exact_head = _remote_ref_matches(github.remote_ref, desired_head)
+    remote_mutation_guard = _remote_ref_mutation_guard(github.remote_ref, desired_head, owner)
     if remote_exact_head and _possible_unpushed(owner):
         return HandoffClassification(
             outbox_file=path.name,
@@ -968,10 +994,17 @@ def classify_handoff_item(
             branch=branch,
             desired_head_sha=desired_head or None,
             state=HandoffState.REPRESENTED_BY_EXACT_REMOTE_BRANCH,
-            reason="desired head is preserved by exact remote branch",
+            reason=(
+                f"desired head is preserved by exact remote branch but {remote_mutation_guard}"
+                if remote_mutation_guard
+                else "desired head is preserved by exact remote branch"
+            ),
             evidence=evidence,
-            next_mutation_candidate="represent_or_publish_remote_branch",
-            safe_to_mutate=not (
+            next_mutation_candidate=(
+                "none" if remote_mutation_guard else "represent_or_publish_remote_branch"
+            ),
+            safe_to_mutate=remote_mutation_guard is None
+            and not (
                 _possible_unpushed(owner)
                 or _human_blocked(owner, steering)
                 or _owner_blocked(owner, steering)
@@ -1360,13 +1393,16 @@ def steering_evidence_for_branch(
     branch: str,
     owner_session: str | None,
     lane_id: str | None,
+    message_rows: Sequence[Mapping[str, Any]] | None = None,
 ) -> SteeringEvidence:
     root = _state_path(state_root, DEFAULT_STEERING_ROOT)
-    if not root.exists():
+    rows = list(message_rows) if message_rows is not None else _steering_message_rows(root)
+    if not rows:
         return SteeringEvidence()
     matches: list[dict[str, Any]] = []
-    for path in sorted(root.glob("*/*.json")):
-        payload = _load_json(path)
+    for row in rows:
+        path = Path(str(row.get("path") or ""))
+        payload = row.get("payload")
         if not isinstance(payload, dict):
             continue
         to_session = str(payload.get("to_session") or "")
@@ -1386,7 +1422,7 @@ def steering_evidence_for_branch(
             pass
         else:
             continue
-        receipt = latest_read_receipt_for_message(path)
+        receipt = row.get("latest_read_receipt")
         human_detected = _looks_human(payload)
         matches.append(
             {
@@ -1427,6 +1463,24 @@ def steering_evidence_for_branch(
         latest_message=latest,
         latest_read_receipt=latest_receipt,
     )
+
+
+def _steering_message_rows(root: Path) -> list[dict[str, Any]]:
+    if not root.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    for path in sorted(root.glob("*/*.json")):
+        payload = _load_json(path)
+        if not isinstance(payload, dict):
+            continue
+        rows.append(
+            {
+                "path": str(path),
+                "payload": payload,
+                "latest_read_receipt": latest_read_receipt_for_message(path),
+            }
+        )
+    return rows
 
 
 def branch_from_payload(payload: Mapping[str, Any]) -> str:
@@ -1523,17 +1577,17 @@ def local_evidence_conflict_reason(payload: Mapping[str, Any]) -> str | None:
         for record in records
         if str(record.get("branch") or "").strip()
     }
-    heads: list[str] = []
+    head_values: list[str] = []
     for record in records:
         value = _first_text(record, *HEAD_FIELD_KEYS)
-        if value and not any(heads_match(value, existing) for existing in heads):
-            heads.append(value)
+        if value:
+            head_values.append(value)
     bases = {
         _normalize_base_ref(value)
         for record in records
         if (value := _first_text(record, *BASE_FIELD_KEYS))
     }
-    if len(branches) > 1 or len(heads) > 1 or len(bases) > 1:
+    if len(branches) > 1 or _head_values_conflict(head_values) or len(bases) > 1:
         return "multiple local_evidence records disagree on branch, head, or base"
     return None
 
@@ -1606,6 +1660,29 @@ def heads_match(expected: str, actual: str) -> bool:
     return expected_value.startswith(actual_value) or actual_value.startswith(expected_value)
 
 
+def _head_values_conflict(values: Sequence[str]) -> bool:
+    normalized = [str(value or "").strip().lower() for value in values if str(value or "").strip()]
+    full_values = {_full_sha_or_none(value) for value in normalized}
+    full_values.discard(None)
+    if len(full_values) > 1:
+        return True
+    representatives: list[str] = []
+    for value in normalized:
+        if not any(heads_match(value, existing) for existing in representatives):
+            representatives.append(value)
+    return len(representatives) > 1
+
+
+def full_heads_match(expected: str, actual: str) -> bool:
+    expected_value = str(expected or "").strip().lower()
+    actual_value = str(actual or "").strip().lower()
+    return bool(
+        _full_sha_or_none(expected_value)
+        and _full_sha_or_none(actual_value)
+        and expected_value == actual_value
+    )
+
+
 def _full_sha_or_none(value: str) -> str | None:
     return value if re.fullmatch(r"[0-9a-f]{40}", value) else None
 
@@ -1618,6 +1695,32 @@ def _remote_ref_matches(remote_ref: Mapping[str, Any] | None, desired_head: str)
     if not remote_ref or not desired_head:
         return False
     return heads_match(desired_head, str(remote_ref.get("sha") or ""))
+
+
+def _remote_ref_mutation_guard(
+    remote_ref: Mapping[str, Any] | None,
+    desired_head: str,
+    owner: OwnerEvidence,
+) -> str | None:
+    if not full_heads_match(desired_head, str((remote_ref or {}).get("sha") or "")):
+        return "full desired-head SHA does not exactly match the remote branch head"
+    return _owner_probe_mutation_guard(owner)
+
+
+def _exact_open_pr_mutation_guard(
+    exact_open_pr: Mapping[str, Any] | None,
+    desired_head: str,
+    owner: OwnerEvidence,
+) -> str | None:
+    if not full_heads_match(desired_head, str((exact_open_pr or {}).get("head_sha") or "")):
+        return "full desired-head SHA does not exactly match the PR head"
+    return _owner_probe_mutation_guard(owner)
+
+
+def _owner_probe_mutation_guard(owner: OwnerEvidence) -> str | None:
+    if str(owner.source or "") == "lane_registry":
+        return "owner liveness helper was not used for mutation-grade safety"
+    return None
 
 
 def _base_matches(desired_base: str, actual_base: str, *, actual_is_live: bool = False) -> bool:

--- a/scripts/handoff_state.py
+++ b/scripts/handoff_state.py
@@ -1,0 +1,2105 @@
+#!/usr/bin/env python3
+"""Read-only handoff state classifier for Aragora automation outbox items."""
+
+from __future__ import annotations
+
+import dataclasses
+import ast
+import json
+import os
+import re
+import subprocess
+import sys
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+try:  # Works both as ``python scripts/handoff_state.py`` and as ``scripts.handoff_state``.
+    from scripts.github_cli_health import github_cli_env
+except Exception:  # pragma: no cover - script-path fallback
+    try:
+        from github_cli_health import github_cli_env  # type: ignore[no-redef]
+    except Exception:  # pragma: no cover - partially bootstrapped fallback
+
+        def github_cli_env(
+            base_env: Mapping[str, str] | None = None,
+            *,
+            prefer_app: bool = True,
+        ) -> dict[str, str]:
+            return dict(os.environ if base_env is None else base_env)
+
+
+UTC = timezone.utc
+SCHEMA_VERSION = "aragora-handoff-state/1.0"
+
+DEFAULT_REPO_ROOT = Path(".")
+DEFAULT_OUTBOX_DIR = Path(".aragora/automation-outbox")
+DEFAULT_RECEIPT_DIR = Path(".aragora/automation-receipts")
+DEFAULT_STATUS_CACHE = Path(".aragora/automation-github-status/latest.json")
+DEFAULT_LANE_REGISTRY = Path(".aragora/agent-bridge/lanes.json")
+DEFAULT_STEERING_ROOT = Path(".aragora/operator-steering")
+DEFAULT_HEARTBEATS = Path(".aragora/agent-bridge/heartbeats.json")
+DEFAULT_QUEUE_CAP_CACHE_MAX_AGE_SECONDS = 1800
+DEFAULT_PR_BASE = "main"
+URL_PATTERN = re.compile(r"https?://\S+")
+
+TERMINAL_RECEIPT_STATUSES = {"published", "already_satisfied", "completed", "skipped"}
+ACTIVE_LANE_STATUSES = {
+    "acknowledged",
+    "active",
+    "blocked",
+    "blocked_on_publication",
+    "claimed",
+    "pending",
+    "queued",
+    "running",
+    "waiting_for_steering",
+    "working",
+}
+BLOCKING_LANE_STATUSES = {
+    "blocked",
+    "blocked_on_publication",
+    "waiting_for_steering",
+}
+PR_PUBLICATION_ACTIONS = {
+    "open_pr",
+    "open_pull_request",
+    "open_or_update_pr",
+    "open_or_update_pull_request",
+    "push_branch_and_open_pr",
+    "push_branch_and_open_pull_request",
+    "push_branch_and_open_or_update_pr",
+    "push_branch_and_open_or_update_pull_request",
+}
+PR_PUBLICATION_IDEMPOTENCY_PREFIXES = ("open-pr-", "update-pr-")
+HEAD_FIELD_KEYS = (
+    "desired_head_sha",
+    "target_head_sha",
+    "head_sha",
+    "headRefOid",
+    "head_ref_oid",
+    "head",
+    "commit",
+)
+BASE_FIELD_KEYS = (
+    "base",
+    "base_ref",
+    "base_ref_name",
+    "baseRefName",
+    "target_base",
+    "base_branch",
+)
+LOCAL_WORK_MARKER_KEYS = (
+    "uncommitted_changes",
+    "has_uncommitted_changes",
+    "uncommitted",
+    "unpushed_commits",
+    "local_changes",
+    "local_work",
+    "dirty",
+)
+OWNER_WORK_MARKER_KEYS = (
+    *LOCAL_WORK_MARKER_KEYS,
+    "dirty_worktree",
+    "branch_ahead",
+    "branch_ahead_of_origin_main",
+    "has_unique_commits",
+    "unique_commits",
+    "worktree_dirty",
+)
+LOCAL_WORK_FALSE_MARKER_VALUES = frozenset(
+    (
+        "0",
+        "clean",
+        "false",
+        "no",
+        "none",
+        "verified-clean",
+        "verified_clean",
+    )
+)
+LOCAL_WORK_TRUE_MARKER_VALUES = frozenset(
+    (
+        "1",
+        "ahead",
+        "branch_ahead",
+        "dirty",
+        "local_work",
+        "possible_unpushed_work",
+        "true",
+        "uncommitted",
+        "uncommitted_changes",
+        "unpushed",
+        "unpushed_commits",
+        "yes",
+    )
+)
+
+
+class HandoffState(str, Enum):
+    PUBLICATION_REQUESTED = "publication_requested"
+    REPRESENTED_BY_EXACT_OPEN_PR = "represented_by_exact_open_pr"
+    REPRESENTED_BY_EXACT_REMOTE_BRANCH = "represented_by_exact_remote_branch"
+    BLOCKED_BY_OWNER = "blocked_by_owner"
+    BLOCKED_BY_HUMAN = "blocked_by_human"
+    BLOCKED_BY_POSSIBLE_UNPUSHED_WORK = "blocked_by_possible_unpushed_work"
+    BLOCKED_BY_LIVE_QUEUE_CAP = "blocked_by_live_queue_cap"
+    PRESERVED_NOT_ACTIONABLE = "preserved_not_actionable"
+    UNKNOWN = "unknown"
+
+
+@dataclass
+class GitHubEvidence:
+    mode: str
+    error: str | None = None
+    open_prs: list[dict[str, Any]] = field(default_factory=list)
+    exact_open_pr: dict[str, Any] | None = None
+    remote_ref: dict[str, Any] | None = None
+
+
+@dataclass
+class ReceiptEvidence:
+    status: str | None = None
+    reason: str | None = None
+    has_pr_reference: bool = False
+    has_issue_reference: bool = False
+    issue_only_pr_receipt: bool = False
+    path: str | None = None
+    target_pr: int | None = None
+
+
+@dataclass
+class OwnerEvidence:
+    available: bool = False
+    matched: bool = False
+    error: str | None = None
+    lane_id: str | None = None
+    owner_session: str | None = None
+    source: str | None = None
+    status: str | None = None
+    owner_state: str | None = None
+    owner_blocking_state: str | None = None
+    owner_blocking_state_reason: str | None = None
+    advisory_withheld: str | None = None
+    stale_claim_available: bool | None = None
+    payload: dict[str, Any] | None = None
+
+
+@dataclass
+class SteeringEvidence:
+    pending_message_count: int = 0
+    blocking_message_count: int = 0
+    resolved_read_receipt_count: int = 0
+    human_message_count: int = 0
+    latest_message: dict[str, Any] | None = None
+    latest_read_receipt: dict[str, Any] | None = None
+    ack_protocol: str = "top_level_message_remains_pending"
+
+
+@dataclass
+class QueueCapEvidence:
+    available: bool = False
+    github_queue_available: bool | None = None
+    degraded: bool | None = None
+    degraded_reason: str | None = None
+    open_pr_cap_reached: bool | None = None
+    raw_open_pr_cap_reached: bool | None = None
+    open_codex_pr_count: int | None = None
+    max_open_prs: int | None = None
+    generated_at: str | None = None
+    cache_age_seconds: float | None = None
+    cache_stale: bool | None = None
+    cache_stale_threshold_seconds: int | None = None
+    decision_source: str | None = None
+
+
+@dataclass
+class HandoffClassification:
+    outbox_file: str
+    idempotency_key: str | None
+    branch: str | None
+    desired_head_sha: str | None
+    state: HandoffState
+    reason: str
+    evidence: dict[str, Any]
+    next_mutation_candidate: str = "none"
+    safe_to_mutate: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "outbox_file": self.outbox_file,
+            "idempotency_key": self.idempotency_key,
+            "branch": self.branch,
+            "desired_head_sha": self.desired_head_sha,
+            "state": self.state.value,
+            "reason": self.reason,
+            "evidence": self.evidence,
+            "next_mutation_candidate": self.next_mutation_candidate,
+            "safe_to_mutate": self.safe_to_mutate,
+        }
+
+
+class NarrowGitHubClient:
+    """Narrow REST-only GitHub reader.
+
+    This intentionally uses exact branch/ref endpoints and never calls GraphQL
+    or mutating gh commands.
+    """
+
+    def __init__(
+        self,
+        *,
+        repo_root: Path,
+        github_repo: str,
+        disabled: bool = False,
+        timeout_seconds: int = 20,
+    ) -> None:
+        self.repo_root = repo_root
+        self.github_repo = github_repo
+        self.disabled = disabled
+        self.timeout_seconds = timeout_seconds
+        self._pr_cache: dict[str, tuple[list[dict[str, Any]] | None, str | None]] = {}
+        self._pr_number_cache: dict[int, tuple[dict[str, Any] | None, str | None]] = {}
+        self._ref_cache: dict[str, tuple[dict[str, Any] | None, str | None]] = {}
+
+    @property
+    def mode(self) -> str:
+        if self.disabled:
+            return "disabled"
+        return "ready"
+
+    def open_prs_for_branch(self, branch: str) -> tuple[list[dict[str, Any]] | None, str | None]:
+        if self.disabled:
+            return None, "github disabled"
+        if branch in self._pr_cache:
+            return self._pr_cache[branch]
+        owner, repo_error = _github_repo_owner(self.github_repo)
+        if repo_error is not None:
+            result = (None, repo_error)
+            self._pr_cache[branch] = result
+            return result
+        head = f"{owner}:{quote(branch, safe='')}"
+        per_page = 100
+        items: list[dict[str, Any]] = []
+        result: tuple[list[dict[str, Any]] | None, str | None]
+        max_pages = 20
+        for page in range(1, max_pages + 1):
+            endpoint = (
+                f"repos/{self.github_repo}/pulls?state=open&head={head}"
+                f"&per_page={per_page}&page={page}"
+            )
+            payload, error = self._api(endpoint)
+            if error is not None:
+                result = (None, error)
+                break
+            if not isinstance(payload, list):
+                result = (None, "open PR REST response was not a list")
+                break
+            items.extend(item for item in payload if isinstance(item, dict))
+            if len(payload) < per_page:
+                result = (items, None)
+                break
+        else:
+            result = (
+                None,
+                f"open PR REST page cap reached after {max_pages} pages for exact branch",
+            )
+        self._pr_cache[branch] = result
+        return result
+
+    def open_pr_by_number(self, pr_number: int) -> tuple[dict[str, Any] | None, str | None]:
+        if self.disabled:
+            return None, "github disabled"
+        if pr_number in self._pr_number_cache:
+            return self._pr_number_cache[pr_number]
+        _, repo_error = _github_repo_owner(self.github_repo)
+        if repo_error is not None:
+            result = (None, repo_error)
+            self._pr_number_cache[pr_number] = result
+            return result
+        payload, error = self._api(f"repos/{self.github_repo}/pulls/{pr_number}")
+        if error is not None and _github_not_found_error(error):
+            result = (None, None)
+        elif error is not None:
+            result = (None, error)
+        elif not isinstance(payload, dict):
+            result = (None, "target PR REST response was not a mapping")
+        else:
+            result = (payload, None)
+        self._pr_number_cache[pr_number] = result
+        return result
+
+    def remote_ref(self, branch: str) -> tuple[dict[str, Any] | None, str | None]:
+        if self.disabled:
+            return None, "github disabled"
+        if branch in self._ref_cache:
+            return self._ref_cache[branch]
+        _, repo_error = _github_repo_owner(self.github_repo)
+        if repo_error is not None:
+            result = (None, repo_error)
+            self._ref_cache[branch] = result
+            return result
+        endpoint = f"repos/{self.github_repo}/git/ref/heads/{quote(branch, safe='/')}"
+        payload, error = self._api(endpoint)
+        if error is not None and _github_not_found_error(error):
+            result = (None, None)
+        elif error is not None:
+            result = (None, error)
+        elif not isinstance(payload, dict):
+            result = (None, "ref REST response was not a mapping")
+        else:
+            result = (payload, None)
+        self._ref_cache[branch] = result
+        return result
+
+    def _api(self, endpoint: str) -> tuple[Any | None, str | None]:
+        try:
+            proc = subprocess.run(
+                ["gh", "api", endpoint],
+                cwd=self.repo_root,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=self.timeout_seconds,
+                env=github_cli_env(os.environ),
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            return None, f"gh api failed ({exc.__class__.__name__})"
+        if proc.returncode != 0:
+            detail = (proc.stderr or "").strip().splitlines()
+            message = detail[0] if detail else ""
+            prefix = "github_not_found: " if _gh_stderr_is_not_found(message) else ""
+            return None, f"{prefix}gh api exited {proc.returncode}: {message}"
+        try:
+            return json.loads(proc.stdout), None
+        except json.JSONDecodeError:
+            return None, "gh api returned unparseable JSON"
+
+
+class OwnerProbe:
+    """Read-only owner/liveness probe via the existing supported helper."""
+
+    def __init__(self, *, repo_root: Path, state_root: Path, timeout_seconds: int = 20) -> None:
+        self.repo_root = repo_root
+        self.state_root = _as_aragora_root(state_root)
+        self.timeout_seconds = timeout_seconds
+        self._cache: dict[str, OwnerEvidence] = {}
+
+    def probe(self, branch: str) -> OwnerEvidence:
+        if branch in self._cache:
+            return self._cache[branch]
+        registry = self.state_root / "agent-bridge" / "lanes.json"
+        steering_root = self.state_root / "operator-steering"
+        heartbeat_path = self.state_root / "agent-bridge" / "heartbeats.json"
+        script = self.repo_root / "scripts" / "identify_lane_owner.py"
+        cmd = [
+            sys.executable,
+            str(script),
+            "--branch",
+            branch,
+            "--liveness",
+            "--json",
+            "--registry-path",
+            str(registry),
+            "--steering-inbox-root",
+            str(steering_root),
+            "--heartbeat-path",
+            str(heartbeat_path),
+        ]
+        try:
+            proc = subprocess.run(
+                cmd,
+                cwd=self.repo_root,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=self.timeout_seconds,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            result = OwnerEvidence(
+                available=False, error=f"owner probe failed ({exc.__class__.__name__})"
+            )
+            self._cache[branch] = result
+            return result
+        if proc.returncode != 0:
+            message = (proc.stderr or proc.stdout or "").strip().splitlines()
+            text = message[0] if message else f"identify_lane_owner exited {proc.returncode}"
+            no_match = _owner_probe_no_match(text)
+            result = OwnerEvidence(
+                available=no_match,
+                matched=False,
+                error=text,
+            )
+            self._cache[branch] = result
+            return result
+        try:
+            payload = json.loads(proc.stdout)
+        except json.JSONDecodeError:
+            result = OwnerEvidence(available=False, error="owner probe returned unparseable JSON")
+            self._cache[branch] = result
+            return result
+        if not isinstance(payload, dict):
+            result = OwnerEvidence(available=False, error="owner probe returned non-mapping JSON")
+            self._cache[branch] = result
+            return result
+        result = owner_evidence_from_payload(payload)
+        self._cache[branch] = result
+        return result
+
+
+class LaneRegistryOwnerProbe:
+    """Fast read-only owner probe from the shared lane registry.
+
+    This is intentionally less deep than identify_lane_owner.py --liveness, but
+    it is enough to keep whole-outbox classification bounded and deterministic.
+    Focused runs can still opt into the supported liveness helper.
+    """
+
+    def __init__(self, *, state_root: Path) -> None:
+        self.state_root = _as_aragora_root(state_root)
+        self.records = _load_lane_records(self.state_root / "agent-bridge" / "lanes.json")
+
+    def probe(self, branch: str) -> OwnerEvidence:
+        candidates = [row for row in self.records if str(row.get("branch") or "") == branch]
+        if not candidates:
+            return OwnerEvidence(available=True, matched=False, error="no lane matched")
+        row = _best_lane_record(candidates)
+        status = str(row.get("status") or "").strip().lower()
+        blocking_state = str(row.get("owner_blocking_state") or "").strip() or None
+        if blocking_state is None and status in BLOCKING_LANE_STATUSES:
+            blocking_state = "unknown_owner"
+        elif blocking_state is None and status in ACTIVE_LANE_STATUSES:
+            blocking_state = "unknown_owner"
+        evidence = owner_evidence_from_payload(row)
+        evidence.status = status or evidence.status
+        evidence.owner_blocking_state = evidence.owner_blocking_state or blocking_state
+        evidence.owner_blocking_state_reason = evidence.owner_blocking_state_reason or (
+            _lane_registry_blocking_reason(status, blocking_state) if blocking_state else None
+        )
+        evidence.advisory_withheld = evidence.advisory_withheld or _possible_unpushed_marker(row)
+        return evidence
+
+
+def owner_evidence_from_payload(payload: Mapping[str, Any]) -> OwnerEvidence:
+    advisory = payload.get("stale_claim_advisory")
+    available = None
+    if isinstance(advisory, Mapping):
+        available = bool(advisory.get("available"))
+    owner_session = _first_text(payload, "owner_session", "session", "to_session")
+    lane_id = _first_text(payload, "lane_id", "lane")
+    return OwnerEvidence(
+        available=True,
+        matched=True,
+        lane_id=lane_id,
+        owner_session=owner_session,
+        source=_first_text(payload, "source"),
+        status=_first_text(payload, "status", "lane_status"),
+        owner_state=_first_text(payload, "owner_state", "assessed"),
+        owner_blocking_state=_first_text(payload, "owner_blocking_state"),
+        owner_blocking_state_reason=_first_text(payload, "owner_blocking_state_reason"),
+        advisory_withheld=_first_text(payload, "advisory_withheld")
+        or _possible_unpushed_marker(payload, marker_keys=OWNER_WORK_MARKER_KEYS),
+        stale_claim_available=available,
+        payload=_owner_payload_summary(payload),
+    )
+
+
+def _possible_unpushed_marker(
+    payload: Mapping[str, Any],
+    *,
+    marker_keys: Sequence[str] = LOCAL_WORK_MARKER_KEYS,
+) -> str | None:
+    if _first_text(payload, "advisory_withheld") == "possible_unpushed_work":
+        return "possible_unpushed_work"
+    for key in (
+        "owner_blocking_state_reason",
+        "withheld_reason",
+        "cleanup_state",
+        "decision",
+    ):
+        value = str(payload.get(key) or "").strip().lower()
+        if value == "possible_unpushed_work" or "possible unpushed work" in value:
+            return "possible_unpushed_work"
+    for key in marker_keys:
+        value = payload.get(key)
+        if value is True:
+            return "possible_unpushed_work"
+        if isinstance(value, int) and value > 0:
+            return "possible_unpushed_work"
+        if isinstance(value, str):
+            string_marker = _local_work_string_marker(value)
+            if string_marker is True:
+                return "possible_unpushed_work"
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)) and value:
+            return "possible_unpushed_work"
+    for key in ("stale_claim_advisory", "owner_liveness", "cleanup_safety"):
+        value = payload.get(key)
+        if isinstance(value, Mapping) and _possible_unpushed_marker(value, marker_keys=marker_keys):
+            return "possible_unpushed_work"
+    advisory = payload.get("stale_claim_advisory")
+    if isinstance(advisory, Mapping) and advisory.get("available") is True:
+        return None
+    return None
+
+
+def _local_work_string_marker(value: str) -> bool:
+    normalized = str(value or "").strip().lower().replace(" ", "_")
+    if not normalized:
+        return False
+    if normalized in LOCAL_WORK_FALSE_MARKER_VALUES:
+        return False
+    if normalized in LOCAL_WORK_TRUE_MARKER_VALUES:
+        return True
+    return True
+
+
+def _owner_payload_summary(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Keep classifier evidence useful without exposing local session internals."""
+
+    summary: dict[str, Any] = {}
+    for key in (
+        "lane_id",
+        "branch",
+        "status",
+        "owner_state",
+        "owner_blocking_state",
+        "owner_blocking_state_reason",
+        "advisory_withheld",
+        "updated_at",
+        "last_heartbeat_at",
+    ):
+        value = payload.get(key)
+        if value not in (None, ""):
+            summary[key] = value
+    advisory = payload.get("stale_claim_advisory")
+    if isinstance(advisory, Mapping):
+        compact = {
+            key: advisory.get(key)
+            for key in ("available", "protocol", "reason")
+            if advisory.get(key) not in (None, "")
+        }
+        if compact:
+            summary["stale_claim_advisory"] = compact
+    return summary
+
+
+def classify_handoffs(
+    *,
+    repo_root: Path,
+    state_root: Path | None = None,
+    github_repo: str | None = None,
+    outbox_file: str | Path | None = None,
+    no_github: bool = False,
+    owner_timeout_seconds: int = 20,
+    github_timeout_seconds: int = 20,
+    with_liveness_helper: bool = False,
+    queue_cache_max_age_seconds: int = DEFAULT_QUEUE_CAP_CACHE_MAX_AGE_SECONDS,
+    github_client: Any | None = None,
+    owner_probe: Any | None = None,
+) -> dict[str, Any]:
+    repo_root = repo_root.expanduser().resolve()
+    state_root = resolve_state_root(repo_root=repo_root, state_root=state_root)
+    github_repo = github_repo or _github_repo_from_origin(repo_root)
+    outbox_dir = _state_path(state_root, DEFAULT_OUTBOX_DIR)
+    receipt_dir = _state_path(state_root, DEFAULT_RECEIPT_DIR)
+    status_cache_path = _state_path(state_root, DEFAULT_STATUS_CACHE)
+
+    queue_cap = load_queue_cap_evidence(
+        status_cache_path,
+        max_age_seconds=queue_cache_max_age_seconds,
+    )
+    receipts = load_terminal_receipts(receipt_dir)
+    outbox_files = _selected_outbox_files(outbox_dir, outbox_file)
+    gh = github_client or NarrowGitHubClient(
+        repo_root=repo_root,
+        github_repo=github_repo or "",
+        disabled=no_github or github_repo is None,
+        timeout_seconds=github_timeout_seconds,
+    )
+    if owner_probe is not None:
+        owner = owner_probe
+    elif with_liveness_helper:
+        owner = OwnerProbe(
+            repo_root=repo_root,
+            state_root=state_root,
+            timeout_seconds=owner_timeout_seconds,
+        )
+    else:
+        owner = LaneRegistryOwnerProbe(state_root=state_root)
+
+    items: list[HandoffClassification] = []
+    github_errors: list[str] = []
+    for path in outbox_files:
+        payload = _load_json(path)
+        if not isinstance(payload, dict):
+            items.append(
+                HandoffClassification(
+                    outbox_file=path.name,
+                    idempotency_key=path.stem,
+                    branch=None,
+                    desired_head_sha=None,
+                    state=HandoffState.UNKNOWN,
+                    reason="outbox file is missing or unparseable",
+                    evidence={},
+                )
+            )
+            continue
+        item = classify_handoff_item(
+            path=path,
+            payload=payload,
+            receipt=receipts.get(str(payload.get("idempotency_key") or path.stem).strip()),
+            queue_cap=queue_cap,
+            github_client=gh,
+            owner_probe=owner,
+            state_root=state_root,
+        )
+        gh_error = item.evidence.get("github", {}).get("error")
+        if isinstance(gh_error, str) and gh_error:
+            github_errors.append(gh_error)
+        items.append(item)
+
+    counts = Counter(item.state.value for item in items)
+    github_mode = (
+        "disabled" if getattr(gh, "disabled", False) else ("partial" if github_errors else "ready")
+    )
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "repo": str(repo_root),
+        "state_root": str(state_root),
+        "github_repo": github_repo,
+        "outbox_dir": str(outbox_dir),
+        "receipt_dir": str(receipt_dir),
+        "outbox_count": len(items),
+        "counts": dict(sorted(counts.items())),
+        "github": {
+            "mode": github_mode,
+            "error": github_errors[0] if github_errors else None,
+            "item_error_count": len(github_errors),
+            "partial_degradation": bool(github_errors) and not getattr(gh, "disabled", False),
+        },
+        "queue_cap": dataclasses.asdict(queue_cap),
+        "items": [item.to_dict() for item in items],
+    }
+    return payload
+
+
+def classify_handoff_item(
+    *,
+    path: Path,
+    payload: Mapping[str, Any],
+    receipt: Mapping[str, Any] | None,
+    queue_cap: QueueCapEvidence,
+    github_client: Any,
+    owner_probe: Any,
+    state_root: Path,
+) -> HandoffClassification:
+    idem = str(payload.get("idempotency_key") or path.stem).strip() or path.stem
+    branch = branch_from_payload(payload)
+    desired_head = desired_head_from_payload(payload)
+    desired_base = desired_base_from_payload(payload)
+    receipt_evidence = receipt_evidence_from_payload(receipt, payload)
+
+    evidence: dict[str, Any] = {
+        "receipt": dataclasses.asdict(receipt_evidence),
+        "queue_cap": dataclasses.asdict(queue_cap),
+    }
+    local_conflict_reason = local_evidence_conflict_reason(payload)
+    if local_conflict_reason is not None:
+        evidence["local_evidence"] = {
+            "record_count": len(_local_evidence_mappings(payload.get("local_evidence"))),
+            "conflict": local_conflict_reason,
+        }
+        return HandoffClassification(
+            outbox_file=path.name,
+            idempotency_key=idem,
+            branch=branch or None,
+            desired_head_sha=desired_head or None,
+            state=HandoffState.UNKNOWN,
+            reason=local_conflict_reason,
+            evidence=evidence,
+        )
+    if not branch:
+        return HandoffClassification(
+            outbox_file=path.name,
+            idempotency_key=idem,
+            branch=None,
+            desired_head_sha=desired_head or None,
+            state=HandoffState.UNKNOWN,
+            reason="outbox payload has no branch",
+            evidence=evidence,
+        )
+
+    github = github_evidence_for_branch(
+        github_client,
+        branch,
+        desired_head,
+        desired_base,
+        target_pr=receipt_evidence.target_pr,
+    )
+    evidence["github"] = dataclasses.asdict(github)
+    owner = owner_probe.probe(branch) if branch else OwnerEvidence()
+    local_work_marker = _payload_possible_unpushed_marker(payload)
+    if local_work_marker and owner.advisory_withheld is None:
+        owner = dataclasses.replace(owner, advisory_withheld=local_work_marker)
+    evidence["owner"] = dataclasses.asdict(owner)
+    steering = steering_evidence_for_branch(
+        state_root=state_root,
+        branch=branch,
+        owner_session=owner.owner_session,
+        lane_id=owner.lane_id,
+    )
+    evidence["steering"] = dataclasses.asdict(steering)
+    if not desired_head and github.open_prs:
+        return HandoffClassification(
+            outbox_file=path.name,
+            idempotency_key=idem,
+            branch=branch,
+            desired_head_sha=None,
+            state=HandoffState.UNKNOWN,
+            reason="branch has open PR(s) but handoff has no desired head to verify",
+            evidence=evidence,
+        )
+
+    if github.exact_open_pr is not None:
+        number = github.exact_open_pr.get("number")
+        if _possible_unpushed(owner):
+            return HandoffClassification(
+                outbox_file=path.name,
+                idempotency_key=idem,
+                branch=branch,
+                desired_head_sha=desired_head or None,
+                state=HandoffState.BLOCKED_BY_POSSIBLE_UNPUSHED_WORK,
+                reason=f"branch has exact-head open PR #{number} but possible unpushed work exists",
+                evidence=evidence,
+                next_mutation_candidate="owner_preservation_request",
+            )
+        if _human_blocked(owner, steering):
+            return HandoffClassification(
+                outbox_file=path.name,
+                idempotency_key=idem,
+                branch=branch,
+                desired_head_sha=desired_head or None,
+                state=HandoffState.BLOCKED_BY_HUMAN,
+                reason=f"branch has exact-head open PR #{number} but human gate remains",
+                evidence=evidence,
+                next_mutation_candidate="human_gate",
+            )
+        if _owner_blocked(owner, steering):
+            return HandoffClassification(
+                outbox_file=path.name,
+                idempotency_key=idem,
+                branch=branch,
+                desired_head_sha=desired_head or None,
+                state=HandoffState.BLOCKED_BY_OWNER,
+                reason=f"branch has exact-head open PR #{number} but owner gate remains",
+                evidence=evidence,
+                next_mutation_candidate="owner_followup",
+            )
+        if github.exact_open_pr.get("draft") is True:
+            return HandoffClassification(
+                outbox_file=path.name,
+                idempotency_key=idem,
+                branch=branch,
+                desired_head_sha=desired_head or None,
+                state=HandoffState.REPRESENTED_BY_EXACT_OPEN_PR,
+                reason=f"branch has exact-head draft open PR #{number}",
+                evidence=evidence,
+            )
+        if github.mode != "ready":
+            return HandoffClassification(
+                outbox_file=path.name,
+                idempotency_key=idem,
+                branch=branch,
+                desired_head_sha=desired_head or None,
+                state=HandoffState.REPRESENTED_BY_EXACT_OPEN_PR,
+                reason=f"branch has exact-head open PR #{number} but GitHub PR evidence is degraded",
+                evidence=evidence,
+            )
+        return HandoffClassification(
+            outbox_file=path.name,
+            idempotency_key=idem,
+            branch=branch,
+            desired_head_sha=desired_head or None,
+            state=HandoffState.REPRESENTED_BY_EXACT_OPEN_PR,
+            reason=f"branch has exact-head open PR #{number}",
+            evidence=evidence,
+            next_mutation_candidate="write_representation_receipt_then_archive",
+            safe_to_mutate=True,
+        )
+
+    remote_exact_head = _remote_ref_matches(github.remote_ref, desired_head)
+    if remote_exact_head and _possible_unpushed(owner):
+        return HandoffClassification(
+            outbox_file=path.name,
+            idempotency_key=idem,
+            branch=branch,
+            desired_head_sha=desired_head or None,
+            state=HandoffState.BLOCKED_BY_POSSIBLE_UNPUSHED_WORK,
+            reason="desired head is preserved by exact remote branch but possible unpushed work exists",
+            evidence=evidence,
+            next_mutation_candidate="owner_preservation_request",
+        )
+
+    if remote_exact_head:
+        if _human_blocked(owner, steering):
+            return HandoffClassification(
+                outbox_file=path.name,
+                idempotency_key=idem,
+                branch=branch,
+                desired_head_sha=desired_head or None,
+                state=HandoffState.BLOCKED_BY_HUMAN,
+                reason="desired head is preserved by exact remote branch but human gate remains",
+                evidence=evidence,
+                next_mutation_candidate="human_gate",
+            )
+        if _owner_blocked(owner, steering):
+            return HandoffClassification(
+                outbox_file=path.name,
+                idempotency_key=idem,
+                branch=branch,
+                desired_head_sha=desired_head or None,
+                state=HandoffState.BLOCKED_BY_OWNER,
+                reason="desired head is preserved by exact remote branch but owner gate remains",
+                evidence=evidence,
+                next_mutation_candidate="owner_followup",
+            )
+        if github.mode in {"degraded", "disabled"}:
+            return HandoffClassification(
+                outbox_file=path.name,
+                idempotency_key=idem,
+                branch=branch,
+                desired_head_sha=desired_head or None,
+                state=HandoffState.UNKNOWN,
+                reason="GitHub PR evidence is unavailable; cannot prove absence of exact open PR",
+                evidence=evidence,
+            )
+        if github.open_prs:
+            if is_pr_publication_request(payload):
+                if queue_cap.open_pr_cap_reached:
+                    return HandoffClassification(
+                        outbox_file=path.name,
+                        idempotency_key=idem,
+                        branch=branch,
+                        desired_head_sha=desired_head or None,
+                        state=HandoffState.BLOCKED_BY_LIVE_QUEUE_CAP,
+                        reason="remote branch is exact but existing open PR is not exact and open PR cap is reached",
+                        evidence=evidence,
+                        next_mutation_candidate="queue_drain",
+                    )
+                if _queue_cap_uncertain_for_publication(queue_cap):
+                    return HandoffClassification(
+                        outbox_file=path.name,
+                        idempotency_key=idem,
+                        branch=branch,
+                        desired_head_sha=desired_head or None,
+                        state=HandoffState.UNKNOWN,
+                        reason=(
+                            "remote branch is exact but queue-cap evidence is stale or unavailable; "
+                            "cannot prove publication is safe"
+                        ),
+                        evidence=evidence,
+                    )
+                return HandoffClassification(
+                    outbox_file=path.name,
+                    idempotency_key=idem,
+                    branch=branch,
+                    desired_head_sha=desired_head or None,
+                    state=HandoffState.PUBLICATION_REQUESTED,
+                    reason="remote branch is exact but existing open PR head does not match desired head",
+                    evidence=evidence,
+                    next_mutation_candidate="publish_or_represent_pr",
+                )
+            return HandoffClassification(
+                outbox_file=path.name,
+                idempotency_key=idem,
+                branch=branch,
+                desired_head_sha=desired_head or None,
+                state=HandoffState.UNKNOWN,
+                reason=(
+                    "remote branch is exact but existing open PR head does not match desired head; "
+                    "manual reconciliation is required before treating the branch as preserved"
+                ),
+                evidence=evidence,
+            )
+        if queue_cap.open_pr_cap_reached and is_pr_publication_request(payload):
+            return HandoffClassification(
+                outbox_file=path.name,
+                idempotency_key=idem,
+                branch=branch,
+                desired_head_sha=desired_head or None,
+                state=HandoffState.BLOCKED_BY_LIVE_QUEUE_CAP,
+                reason="remote branch is exact but live cache reports open PR cap reached",
+                evidence=evidence,
+                next_mutation_candidate="queue_drain",
+            )
+        if _queue_cap_uncertain_for_publication(queue_cap) and is_pr_publication_request(payload):
+            return HandoffClassification(
+                outbox_file=path.name,
+                idempotency_key=idem,
+                branch=branch,
+                desired_head_sha=desired_head or None,
+                state=HandoffState.UNKNOWN,
+                reason=(
+                    "remote branch is exact but queue-cap evidence is stale or unavailable; "
+                    "cannot prove publication is safe"
+                ),
+                evidence=evidence,
+            )
+        if is_pr_publication_request(payload):
+            return HandoffClassification(
+                outbox_file=path.name,
+                idempotency_key=idem,
+                branch=branch,
+                desired_head_sha=desired_head or None,
+                state=HandoffState.PUBLICATION_REQUESTED,
+                reason="remote branch is exact but PR publication remains requested",
+                evidence=evidence,
+                next_mutation_candidate="publish_or_represent_pr",
+            )
+        return HandoffClassification(
+            outbox_file=path.name,
+            idempotency_key=idem,
+            branch=branch,
+            desired_head_sha=desired_head or None,
+            state=HandoffState.REPRESENTED_BY_EXACT_REMOTE_BRANCH,
+            reason="desired head is preserved by exact remote branch",
+            evidence=evidence,
+            next_mutation_candidate="represent_or_publish_remote_branch",
+            safe_to_mutate=not (
+                _possible_unpushed(owner)
+                or _human_blocked(owner, steering)
+                or _owner_blocked(owner, steering)
+            ),
+        )
+
+    if _terminal_receipt_satisfied(receipt_evidence):
+        return HandoffClassification(
+            outbox_file=path.name,
+            idempotency_key=idem,
+            branch=branch,
+            desired_head_sha=desired_head or None,
+            state=HandoffState.UNKNOWN,
+            reason="terminal receipt exists but live PR/ref representation is not proven",
+            evidence=evidence,
+        )
+
+    if _possible_unpushed(owner):
+        return HandoffClassification(
+            outbox_file=path.name,
+            idempotency_key=idem,
+            branch=branch,
+            desired_head_sha=desired_head or None,
+            state=HandoffState.BLOCKED_BY_POSSIBLE_UNPUSHED_WORK,
+            reason="owner liveness withholds advisory because possible unpushed work exists",
+            evidence=evidence,
+            next_mutation_candidate="owner_preservation_request",
+        )
+
+    if _human_blocked(owner, steering):
+        return HandoffClassification(
+            outbox_file=path.name,
+            idempotency_key=idem,
+            branch=branch,
+            desired_head_sha=desired_head or None,
+            state=HandoffState.BLOCKED_BY_HUMAN,
+            reason="handoff is gated by a human owner or human-directed steering",
+            evidence=evidence,
+            next_mutation_candidate="human_gate",
+        )
+
+    if not remote_exact_head and _owner_blocked(owner, steering):
+        return HandoffClassification(
+            outbox_file=path.name,
+            idempotency_key=idem,
+            branch=branch,
+            desired_head_sha=desired_head or None,
+            state=HandoffState.BLOCKED_BY_OWNER,
+            reason="handoff has an owner/lane blocker and no exact representation proof",
+            evidence=evidence,
+            next_mutation_candidate="owner_followup",
+        )
+
+    if queue_cap.open_pr_cap_reached and is_pr_publication_request(payload):
+        return HandoffClassification(
+            outbox_file=path.name,
+            idempotency_key=idem,
+            branch=branch,
+            desired_head_sha=desired_head or None,
+            state=HandoffState.BLOCKED_BY_LIVE_QUEUE_CAP,
+            reason="publication requested but live cache reports open PR cap reached",
+            evidence=evidence,
+            next_mutation_candidate="queue_drain",
+        )
+
+    if _queue_cap_uncertain_for_publication(queue_cap) and is_pr_publication_request(payload):
+        return HandoffClassification(
+            outbox_file=path.name,
+            idempotency_key=idem,
+            branch=branch,
+            desired_head_sha=desired_head or None,
+            state=HandoffState.UNKNOWN,
+            reason="publication requested but queue-cap evidence is stale or unavailable",
+            evidence=evidence,
+        )
+
+    if github.mode in {"degraded", "disabled"} and is_pr_publication_request(payload):
+        return HandoffClassification(
+            outbox_file=path.name,
+            idempotency_key=idem,
+            branch=branch,
+            desired_head_sha=desired_head or None,
+            state=HandoffState.UNKNOWN,
+            reason="GitHub evidence is unavailable; cannot prove absence of exact open PR/ref",
+            evidence=evidence,
+        )
+
+    if receipt_evidence.issue_only_pr_receipt:
+        return HandoffClassification(
+            outbox_file=path.name,
+            idempotency_key=idem,
+            branch=branch,
+            desired_head_sha=desired_head or None,
+            state=HandoffState.PUBLICATION_REQUESTED,
+            reason="PR-intended handoff has issue-only receipt; PR representation still requested",
+            evidence=evidence,
+            next_mutation_candidate="publish_or_represent_pr",
+        )
+
+    if is_pr_publication_request(payload):
+        return HandoffClassification(
+            outbox_file=path.name,
+            idempotency_key=idem,
+            branch=branch,
+            desired_head_sha=desired_head or None,
+            state=HandoffState.PUBLICATION_REQUESTED,
+            reason="PR publication remains requested and no stronger representation/blocker matched",
+            evidence=evidence,
+            next_mutation_candidate="publish_or_represent_pr",
+        )
+
+    if github.remote_ref is not None:
+        return HandoffClassification(
+            outbox_file=path.name,
+            idempotency_key=idem,
+            branch=branch,
+            desired_head_sha=desired_head or None,
+            state=HandoffState.PRESERVED_NOT_ACTIONABLE,
+            reason="remote branch exists but exact desired-head representation is not proven",
+            evidence=evidence,
+        )
+
+    return HandoffClassification(
+        outbox_file=path.name,
+        idempotency_key=idem,
+        branch=branch,
+        desired_head_sha=desired_head or None,
+        state=HandoffState.UNKNOWN,
+        reason="no representation, owner, cap, or publication state could be proven",
+        evidence=evidence,
+    )
+
+
+def github_evidence_for_branch(
+    github_client: Any,
+    branch: str,
+    desired_head: str,
+    desired_base: str = "",
+    target_pr: int | None = None,
+) -> GitHubEvidence:
+    open_prs, pr_error = github_client.open_prs_for_branch(branch)
+    ref, ref_error = github_client.remote_ref(branch)
+    exact_open_pr = None
+    open_pr_items = open_prs or []
+    if desired_head:
+        for item in open_pr_items:
+            compact = _compact_open_pr(item)
+            head_ref = str(compact.get("head") or "")
+            head_sha = str(compact.get("head_sha") or "")
+            base_ref = str(compact.get("base") or DEFAULT_PR_BASE)
+            if (
+                head_ref == branch
+                and heads_match(desired_head, head_sha)
+                and _base_matches(
+                    desired_base,
+                    base_ref,
+                    actual_is_live=True,
+                )
+            ):
+                exact_open_pr = {**compact, "base": base_ref or None}
+                break
+    target_pr_error = None
+    if exact_open_pr is None and target_pr is not None:
+        target_payload, target_pr_error = _open_pr_by_number(github_client, target_pr)
+        if target_payload is not None:
+            exact_open_pr = _exact_open_pr_from_payload(
+                target_payload,
+                desired_head=desired_head,
+                desired_base=desired_base,
+                expected_branch=branch,
+            )
+    remote_ref = None
+    if ref is not None:
+        obj = ref.get("object") if isinstance(ref.get("object"), Mapping) else {}
+        remote_ref = {
+            "ref": ref.get("ref"),
+            "sha": obj.get("sha") or ref.get("sha"),
+        }
+    errors = "; ".join(error for error in (pr_error, target_pr_error, ref_error) if error)
+    if getattr(github_client, "disabled", False):
+        mode = "disabled"
+    elif errors:
+        mode = "degraded"
+    else:
+        mode = "ready"
+    return GitHubEvidence(
+        mode=mode,
+        error=errors or None,
+        open_prs=[_compact_open_pr(item) for item in open_pr_items],
+        exact_open_pr=exact_open_pr,
+        remote_ref=remote_ref,
+    )
+
+
+def _open_pr_by_number(
+    github_client: Any,
+    target_pr: int,
+) -> tuple[dict[str, Any] | None, str | None]:
+    lookup = getattr(github_client, "open_pr_by_number", None)
+    if lookup is None:
+        return None, "github client cannot lookup target PR by number"
+    payload, error = lookup(target_pr)
+    if payload is not None and not isinstance(payload, dict):
+        return None, "target PR lookup response was not a mapping"
+    return payload, error
+
+
+def _exact_open_pr_from_payload(
+    item: Mapping[str, Any],
+    *,
+    desired_head: str,
+    desired_base: str,
+    expected_branch: str | None = None,
+) -> dict[str, Any] | None:
+    if str(item.get("state") or "").strip().lower() != "open":
+        return None
+    if not desired_head:
+        return None
+    head = item.get("head") if isinstance(item.get("head"), Mapping) else {}
+    base = item.get("base") if isinstance(item.get("base"), Mapping) else {}
+    head_ref = str(head.get("ref") or item.get("head_ref") or item.get("headRefName") or "").strip()
+    if expected_branch and head_ref != expected_branch:
+        return None
+    head_sha = str(head.get("sha") or item.get("head_sha") or item.get("headRefOid") or "")
+    base_ref = str(
+        base.get("ref") or item.get("base_ref") or item.get("baseRefName") or DEFAULT_PR_BASE
+    )
+    if not heads_match(desired_head, head_sha) or not _base_matches(
+        desired_base,
+        base_ref,
+        actual_is_live=True,
+    ):
+        return None
+    return {**_compact_open_pr(item), "base": base_ref or None}
+
+
+def _compact_open_pr(item: Mapping[str, Any]) -> dict[str, Any]:
+    head = item.get("head") if isinstance(item.get("head"), Mapping) else {}
+    base = item.get("base") if isinstance(item.get("base"), Mapping) else {}
+    head_ref = str(head.get("ref") or item.get("head_ref") or item.get("headRefName") or "").strip()
+    head_sha = str(head.get("sha") or item.get("head_sha") or item.get("headRefOid") or "").strip()
+    base_ref = str(base.get("ref") or item.get("base_ref") or item.get("baseRefName") or "").strip()
+    return {
+        "number": item.get("number"),
+        "state": item.get("state"),
+        "draft": item.get("draft"),
+        "head": head_ref or None,
+        "head_sha": head_sha or None,
+        "base": base_ref or None,
+        "html_url": item.get("html_url") or item.get("url"),
+    }
+
+
+def load_terminal_receipts(receipt_dir: Path) -> dict[str, dict[str, Any]]:
+    receipts: dict[str, dict[str, Any]] = {}
+    receipt_order: dict[str, float] = {}
+    if not receipt_dir.exists():
+        return receipts
+    for path in sorted(receipt_dir.glob("*.json")):
+        payload = _load_json(path)
+        if not isinstance(payload, dict):
+            continue
+        status = str(payload.get("status") or "").strip().lower()
+        if status not in TERMINAL_RECEIPT_STATUSES:
+            continue
+        key = str(payload.get("idempotency_key") or path.stem).strip()
+        if key:
+            payload = dict(payload)
+            payload["__receipt_path"] = str(path)
+            order = _receipt_sort_timestamp(payload, path)
+            if key not in receipts or order >= receipt_order.get(key, 0.0):
+                receipts[key] = payload
+                receipt_order[key] = order
+    return receipts
+
+
+def load_queue_cap_evidence(
+    path: Path,
+    *,
+    max_age_seconds: int = DEFAULT_QUEUE_CAP_CACHE_MAX_AGE_SECONDS,
+    now: datetime | None = None,
+) -> QueueCapEvidence:
+    payload = _load_json(path)
+    if isinstance(payload, list):
+        payload = next((item for item in reversed(payload) if isinstance(item, dict)), None)
+    if not isinstance(payload, dict):
+        return QueueCapEvidence(available=False)
+    github_queue = (
+        payload.get("github_queue") if isinstance(payload.get("github_queue"), Mapping) else {}
+    )
+    limits = payload.get("limits") if isinstance(payload.get("limits"), Mapping) else {}
+    pressure = (
+        github_queue.get("pressure") if isinstance(github_queue.get("pressure"), Mapping) else {}
+    )
+    generated_at = str(payload.get("generated_at") or "") or None
+    generated_dt = _parse_datetime(generated_at)
+    cache_age_seconds = None
+    cache_stale = None
+    decision_source = "fresh_cache"
+    if generated_dt is None:
+        cache_stale = True
+        decision_source = "cache_missing_or_invalid_generated_at"
+    else:
+        current = now or datetime.now(UTC)
+        cache_age_seconds = max(0.0, (current - generated_dt).total_seconds())
+        cache_stale = cache_age_seconds > max_age_seconds
+        if cache_stale:
+            decision_source = "expired_cache"
+    raw_cap = _bool_or_none(pressure.get("open_pr_cap_reached"))
+    queue_available = _bool_or_none(github_queue.get("available"))
+    degraded = _bool_or_none(github_queue.get("degraded"))
+    if not cache_stale and queue_available is False:
+        decision_source = "github_queue_unavailable"
+    elif not cache_stale and degraded:
+        decision_source = "fresh_degraded_cache_rest_fallback"
+    effective_cap = (
+        raw_cap if raw_cap is True else None if cache_stale or queue_available is False else raw_cap
+    )
+    return QueueCapEvidence(
+        available=True,
+        github_queue_available=queue_available,
+        degraded=degraded,
+        degraded_reason=str(github_queue.get("degraded_reason") or "") or None,
+        open_pr_cap_reached=effective_cap,
+        raw_open_pr_cap_reached=raw_cap,
+        open_codex_pr_count=_int_or_none(github_queue.get("open_codex_pr_count")),
+        max_open_prs=_int_or_none(limits.get("max_open_prs")),
+        generated_at=generated_at,
+        cache_age_seconds=cache_age_seconds,
+        cache_stale=cache_stale,
+        cache_stale_threshold_seconds=max_age_seconds,
+        decision_source=decision_source,
+    )
+
+
+def _receipt_sort_timestamp(receipt: Mapping[str, Any], path: Path) -> float:
+    for key in (
+        "generated_at",
+        "created_at",
+        "updated_at",
+        "published_at",
+        "completed_at",
+        "receipt_at",
+        "read_at_utc",
+    ):
+        parsed = _parse_datetime(str(receipt.get(key) or "") or None)
+        if parsed is not None:
+            return parsed.timestamp()
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return 0.0
+
+
+def receipt_evidence_from_payload(
+    receipt: Mapping[str, Any] | None,
+    outbox_payload: Mapping[str, Any],
+) -> ReceiptEvidence:
+    if receipt is None:
+        return ReceiptEvidence(target_pr=target_pr_number_from_receipt(outbox_payload))
+    status = str(receipt.get("status") or "").strip().lower() or None
+    reason = str(receipt.get("reason") or "").strip().lower() or None
+    has_pr = receipt_has_pr_reference(receipt)
+    has_issue = receipt_has_issue_reference(receipt)
+    issue_only = (
+        is_pr_publication_request(outbox_payload)
+        and status in {"already_satisfied", "published"}
+        and not has_pr
+        and (reason in {"published", "existing_issue", "created_issue"} or has_issue)
+    )
+    return ReceiptEvidence(
+        status=status,
+        reason=reason,
+        has_pr_reference=has_pr,
+        has_issue_reference=has_issue,
+        issue_only_pr_receipt=issue_only,
+        path=str(receipt.get("__receipt_path") or "") or None,
+        target_pr=target_pr_number_from_receipt(receipt)
+        or target_pr_number_from_receipt(outbox_payload),
+    )
+
+
+def steering_evidence_for_branch(
+    *,
+    state_root: Path,
+    branch: str,
+    owner_session: str | None,
+    lane_id: str | None,
+) -> SteeringEvidence:
+    root = _state_path(state_root, DEFAULT_STEERING_ROOT)
+    if not root.exists():
+        return SteeringEvidence()
+    matches: list[dict[str, Any]] = []
+    for path in sorted(root.glob("*/*.json")):
+        payload = _load_json(path)
+        if not isinstance(payload, dict):
+            continue
+        to_session = str(payload.get("to_session") or "")
+        lane_hint = str(payload.get("lane_id_hint") or "")
+        branch_conflict = _steering_mentions_other_branch(payload, branch)
+        if branch_conflict:
+            continue
+        branch_match = bool(branch and _steering_branch_matches(payload, branch))
+        lane_match = bool(lane_id and _lane_hint_matches(lane_hint, lane_id))
+        if owner_session and to_session == owner_session:
+            if not (branch_match or lane_match):
+                continue
+            pass
+        elif lane_match:
+            pass
+        elif branch_match:
+            pass
+        else:
+            continue
+        receipt = latest_read_receipt_for_message(path)
+        human_detected = _looks_human(payload)
+        matches.append(
+            {
+                "path": str(path),
+                "to_session": to_session or None,
+                "lane_id_hint": lane_hint or None,
+                "priority": str(payload.get("priority") or "").lower() or None,
+                "human_detected": human_detected,
+                "subject_present": bool(str(payload.get("subject") or "").strip()),
+                "body_present": bool(str(payload.get("body") or "").strip()),
+                "sent_at_utc": payload.get("sent_at_utc"),
+                "from": payload.get("from"),
+                "latest_read_receipt": receipt,
+            }
+        )
+    blocking = [m for m in matches if m.get("priority") == "blocking"]
+    human = [m for m in matches if m.get("human_detected")]
+    latest = sorted(matches, key=lambda m: str(m.get("sent_at_utc") or ""))[-1] if matches else None
+    receipts = [
+        receipt
+        for receipt in (m.get("latest_read_receipt") for m in matches)
+        if isinstance(receipt, dict)
+    ]
+    resolved_receipts = [
+        receipt
+        for receipt in receipts
+        if str(receipt.get("outcome") or "").strip().lower()
+        in {"obeyed", "stale", "superseded", "completed"}
+    ]
+    latest_receipt = (
+        sorted(receipts, key=lambda r: str(r.get("read_at_utc") or ""))[-1] if receipts else None
+    )
+    return SteeringEvidence(
+        pending_message_count=len(matches),
+        blocking_message_count=len(blocking),
+        resolved_read_receipt_count=len(resolved_receipts),
+        human_message_count=len(human),
+        latest_message=latest,
+        latest_read_receipt=latest_receipt,
+    )
+
+
+def branch_from_payload(payload: Mapping[str, Any]) -> str:
+    for local_evidence in _local_evidence_mappings(payload.get("local_evidence")):
+        branch = str(local_evidence.get("branch") or "").strip()
+        if branch:
+            return branch
+    branch = str(payload.get("branch") or "").strip()
+    if branch:
+        return branch
+    requested_action = _mapping_from_action(payload.get("requested_action"))
+    if requested_action is not None:
+        return str(requested_action.get("branch") or "").strip()
+    return ""
+
+
+def desired_head_from_payload(payload: Mapping[str, Any]) -> str:
+    for local_evidence in _local_evidence_mappings(payload.get("local_evidence")):
+        for key in HEAD_FIELD_KEYS:
+            head = str(local_evidence.get(key) or "").strip()
+            if head:
+                return head
+    for key in HEAD_FIELD_KEYS:
+        head = str(payload.get(key) or "").strip()
+        if head:
+            return head
+    requested_action = _mapping_from_action(payload.get("requested_action"))
+    if requested_action is not None:
+        for key in HEAD_FIELD_KEYS:
+            head = str(requested_action.get(key) or "").strip()
+            if head:
+                return head
+    return ""
+
+
+def desired_base_from_payload(payload: Mapping[str, Any]) -> str:
+    for local_evidence in _local_evidence_mappings(payload.get("local_evidence")):
+        for key in BASE_FIELD_KEYS:
+            base = str(local_evidence.get(key) or "").strip()
+            if base:
+                return base
+    for key in BASE_FIELD_KEYS:
+        base = str(payload.get(key) or "").strip()
+        if base:
+            return base
+    requested_action = _mapping_from_action(payload.get("requested_action"))
+    if requested_action is not None:
+        for key in BASE_FIELD_KEYS:
+            base = str(requested_action.get(key) or "").strip()
+            if base:
+                return base
+    if is_pr_publication_request(payload):
+        return DEFAULT_PR_BASE
+    return ""
+
+
+def local_evidence_conflict_reason(payload: Mapping[str, Any]) -> str | None:
+    records = _local_evidence_mappings(payload.get("local_evidence"))
+    top_branch = _first_text(payload, "branch")
+    top_head = _first_text(payload, *HEAD_FIELD_KEYS)
+    top_base = _first_text(payload, *BASE_FIELD_KEYS)
+    requested_action = _mapping_from_action(payload.get("requested_action")) or {}
+    action_branch = _first_text(requested_action, "branch")
+    action_head = _first_text(requested_action, *HEAD_FIELD_KEYS)
+    action_base = _first_text(requested_action, *BASE_FIELD_KEYS)
+    if top_branch and action_branch and top_branch != action_branch:
+        return "top-level branch conflicts with requested_action branch"
+    if top_head and action_head and not heads_match(top_head, action_head):
+        return "top-level desired head conflicts with requested_action desired head"
+    if top_base and action_base and not _base_matches(top_base, action_base):
+        return "top-level base conflicts with requested_action base"
+    if not records:
+        return None
+    for record in records:
+        record_branch = _first_text(record, "branch")
+        record_head = _first_text(record, *HEAD_FIELD_KEYS)
+        record_base = _first_text(record, *BASE_FIELD_KEYS)
+        if top_branch and record_branch and top_branch != record_branch:
+            return "local_evidence branch conflicts with top-level branch"
+        if action_branch and record_branch and action_branch != record_branch:
+            return "local_evidence branch conflicts with requested_action branch"
+        if top_head and record_head and not heads_match(top_head, record_head):
+            return "local_evidence head conflicts with top-level desired head"
+        if action_head and record_head and not heads_match(action_head, record_head):
+            return "local_evidence head conflicts with requested_action desired head"
+        if top_base and record_base and not _base_matches(top_base, record_base):
+            return "local_evidence base conflicts with top-level base"
+        if action_base and record_base and not _base_matches(action_base, record_base):
+            return "local_evidence base conflicts with requested_action base"
+    if len(records) <= 1:
+        return None
+    branches = {
+        str(record.get("branch") or "").strip()
+        for record in records
+        if str(record.get("branch") or "").strip()
+    }
+    heads: list[str] = []
+    for record in records:
+        value = _first_text(record, *HEAD_FIELD_KEYS)
+        if value and not any(heads_match(value, existing) for existing in heads):
+            heads.append(value)
+    bases = {
+        _normalize_base_ref(value)
+        for record in records
+        if (value := _first_text(record, *BASE_FIELD_KEYS))
+    }
+    if len(branches) > 1 or len(heads) > 1 or len(bases) > 1:
+        return "multiple local_evidence records disagree on branch, head, or base"
+    return None
+
+
+def is_pr_publication_request(payload: Mapping[str, Any]) -> bool:
+    action = requested_action_type(payload)
+    idempotency_key = str(payload.get("idempotency_key") or "")
+    return action in PR_PUBLICATION_ACTIONS or idempotency_key.startswith(
+        PR_PUBLICATION_IDEMPOTENCY_PREFIXES
+    )
+
+
+def requested_action_type(payload: Mapping[str, Any]) -> str:
+    requested_action = payload.get("requested_action")
+    mapping = _mapping_from_action(requested_action)
+    if mapping is not None:
+        return str(mapping.get("type") or mapping.get("action") or "").strip().lower()
+    if isinstance(requested_action, str):
+        return requested_action.strip().lower()
+    return ""
+
+
+def receipt_has_pr_reference(receipt: Mapping[str, Any]) -> bool:
+    for key in (
+        "created_pr_url",
+        "existing_pr_url",
+        "pr_url",
+        "pull_request_url",
+        "created_pull_request_url",
+        "existing_pull_request_url",
+    ):
+        if str(receipt.get(key) or "").strip():
+            return True
+    return False
+
+
+def receipt_has_issue_reference(receipt: Mapping[str, Any]) -> bool:
+    for key in ("created_issue_url", "existing_issue_url", "issue_url"):
+        if str(receipt.get(key) or "").strip():
+            return True
+    return False
+
+
+def target_pr_number_from_receipt(receipt: Mapping[str, Any]) -> int | None:
+    for key in ("target_pr", "target_open_pr", "pr_number", "pull_request_number"):
+        number = _pr_number_from_value(receipt.get(key))
+        if number is not None:
+            return number
+    for key in (
+        "created_pr_url",
+        "existing_pr_url",
+        "pr_url",
+        "pull_request_url",
+        "created_pull_request_url",
+        "existing_pull_request_url",
+    ):
+        number = _pr_number_from_value(receipt.get(key))
+        if number is not None:
+            return number
+    return None
+
+
+def heads_match(expected: str, actual: str) -> bool:
+    expected_value = str(expected or "").strip().lower()
+    actual_value = str(actual or "").strip().lower()
+    if not _sha_prefix_is_usable(expected_value) or not _sha_prefix_is_usable(actual_value):
+        return False
+    if _full_sha_or_none(expected_value) and _full_sha_or_none(actual_value):
+        return expected_value == actual_value
+    return expected_value.startswith(actual_value) or actual_value.startswith(expected_value)
+
+
+def _full_sha_or_none(value: str) -> str | None:
+    return value if re.fullmatch(r"[0-9a-f]{40}", value) else None
+
+
+def _sha_prefix_is_usable(value: str) -> bool:
+    return bool(re.fullmatch(r"[0-9a-f]{7,40}", value))
+
+
+def _remote_ref_matches(remote_ref: Mapping[str, Any] | None, desired_head: str) -> bool:
+    if not remote_ref or not desired_head:
+        return False
+    return heads_match(desired_head, str(remote_ref.get("sha") or ""))
+
+
+def _base_matches(desired_base: str, actual_base: str, *, actual_is_live: bool = False) -> bool:
+    expected = _normalize_base_ref(desired_base)
+    if not expected:
+        if actual_is_live:
+            return _normalize_base_ref(actual_base) == DEFAULT_PR_BASE
+        return True
+    actual = str(actual_base or "").strip()
+    if not actual:
+        return False
+    if actual_is_live:
+        return expected == actual
+    return expected == _normalize_base_ref(actual)
+
+
+def _normalize_base_ref(value: str) -> str:
+    base = str(value or "").strip()
+    for prefix in ("refs/remotes/origin/", "refs/heads/", "origin/", "remotes/origin/"):
+        if base.startswith(prefix):
+            return base[len(prefix) :]
+    return base
+
+
+def _possible_unpushed(owner: OwnerEvidence) -> bool:
+    value = str(owner.advisory_withheld or "").strip().lower()
+    return value == "possible_unpushed_work"
+
+
+def _payload_possible_unpushed_marker(payload: Mapping[str, Any]) -> str | None:
+    if _possible_unpushed_marker(payload):
+        return "possible_unpushed_work"
+    for local_evidence in _local_evidence_mappings(payload.get("local_evidence")):
+        if _possible_unpushed_marker(local_evidence):
+            return "possible_unpushed_work"
+    return None
+
+
+def _owner_probe_no_match(text: str) -> bool:
+    normalized = str(text or "").strip().lower()
+    return "no lane matched" in normalized or "no matching lane" in normalized
+
+
+def _human_blocked(owner: OwnerEvidence, steering: SteeringEvidence) -> bool:
+    tokens = [
+        owner.owner_session,
+        owner.lane_id,
+        owner.source,
+        owner.status,
+        owner.owner_blocking_state,
+    ]
+    if any(_contains_human_token(str(token or "")) for token in tokens):
+        return True
+    return steering.human_message_count > 0
+
+
+def _owner_blocked(owner: OwnerEvidence, steering: SteeringEvidence) -> bool:
+    if owner.available is False:
+        return True
+    if steering.blocking_message_count > 0:
+        return True
+    blocking = str(owner.owner_blocking_state or "").strip().lower()
+    if blocking in {"live_owner", "stale_owner", "unknown_owner", "stale_terminal_owner"}:
+        return True
+    return False
+
+
+def _queue_cap_uncertain_for_publication(queue_cap: QueueCapEvidence) -> bool:
+    if queue_cap.available is not True:
+        return True
+    if queue_cap.open_pr_cap_reached is None:
+        return True
+    return queue_cap.cache_stale is True or queue_cap.github_queue_available is False
+
+
+def _terminal_receipt_satisfied(receipt: ReceiptEvidence) -> bool:
+    if receipt.status not in TERMINAL_RECEIPT_STATUSES or receipt.issue_only_pr_receipt:
+        return False
+    return receipt.has_pr_reference or receipt.target_pr is not None
+
+
+def _looks_human(mapping: Mapping[str, Any]) -> bool:
+    # Do not inspect the filesystem path: all steering messages live under
+    # ".aragora/operator-steering", which would make every matched message look
+    # human/operator-gated.
+    fields = (
+        "subject",
+        "body",
+        "to_session",
+        "lane_id_hint",
+    )
+    text = " ".join(str(mapping.get(field) or "") for field in fields).lower()
+    if _contains_human_token(text):
+        return True
+    operator_phrases = (
+        "operator approval",
+        "operator authorization",
+        "operator decision",
+        "operator settlement",
+        "operator must",
+        "ask operator",
+    )
+    return any(phrase in text for phrase in operator_phrases)
+
+
+def _contains_human_token(value: str) -> bool:
+    return re.search(r"(?<!non-)\bhuman\b", value.lower()) is not None
+
+
+def _lane_hint_matches(lane_hint: str, lane_id: str) -> bool:
+    normalized_lane = lane_id.strip()
+    if not normalized_lane:
+        return False
+    hints = [part.strip() for part in re.split(r"[,;\s]+", lane_hint) if part.strip()]
+    return normalized_lane in hints
+
+
+def _steering_branch_matches(payload: Mapping[str, Any], branch: str) -> bool:
+    exact_keys = (
+        "branch",
+        "head_branch",
+        "target_branch",
+        "source_branch",
+        "base_branch",
+    )
+    text_keys = (
+        "subject",
+        "body",
+        "summary",
+        "requested_next_action",
+    )
+    for key in exact_keys:
+        if str(payload.get(key) or "").strip() == branch:
+            return True
+    for key in text_keys:
+        if _text_contains_exact_branch(str(payload.get(key) or ""), branch):
+            return True
+    for key in ("branches", "branch_names"):
+        value = payload.get(key)
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+            if any(str(item) == branch for item in value):
+                return True
+    for key in ("metadata", "context", "evidence"):
+        value = payload.get(key)
+        if not isinstance(value, Mapping):
+            continue
+        for nested_key in exact_keys:
+            if str(value.get(nested_key) or "").strip() == branch:
+                return True
+        for nested_key in text_keys:
+            if _text_contains_exact_branch(str(value.get(nested_key) or ""), branch):
+                return True
+    return False
+
+
+def _steering_mentions_other_branch(payload: Mapping[str, Any], branch: str) -> bool:
+    tokens = _steering_branch_tokens(payload)
+    return bool(tokens and branch not in tokens)
+
+
+def _steering_branch_tokens(payload: Mapping[str, Any]) -> set[str]:
+    tokens: set[str] = set()
+    exact_keys = (
+        "branch",
+        "head_branch",
+        "target_branch",
+        "source_branch",
+        "base_branch",
+    )
+    text_keys = (
+        "subject",
+        "body",
+        "summary",
+        "requested_next_action",
+    )
+    for key in exact_keys:
+        value = str(payload.get(key) or "").strip()
+        if value:
+            tokens.add(value)
+    for key in ("branches", "branch_names"):
+        value = payload.get(key)
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+            tokens.update(str(item).strip() for item in value if str(item).strip())
+    for key in text_keys:
+        tokens.update(_branch_tokens_from_text(str(payload.get(key) or "")))
+    for key in ("metadata", "context", "evidence"):
+        value = payload.get(key)
+        if not isinstance(value, Mapping):
+            continue
+        for nested_key in exact_keys:
+            nested = str(value.get(nested_key) or "").strip()
+            if nested:
+                tokens.add(nested)
+        for nested_key in text_keys:
+            tokens.update(_branch_tokens_from_text(str(value.get(nested_key) or "")))
+    return tokens
+
+
+def _branch_tokens_from_text(text: str) -> set[str]:
+    text = URL_PATTERN.sub("", text)
+    return {
+        token.rstrip(".,;:!?)]}'\"")
+        for token in re.findall(r"\b[A-Za-z0-9._-]+/[A-Za-z0-9._/-]+", text)
+    }
+
+
+def _text_contains_exact_branch(text: str, branch: str) -> bool:
+    candidate = str(branch or "").strip()
+    if not candidate:
+        return False
+    if text.strip() == candidate:
+        return True
+    return candidate in _branch_tokens_from_text(text)
+
+
+def latest_read_receipt_for_message(message_path: Path) -> dict[str, Any] | None:
+    receipt_dir = message_path.parent / "_read_receipts"
+    if not receipt_dir.is_dir():
+        return None
+    receipts: list[dict[str, Any]] = []
+    data = _load_json(message_path)
+    if not isinstance(data, dict):
+        data = {}
+    message_sha = str(data.get("message_sha256") or "")
+    for receipt_path in sorted(receipt_dir.glob("*.json")):
+        payload = _load_json(receipt_path)
+        if not isinstance(payload, dict):
+            continue
+        if str(payload.get("message_filename") or "") != message_path.name:
+            continue
+        receipt_sha = str(payload.get("message_sha256") or "")
+        if message_sha and receipt_sha and receipt_sha != message_sha:
+            continue
+        receipts.append(
+            {
+                "path": str(receipt_path),
+                "read_at_utc": payload.get("read_at_utc"),
+                "read_by_session": payload.get("read_by_session"),
+                "outcome": payload.get("outcome"),
+                "outcome_note": payload.get("outcome_note"),
+            }
+        )
+    if not receipts:
+        return None
+    return sorted(receipts, key=lambda r: str(r.get("read_at_utc") or ""))[-1]
+
+
+def _selected_outbox_files(outbox_dir: Path, outbox_file: str | Path | None) -> list[Path]:
+    outbox_root = outbox_dir.resolve()
+    if outbox_file is None:
+        if not outbox_dir.exists():
+            return []
+        return sorted(p for p in outbox_dir.iterdir() if p.is_file() and p.suffix == ".json")
+    value = Path(outbox_file).expanduser()
+    path = (value if value.is_absolute() else outbox_dir / value).resolve()
+    try:
+        path.relative_to(outbox_root)
+    except ValueError:
+        raise ValueError(f"outbox file must be inside {outbox_root}: {value}") from None
+    if not path.is_file():
+        raise FileNotFoundError(f"outbox file does not exist: {path}")
+    return [path]
+
+
+def _load_lane_records(path: Path) -> list[dict[str, Any]]:
+    payload = _load_json(path)
+    if isinstance(payload, list):
+        return [item for item in payload if isinstance(item, dict)]
+    if isinstance(payload, Mapping):
+        records = payload.get("lanes") or payload.get("records")
+        if isinstance(records, list):
+            return [item for item in records if isinstance(item, dict)]
+    return []
+
+
+def _lane_registry_blocking_reason(status: str, blocking_state: str | None) -> str | None:
+    if blocking_state == "live_owner":
+        return "lane registry status is active/blocking; use focused liveness before mutation"
+    if blocking_state == "stale_terminal_owner":
+        return "lane registry status is terminal but needs focused liveness proof"
+    if blocking_state == "unknown_owner":
+        return "lane registry matched an owner without enough liveness proof"
+    return f"lane registry owner_blocking_state={blocking_state}" if blocking_state else None
+
+
+def _best_lane_record(records: list[dict[str, Any]]) -> dict[str, Any]:
+    active = [
+        row
+        for row in records
+        if str(row.get("status") or "").strip().lower() in ACTIVE_LANE_STATUSES
+    ]
+    candidates = active or records
+    return sorted(candidates, key=lambda row: str(row.get("updated_at") or ""), reverse=True)[0]
+
+
+def _gh_stderr_is_not_found(message: str) -> bool:
+    text = str(message or "").strip().lower()
+    return "http 404" in text or "not found" in text or "status code 404" in text
+
+
+def _github_not_found_error(error: str) -> bool:
+    return str(error or "").startswith("github_not_found:")
+
+
+def _load_json(path: Path) -> Any | None:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _mapping_from_action(value: Any) -> Mapping[str, Any] | None:
+    if isinstance(value, Mapping):
+        return value
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not (text.startswith("{") and text.endswith("}")):
+        return None
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        try:
+            parsed = ast.literal_eval(text)
+        except (SyntaxError, ValueError):
+            parsed = None
+    if isinstance(parsed, Mapping):
+        return parsed
+    return None
+
+
+def _local_evidence_mappings(value: Any) -> list[Mapping[str, Any]]:
+    if isinstance(value, Mapping):
+        return [value]
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [item for item in value if isinstance(item, Mapping)]
+    return []
+
+
+def _state_path(state_root: Path, default_relative: Path) -> Path:
+    state_root = _as_aragora_root(state_root)
+    if default_relative.parts[:1] == (".aragora",):
+        return state_root.joinpath(*default_relative.parts[1:])
+    return state_root / default_relative
+
+
+def resolve_state_root(*, repo_root: Path, state_root: Path | None = None) -> Path:
+    if state_root is not None:
+        return _as_aragora_root(state_root)
+    env_root = os.environ.get("ARAGORA_AUTOMATION_STATE_ROOT")
+    if env_root:
+        return _as_aragora_root(Path(env_root))
+    common_root = _git_common_worktree_root(repo_root)
+    if common_root is not None and (common_root / ".aragora").exists():
+        return common_root / ".aragora"
+    return _as_aragora_root(repo_root)
+
+
+def _as_aragora_root(path: Path) -> Path:
+    expanded = path.expanduser().resolve()
+    if expanded.name == ".aragora":
+        return expanded
+    return expanded / ".aragora"
+
+
+def _git_common_worktree_root(repo_root: Path) -> Path | None:
+    try:
+        proc = subprocess.run(
+            ["git", "rev-parse", "--git-common-dir"],
+            cwd=repo_root,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if proc.returncode != 0:
+        return None
+    common = Path(proc.stdout.strip())
+    if not common.is_absolute():
+        common = (repo_root / common).resolve()
+    if common.name == ".git":
+        return common.parent
+    return None
+
+
+def _github_repo_from_origin(repo_root: Path) -> str | None:
+    try:
+        proc = subprocess.run(
+            ["git", "config", "--get", "remote.origin.url"],
+            cwd=repo_root,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if proc.returncode != 0:
+        return None
+    value = proc.stdout.strip()
+    if not value:
+        return None
+    if value.startswith("git@github.com:"):
+        value = value.removeprefix("git@github.com:")
+    elif "github.com/" in value:
+        value = value.split("github.com/", 1)[1]
+    value = value.removesuffix(".git").strip("/")
+    parts = value.split("/")
+    if len(parts) >= 2:
+        return "/".join(parts[:2])
+    return None
+
+
+def _github_repo_owner(github_repo: str) -> tuple[str, str | None]:
+    parts = [part for part in str(github_repo or "").strip().split("/") if part]
+    if len(parts) != 2:
+        return "", "github repo must be in owner/name form"
+    return parts[0], None
+
+
+def _first_text(mapping: Mapping[str, Any], *keys: str) -> str | None:
+    for key in keys:
+        value = str(mapping.get(key) or "").strip()
+        if value:
+            return value
+    return None
+
+
+def _pr_number_from_value(value: Any) -> int | None:
+    text = str(value or "").strip().rstrip("/")
+    if not text:
+        return None
+    if text.isdigit():
+        return int(text)
+    marker = "/pull/"
+    if marker not in text:
+        return None
+    candidate = text.rsplit(marker, 1)[1].split("/", 1)[0]
+    return int(candidate) if candidate.isdigit() else None
+
+
+def _int_or_none(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _bool_or_none(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    return None
+
+
+def compact_summary(payload: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "schema_version": payload.get("schema_version"),
+        "generated_at": payload.get("generated_at"),
+        "repo": payload.get("repo"),
+        "state_root": payload.get("state_root"),
+        "github_repo": payload.get("github_repo"),
+        "outbox_count": payload.get("outbox_count"),
+        "counts": payload.get("counts", {}),
+        "github": payload.get("github", {}),
+        "queue_cap": payload.get("queue_cap", {}),
+    }
+
+
+def _parse_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)

--- a/tests/scripts/test_classify_handoff_state.py
+++ b/tests/scripts/test_classify_handoff_state.py
@@ -1,0 +1,2716 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import scripts.handoff_state as mod
+import scripts.classify_handoff_state as cli
+
+
+HEAD = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+OTHER_HEAD = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+RECONCILE_LOCAL_WORK_MARKER_KEYS = (
+    "uncommitted_changes",
+    "has_uncommitted_changes",
+    "uncommitted",
+    "unpushed_commits",
+    "local_changes",
+    "local_work",
+    "dirty",
+)
+
+
+class FakeGitHub:
+    disabled = False
+
+    def __init__(
+        self,
+        *,
+        open_prs: dict[str, list[dict[str, Any]]] | None = None,
+        pr_by_number: dict[int, dict[str, Any]] | None = None,
+        refs: dict[str, dict[str, Any]] | None = None,
+        errors: dict[str, str] | None = None,
+    ) -> None:
+        self.open_prs = open_prs or {}
+        self.pr_by_number = pr_by_number or {}
+        self.refs = refs or {}
+        self.errors = errors or {}
+        self.pr_calls = 0
+        self.pr_number_calls = 0
+        self.ref_calls = 0
+
+    def open_prs_for_branch(self, branch: str) -> tuple[list[dict[str, Any]] | None, str | None]:
+        self.pr_calls += 1
+        error = self.errors.get(f"pr:{branch}")
+        if error:
+            return None, error
+        return self.open_prs.get(branch, []), None
+
+    def open_pr_by_number(self, pr_number: int) -> tuple[dict[str, Any] | None, str | None]:
+        self.pr_number_calls += 1
+        error = self.errors.get(f"pr-number:{pr_number}")
+        if error:
+            return None, error
+        return self.pr_by_number.get(pr_number), None
+
+    def remote_ref(self, branch: str) -> tuple[dict[str, Any] | None, str | None]:
+        self.ref_calls += 1
+        error = self.errors.get(f"ref:{branch}")
+        if error:
+            return None, error
+        return self.refs.get(branch), None
+
+
+class FakeOwnerProbe:
+    def __init__(self, payloads: dict[str, dict[str, Any]] | None = None) -> None:
+        self.payloads = payloads or {}
+
+    def probe(self, branch: str) -> mod.OwnerEvidence:
+        payload = self.payloads.get(branch)
+        if payload is None:
+            return mod.OwnerEvidence(available=True, matched=False, error="no lane matched")
+        return mod.owner_evidence_from_payload(payload)
+
+
+def _write_outbox(
+    state_root: Path,
+    *,
+    key: str = "open-pr-codex-example-aaaaaaaa",
+    branch: str = "codex/example",
+    head: str = HEAD,
+    base: str | None = None,
+    action_type: str = "open_or_update_pr",
+    local_evidence: list[dict[str, Any]] | None = None,
+    extra_payload: dict[str, Any] | None = None,
+) -> Path:
+    outbox = state_root / ".aragora" / "automation-outbox"
+    outbox.mkdir(parents=True, exist_ok=True)
+    path = outbox / f"{key}.json"
+    requested_action = {
+        "type": action_type,
+        "branch": branch,
+        "desired_head_sha": head,
+        "head_sha": head,
+    }
+    payload = {
+        "idempotency_key": key,
+        "requested_action": requested_action,
+        "branch": branch,
+        "desired_head_sha": head,
+        "head_sha": head,
+        "repo": "synaptent/aragora",
+        "task": f"Open PR for {branch}",
+    }
+    if base is not None:
+        requested_action["base"] = base
+        payload["base"] = base
+    if local_evidence is not None:
+        payload["local_evidence"] = local_evidence
+    if extra_payload is not None:
+        payload.update(extra_payload)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _write_receipt(state_root: Path, key: str, payload: dict[str, Any]) -> None:
+    receipts = state_root / ".aragora" / "automation-receipts"
+    receipts.mkdir(parents=True, exist_ok=True)
+    body = {"idempotency_key": key, **payload}
+    (receipts / f"{key}.json").write_text(json.dumps(body), encoding="utf-8")
+
+
+def _write_status_cache(
+    state_root: Path,
+    *,
+    open_pr_cap_reached: bool = False,
+    degraded: bool = False,
+    available: bool | None = True,
+    generated_at: str | None = None,
+    open_pr_heads: list[str] | None = None,
+) -> None:
+    status = state_root / ".aragora" / "automation-github-status"
+    status.mkdir(parents=True, exist_ok=True)
+    timestamp = generated_at or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    (status / "latest.json").write_text(
+        json.dumps(
+            {
+                "generated_at": timestamp,
+                "github_queue": {
+                    "available": available,
+                    "degraded": degraded,
+                    "degraded_reason": "heavy_open_pr_query_failed:HTTP 504" if degraded else None,
+                    "open_pr_heads": open_pr_heads if open_pr_heads is not None else [],
+                    "open_pr_heads_cached_at": timestamp,
+                    "open_codex_pr_count": len(open_pr_heads) if open_pr_heads is not None else 144,
+                    "pressure": {"open_pr_cap_reached": open_pr_cap_reached},
+                },
+                "limits": {"max_open_prs": 120},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_steering_message(
+    state_root: Path,
+    *,
+    owner_session: str = "engineering-autopilot-Q1",
+    branch: str = "codex/example",
+    filename: str = "2026-06-24T00-00-00-000Z-fixture.json",
+    priority: str = "blocking",
+) -> Path:
+    inbox = state_root / ".aragora" / "operator-steering" / owner_session
+    inbox.mkdir(parents=True, exist_ok=True)
+    path = inbox / filename
+    payload = {
+        "schema_version": "aragora-operator-steering/1.0",
+        "to_session": owner_session,
+        "from": "operator",
+        "sent_at_utc": "2026-06-24T00:00:00.000Z",
+        "lane_id_hint": "Q1",
+        "priority": priority,
+        "subject": f"Block {branch}",
+        "body": f"Please resolve {branch} before non-owner movement.",
+        "message_sha256": "fixture-sha",
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _write_steering_receipt(
+    message_path: Path,
+    *,
+    outcome: str,
+    read_at_utc: str = "2026-06-24T00:05:00.000Z",
+) -> Path:
+    receipt_dir = message_path.parent / "_read_receipts"
+    receipt_dir.mkdir(parents=True, exist_ok=True)
+    path = receipt_dir / f"{read_at_utc.replace(':', '-')}-fixture.json"
+    receipt = {
+        "schema_version": "aragora-operator-steering-read-receipt/1.0",
+        "owner_session": message_path.parent.name,
+        "read_by_session": "reader",
+        "read_at_utc": read_at_utc,
+        "message_filename": message_path.name,
+        "message_sha256": "fixture-sha",
+        "outcome": outcome,
+        "outcome_note": f"fixture {outcome}",
+    }
+    path.write_text(json.dumps(receipt), encoding="utf-8")
+    return path
+
+
+def _classify_one(
+    tmp_path: Path,
+    *,
+    branch: str = "codex/example",
+    outbox_file: str = "open-pr-codex-example-aaaaaaaa.json",
+    github: FakeGitHub | None = None,
+    owner: FakeOwnerProbe | None = None,
+) -> dict[str, Any]:
+    payload = mod.classify_handoffs(
+        repo_root=tmp_path,
+        state_root=tmp_path,
+        github_repo="synaptent/aragora",
+        outbox_file=outbox_file,
+        github_client=github or FakeGitHub(),
+        owner_probe=owner or FakeOwnerProbe(),
+    )
+    assert payload["outbox_count"] == 1
+    return payload["items"][0]
+
+
+def test_exact_open_pr_representation_does_not_hide_owner_noise(tmp_path: Path) -> None:
+    _write_status_cache(tmp_path, open_pr_cap_reached=True)
+    _write_outbox(tmp_path, branch="codex/example")
+    github = FakeGitHub(
+        open_prs={
+            "codex/example": [
+                {
+                    "number": 8570,
+                    "state": "open",
+                    "draft": False,
+                    "html_url": "https://github.com/synaptent/aragora/pull/8570",
+                    "head": {"ref": "codex/example", "sha": HEAD},
+                }
+            ]
+        }
+    )
+    owner = FakeOwnerProbe(
+        {
+            "codex/example": {
+                "lane_id": "Q1",
+                "owner_session": "engineering-autopilot-Q1",
+                "status": "active",
+                "owner_blocking_state": "live_owner",
+            }
+        }
+    )
+
+    item = _classify_one(tmp_path, github=github, owner=owner)
+
+    assert item["state"] == mod.HandoffState.BLOCKED_BY_OWNER.value
+    assert item["evidence"]["github"]["exact_open_pr"]["number"] == 8570
+    assert item["next_mutation_candidate"] == "owner_followup"
+    assert item["safe_to_mutate"] is False
+
+
+def test_exact_open_pr_representation_is_safe_without_owner_blockers(tmp_path: Path) -> None:
+    _write_status_cache(tmp_path, open_pr_cap_reached=True)
+    _write_outbox(tmp_path, branch="codex/example")
+    github = FakeGitHub(
+        open_prs={
+            "codex/example": [
+                {
+                    "number": 8570,
+                    "state": "open",
+                    "draft": False,
+                    "html_url": "https://github.com/synaptent/aragora/pull/8570",
+                    "head": {"ref": "codex/example", "sha": HEAD},
+                }
+            ]
+        }
+    )
+
+    item = _classify_one(tmp_path, github=github)
+
+    assert item["state"] == mod.HandoffState.REPRESENTED_BY_EXACT_OPEN_PR.value
+    assert item["safe_to_mutate"] is True
+
+
+def test_exact_draft_open_pr_representation_is_not_safe_to_mutate(tmp_path: Path) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, branch="codex/example")
+    github = FakeGitHub(
+        open_prs={
+            "codex/example": [
+                {
+                    "number": 8570,
+                    "state": "open",
+                    "draft": True,
+                    "head": {"ref": "codex/example", "sha": HEAD},
+                }
+            ]
+        }
+    )
+
+    item = _classify_one(tmp_path, github=github)
+
+    assert item["state"] == mod.HandoffState.REPRESENTED_BY_EXACT_OPEN_PR.value
+    assert item["next_mutation_candidate"] == "none"
+    assert item["safe_to_mutate"] is False
+
+
+def test_open_pr_without_desired_head_fails_closed(tmp_path: Path) -> None:
+    _write_status_cache(tmp_path)
+    handoff = _write_outbox(tmp_path, branch="codex/example")
+    payload = json.loads(handoff.read_text(encoding="utf-8"))
+    for key in ("desired_head_sha", "target_head_sha", "head_sha", "head", "commit"):
+        payload.pop(key, None)
+        payload["requested_action"].pop(key, None)
+    handoff.write_text(json.dumps(payload), encoding="utf-8")
+    github = FakeGitHub(
+        open_prs={
+            "codex/example": [
+                {
+                    "number": 8570,
+                    "state": "open",
+                    "draft": True,
+                    "head": {"ref": "codex/example", "sha": OTHER_HEAD},
+                }
+            ]
+        }
+    )
+
+    item = _classify_one(tmp_path, github=github)
+
+    assert item["state"] == mod.HandoffState.UNKNOWN.value
+    assert "no desired head" in item["reason"]
+
+
+def test_exact_open_pr_representation_requires_requested_base(tmp_path: Path) -> None:
+    _write_status_cache(tmp_path, open_pr_cap_reached=False)
+    _write_outbox(tmp_path, branch="codex/example", base="main")
+    github = FakeGitHub(
+        open_prs={
+            "codex/example": [
+                {
+                    "number": 8570,
+                    "state": "open",
+                    "draft": True,
+                    "html_url": "https://github.com/synaptent/aragora/pull/8570",
+                    "head": {"ref": "codex/example", "sha": HEAD},
+                    "base": {"ref": "release"},
+                }
+            ]
+        }
+    )
+
+    item = _classify_one(tmp_path, github=github)
+
+    assert item["state"] == mod.HandoffState.PUBLICATION_REQUESTED.value
+    assert item["evidence"]["github"]["exact_open_pr"] is None
+
+
+def test_missing_base_defaults_to_main_for_exact_open_pr_representation(
+    tmp_path: Path,
+) -> None:
+    _write_status_cache(tmp_path, open_pr_cap_reached=False)
+    _write_outbox(tmp_path, branch="codex/example")
+    github = FakeGitHub(
+        open_prs={
+            "codex/example": [
+                {
+                    "number": 8570,
+                    "state": "open",
+                    "draft": True,
+                    "html_url": "https://github.com/synaptent/aragora/pull/8570",
+                    "head": {"ref": "codex/example", "sha": HEAD},
+                    "base": {"ref": "release"},
+                }
+            ]
+        }
+    )
+
+    item = _classify_one(tmp_path, github=github)
+
+    assert item["state"] == mod.HandoffState.PUBLICATION_REQUESTED.value
+    assert item["evidence"]["github"]["exact_open_pr"] is None
+
+
+def test_non_pr_exact_open_pr_representation_requires_default_base(
+    tmp_path: Path,
+) -> None:
+    _write_status_cache(tmp_path, open_pr_cap_reached=False)
+    _write_outbox(
+        tmp_path,
+        key="preserve-branch-codex-example-aaaaaaaa",
+        branch="codex/example",
+        action_type="preserve_branch",
+    )
+    github = FakeGitHub(
+        open_prs={
+            "codex/example": [
+                {
+                    "number": 8570,
+                    "state": "open",
+                    "draft": False,
+                    "html_url": "https://github.com/synaptent/aragora/pull/8570",
+                    "head": {"ref": "codex/example", "sha": HEAD},
+                    "base": {"ref": "release"},
+                }
+            ]
+        }
+    )
+
+    item = _classify_one(
+        tmp_path,
+        outbox_file="preserve-branch-codex-example-aaaaaaaa.json",
+        github=github,
+    )
+
+    assert item["state"] == mod.HandoffState.UNKNOWN.value
+    assert item["safe_to_mutate"] is False
+    assert item["next_mutation_candidate"] == "none"
+    assert item["evidence"]["github"]["exact_open_pr"] is None
+
+
+def test_exact_open_pr_representation_honors_base_ref_name_alias(
+    tmp_path: Path,
+) -> None:
+    _write_status_cache(tmp_path, open_pr_cap_reached=False)
+    handoff = _write_outbox(tmp_path, branch="codex/example")
+    payload = json.loads(handoff.read_text(encoding="utf-8"))
+    payload.pop("base", None)
+    payload["base_ref_name"] = "release"
+    payload["requested_action"].pop("base", None)
+    payload["requested_action"]["baseRefName"] = "release"
+    handoff.write_text(json.dumps(payload), encoding="utf-8")
+    github = FakeGitHub(
+        open_prs={
+            "codex/example": [
+                {
+                    "number": 8570,
+                    "state": "open",
+                    "draft": True,
+                    "head": {"ref": "codex/example", "sha": HEAD},
+                    "base": {"ref": "main"},
+                }
+            ]
+        }
+    )
+
+    item = _classify_one(tmp_path, github=github)
+
+    assert item["state"] == mod.HandoffState.PUBLICATION_REQUESTED.value
+    assert item["evidence"]["github"]["exact_open_pr"] is None
+
+
+def test_exact_open_pr_representation_honors_target_head_sha_alias(
+    tmp_path: Path,
+) -> None:
+    _write_status_cache(tmp_path, open_pr_cap_reached=True)
+    handoff = _write_outbox(tmp_path, branch="codex/example")
+    payload = json.loads(handoff.read_text(encoding="utf-8"))
+    payload.pop("desired_head_sha", None)
+    payload.pop("head_sha", None)
+    payload["target_head_sha"] = HEAD
+    payload["requested_action"].pop("desired_head_sha", None)
+    payload["requested_action"].pop("head_sha", None)
+    handoff.write_text(json.dumps(payload), encoding="utf-8")
+    github = FakeGitHub(
+        open_prs={
+            "codex/example": [
+                {
+                    "number": 8570,
+                    "state": "open",
+                    "draft": True,
+                    "head": {"ref": "codex/example", "sha": HEAD},
+                    "base": {"ref": "main"},
+                }
+            ]
+        }
+    )
+
+    item = _classify_one(tmp_path, github=github)
+
+    assert item["state"] == mod.HandoffState.REPRESENTED_BY_EXACT_OPEN_PR.value
+    assert item["evidence"]["github"]["exact_open_pr"]["number"] == 8570
+
+
+def test_exact_open_pr_representation_accepts_reconcile_sha_prefix(
+    tmp_path: Path,
+) -> None:
+    _write_status_cache(tmp_path, open_pr_cap_reached=False)
+    _write_outbox(tmp_path, branch="codex/example", head=HEAD[:12])
+    github = FakeGitHub(
+        open_prs={
+            "codex/example": [
+                {
+                    "number": 8570,
+                    "state": "open",
+                    "draft": True,
+                    "head": {"ref": "codex/example", "sha": HEAD},
+                    "base": {"ref": "main"},
+                }
+            ]
+        }
+    )
+
+    item = _classify_one(tmp_path, github=github)
+
+    assert item["state"] == mod.HandoffState.REPRESENTED_BY_EXACT_OPEN_PR.value
+    assert item["evidence"]["github"]["exact_open_pr"]["number"] == 8570
+
+
+def test_exact_open_pr_representation_blocks_when_owner_probe_unavailable(
+    tmp_path: Path,
+) -> None:
+    _write_status_cache(tmp_path, open_pr_cap_reached=True)
+    _write_outbox(tmp_path, branch="codex/example")
+    github = FakeGitHub(
+        open_prs={
+            "codex/example": [
+                {
+                    "number": 8570,
+                    "state": "open",
+                    "draft": True,
+                    "html_url": "https://github.com/synaptent/aragora/pull/8570",
+                    "head": {"ref": "codex/example", "sha": HEAD},
+                }
+            ]
+        }
+    )
+
+    class UnavailableOwnerProbe:
+        def probe(self, branch: str) -> mod.OwnerEvidence:
+            return mod.OwnerEvidence(available=False, error="owner probe failed")
+
+    item = _classify_one(tmp_path, github=github, owner=UnavailableOwnerProbe())
+
+    assert item["state"] == mod.HandoffState.BLOCKED_BY_OWNER.value
+    assert item["safe_to_mutate"] is False
+
+
+def test_issue_only_receipt_limbo_stays_publication_requested(tmp_path: Path) -> None:
+    key = "open-pr-codex-example-aaaaaaaa"
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, key=key, branch="codex/example")
+    _write_receipt(
+        tmp_path,
+        key,
+        {
+            "status": "already_satisfied",
+            "reason": "existing_issue",
+            "existing_issue_url": "https://github.com/synaptent/aragora/issues/123",
+            "existing_pr_url": None,
+        },
+    )
+
+    item = _classify_one(tmp_path)
+
+    assert item["state"] == mod.HandoffState.PUBLICATION_REQUESTED.value
+    assert item["evidence"]["receipt"]["issue_only_pr_receipt"] is True
+    assert "issue-only receipt" in item["reason"]
+
+
+def test_issue_only_receipt_limbo_is_cap_blocked_when_open_pr_cap_reached(
+    tmp_path: Path,
+) -> None:
+    key = "open-pr-codex-example-aaaaaaaa"
+    _write_status_cache(tmp_path, open_pr_cap_reached=True)
+    _write_outbox(tmp_path, key=key, branch="codex/example")
+    _write_receipt(
+        tmp_path,
+        key,
+        {
+            "status": "already_satisfied",
+            "reason": "existing_issue",
+            "existing_issue_url": "https://github.com/synaptent/aragora/issues/123",
+        },
+    )
+
+    item = _classify_one(tmp_path)
+
+    assert item["state"] == mod.HandoffState.BLOCKED_BY_LIVE_QUEUE_CAP.value
+    assert item["evidence"]["receipt"]["issue_only_pr_receipt"] is True
+    assert item["next_mutation_candidate"] == "queue_drain"
+
+
+def test_conflicting_local_evidence_records_fail_closed(tmp_path: Path) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(
+        tmp_path,
+        branch="codex/example",
+        local_evidence=[
+            {"branch": "codex/example", "desired_head_sha": HEAD},
+            {"branch": "codex/example", "desired_head_sha": OTHER_HEAD},
+        ],
+    )
+    github = FakeGitHub(
+        open_prs={
+            "codex/example": [
+                {
+                    "number": 8570,
+                    "state": "open",
+                    "draft": True,
+                    "head": {"ref": "codex/example", "sha": HEAD},
+                    "base": {"ref": "main"},
+                }
+            ]
+        }
+    )
+
+    item = _classify_one(tmp_path, github=github)
+
+    assert item["state"] == mod.HandoffState.UNKNOWN.value
+    assert "local_evidence head conflicts" in item["reason"]
+
+
+def test_conflicting_local_evidence_alias_records_fail_closed(tmp_path: Path) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(
+        tmp_path,
+        branch="codex/example",
+        local_evidence=[
+            {"branch": "codex/example", "target_head_sha": HEAD, "base_ref_name": "main"},
+            {"branch": "codex/example", "headRefOid": OTHER_HEAD, "baseRefName": "release"},
+        ],
+    )
+    github = FakeGitHub(
+        open_prs={
+            "codex/example": [
+                {
+                    "number": 8570,
+                    "state": "open",
+                    "draft": False,
+                    "head": {"ref": "codex/example", "sha": HEAD},
+                    "base": {"ref": "main"},
+                }
+            ]
+        }
+    )
+
+    item = _classify_one(tmp_path, github=github)
+
+    assert item["state"] == mod.HandoffState.UNKNOWN.value
+    assert "local_evidence head conflicts" in item["reason"]
+
+
+def test_local_evidence_equivalent_sha_prefix_records_do_not_conflict(
+    tmp_path: Path,
+) -> None:
+    _write_status_cache(tmp_path, open_pr_cap_reached=False)
+    _write_outbox(
+        tmp_path,
+        branch="codex/example",
+        head=HEAD,
+        local_evidence=[
+            {"branch": "codex/example", "desired_head_sha": HEAD},
+            {"branch": "codex/example", "target_head_sha": HEAD[:12]},
+        ],
+    )
+
+    item = _classify_one(tmp_path, github=FakeGitHub())
+
+    assert item["state"] == mod.HandoffState.PUBLICATION_REQUESTED.value
+    assert "local_evidence" not in item["evidence"]
+
+
+def test_single_local_evidence_conflict_with_top_level_fails_closed(
+    tmp_path: Path,
+) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(
+        tmp_path,
+        branch="codex/example",
+        head=OTHER_HEAD,
+        local_evidence=[
+            {"branch": "codex/example", "target_head_sha": HEAD, "baseRefName": "main"},
+        ],
+    )
+    github = FakeGitHub(
+        open_prs={
+            "codex/example": [
+                {
+                    "number": 8570,
+                    "state": "open",
+                    "draft": False,
+                    "head": {"ref": "codex/example", "sha": HEAD},
+                    "base": {"ref": "main"},
+                }
+            ]
+        }
+    )
+
+    item = _classify_one(tmp_path, github=github)
+
+    assert item["state"] == mod.HandoffState.UNKNOWN.value
+    assert "local_evidence head conflicts" in item["reason"]
+
+
+def test_local_evidence_origin_main_base_alias_does_not_conflict(tmp_path: Path) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(
+        tmp_path,
+        branch="codex/example",
+        base="main",
+        local_evidence=[
+            {"branch": "codex/example", "target_head_sha": HEAD, "base": "origin/main"},
+        ],
+    )
+    github = FakeGitHub(
+        refs={
+            "codex/example": {
+                "ref": "refs/heads/codex/example",
+                "object": {"sha": HEAD},
+            }
+        }
+    )
+
+    item = _classify_one(tmp_path, github=github)
+
+    assert item["state"] == mod.HandoffState.PUBLICATION_REQUESTED.value
+    assert "local_evidence" not in item["evidence"]
+
+
+def test_requested_action_branch_conflict_without_local_evidence_fails_closed(
+    tmp_path: Path,
+) -> None:
+    _write_status_cache(tmp_path)
+    handoff = _write_outbox(tmp_path, branch="codex/example")
+    payload = json.loads(handoff.read_text(encoding="utf-8"))
+    payload["requested_action"]["branch"] = "codex/other"
+    handoff.write_text(json.dumps(payload), encoding="utf-8")
+
+    item = _classify_one(tmp_path, github=FakeGitHub())
+
+    assert item["state"] == mod.HandoffState.UNKNOWN.value
+    assert item["reason"] == "top-level branch conflicts with requested_action branch"
+
+
+def test_requested_action_head_conflict_without_local_evidence_fails_closed(
+    tmp_path: Path,
+) -> None:
+    _write_status_cache(tmp_path)
+    handoff = _write_outbox(tmp_path, branch="codex/example")
+    payload = json.loads(handoff.read_text(encoding="utf-8"))
+    payload["requested_action"]["desired_head_sha"] = OTHER_HEAD
+    payload["requested_action"]["head_sha"] = OTHER_HEAD
+    handoff.write_text(json.dumps(payload), encoding="utf-8")
+
+    item = _classify_one(tmp_path, github=FakeGitHub())
+
+    assert item["state"] == mod.HandoffState.UNKNOWN.value
+    assert item["reason"] == "top-level desired head conflicts with requested_action desired head"
+
+
+def test_live_open_pr_base_ref_is_not_collapsed_as_local_alias(tmp_path: Path) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, branch="codex/example", base="main")
+    github = FakeGitHub(
+        open_prs={
+            "codex/example": [
+                {
+                    "number": 8570,
+                    "state": "open",
+                    "draft": False,
+                    "head": {"ref": "codex/example", "sha": HEAD},
+                    "base": {"ref": "origin/main"},
+                }
+            ]
+        }
+    )
+
+    item = _classify_one(tmp_path, github=github)
+
+    assert item["state"] == mod.HandoffState.PUBLICATION_REQUESTED.value
+    assert item["evidence"]["github"]["exact_open_pr"] is None
+
+
+def test_terminal_receipts_choose_newest_by_timestamp_not_filename(tmp_path: Path) -> None:
+    receipts = tmp_path / ".aragora" / "automation-receipts"
+    receipts.mkdir(parents=True, exist_ok=True)
+    key = "open-pr-codex-example-aaaaaaaa"
+    (receipts / "zz-old.json").write_text(
+        json.dumps(
+            {
+                "idempotency_key": key,
+                "status": "published",
+                "created_pr_url": "https://github.com/synaptent/aragora/pull/1",
+                "generated_at": "2026-06-24T00:00:00Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (receipts / "aa-new.json").write_text(
+        json.dumps(
+            {
+                "idempotency_key": key,
+                "status": "published",
+                "created_pr_url": "https://github.com/synaptent/aragora/pull/2",
+                "generated_at": "2026-06-24T01:00:00Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    loaded = mod.load_terminal_receipts(receipts)
+
+    assert loaded[key]["created_pr_url"].endswith("/2")
+
+
+def test_terminal_pr_receipt_without_live_proof_does_not_publish(tmp_path: Path) -> None:
+    key = "open-pr-codex-example-aaaaaaaa"
+    _write_status_cache(tmp_path, open_pr_cap_reached=True)
+    _write_outbox(tmp_path, key=key, branch="codex/example")
+    _write_receipt(
+        tmp_path,
+        key,
+        {
+            "status": "published",
+            "reason": "created_pr",
+            "created_pr_url": "https://github.com/synaptent/aragora/pull/8570",
+        },
+    )
+
+    item = _classify_one(tmp_path)
+
+    assert item["state"] == mod.HandoffState.UNKNOWN.value
+    assert item["next_mutation_candidate"] == "none"
+    assert "terminal receipt exists" in item["reason"]
+
+
+def test_terminal_pr_receipt_with_owner_noise_stays_unknown_without_live_proof(
+    tmp_path: Path,
+) -> None:
+    key = "open-pr-codex-example-aaaaaaaa"
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, key=key, branch="codex/example")
+    _write_receipt(
+        tmp_path,
+        key,
+        {
+            "status": "published",
+            "reason": "created_pr",
+            "target_pr": 8570,
+        },
+    )
+    owner = FakeOwnerProbe(
+        {
+            "codex/example": {
+                "lane_id": "Q1",
+                "owner_session": "engineering-autopilot-Q1",
+                "status": "active",
+                "owner_blocking_state": "live_owner",
+            }
+        }
+    )
+
+    item = _classify_one(tmp_path, owner=owner)
+
+    assert item["state"] == mod.HandoffState.UNKNOWN.value
+    assert item["next_mutation_candidate"] == "none"
+    assert "terminal receipt exists" in item["reason"]
+
+
+def test_target_pr_reference_can_prove_exact_open_pr_representation(
+    tmp_path: Path,
+) -> None:
+    key = "open-pr-codex-example-aaaaaaaa"
+    _write_status_cache(tmp_path, open_pr_cap_reached=True)
+    _write_outbox(
+        tmp_path,
+        key=key,
+        branch="codex/original-branch",
+        extra_payload={"target_open_pr": 8570},
+    )
+    github = FakeGitHub(
+        pr_by_number={
+            8570: {
+                "number": 8570,
+                "state": "open",
+                "draft": False,
+                "head": {"ref": "codex/original-branch", "sha": HEAD},
+                "base": {"ref": "main"},
+                "html_url": "https://github.com/synaptent/aragora/pull/8570",
+            }
+        }
+    )
+
+    item = _classify_one(tmp_path, github=github)
+
+    assert item["state"] == mod.HandoffState.REPRESENTED_BY_EXACT_OPEN_PR.value
+    assert item["safe_to_mutate"] is True
+    assert item["evidence"]["github"]["exact_open_pr"]["number"] == 8570
+    assert item["evidence"]["github"]["exact_open_pr"]["head"] == "codex/original-branch"
+    assert github.pr_number_calls == 1
+
+
+def test_target_pr_reference_accepts_matching_branch_pr_lookup(
+    tmp_path: Path,
+) -> None:
+    key = "open-pr-codex-example-aaaaaaaa"
+    _write_status_cache(tmp_path, open_pr_cap_reached=True)
+    _write_outbox(
+        tmp_path,
+        key=key,
+        branch="codex/original-branch",
+        extra_payload={"target_open_pr": 8570},
+    )
+    github = FakeGitHub(
+        open_prs={
+            "codex/original-branch": [
+                {
+                    "number": 8570,
+                    "state": "open",
+                    "draft": False,
+                    "head": {"ref": "codex/original-branch", "sha": HEAD},
+                    "base": {"ref": "main"},
+                    "html_url": "https://github.com/synaptent/aragora/pull/8570",
+                }
+            ]
+        }
+    )
+
+    item = _classify_one(tmp_path, github=github)
+
+    assert item["state"] == mod.HandoffState.REPRESENTED_BY_EXACT_OPEN_PR.value
+    assert item["safe_to_mutate"] is True
+    assert item["evidence"]["github"]["exact_open_pr"]["number"] == 8570
+    assert item["evidence"]["github"]["exact_open_pr"]["head"] == "codex/original-branch"
+    assert github.pr_number_calls == 0
+
+
+def test_target_pr_representation_is_not_safe_when_branch_pr_lookup_degrades(
+    tmp_path: Path,
+) -> None:
+    key = "open-pr-codex-example-aaaaaaaa"
+    _write_status_cache(tmp_path, open_pr_cap_reached=True)
+    _write_outbox(
+        tmp_path,
+        key=key,
+        branch="codex/original-branch",
+        extra_payload={"target_open_pr": 8570},
+    )
+    github = FakeGitHub(
+        pr_by_number={
+            8570: {
+                "number": 8570,
+                "state": "open",
+                "draft": False,
+                "head": {"ref": "codex/original-branch", "sha": HEAD},
+                "base": {"ref": "main"},
+                "html_url": "https://github.com/synaptent/aragora/pull/8570",
+            }
+        },
+        errors={"pr:codex/original-branch": "gh api failed (HTTP 504)"},
+    )
+
+    item = _classify_one(tmp_path, github=github)
+
+    assert item["state"] == mod.HandoffState.REPRESENTED_BY_EXACT_OPEN_PR.value
+    assert item["safe_to_mutate"] is False
+    assert item["next_mutation_candidate"] == "none"
+    assert item["evidence"]["github"]["mode"] == "degraded"
+    assert item["evidence"]["github"]["exact_open_pr"]["number"] == 8570
+    assert "GitHub PR evidence is degraded" in item["reason"]
+    assert github.pr_number_calls == 1
+
+
+def test_target_pr_branch_lookup_must_match_handoff_branch(
+    tmp_path: Path,
+) -> None:
+    key = "open-pr-codex-example-aaaaaaaa"
+    _write_status_cache(tmp_path, open_pr_cap_reached=True)
+    _write_outbox(
+        tmp_path,
+        key=key,
+        branch="codex/original-branch",
+        extra_payload={"target_open_pr": 8570},
+    )
+    github = FakeGitHub(
+        open_prs={
+            "codex/original-branch": [
+                {
+                    "number": 8570,
+                    "state": "open",
+                    "draft": False,
+                    "head": {"ref": "codex/represented-elsewhere", "sha": HEAD},
+                    "base": {"ref": "main"},
+                    "html_url": "https://github.com/synaptent/aragora/pull/8570",
+                }
+            ]
+        }
+    )
+
+    item = _classify_one(tmp_path, github=github)
+
+    assert item["state"] == mod.HandoffState.BLOCKED_BY_LIVE_QUEUE_CAP.value
+    assert item["safe_to_mutate"] is False
+    assert item["next_mutation_candidate"] == "queue_drain"
+    assert item["evidence"]["github"]["exact_open_pr"] is None
+    assert github.pr_number_calls == 1
+
+
+def test_target_pr_reference_must_match_handoff_branch(
+    tmp_path: Path,
+) -> None:
+    key = "open-pr-codex-example-aaaaaaaa"
+    _write_status_cache(tmp_path, open_pr_cap_reached=True)
+    _write_outbox(
+        tmp_path,
+        key=key,
+        branch="codex/original-branch",
+        extra_payload={"target_open_pr": 8570},
+    )
+    github = FakeGitHub(
+        pr_by_number={
+            8570: {
+                "number": 8570,
+                "state": "open",
+                "draft": False,
+                "head": {"ref": "codex/represented-elsewhere", "sha": HEAD},
+                "base": {"ref": "main"},
+                "html_url": "https://github.com/synaptent/aragora/pull/8570",
+            }
+        }
+    )
+
+    item = _classify_one(tmp_path, github=github)
+
+    assert item["state"] == mod.HandoffState.BLOCKED_BY_LIVE_QUEUE_CAP.value
+    assert item["safe_to_mutate"] is False
+    assert item["next_mutation_candidate"] == "queue_drain"
+    assert item["evidence"]["github"]["exact_open_pr"] is None
+    assert github.pr_number_calls == 1
+
+
+def test_terminal_completed_receipt_without_pr_does_not_suppress_publication(
+    tmp_path: Path,
+) -> None:
+    key = "open-pr-codex-example-aaaaaaaa"
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, key=key, branch="codex/example")
+    _write_receipt(
+        tmp_path,
+        key,
+        {
+            "status": "completed",
+            "reason": "completed_without_pr",
+        },
+    )
+
+    item = _classify_one(tmp_path)
+
+    assert item["state"] == mod.HandoffState.PUBLICATION_REQUESTED.value
+    assert item["next_mutation_candidate"] == "publish_or_represent_pr"
+
+
+def test_unique_branch_without_pr_is_cap_blocked_when_cache_says_cap_reached(
+    tmp_path: Path,
+) -> None:
+    _write_status_cache(tmp_path, open_pr_cap_reached=True)
+    _write_outbox(tmp_path, branch="codex/example")
+
+    item = _classify_one(tmp_path)
+
+    assert item["state"] == mod.HandoffState.BLOCKED_BY_LIVE_QUEUE_CAP.value
+    assert item["evidence"]["queue_cap"]["open_pr_cap_reached"] is True
+    assert item["evidence"]["queue_cap"]["raw_open_pr_cap_reached"] is True
+    assert item["evidence"]["queue_cap"]["cache_stale"] is False
+
+
+def test_unique_branch_without_pr_is_publication_requested_when_cap_clear(
+    tmp_path: Path,
+) -> None:
+    _write_status_cache(tmp_path, open_pr_cap_reached=False)
+    _write_outbox(tmp_path, branch="codex/example")
+
+    item = _classify_one(tmp_path)
+
+    assert item["state"] == mod.HandoffState.PUBLICATION_REQUESTED.value
+
+
+def test_stale_queue_cap_cache_preserves_raw_cap_block(tmp_path: Path) -> None:
+    stale = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat().replace("+00:00", "Z")
+    _write_status_cache(tmp_path, open_pr_cap_reached=True, generated_at=stale)
+    _write_outbox(tmp_path, branch="codex/example")
+
+    item = _classify_one(tmp_path)
+
+    assert item["state"] == mod.HandoffState.BLOCKED_BY_LIVE_QUEUE_CAP.value
+    assert item["evidence"]["queue_cap"]["raw_open_pr_cap_reached"] is True
+    assert item["evidence"]["queue_cap"]["open_pr_cap_reached"] is True
+    assert item["evidence"]["queue_cap"]["cache_stale"] is True
+    assert item["evidence"]["queue_cap"]["decision_source"] == "expired_cache"
+
+
+def test_stale_queue_cap_cache_with_raw_clear_fails_closed(tmp_path: Path) -> None:
+    stale = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat().replace("+00:00", "Z")
+    _write_status_cache(tmp_path, open_pr_cap_reached=False, generated_at=stale)
+    _write_outbox(tmp_path, branch="codex/example")
+
+    item = _classify_one(tmp_path)
+
+    assert item["state"] == mod.HandoffState.UNKNOWN.value
+    assert item["reason"] == "publication requested but queue-cap evidence is stale or unavailable"
+    assert item["evidence"]["queue_cap"]["raw_open_pr_cap_reached"] is False
+    assert item["evidence"]["queue_cap"]["open_pr_cap_reached"] is None
+    assert item["evidence"]["queue_cap"]["cache_stale"] is True
+
+
+def test_unavailable_queue_cap_cache_preserves_raw_cap_block(tmp_path: Path) -> None:
+    _write_status_cache(tmp_path, open_pr_cap_reached=True, available=False)
+    _write_outbox(tmp_path, branch="codex/example")
+
+    item = _classify_one(tmp_path)
+
+    assert item["state"] == mod.HandoffState.BLOCKED_BY_LIVE_QUEUE_CAP.value
+    assert item["evidence"]["queue_cap"]["github_queue_available"] is False
+    assert item["evidence"]["queue_cap"]["raw_open_pr_cap_reached"] is True
+    assert item["evidence"]["queue_cap"]["open_pr_cap_reached"] is True
+    assert item["evidence"]["queue_cap"]["decision_source"] == "github_queue_unavailable"
+
+
+def test_unavailable_queue_cap_cache_with_raw_clear_fails_closed(tmp_path: Path) -> None:
+    _write_status_cache(tmp_path, open_pr_cap_reached=False, available=False)
+    _write_outbox(tmp_path, branch="codex/example")
+
+    item = _classify_one(tmp_path)
+
+    assert item["state"] == mod.HandoffState.UNKNOWN.value
+    assert item["reason"] == "publication requested but queue-cap evidence is stale or unavailable"
+    assert item["evidence"]["queue_cap"]["github_queue_available"] is False
+    assert item["evidence"]["queue_cap"]["raw_open_pr_cap_reached"] is False
+    assert item["evidence"]["queue_cap"]["open_pr_cap_reached"] is None
+
+
+def test_fresh_degraded_queue_cap_cache_blocks_with_rest_fallback_evidence(
+    tmp_path: Path,
+) -> None:
+    _write_status_cache(tmp_path, open_pr_cap_reached=True, degraded=True)
+    _write_outbox(tmp_path, branch="codex/example")
+
+    item = _classify_one(tmp_path)
+
+    assert item["state"] == mod.HandoffState.BLOCKED_BY_LIVE_QUEUE_CAP.value
+    assert item["evidence"]["queue_cap"]["degraded"] is True
+    assert item["evidence"]["queue_cap"]["open_pr_cap_reached"] is True
+    assert item["evidence"]["queue_cap"]["decision_source"] == "fresh_degraded_cache_rest_fallback"
+
+
+def test_stale_owner_remote_exact_head_blocks_like_open_pr_path(
+    tmp_path: Path,
+) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, branch="codex/example")
+    github = FakeGitHub(
+        refs={"codex/example": {"ref": "refs/heads/codex/example", "object": {"sha": HEAD}}}
+    )
+    owner = FakeOwnerProbe(
+        {
+            "codex/example": {
+                "lane_id": "Q1",
+                "owner_session": "engineering-autopilot-Q1",
+                "status": "released",
+                "owner_state": "stale",
+                "owner_blocking_state": "stale_owner",
+                "stale_claim_advisory": {"available": True},
+            }
+        }
+    )
+
+    item = _classify_one(tmp_path, github=github, owner=owner)
+
+    assert item["state"] == mod.HandoffState.BLOCKED_BY_OWNER.value
+    assert item["evidence"]["github"]["remote_ref"]["sha"] == HEAD
+
+
+def test_remote_exact_head_respects_open_pr_cap(
+    tmp_path: Path,
+) -> None:
+    _write_status_cache(tmp_path, open_pr_cap_reached=True)
+    _write_outbox(tmp_path, branch="codex/example")
+    github = FakeGitHub(
+        refs={"codex/example": {"ref": "refs/heads/codex/example", "object": {"sha": HEAD}}}
+    )
+
+    item = _classify_one(tmp_path, github=github)
+
+    assert item["state"] == mod.HandoffState.BLOCKED_BY_LIVE_QUEUE_CAP.value
+    assert item["evidence"]["github"]["remote_ref"]["sha"] == HEAD
+    assert item["next_mutation_candidate"] == "queue_drain"
+
+
+def test_remote_exact_head_representation_survives_pr_lookup_degradation(
+    tmp_path: Path,
+) -> None:
+    _write_status_cache(tmp_path, open_pr_cap_reached=True)
+    _write_outbox(tmp_path, branch="codex/example")
+    github = FakeGitHub(
+        refs={"codex/example": {"ref": "refs/heads/codex/example", "object": {"sha": HEAD}}},
+        errors={"pr:codex/example": "gh api failed (TimeoutExpired)"},
+    )
+
+    item = _classify_one(tmp_path, github=github)
+
+    assert item["state"] == mod.HandoffState.UNKNOWN.value
+    assert item["evidence"]["github"]["mode"] == "degraded"
+    assert item["evidence"]["github"]["remote_ref"]["sha"] == HEAD
+
+
+def test_non_pr_remote_exact_head_does_not_hide_pr_lookup_degradation(
+    tmp_path: Path,
+) -> None:
+    _write_status_cache(tmp_path, open_pr_cap_reached=False)
+    _write_outbox(
+        tmp_path,
+        key="preserve-branch-codex-example-aaaaaaaa",
+        branch="codex/example",
+        action_type="preserve_branch",
+    )
+    github = FakeGitHub(
+        refs={"codex/example": {"ref": "refs/heads/codex/example", "object": {"sha": HEAD}}},
+        errors={"pr:codex/example": "gh api failed (TimeoutExpired)"},
+    )
+
+    item = _classify_one(
+        tmp_path,
+        outbox_file="preserve-branch-codex-example-aaaaaaaa.json",
+        github=github,
+    )
+
+    assert item["state"] == mod.HandoffState.UNKNOWN.value
+    assert item["evidence"]["github"]["mode"] == "degraded"
+    assert item["safe_to_mutate"] is False
+
+
+def test_local_evidence_identical_sha_prefix_does_not_conflict(tmp_path: Path) -> None:
+    _write_status_cache(tmp_path, open_pr_cap_reached=False)
+    _write_outbox(
+        tmp_path,
+        branch="codex/example",
+        head=HEAD[:12],
+        local_evidence=[{"branch": "codex/example", "head_sha": HEAD[:12]}],
+    )
+
+    item = _classify_one(tmp_path, github=FakeGitHub())
+
+    assert item["state"] == mod.HandoffState.PUBLICATION_REQUESTED.value
+    assert "local_evidence" not in item["evidence"]
+
+
+def test_remote_exact_head_with_mismatched_open_pr_stays_publication_requested(
+    tmp_path: Path,
+) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, branch="codex/example")
+    github = FakeGitHub(
+        open_prs={
+            "codex/example": [
+                {
+                    "number": 9000,
+                    "state": "open",
+                    "draft": False,
+                    "head": {"ref": "codex/example", "sha": OTHER_HEAD},
+                }
+            ]
+        },
+        refs={"codex/example": {"ref": "refs/heads/codex/example", "object": {"sha": HEAD}}},
+    )
+
+    item = _classify_one(tmp_path, github=github)
+
+    assert item["state"] == mod.HandoffState.PUBLICATION_REQUESTED.value
+    assert item["evidence"]["github"]["exact_open_pr"] is None
+    assert item["evidence"]["github"]["remote_ref"]["sha"] == HEAD
+
+
+def test_non_pr_remote_exact_head_with_mismatched_open_pr_is_not_mutable(
+    tmp_path: Path,
+) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(
+        tmp_path,
+        key="preserve-branch-codex-example-aaaaaaaa",
+        branch="codex/example",
+        action_type="preserve_branch",
+    )
+    github = FakeGitHub(
+        open_prs={
+            "codex/example": [
+                {
+                    "number": 9000,
+                    "state": "open",
+                    "draft": False,
+                    "head": {"ref": "codex/example", "sha": OTHER_HEAD},
+                    "base": {"ref": "main"},
+                }
+            ]
+        },
+        refs={"codex/example": {"ref": "refs/heads/codex/example", "object": {"sha": HEAD}}},
+    )
+
+    item = _classify_one(
+        tmp_path,
+        outbox_file="preserve-branch-codex-example-aaaaaaaa.json",
+        github=github,
+    )
+
+    assert item["state"] == mod.HandoffState.UNKNOWN.value
+    assert item["safe_to_mutate"] is False
+    assert item["next_mutation_candidate"] == "none"
+    assert item["evidence"]["github"]["exact_open_pr"] is None
+    assert item["evidence"]["github"]["remote_ref"]["sha"] == HEAD
+    assert "existing open PR head does not match desired head" in item["reason"]
+
+
+def test_open_pr_evidence_is_compact_when_pr_is_not_exact(tmp_path: Path) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, branch="codex/example")
+    github = FakeGitHub(
+        open_prs={
+            "codex/example": [
+                {
+                    "number": 9000,
+                    "state": "open",
+                    "draft": True,
+                    "html_url": "https://github.com/synaptent/aragora/pull/9000",
+                    "head": {"ref": "codex/example", "sha": OTHER_HEAD},
+                    "base": {"ref": "main"},
+                    "_links": {"self": {"href": "https://api.github.com/noisy"}},
+                    "repo": {"full_name": "synaptent/aragora"},
+                    "user": {"login": "scarmani"},
+                }
+            ]
+        },
+        refs={"codex/example": {"ref": "refs/heads/codex/example", "object": {"sha": HEAD}}},
+    )
+
+    item = _classify_one(tmp_path, github=github)
+
+    assert item["state"] == mod.HandoffState.PUBLICATION_REQUESTED.value
+    assert item["evidence"]["github"]["open_prs"] == [
+        {
+            "number": 9000,
+            "state": "open",
+            "draft": True,
+            "head": "codex/example",
+            "head_sha": OTHER_HEAD,
+            "base": "main",
+            "html_url": "https://github.com/synaptent/aragora/pull/9000",
+        }
+    ]
+
+
+def test_remote_exact_head_does_not_hide_live_owner_gate(tmp_path: Path) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, branch="codex/example")
+    github = FakeGitHub(
+        refs={"codex/example": {"ref": "refs/heads/codex/example", "object": {"sha": HEAD}}}
+    )
+    owner = FakeOwnerProbe(
+        {
+            "codex/example": {
+                "lane_id": "Q1",
+                "owner_session": "engineering-autopilot-Q1",
+                "status": "active",
+                "owner_blocking_state": "live_owner",
+            }
+        }
+    )
+
+    item = _classify_one(tmp_path, github=github, owner=owner)
+
+    assert item["state"] == mod.HandoffState.BLOCKED_BY_OWNER.value
+    assert "remote branch" in item["reason"]
+    assert item["next_mutation_candidate"] == "owner_followup"
+
+
+def test_possible_unpushed_work_blocks_non_owner_movement(tmp_path: Path) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, branch="codex/example")
+    owner = FakeOwnerProbe(
+        {
+            "codex/example": {
+                "lane_id": "Q1",
+                "owner_session": "engineering-autopilot-Q1",
+                "status": "blocked",
+                "owner_state": "stale",
+                "owner_blocking_state": "stale_owner",
+                "advisory_withheld": "possible_unpushed_work",
+            }
+        }
+    )
+
+    item = _classify_one(tmp_path, owner=owner)
+
+    assert item["state"] == mod.HandoffState.BLOCKED_BY_POSSIBLE_UNPUSHED_WORK.value
+    assert item["evidence"]["owner"]["advisory_withheld"] == "possible_unpushed_work"
+
+
+def test_lane_registry_possible_unpushed_marker_blocks_default_classifier(
+    tmp_path: Path,
+) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, branch="codex/example")
+    lanes_path = tmp_path / ".aragora" / "agent-bridge" / "lanes.json"
+    lanes_path.parent.mkdir(parents=True, exist_ok=True)
+    lanes_path.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "Q1",
+                    "owner_session": "engineering-autopilot-Q1",
+                    "branch": "codex/example",
+                    "status": "released",
+                    "advisory_withheld": "possible_unpushed_work",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    payload = mod.classify_handoffs(
+        repo_root=tmp_path,
+        state_root=tmp_path,
+        github_repo="synaptent/aragora",
+        outbox_file="open-pr-codex-example-aaaaaaaa.json",
+        github_client=FakeGitHub(),
+    )
+    item = payload["items"][0]
+
+    assert item["state"] == mod.HandoffState.BLOCKED_BY_POSSIBLE_UNPUSHED_WORK.value
+    assert item["evidence"]["owner"]["advisory_withheld"] == "possible_unpushed_work"
+
+
+def test_local_work_marker_keys_match_reconcile_fail_closed_keys() -> None:
+    assert mod.LOCAL_WORK_MARKER_KEYS == RECONCILE_LOCAL_WORK_MARKER_KEYS
+
+
+def test_top_level_local_work_marker_blocks_publication(tmp_path: Path) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(
+        tmp_path,
+        branch="codex/example",
+        extra_payload={"unpushed_commits": "1"},
+    )
+
+    item = _classify_one(tmp_path)
+
+    assert item["state"] == mod.HandoffState.BLOCKED_BY_POSSIBLE_UNPUSHED_WORK.value
+    assert item["evidence"]["owner"]["advisory_withheld"] == "possible_unpushed_work"
+
+
+@pytest.mark.parametrize("marker_value", ["false", "0", "none", "clean", "verified-clean"])
+def test_top_level_negative_local_work_marker_does_not_block_publication(
+    tmp_path: Path,
+    marker_value: str,
+) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(
+        tmp_path,
+        branch="codex/example",
+        extra_payload={"local_work": marker_value},
+    )
+
+    item = _classify_one(tmp_path)
+
+    assert item["state"] == mod.HandoffState.PUBLICATION_REQUESTED.value
+    assert item["evidence"]["owner"]["advisory_withheld"] is None
+
+
+def test_local_evidence_local_work_marker_blocks_publication(tmp_path: Path) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(
+        tmp_path,
+        branch="codex/example",
+        local_evidence=[
+            {
+                "branch": "codex/example",
+                "desired_head_sha": HEAD,
+                "local_work": "yes",
+            }
+        ],
+    )
+
+    item = _classify_one(tmp_path)
+
+    assert item["state"] == mod.HandoffState.BLOCKED_BY_POSSIBLE_UNPUSHED_WORK.value
+    assert item["evidence"]["owner"]["advisory_withheld"] == "possible_unpushed_work"
+
+
+@pytest.mark.parametrize("marker_value", ["false", "0", "none", "clean", "verified-clean"])
+def test_local_evidence_negative_local_work_marker_does_not_block_publication(
+    tmp_path: Path,
+    marker_value: str,
+) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(
+        tmp_path,
+        branch="codex/example",
+        local_evidence=[
+            {
+                "branch": "codex/example",
+                "desired_head_sha": HEAD,
+                "local_work": marker_value,
+            }
+        ],
+    )
+
+    item = _classify_one(tmp_path)
+
+    assert item["state"] == mod.HandoffState.PUBLICATION_REQUESTED.value
+    assert item["evidence"]["owner"]["advisory_withheld"] is None
+
+
+def test_lane_registry_terminal_owner_does_not_block_by_default(
+    tmp_path: Path,
+) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, branch="codex/example")
+    lanes_path = tmp_path / ".aragora" / "agent-bridge" / "lanes.json"
+    lanes_path.parent.mkdir(parents=True, exist_ok=True)
+    lanes_path.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "Q1",
+                    "owner_session": "engineering-autopilot-Q1",
+                    "branch": "codex/example",
+                    "status": "released",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    payload = mod.classify_handoffs(
+        repo_root=tmp_path,
+        state_root=tmp_path,
+        github_repo="synaptent/aragora",
+        outbox_file="open-pr-codex-example-aaaaaaaa.json",
+        github_client=FakeGitHub(),
+    )
+    item = payload["items"][0]
+
+    assert item["state"] == mod.HandoffState.PUBLICATION_REQUESTED.value
+    assert item["evidence"]["owner"]["owner_blocking_state"] is None
+
+
+def test_lane_registry_active_without_fresh_liveness_blocks_default_classifier(
+    tmp_path: Path,
+) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, branch="codex/example")
+    lanes_path = tmp_path / ".aragora" / "agent-bridge" / "lanes.json"
+    lanes_path.parent.mkdir(parents=True, exist_ok=True)
+    lanes_path.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "Q1",
+                    "owner_session": "engineering-autopilot-Q1",
+                    "branch": "codex/example",
+                    "status": "active",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    payload = mod.classify_handoffs(
+        repo_root=tmp_path,
+        state_root=tmp_path,
+        github_repo="synaptent/aragora",
+        outbox_file="open-pr-codex-example-aaaaaaaa.json",
+        github_client=FakeGitHub(),
+    )
+    item = payload["items"][0]
+
+    assert item["state"] == mod.HandoffState.BLOCKED_BY_OWNER.value
+    assert item["evidence"]["owner"]["owner_blocking_state"] == "unknown_owner"
+
+
+def test_lane_registry_active_with_fresh_timestamp_blocks_default_classifier(
+    tmp_path: Path,
+) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, branch="codex/example")
+    lanes_path = tmp_path / ".aragora" / "agent-bridge" / "lanes.json"
+    lanes_path.parent.mkdir(parents=True, exist_ok=True)
+    lanes_path.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "Q1",
+                    "owner_session": "engineering-autopilot-Q1",
+                    "branch": "codex/example",
+                    "status": "active",
+                    "last_heartbeat_at": datetime.now(timezone.utc).isoformat(),
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    payload = mod.classify_handoffs(
+        repo_root=tmp_path,
+        state_root=tmp_path,
+        github_repo="synaptent/aragora",
+        outbox_file="open-pr-codex-example-aaaaaaaa.json",
+        github_client=FakeGitHub(),
+    )
+    item = payload["items"][0]
+
+    assert item["state"] == mod.HandoffState.BLOCKED_BY_OWNER.value
+    assert item["evidence"]["owner"]["owner_blocking_state"] == "unknown_owner"
+
+
+def test_lane_registry_blocked_status_blocks_default_classifier(tmp_path: Path) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, branch="codex/example")
+    lanes_path = tmp_path / ".aragora" / "agent-bridge" / "lanes.json"
+    lanes_path.parent.mkdir(parents=True, exist_ok=True)
+    lanes_path.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "Q1",
+                    "owner_session": "engineering-autopilot-Q1",
+                    "branch": "codex/example",
+                    "status": "blocked",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    payload = mod.classify_handoffs(
+        repo_root=tmp_path,
+        state_root=tmp_path,
+        github_repo="synaptent/aragora",
+        outbox_file="open-pr-codex-example-aaaaaaaa.json",
+        github_client=FakeGitHub(),
+    )
+    item = payload["items"][0]
+
+    assert item["state"] == mod.HandoffState.BLOCKED_BY_OWNER.value
+    assert item["evidence"]["owner"]["owner_blocking_state"] == "unknown_owner"
+
+
+def test_lane_registry_active_status_synonyms_block_default_classifier(
+    tmp_path: Path,
+) -> None:
+    for status in (
+        "running",
+        "pending",
+        "queued",
+        "acknowledged",
+        "working",
+    ):
+        state_root = tmp_path / status
+        _write_status_cache(state_root)
+        _write_outbox(state_root, branch="codex/example")
+        lanes_path = state_root / ".aragora" / "agent-bridge" / "lanes.json"
+        lanes_path.parent.mkdir(parents=True, exist_ok=True)
+        lanes_path.write_text(
+            json.dumps(
+                [
+                    {
+                        "lane_id": "Q1",
+                        "owner_session": "engineering-autopilot-Q1",
+                        "branch": "codex/example",
+                        "status": status,
+                    }
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        payload = mod.classify_handoffs(
+            repo_root=state_root,
+            state_root=state_root,
+            github_repo="synaptent/aragora",
+            outbox_file="open-pr-codex-example-aaaaaaaa.json",
+            github_client=FakeGitHub(),
+        )
+        item = payload["items"][0]
+
+        assert item["state"] == mod.HandoffState.BLOCKED_BY_OWNER.value
+        assert item["evidence"]["owner"]["owner_blocking_state"] == "unknown_owner"
+
+
+def test_lane_registry_released_worktree_hint_does_not_imply_unpushed_work(
+    tmp_path: Path,
+) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, branch="codex/example")
+    lanes_path = tmp_path / ".aragora" / "agent-bridge" / "lanes.json"
+    lanes_path.parent.mkdir(parents=True, exist_ok=True)
+    lanes_path.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "Q1",
+                    "owner_session": "engineering-autopilot-Q1",
+                    "branch": "codex/example",
+                    "status": "released",
+                    "worktree": "/tmp/aragora-q1",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    payload = mod.classify_handoffs(
+        repo_root=tmp_path,
+        state_root=tmp_path,
+        github_repo="synaptent/aragora",
+        outbox_file="open-pr-codex-example-aaaaaaaa.json",
+        github_client=FakeGitHub(),
+    )
+    item = payload["items"][0]
+
+    assert item["state"] == mod.HandoffState.PUBLICATION_REQUESTED.value
+    assert item["evidence"]["owner"]["advisory_withheld"] is None
+
+
+def test_lane_registry_terminal_owner_with_available_advisory_does_not_block(
+    tmp_path: Path,
+) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, branch="codex/example")
+    lanes_path = tmp_path / ".aragora" / "agent-bridge" / "lanes.json"
+    lanes_path.parent.mkdir(parents=True, exist_ok=True)
+    lanes_path.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "Q1",
+                    "owner_session": "engineering-autopilot-Q1",
+                    "branch": "codex/example",
+                    "status": "released",
+                    "stale_claim_advisory": {"available": True},
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    payload = mod.classify_handoffs(
+        repo_root=tmp_path,
+        state_root=tmp_path,
+        github_repo="synaptent/aragora",
+        outbox_file="open-pr-codex-example-aaaaaaaa.json",
+        github_client=FakeGitHub(),
+    )
+    item = payload["items"][0]
+
+    assert item["state"] == mod.HandoffState.PUBLICATION_REQUESTED.value
+    assert item["evidence"]["owner"]["owner_blocking_state"] is None
+
+
+def test_lane_registry_possible_unpushed_marker_ignores_unrelated_text(
+    tmp_path: Path,
+) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, branch="codex/example")
+    lanes_path = tmp_path / ".aragora" / "agent-bridge" / "lanes.json"
+    lanes_path.parent.mkdir(parents=True, exist_ok=True)
+    lanes_path.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "Q1",
+                    "owner_session": "engineering-autopilot-Q1",
+                    "branch": "codex/example",
+                    "status": "released",
+                    "note": "documentation mentions possible_unpushed_work",
+                    "stale_claim_advisory": {"available": True},
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    payload = mod.classify_handoffs(
+        repo_root=tmp_path,
+        state_root=tmp_path,
+        github_repo="synaptent/aragora",
+        outbox_file="open-pr-codex-example-aaaaaaaa.json",
+        github_client=FakeGitHub(),
+    )
+    item = payload["items"][0]
+
+    assert item["state"] == mod.HandoffState.PUBLICATION_REQUESTED.value
+    assert item["evidence"]["owner"]["advisory_withheld"] is None
+
+
+def test_lane_registry_dirty_signal_overrides_available_advisory(
+    tmp_path: Path,
+) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, branch="codex/example")
+    lanes_path = tmp_path / ".aragora" / "agent-bridge" / "lanes.json"
+    lanes_path.parent.mkdir(parents=True, exist_ok=True)
+    lanes_path.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "Q1",
+                    "owner_session": "engineering-autopilot-Q1",
+                    "branch": "codex/example",
+                    "status": "released",
+                    "stale_claim_advisory": {"available": True},
+                    "dirty_worktree": True,
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    payload = mod.classify_handoffs(
+        repo_root=tmp_path,
+        state_root=tmp_path,
+        github_repo="synaptent/aragora",
+        outbox_file="open-pr-codex-example-aaaaaaaa.json",
+        github_client=FakeGitHub(),
+    )
+    item = payload["items"][0]
+
+    assert item["state"] == mod.HandoffState.BLOCKED_BY_POSSIBLE_UNPUSHED_WORK.value
+    assert item["evidence"]["owner"]["advisory_withheld"] == "possible_unpushed_work"
+
+
+@pytest.mark.parametrize("marker_value", ["false", "0", "none", "clean", "verified-clean"])
+def test_lane_registry_negative_dirty_signal_keeps_available_advisory(
+    tmp_path: Path,
+    marker_value: str,
+) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, branch="codex/example")
+    lanes_path = tmp_path / ".aragora" / "agent-bridge" / "lanes.json"
+    lanes_path.parent.mkdir(parents=True, exist_ok=True)
+    lanes_path.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "Q1",
+                    "owner_session": "engineering-autopilot-Q1",
+                    "branch": "codex/example",
+                    "status": "released",
+                    "stale_claim_advisory": {"available": True},
+                    "dirty_worktree": marker_value,
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    payload = mod.classify_handoffs(
+        repo_root=tmp_path,
+        state_root=tmp_path,
+        github_repo="synaptent/aragora",
+        outbox_file="open-pr-codex-example-aaaaaaaa.json",
+        github_client=FakeGitHub(),
+    )
+    item = payload["items"][0]
+
+    assert item["state"] == mod.HandoffState.PUBLICATION_REQUESTED.value
+    assert item["evidence"]["owner"]["advisory_withheld"] is None
+
+
+def test_owner_payload_evidence_redacts_local_session_metadata(tmp_path: Path) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, branch="codex/example")
+    lanes_path = tmp_path / ".aragora" / "agent-bridge" / "lanes.json"
+    lanes_path.parent.mkdir(parents=True, exist_ok=True)
+    lanes_path.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "Q1",
+                    "owner_session": "engineering-autopilot-Q1",
+                    "branch": "codex/example",
+                    "status": "active",
+                    "worktree": "/private/tmp/sensitive-worktree",
+                    "cwd": "/private/tmp/sensitive-worktree",
+                    "pid": 12345,
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    payload = mod.classify_handoffs(
+        repo_root=tmp_path,
+        state_root=tmp_path,
+        github_repo="synaptent/aragora",
+        outbox_file="open-pr-codex-example-aaaaaaaa.json",
+        github_client=FakeGitHub(),
+    )
+    owner_payload = payload["items"][0]["evidence"]["owner"]["payload"]
+
+    assert owner_payload["lane_id"] == "Q1"
+    assert "worktree" not in owner_payload
+    assert "cwd" not in owner_payload
+    assert "pid" not in owner_payload
+
+
+def test_human_owner_blocks_handoff(tmp_path: Path) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, branch="codex/example")
+    owner = FakeOwnerProbe(
+        {
+            "codex/example": {
+                "lane_id": "human-pr8570",
+                "owner_session": "human-operator-pr8570",
+                "source": "human",
+                "status": "blocked",
+                "owner_blocking_state": "live_owner",
+            }
+        }
+    )
+
+    item = _classify_one(tmp_path, owner=owner)
+
+    assert item["state"] == mod.HandoffState.BLOCKED_BY_HUMAN.value
+
+
+def test_terminal_steering_receipt_consumes_blocking_effect(tmp_path: Path) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, branch="codex/example")
+    message_path = _write_steering_message(tmp_path, branch="codex/example")
+    _write_steering_receipt(message_path, outcome="completed")
+
+    item = _classify_one(tmp_path)
+
+    assert item["state"] == mod.HandoffState.BLOCKED_BY_OWNER.value
+    assert item["evidence"]["steering"]["pending_message_count"] == 1
+    assert item["evidence"]["steering"]["blocking_message_count"] == 1
+    assert item["evidence"]["steering"]["resolved_read_receipt_count"] == 1
+    assert item["evidence"]["steering"]["ack_protocol"] == "top_level_message_remains_pending"
+    assert item["evidence"]["steering"]["latest_read_receipt"]["outcome"] == "completed"
+    assert "resolved_message_count" not in item["evidence"]["steering"]
+    assert "resolved_by_read_receipt" not in item["evidence"]["steering"]["latest_message"]
+    assert "subject" not in item["evidence"]["steering"]["latest_message"]
+    assert "body" not in item["evidence"]["steering"]["latest_message"]
+    assert item["evidence"]["steering"]["latest_message"]["subject_present"] is True
+    assert item["evidence"]["steering"]["latest_message"]["body_present"] is True
+
+
+def test_nonterminal_steering_receipt_still_blocks(tmp_path: Path) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, branch="codex/example")
+    message_path = _write_steering_message(tmp_path, branch="codex/example")
+    _write_steering_receipt(message_path, outcome="blocked")
+
+    item = _classify_one(tmp_path)
+
+    assert item["state"] == mod.HandoffState.BLOCKED_BY_OWNER.value
+    assert item["evidence"]["steering"]["pending_message_count"] == 1
+    assert item["evidence"]["steering"]["blocking_message_count"] == 1
+    assert item["evidence"]["steering"]["human_message_count"] == 0
+    assert item["evidence"]["steering"]["latest_read_receipt"]["outcome"] == "blocked"
+
+
+def test_operator_steering_without_human_keyword_is_owner_block(tmp_path: Path) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, branch="codex/example")
+    _write_steering_message(tmp_path, branch="codex/example")
+
+    item = _classify_one(tmp_path)
+
+    assert item["state"] == mod.HandoffState.BLOCKED_BY_OWNER.value
+    assert item["evidence"]["steering"]["blocking_message_count"] == 1
+    assert item["evidence"]["steering"]["human_message_count"] == 0
+
+
+def test_steering_branch_match_does_not_use_substring(tmp_path: Path) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, branch="codex/example")
+    _write_steering_message(
+        tmp_path,
+        branch="codex/example-long",
+        owner_session="engineering-autopilot-Q1",
+    )
+
+    item = _classify_one(tmp_path)
+
+    assert item["state"] == mod.HandoffState.PUBLICATION_REQUESTED.value
+    assert item["evidence"]["steering"]["pending_message_count"] == 0
+
+
+def test_steering_branch_match_survives_trailing_punctuation(tmp_path: Path) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, branch="codex/example")
+    inbox = tmp_path / ".aragora" / "operator-steering" / "engineering-autopilot-Q1"
+    inbox.mkdir(parents=True, exist_ok=True)
+    (inbox / "2026-06-24T00-00-00-000Z-fixture.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "aragora-operator-steering/1.0",
+                "to_session": "engineering-autopilot-Q1",
+                "priority": "blocking",
+                "subject": "Block codex/example.",
+                "body": "Please resolve codex/example.",
+                "message_sha256": "fixture-sha",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    item = _classify_one(tmp_path)
+
+    assert item["state"] == mod.HandoffState.BLOCKED_BY_OWNER.value
+    assert item["evidence"]["steering"]["blocking_message_count"] == 1
+
+
+def test_steering_lane_hint_match_survives_github_pr_url_without_branch(
+    tmp_path: Path,
+) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, branch="codex/example")
+    inbox = tmp_path / ".aragora" / "operator-steering" / "engineering-autopilot-Q1"
+    inbox.mkdir(parents=True, exist_ok=True)
+    (inbox / "2026-06-24T00-00-00-000Z-pr-url.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "aragora-operator-steering/1.0",
+                "to_session": "engineering-autopilot-Q1",
+                "lane_id_hint": "Q1",
+                "priority": "blocking",
+                "subject": "Resolve https://github.com/synaptent/aragora/pull/8570",
+                "body": "Do not move non-owner state until that PR is represented.",
+                "message_sha256": "fixture-sha",
+            }
+        ),
+        encoding="utf-8",
+    )
+    owner = FakeOwnerProbe(
+        {
+            "codex/example": {
+                "lane_id": "Q1",
+                "owner_session": "engineering-autopilot-Q1",
+                "status": "released",
+                "stale_claim_advisory": {"available": True},
+            }
+        }
+    )
+
+    item = _classify_one(tmp_path, owner=owner)
+
+    assert item["state"] == mod.HandoffState.BLOCKED_BY_OWNER.value
+    assert item["evidence"]["steering"]["pending_message_count"] == 1
+    assert item["evidence"]["steering"]["blocking_message_count"] == 1
+
+
+def test_steering_to_session_requires_branch_or_lane_correlation(tmp_path: Path) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, branch="codex/example")
+    _write_steering_message(
+        tmp_path,
+        branch="codex/other",
+        owner_session="engineering-autopilot-Q1",
+    )
+    owner = FakeOwnerProbe(
+        {
+            "codex/example": {
+                "lane_id": "Q1",
+                "owner_session": "engineering-autopilot-Q1",
+                "status": "released",
+                "stale_claim_advisory": {"available": True},
+            }
+        }
+    )
+
+    item = _classify_one(tmp_path, owner=owner)
+
+    assert item["state"] == mod.HandoffState.PUBLICATION_REQUESTED.value
+    assert item["evidence"]["steering"]["pending_message_count"] == 0
+
+
+def test_steering_unrelated_branch_message_with_pr_url_stays_excluded(
+    tmp_path: Path,
+) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, branch="codex/example")
+    inbox = tmp_path / ".aragora" / "operator-steering" / "engineering-autopilot-Q1"
+    inbox.mkdir(parents=True, exist_ok=True)
+    (inbox / "2026-06-24T00-00-00-000Z-other-pr-url.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "aragora-operator-steering/1.0",
+                "to_session": "engineering-autopilot-Q1",
+                "priority": "blocking",
+                "subject": "Block codex/other",
+                "body": "Evidence: https://github.com/synaptent/aragora/pull/8570",
+                "message_sha256": "fixture-sha",
+            }
+        ),
+        encoding="utf-8",
+    )
+    owner = FakeOwnerProbe(
+        {
+            "codex/example": {
+                "lane_id": "Q1",
+                "owner_session": "engineering-autopilot-Q1",
+                "status": "released",
+                "stale_claim_advisory": {"available": True},
+            }
+        }
+    )
+
+    item = _classify_one(tmp_path, owner=owner)
+
+    assert item["state"] == mod.HandoffState.PUBLICATION_REQUESTED.value
+    assert item["evidence"]["steering"]["pending_message_count"] == 0
+
+
+def test_steering_session_wide_message_without_branch_or_lane_does_not_match(
+    tmp_path: Path,
+) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, branch="codex/example")
+    inbox = tmp_path / ".aragora" / "operator-steering" / "engineering-autopilot-Q1"
+    inbox.mkdir(parents=True, exist_ok=True)
+    (inbox / "2026-06-24T00-00-00-000Z-generic.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "aragora-operator-steering/1.0",
+                "to_session": "engineering-autopilot-Q1",
+                "priority": "blocking",
+                "subject": "Please wait",
+                "body": "Pause until the operator reviews this lane.",
+                "message_sha256": "fixture-sha",
+            }
+        ),
+        encoding="utf-8",
+    )
+    owner = FakeOwnerProbe(
+        {
+            "codex/example": {
+                "lane_id": "Q1",
+                "owner_session": "engineering-autopilot-Q1",
+                "status": "released",
+                "stale_claim_advisory": {"available": True},
+            }
+        }
+    )
+
+    item = _classify_one(tmp_path, owner=owner)
+
+    assert item["state"] == mod.HandoffState.PUBLICATION_REQUESTED.value
+    assert item["evidence"]["steering"]["pending_message_count"] == 0
+
+
+def test_human_detection_ignores_operator_steering_path() -> None:
+    assert (
+        mod._looks_human(  # noqa: SLF001 - regression coverage for classifier helper
+            {
+                "path": "/repo/.aragora/operator-steering/worker/message.json",
+                "from": "automation",
+                "subject": "Block codex/example",
+                "body": "Machine-generated lane advisory",
+            }
+        )
+        is False
+    )
+    assert mod._looks_human({"body": "non-human automated advisory"}) is False  # noqa: SLF001
+    assert mod._looks_human({"from": "operator"}) is False  # noqa: SLF001
+    assert mod._looks_human({"body": "operator approval required"}) is True  # noqa: SLF001
+
+
+def test_steering_lane_hint_requires_exact_token(tmp_path: Path) -> None:
+    inbox = tmp_path / ".aragora" / "operator-steering" / "engineering-autopilot-Q100"
+    inbox.mkdir(parents=True, exist_ok=True)
+    (inbox / "2026-06-24T00-00-00-000Z-q100.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "aragora-operator-steering/1.0",
+                "to_session": "engineering-autopilot-Q100",
+                "lane_id_hint": "Q100-read-steering",
+                "priority": "blocking",
+                "subject": "Block codex/other",
+                "body": "This message is for codex/other.",
+                "message_sha256": "fixture-sha",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    evidence = mod.steering_evidence_for_branch(
+        state_root=tmp_path,
+        branch="codex/example",
+        owner_session=None,
+        lane_id="Q1",
+    )
+
+    assert evidence.pending_message_count == 0
+
+
+def test_heads_match_accepts_reconcile_compatible_sha_prefix() -> None:
+    full_sha = "abcdef1234567890abcdef1234567890abcdef12"
+
+    assert mod.heads_match(full_sha, full_sha) is True
+    assert mod.heads_match("abcdef1", "abcdef1") is True
+    assert mod.heads_match("abcdef1", full_sha) is True
+    assert mod.heads_match(full_sha, "abcdef1") is True
+    assert mod.heads_match("abcdef", full_sha) is False
+    assert mod.heads_match("abcdeff", full_sha) is False
+
+
+def test_narrow_rest_queries_when_open_pr_cache_lacks_branch(
+    tmp_path: Path,
+) -> None:
+    client = mod.NarrowGitHubClient(
+        repo_root=tmp_path,
+        github_repo="synaptent/aragora",
+    )
+    seen: list[str] = []
+
+    def capture_api(endpoint: str) -> tuple[Any | None, str | None]:
+        seen.append(endpoint)
+        return [], None
+
+    client._api = capture_api  # type: ignore[method-assign]
+
+    open_prs, error = client.open_prs_for_branch("elves/run-example")
+
+    assert error is None
+    assert open_prs == []
+    assert seen == [
+        "repos/synaptent/aragora/pulls?state=open&head=synaptent:elves%2Frun-example&per_page=100&page=1"
+    ]
+
+
+def test_narrow_rest_open_pr_query_preserves_owner_separator(tmp_path: Path) -> None:
+    client = mod.NarrowGitHubClient(
+        repo_root=tmp_path,
+        github_repo="synaptent/aragora",
+    )
+    seen: list[str] = []
+
+    def capture_api(endpoint: str) -> tuple[Any | None, str | None]:
+        seen.append(endpoint)
+        return [], None
+
+    client._api = capture_api  # type: ignore[method-assign]
+
+    open_prs, error = client.open_prs_for_branch("codex/example")
+
+    assert error is None
+    assert open_prs == []
+    assert seen == [
+        "repos/synaptent/aragora/pulls?state=open&head=synaptent:codex%2Fexample&per_page=100&page=1"
+    ]
+
+
+def test_narrow_rest_open_pr_query_paginates_exact_branch_results(tmp_path: Path) -> None:
+    client = mod.NarrowGitHubClient(
+        repo_root=tmp_path,
+        github_repo="synaptent/aragora",
+    )
+    page_one = [{"number": index} for index in range(100)]
+    page_two = [{"number": 200}]
+    seen: list[str] = []
+
+    def capture_api(endpoint: str) -> tuple[Any | None, str | None]:
+        seen.append(endpoint)
+        if endpoint.endswith("page=1"):
+            return page_one, None
+        return page_two, None
+
+    client._api = capture_api  # type: ignore[method-assign]
+
+    open_prs, error = client.open_prs_for_branch("codex/example")
+
+    assert error is None
+    assert open_prs == [*page_one, *page_two]
+    assert seen == [
+        "repos/synaptent/aragora/pulls?state=open&head=synaptent:codex%2Fexample&per_page=100&page=1",
+        "repos/synaptent/aragora/pulls?state=open&head=synaptent:codex%2Fexample&per_page=100&page=2",
+    ]
+
+
+def test_narrow_rest_open_pr_query_fails_closed_when_page_cap_reached(tmp_path: Path) -> None:
+    client = mod.NarrowGitHubClient(
+        repo_root=tmp_path,
+        github_repo="synaptent/aragora",
+    )
+
+    def capture_api(endpoint: str) -> tuple[Any | None, str | None]:
+        return [{"number": index} for index in range(100)], None
+
+    client._api = capture_api  # type: ignore[method-assign]
+
+    open_prs, error = client.open_prs_for_branch("codex/example")
+
+    assert open_prs is None
+    assert "page cap" in (error or "")
+
+
+def test_narrow_rest_open_pr_query_fails_closed_for_malformed_github_repo(
+    tmp_path: Path,
+) -> None:
+    client = mod.NarrowGitHubClient(
+        repo_root=tmp_path,
+        github_repo="synaptent",
+    )
+
+    open_prs, error = client.open_prs_for_branch("codex/example")
+    ref, ref_error = client.remote_ref("codex/example")
+
+    assert open_prs is None
+    assert "owner/name" in (error or "")
+    assert ref is None
+    assert "owner/name" in (ref_error or "")
+
+
+def test_remote_ref_treats_structured_not_found_as_absent(tmp_path: Path) -> None:
+    client = mod.NarrowGitHubClient(
+        repo_root=tmp_path,
+        github_repo="synaptent/aragora",
+    )
+
+    def capture_api(endpoint: str) -> tuple[Any | None, str | None]:
+        return None, "github_not_found: gh api exited 1: HTTP 404: Not Found"
+
+    client._api = capture_api  # type: ignore[method-assign]
+
+    ref, error = client.remote_ref("codex/example")
+
+    assert ref is None
+    assert error is None
+
+
+def test_github_degraded_pr_lookup_fails_closed_for_publication(tmp_path: Path) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, branch="codex/example")
+    github = FakeGitHub(errors={"pr:codex/example": "gh api failed (TimeoutExpired)"})
+
+    item = _classify_one(tmp_path, github=github)
+
+    assert item["state"] == mod.HandoffState.UNKNOWN.value
+    assert "GitHub evidence is unavailable" in item["reason"]
+    assert item["next_mutation_candidate"] == "none"
+
+
+def test_github_degraded_pr_lookup_still_reports_local_owner_blocker(
+    tmp_path: Path,
+) -> None:
+    _write_status_cache(tmp_path, open_pr_cap_reached=False)
+    _write_outbox(tmp_path, branch="codex/example")
+    github = FakeGitHub(errors={"pr:codex/example": "gh api failed (TimeoutExpired)"})
+    owner = FakeOwnerProbe(
+        {
+            "codex/example": {
+                "available": True,
+                "matched": True,
+                "lane_id": "Q1",
+                "owner_session": "engineering-autopilot-Q1",
+                "owner_blocking_state": "live_owner",
+                "status": "active",
+            }
+        }
+    )
+
+    item = _classify_one(tmp_path, github=github, owner=owner)
+
+    assert item["state"] == mod.HandoffState.BLOCKED_BY_OWNER.value
+    assert item["evidence"]["github"]["mode"] == "degraded"
+    assert item["next_mutation_candidate"] == "owner_followup"
+
+
+def test_github_degraded_pr_lookup_still_reports_live_queue_cap(
+    tmp_path: Path,
+) -> None:
+    _write_status_cache(tmp_path, open_pr_cap_reached=True)
+    _write_outbox(tmp_path, branch="codex/example")
+    github = FakeGitHub(errors={"pr:codex/example": "gh api failed (TimeoutExpired)"})
+
+    item = _classify_one(tmp_path, github=github)
+
+    assert item["state"] == mod.HandoffState.BLOCKED_BY_LIVE_QUEUE_CAP.value
+    assert item["evidence"]["github"]["mode"] == "degraded"
+    assert item["next_mutation_candidate"] == "queue_drain"
+
+
+def test_missing_origin_disables_github_instead_of_defaulting_repo(tmp_path: Path) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, branch="codex/example")
+
+    payload = mod.classify_handoffs(
+        repo_root=tmp_path,
+        state_root=tmp_path,
+        outbox_file="open-pr-codex-example-aaaaaaaa.json",
+    )
+
+    assert payload["github_repo"] is None
+    assert payload["github"]["mode"] == "disabled"
+    assert payload["items"][0]["evidence"]["github"]["mode"] == "disabled"
+    assert payload["items"][0]["state"] == mod.HandoffState.UNKNOWN.value
+
+
+def test_default_state_root_uses_automation_state_root_env(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    state_repo = tmp_path / "shared"
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _write_status_cache(state_repo)
+    _write_outbox(state_repo, branch="codex/example")
+    monkeypatch.setenv("ARAGORA_AUTOMATION_STATE_ROOT", str(state_repo / ".aragora"))
+
+    payload = mod.classify_handoffs(
+        repo_root=repo,
+        github_repo="synaptent/aragora",
+        github_client=FakeGitHub(),
+    )
+
+    assert payload["outbox_count"] == 1
+    assert payload["state_root"] == str(state_repo / ".aragora")
+
+
+def test_text_summary_only_omits_items(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, branch="codex/example")
+
+    code = cli.main(
+        [
+            "--repo",
+            str(tmp_path),
+            "--state-root",
+            str(tmp_path),
+            "--outbox-file",
+            "open-pr-codex-example-aaaaaaaa.json",
+            "--summary-only",
+        ]
+    )
+    output = capsys.readouterr().out
+
+    assert code == 0
+    assert "counts:" in output
+    assert "items:" not in output
+
+
+def test_outbox_file_outside_outbox_fails_loudly(tmp_path: Path) -> None:
+    _write_status_cache(tmp_path)
+    outside = tmp_path / "outside.json"
+    outside.write_text("{}", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="outbox file must be inside"):
+        mod.classify_handoffs(
+            repo_root=tmp_path,
+            state_root=tmp_path,
+            github_repo="synaptent/aragora",
+            outbox_file=outside,
+            github_client=FakeGitHub(),
+        )
+
+
+def test_cli_fail_on_unsafe_state_returns_nonzero_for_disabled_github(
+    tmp_path: Path,
+) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, branch="codex/example")
+
+    code = cli.main(
+        [
+            "--repo",
+            str(tmp_path),
+            "--state-root",
+            str(tmp_path),
+            "--outbox-file",
+            "open-pr-codex-example-aaaaaaaa.json",
+            "--json",
+            "--fail-on-unsafe-state",
+        ]
+    )
+
+    assert code == 2
+
+
+def test_cli_fail_on_unsafe_state_rejects_partial_github_item_errors() -> None:
+    payload = {
+        "github": {"mode": "partial", "partial_degradation": True, "item_error_count": 1},
+        "items": [
+            {
+                "state": "blocked_by_owner",
+                "next_mutation_candidate": "owner_followup",
+                "safe_to_mutate": False,
+                "evidence": {"github": {"error": "gh api failed (TimeoutExpired)"}},
+            }
+        ],
+    }
+
+    assert cli._has_unsafe_state(payload) is True  # noqa: SLF001
+
+
+def test_cli_fail_on_unsafe_state_rejects_partial_github_even_when_items_look_safe() -> None:
+    payload = {
+        "github": {"mode": "partial", "partial_degradation": True, "item_error_count": 1},
+        "items": [
+            {
+                "state": "represented_by_exact_open_pr",
+                "next_mutation_candidate": "write_representation_receipt_then_archive",
+                "safe_to_mutate": True,
+            }
+        ],
+    }
+
+    assert cli._has_unsafe_state(payload) is True  # noqa: SLF001
+
+
+def test_cli_fail_on_unsafe_state_rejects_preserved_not_actionable() -> None:
+    payload = {
+        "github": {"mode": "ready"},
+        "items": [
+            {
+                "state": "preserved_not_actionable",
+                "next_mutation_candidate": "none",
+                "safe_to_mutate": False,
+            }
+        ],
+    }
+
+    assert cli._has_unsafe_state(payload) is True  # noqa: SLF001
+
+
+def test_cli_fail_on_unsafe_state_rejects_non_mutatable_exact_draft_pr() -> None:
+    payload = {
+        "github": {"mode": "ready"},
+        "items": [
+            {
+                "state": "represented_by_exact_open_pr",
+                "next_mutation_candidate": "none",
+                "safe_to_mutate": False,
+            }
+        ],
+    }
+
+    assert cli._has_unsafe_state(payload) is True  # noqa: SLF001
+
+
+def test_classify_reports_partial_github_errors_without_global_blindness(
+    tmp_path: Path,
+) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, key="open-pr-codex-safe-aaaaaaaa", branch="codex/safe")
+    _write_outbox(tmp_path, key="open-pr-codex-blocked-aaaaaaaa", branch="codex/blocked")
+    lanes_path = tmp_path / ".aragora" / "agent-bridge" / "lanes.json"
+    lanes_path.parent.mkdir(parents=True, exist_ok=True)
+    lanes_path.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "Q1",
+                    "owner_session": "engineering-autopilot-Q1",
+                    "branch": "codex/blocked",
+                    "status": "active",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    github = FakeGitHub(
+        open_prs={
+            "codex/safe": [
+                {
+                    "number": 8599,
+                    "state": "open",
+                    "draft": True,
+                    "head": {"ref": "codex/safe", "sha": HEAD},
+                }
+            ]
+        },
+        errors={"pr:codex/blocked": "gh api failed (TimeoutExpired)"},
+    )
+
+    payload = mod.classify_handoffs(
+        repo_root=tmp_path,
+        state_root=tmp_path,
+        github_repo="synaptent/aragora",
+        github_client=github,
+    )
+
+    assert payload["github"]["mode"] == "partial"
+    assert payload["github"]["item_error_count"] == 1
+    assert payload["counts"][mod.HandoffState.REPRESENTED_BY_EXACT_OPEN_PR.value] == 1
+    assert payload["counts"][mod.HandoffState.BLOCKED_BY_OWNER.value] == 1
+
+
+def test_owner_probe_failure_fails_closed(tmp_path: Path) -> None:
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    (scripts / "identify_lane_owner.py").write_text(
+        "import sys\nprint('database locked', file=sys.stderr)\nsys.exit(2)\n",
+        encoding="utf-8",
+    )
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, branch="codex/example")
+    owner = mod.OwnerProbe(repo_root=tmp_path, state_root=tmp_path, timeout_seconds=2)
+
+    item = _classify_one(tmp_path, owner=owner)
+
+    assert item["state"] == mod.HandoffState.BLOCKED_BY_OWNER.value
+    assert item["evidence"]["owner"]["available"] is False
+    assert item["evidence"]["owner"]["matched"] is False
+
+
+def test_owner_probe_no_matching_lane_does_not_block(tmp_path: Path) -> None:
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    (scripts / "identify_lane_owner.py").write_text(
+        "import sys\nprint('ERROR: no matching lane criteria', file=sys.stderr)\nsys.exit(1)\n",
+        encoding="utf-8",
+    )
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, branch="codex/example")
+    owner = mod.OwnerProbe(repo_root=tmp_path, state_root=tmp_path, timeout_seconds=2)
+
+    item = _classify_one(tmp_path, owner=owner)
+
+    assert item["state"] == mod.HandoffState.PUBLICATION_REQUESTED.value
+    assert item["evidence"]["owner"]["available"] is True
+    assert item["evidence"]["owner"]["matched"] is False
+
+
+def test_owner_probe_liveness_dirty_signal_blocks(tmp_path: Path) -> None:
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    (scripts / "identify_lane_owner.py").write_text(
+        "import json\n"
+        "print(json.dumps({"
+        "'branch': 'codex/example', "
+        "'status': 'released', "
+        "'dirty_worktree': True, "
+        "'stale_claim_advisory': {'available': True}"
+        "}))\n",
+        encoding="utf-8",
+    )
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, branch="codex/example")
+    owner = mod.OwnerProbe(repo_root=tmp_path, state_root=tmp_path, timeout_seconds=2)
+
+    item = _classify_one(tmp_path, owner=owner)
+
+    assert item["state"] == mod.HandoffState.BLOCKED_BY_POSSIBLE_UNPUSHED_WORK.value
+    assert item["evidence"]["owner"]["advisory_withheld"] == "possible_unpushed_work"
+
+
+def test_selected_outbox_file_cannot_escape_outbox_dir(tmp_path: Path) -> None:
+    outbox = tmp_path / ".aragora" / "automation-outbox"
+    outbox.mkdir(parents=True)
+    outside = tmp_path / ".aragora" / "outside.json"
+    outside.write_text("{}", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="outbox file must be inside"):
+        mod._selected_outbox_files(outbox, "../outside.json")  # noqa: SLF001
+
+
+def test_update_pr_idempotency_key_is_pr_publication_request() -> None:
+    assert mod.is_pr_publication_request({"idempotency_key": "update-pr-codex-example-abc123"})
+
+
+def test_requested_action_python_repr_is_pr_publication_request() -> None:
+    payload = {
+        "requested_action": "{'type': 'open_or_update_pr', 'branch': 'codex/example'}",
+    }
+
+    assert mod.is_pr_publication_request(payload)
+
+
+def test_graphql_degraded_cache_still_uses_rest_open_pr_fallback(tmp_path: Path) -> None:
+    _write_status_cache(tmp_path, open_pr_cap_reached=True, degraded=True)
+    _write_outbox(tmp_path, branch="codex/example")
+    github = FakeGitHub(
+        open_prs={
+            "codex/example": [
+                {
+                    "number": 8589,
+                    "state": "open",
+                    "draft": True,
+                    "head": {"ref": "codex/example", "sha": HEAD},
+                }
+            ]
+        }
+    )
+
+    item = _classify_one(tmp_path, github=github)
+
+    assert item["state"] == mod.HandoffState.REPRESENTED_BY_EXACT_OPEN_PR.value
+    assert item["evidence"]["queue_cap"]["degraded"] is True
+    assert item["evidence"]["github"]["exact_open_pr"]["number"] == 8589
+
+
+def test_open_pr_head_mismatch_does_not_count_as_exact_representation(tmp_path: Path) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, branch="codex/example")
+    github = FakeGitHub(
+        open_prs={
+            "codex/example": [
+                {
+                    "number": 9000,
+                    "state": "open",
+                    "draft": True,
+                    "head": {"ref": "codex/example", "sha": OTHER_HEAD},
+                }
+            ]
+        }
+    )
+
+    item = _classify_one(tmp_path, github=github)
+
+    assert item["state"] == mod.HandoffState.PUBLICATION_REQUESTED.value
+    assert item["evidence"]["github"]["exact_open_pr"] is None

--- a/tests/scripts/test_classify_handoff_state.py
+++ b/tests/scripts/test_classify_handoff_state.py
@@ -276,10 +276,44 @@ def test_exact_open_pr_representation_is_safe_without_owner_blockers(tmp_path: P
         }
     )
 
-    item = _classify_one(tmp_path, github=github)
+    item = _classify_one(tmp_path, github=github, owner=FakeOwnerProbe())
 
     assert item["state"] == mod.HandoffState.REPRESENTED_BY_EXACT_OPEN_PR.value
     assert item["safe_to_mutate"] is True
+
+
+def test_registry_only_owner_probe_representation_is_not_safe_to_mutate(
+    tmp_path: Path,
+) -> None:
+    _write_status_cache(tmp_path, open_pr_cap_reached=True)
+    _write_outbox(tmp_path, branch="codex/example")
+    github = FakeGitHub(
+        open_prs={
+            "codex/example": [
+                {
+                    "number": 8570,
+                    "state": "open",
+                    "draft": False,
+                    "html_url": "https://github.com/synaptent/aragora/pull/8570",
+                    "head": {"ref": "codex/example", "sha": HEAD},
+                }
+            ]
+        }
+    )
+
+    payload = mod.classify_handoffs(
+        repo_root=tmp_path,
+        state_root=tmp_path,
+        github_repo="synaptent/aragora",
+        outbox_file="open-pr-codex-example-aaaaaaaa.json",
+        github_client=github,
+    )
+    item = payload["items"][0]
+
+    assert item["state"] == mod.HandoffState.REPRESENTED_BY_EXACT_OPEN_PR.value
+    assert item["safe_to_mutate"] is False
+    assert item["next_mutation_candidate"] == "none"
+    assert "owner liveness helper was not used" in item["reason"]
 
 
 def test_exact_draft_open_pr_representation_is_not_safe_to_mutate(tmp_path: Path) -> None:
@@ -298,7 +332,7 @@ def test_exact_draft_open_pr_representation_is_not_safe_to_mutate(tmp_path: Path
         }
     )
 
-    item = _classify_one(tmp_path, github=github)
+    item = _classify_one(tmp_path, github=github, owner=FakeOwnerProbe())
 
     assert item["state"] == mod.HandoffState.REPRESENTED_BY_EXACT_OPEN_PR.value
     assert item["next_mutation_candidate"] == "none"
@@ -326,7 +360,7 @@ def test_open_pr_without_desired_head_fails_closed(tmp_path: Path) -> None:
         }
     )
 
-    item = _classify_one(tmp_path, github=github)
+    item = _classify_one(tmp_path, github=github, owner=FakeOwnerProbe())
 
     assert item["state"] == mod.HandoffState.UNKNOWN.value
     assert "no desired head" in item["reason"]
@@ -507,6 +541,33 @@ def test_exact_open_pr_representation_accepts_reconcile_sha_prefix(
     assert item["evidence"]["github"]["exact_open_pr"]["number"] == 8570
 
 
+def test_open_pr_sha_prefix_representation_is_not_safe_to_mutate(
+    tmp_path: Path,
+) -> None:
+    _write_status_cache(tmp_path, open_pr_cap_reached=True)
+    _write_outbox(tmp_path, branch="codex/example", head=HEAD[:12])
+    github = FakeGitHub(
+        open_prs={
+            "codex/example": [
+                {
+                    "number": 8570,
+                    "state": "open",
+                    "draft": False,
+                    "head": {"ref": "codex/example", "sha": HEAD},
+                    "base": {"ref": "main"},
+                }
+            ]
+        }
+    )
+
+    item = _classify_one(tmp_path, github=github, owner=FakeOwnerProbe())
+
+    assert item["state"] == mod.HandoffState.REPRESENTED_BY_EXACT_OPEN_PR.value
+    assert item["safe_to_mutate"] is False
+    assert item["next_mutation_candidate"] == "none"
+    assert "full desired-head SHA does not exactly match the PR head" in item["reason"]
+
+
 def test_exact_open_pr_representation_blocks_when_owner_probe_unavailable(
     tmp_path: Path,
 ) -> None:
@@ -659,6 +720,29 @@ def test_local_evidence_equivalent_sha_prefix_records_do_not_conflict(
 
     assert item["state"] == mod.HandoffState.PUBLICATION_REQUESTED.value
     assert "local_evidence" not in item["evidence"]
+
+
+def test_local_evidence_prefix_does_not_hide_multiple_full_heads(
+    tmp_path: Path,
+) -> None:
+    first = "abcdef1111111111111111111111111111111111"
+    second = "abcdef1222222222222222222222222222222222"
+    _write_status_cache(tmp_path, open_pr_cap_reached=False)
+    _write_outbox(
+        tmp_path,
+        branch="codex/example",
+        head="abcdef1",
+        local_evidence=[
+            {"branch": "codex/example", "desired_head_sha": "abcdef1"},
+            {"branch": "codex/example", "target_head_sha": first},
+            {"branch": "codex/example", "headRefOid": second},
+        ],
+    )
+
+    item = _classify_one(tmp_path, github=FakeGitHub())
+
+    assert item["state"] == mod.HandoffState.UNKNOWN.value
+    assert "multiple local_evidence records disagree" in item["reason"]
 
 
 def test_single_local_evidence_conflict_with_top_level_fails_closed(
@@ -1269,6 +1353,34 @@ def test_remote_exact_head_with_mismatched_open_pr_stays_publication_requested(
     assert item["state"] == mod.HandoffState.PUBLICATION_REQUESTED.value
     assert item["evidence"]["github"]["exact_open_pr"] is None
     assert item["evidence"]["github"]["remote_ref"]["sha"] == HEAD
+
+
+def test_remote_sha_prefix_representation_is_not_safe_to_mutate(
+    tmp_path: Path,
+) -> None:
+    _write_status_cache(tmp_path, open_pr_cap_reached=False)
+    _write_outbox(
+        tmp_path,
+        key="preserve-branch-codex-example-aaaaaaaa",
+        branch="codex/example",
+        head=HEAD[:12],
+        action_type="preserve_branch",
+    )
+    github = FakeGitHub(
+        refs={"codex/example": {"ref": "refs/heads/codex/example", "object": {"sha": HEAD}}}
+    )
+
+    item = _classify_one(
+        tmp_path,
+        outbox_file="preserve-branch-codex-example-aaaaaaaa.json",
+        github=github,
+        owner=FakeOwnerProbe(),
+    )
+
+    assert item["state"] == mod.HandoffState.REPRESENTED_BY_EXACT_REMOTE_BRANCH.value
+    assert item["safe_to_mutate"] is False
+    assert item["next_mutation_candidate"] == "none"
+    assert "full desired-head SHA does not exactly match the remote branch head" in item["reason"]
 
 
 def test_non_pr_remote_exact_head_with_mismatched_open_pr_is_not_mutable(
@@ -2439,7 +2551,7 @@ def test_text_summary_only_omits_items(
     )
     output = capsys.readouterr().out
 
-    assert code == 0
+    assert code == 2
     assert "counts:" in output
     assert "items:" not in output
 
@@ -2475,6 +2587,27 @@ def test_cli_fail_on_unsafe_state_returns_nonzero_for_disabled_github(
             "open-pr-codex-example-aaaaaaaa.json",
             "--json",
             "--fail-on-unsafe-state",
+        ]
+    )
+
+    assert code == 2
+
+
+def test_cli_returns_nonzero_for_unsafe_state_by_default(
+    tmp_path: Path,
+) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(tmp_path, branch="codex/example")
+
+    code = cli.main(
+        [
+            "--repo",
+            str(tmp_path),
+            "--state-root",
+            str(tmp_path),
+            "--outbox-file",
+            "open-pr-codex-example-aaaaaaaa.json",
+            "--json",
         ]
     )
 


### PR DESCRIPTION
## Summary
- add a read-only automation handoff-state classifier for `.aragora/automation-outbox` items
- classify exact-head PR/ref representation, terminal receipt evidence, owner/human gates, possible unpushed work, and queue-cap blockers
- document the classifier as reconcile-lane PR/outbox guardrail evidence

## Validation
- `python3 -m pytest tests/scripts/test_classify_handoff_state.py -q` -> 116 passed, 3 existing deprecation warnings
- `python3 -m ruff check scripts/classify_handoff_state.py scripts/handoff_state.py tests/scripts/test_classify_handoff_state.py` -> passed
- `python3 -m py_compile scripts/classify_handoff_state.py scripts/handoff_state.py` -> passed
- `python3 scripts/classify_handoff_state.py --repo /private/tmp/aragora-handoff-state-classifier-r2 --state-root /Users/armand/Development/aragora/.aragora --json --summary-only` -> 25 outbox items classified, GitHub mode ready, 23 blocked_by_owner, 2 blocked_by_human
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> passed

## Notes
The shared-root reconcile-lane doc copy was stale relative to current `origin/main`, so this PR keeps the stronger current safety language and adds only the classifier reference.