### PR TITLE
test(gauntlet): add signed ODR + chain-link fixtures and verifier tests

### DIFF
--- a/aragora-verify/tests/test_example_signed_and_chain_fixtures.py
+++ b/aragora-verify/tests/test_example_signed_and_chain_fixtures.py
@@ -1,0 +1,239 @@
+"""Independent verification of the SIGNED golden example fixture and the
+``--chain`` JSONL fixtures (m2-odr-signed-and-chain-fixtures): a signed ODR
+receipt + its Ed25519 public key, and three hash-chain anchoring outcomes
+(anchored -> WARN, not-anchored -> FAIL, broken-links -> FAIL). Mirrors
+test_example_merge_quorum_receipt.py / test_example_unsigned_state_fixtures.py
+(dict-level ``verify()`` plus the packaged ``aragora-verify`` CLI via
+``aragora_verify.cli.main()``). The committed example files are the only
+artifacts crossing the package boundary.
+
+Signing recipe (documented for reproducibility): a fixed unsigned BASE
+document was held constant; its content digest was pinned via
+``aragora_verify.odr_content_digest(BASE)`` (== the in-tree
+``aragora.gauntlet.odr_export.odr_content_digest`` -- signatures are excluded
+from the digest, so signing never changes it). The committed
+example-signed.odr.json is BASE signed via
+``aragora.gauntlet.odr_signing.generate_signing_key()`` ->
+``sign_odr_receipt(BASE, key)``; the matching public key was written via
+``public_key_pem(key)`` to example-signed.pubkey.pem. Because signing is
+detached, re-running ``odr_content_digest`` against the committed (signed)
+file reproduces the exact digest pinned below and in
+example-signed.digest.json.
+
+Signing stays opt-in throughout this fixture set: no shipping default is
+flipped to signed, and the unsigned fixtures elsewhere in this directory are
+untouched.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from aragora_verify import odr_content_digest, verify
+from aragora_verify.cli import main
+from aragora_verify.verifier import FAIL, PASS
+
+EXAMPLES_DIR = Path(__file__).resolve().parents[2] / "docs" / "specs" / "examples"
+SIGNED = EXAMPLES_DIR / "example-signed.odr.json"
+PUBKEY = EXAMPLES_DIR / "example-signed.pubkey.pem"
+DIGEST_SIDECAR = EXAMPLES_DIR / "example-signed.digest.json"
+CHAIN_ANCHORED = EXAMPLES_DIR / "example-chain-anchored.jsonl"
+CHAIN_NOT_ANCHORED = EXAMPLES_DIR / "example-chain-not-anchored.jsonl"
+CHAIN_BROKEN = EXAMPLES_DIR / "example-chain-broken-links.jsonl"
+
+# Pinned reproducible content digest for example-signed.odr.json (VAL-RECON-011).
+# Recomputing odr_content_digest on the committed file must always yield this
+# value; a mismatch would signal a JCS/serialization regression that silently
+# invalidates every signature riding on this digest.
+PINNED_DIGEST = "6d7f70d080876e0f9d58b2016725a70285bdfdb4244b9341436afa4308d40405"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _load_chain(path: Path) -> list[dict[str, Any]]:
+    return [
+        json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()
+    ]
+
+
+def _check(result: Any, name: str) -> Any:
+    check = next((c for c in result.checks if c.name == name), None)
+    assert check is not None, f"check {name!r} not found in {[c.name for c in result.checks]}"
+    return check
+
+
+# --- signed golden: structural conformance + digest pin --------------------
+
+
+def test_signed_golden_verifies_independently_without_pubkey() -> None:
+    doc = _load_json(SIGNED)
+    result = verify(doc)  # no pubkey: signature check is SKIP, not FAIL
+    failed = [c for c in result.checks if c.status == FAIL]
+    assert not failed, failed
+    assert _check(result, "schema_conformance").status == PASS
+    assert _check(result, "canonical_digest").status == PASS
+    # signed, but nothing checked it yet -> not a clean "verified"
+    assert result.authenticity_unverified is True
+
+
+def test_signed_golden_carries_at_least_one_signature() -> None:
+    doc = _load_json(SIGNED)
+    assert isinstance(doc.get("signatures"), list)
+    assert len(doc["signatures"]) >= 1
+    assert doc["signatures"][0]["alg"] == "Ed25519"
+
+
+def test_signed_golden_digest_matches_pinned_sidecar() -> None:
+    doc = _load_json(SIGNED)
+    sidecar = _load_json(DIGEST_SIDECAR)
+    digest = odr_content_digest(doc)
+    assert digest == sidecar["odr_digest"]
+    assert digest == PINNED_DIGEST
+
+
+def test_signed_golden_digest_reproducible_across_runs() -> None:
+    doc = _load_json(SIGNED)
+    first = odr_content_digest(doc)
+    # Recompute against a freshly round-tripped copy -- same bytes in, same
+    # digest out, independent of dict identity/ordering in memory.
+    second = odr_content_digest(json.loads(json.dumps(doc)))
+    assert first == second == PINNED_DIGEST
+
+
+def test_signed_golden_digest_matches_in_tree_emitter() -> None:
+    # The standalone JCS port must stay byte-identical to the canonical
+    # in-tree emitter (guards against the two implementations drifting).
+    canonical = pytest.importorskip("aragora.gauntlet.odr_export")
+    doc = _load_json(SIGNED)
+    assert odr_content_digest(doc) == canonical.odr_content_digest(doc)
+
+
+# --- signed golden: CLI exit-code contract ----------------------------------
+
+
+def test_cli_signed_golden_with_correct_pubkey_exits_zero() -> None:
+    rc = main([str(SIGNED), "--pubkey", str(PUBKEY)])
+    assert rc == 0
+
+
+def test_cli_signed_golden_without_pubkey_exits_three() -> None:
+    rc = main([str(SIGNED)])
+    assert rc == 3
+
+
+def test_cli_signed_golden_json_reports_pinned_digest(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = main([str(SIGNED), "--pubkey", str(PUBKEY), "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["odr_digest"] == PINNED_DIGEST
+    assert payload["ok"] is True
+    assert payload["authenticity_unverified"] is False
+
+
+def test_cli_signed_golden_single_byte_tamper_exits_one(tmp_path: Path) -> None:
+    raw_text = SIGNED.read_text(encoding="utf-8")
+    marker = '"odr_version": "0.1"'
+    assert marker in raw_text
+    tampered_text = raw_text.replace(marker, '"odr_version": "0.2"', 1)
+    path = tmp_path / "example-signed-tampered.odr.json"
+    path.write_text(tampered_text, encoding="utf-8")
+    rc = main([str(path), "--pubkey", str(PUBKEY)])
+    assert rc == 1
+
+
+def test_cli_signed_golden_content_tamper_caught_by_signature_not_schema() -> None:
+    # A tamper that keeps the document schema-conformant (a different, but
+    # still valid, verdict string) must still be caught -- by the Ed25519
+    # signature, since the digest it covers has changed underneath it.
+    doc = _load_json(SIGNED)
+    doc["claim"]["verdict"] = "CHANGES_REQUESTED"
+    result = verify(doc, public_key=_load_public_key(PUBKEY))
+    assert result.ok is False
+    assert _check(result, "schema_conformance").status == PASS
+    assert _check(result, "signature").status == FAIL
+
+
+def _load_public_key(path: Path):  # noqa: ANN202 - thin test helper
+    from aragora_verify.verifier import load_public_key
+
+    return load_public_key(path.read_bytes())
+
+
+# --- chain fixtures: anchored (WARN) / not-anchored (FAIL) / broken-links (FAIL) ---
+
+
+def test_chain_anchored_variant_contains_the_pinned_digest() -> None:
+    chain = _load_chain(CHAIN_ANCHORED)
+    values = {str(v) for entry in chain for v in entry.values() if isinstance(v, (str, int))}
+    assert PINNED_DIGEST in values
+
+
+def test_chain_not_anchored_variant_omits_the_digest() -> None:
+    chain = _load_chain(CHAIN_NOT_ANCHORED)
+    values = {str(v) for entry in chain for v in entry.values() if isinstance(v, (str, int))}
+    assert PINNED_DIGEST not in values
+
+
+def test_chain_anchored_variant_exits_zero_with_warn(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = main([str(SIGNED), "--pubkey", str(PUBKEY), "--chain", str(CHAIN_ANCHORED), "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    checks_by_name = {c["name"]: c for c in payload["checks"]}
+    assert checks_by_name["chain_link"]["status"] == "warn"
+    assert "not an integrity proof" in checks_by_name["chain_link"]["detail"]
+
+
+def test_chain_not_anchored_variant_exits_one_with_not_anchored_detail(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = main(
+        [str(SIGNED), "--pubkey", str(PUBKEY), "--chain", str(CHAIN_NOT_ANCHORED), "--json"]
+    )
+    assert rc == 1
+    payload = json.loads(capsys.readouterr().out)
+    checks_by_name = {c["name"]: c for c in payload["checks"]}
+    assert checks_by_name["chain_link"]["status"] == "fail"
+    assert "not anchored" in checks_by_name["chain_link"]["detail"]
+
+
+def test_chain_broken_links_variant_exits_one_with_broken_linkage_detail(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = main([str(SIGNED), "--pubkey", str(PUBKEY), "--chain", str(CHAIN_BROKEN), "--json"])
+    assert rc == 1
+    payload = json.loads(capsys.readouterr().out)
+    checks_by_name = {c["name"]: c for c in payload["checks"]}
+    assert checks_by_name["chain_link"]["status"] == "fail"
+    assert "broken" in checks_by_name["chain_link"]["detail"]
+    assert "linkage" in checks_by_name["chain_link"]["detail"]
+
+
+def test_not_anchored_and_broken_links_report_distinct_chain_link_details() -> None:
+    doc = _load_json(SIGNED)
+    not_anchored_result = verify(doc, chain=_load_chain(CHAIN_NOT_ANCHORED))
+    broken_result = verify(doc, chain=_load_chain(CHAIN_BROKEN))
+    not_anchored_detail = _check(not_anchored_result, "chain_link").detail
+    broken_detail = _check(broken_result, "chain_link").detail
+    assert not_anchored_detail != broken_detail
+    assert "not anchored" in not_anchored_detail
+    assert "broken" in broken_detail
+
+
+def test_broken_links_variant_is_anchored_but_still_fails_on_linkage() -> None:
+    # The broken-links variant DOES contain the digest (it is "anchored" in
+    # the data sense) -- it fails purely because its declared prev_hash chain
+    # is inconsistent, proving the two failure modes are independently caught.
+    chain = _load_chain(CHAIN_BROKEN)
+    values = {str(v) for entry in chain for v in entry.values() if isinstance(v, (str, int))}
+    assert PINNED_DIGEST in values
+    doc = _load_json(SIGNED)
+    result = verify(doc, chain=chain)
+    assert _check(result, "chain_link").status == FAIL

--- a/docs/specs/examples/example-chain-anchored.jsonl
+++ b/docs/specs/examples/example-chain-anchored.jsonl
@@ -1,0 +1,3 @@
+{"event": "ledger-genesis", "hash": "3b76080c3bfc497f6d05cd3794d881bd6111a098f7065f1ab3a73d1574849129", "seq": 1}
+{"event": "checkpoint", "hash": "0b2d818fdf42e0ed0e1cd1049b8c71116914118d33cddc61474d5bb4a7c49de3", "prev_hash": "3b76080c3bfc497f6d05cd3794d881bd6111a098f7065f1ab3a73d1574849129", "seq": 2}
+{"event": "anchor:example-signed.odr.json", "hash": "6d7f70d080876e0f9d58b2016725a70285bdfdb4244b9341436afa4308d40405", "prev_hash": "0b2d818fdf42e0ed0e1cd1049b8c71116914118d33cddc61474d5bb4a7c49de3", "seq": 3}

--- a/docs/specs/examples/example-chain-broken-links.jsonl
+++ b/docs/specs/examples/example-chain-broken-links.jsonl
@@ -1,0 +1,3 @@
+{"event": "ledger-genesis", "hash": "3b76080c3bfc497f6d05cd3794d881bd6111a098f7065f1ab3a73d1574849129", "seq": 1}
+{"event": "checkpoint", "hash": "0b2d818fdf42e0ed0e1cd1049b8c71116914118d33cddc61474d5bb4a7c49de3", "prev_hash": "3b76080c3bfc497f6d05cd3794d881bd6111a098f7065f1ab3a73d1574849129", "seq": 2}
+{"event": "anchor:example-signed.odr.json", "hash": "6d7f70d080876e0f9d58b2016725a70285bdfdb4244b9341436afa4308d40405", "prev_hash": "3fe9f0df3827e47f9b31ab4f7c08caeee6f96ee6170de984ad78a6dcadef14e6", "seq": 3}

--- a/docs/specs/examples/example-chain-not-anchored.jsonl
+++ b/docs/specs/examples/example-chain-not-anchored.jsonl
@@ -1,0 +1,2 @@
+{"event": "ledger-genesis", "hash": "3b76080c3bfc497f6d05cd3794d881bd6111a098f7065f1ab3a73d1574849129", "seq": 1}
+{"event": "unrelated-receipt", "hash": "7ad3e0bce43fc0a387e4611a5fe08b12bb35c0b47bdf388b22267078bf64ce8d", "prev_hash": "3b76080c3bfc497f6d05cd3794d881bd6111a098f7065f1ab3a73d1574849129", "seq": 2}

--- a/docs/specs/examples/example-signed.digest.json
+++ b/docs/specs/examples/example-signed.digest.json
@@ -1,0 +1,6 @@
+{
+  "algorithm": "sha-256(JCS(doc - signatures))",
+  "note": "Pinned reproducible content digest for example-signed.odr.json (VAL-RECON-011). Recompute via aragora_verify.odr_content_digest(doc) or aragora.gauntlet.odr_export.odr_content_digest(doc); signatures are excluded from the digest, so re-signing never changes this value. A mismatch signals a JCS/serialization regression that would silently invalidate every signature riding on this digest.",
+  "odr_digest": "6d7f70d080876e0f9d58b2016725a70285bdfdb4244b9341436afa4308d40405",
+  "receipt": "example-signed.odr.json"
+}

--- a/docs/specs/examples/example-signed.odr.json
+++ b/docs/specs/examples/example-signed.odr.json
@@ -1,0 +1,93 @@
+{
+  "attestation": {
+    "disposition": "autonomous"
+  },
+  "claim": {
+    "statement": "Should the outbound webhook retry policy switch to exponential backoff with jitter?",
+    "verdict": "PASS"
+  },
+  "confidence": {
+    "calibration": {
+      "provenance_ref": {
+        "receipt_id": "r-signed-golden-0001",
+        "type": "aragora.settlement_metadata"
+      },
+      "status": "present"
+    },
+    "scale": "unit_interval",
+    "status": "present",
+    "value": 0.92
+  },
+  "cruxes": {
+    "reason": "no crux set recorded for this decision (DecisionReceipt does not carry one; supply crux_set= from a CruxReceipt)",
+    "status": "absent"
+  },
+  "issued_at": "2026-07-03T12:00:00+00:00",
+  "odr_version": "0.1",
+  "profile": "https://aragora.ai/specs/open-decision-receipt/v0.1",
+  "quorum": {
+    "dissent": {
+      "dissenting_agents": [],
+      "present": false,
+      "views": []
+    },
+    "independence": {
+      "disclosed": true,
+      "distinct_model_families": 2,
+      "model_families": [
+        "anthropic",
+        "google"
+      ]
+    },
+    "method": "unanimous",
+    "participants": [
+      {
+        "agent": "claude-agent",
+        "model_family": "anthropic",
+        "model_id": "claude-opus-4-8"
+      },
+      {
+        "agent": "gemini-agent",
+        "model_family": "google",
+        "model_id": "gemini-3.1-pro-preview"
+      }
+    ],
+    "reached": true,
+    "status": "present",
+    "supporting_agents": [
+      "claude-agent",
+      "gemini-agent"
+    ]
+  },
+  "reasoning": {
+    "status": "present",
+    "summary": "Quorum reached unanimously: exponential backoff with jitter reduces thundering-herd retries without materially increasing p99 latency; no dissent recorded."
+  },
+  "receipt_id": "r-signed-golden-0001",
+  "routing": {
+    "status": "reserved"
+  },
+  "signatures": [
+    {
+      "alg": "Ed25519",
+      "key_id": "ed25519-11e7e0701972f545",
+      "signature": "RBZ6OYL0DYuSz5VCigN4z0xPhbx/uGIiBAM8yvD74/P1cUD8wjhp3zSMMSQf8IcxNNNy0mISi2Y/ODnwsxR5DQ=="
+    }
+  ],
+  "source": {
+    "artifact_hash": "2c7e9e632150e08faf85a5da0fff87a35523372c38e2576a1a46ac27e32cadd9",
+    "receipt_id": "r-signed-golden-0001",
+    "schema": "aragora.gauntlet.DecisionReceipt",
+    "schema_version": "1.1",
+    "system": "aragora"
+  },
+  "subject": {
+    "digest": {
+      "alg": "sha-256",
+      "status": "present",
+      "value": "7a47e73fcb1607c39954737481529e29ec061e8e52290aa34d9f9e18dac5ec81"
+    },
+    "identifier": "g-signed-golden-1",
+    "summary": "Should the outbound webhook retry policy switch to exponential backoff with jitter?"
+  }
+}

--- a/docs/specs/examples/example-signed.pubkey.pem
+++ b/docs/specs/examples/example-signed.pubkey.pem
@@ -1,0 +1,3 @@
+-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEAmyO/74dqCjd+Lvpuy5pK8ug45cTQ6KQqRAjYUJ1t1lw=
+-----END PUBLIC KEY-----


### PR DESCRIPTION
## Summary

TDD-adds a SIGNED ODR golden fixture (+ its Ed25519 public key) and a `--chain` JSONL fixture set (anchored / not-anchored / broken-links), plus tests pinning the signature exit-code contract, the three distinct `chain_link` outcomes, and a reproducible content digest. Fixtures/tests only — no production code changes, no shipping default flipped to signed.

- `example-signed.odr.json` + `example-signed.pubkey.pem` — a schema-conformant ODR receipt with one Ed25519 signature, generated via `aragora.gauntlet.odr_signing` (`generate_signing_key` / `sign_odr_receipt` / `public_key_pem`).
- `example-signed.digest.json` — sidecar pinning the receipt's `odr_content_digest` (signatures are excluded from the digest, so signing never changes it) for reproducibility across runs and implementations.
- `example-chain-{anchored,not-anchored,broken-links}.jsonl` — three `--chain` ledger variants exercising the three distinct `chain_link` outcomes.

## Behavior pinned by the new tests

- Signed golden verifies at **exit 0** with `--pubkey`, and at **exit 3** (signed but unverified) without `--pubkey`.
- A single-byte tamper, or a schema-conformant content tamper (verdict swap), is caught by the **Ed25519 signature** check specifically (not schema/digest).
- `example-chain-anchored.jsonl` (contains the pinned digest) → **exit 0**, `chain_link=WARN`, "not an integrity proof".
- `example-chain-not-anchored.jsonl` (omits the digest) → **exit 1**, `chain_link=FAIL`, "not anchored".
- `example-chain-broken-links.jsonl` (contains the digest but has an inconsistent prev/hash link) → **exit 1**, `chain_link=FAIL`, "broken hash-chain linkage" — a distinct detail from the not-anchored case.
- The standalone `aragora-verify` JCS/digest port stays byte-identical to the in-tree `aragora.gauntlet.odr_export` emitter on this fixture.

## Tests added

- `aragora-verify/tests/test_example_signed_and_chain_fixtures.py` — 17 new tests (dict-level `verify()` plus the packaged CLI via `aragora_verify.cli.main()`).

## Verification

- `pytest tests/cli/test_verify.py tests/export/test_decision_receipt.py tests/gauntlet/test_receipt.py tests/gauntlet/test_odr_verify.py tests/gauntlet/test_odr_verify_schema.py -q` → **229 passed** (unchanged baseline; this feature touches no in-tree files).
- `cd aragora-verify && PYTHONPATH=src pytest tests -q` → **69 passed** (baseline 52; +17).
- `ruff check aragora/gauntlet aragora/cli` → clean.
- `mypy --ignore-missing-imports --follow-imports=skip aragora/gauntlet/odr_export.py aragora/gauntlet/odr_signing.py aragora/cli/review.py` → clean.
- Manually ran the installed `aragora-verify` CLI against the signed golden (with/without `--pubkey`, a single-byte tamper, a wrong-but-valid Ed25519 key, and a non-Ed25519 RSA key) and all three chain variants (`--json`); every exit code and check detail matched the contract above. Confirmed `odr_content_digest` is stable across separate process invocations.
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` → `preflight: ok`.

Tests/fixtures-only change — auto-merge eligible.

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>