### PR TITLE
ci(lint): isolate safety from project typer pin (main-red repair)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -696,7 +696,9 @@ jobs:
       - name: Install security tools
         run: |
           python -m pip install --upgrade pip
-          python -m pip install bandit safety
+          # safety runs pinned in its own venv in the dependency-check step below;
+          # only bandit is needed in this base env.
+          python -m pip install bandit
 
       - name: Run Bandit security scan
         run: |
@@ -715,7 +717,12 @@ jobs:
           # safety pins typer<0.26.0, so installing the project into safety's env
           # breaks the safety CLI. Isolating safety satisfies both pins.
           python -m venv /tmp/safety-env
-          /tmp/safety-env/bin/python -m pip install --quiet --upgrade pip safety
+          /tmp/safety-env/bin/python -m pip install --upgrade pip
+          # Pin Safety so this REQUIRED gate is reproducible (a future Safety
+          # release could change/remove `check` or require an API key); no
+          # --quiet so the installed version is visible in CI logs.
+          /tmp/safety-env/bin/python -m pip install "safety==3.8.1"
+          /tmp/safety-env/bin/safety --version
           # Blocking: fail on HIGH/CRITICAL vulnerabilities.
           # --ignore 70612: Known false positive / accepted risk.
           /tmp/safety-env/bin/safety check --full-report --ignore 70612 -r /tmp/aragora-deps.txt

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -708,9 +708,17 @@ jobs:
       - name: Check dependencies for vulnerabilities
         run: |
           python -m pip install -e .
+          # Capture the project's resolved deps (drop the editable self-install)
+          # so safety scans them without sharing the project's environment.
+          python -m pip freeze --exclude-editable > /tmp/aragora-deps.txt
+          # Run safety in an ISOLATED venv: aragora requires typer>=0.26.7 while
+          # safety pins typer<0.26.0, so installing the project into safety's env
+          # breaks the safety CLI. Isolating safety satisfies both pins.
+          python -m venv /tmp/safety-env
+          /tmp/safety-env/bin/python -m pip install --quiet --upgrade pip safety
           # Blocking: fail on HIGH/CRITICAL vulnerabilities.
           # --ignore 70612: Known false positive / accepted risk.
-          safety check --full-report --ignore 70612
+          /tmp/safety-env/bin/safety check --full-report --ignore 70612 -r /tmp/aragora-deps.txt
 
   secrets:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Main-red repair** — the required `lint` context is failing on `main` (`d72b397637`, run 28385958102).

**Failure:** the `security` job runs `pip install -e .` (aragora needs `typer>=0.26.7` → installs 0.26.8) then `safety check`. But `safety 3.8.1` pins `typer<0.26.0`, so the safety CLI crashes (`typer.main.get_command` incompatibility) → `lint` red.

**Fix (smallest):** install the project (to resolve real deps), `pip freeze --exclude-editable` them, then run `safety check -r` in its **own venv** so the project's typer can't clobber safety's. No dependency refresh; scan coverage unchanged.

**Validated locally:** isolated venv resolves typer 0.25.1; `safety check -r` runs without crashing; `check_workflow_pip_install_policy.py` passes (exit 0).

Files: `.github/workflows/lint.yml` (one step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)