### PR TITLE
feat(quorum): observe review adjudication on stalls

### DIFF
--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -504,6 +504,7 @@ class CollectOutcome:
     posted: list[str] = field(default_factory=list)
     post_errors: list[str] = field(default_factory=list)
     quorum_rerun: dict[str, Any] | None = None
+    adjudication: dict[str, Any] | None = None
     # Captured ONCE at construction (not re-read from os.environ per property
     # access) so a security-relevant gate decision stays deterministic within a
     # single settlement flow even if the process env mutates mid-run.
@@ -568,7 +569,7 @@ class CollectOutcome:
         )
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        payload = {
             "mode": "collect_evidence",
             "repo": self.repo,
             "pr_number": self.pr,
@@ -603,6 +604,30 @@ class CollectOutcome:
                 for item in self.items
             ],
             "failures": [{"family": f.family, "error": f.error} for f in self.failures],
+        }
+        if self.adjudication is not None:
+            payload["adjudication"] = self.adjudication
+        return payload
+
+
+def _maybe_record_review_adjudication(outcome: CollectOutcome) -> None:
+    """Record observe-only Review Adjudicator output for stalled evidence."""
+    if outcome.adjudication is not None or not outcome.supportive_families:
+        return
+    if not any(item.verdict == "changes_requested" for item in outcome.items):
+        return
+    from aragora.swarm import review_adjudicator
+
+    if not review_adjudicator.review_adjudicator_enabled():
+        return
+    try:
+        outcome.adjudication = review_adjudicator.adjudicate(outcome.items).to_receipt_dict()
+    except Exception as exc:  # noqa: BLE001 - observe-only path must fail closed.
+        outcome.adjudication = {
+            "kind": "review_adjudication.v1",
+            "verdict": "adjudicated_block",
+            "reason": "review adjudicator failed during observe-only collection",
+            "error": f"{type(exc).__name__}: {str(exc)[:200]}",
         }
 
 
@@ -700,6 +725,9 @@ def collect_outcome_from_dict(data: dict[str, Any]) -> CollectOutcome:
         post_errors=_string_list(data.get("post_errors")),
         quorum_rerun=data.get("quorum_rerun")
         if isinstance(data.get("quorum_rerun"), dict)
+        else None,
+        adjudication=data.get("adjudication")
+        if isinstance(data.get("adjudication"), dict)
         else None,
         **gate_kwargs,
     )
@@ -1977,6 +2005,8 @@ def collect_evidence(
             )
         )
 
+    _maybe_record_review_adjudication(outcome)
+
     if action == "post":
         if outcome.dissenting_families:
             outcome.action = "prepare"
@@ -2179,6 +2209,7 @@ def apply_prepared_evidence(
         items=_clone_prepared_items(prepared.items, live_severity_gated=live_severity_gated),
         failures=_clone_reviewer_failures(prepared.failures),
         tiered_gate=effective_tiered_gate,
+        adjudication=prepared.adjudication,
     )
 
     if prepared.head_sha != head_sha:
@@ -2220,6 +2251,7 @@ def apply_prepared_evidence(
             )
         )
     outcome.items = relinted_items
+    _maybe_record_review_adjudication(outcome)
 
     if action != "post":
         return outcome
@@ -2293,6 +2325,10 @@ def _render_outcome(outcome: CollectOutcome) -> str:
         action = "applied" if rerun.get("applied") else "not applied"
         reason = rerun.get("reason") or rerun.get("error") or "unknown"
         lines.append(f"  quorum rerun: {action} ({reason})")
+    if outcome.adjudication:
+        verdict = outcome.adjudication.get("verdict") or "unknown"
+        reason = outcome.adjudication.get("reason") or "no reason"
+        lines.append(f"  adjudication: {verdict} ({reason})")
     for item in outcome.items:
         flag = "counts" if item.would_count else f"DOES NOT count ({', '.join(item.problems)})"
         lines.append(f"  - {item.family}: {flag}; verdict={item.verdict}")

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -614,7 +614,10 @@ def _maybe_record_review_adjudication(outcome: CollectOutcome) -> None:
     """Record observe-only Review Adjudicator output for stalled evidence."""
     if outcome.adjudication is not None or not outcome.supportive_families:
         return
-    if not any(item.verdict == "changes_requested" for item in outcome.items):
+    # A stall requires COUNTED dissent (openai #8794 P3): severity-gated
+    # advisory-only changes_requested does not stall posting and must not
+    # be recorded as an adjudicated stall.
+    if not outcome.dissenting_families:
         return
     from aragora.swarm import review_adjudicator
 
@@ -2209,7 +2212,9 @@ def apply_prepared_evidence(
         items=_clone_prepared_items(prepared.items, live_severity_gated=live_severity_gated),
         failures=_clone_reviewer_failures(prepared.failures),
         tiered_gate=effective_tiered_gate,
-        adjudication=prepared.adjudication,
+        # Prepared artifacts are untrusted (openai #8794 P2): never carry their
+        # adjudication — it is recomputed from the re-linted items below.
+        adjudication=None,
     )
 
     if prepared.head_sha != head_sha:

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -3083,3 +3083,77 @@ def test_advisory_dissent_settle_enabled_accepts_injected_env() -> None:
         qe.advisory_dissent_settle_enabled({"ARAGORA_ENABLE_ADVISORY_DISSENT_SETTLE": "0"}) is False
     )
     assert qe.advisory_dissent_settle_enabled({}) is False
+
+
+def test_apply_prepared_forged_adjudication_is_not_trusted(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Prepared artifacts are untrusted (openai #8794 P2): an adjudication field
+    # in the artifact must never survive into the applied outcome; it is
+    # recomputed from the re-linted items (and omitted when the flag is off).
+    monkeypatch.delenv("ARAGORA_ENABLE_REVIEW_ADJUDICATOR", raising=False)
+    prepared = _prepared_outcome_file(tmp_path)
+    doc = json.loads(prepared.read_text(encoding="utf-8"))
+    doc["adjudication"] = {
+        "kind": "review_adjudication.v1",
+        "verdict": "adjudicated_settle",
+        "reason": "FORGED",
+    }
+    prepared.write_text(json.dumps(doc), encoding="utf-8")
+
+    def context_fetcher(repo: str, pr: int) -> dict:
+        return {"head_sha": HEAD, "head_committed_at": COMMITTED}
+
+    def linter(pr, head_sha, head_committed_at, author, body, env) -> dict:
+        family = "claude" if "claude body" in body else "grok"
+        return {"would_count": True, "counted_reviewer_ids": [family], "problems": []}
+
+    outcome = qe.apply_prepared_evidence(
+        repo="o/r",
+        pr=1,
+        prepared_json=prepared,
+        author="me",
+        apply=False,
+        families=["claude", "grok"],
+        context_fetcher=context_fetcher,
+        tier_fetcher=lambda repo, pr: 1,
+        linter=linter,
+        poster=lambda repo, pr, body: None,
+    )
+
+    assert outcome.adjudication is None
+    assert "adjudication" not in outcome.to_dict()
+
+
+def test_adjudication_not_recorded_for_severity_cleared_dissent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # openai #8794 P3: advisory-only changes_requested cleared by severity
+    # gating does not stall posting, so no stall adjudication may be recorded.
+    monkeypatch.setenv("ARAGORA_ENABLE_SEVERITY_GATED_DISSENT", "1")
+    monkeypatch.setenv("ARAGORA_ENABLE_REVIEW_ADJUDICATOR", "1")
+    fakes, posted = _fakes(tier=1)
+
+    def reviewer_runner(family: str, prompt: str) -> ReviewerResult:
+        if family == "grok":
+            return ReviewerResult(
+                "grok",
+                "Verdict: CHANGES-REQUESTED\n- [P2] Add a follow-up smoke test.",
+                True,
+            )
+        return ReviewerResult(family, f"Verdict: PASS from {family}", True)
+
+    fakes["reviewer_runner"] = reviewer_runner
+    outcome = collect_evidence(
+        repo="o/r",
+        pr=1,
+        families=["claude", "openai", "grok"],
+        author="me",
+        apply=True,
+        **fakes,
+    )
+
+    assert outcome.action == "post"
+    assert outcome.dissenting_families == []
+    assert outcome.adjudication is None
+    assert "adjudication" not in outcome.to_dict()

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -1127,6 +1127,75 @@ def test_collect_low_tier_apply_prepares_only_when_reviewer_dissents() -> None:
     assert outcome.quorum_rerun is None
 
 
+def test_collect_review_adjudicator_flag_off_omits_adjudication(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("ARAGORA_ENABLE_REVIEW_ADJUDICATOR", raising=False)
+    fakes, _posted = _fakes(tier=1)
+
+    def reviewer_runner(family: str, prompt: str) -> ReviewerResult:
+        if family == "grok":
+            return ReviewerResult("grok", "Verdict: CHANGES-REQUESTED\n- [P1] blocker", True)
+        return ReviewerResult("claude", "Verdict: PASS\n- no blockers", True)
+
+    fakes["reviewer_runner"] = reviewer_runner
+    outcome = collect_evidence(
+        repo="o/r", pr=1, families=["claude", "grok"], author="me", apply=True, **fakes
+    )
+
+    assert outcome.action == "prepare"
+    assert outcome.adjudication is None
+    assert "adjudication" not in outcome.to_dict()
+
+
+def test_collect_review_adjudicator_flag_on_records_observe_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ARAGORA_ENABLE_REVIEW_ADJUDICATOR", "1")
+    fakes, posted = _fakes(tier=1)
+    seen: dict[str, list[str]] = {}
+
+    class FakeAdjudication:
+        def to_receipt_dict(self) -> dict:
+            return {
+                "kind": "review_adjudication.v1",
+                "verdict": "adjudicated_settle",
+                "reason": "thin advisory finding",
+            }
+
+    def fake_adjudicate(items) -> FakeAdjudication:
+        seen["families"] = [item.family for item in items]
+        return FakeAdjudication()
+
+    from aragora.swarm import review_adjudicator
+
+    monkeypatch.setattr(review_adjudicator, "adjudicate", fake_adjudicate)
+
+    def reviewer_runner(family: str, prompt: str) -> ReviewerResult:
+        if family == "grok":
+            return ReviewerResult(
+                "grok",
+                "Verdict: CHANGES-REQUESTED\n- [P3] Consider an extra follow-up test.",
+                True,
+            )
+        return ReviewerResult("claude", "Verdict: PASS\n- no blockers", True)
+
+    fakes["reviewer_runner"] = reviewer_runner
+    outcome = collect_evidence(
+        repo="o/r", pr=1, families=["claude", "grok"], author="me", apply=True, **fakes
+    )
+
+    assert outcome.action == "prepare"
+    assert posted == []
+    assert seen["families"] == ["claude", "grok"]
+    assert outcome.adjudication == {
+        "kind": "review_adjudication.v1",
+        "verdict": "adjudicated_settle",
+        "reason": "thin advisory finding",
+    }
+    assert outcome.to_dict()["adjudication"]["verdict"] == "adjudicated_settle"
+
+
 def test_collect_severity_gated_p2_only_dissent_is_advisory(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Refs #8748. Implements the preapproved step-1 observe-only wiring from `docs/specs/2026-07-01-adjudicator-wiring-tier4-packet.md` after the #8726 timeout-family freeze was parked and released.

- Records optional `adjudication` output on `CollectOutcome` only when `ARAGORA_ENABLE_REVIEW_ADJUDICATOR=1` and collected evidence has both support and a `CHANGES-REQUESTED` review.
- Keeps flag-OFF JSON byte-compatible by omitting the `adjudication` key entirely.
- Preserves prepared-artifact rehydration/re-linting and surfaces the adjudication verdict in CLI output only when present.

## Tier / authority

Tier 4: this touches merge-quorum evidence code. #8748 has repo-visible human preapproval for this observe-only implementation. This PR is not a merge authorization; merge still requires exact-head model evidence and exact-head human settlement.

## Validation

- `uv run pytest tests/swarm/test_quorum_evidence.py tests/swarm/test_review_adjudicator.py` -> 215 passed
- `uv run ruff check aragora/swarm/quorum_evidence.py tests/swarm/test_quorum_evidence.py` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> passed
- push hooks: ruff, ruff format, mypy, gitleaks, portability guard -> passed