### PR TITLE
feat(scripts): unattended Tier 0-2 merge executor — authorized→merged closed circuit (#8759)

### DIFF
--- a/scripts/merge_executor.py
+++ b/scripts/merge_executor.py
@@ -1,0 +1,414 @@
+#!/usr/bin/env python3
+"""Bounded single-pass Tier 0-2 merge executor: authorized -> merged, unattended.
+
+Closes issue #8759: CI authorizes Tier 0-2 merges (merge-quorum packet
+``status=satisfied``) but nothing executed them without a human typing
+``--apply``. This is the launchd/cron invocable that does — ONE bounded pass
+per invocation, never a daemon loop, and NO new risk judgment: discovery and
+merge I/O come verbatim from ``scripts/auto_merge_quorum_green.py`` (the exact
+``gh pr merge --squash --admin --match-head-commit`` path) and eligibility is
+the pure defense-in-depth ``aragora.swarm.auto_merge_green.decide_auto_merge``.
+
+The executor shell adds: dry-run by default (the decision trace prints,
+nothing mutates); Tier 3-4 PRs never acted on (human-review digest only);
+``--max-merges`` (default 1) bounding; exact-head re-verification immediately
+before each merge; auto-halt (red main writes a halt marker that blocks every
+later pass until a human deletes it); a one-way ``--disarm-file`` kill switch;
+and an operator receipt JSON per executed merge in ``--receipt-dir``.
+
+ARMING IS A HUMAN STEP: installing this under launchd and passing ``--apply``
+is Tier 4 per docs/AGENT_OPERATING_CONTRACT.md; this file only makes that step
+possible and safe, it never takes it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import getpass
+import importlib.util
+import json
+import os
+import socket
+import subprocess
+import sys
+from collections.abc import Callable, Iterable
+from pathlib import Path
+from typing import Any
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _SCRIPTS_DIR.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from aragora.swarm.auto_merge_green import (  # noqa: E402
+    MAX_AUTO_MERGE_TIER,
+    REQUIRED_CHECKS,
+    context_from_gh,
+    decide_auto_merge,
+)
+
+
+def _load_amqg() -> Any:
+    """Load auto_merge_quorum_green.py (its I/O + merge invocation are reused
+    verbatim, never reimplemented)."""
+    path = _SCRIPTS_DIR / "auto_merge_quorum_green.py"
+    spec = importlib.util.spec_from_file_location("merge_executor_amqg", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_amqg = _load_amqg()
+
+# Conservative default: ONE merge per pass. Cadence (the launchd interval), not
+# this cap, sets throughput; a small cap keeps any single bad pass small.
+DEFAULT_MAX_MERGES = 1
+
+DEFAULT_RECEIPT_DIR = _REPO_ROOT / ".aragora" / "merge_executor" / "receipts"
+DEFAULT_HALT_FILE = _REPO_ROOT / ".aragora" / "merge_executor.halt"
+DEFAULT_DISARM_FILE = _REPO_ROOT / ".aragora" / "merge_executor.disarm"
+
+# REST check-runs conclusions that make a required check on main "red".
+_RED_CONCLUSIONS = frozenset(
+    {"failure", "error", "cancelled", "timed_out", "startup_failure", "action_required"}
+)
+
+
+# Delegated I/O: module-level aliases (tests monkeypatch these) whose bodies
+# are the existing script's, never re-implemented here.
+fetch_view = _amqg.fetch_view
+fetch_packet = _amqg.fetch_packet_entry
+list_open_prs = _amqg.list_open_pr_numbers
+
+
+def make_merge_fn(repo: str) -> Callable[[int, str], tuple[bool, str]]:
+    """The one and only merge invocation: auto_merge_quorum_green's, verbatim."""
+    return _amqg._make_merge_fn(repo)
+
+
+def fetch_main_checks(repo: str, branch: str = "main") -> list[dict[str, Any]] | None:
+    """Latest check-runs on the tip of ``branch`` (None on any fetch problem)."""
+    cmd = ["gh", "api", f"repos/{repo}/commits/{branch}/check-runs", "--paginate"]
+    cmd += ["--jq", ".check_runs[]"]
+    try:
+        out = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if out.returncode != 0:
+        return None
+    try:
+        runs = [json.loads(line) for line in out.stdout.splitlines() if line.strip()]
+    except json.JSONDecodeError:
+        return None
+    return [run for run in runs if isinstance(run, dict)]
+
+
+def evaluate_main_health(
+    check_runs: list[dict[str, Any]] | None,
+    required: Iterable[str] = REQUIRED_CHECKS,
+) -> tuple[str, list[str]]:
+    """Classify main as ``green`` / ``red`` / ``indeterminate``.
+
+    red: any required check's LATEST run completed failing (auto-halt trigger).
+    green: every required check PRESENT completed ``success`` — absent required
+    checks are not-applicable, NOT blockers (verified live: "Generate & Validate"
+    and "TypeScript SDK Type Check" only run on PRs, never on main-push commits;
+    treating absence as pending would make green unreachable when armed).
+    indeterminate: fetch failed, a present check pending/inconclusive, or none
+    reported. Indeterminate blocks merging (fail closed) but does NOT halt — a
+    merge freshly landed by a previous pass leaves main pending, which is not
+    evidence of breakage.
+    """
+    if check_runs is None:
+        return ("indeterminate", ["check-runs fetch failed"])
+
+    def _run_id(run: dict[str, Any]) -> int:
+        try:
+            return int(run.get("id") or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    latest: dict[str, dict[str, Any]] = {}  # ascending sort -> last write wins
+    for run in sorted((r for r in check_runs if isinstance(r, dict)), key=_run_id):
+        name = str(run.get("name") or "").strip()
+        if name:
+            latest[name] = run
+
+    red: list[str] = []
+    not_green: list[str] = []
+    present = 0
+    for name in sorted(required):
+        latest_run = latest.get(name)
+        if latest_run is None:
+            continue  # not-applicable on this commit (PR-only check)
+        present += 1
+        status = str(latest_run.get("status") or "").strip().lower()
+        conclusion = str(latest_run.get("conclusion") or "").strip().lower()
+        if status != "completed":
+            not_green.append(f"{name}: {status or 'pending'}")
+        elif conclusion in _RED_CONCLUSIONS:
+            red.append(f"{name}: {conclusion}")
+        elif conclusion != "success":
+            not_green.append(f"{name}: {conclusion or 'no conclusion'}")
+    if red:
+        return ("red", red)
+    if present == 0:
+        return ("indeterminate", ["no required checks reported on this commit yet"])
+    if not_green:
+        return ("indeterminate", not_green)
+    return ("green", [])
+
+
+def exit_code_for(summary: dict[str, Any], *, apply: bool) -> int:
+    """0 ok (dry-run is always informational), 3 halted/disarmed under --apply,
+    1 if an attempted merge actually failed."""
+    if not apply:
+        return 0
+    if summary.get("halted") or summary.get("disarmed"):
+        return 3
+    if any(r.get("action") == "merge-failed" for r in summary.get("results") or []):
+        return 1
+    return 0
+
+
+def _now_iso() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+
+def _executor_identity() -> dict[str, Any]:
+    try:
+        user = getpass.getuser()
+    except OSError:
+        user = os.environ.get("USER") or "unknown"
+    host = socket.gethostname()
+    return {"user": user, "host": host, "pid": os.getpid(), "script": "scripts/merge_executor.py"}
+
+
+def _write_receipt(receipt_dir: Path, receipt: dict[str, Any]) -> Path:
+    receipt_dir.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    path = receipt_dir / f"MERGE_EXECUTOR_RECEIPT_{stamp}_PR{receipt['pr']}.json"
+    path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def _write_halt_marker(halt_file: Path, *, repo: str, details: list[str]) -> None:
+    halt_file.parent.mkdir(parents=True, exist_ok=True)
+    marker = {
+        "reason": "main_red",
+        "repo": repo,
+        "details": details,
+        "written_at": _now_iso(),
+        "written_by": _executor_identity(),
+        "re_arm": "a human deletes this file after verifying main is green",
+    }
+    halt_file.write_text(json.dumps(marker, indent=2) + "\n", encoding="utf-8")
+
+
+def run_pass(
+    *,
+    repo: str,
+    prs: list[int],
+    apply: bool,
+    max_merges: int,
+    receipt_dir: Path,
+    halt_file: Path,
+    disarm_file: Path,
+    fetch_view: Callable[[int], dict[str, Any] | None],
+    fetch_packet: Callable[[int], dict[str, Any] | None],
+    promising: Callable[[dict[str, Any]], bool],
+    merge_fn: Callable[[int, str], tuple[bool, str]],
+    fetch_main_checks: Callable[[], list[dict[str, Any]] | None],
+) -> dict[str, Any]:
+    """One bounded pass: discover -> gate -> (re-verify -> merge -> receipt).
+    Read-only unless ``apply`` AND no kill switch / halt condition is active.
+    Returns the full decision trace as a JSON-serializable summary."""
+    disarmed = disarm_file.exists()
+    previously_halted = halt_file.exists()
+    health, health_details = evaluate_main_health(fetch_main_checks(), REQUIRED_CHECKS)
+
+    halted = previously_halted
+    if apply and not disarmed and not previously_halted and health == "red":
+        _write_halt_marker(halt_file, repo=repo, details=health_details)
+        halted = True
+
+    results: list[dict[str, Any]] = []
+    tier_3_4_digest: list[dict[str, Any]] = []
+    eligible: list[dict[str, Any]] = []
+    for pr in prs:
+        view = fetch_view(pr)
+        if view is None:
+            results.append({"pr": pr, "action": "skip", "blockers": ["gh pr view failed"]})
+            continue
+        packet = fetch_packet(pr) if promising(view) else None
+        ctx = context_from_gh(view, packet)
+        decision = decide_auto_merge(ctx)
+        if ctx.tier is not None and ctx.tier > MAX_AUTO_MERGE_TIER:
+            note = "Tier 3-4: human settlement required (settle_tier4_pr.py); never auto-merged"
+            tier_3_4_digest.append({"pr": pr, "tier": ctx.tier, "head": ctx.head_sha, "note": note})
+        record: dict[str, Any] = {"pr": pr, "head": ctx.head_sha, "tier": ctx.tier}
+        if not decision.should_merge:
+            record["action"] = "skip"
+            record["blockers"] = list(decision.blockers)
+            results.append(record)
+            continue
+        eligible.append(record)
+
+    can_merge = apply and not disarmed and not halted and health == "green"
+    merged_count = 0
+    for record in eligible:
+        pr = record["pr"]
+        if merged_count >= max_merges:
+            record["action"] = "deferred (max-merges reached)"
+        elif disarmed:
+            record["action"] = "blocked (disarm file present — kill switch)"
+        elif halted:
+            record["action"] = "blocked (halt marker present — human re-arm required)"
+        elif health != "green":
+            record["action"] = f"blocked (main health {health}, requires green)"
+        elif not apply:
+            record["action"] = "would-merge"
+            merged_count += 1
+        elif can_merge:
+            if disarm_file.exists():  # live kill switch, honored mid-pass
+                record["action"] = "blocked (disarm file appeared mid-pass)"
+                results.append(record)
+                continue
+            # Re-verify at the EXACT head: refetch both sources, re-run the gate.
+            view2 = fetch_view(pr)
+            if view2 is None or str(view2.get("headRefOid") or "") != record["head"]:
+                record["action"] = "skip"
+                record["blockers"] = [
+                    "head moved (or view lost) between discovery and merge — re-verify failed"
+                ]
+                results.append(record)
+                continue
+            packet2 = fetch_packet(pr)
+            decision2 = decide_auto_merge(context_from_gh(view2, packet2))
+            if not decision2.should_merge:
+                record["action"] = "skip"
+                record["blockers"] = ["re-verification regressed: " + b for b in decision2.blockers]
+                results.append(record)
+                continue
+            ok, detail = merge_fn(pr, record["head"])
+            record["detail"] = detail
+            if ok:
+                record["action"] = "merged"
+                merged_count += 1
+                authority = (
+                    "merge-quorum packet (status=satisfied) + aragora-merge-quorum "
+                    "check; executor added no new risk judgment"
+                )
+                receipt = {
+                    "schema": "merge-executor-receipt/v1",
+                    "repo": repo,
+                    "pr": pr,
+                    "head_sha": record["head"],
+                    "tier": record["tier"],
+                    "merged_at": _now_iso(),
+                    "executor": _executor_identity(),
+                    "merge_detail": detail,
+                    "main_health_at_pass_start": health,
+                    "packet_entry": packet2,
+                    "authority": authority,
+                }
+                record["receipt"] = str(_write_receipt(receipt_dir, receipt))
+            else:
+                record["action"] = "merge-failed"
+        results.append(record)
+
+    return {
+        "schema": "merge-executor-pass/v1",
+        "repo": repo,
+        "mode": "apply" if apply else "dry-run",
+        "timestamp": _now_iso(),
+        "executor": _executor_identity(),
+        "main_health": health,
+        "main_health_details": health_details,
+        "disarmed": disarmed,
+        "halted": halted,
+        "max_merges": max_merges,
+        "scanned": len(prs),
+        "eligible": len(eligible),
+        "merged": merged_count if apply else 0,
+        "tier_3_4_digest": tier_3_4_digest,
+        "results": results,
+    }
+
+
+def _render_human(summary: dict[str, Any]) -> None:
+    print(
+        f"[merge-executor] {summary['mode']}: repo={summary['repo']} "
+        f"main={summary['main_health']} scanned={summary['scanned']} "
+        f"eligible={summary['eligible']} merged={summary['merged']}"
+    )
+    if summary["disarmed"]:
+        print("  DISARMED: disarm file present — no merging until a human removes it")
+    if summary["halted"]:
+        print("  HALTED: halt marker present/written — human re-arm required")
+    for detail in summary["main_health_details"]:
+        print(f"  main: {detail}")
+    for record in summary["results"]:
+        print(f"  #{record['pr']} (tier={record.get('tier')}): {record.get('action')}")
+        for blocker in (record.get("blockers") or [])[:3]:
+            print(f"      blocker: {blocker}")
+        if record.get("receipt"):
+            print(f"      receipt: {record['receipt']}")
+    if summary["tier_3_4_digest"]:
+        print("  Tier 3-4 human-review digest (never auto-merged):")
+        for entry in summary["tier_3_4_digest"]:
+            print(f"    #{entry['pr']} tier={entry['tier']} head={entry['head'][:8]}")
+    if summary["mode"] == "dry-run":
+        print("  DRY RUN — nothing mutated. Arming (--apply) is a Tier 4 human step.")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Bounded single-pass Tier 0-2 merge executor (dry-run by default). "
+        "Designed to be invoked by launchd/cron; never a daemon loop itself."
+    )
+    add = parser.add_argument
+    add("--repo", required=True, help="owner/name")
+    add("--pr", type=int, action="append", help="specific PR(s); default scans open non-drafts")
+    add("--limit", type=int, default=300, help="max open PRs to scan")
+    cap_help = f"cap merges in this pass (default {DEFAULT_MAX_MERGES})"
+    add("--max-merges", type=int, default=DEFAULT_MAX_MERGES, help=cap_help)
+    add("--branch", default="main", help="protected branch to health-check")
+    add("--receipt-dir", type=Path, default=DEFAULT_RECEIPT_DIR, help="operator receipt dir (JSON)")
+    halt_help = "halt marker: written when main is red; blocks merging until a human deletes it"
+    add("--halt-file", type=Path, default=DEFAULT_HALT_FILE, help=halt_help)
+    disarm_help = "one-way kill switch: if this file exists, nothing merges"
+    add("--disarm-file", type=Path, default=DEFAULT_DISARM_FILE, help=disarm_help)
+    add("--apply", action="store_true", help="actually merge (default: dry-run, mutates nothing)")
+    add("--json", action="store_true", help="emit structured JSON summary")
+    args = parser.parse_args(argv)
+
+    prs = args.pr if args.pr else list_open_prs(args.repo, args.limit)
+    summary = run_pass(
+        repo=args.repo,
+        prs=prs,
+        apply=args.apply,
+        max_merges=args.max_merges,
+        receipt_dir=args.receipt_dir,
+        halt_file=args.halt_file,
+        disarm_file=args.disarm_file,
+        fetch_view=lambda pr: fetch_view(args.repo, pr),
+        fetch_packet=lambda pr: fetch_packet(args.repo, pr),
+        promising=_amqg._cheaply_promising,
+        merge_fn=make_merge_fn(args.repo),
+        fetch_main_checks=lambda: fetch_main_checks(args.repo, args.branch),
+    )
+
+    if args.json:
+        print(json.dumps(summary, indent=2))
+    else:
+        _render_human(summary)
+    return exit_code_for(summary, apply=args.apply)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/merge_executor.py
+++ b/scripts/merge_executor.py
@@ -12,9 +12,11 @@ the pure defense-in-depth ``aragora.swarm.auto_merge_green.decide_auto_merge``.
 The executor shell adds: dry-run by default (the decision trace prints,
 nothing mutates); Tier 3-4 PRs never acted on (human-review digest only);
 ``--max-merges`` (default 1) bounding; exact-head re-verification immediately
-before each merge; auto-halt (red main writes a halt marker that blocks every
-later pass until a human deletes it); a one-way ``--disarm-file`` kill switch;
-and an operator receipt JSON per executed merge in ``--receipt-dir``.
+before each merge; auto-halt (main health — check runs AND commit statuses —
+re-evaluated before EVERY merge, not once per pass; red writes a halt marker
+that blocks every later pass until a human deletes it, non-green blocks the
+remainder of the pass); a one-way ``--disarm-file`` kill switch; and an
+operator receipt JSON per executed merge in ``--receipt-dir``.
 
 ARMING IS A HUMAN STEP: installing this under launchd and passing ``--apply``
 is Tier 4 per docs/AGENT_OPERATING_CONTRACT.md; this file only makes that step
@@ -32,7 +34,7 @@ import os
 import socket
 import subprocess
 import sys
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -107,24 +109,50 @@ def fetch_main_checks(repo: str, branch: str = "main") -> list[dict[str, Any]] |
     return [run for run in runs if isinstance(run, dict)]
 
 
+def fetch_main_statuses(repo: str, branch: str = "main") -> list[dict[str, Any]] | None:
+    """Commit *statuses* on the tip of ``branch`` (combined status API; None on
+    any fetch problem). Required branch-protection contexts can be delivered as
+    statuses rather than check runs — reading only check-runs would leave a
+    failing required status context invisible."""
+    cmd = ["gh", "api", f"repos/{repo}/commits/{branch}/status", "--paginate"]
+    cmd += ["--jq", ".statuses[]"]
+    try:
+        out = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if out.returncode != 0:
+        return None
+    try:
+        statuses = [json.loads(line) for line in out.stdout.splitlines() if line.strip()]
+    except json.JSONDecodeError:
+        return None
+    return [st for st in statuses if isinstance(st, dict)]
+
+
 def evaluate_main_health(
     check_runs: list[dict[str, Any]] | None,
     required: Iterable[str] = REQUIRED_CHECKS,
+    statuses: Sequence[dict[str, Any]] | None = (),
 ) -> tuple[str, list[str]]:
     """Classify main as ``green`` / ``red`` / ``indeterminate``.
 
-    red: any required check's LATEST run completed failing (auto-halt trigger).
-    green: every required check PRESENT completed ``success`` — absent required
-    checks are not-applicable, NOT blockers (verified live: "Generate & Validate"
-    and "TypeScript SDK Type Check" only run on PRs, never on main-push commits;
-    treating absence as pending would make green unreachable when armed).
-    indeterminate: fetch failed, a present check pending/inconclusive, or none
-    reported. Indeterminate blocks merging (fail closed) but does NOT halt — a
-    merge freshly landed by a previous pass leaves main pending, which is not
-    evidence of breakage.
+    A required context may report as a check *run* or as a commit *status*
+    (branch protection accepts both); both sources are consulted and a
+    present-and-failing entry in EITHER always blocks.
+
+    red: any required context's LATEST report completed failing (auto-halt).
+    green: every required context PRESENT in either source reports ``success``
+    — a context absent from BOTH sources is not-applicable, NOT a blocker
+    (verified live: "Generate & Validate" and "TypeScript SDK Type Check" only
+    run on PRs, never on main-push commits; treating absence as pending would
+    make green unreachable when armed).
+    indeterminate: a fetch failed (``None``), a present context is pending or
+    inconclusive, or no required context reported at all. Indeterminate blocks
+    merging (fail closed) but does NOT halt — a merge freshly landed by a
+    previous pass leaves main pending, which is not evidence of breakage.
     """
-    if check_runs is None:
-        return ("indeterminate", ["check-runs fetch failed"])
+    if check_runs is None or statuses is None:
+        return ("indeterminate", ["check-runs/commit-status fetch failed"])
 
     def _run_id(run: dict[str, Any]) -> int:
         try:
@@ -138,22 +166,39 @@ def evaluate_main_health(
         if name:
             latest[name] = run
 
+    # Combined status API already returns the latest status per context.
+    status_states: dict[str, str] = {}
+    for st in statuses:
+        if isinstance(st, dict):
+            context = str(st.get("context") or "").strip()
+            if context:
+                status_states[context] = str(st.get("state") or "").strip().lower()
+
     red: list[str] = []
     not_green: list[str] = []
     present = 0
     for name in sorted(required):
+        seen = False
         latest_run = latest.get(name)
-        if latest_run is None:
-            continue  # not-applicable on this commit (PR-only check)
-        present += 1
-        status = str(latest_run.get("status") or "").strip().lower()
-        conclusion = str(latest_run.get("conclusion") or "").strip().lower()
-        if status != "completed":
-            not_green.append(f"{name}: {status or 'pending'}")
-        elif conclusion in _RED_CONCLUSIONS:
-            red.append(f"{name}: {conclusion}")
-        elif conclusion != "success":
-            not_green.append(f"{name}: {conclusion or 'no conclusion'}")
+        if latest_run is not None:
+            seen = True
+            status = str(latest_run.get("status") or "").strip().lower()
+            conclusion = str(latest_run.get("conclusion") or "").strip().lower()
+            if status != "completed":
+                not_green.append(f"{name}: {status or 'pending'}")
+            elif conclusion in _RED_CONCLUSIONS:
+                red.append(f"{name}: {conclusion}")
+            elif conclusion != "success":
+                not_green.append(f"{name}: {conclusion or 'no conclusion'}")
+        state = status_states.get(name)
+        if state is not None:
+            seen = True
+            if state in {"failure", "error"}:
+                red.append(f"{name}: status {state}")
+            elif state != "success":
+                not_green.append(f"{name}: status {state or 'pending'}")
+        if seen:
+            present += 1
     if red:
         return ("red", red)
     if present == 0:
@@ -223,13 +268,18 @@ def run_pass(
     promising: Callable[[dict[str, Any]], bool],
     merge_fn: Callable[[int, str], tuple[bool, str]],
     fetch_main_checks: Callable[[], list[dict[str, Any]] | None],
+    fetch_main_statuses: Callable[[], list[dict[str, Any]] | None],
 ) -> dict[str, Any]:
     """One bounded pass: discover -> gate -> (re-verify -> merge -> receipt).
     Read-only unless ``apply`` AND no kill switch / halt condition is active.
     Returns the full decision trace as a JSON-serializable summary."""
     disarmed = disarm_file.exists()
     previously_halted = halt_file.exists()
-    health, health_details = evaluate_main_health(fetch_main_checks(), REQUIRED_CHECKS)
+
+    def _main_health() -> tuple[str, list[str]]:
+        return evaluate_main_health(fetch_main_checks(), REQUIRED_CHECKS, fetch_main_statuses())
+
+    health, health_details = _main_health()
 
     halted = previously_halted
     if apply and not disarmed and not previously_halted and health == "red":
@@ -258,7 +308,6 @@ def run_pass(
             continue
         eligible.append(record)
 
-    can_merge = apply and not disarmed and not halted and health == "green"
     merged_count = 0
     for record in eligible:
         pr = record["pr"]
@@ -273,7 +322,7 @@ def run_pass(
         elif not apply:
             record["action"] = "would-merge"
             merged_count += 1
-        elif can_merge:
+        else:
             if disarm_file.exists():  # live kill switch, honored mid-pass
                 record["action"] = "blocked (disarm file appeared mid-pass)"
                 results.append(record)
@@ -294,6 +343,19 @@ def run_pass(
                 record["blockers"] = ["re-verification regressed: " + b for b in decision2.blockers]
                 results.append(record)
                 continue
+            # Re-evaluate main health immediately before EACH merge — the
+            # pass-start read is stale the moment main advances (including by
+            # our own previous merge). Red mid-pass halts the remainder and
+            # writes the halt marker; any non-green blocks the remainder.
+            health, health_details = _main_health()
+            if health != "green":
+                if health == "red":
+                    if not halt_file.exists():
+                        _write_halt_marker(halt_file, repo=repo, details=health_details)
+                    halted = True
+                record["action"] = f"blocked (main health {health} at merge time)"
+                results.append(record)
+                continue
             ok, detail = merge_fn(pr, record["head"])
             record["detail"] = detail
             if ok:
@@ -312,7 +374,7 @@ def run_pass(
                     "merged_at": _now_iso(),
                     "executor": _executor_identity(),
                     "merge_detail": detail,
-                    "main_health_at_pass_start": health,
+                    "main_health_at_merge": health,
                     "packet_entry": packet2,
                     "authority": authority,
                 }
@@ -401,6 +463,7 @@ def main(argv: list[str] | None = None) -> int:
         promising=_amqg._cheaply_promising,
         merge_fn=make_merge_fn(args.repo),
         fetch_main_checks=lambda: fetch_main_checks(args.repo, args.branch),
+        fetch_main_statuses=lambda: fetch_main_statuses(args.repo, args.branch),
     )
 
     if args.json:

--- a/tests/scripts/test_merge_executor.py
+++ b/tests/scripts/test_merge_executor.py
@@ -1,0 +1,384 @@
+"""Tests for ``scripts/merge_executor.py`` (issue #8759).
+
+The executor is a bounded single-pass composition over the existing
+auto-merge-on-green machinery; it never invents a new merge gate. These tests
+drive the pass core (``run_pass``) and helpers with injected I/O — no real
+``gh``, no network, no live GitHub mutation.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from aragora.swarm.auto_merge_green import REQUIRED_CHECKS
+
+
+def _load_module() -> Any:
+    script = Path(__file__).resolve().parents[2] / "scripts" / "merge_executor.py"
+    spec = importlib.util.spec_from_file_location("merge_executor_under_test", script)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load spec for {script}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+me = _load_module()
+
+HEAD = "a" * 40
+
+
+def _rollup_all_green() -> list[dict]:
+    rollup = [{"name": name, "conclusion": "SUCCESS"} for name in REQUIRED_CHECKS]
+    rollup.append({"name": "aragora-merge-quorum", "conclusion": "SUCCESS"})
+    return rollup
+
+
+def _view(number: int = 100, head: str = HEAD, **overrides) -> dict:
+    base = dict(
+        number=number,
+        headRefOid=head,
+        isDraft=False,
+        mergeable="MERGEABLE",
+        mergeStateStatus="BLOCKED",
+        statusCheckRollup=_rollup_all_green(),
+    )
+    base.update(overrides)
+    return base
+
+
+def _packet(number: int = 100, head: str = HEAD, tier: int = 1, **overrides) -> dict:
+    base = dict(
+        pr_number=number,
+        tier=tier,
+        status="satisfied",
+        verdict="admin_squash_allowed",
+        requires_human_risk_settlement=False,
+        unresolved_dissent=False,
+        admin_squash_allowed=True,
+        head_sha=head,
+    )
+    base.update(overrides)
+    return base
+
+
+def _main_runs_green() -> list[dict]:
+    return [
+        {"id": i, "name": name, "status": "completed", "conclusion": "success"}
+        for i, name in enumerate(sorted(REQUIRED_CHECKS), start=1)
+    ]
+
+
+def _main_runs_red() -> list[dict]:
+    runs = _main_runs_green()
+    runs[0] = dict(runs[0], conclusion="failure")
+    return runs
+
+
+class _Harness:
+    """Injected I/O for run_pass: fixture-backed, records every merge call."""
+
+    def __init__(self, views: dict[int, dict], packets: dict[int, dict | None]):
+        self.views = views
+        self.packets = packets
+        self.merge_calls: list[tuple[int, str]] = []
+        self.merge_result: tuple[bool, str] = (True, "merged")
+        self.main_runs: list[dict] | None = _main_runs_green()
+
+    def merge_fn(self, pr: int, head: str) -> tuple[bool, str]:
+        self.merge_calls.append((pr, head))
+        return self.merge_result
+
+
+def _kwargs(h: _Harness, tmp_path: Path, **overrides) -> dict:
+    base = dict(
+        repo="owner/name",
+        prs=[100],
+        apply=False,
+        max_merges=1,
+        receipt_dir=tmp_path / "receipts",
+        halt_file=tmp_path / "halt.json",
+        disarm_file=tmp_path / "disarm",
+        fetch_view=h.views.get,
+        fetch_packet=h.packets.get,
+        promising=lambda view: True,
+        merge_fn=h.merge_fn,
+        fetch_main_checks=lambda: h.main_runs,
+    )
+    base.update(overrides)
+    return base
+
+
+def _actions(summary: dict) -> dict[int, str]:
+    return {r["pr"]: r["action"] for r in summary["results"]}
+
+
+def test_main_health_green_when_all_required_success():
+    assert me.evaluate_main_health(_main_runs_green(), REQUIRED_CHECKS) == ("green", [])
+
+
+def test_main_health_red_on_required_failure():
+    state, details = me.evaluate_main_health(_main_runs_red(), REQUIRED_CHECKS)
+    assert state == "red"
+    assert any("failure" in d for d in details)
+
+
+def test_main_health_indeterminate_on_pending_empty_or_fetch_failure():
+    pending = _main_runs_green()
+    pending[0] = dict(pending[0], status="in_progress", conclusion="")
+    for runs in (pending, [], None):
+        assert me.evaluate_main_health(runs, REQUIRED_CHECKS)[0] == "indeterminate"
+
+
+def test_main_health_green_when_pr_only_checks_absent_on_main_push():
+    # Structural reality (verified live): "Generate & Validate" and
+    # "TypeScript SDK Type Check" only run on PRs, never on main-push commits.
+    # Their absence must read as not-applicable, otherwise the armed executor
+    # could never see green. Failing/pending PRESENT checks still block.
+    present = {"lint", "typecheck", "sdk-parity"}
+    runs = [r for r in _main_runs_green() if r["name"] in present]
+    assert me.evaluate_main_health(runs, REQUIRED_CHECKS)[0] == "green"
+
+
+def test_main_health_red_still_wins_when_other_checks_absent():
+    runs = [
+        {"id": 1, "name": "lint", "status": "completed", "conclusion": "failure"},
+        {"id": 2, "name": "typecheck", "status": "completed", "conclusion": "success"},
+    ]
+    state, details = me.evaluate_main_health(runs, REQUIRED_CHECKS)
+    assert state == "red"
+    assert any("lint" in d for d in details)
+
+
+def test_main_health_uses_latest_run_per_check():
+    # An old failing run superseded by a newer success must not read as red.
+    name = sorted(REQUIRED_CHECKS)[0]
+    runs = _main_runs_green()
+    runs.append({"id": 0, "name": name, "status": "completed", "conclusion": "failure"})
+    assert me.evaluate_main_health(runs, REQUIRED_CHECKS)[0] == "green"
+
+
+def test_dry_run_never_calls_merge_fn(tmp_path):
+    h = _Harness({100: _view()}, {100: _packet()})
+    summary = me.run_pass(**_kwargs(h, tmp_path))
+    assert h.merge_calls == []
+    assert summary["mode"] == "dry-run"
+    assert _actions(summary)[100] == "would-merge"
+
+
+def test_dry_run_writes_no_receipts_and_no_halt_even_on_red_main(tmp_path):
+    h = _Harness({100: _view()}, {100: _packet()})
+    h.main_runs = _main_runs_red()
+    summary = me.run_pass(**_kwargs(h, tmp_path))
+    assert summary["main_health"] == "red"
+    assert not (tmp_path / "receipts").exists()
+    assert not (tmp_path / "halt.json").exists()
+
+
+def test_dry_run_reports_blockers_for_ineligible(tmp_path):
+    h = _Harness({100: _view(isDraft=True)}, {100: _packet()})
+    record = me.run_pass(**_kwargs(h, tmp_path))["results"][0]
+    assert record["action"] == "skip"
+    assert any("draft" in b for b in record["blockers"])
+
+
+@pytest.mark.parametrize(("tier", "in_digest"), [(0, False), (2, False), (3, True), (4, True)])
+def test_tier_3_and_4_never_merged_and_listed_in_digest(tmp_path, tier, in_digest):
+    h = _Harness({100: _view()}, {100: _packet(tier=tier)})
+    summary = me.run_pass(**_kwargs(h, tmp_path, apply=True))
+    digest = [(d["pr"], d["tier"]) for d in summary["tier_3_4_digest"]]
+    assert digest == ([(100, tier)] if in_digest else [])
+    if in_digest:
+        assert h.merge_calls == []  # NEVER acted on, even under --apply
+
+
+def test_unknown_tier_blocks_merge(tmp_path):
+    h = _Harness({100: _view()}, {100: None})
+    summary = me.run_pass(**_kwargs(h, tmp_path, apply=True))
+    assert h.merge_calls == []
+    assert _actions(summary)[100] == "skip"
+
+
+def test_apply_merges_and_writes_receipt(tmp_path):
+    h = _Harness({100: _view()}, {100: _packet(tier=2)})
+    summary = me.run_pass(**_kwargs(h, tmp_path, apply=True))
+    assert h.merge_calls == [(100, HEAD)]
+    assert _actions(summary)[100] == "merged"
+
+    receipts = list((tmp_path / "receipts").glob("*.json"))
+    assert len(receipts) == 1
+    receipt = json.loads(receipts[0].read_text())
+    expected = {"pr": 100, "head_sha": HEAD, "tier": 2, "repo": "owner/name"}
+    assert {k: receipt[k] for k in expected} == expected
+    assert receipt["merged_at"] and receipt["executor"]["user"] and receipt["executor"]["host"]
+    # packet evidence travels with the receipt
+    assert receipt["packet_entry"]["status"] == "satisfied"
+    assert receipt["packet_entry"]["verdict"] == "admin_squash_allowed"
+
+
+def test_apply_max_merges_defers_extras(tmp_path):
+    views = {1: _view(1, head="1" * 40), 2: _view(2, head="2" * 40)}
+    packets = {1: _packet(1, head="1" * 40), 2: _packet(2, head="2" * 40)}
+    h = _Harness(views, packets)
+    summary = me.run_pass(**_kwargs(h, tmp_path, prs=[1, 2], apply=True, max_merges=1))
+    assert len(h.merge_calls) == 1
+    assert _actions(summary)[1] == "merged"
+    assert "deferred" in _actions(summary)[2]
+
+
+def test_apply_merge_failure_recorded_and_no_receipt(tmp_path):
+    h = _Harness({100: _view()}, {100: _packet()})
+    h.merge_result = (False, "gh rejected")
+    summary = me.run_pass(**_kwargs(h, tmp_path, apply=True))
+    assert _actions(summary)[100] == "merge-failed"
+    assert not list((tmp_path / "receipts").glob("*.json"))
+
+
+def test_head_moved_between_discovery_and_merge_skips(tmp_path):
+    h = _Harness({}, {100: _packet()})
+    # Discovery sees HEAD; re-verification sees a new head -> must not merge.
+    views = iter([_view(), _view(head="b" * 40)])
+    moving = lambda pr: next(views, None)  # noqa: E731
+    summary = me.run_pass(**_kwargs(h, tmp_path, apply=True, fetch_view=moving))
+    assert h.merge_calls == []
+    record = summary["results"][0]
+    assert record["action"] == "skip"
+    assert any("head" in b.lower() for b in record["blockers"])
+
+
+def test_packet_regression_at_reverify_skips(tmp_path):
+    h = _Harness({100: _view()}, {})
+    packets = iter([_packet(), _packet(status="pending")])
+    summary = me.run_pass(
+        **_kwargs(h, tmp_path, apply=True, fetch_packet=lambda pr: next(packets, None))
+    )
+    assert h.merge_calls == []
+    record = summary["results"][0]
+    assert record["action"] == "skip"
+    assert record["blockers"]
+
+
+def test_apply_red_main_halts_writes_marker_and_merges_nothing(tmp_path):
+    h = _Harness({100: _view()}, {100: _packet()})
+    h.main_runs = _main_runs_red()
+    summary = me.run_pass(**_kwargs(h, tmp_path, apply=True))
+    assert h.merge_calls == []
+    assert summary["halted"] is True
+    payload = json.loads((tmp_path / "halt.json").read_text())
+    assert payload["reason"] == "main_red"
+    assert payload["repo"] == "owner/name"
+
+
+def test_apply_indeterminate_main_blocks_merges_without_marker(tmp_path):
+    h = _Harness({100: _view()}, {100: _packet()})
+    h.main_runs = None  # fetch failed -> indeterminate
+    summary = me.run_pass(**_kwargs(h, tmp_path, apply=True))
+    assert h.merge_calls == []
+    assert summary["halted"] is False
+    assert not (tmp_path / "halt.json").exists()
+    assert "blocked" in _actions(summary)[100]
+
+
+def test_existing_halt_marker_blocks_apply(tmp_path):
+    (tmp_path / "halt.json").write_text("{}")
+    h = _Harness({100: _view()}, {100: _packet()})
+    summary = me.run_pass(**_kwargs(h, tmp_path, apply=True))
+    assert h.merge_calls == []
+    assert summary["halted"] is True
+
+
+@pytest.mark.parametrize("apply", [True, False])
+def test_disarm_file_blocks_all_merging(tmp_path, apply):
+    (tmp_path / "disarm").write_text("")
+    h = _Harness({100: _view()}, {100: _packet()})
+    summary = me.run_pass(**_kwargs(h, tmp_path, apply=apply))
+    assert h.merge_calls == []
+    assert summary["disarmed"] is True
+    assert "blocked" in _actions(summary)[100]
+
+
+def test_exit_codes():
+    ok = {"halted": False, "disarmed": False, "results": []}
+    assert me.exit_code_for(ok, apply=False) == 0
+    assert me.exit_code_for(ok, apply=True) == 0
+    assert me.exit_code_for(dict(ok, halted=True), apply=True) == 3
+    assert me.exit_code_for(dict(ok, disarmed=True), apply=True) == 3
+    failed = dict(ok, results=[{"pr": 1, "action": "merge-failed"}])
+    assert me.exit_code_for(failed, apply=True) == 1
+    # Dry-run is informational: never an error exit.
+    assert me.exit_code_for(dict(ok, disarmed=True, halted=True), apply=False) == 0
+
+
+def test_merge_command_is_delegated_to_auto_merge_quorum_green(monkeypatch):
+    # The executor must NEVER construct its own `gh pr merge`; it reuses the
+    # existing script's merge path verbatim.
+    calls: list[str] = []
+    monkeypatch.setattr(
+        me._amqg,
+        "_make_merge_fn",
+        lambda repo: calls.append(repo) or (lambda pr, head: (True, "sentinel")),
+    )
+    fn = me.make_merge_fn("owner/name")
+    assert calls == ["owner/name"]
+    assert fn(1, "x") == (True, "sentinel")
+
+
+def test_discovery_helpers_are_delegated():
+    assert me.fetch_view is me._amqg.fetch_view
+    assert me.fetch_packet is me._amqg.fetch_packet_entry
+    assert me.list_open_prs is me._amqg.list_open_pr_numbers
+    assert me.DEFAULT_MAX_MERGES == 1
+
+
+def _cli_args(tmp_path: Path, *extra: str) -> list[str]:
+    return [
+        "--repo",
+        "owner/name",
+        "--json",
+        "--receipt-dir",
+        str(tmp_path / "receipts"),
+        "--halt-file",
+        str(tmp_path / "halt.json"),
+        "--disarm-file",
+        str(tmp_path / "disarm"),
+        *extra,
+    ]
+
+
+def test_main_json_output_dry_run(tmp_path, capsys, monkeypatch):
+    monkeypatch.setattr(me, "list_open_prs", lambda repo, limit: [100])
+    monkeypatch.setattr(me, "fetch_view", lambda repo, pr: _view())
+    monkeypatch.setattr(me, "fetch_packet", lambda repo, pr: _packet())
+    monkeypatch.setattr(me, "fetch_main_checks", lambda repo, branch: _main_runs_green())
+
+    rc = me.main(_cli_args(tmp_path))
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["mode"] == "dry-run"
+    assert payload["repo"] == "owner/name"
+    assert payload["main_health"] == "green"
+    assert _actions(payload)[100] == "would-merge"
+    assert not (tmp_path / "receipts").exists()
+
+
+def test_main_apply_red_main_returns_halt_exit(tmp_path, monkeypatch):
+    monkeypatch.setattr(me, "list_open_prs", lambda repo, limit: [100])
+    monkeypatch.setattr(me, "fetch_view", lambda repo, pr: _view())
+    monkeypatch.setattr(me, "fetch_packet", lambda repo, pr: _packet())
+    monkeypatch.setattr(me, "fetch_main_checks", lambda repo, branch: _main_runs_red())
+    merge_calls: list[int] = []
+    monkeypatch.setattr(
+        me, "make_merge_fn", lambda repo: lambda pr, head: merge_calls.append(pr) or (True, "x")
+    )
+
+    rc = me.main(_cli_args(tmp_path, "--apply"))
+    assert rc == 3
+    assert merge_calls == []
+    assert (tmp_path / "halt.json").exists()

--- a/tests/scripts/test_merge_executor.py
+++ b/tests/scripts/test_merge_executor.py
@@ -111,6 +111,7 @@ def _kwargs(h: _Harness, tmp_path: Path, **overrides) -> dict:
         promising=lambda view: True,
         merge_fn=h.merge_fn,
         fetch_main_checks=lambda: h.main_runs,
+        fetch_main_statuses=lambda: [],
     )
     base.update(overrides)
     return base
@@ -163,6 +164,30 @@ def test_main_health_uses_latest_run_per_check():
     runs = _main_runs_green()
     runs.append({"id": 0, "name": name, "status": "completed", "conclusion": "failure"})
     assert me.evaluate_main_health(runs, REQUIRED_CHECKS)[0] == "green"
+
+
+def test_main_health_red_on_failing_commit_status_even_with_green_check_runs():
+    # A required context can report as a commit *status* instead of a check
+    # run; a present-and-failing status must always block (review P2).
+    statuses = [{"context": "lint", "state": "failure"}]
+    state, details = me.evaluate_main_health(_main_runs_green(), REQUIRED_CHECKS, statuses)
+    assert state == "red"
+    assert any("lint" in d and "status" in d for d in details)
+
+
+def test_main_health_status_only_required_context_counts_as_present():
+    # 'lint' delivered ONLY as a commit status: success -> green;
+    # pending -> indeterminate (fail closed, no halt).
+    runs = [r for r in _main_runs_green() if r["name"] != "lint"]
+    ok = [{"context": "lint", "state": "success"}]
+    assert me.evaluate_main_health(runs, REQUIRED_CHECKS, ok)[0] == "green"
+    pending = [{"context": "lint", "state": "pending"}]
+    assert me.evaluate_main_health(runs, REQUIRED_CHECKS, pending)[0] == "indeterminate"
+
+
+def test_main_health_indeterminate_on_statuses_fetch_failure():
+    state, _ = me.evaluate_main_health(_main_runs_green(), REQUIRED_CHECKS, None)
+    assert state == "indeterminate"
 
 
 def test_dry_run_never_calls_merge_fn(tmp_path):
@@ -286,6 +311,58 @@ def test_apply_indeterminate_main_blocks_merges_without_marker(tmp_path):
     assert "blocked" in _actions(summary)[100]
 
 
+def _two_pr_harness() -> _Harness:
+    views = {1: _view(1, head="1" * 40), 2: _view(2, head="2" * 40)}
+    packets = {1: _packet(1, head="1" * 40), 2: _packet(2, head="2" * 40)}
+    return _Harness(views, packets)
+
+
+def test_health_flips_red_between_merges_blocks_second_and_halts(tmp_path):
+    # Health is re-evaluated before EACH merge (review P1): pass-start green,
+    # green before merge 1, red before merge 2 -> merge 2 blocked, marker written.
+    h = _two_pr_harness()
+    sequence = iter([_main_runs_green(), _main_runs_green(), _main_runs_red()])
+    summary = me.run_pass(
+        **_kwargs(
+            h,
+            tmp_path,
+            prs=[1, 2],
+            apply=True,
+            max_merges=2,
+            fetch_main_checks=lambda: next(sequence, _main_runs_red()),
+        )
+    )
+    assert [pr for pr, _ in h.merge_calls] == [1]
+    assert _actions(summary)[1] == "merged"
+    assert "blocked" in _actions(summary)[2]
+    assert summary["halted"] is True
+    assert json.loads((tmp_path / "halt.json").read_text())["reason"] == "main_red"
+
+
+def test_health_flips_pending_between_merges_blocks_second_without_marker(tmp_path):
+    # Pending main mid-pass (e.g. our own merge 1 landed) blocks the remainder
+    # of the pass fail-closed, but is not evidence of breakage: no halt marker,
+    # so the NEXT pass re-evaluates fresh instead of requiring human re-arm.
+    h = _two_pr_harness()
+    pending = _main_runs_green()
+    pending[0] = dict(pending[0], status="in_progress", conclusion="")
+    sequence = iter([_main_runs_green(), _main_runs_green(), pending])
+    summary = me.run_pass(
+        **_kwargs(
+            h,
+            tmp_path,
+            prs=[1, 2],
+            apply=True,
+            max_merges=2,
+            fetch_main_checks=lambda: next(sequence, pending),
+        )
+    )
+    assert [pr for pr, _ in h.merge_calls] == [1]
+    assert "blocked" in _actions(summary)[2]
+    assert summary["halted"] is False
+    assert not (tmp_path / "halt.json").exists()
+
+
 def test_existing_halt_marker_blocks_apply(tmp_path):
     (tmp_path / "halt.json").write_text("{}")
     h = _Harness({100: _view()}, {100: _packet()})
@@ -357,6 +434,7 @@ def test_main_json_output_dry_run(tmp_path, capsys, monkeypatch):
     monkeypatch.setattr(me, "fetch_view", lambda repo, pr: _view())
     monkeypatch.setattr(me, "fetch_packet", lambda repo, pr: _packet())
     monkeypatch.setattr(me, "fetch_main_checks", lambda repo, branch: _main_runs_green())
+    monkeypatch.setattr(me, "fetch_main_statuses", lambda repo, branch: [])
 
     rc = me.main(_cli_args(tmp_path))
     assert rc == 0
@@ -373,6 +451,7 @@ def test_main_apply_red_main_returns_halt_exit(tmp_path, monkeypatch):
     monkeypatch.setattr(me, "fetch_view", lambda repo, pr: _view())
     monkeypatch.setattr(me, "fetch_packet", lambda repo, pr: _packet())
     monkeypatch.setattr(me, "fetch_main_checks", lambda repo, branch: _main_runs_red())
+    monkeypatch.setattr(me, "fetch_main_statuses", lambda repo, branch: [])
     merge_calls: list[int] = []
     monkeypatch.setattr(
         me, "make_merge_fn", lambda repo: lambda pr, head: merge_calls.append(pr) or (True, "x")


### PR DESCRIPTION
Closes #8759. Part of epic #8762.

## What

`scripts/merge_executor.py` — a bounded **single-pass** executor (designed to be invoked by launchd/cron, never a daemon loop itself) that closes the authorized→merged circuit for Tier 0-2 PRs:

- **Discovery (read-only):** open non-draft PRs; a cheap gh pre-filter decides whether to spend a merge-packet subprocess (both reused verbatim from `scripts/auto_merge_quorum_green.py`).
- **Gate:** the pure defense-in-depth `aragora.swarm.auto_merge_green.decide_auto_merge` — tier ≤ 2, packet `status=satisfied` + head-bound + PR-bound, no unresolved dissent, quorum + every required check green, no failing check at all. No new risk judgment is added.
- **Tier 3-4:** never acted on; listed in a human-review digest in the output.
- **Execution (bounded, `--max-merges` default 1):** each candidate is re-fetched and re-gated at the **exact head SHA** discovery decided on, then merged via `auto_merge_quorum_green._make_merge_fn` verbatim (`gh pr merge --squash --admin --match-head-commit <head>` — mirrors the existing authorized path exactly, including its `--match-head-commit` race guard).
- **Receipts:** every executed merge writes an operator receipt JSON (pr, head sha, tier, packet evidence entry, timestamp, executor identity, authority statement) to `--receipt-dir`.
- **Auto-halt (re-checked per merge):** main health — required-check *runs* AND commit *statuses* (combined status API) — is evaluated at pass start **and re-evaluated immediately before every individual merge**, so a stale pass-start green can never authorize a later merge. Red → halt marker file written, remainder of the pass halted, and the marker blocks every later pass until a human deletes it (re-arm). Pending/indeterminate → remainder blocked fail-closed without the persistent marker (a merge freshly landed leaves main pending; that is not evidence of breakage, and the next pass re-evaluates fresh).
- **Kill switch:** `--disarm-file` existence blocks all merging (checked at pass start AND live before each merge).
- **DRY-RUN BY DEFAULT:** without `--apply` the full decision trace prints and nothing mutates. `--json` emits the structured summary. Exit codes: 0 ok, 1 a merge attempt failed, 3 halted/disarmed under `--apply`.

## Review revision (quorum round 1: claude PASS, openai CHANGES-REQUESTED)

Both findings addressed at `d6a1a1e0`:
- **[P1] stale pass-start health** → health re-evaluated inside the per-candidate loop, after exact-head re-verification, before each merge. New pinning test: green→green→red sequence with `--max-merges 2` merges PR 1, blocks PR 2, writes the halt marker.
- **[P2] status contexts invisible** → `fetch_main_statuses()` (combined status API) added; a present-and-failing required status context is always red, status-only contexts count as present, absent-from-BOTH-sources remains not-applicable, either fetch failing is indeterminate (fail closed). New pinning tests for each.

## Live findings folded into the design

Verified against live check-runs: **"Generate & Validate" and "TypeScript SDK Type Check" never run on main-push commits** (PR-only). The main-health classifier therefore treats a required context absent from both check-runs and commit statuses as not-applicable — otherwise the armed executor could never observe green and would be a permanent no-op. A failing or pending *present* required context still blocks (red halts; pending blocks without halting).

## Dry-run demonstration (read-only, live repo, head d6a1a1e0)

```
$ python scripts/merge_executor.py --repo synaptent/aragora --limit 25 --json
mode: dry-run | main_health: green (check runs + commit statuses)
scanned: 11  eligible: 0  merged: 0  tier_3_4_digest: 0
all 11 open non-draft PRs skipped with explicit blockers
(e.g. "tier unknown (merge-packet did not classify)", "merge-packet status not satisfied")
```

No PR currently holds a satisfied packet, so the executor correctly fails closed on everything. Full trace saved in the worktree at `docs/plans/2026-07-01-merge-executor-dryrun-demo.json` (not committed).

## Tests

- 34 tests in `tests/scripts/test_merge_executor.py` (29 original + 5 review-pinning) — all I/O injected; no real `gh`, no network, no live GitHub mutations. Existing related suites still green (202 passed across auto_merge_green / settle_plan / settle_pr / auto_merge_bucket_a + new file).
- `mypy scripts/merge_executor.py` clean; `pre-commit` clean.
- 2 files touched total (script + its test file).

## Arming

**Arming (launchd installation + `--apply`) is a Tier 4 human step, conditionally pre-approved pending this PR's demonstrated dry-run.** This PR does not install any launchd job, does not run with `--apply`, and does not touch workflows, `review_queue.py`, `quorum_evidence.py`, or the launchd install scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)