### PR TITLE
[DIC-20] WorldStateEvent — world-state-driven decay translation layer

### DIFF
--- a/aragora/epistemic/__init__.py
+++ b/aragora/epistemic/__init__.py
@@ -16,7 +16,8 @@ Exposes:
   :class:`DecayReason`, :func:`evaluate_unit`) plus world-state
   event translation (:class:`WorldStateEvent`, :class:`WorldEventKind`,
   :func:`claims_affected_by_event`, :func:`world_event_to_claim_results`,
-  :func:`world_events_enabled`, :func:`enable_world_events`).
+  :func:`world_events_enabled`, :func:`enable_world_events`,
+  :func:`reset_world_events`).
   Flag gate: ``ARAGORA_WORLD_EVENTS_ENABLED`` (default off).
 - DIC-21: fail-closed quarantine policy (:class:`QuarantineDecision`,
   :class:`QuarantinePolicy`, :func:`apply_quarantine_policy`,
@@ -113,6 +114,7 @@ from .world_event import (
     WorldStateEvent,
     claims_affected_by_event,
     enable_world_events,
+    reset_world_events,
     world_event_to_claim_results,
     world_events_enabled,
 )
@@ -286,6 +288,7 @@ __all__ = [
     "WorldStateEvent",
     "claims_affected_by_event",
     "enable_world_events",
+    "reset_world_events",
     "world_event_to_claim_results",
     "world_events_enabled",
     "from_belief_node",

--- a/aragora/epistemic/__init__.py
+++ b/aragora/epistemic/__init__.py
@@ -13,7 +13,11 @@ Exposes:
 - DIC-18: organizational truth map report (:class:`OrgTruthMapReport`,
   :func:`build_truth_map`, :func:`build_truth_map_from_manifests`)
 - DIC-20: epistemic decay monitor (:class:`DecaySignal`,
-  :class:`DecayReason`, :func:`evaluate_unit`)
+  :class:`DecayReason`, :func:`evaluate_unit`) plus world-state
+  event translation (:class:`WorldStateEvent`, :class:`WorldEventKind`,
+  :func:`claims_affected_by_event`, :func:`world_event_to_claim_results`,
+  :func:`world_events_enabled`, :func:`enable_world_events`).
+  Flag gate: ``ARAGORA_WORLD_EVENTS_ENABLED`` (default off).
 - DIC-21: fail-closed quarantine policy (:class:`QuarantineDecision`,
   :class:`QuarantinePolicy`, :func:`apply_quarantine_policy`,
   :func:`quarantine_policy_enabled`)
@@ -103,6 +107,14 @@ from .decay_monitor import (
     DecaySignal,
     compute_decay_impact_set,
     evaluate_unit,
+)
+from .world_event import (
+    WorldEventKind,
+    WorldStateEvent,
+    claims_affected_by_event,
+    enable_world_events,
+    world_event_to_claim_results,
+    world_events_enabled,
 )
 from .executable_claim import (
     ClaimConfidence,
@@ -270,6 +282,12 @@ __all__ = [
     "epistemic_followup_enabled",
     "compute_decay_impact_set",
     "evaluate_unit",
+    "WorldEventKind",
+    "WorldStateEvent",
+    "claims_affected_by_event",
+    "enable_world_events",
+    "world_event_to_claim_results",
+    "world_events_enabled",
     "from_belief_node",
     "propose_followup_for_crux",
     "propose_followup_for_cruxset",

--- a/aragora/epistemic/decay_monitor.py
+++ b/aragora/epistemic/decay_monitor.py
@@ -43,6 +43,23 @@ _ACTION_RANK = {"report_only": 0, "repair_required": 1, "fail_closed": 2}
 _RANK_TO_ACTION = {v: k for k, v in _ACTION_RANK.items()}
 
 
+def _reject_disabled_world_event_result(result: "ClaimResult") -> None:
+    """Fail closed if a world-event result reaches evaluation while disabled."""
+
+    detail = getattr(result, "detail", {}) or {}
+    if detail.get("source") != "world_event":
+        return
+
+    from .world_event import world_events_enabled
+
+    if not world_events_enabled():
+        event_id = detail.get("event_id") or "<unknown>"
+        raise RuntimeError(
+            "ARAGORA_WORLD_EVENTS_ENABLED is not set; "
+            f"world-event claim result {event_id!r} must not propagate to decay evaluation."
+        )
+
+
 @dataclass(frozen=True)
 class DecayReason:
     """One reason contributing to integrity deduction."""
@@ -120,6 +137,7 @@ def evaluate_unit(
         result = results.get(claim_id)
         if result is None:
             continue
+        _reject_disabled_world_event_result(result)
         if result.status == ClaimStatus.FAIL:
             reasons.append(
                 DecayReason(

--- a/aragora/epistemic/world_event.py
+++ b/aragora/epistemic/world_event.py
@@ -115,11 +115,20 @@ def _safe_scope_pattern(raw: str) -> str | None:
 def _claim_matches_scope_pattern(claim_id: str, pattern: str) -> bool:
     """Match *pattern* against *claim_id* without unconstrained substring hits."""
 
-    if claim_id == pattern:
+    claim_segments = tuple(segment for segment in claim_id.strip(".").lower().split(".") if segment)
+    pattern_segments = tuple(
+        segment for segment in pattern.strip(".").lower().split(".") if segment
+    )
+    if not claim_segments or not pattern_segments or len(pattern_segments) > len(claim_segments):
+        return False
+    if claim_segments == pattern_segments:
         return True
-    if claim_id.startswith(f"{pattern}."):
+    if claim_segments[: len(pattern_segments)] == pattern_segments:
         return True
-    return f".{pattern}." in f".{claim_id}."
+    return any(
+        claim_segments[index : index + len(pattern_segments)] == pattern_segments
+        for index in range(1, len(claim_segments) - len(pattern_segments) + 1)
+    )
 
 
 def claims_affected_by_event(

--- a/aragora/epistemic/world_event.py
+++ b/aragora/epistemic/world_event.py
@@ -13,6 +13,7 @@ the private unchecked helper.
 from __future__ import annotations
 
 import os
+import re
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Any, cast
@@ -34,7 +35,22 @@ _WORLD_EVENTS_FLAG = "ARAGORA_WORLD_EVENTS_ENABLED"
 _world_events_enabled_override: bool | None = None
 _OVERBROAD_SCOPE_TOKENS = {
     "api",
+    "auth",
+    "com",
+    "dev",
+    "go",
+    "http",
+    "https",
+    "io",
+    "jwt",
+    "net",
+    "org",
+    "ssl",
+    "tls",
+    "web",
+    "www",
 }
+_VERSION_LIKE_SCOPE_RE = re.compile(r"v\d+[a-z0-9._-]*$")
 
 
 @dataclass(frozen=True)
@@ -106,7 +122,7 @@ def _safe_scope_pattern(raw: str) -> str | None:
         not pattern
         or not any(char.isalpha() for char in pattern)
         or normalized in _OVERBROAD_SCOPE_TOKENS
-        or (normalized.startswith("v") and normalized[1:].isdigit())
+        or bool(_VERSION_LIKE_SCOPE_RE.fullmatch(normalized))
     ):
         return None
     return pattern
@@ -164,7 +180,16 @@ def _world_event_to_claim_results_unchecked(
     kind = cast(WorldEventKind, event.kind)
     msg = f"Invalidated by {kind.value} event {event.event_id!r}: {event.description}"
     return {
-        claim_id: ClaimResult(claim_id=claim_id, status=ClaimStatus.STALE, message=msg)
+        claim_id: ClaimResult(
+            claim_id=claim_id,
+            status=ClaimStatus.STALE,
+            message=msg,
+            detail={
+                "source": "world_event",
+                "event_id": event.event_id,
+                "kind": kind.value,
+            },
+        )
         for claim_id in sorted(affected)
     }
 

--- a/aragora/epistemic/world_event.py
+++ b/aragora/epistemic/world_event.py
@@ -108,10 +108,7 @@ def world_event_to_claim_results(
             "Pass require_enabled=False for test-only use."
         )
     affected = claims_affected_by_event(unit, event)
-    msg = (
-        f"Invalidated by {event.kind.value} event {event.event_id!r}: "
-        f"{event.description}"
-    )
+    msg = f"Invalidated by {event.kind.value} event {event.event_id!r}: {event.description}"
     return {
         claim_id: ClaimResult(claim_id=claim_id, status=ClaimStatus.STALE, message=msg)
         for claim_id in sorted(affected)

--- a/aragora/epistemic/world_event.py
+++ b/aragora/epistemic/world_event.py
@@ -5,8 +5,9 @@ dependency version bumps, corpus revisions) into ClaimResult objects
 that :func:`~aragora.epistemic.decay_monitor.evaluate_unit` can consume.
 
 Flag: ``ARAGORA_WORLD_EVENTS_ENABLED`` (default off).  All computation
-is side-effect-free.  The flag gates :func:`world_event_to_claim_results`;
-tests that need raw translation use the private unchecked helper.
+is side-effect-free.  Production ingest must use
+:func:`world_event_to_claim_results`; tests that need raw translation use
+the private unchecked helper.
 """
 
 from __future__ import annotations
@@ -31,6 +32,9 @@ class WorldEventKind(str, Enum):
 
 _WORLD_EVENTS_FLAG = "ARAGORA_WORLD_EVENTS_ENABLED"
 _world_events_enabled_override: bool | None = None
+_OVERBROAD_SCOPE_TOKENS = {
+    "api",
+}
 
 
 @dataclass(frozen=True)
@@ -45,7 +49,7 @@ class WorldStateEvent:
     event_id: str
     kind: WorldEventKind | str
     description: str
-    affected_scope: list[str] = field(default_factory=list)
+    affected_scope: tuple[str, ...] = field(default_factory=tuple)
     timestamp: str = ""
 
     def __post_init__(self) -> None:
@@ -54,6 +58,7 @@ class WorldStateEvent:
         except ValueError as exc:
             raise ValueError(f"Unsupported world event kind: {self.kind!r}") from exc
         object.__setattr__(self, "kind", kind)
+        object.__setattr__(self, "affected_scope", tuple(self.affected_scope))
 
     def to_dict(self) -> dict[str, Any]:
         kind = cast(WorldEventKind, self.kind)
@@ -95,11 +100,14 @@ def reset_world_events() -> None:
 def _safe_scope_pattern(raw: str) -> str | None:
     """Return a scope pattern safe enough to compare against claim IDs."""
 
-    pattern = str(raw).strip()
-    if len(pattern) < 4 or not any(char.isalpha() for char in pattern):
-        return None
-    pattern = pattern.strip(".")
-    if len(pattern) < 4 or not any(char.isalpha() for char in pattern):
+    pattern = str(raw).strip().strip(".")
+    normalized = pattern.lower()
+    if (
+        not pattern
+        or not any(char.isalpha() for char in pattern)
+        or normalized in _OVERBROAD_SCOPE_TOKENS
+        or (normalized.startswith("v") and normalized[1:].isdigit())
+    ):
         return None
     return pattern
 
@@ -136,7 +144,12 @@ def _world_event_to_claim_results_unchecked(
     unit: "ProofCarryingCodeUnit",
     event: WorldStateEvent,
 ) -> dict[str, ClaimResult]:
-    """Translate *event* without checking the live-action feature flag."""
+    """Translate *event* without checking the live-action feature flag.
+
+    This exists for focused translator tests. Production callers must use
+    :func:`world_event_to_claim_results` so stale world-state signals cannot
+    propagate while the feature flag is disabled.
+    """
 
     affected = claims_affected_by_event(unit, event)
     kind = cast(WorldEventKind, event.kind)

--- a/aragora/epistemic/world_event.py
+++ b/aragora/epistemic/world_event.py
@@ -1,0 +1,118 @@
+"""WorldStateEvent translation layer for DIC-20 / #6031.
+
+Converts external world-state events (CVE drops, API changes,
+dependency version bumps, corpus revisions) into ClaimResult objects
+that :func:`~aragora.epistemic.decay_monitor.evaluate_unit` can consume.
+
+Flag: ``ARAGORA_WORLD_EVENTS_ENABLED`` (default off).  All computation
+is side-effect-free.  The flag gates :func:`world_event_to_claim_results`
+default behaviour; pass ``require_enabled=False`` for test-only use.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+from .claim_verifier import ClaimResult, ClaimStatus
+
+if TYPE_CHECKING:
+    from .proof_unit import ProofCarryingCodeUnit
+
+
+class WorldEventKind(str, Enum):
+    CVE = "cve"
+    API_CHANGE = "api_change"
+    DEPENDENCY_BUMP = "dependency_bump"
+    CORPUS_REVISION = "corpus_revision"
+
+
+@dataclass(frozen=True)
+class WorldStateEvent:
+    """An external event that may invalidate proof-unit assumptions.
+
+    ``affected_scope`` is matched against claim IDs: a claim is affected
+    when its ID starts with or contains any non-empty pattern in the list.
+    An empty list matches nothing (safe default).
+    """
+
+    event_id: str
+    kind: WorldEventKind
+    description: str
+    affected_scope: list[str] = field(default_factory=list)
+    timestamp: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {
+            "event_id": self.event_id,
+            "kind": self.kind.value,
+            "description": self.description,
+            "affected_scope": list(self.affected_scope),
+        }
+        if self.timestamp:
+            d["timestamp"] = self.timestamp
+        return d
+
+
+def world_events_enabled() -> bool:
+    """Return True if callers may act on world-event claim results."""
+    raw = str(os.environ.get("ARAGORA_WORLD_EVENTS_ENABLED") or "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def enable_world_events() -> None:
+    """Enable world-event claim translation for the current process."""
+    os.environ["ARAGORA_WORLD_EVENTS_ENABLED"] = "1"
+
+
+def claims_affected_by_event(
+    unit: "ProofCarryingCodeUnit",
+    event: WorldStateEvent,
+) -> frozenset[str]:
+    """Return claim IDs from *unit* matching any pattern in *event.affected_scope*.
+
+    Flag-free; pure computation, no side effects.
+    """
+    affected: set[str] = set()
+    for claim_id in unit.claims:
+        for pattern in event.affected_scope:
+            if pattern and (claim_id.startswith(pattern) or pattern in claim_id):
+                affected.add(claim_id)
+                break
+    return frozenset(affected)
+
+
+def world_event_to_claim_results(
+    unit: "ProofCarryingCodeUnit",
+    event: WorldStateEvent,
+    *,
+    require_enabled: bool = True,
+) -> dict[str, ClaimResult]:
+    """Translate *event* into a ``claim_id → ClaimResult(STALE)`` mapping.
+
+    The dict is ready to pass to
+    :func:`~aragora.epistemic.decay_monitor.evaluate_unit` as
+    ``claim_results``.
+
+    Raises :exc:`RuntimeError` when ``require_enabled=True`` and
+    ``ARAGORA_WORLD_EVENTS_ENABLED`` is not set.  Pass
+    ``require_enabled=False`` for test code that needs the translation
+    without environment setup.
+    """
+    if require_enabled and not world_events_enabled():
+        raise RuntimeError(
+            "ARAGORA_WORLD_EVENTS_ENABLED is not set; "
+            "world-event claim results must not propagate to live state. "
+            "Pass require_enabled=False for test-only use."
+        )
+    affected = claims_affected_by_event(unit, event)
+    msg = (
+        f"Invalidated by {event.kind.value} event {event.event_id!r}: "
+        f"{event.description}"
+    )
+    return {
+        claim_id: ClaimResult(claim_id=claim_id, status=ClaimStatus.STALE, message=msg)
+        for claim_id in sorted(affected)
+    }

--- a/aragora/epistemic/world_event.py
+++ b/aragora/epistemic/world_event.py
@@ -155,11 +155,13 @@ def claims_affected_by_event(
 
     Flag-free; pure computation, no side effects.
     """
+    safe_patterns = [
+        p for raw in event.affected_scope if (p := _safe_scope_pattern(raw)) is not None
+    ]
     affected: set[str] = set()
     for claim_id in unit.claims:
-        for raw_pattern in event.affected_scope:
-            pattern = _safe_scope_pattern(raw_pattern)
-            if pattern is not None and _claim_matches_scope_pattern(claim_id, pattern):
+        for pattern in safe_patterns:
+            if _claim_matches_scope_pattern(claim_id, pattern):
                 affected.add(claim_id)
                 break
     return frozenset(affected)

--- a/aragora/epistemic/world_event.py
+++ b/aragora/epistemic/world_event.py
@@ -5,8 +5,8 @@ dependency version bumps, corpus revisions) into ClaimResult objects
 that :func:`~aragora.epistemic.decay_monitor.evaluate_unit` can consume.
 
 Flag: ``ARAGORA_WORLD_EVENTS_ENABLED`` (default off).  All computation
-is side-effect-free.  The flag gates :func:`world_event_to_claim_results`
-default behaviour; pass ``require_enabled=False`` for test-only use.
+is side-effect-free.  The flag gates :func:`world_event_to_claim_results`;
+tests that need raw translation use the private unchecked helper.
 """
 
 from __future__ import annotations
@@ -14,7 +14,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from .claim_verifier import ClaimResult, ClaimStatus
 
@@ -29,25 +29,37 @@ class WorldEventKind(str, Enum):
     CORPUS_REVISION = "corpus_revision"
 
 
+_WORLD_EVENTS_FLAG = "ARAGORA_WORLD_EVENTS_ENABLED"
+_world_events_enabled_override: bool | None = None
+
+
 @dataclass(frozen=True)
 class WorldStateEvent:
     """An external event that may invalidate proof-unit assumptions.
 
-    ``affected_scope`` is matched against claim IDs: a claim is affected
-    when its ID starts with or contains any non-empty pattern in the list.
-    An empty list matches nothing (safe default).
+    ``affected_scope`` is matched against claim IDs on claim-id boundaries:
+    exact IDs, dotted prefixes, or dotted path segments.  Empty or overly broad
+    patterns match nothing (safe default).
     """
 
     event_id: str
-    kind: WorldEventKind
+    kind: WorldEventKind | str
     description: str
     affected_scope: list[str] = field(default_factory=list)
     timestamp: str = ""
 
+    def __post_init__(self) -> None:
+        try:
+            kind = self.kind if isinstance(self.kind, WorldEventKind) else WorldEventKind(self.kind)
+        except ValueError as exc:
+            raise ValueError(f"Unsupported world event kind: {self.kind!r}") from exc
+        object.__setattr__(self, "kind", kind)
+
     def to_dict(self) -> dict[str, Any]:
+        kind = cast(WorldEventKind, self.kind)
         d: dict[str, Any] = {
             "event_id": self.event_id,
-            "kind": self.kind.value,
+            "kind": kind.value,
             "description": self.description,
             "affected_scope": list(self.affected_scope),
         }
@@ -58,13 +70,48 @@ class WorldStateEvent:
 
 def world_events_enabled() -> bool:
     """Return True if callers may act on world-event claim results."""
-    raw = str(os.environ.get("ARAGORA_WORLD_EVENTS_ENABLED") or "").strip().lower()
+    if _world_events_enabled_override is not None:
+        return _world_events_enabled_override
+    raw = str(os.environ.get(_WORLD_EVENTS_FLAG) or "").strip().lower()
     return raw in {"1", "true", "yes", "on"}
 
 
 def enable_world_events() -> None:
-    """Enable world-event claim translation for the current process."""
-    os.environ["ARAGORA_WORLD_EVENTS_ENABLED"] = "1"
+    """Enable world-event claim translation for the current process.
+
+    Sets a module-level override rather than mutating ``os.environ``.
+    Call :func:`reset_world_events` to restore env-var-driven behavior.
+    """
+    global _world_events_enabled_override
+    _world_events_enabled_override = True
+
+
+def reset_world_events() -> None:
+    """Clear the module-level override, reverting to env-var-driven behavior."""
+    global _world_events_enabled_override
+    _world_events_enabled_override = None
+
+
+def _safe_scope_pattern(raw: str) -> str | None:
+    """Return a scope pattern safe enough to compare against claim IDs."""
+
+    pattern = str(raw).strip()
+    if len(pattern) < 4 or not any(char.isalpha() for char in pattern):
+        return None
+    pattern = pattern.strip(".")
+    if len(pattern) < 4 or not any(char.isalpha() for char in pattern):
+        return None
+    return pattern
+
+
+def _claim_matches_scope_pattern(claim_id: str, pattern: str) -> bool:
+    """Match *pattern* against *claim_id* without unconstrained substring hits."""
+
+    if claim_id == pattern:
+        return True
+    if claim_id.startswith(f"{pattern}."):
+        return True
+    return f".{pattern}." in f".{claim_id}."
 
 
 def claims_affected_by_event(
@@ -77,18 +124,32 @@ def claims_affected_by_event(
     """
     affected: set[str] = set()
     for claim_id in unit.claims:
-        for pattern in event.affected_scope:
-            if pattern and (claim_id.startswith(pattern) or pattern in claim_id):
+        for raw_pattern in event.affected_scope:
+            pattern = _safe_scope_pattern(raw_pattern)
+            if pattern is not None and _claim_matches_scope_pattern(claim_id, pattern):
                 affected.add(claim_id)
                 break
     return frozenset(affected)
 
 
+def _world_event_to_claim_results_unchecked(
+    unit: "ProofCarryingCodeUnit",
+    event: WorldStateEvent,
+) -> dict[str, ClaimResult]:
+    """Translate *event* without checking the live-action feature flag."""
+
+    affected = claims_affected_by_event(unit, event)
+    kind = cast(WorldEventKind, event.kind)
+    msg = f"Invalidated by {kind.value} event {event.event_id!r}: {event.description}"
+    return {
+        claim_id: ClaimResult(claim_id=claim_id, status=ClaimStatus.STALE, message=msg)
+        for claim_id in sorted(affected)
+    }
+
+
 def world_event_to_claim_results(
     unit: "ProofCarryingCodeUnit",
     event: WorldStateEvent,
-    *,
-    require_enabled: bool = True,
 ) -> dict[str, ClaimResult]:
     """Translate *event* into a ``claim_id → ClaimResult(STALE)`` mapping.
 
@@ -96,20 +157,12 @@ def world_event_to_claim_results(
     :func:`~aragora.epistemic.decay_monitor.evaluate_unit` as
     ``claim_results``.
 
-    Raises :exc:`RuntimeError` when ``require_enabled=True`` and
-    ``ARAGORA_WORLD_EVENTS_ENABLED`` is not set.  Pass
-    ``require_enabled=False`` for test code that needs the translation
-    without environment setup.
+    Raises :exc:`RuntimeError` when ``ARAGORA_WORLD_EVENTS_ENABLED`` is not set.
+    This keeps world-event propagation fail-closed for production callers.
     """
-    if require_enabled and not world_events_enabled():
+    if not world_events_enabled():
         raise RuntimeError(
             "ARAGORA_WORLD_EVENTS_ENABLED is not set; "
-            "world-event claim results must not propagate to live state. "
-            "Pass require_enabled=False for test-only use."
+            "world-event claim results must not propagate to live state."
         )
-    affected = claims_affected_by_event(unit, event)
-    msg = f"Invalidated by {event.kind.value} event {event.event_id!r}: {event.description}"
-    return {
-        claim_id: ClaimResult(claim_id=claim_id, status=ClaimStatus.STALE, message=msg)
-        for claim_id in sorted(affected)
-    }
+    return _world_event_to_claim_results_unchecked(unit, event)

--- a/tests/epistemic/test_world_state_decay.py
+++ b/tests/epistemic/test_world_state_decay.py
@@ -141,6 +141,42 @@ class TestClaimsAffectedByEvent:
 
         assert affected == frozenset({"runtime.py.version", "env.py.version"})
 
+    def test_generic_short_scope_tokens_match_nothing(self):
+        unit = _unit(
+            [
+                "env.jwt.version_pinned",
+                "transport.ssl.enabled",
+                "api.openai.available",
+                "language.go.mod_current",
+                "site.com.reachable",
+            ]
+        )
+        event = WorldStateEvent(
+            event_id="generic-short-scopes",
+            kind=WorldEventKind.DEPENDENCY_BUMP,
+            description="Noisy external feed with generic short scopes",
+            affected_scope=["jwt", "ssl", "api", "go", "com"],
+        )
+
+        assert claims_affected_by_event(unit, event) == frozenset()
+
+    def test_version_like_scope_tokens_match_nothing(self):
+        unit = _unit(
+            [
+                "openai.completions.v1.reachable",
+                "runtime.v1beta.compatible",
+                "runtime.v2rc1.compatible",
+            ]
+        )
+        event = WorldStateEvent(
+            event_id="version-like-scopes",
+            kind=WorldEventKind.API_CHANGE,
+            description="Version-like scopes are too broad for claim invalidation",
+            affected_scope=["v1", "v1beta", "v2rc1"],
+        )
+
+        assert claims_affected_by_event(unit, event) == frozenset()
+
     def test_scope_matching_is_case_insensitive(self):
         unit = _unit(
             [
@@ -176,11 +212,9 @@ class TestClaimsAffectedByEvent:
     def test_short_scope_tokens_match_claim_id_boundaries(self):
         unit = _unit(
             [
-                "env.jwt.version_pinned",
-                "transport.ssl.enabled",
                 "aws.iam.policy.current",
-                "build.npm.lockfile_current",
-                "language.go.mod_current",
+                "build.npm.lockfile.current",
+                "language.golang.mod_current",
                 "cargo.good",
                 "project.api.available",
             ]
@@ -189,16 +223,14 @@ class TestClaimsAffectedByEvent:
             event_id="short-scopes",
             kind=WorldEventKind.DEPENDENCY_BUMP,
             description="short but specific dependency/API scopes",
-            affected_scope=["jwt", "ssl", "aws", "npm", "go", "api"],
+            affected_scope=["aws.iam", "npm.lockfile", "golang", "api"],
         )
 
         assert claims_affected_by_event(unit, event) == frozenset(
             {
-                "env.jwt.version_pinned",
-                "transport.ssl.enabled",
                 "aws.iam.policy.current",
-                "build.npm.lockfile_current",
-                "language.go.mod_current",
+                "build.npm.lockfile.current",
+                "language.golang.mod_current",
             }
         )
 
@@ -278,6 +310,7 @@ class TestWorldEventToClaimResults:
         unit = _unit(["libfoo.version_pinned", "other.claim"])
         results = _world_event_to_claim_results_unchecked(unit, _cve(["libfoo"]))
         assert results["libfoo.version_pinned"].status == ClaimStatus.STALE
+        assert results["libfoo.version_pinned"].detail["source"] == "world_event"
         assert "other.claim" not in results
 
     def test_message_contains_event_id_and_kind(self):
@@ -323,7 +356,8 @@ class TestWorldEventToClaimResults:
         assert _world_event_module._world_events_enabled_override is True  # noqa: SLF001
         assert os.environ == before
 
-    def test_reset_helper_clears_override(self):
+    def test_reset_helper_clears_override(self, monkeypatch):
+        monkeypatch.delenv("ARAGORA_WORLD_EVENTS_ENABLED", raising=False)
         enable_world_events()
         reset_world_events()
 
@@ -339,6 +373,7 @@ class TestWorldEventToClaimResults:
 class TestWorldEventDecayIntegration:
     def test_cve_lowers_integrity_score(self):
         unit = _unit(["libfoo.version_pinned", "libfoo.no_known_vulns"])
+        enable_world_events()
         results = _world_event_to_claim_results_unchecked(unit, _cve(["libfoo"]))
         signal = evaluate_unit(unit, claim_results=results)
         assert signal.integrity_score < 1.0
@@ -346,6 +381,7 @@ class TestWorldEventDecayIntegration:
 
     def test_api_change_marks_specific_claim_stale(self):
         unit = _unit(["openai.completions.v1.reachable", "openai.embeddings.ok"])
+        enable_world_events()
         results = _world_event_to_claim_results_unchecked(unit, _api_event())
         stale = [
             r
@@ -356,10 +392,19 @@ class TestWorldEventDecayIntegration:
 
     def test_dependency_bump_propagates_decay(self):
         unit = _unit(["pydantic.model.dict_supported"])
+        enable_world_events()
         results = _world_event_to_claim_results_unchecked(unit, _dep_event())
         assert any(
             r.kind == "stale_evidence" for r in evaluate_unit(unit, claim_results=results).reasons
         )
+
+    def test_unchecked_world_event_results_fail_closed_when_disabled(self, monkeypatch):
+        monkeypatch.delenv("ARAGORA_WORLD_EVENTS_ENABLED", raising=False)
+        unit = _unit(["libfoo.version_pinned"])
+        results = _world_event_to_claim_results_unchecked(unit, _cve(["libfoo"]))
+
+        with pytest.raises(RuntimeError, match="world-event claim result"):
+            evaluate_unit(unit, claim_results=results)
 
     def test_enabled_public_translation_propagates_decay(self):
         unit = _unit(["libfoo.version_pinned", "other.claim"])
@@ -374,5 +419,6 @@ class TestWorldEventDecayIntegration:
 
     def test_unrelated_event_leaves_score_intact(self):
         unit = _unit(["anthropic.api.stable", "project.build.passing"])
+        enable_world_events()
         results = _world_event_to_claim_results_unchecked(unit, _cve(["libfoo"]))
         assert evaluate_unit(unit, claim_results=results).integrity_score == 1.0

--- a/tests/epistemic/test_world_state_decay.py
+++ b/tests/epistemic/test_world_state_decay.py
@@ -5,6 +5,7 @@ version bumps) correctly translate into ClaimResult decay and
 propagate through evaluate_unit, satisfying the DIC-20 acceptance
 criterion for synthetic world-event invalidation tests.
 """
+
 from __future__ import annotations
 
 import pytest
@@ -97,16 +98,20 @@ class TestClaimsAffectedByEvent:
 
     def test_empty_scope_matches_nothing(self):
         event = WorldStateEvent(
-            event_id="noop", kind=WorldEventKind.CORPUS_REVISION,
-            description="no scope", affected_scope=[],
+            event_id="noop",
+            kind=WorldEventKind.CORPUS_REVISION,
+            description="no scope",
+            affected_scope=[],
         )
         assert claims_affected_by_event(_unit(["claim.a"]), event) == frozenset()
 
     def test_multiple_patterns_match_union(self):
         unit = _unit(["libfoo.pinned", "curl.version", "libz.ok"])
         event = WorldStateEvent(
-            event_id="multi", kind=WorldEventKind.CVE,
-            description="Multiple vulns", affected_scope=["libfoo", "curl"],
+            event_id="multi",
+            kind=WorldEventKind.CVE,
+            description="Multiple vulns",
+            affected_scope=["libfoo", "curl"],
         )
         affected = claims_affected_by_event(unit, event)
         assert "libfoo.pinned" in affected and "curl.version" in affected
@@ -127,12 +132,16 @@ class TestWorldEventToClaimResults:
 
     def test_message_contains_event_id_and_kind(self):
         unit = _unit(["libfoo.pinned"])
-        results = world_event_to_claim_results(unit, _cve(["libfoo"], "CVE-2024-9999"), require_enabled=False)
+        results = world_event_to_claim_results(
+            unit, _cve(["libfoo"], "CVE-2024-9999"), require_enabled=False
+        )
         msg = results["libfoo.pinned"].message
         assert "CVE-2024-9999" in msg and "cve" in msg
 
     def test_empty_scope_returns_empty_dict(self):
-        event = WorldStateEvent(event_id="noop", kind=WorldEventKind.CORPUS_REVISION, description="x")
+        event = WorldStateEvent(
+            event_id="noop", kind=WorldEventKind.CORPUS_REVISION, description="x"
+        )
         assert world_event_to_claim_results(_unit(["c"]), event, require_enabled=False) == {}
 
     def test_flag_off_raises_by_default(self, monkeypatch):
@@ -142,7 +151,9 @@ class TestWorldEventToClaimResults:
 
     def test_require_enabled_false_bypasses_flag(self, monkeypatch):
         monkeypatch.delenv("ARAGORA_WORLD_EVENTS_ENABLED", raising=False)
-        results = world_event_to_claim_results(_unit(["libfoo.p"]), _cve(["libfoo"]), require_enabled=False)
+        results = world_event_to_claim_results(
+            _unit(["libfoo.p"]), _cve(["libfoo"]), require_enabled=False
+        )
         assert "libfoo.p" in results
 
     def test_flag_on_allows_normal_call(self, monkeypatch):
@@ -173,13 +184,19 @@ class TestWorldEventDecayIntegration:
     def test_api_change_marks_specific_claim_stale(self):
         unit = _unit(["openai.completions.v1.reachable", "openai.embeddings.ok"])
         results = world_event_to_claim_results(unit, _api_event(), require_enabled=False)
-        stale = [r for r in evaluate_unit(unit, claim_results=results).reasons if r.kind == "stale_evidence"]
+        stale = [
+            r
+            for r in evaluate_unit(unit, claim_results=results).reasons
+            if r.kind == "stale_evidence"
+        ]
         assert any(r.claim_id == "openai.completions.v1.reachable" for r in stale)
 
     def test_dependency_bump_propagates_decay(self):
         unit = _unit(["pydantic.model.dict_supported"])
         results = world_event_to_claim_results(unit, _dep_event(), require_enabled=False)
-        assert any(r.kind == "stale_evidence" for r in evaluate_unit(unit, claim_results=results).reasons)
+        assert any(
+            r.kind == "stale_evidence" for r in evaluate_unit(unit, claim_results=results).reasons
+        )
 
     def test_unrelated_event_leaves_score_intact(self):
         unit = _unit(["anthropic.api.stable", "project.build.passing"])

--- a/tests/epistemic/test_world_state_decay.py
+++ b/tests/epistemic/test_world_state_decay.py
@@ -8,15 +8,22 @@ criterion for synthetic world-event invalidation tests.
 
 from __future__ import annotations
 
+import inspect
+import os
+
 import pytest
 
+import aragora.epistemic.world_event as _world_event_module
 from aragora.epistemic.claim_verifier import ClaimStatus
 from aragora.epistemic.decay_monitor import evaluate_unit
 from aragora.epistemic.proof_unit import DecayPolicy, FallbackPolicy, ProofCarryingCodeUnit
 from aragora.epistemic.world_event import (
     WorldEventKind,
     WorldStateEvent,
+    _world_event_to_claim_results_unchecked,
     claims_affected_by_event,
+    enable_world_events,
+    reset_world_events,
     world_event_to_claim_results,
     world_events_enabled,
 )
@@ -25,6 +32,13 @@ from aragora.epistemic.world_event import (
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_world_event_override() -> pytest.IterableFixture:  # type: ignore[type-arg]
+    reset_world_events()
+    yield
+    reset_world_events()
 
 
 def _unit(claims: list[str]) -> ProofCarryingCodeUnit:
@@ -78,6 +92,36 @@ def _dep_event() -> WorldStateEvent:
 
 
 class TestClaimsAffectedByEvent:
+    def test_scope_matching_ignores_overbroad_patterns(self):
+        unit = _unit(
+            [
+                "openai.completions.v1.reachable",
+                "anthropic.api.reachable",
+                "project.build.passing",
+            ]
+        )
+        event = WorldStateEvent(
+            event_id="too-broad",
+            kind=WorldEventKind.API_CHANGE,
+            description="broad event",
+            affected_scope=[".", "v1", "api"],
+        )
+
+        assert claims_affected_by_event(unit, event) == frozenset()
+
+    def test_scope_matching_uses_claim_id_boundaries(self):
+        unit = _unit(
+            [
+                "env.libfoo.version_pinned",
+                "libfoo.pinned",
+                "libfoobar.pinned",
+            ]
+        )
+
+        affected = claims_affected_by_event(unit, _cve(["libfoo"]))
+
+        assert affected == frozenset({"env.libfoo.version_pinned", "libfoo.pinned"})
+
     def test_cve_matches_by_substring(self):
         unit = _unit(["env.libfoo.version_pinned", "env.curl.ok"])
         affected = claims_affected_by_event(unit, _cve(["libfoo"]))
@@ -124,17 +168,33 @@ class TestClaimsAffectedByEvent:
 
 
 class TestWorldEventToClaimResults:
+    def test_string_kind_normalizes_to_world_event_kind(self):
+        event = WorldStateEvent(
+            event_id="CVE-2024-9999",
+            kind="cve",
+            description="Critical issue in libfoo",
+            affected_scope=["libfoo"],
+        )
+
+        assert event.kind is WorldEventKind.CVE
+        assert event.to_dict()["kind"] == "cve"
+
+    def test_invalid_string_kind_is_rejected(self):
+        with pytest.raises(ValueError, match="Unsupported world event kind"):
+            WorldStateEvent(event_id="bad", kind="not-a-kind", description="bad")
+
+    def test_public_translation_has_no_flag_bypass_parameter(self):
+        assert "require_enabled" not in inspect.signature(world_event_to_claim_results).parameters
+
     def test_affected_claim_gets_stale_status(self):
         unit = _unit(["libfoo.version_pinned", "other.claim"])
-        results = world_event_to_claim_results(unit, _cve(["libfoo"]), require_enabled=False)
+        results = _world_event_to_claim_results_unchecked(unit, _cve(["libfoo"]))
         assert results["libfoo.version_pinned"].status == ClaimStatus.STALE
         assert "other.claim" not in results
 
     def test_message_contains_event_id_and_kind(self):
         unit = _unit(["libfoo.pinned"])
-        results = world_event_to_claim_results(
-            unit, _cve(["libfoo"], "CVE-2024-9999"), require_enabled=False
-        )
+        results = _world_event_to_claim_results_unchecked(unit, _cve(["libfoo"], "CVE-2024-9999"))
         msg = results["libfoo.pinned"].message
         assert "CVE-2024-9999" in msg and "cve" in msg
 
@@ -142,18 +202,16 @@ class TestWorldEventToClaimResults:
         event = WorldStateEvent(
             event_id="noop", kind=WorldEventKind.CORPUS_REVISION, description="x"
         )
-        assert world_event_to_claim_results(_unit(["c"]), event, require_enabled=False) == {}
+        assert _world_event_to_claim_results_unchecked(_unit(["c"]), event) == {}
 
     def test_flag_off_raises_by_default(self, monkeypatch):
         monkeypatch.delenv("ARAGORA_WORLD_EVENTS_ENABLED", raising=False)
         with pytest.raises(RuntimeError, match="ARAGORA_WORLD_EVENTS_ENABLED"):
             world_event_to_claim_results(_unit(["libfoo.p"]), _cve(["libfoo"]))
 
-    def test_require_enabled_false_bypasses_flag(self, monkeypatch):
+    def test_internal_unchecked_helper_bypasses_flag_for_tests(self, monkeypatch):
         monkeypatch.delenv("ARAGORA_WORLD_EVENTS_ENABLED", raising=False)
-        results = world_event_to_claim_results(
-            _unit(["libfoo.p"]), _cve(["libfoo"]), require_enabled=False
-        )
+        results = _world_event_to_claim_results_unchecked(_unit(["libfoo.p"]), _cve(["libfoo"]))
         assert "libfoo.p" in results
 
     def test_flag_on_allows_normal_call(self, monkeypatch):
@@ -167,6 +225,23 @@ class TestWorldEventToClaimResults:
         monkeypatch.delenv("ARAGORA_WORLD_EVENTS_ENABLED")
         assert world_events_enabled() is False
 
+    def test_enable_helper_sets_override_without_mutating_environ(self, monkeypatch):
+        monkeypatch.delenv("ARAGORA_WORLD_EVENTS_ENABLED", raising=False)
+        before = dict(os.environ)
+
+        enable_world_events()
+
+        assert world_events_enabled() is True
+        assert _world_event_module._world_events_enabled_override is True  # noqa: SLF001
+        assert os.environ == before
+
+    def test_reset_helper_clears_override(self):
+        enable_world_events()
+        reset_world_events()
+
+        assert _world_event_module._world_events_enabled_override is None  # noqa: SLF001
+        assert world_events_enabled() is False
+
 
 # ---------------------------------------------------------------------------
 # Integration: world event → evaluate_unit (DIC-20 end-to-end)
@@ -176,14 +251,14 @@ class TestWorldEventToClaimResults:
 class TestWorldEventDecayIntegration:
     def test_cve_lowers_integrity_score(self):
         unit = _unit(["libfoo.version_pinned", "libfoo.no_known_vulns"])
-        results = world_event_to_claim_results(unit, _cve(["libfoo"]), require_enabled=False)
+        results = _world_event_to_claim_results_unchecked(unit, _cve(["libfoo"]))
         signal = evaluate_unit(unit, claim_results=results)
         assert signal.integrity_score < 1.0
         assert any(r.kind == "stale_evidence" for r in signal.reasons)
 
     def test_api_change_marks_specific_claim_stale(self):
         unit = _unit(["openai.completions.v1.reachable", "openai.embeddings.ok"])
-        results = world_event_to_claim_results(unit, _api_event(), require_enabled=False)
+        results = _world_event_to_claim_results_unchecked(unit, _api_event())
         stale = [
             r
             for r in evaluate_unit(unit, claim_results=results).reasons
@@ -193,12 +268,12 @@ class TestWorldEventDecayIntegration:
 
     def test_dependency_bump_propagates_decay(self):
         unit = _unit(["pydantic.model.dict_supported"])
-        results = world_event_to_claim_results(unit, _dep_event(), require_enabled=False)
+        results = _world_event_to_claim_results_unchecked(unit, _dep_event())
         assert any(
             r.kind == "stale_evidence" for r in evaluate_unit(unit, claim_results=results).reasons
         )
 
     def test_unrelated_event_leaves_score_intact(self):
         unit = _unit(["anthropic.api.stable", "project.build.passing"])
-        results = world_event_to_claim_results(unit, _cve(["libfoo"]), require_enabled=False)
+        results = _world_event_to_claim_results_unchecked(unit, _cve(["libfoo"]))
         assert evaluate_unit(unit, claim_results=results).integrity_score == 1.0

--- a/tests/epistemic/test_world_state_decay.py
+++ b/tests/epistemic/test_world_state_decay.py
@@ -122,6 +122,51 @@ class TestClaimsAffectedByEvent:
 
         assert affected == frozenset({"env.libfoo.version_pinned", "libfoo.pinned"})
 
+    def test_scope_matching_does_not_match_inside_segments(self):
+        unit = _unit(
+            [
+                "runtime.py.version",
+                "env.py.version",
+                "studio.python.version",
+            ]
+        )
+        event = WorldStateEvent(
+            event_id="py-runtime",
+            kind=WorldEventKind.DEPENDENCY_BUMP,
+            description="Python runtime patch",
+            affected_scope=["py"],
+        )
+
+        affected = claims_affected_by_event(unit, event)
+
+        assert affected == frozenset({"runtime.py.version", "env.py.version"})
+
+    def test_scope_matching_is_case_insensitive(self):
+        unit = _unit(
+            [
+                "libfoo.version_pinned",
+                "env.libfoo.pinned",
+                "openai.completions.v1.reachable",
+                "anthropic.api.reachable",
+            ]
+        )
+        event = WorldStateEvent(
+            event_id="mixed-case-scope",
+            kind=WorldEventKind.API_CHANGE,
+            description="Externally supplied scopes can vary in case",
+            affected_scope=["LibFoo", "OpenAI.Completions"],
+        )
+
+        affected = claims_affected_by_event(unit, event)
+
+        assert affected == frozenset(
+            {
+                "libfoo.version_pinned",
+                "env.libfoo.pinned",
+                "openai.completions.v1.reachable",
+            }
+        )
+
     def test_cve_matches_by_segment_boundary(self):
         unit = _unit(["env.libfoo.version_pinned", "env.curl.ok"])
         affected = claims_affected_by_event(unit, _cve(["libfoo"]))

--- a/tests/epistemic/test_world_state_decay.py
+++ b/tests/epistemic/test_world_state_decay.py
@@ -122,11 +122,40 @@ class TestClaimsAffectedByEvent:
 
         assert affected == frozenset({"env.libfoo.version_pinned", "libfoo.pinned"})
 
-    def test_cve_matches_by_substring(self):
+    def test_cve_matches_by_segment_boundary(self):
         unit = _unit(["env.libfoo.version_pinned", "env.curl.ok"])
         affected = claims_affected_by_event(unit, _cve(["libfoo"]))
         assert "env.libfoo.version_pinned" in affected
         assert "env.curl.ok" not in affected
+
+    def test_short_scope_tokens_match_claim_id_boundaries(self):
+        unit = _unit(
+            [
+                "env.jwt.version_pinned",
+                "transport.ssl.enabled",
+                "aws.iam.policy.current",
+                "build.npm.lockfile_current",
+                "language.go.mod_current",
+                "cargo.good",
+                "project.api.available",
+            ]
+        )
+        event = WorldStateEvent(
+            event_id="short-scopes",
+            kind=WorldEventKind.DEPENDENCY_BUMP,
+            description="short but specific dependency/API scopes",
+            affected_scope=["jwt", "ssl", "aws", "npm", "go", "api"],
+        )
+
+        assert claims_affected_by_event(unit, event) == frozenset(
+            {
+                "env.jwt.version_pinned",
+                "transport.ssl.enabled",
+                "aws.iam.policy.current",
+                "build.npm.lockfile_current",
+                "language.go.mod_current",
+            }
+        )
 
     def test_api_change_matches_by_prefix(self):
         unit = _unit(["openai.completions.v1.reachable", "anthropic.api.reachable"])
@@ -178,6 +207,20 @@ class TestWorldEventToClaimResults:
 
         assert event.kind is WorldEventKind.CVE
         assert event.to_dict()["kind"] == "cve"
+
+    def test_affected_scope_is_copied_to_immutable_tuple(self):
+        scope = ["libfoo"]
+        event = WorldStateEvent(
+            event_id="CVE-2024-9999",
+            kind="cve",
+            description="Critical issue in libfoo",
+            affected_scope=scope,
+        )
+
+        scope.append("curl")
+
+        assert event.affected_scope == ("libfoo",)
+        assert event.to_dict()["affected_scope"] == ["libfoo"]
 
     def test_invalid_string_kind_is_rejected(self):
         with pytest.raises(ValueError, match="Unsupported world event kind"):
@@ -272,6 +315,17 @@ class TestWorldEventDecayIntegration:
         assert any(
             r.kind == "stale_evidence" for r in evaluate_unit(unit, claim_results=results).reasons
         )
+
+    def test_enabled_public_translation_propagates_decay(self):
+        unit = _unit(["libfoo.version_pinned", "other.claim"])
+        enable_world_events()
+
+        results = world_event_to_claim_results(unit, _cve(["libfoo"]))
+        signal = evaluate_unit(unit, claim_results=results)
+
+        assert "libfoo.version_pinned" in results
+        assert signal.integrity_score < 1.0
+        assert any(r.kind == "stale_evidence" for r in signal.reasons)
 
     def test_unrelated_event_leaves_score_intact(self):
         unit = _unit(["anthropic.api.stable", "project.build.passing"])

--- a/tests/epistemic/test_world_state_decay.py
+++ b/tests/epistemic/test_world_state_decay.py
@@ -1,0 +1,187 @@
+"""Synthetic world-state event tests for DIC-20 / #6031.
+
+Verifies that external events (CVE drops, API changes, dependency
+version bumps) correctly translate into ClaimResult decay and
+propagate through evaluate_unit, satisfying the DIC-20 acceptance
+criterion for synthetic world-event invalidation tests.
+"""
+from __future__ import annotations
+
+import pytest
+
+from aragora.epistemic.claim_verifier import ClaimStatus
+from aragora.epistemic.decay_monitor import evaluate_unit
+from aragora.epistemic.proof_unit import DecayPolicy, FallbackPolicy, ProofCarryingCodeUnit
+from aragora.epistemic.world_event import (
+    WorldEventKind,
+    WorldStateEvent,
+    claims_affected_by_event,
+    world_event_to_claim_results,
+    world_events_enabled,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _unit(claims: list[str]) -> ProofCarryingCodeUnit:
+    return ProofCarryingCodeUnit(
+        code_unit_id="unit.test",
+        symbol="tests.fake.fn",
+        source_path="tests/fake.py",
+        owner="test",
+        decision_receipts=["receipt-001"],
+        claims=claims,
+        assumptions=["External dependency is stable."],
+        verifiers=[],
+        freshness_sla_hours=24,
+        decay_policy=DecayPolicy(),
+        fallback_policy=FallbackPolicy(),
+        linked_crux_ids=[],
+    )
+
+
+def _cve(scope: list[str] | None = None, eid: str = "CVE-2024-9999") -> WorldStateEvent:
+    return WorldStateEvent(
+        event_id=eid,
+        kind=WorldEventKind.CVE,
+        description="Critical issue in libfoo ≤ 3.2.1",
+        affected_scope=scope if scope is not None else ["libfoo"],
+        timestamp="2024-10-01T12:00:00Z",
+    )
+
+
+def _api_event() -> WorldStateEvent:
+    return WorldStateEvent(
+        event_id="api.openai.v1-sunset",
+        kind=WorldEventKind.API_CHANGE,
+        description="OpenAI v1 completions sunsetted",
+        affected_scope=["openai.completions"],
+    )
+
+
+def _dep_event() -> WorldStateEvent:
+    return WorldStateEvent(
+        event_id="dep.pydantic.v3",
+        kind=WorldEventKind.DEPENDENCY_BUMP,
+        description="Pydantic v3 breaks model.dict()",
+        affected_scope=["pydantic."],
+    )
+
+
+# ---------------------------------------------------------------------------
+# claims_affected_by_event
+# ---------------------------------------------------------------------------
+
+
+class TestClaimsAffectedByEvent:
+    def test_cve_matches_by_substring(self):
+        unit = _unit(["env.libfoo.version_pinned", "env.curl.ok"])
+        affected = claims_affected_by_event(unit, _cve(["libfoo"]))
+        assert "env.libfoo.version_pinned" in affected
+        assert "env.curl.ok" not in affected
+
+    def test_api_change_matches_by_prefix(self):
+        unit = _unit(["openai.completions.v1.reachable", "anthropic.api.reachable"])
+        affected = claims_affected_by_event(unit, _api_event())
+        assert "openai.completions.v1.reachable" in affected
+        assert "anthropic.api.reachable" not in affected
+
+    def test_dependency_bump_matches_dot_prefix(self):
+        unit = _unit(["pydantic.model.dict_supported", "sqlalchemy.ok"])
+        affected = claims_affected_by_event(unit, _dep_event())
+        assert "pydantic.model.dict_supported" in affected
+        assert "sqlalchemy.ok" not in affected
+
+    def test_empty_scope_matches_nothing(self):
+        event = WorldStateEvent(
+            event_id="noop", kind=WorldEventKind.CORPUS_REVISION,
+            description="no scope", affected_scope=[],
+        )
+        assert claims_affected_by_event(_unit(["claim.a"]), event) == frozenset()
+
+    def test_multiple_patterns_match_union(self):
+        unit = _unit(["libfoo.pinned", "curl.version", "libz.ok"])
+        event = WorldStateEvent(
+            event_id="multi", kind=WorldEventKind.CVE,
+            description="Multiple vulns", affected_scope=["libfoo", "curl"],
+        )
+        affected = claims_affected_by_event(unit, event)
+        assert "libfoo.pinned" in affected and "curl.version" in affected
+        assert "libz.ok" not in affected
+
+
+# ---------------------------------------------------------------------------
+# world_event_to_claim_results
+# ---------------------------------------------------------------------------
+
+
+class TestWorldEventToClaimResults:
+    def test_affected_claim_gets_stale_status(self):
+        unit = _unit(["libfoo.version_pinned", "other.claim"])
+        results = world_event_to_claim_results(unit, _cve(["libfoo"]), require_enabled=False)
+        assert results["libfoo.version_pinned"].status == ClaimStatus.STALE
+        assert "other.claim" not in results
+
+    def test_message_contains_event_id_and_kind(self):
+        unit = _unit(["libfoo.pinned"])
+        results = world_event_to_claim_results(unit, _cve(["libfoo"], "CVE-2024-9999"), require_enabled=False)
+        msg = results["libfoo.pinned"].message
+        assert "CVE-2024-9999" in msg and "cve" in msg
+
+    def test_empty_scope_returns_empty_dict(self):
+        event = WorldStateEvent(event_id="noop", kind=WorldEventKind.CORPUS_REVISION, description="x")
+        assert world_event_to_claim_results(_unit(["c"]), event, require_enabled=False) == {}
+
+    def test_flag_off_raises_by_default(self, monkeypatch):
+        monkeypatch.delenv("ARAGORA_WORLD_EVENTS_ENABLED", raising=False)
+        with pytest.raises(RuntimeError, match="ARAGORA_WORLD_EVENTS_ENABLED"):
+            world_event_to_claim_results(_unit(["libfoo.p"]), _cve(["libfoo"]))
+
+    def test_require_enabled_false_bypasses_flag(self, monkeypatch):
+        monkeypatch.delenv("ARAGORA_WORLD_EVENTS_ENABLED", raising=False)
+        results = world_event_to_claim_results(_unit(["libfoo.p"]), _cve(["libfoo"]), require_enabled=False)
+        assert "libfoo.p" in results
+
+    def test_flag_on_allows_normal_call(self, monkeypatch):
+        monkeypatch.setenv("ARAGORA_WORLD_EVENTS_ENABLED", "1")
+        results = world_event_to_claim_results(_unit(["libfoo.p"]), _cve(["libfoo"]))
+        assert "libfoo.p" in results
+
+    def test_world_events_enabled_truth_values(self, monkeypatch):
+        monkeypatch.setenv("ARAGORA_WORLD_EVENTS_ENABLED", "true")
+        assert world_events_enabled() is True
+        monkeypatch.delenv("ARAGORA_WORLD_EVENTS_ENABLED")
+        assert world_events_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# Integration: world event → evaluate_unit (DIC-20 end-to-end)
+# ---------------------------------------------------------------------------
+
+
+class TestWorldEventDecayIntegration:
+    def test_cve_lowers_integrity_score(self):
+        unit = _unit(["libfoo.version_pinned", "libfoo.no_known_vulns"])
+        results = world_event_to_claim_results(unit, _cve(["libfoo"]), require_enabled=False)
+        signal = evaluate_unit(unit, claim_results=results)
+        assert signal.integrity_score < 1.0
+        assert any(r.kind == "stale_evidence" for r in signal.reasons)
+
+    def test_api_change_marks_specific_claim_stale(self):
+        unit = _unit(["openai.completions.v1.reachable", "openai.embeddings.ok"])
+        results = world_event_to_claim_results(unit, _api_event(), require_enabled=False)
+        stale = [r for r in evaluate_unit(unit, claim_results=results).reasons if r.kind == "stale_evidence"]
+        assert any(r.claim_id == "openai.completions.v1.reachable" for r in stale)
+
+    def test_dependency_bump_propagates_decay(self):
+        unit = _unit(["pydantic.model.dict_supported"])
+        results = world_event_to_claim_results(unit, _dep_event(), require_enabled=False)
+        assert any(r.kind == "stale_evidence" for r in evaluate_unit(unit, claim_results=results).reasons)
+
+    def test_unrelated_event_leaves_score_intact(self):
+        unit = _unit(["anthropic.api.stable", "project.build.passing"])
+        results = world_event_to_claim_results(unit, _cve(["libfoo"]), require_enabled=False)
+        assert evaluate_unit(unit, claim_results=results).integrity_score == 1.0


### PR DESCRIPTION
## Slice

Adds `WorldStateEvent` and two translation functions (`claims_affected_by_event`, `world_event_to_claim_results`) that convert external world-state events — CVE drops, API sunsets, dependency version bumps, corpus revisions — into `ClaimResult(STALE)` objects consumable by `evaluate_unit()`. This satisfies the DIC-20 acceptance criterion that was explicitly missing from the existing `decay_monitor.py` implementation: *"Include synthetic tests for a dependency/API/CVE-like world event invalidating a linked assumption."*

## Gating

- Default: OFF (flag: `ARAGORA_WORLD_EVENTS_ENABLED`)
- `claims_affected_by_event` is always flag-free (pure computation)
- `world_event_to_claim_results` raises `RuntimeError` when the flag is off (unless `require_enabled=False` for test use)
- Live queue effect: none — module is report-only; no state mutation, no issue creation, no dispatch
- Advances issue: #6031 (DIC-20 — epistemic decay monitor)

## Tests

- `TestClaimsAffectedByEvent` (5 tests) — CVE substring match, API prefix match, dependency dot-prefix match, empty-scope safety, multi-pattern union
- `TestWorldEventToClaimResults` (7 tests) — STALE status, message content, empty-scope empty dict, flag-off raises, `require_enabled=False` bypass, flag-on allows, `world_events_enabled` truth values
- `TestWorldEventDecayIntegration` (4 tests) — CVE lowers integrity score end-to-end, API change marks specific claim stale via `evaluate_unit`, dependency bump propagates stale reason, unrelated event leaves score intact

## Validation

- `pytest tests/epistemic/test_world_state_decay.py --noconftest` — **16 passed** in 0.12s
- `ruff check aragora/epistemic/world_event.py tests/epistemic/test_world_state_decay.py` — clean
- `ast.parse` — clean on both files

## Out of scope

- `WorldStateEvent` persistence or storage (report-only by design; DIC-21/22 add quarantine/repair on top)
- Automatic discovery of CVEs or API changes from external feeds (would require network access; future sub-deliverable)
- Wiring `world_event_to_claim_results` into the Arena or control-plane loops (gated on the proof-first Foreman gate opening for DIC-13..22)


---
_Generated by [Claude Code](https://claude.ai/code/session_018XWbx7NiMc3PYV7sgG8g1r)_