### PR TITLE
fix(evidence): expose bounded reviewer timeouts

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -732,6 +732,20 @@ def add_review_queue_parser(subparsers: argparse._SubParsersAction) -> None:
     collect_evidence_arg(
         "--apply", action="store_true", help="Post Tier 0-2 evidence; Tier 3-4 prepare only."
     )
+    collect_evidence_arg(
+        "--reviewer-timeout",
+        dest="reviewer_timeout",
+        type=float,
+        default=None,
+        help="Per-reviewer timeout in seconds for this invocation.",
+    )
+    collect_evidence_arg(
+        "--overall-timeout",
+        dest="overall_timeout",
+        type=float,
+        default=None,
+        help="Overall reviewer orchestration timeout in seconds for this invocation.",
+    )
     collect_evidence_arg("--json", dest="json_output", action="store_true", help="Output as JSON")
 
     lint_comment_p = sub.add_parser(
@@ -1367,6 +1381,8 @@ def _cmd_collect_evidence(args: argparse.Namespace) -> int:
         author=getattr(args, "author", None),
         apply=bool(getattr(args, "apply", False)),
         json_output=json_output,
+        reviewer_timeout_seconds=getattr(args, "reviewer_timeout", None),
+        overall_timeout_seconds=getattr(args, "overall_timeout", None),
     )
 
 

--- a/aragora/cli/commands/review_queue_transport.py
+++ b/aragora/cli/commands/review_queue_transport.py
@@ -18,6 +18,7 @@ _GITHUB_TRANSPORT_ERROR_MARKERS = (
     "api rate limit already exceeded",
     "check your internet connection",
     "client.timeout exceeded",
+    "command timed out",
     "connection refused",
     "connection reset",
     "connection timed out",
@@ -35,6 +36,7 @@ _GITHUB_TRANSPORT_ERROR_MARKERS = (
     "rate limit exceeded",
     "temporary failure in name resolution",
     "timeout awaiting response headers",
+    "timed out after",
     "tls handshake timeout",
 )
 

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -2354,6 +2354,20 @@ def _add_review_queue_parser(subparsers) -> None:
         help="Post evidence for Tier 0-2 PRs (Tier 3-4 always prepare-only).",
     )
     collect_evidence_parser.add_argument(
+        "--reviewer-timeout",
+        dest="reviewer_timeout",
+        type=float,
+        default=None,
+        help="Per-reviewer timeout in seconds for this invocation.",
+    )
+    collect_evidence_parser.add_argument(
+        "--overall-timeout",
+        dest="overall_timeout",
+        type=float,
+        default=None,
+        help="Overall reviewer orchestration timeout in seconds for this invocation.",
+    )
+    collect_evidence_parser.add_argument(
         "--json", dest="json_output", action="store_true", help="Output as JSON"
     )
     collect_evidence_parser.set_defaults(

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -40,6 +40,7 @@ import secrets
 import signal
 import subprocess
 import tempfile
+import threading
 import time
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from contextlib import contextmanager
@@ -2131,7 +2132,7 @@ def _fetch_preflight_context(
         try:
             return context_fetcher(repo, pr)
         except Exception as exc:  # noqa: BLE001 - classify injected/live transport errors.
-            if not _is_github_transport_error(exc):
+            if not _is_preflight_context_transport_error(exc):
                 raise
             last_transport_error = exc
             if attempt >= bounded_attempts:
@@ -2149,12 +2150,57 @@ def _fetch_preflight_context(
     )
 
 
+_PREFLIGHT_TIMEOUT_MARKERS = (
+    "client.timeout exceeded",
+    "command timed out",
+    "context deadline exceeded",
+    "operation timed out",
+    "timeout awaiting response headers",
+    "timed out after",
+    "tls handshake timeout",
+)
+_PREFLIGHT_GITHUB_ANCHORS = (
+    " api.github.com",
+    "github.com",
+    "gh ",
+    "gh:",
+    "gh.exe",
+    "gh pr ",
+    "gh api ",
+    "repos/",
+)
+
+
+def _is_preflight_context_transport_error(error: BaseException) -> bool:
+    """Classify only GitHub transport failures as preflight transport blockers.
+
+    ``context_fetcher`` is injected in tests and in future orchestration callers.
+    Timeout-shaped words in arbitrary business/auth/parser exceptions should not
+    be retried or reported as GitHub transport just because they contain
+    "timed out after". Raw ``subprocess.TimeoutExpired`` is still transport for
+    this preflight phase because the supported live fetcher shells out to ``gh``.
+    """
+    if isinstance(error, subprocess.TimeoutExpired):
+        return True
+    if not _is_github_transport_error(error):
+        return False
+    text = str(error or "").lower()
+    if any(marker in text for marker in _PREFLIGHT_TIMEOUT_MARKERS):
+        return any(anchor in text for anchor in _PREFLIGHT_GITHUB_ANCHORS)
+    return True
+
+
 def _reviewer_process_context() -> Any:
     """Return a process context usable for locally injected reviewer callables."""
     try:
         methods = multiprocessing.get_all_start_methods()
     except (AttributeError, ValueError):  # pragma: no cover - platform defensive.
         methods = []
+    if threading.active_count() > 1:
+        for method in ("forkserver", "spawn"):
+            if method in methods:
+                return multiprocessing.get_context(method)
+        raise RuntimeError("cannot safely fork reviewer workers from a multi-threaded parent")
     if "fork" in methods:
         return multiprocessing.get_context("fork")
     return multiprocessing.get_context()
@@ -2310,7 +2356,16 @@ def _run_reviewers_with_overall_timeout(
     overall_timeout_seconds: float,
 ) -> tuple[dict[str, ReviewerResult], list[str]]:
     """Run reviewers with a hard orchestration deadline and terminate stragglers."""
-    ctx = _reviewer_process_context()
+    try:
+        ctx = _reviewer_process_context()
+    except (OSError, RuntimeError, ValueError) as exc:
+        return (
+            {
+                family: ReviewerResult(family, "", False, f"{type(exc).__name__}: {str(exc)[:200]}")
+                for family in families
+            },
+            [],
+        )
     deadline = time.monotonic() + overall_timeout_seconds
     pending = list(families)
     active: list[_ReviewerWorker] = []
@@ -2327,9 +2382,26 @@ def _run_reviewers_with_overall_timeout(
                     family, "", False, f"{type(exc).__name__}: {str(exc)[:200]}"
                 )
 
+    def reap_finished() -> None:
+        finished = [worker for worker in active if not worker.process.is_alive()]
+        for worker in finished:
+            worker.process.join(0)
+            results[worker.family] = _read_reviewer_worker_result(worker)
+            _close_reviewer_worker(worker)
+            active.remove(worker)
+        if finished:
+            start_more()
+
     start_more()
     while active or pending:
+        reap_finished()
+        if not active and not pending:
+            break
+
         if time.monotonic() >= deadline:
+            reap_finished()
+            if not active and not pending:
+                break
             timed_out.extend(worker.family for worker in active)
             timed_out.extend(pending)
             pending.clear()
@@ -2338,16 +2410,8 @@ def _run_reviewers_with_overall_timeout(
             active.clear()
             break
 
-        finished = [worker for worker in active if not worker.process.is_alive()]
-        if not finished:
-            time.sleep(0.01)
-            continue
-        for worker in finished:
-            worker.process.join(0)
-            results[worker.family] = _read_reviewer_worker_result(worker)
-            _close_reviewer_worker(worker)
-            active.remove(worker)
-        start_more()
+        remaining = max(0.0, deadline - time.monotonic())
+        time.sleep(min(0.01, remaining))
 
     return results, timed_out
 

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -2221,7 +2221,10 @@ def _signal_reviewer_process_group(
     try:
         os.killpg(pid, sig)
     except ProcessLookupError:
-        return True
+        try:
+            return not process.is_alive()
+        except (OSError, ValueError):
+            return False
     except OSError:
         return False
     return True

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -395,6 +395,18 @@ def _timeout_seconds(env_name: str, default: int) -> float:
     return value
 
 
+def _positive_timeout_seconds(value: float | int | str | None, name: str) -> float | None:
+    if value is None:
+        return None
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a positive finite number of seconds") from exc
+    if not math.isfinite(seconds) or seconds <= 0:
+        raise ValueError(f"{name} must be a positive finite number of seconds")
+    return seconds
+
+
 def _format_seconds(seconds: float) -> str:
     return f"{seconds:g}"
 
@@ -466,6 +478,9 @@ class CollectOutcome:
     posted: list[str] = field(default_factory=list)
     post_errors: list[str] = field(default_factory=list)
     quorum_rerun: dict[str, Any] | None = None
+    orchestration_timeout: bool = False
+    timed_out_families: list[str] = field(default_factory=list)
+    overall_timeout_seconds: float | None = None
     # Captured ONCE at construction (not re-read from os.environ per property
     # access) so a security-relevant gate decision stays deterministic within a
     # single settlement flow even if the process env mutates mid-run.
@@ -548,6 +563,9 @@ class CollectOutcome:
             "posted_families": list(self.posted),
             "post_errors": list(self.post_errors),
             "quorum_rerun": self.quorum_rerun,
+            "orchestration_timeout": self.orchestration_timeout,
+            "timed_out_families": list(self.timed_out_families),
+            "overall_timeout_seconds": self.overall_timeout_seconds,
             "items": [
                 {
                     "family": item.family,
@@ -1251,10 +1269,12 @@ def _run_grok_reviewer(prompt: str) -> ReviewerResult:
     """
     grok_bin = _resolve_grok_build_bin()
     if os.path.isfile(grok_bin) and os.access(grok_bin, os.X_OK):
+        timeout = _timeout_seconds(_REVIEWER_TIMEOUT_ENV, _REVIEWER_TIMEOUT)
         result = _run_argv_cli_reviewer(
             "grok",
             [grok_bin, "--sandbox", "read-only", "--no-plan", "-p", prompt],
             _GROK_BUILD_HARNESS,
+            timeout=timeout,
         )
         if result.ok or not _env_key_present("XAI_API_KEY", "GROK_API_KEY"):
             return result
@@ -1272,8 +1292,12 @@ def _run_gemini_reviewer(prompt: str) -> ReviewerResult:
 
     agy_path = shutil.which("agy")
     if agy_path:
+        timeout = _timeout_seconds(_REVIEWER_TIMEOUT_ENV, _REVIEWER_TIMEOUT)
         result = _run_argv_cli_reviewer(
-            "gemini", [agy_path, "--sandbox", "-p", prompt], _ANTIGRAVITY_HARNESS
+            "gemini",
+            [agy_path, "--sandbox", "-p", prompt],
+            _ANTIGRAVITY_HARNESS,
+            timeout=timeout,
         )
         if result.ok or not _env_key_present("GEMINI_API_KEY", "GOOGLE_API_KEY"):
             return result
@@ -1848,8 +1872,12 @@ def collect_evidence(
     poster: Callable[[str, int, str], None] = default_poster,
     quorum_reconciler: Callable[[str, int], dict[str, Any] | None] | None = None,
     env: dict[str, str] | None = None,
+    overall_timeout_seconds: float | None = None,
 ) -> CollectOutcome:
     """Run reviewers, validate evidence, and post only when tier-gating allows."""
+    overall_timeout_seconds = _positive_timeout_seconds(
+        overall_timeout_seconds, "overall_timeout_seconds"
+    )
     ctx = context_fetcher(repo, pr)
     head_sha = str(ctx.get("head_sha") or "").strip()
     head_committed_at = str(ctx.get("head_committed_at") or "")
@@ -1867,6 +1895,7 @@ def collect_evidence(
         tier=tier,
         action=action,
         action_reason=action_reason,
+        overall_timeout_seconds=overall_timeout_seconds,
     )
 
     prompt = prompt_builder(repo, pr, ctx)
@@ -1897,7 +1926,29 @@ def collect_evidence(
                 pool.submit(_run_reviewer_with_infra_retry, reviewer_runner, family, prompt): family
                 for family in supported
             }
-            for future in concurrent.futures.as_completed(future_to_family):
+            if overall_timeout_seconds is None:
+                done = set(concurrent.futures.as_completed(future_to_family))
+                not_done: set[concurrent.futures.Future[ReviewerResult]] = set()
+            else:
+                done, not_done = concurrent.futures.wait(
+                    future_to_family, timeout=overall_timeout_seconds
+                )
+            if not_done:
+                outcome.orchestration_timeout = True
+                outcome.timed_out_families = [
+                    future_to_family[future] for future in future_to_family if future in not_done
+                ]
+                for future in not_done:
+                    future.cancel()
+                    family = future_to_family[future]
+                    reviews[family] = ReviewerResult(
+                        family,
+                        "",
+                        False,
+                        "reviewer orchestration timed out after "
+                        f"{_format_seconds(overall_timeout_seconds or 0)}s",
+                    )
+            for future in done:
                 family = future_to_family[future]
                 try:
                     reviews[family] = future.result()
@@ -1938,6 +1989,15 @@ def collect_evidence(
                 problems=list(lint.get("problems") or []),
             )
         )
+
+    if outcome.orchestration_timeout:
+        outcome.action = "prepare"
+        outcome.action_reason = (
+            "reviewer orchestration timeout "
+            f"({', '.join(outcome.timed_out_families) or 'deadline expired'}); "
+            "prepared evidence only"
+        )
+        return outcome
 
     if action == "post":
         if outcome.dissenting_families:
@@ -2270,6 +2330,48 @@ def _render_outcome(outcome: CollectOutcome) -> str:
     return "\n".join(lines)
 
 
+@contextmanager
+def _scoped_env(overrides: dict[str, str]) -> Iterator[None]:
+    previous = {key: os.environ.get(key) for key in overrides}
+    try:
+        os.environ.update(overrides)
+        yield
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+def _reviewer_timeout_env_overrides(
+    reviewer_timeout_seconds: float | None,
+    overall_timeout_seconds: float | None,
+) -> dict[str, str]:
+    reviewer_timeout_seconds = _positive_timeout_seconds(
+        reviewer_timeout_seconds, "reviewer_timeout_seconds"
+    )
+    overall_timeout_seconds = _positive_timeout_seconds(
+        overall_timeout_seconds, "overall_timeout_seconds"
+    )
+    if reviewer_timeout_seconds is None and overall_timeout_seconds is None:
+        return {}
+    if reviewer_timeout_seconds is None:
+        effective = overall_timeout_seconds
+    elif overall_timeout_seconds is None:
+        effective = reviewer_timeout_seconds
+    else:
+        effective = min(reviewer_timeout_seconds, overall_timeout_seconds)
+    if effective is None:  # pragma: no cover - defensive guard for future edits.
+        return {}
+    value = _format_seconds(effective)
+    return {
+        _CLAUDE_TIMEOUT_ENV: value,
+        _CODEX_TIMEOUT_ENV: value,
+        _REVIEWER_TIMEOUT_ENV: value,
+    }
+
+
 def run_collect_cli(
     *,
     repo: str,
@@ -2279,6 +2381,8 @@ def run_collect_cli(
     apply: bool,
     json_output: bool,
     prepared_json: Path | None = None,
+    reviewer_timeout_seconds: float | None = None,
+    overall_timeout_seconds: float | None = None,
     printer: Callable[[str], None] = print,
 ) -> int:
     """Shared entry point for the script and ``review-queue collect-evidence``.
@@ -2292,27 +2396,35 @@ def run_collect_cli(
     fams = tuple(families) if families else DEFAULT_FAMILIES
     resolved_author = author or resolve_author()
     try:
-        if prepared_json is None:
-            outcome = collect_evidence(
-                repo=repo,
-                pr=pr,
-                families=fams,
-                author=resolved_author,
-                apply=apply,
-                env=merge_quorum_io.aragora_env(),
-                quorum_reconciler=default_quorum_reconciler if apply else None,
-            )
-        else:
-            outcome = apply_prepared_evidence(
-                repo=repo,
-                pr=pr,
-                prepared_json=prepared_json,
-                author=resolved_author,
-                apply=apply,
-                families=fams,
-                env=merge_quorum_io.aragora_env(),
-                quorum_reconciler=default_quorum_reconciler if apply else None,
-            )
+        overall_timeout_seconds = _positive_timeout_seconds(
+            overall_timeout_seconds, "overall_timeout_seconds"
+        )
+        env_overrides = _reviewer_timeout_env_overrides(
+            reviewer_timeout_seconds, overall_timeout_seconds
+        )
+        with _scoped_env(env_overrides):
+            if prepared_json is None:
+                outcome = collect_evidence(
+                    repo=repo,
+                    pr=pr,
+                    families=fams,
+                    author=resolved_author,
+                    apply=apply,
+                    env=merge_quorum_io.aragora_env(),
+                    quorum_reconciler=default_quorum_reconciler if apply else None,
+                    overall_timeout_seconds=overall_timeout_seconds,
+                )
+            else:
+                outcome = apply_prepared_evidence(
+                    repo=repo,
+                    pr=pr,
+                    prepared_json=prepared_json,
+                    author=resolved_author,
+                    apply=apply,
+                    families=fams,
+                    env=merge_quorum_io.aragora_env(),
+                    quorum_reconciler=default_quorum_reconciler if apply else None,
+                )
     except (ValueError, RuntimeError, OSError, subprocess.SubprocessError) as exc:
         if json_output:
             printer(json.dumps({"mode": "collect_evidence", "error": str(exc)}, indent=2))
@@ -2324,4 +2436,4 @@ def run_collect_cli(
         printer(json.dumps(outcome.to_dict(), indent=2))
     else:
         printer(_render_outcome(outcome))
-    return 0 if outcome.has_supportive_quorum else 1
+    return 0 if outcome.has_supportive_quorum and not outcome.orchestration_timeout else 1

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -48,6 +48,10 @@ from pathlib import Path
 from typing import Any
 
 from aragora.cli.commands.review_queue_comment_verdicts import has_blocking_finding_or_label
+from aragora.cli.commands.review_queue_transport import (
+    GITHUB_TRANSPORT_BLOCKED_STATUS,
+    _is_github_transport_error,
+)
 from aragora.swarm import merge_quorum_io
 
 logger = logging.getLogger(__name__)
@@ -294,6 +298,7 @@ QUORUM_RERUN_MAX_PER_HEAD = 3
 QUORUM_STATE_LOCK_TIMEOUT_SECONDS = 60.0
 QUORUM_STATE_LOCK_POLL_SECONDS = 0.2
 QUORUM_STATE_LOCK_STALE_SECONDS = 15 * 60
+_PREFLIGHT_CONTEXT_ATTEMPTS = 2
 _REVIEWER_RESULT_QUEUE_TIMEOUT = 1.0
 # Cap the diff fed to reviewers so a huge PR cannot blow the model context.
 _MAX_DIFF_CHARS = 60_000
@@ -583,6 +588,64 @@ class CollectOutcome:
                 for item in self.items
             ],
             "failures": [{"family": f.family, "error": f.error} for f in self.failures],
+        }
+
+
+class CollectPreflightTransportError(RuntimeError):
+    """Fail-closed diagnostic for PR-context transport failure before reviewers."""
+
+    def __init__(
+        self,
+        *,
+        repo: str,
+        pr: int,
+        phase: str,
+        error: BaseException,
+        attempts: int,
+    ) -> None:
+        self.repo = repo
+        self.pr = pr
+        self.phase = phase
+        self.error = error
+        self.attempts = attempts
+        super().__init__(
+            f"GitHub transport blocked during {phase} for {repo}#{pr} "
+            f"after {attempts} attempts: {error}"
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "mode": "collect_evidence",
+            "status": GITHUB_TRANSPORT_BLOCKED_STATUS,
+            "transport_blocked": True,
+            "preserve_no_mutate": True,
+            "retryable": True,
+            "phase": self.phase,
+            "repo": self.repo,
+            "pr_number": self.pr,
+            "error": str(self.error),
+            "attempts": self.attempts,
+            "head_sha": "",
+            "head_committed_at": "",
+            "tier": None,
+            "tiered_gate": tiered_merge_gate_enabled(),
+            "policy_version": QUORUM_POLICY_VERSION,
+            "action": "prepare",
+            "action_reason": (
+                "GitHub transport blocked before reviewer execution; prepared evidence only"
+            ),
+            "counting_families": [],
+            "supportive_families": [],
+            "dissenting_families": [],
+            "has_supportive_quorum": False,
+            "posted_families": [],
+            "post_errors": [],
+            "quorum_rerun": None,
+            "orchestration_timeout": False,
+            "timed_out_families": [],
+            "overall_timeout_seconds": None,
+            "items": [],
+            "failures": [],
         }
 
 
@@ -1878,7 +1941,7 @@ def collect_evidence(
     overall_timeout_seconds = _positive_timeout_seconds(
         overall_timeout_seconds, "overall_timeout_seconds"
     )
-    ctx = context_fetcher(repo, pr)
+    ctx = _fetch_preflight_context(repo, pr, context_fetcher)
     head_sha = str(ctx.get("head_sha") or "").strip()
     head_committed_at = str(ctx.get("head_committed_at") or "")
     if not head_sha:
@@ -2049,6 +2112,36 @@ def collect_evidence(
                 outcome.quorum_rerun = {"applied": False, "error": str(exc)[:200]}
 
     return outcome
+
+
+def _fetch_preflight_context(
+    repo: str,
+    pr: int,
+    context_fetcher: Callable[[str, int], dict[str, Any]],
+    *,
+    attempts: int = _PREFLIGHT_CONTEXT_ATTEMPTS,
+) -> dict[str, Any]:
+    """Fetch initial PR context with bounded transport-only retries."""
+    bounded_attempts = max(1, attempts)
+    last_transport_error: BaseException | None = None
+    for attempt in range(1, bounded_attempts + 1):
+        try:
+            return context_fetcher(repo, pr)
+        except Exception as exc:  # noqa: BLE001 - classify injected/live transport errors.
+            if not _is_github_transport_error(exc):
+                raise
+            last_transport_error = exc
+            if attempt >= bounded_attempts:
+                break
+    if last_transport_error is None:  # pragma: no cover - defensive future-proofing.
+        last_transport_error = RuntimeError("preflight context unavailable")
+    raise CollectPreflightTransportError(
+        repo=repo,
+        pr=pr,
+        phase="preflight_pr_context",
+        error=last_transport_error,
+        attempts=bounded_attempts,
+    )
 
 
 def _clone_prepared_items(
@@ -2425,6 +2518,12 @@ def run_collect_cli(
                     env=merge_quorum_io.aragora_env(),
                     quorum_reconciler=default_quorum_reconciler if apply else None,
                 )
+    except CollectPreflightTransportError as exc:
+        if json_output:
+            printer(json.dumps(exc.to_dict(), indent=2))
+        else:
+            printer(f"error: {exc}")
+        return 1
     except (ValueError, RuntimeError, OSError, subprocess.SubprocessError) as exc:
         if json_output:
             printer(json.dumps({"mode": "collect_evidence", "error": str(exc)}, indent=2))

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -2165,13 +2165,10 @@ def _reviewer_process_worker(
     prompt: str,
     result_queue: multiprocessing.Queue,
 ) -> None:
-    try:
-        result = _run_reviewer_with_infra_retry(reviewer_runner, family, prompt)
-    except Exception as exc:  # noqa: BLE001 - one bad reviewer must not abort orchestration.
-        result = ReviewerResult(family, "", False, f"{type(exc).__name__}: {str(exc)[:200]}")
+    result = _run_reviewer_with_infra_retry(reviewer_runner, family, prompt)
     try:
         result_queue.put(result)
-    except Exception:
+    except (OSError, ValueError):
         # Parent will report "exited without returning a result"; do not let a
         # broken queue keep the worker alive.
         pass
@@ -2203,11 +2200,11 @@ def _start_reviewer_worker(
 def _close_reviewer_worker(worker: _ReviewerWorker) -> None:
     try:
         worker.result_queue.close()
-    except Exception:
+    except (OSError, ValueError):
         pass
     try:
         worker.result_queue.join_thread()
-    except Exception:
+    except (AssertionError, OSError, ValueError):
         pass
 
 
@@ -2216,13 +2213,13 @@ def _terminate_reviewer_worker(worker: _ReviewerWorker) -> None:
     if process.is_alive():
         try:
             process.terminate()
-        except Exception:
+        except (OSError, ValueError):
             pass
         process.join(_REVIEWER_CLEANUP_TIMEOUT)
     if process.is_alive():
         try:
             process.kill()
-        except Exception:
+        except (OSError, ValueError):
             pass
         process.join(_REVIEWER_CLEANUP_TIMEOUT)
     _close_reviewer_worker(worker)
@@ -2271,7 +2268,7 @@ def _run_reviewers_with_overall_timeout(
             family = pending.pop(0)
             try:
                 active.append(_start_reviewer_worker(ctx, reviewer_runner, family, prompt))
-            except Exception as exc:  # noqa: BLE001 - report start failures as reviewer failures.
+            except (OSError, RuntimeError, ValueError) as exc:
                 results[family] = ReviewerResult(
                     family, "", False, f"{type(exc).__name__}: {str(exc)[:200]}"
                 )

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -37,6 +37,7 @@ import os
 import queue
 import re
 import secrets
+import signal
 import subprocess
 import tempfile
 import time
@@ -2165,6 +2166,7 @@ def _reviewer_process_worker(
     prompt: str,
     result_queue: multiprocessing.Queue,
 ) -> None:
+    _isolate_reviewer_worker_process_group()
     result = _run_reviewer_with_infra_retry(reviewer_runner, family, prompt)
     try:
         result_queue.put(result)
@@ -2174,11 +2176,55 @@ def _reviewer_process_worker(
         pass
 
 
+def _isolate_reviewer_worker_process_group() -> None:
+    """Put POSIX reviewer workers in their own process group.
+
+    CLI reviewer subprocesses inherit this group, letting the parent terminate
+    the whole timed-out reviewer tree instead of only the Python supervisor.
+    Guard the main process because unit tests may call the worker directly.
+    """
+    if os.name != "posix" or not hasattr(os, "setsid"):
+        return
+    try:
+        if multiprocessing.current_process().name == "MainProcess":
+            return
+    except Exception:  # pragma: no cover - defensive for nonstandard contexts.
+        return
+    try:
+        os.setsid()
+    except OSError:
+        pass
+
+
 @dataclass
 class _ReviewerWorker:
     family: str
     process: multiprocessing.Process
     result_queue: multiprocessing.Queue
+
+
+def _signal_reviewer_process_group(
+    process: multiprocessing.Process,
+    sig: signal.Signals,
+) -> bool:
+    """Signal a reviewer process group when available.
+
+    Returns ``True`` when the group signal was sent or the group is already
+    gone. Returns ``False`` when the caller should fall back to signaling the
+    supervisor process only.
+    """
+    if os.name != "posix" or not hasattr(os, "killpg"):
+        return False
+    pid = getattr(process, "pid", None)
+    if not isinstance(pid, int) or pid <= 0:
+        return False
+    try:
+        os.killpg(pid, sig)
+    except ProcessLookupError:
+        return True
+    except OSError:
+        return False
+    return True
 
 
 def _start_reviewer_worker(
@@ -2191,7 +2237,7 @@ def _start_reviewer_worker(
     process = ctx.Process(
         target=_reviewer_process_worker,
         args=(reviewer_runner, family, prompt, result_queue),
-        daemon=True,
+        daemon=False,
     )
     process.start()
     return _ReviewerWorker(family=family, process=process, result_queue=result_queue)
@@ -2211,16 +2257,18 @@ def _close_reviewer_worker(worker: _ReviewerWorker) -> None:
 def _terminate_reviewer_worker(worker: _ReviewerWorker) -> None:
     process = worker.process
     if process.is_alive():
-        try:
-            process.terminate()
-        except (OSError, ValueError):
-            pass
+        if not _signal_reviewer_process_group(process, signal.SIGTERM):
+            try:
+                process.terminate()
+            except (OSError, ValueError):
+                pass
         process.join(_REVIEWER_CLEANUP_TIMEOUT)
     if process.is_alive():
-        try:
-            process.kill()
-        except (OSError, ValueError):
-            pass
+        if not _signal_reviewer_process_group(process, signal.SIGKILL):
+            try:
+                process.kill()
+            except (OSError, ValueError):
+                pass
         process.join(_REVIEWER_CLEANUP_TIMEOUT)
     _close_reviewer_worker(worker)
 

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -299,6 +299,7 @@ QUORUM_STATE_LOCK_TIMEOUT_SECONDS = 60.0
 QUORUM_STATE_LOCK_POLL_SECONDS = 0.2
 QUORUM_STATE_LOCK_STALE_SECONDS = 15 * 60
 _PREFLIGHT_CONTEXT_ATTEMPTS = 2
+_PREFLIGHT_CONTEXT_RETRY_DELAY_SECONDS = 0.5
 _REVIEWER_RESULT_QUEUE_TIMEOUT = 1.0
 # Cap the diff fed to reviewers so a huge PR cannot blow the model context.
 _MAX_DIFF_CHARS = 60_000
@@ -1975,49 +1976,49 @@ def collect_evidence(
         seen.add(family)
         ordered_families.append(family)
 
-    # Run the supported reviewers concurrently. Each runner already bounds itself
-    # with its own timeout and isolates its work in a child subprocess/process, so
-    # threads here only wait -- but they turn serial wall-time (sum of timeouts)
-    # into roughly the slowest single reviewer. One reviewer raising never aborts
-    # the run; it is recorded as a failure like any empty/non-ok result.
+    # Run the supported reviewers concurrently. Without an orchestration timeout,
+    # a ThreadPoolExecutor is sufficient and keeps test fakes simple. With an
+    # orchestration timeout, use process-supervised reviewer workers so the
+    # collector can fail closed at the deadline without waiting for a stuck
+    # reviewer thread during executor shutdown.
     supported = [family for family in ordered_families if family in FAMILY_PROVIDERS]
     reviews: dict[str, ReviewerResult] = {}
     if supported:
-        max_workers = min(len(supported), _MAX_REVIEWER_WORKERS)
-        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
-            future_to_family = {
-                pool.submit(_run_reviewer_with_infra_retry, reviewer_runner, family, prompt): family
-                for family in supported
-            }
-            if overall_timeout_seconds is None:
+        if overall_timeout_seconds is None:
+            max_workers = min(len(supported), _MAX_REVIEWER_WORKERS)
+            with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
+                future_to_family = {
+                    pool.submit(
+                        _run_reviewer_with_infra_retry, reviewer_runner, family, prompt
+                    ): family
+                    for family in supported
+                }
                 done = set(concurrent.futures.as_completed(future_to_family))
-                not_done: set[concurrent.futures.Future[ReviewerResult]] = set()
-            else:
-                done, not_done = concurrent.futures.wait(
-                    future_to_family, timeout=overall_timeout_seconds
-                )
-            if not_done:
-                outcome.orchestration_timeout = True
-                outcome.timed_out_families = [
-                    future_to_family[future] for future in future_to_family if future in not_done
-                ]
-                for future in not_done:
-                    future.cancel()
+                for future in done:
                     family = future_to_family[future]
+                    try:
+                        reviews[family] = future.result()
+                    except Exception as exc:  # noqa: BLE001 - one bad reviewer must not abort.
+                        reviews[family] = ReviewerResult(
+                            family, "", False, f"{type(exc).__name__}: {str(exc)[:200]}"
+                        )
+        else:
+            reviews, timed_out_families = _run_reviewers_with_overall_timeout(
+                reviewer_runner=reviewer_runner,
+                prompt=prompt,
+                families=supported,
+                overall_timeout_seconds=overall_timeout_seconds,
+            )
+            if timed_out_families:
+                outcome.orchestration_timeout = True
+                outcome.timed_out_families = timed_out_families
+                for family in timed_out_families:
                     reviews[family] = ReviewerResult(
                         family,
                         "",
                         False,
                         "reviewer orchestration timed out after "
                         f"{_format_seconds(overall_timeout_seconds or 0)}s",
-                    )
-            for future in done:
-                family = future_to_family[future]
-                try:
-                    reviews[family] = future.result()
-                except Exception as exc:  # noqa: BLE001 - one bad reviewer must not abort the run
-                    reviews[family] = ReviewerResult(
-                        family, "", False, f"{type(exc).__name__}: {str(exc)[:200]}"
                     )
 
     for family in ordered_families:
@@ -2120,6 +2121,7 @@ def _fetch_preflight_context(
     context_fetcher: Callable[[str, int], dict[str, Any]],
     *,
     attempts: int = _PREFLIGHT_CONTEXT_ATTEMPTS,
+    retry_delay_seconds: float = _PREFLIGHT_CONTEXT_RETRY_DELAY_SECONDS,
 ) -> dict[str, Any]:
     """Fetch initial PR context with bounded transport-only retries."""
     bounded_attempts = max(1, attempts)
@@ -2133,6 +2135,8 @@ def _fetch_preflight_context(
             last_transport_error = exc
             if attempt >= bounded_attempts:
                 break
+            if retry_delay_seconds > 0:
+                time.sleep(retry_delay_seconds)
     if last_transport_error is None:  # pragma: no cover - defensive future-proofing.
         last_transport_error = RuntimeError("preflight context unavailable")
     raise CollectPreflightTransportError(
@@ -2142,6 +2146,159 @@ def _fetch_preflight_context(
         error=last_transport_error,
         attempts=bounded_attempts,
     )
+
+
+def _reviewer_process_context() -> Any:
+    """Return a process context usable for locally injected reviewer callables."""
+    try:
+        methods = multiprocessing.get_all_start_methods()
+    except (AttributeError, ValueError):  # pragma: no cover - platform defensive.
+        methods = []
+    if "fork" in methods:
+        return multiprocessing.get_context("fork")
+    return multiprocessing.get_context()
+
+
+def _reviewer_process_worker(
+    reviewer_runner: Callable[[str, str], ReviewerResult],
+    family: str,
+    prompt: str,
+    result_queue: multiprocessing.Queue,
+) -> None:
+    try:
+        result = _run_reviewer_with_infra_retry(reviewer_runner, family, prompt)
+    except Exception as exc:  # noqa: BLE001 - one bad reviewer must not abort orchestration.
+        result = ReviewerResult(family, "", False, f"{type(exc).__name__}: {str(exc)[:200]}")
+    try:
+        result_queue.put(result)
+    except Exception:
+        # Parent will report "exited without returning a result"; do not let a
+        # broken queue keep the worker alive.
+        pass
+
+
+@dataclass
+class _ReviewerWorker:
+    family: str
+    process: multiprocessing.Process
+    result_queue: multiprocessing.Queue
+
+
+def _start_reviewer_worker(
+    ctx: Any,
+    reviewer_runner: Callable[[str, str], ReviewerResult],
+    family: str,
+    prompt: str,
+) -> _ReviewerWorker:
+    result_queue: multiprocessing.Queue = ctx.Queue(maxsize=1)
+    process = ctx.Process(
+        target=_reviewer_process_worker,
+        args=(reviewer_runner, family, prompt, result_queue),
+        daemon=True,
+    )
+    process.start()
+    return _ReviewerWorker(family=family, process=process, result_queue=result_queue)
+
+
+def _close_reviewer_worker(worker: _ReviewerWorker) -> None:
+    try:
+        worker.result_queue.close()
+    except Exception:
+        pass
+    try:
+        worker.result_queue.join_thread()
+    except Exception:
+        pass
+
+
+def _terminate_reviewer_worker(worker: _ReviewerWorker) -> None:
+    process = worker.process
+    if process.is_alive():
+        try:
+            process.terminate()
+        except Exception:
+            pass
+        process.join(_REVIEWER_CLEANUP_TIMEOUT)
+    if process.is_alive():
+        try:
+            process.kill()
+        except Exception:
+            pass
+        process.join(_REVIEWER_CLEANUP_TIMEOUT)
+    _close_reviewer_worker(worker)
+
+
+def _read_reviewer_worker_result(worker: _ReviewerWorker) -> ReviewerResult:
+    try:
+        payload = worker.result_queue.get_nowait()
+    except queue.Empty:
+        return ReviewerResult(
+            worker.family,
+            "",
+            False,
+            f"{worker.family} reviewer exited without returning a result",
+        )
+    if isinstance(payload, ReviewerResult):
+        return payload
+    if isinstance(payload, dict):
+        return ReviewerResult(
+            str(payload.get("family") or worker.family),
+            str(payload.get("text") or ""),
+            bool(payload.get("ok")),
+            str(payload.get("error") or ""),
+            str(payload.get("harness") or ""),
+        )
+    return ReviewerResult(worker.family, "", False, "reviewer returned invalid result")
+
+
+def _run_reviewers_with_overall_timeout(
+    *,
+    reviewer_runner: Callable[[str, str], ReviewerResult],
+    prompt: str,
+    families: Sequence[str],
+    overall_timeout_seconds: float,
+) -> tuple[dict[str, ReviewerResult], list[str]]:
+    """Run reviewers with a hard orchestration deadline and terminate stragglers."""
+    ctx = _reviewer_process_context()
+    deadline = time.monotonic() + overall_timeout_seconds
+    pending = list(families)
+    active: list[_ReviewerWorker] = []
+    results: dict[str, ReviewerResult] = {}
+    timed_out: list[str] = []
+
+    def start_more() -> None:
+        while pending and len(active) < _MAX_REVIEWER_WORKERS:
+            family = pending.pop(0)
+            try:
+                active.append(_start_reviewer_worker(ctx, reviewer_runner, family, prompt))
+            except Exception as exc:  # noqa: BLE001 - report start failures as reviewer failures.
+                results[family] = ReviewerResult(
+                    family, "", False, f"{type(exc).__name__}: {str(exc)[:200]}"
+                )
+
+    start_more()
+    while active or pending:
+        if time.monotonic() >= deadline:
+            timed_out.extend(worker.family for worker in active)
+            timed_out.extend(pending)
+            pending.clear()
+            for worker in active:
+                _terminate_reviewer_worker(worker)
+            active.clear()
+            break
+
+        finished = [worker for worker in active if not worker.process.is_alive()]
+        if not finished:
+            time.sleep(0.01)
+            continue
+        for worker in finished:
+            worker.process.join(0)
+            results[worker.family] = _read_reviewer_worker_result(worker)
+            _close_reviewer_worker(worker)
+            active.remove(worker)
+        start_more()
+
+    return results, timed_out
 
 
 def _clone_prepared_items(

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -2280,12 +2280,15 @@ def _read_reviewer_worker_result(worker: _ReviewerWorker) -> ReviewerResult:
     try:
         payload = worker.result_queue.get_nowait()
     except queue.Empty:
-        return ReviewerResult(
-            worker.family,
-            "",
-            False,
-            f"{worker.family} reviewer exited without returning a result",
-        )
+        try:
+            payload = worker.result_queue.get(timeout=_REVIEWER_RESULT_QUEUE_TIMEOUT)
+        except queue.Empty:
+            return ReviewerResult(
+                worker.family,
+                "",
+                False,
+                f"{worker.family} reviewer exited without returning a result",
+            )
     if isinstance(payload, ReviewerResult):
         return payload
     if isinstance(payload, dict):

--- a/scripts/collect_quorum_evidence.py
+++ b/scripts/collect_quorum_evidence.py
@@ -86,6 +86,20 @@ def main(argv: list[str] | None = None) -> int:
         help="Post evidence for Tier 0-2 PRs (Tier 3-4 always prepare-only).",
     )
     parser.add_argument(
+        "--reviewer-timeout",
+        dest="reviewer_timeout",
+        type=float,
+        default=None,
+        help="Per-reviewer timeout in seconds for this invocation.",
+    )
+    parser.add_argument(
+        "--overall-timeout",
+        dest="overall_timeout",
+        type=float,
+        default=None,
+        help="Overall reviewer orchestration timeout in seconds for this invocation.",
+    )
+    parser.add_argument(
         "--prepared-json",
         type=Path,
         default=None,
@@ -105,6 +119,8 @@ def main(argv: list[str] | None = None) -> int:
         apply=args.apply,
         json_output=args.json_output,
         prepared_json=args.prepared_json,
+        reviewer_timeout_seconds=args.reviewer_timeout,
+        overall_timeout_seconds=args.overall_timeout,
     )
 
 

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -5753,6 +5753,10 @@ class TestCommandDispatch:
                 "openai",
                 "--author",
                 "an0mium",
+                "--reviewer-timeout",
+                "90",
+                "--overall-timeout",
+                "150",
                 "--json",
             ]
         )
@@ -5761,6 +5765,8 @@ class TestCommandDispatch:
         assert ns_collect.pr == 6280
         assert ns_collect.reviewers == ["claude", "openai"]
         assert ns_collect.author == "an0mium"
+        assert ns_collect.reviewer_timeout == 90.0
+        assert ns_collect.overall_timeout == 150.0
         assert ns_collect.apply is False
         assert ns_collect.json_output is True
         # run invocation parses

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -15,6 +15,7 @@ import asyncio
 import json
 import multiprocessing
 import os
+import queue
 import signal
 import subprocess
 import threading
@@ -1232,6 +1233,27 @@ def test_signal_reviewer_process_group_falls_back_when_group_missing_but_process
     monkeypatch.setattr(qe.os, "killpg", fake_killpg, raising=False)
 
     assert qe._signal_reviewer_process_group(FakeProcess(), signal.SIGTERM) is False  # type: ignore[arg-type]
+
+
+def test_read_reviewer_worker_result_waits_briefly_for_queue_feeder() -> None:
+    events: list[str] = []
+
+    class FakeQueue:
+        def get_nowait(self) -> ReviewerResult:
+            events.append("get_nowait")
+            raise queue.Empty
+
+        def get(self, timeout: float) -> ReviewerResult:
+            events.append(f"get:{timeout}")
+            return ReviewerResult("grok", "Verdict: PASS", True)
+
+    result = qe._read_reviewer_worker_result(
+        qe._ReviewerWorker("grok", SimpleNamespace(), FakeQueue())  # type: ignore[arg-type]
+    )
+
+    assert result.ok is True
+    assert result.family == "grok"
+    assert events == ["get_nowait", f"get:{qe._REVIEWER_RESULT_QUEUE_TIMEOUT}"]
 
 
 def test_collect_preserves_family_order_despite_completion_order() -> None:

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -15,6 +15,7 @@ import asyncio
 import json
 import multiprocessing
 import os
+import signal
 import subprocess
 import threading
 import time
@@ -1096,6 +1097,121 @@ def test_collect_overall_timeout_does_not_wait_for_stuck_reviewer() -> None:
     assert outcome.timed_out_families == ["grok"]
     assert outcome.action == "prepare"
     assert posted == []
+
+
+def test_start_reviewer_worker_is_not_daemon_so_api_fallback_can_spawn_children() -> None:
+    created: dict[str, object] = {}
+
+    class FakeQueue:
+        pass
+
+    class FakeProcess:
+        def __init__(self, *, target, args, daemon) -> None:
+            created["target"] = target
+            created["args"] = args
+            created["daemon"] = daemon
+
+        def start(self) -> None:
+            created["started"] = True
+
+    class FakeContext:
+        def Queue(self, maxsize: int) -> FakeQueue:
+            assert maxsize == 1
+            return FakeQueue()
+
+        def Process(self, *, target, args, daemon) -> FakeProcess:
+            return FakeProcess(target=target, args=args, daemon=daemon)
+
+    worker = qe._start_reviewer_worker(
+        FakeContext(),
+        lambda family, prompt: ReviewerResult(family, prompt, True),
+        "grok",
+        "review prompt",
+    )
+
+    assert worker.family == "grok"
+    assert created["started"] is True
+    assert created["daemon"] is False
+
+
+def test_reviewer_process_worker_creates_posix_process_group(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    if os.name != "posix" or not hasattr(qe.os, "setsid"):
+        pytest.skip("process-group isolation is POSIX-only")
+    events: list[str] = []
+
+    class FakeQueue:
+        def put(self, result: ReviewerResult) -> None:
+            events.append(f"put:{result.family}:{result.ok}")
+
+    monkeypatch.setattr(qe.os, "setsid", lambda: events.append("setsid"), raising=False)
+    monkeypatch.setattr(
+        qe.multiprocessing,
+        "current_process",
+        lambda: SimpleNamespace(name="ForkProcess-1"),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        qe,
+        "_run_reviewer_with_infra_retry",
+        lambda runner, family, prompt: ReviewerResult(family, "Verdict: PASS", True),
+    )
+
+    qe._reviewer_process_worker(
+        lambda family, prompt: ReviewerResult(family, prompt, True),
+        "grok",
+        "review prompt",
+        FakeQueue(),
+    )
+
+    assert events == ["setsid", "put:grok:True"]
+
+
+def test_terminate_reviewer_worker_signals_posix_process_group(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    if os.name != "posix" or not hasattr(qe.os, "killpg"):
+        pytest.skip("process-group termination is POSIX-only")
+    events: list[tuple[str, int, int] | tuple[str, float]] = []
+
+    class FakeQueue:
+        def close(self) -> None:
+            pass
+
+        def join_thread(self) -> None:
+            pass
+
+    class FakeProcess:
+        pid = 4242
+
+        def __init__(self) -> None:
+            self.alive = True
+
+        def is_alive(self) -> bool:
+            return self.alive
+
+        def join(self, timeout: float) -> None:
+            events.append(("join", timeout))
+
+        def terminate(self) -> None:
+            raise AssertionError("process-group cleanup should not fall back first")
+
+        def kill(self) -> None:
+            raise AssertionError("hard kill should not be needed after SIGTERM")
+
+    fake_process = FakeProcess()
+
+    def fake_killpg(pid: int, sig: int) -> None:
+        events.append(("killpg", pid, sig))
+        fake_process.alive = False
+
+    monkeypatch.setattr(qe.os, "killpg", fake_killpg, raising=False)
+    qe._terminate_reviewer_worker(
+        qe._ReviewerWorker("grok", fake_process, FakeQueue())  # type: ignore[arg-type]
+    )
+
+    assert events == [("killpg", 4242, signal.SIGTERM), ("join", qe._REVIEWER_CLEANUP_TIMEOUT)]
 
 
 def test_collect_preserves_family_order_despite_completion_order() -> None:

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -1214,6 +1214,26 @@ def test_terminate_reviewer_worker_signals_posix_process_group(
     assert events == [("killpg", 4242, signal.SIGTERM), ("join", qe._REVIEWER_CLEANUP_TIMEOUT)]
 
 
+def test_signal_reviewer_process_group_falls_back_when_group_missing_but_process_alive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    if os.name != "posix" or not hasattr(qe.os, "killpg"):
+        pytest.skip("process-group termination is POSIX-only")
+
+    class FakeProcess:
+        pid = 4242
+
+        def is_alive(self) -> bool:
+            return True
+
+    def fake_killpg(pid: int, sig: int) -> None:
+        raise ProcessLookupError(pid)
+
+    monkeypatch.setattr(qe.os, "killpg", fake_killpg, raising=False)
+
+    assert qe._signal_reviewer_process_group(FakeProcess(), signal.SIGTERM) is False  # type: ignore[arg-type]
+
+
 def test_collect_preserves_family_order_despite_completion_order() -> None:
     # The first-requested reviewer (claude) finishes last; items must still be
     # ordered by the caller's requested family order, not by completion.

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -1220,6 +1220,81 @@ def test_collect_severity_gated_finding_free_changes_requested_is_advisory(
     assert all("changes-requested" not in body.lower() for _repo, body in posted)
 
 
+def test_collect_preflight_transport_retries_then_fails_closed_without_reviewers() -> None:
+    attempts = 0
+    reviewer_calls: list[str] = []
+    fakes, posted = _fakes(tier=1)
+
+    def flaky_context_fetcher(repo: str, pr: int) -> dict:
+        nonlocal attempts
+        attempts += 1
+        raise RuntimeError("error connecting to api.github.com")
+
+    def reviewer_runner(family: str, prompt: str) -> ReviewerResult:
+        reviewer_calls.append(family)
+        return ReviewerResult(family, f"Verdict: PASS from {family}", True)
+
+    fakes["context_fetcher"] = flaky_context_fetcher
+    fakes["reviewer_runner"] = reviewer_runner
+
+    with pytest.raises(qe.CollectPreflightTransportError) as raised:
+        collect_evidence(
+            repo="o/r",
+            pr=1,
+            families=["claude", "grok"],
+            author="me",
+            apply=True,
+            **fakes,
+        )
+
+    assert attempts == 2
+    assert reviewer_calls == []
+    assert posted == []
+    payload = raised.value.to_dict()
+    assert payload["status"] == "transport_blocked"
+    assert payload["transport_blocked"] is True
+    assert payload["preserve_no_mutate"] is True
+    assert payload["phase"] == "preflight_pr_context"
+    assert payload["posted_families"] == []
+    assert payload["items"] == []
+    assert payload["failures"] == []
+
+
+def test_collect_preflight_transport_retry_can_recover_and_run_reviewers() -> None:
+    attempts = 0
+    reviewer_calls: list[str] = []
+    fakes, posted = _fakes(tier=1)
+
+    def flaky_context_fetcher(repo: str, pr: int) -> dict:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("error connecting to api.github.com")
+        return {"head_sha": HEAD, "head_committed_at": COMMITTED}
+
+    def reviewer_runner(family: str, prompt: str) -> ReviewerResult:
+        reviewer_calls.append(family)
+        return ReviewerResult(family, f"Verdict: PASS from {family}", True)
+
+    fakes["context_fetcher"] = flaky_context_fetcher
+    fakes["reviewer_runner"] = reviewer_runner
+
+    outcome = collect_evidence(
+        repo="o/r",
+        pr=1,
+        families=["claude", "grok"],
+        author="me",
+        apply=True,
+        **fakes,
+    )
+
+    assert attempts >= 2
+    assert sorted(reviewer_calls) == ["claude", "grok"]
+    assert outcome.action == "post"
+    assert sorted(outcome.posted) == ["claude", "grok"]
+    assert len(posted) == 2
+
+
 def test_evidence_item_dissenting_uses_captured_outcome_policy(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -2464,6 +2539,36 @@ def test_run_collect_cli_catches_runtime_error(monkeypatch, capsys) -> None:
     )
     assert rc == 1
     assert "empty diff" in capsys.readouterr().out
+
+
+def test_run_collect_cli_preflight_transport_error_serializes_fail_closed_json(
+    monkeypatch, capsys
+) -> None:
+    def boom(**kwargs):
+        raise qe.CollectPreflightTransportError(
+            repo="o/r",
+            pr=1,
+            phase="preflight_pr_context",
+            error=RuntimeError("error connecting to api.github.com"),
+            attempts=2,
+        )
+
+    monkeypatch.setattr(qe, "collect_evidence", boom)
+    monkeypatch.setattr(qe, "resolve_author", lambda default="local": "me")
+    rc = qe.run_collect_cli(
+        repo="o/r", pr=1, families=None, author=None, apply=True, json_output=True
+    )
+
+    assert rc == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["mode"] == "collect_evidence"
+    assert payload["status"] == "transport_blocked"
+    assert payload["transport_blocked"] is True
+    assert payload["preserve_no_mutate"] is True
+    assert payload["phase"] == "preflight_pr_context"
+    assert payload["posted_families"] == []
+    assert payload["items"] == []
+    assert payload["failures"] == []
 
 
 # --- build_review_prompt: complete file list + fair per-file body bounding ---

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -1100,6 +1100,74 @@ def test_collect_overall_timeout_does_not_wait_for_stuck_reviewer() -> None:
     assert posted == []
 
 
+def test_overall_timeout_reaps_finished_reviewer_before_deadline_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    closed: list[str] = []
+
+    class FinishedProcess:
+        pid = 12345
+
+        def is_alive(self) -> bool:
+            return False
+
+        def join(self, timeout: float | None = None) -> None:
+            return None
+
+    def start_worker(ctx, reviewer_runner, family: str, prompt: str) -> qe._ReviewerWorker:
+        result_queue: queue.Queue[ReviewerResult] = queue.Queue(maxsize=1)
+        result_queue.put(ReviewerResult(family, f"Verdict: PASS from {family}", True))
+        return qe._ReviewerWorker(
+            family=family,
+            process=FinishedProcess(),
+            result_queue=result_queue,
+        )
+
+    monkeypatch.setattr(qe, "_reviewer_process_context", lambda: object())
+    monkeypatch.setattr(qe, "_start_reviewer_worker", start_worker)
+    monkeypatch.setattr(qe, "_close_reviewer_worker", lambda worker: closed.append(worker.family))
+
+    results, timed_out = qe._run_reviewers_with_overall_timeout(
+        reviewer_runner=lambda family, prompt: ReviewerResult(family, "", True),
+        prompt="review prompt",
+        families=["claude"],
+        overall_timeout_seconds=0.0,
+    )
+
+    assert timed_out == []
+    assert results["claude"].ok is True
+    assert closed == ["claude"]
+
+
+def test_reviewer_process_context_avoids_fork_from_threaded_parent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requested: list[str | None] = []
+
+    monkeypatch.setattr(qe.threading, "active_count", lambda: 2)
+    monkeypatch.setattr(qe.multiprocessing, "get_all_start_methods", lambda: ["fork", "spawn"])
+
+    def fake_get_context(method: str | None = None) -> object:
+        requested.append(method)
+        return object()
+
+    monkeypatch.setattr(qe.multiprocessing, "get_context", fake_get_context)
+
+    qe._reviewer_process_context()
+
+    assert requested == ["spawn"]
+
+
+def test_reviewer_process_context_fails_closed_when_only_fork_is_available_in_threaded_parent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(qe.threading, "active_count", lambda: 2)
+    monkeypatch.setattr(qe.multiprocessing, "get_all_start_methods", lambda: ["fork"])
+
+    with pytest.raises(RuntimeError, match="cannot safely fork reviewer workers"):
+        qe._reviewer_process_context()
+
+
 def test_start_reviewer_worker_is_not_daemon_so_api_fallback_can_spawn_children() -> None:
     created: dict[str, object] = {}
 
@@ -1451,7 +1519,52 @@ def test_collect_preflight_transport_retries_then_fails_closed_without_reviewers
 
 
 def test_collect_preflight_timeout_message_is_transport_error() -> None:
-    assert qe._is_github_transport_error(RuntimeError("gh pr view 1 timed out after 30s"))
+    assert qe._is_preflight_context_transport_error(
+        RuntimeError("gh pr view 1 timed out after 30s")
+    )
+
+
+def test_collect_preflight_raw_timeout_exception_is_transport_blocked() -> None:
+    attempts = 0
+
+    def timeout_context_fetcher(repo: str, pr: int) -> dict:
+        nonlocal attempts
+        attempts += 1
+        raise subprocess.TimeoutExpired(["gh", "pr", "view", str(pr)], timeout=30)
+
+    with pytest.raises(qe.CollectPreflightTransportError) as raised:
+        qe._fetch_preflight_context(
+            "o/r",
+            1,
+            timeout_context_fetcher,
+            attempts=2,
+            retry_delay_seconds=0,
+        )
+
+    assert attempts == 2
+    payload = raised.value.to_dict()
+    assert payload["status"] == "transport_blocked"
+    assert payload["transport_blocked"] is True
+
+
+def test_collect_preflight_non_github_timeout_message_is_not_transport_error() -> None:
+    attempts = 0
+
+    def logic_context_fetcher(repo: str, pr: int) -> dict:
+        nonlocal attempts
+        attempts += 1
+        raise RuntimeError("policy parser timed out after reading an invalid fixture")
+
+    with pytest.raises(RuntimeError, match="policy parser timed out"):
+        qe._fetch_preflight_context(
+            "o/r",
+            1,
+            logic_context_fetcher,
+            attempts=2,
+            retry_delay_seconds=0,
+        )
+
+    assert attempts == 1
 
 
 def test_collect_preflight_transport_retry_can_recover_and_run_reviewers() -> None:

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -1037,6 +1037,35 @@ def test_collect_runs_reviewers_concurrently() -> None:
     assert outcome.failures == []
 
 
+def test_collect_overall_timeout_fails_closed_and_ignores_late_results() -> None:
+    fakes, posted = _fakes(tier=0)
+
+    def runner(family: str, prompt: str) -> ReviewerResult:
+        if family == "claude":
+            return ReviewerResult(family, "Verdict: PASS from claude", True)
+        time.sleep(0.05)
+        return ReviewerResult(family, "Verdict: PASS from grok", True)
+
+    fakes["reviewer_runner"] = runner
+    outcome = collect_evidence(
+        repo="o/r",
+        pr=1,
+        families=["claude", "grok"],
+        author="me",
+        apply=True,
+        overall_timeout_seconds=0.01,
+        **fakes,
+    )
+
+    assert outcome.orchestration_timeout is True
+    assert outcome.timed_out_families == ["grok"]
+    assert outcome.action == "prepare"
+    assert "reviewer orchestration timeout" in outcome.action_reason
+    assert [item.family for item in outcome.items] == ["claude"]
+    assert [failure.family for failure in outcome.failures] == ["grok"]
+    assert posted == []
+
+
 def test_collect_preserves_family_order_despite_completion_order() -> None:
     # The first-requested reviewer (claude) finishes last; items must still be
     # ordered by the caller's requested family order, not by completion.
@@ -2274,6 +2303,54 @@ def test_run_collect_cli_exit_code_quorum_met(monkeypatch, capsys) -> None:
     assert "collect_evidence" in capsys.readouterr().out
 
 
+def test_run_collect_cli_scopes_timeout_env_overrides(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+    monkeypatch.setenv(qe._CLAUDE_TIMEOUT_ENV, "111")
+    monkeypatch.delenv(qe._CODEX_TIMEOUT_ENV, raising=False)
+    monkeypatch.delenv(qe._REVIEWER_TIMEOUT_ENV, raising=False)
+
+    def fake_collect(**kwargs) -> CollectOutcome:
+        captured.update(kwargs)
+        captured["claude_timeout"] = qe.os.environ.get(qe._CLAUDE_TIMEOUT_ENV)
+        captured["codex_timeout"] = qe.os.environ.get(qe._CODEX_TIMEOUT_ENV)
+        captured["reviewer_timeout"] = qe.os.environ.get(qe._REVIEWER_TIMEOUT_ENV)
+        return CollectOutcome(
+            repo="o/r",
+            pr=1,
+            head_sha=HEAD,
+            head_committed_at=COMMITTED,
+            tier=1,
+            action="prepare",
+            action_reason="dry run",
+            items=[
+                EvidenceItem("claude", "body", True, ["claude"], [], "pass"),
+                EvidenceItem("grok", "body", True, ["grok"], [], "pass"),
+            ],
+        )
+
+    monkeypatch.setattr(qe, "collect_evidence", fake_collect)
+    monkeypatch.setattr(qe, "resolve_author", lambda default="local": "me")
+    rc = qe.run_collect_cli(
+        repo="o/r",
+        pr=1,
+        families=["claude", "grok"],
+        author=None,
+        apply=False,
+        json_output=False,
+        reviewer_timeout_seconds=90,
+        overall_timeout_seconds=150,
+    )
+
+    assert rc == 0
+    assert captured["overall_timeout_seconds"] == 150.0
+    assert captured["claude_timeout"] == "90"
+    assert captured["codex_timeout"] == "90"
+    assert captured["reviewer_timeout"] == "90"
+    assert qe.os.environ.get(qe._CLAUDE_TIMEOUT_ENV) == "111"
+    assert qe.os.environ.get(qe._CODEX_TIMEOUT_ENV) is None
+    assert qe.os.environ.get(qe._REVIEWER_TIMEOUT_ENV) is None
+
+
 def test_run_collect_cli_prepared_json_skips_collect_evidence(monkeypatch, tmp_path) -> None:
     prepared = _prepared_outcome_file(tmp_path)
     seen: dict[str, object] = {}
@@ -2335,6 +2412,30 @@ def test_run_collect_cli_exit_code_quorum_incomplete(monkeypatch) -> None:
     monkeypatch.setattr(qe, "resolve_author", lambda default="local": "me")
     rc = qe.run_collect_cli(
         repo="o/r", pr=1, families=None, author=None, apply=False, json_output=False
+    )
+    assert rc == 1
+
+
+def test_run_collect_cli_timeout_returns_failure_even_with_supportive_quorum(monkeypatch) -> None:
+    def fake_collect(**kwargs) -> CollectOutcome:
+        return CollectOutcome(
+            repo="o/r",
+            pr=1,
+            head_sha=HEAD,
+            head_committed_at=COMMITTED,
+            tier=0,
+            action="prepare",
+            action_reason="reviewer orchestration timeout; prepared only",
+            items=[EvidenceItem("claude", "body", True, ["claude"], [], "pass")],
+            orchestration_timeout=True,
+            timed_out_families=["grok"],
+            overall_timeout_seconds=1.0,
+        )
+
+    monkeypatch.setattr(qe, "collect_evidence", fake_collect)
+    monkeypatch.setattr(qe, "resolve_author", lambda default="local": "me")
+    rc = qe.run_collect_cli(
+        repo="o/r", pr=1, families=None, author=None, apply=True, json_output=False
     )
     assert rc == 1
 
@@ -2570,10 +2671,12 @@ def _force_grok_bin(monkeypatch, present: bool) -> None:
 
 def test_grok_reviewer_prefers_sandboxed_cli_when_installed(monkeypatch) -> None:
     _force_grok_bin(monkeypatch, True)
+    monkeypatch.setenv(qe._REVIEWER_TIMEOUT_ENV, "17")
     seen: dict = {}
 
     def fake_cli(family, argv, harness, timeout=qe._REVIEWER_TIMEOUT):
         seen["argv"] = argv
+        seen["timeout"] = timeout
         return qe.ReviewerResult(family, "verdict", True, harness=harness)
 
     monkeypatch.setattr(qe, "_run_argv_cli_reviewer", fake_cli)
@@ -2583,6 +2686,7 @@ def test_grok_reviewer_prefers_sandboxed_cli_when_installed(monkeypatch) -> None
     # read-only sandbox + headless single-prompt, explicit Grok Build path.
     assert seen["argv"][1:] == ["--sandbox", "read-only", "--no-plan", "-p", "review prompt"]
     assert seen["argv"][0].endswith(".grok/bin/grok")
+    assert seen["timeout"] == 17.0
 
 
 def test_grok_build_bin_override(monkeypatch) -> None:
@@ -2613,11 +2717,13 @@ def test_grok_reviewer_falls_back_to_api_on_cli_failure_when_key_present(monkeyp
 def test_gemini_reviewer_prefers_resolved_sandboxed_agy(monkeypatch) -> None:
     import shutil as _sh
 
+    monkeypatch.setenv(qe._REVIEWER_TIMEOUT_ENV, "19")
     monkeypatch.setattr(_sh, "which", lambda name: "/usr/local/bin/agy" if name == "agy" else None)
     seen: dict = {}
 
     def fake_cli(family, argv, harness, timeout=qe._REVIEWER_TIMEOUT):
         seen["argv"] = argv
+        seen["timeout"] = timeout
         return qe.ReviewerResult(family, "v", True, harness=harness)
 
     monkeypatch.setattr(qe, "_run_argv_cli_reviewer", fake_cli)
@@ -2626,6 +2732,7 @@ def test_gemini_reviewer_prefers_resolved_sandboxed_agy(monkeypatch) -> None:
     assert res.family == "gemini"
     # resolved path (not bare "agy") + sandbox.
     assert seen["argv"] == ["/usr/local/bin/agy", "--sandbox", "-p", "review prompt"]
+    assert seen["timeout"] == 19.0
 
 
 def test_gemini_reviewer_falls_back_to_api_without_agy(monkeypatch) -> None:

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import multiprocessing
 import os
 import subprocess
 import threading
@@ -1043,7 +1044,7 @@ def test_collect_overall_timeout_fails_closed_and_ignores_late_results() -> None
     def runner(family: str, prompt: str) -> ReviewerResult:
         if family == "claude":
             return ReviewerResult(family, "Verdict: PASS from claude", True)
-        time.sleep(0.05)
+        time.sleep(1.5)
         return ReviewerResult(family, "Verdict: PASS from grok", True)
 
     fakes["reviewer_runner"] = runner
@@ -1053,7 +1054,7 @@ def test_collect_overall_timeout_fails_closed_and_ignores_late_results() -> None
         families=["claude", "grok"],
         author="me",
         apply=True,
-        overall_timeout_seconds=0.01,
+        overall_timeout_seconds=0.2,
         **fakes,
     )
 
@@ -1063,6 +1064,37 @@ def test_collect_overall_timeout_fails_closed_and_ignores_late_results() -> None
     assert "reviewer orchestration timeout" in outcome.action_reason
     assert [item.family for item in outcome.items] == ["claude"]
     assert [failure.family for failure in outcome.failures] == ["grok"]
+    assert posted == []
+
+
+def test_collect_overall_timeout_does_not_wait_for_stuck_reviewer() -> None:
+    if "fork" not in multiprocessing.get_all_start_methods():
+        pytest.skip("process-supervised timeout regression requires fork context")
+    fakes, posted = _fakes(tier=0)
+
+    def runner(family: str, prompt: str) -> ReviewerResult:
+        if family == "claude":
+            return ReviewerResult(family, "Verdict: PASS from claude", True)
+        time.sleep(10)
+        return ReviewerResult(family, "Verdict: PASS from grok", True)
+
+    fakes["reviewer_runner"] = runner
+    started_at = time.monotonic()
+    outcome = collect_evidence(
+        repo="o/r",
+        pr=1,
+        families=["claude", "grok"],
+        author="me",
+        apply=True,
+        overall_timeout_seconds=0.05,
+        **fakes,
+    )
+    elapsed = time.monotonic() - started_at
+
+    assert elapsed < 1.0
+    assert outcome.orchestration_timeout is True
+    assert outcome.timed_out_families == ["grok"]
+    assert outcome.action == "prepare"
     assert posted == []
 
 
@@ -1258,6 +1290,10 @@ def test_collect_preflight_transport_retries_then_fails_closed_without_reviewers
     assert payload["posted_families"] == []
     assert payload["items"] == []
     assert payload["failures"] == []
+
+
+def test_collect_preflight_timeout_message_is_transport_error() -> None:
+    assert qe._is_github_transport_error(RuntimeError("gh pr view 1 timed out after 30s"))
 
 
 def test_collect_preflight_transport_retry_can_recover_and_run_reviewers() -> None:


### PR DESCRIPTION
## Summary
- Add explicit `--reviewer-timeout` and `--overall-timeout` controls to `review-queue collect-evidence` and `scripts/collect_quorum_evidence.py`.
- Fail closed when the overall reviewer deadline expires, with JSON diagnostics for `orchestration_timeout`, `timed_out_families`, and `overall_timeout_seconds`.
- Apply per-reviewer timeout overrides to Claude, Codex/OpenAI, API reviewers, Grok Build, and Antigravity/Gemini CLI paths for only the current invocation.

## Validation
- Current-main baseline: `origin/main` = `3d2af8d2c10f981d7ddd37cba6cc3f96af1afaba`; `python3 -m aragora.cli.main review-queue collect-evidence --help` does not expose the timeout flags there.
- Exact PR head: `1bf591bdb41193bc9d12a1908583f3f97ce264ec`; both `python3 -m aragora.cli.main review-queue collect-evidence --help` and `python3 scripts/collect_quorum_evidence.py --help` expose `--reviewer-timeout` and `--overall-timeout`.
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 timeout 300 /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/swarm/test_quorum_evidence.py tests/cli/commands/test_review_queue.py -q` - 476 passed.
- `timeout 240 pre-commit run --files scripts/collect_quorum_evidence.py aragora/swarm/quorum_evidence.py aragora/cli/commands/review_queue.py aragora/cli/parser.py tests/swarm/test_quorum_evidence.py tests/cli/commands/test_review_queue.py` - passed.
- After marking ready for review, required non-quorum checks are green (`lint`, `typecheck`, `Generate & Validate`, `TypeScript SDK Type Check`, `sdk-parity`). `aragora-merge-quorum` fails closed as expected because this is Tier 4 merge/evidence-authority code and still needs current-head model quorum plus human preapproval/settlement before merge.

## Dogfood on blocked PR evidence flow
- #8389 merge-packet at `136f3002013c7026c74f68d1892c52718e33b23b`: Tier 1, mergeable, required checks green except `aragora-merge-quorum`, blocker is missing model quorum/focused dogfood.
- Artificial fail-closed check on #8389 through both public entrypoints with `--reviewer-timeout 1 --overall-timeout 0.01 --json`: returned `action=prepare`, `orchestration_timeout=true`, `timed_out_families=[claude,grok]`, `overall_timeout_seconds=0.01`, zero evidence items, and no posted families.
- Bounded real dry-run on #8389: `python3 -m aragora.cli.main review-queue collect-evidence --repo synaptent/aragora --pr 8389 --reviewers claude grok --reviewer-timeout 45 --overall-timeout 60 --json` returned one countable Grok PASS (`would_count=true`) while Claude exceeded the 60s orchestration deadline. The collector still failed closed with `action=prepare`, `orchestration_timeout=true`, `timed_out_families=[claude]`, `has_supportive_quorum=false`, and no posts.
- #8393 merge-packet at `7aacade51697f601c4e595325940143505ded01d`: PR is closed, and the packet correctly reports `not_ready_for_settlement`; no reviewer evidence was collected for the closed PR.
- #8519 and #8713 packet checks still report exact-head missing quorum; both are Tier 3 and require human risk settlement after model evidence.

## Dogfood note
- During the #8389 Grok dry-run, the reviewer CLI left two untracked #8389 target files in the disposable worktree. They were removed before validation and are not part of this PR diff; the timeout feature still failed closed correctly. This is a reviewer-harness isolation follow-up, not a timeout-control blocker.
