### PR TITLE
feat(quorum): default reviewer pair → claude + openai (western-frontier)

### DIFF
--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -316,7 +316,13 @@ def canonical_family(name: str) -> str:
     return _FAMILY_ALIASES.get(fam, fam)
 
 
-DEFAULT_FAMILIES: tuple[str, ...] = ("claude", "grok")
+# Default reviewer pair: the two western-frontier families (claude→opus-4.8,
+# openai→gpt-5.5). Chosen as the strongest, most-aligned adversarial reviewers so
+# a substantial diff can actually clear a 2-signal quorum, and because Tier 3-4
+# requires two western-frontier families. grok (xai) remains available via
+# --reviewers but is not western-frontier and empirically tends to reopen an
+# advisory nitpick loop on large diffs. Override per-run with --reviewers.
+DEFAULT_FAMILIES: tuple[str, ...] = ("claude", "openai")
 
 # Tiers at or above this require exact-head operator settlement; never auto-post.
 SETTLEMENT_TIER_FLOOR = 3

--- a/scripts/auto_evidence_cycle.py
+++ b/scripts/auto_evidence_cycle.py
@@ -77,7 +77,9 @@ from datetime import datetime, timezone
 from typing import Any, Callable
 
 DEFAULT_REPO = "synaptent/aragora"
-DEFAULT_FAMILIES = ("claude", "grok")
+# Western-frontier pair (claude→opus-4.8, openai→gpt-5.5); see
+# aragora.swarm.quorum_evidence.DEFAULT_FAMILIES. Override with --families.
+DEFAULT_FAMILIES = ("claude", "openai")
 DEFAULT_ROUTING_RECORDS_DIR = os.path.join(".aragora", "automation-receipts", "routing")
 ROUTING_RECORD_SCHEMA = "aragora.routing_rationale/v1"
 SELECTABLE_STATUS = "needs_model_review_quorum"

--- a/scripts/collect_quorum_evidence.py
+++ b/scripts/collect_quorum_evidence.py
@@ -21,7 +21,7 @@ Examples
 
     python3 scripts/collect_quorum_evidence.py --repo synaptent/aragora --pr 7720
     python3 scripts/collect_quorum_evidence.py --repo synaptent/aragora --pr 7720 \\
-        --reviewers claude grok --apply
+        --reviewers claude openai --apply
 """
 
 from __future__ import annotations

--- a/scripts/settle_pr.py
+++ b/scripts/settle_pr.py
@@ -154,8 +154,8 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument(
         "--reviewers",
         nargs="+",
-        default=["claude", "grok"],
-        help="reviewer model families (default: claude grok)",
+        default=["claude", "openai"],
+        help="reviewer model families (default: claude openai — western-frontier pair)",
     )
     ap.add_argument(
         "--operator-login",


### PR DESCRIPTION
## Summary
Changes the default model-review pair from `(claude, grok)` to `(claude, openai)` — the two western-frontier families (claude→opus-4.8, openai→gpt-5.5).

**Why**
- **Tier 3-4 requires two western-frontier families**; grok (xai) is not one, so the old default could never satisfy the high tiers and forced an ad-hoc `--reviewers` override every time (hit live on #8738).
- The two frontier models are the strongest, most-aligned adversarial reviewers, so a substantial diff can actually clear a 2-signal quorum instead of bouncing in an advisory nitpick loop (empirically observed with grok on large diffs during #8738: grok re-opened a fresh advisory finding every round and objected to the feature policy itself).
- grok stays available via `--reviewers` / `--families` when heterogeneity matters more than convergence.

**Changes** (canonical + script-local copies)
- `aragora/swarm/quorum_evidence.py` — `DEFAULT_FAMILIES` (canonical)
- `scripts/auto_evidence_cycle.py`, `scripts/settle_pr.py`, `scripts/collect_quorum_evidence.py`

**Verification**: `216 passed` (test_quorum_evidence + test_settle_plan); ruff clean.

**Tradeoff noted**: two western-frontier models are slightly more correlated than a cross-jurisdiction pair, trading some heterogeneity for convergence/quality. That's the intended operator call; diversity is a per-run `--reviewers` flag away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)