### PR TITLE
Add read-only reconcile settle CLI

### DIFF
--- a/aragora/cli/commands/reconcile.py
+++ b/aragora/cli/commands/reconcile.py
@@ -76,16 +76,6 @@ def add_reconcile_parser(subparsers: argparse._SubParsersAction) -> None:
         default=None,
         help="Override the review-queue store root used by merge-packet.",
     )
-    settle.add_argument(
-        "--execute-reviewers",
-        action="store_true",
-        help="Pass through to review-queue merge-packet reviewer execution.",
-    )
-    settle.add_argument(
-        "--ignore-own-quorum-check",
-        action="store_true",
-        help="Diagnostic pass-through to review-queue merge-packet.",
-    )
     settle.add_argument("--json", action="store_true", help="Output as JSON.")
     settle.set_defaults(func=cmd_reconcile)
     parser.set_defaults(command="reconcile", func=cmd_reconcile)
@@ -130,6 +120,9 @@ def _cmd_settle(args: argparse.Namespace) -> int:
             repo=getattr(args, "repo", None),
         )
     except Exception as exc:  # pragma: no cover - exact exception class comes from gh/review-queue
+        if getattr(args, "json", False) and _is_github_transport_error(exc):
+            print(json.dumps(_transport_blocked_settle_report(args=args, error=exc), indent=2))
+            return 1
         print(f"error: {exc}", file=sys.stderr)
         return 1
 
@@ -145,6 +138,7 @@ def _load_settle_inputs(
 ) -> tuple[dict[str, Any], dict[int, dict[str, Any]]]:
     pr_refs = [str(ref).strip() for ref in (getattr(args, "pr", []) or []) if str(ref).strip()]
     repo = getattr(args, "repo", None)
+    limit = int(getattr(args, "limit", 30) or 30)
     if pr_refs:
         views: dict[int, dict[str, Any]] = {}
         open_refs: list[str] = []
@@ -157,7 +151,7 @@ def _load_settle_inputs(
         packet = (
             _build_merge_packet(
                 pr_refs=open_refs,
-                limit=int(getattr(args, "limit", 30) or 30),
+                limit=limit,
                 repo=repo,
                 review_queue_root=getattr(args, "review_queue_root", None),
                 execute_reviewers=bool(getattr(args, "execute_reviewers", False)),
@@ -166,14 +160,35 @@ def _load_settle_inputs(
             if open_refs
             else _empty_merge_packet(repo=repo)
         )
-        for ref in open_refs:
-            view = _fetch_pr_view(ref, repo=repo)
-            views[_view_number(view)] = view
+        return packet, views
+
+    if repo:
+        repo_refs = _fetch_repo_open_pr_refs(repo=repo, limit=limit)
+        packet = (
+            _build_merge_packet(
+                pr_refs=repo_refs,
+                limit=limit,
+                repo=repo,
+                review_queue_root=getattr(args, "review_queue_root", None),
+                execute_reviewers=bool(getattr(args, "execute_reviewers", False)),
+                ignore_own_quorum_check=bool(getattr(args, "ignore_own_quorum_check", False)),
+            )
+            if repo_refs
+            else _empty_merge_packet(repo=repo)
+        )
+        views = {}
+        for entry in packet.get("entries") or []:
+            if not isinstance(entry, dict):
+                continue
+            number = _entry_number(entry)
+            if number <= 0:
+                continue
+            views[number] = _fetch_pr_view(str(number), repo=repo)
         return packet, views
 
     packet = _build_merge_packet(
         pr_refs=[],
-        limit=int(getattr(args, "limit", 30) or 30),
+        limit=limit,
         repo=repo,
         review_queue_root=getattr(args, "review_queue_root", None),
         execute_reviewers=bool(getattr(args, "execute_reviewers", False)),
@@ -376,18 +391,88 @@ def _build_merge_packet(
     )
 
 
+def _fetch_repo_open_pr_refs(*, repo: str, limit: int) -> list[str]:
+    raw = _gh_json(
+        [
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--limit",
+            str(limit),
+            "--json",
+            "number",
+        ]
+    )
+    if not isinstance(raw, list):
+        raise RuntimeError(f"open PR list for {repo} did not return a list")
+    refs: list[str] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        try:
+            number = int(item.get("number") or 0)
+        except (TypeError, ValueError):
+            continue
+        if number > 0:
+            refs.append(str(number))
+    return refs
+
+
 def _gh_json(args: list[str]) -> Any:
     from aragora.cli.commands.review_queue import _gh_json as review_queue_gh_json
 
     return review_queue_gh_json(args)
 
 
-def _merge_pr(*_args: Any, **_kwargs: Any) -> None:
-    raise NotImplementedError("merge application is intentionally absent from report mode")
+def _is_github_transport_error(error: object) -> bool:
+    from aragora.cli.commands.review_queue_transport import _is_github_transport_error as is_error
+
+    return is_error(error)
 
 
-def _collect_quorum_evidence_apply(*_args: Any, **_kwargs: Any) -> None:
-    raise NotImplementedError("evidence application is intentionally absent from report mode")
+def _transport_blocked_settle_report(
+    *,
+    args: argparse.Namespace,
+    error: Exception,
+) -> dict[str, Any]:
+    pr_refs = [str(ref).strip() for ref in (getattr(args, "pr", []) or []) if str(ref).strip()]
+    limit = int(getattr(args, "limit", 30) or 30)
+    repo = getattr(args, "repo", None)
+    from aragora.cli.commands.review_queue_transport import (
+        _merge_packet_transport_blocked_envelope_with_rest_fallback,
+    )
+
+    return {
+        "version": SETTLE_REPORT_VERSION,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "autonomy": str(getattr(args, "autonomy", "report") or "report"),
+        "mutated": False,
+        "repo": repo,
+        "counts": {bucket: 0 for bucket in SETTLE_BUCKETS},
+        **{bucket: [] for bucket in SETTLE_BUCKETS},
+        "status": "transport_blocked",
+        "transport_blocked": True,
+        "preserve_no_mutate": True,
+        "mutation_forbidden": True,
+        "error_kind": "github_transport",
+        "command": "reconcile settle",
+        "error": str(error),
+        "pr_refs": pr_refs,
+        "merge_packet": _merge_packet_transport_blocked_envelope_with_rest_fallback(
+            error=str(error),
+            pr_refs=pr_refs,
+            repo_override=repo,
+            limit=limit,
+            gh_json=_gh_json,
+        ),
+        "next_prompt": (
+            "GitHub transport is blocked; preserve no-mutate state and rerun reconcile settle "
+            "after transport recovers. Do not mark ready or settle from this degraded report."
+        ),
+    }
 
 
 def _empty_merge_packet(*, repo: str | None) -> dict[str, Any]:

--- a/aragora/cli/commands/reconcile.py
+++ b/aragora/cli/commands/reconcile.py
@@ -1,0 +1,414 @@
+"""Read-only reconcile-lane operator commands."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from typing import Any
+
+from aragora.swarm.auto_merge_green import (
+    MAX_AUTO_MERGE_TIER,
+    context_from_gh,
+    decide_auto_merge,
+)
+
+SETTLE_REPORT_VERSION = "reconcile_settle_report.v1"
+SETTLE_BUCKETS: tuple[str, ...] = ("mergeable", "parked", "superseded", "needs_human")
+PR_VIEW_FIELDS = ",".join(
+    (
+        "number",
+        "title",
+        "url",
+        "state",
+        "mergedAt",
+        "headRefName",
+        "headRefOid",
+        "isDraft",
+        "mergeable",
+        "mergeStateStatus",
+        "statusCheckRollup",
+    )
+)
+
+
+def add_reconcile_parser(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser(
+        "reconcile",
+        help="Run reconcile-lane repo cleanup and settlement reports",
+        description=(
+            "Read-only first slice of the reconcile lane. The settle report reuses "
+            "review-queue merge-packet evidence and the auto-merge decision core."
+        ),
+    )
+    sub = parser.add_subparsers(dest="reconcile_command")
+
+    settle = sub.add_parser(
+        "settle",
+        help="Report exact-head PR settlement buckets without mutating state",
+    )
+    settle.add_argument(
+        "--autonomy",
+        default="report",
+        choices=("report",),
+        help="Autonomy mode. This first slice supports report only.",
+    )
+    settle.add_argument(
+        "--pr",
+        action="append",
+        default=[],
+        help="Specific PR number/ref to include. Repeatable. Defaults to open queue.",
+    )
+    settle.add_argument(
+        "--limit",
+        type=int,
+        default=30,
+        help="Max open PRs to inspect when --pr is not supplied.",
+    )
+    settle.add_argument(
+        "--repo",
+        default=None,
+        help="GitHub repo slug override (owner/name). Defaults to current repo context.",
+    )
+    settle.add_argument(
+        "--review-queue-root",
+        default=None,
+        help="Override the review-queue store root used by merge-packet.",
+    )
+    settle.add_argument(
+        "--execute-reviewers",
+        action="store_true",
+        help="Pass through to review-queue merge-packet reviewer execution.",
+    )
+    settle.add_argument(
+        "--ignore-own-quorum-check",
+        action="store_true",
+        help="Diagnostic pass-through to review-queue merge-packet.",
+    )
+    settle.add_argument("--json", action="store_true", help="Output as JSON.")
+    settle.set_defaults(func=cmd_reconcile)
+    parser.set_defaults(command="reconcile", func=cmd_reconcile)
+
+
+def cmd_reconcile(args: argparse.Namespace) -> int:
+    command = getattr(args, "reconcile_command", None)
+    if command != "settle":
+        print("Usage: aragora reconcile {settle}", file=sys.stderr)
+        return 2
+    return _cmd_settle(args)
+
+
+def _cmd_settle(args: argparse.Namespace) -> int:
+    autonomy = str(getattr(args, "autonomy", "report") or "report")
+    if autonomy != "report":
+        print(
+            "error: only --autonomy report is implemented in this first slice",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        packet, views = _load_settle_inputs(args)
+        report = build_settle_report(
+            packet=packet,
+            views=views,
+            autonomy=autonomy,
+            repo=getattr(args, "repo", None),
+        )
+    except Exception as exc:  # pragma: no cover - exact exception class comes from gh/review-queue
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if getattr(args, "json", False):
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        _render_settle_report(report)
+    return 0
+
+
+def _load_settle_inputs(
+    args: argparse.Namespace,
+) -> tuple[dict[str, Any], dict[int, dict[str, Any]]]:
+    pr_refs = [str(ref).strip() for ref in (getattr(args, "pr", []) or []) if str(ref).strip()]
+    repo = getattr(args, "repo", None)
+    if pr_refs:
+        views: dict[int, dict[str, Any]] = {}
+        open_refs: list[str] = []
+        for ref in pr_refs:
+            view = _fetch_pr_view(ref, repo=repo)
+            number = _view_number(view)
+            views[number] = view
+            if not _view_is_superseded(view):
+                open_refs.append(str(number))
+        packet = (
+            _build_merge_packet(
+                pr_refs=open_refs,
+                limit=int(getattr(args, "limit", 30) or 30),
+                repo=repo,
+                review_queue_root=getattr(args, "review_queue_root", None),
+                execute_reviewers=bool(getattr(args, "execute_reviewers", False)),
+                ignore_own_quorum_check=bool(getattr(args, "ignore_own_quorum_check", False)),
+            )
+            if open_refs
+            else _empty_merge_packet(repo=repo)
+        )
+        for ref in open_refs:
+            view = _fetch_pr_view(ref, repo=repo)
+            views[_view_number(view)] = view
+        return packet, views
+
+    packet = _build_merge_packet(
+        pr_refs=[],
+        limit=int(getattr(args, "limit", 30) or 30),
+        repo=repo,
+        review_queue_root=getattr(args, "review_queue_root", None),
+        execute_reviewers=bool(getattr(args, "execute_reviewers", False)),
+        ignore_own_quorum_check=bool(getattr(args, "ignore_own_quorum_check", False)),
+    )
+    views = {}
+    for entry in packet.get("entries") or []:
+        if not isinstance(entry, dict):
+            continue
+        number = _entry_number(entry)
+        if number <= 0:
+            continue
+        views[number] = _fetch_pr_view(str(number), repo=repo)
+    return packet, views
+
+
+def build_settle_report(
+    *,
+    packet: dict[str, Any],
+    views: dict[int, dict[str, Any]],
+    autonomy: str,
+    repo: str | None,
+) -> dict[str, Any]:
+    entries_by_pr = {
+        _entry_number(entry): entry
+        for entry in packet.get("entries") or []
+        if isinstance(entry, dict) and _entry_number(entry) > 0
+    }
+    buckets: dict[str, list[dict[str, Any]]] = {bucket: [] for bucket in SETTLE_BUCKETS}
+    for view in views.values():
+        entry = entries_by_pr.get(_view_number(view))
+        bucket, record = _classify_settle_record(view, entry)
+        buckets[bucket].append(record)
+
+    counts = {bucket: len(buckets[bucket]) for bucket in SETTLE_BUCKETS}
+    return {
+        "version": SETTLE_REPORT_VERSION,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "autonomy": autonomy,
+        "mutated": False,
+        "repo": repo,
+        "counts": counts,
+        "merge_packet": {
+            "version": packet.get("version"),
+            "generated_at": packet.get("generated_at"),
+            "queue_pressure": packet.get("queue_pressure") or {},
+            "admin_squash_order": list(packet.get("admin_squash_order") or []),
+            "human_risk_settlement_required": list(
+                packet.get("human_risk_settlement_required") or []
+            ),
+            "not_ready": list(packet.get("not_ready") or []),
+        },
+        **buckets,
+    }
+
+
+def _classify_settle_record(
+    view: dict[str, Any],
+    entry: dict[str, Any] | None,
+) -> tuple[str, dict[str, Any]]:
+    if _view_is_superseded(view) or (entry and entry.get("status") == "already_merged"):
+        return "superseded", _record(
+            view, entry, blockers=(), bucket_reason=_superseded_reason(view)
+        )
+
+    ctx = context_from_gh(view, entry)
+    decision = decide_auto_merge(ctx)
+    if decision.should_merge:
+        return "mergeable", _record(view, entry, blockers=(), bucket_reason="would_merge")
+    if _record_needs_human(entry, decision):
+        return (
+            "needs_human",
+            _record(view, entry, blockers=decision.blockers, bucket_reason="human_required"),
+        )
+    return "parked", _record(view, entry, blockers=decision.blockers, bucket_reason="not_ready")
+
+
+def _record(
+    view: dict[str, Any],
+    entry: dict[str, Any] | None,
+    *,
+    blockers: tuple[str, ...],
+    bucket_reason: str,
+) -> dict[str, Any]:
+    packet = entry or {}
+    return {
+        "pr": _view_number(view),
+        "title": str(view.get("title") or packet.get("title") or ""),
+        "url": str(view.get("url") or packet.get("url") or ""),
+        "state": str(view.get("state") or ""),
+        "head": str(view.get("headRefOid") or ""),
+        "packet_head": str(packet.get("head_sha") or ""),
+        "tier": packet.get("tier"),
+        "status": packet.get("status"),
+        "verdict": packet.get("verdict"),
+        "bucket_reason": bucket_reason,
+        "blockers": list(blockers),
+        "packet_reasons": list(packet.get("reasons") or []),
+        "counted_model_families": list(packet.get("counted_model_families") or []),
+        "reviewer_signal_count": len(packet.get("reviewer_signals") or []),
+        "dogfood_evidence_count": len(packet.get("dogfood_evidence") or []),
+    }
+
+
+def _record_needs_human(entry: dict[str, Any] | None, decision: Any) -> bool:
+    if not entry:
+        return False
+    tier = entry.get("tier")
+    try:
+        tier_int = int(tier) if tier is not None else None
+    except (TypeError, ValueError):
+        tier_int = None
+    if tier_int is not None and tier_int > MAX_AUTO_MERGE_TIER:
+        return True
+    if bool(entry.get("requires_human_risk_settlement")):
+        return True
+    if bool(entry.get("requires_human_preapproval")) and not bool(
+        entry.get("human_preapproval_recorded")
+    ):
+        return True
+    if entry.get("status") == "human_risk_settlement_required":
+        return True
+    return any("human" in blocker.lower() for blocker in decision.blockers)
+
+
+def _render_settle_report(report: dict[str, Any]) -> None:
+    counts = report["counts"]
+    print("# Reconcile settle report")
+    print(f"autonomy: {report['autonomy']} (read-only; mutated=false)")
+    print(
+        "counts: "
+        f"mergeable={counts['mergeable']} "
+        f"parked={counts['parked']} "
+        f"superseded={counts['superseded']} "
+        f"needs-human={counts['needs_human']}"
+    )
+    for bucket, label in (
+        ("mergeable", "mergeable"),
+        ("parked", "parked"),
+        ("superseded", "superseded"),
+        ("needs_human", "needs-human"),
+    ):
+        print(f"\n## {label}")
+        records = report[bucket]
+        if not records:
+            print("  (none)")
+            continue
+        for record in records:
+            print(f"  #{record['pr']} {record['title']}")
+            print(
+                "    "
+                f"head={_short(record['head'])} "
+                f"tier={record['tier']} "
+                f"status={record['status']} "
+                f"verdict={record['verdict']}"
+            )
+            if record["blockers"]:
+                print(f"    blockers: {'; '.join(record['blockers'][:4])}")
+            if record["packet_reasons"]:
+                print(f"    packet: {'; '.join(record['packet_reasons'][:2])}")
+
+
+def _fetch_pr_view(ref: str, *, repo: str | None) -> dict[str, Any]:
+    args = ["pr", "view", str(ref), "--json", PR_VIEW_FIELDS]
+    if repo:
+        args.extend(["--repo", repo])
+    view = _gh_json(args)
+    if not isinstance(view, dict):
+        raise RuntimeError(f"PR {ref} did not return an object")
+    return view
+
+
+def _build_merge_packet(
+    *,
+    pr_refs: list[str],
+    limit: int,
+    repo: str | None,
+    review_queue_root: str | None,
+    execute_reviewers: bool,
+    ignore_own_quorum_check: bool,
+) -> dict[str, Any]:
+    from aragora.cli.commands.review_queue import _build_merge_authorization_packet
+
+    return _build_merge_authorization_packet(
+        pr_refs=pr_refs,
+        limit=limit,
+        repo_override=repo,
+        review_queue_root=review_queue_root,
+        execute_reviewers=execute_reviewers,
+        ignore_own_quorum_check=ignore_own_quorum_check,
+    )
+
+
+def _gh_json(args: list[str]) -> Any:
+    from aragora.cli.commands.review_queue import _gh_json as review_queue_gh_json
+
+    return review_queue_gh_json(args)
+
+
+def _merge_pr(*_args: Any, **_kwargs: Any) -> None:
+    raise NotImplementedError("merge application is intentionally absent from report mode")
+
+
+def _collect_quorum_evidence_apply(*_args: Any, **_kwargs: Any) -> None:
+    raise NotImplementedError("evidence application is intentionally absent from report mode")
+
+
+def _empty_merge_packet(*, repo: str | None) -> dict[str, Any]:
+    return {
+        "version": "merge_authorization_packet.v1",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "repo": repo,
+        "queue_pressure": {"current_open_prs": 0, "cap": 0, "active": False},
+        "entries": [],
+        "admin_squash_order": [],
+        "human_risk_settlement_required": [],
+        "not_ready": [],
+    }
+
+
+def _view_number(view: dict[str, Any]) -> int:
+    try:
+        return int(view.get("number") or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _entry_number(entry: dict[str, Any]) -> int:
+    try:
+        return int(entry.get("pr_number") or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _view_is_superseded(view: dict[str, Any]) -> bool:
+    state = str(view.get("state") or "").upper()
+    return state in {"MERGED", "CLOSED"} or bool(view.get("mergedAt"))
+
+
+def _superseded_reason(view: dict[str, Any]) -> str:
+    state = str(view.get("state") or "").upper()
+    if state == "MERGED" or view.get("mergedAt"):
+        return "already_merged"
+    if state == "CLOSED":
+        return "closed"
+    return "not_open"
+
+
+def _short(value: object) -> str:
+    text = str(value or "")
+    return text[:12] if text else ""

--- a/aragora/cli/commands/reconcile.py
+++ b/aragora/cli/commands/reconcile.py
@@ -107,6 +107,19 @@ def _cmd_settle(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 2
+    if bool(getattr(args, "execute_reviewers", False)):
+        print(
+            "error: reconcile settle is read-only; --execute-reviewers is not allowed",
+            file=sys.stderr,
+        )
+        return 2
+    if bool(getattr(args, "ignore_own_quorum_check", False)):
+        print(
+            "error: reconcile settle reports enforce the normal quorum gate; "
+            "--ignore-own-quorum-check is not allowed",
+            file=sys.stderr,
+        )
+        return 2
 
     try:
         packet, views = _load_settle_inputs(args)
@@ -226,15 +239,15 @@ def _classify_settle_record(
             view, entry, blockers=(), bucket_reason=_superseded_reason(view)
         )
 
-    ctx = context_from_gh(view, entry)
+    ctx = context_from_gh(_view_with_latest_status_rollup(view), entry)
     decision = decide_auto_merge(ctx)
-    if decision.should_merge:
-        return "mergeable", _record(view, entry, blockers=(), bucket_reason="would_merge")
     if _record_needs_human(entry, decision):
         return (
             "needs_human",
             _record(view, entry, blockers=decision.blockers, bucket_reason="human_required"),
         )
+    if decision.should_merge:
+        return "mergeable", _record(view, entry, blockers=(), bucket_reason="would_merge")
     return "parked", _record(view, entry, blockers=decision.blockers, bucket_reason="not_ready")
 
 
@@ -284,6 +297,15 @@ def _record_needs_human(entry: dict[str, Any] | None, decision: Any) -> bool:
     if entry.get("status") == "human_risk_settlement_required":
         return True
     return any("human" in blocker.lower() for blocker in decision.blockers)
+
+
+def _view_with_latest_status_rollup(view: dict[str, Any]) -> dict[str, Any]:
+    rollup = view.get("statusCheckRollup")
+    if not isinstance(rollup, list):
+        return view
+    from aragora.cli.commands.review_queue import _latest_status_check_rollup
+
+    return {**view, "statusCheckRollup": _latest_status_check_rollup(rollup)}
 
 
 def _render_settle_report(report: dict[str, Any]) -> None:

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -154,6 +154,7 @@ Examples:
     _add_review_pr_parser(subparsers)
     _add_review_local_parser(subparsers)
     _add_review_queue_parser(subparsers)
+    _add_reconcile_parser(subparsers)
     _add_codebase_audit_parser(subparsers)
     _add_external_parsers(subparsers)
     _add_badge_parser(subparsers)
@@ -2719,6 +2720,12 @@ def _add_review_queue_parser(subparsers) -> None:
         help="Output the result as JSON (kind, paths, alerting surfaces).",
     )
     alert_parser.set_defaults(func=_lazy("aragora.cli.commands.review_queue", "cmd_review_queue"))
+
+
+def _add_reconcile_parser(subparsers) -> None:
+    from aragora.cli.commands.reconcile import add_reconcile_parser
+
+    add_reconcile_parser(subparsers)
 
 
 def _add_codebase_audit_parser(subparsers) -> None:

--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -11,8 +11,8 @@ description: Generated Aragora CLI command catalog from live parser
 
 This reference documents the command surface as implemented in code. It includes all top-level commands and known aliases.
 
-- Canonical top-level commands: **110**
-- Total top-level invocations (including aliases): **111**
+- Canonical top-level commands: **111**
+- Total top-level invocations (including aliases): **112**
 
 ## Installation
 
@@ -117,6 +117,7 @@ For full runtime configuration, see [ENVIRONMENT](../getting-started/environment
 | `ralph` | - | Ralph campaign supervisor — autonomous incident commander | - |
 | `rbac` | - | RBAC management commands | `assign`, `check`, `check-local`, `list-permissions`, `list-roles`, `permissions`, `roles` |
 | `receipt` | - | View, verify, and export decision receipts | `export`, `inspect`, `list`, `show`, `verify`, `view` |
+| `reconcile` | - | Run reconcile-lane repo cleanup and settlement reports | `settle` |
 | `repl` | - | Interactive debate mode | - |
 | `replay` | - | Replay stored debates | - |
 | `review` | - | Run AI code review on a diff or PR | - |

--- a/docs-site/docs/contributing/capability-matrix.md
+++ b/docs-site/docs/contributing/capability-matrix.md
@@ -8,7 +8,7 @@
 | Surface | Inventory | Capability Coverage |
 |---------|-----------|---------------------|
 | **HTTP API** | 2870 paths / 3297 operations | 81.1% |
-| **CLI** | 111 commands | 43.2% |
+| **CLI** | 112 commands | 43.2% |
 | **SDK (Python)** | 191 namespaces | 70.3% |
 | **SDK (TypeScript)** | 190 namespaces | 70.3% |
 | **UI** | tracked in capability surfaces | 86.5% |

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -8,7 +8,7 @@
 | Surface | Inventory | Capability Coverage |
 |---------|-----------|---------------------|
 | **HTTP API** | 2870 paths / 3297 operations | 81.1% |
-| **CLI** | 111 commands | 43.2% |
+| **CLI** | 112 commands | 43.2% |
 | **SDK (Python)** | 191 namespaces | 70.3% |
 | **SDK (TypeScript)** | 190 namespaces | 70.3% |
 | **UI** | tracked in capability surfaces | 86.5% |

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -6,8 +6,8 @@
 
 This reference documents the command surface as implemented in code. It includes all top-level commands and known aliases.
 
-- Canonical top-level commands: **110**
-- Total top-level invocations (including aliases): **111**
+- Canonical top-level commands: **111**
+- Total top-level invocations (including aliases): **112**
 
 ## Installation
 
@@ -112,6 +112,7 @@ For full runtime configuration, see [ENVIRONMENT](ENVIRONMENT.md).
 | `ralph` | - | Ralph campaign supervisor — autonomous incident commander | - |
 | `rbac` | - | RBAC management commands | `assign`, `check`, `check-local`, `list-permissions`, `list-roles`, `permissions`, `roles` |
 | `receipt` | - | View, verify, and export decision receipts | `export`, `inspect`, `list`, `show`, `verify`, `view` |
+| `reconcile` | - | Run reconcile-lane repo cleanup and settlement reports | `settle` |
 | `repl` | - | Interactive debate mode | - |
 | `replay` | - | Replay stored debates | - |
 | `review` | - | Run AI code review on a diff or PR | - |

--- a/tests/cli/commands/test_reconcile.py
+++ b/tests/cli/commands/test_reconcile.py
@@ -139,6 +139,56 @@ def test_build_settle_report_buckets_exact_head_prs() -> None:
     assert report["superseded"][0]["pr"] == 4
 
 
+def test_build_settle_report_uses_latest_status_rollup_entries() -> None:
+    packet = _packet(_entry(1))
+    stale_success = {
+        "name": "lint",
+        "workflowName": "Lint",
+        "conclusion": "SUCCESS",
+        "completedAt": "2026-06-28T00:00:00Z",
+    }
+    latest_failure = {
+        "name": "lint",
+        "workflowName": "Lint",
+        "conclusion": "FAILURE",
+        "completedAt": "2026-06-28T00:05:00Z",
+    }
+    views = {
+        1: _view(
+            1,
+            rollup=[
+                latest_failure,
+                {"name": "Generate & Validate", "conclusion": "SUCCESS"},
+                {"name": "TypeScript SDK Type Check", "conclusion": "SUCCESS"},
+                {"name": "aragora-merge-quorum", "conclusion": "SUCCESS"},
+                {"name": "sdk-parity", "conclusion": "SUCCESS"},
+                {"name": "typecheck", "conclusion": "SUCCESS"},
+                stale_success,
+            ],
+        )
+    }
+
+    report = build_settle_report(packet=packet, views=views, autonomy="report", repo=None)
+
+    assert report["counts"]["mergeable"] == 0
+    assert report["counts"]["parked"] == 1
+    assert any("lint=FAILURE" in blocker for blocker in report["parked"][0]["blockers"])
+
+
+def test_build_settle_report_classifies_human_gate_before_mergeable() -> None:
+    entry = _entry(1)
+    entry["requires_human_preapproval"] = True
+    entry["human_preapproval_recorded"] = False
+    packet = _packet(entry)
+    views = {1: _view(1)}
+
+    report = build_settle_report(packet=packet, views=views, autonomy="report", repo=None)
+
+    assert report["counts"]["mergeable"] == 0
+    assert report["counts"]["needs_human"] == 1
+    assert report["needs_human"][0]["bucket_reason"] == "human_required"
+
+
 def test_report_mode_does_not_call_merger_or_evidence_apply(monkeypatch) -> None:
     packet = _packet(_entry(1))
     calls: list[str] = []
@@ -178,3 +228,49 @@ def test_report_mode_does_not_call_merger_or_evidence_apply(monkeypatch) -> None
 
     assert rc == 0
     assert calls == ["view:1:None", "packet", "view:1:None"]
+
+
+def test_report_mode_rejects_execute_reviewers(monkeypatch, capsys) -> None:
+    def forbidden_packet(**_kwargs):  # pragma: no cover - must not run
+        raise AssertionError("read-only report must reject reviewer execution first")
+
+    monkeypatch.setattr("aragora.cli.commands.reconcile._build_merge_packet", forbidden_packet)
+    args = argparse.Namespace(
+        reconcile_command="settle",
+        autonomy="report",
+        pr=["1"],
+        limit=30,
+        repo=None,
+        review_queue_root=None,
+        execute_reviewers=True,
+        ignore_own_quorum_check=False,
+        json=True,
+    )
+
+    rc = cmd_reconcile(args)
+
+    assert rc == 2
+    assert "--execute-reviewers is not allowed" in capsys.readouterr().err
+
+
+def test_report_mode_rejects_ignore_own_quorum_check(monkeypatch, capsys) -> None:
+    def forbidden_packet(**_kwargs):  # pragma: no cover - must not run
+        raise AssertionError("read-only report must reject quorum bypass first")
+
+    monkeypatch.setattr("aragora.cli.commands.reconcile._build_merge_packet", forbidden_packet)
+    args = argparse.Namespace(
+        reconcile_command="settle",
+        autonomy="report",
+        pr=["1"],
+        limit=30,
+        repo=None,
+        review_queue_root=None,
+        execute_reviewers=False,
+        ignore_own_quorum_check=True,
+        json=True,
+    )
+
+    rc = cmd_reconcile(args)
+
+    assert rc == 2
+    assert "--ignore-own-quorum-check is not allowed" in capsys.readouterr().err

--- a/tests/cli/commands/test_reconcile.py
+++ b/tests/cli/commands/test_reconcile.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 import argparse
+import json
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
 
 from aragora.cli.commands.reconcile import (
     add_reconcile_parser,
     build_settle_report,
     cmd_reconcile,
 )
+from aragora.cli.commands.review_queue_transport import _GhError
 
 
 def _green_rollup() -> list[dict[str, str]]:
@@ -95,6 +99,20 @@ def test_reconcile_parser_registers_settle_report() -> None:
     assert ns.autonomy == "report"
     assert ns.pr == ["8658"]
     assert ns.json is True
+
+
+def test_reconcile_parser_does_not_advertise_report_side_effect_flags() -> None:
+    root = argparse.ArgumentParser()
+    sub = root.add_subparsers()
+    add_reconcile_parser(sub)
+
+    for flag in ("--execute-reviewers", "--ignore-own-quorum-check"):
+        try:
+            root.parse_args(["reconcile", "settle", flag])
+        except SystemExit as exc:
+            assert exc.code == 2
+        else:  # pragma: no cover - argparse should reject these flags
+            raise AssertionError(f"{flag} should not be accepted by reconcile settle")
 
 
 def test_top_level_parser_registers_reconcile_settle() -> None:
@@ -189,7 +207,7 @@ def test_build_settle_report_classifies_human_gate_before_mergeable() -> None:
     assert report["needs_human"][0]["bucket_reason"] == "human_required"
 
 
-def test_report_mode_does_not_call_merger_or_evidence_apply(monkeypatch) -> None:
+def test_report_mode_uses_read_only_packet_and_single_explicit_view(monkeypatch) -> None:
     packet = _packet(_entry(1))
     calls: list[str] = []
 
@@ -201,16 +219,8 @@ def test_report_mode_does_not_call_merger_or_evidence_apply(monkeypatch) -> None
         calls.append(f"view:{ref}:{repo}")
         return _view(int(ref))
 
-    def forbidden_side_effect(*_args, **_kwargs):  # pragma: no cover - must not run
-        raise AssertionError("report autonomy must not mutate")
-
     monkeypatch.setattr("aragora.cli.commands.reconcile._build_merge_packet", fake_packet)
     monkeypatch.setattr("aragora.cli.commands.reconcile._fetch_pr_view", fake_view)
-    monkeypatch.setattr("aragora.cli.commands.reconcile._merge_pr", forbidden_side_effect)
-    monkeypatch.setattr(
-        "aragora.cli.commands.reconcile._collect_quorum_evidence_apply",
-        forbidden_side_effect,
-    )
 
     args = argparse.Namespace(
         reconcile_command="settle",
@@ -227,7 +237,103 @@ def test_report_mode_does_not_call_merger_or_evidence_apply(monkeypatch) -> None
     rc = cmd_reconcile(args)
 
     assert rc == 0
-    assert calls == ["view:1:None", "packet", "view:1:None"]
+    assert calls == ["view:1:None", "packet"]
+
+
+def test_repo_open_queue_lists_prs_with_repo_override(monkeypatch) -> None:
+    packet = _packet(_entry(11), _entry(12, status="needs_model_review_quorum"))
+    calls: list[object] = []
+
+    def fake_gh_json(args: list[str]):
+        calls.append(["gh", *args])
+        assert args == [
+            "pr",
+            "list",
+            "--repo",
+            "owner/repo",
+            "--state",
+            "open",
+            "--limit",
+            "2",
+            "--json",
+            "number",
+        ]
+        return [{"number": 11}, {"number": 12}]
+
+    def fake_packet(**kwargs):
+        calls.append(kwargs)
+        return packet
+
+    def fake_view(ref: str, *, repo: str | None):
+        calls.append(f"view:{ref}:{repo}")
+        return _view(int(ref))
+
+    monkeypatch.setattr("aragora.cli.commands.reconcile._gh_json", fake_gh_json)
+    monkeypatch.setattr("aragora.cli.commands.reconcile._build_merge_packet", fake_packet)
+    monkeypatch.setattr("aragora.cli.commands.reconcile._fetch_pr_view", fake_view)
+    args = argparse.Namespace(
+        reconcile_command="settle",
+        autonomy="report",
+        pr=[],
+        limit=2,
+        repo="owner/repo",
+        review_queue_root=None,
+        execute_reviewers=False,
+        ignore_own_quorum_check=False,
+        json=True,
+    )
+
+    rc = cmd_reconcile(args)
+
+    assert rc == 0
+    packet_call = next(call for call in calls if isinstance(call, dict))
+    assert packet_call["pr_refs"] == ["11", "12"]
+    assert packet_call["repo"] == "owner/repo"
+    assert "view:11:owner/repo" in calls
+    assert "view:12:owner/repo" in calls
+
+
+def test_report_mode_json_transport_error_fails_closed(monkeypatch) -> None:
+    def fail_transport(_args) -> None:
+        raise _GhError(
+            "gh pr view 1 --json number failed: error connecting to api.github.com\n"
+            "check your internet connection or https://githubstatus.com"
+        )
+
+    monkeypatch.setattr("aragora.cli.commands.reconcile._load_settle_inputs", fail_transport)
+    monkeypatch.setattr(
+        "aragora.cli.commands.reconcile._gh_json",
+        lambda _args: (_ for _ in ()).throw(_GhError("REST fallback unavailable")),
+    )
+    args = argparse.Namespace(
+        reconcile_command="settle",
+        autonomy="report",
+        pr=["1"],
+        limit=30,
+        repo="owner/repo",
+        review_queue_root=None,
+        execute_reviewers=False,
+        ignore_own_quorum_check=False,
+        json=True,
+    )
+    stdout = StringIO()
+    stderr = StringIO()
+
+    with redirect_stdout(stdout), redirect_stderr(stderr):
+        rc = cmd_reconcile(args)
+
+    assert rc == 1
+    assert stderr.getvalue() == ""
+    payload = json.loads(stdout.getvalue())
+    assert payload["version"] == "reconcile_settle_report.v1"
+    assert payload["status"] == "transport_blocked"
+    assert payload["transport_blocked"] is True
+    assert payload["preserve_no_mutate"] is True
+    assert payload["mutation_forbidden"] is True
+    assert payload["command"] == "reconcile settle"
+    assert payload["pr_refs"] == ["1"]
+    assert payload["merge_packet"]["status"] == "transport_blocked"
+    assert payload["merge_packet"]["rest_fallback"]["available"] is False
 
 
 def test_report_mode_rejects_execute_reviewers(monkeypatch, capsys) -> None:

--- a/tests/cli/commands/test_reconcile.py
+++ b/tests/cli/commands/test_reconcile.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import argparse
+
+from aragora.cli.commands.reconcile import (
+    add_reconcile_parser,
+    build_settle_report,
+    cmd_reconcile,
+)
+
+
+def _green_rollup() -> list[dict[str, str]]:
+    return [
+        {"name": "Generate & Validate", "conclusion": "SUCCESS"},
+        {"name": "TypeScript SDK Type Check", "conclusion": "SUCCESS"},
+        {"name": "aragora-merge-quorum", "conclusion": "SUCCESS"},
+        {"name": "lint", "conclusion": "SUCCESS"},
+        {"name": "sdk-parity", "conclusion": "SUCCESS"},
+        {"name": "typecheck", "conclusion": "SUCCESS"},
+    ]
+
+
+def _view(
+    number: int,
+    *,
+    state: str = "OPEN",
+    head: str | None = None,
+    is_draft: bool = False,
+    mergeable: str = "MERGEABLE",
+    merge_state: str = "BLOCKED",
+    merged_at: str = "",
+    rollup: list[dict[str, str]] | None = None,
+) -> dict:
+    return {
+        "number": number,
+        "title": f"PR {number}",
+        "url": f"https://github.com/synaptent/aragora/pull/{number}",
+        "state": state,
+        "mergedAt": merged_at,
+        "headRefName": f"branch-{number}",
+        "headRefOid": head or f"{number:040d}"[-40:],
+        "isDraft": is_draft,
+        "mergeable": mergeable,
+        "mergeStateStatus": merge_state,
+        "statusCheckRollup": rollup or _green_rollup(),
+    }
+
+
+def _entry(number: int, *, head: str | None = None, tier: int = 2, status: str = "satisfied"):
+    return {
+        "pr_number": number,
+        "title": f"PR {number}",
+        "url": f"https://github.com/synaptent/aragora/pull/{number}",
+        "head_sha": head or f"{number:040d}"[-40:],
+        "tier": tier,
+        "tier_name": f"tier_{tier}",
+        "status": status,
+        "verdict": "admin_squash_allowed" if status == "satisfied" else "not_ready",
+        "admin_squash_allowed": status == "satisfied",
+        "requires_human_risk_settlement": tier >= 3,
+        "requires_human_preapproval": tier >= 4,
+        "human_preapproval_recorded": False,
+        "unresolved_dissent": False,
+        "reviewer_signals": [],
+        "dogfood_evidence": [],
+        "counted_reviewer_ids": [],
+        "counted_model_families": [],
+        "reasons": [],
+    }
+
+
+def _packet(*entries: dict) -> dict:
+    return {
+        "version": "merge_authorization_packet.v1",
+        "generated_at": "2026-06-28T00:00:00+00:00",
+        "queue_pressure": {"current_open_prs": len(entries), "cap": 6, "active": False},
+        "entries": list(entries),
+        "admin_squash_order": [e["pr_number"] for e in entries if e["admin_squash_allowed"]],
+        "human_risk_settlement_required": [
+            e["pr_number"] for e in entries if e["requires_human_risk_settlement"]
+        ],
+        "not_ready": [e["pr_number"] for e in entries if e["status"] != "satisfied"],
+    }
+
+
+def test_reconcile_parser_registers_settle_report() -> None:
+    root = argparse.ArgumentParser()
+    sub = root.add_subparsers()
+    add_reconcile_parser(sub)
+
+    ns = root.parse_args(["reconcile", "settle", "--autonomy", "report", "--pr", "8658", "--json"])
+
+    assert ns.command == "reconcile"
+    assert ns.reconcile_command == "settle"
+    assert ns.autonomy == "report"
+    assert ns.pr == ["8658"]
+    assert ns.json is True
+
+
+def test_top_level_parser_registers_reconcile_settle() -> None:
+    from aragora.cli.parser import build_parser
+
+    ns = build_parser().parse_args(
+        ["reconcile", "settle", "--autonomy", "report", "--pr", "8658", "--json"]
+    )
+
+    assert ns.command == "reconcile"
+    assert ns.reconcile_command == "settle"
+    assert ns.autonomy == "report"
+    assert ns.pr == ["8658"]
+    assert ns.json is True
+
+
+def test_build_settle_report_buckets_exact_head_prs() -> None:
+    packet = _packet(
+        _entry(1),
+        _entry(2, status="needs_model_review_quorum"),
+        _entry(3, tier=4, status="human_risk_settlement_required"),
+    )
+    views = {
+        1: _view(1),
+        2: _view(2),
+        3: _view(3),
+        4: _view(4, state="MERGED", merged_at="2026-06-28T01:02:03Z"),
+    }
+
+    report = build_settle_report(packet=packet, views=views, autonomy="report", repo=None)
+
+    assert report["mutated"] is False
+    assert report["counts"] == {
+        "mergeable": 1,
+        "parked": 1,
+        "superseded": 1,
+        "needs_human": 1,
+    }
+    assert report["mergeable"][0]["pr"] == 1
+    assert report["parked"][0]["pr"] == 2
+    assert report["needs_human"][0]["pr"] == 3
+    assert report["superseded"][0]["pr"] == 4
+
+
+def test_report_mode_does_not_call_merger_or_evidence_apply(monkeypatch) -> None:
+    packet = _packet(_entry(1))
+    calls: list[str] = []
+
+    def fake_packet(**_kwargs):
+        calls.append("packet")
+        return packet
+
+    def fake_view(ref: str, *, repo: str | None):
+        calls.append(f"view:{ref}:{repo}")
+        return _view(int(ref))
+
+    def forbidden_side_effect(*_args, **_kwargs):  # pragma: no cover - must not run
+        raise AssertionError("report autonomy must not mutate")
+
+    monkeypatch.setattr("aragora.cli.commands.reconcile._build_merge_packet", fake_packet)
+    monkeypatch.setattr("aragora.cli.commands.reconcile._fetch_pr_view", fake_view)
+    monkeypatch.setattr("aragora.cli.commands.reconcile._merge_pr", forbidden_side_effect)
+    monkeypatch.setattr(
+        "aragora.cli.commands.reconcile._collect_quorum_evidence_apply",
+        forbidden_side_effect,
+    )
+
+    args = argparse.Namespace(
+        reconcile_command="settle",
+        autonomy="report",
+        pr=["1"],
+        limit=30,
+        repo=None,
+        review_queue_root=None,
+        execute_reviewers=False,
+        ignore_own_quorum_check=False,
+        json=True,
+    )
+
+    rc = cmd_reconcile(args)
+
+    assert rc == 0
+    assert calls == ["view:1:None", "packet", "view:1:None"]


### PR DESCRIPTION
## Summary
- add `aragora reconcile settle` as a read-only report command
- bucket exact-head PRs using review-queue merge-packet data and the auto-merge decision core
- wire the command into the top-level parser with focused regression coverage
- refresh the required generated CLI reference and capability-matrix docs for the new command

## Scope hygiene
- rebuilt on current `origin/main`
- stripped metrics churn and `generate_capability_matrix.py` implementation churn
- kept only required generated docs: CLI references and the two capability-matrix mirrors
- no settlement, merge, evidence-apply, or lane-state mutation path is implemented in report mode

## Validation
- `ARAGORA_USE_SECRETS_MANAGER=0 python3 -m pytest tests/cli/commands/test_reconcile.py -q`
- `ARAGORA_USE_SECRETS_MANAGER=0 python3 -m pytest tests/swarm/test_auto_merge_green.py tests/swarm/test_auto_merge_green_cli.py -q`
- `python3 scripts/generate_cli_reference.py --check --check-site`
- `python3 scripts/check_capability_matrix_sync.py`
- `python3 -m ruff check aragora/cli/commands/reconcile.py aragora/cli/parser.py tests/cli/commands/test_reconcile.py`
- `python3 -m ruff format --check aragora/cli/commands/reconcile.py tests/cli/commands/test_reconcile.py`
- `python3 -m mypy --config-file=/dev/null --follow-imports=skip --ignore-missing-imports aragora/cli/commands/reconcile.py aragora/cli/parser.py`
- `ARAGORA_USE_SECRETS_MANAGER=0 python3 -m aragora.cli.main reconcile settle --help`
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- commit and push hooks passed, including changed-file mypy, ruff, format, secrets, and portability guards
