### PR TITLE
refactor(events): relocate debate reactions to debate domain home (P4a Batch E4)

### DIFF
--- a/aragora/debate/event_subscribers.py
+++ b/aragora/debate/event_subscribers.py
@@ -1,11 +1,34 @@
-"""Domain-subset bootstrap for cross-subsystem event subscribers (P4a E1).
+"""Debate-domain event-subscriber home + domain-subset bootstrap (P4a EventBus
+inversion; E1 skeleton, home content added by Batch E4).
 
-Composition root for the *domain* layer (Arena / pure-library debate). It imports
-only domain home modules so their subscribers self-register, then wires them into
-the cross-subscriber manager. Application/interface reactions (workflow, nomic,
-server) register when *those* subsystems initialize; a pure-library debate with no
-server/workflow engine simply has no such reactions (matching today's try/except
-fallbacks).
+This module has two roles:
+
+1. The debate-domain's own event-subscriber **home**: the debate-coupled
+   cross-subsystem reactions, relocated here from infrastructure
+   ``aragora.events.cross_subscribers.handlers.{basic,strategic}`` (P4a Batch E4
+   relocate-UP) so they live in their DOMAIN home. ``DebateEventSubscriber``
+   self-registers via the domain-free registry
+   (``aragora.events.cross_subscribers.register_subscriber`` - domain ->
+   infrastructure, downward = legal).
+2. Domain-subset **composition root** for the *domain* layer (Arena / pure-library
+   debate): ``bootstrap_debate_event_subscribers`` imports sibling domain home
+   modules so their subscribers self-register, then wires every domain subscriber
+   (including this module's own) into the cross-subscriber manager.
+   Application/interface reactions (workflow, nomic, server) register when *those*
+   subsystems initialize; a pure-library debate with no server/workflow engine
+   simply has no such reactions (matching today's try/except fallbacks).
+
+Per the relocate-UP no-shim exemption (AGENTS.md "P4a Contracts-Thread Shared Rules"
+and docs/architecture/P4A_EVENTS_QUEUE_INVERSION.md §8) there is NO re-export shim at
+the old path; every consumer is repointed instead.
+
+Handles:
+- Agent ELO → Debate: Performance updates propagate to agent-pool team selection weights
+- Calibration → Agent: Confidence weight updates propagate to the agent pool
+- Consensus → Selection feedback learning
+- Agent message → Rhetorical analysis
+- Budget alert → Team selection constraint
+- Meta-learning adjustment → Team selection recalibration
 
 This module lives in ``debate`` (domain) and imports only sibling-domain home
 modules plus ``aragora.events.cross_subscribers`` (domain -> infrastructure,
@@ -15,28 +38,358 @@ recreate an upward import. See docs/architecture/P4A_EVENTS_QUEUE_INVERSION.md �
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import logging
+from typing import TYPE_CHECKING, Protocol, cast
+
+from aragora.events.cross_subscribers import get_registered_subscribers, register_subscriber
+from aragora.events.types import StreamEventType
 
 if TYPE_CHECKING:
     from aragora.events.cross_subscribers import CrossSubscriberManager
+    from aragora.events.types import StreamEvent
+
+logger = logging.getLogger(__name__)
+
+DEBATE_EVENT_SUBSCRIBER_HANDLER_NAMES = frozenset(
+    {
+        "elo_to_debate",
+        "calibration_to_agent",
+        "consensus_to_learning",
+        "agent_message_to_rhetorical",
+        "budget_alert_to_team_selection",
+        "meta_learning_to_team_selection",
+    }
+)
+
+
+class AgentPoolProtocol(Protocol):
+    """Protocol for agent pool with ELO and calibration updates."""
+
+    def update_elo_weight(self, agent_name: str, elo: float) -> None:
+        """Update the ELO weight for an agent."""
+        ...
+
+    def update_calibration(
+        self,
+        agent_name: str,
+        score: float,
+        brier_score: float | None = None,
+    ) -> None:
+        """Update calibration data for an agent."""
+        ...
+
+
+class DebateEventSubscriber:
+    """Debate-domain cross-subscriber: ELO/calibration/consensus/rhetoric/team-selection reactions."""
+
+    def _handle_elo_to_debate(self, event: "StreamEvent") -> None:
+        """
+        ELO update → Debate team selection weights.
+
+        When agent ELO changes, update team selection weights
+        for future debates. Significant changes are logged.
+        """
+        data = event.data
+        agent_name = data.get("agent", "")
+        new_elo = data.get("elo", 1500)
+        delta = data.get("delta", 0)
+        debate_id = data.get("debate_id", "")
+
+        # Log significant ELO changes
+        if abs(delta) > 50:
+            logger.info(
+                f"Significant ELO change: {agent_name} -> {new_elo} "
+                f"(Δ{delta:+.0f}) in debate {debate_id}"
+            )
+
+        # Update agent pool weights for future team selection
+        try:
+            import aragora.debate.agent_pool as agent_pool_module
+
+            # get_agent_pool may not exist yet (planned feature)
+            get_agent_pool = getattr(agent_pool_module, "get_agent_pool", None)
+            if get_agent_pool is None:
+                return
+
+            pool: AgentPoolProtocol | None = get_agent_pool()
+            if pool and hasattr(pool, "update_elo_weight"):
+                pool.update_elo_weight(agent_name, new_elo)
+        except ImportError:
+            pass  # AgentPool module not available
+        except (RuntimeError, TypeError, AttributeError, ValueError) as e:
+            logger.debug("AgentPool weight update failed: %s", e)
+
+    def _handle_calibration_to_agent(self, event: "StreamEvent") -> None:
+        """
+        Calibration update → Agent confidence weights.
+
+        When calibration data changes, update agent confidence
+        weights for vote weighting and team selection.
+        """
+        data = event.data
+        agent_name = data.get("agent", "")
+        calibration_score = data.get("score", 0.5)
+        brier_score = data.get("brier_score", None)
+        prediction_count = data.get("prediction_count", 0)
+
+        logger.debug(
+            f"Calibration update: {agent_name} -> {calibration_score:.2f} "
+            f"(predictions: {prediction_count})"
+        )
+
+        # Update agent pool with calibration data
+        try:
+            from aragora.debate.agent_pool import get_agent_pool
+
+            pool = cast("AgentPoolProtocol | None", get_agent_pool())
+            if pool and hasattr(pool, "update_calibration"):
+                pool.update_calibration(
+                    agent_name=agent_name,
+                    score=calibration_score,
+                    brier_score=brier_score,
+                )
+        except (ImportError, AttributeError):
+            pass  # AgentPool or get_agent_pool not available
+        except (RuntimeError, TypeError, ValueError) as e:
+            logger.debug("AgentPool calibration update failed: %s", e)
+
+    def _handle_consensus_to_learning(self, event: "StreamEvent") -> None:
+        """Consensus → Selection feedback learning.
+
+        When consensus is reached, feed the outcome to the
+        SelectionFeedbackLoop for performance-based agent selection.
+        """
+        data = event.data
+        debate_id = data.get("debate_id", "")
+        confidence = data.get("confidence", 0.0)
+        agents_used = data.get("agents", [])
+
+        if not agents_used or confidence < 0.5:
+            return
+
+        logger.debug(f"Learning from consensus: {debate_id} confidence={confidence:.2f}")
+
+        try:
+            from aragora.debate.selection_feedback import SelectionFeedbackLoop
+
+            loop = SelectionFeedbackLoop()
+            if hasattr(loop, "process_debate_outcome"):
+                loop.process_debate_outcome(
+                    debate_id=debate_id,
+                    participants=agents_used,
+                    winner=None,
+                    confidence=confidence,
+                )
+        except ImportError:
+            pass  # SelectionFeedbackLoop not available
+        except (RuntimeError, TypeError, AttributeError, ValueError) as e:
+            logger.debug("Selection feedback learning failed: %s", e)
+
+    def _handle_agent_message_to_rhetorical(self, event: "StreamEvent") -> None:
+        """Agent message → Rhetorical analysis.
+
+        When an agent sends a message, pass it to the RhetoricalObserver
+        for argumentation quality analysis.
+        """
+        data = event.data
+        agent_name = data.get("agent", "")
+        content = data.get("content", "")
+
+        if not content or len(content) < 20:
+            return
+
+        try:
+            from aragora.debate.rhetorical_observer import get_rhetorical_observer
+
+            observer = get_rhetorical_observer()
+            if observer and hasattr(observer, "analyze_message"):
+                observer.analyze_message(
+                    agent_name=agent_name,
+                    content=content,
+                    metadata=data,
+                )
+        except ImportError:
+            pass  # RhetoricalObserver not available
+        except (RuntimeError, TypeError, AttributeError, ValueError) as e:
+            logger.debug("Rhetorical analysis failed: %s", e)
+
+    def _handle_budget_alert_to_team_selection(self, event: "StreamEvent") -> None:
+        """Budget alert → Team selection constraint.
+
+        When a budget threshold is exceeded, record the constraint
+        so that future debate team selections prefer cheaper agents
+        and smaller team sizes. This prevents cost overruns while
+        maintaining decision quality.
+        """
+        data = event.data
+        alert_type = data.get("alert_type", data.get("type", ""))
+        threshold = data.get("threshold", 0.0)
+        current_spend = data.get("current_spend", data.get("current", 0.0))
+        workspace_id = data.get("workspace_id", "default")
+
+        logger.info(
+            "Budget alert → team selection: type=%s spend=%.2f threshold=%.2f workspace=%s",
+            alert_type,
+            current_spend,
+            threshold,
+            workspace_id,
+        )
+
+        try:
+            from aragora.debate.team_selector import TeamSelector
+
+            # Record budget constraint in TeamSelector's class-level state
+            if hasattr(TeamSelector, "record_budget_constraint"):
+                TeamSelector.record_budget_constraint(
+                    workspace_id=workspace_id,
+                    alert_type=alert_type,
+                    threshold=threshold,
+                    current_spend=current_spend,
+                )
+            else:
+                # Fallback: store in module-level dict for TeamSelector to query
+                if not hasattr(TeamSelector, "_budget_constraints"):
+                    TeamSelector._budget_constraints = {}  # type: ignore[attr-defined]
+                TeamSelector._budget_constraints[workspace_id] = {  # type: ignore[attr-defined]
+                    "alert_type": alert_type,
+                    "threshold": threshold,
+                    "current_spend": current_spend,
+                    "constrained": True,
+                }
+                logger.debug(
+                    "Stored budget constraint for workspace %s (fallback)",
+                    workspace_id,
+                )
+        except ImportError:
+            pass  # TeamSelector not available
+        except (RuntimeError, TypeError, AttributeError, ValueError) as e:
+            logger.debug("Budget alert → team selection failed: %s", e)
+
+    def _handle_meta_learning_to_team_selection(self, event: "StreamEvent") -> None:
+        """Meta-learning adjustment → Team selection recalibration.
+
+        When the MetaLearner auto-tunes hyperparameters based on
+        debate outcomes, propagate the adjustments to the team
+        selector so it can adapt its scoring weights accordingly.
+        This creates a self-improving selection loop.
+        """
+        data = event.data
+        adjustments = data.get("adjustments", {})
+        learning_rate = data.get("learning_rate", 0.0)
+        total_adjustments = data.get("total_adjustments", 0)
+
+        if not adjustments:
+            return
+
+        logger.debug(
+            "Meta-learning → team selection: %d adjustments, lr=%.4f",
+            total_adjustments,
+            learning_rate,
+        )
+
+        try:
+            from aragora.debate.team_selector import TeamSelector
+
+            # Propagate relevant hyperparameter adjustments
+            if hasattr(TeamSelector, "apply_meta_learning"):
+                TeamSelector.apply_meta_learning(
+                    adjustments=adjustments,
+                    learning_rate=learning_rate,
+                )
+            else:
+                # Fallback: store adjustments for TeamSelector to query
+                if not hasattr(TeamSelector, "_meta_learning_state"):
+                    TeamSelector._meta_learning_state = {}  # type: ignore[attr-defined]
+                TeamSelector._meta_learning_state.update(  # type: ignore[attr-defined]
+                    {
+                        "adjustments": adjustments,
+                        "learning_rate": learning_rate,
+                        "total_adjustments": total_adjustments,
+                    }
+                )
+                logger.debug("Stored meta-learning state for team selection (fallback)")
+        except ImportError:
+            pass  # TeamSelector not available
+        except (RuntimeError, TypeError, AttributeError, ValueError) as e:
+            logger.debug("Meta-learning → team selection failed: %s", e)
+
+    def register(self, manager: "CrossSubscriberManager") -> None:
+        """Wire the debate-domain reactions into ``manager`` (keyed/idempotent)."""
+        manager.register(
+            "elo_to_debate",
+            StreamEventType.AGENT_ELO_UPDATED,
+            self._handle_elo_to_debate,
+        )
+        manager.register(
+            "calibration_to_agent",
+            StreamEventType.CALIBRATION_UPDATE,
+            self._handle_calibration_to_agent,
+        )
+        manager.register(
+            "consensus_to_learning",
+            StreamEventType.CONSENSUS,
+            self._handle_consensus_to_learning,
+        )
+        manager.register(
+            "agent_message_to_rhetorical",
+            StreamEventType.AGENT_MESSAGE,
+            self._handle_agent_message_to_rhetorical,
+        )
+        manager.register(
+            "budget_alert_to_team_selection",
+            StreamEventType.BUDGET_ALERT,
+            self._handle_budget_alert_to_team_selection,
+        )
+        manager.register(
+            "meta_learning_to_team_selection",
+            StreamEventType.META_LEARNING_ADJUSTED,
+            self._handle_meta_learning_to_team_selection,
+        )
+
+
+def get_debate_event_subscriber() -> DebateEventSubscriber:
+    """Return the ``DebateEventSubscriber`` currently wired into the registry.
+
+    Registers a fresh instance first if none is present yet, reusing the
+    existing one otherwise so repeated calls resolve to the same instance
+    (mirrors ``aragora.knowledge.event_subscribers.get_knowledge_event_subscriber``).
+    """
+    subscriber = get_registered_subscribers().get("debate")
+    if not isinstance(subscriber, DebateEventSubscriber):
+        subscriber = DebateEventSubscriber()
+        register_subscriber("debate", subscriber)
+    return subscriber
+
+
+def register() -> None:
+    """(Re-)register this home's subscriber into the domain-free registry.
+
+    Delegates to :func:`get_debate_event_subscriber`'s get-or-create so repeated
+    calls reuse the existing instance instead of replacing it. Called explicitly
+    (not just import side-effect) so registration survives a cached re-import
+    after ``reset_registry`` in tests.
+    """
+    get_debate_event_subscriber()
+
+
+register()
 
 
 def bootstrap_debate_event_subscribers() -> CrossSubscriberManager:
     """Import domain event-subscriber home modules and wire them into the manager.
 
-    Idempotent (registration is keyed by name). E1 is a pure enabler: no domain
-    home modules exist yet, so this currently only ensures the manager is
-    initialized. E2-E3 wired knowledge, memory, and reasoning; E4-E6 add further
-    ``import aragora.<domain>.event_subscribers`` lines here (e.g. debate/ranking)
-    as remaining handlers relocate to their home layers.
+    Idempotent (registration is keyed by name). Wires knowledge, memory,
+    reasoning, and this module's own debate-domain subscriber. E5-E6 add further
+    ``import aragora.<domain>.event_subscribers`` lines here as remaining handlers
+    relocate to their (application/interface) home layers.
 
     Returns:
         The registry-backed cross-subscriber manager singleton.
     """
     # Domain home modules register their subscribers here. ``register()`` is called
     # explicitly (not just import side-effect) so registration survives a cached
-    # re-import after ``reset_registry`` in tests. More are added by E4-E6 as
-    # handlers relocate (e.g. debate/ranking).
+    # re-import after ``reset_registry`` in tests. More are added by E5-E6 as
+    # remaining (application/interface) handlers relocate.
     from aragora.knowledge import event_subscribers as knowledge_home
     from aragora.memory import event_subscribers as memory_home
     from aragora.reasoning import event_subscribers as reasoning_home
@@ -44,6 +397,7 @@ def bootstrap_debate_event_subscribers() -> CrossSubscriberManager:
     knowledge_home.register()
     memory_home.register()
     reasoning_home.register()
+    register()  # this module's own debate-domain subscriber
 
     from aragora.events.cross_subscribers import bootstrap
 
@@ -52,6 +406,7 @@ def bootstrap_debate_event_subscribers() -> CrossSubscriberManager:
         knowledge_home.KNOWLEDGE_EVENT_SUBSCRIBER_HANDLER_NAMES
         | memory_home.MEMORY_EVENT_SUBSCRIBER_HANDLER_NAMES
         | reasoning_home.REASONING_EVENT_SUBSCRIBER_HANDLER_NAMES
+        | DEBATE_EVENT_SUBSCRIBER_HANDLER_NAMES
     )
     missing = expected_handlers - set(manager.get_stats())
     if missing:

--- a/aragora/events/cross_subscribers/handlers/basic.py
+++ b/aragora/events/cross_subscribers/handlers/basic.py
@@ -3,20 +3,21 @@ Basic cross-subsystem event handlers.
 
 Handles core subsystem integrations:
 - Memory → RLM: Retrieval patterns inform compression strategies
-- Agent ELO → Debate: Performance updates team selection weights
-- Calibration → Agent: Confidence weight updates
 - Webhook delivery: External system notifications
 
 The knowledge/evidence/mound → memory reactions and the vote → belief reaction
 relocated to their domain homes (``aragora.memory.event_subscribers`` and
 ``aragora.reasoning.event_subscribers``, P4a Batch E3 relocate-UP); see those
-modules for the memory-sync and belief-network handlers.
+modules for the memory-sync and belief-network handlers. The ELO → debate,
+calibration → agent, consensus → learning, and agent message → rhetorical
+reactions relocated to ``aragora.debate.event_subscribers`` (P4a Batch E4
+relocate-UP); see that module for those handlers.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Protocol, cast
+from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
     from aragora.events.types import StreamEvent
@@ -34,23 +35,6 @@ class CompressorProtocol(Protocol):
         importance: float,
     ) -> None:
         """Record a memory access pattern for compression optimization."""
-        ...
-
-
-class AgentPoolProtocol(Protocol):
-    """Protocol for agent pool with ELO and calibration updates."""
-
-    def update_elo_weight(self, agent_name: str, elo: float) -> None:
-        """Update the ELO weight for an agent."""
-        ...
-
-    def update_calibration(
-        self,
-        agent_name: str,
-        score: float,
-        brier_score: float | None = None,
-    ) -> None:
-        """Update calibration data for an agent."""
         ...
 
 
@@ -93,77 +77,6 @@ class BasicHandlersMixin:
             pass  # RLM module not available
         except (RuntimeError, TypeError, AttributeError, ValueError) as e:
             logger.debug("RLM pattern recording failed: %s", e)
-
-    def _handle_elo_to_debate(self, event: StreamEvent) -> None:
-        """
-        ELO update → Debate team selection weights.
-
-        When agent ELO changes, update team selection weights
-        for future debates. Significant changes are logged.
-        """
-        data = event.data
-        agent_name = data.get("agent", "")
-        new_elo = data.get("elo", 1500)
-        delta = data.get("delta", 0)
-        debate_id = data.get("debate_id", "")
-
-        # Log significant ELO changes
-        if abs(delta) > 50:
-            logger.info(
-                f"Significant ELO change: {agent_name} -> {new_elo} "
-                f"(Δ{delta:+.0f}) in debate {debate_id}"
-            )
-
-        # Update agent pool weights for future team selection
-        try:
-            import aragora.debate.agent_pool as agent_pool_module
-
-            # get_agent_pool may not exist yet (planned feature)
-            get_agent_pool = getattr(agent_pool_module, "get_agent_pool", None)
-            if get_agent_pool is None:
-                return
-
-            pool: AgentPoolProtocol | None = get_agent_pool()
-            if pool and hasattr(pool, "update_elo_weight"):
-                pool.update_elo_weight(agent_name, new_elo)
-        except ImportError:
-            pass  # AgentPool module not available
-        except (RuntimeError, TypeError, AttributeError, ValueError) as e:
-            logger.debug("AgentPool weight update failed: %s", e)
-
-    def _handle_calibration_to_agent(self, event: StreamEvent) -> None:
-        """
-        Calibration update → Agent confidence weights.
-
-        When calibration data changes, update agent confidence
-        weights for vote weighting and team selection.
-        """
-        data = event.data
-        agent_name = data.get("agent", "")
-        calibration_score = data.get("score", 0.5)
-        brier_score = data.get("brier_score", None)
-        prediction_count = data.get("prediction_count", 0)
-
-        logger.debug(
-            f"Calibration update: {agent_name} -> {calibration_score:.2f} "
-            f"(predictions: {prediction_count})"
-        )
-
-        # Update agent pool with calibration data
-        try:
-            from aragora.debate.agent_pool import get_agent_pool
-
-            pool = cast("AgentPoolProtocol | None", get_agent_pool())
-            if pool and hasattr(pool, "update_calibration"):
-                pool.update_calibration(
-                    agent_name=agent_name,
-                    score=calibration_score,
-                    brier_score=brier_score,
-                )
-        except (ImportError, AttributeError):
-            pass  # AgentPool or get_agent_pool not available
-        except (RuntimeError, TypeError, ValueError) as e:
-            logger.debug("AgentPool calibration update failed: %s", e)
 
     def _handle_webhook_delivery(self, event: StreamEvent) -> None:
         """
@@ -278,66 +191,6 @@ class BasicHandlersMixin:
             pass  # CostTracker not available
         except (RuntimeError, TypeError, AttributeError, ValueError) as e:
             logger.debug("Cost tracking record failed: %s", e)
-
-    def _handle_consensus_to_learning(self, event: StreamEvent) -> None:
-        """Consensus → Selection feedback learning.
-
-        When consensus is reached, feed the outcome to the
-        SelectionFeedbackLoop for performance-based agent selection.
-        """
-        data = event.data
-        debate_id = data.get("debate_id", "")
-        confidence = data.get("confidence", 0.0)
-        agents_used = data.get("agents", [])
-
-        if not agents_used or confidence < 0.5:
-            return
-
-        logger.debug(f"Learning from consensus: {debate_id} confidence={confidence:.2f}")
-
-        try:
-            from aragora.debate.selection_feedback import SelectionFeedbackLoop
-
-            loop = SelectionFeedbackLoop()
-            if hasattr(loop, "process_debate_outcome"):
-                loop.process_debate_outcome(
-                    debate_id=debate_id,
-                    participants=agents_used,
-                    winner=None,
-                    confidence=confidence,
-                )
-        except ImportError:
-            pass  # SelectionFeedbackLoop not available
-        except (RuntimeError, TypeError, AttributeError, ValueError) as e:
-            logger.debug("Selection feedback learning failed: %s", e)
-
-    def _handle_agent_message_to_rhetorical(self, event: StreamEvent) -> None:
-        """Agent message → Rhetorical analysis.
-
-        When an agent sends a message, pass it to the RhetoricalObserver
-        for argumentation quality analysis.
-        """
-        data = event.data
-        agent_name = data.get("agent", "")
-        content = data.get("content", "")
-
-        if not content or len(content) < 20:
-            return
-
-        try:
-            from aragora.debate.rhetorical_observer import get_rhetorical_observer
-
-            observer = get_rhetorical_observer()
-            if observer and hasattr(observer, "analyze_message"):
-                observer.analyze_message(
-                    agent_name=agent_name,
-                    content=content,
-                    metadata=data,
-                )
-        except ImportError:
-            pass  # RhetoricalObserver not available
-        except (RuntimeError, TypeError, AttributeError, ValueError) as e:
-            logger.debug("Rhetorical analysis failed: %s", e)
 
     def _handle_debate_end_to_explainability(self, event: StreamEvent) -> None:
         """Debate end → Explainability auto-trigger.

--- a/aragora/events/cross_subscribers/handlers/strategic.py
+++ b/aragora/events/cross_subscribers/handlers/strategic.py
@@ -5,9 +5,11 @@ Closes feedback loops between subsystems that emit events (Tiers 1-4)
 and subsystems that should consume them:
 - Risk Warning → Health Registry: Degrade component health on security anomalies
 - Agent Birth/Death → Control Plane: Sync genesis events to agent registry
-- Budget Alert → Team Selection: Cost constraints limit debate composition
 - Alert Escalated → Workflow Brake: Critical alerts pause active workflows
-- Meta-Learning Adjusted → Team Selection: Hyperparameter changes inform selection
+
+The Budget Alert → Team Selection and Meta-Learning Adjusted → Team Selection
+reactions relocated to ``aragora.debate.event_subscribers`` (P4a Batch E4
+relocate-UP); see that module for those handlers.
 """
 
 from __future__ import annotations
@@ -154,58 +156,6 @@ class StrategicHandlersMixin:
         except (RuntimeError, TypeError, AttributeError, ValueError) as e:
             logger.debug("Genesis → control plane sync failed: %s", e)
 
-    def _handle_budget_alert_to_team_selection(self, event: StreamEvent) -> None:
-        """Budget alert → Team selection constraint.
-
-        When a budget threshold is exceeded, record the constraint
-        so that future debate team selections prefer cheaper agents
-        and smaller team sizes. This prevents cost overruns while
-        maintaining decision quality.
-        """
-        data = event.data
-        alert_type = data.get("alert_type", data.get("type", ""))
-        threshold = data.get("threshold", 0.0)
-        current_spend = data.get("current_spend", data.get("current", 0.0))
-        workspace_id = data.get("workspace_id", "default")
-
-        logger.info(
-            "Budget alert → team selection: type=%s spend=%.2f threshold=%.2f workspace=%s",
-            alert_type,
-            current_spend,
-            threshold,
-            workspace_id,
-        )
-
-        try:
-            from aragora.debate.team_selector import TeamSelector
-
-            # Record budget constraint in TeamSelector's class-level state
-            if hasattr(TeamSelector, "record_budget_constraint"):
-                TeamSelector.record_budget_constraint(
-                    workspace_id=workspace_id,
-                    alert_type=alert_type,
-                    threshold=threshold,
-                    current_spend=current_spend,
-                )
-            else:
-                # Fallback: store in module-level dict for TeamSelector to query
-                if not hasattr(TeamSelector, "_budget_constraints"):
-                    TeamSelector._budget_constraints = {}  # type: ignore[attr-defined]
-                TeamSelector._budget_constraints[workspace_id] = {  # type: ignore[attr-defined]
-                    "alert_type": alert_type,
-                    "threshold": threshold,
-                    "current_spend": current_spend,
-                    "constrained": True,
-                }
-                logger.debug(
-                    "Stored budget constraint for workspace %s (fallback)",
-                    workspace_id,
-                )
-        except ImportError:
-            pass  # TeamSelector not available
-        except (RuntimeError, TypeError, AttributeError, ValueError) as e:
-            logger.debug("Budget alert → team selection failed: %s", e)
-
     def _handle_alert_escalated_to_workflow_brake(self, event: StreamEvent) -> None:
         """Alert escalated → Workflow emergency brake.
 
@@ -249,51 +199,3 @@ class StrategicHandlersMixin:
             pass  # Workflow engine not available
         except (RuntimeError, TypeError, AttributeError, ValueError) as e:
             logger.debug("Workflow emergency brake failed: %s", e)
-
-    def _handle_meta_learning_to_team_selection(self, event: StreamEvent) -> None:
-        """Meta-learning adjustment → Team selection recalibration.
-
-        When the MetaLearner auto-tunes hyperparameters based on
-        debate outcomes, propagate the adjustments to the team
-        selector so it can adapt its scoring weights accordingly.
-        This creates a self-improving selection loop.
-        """
-        data = event.data
-        adjustments = data.get("adjustments", {})
-        learning_rate = data.get("learning_rate", 0.0)
-        total_adjustments = data.get("total_adjustments", 0)
-
-        if not adjustments:
-            return
-
-        logger.debug(
-            "Meta-learning → team selection: %d adjustments, lr=%.4f",
-            total_adjustments,
-            learning_rate,
-        )
-
-        try:
-            from aragora.debate.team_selector import TeamSelector
-
-            # Propagate relevant hyperparameter adjustments
-            if hasattr(TeamSelector, "apply_meta_learning"):
-                TeamSelector.apply_meta_learning(
-                    adjustments=adjustments,
-                    learning_rate=learning_rate,
-                )
-            else:
-                # Fallback: store adjustments for TeamSelector to query
-                if not hasattr(TeamSelector, "_meta_learning_state"):
-                    TeamSelector._meta_learning_state = {}  # type: ignore[attr-defined]
-                TeamSelector._meta_learning_state.update(  # type: ignore[attr-defined]
-                    {
-                        "adjustments": adjustments,
-                        "learning_rate": learning_rate,
-                        "total_adjustments": total_adjustments,
-                    }
-                )
-                logger.debug("Stored meta-learning state for team selection (fallback)")
-        except ImportError:
-            pass  # TeamSelector not available
-        except (RuntimeError, TypeError, AttributeError, ValueError) as e:
-            logger.debug("Meta-learning → team selection failed: %s", e)

--- a/aragora/events/cross_subscribers/manager.py
+++ b/aragora/events/cross_subscribers/manager.py
@@ -9,7 +9,7 @@ The heavy lifting is delegated to specialized mixins:
 - AdminMixin: Stats reporting, enable/disable, sampling, filtering, retry config
 - BasicHandlersMixin: Core subsystem event handlers
 - CultureHandlersMixin: Culture pattern handlers
-- StrategicHandlersMixin: Strategic feedback loop handlers (risk, genesis, budget, alerts)
+- StrategicHandlersMixin: Strategic feedback loop handlers (risk, genesis, alerts)
 """
 
 from __future__ import annotations
@@ -203,23 +203,17 @@ class CrossSubscriberManager(
             self._handle_memory_to_rlm,
         )
 
-        # Agent ELO → Debate team selection
-        self.register(
-            "elo_to_debate",
-            StreamEventType.AGENT_ELO_UPDATED,
-            self._handle_elo_to_debate,
-        )
+        # Agent ELO → Debate team selection relocated to
+        # aragora.debate.event_subscribers (P4a Batch E4 relocate-UP); wired at
+        # bootstrap via apply_registered_subscribers, not registered here.
 
         # Knowledge → Memory sync relocated to aragora.memory.event_subscribers
         # (P4a Batch E3 relocate-UP); wired at bootstrap via
         # apply_registered_subscribers, not registered here.
 
-        # Calibration → Agent weights
-        self.register(
-            "calibration_to_agent",
-            StreamEventType.CALIBRATION_UPDATE,
-            self._handle_calibration_to_agent,
-        )
+        # Calibration → Agent weights relocated to
+        # aragora.debate.event_subscribers (P4a Batch E4 relocate-UP); wired at
+        # bootstrap via apply_registered_subscribers, not registered here.
 
         # Evidence → Insight extraction and Mound structure → Memory/Debate sync
         # relocated to aragora.memory.event_subscribers (P4a Batch E3 relocate-UP);
@@ -277,19 +271,13 @@ class CrossSubscriberManager(
             self._handle_debate_end_to_cost_tracking,
         )
 
-        # Consensus → Selection Learning
-        self.register(
-            "consensus_to_learning",
-            StreamEventType.CONSENSUS,
-            self._handle_consensus_to_learning,
-        )
+        # Consensus → Selection Learning relocated to
+        # aragora.debate.event_subscribers (P4a Batch E4 relocate-UP); wired at
+        # bootstrap via apply_registered_subscribers, not registered here.
 
-        # Agent Message → Rhetorical Analysis
-        self.register(
-            "agent_message_to_rhetorical",
-            StreamEventType.AGENT_MESSAGE,
-            self._handle_agent_message_to_rhetorical,
-        )
+        # Agent Message → Rhetorical Analysis relocated to
+        # aragora.debate.event_subscribers (P4a Batch E4 relocate-UP); wired at
+        # bootstrap via apply_registered_subscribers, not registered here.
 
         # Vote → Belief Network relocated to aragora.reasoning.event_subscribers
         # (P4a Batch E3 relocate-UP); wired at bootstrap via
@@ -355,12 +343,9 @@ class CrossSubscriberManager(
         # aragora.knowledge.event_subscribers (P4a Batch E2c); wired at bootstrap
         # via apply_registered_subscribers, not registered here.
 
-        # Budget Alert → Team Selection Constraint
-        self.register(
-            "budget_alert_to_team_selection",
-            StreamEventType.BUDGET_ALERT,
-            self._handle_budget_alert_to_team_selection,
-        )
+        # Budget Alert → Team Selection Constraint relocated to
+        # aragora.debate.event_subscribers (P4a Batch E4 relocate-UP); wired at
+        # bootstrap via apply_registered_subscribers, not registered here.
 
         # Alert Escalated → Workflow Emergency Brake
         self.register(
@@ -369,12 +354,9 @@ class CrossSubscriberManager(
             self._handle_alert_escalated_to_workflow_brake,
         )
 
-        # Meta-Learning Adjusted → Team Selection Recalibration
-        self.register(
-            "meta_learning_to_team_selection",
-            StreamEventType.META_LEARNING_ADJUSTED,
-            self._handle_meta_learning_to_team_selection,
-        )
+        # Meta-Learning Adjusted → Team Selection Recalibration relocated to
+        # aragora.debate.event_subscribers (P4a Batch E4 relocate-UP); wired at
+        # bootstrap via apply_registered_subscribers, not registered here.
 
         logger.debug("Registered built-in cross-subsystem subscribers")
 

--- a/tests/debate/test_event_subscribers.py
+++ b/tests/debate/test_event_subscribers.py
@@ -1,0 +1,198 @@
+"""Tests for the debate-domain event-subscriber home (P4a Batch E4).
+
+Covers ``aragora.debate.event_subscribers``: the ELO/calibration/consensus/
+rhetorical reactions relocated out of infrastructure
+(``aragora.events.cross_subscribers.handlers.basic``) and the budget-alert/
+meta-learning reactions relocated out of
+``aragora.events.cross_subscribers.handlers.strategic`` into this domain home,
+plus the self-registration surface (get-or-create accessor, ``register()``).
+
+The budget-alert and meta-learning handlers already had dedicated test classes
+in ``tests/events/test_strategic_handlers.py`` (``TestBudgetAlertToTeamSelection``,
+``TestMetaLearningToTeamSelection``); those were repointed to
+``DebateEventSubscriber`` in place rather than duplicated here (same precedent
+as ``TestApprovalToKMReinforcement`` for the P4a Batch E2c knowledge relocation).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.events.cross_subscribers import (
+    CrossSubscriberManager,
+    get_registered_subscribers,
+    reset_cross_subscriber_manager,
+    reset_registry,
+)
+from aragora.events.types import StreamEvent, StreamEventType
+from aragora.debate.event_subscribers import (
+    DEBATE_EVENT_SUBSCRIBER_HANDLER_NAMES,
+    DebateEventSubscriber,
+    get_debate_event_subscriber,
+    register,
+)
+
+
+def make_stream_event(event_type: StreamEventType, data: dict | None = None) -> StreamEvent:
+    """Factory for creating test stream events."""
+    return StreamEvent(type=event_type, data=data or {}, round=0, agent="test_agent")
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry_and_manager():
+    """Isolate each test: empty registry + fresh manager before and after."""
+    reset_registry()
+    reset_cross_subscriber_manager()
+    yield
+    reset_registry()
+    reset_cross_subscriber_manager()
+
+
+class TestDebateEventSubscriberHandlers:
+    """Direct handler-execution tests."""
+
+    def test_elo_to_debate_handler_executes_without_error(self):
+        subscriber = DebateEventSubscriber()
+        event = make_stream_event(
+            StreamEventType.AGENT_ELO_UPDATED,
+            data={"agent": "claude", "elo": 1600, "delta": 20, "debate_id": "d1"},
+        )
+        subscriber._handle_elo_to_debate(event)
+
+    def test_elo_to_debate_handler_logs_significant_change(self):
+        subscriber = DebateEventSubscriber()
+        event = make_stream_event(
+            StreamEventType.AGENT_ELO_UPDATED,
+            data={"agent": "claude", "elo": 1650, "delta": 75, "debate_id": "d1"},
+        )
+        subscriber._handle_elo_to_debate(event)
+
+    def test_calibration_to_agent_handler_executes_without_error(self):
+        subscriber = DebateEventSubscriber()
+        event = make_stream_event(
+            StreamEventType.CALIBRATION_UPDATE,
+            data={"agent": "claude", "score": 0.85, "prediction_count": 12},
+        )
+        subscriber._handle_calibration_to_agent(event)
+
+    def test_consensus_to_learning_handler_executes_without_error(self):
+        subscriber = DebateEventSubscriber()
+        event = make_stream_event(
+            StreamEventType.CONSENSUS,
+            data={"debate_id": "d1", "confidence": 0.9, "agents": ["claude", "gpt"]},
+        )
+        subscriber._handle_consensus_to_learning(event)
+
+    def test_consensus_to_learning_skips_low_confidence(self):
+        subscriber = DebateEventSubscriber()
+        event = make_stream_event(
+            StreamEventType.CONSENSUS,
+            data={"debate_id": "d1", "confidence": 0.2, "agents": ["claude", "gpt"]},
+        )
+        subscriber._handle_consensus_to_learning(event)
+
+    def test_consensus_to_learning_skips_no_agents(self):
+        subscriber = DebateEventSubscriber()
+        event = make_stream_event(
+            StreamEventType.CONSENSUS,
+            data={"debate_id": "d1", "confidence": 0.9, "agents": []},
+        )
+        subscriber._handle_consensus_to_learning(event)
+
+    def test_agent_message_to_rhetorical_handler_executes_without_error(self):
+        subscriber = DebateEventSubscriber()
+        event = make_stream_event(
+            StreamEventType.AGENT_MESSAGE,
+            data={"agent": "claude", "content": "This is a sufficiently long message body."},
+        )
+        subscriber._handle_agent_message_to_rhetorical(event)
+
+    def test_agent_message_to_rhetorical_skips_short_content(self):
+        subscriber = DebateEventSubscriber()
+        event = make_stream_event(
+            StreamEventType.AGENT_MESSAGE,
+            data={"agent": "claude", "content": "too short"},
+        )
+        subscriber._handle_agent_message_to_rhetorical(event)
+
+
+class TestDebateEventSubscriberRegistration:
+    """Registration + self-registration surface tests."""
+
+    def test_handler_names_frozenset(self):
+        assert DEBATE_EVENT_SUBSCRIBER_HANDLER_NAMES == frozenset(
+            {
+                "elo_to_debate",
+                "calibration_to_agent",
+                "consensus_to_learning",
+                "agent_message_to_rhetorical",
+                "budget_alert_to_team_selection",
+                "meta_learning_to_team_selection",
+            }
+        )
+
+    def test_register_wires_all_handlers_into_manager(self):
+        manager = CrossSubscriberManager()
+        subscriber = DebateEventSubscriber()
+
+        subscriber.register(manager)
+
+        registered = set(manager.get_stats())
+        assert DEBATE_EVENT_SUBSCRIBER_HANDLER_NAMES <= registered
+
+    @pytest.mark.parametrize(
+        ("handler_name", "event_type", "data"),
+        [
+            (
+                "elo_to_debate",
+                StreamEventType.AGENT_ELO_UPDATED,
+                {"agent": "claude", "elo": 1600, "delta": 20},
+            ),
+            (
+                "calibration_to_agent",
+                StreamEventType.CALIBRATION_UPDATE,
+                {"agent": "claude", "score": 0.7},
+            ),
+            (
+                "consensus_to_learning",
+                StreamEventType.CONSENSUS,
+                {"debate_id": "d1", "confidence": 0.9, "agents": ["claude"]},
+            ),
+            (
+                "agent_message_to_rhetorical",
+                StreamEventType.AGENT_MESSAGE,
+                {"agent": "claude", "content": "x" * 30},
+            ),
+            (
+                "budget_alert_to_team_selection",
+                StreamEventType.BUDGET_ALERT,
+                {"alert_type": "soft_limit", "workspace_id": "ws1"},
+            ),
+            (
+                "meta_learning_to_team_selection",
+                StreamEventType.META_LEARNING_ADJUSTED,
+                {"adjustments": {"elo_weight": 0.3}, "learning_rate": 0.01},
+            ),
+        ],
+    )
+    def test_register_dispatches_events_through_manager(self, handler_name, event_type, data):
+        manager = CrossSubscriberManager()
+        DebateEventSubscriber().register(manager)
+
+        manager._dispatch_event(make_stream_event(event_type, data=data))
+
+        stats = manager.get_stats()
+        assert stats[handler_name]["events_processed"] == 1
+
+    def test_get_debate_event_subscriber_returns_singleton(self):
+        first = get_debate_event_subscriber()
+        second = get_debate_event_subscriber()
+        assert first is second
+        assert get_registered_subscribers()["debate"] is first
+
+    def test_register_function_is_idempotent(self):
+        register()
+        first = get_registered_subscribers()["debate"]
+        register()
+        second = get_registered_subscribers()["debate"]
+        assert first is second

--- a/tests/events/test_arena_bridge.py
+++ b/tests/events/test_arena_bridge.py
@@ -106,9 +106,17 @@ class TestArenaEventBridge:
         assert received_events[0].data["tier"] == "medium"
 
     def test_elo_event_triggers_handler(self):
-        """Test ELO events trigger built-in handler."""
+        """Test ELO events trigger the debate-domain handler once wired.
+
+        elo_to_debate relocated to ``DebateEventSubscriber`` (P4a Batch E4); a
+        bare ``CrossSubscriberManager`` no longer registers it, so the bridge
+        test wires it explicitly here (mirroring what a real bootstrap does).
+        """
+        from aragora.debate.event_subscribers import DebateEventSubscriber
+
         event_bus = EventBus()
         cross_manager = CrossSubscriberManager()
+        DebateEventSubscriber().register(cross_manager)
 
         bridge = ArenaEventBridge(event_bus, cross_manager)
         bridge.connect_to_cross_subscribers()
@@ -122,7 +130,7 @@ class TestArenaEventBridge:
             delta=100,
         )
 
-        # Check built-in handler was called
+        # Check debate-domain handler was called
         stats = cross_manager.get_stats()
         assert stats["elo_to_debate"]["events_processed"] == 1
 

--- a/tests/events/test_cross_subscriber_registry.py
+++ b/tests/events/test_cross_subscriber_registry.py
@@ -104,6 +104,11 @@ GOLDEN_SUBSCRIBER_NAMES = frozenset(
 # aragora/memory/event_subscribers.py; the reasoning-coupled reaction embedded
 # in the basic mixin -> aragora/reasoning/event_subscribers.py; this closes out
 # events->memory and events->reasoning.
+# E4: the debate-coupled reactions embedded in the basic (ELO, calibration,
+# consensus, agent-message) and strategic (budget alert, meta-learning) mixins
+# -> aragora/debate/event_subscribers.py. events->debate is a shared edge (also
+# contributed by E7a security_dispatcher and E7b arena_bridge); only the last of
+# the three batches to land hand-shrinks the frozen baseline string.
 RELOCATED_SUBSCRIBER_NAMES = frozenset(
     {
         "memory_to_mound",
@@ -132,6 +137,12 @@ RELOCATED_SUBSCRIBER_NAMES = frozenset(
         "evidence_to_insight",
         "mound_to_memory",
         "vote_to_belief",
+        "elo_to_debate",
+        "calibration_to_agent",
+        "consensus_to_learning",
+        "agent_message_to_rhetorical",
+        "budget_alert_to_team_selection",
+        "meta_learning_to_team_selection",
     }
 )
 
@@ -322,6 +333,21 @@ def test_domain_bootstrap_fails_closed_when_reasoning_home_registration_is_missi
 
     with pytest.raises(RuntimeError, match="Domain event subscriber bootstrap incomplete"):
         bootstrap_debate_event_subscribers()
+
+
+def test_domain_bootstrap_fails_closed_when_debate_home_registration_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A missing debate-home (own) registration must fail instead of silently dropping it."""
+    import aragora.debate.event_subscribers as debate_home
+    from aragora.events.cross_subscribers import reset_cross_subscriber_manager, reset_registry
+
+    reset_registry()
+    reset_cross_subscriber_manager()
+    monkeypatch.setattr(debate_home, "register", lambda: None)
+
+    with pytest.raises(RuntimeError, match="Domain event subscriber bootstrap incomplete"):
+        debate_home.bootstrap_debate_event_subscribers()
 
 
 def test_domain_subset_bootstrap_returns_manager():

--- a/tests/events/test_cross_subscribers.py
+++ b/tests/events/test_cross_subscribers.py
@@ -47,8 +47,9 @@ class TestCrossSubscriberManager:
         # Should have built-in subscribers
         assert len(manager._stats) > 0
         assert "memory_to_rlm" in manager._stats
-        assert "elo_to_debate" in manager._stats
-        assert "calibration_to_agent" in manager._stats
+        # elo_to_debate / calibration_to_agent relocated to
+        # aragora.debate.event_subscribers (P4a Batch E4); see
+        # tests/debate/test_event_subscribers.py for their coverage.
 
     def test_register_custom_subscriber(self):
         """Test registering a custom subscriber."""
@@ -124,7 +125,13 @@ class TestCrossSubscriberManager:
 
 
 class TestBuiltinHandlers:
-    """Test built-in cross-subsystem handlers."""
+    """Test built-in cross-subsystem handlers.
+
+    elo_to_debate / calibration_to_agent relocated to
+    ``aragora.debate.event_subscribers`` (P4a Batch E4 relocate-UP); see
+    ``tests/debate/test_event_subscribers.py`` for their handler-execution
+    coverage.
+    """
 
     def setup_method(self):
         reset_cross_subscriber_manager()
@@ -136,30 +143,6 @@ class TestBuiltinHandlers:
         event = make_stream_event(
             StreamEventType.MEMORY_RETRIEVED,
             data={"tier": "fast", "cache_hit": True},
-        )
-
-        # Should not raise
-        manager._dispatch_event(event)
-
-    def test_elo_to_debate_handler(self):
-        """Test ELO update handler executes without error."""
-        manager = CrossSubscriberManager()
-
-        event = make_stream_event(
-            StreamEventType.AGENT_ELO_UPDATED,
-            data={"agent": "claude", "elo": 1600, "delta": 75},
-        )
-
-        # Should not raise
-        manager._dispatch_event(event)
-
-    def test_calibration_to_agent_handler(self):
-        """Test calibration update handler executes without error."""
-        manager = CrossSubscriberManager()
-
-        event = make_stream_event(
-            StreamEventType.CALIBRATION_UPDATE,
-            data={"agent": "claude", "score": 0.85},
         )
 
         # Should not raise

--- a/tests/events/test_strategic_handlers.py
+++ b/tests/events/test_strategic_handlers.py
@@ -309,12 +309,16 @@ class TestApprovalToKMReinforcement:
 
 
 class TestBudgetAlertToTeamSelection:
-    """Test budget alert → team selection constraint handler."""
+    """Test budget alert → team selection constraint handler.
+
+    Relocated to ``DebateEventSubscriber`` (P4a Batch E4): it is
+    debate-coupled, unlike the rest of ``StrategicHandlersMixin``.
+    """
 
     def _get_handler(self):
-        from aragora.events.cross_subscribers.handlers.strategic import StrategicHandlersMixin
+        from aragora.debate.event_subscribers import DebateEventSubscriber
 
-        return StrategicHandlersMixin()
+        return DebateEventSubscriber()
 
     def test_records_budget_constraint_via_method(self, make_event):
         handler = self._get_handler()
@@ -447,12 +451,16 @@ class TestAlertEscalatedToWorkflowBrake:
 
 
 class TestMetaLearningToTeamSelection:
-    """Test meta-learning → team selection recalibration handler."""
+    """Test meta-learning → team selection recalibration handler.
+
+    Relocated to ``DebateEventSubscriber`` (P4a Batch E4): it is
+    debate-coupled, unlike the rest of ``StrategicHandlersMixin``.
+    """
 
     def _get_handler(self):
-        from aragora.events.cross_subscribers.handlers.strategic import StrategicHandlersMixin
+        from aragora.debate.event_subscribers import DebateEventSubscriber
 
-        return StrategicHandlersMixin()
+        return DebateEventSubscriber()
 
     def test_skips_when_no_adjustments(self, make_event):
         handler = self._get_handler()
@@ -537,9 +545,7 @@ class TestStrategicHandlersRegistration:
             "agent_birth_to_control_plane",
             "agent_death_to_control_plane",
             "agent_evolution_to_control_plane",
-            "budget_alert_to_team_selection",
             "alert_escalated_to_workflow_brake",
-            "meta_learning_to_team_selection",
         }
         assert expected.issubset(registered_names), (
             f"Missing handlers: {expected - registered_names}"
@@ -547,6 +553,11 @@ class TestStrategicHandlersRegistration:
         # approval_to_km_reinforcement relocated to KnowledgeEventSubscriber
         # (P4a Batch E2c); a bare manager no longer registers it directly.
         assert "approval_to_km_reinforcement" not in registered_names
+        # budget_alert_to_team_selection / meta_learning_to_team_selection
+        # relocated to DebateEventSubscriber (P4a Batch E4); a bare manager no
+        # longer registers them directly.
+        assert "budget_alert_to_team_selection" not in registered_names
+        assert "meta_learning_to_team_selection" not in registered_names
 
     def test_strategic_event_types_have_subscribers(self):
         from aragora.events.cross_subscribers.manager import CrossSubscriberManager
@@ -556,14 +567,16 @@ class TestStrategicHandlersRegistration:
         # APPROVAL_APPROVED excluded: its only bare-manager subscriber
         # (approval_to_km_reinforcement) relocated to KnowledgeEventSubscriber
         # (P4a Batch E2c) and is wired only via apply_registered_subscribers.
+        # BUDGET_ALERT / META_LEARNING_ADJUSTED excluded: their only bare-manager
+        # subscribers (budget_alert_to_team_selection, meta_learning_to_team_selection)
+        # relocated to DebateEventSubscriber (P4a Batch E4) and are wired only via
+        # apply_registered_subscribers.
         expected_event_types = {
             StreamEventType.RISK_WARNING,
             StreamEventType.AGENT_BIRTH,
             StreamEventType.AGENT_DEATH,
             StreamEventType.AGENT_EVOLUTION,
-            StreamEventType.BUDGET_ALERT,
             StreamEventType.ALERT_ESCALATED,
-            StreamEventType.META_LEARNING_ADJUSTED,
         }
 
         for event_type in expected_event_types:

--- a/tests/integration/test_cross_pollination.py
+++ b/tests/integration/test_cross_pollination.py
@@ -103,10 +103,19 @@ class TestEventFlowIntegration:
         assert received_events[0].data["node_id"] == "kn_001"
 
     def test_builtin_handlers_receive_events(self):
-        """Test built-in handlers process events and update stats."""
-        manager = CrossSubscriberManager()
+        """Test built-in + debate-domain handlers process events and update stats.
 
-        # Dispatch events that trigger built-in handlers
+        elo_to_debate / calibration_to_agent relocated to
+        ``DebateEventSubscriber`` (P4a Batch E4); a bare manager no longer
+        registers them by default, so this wires them explicitly (mirroring
+        what a real bootstrap does) to keep exercising the event-flow path.
+        """
+        from aragora.debate.event_subscribers import DebateEventSubscriber
+
+        manager = CrossSubscriberManager()
+        DebateEventSubscriber().register(manager)
+
+        # Dispatch events that trigger built-in + debate-domain handlers
         events = [
             StreamEvent(
                 type=StreamEventType.MEMORY_RETRIEVED,
@@ -127,7 +136,7 @@ class TestEventFlowIntegration:
 
         stats = manager.get_stats()
 
-        # Check that built-in handlers processed events
+        # Check that built-in + debate-domain handlers processed events
         assert stats["memory_to_rlm"]["events_processed"] == 1
         assert stats["elo_to_debate"]["events_processed"] == 1
         assert stats["calibration_to_agent"]["events_processed"] == 1


### PR DESCRIPTION
## Source

P4a EventBus/Job-Queue inversion, Batch E4 (`docs/architecture/P4A_EVENTS_QUEUE_INVERSION.md` §10). Per the orchestrator correction for this batch: `subscribers/debate_handlers.py` was already deleted by E2c (nothing to delete here), and `aragora.events -> aragora.debate` is a **shared** edge also contributed by E7a (`security_events.py`/`security_dispatcher.py`) and E7b (`arena_bridge.py`) — this PR removes only E4's own contributing imports and intentionally does **not** hand-shrink the baseline string (only the last of {E4,E7a,E7b} to land does that).

## Behavior summary

Relocates 6 debate-coupled cross-subsystem event reactions out of infrastructure (`aragora.events.cross_subscribers.handlers.{basic,strategic}`) into a new self-registering domain home, following the exact pattern `aragora/knowledge/event_subscribers.py` (E2c) and `aragora/memory,reasoning/event_subscribers.py` (E3) established, extending the E1-created `aragora/debate/event_subscribers.py` skeleton:

- **`elo_to_debate`**, **`calibration_to_agent`**, **`consensus_to_learning`**, **`agent_message_to_rhetorical`** (previously in `handlers/basic.py`'s `BasicHandlersMixin`)
- **`budget_alert_to_team_selection`**, **`meta_learning_to_team_selection`** (previously in `handlers/strategic.py`'s `StrategicHandlersMixin`)

All 6 move into a new `DebateEventSubscriber` class in `aragora/debate/event_subscribers.py` with verbatim handler bodies (no behavior change). It self-registers via `aragora.events.cross_subscribers.register_subscriber`; the domain-subset bootstrap (`bootstrap_debate_event_subscribers`) now also wires this module's own subscriber alongside the existing knowledge/memory/reasoning homes, with the combined fail-closed check extended to cover all 6 new handler names.

`basic.py`/`strategic.py`/`manager.py` drop the 6 relocated handlers/registrations (mirroring the relocation-comment style E2c/E3 used). `basic.py` also drops the now-unused `AgentPoolProtocol` + `cast` import (both only served the relocated ELO/calibration handlers).

**`scripts/baselines/import_contracts_baseline.json` is intentionally UNCHANGED**: `aragora.events -> aragora.debate` remains present because `security_events.py`, `security_dispatcher.py` (E7a), and `arena_bridge.py` (E7b) still hold real `from aragora.debate...` imports — confirmed via `rg` that after this PR, `aragora.debate` appears in `aragora/events/` **only** as relocation comments/docstrings in the 4 files this PR touches, never as a live import.

**No re-export shim** (Relocate-UP no-shim exemption, AGENTS.md "P4a Contracts-Thread Shared Rules"): consumer census found zero external/SDK/API-spec references to the moved handler or registration names. Every internal consumer (`basic.py`, `strategic.py`, `manager.py`, 5 test files) is repointed in this same PR.

## Tests

- New `tests/debate/test_event_subscribers.py` (18 cases): direct handler execution for all 6 handlers + registration/self-registration surface (frozenset check, `register()` wiring, parametrized dispatch-through-manager for all 6, singleton accessor, idempotent module-level `register()`).
- `tests/events/test_cross_subscriber_registry.py`: the 6 relocated names added to `RELOCATED_SUBSCRIBER_NAMES` (with a comment documenting the shared-edge nuance); added `test_domain_bootstrap_fails_closed_when_debate_home_registration_is_missing` mirroring the existing knowledge/memory/reasoning fail-closed tests.
- `tests/events/test_cross_subscribers.py`: removed the 2 now-relocated built-in assertions/tests (`elo_to_debate`, `calibration_to_agent`), replaced with a relocation comment pointing at the new test file.
- `tests/events/test_strategic_handlers.py`: repointed `TestBudgetAlertToTeamSelection`/`TestMetaLearningToTeamSelection` to construct `DebateEventSubscriber` instead of `StrategicHandlersMixin` (same precedent as `TestApprovalToKMReinforcement` for E2c); updated the bare-manager registration/event-type assertions to explicitly assert the 2 relocated handlers/event-types are ABSENT from a bare manager.
- `tests/events/test_arena_bridge.py` / `tests/integration/test_cross_pollination.py`: both explicitly construct + `.register()` a `DebateEventSubscriber` on the manager before dispatching ELO/calibration events (a bare manager no longer carries them by default).

## Validation

    $ python3 -m pytest tests/debate/test_event_subscribers.py tests/events/test_cross_subscribers.py \
        tests/events/test_cross_subscriber_registry.py tests/events/test_strategic_handlers.py \
        tests/events/test_arena_bridge.py tests/integration/test_cross_pollination.py -q
    112 passed

    $ python3 scripts/ci/check_import_contracts.py --layers foundation,infrastructure --json
    # only pre-existing ambient "aragora.utils -> aragora.caching" as new_violations; events->nomic
    # resolved (unrelated E2c/E3 side-effect); events->debate absent from BOTH new and resolved
    # (correctly untouched - shared edge, E4 is not the sole/last contributor)

    $ python3 scripts/ci/check_import_contracts.py --json
    # same events->debate non-movement; only new_violations are the same ambient sibling-fleet
    # edges already present on a pristine origin/main worktree (aragora.evaluation -> connectors/swarm,
    # aragora.swarm -> aragora.cli, aragora.utils -> aragora.caching)

    $ python3 -m mypy --ignore-missing-imports --follow-imports=skip --show-error-codes \
        aragora/debate/event_subscribers.py aragora/events/cross_subscribers/handlers/basic.py \
        aragora/events/cross_subscribers/handlers/strategic.py aragora/events/cross_subscribers/manager.py
    Success: no issues found in 4 source files

    $ AWS_CONFIG_FILE=/dev/null AWS_SHARED_CREDENTIALS_FILE=/dev/null AWS_EC2_METADATA_DISABLED=true make test-smoke
    Smoke tests passed!

Red-first (registry test): the new `test_domain_bootstrap_fails_closed_when_debate_home_registration_is_missing` fails without the fail-closed check (verified the same way the E2c/E3 precedent tests were authored - monkeypatching this module's own `register` to a no-op and asserting `bootstrap_debate_event_subscribers()` raises).

## Risks

Low. Pure code relocation with identical logic (verbatim handler bodies moved); no behavior change to the reactions themselves. `get_cross_subscriber_manager()` import path is unchanged (still `aragora.events.cross_subscribers`). The mypy full-tree differential (`scripts/ci/mypy_with_baseline.py`) shows `new=115 > 66`, but this is documented pre-existing ambient drift (`library/environment.md`, tracked at exactly 115 as of the prior P4a batch #8719) - re-confirmed here as 100% `scripts/` + 3 scattered non-mission `aragora/` files (`redis_ha.py`, `auth/lockout.py`, `redis_utils.py`), zero in any file this PR touches; the required CI changed-file typecheck is green on all 4 touched `aragora/` files.

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>
