### PR TITLE
ci: aragora-verify PyPI publish workflow (one-click)

### DIFF
--- a/.github/workflows/publish-aragora-verify.yml
+++ b/.github/workflows/publish-aragora-verify.yml
@@ -20,13 +20,15 @@ on:
         description: 'Type PUBLISH to confirm'
         required: true
 
+# Least privilege at the top level; each job re-grants only what it needs.
 permissions:
-  contents: write
-  id-token: write  # Required for PyPI trusted publishing
+  contents: read
 
 jobs:
   test:
     runs-on: aragora
+    permissions:
+      contents: read  # checkout + run tests only; no OIDC, no write
     steps:
       - uses: actions/checkout@v4
 
@@ -47,8 +49,14 @@ jobs:
   publish:
     needs: test
     runs-on: aragora
-    if: github.event.inputs.confirm == 'PUBLISH'
+    # Gate on explicit confirmation AND the protected default branch, so a
+    # workflow_dispatch against any other ref can never reach PyPI even though
+    # the OIDC trusted publisher is scoped only to workflow + environment.
+    if: ${{ github.event.inputs.confirm == 'PUBLISH' && github.ref == 'refs/heads/main' }}
     environment: pypi
+    permissions:
+      id-token: write  # PyPI trusted publishing (OIDC)
+      contents: write  # create the GitHub Release / tag
     steps:
       - uses: actions/checkout@v4
 
@@ -68,7 +76,7 @@ jobs:
         env:
           VERSION: ${{ github.event.inputs.version }}
         run: |
-          python3 -c "import re,pathlib,os; p=pathlib.Path('pyproject.toml'); v=os.environ['VERSION']; assert re.fullmatch(r'[0-9A-Za-z.+-]+', v), 'bad version'; p.write_text(re.sub(r'(?m)^version = \"[^\"]*\"', f'version = \"{v}\"', p.read_text()))"
+          python3 -c "import re,pathlib,os; p=pathlib.Path('pyproject.toml'); v=os.environ['VERSION']; assert re.fullmatch(r'[0-9A-Za-z.+-]+', v), 'bad version'; text,n=re.subn(r'(?m)^version = \"[^\"]*\"', f'version = \"{v}\"', p.read_text()); assert n==1, f'expected exactly one version line, rewrote {n}'; p.write_text(text)"
           grep '^version' pyproject.toml | head -1
 
       - name: Build
@@ -87,7 +95,7 @@ jobs:
           attestations: false
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2 (pinned to commit)
         with:
           tag_name: aragora-verify-v${{ github.event.inputs.version }}
           name: aragora-verify v${{ github.event.inputs.version }}

--- a/.github/workflows/publish-aragora-verify.yml
+++ b/.github/workflows/publish-aragora-verify.yml
@@ -1,0 +1,124 @@
+name: Publish aragora-verify to PyPI
+
+# Publishes the standalone receipt verifier (aragora-verify/) to PyPI so the
+# "anyone can verify, zero Aragora install" story is real (`pip install
+# aragora-verify`). Manual, confirmed, one-click.
+#
+# PREREQUISITE (one-time): configure PyPI trusted publishing for the
+# `aragora-verify` project — on PyPI, add a "pending publisher" for repo
+# synaptent/aragora, workflow `publish-aragora-verify.yml`, environment `pypi`.
+# Until that exists, the publish step will fail at the OIDC handshake (no code
+# change needed once configured).
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., 0.1.0)'
+        required: true
+      confirm:
+        description: 'Type PUBLISH to confirm'
+        required: true
+
+permissions:
+  contents: write
+  id-token: write  # Required for PyPI trusted publishing
+
+jobs:
+  test:
+    runs-on: aragora
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify checkout integrity
+        shell: bash
+        run: |
+          if [[ ! -f aragora-verify/pyproject.toml ]]; then
+            echo "::warning::aragora-verify missing after checkout; attempting recovery"
+            git sparse-checkout disable || true
+            git fetch --no-tags origin "${GITHUB_SHA:-HEAD}"
+            git reset --hard FETCH_HEAD
+          fi
+          if [[ ! -f aragora-verify/pyproject.toml ]]; then
+            echo "::error::aragora-verify/pyproject.toml missing"; ls -la; exit 1
+          fi
+
+      - name: Setup Python
+        uses: ./.github/actions/setup-python-safe
+        with:
+          python-version: "3.11"
+
+      - name: Test (zero Aragora dependency)
+        working-directory: aragora-verify
+        run: |
+          python -m pip install -e ".[dev]"
+          PYTHONPATH=src python -m pytest tests/ -q
+
+  publish:
+    needs: test
+    runs-on: aragora
+    if: github.event.inputs.confirm == 'PUBLISH'
+    environment: pypi
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify checkout integrity
+        shell: bash
+        run: |
+          if [[ ! -f aragora-verify/pyproject.toml ]]; then
+            git sparse-checkout disable || true
+            git fetch --no-tags origin "${GITHUB_SHA:-HEAD}"
+            git reset --hard FETCH_HEAD
+          fi
+          test -f aragora-verify/pyproject.toml || { echo "::error::aragora-verify missing"; exit 1; }
+
+      - name: Setup Python
+        uses: ./.github/actions/setup-python-safe
+        with:
+          python-version: "3.11"
+
+      - name: Install build tools
+        run: python -m pip install build twine
+
+      - name: Set version
+        working-directory: aragora-verify
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+        run: |
+          python3 -c "import re,pathlib,os; p=pathlib.Path('pyproject.toml'); v=os.environ['VERSION']; assert re.fullmatch(r'[0-9A-Za-z.+-]+', v), 'bad version'; p.write_text(re.sub(r'(?m)^version = \"[^\"]*\"', f'version = \"{v}\"', p.read_text()))"
+          grep '^version' pyproject.toml | head -1
+
+      - name: Build
+        working-directory: aragora-verify
+        run: python -m build
+
+      - name: Check
+        working-directory: aragora-verify
+        run: twine check dist/*
+
+      - name: Publish to PyPI (trusted publishing)
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: aragora-verify/dist/
+          verbose: true
+          attestations: false
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: aragora-verify-v${{ github.event.inputs.version }}
+          name: aragora-verify v${{ github.event.inputs.version }}
+          body: |
+            ## aragora-verify v${{ github.event.inputs.version }}
+
+            Standalone, offline verifier for Open Decision Receipts (ODR) — zero
+            Aragora dependency. Validate a receipt with nothing but the JSON:
+            schema conformance, RFC 8785 (JCS) canonical digest, Ed25519
+            signature, quorum consistency, and hash-chain linkage.
+
+            ```bash
+            pip install aragora-verify==${{ github.event.inputs.version }}
+            aragora-verify decision-receipt.odr.json
+            ```
+          draft: false
+          prerelease: ${{ contains(github.event.inputs.version, 'beta') || contains(github.event.inputs.version, 'alpha') || contains(github.event.inputs.version, 'rc') }}

--- a/.github/workflows/publish-aragora-verify.yml
+++ b/.github/workflows/publish-aragora-verify.yml
@@ -31,17 +31,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Verify checkout integrity
-        shell: bash
-        run: |
-          if [[ ! -f aragora-verify/pyproject.toml ]]; then
-            echo "::warning::aragora-verify missing after checkout; attempting recovery"
-            git sparse-checkout disable || true
-            git fetch --no-tags origin "${GITHUB_SHA:-HEAD}"
-            git reset --hard FETCH_HEAD
-          fi
-          if [[ ! -f aragora-verify/pyproject.toml ]]; then
-            echo "::error::aragora-verify/pyproject.toml missing"; ls -la; exit 1
-          fi
+        uses: ./.github/actions/checkout-integrity
 
       - name: Setup Python
         uses: ./.github/actions/setup-python-safe
@@ -63,14 +53,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Verify checkout integrity
-        shell: bash
-        run: |
-          if [[ ! -f aragora-verify/pyproject.toml ]]; then
-            git sparse-checkout disable || true
-            git fetch --no-tags origin "${GITHUB_SHA:-HEAD}"
-            git reset --hard FETCH_HEAD
-          fi
-          test -f aragora-verify/pyproject.toml || { echo "::error::aragora-verify missing"; exit 1; }
+        uses: ./.github/actions/checkout-integrity
 
       - name: Setup Python
         uses: ./.github/actions/setup-python-safe

--- a/.github/workflows/publish-aragora-verify.yml
+++ b/.github/workflows/publish-aragora-verify.yml
@@ -88,7 +88,7 @@ jobs:
         run: twine check dist/*
 
       - name: Publish to PyPI (trusted publishing)
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0 (pinned to commit)
         with:
           packages-dir: aragora-verify/dist/
           verbose: true

--- a/aragora-verify/src/aragora_verify/__init__.py
+++ b/aragora-verify/src/aragora_verify/__init__.py
@@ -25,7 +25,17 @@ from .verifier import (
     verify,
 )
 
-__version__ = "0.1.0"
+# Single-source the version from installed package metadata (pyproject.toml is
+# the only place the number lives). Falls back when running from a source tree
+# with no installed dist metadata.
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
+
+try:
+    __version__ = _pkg_version("aragora-verify")
+except PackageNotFoundError:  # pragma: no cover - source tree without metadata
+    __version__ = "0.0.0+source"
+
+del PackageNotFoundError, _pkg_version
 
 __all__ = [
     "__version__",


### PR DESCRIPTION
Prepped for your one-click. Makes `pip install aragora-verify` real — the standalone receipt verifier the public 'anyone can verify' pitch depends on (today it's in-repo only; `pip install aragora-verify` fails).

- `workflow_dispatch` with `version` + `confirm: PUBLISH` (mirrors publish-aragora.yml)
- runs-on `aragora`, `setup-python-safe`, builds from `aragora-verify/`, twine check, **trusted publishing via OIDC**, GitHub release
- runs the 50-test `aragora-verify` suite before publishing
- version input hardened via env (no inline interpolation in run:)

**One-time prerequisite (yours):** on PyPI, add a *pending publisher* for project `aragora-verify` → repo `synaptent/aragora`, workflow `publish-aragora-verify.yml`, environment `pypi`. Then run the workflow with version `0.1.0` + `PUBLISH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)