### PR TITLE
feat(scripts): harvest engine — fold merged/parked/orphaned outcomes back into the backlog (#8760)

### DIFF
--- a/scripts/harvest_outcomes.py
+++ b/scripts/harvest_outcomes.py
@@ -123,6 +123,27 @@ def fetch_open_pr_head_refs(*, repo: str) -> set[str]:
     return {row.get("headRefName", "") for row in json.loads(proc.stdout or "[]")}
 
 
+def _verify_origin_fresh(repo_root: Path) -> None:
+    """Fail loud if local origin/main is stale vs the remote.
+
+    Branch ancestry facts (merge-base, is-ancestor, ahead counts) are only
+    meaningful against fresh remote-tracking refs. ``git ls-remote`` is a
+    read-only network check; on mismatch we refuse rather than misclassify.
+    """
+    local = run_git(["rev-parse", "refs/remotes/origin/main"], repo_root)
+    remote = run_git(["ls-remote", "origin", "refs/heads/main"], repo_root, timeout=120)
+    if local.returncode != 0 or remote.returncode != 0:
+        raise RuntimeError(
+            "cannot verify origin/main freshness; run `git fetch origin --prune` and retry"
+        )
+    remote_sha = remote.stdout.split()[0] if remote.stdout.split() else ""
+    if remote_sha and remote_sha != local.stdout.strip():
+        raise RuntimeError(
+            f"local origin/main ({local.stdout.strip()[:12]}) is stale vs remote "
+            f"({remote_sha[:12]}); run `git fetch origin --prune` before harvesting"
+        )
+
+
 def fetch_stale_branches(
     *,
     repo_root: Path,
@@ -130,7 +151,8 @@ def fetch_stale_branches(
     max_branches: int,
     exclude_refs: set[str] | None = None,
 ) -> list[dict[str, Any]]:
-    """Discover stale remote branches (read-only; never mutates refs)."""
+    """Discover stale remote branches (read-only; requires fresh origin refs)."""
+    _verify_origin_fresh(repo_root)
     fmt = "%(refname:short)%09%(objectname)%09%(committerdate:iso8601-strict)"
     proc = run_git(
         ["for-each-ref", "--sort=-committerdate", "refs/remotes/origin/", f"--format={fmt}"],
@@ -301,42 +323,86 @@ def load_filed_sources(ledger_path: Path) -> set[str]:
     return sources
 
 
-def emit_learned_signals(items: list[HarvestItem], signal_log: Path) -> int:
-    """Append one OutcomeSignal per learned-pattern item to the signal log.
+def load_emitted_signal_sources(ledger_path: Path) -> set[str]:
+    """Sources whose learner signal was already emitted in a prior run."""
+    if not ledger_path.exists():
+        return set()
+    sources: set[str] = set()
+    try:
+        with open(ledger_path, encoding="utf-8", errors="replace") as f:
+            for line in f:
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                for source in record.get("signal_sources", []) or []:
+                    sources.add(str(source))
+    except OSError:
+        pass
+    return sources
+
+
+def emit_learned_signals(items: list[HarvestItem], signal_log: Path, ledger_path: Path) -> int:
+    """Append one OutcomeSignal per not-yet-emitted learned-pattern item.
 
     ``aragora.swarm.outcome_learner.load_category_success_rates`` consumes this
-    JSONL log, so appending here is exactly "feeding the learner". Falls back
-    to a plain-dict row (same schema) if the aragora package is unavailable.
+    JSONL log, so appending here is exactly "feeding the learner" (plain-dict
+    fallback if the aragora package is unavailable). Emission is deduped by
+    source via the ledger so repeated --apply runs over overlapping windows
+    never double-count; sources actually written are ledgered even if a
+    mid-batch write fails.
     """
+    already = load_emitted_signal_sources(ledger_path)
+    to_emit = [i for i in items if i.source not in already]
+    if not to_emit:
+        return 0
     signal_log.parent.mkdir(parents=True, exist_ok=True)
-    emitted = 0
-    with open(signal_log, "a", encoding="utf-8") as f:
-        for item in items:
-            ref = str(item.details.get("headRefName") or item.identifier).lower()
-            agent = next(
-                (a for a in ("codex", "claude", "gemini", "grok") if ref.startswith(f"{a}/")), ""
+    written: list[str] = []
+    try:
+        with open(signal_log, "a", encoding="utf-8") as f:
+            for item in to_emit:
+                ref = str(item.details.get("headRefName") or item.identifier).lower()
+                agent = next(
+                    (a for a in ("codex", "claude", "gemini", "grok") if ref.startswith(f"{a}/")),
+                    "",
+                )
+                base: dict[str, Any] = {
+                    "source_loop": "harvest",
+                    "signal_type": "completed",
+                    "entity_id": item.source,
+                    "entity_title": item.title,
+                    "did_merge": "merged" in item.reason or "landed" in item.reason,
+                    "agent_type": agent,
+                }
+                try:
+                    from aragora.swarm.outcome_signals import OutcomeSignal
+
+                    row = OutcomeSignal(**base).to_dict()
+                except ImportError:
+                    row = {**base, "timestamp": datetime.now(UTC).isoformat()}
+                f.write(json.dumps(row) + "\n")
+                written.append(item.source)
+    finally:
+        if written:
+            append_ledger(
+                ledger_path,
+                {
+                    "timestamp": datetime.now(UTC).isoformat(),
+                    "event": "signals_emitted",
+                    "signal_sources": written,
+                },
             )
-            base: dict[str, Any] = {
-                "source_loop": "harvest",
-                "signal_type": "completed",
-                "entity_id": item.source,
-                "entity_title": item.title,
-                "did_merge": "merged" in item.reason or "landed" in item.reason,
-                "agent_type": agent,
-            }
-            try:
-                from aragora.swarm.outcome_signals import OutcomeSignal
-
-                row = OutcomeSignal(**base).to_dict()
-            except ImportError:
-                row = {**base, "timestamp": datetime.now(UTC).isoformat()}
-            f.write(json.dumps(row) + "\n")
-            emitted += 1
-    return emitted
+    return len(written)
 
 
-def file_salvage_issues(repo: str, items: list[HarvestItem]) -> list[dict[str, str]]:
-    """The ONLY gh write path in this script; called only under --apply."""
+def file_salvage_issues(
+    repo: str, items: list[HarvestItem], ledger_path: Path
+) -> list[dict[str, str]]:
+    """The ONLY gh write path in this script; called only under --apply.
+
+    Each successfully-created issue is ledgered IMMEDIATELY so a mid-batch gh
+    failure leaves the ledger true and the next run's dedup skips it.
+    """
     filed = []
     for item in items:
         issue = build_salvage_issue(item)
@@ -345,8 +411,18 @@ def file_salvage_issues(repo: str, items: list[HarvestItem]) -> list[dict[str, s
         )
         if proc.returncode != 0:
             raise RuntimeError(f"gh issue create failed for {item.source}: {proc.stderr.strip()}")
-        url = str(proc.stdout or "").strip().splitlines()[-1].strip()
-        filed.append({"source": item.source, "title": issue["title"], "url": url})
+        lines = str(proc.stdout or "").strip().splitlines()
+        url = lines[-1].strip() if lines else ""
+        record = {"source": item.source, "title": issue["title"], "url": url}
+        append_ledger(
+            ledger_path,
+            {
+                "timestamp": datetime.now(UTC).isoformat(),
+                "event": "issue_filed",
+                "issues_filed": [record],
+            },
+        )
+        filed.append(record)
     return filed
 
 
@@ -414,12 +490,15 @@ def run_harvest(
     issues_filed: list[dict[str, str]] = []
     signals_emitted = 0
     if apply:
-        issues_filed = file_salvage_issues(repo, to_file)
-        signals_emitted = emit_learned_signals(learned, signal_log)
+        # Both steps ledger their own successes incrementally, so a mid-batch
+        # failure in either leaves the ledger true for the next run's dedup.
+        issues_filed = file_salvage_issues(repo, to_file, ledger_path)
+        signals_emitted = emit_learned_signals(learned, signal_log, ledger_path)
         append_ledger(
             ledger_path,
             {
                 "timestamp": datetime.now(UTC).isoformat(),
+                "event": "run_summary",
                 "repo": repo,
                 "since_days": since_days,
                 "counts": counts,
@@ -450,7 +529,8 @@ def run_harvest(
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description=__doc__.splitlines()[1])
+    description = next((line for line in (__doc__ or "").splitlines() if line.strip()), "")
+    parser = argparse.ArgumentParser(description=description)
     parser.add_argument("--repo", default=DEFAULT_REPO)
     parser.add_argument("--repo-root", type=Path, default=Path.cwd())
     parser.add_argument("--since-days", type=int, default=DEFAULT_SINCE_DAYS)

--- a/scripts/harvest_outcomes.py
+++ b/scripts/harvest_outcomes.py
@@ -1,0 +1,511 @@
+#!/usr/bin/env python3
+"""Harvest engine: fold merged/parked/orphaned outcomes back into the backlog (#8760).
+
+Bounded single-pass harvest for cron/launchd (not a daemon): scans recently
+closed/merged PRs and stale remote branches (read-only via gh/git) and
+classifies each as learned-pattern (fed to the swarm OutcomeLearner via the
+outcome-signal JSONL log), salvage-candidate (WIP-capped boss-loop follow-up
+issue), or write-off (recorded, no action). Overflow beyond --max-issues is
+recorded as deferred, never silently dropped; per-run counts append to a
+durable JSONL ledger. DRY-RUN BY DEFAULT — nothing is mutated without --apply.
+This script NEVER closes PRs, deletes branches, or comments on others' PRs;
+those authorities stay with the separately-gated cleanup plan
+(docs/plans/2026-06-30-queue-drain-diagnosis-and-cleanup-plan.md).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+UTC = timezone.utc
+
+DEFAULT_REPO = "synaptent/aragora"
+DEFAULT_SINCE_DAYS = 7
+DEFAULT_MAX_ISSUES = 5
+DEFAULT_MAX_BRANCHES = 50
+DEFAULT_BRANCH_STALE_DAYS = 14
+DEFAULT_PR_SCAN_LIMIT = 200
+DEFAULT_LEDGER_PATH = Path("docs/status/harvest_ledger.jsonl")
+DEFAULT_SIGNAL_LOG = Path("~/.aragora/outcome_signals.jsonl").expanduser()
+
+CLASS_LEARNED = "learned-pattern"
+CLASS_SALVAGE = "salvage-candidate"
+CLASS_WRITEOFF = "write-off"
+
+# Minimum additive diff for salvage (the "genuine feature: additive, tested"
+# archetype from the 2026-06-30 harvest map).
+SALVAGE_MIN_ADDITIONS = 30
+# gh subcommands this script must never issue (cleanup-plan authority).
+_FORBIDDEN_GH_TOKENS = frozenset({"close", "delete", "merge", "comment", "DELETE"})
+# Branch name hints for feature work worth salvaging (vs. substrate churn).
+_SALVAGE_NAME_HINTS = ("feat/", "feat-", "feature/")
+
+_PR_JSON_FIELDS = "number,title,mergedAt,closedAt,additions,deletions,isDraft,headRefName,url"
+
+
+def run_gh(args: list[str], timeout: int = 60) -> subprocess.CompletedProcess[str]:
+    """Run a gh command with a hard guard against destructive subcommands."""
+    forbidden = _FORBIDDEN_GH_TOKENS.intersection(args)
+    if forbidden:
+        raise RuntimeError(
+            f"harvest_outcomes refuses destructive gh subcommand {sorted(forbidden)}; "
+            "close/delete/comment authority stays with the gated cleanup plan"
+        )
+    return subprocess.run(
+        ["gh", *args], capture_output=True, text=True, timeout=timeout, check=False
+    )
+
+
+def run_git(
+    args: list[str], repo_root: Path, timeout: int = 60
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+@dataclass
+class HarvestItem:
+    """One classified PR or branch."""
+
+    kind: str  # "pr" | "branch"
+    identifier: str  # "#8389" or "feat/goals-store"
+    title: str
+    classification: str
+    reason: str
+    url: str = ""
+    head_sha: str = ""
+    details: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def source(self) -> str:
+        """Stable provenance key used for ledger dedup."""
+        return f"{self.kind}:{self.identifier}"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {**asdict(self), "source": self.source}
+
+
+def fetch_recent_prs(
+    *, repo: str, since_days: int, limit: int = DEFAULT_PR_SCAN_LIMIT
+) -> list[dict[str, Any]]:
+    """List PRs closed within the past ``since_days`` days (read-only)."""
+    args = ["pr", "list", "--repo", repo, "--state", "closed", "--limit", str(limit)]
+    proc = run_gh([*args, "--json", _PR_JSON_FIELDS])
+    if proc.returncode != 0:
+        raise RuntimeError(f"gh pr list failed: {proc.stderr.strip()}")
+    cutoff = datetime.now(UTC) - timedelta(days=since_days)
+    prs = []
+    for pr in json.loads(proc.stdout or "[]"):
+        closed_at = _parse_ts(pr.get("closedAt") or pr.get("mergedAt") or "")
+        if closed_at is not None and closed_at >= cutoff:
+            prs.append(pr)
+    return prs
+
+
+def fetch_open_pr_head_refs(*, repo: str) -> set[str]:
+    """Head branch names of open PRs — those branches belong to the PR flow."""
+    args = ["pr", "list", "--repo", repo, "--state", "open", "--limit", "300"]
+    proc = run_gh([*args, "--json", "headRefName"])
+    if proc.returncode != 0:
+        raise RuntimeError(f"gh pr list (open) failed: {proc.stderr.strip()}")
+    return {row.get("headRefName", "") for row in json.loads(proc.stdout or "[]")}
+
+
+def fetch_stale_branches(
+    *,
+    repo_root: Path,
+    stale_days: int,
+    max_branches: int,
+    exclude_refs: set[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Discover stale remote branches (read-only; never mutates refs)."""
+    fmt = "%(refname:short)%09%(objectname)%09%(committerdate:iso8601-strict)"
+    proc = run_git(
+        ["for-each-ref", "--sort=-committerdate", "refs/remotes/origin/", f"--format={fmt}"],
+        repo_root,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"git for-each-ref failed: {proc.stderr.strip()}")
+    exclude = exclude_refs or set()
+    cutoff = datetime.now(UTC) - timedelta(days=stale_days)
+    branches: list[dict[str, Any]] = []
+    for line in proc.stdout.splitlines():
+        parts = line.split("\t")
+        if len(parts) != 3:
+            continue
+        refname, sha, committed = parts
+        name = refname.removeprefix("origin/")
+        if name in ("HEAD", "main", "master") or name in exclude:
+            continue
+        committed_at = _parse_ts(committed)
+        if committed_at is None or committed_at >= cutoff:
+            continue
+        branches.append(_inspect_branch(repo_root, refname, name, sha, committed))
+        if len(branches) >= max_branches:
+            break
+    return branches
+
+
+def _inspect_branch(
+    repo_root: Path, refname: str, name: str, sha: str, committed_at: str
+) -> dict[str, Any]:
+    """Compute ancestry facts for a single remote branch (read-only)."""
+    merge_base = run_git(["merge-base", "origin/main", refname], repo_root)
+    orphaned = merge_base.returncode != 0 or not merge_base.stdout.strip()
+    merged = False
+    ahead_count = 0
+    if not orphaned:
+        is_ancestor = run_git(["merge-base", "--is-ancestor", refname, "origin/main"], repo_root)
+        merged = is_ancestor.returncode == 0
+        if not merged:
+            counted = run_git(["rev-list", "--count", f"origin/main..{refname}"], repo_root)
+            try:
+                ahead_count = int(counted.stdout.strip()) if counted.returncode == 0 else 0
+            except ValueError:
+                ahead_count = 0
+    return {
+        "name": name,
+        "sha": sha[:12],
+        "committed_at": committed_at,
+        "orphaned": orphaned,
+        "merged": merged,
+        "ahead_count": ahead_count,
+    }
+
+
+def _parse_ts(value: str) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
+
+def classify_pr(pr: dict[str, Any]) -> tuple[str, str]:
+    """Classify a recently closed PR into exactly one harvest bucket."""
+    if pr.get("mergedAt"):
+        return CLASS_LEARNED, "merged to main — success outcome for the learner"
+    if pr.get("isDraft"):
+        return CLASS_WRITEOFF, "closed while still draft — abandoned in-flight work"
+    title = str(pr.get("title", ""))
+    additions = int(pr.get("additions") or 0)
+    deletions = int(pr.get("deletions") or 0)
+    is_feature = title.lower().startswith("feat")
+    if is_feature and additions >= SALVAGE_MIN_ADDITIONS and additions > deletions:
+        return CLASS_SALVAGE, (
+            f"closed feature PR with non-trivial additive diff (+{additions}/-{deletions})"
+        )
+    return CLASS_WRITEOFF, (
+        f"closed without merge and no salvage archetype (+{additions}/-{deletions})"
+    )
+
+
+def classify_branch(branch: dict[str, Any]) -> tuple[str, str]:
+    """Classify a stale remote branch into exactly one harvest bucket."""
+    if branch.get("merged"):
+        return CLASS_LEARNED, "branch tip already on main — work landed"
+    if branch.get("orphaned"):
+        return CLASS_WRITEOFF, (
+            "orphaned by history rewrite (no merge-base with origin/main); "
+            "ancestry-unrecoverable — deletion stays with the gated cleanup plan"
+        )
+    name = str(branch.get("name", "")).lower()
+    ahead = int(branch.get("ahead_count") or 0)
+    if ahead > 0 and any(hint in name for hint in _SALVAGE_NAME_HINTS):
+        return CLASS_SALVAGE, f"stale feature branch with {ahead} unique commit(s)"
+    if ahead == 0:
+        return CLASS_WRITEOFF, "no unique commits vs origin/main"
+    return CLASS_WRITEOFF, "stale non-feature branch (substrate churn archetype)"
+
+
+def build_salvage_issue(item: HarvestItem) -> dict[str, str]:
+    """Render a bounded follow-up issue in boss-loop format."""
+    origin = f"PR {item.identifier}" if item.kind == "pr" else f"branch `{item.identifier}`"
+    provenance = [f"- harvest-source: {item.source}"]
+    if item.url:
+        provenance.append(f"- origin: {item.url}")
+    if item.head_sha:
+        provenance.append(f"- head SHA: {item.head_sha}")
+    provenance.append(f"- classification reason: {item.reason}")
+    body = "\n".join(
+        [
+            "Bounded salvage follow-up generated by `scripts/harvest_outcomes.py` (#8760).",
+            "",
+            "## Files",
+            f"- Recover the diff from {origin} "
+            "(cherry-pick or re-implement against current main; do NOT force-merge stale history).",
+            "",
+            "## Acceptance",
+            "- The salvageable behavior from the source is re-landed on main behind tests.",
+            "- New/changed code has test coverage; full suite stays green.",
+            "- If the value is no longer relevant, close this issue with a recorded rationale.",
+            "",
+            "## Constraints",
+            "- Scope to the single feature from the source diff; no drive-by refactors.",
+            "- Never delete the source branch or close the source PR from this issue "
+            "(that authority stays with the gated cleanup plan).",
+            "- Keep the change reviewable (<800 LOC delta).",
+            "",
+            "## Provenance",
+            *provenance,
+        ]
+    )
+    return {"title": f"Salvage: {item.title} (from {origin})"[:200], "body": body}
+
+
+def apply_wip_cap(
+    items: list[HarvestItem], max_issues: int
+) -> tuple[list[HarvestItem], list[HarvestItem]]:
+    """Split salvage candidates at the WIP cap; the tail is deferred, not dropped."""
+    cap = max(0, int(max_issues))
+    return items[:cap], items[cap:]
+
+
+def append_ledger(ledger_path: Path, record: dict[str, Any]) -> None:
+    ledger_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(ledger_path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def load_filed_sources(ledger_path: Path) -> set[str]:
+    """Sources for which a salvage issue was already filed in a prior run."""
+    if not ledger_path.exists():
+        return set()
+    sources: set[str] = set()
+    try:
+        with open(ledger_path, encoding="utf-8", errors="replace") as f:
+            for line in f:
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                for filed in record.get("issues_filed", []) or []:
+                    if filed.get("source"):
+                        sources.add(str(filed["source"]))
+    except OSError:
+        pass
+    return sources
+
+
+def emit_learned_signals(items: list[HarvestItem], signal_log: Path) -> int:
+    """Append one OutcomeSignal per learned-pattern item to the signal log.
+
+    ``aragora.swarm.outcome_learner.load_category_success_rates`` consumes this
+    JSONL log, so appending here is exactly "feeding the learner". Falls back
+    to a plain-dict row (same schema) if the aragora package is unavailable.
+    """
+    signal_log.parent.mkdir(parents=True, exist_ok=True)
+    emitted = 0
+    with open(signal_log, "a", encoding="utf-8") as f:
+        for item in items:
+            ref = str(item.details.get("headRefName") or item.identifier).lower()
+            agent = next(
+                (a for a in ("codex", "claude", "gemini", "grok") if ref.startswith(f"{a}/")), ""
+            )
+            base: dict[str, Any] = {
+                "source_loop": "harvest",
+                "signal_type": "completed",
+                "entity_id": item.source,
+                "entity_title": item.title,
+                "did_merge": "merged" in item.reason or "landed" in item.reason,
+                "agent_type": agent,
+            }
+            try:
+                from aragora.swarm.outcome_signals import OutcomeSignal
+
+                row = OutcomeSignal(**base).to_dict()
+            except ImportError:
+                row = {**base, "timestamp": datetime.now(UTC).isoformat()}
+            f.write(json.dumps(row) + "\n")
+            emitted += 1
+    return emitted
+
+
+def file_salvage_issues(repo: str, items: list[HarvestItem]) -> list[dict[str, str]]:
+    """The ONLY gh write path in this script; called only under --apply."""
+    filed = []
+    for item in items:
+        issue = build_salvage_issue(item)
+        proc = run_gh(
+            ["issue", "create", "--repo", repo, "--title", issue["title"], "--body", issue["body"]]
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(f"gh issue create failed for {item.source}: {proc.stderr.strip()}")
+        url = str(proc.stdout or "").strip().splitlines()[-1].strip()
+        filed.append({"source": item.source, "title": issue["title"], "url": url})
+    return filed
+
+
+def run_harvest(
+    *,
+    repo: str,
+    repo_root: Path,
+    since_days: int = DEFAULT_SINCE_DAYS,
+    max_issues: int = DEFAULT_MAX_ISSUES,
+    max_branches: int = DEFAULT_MAX_BRANCHES,
+    branch_stale_days: int = DEFAULT_BRANCH_STALE_DAYS,
+    ledger_path: Path = DEFAULT_LEDGER_PATH,
+    signal_log: Path = DEFAULT_SIGNAL_LOG,
+    apply: bool = False,
+) -> dict[str, Any]:
+    """One bounded harvest pass. Read-only unless ``apply`` is True."""
+    items: list[HarvestItem] = []
+    for pr in fetch_recent_prs(repo=repo, since_days=since_days):
+        classification, reason = classify_pr(pr)
+        items.append(
+            HarvestItem(
+                "pr",
+                f"#{pr.get('number')}",
+                str(pr.get("title", "")),
+                classification,
+                reason,
+                url=str(pr.get("url", "")),
+                details={"headRefName": pr.get("headRefName", "")},
+            )
+        )
+    open_heads = fetch_open_pr_head_refs(repo=repo)
+    for branch in fetch_stale_branches(
+        repo_root=repo_root,
+        stale_days=branch_stale_days,
+        max_branches=max_branches,
+        exclude_refs=open_heads,
+    ):
+        classification, reason = classify_branch(branch)
+        name = str(branch.get("name", ""))
+        items.append(
+            HarvestItem(
+                "branch",
+                name,
+                name,
+                classification,
+                reason,
+                head_sha=str(branch.get("sha", "")),
+                details={"ahead_count": branch.get("ahead_count", 0)},
+            )
+        )
+
+    learned = [i for i in items if i.classification == CLASS_LEARNED]
+    salvage = [i for i in items if i.classification == CLASS_SALVAGE]
+    already_filed = load_filed_sources(ledger_path)
+    skipped = [i for i in salvage if i.source in already_filed]
+    fresh = [i for i in salvage if i.source not in already_filed]
+    to_file, deferred = apply_wip_cap(fresh, max_issues)
+    counts = {
+        CLASS_LEARNED: len(learned),
+        CLASS_SALVAGE: len(salvage),
+        CLASS_WRITEOFF: sum(1 for i in items if i.classification == CLASS_WRITEOFF),
+        "total": len(items),
+    }
+
+    issues_filed: list[dict[str, str]] = []
+    signals_emitted = 0
+    if apply:
+        issues_filed = file_salvage_issues(repo, to_file)
+        signals_emitted = emit_learned_signals(learned, signal_log)
+        append_ledger(
+            ledger_path,
+            {
+                "timestamp": datetime.now(UTC).isoformat(),
+                "repo": repo,
+                "since_days": since_days,
+                "counts": counts,
+                "issues_filed": issues_filed,
+                "deferred": [i.source for i in deferred],
+                "skipped_already_filed": [i.source for i in skipped],
+                "signals_emitted": signals_emitted,
+            },
+        )
+
+    return {
+        "timestamp": datetime.now(UTC).isoformat(),
+        "mode": "apply" if apply else "dry-run",
+        "repo": repo,
+        "since_days": since_days,
+        "counts": counts,
+        "items": [i.to_dict() for i in items],
+        "salvage": {
+            "to_file": [i.to_dict() for i in to_file],
+            "deferred": [i.to_dict() for i in deferred],
+            "skipped_already_filed": [i.to_dict() for i in skipped],
+        },
+        "issues_filed": issues_filed,
+        "signals_emitted": signals_emitted,
+        "ledger_appended": apply,
+        "ledger_path": str(ledger_path),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[1])
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--since-days", type=int, default=DEFAULT_SINCE_DAYS)
+    parser.add_argument("--max-issues", type=int, default=DEFAULT_MAX_ISSUES)
+    parser.add_argument("--max-branches", type=int, default=DEFAULT_MAX_BRANCHES)
+    parser.add_argument("--branch-stale-days", type=int, default=DEFAULT_BRANCH_STALE_DAYS)
+    parser.add_argument("--ledger-path", type=Path, default=DEFAULT_LEDGER_PATH)
+    parser.add_argument("--signal-log", type=Path, default=DEFAULT_SIGNAL_LOG)
+    parser.add_argument("--apply", action="store_true", help="Mutate (otherwise dry-run)")
+    parser.add_argument("--json", action="store_true", help="Emit structured JSON output")
+    return parser
+
+
+def _print_human(result: dict[str, Any]) -> None:
+    counts = result["counts"]
+    print(f"harvest_outcomes [{result['mode']}] repo={result['repo']}")
+    print("  counts: " + " | ".join(f"{v} {k}" for k, v in counts.items()))
+    for item in result.get("items", []):
+        print(f"  [{item['classification']:>17}] {item['source']}: {item['reason']}")
+    salvage = result.get("salvage", {})
+    for bucket in ("to_file", "deferred", "skipped_already_filed"):
+        for item in salvage.get(bucket, []):
+            print(f"  salvage {bucket}: {item['source']} — {item['title']}")
+    for filed in result.get("issues_filed", []):
+        print(f"  filed: {filed['url']} ({filed['source']})")
+    print(
+        f"  signals_emitted={result.get('signals_emitted', 0)} "
+        f"ledger_appended={result.get('ledger_appended', False)} "
+        f"ledger={result.get('ledger_path', '')}"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        result = run_harvest(
+            repo=args.repo,
+            repo_root=args.repo_root,
+            since_days=args.since_days,
+            max_issues=args.max_issues,
+            max_branches=args.max_branches,
+            branch_stale_days=args.branch_stale_days,
+            ledger_path=args.ledger_path,
+            signal_log=args.signal_log,
+            apply=args.apply,
+        )
+    except (RuntimeError, subprocess.TimeoutExpired, OSError) as exc:
+        print(f"harvest_outcomes failed: {exc}", file=sys.stderr)
+        return 1
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        _print_human(result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_harvest_outcomes.py
+++ b/tests/scripts/test_harvest_outcomes.py
@@ -229,6 +229,11 @@ class TestRunHarvestDryRun:
         assert len(result["salvage"]["to_file"]) == 2  # still rendered for inspection
 
 
+def _ledger_records(ledger: Path, event: str | None = None) -> list[dict[str, Any]]:
+    records = [json.loads(line) for line in ledger.read_text().strip().splitlines()]
+    return [r for r in records if event is None or r.get("event") == event]
+
+
 class TestRunHarvestApply:
     def test_apply_files_issues_and_appends_ledger(self, harness):
         result = _run(harness, apply=True)
@@ -236,19 +241,58 @@ class TestRunHarvestApply:
         creates = [c for c in harness["gh_calls"] if c[:2] == ["issue", "create"]]
         assert len(creates) == 2
         assert len(result["issues_filed"]) == 2
-        lines = harness["ledger"].read_text().strip().splitlines()
-        assert len(lines) == 1
-        record = json.loads(lines[0])
-        assert record["counts"]["total"] == 6
-        assert len(record["issues_filed"]) == 2
+        # Each filed issue is ledgered immediately, then signals, then summary.
+        assert len(_ledger_records(harness["ledger"], "issue_filed")) == 2
+        summaries = _ledger_records(harness["ledger"], "run_summary")
+        assert len(summaries) == 1
+        assert summaries[0]["counts"]["total"] == 6
+        assert len(summaries[0]["issues_filed"]) == 2
 
     def test_apply_respects_wip_cap_and_records_deferred(self, harness):
         result = _run(harness, apply=True, max_issues=1)
         creates = [c for c in harness["gh_calls"] if c[:2] == ["issue", "create"]]
         assert len(creates) == 1
         assert len(result["salvage"]["deferred"]) == 1
-        record = json.loads(harness["ledger"].read_text().strip().splitlines()[0])
-        assert len(record["deferred"]) == 1  # deferred is never silently dropped
+        summary = _ledger_records(harness["ledger"], "run_summary")[0]
+        assert len(summary["deferred"]) == 1  # deferred is never silently dropped
+
+    def test_mid_batch_gh_failure_leaves_ledger_true(self, harness, monkeypatch):
+        """First create succeeds, second fails: the success is still ledgered
+        and the next run dedups it instead of re-filing a duplicate."""
+        calls = {"n": 0}
+
+        class Ok:
+            returncode = 0
+            stdout = "https://github.com/synaptent/aragora/issues/901\n"
+            stderr = ""
+
+        class Boom:
+            returncode = 1
+            stdout = ""
+            stderr = "HTTP 502"
+
+        def flaky_run_gh(args: list[str], timeout: int = 60) -> Any:
+            harness["gh_calls"].append(list(args))
+            calls["n"] += 1
+            return Ok() if calls["n"] == 1 else Boom()
+
+        monkeypatch.setattr(mod, "run_gh", flaky_run_gh)
+        with pytest.raises(RuntimeError):
+            _run(harness, apply=True)
+        filed = _ledger_records(harness["ledger"], "issue_filed")
+        assert len(filed) == 1  # the success survived the mid-batch failure
+        first_source = filed[0]["issues_filed"][0]["source"]
+
+        def healthy_run_gh(args: list[str], timeout: int = 60) -> Any:
+            harness["gh_calls"].append(list(args))
+            return Ok()
+
+        # Second run with healthy gh: the ledgered issue is NOT re-filed.
+        monkeypatch.setattr(mod, "run_gh", healthy_run_gh)
+        result = _run(harness, apply=True)
+        refiled = [f["source"] for f in result["issues_filed"]]
+        assert first_source not in refiled
+        assert len(refiled) == 1  # only the remaining candidate
 
     def test_apply_emits_learned_signals(self, harness):
         result = _run(harness, apply=True)
@@ -256,6 +300,28 @@ class TestRunHarvestApply:
         lines = harness["signal_log"].read_text().strip().splitlines()
         assert len(lines) == 2
         assert json.loads(lines[0])["source_loop"] == "harvest"
+
+    def test_double_apply_emits_no_duplicate_signals(self, harness):
+        first = _run(harness, apply=True)
+        second = _run(harness, apply=True)
+        assert first["signals_emitted"] == 2
+        assert second["signals_emitted"] == 0
+        # Same window twice: the learner input is never double-counted.
+        assert len(harness["signal_log"].read_text().strip().splitlines()) == 2
+
+    def test_empty_stdout_gh_success_is_handled(self, harness, monkeypatch):
+        class EmptyOk:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        def empty_run_gh(args: list[str], timeout: int = 60) -> Any:
+            harness["gh_calls"].append(list(args))
+            return EmptyOk()
+
+        monkeypatch.setattr(mod, "run_gh", empty_run_gh)
+        result = _run(harness, apply=True)  # must not raise IndexError
+        assert all(f["url"] == "" for f in result["issues_filed"])
 
     def test_apply_skips_sources_already_filed(self, harness):
         mod.append_ledger(
@@ -275,12 +341,47 @@ class TestRunHarvestApply:
             assert call[:2] == ["issue", "create"]
 
 
+class TestOriginFreshness:
+    @staticmethod
+    def _proc(rc: int, out: str) -> Any:
+        class P:
+            returncode = rc
+            stdout = out
+            stderr = ""
+
+        return P()
+
+    def test_stale_origin_main_fails_loud(self, monkeypatch):
+        def fake_run_git(args: list[str], repo_root: Path, timeout: int = 60) -> Any:
+            if args[0] == "rev-parse":
+                return self._proc(0, "aaa111\n")
+            return self._proc(0, "bbb222\trefs/heads/main\n")
+
+        monkeypatch.setattr(mod, "run_git", fake_run_git)
+        with pytest.raises(RuntimeError, match="stale"):
+            mod._verify_origin_fresh(Path("."))
+
+    def test_fresh_origin_main_passes(self, monkeypatch):
+        def fake_run_git(args: list[str], repo_root: Path, timeout: int = 60) -> Any:
+            if args[0] == "rev-parse":
+                return self._proc(0, "aaa111\n")
+            return self._proc(0, "aaa111\trefs/heads/main\n")
+
+        monkeypatch.setattr(mod, "run_git", fake_run_git)
+        mod._verify_origin_fresh(Path("."))  # must not raise
+
+
 class TestMain:
     def test_defaults(self):
         args = mod.build_parser().parse_args([])
         assert args.since_days == 7
         assert args.max_issues == 5
         assert args.apply is False
+
+    def test_help_description_is_first_nonempty_docstring_line(self):
+        description = mod.build_parser().description
+        assert description and description.strip()
+        assert "Harvest engine" in description
 
     def test_json_output(self, harness, capsys, monkeypatch):
         monkeypatch.setattr(mod, "run_harvest", lambda **kw: {"mode": "dry-run", "counts": {}})

--- a/tests/scripts/test_harvest_outcomes.py
+++ b/tests/scripts/test_harvest_outcomes.py
@@ -1,0 +1,289 @@
+"""Tests for scripts/harvest_outcomes.py (#8760). gh/git fully mocked; no live GitHub access."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import scripts.harvest_outcomes as mod
+
+
+def _pr(**overrides: Any) -> dict[str, Any]:
+    pr: dict[str, Any] = {
+        "number": 1,
+        "title": "feat: add widget",
+        "mergedAt": None,
+        "closedAt": "2026-06-30T00:00:00Z",
+        "additions": 120,
+        "deletions": 10,
+        "isDraft": False,
+        "headRefName": "feat/widget",
+        "url": "https://github.com/synaptent/aragora/pull/1",
+    }
+    pr.update(overrides)
+    return pr
+
+
+def _branch(**overrides: Any) -> dict[str, Any]:
+    branch: dict[str, Any] = {
+        "name": "feat/orphan-widget",
+        "sha": "abc1234",
+        "merged": False,
+        "orphaned": False,
+        "ahead_count": 3,
+        "committed_at": "2026-06-01T00:00:00+00:00",
+    }
+    branch.update(overrides)
+    return branch
+
+
+def _item(kind: str = "pr", identifier: str = "#42", **kw: Any) -> mod.HarvestItem:
+    return mod.HarvestItem(
+        kind, identifier, kw.pop("title", "feat: add widget"), mod.CLASS_SALVAGE, "reason", **kw
+    )
+
+
+class TestClassifyPR:
+    def test_merged_pr_is_learned_pattern(self):
+        classification, reason = mod.classify_pr(_pr(mergedAt="2026-06-29T12:00:00Z"))
+        assert classification == mod.CLASS_LEARNED
+        assert "merged" in reason.lower()
+
+    def test_closed_feature_pr_with_additive_diff_is_salvage(self):
+        pr = _pr(title="feat(routing): pareto optimizer", additions=200, deletions=20)
+        assert mod.classify_pr(pr)[0] == mod.CLASS_SALVAGE
+
+    def test_closed_trivial_pr_is_write_off(self):
+        pr = _pr(title="fix: bump lockfile", additions=4, deletions=4)
+        assert mod.classify_pr(pr)[0] == mod.CLASS_WRITEOFF
+
+    def test_closed_draft_pr_is_write_off(self):
+        assert (
+            mod.classify_pr(_pr(title="feat: half-finished", isDraft=True))[0] == mod.CLASS_WRITEOFF
+        )
+
+    def test_closed_non_feature_churn_is_write_off(self):
+        pr = _pr(title="fix(reconcile): patch proof path again", additions=300)
+        assert mod.classify_pr(pr)[0] == mod.CLASS_WRITEOFF
+
+
+class TestClassifyBranch:
+    def test_merged_branch_is_learned_pattern(self):
+        classification, reason = mod.classify_branch(_branch(merged=True))
+        assert classification == mod.CLASS_LEARNED
+        assert "main" in reason.lower()
+
+    def test_orphaned_branch_is_write_off(self):
+        classification, reason = mod.classify_branch(_branch(orphaned=True))
+        assert classification == mod.CLASS_WRITEOFF
+        assert "merge-base" in reason.lower() or "orphan" in reason.lower()
+
+    def test_stale_feature_branch_with_unique_commits_is_salvage(self):
+        branch = _branch(name="feat/goals-store", ahead_count=5)
+        assert mod.classify_branch(branch)[0] == mod.CLASS_SALVAGE
+
+    def test_stale_non_feature_branch_is_write_off(self):
+        assert mod.classify_branch(_branch(name="codex/settle-retry-17"))[0] == mod.CLASS_WRITEOFF
+
+    def test_branch_with_no_unique_commits_is_write_off(self):
+        branch = _branch(name="feat/empty", ahead_count=0)
+        assert mod.classify_branch(branch)[0] == mod.CLASS_WRITEOFF
+
+
+class TestSalvageIssueFormat:
+    def test_body_uses_boss_loop_sections(self):
+        issue = mod.build_salvage_issue(
+            _item(url="https://github.com/synaptent/aragora/pull/42", head_sha="abc1234")
+        )
+        assert issue["title"]
+        for section in ("## Files", "## Acceptance", "## Constraints"):
+            assert section in issue["body"]
+
+    def test_body_carries_provenance_marker(self):
+        item = _item(kind="branch", identifier="feat/goals-store", head_sha="deadbee")
+        issue = mod.build_salvage_issue(item)
+        assert "harvest-source: branch:feat/goals-store" in issue["body"]
+        assert "deadbee" in issue["body"]
+
+
+class TestWipCap:
+    def test_cap_splits_without_dropping(self):
+        items = [_item(identifier=f"#{i}") for i in range(7)]
+        to_file, deferred = mod.apply_wip_cap(items, max_issues=5)
+        assert len(to_file) == 5
+        assert len(deferred) == 2
+        # Nothing silently dropped, order preserved.
+        assert [i.identifier for i in to_file + deferred] == [f"#{i}" for i in range(7)]
+
+    def test_zero_cap_defers_everything(self):
+        to_file, deferred = mod.apply_wip_cap([_item()], max_issues=0)
+        assert to_file == []
+        assert len(deferred) == 1
+
+
+class TestLedger:
+    def test_append_and_reload_filed_sources(self, tmp_path: Path):
+        ledger = tmp_path / "harvest_ledger.jsonl"
+        mod.append_ledger(
+            ledger,
+            {
+                "timestamp": "2026-07-01T00:00:00+00:00",
+                "counts": {mod.CLASS_SALVAGE: 1},
+                "issues_filed": [{"source": "pr:#42", "url": "https://x/issues/1"}],
+            },
+        )
+        mod.append_ledger(ledger, {"timestamp": "t2", "counts": {}, "issues_filed": []})
+        lines = ledger.read_text().strip().splitlines()
+        assert len(lines) == 2
+        assert json.loads(lines[0])["counts"][mod.CLASS_SALVAGE] == 1
+        assert mod.load_filed_sources(ledger) == {"pr:#42"}
+
+    def test_load_filed_sources_missing_file(self, tmp_path: Path):
+        assert mod.load_filed_sources(tmp_path / "nope.jsonl") == set()
+
+
+class TestGhGuard:
+    def test_destructive_gh_subcommands_are_refused(self):
+        for argv in (
+            ["pr", "close", "42"],
+            ["pr", "merge", "42"],
+            ["issue", "close", "42"],
+            ["pr", "comment", "42", "--body", "x"],
+            ["api", "-X", "DELETE", "repos/o/r/git/refs/heads/b"],
+        ):
+            with pytest.raises(RuntimeError):
+                mod.run_gh(argv)
+
+
+@pytest.fixture
+def harness(monkeypatch, tmp_path: Path):
+    """Mock all gh/git discovery and record write attempts."""
+    prs = [
+        _pr(number=1, title="feat: merged thing", mergedAt="2026-06-29T00:00:00Z"),
+        _pr(number=2, title="feat(goals): salvageable", additions=150, deletions=10),
+        _pr(number=3, title="chore: churn", additions=2, deletions=2),
+    ]
+    branches = [
+        _branch(name="feat/stranded-value", ahead_count=4),
+        _branch(name="codex/orphan-1", orphaned=True),
+        _branch(name="codex/landed", merged=True),
+    ]
+    gh_calls: list[list[str]] = []
+
+    monkeypatch.setattr(mod, "fetch_recent_prs", lambda **kw: prs)
+    monkeypatch.setattr(mod, "fetch_stale_branches", lambda **kw: branches)
+    monkeypatch.setattr(mod, "fetch_open_pr_head_refs", lambda **kw: set())
+
+    class FakeProc:
+        returncode = 0
+        stdout = "https://github.com/synaptent/aragora/issues/999\n"
+        stderr = ""
+
+    def fake_run_gh(args: list[str], timeout: int = 60) -> Any:
+        gh_calls.append(list(args))
+        return FakeProc()
+
+    monkeypatch.setattr(mod, "run_gh", fake_run_gh)
+    return {
+        "gh_calls": gh_calls,
+        "ledger": tmp_path / "ledger.jsonl",
+        "signal_log": tmp_path / "signals.jsonl",
+    }
+
+
+def _run(harness: dict[str, Any], **overrides: Any) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {
+        "repo": "synaptent/aragora",
+        "repo_root": Path("."),
+        "since_days": 7,
+        "max_issues": 5,
+        "max_branches": 50,
+        "branch_stale_days": 14,
+        "ledger_path": harness["ledger"],
+        "signal_log": harness["signal_log"],
+        "apply": False,
+    }
+    kwargs.update(overrides)
+    return mod.run_harvest(**kwargs)
+
+
+class TestRunHarvestDryRun:
+    def test_classifies_all_items(self, harness):
+        result = _run(harness)
+        assert result["mode"] == "dry-run"
+        counts = result["counts"]
+        assert counts[mod.CLASS_LEARNED] == 2  # merged PR + merged branch
+        assert counts[mod.CLASS_SALVAGE] == 2  # PR #2 + feat/stranded-value
+        assert counts[mod.CLASS_WRITEOFF] == 2  # churn PR + orphaned branch
+        assert counts["total"] == 6
+
+    def test_dry_run_never_writes(self, harness):
+        result = _run(harness)
+        assert harness["gh_calls"] == []
+        assert not harness["ledger"].exists()
+        assert not harness["signal_log"].exists()
+        assert result["issues_filed"] == []
+        assert len(result["salvage"]["to_file"]) == 2  # still rendered for inspection
+
+
+class TestRunHarvestApply:
+    def test_apply_files_issues_and_appends_ledger(self, harness):
+        result = _run(harness, apply=True)
+        assert result["mode"] == "apply"
+        creates = [c for c in harness["gh_calls"] if c[:2] == ["issue", "create"]]
+        assert len(creates) == 2
+        assert len(result["issues_filed"]) == 2
+        lines = harness["ledger"].read_text().strip().splitlines()
+        assert len(lines) == 1
+        record = json.loads(lines[0])
+        assert record["counts"]["total"] == 6
+        assert len(record["issues_filed"]) == 2
+
+    def test_apply_respects_wip_cap_and_records_deferred(self, harness):
+        result = _run(harness, apply=True, max_issues=1)
+        creates = [c for c in harness["gh_calls"] if c[:2] == ["issue", "create"]]
+        assert len(creates) == 1
+        assert len(result["salvage"]["deferred"]) == 1
+        record = json.loads(harness["ledger"].read_text().strip().splitlines()[0])
+        assert len(record["deferred"]) == 1  # deferred is never silently dropped
+
+    def test_apply_emits_learned_signals(self, harness):
+        result = _run(harness, apply=True)
+        assert result["signals_emitted"] == 2
+        lines = harness["signal_log"].read_text().strip().splitlines()
+        assert len(lines) == 2
+        assert json.loads(lines[0])["source_loop"] == "harvest"
+
+    def test_apply_skips_sources_already_filed(self, harness):
+        mod.append_ledger(
+            harness["ledger"],
+            {"timestamp": "t", "counts": {}, "issues_filed": [{"source": "pr:#2"}]},
+        )
+        result = _run(harness, apply=True)
+        creates = [c for c in harness["gh_calls"] if c[:2] == ["issue", "create"]]
+        assert len(creates) == 1  # only the branch candidate; pr:#2 deduped
+        assert len(result["salvage"]["skipped_already_filed"]) == 1
+
+    def test_apply_only_ever_creates_issues(self, harness):
+        _run(harness, apply=True)
+        for call in harness["gh_calls"]:
+            # The only gh invocation an apply run may make is `gh issue create`;
+            # close/delete/comment/merge authority stays with the cleanup plan.
+            assert call[:2] == ["issue", "create"]
+
+
+class TestMain:
+    def test_defaults(self):
+        args = mod.build_parser().parse_args([])
+        assert args.since_days == 7
+        assert args.max_issues == 5
+        assert args.apply is False
+
+    def test_json_output(self, harness, capsys, monkeypatch):
+        monkeypatch.setattr(mod, "run_harvest", lambda **kw: {"mode": "dry-run", "counts": {}})
+        rc = mod.main(["--json", "--ledger-path", str(harness["ledger"])])
+        assert rc == 0
+        assert json.loads(capsys.readouterr().out)["mode"] == "dry-run"


### PR DESCRIPTION
Implements #8760 (part of epic #8762): the recurring harvest pass that folds merged/parked/orphaned outcomes back into the backlog, closing the "no harvest engine" gap from the 2026-06-30 queue-drain diagnosis.

## What

`scripts/harvest_outcomes.py` — a bounded, single-pass harvest (cron/launchd-invokable, not a daemon):

- Scans recently closed/merged PRs (`--since-days`, default 7) and stale remote branches (`--branch-stale-days` 14, capped at `--max-branches` 50) — read-only discovery via `gh` / `git`
- Classifies each item into exactly one bucket:
  - **learned-pattern** — merged PRs / already-landed branches; fed to the swarm `OutcomeLearner` by appending `OutcomeSignal` rows to the outcome-signal JSONL log it consumes (composes `aragora.swarm.outcome_signals` + `outcome_learner`; no new framework)
  - **salvage-candidate** — closed feature PRs with non-trivial additive diffs and stale feature branches with unique commits; would file a bounded follow-up issue in boss-loop format (`## Files` / `## Acceptance` / `## Constraints`, with provenance + `harvest-source:` dedup marker)
  - **write-off** — recorded, no action (incl. history-rewrite-orphaned branches with no merge-base)
- WIP-capped: `--max-issues` (default 5); overflow is recorded as **deferred** in output + ledger, never silently dropped; ledger-based dedup prevents refiling the same source across runs
- Durable ledger: per-run counts append to `docs/status/harvest_ledger.jsonl` (`--ledger-path`) so drain progress is measurable week over week
- **Dry-run by default**; `--apply` gates all three write paths (issue filing, signal emission, ledger append); `--json` for structured output
- Safety: `run_gh` hard-refuses `close`/`delete`/`merge`/`comment`/`DELETE` — this script never closes PRs, never deletes branches, never comments on others' PRs; those authorities stay with the separately-gated cleanup plan

## Tests

`tests/scripts/test_harvest_outcomes.py` — 26 tests, all gh/git mocked, no live GitHub mutations. Covers classification of both kinds, boss-loop issue format, WIP cap (nothing dropped), ledger roundtrip + dedup, dry-run makes zero writes, apply files only `gh issue create`, destructive-subcommand guard, CLI defaults, `--json` output.

## Read-only dry-run demo (real repo, 2026-07-01)

172 items classified: **63 learned-pattern** (merged PRs + landed branches), **5 salvage-candidate**, **104 write-off** (churn PRs + orphaned/no-merge-base branches). Would file exactly the WIP cap of 5: `pr:#8628`, `pr:#8627`, `pr:#8543`, `pr:#8541`, `branch:feature/ground-threshold-6375` — note #8543 and #8541 are two of the 8 genuine features independently identified in the 2026-06-30 harvest map. No mutations occurred (`ledger_appended: false`, zero gh writes).

## Constraints honored

- Composes `outcome_feedback`/`outcome_learner` surface; no new learning framework
- Untouched: `.github/workflows`, `aragora/cli/commands/review_queue.py`, `aragora/swarm/quorum_evidence.py`
- 800 LOC delta (2 new files); pre-commit + mypy clean; suite count only increases (+26)

Refs #8760, epic #8762.

🤖 Generated with [Claude Code](https://claude.com/claude-code)