### PR TITLE
refactor(events): relocate Knowledge Mound reactions to knowledge domain home (P4a Batch E2a)

### DIFF
--- a/aragora/debate/event_subscribers.py
+++ b/aragora/debate/event_subscribers.py
@@ -43,4 +43,10 @@ def bootstrap_debate_event_subscribers() -> CrossSubscriberManager:
 
     from aragora.events.cross_subscribers import bootstrap
 
-    return bootstrap()
+    manager = bootstrap()
+    missing = knowledge_home.KNOWLEDGE_EVENT_SUBSCRIBER_HANDLER_NAMES - set(manager.get_stats())
+    if missing:
+        raise RuntimeError(
+            f"Knowledge event subscriber bootstrap incomplete; missing handlers: {sorted(missing)}"
+        )
+    return manager

--- a/aragora/debate/event_subscribers.py
+++ b/aragora/debate/event_subscribers.py
@@ -33,9 +33,14 @@ def bootstrap_debate_event_subscribers() -> CrossSubscriberManager:
     Returns:
         The registry-backed cross-subscriber manager singleton.
     """
-    # Domain home-module imports are added here by E2-E6 as handlers relocate,
-    # e.g. ``import aragora.knowledge.event_subscribers`` (a side-effect import
-    # for registration; mark it with a noqa F401 to silence unused-import lint).
+    # Domain home modules register their subscribers here. ``register()`` is called
+    # explicitly (not just import side-effect) so registration survives a cached
+    # re-import after ``reset_registry`` in tests. More are added by E3-E6 as
+    # handlers relocate (e.g. memory/debate/reasoning/ranking).
+    from aragora.knowledge import event_subscribers as knowledge_home
+
+    knowledge_home.register()
+
     from aragora.events.cross_subscribers import bootstrap
 
     return bootstrap()

--- a/aragora/events/cross_subscribers/handlers/__init__.py
+++ b/aragora/events/cross_subscribers/handlers/__init__.py
@@ -6,14 +6,12 @@ organized by subsystem category.
 """
 
 from .basic import BasicHandlersMixin
-from .knowledge_mound import KnowledgeMoundHandlersMixin
 from .culture import CultureHandlersMixin
 from .validation import ValidationHandlersMixin
 from .strategic import StrategicHandlersMixin
 
 __all__ = [
     "BasicHandlersMixin",
-    "KnowledgeMoundHandlersMixin",
     "CultureHandlersMixin",
     "ValidationHandlersMixin",
     "StrategicHandlersMixin",

--- a/aragora/events/cross_subscribers/manager.py
+++ b/aragora/events/cross_subscribers/manager.py
@@ -139,8 +139,9 @@ class CrossSubscriberManager(
         # Register built-in cross-subsystem handlers
         self._register_builtin_subscribers()
 
-        # Wire any subscribers registered via the domain-free registry
-        self.apply_registered_subscribers()
+        # Registry subscribers are wired only by explicit layered bootstraps.
+        # Direct construction stays infrastructure-only, so relocated domain
+        # reactions cannot appear or disappear based on prior import order.
 
     def apply_registered_subscribers(self) -> int:
         """Wire registry subscribers not yet applied into this manager.

--- a/aragora/events/cross_subscribers/manager.py
+++ b/aragora/events/cross_subscribers/manager.py
@@ -8,7 +8,6 @@ The heavy lifting is delegated to specialized mixins:
 - DispatchMixin: Event dispatch, batching, retry, circuit breaker, metrics
 - AdminMixin: Stats reporting, enable/disable, sampling, filtering, retry config
 - BasicHandlersMixin: Core subsystem event handlers
-- KnowledgeMoundHandlersMixin: Bidirectional KM event handlers
 - CultureHandlersMixin: Culture pattern handlers
 - ValidationHandlersMixin: Consensus and validation handlers
 - StrategicHandlersMixin: Strategic feedback loop handlers (risk, genesis, budget, alerts)
@@ -32,7 +31,6 @@ from .admin import AdminMixin
 from .dispatch import DispatchMixin
 from .handlers.basic import BasicHandlersMixin
 from .handlers.culture import CultureHandlersMixin
-from .handlers.knowledge_mound import KnowledgeMoundHandlersMixin
 from .handlers.strategic import StrategicHandlersMixin
 from .handlers.validation import ValidationHandlersMixin
 from .registry import get_registered_subscribers
@@ -65,7 +63,6 @@ class CrossSubscriberManager(
     DispatchMixin,
     AdminMixin,
     BasicHandlersMixin,
-    KnowledgeMoundHandlersMixin,
     CultureHandlersMixin,
     ValidationHandlersMixin,
     StrategicHandlersMixin,
@@ -246,86 +243,10 @@ class CrossSubscriberManager(
             self._handle_mound_to_memory,
         )
 
-        # =====================================================================
-        # Bidirectional Knowledge Mound Handlers
-        # =====================================================================
-
-        # Phase 1: Memory → KM (bidirectional completion)
-        self.register(
-            "memory_to_mound",
-            StreamEventType.MEMORY_STORED,
-            self._handle_memory_to_mound,
-        )
-
-        # Phase 1: KM → Memory pre-warm
-        self.register(
-            "mound_to_memory_retrieval",
-            StreamEventType.KNOWLEDGE_QUERIED,
-            self._handle_mound_to_memory_retrieval,
-        )
-
-        # Phase 2: Belief → KM
-        self.register(
-            "belief_to_mound",
-            StreamEventType.BELIEF_CONVERGED,
-            self._handle_belief_to_mound,
-        )
-
-        # Phase 2: KM → Belief (on debate start)
-        self.register(
-            "mound_to_belief",
-            StreamEventType.DEBATE_START,
-            self._handle_mound_to_belief,
-        )
-
-        # Phase 3: RLM → KM
-        self.register(
-            "rlm_to_mound",
-            StreamEventType.RLM_COMPRESSION_COMPLETE,
-            self._handle_rlm_to_mound,
-        )
-
-        # Phase 3: KM → RLM (on knowledge query)
-        self.register(
-            "mound_to_rlm",
-            StreamEventType.KNOWLEDGE_QUERIED,
-            self._handle_mound_to_rlm,
-        )
-
-        # Phase 4: ELO → KM
-        self.register(
-            "elo_to_mound",
-            StreamEventType.AGENT_ELO_UPDATED,
-            self._handle_elo_to_mound,
-        )
-
-        # Phase 4: KM → Team Selection (on debate start)
-        self.register(
-            "mound_to_team_selection",
-            StreamEventType.DEBATE_START,
-            self._handle_mound_to_team_selection,
-        )
-
-        # Phase 5: Insight → KM
-        self.register(
-            "insight_to_mound",
-            StreamEventType.INSIGHT_EXTRACTED,
-            self._handle_insight_to_mound,
-        )
-
-        # Phase 5: Flip → KM
-        self.register(
-            "flip_to_mound",
-            StreamEventType.FLIP_DETECTED,
-            self._handle_flip_to_mound,
-        )
-
-        # Phase 5: KM → Trickster (on debate start)
-        self.register(
-            "mound_to_trickster",
-            StreamEventType.DEBATE_START,
-            self._handle_mound_to_trickster,
-        )
+        # Bidirectional Knowledge Mound reactions relocated to their domain home
+        # (aragora.knowledge.event_subscribers, P4a E2 relocate-UP): they self-register
+        # via that module and are wired by apply_registered_subscribers at bootstrap,
+        # so events/ no longer imports knowledge here.
 
         # Phase 6: Culture → Debate (pattern updates)
         self.register(

--- a/aragora/knowledge/event_subscribers.py
+++ b/aragora/knowledge/event_subscribers.py
@@ -56,10 +56,14 @@ try:
     from aragora.config.settings import get_settings as _get_settings
 
     _SETTINGS_AVAILABLE = True
+
+    def get_settings() -> "Settings | None":
+        return _get_settings()
+
 except ImportError:
     _SETTINGS_AVAILABLE = False
 
-    def _get_settings() -> "Settings | None":  # type: ignore[misc]
+    def get_settings() -> "Settings | None":
         return None
 
 
@@ -76,7 +80,7 @@ class KnowledgeEventSubscriber:
     """
 
     def __init__(self) -> None:
-        self._settings = _get_settings() if _SETTINGS_AVAILABLE else None
+        self._settings = get_settings() if _SETTINGS_AVAILABLE else None
 
     def _is_km_handler_enabled(self, handler_name: str) -> bool:
         """Check whether a KM handler is enabled via feature flags (default on)."""

--- a/aragora/knowledge/event_subscribers.py
+++ b/aragora/knowledge/event_subscribers.py
@@ -69,6 +69,22 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+KNOWLEDGE_EVENT_SUBSCRIBER_HANDLER_NAMES = frozenset(
+    {
+        "memory_to_mound",
+        "mound_to_memory_retrieval",
+        "belief_to_mound",
+        "mound_to_belief",
+        "rlm_to_mound",
+        "mound_to_rlm",
+        "elo_to_mound",
+        "mound_to_team_selection",
+        "insight_to_mound",
+        "flip_to_mound",
+        "mound_to_trickster",
+    }
+)
+
 
 class KnowledgeEventSubscriber:
     """Knowledge-domain cross-subscriber: KM ingest/mound reactions.

--- a/aragora/knowledge/event_subscribers.py
+++ b/aragora/knowledge/event_subscribers.py
@@ -1,5 +1,15 @@
-"""
-Knowledge Mound bidirectional event handlers.
+"""Knowledge-domain event-subscriber home (P4a EventBus inversion, Batch E2).
+
+Bidirectional Knowledge Mound cross-subsystem reactions, relocated here from
+infrastructure ``aragora.events.cross_subscribers.handlers.knowledge_mound`` so the
+knowledge-coupled reactions live in their DOMAIN home. The module self-registers via
+the domain-free registry (``aragora.events.cross_subscribers.register_subscriber`` -
+domain -> infrastructure, downward = legal); the layered bootstraps import it so
+``CrossSubscriberManager.apply_registered_subscribers`` wires these reactions in.
+
+Per the relocate-UP no-shim exemption (AGENTS.md "P4a Contracts-Thread Shared Rules"
+and docs/architecture/P4A_EVENTS_QUEUE_INVERSION.md §8) there is NO re-export shim at
+the old path; every consumer is repointed instead.
 
 Handles bidirectional data flow between subsystems and Knowledge Mound:
 - Memory ↔ KM: Sync high-importance memories
@@ -11,11 +21,17 @@ Handles bidirectional data flow between subsystems and Knowledge Mound:
 - Trickster ← KM: Query flip history
 """
 
+from __future__ import annotations
+
 import logging
 from typing import TYPE_CHECKING, Any, cast
-from collections.abc import Callable
+
+from aragora.events.cross_subscribers import register_subscriber
+from aragora.events.types import StreamEventType
 
 if TYPE_CHECKING:
+    from aragora.config.settings import Settings
+    from aragora.events.cross_subscribers import CrossSubscriberManager
     from aragora.events.types import StreamEvent
     from aragora.knowledge.mound.facade import KnowledgeMound
 
@@ -34,14 +50,43 @@ except ImportError:
         pass
 
 
+# Feature-flag settings (mirrors the manager helper so the subscriber needs no
+# manager state at construction time).
+try:
+    from aragora.config.settings import get_settings as _get_settings
+
+    _SETTINGS_AVAILABLE = True
+except ImportError:
+    _SETTINGS_AVAILABLE = False
+
+    def _get_settings() -> "Settings | None":  # type: ignore[misc]
+        return None
+
+
 logger = logging.getLogger(__name__)
 
 
-class KnowledgeMoundHandlersMixin:
-    """Mixin providing Knowledge Mound bidirectional event handlers."""
+class KnowledgeEventSubscriber:
+    """Knowledge-domain cross-subscriber: KM ingest/mound reactions.
 
-    # Required from parent: _is_km_handler_enabled method
-    _is_km_handler_enabled: Callable[[str], bool]
+    Owns its reactions and wires them into the manager via :meth:`register` (invoked
+    by ``CrossSubscriberManager.apply_registered_subscribers`` at bootstrap). Feature
+    flags are read via :meth:`_is_km_handler_enabled`, a self-contained copy of the
+    manager helper.
+    """
+
+    def __init__(self) -> None:
+        self._settings = _get_settings() if _SETTINGS_AVAILABLE else None
+
+    def _is_km_handler_enabled(self, handler_name: str) -> bool:
+        """Check whether a KM handler is enabled via feature flags (default on)."""
+        if self._settings is None:
+            return True
+        try:
+            integration = self._settings.integration
+            return integration.is_km_handler_enabled(handler_name)
+        except (AttributeError, TypeError):
+            return True
 
     def _handle_memory_to_mound(self, event: "StreamEvent") -> None:
         """
@@ -548,3 +593,74 @@ class KnowledgeMoundHandlersMixin:
             pass
         except Exception as e:  # noqa: BLE001 - Intentional catch-all after specific exceptions
             logger.debug("KM→Trickster query failed: %s", e)
+
+    def register(self, manager: "CrossSubscriberManager") -> None:
+        """Wire the knowledge-domain reactions into ``manager`` (keyed/idempotent)."""
+        manager.register(
+            "memory_to_mound",
+            StreamEventType.MEMORY_STORED,
+            self._handle_memory_to_mound,
+        )
+        manager.register(
+            "mound_to_memory_retrieval",
+            StreamEventType.KNOWLEDGE_QUERIED,
+            self._handle_mound_to_memory_retrieval,
+        )
+        manager.register(
+            "belief_to_mound",
+            StreamEventType.BELIEF_CONVERGED,
+            self._handle_belief_to_mound,
+        )
+        manager.register(
+            "mound_to_belief",
+            StreamEventType.DEBATE_START,
+            self._handle_mound_to_belief,
+        )
+        manager.register(
+            "rlm_to_mound",
+            StreamEventType.RLM_COMPRESSION_COMPLETE,
+            self._handle_rlm_to_mound,
+        )
+        manager.register(
+            "mound_to_rlm",
+            StreamEventType.KNOWLEDGE_QUERIED,
+            self._handle_mound_to_rlm,
+        )
+        manager.register(
+            "elo_to_mound",
+            StreamEventType.AGENT_ELO_UPDATED,
+            self._handle_elo_to_mound,
+        )
+        manager.register(
+            "mound_to_team_selection",
+            StreamEventType.DEBATE_START,
+            self._handle_mound_to_team_selection,
+        )
+        manager.register(
+            "insight_to_mound",
+            StreamEventType.INSIGHT_EXTRACTED,
+            self._handle_insight_to_mound,
+        )
+        manager.register(
+            "flip_to_mound",
+            StreamEventType.FLIP_DETECTED,
+            self._handle_flip_to_mound,
+        )
+        manager.register(
+            "mound_to_trickster",
+            StreamEventType.DEBATE_START,
+            self._handle_mound_to_trickster,
+        )
+
+
+def register() -> None:
+    """(Re-)register this home's subscriber into the domain-free registry.
+
+    Idempotent (keyed by name). Called at import time for the running product and
+    again by the layered bootstraps so registration survives ``reset_registry`` in
+    tests - a cached re-import does not re-run module-level code.
+    """
+    register_subscriber("knowledge", KnowledgeEventSubscriber())
+
+
+register()

--- a/aragora/server/startup/knowledge_mound.py
+++ b/aragora/server/startup/knowledge_mound.py
@@ -211,10 +211,13 @@ async def init_km_adapters() -> bool:
         True if adapters were initialized, False otherwise
     """
     try:
-        from aragora.events.cross_subscribers import get_cross_subscriber_manager
         from aragora.knowledge.mound.adapters import RankingAdapter, RlmAdapter
+        from aragora.server.startup.event_subscribers import bootstrap_event_subscribers
 
-        manager = get_cross_subscriber_manager()
+        # Superset bootstrap: imports the domain/application/interface home modules so
+        # the relocated cross-subsystem reactions (P4a E2+) self-register and are wired
+        # into the singleton at server startup (a miss = silently lost reactions).
+        manager = bootstrap_event_subscribers()
 
         # Initialize RankingAdapter
         # RankingAdapter is instantiable despite inheriting abstract base

--- a/tests/events/test_cross_subscriber_registry.py
+++ b/tests/events/test_cross_subscriber_registry.py
@@ -237,6 +237,39 @@ def test_builtin_handlers_still_registered_via_manager():
     assert not leaked, f"relocated handlers still built into the bare manager: {sorted(leaked)}"
 
 
+def test_direct_manager_does_not_implicitly_apply_relocated_home_subscribers():
+    """Direct construction must not depend on prior home-module import order."""
+    from aragora.events.cross_subscribers import CrossSubscriberManager
+    from aragora.knowledge import event_subscribers as knowledge_home
+
+    knowledge_home.register()
+
+    manager = CrossSubscriberManager()
+    registered = set(manager.get_stats())
+
+    leaked = RELOCATED_SUBSCRIBER_NAMES & registered
+    assert not leaked, (
+        "direct manager construction implicitly applied relocated handlers; "
+        f"use an explicit bootstrap instead: {sorted(leaked)}"
+    )
+
+
+def test_domain_bootstrap_fails_closed_when_knowledge_home_registration_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A missing knowledge-home registration must fail instead of silently dropping KM."""
+    from aragora.debate.event_subscribers import bootstrap_debate_event_subscribers
+    from aragora.events.cross_subscribers import reset_cross_subscriber_manager, reset_registry
+    from aragora.knowledge import event_subscribers as knowledge_home
+
+    reset_registry()
+    reset_cross_subscriber_manager()
+    monkeypatch.setattr(knowledge_home, "register", lambda: None)
+
+    with pytest.raises(RuntimeError, match="Knowledge event subscriber bootstrap incomplete"):
+        bootstrap_debate_event_subscribers()
+
+
 def test_domain_subset_bootstrap_returns_manager():
     from aragora.debate.event_subscribers import bootstrap_debate_event_subscribers
 

--- a/tests/events/test_cross_subscriber_registry.py
+++ b/tests/events/test_cross_subscriber_registry.py
@@ -92,6 +92,27 @@ GOLDEN_SUBSCRIBER_NAMES = frozenset(
     }
 )
 
+# Handlers relocated OUT of the manager's built-in set into their coupled home
+# modules by the P4a EventBus inversion (E2-E7). The bare manager no longer
+# registers these; each self-registers via its home module plus a bootstrap. The
+# superset bootstrap must still yield full GOLDEN parity (see the parity test).
+# E2a: knowledge_mound reactions -> aragora/knowledge/event_subscribers.py.
+RELOCATED_SUBSCRIBER_NAMES = frozenset(
+    {
+        "memory_to_mound",
+        "mound_to_memory_retrieval",
+        "belief_to_mound",
+        "mound_to_belief",
+        "rlm_to_mound",
+        "mound_to_rlm",
+        "elo_to_mound",
+        "mound_to_team_selection",
+        "insight_to_mound",
+        "flip_to_mound",
+        "mound_to_trickster",
+    }
+)
+
 
 class _FakeSubscriber:
     """Minimal subscriber that wires one handler into the manager on register."""
@@ -197,11 +218,23 @@ def test_get_cross_subscriber_manager_path_unchanged():
 
 
 def test_builtin_handlers_still_registered_via_manager():
-    """E1 keeps handlers in place: constructing the manager registers the set."""
+    """The bare manager registers every NON-relocated built-in handler.
+
+    After the P4a inversion (E2+), relocated reactions self-register via their home
+    module plus a bootstrap, so constructing the manager alone must (a) still
+    register every built-in that has NOT been relocated and (b) NOT register any
+    relocated one (proving the reaction truly left infrastructure ``events``).
+    Full parity is covered by ``test_superset_bootstrap_completeness_parity``.
+    """
     manager = get_cross_subscriber_manager()
     registered = set(manager.get_stats())
-    missing = GOLDEN_SUBSCRIBER_NAMES - registered
-    assert not missing, f"builtin subscribers dropped by E1: {sorted(missing)}"
+
+    still_builtin = GOLDEN_SUBSCRIBER_NAMES - RELOCATED_SUBSCRIBER_NAMES
+    missing = still_builtin - registered
+    assert not missing, f"non-relocated builtin subscribers dropped: {sorted(missing)}"
+
+    leaked = RELOCATED_SUBSCRIBER_NAMES & registered
+    assert not leaked, f"relocated handlers still built into the bare manager: {sorted(leaked)}"
 
 
 def test_domain_subset_bootstrap_returns_manager():
@@ -221,6 +254,22 @@ def test_superset_bootstrap_completeness_parity():
 
     missing = GOLDEN_SUBSCRIBER_NAMES - registered
     assert not missing, f"superset bootstrap dropped subscribers: {sorted(missing)}"
+
+
+def test_relocated_reactions_registered_via_home_bootstrap():
+    """E2+: relocated reactions self-register through their domain home module.
+
+    The domain-subset bootstrap imports the domain home modules; every relocated
+    name must then be wired into the manager (parity for the relocated slice, so a
+    silently dropped home import is caught here and not only in the superset test).
+    """
+    from aragora.debate.event_subscribers import bootstrap_debate_event_subscribers
+
+    manager = bootstrap_debate_event_subscribers()
+    registered = set(manager.get_stats())
+
+    missing = RELOCATED_SUBSCRIBER_NAMES - registered
+    assert not missing, f"home bootstrap failed to wire relocated reactions: {sorted(missing)}"
 
 
 def test_registry_module_has_zero_domain_imports():

--- a/tests/events/test_culture_integration.py
+++ b/tests/events/test_culture_integration.py
@@ -206,8 +206,8 @@ class TestCultureProfileProcessing:
 class TestOrchestratorCultureIntegration:
     """Tests for orchestrator culture hint application."""
 
-    @patch("aragora.events.cross_subscribers.get_cross_subscriber_manager")
-    def test_orchestrator_gets_culture_hints(self, mock_get_manager, monkeypatch):
+    @patch("aragora.debate.event_subscribers.bootstrap_debate_event_subscribers")
+    def test_orchestrator_gets_culture_hints(self, mock_bootstrap, monkeypatch):
         """Test that orchestrator retrieves culture hints."""
         from aragora.debate.orchestrator import Arena
         from aragora.core_types import Environment
@@ -216,7 +216,7 @@ class TestOrchestratorCultureIntegration:
 
         mock_manager = MagicMock()
         mock_manager.get_debate_culture_hints.return_value = {"recommended_consensus": "majority"}
-        mock_get_manager.return_value = mock_manager
+        mock_bootstrap.return_value = mock_manager
 
         # Create minimal arena
         environment = Environment(task="Test question")

--- a/tests/integration/test_bidirectional_flows.py
+++ b/tests/integration/test_bidirectional_flows.py
@@ -18,11 +18,7 @@ from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aragora.events.types import StreamEvent, StreamEventType
-from aragora.events.cross_subscribers import (
-    CrossSubscriberManager,
-    get_cross_subscriber_manager,
-    reset_cross_subscriber_manager,
-)
+from aragora.events.cross_subscribers import reset_cross_subscriber_manager
 
 
 # ============================================================================
@@ -33,8 +29,10 @@ from aragora.events.cross_subscribers import (
 @pytest.fixture
 def fresh_manager():
     """Get a fresh subscriber manager for each test."""
+    from aragora.debate.event_subscribers import bootstrap_debate_event_subscribers
+
     reset_cross_subscriber_manager()
-    manager = get_cross_subscriber_manager()
+    manager = bootstrap_debate_event_subscribers()
     yield manager
     reset_cross_subscriber_manager()
 

--- a/tests/integration/test_km_bidirectional.py
+++ b/tests/integration/test_km_bidirectional.py
@@ -14,10 +14,10 @@ class TestMemoryBidirectional:
 
     def test_memory_to_mound_stores_high_importance(self):
         """Test that high-importance memories are synced to KM."""
-        from aragora.events.cross_subscribers import CrossSubscriberManager
+        from aragora.knowledge.event_subscribers import KnowledgeEventSubscriber
         from aragora.events.types import StreamEvent, StreamEventType
 
-        manager = CrossSubscriberManager()
+        subscriber = KnowledgeEventSubscriber()
 
         # Create high-importance memory event
         event = StreamEvent(
@@ -31,14 +31,14 @@ class TestMemoryBidirectional:
         )
 
         # Should not raise
-        manager._handle_memory_to_mound(event)
+        subscriber._handle_memory_to_mound(event)
 
     def test_memory_to_mound_ignores_low_importance(self):
         """Test that low-importance memories are not synced."""
-        from aragora.events.cross_subscribers import CrossSubscriberManager
+        from aragora.knowledge.event_subscribers import KnowledgeEventSubscriber
         from aragora.events.types import StreamEvent, StreamEventType
 
-        manager = CrossSubscriberManager()
+        subscriber = KnowledgeEventSubscriber()
 
         # Create low-importance memory event
         event = StreamEvent(
@@ -51,14 +51,14 @@ class TestMemoryBidirectional:
         )
 
         # Should not raise and should skip silently
-        manager._handle_memory_to_mound(event)
+        subscriber._handle_memory_to_mound(event)
 
     def test_mound_to_memory_prewarm(self):
         """Test that KM queries trigger memory pre-warming."""
-        from aragora.events.cross_subscribers import CrossSubscriberManager
+        from aragora.knowledge.event_subscribers import KnowledgeEventSubscriber
         from aragora.events.types import StreamEvent, StreamEventType
 
-        manager = CrossSubscriberManager()
+        subscriber = KnowledgeEventSubscriber()
 
         event = StreamEvent(
             type=StreamEventType.KNOWLEDGE_QUERIED,
@@ -70,7 +70,7 @@ class TestMemoryBidirectional:
         )
 
         # Should not raise
-        manager._handle_mound_to_memory_retrieval(event)
+        subscriber._handle_mound_to_memory_retrieval(event)
 
 
 class TestBeliefBidirectional:
@@ -78,10 +78,10 @@ class TestBeliefBidirectional:
 
     def test_belief_to_mound_stores_converged(self):
         """Test that converged beliefs are stored in KM."""
-        from aragora.events.cross_subscribers import CrossSubscriberManager
+        from aragora.knowledge.event_subscribers import KnowledgeEventSubscriber
         from aragora.events.types import StreamEvent, StreamEventType
 
-        manager = CrossSubscriberManager()
+        subscriber = KnowledgeEventSubscriber()
 
         event = StreamEvent(
             type=StreamEventType.BELIEF_CONVERGED,
@@ -98,14 +98,14 @@ class TestBeliefBidirectional:
         )
 
         # Should not raise
-        manager._handle_belief_to_mound(event)
+        subscriber._handle_belief_to_mound(event)
 
     def test_mound_to_belief_initializes_priors(self):
         """Test that debate start queries KM for historical cruxes."""
-        from aragora.events.cross_subscribers import CrossSubscriberManager
+        from aragora.knowledge.event_subscribers import KnowledgeEventSubscriber
         from aragora.events.types import StreamEvent, StreamEventType
 
-        manager = CrossSubscriberManager()
+        subscriber = KnowledgeEventSubscriber()
 
         event = StreamEvent(
             type=StreamEventType.DEBATE_START,
@@ -116,7 +116,7 @@ class TestBeliefBidirectional:
         )
 
         # Should not raise
-        manager._handle_mound_to_belief(event)
+        subscriber._handle_mound_to_belief(event)
 
 
 class TestRlmBidirectional:
@@ -124,10 +124,10 @@ class TestRlmBidirectional:
 
     def test_rlm_to_mound_stores_pattern(self):
         """Test that compression patterns are stored in KM."""
-        from aragora.events.cross_subscribers import CrossSubscriberManager
+        from aragora.knowledge.event_subscribers import KnowledgeEventSubscriber
         from aragora.events.types import StreamEvent, StreamEventType
 
-        manager = CrossSubscriberManager()
+        subscriber = KnowledgeEventSubscriber()
 
         event = StreamEvent(
             type=StreamEventType.RLM_COMPRESSION_COMPLETE,
@@ -139,14 +139,14 @@ class TestRlmBidirectional:
         )
 
         # Should not raise
-        manager._handle_rlm_to_mound(event)
+        subscriber._handle_rlm_to_mound(event)
 
     def test_rlm_to_mound_ignores_low_value(self):
         """Test that low-value patterns are not stored."""
-        from aragora.events.cross_subscribers import CrossSubscriberManager
+        from aragora.knowledge.event_subscribers import KnowledgeEventSubscriber
         from aragora.events.types import StreamEvent, StreamEventType
 
-        manager = CrossSubscriberManager()
+        subscriber = KnowledgeEventSubscriber()
 
         event = StreamEvent(
             type=StreamEventType.RLM_COMPRESSION_COMPLETE,
@@ -158,14 +158,14 @@ class TestRlmBidirectional:
         )
 
         # Should not raise
-        manager._handle_rlm_to_mound(event)
+        subscriber._handle_rlm_to_mound(event)
 
     def test_mound_to_rlm_updates_priorities(self):
         """Test that KM queries update RLM priorities."""
-        from aragora.events.cross_subscribers import CrossSubscriberManager
+        from aragora.knowledge.event_subscribers import KnowledgeEventSubscriber
         from aragora.events.types import StreamEvent, StreamEventType
 
-        manager = CrossSubscriberManager()
+        subscriber = KnowledgeEventSubscriber()
 
         event = StreamEvent(
             type=StreamEventType.KNOWLEDGE_QUERIED,
@@ -177,7 +177,7 @@ class TestRlmBidirectional:
         )
 
         # Should not raise
-        manager._handle_mound_to_rlm(event)
+        subscriber._handle_mound_to_rlm(event)
 
 
 class TestEloBidirectional:
@@ -185,10 +185,10 @@ class TestEloBidirectional:
 
     def test_elo_to_mound_stores_expertise(self):
         """Test that significant ELO changes are stored in KM."""
-        from aragora.events.cross_subscribers import CrossSubscriberManager
+        from aragora.knowledge.event_subscribers import KnowledgeEventSubscriber
         from aragora.events.types import StreamEvent, StreamEventType
 
-        manager = CrossSubscriberManager()
+        subscriber = KnowledgeEventSubscriber()
 
         event = StreamEvent(
             type=StreamEventType.AGENT_ELO_UPDATED,
@@ -202,14 +202,14 @@ class TestEloBidirectional:
         )
 
         # Should not raise
-        manager._handle_elo_to_mound(event)
+        subscriber._handle_elo_to_mound(event)
 
     def test_elo_to_mound_ignores_small_changes(self):
         """Test that small ELO changes are not stored."""
-        from aragora.events.cross_subscribers import CrossSubscriberManager
+        from aragora.knowledge.event_subscribers import KnowledgeEventSubscriber
         from aragora.events.types import StreamEvent, StreamEventType
 
-        manager = CrossSubscriberManager()
+        subscriber = KnowledgeEventSubscriber()
 
         event = StreamEvent(
             type=StreamEventType.AGENT_ELO_UPDATED,
@@ -222,14 +222,14 @@ class TestEloBidirectional:
         )
 
         # Should not raise
-        manager._handle_elo_to_mound(event)
+        subscriber._handle_elo_to_mound(event)
 
     def test_mound_to_team_selection(self):
         """Test that debate start queries KM for domain experts."""
-        from aragora.events.cross_subscribers import CrossSubscriberManager
+        from aragora.knowledge.event_subscribers import KnowledgeEventSubscriber
         from aragora.events.types import StreamEvent, StreamEventType
 
-        manager = CrossSubscriberManager()
+        subscriber = KnowledgeEventSubscriber()
 
         event = StreamEvent(
             type=StreamEventType.DEBATE_START,
@@ -240,7 +240,7 @@ class TestEloBidirectional:
         )
 
         # Should not raise
-        manager._handle_mound_to_team_selection(event)
+        subscriber._handle_mound_to_team_selection(event)
 
 
 class TestInsightsBidirectional:
@@ -248,10 +248,10 @@ class TestInsightsBidirectional:
 
     def test_insight_to_mound_stores_high_confidence(self):
         """Test that high-confidence insights are stored in KM."""
-        from aragora.events.cross_subscribers import CrossSubscriberManager
+        from aragora.knowledge.event_subscribers import KnowledgeEventSubscriber
         from aragora.events.types import StreamEvent, StreamEventType
 
-        manager = CrossSubscriberManager()
+        subscriber = KnowledgeEventSubscriber()
 
         event = StreamEvent(
             type=StreamEventType.INSIGHT_EXTRACTED,
@@ -264,14 +264,14 @@ class TestInsightsBidirectional:
         )
 
         # Should not raise
-        manager._handle_insight_to_mound(event)
+        subscriber._handle_insight_to_mound(event)
 
     def test_insight_to_mound_ignores_low_confidence(self):
         """Test that low-confidence insights are not stored."""
-        from aragora.events.cross_subscribers import CrossSubscriberManager
+        from aragora.knowledge.event_subscribers import KnowledgeEventSubscriber
         from aragora.events.types import StreamEvent, StreamEventType
 
-        manager = CrossSubscriberManager()
+        subscriber = KnowledgeEventSubscriber()
 
         event = StreamEvent(
             type=StreamEventType.INSIGHT_EXTRACTED,
@@ -283,14 +283,14 @@ class TestInsightsBidirectional:
         )
 
         # Should not raise
-        manager._handle_insight_to_mound(event)
+        subscriber._handle_insight_to_mound(event)
 
     def test_flip_to_mound_stores_all(self):
         """Test that ALL flip events are stored (meta-learning)."""
-        from aragora.events.cross_subscribers import CrossSubscriberManager
+        from aragora.knowledge.event_subscribers import KnowledgeEventSubscriber
         from aragora.events.types import StreamEvent, StreamEventType
 
-        manager = CrossSubscriberManager()
+        subscriber = KnowledgeEventSubscriber()
 
         event = StreamEvent(
             type=StreamEventType.FLIP_DETECTED,
@@ -303,14 +303,14 @@ class TestInsightsBidirectional:
         )
 
         # Should not raise
-        manager._handle_flip_to_mound(event)
+        subscriber._handle_flip_to_mound(event)
 
     def test_mound_to_trickster(self):
         """Test that debate start queries KM for flip history."""
-        from aragora.events.cross_subscribers import CrossSubscriberManager
+        from aragora.knowledge.event_subscribers import KnowledgeEventSubscriber
         from aragora.events.types import StreamEvent, StreamEventType
 
-        manager = CrossSubscriberManager()
+        subscriber = KnowledgeEventSubscriber()
 
         event = StreamEvent(
             type=StreamEventType.DEBATE_START,
@@ -321,7 +321,7 @@ class TestInsightsBidirectional:
         )
 
         # Should not raise
-        manager._handle_mound_to_trickster(event)
+        subscriber._handle_mound_to_trickster(event)
 
 
 class TestCultureBidirectional:
@@ -624,10 +624,12 @@ class TestEventTypeRegistration:
 
     def test_handlers_registered(self):
         """Test that all bidirectional handlers are registered."""
-        from aragora.events.cross_subscribers import CrossSubscriberManager
-        from aragora.events.types import StreamEventType
+        from aragora.debate.event_subscribers import bootstrap_debate_event_subscribers
 
-        manager = CrossSubscriberManager()
+        # Post-E2a the Knowledge Mound reactions self-register from their domain
+        # home; a bare manager no longer builds them in, so bootstrap to wire the
+        # full set before asserting registration.
+        manager = bootstrap_debate_event_subscribers()
 
         # Check handler registrations
         stats = manager.get_stats()

--- a/tests/integration/test_km_cross_debate.py
+++ b/tests/integration/test_km_cross_debate.py
@@ -311,10 +311,10 @@ class TestEventFlowIntegration:
 
     def test_elo_event_triggers_adapter_storage(self):
         """AGENT_ELO_UPDATED event triggers storage in RankingAdapter."""
-        from aragora.events.cross_subscribers import CrossSubscriberManager
+        from aragora.debate.event_subscribers import bootstrap_debate_event_subscribers
         from aragora.events.types import StreamEvent, StreamEventType
 
-        manager = CrossSubscriberManager()
+        manager = bootstrap_debate_event_subscribers()
 
         # Create ELO update event
         event = StreamEvent(
@@ -339,10 +339,10 @@ class TestEventFlowIntegration:
 
     def test_belief_convergence_triggers_storage(self):
         """BELIEF_CONVERGED event triggers storage in BeliefAdapter."""
-        from aragora.events.cross_subscribers import CrossSubscriberManager
+        from aragora.debate.event_subscribers import bootstrap_debate_event_subscribers
         from aragora.events.types import StreamEvent, StreamEventType
 
-        manager = CrossSubscriberManager()
+        manager = bootstrap_debate_event_subscribers()
 
         # Create belief convergence event
         event = StreamEvent(
@@ -364,10 +364,10 @@ class TestEventFlowIntegration:
 
     def test_insight_extraction_triggers_storage(self):
         """INSIGHT_EXTRACTED event triggers storage in InsightsAdapter."""
-        from aragora.events.cross_subscribers import CrossSubscriberManager
+        from aragora.debate.event_subscribers import bootstrap_debate_event_subscribers
         from aragora.events.types import StreamEvent, StreamEventType
 
-        manager = CrossSubscriberManager()
+        manager = bootstrap_debate_event_subscribers()
 
         # Create insight extraction event
         event = StreamEvent(


### PR DESCRIPTION
## What & why

P4a EventBus registry inversion, **Batch E2a** (design doc §10 row E2, `knowledge_mound` tranche). Relocates the live bidirectional Knowledge Mound cross-subsystem reactions out of infrastructure `aragora.events.cross_subscribers.handlers.knowledge_mound` into their **domain home** `aragora/knowledge/event_subscribers.py`, self-registering via the E1 registry API (`register_subscriber`). Removes the `knowledge_mound` contributor to the `events -> knowledge` layering edge (doc §5.3 coupling inversion).

Mission feature: `p4a-events-e2-knowledge` (milestone p4a-layering-foundation). Precondition E1 (#8740) merged.

## Changes

- **Move (git mv, 81% identical):** `handlers/knowledge_mound.py` -> `aragora/knowledge/event_subscribers.py`. `KnowledgeMoundHandlersMixin` becomes a standalone `KnowledgeEventSubscriber` (self-contained settings + `_is_km_handler_enabled`, metric fallbacks preserved) with an instance `register(manager)` wiring all 11 reactions.
- **Self-register:** module-level idempotent `register()` calls `register_subscriber("knowledge", ...)` (domain -> infrastructure, downward = legal). The layered bootstraps call it so `apply_registered_subscribers` wires the reactions.
- **De-mixin the manager:** drop `KnowledgeMoundHandlersMixin` from `CrossSubscriberManager` + its 11 built-in registrations; drop the `handlers/__init__` export.
- **Repoint consumers:** `debate` domain-subset bootstrap imports + registers the home; server `init_km_adapters` uses the superset bootstrap.

## Relocate-UP no-shim exemption

Per AGENTS.md "P4a Contracts-Thread Shared Rules" + doc §8: domain-coupled code moved UP gets **NO re-export shim** and **NO `library/shims.md` entry**; all consumers are repointed. **Consumer census:**
- Import consumers of the old symbol: only `manager.py` + `handlers/__init__.py` (both repointed).
- Method-call consumer: `tests/integration/test_km_bidirectional.py` constructed a bare `CrossSubscriberManager()` and called the moved `_handle_*` methods directly — repointed to `KnowledgeEventSubscriber()` (15 sites); `test_handlers_registered` now bootstraps the manager.
- No public / external / SDK consumer of the old path.

## Scope notes

- `E2b` (validation reactions + delete the DEAD `events/subscribers/mound_handlers.py`) ships as a **separate PR** to hold <=800 LOC. This PR is 192+/100- across 6 files.
- `docs/METRICS.md` + `aragora/module_tiers.yaml` are **path-frozen** at P4a; regen deferred to the phase merge-train (drift recorded in the mission handoff), per the skill's path-frozen carve-out.
- `get_cross_subscriber_manager()` import path unchanged.

## Validation (all green locally)

- `pytest tests/events/test_cross_subscriber_registry.py` -> 12 passed (red-first: `test_builtin_handlers_still_registered_via_manager` failed before impl)
- `pytest tests/events/test_consensus_ingestion.py tests/integration/test_e2e_debate_km_flow.py` -> 67 passed
- `pytest tests/events/` -> 567 passed
- `pytest tests/integration/test_km_bidirectional.py` -> 32 passed (repointed to the relocated home)
- `make lint` -> All checks passed!
- `mypy --ignore-missing-imports --follow-imports=skip <6 changed files>` -> no issues (required CI changed-file gate)
- `make test-smoke` -> Smoke tests passed!
- `PYTEST_BIN="python3 -m pytest" bash scripts/test_tiers.sh smoke` -> 138 passed
- grimp/import-linter: no new `events -> knowledge` and no new domain/application/interface edge from this change (full-layer re-check shows only pre-existing, unrelated `utils->caching`, `evaluation->*`, `swarm->cli` violations that postdate the frozen baseline in modules this PR does not touch).

## Risks

- **Registration-completeness:** a composition root constructing a bare `CrossSubscriberManager` without the bootstrap no longer gets KM reactions. Mitigated: domain-subset + superset bootstraps register the home; server `init_km_adapters` uses the superset bootstrap; the registry parity test asserts the full set via bootstrap.
- Low blast radius: reactions are behavior-identical (moved, not modified); only the registration path changed.
