### PR TITLE
ci(sdk): install TS SDK node deps before SDK Integration Tests

### DIFF
--- a/.github/workflows/sdk-test.yml
+++ b/.github/workflows/sdk-test.yml
@@ -240,6 +240,21 @@ jobs:
           bash scripts/ci_install_project.sh --extras dev
           python -m pip install -e sdk/python/
 
+      # tests/sdk/test_typescript_exports.py::test_sdk_compiles_cleanly shells out
+      # to `npx tsc --noEmit` in sdk/typescript, which needs the pinned TypeScript
+      # and @types/node from node_modules. Without npm ci, npx resolves an
+      # unpinned tsc and @types/node is absent (TS2688/TS5103).
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: sdk/typescript/package-lock.json
+
+      - name: Install TypeScript SDK dependencies
+        working-directory: sdk/typescript
+        run: npm ci
+
       - name: Run SDK integration tests
         run: |
           python -m pytest tests/sdk/ -v --tb=short --timeout=60


### PR DESCRIPTION
## Problem

The **SDK Integration Tests** CI job (`sdk-integration` in `.github/workflows/sdk-test.yml`) was failing on:

```
tests/sdk/test_typescript_exports.py::TestTypeScriptCompilation::test_sdk_compiles_cleanly
```

with:

```
src/typecheck/node26-consumer.ts(1,23): error TS2688: Cannot find type definition file for 'node'.
src/typecheck/node26-consumer.ts(4,59): error TS2591: Cannot find name 'node:stream/web'. ...
```

This is a **pre-existing toolchain gap**, not a product bug. It surfaced on [#8701](https://github.com/synaptent/aragora/pull/8701) but is unrelated to that PR's 2-line version change.

## Root cause

`test_sdk_compiles_cleanly` shells out to `npx tsc --noEmit` inside `sdk/typescript`. The `sdk-integration` job sets up **Python only** — it never ran `actions/setup-node` or `npm ci`. With no `node_modules`:

- `npx` resolved an **unpinned** `tsc` instead of the repo-pinned `typescript@^6.0.3`, and
- `@types/node` (already a devDependency at `^26.0.0`) was **absent**, so the `/// <reference types="node" />` and `node:stream/web` import in `src/typecheck/node26-consumer.ts` could not resolve → TS2688 / TS5103.

The sibling `typescript-sdk-run` job already does `setup-node` + `npm ci`; the integration job that actually runs the pytest compile check did not.

## Fix

Add `actions/setup-node@v4` + `npm ci` (scoped to `sdk/typescript`) to the `sdk-integration` job, before the pytest step. `tsconfig.json` needs no change — with `@types/node` present in `node_modules`, the triple-slash node reference resolves via the default `@types` auto-include.

## Verification

Reproduced locally via the exact failing path:

- **Before** (`node_modules` absent): `test_sdk_compiles_cleanly` **fails** (unpinned tsc → TS5103 / TS2688).
- **After** (`npm ci` in `sdk/typescript`): `1 passed`.

```
$ python -m pytest tests/sdk/test_typescript_exports.py::TestTypeScriptCompilation::test_sdk_compiles_cleanly -q
1 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)