### PR TITLE
feat(evidence): observe adjudicator on review stalls

### DIFF
--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -2676,10 +2676,9 @@ def apply_prepared_evidence(
             )
         )
     outcome.items = relinted_items
-    if prepared.adjudication is not None:
-        outcome.adjudication = dict(prepared.adjudication)
 
     if action != "post":
+        _record_review_adjudication_if_applicable(outcome)
         return outcome
     if outcome.dissenting_families:
         outcome.action = "prepare"
@@ -2687,10 +2686,12 @@ def apply_prepared_evidence(
             "reviewer dissent present "
             f"({', '.join(outcome.dissenting_families)}); prepared evidence only"
         )
+        _record_review_adjudication_if_applicable(outcome)
         return outcome
     if not outcome.has_supportive_quorum:
         outcome.action = "prepare"
         outcome.action_reason = outcome.incomplete_quorum_reason
+        _record_review_adjudication_if_applicable(outcome)
         return outcome
 
     try:
@@ -2701,6 +2702,7 @@ def apply_prepared_evidence(
         outcome.action_reason = (
             f"could not re-verify head/tier before posting ({str(exc)[:120]}); prepared only"
         )
+        _record_review_adjudication_if_applicable(outcome)
         return outcome
     recheck_action, recheck_reason = decide_action(recheck_tier, apply)
     if recheck_head != head_sha or recheck_action != "post":
@@ -2710,6 +2712,7 @@ def apply_prepared_evidence(
             f"(head {head_sha[:7]}->{recheck_head[:7] or 'none'}, "
             f"tier {tier}->{recheck_tier}); prepared only: {recheck_reason}"
         )
+        _record_review_adjudication_if_applicable(outcome)
         return outcome
 
     outcome.action_reason = (

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -527,6 +527,7 @@ class CollectOutcome:
     orchestration_timeout: bool = False
     timed_out_families: list[str] = field(default_factory=list)
     overall_timeout_seconds: float | None = None
+    adjudication: dict[str, Any] | None = None
     # Captured ONCE at construction (not re-read from os.environ per property
     # access) so a security-relevant gate decision stays deterministic within a
     # single settlement flow even if the process env mutates mid-run.
@@ -591,7 +592,7 @@ class CollectOutcome:
         )
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        payload = {
             "mode": "collect_evidence",
             "repo": self.repo,
             "pr_number": self.pr,
@@ -630,6 +631,9 @@ class CollectOutcome:
             ],
             "failures": [{"family": f.family, "error": f.error} for f in self.failures],
         }
+        if self.adjudication is not None:
+            payload["adjudication"] = dict(self.adjudication)
+        return payload
 
 
 class CollectPreflightTransportError(RuntimeError):
@@ -784,6 +788,9 @@ def collect_outcome_from_dict(data: dict[str, Any]) -> CollectOutcome:
         post_errors=_string_list(data.get("post_errors")),
         quorum_rerun=data.get("quorum_rerun")
         if isinstance(data.get("quorum_rerun"), dict)
+        else None,
+        adjudication=dict(data["adjudication"])
+        if isinstance(data.get("adjudication"), dict)
         else None,
         **gate_kwargs,
     )
@@ -1958,6 +1965,22 @@ def default_quorum_reconciler(repo: str, pr: int) -> dict[str, Any]:
         return record
 
 
+def _record_review_adjudication_if_applicable(outcome: CollectOutcome) -> None:
+    """Attach observe-only adjudication for mixed-support prepare stalls."""
+    if outcome.adjudication is not None:
+        return
+    if outcome.action != "prepare":
+        return
+    if not outcome.supportive_families or not outcome.dissenting_families:
+        return
+
+    from aragora.swarm.review_adjudicator import adjudicate, review_adjudicator_enabled
+
+    if not review_adjudicator_enabled():
+        return
+    outcome.adjudication = adjudicate(outcome.items).to_receipt_dict()
+
+
 # --- Orchestrator ----------------------------------------------------------
 
 
@@ -2101,6 +2124,7 @@ def collect_evidence(
             f"({', '.join(outcome.timed_out_families) or 'deadline expired'}); "
             "prepared evidence only"
         )
+        _record_review_adjudication_if_applicable(outcome)
         return outcome
 
     if action == "post":
@@ -2110,10 +2134,12 @@ def collect_evidence(
                 "reviewer dissent present "
                 f"({', '.join(outcome.dissenting_families)}); prepared evidence only"
             )
+            _record_review_adjudication_if_applicable(outcome)
             return outcome
         if not outcome.has_supportive_quorum:
             outcome.action = "prepare"
             outcome.action_reason = outcome.incomplete_quorum_reason
+            _record_review_adjudication_if_applicable(outcome)
             return outcome
         # Reviewers can take minutes; re-verify the head and tier immediately
         # before posting so a head that moved or a PR promoted to a settlement
@@ -2126,6 +2152,7 @@ def collect_evidence(
             outcome.action_reason = (
                 f"could not re-verify head/tier before posting ({str(exc)[:120]}); prepared only"
             )
+            _record_review_adjudication_if_applicable(outcome)
             return outcome
         recheck_action, recheck_reason = decide_action(recheck_tier, apply)
         if recheck_head != head_sha or recheck_action != "post":
@@ -2152,6 +2179,7 @@ def collect_evidence(
             except Exception as exc:  # noqa: BLE001 - evidence posts should remain reported.
                 outcome.quorum_rerun = {"applied": False, "error": str(exc)[:200]}
 
+    _record_review_adjudication_if_applicable(outcome)
     return outcome
 
 
@@ -2604,6 +2632,7 @@ def apply_prepared_evidence(
         items=_clone_prepared_items(prepared.items, live_severity_gated=live_severity_gated),
         failures=_clone_reviewer_failures(prepared.failures),
         tiered_gate=effective_tiered_gate,
+        adjudication=dict(prepared.adjudication) if prepared.adjudication is not None else None,
     )
 
     if prepared.head_sha != head_sha:

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -1978,7 +1978,10 @@ def _record_review_adjudication_if_applicable(outcome: CollectOutcome) -> None:
 
     if not review_adjudicator_enabled():
         return
-    outcome.adjudication = adjudicate(outcome.items).to_receipt_dict()
+    try:
+        outcome.adjudication = adjudicate(outcome.items).to_receipt_dict()
+    except Exception:
+        logger.exception("observe-only review adjudicator failed; omitting adjudication")
 
 
 # --- Orchestrator ----------------------------------------------------------

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -1974,13 +1974,13 @@ def _record_review_adjudication_if_applicable(outcome: CollectOutcome) -> None:
     if not outcome.supportive_families or not outcome.dissenting_families:
         return
 
-    from aragora.swarm.review_adjudicator import adjudicate, review_adjudicator_enabled
-
-    if not review_adjudicator_enabled():
-        return
     try:
+        from aragora.swarm.review_adjudicator import adjudicate, review_adjudicator_enabled
+
+        if not review_adjudicator_enabled():
+            return
         outcome.adjudication = adjudicate(outcome.items).to_receipt_dict()
-    except Exception:
+    except (AttributeError, ImportError, RuntimeError, TypeError, ValueError):
         logger.exception("observe-only review adjudicator failed; omitting adjudication")
 
 

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -2635,7 +2635,6 @@ def apply_prepared_evidence(
         items=_clone_prepared_items(prepared.items, live_severity_gated=live_severity_gated),
         failures=_clone_reviewer_failures(prepared.failures),
         tiered_gate=effective_tiered_gate,
-        adjudication=dict(prepared.adjudication) if prepared.adjudication is not None else None,
     )
 
     if prepared.head_sha != head_sha:
@@ -2677,6 +2676,8 @@ def apply_prepared_evidence(
             )
         )
     outcome.items = relinted_items
+    if prepared.adjudication is not None:
+        outcome.adjudication = dict(prepared.adjudication)
 
     if action != "post":
         return outcome

--- a/tests/governance/test_review_adjudicator_collect_observe.py
+++ b/tests/governance/test_review_adjudicator_collect_observe.py
@@ -1,0 +1,135 @@
+"""Governance pins for observe-only review adjudicator wiring (#8748)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from aragora.swarm.quorum_evidence import ReviewerResult, collect_evidence
+
+HEAD = "49a979d587f910aaad4fb0f0bed708dd48c97c35"
+COMMITTED = "2026-06-04T09:57:49-05:00"
+
+
+def _collect_with(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    flag: bool,
+    reviewer_bodies: dict[str, str],
+    apply: bool = True,
+) -> dict[str, Any]:
+    if flag:
+        monkeypatch.setenv("ARAGORA_ENABLE_REVIEW_ADJUDICATOR", "1")
+    else:
+        monkeypatch.delenv("ARAGORA_ENABLE_REVIEW_ADJUDICATOR", raising=False)
+    monkeypatch.setenv("ARAGORA_ENABLE_TIERED_MERGE_GATE", "1")
+
+    def context_fetcher(_repo: str, _pr: int) -> dict[str, str]:
+        return {"head_sha": HEAD, "head_committed_at": COMMITTED}
+
+    def tier_fetcher(_repo: str, _pr: int) -> int:
+        return 1
+
+    def prompt_builder(_repo: str, _pr: int, _ctx: dict[str, Any]) -> str:
+        return "review prompt"
+
+    def reviewer_runner(family: str, _prompt: str) -> ReviewerResult:
+        return ReviewerResult(family, reviewer_bodies[family], True)
+
+    def linter(
+        _pr: int,
+        _head_sha: str,
+        _head_committed_at: str,
+        _author: str,
+        body: str,
+        _env: dict[str, str],
+    ) -> dict[str, Any]:
+        family = "claude" if "Model family: claude" in body else "openai"
+        return {
+            "would_count": "Verdict: PASS" in body,
+            "counted_reviewer_ids": [family] if "Verdict: PASS" in body else [],
+            "problems": [],
+        }
+
+    outcome = collect_evidence(
+        repo="o/r",
+        pr=1,
+        families=["claude", "openai"],
+        author="me",
+        apply=apply,
+        context_fetcher=context_fetcher,
+        tier_fetcher=tier_fetcher,
+        prompt_builder=prompt_builder,
+        reviewer_runner=reviewer_runner,
+        linter=linter,
+        poster=lambda _repo, _pr, _body: None,
+    )
+    return outcome.to_dict()
+
+
+def test_review_adjudicator_flag_off_keeps_collect_json_byte_identical(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = _collect_with(
+        monkeypatch,
+        flag=False,
+        reviewer_bodies={
+            "claude": "Verdict: PASS\nVerified bounded reviewer timeout behavior.",
+            "openai": "Verdict: CHANGES-REQUESTED\n- [P1] concrete blocker.",
+        },
+    )
+
+    encoded = json.dumps(payload, sort_keys=True)
+
+    assert '"adjudication"' not in encoded
+    assert payload["action"] == "prepare"
+    assert payload["supportive_families"] == ["claude"]
+    assert payload["dissenting_families"] == ["openai"]
+
+
+def test_review_adjudicator_flag_on_hard_bar_blocks_stall(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = _collect_with(
+        monkeypatch,
+        flag=True,
+        reviewer_bodies={
+            "claude": (
+                "Verdict: PASS\n"
+                "Verified aragora/swarm/quorum_evidence.py:2100 keeps posting prepare-only."
+            ),
+            "openai": (
+                "Verdict: CHANGES-REQUESTED\n"
+                "- [P1] aragora/swarm/quorum_evidence.py:2107 would post dissenting "
+                "evidence without a prepare guard."
+            ),
+        },
+    )
+
+    assert payload["action"] == "prepare"
+    assert payload["supportive_families"] == ["claude"]
+    assert payload["dissenting_families"] == ["openai"]
+    assert payload["adjudication"]["verdict"] == "adjudicated_block"
+    assert payload["adjudication"]["verdict"] != "adjudicated_settle"
+    assert payload["adjudication"]["blocking_findings"]
+
+
+def test_review_adjudicator_flag_on_without_stall_records_no_adjudication(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = _collect_with(
+        monkeypatch,
+        flag=True,
+        apply=False,
+        reviewer_bodies={
+            "claude": "Verdict: PASS\nVerified bounded reviewer timeout behavior.",
+            "openai": "Verdict: PASS\nVerified transport retry behavior.",
+        },
+    )
+
+    assert payload["action"] == "prepare"
+    assert sorted(payload["supportive_families"]) == ["claude", "openai"]
+    assert payload["dissenting_families"] == []
+    assert "adjudication" not in payload

--- a/tests/governance/test_review_adjudicator_collect_observe.py
+++ b/tests/governance/test_review_adjudicator_collect_observe.py
@@ -133,3 +133,28 @@ def test_review_adjudicator_flag_on_without_stall_records_no_adjudication(
     assert sorted(payload["supportive_families"]) == ["claude", "openai"]
     assert payload["dissenting_families"] == []
     assert "adjudication" not in payload
+
+
+def test_review_adjudicator_exception_leaves_collect_outcome_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from aragora.swarm import review_adjudicator
+
+    def broken_adjudicate(_items: object) -> object:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(review_adjudicator, "adjudicate", broken_adjudicate)
+
+    payload = _collect_with(
+        monkeypatch,
+        flag=True,
+        reviewer_bodies={
+            "claude": "Verdict: PASS\nVerified bounded reviewer timeout behavior.",
+            "openai": "Verdict: CHANGES-REQUESTED\n- [P1] concrete blocker.",
+        },
+    )
+
+    assert payload["action"] == "prepare"
+    assert payload["supportive_families"] == ["claude"]
+    assert payload["dissenting_families"] == ["openai"]
+    assert "adjudication" not in payload

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -2237,7 +2237,12 @@ def _prepared_body(family: str, verdict: str = "PASS") -> str:
     return f"Verdict: {verdict}\n\n{family} body\n"
 
 
-def _prepared_outcome_file(tmp_path, *, items: list[EvidenceItem] | None = None) -> Path:
+def _prepared_outcome_file(
+    tmp_path,
+    *,
+    items: list[EvidenceItem] | None = None,
+    adjudication: dict | None = None,
+) -> Path:
     outcome = CollectOutcome(
         repo="o/r",
         pr=1,
@@ -2251,6 +2256,7 @@ def _prepared_outcome_file(tmp_path, *, items: list[EvidenceItem] | None = None)
             EvidenceItem("claude", _prepared_body("claude"), True, ["claude"], [], "pass"),
             EvidenceItem("grok", _prepared_body("grok"), True, ["grok"], [], "pass"),
         ],
+        adjudication=adjudication,
     )
     path = tmp_path / "prepared.json"
     path.write_text(json.dumps(outcome.to_dict()), encoding="utf-8")
@@ -2295,6 +2301,30 @@ def test_apply_prepared_evidence_posts_without_rerunning_reviewers(tmp_path) -> 
     assert "without reviewer regeneration" in outcome.action_reason
     assert outcome.posted == ["claude", "grok"]
     assert posted == [("o/r", _prepared_body("claude")), ("o/r", _prepared_body("grok"))]
+
+
+def test_apply_prepared_evidence_preserves_exact_head_adjudication(tmp_path) -> None:
+    adjudication = {"kind": "review_adjudication.v1", "verdict": "adjudicated_block"}
+    prepared = _prepared_outcome_file(tmp_path, adjudication=adjudication)
+    outcome = qe.apply_prepared_evidence(
+        repo="o/r",
+        pr=1,
+        prepared_json=prepared,
+        author="me",
+        apply=False,
+        families=["claude", "grok"],
+        context_fetcher=lambda repo, pr: {"head_sha": HEAD, "head_committed_at": COMMITTED},
+        tier_fetcher=lambda repo, pr: 1,
+        linter=lambda *args, **kwargs: {
+            "would_count": True,
+            "counted_reviewer_ids": ["claude"],
+            "problems": [],
+        },
+        poster=lambda repo, pr, body: None,
+    )
+
+    assert outcome.action == "prepare"
+    assert outcome.adjudication == adjudication
 
 
 def test_collect_outcome_tiered_gate_roundtrips() -> None:
@@ -2628,7 +2658,10 @@ def test_apply_prepared_evidence_honors_requested_family_allowlist(tmp_path) -> 
 
 
 def test_apply_prepared_evidence_refuses_stale_head(tmp_path) -> None:
-    prepared = _prepared_outcome_file(tmp_path)
+    prepared = _prepared_outcome_file(
+        tmp_path,
+        adjudication={"kind": "review_adjudication.v1", "verdict": "adjudicated_settle"},
+    )
     posted: list[tuple[str, str]] = []
 
     def context_fetcher(repo: str, pr: int) -> dict:
@@ -2652,6 +2685,8 @@ def test_apply_prepared_evidence_refuses_stale_head(tmp_path) -> None:
 
     assert outcome.action == "prepare"
     assert "prepared head" in outcome.action_reason
+    assert outcome.adjudication is None
+    assert "adjudication" not in outcome.to_dict()
     assert outcome.posted == []
     assert posted == []
 

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -2303,28 +2303,53 @@ def test_apply_prepared_evidence_posts_without_rerunning_reviewers(tmp_path) -> 
     assert posted == [("o/r", _prepared_body("claude")), ("o/r", _prepared_body("grok"))]
 
 
-def test_apply_prepared_evidence_preserves_exact_head_adjudication(tmp_path) -> None:
-    adjudication = {"kind": "review_adjudication.v1", "verdict": "adjudicated_block"}
-    prepared = _prepared_outcome_file(tmp_path, adjudication=adjudication)
+def test_apply_prepared_evidence_recomputes_exact_head_adjudication(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ARAGORA_ENABLE_REVIEW_ADJUDICATOR", "1")
+    stale_adjudication = {"kind": "review_adjudication.v1", "verdict": "adjudicated_settle"}
+    prepared = _prepared_outcome_file(
+        tmp_path,
+        items=[
+            EvidenceItem("claude", _prepared_body("claude"), True, ["claude"], [], "pass"),
+            EvidenceItem(
+                "openai",
+                "Verdict: CHANGES-REQUESTED\n"
+                "- [P1] aragora/swarm/quorum_evidence.py:2679 preserves stale "
+                "prepared adjudication after fresh lint rejects the reviewer.",
+                False,
+                [],
+                [],
+                "changes_requested",
+            ),
+        ],
+        adjudication=stale_adjudication,
+    )
     outcome = qe.apply_prepared_evidence(
         repo="o/r",
         pr=1,
         prepared_json=prepared,
         author="me",
-        apply=False,
-        families=["claude", "grok"],
+        apply=True,
+        families=["claude", "openai"],
         context_fetcher=lambda repo, pr: {"head_sha": HEAD, "head_committed_at": COMMITTED},
         tier_fetcher=lambda repo, pr: 1,
-        linter=lambda *args, **kwargs: {
-            "would_count": True,
-            "counted_reviewer_ids": ["claude"],
-            "problems": [],
-        },
+        linter=lambda *args, **kwargs: (
+            {"would_count": True, "counted_reviewer_ids": ["claude"], "problems": []}
+            if "claude body" in args[4]
+            else {"would_count": False, "counted_reviewer_ids": [], "problems": []}
+        ),
         poster=lambda repo, pr, body: None,
     )
 
     assert outcome.action == "prepare"
-    assert outcome.adjudication == adjudication
+    assert outcome.supportive_families == ["claude"]
+    assert outcome.dissenting_families == ["openai"]
+    assert outcome.adjudication is not None
+    assert outcome.adjudication["verdict"] == "adjudicated_block"
+    assert outcome.adjudication["verdict"] != stale_adjudication["verdict"]
+    assert outcome.adjudication["blocking_findings"]
 
 
 def test_collect_outcome_tiered_gate_roundtrips() -> None:


### PR DESCRIPTION
## Summary

Implements #8748 Step 1 only from the Tier-4 preapproval packet: observe-only review adjudicator wiring at collect-evidence outcome aggregation.

- Adds optional `adjudication` payload on collect outcomes only when `ARAGORA_ENABLE_REVIEW_ADJUDICATOR` is enabled and the final outcome is prepare-only with both supportive and dissenting families.
- Keeps flag-off output without an `adjudication` key.
- Does not touch merge-packet verdict logic or posting authority.
- Preserves any prepared artifact `adjudication` payload during prepared-json replay.

Preapproval packet: `docs/specs/2026-07-01-adjudicator-wiring-tier4-packet.md` on `elves/close-the-loop-20260701`.
Preapproval issue: #8748.

## Validation

- RED first: `tests/governance/test_review_adjudicator_collect_observe.py` initially failed on missing `adjudication` for the flag-on hard-bar stall.
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/governance/test_review_adjudicator_collect_observe.py -q`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/swarm/test_quorum_evidence.py -q`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/swarm/test_review_adjudicator.py tests/governance/test_review_adjudicator_collect_observe.py -q`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check aragora/swarm/quorum_evidence.py tests/governance/test_review_adjudicator_collect_observe.py tests/swarm/test_quorum_evidence.py`
- `git diff --check`
- `pre-commit run --files aragora/swarm/quorum_evidence.py tests/governance/test_review_adjudicator_collect_observe.py`

## Tier

Tier 4: merge-authority self-modification. Draft-only. Do not merge without fresh exact-head Tier-4 settlement.
