### PR TITLE
fix(aragora-verify): explicit sdist include list so local venvs never break python -m build

### DIFF
--- a/aragora-verify/pyproject.toml
+++ b/aragora-verify/pyproject.toml
@@ -59,7 +59,28 @@ Changelog = "https://github.com/synaptent/aragora/blob/main/aragora-verify/CHANG
 "Bug Tracker" = "https://github.com/synaptent/aragora/issues"
 
 [tool.hatch.build.targets.sdist]
-exclude = ["CLAUDE.md", "**/CLAUDE.md", ".nomic/", ".benchmarks/"]
+# Explicit include list so stray local directories (venvs like .pub/ or .venv/,
+# dist/, caches) never get swept into the sdist -- a venv's absolute symlinks
+# make `python -m build` fail with tarfile.AbsoluteLinkError.
+include = [
+    "src/",
+    "tests/",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md",
+    "pyproject.toml",
+]
+exclude = [
+    "CLAUDE.md",
+    "**/CLAUDE.md",
+    ".nomic/",
+    ".benchmarks/",
+    "**/__pycache__",
+    "**/.pytest_cache",
+    ".pub/",
+    ".venv/",
+    "dist/",
+]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/aragora_verify"]


### PR DESCRIPTION
## Summary
- `aragora-verify`'s hatchling sdist target had no explicit include list, so running `python -m build` from a directory containing a venv (e.g. `.pub/` left over from a publish run) swept the venv into the sdist and failed on its absolute symlinks with `tarfile.AbsoluteLinkError`. This broke the 0.1.1 publish attempt on 2026-07-02.
- Fix: explicit `[tool.hatch.build.targets.sdist] include` list (`src/`, `tests/`, `README.md`, `LICENSE`, `CHANGELOG.md`, `pyproject.toml`) plus excludes for common junk (`.pub/`, `.venv/`, `dist/`, `__pycache__`, `.pytest_cache`).
- Scope: only `aragora-verify/pyproject.toml`. Does not touch `aragora/gauntlet/odr_verify.py` or `odr_schema.json` (Codex lane #8765).

## Proof
1. Reproduced: created a dummy venv at `aragora-verify/.pub`, ran `python -m build` → `tarfile.AbsoluteLinkError: 'aragora_verify-0.1.0/.pub/bin/python3' is a link to an absolute path`.
2. With the fix and the venv still present: `python -m build` succeeds (sdist + wheel, wheel built *from* the sdist).
3. Sdist contains only the intended files: `src/`, `tests/`, `README.md`, `LICENSE`, `CHANGELOG.md`, `pyproject.toml` (+ hatchling's automatic `.gitignore`/`PKG-INFO`). No venv, no caches.
4. Installed the built wheel into the dummy venv: `aragora-verify --help` works; `pytest tests/` → 51 passed, 1 skipped.
5. `pre-commit run --files aragora-verify/pyproject.toml` → all hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)