### PR TITLE
docs(pyproject): reframe tagline away from 'Decision Integrity Platform'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,8 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "aragora"
 version = "2.9.0"
-description = "Decision Integrity Platform — multi-agent vetted decisionmaking with audit-ready receipts"
-readme = {text = "# Aragora\n\nThe Decision Integrity Platform: orchestrate multi-agent debates against your org's knowledge and deliver audit-ready decision receipts. Installing this distribution provides the `aragora` CLI and the full `aragora` package. The small standalone debate wedge is published separately as `aragora-debate` (see the `aragora-debate/` subproject).", content-type = "text/markdown"}
+description = "Auditable execution control plane for AI-assisted decisions: multi-model review in, a verifiable Decision Receipt out"
+readme = {text = "# Aragora\n\nAragora is an auditable execution control plane for AI-assisted decisions: multi-model review in, a verifiable Decision Receipt out. Installing this distribution provides the `aragora` CLI and the full `aragora` package. The small standalone debate wedge is published separately as `aragora-debate` (see the `aragora-debate/` subproject).", content-type = "text/markdown"}
 license = "MIT"
 license-files = ["LICENSE"]
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Milestone: m1-front-door. Feature: m1-pyproject-tagline-reframe.

Reframes root `pyproject.toml`'s `description` and inline `readme` text away from
the retired **"Decision Integrity Platform"** tagline (still present at L8-9) to
the audit-layer / control-plane framing that shipped on the README front door via
merged #8674, and that the sibling feature `m1-front-door-positioning-docs`
(PR #8813) confirmed is consistent with `docs/THESIS.md` and
`docs/CANONICAL_GOALS.md`.

## What changed

- `pyproject.toml` `[project].description`:
  - Before: `"Decision Integrity Platform — multi-agent vetted decisionmaking with audit-ready receipts"`
  - After: `"Auditable execution control plane for AI-assisted decisions: multi-model review in, a verifiable Decision Receipt out"`
- `pyproject.toml` `[project].readme.text` (inline PyPI long-description):
  - Before opened with: `"The Decision Integrity Platform: orchestrate multi-agent debates against your org's knowledge and deliver audit-ready decision receipts."`
  - After opens with the verbatim root `README.md` top-line claim: `"Aragora is an auditable execution control plane for AI-assisted decisions: multi-model review in, a verifiable Decision Receipt out."`
  - The remaining two sentences (CLI/package install note + `aragora-debate` subproject pointer) are unchanged.

No version bump, no dependency change, no other file touched (1 file, 2 insertions / 2 deletions).

## ⚠️ PARKED — do NOT auto-merge — coordinate with #8713 (and #8802)

Root `pyproject.toml` is concurrently touched by two other **open** PRs:

- **#8713** — `chore(deps): consolidate httpx and sdk dependency bumps` — bumps the
  `httpx` dependency floor at **`pyproject.toml` line ~39** (inside the
  `dependencies` array) + `uv.lock`.
- **#8802** — `docs(compliance): executable ODR verification walkthrough…` — adds a
  `hatchling` dev-extra at **`pyproject.toml` lines ~98-101**.

I checked both PRs' actual diffs via `gh pr view --json files` + `gh pr diff` before
writing this PR. **This PR's edit is confined to lines 8-9** (`description` +
`readme`) and does not add/remove any lines (both fields stay single-line string
literals), so the file's total line count is unchanged and neither #8713's nor
#8802's diff hunks are shifted or overlapped — **this does not strictly collide**
at the text/diff level.

That said, per the mission's path-freeze rule (`AGENTS.md` / `library/governance.md`:
"root `pyproject.toml`/`uv.lock` → #8713") this PR is intentionally prepared as a
**PARKED, operator-review** change:

- **Not auto-merged.** `gh pr merge --auto` is deliberately NOT invoked.
- **Labelled** `operator-review-required`.
- **Operator action needed:** merge/rebase order coordination across this PR,
  #8713, and #8802 (all three touch the same file, currently non-overlapping, but
  a merge order should still be chosen deliberately by a human rather than three
  automated PRs racing each other). A rebase-and-recheck of this PR's diff hunk
  (still lines 8-9 only) is recommended immediately before merge, after #8713/#8802
  land, to reconfirm no drift.

## Verification

- `python3 -c "import tomllib; tomllib.load(open('pyproject.toml','rb'))"` → valid TOML, fields read back exactly as intended.
- `grep -n "Decision Integrity Platform" pyproject.toml` → **no matches** (exit 1).
- Fresh throwaway venv smoke test: `pip install --no-deps <worktree>` succeeds;
  `pip show aragora` → `Summary: Auditable execution control plane for AI-assisted
  decisions: multi-model review in, a verifiable Decision Receipt out` (confirms
  setuptools parses the new metadata correctly end-to-end, not just TOML syntax).
- `python3 scripts/check_version_alignment.py` → `All versions aligned!` (unaffected; no version touched).
- `make docs-check` (`scripts/check_docs_consistency.py`) → all 4 checks PASS, no findings (pyproject.toml is outside its scope; run anyway for hygiene).
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` → `preflight: ok` (whitespace + changed-files checks clean).
- Pre-commit + pre-push hooks (trailing whitespace, EOF, large files, merge conflicts, gitleaks secret scan, mypy, portability guard) → all Passed/Skipped-clean on push.
- Cross-checked the new sentence is byte-identical to the shipped root `README.md`
  top-line claim (L3-4) and to the sentence PR #8813 confirmed consistent with
  `docs/THESIS.md` (adversarial cross-checking, dissent preservation) and
  `docs/CANONICAL_GOALS.md` (Pillar 1 Adversarial Heterogeneous Consensus, Pillar 5
  Cryptographic Receipts and Auditability, Mission Statement item 2 "a decision
  integrity layer for consequential choices").
- Confirmed `docs/CANONICAL_GOALS.md`'s own reconciliation note (§ Eight
  Foundational Pillars) blesses "Decision Integrity Platform" as a legitimate,
  *complementary* product-messaging frame elsewhere (e.g. `docs/EXTENDED_README.md`,
  `CLAUDE.md`) — this PR does **not** purge that phrase repo-wide, only from the
  PyPI-facing packaging metadata in root `pyproject.toml`, per this feature's exact scope.

Risk: **Tier 0-1 (docs/packaging-metadata text only)**, but parked per path-freeze
coordination, not the risk tier.

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>
