### PR TITLE
feat(tooling): bounded Claude Fable 5 advisory consult + consult-fable skill

### DIFF
--- a/.agents/skills/consult-fable/SKILL.md
+++ b/.agents/skills/consult-fable/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: consult-fable
+description: Bounded advisory consult of Claude Fable 5 from inside the aragora repo. Use when you are stuck on prioritization ("what should I work on next?"), need a second opinion on a design or a reviewer deadlock, want a plan sanity-checked, or were asked to "ask Claude / Fable" something. Runs scripts/consult_claude.py with a hard timeout (default 600s) and never hangs. Advice is input, not authority — it cannot approve merges, settle quorum, or override gates.
+license: MIT
+compatibility: Works with Codex (.agents/skills), Claude Code (.claude/skills), and any Agent Skills platform. Requires python3; uses the local `claude` CLI when present, else the Anthropic API via aragora's secrets manager.
+metadata:
+  author: Synaptent (aragora)
+  version: "1.0.0"
+  argument-hint: The question to ask, or a path to a prompt file.
+---
+
+# Consult Fable (bounded Claude Fable 5 advisory)
+
+Ask Claude Fable 5 a question and get an answer back within a hard time budget.
+This replaces ad-hoc `timeout 120 claude -p "..."` calls, which hang or expire
+with no output. The tool passes the prompt via stdin, forwards `--model`,
+enforces a per-attempt timeout, and falls back (claude CLI on
+`claude-opus-4-8`, then the Anthropic Messages API) if the primary attempt
+fails.
+
+## How to invoke
+
+From the repo root (any worktree):
+
+```bash
+# Inline question, defaults: model claude-fable-5, timeout 600s
+python3 scripts/consult_claude.py "One-paragraph question with the live state inlined."
+
+# Long prompt from a file, machine-readable result
+python3 scripts/consult_claude.py --prompt-file /tmp/question.md --json
+
+# Bigger budget for a hard question
+python3 scripts/consult_claude.py --timeout 900 --prompt-file /tmp/question.md
+```
+
+`--json` returns `{ok, model, backend, elapsed_s, text, attempts}`. Exit codes:
+`0` ok, `2` timed out, `3` no prompt, `4` all backends failed.
+
+If `scripts/consult_claude.py` does not exist in your checkout yet (the branch
+adding it has not merged), use the copy bundled next to this SKILL.md
+(`consult_claude.py`) — same interface.
+
+## Writing a good consult prompt
+
+Fable has **no access to your session state**. Inline everything it needs:
+
+- The decision you are facing and the 2-4 options you see.
+- Live facts, verified this cycle: PR numbers with head SHAs, gate/quorum
+  state, dissent findings, owner state. Never paste stale transcript claims.
+- Constraints that bind you (operating contract tier limits, no `--admin`,
+  shared-root read-only, anti-treadmill rules).
+- Ask for a **single recommendation with reasoning**, not a survey.
+
+For "what should I work on next?" consults, a good shape is: list the
+candidate progress units with one line of live state each, state the
+anti-treadmill rules that apply, and ask Fable to pick exactly one and say why.
+
+## Hard rules
+
+1. **Advisory only.** The answer is one input to your decision. It is never
+   authority to merge, settle, post evidence, or bypass a gate. Verify any
+   factual claim in the answer against live repo state before acting on it.
+2. **One consult per decision.** Do not loop consults on the same question;
+   if the answer doesn't unblock you, the blocker is information, not advice.
+3. **Bounded always.** Keep the default 600s timeout or raise it explicitly;
+   never wrap this tool in an outer retry loop.
+4. **No secrets in prompts.** Inline repo state, not credentials or tokens.
+
+## Failure handling
+
+- Exit 2 (timeout) or 4 (all backends failed): report the consult as
+  unavailable and proceed with your own judgment. Do not retry more than once.
+- If only the API backend fails with a missing-key error, the local `claude`
+  CLI is the expected path; check `which claude` before concluding anything.

--- a/.agents/skills/consult-fable/SKILL.md
+++ b/.agents/skills/consult-fable/SKILL.md
@@ -28,6 +28,8 @@ API fallback is off by default because it can consume Anthropic API credits or
 billing when `ANTHROPIC_API_KEY` or aragora secrets are configured. Use
 `--api-fallback` only when paid API fallback is acceptable; unsupported
 CLI-only model ids such as `claude-fable-5` are skipped for direct API calls.
+If no API key is available, the API backend records a normal failed attempt in
+the JSON envelope instead of being omitted.
 
 ## How to invoke
 
@@ -49,8 +51,10 @@ python3 scripts/consult_claude.py --api-fallback --prompt-file /tmp/question.md
 ```
 
 `--json` returns `{ok, model, backend, elapsed_s, text, attempts}`. Exit codes:
-`0` ok, `2` timed out, `3` no prompt, `4` all backends failed, `64`
-usage/config error.
+`0` ok, `2` timed out, `3` no prompt, `4` all backends failed or the explicit
+overall budget was exhausted before all fallback attempts could run, `64`
+usage/config error. In JSON, budget exhaustion is reported as
+`budget_exhausted: true`, distinct from backend `timed_out: true`.
 
 If `scripts/consult_claude.py` does not exist in your checkout yet, use an
 installed user skill copy such as `~/.codex/skills/consult-fable/consult_claude.py`.

--- a/.agents/skills/consult-fable/SKILL.md
+++ b/.agents/skills/consult-fable/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: consult-fable
-description: Bounded advisory consult of Claude Fable 5 from inside the aragora repo. Use when you are stuck on prioritization ("what should I work on next?"), need a second opinion on a design or a reviewer deadlock, want a plan sanity-checked, or were asked to "ask Claude / Fable" something. Runs scripts/consult_claude.py with a hard timeout (default 600s) and never hangs. Advice is input, not authority — it cannot approve merges, settle quorum, or override gates.
+description: Bounded advisory consult of Claude Fable 5 from inside the aragora repo. Use when you are stuck on prioritization ("what should I work on next?"), need a second opinion on a design or a reviewer deadlock, want a plan sanity-checked, or were asked to "ask Claude / Fable" something. Runs scripts/consult_claude.py with a per-attempt timeout (default 600s), strict empty MCP config for CLI calls, and fail-closed backend attempts. Advice is input, not authority — it cannot approve merges, settle quorum, or override gates.
 license: MIT
 compatibility: Works with Codex (.agents/skills), Claude Code (.claude/skills), and any Agent Skills platform. Requires python3; uses the local `claude` CLI when present, else the Anthropic API via aragora's secrets manager.
 metadata:
@@ -11,12 +11,16 @@ metadata:
 
 # Consult Fable (bounded Claude Fable 5 advisory)
 
-Ask Claude Fable 5 a question and get an answer back within a hard time budget.
+Ask Claude Fable 5 a question and get an answer back through bounded backend
+attempts.
 This replaces ad-hoc `timeout 120 claude -p "..."` calls, which hang or expire
 with no output. The tool passes the prompt via stdin, forwards `--model`,
-enforces a per-attempt timeout, and falls back (claude CLI on
+disables local MCP servers for CLI attempts, enforces a per-attempt timeout,
+and falls back (claude CLI on
 `claude-opus-4-8`, then the Anthropic Messages API) if the primary attempt
-fails.
+fails. The timeout is per backend attempt, not a single process-wide wall-clock
+cap; use an external wrapper if your conductor cycle needs a stricter total
+budget.
 
 ## How to invoke
 
@@ -36,9 +40,9 @@ python3 scripts/consult_claude.py --timeout 900 --prompt-file /tmp/question.md
 `--json` returns `{ok, model, backend, elapsed_s, text, attempts}`. Exit codes:
 `0` ok, `2` timed out, `3` no prompt, `4` all backends failed.
 
-If `scripts/consult_claude.py` does not exist in your checkout yet (the branch
-adding it has not merged), use the copy bundled next to this SKILL.md
-(`consult_claude.py`) — same interface.
+If `scripts/consult_claude.py` does not exist in your checkout yet, use an
+installed user skill copy such as `~/.codex/skills/consult-fable/consult_claude.py`.
+The tracked repo skill itself expects the tracked repo script.
 
 ## Writing a good consult prompt
 
@@ -62,8 +66,8 @@ anti-treadmill rules that apply, and ask Fable to pick exactly one and say why.
    factual claim in the answer against live repo state before acting on it.
 2. **One consult per decision.** Do not loop consults on the same question;
    if the answer doesn't unblock you, the blocker is information, not advice.
-3. **Bounded always.** Keep the default 600s timeout or raise it explicitly;
-   never wrap this tool in an outer retry loop.
+3. **Bounded always.** Keep the default 600s per-attempt timeout or raise it
+   explicitly; never wrap this tool in an outer retry loop.
 4. **No secrets in prompts.** Inline repo state, not credentials or tokens.
 
 ## Failure handling

--- a/.agents/skills/consult-fable/SKILL.md
+++ b/.agents/skills/consult-fable/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: consult-fable
-description: Bounded advisory consult of Claude Fable 5 from inside the aragora repo. Use when you are stuck on prioritization ("what should I work on next?"), need a second opinion on a design or a reviewer deadlock, want a plan sanity-checked, or were asked to "ask Claude / Fable" something. Runs scripts/consult_claude.py with a per-attempt timeout (default 600s), strict empty MCP config for CLI calls, and fail-closed backend attempts. Advice is input, not authority — it cannot approve merges, settle quorum, or override gates.
+description: Bounded advisory consult of Claude Fable 5 from inside the aragora repo. Use when you are stuck on prioritization ("what should I work on next?"), need a second opinion on a design or a reviewer deadlock, want a plan sanity-checked, or were asked to "ask Claude / Fable" something. Runs scripts/consult_claude.py with per-attempt and total timeouts (defaults 600s), strict empty MCP config for CLI calls, and fail-closed backend attempts. Advice is input, not authority — it cannot approve merges, settle quorum, or override gates.
 license: MIT
-compatibility: Works with Codex (.agents/skills), Claude Code (.claude/skills), and any Agent Skills platform. Requires python3; uses the local `claude` CLI when present, else the Anthropic API via aragora's secrets manager.
+compatibility: Works with Codex (.agents/skills), Claude Code (.claude/skills), and any Agent Skills platform. Requires python3; uses the local `claude` CLI when present, then may use the Anthropic API via aragora's secrets manager unless disabled.
 metadata:
   author: Synaptent (aragora)
   version: "1.0.0"
@@ -15,30 +15,37 @@ Ask Claude Fable 5 a question and get an answer back through bounded backend
 attempts.
 This replaces ad-hoc `timeout 120 claude -p "..."` calls, which hang or expire
 with no output. The tool passes the prompt via stdin, forwards `--model`,
-disables local MCP servers for CLI attempts, enforces a per-attempt timeout,
-and falls back (claude CLI on
-`claude-opus-4-8`, then the Anthropic Messages API) if the primary attempt
-fails. The timeout is per backend attempt, not a single process-wide wall-clock
-cap; use an external wrapper if your conductor cycle needs a stricter total
-budget.
+disables local MCP servers for CLI attempts, enforces per-attempt and overall
+timeouts, and falls back (claude CLI on `claude-opus-4-8`, then the Anthropic
+Messages API) if the primary attempt fails. `--timeout` is the maximum for a
+single backend attempt; `--overall-timeout` is the total consult budget shared
+across all CLI/API attempts.
+
+API fallback can consume Anthropic API credits or billing when `ANTHROPIC_API_KEY`
+or aragora secrets are configured. Use `--no-api-fallback` when the consult must
+stay CLI/subscription-only.
 
 ## How to invoke
 
 From the repo root (any worktree):
 
 ```bash
-# Inline question, defaults: model claude-fable-5, timeout 600s
+# Inline question, defaults: model claude-fable-5, timeout 600s, overall timeout 600s
 python3 scripts/consult_claude.py "One-paragraph question with the live state inlined."
 
 # Long prompt from a file, machine-readable result
 python3 scripts/consult_claude.py --prompt-file /tmp/question.md --json
 
-# Bigger budget for a hard question
-python3 scripts/consult_claude.py --timeout 900 --prompt-file /tmp/question.md
+# Bigger total budget for a hard question
+python3 scripts/consult_claude.py --timeout 300 --overall-timeout 900 --prompt-file /tmp/question.md
+
+# CLI-only consult with no paid API fallback
+python3 scripts/consult_claude.py --no-api-fallback --prompt-file /tmp/question.md
 ```
 
 `--json` returns `{ok, model, backend, elapsed_s, text, attempts}`. Exit codes:
-`0` ok, `2` timed out, `3` no prompt, `4` all backends failed.
+`0` ok, `2` timed out, `3` no prompt, `4` all backends failed, `64`
+usage/config error.
 
 If `scripts/consult_claude.py` does not exist in your checkout yet, use an
 installed user skill copy such as `~/.codex/skills/consult-fable/consult_claude.py`.

--- a/.agents/skills/consult-fable/SKILL.md
+++ b/.agents/skills/consult-fable/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: consult-fable
-description: Bounded advisory consult of Claude Fable 5 from inside the aragora repo. Use when you are stuck on prioritization ("what should I work on next?"), need a second opinion on a design or a reviewer deadlock, want a plan sanity-checked, or were asked to "ask Claude / Fable" something. Runs scripts/consult_claude.py with per-attempt and total timeouts (defaults 600s), strict empty MCP config for CLI calls, and fail-closed backend attempts. Advice is input, not authority — it cannot approve merges, settle quorum, or override gates.
+description: Bounded advisory consult of Claude Fable 5 from inside the aragora repo. Use when you are stuck on prioritization ("what should I work on next?"), need a second opinion on a design or a reviewer deadlock, want a plan sanity-checked, or were asked to "ask Claude / Fable" something. Runs scripts/consult_claude.py with a per-attempt timeout and a derived total timeout, strict empty MCP config for CLI calls, and fail-closed backend attempts. Advice is input, not authority — it cannot approve merges, settle quorum, or override gates.
 license: MIT
 compatibility: Works with Codex (.agents/skills), Claude Code (.claude/skills), and any Agent Skills platform. Requires python3; uses the local `claude` CLI when present, then may use the Anthropic API via aragora's secrets manager unless disabled.
 metadata:
@@ -18,8 +18,11 @@ with no output. The tool passes the prompt via stdin, forwards `--model`,
 disables local MCP servers for CLI attempts, enforces per-attempt and overall
 timeouts, and falls back (claude CLI on `claude-opus-4-8`, then the Anthropic
 Messages API) if the primary attempt fails. `--timeout` is the maximum for a
-single backend attempt; `--overall-timeout` is the total consult budget shared
-across all CLI/API attempts.
+single backend attempt. By default, the total consult budget is derived from the
+enabled attempt plan (`--timeout` multiplied by CLI/API attempts), so the
+documented CLI primary -> CLI fallback -> API primary -> API fallback chain can
+still run after a full-timeout primary attempt. Pass `--overall-timeout` to set
+an explicit total cap shared across all attempts.
 
 API fallback can consume Anthropic API credits or billing when `ANTHROPIC_API_KEY`
 or aragora secrets are configured. Use `--no-api-fallback` when the consult must
@@ -30,14 +33,15 @@ stay CLI/subscription-only.
 From the repo root (any worktree):
 
 ```bash
-# Inline question, defaults: model claude-fable-5, timeout 600s, overall timeout 600s
+# Inline question, defaults: model claude-fable-5, timeout 600s per attempt
+# Default total budget is timeout multiplied by enabled backend attempts.
 python3 scripts/consult_claude.py "One-paragraph question with the live state inlined."
 
 # Long prompt from a file, machine-readable result
 python3 scripts/consult_claude.py --prompt-file /tmp/question.md --json
 
 # Bigger total budget for a hard question
-python3 scripts/consult_claude.py --timeout 300 --overall-timeout 900 --prompt-file /tmp/question.md
+python3 scripts/consult_claude.py --timeout 300 --overall-timeout 1200 --prompt-file /tmp/question.md
 
 # CLI-only consult with no paid API fallback
 python3 scripts/consult_claude.py --no-api-fallback --prompt-file /tmp/question.md

--- a/.agents/skills/consult-fable/SKILL.md
+++ b/.agents/skills/consult-fable/SKILL.md
@@ -25,7 +25,9 @@ Pass `--overall-timeout` to set an explicit total cap shared across all
 attempts.
 Prompts from inline args, `--prompt-file`, and stdin are capped at 512 KiB and
 are rejected before any CLI/API backend attempt, so oversized context cannot
-silently burn API tokens when `--api-fallback` is enabled.
+silently burn API tokens when `--api-fallback` is enabled. The cap also applies
+to programmatic `consult()` calls after any `--system`/system preamble is
+combined with the user prompt.
 
 API fallback is off by default because it can consume Anthropic API credits or
 billing when `ANTHROPIC_API_KEY` or aragora secrets are configured. Use

--- a/.agents/skills/consult-fable/SKILL.md
+++ b/.agents/skills/consult-fable/SKILL.md
@@ -2,7 +2,7 @@
 name: consult-fable
 description: Bounded advisory consult of Claude Fable 5 from inside the aragora repo. Use when you are stuck on prioritization ("what should I work on next?"), need a second opinion on a design or a reviewer deadlock, want a plan sanity-checked, or were asked to "ask Claude / Fable" something. Runs scripts/consult_claude.py with a per-attempt timeout and a derived total timeout, strict empty MCP config for CLI calls, and fail-closed backend attempts. Advice is input, not authority — it cannot approve merges, settle quorum, or override gates.
 license: MIT
-compatibility: Works with Codex (.agents/skills), Claude Code (.claude/skills), and any Agent Skills platform. Requires python3; uses the local `claude` CLI when present, then may use the Anthropic API via aragora's secrets manager unless disabled.
+compatibility: Works with Codex (.agents/skills), Claude Code (.claude/skills), and any Agent Skills platform. Requires python3; uses the local `claude` CLI by default, and uses the Anthropic API via aragora's secrets manager only when explicitly requested.
 metadata:
   author: Synaptent (aragora)
   version: "1.0.0"
@@ -16,17 +16,18 @@ attempts.
 This replaces ad-hoc `timeout 120 claude -p "..."` calls, which hang or expire
 with no output. The tool passes the prompt via stdin, forwards `--model`,
 disables local MCP servers for CLI attempts, enforces per-attempt and overall
-timeouts, and falls back (claude CLI on `claude-opus-4-8`, then the Anthropic
-Messages API) if the primary attempt fails. `--timeout` is the maximum for a
-single backend attempt. By default, the total consult budget is derived from the
-enabled attempt plan (`--timeout` multiplied by CLI/API attempts), so the
-documented CLI primary -> CLI fallback -> API primary -> API fallback chain can
-still run after a full-timeout primary attempt. Pass `--overall-timeout` to set
-an explicit total cap shared across all attempts.
+timeouts, and falls back to a second `claude` CLI attempt on `claude-opus-4-8`
+if the primary attempt fails. `--timeout` is the maximum for a single backend
+attempt. By default, the total consult budget is derived from the enabled
+attempt plan (`--timeout` multiplied by CLI/API attempts), so the documented CLI
+primary -> CLI fallback path can still run after a full-timeout primary attempt.
+Pass `--overall-timeout` to set an explicit total cap shared across all
+attempts.
 
-API fallback can consume Anthropic API credits or billing when `ANTHROPIC_API_KEY`
-or aragora secrets are configured. Use `--no-api-fallback` when the consult must
-stay CLI/subscription-only.
+API fallback is off by default because it can consume Anthropic API credits or
+billing when `ANTHROPIC_API_KEY` or aragora secrets are configured. Use
+`--api-fallback` only when paid API fallback is acceptable; unsupported
+CLI-only model ids such as `claude-fable-5` are skipped for direct API calls.
 
 ## How to invoke
 
@@ -43,8 +44,8 @@ python3 scripts/consult_claude.py --prompt-file /tmp/question.md --json
 # Bigger total budget for a hard question
 python3 scripts/consult_claude.py --timeout 300 --overall-timeout 1200 --prompt-file /tmp/question.md
 
-# CLI-only consult with no paid API fallback
-python3 scripts/consult_claude.py --no-api-fallback --prompt-file /tmp/question.md
+# Explicit paid API fallback after CLI attempts fail
+python3 scripts/consult_claude.py --api-fallback --prompt-file /tmp/question.md
 ```
 
 `--json` returns `{ok, model, backend, elapsed_s, text, attempts}`. Exit codes:

--- a/.agents/skills/consult-fable/SKILL.md
+++ b/.agents/skills/consult-fable/SKILL.md
@@ -23,6 +23,9 @@ attempt plan (`--timeout` multiplied by CLI/API attempts), so the documented CLI
 primary -> CLI fallback path can still run after a full-timeout primary attempt.
 Pass `--overall-timeout` to set an explicit total cap shared across all
 attempts.
+Prompts from inline args, `--prompt-file`, and stdin are capped at 512 KiB and
+are rejected before any CLI/API backend attempt, so oversized context cannot
+silently burn API tokens when `--api-fallback` is enabled.
 
 API fallback is off by default because it can consume Anthropic API credits or
 billing when `ANTHROPIC_API_KEY` or aragora secrets are configured. Use

--- a/scripts/consult_claude.py
+++ b/scripts/consult_claude.py
@@ -57,6 +57,7 @@ API_MAX_TOKENS = 8192
 MAX_API_RESPONSE_BYTES = 4 * 1024 * 1024
 API_UNSUPPORTED_MODELS = {"claude-fable-5"}
 MAX_PROMPT_BYTES = 512 * 1024
+API_RESPONSE_READ_CHUNK_BYTES = 64 * 1024
 
 EXIT_OK = 0
 EXIT_TIMEOUT = 2
@@ -218,6 +219,26 @@ def _resolve_api_key() -> str | None:
         return None
 
 
+def _read_api_response_with_deadline(response, *, deadline: float) -> bytes:
+    """Read a bounded API body without letting slow streams exceed the wall clock."""
+
+    chunks: list[bytes] = []
+    total = 0
+    limit = MAX_API_RESPONSE_BYTES + 1
+    while total < limit:
+        if time.monotonic() >= deadline:
+            raise TimeoutError("API response read exceeded timeout")
+        amount = min(API_RESPONSE_READ_CHUNK_BYTES, limit - total)
+        chunk = response.read(amount)
+        if time.monotonic() > deadline:
+            raise TimeoutError("API response read exceeded timeout")
+        if not chunk:
+            break
+        chunks.append(chunk)
+        total += len(chunk)
+    return b"".join(chunks)
+
+
 def _run_api(prompt: str, model: str, timeout: float, system: str | None) -> dict:
     """One bounded Anthropic Messages API attempt. Never raises."""
     key = _resolve_api_key()
@@ -240,9 +261,10 @@ def _run_api(prompt: str, model: str, timeout: float, system: str | None) -> dic
         },
     )
     started = time.monotonic()
+    deadline = started + timeout
     try:
         with urllib.request.urlopen(request, timeout=timeout) as response:
-            raw = response.read(MAX_API_RESPONSE_BYTES + 1)
+            raw = _read_api_response_with_deadline(response, deadline=deadline)
             if len(raw) > MAX_API_RESPONSE_BYTES:
                 return {
                     "ok": False,
@@ -255,10 +277,6 @@ def _run_api(prompt: str, model: str, timeout: float, system: str | None) -> dic
             if not isinstance(body, dict):
                 raise ValueError("API response JSON is not an object")
     except urllib.error.HTTPError as exc:
-        try:
-            exc.read(MAX_API_RESPONSE_BYTES)
-        except OSError:
-            pass
         return {
             "ok": False,
             "backend": "api",

--- a/scripts/consult_claude.py
+++ b/scripts/consult_claude.py
@@ -54,6 +54,7 @@ FALLBACK_MODEL = "claude-opus-4-8"
 DEFAULT_TIMEOUT_SECONDS = 600
 ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages"
 API_MAX_TOKENS = 8192
+MAX_API_RESPONSE_BYTES = 4 * 1024 * 1024
 API_UNSUPPORTED_MODELS = {"claude-fable-5"}
 MAX_PROMPT_BYTES = 512 * 1024
 
@@ -161,6 +162,8 @@ def _run_cli(prompt: str, model: str, timeout: float) -> dict:
             "error": f"claude CLI exceeded {timeout:.0f}s timeout",
         }
     except (OSError, UnicodeError, ValueError) as exc:
+        if proc is not None:
+            _kill_process_group(proc)
         return {
             "ok": False,
             "backend": locals().get("backend", "cli"),
@@ -239,12 +242,21 @@ def _run_api(prompt: str, model: str, timeout: float, system: str | None) -> dic
     started = time.monotonic()
     try:
         with urllib.request.urlopen(request, timeout=timeout) as response:
-            body = json.loads(response.read().decode())
+            raw = response.read(MAX_API_RESPONSE_BYTES + 1)
+            if len(raw) > MAX_API_RESPONSE_BYTES:
+                return {
+                    "ok": False,
+                    "backend": "api",
+                    "error": _safe_api_error(
+                        "response exceeds maximum size: response body redacted"
+                    ),
+                }
+            body = json.loads(raw.decode())
             if not isinstance(body, dict):
                 raise ValueError("API response JSON is not an object")
     except urllib.error.HTTPError as exc:
         try:
-            exc.read()
+            exc.read(MAX_API_RESPONSE_BYTES)
         except OSError:
             pass
         return {
@@ -391,7 +403,7 @@ def consult(
     budget_exhausted = any(a.get("budget_exhausted") for a in attempts)
     return {
         "ok": False,
-        "model": model,
+        "model": str(attempts[-1].get("model", model)) if attempts else model,
         "timed_out": timed_out,
         "budget_exhausted": budget_exhausted,
         "attempts": attempts,

--- a/scripts/consult_claude.py
+++ b/scripts/consult_claude.py
@@ -11,19 +11,21 @@ Backends, in order:
 1. ``claude`` CLI (subscription auth) — routed through the authenticated
    ``claude_profile.sh`` pool when available, with ``--model`` forwarded and a
    hard subprocess timeout.
-2. Anthropic Messages API — used only if the CLI is missing, fails, or times
-   out. The key comes from ``ANTHROPIC_API_KEY`` or the aragora secrets
-   manager; if neither is present the fallback is skipped silently.
+2. Anthropic Messages API — used only with explicit ``--api-fallback`` opt-in
+   after CLI attempts fail. The key comes from ``ANTHROPIC_API_KEY`` or the
+   aragora secrets manager; if neither is present the fallback is skipped
+   silently.
 
 Output is the raw model text on stdout, or a JSON envelope with ``--json``.
-Exit codes: 0 ok, 2 all backends timed out, 3 no prompt, 4 all backends
-failed, 64 usage/config error.
+Exit codes: 0 ok, 2 all backends timed out, 3 no prompt, 4 all backends failed
+or budget exhausted, 64 usage/config error.
 
 Examples::
 
     python scripts/consult_claude.py "Which PR should I settle next?"
     python scripts/consult_claude.py --prompt-file /tmp/question.md --json
     echo "$QUESTION" | python scripts/consult_claude.py --timeout 300 --overall-timeout 1200
+    python scripts/consult_claude.py --api-fallback --prompt-file /tmp/question.md
 """
 
 from __future__ import annotations
@@ -52,6 +54,7 @@ FALLBACK_MODEL = "claude-opus-4-8"
 DEFAULT_TIMEOUT_SECONDS = 600
 ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages"
 API_MAX_TOKENS = 8192
+API_UNSUPPORTED_MODELS = {"claude-fable-5"}
 
 EXIT_OK = 0
 EXIT_TIMEOUT = 2
@@ -280,7 +283,7 @@ def _append_budget_exhausted(attempts: list[dict], *, model: str, backend: str) 
             "model": model,
             "ok": False,
             "backend": backend,
-            "timed_out": True,
+            "budget_exhausted": True,
             "error": "overall consult timeout exhausted before attempt",
         }
     )
@@ -289,7 +292,7 @@ def _append_budget_exhausted(attempts: list[dict], *, model: str, backend: str) 
 def _api_models(model: str, fallback_model: str | None) -> list[str]:
     models: list[str] = []
     for candidate in (model, fallback_model):
-        if candidate and candidate not in models:
+        if candidate and candidate not in API_UNSUPPORTED_MODELS and candidate not in models:
             models.append(candidate)
     return models
 
@@ -317,7 +320,7 @@ def consult(
     overall_timeout: float | None = None,
     fallback_model: str | None = FALLBACK_MODEL,
     system: str | None = None,
-    api_fallback: bool = True,
+    api_fallback: bool = False,
 ) -> dict:
     """Run the consult across backends and return the first success.
 
@@ -355,9 +358,7 @@ def consult(
             if result.get("ok"):
                 return {**result, "model": fallback_model, "attempts": attempts}
     if api_fallback:
-        for api_model in (model, fallback_model):
-            if not api_model:
-                continue
+        for api_model in _api_models(model, fallback_model):
             if any(
                 attempt.get("backend") == "api" and attempt.get("model") == api_model
                 for attempt in attempts
@@ -372,10 +373,12 @@ def consult(
             if result.get("ok"):
                 return {**result, "model": api_model, "attempts": attempts}
     timed_out = all(a.get("timed_out") for a in attempts) and bool(attempts)
+    budget_exhausted = any(a.get("budget_exhausted") for a in attempts)
     return {
         "ok": False,
         "model": model,
         "timed_out": timed_out,
+        "budget_exhausted": budget_exhausted,
         "attempts": attempts,
         "error": "; ".join(str(a.get("error")) for a in attempts),
     }
@@ -409,10 +412,19 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     parser.add_argument("--system", help="Optional system-style preamble prepended to the prompt")
-    parser.add_argument(
-        "--no-api-fallback",
+    parser.set_defaults(api_fallback=False)
+    api_fallback_group = parser.add_mutually_exclusive_group()
+    api_fallback_group.add_argument(
+        "--api-fallback",
+        dest="api_fallback",
         action="store_true",
-        help="Do not fall back to the Anthropic API when the CLI fails",
+        help=("Opt in to Anthropic API fallback when CLI attempts fail (may use paid API credits)"),
+    )
+    api_fallback_group.add_argument(
+        "--no-api-fallback",
+        dest="api_fallback",
+        action="store_false",
+        help=argparse.SUPPRESS,
     )
     parser.add_argument("--json", action="store_true", help="Emit a JSON result envelope")
     args = parser.parse_args(argv)
@@ -453,7 +465,7 @@ def main(argv: list[str] | None = None) -> int:
         overall_timeout=args.overall_timeout,
         fallback_model=args.fallback_model or None,
         system=args.system,
-        api_fallback=not args.no_api_fallback,
+        api_fallback=args.api_fallback,
     )
     if args.json:
         print(json.dumps(result, indent=2))

--- a/scripts/consult_claude.py
+++ b/scripts/consult_claude.py
@@ -55,6 +55,7 @@ DEFAULT_TIMEOUT_SECONDS = 600
 ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages"
 API_MAX_TOKENS = 8192
 API_UNSUPPORTED_MODELS = {"claude-fable-5"}
+MAX_PROMPT_BYTES = 512 * 1024
 
 EXIT_OK = 0
 EXIT_TIMEOUT = 2
@@ -116,7 +117,7 @@ def _build_cli_command(model: str, mcp_config_path: Path) -> tuple[list[str], bo
     try:
         from aragora.agents.claude_profile_pool import build_claude_command
 
-        return build_claude_command(base)
+        return build_claude_command(base, repo_root=_REPO_ROOT)
     except Exception:
         return base, False
 
@@ -167,11 +168,6 @@ def _run_cli(prompt: str, model: str, timeout: float) -> dict:
         }
     elapsed = round(time.monotonic() - started, 1)
     text = _strip_preamble(stdout) if used_profile else stdout.strip()
-    if text:
-        result = {"ok": True, "backend": backend, "elapsed_s": elapsed, "text": text}
-        if proc.returncode != 0:
-            result["warning"] = _safe_cli_error(returncode=proc.returncode, empty=False)
-        return result
     if proc.returncode != 0:
         return {
             "ok": False,
@@ -179,6 +175,8 @@ def _run_cli(prompt: str, model: str, timeout: float) -> dict:
             "elapsed_s": elapsed,
             "error": _safe_cli_error(returncode=proc.returncode, empty=not text),
         }
+    if text:
+        return {"ok": True, "backend": backend, "elapsed_s": elapsed, "text": text}
     return {
         "ok": False,
         "backend": backend,
@@ -402,6 +400,38 @@ def consult(
     }
 
 
+def _prompt_too_large_error() -> str:
+    return f"prompt exceeds maximum size ({MAX_PROMPT_BYTES} bytes)"
+
+
+def _validate_prompt_bytes(prompt: str) -> None:
+    if len(prompt.encode("utf-8")) > MAX_PROMPT_BYTES:
+        raise ValueError(_prompt_too_large_error())
+
+
+def _read_prompt_file(path_text: str) -> str:
+    path = Path(path_text)
+    if path.stat().st_size > MAX_PROMPT_BYTES:
+        raise ValueError(_prompt_too_large_error())
+    data = path.read_bytes()
+    if len(data) > MAX_PROMPT_BYTES:
+        raise ValueError(_prompt_too_large_error())
+    return data.decode("utf-8")
+
+
+def _read_stdin_prompt() -> str:
+    stream = sys.stdin
+    buffer = getattr(stream, "buffer", None)
+    if buffer is not None:
+        data = buffer.read(MAX_PROMPT_BYTES + 1)
+        if len(data) > MAX_PROMPT_BYTES:
+            raise ValueError(_prompt_too_large_error())
+        return data.decode("utf-8")
+    prompt = stream.read(MAX_PROMPT_BYTES + 1)
+    _validate_prompt_bytes(prompt)
+    return prompt
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("prompt", nargs="?", help="Question text (or use --prompt-file / stdin)")
@@ -457,15 +487,18 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.prompt_file:
         try:
-            with open(args.prompt_file, encoding="utf-8") as handle:
-                prompt = handle.read()
-        except OSError as exc:
+            prompt = _read_prompt_file(args.prompt_file)
+        except (OSError, UnicodeError, ValueError) as exc:
             print(f"error: cannot read --prompt-file: {exc}", file=sys.stderr)
             return EXIT_NO_PROMPT
     elif args.prompt:
         prompt = args.prompt
     elif not sys.stdin.isatty():
-        prompt = sys.stdin.read()
+        try:
+            prompt = _read_stdin_prompt()
+        except (OSError, UnicodeError, ValueError) as exc:
+            print(f"error: cannot read stdin prompt: {exc}", file=sys.stderr)
+            return EXIT_NO_PROMPT
     else:
         parser.print_usage(sys.stderr)
         print("error: no prompt given (arg, --prompt-file, or stdin)", file=sys.stderr)
@@ -473,6 +506,11 @@ def main(argv: list[str] | None = None) -> int:
     prompt = prompt.strip()
     if not prompt:
         print("error: prompt is empty", file=sys.stderr)
+        return EXIT_NO_PROMPT
+    try:
+        _validate_prompt_bytes(prompt)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
         return EXIT_NO_PROMPT
 
     result = consult(

--- a/scripts/consult_claude.py
+++ b/scripts/consult_claude.py
@@ -220,6 +220,33 @@ def _resolve_api_key() -> str | None:
         return None
 
 
+def _response_socket(response):
+    fp = getattr(response, "fp", None)
+    raw = getattr(fp, "raw", None)
+    for candidate in (
+        getattr(raw, "_sock", None),
+        getattr(raw, "sock", None),
+        getattr(fp, "_sock", None),
+        getattr(response, "_sock", None),
+    ):
+        if hasattr(candidate, "settimeout"):
+            return candidate
+    return None
+
+
+def _set_response_timeout(response, timeout: float) -> None:
+    sock = _response_socket(response)
+    if sock is not None:
+        sock.settimeout(max(0.001, timeout))
+
+
+def _read_api_response_chunk(response, amount: int) -> bytes:
+    read1 = getattr(response, "read1", None)
+    if callable(read1):
+        return read1(amount)
+    return response.read(min(amount, 1))
+
+
 def _read_api_response_with_deadline(response, *, deadline: float) -> bytes:
     """Read a bounded API body without letting slow streams exceed the wall clock."""
 
@@ -227,11 +254,13 @@ def _read_api_response_with_deadline(response, *, deadline: float) -> bytes:
     total = 0
     limit = MAX_API_RESPONSE_BYTES + 1
     while total < limit:
-        if time.monotonic() >= deadline:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
             raise TimeoutError("API response read exceeded timeout")
         amount = min(API_RESPONSE_READ_CHUNK_BYTES, limit - total)
-        chunk = response.read(amount)
-        if time.monotonic() > deadline:
+        _set_response_timeout(response, remaining)
+        chunk = _read_api_response_chunk(response, amount)
+        if time.monotonic() >= deadline:
             raise TimeoutError("API response read exceeded timeout")
         if not chunk:
             break

--- a/scripts/consult_claude.py
+++ b/scripts/consult_claude.py
@@ -145,7 +145,7 @@ def _run_cli(prompt: str, model: str, timeout: float) -> dict:
                 command,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
                 text=True,
                 start_new_session=True,
             )
@@ -345,8 +345,7 @@ def consult(
     _validate_timeout(timeout, "timeout")
     if overall_timeout is not None:
         _validate_timeout(overall_timeout, "overall_timeout")
-    if system:
-        prompt = f"{system}\n\n---\n\n{prompt}"
+    prompt = _compose_prompt(prompt, system)
     attempts: list[dict] = []
     started = time.monotonic()
     if overall_timeout is None:
@@ -407,6 +406,13 @@ def _prompt_too_large_error() -> str:
 def _validate_prompt_bytes(prompt: str) -> None:
     if len(prompt.encode("utf-8")) > MAX_PROMPT_BYTES:
         raise ValueError(_prompt_too_large_error())
+
+
+def _compose_prompt(prompt: str, system: str | None) -> str:
+    if system:
+        prompt = f"{system}\n\n---\n\n{prompt}"
+    _validate_prompt_bytes(prompt)
+    return prompt
 
 
 def _read_prompt_file(path_text: str) -> str:
@@ -513,15 +519,19 @@ def main(argv: list[str] | None = None) -> int:
         print(f"error: {exc}", file=sys.stderr)
         return EXIT_NO_PROMPT
 
-    result = consult(
-        prompt,
-        model=args.model,
-        timeout=args.timeout,
-        overall_timeout=args.overall_timeout,
-        fallback_model=args.fallback_model or None,
-        system=args.system,
-        api_fallback=args.api_fallback,
-    )
+    try:
+        result = consult(
+            prompt,
+            model=args.model,
+            timeout=args.timeout,
+            overall_timeout=args.overall_timeout,
+            fallback_model=args.fallback_model or None,
+            system=args.system,
+            api_fallback=args.api_fallback,
+        )
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return EXIT_NO_PROMPT
     if args.json:
         print(json.dumps(result, indent=2))
     elif result.get("ok"):

--- a/scripts/consult_claude.py
+++ b/scripts/consult_claude.py
@@ -2,9 +2,9 @@
 """Bounded advisory consult of a specific Claude model (default: Claude Fable 5).
 
 Gives any agent (Codex conductor, Droid, Claude Code, humans) a reliable way to
-ask a named Claude model for read-only advice with a hard timeout. The known
-failure mode this fixes: ad-hoc ``timeout 120 claude -p "..."`` calls hang or
-time out with no output and no diagnostics.
+ask a named Claude model for read-only advice with hard per-attempt and overall
+timeouts. The known failure mode this fixes: ad-hoc ``timeout 120 claude -p
+"..."`` calls hang or time out with no output and no diagnostics.
 
 Backends, in order:
 
@@ -16,13 +16,14 @@ Backends, in order:
    manager; if neither is present the fallback is skipped silently.
 
 Output is the raw model text on stdout, or a JSON envelope with ``--json``.
-Exit codes: 0 ok, 2 all backends timed out, 3 no prompt, 4 all backends failed.
+Exit codes: 0 ok, 2 all backends timed out, 3 no prompt, 4 all backends
+failed, 64 usage/config error.
 
 Examples::
 
     python scripts/consult_claude.py "Which PR should I settle next?"
     python scripts/consult_claude.py --prompt-file /tmp/question.md --json
-    echo "$QUESTION" | python scripts/consult_claude.py --timeout 900
+    echo "$QUESTION" | python scripts/consult_claude.py --timeout 300 --overall-timeout 900
 """
 
 from __future__ import annotations
@@ -49,6 +50,7 @@ if str(_REPO_ROOT) not in sys.path:
 DEFAULT_MODEL = "claude-fable-5"
 FALLBACK_MODEL = "claude-opus-4-8"
 DEFAULT_TIMEOUT_SECONDS = 600
+DEFAULT_OVERALL_TIMEOUT_SECONDS = 600
 ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages"
 API_MAX_TOKENS = 8192
 
@@ -56,6 +58,7 @@ EXIT_OK = 0
 EXIT_TIMEOUT = 2
 EXIT_NO_PROMPT = 3
 EXIT_ALL_FAILED = 4
+EXIT_USAGE = 64
 
 
 def _safe_cli_error(*, returncode: int | None = None, empty: bool | None = None) -> str:
@@ -67,6 +70,12 @@ def _safe_cli_error(*, returncode: int | None = None, empty: bool | None = None)
     if empty is not None:
         parts.append(f"empty={empty}")
     return ", ".join(parts)
+
+
+def _safe_api_error(message: str) -> str:
+    """Public API failure string safe for JSON logs and durable artifacts."""
+
+    return f"API {message}"
 
 
 @contextmanager
@@ -216,20 +225,40 @@ def _run_api(prompt: str, model: str, timeout: float, system: str | None) -> dic
     try:
         with urllib.request.urlopen(request, timeout=timeout) as response:
             body = json.loads(response.read().decode())
+            if not isinstance(body, dict):
+                raise ValueError("API response JSON is not an object")
     except urllib.error.HTTPError as exc:
-        detail = exc.read().decode(errors="replace")[:500]
-        return {"ok": False, "backend": "api", "error": f"API HTTP {exc.code}: {detail}"}
+        try:
+            exc.read()
+        except OSError:
+            pass
+        return {
+            "ok": False,
+            "backend": "api",
+            "error": _safe_api_error(f"HTTP {exc.code}: response body redacted"),
+        }
+    except (json.JSONDecodeError, UnicodeError, ValueError):
+        return {
+            "ok": False,
+            "backend": "api",
+            "error": _safe_api_error("response parse failed: response body redacted"),
+        }
     except (urllib.error.URLError, TimeoutError, OSError) as exc:
         timed_out = "timed out" in str(exc).lower() or isinstance(exc, TimeoutError)
         return {
             "ok": False,
             "backend": "api",
             "timed_out": timed_out,
-            "error": f"API request failed: {exc}",
+            "error": _safe_api_error(f"request failed: {type(exc).__name__}"),
         }
     elapsed = round(time.monotonic() - started, 1)
+    content = body.get("content", [])
+    if not isinstance(content, list):
+        content = []
     text = "".join(
-        block.get("text", "") for block in body.get("content", []) if block.get("type") == "text"
+        block.get("text", "")
+        for block in content
+        if isinstance(block, dict) and block.get("type") == "text"
     ).strip()
     if not text:
         return {
@@ -241,31 +270,58 @@ def _run_api(prompt: str, model: str, timeout: float, system: str | None) -> dic
     return {"ok": True, "backend": "api", "elapsed_s": elapsed, "text": text}
 
 
+def _remaining_timeout(started: float, overall_timeout: float, per_attempt_timeout: float) -> float:
+    remaining = overall_timeout - (time.monotonic() - started)
+    return max(0.0, min(per_attempt_timeout, remaining))
+
+
+def _append_budget_exhausted(attempts: list[dict], *, model: str, backend: str) -> None:
+    attempts.append(
+        {
+            "model": model,
+            "ok": False,
+            "backend": backend,
+            "timed_out": True,
+            "error": "overall consult timeout exhausted before attempt",
+        }
+    )
+
+
 def consult(
     prompt: str,
     model: str = DEFAULT_MODEL,
     timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    overall_timeout: float = DEFAULT_OVERALL_TIMEOUT_SECONDS,
     fallback_model: str | None = FALLBACK_MODEL,
     system: str | None = None,
     api_fallback: bool = True,
 ) -> dict:
     """Run the consult across backends and return the first success.
 
-    The full timeout budget is granted to each attempt independently so a CLI
-    hang cannot starve the API fallback of time.
+    ``timeout`` is the per-attempt ceiling. ``overall_timeout`` is the total
+    consult budget shared by every CLI/API attempt.
     """
     if system:
         prompt = f"{system}\n\n---\n\n{prompt}"
     attempts: list[dict] = []
-    result = _run_cli(prompt, model, timeout)
-    attempts.append({"model": model, **result})
-    if result.get("ok"):
-        return {**result, "model": model, "attempts": attempts}
-    if fallback_model and fallback_model != model:
-        result = _run_cli(prompt, fallback_model, timeout)
-        attempts.append({"model": fallback_model, **result})
+    started = time.monotonic()
+    attempt_timeout = _remaining_timeout(started, overall_timeout, timeout)
+    if attempt_timeout <= 0:
+        _append_budget_exhausted(attempts, model=model, backend="cli")
+    else:
+        result = _run_cli(prompt, model, attempt_timeout)
+        attempts.append({"model": model, **result})
         if result.get("ok"):
-            return {**result, "model": fallback_model, "attempts": attempts}
+            return {**result, "model": model, "attempts": attempts}
+    if fallback_model and fallback_model != model:
+        attempt_timeout = _remaining_timeout(started, overall_timeout, timeout)
+        if attempt_timeout <= 0:
+            _append_budget_exhausted(attempts, model=fallback_model, backend="cli")
+        else:
+            result = _run_cli(prompt, fallback_model, attempt_timeout)
+            attempts.append({"model": fallback_model, **result})
+            if result.get("ok"):
+                return {**result, "model": fallback_model, "attempts": attempts}
     if api_fallback:
         for api_model in (model, fallback_model):
             if not api_model:
@@ -275,7 +331,11 @@ def consult(
                 for attempt in attempts
             ):
                 continue
-            result = _run_api(prompt, api_model, timeout, system=None)
+            attempt_timeout = _remaining_timeout(started, overall_timeout, timeout)
+            if attempt_timeout <= 0:
+                _append_budget_exhausted(attempts, model=api_model, backend="api")
+                continue
+            result = _run_api(prompt, api_model, attempt_timeout, system=None)
             attempts.append({"model": api_model, **result})
             if result.get("ok"):
                 return {**result, "model": api_model, "attempts": attempts}
@@ -307,6 +367,12 @@ def main(argv: list[str] | None = None) -> int:
         default=DEFAULT_TIMEOUT_SECONDS,
         help=f"Hard per-attempt timeout in seconds (default {DEFAULT_TIMEOUT_SECONDS})",
     )
+    parser.add_argument(
+        "--overall-timeout",
+        type=float,
+        default=DEFAULT_OVERALL_TIMEOUT_SECONDS,
+        help=f"Hard total consult timeout in seconds (default {DEFAULT_OVERALL_TIMEOUT_SECONDS})",
+    )
     parser.add_argument("--system", help="Optional system-style preamble prepended to the prompt")
     parser.add_argument(
         "--no-api-fallback",
@@ -318,7 +384,10 @@ def main(argv: list[str] | None = None) -> int:
 
     if not math.isfinite(args.timeout) or args.timeout <= 0:
         print("error: --timeout must be a positive finite number", file=sys.stderr)
-        return EXIT_NO_PROMPT
+        return EXIT_USAGE
+    if not math.isfinite(args.overall_timeout) or args.overall_timeout <= 0:
+        print("error: --overall-timeout must be a positive finite number", file=sys.stderr)
+        return EXIT_USAGE
 
     if args.prompt_file:
         try:
@@ -344,6 +413,7 @@ def main(argv: list[str] | None = None) -> int:
         prompt,
         model=args.model,
         timeout=args.timeout,
+        overall_timeout=args.overall_timeout,
         fallback_model=args.fallback_model or None,
         system=args.system,
         api_fallback=not args.no_api_fallback,

--- a/scripts/consult_claude.py
+++ b/scripts/consult_claude.py
@@ -23,7 +23,7 @@ Examples::
 
     python scripts/consult_claude.py "Which PR should I settle next?"
     python scripts/consult_claude.py --prompt-file /tmp/question.md --json
-    echo "$QUESTION" | python scripts/consult_claude.py --timeout 300 --overall-timeout 900
+    echo "$QUESTION" | python scripts/consult_claude.py --timeout 300 --overall-timeout 1200
 """
 
 from __future__ import annotations
@@ -50,7 +50,6 @@ if str(_REPO_ROOT) not in sys.path:
 DEFAULT_MODEL = "claude-fable-5"
 FALLBACK_MODEL = "claude-opus-4-8"
 DEFAULT_TIMEOUT_SECONDS = 600
-DEFAULT_OVERALL_TIMEOUT_SECONDS = 600
 ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages"
 API_MAX_TOKENS = 8192
 
@@ -287,11 +286,35 @@ def _append_budget_exhausted(attempts: list[dict], *, model: str, backend: str) 
     )
 
 
+def _api_models(model: str, fallback_model: str | None) -> list[str]:
+    models: list[str] = []
+    for candidate in (model, fallback_model):
+        if candidate and candidate not in models:
+            models.append(candidate)
+    return models
+
+
+def _planned_attempt_count(*, model: str, fallback_model: str | None, api_fallback: bool) -> int:
+    cli_attempts = 1 + int(bool(fallback_model and fallback_model != model))
+    api_attempts = len(_api_models(model, fallback_model)) if api_fallback else 0
+    return cli_attempts + api_attempts
+
+
+def _default_overall_timeout(
+    *, timeout: float, model: str, fallback_model: str | None, api_fallback: bool
+) -> float:
+    return timeout * _planned_attempt_count(
+        model=model,
+        fallback_model=fallback_model,
+        api_fallback=api_fallback,
+    )
+
+
 def consult(
     prompt: str,
     model: str = DEFAULT_MODEL,
     timeout: float = DEFAULT_TIMEOUT_SECONDS,
-    overall_timeout: float = DEFAULT_OVERALL_TIMEOUT_SECONDS,
+    overall_timeout: float | None = None,
     fallback_model: str | None = FALLBACK_MODEL,
     system: str | None = None,
     api_fallback: bool = True,
@@ -299,12 +322,21 @@ def consult(
     """Run the consult across backends and return the first success.
 
     ``timeout`` is the per-attempt ceiling. ``overall_timeout`` is the total
-    consult budget shared by every CLI/API attempt.
+    consult budget shared by every CLI/API attempt. When omitted, the default
+    budget is derived from the enabled attempt plan so each documented fallback
+    path can still run after a full-timeout primary attempt.
     """
     if system:
         prompt = f"{system}\n\n---\n\n{prompt}"
     attempts: list[dict] = []
     started = time.monotonic()
+    if overall_timeout is None:
+        overall_timeout = _default_overall_timeout(
+            timeout=timeout,
+            model=model,
+            fallback_model=fallback_model,
+            api_fallback=api_fallback,
+        )
     attempt_timeout = _remaining_timeout(started, overall_timeout, timeout)
     if attempt_timeout <= 0:
         _append_budget_exhausted(attempts, model=model, backend="cli")
@@ -370,8 +402,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--overall-timeout",
         type=float,
-        default=DEFAULT_OVERALL_TIMEOUT_SECONDS,
-        help=f"Hard total consult timeout in seconds (default {DEFAULT_OVERALL_TIMEOUT_SECONDS})",
+        default=None,
+        help=(
+            "Hard total consult timeout in seconds "
+            "(default: --timeout multiplied by enabled backend attempts)"
+        ),
     )
     parser.add_argument("--system", help="Optional system-style preamble prepended to the prompt")
     parser.add_argument(
@@ -385,7 +420,9 @@ def main(argv: list[str] | None = None) -> int:
     if not math.isfinite(args.timeout) or args.timeout <= 0:
         print("error: --timeout must be a positive finite number", file=sys.stderr)
         return EXIT_USAGE
-    if not math.isfinite(args.overall_timeout) or args.overall_timeout <= 0:
+    if args.overall_timeout is not None and (
+        not math.isfinite(args.overall_timeout) or args.overall_timeout <= 0
+    ):
         print("error: --overall-timeout must be a positive finite number", file=sys.stderr)
         return EXIT_USAGE
 

--- a/scripts/consult_claude.py
+++ b/scripts/consult_claude.py
@@ -13,8 +13,8 @@ Backends, in order:
    hard subprocess timeout.
 2. Anthropic Messages API — used only with explicit ``--api-fallback`` opt-in
    after CLI attempts fail. The key comes from ``ANTHROPIC_API_KEY`` or the
-   aragora secrets manager; if neither is present the fallback is skipped
-   silently.
+   aragora secrets manager; if neither is present the attempt is recorded as a
+   normal failed backend attempt.
 
 Output is the raw model text on stdout, or a JSON envelope with ``--json``.
 Exit codes: 0 ok, 2 all backends timed out, 3 no prompt, 4 all backends failed
@@ -78,6 +78,11 @@ def _safe_api_error(message: str) -> str:
     """Public API failure string safe for JSON logs and durable artifacts."""
 
     return f"API {message}"
+
+
+def _validate_timeout(value: float, name: str) -> None:
+    if not math.isfinite(value) or value <= 0:
+        raise ValueError(f"{name} must be a positive finite number")
 
 
 @contextmanager
@@ -162,14 +167,24 @@ def _run_cli(prompt: str, model: str, timeout: float) -> dict:
         }
     elapsed = round(time.monotonic() - started, 1)
     text = _strip_preamble(stdout) if used_profile else stdout.strip()
-    if proc.returncode != 0 or not text:
+    if text:
+        result = {"ok": True, "backend": backend, "elapsed_s": elapsed, "text": text}
+        if proc.returncode != 0:
+            result["warning"] = _safe_cli_error(returncode=proc.returncode, empty=False)
+        return result
+    if proc.returncode != 0:
         return {
             "ok": False,
             "backend": backend,
             "elapsed_s": elapsed,
             "error": _safe_cli_error(returncode=proc.returncode, empty=not text),
         }
-    return {"ok": True, "backend": backend, "elapsed_s": elapsed, "text": text}
+    return {
+        "ok": False,
+        "backend": backend,
+        "elapsed_s": elapsed,
+        "error": _safe_cli_error(empty=True),
+    }
 
 
 def _kill_process_group(proc: subprocess.Popen[str]) -> None:
@@ -329,6 +344,9 @@ def consult(
     budget is derived from the enabled attempt plan so each documented fallback
     path can still run after a full-timeout primary attempt.
     """
+    _validate_timeout(timeout, "timeout")
+    if overall_timeout is not None:
+        _validate_timeout(overall_timeout, "overall_timeout")
     if system:
         prompt = f"{system}\n\n---\n\n{prompt}"
     attempts: list[dict] = []
@@ -429,13 +447,12 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--json", action="store_true", help="Emit a JSON result envelope")
     args = parser.parse_args(argv)
 
-    if not math.isfinite(args.timeout) or args.timeout <= 0:
-        print("error: --timeout must be a positive finite number", file=sys.stderr)
-        return EXIT_USAGE
-    if args.overall_timeout is not None and (
-        not math.isfinite(args.overall_timeout) or args.overall_timeout <= 0
-    ):
-        print("error: --overall-timeout must be a positive finite number", file=sys.stderr)
+    try:
+        _validate_timeout(args.timeout, "--timeout")
+        if args.overall_timeout is not None:
+            _validate_timeout(args.overall_timeout, "--overall-timeout")
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
         return EXIT_USAGE
 
     if args.prompt_file:

--- a/scripts/consult_claude.py
+++ b/scripts/consult_claude.py
@@ -114,8 +114,6 @@ def _build_cli_command(model: str, mcp_config_path: Path) -> tuple[list[str], bo
         str(mcp_config_path),
         "--model",
         model,
-        "-p",
-        "-",
     ]
     try:
         from aragora.agents.claude_profile_pool import build_claude_command

--- a/scripts/consult_claude.py
+++ b/scripts/consult_claude.py
@@ -33,9 +33,16 @@ import os
 import shutil
 import subprocess
 import sys
+import tempfile
 import time
 import urllib.error
 import urllib.request
+from contextlib import contextmanager
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
 DEFAULT_MODEL = "claude-fable-5"
 FALLBACK_MODEL = "claude-opus-4-8"
@@ -49,9 +56,34 @@ EXIT_NO_PROMPT = 3
 EXIT_ALL_FAILED = 4
 
 
-def _build_cli_command(model: str) -> tuple[list[str], bool]:
+@contextmanager
+def _claude_empty_mcp_config_file():
+    """Write an empty Claude MCP config to avoid wedged local server handshakes."""
+
+    fd, path_text = tempfile.mkstemp(prefix="aragora-consult-claude-mcp-", suffix=".json")
+    path = Path(path_text)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump({"mcpServers": {}}, handle)
+            handle.write("\n")
+        yield path
+    finally:
+        path.unlink(missing_ok=True)
+
+
+def _build_cli_command(model: str, mcp_config_path: Path) -> tuple[list[str], bool]:
     """Return the claude CLI command, profile-pool wrapped when possible."""
-    base = ["claude", "--print", "--model", model, "-p", "-"]
+    base = [
+        "claude",
+        "--print",
+        "--strict-mcp-config",
+        "--mcp-config",
+        str(mcp_config_path),
+        "--model",
+        model,
+        "-p",
+        "-",
+    ]
     try:
         from aragora.agents.claude_profile_pool import build_claude_command
 
@@ -73,27 +105,32 @@ def _run_cli(prompt: str, model: str, timeout: float) -> dict:
     """One bounded claude CLI attempt. Never raises; returns a result dict."""
     if shutil.which("claude") is None:
         return {"ok": False, "backend": "cli", "error": "claude CLI not on PATH"}
-    command, used_profile = _build_cli_command(model)
-    backend = "cli-profile" if used_profile else "cli"
     started = time.monotonic()
     try:
-        proc = subprocess.run(
-            command,
-            input=prompt,
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-        )
+        with _claude_empty_mcp_config_file() as mcp_config_path:
+            command, used_profile = _build_cli_command(model, mcp_config_path)
+            backend = "cli-profile" if used_profile else "cli"
+            proc = subprocess.run(
+                command,
+                input=prompt,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
     except subprocess.TimeoutExpired:
         return {
             "ok": False,
-            "backend": backend,
+            "backend": locals().get("backend", "cli"),
             "timed_out": True,
             "elapsed_s": round(time.monotonic() - started, 1),
             "error": f"claude CLI exceeded {timeout:.0f}s timeout",
         }
     except OSError as exc:
-        return {"ok": False, "backend": backend, "error": f"claude CLI launch failed: {exc}"}
+        return {
+            "ok": False,
+            "backend": locals().get("backend", "cli"),
+            "error": f"claude CLI launch failed: {exc}",
+        }
     elapsed = round(time.monotonic() - started, 1)
     text = _strip_preamble(proc.stdout) if used_profile else proc.stdout.strip()
     if proc.returncode != 0 or not text:
@@ -195,10 +232,18 @@ def consult(
         if result.get("ok"):
             return {**result, "model": fallback_model, "attempts": attempts}
     if api_fallback:
-        result = _run_api(prompt, model, timeout, system=None)
-        attempts.append({"model": model, **result})
-        if result.get("ok"):
-            return {**result, "model": model, "attempts": attempts}
+        for api_model in (model, fallback_model):
+            if not api_model:
+                continue
+            if any(
+                attempt.get("backend") == "api" and attempt.get("model") == api_model
+                for attempt in attempts
+            ):
+                continue
+            result = _run_api(prompt, api_model, timeout, system=None)
+            attempts.append({"model": api_model, **result})
+            if result.get("ok"):
+                return {**result, "model": api_model, "attempts": attempts}
     timed_out = all(a.get("timed_out") for a in attempts) and bool(attempts)
     return {
         "ok": False,

--- a/scripts/consult_claude.py
+++ b/scripts/consult_claude.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Bounded advisory consult of a specific Claude model (default: Claude Fable 5).
+
+Gives any agent (Codex conductor, Droid, Claude Code, humans) a reliable way to
+ask a named Claude model for read-only advice with a hard timeout. The known
+failure mode this fixes: ad-hoc ``timeout 120 claude -p "..."`` calls hang or
+time out with no output and no diagnostics.
+
+Backends, in order:
+
+1. ``claude`` CLI (subscription auth) — routed through the authenticated
+   ``claude_profile.sh`` pool when available, with ``--model`` forwarded and a
+   hard subprocess timeout.
+2. Anthropic Messages API — used only if the CLI is missing, fails, or times
+   out. The key comes from ``ANTHROPIC_API_KEY`` or the aragora secrets
+   manager; if neither is present the fallback is skipped silently.
+
+Output is the raw model text on stdout, or a JSON envelope with ``--json``.
+Exit codes: 0 ok, 2 all backends timed out, 3 no prompt, 4 all backends failed.
+
+Examples::
+
+    python scripts/consult_claude.py "Which PR should I settle next?"
+    python scripts/consult_claude.py --prompt-file /tmp/question.md --json
+    echo "$QUESTION" | python scripts/consult_claude.py --timeout 900
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+
+DEFAULT_MODEL = "claude-fable-5"
+FALLBACK_MODEL = "claude-opus-4-8"
+DEFAULT_TIMEOUT_SECONDS = 600
+ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages"
+API_MAX_TOKENS = 8192
+
+EXIT_OK = 0
+EXIT_TIMEOUT = 2
+EXIT_NO_PROMPT = 3
+EXIT_ALL_FAILED = 4
+
+
+def _build_cli_command(model: str) -> tuple[list[str], bool]:
+    """Return the claude CLI command, profile-pool wrapped when possible."""
+    base = ["claude", "--print", "--model", model, "-p", "-"]
+    try:
+        from aragora.agents.claude_profile_pool import build_claude_command
+
+        return build_claude_command(base)
+    except Exception:
+        return base, False
+
+
+def _strip_preamble(text: str) -> str:
+    try:
+        from aragora.agents.claude_profile_pool import strip_profile_preamble
+
+        return strip_profile_preamble(text)
+    except Exception:
+        return text.strip()
+
+
+def _run_cli(prompt: str, model: str, timeout: float) -> dict:
+    """One bounded claude CLI attempt. Never raises; returns a result dict."""
+    if shutil.which("claude") is None:
+        return {"ok": False, "backend": "cli", "error": "claude CLI not on PATH"}
+    command, used_profile = _build_cli_command(model)
+    backend = "cli-profile" if used_profile else "cli"
+    started = time.monotonic()
+    try:
+        proc = subprocess.run(
+            command,
+            input=prompt,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            "ok": False,
+            "backend": backend,
+            "timed_out": True,
+            "elapsed_s": round(time.monotonic() - started, 1),
+            "error": f"claude CLI exceeded {timeout:.0f}s timeout",
+        }
+    except OSError as exc:
+        return {"ok": False, "backend": backend, "error": f"claude CLI launch failed: {exc}"}
+    elapsed = round(time.monotonic() - started, 1)
+    text = _strip_preamble(proc.stdout) if used_profile else proc.stdout.strip()
+    if proc.returncode != 0 or not text:
+        stderr_tail = (proc.stderr or "").strip()[-500:]
+        return {
+            "ok": False,
+            "backend": backend,
+            "elapsed_s": elapsed,
+            "error": f"claude CLI rc={proc.returncode}, empty={not text}: {stderr_tail}",
+        }
+    return {"ok": True, "backend": backend, "elapsed_s": elapsed, "text": text}
+
+
+def _resolve_api_key() -> str | None:
+    key = os.environ.get("ANTHROPIC_API_KEY")
+    if key:
+        return key
+    try:
+        from aragora.config.secrets import get_secret
+
+        return get_secret("ANTHROPIC_API_KEY")
+    except Exception:
+        return None
+
+
+def _run_api(prompt: str, model: str, timeout: float, system: str | None) -> dict:
+    """One bounded Anthropic Messages API attempt. Never raises."""
+    key = _resolve_api_key()
+    if not key:
+        return {"ok": False, "backend": "api", "error": "no ANTHROPIC_API_KEY available"}
+    payload: dict = {
+        "model": model,
+        "max_tokens": API_MAX_TOKENS,
+        "messages": [{"role": "user", "content": prompt}],
+    }
+    if system:
+        payload["system"] = system
+    request = urllib.request.Request(
+        ANTHROPIC_API_URL,
+        data=json.dumps(payload).encode(),
+        headers={
+            "x-api-key": key,
+            "anthropic-version": "2023-06-01",
+            "content-type": "application/json",
+        },
+    )
+    started = time.monotonic()
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            body = json.loads(response.read().decode())
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode(errors="replace")[:500]
+        return {"ok": False, "backend": "api", "error": f"API HTTP {exc.code}: {detail}"}
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        timed_out = "timed out" in str(exc).lower() or isinstance(exc, TimeoutError)
+        return {
+            "ok": False,
+            "backend": "api",
+            "timed_out": timed_out,
+            "error": f"API request failed: {exc}",
+        }
+    elapsed = round(time.monotonic() - started, 1)
+    text = "".join(
+        block.get("text", "") for block in body.get("content", []) if block.get("type") == "text"
+    ).strip()
+    if not text:
+        return {
+            "ok": False,
+            "backend": "api",
+            "elapsed_s": elapsed,
+            "error": "API returned no text",
+        }
+    return {"ok": True, "backend": "api", "elapsed_s": elapsed, "text": text}
+
+
+def consult(
+    prompt: str,
+    model: str = DEFAULT_MODEL,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    fallback_model: str | None = FALLBACK_MODEL,
+    system: str | None = None,
+    api_fallback: bool = True,
+) -> dict:
+    """Run the consult across backends and return the first success.
+
+    The full timeout budget is granted to each attempt independently so a CLI
+    hang cannot starve the API fallback of time.
+    """
+    if system:
+        prompt = f"{system}\n\n---\n\n{prompt}"
+    attempts: list[dict] = []
+    result = _run_cli(prompt, model, timeout)
+    attempts.append({"model": model, **result})
+    if result.get("ok"):
+        return {**result, "model": model, "attempts": attempts}
+    if fallback_model and fallback_model != model and not result.get("timed_out"):
+        result = _run_cli(prompt, fallback_model, timeout)
+        attempts.append({"model": fallback_model, **result})
+        if result.get("ok"):
+            return {**result, "model": fallback_model, "attempts": attempts}
+    if api_fallback:
+        result = _run_api(prompt, model, timeout, system=None)
+        attempts.append({"model": model, **result})
+        if result.get("ok"):
+            return {**result, "model": model, "attempts": attempts}
+    timed_out = all(a.get("timed_out") for a in attempts) and bool(attempts)
+    return {
+        "ok": False,
+        "model": model,
+        "timed_out": timed_out,
+        "attempts": attempts,
+        "error": "; ".join(str(a.get("error")) for a in attempts),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("prompt", nargs="?", help="Question text (or use --prompt-file / stdin)")
+    parser.add_argument("--prompt-file", help="Read the question from a file")
+    parser.add_argument(
+        "--model", default=DEFAULT_MODEL, help=f"Model id (default {DEFAULT_MODEL})"
+    )
+    parser.add_argument(
+        "--fallback-model",
+        default=FALLBACK_MODEL,
+        help=f"Second CLI attempt if the primary model errors (default {FALLBACK_MODEL}; '' disables)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=DEFAULT_TIMEOUT_SECONDS,
+        help=f"Hard per-attempt timeout in seconds (default {DEFAULT_TIMEOUT_SECONDS})",
+    )
+    parser.add_argument("--system", help="Optional system-style preamble prepended to the prompt")
+    parser.add_argument(
+        "--no-api-fallback",
+        action="store_true",
+        help="Do not fall back to the Anthropic API when the CLI fails",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit a JSON result envelope")
+    args = parser.parse_args(argv)
+
+    if args.prompt_file:
+        with open(args.prompt_file, encoding="utf-8") as handle:
+            prompt = handle.read()
+    elif args.prompt:
+        prompt = args.prompt
+    elif not sys.stdin.isatty():
+        prompt = sys.stdin.read()
+    else:
+        parser.print_usage(sys.stderr)
+        print("error: no prompt given (arg, --prompt-file, or stdin)", file=sys.stderr)
+        return EXIT_NO_PROMPT
+    prompt = prompt.strip()
+    if not prompt:
+        print("error: prompt is empty", file=sys.stderr)
+        return EXIT_NO_PROMPT
+
+    result = consult(
+        prompt,
+        model=args.model,
+        timeout=args.timeout,
+        fallback_model=args.fallback_model or None,
+        system=args.system,
+        api_fallback=not args.no_api_fallback,
+    )
+    if args.json:
+        print(json.dumps(result, indent=2))
+    elif result.get("ok"):
+        print(result["text"])
+    else:
+        print(f"consult failed: {result.get('error')}", file=sys.stderr)
+    if result.get("ok"):
+        return EXIT_OK
+    return EXIT_TIMEOUT if result.get("timed_out") else EXIT_ALL_FAILED
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/consult_claude.py
+++ b/scripts/consult_claude.py
@@ -29,8 +29,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
@@ -54,6 +56,17 @@ EXIT_OK = 0
 EXIT_TIMEOUT = 2
 EXIT_NO_PROMPT = 3
 EXIT_ALL_FAILED = 4
+
+
+def _safe_cli_error(*, returncode: int | None = None, empty: bool | None = None) -> str:
+    """Public CLI failure string safe for JSON logs and durable artifacts."""
+
+    parts = ["claude CLI failed"]
+    if returncode is not None:
+        parts.append(f"rc={returncode}")
+    if empty is not None:
+        parts.append(f"empty={empty}")
+    return ", ".join(parts)
 
 
 @contextmanager
@@ -106,18 +119,23 @@ def _run_cli(prompt: str, model: str, timeout: float) -> dict:
     if shutil.which("claude") is None:
         return {"ok": False, "backend": "cli", "error": "claude CLI not on PATH"}
     started = time.monotonic()
+    proc: subprocess.Popen[str] | None = None
     try:
         with _claude_empty_mcp_config_file() as mcp_config_path:
             command, used_profile = _build_cli_command(model, mcp_config_path)
-            backend = "cli-profile" if used_profile else "cli"
-            proc = subprocess.run(
+            backend = "cli"
+            proc = subprocess.Popen(
                 command,
-                input=prompt,
-                capture_output=True,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
                 text=True,
-                timeout=timeout,
+                start_new_session=True,
             )
+            stdout, _stderr = proc.communicate(prompt, timeout=timeout)
     except subprocess.TimeoutExpired:
+        if proc is not None:
+            _kill_process_group(proc)
         return {
             "ok": False,
             "backend": locals().get("backend", "cli"),
@@ -125,23 +143,40 @@ def _run_cli(prompt: str, model: str, timeout: float) -> dict:
             "elapsed_s": round(time.monotonic() - started, 1),
             "error": f"claude CLI exceeded {timeout:.0f}s timeout",
         }
-    except OSError as exc:
+    except (OSError, UnicodeError, ValueError) as exc:
         return {
             "ok": False,
             "backend": locals().get("backend", "cli"),
-            "error": f"claude CLI launch failed: {exc}",
+            "error": f"claude CLI launch failed: {type(exc).__name__}",
         }
     elapsed = round(time.monotonic() - started, 1)
-    text = _strip_preamble(proc.stdout) if used_profile else proc.stdout.strip()
+    text = _strip_preamble(stdout) if used_profile else stdout.strip()
     if proc.returncode != 0 or not text:
-        stderr_tail = (proc.stderr or "").strip()[-500:]
         return {
             "ok": False,
             "backend": backend,
             "elapsed_s": elapsed,
-            "error": f"claude CLI rc={proc.returncode}, empty={not text}: {stderr_tail}",
+            "error": _safe_cli_error(returncode=proc.returncode, empty=not text),
         }
     return {"ok": True, "backend": backend, "elapsed_s": elapsed, "text": text}
+
+
+def _kill_process_group(proc: subprocess.Popen[str]) -> None:
+    """Best-effort cleanup for spawned Claude and any nested child process."""
+
+    try:
+        os.killpg(proc.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        return
+    except OSError:
+        try:
+            proc.kill()
+        except OSError:
+            return
+    try:
+        proc.wait(timeout=5)
+    except (OSError, subprocess.TimeoutExpired):
+        pass
 
 
 def _resolve_api_key() -> str | None:
@@ -226,7 +261,7 @@ def consult(
     attempts.append({"model": model, **result})
     if result.get("ok"):
         return {**result, "model": model, "attempts": attempts}
-    if fallback_model and fallback_model != model and not result.get("timed_out"):
+    if fallback_model and fallback_model != model:
         result = _run_cli(prompt, fallback_model, timeout)
         attempts.append({"model": fallback_model, **result})
         if result.get("ok"):
@@ -281,9 +316,17 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--json", action="store_true", help="Emit a JSON result envelope")
     args = parser.parse_args(argv)
 
+    if not math.isfinite(args.timeout) or args.timeout <= 0:
+        print("error: --timeout must be a positive finite number", file=sys.stderr)
+        return EXIT_NO_PROMPT
+
     if args.prompt_file:
-        with open(args.prompt_file, encoding="utf-8") as handle:
-            prompt = handle.read()
+        try:
+            with open(args.prompt_file, encoding="utf-8") as handle:
+                prompt = handle.read()
+        except OSError as exc:
+            print(f"error: cannot read --prompt-file: {exc}", file=sys.stderr)
+            return EXIT_NO_PROMPT
     elif args.prompt:
         prompt = args.prompt
     elif not sys.stdin.isatty():

--- a/scripts/consult_claude.py
+++ b/scripts/consult_claude.py
@@ -36,6 +36,7 @@ import math
 import os
 import shutil
 import signal
+import stat
 import subprocess
 import sys
 import tempfile
@@ -447,9 +448,13 @@ def _compose_prompt(prompt: str, system: str | None) -> str:
 
 def _read_prompt_file(path_text: str) -> str:
     path = Path(path_text)
-    if path.stat().st_size > MAX_PROMPT_BYTES:
+    info = path.stat()
+    if not stat.S_ISREG(info.st_mode):
+        raise ValueError("prompt file must be a regular file")
+    if info.st_size > MAX_PROMPT_BYTES:
         raise ValueError(_prompt_too_large_error())
-    data = path.read_bytes()
+    with path.open("rb") as handle:
+        data = handle.read(MAX_PROMPT_BYTES + 1)
     if len(data) > MAX_PROMPT_BYTES:
         raise ValueError(_prompt_too_large_error())
     return data.decode("utf-8")

--- a/tests/scripts/test_consult_claude.py
+++ b/tests/scripts/test_consult_claude.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 import io
 import json
+import stat
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -604,6 +605,51 @@ def test_main_reports_missing_prompt_file(capsys, tmp_path) -> None:
 
     assert rc == consult_claude.EXIT_NO_PROMPT
     assert "cannot read --prompt-file" in capsys.readouterr().err
+
+
+def test_main_rejects_non_regular_prompt_file_before_read(capsys, tmp_path) -> None:
+    rc = consult_claude.main(["--prompt-file", str(tmp_path)])
+
+    assert rc == consult_claude.EXIT_NO_PROMPT
+    assert "prompt file must be a regular file" in capsys.readouterr().err
+
+
+def test_prompt_file_read_is_capped_after_stat(monkeypatch) -> None:
+    read_amounts: list[int] = []
+
+    class FakeHandle:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self, amount: int) -> bytes:
+            read_amounts.append(amount)
+            return b"x" * amount
+
+    class FakePath:
+        def __init__(self, path_text: str):
+            self.path_text = path_text
+
+        def stat(self):
+            return SimpleNamespace(st_size=0, st_mode=stat.S_IFREG | 0o644)
+
+        def open(self, mode: str):
+            assert mode == "rb"
+            return FakeHandle()
+
+    monkeypatch.setattr(consult_claude, "MAX_PROMPT_BYTES", 8)
+    monkeypatch.setattr(consult_claude, "Path", FakePath)
+
+    try:
+        consult_claude._read_prompt_file("growing-prompt.md")
+    except ValueError as exc:
+        assert "prompt exceeds maximum size" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")
+
+    assert read_amounts == [9]
 
 
 def test_main_rejects_oversized_prompt_file_before_consult(monkeypatch, capsys, tmp_path) -> None:

--- a/tests/scripts/test_consult_claude.py
+++ b/tests/scripts/test_consult_claude.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import io
 import json
 import subprocess
 from pathlib import Path
@@ -101,6 +102,79 @@ def test_consult_api_fallback_tries_fallback_model(monkeypatch) -> None:
     assert api_models == [consult_claude.DEFAULT_MODEL, consult_claude.FALLBACK_MODEL]
 
 
+def test_run_api_redacts_http_error_body(monkeypatch) -> None:
+    class RaisingUrlopen:
+        def __call__(self, *_args, **_kwargs):
+            raise consult_claude.urllib.error.HTTPError(
+                url=consult_claude.ANTHROPIC_API_URL,
+                code=429,
+                msg="Too Many Requests",
+                hdrs={},
+                fp=io.BytesIO(b"profile=/secret/path token=secret prompt text"),
+            )
+
+    monkeypatch.setattr(consult_claude, "_resolve_api_key", lambda: "test-key")
+    monkeypatch.setattr(consult_claude.urllib.request, "urlopen", RaisingUrlopen())
+
+    result = consult_claude._run_api("secret prompt", "claude-fable-5", 1.0, None)
+
+    assert result["ok"] is False
+    assert result["error"] == "API HTTP 429: response body redacted"
+    assert "secret" not in json.dumps(result)
+    assert "profile" not in json.dumps(result).lower()
+
+
+def test_run_api_redacts_invalid_response_body(monkeypatch) -> None:
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self) -> bytes:
+            return b"\xff\xfe not utf-8"
+
+    monkeypatch.setattr(consult_claude, "_resolve_api_key", lambda: "test-key")
+    monkeypatch.setattr(
+        consult_claude.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: FakeResponse(),
+    )
+
+    result = consult_claude._run_api("secret prompt", "claude-fable-5", 1.0, None)
+
+    assert result["ok"] is False
+    assert result["error"] == "API response parse failed: response body redacted"
+    assert "secret" not in json.dumps(result)
+
+
+def test_consult_enforces_overall_timeout_before_fallbacks(monkeypatch) -> None:
+    cli_models: list[str] = []
+    monotonic_values = iter([0.0, 0.0, 10.0, 10.0, 10.0])
+
+    def fake_cli(_prompt: str, model: str, _timeout: float) -> dict:
+        cli_models.append(model)
+        return {"ok": False, "backend": "cli", "timed_out": True, "error": "timeout"}
+
+    monkeypatch.setattr(consult_claude.time, "monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr(consult_claude, "_run_cli", fake_cli)
+
+    result = consult_claude.consult("question", timeout=10, overall_timeout=10)
+
+    assert result["ok"] is False
+    assert result["timed_out"] is True
+    assert cli_models == [consult_claude.DEFAULT_MODEL]
+    assert [attempt["backend"] for attempt in result["attempts"]] == [
+        "cli",
+        "cli",
+        "api",
+        "api",
+    ]
+    assert all(attempt.get("timed_out") for attempt in result["attempts"])
+    assert "overall consult timeout exhausted before attempt" in result["error"]
+
+
 def test_consult_reports_timeout_only_when_all_attempts_timeout(monkeypatch) -> None:
     def fake_cli(_prompt: str, model: str, _timeout: float) -> dict:
         return {
@@ -184,7 +258,14 @@ def test_consult_tries_fallback_cli_after_primary_timeout(monkeypatch) -> None:
 def test_main_rejects_non_positive_timeout(capsys) -> None:
     rc = consult_claude.main(["--timeout", "0", "question"])
 
-    assert rc == consult_claude.EXIT_NO_PROMPT
+    assert rc == consult_claude.EXIT_USAGE
+    assert "positive finite" in capsys.readouterr().err
+
+
+def test_main_rejects_non_positive_overall_timeout(capsys) -> None:
+    rc = consult_claude.main(["--overall-timeout", "0", "question"])
+
+    assert rc == consult_claude.EXIT_USAGE
     assert "positive finite" in capsys.readouterr().err
 
 

--- a/tests/scripts/test_consult_claude.py
+++ b/tests/scripts/test_consult_claude.py
@@ -9,6 +9,8 @@ import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 
+from aragora.agents import claude_profile_pool
+
 
 SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "consult_claude.py"
 SPEC = importlib.util.spec_from_file_location("consult_claude_under_test", SCRIPT)
@@ -29,6 +31,26 @@ def test_build_cli_command_disables_mcp() -> None:
         assert json.loads(mcp_config_path.read_text(encoding="utf-8")) == {"mcpServers": {}}
         assert "--model" in command
         assert command[command.index("--model") + 1] == "claude-fable-5"
+
+
+def test_build_cli_command_routes_profile_pool_through_script_repo_root(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_build_claude_command(base_cmd, *, repo_root=None, index=None):
+        captured["base_cmd"] = base_cmd
+        captured["repo_root"] = repo_root
+        captured["index"] = index
+        return list(base_cmd), False
+
+    monkeypatch.setattr(claude_profile_pool, "build_claude_command", fake_build_claude_command)
+
+    with consult_claude._claude_empty_mcp_config_file() as mcp_config_path:
+        command, used_profile = consult_claude._build_cli_command("claude-fable-5", mcp_config_path)
+
+    assert command == captured["base_cmd"]
+    assert used_profile is False
+    assert captured["repo_root"] == consult_claude._REPO_ROOT
+    assert captured["index"] is None
 
 
 def test_run_cli_uses_stdin_prompt_timeout_and_redacts_stderr(monkeypatch) -> None:
@@ -76,7 +98,7 @@ def test_run_cli_uses_stdin_prompt_timeout_and_redacts_stderr(monkeypatch) -> No
     assert captured["command"][captured["command"].index("-p") + 1] == "-"
 
 
-def test_run_cli_preserves_stdout_from_nonzero_exit(monkeypatch) -> None:
+def test_run_cli_does_not_treat_nonzero_stdout_as_success(monkeypatch) -> None:
     class FakePopen:
         returncode = 1
         pid = 54321
@@ -94,9 +116,9 @@ def test_run_cli_preserves_stdout_from_nonzero_exit(monkeypatch) -> None:
 
     result = consult_claude._run_cli("live prompt", "claude-fable-5", 12.5)
 
-    assert result["ok"] is True
-    assert result["text"] == "usable advice"
-    assert result["warning"] == "claude CLI failed, rc=1, empty=False"
+    assert result["ok"] is False
+    assert "text" not in result
+    assert result["error"] == "claude CLI failed, rc=1, empty=False"
     assert "secret" not in json.dumps(result)
 
 
@@ -411,3 +433,34 @@ def test_main_reports_missing_prompt_file(capsys, tmp_path) -> None:
 
     assert rc == consult_claude.EXIT_NO_PROMPT
     assert "cannot read --prompt-file" in capsys.readouterr().err
+
+
+def test_main_rejects_oversized_prompt_file_before_consult(monkeypatch, capsys, tmp_path) -> None:
+    prompt_file = tmp_path / "prompt.md"
+    prompt_file.write_text("x" * 9, encoding="utf-8")
+    monkeypatch.setattr(consult_claude, "MAX_PROMPT_BYTES", 8)
+
+    def fail_consult(*_args, **_kwargs):
+        raise AssertionError("oversized prompt must be rejected before consult")
+
+    monkeypatch.setattr(consult_claude, "consult", fail_consult)
+
+    rc = consult_claude.main(["--prompt-file", str(prompt_file), "--api-fallback"])
+
+    assert rc == consult_claude.EXIT_NO_PROMPT
+    assert "prompt exceeds maximum size" in capsys.readouterr().err
+
+
+def test_main_rejects_oversized_stdin_before_consult(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(consult_claude, "MAX_PROMPT_BYTES", 8)
+    monkeypatch.setattr(consult_claude.sys, "stdin", io.StringIO("x" * 9))
+
+    def fail_consult(*_args, **_kwargs):
+        raise AssertionError("oversized prompt must be rejected before consult")
+
+    monkeypatch.setattr(consult_claude, "consult", fail_consult)
+
+    rc = consult_claude.main(["--json"])
+
+    assert rc == consult_claude.EXIT_NO_PROMPT
+    assert "prompt exceeds maximum size" in capsys.readouterr().err

--- a/tests/scripts/test_consult_claude.py
+++ b/tests/scripts/test_consult_claude.py
@@ -1,0 +1,120 @@
+"""Focused tests for the bounded Claude consult helper."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "consult_claude.py"
+SPEC = importlib.util.spec_from_file_location("consult_claude_under_test", SCRIPT)
+assert SPEC and SPEC.loader
+consult_claude = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(consult_claude)
+
+
+def test_build_cli_command_disables_mcp() -> None:
+    with consult_claude._claude_empty_mcp_config_file() as mcp_config_path:
+        command, _used_profile = consult_claude._build_cli_command(
+            "claude-fable-5", mcp_config_path
+        )
+
+        assert "--strict-mcp-config" in command
+        assert "--mcp-config" in command
+        assert command[command.index("--mcp-config") + 1] == str(mcp_config_path)
+        assert json.loads(mcp_config_path.read_text(encoding="utf-8")) == {"mcpServers": {}}
+        assert "--model" in command
+        assert command[command.index("--model") + 1] == "claude-fable-5"
+
+
+def test_run_cli_uses_stdin_prompt_and_timeout(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run(command, *, input, capture_output, text, timeout):
+        mcp_config_path = Path(command[command.index("--mcp-config") + 1])
+        captured.update(
+            {
+                "command": command,
+                "input": input,
+                "capture_output": capture_output,
+                "text": text,
+                "timeout": timeout,
+                "mcp_exists_during_run": mcp_config_path.exists(),
+                "mcp_json": json.loads(mcp_config_path.read_text(encoding="utf-8")),
+            }
+        )
+        return SimpleNamespace(returncode=0, stdout="answer\n", stderr="")
+
+    monkeypatch.setattr(consult_claude.shutil, "which", lambda name: "/usr/bin/claude")
+    monkeypatch.setattr(consult_claude.subprocess, "run", fake_run)
+
+    result = consult_claude._run_cli("live prompt", "claude-fable-5", 12.5)
+
+    assert result["ok"] is True
+    assert result["text"] == "answer"
+    assert captured["input"] == "live prompt"
+    assert captured["timeout"] == 12.5
+    assert captured["mcp_exists_during_run"] is True
+    assert captured["mcp_json"] == {"mcpServers": {}}
+    assert "-p" in captured["command"]
+    assert captured["command"][captured["command"].index("-p") + 1] == "-"
+
+
+def test_consult_api_fallback_tries_fallback_model(monkeypatch) -> None:
+    cli_models: list[str] = []
+    api_models: list[str] = []
+
+    def fake_cli(_prompt: str, model: str, _timeout: float) -> dict:
+        cli_models.append(model)
+        return {"ok": False, "backend": "cli", "error": f"{model} unavailable"}
+
+    def fake_api(_prompt: str, model: str, _timeout: float, *, system: str | None = None) -> dict:
+        del system
+        api_models.append(model)
+        if model == consult_claude.FALLBACK_MODEL:
+            return {"ok": True, "backend": "api", "text": "fallback answer", "elapsed_s": 0.1}
+        return {"ok": False, "backend": "api", "error": f"{model} unavailable"}
+
+    monkeypatch.setattr(consult_claude, "_run_cli", fake_cli)
+    monkeypatch.setattr(consult_claude, "_run_api", fake_api)
+
+    result = consult_claude.consult("question")
+
+    assert result["ok"] is True
+    assert result["model"] == consult_claude.FALLBACK_MODEL
+    assert cli_models == [consult_claude.DEFAULT_MODEL, consult_claude.FALLBACK_MODEL]
+    assert api_models == [consult_claude.DEFAULT_MODEL, consult_claude.FALLBACK_MODEL]
+
+
+def test_consult_reports_timeout_only_when_all_attempts_timeout(monkeypatch) -> None:
+    def fake_cli(_prompt: str, model: str, _timeout: float) -> dict:
+        return {
+            "ok": False,
+            "backend": "cli",
+            "timed_out": True,
+            "error": f"{model} timed out",
+        }
+
+    def fake_api(_prompt: str, model: str, _timeout: float, *, system: str | None = None) -> dict:
+        del system
+        return {
+            "ok": False,
+            "backend": "api",
+            "timed_out": True,
+            "error": f"{model} timed out",
+        }
+
+    monkeypatch.setattr(consult_claude, "_run_cli", fake_cli)
+    monkeypatch.setattr(consult_claude, "_run_api", fake_api)
+
+    result = consult_claude.consult("question")
+
+    assert result["ok"] is False
+    assert result["timed_out"] is True
+    assert [attempt["model"] for attempt in result["attempts"]] == [
+        consult_claude.DEFAULT_MODEL,
+        consult_claude.DEFAULT_MODEL,
+        consult_claude.FALLBACK_MODEL,
+    ]

--- a/tests/scripts/test_consult_claude.py
+++ b/tests/scripts/test_consult_claude.py
@@ -76,6 +76,30 @@ def test_run_cli_uses_stdin_prompt_timeout_and_redacts_stderr(monkeypatch) -> No
     assert captured["command"][captured["command"].index("-p") + 1] == "-"
 
 
+def test_run_cli_preserves_stdout_from_nonzero_exit(monkeypatch) -> None:
+    class FakePopen:
+        returncode = 1
+        pid = 54321
+
+        def __init__(self, *args, **kwargs):
+            assert kwargs["start_new_session"] is True
+
+        def communicate(self, input, timeout):
+            assert input == "live prompt"
+            assert timeout == 12.5
+            return "usable advice\n", "auth warning with token=secret"
+
+    monkeypatch.setattr(consult_claude.shutil, "which", lambda name: "/usr/bin/claude")
+    monkeypatch.setattr(consult_claude.subprocess, "Popen", FakePopen)
+
+    result = consult_claude._run_cli("live prompt", "claude-fable-5", 12.5)
+
+    assert result["ok"] is True
+    assert result["text"] == "usable advice"
+    assert result["warning"] == "claude CLI failed, rc=1, empty=False"
+    assert "secret" not in json.dumps(result)
+
+
 def test_consult_default_is_cli_only(monkeypatch) -> None:
     cli_models: list[str] = []
 
@@ -360,6 +384,24 @@ def test_main_rejects_non_positive_overall_timeout(capsys) -> None:
 
     assert rc == consult_claude.EXIT_USAGE
     assert "positive finite" in capsys.readouterr().err
+
+
+def test_consult_rejects_non_positive_timeout_for_programmatic_callers() -> None:
+    try:
+        consult_claude.consult("question", timeout=0)
+    except ValueError as exc:
+        assert "timeout must be a positive finite number" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")
+
+
+def test_consult_rejects_non_positive_overall_timeout_for_programmatic_callers() -> None:
+    try:
+        consult_claude.consult("question", overall_timeout=0)
+    except ValueError as exc:
+        assert "overall_timeout must be a positive finite number" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")
 
 
 def test_main_reports_missing_prompt_file(capsys, tmp_path) -> None:

--- a/tests/scripts/test_consult_claude.py
+++ b/tests/scripts/test_consult_claude.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -29,35 +30,47 @@ def test_build_cli_command_disables_mcp() -> None:
         assert command[command.index("--model") + 1] == "claude-fable-5"
 
 
-def test_run_cli_uses_stdin_prompt_and_timeout(monkeypatch) -> None:
+def test_run_cli_uses_stdin_prompt_timeout_and_redacts_stderr(monkeypatch) -> None:
     captured: dict[str, object] = {}
 
-    def fake_run(command, *, input, capture_output, text, timeout):
-        mcp_config_path = Path(command[command.index("--mcp-config") + 1])
-        captured.update(
-            {
-                "command": command,
-                "input": input,
-                "capture_output": capture_output,
-                "text": text,
-                "timeout": timeout,
-                "mcp_exists_during_run": mcp_config_path.exists(),
-                "mcp_json": json.loads(mcp_config_path.read_text(encoding="utf-8")),
-            }
-        )
-        return SimpleNamespace(returncode=0, stdout="answer\n", stderr="")
+    class FakePopen:
+        returncode = 1
+        pid = 12345
+
+        def __init__(self, command, *, stdin, stdout, stderr, text, start_new_session):
+            mcp_config_path = Path(command[command.index("--mcp-config") + 1])
+            captured.update(
+                {
+                    "command": command,
+                    "stdin": stdin,
+                    "stdout": stdout,
+                    "stderr": stderr,
+                    "text": text,
+                    "start_new_session": start_new_session,
+                    "mcp_exists_during_run": mcp_config_path.exists(),
+                    "mcp_json": json.loads(mcp_config_path.read_text(encoding="utf-8")),
+                }
+            )
+
+        def communicate(self, input, timeout):
+            captured["input"] = input
+            captured["timeout"] = timeout
+            return "", "Using profile home: /secret/profile\nCommand: claude --print\ntoken=secret"
 
     monkeypatch.setattr(consult_claude.shutil, "which", lambda name: "/usr/bin/claude")
-    monkeypatch.setattr(consult_claude.subprocess, "run", fake_run)
+    monkeypatch.setattr(consult_claude.subprocess, "Popen", FakePopen)
 
     result = consult_claude._run_cli("live prompt", "claude-fable-5", 12.5)
 
-    assert result["ok"] is True
-    assert result["text"] == "answer"
+    assert result["ok"] is False
+    assert result["error"] == "claude CLI failed, rc=1, empty=True"
+    assert "secret" not in json.dumps(result)
+    assert "profile" not in json.dumps(result).lower()
     assert captured["input"] == "live prompt"
     assert captured["timeout"] == 12.5
     assert captured["mcp_exists_during_run"] is True
     assert captured["mcp_json"] == {"mcpServers": {}}
+    assert captured["start_new_session"] is True
     assert "-p" in captured["command"]
     assert captured["command"][captured["command"].index("-p") + 1] == "-"
 
@@ -115,6 +128,70 @@ def test_consult_reports_timeout_only_when_all_attempts_timeout(monkeypatch) -> 
     assert result["timed_out"] is True
     assert [attempt["model"] for attempt in result["attempts"]] == [
         consult_claude.DEFAULT_MODEL,
+        consult_claude.FALLBACK_MODEL,
         consult_claude.DEFAULT_MODEL,
         consult_claude.FALLBACK_MODEL,
     ]
+
+
+def test_run_cli_timeout_kills_process_group(monkeypatch) -> None:
+    calls: list[tuple[str, object]] = []
+
+    class FakePopen:
+        returncode = None
+        pid = 6789
+
+        def __init__(self, *args, **kwargs):
+            calls.append(("popen", kwargs["start_new_session"]))
+
+        def communicate(self, input, timeout):
+            calls.append(("communicate", timeout))
+            raise subprocess.TimeoutExpired(cmd=["claude"], timeout=timeout)
+
+        def wait(self, timeout):
+            calls.append(("wait", timeout))
+
+    monkeypatch.setattr(consult_claude.shutil, "which", lambda name: "/usr/bin/claude")
+    monkeypatch.setattr(consult_claude.subprocess, "Popen", FakePopen)
+    monkeypatch.setattr(consult_claude.os, "killpg", lambda pid, sig: calls.append(("killpg", pid)))
+
+    result = consult_claude._run_cli("question", "claude-fable-5", 1.5)
+
+    assert result["timed_out"] is True
+    assert ("popen", True) in calls
+    assert ("killpg", 6789) in calls
+    assert ("wait", 5) in calls
+
+
+def test_consult_tries_fallback_cli_after_primary_timeout(monkeypatch) -> None:
+    cli_models: list[str] = []
+
+    def fake_cli(_prompt: str, model: str, _timeout: float) -> dict:
+        cli_models.append(model)
+        if model == consult_claude.DEFAULT_MODEL:
+            return {"ok": False, "backend": "cli", "timed_out": True, "error": "timeout"}
+        return {"ok": True, "backend": "cli", "text": "fallback cli answer", "elapsed_s": 0.1}
+
+    monkeypatch.setattr(consult_claude, "_run_cli", fake_cli)
+
+    result = consult_claude.consult("question", api_fallback=False)
+
+    assert result["ok"] is True
+    assert result["model"] == consult_claude.FALLBACK_MODEL
+    assert cli_models == [consult_claude.DEFAULT_MODEL, consult_claude.FALLBACK_MODEL]
+
+
+def test_main_rejects_non_positive_timeout(capsys) -> None:
+    rc = consult_claude.main(["--timeout", "0", "question"])
+
+    assert rc == consult_claude.EXIT_NO_PROMPT
+    assert "positive finite" in capsys.readouterr().err
+
+
+def test_main_reports_missing_prompt_file(capsys, tmp_path) -> None:
+    missing = tmp_path / "missing.md"
+
+    rc = consult_claude.main(["--prompt-file", str(missing)])
+
+    assert rc == consult_claude.EXIT_NO_PROMPT
+    assert "cannot read --prompt-file" in capsys.readouterr().err

--- a/tests/scripts/test_consult_claude.py
+++ b/tests/scripts/test_consult_claude.py
@@ -91,6 +91,7 @@ def test_run_cli_uses_stdin_prompt_timeout_and_redacts_stderr(monkeypatch) -> No
     assert "profile" not in json.dumps(result).lower()
     assert captured["input"] == "live prompt"
     assert captured["timeout"] == 12.5
+    assert captured["stderr"] == subprocess.DEVNULL
     assert captured["mcp_exists_during_run"] is True
     assert captured["mcp_json"] == {"mcpServers": {}}
     assert captured["start_new_session"] is True
@@ -426,6 +427,38 @@ def test_consult_rejects_non_positive_overall_timeout_for_programmatic_callers()
         raise AssertionError("expected ValueError")
 
 
+def test_consult_rejects_oversized_prompt_for_programmatic_callers(monkeypatch) -> None:
+    monkeypatch.setattr(consult_claude, "MAX_PROMPT_BYTES", 8)
+
+    def fail_cli(*_args, **_kwargs):
+        raise AssertionError("oversized prompt must be rejected before CLI")
+
+    monkeypatch.setattr(consult_claude, "_run_cli", fail_cli)
+
+    try:
+        consult_claude.consult("x" * 9)
+    except ValueError as exc:
+        assert "prompt exceeds maximum size" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")
+
+
+def test_consult_rejects_oversized_system_prompt_for_programmatic_callers(monkeypatch) -> None:
+    monkeypatch.setattr(consult_claude, "MAX_PROMPT_BYTES", 10)
+
+    def fail_cli(*_args, **_kwargs):
+        raise AssertionError("oversized prompt must be rejected before CLI")
+
+    monkeypatch.setattr(consult_claude, "_run_cli", fail_cli)
+
+    try:
+        consult_claude.consult("abc", system="system")
+    except ValueError as exc:
+        assert "prompt exceeds maximum size" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")
+
+
 def test_main_reports_missing_prompt_file(capsys, tmp_path) -> None:
     missing = tmp_path / "missing.md"
 
@@ -446,6 +479,20 @@ def test_main_rejects_oversized_prompt_file_before_consult(monkeypatch, capsys, 
     monkeypatch.setattr(consult_claude, "consult", fail_consult)
 
     rc = consult_claude.main(["--prompt-file", str(prompt_file), "--api-fallback"])
+
+    assert rc == consult_claude.EXIT_NO_PROMPT
+    assert "prompt exceeds maximum size" in capsys.readouterr().err
+
+
+def test_main_rejects_oversized_prompt_after_system_before_backend(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(consult_claude, "MAX_PROMPT_BYTES", 10)
+
+    def fail_cli(*_args, **_kwargs):
+        raise AssertionError("oversized prompt must be rejected before CLI")
+
+    monkeypatch.setattr(consult_claude, "_run_cli", fail_cli)
+
+    rc = consult_claude.main(["--system", "system", "abc"])
 
     assert rc == consult_claude.EXIT_NO_PROMPT
     assert "prompt exceeds maximum size" in capsys.readouterr().err

--- a/tests/scripts/test_consult_claude.py
+++ b/tests/scripts/test_consult_claude.py
@@ -96,8 +96,9 @@ def test_run_cli_uses_stdin_prompt_timeout_and_redacts_stderr(monkeypatch) -> No
     assert captured["mcp_exists_during_run"] is True
     assert captured["mcp_json"] == {"mcpServers": {}}
     assert captured["start_new_session"] is True
-    assert "-p" in captured["command"]
-    assert captured["command"][captured["command"].index("-p") + 1] == "-"
+    assert "--print" in captured["command"]
+    assert "-p" not in captured["command"]
+    assert "-" not in captured["command"]
 
 
 def test_run_cli_does_not_treat_nonzero_stdout_as_success(monkeypatch) -> None:

--- a/tests/scripts/test_consult_claude.py
+++ b/tests/scripts/test_consult_claude.py
@@ -199,7 +199,7 @@ def test_run_api_redacts_invalid_response_body(monkeypatch) -> None:
         def __exit__(self, *_args):
             return False
 
-        def read(self) -> bytes:
+        def read(self, _amt=None) -> bytes:
             return b"\xff\xfe not utf-8"
 
     monkeypatch.setattr(consult_claude, "_resolve_api_key", lambda: "test-key")
@@ -213,6 +213,39 @@ def test_run_api_redacts_invalid_response_body(monkeypatch) -> None:
 
     assert result["ok"] is False
     assert result["error"] == "API response parse failed: response body redacted"
+    assert "secret" not in json.dumps(result)
+
+
+def test_run_api_caps_oversized_response_body(monkeypatch) -> None:
+    payload = b'{"content":[{"type":"text","text":"secret response"}]}' + (b" " * 128)
+    read_amounts: list[int | None] = []
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self, amt=None) -> bytes:
+            read_amounts.append(amt)
+            if amt is None or amt < 0:
+                return payload
+            return payload[:amt]
+
+    monkeypatch.setattr(consult_claude, "MAX_API_RESPONSE_BYTES", 8, raising=False)
+    monkeypatch.setattr(consult_claude, "_resolve_api_key", lambda: "test-key")
+    monkeypatch.setattr(
+        consult_claude.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: FakeResponse(),
+    )
+
+    result = consult_claude._run_api("secret prompt", "claude-opus-4-8", 1.0, None)
+
+    assert read_amounts == [9]
+    assert result["ok"] is False
+    assert result["error"] == "API response exceeds maximum size: response body redacted"
     assert "secret" not in json.dumps(result)
 
 
@@ -377,6 +410,41 @@ def test_run_cli_timeout_kills_process_group(monkeypatch) -> None:
     assert ("wait", 5) in calls
 
 
+def test_run_cli_kills_process_group_after_communicate_errors(monkeypatch) -> None:
+    for exc in [OSError("boom"), UnicodeError("boom"), ValueError("boom")]:
+        calls: list[tuple[str, object]] = []
+
+        class FakePopen:
+            returncode = None
+            pid = 2468
+
+            def __init__(self, *args, **kwargs):
+                calls.append(("popen", kwargs["start_new_session"]))
+
+            def communicate(self, input, timeout):
+                calls.append(("communicate", timeout))
+                raise exc
+
+            def wait(self, timeout):
+                calls.append(("wait", timeout))
+
+        monkeypatch.setattr(consult_claude.shutil, "which", lambda name: "/usr/bin/claude")
+        monkeypatch.setattr(consult_claude.subprocess, "Popen", FakePopen)
+        monkeypatch.setattr(
+            consult_claude.os,
+            "killpg",
+            lambda pid, sig: calls.append(("killpg", pid)),
+        )
+
+        result = consult_claude._run_cli("question", "claude-fable-5", 1.5)
+
+        assert result["ok"] is False
+        assert result["error"] == f"claude CLI launch failed: {type(exc).__name__}"
+        assert ("popen", True) in calls
+        assert ("killpg", 2468) in calls
+        assert ("wait", 5) in calls
+
+
 def test_consult_tries_fallback_cli_after_primary_timeout(monkeypatch) -> None:
     cli_models: list[str] = []
 
@@ -393,6 +461,34 @@ def test_consult_tries_fallback_cli_after_primary_timeout(monkeypatch) -> None:
     assert result["ok"] is True
     assert result["model"] == consult_claude.FALLBACK_MODEL
     assert cli_models == [consult_claude.DEFAULT_MODEL, consult_claude.FALLBACK_MODEL]
+
+
+def test_consult_failure_reports_last_attempted_model(monkeypatch) -> None:
+    cli_models: list[str] = []
+
+    def fake_cli(_prompt: str, model: str, _timeout: float) -> dict:
+        cli_models.append(model)
+        return {"ok": False, "backend": "cli", "error": f"{model} unavailable"}
+
+    monkeypatch.setattr(consult_claude, "_run_cli", fake_cli)
+
+    result = consult_claude.consult("question", api_fallback=False)
+
+    assert result["ok"] is False
+    assert result["model"] == consult_claude.FALLBACK_MODEL
+    assert cli_models == [consult_claude.DEFAULT_MODEL, consult_claude.FALLBACK_MODEL]
+
+    cli_models.clear()
+
+    result = consult_claude.consult(
+        "question",
+        fallback_model=None,
+        api_fallback=False,
+    )
+
+    assert result["ok"] is False
+    assert result["model"] == consult_claude.DEFAULT_MODEL
+    assert cli_models == [consult_claude.DEFAULT_MODEL]
 
 
 def test_main_rejects_non_positive_timeout(capsys) -> None:

--- a/tests/scripts/test_consult_claude.py
+++ b/tests/scripts/test_consult_claude.py
@@ -193,6 +193,9 @@ def test_run_api_redacts_http_error_body(monkeypatch) -> None:
 
 def test_run_api_redacts_invalid_response_body(monkeypatch) -> None:
     class FakeResponse:
+        def __init__(self):
+            self._returned = False
+
         def __enter__(self):
             return self
 
@@ -200,6 +203,9 @@ def test_run_api_redacts_invalid_response_body(monkeypatch) -> None:
             return False
 
         def read(self, _amt=None) -> bytes:
+            if self._returned:
+                return b""
+            self._returned = True
             return b"\xff\xfe not utf-8"
 
     monkeypatch.setattr(consult_claude, "_resolve_api_key", lambda: "test-key")
@@ -246,6 +252,42 @@ def test_run_api_caps_oversized_response_body(monkeypatch) -> None:
     assert read_amounts == [9]
     assert result["ok"] is False
     assert result["error"] == "API response exceeds maximum size: response body redacted"
+    assert "secret" not in json.dumps(result)
+
+
+def test_run_api_times_out_slow_streaming_response(monkeypatch) -> None:
+    clock = {"now": 0.0}
+    read_amounts: list[int | None] = []
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self, amt=None) -> bytes:
+            read_amounts.append(amt)
+            clock["now"] += 0.6
+            return b" "
+
+    monkeypatch.setattr(consult_claude.time, "monotonic", lambda: clock["now"])
+    monkeypatch.setattr(consult_claude, "_resolve_api_key", lambda: "test-key")
+    monkeypatch.setattr(
+        consult_claude.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: FakeResponse(),
+    )
+
+    result = consult_claude._run_api("secret prompt", "claude-opus-4-8", 1.0, None)
+
+    assert result["ok"] is False
+    assert result["timed_out"] is True
+    assert result["error"] == "API request failed: TimeoutError"
+    assert read_amounts == [
+        consult_claude.API_RESPONSE_READ_CHUNK_BYTES,
+        consult_claude.API_RESPONSE_READ_CHUNK_BYTES,
+    ]
     assert "secret" not in json.dumps(result)
 
 

--- a/tests/scripts/test_consult_claude.py
+++ b/tests/scripts/test_consult_claude.py
@@ -240,6 +240,8 @@ def test_run_api_caps_oversized_response_body(monkeypatch) -> None:
                 return payload
             return payload[:amt]
 
+        read1 = read
+
     monkeypatch.setattr(consult_claude, "MAX_API_RESPONSE_BYTES", 8, raising=False)
     monkeypatch.setattr(consult_claude, "_resolve_api_key", lambda: "test-key")
     monkeypatch.setattr(
@@ -286,10 +288,108 @@ def test_run_api_times_out_slow_streaming_response(monkeypatch) -> None:
     assert result["timed_out"] is True
     assert result["error"] == "API request failed: TimeoutError"
     assert read_amounts == [
+        1,
+        1,
+    ]
+    assert "secret" not in json.dumps(result)
+
+
+def test_run_api_read1_uses_remaining_socket_timeout(monkeypatch) -> None:
+    clock = {"now": 0.0}
+    read_amounts: list[int] = []
+    socket_timeouts: list[float] = []
+
+    class FakeSocket:
+        def settimeout(self, timeout: float) -> None:
+            socket_timeouts.append(timeout)
+
+    class FakeRaw:
+        _sock = FakeSocket()
+
+    class FakeFp:
+        raw = FakeRaw()
+
+    class FakeResponse:
+        fp = FakeFp()
+
+        def __init__(self):
+            self._chunks = [
+                b'{"content":[{"type":"text","text":"bounded answer"}]}',
+                b"",
+            ]
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read1(self, amount: int) -> bytes:
+            read_amounts.append(amount)
+            chunk = self._chunks.pop(0)
+            clock["now"] += 0.25
+            return chunk
+
+    monkeypatch.setattr(consult_claude.time, "monotonic", lambda: clock["now"])
+    monkeypatch.setattr(consult_claude, "_resolve_api_key", lambda: "test-key")
+    monkeypatch.setattr(
+        consult_claude.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: FakeResponse(),
+    )
+
+    result = consult_claude._run_api("secret prompt", "claude-opus-4-8", 1.0, None)
+
+    assert result["ok"] is True
+    assert result["text"] == "bounded answer"
+    assert read_amounts == [
         consult_claude.API_RESPONSE_READ_CHUNK_BYTES,
         consult_claude.API_RESPONSE_READ_CHUNK_BYTES,
     ]
-    assert "secret" not in json.dumps(result)
+    assert socket_timeouts == [1.0, 0.75]
+
+
+def test_run_api_read1_timeout_after_single_socket_read(monkeypatch) -> None:
+    clock = {"now": 0.0}
+    socket_timeouts: list[float] = []
+
+    class FakeSocket:
+        def settimeout(self, timeout: float) -> None:
+            socket_timeouts.append(timeout)
+
+    class FakeRaw:
+        _sock = FakeSocket()
+
+    class FakeFp:
+        raw = FakeRaw()
+
+    class FakeResponse:
+        fp = FakeFp()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read1(self, _amount: int) -> bytes:
+            clock["now"] += 1.0
+            return b" "
+
+    monkeypatch.setattr(consult_claude.time, "monotonic", lambda: clock["now"])
+    monkeypatch.setattr(consult_claude, "_resolve_api_key", lambda: "test-key")
+    monkeypatch.setattr(
+        consult_claude.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: FakeResponse(),
+    )
+
+    result = consult_claude._run_api("secret prompt", "claude-opus-4-8", 1.0, None)
+
+    assert result["ok"] is False
+    assert result["timed_out"] is True
+    assert result["error"] == "API request failed: TimeoutError"
+    assert socket_timeouts == [1.0]
 
 
 def test_consult_enforces_overall_timeout_before_fallbacks(monkeypatch) -> None:

--- a/tests/scripts/test_consult_claude.py
+++ b/tests/scripts/test_consult_claude.py
@@ -175,8 +175,35 @@ def test_consult_enforces_overall_timeout_before_fallbacks(monkeypatch) -> None:
     assert "overall consult timeout exhausted before attempt" in result["error"]
 
 
+def test_consult_default_budget_allows_fallback_after_primary_timeout(monkeypatch) -> None:
+    cli_models: list[str] = []
+    cli_timeouts: list[float] = []
+    monotonic_values = iter([0.0, 0.0, 10.0])
+
+    def fake_cli(_prompt: str, model: str, timeout: float) -> dict:
+        cli_models.append(model)
+        cli_timeouts.append(timeout)
+        if model == consult_claude.DEFAULT_MODEL:
+            return {"ok": False, "backend": "cli", "timed_out": True, "error": "timeout"}
+        return {"ok": True, "backend": "cli", "text": "fallback cli answer", "elapsed_s": 0.1}
+
+    monkeypatch.setattr(consult_claude.time, "monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr(consult_claude, "_run_cli", fake_cli)
+
+    result = consult_claude.consult("question", timeout=10)
+
+    assert result["ok"] is True
+    assert result["model"] == consult_claude.FALLBACK_MODEL
+    assert cli_models == [consult_claude.DEFAULT_MODEL, consult_claude.FALLBACK_MODEL]
+    assert cli_timeouts == [10, 10]
+
+
 def test_consult_reports_timeout_only_when_all_attempts_timeout(monkeypatch) -> None:
-    def fake_cli(_prompt: str, model: str, _timeout: float) -> dict:
+    attempt_timeouts: list[float] = []
+    monotonic_values = iter([0.0, 0.0, 10.0, 20.0, 30.0])
+
+    def fake_cli(_prompt: str, model: str, timeout: float) -> dict:
+        attempt_timeouts.append(timeout)
         return {
             "ok": False,
             "backend": "cli",
@@ -184,8 +211,9 @@ def test_consult_reports_timeout_only_when_all_attempts_timeout(monkeypatch) -> 
             "error": f"{model} timed out",
         }
 
-    def fake_api(_prompt: str, model: str, _timeout: float, *, system: str | None = None) -> dict:
+    def fake_api(_prompt: str, model: str, timeout: float, *, system: str | None = None) -> dict:
         del system
+        attempt_timeouts.append(timeout)
         return {
             "ok": False,
             "backend": "api",
@@ -195,6 +223,7 @@ def test_consult_reports_timeout_only_when_all_attempts_timeout(monkeypatch) -> 
 
     monkeypatch.setattr(consult_claude, "_run_cli", fake_cli)
     monkeypatch.setattr(consult_claude, "_run_api", fake_api)
+    monkeypatch.setattr(consult_claude.time, "monotonic", lambda: next(monotonic_values))
 
     result = consult_claude.consult("question")
 
@@ -206,6 +235,7 @@ def test_consult_reports_timeout_only_when_all_attempts_timeout(monkeypatch) -> 
         consult_claude.DEFAULT_MODEL,
         consult_claude.FALLBACK_MODEL,
     ]
+    assert attempt_timeouts == [600, 600, 600, 600]
 
 
 def test_run_cli_timeout_kills_process_group(monkeypatch) -> None:

--- a/tests/scripts/test_consult_claude.py
+++ b/tests/scripts/test_consult_claude.py
@@ -76,7 +76,27 @@ def test_run_cli_uses_stdin_prompt_timeout_and_redacts_stderr(monkeypatch) -> No
     assert captured["command"][captured["command"].index("-p") + 1] == "-"
 
 
-def test_consult_api_fallback_tries_fallback_model(monkeypatch) -> None:
+def test_consult_default_is_cli_only(monkeypatch) -> None:
+    cli_models: list[str] = []
+
+    def fake_cli(_prompt: str, model: str, _timeout: float) -> dict:
+        cli_models.append(model)
+        return {"ok": False, "backend": "cli", "error": f"{model} unavailable"}
+
+    def fake_api(*_args, **_kwargs) -> dict:
+        raise AssertionError("API fallback must be explicit")
+
+    monkeypatch.setattr(consult_claude, "_run_cli", fake_cli)
+    monkeypatch.setattr(consult_claude, "_run_api", fake_api)
+
+    result = consult_claude.consult("question")
+
+    assert result["ok"] is False
+    assert cli_models == [consult_claude.DEFAULT_MODEL, consult_claude.FALLBACK_MODEL]
+    assert [attempt["backend"] for attempt in result["attempts"]] == ["cli", "cli"]
+
+
+def test_consult_api_fallback_skips_cli_only_model(monkeypatch) -> None:
     cli_models: list[str] = []
     api_models: list[str] = []
 
@@ -94,12 +114,12 @@ def test_consult_api_fallback_tries_fallback_model(monkeypatch) -> None:
     monkeypatch.setattr(consult_claude, "_run_cli", fake_cli)
     monkeypatch.setattr(consult_claude, "_run_api", fake_api)
 
-    result = consult_claude.consult("question")
+    result = consult_claude.consult("question", api_fallback=True)
 
     assert result["ok"] is True
     assert result["model"] == consult_claude.FALLBACK_MODEL
     assert cli_models == [consult_claude.DEFAULT_MODEL, consult_claude.FALLBACK_MODEL]
-    assert api_models == [consult_claude.DEFAULT_MODEL, consult_claude.FALLBACK_MODEL]
+    assert api_models == [consult_claude.FALLBACK_MODEL]
 
 
 def test_run_api_redacts_http_error_body(monkeypatch) -> None:
@@ -151,7 +171,7 @@ def test_run_api_redacts_invalid_response_body(monkeypatch) -> None:
 
 def test_consult_enforces_overall_timeout_before_fallbacks(monkeypatch) -> None:
     cli_models: list[str] = []
-    monotonic_values = iter([0.0, 0.0, 10.0, 10.0, 10.0])
+    monotonic_values = iter([0.0, 0.0, 10.0, 10.0])
 
     def fake_cli(_prompt: str, model: str, _timeout: float) -> dict:
         cli_models.append(model)
@@ -160,18 +180,24 @@ def test_consult_enforces_overall_timeout_before_fallbacks(monkeypatch) -> None:
     monkeypatch.setattr(consult_claude.time, "monotonic", lambda: next(monotonic_values))
     monkeypatch.setattr(consult_claude, "_run_cli", fake_cli)
 
-    result = consult_claude.consult("question", timeout=10, overall_timeout=10)
+    result = consult_claude.consult(
+        "question",
+        timeout=10,
+        overall_timeout=10,
+        api_fallback=True,
+    )
 
     assert result["ok"] is False
-    assert result["timed_out"] is True
+    assert result["timed_out"] is False
+    assert result["budget_exhausted"] is True
     assert cli_models == [consult_claude.DEFAULT_MODEL]
     assert [attempt["backend"] for attempt in result["attempts"]] == [
         "cli",
         "cli",
         "api",
-        "api",
     ]
-    assert all(attempt.get("timed_out") for attempt in result["attempts"])
+    assert result["attempts"][0]["timed_out"] is True
+    assert all(attempt.get("budget_exhausted") for attempt in result["attempts"][1:])
     assert "overall consult timeout exhausted before attempt" in result["error"]
 
 
@@ -200,7 +226,7 @@ def test_consult_default_budget_allows_fallback_after_primary_timeout(monkeypatc
 
 def test_consult_reports_timeout_only_when_all_attempts_timeout(monkeypatch) -> None:
     attempt_timeouts: list[float] = []
-    monotonic_values = iter([0.0, 0.0, 10.0, 20.0, 30.0])
+    monotonic_values = iter([0.0, 0.0, 10.0])
 
     def fake_cli(_prompt: str, model: str, timeout: float) -> dict:
         attempt_timeouts.append(timeout)
@@ -232,10 +258,47 @@ def test_consult_reports_timeout_only_when_all_attempts_timeout(monkeypatch) -> 
     assert [attempt["model"] for attempt in result["attempts"]] == [
         consult_claude.DEFAULT_MODEL,
         consult_claude.FALLBACK_MODEL,
+    ]
+    assert attempt_timeouts == [600, 600]
+
+
+def test_consult_explicit_api_fallback_has_budget_for_supported_models(monkeypatch) -> None:
+    attempt_timeouts: list[float] = []
+    monotonic_values = iter([0.0, 0.0, 10.0, 20.0])
+
+    def fake_cli(_prompt: str, model: str, timeout: float) -> dict:
+        attempt_timeouts.append(timeout)
+        return {
+            "ok": False,
+            "backend": "cli",
+            "timed_out": True,
+            "error": f"{model} timed out",
+        }
+
+    def fake_api(_prompt: str, model: str, timeout: float, *, system: str | None = None) -> dict:
+        del model, system
+        attempt_timeouts.append(timeout)
+        return {
+            "ok": False,
+            "backend": "api",
+            "timed_out": True,
+            "error": "api timed out",
+        }
+
+    monkeypatch.setattr(consult_claude, "_run_cli", fake_cli)
+    monkeypatch.setattr(consult_claude, "_run_api", fake_api)
+    monkeypatch.setattr(consult_claude.time, "monotonic", lambda: next(monotonic_values))
+
+    result = consult_claude.consult("question", timeout=10, api_fallback=True)
+
+    assert result["ok"] is False
+    assert result["timed_out"] is True
+    assert [attempt["model"] for attempt in result["attempts"]] == [
         consult_claude.DEFAULT_MODEL,
         consult_claude.FALLBACK_MODEL,
+        consult_claude.FALLBACK_MODEL,
     ]
-    assert attempt_timeouts == [600, 600, 600, 600]
+    assert attempt_timeouts == [10, 10, 10]
 
 
 def test_run_cli_timeout_kills_process_group(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

Gives agents (Codex conductor, Droid, Claude Code, humans) a reliable way to request advisory input from **Claude Fable 5** with a hard timeout, and exposes it as an Agent Skill that Codex discovers.

**Motivation:** the Codex conductor tried `timeout 120 claude -p "..."` for a read-only advisory consult and it timed out with no output. There was no repo tooling that (a) addresses a specific Claude model, (b) enforces a >=600s bounded budget, and (c) degrades gracefully.

## Changes

- **`scripts/consult_claude.py`** — bounded consult of a named Claude model (default `claude-fable-5`, default timeout 600s per attempt):
  - CLI-first: `claude --print --model <m> -p -` with the prompt on **stdin** (avoids the inline-arg hang mode), wrapped through the authenticated `claude_profile.sh` pool when available (reuses `aragora.agents.claude_profile_pool`).
  - Fallbacks: one CLI retry on `claude-opus-4-8` (skipped if the primary timed out), then the Anthropic Messages API with the key from env or `aragora.config.secrets`. Each backend gets its own full timeout budget so a CLI hang cannot starve the API path.
  - Plain text or `--json` envelope (`ok/model/backend/elapsed_s/text/attempts`); exit codes 0 ok / 2 timeout / 3 no prompt / 4 all failed. Stdlib-only; aragora imports are best-effort so the script also runs standalone outside the repo.
- **`.agents/skills/consult-fable/SKILL.md`** — Agent Skill (same convention as `elves-aragora`) telling Codex when and how to consult Fable: self-contained prompt requirements (inline live state, ask for one recommendation), and hard rules — advisory only (never merge/settle/gate authority), one consult per decision, bounded always, no retry loops.

Also installed outside the repo (not in this diff): `~/.codex/skills/consult-fable/` (SKILL.md + bundled script so running Codex sessions can use it before this merges) and `~/.claude/skills/consult-fable/`.

## Testing

- Live consult: `python3 scripts/consult_claude.py --json "Reply with exactly: FABLE-CONSULT-OK..."` → `ok=true, backend=cli, model=claude-fable-5, elapsed 7.9s`.
- Bundled standalone copy from `~/.codex/skills/` (outside repo, no aragora imports) → `BUNDLED-COPY-OK`.
- No-prompt path → exit 3 with usage error.
- Pre-commit (ruff, ruff-format, mypy, gitleaks, portability guard) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)