### PR TITLE
fix(settle-one): retry transient merge-packet transport

### DIFF
--- a/scripts/settle_one_pr.py
+++ b/scripts/settle_one_pr.py
@@ -199,6 +199,32 @@ def _merge_packet_failure_message(result: dict[str, Any]) -> str:
     return stderr or stdout or "merge-packet failed"
 
 
+def _merge_packet_transport_blocked(result: dict[str, Any]) -> bool:
+    stdout = str(result.get("stdout") or "").strip()
+    stderr = str(result.get("stderr") or "").strip()
+    if stdout:
+        try:
+            payload = json.loads(stdout)
+        except json.JSONDecodeError:
+            payload = None
+        if isinstance(payload, dict) and (
+            payload.get("transport_blocked")
+            or payload.get("status") == "transport_blocked"
+            or payload.get("error_kind") == "github_transport"
+        ):
+            return True
+    combined = f"{stderr}\n{stdout}".lower()
+    return any(
+        marker in combined
+        for marker in (
+            "error connecting to api.github.com",
+            "api rate limit",
+            "github transport",
+            "transport blocked",
+        )
+    )
+
+
 def _policy_context_for_report(policy_context: dict[str, Any]) -> dict[str, Any]:
     if not policy_context:
         return {}
@@ -1889,6 +1915,19 @@ def _load_single_pr_packet(*, cwd: Path, pr: int, repo: str | None) -> dict[str,
     if repo:
         command.extend(["--repo", repo])
     payload, result = _run_json(command, cwd=cwd, timeout=SINGLE_PACKET_TIMEOUT_SECONDS)
+    if result["returncode"] != 0 and _merge_packet_transport_blocked(result):
+        first_failure = _merge_packet_failure_message(result)
+        payload, result = _run_json(command, cwd=cwd, timeout=SINGLE_PACKET_TIMEOUT_SECONDS)
+        if result["returncode"] == 0 and isinstance(payload, dict):
+            warnings = [
+                str(item) for item in payload.get("load_warnings") or [] if str(item).strip()
+            ]
+            warnings.append(f"single merge-packet transport retry succeeded after: {first_failure}")
+            payload["load_warnings"] = warnings
+            return payload
+        if result["returncode"] != 0:
+            retry_failure = _merge_packet_failure_message(result)
+            raise RuntimeError(f"{retry_failure} (retry after: {first_failure})")
     if result["returncode"] != 0:
         raise RuntimeError(_merge_packet_failure_message(result))
     if not isinstance(payload, dict):

--- a/tests/scripts/test_settle_one_pr.py
+++ b/tests/scripts/test_settle_one_pr.py
@@ -196,9 +196,79 @@ def test_load_single_pr_packet_summarizes_transport_envelope(monkeypatch) -> Non
 
     assert message == (
         "merge-packet transport blocked: "
-        "gh pr view 7841 failed: GraphQL: API rate limit already exceeded"
+        "gh pr view 7841 failed: GraphQL: API rate limit already exceeded "
+        "(retry after: merge-packet transport blocked: "
+        "gh pr view 7841 failed: GraphQL: API rate limit already exceeded)"
     )
     assert "transport_blocked" not in message
+
+
+def test_load_single_pr_packet_retries_transient_transport_envelope(monkeypatch) -> None:
+    calls: list[list[str]] = []
+    packet_error = {
+        "status": "transport_blocked",
+        "transport_blocked": True,
+        "error_kind": "github_transport",
+        "error": "gh api repos/synaptent/aragora/pulls/8707 failed: error connecting to api.github.com",
+    }
+
+    def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
+        del cwd, timeout
+        calls.append(args)
+        if len(calls) == 1:
+            return None, {
+                "command": "packet",
+                "returncode": 1,
+                "stdout": json.dumps(packet_error),
+                "stderr": "",
+            }
+        return _packet(_entry(8707)), {"command": "packet", "returncode": 0}
+
+    monkeypatch.setattr(settle_one_pr, "_run_json", fake_run_json)
+
+    packet = settle_one_pr._load_single_pr_packet(cwd=Path.cwd(), pr=8707, repo=None)
+
+    assert packet["entries"][0]["pr_number"] == 8707
+    assert len(calls) == 2
+    assert packet["load_warnings"] == [
+        "single merge-packet transport retry succeeded after: "
+        "merge-packet transport blocked: gh api repos/synaptent/aragora/pulls/8707 "
+        "failed: error connecting to api.github.com"
+    ]
+
+
+def test_load_single_pr_packet_fails_closed_after_transport_retry(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run_json(args: list[str], *, cwd: Path, timeout: int = 120):
+        del cwd, timeout
+        calls.append(args)
+        return None, {
+            "command": "packet",
+            "returncode": 1,
+            "stdout": json.dumps(
+                {
+                    "status": "transport_blocked",
+                    "transport_blocked": True,
+                    "error_kind": "github_transport",
+                    "error": "gh api repos/synaptent/aragora/pulls/8704 failed: error connecting to api.github.com",
+                }
+            ),
+            "stderr": "",
+        }
+
+    monkeypatch.setattr(settle_one_pr, "_run_json", fake_run_json)
+
+    try:
+        settle_one_pr._load_single_pr_packet(cwd=Path.cwd(), pr=8704, repo=None)
+    except RuntimeError as exc:
+        message = str(exc)
+    else:  # pragma: no cover - the assertion below is clearer than pytest.raises here.
+        raise AssertionError("expected RuntimeError")
+
+    assert len(calls) == 2
+    assert "retry after: merge-packet transport blocked" in message
+    assert "error connecting to api.github.com" in message
 
 
 def test_select_candidate_prefers_admin_order() -> None:


### PR DESCRIPTION
## Summary

- Retries the exact single-PR `review-queue merge-packet --pr` command once when it returns a GitHub transport-blocked envelope.
- Preserves fail-closed behavior: no synthetic merge authorization is created, and a second failure still blocks with both retry and first-failure diagnostics.
- Adds focused tests for transient transport recovery and retry exhaustion.

## Live Context

This came from repeated conveyor blockers where direct `gh api`, `gh pr checks`, and `review-queue merge-packet --pr` surfaces were readable outside `settle_one_pr.py`, while `settle_one_pr.py` failed closed with an internal `gh api repos/synaptent/aragora/pulls/<PR>` transport error.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_settle_one_pr.py` -> 72 passed
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/settle_one_pr.py tests/scripts/test_settle_one_pr.py` -> passed
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/settle_one_pr.py tests/scripts/test_settle_one_pr.py` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> passed
- Push hooks passed, including changed-file mypy.
