### PR TITLE
Add value-preserving queue disposition manifest

### DIFF
--- a/aragora/swarm/queue_disposition.py
+++ b/aragora/swarm/queue_disposition.py
@@ -422,15 +422,29 @@ def build_manifest(
     """Build the complete disposition manifest payload."""
     if now is None:
         now = datetime.now(timezone.utc)
+    merge_packets_not_collected = merge_packet_entries is None
     merge_packet_entries = merge_packet_entries or {}
+    manifest_annotations = list(annotations or [])
     items: list[dict[str, Any]] = []
+    pr_numbers: set[int] = set()
+    pr_branches: set[str] = set()
+    pr_heads: set[str] = set()
     for pr in prs:
         if not isinstance(pr, dict):
             continue
         number = _coerce_optional_pr_number(pr.get("number"))
+        if number is not None:
+            pr_numbers.add(number)
+        if branch := _branch(pr):
+            pr_branches.add(branch)
+        if head := _head(pr):
+            pr_heads.add(head)
+        pr_record = dict(pr)
+        if merge_packets_not_collected:
+            pr_record["_merge_packet_error"] = "merge_packet_not_collected"
         items.append(
             classify_pr_disposition(
-                pr,
+                pr_record,
                 merge_packet_entry=merge_packet_entries.get(number) if number is not None else None,
                 now=now,
                 stale_days=stale_days,
@@ -438,7 +452,17 @@ def build_manifest(
         )
     for candidate in inventory_candidates or []:
         if isinstance(candidate, dict):
-            items.append(classify_inventory_candidate(candidate))
+            item = classify_inventory_candidate(candidate)
+            if (
+                item["open_pr"] in pr_numbers
+                or bool(item["branch"] and item["branch"] in pr_branches)
+                or bool(item["head_sha"] and item["head_sha"] in pr_heads)
+            ):
+                manifest_annotations.append(
+                    f"inventory_duplicate_skipped:{item['item_type']}:{item['id']}"
+                )
+                continue
+            items.append(item)
 
     by_disposition = {name: 0 for name in DISPOSITIONS}
     by_value_class: dict[str, int] = {}
@@ -450,7 +474,7 @@ def build_manifest(
         "schema_version": "aragora.queue_disposition_manifest.v1",
         "generated_at": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
         "policy": "value_of_information_preserve_first",
-        "annotations": list(annotations or []),
+        "annotations": manifest_annotations,
         "summary": {
             "total_items": len(items),
             "by_disposition": by_disposition,

--- a/aragora/swarm/queue_disposition.py
+++ b/aragora/swarm/queue_disposition.py
@@ -7,6 +7,7 @@ deleted after a recovery manifest exists. It is intentionally conservative.
 
 from __future__ import annotations
 
+import re
 from datetime import datetime, timezone
 from typing import Any
 
@@ -69,7 +70,18 @@ def _coerce_int(value: Any, default: int = 0) -> int:
 
 
 def _coerce_bool(value: Any) -> bool:
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "y", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "n", "off", ""}:
+            return False
     return bool(value)
+
+
+def _coerce_optional_pr_number(value: Any) -> int | None:
+    number = _coerce_int(value)
+    return number if number > 0 else None
 
 
 def _title(record: dict[str, Any]) -> str:
@@ -110,18 +122,22 @@ def _is_parked_epic(record: dict[str, Any]) -> bool:
     return title.startswith(PARKED_PREFIXES) or "vision-layer" in labels
 
 
+def _contains_term(text: str, term: str) -> bool:
+    return re.search(rf"(?<![a-z0-9]){re.escape(term)}(?![a-z0-9])", text) is not None
+
+
 def _has_high_value_signal(record: dict[str, Any], value_class: str) -> bool:
     if value_class == CLASS_PRODUCT or _is_parked_epic(record):
         return True
     title = _title(record).lower()
-    return any(term in title for term in HIGH_VALUE_TERMS)
+    return any(_contains_term(title, term) for term in HIGH_VALUE_TERMS)
 
 
 def _has_high_risk_signal(
     record: dict[str, Any], merge_packet_entry: dict[str, Any] | None
 ) -> bool:
     title = _title(record).lower()
-    if any(term in title for term in HIGH_RISK_TERMS):
+    if any(_contains_term(title, term) for term in HIGH_RISK_TERMS):
         return True
     if not merge_packet_entry:
         return False
@@ -192,7 +208,10 @@ def classify_pr_disposition(
     """Classify one open PR into a value-preserving disposition."""
     if now is None:
         now = datetime.now(timezone.utc)
-    number = _coerce_int(record.get("number"))
+    number = _coerce_optional_pr_number(record.get("number"))
+    item_id = str(
+        number or record.get("number") or _branch(record) or _head(record) or "unknown-pr"
+    )
     value_class = classify_value_record(record)
     cost = estimate_evaluation_cost(record)
     title = _title(record)
@@ -205,6 +224,7 @@ def classify_pr_disposition(
     high_risk = _has_high_risk_signal(record, merge_packet_entry)
     unresolved_dissent = _coerce_bool((merge_packet_entry or {}).get("unresolved_dissent"))
     low_expected_value = value_class in {CLASS_MAINTENANCE, CLASS_INFRA} and not high_value
+    merge_packet_error = str(record.get("_merge_packet_error") or "")
 
     evidence = [
         f"title={title}",
@@ -221,12 +241,29 @@ def classify_pr_disposition(
         evidence.append("high_risk_or_human_settlement_signal=true")
     if unresolved_dissent:
         evidence.append("model_dissent_present_but_not_value_proof")
+    if merge_packet_error:
+        evidence.append(f"merge_packet.error={merge_packet_error}")
     evidence.extend(_merge_packet_evidence(merge_packet_entry))
+
+    if merge_packet_error:
+        return _base_item(
+            item_type="pr",
+            item_id=item_id,
+            branch=branch,
+            head_sha=head_sha,
+            open_pr=number,
+            value_class=value_class,
+            evaluation_cost=cost,
+            evidence=evidence,
+            disposition=DISPOSITION_PARK_PRESERVE,
+            next_action="preserve; rerun merge-packet before assigning harvest or close/delete",
+            operator_required=True,
+        )
 
     if high_risk and not is_draft:
         return _base_item(
             item_type="pr",
-            item_id=str(number),
+            item_id=item_id,
             branch=branch,
             head_sha=head_sha,
             open_pr=number,
@@ -241,7 +278,7 @@ def classify_pr_disposition(
     if high_value and unresolved_dissent:
         return _base_item(
             item_type="pr",
-            item_id=str(number),
+            item_id=item_id,
             branch=branch,
             head_sha=head_sha,
             open_pr=number,
@@ -250,13 +287,13 @@ def classify_pr_disposition(
             evidence=evidence,
             disposition=DISPOSITION_PARK_PRESERVE,
             next_action="preserve; repair or adjudicate dissent, never close solely for dissent",
-            operator_required=False,
+            operator_required=high_risk,
         )
 
-    if high_value and not is_draft and mergeable != "CONFLICTING":
+    if high_value and not is_draft and mergeable == "MERGEABLE":
         return _base_item(
             item_type="pr",
-            item_id=str(number),
+            item_id=item_id,
             branch=branch,
             head_sha=head_sha,
             open_pr=number,
@@ -271,7 +308,7 @@ def classify_pr_disposition(
     if _is_parked_epic(record) or high_value or (is_draft and high_risk):
         return _base_item(
             item_type="pr",
-            item_id=str(number),
+            item_id=item_id,
             branch=branch,
             head_sha=head_sha,
             open_pr=number,
@@ -286,7 +323,7 @@ def classify_pr_disposition(
     if low_expected_value and (is_draft or stale or mergeable == "CONFLICTING"):
         return _base_item(
             item_type="pr",
-            item_id=str(number),
+            item_id=item_id,
             branch=branch,
             head_sha=head_sha,
             open_pr=number,
@@ -303,7 +340,7 @@ def classify_pr_disposition(
 
     return _base_item(
         item_type="pr",
-        item_id=str(number),
+        item_id=item_id,
         branch=branch,
         head_sha=head_sha,
         open_pr=number,
@@ -326,9 +363,13 @@ def classify_inventory_candidate(candidate: dict[str, Any]) -> dict[str, Any]:
     branch = str(git.get("branch") or candidate.get("branch") or "")
     head_sha = str(git.get("head") or candidate.get("head") or "")
     open_prs = links.get("open_prs") if isinstance(links.get("open_prs"), list) else []
-    open_pr = _coerce_int(open_prs[0], default=0) if open_prs else None
-    if open_pr == 0:
-        open_pr = None
+    open_pr = None
+    if open_prs:
+        first_pr = open_prs[0]
+        if isinstance(first_pr, dict):
+            open_pr = _coerce_optional_pr_number(first_pr.get("number"))
+        else:
+            open_pr = _coerce_optional_pr_number(first_pr)
     path = str(candidate.get("path") or "")
     item_id = str(candidate.get("candidate_id") or path or branch or head_sha)
     evidence = [
@@ -386,11 +427,11 @@ def build_manifest(
     for pr in prs:
         if not isinstance(pr, dict):
             continue
-        number = _coerce_int(pr.get("number"))
+        number = _coerce_optional_pr_number(pr.get("number"))
         items.append(
             classify_pr_disposition(
                 pr,
-                merge_packet_entry=merge_packet_entries.get(number),
+                merge_packet_entry=merge_packet_entries.get(number) if number is not None else None,
                 now=now,
                 stale_days=stale_days,
             )

--- a/aragora/swarm/queue_disposition.py
+++ b/aragora/swarm/queue_disposition.py
@@ -1,0 +1,420 @@
+"""Value-preserving queue disposition rules.
+
+The manifest produced from these helpers is a pre-cleanup artifact: it records
+why each queue item should be harvested, human-routed, parked, or only closed /
+deleted after a recovery manifest exists. It is intentionally conservative.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from aragora.swarm.pr_value import (
+    CLASS_INFRA,
+    CLASS_MAINTENANCE,
+    CLASS_PRODUCT,
+    CLASS_UNKNOWN,
+    classify_value_record,
+    label_names,
+    parse_iso_datetime,
+)
+
+DISPOSITION_HARVEST_NOW = "harvest_now"
+DISPOSITION_HUMAN_PACKET = "human_packet"
+DISPOSITION_PARK_PRESERVE = "park_preserve"
+DISPOSITION_CLOSE_OR_DELETE = "close_or_delete_after_manifest"
+DISPOSITIONS = (
+    DISPOSITION_HARVEST_NOW,
+    DISPOSITION_HUMAN_PACKET,
+    DISPOSITION_PARK_PRESERVE,
+    DISPOSITION_CLOSE_OR_DELETE,
+)
+
+EVALUATION_LOW = "low"
+EVALUATION_MEDIUM = "medium"
+EVALUATION_HIGH = "high"
+
+PARKED_PREFIXES = ("[AGT-", "[DIC-")
+HIGH_VALUE_TERMS = (
+    "odr",
+    "crux",
+    "receipt",
+    "api",
+    "sdk",
+    "routing",
+    "goals",
+    "gauntlet",
+    "server",
+    "inbox",
+    "decision",
+)
+HIGH_RISK_TERMS = (
+    "crypto",
+    "signing",
+    "rbac",
+    "security",
+    "tier4",
+    "workflow",
+    "deploy",
+    "public api",
+)
+
+
+def _coerce_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_bool(value: Any) -> bool:
+    return bool(value)
+
+
+def _title(record: dict[str, Any]) -> str:
+    return str(record.get("title") or "")
+
+
+def _branch(record: dict[str, Any]) -> str:
+    return str(record.get("headRefName") or record.get("branch") or "")
+
+
+def _head(record: dict[str, Any]) -> str:
+    return str(record.get("headRefOid") or record.get("head") or record.get("head_sha") or "")
+
+
+def _is_stale(record: dict[str, Any], *, now: datetime, stale_days: int) -> bool:
+    created = parse_iso_datetime(record.get("createdAt") or record.get("created_at"))
+    if created is None:
+        return False
+    return (now - created).days >= stale_days
+
+
+def estimate_evaluation_cost(record: dict[str, Any]) -> str:
+    """Estimate the cheapness of deciding whether an item has value."""
+    changed_files = _coerce_int(record.get("changedFiles") or record.get("changed_files"))
+    additions = _coerce_int(record.get("additions"))
+    deletions = _coerce_int(record.get("deletions"))
+    total_delta = additions + deletions
+    if changed_files <= 3 and total_delta <= 500:
+        return EVALUATION_LOW
+    if changed_files <= 20 and total_delta <= 2000:
+        return EVALUATION_MEDIUM
+    return EVALUATION_HIGH
+
+
+def _is_parked_epic(record: dict[str, Any]) -> bool:
+    title = _title(record).strip().upper()
+    labels = label_names(record)
+    return title.startswith(PARKED_PREFIXES) or "vision-layer" in labels
+
+
+def _has_high_value_signal(record: dict[str, Any], value_class: str) -> bool:
+    if value_class == CLASS_PRODUCT or _is_parked_epic(record):
+        return True
+    title = _title(record).lower()
+    return any(term in title for term in HIGH_VALUE_TERMS)
+
+
+def _has_high_risk_signal(
+    record: dict[str, Any], merge_packet_entry: dict[str, Any] | None
+) -> bool:
+    title = _title(record).lower()
+    if any(term in title for term in HIGH_RISK_TERMS):
+        return True
+    if not merge_packet_entry:
+        return False
+    tier = _coerce_int(merge_packet_entry.get("tier"), default=-1)
+    return (
+        tier >= 3
+        or _coerce_bool(merge_packet_entry.get("requires_human_risk_settlement"))
+        or _coerce_bool(merge_packet_entry.get("requires_human_preapproval"))
+    )
+
+
+def _merge_packet_evidence(entry: dict[str, Any] | None) -> list[str]:
+    if not entry:
+        return []
+    evidence = []
+    for key in (
+        "tier",
+        "tier_name",
+        "status",
+        "verdict",
+        "checks_summary",
+        "admin_squash_allowed",
+        "requires_human_risk_settlement",
+        "requires_human_preapproval",
+        "unresolved_dissent",
+    ):
+        if key in entry:
+            evidence.append(f"merge_packet.{key}={entry[key]}")
+    return evidence
+
+
+def _base_item(
+    *,
+    item_type: str,
+    item_id: str,
+    branch: str,
+    head_sha: str,
+    open_pr: int | None,
+    value_class: str,
+    evaluation_cost: str,
+    evidence: list[str],
+    disposition: str,
+    next_action: str,
+    operator_required: bool,
+) -> dict[str, Any]:
+    return {
+        "item_type": item_type,
+        "id": item_id,
+        "branch": branch,
+        "head_sha": head_sha,
+        "open_pr": open_pr,
+        "value_class": value_class,
+        "evaluation_cost": evaluation_cost,
+        "evidence": evidence,
+        "disposition": disposition,
+        "next_action": next_action,
+        "operator_required": operator_required,
+    }
+
+
+def classify_pr_disposition(
+    record: dict[str, Any],
+    *,
+    merge_packet_entry: dict[str, Any] | None = None,
+    now: datetime | None = None,
+    stale_days: int = 14,
+) -> dict[str, Any]:
+    """Classify one open PR into a value-preserving disposition."""
+    if now is None:
+        now = datetime.now(timezone.utc)
+    number = _coerce_int(record.get("number"))
+    value_class = classify_value_record(record)
+    cost = estimate_evaluation_cost(record)
+    title = _title(record)
+    branch = _branch(record)
+    head_sha = _head(record)
+    is_draft = _coerce_bool(record.get("isDraft"))
+    mergeable = str(record.get("mergeable") or "").upper()
+    stale = _is_stale(record, now=now, stale_days=stale_days)
+    high_value = _has_high_value_signal(record, value_class)
+    high_risk = _has_high_risk_signal(record, merge_packet_entry)
+    unresolved_dissent = _coerce_bool((merge_packet_entry or {}).get("unresolved_dissent"))
+    low_expected_value = value_class in {CLASS_MAINTENANCE, CLASS_INFRA} and not high_value
+
+    evidence = [
+        f"title={title}",
+        f"value_class={value_class}",
+        f"evaluation_cost={cost}",
+        f"isDraft={is_draft}",
+        f"mergeable={mergeable or 'unknown'}",
+    ]
+    if stale:
+        evidence.append(f"stale_days>={stale_days}")
+    if high_value:
+        evidence.append("high_value_signal=true")
+    if high_risk:
+        evidence.append("high_risk_or_human_settlement_signal=true")
+    if unresolved_dissent:
+        evidence.append("model_dissent_present_but_not_value_proof")
+    evidence.extend(_merge_packet_evidence(merge_packet_entry))
+
+    if high_risk and not is_draft:
+        return _base_item(
+            item_type="pr",
+            item_id=str(number),
+            branch=branch,
+            head_sha=head_sha,
+            open_pr=number,
+            value_class=value_class,
+            evaluation_cost=cost,
+            evidence=evidence,
+            disposition=DISPOSITION_HUMAN_PACKET,
+            next_action="prepare exact-head human-risk packet; do not close as churn",
+            operator_required=True,
+        )
+
+    if high_value and unresolved_dissent:
+        return _base_item(
+            item_type="pr",
+            item_id=str(number),
+            branch=branch,
+            head_sha=head_sha,
+            open_pr=number,
+            value_class=value_class,
+            evaluation_cost=cost,
+            evidence=evidence,
+            disposition=DISPOSITION_PARK_PRESERVE,
+            next_action="preserve; repair or adjudicate dissent, never close solely for dissent",
+            operator_required=False,
+        )
+
+    if high_value and not is_draft and mergeable != "CONFLICTING":
+        return _base_item(
+            item_type="pr",
+            item_id=str(number),
+            branch=branch,
+            head_sha=head_sha,
+            open_pr=number,
+            value_class=value_class,
+            evaluation_cost=cost,
+            evidence=evidence,
+            disposition=DISPOSITION_HARVEST_NOW,
+            next_action="run one exact-head evidence/merge-packet attempt or settle if already green",
+            operator_required=False,
+        )
+
+    if _is_parked_epic(record) or high_value or (is_draft and high_risk):
+        return _base_item(
+            item_type="pr",
+            item_id=str(number),
+            branch=branch,
+            head_sha=head_sha,
+            open_pr=number,
+            value_class=value_class,
+            evaluation_cost=cost,
+            evidence=evidence,
+            disposition=DISPOSITION_PARK_PRESERVE,
+            next_action="preserve parked/high-risk value until a cheap content pass proves duplicate",
+            operator_required=high_risk,
+        )
+
+    if low_expected_value and (is_draft or stale or mergeable == "CONFLICTING"):
+        return _base_item(
+            item_type="pr",
+            item_id=str(number),
+            branch=branch,
+            head_sha=head_sha,
+            open_pr=number,
+            value_class=value_class,
+            evaluation_cost=cost,
+            evidence=evidence,
+            disposition=DISPOSITION_CLOSE_OR_DELETE,
+            next_action=(
+                "only close after live owner/steering, diffstat, and main-equivalence checks; "
+                "write reversible rationale"
+            ),
+            operator_required=True,
+        )
+
+    return _base_item(
+        item_type="pr",
+        item_id=str(number),
+        branch=branch,
+        head_sha=head_sha,
+        open_pr=number,
+        value_class=value_class or CLASS_UNKNOWN,
+        evaluation_cost=cost,
+        evidence=evidence,
+        disposition=DISPOSITION_PARK_PRESERVE,
+        next_action="preserve pending cheap content pass; value is not disproven",
+        operator_required=False,
+    )
+
+
+def classify_inventory_candidate(candidate: dict[str, Any]) -> dict[str, Any]:
+    """Classify one ``codex_worktree_value_inventory`` candidate."""
+    classification = str(candidate.get("classification") or "unknown")
+    raw_git = candidate.get("git")
+    git: dict[str, Any] = raw_git if isinstance(raw_git, dict) else {}
+    raw_links = candidate.get("links")
+    links: dict[str, Any] = raw_links if isinstance(raw_links, dict) else {}
+    branch = str(git.get("branch") or candidate.get("branch") or "")
+    head_sha = str(git.get("head") or candidate.get("head") or "")
+    open_prs = links.get("open_prs") if isinstance(links.get("open_prs"), list) else []
+    open_pr = _coerce_int(open_prs[0], default=0) if open_prs else None
+    if open_pr == 0:
+        open_pr = None
+    path = str(candidate.get("path") or "")
+    item_id = str(candidate.get("candidate_id") or path or branch or head_sha)
+    evidence = [
+        f"inventory.classification={classification}",
+        f"inventory.decision={candidate.get('decision')}",
+    ]
+    evidence.extend(str(item) for item in candidate.get("proof") or [])
+
+    if classification == "unique_unharvested":
+        disposition = DISPOSITION_HARVEST_NOW
+        next_action = "preserve and represent unique work on an open PR or durable branch"
+        operator_required = False
+    elif classification in {"active_or_dirty", "open_pr_or_outbox", "receipt_protected"}:
+        disposition = DISPOSITION_PARK_PRESERVE
+        next_action = "preserve; route to owner, open PR, outbox, or receipt before cleanup"
+        operator_required = False
+    elif classification in {"patch_equivalent_or_merged", "no_git_cache_residue"}:
+        disposition = DISPOSITION_CLOSE_OR_DELETE
+        next_action = "delete only after fresh safe_worktree_cleanup inspect and SHA/path manifest"
+        operator_required = True
+    else:
+        disposition = DISPOSITION_PARK_PRESERVE
+        next_action = "preserve pending cheap inventory/content pass"
+        operator_required = False
+
+    return _base_item(
+        item_type="worktree",
+        item_id=item_id,
+        branch=branch,
+        head_sha=head_sha,
+        open_pr=open_pr,
+        value_class=CLASS_UNKNOWN,
+        evaluation_cost=EVALUATION_MEDIUM,
+        evidence=evidence,
+        disposition=disposition,
+        next_action=next_action,
+        operator_required=operator_required,
+    )
+
+
+def build_manifest(
+    *,
+    prs: list[dict[str, Any]],
+    merge_packet_entries: dict[int, dict[str, Any]] | None = None,
+    inventory_candidates: list[dict[str, Any]] | None = None,
+    now: datetime | None = None,
+    stale_days: int = 14,
+    annotations: list[str] | None = None,
+) -> dict[str, Any]:
+    """Build the complete disposition manifest payload."""
+    if now is None:
+        now = datetime.now(timezone.utc)
+    merge_packet_entries = merge_packet_entries or {}
+    items: list[dict[str, Any]] = []
+    for pr in prs:
+        if not isinstance(pr, dict):
+            continue
+        number = _coerce_int(pr.get("number"))
+        items.append(
+            classify_pr_disposition(
+                pr,
+                merge_packet_entry=merge_packet_entries.get(number),
+                now=now,
+                stale_days=stale_days,
+            )
+        )
+    for candidate in inventory_candidates or []:
+        if isinstance(candidate, dict):
+            items.append(classify_inventory_candidate(candidate))
+
+    by_disposition = {name: 0 for name in DISPOSITIONS}
+    by_value_class: dict[str, int] = {}
+    for item in items:
+        by_disposition[item["disposition"]] = by_disposition.get(item["disposition"], 0) + 1
+        by_value_class[item["value_class"]] = by_value_class.get(item["value_class"], 0) + 1
+
+    return {
+        "schema_version": "aragora.queue_disposition_manifest.v1",
+        "generated_at": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "policy": "value_of_information_preserve_first",
+        "annotations": list(annotations or []),
+        "summary": {
+            "total_items": len(items),
+            "by_disposition": by_disposition,
+            "by_value_class": by_value_class,
+            "operator_required": sum(1 for item in items if item["operator_required"]),
+        },
+        "items": items,
+    }

--- a/aragora/swarm/queue_disposition.py
+++ b/aragora/swarm/queue_disposition.py
@@ -69,13 +69,20 @@ def _coerce_int(value: Any, default: int = 0) -> int:
         return default
 
 
-def _coerce_bool(value: Any) -> bool:
+def _coerce_bool(
+    value: Any, *, default: bool = False, unknown_string_default: bool | None = None
+) -> bool:
     if isinstance(value, str):
         normalized = value.strip().lower()
         if normalized in {"1", "true", "yes", "y", "on"}:
             return True
         if normalized in {"0", "false", "no", "n", "off", ""}:
             return False
+        if unknown_string_default is not None:
+            return unknown_string_default
+        return default
+    if value is None:
+        return default
     return bool(value)
 
 
@@ -97,10 +104,15 @@ def _head(record: dict[str, Any]) -> str:
 
 
 def _is_stale(record: dict[str, Any], *, now: datetime, stale_days: int) -> bool:
-    created = parse_iso_datetime(record.get("createdAt") or record.get("created_at"))
-    if created is None:
+    activity = parse_iso_datetime(
+        record.get("updatedAt")
+        or record.get("updated_at")
+        or record.get("createdAt")
+        or record.get("created_at")
+    )
+    if activity is None:
         return False
-    return (now - created).days >= stale_days
+    return (now - activity).days >= stale_days
 
 
 def estimate_evaluation_cost(record: dict[str, Any]) -> str:
@@ -144,8 +156,13 @@ def _has_high_risk_signal(
     tier = _coerce_int(merge_packet_entry.get("tier"), default=-1)
     return (
         tier >= 3
-        or _coerce_bool(merge_packet_entry.get("requires_human_risk_settlement"))
-        or _coerce_bool(merge_packet_entry.get("requires_human_preapproval"))
+        or _coerce_bool(
+            merge_packet_entry.get("requires_human_risk_settlement"),
+            unknown_string_default=True,
+        )
+        or _coerce_bool(
+            merge_packet_entry.get("requires_human_preapproval"), unknown_string_default=True
+        )
     )
 
 
@@ -217,12 +234,14 @@ def classify_pr_disposition(
     title = _title(record)
     branch = _branch(record)
     head_sha = _head(record)
-    is_draft = _coerce_bool(record.get("isDraft"))
+    is_draft = _coerce_bool(record.get("isDraft"), unknown_string_default=True)
     mergeable = str(record.get("mergeable") or "").upper()
     stale = _is_stale(record, now=now, stale_days=stale_days)
     high_value = _has_high_value_signal(record, value_class)
     high_risk = _has_high_risk_signal(record, merge_packet_entry)
-    unresolved_dissent = _coerce_bool((merge_packet_entry or {}).get("unresolved_dissent"))
+    unresolved_dissent = _coerce_bool(
+        (merge_packet_entry or {}).get("unresolved_dissent"), unknown_string_default=True
+    )
     low_expected_value = value_class in {CLASS_MAINTENANCE, CLASS_INFRA} and not high_value
     merge_packet_error = str(record.get("_merge_packet_error") or "")
 
@@ -244,6 +263,22 @@ def classify_pr_disposition(
     if merge_packet_error:
         evidence.append(f"merge_packet.error={merge_packet_error}")
     evidence.extend(_merge_packet_evidence(merge_packet_entry))
+
+    if number is None:
+        evidence.append("invalid_pr_identity=true")
+        return _base_item(
+            item_type="pr",
+            item_id=item_id,
+            branch=branch,
+            head_sha=head_sha,
+            open_pr=None,
+            value_class=value_class,
+            evaluation_cost=cost,
+            evidence=evidence,
+            disposition=DISPOSITION_PARK_PRESERVE,
+            next_action="preserve; PR number is missing or invalid, so merge-packet safety cannot be proven",
+            operator_required=True,
+        )
 
     if merge_packet_error:
         return _base_item(
@@ -379,9 +414,9 @@ def classify_inventory_candidate(candidate: dict[str, Any]) -> dict[str, Any]:
     evidence.extend(str(item) for item in candidate.get("proof") or [])
 
     if classification == "unique_unharvested":
-        disposition = DISPOSITION_HARVEST_NOW
+        disposition = DISPOSITION_PARK_PRESERVE
         next_action = "preserve and represent unique work on an open PR or durable branch"
-        operator_required = False
+        operator_required = True
     elif classification in {"active_or_dirty", "open_pr_or_outbox", "receipt_protected"}:
         disposition = DISPOSITION_PARK_PRESERVE
         next_action = "preserve; route to owner, open PR, outbox, or receipt before cleanup"

--- a/scripts/queue_disposition_manifest.py
+++ b/scripts/queue_disposition_manifest.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Build a value-preserving queue disposition manifest (READ-ONLY).
+
+This script is a coordination artifact for queue drain runs. It classifies open
+PRs and, optionally, worktree inventory candidates before any broad close/delete
+batch. It never mutates GitHub or git; the only optional write is ``--out``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from aragora.swarm.queue_disposition import build_manifest  # noqa: E402
+
+DEFAULT_REPO = "synaptent/aragora"
+DEFAULT_LIMIT = 300
+GH_TIMEOUT_SECONDS = 120
+MERGE_PACKET_TIMEOUT_SECONDS = 60
+INVENTORY_TIMEOUT_SECONDS = 300
+DEFAULT_MERGE_PACKET_WORKERS = 4
+
+EXIT_OK = 0
+EXIT_FAILURE = 1
+
+_GH_FIELDS = (
+    "number,title,labels,isDraft,createdAt,updatedAt,headRefName,headRefOid,"
+    "baseRefName,mergeable,reviewDecision,additions,deletions,changedFiles,author"
+)
+
+
+def atomic_write_json(path: str, payload: dict[str, Any]) -> None:
+    directory = os.path.dirname(path) or "."
+    os.makedirs(directory, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=f".{os.path.basename(path)}.", dir=directory)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh, indent=2, sort_keys=True)
+            fh.write("\n")
+        os.replace(tmp, path)
+    finally:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+
+
+def default_list_prs(repo: str, limit: int) -> list[dict[str, Any]]:
+    command = [
+        "gh",
+        "pr",
+        "list",
+        "--repo",
+        repo,
+        "--state",
+        "open",
+        "--json",
+        _GH_FIELDS,
+        "--limit",
+        str(limit),
+    ]
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        timeout=GH_TIMEOUT_SECONDS,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"gh pr list failed (exit {result.returncode}): {result.stderr.strip()}")
+    payload = json.loads(result.stdout or "[]")
+    if not isinstance(payload, list):
+        raise RuntimeError("gh pr list returned unexpected payload (expected a list)")
+    return payload
+
+
+def default_merge_packet(pr: int) -> dict[str, Any]:
+    command = [
+        sys.executable,
+        "-m",
+        "aragora.cli.main",
+        "review-queue",
+        "merge-packet",
+        "--pr",
+        str(pr),
+        "--json",
+    ]
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        timeout=MERGE_PACKET_TIMEOUT_SECONDS,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"merge-packet failed for PR #{pr} (exit {result.returncode}): {result.stderr.strip()}"
+        )
+    payload = json.loads(result.stdout or "{}")
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"merge-packet returned unexpected payload for PR #{pr}")
+    entries = payload.get("entries")
+    if not isinstance(entries, list) or not entries:
+        return {}
+    entry = entries[0]
+    return entry if isinstance(entry, dict) else {}
+
+
+def default_inventory_candidates() -> list[dict[str, Any]]:
+    command = [
+        sys.executable,
+        str(REPO_ROOT / "scripts" / "codex_worktree_value_inventory.py"),
+        "--json",
+        "--dry-run",
+        "--include-pr-state",
+        "--smart-merge-detection",
+        "--size-mode",
+        "none",
+    ]
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        timeout=INVENTORY_TIMEOUT_SECONDS,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            "codex_worktree_value_inventory failed "
+            f"(exit {result.returncode}): {result.stderr.strip()}"
+        )
+    payload = json.loads(result.stdout or "{}")
+    candidates = payload.get("candidates") if isinstance(payload, dict) else None
+    if not isinstance(candidates, list):
+        raise RuntimeError("inventory returned unexpected payload (missing candidates list)")
+    return [candidate for candidate in candidates if isinstance(candidate, dict)]
+
+
+def _merge_packet_failure_annotation(number: int, exc: BaseException) -> str:
+    return f"merge_packet_failed:#{number}:{str(exc)[:200]}"
+
+
+def collect_merge_packets(
+    prs: list[dict[str, Any]],
+    merge_packet: Callable[[int], dict[str, Any]],
+    *,
+    workers: int,
+    annotations: list[str],
+) -> dict[int, dict[str, Any]]:
+    """Collect per-PR merge packets with bounded read-only parallelism."""
+    numbers = [pr["number"] for pr in prs if isinstance(pr.get("number"), int)]
+    merge_entries: dict[int, dict[str, Any]] = {}
+    if not numbers:
+        return merge_entries
+    workers = max(1, min(workers, len(numbers)))
+    if workers == 1:
+        for number in numbers:
+            try:
+                entry = merge_packet(number)
+            except (RuntimeError, OSError, ValueError, subprocess.SubprocessError) as exc:
+                annotations.append(_merge_packet_failure_annotation(number, exc))
+                continue
+            if entry:
+                merge_entries[number] = entry
+        return merge_entries
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = {executor.submit(merge_packet, number): number for number in numbers}
+        for future in as_completed(futures):
+            number = futures[future]
+            try:
+                entry = future.result()
+            except (RuntimeError, OSError, ValueError, subprocess.SubprocessError) as exc:
+                annotations.append(_merge_packet_failure_annotation(number, exc))
+                continue
+            if entry:
+                merge_entries[number] = entry
+    return merge_entries
+
+
+def run_manifest(
+    *,
+    list_prs: Callable[[], list[dict[str, Any]]],
+    merge_packet: Callable[[int], dict[str, Any]] | None = None,
+    merge_packet_workers: int = DEFAULT_MERGE_PACKET_WORKERS,
+    inventory_candidates: Callable[[], list[dict[str, Any]]] | None = None,
+    limit: int = DEFAULT_LIMIT,
+    stale_days: int = 14,
+    out_file: str | None = None,
+    summary: bool = False,
+    now: datetime | None = None,
+    log: Callable[[str], None] = print,
+) -> int:
+    if now is None:
+        now = datetime.now(timezone.utc)
+    annotations: list[str] = []
+    try:
+        prs = [pr for pr in list_prs() if isinstance(pr, dict)]
+        if len(prs) >= limit:
+            annotations.append(f"list_truncated:>={limit}")
+
+        merge_entries: dict[int, dict[str, Any]] = {}
+        if merge_packet is not None:
+            merge_entries = collect_merge_packets(
+                prs,
+                merge_packet,
+                workers=merge_packet_workers,
+                annotations=annotations,
+            )
+
+        candidates = inventory_candidates() if inventory_candidates is not None else []
+        payload = build_manifest(
+            prs=prs,
+            merge_packet_entries=merge_entries,
+            inventory_candidates=candidates,
+            now=now,
+            stale_days=stale_days,
+            annotations=annotations,
+        )
+    except (RuntimeError, OSError, ValueError, subprocess.SubprocessError) as exc:
+        print(json.dumps({"action": "error", "error": str(exc)[:500]}), file=sys.stderr)
+        return EXIT_FAILURE
+
+    if summary:
+        counts = payload["summary"]["by_disposition"]
+        log(
+            "queue disposition: "
+            f"total={payload['summary']['total_items']} "
+            f"harvest={counts.get('harvest_now', 0)} "
+            f"human={counts.get('human_packet', 0)} "
+            f"park={counts.get('park_preserve', 0)} "
+            f"close_delete={counts.get('close_or_delete_after_manifest', 0)} "
+            f"operator_required={payload['summary']['operator_required']}"
+        )
+    else:
+        log(json.dumps(payload, sort_keys=True))
+
+    if out_file:
+        try:
+            atomic_write_json(out_file, payload)
+        except OSError as exc:
+            print(
+                json.dumps({"action": "out_write_failed", "error": str(exc)[:300]}),
+                file=sys.stderr,
+            )
+            return EXIT_FAILURE
+    return EXIT_OK
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Read-only queue disposition manifest for preserve-first drain runs."
+    )
+    parser.add_argument("--repo", default=DEFAULT_REPO, help="GitHub repo (owner/name)")
+    parser.add_argument("--limit", type=int, default=DEFAULT_LIMIT)
+    parser.add_argument("--stale-days", type=int, default=14)
+    parser.add_argument(
+        "--with-merge-packets",
+        action="store_true",
+        help="Run review-queue merge-packet for each open PR (read-only, slower).",
+    )
+    parser.add_argument(
+        "--merge-packet-workers",
+        type=int,
+        default=DEFAULT_MERGE_PACKET_WORKERS,
+        help="Bounded read-only merge-packet workers when --with-merge-packets is set.",
+    )
+    parser.add_argument(
+        "--include-worktrees",
+        action="store_true",
+        help="Include codex_worktree_value_inventory candidates (read-only, slower).",
+    )
+    parser.add_argument("--summary", action="store_true", help="Emit one summary line.")
+    parser.add_argument("--out", default=None, help="Optional atomic JSON output path.")
+    args = parser.parse_args(argv)
+
+    return run_manifest(
+        list_prs=lambda: default_list_prs(args.repo, args.limit),
+        merge_packet=default_merge_packet if args.with_merge_packets else None,
+        merge_packet_workers=args.merge_packet_workers,
+        inventory_candidates=default_inventory_candidates if args.include_worktrees else None,
+        limit=args.limit,
+        stale_days=args.stale_days,
+        out_file=args.out,
+        summary=args.summary,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/queue_disposition_manifest.py
+++ b/scripts/queue_disposition_manifest.py
@@ -30,6 +30,7 @@ GH_TIMEOUT_SECONDS = 120
 MERGE_PACKET_TIMEOUT_SECONDS = 60
 INVENTORY_TIMEOUT_SECONDS = 300
 DEFAULT_MERGE_PACKET_WORKERS = 4
+MAX_MERGE_PACKET_WORKERS = 16
 
 EXIT_OK = 0
 EXIT_FAILURE = 1
@@ -38,6 +39,13 @@ _GH_FIELDS = (
     "number,title,labels,isDraft,createdAt,updatedAt,headRefName,headRefOid,"
     "baseRefName,mergeable,reviewDecision,additions,deletions,changedFiles,author"
 )
+
+
+def subprocess_env() -> dict[str, str]:
+    env = dict(os.environ)
+    existing = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = str(REPO_ROOT) if not existing else f"{REPO_ROOT}{os.pathsep}{existing}"
+    return env
 
 
 def atomic_write_json(path: str, payload: dict[str, Any]) -> None:
@@ -85,7 +93,7 @@ def default_list_prs(repo: str, limit: int) -> list[dict[str, Any]]:
     return payload
 
 
-def default_merge_packet(pr: int) -> dict[str, Any]:
+def default_merge_packet(pr: int, repo: str = DEFAULT_REPO) -> dict[str, Any]:
     command = [
         sys.executable,
         "-m",
@@ -94,6 +102,8 @@ def default_merge_packet(pr: int) -> dict[str, Any]:
         "merge-packet",
         "--pr",
         str(pr),
+        "--repo",
+        repo,
         "--json",
     ]
     result = subprocess.run(
@@ -102,6 +112,8 @@ def default_merge_packet(pr: int) -> dict[str, Any]:
         text=True,
         timeout=MERGE_PACKET_TIMEOUT_SECONDS,
         check=False,
+        cwd=str(REPO_ROOT),
+        env=subprocess_env(),
     )
     if result.returncode != 0:
         raise RuntimeError(
@@ -112,9 +124,11 @@ def default_merge_packet(pr: int) -> dict[str, Any]:
         raise RuntimeError(f"merge-packet returned unexpected payload for PR #{pr}")
     entries = payload.get("entries")
     if not isinstance(entries, list) or not entries:
-        return {}
+        raise RuntimeError(f"merge-packet returned no entries for PR #{pr}")
     entry = entries[0]
-    return entry if isinstance(entry, dict) else {}
+    if not isinstance(entry, dict):
+        raise RuntimeError(f"merge-packet returned malformed entry for PR #{pr}")
+    return entry
 
 
 def default_inventory_candidates() -> list[dict[str, Any]]:
@@ -134,6 +148,8 @@ def default_inventory_candidates() -> list[dict[str, Any]]:
         text=True,
         timeout=INVENTORY_TIMEOUT_SECONDS,
         check=False,
+        cwd=str(REPO_ROOT),
+        env=subprocess_env(),
     )
     if result.returncode != 0:
         raise RuntimeError(
@@ -173,7 +189,7 @@ def collect_merge_packets(
     merge_entries: dict[int, dict[str, Any]] = {}
     if not jobs:
         return merge_entries
-    workers = max(1, min(workers, len(jobs)))
+    workers = max(1, min(workers, len(jobs), MAX_MERGE_PACKET_WORKERS))
     if workers == 1:
         for pr, number in jobs:
             try:
@@ -224,7 +240,7 @@ def run_manifest(
         if len(prs) >= limit:
             annotations.append(f"list_truncated:>={limit}")
 
-        merge_entries: dict[int, dict[str, Any]] = {}
+        merge_entries: dict[int, dict[str, Any]] | None = None
         if merge_packet is not None:
             merge_entries = collect_merge_packets(
                 prs,
@@ -281,8 +297,16 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--stale-days", type=int, default=14)
     parser.add_argument(
         "--with-merge-packets",
+        dest="with_merge_packets",
         action="store_true",
+        default=True,
         help="Run review-queue merge-packet for each open PR (read-only, slower).",
+    )
+    parser.add_argument(
+        "--no-merge-packets",
+        dest="with_merge_packets",
+        action="store_false",
+        help="Skip merge-packet collection; PR dispositions will park until packet data exists.",
     )
     parser.add_argument(
         "--merge-packet-workers",
@@ -298,10 +322,28 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--summary", action="store_true", help="Emit one summary line.")
     parser.add_argument("--out", default=None, help="Optional atomic JSON output path.")
     args = parser.parse_args(argv)
+    if args.stale_days < 1:
+        print(
+            json.dumps({"action": "error", "error": "--stale-days must be >= 1"}), file=sys.stderr
+        )
+        return EXIT_FAILURE
+    if not 1 <= args.merge_packet_workers <= MAX_MERGE_PACKET_WORKERS:
+        print(
+            json.dumps(
+                {
+                    "action": "error",
+                    "error": f"--merge-packet-workers must be between 1 and {MAX_MERGE_PACKET_WORKERS}",
+                }
+            ),
+            file=sys.stderr,
+        )
+        return EXIT_FAILURE
 
     return run_manifest(
         list_prs=lambda: default_list_prs(args.repo, args.limit),
-        merge_packet=default_merge_packet if args.with_merge_packets else None,
+        merge_packet=(lambda pr: default_merge_packet(pr, args.repo))
+        if args.with_merge_packets
+        else None,
         merge_packet_workers=args.merge_packet_workers,
         inventory_candidates=default_inventory_candidates if args.include_worktrees else None,
         limit=args.limit,

--- a/scripts/queue_disposition_manifest.py
+++ b/scripts/queue_disposition_manifest.py
@@ -151,6 +151,14 @@ def _merge_packet_failure_annotation(number: int, exc: BaseException) -> str:
     return f"merge_packet_failed:#{number}:{str(exc)[:200]}"
 
 
+def _coerce_pr_number(value: Any) -> int | None:
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        return None
+    return number if number > 0 else None
+
+
 def collect_merge_packets(
     prs: list[dict[str, Any]],
     merge_packet: Callable[[int], dict[str, Any]],
@@ -159,30 +167,36 @@ def collect_merge_packets(
     annotations: list[str],
 ) -> dict[int, dict[str, Any]]:
     """Collect per-PR merge packets with bounded read-only parallelism."""
-    numbers = [pr["number"] for pr in prs if isinstance(pr.get("number"), int)]
+    jobs = [
+        (pr, number) for pr in prs if (number := _coerce_pr_number(pr.get("number"))) is not None
+    ]
     merge_entries: dict[int, dict[str, Any]] = {}
-    if not numbers:
+    if not jobs:
         return merge_entries
-    workers = max(1, min(workers, len(numbers)))
+    workers = max(1, min(workers, len(jobs)))
     if workers == 1:
-        for number in numbers:
+        for pr, number in jobs:
             try:
                 entry = merge_packet(number)
             except (RuntimeError, OSError, ValueError, subprocess.SubprocessError) as exc:
-                annotations.append(_merge_packet_failure_annotation(number, exc))
+                annotation = _merge_packet_failure_annotation(number, exc)
+                annotations.append(annotation)
+                pr["_merge_packet_error"] = annotation
                 continue
             if entry:
                 merge_entries[number] = entry
         return merge_entries
 
     with ThreadPoolExecutor(max_workers=workers) as executor:
-        futures = {executor.submit(merge_packet, number): number for number in numbers}
+        futures = {executor.submit(merge_packet, number): (pr, number) for pr, number in jobs}
         for future in as_completed(futures):
-            number = futures[future]
+            pr, number = futures[future]
             try:
                 entry = future.result()
             except (RuntimeError, OSError, ValueError, subprocess.SubprocessError) as exc:
-                annotations.append(_merge_packet_failure_annotation(number, exc))
+                annotation = _merge_packet_failure_annotation(number, exc)
+                annotations.append(annotation)
+                pr["_merge_packet_error"] = annotation
                 continue
             if entry:
                 merge_entries[number] = entry

--- a/tests/scripts/test_queue_disposition_manifest.py
+++ b/tests/scripts/test_queue_disposition_manifest.py
@@ -106,7 +106,12 @@ def test_run_manifest_records_merge_packet_failures() -> None:
     assert rc == manifest_cli.EXIT_OK
     payload = json.loads(lines[0])
     assert payload["annotations"] == ["merge_packet_failed:#1:transport down"]
-    assert payload["items"][0]["disposition"] == "harvest_now"
+    assert payload["items"][0]["disposition"] == "park_preserve"
+    assert payload["items"][0]["operator_required"] is True
+    assert (
+        "merge_packet.error=merge_packet_failed:#1:transport down"
+        in payload["items"][0]["evidence"]
+    )
 
 
 def test_collect_merge_packets_uses_bounded_parallel_workers() -> None:
@@ -121,3 +126,36 @@ def test_collect_merge_packets_uses_bounded_parallel_workers() -> None:
 
     assert entries == {1: {"tier": 1}, 2: {"tier": 2}}
     assert annotations == []
+
+
+def test_collect_merge_packets_accepts_string_pr_numbers() -> None:
+    annotations: list[str] = []
+
+    entries = manifest_cli.collect_merge_packets(
+        [{"number": "8718"}],
+        lambda pr: {"tier": pr},
+        workers=1,
+        annotations=annotations,
+    )
+
+    assert entries == {8718: {"tier": 8718}}
+    assert annotations == []
+
+
+def test_collect_merge_packets_marks_failed_pr_record() -> None:
+    annotations: list[str] = []
+    prs = [{"number": "8718"}]
+
+    def boom(pr: int) -> dict[str, Any]:
+        raise RuntimeError("transport down")
+
+    entries = manifest_cli.collect_merge_packets(
+        prs,
+        boom,
+        workers=1,
+        annotations=annotations,
+    )
+
+    assert entries == {}
+    assert annotations == ["merge_packet_failed:#8718:transport down"]
+    assert prs[0]["_merge_packet_error"] == "merge_packet_failed:#8718:transport down"

--- a/tests/scripts/test_queue_disposition_manifest.py
+++ b/tests/scripts/test_queue_disposition_manifest.py
@@ -159,3 +159,53 @@ def test_collect_merge_packets_marks_failed_pr_record() -> None:
     assert entries == {}
     assert annotations == ["merge_packet_failed:#8718:transport down"]
     assert prs[0]["_merge_packet_error"] == "merge_packet_failed:#8718:transport down"
+
+
+def test_main_collects_merge_packets_by_default() -> None:
+    old_list = manifest_cli.default_list_prs
+    old_packet = manifest_cli.default_merge_packet
+    seen: list[tuple[int, str]] = []
+    lines: list[str] = []
+
+    try:
+        manifest_cli.default_list_prs = lambda repo, limit: [
+            {
+                "number": "8541",
+                "title": "feat(api): expose crux finder",
+                "isDraft": False,
+                "mergeable": "MERGEABLE",
+                "headRefName": "codex/x",
+                "headRefOid": "abc",
+                "createdAt": "2026-06-20T12:00:00Z",
+                "additions": 10,
+                "deletions": 0,
+                "changedFiles": 1,
+                "labels": [],
+            }
+        ]
+
+        def fake_packet(pr: int, repo: str = manifest_cli.DEFAULT_REPO) -> dict[str, Any]:
+            seen.append((pr, repo))
+            return {"tier": 3, "unresolved_dissent": False}
+
+        manifest_cli.default_merge_packet = fake_packet
+        rc = manifest_cli.main(["--summary"])
+    finally:
+        manifest_cli.default_list_prs = old_list
+        manifest_cli.default_merge_packet = old_packet
+
+    assert rc == manifest_cli.EXIT_OK
+    assert seen == [(8541, manifest_cli.DEFAULT_REPO)]
+
+
+def test_main_rejects_invalid_bounds(capsys: Any) -> None:
+    assert manifest_cli.main(["--stale-days", "0"]) == manifest_cli.EXIT_FAILURE
+    assert "--stale-days must be >= 1" in capsys.readouterr().err
+
+    assert (
+        manifest_cli.main(
+            ["--merge-packet-workers", str(manifest_cli.MAX_MERGE_PACKET_WORKERS + 1)]
+        )
+        == manifest_cli.EXIT_FAILURE
+    )
+    assert "--merge-packet-workers must be between" in capsys.readouterr().err

--- a/tests/scripts/test_queue_disposition_manifest.py
+++ b/tests/scripts/test_queue_disposition_manifest.py
@@ -1,0 +1,123 @@
+"""Tests for ``scripts/queue_disposition_manifest.py``.
+
+All GitHub and inventory boundaries are injected; no test touches the network.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _load_module(script_name: str) -> Any:
+    here = Path(__file__).resolve()
+    script_path = here.parents[2] / "scripts" / script_name
+    spec = importlib.util.spec_from_file_location(f"{script_name}_under_test", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load spec for {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+manifest_cli = _load_module("queue_disposition_manifest.py")
+NOW = datetime(2026, 6, 30, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def test_run_manifest_writes_atomic_payload_and_summary(tmp_path: Path) -> None:
+    out = tmp_path / "manifest.json"
+    lines: list[str] = []
+
+    rc = manifest_cli.run_manifest(
+        list_prs=lambda: [
+            {
+                "number": 8389,
+                "title": "feat(odr): in-package ODR verification engine",
+                "isDraft": False,
+                "mergeable": "MERGEABLE",
+                "headRefName": "claude/odr3-verify-core",
+                "headRefOid": "abc",
+                "createdAt": "2026-06-20T12:00:00Z",
+                "additions": 734,
+                "deletions": 0,
+                "changedFiles": 2,
+                "labels": [],
+            }
+        ],
+        merge_packet=lambda pr: {"tier": 1, "unresolved_dissent": False},
+        inventory_candidates=lambda: [
+            {
+                "candidate_id": "wt",
+                "classification": "patch_equivalent_or_merged",
+                "decision": "cleanup_candidate",
+                "git": {"branch": "codex/old", "head": "def"},
+                "proof": ["patch-equivalent to base"],
+            }
+        ],
+        out_file=str(out),
+        summary=True,
+        now=NOW,
+        log=lines.append,
+    )
+
+    assert rc == manifest_cli.EXIT_OK
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["generated_at"] == "2026-06-30T12:00:00Z"
+    assert payload["summary"]["total_items"] == 2
+    assert payload["items"][0]["disposition"] == "harvest_now"
+    assert payload["items"][1]["disposition"] == "close_or_delete_after_manifest"
+    assert lines == [
+        "queue disposition: total=2 harvest=1 human=0 park=0 close_delete=1 operator_required=1"
+    ]
+
+
+def test_run_manifest_records_merge_packet_failures() -> None:
+    lines: list[str] = []
+
+    def boom(pr: int) -> dict[str, Any]:
+        raise RuntimeError("transport down")
+
+    rc = manifest_cli.run_manifest(
+        list_prs=lambda: [
+            {
+                "number": 1,
+                "title": "feat(odr): verify",
+                "isDraft": False,
+                "mergeable": "MERGEABLE",
+                "headRefName": "codex/x",
+                "headRefOid": "abc",
+                "createdAt": "2026-06-20T12:00:00Z",
+                "additions": 10,
+                "deletions": 0,
+                "changedFiles": 1,
+                "labels": [],
+            }
+        ],
+        merge_packet=boom,
+        now=NOW,
+        log=lines.append,
+    )
+
+    assert rc == manifest_cli.EXIT_OK
+    payload = json.loads(lines[0])
+    assert payload["annotations"] == ["merge_packet_failed:#1:transport down"]
+    assert payload["items"][0]["disposition"] == "harvest_now"
+
+
+def test_collect_merge_packets_uses_bounded_parallel_workers() -> None:
+    annotations: list[str] = []
+
+    entries = manifest_cli.collect_merge_packets(
+        [{"number": 1}, {"number": 2}],
+        lambda pr: {"tier": pr},
+        workers=2,
+        annotations=annotations,
+    )
+
+    assert entries == {1: {"tier": 1}, 2: {"tier": 2}}
+    assert annotations == []

--- a/tests/swarm/test_queue_disposition.py
+++ b/tests/swarm/test_queue_disposition.py
@@ -25,6 +25,7 @@ def _pr(
     deletions: int = 0,
     changed_files: int = 2,
     created: str = "2026-06-20T12:00:00Z",
+    updated: str = "2026-06-20T12:00:00Z",
 ) -> dict[str, object]:
     return {
         "number": number,
@@ -34,6 +35,7 @@ def _pr(
         "headRefName": f"codex/pr-{number}",
         "headRefOid": f"head-{number}",
         "createdAt": created,
+        "updatedAt": updated,
         "additions": additions,
         "deletions": deletions,
         "changedFiles": changed_files,
@@ -149,6 +151,24 @@ def test_invalid_pr_number_does_not_emit_zero_open_pr() -> None:
 
     assert item["id"] == "codex/value"
     assert item["open_pr"] is None
+    assert item["disposition"] == DISPOSITION_PARK_PRESERVE
+    assert item["operator_required"] is True
+    assert "invalid_pr_identity=true" in item["evidence"]
+
+
+def test_invalid_pr_number_cannot_route_to_harvest_now() -> None:
+    item = classify_pr_disposition(
+        {
+            **_pr(0, "feat(odr): verify core", mergeable="MERGEABLE"),
+            "number": "not-a-number",
+        },
+        merge_packet_entry={"tier": 1, "unresolved_dissent": False},
+        now=NOW,
+    )
+
+    assert item["disposition"] == DISPOSITION_PARK_PRESERVE
+    assert item["operator_required"] is True
+    assert "merge-packet safety cannot be proven" in item["next_action"]
 
 
 def test_stale_maintenance_pr_can_close_only_after_manifest_checks() -> None:
@@ -159,6 +179,7 @@ def test_stale_maintenance_pr_can_close_only_after_manifest_checks() -> None:
             draft=True,
             mergeable="CONFLICTING",
             created="2026-06-01T12:00:00Z",
+            updated="2026-06-01T12:00:00Z",
         ),
         now=NOW,
         stale_days=14,
@@ -169,7 +190,42 @@ def test_stale_maintenance_pr_can_close_only_after_manifest_checks() -> None:
     assert "owner/steering" in item["next_action"]
 
 
-def test_unique_worktree_routes_to_harvest() -> None:
+def test_recently_updated_old_pr_does_not_close_as_stale() -> None:
+    item = classify_pr_disposition(
+        _pr(
+            8156,
+            "chore(ci): refresh cancelled lint snapshots",
+            draft=False,
+            mergeable="MERGEABLE",
+            created="2026-05-01T12:00:00Z",
+            updated="2026-06-29T12:00:00Z",
+        ),
+        now=NOW,
+        stale_days=14,
+    )
+
+    assert item["disposition"] == DISPOSITION_PARK_PRESERVE
+    assert "stale_days>=14" not in item["evidence"]
+
+
+def test_unknown_string_booleans_fail_closed_without_truthy_fallthrough() -> None:
+    item = classify_pr_disposition(
+        _pr(8393, "feat(routing): decision-stakes router"),
+        merge_packet_entry={
+            "tier": "1",
+            "unresolved_dissent": "definitely-not",
+            "requires_human_preapproval": "unknown",
+        },
+        now=NOW,
+    )
+
+    assert item["disposition"] == DISPOSITION_HUMAN_PACKET
+    assert item["operator_required"] is True
+    assert "model_dissent_present_but_not_value_proof" in item["evidence"]
+    assert "merge_packet.requires_human_preapproval=unknown" in item["evidence"]
+
+
+def test_unique_worktree_routes_to_preserve_operator_packet() -> None:
     item = classify_inventory_candidate(
         {
             "candidate_id": "abc",
@@ -182,7 +238,8 @@ def test_unique_worktree_routes_to_harvest() -> None:
     )
 
     assert item["item_type"] == "worktree"
-    assert item["disposition"] == DISPOSITION_HARVEST_NOW
+    assert item["disposition"] == DISPOSITION_PARK_PRESERVE
+    assert item["operator_required"] is True
     assert item["branch"] == "codex/value"
 
 

--- a/tests/swarm/test_queue_disposition.py
+++ b/tests/swarm/test_queue_disposition.py
@@ -90,6 +90,67 @@ def test_model_dissent_on_value_work_never_closes_by_itself() -> None:
     assert "never close solely for dissent" in item["next_action"]
 
 
+def test_string_false_does_not_create_dissent() -> None:
+    item = classify_pr_disposition(
+        _pr(8393, "feat(routing): decision-stakes router"),
+        merge_packet_entry={"tier": "1", "unresolved_dissent": "false"},
+        now=NOW,
+    )
+
+    assert item["disposition"] == DISPOSITION_HARVEST_NOW
+    assert "model_dissent_present_but_not_value_proof" not in item["evidence"]
+
+
+def test_unknown_mergeability_parks_high_value_pr() -> None:
+    item = classify_pr_disposition(
+        _pr(8393, "feat(routing): decision-stakes router", mergeable="UNKNOWN"),
+        merge_packet_entry={"tier": 1, "unresolved_dissent": False},
+        now=NOW,
+    )
+
+    assert item["disposition"] == DISPOSITION_PARK_PRESERVE
+    assert "preserve" in item["next_action"]
+
+
+def test_tier_three_draft_with_dissent_requires_operator() -> None:
+    item = classify_pr_disposition(
+        _pr(8541, "feat(api): expose crux finder", draft=True),
+        merge_packet_entry={"tier": 3, "unresolved_dissent": "true"},
+        now=NOW,
+    )
+
+    assert item["disposition"] == DISPOSITION_PARK_PRESERVE
+    assert item["operator_required"] is True
+
+
+def test_merge_packet_failure_parks_pr_until_tier_known() -> None:
+    item = classify_pr_disposition(
+        {
+            **_pr(8541, "feat(api): expose crux finder"),
+            "_merge_packet_error": "merge_packet_failed:#8541:transport down",
+        },
+        now=NOW,
+    )
+
+    assert item["disposition"] == DISPOSITION_PARK_PRESERVE
+    assert item["operator_required"] is True
+    assert "rerun merge-packet" in item["next_action"]
+
+
+def test_invalid_pr_number_does_not_emit_zero_open_pr() -> None:
+    item = classify_pr_disposition(
+        {
+            **_pr(0, "feat(odr): verify core"),
+            "number": None,
+            "headRefName": "codex/value",
+        },
+        now=NOW,
+    )
+
+    assert item["id"] == "codex/value"
+    assert item["open_pr"] is None
+
+
 def test_stale_maintenance_pr_can_close_only_after_manifest_checks() -> None:
     item = classify_pr_disposition(
         _pr(
@@ -123,6 +184,21 @@ def test_unique_worktree_routes_to_harvest() -> None:
     assert item["item_type"] == "worktree"
     assert item["disposition"] == DISPOSITION_HARVEST_NOW
     assert item["branch"] == "codex/value"
+
+
+def test_worktree_open_pr_dict_link_is_preserved() -> None:
+    item = classify_inventory_candidate(
+        {
+            "candidate_id": "abc",
+            "classification": "open_pr_or_outbox",
+            "decision": "preserve",
+            "git": {"branch": "codex/value", "head": "abc123"},
+            "links": {"open_prs": [{"number": 8718, "title": "manifest"}]},
+        }
+    )
+
+    assert item["disposition"] == DISPOSITION_PARK_PRESERVE
+    assert item["open_pr"] == 8718
 
 
 def test_patch_equivalent_worktree_requires_manifest_before_delete() -> None:

--- a/tests/swarm/test_queue_disposition.py
+++ b/tests/swarm/test_queue_disposition.py
@@ -224,6 +224,7 @@ def test_build_manifest_counts_dispositions() -> None:
             _pr(1, "feat(odr): verify core"),
             _pr(2, "chore(ci): refresh cancelled lint snapshots", draft=True),
         ],
+        merge_packet_entries={1: {"tier": 1, "unresolved_dissent": False}},
         inventory_candidates=[
             {
                 "candidate_id": "wt",
@@ -240,3 +241,34 @@ def test_build_manifest_counts_dispositions() -> None:
     assert manifest["summary"]["by_disposition"][DISPOSITION_HARVEST_NOW] == 1
     assert manifest["summary"]["by_disposition"][DISPOSITION_CLOSE_OR_DELETE] == 1
     assert manifest["summary"]["by_disposition"][DISPOSITION_PARK_PRESERVE] == 1
+
+
+def test_build_manifest_without_merge_packets_parks_prs() -> None:
+    manifest = build_manifest(
+        prs=[_pr(1, "feat(odr): verify core")],
+        now=NOW,
+    )
+
+    assert manifest["summary"]["by_disposition"][DISPOSITION_HARVEST_NOW] == 0
+    assert manifest["summary"]["by_disposition"][DISPOSITION_PARK_PRESERVE] == 1
+    assert "merge_packet.error=merge_packet_not_collected" in manifest["items"][0]["evidence"]
+
+
+def test_build_manifest_skips_inventory_duplicate_for_open_pr() -> None:
+    manifest = build_manifest(
+        prs=[_pr(8718, "feat(odr): verify core")],
+        merge_packet_entries={8718: {"tier": 1, "unresolved_dissent": False}},
+        inventory_candidates=[
+            {
+                "candidate_id": "wt",
+                "classification": "open_pr_or_outbox",
+                "decision": "preserve",
+                "git": {"branch": "codex/pr-8718", "head": "head-8718"},
+                "links": {"open_prs": [{"number": 8718}]},
+            }
+        ],
+        now=NOW,
+    )
+
+    assert manifest["summary"]["total_items"] == 1
+    assert manifest["annotations"] == ["inventory_duplicate_skipped:worktree:wt"]

--- a/tests/swarm/test_queue_disposition.py
+++ b/tests/swarm/test_queue_disposition.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from aragora.swarm.queue_disposition import (
+    DISPOSITION_CLOSE_OR_DELETE,
+    DISPOSITION_HARVEST_NOW,
+    DISPOSITION_HUMAN_PACKET,
+    DISPOSITION_PARK_PRESERVE,
+    build_manifest,
+    classify_inventory_candidate,
+    classify_pr_disposition,
+)
+
+NOW = datetime(2026, 6, 30, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _pr(
+    number: int,
+    title: str,
+    *,
+    draft: bool = False,
+    mergeable: str = "MERGEABLE",
+    additions: int = 100,
+    deletions: int = 0,
+    changed_files: int = 2,
+    created: str = "2026-06-20T12:00:00Z",
+) -> dict[str, object]:
+    return {
+        "number": number,
+        "title": title,
+        "isDraft": draft,
+        "mergeable": mergeable,
+        "headRefName": f"codex/pr-{number}",
+        "headRefOid": f"head-{number}",
+        "createdAt": created,
+        "additions": additions,
+        "deletions": deletions,
+        "changedFiles": changed_files,
+        "labels": [],
+    }
+
+
+def test_product_pr_routes_to_harvest_now() -> None:
+    item = classify_pr_disposition(
+        _pr(8389, "feat(odr): in-package ODR verification engine"),
+        merge_packet_entry={"tier": 1, "unresolved_dissent": False},
+        now=NOW,
+    )
+
+    assert item["disposition"] == DISPOSITION_HARVEST_NOW
+    assert item["operator_required"] is False
+    assert item["open_pr"] == 8389
+
+
+def test_tier_three_product_routes_to_human_packet() -> None:
+    item = classify_pr_disposition(
+        _pr(8541, "feat(api): expose crux finder"),
+        merge_packet_entry={
+            "tier": 3,
+            "requires_human_risk_settlement": True,
+            "unresolved_dissent": False,
+        },
+        now=NOW,
+    )
+
+    assert item["disposition"] == DISPOSITION_HUMAN_PACKET
+    assert item["operator_required"] is True
+
+
+def test_parked_epic_is_preserved_even_when_draft() -> None:
+    item = classify_pr_disposition(
+        _pr(8714, "[DIC-21] quarantine-eval CLI", draft=True),
+        now=NOW,
+    )
+
+    assert item["disposition"] == DISPOSITION_PARK_PRESERVE
+    assert "high_value_signal=true" in item["evidence"]
+
+
+def test_model_dissent_on_value_work_never_closes_by_itself() -> None:
+    item = classify_pr_disposition(
+        _pr(8393, "feat(routing): decision-stakes router"),
+        merge_packet_entry={"tier": 1, "unresolved_dissent": True},
+        now=NOW,
+    )
+
+    assert item["disposition"] == DISPOSITION_PARK_PRESERVE
+    assert "model_dissent_present_but_not_value_proof" in item["evidence"]
+    assert "never close solely for dissent" in item["next_action"]
+
+
+def test_stale_maintenance_pr_can_close_only_after_manifest_checks() -> None:
+    item = classify_pr_disposition(
+        _pr(
+            8156,
+            "chore(ci): refresh cancelled lint snapshots",
+            draft=True,
+            mergeable="CONFLICTING",
+            created="2026-06-01T12:00:00Z",
+        ),
+        now=NOW,
+        stale_days=14,
+    )
+
+    assert item["disposition"] == DISPOSITION_CLOSE_OR_DELETE
+    assert item["operator_required"] is True
+    assert "owner/steering" in item["next_action"]
+
+
+def test_unique_worktree_routes_to_harvest() -> None:
+    item = classify_inventory_candidate(
+        {
+            "candidate_id": "abc",
+            "classification": "unique_unharvested",
+            "decision": "harvest_candidate",
+            "git": {"branch": "codex/value", "head": "abc123"},
+            "links": {"open_prs": []},
+            "proof": ["branch has unique commits or diff ahead of base"],
+        }
+    )
+
+    assert item["item_type"] == "worktree"
+    assert item["disposition"] == DISPOSITION_HARVEST_NOW
+    assert item["branch"] == "codex/value"
+
+
+def test_patch_equivalent_worktree_requires_manifest_before_delete() -> None:
+    item = classify_inventory_candidate(
+        {
+            "candidate_id": "def",
+            "classification": "patch_equivalent_or_merged",
+            "decision": "cleanup_candidate",
+            "git": {"branch": "codex/old", "head": "def456"},
+            "links": {"open_prs": []},
+            "proof": ["patch-equivalent to base"],
+        }
+    )
+
+    assert item["disposition"] == DISPOSITION_CLOSE_OR_DELETE
+    assert item["operator_required"] is True
+    assert "SHA/path manifest" in item["next_action"]
+
+
+def test_build_manifest_counts_dispositions() -> None:
+    manifest = build_manifest(
+        prs=[
+            _pr(1, "feat(odr): verify core"),
+            _pr(2, "chore(ci): refresh cancelled lint snapshots", draft=True),
+        ],
+        inventory_candidates=[
+            {
+                "candidate_id": "wt",
+                "classification": "active_or_dirty",
+                "decision": "preserve",
+                "git": {"branch": "codex/dirty", "head": "h"},
+            }
+        ],
+        now=NOW,
+    )
+
+    assert manifest["schema_version"] == "aragora.queue_disposition_manifest.v1"
+    assert manifest["summary"]["total_items"] == 3
+    assert manifest["summary"]["by_disposition"][DISPOSITION_HARVEST_NOW] == 1
+    assert manifest["summary"]["by_disposition"][DISPOSITION_CLOSE_OR_DELETE] == 1
+    assert manifest["summary"]["by_disposition"][DISPOSITION_PARK_PRESERVE] == 1


### PR DESCRIPTION
## Summary
- Adds a conservative queue disposition classifier with four dispositions: `harvest_now`, `human_packet`, `park_preserve`, and `close_or_delete_after_manifest`.
- Adds `scripts/queue_disposition_manifest.py`, a read-only manifest builder for open PRs and optional worktree inventory candidates.
- Adds bounded read-only parallelism for merge-packet collection via `--merge-packet-workers`, while keeping a single coordinator manifest and no mutation.

## Policy encoded
- Dissent blocks merge/evidence settlement, but is not treated as proof of no value.
- `[AGT-*]`, `[DIC-*]`, high-risk security/signing/workflow/Tier 3+ items, and unknown-value work are preserved or human-routed.
- Close/delete candidates are only manifest candidates; they still require live owner/steering, diffstat, main-equivalence, and recovery rationale checks.
- Worktree cleanup is represented separately from PR drain and requires fresh cleanup inspection plus SHA/path manifesting before deletion.

## Live read-only probe
- `gh pr list --repo synaptent/aragora --state open --json number,title,isDraft,headRefName,headRefOid,mergeable --limit 1000`: 37 open PRs at probe time.
- `python3 -m aragora.cli.main review-queue merge-packet --pr 8389 --json`: Tier 1, no unresolved dissent, still needs model quorum plus focused dogfood evidence.
- `python3 scripts/queue_disposition_manifest.py --summary --limit 1000 --with-merge-packets --merge-packet-workers 8 --include-worktrees --out /tmp/aragora-queue-disposition-live-parallel.json`: `total=198 harvest=5 human=8 park=28 close_delete=157 operator_required=176`.
- Serial merge-packet manifest took about 90s; the 8-worker read-only path completed in about 19s.

## Verification
- `python3 -m pytest tests/swarm/test_queue_disposition.py tests/scripts/test_queue_disposition_manifest.py tests/scripts/test_pr_value_classifier.py tests/scripts/test_backlog_gate.py`
- `python3 -m pytest tests/swarm/test_quorum_evidence.py -k severity_gated tests/cli/commands/test_review_queue.py -k severity_gated`
- `python3 -m mypy aragora/swarm/queue_disposition.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
