### PR TITLE
fix(fable): stage temp cycle context before consult

### DIFF
--- a/scripts/fable_goal_cycle.py
+++ b/scripts/fable_goal_cycle.py
@@ -334,7 +334,9 @@ def _prepare_context_files(
         try:
             staged_root.mkdir(parents=True, exist_ok=True)
             staged = staged_root / _safe_context_name(resolved)
-            data = _read_regular_file_no_follow(candidate, MAX_CONTEXT_FILE_BYTES + 1)
+            if candidate.is_symlink():
+                raise OSError(f"context file is a symlink: {candidate}")
+            data = _read_regular_file_no_follow(resolved, MAX_CONTEXT_FILE_BYTES + 1)
             _write_regular_file_no_follow(staged, data)
         except OSError as exc:
             prepared.append(raw_path)

--- a/scripts/fable_goal_cycle.py
+++ b/scripts/fable_goal_cycle.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import argparse
 import datetime as _dt
+import hashlib
 import json
 import re
 import shutil
@@ -49,6 +50,11 @@ MAX_PACKET_SECTION_BYTES = 96 * 1024
 SAFE_CONTEXT_SUBDIR = Path(".aragora") / "goal-cycle-context"
 DEFAULT_OUTPUT_DIR = ".aragora/goal_cycles"
 DEFAULT_MODEL = "claude-fable-5"
+TEMP_CONTEXT_NAME_RE = re.compile(
+    r"^(?:aragora_goal_cycle_context|cycle[-_]context(?:[-_][A-Za-z0-9._-]+)?|cycle[-_]report(?:[-_][A-Za-z0-9._-]+)?)"
+    r"\.(?:md|txt|json)$",
+    re.IGNORECASE,
+)
 NEXT_PROMPT_HEADING = "## NEXT PROMPT"
 NEXT_PROMPT_HEADING_RE = re.compile(
     rf"^{re.escape(NEXT_PROMPT_HEADING)}\s*$", re.IGNORECASE | re.MULTILINE
@@ -244,14 +250,18 @@ def _is_allowed_temp_context(resolved: Path) -> bool:
         Path("/tmp").resolve(strict=False),
         Path("/private/tmp").resolve(strict=False),
     }
-    if resolved.suffix.lower() not in {".md", ".txt", ".json"}:
+    if not TEMP_CONTEXT_NAME_RE.fullmatch(resolved.name):
         return False
-    return any(_is_relative_to(resolved, temp_root) for temp_root in temp_roots)
+    return any(resolved.parent == temp_root for temp_root in temp_roots)
 
 
 def _safe_context_name(path: Path) -> str:
-    name = re.sub(r"[^A-Za-z0-9._-]+", "_", path.name).strip("._")
-    return name or "context.md"
+    suffix = path.suffix.lower()
+    stem = path.stem if suffix else path.name
+    safe_stem = re.sub(r"[^A-Za-z0-9._-]+", "_", stem).strip("._")
+    safe_stem = safe_stem or "context"
+    digest = hashlib.sha256(str(path).encode("utf-8")).hexdigest()[:12]
+    return f"{safe_stem}-{digest}{suffix or '.txt'}"
 
 
 def _prepare_context_files(

--- a/scripts/fable_goal_cycle.py
+++ b/scripts/fable_goal_cycle.py
@@ -297,11 +297,16 @@ def _prepare_context_files(
             prepared.append(raw_path)
             continue
 
-        staged_root.mkdir(parents=True, exist_ok=True)
-        staged = staged_root / _safe_context_name(resolved)
-        with resolved.open("rb") as source:
-            data = source.read(MAX_CONTEXT_FILE_BYTES + 1)
-        staged.write_bytes(data)
+        try:
+            staged_root.mkdir(parents=True, exist_ok=True)
+            staged = staged_root / _safe_context_name(resolved)
+            with resolved.open("rb") as source:
+                data = source.read(MAX_CONTEXT_FILE_BYTES + 1)
+            staged.write_bytes(data)
+        except OSError as exc:
+            prepared.append(raw_path)
+            notes.append(f"context file staging failed: {resolved}: {exc}")
+            continue
         prepared.append(staged)
         notes.append(f"staged outside-repo context file {resolved} -> {staged}")
     return prepared, notes

--- a/scripts/fable_goal_cycle.py
+++ b/scripts/fable_goal_cycle.py
@@ -37,6 +37,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 DEFAULT_TIMEOUT_SECONDS = 900
@@ -236,6 +237,66 @@ def _read_context_file(path: Path, root: Path) -> tuple[str | None, str | None]:
     return body, note
 
 
+def _is_allowed_temp_context(resolved: Path) -> bool:
+    """Return true for explicit operator context staged from a temp directory."""
+    temp_roots = {
+        Path(tempfile.gettempdir()).resolve(strict=False),
+        Path("/tmp").resolve(strict=False),
+        Path("/private/tmp").resolve(strict=False),
+    }
+    if resolved.suffix.lower() not in {".md", ".txt", ".json"}:
+        return False
+    return any(_is_relative_to(resolved, temp_root) for temp_root in temp_roots)
+
+
+def _safe_context_name(path: Path) -> str:
+    name = re.sub(r"[^A-Za-z0-9._-]+", "_", path.name).strip("._")
+    return name or "context.md"
+
+
+def _prepare_context_files(
+    paths: list[Path], root: Path, stamp: str
+) -> tuple[list[Path], list[str]]:
+    """Stage explicit temp context files under the repo-safe packet boundary.
+
+    ``build_packet`` deliberately refuses arbitrary outside-repo files so a
+    typo cannot leak credentials into a persisted consult packet.  The CLI,
+    however, documents ``--context-file /tmp/...`` for operator cycle reports.
+    Treat only explicit Markdown/text/JSON files from a temp directory as
+    operator-supplied context and copy them into the safe context directory
+    before packet construction.
+    """
+
+    safe_root = root / SAFE_CONTEXT_SUBDIR
+    staged_root = safe_root / "imported" / stamp
+    prepared: list[Path] = []
+    notes: list[str] = []
+    for raw_path in paths:
+        candidate = raw_path if raw_path.is_absolute() else root / raw_path
+        try:
+            resolved = candidate.resolve(strict=True)
+        except OSError:
+            prepared.append(raw_path)
+            continue
+
+        if _is_relative_to(resolved, safe_root.resolve(strict=False)):
+            prepared.append(raw_path)
+            continue
+
+        if not resolved.is_file() or not _is_allowed_temp_context(resolved):
+            prepared.append(raw_path)
+            continue
+
+        staged_root.mkdir(parents=True, exist_ok=True)
+        staged = staged_root / _safe_context_name(resolved)
+        with resolved.open("rb") as source:
+            data = source.read(MAX_CONTEXT_FILE_BYTES + 1)
+        staged.write_bytes(data)
+        prepared.append(staged)
+        notes.append(f"staged outside-repo context file {resolved} -> {staged}")
+    return prepared, notes
+
+
 def gather_context(root: Path, since_hours: float, max_prs: int, skip_digest: bool) -> dict:
     """Collect bounded, read-only context sections. Failures become gaps."""
     sections: dict[str, str] = {}
@@ -337,6 +398,17 @@ def build_packet(
             "## Standing mission",
             _truncate_text_bytes(goal.strip(), MAX_PACKET_SECTION_BYTES),
         ]
+    for path in extra_files:
+        body, note = _read_context_file(path, root)
+        if note:
+            parts += ["", f"### Operator context {path} ({note})"]
+        if body is None:
+            continue
+        parts += [
+            "",
+            f"### Operator context: {path.name}",
+            _markdown_code_block(_bounded_code_block(body)),
+        ]
     parts += ["", "## Live state"]
     for name, body in context["sections"].items():
         parts += ["", f"### {name}", _markdown_code_block(_bounded_code_block(body))]
@@ -348,17 +420,6 @@ def build_packet(
             "",
             "## Context gaps (sources that failed or were skipped this cycle)",
             _markdown_code_block(_bounded_code_block(gap_body)),
-        ]
-    for path in extra_files:
-        body, note = _read_context_file(path, root)
-        if note:
-            parts += ["", f"### Operator context {path} ({note})"]
-        if body is None:
-            continue
-        parts += [
-            "",
-            f"### Operator context: {path.name}",
-            _markdown_code_block(_bounded_code_block(body)),
         ]
     return _packet_with_footer(parts)
 
@@ -454,10 +515,17 @@ def main(argv: list[str] | None = None) -> int:
     cycle_dir = _cycle_dir(cycle_root, stamp)
 
     context = gather_context(root, args.since_hours, args.max_prs, args.skip_digest)
+    context_files, context_notes = _prepare_context_files(
+        [Path(p) for p in args.context_file],
+        root,
+        stamp,
+    )
+    if context_notes:
+        context["sections"]["operator context staging"] = "\n".join(context_notes)
     packet = build_packet(
         context,
         args.goal,
-        [Path(p) for p in args.context_file],
+        context_files,
         args.since_hours,
         root=root,
     )

--- a/scripts/fable_goal_cycle.py
+++ b/scripts/fable_goal_cycle.py
@@ -25,7 +25,7 @@ Examples::
 
     python3 scripts/fable_goal_cycle.py --goal "Close the loop on settlement throughput"
     python3 scripts/fable_goal_cycle.py --dry-run --json      # build packet only
-    python3 scripts/fable_goal_cycle.py --context-file /tmp/cycle-report.md
+    python3 scripts/fable_goal_cycle.py --context-file "$TMPDIR/cycle-report.md"
 """
 
 from __future__ import annotations
@@ -246,15 +246,14 @@ def _read_context_file(path: Path, root: Path) -> tuple[str | None, str | None]:
 
 
 def _is_allowed_temp_context(resolved: Path) -> bool:
-    """Return true for explicit operator context staged from a temp directory."""
-    temp_roots = {
-        Path(tempfile.gettempdir()).resolve(strict=False),
-        Path("/tmp").resolve(strict=False),
-        Path("/private/tmp").resolve(strict=False),
-    }
+    """Return true for explicit operator context staged from the process temp root."""
     if not TEMP_CONTEXT_NAME_RE.fullmatch(resolved.name):
         return False
-    return any(_is_relative_to(resolved, temp_root) for temp_root in temp_roots)
+    try:
+        temp_root = Path(tempfile.gettempdir()).resolve(strict=True)
+    except OSError:
+        return False
+    return _is_relative_to(resolved, temp_root)
 
 
 def _safe_context_name(path: Path) -> str:

--- a/scripts/fable_goal_cycle.py
+++ b/scripts/fable_goal_cycle.py
@@ -312,6 +312,7 @@ def _prepare_context_files(
     """
 
     safe_root = root / SAFE_CONTEXT_SUBDIR
+    repo_root = root.resolve(strict=False)
     staged_root = safe_root / "imported" / stamp
     prepared: list[Path] = []
     notes: list[str] = []
@@ -324,6 +325,10 @@ def _prepare_context_files(
             continue
 
         if _is_relative_to(resolved, safe_root.resolve(strict=False)):
+            prepared.append(raw_path)
+            continue
+
+        if _is_relative_to(resolved, repo_root):
             prepared.append(raw_path)
             continue
 

--- a/scripts/fable_goal_cycle.py
+++ b/scripts/fable_goal_cycle.py
@@ -34,8 +34,10 @@ import argparse
 import datetime as _dt
 import hashlib
 import json
+import os
 import re
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
@@ -264,6 +266,22 @@ def _safe_context_name(path: Path) -> str:
     return f"{safe_stem}-{digest}{suffix or '.txt'}"
 
 
+def _read_regular_file_no_follow(path: Path, max_bytes: int) -> bytes:
+    """Read a regular file through a no-follow descriptor."""
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    fd = os.open(path, flags)
+    try:
+        file_stat = os.fstat(fd)
+        if not stat.S_ISREG(file_stat.st_mode):
+            raise OSError(f"context file is not a regular file: {path}")
+        with os.fdopen(fd, "rb") as source:
+            fd = -1
+            return source.read(max_bytes)
+    finally:
+        if fd >= 0:
+            os.close(fd)
+
+
 def _prepare_context_files(
     paths: list[Path], root: Path, stamp: str
 ) -> tuple[list[Path], list[str]]:
@@ -300,12 +318,11 @@ def _prepare_context_files(
         try:
             staged_root.mkdir(parents=True, exist_ok=True)
             staged = staged_root / _safe_context_name(resolved)
-            with resolved.open("rb") as source:
-                data = source.read(MAX_CONTEXT_FILE_BYTES + 1)
+            data = _read_regular_file_no_follow(candidate, MAX_CONTEXT_FILE_BYTES + 1)
             staged.write_bytes(data)
         except OSError as exc:
             prepared.append(raw_path)
-            notes.append(f"context file staging failed: {resolved}: {exc}")
+            notes.append(f"context file staging failed: {candidate}: {exc}")
             continue
         prepared.append(staged)
         notes.append(f"staged outside-repo context file {resolved} -> {staged}")

--- a/scripts/fable_goal_cycle.py
+++ b/scripts/fable_goal_cycle.py
@@ -254,7 +254,7 @@ def _is_allowed_temp_context(resolved: Path) -> bool:
     }
     if not TEMP_CONTEXT_NAME_RE.fullmatch(resolved.name):
         return False
-    return any(resolved.parent == temp_root for temp_root in temp_roots)
+    return any(_is_relative_to(resolved, temp_root) for temp_root in temp_roots)
 
 
 def _safe_context_name(path: Path) -> str:
@@ -277,6 +277,22 @@ def _read_regular_file_no_follow(path: Path, max_bytes: int) -> bytes:
         with os.fdopen(fd, "rb") as source:
             fd = -1
             return source.read(max_bytes)
+    finally:
+        if fd >= 0:
+            os.close(fd)
+
+
+def _write_regular_file_no_follow(path: Path, data: bytes) -> None:
+    """Create *path* as a regular file without following destination symlinks."""
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    fd = os.open(path, flags, 0o600)
+    try:
+        file_stat = os.fstat(fd)
+        if not stat.S_ISREG(file_stat.st_mode):
+            raise OSError(f"staged context path is not a regular file: {path}")
+        with os.fdopen(fd, "wb") as destination:
+            fd = -1
+            destination.write(data)
     finally:
         if fd >= 0:
             os.close(fd)
@@ -319,7 +335,7 @@ def _prepare_context_files(
             staged_root.mkdir(parents=True, exist_ok=True)
             staged = staged_root / _safe_context_name(resolved)
             data = _read_regular_file_no_follow(candidate, MAX_CONTEXT_FILE_BYTES + 1)
-            staged.write_bytes(data)
+            _write_regular_file_no_follow(staged, data)
         except OSError as exc:
             prepared.append(raw_path)
             notes.append(f"context file staging failed: {candidate}: {exc}")

--- a/tests/scripts/test_fable_goal_cycle.py
+++ b/tests/scripts/test_fable_goal_cycle.py
@@ -320,6 +320,48 @@ def test_prepare_context_files_leaves_non_temp_context_for_fail_closed_read(
     assert "TOKEN=secret" not in packet
 
 
+def test_prepare_context_files_fails_closed_when_staging_write_fails(
+    monkeypatch, tmp_path: Path
+) -> None:
+    temp_root = tmp_path / "tmp"
+    repo_root = tmp_path / "repo"
+    temp_root.mkdir()
+    repo_root.mkdir()
+    context_file = temp_root / "cycle-report-20260704.md"
+    context_file.write_text("operator facts", encoding="utf-8")
+    monkeypatch.setattr(fable_goal_cycle.tempfile, "gettempdir", lambda: str(temp_root))
+
+    original_write_bytes = Path.write_bytes
+
+    def fail_staged_write(path: Path, data: bytes) -> int:
+        if path.is_relative_to(repo_root / fable_goal_cycle.SAFE_CONTEXT_SUBDIR):
+            raise OSError("disk full")
+        return original_write_bytes(path, data)
+
+    monkeypatch.setattr(Path, "write_bytes", fail_staged_write)
+
+    prepared, notes = fable_goal_cycle._prepare_context_files(
+        [context_file],
+        repo_root,
+        "20260704T090000Z",
+    )
+
+    assert prepared == [context_file]
+    assert notes == [f"context file staging failed: {context_file}: disk full"]
+
+    packet = fable_goal_cycle.build_packet(
+        {"sections": {"operator context staging": "\n".join(notes)}, "gaps": []},
+        None,
+        prepared,
+        since_hours=24,
+        root=repo_root,
+    )
+
+    assert "context file staging failed" in packet
+    assert "context file must be under .aragora/goal-cycle-context" in packet
+    assert "operator facts" not in packet
+
+
 def test_build_packet_refuses_symlink_to_sensitive_context_path(tmp_path: Path) -> None:
     context_dir = tmp_path / fable_goal_cycle.SAFE_CONTEXT_SUBDIR
     context_dir.mkdir(parents=True)

--- a/tests/scripts/test_fable_goal_cycle.py
+++ b/tests/scripts/test_fable_goal_cycle.py
@@ -309,6 +309,36 @@ def test_prepare_context_files_stages_nested_temp_context(monkeypatch, tmp_path:
     assert notes == [f"staged outside-repo context file {context_file} -> {staged}"]
 
 
+def test_prepare_context_files_reads_from_resolved_temp_path(monkeypatch, tmp_path: Path) -> None:
+    temp_root = tmp_path / "tmp"
+    repo_root = tmp_path / "repo"
+    temp_root.mkdir()
+    repo_root.mkdir()
+    context_file = temp_root / "cycle-report-20260704.md"
+    context_file.write_text("operator facts", encoding="utf-8")
+    monkeypatch.setattr(fable_goal_cycle.tempfile, "gettempdir", lambda: str(temp_root))
+
+    read_paths: list[Path] = []
+    original_read = fable_goal_cycle._read_regular_file_no_follow
+
+    def capture_read(path: Path, max_bytes: int) -> bytes:
+        read_paths.append(path)
+        return original_read(path, max_bytes)
+
+    monkeypatch.setattr(fable_goal_cycle, "_read_regular_file_no_follow", capture_read)
+
+    prepared, notes = fable_goal_cycle._prepare_context_files(
+        [Path("..") / "tmp" / context_file.name],
+        repo_root,
+        "20260704T090000Z",
+    )
+
+    assert len(prepared) == 1
+    assert prepared[0].read_text(encoding="utf-8") == "operator facts"
+    assert notes == [f"staged outside-repo context file {context_file} -> {prepared[0]}"]
+    assert read_paths == [context_file.resolve()]
+
+
 def test_prepare_context_files_fails_closed_on_staged_destination_symlink(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/tests/scripts/test_fable_goal_cycle.py
+++ b/tests/scripts/test_fable_goal_cycle.py
@@ -221,6 +221,45 @@ def test_prepare_context_files_stages_explicit_temp_context(monkeypatch, tmp_pat
     assert "staged outside-repo context file" in packet
 
 
+def test_prepare_context_files_rejects_shared_tmp_when_process_temp_differs(
+    monkeypatch, tmp_path: Path
+) -> None:
+    process_temp = tmp_path / "process-temp"
+    repo_root = tmp_path / "repo"
+    process_temp.mkdir()
+    repo_root.mkdir()
+    shared_temp = Path("/tmp").resolve(strict=False)
+    context_file = shared_temp / f"cycle-report-{tmp_path.name}.md"
+    try:
+        context_file.write_text("untrusted shared temp", encoding="utf-8")
+    except OSError:
+        return
+    monkeypatch.setattr(fable_goal_cycle.tempfile, "gettempdir", lambda: str(process_temp))
+
+    try:
+        prepared, notes = fable_goal_cycle._prepare_context_files(
+            [context_file],
+            repo_root,
+            "20260704T090000Z",
+        )
+
+        assert prepared == [context_file]
+        assert notes == []
+
+        packet = fable_goal_cycle.build_packet(
+            {"sections": {}, "gaps": []},
+            None,
+            prepared,
+            since_hours=24,
+            root=repo_root,
+        )
+
+        assert "context file must be under .aragora/goal-cycle-context" in packet
+        assert "untrusted shared temp" not in packet
+    finally:
+        context_file.unlink(missing_ok=True)
+
+
 def test_prepare_context_files_rejects_explicit_temp_symlink(monkeypatch, tmp_path: Path) -> None:
     temp_root = tmp_path / "tmp"
     repo_root = tmp_path / "repo"
@@ -474,6 +513,51 @@ def test_prepare_context_files_fails_closed_when_staging_write_fails(
 
     assert prepared == [context_file]
     assert notes == [f"context file staging failed: {context_file}: disk full"]
+
+    packet = fable_goal_cycle.build_packet(
+        {"sections": {"operator context staging": "\n".join(notes)}, "gaps": []},
+        None,
+        prepared,
+        since_hours=24,
+        root=repo_root,
+    )
+
+    assert "context file staging failed" in packet
+    assert "context file must be under .aragora/goal-cycle-context" in packet
+    assert "operator facts" not in packet
+
+
+def test_prepare_context_files_fails_closed_when_staging_mkdir_fails(
+    monkeypatch, tmp_path: Path
+) -> None:
+    temp_root = tmp_path / "tmp"
+    repo_root = tmp_path / "repo"
+    stamp = "20260704T090000Z"
+    temp_root.mkdir()
+    repo_root.mkdir()
+    context_file = temp_root / "cycle-report-20260704.md"
+    context_file.write_text("operator facts", encoding="utf-8")
+    monkeypatch.setattr(fable_goal_cycle.tempfile, "gettempdir", lambda: str(temp_root))
+    staged_root = repo_root / fable_goal_cycle.SAFE_CONTEXT_SUBDIR / "imported" / stamp
+    original_mkdir = fable_goal_cycle.Path.mkdir
+
+    def fail_staging_mkdir(self: Path, *args, **kwargs) -> None:
+        if self == staged_root:
+            raise OSError("read-only staging root")
+        original_mkdir(self, *args, **kwargs)
+
+    monkeypatch.setattr(fable_goal_cycle.Path, "mkdir", fail_staging_mkdir)
+
+    prepared, notes = fable_goal_cycle._prepare_context_files(
+        [context_file],
+        repo_root,
+        stamp,
+    )
+
+    assert prepared == [context_file]
+    assert notes == [
+        f"context file staging failed: {context_file}: read-only staging root"
+    ]
 
     packet = fable_goal_cycle.build_packet(
         {"sections": {"operator context staging": "\n".join(notes)}, "gaps": []},

--- a/tests/scripts/test_fable_goal_cycle.py
+++ b/tests/scripts/test_fable_goal_cycle.py
@@ -555,9 +555,7 @@ def test_prepare_context_files_fails_closed_when_staging_mkdir_fails(
     )
 
     assert prepared == [context_file]
-    assert notes == [
-        f"context file staging failed: {context_file}: read-only staging root"
-    ]
+    assert notes == [f"context file staging failed: {context_file}: read-only staging root"]
 
     packet = fable_goal_cycle.build_packet(
         {"sections": {"operator context staging": "\n".join(notes)}, "gaps": []},

--- a/tests/scripts/test_fable_goal_cycle.py
+++ b/tests/scripts/test_fable_goal_cycle.py
@@ -190,7 +190,7 @@ def test_prepare_context_files_stages_explicit_temp_context(monkeypatch, tmp_pat
     repo_root = tmp_path / "repo"
     temp_root.mkdir()
     repo_root.mkdir()
-    context_file = temp_root / "cycle report.md"
+    context_file = temp_root / "cycle-report-20260704.md"
     context_file.write_text("operator facts", encoding="utf-8")
     monkeypatch.setattr(fable_goal_cycle.tempfile, "gettempdir", lambda: str(temp_root))
 
@@ -203,7 +203,8 @@ def test_prepare_context_files_stages_explicit_temp_context(monkeypatch, tmp_pat
     assert len(prepared) == 1
     staged = prepared[0]
     assert staged.is_relative_to(repo_root / fable_goal_cycle.SAFE_CONTEXT_SUBDIR)
-    assert staged.name == "cycle_report.md"
+    assert staged.name.startswith("cycle-report-20260704-")
+    assert staged.suffix == ".md"
     assert staged.read_text(encoding="utf-8") == "operator facts"
     assert notes == [f"staged outside-repo context file {context_file} -> {staged}"]
 
@@ -218,6 +219,71 @@ def test_prepare_context_files_stages_explicit_temp_context(monkeypatch, tmp_pat
     assert "operator facts" in packet
     assert "context file must be under" not in packet
     assert "staged outside-repo context file" in packet
+
+
+def test_prepare_context_files_rejects_secret_like_temp_context(
+    monkeypatch, tmp_path: Path
+) -> None:
+    temp_root = tmp_path / "tmp"
+    repo_root = tmp_path / "repo"
+    temp_root.mkdir()
+    repo_root.mkdir()
+    context_file = temp_root / "gha-creds-123.json"
+    context_file.write_text("TOKEN=secret", encoding="utf-8")
+    monkeypatch.setattr(fable_goal_cycle.tempfile, "gettempdir", lambda: str(temp_root))
+
+    prepared, notes = fable_goal_cycle._prepare_context_files(
+        [context_file],
+        repo_root,
+        "20260704T090000Z",
+    )
+
+    assert prepared == [context_file]
+    assert notes == []
+
+    packet = fable_goal_cycle.build_packet(
+        {"sections": {}, "gaps": []},
+        None,
+        prepared,
+        since_hours=24,
+        root=repo_root,
+    )
+
+    assert "context file must be under .aragora/goal-cycle-context" in packet
+    assert "TOKEN=secret" not in packet
+
+
+def test_prepare_context_files_rejects_nested_temp_context_outside_repo(
+    monkeypatch, tmp_path: Path
+) -> None:
+    temp_root = tmp_path / "tmp"
+    repo_root = temp_root / "repo"
+    external_dir = temp_root / "other-worktree"
+    repo_root.mkdir(parents=True)
+    external_dir.mkdir()
+    context_file = external_dir / "cycle-context-20260704.md"
+    context_file.write_text("outside temp repo", encoding="utf-8")
+    monkeypatch.setattr(fable_goal_cycle.tempfile, "gettempdir", lambda: str(temp_root))
+
+    prepared, notes = fable_goal_cycle._prepare_context_files(
+        [context_file],
+        repo_root,
+        "20260704T090000Z",
+    )
+
+    assert prepared == [context_file]
+    assert notes == []
+
+
+def test_safe_context_name_disambiguates_same_basename_sources() -> None:
+    first = fable_goal_cycle._safe_context_name(Path("/tmp/one/cycle-context.md"))
+    second = fable_goal_cycle._safe_context_name(Path("/tmp/two/cycle-context.md"))
+
+    assert first != second
+    assert first.startswith("cycle-context-")
+    assert second.startswith("cycle-context-")
+    assert first.endswith(".md")
+    assert second.endswith(".md")
 
 
 def test_prepare_context_files_leaves_non_temp_context_for_fail_closed_read(

--- a/tests/scripts/test_fable_goal_cycle.py
+++ b/tests/scripts/test_fable_goal_cycle.py
@@ -221,6 +221,39 @@ def test_prepare_context_files_stages_explicit_temp_context(monkeypatch, tmp_pat
     assert "staged outside-repo context file" in packet
 
 
+def test_prepare_context_files_rejects_explicit_temp_symlink(monkeypatch, tmp_path: Path) -> None:
+    temp_root = tmp_path / "tmp"
+    repo_root = tmp_path / "repo"
+    temp_root.mkdir()
+    repo_root.mkdir()
+    target_file = temp_root / "cycle-report-target.md"
+    target_file.write_text("operator facts", encoding="utf-8")
+    context_file = temp_root / "cycle-report-link.md"
+    context_file.symlink_to(target_file)
+    monkeypatch.setattr(fable_goal_cycle.tempfile, "gettempdir", lambda: str(temp_root))
+
+    prepared, notes = fable_goal_cycle._prepare_context_files(
+        [context_file],
+        repo_root,
+        "20260704T090000Z",
+    )
+
+    assert prepared == [context_file]
+    assert len(notes) == 1
+    assert notes[0].startswith(f"context file staging failed: {context_file}:")
+
+    packet = fable_goal_cycle.build_packet(
+        {"sections": {"operator context staging": "\n".join(notes)}, "gaps": []},
+        None,
+        prepared,
+        since_hours=24,
+        root=repo_root,
+    )
+
+    assert "operator facts" not in packet
+    assert "context file must be under .aragora/goal-cycle-context" in packet
+
+
 def test_prepare_context_files_rejects_secret_like_temp_context(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/tests/scripts/test_fable_goal_cycle.py
+++ b/tests/scripts/test_fable_goal_cycle.py
@@ -286,9 +286,7 @@ def test_prepare_context_files_rejects_secret_like_temp_context(
     assert "TOKEN=secret" not in packet
 
 
-def test_prepare_context_files_rejects_nested_temp_context_outside_repo(
-    monkeypatch, tmp_path: Path
-) -> None:
+def test_prepare_context_files_stages_nested_temp_context(monkeypatch, tmp_path: Path) -> None:
     temp_root = tmp_path / "tmp"
     repo_root = temp_root / "repo"
     external_dir = temp_root / "other-worktree"
@@ -304,8 +302,44 @@ def test_prepare_context_files_rejects_nested_temp_context_outside_repo(
         "20260704T090000Z",
     )
 
+    assert len(prepared) == 1
+    staged = prepared[0]
+    assert staged.is_relative_to(repo_root / fable_goal_cycle.SAFE_CONTEXT_SUBDIR)
+    assert staged.read_text(encoding="utf-8") == "outside temp repo"
+    assert notes == [f"staged outside-repo context file {context_file} -> {staged}"]
+
+
+def test_prepare_context_files_fails_closed_on_staged_destination_symlink(
+    monkeypatch, tmp_path: Path
+) -> None:
+    temp_root = tmp_path / "tmp"
+    repo_root = tmp_path / "repo"
+    stamp = "20260704T090000Z"
+    temp_root.mkdir()
+    repo_root.mkdir()
+    context_file = temp_root / "cycle-report-20260704.md"
+    context_file.write_text("operator facts", encoding="utf-8")
+    monkeypatch.setattr(fable_goal_cycle.tempfile, "gettempdir", lambda: str(temp_root))
+    staged_root = repo_root / fable_goal_cycle.SAFE_CONTEXT_SUBDIR / "imported" / stamp
+    staged_root.mkdir(parents=True)
+    staged = staged_root / fable_goal_cycle._safe_context_name(context_file.resolve())
+    target = tmp_path / "target.txt"
+    target.write_text("target stays intact", encoding="utf-8")
+    try:
+        staged.symlink_to(target)
+    except OSError:
+        return
+
+    prepared, notes = fable_goal_cycle._prepare_context_files(
+        [context_file],
+        repo_root,
+        stamp,
+    )
+
     assert prepared == [context_file]
-    assert notes == []
+    assert len(notes) == 1
+    assert notes[0].startswith(f"context file staging failed: {context_file}:")
+    assert target.read_text(encoding="utf-8") == "target stays intact"
 
 
 def test_safe_context_name_disambiguates_same_basename_sources() -> None:
@@ -364,14 +398,11 @@ def test_prepare_context_files_fails_closed_when_staging_write_fails(
     context_file.write_text("operator facts", encoding="utf-8")
     monkeypatch.setattr(fable_goal_cycle.tempfile, "gettempdir", lambda: str(temp_root))
 
-    original_write_bytes = Path.write_bytes
-
-    def fail_staged_write(path: Path, data: bytes) -> int:
+    def fail_staged_write(path: Path, data: bytes) -> None:
         if path.is_relative_to(repo_root / fable_goal_cycle.SAFE_CONTEXT_SUBDIR):
             raise OSError("disk full")
-        return original_write_bytes(path, data)
 
-    monkeypatch.setattr(Path, "write_bytes", fail_staged_write)
+    monkeypatch.setattr(fable_goal_cycle, "_write_regular_file_no_follow", fail_staged_write)
 
     prepared, notes = fable_goal_cycle._prepare_context_files(
         [context_file],

--- a/tests/scripts/test_fable_goal_cycle.py
+++ b/tests/scripts/test_fable_goal_cycle.py
@@ -127,6 +127,31 @@ def test_build_packet_respects_aggregate_prompt_budget() -> None:
     assert "## NEXT PROMPT" in packet
 
 
+def test_build_packet_prioritizes_operator_context_before_large_live_state(
+    tmp_path: Path,
+) -> None:
+    context_dir = tmp_path / fable_goal_cycle.SAFE_CONTEXT_SUBDIR
+    context_dir.mkdir(parents=True)
+    context_file = context_dir / "cycle_report.md"
+    context_file.write_text("operator intent survives", encoding="utf-8")
+    oversized_body = "x" * fable_goal_cycle.MAX_PACKET_SECTION_BYTES
+
+    packet = fable_goal_cycle.build_packet(
+        {
+            "sections": {f"large {index}": oversized_body for index in range(10)},
+            "gaps": [],
+        },
+        "standing mission",
+        [context_file],
+        since_hours=24,
+        root=tmp_path,
+    )
+
+    assert len(packet.encode("utf-8")) <= fable_goal_cycle.MAX_PACKET_BYTES
+    assert "operator intent survives" in packet
+    assert "[truncated packet before remaining sections]" in packet
+
+
 def test_build_packet_aggregate_truncation_preserves_closed_fences() -> None:
     oversized_body = "x" * fable_goal_cycle.MAX_PACKET_SECTION_BYTES
 
@@ -154,6 +179,75 @@ def test_build_packet_refuses_sensitive_context_path(tmp_path: Path) -> None:
         [context_file],
         since_hours=24,
         root=tmp_path,
+    )
+
+    assert "context file must be under .aragora/goal-cycle-context" in packet
+    assert "TOKEN=secret" not in packet
+
+
+def test_prepare_context_files_stages_explicit_temp_context(monkeypatch, tmp_path: Path) -> None:
+    temp_root = tmp_path / "tmp"
+    repo_root = tmp_path / "repo"
+    temp_root.mkdir()
+    repo_root.mkdir()
+    context_file = temp_root / "cycle report.md"
+    context_file.write_text("operator facts", encoding="utf-8")
+    monkeypatch.setattr(fable_goal_cycle.tempfile, "gettempdir", lambda: str(temp_root))
+
+    prepared, notes = fable_goal_cycle._prepare_context_files(
+        [context_file],
+        repo_root,
+        "20260704T090000Z",
+    )
+
+    assert len(prepared) == 1
+    staged = prepared[0]
+    assert staged.is_relative_to(repo_root / fable_goal_cycle.SAFE_CONTEXT_SUBDIR)
+    assert staged.name == "cycle_report.md"
+    assert staged.read_text(encoding="utf-8") == "operator facts"
+    assert notes == [f"staged outside-repo context file {context_file} -> {staged}"]
+
+    packet = fable_goal_cycle.build_packet(
+        {"sections": {"operator context staging": "\n".join(notes)}, "gaps": []},
+        None,
+        prepared,
+        since_hours=24,
+        root=repo_root,
+    )
+
+    assert "operator facts" in packet
+    assert "context file must be under" not in packet
+    assert "staged outside-repo context file" in packet
+
+
+def test_prepare_context_files_leaves_non_temp_context_for_fail_closed_read(
+    monkeypatch, tmp_path: Path
+) -> None:
+    temp_root = tmp_path / "tmp"
+    repo_root = tmp_path / "repo"
+    external_root = tmp_path / "elsewhere"
+    temp_root.mkdir()
+    repo_root.mkdir()
+    external_root.mkdir()
+    context_file = external_root / "cycle_report.md"
+    context_file.write_text("TOKEN=secret", encoding="utf-8")
+    monkeypatch.setattr(fable_goal_cycle.tempfile, "gettempdir", lambda: str(temp_root))
+
+    prepared, notes = fable_goal_cycle._prepare_context_files(
+        [context_file],
+        repo_root,
+        "20260704T090000Z",
+    )
+
+    assert prepared == [context_file]
+    assert notes == []
+
+    packet = fable_goal_cycle.build_packet(
+        {"sections": {}, "gaps": []},
+        None,
+        prepared,
+        since_hours=24,
+        root=repo_root,
     )
 
     assert "context file must be under .aragora/goal-cycle-context" in packet

--- a/tests/scripts/test_fable_goal_cycle.py
+++ b/tests/scripts/test_fable_goal_cycle.py
@@ -286,6 +286,38 @@ def test_prepare_context_files_rejects_secret_like_temp_context(
     assert "TOKEN=secret" not in packet
 
 
+def test_prepare_context_files_rejects_repo_local_temp_worktree_context(
+    monkeypatch, tmp_path: Path
+) -> None:
+    temp_root = tmp_path / "tmp"
+    repo_root = temp_root / "repo"
+    repo_root.mkdir(parents=True)
+    context_file = repo_root / "cycle-report-secrets.md"
+    context_file.write_text("TOKEN=secret", encoding="utf-8")
+    raw_path = Path(context_file.name)
+    monkeypatch.setattr(fable_goal_cycle.tempfile, "gettempdir", lambda: str(temp_root))
+
+    prepared, notes = fable_goal_cycle._prepare_context_files(
+        [raw_path],
+        repo_root,
+        "20260704T090000Z",
+    )
+
+    assert prepared == [raw_path]
+    assert notes == []
+
+    packet = fable_goal_cycle.build_packet(
+        {"sections": {}, "gaps": []},
+        None,
+        prepared,
+        since_hours=24,
+        root=repo_root,
+    )
+
+    assert "context file must be under .aragora/goal-cycle-context" in packet
+    assert "TOKEN=secret" not in packet
+
+
 def test_prepare_context_files_stages_nested_temp_context(monkeypatch, tmp_path: Path) -> None:
     temp_root = tmp_path / "tmp"
     repo_root = temp_root / "repo"


### PR DESCRIPTION
## Summary
- stage caller-provided context files into the goal-cycle artifact directory before invoking consult
- keep prompt-file paths under the persisted cycle directory so consult output remains reproducible and does not depend on transient /tmp paths
- add focused regression coverage for staging and packet ordering

## Validation
- python3 -m pytest tests/scripts/test_fable_goal_cycle.py -q
- python3 -m ruff check scripts/fable_goal_cycle.py tests/scripts/test_fable_goal_cycle.py
- git diff --check origin/main...HEAD

Draft because this needs normal CI and model-quorum review before any merge decision.