### PR TITLE
fix(gate): make advisory_settle reachable in enforcing merge-quorum job (#8739) [Tier 4]

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -2582,6 +2582,27 @@ def _build_packet(
             and not required_pending_checks
             and all(_is_merge_quorum_check(check) for check in required_failing_or_cancelled_checks)
         )
+        # Self-check-independent reachability predicate for advisory-dissent
+        # settlement (#8739). Unlike ``required_quorum_only_failure`` above, this
+        # does NOT require the merge-quorum row to be *visible* as a failing
+        # required check. Inside the enforcing Aragora Merge Quorum job the quorum
+        # row is the current self-check and is excluded from
+        # ``effective_required_checks``, so ``required_failing_or_cancelled_checks``
+        # is empty and ``required_quorum_only_failure`` is False even though the
+        # quorum signal is exactly what is missing. Externally the same row appears
+        # as a distinct failing entry. Both collapse to "no NON-quorum required
+        # check is failing/cancelled/pending" — the true condition advisory_settle
+        # needs. Computed separately so the in-job path is reachable WITHOUT
+        # disturbing the self-check semantics ``quorum_only_failure`` (and its guard
+        # tests) rely on. ``all(...)`` over an empty failing set is True (in-job);
+        # over a quorum-only failing set is True (external); over any non-quorum
+        # failure it is False (correctly keeps a real failing check blocking).
+        advisory_settle_surface_clear = (
+            required_available
+            and effective_required_count > 0
+            and not required_pending_checks
+            and all(_is_merge_quorum_check(check) for check in required_failing_or_cancelled_checks)
+        )
         # _rollup_non_green_diagnostics reports the raw GitHub rollup counts/sample
         # and is intentionally not filtered by ignore_own_quorum_check. The flag's
         # effect on the rollup is limited to the summary text computed above; the
@@ -2633,6 +2654,7 @@ def _build_packet(
                 :CHECK_SURFACE_DIAGNOSTIC_LIMIT
             ],
             "quorum_only_failure": required_quorum_only_failure,
+            "advisory_settle_surface_clear": advisory_settle_surface_clear,
         }
         if required_surface.get("error"):
             check_surfaces["required_pr_checks"]["error"] = str(required_surface.get("error"))
@@ -3269,6 +3291,18 @@ def _build_model_review_quorum(
         isinstance(required_pr_check_surface, dict)
         and required_pr_check_surface.get("quorum_only_failure")
     )
+    # #8739: self-check-independent reachability for advisory_settle. In the
+    # enforcing merge-quorum job the quorum row is the excluded self-check, so
+    # ``quorum_only_failure`` is False; ``advisory_settle_surface_clear`` is True
+    # whenever no NON-quorum required check is failing/pending. Since
+    # ``quorum_only_failure`` implies a clear surface, the OR below is
+    # backward-compatible with external settle-tooling callers that only populate
+    # the older key.
+    advisory_settle_surface_clear = bool(
+        isinstance(required_pr_check_surface, dict)
+        and required_pr_check_surface.get("advisory_settle_surface_clear")
+    )
+    advisory_settle_reachable = advisory_settle_surface_clear or quorum_only_required_failure
     stale_quorum_check_after_satisfied_evidence = (
         quorum_only_required_failure and quorum_satisfied and not settlement_recorded
     )
@@ -3306,7 +3340,7 @@ def _build_model_review_quorum(
         advisory_dissent_settle_enabled()
         and tier is not None
         and 0 <= tier <= 2
-        and quorum_only_required_failure
+        and advisory_settle_reachable
         and not quorum_satisfied
         and not settlement_recorded
         # NOTE (#8729 claude [P2]): advisory_settle deliberately does NOT require

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -2886,7 +2886,26 @@ class TestModelReviewQuorum:
         assert _dogfood_evidence_from_comments(comments, head_sha=head) == []
 
 
-_QUORUM_ONLY_FAILURE_SURFACES = {"required_pr_checks": {"quorum_only_failure": True}}
+_QUORUM_ONLY_FAILURE_SURFACES = {
+    "required_pr_checks": {
+        "quorum_only_failure": True,
+        # External settle-tooling shape: the merge-quorum row is a distinct failing
+        # required check, so the surface is also advisory_settle-clear.
+        "advisory_settle_surface_clear": True,
+    }
+}
+
+# In-job (#8739) shape: inside the enforcing Aragora Merge Quorum job the quorum row
+# is the excluded current self-check, so ``quorum_only_failure`` is False even though
+# the quorum signal is exactly what is missing. No NON-quorum required check is
+# failing/pending, so ``advisory_settle_surface_clear`` is True and advisory_settle
+# must still be reachable.
+_INJOB_QUORUM_SELF_CHECK_SURFACES = {
+    "required_pr_checks": {
+        "quorum_only_failure": False,
+        "advisory_settle_surface_clear": True,
+    }
+}
 
 
 class TestAdvisoryDissentSettleGate:
@@ -2948,7 +2967,7 @@ class TestAdvisoryDissentSettleGate:
         ]
         return pr
 
-    def _quorum(self, pr, *, has_failures=True, has_pending=False, files=None):
+    def _quorum(self, pr, *, has_failures=True, has_pending=False, files=None, check_surfaces=None):
         return _build_model_review_quorum(
             pr=pr,
             files=files or ["aragora/agents/router.py"],
@@ -2956,8 +2975,29 @@ class TestAdvisoryDissentSettleGate:
             machine_recommendation="repair_first" if has_failures else "approve_candidate",
             has_pending=has_pending,
             has_failures=has_failures,
-            check_surfaces=_QUORUM_ONLY_FAILURE_SURFACES,
+            check_surfaces=check_surfaces
+            if check_surfaces is not None
+            else _QUORUM_ONLY_FAILURE_SURFACES,
         )
+
+    def test_flag_on_settles_in_enforcing_job_via_surface_clear(self, monkeypatch) -> None:
+        # #8739 regression: inside the enforcing merge-quorum job the quorum row is
+        # the excluded self-check, so quorum_only_failure is False. advisory_settle
+        # must still be reachable via the self-check-independent
+        # advisory_settle_surface_clear predicate — otherwise enabling the flag
+        # (#8738) is a no-op in CI.
+        monkeypatch.setenv("ARAGORA_ENABLE_ADVISORY_DISSENT_SETTLE", "1")
+        monkeypatch.setenv("ARAGORA_ENABLE_SEVERITY_GATED_DISSENT", "1")
+        q = self._quorum(
+            self._tier1_pr_wf_advisory_cr(),
+            has_failures=True,
+            check_surfaces=_INJOB_QUORUM_SELF_CHECK_SURFACES,
+        )
+        assert q["tier"] == 1
+        assert q["status"] == "satisfied"
+        assert q["verdict"] == "advisory_settle"
+        assert q["admin_squash_allowed"] is True
+        assert q["unresolved_dissent"] is False
 
     def test_flag_off_advisory_cr_still_blocked(self, monkeypatch) -> None:
         # Flag OFF (default): advisory_settle dormant; behavior byte-identical.


### PR DESCRIPTION
## Summary
Fixes **#8739** — the advisory-dissent settlement path merged in #8729 (default-OFF) is **unreachable inside the enforcing `Aragora Merge Quorum` job**, so enabling the flag (#8738) is currently a no-op in CI.

**Root cause:** `advisory_settle_eligible` gated on `quorum_only_required_failure`, which needs the merge-quorum row to be a *visible* failing required check. In-job that row is the excluded current self-check → failing set is empty → predicate False even though the quorum signal is the only thing missing. It only computed True for external settle-tooling.

**Fix:** add a self-check-independent predicate `advisory_settle_surface_clear` ("no NON-quorum required check is failing/cancelled/pending"), emitted on the `required_pr_checks` surface and consumed by the gate (OR'd with the old key for backward-compat, since `quorum_only_failure` implies a clear surface). `quorum_only_failure` semantics are untouched, so the two self-check guard tests named in #8739 stay green.

## Verification
- New in-job regression test: `test_flag_on_settles_in_enforcing_job_via_surface_clear` (RED→GREEN).
- The two guard tests from #8739 (`..._ignores_stale_self_row_inside_quorum_run`, `..._self_check_uses_required_gate_despite_shadow_jobs`) still pass — no reconciliation needed because the change is additive.
- `304 passed` (test_review_queue) + `196 passed` (test_quorum_evidence); ruff + mypy clean.
- Byte-identical behavior when `ARAGORA_ENABLE_ADVISORY_DISSENT_SETTLE` is OFF (default): `advisory_dissent_settle_enabled()` short-circuits first.

## ⚠️ Tier 4 — human risk sign-off required
This is merge-authority self-modification. Per docs/plans/2026-06-30-advisory-dissent-settlement-gate-packet.md it must settle via **human sign-off**, not the gate it changes. Leaving as **draft** for @scarmani.

Once this lands, #8738 (enable flag) stops being inert and the quorum-only-blocked pipeline (#8730, #8726, #8740, and future substantial features) can settle on advisory findings with the hard zero-[P0]/[P1] bar intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)