### PR TITLE
Fix handoff classifier dissent edge cases

### DIFF
--- a/scripts/classify_handoff_state.py
+++ b/scripts/classify_handoff_state.py
@@ -82,9 +82,8 @@ def _build_parser() -> argparse.ArgumentParser:
         "--fail-on-unsafe-state",
         action="store_true",
         help=(
-            "Compatibility flag. Unsafe classifications now exit 2 by default when "
-            "classification is unknown, GitHub evidence is unavailable, or any item "
-            "exposes an unsafe mutation candidate."
+            "Deprecated compatibility flag. Unsafe classifications exit 2 by default; "
+            "this flag is accepted for older callers that still pass it explicitly."
         ),
     )
     return parser
@@ -110,6 +109,13 @@ def _has_unsafe_state(payload: dict) -> bool:
     return False
 
 
+def _exit_code_for_payload(payload: dict, *, fail_on_unsafe_state: bool = False) -> int:
+    # Fail-closed exits are now the default; the flag remains an explicit
+    # compatibility alias so older callers do not get a misleading parser error.
+    _ = fail_on_unsafe_state
+    return 2 if _has_unsafe_state(payload) else 0
+
+
 def main(argv: list[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
     payload = classify_handoffs(
@@ -125,7 +131,7 @@ def main(argv: list[str] | None = None) -> int:
     output = compact_summary(payload) if args.summary_only else payload
     if args.json:
         print(json.dumps(output, indent=2, sort_keys=True))
-        return 2 if _has_unsafe_state(payload) else 0
+        return _exit_code_for_payload(payload, fail_on_unsafe_state=args.fail_on_unsafe_state)
 
     print(f"schema_version: {output['schema_version']}")
     print(f"generated_at: {output['generated_at']}")
@@ -138,7 +144,7 @@ def main(argv: list[str] | None = None) -> int:
         print("items:")
         for item in output.get("items", []):
             print(f"  {item.get('outbox_file')}: {item.get('state')} ({item.get('reason')})")
-    return 2 if _has_unsafe_state(payload) else 0
+    return _exit_code_for_payload(payload, fail_on_unsafe_state=args.fail_on_unsafe_state)
 
 
 if __name__ == "__main__":

--- a/scripts/handoff_state.py
+++ b/scripts/handoff_state.py
@@ -561,6 +561,8 @@ def _local_work_string_marker(value: str) -> bool:
         return False
     if normalized in LOCAL_WORK_TRUE_MARKER_VALUES:
         return True
+    # Unknown non-empty markers fail closed: producer-specific sentinels must be
+    # explicitly allowlisted before they can prove absence of local work.
     return True
 
 
@@ -1666,6 +1668,8 @@ def _head_values_conflict(values: Sequence[str]) -> bool:
     full_values.discard(None)
     if len(full_values) > 1:
         return True
+    # A full SHA and its usable prefix describe the same head; only unrelated
+    # representatives should make multiple local-evidence records conflict.
     representatives: list[str] = []
     for value in normalized:
         if not any(heads_match(value, existing) for existing in representatives):

--- a/tests/scripts/test_classify_handoff_state.py
+++ b/tests/scripts/test_classify_handoff_state.py
@@ -316,6 +316,46 @@ def test_registry_only_owner_probe_representation_is_not_safe_to_mutate(
     assert "owner liveness helper was not used" in item["reason"]
 
 
+def test_liveness_helper_exact_open_pr_representation_can_be_safe_to_mutate(
+    tmp_path: Path,
+) -> None:
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    (scripts / "identify_lane_owner.py").write_text(
+        "import sys\nprint('ERROR: no matching lane criteria', file=sys.stderr)\nsys.exit(1)\n",
+        encoding="utf-8",
+    )
+    _write_status_cache(tmp_path, open_pr_cap_reached=True)
+    _write_outbox(tmp_path, branch="codex/example")
+    github = FakeGitHub(
+        open_prs={
+            "codex/example": [
+                {
+                    "number": 8570,
+                    "state": "open",
+                    "draft": False,
+                    "html_url": "https://github.com/synaptent/aragora/pull/8570",
+                    "head": {"ref": "codex/example", "sha": HEAD},
+                }
+            ]
+        }
+    )
+
+    payload = mod.classify_handoffs(
+        repo_root=tmp_path,
+        state_root=tmp_path,
+        github_repo="synaptent/aragora",
+        outbox_file="open-pr-codex-example-aaaaaaaa.json",
+        github_client=github,
+        with_liveness_helper=True,
+    )
+    item = payload["items"][0]
+
+    assert item["state"] == mod.HandoffState.REPRESENTED_BY_EXACT_OPEN_PR.value
+    assert item["next_mutation_candidate"] == "write_representation_receipt_then_archive"
+    assert item["safe_to_mutate"] is True
+
+
 def test_exact_draft_open_pr_representation_is_not_safe_to_mutate(tmp_path: Path) -> None:
     _write_status_cache(tmp_path)
     _write_outbox(tmp_path, branch="codex/example")
@@ -719,6 +759,39 @@ def test_local_evidence_equivalent_sha_prefix_records_do_not_conflict(
     item = _classify_one(tmp_path, github=FakeGitHub())
 
     assert item["state"] == mod.HandoffState.PUBLICATION_REQUESTED.value
+    assert "local_evidence" not in item["evidence"]
+
+
+def test_local_evidence_equivalent_sha_prefix_records_can_prove_exact_open_pr(
+    tmp_path: Path,
+) -> None:
+    _write_status_cache(tmp_path, open_pr_cap_reached=False)
+    _write_outbox(
+        tmp_path,
+        branch="codex/example",
+        head=HEAD,
+        local_evidence=[
+            {"branch": "codex/example", "desired_head_sha": HEAD},
+            {"branch": "codex/example", "target_head_sha": HEAD[:12]},
+        ],
+    )
+    github = FakeGitHub(
+        open_prs={
+            "codex/example": [
+                {
+                    "number": 8570,
+                    "state": "open",
+                    "draft": False,
+                    "html_url": "https://github.com/synaptent/aragora/pull/8570",
+                    "head": {"ref": "codex/example", "sha": HEAD},
+                }
+            ]
+        }
+    )
+
+    item = _classify_one(tmp_path, github=github, owner=FakeOwnerProbe())
+
+    assert item["state"] == mod.HandoffState.REPRESENTED_BY_EXACT_OPEN_PR.value
     assert "local_evidence" not in item["evidence"]
 
 
@@ -1619,6 +1692,26 @@ def test_local_evidence_negative_local_work_marker_does_not_block_publication(
 
     assert item["state"] == mod.HandoffState.PUBLICATION_REQUESTED.value
     assert item["evidence"]["owner"]["advisory_withheld"] is None
+
+
+def test_local_evidence_unknown_local_work_marker_fails_closed(tmp_path: Path) -> None:
+    _write_status_cache(tmp_path)
+    _write_outbox(
+        tmp_path,
+        branch="codex/example",
+        local_evidence=[
+            {
+                "branch": "codex/example",
+                "desired_head_sha": HEAD,
+                "local_work": "producer-specific-sentinel",
+            }
+        ],
+    )
+
+    item = _classify_one(tmp_path, github=FakeGitHub())
+
+    assert item["state"] == mod.HandoffState.BLOCKED_BY_POSSIBLE_UNPUSHED_WORK.value
+    assert item["evidence"]["owner"]["advisory_withheld"] == "possible_unpushed_work"
 
 
 def test_lane_registry_terminal_owner_does_not_block_by_default(
@@ -2591,6 +2684,34 @@ def test_cli_fail_on_unsafe_state_returns_nonzero_for_disabled_github(
     )
 
     assert code == 2
+
+
+def test_cli_fail_on_unsafe_state_flag_is_default_compatibility_alias() -> None:
+    safe_payload = {
+        "github": {"mode": "ready"},
+        "items": [
+            {
+                "state": "represented_by_exact_open_pr",
+                "next_mutation_candidate": "write_representation_receipt_then_archive",
+                "safe_to_mutate": True,
+            }
+        ],
+    }
+    unsafe_payload = {
+        "github": {"mode": "ready"},
+        "items": [
+            {
+                "state": "represented_by_exact_open_pr",
+                "next_mutation_candidate": "none",
+                "safe_to_mutate": False,
+            }
+        ],
+    }
+
+    assert cli._exit_code_for_payload(safe_payload) == 0  # noqa: SLF001
+    assert cli._exit_code_for_payload(safe_payload, fail_on_unsafe_state=True) == 0  # noqa: SLF001
+    assert cli._exit_code_for_payload(unsafe_payload) == 2  # noqa: SLF001
+    assert cli._exit_code_for_payload(unsafe_payload, fail_on_unsafe_state=True) == 2  # noqa: SLF001
 
 
 def test_cli_returns_nonzero_for_unsafe_state_by_default(


### PR DESCRIPTION
## Summary
- follow up on the valid #8662 model dissent after #8662 merged before the repair could be pushed
- keep unknown local-work sentinels fail-closed and pin equivalent SHA-prefix local evidence behavior
- clarify that --fail-on-unsafe-state is a compatibility alias because unsafe states already exit nonzero by default
- add focused tests for liveness-helper mutation-safe classification, SHA-prefix local evidence, unknown local-work sentinels, and CLI exit-code compatibility

## Validation
- pytest tests/scripts/test_classify_handoff_state.py -q
- python3 -m ruff check scripts/classify_handoff_state.py scripts/handoff_state.py tests/scripts/test_classify_handoff_state.py
- git diff --check origin/main...HEAD
- python3 scripts/check_portability.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD

No model evidence, settlement, workflow rerun, or merge was performed.