### PR TITLE
test(gauntlet): add unsigned ODR state fixtures + verifier tests

### DIFF
--- a/aragora-verify/tests/test_example_unsigned_state_fixtures.py
+++ b/aragora-verify/tests/test_example_unsigned_state_fixtures.py
@@ -40,7 +40,9 @@ def _write(tmp_path: Path, name: str, doc: dict[str, Any]) -> str:
 
 
 def _check(result: Any, name: str) -> Any:
-    return next(c for c in result.checks if c.name == name)
+    check = next((c for c in result.checks if c.name == name), None)
+    assert check is not None, f"check {name!r} not found in {[c.name for c in result.checks]}"
+    return check
 
 
 @pytest.mark.parametrize("filename", FIXTURES)

--- a/aragora-verify/tests/test_example_unsigned_state_fixtures.py
+++ b/aragora-verify/tests/test_example_unsigned_state_fixtures.py
@@ -1,0 +1,117 @@
+"""Independent verification of the new unsigned example-state fixtures
+(m2-odr-unsigned-state-fixtures): approved-clean, blocked/FAIL, and
+abstained/inconclusive. Mirrors test_example_live_receipt.py /
+test_example_merge_quorum_receipt.py (dict-level `verify()`) and additionally
+drives the packaged `aragora-verify` CLI end to end -- this feature's contract
+is stated in exit-code + `--json` terms, so the CLI is exercised directly via
+`aragora_verify.cli.main()` (no subprocess needed; same entry point the
+console script uses). The committed example JSON files are the only artifacts
+crossing the package boundary."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from aragora_verify import verify
+from aragora_verify.cli import main
+from aragora_verify.verifier import FAIL, PASS
+
+EXAMPLES_DIR = Path(__file__).resolve().parents[2] / "docs" / "specs" / "examples"
+
+FIXTURES = [
+    "example-approved-clean.odr.json",
+    "example-blocked.odr.json",
+    "example-abstained.odr.json",
+]
+
+
+def _load(filename: str) -> dict[str, Any]:
+    return json.loads((EXAMPLES_DIR / filename).read_text(encoding="utf-8"))
+
+
+def _write(tmp_path: Path, name: str, doc: dict[str, Any]) -> str:
+    path = tmp_path / name
+    path.write_text(json.dumps(doc), encoding="utf-8")
+    return str(path)
+
+
+def _check(result: Any, name: str) -> Any:
+    return next(c for c in result.checks if c.name == name)
+
+
+@pytest.mark.parametrize("filename", FIXTURES)
+def test_new_fixture_verifies_independently(filename: str) -> None:
+    doc = _load(filename)
+    result = verify(doc)  # unsigned: the "signature" check is WARN, not FAIL
+    failed = [c for c in result.checks if c.status == FAIL]
+    assert result.ok, failed
+    assert not failed
+    assert _check(result, "schema_conformance").status == PASS
+    assert _check(result, "canonical_digest").status == PASS
+
+
+@pytest.mark.parametrize("filename", FIXTURES)
+def test_new_fixture_cli_exits_zero_with_unsigned_warning(filename: str) -> None:
+    rc = main([str(EXAMPLES_DIR / filename)])
+    assert rc == 0
+
+
+@pytest.mark.parametrize("filename", FIXTURES)
+def test_new_fixture_single_byte_tamper_cli_exits_one(filename: str, tmp_path: Path) -> None:
+    raw_text = (EXAMPLES_DIR / filename).read_text(encoding="utf-8")
+    marker = '"odr_version": "0.1"'
+    assert marker in raw_text
+    tampered_text = raw_text.replace(marker, '"odr_version": "0.2"', 1)
+    path = tmp_path / filename
+    path.write_text(tampered_text, encoding="utf-8")
+    rc = main([str(path)])
+    assert rc == 1
+
+
+@pytest.mark.parametrize("filename", ["example-blocked.odr.json", "example-abstained.odr.json"])
+def test_weakening_signals_surface_in_json_warnings(filename: str, capsys) -> None:
+    rc = main([str(EXAMPLES_DIR / filename), "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert len(payload["warnings"]) >= 1
+
+
+def test_blocked_fixture_json_warnings_name_expected_categories(capsys) -> None:
+    rc = main([str(EXAMPLES_DIR / "example-blocked.odr.json"), "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    joined = " ".join(payload["warnings"])
+    assert "attestation: autonomous" in joined
+    assert "undisclosed" in joined
+    assert "uncalibrated" in joined
+
+
+def test_abstained_fixture_json_warnings_name_expected_categories(capsys) -> None:
+    rc = main([str(EXAMPLES_DIR / "example-abstained.odr.json"), "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    joined = " ".join(payload["warnings"])
+    assert "attestation: autonomous" in joined
+    assert "quorum: absent" in joined
+    assert "reasoning: absent" in joined
+
+
+def test_quorum_consistency_tamper_cli_exits_one_with_failing_check(
+    tmp_path: Path, capsys
+) -> None:
+    doc = _load("example-blocked.odr.json")
+    doc["quorum"]["dissent"]["dissenting_agents"] = ["ghost-agent"]
+    doc["quorum"]["dissent"]["present"] = True
+    path = _write(tmp_path, "blocked-quorum-tamper.odr.json", doc)
+    rc = main([path, "--json"])
+    assert rc == 1
+    payload = json.loads(capsys.readouterr().out)
+    checks_by_name = {c["name"]: c for c in payload["checks"]}
+    assert checks_by_name["schema_conformance"]["status"] == "pass"
+    assert checks_by_name["quorum_consistency"]["status"] == "fail"
+    assert "ghost-agent" in checks_by_name["quorum_consistency"]["detail"]

--- a/docs/specs/examples/example-abstained.odr.json
+++ b/docs/specs/examples/example-abstained.odr.json
@@ -1,0 +1,49 @@
+{
+  "attestation": {
+    "disposition": "autonomous"
+  },
+  "claim": {
+    "statement": "Should Aragora deprecate the legacy v1 REST API by Q3 2026?",
+    "verdict": "INCONCLUSIVE"
+  },
+  "confidence": {
+    "reason": "the quorum did not converge; no confidence value was computed for an inconclusive outcome",
+    "status": "absent"
+  },
+  "cruxes": {
+    "reason": "no crux set recorded for this decision (DecisionReceipt does not carry one; supply crux_set= from a CruxReceipt)",
+    "status": "absent"
+  },
+  "issued_at": "2026-07-03T11:00:00+00:00",
+  "odr_version": "0.1",
+  "profile": "https://aragora.ai/specs/open-decision-receipt/v0.1",
+  "quorum": {
+    "reason": "the quorum abstained: model responses were too evenly split to reach a decision within the round budget",
+    "status": "absent"
+  },
+  "reasoning": {
+    "reason": "no reasoning summary was recorded for an inconclusive outcome",
+    "status": "absent"
+  },
+  "receipt_id": "r-abstained-0001",
+  "routing": {
+    "status": "reserved"
+  },
+  "signatures": [],
+  "source": {
+    "artifact_hash": "93e62d49619ebce2196e4343d609302a5ffdcce29c340de26379f3a19a381797",
+    "receipt_id": "r-abstained-0001",
+    "schema": "aragora.gauntlet.DecisionReceipt",
+    "schema_version": "1.1",
+    "system": "aragora"
+  },
+  "subject": {
+    "digest": {
+      "alg": "sha-256",
+      "status": "present",
+      "value": "87bcfcd7a4cba508c28d2fa912e12bd716f3f318991cac52f456c8508e02ad3d"
+    },
+    "identifier": "g-abstained-1",
+    "summary": "Should Aragora deprecate the legacy v1 REST API by Q3 2026?"
+  }
+}

--- a/docs/specs/examples/example-approved-clean.odr.json
+++ b/docs/specs/examples/example-approved-clean.odr.json
@@ -1,0 +1,100 @@
+{
+  "attestation": {
+    "attestor": {
+      "id": "release-manager-1",
+      "name": "Priya Natarajan",
+      "role": "release manager"
+    },
+    "attested_at": "2026-07-01T09:05:00+00:00",
+    "disposition": "human_attested"
+  },
+  "claim": {
+    "statement": "Should the billing-retry backoff change ship to production?",
+    "verdict": "PASS"
+  },
+  "confidence": {
+    "calibration": {
+      "provenance_ref": {
+        "receipt_id": "r-approved-clean-0001",
+        "type": "aragora.settlement_metadata"
+      },
+      "status": "present"
+    },
+    "scale": "unit_interval",
+    "status": "present",
+    "value": 0.94
+  },
+  "cruxes": {
+    "reason": "no crux set recorded for this decision (DecisionReceipt does not carry one; supply crux_set= from a CruxReceipt)",
+    "status": "absent"
+  },
+  "issued_at": "2026-07-01T09:00:00+00:00",
+  "odr_version": "0.1",
+  "profile": "https://aragora.ai/specs/open-decision-receipt/v0.1",
+  "quorum": {
+    "dissent": {
+      "dissenting_agents": [],
+      "present": false,
+      "views": []
+    },
+    "independence": {
+      "disclosed": true,
+      "distinct_model_families": 3,
+      "model_families": [
+        "anthropic",
+        "google",
+        "mistral"
+      ]
+    },
+    "method": "unanimous",
+    "participants": [
+      {
+        "agent": "claude-agent",
+        "model_family": "anthropic",
+        "model_id": "claude-opus-4-8"
+      },
+      {
+        "agent": "gemini-agent",
+        "model_family": "google",
+        "model_id": "gemini-3.1-pro-preview"
+      },
+      {
+        "agent": "mistral-agent",
+        "model_family": "mistral",
+        "model_id": "mistral-large-2512"
+      }
+    ],
+    "reached": true,
+    "status": "present",
+    "supporting_agents": [
+      "claude-agent",
+      "gemini-agent",
+      "mistral-agent"
+    ]
+  },
+  "reasoning": {
+    "status": "present",
+    "summary": "Unanimous approval: all required checks green, no dissent recorded, and confidence is calibrated against historical settlement outcomes."
+  },
+  "receipt_id": "r-approved-clean-0001",
+  "routing": {
+    "status": "reserved"
+  },
+  "signatures": [],
+  "source": {
+    "artifact_hash": "fefe428afbff25739dca7ce81911573298acb8eee2a2ab0ee36c1ffd38944bce",
+    "receipt_id": "r-approved-clean-0001",
+    "schema": "aragora.gauntlet.DecisionReceipt",
+    "schema_version": "1.1",
+    "system": "aragora"
+  },
+  "subject": {
+    "digest": {
+      "alg": "sha-256",
+      "status": "present",
+      "value": "dc389b41854c5e100dd20a0ca2fc409ab223ca49e149dcf1a9578e9b3341f417"
+    },
+    "identifier": "g-approved-clean-1",
+    "summary": "Should the billing-retry backoff change ship to production?"
+  }
+}

--- a/docs/specs/examples/example-blocked.odr.json
+++ b/docs/specs/examples/example-blocked.odr.json
@@ -1,0 +1,90 @@
+{
+  "attestation": {
+    "disposition": "autonomous"
+  },
+  "claim": {
+    "statement": "Should PR synaptent/aragora#9014 (raw SQL string interpolation in the reporting export) be merged?",
+    "verdict": "FAIL"
+  },
+  "confidence": {
+    "calibration": {
+      "reason": "no calibration record for these agents",
+      "status": "absent"
+    },
+    "scale": "unit_interval",
+    "status": "present",
+    "value": 0.82
+  },
+  "cruxes": {
+    "reason": "no crux set recorded for this decision (DecisionReceipt does not carry one; supply crux_set= from a CruxReceipt)",
+    "status": "absent"
+  },
+  "issued_at": "2026-07-02T10:00:00+00:00",
+  "odr_version": "0.1",
+  "profile": "https://aragora.ai/specs/open-decision-receipt/v0.1",
+  "quorum": {
+    "dissent": {
+      "dissenting_agents": [],
+      "present": false,
+      "views": []
+    },
+    "independence": {
+      "disclosed": true,
+      "distinct_model_families": 2,
+      "model_families": [
+        "anthropic",
+        "mistral"
+      ]
+    },
+    "method": "unanimous",
+    "participants": [
+      {
+        "agent": "claude-agent",
+        "model_family": "anthropic",
+        "model_id": "claude-opus-4-8"
+      },
+      {
+        "agent": "grok-agent",
+        "model_family": "undisclosed",
+        "model_id": "undisclosed"
+      },
+      {
+        "agent": "mistral-agent",
+        "model_family": "mistral",
+        "model_id": "mistral-large-2512"
+      }
+    ],
+    "reached": true,
+    "status": "present",
+    "supporting_agents": [
+      "claude-agent",
+      "grok-agent",
+      "mistral-agent"
+    ]
+  },
+  "reasoning": {
+    "status": "present",
+    "summary": "Unanimous FAIL: raw SQL string interpolation in the reporting export is a SQL-injection vector; merge blocked pending a parameterized-query fix."
+  },
+  "receipt_id": "r-blocked-0001",
+  "routing": {
+    "status": "reserved"
+  },
+  "signatures": [],
+  "source": {
+    "artifact_hash": "63df3311d82b3bc9b2fad1dcc6ef2b318c69ad318fa30757e6e60cb54c940d9b",
+    "receipt_id": "r-blocked-0001",
+    "schema": "aragora.gauntlet.DecisionReceipt",
+    "schema_version": "1.1",
+    "system": "aragora"
+  },
+  "subject": {
+    "digest": {
+      "alg": "sha-256",
+      "status": "present",
+      "value": "21814d176088bbe00e380cc0c71c42f4c3b5f3c9d35f1247b2541ac80564b853"
+    },
+    "identifier": "merge-quorum/synaptent/aragora#9014",
+    "summary": "Should PR synaptent/aragora#9014 (raw SQL string interpolation in the reporting export) be merged?"
+  }
+}

--- a/tests/gauntlet/test_odr_verify_schema.py
+++ b/tests/gauntlet/test_odr_verify_schema.py
@@ -15,7 +15,9 @@ against the normative ``odr_schema.json`` when jsonschema is installed.
 from __future__ import annotations
 
 import copy
+import json
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -24,6 +26,7 @@ from aragora.gauntlet.odr_export import load_odr_schema, odr_content_digest
 from aragora.gauntlet.odr_verify import (
     FAIL,
     PASS,
+    SKIP,
     WARN,
     verify_odr_document,
 )
@@ -549,3 +552,108 @@ def test_valid_variants_agree_with_jsonschema(jsonschema_validator: Any, mutate:
     doc = _valid_odr()
     mutate(doc)
     assert jsonschema_validator.is_valid(copy.deepcopy(doc))
+
+
+# ---------------------------------------------------------------------------
+# New unsigned example-state fixtures (m2-odr-unsigned-state-fixtures):
+# approved-clean, blocked/FAIL, and abstained/inconclusive. These exercise the
+# committed docs/specs/examples/ files (not synthetic dicts) so the schema-
+# validation + verifier-behavior contract is pinned against the actual
+# shipped fixtures an external auditor would download.
+# ---------------------------------------------------------------------------
+
+_EXAMPLES_DIR = Path(__file__).resolve().parents[2] / "docs" / "specs" / "examples"
+
+_NEW_FIXTURES = [
+    "example-approved-clean.odr.json",
+    "example-blocked.odr.json",
+    "example-abstained.odr.json",
+]
+
+
+def _load_example(filename: str) -> dict[str, Any]:
+    return json.loads((_EXAMPLES_DIR / filename).read_text(encoding="utf-8"))
+
+
+def _tamper_odr_version(raw_text: str) -> str:
+    """Flip a single byte of the fixed ``odr_version`` literal; stays valid JSON."""
+    marker = '"odr_version": "0.1"'
+    assert marker in raw_text, "fixture does not carry the expected odr_version literal"
+    return raw_text.replace(marker, '"odr_version": "0.2"', 1)
+
+
+@pytest.mark.parametrize("filename", _NEW_FIXTURES)
+def test_new_unsigned_fixture_verifies_ok_with_unsigned_warning(filename: str) -> None:
+    doc = _load_example(filename)
+    result = verify_odr_document(doc)
+    assert result.ok is True, [c for c in result.checks if c.status == FAIL]
+    assert _check(result, "schema_conformance").status == PASS
+    assert _check(result, "canonical_digest").status == PASS
+    signature_check = _check(result, "signature")
+    assert signature_check.status == WARN
+    assert "unsigned" in signature_check.detail
+
+
+@pytest.mark.parametrize("filename", _NEW_FIXTURES)
+def test_new_unsigned_fixture_single_byte_tamper_fails(filename: str) -> None:
+    raw_text = (_EXAMPLES_DIR / filename).read_text(encoding="utf-8")
+    tampered = json.loads(_tamper_odr_version(raw_text))
+    result = verify_odr_document(tampered)
+    assert result.ok is False
+    check = _check(result, "schema_conformance")
+    assert check.status == FAIL
+    assert "odr_version" in check.detail
+
+
+@pytest.mark.parametrize("filename", _NEW_FIXTURES)
+def test_new_fixture_agrees_with_jsonschema(jsonschema_validator: Any, filename: str) -> None:
+    doc = _load_example(filename)
+    assert jsonschema_validator.is_valid(doc)
+
+
+def test_approved_clean_fixture_has_no_weakening_signals() -> None:
+    # The "clean" state fixture is deliberately human-attested, disclosed,
+    # calibrated, and unanimous -- it should carry zero weakening warnings,
+    # contrasting with the intentionally weaker blocked/abstained fixtures.
+    doc = _load_example("example-approved-clean.odr.json")
+    result = verify_odr_document(doc)
+    assert result.ok is True
+    assert result.warnings == []
+
+
+def test_blocked_fixture_surfaces_weakening_signals() -> None:
+    doc = _load_example("example-blocked.odr.json")
+    result = verify_odr_document(doc)
+    assert result.ok is True
+    joined = " ".join(result.warnings)
+    assert "attestation: autonomous" in joined
+    assert "undisclosed" in joined
+    assert "uncalibrated" in joined
+
+
+def test_abstained_fixture_surfaces_weakening_signals() -> None:
+    doc = _load_example("example-abstained.odr.json")
+    result = verify_odr_document(doc)
+    assert result.ok is True
+    # No present quorum block to cross-check -- SKIP, never FAIL.
+    assert _check(result, "quorum_consistency").status == SKIP
+    joined = " ".join(result.warnings)
+    assert "attestation: autonomous" in joined
+    assert "quorum: absent" in joined
+    assert "reasoning: absent" in joined
+
+
+def test_quorum_consistency_tamper_on_blocked_fixture_fails() -> None:
+    # Semantically distinct from a digest/schema tamper (spec §8): an agent
+    # referenced in dissent but never disclosed as a participant must FAIL
+    # quorum_consistency specifically, even though the receipt is unsigned
+    # and every other check (schema, digest) still passes on the mutated doc.
+    doc = _load_example("example-blocked.odr.json")
+    doc["quorum"]["dissent"]["dissenting_agents"] = ["ghost-agent"]
+    doc["quorum"]["dissent"]["present"] = True
+    result = verify_odr_document(doc)
+    assert result.ok is False
+    assert _check(result, "schema_conformance").status == PASS
+    check = _check(result, "quorum_consistency")
+    assert check.status == FAIL
+    assert "ghost-agent" in check.detail

--- a/tests/gauntlet/test_odr_verify_schema.py
+++ b/tests/gauntlet/test_odr_verify_schema.py
@@ -75,7 +75,9 @@ def _valid_odr() -> dict[str, Any]:
 
 
 def _check(result: Any, name: str) -> Any:
-    return next(c for c in result.checks if c.name == name)
+    check = next((c for c in result.checks if c.name == name), None)
+    assert check is not None, f"check {name!r} not found in {[c.name for c in result.checks]}"
+    return check
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

TDD-adds three new UNSIGNED ODR example fixtures under `docs/specs/examples/` covering the approved-clean, blocked/FAIL, and abstained/inconclusive verdict states, plus schema-validation + verifier tests pinning their behavior. Fixtures/tests only — no production code changes.

- `example-approved-clean.odr.json` — PASS verdict, human-attested, unanimous 3-family disclosed quorum, calibrated confidence. Zero-warning control fixture.
- `example-blocked.odr.json` — FAIL verdict (SQL-injection-blocked merge), autonomous disposition, one undisclosed participant family, uncalibrated confidence.
- `example-abstained.odr.json` — INCONCLUSIVE verdict, autonomous disposition, quorum/confidence/reasoning all `absent` with explanatory reasons.

## Behavior pinned by the new tests

- Each new unsigned fixture verifies at **exit 0** with a `signature` **WARN** (unsigned, authenticity not established).
- A single-byte tamper (`odr_version` "0.1" → "0.2") on any of the three fixtures → **exit 1** (`schema_conformance` FAIL).
- The blocked/abstained fixtures surface their weakening signals in `--json warnings[]` (autonomous attestation, undisclosed participant family, uncalibrated confidence, absent quorum/reasoning); approved-clean has zero warnings.
- A quorum-consistency tamper (an agent referenced in `quorum.dissent.dissenting_agents` but absent from `quorum.participants[].agent`) on the blocked fixture → **exit 1** with `quorum_consistency=FAIL`, while `schema_conformance`/`canonical_digest` still PASS (a semantically distinct, digest-independent tamper).

## Tests added

- `tests/gauntlet/test_odr_verify_schema.py` (dependency-free in-tree `aragora.gauntlet.odr_verify` engine): 13 new tests.
- `aragora-verify/tests/test_example_unsigned_state_fixtures.py` (new file; standalone CLI package, exit-code + `--json` level): 14 new tests.

## Verification

- `pytest tests/cli/test_verify.py tests/export/test_decision_receipt.py tests/gauntlet/test_receipt.py tests/gauntlet/test_odr_verify.py tests/gauntlet/test_odr_verify_schema.py -q` → **242 passed** (baseline 229; +13).
- `cd aragora-verify && PYTHONPATH=src pytest tests -q` → **66 passed** (baseline 52; +14).
- `ruff check aragora/gauntlet aragora/cli tests/gauntlet/test_odr_verify_schema.py` → clean.
- `mypy --ignore-missing-imports --follow-imports=skip aragora/gauntlet/odr_export.py aragora/gauntlet/odr_signing.py aragora/cli/review.py tests/gauntlet/test_odr_verify_schema.py` → clean.
- Manually ran the installed `aragora-verify` CLI against all three fixtures (exit 0 + expected `--json` warnings), byte-tampered copies (exit 1), and a quorum-consistency-tampered copy (exit 1, `quorum_consistency` FAIL, `ghost-agent` named in detail).
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` → `preflight: ok`.

Tests/fixtures-only change — auto-merge eligible.

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>