### PR TITLE
refactor(events): registry-backed cross-subscriber dispatch + layered bootstrap (P4a Batch E1)

### DIFF
--- a/aragora/cli/commands/stats.py
+++ b/aragora/cli/commands/stats.py
@@ -318,9 +318,9 @@ def cmd_cross_pollination(args: argparse.Namespace) -> None:
     """Handle 'cross-pollination' command - view event system diagnostics."""
     import json as json_module
 
-    from aragora.events.cross_subscribers import get_cross_subscriber_manager
+    from aragora.server.startup.event_subscribers import bootstrap_event_subscribers
 
-    manager = get_cross_subscriber_manager()
+    manager = bootstrap_event_subscribers()
     action = getattr(args, "action", "stats")
     output_json = getattr(args, "json", False)
 

--- a/aragora/debate/event_subscribers.py
+++ b/aragora/debate/event_subscribers.py
@@ -1,0 +1,41 @@
+"""Domain-subset bootstrap for cross-subsystem event subscribers (P4a E1).
+
+Composition root for the *domain* layer (Arena / pure-library debate). It imports
+only domain home modules so their subscribers self-register, then wires them into
+the cross-subscriber manager. Application/interface reactions (workflow, nomic,
+server) register when *those* subsystems initialize; a pure-library debate with no
+server/workflow engine simply has no such reactions (matching today's try/except
+fallbacks).
+
+This module lives in ``debate`` (domain) and imports only sibling-domain home
+modules plus ``aragora.events.cross_subscribers`` (domain -> infrastructure,
+downward = legal). It must NOT be promoted to the interface superset - that would
+recreate an upward import. See docs/architecture/P4A_EVENTS_QUEUE_INVERSION.md §4.4.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from aragora.events.cross_subscribers import CrossSubscriberManager
+
+
+def bootstrap_debate_event_subscribers() -> CrossSubscriberManager:
+    """Import domain event-subscriber home modules and wire them into the manager.
+
+    Idempotent (registration is keyed by name). E1 is a pure enabler: no domain
+    home modules exist yet, so this currently only ensures the manager is
+    initialized. E2-E6 add ``import aragora.<domain>.event_subscribers`` lines
+    here (e.g. knowledge/memory/debate/reasoning/ranking) as handlers relocate to
+    their home layers.
+
+    Returns:
+        The registry-backed cross-subscriber manager singleton.
+    """
+    # Domain home-module imports are added here by E2-E6 as handlers relocate,
+    # e.g. ``import aragora.knowledge.event_subscribers`` (a side-effect import
+    # for registration; mark it with a noqa F401 to silence unused-import lint).
+    from aragora.events.cross_subscribers import bootstrap
+
+    return bootstrap()

--- a/aragora/debate/extensions.py
+++ b/aragora/debate/extensions.py
@@ -571,9 +571,11 @@ class ArenaExtensions:
             workspace_id = self.workspace_id or "default"
 
             # Get cross-subscriber manager to access adapter instances
-            from aragora.events.cross_subscribers import get_cross_subscriber_manager
+            from aragora.debate.event_subscribers import (
+                bootstrap_debate_event_subscribers,
+            )
 
-            manager = get_cross_subscriber_manager()
+            manager = bootstrap_debate_event_subscribers()
 
             # Sync RankingAdapter if expertise was recorded
             try:

--- a/aragora/debate/knowledge_manager.py
+++ b/aragora/debate/knowledge_manager.py
@@ -326,10 +326,12 @@ class ArenaKnowledgeManager:
             return
 
         try:
-            from aragora.events.cross_subscribers import get_cross_subscriber_manager
+            from aragora.debate.event_subscribers import (
+                bootstrap_debate_event_subscribers,
+            )
             from aragora.events.types import StreamEvent, StreamEventType
 
-            manager = get_cross_subscriber_manager()
+            manager = bootstrap_debate_event_subscribers()
 
             # Emit DEBATE_START to trigger KM→subsystem flows
             event = StreamEvent(
@@ -368,9 +370,11 @@ class ArenaKnowledgeManager:
             return {}
 
         try:
-            from aragora.events.cross_subscribers import get_cross_subscriber_manager
+            from aragora.debate.event_subscribers import (
+                bootstrap_debate_event_subscribers,
+            )
 
-            manager = get_cross_subscriber_manager()
+            manager = bootstrap_debate_event_subscribers()
             hints = manager.get_debate_culture_hints(debate_id)
             if hints:
                 logger.debug(

--- a/aragora/events/cross_subscribers/__init__.py
+++ b/aragora/events/cross_subscribers/__init__.py
@@ -24,6 +24,8 @@ Usage:
 
 from __future__ import annotations
 
+import logging
+
 from aragora.events.subscribers.config import (
     AsyncDispatchConfig,
     RetryConfig,
@@ -32,9 +34,20 @@ from aragora.events.subscribers.config import (
 from aragora.observability.metrics import record_km_inbound_event
 
 from .manager import CrossSubscriberManager
+from .registry import (
+    CrossSubscriber,
+    get_registered_subscribers,
+    register_factory,
+    register_subscriber,
+    registered_subscriber_names,
+    reset_registry,
+)
+
+logger = logging.getLogger(__name__)
 
 # Global manager instance
 _global_manager: CrossSubscriberManager | None = None
+_bootstrapped = False
 
 
 def get_cross_subscriber_manager() -> CrossSubscriberManager:
@@ -47,16 +60,54 @@ def get_cross_subscriber_manager() -> CrossSubscriberManager:
 
 def reset_cross_subscriber_manager() -> None:
     """Reset the global manager (for testing)."""
-    global _global_manager
+    global _global_manager, _bootstrapped
     _global_manager = None
+    _bootstrapped = False
+
+
+def bootstrap() -> CrossSubscriberManager:
+    """Ensure the manager exists and has applied every registered subscriber.
+
+    Domain-free composition primitive: this imports NO domain code. Home modules
+    (domain/application/interface) self-register at import time; the layered
+    composition-root bootstraps
+    (:func:`aragora.debate.event_subscribers.bootstrap_debate_event_subscribers`
+    and
+    :func:`aragora.server.startup.event_subscribers.bootstrap_event_subscribers`)
+    import those home modules and then call this to wire them into the manager.
+    Idempotent - repeated calls only apply newly registered subscribers.
+
+    See docs/architecture/P4A_EVENTS_QUEUE_INVERSION.md §4.4.
+    """
+    global _bootstrapped
+    manager = get_cross_subscriber_manager()
+    newly_applied = manager.apply_registered_subscribers()
+    count = len(manager.get_stats())
+    if not _bootstrapped or newly_applied:
+        logger.info(
+            "cross-subscriber bootstrap: %d subscriber(s) registered (+%d newly applied)",
+            count,
+            newly_applied,
+        )
+        _bootstrapped = True
+    else:
+        logger.debug("cross-subscriber bootstrap: %d subscriber(s) already registered", count)
+    return manager
 
 
 __all__ = [
+    "CrossSubscriber",
     "CrossSubscriberManager",
     "SubscriberStats",
     "RetryConfig",
     "AsyncDispatchConfig",
+    "bootstrap",
     "get_cross_subscriber_manager",
+    "get_registered_subscribers",
+    "register_factory",
+    "register_subscriber",
+    "registered_subscriber_names",
     "reset_cross_subscriber_manager",
+    "reset_registry",
     "record_km_inbound_event",
 ]

--- a/aragora/events/cross_subscribers/manager.py
+++ b/aragora/events/cross_subscribers/manager.py
@@ -35,6 +35,7 @@ from .handlers.culture import CultureHandlersMixin
 from .handlers.knowledge_mound import KnowledgeMoundHandlersMixin
 from .handlers.strategic import StrategicHandlersMixin
 from .handlers.validation import ValidationHandlersMixin
+from .registry import get_registered_subscribers
 
 if TYPE_CHECKING:
     from aragora.config.settings import Settings
@@ -135,8 +136,35 @@ class CrossSubscriberManager(
         # Culture storage dict for CultureHandlersMixin
         self._debate_cultures: dict = {}
 
+        # Registry subscribers already wired into this manager instance
+        self._applied_subscribers: set[str] = set()
+
         # Register built-in cross-subsystem handlers
         self._register_builtin_subscribers()
+
+        # Wire any subscribers registered via the domain-free registry
+        self.apply_registered_subscribers()
+
+    def apply_registered_subscribers(self) -> int:
+        """Wire registry subscribers not yet applied into this manager.
+
+        Home modules (domain/application/interface) self-register their
+        subscribers via ``aragora.events.cross_subscribers.register_subscriber``;
+        this applies them by delegating to each subscriber's ``register`` method,
+        reusing the existing per-event dispatch/stats/retry machinery. Idempotent:
+        each subscriber is applied at most once per manager instance.
+
+        Returns:
+            The number of subscribers newly applied by this call.
+        """
+        applied = 0
+        for name, subscriber in get_registered_subscribers().items():
+            if name in self._applied_subscribers:
+                continue
+            subscriber.register(self)
+            self._applied_subscribers.add(name)
+            applied += 1
+        return applied
 
     def _create_async_config_from_settings(self) -> AsyncDispatchConfig:
         """Create AsyncDispatchConfig from settings or use defaults.

--- a/aragora/events/cross_subscribers/registry.py
+++ b/aragora/events/cross_subscribers/registry.py
@@ -1,0 +1,74 @@
+"""Domain-free cross-subscriber registry (P4a EventBus inversion, E1).
+
+Holds cross-subsystem event subscribers keyed by name so that domain,
+application, and interface *home modules* can self-register their subscribers at
+import time. Registration is decoupled from dispatch: a subscriber wires its own
+handlers into the manager via ``manager.register(...)`` when applied, so neither
+this registry nor the manager needs to import any domain code.
+
+This module carries ZERO domain imports (eager OR lazy) - it only stores and
+returns opaque subscriber objects. Registration is keyed by name and idempotent,
+so repeated bootstrap calls are no-ops. See
+docs/architecture/P4A_EVENTS_QUEUE_INVERSION.md §4.1 and §4.4.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from .manager import CrossSubscriberManager
+
+
+@runtime_checkable
+class CrossSubscriber(Protocol):
+    """A cross-subsystem event subscriber.
+
+    A subscriber owns its own reactions and wires them into the manager via
+    ``manager.register(name, event_type, handler)`` when applied. Keeping the
+    wiring on the subscriber lets home modules own their reactions without the
+    registry (or the manager) importing any domain code.
+    """
+
+    def register(self, manager: CrossSubscriberManager) -> None: ...
+
+
+_SUBSCRIBERS: dict[str, CrossSubscriber] = {}
+_FACTORIES: dict[str, Callable[[], CrossSubscriber]] = {}
+
+
+def register_subscriber(name: str, subscriber: CrossSubscriber) -> None:
+    """Register a subscriber instance under ``name`` (keyed, idempotent)."""
+    _SUBSCRIBERS[name] = subscriber
+    _FACTORIES.pop(name, None)
+
+
+def register_factory(name: str, factory: Callable[[], CrossSubscriber]) -> None:
+    """Register a zero-arg factory that lazily builds a subscriber.
+
+    The factory is invoked at most once, the first time the subscriber is
+    materialized by :func:`get_registered_subscribers`.
+    """
+    if name not in _SUBSCRIBERS:
+        _FACTORIES[name] = factory
+
+
+def get_registered_subscribers() -> dict[str, CrossSubscriber]:
+    """Return all registered subscribers, materializing factories once."""
+    for name, factory in list(_FACTORIES.items()):
+        if name not in _SUBSCRIBERS:
+            _SUBSCRIBERS[name] = factory()
+        _FACTORIES.pop(name, None)
+    return dict(_SUBSCRIBERS)
+
+
+def registered_subscriber_names() -> list[str]:
+    """Return the sorted names of all registered subscribers and factories."""
+    return sorted(set(_SUBSCRIBERS) | set(_FACTORIES))
+
+
+def reset_registry() -> None:
+    """Clear the registry (for tests)."""
+    _SUBSCRIBERS.clear()
+    _FACTORIES.clear()

--- a/aragora/server/startup/event_subscribers.py
+++ b/aragora/server/startup/event_subscribers.py
@@ -1,0 +1,38 @@
+"""Superset bootstrap for cross-subsystem event subscribers (P4a E1).
+
+Composition root for the *running product* (server startup, CLI). It imports the
+domain, application, AND interface event-subscriber home modules so every reaction
+self-registers, then wires them into the cross-subscriber manager. Interface may
+import every layer, so this superset lives here (in ``interface``); it must NOT
+live in ``events``/``debate``, which would recreate an upward import.
+
+See docs/architecture/P4A_EVENTS_QUEUE_INVERSION.md §4.4.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from aragora.events.cross_subscribers import CrossSubscriberManager
+
+
+def bootstrap_event_subscribers() -> CrossSubscriberManager:
+    """Import all event-subscriber home modules and wire them into the manager.
+
+    Superset of the domain-subset bootstrap: it also imports application and
+    interface home modules. Idempotent. E1 is a pure enabler: no home modules
+    exist yet, so this currently composes the domain-subset bootstrap and ensures
+    the manager is initialized. E2-E7 add application/interface
+    ``import aragora.<pkg>.event_subscribers`` lines here (e.g. workflow,
+    notifications, server) as handlers relocate to their home layers.
+
+    Returns:
+        The registry-backed cross-subscriber manager singleton.
+    """
+    from aragora.debate.event_subscribers import bootstrap_debate_event_subscribers
+
+    # Application + interface home-module imports are added here by E2-E7, e.g.
+    # ``import aragora.workflow.event_subscribers`` (a side-effect import for
+    # registration; mark it with a noqa F401 to silence unused-import lint).
+    return bootstrap_debate_event_subscribers()

--- a/tests/events/test_cross_subscriber_registry.py
+++ b/tests/events/test_cross_subscriber_registry.py
@@ -1,0 +1,249 @@
+"""Tests for the domain-free cross-subscriber registry + layered bootstrap (P4a E1).
+
+Covers the enabler surface introduced by the EventBus/Job-Queue registry
+inversion (docs/architecture/P4A_EVENTS_QUEUE_INVERSION.md §4.1, §4.4):
+
+- ``register_subscriber`` / ``register_factory`` / ``get_registered_subscribers``
+  / ``reset_registry`` on ``aragora.events.cross_subscribers``.
+- The domain-free ``bootstrap()`` that wires registered subscribers into the
+  manager (idempotent).
+- The layered composition roots: the domain-subset
+  ``aragora.debate.event_subscribers.bootstrap_debate_event_subscribers`` and the
+  interface superset ``aragora.server.startup.event_subscribers.bootstrap_event_subscribers``.
+- The registration-completeness safeguard: the superset bootstrap must register
+  the full pre-inversion subscriber set (parity, no silent drops).
+- The registry surface must carry ZERO domain imports.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aragora.events.cross_subscribers import (
+    bootstrap,
+    get_cross_subscriber_manager,
+    get_registered_subscribers,
+    register_factory,
+    register_subscriber,
+    registered_subscriber_names,
+    reset_cross_subscriber_manager,
+    reset_registry,
+)
+from aragora.events.types import StreamEventType
+
+# Pre-inversion registered-subscriber set, captured on origin/main @708d116ed2
+# (before E2 begins). The superset bootstrap must keep parity with this set; any
+# silent drop as handlers relocate in E2-E7 fails the batch (§4.4 safeguard).
+GOLDEN_SUBSCRIBER_NAMES = frozenset(
+    {
+        "agent_birth_to_control_plane",
+        "agent_death_to_control_plane",
+        "agent_evolution_to_control_plane",
+        "agent_message_to_rhetorical",
+        "alert_escalated_to_workflow_brake",
+        "approval_to_km_reinforcement",
+        "belief_to_mound",
+        "budget_alert_to_team_selection",
+        "calibration_to_agent",
+        "consensus_to_learning",
+        "consensus_to_mound",
+        "culture_to_debate",
+        "debate_end_to_cost_tracking",
+        "debate_end_to_explainability",
+        "debate_outcome_to_knowledge",
+        "elo_to_debate",
+        "elo_to_mound",
+        "evidence_to_insight",
+        "flip_to_mound",
+        "gauntlet_to_notification",
+        "insight_to_mound",
+        "km_validation_feedback",
+        "knowledge_to_memory",
+        "memory_to_mound",
+        "memory_to_rlm",
+        "meta_learning_to_team_selection",
+        "mound_to_belief",
+        "mound_to_culture",
+        "mound_to_memory",
+        "mound_to_memory_retrieval",
+        "mound_to_provenance",
+        "mound_to_rlm",
+        "mound_to_team_selection",
+        "mound_to_trickster",
+        "provenance_to_mound",
+        "risk_warning_to_health",
+        "rlm_to_mound",
+        "staleness_to_debate",
+        "tier_demotion_to_revalidation",
+        "tier_promotion_to_knowledge",
+        "vote_to_belief",
+        "webhook_agent_elo_updated",
+        "webhook_calibration_update",
+        "webhook_evidence_found",
+        "webhook_knowledge_indexed",
+        "webhook_knowledge_queried",
+        "webhook_memory_retrieved",
+        "webhook_memory_stored",
+        "webhook_mound_updated",
+        "workflow_complete_to_supermemory",
+        "workflow_failed_to_supermemory",
+    }
+)
+
+
+class _FakeSubscriber:
+    """Minimal subscriber that wires one handler into the manager on register."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.register_calls = 0
+
+    def register(self, manager: object) -> None:
+        self.register_calls += 1
+        manager.register(self.name, StreamEventType.DEBATE_START, lambda event: None)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry_and_manager():
+    """Isolate each test: empty registry + fresh manager before and after."""
+    reset_registry()
+    reset_cross_subscriber_manager()
+    yield
+    reset_registry()
+    reset_cross_subscriber_manager()
+
+
+def test_register_subscriber_and_get():
+    sub = _FakeSubscriber("test_fake_subscriber")
+    register_subscriber("test_fake_subscriber", sub)
+
+    registered = get_registered_subscribers()
+    assert registered["test_fake_subscriber"] is sub
+    assert "test_fake_subscriber" in registered_subscriber_names()
+
+
+def test_register_subscriber_is_keyed_idempotent():
+    first = _FakeSubscriber("dup")
+    second = _FakeSubscriber("dup")
+    register_subscriber("dup", first)
+    register_subscriber("dup", second)
+
+    registered = get_registered_subscribers()
+    assert registered["dup"] is second
+    assert registered_subscriber_names().count("dup") == 1
+
+
+def test_register_factory_materializes_once():
+    calls = {"n": 0}
+
+    def factory() -> _FakeSubscriber:
+        calls["n"] += 1
+        return _FakeSubscriber("from_factory")
+
+    register_factory("from_factory", factory)
+
+    first = get_registered_subscribers()["from_factory"]
+    second = get_registered_subscribers()["from_factory"]
+    assert first is second
+    assert calls["n"] == 1
+
+
+def test_reset_registry_clears():
+    register_subscriber("gone", _FakeSubscriber("gone"))
+    assert "gone" in get_registered_subscribers()
+
+    reset_registry()
+    assert get_registered_subscribers() == {}
+    assert registered_subscriber_names() == []
+
+
+def test_bootstrap_applies_registered_subscriber():
+    sub = _FakeSubscriber("wired_via_bootstrap")
+    register_subscriber("wired_via_bootstrap", sub)
+
+    manager = bootstrap()
+
+    assert sub.register_calls == 1
+    assert "wired_via_bootstrap" in manager.get_stats()
+
+
+def test_bootstrap_is_idempotent():
+    sub = _FakeSubscriber("only_once")
+    register_subscriber("only_once", sub)
+
+    bootstrap()
+    manager = bootstrap()
+    bootstrap()
+
+    # register() runs at most once per manager instance even across repeated
+    # bootstrap calls (registration is keyed and application is tracked).
+    assert sub.register_calls == 1
+    assert "only_once" in manager.get_stats()
+
+
+def test_get_cross_subscriber_manager_path_unchanged():
+    """Acceptance #3: the public accessor stays at its historical import path."""
+    import importlib
+
+    module = importlib.import_module("aragora.events.cross_subscribers")
+    assert hasattr(module, "get_cross_subscriber_manager")
+    assert module.get_cross_subscriber_manager is get_cross_subscriber_manager
+
+    manager1 = get_cross_subscriber_manager()
+    manager2 = get_cross_subscriber_manager()
+    assert manager1 is manager2
+
+
+def test_builtin_handlers_still_registered_via_manager():
+    """E1 keeps handlers in place: constructing the manager registers the set."""
+    manager = get_cross_subscriber_manager()
+    registered = set(manager.get_stats())
+    missing = GOLDEN_SUBSCRIBER_NAMES - registered
+    assert not missing, f"builtin subscribers dropped by E1: {sorted(missing)}"
+
+
+def test_domain_subset_bootstrap_returns_manager():
+    from aragora.debate.event_subscribers import bootstrap_debate_event_subscribers
+
+    manager = bootstrap_debate_event_subscribers()
+    assert manager is get_cross_subscriber_manager()
+
+
+def test_superset_bootstrap_completeness_parity():
+    """Registration-completeness safeguard (§4.4): superset bootstrap must
+    register the FULL pre-inversion subscriber set with no silent drops."""
+    from aragora.server.startup.event_subscribers import bootstrap_event_subscribers
+
+    manager = bootstrap_event_subscribers()
+    registered = set(manager.get_stats())
+
+    missing = GOLDEN_SUBSCRIBER_NAMES - registered
+    assert not missing, f"superset bootstrap dropped subscribers: {sorted(missing)}"
+
+
+def test_registry_module_has_zero_domain_imports():
+    """The registry surface must not import any domain-layer package (§4.1).
+
+    Static source guard complementing the grimp full-layer re-check: the registry
+    module carries zero domain imports (eager OR lazy).
+    """
+    import aragora.events.cross_subscribers.registry as registry_module
+
+    source = Path(registry_module.__file__).read_text(encoding="utf-8")
+    domain_packages = (
+        "debate",
+        "agents",
+        "memory",
+        "knowledge",
+        "ranking",
+        "reasoning",
+        "evidence",
+        "evaluation",
+        "explainability",
+        "learning",
+        "ml",
+    )
+    offenders = [pkg for pkg in domain_packages if f"aragora.{pkg}" in source]
+    assert not offenders, f"registry.py imports domain packages: {offenders}"


### PR DESCRIPTION
## P4a EventBus inversion — Batch E1 (ENABLER)

Domain-free cross-subscriber registry core. Reworks `aragora/events/cross_subscribers/{__init__,manager}.py` to registry-backed dispatch and adds an explicit `bootstrap()` plus layered composition roots, so event-subscriber home modules can self-register at import time without `events/` importing any domain code. Supersedes cancelled Batch 2a/2b. See `docs/architecture/P4A_EVENTS_QUEUE_INVERSION.md` §4.1, §4.4, §10 (E1).

### What changed
- **New** `aragora/events/cross_subscribers/registry.py`: domain-free registry (`register_subscriber` / `register_factory` / `get_registered_subscribers` / `registered_subscriber_names` / `reset_registry`) + a `CrossSubscriber` Protocol. **ZERO** domain imports (eager or lazy).
- Reuses the existing domain-free `subscribers/config.SubscriberStats` (no duplicate/rename).
- `__init__.py`: adds idempotent `bootstrap()` returning the registry-backed manager; `get_cross_subscriber_manager()` import path **unchanged** (`aragora.events.cross_subscribers`).
- `manager.py`: adds idempotent `apply_registered_subscribers()` wiring registry subscribers into the existing per-event dispatch/stats/retry machinery.
- **New** layered composition roots: domain-subset `debate.event_subscribers.bootstrap_debate_event_subscribers()` and interface-superset `server.startup.event_subscribers.bootstrap_event_subscribers()`.
- Repoint the **actual** callers (grok residual #5): `debate/extensions.py` + `debate/knowledge_manager.py` → domain-subset bootstrap; `cli/commands/stats.py` → interface-superset bootstrap.

### Acceptance (doc §10 per-batch)
1. `check_import_contracts.py --layers foundation,infrastructure`: no new foundation/infra edge (only documented ambient `utils → caching` #8672). E1 clears none (pure enabler).
2. Full-layer re-check: no new domain/application/interface edge (only the 4 documented ambient sibling-fleet edges).
3. `get_cross_subscriber_manager()` import path unchanged.
4. `make test-smoke` exit 0 (VAL-P4A-013); smoke tier 138 passed; targeted registry tests 11 passed.
5. CI changed-file typecheck green ("no issues found in 8 source files").

Handlers stay in place for now and register via the new API. No METRICS.md / module_tiers.yaml regen (path-frozen). Tier 1-2 → self-merge head-bound (`--squash --match-head-commit`).
