### PR TITLE
[codex] fix(stage-gate): pin conductor log target

### DIFF
--- a/aragora/ops/__init__.py
+++ b/aragora/ops/__init__.py
@@ -20,16 +20,32 @@ from aragora.ops.key_rotation import (
     KeyRotationScheduler,
     get_key_rotation_scheduler,
 )
+from aragora.ops.stage_gate_conductor_log import (
+    CANONICAL_STAGE_GATE_LOG_ISSUE,
+    CANONICAL_STAGE_GATE_LOG_LABEL,
+    STAGE_GATE_CONDUCTOR_LOG_TITLE,
+    StageGateLogResolutionError,
+    build_gh_issue_comment_args,
+    build_gh_issue_list_args,
+    resolve_stage_gate_conductor_log_issue,
+)
 
 __all__ = [
     "ComponentStatus",
     "DeploymentValidator",
     "KeyRotationConfig",
     "KeyRotationScheduler",
+    "CANONICAL_STAGE_GATE_LOG_ISSUE",
+    "CANONICAL_STAGE_GATE_LOG_LABEL",
+    "STAGE_GATE_CONDUCTOR_LOG_TITLE",
+    "StageGateLogResolutionError",
     "ValidationResult",
+    "build_gh_issue_comment_args",
+    "build_gh_issue_list_args",
     "get_enterprise_health_summary",
     "get_key_rotation_scheduler",
     "quick_health_check",
+    "resolve_stage_gate_conductor_log_issue",
     "validate_deployment",
     "validate_enterprise_deployment",
 ]

--- a/aragora/ops/stage_gate_conductor_log.py
+++ b/aragora/ops/stage_gate_conductor_log.py
@@ -14,6 +14,7 @@ STAGE_GATE_CONDUCTOR_LOG_TITLE = "[automation] Stage-Gate Conductor Log"
 CANONICAL_STAGE_GATE_LOG_ISSUE = 8671
 CANONICAL_STAGE_GATE_LOG_LABEL = "stage-gate-log-canonical"
 AUTOMATION_LOG_LABEL = "automation-log"
+STAGE_GATE_ISSUE_LIST_LIMIT = 1000
 
 
 class StageGateLogResolutionError(RuntimeError):
@@ -45,16 +46,20 @@ def _issue_number(issue: Mapping[str, Any]) -> int | None:
 
 def _is_open(issue: Mapping[str, Any]) -> bool:
     state = issue.get("state")
-    return not isinstance(state, str) or state.upper() == "OPEN"
+    return isinstance(state, str) and state.upper() == "OPEN"
 
 
-def _is_stage_gate_log_issue(issue: Mapping[str, Any]) -> bool:
-    return (
-        _is_open(issue)
-        and issue.get("title") == STAGE_GATE_CONDUCTOR_LOG_TITLE
-        and AUTOMATION_LOG_LABEL in _label_names(issue)
-        and _issue_number(issue) is not None
-    )
+def _has_stage_gate_log_title(issue: Mapping[str, Any]) -> bool:
+    return _is_open(issue) and issue.get("title") == STAGE_GATE_CONDUCTOR_LOG_TITLE
+
+
+def _require_issue_number(issue: Mapping[str, Any]) -> int:
+    number = _issue_number(issue)
+    if number is None:
+        raise StageGateLogResolutionError(
+            "matching Stage-Gate Conductor Log issue is missing a numeric issue number"
+        )
+    return number
 
 
 def resolve_stage_gate_conductor_log_issue(
@@ -66,23 +71,25 @@ def resolve_stage_gate_conductor_log_issue(
     """Return the single issue number the conductor must comment on.
 
     Resolution order is intentionally fail-closed:
-    1. exactly one open log issue with ``stage-gate-log-canonical`` wins;
-    2. if duplicate logs exist and no canonical label is present, the pinned
-       issue ``#8671`` wins when present;
-    3. if there is exactly one open log issue, use it;
+    1. exactly one open exact-title log issue with
+       ``stage-gate-log-canonical`` wins;
+    2. if no unique canonical label is present, the open exact-title pinned
+       issue ``#8671`` wins even if duplicate label metadata has drifted;
+    3. if there is exactly one open exact-title log issue and it still carries
+       ``automation-log``, use it;
     4. otherwise raise instead of creating or choosing another duplicate.
     """
 
-    candidates = [dict(issue) for issue in issues if _is_stage_gate_log_issue(issue)]
-    if not candidates:
+    log_issues = [dict(issue) for issue in issues if _has_stage_gate_log_title(issue)]
+    if not log_issues:
         raise StageGateLogResolutionError(
             "no open Stage-Gate Conductor Log issue found; do not create a duplicate"
         )
 
     canonical_label = canonical_label.lower()
-    labeled = [issue for issue in candidates if canonical_label in _label_names(issue)]
+    labeled = [issue for issue in log_issues if canonical_label in _label_names(issue)]
     if len(labeled) == 1:
-        return int(_issue_number(labeled[0]) or 0)
+        return _require_issue_number(labeled[0])
     if len(labeled) > 1:
         pinned_labeled = [issue for issue in labeled if _issue_number(issue) == pinned_issue]
         if len(pinned_labeled) == 1:
@@ -95,13 +102,17 @@ def resolve_stage_gate_conductor_log_issue(
             f"{CANONICAL_STAGE_GATE_LOG_LABEL}: {numbers}"
         )
 
-    if any(_issue_number(issue) == pinned_issue for issue in candidates):
+    pinned_matches = [issue for issue in log_issues if _issue_number(issue) == pinned_issue]
+    if len(pinned_matches) == 1:
         return pinned_issue
 
-    if len(candidates) == 1:
-        return int(_issue_number(candidates[0]) or 0)
+    strict_candidates = [
+        issue for issue in log_issues if AUTOMATION_LOG_LABEL in _label_names(issue)
+    ]
+    if len(log_issues) == 1 and len(strict_candidates) == 1:
+        return _require_issue_number(strict_candidates[0])
 
-    numbers = sorted(number for issue in candidates if (number := _issue_number(issue)) is not None)
+    numbers = sorted(number for issue in log_issues if (number := _issue_number(issue)) is not None)
     raise StageGateLogResolutionError(
         "multiple Stage-Gate Conductor Log issues found without a canonical target: "
         f"{numbers}; label one {CANONICAL_STAGE_GATE_LOG_LABEL} or include #{pinned_issue}"
@@ -123,7 +134,11 @@ def build_gh_issue_comment_args(
     return args
 
 
-def build_gh_issue_list_args(*, repo: str = "synaptent/aragora", limit: int = 50) -> list[str]:
+def build_gh_issue_list_args(
+    *,
+    repo: str = "synaptent/aragora",
+    limit: int = STAGE_GATE_ISSUE_LIST_LIMIT,
+) -> list[str]:
     """Build the bounded ``gh issue list`` query used before resolution."""
 
     return [
@@ -147,6 +162,7 @@ __all__ = [
     "CANONICAL_STAGE_GATE_LOG_ISSUE",
     "CANONICAL_STAGE_GATE_LOG_LABEL",
     "STAGE_GATE_CONDUCTOR_LOG_TITLE",
+    "STAGE_GATE_ISSUE_LIST_LIMIT",
     "StageGateLogResolutionError",
     "build_gh_issue_comment_args",
     "build_gh_issue_list_args",

--- a/aragora/ops/stage_gate_conductor_log.py
+++ b/aragora/ops/stage_gate_conductor_log.py
@@ -1,0 +1,154 @@
+"""Canonical Stage-Gate Conductor log issue selection.
+
+The Stage-Gate Conductor has had multiple open issues with the exact same log
+title. Automation must not pick among them by comment count, age, or GitHub
+search ordering; those heuristics caused the log target to drift.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+STAGE_GATE_CONDUCTOR_LOG_TITLE = "[automation] Stage-Gate Conductor Log"
+CANONICAL_STAGE_GATE_LOG_ISSUE = 8671
+CANONICAL_STAGE_GATE_LOG_LABEL = "stage-gate-log-canonical"
+AUTOMATION_LOG_LABEL = "automation-log"
+
+
+class StageGateLogResolutionError(RuntimeError):
+    """Raised when the conductor log target cannot be resolved safely."""
+
+
+def _label_names(issue: Mapping[str, Any]) -> set[str]:
+    labels = issue.get("labels") or ()
+    names: set[str] = set()
+    for label in labels:
+        if isinstance(label, str):
+            names.add(label.lower())
+        elif isinstance(label, Mapping):
+            name = label.get("name")
+            if isinstance(name, str):
+                names.add(name.lower())
+    return names
+
+
+def _issue_number(issue: Mapping[str, Any]) -> int | None:
+    value = issue.get("number")
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _is_open(issue: Mapping[str, Any]) -> bool:
+    state = issue.get("state")
+    return not isinstance(state, str) or state.upper() == "OPEN"
+
+
+def _is_stage_gate_log_issue(issue: Mapping[str, Any]) -> bool:
+    return (
+        _is_open(issue)
+        and issue.get("title") == STAGE_GATE_CONDUCTOR_LOG_TITLE
+        and AUTOMATION_LOG_LABEL in _label_names(issue)
+        and _issue_number(issue) is not None
+    )
+
+
+def resolve_stage_gate_conductor_log_issue(
+    issues: Iterable[Mapping[str, Any]],
+    *,
+    pinned_issue: int = CANONICAL_STAGE_GATE_LOG_ISSUE,
+    canonical_label: str = CANONICAL_STAGE_GATE_LOG_LABEL,
+) -> int:
+    """Return the single issue number the conductor must comment on.
+
+    Resolution order is intentionally fail-closed:
+    1. exactly one open log issue with ``stage-gate-log-canonical`` wins;
+    2. if duplicate logs exist and no canonical label is present, the pinned
+       issue ``#8671`` wins when present;
+    3. if there is exactly one open log issue, use it;
+    4. otherwise raise instead of creating or choosing another duplicate.
+    """
+
+    candidates = [dict(issue) for issue in issues if _is_stage_gate_log_issue(issue)]
+    if not candidates:
+        raise StageGateLogResolutionError(
+            "no open Stage-Gate Conductor Log issue found; do not create a duplicate"
+        )
+
+    canonical_label = canonical_label.lower()
+    labeled = [issue for issue in candidates if canonical_label in _label_names(issue)]
+    if len(labeled) == 1:
+        return int(_issue_number(labeled[0]) or 0)
+    if len(labeled) > 1:
+        pinned_labeled = [issue for issue in labeled if _issue_number(issue) == pinned_issue]
+        if len(pinned_labeled) == 1:
+            return pinned_issue
+        numbers = sorted(
+            number for issue in labeled if (number := _issue_number(issue)) is not None
+        )
+        raise StageGateLogResolutionError(
+            "multiple Stage-Gate Conductor Log issues carry "
+            f"{CANONICAL_STAGE_GATE_LOG_LABEL}: {numbers}"
+        )
+
+    if any(_issue_number(issue) == pinned_issue for issue in candidates):
+        return pinned_issue
+
+    if len(candidates) == 1:
+        return int(_issue_number(candidates[0]) or 0)
+
+    numbers = sorted(number for issue in candidates if (number := _issue_number(issue)) is not None)
+    raise StageGateLogResolutionError(
+        "multiple Stage-Gate Conductor Log issues found without a canonical target: "
+        f"{numbers}; label one {CANONICAL_STAGE_GATE_LOG_LABEL} or include #{pinned_issue}"
+    )
+
+
+def build_gh_issue_comment_args(
+    issues: Iterable[Mapping[str, Any]],
+    *,
+    body: str,
+    repo: str | None = None,
+) -> list[str]:
+    """Build ``gh issue comment`` args for the resolved canonical log issue."""
+
+    issue_number = resolve_stage_gate_conductor_log_issue(issues)
+    args = ["issue", "comment", str(issue_number), "--body", body]
+    if repo:
+        args.extend(["--repo", repo])
+    return args
+
+
+def build_gh_issue_list_args(*, repo: str = "synaptent/aragora", limit: int = 50) -> list[str]:
+    """Build the bounded ``gh issue list`` query used before resolution."""
+
+    return [
+        "issue",
+        "list",
+        "--repo",
+        repo,
+        "--state",
+        "open",
+        "--search",
+        f'"{STAGE_GATE_CONDUCTOR_LOG_TITLE}" in:title repo:{repo}',
+        "--limit",
+        str(limit),
+        "--json",
+        "number,title,labels,state,url,createdAt,updatedAt",
+    ]
+
+
+__all__ = [
+    "AUTOMATION_LOG_LABEL",
+    "CANONICAL_STAGE_GATE_LOG_ISSUE",
+    "CANONICAL_STAGE_GATE_LOG_LABEL",
+    "STAGE_GATE_CONDUCTOR_LOG_TITLE",
+    "StageGateLogResolutionError",
+    "build_gh_issue_comment_args",
+    "build_gh_issue_list_args",
+    "resolve_stage_gate_conductor_log_issue",
+]

--- a/docs/plans/2026-05-16-a2-admission-class-productization.md
+++ b/docs/plans/2026-05-16-a2-admission-class-productization.md
@@ -180,7 +180,7 @@ Steps 2, 5 are observational; they do not block the next PR's merge.
 - Corpus manifest: `docs/benchmarks/corpus.json` (rev-4, 13 in-progress)
 - Operating Law source: `docs/CANONICAL_GOALS.md`
 - Gate doctrine: `docs/status/NEXT_STEPS_CANONICAL.md`
-- Stage-Gate Conductor log: [#7162](https://github.com/synaptent/aragora/issues/7162)
+- Stage-Gate Conductor log: [#8671](https://github.com/synaptent/aragora/issues/8671)
 - Settlement-receipt hygiene precedent: `.aragora/review-queue/receipts/pr-7210-recorded-7210-c44acbeb4888-admin_squash_merge-admin_squash_merge.json`
 - Closure-receipt precedent: `.aragora/audits/closure-receipts/2026-05-14-stale-tasking-closure.json`
 - Related (non-overlapping) stage-gate-drift issues: [#6598](https://github.com/synaptent/aragora/issues/6598), [#6706](https://github.com/synaptent/aragora/issues/6706), [#6097](https://github.com/synaptent/aragora/issues/6097), [#6246](https://github.com/synaptent/aragora/issues/6246)

--- a/docs/prompts/STAGE_GATE_CONDUCTOR_LOG_PROMPT.md
+++ b/docs/prompts/STAGE_GATE_CONDUCTOR_LOG_PROMPT.md
@@ -1,0 +1,35 @@
+# Stage-Gate Conductor Log Target Contract
+
+Use this contract in any Stage-Gate Conductor prompt or automation that writes
+the recurring audit log.
+
+## Canonical Target
+
+- The canonical Stage-Gate Conductor Log is issue
+  [#8671](https://github.com/synaptent/aragora/issues/8671).
+- Prefer an open log issue labeled `stage-gate-log-canonical` when that label is
+  present on exactly one matching issue.
+- If multiple `[automation] Stage-Gate Conductor Log` issues exist and no
+  canonical label is present, fall back only to #8671.
+- If neither a unique canonical label nor #8671 is present, fail closed and
+  report the ambiguity. Do not create a new log issue.
+
+## Required Resolver
+
+Before posting a log comment, resolve the target with the repo helper:
+
+```python
+from aragora.ops.stage_gate_conductor_log import (
+    build_gh_issue_comment_args,
+    build_gh_issue_list_args,
+    resolve_stage_gate_conductor_log_issue,
+)
+```
+
+Fetch open candidates with `build_gh_issue_list_args()`, pass the returned issue
+objects to `resolve_stage_gate_conductor_log_issue()`, then comment on the
+resolved number. Never choose the log by age, comment count, oldest issue,
+newest issue, or raw GitHub search ordering.
+
+If the resolver raises `StageGateLogResolutionError`, include the candidate
+numbers in the operator brief and stop without opening another log issue.

--- a/docs/prompts/STAGE_GATE_CONDUCTOR_LOG_PROMPT.md
+++ b/docs/prompts/STAGE_GATE_CONDUCTOR_LOG_PROMPT.md
@@ -10,7 +10,9 @@ the recurring audit log.
 - Prefer an open log issue labeled `stage-gate-log-canonical` when that label is
   present on exactly one matching issue.
 - If multiple `[automation] Stage-Gate Conductor Log` issues exist and no
-  canonical label is present, fall back only to #8671.
+  canonical label is present, fall back only to #8671 when it is open and has
+  the exact Stage-Gate Conductor Log title. The pinned issue still wins if
+  duplicate label metadata such as `automation-log` has drifted.
 - If neither a unique canonical label nor #8671 is present, fail closed and
   report the ambiguity. Do not create a new log issue.
 
@@ -28,8 +30,10 @@ from aragora.ops.stage_gate_conductor_log import (
 
 Fetch open candidates with `build_gh_issue_list_args()`, pass the returned issue
 objects to `resolve_stage_gate_conductor_log_issue()`, then comment on the
-resolved number. Never choose the log by age, comment count, oldest issue,
-newest issue, or raw GitHub search ordering.
+resolved number. The helper uses a deliberately high result limit to avoid
+partial-result singleton drift, but the resolver is still the authority when
+duplicates are returned. Never choose the log by age, comment count, oldest
+issue, newest issue, or raw GitHub search ordering.
 
 If the resolver raises `StageGateLogResolutionError`, include the candidate
 numbers in the operator brief and stop without opening another log issue.

--- a/tests/ops/test_stage_gate_conductor_log.py
+++ b/tests/ops/test_stage_gate_conductor_log.py
@@ -1,0 +1,74 @@
+"""Regression tests for Stage-Gate Conductor log issue targeting."""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.ops.stage_gate_conductor_log import (
+    CANONICAL_STAGE_GATE_LOG_ISSUE,
+    CANONICAL_STAGE_GATE_LOG_LABEL,
+    STAGE_GATE_CONDUCTOR_LOG_TITLE,
+    StageGateLogResolutionError,
+    build_gh_issue_comment_args,
+    resolve_stage_gate_conductor_log_issue,
+)
+
+
+def _issue(
+    number: int,
+    *,
+    title: str = STAGE_GATE_CONDUCTOR_LOG_TITLE,
+    labels: tuple[str, ...] = ("automation-log",),
+    state: str = "OPEN",
+) -> dict[str, object]:
+    return {
+        "number": number,
+        "title": title,
+        "labels": [{"name": label} for label in labels],
+        "state": state,
+    }
+
+
+def test_pinned_canonical_log_issue_is_8671() -> None:
+    assert CANONICAL_STAGE_GATE_LOG_ISSUE == 8671
+
+
+def test_labeled_canonical_issue_wins_over_duplicate_history() -> None:
+    issues = [
+        _issue(7162),
+        _issue(8671, labels=("automation-log", CANONICAL_STAGE_GATE_LOG_LABEL)),
+        _issue(8402),
+    ]
+
+    assert resolve_stage_gate_conductor_log_issue(issues) == 8671
+
+
+def test_pinned_issue_wins_when_duplicates_have_no_canonical_label() -> None:
+    issues = [
+        _issue(6432),
+        _issue(6763),
+        _issue(7162),
+        _issue(8402),
+        _issue(8671),
+    ]
+
+    assert resolve_stage_gate_conductor_log_issue(issues) == 8671
+
+
+def test_ambiguous_duplicate_logs_fail_closed_when_no_canonical_exists() -> None:
+    issues = [
+        _issue(6432),
+        _issue(6763),
+        _issue(7162),
+        _issue(8402),
+    ]
+
+    with pytest.raises(StageGateLogResolutionError, match="multiple Stage-Gate Conductor Log"):
+        resolve_stage_gate_conductor_log_issue(issues)
+
+
+def test_comment_args_target_resolved_issue_number_not_title_search() -> None:
+    args = build_gh_issue_comment_args([_issue(7162), _issue(8671)], body="run body")
+
+    assert args == ["issue", "comment", "8671", "--body", "run body"]
+    assert STAGE_GATE_CONDUCTOR_LOG_TITLE not in args

--- a/tests/ops/test_stage_gate_conductor_log.py
+++ b/tests/ops/test_stage_gate_conductor_log.py
@@ -5,20 +5,23 @@ from __future__ import annotations
 import pytest
 
 from aragora.ops.stage_gate_conductor_log import (
+    AUTOMATION_LOG_LABEL,
     CANONICAL_STAGE_GATE_LOG_ISSUE,
     CANONICAL_STAGE_GATE_LOG_LABEL,
     STAGE_GATE_CONDUCTOR_LOG_TITLE,
+    STAGE_GATE_ISSUE_LIST_LIMIT,
     StageGateLogResolutionError,
     build_gh_issue_comment_args,
+    build_gh_issue_list_args,
     resolve_stage_gate_conductor_log_issue,
 )
 
 
 def _issue(
-    number: int,
+    number: object,
     *,
     title: str = STAGE_GATE_CONDUCTOR_LOG_TITLE,
-    labels: tuple[str, ...] = ("automation-log",),
+    labels: tuple[str, ...] = (AUTOMATION_LOG_LABEL,),
     state: str = "OPEN",
 ) -> dict[str, object]:
     return {
@@ -43,6 +46,16 @@ def test_labeled_canonical_issue_wins_over_duplicate_history() -> None:
     assert resolve_stage_gate_conductor_log_issue(issues) == 8671
 
 
+def test_canonical_label_does_not_require_automation_log_label() -> None:
+    issues = [
+        _issue(7162),
+        _issue(8671, labels=(CANONICAL_STAGE_GATE_LOG_LABEL,)),
+        _issue(8402),
+    ]
+
+    assert resolve_stage_gate_conductor_log_issue(issues) == 8671
+
+
 def test_pinned_issue_wins_when_duplicates_have_no_canonical_label() -> None:
     issues = [
         _issue(6432),
@@ -50,6 +63,15 @@ def test_pinned_issue_wins_when_duplicates_have_no_canonical_label() -> None:
         _issue(7162),
         _issue(8402),
         _issue(8671),
+    ]
+
+    assert resolve_stage_gate_conductor_log_issue(issues) == 8671
+
+
+def test_pinned_issue_wins_even_when_label_metadata_has_drifted() -> None:
+    issues = [
+        _issue(8402),
+        _issue(8671, labels=()),
     ]
 
     assert resolve_stage_gate_conductor_log_issue(issues) == 8671
@@ -67,8 +89,46 @@ def test_ambiguous_duplicate_logs_fail_closed_when_no_canonical_exists() -> None
         resolve_stage_gate_conductor_log_issue(issues)
 
 
+def test_unlabeled_duplicate_prevents_singleton_drift() -> None:
+    issues = [
+        _issue(8402),
+        _issue(9001, labels=()),
+    ]
+
+    with pytest.raises(StageGateLogResolutionError, match="multiple Stage-Gate Conductor Log"):
+        resolve_stage_gate_conductor_log_issue(issues)
+
+
+@pytest.mark.parametrize("state", ["CLOSED", "", "unknown"])
+def test_non_open_state_fails_closed(state: str) -> None:
+    with pytest.raises(StageGateLogResolutionError, match="no open Stage-Gate"):
+        resolve_stage_gate_conductor_log_issue([_issue(8671, state=state)])
+
+
+def test_missing_state_fails_closed() -> None:
+    issue = _issue(8671)
+    issue.pop("state")
+
+    with pytest.raises(StageGateLogResolutionError, match="no open Stage-Gate"):
+        resolve_stage_gate_conductor_log_issue([issue])
+
+
+def test_missing_numeric_issue_number_raises_instead_of_returning_zero() -> None:
+    issue = _issue("not-a-number", labels=(CANONICAL_STAGE_GATE_LOG_LABEL,))
+
+    with pytest.raises(StageGateLogResolutionError, match="numeric issue number"):
+        resolve_stage_gate_conductor_log_issue([issue])
+
+
 def test_comment_args_target_resolved_issue_number_not_title_search() -> None:
     args = build_gh_issue_comment_args([_issue(7162), _issue(8671)], body="run body")
 
     assert args == ["issue", "comment", "8671", "--body", "run body"]
     assert STAGE_GATE_CONDUCTOR_LOG_TITLE not in args
+
+
+def test_issue_list_query_uses_high_limit_to_reduce_partial_result_drift() -> None:
+    args = build_gh_issue_list_args()
+
+    assert args[args.index("--limit") + 1] == str(STAGE_GATE_ISSUE_LIST_LIMIT)
+    assert STAGE_GATE_ISSUE_LIST_LIMIT == 1000

--- a/tests/test_prompt_path_guidance_docs.py
+++ b/tests/test_prompt_path_guidance_docs.py
@@ -16,3 +16,14 @@ def test_recursive_prompts_do_not_assume_home_aragora_symlink():
         assert "~/aragora" not in text
         assert "repo root" in text
         assert "worktree" in text
+
+
+def test_stage_gate_conductor_prompt_uses_canonical_log_resolver():
+    repo_root = Path(__file__).resolve().parents[1]
+    prompt = (repo_root / "docs/prompts/STAGE_GATE_CONDUCTOR_LOG_PROMPT.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "resolve_stage_gate_conductor_log_issue" in prompt
+    assert "#8671" in prompt
+    assert "#7162" not in prompt


### PR DESCRIPTION
## Summary
- add a canonical Stage-Gate Conductor log resolver that pins duplicate log streams to #8671
- document the prompt contract so conductor automation comments on the resolved issue and fails closed instead of creating another duplicate
- update stale #7162 references and add focused regression coverage

## Root cause
The conductor log target was selected by search/heuristics, so multiple open issues with the exact `[automation] Stage-Gate Conductor Log` title could split future comments or trigger a new issue when lookup degraded.

## Validation
- `ARAGORA_USE_SECRETS_MANAGER=0 pytest tests/ops/test_stage_gate_conductor_log.py`
- `ARAGORA_USE_SECRETS_MANAGER=0 pytest tests/test_prompt_path_guidance_docs.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- live resolver check: `[8671, 8402, 7162, 6763, 6432, 6216, 6096] -> 8671`

Closes #8711