### PR TITLE
feat(tooling): RLM-backed digest of sibling agent (Codex) sessions

### DIFF
--- a/scripts/agent_session_digest.py
+++ b/scripts/agent_session_digest.py
@@ -26,9 +26,50 @@ import time
 from pathlib import Path
 from typing import Any
 
-DEFAULT_SESSIONS_ROOT = Path.home() / ".codex" / "sessions"
+from aragora.swarm.agent_bridge.codex_source import default_codex_home
+
+
+def default_sessions_root() -> Path:
+    return default_codex_home() / "sessions"
+
+
+DEFAULT_SESSIONS_ROOT = default_sessions_root()
+MAX_ROLLOUT_SCAN = 200
 _PR_RE = re.compile(r"#(\d{3,6})\b")
 _CMD_RE = re.compile(r'"cmd"\s*:\s*"([^"]{0,160})')
+
+
+def _rollout_session_id(path: Path, meta_id: str | None = None) -> str:
+    if meta_id:
+        return meta_id
+    name = path.name
+    if name.startswith("rollout-") and name.endswith(".jsonl"):
+        stem = name[len("rollout-") : -len(".jsonl")]
+        match = re.match(r"\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-(?P<sid>.+)", stem)
+        return match.group("sid") if match else stem
+    return path.stem
+
+
+def _iter_rollouts(root: Path, *, since_hours: float | None = None, now: float | None = None):
+    cutoff = (
+        None
+        if since_hours is None
+        else (now if now is not None else time.time()) - since_hours * 3600.0
+    )
+    candidates: list[tuple[float, Path]] = []
+    patterns = ("rollout-*.jsonl", "*/*/*/rollout-*.jsonl")
+    for pattern in patterns:
+        for rollout in root.glob(pattern):
+            try:
+                mtime = rollout.stat().st_mtime
+            except OSError:
+                continue
+            if cutoff is not None and mtime < cutoff:
+                continue
+            candidates.append((mtime, rollout))
+    candidates.sort(key=lambda item: item[0], reverse=True)
+    for _, rollout in candidates[:MAX_ROLLOUT_SCAN]:
+        yield rollout
 
 
 def find_rollout(*, path: str | None, session: str | None, latest: bool, root: Path) -> Path | None:
@@ -36,9 +77,7 @@ def find_rollout(*, path: str | None, session: str | None, latest: bool, root: P
     if path:
         p = Path(path)
         return p if p.is_file() else None
-    candidates = sorted(
-        root.rglob("rollout-*.jsonl"), key=lambda p: p.stat().st_mtime, reverse=True
-    )
+    candidates = list(_iter_rollouts(root))
     if not candidates:
         return None
     if latest:
@@ -58,16 +97,10 @@ def coordinator_view(
     The single cross-agent view: run before editing shared files to see what
     sibling agents are touching (which PRs/files) and avoid collisions.
     """
-    cutoff = (now if now is not None else time.time()) - since_hours * 3600.0
     rows: list[dict[str, Any]] = []
-    for r in sorted(root.rglob("rollout-*.jsonl"), key=lambda p: p.stat().st_mtime, reverse=True):
-        try:
-            if r.stat().st_mtime < cutoff:
-                continue
-        except OSError:
-            continue
+    for r in _iter_rollouts(root, since_hours=since_hours, now=now):
         turns = extract_turns(r)
-        sid = r.name.split("-")[-1].replace(".jsonl", "")
+        sid = _rollout_session_id(r, turns.get("session_id"))
         rows.append(
             {
                 "session_id": sid,
@@ -90,37 +123,82 @@ def extract_turns(rollout: Path) -> dict[str, Any]:
     decisions: list[str] = []
     commands: list[str] = []
     prs: set[str] = set()
-    for line in rollout.read_text(errors="replace").splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            rec = json.loads(line)
-        except (ValueError, TypeError):
-            continue
-        if rec.get("type") != "response_item":
-            continue
-        item = rec.get("payload") or rec
-        itype = item.get("type")
-        if itype == "function_call":
-            args = str(item.get("arguments", ""))
-            m = _CMD_RE.search(args)
-            cmd = m.group(1) if m else f"{item.get('name', 'call')}: {args[:80]}"
-            commands.append(cmd)
-            prs.update(_PR_RE.findall(args))
-        elif item.get("role") in ("user", "assistant"):
-            content = item.get("content")
-            text = ""
-            if isinstance(content, list):
-                text = " ".join(x.get("text", "") for x in content if isinstance(x, dict)).strip()
-            elif isinstance(content, str):
-                text = content.strip()
-            if not text:
+    session_id: str | None = None
+    try:
+        handle = rollout.open("r", encoding="utf-8", errors="replace")
+    except OSError:
+        handle = None
+    if handle is None:
+        return {
+            "rollout": str(rollout),
+            "session_id": _rollout_session_id(rollout),
+            "prompts": [],
+            "decisions": [],
+            "commands": [],
+            "prs_referenced": [],
+            "counts": {"prompts": 0, "decisions": 0, "commands": 0, "prs": 0},
+        }
+    with handle:
+        for raw_line in handle:
+            line = raw_line.strip()
+            if not line:
                 continue
-            prs.update(_PR_RE.findall(text))
-            (prompts if item.get("role") == "user" else decisions).append(text[:300])
+            try:
+                rec = json.loads(line)
+            except (ValueError, TypeError):
+                continue
+            payload = rec.get("payload") if isinstance(rec.get("payload"), dict) else {}
+            if rec.get("type") == "session_meta":
+                sid = payload.get("id")
+                if isinstance(sid, str) and sid:
+                    session_id = sid
+                continue
+            if rec.get("type") == "event_msg":
+                if payload.get("type") == "agent_message":
+                    message = payload.get("message")
+                    if isinstance(message, str) and message.strip():
+                        text = message.strip()
+                        decisions.append(text[:300])
+                        prs.update(_PR_RE.findall(text))
+                continue
+            if rec.get("type") != "response_item":
+                continue
+            item = payload or rec
+            itype = item.get("type")
+            if itype == "function_call":
+                args = item.get("arguments", "")
+                parsed_args = _parse_call_arguments(args)
+                if isinstance(parsed_args, dict) and isinstance(parsed_args.get("cmd"), str):
+                    cmd = parsed_args["cmd"][:160]
+                    arg_text = json.dumps(parsed_args, sort_keys=True, default=str)
+                    prs.update(_pr_ids_from_call_args(parsed_args))
+                else:
+                    arg_text = (
+                        args
+                        if isinstance(args, str)
+                        else json.dumps(args, sort_keys=True, default=str)
+                    )
+                    m = _CMD_RE.search(arg_text)
+                    cmd = m.group(1) if m else f"{item.get('name', 'call')}: {arg_text[:80]}"
+                commands.append(cmd)
+                prs.update(_PR_RE.findall(arg_text))
+            elif item.get("role") in ("user", "assistant"):
+                content = item.get("content")
+                text = ""
+                if isinstance(content, list):
+                    text = " ".join(
+                        x.get("text", "") for x in content if isinstance(x, dict)
+                    ).strip()
+                elif isinstance(content, str):
+                    text = content.strip()
+                if not text:
+                    continue
+                prs.update(_PR_RE.findall(text))
+                (prompts if item.get("role") == "user" else decisions).append(text[:300])
+    session_id = _rollout_session_id(rollout, session_id)
     return {
         "rollout": str(rollout),
+        "session_id": session_id,
         "prompts": prompts,
         "decisions": decisions,
         "commands": commands,
@@ -134,6 +212,28 @@ def extract_turns(rollout: Path) -> dict[str, Any]:
     }
 
 
+def _parse_call_arguments(arguments: Any) -> Any:
+    if isinstance(arguments, dict):
+        return arguments
+    if not isinstance(arguments, str):
+        return arguments
+    try:
+        return json.loads(arguments)
+    except (ValueError, TypeError):
+        return arguments
+
+
+def _pr_ids_from_call_args(arguments: dict[str, Any]) -> set[str]:
+    ids: set[str] = set()
+    for key in ("pr", "pr_number", "pull_request", "pull_request_number"):
+        value = arguments.get(key)
+        if isinstance(value, int):
+            ids.add(str(value))
+        elif isinstance(value, str) and value.isdigit():
+            ids.add(value)
+    return ids
+
+
 def rlm_summary(turns: dict[str, Any], question: str) -> str | None:
     """Best-effort recursive summary via Aragora's RLM CLI; None if unavailable."""
     import tempfile
@@ -142,45 +242,45 @@ def rlm_summary(turns: dict[str, Any], question: str) -> str | None:
         ["# Agent session decisions", *turns["decisions"], "# Commands", *turns["commands"]]
     )
     try:
-        with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False) as src:
-            src.write(body)
-            src_path = src.name
-        ctx_path = src_path + ".ctx.json"
-        comp = subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "aragora.cli.main",
-                "rlm",
-                "compress",
-                src_path,
-                "-o",
-                ctx_path,
-                "-t",
-                "document",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=120,
-        )
-        if comp.returncode != 0 or not Path(ctx_path).exists():
-            return None
-        q = subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "aragora.cli.main",
-                "rlm",
-                "query",
-                question,
-                "--context",
-                ctx_path,
-            ],
-            capture_output=True,
-            text=True,
-            timeout=180,
-        )
-        return q.stdout.strip() or None
+        with tempfile.TemporaryDirectory(prefix="agent-session-digest-") as tmp:
+            src_path = Path(tmp) / "session.txt"
+            ctx_path = Path(tmp) / "session.ctx.json"
+            src_path.write_text(body, encoding="utf-8")
+            comp = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "aragora.cli.main",
+                    "rlm",
+                    "compress",
+                    str(src_path),
+                    "-o",
+                    str(ctx_path),
+                    "-t",
+                    "document",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+            if comp.returncode != 0 or not ctx_path.exists():
+                return None
+            q = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "aragora.cli.main",
+                    "rlm",
+                    "query",
+                    question,
+                    "--context",
+                    str(ctx_path),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=180,
+            )
+            return q.stdout.strip() or None
     except (subprocess.SubprocessError, OSError):
         return None
 
@@ -224,7 +324,7 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="Also produce a recursive RLM summary (optional custom question)",
     )
-    ap.add_argument("--sessions-root", default=str(DEFAULT_SESSIONS_ROOT))
+    ap.add_argument("--sessions-root", default=str(default_sessions_root()))
     ap.add_argument("--json", action="store_true", help="Emit JSON instead of text")
     args = ap.parse_args(argv)
 

--- a/scripts/agent_session_digest.py
+++ b/scripts/agent_session_digest.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Digest a sibling agent's Codex session rollout into a compact, reviewable summary.
+
+Cross-agent visibility: Codex writes a full per-session transcript to
+``~/.codex/sessions/<YYYY>/<MM>/<DD>/rollout-*.jsonl`` (every user prompt, agent
+message, and ``exec_command`` call). Those files are large (MBs), so reading one
+wholesale blows a reviewer's context. This tool extracts the *relevant* turns
+deterministically and — when available — runs them through Aragora's own RLM
+(``aragora rlm compress`` + ``query``) for a recursive summary, so reviewing what
+a sibling agent did is one command instead of hand-parsing JSONL.
+
+Usage:
+    python3 scripts/agent_session_digest.py --latest
+    python3 scripts/agent_session_digest.py --session 019f197d --json
+    python3 scripts/agent_session_digest.py --path <rollout.jsonl> --rlm "what did it do?"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+DEFAULT_SESSIONS_ROOT = Path.home() / ".codex" / "sessions"
+_PR_RE = re.compile(r"#(\d{3,6})\b")
+_CMD_RE = re.compile(r'"cmd"\s*:\s*"([^"]{0,160})')
+
+
+def find_rollout(*, path: str | None, session: str | None, latest: bool, root: Path) -> Path | None:
+    """Resolve a rollout file from an explicit path, a session-id substring, or --latest."""
+    if path:
+        p = Path(path)
+        return p if p.is_file() else None
+    candidates = sorted(
+        root.rglob("rollout-*.jsonl"), key=lambda p: p.stat().st_mtime, reverse=True
+    )
+    if not candidates:
+        return None
+    if latest:
+        return candidates[0]
+    if session:
+        for c in candidates:
+            if session in c.name:
+                return c
+    return None
+
+
+def extract_turns(rollout: Path) -> dict[str, Any]:
+    """Deterministically extract the reviewable signal from a rollout JSONL.
+
+    Returns prompts, agent decisions, exec commands, and referenced PRs — without
+    loading the full transcript into a reviewer's context.
+    """
+    prompts: list[str] = []
+    decisions: list[str] = []
+    commands: list[str] = []
+    prs: set[str] = set()
+    for line in rollout.read_text(errors="replace").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except (ValueError, TypeError):
+            continue
+        if rec.get("type") != "response_item":
+            continue
+        item = rec.get("payload") or rec
+        itype = item.get("type")
+        if itype == "function_call":
+            args = str(item.get("arguments", ""))
+            m = _CMD_RE.search(args)
+            cmd = m.group(1) if m else f"{item.get('name', 'call')}: {args[:80]}"
+            commands.append(cmd)
+            prs.update(_PR_RE.findall(args))
+        elif item.get("role") in ("user", "assistant"):
+            content = item.get("content")
+            text = ""
+            if isinstance(content, list):
+                text = " ".join(x.get("text", "") for x in content if isinstance(x, dict)).strip()
+            elif isinstance(content, str):
+                text = content.strip()
+            if not text:
+                continue
+            prs.update(_PR_RE.findall(text))
+            (prompts if item.get("role") == "user" else decisions).append(text[:300])
+    return {
+        "rollout": str(rollout),
+        "prompts": prompts,
+        "decisions": decisions,
+        "commands": commands,
+        "prs_referenced": sorted(prs, key=int),
+        "counts": {
+            "prompts": len(prompts),
+            "decisions": len(decisions),
+            "commands": len(commands),
+            "prs": len(prs),
+        },
+    }
+
+
+def rlm_summary(turns: dict[str, Any], question: str) -> str | None:
+    """Best-effort recursive summary via Aragora's RLM CLI; None if unavailable."""
+    import tempfile
+
+    body = "\n".join(
+        ["# Agent session decisions", *turns["decisions"], "# Commands", *turns["commands"]]
+    )
+    try:
+        with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False) as src:
+            src.write(body)
+            src_path = src.name
+        ctx_path = src_path + ".ctx.json"
+        comp = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "aragora.cli.main",
+                "rlm",
+                "compress",
+                src_path,
+                "-o",
+                ctx_path,
+                "-t",
+                "document",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        if comp.returncode != 0 or not Path(ctx_path).exists():
+            return None
+        q = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "aragora.cli.main",
+                "rlm",
+                "query",
+                question,
+                "--context",
+                ctx_path,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+        return q.stdout.strip() or None
+    except (subprocess.SubprocessError, OSError):
+        return None
+
+
+def render_text(turns: dict[str, Any], summary: str | None) -> str:
+    c = turns["counts"]
+    lines = [
+        f"Session: {turns['rollout']}",
+        f"Activity: {c['prompts']} prompts · {c['decisions']} decisions · "
+        f"{c['commands']} commands · PRs: {', '.join('#' + p for p in turns['prs_referenced']) or 'none'}",
+        "",
+        "Key decisions:",
+    ]
+    lines += [f"  • {d[:160]}" for d in turns["decisions"][:8]]
+    if summary:
+        lines += ["", "RLM summary:", summary]
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Digest a sibling agent's Codex session rollout.")
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--latest", action="store_true", help="Most recent rollout")
+    g.add_argument("--session", help="Match a session-id substring")
+    g.add_argument("--path", help="Explicit rollout .jsonl path")
+    ap.add_argument(
+        "--rlm",
+        nargs="?",
+        const="Summarize the main actions, files/PRs touched, and any duplicated or wasted work.",
+        default=None,
+        help="Also produce a recursive RLM summary (optional custom question)",
+    )
+    ap.add_argument("--sessions-root", default=str(DEFAULT_SESSIONS_ROOT))
+    ap.add_argument("--json", action="store_true", help="Emit JSON instead of text")
+    args = ap.parse_args(argv)
+
+    rollout = find_rollout(
+        path=args.path,
+        session=args.session,
+        latest=args.latest,
+        root=Path(args.sessions_root),
+    )
+    if rollout is None:
+        print("no matching rollout found", file=sys.stderr)
+        return 1
+    turns = extract_turns(rollout)
+    summary = rlm_summary(turns, args.rlm) if args.rlm is not None else None
+    if args.json:
+        print(json.dumps({**turns, "rlm_summary": summary}, indent=2))
+    else:
+        print(render_text(turns, summary))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/agent_session_digest.py
+++ b/scripts/agent_session_digest.py
@@ -264,7 +264,10 @@ def _pr_ids_from_call_args(arguments: dict[str, Any]) -> set[str]:
         value = arguments.get(key)
         if isinstance(value, int):
             ids.add(str(value))
-        elif isinstance(value, str) and value.isdigit():
+        elif isinstance(value, str) and value.isdecimal():
+            # isdecimal (not isdigit): a Unicode-digit like "²" passes isdigit()
+            # but raises ValueError under the ``sorted(prs, key=int)`` at the end
+            # of extract_turns, crashing the whole digest.
             ids.add(value)
     return ids
 
@@ -319,9 +322,40 @@ def rlm_summary(turns: dict[str, Any], question: str) -> str | None:
                 # A failed query (e.g. missing context) must not be surfaced as
                 # a "summary"; the compress step already guards its returncode.
                 return None
-            return q.stdout.strip() or None
+            return _extract_rlm_answer(q.stdout)
     except (subprocess.SubprocessError, OSError):
         return None
+
+
+def _extract_rlm_answer(stdout: str) -> str | None:
+    """Return just the ANSWER block from ``aragora rlm query`` stdout.
+
+    The CLI decorates the answer with chrome (``Loaded context…``, ``Query:``,
+    ``Strategy:``, separator bars, an ``ANSWER`` banner) and a trailing stats
+    footer (``Ready:``/``Confidence:``/``Tokens processed:``…). Surfacing raw
+    stdout as the "summary" buries the answer; extract the text between the
+    ANSWER banner and the footer separator. Falls back to the stripped stdout
+    if the expected markers are absent.
+    """
+    lines = stdout.splitlines()
+    try:
+        marker = next(i for i, ln in enumerate(lines) if ln.strip() == "ANSWER")
+    except StopIteration:
+        return stdout.strip() or None
+    body: list[str] = []
+    for ln in lines[marker + 1 :]:
+        stripped = ln.strip()
+        # Skip the ``===`` banner immediately under ANSWER.
+        if not body and set(stripped) <= {"="} and stripped:
+            continue
+        # Stop at the footer: the ``---`` separator or the first stats line.
+        if (set(stripped) <= {"-"} and stripped) or stripped.startswith(
+            ("Ready:", "Confidence:", "Iteration:", "Tokens processed:", "Sub-calls made:")
+        ):
+            break
+        body.append(ln)
+    answer = "\n".join(body).strip()
+    return answer or (stdout.strip() or None)
 
 
 def render_text(turns: dict[str, Any], summary: str | None) -> str:
@@ -348,7 +382,10 @@ def main(argv: list[str] | None = None) -> int:
     g.add_argument(
         "--all",
         action="store_true",
-        help="Coordinator view: one-line digest of every rollout in the window",
+        help=(
+            "Coordinator view: one-line digest of each rollout in the window "
+            f"(up to the {MAX_ROLLOUT_SCAN} most recent; older ones are skipped)"
+        ),
     )
     ap.add_argument(
         "--since-hours",
@@ -368,6 +405,10 @@ def main(argv: list[str] | None = None) -> int:
     args = ap.parse_args(argv)
 
     if args.all:
+        if args.rlm is not None:
+            # --rlm summarizes a single session; it has no effect in coordinator
+            # view. Say so rather than silently ignoring it.
+            print("note: --rlm is ignored with --all (coordinator view)", file=sys.stderr)
         lines = coordinator_view(root=Path(args.sessions_root), since_hours=args.since_hours)
         if args.json:
             print(json.dumps(lines, indent=2))

--- a/scripts/agent_session_digest.py
+++ b/scripts/agent_session_digest.py
@@ -22,6 +22,7 @@ import json
 import re
 import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import Any
 
@@ -47,6 +48,36 @@ def find_rollout(*, path: str | None, session: str | None, latest: bool, root: P
             if session in c.name:
                 return c
     return None
+
+
+def coordinator_view(
+    *, root: Path, since_hours: float, now: float | None = None
+) -> list[dict[str, Any]]:
+    """Compact per-session digests for every rollout modified within the window.
+
+    The single cross-agent view: run before editing shared files to see what
+    sibling agents are touching (which PRs/files) and avoid collisions.
+    """
+    cutoff = (now if now is not None else time.time()) - since_hours * 3600.0
+    rows: list[dict[str, Any]] = []
+    for r in sorted(root.rglob("rollout-*.jsonl"), key=lambda p: p.stat().st_mtime, reverse=True):
+        try:
+            if r.stat().st_mtime < cutoff:
+                continue
+        except OSError:
+            continue
+        turns = extract_turns(r)
+        sid = r.name.split("-")[-1].replace(".jsonl", "")
+        rows.append(
+            {
+                "session_id": sid,
+                "rollout": str(r),
+                "counts": turns["counts"],
+                "prs_referenced": turns["prs_referenced"],
+                "last_decision": (turns["decisions"][-1] if turns["decisions"] else ""),
+            }
+        )
+    return rows
 
 
 def extract_turns(rollout: Path) -> dict[str, Any]:
@@ -175,6 +206,17 @@ def main(argv: list[str] | None = None) -> int:
     g.add_argument("--latest", action="store_true", help="Most recent rollout")
     g.add_argument("--session", help="Match a session-id substring")
     g.add_argument("--path", help="Explicit rollout .jsonl path")
+    g.add_argument(
+        "--all",
+        action="store_true",
+        help="Coordinator view: one-line digest of every rollout in the window",
+    )
+    ap.add_argument(
+        "--since-hours",
+        type=float,
+        default=24.0,
+        help="With --all: only rollouts modified within this many hours (default 24)",
+    )
     ap.add_argument(
         "--rlm",
         nargs="?",
@@ -185,6 +227,22 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--sessions-root", default=str(DEFAULT_SESSIONS_ROOT))
     ap.add_argument("--json", action="store_true", help="Emit JSON instead of text")
     args = ap.parse_args(argv)
+
+    if args.all:
+        lines = coordinator_view(root=Path(args.sessions_root), since_hours=args.since_hours)
+        if args.json:
+            print(json.dumps(lines, indent=2))
+        else:
+            if not lines:
+                print("no rollouts in window")
+            for row in lines:
+                c = row["counts"]
+                prs = ", ".join("#" + p for p in row["prs_referenced"]) or "none"
+                print(
+                    f"{row['session_id']}  {c['commands']}cmds {c['decisions']}dec  "
+                    f"PRs:{prs}  | {row['last_decision'][:90]}"
+                )
+        return 0
 
     rollout = find_rollout(
         path=args.path,

--- a/scripts/agent_session_digest.py
+++ b/scripts/agent_session_digest.py
@@ -33,7 +33,6 @@ def default_sessions_root() -> Path:
     return default_codex_home() / "sessions"
 
 
-DEFAULT_SESSIONS_ROOT = default_sessions_root()
 MAX_ROLLOUT_SCAN = 200
 _PR_RE = re.compile(r"#(\d{3,6})\b")
 _CMD_RE = re.compile(r'"cmd"\s*:\s*"([^"]{0,160})')
@@ -50,7 +49,20 @@ def _rollout_session_id(path: Path, meta_id: str | None = None) -> str:
     return path.stem
 
 
-def _iter_rollouts(root: Path, *, since_hours: float | None = None, now: float | None = None):
+def _iter_rollouts(
+    root: Path,
+    *,
+    since_hours: float | None = None,
+    now: float | None = None,
+    limit: int | None = MAX_ROLLOUT_SCAN,
+):
+    """Yield rollout files newest-first.
+
+    ``limit`` caps the scan to the N most-recent rollouts (the default keeps the
+    coordinator view bounded). Pass ``limit=None`` for an exhaustive scan — an
+    exact ``--session <id>`` lookup must not silently miss an older session just
+    because more than ``MAX_ROLLOUT_SCAN`` rollouts exist.
+    """
     cutoff = (
         None
         if since_hours is None
@@ -68,7 +80,8 @@ def _iter_rollouts(root: Path, *, since_hours: float | None = None, now: float |
                 continue
             candidates.append((mtime, rollout))
     candidates.sort(key=lambda item: item[0], reverse=True)
-    for _, rollout in candidates[:MAX_ROLLOUT_SCAN]:
+    selected = candidates if limit is None else candidates[:limit]
+    for _, rollout in selected:
         yield rollout
 
 
@@ -77,13 +90,12 @@ def find_rollout(*, path: str | None, session: str | None, latest: bool, root: P
     if path:
         p = Path(path)
         return p if p.is_file() else None
-    candidates = list(_iter_rollouts(root))
-    if not candidates:
-        return None
     if latest:
-        return candidates[0]
+        return next(iter(_iter_rollouts(root)), None)
     if session:
-        for c in candidates:
+        # Explicit session lookup is an exact request, not a recency scan — scan
+        # uncapped so an older session (beyond MAX_ROLLOUT_SCAN) is still found.
+        for c in _iter_rollouts(root, limit=None):
             if session in c.name:
                 return c
     return None
@@ -124,6 +136,18 @@ def extract_turns(rollout: Path) -> dict[str, Any]:
     commands: list[str] = []
     prs: set[str] = set()
     session_id: str | None = None
+    # Real rollouts carry the same human-visible turn as BOTH an ``event_msg``
+    # (agent_message/user_message) and a ``response_item`` (role assistant/user);
+    # dedupe by text so a turn present in both representations is counted once.
+    seen_prompts: set[str] = set()
+    seen_decisions: set[str] = set()
+
+    def _add(bucket: list[str], seen: set[str], text: str) -> None:
+        if text in seen:
+            return
+        seen.add(text)
+        bucket.append(text)
+
     try:
         handle = rollout.open("r", encoding="utf-8", errors="replace")
     except OSError:
@@ -149,16 +173,24 @@ def extract_turns(rollout: Path) -> dict[str, Any]:
                 continue
             payload = rec.get("payload") if isinstance(rec.get("payload"), dict) else {}
             if rec.get("type") == "session_meta":
-                sid = payload.get("id")
+                # Canonical rollouts nest the id under ``payload`` (codex_source.py);
+                # tolerate a top-level ``id`` too so either shape resolves.
+                sid = payload.get("id") or rec.get("id")
                 if isinstance(sid, str) and sid:
                     session_id = sid
                 continue
             if rec.get("type") == "event_msg":
-                if payload.get("type") == "agent_message":
-                    message = payload.get("message")
-                    if isinstance(message, str) and message.strip():
-                        text = message.strip()
-                        decisions.append(text[:300])
+                etype = payload.get("type")
+                message = payload.get("message")
+                if isinstance(message, str) and message.strip():
+                    text = message.strip()[:300]
+                    if etype == "agent_message":
+                        _add(decisions, seen_decisions, text)
+                        prs.update(_PR_RE.findall(text))
+                    elif etype == "user_message":
+                        # Codex stores human prompts as event_msg/user_message;
+                        # without this the tool's advertised prompt summary is empty.
+                        _add(prompts, seen_prompts, text)
                         prs.update(_PR_RE.findall(text))
                 continue
             if rec.get("type") != "response_item":
@@ -194,7 +226,10 @@ def extract_turns(rollout: Path) -> dict[str, Any]:
                 if not text:
                     continue
                 prs.update(_PR_RE.findall(text))
-                (prompts if item.get("role") == "user" else decisions).append(text[:300])
+                if item.get("role") == "user":
+                    _add(prompts, seen_prompts, text[:300])
+                else:
+                    _add(decisions, seen_decisions, text[:300])
     session_id = _rollout_session_id(rollout, session_id)
     return {
         "rollout": str(rollout),
@@ -280,6 +315,10 @@ def rlm_summary(turns: dict[str, Any], question: str) -> str | None:
                 text=True,
                 timeout=180,
             )
+            if q.returncode != 0:
+                # A failed query (e.g. missing context) must not be surfaced as
+                # a "summary"; the compress step already guards its returncode.
+                return None
             return q.stdout.strip() or None
     except (subprocess.SubprocessError, OSError):
         return None

--- a/tests/scripts/test_agent_session_digest.py
+++ b/tests/scripts/test_agent_session_digest.py
@@ -181,6 +181,41 @@ def test_rlm_summary_cleans_temporary_files(tmp_path: Path, monkeypatch) -> None
     assert all(not path.exists() for path in created)
 
 
+def test_extract_rlm_answer_strips_cli_chrome() -> None:
+    stdout = "\n".join(
+        [
+            "Loaded context with 3 nodes",
+            "",
+            "Query: what happened",
+            "Strategy: auto",
+            "",
+            "-" * 60,
+            "",
+            "=" * 60,
+            "ANSWER",
+            "=" * 60,
+            "The agent fixed PR #8730 and ran the tests.",
+            "",
+            "-" * 60,
+            "Ready: True",
+            "Confidence: 91.0%",
+            "Tokens processed: 1,234",
+        ]
+    )
+    assert digest._extract_rlm_answer(stdout) == "The agent fixed PR #8730 and ran the tests."
+
+
+def test_extract_rlm_answer_falls_back_without_marker() -> None:
+    assert digest._extract_rlm_answer("plain text, no banner") == "plain text, no banner"
+    assert digest._extract_rlm_answer("   ") is None
+
+
+def test_pr_ids_ignore_unicode_digits() -> None:
+    # "²" passes str.isdigit() but crashes int(); must be rejected, not collected.
+    assert digest._pr_ids_from_call_args({"pr": "²"}) == set()
+    assert digest._pr_ids_from_call_args({"pr": "8730"}) == {"8730"}
+
+
 def test_main_all_mode(tmp_path: Path, capsys) -> None:
     sess = tmp_path / "rollout-2026-06-30T12-00-00-019f197d.jsonl"
     _write_rollout(tmp_path).rename(sess)

--- a/tests/scripts/test_agent_session_digest.py
+++ b/tests/scripts/test_agent_session_digest.py
@@ -19,7 +19,7 @@ _SPEC.loader.exec_module(digest)
 
 def _write_rollout(tmp_path: Path) -> Path:
     rows = [
-        {"type": "session_meta", "id": "test"},
+        {"type": "session_meta"},
         {
             "type": "response_item",
             "payload": {"role": "user", "content": "Repair PR #8718 dissent"},
@@ -188,6 +188,58 @@ def test_main_all_mode(tmp_path: Path, capsys) -> None:
     assert rc == 0
     out = json.loads(capsys.readouterr().out)
     assert any(r["session_id"] == "019f197d" for r in out)
+
+
+def test_extract_turns_reads_user_message_events(tmp_path: Path) -> None:
+    """Codex stores human prompts as event_msg/user_message — must be captured."""
+    rollout = tmp_path / "rollout-2026-06-30T12-00-00-usermsg.jsonl"
+    rows = [
+        {"type": "event_msg", "payload": {"type": "user_message", "message": "fix PR #8730"}},
+        {"type": "event_msg", "payload": {"type": "agent_message", "message": "on it"}},
+    ]
+    rollout.write_text("\n".join(json.dumps(r) for r in rows), encoding="utf-8")
+    turns = digest.extract_turns(rollout)
+    assert turns["counts"]["prompts"] == 1
+    assert "fix PR #8730" in turns["prompts"]
+    assert "8730" in turns["prs_referenced"]
+
+
+def test_extract_turns_dedupes_message_in_both_representations(tmp_path: Path) -> None:
+    """A turn present as BOTH event_msg and response_item is counted once."""
+    rollout = tmp_path / "rollout-2026-06-30T12-00-00-dedupe.jsonl"
+    rows = [
+        {"type": "event_msg", "payload": {"type": "agent_message", "message": "same decision"}},
+        {
+            "type": "response_item",
+            "payload": {"role": "assistant", "content": [{"text": "same decision"}]},
+        },
+    ]
+    rollout.write_text("\n".join(json.dumps(r) for r in rows), encoding="utf-8")
+    turns = digest.extract_turns(rollout)
+    assert turns["counts"]["decisions"] == 1
+
+
+def test_extract_turns_reads_session_id_from_payload(tmp_path: Path) -> None:
+    """Canonical rollouts nest the id under payload — the meta-id path must work."""
+    rollout = tmp_path / "rollout-2026-06-30T12-00-00-metaid.jsonl"
+    rows = [{"type": "session_meta", "payload": {"id": "canonical-sid"}}]
+    rollout.write_text("\n".join(json.dumps(r) for r in rows), encoding="utf-8")
+    turns = digest.extract_turns(rollout)
+    assert turns["session_id"] == "canonical-sid"
+
+
+def test_iter_rollouts_limit_is_respected(tmp_path: Path) -> None:
+    """The scan cap is injectable; limit=None is exhaustive (session lookups need it)."""
+    import os
+
+    for i in range(3):
+        f = tmp_path / f"rollout-2026-06-30T12-00-0{i}-sess{i}.jsonl"
+        f.write_text("", encoding="utf-8")
+        os.utime(f, (1000 + i, 1000 + i))
+    assert len(list(digest._iter_rollouts(tmp_path, limit=2))) == 2
+    assert len(list(digest._iter_rollouts(tmp_path, limit=None))) == 3
+    # An older session (not among the newest) is still resolvable by --session.
+    assert digest.find_rollout(path=None, session="sess0", latest=False, root=tmp_path) is not None
 
 
 def test_main_json_output(tmp_path: Path, capsys) -> None:

--- a/tests/scripts/test_agent_session_digest.py
+++ b/tests/scripts/test_agent_session_digest.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 
 _SPEC = importlib.util.spec_from_file_location(
     "agent_session_digest",
@@ -47,10 +49,78 @@ def _write_rollout(tmp_path: Path) -> Path:
 def test_extract_turns_pulls_prompts_decisions_commands_and_prs(tmp_path: Path) -> None:
     turns = digest.extract_turns(_write_rollout(tmp_path))
     assert turns["counts"]["prompts"] == 1
-    assert turns["counts"]["decisions"] == 1
+    assert turns["counts"]["decisions"] == 2
     assert turns["counts"]["commands"] == 1
     assert "8718" in turns["prs_referenced"]
     assert "pytest" in turns["commands"][0]
+    assert "done" in turns["decisions"]
+
+
+def test_extract_turns_streams_rollout_without_read_text(tmp_path: Path, monkeypatch) -> None:
+    rollout = _write_rollout(tmp_path)
+
+    def fail_read_text(self, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        raise AssertionError(f"read_text should not be used for {self}")
+
+    monkeypatch.setattr(Path, "read_text", fail_read_text)
+
+    turns = digest.extract_turns(rollout)
+
+    assert turns["counts"]["commands"] == 1
+    assert "8718" in turns["prs_referenced"]
+
+
+def test_extract_turns_parses_structured_function_call_arguments(tmp_path: Path) -> None:
+    rollout = tmp_path / "rollout-2026-06-30T12-00-00-019f197d.jsonl"
+    rows = [
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "exec_command",
+                "arguments": {
+                    "cmd": "python3 -m pytest tests/scripts/test_agent_session_digest.py",
+                    "pr": "8730",
+                },
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "exec_command",
+                "arguments": json.dumps(
+                    {
+                        "cmd": "gh pr view 8731 --json number",
+                        "pr_number": 8731,
+                    }
+                ),
+            },
+        },
+    ]
+    rollout.write_text("\n".join(json.dumps(r) for r in rows), encoding="utf-8")
+
+    turns = digest.extract_turns(rollout)
+
+    assert turns["counts"]["commands"] == 2
+    assert "pytest" in turns["commands"][0]
+    assert "8730" in turns["prs_referenced"]
+    assert "8731" in turns["prs_referenced"]
+
+
+def test_rollout_session_id_preserves_full_uuid(tmp_path: Path) -> None:
+    rollout = tmp_path / ("rollout-2026-06-15T15-40-37-019ecd03-c60c-7bc1-8b9c-6477893310f6.jsonl")
+    rollout.write_text("", encoding="utf-8")
+
+    turns = digest.extract_turns(rollout)
+
+    assert turns["session_id"] == "019ecd03-c60c-7bc1-8b9c-6477893310f6"
+
+
+def test_default_sessions_root_honors_aragora_codex_home(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("ARAGORA_CODEX_HOME", str(tmp_path))
+
+    assert digest.default_sessions_root() == tmp_path / "sessions"
 
 
 def test_find_rollout_latest_and_session_and_missing(tmp_path: Path) -> None:
@@ -74,6 +144,41 @@ def test_coordinator_view_windows_by_mtime(tmp_path: Path) -> None:
     assert "8718" in rows[0]["prs_referenced"]
     future = os.path.getmtime(sess) + 10 * 3600
     assert digest.coordinator_view(root=tmp_path, since_hours=1.0, now=future) == []
+
+
+def test_rlm_summary_cleans_temporary_files(tmp_path: Path, monkeypatch) -> None:
+    created: list[Path] = []
+
+    class FakeTemporaryDirectory:
+        def __init__(self, prefix: str) -> None:
+            self.path = tmp_path / prefix.rstrip("-")
+
+        def __enter__(self) -> str:
+            self.path.mkdir()
+            created.append(self.path)
+            return str(self.path)
+
+        def __exit__(self, exc_type, exc, tb) -> None:  # noqa: ANN001
+            for child in self.path.iterdir():
+                child.unlink()
+            self.path.rmdir()
+
+    def fake_run(cmd, **kwargs):  # noqa: ANN001, ANN003
+        if "compress" in cmd:
+            Path(cmd[cmd.index("-o") + 1]).write_text("{}", encoding="utf-8")
+            return SimpleNamespace(returncode=0, stdout="")
+        if "query" in cmd:
+            return SimpleNamespace(returncode=0, stdout="summary")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(tempfile, "TemporaryDirectory", FakeTemporaryDirectory)
+    monkeypatch.setattr(digest.subprocess, "run", fake_run)
+
+    summary = digest.rlm_summary({"decisions": ["done"], "commands": ["pytest"]}, "what")
+
+    assert summary == "summary"
+    assert created
+    assert all(not path.exists() for path in created)
 
 
 def test_main_all_mode(tmp_path: Path, capsys) -> None:

--- a/tests/scripts/test_agent_session_digest.py
+++ b/tests/scripts/test_agent_session_digest.py
@@ -1,0 +1,73 @@
+"""Tests for scripts/agent_session_digest.py (cross-agent session digest)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "agent_session_digest",
+    Path(__file__).resolve().parents[2] / "scripts" / "agent_session_digest.py",
+)
+assert _SPEC and _SPEC.loader
+digest = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(digest)
+
+
+def _write_rollout(tmp_path: Path) -> Path:
+    rows = [
+        {"type": "session_meta", "id": "test"},
+        {
+            "type": "response_item",
+            "payload": {"role": "user", "content": "Repair PR #8718 dissent"},
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "role": "assistant",
+                "content": [{"text": "I'm editing the #8718 branch conservatively."}],
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "exec_command",
+                "arguments": '{"cmd":"python3 -m pytest tests/swarm/test_queue_disposition.py","pr":"8718"}',
+            },
+        },
+        {"type": "event_msg", "payload": {"type": "agent_message", "message": "done"}},
+    ]
+    p = tmp_path / "rollout-test.jsonl"
+    p.write_text("\n".join(json.dumps(r) for r in rows))
+    return p
+
+
+def test_extract_turns_pulls_prompts_decisions_commands_and_prs(tmp_path: Path) -> None:
+    turns = digest.extract_turns(_write_rollout(tmp_path))
+    assert turns["counts"]["prompts"] == 1
+    assert turns["counts"]["decisions"] == 1
+    assert turns["counts"]["commands"] == 1
+    assert "8718" in turns["prs_referenced"]
+    assert "pytest" in turns["commands"][0]
+
+
+def test_find_rollout_latest_and_session_and_missing(tmp_path: Path) -> None:
+    p = _write_rollout(tmp_path)
+    # rename to a session-id-bearing name
+    sess = tmp_path / "rollout-2026-06-30T12-00-00-019f197d.jsonl"
+    p.rename(sess)
+    assert digest.find_rollout(path=None, session="019f197d", latest=False, root=tmp_path) == sess
+    assert digest.find_rollout(path=None, session=None, latest=True, root=tmp_path) == sess
+    assert digest.find_rollout(path=None, session="nope", latest=False, root=tmp_path) is None
+
+
+def test_main_json_output(tmp_path: Path, capsys) -> None:
+    sess = tmp_path / "rollout-2026-06-30T12-00-00-019f197d.jsonl"
+    _write_rollout(tmp_path).rename(sess)
+    rc = digest.main(["--session", "019f197d", "--sessions-root", str(tmp_path), "--json"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["counts"]["commands"] == 1
+    assert out["rlm_summary"] is None  # --rlm not passed

--- a/tests/scripts/test_agent_session_digest.py
+++ b/tests/scripts/test_agent_session_digest.py
@@ -63,6 +63,28 @@ def test_find_rollout_latest_and_session_and_missing(tmp_path: Path) -> None:
     assert digest.find_rollout(path=None, session="nope", latest=False, root=tmp_path) is None
 
 
+def test_coordinator_view_windows_by_mtime(tmp_path: Path) -> None:
+    import os
+
+    sess = tmp_path / "rollout-2026-06-30T12-00-00-019f197d.jsonl"
+    _write_rollout(tmp_path).rename(sess)
+    rows = digest.coordinator_view(root=tmp_path, since_hours=24.0)
+    assert len(rows) == 1
+    assert rows[0]["session_id"] == "019f197d"
+    assert "8718" in rows[0]["prs_referenced"]
+    future = os.path.getmtime(sess) + 10 * 3600
+    assert digest.coordinator_view(root=tmp_path, since_hours=1.0, now=future) == []
+
+
+def test_main_all_mode(tmp_path: Path, capsys) -> None:
+    sess = tmp_path / "rollout-2026-06-30T12-00-00-019f197d.jsonl"
+    _write_rollout(tmp_path).rename(sess)
+    rc = digest.main(["--all", "--sessions-root", str(tmp_path), "--json"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert any(r["session_id"] == "019f197d" for r in out)
+
+
 def test_main_json_output(tmp_path: Path, capsys) -> None:
     sess = tmp_path / "rollout-2026-06-30T12-00-00-019f197d.jsonl"
     _write_rollout(tmp_path).rename(sess)


### PR DESCRIPTION
Makes cross-agent visibility one command. Codex writes full per-session transcripts to `~/.codex/sessions/**/rollout-*.jsonl` (MBs each); reading one wholesale blows a reviewer's context. `scripts/agent_session_digest.py` extracts the reviewable signal (prompts, decisions, exec commands, referenced PRs) deterministically, and with `--rlm` runs it through Aragora's **own RLM** (`aragora rlm compress`+`query`) for a recursive summary.

Read-only; deterministic path needs no creds. `--latest` / `--session <id>` / `--path` / `--json`. 3 focused tests; live-smoked on a real rollout. Foundation for a single-coordinator cross-agent view to stop two agents editing the same core files.