### PR TITLE
fix(tooling): bound agent_session_digest --all so goal-cycle packets never time out

### DIFF
--- a/scripts/agent_session_digest.py
+++ b/scripts/agent_session_digest.py
@@ -73,6 +73,8 @@ def _iter_rollouts(
     since_hours: float | None = None,
     now: float | None = None,
     limit: int | None = MAX_ROLLOUT_SCAN,
+    deadline: float | None = None,
+    timeout_state: dict[str, bool] | None = None,
 ):
     """Yield rollout files newest-first.
 
@@ -89,7 +91,15 @@ def _iter_rollouts(
     candidates: list[tuple[float, Path]] = []
     patterns = ("rollout-*.jsonl", "*/*/*/rollout-*.jsonl")
     for pattern in patterns:
+        if deadline is not None and time.monotonic() >= deadline:
+            if timeout_state is not None:
+                timeout_state["timed_out"] = True
+            break
         for rollout in root.glob(pattern):
+            if deadline is not None and time.monotonic() >= deadline:
+                if timeout_state is not None:
+                    timeout_state["timed_out"] = True
+                break
             try:
                 mtime = rollout.stat().st_mtime
             except OSError:
@@ -97,6 +107,8 @@ def _iter_rollouts(
             if cutoff is not None and mtime < cutoff:
                 continue
             candidates.append((mtime, rollout))
+        if timeout_state is not None and timeout_state.get("timed_out"):
+            break
     candidates.sort(key=lambda item: item[0], reverse=True)
     selected = candidates if limit is None else candidates[:limit]
     for _, rollout in selected:
@@ -132,21 +144,26 @@ def coordinator_view(
     The single cross-agent view: run before editing shared files to see what
     sibling agents are touching (which PRs/files) and avoid collisions.
     """
-    rows: list[dict[str, Any]] = []
-    rollouts = list(_iter_rollouts(root, since_hours=since_hours, now=now))
     deadline = (
         None if time_budget_seconds is None else time.monotonic() + max(0.0, time_budget_seconds)
     )
+    timeout_state: dict[str, bool] = {"timed_out": False}
+    rows: list[dict[str, Any]] = []
+    rollouts = list(
+        _iter_rollouts(
+            root,
+            since_hours=since_hours,
+            now=now,
+            deadline=deadline,
+            timeout_state=timeout_state,
+        )
+    )
+    if timeout_state.get("timed_out") and not rollouts:
+        rows.append(_time_budget_row(None))
+        return rows
     for index, r in enumerate(rollouts):
         if deadline is not None and time.monotonic() >= deadline:
-            rows.append(
-                {
-                    "kind": "skipped",
-                    "reason": "time_budget",
-                    "skipped_rollouts": len(rollouts) - index,
-                    "message": f"skipped {len(rollouts) - index} rollouts (time budget)",
-                }
-            )
+            rows.append(_time_budget_row(len(rollouts) - index))
             break
         turns = extract_turns(r, max_bytes=sample_bytes)
         sid = _rollout_session_id(r, turns.get("session_id"))
@@ -164,6 +181,27 @@ def coordinator_view(
     return rows
 
 
+def _time_budget_row(skipped_rollouts: int | None) -> dict[str, Any]:
+    message = (
+        f"skipped {skipped_rollouts} rollouts (time budget)"
+        if skipped_rollouts is not None
+        else "skipped rollouts (time budget during discovery)"
+    )
+    return {
+        "kind": "skipped",
+        "reason": "time_budget",
+        "skipped_rollouts": skipped_rollouts,
+        "message": message,
+    }
+
+
+def _jsonl_text_lines(chunk: bytes) -> list[str]:
+    lines = chunk.decode("utf-8", errors="replace").split("\n")
+    if lines and lines[-1] == "":
+        lines = lines[:-1]
+    return lines
+
+
 def _sample_rollout_lines(
     rollout: Path, *, max_bytes: int
 ) -> tuple[list[str], dict[str, int | bool]]:
@@ -177,22 +215,28 @@ def _sample_rollout_lines(
         with rollout.open("rb") as handle:
             if file_size <= sample_bytes * 2:
                 body = handle.read()
-                return body.decode("utf-8", errors="replace").splitlines(), {
+                return _jsonl_text_lines(body), {
                     "truncated": False,
                     "file_size": file_size,
                     "bytes_scanned": len(body),
                 }
             head = handle.read(sample_bytes)
-            handle.seek(max(0, file_size - sample_bytes))
+            tail_start = max(0, file_size - sample_bytes)
+            if tail_start > 0:
+                handle.seek(tail_start - 1)
+                byte_before_tail = handle.read(1)
+            else:
+                byte_before_tail = b"\n"
+            handle.seek(tail_start)
             tail = handle.read(sample_bytes)
     except OSError:
         return [], {"truncated": False, "file_size": file_size, "bytes_scanned": 0}
 
-    head_lines = head.decode("utf-8", errors="replace").splitlines()
+    head_lines = _jsonl_text_lines(head)
     if not head.endswith(b"\n") and head_lines:
         head_lines = head_lines[:-1]
-    tail_lines = tail.decode("utf-8", errors="replace").splitlines()
-    if not tail.startswith(b"\n") and tail_lines:
+    tail_lines = _jsonl_text_lines(tail)
+    if byte_before_tail != b"\n" and tail_lines:
         tail_lines = tail_lines[1:]
     return head_lines + tail_lines, {
         "truncated": True,

--- a/scripts/agent_session_digest.py
+++ b/scripts/agent_session_digest.py
@@ -18,6 +18,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import io
 import json
 import os
 import re
@@ -49,6 +50,8 @@ def default_sessions_root() -> Path:
 
 
 MAX_ROLLOUT_SCAN = 200
+COORDINATOR_ROLLOUT_SAMPLE_BYTES = 64 * 1024
+DEFAULT_COORDINATOR_TIME_BUDGET_SECONDS = 90.0
 _PR_RE = re.compile(r"#(\d{3,6})\b")
 _CMD_RE = re.compile(r'"cmd"\s*:\s*"([^"]{0,160})')
 
@@ -117,7 +120,12 @@ def find_rollout(*, path: str | None, session: str | None, latest: bool, root: P
 
 
 def coordinator_view(
-    *, root: Path, since_hours: float, now: float | None = None
+    *,
+    root: Path,
+    since_hours: float,
+    now: float | None = None,
+    sample_bytes: int = COORDINATOR_ROLLOUT_SAMPLE_BYTES,
+    time_budget_seconds: float | None = DEFAULT_COORDINATOR_TIME_BUDGET_SECONDS,
 ) -> list[dict[str, Any]]:
     """Compact per-session digests for every rollout modified within the window.
 
@@ -125,22 +133,75 @@ def coordinator_view(
     sibling agents are touching (which PRs/files) and avoid collisions.
     """
     rows: list[dict[str, Any]] = []
-    for r in _iter_rollouts(root, since_hours=since_hours, now=now):
-        turns = extract_turns(r)
+    rollouts = list(_iter_rollouts(root, since_hours=since_hours, now=now))
+    deadline = (
+        None if time_budget_seconds is None else time.monotonic() + max(0.0, time_budget_seconds)
+    )
+    for index, r in enumerate(rollouts):
+        if deadline is not None and time.monotonic() >= deadline:
+            rows.append(
+                {
+                    "kind": "skipped",
+                    "reason": "time_budget",
+                    "skipped_rollouts": len(rollouts) - index,
+                    "message": f"skipped {len(rollouts) - index} rollouts (time budget)",
+                }
+            )
+            break
+        turns = extract_turns(r, max_bytes=sample_bytes)
         sid = _rollout_session_id(r, turns.get("session_id"))
         rows.append(
             {
+                "kind": "session",
                 "session_id": sid,
                 "rollout": str(r),
                 "counts": turns["counts"],
                 "prs_referenced": turns["prs_referenced"],
                 "last_decision": (turns["decisions"][-1] if turns["decisions"] else ""),
+                "scan": turns.get("scan", {}),
             }
         )
     return rows
 
 
-def extract_turns(rollout: Path) -> dict[str, Any]:
+def _sample_rollout_lines(
+    rollout: Path, *, max_bytes: int
+) -> tuple[list[str], dict[str, int | bool]]:
+    """Return bounded head+tail text lines for large coordinator scans."""
+    sample_bytes = max(1, max_bytes)
+    try:
+        file_size = rollout.stat().st_size
+    except OSError:
+        return [], {"truncated": False, "file_size": 0, "bytes_scanned": 0}
+    try:
+        with rollout.open("rb") as handle:
+            if file_size <= sample_bytes * 2:
+                body = handle.read()
+                return body.decode("utf-8", errors="replace").splitlines(), {
+                    "truncated": False,
+                    "file_size": file_size,
+                    "bytes_scanned": len(body),
+                }
+            head = handle.read(sample_bytes)
+            handle.seek(max(0, file_size - sample_bytes))
+            tail = handle.read(sample_bytes)
+    except OSError:
+        return [], {"truncated": False, "file_size": file_size, "bytes_scanned": 0}
+
+    head_lines = head.decode("utf-8", errors="replace").splitlines()
+    if not head.endswith(b"\n") and head_lines:
+        head_lines = head_lines[:-1]
+    tail_lines = tail.decode("utf-8", errors="replace").splitlines()
+    if not tail.startswith(b"\n") and tail_lines:
+        tail_lines = tail_lines[1:]
+    return head_lines + tail_lines, {
+        "truncated": True,
+        "file_size": file_size,
+        "bytes_scanned": len(head) + len(tail),
+    }
+
+
+def extract_turns(rollout: Path, *, max_bytes: int | None = None) -> dict[str, Any]:
     """Deterministically extract the reviewable signal from a rollout JSONL.
 
     Returns prompts, agent decisions, exec commands, and referenced PRs — without
@@ -163,10 +224,15 @@ def extract_turns(rollout: Path) -> dict[str, Any]:
         seen.add(text)
         bucket.append(text)
 
-    try:
-        handle = rollout.open("r", encoding="utf-8", errors="replace")
-    except OSError:
-        handle = None
+    scan: dict[str, int | bool] = {"truncated": False}
+    if max_bytes is not None:
+        raw_lines, scan = _sample_rollout_lines(rollout, max_bytes=max_bytes)
+        handle = io.StringIO("\n".join(raw_lines))
+    else:
+        try:
+            handle = rollout.open("r", encoding="utf-8", errors="replace")
+        except OSError:
+            handle = None
     if handle is None:
         return {
             "rollout": str(rollout),
@@ -176,6 +242,7 @@ def extract_turns(rollout: Path) -> dict[str, Any]:
             "commands": [],
             "prs_referenced": [],
             "counts": {"prompts": 0, "decisions": 0, "commands": 0, "prs": 0},
+            "scan": scan,
         }
     with handle:
         for raw_line in handle:
@@ -259,6 +326,7 @@ def extract_turns(rollout: Path) -> dict[str, Any]:
             "commands": len(commands),
             "prs": len(prs),
         },
+        "scan": scan,
     }
 
 
@@ -412,6 +480,15 @@ def main(argv: list[str] | None = None) -> int:
         help="With --all: only rollouts modified within this many hours (default 24)",
     )
     ap.add_argument(
+        "--time-budget-seconds",
+        type=float,
+        default=DEFAULT_COORDINATOR_TIME_BUDGET_SECONDS,
+        help=(
+            "With --all: stop coordinator digest after this many seconds and report "
+            "how many rollouts were skipped (default 90; use <=0 to skip immediately)"
+        ),
+    )
+    ap.add_argument(
         "--rlm",
         nargs="?",
         const="Summarize the main actions, files/PRs touched, and any duplicated or wasted work.",
@@ -427,17 +504,26 @@ def main(argv: list[str] | None = None) -> int:
             # --rlm summarizes a single session; it has no effect in coordinator
             # view. Say so rather than silently ignoring it.
             print("note: --rlm is ignored with --all (coordinator view)", file=sys.stderr)
-        lines = coordinator_view(root=Path(args.sessions_root), since_hours=args.since_hours)
+        lines = coordinator_view(
+            root=Path(args.sessions_root),
+            since_hours=args.since_hours,
+            time_budget_seconds=args.time_budget_seconds,
+        )
         if args.json:
             print(json.dumps(lines, indent=2))
         else:
             if not lines:
                 print("no rollouts in window")
             for row in lines:
+                if row.get("kind") == "skipped":
+                    print(row["message"])
+                    continue
                 c = row["counts"]
                 prs = ", ".join("#" + p for p in row["prs_referenced"]) or "none"
+                scan = row.get("scan") or {}
+                sampled = " sampled" if scan.get("truncated") else ""
                 print(
-                    f"{row['session_id']}  {c['commands']}cmds {c['decisions']}dec  "
+                    f"{row['session_id']}  {c['commands']}cmds {c['decisions']}dec{sampled}  "
                     f"PRs:{prs}  | {row['last_decision'][:90]}"
                 )
         return 0

--- a/tests/scripts/test_agent_session_digest.py
+++ b/tests/scripts/test_agent_session_digest.py
@@ -147,6 +147,57 @@ def test_coordinator_view_windows_by_mtime(tmp_path: Path) -> None:
     assert digest.coordinator_view(root=tmp_path, since_hours=1.0, now=future) == []
 
 
+def test_coordinator_view_samples_large_rollouts_explicitly(tmp_path: Path) -> None:
+    rollout = tmp_path / "rollout-2026-06-30T12-00-00-large.jsonl"
+    rows = [
+        {"type": "session_meta", "payload": {"id": "large-session"}},
+        {"type": "event_msg", "payload": {"type": "user_message", "message": "start PR #8816"}},
+    ]
+    tail = {
+        "type": "event_msg",
+        "payload": {"type": "agent_message", "message": "finished PR #8817"},
+    }
+    rollout.write_text(
+        "\n".join(json.dumps(row) for row in rows)
+        + "\n"
+        + ("x" * 4096)
+        + "\n"
+        + json.dumps(tail)
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = digest.coordinator_view(root=tmp_path, since_hours=24.0, sample_bytes=256)
+
+    assert len(result) == 1
+    row = result[0]
+    assert row["session_id"] == "large-session"
+    assert row["scan"]["truncated"] is True
+    assert row["scan"]["bytes_scanned"] == 512
+    assert "8816" in row["prs_referenced"]
+    assert "8817" in row["prs_referenced"]
+
+
+def test_coordinator_view_time_budget_reports_skipped_rollouts(tmp_path: Path) -> None:
+    for i in range(3):
+        rollout = tmp_path / f"rollout-2026-06-30T12-00-0{i}-sess{i}.jsonl"
+        rollout.write_text(
+            json.dumps({"type": "session_meta", "payload": {"id": f"sess{i}"}}),
+            encoding="utf-8",
+        )
+
+    result = digest.coordinator_view(root=tmp_path, since_hours=24.0, time_budget_seconds=0.0)
+
+    assert result == [
+        {
+            "kind": "skipped",
+            "reason": "time_budget",
+            "skipped_rollouts": 3,
+            "message": "skipped 3 rollouts (time budget)",
+        }
+    ]
+
+
 def test_rlm_summary_cleans_temporary_files(tmp_path: Path, monkeypatch) -> None:
     created: list[Path] = []
 
@@ -264,6 +315,22 @@ def test_main_all_mode(tmp_path: Path, capsys) -> None:
     assert rc == 0
     out = json.loads(capsys.readouterr().out)
     assert any(r["session_id"] == "019f197d" for r in out)
+
+
+def test_main_all_mode_reports_time_budget_skips(tmp_path: Path, capsys) -> None:
+    sess = tmp_path / "rollout-2026-06-30T12-00-00-019f197d.jsonl"
+    _write_rollout(tmp_path).rename(sess)
+    rc = digest.main(
+        [
+            "--all",
+            "--sessions-root",
+            str(tmp_path),
+            "--time-budget-seconds",
+            "0",
+        ]
+    )
+    assert rc == 0
+    assert "skipped 1 rollouts (time budget)" in capsys.readouterr().out
 
 
 def test_extract_turns_reads_user_message_events(tmp_path: Path) -> None:

--- a/tests/scripts/test_agent_session_digest.py
+++ b/tests/scripts/test_agent_session_digest.py
@@ -178,6 +178,42 @@ def test_coordinator_view_samples_large_rollouts_explicitly(tmp_path: Path) -> N
     assert "8817" in row["prs_referenced"]
 
 
+def test_coordinator_view_keeps_tail_record_when_sample_starts_on_boundary(tmp_path: Path) -> None:
+    rollout = tmp_path / "rollout-2026-06-30T12-00-00-large.jsonl"
+    head = {"type": "event_msg", "payload": {"type": "user_message", "message": "start PR #8816"}}
+    tail = {
+        "type": "event_msg",
+        "payload": {"type": "agent_message", "message": "boundary PR #8817"},
+    }
+    head_line = json.dumps(head)
+    filler_line = json.dumps({"type": "event_msg", "payload": {"message": "x" * 300}})
+    tail_line = json.dumps(tail)
+    body = f"{head_line}\n{filler_line}\n{tail_line}\n"
+    rollout.write_text(body, encoding="utf-8")
+
+    result = digest.coordinator_view(
+        root=tmp_path, since_hours=24.0, sample_bytes=len(tail_line) + 1
+    )
+
+    assert len(result) == 1
+    assert "8816" in result[0]["prs_referenced"]
+    assert "8817" in result[0]["prs_referenced"]
+
+
+def test_sample_rollout_lines_splits_only_jsonl_newlines(tmp_path: Path) -> None:
+    rollout = tmp_path / "rollout-2026-06-30T12-00-00-unicode.jsonl"
+    row = {
+        "type": "event_msg",
+        "payload": {"type": "agent_message", "message": "keeps unicode separator \u2028 PR #8818"},
+    }
+    rollout.write_text(json.dumps(row, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    turns = digest.extract_turns(rollout, max_bytes=4096)
+
+    assert turns["counts"]["decisions"] == 1
+    assert "8818" in turns["prs_referenced"]
+
+
 def test_coordinator_view_time_budget_reports_skipped_rollouts(tmp_path: Path) -> None:
     for i in range(3):
         rollout = tmp_path / f"rollout-2026-06-30T12-00-0{i}-sess{i}.jsonl"
@@ -192,8 +228,8 @@ def test_coordinator_view_time_budget_reports_skipped_rollouts(tmp_path: Path) -
         {
             "kind": "skipped",
             "reason": "time_budget",
-            "skipped_rollouts": 3,
-            "message": "skipped 3 rollouts (time budget)",
+            "skipped_rollouts": None,
+            "message": "skipped rollouts (time budget during discovery)",
         }
     ]
 
@@ -330,7 +366,7 @@ def test_main_all_mode_reports_time_budget_skips(tmp_path: Path, capsys) -> None
         ]
     )
     assert rc == 0
-    assert "skipped 1 rollouts (time budget)" in capsys.readouterr().out
+    assert "skipped rollouts (time budget during discovery)" in capsys.readouterr().out
 
 
 def test_extract_turns_reads_user_message_events(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Bound the `agent_session_digest.py --all` coordinator path by sampling head+tail slices from each rollout instead of reading entire multi-hundred-MB transcripts.
- Add a `--time-budget-seconds` guard that reports explicit skipped rollout counts instead of silently dropping work.
- Mark sampled coordinator rows in text/JSON output while preserving exact `--latest`, `--session`, and `--path` streaming behavior.

## Motivation
The 2026-07-04 Fable goal-cycle packet builder reported:

`agent activity digest: TimeoutExpired: ... scripts/agent_session_digest.py --all --since-hours 24.0 timed out after 120 seconds`

The sessions root contains rollout JSONL files up to ~459 MB, so the coordinator view needs bounded per-file IO.

## Validation
- `python3 -m pytest tests/scripts/test_agent_session_digest.py -q` -> 21 passed
- `python3 -m ruff check scripts/agent_session_digest.py tests/scripts/test_agent_session_digest.py` -> passed
- `git diff --check` -> passed
- Before scoped command: `python3 scripts/agent_session_digest.py --all --since-hours 24` completed in 6.16s in the current environment, but the goal-cycle packet builder had just timed out at 120s.
- After patch: same command completed in 0.24s with sampled rows explicitly marked.

## Broader CI Note
- `make ci-required` was attempted. It passed initial `ruff check aragora/ tests/ scripts/` but failed during repo-wide `mypy aragora/ --ignore-missing-imports` on existing unrelated type errors across hundreds of files, starting in `aragora/server/commands/models.py` and connector/server modules. No failures were in this patch's touched files.
