### PR TITLE
fix(onboarding): five-minute stranger test — verified friction fixes

### DIFF
--- a/aragora/cli/commands/debate.py
+++ b/aragora/cli/commands/debate.py
@@ -20,6 +20,8 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Literal, cast
 
+from pydantic import ValidationError
+
 from aragora.agents.base import AgentType, create_agent
 from aragora.agents.spec import AgentSpec
 from aragora.config import (
@@ -2085,6 +2087,20 @@ def cmd_ask(args: argparse.Namespace) -> None:
                 )
                 _print_decision_integrity_summary(package)
             return
+        except ValidationError as e:
+            # The server answered but returned a payload the SDK models could
+            # not parse (version skew, or a non-Aragora service on the port).
+            # Surface a friendly error instead of a raw pydantic traceback.
+            print(
+                f"API run failed: server at {server_url} returned an unexpected "
+                "response. If this is not an Aragora API server, rerun with "
+                "--local (or set ARAGORA_API_URL). Use --verbose for details.",
+                file=sys.stderr,
+            )
+            logger.debug("SDK response validation failed: %s", e)
+            if args.verbose:
+                print(f"Validation details: {e}", file=sys.stderr)
+            raise SystemExit(1)
         except (OSError, ConnectionError, TimeoutError, RuntimeError) as e:
             if requested_api or graph_mode or matrix_mode:
                 print(f"API run failed: {e}", file=sys.stderr)

--- a/aragora/client/models.py
+++ b/aragora/client/models.py
@@ -133,6 +133,29 @@ class Debate(BaseModel):
     completed_at: datetime | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
 
+    @field_validator("agents", mode="before")
+    @classmethod
+    def _coerce_agents(cls, value: Any) -> list[Any]:
+        """Accept agent specs echoed back by the server as dicts.
+
+        The create API accepts advanced agent specs (``{"provider": ...,
+        "name": ...}``) and the server stores and returns them verbatim, so a
+        GET can legitimately contain dicts. Coerce each entry to its display
+        name so ``agents`` stays ``list[str]`` for SDK consumers.
+        """
+        if value is None:
+            return []
+        if not isinstance(value, list):
+            return value
+        coerced: list[Any] = []
+        for entry in value:
+            if isinstance(entry, dict):
+                name = entry.get("name") or entry.get("provider") or entry.get("agent")
+                coerced.append(str(name) if name else str(entry))
+            else:
+                coerced.append(entry)
+        return coerced
+
     @field_validator("rounds", mode="before")
     @classmethod
     def _coerce_rounds(cls, value: Any) -> list[Any]:

--- a/aragora/security/encryption.py
+++ b/aragora/security/encryption.py
@@ -56,7 +56,11 @@ try:
     CRYPTO_AVAILABLE = True
 except ImportError:
     CRYPTO_AVAILABLE = False
-    logger.warning("cryptography library not available - encryption disabled")
+    # info, not warning: cryptography is an optional dependency, so a plain
+    # ``pip install aragora`` would otherwise print a scary warning on every
+    # CLI invocation. Actual encryption use without the library still raises
+    # (see EncryptionService.__init__ / EncryptionError at point of use).
+    logger.info("cryptography library not available - encryption disabled")
 
 # Encryption enforcement configuration
 # When True, encryption failures raise exceptions instead of returning plaintext

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -16,15 +16,20 @@ No API keys required. The offline demo runs a complete adversarial debate with
 mock agents:
 
 ```bash
-python3 -m aragora.cli.main demo
+python3 -m aragora_debate
 ```
 
 You'll see three agents propose, critique each other, vote, reach consensus, and
 produce an audit-ready decision receipt with a SHA-256 verdict hash.
 
+(If you installed the full platform instead — `pip install aragora` — the
+equivalent zero-key demo is `aragora demo`.)
+
 ## 3. Three-Line Debate (Python)
 
 ```python
+import asyncio
+
 from aragora_debate.arena import Arena
 from aragora_debate.styled_mock import StyledMockAgent
 
@@ -97,7 +102,9 @@ Then visit:
 
 ```bash
 pip install aragora
-aragora debate "Should we build or buy our auth system?"
+aragora demo                                            # zero-key offline demo + receipt
+aragora ask "Should we build or buy our auth system?"   # real debate (needs an API key)
+aragora verify aragora-demo-receipt.json                # verify a receipt offline
 aragora serve --api-port 8080 --ws-port 8765
 ```
 

--- a/tests/client/test_debates_api.py
+++ b/tests/client/test_debates_api.py
@@ -268,6 +268,20 @@ class TestDebateModel:
         )
         assert debate.debate_id == "deb-alias"
 
+    def test_debate_coerces_agent_spec_dicts(self):
+        """Test Debate coerces agent spec dicts (echoed by the server) to names."""
+        debate = Debate(
+            debate_id="deb-agents",
+            task="Test",
+            status=DebateStatus.COMPLETED,
+            agents=[
+                {"provider": "grok", "name": "grok"},  # type: ignore[list-item]
+                "openai-api",
+                {"provider": "deepseek"},  # type: ignore[list-item]
+            ],
+        )
+        assert debate.agents == ["grok", "openai-api", "deepseek"]
+
     def test_debate_coerces_rounds(self):
         """Test Debate coerces int rounds to empty list."""
         debate = Debate(


### PR DESCRIPTION
## What

Wave-3 target 2 on epic #8762: prove or break `pip install aragora` → working CLI → first debate → receipt in five minutes, as an actual stranger, then fix the friction. PR #8517 (root packaging) made the wheel installable; this PR fixes what the timed walkthrough found.

## Method

Built the wheel from origin/main (`d780bd4898`) in an isolated worktree, installed **only that wheel** into a completely fresh venv, and ran every step in a scrubbed environment (`env -i`, empty `$HOME`, no repo on path, no API keys, no reachable server). The `aragora-debate` wedge was tested the same way in its own venv.

## Timed walkthrough (step → time → result)

| Step | Time | Result |
|------|-----:|--------|
| `pip wheel . --no-deps` (build) | 5 s | wheel builds clean, 16.7 MB |
| `python3 -m venv` + `pip install <wheel>` | 11 s | 36 packages, no errors |
| `aragora --help` | <1 s | works |
| `aragora demo` (zero-key) | <1 s | full mock debate + receipt saved to `./aragora-demo-receipt.json` |
| `aragora verify aragora-demo-receipt.json` | <1 s | `Result: VALID` — offline, keyless |
| `aragora quickstart --demo` | <1 s | guided zero-to-receipt run; receipt written under `~/.aragora/receipts/` and verifies VALID |
| `aragora ask "…"` keyless, no server | <1 s | clean, actionable error: lists every accepted key env var + next command. No traceback |
| `aragora doctor` keyless | <1 s | honest red/yellow report |
| **Total (install → receipt → verified)** | **~15 s** | |

**Verdict: PASS** — the five-minute stranger test passes with roughly 4m 45s to spare. But only if the stranger ignores the quickstart doc and uses `--help`, because two documented commands were wrong (fixed here).

## Friction found → fixed (this PR)

1. **`docs/quickstart.md` §2 lies**: after `pip install aragora-debate` it says to run `python3 -m aragora.cli.main demo` → `ModuleNotFoundError: No module named 'aragora'` (that module ships in the full dist). Reproduced in a clean venv. Fixed to the wedge's real zero-key demo, `python3 -m aragora_debate` (verified working).
2. **`docs/quickstart.md` §7 documents a nonexistent command**: `aragora debate "…"` → argparse `invalid choice: 'debate'`. Fixed to `aragora ask`, plus added the zero-key `aragora demo` → `aragora verify` receipt loop.
3. **§3 Python snippet crashes**: uses `asyncio.run` without `import asyncio`. Fixed; snippet now runs verbatim in a fresh `aragora-debate` venv.
4. **Scary warning on every command in a fresh install**: `WARNING aragora.security.encryption: cryptography library not available - encryption disabled`. `cryptography` is deliberately optional (kept out of base deps per pyproject), so a plain `pip install aragora` always printed this. Downgraded to `logger.info`; point-of-use still raises `RuntimeError`/`EncryptionError` when encryption is actually used (existing tests cover that).
5. **Raw pydantic traceback when a server answers on port 8080**: the CLI sends advanced agent specs as dicts (`{"provider": …, "name": …}`), the server echoes them back, and the SDK `Debate` model requires `agents: list[str]` → `ValidationError` with a 30-line traceback out of `aragora ask`. Two-layer fix: `Debate.agents` now coerces dict specs to names (with a unit test), and the `ask` API path catches `ValidationError` and prints a friendly "server returned an unexpected response … rerun with --local" error.

## Bigger issues NOT fixed here

Filed separately (one issue) — includes the silent auto-routing of `aragora ask` to *anything* answering 200 on `localhost:8080/api/health`, the agents-payload round-trip contract (server should normalize, SDK coercion is a shim), and the unpublished `aragora-verify` standalone package the README points at.

## Verification

- `tests/client/test_debates_api.py` 62 passed (incl. new coercion test) · `tests/client/test_client_sdk.py` + `tests/client/resources` 137 passed · encryption suites 129 passed · `tests/cli -k "debate or ask"` 126 passed, 1 skipped
- mypy clean on the three changed modules; pre-commit clean
- Rebuilt the wheel after the fixes and re-ran the whole stranger walkthrough: zero stderr noise on `demo`, keyless `ask` error unchanged and helpful, receipt still verifies VALID

Part of #8762 (close-the-loop, Wave 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)