### PR TITLE
fix(quorum): honor CLI reviewer timeout overrides

### DIFF
--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -1210,7 +1210,7 @@ def _resolve_grok_build_bin() -> str:
 
 
 def _run_argv_cli_reviewer(
-    family: str, argv: list[str], harness: str, timeout: float = _REVIEWER_TIMEOUT
+    family: str, argv: list[str], harness: str, timeout: float | None = None
 ) -> ReviewerResult:
     """Run a headless single-prompt CLI reviewer (prompt passed as an argv value).
 
@@ -1219,13 +1219,18 @@ def _run_argv_cli_reviewer(
     the review body. Same exact-head composition + evidence-lint as every other
     reviewer decides whether the result can count.
     """
+    effective_timeout = (
+        _timeout_seconds(_REVIEWER_TIMEOUT_ENV, _REVIEWER_TIMEOUT) if timeout is None else timeout
+    )
     try:
-        proc = subprocess.run(argv, capture_output=True, text=True, timeout=timeout, check=False)
+        proc = subprocess.run(
+            argv, capture_output=True, text=True, timeout=effective_timeout, check=False
+        )
     except FileNotFoundError:
         return ReviewerResult(family, "", False, f"{family} CLI not found: {argv[0]}")
     except subprocess.TimeoutExpired:
         return ReviewerResult(
-            family, "", False, f"{family} CLI timed out after {_format_seconds(timeout)}s"
+            family, "", False, f"{family} CLI timed out after {_format_seconds(effective_timeout)}s"
         )
     except (OSError, subprocess.SubprocessError) as exc:
         return ReviewerResult(family, "", False, f"{type(exc).__name__}: {str(exc)[:200]}")

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -5753,6 +5753,7 @@ class TestCommandDispatch:
                 "openai",
                 "--author",
                 "an0mium",
+                "--apply",
                 "--json",
             ]
         )
@@ -5761,7 +5762,7 @@ class TestCommandDispatch:
         assert ns_collect.pr == 6280
         assert ns_collect.reviewers == ["claude", "openai"]
         assert ns_collect.author == "an0mium"
-        assert ns_collect.apply is False
+        assert ns_collect.apply is True
         assert ns_collect.json_output is True
         # run invocation parses
         ns_run = root.parse_args(["review-queue", "run", "--limit", "3", "--ready-only"])

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -335,6 +335,52 @@ def test_run_claude_cli_uses_env_timeout(monkeypatch: pytest.MonkeyPatch) -> Non
     )
 
 
+def test_run_argv_cli_reviewer_uses_env_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, object] = {}
+
+    def fake_run(
+        argv: list[str],
+        *,
+        capture_output: bool,
+        text: bool,
+        timeout: float,
+        check: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        seen.update(
+            {
+                "argv": argv,
+                "capture_output": capture_output,
+                "text": text,
+                "timeout": timeout,
+                "check": check,
+            }
+        )
+        raise subprocess.TimeoutExpired(cmd=argv, timeout=timeout)
+
+    monkeypatch.setenv(qe._REVIEWER_TIMEOUT_ENV, "2.5")
+    monkeypatch.setattr(qe.subprocess, "run", fake_run)
+
+    result = qe._run_argv_cli_reviewer(
+        "grok",
+        ["grok", "--sandbox", "read-only", "-p", "review prompt"],
+        "Grok Build CLI harness",
+    )
+
+    assert seen == {
+        "argv": ["grok", "--sandbox", "read-only", "-p", "review prompt"],
+        "capture_output": True,
+        "text": True,
+        "timeout": 2.5,
+        "check": False,
+    }
+    assert result == ReviewerResult(
+        "grok",
+        "",
+        False,
+        "grok CLI timed out after 2.5s",
+    )
+
+
 def test_run_claude_cli_uses_file_backed_mcp_config(monkeypatch: pytest.MonkeyPatch) -> None:
     seen: dict[str, object] = {}
 


### PR DESCRIPTION
## Summary
- restack salvaged quorum evidence timeout override handling onto current origin/main
- preserve CLI reviewer timeout override behavior in quorum evidence collection
- add focused coverage for review-queue and quorum evidence timeout paths

## Validation
- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/cli/commands/test_review_queue.py tests/swarm/test_quorum_evidence.py -q -p no:cacheprovider
- python3 -m ruff check aragora/swarm/quorum_evidence.py tests/cli/commands/test_review_queue.py tests/swarm/test_quorum_evidence.py
- python3 -m ruff format --check aragora/swarm/quorum_evidence.py tests/cli/commands/test_review_queue.py tests/swarm/test_quorum_evidence.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD