### PR TITLE
refactor(events): downshift server.stream.events schemas to aragora.events (P4a Batch 1d)

### DIFF
--- a/aragora/billing/cost_tracker.py
+++ b/aragora/billing/cost_tracker.py
@@ -603,7 +603,7 @@ class CostTracker:
         # Emit stream event for real-time budget monitoring
         if self._event_emitter:
             try:
-                from aragora.server.stream.events import StreamEvent, StreamEventType
+                from aragora.events.types import StreamEvent, StreamEventType
 
                 self._event_emitter.emit(
                     StreamEvent(

--- a/aragora/events/dispatcher.py
+++ b/aragora/events/dispatcher.py
@@ -42,7 +42,7 @@ from aragora.server.middleware.tracing import get_trace_id
 if TYPE_CHECKING:
     from aragora.storage.webhook_config_store import WebhookConfig
     from aragora.server.stream.emitter import SyncEventEmitter
-    from aragora.server.stream.events import StreamEvent
+    from aragora.events.types import StreamEvent
 
 logger = logging.getLogger(__name__)
 

--- a/aragora/server/stream/events.py
+++ b/aragora/server/stream/events.py
@@ -1,18 +1,27 @@
+"""Deprecated import location for the stream event schemas.
+
+The stream event schema surface (``StreamEvent``, ``StreamEventType``,
+``AudienceMessage``) lives in :mod:`aragora.events.types` so that
+foundation/infrastructure modules can reach the event dataclasses without
+importing ``aragora.server``. Importing them from
+``aragora.server.stream.events`` still works but is deprecated; import from
+``aragora.events`` (or ``aragora.events.types``) instead.
 """
-Stream event types and data classes.
 
-Defines the types of events emitted during debates and nomic loop execution,
-along with the dataclasses for representing events and audience messages.
+import warnings
 
-NOTE: The event types are now defined in aragora.events.types to avoid
-layering violations. This module re-exports them for backward compatibility.
-"""
-
-# Re-export from shared events layer for backward compatibility
+# Re-export from the shared events layer for backward compatibility.
 from aragora.events.types import (
     AudienceMessage,
     StreamEvent,
     StreamEventType,
+)
+
+warnings.warn(
+    "aragora.server.stream.events is deprecated; import StreamEvent, "
+    "StreamEventType, and AudienceMessage from aragora.events instead.",
+    DeprecationWarning,
+    stacklevel=2,
 )
 
 __all__ = [


### PR DESCRIPTION
## Summary

P4a Batch 1d (Tier 1-2). Completes the downshift of the importable **stream event schema surface** (`StreamEvent`, `StreamEventType`, `AudienceMessage`) to the `aragora.events` layer, so foundation/infrastructure modules can reach the event dataclasses without importing `aragora.server`.

The schemas already live in `aragora.events.types`; this PR:

- Turns `aragora/server/stream/events.py` into a **`DeprecationWarning` shim** that re-exports the schemas from `aragora.events.types` (back-compat preserved; the warning message carries the old dotted path `aragora.server.stream.events`).
- Repoints the **foundation/infrastructure-layer** importers off the old path:
  - `aragora/billing/cost_tracker.py` (BUDGET_ALERT emit path)
  - `aragora/events/dispatcher.py` (`TYPE_CHECKING` import)

  so they no longer contribute the `stream.events` link to the `events -> server` / `billing -> server` layer edges.

Server-side stream runtime stays in place; only the importable schema surface moves. Domain/app callers (`debate/`, `explainability/`, `ranking/`) and the server-internal stream modules stay on the shim by-design - their `DeprecationWarning` is the intended two-sided signal (VAL-CROSS-004); full caller migration is post-mission shim-retire.

Refs: P4a layering foundation, epic #8257.

## Validation (worktree off origin/main 3d2af8d2c1)

- **Two-sided shim (VAL-CROSS-004):** importing `aragora.server.stream.events` emits a `DeprecationWarning` whose message contains `aragora.server.stream.events`; the shim re-exports all three symbols and imports only `aragora.events` (allowed-imports check PASS). Robust isolated check (worktree-resolved, `__file__` asserted, token-filtered): `TWO_SIDED_OK: True`.
- **Changed-file typecheck gate (required CI flags):** `mypy --ignore-missing-imports --follow-imports=skip --show-error-codes` over the 3 touched files -> `Success: no issues found in 3 source files`.
- **make lint:** All checks passed. **ruff format --check aragora/ tests/ scripts/:** 10603 files already formatted.
- **Targeted pytest:** `tests/billing/test_cost_tracker.py tests/server/stream/test_emitter.py tests/events/test_async_dispatcher.py tests/events/test_batch_dispatcher.py tests/events/test_security_dispatcher.py` -> **218 passed** (shim `DeprecationWarning` observed firing via `emitter.py:19`).
- **make test-smoke (VAL-P4A-013):** Core/Server/Memory imports OK, Smoke tests passed (exit 0).
- **Smoke tier:** `PYTEST_BIN="python3 -m pytest" bash scripts/test_tiers.sh smoke` -> 138 passed (exit 0).

## Risks / notes

- Low. Pure import-source relocation + additive `DeprecationWarning`; symbol identities/values unchanged.
- The `events -> server` and `billing -> server` import-contract baseline edges are intentionally **NOT shrunk**: both packages retain other `aragora.server.*` importers (events: `server.handlers.webhooks`, `server.middleware.tracing` [Batch 1b deferred], `server.stream.{state_manager,emitter}`; billing: `server.middleware.auth`), so the edges stay alive even though the `stream.events` contribution is removed. Recorded as residual drift for the P4a seal/sweep.
- `docs/METRICS.md` / `aragora/module_tiers.yaml` **NOT regenerated** (path-frozen at P4a by #8460/#8461/#8382 per the path-freeze carve-out); the resulting generated-file drift is recorded for the orchestrator-coordinated phase merge-train regen.
