### PR TITLE
docs(receipts): correct PyPI publish claim in receipt lineage reconciliation

### DIFF
--- a/docs/specs/RECEIPT_LINEAGE_RECONCILIATION.md
+++ b/docs/specs/RECEIPT_LINEAGE_RECONCILIATION.md
@@ -64,11 +64,15 @@ must be kept in lockstep:
    document. `odr_verify.py` is exercised today by its own test suite
    (`tests/gauntlet/test_odr_verify.py`, `tests/gauntlet/test_odr_verify_schema.py`)
    and is available for internal callers to import directly.
-2. **`aragora-verify`** (this repo's `aragora-verify/` package, published standalone to
-   PyPI) — the "no-trust" path: pure stdlib + `cryptography`, zero Aragora dependency,
-   with its own real CLI entry point
+2. **`aragora-verify`** (this repo's standalone `aragora-verify/` package) — the
+   "no-trust" path: pure stdlib + `cryptography`, zero Aragora dependency, with its
+   own real CLI entry point
    (`aragora-verify RECEIPT.odr.json [--pubkey KEY.pem] [--chain CHAIN.jsonl]`) for an
-   external auditor who has never installed Aragora.
+   external auditor who has never installed Aragora. **Not yet on PyPI:** the publish
+   workflow merged via #8693, but no release has been run, so today the verifier is
+   invoked locally — `PYTHONPATH=src python -m aragora_verify <r>.odr.json` from
+   `aragora-verify/`, or `pip install ./aragora-verify` for the `aragora-verify`
+   console script. PyPI publish is pending until a release actually runs.
 
 Both engines are hand-rolled, dependency-light mirrors of the same normative artifact
 — `aragora/gauntlet/odr_schema.json`, also bundled inside the `aragora-verify` package


### PR DESCRIPTION
## Summary

BLOCKING scrutiny fix (M2 round 1). `docs/specs/RECEIPT_LINEAGE_RECONCILIATION.md`
(merged via #8820) falsely stated that `aragora-verify` is already "published
standalone to PyPI." In reality the publish workflow merged via #8693, but **no
release has been run** -- PyPI publishing is still pending, and today the verifier
is invoked locally:

- `cd aragora-verify && PYTHONPATH=src python -m aragora_verify <r>.odr.json`, or
- `pip install ./aragora-verify` for the `aragora-verify` console script.

This is a minimal, docs-only reword of the single sentence (list item 2 under
"Two verifiers for the public lineage") that made the false claim. No other
publish/PyPI claims exist elsewhere in the doc (cross-checked). Wording matches
the phrasing already established in `README.md` ("PyPI publish pending; today it
lives in this repo under `aragora-verify/`") and
`docs/status/PUBLIC_UTILITY_MISSION_BASELINE.md` ("workflow merged (#8693) but no
release has been run yet").

## Risk

Tier 0 (docs-only, single sentence, no schema/code/workflow touched).

## Verification

- `make docs-check` -> exit 0 (all 4 checks PASS, 1 skipped as expected without `AIRSCRIPT_CHECK_GH`)
- `python3 scripts/validate_doc_links.py` -> exit 0, "All documentation links are valid!"
- `python scripts/doc_stats.py --write && node docs-site/scripts/sync-docs.js` -> ran clean;
  `docs/specs/**` is outside the sync-docs.js mirror set (per prior M2 worker finding), confirmed
  zero mirror diff (`git diff --stat` shows only the one target file changed)
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> exit 0, "docs-only diff detected"
- Live path-freeze check: `gh pr list --state open` shows no open PR touching
  `docs/specs/RECEIPT_LINEAGE_RECONCILIATION.md` (only `docs/specs/examples/**` and
  `docs/specs/odr-native-mapping.md` are touched by other open PRs)

## Milestone

m2-receipts-reconcile

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>
