### PR TITLE
fix(version): align aragora-sdk __version__ and repair its alignment-check path

### DIFF
--- a/scripts/check_version_alignment.py
+++ b/scripts/check_version_alignment.py
@@ -170,7 +170,7 @@ def main() -> int:
         ),
     ]
     python_version_sources: list[tuple[str, Path]] = [
-        ("sdk/python/aragora/__init__.py", Path("sdk/python/aragora/__init__.py")),
+        ("sdk/python/aragora_sdk/__init__.py", Path("sdk/python/aragora_sdk/__init__.py")),
     ]
     doc_sources: list[tuple[str, Path, str]] = [
         (

--- a/sdk/python/aragora_sdk/__init__.py
+++ b/sdk/python/aragora_sdk/__init__.py
@@ -265,7 +265,7 @@ from .generated_types import Code as ErrorCode
 from .pagination import AsyncPaginator, SyncPaginator
 from .websocket import AragoraWebSocket, WebSocketEvent, WebSocketOptions, stream_debate
 
-__version__ = "2.8.0"
+__version__ = "2.9.0"
 __all__ = [
     # --- Client ---
     "AragoraClient",


### PR DESCRIPTION
Follow-up to #8700. While reconciling the top-level `aragora.__version__` drift, I found a **second, independent** drift that the CI alignment check was structurally blind to.

## Problem

1. **`sdk/python/aragora_sdk/__init__.py`** declared `__version__ = "2.8.0"`, while its own `sdk/python/pyproject.toml` (distribution `aragora-sdk`) is `2.9.0`. The installed SDK reported a stale version.
2. **`scripts/check_version_alignment.py`** was configured to validate `sdk/python/aragora/__init__.py` — a path that **does not exist** (that directory holds only `generated_types.py`; the real package is `aragora_sdk`). The script reported `(not found)` and silently skipped it. That blind spot is exactly why drift (1) went unnoticed.

## Fix

- Bump `sdk/python/aragora_sdk/__init__.py` → `2.9.0`.
- Repoint the alignment check at the real path `sdk/python/aragora_sdk/__init__.py` so the guard actually covers the SDK package and can't silently skip it again.

## Verification

```
$ python scripts/check_version_alignment.py
  ...
  sdk/python/aragora_sdk/__init__.py: 2.9.0 [__version__] [OK]   # was: (not found)
  ...
All versions aligned!          # exit 0
```

- `ruff check` + `ruff format --check` clean on both files; SDK file AST-parses.

## Scope / relationship to #8700

Kept separate so each can settle independently. #8700 fixes the top-level `aragora/__init__.py` by deriving from the canonical `aragora/__version__.py`; this PR fixes the SDK literal and the broken guard path. No overlap in files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)