### PR TITLE
feat(missions): add native Zenith boundary control

### DIFF
--- a/aragora/missions/__init__.py
+++ b/aragora/missions/__init__.py
@@ -11,6 +11,15 @@ Public surface::
 
 from .ledger import Constraint, Ledger, Lease, select_for
 from .live_gate import LiveBossLoopGate
+from .boundary import (
+    MissionBoundaryAction,
+    MissionBoundaryController,
+    MissionBoundaryDecision,
+    MissionBoundaryEvent,
+    apply_boundary_decision,
+    layered_validation_kinds,
+    validate_contract_coverage,
+)
 from .orchestrator import Handoff, MissionOrchestrator
 from .reconcile import (
     AdmissionDecision,
@@ -27,7 +36,11 @@ from .reconcile import (
 )
 from .runtime import MissionRuntimeConfig
 from .state import (
+    ContractAssertion,
+    ContractState,
+    ContractStatus,
     Feature,
+    FeatureKind,
     MissionOwnershipError,
     MissionState,
     Status,
@@ -37,11 +50,19 @@ from .swarm import SwarmResult, reconcile_from_ledger, run_worker
 
 __all__ = [
     "Constraint",
+    "ContractAssertion",
+    "ContractState",
+    "ContractStatus",
     "Feature",
+    "FeatureKind",
     "Handoff",
     "Ledger",
     "Lease",
     "LiveBossLoopGate",
+    "MissionBoundaryAction",
+    "MissionBoundaryController",
+    "MissionBoundaryDecision",
+    "MissionBoundaryEvent",
     "MissionOrchestrator",
     "MissionOwnershipError",
     "MissionRuntimeConfig",
@@ -55,12 +76,15 @@ __all__ = [
     "Status",
     "SwarmResult",
     "WorkArtifact",
+    "apply_boundary_decision",
     "apply_validation_result",
     "classify_artifact",
     "inject_validation_features",
+    "layered_validation_kinds",
     "mission_owner_lock",
     "reconcile_from_ledger",
     "run_worker",
     "select_for",
+    "validate_contract_coverage",
     "write_operator_receipt",
 ]

--- a/aragora/missions/boundary.py
+++ b/aragora/missions/boundary.py
@@ -191,7 +191,11 @@ def validate_contract_coverage(state: MissionState) -> list[ContractCoverageErro
                     )
                 )
                 continue
-            if feature.kind == FeatureKind.WORK and feature.status != Status.BLOCKED:
+            if (
+                feature.kind == FeatureKind.WORK
+                and feature.status != Status.BLOCKED
+                and not feature.metadata.get("repair_for")
+            ):
                 owners[assertion_id].append(feature.id)
 
     for assertion_id, feature_ids in owners.items():
@@ -241,7 +245,13 @@ def apply_boundary_decision(state: MissionState, decision: MissionBoundaryDecisi
 
     if decision.action == MissionBoundaryAction.PARK:
         if decision.feature_id:
-            state.mark_blocked(decision.feature_id, decision.reason)
+            feature = state.get(decision.feature_id)
+            if feature.status == Status.COMPLETED:
+                note = f"PARKED: {decision.reason}"
+                if note not in feature.notes:
+                    feature.notes = (feature.notes + "\n" if feature.notes else "") + note
+            else:
+                state.mark_blocked(decision.feature_id, decision.reason)
         return
 
     if decision.action == MissionBoundaryAction.ADD_VALIDATOR:
@@ -266,11 +276,14 @@ def _apply_patch_plan(state: MissionState, decision: MissionBoundaryDecision) ->
         validator_feature_id=validator.id,
         passed=False,
         reason=decision.reason,
+        reopen_parents=False,
     )
     assertions = list(decision.assertion_ids or validator.fulfills)
     parent_paths = _paths_from_validated_parents(state, validator)
+    repair_preconditions: list[str] = []
     for assertion_id in assertions:
         feature_id = f"repair-{validator.id}-{_slug(assertion_id)}"
+        repair_preconditions.append(f"feature:{feature_id}")
         if _feature_or_none(state, feature_id) is not None:
             continue
         state.insert_feature(
@@ -287,6 +300,10 @@ def _apply_patch_plan(state: MissionState, decision: MissionBoundaryDecision) ->
                 },
             )
         )
+    validator.status = Status.PENDING
+    for precondition in repair_preconditions:
+        if precondition not in validator.preconditions:
+            validator.preconditions.append(precondition)
 
 
 def _needs_fidelity_validation(feature: Feature) -> bool:

--- a/aragora/missions/boundary.py
+++ b/aragora/missions/boundary.py
@@ -1,0 +1,378 @@
+"""Zenith-style mission boundary decisions for native missions.
+
+This module is pure at the controller layer: ``evaluate`` only classifies the
+next boundary action. ``apply_boundary_decision`` performs the small state
+mutation so tests and callers can reason about decisions before applying them.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+from .reconcile import apply_validation_result, inject_validation_features
+from .state import Feature, FeatureKind, MissionState, Status
+
+
+class MissionBoundaryAction(str, Enum):
+    """Actions available at a feature, validator, or milestone boundary."""
+
+    CONTINUE = "continue"
+    PATCH_PLAN = "patch_plan"
+    RETRY = "retry"
+    ADD_WORKER = "add_worker"
+    ADD_VALIDATOR = "add_validator"
+    SYNTHESIZE_SKILL = "synthesize_skill"
+    RESET_STRATEGY = "reset_strategy"
+    SEAL_MILESTONE = "seal_milestone"
+    PARK = "park"
+    STOP = "stop"
+
+
+@dataclass(frozen=True)
+class ContractCoverageError:
+    """One contract-coverage invariant violation."""
+
+    code: str
+    assertion_id: str
+    detail: str
+    feature_ids: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class MissionBoundaryEvent:
+    """The observable event that asks the controller for a next action."""
+
+    kind: str
+    feature_id: str = ""
+    milestone: str = ""
+    reason: str = ""
+    terminal: bool = False
+    risk_tier: int | None = None
+    failed_assertions: list[str] = field(default_factory=list)
+    discovered_skills: list[dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class MissionBoundaryDecision:
+    """Pure boundary verdict returned by ``MissionBoundaryController``."""
+
+    action: MissionBoundaryAction
+    reason: str
+    feature_id: str = ""
+    milestone: str = ""
+    assertion_ids: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "action": self.action.value,
+            "reason": self.reason,
+            "feature_id": self.feature_id,
+            "milestone": self.milestone,
+            "assertion_ids": list(self.assertion_ids),
+            "metadata": dict(self.metadata),
+        }
+
+
+class MissionBoundaryController:
+    """Choose the next mission-control action at explicit boundaries."""
+
+    def __init__(self, *, max_retries: int = 3, operator_tier: int = 3) -> None:
+        self.max_retries = max(1, int(max_retries))
+        self.operator_tier = max(1, int(operator_tier))
+
+    def evaluate(self, state: MissionState, event: MissionBoundaryEvent) -> MissionBoundaryDecision:
+        feature = _feature_or_none(state, event.feature_id)
+        milestone = event.milestone or (feature.milestone if feature else "")
+        reason = event.reason or "mission boundary reached"
+
+        if event.risk_tier is not None and event.risk_tier >= self.operator_tier:
+            return MissionBoundaryDecision(
+                MissionBoundaryAction.PARK,
+                f"tier-{event.risk_tier} boundary requires operator settlement: {reason}",
+                feature_id=event.feature_id,
+                milestone=milestone,
+                assertion_ids=list(event.failed_assertions),
+            )
+
+        if event.terminal:
+            return MissionBoundaryDecision(
+                MissionBoundaryAction.PARK,
+                f"terminal boundary requires operator receipt: {reason}",
+                feature_id=event.feature_id,
+                milestone=milestone,
+                assertion_ids=list(event.failed_assertions),
+            )
+
+        if event.kind == "validation_failed":
+            assertion_ids = list(event.failed_assertions)
+            if not assertion_ids and feature is not None:
+                assertion_ids = list(feature.fulfills)
+            return MissionBoundaryDecision(
+                MissionBoundaryAction.PATCH_PLAN,
+                reason,
+                feature_id=event.feature_id,
+                milestone=milestone,
+                assertion_ids=assertion_ids,
+            )
+
+        if event.kind == "worker_failed":
+            next_retry = (feature.retry_count + 1) if feature is not None else 1
+            if next_retry >= self.max_retries:
+                return MissionBoundaryDecision(
+                    MissionBoundaryAction.PARK,
+                    f"retry budget exhausted after {next_retry} attempt(s): {reason}",
+                    feature_id=event.feature_id,
+                    milestone=milestone,
+                    assertion_ids=list(feature.fulfills if feature else event.failed_assertions),
+                    metadata={"retry_count": next_retry, "max_retries": self.max_retries},
+                )
+            return MissionBoundaryDecision(
+                MissionBoundaryAction.RETRY,
+                reason,
+                feature_id=event.feature_id,
+                milestone=milestone,
+                assertion_ids=list(feature.fulfills if feature else event.failed_assertions),
+                metadata={"retry_count": next_retry, "max_retries": self.max_retries},
+            )
+
+        if (
+            event.kind == "feature_completed"
+            and feature is not None
+            and feature.kind == FeatureKind.WORK
+            and _all_work_completed(state, feature.milestone)
+            and not _has_validation_or_gate(state, feature.milestone)
+        ):
+            return MissionBoundaryDecision(
+                MissionBoundaryAction.ADD_VALIDATOR,
+                f"milestone {feature.milestone} work is complete; add layered validation",
+                feature_id=feature.id,
+                milestone=feature.milestone,
+                assertion_ids=_milestone_assertions(state, feature.milestone),
+            )
+
+        return MissionBoundaryDecision(
+            MissionBoundaryAction.CONTINUE,
+            reason,
+            feature_id=event.feature_id,
+            milestone=milestone,
+            assertion_ids=list(event.failed_assertions),
+        )
+
+
+def validate_contract_coverage(state: MissionState) -> list[ContractCoverageError]:
+    """Validate native contract coverage.
+
+    Every ``VAL-*`` assertion needs exactly one active work owner. Validators and
+    gates may cover many assertions, but they do not count as implementation
+    ownership.
+    """
+    if not state.contract:
+        return []
+
+    assertion_ids = [item.assertion_id for item in state.contract]
+    known = set(assertion_ids)
+    owners: dict[str, list[str]] = {assertion_id: [] for assertion_id in assertion_ids}
+    errors: list[ContractCoverageError] = []
+
+    for feature in state.features:
+        for assertion_id in feature.fulfills:
+            if assertion_id not in known:
+                errors.append(
+                    ContractCoverageError(
+                        code="task_targets_unknown_assertion",
+                        assertion_id=assertion_id,
+                        detail=f"feature {feature.id} targets unknown assertion {assertion_id}",
+                        feature_ids=[feature.id],
+                    )
+                )
+                continue
+            if feature.kind == FeatureKind.WORK and feature.status != Status.BLOCKED:
+                owners[assertion_id].append(feature.id)
+
+    for assertion_id, feature_ids in owners.items():
+        if not feature_ids:
+            errors.append(
+                ContractCoverageError(
+                    code="uncovered_assertion",
+                    assertion_id=assertion_id,
+                    detail=f"assertion {assertion_id} has no active work owner",
+                )
+            )
+        elif len(feature_ids) > 1:
+            errors.append(
+                ContractCoverageError(
+                    code="over_covered_assertion",
+                    assertion_id=assertion_id,
+                    detail=f"assertion {assertion_id} has multiple active work owners",
+                    feature_ids=list(feature_ids),
+                )
+            )
+
+    return errors
+
+
+def layered_validation_kinds(state: MissionState, milestone: str) -> tuple[str, ...]:
+    """Return layered validation kinds for a milestone."""
+    kinds = ["automated", "review"]
+    milestone_features = [
+        feature
+        for feature in state.features
+        if feature.milestone == milestone and feature.kind == FeatureKind.WORK
+    ]
+    if any(_needs_fidelity_validation(feature) for feature in milestone_features):
+        kinds.append("fidelity")
+    return tuple(kinds)
+
+
+def apply_boundary_decision(state: MissionState, decision: MissionBoundaryDecision) -> None:
+    """Apply a previously evaluated boundary decision to mission state."""
+    state.decision_trace.append(decision.to_dict())
+
+    if decision.action == MissionBoundaryAction.RETRY:
+        feature = state.get(decision.feature_id)
+        feature.retry_count += 1
+        feature.status = Status.PENDING
+        return
+
+    if decision.action == MissionBoundaryAction.PARK:
+        if decision.feature_id:
+            state.mark_blocked(decision.feature_id, decision.reason)
+        return
+
+    if decision.action == MissionBoundaryAction.ADD_VALIDATOR:
+        milestone = decision.milestone
+        if milestone:
+            inject_validation_features(
+                state,
+                milestone=milestone,
+                validation_kinds=layered_validation_kinds(state, milestone),
+                include_gate=True,
+            )
+        return
+
+    if decision.action == MissionBoundaryAction.PATCH_PLAN:
+        _apply_patch_plan(state, decision)
+
+
+def _apply_patch_plan(state: MissionState, decision: MissionBoundaryDecision) -> None:
+    validator = state.get(decision.feature_id)
+    apply_validation_result(
+        state,
+        validator_feature_id=validator.id,
+        passed=False,
+        reason=decision.reason,
+    )
+    assertions = list(decision.assertion_ids or validator.fulfills)
+    parent_paths = _paths_from_validated_parents(state, validator)
+    for assertion_id in assertions:
+        feature_id = f"repair-{validator.id}-{_slug(assertion_id)}"
+        if _feature_or_none(state, feature_id) is not None:
+            continue
+        state.insert_feature(
+            Feature(
+                id=feature_id,
+                description=f"Repair {assertion_id}: {decision.reason}",
+                milestone=validator.milestone,
+                skill="worker",
+                kind=FeatureKind.WORK,
+                fulfills=[assertion_id],
+                metadata={
+                    "repair_for": validator.id,
+                    "paths": list(parent_paths),
+                },
+            )
+        )
+
+
+def _needs_fidelity_validation(feature: Feature) -> bool:
+    metadata = dict(feature.metadata or {})
+    surface = str(metadata.get("surface", "") or "").strip().lower()
+    if surface in {"ui", "visual", "benchmark", "external"}:
+        return True
+
+    raw_layers = metadata.get("validation_layers", [])
+    if isinstance(raw_layers, str):
+        layers: Iterable[Any] = [raw_layers]
+    elif isinstance(raw_layers, Iterable):
+        layers = raw_layers
+    else:
+        layers = []
+    normalized_layers = {str(layer).strip().lower() for layer in layers if str(layer).strip()}
+    if normalized_layers & {"fidelity", "visual", "user_testing", "benchmark", "external"}:
+        return True
+
+    expected = " ".join(str(item) for item in feature.expected_behavior).lower()
+    return any(term in expected for term in ("ui", "visual", "browser", "benchmark", "external"))
+
+
+def _paths_from_validated_parents(state: MissionState, validator: Feature) -> list[str]:
+    paths: set[str] = set()
+    validates = validator.metadata.get("validates", [])
+    if not isinstance(validates, list):
+        return []
+    for parent_id in validates:
+        parent = _feature_or_none(state, str(parent_id))
+        if parent is None:
+            continue
+        paths.update(_coerce_strings(parent.metadata.get("paths")))
+    return sorted(paths)
+
+
+def _coerce_strings(value: Any) -> list[str]:
+    if isinstance(value, str):
+        values: Iterable[Any] = [value]
+    elif isinstance(value, Iterable) and not isinstance(value, Mapping):
+        values = value
+    else:
+        values = []
+    return [str(item).strip() for item in values if str(item).strip()]
+
+
+def _feature_or_none(state: MissionState, feature_id: str) -> Feature | None:
+    if not feature_id:
+        return None
+    try:
+        return state.get(feature_id)
+    except KeyError:
+        return None
+
+
+def _all_work_completed(state: MissionState, milestone: str) -> bool:
+    work = [
+        feature
+        for feature in state.features
+        if feature.milestone == milestone and feature.kind == FeatureKind.WORK
+    ]
+    return bool(work) and all(feature.status == Status.COMPLETED for feature in work)
+
+
+def _has_validation_or_gate(state: MissionState, milestone: str) -> bool:
+    return any(
+        feature.milestone == milestone
+        and (
+            feature.kind in {FeatureKind.VALIDATE, FeatureKind.GATE}
+            or feature.metadata.get("validation_for") == milestone
+        )
+        for feature in state.features
+    )
+
+
+def _milestone_assertions(state: MissionState, milestone: str) -> list[str]:
+    return sorted(
+        {
+            assertion_id
+            for feature in state.features
+            if feature.milestone == milestone
+            for assertion_id in feature.fulfills
+            if assertion_id
+        }
+    )
+
+
+def _slug(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", str(value).lower()).strip("-") or "item"

--- a/aragora/missions/orchestrator.py
+++ b/aragora/missions/orchestrator.py
@@ -240,7 +240,7 @@ class MissionOrchestrator:
         reason = handoff.blocked_reason or "feature boundary reached"
 
         if handoff.success:
-            if feat.kind == FeatureKind.VALIDATE:
+            if feat.kind in {FeatureKind.VALIDATE, FeatureKind.GATE}:
                 apply_validation_result(state, feat.id, passed=True, reason=reason)
             else:
                 state.mark_completed(feat.id)

--- a/aragora/missions/orchestrator.py
+++ b/aragora/missions/orchestrator.py
@@ -18,8 +18,14 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from .boundary import (
+    MissionBoundaryController,
+    MissionBoundaryEvent,
+    apply_boundary_decision,
+)
 from .ledger import LedgerCorruptError
-from .state import Feature, MissionState, Status, mission_owner_lock
+from .reconcile import apply_validation_result
+from .state import Feature, FeatureKind, MissionState, Status, mission_owner_lock
 
 logger = logging.getLogger(__name__)
 
@@ -206,6 +212,10 @@ class MissionOrchestrator:
                 state.insert_feature(follow)
                 logger.info("handoff inserted accepted follow-up feature %s", follow.id)
 
+        if _native_contract_enabled(state):
+            self._triage_with_boundary_controller(state, feat, handoff)
+            return
+
         if handoff.success:
             state.mark_completed(feature_id)
             return
@@ -218,6 +228,48 @@ class MissionOrchestrator:
             state.mark_blocked(feature_id, reason)
         else:
             feat.status = Status.PENDING  # bounded retry
+
+    def _triage_with_boundary_controller(
+        self,
+        state: MissionState,
+        feat: Feature,
+        handoff: Handoff,
+    ) -> None:
+        controller = MissionBoundaryController(max_retries=self.max_retries)
+        risk_tier = _feature_risk_tier(feat)
+        reason = handoff.blocked_reason or "feature boundary reached"
+
+        if handoff.success:
+            if feat.kind == FeatureKind.VALIDATE:
+                apply_validation_result(state, feat.id, passed=True, reason=reason)
+            else:
+                state.mark_completed(feat.id)
+            decision = controller.evaluate(
+                state,
+                MissionBoundaryEvent(
+                    kind="feature_completed",
+                    feature_id=feat.id,
+                    reason=reason,
+                    risk_tier=risk_tier,
+                ),
+            )
+            if decision.action.value != "continue":
+                apply_boundary_decision(state, decision)
+            return
+
+        event_kind = "validation_failed" if feat.kind == FeatureKind.VALIDATE else "worker_failed"
+        decision = controller.evaluate(
+            state,
+            MissionBoundaryEvent(
+                kind=event_kind,
+                feature_id=feat.id,
+                reason=reason,
+                terminal=handoff.terminal,
+                risk_tier=risk_tier,
+                failed_assertions=list(feat.fulfills),
+            ),
+        )
+        apply_boundary_decision(state, decision)
 
     def _block_unrunnable_pending(self, state: MissionState, reason: str) -> bool:
         changed = False
@@ -303,3 +355,17 @@ class MissionOrchestrator:
             return self.ledger_path
         default_path = self.state_path.with_name("ledger.json")
         return default_path if default_path.exists() else None
+
+
+def _native_contract_enabled(state: MissionState) -> bool:
+    return bool(state.contract)
+
+
+def _feature_risk_tier(feature: Feature) -> int | None:
+    raw = feature.metadata.get("risk_tier", feature.metadata.get("tier"))
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None

--- a/aragora/missions/reconcile.py
+++ b/aragora/missions/reconcile.py
@@ -17,7 +17,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
-from .state import Feature, MissionState, Status
+from .state import ContractStatus, Feature, FeatureKind, MissionState, Status
 
 
 class ArtifactCategory(str, Enum):
@@ -289,13 +289,16 @@ def inject_validation_features(
     *,
     milestone: str,
     validation_kinds: tuple[str, ...] = ("tests", "scrutiny"),
+    include_gate: bool = False,
 ) -> list[Feature]:
     """Insert validator features for a completed milestone if not already present."""
     milestone_features = [f for f in state.features if f.milestone == milestone]
     if not milestone_features:
         return []
     non_validators = [
-        f for f in milestone_features if f.metadata.get("validation_for") != milestone
+        f
+        for f in milestone_features
+        if f.kind == FeatureKind.WORK and f.metadata.get("validation_for") != milestone
     ]
     if not non_validators or not all(f.status == Status.COMPLETED for f in non_validators):
         return []
@@ -325,6 +328,7 @@ def inject_validation_features(
             description=f"Validate milestone {milestone} with {kind}",
             milestone=milestone,
             skill="validator",
+            kind=FeatureKind.VALIDATE,
             preconditions=list(preconditions),
             fulfills=list(fulfills),
             metadata={
@@ -336,6 +340,36 @@ def inject_validation_features(
         )
         state.insert_feature(feature)
         injected.append(feature)
+
+    if include_gate:
+        gate_id = f"gate-{_slug(milestone)}"
+        if gate_id not in existing_ids:
+            validator_ids = [
+                f.id
+                for f in state.features
+                if f.milestone == milestone
+                and (
+                    f.kind == FeatureKind.VALIDATE or f.metadata.get("validation_for") == milestone
+                )
+            ]
+            gate = Feature(
+                id=gate_id,
+                description=f"Seal milestone {milestone}",
+                milestone=milestone,
+                skill="gate",
+                kind=FeatureKind.GATE,
+                preconditions=[f"feature:{feature_id}" for feature_id in validator_ids],
+                fulfills=list(fulfills),
+                metadata={
+                    "validation_for": milestone,
+                    "validation_kind": "gate",
+                    "validates": [f.id for f in non_validators],
+                    "validator_features": validator_ids,
+                    "paths": paths,
+                },
+            )
+            state.insert_feature(gate)
+            injected.append(gate)
     return injected
 
 
@@ -351,6 +385,12 @@ def apply_validation_result(
     validator = state.get(validator_feature_id)
     if passed:
         validator.status = Status.COMPLETED
+        for assertion_id in validator.fulfills:
+            contract_state = state.contract_state.get(assertion_id)
+            if contract_state is not None:
+                contract_state.status = ContractStatus.PASSED
+                if validator.id not in contract_state.validator_feature_ids:
+                    contract_state.validator_feature_ids.append(validator.id)
         return
 
     ledger = None
@@ -360,6 +400,12 @@ def apply_validation_result(
         ledger = Ledger(ledger_path)
 
     state.mark_blocked(validator_feature_id, reason or "validation failed")
+    for assertion_id in validator.fulfills:
+        contract_state = state.contract_state.get(assertion_id)
+        if contract_state is not None:
+            contract_state.status = ContractStatus.FAILED
+            if validator.id not in contract_state.validator_feature_ids:
+                contract_state.validator_feature_ids.append(validator.id)
     validates = validator.metadata.get("validates", [])
     if not isinstance(validates, list):
         validates = []

--- a/aragora/missions/reconcile.py
+++ b/aragora/missions/reconcile.py
@@ -380,17 +380,14 @@ def apply_validation_result(
     passed: bool,
     reason: str,
     ledger_path: str | Path | None = None,
+    reopen_parents: bool = True,
 ) -> None:
     """Apply a validator outcome and reopen parent work on failure."""
     validator = state.get(validator_feature_id)
     if passed:
         validator.status = Status.COMPLETED
-        for assertion_id in validator.fulfills:
-            contract_state = state.contract_state.get(assertion_id)
-            if contract_state is not None:
-                contract_state.status = ContractStatus.PASSED
-                if validator.id not in contract_state.validator_feature_ids:
-                    contract_state.validator_feature_ids.append(validator.id)
+        _record_validation_feature(state, validator)
+        _refresh_contract_status(state, validator)
         return
 
     ledger = None
@@ -406,6 +403,8 @@ def apply_validation_result(
             contract_state.status = ContractStatus.FAILED
             if validator.id not in contract_state.validator_feature_ids:
                 contract_state.validator_feature_ids.append(validator.id)
+    if not reopen_parents:
+        return
     validates = validator.metadata.get("validates", [])
     if not isinstance(validates, list):
         validates = []
@@ -426,6 +425,43 @@ def apply_validation_result(
             note = f"{note}: {reason}"
         if note not in parent.notes:
             parent.notes = (parent.notes + "\n" if parent.notes else "") + note
+
+
+def _record_validation_feature(state: MissionState, feature: Feature) -> None:
+    for assertion_id in feature.fulfills:
+        contract_state = state.contract_state.get(assertion_id)
+        if contract_state is None:
+            continue
+        if feature.id not in contract_state.validator_feature_ids:
+            contract_state.validator_feature_ids.append(feature.id)
+
+
+def _refresh_contract_status(state: MissionState, feature: Feature) -> None:
+    for assertion_id in feature.fulfills:
+        contract_state = state.contract_state.get(assertion_id)
+        if contract_state is None:
+            continue
+        if _all_validation_requirements_complete(state, feature.milestone, assertion_id):
+            contract_state.status = ContractStatus.PASSED
+        elif contract_state.status != ContractStatus.FAILED:
+            contract_state.status = ContractStatus.PENDING
+
+
+def _all_validation_requirements_complete(
+    state: MissionState,
+    milestone: str,
+    assertion_id: str,
+) -> bool:
+    requirements = [
+        feature
+        for feature in state.features
+        if feature.milestone == milestone
+        and assertion_id in feature.fulfills
+        and feature.kind in {FeatureKind.VALIDATE, FeatureKind.GATE}
+    ]
+    return bool(requirements) and all(
+        feature.status == Status.COMPLETED for feature in requirements
+    )
 
 
 def write_operator_receipt(

--- a/aragora/missions/state.py
+++ b/aragora/missions/state.py
@@ -112,6 +112,26 @@ class Status:
     ALL = frozenset({PENDING, IN_PROGRESS, COMPLETED, BLOCKED})
 
 
+class FeatureKind:
+    """Native mission task kinds, matching the work/validate/gate control shape."""
+
+    WORK = "work"
+    VALIDATE = "validate"
+    GATE = "gate"
+
+    ALL = frozenset({WORK, VALIDATE, GATE})
+
+
+class ContractStatus:
+    """Assertion lifecycle states."""
+
+    PENDING = "pending"
+    PASSED = "passed"
+    FAILED = "failed"
+
+    ALL = frozenset({PENDING, PASSED, FAILED})
+
+
 def preconditions_met(preconditions: list[str], completed: set[str]) -> bool:
     """Return True iff every precondition is explicitly satisfied.
 
@@ -123,6 +143,40 @@ def preconditions_met(preconditions: list[str], completed: set[str]) -> bool:
 
 
 @dataclass
+class ContractAssertion:
+    """A checkable mission contract assertion.
+
+    Assertion ids intentionally use the ``VAL-*`` namespace so work, validators,
+    gates, receipts, and handoffs can refer to the same acceptance surface.
+    """
+
+    assertion_id: str
+    statement: str
+    evidence_expectations: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not str(self.assertion_id or "").startswith("VAL-"):
+            raise ValueError("contract assertion ids must start with 'VAL-'")
+        if not str(self.statement or "").strip():
+            raise ValueError("contract assertion statement must be non-empty")
+
+
+@dataclass
+class ContractState:
+    """Runtime verdict and ownership state for one contract assertion."""
+
+    status: str = ContractStatus.PENDING
+    owner_feature_id: str = ""
+    validator_feature_ids: list[str] = field(default_factory=list)
+    notes: str = ""
+
+    def __post_init__(self) -> None:
+        if self.status not in ContractStatus.ALL:
+            raise ValueError(f"invalid contract status {self.status!r}")
+
+
+@dataclass
 class Feature:
     """One unit of mission work — the atom the orchestrator dispatches."""
 
@@ -131,6 +185,7 @@ class Feature:
     milestone: str
     skill: str = "worker"
     status: str = Status.PENDING
+    kind: str = FeatureKind.WORK
     preconditions: list[str] = field(default_factory=list)
     expected_behavior: list[str] = field(default_factory=list)
     fulfills: list[str] = field(default_factory=list)  # assertion ids (Phase B)
@@ -143,6 +198,8 @@ class Feature:
     def __post_init__(self) -> None:
         if self.status not in Status.ALL:
             raise ValueError(f"invalid status {self.status!r} for feature {self.id!r}")
+        if self.kind not in FeatureKind.ALL:
+            raise ValueError(f"invalid kind {self.kind!r} for feature {self.id!r}")
 
 
 @dataclass
@@ -153,6 +210,11 @@ class MissionState:
     goal: str
     milestones: list[str] = field(default_factory=list)
     features: list[Feature] = field(default_factory=list)
+    contract: list[ContractAssertion] = field(default_factory=list)
+    contract_state: dict[str, ContractState] = field(default_factory=dict)
+    role_specs: dict[str, dict[str, Any]] = field(default_factory=dict)
+    skill_seeds: list[dict[str, Any]] = field(default_factory=list)
+    decision_trace: list[dict[str, Any]] = field(default_factory=list)
 
     # ---- queue / advance API -------------------------------------------------
 
@@ -240,15 +302,36 @@ class MissionState:
             "goal": self.goal,
             "milestones": list(self.milestones),
             "features": [asdict(f) for f in self.features],
+            "contract": [asdict(item) for item in self.contract],
+            "contract_state": {
+                assertion_id: asdict(state) for assertion_id, state in self.contract_state.items()
+            },
+            "role_specs": dict(self.role_specs),
+            "skill_seeds": list(self.skill_seeds),
+            "decision_trace": list(self.decision_trace),
         }
 
     @classmethod
     def from_dict(cls, data: dict) -> MissionState:
+        raw_contract_state = data.get("contract_state", {}) or {}
         return cls(
             mission_id=data["mission_id"],
             goal=data["goal"],
             milestones=list(data.get("milestones", [])),
             features=[from_known_fields(Feature, f) for f in data.get("features", [])],
+            contract=[
+                from_known_fields(ContractAssertion, item)
+                for item in data.get("contract", [])
+                if isinstance(item, dict)
+            ],
+            contract_state={
+                str(assertion_id): from_known_fields(ContractState, state)
+                for assertion_id, state in dict(raw_contract_state).items()
+                if isinstance(state, dict)
+            },
+            role_specs=dict(data.get("role_specs", {}) or {}),
+            skill_seeds=list(data.get("skill_seeds", []) or []),
+            decision_trace=list(data.get("decision_trace", []) or []),
         )
 
     def save(self, path: str | Path) -> None:

--- a/aragora/swarm/mission.py
+++ b/aragora/swarm/mission.py
@@ -275,6 +275,10 @@ def default_context_policy(
             allowed_artifact_classes=[
                 "mission_envelope",
                 "mission_stage",
+                "contract_assertion",
+                "role_spec",
+                "mission_skill_seed",
+                "mission_library_snippet",
                 "validation_command",
                 "acceptance_criteria",
                 "receipt",
@@ -295,6 +299,10 @@ def default_context_policy(
         allowed_artifact_classes=[
             "mission_envelope",
             "mission_stage",
+            "contract_assertion",
+            "role_spec",
+            "mission_skill_seed",
+            "mission_library_snippet",
             "swarm_spec",
             "file_scope",
             "validation_command",

--- a/aragora/swarm/worker_contract.py
+++ b/aragora/swarm/worker_contract.py
@@ -4,8 +4,9 @@ import hashlib
 import json
 import os
 import subprocess
+from collections.abc import Mapping
 from dataclasses import dataclass, field
-from typing import Any, Mapping
+from typing import Any
 
 from aragora.pipeline.execution_mode import ExecutionMode
 from aragora.swarm.mission import normalize_context_policies
@@ -48,6 +49,10 @@ class WorkerContract:
     assertion_ids: list[str] | None = None
     evidence_expectations: list[str] | None = None
     mission_context_policy: dict[str, Any] | None = None
+    contract_assertions: list[dict[str, Any]] | None = None
+    role_specs: dict[str, Any] | None = None
+    skill_seeds: list[dict[str, Any]] | None = None
+    mission_library: list[str] | None = None
     contract_version: str = _CONTRACT_VERSION
     _expected_checksum: str = field(default="", init=False, repr=False)
 
@@ -77,6 +82,18 @@ class WorkerContract:
                 if str(item).strip()
             ],
             "mission_context_policy": dict(self.mission_context_policy or {}),
+            "contract_assertions": [
+                dict(item)
+                for item in list(self.contract_assertions or [])
+                if isinstance(item, Mapping)
+            ],
+            "role_specs": dict(self.role_specs or {}),
+            "skill_seeds": [
+                dict(item) for item in list(self.skill_seeds or []) if isinstance(item, Mapping)
+            ],
+            "mission_library": [
+                str(item).strip() for item in list(self.mission_library or []) if str(item).strip()
+            ],
             "contract_version": self.contract_version,
         }
 
@@ -106,6 +123,22 @@ class WorkerContract:
                 if str(item).strip()
             ],
             mission_context_policy=dict(data.get("mission_context_policy", {}) or {}),
+            contract_assertions=[
+                dict(item)
+                for item in list(data.get("contract_assertions", []) or [])
+                if isinstance(item, Mapping)
+            ],
+            role_specs=dict(data.get("role_specs", {}) or {}),
+            skill_seeds=[
+                dict(item)
+                for item in list(data.get("skill_seeds", []) or [])
+                if isinstance(item, Mapping)
+            ],
+            mission_library=[
+                str(item).strip()
+                for item in list(data.get("mission_library", []) or [])
+                if str(item).strip()
+            ],
             contract_version=str(data.get("contract_version", _CONTRACT_VERSION) or ""),
         )
 
@@ -300,4 +333,20 @@ def build_worker_contract(
         ],
         evidence_expectations=evidence_expectations,
         mission_context_policy=context_policy,
+        contract_assertions=[
+            dict(item)
+            for item in list(work_order_data.get("contract_assertions", []) or [])
+            if isinstance(item, Mapping)
+        ],
+        role_specs=dict(work_order_data.get("role_specs", {}) or {}),
+        skill_seeds=[
+            dict(item)
+            for item in list(work_order_data.get("skill_seeds", []) or [])
+            if isinstance(item, Mapping)
+        ],
+        mission_library=[
+            str(item).strip()
+            for item in list(work_order_data.get("mission_library", []) or [])
+            if str(item).strip()
+        ],
     )

--- a/tests/missions/test_zenith_native_integration.py
+++ b/tests/missions/test_zenith_native_integration.py
@@ -14,6 +14,7 @@ from aragora.missions import (
     MissionOrchestrator,
     MissionState,
     Status,
+    apply_validation_result,
     inject_validation_features,
 )
 from aragora.missions.boundary import (
@@ -209,6 +210,31 @@ def test_boundary_controller_parks_terminal_and_operator_tier_immediately() -> N
     assert "tier-3" in tier.reason
 
 
+def test_operator_tier_park_preserves_completed_feature() -> None:
+    state = MissionState(
+        mission_id="m",
+        goal="respect settlement boundaries",
+        features=[
+            Feature(
+                id="impl",
+                description="Implement high-risk feature",
+                milestone="m1",
+                status=Status.COMPLETED,
+            )
+        ],
+    )
+    controller = MissionBoundaryController(operator_tier=3)
+    decision = controller.evaluate(
+        state,
+        MissionBoundaryEvent(kind="feature_completed", feature_id="impl", risk_tier=3),
+    )
+
+    apply_boundary_decision(state, decision)
+
+    assert state.get("impl").status == Status.COMPLETED
+    assert "PARKED: tier-3" in state.get("impl").notes
+
+
 def test_validation_failure_reopens_parent_and_adds_bounded_followup() -> None:
     state = MissionState(
         mission_id="m",
@@ -250,13 +276,60 @@ def test_validation_failure_reopens_parent_and_adds_bounded_followup() -> None:
 
     apply_boundary_decision(state, decision)
 
-    assert state.get("impl-a").status == Status.PENDING
-    assert state.get("validate-m1-automated").status == Status.BLOCKED
+    assert state.get("impl-a").status == Status.COMPLETED
+    assert state.get("validate-m1-automated").status == Status.PENDING
     followup = state.get("repair-validate-m1-automated-val-a")
     assert followup.kind == "work"
     assert followup.fulfills == ["VAL-A"]
     assert followup.metadata["paths"] == ["aragora/missions/state.py"]
     assert "regression failed" in followup.description
+    assert (
+        "feature:repair-validate-m1-automated-val-a"
+        in state.get("validate-m1-automated").preconditions
+    )
+    assert validate_contract_coverage(state) == []
+
+
+def test_contract_state_passes_only_after_all_validators_and_gate_complete() -> None:
+    state = MissionState(
+        mission_id="m",
+        goal="seal assertions only after all validation gates",
+        milestones=["m1"],
+        contract=[ContractAssertion("VAL-A", "A must hold")],
+        contract_state={"VAL-A": ContractState()},
+        features=[
+            Feature(
+                id="validate-m1-automated",
+                description="Automated validation",
+                milestone="m1",
+                kind="validate",
+                fulfills=["VAL-A"],
+            ),
+            Feature(
+                id="validate-m1-review",
+                description="Review validation",
+                milestone="m1",
+                kind="validate",
+                fulfills=["VAL-A"],
+            ),
+            Feature(
+                id="gate-m1",
+                description="Gate milestone",
+                milestone="m1",
+                kind="gate",
+                fulfills=["VAL-A"],
+            ),
+        ],
+    )
+
+    apply_validation_result(state, "validate-m1-automated", passed=True, reason="")
+    assert state.contract_state["VAL-A"].status == "pending"
+
+    apply_validation_result(state, "validate-m1-review", passed=True, reason="")
+    assert state.contract_state["VAL-A"].status == "pending"
+
+    apply_validation_result(state, "gate-m1", passed=True, reason="")
+    assert state.contract_state["VAL-A"].status == "passed"
 
 
 def test_orchestrator_runs_native_contract_through_validators_and_gate(tmp_path) -> None:
@@ -334,7 +407,11 @@ def test_orchestrator_native_validation_failure_patches_plan(tmp_path) -> None:
     assert MissionOrchestrator(path).tick(dispatch) is True
     final = MissionState.load(path)
 
-    assert final.get("impl-a").status == Status.PENDING
-    assert final.get("validate-m1-automated").status == Status.BLOCKED
+    assert final.get("impl-a").status == Status.COMPLETED
+    assert final.get("validate-m1-automated").status == Status.PENDING
     assert final.get("repair-validate-m1-automated-val-a").fulfills == ["VAL-A"]
+    assert (
+        "feature:repair-validate-m1-automated-val-a"
+        in final.get("validate-m1-automated").preconditions
+    )
     assert final.decision_trace[-1]["action"] == "patch_plan"

--- a/tests/missions/test_zenith_native_integration.py
+++ b/tests/missions/test_zenith_native_integration.py
@@ -1,0 +1,340 @@
+"""Native Zenith-style mission control tests.
+
+These tests pin the small public surface needed to absorb Zenith's control loop
+without importing Zenith as a runtime dependency.
+"""
+
+from __future__ import annotations
+
+from aragora.missions import (
+    ContractAssertion,
+    ContractState,
+    Feature,
+    Handoff,
+    MissionOrchestrator,
+    MissionState,
+    Status,
+    inject_validation_features,
+)
+from aragora.missions.boundary import (
+    MissionBoundaryAction,
+    MissionBoundaryController,
+    MissionBoundaryEvent,
+    apply_boundary_decision,
+    layered_validation_kinds,
+    validate_contract_coverage,
+)
+
+
+def test_mission_state_persists_contract_and_native_task_shape(tmp_path) -> None:
+    state = MissionState(
+        mission_id="zenith-mission",
+        goal="ship with evidence",
+        milestones=["m1"],
+        contract=[
+            ContractAssertion(
+                assertion_id="VAL-API",
+                statement="API behavior remains compatible",
+                evidence_expectations=["pytest tests/api"],
+            )
+        ],
+        contract_state={"VAL-API": ContractState(status="pending")},
+        role_specs={"implementer": {"agent": "codex", "model": "default"}},
+        skill_seeds=[{"id": "debug-imports", "body": "Use targeted import checks first."}],
+        decision_trace=[{"action": "continue", "reason": "seeded"}],
+        features=[
+            Feature(
+                id="impl-api",
+                description="Implement API behavior",
+                milestone="m1",
+                kind="work",
+                fulfills=["VAL-API"],
+                metadata={"role_spec_id": "implementer", "skill_seed_ids": ["debug-imports"]},
+            ),
+            Feature(
+                id="validate-api",
+                description="Validate API behavior",
+                milestone="m1",
+                kind="validate",
+                skill="validator",
+                fulfills=["VAL-API"],
+            ),
+            Feature(
+                id="gate-api",
+                description="Seal API milestone",
+                milestone="m1",
+                kind="gate",
+                fulfills=["VAL-API"],
+            ),
+        ],
+    )
+
+    path = tmp_path / "mission.json"
+    state.save(path)
+
+    restored = MissionState.load(path)
+
+    assert restored.contract[0].assertion_id == "VAL-API"
+    assert restored.contract_state["VAL-API"].status == "pending"
+    assert restored.role_specs["implementer"]["agent"] == "codex"
+    assert restored.skill_seeds[0]["id"] == "debug-imports"
+    assert restored.decision_trace[0]["action"] == "continue"
+    assert [feature.kind for feature in restored.features] == ["work", "validate", "gate"]
+
+
+def test_contract_coverage_requires_exactly_one_active_work_owner() -> None:
+    state = MissionState(
+        mission_id="m",
+        goal="cover assertions",
+        contract=[ContractAssertion("VAL-A", "A must hold")],
+    )
+
+    assert [err.code for err in validate_contract_coverage(state)] == ["uncovered_assertion"]
+
+    state.features.append(
+        Feature(id="impl-a", description="Implement A", milestone="m1", fulfills=["VAL-A"])
+    )
+    assert validate_contract_coverage(state) == []
+
+    state.features.append(
+        Feature(id="impl-a-2", description="Implement A twice", milestone="m1", fulfills=["VAL-A"])
+    )
+    assert [err.code for err in validate_contract_coverage(state)] == ["over_covered_assertion"]
+
+    state.get("impl-a-2").kind = "validate"
+    state.features.append(
+        Feature(
+            id="gate-a",
+            description="Gate A",
+            milestone="m1",
+            kind="gate",
+            fulfills=["VAL-A"],
+        )
+    )
+    assert validate_contract_coverage(state) == []
+
+
+def test_layered_validation_injection_adds_optional_fidelity_and_gate() -> None:
+    state = MissionState(
+        mission_id="m",
+        goal="validate UI carefully",
+        milestones=["ui"],
+        features=[
+            Feature(
+                id="impl-ui",
+                description="Implement UI",
+                milestone="ui",
+                status=Status.COMPLETED,
+                fulfills=["VAL-UI"],
+                metadata={"paths": ["aragora/live"], "surface": "ui"},
+            )
+        ],
+    )
+
+    injected = inject_validation_features(
+        state,
+        milestone="ui",
+        validation_kinds=layered_validation_kinds(state, "ui"),
+        include_gate=True,
+    )
+
+    assert [feature.id for feature in injected] == [
+        "validate-ui-automated",
+        "validate-ui-review",
+        "validate-ui-fidelity",
+        "gate-ui",
+    ]
+    assert [feature.kind for feature in injected] == ["validate", "validate", "validate", "gate"]
+    assert state.get("gate-ui").preconditions == [
+        "feature:validate-ui-automated",
+        "feature:validate-ui-review",
+        "feature:validate-ui-fidelity",
+    ]
+    assert state.get("validate-ui-fidelity").metadata["validation_kind"] == "fidelity"
+
+
+def test_boundary_controller_retries_transient_failure_then_parks() -> None:
+    state = MissionState(
+        mission_id="m",
+        goal="retry transient failures",
+        features=[Feature(id="impl", description="Implement", milestone="m1")],
+    )
+    controller = MissionBoundaryController(max_retries=2)
+
+    first = controller.evaluate(
+        state,
+        MissionBoundaryEvent(kind="worker_failed", feature_id="impl", reason="test failed"),
+    )
+    assert first.action == MissionBoundaryAction.RETRY
+
+    apply_boundary_decision(state, first)
+    assert state.get("impl").status == Status.PENDING
+    assert state.get("impl").retry_count == 1
+
+    second = controller.evaluate(
+        state,
+        MissionBoundaryEvent(kind="worker_failed", feature_id="impl", reason="test failed again"),
+    )
+    assert second.action == MissionBoundaryAction.PARK
+
+    apply_boundary_decision(state, second)
+    assert state.get("impl").status == Status.BLOCKED
+    assert state.decision_trace[-1]["action"] == "park"
+
+
+def test_boundary_controller_parks_terminal_and_operator_tier_immediately() -> None:
+    state = MissionState(
+        mission_id="m",
+        goal="respect settlement boundaries",
+        features=[Feature(id="impl", description="Implement", milestone="m1")],
+    )
+    controller = MissionBoundaryController(operator_tier=3)
+
+    terminal = controller.evaluate(
+        state,
+        MissionBoundaryEvent(
+            kind="worker_failed",
+            feature_id="impl",
+            terminal=True,
+            reason="operator decision required",
+        ),
+    )
+    assert terminal.action == MissionBoundaryAction.PARK
+
+    tier = controller.evaluate(
+        state,
+        MissionBoundaryEvent(kind="feature_completed", feature_id="impl", risk_tier=3),
+    )
+    assert tier.action == MissionBoundaryAction.PARK
+    assert "tier-3" in tier.reason
+
+
+def test_validation_failure_reopens_parent_and_adds_bounded_followup() -> None:
+    state = MissionState(
+        mission_id="m",
+        goal="repair failed validation",
+        milestones=["m1"],
+        contract=[ContractAssertion("VAL-A", "A must hold")],
+        features=[
+            Feature(
+                id="impl-a",
+                description="Implement A",
+                milestone="m1",
+                status=Status.COMPLETED,
+                fulfills=["VAL-A"],
+                metadata={"paths": ["aragora/missions/state.py"]},
+            ),
+            Feature(
+                id="validate-m1-automated",
+                description="Validate A",
+                milestone="m1",
+                kind="validate",
+                skill="validator",
+                metadata={"validation_for": "m1", "validates": ["impl-a"]},
+                fulfills=["VAL-A"],
+            ),
+        ],
+    )
+    controller = MissionBoundaryController()
+
+    decision = controller.evaluate(
+        state,
+        MissionBoundaryEvent(
+            kind="validation_failed",
+            feature_id="validate-m1-automated",
+            reason="regression failed",
+            failed_assertions=["VAL-A"],
+        ),
+    )
+    assert decision.action == MissionBoundaryAction.PATCH_PLAN
+
+    apply_boundary_decision(state, decision)
+
+    assert state.get("impl-a").status == Status.PENDING
+    assert state.get("validate-m1-automated").status == Status.BLOCKED
+    followup = state.get("repair-validate-m1-automated-val-a")
+    assert followup.kind == "work"
+    assert followup.fulfills == ["VAL-A"]
+    assert followup.metadata["paths"] == ["aragora/missions/state.py"]
+    assert "regression failed" in followup.description
+
+
+def test_orchestrator_runs_native_contract_through_validators_and_gate(tmp_path) -> None:
+    path = tmp_path / "mission.json"
+    MissionState(
+        mission_id="m",
+        goal="ship with boundary control",
+        milestones=["ui"],
+        contract=[ContractAssertion("VAL-UI", "UI behavior is preserved")],
+        contract_state={"VAL-UI": ContractState()},
+        features=[
+            Feature(
+                id="impl-ui",
+                description="Implement UI",
+                milestone="ui",
+                fulfills=["VAL-UI"],
+                metadata={"paths": ["aragora/live"], "surface": "ui"},
+            )
+        ],
+    ).save(path)
+    seen: list[str] = []
+
+    def dispatch(feature: Feature) -> Handoff:
+        seen.append(feature.id)
+        return Handoff(success=True)
+
+    done, total = MissionOrchestrator(path).run(dispatch, max_ticks=10)
+    final = MissionState.load(path)
+
+    assert (done, total) == (5, 5)
+    assert seen == [
+        "impl-ui",
+        "validate-ui-automated",
+        "validate-ui-review",
+        "validate-ui-fidelity",
+        "gate-ui",
+    ]
+    assert final.get("gate-ui").status == Status.COMPLETED
+    assert final.decision_trace[0]["action"] == "add_validator"
+    assert final.contract_state["VAL-UI"].status == "passed"
+
+
+def test_orchestrator_native_validation_failure_patches_plan(tmp_path) -> None:
+    path = tmp_path / "mission.json"
+    MissionState(
+        mission_id="m",
+        goal="repair failed validation",
+        milestones=["m1"],
+        contract=[ContractAssertion("VAL-A", "A must hold")],
+        features=[
+            Feature(
+                id="impl-a",
+                description="Implement A",
+                milestone="m1",
+                status=Status.COMPLETED,
+                fulfills=["VAL-A"],
+                metadata={"paths": ["aragora/missions/state.py"]},
+            ),
+            Feature(
+                id="validate-m1-automated",
+                description="Validate A",
+                milestone="m1",
+                kind="validate",
+                skill="validator",
+                metadata={"validation_for": "m1", "validates": ["impl-a"]},
+                fulfills=["VAL-A"],
+            ),
+        ],
+    ).save(path)
+
+    def dispatch(feature: Feature) -> Handoff:
+        assert feature.id == "validate-m1-automated"
+        return Handoff(success=False, blocked_reason="regression failed")
+
+    assert MissionOrchestrator(path).tick(dispatch) is True
+    final = MissionState.load(path)
+
+    assert final.get("impl-a").status == Status.PENDING
+    assert final.get("validate-m1-automated").status == Status.BLOCKED
+    assert final.get("repair-validate-m1-automated-val-a").fulfills == ["VAL-A"]
+    assert final.decision_trace[-1]["action"] == "patch_plan"

--- a/tests/swarm/test_worker_contract.py
+++ b/tests/swarm/test_worker_contract.py
@@ -56,6 +56,52 @@ def test_build_worker_contract_includes_mission_lineage_and_context_policy(tmp_p
     contract.validate()
 
 
+def test_build_worker_contract_carries_native_mission_control_context(tmp_path) -> None:
+    worktree = tmp_path / "repo"
+    worktree.mkdir()
+    config = LaunchConfig(
+        allow_codex_full_auto=True,
+        execution_mode=ExecutionMode.AUTONOMOUS,
+    )
+
+    contract = build_worker_contract(
+        agent="codex",
+        config=config,
+        worktree_path=str(worktree),
+        env={},
+        work_order={
+            "mission_id": "zenith-native",
+            "stage_id": "m1",
+            "assertion_ids": ["VAL-API"],
+            "file_scope": ["aragora/missions/state.py"],
+            "contract_assertions": [
+                {
+                    "assertion_id": "VAL-API",
+                    "statement": "API behavior remains compatible",
+                    "evidence_expectations": ["pytest tests/missions"],
+                }
+            ],
+            "role_specs": {"implementer": {"agent": "codex", "model": "default"}},
+            "skill_seeds": [{"id": "debug-imports", "body": "Run import checks first."}],
+            "mission_library": ["Known setup: run targeted mission tests before full suite."],
+        },
+    )
+
+    payload = contract.to_dict()
+
+    assert payload["contract_assertions"][0]["assertion_id"] == "VAL-API"
+    assert payload["role_specs"]["implementer"]["agent"] == "codex"
+    assert payload["skill_seeds"][0]["id"] == "debug-imports"
+    assert payload["mission_library"] == [
+        "Known setup: run targeted mission tests before full suite."
+    ]
+    assert "contract_assertion" in payload["mission_context_policy"]["allowed_artifact_classes"]
+    assert "role_spec" in payload["mission_context_policy"]["allowed_artifact_classes"]
+    assert "mission_skill_seed" in payload["mission_context_policy"]["allowed_artifact_classes"]
+    assert WorkerContract.from_dict(payload).to_dict() == payload
+    contract.validate()
+
+
 def test_worker_contract_from_dict_round_trips_valid_contract() -> None:
     contract = _make_valid_contract()
 


### PR DESCRIPTION
## Summary
- add native mission contract assertions/state, task kinds, and boundary decisions
- wire contracted missions through layered validators, gates, retry/park, and patch-plan behavior
- pass contract assertions, role specs, mission skill seeds, and mission library snippets through worker contracts/context policy

## Verification
- python -m pytest tests/missions tests/swarm/test_worker_contract.py tests/swarm/test_mission.py tests/nomic/test_pipeline_bridge.py -q
- python -m ruff check aragora/missions/state.py aragora/missions/boundary.py aragora/missions/reconcile.py aragora/missions/orchestrator.py aragora/missions/__init__.py aragora/swarm/mission.py aragora/swarm/worker_contract.py tests/missions/test_zenith_native_integration.py tests/swarm/test_worker_contract.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD