### PR TITLE
fix(agent-bridge): bound exec harness timeout

### DIFF
--- a/aragora/swarm/agent_bridge/exceptions.py
+++ b/aragora/swarm/agent_bridge/exceptions.py
@@ -21,6 +21,10 @@ class TransportResumeError(TransportError):
     """Raised when a resume command exits unsuccessfully."""
 
 
+class TransportTimeoutError(TransportError):
+    """Raised when a harness command exceeds its configured timeout."""
+
+
 class TransportOutputParseError(TransportError):
     """Raised when harness output cannot be parsed."""
 

--- a/aragora/swarm/agent_bridge/harnesses/base.py
+++ b/aragora/swarm/agent_bridge/harnesses/base.py
@@ -15,6 +15,7 @@ from typing import Sequence
 from ..exceptions import TransportLaunchError
 from ..exceptions import TransportNotAvailableError
 from ..exceptions import TransportResumeError
+from ..exceptions import TransportTimeoutError
 from ..types import ParsedTurn
 
 Runner = Callable[..., subprocess.CompletedProcess[str]]
@@ -26,6 +27,7 @@ RESERVED_HARNESS_OPTIONS = {
     "branch",
     "model",
     "auto",
+    "timeout_seconds",
 }
 
 
@@ -64,6 +66,9 @@ class Transport(ABC):
         self.cwd = Path(cwd)
         self.model = model
         self.harness_options = dict(harness_options or {})
+        self.timeout_seconds = self._parse_timeout_seconds(
+            self.harness_options.get("timeout_seconds")
+        )
         self._runner = runner
         self._binary_resolver = binary_resolver
 
@@ -140,14 +145,24 @@ class Transport(ABC):
             raise TransportNotAvailableError(f"{self.harness} is not installed")
 
     def _run_command(self, command: list[str]) -> subprocess.CompletedProcess[str]:
-        return self._runner(
-            command,
-            cwd=self.cwd,
-            stdin=subprocess.DEVNULL,
-            text=True,
-            capture_output=True,
-            check=False,
-        )
+        kwargs: dict[str, Any] = {
+            "cwd": self.cwd,
+            "stdin": subprocess.DEVNULL,
+            "text": True,
+            "capture_output": True,
+            "check": False,
+        }
+        if self.timeout_seconds is not None:
+            kwargs["timeout"] = self.timeout_seconds
+        try:
+            return self._runner(command, **kwargs)
+        except subprocess.TimeoutExpired as exc:
+            timeout_text = (
+                f"{self.timeout_seconds:g}s" if self.timeout_seconds is not None else "unknown"
+            )
+            raise TransportTimeoutError(
+                f"{self.harness} command timed out after {timeout_text}"
+            ) from exc
 
     def _process_error_message(self, process: subprocess.CompletedProcess[str]) -> str:
         parts: list[str] = []
@@ -156,6 +171,18 @@ class Transport(ABC):
         if process.stderr.strip():
             parts.append("stderr:\n" + process.stderr.strip()[:4000])
         return "\n".join(parts) if parts else self.harness
+
+    @staticmethod
+    def _parse_timeout_seconds(value: Any) -> float | None:
+        if value is None or value == "":
+            return None
+        try:
+            timeout = float(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("timeout_seconds must be a positive number") from exc
+        if timeout <= 0:
+            raise ValueError("timeout_seconds must be a positive number")
+        return timeout
 
     def _cli_option_args(self, extra_reserved: Sequence[str] = ()) -> list[str]:
         args: list[str] = []

--- a/aragora/swarm/agent_bridge/harnesses/base.py
+++ b/aragora/swarm/agent_bridge/harnesses/base.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import math
+import os
 import shutil
+import signal
 import subprocess
 from abc import ABC
 from abc import abstractmethod
@@ -155,6 +158,8 @@ class Transport(ABC):
         if self.timeout_seconds is not None:
             kwargs["timeout"] = self.timeout_seconds
         try:
+            if self._runner is subprocess.run:
+                return self._run_subprocess_with_group(command)
             return self._runner(command, **kwargs)
         except subprocess.TimeoutExpired as exc:
             timeout_text = (
@@ -163,6 +168,33 @@ class Transport(ABC):
             raise TransportTimeoutError(
                 f"{self.harness} command timed out after {timeout_text}"
             ) from exc
+
+    def _run_subprocess_with_group(self, command: list[str]) -> subprocess.CompletedProcess[str]:
+        process = subprocess.Popen(
+            command,
+            cwd=self.cwd,
+            stdin=subprocess.DEVNULL,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+        )
+        try:
+            stdout, stderr = process.communicate(timeout=self.timeout_seconds)
+        except subprocess.TimeoutExpired:
+            self._kill_process_group(process)
+            process.communicate()
+            raise
+        return subprocess.CompletedProcess(command, process.returncode, stdout, stderr)
+
+    @staticmethod
+    def _kill_process_group(process: subprocess.Popen[str]) -> None:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            return
+        except OSError:
+            process.kill()
 
     def _process_error_message(self, process: subprocess.CompletedProcess[str]) -> str:
         parts: list[str] = []
@@ -180,7 +212,7 @@ class Transport(ABC):
             timeout = float(value)
         except (TypeError, ValueError) as exc:
             raise ValueError("timeout_seconds must be a positive number") from exc
-        if timeout <= 0:
+        if not math.isfinite(timeout) or timeout <= 0:
             raise ValueError("timeout_seconds must be a positive number")
         return timeout
 

--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -1994,6 +1994,9 @@ def cmd_exec(args: argparse.Namespace) -> int:
         harness_options["auto"] = auto_mode
     elif agent in {"droid", "factory"}:
         harness_options["auto"] = "high"
+    timeout_seconds = getattr(args, "timeout_seconds", None)
+    if timeout_seconds is not None:
+        harness_options["timeout_seconds"] = timeout_seconds
     allowed_roles = set(args.allowed_role or ["reviewer"])
 
     try:
@@ -3257,6 +3260,11 @@ def main() -> int:
         ),
     )
     exec_p.add_argument("--model", help="Model id to pass to the harness")
+    exec_p.add_argument(
+        "--timeout-seconds",
+        type=float,
+        help="Hard timeout for the harness subprocess",
+    )
     exec_p.add_argument("--auto", choices=("low", "medium", "high"), help="Droid autonomy level")
     exec_p.add_argument("--allowed-role", action="append", help="Allowed bridge footer role")
     exec_p.add_argument("prompt", nargs="*")

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -2229,6 +2229,20 @@ def test_cmd_exec_droid_uses_transport_auto_high(
             "Review #7292",
         ]
     ]
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["command"] == commands[0]
+    assert payload["message_text"] == (
+        "Synthesized the review findings.\n\n---BRIDGE-FOOTER---\n"
+        "summary: Synthesized the review findings\n"
+        "next_actor: reviewer\n"
+        "needs_human: false\n"
+        "done: false\n"
+        "artifacts: []\n"
+        'tests_run: ["pytest tests/swarm/agent_bridge/test_harnesses_droid.py"]\n'
+        "---BRIDGE-FOOTER-END---"
+    )
+    assert payload["parse_status"] == "ok"
 
 
 def test_cmd_exec_forwards_timeout_seconds_to_transport(
@@ -2293,6 +2307,117 @@ def test_cmd_exec_forwards_timeout_seconds_to_transport(
     }
     payload = json.loads(capsys.readouterr().out)
     assert payload["ok"] is True
+
+
+def test_cmd_exec_json_reports_transport_timeout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import agent_bridge as mod
+    from aragora.swarm.agent_bridge.exceptions import TransportTimeoutError
+
+    transport_error, _ = mod._load_transport_runtime()
+    assert issubclass(TransportTimeoutError, transport_error)
+
+    def _fake_create_transport(_agent, *, cwd, model, harness_options):
+        del cwd, model, harness_options
+
+        class _TimeoutTransport:
+            def launch(self, _prompt, *, allowed_roles):
+                del allowed_roles
+                raise TransportTimeoutError("droid command timed out after 0.3s")
+
+        return _TimeoutTransport()
+
+    monkeypatch.setattr(mod, "create_transport", _fake_create_transport)
+
+    rc = mod.cmd_exec(
+        argparse.Namespace(
+            agent="droid",
+            cwd=str(tmp_path),
+            model=None,
+            timeout_seconds=0.3,
+            auto="high",
+            allowed_role=["reviewer"],
+            file=None,
+            prompt=["Review", "#7292"],
+            json=True,
+        )
+    )
+
+    assert rc == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {
+        "ok": False,
+        "agent": "droid",
+        "cwd": str(tmp_path.resolve()),
+        "error": "droid command timed out after 0.3s",
+    }
+
+
+@pytest.mark.parametrize("timeout_seconds", [0, -1, "nan", "inf", "-inf", "not-a-number"])
+def test_transport_rejects_invalid_timeout_seconds(
+    tmp_path: Path,
+    timeout_seconds: object,
+) -> None:
+    from aragora.swarm.agent_bridge.harnesses.claude import ClaudeTransport
+
+    with pytest.raises(ValueError, match="timeout_seconds must be a positive number"):
+        ClaudeTransport(
+            cwd=tmp_path,
+            harness_options={"timeout_seconds": timeout_seconds},
+            binary_resolver=lambda _: "/usr/bin/claude",
+        )
+
+
+def test_transport_timeout_kills_process_group(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from aragora.swarm.agent_bridge.exceptions import TransportTimeoutError
+    from aragora.swarm.agent_bridge.harnesses import base as base_mod
+    from aragora.swarm.agent_bridge.harnesses.claude import ClaudeTransport
+
+    popen_kwargs: dict[str, object] = {}
+    killed: list[tuple[int, int]] = []
+
+    class _FakeProcess:
+        pid = 4321
+        returncode = -9
+
+        def __init__(self) -> None:
+            self.communicate_calls = 0
+
+        def communicate(self, timeout=None):
+            self.communicate_calls += 1
+            if self.communicate_calls == 1:
+                raise subprocess.TimeoutExpired(["claude", "-p", "Review"], timeout)
+            return "", ""
+
+        def kill(self) -> None:
+            raise AssertionError("process.kill should only be a killpg fallback")
+
+    fake_process = _FakeProcess()
+
+    def _fake_popen(command, **kwargs):
+        popen_kwargs.update(kwargs)
+        return fake_process
+
+    monkeypatch.setattr(base_mod.subprocess, "Popen", _fake_popen)
+    monkeypatch.setattr(base_mod.os, "killpg", lambda pid, sig: killed.append((pid, sig)))
+
+    transport = ClaudeTransport(
+        cwd=tmp_path,
+        harness_options={"timeout_seconds": 0.3},
+        binary_resolver=lambda _: "/usr/bin/claude",
+    )
+
+    with pytest.raises(TransportTimeoutError, match="timed out after 0.3s"):
+        transport._run_command(["claude", "-p", "Review"])
+
+    assert popen_kwargs["start_new_session"] is True
+    assert killed == [(4321, base_mod.signal.SIGKILL)]
 
 
 def test_write_session_snapshot_falls_back_to_state_root(

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -2229,11 +2229,70 @@ def test_cmd_exec_droid_uses_transport_auto_high(
             "Review #7292",
         ]
     ]
+
+
+def test_cmd_exec_forwards_timeout_seconds_to_transport(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import agent_bridge as mod
+    from aragora.swarm.agent_bridge.harnesses.claude import ClaudeTransport
+
+    fixture = (
+        Path(__file__).resolve().parents[2]
+        / "tests"
+        / "fixtures"
+        / "agent_bridge"
+        / "claude_start.txt"
+    ).read_text(encoding="utf-8")
+    captured: dict[str, object] = {}
+
+    def _fake_runner(command: list[str], **_kwargs) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(command, 0, stdout=fixture, stderr="")
+
+    def _fake_create_transport(agent, *, cwd, model, harness_options):
+        captured.update(
+            {
+                "agent": agent,
+                "cwd": cwd,
+                "model": model,
+                "harness_options": harness_options,
+            }
+        )
+        return ClaudeTransport(
+            cwd=cwd,
+            model=model,
+            harness_options=harness_options,
+            runner=_fake_runner,
+            binary_resolver=lambda _: "/usr/bin/claude",
+        )
+
+    monkeypatch.setattr(mod, "create_transport", _fake_create_transport)
+
+    rc = mod.cmd_exec(
+        argparse.Namespace(
+            agent="claude",
+            cwd=str(tmp_path),
+            model="claude-fable-5",
+            timeout_seconds=600,
+            auto=None,
+            allowed_role=["reviewer"],
+            file=None,
+            prompt=["Review", "#8796"],
+            json=True,
+        )
+    )
+
+    assert rc == 0
+    assert captured == {
+        "agent": "claude",
+        "cwd": tmp_path.resolve(),
+        "model": "claude-fable-5",
+        "harness_options": {"timeout_seconds": 600},
+    }
     payload = json.loads(capsys.readouterr().out)
     assert payload["ok"] is True
-    assert payload["command"] == commands[0]
-    assert payload["message_text"].startswith("Synthesized the review findings.")
-    assert payload["parse_status"] == "ok"
 
 
 def test_write_session_snapshot_falls_back_to_state_root(

--- a/tests/swarm/agent_bridge/test_harnesses_claude.py
+++ b/tests/swarm/agent_bridge/test_harnesses_claude.py
@@ -4,6 +4,9 @@ import subprocess
 import uuid
 from pathlib import Path
 
+import pytest
+
+from aragora.swarm.agent_bridge.exceptions import TransportTimeoutError
 from aragora.swarm.agent_bridge.harnesses.claude import ClaudeTransport
 
 
@@ -58,3 +61,36 @@ def test_claude_launch_assigns_uuid4_and_resume_uses_resume_flag(tmp_path: Path)
         "Repair this",
     ]
     assert resumed.session_id == str(session_id)
+
+
+def test_claude_transport_applies_timeout_and_fails_closed(tmp_path: Path) -> None:
+    observed: dict[str, object] = {}
+    session_id = uuid.UUID("123e4567-e89b-42d3-a456-426614174000")
+
+    def runner(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        observed["command"] = command
+        observed["kwargs"] = kwargs
+        raise subprocess.TimeoutExpired(command, 600)
+
+    transport = ClaudeTransport(
+        cwd=tmp_path,
+        model="claude-fable-5",
+        harness_options={"timeout_seconds": 600},
+        runner=runner,
+        binary_resolver=lambda _: "/usr/bin/claude",
+        uuid_factory=lambda: session_id,
+    )
+
+    with pytest.raises(TransportTimeoutError, match="timed out after 600s"):
+        transport.launch("Review this", allowed_roles={"reviewer"})
+
+    assert observed["command"] == [
+        "claude",
+        "-p",
+        "--session-id",
+        str(session_id),
+        "--model",
+        "claude-fable-5",
+        "Review this",
+    ]
+    assert observed["kwargs"]["timeout"] == 600.0


### PR DESCRIPTION
## Summary
- add --timeout-seconds to agent_bridge.py exec
- thread the timeout into agent-bridge transports without forwarding it to harness CLIs
- fail closed with TransportTimeoutError when the harness subprocess exceeds the configured timeout

## Validation
- python3 -m pytest tests/swarm/agent_bridge/test_harnesses_claude.py tests/scripts/test_agent_bridge.py -q
- pre-commit run --files scripts/agent_bridge.py aragora/swarm/agent_bridge/exceptions.py aragora/swarm/agent_bridge/harnesses/base.py tests/scripts/test_agent_bridge.py tests/swarm/agent_bridge/test_harnesses_claude.py
- git push hook: pre-commit + mypy changed-files passed

## Notes
This is deliberately separate from #8796. The consult-fable script remains the canonical long-prompt path; this PR makes agent_bridge exec safe for bounded model-specific bridge calls.