### PR TITLE
fix(version): derive aragora.__version__ from canonical source (2.8.0 → 2.9.0)

### DIFF
--- a/aragora/__init__.py
+++ b/aragora/__init__.py
@@ -13,7 +13,13 @@ from __future__ import annotations
 import importlib
 from typing import Any
 
-__version__ = "2.8.0"
+# Re-export the package version from the canonical single source of truth
+# (``aragora/__version__.py``), which CI keeps aligned with ``pyproject.toml``
+# via ``scripts/check_version_alignment.py``. Deriving it here instead of
+# hard-coding a literal prevents ``aragora.__version__`` from silently drifting
+# away from the declared/installed version. The version module is stdlib-only
+# and side-effect free, so importing it at package init is safe.
+from aragora.__version__ import __version__ as __version__
 
 _EXPORT_MAP = {
     "Agent": ("aragora.core", "Agent"),


### PR DESCRIPTION
## Problem

`aragora/__init__.py` hard-coded `__version__ = "2.8.0"` while the authoritative `pyproject.toml` and the canonical `aragora/__version__.py` module both declare `2.9.0`. So `import aragora; aragora.__version__` **lied about the installed version**:

```
# before
$ python -c "import aragora; print(aragora.__version__)"
2.8.0
```

## Root cause

`scripts/check_version_alignment.py` (run in CI via `test.yml` / `sdk-parity.yml`) treats `aragora/__version__.py` as the **single source of truth** and validates every manifest + doc against it. Every checked source is already `2.9.0` — but the script **never checks the top-level `aragora/__init__.py`**, so its duplicated literal drifted unnoticed.

## Fix

Re-export `__version__` from the canonical `aragora/__version__.py` module instead of hard-coding a literal:

```python
from aragora.__version__ import __version__ as __version__
```

This is the same pattern `aragora/compat/openclaw/standalone.py:348` already uses. It ties the package attribute to the CI-enforced source of truth so it **can never drift again** — superior to a bare literal bump (drifts at the next release) or `importlib.metadata` (whose fallback literal is itself a second drift source and which depends on the package being pip-installed). The version module is stdlib-only and side-effect free, so importing it at package init is safe and does not pull in any heavy debate-surface submodule.

> ⚠️ **Protected file.** `aragora/__init__.py` is on the project's Protected Files list (CLAUDE.md). This change was explicitly approved for this single, narrow version-reconciliation edit; no other edits were made to the file. Likely **Tier 3–4** (touches a public surface) — leaving evidence-ready for human settlement, not self-merging.

## Verification

```
# after
aragora.__version__                          -> 2.9.0   (import aragora)
from aragora import __version__               -> 2.9.0   (error_monitoring / health consumers)
from aragora.__version__ import __version__   -> 2.9.0   (standalone.py pattern, unchanged)
```

- `scripts/check_version_alignment.py` → **All versions aligned!**
- `ruff check` / `ruff format --check` / `mypy` on the file → clean
- `pytest tests/server/test_error_monitoring.py tests/handlers/test_platform_config.py` → **92 passed**

## Other version literals (out of scope — flagged for follow-up)

Discovered while scoping, intentionally **not** changed here to keep this PR narrow:

- **`sdk/python/aragora_sdk/__init__.py:268`** is still `__version__ = "2.8.0"` while its own `sdk/python/pyproject.toml` (`aragora-sdk`) is `2.9.0` — a real secondary drift. The alignment script misses it because its configured path `sdk/python/aragora/__init__.py` **does not exist** (the actual package dir is `aragora_sdk`). Worth a follow-up: fix the literal *and* correct the path in `check_version_alignment.py`.
- Separate distributions with independent versioning (not drift): `aragora-debate` (`0.2.3`), `aragora-verify` (`0.1.0`), `aragora/genesis/__init__.py` (`0.1.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)