### PR TITLE
test: add ODR verifier key_id parity coverage

### DIFF
--- a/tests/gauntlet/odr_parity_fixtures.py
+++ b/tests/gauntlet/odr_parity_fixtures.py
@@ -1,0 +1,121 @@
+"""Shared ODR signature parity fixtures for in-repo and standalone verifiers."""
+
+from __future__ import annotations
+
+import base64
+import copy
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+
+@dataclass(frozen=True)
+class ODRSignatureParityCase:
+    name: str
+    doc: dict[str, Any]
+    public_key_pem: bytes
+    expected_ok: bool
+    expected_signature_status: str
+
+
+def valid_odr() -> dict[str, Any]:
+    return {
+        "odr_version": "0.1",
+        "profile": "https://aragora.ai/specs/open-decision-receipt/v0.1",
+        "receipt_id": "rcpt-0001",
+        "issued_at": "2026-06-14T00:00:00Z",
+        "subject": {
+            "identifier": "5f1b14e4b5e113dc978d60d1f6bd21b5a478c744",
+            "digest": {"status": "present", "alg": "sha-256", "value": "deadbeef"},
+            "summary": "PR #8360",
+        },
+        "claim": {"verdict": "PASS", "statement": "merge PR #8360"},
+        "reasoning": {"status": "present", "summary": "all checks green; quorum reached"},
+        "quorum": {
+            "status": "present",
+            "method": "majority",
+            "reached": True,
+            "supporting_agents": ["claude", "grok"],
+            "participants": [
+                {"agent": "claude", "model_family": "anthropic", "model_id": "claude-opus-4-8"},
+                {"agent": "grok", "model_family": "xai", "model_id": "grok-4"},
+            ],
+            "independence": {
+                "disclosed": True,
+                "distinct_model_families": 2,
+                "model_families": ["anthropic", "xai"],
+            },
+            "dissent": {"present": False, "dissenting_agents": [], "views": []},
+        },
+        "confidence": {
+            "status": "present",
+            "value": 0.9,
+            "scale": "unit_interval",
+            "calibration": {"status": "absent", "reason": "no calibration record"},
+        },
+        "cruxes": {"status": "absent", "reason": "no crux set supplied"},
+        "attestation": {"disposition": "autonomous"},
+        "routing": {"status": "reserved"},
+        "signatures": [],
+    }
+
+
+def signature_parity_cases(
+    content_digest: Callable[[dict[str, Any]], str],
+    compute_key_id: Callable[[Any], str],
+) -> tuple[ODRSignatureParityCase, ...]:
+    private_key = Ed25519PrivateKey.generate()
+    public_key = private_key.public_key()
+    public_key_pem = public_key.public_bytes(
+        serialization.Encoding.PEM, serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+
+    signed = _sign(valid_odr(), private_key, content_digest, compute_key_id)
+
+    content_tampered = copy.deepcopy(signed)
+    content_tampered["claim"]["verdict"] = "FAIL"
+
+    relabeled_key = copy.deepcopy(signed)
+    relabeled_key["signatures"][0]["key_id"] = "ed25519-deadbeefdeadbeef"
+
+    mixed_multi_signature = copy.deepcopy(signed)
+    relabeled_extra = dict(
+        mixed_multi_signature["signatures"][0],
+        key_id="ed25519-feedfacefeedface",
+    )
+    mixed_multi_signature["signatures"] = [
+        relabeled_extra,
+        mixed_multi_signature["signatures"][0],
+    ]
+
+    return (
+        ODRSignatureParityCase("valid", signed, public_key_pem, True, "pass"),
+        ODRSignatureParityCase("content_tampered", content_tampered, public_key_pem, False, "fail"),
+        ODRSignatureParityCase("relabeled_key", relabeled_key, public_key_pem, False, "fail"),
+        ODRSignatureParityCase(
+            "mixed_multi_signature", mixed_multi_signature, public_key_pem, True, "pass"
+        ),
+    )
+
+
+def _sign(
+    doc: dict[str, Any],
+    private_key: Ed25519PrivateKey,
+    content_digest: Callable[[dict[str, Any]], str],
+    compute_key_id: Callable[[Any], str],
+) -> dict[str, Any]:
+    signed = copy.deepcopy(doc)
+    message = bytes.fromhex(content_digest(signed))
+    signature = private_key.sign(message)
+    signed["signatures"] = [
+        {
+            "alg": "Ed25519",
+            "key_id": compute_key_id(private_key.public_key()),
+            "signature": base64.b64encode(signature).decode("ascii"),
+            "signed_at": "2026-06-14T00:00:01Z",
+        }
+    ]
+    return signed

--- a/tests/gauntlet/test_odr_verify_cross_verifier_parity.py
+++ b/tests/gauntlet/test_odr_verify_cross_verifier_parity.py
@@ -1,0 +1,56 @@
+"""Cross-verifier parity for ODR signature authenticity semantics."""
+
+from __future__ import annotations
+
+import copy
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("cryptography")
+
+_ROOT = Path(__file__).resolve().parents[2]
+_ARAGORA_VERIFY_SRC = _ROOT / "aragora-verify" / "src"
+if str(_ARAGORA_VERIFY_SRC) not in sys.path:
+    sys.path.insert(0, str(_ARAGORA_VERIFY_SRC))
+
+from aragora.gauntlet.odr_export import odr_content_digest  # noqa: E402
+from aragora.gauntlet.odr_verify import (  # noqa: E402
+    compute_key_id,
+    load_public_key as load_in_repo_public_key,
+    verify_odr_document,
+)
+from aragora_verify import (  # noqa: E402
+    load_public_key as load_standalone_public_key,
+    verify as verify_standalone,
+)
+
+from tests.gauntlet.odr_parity_fixtures import signature_parity_cases  # noqa: E402
+
+
+def _check(result: Any, name: str) -> Any:
+    check = next((c for c in result.checks if c.name == name), None)
+    assert check is not None, f"check {name!r} not found in {[c.name for c in result.checks]}"
+    return check
+
+
+@pytest.mark.parametrize(
+    "case",
+    signature_parity_cases(odr_content_digest, compute_key_id),
+    ids=lambda case: case.name,
+)
+def test_signature_key_id_parity_with_aragora_verify_0_1_1(case: Any) -> None:
+    in_repo = verify_odr_document(
+        copy.deepcopy(case.doc),
+        public_key=load_in_repo_public_key(case.public_key_pem),
+    )
+    standalone = verify_standalone(
+        copy.deepcopy(case.doc),
+        public_key=load_standalone_public_key(case.public_key_pem),
+    )
+
+    assert in_repo.ok is standalone.ok is case.expected_ok
+    assert _check(in_repo, "signature").status == case.expected_signature_status
+    assert _check(standalone, "signature").status == case.expected_signature_status


### PR DESCRIPTION
## Summary

Closes #8810.

Live comparison against `aragora-verify` 0.1.1 showed `aragora/gauntlet/odr_verify.py` already agrees for the issue's requested signature-authenticity cases: valid, content-tampered, relabeled-key, and mixed multi-signature receipts. This PR adds shared parity fixtures so that behavior cannot regress.

## What changed

- Added shared ODR signature parity fixtures for both verifier paths.
- Added a cross-verifier test that runs the same receipt objects through `aragora.gauntlet.odr_verify` and the local `aragora-verify` source tree.
- Left production verifier code unchanged because current live semantics already match the 0.1.1 reference for these cases.

## Validation

- `pytest -q tests/gauntlet/test_odr_verify.py tests/gauntlet/test_odr_verify_cross_verifier_parity.py` -> 14 passed
- `PYTHONPATH=aragora-verify/src pytest -q aragora-verify/tests/test_verifier.py` -> 24 passed
- `ruff check tests/gauntlet/odr_parity_fixtures.py tests/gauntlet/test_odr_verify_cross_verifier_parity.py` -> passed
- push hooks: ruff, mypy changed-file hook, gitleaks, portability guard -> passed
