### PR TITLE
docs(readme): add proof ladder full-vision refinement

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ The receipt is the unit that carries through every stage. One review produces:
 ```
 decision ──▶ model jury (heterogeneous, independent)
                ├─ proposals / critiques / revisions
-               ├─ dissent trail + load-bearing cruxes
-               └─ per-agent ELO + Brier calibration (at decision time)
+               ├─ dissent trail (+ cruxes when a CruxReceipt is supplied — ODR-4)
+               └─ per-agent ELO + Brier calibration when provenance present — ODR-5
           ──▶ verdict + confidence
           ──▶ human attestation (optional; EU AI Act Art. 14)   🔄 #8230
           ──▶ Ed25519 signature                                 🔄 #8225
@@ -156,8 +156,10 @@ decision ──▶ model jury (heterogeneous, independent)
           ──▶ Rekor public anchoring (tamper-evidence)          🔄 #8231
 ```
 
-Today's receipts verify on schema, digest, and quorum consistency offline; public-key
-signing and anchoring are in-flight. See the [proof ladder](#proof-ladder).
+Today's receipts verify on schema, digest, and quorum consistency offline; per the
+[ODR spec](docs/specs/OPEN_DECISION_RECEIPT.md), cruxes and calibration carry explicit
+*absent markers* unless their source is supplied (ODR-4/5), and public-key signing and
+anchoring are in-flight. See the [proof ladder](#proof-ladder).
 
 ## Find your path
 
@@ -438,7 +440,7 @@ metric. *(docs/plans/ agent-civilization designs)*
 
 - **Crux Finder (✅ MVP / 🔮 shaping).** Consensus mode `crux_finder` surfaces the 3–5
   load-bearing disagreements where flipping a belief flips the conclusion; signed
-  CruxReceipts, `aragora crux find "<question>"`. Crux-shaping prompts and per-round
+  CruxReceipts, `aragora crux "<question>"`. Crux-shaping prompts and per-round
   claim targeting are deferred pending dogfood runs.
 - **Epistemic CI / Decision Integrity Core (🔮 DIC-13..22).** Extend receipts beyond
   debates to *code and organizational claims*: executable claims (evidence + freshness
@@ -506,8 +508,10 @@ multi-format export, ELO rankings, Continuum memory, the fully-wired self-improv
 infrastructure, enterprise auth/encryption/key-rotation, and a very large test suite.
 GA readiness is tracked at **~98%** (58/59 checklist items).
 
-**Honest qualifications:** the B0 benchmark shows 100% verified-truth on a small strict
-set but ~69% on the full corpus; **SOC 2 Type II is not certified** (the one open GA
+**Honest qualifications:** the B0 benchmark reports 100% verified-truth on the strict
+set, with a separate, lower legacy full-corpus metric tracked alongside it (see
+[`docs/status/B0_BENCHMARK_TRUTH_STATUS.md`](docs/status/B0_BENCHMARK_TRUTH_STATUS.md));
+**SOC 2 Type II is not certified** (the one open GA
 blocker is the external penetration test); semantic convergence degrades to TF-IDF/Jaccard
 without the optional `sentence-transformers` dependency; "blockchain" receipts are SHA-256
 hashing, *not* an on-chain immutable ledger; and practical real-time parallelism is 2–6

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Contributions welcome — see [CONTRIBUTING.md](CONTRIBUTING.md). MIT licensed
 
 ---
 
-<a name="full-vision"></a>
+<a id="full-vision"></a>
 
 ## Postscript — The Full Vision
 
@@ -210,7 +210,7 @@ Contributions welcome — see [CONTRIBUTING.md](CONTRIBUTING.md). MIT licensed
 > across docs it is rounded here on purpose. Every major claim below carries a proof
 > link, a status marker, or an explicit aspirational label — start with the proof ladder.
 
-<a name="proof-ladder"></a>
+<a id="proof-ladder"></a>
 
 ### Proof ladder — how to verify every claim here
 
@@ -306,7 +306,7 @@ truth. *(docs/CANONICAL_GOALS.md)*
 
 > Scale (canonical counts in [`docs/METRICS.md`](docs/METRICS.md), rounded):
 > **~4,200 Python files · ~1.9M LOC · 140+ top-level modules · 200,000+ test
-> functions across ~5,400 files · ~3,300 API operations over ~2,870 paths ·
+> functions across ~5,400 files · 3,386 API operations across 2,928 paths ·
 > 35+ allowlisted agent types across 12+ providers · 41 Knowledge Mound adapter specs
 > (46 files) · 360+ RBAC permissions · Python + TypeScript SDKs · v2.9.0.**
 > (Practical real-time debate uses 2–6 agents; the value is *heterogeneity*, not raw
@@ -448,7 +448,7 @@ metric. *(docs/plans/ agent-civilization designs)*
   assumptions decay, epistemic decay signals proposing bounded repair, and a read-only
   organizational truth map. Initial shape is manifest-based and read-only.
 - **Trust-Compound plan (🔄 TCP-1..7).** Make the large surface *legible without
-  deletion*: a canonical-metrics manifest verified in CI (so a claim like "40+ adapters"
+  deletion*: a canonical-metrics manifest verified in CI (so a claim like "46 adapters"
   passes or fails the build), packaging clarity, hotspot-file splits, wire/showcase/
   shelve classification per subsystem, generated artifacts as build outputs, this README
   rewrite, and public CruxSets at `aragora.ai/cruxes`.
@@ -498,7 +498,7 @@ canvas — move to `contrib/` or shelve until customer demand). The standalone
 `aragora-debate` library extracts Tier 1 so anyone can run an adversarial debate in ~10
 lines with zero infra dependencies.
 
-<a name="honest-current-state"></a>
+<a id="honest-current-state"></a>
 
 ### Honest current state *(docs/HONEST_ASSESSMENT.md, docs/GA_CHECKLIST.md)*
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ jobs:
 The action posts a PR review comment and uploads the machine-readable review
 artifact. When a Decision Receipt artifact exists, anyone — a teammate, an
 auditor, a customer — can verify it independently with the standalone
-`aragora-verify` package (no Aragora dependency):
+`aragora-verify` verifier (no Aragora dependency):
 
 ```bash
 # PyPI publish pending; today it lives in this repo under aragora-verify/:
@@ -106,7 +106,7 @@ Aragora is large, but five modules carry the product. Start here:
 | `aragora/swarm/` | The merge-quorum gate — collects model-review evidence and tiers settlement. |
 | `aragora/server/` | The HTTP/WebSocket API and handlers. |
 
-`aragora-verify/` is a separate verifier package with no Aragora dependency:
+`aragora-verify/` is a separate verifier project with no Aragora dependency:
 the public verifier for receipts. Everything else under `aragora/` is
 supporting or experimental surface — treat it as such until it's documented
 here.
@@ -123,6 +123,49 @@ existing runtimes when raw speed is all you need.
 - Consequential effectors are denied by default unless an admin-scoped approval artifact exists; sandboxed backends are mandatory for browser/host effectors.
 
 See [Boundaries and Scope](docs/strategy/BOUNDARIES_AND_SCOPE.md) for the full non-goals ledger.
+
+## From the wedge to the full vision
+
+The CI review gate is the first rung of a deliberate ladder — each step reuses the
+same receipt, memory, and quorum substrate rather than bolting on a new system:
+
+```
+CI review gate ─▶ portable Decision Receipt (ODR) ─▶ crux + calibration in the receipt
+   ─▶ bounded-backlog foreman (unattended work, receipts + stop conditions)
+   ─▶ unified idea→goal→action→orchestration DAG ─▶ organization substrate
+```
+
+The narrow product you can adopt today and the long-horizon thesis are the same
+system at different stages. The complete scope — every capability, the roadmap, and
+the agent-civilization frontier — is in the [Full Vision postscript](#full-vision),
+annotated by status and gate.
+
+### Anatomy of a Decision Receipt
+
+The receipt is the unit that carries through every stage. One review produces:
+
+```
+decision ──▶ model jury (heterogeneous, independent)
+               ├─ proposals / critiques / revisions
+               ├─ dissent trail + load-bearing cruxes
+               └─ per-agent ELO + Brier calibration (at decision time)
+          ──▶ verdict + confidence
+          ──▶ human attestation (optional; EU AI Act Art. 14)   🔄 #8230
+          ──▶ Ed25519 signature                                 🔄 #8225
+          ──▶ portable ODR JSON  ──▶  aragora-verify <receipt>  ✅ schema+digest+quorum, offline
+          ──▶ Rekor public anchoring (tamper-evidence)          🔄 #8231
+```
+
+Today's receipts verify on schema, digest, and quorum consistency offline; public-key
+signing and anchoring are in-flight. See the [proof ladder](#proof-ladder).
+
+## Find your path
+
+- **Developer** — [Quickstart](docs/quickstart.md) → `aragora review-pr` → [CLI Reference](docs/CLI_REFERENCE.md) · [SDK Guide](docs/SDK_GUIDE.md)
+- **Auditor / reviewer** — [Cold Reviewer Guide](docs/COLD_REVIEWER_GUIDE.md) → [Open Decision Receipt spec](docs/specs/OPEN_DECISION_RECEIPT.md) → `aragora-verify`
+- **Founder / operator** — the wedge above → [proof ladder](#proof-ladder) → [Full Vision](#full-vision)
+- **Compliance buyer** — [Enterprise features](docs/enterprise/ENTERPRISE_FEATURES.md) → EU AI Act / SOC 2 status in [honest current state](#honest-current-state)
+- **Agent / tool builder** — the [ODR](docs/specs/OPEN_DECISION_RECEIPT.md) as the external contract → MCP tools → [API Reference](docs/api/API_REFERENCE.md)
 
 ## Documentation
 
@@ -143,3 +186,340 @@ local development uses a gitignored `.env`. See the
 
 Contributions welcome — see [CONTRIBUTING.md](CONTRIBUTING.md). MIT licensed
 (see [LICENSE](LICENSE)).
+
+---
+
+<a name="full-vision"></a>
+
+## Postscript — The Full Vision
+
+> The sections above are what Aragora **is today** and how to use it. What follows
+> is the **complete intended scope** — the thesis, the whole capability surface, the
+> roadmap, and the long-horizon vision — recorded in one place so that anyone (human
+> or agent) who reads to the end sees exactly how large this project means to become.
+> It is deliberately dense.
+>
+> **Read this honestly.** Markers: ✅ shipped/working · 🟡 built but not productized ·
+> 🔄 in-flight · 🔮 designed or aspirational. Per our
+> [commercial discipline](docs/COMMERCIAL_OVERVIEW.md), *external claims stay narrower
+> than this roadmap and tied to measured proof.* Canonical metrics live in
+> [`docs/METRICS.md`](docs/METRICS.md); the candid current-state ledger is
+> [`docs/HONEST_ASSESSMENT.md`](docs/HONEST_ASSESSMENT.md). Where a number is contested
+> across docs it is rounded here on purpose. Every major claim below carries a proof
+> link, a status marker, or an explicit aspirational label — start with the proof ladder.
+
+<a name="proof-ladder"></a>
+
+### Proof ladder — how to verify every claim here
+
+| Claim class | Canonical source / gate |
+|---|---|
+| Scale & metrics | [`docs/METRICS.md`](docs/METRICS.md) — `python scripts/regenerate_metrics.py --check` fails CI on >0.5% drift |
+| What's real vs aspirational | [`docs/HONEST_ASSESSMENT.md`](docs/HONEST_ASSESSMENT.md) |
+| Receipt format (the external contract) | [Open Decision Receipt spec](docs/specs/OPEN_DECISION_RECEIPT.md) |
+| Decision-semantics roadmap | ODR spine epic [#8223](https://github.com/synaptent/aragora/issues/8223); ODR-1..7 → [#8224](https://github.com/synaptent/aragora/issues/8224)/[#8225](https://github.com/synaptent/aragora/issues/8225)/[#8226](https://github.com/synaptent/aragora/issues/8226)/[#8227](https://github.com/synaptent/aragora/issues/8227)/[#8229](https://github.com/synaptent/aragora/issues/8229)/[#8230](https://github.com/synaptent/aragora/issues/8230)/[#8231](https://github.com/synaptent/aragora/issues/8231) |
+| Autonomy truth | B0 benchmark [`docs/status/B0_BENCHMARK_TRUTH_STATUS.md`](docs/status/B0_BENCHMARK_TRUTH_STATUS.md) |
+| Enterprise / compliance | [GA checklist](docs/GA_CHECKLIST.md) (SOC 2 / pentest gate) · [Enterprise features](docs/enterprise/ENTERPRISE_FEATURES.md) |
+| Frontier work is bounded | the proof-first Foreman gate + capability checkpoints CP-1..5 (below) |
+
+### The thesis — Decision Integrity
+
+Aragora orchestrates **heterogeneous, adversarial multi-model debate** to vet,
+challenge, and audit consequential decisions *before* they ship — and emits
+cryptographic proof that the decision was rigorously examined. This is a distinct
+category from cooperative agent orchestration (LangGraph, CrewAI, AutoGen), from
+single-provider agent SDKs, and from post-hoc AI observability: those coordinate
+graphs or monitor behavior after the fact; Aragora improves decision *quality*
+before commit and produces the audit trail as a byproduct.
+*(docs/WHY_ARAGORA.md, docs/COMPARISON_MATRIX.md)*
+
+**Why a single model isn't enough.** LLMs exhibit correlated failures (shared
+training data and RLHF biases), sycophantic agreement (confidence uncorrelated with
+accuracy), and persona instability (minor prompt changes flip answers). Treat each
+model as an *unreliable witness* and extract signal from where independent witnesses
+disagree. Clinical triage, financial risk, legal review, and architecture decisions
+cannot rest on "probably right." The moat: no funded competitor combines structured
+adversarial multi-agent debate with portable, verifiable decision receipts.
+*(docs/WHY_ARAGORA.md, docs/HONEST_ASSESSMENT.md)*
+
+**Why this is not generic orchestration:**
+
+| | Cooperative orchestration (LangGraph / CrewAI / AutoGen) | Aragora |
+|---|---|---|
+| Agent disagreement | a bug to resolve | the signal — preserved as dissent + cruxes |
+| Primary output | the completed task | a verifiable Decision Receipt |
+| Model independence | often single-provider | heterogeneous providers by design |
+| When evidence is thin | proceeds | stops truthfully; the receipt says so |
+| Delegation | open-ended | bounded; approval artifacts + sandboxed effectors |
+
+*(docs/strategy/BOUNDARIES_AND_SCOPE.md, docs/COMPARISON_MATRIX.md)*
+
+### The Five Pillars *(product framing — docs/EXTENDED_README.md)*
+
+1. **SMB-ready, enterprise-grade.** Works for a 5-person startup on day one; scales
+   to regulated enterprise without rearchitecting. SSO/MFA, encryption, RBAC, and
+   compliance frameworks are built-in defaults, not premium tiers.
+2. **Leading-edge memory & context.** 4-tier Continuum Memory (fast/medium/slow/
+   glacial) + Knowledge Mound give every debate institutional history and evidence
+   provenance; RLM (Recursive Language Models) sustains coherence over long sessions
+   and large corpora where single models degrade.
+3. **Extensible & modular.** 12+ model providers, broad connectors, Python + TypeScript
+   SDKs, a large REST/WebSocket API surface, and a workflow-template library.
+4. **Multi-agent robustness.** Claude, GPT, Gemini, Grok, Mistral, DeepSeek run in
+   structured Propose/Critique/Revise debates with multiple consensus modes; ELO and
+   Brier calibration track per-domain agent quality; the Trickster flags hollow
+   consensus. Output is higher-quality and lower-bias than any single model, with a
+   complete dissent trail.
+5. **Self-healing & self-extending.** The Nomic Loop lets the platform debate, design,
+   implement, and verify improvements to *itself*, with human approval gates and
+   automatic rollback.
+
+### The long arc — Tool → Organization Substrate
+
+Aragora is designed to climb five stages: **Tool → Teammate → Foreman → Chief of
+Staff → Organization Substrate** — from bounded useful results today to a cross-org
+agentic operating system. The near-term focus (next 60 days) narrows hard to two of
+these pillars: **reliable autonomous execution** on bounded backlogs, and
+**cryptographic receipts & auditability**. *(docs/CANONICAL_GOALS.md)*
+
+```
+Tool ──▶ Teammate ──▶ Foreman ──▶ Chief of Staff ──▶ Organization Substrate
+ one      assists      runs bounded   plans & routes      agents + humans as
+ review   a human      backlogs       across backlogs     co-equal consumers
+ +receipt              unattended     with receipts       on one runtime truth
+(today's wedge) ───────────────────────────────────────▶ (long-horizon thesis)
+```
+
+The eight foundational pillars the substrate is organized around: ① adversarial
+heterogeneous consensus + crux-finding · ② reliable autonomous execution (contracts,
+preflight, repair, fail-closed escalation) · ③ a unified DAG (ideas → goals → actions
+→ orchestration) with optional interactivity · ④ permissioned, portable, attributable
+memory across repos/docs/APIs/chat/inbox/telemetry · ⑤ cryptographic receipts &
+auditability with eventual proof-carrying code · ⑥ SMB operator leverage (intent →
+action in <10 min) · ⑦ self-improvement on the *same* substrate as user-facing work ·
+⑧ agents and humans as co-equal consumers with parity surfaces backed by one runtime
+truth. *(docs/CANONICAL_GOALS.md)*
+
+### The complete capability surface
+
+> Scale (canonical counts in [`docs/METRICS.md`](docs/METRICS.md), rounded):
+> **~4,200 Python files · ~1.9M LOC · 140+ top-level modules · 200,000+ test
+> functions across ~5,400 files · ~3,300 API operations over ~2,870 paths ·
+> 35+ allowlisted agent types across 12+ providers · 41 Knowledge Mound adapter specs
+> (46 files) · 360+ RBAC permissions · Python + TypeScript SDKs · v2.9.0.**
+> (Practical real-time debate uses 2–6 agents; the value is *heterogeneity*, not raw
+> count — see docs/HONEST_ASSESSMENT.md.)
+
+**Core debate (✅).** Arena engine orchestrates Propose/Critique/Revise/Vote phases,
+extended multi-round debates, semantic convergence detection, ELO-based team
+selection with continuous calibration. Consensus modes: majority, unanimous, weighted/
+judge, byzantine, and Prover-Estimator. Enhancements: Trickster (hollow-consensus
+detection), Rhetorical Observer, Security Barrier (telemetry redaction), Calibration
+Tracker, Performance Monitor, Graph/Matrix topologies, breakpoints (pause/resume).
+
+**Agents (✅).** API providers: Anthropic, OpenAI, Google Gemini, Mistral (Large/
+Codestral), xAI Grok, OpenRouter (DeepSeek/Llama/Qwen/Yi/Kimi), local Ollama/LM Studio.
+CLI agents: Claude, Codex, Gemini, Grok. Resilience: Airlock circuit breaker,
+automatic OpenRouter fallback on 429, session circuit-breaker (auth-state pinning),
+per-provider rate limiting, unified error hierarchy.
+
+**Memory & learning (✅).** Continuum Memory (4 tiers, atomic cross-system writes via
+Memory Coordinator); Unified Memory Gateway fanning out across Continuum, Knowledge
+Mound, Supermemory, and claude-mem with a surprise-driven RetentionGate (Titans/MIRAS)
+and SHA-256 + Jaccard dedup; RLM context-as-REPL-variables (not prompt compression);
+ELO ratings, tournaments, leaderboards, performance-based selection.
+
+**Knowledge management (✅, Phase A2).** Knowledge Mound: semantic vector search,
+graph store with lineage, domain taxonomy, visibility tiers (private→workspace→org→
+public→system), time-bounded access grants, cross-workspace federation. Auto-curation:
+dedup, contradiction detection, confidence decay, RBAC governance, ResilientPostgres
+store, SLO alerting. 40+ registered adapters auto-built from Arena subsystems; bridges
+(MetaLearner, Evidence, Pattern); belief networks with claim provenance and cruxes.
+
+**Enterprise & security (✅, production-ready).** OIDC/SAML SSO, TOTP/HOTP MFA, SCIM 2.0
+(Okta/Azure/OneLogin), scoped API keys; RBAC v2 (360+ permissions, 7 roles, hierarchy,
+decorators, middleware, audit); multi-tenancy (SQL auto-filtering, quotas, metering);
+AES-256-GCM field encryption with Cloud KMS + key rotation, PII anonymization, GDPR
+erasure; circuit breakers, rate limiting, SSRF protection, security headers; incremental
+backup/DR with drills.
+
+**Compliance & governance (mixed).** EU AI Act artifact generation for Articles 9/12/13/
+14/15 with risk classification (🔄, bundle ~90/100 complete; enforcement deadline **Aug 2,
+2026**); SOC 2 Type II controls implemented (🔄 ~98%; **blocker: external penetration test
+not yet commissioned** — *not certified*); GDPR DSAR/erasure/consent/retention (✅);
+HIPAA field encryption, Safe Harbor de-identification, breach-notification workflows (✅
+controls); SOX-oriented audit profiles (✅). *(docs/HONEST_ASSESSMENT.md, docs/GA_CHECKLIST.md)*
+
+**Integrations & connectors (✅, 50+).** Chat: Slack, Discord, Teams, Google Chat,
+Telegram, WhatsApp (with TTS/voice). Streaming: Kafka, RabbitMQ (DLQ, bidirectional).
+Enterprise data: SharePoint, Confluence, Notion, PostgreSQL/MongoDB/MySQL/SQL Server/
+Snowflake (CDC), Salesforce, HubSpot, Zendesk, Jira. Sources: GitHub, ArXiv, Wikipedia,
+SEC filings, HackerNews, Reddit, Twitter/X. Email/voice: Gmail + Outlook sync, Twilio
+phone debates, SMTP. Healthcare: HL7v2, FHIR. Bidirectional routing returns results to
+the originating platform.
+
+**Observability & control plane (✅).** Prometheus custom metrics, Grafana dashboards,
+OpenTelemetry tracing (OTLP, multiple backends), structured JSON logs with PII redaction
+and correlation IDs; agent registry with heartbeats, priority scheduler, liveness/
+readiness probes; policy governance (conflict detection, Redis cache, background sync,
+versioned rollback). 1,500+ control-plane tests.
+
+**Advanced capabilities.** Pulse trending-topic ingestion (✅); Gauntlet adversarial
+red-team + cryptographic receipts (✅); Swarm orchestration — bounded work orders,
+worker launcher into managed worktrees, reconciler, leases, salvage queue (✅); Inbox
+Trust Wedge — Gmail → debate → signed receipt → approval → execute (✅ CLI, 🔮 web GUI
+for retest); Live Explainability, structural argument verification, outcome-feedback
+loop (✅); Workflow Engine — DAG automation with 50+ templates (✅); Prompt Engine —
+vague prompt → validated spec via debate (✅); Computer-Use bridge + OpenClaw
+compatibility (🔄).
+
+**SDK & ecosystem (✅/🔄).** `aragora-sdk` (blessed Python client), full `aragora`
+package, `@aragora/sdk` (TypeScript); MCP server exposing a large tool surface for
+Claude integration with reasoning-trace capture; extensible plugin/marketplace
+architecture (🔮 no public marketplace endpoint yet).
+
+**Deployment & HA (✅).** Docker Compose (dev/prod), Kubernetes Helm chart with
+multi-region values (US/EU/APAC data residency), HPA/PDB/network policies, External
+Secrets Operator, cert-manager; Terraform IaC; SQLite (dev) / PostgreSQL (prod) with
+pooling; unified TTL cache + Redis cluster failover; incremental backup to local/S3/GCS,
+offline/air-gapped mode.
+
+**Built but not productized (🟡).** Real code in-tree, little or no public surface —
+tracked openly, not hidden *(docs/FEATURE_GAP_LIST.md dormant table)*:
+- **Crux detector** — engine + operator CLI complete; no public API/SDK or crux-set-in-receipt yet ([#8227](https://github.com/synaptent/aragora/issues/8227), ODR-4).
+- **Pareto provider router** — optimizer + pricing DB shipped; the loop doesn't yet route by decision stakes or record rationale ([#8233](https://github.com/synaptent/aragora/issues/8233)).
+- **Tamper-evident audit trail** — trail verifies checksums; external-witness append-only anchoring is building (TET spec; Rekor [#8231](https://github.com/synaptent/aragora/issues/8231)).
+- **ERC-8004 / blockchain** — registries + handlers in-tree, deployed to no network; **de-scoped** by the steering-leverage filter (the anchoring need is served by Rekor instead).
+- **Skills marketplace** — code + seed catalog exist; no public endpoint or third-party content.
+
+### Vertical specialists *(docs/verticals/, 🔄 guides exist; packaged offerings 🔮)*
+
+- **Healthcare** — FHIR R4 (Epic/Cerner via SMART-on-FHIR), drug-interaction and
+  contraindication analysis, treatment-pathway debate, HIPAA-compliant receipts.
+- **Financial services** — credit underwriting, fraud investigation, investment-committee
+  review, stress-testing, audit-grade dissent trails (SOX/SOC 2 workflows).
+- **Legal** — clause-by-clause adversarial contract analysis, counterparty modeling,
+  missing-clause detection, M&A due diligence (6 concurrent review streams), litigation
+  risk.
+- **Accounting** — loan risk, equity valuation, deal-structure analysis, materiality
+  assessment.
+
+### Self-improvement — the Nomic Loop & the flywheel
+
+**The Nomic Loop (✅, 233+ tests).** A five-phase autonomous self-improvement cycle:
+**Context → Debate → Design → Implement → Verify.** Heterogeneous agents propose and
+argue improvements, architect a solution, generate code in isolated worktrees, then
+gate on automated tests + cross-agent review + merge arbiter + Knowledge Mound learning.
+Infrastructure: TaskDecomposer, HardenedOrchestrator (default since Feb 2026),
+BranchCoordinator, MetaPlanner, AutonomousOrchestrator. Safety: prompt-injection
+scanning, canary tokens, sandbox execution, review-gate scoring, automatic rollback,
+protected-file checksums, human approval gates. CLI: `aragora self-improve "<goal>"`,
+`scripts/self_develop.py`, `scripts/nomic_staged.py`. *(CLAUDE.md, docs/plans/SELF_IMPROVING_ARAGORA.md)*
+
+**The flywheel.** Aragora uses Aragora to improve Aragora: debates over tradeoffs →
+receipts capturing the reasoning → Knowledge Mound learning → better-calibrated next
+debate. As the system fixes its own bugs and ships its own features, the verifiable
+corpus and the agent-calibration data grow — and that calibration data is the moat. The
+strategy-mission cadence that produced *this very README* gated its own merge through
+Aragora's quorum→receipt machinery — the flywheel, demonstrated.
+
+### The frontier — Agent Civilization Substrate *(🔮 designed; gated, see below)*
+
+Beyond human-operated orgs, Aragora is designed as a substrate for consequential
+multi-agent coordination where **reputation is earned against external ground truth,
+not closed-loop agreement.** Six tracks (AGT-01..06): activate the CruxDetector in live
+debates; an A2A consumer surface where agents register/discover/transact/consume
+receipts; Manifold Markets integration with rolling Brier scoring; synthetic GitHub
+markets (predict PR merges / issue closures with verifiable resolution); ERC-8004
+reputation flow (claims → stakes → resolution → reputation deltas → dispatch
+eligibility — *contracts written, no mainnet; de-scoped June 2026 in favor of Sigstore
+Rekor anchoring*); and a Verifiable-Improvements-per-Agent-Hour (VIAH) self-justification
+metric. *(docs/plans/ agent-civilization designs)*
+
+- **Crux Finder (✅ MVP / 🔮 shaping).** Consensus mode `crux_finder` surfaces the 3–5
+  load-bearing disagreements where flipping a belief flips the conclusion; signed
+  CruxReceipts, `aragora crux find "<question>"`. Crux-shaping prompts and per-round
+  claim targeting are deferred pending dogfood runs.
+- **Epistemic CI / Decision Integrity Core (🔮 DIC-13..22).** Extend receipts beyond
+  debates to *code and organizational claims*: executable claims (evidence + freshness
+  SLAs + verification contracts), proof-carrying code units that fail closed when
+  assumptions decay, epistemic decay signals proposing bounded repair, and a read-only
+  organizational truth map. Initial shape is manifest-based and read-only.
+- **Trust-Compound plan (🔄 TCP-1..7).** Make the large surface *legible without
+  deletion*: a canonical-metrics manifest verified in CI (so a claim like "40+ adapters"
+  passes or fails the build), packaging clarity, hotspot-file splits, wire/showcase/
+  shelve classification per subsystem, generated artifacts as build outputs, this README
+  rewrite, and public CruxSets at `aragora.ai/cruxes`.
+
+### Discipline — capability checkpoints (CP-1..5)
+
+The vision is **bounded, not open-ended.** Booster-stage investment in the frontier must
+graduate through checkpoints, each ~4 weeks apart: CP-1 stable self-healing soaks → CP-2
+CruxDetector driving real follow-ups → CP-3 stable prediction-calibration curves → CP-4
+a reputation delta changing real dispatch → CP-5 positive VIAH trend without an operator-
+rescue spike. **Failing a checkpoint downscales the next investment; it does not kill the
+vision.** Frontier (AGT-*/DIC-*) work never carries `boss-ready` until the proof-first
+gate explicitly opens the upper tranche. *(docs/plans/ trust-compound + checkpoints)*
+
+### Roadmap — priority-gated *(docs/FEATURE_GAP_LIST.md, docs/CANONICAL_GOALS.md)*
+
+**Current execution spine — Open Decision Receipt** (epic [#8223](https://github.com/synaptent/aragora/issues/8223); supersedes the P0/P1 ordering below): **ODR-1** vendor-neutral receipt profile (JSON Schema + JCS) [#8224](https://github.com/synaptent/aragora/issues/8224) → **ODR-2** Ed25519 public-key signing [#8225](https://github.com/synaptent/aragora/issues/8225) → **ODR-3** `aragora-verify` standalone offline verifier + `/api/receipts/verify` [#8226](https://github.com/synaptent/aragora/issues/8226) → **ODR-4** expose the crux finder [#8227](https://github.com/synaptent/aragora/issues/8227) → **ODR-5** calibration report + calibrated confidence [#8229](https://github.com/synaptent/aragora/issues/8229) → **ODR-6** human-oversight attestation + EU AI Act Art. 14 pack [#8230](https://github.com/synaptent/aragora/issues/8230) → **ODR-7** Sigstore Rekor public anchoring [#8231](https://github.com/synaptent/aragora/issues/8231). (1–3 are the spine: a receipt a stranger can verify; 4–6 enrich the payload; 7 makes anchoring public.)
+
+- **P0 — PMF blockers:** truthful live founder loop (✅ 5/5 proved); smart provider
+  routing (✅ optimizer + runtime; 🔄 decision-stakes routing); complete repeatable user
+  journey (🔄); KM reads enrich debate context (🔄 live proof pending).
+- **P1 — value-prop proof (Q2 2026):** OpenClaw end-to-end (🔄); 5 functional frontend
+  paths (🔄); 10+ agent coordinated debates (🔄 scale testing); agent-first beta via REST
+  (✅ 12-runner fleet); GitHub Actions pre-merge gate (🔄); public demo at aragora.ai/demo
+  (🔄); EU AI Act bundle (🔄 ~90/100); <10-min onboarding (🔄).
+- **P2 — hardening & enterprise (post-PMF):** external penetration test (🔮 vendor
+  shortlisted); Decision-Integrity UI Workbench (🔄 partial); SOC 2 Type II audit (🔄
+  ~98% controls); Enterprise Communication Hub (✅ shipped, 🔄 trigger validation).
+- **P3 — scale & revenue (Q3–Q4 2026, de-scoped until PMF):** cloud marketplace listings;
+  vertical packages; Skills Marketplace pilot; on-prem productization; data residency /
+  international.
+- **P4 — strategic evolution (2026+):** ✅ Prover-Estimator, cross-verification, truth-
+  ratio weighting, anti-sycophancy, prompt-to-spec, Obsidian sync; 🔮 Dialectical Runtime
+  synthesis (DIC-23..28), market-resolution mechanism, meta-improver for protocols.
+- **P5 — federation (🔮):** distributed debates across orgs, cross-org knowledge sync.
+
+### Focus strategy — depth over breadth *(docs/FOCUS.md)*
+
+The codebase is explicitly tiered for investment: **Tier 1 defensible core** (~17% of
+files, ~100% of unique value: debate engine, Gauntlet, Knowledge Mound, ELO/calibration,
+Continuum memory, belief networks, verification, explainability) — invest, harden, make
+receipts the primary output; **Tier 2 essential infrastructure** (agents, API, storage,
+CLI — maintain, prune the oversized server surface); **Tier 3 enterprise** (RBAC, audit,
+billing, compliance — keep, don't differentiate); **Tier 4 connectors** (commodity —
+sufficient as-is); **Tier 5 scope creep** (some workflow/RLM/blockchain/computer-use/
+canvas — move to `contrib/` or shelve until customer demand). The standalone
+`aragora-debate` library extracts Tier 1 so anyone can run an adversarial debate in ~10
+lines with zero infra dependencies.
+
+<a name="honest-current-state"></a>
+
+### Honest current state *(docs/HONEST_ASSESSMENT.md, docs/GA_CHECKLIST.md)*
+
+**Real and working:** the debate engine (genuine multi-agent debates against live LLM
+APIs), multiple consensus modes, hollow-consensus detection, cryptographic receipts with
+multi-format export, ELO rankings, Continuum memory, the fully-wired self-improvement
+infrastructure, enterprise auth/encryption/key-rotation, and a very large test suite.
+GA readiness is tracked at **~98%** (58/59 checklist items).
+
+**Honest qualifications:** the B0 benchmark shows 100% verified-truth on a small strict
+set but ~69% on the full corpus; **SOC 2 Type II is not certified** (the one open GA
+blocker is the external penetration test); semantic convergence degrades to TF-IDF/Jaccard
+without the optional `sentence-transformers` dependency; "blockchain" receipts are SHA-256
+hashing, *not* an on-chain immutable ledger; and practical real-time parallelism is 2–6
+agents, not the larger allowlisted count — the value is heterogeneity. External positioning
+should remain **narrower** than this roadmap and anchored to measured proof.
+
+### North stars *(docs/CANONICAL_GOALS.md)*
+
+1. A vague request becomes a reviewable, executable spec in minutes.
+2. A bounded backlog runs unattended with clear receipts, stop conditions, and minimal rescue.
+3. Any decision is inspectable from one-line summary down to evidence and provenance.
+4. Shared memory improves future work without collapsing trust boundaries.
+5. Important claims and cruxes stay linked to evidence, receipts, freshness, and delayed settlement.
+6. Aragora evolves tool → teammate → foreman → chief of staff → org substrate on one coherent runtime.
+7. Agents and humans participate as co-equal consumers with portable reputation tied to external truth oracles.


### PR DESCRIPTION
## Summary
- Replays the additive README refinement onto the already-merged #8674 control-plane front door without touching #8674's branch.
- Adds the wedge-to-full-vision bridge, Decision Receipt anatomy, audience paths, proof ladder, built-but-not-productized class, ODR execution spine, and explicit honest-current-state anchor.
- Tightens aragora-verify wording so the README keeps the PyPI-pending caveat and does not imply published package availability.

## Test Plan
- `python scripts/regenerate_metrics.py --check`
- `git diff --cached --check`
- README anchor/relative-link validation for `#full-vision`, `#proof-ladder`, and `#honest-current-state`
- README scan for stale `v2.8.0`, false `pip install aragora-verify`, package-wording implication, and conflict markers
- Live PyPI availability scan: `aragora`/`aragora-debate`/`aragora-sdk` = 200; `aragora-verify` = 404

## Notes
- #8674 is already merged and intentionally left untouched.
- `aragora/__init__.py` version drift remains a separate protected-file follow-up, not part of this README PR.