### PR TITLE
fix(leases): clarify fleet claim overlap checks

### DIFF
--- a/aragora/nomic/dev_leases.py
+++ b/aragora/nomic/dev_leases.py
@@ -2,14 +2,16 @@
 
 from __future__ import annotations
 
-from . import dev_coordination as _dev
+import sqlite3
+import uuid
+from datetime import timedelta
+from pathlib import Path
+from typing import Any
 
-Any = _dev.Any
-LeaseConflictError = _dev.LeaseConflictError
-LeaseStatus = _dev.LeaseStatus
-Path = _dev.Path
-WorkLease = _dev.WorkLease
-_claims_overlap = _dev._claims_overlap
+from . import dev_coordination as _dev
+from .dev_coordination.core import _claims_overlap
+from .dev_coordination.models import LeaseConflictError, LeaseStatus, WorkLease
+
 _json_dump = _dev._json_dump
 _json_loads = _dev._json_loads
 _normalize_claim = _dev._normalize_claim
@@ -17,9 +19,16 @@ _parse_dt = _dev._parse_dt
 _path_matches_glob = _dev._path_matches_glob
 _safe_kill_probe = _dev._safe_kill_probe
 _utcnow = _dev._utcnow
-sqlite3 = _dev.sqlite3
-timedelta = _dev.timedelta
-uuid = _dev.uuid
+
+
+def _fleet_claim_overlaps_requested_scope(
+    fleet_claim_path: str,
+    requested_globs: list[str],
+    requested_paths: list[str],
+) -> bool:
+    """Return whether an existing fleet path claim conflicts with a requested lease."""
+
+    return _claims_overlap([fleet_claim_path], requested_globs, requested_paths)
 
 
 def list_active_leases(self) -> list[WorkLease]:
@@ -251,7 +260,7 @@ def find_conflicting_leases(
         path = _normalize_claim(str(claim.get("path", "")))
         if not path:
             continue
-        if not _claims_overlap([path], normalized_globs, normalized_paths):
+        if not _fleet_claim_overlaps_requested_scope(path, normalized_globs, normalized_paths):
             continue
         conflicts.append(
             {
@@ -434,7 +443,7 @@ def _find_conflicting_leases_locked(
         path = _normalize_claim(str(claim.get("path", "")))
         if not path:
             continue
-        if not _claims_overlap([path], normalized_globs, normalized_paths):
+        if not _fleet_claim_overlaps_requested_scope(path, normalized_globs, normalized_paths):
             continue
         conflicts.append(
             {

--- a/tests/nomic/test_dev_coordination.py
+++ b/tests/nomic/test_dev_coordination.py
@@ -193,6 +193,53 @@ def test_claim_lease_detects_existing_fleet_claim(store: DevCoordinationStore) -
     assert exc_info.value.conflicts[0]["source"] == "fleet_claim"
 
 
+def test_claim_lease_detects_existing_fleet_claim_overlapping_allowed_glob(
+    store: DevCoordinationStore,
+) -> None:
+    store.fleet_store.claim_paths(
+        session_id="external-session",
+        paths=["aragora/server/auth_checks.py"],
+        branch="codex/external",
+    )
+
+    with pytest.raises(LeaseConflictError) as exc_info:
+        store.claim_lease(
+            task_id="clb-fleet-glob",
+            title="Server-wide auth hardening",
+            owner_agent="codex",
+            owner_session_id="sess-local",
+            branch="codex/local",
+            worktree_path="/tmp/wt-local",
+            allowed_globs=["aragora/server/**"],
+        )
+
+    conflict = exc_info.value.conflicts[0]
+    assert conflict["source"] == "fleet_claim"
+    assert conflict["path"] == "aragora/server/auth_checks.py"
+
+
+def test_claim_lease_allows_existing_fleet_claim_outside_allowed_glob(
+    store: DevCoordinationStore,
+) -> None:
+    store.fleet_store.claim_paths(
+        session_id="external-session",
+        paths=["aragora/server/auth_checks.py"],
+        branch="codex/external",
+    )
+
+    lease = store.claim_lease(
+        task_id="clb-fleet-disjoint-glob",
+        title="Frontend polish",
+        owner_agent="codex",
+        owner_session_id="sess-local",
+        branch="codex/local",
+        worktree_path="/tmp/wt-local",
+        allowed_globs=["aragora/live/src/**"],
+    )
+
+    assert lease.is_active is True
+
+
 def test_claim_lease_reaps_stale_fleet_claim_conflicts(store: DevCoordinationStore) -> None:
     store.fleet_store.claim_paths(
         session_id="external-session",


### PR DESCRIPTION
## Summary
- name the fleet-claim overlap direction used when checking standalone fleet path claims against a requested lease scope
- add regression coverage for an existing fleet path claim blocking a new overlapping glob lease
- keep disjoint fleet path claims allowed and preserve existing same-path conflict behavior

## Context
This unblocks the #8704 proof-surface refresh evidence lane, where exact-head Gemini review flagged the fleet-claim overlap call direction as a concrete P1. Current behavior was already correct for the checked cases; this patch makes that invariant explicit and covered.

## Validation
- `python3 -m pytest tests/nomic/test_dev_coordination.py -q`
- `python3 -m mypy aragora/nomic/dev_leases.py`
- `python3 scripts/report_code_quality.py --check`
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- pre-push hooks, including changed-file mypy
