### PR TITLE
fix(evidence): persist prepared quorum artifacts

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -732,6 +732,15 @@ def add_review_queue_parser(subparsers: argparse._SubParsersAction) -> None:
     collect_evidence_arg(
         "--apply", action="store_true", help="Post Tier 0-2 evidence; Tier 3-4 prepare only."
     )
+    collect_evidence_arg(
+        "--out",
+        type=Path,
+        default=None,
+        help=(
+            "Write the dry-run collect-evidence JSON artifact to this path so it "
+            "can later be reused with --prepared-json."
+        ),
+    )
     collect_evidence_arg("--json", dest="json_output", action="store_true", help="Output as JSON")
 
     lint_comment_p = sub.add_parser(
@@ -1367,6 +1376,7 @@ def _cmd_collect_evidence(args: argparse.Namespace) -> int:
         author=getattr(args, "author", None),
         apply=bool(getattr(args, "apply", False)),
         json_output=json_output,
+        out_path=getattr(args, "out", None),
     )
 
 

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -7,6 +7,7 @@ Separated from command implementations for clarity and maintainability.
 
 import argparse
 import os
+from pathlib import Path
 
 from aragora.cli._mission_parser import add_mission_parser
 from aragora.config import DEFAULT_AGENTS, DEFAULT_CONSENSUS, DEFAULT_ROUNDS
@@ -2352,6 +2353,15 @@ def _add_review_queue_parser(subparsers) -> None:
         "--apply",
         action="store_true",
         help="Post evidence for Tier 0-2 PRs (Tier 3-4 always prepare-only).",
+    )
+    collect_evidence_parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help=(
+            "Write the dry-run collect-evidence JSON artifact to this path so it "
+            "can later be reused with --prepared-json."
+        ),
     )
     collect_evidence_parser.add_argument(
         "--json", dest="json_output", action="store_true", help="Output as JSON"

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -2279,6 +2279,7 @@ def run_collect_cli(
     apply: bool,
     json_output: bool,
     prepared_json: Path | None = None,
+    out_path: Path | None = None,
     printer: Callable[[str], None] = print,
 ) -> int:
     """Shared entry point for the script and ``review-queue collect-evidence``.
@@ -2289,6 +2290,14 @@ def run_collect_cli(
     return 1 (quorum is enforced as N-of-M elsewhere). Inspect ``posted_families``
     in the JSON output rather than treating exit-code 1 as "nothing posted".
     """
+    if out_path is not None and apply:
+        msg = "--out is only valid for dry-run evidence preparation"
+        if json_output:
+            printer(json.dumps({"mode": "collect_evidence", "error": msg}, indent=2))
+        else:
+            printer(f"error: {msg}")
+        return 2
+
     fams = tuple(families) if families else DEFAULT_FAMILIES
     resolved_author = author or resolve_author()
     try:
@@ -2313,6 +2322,9 @@ def run_collect_cli(
                 env=merge_quorum_io.aragora_env(),
                 quorum_reconciler=default_quorum_reconciler if apply else None,
             )
+        if out_path is not None:
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            out_path.write_text(json.dumps(outcome.to_dict(), indent=2) + "\n", encoding="utf-8")
     except (ValueError, RuntimeError, OSError, subprocess.SubprocessError) as exc:
         if json_output:
             printer(json.dumps({"mode": "collect_evidence", "error": str(exc)}, indent=2))

--- a/scripts/collect_quorum_evidence.py
+++ b/scripts/collect_quorum_evidence.py
@@ -65,6 +65,15 @@ def main(argv: list[str] | None = None) -> int:
             "re-running reviewers."
         ),
     )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help=(
+            "Write the dry-run collect-evidence JSON artifact to this path so it "
+            "can later be reused with --prepared-json."
+        ),
+    )
     parser.add_argument("--json", dest="json_output", action="store_true", help="Output as JSON")
     args = parser.parse_args(argv)
 
@@ -76,6 +85,7 @@ def main(argv: list[str] | None = None) -> int:
         apply=args.apply,
         json_output=args.json_output,
         prepared_json=args.prepared_json,
+        out_path=args.out,
     )
 
 

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -5753,6 +5753,8 @@ class TestCommandDispatch:
                 "openai",
                 "--author",
                 "an0mium",
+                "--out",
+                "/tmp/prepared-evidence.json",
                 "--json",
             ]
         )
@@ -5761,6 +5763,7 @@ class TestCommandDispatch:
         assert ns_collect.pr == 6280
         assert ns_collect.reviewers == ["claude", "openai"]
         assert ns_collect.author == "an0mium"
+        assert str(ns_collect.out) == "/tmp/prepared-evidence.json"
         assert ns_collect.apply is False
         assert ns_collect.json_output is True
         # run invocation parses

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -2318,6 +2318,65 @@ def test_run_collect_cli_prepared_json_skips_collect_evidence(monkeypatch, tmp_p
     assert seen["families"] == ("claude", "grok")
 
 
+def test_run_collect_cli_writes_prepared_artifact(monkeypatch, tmp_path, capsys) -> None:
+    def fake_collect(**kwargs) -> CollectOutcome:
+        return CollectOutcome(
+            repo="o/r",
+            pr=1,
+            head_sha=HEAD,
+            head_committed_at=COMMITTED,
+            tier=1,
+            action="prepare",
+            action_reason="dry-run",
+            items=[
+                EvidenceItem("claude", _prepared_body("claude"), True, ["claude"], [], "pass"),
+                EvidenceItem("grok", _prepared_body("grok"), True, ["grok"], [], "pass"),
+            ],
+        )
+
+    monkeypatch.setattr(qe, "collect_evidence", fake_collect)
+    monkeypatch.setattr(qe, "resolve_author", lambda default="local": "me")
+
+    out_path = tmp_path / "artifacts" / "prepared.json"
+    rc = qe.run_collect_cli(
+        repo="o/r",
+        pr=1,
+        families=None,
+        author=None,
+        apply=False,
+        json_output=True,
+        out_path=out_path,
+    )
+
+    assert rc == 0
+    stdout_payload = json.loads(capsys.readouterr().out)
+    artifact_payload = json.loads(out_path.read_text(encoding="utf-8"))
+    assert artifact_payload == stdout_payload
+    assert artifact_payload["head_sha"] == HEAD
+    assert artifact_payload["items"][0]["family"] == "claude"
+
+
+def test_run_collect_cli_rejects_out_with_apply(monkeypatch, tmp_path, capsys) -> None:
+    def boom_collect(**kwargs) -> CollectOutcome:
+        raise AssertionError("collect_evidence must not run when --out and --apply conflict")
+
+    monkeypatch.setattr(qe, "collect_evidence", boom_collect)
+
+    rc = qe.run_collect_cli(
+        repo="o/r",
+        pr=1,
+        families=None,
+        author=None,
+        apply=True,
+        json_output=True,
+        out_path=tmp_path / "prepared.json",
+    )
+
+    assert rc == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error"] == "--out is only valid for dry-run evidence preparation"
+
+
 def test_run_collect_cli_exit_code_quorum_incomplete(monkeypatch) -> None:
     def fake_collect(**kwargs) -> CollectOutcome:
         return CollectOutcome(


### PR DESCRIPTION
## Summary
- add collect-evidence --out for dry-run JSON artifact persistence
- allow exact prepared artifacts to be reused with the existing --prepared-json apply path instead of rerunning slow reviewers
- reject --out with --apply so artifact writing stays prepare-only

## Live context
- #8680 dry-run produced supportive Claude+Grok evidence at exact head 6d62986fc929a6fcfb4ac1615c3bbadf05e3b388
- direct --apply then timed out before posting, leaving comments empty and merge-quorum still missing evidence
- this repair makes the safe path explicit: dry-run once with --out, inspect/lint, then apply the exact artifact through --prepared-json

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/swarm/test_quorum_evidence.py tests/cli/commands/test_review_queue.py::TestCommandDispatch::test_parser_registers_build_packet_run_and_act
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check aragora/swarm/quorum_evidence.py scripts/collect_quorum_evidence.py aragora/cli/commands/review_queue.py aragora/cli/parser.py tests/swarm/test_quorum_evidence.py tests/cli/commands/test_review_queue.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check aragora/swarm/quorum_evidence.py scripts/collect_quorum_evidence.py aragora/cli/commands/review_queue.py aragora/cli/parser.py tests/swarm/test_quorum_evidence.py tests/cli/commands/test_review_queue.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD