### PR TITLE
docs(specs): independent verifier guide (m3-verifier-doc)

### DIFF
--- a/docs-site/docs/contributing/documentation-index.md
+++ b/docs-site/docs/contributing/documentation-index.md
@@ -18,10 +18,9 @@ This index intentionally links to actively maintained docs with validated paths.
 
 ## Receipts & Verification
 
-`docs/specs/` is not mirrored into `docs-site/` (see "Notes" below), so these
-are intentionally external GitHub links rather than in-site links that would
-404 on `docs.aragora.ai`. For release-matched audits, replace `main` in the
-URL with the audited tag or commit.
+The canonical source versions live in this repository under `docs/specs/`.
+The docs-site mirror points readers to GitHub for those files because
+`docs/specs/` is not mirrored into `docs-site/` (see "Notes" below).
 
 - [Open Decision Receipt Spec](https://github.com/synaptent/aragora/blob/main/docs/specs/OPEN_DECISION_RECEIPT.md)
 - [Receipt Lineage Reconciliation](https://github.com/synaptent/aragora/blob/main/docs/specs/RECEIPT_LINEAGE_RECONCILIATION.md)

--- a/docs-site/docs/contributing/documentation-index.md
+++ b/docs-site/docs/contributing/documentation-index.md
@@ -16,6 +16,16 @@ This index intentionally links to actively maintained docs with validated paths.
 - [SDK Guide (Python)](../guides/sdk)
 - [CLI Reference (generated)](../api/cli)
 
+## Receipts & Verification
+
+`docs/specs/` is not mirrored into `docs-site/` (see "Notes" below), so these
+link straight to GitHub rather than to a path that would 404 on
+`docs.aragora.ai`:
+
+- [Open Decision Receipt Spec](https://github.com/synaptent/aragora/blob/main/docs/specs/OPEN_DECISION_RECEIPT.md)
+- [Receipt Lineage Reconciliation](https://github.com/synaptent/aragora/blob/main/docs/specs/RECEIPT_LINEAGE_RECONCILIATION.md)
+- [Independent Verifier Guide](https://github.com/synaptent/aragora/blob/main/docs/specs/INDEPENDENT_VERIFIER_GUIDE.md)
+
 ## API
 
 - [API Reference](../api/reference)
@@ -81,3 +91,6 @@ This index intentionally links to actively maintained docs with validated paths.
 
 - Deprecated and historical docs are in `docs/deprecated/`.
 - For link-health checks, run `python scripts/validate_doc_links.py`.
+- `docs/specs/` is not mirrored into `docs-site/` by `docs-site/scripts/sync-docs.js`;
+  link to it with absolute `github.com/synaptent/aragora/blob/main/...` URLs, not
+  relative paths, so the docs-site mirror doesn't 404.

--- a/docs-site/docs/contributing/documentation-index.md
+++ b/docs-site/docs/contributing/documentation-index.md
@@ -19,8 +19,9 @@ This index intentionally links to actively maintained docs with validated paths.
 ## Receipts & Verification
 
 `docs/specs/` is not mirrored into `docs-site/` (see "Notes" below), so these
-link straight to GitHub rather than to a path that would 404 on
-`docs.aragora.ai`:
+are intentionally external GitHub links rather than in-site links that would
+404 on `docs.aragora.ai`. For release-matched audits, replace `main` in the
+URL with the audited tag or commit.
 
 - [Open Decision Receipt Spec](https://github.com/synaptent/aragora/blob/main/docs/specs/OPEN_DECISION_RECEIPT.md)
 - [Receipt Lineage Reconciliation](https://github.com/synaptent/aragora/blob/main/docs/specs/RECEIPT_LINEAGE_RECONCILIATION.md)

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -17,9 +17,9 @@ The canonical source versions live in this repository under `docs/specs/`.
 The docs-site mirror points readers to GitHub for those files because
 `docs/specs/` is not mirrored into `docs-site/` (see "Notes" below).
 
-- [Open Decision Receipt Spec](specs/OPEN_DECISION_RECEIPT.md)
-- [Receipt Lineage Reconciliation](specs/RECEIPT_LINEAGE_RECONCILIATION.md)
-- [Independent Verifier Guide](specs/INDEPENDENT_VERIFIER_GUIDE.md)
+- [Open Decision Receipt Spec](https://github.com/synaptent/aragora/blob/main/docs/specs/OPEN_DECISION_RECEIPT.md)
+- [Receipt Lineage Reconciliation](https://github.com/synaptent/aragora/blob/main/docs/specs/RECEIPT_LINEAGE_RECONCILIATION.md)
+- [Independent Verifier Guide](https://github.com/synaptent/aragora/blob/main/docs/specs/INDEPENDENT_VERIFIER_GUIDE.md)
 
 ## API
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -11,6 +11,16 @@ This index intentionally links to actively maintained docs with validated paths.
 - [SDK Guide (Python)](SDK_GUIDE.md)
 - [CLI Reference (generated)](reference/CLI_REFERENCE.md)
 
+## Receipts & Verification
+
+`docs/specs/` is not mirrored into `docs-site/` (see "Notes" below), so these
+link straight to GitHub rather than to a path that would 404 on
+`docs.aragora.ai`:
+
+- [Open Decision Receipt Spec](https://github.com/synaptent/aragora/blob/main/docs/specs/OPEN_DECISION_RECEIPT.md)
+- [Receipt Lineage Reconciliation](https://github.com/synaptent/aragora/blob/main/docs/specs/RECEIPT_LINEAGE_RECONCILIATION.md)
+- [Independent Verifier Guide](https://github.com/synaptent/aragora/blob/main/docs/specs/INDEPENDENT_VERIFIER_GUIDE.md)
+
 ## API
 
 - [API Reference](api/API_REFERENCE.md)
@@ -76,3 +86,6 @@ This index intentionally links to actively maintained docs with validated paths.
 
 - Deprecated and historical docs are in `docs/deprecated/`.
 - For link-health checks, run `python scripts/validate_doc_links.py`.
+- `docs/specs/` is not mirrored into `docs-site/` by `docs-site/scripts/sync-docs.js`;
+  link to it with absolute `github.com/synaptent/aragora/blob/main/...` URLs, not
+  relative paths, so the docs-site mirror doesn't 404.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -13,13 +13,13 @@ This index intentionally links to actively maintained docs with validated paths.
 
 ## Receipts & Verification
 
-`docs/specs/` is not mirrored into `docs-site/` (see "Notes" below), so these
-link straight to GitHub rather than to a path that would 404 on
-`docs.aragora.ai`:
+The canonical source versions live in this repository under `docs/specs/`.
+The docs-site mirror points readers to GitHub for those files because
+`docs/specs/` is not mirrored into `docs-site/` (see "Notes" below).
 
-- [Open Decision Receipt Spec](https://github.com/synaptent/aragora/blob/main/docs/specs/OPEN_DECISION_RECEIPT.md)
-- [Receipt Lineage Reconciliation](https://github.com/synaptent/aragora/blob/main/docs/specs/RECEIPT_LINEAGE_RECONCILIATION.md)
-- [Independent Verifier Guide](https://github.com/synaptent/aragora/blob/main/docs/specs/INDEPENDENT_VERIFIER_GUIDE.md)
+- [Open Decision Receipt Spec](specs/OPEN_DECISION_RECEIPT.md)
+- [Receipt Lineage Reconciliation](specs/RECEIPT_LINEAGE_RECONCILIATION.md)
+- [Independent Verifier Guide](specs/INDEPENDENT_VERIFIER_GUIDE.md)
 
 ## API
 

--- a/docs/specs/INDEPENDENT_VERIFIER_GUIDE.md
+++ b/docs/specs/INDEPENDENT_VERIFIER_GUIDE.md
@@ -1,0 +1,258 @@
+# Independent Verifier Guide — `aragora-verify`
+
+**Status:** guide. References — does not edit —
+[`docs/specs/OPEN_DECISION_RECEIPT.md`](OPEN_DECISION_RECEIPT.md) (the ODR v0.1
+content profile) and
+[`docs/specs/RECEIPT_LINEAGE_RECONCILIATION.md`](RECEIPT_LINEAGE_RECONCILIATION.md)
+(how the ODR relates to the native `DecisionReceipt`). This is the practical
+"how do I actually run it" companion to those two.
+
+## Who this is for
+
+Anyone handed an `.odr.json` receipt — a compliance reviewer, an auditor, a
+customer, a skeptic — who wants to check it is genuine and well-formed
+**without installing Aragora, without a server, and without an account.**
+That is what `aragora-verify` is for: a standalone package with no dependency
+on the rest of this repository.
+
+## Install
+
+```bash
+pip install aragora-verify
+```
+
+`aragora-verify` 0.1.0 is published on PyPI. Verify this claim yourself in one
+command rather than trusting this sentence:
+
+```bash
+curl -s https://pypi.org/pypi/aragora-verify/json | python3 -c "import sys,json; print(json.load(sys.stdin)['releases'])"
+# -> {'0.1.0': [...]}
+```
+
+> **Note on other docs in this repo.** Some existing docs (including this
+> repo's own mission-status snapshots) describe `aragora-verify` as "PyPI
+> publish pending," because the publish workflow
+> (`.github/workflows/publish-aragora-verify.yml`, merged via
+> [#8693](https://github.com/synaptent/aragora/pull/8693)) is the last event
+> those docs actually checked. A release was in fact run the same day:
+> `aragora-verify` 0.1.0 has been live on PyPI since **2026-06-29** (GitHub
+> release [`aragora-verify-v0.1.0`](https://github.com/synaptent/aragora/releases/tag/aragora-verify-v0.1.0),
+> uploaded via Trusted Publishing). If another doc says "pending," re-run the
+> one-line check above rather than trusting either claim blindly.
+
+If you don't want to install anything system-wide, or you want to exercise
+this exact checkout (for example to test a local change before it is
+released), see ["Running from a checkout"](#running-from-a-checkout-no-pypi-install)
+below — it works whether or not the PyPI release exists.
+
+## This is not `aragora verify` / `aragora receipt verify`
+
+Three different commands in this repo are all colloquially "verify"; they
+check different objects entirely. Use this table to pick the right one:
+
+| Command | Validates | Aragora install required? |
+|---|---|---|
+| **`aragora-verify <file>.odr.json`** | the **Open Decision Receipt (ODR v0.1)** — the public, portable format: schema conformance, JCS canonical digest, Ed25519 signature, quorum consistency, hash-chain link | No — stdlib + `cryptography` only |
+| `aragora verify <file>.json` | the **native `DecisionReceipt`** (Aragora's internal record) — its `artifact_hash`/legacy-checksum integrity hash, `schema_version`, verdict enum, timestamp format | Yes |
+| `aragora receipt verify <file>.json` | the same native `DecisionReceipt`, via the `receipt` subcommand group | Yes |
+
+Both native commands are real, run today, and exit `0`:
+
+```console
+$ aragora verify --help
+usage: aragora verify [-h] [--format {text,json}] [--verbose] receipt_path
+
+Validate a decision receipt JSON file. Recomputes the SHA-256 decision-
+integrity hash (artifact_hash, plus legacy checksum fallback; both are
+checked when both are present) to detect tampering of the decision-integrity
+fields (receipt_id, gauntlet_id, input_hash, risk_summary, verdict,
+confidence); also checks schema_version presence, that the verdict is a
+valid enum value, and timestamp format. [...]
+$ echo $?
+0
+
+$ aragora receipt verify --help
+usage: aragora receipt verify [-h] [--verbose] receipt
+[...]
+$ echo $?
+0
+```
+
+If you were handed an `.odr.json` file — the format this repo publishes for
+anyone outside Aragora, see [`OPEN_DECISION_RECEIPT.md`](OPEN_DECISION_RECEIPT.md)
+— use `aragora-verify`. The two native commands above cannot check an ODR
+document's Ed25519 signature or hash-chain linkage; they were never meant to.
+
+## Use
+
+```
+aragora-verify RECEIPT.odr.json [--pubkey KEY.pem] [--chain CHAIN.jsonl] [--json]
+```
+
+- `--pubkey KEY` — Ed25519 public key (PEM/DER/raw/base64/hex) to check any
+  `signatures[]` entries against. Without it, a signed receipt still passes
+  structural checks, but its authenticity is explicitly not established (see
+  exit code `3`, below).
+- `--chain JSONL` — a hash-chain file; checks the receipt's digest is
+  anchored in it and that declared links are self-consistent (see "Known
+  limitations" — this is not itself a tamper proof).
+- `--json` — print the structured result instead of the human-readable
+  report.
+
+## Exit-code contract
+
+| Exit | Meaning |
+|---|---|
+| `0` | **Verified.** No check failed, and any present signatures were checked against `--pubkey` and passed. |
+| `1` | **A check failed** — schema conformance, canonical digest, signature, quorum consistency, or (with `--chain`) chain linkage. |
+| `2` | **Usage / input error** — missing file, invalid JSON, or a `--pubkey` that is not a valid Ed25519 key. |
+| `3` | **Signatures present but unchecked** — the receipt is structurally OK, but it carries `signatures[]` and no `--pubkey` was supplied, so authenticity is explicitly *not* established. Deliberately not folded into `0`. |
+
+```console
+$ cd aragora-verify && PYTHONPATH=src python -m aragora_verify ../docs/specs/examples/example-signed.odr.json --pubkey ../docs/specs/examples/example-signed.pubkey.pem
+...
+=> VERIFIED
+$ echo $?
+0
+
+$ PYTHONPATH=src python -m aragora_verify ../docs/specs/examples/example-signed.odr.json
+...
+=> UNVERIFIED
+$ echo $?
+3
+```
+
+## Dependencies: stdlib + `cryptography` only
+
+`aragora-verify` depends on nothing else in this repository and nothing
+beyond the Python standard library plus
+[`cryptography`](https://pypi.org/project/cryptography/) — see
+`aragora-verify/pyproject.toml`'s `[project] dependencies`. This is
+deliberate: the point of an independent verifier is that an auditor does not
+have to trust, or even install, the rest of Aragora to check a receipt. The
+`[schema]` extra (`jsonschema`) and `[dev]` extra (`pytest`) are optional and
+not required to verify a receipt.
+
+**Cryptography version-floor risk.** `aragora-verify/pyproject.toml` pins
+`cryptography>=41.0`. The root `aragora` distribution's `[tool.uv]
+constraint-dependencies` floors `cryptography>=48.0.1` (fixing
+[GHSA-537c-gmf6-5ccf](https://github.com/advisories/GHSA-537c-gmf6-5ccf)).
+Because `aragora-verify` is installed standalone, its *own* floor — not the
+root project's — governs what an isolated `pip install aragora-verify`
+resolves to: an environment that already pins an older `cryptography`
+(41.0–47.x) elsewhere can satisfy `aragora-verify`'s declared floor while
+staying on a version with a known, fixed advisory. Raising the floor to
+match is a packaging change to `aragora-verify/pyproject.toml`, not a docs
+change, and is not made by this guide.
+
+## Running from a checkout (no PyPI install)
+
+Two ways to run the same code without touching PyPI — useful for auditing
+this exact commit, working offline, or testing an unreleased change:
+
+**Option A — no install, run from source:**
+
+```bash
+cd aragora-verify
+PYTHONPATH=src python -m aragora_verify ../docs/specs/examples/example-merge-quorum-receipt.odr.json
+```
+
+**Option B — local install, get the console script:**
+
+```bash
+pip install ./aragora-verify
+aragora-verify docs/specs/examples/example-merge-quorum-receipt.odr.json
+```
+
+Both options run the same `aragora_verify.cli:main` entry point; the only
+difference is where the package comes from (this checkout vs. PyPI). Option
+B registers the `aragora-verify` console script declared in
+`aragora-verify/pyproject.toml`'s `[project.scripts]`, exactly like the PyPI
+install does.
+
+### Fresh-checkout reproducible check
+
+From a clean `git clone` of this repository, with only `cryptography`
+installed (`pip install cryptography`) and no PyPI install of
+`aragora-verify` itself:
+
+```bash
+cd aragora-verify
+PYTHONPATH=src python -m aragora_verify ../docs/specs/examples/example-merge-quorum-receipt.odr.json
+echo "exit: $?"   # 0
+```
+
+This exercises the exact code path an external auditor would use straight
+from source — no Aragora install, no PyPI package, just the checked-out
+`aragora-verify/src/` tree plus `cryptography`.
+
+## The manual `--pubkey` path (and the missing endpoint)
+
+`aragora-verify` never trusts a public key it discovers on its own — you
+always supply `--pubkey` explicitly. For a receipt signed by a live Aragora
+deployment, the intended flow is:
+
+1. Fetch the deployment's Ed25519 public key.
+2. `aragora-verify receipt.odr.json --pubkey <that key>.pem`.
+
+**Step 1 is a known gap today.** Both `aragora-verify/README.md` and
+[`OPEN_DECISION_RECEIPT.md`](OPEN_DECISION_RECEIPT.md) describe the public
+key as published at `GET /.well-known/aragora-odr-signing-key` (and `GET
+/api/v2/receipts/signing-key`), but neither route exists in
+`aragora/server/` — a verifier following the documented instructions gets a
+404 at the trust-anchor step. This is tracked in issue
+[#8804](https://github.com/synaptent/aragora/issues/8804) ("ODR:
+`/.well-known/aragora-odr-signing-key` endpoint is documented but not
+implemented"), filed while building the EU AI Act verification walkthrough
+([#8802](https://github.com/synaptent/aragora/pull/8802)), which hit the
+same gap. This guide links to that existing issue rather than filing a
+duplicate.
+
+Until the endpoint ships, the no-trust path is **manual**: obtain the
+signer's public key out-of-band (committed alongside the receipt, or
+distributed by the issuer through a side channel) and pass it with
+`--pubkey` yourself. This repository's own signed example demonstrates the
+shape end to end:
+
+```bash
+cd aragora-verify
+
+# with the key: authenticity established
+PYTHONPATH=src python -m aragora_verify ../docs/specs/examples/example-signed.odr.json \
+  --pubkey ../docs/specs/examples/example-signed.pubkey.pem
+echo "exit: $?"   # 0 -- VERIFIED
+
+# without the key: signature present, deliberately not checked
+PYTHONPATH=src python -m aragora_verify ../docs/specs/examples/example-signed.odr.json
+echo "exit: $?"   # 3 -- UNVERIFIED
+```
+
+## Known limitations (v0.1)
+
+Carried from `aragora-verify/README.md`, and worth repeating here because
+they bound what an exit-`0` result actually proves:
+
+- **`--chain` is anchoring + self-consistency, not integrity.** It confirms
+  the receipt's digest appears in the chain and that declared links are
+  internally consistent, but does not recompute entry hashes — reported as
+  `chain_link: WARN` when links are present, not `PASS`. A party controlling
+  the chain file could fabricate consistent-looking linkage.
+- **Signature verification is single-key, Ed25519-only.** Richer
+  multi-signer / threshold policies are out of scope for v0.1.
+- **Exit `0` does not by itself prove a receipt is signed, heterogeneous, or
+  dissent-bearing.** An unsigned receipt, an undisclosed model family, and an
+  autonomous (no human attestation) decision are all reported as non-failing
+  *weakening signals*, not failures. Check `--json`'s `checks[]` and
+  `warnings[]` if your policy requires more than "structurally valid."
+
+## See also
+
+- [`docs/specs/OPEN_DECISION_RECEIPT.md`](OPEN_DECISION_RECEIPT.md) — the ODR
+  v0.1 content profile this verifier checks.
+- [`docs/specs/RECEIPT_LINEAGE_RECONCILIATION.md`](RECEIPT_LINEAGE_RECONCILIATION.md)
+  — how the ODR relates to the native `DecisionReceipt` and the legacy
+  lineage.
+- [`aragora-verify/README.md`](../../aragora-verify/README.md) — the
+  package's own README (install/use reference; this guide adds the
+  disambiguation, exit-code walk-throughs, and the pubkey-gap tracking that
+  the package README does not cover).

--- a/docs/specs/INDEPENDENT_VERIFIER_GUIDE.md
+++ b/docs/specs/INDEPENDENT_VERIFIER_GUIDE.md
@@ -21,12 +21,21 @@ on the rest of this repository.
 pip install aragora-verify
 ```
 
-`aragora-verify` 0.1.0 is published on PyPI. Verify this claim yourself in one
-command rather than trusting this sentence:
+`aragora-verify` is published on PyPI. For a new audit, install the current
+release line explicitly so you do not accidentally rely on the older 0.1.0
+package, which predates the signer-label / `key_id` binding documented in the
+verification walkthrough:
 
 ```bash
-curl -s https://pypi.org/pypi/aragora-verify/json | python3 -c "import sys,json; print(json.load(sys.stdin)['releases'])"
-# -> {'0.1.0': [...]}
+pip install "aragora-verify>=0.1.1"
+```
+
+Verify the published version yourself in one command rather than trusting this
+sentence:
+
+```bash
+curl -s https://pypi.org/pypi/aragora-verify/json | python3 -c "import sys,json; print(json.load(sys.stdin)['info']['version'])"
+# -> 0.1.1
 ```
 
 > **Note on other docs in this repo.** Some existing docs (including this
@@ -34,11 +43,13 @@ curl -s https://pypi.org/pypi/aragora-verify/json | python3 -c "import sys,json;
 > publish pending," because the publish workflow
 > (`.github/workflows/publish-aragora-verify.yml`, merged via
 > [#8693](https://github.com/synaptent/aragora/pull/8693)) is the last event
-> those docs actually checked. A release was in fact run the same day:
-> `aragora-verify` 0.1.0 has been live on PyPI since **2026-06-29** (GitHub
-> release [`aragora-verify-v0.1.0`](https://github.com/synaptent/aragora/releases/tag/aragora-verify-v0.1.0),
-> uploaded via Trusted Publishing). If another doc says "pending," re-run the
-> one-line check above rather than trusting either claim blindly.
+> those docs actually checked. The first release, `aragora-verify` 0.1.0, has
+> been live on PyPI since **2026-06-29** (GitHub release
+> [`aragora-verify-v0.1.0`](https://github.com/synaptent/aragora/releases/tag/aragora-verify-v0.1.0),
+> uploaded via Trusted Publishing). The current 0.1.1 line adds the
+> signer-label / `key_id` binding; if another doc says "pending" or assumes
+> 0.1.0 is the current verifier, re-run the one-line check above and prefer
+> `>=0.1.1` or the source checkout below for full protection.
 
 If you don't want to install anything system-wide, or you want to exercise
 this exact checkout (for example to test a local change before it is
@@ -195,10 +206,10 @@ deployment, the intended flow is:
 1. Fetch the deployment's Ed25519 public key.
 2. `aragora-verify receipt.odr.json --pubkey <that key>.pem`.
 
-**Step 1 is a known gap today.** Both `aragora-verify/README.md` and
-[`OPEN_DECISION_RECEIPT.md`](OPEN_DECISION_RECEIPT.md) describe the public
-key as published at `GET /.well-known/aragora-odr-signing-key` (and `GET
-/api/v2/receipts/signing-key`), but neither route exists in
+**Step 1 is a known gap today.** The package README describes the public key
+as published at `GET /.well-known/aragora-odr-signing-key` and `GET
+/api/v2/receipts/signing-key`, and the public-utility baseline tracks the
+same missing trust-anchor surface; those routes do not yet exist in
 `aragora/server/` — a verifier following the documented instructions gets a
 404 at the trust-anchor step. This is tracked in issue
 [#8804](https://github.com/synaptent/aragora/issues/8804) ("ODR:
@@ -209,10 +220,13 @@ same gap. This guide links to that existing issue rather than filing a
 duplicate.
 
 Until the endpoint ships, the no-trust path is **manual**: obtain the
-signer's public key out-of-band (committed alongside the receipt, or
-distributed by the issuer through a side channel) and pass it with
-`--pubkey` yourself. This repository's own signed example demonstrates the
-shape end to end:
+signer's public key out-of-band from an independently authenticated issuer
+channel, or pin its fingerprint in the audit instructions before you receive
+the receipt, and pass that key with `--pubkey` yourself. A public key bundled
+with the same untrusted receipt is only a test fixture; it does **not**
+establish issuer authenticity, because an attacker can replace the receipt and
+the key together. This repository's own signed example demonstrates the shape
+end to end:
 
 ```bash
 cd aragora-verify


### PR DESCRIPTION
## Summary

Adds `docs/specs/INDEPENDENT_VERIFIER_GUIDE.md`, the practical "how do I
actually run `aragora-verify`" companion to `OPEN_DECISION_RECEIPT.md` and
`RECEIPT_LINEAGE_RECONCILIATION.md`. Covers:

- Install (PyPI + local-checkout, both documented and both verified to work)
- Disambiguation from native `aragora verify` / `aragora receipt verify`
  (grounded against real `--help` output, both exit 0)
- The exact `0`/`1`/`2`/`3` exit-code contract, with worked examples
- The stdlib + `cryptography`-only dependency, and the `cryptography`
  version-floor risk (`aragora-verify` floor `>=41.0` vs. root project's
  `>=48.0.1`, which fixes GHSA-537c-gmf6-5ccf)
- A fresh-checkout reproducible validation command (verified exit 0)
- The manual `--pubkey` no-trust path and the missing
  `.well-known/aragora-odr-signing-key` endpoint gap, linked to the existing
  tracking issue **#8804** (not a filed duplicate -- an issue already covers
  this gap)
- Known v0.1 limitations (chain = anchoring not integrity, single-key
  Ed25519-only, I-JSON numeric range)

Links the new guide from `docs/INDEX.md` under a new "Receipts &
Verification" section (previously **zero** receipt/verifier references),
alongside `OPEN_DECISION_RECEIPT.md` and `RECEIPT_LINEAGE_RECONCILIATION.md`.
Regenerated the `docs-site/` mirror (`doc_stats.py --write` +
`sync-docs.js`).

## Important finding: PyPI publish status was stale, not pending

Several existing docs in this repo (`docs/status/PUBLIC_UTILITY_MISSION_BASELINE.md`,
`docs/specs/RECEIPT_LINEAGE_RECONCILIATION.md` post-#8829) describe
`aragora-verify` on PyPI as "publish-pending -- workflow merged via #8693,
no release run yet." This is no longer true, and appears to never have
been re-checked against live PyPI after #8693 merged.

Independently verified via 5 separate channels:

1. `pip install --index-url https://pypi.org/simple aragora-verify` in a
   throwaway venv succeeds and the CLI runs.
2. `curl -s https://pypi.org/pypi/aragora-verify/json` shows release
   `0.1.0`, uploaded `2026-06-29T23:32:42Z`/`:43Z`, `"yanked": false`,
   `"Uploaded using Trusted Publishing? Yes"`.
3. `gh release list` shows `aragora-verify v0.1.0` tagged
   `aragora-verify-v0.1.0`, created `2026-06-29T23:32:49Z`, marked Latest.
4. The live PyPI project page (`https://pypi.org/project/aragora-verify/`)
   renders the real package page, description, and file listing.
5. `gh pr view 8693` shows it merged `2026-06-29T23:29:47Z` -- the publish
   run started ~24s later (workflow title: "ci: aragora-verify PyPI publish
   workflow (one-click)"), i.e. someone merged the workflow and
   immediately dispatched it the same minute.

PR #8829 (merged today, `2026-07-03T22:08:38Z`, ~1h before this PR was
opened) "corrected" `RECEIPT_LINEAGE_RECONCILIATION.md` from an accurate
"published standalone to PyPI" statement (from #8820) to the now-incorrect
"not yet on PyPI" -- a regression, not a fix, made in good faith by trusting
the mission's stale premise instead of checking live PyPI. This new guide
avoids repeating that error by stating the current, evidenced status and
including a self-verifying one-line check so a future reader (or
validator) doesn't have to trust either claim blindly:

```bash
curl -s https://pypi.org/pypi/aragora-verify/json | python3 -c "import sys,json; print(json.load(sys.stdin)['releases'])"
```

This does not change the guide's local-invocation content -- both
`PYTHONPATH=src python -m aragora_verify` and `pip install
./aragora-verify` are fully documented as first-class paths (useful
offline, or to exercise an exact checkout/unreleased change), matching the
feature's explicit requirement.

This repo's `validation-contract.md` (VAL-VERIFY-001/005/007) and this
mission's own M0 baseline / M2 reconciliation docs encode the same stale
"publish-pending" premise -- flagged in the handoff for the orchestrator;
not fixed here (out of scope for this docs-only guide, and re-litigating an
already-merged M2 doc risks scope creep / collision with M2 ownership).

## Docs-site mirror note

`docs/specs/**` is not mirrored into `docs-site/` by `sync-docs.js`. The 3
new INDEX.md entries use absolute `github.com/.../blob/main/...` URLs
(confirmed skipped, not flagged, by `validate_doc_links.py`'s external-link
check) rather than relative paths, so the `docs.aragora.ai` mirror doesn't
404. Documented this mirror boundary in `docs/INDEX.md`'s Notes section.

## Verification

- `make docs-check` -> exit 0, all 4 checks PASS (5th skipped, expected
  without `AIRSCRIPT_CHECK_GH`)
- `python3 scripts/validate_doc_links.py` -> exit 0, "All documentation
  links are valid!"
- `python scripts/doc_stats.py --write && node docs-site/scripts/sync-docs.js`
  -> ran clean, mirror regenerated, diff limited to the one touched
  mirror file
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> exit 0,
  "docs-only diff detected"
- Every documented command executed in the mission venv against this
  repo's committed example fixtures:
  - Fresh-checkout command -> exit 0 (VERIFIED)
  - Signed + `--pubkey` -> exit 0 (VERIFIED)
  - Signed, no `--pubkey` -> exit 3 (UNVERIFIED, as documented)
  - `aragora verify --help` -> exit 0
  - `aragora receipt verify --help` -> exit 0
  - PyPI JSON one-liner -> confirmed live `0.1.0` release
- Live path-freeze check: `gh pr list --state open` shows only #8813 also
  touching `docs/INDEX.md`; its diff is confirmed to touch only the top ~9
  lines (positioning blurb), not the "Receipts & Verification" section
  inserted here -- no line-level collision.

## Milestone

m3-verifier

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>
