### PR TITLE
fix(handoff): share target PR receipt extraction

### DIFF
--- a/scripts/cache_codex_automation_github_status.py
+++ b/scripts/cache_codex_automation_github_status.py
@@ -28,7 +28,12 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from scripts.github_cli_health import check_github_cli_health
-from scripts.handoff_state import TargetPrReference, target_pr_reference_from_receipt
+from scripts.handoff_state import (
+    TargetPrReference,
+    target_pr_reference_from_receipt,
+    target_pr_reference_label,
+    target_pr_references_match,
+)
 from scripts.publish_automation_handoffs import _open_boss_ready_count
 from scripts.publish_codex_automation_branches import (
     CODEX_BRANCH_PREFIX,
@@ -257,15 +262,11 @@ def _target_pr_references_match(
     right: TargetPrReference,
     default_repo: str = DEFAULT_REPO,
 ) -> bool:
-    if left.number != right.number:
-        return False
-    left_repo = (left.repo or default_repo).strip()
-    right_repo = (right.repo or default_repo).strip()
-    return left_repo == right_repo
+    return target_pr_references_match(left, right, default_repo)
 
 
 def _target_pr_reference_label(reference: TargetPrReference) -> str:
-    return f"{reference.repo or DEFAULT_REPO}#{reference.number}"
+    return target_pr_reference_label(reference, DEFAULT_REPO)
 
 
 def _target_pr_reference(payload: Mapping[str, Any]) -> TargetPrReference | None:
@@ -319,7 +320,6 @@ def _stale_target_pr_receipt_evidence(
     branch: str,
     receipt_payload: Mapping[str, Any],
 ) -> dict[str, str] | None:
-    _ = (repo_root, branch)
     reason = str(receipt_payload.get("reason") or "").strip().lower()
     outbox_reference = _target_pr_reference(outbox_payload)
     if reason != "target_open_pr" or outbox_reference is None:
@@ -349,6 +349,14 @@ def _stale_target_pr_receipt_evidence(
         }
     if receipt_head:
         return None
+    if receipt_reference is None:
+        remote_head = _remote_tracking_head(repo_root, branch)
+        if remote_head and remote_head == desired_head:
+            return None
+        return {
+            "outbox_target_pr": _target_pr_reference_label(outbox_reference),
+            "reason": "target_pr_receipt_missing",
+        }
 
     # Target-PR receipts are proved by the target PR, not by the original
     # handoff branch. If the receipt lacks a target_pr_head_sha, keep the local
@@ -534,6 +542,7 @@ def _local_queue_state(
                 unsatisfied_receipted_outbox.append(unsatisfied_evidence)
                 if unsatisfied_evidence.get("reason") in {
                     "receipt_head_mismatch",
+                    "target_pr_receipt_missing",
                     "target_pr_reference_mismatch",
                 }:
                     stale_target_pr_receipted_outbox.append(unsatisfied_evidence)

--- a/scripts/cache_codex_automation_github_status.py
+++ b/scripts/cache_codex_automation_github_status.py
@@ -28,6 +28,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from scripts.github_cli_health import check_github_cli_health
+from scripts.handoff_state import target_pr_number_from_receipt
 from scripts.publish_automation_handoffs import _open_boss_ready_count
 from scripts.publish_codex_automation_branches import (
     CODEX_BRANCH_PREFIX,
@@ -252,12 +253,7 @@ def _head_from_receipt(payload: Mapping[str, Any]) -> str:
 
 
 def _requests_target_pr(payload: Mapping[str, Any]) -> bool:
-    if str(payload.get("target_pr") or "").strip():
-        return True
-    requested_action = _mapping_from_action(payload.get("requested_action"))
-    if requested_action is None:
-        return False
-    return bool(str(requested_action.get("target_pr") or "").strip())
+    return target_pr_number_from_receipt(payload) is not None
 
 
 def _is_pr_publication_request(payload: Mapping[str, Any]) -> bool:

--- a/scripts/cache_codex_automation_github_status.py
+++ b/scripts/cache_codex_automation_github_status.py
@@ -28,7 +28,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from scripts.github_cli_health import check_github_cli_health
-from scripts.handoff_state import target_pr_number_from_receipt
+from scripts.handoff_state import TargetPrReference, target_pr_reference_from_receipt
 from scripts.publish_automation_handoffs import _open_boss_ready_count
 from scripts.publish_codex_automation_branches import (
     CODEX_BRANCH_PREFIX,
@@ -252,8 +252,28 @@ def _head_from_receipt(payload: Mapping[str, Any]) -> str:
     return ""
 
 
+def _target_pr_references_match(
+    left: TargetPrReference,
+    right: TargetPrReference,
+    default_repo: str = DEFAULT_REPO,
+) -> bool:
+    if left.number != right.number:
+        return False
+    left_repo = (left.repo or default_repo).strip()
+    right_repo = (right.repo or default_repo).strip()
+    return left_repo == right_repo
+
+
+def _target_pr_reference_label(reference: TargetPrReference) -> str:
+    return f"{reference.repo or DEFAULT_REPO}#{reference.number}"
+
+
+def _target_pr_reference(payload: Mapping[str, Any]) -> TargetPrReference | None:
+    return target_pr_reference_from_receipt(payload)
+
+
 def _requests_target_pr(payload: Mapping[str, Any]) -> bool:
-    return target_pr_number_from_receipt(payload) is not None
+    return _target_pr_reference(payload) is not None
 
 
 def _is_pr_publication_request(payload: Mapping[str, Any]) -> bool:
@@ -299,9 +319,22 @@ def _stale_target_pr_receipt_evidence(
     branch: str,
     receipt_payload: Mapping[str, Any],
 ) -> dict[str, str] | None:
+    _ = (repo_root, branch)
     reason = str(receipt_payload.get("reason") or "").strip().lower()
-    if reason != "target_open_pr" or not _requests_target_pr(outbox_payload):
+    outbox_reference = _target_pr_reference(outbox_payload)
+    if reason != "target_open_pr" or outbox_reference is None:
         return None
+
+    receipt_reference = _target_pr_reference(receipt_payload)
+    if receipt_reference is not None and not _target_pr_references_match(
+        outbox_reference,
+        receipt_reference,
+    ):
+        return {
+            "outbox_target_pr": _target_pr_reference_label(outbox_reference),
+            "receipt_target_pr": _target_pr_reference_label(receipt_reference),
+            "reason": "target_pr_reference_mismatch",
+        }
 
     desired_head = _desired_head_from_outbox(outbox_payload)
     if not desired_head:
@@ -317,13 +350,10 @@ def _stale_target_pr_receipt_evidence(
     if receipt_head:
         return None
 
-    remote_head = _remote_tracking_head(repo_root, branch)
-    if remote_head and remote_head != desired_head:
-        return {
-            "desired_head_sha": desired_head,
-            "remote_head_sha": remote_head,
-            "reason": "remote_tracking_head_mismatch",
-        }
+    # Target-PR receipts are proved by the target PR, not by the original
+    # handoff branch. If the receipt lacks a target_pr_head_sha, keep the local
+    # cache neutral; reconcile can query the PR directly when stronger proof is
+    # required.
     return None
 
 
@@ -504,7 +534,7 @@ def _local_queue_state(
                 unsatisfied_receipted_outbox.append(unsatisfied_evidence)
                 if unsatisfied_evidence.get("reason") in {
                     "receipt_head_mismatch",
-                    "remote_tracking_head_mismatch",
+                    "target_pr_reference_mismatch",
                 }:
                     stale_target_pr_receipted_outbox.append(unsatisfied_evidence)
 

--- a/scripts/cache_codex_automation_github_status.py
+++ b/scripts/cache_codex_automation_github_status.py
@@ -314,6 +314,8 @@ def _stale_target_pr_receipt_evidence(
             "receipt_head_sha": receipt_head,
             "reason": "receipt_head_mismatch",
         }
+    if receipt_head:
+        return None
 
     remote_head = _remote_tracking_head(repo_root, branch)
     if remote_head and remote_head != desired_head:

--- a/scripts/cache_codex_automation_github_status.py
+++ b/scripts/cache_codex_automation_github_status.py
@@ -358,11 +358,14 @@ def _stale_target_pr_receipt_evidence(
             "reason": "target_pr_receipt_missing",
         }
 
-    # Target-PR receipts are proved by the target PR, not by the original
-    # handoff branch. If the receipt lacks a target_pr_head_sha, keep the local
-    # cache neutral; reconcile can query the PR directly when stronger proof is
-    # required.
-    return None
+    remote_head = _remote_tracking_head(repo_root, branch)
+    if remote_head and remote_head == desired_head:
+        return None
+    return {
+        "outbox_target_pr": _target_pr_reference_label(outbox_reference),
+        "receipt_target_pr": _target_pr_reference_label(receipt_reference),
+        "reason": "target_pr_receipt_missing",
+    }
 
 
 def _unsatisfied_receipt_evidence(

--- a/scripts/handoff_state.py
+++ b/scripts/handoff_state.py
@@ -674,6 +674,7 @@ def classify_handoffs(
             github_client=gh,
             owner_probe=owner,
             state_root=state_root,
+            default_repo=github_repo,
             steering_rows=steering_rows,
         )
         gh_error = item.evidence.get("github", {}).get("error")
@@ -716,13 +717,14 @@ def classify_handoff_item(
     github_client: Any,
     owner_probe: Any,
     state_root: Path,
+    default_repo: str | None = None,
     steering_rows: Sequence[Mapping[str, Any]] | None = None,
 ) -> HandoffClassification:
     idem = str(payload.get("idempotency_key") or path.stem).strip() or path.stem
     branch = branch_from_payload(payload)
     desired_head = desired_head_from_payload(payload)
     desired_base = desired_base_from_payload(payload)
-    receipt_evidence = receipt_evidence_from_payload(receipt, payload)
+    receipt_evidence = receipt_evidence_from_payload(receipt, payload, default_repo=default_repo)
 
     evidence: dict[str, Any] = {
         "receipt": dataclasses.asdict(receipt_evidence),
@@ -1193,10 +1195,16 @@ def github_evidence_for_branch(
     if exact_open_pr is None and target_pr is not None:
         client_repo = _normalize_github_repo_name(str(getattr(github_client, "github_repo", "")))
         normalized_target_repo = _normalize_github_repo_name(target_pr_repo or "")
-        if normalized_target_repo and client_repo and normalized_target_repo != client_repo:
+        if not normalized_target_repo and not client_repo:
+            target_pr_error = "target PR repo is unavailable; skipping target PR lookup"
+        elif normalized_target_repo and client_repo and normalized_target_repo != client_repo:
             target_pr_error = (
                 f"target PR repo {target_pr_repo} differs from configured repo "
                 f"{getattr(github_client, 'github_repo', '')}"
+            )
+        elif normalized_target_repo and not client_repo:
+            target_pr_error = (
+                f"target PR repo {target_pr_repo} cannot be checked without configured repo"
             )
         else:
             target_payload, target_pr_error = _open_pr_by_number(github_client, target_pr)
@@ -1393,9 +1401,15 @@ def _receipt_sort_timestamp(receipt: Mapping[str, Any], path: Path) -> float:
 def receipt_evidence_from_payload(
     receipt: Mapping[str, Any] | None,
     outbox_payload: Mapping[str, Any],
+    *,
+    default_repo: str | None = None,
 ) -> ReceiptEvidence:
     outbox_reference = target_pr_reference_from_receipt(outbox_payload)
     if receipt is None:
+        if outbox_reference is not None:
+            outbox_reference = _target_pr_reference_with_default_repo(
+                outbox_reference, default_repo
+            )
         return ReceiptEvidence(
             target_pr=outbox_reference.number if outbox_reference is not None else None,
             target_pr_repo=outbox_reference.repo if outbox_reference is not None else None,
@@ -1412,7 +1426,7 @@ def receipt_evidence_from_payload(
     )
     receipt_reference = target_pr_reference_from_receipt(receipt)
     target_pr_mismatch = None
-    default_repo = _repo_name_from_mapping(outbox_payload)
+    default_repo = _repo_name_from_mapping(outbox_payload) or default_repo
     if (
         receipt_reference is not None
         and outbox_reference is not None
@@ -1426,6 +1440,8 @@ def receipt_evidence_from_payload(
         reference = None
     else:
         reference = receipt_reference or outbox_reference
+    if reference is not None:
+        reference = _target_pr_reference_with_default_repo(reference, default_repo)
     return ReceiptEvidence(
         status=status,
         reason=reason,
@@ -2285,6 +2301,18 @@ def _target_pr_reference_with_mapping_repo(
     if reference.repo:
         return reference
     repo = _repo_name_from_mapping(mapping)
+    if repo is None:
+        return reference
+    return TargetPrReference(number=reference.number, repo=repo)
+
+
+def _target_pr_reference_with_default_repo(
+    reference: TargetPrReference,
+    default_repo: str | None,
+) -> TargetPrReference:
+    if reference.repo:
+        return reference
+    repo = _normalize_github_repo_name(default_repo or "")
     if repo is None:
         return reference
     return TargetPrReference(number=reference.number, repo=repo)

--- a/scripts/handoff_state.py
+++ b/scripts/handoff_state.py
@@ -17,7 +17,7 @@ from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
 from typing import Any
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 
 try:  # Works both as ``python scripts/handoff_state.py`` and as ``scripts.handoff_state``.
     from scripts.github_cli_health import github_cli_env
@@ -2199,11 +2199,22 @@ def _target_pr_reference_from_value(value: Any) -> TargetPrReference | None:
     if not candidate.isdigit():
         return None
     repo = _github_repo_from_pull_url_prefix(repo_part)
+    parsed_repo_part = urlparse(repo_part.strip())
+    if repo is None and (parsed_repo_part.scheme or parsed_repo_part.netloc):
+        return None
     return TargetPrReference(number=int(candidate), repo=repo)
 
 
 def _github_repo_from_pull_url_prefix(prefix: str) -> str | None:
-    parts = [part for part in prefix.strip("/").split("/") if part]
+    value = prefix.strip()
+    parsed = urlparse(value)
+    if parsed.scheme or parsed.netloc:
+        if parsed.scheme not in {"http", "https"}:
+            return None
+        if parsed.netloc.lower() != "github.com":
+            return None
+        value = parsed.path
+    parts = [part for part in value.strip("/").split("/") if part]
     if len(parts) < 2:
         return None
     owner = parts[-2]

--- a/scripts/handoff_state.py
+++ b/scripts/handoff_state.py
@@ -173,6 +173,12 @@ class ReceiptEvidence:
     target_pr: int | None = None
 
 
+@dataclass(frozen=True)
+class TargetPrReference:
+    number: int
+    repo: str | None = None
+
+
 @dataclass
 class OwnerEvidence:
     available: bool = False
@@ -1644,25 +1650,30 @@ TARGET_PR_URL_KEYS = (
 )
 
 
-def target_pr_number_from_receipt(receipt: Mapping[str, Any]) -> int | None:
-    number = _target_pr_number_from_mapping(receipt)
-    if number is not None:
-        return number
+def target_pr_reference_from_receipt(receipt: Mapping[str, Any]) -> TargetPrReference | None:
+    reference = _target_pr_reference_from_mapping(receipt)
+    if reference is not None:
+        return reference
     requested_action = _mapping_from_action(receipt.get("requested_action"))
     if requested_action is not None:
-        return _target_pr_number_from_mapping(requested_action)
+        return _target_pr_reference_from_mapping(requested_action)
     return None
 
 
-def _target_pr_number_from_mapping(mapping: Mapping[str, Any]) -> int | None:
+def target_pr_number_from_receipt(receipt: Mapping[str, Any]) -> int | None:
+    reference = target_pr_reference_from_receipt(receipt)
+    return reference.number if reference is not None else None
+
+
+def _target_pr_reference_from_mapping(mapping: Mapping[str, Any]) -> TargetPrReference | None:
     for key in TARGET_PR_NUMBER_KEYS:
-        number = _pr_number_from_value(mapping.get(key))
-        if number is not None:
-            return number
+        reference = _target_pr_reference_from_value(mapping.get(key))
+        if reference is not None:
+            return reference
     for key in TARGET_PR_URL_KEYS:
-        number = _pr_number_from_value(mapping.get(key))
-        if number is not None:
-            return number
+        reference = _target_pr_reference_from_value(mapping.get(key))
+        if reference is not None:
+            return reference
     return None
 
 
@@ -2170,16 +2181,36 @@ def _first_text(mapping: Mapping[str, Any], *keys: str) -> str | None:
 
 
 def _pr_number_from_value(value: Any) -> int | None:
+    reference = _target_pr_reference_from_value(value)
+    return reference.number if reference is not None else None
+
+
+def _target_pr_reference_from_value(value: Any) -> TargetPrReference | None:
     text = str(value or "").strip().rstrip("/")
     if not text:
         return None
     if text.isdigit():
-        return int(text)
+        return TargetPrReference(number=int(text))
     marker = "/pull/"
     if marker not in text:
         return None
-    candidate = text.rsplit(marker, 1)[1].split("/", 1)[0]
-    return int(candidate) if candidate.isdigit() else None
+    repo_part, suffix = text.rsplit(marker, 1)
+    candidate = suffix.split("/", 1)[0]
+    if not candidate.isdigit():
+        return None
+    repo = _github_repo_from_pull_url_prefix(repo_part)
+    return TargetPrReference(number=int(candidate), repo=repo)
+
+
+def _github_repo_from_pull_url_prefix(prefix: str) -> str | None:
+    parts = [part for part in prefix.strip("/").split("/") if part]
+    if len(parts) < 2:
+        return None
+    owner = parts[-2]
+    repo = parts[-1]
+    if owner.lower() in {"http:", "https:", "github.com"}:
+        return None
+    return f"{owner}/{repo}"
 
 
 def _int_or_none(value: Any) -> int | None:

--- a/scripts/handoff_state.py
+++ b/scripts/handoff_state.py
@@ -171,6 +171,7 @@ class ReceiptEvidence:
     issue_only_pr_receipt: bool = False
     path: str | None = None
     target_pr: int | None = None
+    target_pr_repo: str | None = None
 
 
 @dataclass(frozen=True)
@@ -758,6 +759,7 @@ def classify_handoff_item(
         desired_head,
         desired_base,
         target_pr=receipt_evidence.target_pr,
+        target_pr_repo=receipt_evidence.target_pr_repo,
     )
     evidence["github"] = dataclasses.asdict(github)
     owner = owner_probe.probe(branch) if branch else OwnerEvidence()
@@ -1152,6 +1154,7 @@ def github_evidence_for_branch(
     desired_head: str,
     desired_base: str = "",
     target_pr: int | None = None,
+    target_pr_repo: str | None = None,
 ) -> GitHubEvidence:
     open_prs, pr_error = github_client.open_prs_for_branch(branch)
     ref, ref_error = github_client.remote_ref(branch)
@@ -1176,14 +1179,22 @@ def github_evidence_for_branch(
                 break
     target_pr_error = None
     if exact_open_pr is None and target_pr is not None:
-        target_payload, target_pr_error = _open_pr_by_number(github_client, target_pr)
-        if target_payload is not None:
-            exact_open_pr = _exact_open_pr_from_payload(
-                target_payload,
-                desired_head=desired_head,
-                desired_base=desired_base,
-                expected_branch=branch,
+        client_repo = _normalize_github_repo_name(str(getattr(github_client, "github_repo", "")))
+        normalized_target_repo = _normalize_github_repo_name(target_pr_repo or "")
+        if normalized_target_repo and client_repo and normalized_target_repo != client_repo:
+            target_pr_error = (
+                f"target PR repo {target_pr_repo} differs from configured repo "
+                f"{getattr(github_client, 'github_repo', '')}"
             )
+        else:
+            target_payload, target_pr_error = _open_pr_by_number(github_client, target_pr)
+            if target_payload is not None:
+                exact_open_pr = _exact_open_pr_from_payload(
+                    target_payload,
+                    desired_head=desired_head,
+                    desired_base=desired_base,
+                    expected_branch=branch,
+                )
     remote_ref = None
     if ref is not None:
         obj = ref.get("object") if isinstance(ref.get("object"), Mapping) else {}
@@ -1371,8 +1382,12 @@ def receipt_evidence_from_payload(
     receipt: Mapping[str, Any] | None,
     outbox_payload: Mapping[str, Any],
 ) -> ReceiptEvidence:
+    outbox_reference = target_pr_reference_from_receipt(outbox_payload)
     if receipt is None:
-        return ReceiptEvidence(target_pr=target_pr_number_from_receipt(outbox_payload))
+        return ReceiptEvidence(
+            target_pr=outbox_reference.number if outbox_reference is not None else None,
+            target_pr_repo=outbox_reference.repo if outbox_reference is not None else None,
+        )
     status = str(receipt.get("status") or "").strip().lower() or None
     reason = str(receipt.get("reason") or "").strip().lower() or None
     has_pr = receipt_has_pr_reference(receipt)
@@ -1383,6 +1398,8 @@ def receipt_evidence_from_payload(
         and not has_pr
         and (reason in {"published", "existing_issue", "created_issue"} or has_issue)
     )
+    receipt_reference = target_pr_reference_from_receipt(receipt)
+    reference = receipt_reference or outbox_reference
     return ReceiptEvidence(
         status=status,
         reason=reason,
@@ -1390,8 +1407,8 @@ def receipt_evidence_from_payload(
         has_issue_reference=has_issue,
         issue_only_pr_receipt=issue_only,
         path=str(receipt.get("__receipt_path") or "") or None,
-        target_pr=target_pr_number_from_receipt(receipt)
-        or target_pr_number_from_receipt(outbox_payload),
+        target_pr=reference.number if reference is not None else None,
+        target_pr_repo=reference.repo if reference is not None else None,
     )
 
 
@@ -1648,6 +1665,7 @@ TARGET_PR_URL_KEYS = (
     "created_pull_request_url",
     "existing_pull_request_url",
 )
+TARGET_PR_REPO_KEYS = ("target_pr_repo", "repo", "github_repo")
 
 
 def target_pr_reference_from_receipt(receipt: Mapping[str, Any]) -> TargetPrReference | None:
@@ -1669,12 +1687,36 @@ def _target_pr_reference_from_mapping(mapping: Mapping[str, Any]) -> TargetPrRef
     for key in TARGET_PR_NUMBER_KEYS:
         reference = _target_pr_reference_from_value(mapping.get(key))
         if reference is not None:
-            return reference
+            return _target_pr_reference_with_mapping_repo(reference, mapping)
     for key in TARGET_PR_URL_KEYS:
         reference = _target_pr_reference_from_value(mapping.get(key))
         if reference is not None:
-            return reference
+            return _target_pr_reference_with_mapping_repo(reference, mapping)
     return None
+
+
+def target_pr_references_match(
+    left: TargetPrReference,
+    right: TargetPrReference,
+    default_repo: str | None = None,
+) -> bool:
+    if left.number != right.number:
+        return False
+    left_repo = _normalize_github_repo_name(left.repo or default_repo or "")
+    right_repo = _normalize_github_repo_name(right.repo or default_repo or "")
+    if not left_repo and not right_repo:
+        return True
+    return bool(left_repo and right_repo and left_repo == right_repo)
+
+
+def target_pr_reference_label(
+    reference: TargetPrReference,
+    default_repo: str | None = None,
+) -> str:
+    repo = _normalize_github_repo_name(reference.repo or default_repo or "") or (
+        reference.repo or default_repo or ""
+    )
+    return f"{repo}#{reference.number}" if repo else f"#{reference.number}"
 
 
 def heads_match(expected: str, actual: str) -> bool:
@@ -2202,7 +2244,47 @@ def _target_pr_reference_from_value(value: Any) -> TargetPrReference | None:
     parsed_repo_part = urlparse(repo_part.strip())
     if repo is None and (parsed_repo_part.scheme or parsed_repo_part.netloc):
         return None
-    return TargetPrReference(number=int(candidate), repo=repo)
+    return TargetPrReference(number=int(candidate), repo=_normalize_github_repo_name(repo or ""))
+
+
+def _target_pr_reference_with_mapping_repo(
+    reference: TargetPrReference,
+    mapping: Mapping[str, Any],
+) -> TargetPrReference:
+    if reference.repo:
+        return reference
+    repo = _repo_name_from_mapping(mapping)
+    if repo is None:
+        return reference
+    return TargetPrReference(number=reference.number, repo=repo)
+
+
+def _repo_name_from_mapping(mapping: Mapping[str, Any]) -> str | None:
+    for key in TARGET_PR_REPO_KEYS:
+        value = mapping.get(key)
+        if isinstance(value, Mapping):
+            normalized = _normalize_github_repo_name(str(value.get("full_name") or ""))
+        else:
+            normalized = _normalize_github_repo_name(str(value or ""))
+        if normalized:
+            return normalized
+    return None
+
+
+def _normalize_github_repo_name(value: str) -> str | None:
+    text = str(value or "").strip().removesuffix(".git").strip("/")
+    if not text:
+        return None
+    parsed = urlparse(text)
+    if parsed.scheme or parsed.netloc:
+        if parsed.netloc.lower() != "github.com":
+            return None
+        text = parsed.path.strip("/")
+    parts = [part for part in text.split("/") if part]
+    if len(parts) != 2:
+        return None
+    owner, repo = parts
+    return f"{owner.lower()}/{repo.lower()}"
 
 
 def _github_repo_from_pull_url_prefix(prefix: str) -> str | None:

--- a/scripts/handoff_state.py
+++ b/scripts/handoff_state.py
@@ -172,6 +172,7 @@ class ReceiptEvidence:
     path: str | None = None
     target_pr: int | None = None
     target_pr_repo: str | None = None
+    target_pr_mismatch: str | None = None
 
 
 @dataclass(frozen=True)
@@ -750,6 +751,17 @@ def classify_handoff_item(
             desired_head_sha=desired_head or None,
             state=HandoffState.UNKNOWN,
             reason="outbox payload has no branch",
+            evidence=evidence,
+        )
+
+    if receipt_evidence.target_pr_mismatch:
+        return HandoffClassification(
+            outbox_file=path.name,
+            idempotency_key=idem,
+            branch=branch,
+            desired_head_sha=desired_head or None,
+            state=HandoffState.UNKNOWN,
+            reason=receipt_evidence.target_pr_mismatch,
             evidence=evidence,
         )
 
@@ -1399,7 +1411,21 @@ def receipt_evidence_from_payload(
         and (reason in {"published", "existing_issue", "created_issue"} or has_issue)
     )
     receipt_reference = target_pr_reference_from_receipt(receipt)
-    reference = receipt_reference or outbox_reference
+    target_pr_mismatch = None
+    default_repo = _repo_name_from_mapping(outbox_payload)
+    if (
+        receipt_reference is not None
+        and outbox_reference is not None
+        and not target_pr_references_match(receipt_reference, outbox_reference, default_repo)
+    ):
+        target_pr_mismatch = (
+            "receipt target PR "
+            f"{target_pr_reference_label(receipt_reference, default_repo)} does not match "
+            f"outbox target PR {target_pr_reference_label(outbox_reference, default_repo)}"
+        )
+        reference = None
+    else:
+        reference = receipt_reference or outbox_reference
     return ReceiptEvidence(
         status=status,
         reason=reason,
@@ -1409,6 +1435,7 @@ def receipt_evidence_from_payload(
         path=str(receipt.get("__receipt_path") or "") or None,
         target_pr=reference.number if reference is not None else None,
         target_pr_repo=reference.repo if reference is not None else None,
+        target_pr_mismatch=target_pr_mismatch,
     )
 
 
@@ -1684,11 +1711,11 @@ def target_pr_number_from_receipt(receipt: Mapping[str, Any]) -> int | None:
 
 
 def _target_pr_reference_from_mapping(mapping: Mapping[str, Any]) -> TargetPrReference | None:
-    for key in TARGET_PR_NUMBER_KEYS:
+    for key in TARGET_PR_URL_KEYS:
         reference = _target_pr_reference_from_value(mapping.get(key))
         if reference is not None:
             return _target_pr_reference_with_mapping_repo(reference, mapping)
-    for key in TARGET_PR_URL_KEYS:
+    for key in TARGET_PR_NUMBER_KEYS:
         reference = _target_pr_reference_from_value(mapping.get(key))
         if reference is not None:
             return _target_pr_reference_with_mapping_repo(reference, mapping)
@@ -1868,7 +1895,11 @@ def _queue_cap_uncertain_for_publication(queue_cap: QueueCapEvidence) -> bool:
 
 
 def _terminal_receipt_satisfied(receipt: ReceiptEvidence) -> bool:
-    if receipt.status not in TERMINAL_RECEIPT_STATUSES or receipt.issue_only_pr_receipt:
+    if (
+        receipt.status not in TERMINAL_RECEIPT_STATUSES
+        or receipt.issue_only_pr_receipt
+        or receipt.target_pr_mismatch
+    ):
         return False
     return receipt.has_pr_reference or receipt.target_pr is not None
 

--- a/scripts/reconcile_automation_outbox.py
+++ b/scripts/reconcile_automation_outbox.py
@@ -42,7 +42,7 @@ from audit_codex_branch_backlog import (  # noqa: E402
     run_git,
 )
 from github_cli_health import check_github_cli_health  # noqa: E402
-from handoff_state import target_pr_number_from_receipt  # noqa: E402
+from handoff_state import TargetPrReference, target_pr_reference_from_receipt  # noqa: E402
 from identify_lane_owner import build_worktree_reference_preservation_proof  # noqa: E402
 
 UTC = timezone.utc
@@ -637,8 +637,20 @@ def _receipt_has_pr_reference(receipt: Mapping[str, Any]) -> bool:
     return False
 
 
-def _target_pr_number_from_receipt(receipt: Mapping[str, Any]) -> int | None:
-    return target_pr_number_from_receipt(receipt)
+def _target_pr_reference_from_receipt(receipt: Mapping[str, Any]) -> TargetPrReference | None:
+    return target_pr_reference_from_receipt(receipt)
+
+
+def _target_pr_references_match(
+    left: TargetPrReference,
+    right: TargetPrReference,
+    default_repo: str,
+) -> bool:
+    if left.number != right.number:
+        return False
+    left_repo = (left.repo or default_repo).strip()
+    right_repo = (right.repo or default_repo).strip()
+    return left_repo == right_repo
 
 
 def _target_pr_state(
@@ -647,19 +659,25 @@ def _target_pr_state(
     receipt: Mapping[str, Any],
     outbox_payload: Mapping[str, Any] | None = None,
 ) -> Mapping[str, Any] | None:
-    number = _target_pr_number_from_receipt(receipt)
-    if number is None and outbox_payload is not None:
-        number = _target_pr_number_from_receipt(outbox_payload)
-    if number is None:
+    reference = _target_pr_reference_from_receipt(receipt)
+    if reference is None:
         return None
-    repo = str(receipt.get("repo") or repo_name).strip() or repo_name
+    if outbox_payload is not None:
+        outbox_reference = _target_pr_reference_from_receipt(outbox_payload)
+        if outbox_reference is not None and not _target_pr_references_match(
+            reference, outbox_reference, repo_name
+        ):
+            return None
+    repo = (reference.repo or str(receipt.get("repo") or "").strip() or repo_name).strip()
+    if not repo:
+        return None
     try:
         proc = subprocess.run(
             [
                 "gh",
                 "pr",
                 "view",
-                str(number),
+                str(reference.number),
                 "--repo",
                 repo,
                 "--json",
@@ -703,6 +721,14 @@ def _merged_target_pr_receipt_resolution(
     desired_head = _desired_head_from_payload(payload)
     if not desired_head:
         return False, None
+    receipt_reference = _target_pr_reference_from_receipt(receipt)
+    if receipt_reference is None:
+        return False, None
+    payload_reference = _target_pr_reference_from_receipt(payload)
+    if payload_reference is not None and not _target_pr_references_match(
+        receipt_reference, payload_reference, repo_name
+    ):
+        return True, f"{receipt_label} target PR does not match handoff target PR"
 
     target_pr_state = _target_pr_state(root, repo_name, receipt, payload)
     if str((target_pr_state or {}).get("state") or "").strip().upper() != "MERGED":
@@ -1032,7 +1058,7 @@ def _receipt_handoff_keep_reason(
             f"{receipt_label} exists, but origin/{branch} is unavailable "
             f"and local desired head {short_desired} still needs publication"
         )
-    return None
+    return f"{receipt_label} exists, but no matching target PR or branch proof is available"
 
 
 def _superseded_targets(

--- a/scripts/reconcile_automation_outbox.py
+++ b/scripts/reconcile_automation_outbox.py
@@ -42,6 +42,7 @@ from audit_codex_branch_backlog import (  # noqa: E402
     run_git,
 )
 from github_cli_health import check_github_cli_health  # noqa: E402
+from handoff_state import target_pr_number_from_receipt  # noqa: E402
 from identify_lane_owner import build_worktree_reference_preservation_proof  # noqa: E402
 
 UTC = timezone.utc
@@ -650,22 +651,7 @@ def _pr_number_from_value(value: Any) -> int | None:
 
 
 def _target_pr_number_from_receipt(receipt: Mapping[str, Any]) -> int | None:
-    for key in ("target_pr", "pr_number", "pull_request_number"):
-        number = _pr_number_from_value(receipt.get(key))
-        if number is not None:
-            return number
-    for key in (
-        "created_pr_url",
-        "existing_pr_url",
-        "pr_url",
-        "pull_request_url",
-        "created_pull_request_url",
-        "existing_pull_request_url",
-    ):
-        number = _pr_number_from_value(receipt.get(key))
-        if number is not None:
-            return number
-    return None
+    return target_pr_number_from_receipt(receipt)
 
 
 def _target_pr_state(

--- a/scripts/reconcile_automation_outbox.py
+++ b/scripts/reconcile_automation_outbox.py
@@ -1061,6 +1061,13 @@ def _receipt_handoff_keep_reason(
     return f"{receipt_label} exists, but no matching target PR or branch proof is available"
 
 
+def _receipt_keep_counter(reason: str) -> str:
+    normalized = reason.lower()
+    if "not desired head" in normalized or "target pr does not match" in normalized:
+        return "blocked_receipt_pr_head_mismatch"
+    return "blocked_receipt_unverified_publication"
+
+
 def _superseded_targets(
     outbox_payloads: Sequence[tuple[Path, dict[str, Any]]],
 ) -> dict[tuple[str, str], dict[str, str]]:
@@ -1411,6 +1418,7 @@ def main(argv: list[str] | None = None) -> int:
         "satisfied_by_existing_receipt": 0,
         "archived_superseded_by_existing_issue": 0,
         "blocked_receipt_pr_head_mismatch": 0,
+        "blocked_receipt_unverified_publication": 0,
         "blocked_receipt_issue_only": 0,
         "satisfied_by_superseded_handoff": 0,
         "satisfied_by_landed_on_main": 0,
@@ -1525,7 +1533,7 @@ def main(argv: list[str] | None = None) -> int:
             )
             if target_pr_handled:
                 if target_pr_keep_reason is not None:
-                    counts["blocked_receipt_pr_head_mismatch"] += 1
+                    counts[_receipt_keep_counter(target_pr_keep_reason)] += 1
                     counts["still_protecting_active_work"] += 1
                     actions.append(
                         {
@@ -1555,7 +1563,7 @@ def main(argv: list[str] | None = None) -> int:
                     root, args.repo_name, payload, receipt, branch
                 )
                 if keep_reason is not None:
-                    counts["blocked_receipt_pr_head_mismatch"] += 1
+                    counts[_receipt_keep_counter(keep_reason)] += 1
                     counts["still_protecting_active_work"] += 1
                     actions.append(
                         {
@@ -1598,7 +1606,7 @@ def main(argv: list[str] | None = None) -> int:
                 root, args.repo_name, payload, receipt, branch
             )
             if keep_reason is not None:
-                counts["blocked_receipt_pr_head_mismatch"] += 1
+                counts[_receipt_keep_counter(keep_reason)] += 1
                 counts["still_protecting_active_work"] += 1
                 actions.append(
                     {

--- a/scripts/reconcile_automation_outbox.py
+++ b/scripts/reconcile_automation_outbox.py
@@ -42,7 +42,11 @@ from audit_codex_branch_backlog import (  # noqa: E402
     run_git,
 )
 from github_cli_health import check_github_cli_health  # noqa: E402
-from handoff_state import TargetPrReference, target_pr_reference_from_receipt  # noqa: E402
+from handoff_state import (  # noqa: E402
+    TargetPrReference,
+    target_pr_reference_from_receipt,
+    target_pr_references_match,
+)
 from identify_lane_owner import build_worktree_reference_preservation_proof  # noqa: E402
 
 UTC = timezone.utc
@@ -646,11 +650,7 @@ def _target_pr_references_match(
     right: TargetPrReference,
     default_repo: str,
 ) -> bool:
-    if left.number != right.number:
-        return False
-    left_repo = (left.repo or default_repo).strip()
-    right_repo = (right.repo or default_repo).strip()
-    return left_repo == right_repo
+    return target_pr_references_match(left, right, default_repo)
 
 
 def _target_pr_state(

--- a/scripts/reconcile_automation_outbox.py
+++ b/scripts/reconcile_automation_outbox.py
@@ -645,8 +645,11 @@ def _target_pr_state(
     root: Path,
     repo_name: str,
     receipt: Mapping[str, Any],
+    outbox_payload: Mapping[str, Any] | None = None,
 ) -> Mapping[str, Any] | None:
     number = _target_pr_number_from_receipt(receipt)
+    if number is None and outbox_payload is not None:
+        number = _target_pr_number_from_receipt(outbox_payload)
     if number is None:
         return None
     repo = str(receipt.get("repo") or repo_name).strip() or repo_name
@@ -701,7 +704,7 @@ def _merged_target_pr_receipt_resolution(
     if not desired_head:
         return False, None
 
-    target_pr_state = _target_pr_state(root, repo_name, receipt)
+    target_pr_state = _target_pr_state(root, repo_name, receipt, payload)
     if str((target_pr_state or {}).get("state") or "").strip().upper() != "MERGED":
         return False, None
 

--- a/scripts/reconcile_automation_outbox.py
+++ b/scripts/reconcile_automation_outbox.py
@@ -637,19 +637,6 @@ def _receipt_has_pr_reference(receipt: Mapping[str, Any]) -> bool:
     return False
 
 
-def _pr_number_from_value(value: Any) -> int | None:
-    text = str(value or "").strip().rstrip("/")
-    if not text:
-        return None
-    if text.isdigit():
-        return int(text)
-    marker = "/pull/"
-    if marker not in text:
-        return None
-    candidate = text.rsplit(marker, 1)[1].split("/", 1)[0]
-    return int(candidate) if candidate.isdigit() else None
-
-
 def _target_pr_number_from_receipt(receipt: Mapping[str, Any]) -> int | None:
     return target_pr_number_from_receipt(receipt)
 

--- a/tests/scripts/test_cache_codex_automation_github_status.py
+++ b/tests/scripts/test_cache_codex_automation_github_status.py
@@ -516,6 +516,59 @@ def test_local_queue_state_accepts_requested_action_target_open_pr(
     assert payload["stale_target_pr_receipted_outbox_count"] == 0
 
 
+def test_local_queue_state_keeps_exact_receipt_head_despite_stale_target_branch(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    outbox = tmp_path / ".aragora" / "automation-outbox"
+    receipts = tmp_path / ".aragora" / "automation-receipts"
+    outbox.mkdir(parents=True)
+    receipts.mkdir(parents=True)
+    key = "open-pr-codex-example-refresh"
+    branch = "codex/example"
+    desired_head = "a" * 40
+    remote_head = "b" * 40
+    (outbox / "handoff.json").write_text(
+        json.dumps(
+            {
+                "idempotency_key": key,
+                "local_evidence": {
+                    "branch": branch,
+                    "desired_head_sha": desired_head,
+                },
+                "requested_action": {
+                    "branch": branch,
+                    "target_open_pr": "https://github.com/synaptent/aragora/pull/123",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (receipts / "receipt.json").write_text(
+        json.dumps(
+            {
+                "idempotency_key": key,
+                "reason": "target_open_pr",
+                "status": "already_satisfied",
+                "target_pr_head_sha": desired_head,
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mod, "_remote_tracking_head", lambda _repo, _branch: remote_head)
+
+    payload = mod._local_queue_state(
+        repo_root=tmp_path,
+        outbox_dir=None,
+        receipt_dir=None,
+    )
+
+    assert payload["terminal_receipted_outbox_count"] == 1
+    assert payload["unreceipted_outbox_count"] == 0
+    assert payload["unsatisfied_receipted_outbox_count"] == 0
+    assert payload["stale_target_pr_receipted_outbox_count"] == 0
+
+
 def test_local_queue_state_treats_issue_receipt_for_pr_handoff_as_unreceipted(
     tmp_path: Path,
 ) -> None:

--- a/tests/scripts/test_cache_codex_automation_github_status.py
+++ b/tests/scripts/test_cache_codex_automation_github_status.py
@@ -386,8 +386,60 @@ def test_local_queue_state_ignores_target_pr_branch_drift_without_exact_pr_head(
 
     assert payload["outbox_count"] == 1
     assert payload["terminal_receipt_count"] == 1
+    assert payload["terminal_receipted_outbox_count"] == 0
+    assert payload["unreceipted_outbox_count"] == 1
+    assert payload["unsatisfied_receipted_outbox_count"] == 1
+    assert payload["unsatisfied_receipted_outbox"][0]["reason"] == "target_pr_receipt_missing"
+    assert payload["stale_target_pr_receipted_outbox_count"] == 1
+
+
+def test_local_queue_state_accepts_target_pr_reference_case_variants(
+    tmp_path: Path,
+) -> None:
+    outbox = tmp_path / ".aragora" / "automation-outbox"
+    receipts = tmp_path / ".aragora" / "automation-receipts"
+    outbox.mkdir(parents=True)
+    receipts.mkdir(parents=True)
+    key = "open-pr-codex-example-refresh"
+    branch = "codex/example"
+    desired_head = "a" * 40
+    (outbox / "handoff.json").write_text(
+        json.dumps(
+            {
+                "idempotency_key": key,
+                "local_evidence": {
+                    "branch": branch,
+                    "desired_head_sha": desired_head,
+                },
+                "requested_action": {
+                    "branch": branch,
+                    "target_pr": "https://github.com/Synaptent/Aragora/pull/123",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (receipts / "receipt.json").write_text(
+        json.dumps(
+            {
+                "idempotency_key": key,
+                "reason": "target_open_pr",
+                "status": "already_satisfied",
+                "target_pr": 123,
+                "repo": "synaptent/aragora",
+                "target_pr_head_sha": desired_head,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    payload = mod._local_queue_state(
+        repo_root=tmp_path,
+        outbox_dir=None,
+        receipt_dir=None,
+    )
+
     assert payload["terminal_receipted_outbox_count"] == 1
-    assert payload["unreceipted_outbox_count"] == 0
     assert payload["unsatisfied_receipted_outbox_count"] == 0
     assert payload["stale_target_pr_receipted_outbox_count"] == 0
 

--- a/tests/scripts/test_cache_codex_automation_github_status.py
+++ b/tests/scripts/test_cache_codex_automation_github_status.py
@@ -465,6 +465,57 @@ def test_local_queue_state_counts_target_pr_receipt_when_remote_head_matches(
     assert payload["stale_target_pr_receipted_outbox_count"] == 0
 
 
+def test_local_queue_state_accepts_requested_action_target_open_pr(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    outbox = tmp_path / ".aragora" / "automation-outbox"
+    receipts = tmp_path / ".aragora" / "automation-receipts"
+    outbox.mkdir(parents=True)
+    receipts.mkdir(parents=True)
+    key = "open-pr-codex-example-refresh"
+    branch = "codex/example"
+    desired_head = "a" * 40
+    (outbox / "handoff.json").write_text(
+        json.dumps(
+            {
+                "idempotency_key": key,
+                "local_evidence": {
+                    "branch": branch,
+                    "desired_head_sha": desired_head,
+                },
+                "requested_action": {
+                    "branch": branch,
+                    "target_open_pr": "https://github.com/synaptent/aragora/pull/123",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (receipts / "receipt.json").write_text(
+        json.dumps(
+            {
+                "idempotency_key": key,
+                "reason": "target_open_pr",
+                "status": "already_satisfied",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mod, "_remote_tracking_head", lambda _repo, _branch: desired_head)
+
+    payload = mod._local_queue_state(
+        repo_root=tmp_path,
+        outbox_dir=None,
+        receipt_dir=None,
+    )
+
+    assert payload["terminal_receipted_outbox_count"] == 1
+    assert payload["unreceipted_outbox_count"] == 0
+    assert payload["unsatisfied_receipted_outbox_count"] == 0
+    assert payload["stale_target_pr_receipted_outbox_count"] == 0
+
+
 def test_local_queue_state_treats_issue_receipt_for_pr_handoff_as_unreceipted(
     tmp_path: Path,
 ) -> None:

--- a/tests/scripts/test_cache_codex_automation_github_status.py
+++ b/tests/scripts/test_cache_codex_automation_github_status.py
@@ -337,7 +337,7 @@ def test_local_queue_state_treats_cleanup_receipts_as_terminal(tmp_path: Path) -
     assert payload["nonterminal_receipts"] == []
 
 
-def test_local_queue_state_treats_stale_target_pr_receipt_as_unreceipted(
+def test_local_queue_state_ignores_target_pr_branch_drift_without_exact_pr_head(
     monkeypatch: Any,
     tmp_path: Path,
 ) -> None:
@@ -386,32 +386,119 @@ def test_local_queue_state_treats_stale_target_pr_receipt_as_unreceipted(
 
     assert payload["outbox_count"] == 1
     assert payload["terminal_receipt_count"] == 1
+    assert payload["terminal_receipted_outbox_count"] == 1
+    assert payload["unreceipted_outbox_count"] == 0
+    assert payload["unsatisfied_receipted_outbox_count"] == 0
+    assert payload["stale_target_pr_receipted_outbox_count"] == 0
+
+
+def test_local_queue_state_rejects_mismatched_target_pr_reference(
+    tmp_path: Path,
+) -> None:
+    outbox = tmp_path / ".aragora" / "automation-outbox"
+    receipts = tmp_path / ".aragora" / "automation-receipts"
+    outbox.mkdir(parents=True)
+    receipts.mkdir(parents=True)
+    key = "open-pr-codex-example-refresh"
+    branch = "codex/example"
+    (outbox / "handoff.json").write_text(
+        json.dumps(
+            {
+                "idempotency_key": key,
+                "local_evidence": {"branch": branch},
+                "requested_action": {
+                    "branch": branch,
+                    "target_pr": "https://github.com/synaptent/aragora/pull/123",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (receipts / "receipt.json").write_text(
+        json.dumps(
+            {
+                "idempotency_key": key,
+                "reason": "target_open_pr",
+                "status": "already_satisfied",
+                "existing_pr_url": "https://github.com/other/repo/pull/123",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    payload = mod._local_queue_state(
+        repo_root=tmp_path,
+        outbox_dir=None,
+        receipt_dir=None,
+    )
+
     assert payload["terminal_receipted_outbox_count"] == 0
     assert payload["unreceipted_outbox_count"] == 1
     assert payload["unsatisfied_receipted_outbox_count"] == 1
     assert payload["unsatisfied_receipted_outbox"] == [
         {
             "branch": branch,
-            "desired_head_sha": desired_head,
             "file": "handoff.json",
             "idempotency_key": key,
-            "reason": "remote_tracking_head_mismatch",
+            "outbox_target_pr": "synaptent/aragora#123",
+            "reason": "target_pr_reference_mismatch",
             "receipt_file": "receipt.json",
-            "remote_head_sha": remote_head,
+            "receipt_target_pr": "other/repo#123",
         }
     ]
     assert payload["stale_target_pr_receipted_outbox_count"] == 1
-    assert payload["stale_target_pr_receipted_outbox"] == [
-        {
-            "branch": branch,
-            "desired_head_sha": desired_head,
-            "file": "handoff.json",
-            "idempotency_key": key,
-            "reason": "remote_tracking_head_mismatch",
-            "receipt_file": "receipt.json",
-            "remote_head_sha": remote_head,
-        }
-    ]
+
+
+def test_local_queue_state_rejects_target_pr_receipt_head_mismatch(
+    tmp_path: Path,
+) -> None:
+    outbox = tmp_path / ".aragora" / "automation-outbox"
+    receipts = tmp_path / ".aragora" / "automation-receipts"
+    outbox.mkdir(parents=True)
+    receipts.mkdir(parents=True)
+    key = "open-pr-codex-example-refresh"
+    branch = "codex/example"
+    desired_head = "a" * 40
+    receipt_head = "b" * 40
+    (outbox / "handoff.json").write_text(
+        json.dumps(
+            {
+                "idempotency_key": key,
+                "local_evidence": {
+                    "branch": branch,
+                    "desired_head_sha": desired_head,
+                },
+                "requested_action": {
+                    "branch": branch,
+                    "target_pr": "https://github.com/synaptent/aragora/pull/123",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (receipts / "receipt.json").write_text(
+        json.dumps(
+            {
+                "idempotency_key": key,
+                "reason": "target_open_pr",
+                "status": "already_satisfied",
+                "target_pr_head_sha": receipt_head,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    payload = mod._local_queue_state(
+        repo_root=tmp_path,
+        outbox_dir=None,
+        receipt_dir=None,
+    )
+
+    assert payload["terminal_receipted_outbox_count"] == 0
+    assert payload["unreceipted_outbox_count"] == 1
+    assert payload["unsatisfied_receipted_outbox_count"] == 1
+    assert payload["unsatisfied_receipted_outbox"][0]["reason"] == "receipt_head_mismatch"
+    assert payload["stale_target_pr_receipted_outbox_count"] == 1
 
 
 def test_local_queue_state_counts_target_pr_receipt_when_remote_head_matches(

--- a/tests/scripts/test_cache_codex_automation_github_status.py
+++ b/tests/scripts/test_cache_codex_automation_github_status.py
@@ -337,7 +337,7 @@ def test_local_queue_state_treats_cleanup_receipts_as_terminal(tmp_path: Path) -
     assert payload["nonterminal_receipts"] == []
 
 
-def test_local_queue_state_ignores_target_pr_branch_drift_without_exact_pr_head(
+def test_local_queue_state_reports_target_pr_branch_drift_without_exact_pr_head(
     monkeypatch: Any,
     tmp_path: Path,
 ) -> None:
@@ -442,6 +442,71 @@ def test_local_queue_state_accepts_target_pr_reference_case_variants(
     assert payload["terminal_receipted_outbox_count"] == 1
     assert payload["unsatisfied_receipted_outbox_count"] == 0
     assert payload["stale_target_pr_receipted_outbox_count"] == 0
+
+
+def test_local_queue_state_reports_matching_target_pr_without_head_when_branch_drifted(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    outbox = tmp_path / ".aragora" / "automation-outbox"
+    receipts = tmp_path / ".aragora" / "automation-receipts"
+    outbox.mkdir(parents=True)
+    receipts.mkdir(parents=True)
+    key = "open-pr-codex-example-refresh"
+    branch = "codex/example"
+    desired_head = "a" * 40
+    remote_head = "b" * 40
+    (outbox / "handoff.json").write_text(
+        json.dumps(
+            {
+                "idempotency_key": key,
+                "local_evidence": {
+                    "branch": branch,
+                    "desired_head_sha": desired_head,
+                },
+                "requested_action": {
+                    "branch": branch,
+                    "target_pr": "https://github.com/synaptent/aragora/pull/123",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (receipts / "receipt.json").write_text(
+        json.dumps(
+            {
+                "idempotency_key": key,
+                "reason": "target_open_pr",
+                "status": "already_satisfied",
+                "target_pr": 123,
+                "repo": "synaptent/aragora",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mod, "_remote_tracking_head", lambda _repo, _branch: remote_head)
+
+    payload = mod._local_queue_state(
+        repo_root=tmp_path,
+        outbox_dir=None,
+        receipt_dir=None,
+    )
+
+    assert payload["terminal_receipted_outbox_count"] == 0
+    assert payload["unreceipted_outbox_count"] == 1
+    assert payload["unsatisfied_receipted_outbox_count"] == 1
+    assert payload["unsatisfied_receipted_outbox"] == [
+        {
+            "branch": branch,
+            "file": "handoff.json",
+            "idempotency_key": key,
+            "outbox_target_pr": "synaptent/aragora#123",
+            "reason": "target_pr_receipt_missing",
+            "receipt_file": "receipt.json",
+            "receipt_target_pr": "synaptent/aragora#123",
+        }
+    ]
+    assert payload["stale_target_pr_receipted_outbox_count"] == 1
 
 
 def test_local_queue_state_rejects_mismatched_target_pr_reference(

--- a/tests/scripts/test_classify_handoff_state.py
+++ b/tests/scripts/test_classify_handoff_state.py
@@ -34,11 +34,13 @@ class FakeGitHub:
         pr_by_number: dict[int, dict[str, Any]] | None = None,
         refs: dict[str, dict[str, Any]] | None = None,
         errors: dict[str, str] | None = None,
+        github_repo: str = "synaptent/aragora",
     ) -> None:
         self.open_prs = open_prs or {}
         self.pr_by_number = pr_by_number or {}
         self.refs = refs or {}
         self.errors = errors or {}
+        self.github_repo = github_repo
         self.pr_calls = 0
         self.pr_number_calls = 0
         self.ref_calls = 0
@@ -1286,6 +1288,96 @@ def test_requested_action_target_pr_can_prove_exact_open_pr_representation_when_
     assert item["evidence"]["github"]["exact_open_pr"]["number"] == 8570
     assert "GitHub PR evidence is degraded" in item["reason"]
     assert github.pr_number_calls == 1
+
+
+def test_numeric_outbox_target_matches_same_repo_receipt_url_with_default_repo(
+    tmp_path: Path,
+) -> None:
+    key = "open-pr-codex-example-aaaaaaaa"
+    _write_status_cache(tmp_path, open_pr_cap_reached=True)
+    path = _write_outbox(tmp_path, key=key, branch="codex/original-branch")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload.pop("repo")
+    payload["requested_action"]["target_pr"] = 8570
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    _write_receipt(
+        tmp_path,
+        key,
+        {
+            "status": "already_satisfied",
+            "reason": "target_open_pr",
+            "existing_pr_url": "https://github.com/synaptent/aragora/pull/8570",
+        },
+    )
+    github = FakeGitHub(
+        pr_by_number={
+            8570: {
+                "number": 8570,
+                "state": "open",
+                "draft": False,
+                "head": {"ref": "codex/original-branch", "sha": HEAD},
+                "base": {"ref": "main"},
+                "html_url": "https://github.com/synaptent/aragora/pull/8570",
+            }
+        },
+        errors={"pr:codex/original-branch": "gh api failed (HTTP 504)"},
+    )
+
+    item = _classify_one(tmp_path, github=github)
+
+    assert item["state"] == mod.HandoffState.REPRESENTED_BY_EXACT_OPEN_PR.value
+    assert item["safe_to_mutate"] is False
+    assert item["next_mutation_candidate"] == "none"
+    assert item["evidence"]["receipt"]["target_pr"] == 8570
+    assert item["evidence"]["receipt"]["target_pr_repo"] == "synaptent/aragora"
+    assert item["evidence"]["receipt"]["target_pr_mismatch"] is None
+    assert item["evidence"]["github"]["exact_open_pr"]["number"] == 8570
+    assert github.pr_number_calls == 1
+
+
+def test_numeric_outbox_target_rejects_cross_repo_receipt_url_with_default_repo(
+    tmp_path: Path,
+) -> None:
+    key = "open-pr-codex-example-aaaaaaaa"
+    _write_status_cache(tmp_path, open_pr_cap_reached=False)
+    path = _write_outbox(tmp_path, key=key, branch="codex/original-branch")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload.pop("repo")
+    payload["requested_action"]["target_pr"] = 8570
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    _write_receipt(
+        tmp_path,
+        key,
+        {
+            "status": "already_satisfied",
+            "reason": "target_open_pr",
+            "existing_pr_url": "https://github.com/other/repo/pull/8570",
+        },
+    )
+    github = FakeGitHub(
+        pr_by_number={
+            8570: {
+                "number": 8570,
+                "state": "open",
+                "draft": False,
+                "head": {"ref": "codex/original-branch", "sha": HEAD},
+                "base": {"ref": "main"},
+                "html_url": "https://github.com/synaptent/aragora/pull/8570",
+            }
+        }
+    )
+
+    item = _classify_one(tmp_path, github=github)
+
+    assert item["state"] == mod.HandoffState.UNKNOWN.value
+    assert item["safe_to_mutate"] is False
+    assert item["next_mutation_candidate"] == "none"
+    assert item["evidence"]["receipt"]["target_pr"] is None
+    assert "receipt target PR other/repo#8570" in item["reason"]
+    assert "outbox target PR synaptent/aragora#8570" in item["reason"]
+    assert github.pr_calls == 0
+    assert github.pr_number_calls == 0
+    assert github.ref_calls == 0
 
 
 def test_target_pr_branch_lookup_must_match_handoff_branch(

--- a/tests/scripts/test_classify_handoff_state.py
+++ b/tests/scripts/test_classify_handoff_state.py
@@ -1056,6 +1056,23 @@ def test_target_pr_reference_parses_github_url_repo() -> None:
     assert reference == mod.TargetPrReference(number=8570, repo="synaptent/aragora")
 
 
+def test_target_pr_reference_uses_sibling_repo_for_numeric_target() -> None:
+    reference = mod.target_pr_reference_from_receipt({"target_pr": 8570, "repo": "Other/Repo"})
+
+    assert reference == mod.TargetPrReference(number=8570, repo="other/repo")
+
+
+def test_target_pr_reference_matches_repo_case_insensitively() -> None:
+    left = mod.target_pr_reference_from_receipt(
+        {"target_pr": "https://github.com/Synaptent/Aragora/pull/8570"}
+    )
+    right = mod.target_pr_reference_from_receipt({"target_pr": 8570, "repo": "synaptent/aragora"})
+
+    assert left is not None
+    assert right is not None
+    assert mod.target_pr_references_match(left, right, "SYNAPTENT/ARAGORA")
+
+
 def test_target_pr_reference_rejects_enterprise_url_host() -> None:
     reference = mod.target_pr_reference_from_receipt(
         {"target_pr": "https://github.enterprise.example/synaptent/aragora/pull/8570"}
@@ -1105,6 +1122,42 @@ def test_target_pr_reference_accepts_matching_branch_pr_lookup(
     assert item["evidence"]["github"]["exact_open_pr"]["number"] == 8570
     assert item["evidence"]["github"]["exact_open_pr"]["head"] == "codex/original-branch"
     assert github.pr_number_calls == 0
+
+
+def test_cross_repo_target_pr_reference_does_not_probe_default_repo(
+    tmp_path: Path,
+) -> None:
+    key = "open-pr-codex-example-aaaaaaaa"
+    _write_status_cache(tmp_path, open_pr_cap_reached=True)
+    outbox = _write_outbox(
+        tmp_path,
+        key=key,
+        branch="codex/original-branch",
+        extra_payload={"target_pr": 8570, "repo": "other/repo"},
+    )
+    payload = json.loads(outbox.read_text(encoding="utf-8"))
+    payload["requested_action"]["target_pr"] = 8570
+    payload["requested_action"]["repo"] = "other/repo"
+    outbox.write_text(json.dumps(payload), encoding="utf-8")
+    github = FakeGitHub(
+        pr_by_number={
+            8570: {
+                "number": 8570,
+                "state": "open",
+                "draft": False,
+                "head": {"ref": "codex/original-branch", "sha": HEAD},
+                "base": {"ref": "main"},
+                "html_url": "https://github.com/synaptent/aragora/pull/8570",
+            }
+        }
+    )
+    github.github_repo = "synaptent/aragora"
+
+    item = _classify_one(tmp_path, github=github)
+
+    assert item["state"] == mod.HandoffState.BLOCKED_BY_LIVE_QUEUE_CAP.value
+    assert github.pr_number_calls == 0
+    assert "target PR repo other/repo differs" in item["evidence"]["github"]["error"]
 
 
 def test_target_pr_representation_is_not_safe_when_branch_pr_lookup_degrades(

--- a/tests/scripts/test_classify_handoff_state.py
+++ b/tests/scripts/test_classify_handoff_state.py
@@ -1048,6 +1048,30 @@ def test_target_pr_reference_can_prove_exact_open_pr_representation(
     assert github.pr_number_calls == 1
 
 
+def test_target_pr_reference_parses_github_url_repo() -> None:
+    reference = mod.target_pr_reference_from_receipt(
+        {"target_pr": "https://github.com/synaptent/aragora/pull/8570"}
+    )
+
+    assert reference == mod.TargetPrReference(number=8570, repo="synaptent/aragora")
+
+
+def test_target_pr_reference_rejects_enterprise_url_host() -> None:
+    reference = mod.target_pr_reference_from_receipt(
+        {"target_pr": "https://github.enterprise.example/synaptent/aragora/pull/8570"}
+    )
+
+    assert reference is None
+
+
+def test_target_pr_reference_rejects_non_github_url_host() -> None:
+    reference = mod.target_pr_reference_from_receipt(
+        {"target_pr": "https://example.com/synaptent/aragora/pull/8570"}
+    )
+
+    assert reference is None
+
+
 def test_target_pr_reference_accepts_matching_branch_pr_lookup(
     tmp_path: Path,
 ) -> None:

--- a/tests/scripts/test_classify_handoff_state.py
+++ b/tests/scripts/test_classify_handoff_state.py
@@ -1062,6 +1062,18 @@ def test_target_pr_reference_uses_sibling_repo_for_numeric_target() -> None:
     assert reference == mod.TargetPrReference(number=8570, repo="other/repo")
 
 
+def test_target_pr_reference_prefers_url_repo_over_numeric_target() -> None:
+    reference = mod.target_pr_reference_from_receipt(
+        {
+            "target_pr": 8570,
+            "existing_pr_url": "https://github.com/other/repo/pull/8570",
+            "repo": "synaptent/aragora",
+        }
+    )
+
+    assert reference == mod.TargetPrReference(number=8570, repo="other/repo")
+
+
 def test_target_pr_reference_matches_repo_case_insensitively() -> None:
     left = mod.target_pr_reference_from_receipt(
         {"target_pr": "https://github.com/Synaptent/Aragora/pull/8570"}
@@ -1158,6 +1170,52 @@ def test_cross_repo_target_pr_reference_does_not_probe_default_repo(
     assert item["state"] == mod.HandoffState.BLOCKED_BY_LIVE_QUEUE_CAP.value
     assert github.pr_number_calls == 0
     assert "target PR repo other/repo differs" in item["evidence"]["github"]["error"]
+
+
+def test_mismatched_receipt_target_pr_blocks_classification_before_probe(
+    tmp_path: Path,
+) -> None:
+    key = "open-pr-codex-example-aaaaaaaa"
+    _write_status_cache(tmp_path, open_pr_cap_reached=False)
+    _write_outbox(
+        tmp_path,
+        key=key,
+        branch="codex/original-branch",
+        extra_payload={"target_pr": "https://github.com/synaptent/aragora/pull/8570"},
+    )
+    _write_receipt(
+        tmp_path,
+        key,
+        {
+            "status": "already_satisfied",
+            "reason": "target_open_pr",
+            "existing_pr_url": "https://github.com/other/repo/pull/8570",
+        },
+    )
+    github = FakeGitHub(
+        pr_by_number={
+            8570: {
+                "number": 8570,
+                "state": "open",
+                "draft": False,
+                "head": {"ref": "codex/original-branch", "sha": HEAD},
+                "base": {"ref": "main"},
+                "html_url": "https://github.com/synaptent/aragora/pull/8570",
+            }
+        }
+    )
+
+    item = _classify_one(tmp_path, github=github)
+
+    assert item["state"] == mod.HandoffState.UNKNOWN.value
+    assert item["safe_to_mutate"] is False
+    assert item["next_mutation_candidate"] == "none"
+    assert item["evidence"]["receipt"]["target_pr"] is None
+    assert "receipt target PR other/repo#8570" in item["reason"]
+    assert "outbox target PR synaptent/aragora#8570" in item["reason"]
+    assert github.pr_calls == 0
+    assert github.pr_number_calls == 0
+    assert github.ref_calls == 0
 
 
 def test_target_pr_representation_is_not_safe_when_branch_pr_lookup_degrades(

--- a/tests/scripts/test_reconcile_automation_outbox.py
+++ b/tests/scripts/test_reconcile_automation_outbox.py
@@ -1441,6 +1441,44 @@ def test_reconcile_target_pr_state_uses_repo_from_receipt_url(
     assert commands[0][:6] == ["gh", "pr", "view", "7105", "--repo", "other/repo"]
 
 
+def test_reconcile_target_pr_state_uses_sibling_repo_for_numeric_target(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    receipt = {
+        "status": "already_satisfied",
+        "reason": "target_open_pr",
+        "target_pr": 7105,
+        "repo": "Other/Repo",
+    }
+    commands: list[list[str]] = []
+
+    def fake_subprocess_run(
+        command: list[str],
+        **_kwargs: Any,
+    ) -> SimpleNamespace:
+        commands.append(command)
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "number": 7105,
+                    "state": "MERGED",
+                    "headRefOid": "abcdef1234567890abcdef1234567890abcdef12",
+                }
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_subprocess_run)
+
+    state = mod._target_pr_state(tmp_path, "synaptent/aragora", receipt)
+
+    assert state is not None
+    assert commands
+    assert commands[0][:6] == ["gh", "pr", "view", "7105", "--repo", "other/repo"]
+
+
 def test_reconcile_keeps_target_pr_receipt_when_merged_pr_head_differs(
     tmp_path: Path,
     monkeypatch: Any,

--- a/tests/scripts/test_reconcile_automation_outbox.py
+++ b/tests/scripts/test_reconcile_automation_outbox.py
@@ -1342,6 +1342,8 @@ def test_reconcile_keeps_outbox_requested_action_target_open_pr_without_branch_p
 
     payload = json.loads(capsys.readouterr().out)
     assert payload["counts"]["satisfied_by_existing_receipt"] == 0
+    assert payload["counts"]["blocked_receipt_pr_head_mismatch"] == 0
+    assert payload["counts"]["blocked_receipt_unverified_publication"] == 1
     assert payload["counts"]["still_protecting_active_work"] == 1
     assert payload["actions"][0]["decision"] == "keep"
     assert handoff.exists()

--- a/tests/scripts/test_reconcile_automation_outbox.py
+++ b/tests/scripts/test_reconcile_automation_outbox.py
@@ -1191,6 +1191,91 @@ def test_reconcile_archives_requested_action_target_open_pr_receipt_when_merged(
     assert gh_commands
 
 
+def test_reconcile_archives_outbox_requested_action_target_open_pr_receipt_when_merged(
+    tmp_path: Path,
+    monkeypatch: Any,
+    capsys: Any,
+) -> None:
+    outbox_dir = tmp_path / ".aragora" / "automation-outbox"
+    receipt_dir = tmp_path / ".aragora" / "automation-receipts"
+    key = "open-pr-codex-target-pr-merged"
+    desired_head = "abcdef1234567890abcdef1234567890abcdef12"
+    handoff = _write_outbox_handoff(
+        outbox_dir,
+        branch="codex/target-pr-merged",
+        key=key,
+        local_evidence={
+            "branch": "codex/target-pr-merged",
+            "desired_head_sha": desired_head,
+        },
+    )
+    handoff_payload = json.loads(handoff.read_text(encoding="utf-8"))
+    handoff_payload["requested_action"]["target_open_pr"] = (
+        "https://github.com/synaptent/aragora/pull/7105"
+    )
+    handoff.write_text(json.dumps(handoff_payload), encoding="utf-8")
+    receipt_dir.mkdir(parents=True)
+    (receipt_dir / f"{key}.json").write_text(
+        json.dumps(
+            {
+                "idempotency_key": key,
+                "status": "already_satisfied",
+                "reason": "target_open_pr",
+                "repo": "synaptent/aragora",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    gh_commands: list[list[str]] = []
+
+    def fake_subprocess_run(
+        command: list[str],
+        **_kwargs: Any,
+    ) -> SimpleNamespace:
+        gh_commands.append(command)
+        assert command[:4] == ["gh", "pr", "view", "7105"]
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "number": 7105,
+                    "state": "MERGED",
+                    "headRefOid": desired_head,
+                }
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_subprocess_run)
+    monkeypatch.setattr(
+        mod,
+        "run_git",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("git ref checks should not run for merged target PR receipts")
+        ),
+    )
+    monkeypatch.setattr(
+        mod,
+        "open_pr_heads",
+        lambda *_args: (_ for _ in ()).throw(
+            AssertionError("open PR fetch should not run for matched target PR receipts")
+        ),
+    )
+
+    assert mod.main(["--repo", str(tmp_path), "--json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["counts"]["satisfied_by_existing_receipt"] == 1
+    assert payload["counts"]["blocked_receipt_pr_head_mismatch"] == 0
+    assert payload["counts"]["still_protecting_active_work"] == 0
+    assert payload["actions"][0]["decision"] == "archive"
+    assert payload["actions"][0]["reason"] == "matching receipt exists"
+    assert handoff.exists()
+    assert not (tmp_path / ".aragora" / "automation-outbox-archive").exists()
+    assert gh_commands
+
+
 def test_reconcile_keeps_target_pr_receipt_when_merged_pr_head_differs(
     tmp_path: Path,
     monkeypatch: Any,

--- a/tests/scripts/test_reconcile_automation_outbox.py
+++ b/tests/scripts/test_reconcile_automation_outbox.py
@@ -1059,15 +1059,27 @@ def test_reconcile_archives_target_pr_receipt_when_pr_merged_at_desired_head(
         encoding="utf-8",
     )
 
-    monkeypatch.setattr(
-        mod,
-        "_target_pr_state",
-        lambda *_args: {
-            "number": 7105,
-            "state": "MERGED",
-            "headRefOid": desired_head,
-        },
-    )
+    gh_commands: list[list[str]] = []
+
+    def fake_subprocess_run(
+        command: list[str],
+        **_kwargs: Any,
+    ) -> SimpleNamespace:
+        gh_commands.append(command)
+        assert command[:4] == ["gh", "pr", "view", "7105"]
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "number": 7105,
+                    "state": "MERGED",
+                    "headRefOid": desired_head,
+                }
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_subprocess_run)
     monkeypatch.setattr(
         mod,
         "run_git",
@@ -1093,6 +1105,7 @@ def test_reconcile_archives_target_pr_receipt_when_pr_merged_at_desired_head(
     assert payload["actions"][0]["reason"] == "matching receipt exists"
     assert handoff.exists()
     assert not (tmp_path / ".aragora" / "automation-outbox-archive").exists()
+    assert gh_commands
 
 
 def test_reconcile_archives_requested_action_target_open_pr_receipt_when_merged(
@@ -1129,15 +1142,27 @@ def test_reconcile_archives_requested_action_target_open_pr_receipt_when_merged(
         encoding="utf-8",
     )
 
-    monkeypatch.setattr(
-        mod,
-        "_target_pr_state",
-        lambda *_args: {
-            "number": 7105,
-            "state": "MERGED",
-            "headRefOid": desired_head,
-        },
-    )
+    gh_commands: list[list[str]] = []
+
+    def fake_subprocess_run(
+        command: list[str],
+        **_kwargs: Any,
+    ) -> SimpleNamespace:
+        gh_commands.append(command)
+        assert command[:4] == ["gh", "pr", "view", "7105"]
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "number": 7105,
+                    "state": "MERGED",
+                    "headRefOid": desired_head,
+                }
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_subprocess_run)
     monkeypatch.setattr(
         mod,
         "run_git",
@@ -1163,6 +1188,7 @@ def test_reconcile_archives_requested_action_target_open_pr_receipt_when_merged(
     assert payload["actions"][0]["reason"] == "matching receipt exists"
     assert handoff.exists()
     assert not (tmp_path / ".aragora" / "automation-outbox-archive").exists()
+    assert gh_commands
 
 
 def test_reconcile_keeps_target_pr_receipt_when_merged_pr_head_differs(

--- a/tests/scripts/test_reconcile_automation_outbox.py
+++ b/tests/scripts/test_reconcile_automation_outbox.py
@@ -1095,6 +1095,76 @@ def test_reconcile_archives_target_pr_receipt_when_pr_merged_at_desired_head(
     assert not (tmp_path / ".aragora" / "automation-outbox-archive").exists()
 
 
+def test_reconcile_archives_requested_action_target_open_pr_receipt_when_merged(
+    tmp_path: Path,
+    monkeypatch: Any,
+    capsys: Any,
+) -> None:
+    outbox_dir = tmp_path / ".aragora" / "automation-outbox"
+    receipt_dir = tmp_path / ".aragora" / "automation-receipts"
+    key = "open-pr-codex-target-pr-merged"
+    desired_head = "abcdef1234567890abcdef1234567890abcdef12"
+    handoff = _write_outbox_handoff(
+        outbox_dir,
+        branch="codex/target-pr-merged",
+        key=key,
+        local_evidence={
+            "branch": "codex/target-pr-merged",
+            "desired_head_sha": desired_head,
+        },
+    )
+    receipt_dir.mkdir(parents=True)
+    (receipt_dir / f"{key}.json").write_text(
+        json.dumps(
+            {
+                "idempotency_key": key,
+                "status": "already_satisfied",
+                "reason": "target_open_pr",
+                "requested_action": {
+                    "target_open_pr": "https://github.com/synaptent/aragora/pull/7105",
+                },
+                "repo": "synaptent/aragora",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        mod,
+        "_target_pr_state",
+        lambda *_args: {
+            "number": 7105,
+            "state": "MERGED",
+            "headRefOid": desired_head,
+        },
+    )
+    monkeypatch.setattr(
+        mod,
+        "run_git",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("git ref checks should not run for merged target PR receipts")
+        ),
+    )
+    monkeypatch.setattr(
+        mod,
+        "open_pr_heads",
+        lambda *_args: (_ for _ in ()).throw(
+            AssertionError("open PR fetch should not run for matched target PR receipts")
+        ),
+    )
+
+    assert mod.main(["--repo", str(tmp_path), "--json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["counts"]["satisfied_by_existing_receipt"] == 1
+    assert payload["counts"]["blocked_receipt_pr_head_mismatch"] == 0
+    assert payload["counts"]["still_protecting_active_work"] == 0
+    assert payload["actions"][0]["decision"] == "archive"
+    assert payload["actions"][0]["reason"] == "matching receipt exists"
+    assert handoff.exists()
+    assert not (tmp_path / ".aragora" / "automation-outbox-archive").exists()
+
+
 def test_reconcile_keeps_target_pr_receipt_when_merged_pr_head_differs(
     tmp_path: Path,
     monkeypatch: Any,

--- a/tests/scripts/test_reconcile_automation_outbox.py
+++ b/tests/scripts/test_reconcile_automation_outbox.py
@@ -1191,7 +1191,7 @@ def test_reconcile_archives_requested_action_target_open_pr_receipt_when_merged(
     assert gh_commands
 
 
-def test_reconcile_archives_outbox_requested_action_target_open_pr_receipt_when_merged(
+def test_reconcile_archives_outbox_requested_action_target_open_pr_receipt_with_branch_proof(
     tmp_path: Path,
     monkeypatch: Any,
     capsys: Any,
@@ -1227,34 +1227,39 @@ def test_reconcile_archives_outbox_requested_action_target_open_pr_receipt_when_
         encoding="utf-8",
     )
 
-    gh_commands: list[list[str]] = []
+    def fake_run_git(
+        args: list[str],
+        _root: Path,
+        *,
+        timeout: int = 60,
+    ) -> subprocess.CompletedProcess[str]:
+        if args == ["rev-parse", "--verify", "codex/target-pr-merged"]:
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout=desired_head)
+        if args == ["merge-base", "--is-ancestor", "codex/target-pr-merged", "origin/main"]:
+            return subprocess.CompletedProcess(args=args, returncode=1, stdout="", stderr="")
+        if args == ["cherry", "origin/main", "codex/target-pr-merged"]:
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=0,
+                stdout=f"+ {desired_head}\n",
+                stderr="",
+            )
+        if args == [
+            "rev-parse",
+            "--verify",
+            "refs/remotes/origin/codex/target-pr-merged",
+        ]:
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout=desired_head)
+        raise AssertionError(f"unexpected git call: {args}")
 
-    def fake_subprocess_run(
-        command: list[str],
-        **_kwargs: Any,
-    ) -> SimpleNamespace:
-        gh_commands.append(command)
-        assert command[:4] == ["gh", "pr", "view", "7105"]
-        return SimpleNamespace(
-            returncode=0,
-            stdout=json.dumps(
-                {
-                    "number": 7105,
-                    "state": "MERGED",
-                    "headRefOid": desired_head,
-                }
-            ),
-            stderr="",
-        )
-
-    monkeypatch.setattr(mod.subprocess, "run", fake_subprocess_run)
     monkeypatch.setattr(
         mod,
-        "run_git",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(
-            AssertionError("git ref checks should not run for merged target PR receipts")
+        "_target_pr_state",
+        lambda *_args: (_ for _ in ()).throw(
+            AssertionError("outbox-only target_open_pr must not query gh PR state")
         ),
     )
+    monkeypatch.setattr(mod, "run_git", fake_run_git)
     monkeypatch.setattr(
         mod,
         "open_pr_heads",
@@ -1273,7 +1278,165 @@ def test_reconcile_archives_outbox_requested_action_target_open_pr_receipt_when_
     assert payload["actions"][0]["reason"] == "matching receipt exists"
     assert handoff.exists()
     assert not (tmp_path / ".aragora" / "automation-outbox-archive").exists()
-    assert gh_commands
+
+
+def test_reconcile_keeps_outbox_requested_action_target_open_pr_without_branch_proof(
+    tmp_path: Path,
+    monkeypatch: Any,
+    capsys: Any,
+) -> None:
+    outbox_dir = tmp_path / ".aragora" / "automation-outbox"
+    receipt_dir = tmp_path / ".aragora" / "automation-receipts"
+    key = "open-pr-codex-target-pr-unproven"
+    desired_head = "abcdef1234567890abcdef1234567890abcdef12"
+    handoff = _write_outbox_handoff(
+        outbox_dir,
+        branch="codex/target-pr-unproven",
+        key=key,
+        local_evidence={
+            "branch": "codex/target-pr-unproven",
+            "desired_head_sha": desired_head,
+        },
+    )
+    handoff_payload = json.loads(handoff.read_text(encoding="utf-8"))
+    handoff_payload["requested_action"]["target_open_pr"] = (
+        "https://github.com/synaptent/aragora/pull/7105"
+    )
+    handoff.write_text(json.dumps(handoff_payload), encoding="utf-8")
+    receipt_dir.mkdir(parents=True)
+    (receipt_dir / f"{key}.json").write_text(
+        json.dumps(
+            {
+                "idempotency_key": key,
+                "status": "already_satisfied",
+                "reason": "target_open_pr",
+                "repo": "synaptent/aragora",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def fake_run_git(
+        args: list[str],
+        _root: Path,
+        *,
+        timeout: int = 60,
+    ) -> subprocess.CompletedProcess[str]:
+        if args[0] == "rev-parse":
+            return subprocess.CompletedProcess(args=args, returncode=1, stdout="", stderr="")
+        if args[:2] == ["merge-base", "--is-ancestor"] or args[0] == "cherry":
+            return subprocess.CompletedProcess(args=args, returncode=1, stdout="", stderr="")
+        raise AssertionError(f"unexpected git call: {args}")
+
+    monkeypatch.setattr(
+        mod,
+        "_target_pr_state",
+        lambda *_args: (_ for _ in ()).throw(
+            AssertionError("outbox-only target_open_pr must not query gh PR state")
+        ),
+    )
+    monkeypatch.setattr(mod, "run_git", fake_run_git)
+    monkeypatch.setattr(mod, "open_pr_heads", lambda *_args: {})
+
+    assert mod.main(["--repo", str(tmp_path), "--json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["counts"]["satisfied_by_existing_receipt"] == 0
+    assert payload["counts"]["still_protecting_active_work"] == 1
+    assert payload["actions"][0]["decision"] == "keep"
+    assert handoff.exists()
+
+
+def test_reconcile_keeps_target_pr_receipt_when_receipt_and_outbox_targets_differ(
+    tmp_path: Path,
+    monkeypatch: Any,
+    capsys: Any,
+) -> None:
+    outbox_dir = tmp_path / ".aragora" / "automation-outbox"
+    receipt_dir = tmp_path / ".aragora" / "automation-receipts"
+    key = "open-pr-codex-target-pr-mismatch"
+    desired_head = "abcdef1234567890abcdef1234567890abcdef12"
+    handoff = _write_outbox_handoff(
+        outbox_dir,
+        branch="codex/target-pr-mismatch",
+        key=key,
+        local_evidence={
+            "branch": "codex/target-pr-mismatch",
+            "desired_head_sha": desired_head,
+        },
+    )
+    handoff_payload = json.loads(handoff.read_text(encoding="utf-8"))
+    handoff_payload["requested_action"]["target_open_pr"] = (
+        "https://github.com/other/repo/pull/7105"
+    )
+    handoff.write_text(json.dumps(handoff_payload), encoding="utf-8")
+    receipt_dir.mkdir(parents=True)
+    (receipt_dir / f"{key}.json").write_text(
+        json.dumps(
+            {
+                "idempotency_key": key,
+                "status": "already_satisfied",
+                "reason": "target_open_pr",
+                "existing_pr_url": "https://github.com/synaptent/aragora/pull/7105",
+                "repo": "synaptent/aragora",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        mod,
+        "_target_pr_state",
+        lambda *_args: (_ for _ in ()).throw(
+            AssertionError("mismatched target PRs must not query gh PR state")
+        ),
+    )
+
+    assert mod.main(["--repo", str(tmp_path), "--json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["counts"]["blocked_receipt_pr_head_mismatch"] == 1
+    assert payload["counts"]["satisfied_by_existing_receipt"] == 0
+    assert payload["actions"][0]["decision"] == "keep"
+    assert payload["actions"][0]["reason"] == (
+        "target_open_pr receipt target PR does not match handoff target PR"
+    )
+
+
+def test_reconcile_target_pr_state_uses_repo_from_receipt_url(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    receipt = {
+        "status": "already_satisfied",
+        "reason": "target_open_pr",
+        "existing_pr_url": "https://github.com/other/repo/pull/7105",
+    }
+    commands: list[list[str]] = []
+
+    def fake_subprocess_run(
+        command: list[str],
+        **_kwargs: Any,
+    ) -> SimpleNamespace:
+        commands.append(command)
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "number": 7105,
+                    "state": "MERGED",
+                    "headRefOid": "abcdef1234567890abcdef1234567890abcdef12",
+                }
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_subprocess_run)
+
+    state = mod._target_pr_state(tmp_path, "synaptent/aragora", receipt)
+
+    assert state is not None
+    assert commands
+    assert commands[0][:6] == ["gh", "pr", "view", "7105", "--repo", "other/repo"]
 
 
 def test_reconcile_keeps_target_pr_receipt_when_merged_pr_head_differs(


### PR DESCRIPTION
## Summary\n- route cache and reconciler target-PR detection through the shared handoff_state extractor\n- cover nested requested_action.target_open_pr receipts in cache and outbox reconciliation\n\n## Validation\n- timeout 240 python3 -m pytest tests/scripts/test_classify_handoff_state.py tests/scripts/test_cache_codex_automation_github_status.py tests/scripts/test_reconcile_automation_outbox.py -q\n- timeout 240 pre-commit run --files scripts/reconcile_automation_outbox.py scripts/cache_codex_automation_github_status.py tests/scripts/test_cache_codex_automation_github_status.py tests/scripts/test_reconcile_automation_outbox.py