### PR TITLE
fix(cli): aragora ask verifies server identity before trusting localhost discovery (#8805)

### DIFF
--- a/aragora/cli/commands/debate.py
+++ b/aragora/cli/commands/debate.py
@@ -350,14 +350,22 @@ def _probe_server_identity(server_url: str) -> str:
     return "foreign"
 
 
-def _is_explicitly_configured_api_url(server_url: str) -> bool:
-    """True when the user opted in to this API URL (env var or --api-url flag)."""
+def _is_explicitly_configured_api_url(server_url: str, *, flag_passed: bool = False) -> bool:
+    """True when the user opted in to this API URL (env var or --api-url flag).
+
+    ``flag_passed`` carries actual flag presence from argparse (the parser
+    defaults ``--api-url`` to ``None``), so ``--api-url http://localhost:8080``
+    counts as explicit even though it equals the default URL. The value
+    comparison remains as a fallback for callers without flag information.
+    """
+    if flag_passed:
+        return True
     if os.environ.get("ARAGORA_API_URL", "").strip():
         return True
     return server_url.rstrip("/") != DEFAULT_API_URL.rstrip("/")
 
 
-def _trusted_server_available(server_url: str) -> bool:
+def _trusted_server_available(server_url: str, *, flag_passed: bool = False) -> bool:
     """Availability gate for auto-discovery: reachable AND identifies as Aragora.
 
     Fail-closed trust check: port 8080 is the most commonly squatted dev port
@@ -368,7 +376,7 @@ def _trusted_server_available(server_url: str) -> bool:
     """
     if not _is_server_available(server_url):
         return False
-    if _is_explicitly_configured_api_url(server_url):
+    if _is_explicitly_configured_api_url(server_url, flag_passed=flag_passed):
         return True
     identity = _probe_server_identity(server_url)
     if identity == "aragora":
@@ -1845,7 +1853,9 @@ def cmd_ask(args: argparse.Namespace) -> None:
             }
         )
 
-    server_url = getattr(args, "api_url", DEFAULT_API_URL)
+    api_url_arg = getattr(args, "api_url", None)
+    api_url_flag_passed = api_url_arg is not None
+    server_url = api_url_arg or DEFAULT_API_URL
     api_key = (
         getattr(args, "api_key", None)
         or os.environ.get("ARAGORA_API_TOKEN")
@@ -2095,7 +2105,7 @@ def cmd_ask(args: argparse.Namespace) -> None:
 
     use_api = requested_api
     if not requested_api and not requested_local:
-        use_api = _trusted_server_available(server_url)
+        use_api = _trusted_server_available(server_url, flag_passed=api_url_flag_passed)
 
     if use_api:
         try:

--- a/aragora/cli/commands/debate.py
+++ b/aragora/cli/commands/debate.py
@@ -296,6 +296,92 @@ def _is_server_available(server_url: str) -> bool:
         return False
 
 
+# Statuses Aragora's health endpoint can report. The public (unauthenticated)
+# ``/api/health`` response is exactly {"status": "healthy"|"degraded",
+# "timestamp": "<iso8601>Z"} (see aragora/server/handlers/admin/health).
+_ARAGORA_HEALTH_STATUSES = frozenset({"healthy", "degraded"})
+
+
+def _identifies_as_aragora(body: bytes) -> bool:
+    """Return True when a health response body matches Aragora's health schema.
+
+    This is a positive-signal check: the payload must be a JSON object whose
+    ``status`` is one of Aragora's health statuses and which carries a
+    ``timestamp`` field. Anything else (HTML login pages, Jenkins/Tomcat
+    banners, other projects' ``{"status": "ok"}`` probes) is rejected.
+    """
+    try:
+        payload = json.loads(body.decode("utf-8"))
+    except (UnicodeDecodeError, ValueError):
+        return False
+    if not isinstance(payload, dict):
+        return False
+    status = payload.get("status")
+    return (
+        isinstance(status, str)
+        and status.lower() in _ARAGORA_HEALTH_STATUSES
+        and "timestamp" in payload
+    )
+
+
+def _probe_server_identity(server_url: str) -> str:
+    """Probe ``server_url`` and classify what is listening.
+
+    Returns:
+        ``"aragora"``: HTTP 200 whose payload matches Aragora's health schema.
+        ``"foreign"``: something answered HTTP 200 but does not identify as an
+            Aragora server (e.g. another dev service squatting the port).
+        ``"unavailable"``: nothing healthy is listening.
+    """
+    try:
+        import urllib.request
+
+        with urllib.request.urlopen(f"{server_url}/api/health", timeout=2) as resp:  # noqa: S310 -- local server health check
+            status_code = getattr(resp, "status", None) or resp.getcode()
+            if status_code != 200:
+                return "unavailable"
+            body = resp.read(8192)
+    except (OSError, TimeoutError, ValueError) as e:
+        logger.debug("Server health probe failed at %s: %s", server_url, e)
+        return "unavailable"
+    if _identifies_as_aragora(body):
+        return "aragora"
+    logger.debug("Service at %s answered 200 but does not identify as Aragora", server_url)
+    return "foreign"
+
+
+def _is_explicitly_configured_api_url(server_url: str) -> bool:
+    """True when the user opted in to this API URL (env var or --api-url flag)."""
+    if os.environ.get("ARAGORA_API_URL", "").strip():
+        return True
+    return server_url.rstrip("/") != DEFAULT_API_URL.rstrip("/")
+
+
+def _trusted_server_available(server_url: str) -> bool:
+    """Availability gate for auto-discovery: reachable AND identifies as Aragora.
+
+    Fail-closed trust check: port 8080 is the most commonly squatted dev port
+    (Jenkins, Tomcat, other projects' dev servers), so a bare HTTP 200 on
+    ``/api/health`` is not enough to route the user's debate content there.
+    An explicitly configured URL (``ARAGORA_API_URL`` or ``--api-url``) is
+    trusted as-is because the user opted in.
+    """
+    if not _is_server_available(server_url):
+        return False
+    if _is_explicitly_configured_api_url(server_url):
+        return True
+    identity = _probe_server_identity(server_url)
+    if identity == "aragora":
+        return True
+    if identity == "foreign":
+        print(
+            f"Note: service at {server_url} does not identify as an Aragora API server; "
+            "running the debate locally. Set ARAGORA_API_URL or pass --api-url to use it anyway.",
+            file=sys.stderr,
+        )
+    return False
+
+
 def _build_api_client(server_url: str, api_key: str | None):
     """Build an AragoraClient for API-backed runs."""
     from aragora.client import AragoraClient
@@ -2009,7 +2095,7 @@ def cmd_ask(args: argparse.Namespace) -> None:
 
     use_api = requested_api
     if not requested_api and not requested_local:
-        use_api = _is_server_available(server_url)
+        use_api = _trusted_server_available(server_url)
 
     if use_api:
         try:

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -1108,8 +1108,9 @@ def _add_ask_parser(subparsers) -> None:
     )
     ask_parser.add_argument(
         "--api-url",
-        default=DEFAULT_API_URL,
-        help=f"API server URL (default: {DEFAULT_API_URL})",
+        default=None,
+        help=f"API server URL (default: {DEFAULT_API_URL}); passing the flag "
+        "explicitly opts in to that server even if it does not identify as Aragora",
     )
     ask_parser.add_argument(
         "--api-key",

--- a/tests/cli/test_ask_server_identity.py
+++ b/tests/cli/test_ask_server_identity.py
@@ -1,0 +1,193 @@
+"""Tests for the `aragora ask` server-identity trust check (issue #8805).
+
+`aragora ask` auto-discovers a local API server by probing
+``localhost:8080/api/health``. Port 8080 is the most commonly squatted dev
+port, so a bare HTTP 200 must NOT be treated as an Aragora server: the health
+payload has to positively identify as Aragora (``status`` in
+{"healthy", "degraded"} plus a ``timestamp`` field — the exact shape the
+public /api/health endpoint returns). An explicitly configured URL
+(ARAGORA_API_URL or --api-url) is trusted as-is because the user opted in.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+
+from aragora.cli.commands import debate as debate_cmd
+
+ARAGORA_MINIMAL_HEALTH = json.dumps(
+    {"status": "healthy", "timestamp": "2026-07-02T12:00:00+00:00Z"}
+).encode()
+
+ARAGORA_FULL_HEALTH = json.dumps(
+    {
+        "status": "healthy",
+        "version": "2.8.0",
+        "uptime_seconds": 12,
+        "demo_mode": False,
+        "db_mode": "sqlite",
+        "checks": {"degraded_mode": {"healthy": True}},
+        "timestamp": "2026-07-02T12:00:00+00:00Z",
+        "response_time_ms": 1.2,
+    }
+).encode()
+
+
+class _FakeResponse(io.BytesIO):
+    """Minimal stand-in for the urlopen response object."""
+
+    def __init__(self, body: bytes, status: int = 200):
+        super().__init__(body)
+        self.status = status
+
+    def getcode(self) -> int:
+        return self.status
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
+
+
+@contextmanager
+def _serving(body: bytes, status: int = 200):
+    """Patch urlopen so every request gets the given response."""
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=lambda *a, **k: _FakeResponse(body, status),
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _no_env_api_url(monkeypatch):
+    """Default: no explicit opt-in via environment."""
+    monkeypatch.delenv("ARAGORA_API_URL", raising=False)
+
+
+class TestIdentifiesAsAragora:
+    def test_minimal_health_payload_accepted(self):
+        assert debate_cmd._identifies_as_aragora(ARAGORA_MINIMAL_HEALTH) is True
+
+    def test_full_health_payload_accepted(self):
+        assert debate_cmd._identifies_as_aragora(ARAGORA_FULL_HEALTH) is True
+
+    def test_degraded_status_accepted(self):
+        body = json.dumps({"status": "degraded", "timestamp": "2026-07-02T12:00:00Z"}).encode()
+        assert debate_cmd._identifies_as_aragora(body) is True
+
+    def test_generic_ok_status_rejected(self):
+        # Common non-Aragora health shape ({"status": "ok"}) must not match.
+        body = json.dumps({"status": "ok", "timestamp": "2026-07-02T12:00:00Z"}).encode()
+        assert debate_cmd._identifies_as_aragora(body) is False
+
+    def test_missing_timestamp_rejected(self):
+        assert debate_cmd._identifies_as_aragora(b'{"status": "healthy"}') is False
+
+    def test_html_rejected(self):
+        assert debate_cmd._identifies_as_aragora(b"<html><body>Jenkins</body></html>") is False
+
+    def test_non_dict_json_rejected(self):
+        assert debate_cmd._identifies_as_aragora(b'["healthy"]') is False
+
+    def test_empty_body_rejected(self):
+        assert debate_cmd._identifies_as_aragora(b"") is False
+
+    def test_non_utf8_rejected(self):
+        assert debate_cmd._identifies_as_aragora(b"\xff\xfe\x00garbage") is False
+
+
+class TestProbeServerIdentity:
+    URL = "http://localhost:8080"
+
+    def test_aragora_health_response(self):
+        with _serving(ARAGORA_MINIMAL_HEALTH):
+            assert debate_cmd._probe_server_identity(self.URL) == "aragora"
+
+    def test_foreign_json_response(self):
+        with _serving(b'{"app": "someone-elses-dashboard"}'):
+            assert debate_cmd._probe_server_identity(self.URL) == "foreign"
+
+    def test_foreign_html_response(self):
+        with _serving(b"<html>Tomcat manager</html>"):
+            assert debate_cmd._probe_server_identity(self.URL) == "foreign"
+
+    def test_connection_refused(self):
+        with patch("urllib.request.urlopen", side_effect=OSError("connection refused")):
+            assert debate_cmd._probe_server_identity(self.URL) == "unavailable"
+
+    def test_non_200_status(self):
+        with _serving(b"{}", status=204):
+            assert debate_cmd._probe_server_identity(self.URL) == "unavailable"
+
+
+class TestTrustedServerAvailable:
+    URL = debate_cmd.DEFAULT_API_URL  # the auto-discovery default
+
+    def test_real_aragora_server_is_used(self):
+        with _serving(ARAGORA_MINIMAL_HEALTH):
+            assert debate_cmd._trusted_server_available(self.URL) is True
+
+    def test_non_aragora_200_is_skipped_with_notice(self, capsys):
+        with _serving(b'{"status": "ok"}'):
+            assert debate_cmd._trusted_server_available(self.URL) is False
+        err = capsys.readouterr().err
+        assert "does not identify as an Aragora API server" in err
+        assert "running the debate locally" in err
+
+    def test_no_server_is_unavailable_without_notice(self, capsys):
+        with patch("urllib.request.urlopen", side_effect=OSError("connection refused")):
+            assert debate_cmd._trusted_server_available(self.URL) is False
+        assert capsys.readouterr().err == ""
+
+    def test_explicit_env_url_trusted_without_identity_check(self, monkeypatch):
+        monkeypatch.setenv("ARAGORA_API_URL", "http://localhost:9999")
+        with (
+            patch.object(debate_cmd, "_is_server_available", return_value=True),
+            patch.object(
+                debate_cmd,
+                "_probe_server_identity",
+                side_effect=AssertionError("identity probe must be skipped for explicit URLs"),
+            ),
+        ):
+            assert debate_cmd._trusted_server_available("http://localhost:9999") is True
+
+    def test_explicit_flag_url_trusted_without_identity_check(self):
+        # A URL differing from the default means the user passed --api-url.
+        with (
+            patch.object(debate_cmd, "_is_server_available", return_value=True),
+            patch.object(
+                debate_cmd,
+                "_probe_server_identity",
+                side_effect=AssertionError("identity probe must be skipped for explicit URLs"),
+            ),
+        ):
+            assert debate_cmd._trusted_server_available("http://intranet:8080") is True
+
+    def test_explicit_url_still_requires_reachability(self, monkeypatch):
+        monkeypatch.setenv("ARAGORA_API_URL", "http://localhost:9999")
+        with patch.object(debate_cmd, "_is_server_available", return_value=False):
+            assert debate_cmd._trusted_server_available("http://localhost:9999") is False
+
+
+class TestExplicitConfigDetection:
+    def test_default_url_is_not_explicit(self):
+        assert debate_cmd._is_explicitly_configured_api_url(debate_cmd.DEFAULT_API_URL) is False
+
+    def test_env_var_makes_url_explicit(self, monkeypatch):
+        monkeypatch.setenv("ARAGORA_API_URL", debate_cmd.DEFAULT_API_URL)
+        assert debate_cmd._is_explicitly_configured_api_url(debate_cmd.DEFAULT_API_URL) is True
+
+    def test_non_default_url_is_explicit(self):
+        assert debate_cmd._is_explicitly_configured_api_url("http://example.com:8080") is True
+
+    def test_trailing_slash_still_matches_default(self):
+        assert (
+            debate_cmd._is_explicitly_configured_api_url(debate_cmd.DEFAULT_API_URL + "/") is False
+        )

--- a/tests/cli/test_ask_server_identity.py
+++ b/tests/cli/test_ask_server_identity.py
@@ -170,6 +170,24 @@ class TestTrustedServerAvailable:
         ):
             assert debate_cmd._trusted_server_available("http://intranet:8080") is True
 
+    def test_flag_passed_with_default_url_trusted_without_identity_check(self):
+        # Round-1 review [P2]: `--api-url http://localhost:8080` equals the
+        # default value, but the user typed the flag — that is an explicit
+        # opt-in and must skip the identity probe. Flag presence comes from
+        # argparse (parser default is None), threaded through flag_passed.
+        with (
+            patch.object(debate_cmd, "_is_server_available", return_value=True),
+            patch.object(
+                debate_cmd,
+                "_probe_server_identity",
+                side_effect=AssertionError("identity probe must be skipped for explicit URLs"),
+            ),
+        ):
+            assert (
+                debate_cmd._trusted_server_available(debate_cmd.DEFAULT_API_URL, flag_passed=True)
+                is True
+            )
+
     def test_explicit_url_still_requires_reachability(self, monkeypatch):
         monkeypatch.setenv("ARAGORA_API_URL", "http://localhost:9999")
         with patch.object(debate_cmd, "_is_server_available", return_value=False):
@@ -186,6 +204,14 @@ class TestExplicitConfigDetection:
 
     def test_non_default_url_is_explicit(self):
         assert debate_cmd._is_explicitly_configured_api_url("http://example.com:8080") is True
+
+    def test_flag_presence_makes_default_url_explicit(self):
+        assert (
+            debate_cmd._is_explicitly_configured_api_url(
+                debate_cmd.DEFAULT_API_URL, flag_passed=True
+            )
+            is True
+        )
 
     def test_trailing_slash_still_matches_default(self):
         assert (


### PR DESCRIPTION
## Summary

Fixes item 1 of #8805 (does **not** close it — the agents-payload contract and `aragora-verify` publish items remain).

`aragora ask` auto-discovery treated **any** process answering HTTP 200 on `localhost:8080/api/health` as an Aragora server and silently routed the user's debate content to it. Port 8080 is the most commonly squatted dev port (Jenkins, Tomcat, other projects' dev servers) — a trust-surface bug on the five-minute stranger path.

## What changed (`aragora/cli/commands/debate.py`)

- Auto-discovery (`use_api` when neither `--api` nor `--local` is passed) now goes through `_trusted_server_available()`, which requires the health payload to **positively identify as Aragora** before routing to it.
- **Positive-identity signal:** a JSON object with `status` in `{"healthy", "degraded"}` **and** a `timestamp` field — exactly what the public (unauthenticated) `/api/health` returns today (`aragora/server/handlers/admin/health/__init__.py::_minimal_health_check`; the authenticated full response matches too). HTML banners, generic `{"status": "ok"}` probes, and non-JSON bodies are rejected.
- **Fail-closed:** a foreign 200 falls back to the existing local/keyless path with a one-line stderr notice (`Note: service at <url> does not identify as an Aragora API server; running the debate locally. Set ARAGORA_API_URL or pass --api-url to use it anyway.`) — never a traceback.
- **Explicit opt-in is trusted as-is:** if `ARAGORA_API_URL` is set, or `--api-url` differs from the default, the identity probe is skipped (old behavior). `--api`/graph/matrix forced-API paths are untouched.
- Behavior is unchanged when a real Aragora server answers, and when nothing is listening.

## Tests (`tests/cli/test_ask_server_identity.py`, 24 tests, all passing)

- Real-shaped minimal + full health payloads → used
- Non-Aragora 200 (random JSON, `{"status":"ok"}`, HTML) → skipped with notice
- Explicit env URL / explicit `--api-url` → trusted without the identity check
- No server → existing behavior (no notice, local path)
- Existing suites `tests/cli/test_cli_main.py` + `tests/cli/test_offline_golden_path.py` pass (1 pre-existing failure on clean origin/main, unrelated: `test_main_record_settlement_does_not_hydrate_secrets`, reproduced with this change stashed)
- pre-commit clean on changed files

## Server-side gap noted for #8805 / #8804 lane

The public `/api/health` payload is deliberately minimal (`status` + `timestamp` only, to prevent info leakage) and carries **no explicit service identifier**. The identity check above is therefore a shape match, not a name match. A stronger signal would be a `"service": "aragora"` field (or an `X-Aragora-Service` header) on the public health response — that's a `aragora/server/handlers/` change owned by the parallel #8804 lane, so this PR works with what the server returns today. If that field lands, the CLI check can be tightened to key on it.

Refs #8805

🤖 Generated with [Claude Code](https://claude.com/claude-code)