### PR TITLE
docs: sweep 'publish pending' hedges — aragora-verify 0.1.1 is live on PyPI (verified)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ multi-model review in, a verifiable Decision Receipt out.**
 It coordinates heterogeneous models to adversarially review a change or a
 decision, preserves the dissent and provenance, stops truthfully when evidence
 is thin, and emits a portable receipt anyone can verify offline with the
-standalone verifier ([`pip install aragora-verify`](https://pypi.org/project/aragora-verify/)).
+standalone verifier ([`pip install -U 'aragora-verify>=0.1.1'`](https://pypi.org/project/aragora-verify/)).
 
 [![PyPI](https://img.shields.io/pypi/v/aragora)](https://pypi.org/project/aragora/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -18,7 +18,7 @@ standalone verifier ([`pip install aragora-verify`](https://pypi.org/project/ara
 | I want to… | Command |
 |------------|---------|
 | Run the standalone debate engine | `pip install aragora-debate` |
-| Verify an Open Decision Receipt with the standalone verifier | `pip install aragora-verify && aragora-verify receipt.odr.json` |
+| Verify an Open Decision Receipt with the standalone verifier | `pip install -U 'aragora-verify>=0.1.1' && aragora-verify receipt.odr.json` |
 | See a native debate → receipt → verify loop in ~15 seconds, no API keys | `pip install aragora && aragora demo --offline && aragora verify aragora-demo-receipt.json` |
 | Call the Aragora API from Python | `pip install aragora-sdk` |
 | Self-host the full platform | `docker compose -f deploy/demo/docker-compose.yml up` |
@@ -70,7 +70,7 @@ auditor, a customer — can verify it independently with the standalone
 `aragora-verify` verifier (no Aragora dependency):
 
 ```bash
-pip install aragora-verify
+pip install -U 'aragora-verify>=0.1.1'
 aragora-verify decision-receipt.odr.json
 
 # Add a public key when you need issuer authenticity, not just structure/digest:

--- a/README.md
+++ b/README.md
@@ -80,11 +80,9 @@ aragora-verify decision-receipt.odr.json --pubkey signing-key.pem
 pip install ./aragora-verify
 ```
 
-> Version note: the signer-label (`key_id`) binding fix ships in **0.1.1**
-> (in this repo now; PyPI publish pending — see `aragora-verify/CHANGELOG.md`).
-> Until it's published, prefer the source build above for full signer-label
-> protection; PyPI **0.1.0** verifies content integrity and signature validity
-> but does not bind the recorded `key_id` to your key.
+> Use **0.1.1+** (`pip install 'aragora-verify>=0.1.1'`): it binds each
+> signature's recorded `key_id` to the key you supply, so a relabeled signer
+> fails as tampering. 0.1.0 lacks that binding — upgrade if you have it.
 
 We run this gate on our own repository — every substantive merge is reviewed
 by a heterogeneous model quorum, dissent preserved, receipts written. The

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ aragora-verify decision-receipt.odr.json --pubkey signing-key.pem
 pip install ./aragora-verify
 ```
 
-> Use **0.1.1+** (`pip install 'aragora-verify>=0.1.1'`): it binds each
+> Use **0.1.1+** (`pip install -U 'aragora-verify>=0.1.1'`): it binds each
 > signature's recorded `key_id` to the key you supply, so a relabeled signer
 > fails as tampering. 0.1.0 lacks that binding — upgrade if you have it.
 

--- a/aragora-verify/CHANGELOG.md
+++ b/aragora-verify/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `aragora-verify` are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and the project uses semantic
 versioning.
 
-## [0.1.1] — 2026-07-04
+## [0.1.1] — 2026-07-04 (03:28 UTC)
 
 ### Fixed
 - Signature `key_id` binding: a cryptographically valid signature only counts when

--- a/aragora-verify/CHANGELOG.md
+++ b/aragora-verify/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `aragora-verify` are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and the project uses semantic
 versioning.
 
-## [0.1.1] — unreleased (on main; PyPI publish pending)
+## [0.1.1] — 2026-07-04
 
 ### Fixed
 - Signature `key_id` binding: a cryptographically valid signature only counts when

--- a/docs/compliance/ODR_VERIFICATION_WALKTHROUGH.md
+++ b/docs/compliance/ODR_VERIFICATION_WALKTHROUGH.md
@@ -54,13 +54,15 @@ the public key that verifies it. The only tool needed is **`aragora-verify`**,
 a free, standalone, MIT-licensed verifier published on PyPI whose only
 dependency is the `cryptography` package.
 
-> PyPI install target: `pip install -U 'aragora-verify>=0.1.1'` from a clean
-> venv (real PyPI, no local wheel). Version 0.1.1+ (published 2026-07-04
-> 03:28 UTC; verify live: https://pypi.org/pypi/aragora-verify/json) binds each
-> signature's recorded `key_id` to the supplied key, so a relabeled signer fails
-> as tampering. Earlier 0.1.0 verification on 2026-07-02 covered content
-> integrity and signature validity but lacked that binding. CI additionally
-> smoke-tests the CLI against a wheel built from the in-repo
+> PyPI release verified: `pip install -U 'aragora-verify>=0.1.1'` from a clean
+> venv (real PyPI, no local wheel) installed `aragora-verify-0.1.1` and verified
+> this fixture with all checks PASS on 2026-07-04. Version 0.1.1+ (published
+> 2026-07-04 03:28 UTC; verify live:
+> https://pypi.org/pypi/aragora-verify/json) binds each signature's recorded
+> `key_id` to the supplied key, so a relabeled signer fails as tampering.
+> Earlier 0.1.0 verification on 2026-07-02 covered content integrity and
+> signature validity but lacked that binding. CI additionally smoke-tests the
+> CLI against a wheel built from the in-repo
 > [`aragora-verify/`](../../aragora-verify/) source.
 
 ```bash

--- a/docs/compliance/ODR_VERIFICATION_WALKTHROUGH.md
+++ b/docs/compliance/ODR_VERIFICATION_WALKTHROUGH.md
@@ -58,11 +58,10 @@ dependency is the `cryptography` package.
 > venv (real PyPI, no local wheel) installed and verified this fixture with
 > all checks PASS on 2026-07-02. CI additionally smoke-tests the CLI against
 > a wheel built from the in-repo [`aragora-verify/`](../../aragora-verify/)
-> source. **Version note:** the signer-label (`key_id`) binding described in
-> §"What each check proves" ships in 0.1.1 (in-repo source; PyPI publication
-> pending). 0.1.0 verifies content integrity and signature validity but does
-> not bind the recorded `key_id` to the supplied key — prefer 0.1.1+ or the
-> source build for full signer-label protection.
+> source. **Version note:** use 0.1.1+ (`pip install 'aragora-verify>=0.1.1'`,
+> published 2026-07-04) — it binds each signature's recorded `key_id` to the
+> supplied key, so a relabeled signer fails as tampering. 0.1.0 verifies
+> content integrity and signature validity but lacks that binding.
 
 ```bash
 # 1. Install the standalone verifier into a clean environment

--- a/docs/compliance/ODR_VERIFICATION_WALKTHROUGH.md
+++ b/docs/compliance/ODR_VERIFICATION_WALKTHROUGH.md
@@ -59,7 +59,7 @@ dependency is the `cryptography` package.
 > all checks PASS on 2026-07-02. CI additionally smoke-tests the CLI against
 > a wheel built from the in-repo [`aragora-verify/`](../../aragora-verify/)
 > source. **Version note:** use 0.1.1+ (`pip install 'aragora-verify>=0.1.1'`,
-> published 2026-07-04) — it binds each signature's recorded `key_id` to the
+> published 2026-07-04 03:28 UTC; verify live: https://pypi.org/pypi/aragora-verify/json) — it binds each signature's recorded `key_id` to the
 > supplied key, so a relabeled signer fails as tampering. 0.1.0 verifies
 > content integrity and signature validity but lacks that binding.
 

--- a/docs/compliance/ODR_VERIFICATION_WALKTHROUGH.md
+++ b/docs/compliance/ODR_VERIFICATION_WALKTHROUGH.md
@@ -54,19 +54,19 @@ the public key that verifies it. The only tool needed is **`aragora-verify`**,
 a free, standalone, MIT-licensed verifier published on PyPI whose only
 dependency is the `cryptography` package.
 
-> PyPI release verified: `pip install aragora-verify==0.1.0` from a clean
-> venv (real PyPI, no local wheel) installed and verified this fixture with
-> all checks PASS on 2026-07-02. CI additionally smoke-tests the CLI against
-> a wheel built from the in-repo [`aragora-verify/`](../../aragora-verify/)
-> source. **Version note:** use 0.1.1+ (`pip install 'aragora-verify>=0.1.1'`,
-> published 2026-07-04 03:28 UTC; verify live: https://pypi.org/pypi/aragora-verify/json) — it binds each signature's recorded `key_id` to the
-> supplied key, so a relabeled signer fails as tampering. 0.1.0 verifies
-> content integrity and signature validity but lacks that binding.
+> PyPI install target: `pip install -U 'aragora-verify>=0.1.1'` from a clean
+> venv (real PyPI, no local wheel). Version 0.1.1+ (published 2026-07-04
+> 03:28 UTC; verify live: https://pypi.org/pypi/aragora-verify/json) binds each
+> signature's recorded `key_id` to the supplied key, so a relabeled signer fails
+> as tampering. Earlier 0.1.0 verification on 2026-07-02 covered content
+> integrity and signature validity but lacked that binding. CI additionally
+> smoke-tests the CLI against a wheel built from the in-repo
+> [`aragora-verify/`](../../aragora-verify/) source.
 
 ```bash
 # 1. Install the standalone verifier into a clean environment
 python3 -m venv odr-env && . odr-env/bin/activate
-pip install aragora-verify
+pip install -U 'aragora-verify>=0.1.1'
 
 # 2. Fetch the two fixture files (or copy them from a repo checkout)
 #    docs/compliance/fixtures/sample_decision_receipt.odr.json


### PR DESCRIPTION
aragora-verify **0.1.1 published to PyPI 2026-07-04** via the trusted-publishing workflow (run 28693457229) and verified from a clean venv against the compliance fixtures: real receipt → VERIFIED exit 0; spoofed `key_id` → FAILED exit 1 with the signer-label-tampering message (the fix 0.1.0 lacks).

This sweeps the three hedges that existed only because publication was pending:
- `aragora-verify/CHANGELOG.md`: 0.1.1 dated
- `README.md`: version note → 'use 0.1.1+' with the one-line security reason
- `docs/compliance/ODR_VERIFICATION_WALKTHROUGH.md`: same

Every claim the repo makes about the verifier is now unconditionally true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)