### PR TITLE
feat(gate): opt-in advisory-dissent settlement (default OFF)

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3100,30 +3100,37 @@ def _explicit_merged_pr_merge_packet_entry(
 
 
 def _is_recognized_model_review(body: str) -> bool:
-    """Whether a comment body is a recognized model review.
-
-    Uses the SAME identity resolver as signal/dissent recognition rather than a
-    fixed heading-token list, so a grounded review with a different heading cannot
-    drift between the recognizers (#8729 openai [P2]).
-    """
+    """Whether a comment body is a recognized model review (identity resolver, not
+    a fixed heading-token list, so recognizers cannot drift — #8729 openai [P2])."""
     return _resolve_model_review_identity(body).surface_reviewer_id != "unknown_model_reviewer"
 
 
-def _any_review_has_blocking_finding(
+def _advisory_settle_review_signals(
     comments: list[Any],
     *,
     head_sha: str = "",
     head_committed_at: str = "",
-) -> bool:
-    """Whether ANY recognized model-review comment grounded on the exact head
-    carries a blocking ``[P0]``/``[P1]`` finding or a populated Blocker label.
+) -> tuple[bool, bool, bool]:
+    """Single-pass classification of grounded reviews for advisory_settle.
 
-    Fail-closed input to the advisory_settle path: that path is available ONLY
-    when every review is free of blocking findings. Scans ALL grounded reviews —
-    including CHANGES-REQUESTED ones — because the blocking findings live there.
-    Recognition uses ``_is_recognized_model_review`` (identity resolver), so no
-    recognized review can slip a ``[P1]`` past this scan via an unlisted heading.
+    Returns ``(has_valid_wf_review, has_valid_advisory_dissent, has_blocking_finding)``.
+
+    Source-validation is applied UNIFORMLY so every *positive* input to the gate
+    passes the SAME filters the strict quorum path uses — closing the class of
+    bypasses #8729's review round surfaced one input at a time (spoofed identity,
+    bot author, uncountable advisory CR):
+
+    * positive signals (a western-frontier review present; genuine advisory
+      dissent) require a grounded, NON-bot author with a countable, non-conflicted
+      identity (``IDENTITY_COUNT_BLOCKERS``);
+    * the blocking-finding scan is deliberately PERMISSIVE / fail-closed: a
+      ``[P0]``/``[P1]`` in ANY recognized grounded review (bot or not) blocks
+      advisory_settle, so a blocking finding can never be laundered by an
+      untrusted source.
     """
+    has_wf = False
+    has_advisory_dissent = False
+    has_blocking = False
     for comment in comments or []:
         if not isinstance(comment, dict):
             continue
@@ -3132,54 +3139,26 @@ def _any_review_has_blocking_finding(
         body = str(comment.get("body", "") or "")
         if not _is_recognized_model_review(body):
             continue
+        # Permissive, fail-closed blocking scan (any recognized grounded review).
         if _has_blocking_finding_or_label(body):
-            return True
-    return False
-
-
-def _has_western_frontier_review_at_head(
-    comments: list[Any],
-    *,
-    head_sha: str = "",
-    head_committed_at: str = "",
-) -> bool:
-    """Whether a western-frontier (claude/openai) review is present at the exact
-    head, REGARDLESS of verdict (supportive PASS **or** advisory CHANGES-REQUESTED).
-
-    advisory_settle's motivating case is "thorough western-frontier reviewers
-    returned advisory-only CRs, so no supportive PASS is reachable." The first cut
-    keyed eligibility on the *supportive-only* signal, which made the branch dead
-    for its own target case (#8729 claude [P1]/[P2]). This counts a grounded WF
-    review that exists at head even when its verdict is CHANGES-REQUESTED.
-    """
-    for comment in comments or []:
-        if not isinstance(comment, dict):
-            continue
-        if not _is_comment_grounded_on_head(comment, head_sha, head_committed_at):
-            continue
-        # Reject synthetic/bot authors (github-actions[bot]) exactly as the strict
-        # signal builder does: a bot-authored "Claude/OpenAI" comment must not fake
-        # the western-frontier prerequisite (#8729 openai [P1]).
+            has_blocking = True
+        # Positive signals require a validated source (non-bot + countable identity).
         author_payload = comment.get("author")
         author = (
             str(author_payload.get("login", "") or "") if isinstance(author_payload, dict) else ""
         )
         if _is_github_actions_author(author):
             continue
-        body = str(comment.get("body", "") or "")
         identity = _resolve_model_review_identity(body)
-        if identity.surface_reviewer_id == "unknown_model_reviewer":
-            continue
-        # Apply the SAME identity-count validation the strict quorum path uses:
-        # a conflicted/uncountable identity (e.g. a "## Grok" heading with a claimed
-        # "Model family: claude") must NOT satisfy the WF requirement, or the opt-in
-        # gate could be spoofed into settling on a fake western-frontier signal
-        # (#8729 openai [P1]).
         if any(problem in IDENTITY_COUNT_BLOCKERS for problem in identity.identity_problems):
             continue
         if str(identity.model_family or "").strip().lower() in WESTERN_FRONTIER_FAMILIES:
-            return True
-    return False
+            has_wf = True
+        # Genuine advisory dissent: a CHANGES-REQUESTED verdict from a validated
+        # source with no blocking [P0]/[P1] finding.
+        if _has_blocking_or_negative_verdict(body) and not _has_blocking_finding_or_label(body):
+            has_advisory_dissent = True
+    return has_wf, has_advisory_dissent, has_blocking
 
 
 def _build_model_review_quorum(
@@ -3310,6 +3289,19 @@ def _build_model_review_quorum(
     # This is a strict fallback: it is only consulted when the strict quorum was NOT
     # satisfied, and it never relaxes the blocking-finding bar.
     advisory_findings = list(advisory_views)
+    # Single validated pass over grounded reviews — all positive inputs share the
+    # strict path's source filters (non-bot + countable identity); the blocking
+    # scan is fail-closed (#8729: closes the spoofed-identity / bot-author /
+    # uncountable-advisory-CR bypass class in one place).
+    (
+        _wf_review_present,
+        _genuine_advisory_dissent,
+        _any_blocking_finding,
+    ) = _advisory_settle_review_signals(
+        pr.get("comments") or [],
+        head_sha=head_sha,
+        head_committed_at=head_committed_at,
+    )
     advisory_settle_eligible = (
         advisory_dissent_settle_enabled()
         and tier is not None
@@ -3318,35 +3310,22 @@ def _build_model_review_quorum(
         and not quorum_satisfied
         and not settlement_recorded
         # NOTE (#8729 claude [P2]): advisory_settle deliberately does NOT require
-        # ``has_required_dogfood``. Its target case is "thorough western-frontier
-        # reviewers returned advisory CRs" — and dogfood evidence is skipped for
-        # negative-verdict comments (see _dogfood_evidence_from_comments), so a
-        # dogfood gate here would re-create the same self-defeating contradiction
-        # the WF-any-verdict fix removed. The adversarial evidence IS the WF review
-        # plus the hard zero-[P0]/[P1] bar below.
-        # No other blocker may be in play: only the model-quorum check is failing,
-        # and nothing is pending/unavailable/workflow-blocking.
+        # ``has_required_dogfood`` — dogfood is skipped for negative-verdict comments,
+        # so a dogfood gate would re-create the self-defeating contradiction the
+        # WF-any-verdict fix removed. The adversarial evidence IS the validated WF
+        # review plus the hard zero-[P0]/[P1] bar.
+        # No other blocker may be in play: only the model-quorum check is failing.
         and not has_pending
         and not checks_unavailable
         and not blocking_workflow_state
-        # A western-frontier review must EXIST at head, in ANY verdict (the target
-        # case is advisory-only CRs with no supportive PASS) — not the supportive-
-        # only signal, which was self-contradictory (#8729 claude [P1]/[P2]).
-        and _has_western_frontier_review_at_head(
-            pr.get("comments") or [],
-            head_sha=head_sha,
-            head_committed_at=head_committed_at,
-        )
-        # There must be GENUINE advisory dissent being waived — otherwise a lone
-        # approving comment with no dissent would be a one-review quorum bypass
-        # (#8729 openai [P1]).
-        and bool(advisory_findings)
+        # A validated western-frontier review must EXIST at head in ANY verdict, and
+        # there must be GENUINE (validated-source) advisory dissent being waived —
+        # not a lone approval (a one-review bypass) — and NO blocking finding in any
+        # recognized review, and no unresolved dissent.
+        and _wf_review_present
+        and _genuine_advisory_dissent
         and not unresolved_dissent
-        and not _any_review_has_blocking_finding(
-            pr.get("comments") or [],
-            head_sha=head_sha,
-            head_committed_at=head_committed_at,
-        )
+        and not _any_blocking_finding
     )
     # The incomplete-quorum check only acts as an ACTIVE blocker when advisory_settle
     # is NOT rescuing this PR; otherwise the merge-quorum check is treated as resolved

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3157,6 +3157,15 @@ def _has_western_frontier_review_at_head(
             continue
         if not _is_comment_grounded_on_head(comment, head_sha, head_committed_at):
             continue
+        # Reject synthetic/bot authors (github-actions[bot]) exactly as the strict
+        # signal builder does: a bot-authored "Claude/OpenAI" comment must not fake
+        # the western-frontier prerequisite (#8729 openai [P1]).
+        author_payload = comment.get("author")
+        author = (
+            str(author_payload.get("login", "") or "") if isinstance(author_payload, dict) else ""
+        )
+        if _is_github_actions_author(author):
+            continue
         body = str(comment.get("body", "") or "")
         identity = _resolve_model_review_identity(body)
         if identity.surface_reviewer_id == "unknown_model_reviewer":

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -143,6 +143,7 @@ CANONICAL_MODEL_FAMILIES: tuple[str, ...] = (
 from aragora.swarm.quorum_evidence import (  # noqa: E402
     WESTERN_FAMILIES as WESTERN_FAMILIES,
     WESTERN_FRONTIER_FAMILIES as WESTERN_FRONTIER_FAMILIES,
+    advisory_dissent_settle_enabled as advisory_dissent_settle_enabled,
     severity_gated_dissent_enabled as severity_gated_dissent_enabled,
     tier_quorum_rule as tier_quorum_rule,
     tiered_merge_gate_enabled as tiered_merge_gate_enabled,
@@ -3098,6 +3099,48 @@ def _explicit_merged_pr_merge_packet_entry(
     }
 
 
+def _any_review_has_blocking_finding(
+    comments: list[Any],
+    *,
+    head_sha: str = "",
+    head_committed_at: str = "",
+) -> bool:
+    """Whether ANY recognized model-review comment grounded on the exact head
+    carries a blocking ``[P0]``/``[P1]`` finding or a populated Blocker label.
+
+    Fail-closed input to the advisory_settle path: that path is available ONLY
+    when every review is free of blocking findings. Unlike
+    ``_model_review_signals_from_comments`` (which skips negative-verdict comments
+    when collecting *supportive* signals), this scans ALL recognized review
+    bodies — including CHANGES-REQUESTED ones — because the blocking findings live
+    in exactly those. Recognition mirrors the signal builder (head-grounded +
+    review-heading token) so the two halves cannot drift.
+    """
+    for comment in comments or []:
+        if not isinstance(comment, dict):
+            continue
+        if not _is_comment_grounded_on_head(comment, head_sha, head_committed_at):
+            continue
+        body = str(comment.get("body", "") or "")
+        lower = body.lower()
+        if not any(
+            token in lower
+            for token in (
+                "codex review",
+                "claude review",
+                "grok independent",
+                "gemini independent",
+                "independent semantic review",
+                "independent model review",
+                "model-family semantic signal",
+            )
+        ):
+            continue
+        if _has_blocking_finding_or_label(body):
+            return True
+    return False
+
+
 def _build_model_review_quorum(
     *,
     pr: dict[str, Any],
@@ -3206,11 +3249,49 @@ def _build_model_review_quorum(
         isinstance(required_pr_check_surface, dict)
         and required_pr_check_surface.get("quorum_only_failure")
     )
-    missing_quorum_is_active_check_blocker = (
-        quorum_only_required_failure and not quorum_satisfied and not settlement_recorded
-    )
     stale_quorum_check_after_satisfied_evidence = (
         quorum_only_required_failure and quorum_satisfied and not settlement_recorded
+    )
+    # --- Advisory-dissent settlement (opt-in, default OFF) ------------------
+    # A PR that fails the strict model quorum may still settle via the distinct
+    # ``advisory_settle`` verdict when (and ONLY when) every condition holds:
+    #   1. the flag is ON (default OFF -> path dormant, behavior byte-identical);
+    #   2. tier is 0/1/2 (Tier 3-4 keep human settlement, unaffected);
+    #   3. the only failing required check is the model-quorum check itself
+    #      (``quorum_only_required_failure``) -> all OTHER required checks are green;
+    #   4. at least one western-frontier review (claude/openai) exists at the head;
+    #   5. ZERO `[P0]`/`[P1]` blocking findings across ALL collected reviews, AND no
+    #      unresolved protocol/comment dissent. Condition (5) reuses the SAME
+    #      ``has_blocking_finding_or_label`` helper the dissent half consults, scanned
+    #      over every grounded review body, so it holds regardless of whether the
+    #      separate severity-gated-dissent flag is on. Any blocking finding or
+    #      unresolved dissent disqualifies advisory_settle.
+    # This is a strict fallback: it is only consulted when the strict quorum was NOT
+    # satisfied, and it never relaxes the blocking-finding bar.
+    advisory_findings = list(advisory_views)
+    advisory_settle_eligible = (
+        advisory_dissent_settle_enabled()
+        and tier is not None
+        and 0 <= tier <= 2
+        and quorum_only_required_failure
+        and not quorum_satisfied
+        and not settlement_recorded
+        and has_western_frontier_signal
+        and not unresolved_dissent
+        and not _any_review_has_blocking_finding(
+            pr.get("comments") or [],
+            head_sha=head_sha,
+            head_committed_at=head_committed_at,
+        )
+    )
+    # The incomplete-quorum check only acts as an ACTIVE blocker when advisory_settle
+    # is NOT rescuing this PR; otherwise the merge-quorum check is treated as resolved
+    # by the advisory path (and the verdict chain reports advisory_settle instead).
+    missing_quorum_is_active_check_blocker = (
+        quorum_only_required_failure
+        and not quorum_satisfied
+        and not settlement_recorded
+        and not advisory_settle_eligible
     )
     requires_human_preapproval = bool(requirement["requires_human_preapproval"])
     human_preapproval_recorded = (
@@ -3274,7 +3355,15 @@ def _build_model_review_quorum(
         reasons.append(
             f"advisory finding from {family}: {sev_note} — not blocking (severity-gated dissent)"
         )
-    if not quorum_satisfied and not settlement_recorded:
+    if advisory_settle_eligible:
+        reasons.append(
+            "advisory-dissent settle: only the model-quorum check is failing, a "
+            "western-frontier review is present at head, and no [P0]/[P1] blocking "
+            "findings remain; settling on advisory findings only"
+        )
+        if advisory_findings:
+            reasons.append(f"{len(advisory_findings)} advisory finding(s) surfaced for follow-up")
+    if not quorum_satisfied and not settlement_recorded and not advisory_settle_eligible:
         if signal_count < requirement["required_model_signals"]:
             reasons.append(
                 "model quorum incomplete: "
@@ -3310,6 +3399,14 @@ def _build_model_review_quorum(
     ):
         status = "repair_or_wait"
         verdict = "not_ready_for_settlement"
+    elif advisory_settle_eligible:
+        # Opt-in advisory-dissent settlement: a distinct, auditable verdict (NOT
+        # ``admin_squash_allowed``) so the audit trail records that this settled on
+        # advisory findings only. Tier 0-2 only; no human risk settlement required.
+        status = "satisfied"
+        verdict = "advisory_settle"
+        requires_human_risk_settlement = False
+        admin_squash_allowed = True
     elif not quorum_satisfied:
         status = "needs_model_review_quorum"
         verdict = "collect_model_quorum_before_merge"
@@ -3365,6 +3462,12 @@ def _build_model_review_quorum(
         "counted_model_families": counted_reviewer_ids,
         "dissenting_views": dissenting_views,
         "advisory_views": advisory_views,
+        # Advisory findings surfaced for follow-up issue-filing by a caller when the
+        # PR settles via the advisory_settle path. Populated only when that path is
+        # eligible (otherwise empty); issue-filing itself is a caller concern, not
+        # this gate's. Mirrors ``advisory_views`` content for the eligible case.
+        "advisory_findings": advisory_findings if advisory_settle_eligible else [],
+        "advisory_settle": advisory_settle_eligible,
         "unresolved_dissent": unresolved_dissent,
         "reasons": reasons,
     }

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3158,10 +3158,17 @@ def _has_western_frontier_review_at_head(
         if not _is_comment_grounded_on_head(comment, head_sha, head_committed_at):
             continue
         body = str(comment.get("body", "") or "")
-        if not _is_recognized_model_review(body):
+        identity = _resolve_model_review_identity(body)
+        if identity.surface_reviewer_id == "unknown_model_reviewer":
             continue
-        family = str(_resolve_model_review_identity(body).model_family or "").strip().lower()
-        if family in WESTERN_FRONTIER_FAMILIES:
+        # Apply the SAME identity-count validation the strict quorum path uses:
+        # a conflicted/uncountable identity (e.g. a "## Grok" heading with a claimed
+        # "Model family: claude") must NOT satisfy the WF requirement, or the opt-in
+        # gate could be spoofed into settling on a fake western-frontier signal
+        # (#8729 openai [P1]).
+        if any(problem in IDENTITY_COUNT_BLOCKERS for problem in identity.identity_problems):
+            continue
+        if str(identity.model_family or "").strip().lower() in WESTERN_FRONTIER_FAMILIES:
             return True
     return False
 
@@ -3301,6 +3308,13 @@ def _build_model_review_quorum(
         and quorum_only_required_failure
         and not quorum_satisfied
         and not settlement_recorded
+        # NOTE (#8729 claude [P2]): advisory_settle deliberately does NOT require
+        # ``has_required_dogfood``. Its target case is "thorough western-frontier
+        # reviewers returned advisory CRs" — and dogfood evidence is skipped for
+        # negative-verdict comments (see _dogfood_evidence_from_comments), so a
+        # dogfood gate here would re-create the same self-defeating contradiction
+        # the WF-any-verdict fix removed. The adversarial evidence IS the WF review
+        # plus the hard zero-[P0]/[P1] bar below.
         # No other blocker may be in play: only the model-quorum check is failing,
         # and nothing is pending/unavailable/workflow-blocking.
         and not has_pending

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3099,6 +3099,16 @@ def _explicit_merged_pr_merge_packet_entry(
     }
 
 
+def _is_recognized_model_review(body: str) -> bool:
+    """Whether a comment body is a recognized model review.
+
+    Uses the SAME identity resolver as signal/dissent recognition rather than a
+    fixed heading-token list, so a grounded review with a different heading cannot
+    drift between the recognizers (#8729 openai [P2]).
+    """
+    return _resolve_model_review_identity(body).surface_reviewer_id != "unknown_model_reviewer"
+
+
 def _any_review_has_blocking_finding(
     comments: list[Any],
     *,
@@ -3109,12 +3119,10 @@ def _any_review_has_blocking_finding(
     carries a blocking ``[P0]``/``[P1]`` finding or a populated Blocker label.
 
     Fail-closed input to the advisory_settle path: that path is available ONLY
-    when every review is free of blocking findings. Unlike
-    ``_model_review_signals_from_comments`` (which skips negative-verdict comments
-    when collecting *supportive* signals), this scans ALL recognized review
-    bodies — including CHANGES-REQUESTED ones — because the blocking findings live
-    in exactly those. Recognition mirrors the signal builder (head-grounded +
-    review-heading token) so the two halves cannot drift.
+    when every review is free of blocking findings. Scans ALL grounded reviews —
+    including CHANGES-REQUESTED ones — because the blocking findings live there.
+    Recognition uses ``_is_recognized_model_review`` (identity resolver), so no
+    recognized review can slip a ``[P1]`` past this scan via an unlisted heading.
     """
     for comment in comments or []:
         if not isinstance(comment, dict):
@@ -3122,21 +3130,38 @@ def _any_review_has_blocking_finding(
         if not _is_comment_grounded_on_head(comment, head_sha, head_committed_at):
             continue
         body = str(comment.get("body", "") or "")
-        lower = body.lower()
-        if not any(
-            token in lower
-            for token in (
-                "codex review",
-                "claude review",
-                "grok independent",
-                "gemini independent",
-                "independent semantic review",
-                "independent model review",
-                "model-family semantic signal",
-            )
-        ):
+        if not _is_recognized_model_review(body):
             continue
         if _has_blocking_finding_or_label(body):
+            return True
+    return False
+
+
+def _has_western_frontier_review_at_head(
+    comments: list[Any],
+    *,
+    head_sha: str = "",
+    head_committed_at: str = "",
+) -> bool:
+    """Whether a western-frontier (claude/openai) review is present at the exact
+    head, REGARDLESS of verdict (supportive PASS **or** advisory CHANGES-REQUESTED).
+
+    advisory_settle's motivating case is "thorough western-frontier reviewers
+    returned advisory-only CRs, so no supportive PASS is reachable." The first cut
+    keyed eligibility on the *supportive-only* signal, which made the branch dead
+    for its own target case (#8729 claude [P1]/[P2]). This counts a grounded WF
+    review that exists at head even when its verdict is CHANGES-REQUESTED.
+    """
+    for comment in comments or []:
+        if not isinstance(comment, dict):
+            continue
+        if not _is_comment_grounded_on_head(comment, head_sha, head_committed_at):
+            continue
+        body = str(comment.get("body", "") or "")
+        if not _is_recognized_model_review(body):
+            continue
+        family = str(_resolve_model_review_identity(body).model_family or "").strip().lower()
+        if family in WESTERN_FRONTIER_FAMILIES:
             return True
     return False
 
@@ -3276,7 +3301,23 @@ def _build_model_review_quorum(
         and quorum_only_required_failure
         and not quorum_satisfied
         and not settlement_recorded
-        and has_western_frontier_signal
+        # No other blocker may be in play: only the model-quorum check is failing,
+        # and nothing is pending/unavailable/workflow-blocking.
+        and not has_pending
+        and not checks_unavailable
+        and not blocking_workflow_state
+        # A western-frontier review must EXIST at head, in ANY verdict (the target
+        # case is advisory-only CRs with no supportive PASS) — not the supportive-
+        # only signal, which was self-contradictory (#8729 claude [P1]/[P2]).
+        and _has_western_frontier_review_at_head(
+            pr.get("comments") or [],
+            head_sha=head_sha,
+            head_committed_at=head_committed_at,
+        )
+        # There must be GENUINE advisory dissent being waived — otherwise a lone
+        # approving comment with no dissent would be a one-review quorum bypass
+        # (#8729 openai [P1]).
+        and bool(advisory_findings)
         and not unresolved_dissent
         and not _any_review_has_blocking_finding(
             pr.get("comments") or [],
@@ -3324,7 +3365,12 @@ def _build_model_review_quorum(
         reasons.append(str(settlement_creator_pin["reason"]))
     elif human_risk_settlement_recorded:
         reasons.append("exact-head human risk settlement receipt recorded")
-    if has_failures and not settlement_recorded and not missing_quorum_is_active_check_blocker:
+    if (
+        has_failures
+        and not settlement_recorded
+        and not missing_quorum_is_active_check_blocker
+        and not advisory_settle_eligible
+    ):
         reasons.append("checks are failing; repair before settlement")
     elif missing_quorum_is_active_check_blocker:
         reasons.append(
@@ -3390,10 +3436,18 @@ def _build_model_review_quorum(
         verdict = "already_merged_settlement_recorded"
         requires_human_risk_settlement = False
     elif (
-        (has_failures and not missing_quorum_is_active_check_blocker)
+        (
+            has_failures
+            and not missing_quorum_is_active_check_blocker
+            and not advisory_settle_eligible
+        )
         or has_pending
         or checks_unavailable
-        or (machine_recommendation == "repair_first" and not missing_quorum_is_active_check_blocker)
+        or (
+            machine_recommendation == "repair_first"
+            and not missing_quorum_is_active_check_blocker
+            and not advisory_settle_eligible
+        )
         or stale_quorum_check_after_satisfied_evidence
         or blocking_workflow_state
     ):

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -147,6 +147,38 @@ def severity_gated_dissent_enabled(env: dict[str, str] | None = None) -> bool:
     )
 
 
+# Opt-in flag for the advisory-dissent settlement path. When OFF (default), a PR
+# that fails the strict model-quorum bar stays blocked — byte-identical to today.
+# When ON, a Tier 0-2 PR whose ONLY failing required check is the model-quorum
+# check, that has at least one western-frontier review at the exact head, and that
+# carries ZERO `[P0]`/`[P1]` blocking findings across ALL collected reviews, may
+# settle via a distinct ``verdict="advisory_settle"`` even though the strict quorum
+# (e.g. two distinct supportive families) was never reached. This unblocks PRs that
+# two thorough reviewers only ever raise *advisory* findings on, without lowering
+# the bar for blocking findings.
+#
+# IMPORTANT — the flag is opt-in and default OFF: with it unset, this path is fully
+# dormant and the gate behaves exactly as it does on current main. Enabling it is a
+# separate, deliberate workflow edit (the in-tree audit point for the operator's
+# approval). The advisory_settle path is UNAVAILABLE at Tier 3-4, which keep human
+# settlement regardless of this flag. See
+# docs/plans/2026-06-30-advisory-dissent-settlement-gate-packet.md.
+_ADVISORY_DISSENT_SETTLE_ENV = "ARAGORA_ENABLE_ADVISORY_DISSENT_SETTLE"
+_ADVISORY_DISSENT_SETTLE_TRUE = frozenset(("1", "true", "yes", "on"))
+
+
+def advisory_dissent_settle_enabled(env: dict[str, str] | None = None) -> bool:
+    """Whether the opt-in advisory-dissent settlement path is active. Default OFF;
+    a Tier 0-2 PR with only advisory (non-`[P0]`/`[P1]`) findings settles via
+    ``advisory_settle`` only when this is ON. See
+    :data:`_ADVISORY_DISSENT_SETTLE_ENV`."""
+    source = os.environ if env is None else env
+    return (
+        str(source.get(_ADVISORY_DISSENT_SETTLE_ENV, "")).strip().lower()
+        in _ADVISORY_DISSENT_SETTLE_TRUE
+    )
+
+
 def _coerce_relaxed_flag(value: Any) -> bool:
     """Coerce a serialized gate-regime flag (``severity_gated`` / ``tiered_gate``) to
     bool, fail-closed. A real bool passes through; a string counts as relaxed ONLY for

--- a/docs/plans/2026-06-30-advisory-dissent-settlement-gate-packet.md
+++ b/docs/plans/2026-06-30-advisory-dissent-settlement-gate-packet.md
@@ -1,0 +1,59 @@
+# Tier-4 Packet: Advisory-Dissent Settlement (unblock substantial new features)
+
+**Status:** awaiting operator (human-risk) sign-off — this modifies merge-authority logic (Tier 4).
+**Author:** Claude Code session 2026-06-30. **Owner sign-off required:** scarmani.
+
+## Problem (structural, proven empirically)
+The merge-quorum gate requires **2 supportive PASS verdicts** for Tier 1 (`tier_quorum_rule`,
+`aragora/swarm/quorum_evidence.py:230`). Two thorough adversarial reviewers (claude, openai)
+**never both PASS substantial net-new code** — they each find an endless tail of *advisory*
+`[P2]/[P3]` robustness nits (different ones each round). Demonstrated on #8389 (700-line ODR
+verify engine): 3 rounds of claude findings + a disjoint openai set, all advisory, **zero
+[P0]/[P1]**, `unresolved_dissent: false`. Net effect: **large valuable features cannot clear the
+gate while trivial churn sails through** — backwards for velocity *and* for shipping value.
+`--admin` does **not** bypass it (branch protection enforces the check against admins), and Tier 1
+has no human-settlement path — so there is currently **no clean way to land a substantial new
+feature** the reviewers keep nitpicking.
+
+## The change (staged)
+
+### Phase 1 — enable the existing tiered gate (low risk; flag already implemented)
+Set `ARAGORA_ENABLE_TIERED_MERGE_GATE: "1"` in `.github/workflows/aragora-merge-quorum.yml`
+(alongside the already-enabled `ARAGORA_ENABLE_SEVERITY_GATED_DISSENT: "1"`). Effect:
+`tier_quorum_rule` returns `required_signals=1, requires_western_frontier=True` for Tier 1-2
+(`quorum_evidence.py:228-229`). A single claude/openai **PASS** settles Tier 1-2. Helps every
+recovered feat that earns ≥1 western-frontier PASS. No code change.
+
+### Phase 2 — count advisory-only western-frontier review as a settling signal (the real fix)
+For PRs where reviewers nitpick endlessly (#8389: 0 PASS), Phase 1 is insufficient. Narrowly
+extend the gate so a PR is settleable when **all** hold:
+- all non-quorum required checks green;
+- ≥1 **western-frontier** model review collected at the exact head;
+- **zero [P0]/[P1] blocking findings** across all reviews (i.e. every CR is severity-gated
+  advisory per `EvidenceItem.dissenting`, `quorum_evidence.py:437-452`);
+- the advisory findings are **auto-filed as follow-up issues** on settle (value preserved).
+
+Change site: `tier_quorum_rule` / `TierQuorumRule.is_satisfied` (`quorum_evidence.py:162-208`) and
+the packet builder `_build_merge_authorization_packet` (`aragora/cli/commands/review_queue.py:2908`).
+Add an `advisory_settle` path: when the only thing missing is PASS verdicts but reviews exist with
+no blocking findings, mark `status=satisfied, verdict=advisory_settle` and emit the follow-up issue.
+
+## Risk + mitigations
+- **Risk:** lowers the bar from "2 PASS" to "reviewed + no blocking findings + 1 western-frontier".
+- **Mitigations:** still requires green CI; still requires a western-frontier reviewer; **still
+  hard-blocks on any [P0]/[P1]**; advisory findings are not discarded (auto-filed); applies to
+  Tier 0-2 only (Tier 3-4 keep human settlement). Net: nothing crash-unsafe or incorrect merges;
+  only *advisory robustness/style* nits stop being merge-blockers.
+- This is a **merge-authority self-modification → Tier 4**; it must itself settle via human
+  sign-off (this packet), not via the gate it changes.
+
+## Test plan
+- `tests/swarm/test_quorum_evidence.py` — add `advisory_settle` cases (advisory-only CR + 1
+  western-frontier → satisfied; any [P0]/[P1] → still blocked).
+- `tests/cli/commands/test_review_queue.py` — merge-packet emits `verdict=advisory_settle` +
+  follow-up-issue payload only when no blocking findings.
+- Regression: a PASS-based quorum still settles unchanged; Tier 3-4 unaffected.
+
+## Immediate beneficiary
+Unblocks the 19 recovered feats at once (esp. #8389, already hardened crash-safe with advisory
+follow-ups in #8725) without per-PR nit-chasing — ends the treadmill, keeps the quality signal.

--- a/docs/plans/2026-06-30-advisory-dissent-settlement-gate-packet.md
+++ b/docs/plans/2026-06-30-advisory-dissent-settlement-gate-packet.md
@@ -31,7 +31,7 @@ extend the gate so a PR is settleable when **all** hold:
 - ≥1 **western-frontier** model review collected at the exact head;
 - **zero [P0]/[P1] blocking findings** across all reviews (i.e. every CR is severity-gated
   advisory per `EvidenceItem.dissenting`, `quorum_evidence.py:437-452`);
-- the advisory findings are **auto-filed as follow-up issues** on settle (value preserved).
+- the advisory findings are **surfaced in the merge-packet (`advisory_findings`)** so a caller can file them as follow-ups (the gate itself does not create issues; wiring a caller is a separate step).
 
 Change site: `tier_quorum_rule` / `TierQuorumRule.is_satisfied` (`quorum_evidence.py:162-208`) and
 the packet builder `_build_merge_authorization_packet` (`aragora/cli/commands/review_queue.py:2908`).
@@ -41,7 +41,7 @@ no blocking findings, mark `status=satisfied, verdict=advisory_settle` and emit 
 ## Risk + mitigations
 - **Risk:** lowers the bar from "2 PASS" to "reviewed + no blocking findings + 1 western-frontier".
 - **Mitigations:** still requires green CI; still requires a western-frontier reviewer; **still
-  hard-blocks on any [P0]/[P1]**; advisory findings are not discarded (auto-filed); applies to
+  hard-blocks on any [P0]/[P1]**; advisory findings are not discarded (surfaced in the packet for a caller to file); applies to
   Tier 0-2 only (Tier 3-4 keep human settlement). Net: nothing crash-unsafe or incorrect merges;
   only *advisory robustness/style* nits stop being merge-blockers.
 - This is a **merge-authority self-modification → Tier 4**; it must itself settle via human

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -2886,6 +2886,256 @@ class TestModelReviewQuorum:
         assert _dogfood_evidence_from_comments(comments, head_sha=head) == []
 
 
+_QUORUM_ONLY_FAILURE_SURFACES = {"required_pr_checks": {"quorum_only_failure": True}}
+
+
+class TestAdvisoryDissentSettleGate:
+    """The opt-in advisory_settle path (ARAGORA_ENABLE_ADVISORY_DISSENT_SETTLE).
+
+    Default OFF — byte-identical to today. When ON, a Tier 0-2 PR whose only
+    failing required check is the model-quorum check, with at least one
+    western-frontier review at head and ZERO [P0]/[P1] blocking findings across
+    all reviews, settles via verdict=advisory_settle even when the strict model
+    quorum is not met.
+    """
+
+    HEAD = "cd87c5a1b2db34f04167906553502db3ede9525e"
+
+    @pytest.fixture(autouse=True)
+    def _strict_tiered_gate(self, monkeypatch) -> None:
+        # Pin the (separate) tiered-merge-gate flag OFF so a lone western-frontier
+        # signal does NOT satisfy the strict Tier 1-2 quorum on its own. This keeps
+        # these tests exercising the advisory_settle rescue path rather than the
+        # tiered-gate relaxation, regardless of ambient env.
+        monkeypatch.setenv("ARAGORA_ENABLE_TIERED_MERGE_GATE", "0")
+
+    def _tier_one_pr_with_lone_wf_signal(self) -> dict[str, Any]:
+        # Tier 1 (bounded internal code surface) needs 2 distinct families under
+        # the strict (default) gate; a single western-frontier (codex/openai)
+        # signal + dogfood therefore does NOT satisfy the quorum.
+        pr = _make_pr(files=["aragora/agents/router.py"])
+        pr["headRefOid"] = self.HEAD
+        pr["comments"] = [
+            _codex_openai_review_comment(
+                body=(
+                    f"Current head: {self.HEAD}\nVerdict: approve.\n"
+                    "Focused adversarial dogfood passed."
+                )
+            ),
+        ]
+        return pr
+
+    def test_flag_off_lone_wf_signal_still_blocked(self, monkeypatch) -> None:
+        # Flag OFF (default): the advisory_settle path is dormant, so a lone
+        # western-frontier signal at Tier 1 stays blocked exactly as today.
+        monkeypatch.delenv("ARAGORA_ENABLE_ADVISORY_DISSENT_SETTLE", raising=False)
+        pr = self._tier_one_pr_with_lone_wf_signal()
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=["aragora/agents/router.py"],
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+            check_surfaces=_QUORUM_ONLY_FAILURE_SURFACES,
+        )
+        assert quorum["tier"] == 1
+        assert quorum["status"] == "needs_model_review_quorum"
+        assert quorum["verdict"] == "collect_model_quorum_before_merge"
+        assert quorum["admin_squash_allowed"] is False
+        assert "advisory_findings" not in quorum or quorum["advisory_findings"] == []
+
+    def test_flag_off_advisory_only_cr_still_blocked(self, monkeypatch) -> None:
+        # Flag OFF + an advisory-only ([P2]) CHANGES-REQUESTED: still does NOT
+        # settle (severity-gated dissent is a SEPARATE flag; here it is OFF too,
+        # so the [P2] CR even blocks as today).
+        monkeypatch.delenv("ARAGORA_ENABLE_ADVISORY_DISSENT_SETTLE", raising=False)
+        monkeypatch.delenv("ARAGORA_ENABLE_SEVERITY_GATED_DISSENT", raising=False)
+        pr = self._tier_one_pr_with_lone_wf_signal()
+        pr["comments"].append(
+            {
+                "author": {"login": "an0mium"},
+                "body": (
+                    "## Claude independent model review\n"
+                    f"Current head: {self.HEAD}\n"
+                    "Verdict: CHANGES-REQUESTED\n"
+                    "[P2] Add stronger smoke coverage in a follow-up."
+                ),
+            }
+        )
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=["aragora/agents/router.py"],
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+            check_surfaces=_QUORUM_ONLY_FAILURE_SURFACES,
+        )
+        assert quorum["status"] != "satisfied"
+        assert quorum["verdict"] != "advisory_settle"
+        assert quorum["admin_squash_allowed"] is False
+
+    def test_flag_on_lone_wf_signal_advisory_settles(self, monkeypatch) -> None:
+        # Flag ON, Tier 1, one western-frontier signal at head, all non-quorum
+        # required checks green, zero [P0]/[P1] findings -> advisory_settle.
+        monkeypatch.setenv("ARAGORA_ENABLE_ADVISORY_DISSENT_SETTLE", "1")
+        pr = self._tier_one_pr_with_lone_wf_signal()
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=["aragora/agents/router.py"],
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+            check_surfaces=_QUORUM_ONLY_FAILURE_SURFACES,
+        )
+        assert quorum["tier"] == 1
+        assert quorum["status"] == "satisfied"
+        assert quorum["verdict"] == "advisory_settle"
+        assert quorum["admin_squash_allowed"] is True
+        assert quorum["requires_human_risk_settlement"] is False
+        assert quorum["advisory_findings"] == []
+        assert any("advisory-dissent settle" in r for r in quorum["reasons"])
+
+    def test_flag_on_surfaces_advisory_findings(self, monkeypatch) -> None:
+        # Flag ON + severity-gated dissent ON: a [P2]-only CR is advisory (non-
+        # blocking). It must be surfaced in advisory_findings so a caller can file
+        # follow-up issues.
+        monkeypatch.setenv("ARAGORA_ENABLE_ADVISORY_DISSENT_SETTLE", "1")
+        monkeypatch.setenv("ARAGORA_ENABLE_SEVERITY_GATED_DISSENT", "1")
+        pr = self._tier_one_pr_with_lone_wf_signal()
+        pr["comments"].append(
+            {
+                "author": {"login": "an0mium"},
+                "body": (
+                    "## Claude independent model review\n"
+                    f"Current head: {self.HEAD}\n"
+                    "Verdict: CHANGES-REQUESTED\n"
+                    "[P2] Add stronger smoke coverage in a follow-up."
+                ),
+            }
+        )
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=["aragora/agents/router.py"],
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+            check_surfaces=_QUORUM_ONLY_FAILURE_SURFACES,
+        )
+        assert quorum["status"] == "satisfied"
+        assert quorum["verdict"] == "advisory_settle"
+        assert quorum["unresolved_dissent"] is False
+        assert len(quorum["advisory_findings"]) == 1
+        assert quorum["advisory_findings"][0]["position"] == "advisory_changes_requested"
+
+    def test_flag_on_p1_finding_still_blocked(self, monkeypatch) -> None:
+        # Flag ON: a real [P1] finding in ANY review blocks advisory_settle, even
+        # when severity-gated dissent would otherwise not apply. The strong-finding
+        # invariant always holds.
+        monkeypatch.setenv("ARAGORA_ENABLE_ADVISORY_DISSENT_SETTLE", "1")
+        pr = self._tier_one_pr_with_lone_wf_signal()
+        pr["comments"].append(
+            {
+                "author": {"login": "an0mium"},
+                "body": (
+                    "## Claude independent model review\n"
+                    f"Current head: {self.HEAD}\n"
+                    "Verdict: CHANGES-REQUESTED\n"
+                    "[P1] Merge gate dissent is unresolved."
+                ),
+            }
+        )
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=["aragora/agents/router.py"],
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+            check_surfaces=_QUORUM_ONLY_FAILURE_SURFACES,
+        )
+        assert quorum["verdict"] != "advisory_settle"
+        assert quorum["status"] != "satisfied"
+        assert quorum["admin_squash_allowed"] is False
+
+    def test_flag_on_tier_three_unaffected(self, monkeypatch) -> None:
+        # Tier 3 keeps human settlement: advisory_settle never applies above Tier 2.
+        monkeypatch.setenv("ARAGORA_ENABLE_ADVISORY_DISSENT_SETTLE", "1")
+        pr = _make_pr(files=["aragora/auth/session.py"])
+        pr["headRefOid"] = self.HEAD
+        pr["comments"] = [
+            _codex_openai_review_comment(
+                body=(
+                    f"Current head: {self.HEAD}\nVerdict: approve.\n"
+                    "Focused adversarial dogfood passed."
+                )
+            ),
+        ]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=["aragora/auth/session.py"],
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+            check_surfaces=_QUORUM_ONLY_FAILURE_SURFACES,
+        )
+        assert quorum["tier"] == 3
+        assert quorum["verdict"] != "advisory_settle"
+        assert quorum["verdict"] == "collect_model_quorum_before_merge"
+        assert quorum["admin_squash_allowed"] is False
+
+    def test_flag_on_requires_western_frontier_signal(self, monkeypatch) -> None:
+        # Flag ON but only a NON-western-frontier (grok) signal at head: condition
+        # (3) fails, so advisory_settle does NOT apply.
+        monkeypatch.setenv("ARAGORA_ENABLE_ADVISORY_DISSENT_SETTLE", "1")
+        pr = _make_pr(files=["aragora/agents/router.py"])
+        pr["headRefOid"] = self.HEAD
+        pr["comments"] = [
+            {
+                "author": {"login": "an0mium"},
+                "body": (
+                    "## Grok independent model review\n"
+                    f"Current head: {self.HEAD}\nVerdict: approve.\n"
+                    "Focused adversarial dogfood passed."
+                ),
+            },
+        ]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=["aragora/agents/router.py"],
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+            check_surfaces=_QUORUM_ONLY_FAILURE_SURFACES,
+        )
+        assert quorum["tier"] == 1
+        assert quorum["verdict"] != "advisory_settle"
+        assert quorum["admin_squash_allowed"] is False
+
+    def test_flag_on_requires_quorum_only_failure(self, monkeypatch) -> None:
+        # Flag ON but a non-quorum required check is ALSO failing
+        # (quorum_only_failure False): condition (2) fails, advisory_settle does
+        # not apply (other failing checks must be repaired first).
+        monkeypatch.setenv("ARAGORA_ENABLE_ADVISORY_DISSENT_SETTLE", "1")
+        pr = self._tier_one_pr_with_lone_wf_signal()
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=["aragora/agents/router.py"],
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+            check_surfaces={"required_pr_checks": {"quorum_only_failure": False}},
+        )
+        assert quorum["verdict"] != "advisory_settle"
+        assert quorum["admin_squash_allowed"] is False
+
+
 class TestHasBlockingOrNegativeVerdict:
     def test_blocker_value_starting_with_no_letters_is_still_blocking(self) -> None:
         # Word-boundary regression: "node"/"not working" must not be swallowed

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -3079,6 +3079,29 @@ class TestAdvisoryDissentSettleGate:
         assert q["verdict"] != "advisory_settle"
         assert q["admin_squash_allowed"] is False
 
+    def test_flag_on_bot_authored_wf_review_does_not_settle(self, monkeypatch) -> None:
+        # #8729 openai [P1] (r2): a github-actions[bot]-authored "Claude" advisory
+        # comment must NOT satisfy the WF prerequisite — the strict signal path
+        # rejects synthetic authors, and so must advisory_settle.
+        monkeypatch.setenv("ARAGORA_ENABLE_ADVISORY_DISSENT_SETTLE", "1")
+        monkeypatch.setenv("ARAGORA_ENABLE_SEVERITY_GATED_DISSENT", "1")
+        pr = _make_pr(files=["aragora/agents/router.py"])
+        pr["headRefOid"] = self.HEAD
+        pr["comments"] = [
+            {
+                "author": {"login": "github-actions[bot]"},
+                "body": (
+                    "## Claude independent model review\n"
+                    "Model family: claude\n"
+                    f"Current head: {self.HEAD}\n"
+                    "Verdict: CHANGES-REQUESTED\n[P2] follow-up."
+                ),
+            },
+        ]
+        q = self._quorum(pr)
+        assert q["verdict"] != "advisory_settle"
+        assert q["admin_squash_allowed"] is False
+
 
 class TestHasBlockingOrNegativeVerdict:
     def test_blocker_value_starting_with_no_letters_is_still_blocking(self) -> None:

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -3079,6 +3079,30 @@ class TestAdvisoryDissentSettleGate:
         assert q["verdict"] != "advisory_settle"
         assert q["admin_squash_allowed"] is False
 
+    def test_flag_on_bot_authored_advisory_cr_is_not_genuine_dissent(self, monkeypatch) -> None:
+        # #8729 openai [P1] (r4): a valid WF approval PLUS a github-actions[bot]
+        # advisory CR must NOT settle — the bot CR is not genuine (validated-source)
+        # advisory dissent, so there is nothing legitimate to waive.
+        monkeypatch.setenv("ARAGORA_ENABLE_ADVISORY_DISSENT_SETTLE", "1")
+        monkeypatch.setenv("ARAGORA_ENABLE_SEVERITY_GATED_DISSENT", "1")
+        pr = _make_pr(files=["aragora/agents/router.py"])
+        pr["headRefOid"] = self.HEAD
+        pr["comments"] = [
+            _codex_openai_review_comment(
+                body=f"Current head: {self.HEAD}\nVerdict: approve.\nFocused adversarial dogfood passed."
+            ),
+            {
+                "author": {"login": "github-actions[bot]"},
+                "body": (
+                    "## Claude independent model review\nModel family: claude\n"
+                    f"Current head: {self.HEAD}\nVerdict: CHANGES-REQUESTED\n[P2] nit."
+                ),
+            },
+        ]
+        q = self._quorum(pr)
+        assert q["verdict"] != "advisory_settle"
+        assert q["admin_squash_allowed"] is False
+
     def test_flag_on_bot_authored_wf_review_does_not_settle(self, monkeypatch) -> None:
         # #8729 openai [P1] (r2): a github-actions[bot]-authored "Claude" advisory
         # comment must NOT satisfy the WF prerequisite — the strict signal path

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -2893,10 +2893,15 @@ class TestAdvisoryDissentSettleGate:
     """The opt-in advisory_settle path (ARAGORA_ENABLE_ADVISORY_DISSENT_SETTLE).
 
     Default OFF — byte-identical to today. When ON, a Tier 0-2 PR whose only
-    failing required check is the model-quorum check, with at least one
-    western-frontier review at head and ZERO [P0]/[P1] blocking findings across
-    all reviews, settles via verdict=advisory_settle even when the strict model
-    quorum is not met.
+    failing required check is the model-quorum check settles via
+    verdict=advisory_settle when (and only when): a western-frontier review is
+    present at head IN ANY VERDICT, there is GENUINE advisory dissent being waived
+    (advisory_findings non-empty), zero [P0]/[P1] blocking findings across all
+    reviews, and nothing else is pending/unavailable/blocking.
+
+    These tests exercise the REAL caller shape: the quorum-only failure means the
+    merge-quorum required check IS failing, so ``has_failures=True`` (the first
+    cut's ``has_failures=False`` masked the dead-code path — #8729 claude [P1]).
     """
 
     HEAD = "cd87c5a1b2db34f04167906553502db3ede9525e"
@@ -2904,15 +2909,33 @@ class TestAdvisoryDissentSettleGate:
     @pytest.fixture(autouse=True)
     def _strict_tiered_gate(self, monkeypatch) -> None:
         # Pin the (separate) tiered-merge-gate flag OFF so a lone western-frontier
-        # signal does NOT satisfy the strict Tier 1-2 quorum on its own. This keeps
-        # these tests exercising the advisory_settle rescue path rather than the
-        # tiered-gate relaxation, regardless of ambient env.
+        # signal does NOT satisfy strict Tier 1-2 quorum on its own — keeps these
+        # tests on the advisory_settle rescue path, not the tiered-gate relaxation.
         monkeypatch.setenv("ARAGORA_ENABLE_TIERED_MERGE_GATE", "0")
 
-    def _tier_one_pr_with_lone_wf_signal(self) -> dict[str, Any]:
-        # Tier 1 (bounded internal code surface) needs 2 distinct families under
-        # the strict (default) gate; a single western-frontier (codex/openai)
-        # signal + dogfood therefore does NOT satisfy the quorum.
+    def _wf_advisory_cr_comment(self) -> dict[str, Any]:
+        # A western-frontier (claude) review at head whose verdict is an advisory
+        # [P2] CHANGES-REQUESTED (no [P0]/[P1]). Advisory only when the severity
+        # gate is ON.
+        return {
+            "author": {"login": "an0mium"},
+            "body": (
+                "## Claude independent model review\n"
+                "Model family: claude\n"
+                f"Current head: {self.HEAD}\n"
+                "Verdict: CHANGES-REQUESTED\n"
+                "[P2] Add stronger smoke coverage in a follow-up."
+            ),
+        }
+
+    def _tier1_pr_wf_advisory_cr(self) -> dict[str, Any]:
+        pr = _make_pr(files=["aragora/agents/router.py"])
+        pr["headRefOid"] = self.HEAD
+        pr["comments"] = [self._wf_advisory_cr_comment()]
+        return pr
+
+    def _tier1_pr_lone_approval(self) -> dict[str, Any]:
+        # A single western-frontier APPROVAL and no dissent at all.
         pr = _make_pr(files=["aragora/agents/router.py"])
         pr["headRefOid"] = self.HEAD
         pr["comments"] = [
@@ -2925,215 +2948,113 @@ class TestAdvisoryDissentSettleGate:
         ]
         return pr
 
-    def test_flag_off_lone_wf_signal_still_blocked(self, monkeypatch) -> None:
-        # Flag OFF (default): the advisory_settle path is dormant, so a lone
-        # western-frontier signal at Tier 1 stays blocked exactly as today.
+    def _quorum(self, pr, *, has_failures=True, has_pending=False, files=None):
+        return _build_model_review_quorum(
+            pr=pr,
+            files=files or ["aragora/agents/router.py"],
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="repair_first" if has_failures else "approve_candidate",
+            has_pending=has_pending,
+            has_failures=has_failures,
+            check_surfaces=_QUORUM_ONLY_FAILURE_SURFACES,
+        )
+
+    def test_flag_off_advisory_cr_still_blocked(self, monkeypatch) -> None:
+        # Flag OFF (default): advisory_settle dormant; behavior byte-identical.
         monkeypatch.delenv("ARAGORA_ENABLE_ADVISORY_DISSENT_SETTLE", raising=False)
-        pr = self._tier_one_pr_with_lone_wf_signal()
-        quorum = _build_model_review_quorum(
-            pr=pr,
-            files=["aragora/agents/router.py"],
-            protocol={"status": "metadata_heuristic"},
-            machine_recommendation="approve_candidate",
-            has_pending=False,
-            has_failures=False,
-            check_surfaces=_QUORUM_ONLY_FAILURE_SURFACES,
-        )
-        assert quorum["tier"] == 1
-        assert quorum["status"] == "needs_model_review_quorum"
-        assert quorum["verdict"] == "collect_model_quorum_before_merge"
-        assert quorum["admin_squash_allowed"] is False
-        assert "advisory_findings" not in quorum or quorum["advisory_findings"] == []
+        monkeypatch.setenv("ARAGORA_ENABLE_SEVERITY_GATED_DISSENT", "1")
+        q = self._quorum(self._tier1_pr_wf_advisory_cr())
+        assert q["verdict"] != "advisory_settle"
+        assert q["admin_squash_allowed"] is False
 
-    def test_flag_off_advisory_only_cr_still_blocked(self, monkeypatch) -> None:
-        # Flag OFF + an advisory-only ([P2]) CHANGES-REQUESTED: still does NOT
-        # settle (severity-gated dissent is a SEPARATE flag; here it is OFF too,
-        # so the [P2] CR even blocks as today).
-        monkeypatch.delenv("ARAGORA_ENABLE_ADVISORY_DISSENT_SETTLE", raising=False)
-        monkeypatch.delenv("ARAGORA_ENABLE_SEVERITY_GATED_DISSENT", raising=False)
-        pr = self._tier_one_pr_with_lone_wf_signal()
-        pr["comments"].append(
-            {
-                "author": {"login": "an0mium"},
-                "body": (
-                    "## Claude independent model review\n"
-                    f"Current head: {self.HEAD}\n"
-                    "Verdict: CHANGES-REQUESTED\n"
-                    "[P2] Add stronger smoke coverage in a follow-up."
-                ),
-            }
-        )
-        quorum = _build_model_review_quorum(
-            pr=pr,
-            files=["aragora/agents/router.py"],
-            protocol={"status": "metadata_heuristic"},
-            machine_recommendation="approve_candidate",
-            has_pending=False,
-            has_failures=False,
-            check_surfaces=_QUORUM_ONLY_FAILURE_SURFACES,
-        )
-        assert quorum["status"] != "satisfied"
-        assert quorum["verdict"] != "advisory_settle"
-        assert quorum["admin_squash_allowed"] is False
-
-    def test_flag_on_lone_wf_signal_advisory_settles(self, monkeypatch) -> None:
-        # Flag ON, Tier 1, one western-frontier signal at head, all non-quorum
-        # required checks green, zero [P0]/[P1] findings -> advisory_settle.
-        monkeypatch.setenv("ARAGORA_ENABLE_ADVISORY_DISSENT_SETTLE", "1")
-        pr = self._tier_one_pr_with_lone_wf_signal()
-        quorum = _build_model_review_quorum(
-            pr=pr,
-            files=["aragora/agents/router.py"],
-            protocol={"status": "metadata_heuristic"},
-            machine_recommendation="approve_candidate",
-            has_pending=False,
-            has_failures=False,
-            check_surfaces=_QUORUM_ONLY_FAILURE_SURFACES,
-        )
-        assert quorum["tier"] == 1
-        assert quorum["status"] == "satisfied"
-        assert quorum["verdict"] == "advisory_settle"
-        assert quorum["admin_squash_allowed"] is True
-        assert quorum["requires_human_risk_settlement"] is False
-        assert quorum["advisory_findings"] == []
-        assert any("advisory-dissent settle" in r for r in quorum["reasons"])
-
-    def test_flag_on_surfaces_advisory_findings(self, monkeypatch) -> None:
-        # Flag ON + severity-gated dissent ON: a [P2]-only CR is advisory (non-
-        # blocking). It must be surfaced in advisory_findings so a caller can file
-        # follow-up issues.
+    def test_flag_on_wf_advisory_cr_settles_with_real_caller_has_failures(
+        self, monkeypatch
+    ) -> None:
+        # THE regression: real caller passes has_failures=True (merge-quorum is the
+        # failing check). advisory_settle must still be REACHED (not masked by the
+        # repair_or_wait branch — #8729 claude [P1]).
         monkeypatch.setenv("ARAGORA_ENABLE_ADVISORY_DISSENT_SETTLE", "1")
         monkeypatch.setenv("ARAGORA_ENABLE_SEVERITY_GATED_DISSENT", "1")
-        pr = self._tier_one_pr_with_lone_wf_signal()
-        pr["comments"].append(
-            {
-                "author": {"login": "an0mium"},
-                "body": (
-                    "## Claude independent model review\n"
-                    f"Current head: {self.HEAD}\n"
-                    "Verdict: CHANGES-REQUESTED\n"
-                    "[P2] Add stronger smoke coverage in a follow-up."
-                ),
-            }
-        )
-        quorum = _build_model_review_quorum(
-            pr=pr,
-            files=["aragora/agents/router.py"],
-            protocol={"status": "metadata_heuristic"},
-            machine_recommendation="approve_candidate",
-            has_pending=False,
-            has_failures=False,
-            check_surfaces=_QUORUM_ONLY_FAILURE_SURFACES,
-        )
-        assert quorum["status"] == "satisfied"
-        assert quorum["verdict"] == "advisory_settle"
-        assert quorum["unresolved_dissent"] is False
-        assert len(quorum["advisory_findings"]) == 1
-        assert quorum["advisory_findings"][0]["position"] == "advisory_changes_requested"
+        q = self._quorum(self._tier1_pr_wf_advisory_cr(), has_failures=True)
+        assert q["tier"] == 1
+        assert q["status"] == "satisfied"
+        assert q["verdict"] == "advisory_settle"
+        assert q["admin_squash_allowed"] is True
+        assert q["unresolved_dissent"] is False
+
+    def test_flag_on_surfaces_advisory_findings(self, monkeypatch) -> None:
+        monkeypatch.setenv("ARAGORA_ENABLE_ADVISORY_DISSENT_SETTLE", "1")
+        monkeypatch.setenv("ARAGORA_ENABLE_SEVERITY_GATED_DISSENT", "1")
+        q = self._quorum(self._tier1_pr_wf_advisory_cr())
+        assert q["verdict"] == "advisory_settle"
+        assert len(q["advisory_findings"]) >= 1
+
+    def test_flag_on_lone_approval_no_dissent_does_not_settle(self, monkeypatch) -> None:
+        # #8729 openai [P1]: a lone approving WF comment with NO advisory dissent
+        # must NOT settle (that would be a one-review quorum bypass).
+        monkeypatch.setenv("ARAGORA_ENABLE_ADVISORY_DISSENT_SETTLE", "1")
+        monkeypatch.setenv("ARAGORA_ENABLE_SEVERITY_GATED_DISSENT", "1")
+        q = self._quorum(self._tier1_pr_lone_approval())
+        assert q["verdict"] != "advisory_settle"
+        assert q["admin_squash_allowed"] is False
 
     def test_flag_on_p1_finding_still_blocked(self, monkeypatch) -> None:
-        # Flag ON: a real [P1] finding in ANY review blocks advisory_settle, even
-        # when severity-gated dissent would otherwise not apply. The strong-finding
-        # invariant always holds.
         monkeypatch.setenv("ARAGORA_ENABLE_ADVISORY_DISSENT_SETTLE", "1")
-        pr = self._tier_one_pr_with_lone_wf_signal()
+        monkeypatch.setenv("ARAGORA_ENABLE_SEVERITY_GATED_DISSENT", "1")
+        pr = self._tier1_pr_wf_advisory_cr()
         pr["comments"].append(
             {
                 "author": {"login": "an0mium"},
                 "body": (
-                    "## Claude independent model review\n"
+                    "## Codex review\nModel family: openai\n"
                     f"Current head: {self.HEAD}\n"
                     "Verdict: CHANGES-REQUESTED\n"
                     "[P1] Merge gate dissent is unresolved."
                 ),
             }
         )
-        quorum = _build_model_review_quorum(
-            pr=pr,
-            files=["aragora/agents/router.py"],
-            protocol={"status": "metadata_heuristic"},
-            machine_recommendation="approve_candidate",
-            has_pending=False,
-            has_failures=False,
-            check_surfaces=_QUORUM_ONLY_FAILURE_SURFACES,
-        )
-        assert quorum["verdict"] != "advisory_settle"
-        assert quorum["status"] != "satisfied"
-        assert quorum["admin_squash_allowed"] is False
+        q = self._quorum(pr)
+        assert q["verdict"] != "advisory_settle"
+        assert q["admin_squash_allowed"] is False
 
     def test_flag_on_tier_three_unaffected(self, monkeypatch) -> None:
-        # Tier 3 keeps human settlement: advisory_settle never applies above Tier 2.
         monkeypatch.setenv("ARAGORA_ENABLE_ADVISORY_DISSENT_SETTLE", "1")
+        monkeypatch.setenv("ARAGORA_ENABLE_SEVERITY_GATED_DISSENT", "1")
         pr = _make_pr(files=["aragora/auth/session.py"])
         pr["headRefOid"] = self.HEAD
-        pr["comments"] = [
-            _codex_openai_review_comment(
-                body=(
-                    f"Current head: {self.HEAD}\nVerdict: approve.\n"
-                    "Focused adversarial dogfood passed."
-                )
-            ),
-        ]
-        quorum = _build_model_review_quorum(
-            pr=pr,
-            files=["aragora/auth/session.py"],
-            protocol={"status": "metadata_heuristic"},
-            machine_recommendation="approve_candidate",
-            has_pending=False,
-            has_failures=False,
-            check_surfaces=_QUORUM_ONLY_FAILURE_SURFACES,
-        )
-        assert quorum["tier"] == 3
-        assert quorum["verdict"] != "advisory_settle"
-        assert quorum["verdict"] == "collect_model_quorum_before_merge"
-        assert quorum["admin_squash_allowed"] is False
+        pr["comments"] = [self._wf_advisory_cr_comment()]
+        q = self._quorum(pr, files=["aragora/auth/session.py"])
+        assert q["tier"] == 3
+        assert q["verdict"] != "advisory_settle"
+        assert q["admin_squash_allowed"] is False
 
-    def test_flag_on_requires_western_frontier_signal(self, monkeypatch) -> None:
-        # Flag ON but only a NON-western-frontier (grok) signal at head: condition
-        # (3) fails, so advisory_settle does NOT apply.
+    def test_flag_on_non_wf_only_does_not_settle(self, monkeypatch) -> None:
+        # Only a NON-western-frontier (grok) review at head -> no WF review present.
         monkeypatch.setenv("ARAGORA_ENABLE_ADVISORY_DISSENT_SETTLE", "1")
+        monkeypatch.setenv("ARAGORA_ENABLE_SEVERITY_GATED_DISSENT", "1")
         pr = _make_pr(files=["aragora/agents/router.py"])
         pr["headRefOid"] = self.HEAD
         pr["comments"] = [
             {
                 "author": {"login": "an0mium"},
                 "body": (
-                    "## Grok independent model review\n"
-                    f"Current head: {self.HEAD}\nVerdict: approve.\n"
-                    "Focused adversarial dogfood passed."
+                    "## Grok independent model review\nModel family: grok\n"
+                    f"Current head: {self.HEAD}\n"
+                    "Verdict: CHANGES-REQUESTED\n[P2] follow-up."
                 ),
             },
         ]
-        quorum = _build_model_review_quorum(
-            pr=pr,
-            files=["aragora/agents/router.py"],
-            protocol={"status": "metadata_heuristic"},
-            machine_recommendation="approve_candidate",
-            has_pending=False,
-            has_failures=False,
-            check_surfaces=_QUORUM_ONLY_FAILURE_SURFACES,
-        )
-        assert quorum["tier"] == 1
-        assert quorum["verdict"] != "advisory_settle"
-        assert quorum["admin_squash_allowed"] is False
+        q = self._quorum(pr)
+        assert q["verdict"] != "advisory_settle"
+        assert q["admin_squash_allowed"] is False
 
-    def test_flag_on_requires_quorum_only_failure(self, monkeypatch) -> None:
-        # Flag ON but a non-quorum required check is ALSO failing
-        # (quorum_only_failure False): condition (2) fails, advisory_settle does
-        # not apply (other failing checks must be repaired first).
+    def test_flag_on_pending_checks_does_not_settle(self, monkeypatch) -> None:
+        # A pending check is a real "wait" condition; advisory_settle must not fire.
         monkeypatch.setenv("ARAGORA_ENABLE_ADVISORY_DISSENT_SETTLE", "1")
-        pr = self._tier_one_pr_with_lone_wf_signal()
-        quorum = _build_model_review_quorum(
-            pr=pr,
-            files=["aragora/agents/router.py"],
-            protocol={"status": "metadata_heuristic"},
-            machine_recommendation="approve_candidate",
-            has_pending=False,
-            has_failures=False,
-            check_surfaces={"required_pr_checks": {"quorum_only_failure": False}},
-        )
-        assert quorum["verdict"] != "advisory_settle"
-        assert quorum["admin_squash_allowed"] is False
+        monkeypatch.setenv("ARAGORA_ENABLE_SEVERITY_GATED_DISSENT", "1")
+        q = self._quorum(self._tier1_pr_wf_advisory_cr(), has_failures=False, has_pending=True)
+        assert q["verdict"] != "advisory_settle"
+        assert q["admin_squash_allowed"] is False
 
 
 class TestHasBlockingOrNegativeVerdict:

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -3056,6 +3056,29 @@ class TestAdvisoryDissentSettleGate:
         assert q["verdict"] != "advisory_settle"
         assert q["admin_squash_allowed"] is False
 
+    def test_flag_on_spoofed_wf_identity_does_not_settle(self, monkeypatch) -> None:
+        # #8729 openai [P1]: a conflicted/uncountable identity (a "## Grok" heading
+        # with a claimed "Model family: claude") must NOT satisfy the WF requirement
+        # — it is not a countable western-frontier signal on the strict path either.
+        monkeypatch.setenv("ARAGORA_ENABLE_ADVISORY_DISSENT_SETTLE", "1")
+        monkeypatch.setenv("ARAGORA_ENABLE_SEVERITY_GATED_DISSENT", "1")
+        pr = _make_pr(files=["aragora/agents/router.py"])
+        pr["headRefOid"] = self.HEAD
+        pr["comments"] = [
+            {
+                "author": {"login": "an0mium"},
+                "body": (
+                    "## Grok independent model review\n"
+                    "Model family: claude\n"  # conflicts with the Grok heading
+                    f"Current head: {self.HEAD}\n"
+                    "Verdict: CHANGES-REQUESTED\n[P2] follow-up."
+                ),
+            },
+        ]
+        q = self._quorum(pr)
+        assert q["verdict"] != "advisory_settle"
+        assert q["admin_squash_allowed"] is False
+
 
 class TestHasBlockingOrNegativeVerdict:
     def test_blocker_value_starting_with_no_letters_is_still_blocking(self) -> None:

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -2982,3 +2982,35 @@ def test_severity_gated_string_false_stays_strict_through_restore() -> None:
         }
     )
     assert item.severity_gated is False
+
+
+# --- advisory_dissent_settle_enabled (opt-in flag, default OFF) -------------
+def test_advisory_dissent_settle_enabled_default_off(monkeypatch) -> None:
+    # Production default is the env var UNSET; that MUST read as OFF so the new
+    # advisory_settle path is dormant until an operator opts in.
+    monkeypatch.delenv("ARAGORA_ENABLE_ADVISORY_DISSENT_SETTLE", raising=False)
+    assert qe.advisory_dissent_settle_enabled() is False
+
+
+@pytest.mark.parametrize("raw", ["1", "true", "TRUE", "yes", "on", "On"])
+def test_advisory_dissent_settle_enabled_true_tokens(monkeypatch, raw: str) -> None:
+    monkeypatch.setenv("ARAGORA_ENABLE_ADVISORY_DISSENT_SETTLE", raw)
+    assert qe.advisory_dissent_settle_enabled() is True
+
+
+@pytest.mark.parametrize("raw", ["0", "false", "off", "no", "", "  ", "maybe"])
+def test_advisory_dissent_settle_enabled_false_tokens(monkeypatch, raw: str) -> None:
+    monkeypatch.setenv("ARAGORA_ENABLE_ADVISORY_DISSENT_SETTLE", raw)
+    assert qe.advisory_dissent_settle_enabled() is False
+
+
+def test_advisory_dissent_settle_enabled_accepts_injected_env() -> None:
+    # Mirrors severity_gated_dissent_enabled / tiered_merge_gate_enabled: an
+    # explicit env mapping overrides os.environ for deterministic testing.
+    assert (
+        qe.advisory_dissent_settle_enabled({"ARAGORA_ENABLE_ADVISORY_DISSENT_SETTLE": "1"}) is True
+    )
+    assert (
+        qe.advisory_dissent_settle_enabled({"ARAGORA_ENABLE_ADVISORY_DISSENT_SETTLE": "0"}) is False
+    )
+    assert qe.advisory_dissent_settle_enabled({}) is False


### PR DESCRIPTION
Tier-4 / merge-authority change. **Default OFF (`ARAGORA_ENABLE_ADVISORY_DISSENT_SETTLE`), behavior-preserving until enabled.**

When ON, a Tier 0-2 PR settles via `verdict=advisory_settle` when: all non-quorum required checks green, >=1 western-frontier review, and ZERO [P0]/[P1] blocking findings across all reviews; advisory findings are surfaced for follow-up issues. Tier 3-4 unaffected (keep human settlement).

Unblocks substantial new features that two thorough reviewers never both PASS (the structural gate finding). 496 tests pass (no regression). Spec: `docs/plans/2026-06-30-advisory-dissent-settlement-gate-packet.md`; advisory-findings follow-up #8725.

Enabling is a separate one-line workflow flip after sign-off.