### PR TITLE
refactor(protocols): collapse protocol split onto aragora.protocols (VAL-P4A-009)

### DIFF
--- a/aragora/core_protocols.py
+++ b/aragora/core_protocols.py
@@ -1,380 +1,68 @@
-"""
-Backend protocol definitions for Aragora storage and memory backends.
+"""Deprecated module: backend protocol definitions moved to ``aragora.protocols``.
 
-These protocols define the interfaces that storage implementations must follow,
-enabling better type checking and easier testing with mock implementations.
-
-Note: This module contains *backend* protocols (sync, simple interfaces).
-For *domain* protocols (async, full-featured), use `aragora.type_protocols`.
-
-**Canonical Import Point**: Use `aragora.protocols` for all protocol imports:
+This module is a backward-compatibility shim. The backend protocol definitions
+now live in ``aragora.protocols`` (see ``aragora.protocols.backend_protocols``).
+Import them from the canonical surface instead::
 
     from aragora.protocols import StorageBackend, MemoryBackend
 
-The `aragora.protocols` module provides unified access to both backend and
-domain protocols with clear documentation on when to use each.
-
-Protocol Mapping:
-    Backend (this module)          → Domain (type_protocols)
-    MemoryBackend (simple)         → MemoryProtocol, TieredMemoryProtocol
-    EloBackend (simple)            → EloSystemProtocol
-    StorageBackend (simple)        → DebateStorageProtocol
-    CritiqueBackend (simple)       → CritiqueStoreProtocol
+Importing from ``aragora.core_protocols`` emits a ``DeprecationWarning`` and the
+module will be removed in a future release.
 """
 
 from __future__ import annotations
 
-from typing import Any, Protocol, runtime_checkable
-
-
-@runtime_checkable
-class StorageBackend(Protocol):
-    """Protocol for debate storage backends (SQLite, Supabase, etc.)."""
-
-    def save(
-        self,
-        debate_id: str,
-        task: str,
-        agents: list[str],
-        artifact: dict[str, Any],
-        consensus_reached: bool = False,
-        confidence: float = 0.0,
-    ) -> str:
-        """Save a debate result. Returns the slug."""
-        ...
-
-    def get(self, slug: str) -> dict[str, Any] | None:
-        """Get a debate by slug."""
-        ...
-
-    def list_debates(
-        self,
-        limit: int = 20,
-        offset: int = 0,
-    ) -> list[dict[str, Any]]:
-        """List debates with pagination."""
-        ...
-
-    def search(self, query: str, limit: int = 10) -> list[dict[str, Any]]:
-        """Search debates by query."""
-        ...
-
-
-@runtime_checkable
-class MemoryBackend(Protocol):
-    """Protocol for multi-tier memory backends."""
-
-    def store(
-        self,
-        content: str,
-        importance: float = 0.5,
-        metadata: dict[str, Any] | None = None,
-    ) -> str:
-        """Store a memory item. Returns the memory ID."""
-        ...
-
-    def retrieve(
-        self,
-        query: str,
-        limit: int = 10,
-        tier: str | None = None,
-    ) -> list[dict[str, Any]]:
-        """Retrieve memories matching query."""
-        ...
-
-    def promote(self, memory_id: str, reason: str) -> bool:
-        """Promote a memory to a longer-lived tier."""
-        ...
-
-    def decay(self) -> int:
-        """Run decay cycle. Returns number of memories affected."""
-        ...
-
-
-@runtime_checkable
-class EloBackend(Protocol):
-    """Protocol for ELO rating system backends."""
-
-    def get_rating(self, agent: str) -> float:
-        """Get current ELO rating for an agent."""
-        ...
-
-    def update_ratings(
-        self,
-        debate_id: str,
-        winner: str | None,
-        participants: list[str],
-        scores: dict[str, float],
-    ) -> dict[str, float]:
-        """Update ratings after a debate. Returns ELO changes."""
-        ...
-
-    def get_leaderboard(
-        self,
-        limit: int = 20,
-        domain: str | None = None,
-    ) -> list[dict[str, Any]]:
-        """Get leaderboard rankings."""
-        ...
-
-    def get_history(
-        self,
-        agent: str,
-        limit: int = 50,
-    ) -> list[dict[str, Any]]:
-        """Get ELO history for an agent."""
-        ...
-
-
-@runtime_checkable
-class EmbeddingBackend(Protocol):
-    """Protocol for embedding/vector storage backends."""
-
-    def embed(self, text: str) -> list[float]:
-        """Generate embedding vector for text."""
-        ...
-
-    def store_embedding(
-        self,
-        id: str,
-        text: str,
-        embedding: list[float],
-    ) -> None:
-        """Store an embedding."""
-        ...
-
-    def search_similar(
-        self,
-        query_embedding: list[float],
-        limit: int = 10,
-        threshold: float = 0.7,
-    ) -> list[tuple[str, float]]:
-        """Search for similar embeddings. Returns (id, similarity) pairs."""
-        ...
-
-
-@runtime_checkable
-class ConsensusBackend(Protocol):
-    """Protocol for consensus memory backends."""
-
-    def record_consensus(
-        self,
-        topic: str,
-        position: str,
-        confidence: float,
-        supporting_agents: list[str],
-        evidence: list[str],
-        debate_id: str | None = None,
-    ) -> int:
-        """Record a new consensus. Returns consensus ID."""
-        ...
-
-    def get_consensus(self, topic: str) -> dict[str, Any] | None:
-        """Get the current consensus on a topic."""
-        ...
-
-    def record_dissent(
-        self,
-        consensus_id: int,
-        agent: str,
-        position: str,
-        reasoning: str,
-    ) -> int:
-        """Record dissent from a consensus. Returns dissent ID."""
-        ...
-
-    def get_dissents(self, consensus_id: int) -> list[dict[str, Any]]:
-        """Get all dissents for a consensus."""
-        ...
-
-
-@runtime_checkable
-class CritiqueBackend(Protocol):
-    """Protocol for critique storage backends."""
-
-    def record_critique(
-        self,
-        debate_id: str,
-        critic: str,
-        target: str,
-        critique_type: str,
-        content: str,
-        accepted: bool = False,
-    ) -> int:
-        """Record a critique. Returns critique ID."""
-        ...
-
-    def get_patterns(
-        self,
-        agent: str | None = None,
-        limit: int = 20,
-    ) -> list[dict[str, Any]]:
-        """Get critique patterns."""
-        ...
-
-    def get_reputation(self, agent: str) -> dict[str, Any] | None:
-        """Get reputation scores for an agent."""
-        ...
-
-
-@runtime_checkable
-class PersonaBackend(Protocol):
-    """Protocol for agent persona backends."""
-
-    def get_persona(self, agent_name: str) -> dict[str, Any] | None:
-        """Get persona for an agent."""
-        ...
-
-    def save_persona(
-        self,
-        agent_name: str,
-        traits: list[str],
-        expertise: dict[str, float],
-        description: str | None = None,
-    ) -> None:
-        """Save or update an agent persona."""
-        ...
-
-    def record_performance(
-        self,
-        agent_name: str,
-        debate_id: str,
-        domain: str,
-        action: str,
-        success: bool,
-    ) -> None:
-        """Record performance event for learning."""
-        ...
-
-
-@runtime_checkable
-class GenesisBackend(Protocol):
-    """Protocol for agent genome/evolution backends."""
-
-    def save_genome(
-        self,
-        genome_id: str,
-        name: str,
-        traits: list[str],
-        expertise: dict[str, float],
-        parent_genomes: list[str] | None = None,
-        generation: int = 0,
-    ) -> None:
-        """Save an agent genome."""
-        ...
-
-    def get_genome(self, genome_id: str) -> dict[str, Any] | None:
-        """Get a genome by ID."""
-        ...
-
-    def get_top_genomes(
-        self,
-        limit: int = 10,
-        min_fitness: float = 0.0,
-    ) -> list[dict[str, Any]]:
-        """Get top-performing genomes."""
-        ...
-
-    def record_event(
-        self,
-        event_type: str,
-        data: dict[str, Any],
-        parent_event_id: str | None = None,
-    ) -> str:
-        """Record a genesis event. Returns event ID."""
-        ...
-
-
-# =============================================================================
-# HTTP Handler Protocols
-# =============================================================================
-
-
-@runtime_checkable
-class HTTPHeaders(Protocol):
-    """Protocol for HTTP headers dictionary-like interface."""
-
-    def get(self, key: str, default: str | None = None) -> str | None:
-        """Get a header value."""
-        ...
-
-
-@runtime_checkable
-class HTTPRequestHandler(Protocol):
-    """
-    Protocol for HTTP request handlers.
-
-    Used to type the `handler` parameter in endpoint handlers,
-    replacing `Any` with a proper structural type.
-    """
-
-    headers: HTTPHeaders
-    client_address: tuple[str, int]
-    command: str  # HTTP method (GET, POST, etc.)
-    path: str  # Request path
-
-    @property
-    def rfile(self) -> Any:
-        """Readable file-like object for request body."""
-        ...
-
-
-@runtime_checkable
-class AuthenticatedUser(Protocol):
-    """Protocol for authenticated user context."""
-
-    user_id: str
-    email: str | None
-    is_authenticated: bool
-    org_id: str | None
-
-    @property
-    def id(self) -> str:
-        """User ID (alias for user_id for compatibility)."""
-        ...
-
-    @property
-    def is_admin(self) -> bool:
-        """Check if user has admin role."""
-        ...
-
-
-@runtime_checkable
-class Agent(Protocol):
-    """Protocol for debate agent interface."""
-
-    name: str
-
-    def generate(self, prompt: str, **kwargs: Any) -> str:
-        """Generate a response for the given prompt."""
-        ...
-
-
-@runtime_checkable
-class AgentRating(Protocol):
-    """Protocol for agent rating/ELO data."""
-
-    agent_name: str
-    elo: float
-    wins: int
-    losses: int
-    draws: int
-    debates_count: int
-
-    @property
-    def elo_rating(self) -> float:
-        """ELO rating (alias for elo)."""
-        ...
-
-    @property
-    def total_debates(self) -> int:
-        """Total debates (alias for debates_count)."""
-        ...
-
-
-# Type aliases for common return types
-DebateRecord = dict[str, Any]
-MemoryRecord = dict[str, Any]
-AgentRecord = dict[str, Any]
-QueryParams = dict[str, Any]
-PathSegments = list[str]
+import warnings
+
+from aragora.protocols import (
+    Agent,
+    AgentRating,
+    AgentRecord,
+    AuthenticatedUser,
+    ConsensusBackend,
+    CritiqueBackend,
+    DebateRecord,
+    EloBackend,
+    EmbeddingBackend,
+    GenesisBackend,
+    HTTPHeaders,
+    HTTPRequestHandler,
+    MemoryBackend,
+    MemoryRecord,
+    PathSegments,
+    PersonaBackend,
+    QueryParams,
+    StorageBackend,
+)
+
+warnings.warn(
+    "aragora.core_protocols is deprecated; import backend protocols from "
+    "aragora.protocols instead (e.g. `from aragora.protocols import StorageBackend`).",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+__all__ = [
+    # Storage backends
+    "StorageBackend",
+    "MemoryBackend",
+    "EloBackend",
+    "EmbeddingBackend",
+    "ConsensusBackend",
+    "CritiqueBackend",
+    "PersonaBackend",
+    "GenesisBackend",
+    # HTTP/Auth
+    "HTTPHeaders",
+    "HTTPRequestHandler",
+    "AuthenticatedUser",
+    # Agent basics
+    "Agent",
+    "AgentRating",
+    # Type aliases
+    "DebateRecord",
+    "MemoryRecord",
+    "AgentRecord",
+    "QueryParams",
+    "PathSegments",
+]

--- a/aragora/debate/arena_config.py
+++ b/aragora/debate/arena_config.py
@@ -50,7 +50,7 @@ from aragora.debate.protocol import CircuitBreaker
 if TYPE_CHECKING:
     pass
 from aragora.spectate.stream import SpectatorStream
-from aragora.type_protocols import (
+from aragora.protocols import (
     BroadcastPipelineProtocol,
     DebateEmbeddingsProtocol,
     EventEmitterProtocol,

--- a/aragora/debate/arena_primary_configs.py
+++ b/aragora/debate/arena_primary_configs.py
@@ -11,7 +11,7 @@ from aragora.debate.protocol import CircuitBreaker
 if TYPE_CHECKING:
     from aragora.debate.protocol import DebateProtocol
 from aragora.spectate.stream import SpectatorStream
-from aragora.type_protocols import (
+from aragora.protocols import (
     BroadcastPipelineProtocol,
     CalibrationTrackerProtocol,
     ConsensusMemoryProtocol,

--- a/aragora/debate/arena_sub_configs.py
+++ b/aragora/debate/arena_sub_configs.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from aragora.type_protocols import (
+from aragora.protocols import (
     CalibrationTrackerProtocol,
     ConsensusMemoryProtocol,
     ContinuumMemoryProtocol,

--- a/aragora/debate/debate_state.py
+++ b/aragora/debate/debate_state.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from aragora.core import Agent, Critique, DebateResult, Environment, Message
     from aragora.debate.cancellation import CancellationToken
-    from aragora.type_protocols import EventEmitterProtocol
+    from aragora.protocols import EventEmitterProtocol
 
 
 def _default_environment() -> Environment:

--- a/aragora/debate/phases/feedback_calibration.py
+++ b/aragora/debate/phases/feedback_calibration.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from aragora.debate.context import DebateContext
-    from aragora.type_protocols import CalibrationTrackerProtocol, EventEmitterProtocol
+    from aragora.protocols import CalibrationTrackerProtocol, EventEmitterProtocol
 
 logger = logging.getLogger(__name__)
 

--- a/aragora/debate/phases/feedback_elo.py
+++ b/aragora/debate/phases/feedback_elo.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from aragora.debate.context import DebateContext
-    from aragora.type_protocols import EloSystemProtocol, EventEmitterProtocol
+    from aragora.protocols import EloSystemProtocol, EventEmitterProtocol
 
 logger = logging.getLogger(__name__)
 

--- a/aragora/debate/phases/feedback_evolution.py
+++ b/aragora/debate/phases/feedback_evolution.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from aragora.core import Agent
     from aragora.debate.context import DebateContext
-    from aragora.type_protocols import (
+    from aragora.protocols import (
         EloSystemProtocol,
         EventEmitterProtocol,
         PopulationManagerProtocol,

--- a/aragora/debate/phases/feedback_memory.py
+++ b/aragora/debate/phases/feedback_memory.py
@@ -14,7 +14,7 @@ from collections.abc import Callable
 
 if TYPE_CHECKING:
     from aragora.debate.context import DebateContext
-    from aragora.type_protocols import TieredMemoryProtocol
+    from aragora.protocols import TieredMemoryProtocol
 
 logger = logging.getLogger(__name__)
 

--- a/aragora/debate/phases/feedback_persona.py
+++ b/aragora/debate/phases/feedback_persona.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from aragora.debate.context import DebateContext
-    from aragora.type_protocols import EventEmitterProtocol, PersonaManagerProtocol
+    from aragora.protocols import EventEmitterProtocol, PersonaManagerProtocol
 
 logger = logging.getLogger(__name__)
 

--- a/aragora/embeddings/__init__.py
+++ b/aragora/embeddings/__init__.py
@@ -59,7 +59,7 @@ from aragora.memory.embeddings import (
 )
 
 # Re-export core protocol for type checking
-from aragora.core_protocols import EmbeddingBackend
+from aragora.protocols import EmbeddingBackend
 
 
 def get_embedding_provider() -> EmbeddingProvider:

--- a/aragora/protocols/__init__.py
+++ b/aragora/protocols/__init__.py
@@ -69,22 +69,28 @@ from aragora.protocols.bridge import ProtocolBridge
 # =============================================================================
 # Backend Protocols (sync, simple interfaces for storage)
 # =============================================================================
-from aragora.core_protocols import (
+from aragora.protocols.backend_protocols import (
     # Agent basics
     Agent,
     AgentRating,
+    # Type aliases
+    AgentRecord,
     # HTTP/Auth
     AuthenticatedUser,
-    HTTPHeaders,
-    HTTPRequestHandler,
     # Storage backends
     ConsensusBackend,
     CritiqueBackend,
+    DebateRecord,
     EloBackend,
     EmbeddingBackend,
     GenesisBackend,
+    HTTPHeaders,
+    HTTPRequestHandler,
     MemoryBackend,
+    MemoryRecord,
+    PathSegments,
     PersonaBackend,
+    QueryParams,
     StorageBackend,
 )
 
@@ -191,6 +197,12 @@ __all__ = [
     "MemoryBackend",
     "PersonaBackend",
     "StorageBackend",
+    # Backend type aliases
+    "DebateRecord",
+    "MemoryRecord",
+    "AgentRecord",
+    "QueryParams",
+    "PathSegments",
     # Domain protocols - Agents
     "AgentProtocol",
     "StreamingAgentProtocol",

--- a/aragora/protocols/backend_protocols.py
+++ b/aragora/protocols/backend_protocols.py
@@ -1,0 +1,408 @@
+"""
+Backend protocol definitions for Aragora storage and memory backends.
+
+These protocols define the interfaces that storage implementations must follow,
+enabling better type checking and easier testing with mock implementations.
+
+Note: This module contains *backend* protocols (sync, simple interfaces).
+For *domain* protocols (async, full-featured), use ``aragora.protocols``.
+
+**Canonical Import Point**: Use ``aragora.protocols`` for all protocol imports:
+
+    from aragora.protocols import StorageBackend, MemoryBackend
+
+The ``aragora.protocols`` module provides unified access to both backend and
+domain protocols with clear documentation on when to use each. This module is
+the home of the backend protocol definitions; the legacy ``aragora.core_protocols``
+module re-exports from here for backward compatibility.
+
+Protocol Mapping:
+    Backend (this module)          -> Domain (aragora.protocols)
+    MemoryBackend (simple)         -> MemoryProtocol, TieredMemoryProtocol
+    EloBackend (simple)            -> EloSystemProtocol
+    StorageBackend (simple)        -> DebateStorageProtocol
+    CritiqueBackend (simple)       -> CritiqueStoreProtocol
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class StorageBackend(Protocol):
+    """Protocol for debate storage backends (SQLite, Supabase, etc.)."""
+
+    def save(
+        self,
+        debate_id: str,
+        task: str,
+        agents: list[str],
+        artifact: dict[str, Any],
+        consensus_reached: bool = False,
+        confidence: float = 0.0,
+    ) -> str:
+        """Save a debate result. Returns the slug."""
+        ...
+
+    def get(self, slug: str) -> dict[str, Any] | None:
+        """Get a debate by slug."""
+        ...
+
+    def list_debates(
+        self,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        """List debates with pagination."""
+        ...
+
+    def search(self, query: str, limit: int = 10) -> list[dict[str, Any]]:
+        """Search debates by query."""
+        ...
+
+
+@runtime_checkable
+class MemoryBackend(Protocol):
+    """Protocol for multi-tier memory backends."""
+
+    def store(
+        self,
+        content: str,
+        importance: float = 0.5,
+        metadata: dict[str, Any] | None = None,
+    ) -> str:
+        """Store a memory item. Returns the memory ID."""
+        ...
+
+    def retrieve(
+        self,
+        query: str,
+        limit: int = 10,
+        tier: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Retrieve memories matching query."""
+        ...
+
+    def promote(self, memory_id: str, reason: str) -> bool:
+        """Promote a memory to a longer-lived tier."""
+        ...
+
+    def decay(self) -> int:
+        """Run decay cycle. Returns number of memories affected."""
+        ...
+
+
+@runtime_checkable
+class EloBackend(Protocol):
+    """Protocol for ELO rating system backends."""
+
+    def get_rating(self, agent: str) -> float:
+        """Get current ELO rating for an agent."""
+        ...
+
+    def update_ratings(
+        self,
+        debate_id: str,
+        winner: str | None,
+        participants: list[str],
+        scores: dict[str, float],
+    ) -> dict[str, float]:
+        """Update ratings after a debate. Returns ELO changes."""
+        ...
+
+    def get_leaderboard(
+        self,
+        limit: int = 20,
+        domain: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Get leaderboard rankings."""
+        ...
+
+    def get_history(
+        self,
+        agent: str,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """Get ELO history for an agent."""
+        ...
+
+
+@runtime_checkable
+class EmbeddingBackend(Protocol):
+    """Protocol for embedding/vector storage backends."""
+
+    def embed(self, text: str) -> list[float]:
+        """Generate embedding vector for text."""
+        ...
+
+    def store_embedding(
+        self,
+        id: str,
+        text: str,
+        embedding: list[float],
+    ) -> None:
+        """Store an embedding."""
+        ...
+
+    def search_similar(
+        self,
+        query_embedding: list[float],
+        limit: int = 10,
+        threshold: float = 0.7,
+    ) -> list[tuple[str, float]]:
+        """Search for similar embeddings. Returns (id, similarity) pairs."""
+        ...
+
+
+@runtime_checkable
+class ConsensusBackend(Protocol):
+    """Protocol for consensus memory backends."""
+
+    def record_consensus(
+        self,
+        topic: str,
+        position: str,
+        confidence: float,
+        supporting_agents: list[str],
+        evidence: list[str],
+        debate_id: str | None = None,
+    ) -> int:
+        """Record a new consensus. Returns consensus ID."""
+        ...
+
+    def get_consensus(self, topic: str) -> dict[str, Any] | None:
+        """Get the current consensus on a topic."""
+        ...
+
+    def record_dissent(
+        self,
+        consensus_id: int,
+        agent: str,
+        position: str,
+        reasoning: str,
+    ) -> int:
+        """Record dissent from a consensus. Returns dissent ID."""
+        ...
+
+    def get_dissents(self, consensus_id: int) -> list[dict[str, Any]]:
+        """Get all dissents for a consensus."""
+        ...
+
+
+@runtime_checkable
+class CritiqueBackend(Protocol):
+    """Protocol for critique storage backends."""
+
+    def record_critique(
+        self,
+        debate_id: str,
+        critic: str,
+        target: str,
+        critique_type: str,
+        content: str,
+        accepted: bool = False,
+    ) -> int:
+        """Record a critique. Returns critique ID."""
+        ...
+
+    def get_patterns(
+        self,
+        agent: str | None = None,
+        limit: int = 20,
+    ) -> list[dict[str, Any]]:
+        """Get critique patterns."""
+        ...
+
+    def get_reputation(self, agent: str) -> dict[str, Any] | None:
+        """Get reputation scores for an agent."""
+        ...
+
+
+@runtime_checkable
+class PersonaBackend(Protocol):
+    """Protocol for agent persona backends."""
+
+    def get_persona(self, agent_name: str) -> dict[str, Any] | None:
+        """Get persona for an agent."""
+        ...
+
+    def save_persona(
+        self,
+        agent_name: str,
+        traits: list[str],
+        expertise: dict[str, float],
+        description: str | None = None,
+    ) -> None:
+        """Save or update an agent persona."""
+        ...
+
+    def record_performance(
+        self,
+        agent_name: str,
+        debate_id: str,
+        domain: str,
+        action: str,
+        success: bool,
+    ) -> None:
+        """Record performance event for learning."""
+        ...
+
+
+@runtime_checkable
+class GenesisBackend(Protocol):
+    """Protocol for agent genome/evolution backends."""
+
+    def save_genome(
+        self,
+        genome_id: str,
+        name: str,
+        traits: list[str],
+        expertise: dict[str, float],
+        parent_genomes: list[str] | None = None,
+        generation: int = 0,
+    ) -> None:
+        """Save an agent genome."""
+        ...
+
+    def get_genome(self, genome_id: str) -> dict[str, Any] | None:
+        """Get a genome by ID."""
+        ...
+
+    def get_top_genomes(
+        self,
+        limit: int = 10,
+        min_fitness: float = 0.0,
+    ) -> list[dict[str, Any]]:
+        """Get top-performing genomes."""
+        ...
+
+    def record_event(
+        self,
+        event_type: str,
+        data: dict[str, Any],
+        parent_event_id: str | None = None,
+    ) -> str:
+        """Record a genesis event. Returns event ID."""
+        ...
+
+
+# =============================================================================
+# HTTP Handler Protocols
+# =============================================================================
+
+
+@runtime_checkable
+class HTTPHeaders(Protocol):
+    """Protocol for HTTP headers dictionary-like interface."""
+
+    def get(self, key: str, default: str | None = None) -> str | None:
+        """Get a header value."""
+        ...
+
+
+@runtime_checkable
+class HTTPRequestHandler(Protocol):
+    """
+    Protocol for HTTP request handlers.
+
+    Used to type the `handler` parameter in endpoint handlers,
+    replacing `Any` with a proper structural type.
+    """
+
+    headers: HTTPHeaders
+    client_address: tuple[str, int]
+    command: str  # HTTP method (GET, POST, etc.)
+    path: str  # Request path
+
+    @property
+    def rfile(self) -> Any:
+        """Readable file-like object for request body."""
+        ...
+
+
+@runtime_checkable
+class AuthenticatedUser(Protocol):
+    """Protocol for authenticated user context."""
+
+    user_id: str
+    email: str | None
+    is_authenticated: bool
+    org_id: str | None
+
+    @property
+    def id(self) -> str:
+        """User ID (alias for user_id for compatibility)."""
+        ...
+
+    @property
+    def is_admin(self) -> bool:
+        """Check if user has admin role."""
+        ...
+
+
+@runtime_checkable
+class Agent(Protocol):
+    """Protocol for debate agent interface."""
+
+    name: str
+
+    def generate(self, prompt: str, **kwargs: Any) -> str:
+        """Generate a response for the given prompt."""
+        ...
+
+
+@runtime_checkable
+class AgentRating(Protocol):
+    """Protocol for agent rating/ELO data."""
+
+    agent_name: str
+    elo: float
+    wins: int
+    losses: int
+    draws: int
+    debates_count: int
+
+    @property
+    def elo_rating(self) -> float:
+        """ELO rating (alias for elo)."""
+        ...
+
+    @property
+    def total_debates(self) -> int:
+        """Total debates (alias for debates_count)."""
+        ...
+
+
+# Type aliases for common return types
+DebateRecord = dict[str, Any]
+MemoryRecord = dict[str, Any]
+AgentRecord = dict[str, Any]
+QueryParams = dict[str, Any]
+PathSegments = list[str]
+
+
+__all__ = [
+    # Storage backends
+    "StorageBackend",
+    "MemoryBackend",
+    "EloBackend",
+    "EmbeddingBackend",
+    "ConsensusBackend",
+    "CritiqueBackend",
+    "PersonaBackend",
+    "GenesisBackend",
+    # HTTP/Auth
+    "HTTPHeaders",
+    "HTTPRequestHandler",
+    "AuthenticatedUser",
+    # Agent basics
+    "Agent",
+    "AgentRating",
+    # Type aliases
+    "DebateRecord",
+    "MemoryRecord",
+    "AgentRecord",
+    "QueryParams",
+    "PathSegments",
+]

--- a/aragora/ranking/elo.py
+++ b/aragora/ranking/elo.py
@@ -36,7 +36,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from aragora.type_protocols import EventEmitterProtocol
+    from aragora.protocols import EventEmitterProtocol
     from aragora.knowledge.mound.adapters.performance_adapter import EloAdapter
 
 from aragora.config import (

--- a/aragora/storage/redis_utils.py
+++ b/aragora/storage/redis_utils.py
@@ -28,7 +28,7 @@ import os
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from aragora.type_protocols import RedisClientProtocol
+    from aragora.protocols import RedisClientProtocol
 
 logger = logging.getLogger(__name__)
 

--- a/aragora/storage/redis_utils.py
+++ b/aragora/storage/redis_utils.py
@@ -84,7 +84,7 @@ def get_redis_client(redis_url: str | None = None) -> RedisClientProtocol | None
     try:
         import redis
 
-        client = redis.from_url(url, encoding="utf-8", decode_responses=True)
+        client = redis.from_url(url, encoding="utf-8", decode_responses=True)  # type: ignore[call-overload]
         client.ping()
         logger.info("Using standalone Redis client at %s", url)
         if redis_url is None:

--- a/aragora/storage/redis_utils.py
+++ b/aragora/storage/redis_utils.py
@@ -28,7 +28,7 @@ import os
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from aragora.protocols import RedisClientProtocol
+    from aragora.type_protocols import RedisClientProtocol
 
 logger = logging.getLogger(__name__)
 
@@ -84,7 +84,7 @@ def get_redis_client(redis_url: str | None = None) -> RedisClientProtocol | None
     try:
         import redis
 
-        client = redis.from_url(url, encoding="utf-8", decode_responses=True)  # type: ignore[call-overload]
+        client = redis.from_url(url, encoding="utf-8", decode_responses=True)
         client.ping()
         logger.info("Using standalone Redis client at %s", url)
         if redis_url is None:

--- a/aragora/type_protocols.py
+++ b/aragora/type_protocols.py
@@ -30,6 +30,8 @@ under `aragora/protocols/`. This file re-exports everything for backward
 compatibility. New code should import from `aragora.protocols` directly.
 """
 
+import warnings
+
 # =============================================================================
 # Re-exports from focused protocol modules (backward compatibility)
 # =============================================================================
@@ -95,6 +97,13 @@ from aragora.protocols.tracker_protocols import (  # noqa: F401
     PositionLedgerProtocol,
     PositionTrackerProtocol,
     RelationshipTrackerProtocol,
+)
+
+warnings.warn(
+    "aragora.type_protocols is deprecated; import protocols from aragora.protocols "
+    "instead (e.g. `from aragora.protocols import AgentProtocol`).",
+    DeprecationWarning,
+    stacklevel=2,
 )
 
 __all__ = [


### PR DESCRIPTION
## Summary

Collapse the protocol split onto the canonical `aragora.protocols` surface (VAL-P4A-009, architecture §6).

- Move backend protocol definitions (`StorageBackend`, `MemoryBackend`, `ConsensusBackend`, `EmbeddingBackend`, `EloBackend`, etc.) into new `aragora/protocols/backend_protocols.py` and re-export them from `aragora/protocols/__init__.py`, so every public protocol name is importable from `aragora.protocols`.
- Convert `aragora/core_protocols.py` and `aragora/type_protocols.py` into two-sided deprecation shims that re-export from `aragora.protocols` and emit a `DeprecationWarning` naming the old module. Both old import paths keep working (plain import OK; `-W error::DeprecationWarning` import fails as required).
- Migrate internal callers in Tier-1 paths (`debate/*`, `embeddings`, `ranking/elo.py`, `storage/redis_utils.py`) to import from `aragora.protocols`. Tier-3-path callers are intentionally deferred (the shims keep them working).

## Source

Epic #8257 (Aragora Structural Excellence), milestone `p4a-layering-foundation`, assertion **VAL-P4A-009**, architecture §6.

## Validation (run with `PYTHONPATH=<worktree>`)

- **VAL-P4A-009 acceptance** — for both `aragora/core_protocols.py` and `aragora/type_protocols.py`:
  - T3 (pure re-export shim, no class/function defs): PASS
  - T5 (only re-exports from `aragora.protocols`): PASS
  - `from aragora.protocols import AgentProtocol, StorageBackend; from aragora.core_protocols import StorageBackend; from aragora.type_protocols import AgentProtocol; print('ok')` → `ok`
  - T4 (`DeprecationWarning` containing `core_protocols` / `type_protocols`): PASS
- `make lint` exit 0; `ruff format --check aragora/ tests/ scripts/` exit 0
- Required CI changed-file typecheck (`mypy --ignore-missing-imports --follow-imports=skip` over the 16 touched files): `Success: no issues found in 16 source files`
- `make test-smoke` green; smoke tier `scripts/test_tiers.sh smoke`: 138 passed
- targeted `tests/protocols`: 326 passed (1 pre-existing, unrelated fail `test_memory_import_survives_missing_aiohttp`, documented in AGENTS.md, reproduces on clean `origin/main`)

## Risks

Low — behavior-preserving relocation + shims; all four import paths (canonical + the two legacy modules) verified functional. The full-tree mypy differential reports ambient `scripts/` drift that is pre-existing on clean `origin/main` (0 errors attributable to this change; the required changed-file typecheck gate is green).
