### PR TITLE
[codex] fix action.yml YAML parsing

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -188,50 +188,8 @@ runs:
         # Action-level metadata and extracted counts from JSON output
         echo "review_log_path=./aragora-artifacts/review.log" >> $GITHUB_OUTPUT
 
-        python3 - <<'PY' >> "$GITHUB_OUTPUT"
-import json
-from pathlib import Path
-
-path = Path("./aragora-artifacts/review.json")
-if path.is_file():
-    print("review_json_path=./aragora-artifacts/review.json")
-    try:
-        data = json.loads(path.read_text())
-    except Exception:
-        data = {}
-else:
-    print("review_json_path=")
-    data = {}
-
-def count_list(key: str) -> int:
-    value = data.get(key, [])
-    return len(value) if isinstance(value, list) else 0
-
-unanimous = count_list("unanimous_critiques")
-critical = count_list("critical_issues")
-high = count_list("high_issues")
-medium = count_list("medium_issues")
-low = count_list("low_issues")
-risk_areas = count_list("risk_areas")
-split_opinions = count_list("split_opinions")
-total = critical + high + medium + low
-
-agreement = data.get("agreement_score", 0) or 0
-try:
-    agreement = float(agreement)
-except Exception:
-    agreement = 0
-
-print(f"unanimous_count={unanimous}")
-print(f"critical_count={critical}")
-print(f"high_count={high}")
-print(f"medium_count={medium}")
-print(f"low_count={low}")
-print(f"total_count={total}")
-print(f"risk_areas_count={risk_areas}")
-print(f"split_opinions_count={split_opinions}")
-print(f"agreement_score={agreement}")
-PY
+        python3 "$GITHUB_ACTION_PATH/scripts/extract_review_counts.py" \
+          ./aragora-artifacts/review.json >> "$GITHUB_OUTPUT"
       env:
         ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
         OPENAI_API_KEY: ${{ inputs.openai-api-key }}

--- a/scripts/extract_review_counts.py
+++ b/scripts/extract_review_counts.py
@@ -1,0 +1,76 @@
+"""Extract GitHub Actions step outputs from an ``aragora review`` JSON file.
+
+Previously this logic lived as a column-0 ``python3 - <<'PY'`` heredoc embedded
+in ``action.yml``; that body broke the YAML block scalar, so the action did not
+parse with standard parsers. Moving it to a real, stdlib-only, unit-tested
+script makes the action valid YAML and the logic testable.
+
+Prints ``key=value`` lines suitable for appending to ``$GITHUB_OUTPUT``.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _count_list(data: dict[str, Any], key: str) -> int:
+    value = data.get(key, [])
+    return len(value) if isinstance(value, list) else 0
+
+
+def render_outputs(review_json_path: str | Path) -> str:
+    """Return the ``key=value`` block for the given review JSON path."""
+    path = Path(review_json_path)
+    lines: list[str] = []
+    if path.is_file():
+        lines.append(f"review_json_path={path}")
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            data = {}
+    else:
+        lines.append("review_json_path=")
+        data = {}
+    if not isinstance(data, dict):
+        data = {}
+
+    critical = _count_list(data, "critical_issues")
+    high = _count_list(data, "high_issues")
+    medium = _count_list(data, "medium_issues")
+    low = _count_list(data, "low_issues")
+    total = critical + high + medium + low
+
+    agreement_raw = data.get("agreement_score", 0) or 0
+    try:
+        agreement: float = float(agreement_raw)
+    except (TypeError, ValueError):
+        agreement = 0.0
+
+    lines.extend(
+        [
+            f"unanimous_count={_count_list(data, 'unanimous_critiques')}",
+            f"critical_count={critical}",
+            f"high_count={high}",
+            f"medium_count={medium}",
+            f"low_count={low}",
+            f"total_count={total}",
+            f"risk_areas_count={_count_list(data, 'risk_areas')}",
+            f"split_opinions_count={_count_list(data, 'split_opinions')}",
+            f"agreement_score={agreement}",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    path = args[0] if args else "./aragora-artifacts/review.json"
+    print(render_outputs(path))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_extract_review_counts.py
+++ b/tests/scripts/test_extract_review_counts.py
@@ -1,0 +1,54 @@
+"""The review-counts extractor used by the marketplace action must emit correct
+GitHub Actions key=value outputs and degrade safely on missing or garbage input.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.extract_review_counts import render_outputs
+
+
+def _parse(block: str) -> dict[str, str]:
+    return dict(line.split("=", 1) for line in block.splitlines())
+
+
+def test_counts_from_a_real_review_json(tmp_path: Path):
+    review = tmp_path / "review.json"
+    review.write_text(
+        json.dumps(
+            {
+                "critical_issues": [{"x": 1}],
+                "high_issues": [{"x": 1}, {"x": 2}],
+                "medium_issues": [],
+                "low_issues": [{"x": 1}],
+                "unanimous_critiques": [{"x": 1}],
+                "risk_areas": [],
+                "split_opinions": [{"x": 1}, {"x": 2}],
+                "agreement_score": 0.75,
+            }
+        ),
+        encoding="utf-8",
+    )
+    out = _parse(render_outputs(review))
+    assert out["critical_count"] == "1"
+    assert out["high_count"] == "2"
+    assert out["total_count"] == "4"  # 1 + 2 + 0 + 1
+    assert out["split_opinions_count"] == "2"
+    assert out["agreement_score"] == "0.75"
+    assert out["review_json_path"].endswith("review.json")
+
+
+def test_missing_file_degrades_to_zeros(tmp_path: Path):
+    out = _parse(render_outputs(tmp_path / "nope.json"))
+    assert out["review_json_path"] == ""
+    assert out["total_count"] == "0"
+    assert out["agreement_score"] == "0.0"
+
+
+def test_garbage_json_degrades_to_zeros(tmp_path: Path):
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json", encoding="utf-8")
+    out = _parse(render_outputs(bad))
+    assert out["total_count"] == "0"


### PR DESCRIPTION
## Summary

Carves the public-surface YAML parse fix out of draft PR #8669 without bringing the broader M2 receipt / mission-cadence stack or the #8667 dependency with it.

Current `origin/main` still fails PyYAML on `action.yml` because the embedded `python3 - <<'PY'` body starts at column 0 inside a composite-action `run:` block. This moves that review-count extraction into a stdlib helper and keeps `action.yml` as valid YAML.

## Scope

- replace the inline Python heredoc in `action.yml` with a call to `scripts/extract_review_counts.py`
- add focused tests for valid, missing, and malformed review JSON
- no receipt-emission, quorum, workflow, mission-cadence, or #8667 changes

## Validation

- `python3 -c 'import yaml; yaml.safe_load(open("action.yml", encoding="utf-8")); print("action.yml parses")'`
- `python3 -m pytest tests/scripts/test_extract_review_counts.py`
- `python3 -c 'import yaml; data=yaml.safe_load(open("action.yml", encoding="utf-8")); steps=data["runs"]["steps"]; review=next(s for s in steps if s.get("id") == "review"); assert "scripts/extract_review_counts.py" in review["run"]; assert "python3 - <<" not in review["run"]'`
- pre-commit and push hooks passed, including `check yaml`, ruff, format, mypy, gitleaks, and portability guard

`actionlint action.yml` now reaches normal workflow-schema complaints because this file is action metadata, not a workflow; it no longer fails on the YAML scanner issue.
