### PR TITLE
fix(agent-bridge): bootstrap session digest imports

### DIFF
--- a/scripts/agent_session_digest.py
+++ b/scripts/agent_session_digest.py
@@ -26,6 +26,10 @@ import time
 from pathlib import Path
 from typing import Any
 
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from aragora.swarm.agent_bridge.codex_source import default_codex_home
 
 

--- a/scripts/agent_session_digest.py
+++ b/scripts/agent_session_digest.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
@@ -31,6 +32,16 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from aragora.swarm.agent_bridge.codex_source import default_codex_home
+
+
+def _repo_python_env() -> dict[str, str]:
+    """Give child Python processes the same repo import root as this script."""
+    env = os.environ.copy()
+    existing_pythonpath = env.get("PYTHONPATH", "").strip()
+    env["PYTHONPATH"] = (
+        f"{REPO_ROOT}{os.pathsep}{existing_pythonpath}" if existing_pythonpath else str(REPO_ROOT)
+    )
+    return env
 
 
 def default_sessions_root() -> Path:
@@ -280,6 +291,7 @@ def rlm_summary(turns: dict[str, Any], question: str) -> str | None:
     """Best-effort recursive summary via Aragora's RLM CLI; None if unavailable."""
     import tempfile
 
+    child_env = _repo_python_env()
     body = "\n".join(
         ["# Agent session decisions", *turns["decisions"], "# Commands", *turns["commands"]]
     )
@@ -304,6 +316,7 @@ def rlm_summary(turns: dict[str, Any], question: str) -> str | None:
                 capture_output=True,
                 text=True,
                 timeout=120,
+                env=child_env,
             )
             if comp.returncode != 0 or not ctx_path.exists():
                 return None
@@ -321,6 +334,7 @@ def rlm_summary(turns: dict[str, Any], question: str) -> str | None:
                 capture_output=True,
                 text=True,
                 timeout=180,
+                env=child_env,
             )
             if q.returncode != 0:
                 # A failed query (e.g. missing context) must not be surfaced as

--- a/tests/scripts/test_agent_session_digest.py
+++ b/tests/scripts/test_agent_session_digest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import tempfile
 from pathlib import Path
 from types import SimpleNamespace
@@ -179,6 +180,46 @@ def test_rlm_summary_cleans_temporary_files(tmp_path: Path, monkeypatch) -> None
     assert summary == "summary"
     assert created
     assert all(not path.exists() for path in created)
+
+
+def test_rlm_summary_children_inherit_repo_pythonpath(tmp_path: Path, monkeypatch) -> None:
+    pythonpaths: list[str] = []
+
+    class FakeTemporaryDirectory:
+        def __init__(self, prefix: str) -> None:
+            self.path = tmp_path / prefix.rstrip("-")
+
+        def __enter__(self) -> str:
+            self.path.mkdir()
+            return str(self.path)
+
+        def __exit__(self, exc_type, exc, tb) -> None:  # noqa: ANN001
+            for child in self.path.iterdir():
+                child.unlink()
+            self.path.rmdir()
+
+    def fake_run(cmd, **kwargs):  # noqa: ANN001, ANN003
+        env = kwargs.get("env") or {}
+        pythonpaths.append(env.get("PYTHONPATH", ""))
+        if "compress" in cmd:
+            Path(cmd[cmd.index("-o") + 1]).write_text("{}", encoding="utf-8")
+            return SimpleNamespace(returncode=0, stdout="")
+        if "query" in cmd:
+            return SimpleNamespace(returncode=0, stdout="summary")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(tempfile, "TemporaryDirectory", FakeTemporaryDirectory)
+    monkeypatch.setattr(digest.subprocess, "run", fake_run)
+    monkeypatch.setenv("PYTHONPATH", "/existing/path")
+
+    summary = digest.rlm_summary({"decisions": ["done"], "commands": ["pytest"]}, "what")
+
+    assert summary == "summary"
+    assert len(pythonpaths) == 2
+    for value in pythonpaths:
+        paths = value.split(os.pathsep)
+        assert paths[0] == str(digest.REPO_ROOT)
+        assert "/existing/path" in paths
 
 
 def test_extract_rlm_answer_strips_cli_chrome() -> None:


### PR DESCRIPTION
## Summary
- add a repo-root sys.path bootstrap before scripts/agent_session_digest.py imports aragora modules
- preserve direct script invocation from both the repo root and arbitrary external cwd
- fixes the Fable-cycle context gap: ModuleNotFoundError: No module named 'aragora'

## Validation
- python3 scripts/agent_session_digest.py --help
- cd /tmp && python3 /tmp/aragora-agent-session-digest-path-bootstrap-20260703/scripts/agent_session_digest.py --help
- python3 -m ruff check scripts/agent_session_digest.py
- git diff --check origin/main...HEAD
- python3 scripts/check_portability.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD

Draft until required checks settle.