### PR TITLE
refactor(events): relocate server-coupled reactions to server interface home (P4a Batch E6)

### DIFF
--- a/aragora/events/cross_subscribers/handlers/basic.py
+++ b/aragora/events/cross_subscribers/handlers/basic.py
@@ -3,7 +3,6 @@ Basic cross-subsystem event handlers.
 
 Handles core subsystem integrations:
 - Memory → RLM: Retrieval patterns inform compression strategies
-- Webhook delivery: External system notifications
 
 The knowledge/evidence/mound → memory reactions and the vote → belief reaction
 relocated to their domain homes (``aragora.memory.event_subscribers`` and
@@ -11,7 +10,9 @@ relocated to their domain homes (``aragora.memory.event_subscribers`` and
 modules for the memory-sync and belief-network handlers. The ELO → debate,
 calibration → agent, consensus → learning, and agent message → rhetorical
 reactions relocated to ``aragora.debate.event_subscribers`` (P4a Batch E4
-relocate-UP); see that module for those handlers.
+relocate-UP); see that module for those handlers. The webhook-delivery reaction
+relocated to ``aragora.server.event_subscribers`` (P4a Batch E6 relocate-UP); it
+is server-coupled (``server.handlers.webhooks``) while this module is not.
 
 The unregistered ``_handle_debate_end_to_workflow`` delegate (dead at runtime -
 it instantiated a throwaway ``PostDebateWorkflowSubscriber`` on every call but
@@ -85,52 +86,6 @@ class BasicHandlersMixin:
             pass  # RLM module not available
         except (RuntimeError, TypeError, AttributeError, ValueError) as e:
             logger.debug("RLM pattern recording failed: %s", e)
-
-    def _handle_webhook_delivery(self, event: StreamEvent) -> None:
-        """
-        Event → Webhook delivery.
-
-        When any subscribable event occurs, deliver to registered webhooks.
-        This enables external systems to receive real-time notifications.
-        """
-        try:
-            from aragora.server.handlers.webhooks import get_webhook_store
-            from aragora.events.dispatcher import dispatch_webhook_with_retry
-
-            # Get registered webhooks for this event type
-            store = get_webhook_store()
-            event_type_str = event.type.value.lower()  # Convert enum to string
-            webhooks = store.get_for_event(event_type_str)
-
-            if not webhooks:
-                return  # No webhooks registered for this event
-
-            # Build payload
-            import time
-            import uuid
-
-            payload = {
-                "event": event_type_str,
-                "delivery_id": str(uuid.uuid4()),
-                "timestamp": time.time(),
-                "data": event.data or {},
-            }
-
-            # Deliver to each matching webhook
-            for webhook in webhooks:
-                try:
-                    result = dispatch_webhook_with_retry(webhook, payload)
-                    if not result.success:
-                        logger.warning(
-                            "Webhook delivery failed for %s: %s", webhook.id, result.error
-                        )
-                except (OSError, ConnectionError, RuntimeError, ValueError, TypeError) as e:
-                    logger.error("Webhook dispatch error for %s: %s", webhook.id, e)
-
-        except ImportError:
-            logger.debug("Webhook modules not available for event delivery")
-        except (KeyError, AttributeError, TypeError, ValueError) as e:
-            logger.debug("Webhook delivery handler error: %s", e)
 
     def _handle_gauntlet_complete_to_notification(self, event: StreamEvent) -> None:
         """Gauntlet complete → Notification dispatch.

--- a/aragora/events/cross_subscribers/handlers/culture.py
+++ b/aragora/events/cross_subscribers/handlers/culture.py
@@ -3,11 +3,14 @@ Culture-related event handlers.
 
 Handles organizational culture patterns and debate protocol hints:
 - Culture patterns → Debate protocol
-- Knowledge staleness → Debate warnings
 
 Debate start → Load culture from KM (``mound_to_culture``) relocated to
 ``aragora.knowledge.event_subscribers.KnowledgeEventSubscriber`` (P4a Batch E2c);
-it is knowledge-coupled while this module is not.
+it is knowledge-coupled while this module is not. Knowledge staleness → Debate
+warning (``staleness_to_debate``) relocated to
+``aragora.server.event_subscribers.ServerEventSubscriber`` (P4a Batch E6
+relocate-UP); it is server-coupled (``server.stream.state_manager``) while this
+module is not.
 """
 
 import logging
@@ -16,15 +19,6 @@ from collections.abc import Callable
 
 if TYPE_CHECKING:
     from aragora.events.types import StreamEvent
-
-# Import metrics stubs - will be overwritten if metrics available
-try:
-    from aragora.observability.prometheus_cross_pollination import record_km_outbound_event
-except ImportError:
-
-    def record_km_outbound_event(target: str, event_type: str) -> None:
-        pass
-
 
 logger = logging.getLogger(__name__)
 
@@ -60,39 +54,3 @@ class CultureHandlersMixin:
 
         # Culture patterns are used passively during debate initialization
         # by querying the CultureAccumulator
-
-    def _handle_staleness_to_debate(self, event: "StreamEvent") -> None:
-        """
-        Knowledge stale → Debate warning.
-
-        When knowledge becomes stale, check if any active debate cites it.
-        """
-        if not self._is_km_handler_enabled("staleness_to_debate"):
-            return
-
-        data = event.data
-        node_id = data.get("node_id", "")
-        staleness_reason = data.get("reason", "")
-        data.get("last_verified", "")
-
-        logger.debug("Knowledge stale: %s - %s", node_id, staleness_reason)
-
-        # Record KM outbound metric (staleness warning to debate)
-        record_km_outbound_event("debate", event.type.value)
-
-        try:
-            from aragora.server.stream.state_manager import get_active_debates
-
-            active_debates = get_active_debates()
-
-            # Check if any active debate references this node
-            for debate_id, debate_state in active_debates.items():
-                cited_nodes = debate_state.get("cited_knowledge", [])
-                if node_id in cited_nodes:
-                    logger.warning("Active debate %s cites stale knowledge: %s", debate_id, node_id)
-                    # Could emit a warning event to the debate here
-
-        except ImportError:
-            pass
-        except (RuntimeError, TypeError, AttributeError, ValueError, KeyError) as e:
-            logger.debug("Staleness→Debate check failed: %s", e)

--- a/aragora/events/cross_subscribers/manager.py
+++ b/aragora/events/cross_subscribers/manager.py
@@ -250,12 +250,11 @@ class CrossSubscriberManager(
         # aragora.knowledge.event_subscribers (P4a Batch E2c); wired at bootstrap
         # via apply_registered_subscribers, not registered here.
 
-        # Phase 7: Staleness → Debate
-        self.register(
-            "staleness_to_debate",
-            StreamEventType.KNOWLEDGE_STALE,
-            self._handle_staleness_to_debate,
-        )
+        # Phase 7: Staleness → Debate relocated to
+        # aragora.server.event_subscribers (P4a Batch E6 relocate-UP; interface-tier
+        # home); wired at bootstrap via apply_registered_subscribers
+        # (interface-superset only - a pure-domain manager has no WebSocket state
+        # manager to react through), not registered here.
 
         # Explainability: Debate End → Explanation auto-trigger
         self.register(
@@ -303,24 +302,11 @@ class CrossSubscriberManager(
         # aragora.knowledge.event_subscribers (P4a Batch E2c); wired at bootstrap
         # via apply_registered_subscribers, not registered here.
 
-        # Register webhook delivery for all cross-pollination events
-        webhook_event_types = [
-            StreamEventType.MEMORY_STORED,
-            StreamEventType.MEMORY_RETRIEVED,
-            StreamEventType.AGENT_ELO_UPDATED,
-            StreamEventType.KNOWLEDGE_INDEXED,
-            StreamEventType.KNOWLEDGE_QUERIED,
-            StreamEventType.MOUND_UPDATED,
-            StreamEventType.CALIBRATION_UPDATE,
-            StreamEventType.EVIDENCE_FOUND,
-        ]
-
-        for event_type in webhook_event_types:
-            self.register(
-                f"webhook_{event_type.value.lower()}",
-                event_type,
-                self._handle_webhook_delivery,
-            )
+        # Webhook delivery for all cross-pollination events (8 webhook_* names)
+        # relocated to aragora.server.event_subscribers (P4a Batch E6
+        # relocate-UP; interface-tier home); wired at bootstrap via
+        # apply_registered_subscribers (interface-superset only - a pure-domain
+        # manager has no webhook store to react through), not registered here.
 
         # =====================================================================
         # Strategic Feedback Loops (Tier 5)

--- a/aragora/server/event_subscribers.py
+++ b/aragora/server/event_subscribers.py
@@ -1,0 +1,242 @@
+"""Server-domain (interface) event-subscriber home (P4a EventBus inversion, Batch E6).
+
+The webhook-delivery and knowledge-staleness-to-debate reactions, relocated here
+from infrastructure ``aragora.events.cross_subscribers.handlers.{basic,culture}``
+(P4a Batch E6 relocate-UP) so the server-coupled reactions live in their
+INTERFACE home. ``ServerEventSubscriber`` self-registers via the domain-free
+registry (``aragora.events.cross_subscribers.register_subscriber`` - interface ->
+infrastructure, downward = legal); the interface-superset bootstrap
+(``aragora.server.startup.event_subscribers.bootstrap_event_subscribers``)
+imports this module so ``CrossSubscriberManager.apply_registered_subscribers``
+wires the reactions in. A pure-domain/pure-library debate with no HTTP server has
+no webhook store or WebSocket state manager to react through, so this module is
+NOT imported by the domain-subset bootstrap
+(``aragora.debate.event_subscribers.bootstrap_debate_event_subscribers``) -
+importing an interface-tier module from that domain-tier bootstrap would
+recreate the very upward edge this inversion removes.
+
+Per the relocate-UP no-shim exemption (AGENTS.md "P4a Contracts-Thread Shared
+Rules" and docs/architecture/P4A_EVENTS_QUEUE_INVERSION.md §8) there is NO
+re-export shim at the old paths; every consumer is repointed instead.
+
+This batch clears only the SUBSCRIBER-SIDE ``aragora.events -> aragora.server``
+contributors. The baseline string itself is NOT hand-shrunk here: core-side
+contributors remain in ``aragora/events/dispatcher.py`` (module-level
+``server.middleware.tracing.get_trace_id``; ``server.handlers.webhooks``) and
+``aragora/events/async_dispatcher.py`` (``webhooks.generate_signature``,
+``middleware.tracing``), owned by the webhook-signing extraction and the
+shim-caller sweep batches.
+
+Handles:
+- Any subscribable event -> Webhook delivery (registered under 8 ``webhook_<event>`` names)
+- Knowledge stale -> Debate warning (active-debate citation check)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from aragora.events.cross_subscribers import get_registered_subscribers, register_subscriber
+from aragora.events.types import StreamEventType
+
+if TYPE_CHECKING:
+    from aragora.config.settings import Settings
+    from aragora.events.cross_subscribers import CrossSubscriberManager
+    from aragora.events.types import StreamEvent
+
+# Import metrics stub - will be overwritten if metrics available (mirrors the
+# pre-relocation aragora.events.cross_subscribers.handlers.culture import).
+try:
+    from aragora.observability.prometheus_cross_pollination import record_km_outbound_event
+except ImportError:
+
+    def record_km_outbound_event(target: str, event_type: str) -> None:
+        pass
+
+
+# Feature-flag settings (mirrors the manager helper so the subscriber needs no
+# manager state at construction time; same self-contained-copy pattern as
+# aragora.knowledge.event_subscribers.KnowledgeEventSubscriber).
+try:
+    from aragora.config.settings import get_settings as _get_settings
+
+    _SETTINGS_AVAILABLE = True
+
+    def get_settings() -> "Settings | None":
+        return _get_settings()
+
+except ImportError:
+    _SETTINGS_AVAILABLE = False
+
+    def get_settings() -> "Settings | None":
+        return None
+
+
+logger = logging.getLogger(__name__)
+
+SERVER_EVENT_SUBSCRIBER_HANDLER_NAMES = frozenset(
+    {
+        "staleness_to_debate",
+        "webhook_memory_stored",
+        "webhook_memory_retrieved",
+        "webhook_agent_elo_updated",
+        "webhook_knowledge_indexed",
+        "webhook_knowledge_queried",
+        "webhook_mound_updated",
+        "webhook_calibration_update",
+        "webhook_evidence_found",
+    }
+)
+
+
+class ServerEventSubscriber:
+    """Server-domain (interface) cross-subscriber: webhook delivery + staleness reactions."""
+
+    def __init__(self) -> None:
+        self._settings = get_settings() if _SETTINGS_AVAILABLE else None
+
+    def _is_km_handler_enabled(self, handler_name: str) -> bool:
+        """Check whether a KM handler is enabled via feature flags (default on)."""
+        if self._settings is None:
+            return True
+        try:
+            integration = self._settings.integration
+            return integration.is_km_handler_enabled(handler_name)
+        except (AttributeError, TypeError):
+            return True
+
+    def _handle_webhook_delivery(self, event: "StreamEvent") -> None:
+        """
+        Event → Webhook delivery.
+
+        When any subscribable event occurs, deliver to registered webhooks.
+        This enables external systems to receive real-time notifications.
+        """
+        try:
+            from aragora.server.handlers.webhooks import get_webhook_store
+            from aragora.events.dispatcher import dispatch_webhook_with_retry
+
+            # Get registered webhooks for this event type
+            store = get_webhook_store()
+            event_type_str = event.type.value.lower()  # Convert enum to string
+            webhooks = store.get_for_event(event_type_str)
+
+            if not webhooks:
+                return  # No webhooks registered for this event
+
+            # Build payload
+            import time
+            import uuid
+
+            payload = {
+                "event": event_type_str,
+                "delivery_id": str(uuid.uuid4()),
+                "timestamp": time.time(),
+                "data": event.data or {},
+            }
+
+            # Deliver to each matching webhook
+            for webhook in webhooks:
+                try:
+                    result = dispatch_webhook_with_retry(webhook, payload)
+                    if not result.success:
+                        logger.warning(
+                            "Webhook delivery failed for %s: %s", webhook.id, result.error
+                        )
+                except (OSError, ConnectionError, RuntimeError, ValueError, TypeError) as e:
+                    logger.error("Webhook dispatch error for %s: %s", webhook.id, e)
+
+        except ImportError:
+            logger.debug("Webhook modules not available for event delivery")
+        except (KeyError, AttributeError, TypeError, ValueError) as e:
+            logger.debug("Webhook delivery handler error: %s", e)
+
+    def _handle_staleness_to_debate(self, event: "StreamEvent") -> None:
+        """
+        Knowledge stale → Debate warning.
+
+        When knowledge becomes stale, check if any active debate cites it.
+        """
+        if not self._is_km_handler_enabled("staleness_to_debate"):
+            return
+
+        data = event.data
+        node_id = data.get("node_id", "")
+        staleness_reason = data.get("reason", "")
+        data.get("last_verified", "")
+
+        logger.debug("Knowledge stale: %s - %s", node_id, staleness_reason)
+
+        # Record KM outbound metric (staleness warning to debate)
+        record_km_outbound_event("debate", event.type.value)
+
+        try:
+            from aragora.server.stream.state_manager import get_active_debates
+
+            active_debates = get_active_debates()
+
+            # Check if any active debate references this node
+            for debate_id, debate_state in active_debates.items():
+                cited_nodes = debate_state.get("cited_knowledge", [])
+                if node_id in cited_nodes:
+                    logger.warning("Active debate %s cites stale knowledge: %s", debate_id, node_id)
+                    # Could emit a warning event to the debate here
+
+        except ImportError:
+            pass
+        except (RuntimeError, TypeError, AttributeError, ValueError, KeyError) as e:
+            logger.debug("Staleness→Debate check failed: %s", e)
+
+    def register(self, manager: "CrossSubscriberManager") -> None:
+        """Wire the server-domain reactions into ``manager`` (keyed/idempotent)."""
+        manager.register(
+            "staleness_to_debate",
+            StreamEventType.KNOWLEDGE_STALE,
+            self._handle_staleness_to_debate,
+        )
+
+        webhook_event_types = [
+            StreamEventType.MEMORY_STORED,
+            StreamEventType.MEMORY_RETRIEVED,
+            StreamEventType.AGENT_ELO_UPDATED,
+            StreamEventType.KNOWLEDGE_INDEXED,
+            StreamEventType.KNOWLEDGE_QUERIED,
+            StreamEventType.MOUND_UPDATED,
+            StreamEventType.CALIBRATION_UPDATE,
+            StreamEventType.EVIDENCE_FOUND,
+        ]
+        for event_type in webhook_event_types:
+            manager.register(
+                f"webhook_{event_type.value.lower()}",
+                event_type,
+                self._handle_webhook_delivery,
+            )
+
+
+def get_server_event_subscriber() -> ServerEventSubscriber:
+    """Return the ``ServerEventSubscriber`` currently wired into the registry.
+
+    Registers a fresh instance first if none is present yet, reusing the
+    existing one otherwise so repeated calls resolve to the same instance
+    (mirrors ``aragora.knowledge.event_subscribers.get_knowledge_event_subscriber``).
+    """
+    subscriber = get_registered_subscribers().get("server")
+    if not isinstance(subscriber, ServerEventSubscriber):
+        subscriber = ServerEventSubscriber()
+        register_subscriber("server", subscriber)
+    return subscriber
+
+
+def register() -> None:
+    """(Re-)register this home's subscriber into the domain-free registry.
+
+    Delegates to :func:`get_server_event_subscriber`'s get-or-create so repeated
+    calls reuse the existing instance instead of replacing it. Called explicitly
+    (not just import side-effect) so registration survives a cached re-import
+    after ``reset_registry`` in tests.
+    """
+    get_server_event_subscriber()
+
+
+register()

--- a/aragora/server/startup/event_subscribers.py
+++ b/aragora/server/startup/event_subscribers.py
@@ -22,26 +22,33 @@ def bootstrap_event_subscribers() -> CrossSubscriberManager:
 
     Superset of the domain-subset bootstrap: it also imports application and
     interface home modules. Idempotent. Currently adds the workflow
-    application-tier home (P4a Batch E5): a pure-library debate with no
-    workflow engine has no such reaction, so ``aragora.workflow.event_subscribers``
-    is imported here rather than by the domain-subset bootstrap. Further
-    application/interface ``import aragora.<pkg>.event_subscribers`` lines
-    (e.g. notifications, server) are added here as remaining handlers relocate
-    to their home layers.
+    application-tier home (P4a Batch E5) and the server interface-tier home
+    (P4a Batch E6): a pure-library debate with no workflow engine or HTTP server
+    has no such reactions, so ``aragora.workflow.event_subscribers`` and
+    ``aragora.server.event_subscribers`` are imported here rather than by the
+    domain-subset bootstrap. Further application/interface
+    ``import aragora.<pkg>.event_subscribers`` lines (e.g. notifications) are
+    added here as remaining handlers relocate to their home layers.
 
     Returns:
         The registry-backed cross-subscriber manager singleton.
     """
     from aragora.debate.event_subscribers import bootstrap_debate_event_subscribers
+    from aragora.server import event_subscribers as server_home
     from aragora.workflow import event_subscribers as workflow_home
 
     bootstrap_debate_event_subscribers()
     workflow_home.register()
+    server_home.register()
 
     from aragora.events.cross_subscribers import bootstrap
 
     manager = bootstrap()
-    missing = workflow_home.WORKFLOW_EVENT_SUBSCRIBER_HANDLER_NAMES - set(manager.get_stats())
+    expected_handlers = (
+        workflow_home.WORKFLOW_EVENT_SUBSCRIBER_HANDLER_NAMES
+        | server_home.SERVER_EVENT_SUBSCRIBER_HANDLER_NAMES
+    )
+    missing = expected_handlers - set(manager.get_stats())
     if missing:
         raise RuntimeError(
             f"Application event subscriber bootstrap incomplete; missing handlers: {sorted(missing)}"

--- a/tests/events/test_cross_subscriber_registry.py
+++ b/tests/events/test_cross_subscriber_registry.py
@@ -113,6 +113,15 @@ GOLDEN_SUBSCRIBER_NAMES = frozenset(
 # mixin -> aragora/workflow/event_subscribers.py (application-tier home, see
 # APPLICATION_TIER_SUBSCRIBER_NAMES below - it is wired only via the
 # interface-superset bootstrap, unlike E2-E4's domain-tier relocations).
+# E6: the server-coupled webhook-delivery reaction embedded in the basic mixin
+# and the staleness-to-debate reaction embedded in the culture mixin ->
+# aragora/server/event_subscribers.py (interface-tier home, see
+# INTERFACE_TIER_SUBSCRIBER_NAMES below - also wired only via the
+# interface-superset bootstrap). This clears the subscriber-side
+# events->server contributors only; the frozen baseline string
+# "aragora.events -> aragora.server" is NOT hand-shrunk by E6 (core-side
+# events/dispatcher.py + events/async_dispatcher.py contributors remain,
+# owned by later batches).
 RELOCATED_SUBSCRIBER_NAMES = frozenset(
     {
         "memory_to_mound",
@@ -148,6 +157,15 @@ RELOCATED_SUBSCRIBER_NAMES = frozenset(
         "budget_alert_to_team_selection",
         "meta_learning_to_team_selection",
         "alert_escalated_to_workflow_brake",
+        "staleness_to_debate",
+        "webhook_agent_elo_updated",
+        "webhook_calibration_update",
+        "webhook_evidence_found",
+        "webhook_knowledge_indexed",
+        "webhook_knowledge_queried",
+        "webhook_memory_retrieved",
+        "webhook_memory_stored",
+        "webhook_mound_updated",
     }
 )
 
@@ -161,6 +179,27 @@ RELOCATED_SUBSCRIBER_NAMES = frozenset(
 APPLICATION_TIER_SUBSCRIBER_NAMES = frozenset(
     {
         "alert_escalated_to_workflow_brake",
+    }
+)
+
+# Slice of RELOCATED_SUBSCRIBER_NAMES relocated to an INTERFACE (not domain or
+# application) home. These self-register via aragora/server/event_subscribers.py
+# and are wired ONLY by the interface-superset bootstrap, never by the
+# domain-subset bootstrap: a pure-library debate with no HTTP server has no
+# webhook store or WebSocket state manager to react through (matching the
+# pre-inversion try/except ImportError fallback). See
+# docs/architecture/P4A_EVENTS_QUEUE_INVERSION.md §4.4 (P4a Batch E6).
+INTERFACE_TIER_SUBSCRIBER_NAMES = frozenset(
+    {
+        "staleness_to_debate",
+        "webhook_agent_elo_updated",
+        "webhook_calibration_update",
+        "webhook_evidence_found",
+        "webhook_knowledge_indexed",
+        "webhook_knowledge_queried",
+        "webhook_memory_retrieved",
+        "webhook_memory_stored",
+        "webhook_mound_updated",
     }
 )
 
@@ -427,23 +466,26 @@ def test_relocated_reactions_registered_via_home_bootstrap():
     The domain-subset bootstrap imports the domain home modules; every relocated
     DOMAIN-tier name must then be wired into the manager (parity for the relocated
     slice, so a silently dropped home import is caught here and not only in the
-    superset test). APPLICATION_TIER_SUBSCRIBER_NAMES is excluded: those reactions
-    (e.g. alert_escalated_to_workflow_brake, P4a Batch E5) wire only via the
-    interface-superset bootstrap - see
-    ``test_application_tier_reactions_registered_via_superset_bootstrap``.
+    superset test). APPLICATION_TIER_SUBSCRIBER_NAMES and
+    INTERFACE_TIER_SUBSCRIBER_NAMES are excluded: those reactions (e.g.
+    alert_escalated_to_workflow_brake, P4a Batch E5; staleness_to_debate /
+    webhook_*, P4a Batch E6) wire only via the interface-superset bootstrap -
+    see ``test_application_tier_reactions_registered_via_superset_bootstrap``
+    and ``test_interface_tier_reactions_registered_via_superset_bootstrap``.
     """
     from aragora.debate.event_subscribers import bootstrap_debate_event_subscribers
 
     manager = bootstrap_debate_event_subscribers()
     registered = set(manager.get_stats())
 
-    missing = (RELOCATED_SUBSCRIBER_NAMES - APPLICATION_TIER_SUBSCRIBER_NAMES) - registered
+    non_domain_tier = APPLICATION_TIER_SUBSCRIBER_NAMES | INTERFACE_TIER_SUBSCRIBER_NAMES
+    missing = (RELOCATED_SUBSCRIBER_NAMES - non_domain_tier) - registered
     assert not missing, f"home bootstrap failed to wire relocated reactions: {sorted(missing)}"
 
-    leaked = APPLICATION_TIER_SUBSCRIBER_NAMES & registered
+    leaked = non_domain_tier & registered
     assert not leaked, (
-        "application-tier reactions must not be wired by the domain-subset "
-        f"bootstrap: {sorted(leaked)}"
+        "application/interface-tier reactions must not be wired by the "
+        f"domain-subset bootstrap: {sorted(leaked)}"
     )
 
 
@@ -459,6 +501,21 @@ def test_application_tier_reactions_registered_via_superset_bootstrap():
     missing = APPLICATION_TIER_SUBSCRIBER_NAMES - registered
     assert not missing, (
         f"superset bootstrap failed to wire application-tier reactions: {sorted(missing)}"
+    )
+
+
+def test_interface_tier_reactions_registered_via_superset_bootstrap():
+    """E6+: interface-tier relocated reactions self-register through their
+    interface home module, wired ONLY via the interface-superset bootstrap
+    (never the domain-subset one - see INTERFACE_TIER_SUBSCRIBER_NAMES)."""
+    from aragora.server.startup.event_subscribers import bootstrap_event_subscribers
+
+    manager = bootstrap_event_subscribers()
+    registered = set(manager.get_stats())
+
+    missing = INTERFACE_TIER_SUBSCRIBER_NAMES - registered
+    assert not missing, (
+        f"superset bootstrap failed to wire interface-tier reactions: {sorted(missing)}"
     )
 
 
@@ -494,6 +551,31 @@ def test_domain_subset_bootstrap_does_not_leak_application_tier_via_prior_import
     )
 
 
+def test_domain_subset_bootstrap_does_not_leak_interface_tier_via_prior_import():
+    """A pure-domain process must stay server-free even when something
+    unrelated already imported the server home first.
+
+    Mirrors ``test_domain_subset_bootstrap_does_not_leak_application_tier_via_prior_import``
+    for the P4a Batch E6 interface-tier home: a prior, unrelated import of
+    ``aragora.server.event_subscribers`` must not let the domain-subset
+    bootstrap pick up its server-coupled reactions.
+    """
+    from aragora.debate.event_subscribers import bootstrap_debate_event_subscribers
+    from aragora.server import event_subscribers as server_home
+
+    server_home.register()  # the "unrelated earlier import" elsewhere in-process
+    assert "server" in get_registered_subscribers()
+
+    manager = bootstrap_debate_event_subscribers()
+    registered = set(manager.get_stats())
+
+    leaked = INTERFACE_TIER_SUBSCRIBER_NAMES & registered
+    assert not leaked, (
+        "domain-subset bootstrap picked up an interface-tier reaction left "
+        f"in the registry by a prior, unrelated import: {sorted(leaked)}"
+    )
+
+
 def test_superset_bootstrap_fails_closed_when_workflow_home_registration_is_missing(
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -510,6 +592,26 @@ def test_superset_bootstrap_fails_closed_when_workflow_home_registration_is_miss
     reset_registry()
     reset_cross_subscriber_manager()
     monkeypatch.setattr(workflow_home, "register", lambda: None)
+
+    with pytest.raises(RuntimeError, match="Application event subscriber bootstrap incomplete"):
+        bootstrap_event_subscribers()
+
+
+def test_superset_bootstrap_fails_closed_when_server_home_registration_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A missing server-home registration must fail instead of silently dropping it.
+
+    Mirrors the workflow-home fail-closed test above, but for the P4a Batch E6
+    interface-tier completeness check.
+    """
+    from aragora.events.cross_subscribers import reset_cross_subscriber_manager, reset_registry
+    from aragora.server import event_subscribers as server_home
+    from aragora.server.startup.event_subscribers import bootstrap_event_subscribers
+
+    reset_registry()
+    reset_cross_subscriber_manager()
+    monkeypatch.setattr(server_home, "register", lambda: None)
 
     with pytest.raises(RuntimeError, match="Application event subscriber bootstrap incomplete"):
         bootstrap_event_subscribers()

--- a/tests/integration/test_km_bidirectional.py
+++ b/tests/integration/test_km_bidirectional.py
@@ -369,11 +369,15 @@ class TestStalenessBidirectional:
     """Test Staleness ↔ Debate integration."""
 
     def test_staleness_to_debate_warns_active(self):
-        """Test that staleness warnings are checked against active debates."""
-        from aragora.events.cross_subscribers import CrossSubscriberManager
+        """Test that staleness warnings are checked against active debates.
+
+        Relocated from ``CrossSubscriberManager`` (P4a Batch E6): it is
+        server-coupled, now living on ``ServerEventSubscriber``.
+        """
+        from aragora.server.event_subscribers import ServerEventSubscriber
         from aragora.events.types import StreamEvent, StreamEventType
 
-        manager = CrossSubscriberManager()
+        subscriber = ServerEventSubscriber()
 
         event = StreamEvent(
             type=StreamEventType.KNOWLEDGE_STALE,
@@ -385,7 +389,7 @@ class TestStalenessBidirectional:
         )
 
         # Should not raise
-        manager._handle_staleness_to_debate(event)
+        subscriber._handle_staleness_to_debate(event)
 
 
 class TestProvenanceBidirectional:
@@ -624,12 +628,14 @@ class TestEventTypeRegistration:
 
     def test_handlers_registered(self):
         """Test that all bidirectional handlers are registered."""
-        from aragora.debate.event_subscribers import bootstrap_debate_event_subscribers
+        from aragora.server.startup.event_subscribers import bootstrap_event_subscribers
 
         # Post-E2a the Knowledge Mound reactions self-register from their domain
         # home; a bare manager no longer builds them in, so bootstrap to wire the
-        # full set before asserting registration.
-        manager = bootstrap_debate_event_subscribers()
+        # full set before asserting registration. Use the interface-superset
+        # bootstrap (not the domain-subset one) since staleness_to_debate is now
+        # an interface-tier reaction (P4a Batch E6) wired only there.
+        manager = bootstrap_event_subscribers()
 
         # Check handler registrations
         stats = manager.get_stats()

--- a/tests/server/test_event_subscribers.py
+++ b/tests/server/test_event_subscribers.py
@@ -1,0 +1,200 @@
+"""Tests for the server-domain (interface-tier) event-subscriber home
+(P4a Batch E6).
+
+Covers ``aragora.server.event_subscribers``: the webhook-delivery reaction
+relocated out of ``aragora.events.cross_subscribers.handlers.basic`` and the
+knowledge-staleness-to-debate reaction relocated out of
+``aragora.events.cross_subscribers.handlers.culture``, into this interface
+home, plus the self-registration surface (get-or-create accessor,
+``register()``).
+
+Both reactions are server-coupled (``server.handlers.webhooks``,
+``server.stream.state_manager``) so ``ServerEventSubscriber`` is wired ONLY
+via the interface-superset bootstrap
+(``aragora.server.startup.event_subscribers.bootstrap_event_subscribers``),
+never the domain-subset one (``aragora.debate.event_subscribers.
+bootstrap_debate_event_subscribers``) - see
+``tests/events/test_cross_subscriber_registry.py`` for the cross-cutting
+golden-name parity/leak-prevention/fail-closed tests.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aragora.events.cross_subscribers import (
+    CrossSubscriberManager,
+    get_registered_subscribers,
+    reset_cross_subscriber_manager,
+    reset_registry,
+)
+from aragora.events.types import StreamEvent, StreamEventType
+from aragora.server.event_subscribers import (
+    SERVER_EVENT_SUBSCRIBER_HANDLER_NAMES,
+    ServerEventSubscriber,
+    get_server_event_subscriber,
+    register,
+)
+
+
+def make_stream_event(event_type: StreamEventType, data: dict | None = None) -> StreamEvent:
+    """Factory for creating test stream events."""
+    return StreamEvent(type=event_type, data=data or {}, round=0, agent="test_agent")
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry_and_manager():
+    """Isolate each test: empty registry + fresh manager before and after."""
+    reset_registry()
+    reset_cross_subscriber_manager()
+    yield
+    reset_registry()
+    reset_cross_subscriber_manager()
+
+
+class TestServerEventSubscriberHandlers:
+    """Direct handler-execution tests."""
+
+    def test_staleness_to_debate_handler_executes_without_error(self):
+        subscriber = ServerEventSubscriber()
+        event = make_stream_event(
+            StreamEventType.KNOWLEDGE_STALE,
+            data={"node_id": "n1", "reason": "source updated"},
+        )
+        subscriber._handle_staleness_to_debate(event)
+
+    def test_staleness_to_debate_warns_on_active_debate_citation(self):
+        subscriber = ServerEventSubscriber()
+        event = make_stream_event(
+            StreamEventType.KNOWLEDGE_STALE,
+            data={"node_id": "stale-node-1", "reason": "source updated"},
+        )
+        active_debates = {"debate-1": {"cited_knowledge": ["stale-node-1"]}}
+        with patch(
+            "aragora.server.stream.state_manager.get_active_debates",
+            return_value=active_debates,
+        ):
+            subscriber._handle_staleness_to_debate(event)
+
+    def test_webhook_delivery_handler_executes_without_error(self):
+        subscriber = ServerEventSubscriber()
+        event = make_stream_event(
+            StreamEventType.MEMORY_STORED,
+            data={"content": "test"},
+        )
+        subscriber._handle_webhook_delivery(event)
+
+    def test_webhook_delivery_dispatches_to_matching_webhooks(self):
+        subscriber = ServerEventSubscriber()
+        event = make_stream_event(
+            StreamEventType.MEMORY_STORED,
+            data={"content": "test"},
+        )
+        mock_webhook = MagicMock(id="wh1")
+        mock_store = MagicMock()
+        mock_store.get_for_event.return_value = [mock_webhook]
+        mock_result = MagicMock(success=True)
+
+        with (
+            patch(
+                "aragora.server.handlers.webhooks.get_webhook_store",
+                return_value=mock_store,
+            ),
+            patch(
+                "aragora.events.dispatcher.dispatch_webhook_with_retry",
+                return_value=mock_result,
+            ) as mock_dispatch,
+        ):
+            subscriber._handle_webhook_delivery(event)
+
+        mock_dispatch.assert_called_once()
+        assert mock_dispatch.call_args[0][0] is mock_webhook
+
+
+class TestServerEventSubscriberRegistration:
+    """Registration + self-registration surface tests."""
+
+    def test_handler_names_frozenset(self):
+        assert SERVER_EVENT_SUBSCRIBER_HANDLER_NAMES == frozenset(
+            {
+                "staleness_to_debate",
+                "webhook_memory_stored",
+                "webhook_memory_retrieved",
+                "webhook_agent_elo_updated",
+                "webhook_knowledge_indexed",
+                "webhook_knowledge_queried",
+                "webhook_mound_updated",
+                "webhook_calibration_update",
+                "webhook_evidence_found",
+            }
+        )
+
+    def test_register_wires_all_handlers_into_manager(self):
+        manager = CrossSubscriberManager()
+        subscriber = ServerEventSubscriber()
+
+        subscriber.register(manager)
+
+        registered = set(manager.get_stats())
+        assert SERVER_EVENT_SUBSCRIBER_HANDLER_NAMES <= registered
+
+    def test_register_dispatches_staleness_to_debate_through_manager(self):
+        manager = CrossSubscriberManager()
+        ServerEventSubscriber().register(manager)
+
+        manager._dispatch_event(
+            make_stream_event(
+                StreamEventType.KNOWLEDGE_STALE,
+                data={"node_id": "n1", "reason": "x"},
+            )
+        )
+
+        stats = manager.get_stats()
+        assert stats["staleness_to_debate"]["events_processed"] == 1
+
+    def test_register_dispatches_webhook_delivery_through_manager(self):
+        manager = CrossSubscriberManager()
+        ServerEventSubscriber().register(manager)
+
+        manager._dispatch_event(make_stream_event(StreamEventType.EVIDENCE_FOUND, data={}))
+
+        stats = manager.get_stats()
+        assert stats["webhook_evidence_found"]["events_processed"] == 1
+
+    def test_get_server_event_subscriber_returns_singleton(self):
+        first = get_server_event_subscriber()
+        second = get_server_event_subscriber()
+        assert first is second
+        assert get_registered_subscribers()["server"] is first
+
+    def test_register_function_is_idempotent(self):
+        register()
+        first = get_registered_subscribers()["server"]
+        register()
+        second = get_registered_subscribers()["server"]
+        assert first is second
+
+
+class TestLegacyDelegatingSitesRemoved:
+    """Structural regression guard: both pre-inversion handler methods are
+    gone entirely from their old infrastructure mixins, not merely
+    unregistered (docs/architecture/P4A_EVENTS_QUEUE_INVERSION.md §5.3)."""
+
+    def test_basic_handlers_mixin_has_no_webhook_delivery(self):
+        from aragora.events.cross_subscribers.handlers.basic import BasicHandlersMixin
+
+        assert not hasattr(BasicHandlersMixin, "_handle_webhook_delivery")
+
+    def test_culture_handlers_mixin_has_no_staleness_to_debate(self):
+        from aragora.events.cross_subscribers.handlers.culture import CultureHandlersMixin
+
+        assert not hasattr(CultureHandlersMixin, "_handle_staleness_to_debate")
+
+    def test_manager_no_longer_registers_relocated_names_directly(self):
+        """A bare, non-bootstrapped manager must not carry the relocated
+        names: only the interface-superset bootstrap wires them in now."""
+        manager = CrossSubscriberManager()
+        registered = set(manager.get_stats())
+        assert not (SERVER_EVENT_SUBSCRIBER_HANDLER_NAMES & registered)


### PR DESCRIPTION
## Source

P4a EventBus/queue inversion, Batch E6 (interface home for server-coupled
reactions). Scope corrected by orchestrator note (superseding stale spec
text) per `library/p4a-post-e2c-reaction-inventory.md`:

1. The `execution_handlers` emitter contributor was already deleted by E2c
   (dropped from scope here).
2. Relocates ONLY the subscriber-side `events -> server` reactions:
   `basic.py::_handle_webhook_delivery` (imports
   `server.handlers.webhooks.get_webhook_store`) and
   `culture.py::_handle_staleness_to_debate` (imports
   `server.stream.state_manager.get_active_debates`).
3. `notification_handlers.py` relocation is optional (not an edge
   contributor); deferred, not part of this batch.
4. Does **not** hand-shrink the `"aragora.events -> aragora.server"`
   baseline string — core-side contributors remain in
   `events/dispatcher.py` / `events/async_dispatcher.py`, owned by later
   batches (webhook-signing extraction + shim-caller sweep).

## Behavior summary

Both reactions move verbatim into a new interface-tier home,
`aragora/server/event_subscribers.py` (`ServerEventSubscriber`), following
the relocate-UP no-shim pattern established by E2c/E3/E4/E5. Since both
reactions are server-coupled (webhook store, WebSocket state manager), the
new home is wired **only** via the interface-superset bootstrap
(`aragora/server/startup/event_subscribers.py`), never the domain-subset
bootstrap — a pure-domain debate process has neither a webhook store nor a
WebSocket state manager to react through.

- `handlers/basic.py` / `handlers/culture.py`: handler methods removed
  (relocated), docstrings updated.
- `manager.py`: the 9 built-in registrations for these names removed from
  `_register_builtin_subscribers`, replaced with relocation comments
  (matches E2c/E3/E4/E5 precedent).
- `server/startup/event_subscribers.py`: imports + registers the new
  server home alongside the existing workflow home; unions its handler
  names into the fail-closed completeness check.
- No re-export shim (Relocate-UP no-shim exemption): consumer census found
  only two true consumers
  (`tests/integration/test_km_bidirectional.py`,
  `tests/events/test_cross_subscriber_registry.py`), both repointed in
  place.
- New `tests/server/test_event_subscribers.py`: handler-execution,
  registration/dispatch, singleton-accessor, and structural
  regression-guard tests (mirrors `tests/workflow/test_event_subscribers.py`
  from E5).

`docs/METRICS.md` / `aragora/module_tiers.yaml` regen skipped: both are
path-frozen by open PRs; drift recorded in the mission library instead of
regenerated here.

## Validation

```
ruff check aragora/ tests/                                  -> All checks passed!
ruff format --check aragora/ tests/ scripts/                -> clean (10622 files)
mypy --ignore-missing-imports --follow-imports=skip \
  --show-error-codes <5 touched aragora/ files>             -> Success: no issues found
make test-smoke                                             -> Smoke tests passed!
PYTEST_BIN="python3 -m pytest" bash scripts/test_tiers.sh smoke   -> 138 passed
pytest tests/events/ tests/server/test_event_subscribers.py \
  tests/workflow/test_event_subscribers.py \
  tests/debate/test_event_subscribers.py \
  tests/memory/test_event_subscribers.py \
  tests/reasoning/test_event_subscribers.py \
  tests/integration/test_km_bidirectional.py \
  tests/integration/test_event_pipeline_e2e.py \
  tests/handlers/test_cross_pollination.py \
  tests/memory/test_tier_transition_events.py -q            -> 831 passed
python3 scripts/ci/check_import_contracts.py \
  --layers foundation,infrastructure --json                 -> 1 new violation,
                                                                 pre-existing/ambient
                                                                 (aragora.utils -> aragora.caching),
                                                                 unrelated to this change
python3 scripts/ci/check_import_contracts.py --json          -> 4 new violations, all
  (full-layer, no --layers filter)                              pre-existing/ambient
                                                                 sibling-fleet churn; NONE
                                                                 reference aragora.events or
                                                                 aragora.server
get_cross_subscriber_manager() import path                  -> unchanged
  (aragora.events.cross_subscribers.manager.CrossSubscriberManager)
scripts/baselines/import_contracts_baseline.json             -> untouched (git diff empty);
                                                                 "aragora.events -> aragora.server"
                                                                 stays recorded (core-side
                                                                 contributors remain, owned by
                                                                 later batches)
```

## Risks

- Behavior-preserving relocation only: handler bodies are moved verbatim
  (no logic changes). Runtime dispatch continues via the interface-superset
  bootstrap, which every server startup path already calls.
- No shim at the old paths (relocate-UP exemption); the two true consumers
  are repointed in this PR.

## Pre-existing issue discovered (out of scope, not caused by this change)

`tests/server/startup/test_knowledge_mound.py::TestInitKMAdapters::test_successful_initialization`
and `::test_metrics_import_error_continues` fail on a clean E5-baseline
worktree too (verified via empty `git diff` against every file in the
failure's call path). The test's `sys.modules` mock only stubs
`get_cross_subscriber_manager`, but `bootstrap_debate_event_subscribers`
now calls `cross_subscribers.bootstrap(include_names=...)` (added by an
earlier batch), so the mock no longer matches. Not smoke-tier marked, so it
does not affect VAL-P4A-013.
