### PR TITLE
fix(ci): install TypeScript SDK deps in SDK Integration Tests job

### DIFF
--- a/.github/workflows/sdk-test.yml
+++ b/.github/workflows/sdk-test.yml
@@ -234,6 +234,17 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: sdk/typescript/package-lock.json
+
+      - name: Install TypeScript SDK dependencies
+        working-directory: sdk/typescript
+        run: npm ci
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
The **SDK Integration Tests** job in `.github/workflows/sdk-test.yml` fails on main whenever it actually runs (it is path-gated to SDK changes, so the failure only surfaces on SDK-touching PRs).

**Evidence:** main run [28563420671](https://github.com/synaptent/aragora/actions/runs/28563420671) (2026-07-02T03:33Z) failed `tests/sdk/test_typescript_exports.py::TestTypeScriptCompilation::test_sdk_compiles_cleanly` with:
```
src/typecheck/node26-consumer.ts(1,23): error TS2688: Cannot find type definition file for 'node'
```

**Root cause:** the `sdk-integration` job installs Python deps only and never runs `npm ci` in `sdk/typescript`, so `npx tsc --noEmit` (invoked by the test with `cwd=sdk/typescript`) has no `node_modules` and no `@types/node`.

**Fix:** add the same `actions/setup-node@v4` + `npm ci` (working-directory: `sdk/typescript`) steps the `typescript-sdk-run` job already uses, before running `pytest tests/sdk/`.

## Verification
- `cd sdk/typescript && npm ci && npx tsc --noEmit` — passes locally
- `python -m pytest tests/sdk/test_typescript_exports.py::TestTypeScriptCompilation::test_sdk_compiles_cleanly -v` — **1 passed** with node_modules present
- Workflow YAML validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)