### PR TITLE
fix(storage): stabilize optional PostgreSQL storage tests

### DIFF
--- a/aragora/memory/store.py
+++ b/aragora/memory/store.py
@@ -265,28 +265,42 @@ class CritiqueStore(SQLiteStore):
         """Backfill columns for legacy critique store databases."""
         with self.connection() as conn:
             # safe_add_column is idempotent (no-op if column already exists)
-            for col_name, col_type, default in [
+            for pattern_col_name, pattern_col_type, pattern_default in [
                 ("surprise_score", "REAL", "0.0"),
                 ("base_rate", "REAL", "0.5"),
                 ("avg_prediction_error", "REAL", "0.0"),
                 ("prediction_count", "INTEGER", "0"),
             ]:
-                safe_add_column(conn, "patterns", col_name, col_type, default)
+                safe_add_column(
+                    conn, "patterns", pattern_col_name, pattern_col_type, pattern_default
+                )
 
             critique_columns: list[tuple[str, str, str | None]] = [
                 ("expected_usefulness", "REAL", "0.5"),
                 ("actual_usefulness", "REAL", None),
                 ("prediction_error", "REAL", None),
             ]
-            for col_name, col_type, default in critique_columns:
-                safe_add_column(conn, "critiques", col_name, col_type, default)
+            for critique_col_name, critique_col_type, critique_default in critique_columns:
+                safe_add_column(
+                    conn,
+                    "critiques",
+                    critique_col_name,
+                    critique_col_type,
+                    critique_default,
+                )
 
-            for col_name, col_type, default in [
+            for reputation_col_name, reputation_col_type, reputation_default in [
                 ("total_predictions", "INTEGER", "0"),
                 ("total_prediction_error", "REAL", "0.0"),
                 ("calibration_score", "REAL", "0.5"),
             ]:
-                safe_add_column(conn, "agent_reputation", col_name, col_type, default)
+                safe_add_column(
+                    conn,
+                    "agent_reputation",
+                    reputation_col_name,
+                    reputation_col_type,
+                    reputation_default,
+                )
 
             conn.commit()
 

--- a/aragora/memory/store.py
+++ b/aragora/memory/store.py
@@ -25,7 +25,6 @@ logger = logging.getLogger(__name__)
 from aragora.config import (
     CACHE_TTL_AGENT_REPUTATION,
     CACHE_TTL_ALL_REPUTATIONS,
-    CACHE_TTL_ARCHIVE_STATS,
     CACHE_TTL_CRITIQUE_PATTERNS,
     CACHE_TTL_CRITIQUE_STATS,
     resolve_db_path,
@@ -1527,7 +1526,6 @@ class CritiqueStore(SQLiteStore):
         invalidate_cache("archive_stats")
         return pruned
 
-    @ttl_cache(ttl_seconds=CACHE_TTL_ARCHIVE_STATS, key_prefix="archive_stats", skip_first=False)
     def get_archive_stats(self) -> dict:
         """Get statistics about archived patterns."""
         with self.connection() as conn:

--- a/aragora/memory/store.py
+++ b/aragora/memory/store.py
@@ -273,11 +273,12 @@ class CritiqueStore(SQLiteStore):
             ]:
                 safe_add_column(conn, "patterns", col_name, col_type, default)
 
-            for col_name, col_type, default in [
+            critique_columns: list[tuple[str, str, str | None]] = [
                 ("expected_usefulness", "REAL", "0.5"),
                 ("actual_usefulness", "REAL", None),
                 ("prediction_error", "REAL", None),
-            ]:
+            ]
+            for col_name, col_type, default in critique_columns:
                 safe_add_column(conn, "critiques", col_name, col_type, default)
 
             for col_name, col_type, default in [

--- a/aragora/storage/backends.py
+++ b/aragora/storage/backends.py
@@ -414,7 +414,8 @@ class PostgreSQLBackend(DatabaseBackend):
             with conn.cursor() as cursor:
                 cursor.executemany(sql, params_list)
 
-    def convert_placeholder(self, sql: str) -> str:
+    @staticmethod
+    def convert_placeholder(sql: str) -> str:
         """Convert SQLite ? placeholders to PostgreSQL %s."""
         # Simple conversion - doesn't handle ? inside strings
         return sql.replace("?", "%s")

--- a/tests/storage/test_storage_backends.py
+++ b/tests/storage/test_storage_backends.py
@@ -154,19 +154,13 @@ class TestPostgreSQLBackend:
 
     def test_placeholder_conversion(self):
         """Test SQL placeholder conversion."""
-        from aragora.storage.backends import PostgreSQLBackend, POSTGRESQL_AVAILABLE
-        from unittest.mock import MagicMock, patch
+        from aragora.storage.backends import PostgreSQLBackend
 
-        # Create mock pool
-        with patch("aragora.storage.backends.pg_pool") as mock_pool:
-            mock_pool.ThreadedConnectionPool.return_value = MagicMock()
-
-            backend = PostgreSQLBackend("postgresql://user:pass@localhost/db")
-
-            # Test placeholder conversion
-            sql = "SELECT * FROM users WHERE id = ? AND name = ?"
-            converted = backend.convert_placeholder(sql)
-            assert converted == "SELECT * FROM users WHERE id = %s AND name = %s"
+        # Placeholder conversion is a pure SQL-string compatibility helper; it
+        # must stay testable in smoke environments without optional psycopg2.
+        sql = "SELECT * FROM users WHERE id = ? AND name = ?"
+        converted = PostgreSQLBackend.convert_placeholder(sql)
+        assert converted == "SELECT * FROM users WHERE id = %s AND name = %s"
 
 
 class TestGetDatabaseBackend:


### PR DESCRIPTION
## Summary
- keep PostgreSQL placeholder conversion testable without constructing the optional psycopg2-backed backend
- stop caching per-store archive stats so temp database shards cannot observe stale archive counts
- isolate nullable migration defaults for changed-file mypy checks

## Context
Repairs current-main storage test drift observed while watching #8802: run 28688212472 job 85085666890 failed `tests/storage/test_store_extended.py::TestPatternPruningExtended::test_prune_patterns_archive_created` and `tests/storage/test_storage_backends.py::TestPostgreSQLBackend::test_placeholder_conversion`.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/storage/test_store_extended.py::TestPatternPruningExtended::test_prune_patterns_archive_created tests/storage/test_storage_backends.py::TestPostgreSQLBackend::test_placeholder_conversion -q -p no:cacheprovider`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/storage -q -p no:cacheprovider`
- `python3 -m ruff check aragora/memory/store.py aragora/storage/backends.py tests/storage/test_storage_backends.py`
- `python3 -m ruff format --check aragora/memory/store.py aragora/storage/backends.py tests/storage/test_storage_backends.py`
- `pre-commit run typecheck-changed --hook-stage push`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

After this lands, resume #8802 at its live head and re-check the storage shard.
