### PR TITLE
fix(queue): gate strategy mission boss-ready intake

### DIFF
--- a/aragora/swarm/proof_first_queue.py
+++ b/aragora/swarm/proof_first_queue.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
@@ -62,11 +63,14 @@ _DRIFT_TERMS = (
     "current gate",
 )
 _STRATEGY_MISSION_GATED_TERMS = (
+    "8665",
     "#8665",
+    "epic 8665",
     "issues/8665",
     "strategy mission cadence",
     "strategy mission queue",
 )
+_STRATEGY_MISSION_QUEUE_REGISTER_PATH = Path("docs/status/ROADMAP_INTAKE_REGISTER.md")
 _REV4_STAGING_CORPUS_PATH = Path("tests/benchmarks/corpus_rev4.json")
 
 
@@ -86,6 +90,10 @@ def _normalize_text(*parts: str) -> str:
 
 def _matched_terms(text: str, terms: tuple[str, ...]) -> tuple[str, ...]:
     return tuple(term for term in terms if term in text)
+
+
+def _tokens(text: str) -> frozenset[str]:
+    return frozenset(re.findall(r"[a-z0-9]+", text))
 
 
 def _load_policy(
@@ -142,6 +150,73 @@ def _is_explicit_staged_rev4_issue(
     return normalized_issue_number in _staged_rev4_issue_numbers(str(Path(repo_root)))
 
 
+def _split_markdown_row(line: str) -> list[str]:
+    stripped = line.strip()
+    if not stripped.startswith("|") or not stripped.endswith("|"):
+        return []
+    return [cell.strip() for cell in stripped.strip("|").split("|")]
+
+
+@lru_cache(maxsize=8)
+def _active_strategy_mission_rows(repo_root: str) -> tuple[dict[str, str], ...]:
+    path = Path(repo_root) / _STRATEGY_MISSION_QUEUE_REGISTER_PATH
+    try:
+        lines = path.read_text().splitlines()
+    except OSError:
+        return ()
+
+    in_section = False
+    header: list[str] | None = None
+    rows: list[dict[str, str]] = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped == "## Strategy Mission Queue":
+            in_section = True
+            continue
+        if in_section and stripped.startswith("## "):
+            break
+        if not in_section or not stripped.startswith("|"):
+            continue
+
+        cells = _split_markdown_row(stripped)
+        if not cells:
+            continue
+        if all(set(cell) <= {"-", ":"} for cell in cells):
+            continue
+        if header is None:
+            header = [cell.lower() for cell in cells]
+            continue
+        if len(cells) != len(header):
+            continue
+        row = dict(zip(header, cells, strict=True))
+        if row.get("status", "").strip().lower() == "active":
+            rows.append(row)
+    return tuple(rows)
+
+
+def _active_strategy_mission_match_terms(
+    normalized_text: str,
+    *,
+    repo_root: Path | str | None,
+) -> tuple[str, ...]:
+    """Return active queue-row terms matched by this issue, if source truth proves one."""
+
+    if repo_root is None:
+        return ()
+    text_tokens = _tokens(normalized_text)
+    terms: list[str] = []
+    for row in _active_strategy_mission_rows(str(Path(repo_root))):
+        row_id = row.get("id", "").strip().lower()
+        title = row.get("title", "").strip().lower()
+        title_prefix = title.split("(", 1)[0].strip()
+        if row_id and row_id in text_tokens:
+            terms.append(f"active:{row_id}")
+            continue
+        if title_prefix and title_prefix in normalized_text:
+            terms.append(f"active:{row_id or title_prefix}")
+    return tuple(terms)
+
+
 def classify_proof_first_queue_issue(
     title: str,
     body: str = "",
@@ -180,6 +255,19 @@ def classify_proof_first_queue_issue(
 
     strategy_mission_matches = _matched_terms(normalized_text, _STRATEGY_MISSION_GATED_TERMS)
     if strategy_mission_matches:
+        active_strategy_terms = _active_strategy_mission_match_terms(
+            normalized_text,
+            repo_root=repo_root,
+        )
+        if active_strategy_terms:
+            return ProofFirstQueueDecision(
+                allowed=True,
+                lane="strategy_mission_active_row",
+                reason="matches an explicitly active Strategy Mission Queue row",
+                matched_terms=strategy_mission_matches + active_strategy_terms,
+                roadmap_codes=roadmap_codes,
+                blocked_codes=(),
+            )
         return ProofFirstQueueDecision(
             allowed=False,
             lane="strategy_mission_gated",

--- a/aragora/swarm/proof_first_queue.py
+++ b/aragora/swarm/proof_first_queue.py
@@ -92,6 +92,19 @@ def _matched_terms(text: str, terms: tuple[str, ...]) -> tuple[str, ...]:
     return tuple(term for term in terms if term in text)
 
 
+def _matched_strategy_mission_terms(text: str) -> tuple[str, ...]:
+    text_tokens = _tokens(text)
+    matches: list[str] = []
+    for term in _STRATEGY_MISSION_GATED_TERMS:
+        if term == "8665":
+            if "8665" in text_tokens:
+                matches.append(term)
+            continue
+        if term in text:
+            matches.append(term)
+    return tuple(matches)
+
+
 def _tokens(text: str) -> frozenset[str]:
     return frozenset(re.findall(r"[a-z0-9]+", text))
 
@@ -157,7 +170,6 @@ def _split_markdown_row(line: str) -> list[str]:
     return [cell.strip() for cell in stripped.strip("|").split("|")]
 
 
-@lru_cache(maxsize=8)
 def _active_strategy_mission_rows(repo_root: str) -> tuple[dict[str, str], ...]:
     path = Path(repo_root) / _STRATEGY_MISSION_QUEUE_REGISTER_PATH
     try:
@@ -253,7 +265,21 @@ def classify_proof_first_queue_issue(
                 blocked_codes=priority.blocked_codes,
             )
 
-    strategy_mission_matches = _matched_terms(normalized_text, _STRATEGY_MISSION_GATED_TERMS)
+    if _is_explicit_staged_rev4_issue(
+        issue_number=issue_number,
+        labels=labels,
+        repo_root=repo_root,
+    ):
+        return ProofFirstQueueDecision(
+            allowed=True,
+            lane="staged_rev4_corpus",
+            reason="explicit boss-ready issue is present in the staged rev-4 corpus",
+            matched_terms=("boss-ready", "corpus_rev4"),
+            roadmap_codes=roadmap_codes,
+            blocked_codes=(),
+        )
+
+    strategy_mission_matches = _matched_strategy_mission_terms(normalized_text)
     if strategy_mission_matches:
         active_strategy_terms = _active_strategy_mission_match_terms(
             normalized_text,
@@ -276,20 +302,6 @@ def classify_proof_first_queue_issue(
                 "explicitly active queue row may enter boss-ready"
             ),
             matched_terms=strategy_mission_matches,
-            roadmap_codes=roadmap_codes,
-            blocked_codes=(),
-        )
-
-    if _is_explicit_staged_rev4_issue(
-        issue_number=issue_number,
-        labels=labels,
-        repo_root=repo_root,
-    ):
-        return ProofFirstQueueDecision(
-            allowed=True,
-            lane="staged_rev4_corpus",
-            reason="explicit boss-ready issue is present in the staged rev-4 corpus",
-            matched_terms=("boss-ready", "corpus_rev4"),
             roadmap_codes=roadmap_codes,
             blocked_codes=(),
         )

--- a/aragora/swarm/proof_first_queue.py
+++ b/aragora/swarm/proof_first_queue.py
@@ -61,6 +61,12 @@ _DRIFT_TERMS = (
     "outrun",
     "current gate",
 )
+_STRATEGY_MISSION_GATED_TERMS = (
+    "#8665",
+    "issues/8665",
+    "strategy mission cadence",
+    "strategy mission queue",
+)
 _REV4_STAGING_CORPUS_PATH = Path("tests/benchmarks/corpus_rev4.json")
 
 
@@ -171,6 +177,20 @@ def classify_proof_first_queue_issue(
                 roadmap_codes=priority.codes,
                 blocked_codes=priority.blocked_codes,
             )
+
+    strategy_mission_matches = _matched_terms(normalized_text, _STRATEGY_MISSION_GATED_TERMS)
+    if strategy_mission_matches:
+        return ProofFirstQueueDecision(
+            allowed=False,
+            lane="strategy_mission_gated",
+            reason=(
+                "strategy mission cadence is tracked by the intake register; only an "
+                "explicitly active queue row may enter boss-ready"
+            ),
+            matched_terms=strategy_mission_matches,
+            roadmap_codes=roadmap_codes,
+            blocked_codes=(),
+        )
 
     if _is_explicit_staged_rev4_issue(
         issue_number=issue_number,

--- a/docs/status/NEXT_STEPS_CANONICAL.md
+++ b/docs/status/NEXT_STEPS_CANONICAL.md
@@ -122,6 +122,10 @@ Queue rule for this tranche:
 
 - only roadmap codes in the **Do now** set may carry or be auto-created with `boss-ready`
 - delayed-track issues may stay open for planning truth, but restock and auto-decomposition should strip them from the live dispatch queue
+- strategy mission cadence / Epic [#8665](https://github.com/synaptent/aragora/issues/8665)
+  is durable planning truth in the intake register, not wholesale `boss-ready`
+  work; only a specifically opened active row from the Strategy Mission Queue may
+  enter live dispatch after its predecessor's external-proof gate verifies
 
 Observer rule for this tranche:
 

--- a/docs/status/ROADMAP_INTAKE_REGISTER.md
+++ b/docs/status/ROADMAP_INTAKE_REGISTER.md
@@ -50,13 +50,14 @@ When an agent or human is asked to "make this plan permanent / durable":
 | **Workspace reconciliation (2026-06-26)** branches 2,749→489, worktrees 319→1; 1,695 stale codex branches inspected, 4 preserved | this session | Done | (operational) | preserved branches: `codex/review-6887`, `codex/rbac-openapi-coverage-primary-20260615`, `codex/validate-doc-links-anchor-check-r2-20260514`, `codex/disaster-recovery-stat-portability-improver-20260609` — harvest to PRs |
 | **Head freeze** — 5 grinder daemons disabled (boss-loop, merge-arbiter, merge-shepherd, overnight-watchdog, publisher); publisher pause-manifest bug confirmed (never read) | this session | Done | (operational) | fixed by reconcile-lane "real pause/lock" (above) |
 
-## Open planning epics (index, 2026-06-26)
+## Open planning epics (index, 2026-06-30)
 
 These are the durable, tracked roadmap epics. Keep this list current as the intake gate.
 
 | Epic | Title |
 |---|---|
 | [#8641](https://github.com/synaptent/aragora/issues/8641) | Sakana Fugu integration |
+| [#8665](https://github.com/synaptent/aragora/issues/8665) | Strategy mission cadence — ODR GA, Action wedge, proof corpus |
 | [#8257](https://github.com/synaptent/aragora/issues/8257) | Codebase health: macro-architecture, packaging, gate-rigor (Factory "Structural Excellence") |
 | [#8223](https://github.com/synaptent/aragora/issues/8223) | Open Decision Receipt (ODR) — decision-semantics layer |
 | [#8344](https://github.com/synaptent/aragora/issues/8344) | Conveyor hardening — close the six failure classes |

--- a/tests/swarm/test_proof_first_queue_classification.py
+++ b/tests/swarm/test_proof_first_queue_classification.py
@@ -15,6 +15,30 @@ _ROADMAP_POLICY = RoadmapPriorityPolicy(
 )
 
 
+def _write_strategy_mission_register(tmp_path, *, status: str = "queued") -> None:
+    register_path = tmp_path / "docs" / "status" / "ROADMAP_INTAKE_REGISTER.md"
+    register_path.parent.mkdir(parents=True)
+    register_path.write_text(
+        "\n".join(
+            [
+                "# Roadmap Intake Register",
+                "",
+                "## Strategy Mission Queue",
+                "",
+                "| id | title | tier | status | external-proof gate | tracking |",
+                "|---|---|---|---|---|---|",
+                (
+                    "| M1 | ODR v1.0 GA (docs + verification only) | 0-1 | "
+                    f"{status} | aragora-verify checks the example | Epic #8665 |"
+                ),
+                "",
+                "## Maintenance",
+                "",
+            ]
+        )
+    )
+
+
 @pytest.mark.parametrize(
     ("title", "body", "expected_codes"),
     [
@@ -100,6 +124,16 @@ def test_classifies_blocked_roadmap_lane(
             "Roadmap proof drift should stay queued until the prior external gate verifies.",
             "strategy mission queue",
         ),
+        (
+            "Strategy mission intake for issues/8665",
+            "Proof drift stays planning truth until the queue gate opens.",
+            "8665",
+        ),
+        (
+            "Epic 8665 proof-drift candidate",
+            "Docs proof drift wording should not bypass the strategy-mission gate.",
+            "8665",
+        ),
     ],
 )
 def test_strategy_mission_tracking_stays_out_of_boss_ready(
@@ -115,6 +149,35 @@ def test_strategy_mission_tracking_stays_out_of_boss_ready(
     assert decision.lane == "strategy_mission_gated"
     assert expected_term in decision.matched_terms
     assert "docs_proof_drift" != decision.lane
+
+
+def test_strategy_mission_queue_row_stays_blocked_until_register_marks_active(tmp_path) -> None:
+    _write_strategy_mission_register(tmp_path, status="queued")
+
+    decision = classify_proof_first_queue_issue(
+        "M1 ODR v1.0 GA proof drift worker for Epic #8665",
+        "The strategy mission queue row is still queued, so boss-ready is premature.",
+        labels=("boss-ready",),
+        repo_root=tmp_path,
+    )
+
+    assert decision.allowed is False
+    assert decision.lane == "strategy_mission_gated"
+
+
+def test_strategy_mission_active_queue_row_can_enter_boss_ready(tmp_path) -> None:
+    _write_strategy_mission_register(tmp_path, status="active")
+
+    decision = classify_proof_first_queue_issue(
+        "M1 ODR v1.0 GA proof drift worker for Epic #8665",
+        "The specifically opened strategy mission queue row is active.",
+        labels=("boss-ready",),
+        repo_root=tmp_path,
+    )
+
+    assert decision.allowed is True
+    assert decision.lane == "strategy_mission_active_row"
+    assert "active:m1" in decision.matched_terms
 
 
 @pytest.mark.parametrize(

--- a/tests/swarm/test_proof_first_queue_classification.py
+++ b/tests/swarm/test_proof_first_queue_classification.py
@@ -17,7 +17,7 @@ _ROADMAP_POLICY = RoadmapPriorityPolicy(
 
 def _write_strategy_mission_register(tmp_path, *, status: str = "queued") -> None:
     register_path = tmp_path / "docs" / "status" / "ROADMAP_INTAKE_REGISTER.md"
-    register_path.parent.mkdir(parents=True)
+    register_path.parent.mkdir(parents=True, exist_ok=True)
     register_path.write_text(
         "\n".join(
             [
@@ -165,6 +165,42 @@ def test_strategy_mission_queue_row_stays_blocked_until_register_marks_active(tm
     assert decision.lane == "strategy_mission_gated"
 
 
+def test_strategy_mission_numeric_reference_requires_token_boundary() -> None:
+    decision = classify_proof_first_queue_issue(
+        "Investigate unrelated issue #18665 before promotion",
+        "A substring-only numeric reference must not trip the strategy mission gate.",
+        labels=("boss-ready",),
+    )
+
+    assert decision.allowed is False
+    assert decision.lane == "non_canonical"
+    assert "8665" not in decision.matched_terms
+
+
+def test_strategy_mission_active_row_refreshes_after_register_edit(tmp_path) -> None:
+    _write_strategy_mission_register(tmp_path, status="queued")
+
+    first_decision = classify_proof_first_queue_issue(
+        "M1 ODR v1.0 GA proof drift worker for Epic #8665",
+        "The strategy mission queue row starts queued.",
+        labels=("boss-ready",),
+        repo_root=tmp_path,
+    )
+    assert first_decision.allowed is False
+    assert first_decision.lane == "strategy_mission_gated"
+
+    _write_strategy_mission_register(tmp_path, status="active")
+
+    second_decision = classify_proof_first_queue_issue(
+        "M1 ODR v1.0 GA proof drift worker for Epic #8665",
+        "The same process must see the register row become active.",
+        labels=("boss-ready",),
+        repo_root=tmp_path,
+    )
+    assert second_decision.allowed is True
+    assert second_decision.lane == "strategy_mission_active_row"
+
+
 def test_strategy_mission_active_queue_row_can_enter_boss_ready(tmp_path) -> None:
     _write_strategy_mission_register(tmp_path, status="active")
 
@@ -178,6 +214,23 @@ def test_strategy_mission_active_queue_row_can_enter_boss_ready(tmp_path) -> Non
     assert decision.allowed is True
     assert decision.lane == "strategy_mission_active_row"
     assert "active:m1" in decision.matched_terms
+
+
+def test_staged_rev4_corpus_precedence_beats_strategy_mission_gate(tmp_path) -> None:
+    corpus_path = tmp_path / "tests" / "benchmarks" / "corpus_rev4.json"
+    corpus_path.parent.mkdir(parents=True)
+    corpus_path.write_text(json.dumps({"issues": [{"issue_id": 5788}]}))
+
+    decision = classify_proof_first_queue_issue(
+        "Epic #8665 should not hide an explicit staged rev4 issue",
+        "Single-file exception hygiene task.",
+        labels=("autonomous", "boss-ready"),
+        issue_number=5788,
+        repo_root=tmp_path,
+    )
+
+    assert decision.allowed is True
+    assert decision.lane == "staged_rev4_corpus"
 
 
 @pytest.mark.parametrize(

--- a/tests/swarm/test_proof_first_queue_classification.py
+++ b/tests/swarm/test_proof_first_queue_classification.py
@@ -88,6 +88,36 @@ def test_classifies_blocked_roadmap_lane(
 
 
 @pytest.mark.parametrize(
+    ("title", "body", "expected_term"),
+    [
+        (
+            "Strategy mission cadence: reconcile proof docs for Epic #8665",
+            "Status docs must align with proof drift before the strategy mission queue moves.",
+            "#8665",
+        ),
+        (
+            "Open Strategy Mission Queue worker",
+            "Roadmap proof drift should stay queued until the prior external gate verifies.",
+            "strategy mission queue",
+        ),
+    ],
+)
+def test_strategy_mission_tracking_stays_out_of_boss_ready(
+    title: str, body: str, expected_term: str
+) -> None:
+    decision = classify_proof_first_queue_issue(
+        title,
+        body,
+        labels=("boss-ready",),
+    )
+
+    assert decision.allowed is False
+    assert decision.lane == "strategy_mission_gated"
+    assert expected_term in decision.matched_terms
+    assert "docs_proof_drift" != decision.lane
+
+
+@pytest.mark.parametrize(
     ("title", "body", "expected_terms"),
     [
         (


### PR DESCRIPTION
## Summary
- add a fail-closed strategy_mission_gated queue classifier before proof/docs keyword heuristics
- index Epic #8665 in the roadmap intake register
- make the canonical queue rule discoverable in NEXT_STEPS_CANONICAL

## Validation
- python3 -m pytest tests/swarm/test_proof_first_queue.py tests/swarm/test_proof_first_queue_classification.py
- pre-commit run --files aragora/swarm/proof_first_queue.py tests/swarm/test_proof_first_queue.py tests/swarm/test_proof_first_queue_classification.py docs/status/ROADMAP_INTAKE_REGISTER.md docs/status/NEXT_STEPS_CANONICAL.md
- git push hook: mypy changed aragora files passed

## Notes
- Follow-up to the #8703 Grok dissent: strategy mission cadence / Epic #8665 is durable planning truth, not wholesale boss-ready work.
- Draft only; do not merge in this cycle.