### PR TITLE
fix(review-queue): require verdict for model evidence

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3694,6 +3694,15 @@ def _lint_evidence_comment(
     identity = _resolve_model_review_identity(body)
     inferred_reviewer = identity.surface_reviewer_id
     lower = body.lower()
+    explicit_model_verdict = _explicit_model_review_verdict(body)
+    requires_explicit_model_verdict = any(
+        token in lower
+        for token in (
+            "independent model review",
+            "independent semantic review",
+            "model-family semantic signal",
+        )
+    )
 
     problems: list[str] = []
     if not body.strip():
@@ -3706,6 +3715,8 @@ def _lint_evidence_comment(
         problems.append("github_actions_author_not_counted")
     if negative_verdict:
         problems.append("blocking_or_negative_verdict")
+    if requires_explicit_model_verdict and explicit_model_verdict == "unknown":
+        problems.append("missing_explicit_model_review_verdict")
     if inferred_reviewer == "unknown_model_reviewer":
         problems.append("missing_known_model_reviewer_heading")
     for problem in identity.identity_problems:
@@ -3746,6 +3757,7 @@ def _lint_evidence_comment(
         "model_id": identity.model_id,
         "identity_source": identity.identity_source,
         "identity_problems": list(identity.identity_problems),
+        "evidence_verdict": explicit_model_verdict,
         "current_head_grounded": grounded,
         "current_head_grounding_method": grounding_method,
         "current_pr_grounded": pr_grounded,
@@ -3754,9 +3766,24 @@ def _lint_evidence_comment(
         "reviewer_signals": reviewer_signals,
         "counted_reviewer_ids": counted_reviewer_ids,
         "counted_model_families": counted_reviewer_ids,
-        "would_count": bool(counted_reviewer_ids),
+        "would_count": bool(counted_reviewer_ids) and not problems,
         "problems": problems,
     }
+
+
+def _explicit_model_review_verdict(body: str) -> str:
+    """Return the explicit reviewer verdict used to count model-review evidence."""
+    for line in body.splitlines():
+        probe = line.strip().lstrip("*#>-`0123456789.)\t ").lower()
+        if not probe.startswith("verdict:"):
+            continue
+        verdict = probe.split(":", 1)[1].strip().lstrip("*`# \t")
+        if verdict.startswith("pass"):
+            return "pass"
+        if verdict.startswith("changes-requested") or verdict.startswith("changes requested"):
+            return "changes_requested"
+        return "unknown"
+    return "unknown"
 
 
 def _proposed_evidence_pr_grounding(body: str, pr: str) -> tuple[bool, str]:

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -5922,6 +5922,40 @@ class TestCommandDispatch:
         assert payload["current_head_grounding_method"] == "head_sha_citation"
         assert payload["problems"] == []
 
+    def test_evidence_lint_rejects_model_review_without_explicit_verdict(self) -> None:
+        ns = argparse.Namespace(
+            review_queue_command="evidence-lint",
+            pr="8707",
+            head_sha="515c145ddd6e679042e37862dde84b3a1b06586f",
+            head_committed_at="2026-06-30T02:15:14Z",
+            body=(
+                "## Grok independent model review\n\n"
+                "Reviewer: grok (xai) - independent adversarial model review via Grok "
+                "Build CLI harness, grounded on the exact PR head.\n"
+                "Head: 515c145 (515c145ddd6e679042e37862dde84b3a1b06586f), "
+                "committed 2026-06-30T02:15:14Z.\n"
+                "PR: #8707.\n"
+                "Model family: grok\n\n"
+                "Reviewing the PR diff in context: tracing `_claims_overlap`, "
+                "fleet-claim conflict detection, and the new tests.\n\n"
+                "dogfood: yes\n"
+            ),
+            body_file=None,
+            author="an0mium",
+            json=True,
+        )
+
+        out = io.StringIO()
+        with redirect_stdout(out):
+            rc = cmd_review_queue(ns)
+
+        payload = json.loads(out.getvalue())
+        assert rc == 1
+        assert payload["would_count"] is False
+        assert payload["evidence_verdict"] == "unknown"
+        assert payload["counted_reviewer_ids"] == ["grok"]
+        assert "missing_explicit_model_review_verdict" in payload["problems"]
+
     def test_evidence_lint_rejects_github_actions_bot_author(self) -> None:
         ns = argparse.Namespace(
             review_queue_command="evidence-lint",


### PR DESCRIPTION
## Summary
- require an explicit `Verdict:` line for model-review evidence bodies before evidence-lint can count them
- report the parsed model-review verdict in evidence-lint JSON output
- make `would_count` false whenever lint problems are present

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/cli/commands/test_review_queue.py -q -p no:cacheprovider` (293 passed)
- `python3 -m ruff check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py`
- `python3 -m ruff format --check aragora/cli/commands/review_queue.py tests/cli/commands/test_review_queue.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Notes
- Opened as draft for normal Aragora gate progression.
- No merge, evidence collection, settlement, or CI rerun was performed by this lane.