### PR TITLE
docs(specs): correct stale PyPI publish-pending claims for aragora-verify (m3-verifier)

### DIFF
--- a/docs/compliance/ODR_VERIFICATION_WALKTHROUGH.md
+++ b/docs/compliance/ODR_VERIFICATION_WALKTHROUGH.md
@@ -58,10 +58,12 @@ dependency is the `cryptography` package.
 > venv (real PyPI, no local wheel) installed and verified this fixture with
 > all checks PASS on 2026-07-02. CI additionally smoke-tests the CLI against
 > a wheel built from the in-repo [`aragora-verify/`](../../aragora-verify/)
-> source. **Version note:** the signer-label (`key_id`) binding described in
-> §"What each check proves" ships in 0.1.1 (in-repo source; PyPI publication
-> pending). 0.1.0 verifies content integrity and signature validity but does
-> not bind the recorded `key_id` to the supplied key — prefer 0.1.1+ or the
+> source. **Version note (corrected 2026-07-04):** the signer-label (`key_id`)
+> binding described in §"What each check proves" ships in 0.1.1, published to
+> PyPI on 2026-07-04 (self-verify: `curl -s
+> https://pypi.org/pypi/aragora-verify/json`). 0.1.0 verifies content
+> integrity and signature validity but does not bind the recorded `key_id` to
+> the supplied key — prefer `pip install "aragora-verify>=0.1.1"` or the
 > source build for full signer-label protection.
 
 ```bash

--- a/docs/compliance/ODR_VERIFICATION_WALKTHROUGH.md
+++ b/docs/compliance/ODR_VERIFICATION_WALKTHROUGH.md
@@ -9,8 +9,12 @@ network access to Aragora — verification is fully offline.
 
 This document is executable: every command below was run against the
 checked-in sample receipt in [`fixtures/`](fixtures/) and the outputs shown
-are real (verified 2026-07-02 with `aragora-verify` 0.1.0, Python 3.11,
-`cryptography` 49.0, `jsonschema` 4.26).
+are real (originally verified 2026-07-02 with `aragora-verify` 0.1.0, Python
+3.11, `cryptography` 49.0, `jsonschema` 4.26; re-verified 2026-07-04 with the
+published `aragora-verify` 0.1.1 installed from PyPI into a clean venv —
+byte-for-byte identical output for this non-tampered fixture, since 0.1.1's
+added `key_id`-binding check only changes behavior on a relabeled/tampered
+signature; see the version note below).
 
 ---
 
@@ -61,8 +65,11 @@ dependency is the `cryptography` package.
 > [`aragora-verify/`](../../aragora-verify/) source. **Version note (corrected
 > 2026-07-04):** the signer-label (`key_id`) binding described in §"What each
 > check proves" ships in 0.1.1. Pin `pip install aragora-verify==0.1.1` for
-> full signer-label protection; 0.1.0 verifies content integrity and signature
-> validity but does not bind the recorded `key_id` to the supplied key.
+> full signer-label protection; 0.1.0 displays the recorded `key_id` but does
+> not check it against the supplied key, so a relabeled `key_id` on an
+> otherwise-valid signature would silently PASS on 0.1.0 and FAIL as
+> signer-label tampering on 0.1.1. This fixture's `key_id` is correctly bound,
+> so its output is identical on both versions (see the intro above).
 
 ```bash
 # 1. Install the standalone verifier into a clean environment

--- a/docs/compliance/ODR_VERIFICATION_WALKTHROUGH.md
+++ b/docs/compliance/ODR_VERIFICATION_WALKTHROUGH.md
@@ -54,22 +54,20 @@ the public key that verifies it. The only tool needed is **`aragora-verify`**,
 a free, standalone, MIT-licensed verifier published on PyPI whose only
 dependency is the `cryptography` package.
 
-> PyPI release verified: `pip install aragora-verify==0.1.0` from a clean
-> venv (real PyPI, no local wheel) installed and verified this fixture with
-> all checks PASS on 2026-07-02. CI additionally smoke-tests the CLI against
-> a wheel built from the in-repo [`aragora-verify/`](../../aragora-verify/)
-> source. **Version note (corrected 2026-07-04):** the signer-label (`key_id`)
-> binding described in §"What each check proves" ships in 0.1.1, published to
-> PyPI on 2026-07-04 (self-verify: `curl -s
-> https://pypi.org/pypi/aragora-verify/json`). 0.1.0 verifies content
-> integrity and signature validity but does not bind the recorded `key_id` to
-> the supplied key — prefer `pip install "aragora-verify>=0.1.1"` or the
-> source build for full signer-label protection.
+> PyPI release verified: the public index lists `aragora-verify` 0.1.1 as the
+> latest release (self-verify: `python3 -m pip index versions aragora-verify`
+> or `curl -s https://pypi.org/pypi/aragora-verify/json`). CI additionally
+> smoke-tests the CLI against a wheel built from the in-repo
+> [`aragora-verify/`](../../aragora-verify/) source. **Version note (corrected
+> 2026-07-04):** the signer-label (`key_id`) binding described in §"What each
+> check proves" ships in 0.1.1. Pin `pip install aragora-verify==0.1.1` for
+> full signer-label protection; 0.1.0 verifies content integrity and signature
+> validity but does not bind the recorded `key_id` to the supplied key.
 
 ```bash
 # 1. Install the standalone verifier into a clean environment
 python3 -m venv odr-env && . odr-env/bin/activate
-pip install aragora-verify
+pip install aragora-verify==0.1.1
 
 # 2. Fetch the two fixture files (or copy them from a repo checkout)
 #    docs/compliance/fixtures/sample_decision_receipt.odr.json

--- a/docs/compliance/fixtures/README.md
+++ b/docs/compliance/fixtures/README.md
@@ -12,7 +12,7 @@ Executable sample artifacts for
 Verify the signed receipt with nothing but the standalone verifier:
 
 ```bash
-pip install aragora-verify==0.1.1
+pip install "aragora-verify>=0.1.1"
 aragora-verify sample_decision_receipt.odr.json --pubkey odr_sample_signing_public_key.pem
 ```
 

--- a/docs/compliance/fixtures/README.md
+++ b/docs/compliance/fixtures/README.md
@@ -12,7 +12,7 @@ Executable sample artifacts for
 Verify the signed receipt with nothing but the standalone verifier:
 
 ```bash
-pip install aragora-verify
+pip install aragora-verify==0.1.1
 aragora-verify sample_decision_receipt.odr.json --pubkey odr_sample_signing_public_key.pem
 ```
 

--- a/docs/specs/RECEIPT_LINEAGE_RECONCILIATION.md
+++ b/docs/specs/RECEIPT_LINEAGE_RECONCILIATION.md
@@ -64,15 +64,19 @@ must be kept in lockstep:
    document. `odr_verify.py` is exercised today by its own test suite
    (`tests/gauntlet/test_odr_verify.py`, `tests/gauntlet/test_odr_verify_schema.py`)
    and is available for internal callers to import directly.
-2. **`aragora-verify`** (this repo's standalone `aragora-verify/` package) — the
-   "no-trust" path: pure stdlib + `cryptography`, zero Aragora dependency, with its
-   own real CLI entry point
+2. **`aragora-verify`** (this repo's standalone `aragora-verify/` package, **published
+   on PyPI**) — the "no-trust" path: pure stdlib + `cryptography`, zero Aragora
+   dependency, with its own real CLI entry point
    (`aragora-verify RECEIPT.odr.json [--pubkey KEY.pem] [--chain CHAIN.jsonl]`) for an
-   external auditor who has never installed Aragora. **Not yet on PyPI:** the publish
-   workflow merged via #8693, but no release has been run, so today the verifier is
-   invoked locally — `PYTHONPATH=src python -m aragora_verify <r>.odr.json` from
-   `aragora-verify/`, or `pip install ./aragora-verify` for the `aragora-verify`
-   console script. PyPI publish is pending until a release actually runs.
+   external auditor who has never installed Aragora. `aragora-verify` 0.1.0 has been
+   live on PyPI since **2026-06-29T23:32Z** (GitHub release
+   [`aragora-verify-v0.1.0`](https://github.com/synaptent/aragora/releases/tag/aragora-verify-v0.1.0),
+   uploaded via Trusted Publishing ~24s after #8693 merged); `pip install
+   aragora-verify` installs it from the public index today. Self-verify rather than
+   trust this sentence: `curl -s https://pypi.org/pypi/aragora-verify/json`. To
+   exercise this exact checkout instead of the published package, run
+   `PYTHONPATH=src python -m aragora_verify <r>.odr.json` from `aragora-verify/`, or
+   `pip install ./aragora-verify` for a local `aragora-verify` console script.
 
 Both engines are hand-rolled, dependency-light mirrors of the same normative artifact
 — `aragora/gauntlet/odr_schema.json`, also bundled inside the `aragora-verify` package

--- a/docs/specs/RECEIPT_LINEAGE_RECONCILIATION.md
+++ b/docs/specs/RECEIPT_LINEAGE_RECONCILIATION.md
@@ -68,12 +68,13 @@ must be kept in lockstep:
    on PyPI**) — the "no-trust" path: pure stdlib + `cryptography`, zero Aragora
    dependency, with its own real CLI entry point
    (`aragora-verify RECEIPT.odr.json [--pubkey KEY.pem] [--chain CHAIN.jsonl]`) for an
-   external auditor who has never installed Aragora. `aragora-verify` 0.1.0 has been
-   live on PyPI since **2026-06-29T23:32Z** (GitHub release
-   [`aragora-verify-v0.1.0`](https://github.com/synaptent/aragora/releases/tag/aragora-verify-v0.1.0),
-   uploaded via Trusted Publishing ~24s after #8693 merged); `pip install
-   aragora-verify` installs it from the public index today. Self-verify rather than
-   trust this sentence: `curl -s https://pypi.org/pypi/aragora-verify/json`. To
+   external auditor who has never installed Aragora. `aragora-verify` is live on
+   PyPI; 0.1.1 is the latest published version, and 0.1.0 was first published
+   2026-06-29T23:32Z (GitHub release
+   [`aragora-verify-v0.1.0`](https://github.com/synaptent/aragora/releases/tag/aragora-verify-v0.1.0)).
+   Use `pip install aragora-verify==0.1.1` for the public-index verifier today.
+   Self-verify rather than trust this sentence: `python3 -m pip index versions
+   aragora-verify` or `curl -s https://pypi.org/pypi/aragora-verify/json`. To
    exercise this exact checkout instead of the published package, run
    `PYTHONPATH=src python -m aragora_verify <r>.odr.json` from `aragora-verify/`, or
    `pip install ./aragora-verify` for a local `aragora-verify` console script.

--- a/docs/specs/RECEIPT_LINEAGE_RECONCILIATION.md
+++ b/docs/specs/RECEIPT_LINEAGE_RECONCILIATION.md
@@ -72,7 +72,7 @@ must be kept in lockstep:
    PyPI; 0.1.1 is the latest published version, and 0.1.0 was first published
    2026-06-29T23:32Z (GitHub release
    [`aragora-verify-v0.1.0`](https://github.com/synaptent/aragora/releases/tag/aragora-verify-v0.1.0)).
-   Use `pip install aragora-verify==0.1.1` for the public-index verifier today.
+   Use `pip install "aragora-verify>=0.1.1"` for the public-index verifier today.
    Self-verify rather than trust this sentence: `python3 -m pip index versions
    aragora-verify` or `curl -s https://pypi.org/pypi/aragora-verify/json`. To
    exercise this exact checkout instead of the published package, run

--- a/docs/status/PUBLIC_UTILITY_MISSION_BASELINE.md
+++ b/docs/status/PUBLIC_UTILITY_MISSION_BASELINE.md
@@ -15,11 +15,13 @@ aspirational; where a capability does not exist yet it is labeled a **gap**, not
 
 > **Correction (2026-07-04):** §3.1, §3.3, and §7 below describe `aragora-verify` PyPI
 > publishing as "pending" as of the 2026-07-02 snapshot. That premise was **false even
-> at snapshot time**: Trusted Publishing fired automatically ~24s after #8693 merged, and
-> `aragora-verify` 0.1.0 has been live on PyPI since **2026-06-29T23:32Z** (GitHub release
+> at snapshot time**: Trusted Publishing published `aragora-verify`; 0.1.0 has
+> been live on PyPI since **2026-06-29T23:32Z** (GitHub release
 > [`aragora-verify-v0.1.0`](https://github.com/synaptent/aragora/releases/tag/aragora-verify-v0.1.0),
-> not yanked). `pip install aragora-verify` works from the public index today.
-> Self-verify: `curl -s https://pypi.org/pypi/aragora-verify/json`. See
+> not yanked), and 0.1.1 is now the latest version. `pip install
+> aragora-verify==0.1.1` works from the public index today. Self-verify:
+> `python3 -m pip index versions aragora-verify` or
+> `curl -s https://pypi.org/pypi/aragora-verify/json`. See
 > `docs/specs/RECEIPT_LINEAGE_RECONCILIATION.md` for the corrected verifier-install story.
 > The sections below are left as originally snapshotted, with the affected passages
 > marked "Corrected 2026-07-04" inline, so this document's as-of framing stays intact.
@@ -148,7 +150,7 @@ open PR #8713, see §7).
 | `aragora` | `pyproject.toml` (root) | 2.9.0 | `pip install aragora` (PyPI, badge confirms) or `pip install -e .` from a clone (`INSTALL.md`) |
 | `aragora-debate` | `aragora-debate/pyproject.toml` | 0.2.3 | `pip install aragora-debate` (`docs/quickstart.md`) — small standalone debate wedge |
 | `aragora-sdk` | `sdk/python/pyproject.toml` | 2.9.0 | `pip install ./sdk/python` (local; no PyPI badge found for this one) |
-| `aragora-verify` | `aragora-verify/pyproject.toml` | 0.1.0 (snapshot); 0.1.1 latest | **Corrected 2026-07-04 — PUBLISHED:** `pip install aragora-verify` installs it from PyPI (live since **2026-06-29T23:32Z**, GitHub release `aragora-verify-v0.1.0`; self-verify `curl -s https://pypi.org/pypi/aragora-verify/json`). From-checkout alternatives remain available: `cd aragora-verify && PYTHONPATH=src python -m aragora_verify <file>`, or `pip install ./aragora-verify` for a local console script. *(Snapshotted 2026-07-02 as "no release has been run yet" — that premise was false; see the correction note near the top of this document.)* |
+| `aragora-verify` | `aragora-verify/pyproject.toml` | 0.1.0 (snapshot); 0.1.1 latest | **Corrected 2026-07-04 — PUBLISHED:** `pip install aragora-verify==0.1.1` installs the current verifier from PyPI (0.1.0 live since **2026-06-29T23:32Z**, GitHub release `aragora-verify-v0.1.0`; 0.1.1 is now latest; self-verify `python3 -m pip index versions aragora-verify` or `curl -s https://pypi.org/pypi/aragora-verify/json`). From-checkout alternatives remain available: `cd aragora-verify && PYTHONPATH=src python -m aragora_verify <file>`, or `pip install ./aragora-verify` for a local console script. *(Snapshotted 2026-07-02 as "no release has been run yet" — that premise was false; see the correction note near the top of this document.)* |
 
 A packaging-level drift also exists but is not a docs problem: `aragora-verify`'s runtime floor is
 `cryptography>=41.0` while the root `[tool.uv] constraint-dependencies` floor is `>=48.0.1` (fixes
@@ -286,10 +288,12 @@ paths in a later milestone.
   ladder" sections; see §3.1).
 - **#8692** — dependency refresh — **MERGED** 2026-06-30.
 - **#8693** — `aragora-verify` PyPI publish workflow — **MERGED** 2026-06-29. **Corrected
-  2026-07-04:** Trusted Publishing fired automatically ~24s after this merge — `aragora-verify`
-  0.1.0 has been live on PyPI since 2026-06-29T23:32Z (see §3.3). The snapshot's original
+  2026-07-04:** Trusted Publishing published `aragora-verify` after this merge; 0.1.0
+  has been live on PyPI since 2026-06-29T23:32Z, and 0.1.1 is now the latest
+  public-index version (see §3.3). The snapshot's original
   guidance here ("no release has actually been published yet... do not assert `pip install
-  aragora-verify`") was incorrect even at the time; `pip install aragora-verify` works today.
+  aragora-verify`") was incorrect even at the time; `pip install aragora-verify==0.1.1`
+  works today.
 - **#8694** — read-only reconcile/settle CLI — **CLOSED, unmerged**, 2026-06-30.
 
 Additionally, `docs/plans/2026-06-30-*.md` (once untracked scratch content) is now **tracked** repo

--- a/docs/status/PUBLIC_UTILITY_MISSION_BASELINE.md
+++ b/docs/status/PUBLIC_UTILITY_MISSION_BASELINE.md
@@ -19,7 +19,7 @@ aspirational; where a capability does not exist yet it is labeled a **gap**, not
 > been live on PyPI since **2026-06-29T23:32Z** (GitHub release
 > [`aragora-verify-v0.1.0`](https://github.com/synaptent/aragora/releases/tag/aragora-verify-v0.1.0),
 > not yanked), and 0.1.1 is now the latest version. `pip install
-> aragora-verify==0.1.1` works from the public index today. Self-verify:
+> "aragora-verify>=0.1.1"` works from the public index today. Self-verify:
 > `python3 -m pip index versions aragora-verify` or
 > `curl -s https://pypi.org/pypi/aragora-verify/json`. See
 > `docs/specs/RECEIPT_LINEAGE_RECONCILIATION.md` for the corrected verifier-install story.
@@ -150,7 +150,7 @@ open PR #8713, see §7).
 | `aragora` | `pyproject.toml` (root) | 2.9.0 | `pip install aragora` (PyPI, badge confirms) or `pip install -e .` from a clone (`INSTALL.md`) |
 | `aragora-debate` | `aragora-debate/pyproject.toml` | 0.2.3 | `pip install aragora-debate` (`docs/quickstart.md`) — small standalone debate wedge |
 | `aragora-sdk` | `sdk/python/pyproject.toml` | 2.9.0 | `pip install ./sdk/python` (local; no PyPI badge found for this one) |
-| `aragora-verify` | `aragora-verify/pyproject.toml` | 0.1.0 (snapshot); 0.1.1 latest | **Corrected 2026-07-04 — PUBLISHED:** `pip install aragora-verify==0.1.1` installs the current verifier from PyPI (0.1.0 live since **2026-06-29T23:32Z**, GitHub release `aragora-verify-v0.1.0`; 0.1.1 is now latest; self-verify `python3 -m pip index versions aragora-verify` or `curl -s https://pypi.org/pypi/aragora-verify/json`). From-checkout alternatives remain available: `cd aragora-verify && PYTHONPATH=src python -m aragora_verify <file>`, or `pip install ./aragora-verify` for a local console script. *(Snapshotted 2026-07-02 as "no release has been run yet" — that premise was false; see the correction note near the top of this document.)* |
+| `aragora-verify` | `aragora-verify/pyproject.toml` | 0.1.0 (snapshot); 0.1.1 latest | **Corrected 2026-07-04 — PUBLISHED:** `pip install "aragora-verify>=0.1.1"` installs the current verifier from PyPI (0.1.0 live since **2026-06-29T23:32Z**, GitHub release `aragora-verify-v0.1.0`; 0.1.1 is now latest; self-verify `python3 -m pip index versions aragora-verify` or `curl -s https://pypi.org/pypi/aragora-verify/json`). From-checkout alternatives remain available: `cd aragora-verify && PYTHONPATH=src python -m aragora_verify <file>`, or `pip install ./aragora-verify` for a local console script. *(Snapshotted 2026-07-02 as "no release has been run yet" — that premise was false; see the correction note near the top of this document.)* |
 
 A packaging-level drift also exists but is not a docs problem: `aragora-verify`'s runtime floor is
 `cryptography>=41.0` while the root `[tool.uv] constraint-dependencies` floor is `>=48.0.1` (fixes
@@ -292,7 +292,7 @@ paths in a later milestone.
   has been live on PyPI since 2026-06-29T23:32Z, and 0.1.1 is now the latest
   public-index version (see §3.3). The snapshot's original
   guidance here ("no release has actually been published yet... do not assert `pip install
-  aragora-verify`") was incorrect even at the time; `pip install aragora-verify==0.1.1`
+  aragora-verify`") was incorrect even at the time; `pip install "aragora-verify>=0.1.1"`
   works today.
 - **#8694** — read-only reconcile/settle CLI — **CLOSED, unmerged**, 2026-06-30.
 

--- a/docs/status/PUBLIC_UTILITY_MISSION_BASELINE.md
+++ b/docs/status/PUBLIC_UTILITY_MISSION_BASELINE.md
@@ -13,6 +13,17 @@ Every factual claim below was verified directly against `origin/main` at commit 
 (2026-07-02) using `grep`/`diff`/`wc`/`gh` — see §8 for the exact commands. Nothing here is
 aspirational; where a capability does not exist yet it is labeled a **gap**, not implied to ship.
 
+> **Correction (2026-07-04):** §3.1, §3.3, and §7 below describe `aragora-verify` PyPI
+> publishing as "pending" as of the 2026-07-02 snapshot. That premise was **false even
+> at snapshot time**: Trusted Publishing fired automatically ~24s after #8693 merged, and
+> `aragora-verify` 0.1.0 has been live on PyPI since **2026-06-29T23:32Z** (GitHub release
+> [`aragora-verify-v0.1.0`](https://github.com/synaptent/aragora/releases/tag/aragora-verify-v0.1.0),
+> not yanked). `pip install aragora-verify` works from the public index today.
+> Self-verify: `curl -s https://pypi.org/pypi/aragora-verify/json`. See
+> `docs/specs/RECEIPT_LINEAGE_RECONCILIATION.md` for the corrected verifier-install story.
+> The sections below are left as originally snapshotted, with the affected passages
+> marked "Corrected 2026-07-04" inline, so this document's as-of framing stays intact.
+
 ---
 
 ## 1. Receipt lineages (as-is) and the canonical statement
@@ -105,8 +116,11 @@ targeted at M4):
   (line 215) and `### Honest current state *(docs/HONEST_ASSESSMENT.md, docs/GA_CHECKLIST.md)*`
   (line 503). Both section headings exist verbatim. This satisfies the mission's non-negotiable
   invariant (architecture.md §5.1) — the mission must not delete or water down this content.
-- A PyPI badge (`https://pypi.org/project/aragora/`) is present for the root `aragora` package; the
-  verifier row in the README's own comparison table states `aragora-verify` "PyPI publish pending".
+- A PyPI badge (`https://pypi.org/project/aragora/`) is present for the root `aragora` package; at
+  snapshot time the verifier row in the README's own comparison table stated `aragora-verify`
+  "PyPI publish pending". **Corrected 2026-07-04:** that line (and the premise behind it) was
+  false even at snapshot time — see the correction note above; README's own row is fixed by a
+  separate PR (#8824).
 
 ### 3.2 pyproject.toml — "Decision Integrity Platform" drift persists
 
@@ -134,7 +148,7 @@ open PR #8713, see §7).
 | `aragora` | `pyproject.toml` (root) | 2.9.0 | `pip install aragora` (PyPI, badge confirms) or `pip install -e .` from a clone (`INSTALL.md`) |
 | `aragora-debate` | `aragora-debate/pyproject.toml` | 0.2.3 | `pip install aragora-debate` (`docs/quickstart.md`) — small standalone debate wedge |
 | `aragora-sdk` | `sdk/python/pyproject.toml` | 2.9.0 | `pip install ./sdk/python` (local; no PyPI badge found for this one) |
-| `aragora-verify` | `aragora-verify/pyproject.toml` | 0.1.0 | **Local only**: `cd aragora-verify && PYTHONPATH=src python -m aragora_verify <file>`, or `pip install ./aragora-verify` for the console script. PyPI publish workflow **merged** (#8693) but **no release has been run yet** — `pip install aragora-verify` from PyPI does **not** work today. |
+| `aragora-verify` | `aragora-verify/pyproject.toml` | 0.1.0 (snapshot); 0.1.1 latest | **Corrected 2026-07-04 — PUBLISHED:** `pip install aragora-verify` installs it from PyPI (live since **2026-06-29T23:32Z**, GitHub release `aragora-verify-v0.1.0`; self-verify `curl -s https://pypi.org/pypi/aragora-verify/json`). From-checkout alternatives remain available: `cd aragora-verify && PYTHONPATH=src python -m aragora_verify <file>`, or `pip install ./aragora-verify` for a local console script. *(Snapshotted 2026-07-02 as "no release has been run yet" — that premise was false; see the correction note near the top of this document.)* |
 
 A packaging-level drift also exists but is not a docs problem: `aragora-verify`'s runtime floor is
 `cryptography>=41.0` while the root `[tool.uv] constraint-dependencies` floor is `>=48.0.1` (fixes
@@ -271,9 +285,11 @@ paths in a later milestone.
 - **#8674** — README rewrite — **MERGED** 2026-06-29 (added the "Honest current state" + "Proof
   ladder" sections; see §3.1).
 - **#8692** — dependency refresh — **MERGED** 2026-06-30.
-- **#8693** — `aragora-verify` PyPI publish workflow — **MERGED** 2026-06-29. The workflow exists;
-  **no release has actually been published yet** (see §3.3) — do not assert `pip install
-  aragora-verify` from PyPI in any doc.
+- **#8693** — `aragora-verify` PyPI publish workflow — **MERGED** 2026-06-29. **Corrected
+  2026-07-04:** Trusted Publishing fired automatically ~24s after this merge — `aragora-verify`
+  0.1.0 has been live on PyPI since 2026-06-29T23:32Z (see §3.3). The snapshot's original
+  guidance here ("no release has actually been published yet... do not assert `pip install
+  aragora-verify`") was incorrect even at the time; `pip install aragora-verify` works today.
 - **#8694** — read-only reconcile/settle CLI — **CLOSED, unmerged**, 2026-06-30.
 
 Additionally, `docs/plans/2026-06-30-*.md` (once untracked scratch content) is now **tracked** repo


### PR DESCRIPTION
## What

Corrects a FALSE "PyPI publish pending" premise for `aragora-verify` across mission docs.

**Live-verified 2026-07-04** (not trusting any prior doc's claim):
- `curl -s https://pypi.org/pypi/aragora-verify/json` → releases `['0.1.0', '0.1.1']`, latest `0.1.1` (not yanked); `0.1.0` uploaded `2026-06-29T23:32:49Z`, `0.1.1` uploaded `2026-07-04T03:28:00Z`.
- `gh release list` → `aragora-verify v0.1.0` (2026-06-29T23:32:49Z), `aragora-verify v0.1.1` (Latest, 2026-07-04T03:28:05Z).
- `pip install aragora-verify` installs from the public index today.

## Files changed

1. **`docs/specs/RECEIPT_LINEAGE_RECONCILIATION.md`** — PR #8829 regressed an accurate "published to PyPI" line to a false "Not yet on PyPI ... publish is pending" claim. Rewritten to the verified PUBLISHED status with a self-verify one-liner, keeping the from-checkout invocation options (`PYTHONPATH=src python -m aragora_verify` / `pip install ./aragora-verify`).
2. **`docs/status/PUBLIC_UTILITY_MISSION_BASELINE.md`** — this M0 baseline is an explicit dated snapshot ("Snapshot date: 2026-07-02"). Added a dated correction blockquote near the top, plus inline "Corrected 2026-07-04" annotations at each of the 3 spots (§3.1, §3.3 distribution table, §7 PR-history bullet) that repeated the stale premise — the original snapshot text is preserved for historical honesty, with the correction layered on top, consistent with the doc's as-of framing.
3. **`docs/compliance/ODR_VERIFICATION_WALKTHROUGH.md`** (discovered via full-repo grep sweep for other `aragora-verify` PyPI-pending claims) — its "Version note" said the 0.1.1 signer-label binding "ships in 0.1.1 (in-repo source; PyPI publication pending)". 0.1.1 is now itself published (2026-07-04), so this is corrected too.

**`README.md` intentionally left untouched** — live path-freeze check (`gh pr view 8824 --json state,files`) confirms open PR #8824 ("docs(readme): verifier is on PyPI, 15-second demo path, dogfooding proof link") independently and solely owns README's PyPI-status row; never co-edited.

Wording kept consistent with the (still-open) `docs/specs/INDEPENDENT_VERIFIER_GUIDE.md` (PR #8832), which already documents this exact correction ("Some existing docs ... describe `aragora-verify` as 'PyPI publish pending' ... The first release, `aragora-verify` 0.1.0, has been live on PyPI since 2026-06-29").

Also swept `docs/ROADMAP_30_60_90.md`'s "PyPI publish pending" hit — left untouched, it is about the unrelated `aragora-debate` package in a historical, already-checked-off Day-60 roadmap entry, not `aragora-verify`.

## Verification

- `make docs-check` → PASS (all 4 checks pass, 0 findings).
- `python3 scripts/validate_doc_links.py` → "All documentation links are valid!" (exit 0).
- `python scripts/doc_stats.py --write && node docs-site/scripts/sync-docs.js` → 0 mirror diff (none of the 3 touched files are in the `docs-site` `DOC_MAP`; `docs/specs/**`, `docs/status/**`, `docs/compliance/**` here are outside the mirror set).
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` → `preflight: ok` (docs-only diff detected).

Docs-only, ≤800 LOC (40 lines changed). No frozen/gated files touched.

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>
