### PR TITLE
feat(tier4): --skew-auto-resolve — bounded auto-clear of required-check visibility skew

### DIFF
--- a/scripts/settle_tier4_pr.py
+++ b/scripts/settle_tier4_pr.py
@@ -10,9 +10,11 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import shlex
 import subprocess
 import sys
+import time
 from collections.abc import Callable, Collection, Mapping, Sequence
 from pathlib import Path
 from typing import Any
@@ -790,6 +792,115 @@ def _required_check_visibility_skew_report(
             "refusing Tier 4 merge/apply before mergePullRequest can reject on stale state."
         ),
         "next_prompt": _visibility_skew_next_prompt(pr=pr, head=head),
+    }
+
+
+_RUN_ID_RE = re.compile(r"/actions/runs/(\d+)")
+
+
+def _superseded_run_ids(skew_report: Mapping[str, Any]) -> list[str]:
+    """Extract the workflow run IDs of the superseded stale-FAILURE contexts.
+
+    Every context in ``stale_failed_required_contexts`` is, by construction of
+    :func:`_required_check_visibility_skew_report`, a required check that GitHub's
+    ``--required`` surface reports GREEN (a newer successful run exists) yet the
+    GraphQL rollup still lists as failed. Re-running that superseded failed run so
+    it re-concludes green is therefore always safe — we never re-run a context
+    whose latest run is genuinely failing. Run IDs are parsed from each context's
+    ``details_url``; contexts without a parseable run URL are skipped.
+    """
+    run_ids: list[str] = []
+    for context in skew_report.get("stale_failed_required_contexts") or []:
+        if not isinstance(context, Mapping):
+            continue
+        url = str(context.get("details_url") or "")
+        match = _RUN_ID_RE.search(url)
+        if match:
+            run_id = match.group(1)
+            if run_id not in run_ids:
+                run_ids.append(run_id)
+    return run_ids
+
+
+def _rerun_workflow_run(run_id: str, *, cwd: Path, repo: str) -> bool:
+    """``gh run rerun <run_id>`` (a read-safe CI re-trigger). Returns success."""
+    try:
+        _run_text_command(["gh", "run", "rerun", run_id, "--repo", repo], cwd=cwd)
+        return True
+    except (subprocess.CalledProcessError, RuntimeError, OSError):
+        return False
+
+
+def _auto_resolve_visibility_skew(
+    *,
+    pr: int,
+    head: str,
+    repo: str,
+    cwd: Path,
+    skew_report: Mapping[str, Any],
+    max_reruns: int,
+    timeout_seconds: float,
+    poll_seconds: float,
+    load_inputs: Callable[[], tuple[dict[str, Any], dict[str, Any], list[dict[str, Any]]]],
+    rerun_run: Callable[[str], bool] | None = None,
+    sleep: Callable[[float], None] = time.sleep,
+    monotonic: Callable[[], float] = time.monotonic,
+    log: Callable[[str], None] = lambda _msg: None,
+) -> dict[str, Any]:
+    """Bounded rerun-and-wait to clear a superseded required-check visibility skew.
+
+    Re-runs the superseded stale-FAILURE run(s), then polls the live rollup until
+    the skew clears or the budget is spent. The timeout is split into ``max_reruns``
+    windows; a fresh re-trigger opens each window. Purely mechanical: only re-runs
+    already-superseded runs (see :func:`_superseded_run_ids`), never edits files,
+    never touches branch protection. Dependencies are injected so this is unit-
+    testable without the network or real sleeps.
+
+    Returns ``{cleared: bool, reruns: [...], triggers: int, reason: str}``.
+    """
+    rerun = rerun_run or (lambda rid: _rerun_workflow_run(rid, cwd=cwd, repo=repo))
+    reruns: list[dict[str, Any]] = []
+    current_skew: Mapping[str, Any] | None = skew_report
+    max_reruns = max(1, int(max_reruns))
+    window = timeout_seconds / max_reruns
+
+    for trigger in range(max_reruns):
+        if current_skew is None:
+            break
+        run_ids = _superseded_run_ids(current_skew)
+        if not run_ids:
+            return {
+                "cleared": False,
+                "reruns": reruns,
+                "triggers": trigger,
+                "reason": "no parseable superseded run id in skew report; cannot auto-resolve",
+            }
+        for run_id in run_ids:
+            ok = rerun(run_id)
+            reruns.append({"run_id": run_id, "ok": ok})
+            log(f"re-ran superseded merge-quorum run {run_id} (ok={ok})")
+
+        window_deadline = monotonic() + window
+        while monotonic() < window_deadline:
+            sleep(poll_seconds)
+            pr_view, _packet, required_checks = load_inputs()
+            current_skew = _required_check_visibility_skew_report(
+                pr=pr, head=head, pr_view=pr_view, required_checks=required_checks
+            )
+            if current_skew is None:
+                log("required-check visibility skew cleared")
+                return {
+                    "cleared": True,
+                    "reruns": reruns,
+                    "triggers": trigger + 1,
+                    "reason": "skew cleared after rerun-and-wait",
+                }
+
+    return {
+        "cleared": False,
+        "reruns": reruns,
+        "triggers": max_reruns,
+        "reason": "skew persisted after auto-resolve budget was exhausted",
     }
 
 
@@ -2020,6 +2131,36 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument("--json", action="store_true")
+    parser.add_argument(
+        "--skew-auto-resolve",
+        action="store_true",
+        help=(
+            "On --merge-apply, if a required_check_visibility_skew is detected "
+            "(a superseded stale-FAILURE required run lingering beside a newer "
+            "SUCCESS at the same head), automatically re-run the superseded run(s) "
+            "and wait, bounded, for the rollup to clear before applying. Only "
+            "re-runs already-superseded runs; never touches branch protection. "
+            "Default OFF (falls back to today's block + operator prompt)."
+        ),
+    )
+    parser.add_argument(
+        "--skew-max-reruns",
+        type=int,
+        default=1,
+        help="Max superseded-run re-trigger rounds for --skew-auto-resolve (default: 1).",
+    )
+    parser.add_argument(
+        "--skew-timeout-seconds",
+        type=float,
+        default=300.0,
+        help="Total wall-clock budget for --skew-auto-resolve (default: 300).",
+    )
+    parser.add_argument(
+        "--skew-poll-seconds",
+        type=float,
+        default=20.0,
+        help="Poll interval while waiting for the skew to clear (default: 20).",
+    )
     return parser
 
 
@@ -2124,6 +2265,32 @@ def main(argv: Sequence[str] | None = None) -> int:
                 pr_view=pr_view,
                 required_checks=required_checks,
             )
+            skew_auto_resolution: dict[str, Any] | None = None
+            if visibility_skew is not None and args.skew_auto_resolve:
+                skew_auto_resolution = _auto_resolve_visibility_skew(
+                    pr=args.pr,
+                    head=args.head,
+                    repo=args.repo,
+                    cwd=args.cwd,
+                    skew_report=visibility_skew,
+                    max_reruns=args.skew_max_reruns,
+                    timeout_seconds=args.skew_timeout_seconds,
+                    poll_seconds=args.skew_poll_seconds,
+                    load_inputs=lambda: _load_live_inputs(args.pr, cwd=args.cwd, repo=args.repo),
+                    log=lambda msg: None if args.json else print(msg),
+                )
+                if skew_auto_resolution.get("cleared"):
+                    # Skew is gone (the superseded run re-concluded green). Re-read
+                    # live inputs so the merge acts on current truth.
+                    pr_view, merge_packet, required_checks = _load_live_inputs(
+                        args.pr, cwd=args.cwd, repo=args.repo
+                    )
+                    visibility_skew = _required_check_visibility_skew_report(
+                        pr=args.pr,
+                        head=args.head,
+                        pr_view=pr_view,
+                        required_checks=required_checks,
+                    )
             if visibility_skew is not None:
                 out = {
                     "ok": False,
@@ -2133,11 +2300,18 @@ def main(argv: Sequence[str] | None = None) -> int:
                     "required_check_visibility_skew": visibility_skew,
                     "next_prompt": visibility_skew["next_prompt"],
                 }
+                if skew_auto_resolution is not None:
+                    out["skew_auto_resolution"] = skew_auto_resolution
                 if args.json:
                     print(json.dumps(out, indent=2, sort_keys=True))
                 else:
                     print("blocked")
                     print(f"- {REQUIRED_CHECK_VISIBILITY_SKEW_BLOCKER}")
+                    if skew_auto_resolution is not None:
+                        print(
+                            f"- skew-auto-resolve: {skew_auto_resolution.get('reason')} "
+                            f"(reruns={len(skew_auto_resolution.get('reruns') or [])})"
+                        )
                     print(visibility_skew["next_prompt"])
                 return 2
             applied_commands = _apply_merge(

--- a/scripts/settle_tier4_pr.py
+++ b/scripts/settle_tier4_pr.py
@@ -2285,6 +2285,26 @@ def main(argv: Sequence[str] | None = None) -> int:
                     pr_view, merge_packet, required_checks = _load_live_inputs(
                         args.pr, cwd=args.cwd, repo=args.repo
                     )
+                    # Re-evaluate the FULL gate on the fresh inputs — the reload
+                    # could have changed gate-relevant state (head moved, a required
+                    # check regressed, settlement invalidated); never merge on the
+                    # stale pre-resolve gate (#8750 openai [P1]).
+                    gate = evaluate_tier4_gate(
+                        pr=args.pr,
+                        expected_head=args.head,
+                        pr_view=pr_view,
+                        merge_packet=merge_packet,
+                        required_checks=required_checks,
+                        require_branch_protection_token=False,
+                        repo=args.repo,
+                        cwd=args.cwd,
+                        trusted_operator_logins=args.trusted_operator_login,
+                    )
+                    if not gate["ok"]:
+                        raise RuntimeError(
+                            "Tier 4 gate is not satisfied after skew auto-resolve "
+                            "reload; refusing --merge-apply"
+                        )
                     visibility_skew = _required_check_visibility_skew_report(
                         pr=args.pr,
                         head=args.head,

--- a/tests/scripts/test_settle_tier4_pr.py
+++ b/tests/scripts/test_settle_tier4_pr.py
@@ -3263,3 +3263,186 @@ def test_check_text_prints_merge_packet_reasons_when_blocked(
     assert "checks: 1 failing / 42 total" in out
     assert "counted_model_families: 0 []" in out
     assert "reason: model quorum incomplete: 0/2 signal(s)" in out
+
+
+# --- #8742: --skew-auto-resolve (bounded rerun-and-wait) --------------------
+
+
+def _skew_report(run_url: str) -> dict[str, Any]:
+    return {
+        "blocker": "required_check_visibility_skew",
+        "stale_failed_required_contexts": [
+            {"context": "aragora-merge-quorum", "details_url": run_url}
+        ],
+        "next_prompt": "…",
+    }
+
+
+def _incrementing_clock(step: float = 1.0):
+    state = {"t": 0.0}
+
+    def _now() -> float:
+        state["t"] += step
+        return state["t"]
+
+    return _now
+
+
+def test_superseded_run_ids_extracts_from_details_url() -> None:
+    report = {
+        "stale_failed_required_contexts": [
+            {"details_url": "https://github.com/o/r/actions/runs/28535700881/job/84596779648"},
+            {"details_url": "https://github.com/o/r/actions/runs/999/job/1"},
+            {"details_url": "no-run-here"},
+            {"details_url": "https://github.com/o/r/actions/runs/28535700881/job/2"},  # dup
+        ]
+    }
+    assert settler._superseded_run_ids(report) == ["28535700881", "999"]
+
+
+def test_auto_resolve_clears_after_rerun(monkeypatch: Any) -> None:
+    url = "https://github.com/o/r/actions/runs/123/job/9"
+    reports = [_skew_report(url), None]  # still skewed on 1st poll, clear on 2nd
+    calls = {"i": 0}
+
+    def _report(**_kwargs: Any):
+        i = calls["i"]
+        calls["i"] += 1
+        return reports[i] if i < len(reports) else None
+
+    monkeypatch.setattr(settler, "_required_check_visibility_skew_report", _report)
+    reran: list[str] = []
+    result = settler._auto_resolve_visibility_skew(
+        pr=1,
+        head="h",
+        repo="r",
+        cwd=Path("."),
+        skew_report=_skew_report(url),
+        max_reruns=1,
+        timeout_seconds=1000.0,
+        poll_seconds=1.0,
+        load_inputs=lambda: ({}, {}, []),
+        rerun_run=lambda rid: (reran.append(rid) or True),
+        sleep=lambda _s: None,
+        monotonic=_incrementing_clock(step=1.0),
+    )
+    assert result["cleared"] is True
+    assert reran == ["123"]
+    assert result["reruns"] == [{"run_id": "123", "ok": True}]
+
+
+def test_auto_resolve_times_out_when_skew_persists(monkeypatch: Any) -> None:
+    url = "https://github.com/o/r/actions/runs/123/job/9"
+    monkeypatch.setattr(
+        settler, "_required_check_visibility_skew_report", lambda **_k: _skew_report(url)
+    )
+    reran: list[str] = []
+    result = settler._auto_resolve_visibility_skew(
+        pr=1,
+        head="h",
+        repo="r",
+        cwd=Path("."),
+        skew_report=_skew_report(url),
+        max_reruns=1,
+        timeout_seconds=5.0,
+        poll_seconds=1.0,
+        load_inputs=lambda: ({}, {}, []),
+        rerun_run=lambda rid: (reran.append(rid) or True),
+        sleep=lambda _s: None,
+        monotonic=_incrementing_clock(step=2.0),  # expires the 5s window fast
+    )
+    assert result["cleared"] is False
+    assert reran == ["123"]  # it did try
+    assert "exhausted" in result["reason"]
+
+
+def test_auto_resolve_abstains_without_parseable_run_id() -> None:
+    report = _skew_report("no-run-id-here")
+    result = settler._auto_resolve_visibility_skew(
+        pr=1,
+        head="h",
+        repo="r",
+        cwd=Path("."),
+        skew_report=report,
+        max_reruns=1,
+        timeout_seconds=10.0,
+        poll_seconds=1.0,
+        load_inputs=lambda: ({}, {}, []),
+        rerun_run=lambda _rid: True,
+        sleep=lambda _s: None,
+        monotonic=_incrementing_clock(),
+    )
+    assert result["cleared"] is False
+    assert "no parseable" in result["reason"]
+
+
+def _skewed_then_clean_inputs(head: str, monkeypatch: Any):
+    """_load_live_inputs stub: skewed rollup on call 1, clean on calls >=2."""
+    state = {"n": 0}
+    stale = {
+        "__typename": "CheckRun",
+        "name": "aragora-merge-quorum",
+        "status": "COMPLETED",
+        "conclusion": "FAILURE",
+        "detailsUrl": "https://github.com/o/r/actions/runs/456/job/1",
+        "completedAt": "2026-06-13T01:49:55Z",
+    }
+    ok = {
+        "__typename": "CheckRun",
+        "name": "aragora-merge-quorum",
+        "status": "COMPLETED",
+        "conclusion": "SUCCESS",
+        "detailsUrl": "https://github.com/o/r/actions/runs/457/job/1",
+        "completedAt": "2026-06-13T01:50:41Z",
+    }
+
+    def _load(pr, cwd, repo=settler.DEFAULT_REPO):
+        state["n"] += 1
+        rollup = [stale, ok] if state["n"] == 1 else [ok]
+        return (
+            _pr_view(head, comments=[_authorized_comment(head)], extra_status_rollup=rollup),
+            _tier4_packet(),
+            _valid_checks(),
+        )
+
+    monkeypatch.setattr(settler, "_load_live_inputs", _load)
+    return state
+
+
+def test_merge_apply_auto_resolve_clears_skew_and_merges(
+    monkeypatch: Any, tmp_path: Path, capsys: Any
+) -> None:
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    _skewed_then_clean_inputs(head, monkeypatch)
+    commands: list[tuple[list[str], str | None]] = []
+    reran: list[str] = []
+    monkeypatch.setattr(
+        settler,
+        "_run_command",
+        lambda command, cwd, input_text=None: commands.append((command, input_text)),
+    )
+    monkeypatch.setattr(
+        settler,
+        "_rerun_workflow_run",
+        lambda run_id, cwd, repo: (reran.append(run_id) or True),
+    )
+
+    rc = settler.main(
+        [
+            "--merge-apply",
+            "--pr",
+            "7423",
+            "--head",
+            head,
+            "--cwd",
+            str(tmp_path),
+            "--json",
+            "--skew-auto-resolve",
+            "--skew-poll-seconds",
+            "0",
+        ]
+    )
+
+    assert reran == ["456"]  # re-ran the superseded failed run
+    assert commands != []  # merge proceeded after the skew cleared
+    assert rc == 0

--- a/tests/scripts/test_settle_tier4_pr.py
+++ b/tests/scripts/test_settle_tier4_pr.py
@@ -3446,3 +3446,54 @@ def test_merge_apply_auto_resolve_clears_skew_and_merges(
     assert reran == ["456"]  # re-ran the superseded failed run
     assert commands != []  # merge proceeded after the skew cleared
     assert rc == 0
+
+
+def test_merge_apply_auto_resolve_reblocks_if_gate_regresses(
+    monkeypatch: Any, tmp_path: Path, capsys: Any
+) -> None:
+    # #8750 openai [P1]: after --skew-auto-resolve clears and reloads inputs, the
+    # gate is RE-EVALUATED; if it is no longer ok on the fresh inputs, the merge
+    # must be refused (never merge on the stale pre-resolve gate).
+    head = "57c740022e3c432718462efa12ca79f1df4f674d"
+    _skewed_then_clean_inputs(head, monkeypatch)
+    commands: list[tuple[list[str], str | None]] = []
+    monkeypatch.setattr(
+        settler,
+        "_run_command",
+        lambda command, cwd, input_text=None: commands.append((command, input_text)),
+    )
+    monkeypatch.setattr(settler, "_rerun_workflow_run", lambda run_id, cwd, repo: True)
+    # Gate ok on the initial evaluation (so we enter merge-apply), then NOT ok on
+    # the post-resolve re-evaluation.
+    gate_calls = {"n": 0}
+    real_gate = settler.evaluate_tier4_gate
+
+    def _flaky_gate(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        gate_calls["n"] += 1
+        g = real_gate(*args, **kwargs)
+        if gate_calls["n"] >= 2:
+            g = dict(g)
+            g["ok"] = False
+            g["blockers"] = ["regressed after reload"]
+        return g
+
+    monkeypatch.setattr(settler, "evaluate_tier4_gate", _flaky_gate)
+
+    rc = settler.main(
+        [
+            "--merge-apply",
+            "--pr",
+            "7423",
+            "--head",
+            head,
+            "--cwd",
+            str(tmp_path),
+            "--skew-auto-resolve",
+            "--skew-poll-seconds",
+            "0",
+        ]
+    )
+
+    assert rc == 2
+    assert commands == []  # merge NOT applied
+    assert gate_calls["n"] >= 2  # the gate was re-evaluated post-resolve


### PR DESCRIPTION
Implements #8742.

## Problem
`--merge-apply` (correctly) refuses with `required_check_visibility_skew` when GitHub's GraphQL rollup still lists a **superseded stale-FAILURE** required run beside a newer SUCCESS at the same head — branch protection stays `BLOCKED` even though `gh pr checks --required` is green. Today a human must find the stale run and `gh run rerun` it, wait, then retry. Hit **3× in one session** (#8741, #8738, #8745), each the identical manual dance.

## Change
Opt-in `--skew-auto-resolve`: on skew, re-run the superseded run(s) and wait, bounded, for the rollup to clear, then apply.

**Guardrails**
- Only re-runs **genuinely superseded** runs — the skew report already restricts its stale contexts to required checks the `--required` surface reports GREEN, so a context whose *latest* run is actually failing is never re-run.
- Never edits files, never touches branch protection; only re-triggers CI.
- Bounded: `--skew-max-reruns` (1), `--skew-timeout-seconds` (300), `--skew-poll-seconds` (20). On timeout → today's exact block + operator prompt. **Byte-identical when the flag is off.**
- Emits `skew_auto_resolution` in `--json` / a one-line summary — no silent action.

## Verification
Composes the existing `_required_check_visibility_skew_report`; the poll loop injects `load_inputs`/`rerun`/`sleep`/`monotonic` so it's unit-tested with **no network or real sleeps**. 5 new tests (run-id extraction, clears-after-rerun, timeout, abstain-without-run-id, end-to-end `main()` clears+merges); full **101-test** settle_tier4 suite green; ruff + mypy clean.

**Tier 4** (modifies `settle_tier4_pr.py`, merge-authority tooling) — human-settled. Refs #8741, #8738, #8745.

🤖 Generated with [Claude Code](https://claude.com/claude-code)