### PR TITLE
feat(cli): add founder status report

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,7 +192,7 @@ Aragora is the **Decision Integrity Platform** -- orchestrating 46 agent types t
 **Five Pillars:** (1) SMB-ready with enterprise-grade security, (2) leading-edge memory and context processing, (3) extensible/modular with broad connectors and SDKs, (4) multi-agent robustness via heterogeneous model consensus, (5) self-healing and self-extending via the Nomic Loop.
 
 <!-- metrics:begin claude-codebase-scale -->
-**Codebase Scale:** 4,259 tracked Python files | 144 top-level modules | 223,050 test functions | 5,429 test files | 3,297 API operations across 2,870 paths | canonical counts in `docs/METRICS.md`
+**Codebase Scale:** 4,260 tracked Python files | 144 top-level modules | 223,079 test functions | 5,433 test files | 3,297 API operations across 2,870 paths | canonical counts in `docs/METRICS.md`
 <!-- metrics:end -->
 
 ## Architecture
@@ -442,7 +442,7 @@ See `docs/reference/ENVIRONMENT.md` for full reference.
 ## Feature Status
 
 <!-- metrics:begin claude-test-suite -->
-**Test Suite:** 223,050 test functions across 5,429 test files (canonical counts in `docs/METRICS.md`)
+**Test Suite:** 223,079 test functions across 5,433 test files (canonical counts in `docs/METRICS.md`)
 <!-- metrics:end -->
 
 **Core (stable):**

--- a/aragora/cli/commands/founder_status.py
+++ b/aragora/cli/commands/founder_status.py
@@ -32,7 +32,7 @@ def add_founder_status_arguments(
             "proof-loop health, latest brief, and one next action."
         ),
     )
-    status_parser.add_argument("--json", action="store_true", help="Output as JSON")
+    status_parser.add_argument("--json", action="store_true", help="Output founder status as JSON")
     status_parser.add_argument(
         "--repo",
         default=None,

--- a/aragora/cli/commands/founder_status.py
+++ b/aragora/cli/commands/founder_status.py
@@ -221,12 +221,21 @@ def _queue_next_action(
         }
 
     not_ready = queue.get("not_ready") or []
-    entries = queue.get("top_entries") or []
+    not_ready_entries = queue.get("not_ready_entries") or []
+    top_entries = queue.get("top_entries") or []
     if not_ready:
+        not_ready_set = set(not_ready)
         first_not_ready = next(
-            (entry for entry in entries if entry.get("pr_number") in set(not_ready)),
-            entries[0] if entries else None,
+            (entry for entry in not_ready_entries if entry.get("pr_number") in not_ready_set),
+            None,
         )
+        if first_not_ready is None:
+            first_not_ready = next(
+                (entry for entry in top_entries if entry.get("pr_number") in not_ready_set),
+                None,
+            )
+        if first_not_ready is None:
+            first_not_ready = {"pr_number": not_ready[0], "status": "unknown", "reasons": []}
         if first_not_ready:
             pr = first_not_ready.get("pr_number")
             status = first_not_ready.get("status") or "unknown"
@@ -257,6 +266,11 @@ def _queue_next_action(
         "summary": "No queue action was selected from available local evidence.",
         "detail": "Run with --json and inspect transport/proof-loop fields.",
     }
+
+
+def _not_ready_entries(entries: list[dict[str, Any]], not_ready: list[Any]) -> list[dict[str, Any]]:
+    not_ready_set = set(not_ready)
+    return [entry for entry in entries if entry.get("pr_number") in not_ready_set]
 
 
 def _queue_report(
@@ -291,12 +305,14 @@ def _queue_report(
             "admin_squash_order": [],
             "human_risk_settlement_required": [],
             "not_ready": [],
+            "not_ready_entries": [],
             "top_entries": [],
         }
 
     entries = [
         _entry_summary(entry) for entry in packet.get("entries", []) if isinstance(entry, dict)
     ]
+    not_ready = packet.get("not_ready") or []
     counts = Counter(str(entry.get("status") or "unknown") for entry in entries)
     return {
         "transport_status": "ok",
@@ -305,7 +321,8 @@ def _queue_report(
         "status_counts": dict(sorted(counts.items())),
         "admin_squash_order": packet.get("admin_squash_order") or [],
         "human_risk_settlement_required": packet.get("human_risk_settlement_required") or [],
-        "not_ready": packet.get("not_ready") or [],
+        "not_ready": not_ready,
+        "not_ready_entries": _not_ready_entries(entries, not_ready),
         "top_entries": entries[: min(limit, 10)],
     }
 

--- a/aragora/cli/commands/founder_status.py
+++ b/aragora/cli/commands/founder_status.py
@@ -1,0 +1,414 @@
+"""Founder-facing Aragora status report.
+
+This is a read-only transport-compression surface: it answers the repeated
+"what is status / what should happen next?" operator question by composing
+existing health and merge-packet primitives. It never posts, reruns, approves,
+settles, merges, or writes receipts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+UTC = timezone.utc
+
+
+def _now() -> datetime:
+    return datetime.now(tz=UTC)
+
+
+def _age_hours(path: Path, *, now: datetime) -> float | None:
+    try:
+        mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=UTC)
+    except OSError:
+        return None
+    return (now - mtime).total_seconds() / 3600.0
+
+
+def _resolve_repo_root(raw: str | None) -> Path:
+    if raw:
+        return Path(raw).expanduser().resolve()
+    cwd = Path.cwd()
+    for candidate in (cwd, *cwd.parents):
+        if (candidate / ".git").exists() or (candidate / ".aragora").exists():
+            return candidate.resolve()
+    return cwd.resolve()
+
+
+def _resolve_state_dir(repo_root: Path) -> Path:
+    local = repo_root / ".aragora"
+    if local.is_dir():
+        return local
+    configured = os.environ.get("ARAGORA_AUTOMATION_STATE_ROOT")
+    candidates = [Path(configured).expanduser()] if configured else []
+    candidates.append(Path.home() / "Development" / "aragora")
+    for candidate in candidates:
+        state = candidate if candidate.name == ".aragora" else candidate / ".aragora"
+        if state.is_dir():
+            return state
+    return local
+
+
+def _newest_file(root: Path) -> Path | None:
+    if root.is_file():
+        return root
+    if not root.exists() or not root.is_dir():
+        return None
+    newest: tuple[float, Path] | None = None
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        try:
+            mtime = path.stat().st_mtime
+        except OSError:
+            continue
+        if newest is None or mtime > newest[0]:
+            newest = (mtime, path)
+    return newest[1] if newest is not None else None
+
+
+def _brief_preview(path: Path, *, max_lines: int = 3) -> str:
+    lines: list[str] = []
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                lines.append(stripped)
+                if len(lines) >= max_lines:
+                    break
+    except OSError:
+        return ""
+    return " / ".join(lines)
+
+
+def _latest_brief(state_dir: Path, raw_root: str | None, *, now: datetime) -> dict[str, Any]:
+    brief_root = Path(raw_root).expanduser() if raw_root else state_dir / "overnight-brief"
+    preferred = brief_root / "latest.md"
+    path = preferred if preferred.is_file() else _newest_file(brief_root)
+    if path is None:
+        return {
+            "available": False,
+            "root": str(brief_root),
+            "path": None,
+            "age_hours": None,
+            "preview": "",
+        }
+    return {
+        "available": True,
+        "root": str(brief_root),
+        "path": str(path),
+        "age_hours": _age_hours(path, now=now),
+        "preview": _brief_preview(path),
+    }
+
+
+def _entry_summary(entry: dict[str, Any]) -> dict[str, Any]:
+    raw_reasons = entry.get("reasons")
+    reasons: list[Any] = raw_reasons if isinstance(raw_reasons, list) else []
+    return {
+        "pr_number": entry.get("pr_number"),
+        "title": entry.get("title"),
+        "url": entry.get("url"),
+        "head_sha": entry.get("head_sha"),
+        "tier": entry.get("tier"),
+        "status": entry.get("status"),
+        "verdict": entry.get("verdict"),
+        "admin_squash_allowed": bool(entry.get("admin_squash_allowed")),
+        "requires_human_risk_settlement": bool(entry.get("requires_human_risk_settlement")),
+        "requires_human_preapproval": bool(entry.get("requires_human_preapproval")),
+        "unresolved_dissent": bool(entry.get("unresolved_dissent")),
+        "checks_summary": entry.get("checks_summary"),
+        "counted_model_families": entry.get("counted_model_families") or [],
+        "reasons": [str(reason) for reason in reasons[:5]],
+    }
+
+
+def _queue_next_action(
+    *,
+    queue: dict[str, Any],
+    proof_loop: dict[str, Any],
+    brief: dict[str, Any],
+) -> dict[str, str]:
+    if queue.get("transport_status") != "ok":
+        return {
+            "kind": "repair_transport",
+            "summary": "Restore GitHub transport before making queue decisions.",
+            "detail": str(queue.get("transport_error") or "merge-packet transport failed"),
+        }
+
+    admin_order = queue.get("admin_squash_order") or []
+    if admin_order:
+        first = admin_order[0]
+        return {
+            "kind": "settlement_ready",
+            "summary": f"Review exact-head merge authority for PR #{first}.",
+            "detail": "Use the normal merge gate only; this report is not settlement authority.",
+        }
+
+    human_required = queue.get("human_risk_settlement_required") or []
+    if human_required:
+        first = human_required[0]
+        return {
+            "kind": "human_settlement",
+            "summary": f"Record or reject human risk settlement for PR #{first}.",
+            "detail": "Human judgment remains explicit; automate only the receipt/status tail.",
+        }
+
+    not_ready = queue.get("not_ready") or []
+    entries = queue.get("top_entries") or []
+    if not_ready:
+        first_not_ready = next(
+            (entry for entry in entries if entry.get("pr_number") in set(not_ready)),
+            entries[0] if entries else None,
+        )
+        if first_not_ready:
+            pr = first_not_ready.get("pr_number")
+            status = first_not_ready.get("status") or "unknown"
+            reasons = first_not_ready.get("reasons") or []
+            detail = str(reasons[0]) if reasons else "inspect merge-packet blockers"
+            return {
+                "kind": "queue_blocker",
+                "summary": f"Work one bounded blocker on PR #{pr} ({status}).",
+                "detail": detail,
+            }
+
+    if proof_loop.get("overall_status") in {"stale", "missing"}:
+        return {
+            "kind": "proof_loop_repair",
+            "summary": "Repair stale or missing proof-loop surfaces.",
+            "detail": "Run review-queue health for exact stale surfaces.",
+        }
+
+    if brief.get("available"):
+        return {
+            "kind": "read_brief",
+            "summary": "Read the latest founder brief, then pick one bounded queue action.",
+            "detail": str(brief.get("path") or ""),
+        }
+
+    return {
+        "kind": "idle",
+        "summary": "No queue action was selected from available local evidence.",
+        "detail": "Run with --json and inspect transport/proof-loop fields.",
+    }
+
+
+def _queue_report(
+    *,
+    limit: int,
+    repo: str | None,
+    review_queue_root: str | None,
+    merge_packet_builder: Any | None = None,
+) -> dict[str, Any]:
+    if merge_packet_builder is None:
+        from aragora.cli.commands.review_queue import _build_merge_authorization_packet
+
+        merge_packet_builder = _build_merge_authorization_packet
+
+    try:
+        packet = merge_packet_builder(
+            pr_refs=[],
+            limit=limit,
+            repo_override=repo,
+            review_queue_root=review_queue_root,
+            execute_reviewers=False,
+            ignore_own_quorum_check=False,
+        )
+    except Exception as exc:  # noqa: BLE001 - status should degrade, not crash
+        return {
+            "transport_status": "blocked",
+            "transport_error": f"{type(exc).__name__}: {exc}",
+            "queue_pressure": None,
+            "status_counts": {},
+            "admin_squash_order": [],
+            "human_risk_settlement_required": [],
+            "not_ready": [],
+            "top_entries": [],
+        }
+
+    entries = [
+        _entry_summary(entry) for entry in packet.get("entries", []) if isinstance(entry, dict)
+    ]
+    counts = Counter(str(entry.get("status") or "unknown") for entry in entries)
+    return {
+        "transport_status": "ok",
+        "transport_error": None,
+        "queue_pressure": packet.get("queue_pressure") or {},
+        "status_counts": dict(sorted(counts.items())),
+        "admin_squash_order": packet.get("admin_squash_order") or [],
+        "human_risk_settlement_required": packet.get("human_risk_settlement_required") or [],
+        "not_ready": packet.get("not_ready") or [],
+        "top_entries": entries[: min(limit, 10)],
+    }
+
+
+def gather_founder_status(
+    *,
+    repo_root: str | None = None,
+    repo: str | None = None,
+    limit: int = 10,
+    review_queue_root: str | None = None,
+    overnight_root: str | None = None,
+    automation_receipts_root: str | None = None,
+    overnight_brief_root: str | None = None,
+    health_gatherer: Any | None = None,
+    merge_packet_builder: Any | None = None,
+) -> dict[str, Any]:
+    """Build the read-only founder status report."""
+    from aragora.review.health import gather_health
+
+    now = _now()
+    resolved_repo = _resolve_repo_root(repo_root)
+    state_dir = _resolve_state_dir(resolved_repo)
+    health_fn = health_gatherer or gather_health
+    health = health_fn(
+        repo_root=resolved_repo,
+        review_queue_root=Path(review_queue_root).expanduser() if review_queue_root else None,
+        overnight_root=Path(overnight_root).expanduser() if overnight_root else None,
+        automation_receipts_root=(
+            Path(automation_receipts_root).expanduser() if automation_receipts_root else None
+        ),
+    )
+    proof_loop = health.to_dict()
+    queue = _queue_report(
+        limit=max(1, limit),
+        repo=repo,
+        review_queue_root=review_queue_root,
+        merge_packet_builder=merge_packet_builder,
+    )
+    brief = _latest_brief(state_dir, overnight_brief_root, now=now)
+    next_action = _queue_next_action(queue=queue, proof_loop=proof_loop, brief=brief)
+    return {
+        "version": "founder_status.v1",
+        "generated_at": now.isoformat(),
+        "repo_root": str(resolved_repo),
+        "state_dir": str(state_dir),
+        "queue": queue,
+        "proof_loop": proof_loop,
+        "latest_brief": brief,
+        "next_action": next_action,
+    }
+
+
+def _format_age(age_hours: Any) -> str:
+    if age_hours is None:
+        return "n/a"
+    age = float(age_hours)
+    if age < 96:
+        return f"{age:.1f}h"
+    return f"{age / 24:.1f}d"
+
+
+def render_founder_status(report: dict[str, Any]) -> str:
+    """Render the founder status report for terminal use."""
+    queue = report.get("queue") or {}
+    proof = report.get("proof_loop") or {}
+    brief = report.get("latest_brief") or {}
+    next_action = report.get("next_action") or {}
+    pressure = queue.get("queue_pressure") or {}
+
+    lines = [
+        "Aragora Founder Status",
+        f"  generated_at: {report.get('generated_at')}",
+        f"  repo_root:    {report.get('repo_root')}",
+        (
+            "  queue:        "
+            f"transport={queue.get('transport_status')} "
+            f"open_prs={pressure.get('current_open_prs', 'n/a')} "
+            f"cap={pressure.get('cap', 'n/a')} active={pressure.get('active', 'n/a')}"
+        ),
+        f"  proof_loop:   {str(proof.get('overall_status') or 'unknown').upper()}",
+        (
+            "  latest_brief: "
+            f"{brief.get('path') or '(none)'} age={_format_age(brief.get('age_hours'))}"
+        ),
+        "",
+        f"Next action: {next_action.get('summary', '(none)')}",
+    ]
+    if next_action.get("detail"):
+        lines.append(f"  detail: {next_action['detail']}")
+
+    if queue.get("transport_status") != "ok":
+        lines.extend(["", f"Queue transport: {queue.get('transport_error')}"])
+    else:
+        lines.extend(
+            [
+                "",
+                "Queue summary:",
+                f"  status_counts: {queue.get('status_counts') or {}}",
+                f"  admin_squash_order: {queue.get('admin_squash_order') or []}",
+                (
+                    "  human_risk_settlement_required: "
+                    f"{queue.get('human_risk_settlement_required') or []}"
+                ),
+                f"  not_ready: {queue.get('not_ready') or []}",
+            ]
+        )
+        entries = queue.get("top_entries") or []
+        if entries:
+            lines.append("")
+            lines.append("Top PRs:")
+            for entry in entries[:5]:
+                lines.append(
+                    "  "
+                    f"#{entry.get('pr_number')} T{entry.get('tier')} "
+                    f"{entry.get('status')} | {entry.get('verdict')} | "
+                    f"{entry.get('checks_summary')}"
+                )
+                reasons = entry.get("reasons") or []
+                if reasons:
+                    lines.append(f"    - {reasons[0]}")
+
+    stale = [
+        surface
+        for surface in proof.get("surfaces", [])
+        if isinstance(surface, dict) and surface.get("status") in {"stale", "missing"}
+    ]
+    if stale:
+        lines.append("")
+        lines.append("Proof-loop attention:")
+        for surface in stale[:5]:
+            lines.append(
+                "  "
+                f"{surface.get('name')}: {surface.get('status')} "
+                f"age={_format_age(surface.get('age_hours'))} "
+                f"{surface.get('detail') or ''}"
+            )
+
+    preview = brief.get("preview")
+    if preview:
+        lines.extend(["", f"Brief preview: {preview}"])
+
+    return "\n".join(lines)
+
+
+def cmd_founder_status(args: argparse.Namespace) -> int:
+    report = gather_founder_status(
+        repo_root=getattr(args, "repo_root", None),
+        repo=getattr(args, "repo", None),
+        limit=int(getattr(args, "limit", 10) or 10),
+        review_queue_root=getattr(args, "review_queue_root", None),
+        overnight_root=getattr(args, "overnight_root", None),
+        automation_receipts_root=getattr(args, "automation_receipts_root", None),
+        overnight_brief_root=getattr(args, "overnight_brief_root", None),
+    )
+    if bool(getattr(args, "json", False)):
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(render_founder_status(report))
+    return 0
+
+
+__all__ = [
+    "cmd_founder_status",
+    "gather_founder_status",
+    "render_founder_status",
+]

--- a/aragora/cli/commands/founder_status.py
+++ b/aragora/cli/commands/founder_status.py
@@ -19,6 +19,64 @@ from typing import Any
 UTC = timezone.utc
 
 
+def add_founder_status_arguments(
+    status_parser: argparse.ArgumentParser,
+    *,
+    default_api_url: str,
+) -> None:
+    status_parser.add_argument(
+        "--founder",
+        action="store_true",
+        help=(
+            "Show a read-only founder ops report: queue pressure, merge blockers, "
+            "proof-loop health, latest brief, and one next action."
+        ),
+    )
+    status_parser.add_argument("--json", action="store_true", help="Output as JSON")
+    status_parser.add_argument(
+        "--repo",
+        default=None,
+        help="GitHub repo slug override for founder status (owner/name).",
+    )
+    status_parser.add_argument(
+        "--limit",
+        type=int,
+        default=10,
+        help="Max PRs to inspect for founder status (default: 10).",
+    )
+    status_parser.add_argument(
+        "--repo-root",
+        default=None,
+        help="Override repo root for founder status local health and brief lookups.",
+    )
+    status_parser.add_argument(
+        "--review-queue-root",
+        default=None,
+        help="Override .aragora/review-queue root for founder status.",
+    )
+    status_parser.add_argument(
+        "--overnight-root",
+        default=None,
+        help="Override .aragora/overnight root for founder status health checks.",
+    )
+    status_parser.add_argument(
+        "--automation-receipts-root",
+        default=None,
+        help="Override .aragora/automation-receipts root for founder status health checks.",
+    )
+    status_parser.add_argument(
+        "--overnight-brief-root",
+        default=None,
+        help="Override .aragora/overnight-brief root for founder status.",
+    )
+    status_parser.add_argument(
+        "--server",
+        "-s",
+        default=default_api_url,
+        help=f"Server URL to check (default: {default_api_url})",
+    )
+
+
 def _now() -> datetime:
     return datetime.now(tz=UTC)
 
@@ -208,6 +266,8 @@ def _queue_report(
     review_queue_root: str | None,
     merge_packet_builder: Any | None = None,
 ) -> dict[str, Any]:
+    from aragora.cli.commands.review_queue_transport import _GhError
+
     if merge_packet_builder is None:
         from aragora.cli.commands.review_queue import _build_merge_authorization_packet
 
@@ -222,7 +282,7 @@ def _queue_report(
             execute_reviewers=False,
             ignore_own_quorum_check=False,
         )
-    except Exception as exc:  # noqa: BLE001 - status should degrade, not crash
+    except (_GhError, RuntimeError, OSError, ValueError) as exc:
         return {
             "transport_status": "blocked",
             "transport_error": f"{type(exc).__name__}: {exc}",
@@ -408,6 +468,7 @@ def cmd_founder_status(args: argparse.Namespace) -> int:
 
 
 __all__ = [
+    "add_founder_status_arguments",
     "cmd_founder_status",
     "gather_founder_status",
     "render_founder_status",

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -1006,7 +1006,7 @@ def cmd_review_queue(args: argparse.Namespace) -> int:
 def _cmd_build(args: argparse.Namespace) -> int:
     json_output = bool(getattr(args, "json", False) or getattr(args, "json_output", False))
     try:
-        items = _build_queue(limit=args.limit)
+        items = _build_queue(limit=args.limit, repo_override=getattr(args, "repo", None))
     except _GhError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
@@ -1080,7 +1080,7 @@ def _cmd_run(args: argparse.Namespace) -> int:
     repo_root = resolve_repo_root(Path.cwd())
     try:
         _require_clean_worktree(repo_root)
-        items = _build_queue(limit=args.limit)
+        items = _build_queue(limit=args.limit, repo_override=getattr(args, "repo", None))
     except _GhError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
@@ -1661,7 +1661,7 @@ def _post_human_settlement_status(
     }
 
 
-def _build_queue(*, limit: int) -> list[QueueItem]:
+def _build_queue(*, limit: int, repo_override: str | None = None) -> list[QueueItem]:
     fields = ",".join(
         [
             "number",
@@ -1680,18 +1680,19 @@ def _build_queue(*, limit: int) -> list[QueueItem]:
             "statusCheckRollup",
         ]
     )
-    raw = _gh_json(
-        [
-            "pr",
-            "list",
-            "--state",
-            "open",
-            "--limit",
-            str(limit),
-            "--json",
-            fields,
-        ]
-    )
+    args = [
+        "pr",
+        "list",
+        "--state",
+        "open",
+        "--limit",
+        str(limit),
+        "--json",
+        fields,
+    ]
+    if repo_override:
+        args.extend(["--repo", repo_override])
+    raw = _gh_json(args)
     items: list[QueueItem] = []
     for pr in raw or []:
         if not isinstance(pr, dict):
@@ -2959,7 +2960,7 @@ def _build_merge_authorization_packet(
         queue_size = len(refs)
         scoped_pr_refs = True
     else:
-        queue = _build_queue(limit=limit)
+        queue = _build_queue(limit=limit, repo_override=repo_override)
         refs = [str(item.number) for item in queue]
         queue_size = len(queue)
 

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -505,6 +505,11 @@ def add_review_queue_parser(subparsers: argparse._SubParsersAction) -> None:
     build_p = sub.add_parser("build", help="Build prioritized review queue from open PRs")
     build_p.add_argument("--limit", type=int, default=100, help="Max PRs to fetch (default: 100)")
     build_p.add_argument(
+        "--repo",
+        default=None,
+        help="GitHub repo slug override (owner/name). Defaults to current repo context.",
+    )
+    build_p.add_argument(
         "--ready-only",
         action="store_true",
         help="Show only ready_now lane",

--- a/aragora/cli/commands/status.py
+++ b/aragora/cli/commands/status.py
@@ -120,8 +120,13 @@ async def _run_provider_smoke_checks(
     }
 
 
-def cmd_status(args: argparse.Namespace) -> None:
+def cmd_status(args: argparse.Namespace) -> int:
     """Handle 'status' command - show environment health and agent availability."""
+    if bool(getattr(args, "founder", False)):
+        from aragora.cli.commands.founder_status import cmd_founder_status
+
+        return cmd_founder_status(args)
+
     import shutil
 
     from aragora.config.provider_readiness import discover_provider_credentials
@@ -220,6 +225,7 @@ def cmd_status(args: argparse.Namespace) -> None:
 
     print("\n" + "=" * 60)
     print("Run 'aragora ask' to start a debate or 'aragora serve' to start the server")
+    return 0
 
 
 def cmd_doctor(args: argparse.Namespace) -> None:

--- a/aragora/cli/commands/status.py
+++ b/aragora/cli/commands/status.py
@@ -126,6 +126,9 @@ def cmd_status(args: argparse.Namespace) -> int:
         from aragora.cli.commands.founder_status import cmd_founder_status
 
         return cmd_founder_status(args)
+    if bool(getattr(args, "json", False)):
+        print("error: status --json requires --founder", file=sys.stderr)
+        return 2
 
     import shutil
 

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -1350,7 +1350,52 @@ def _add_stats_parser(subparsers) -> None:
 def _add_status_parser(subparsers) -> None:
     """Add the 'status' subcommand parser."""
     status_parser = subparsers.add_parser(
-        "status", help="Show environment health and agent availability"
+        "status", help="Show environment health, agent availability, or founder ops status"
+    )
+    status_parser.add_argument(
+        "--founder",
+        action="store_true",
+        help=(
+            "Show a read-only founder ops report: queue pressure, merge blockers, "
+            "proof-loop health, latest brief, and one next action."
+        ),
+    )
+    status_parser.add_argument("--json", action="store_true", help="Output as JSON")
+    status_parser.add_argument(
+        "--repo",
+        default=None,
+        help="GitHub repo slug override for founder status (owner/name).",
+    )
+    status_parser.add_argument(
+        "--limit",
+        type=int,
+        default=10,
+        help="Max PRs to inspect for founder status (default: 10).",
+    )
+    status_parser.add_argument(
+        "--repo-root",
+        default=None,
+        help="Override repo root for founder status local health and brief lookups.",
+    )
+    status_parser.add_argument(
+        "--review-queue-root",
+        default=None,
+        help="Override .aragora/review-queue root for founder status.",
+    )
+    status_parser.add_argument(
+        "--overnight-root",
+        default=None,
+        help="Override .aragora/overnight root for founder status health checks.",
+    )
+    status_parser.add_argument(
+        "--automation-receipts-root",
+        default=None,
+        help="Override .aragora/automation-receipts root for founder status health checks.",
+    )
+    status_parser.add_argument(
+        "--overnight-brief-root",
+        default=None,
+        help="Override .aragora/overnight-brief root for founder status.",
     )
     status_parser.add_argument(
         "--server",

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -2145,6 +2145,11 @@ def _add_review_queue_parser(subparsers) -> None:
     )
     build_parser.add_argument("--limit", type=int, default=100, help="Max PRs to fetch")
     build_parser.add_argument(
+        "--repo",
+        default=None,
+        help="GitHub repo slug override (owner/name). Defaults to current repo context.",
+    )
+    build_parser.add_argument(
         "--ready-only",
         action="store_true",
         help="Show only ready_now lane",

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -1352,57 +1352,9 @@ def _add_status_parser(subparsers) -> None:
     status_parser = subparsers.add_parser(
         "status", help="Show environment health, agent availability, or founder ops status"
     )
-    status_parser.add_argument(
-        "--founder",
-        action="store_true",
-        help=(
-            "Show a read-only founder ops report: queue pressure, merge blockers, "
-            "proof-loop health, latest brief, and one next action."
-        ),
-    )
-    status_parser.add_argument("--json", action="store_true", help="Output as JSON")
-    status_parser.add_argument(
-        "--repo",
-        default=None,
-        help="GitHub repo slug override for founder status (owner/name).",
-    )
-    status_parser.add_argument(
-        "--limit",
-        type=int,
-        default=10,
-        help="Max PRs to inspect for founder status (default: 10).",
-    )
-    status_parser.add_argument(
-        "--repo-root",
-        default=None,
-        help="Override repo root for founder status local health and brief lookups.",
-    )
-    status_parser.add_argument(
-        "--review-queue-root",
-        default=None,
-        help="Override .aragora/review-queue root for founder status.",
-    )
-    status_parser.add_argument(
-        "--overnight-root",
-        default=None,
-        help="Override .aragora/overnight root for founder status health checks.",
-    )
-    status_parser.add_argument(
-        "--automation-receipts-root",
-        default=None,
-        help="Override .aragora/automation-receipts root for founder status health checks.",
-    )
-    status_parser.add_argument(
-        "--overnight-brief-root",
-        default=None,
-        help="Override .aragora/overnight-brief root for founder status.",
-    )
-    status_parser.add_argument(
-        "--server",
-        "-s",
-        default=DEFAULT_API_URL,
-        help=f"Server URL to check (default: {DEFAULT_API_URL})",
-    )
+    from aragora.cli.commands.founder_status import add_founder_status_arguments
+
+    add_founder_status_arguments(status_parser, default_api_url=DEFAULT_API_URL)
     status_parser.set_defaults(func=_lazy("aragora.cli.commands.status", "cmd_status"))
 
 

--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -134,7 +134,7 @@ For full runtime configuration, see [ENVIRONMENT](../getting-started/environment
 | `spec` | - | Transform a vague idea into a structured specification | - |
 | `starter` | - | SME Starter Pack -- install to decision receipt in 15 minutes | - |
 | `stats` | - | Show memory statistics | - |
-| `status` | - | Show environment health and agent availability | - |
+| `status` | - | Show environment health, agent availability, or founder ops status | - |
 | `swarm` | - | Launch a swarm of AI agents to accomplish a goal | - |
 | `tasks` | - | Inspect and operate the developer task queue | `claim`, `complete`, `heartbeat`, `leases`, `list`, `release`, `salvage`, `show`, `stats`, `sync` |
 | `template` | - | Manage workflow templates | `list`, `package`, `run`, `show`, `validate` |

--- a/docs-site/docs/contributing/canonical-goals.md
+++ b/docs-site/docs/contributing/canonical-goals.md
@@ -18,11 +18,11 @@ Live project-scale numbers are auto-regenerated in [`docs/METRICS.md`](METRICS.m
 | Metric | Value | Source |
 |--------|-------|--------|
 | Version | 2.9.0 | `pyproject.toml` |
-| Python files under `aragora/` | 4,259 | `docs/METRICS.md` |
+| Python files under `aragora/` | 4,260 | `docs/METRICS.md` |
 | Python modules | 144 top-level package directories | `docs/METRICS.md` |
-| Lines of code under `aragora/` | 1,975,083 | `docs/METRICS.md` |
-| Automated tests | 223,050 test functions | `docs/METRICS.md` |
-| Test files | 5,429 | `docs/METRICS.md` |
+| Lines of code under `aragora/` | 1,975,628 | `docs/METRICS.md` |
+| Automated tests | 223,079 test functions | `docs/METRICS.md` |
+| Test files | 5,433 | `docs/METRICS.md` |
 | API operations | 3,297 across 2,870 paths | `docs/METRICS.md` |
 | API paths | 2,870 | `docs/METRICS.md` |
 | Knowledge Mound adapters | 46 adapter files / 41 registered specs | `docs/METRICS.md` |

--- a/docs-site/docs/contributing/claude.md
+++ b/docs-site/docs/contributing/claude.md
@@ -197,7 +197,7 @@ Aragora is the **Decision Integrity Platform** -- orchestrating 46 agent types t
 **Five Pillars:** (1) SMB-ready with enterprise-grade security, (2) leading-edge memory and context processing, (3) extensible/modular with broad connectors and SDKs, (4) multi-agent robustness via heterogeneous model consensus, (5) self-healing and self-extending via the Nomic Loop.
 
 <!-- metrics:begin claude-codebase-scale -->
-**Codebase Scale:** 4,259 tracked Python files | 144 top-level modules | 223,050 test functions | 5,429 test files | 3,297 API operations across 2,870 paths | canonical counts in `docs/METRICS.md`
+**Codebase Scale:** 4,260 tracked Python files | 144 top-level modules | 223,079 test functions | 5,433 test files | 3,297 API operations across 2,870 paths | canonical counts in `docs/METRICS.md`
 <!-- metrics:end -->
 
 ## Architecture
@@ -447,7 +447,7 @@ See `docs/reference/ENVIRONMENT.md` for full reference.
 ## Feature Status
 
 <!-- metrics:begin claude-test-suite -->
-**Test Suite:** 223,050 test functions across 5,429 test files (canonical counts in `docs/METRICS.md`)
+**Test Suite:** 223,079 test functions across 5,433 test files (canonical counts in `docs/METRICS.md`)
 <!-- metrics:end -->
 
 **Core (stable):**

--- a/docs-site/docs/contributing/extended-readme.md
+++ b/docs-site/docs/contributing/extended-readme.md
@@ -342,7 +342,7 @@ aragora/
 ```
 
 <!-- metrics:begin extended-readme-scale -->
-**Scale:** 4,259 tracked Python files | 144 top-level modules | 223,050 test functions across 5,429 test files | canonical counts in [METRICS.md](METRICS.md)
+**Scale:** 4,260 tracked Python files | 144 top-level modules | 223,079 test functions across 5,433 test files | canonical counts in [METRICS.md](METRICS.md)
 <!-- metrics:end -->
 
 ---

--- a/docs-site/docs/contributing/feature-discovery.md
+++ b/docs-site/docs/contributing/feature-discovery.md
@@ -28,7 +28,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | [Self-Improvement](#9-self-improvement--nomic-loop) | 18+ | Stable |
 
 <!-- metrics:begin feature-discovery-total -->
-**Total**: 230+ features | 4,259 Python files | 223,050 tests | 3,297 API operations across 2,870 paths
+**Total**: 230+ features | 4,260 Python files | 223,079 tests | 3,297 API operations across 2,870 paths
 <!-- metrics:end -->
 
 ---

--- a/docs-site/docs/contributing/status.md
+++ b/docs-site/docs/contributing/status.md
@@ -158,8 +158,8 @@ For the full current-status narrative, use the canonical doc:
 
 ### Codebase Metrics (generated from `docs/METRICS.md`)
 <!-- metrics:begin status-codebase-metrics -->
-- **Python files (`aragora/`)**: 4,259
-- **Tests**: 223,050 across 5,429 test files
+- **Python files (`aragora/`)**: 4,260
+- **Tests**: 223,079 across 5,433 test files
 - **KM adapters**: 41 registered adapter specs
 - **API operations**: 3,297 across 2,870 paths
 <!-- metrics:end -->

--- a/docs-site/docs/core-concepts/architecture.md
+++ b/docs-site/docs/core-concepts/architecture.md
@@ -759,8 +759,8 @@ Critical operations use explicit transactions:
 - **Storage tests**: 4,300+ tests across all backends including KM (Phase A2)
 - **SDK breadth**: Python and TypeScript SDKs (module counts in `docs/METRICS.md`)
 <!-- metrics:begin architecture-scale -->
-- **Test coverage**: 223,050 tests across 5,429 test files
-- **Source files**: 4,259 Python files under `aragora/`
+- **Test coverage**: 223,079 tests across 5,433 test files
+- **Source files**: 4,260 Python files under `aragora/`
 - **API surface**: 3,297 API operations across 2,870 paths
 - **KM adapters**: 41 registered adapters (see `aragora/knowledge/mound/adapters/`)
 <!-- metrics:end -->

--- a/docs/CANONICAL_GOALS.md
+++ b/docs/CANONICAL_GOALS.md
@@ -13,11 +13,11 @@ Live project-scale numbers are auto-regenerated in [`docs/METRICS.md`](METRICS.m
 | Metric | Value | Source |
 |--------|-------|--------|
 | Version | 2.9.0 | `pyproject.toml` |
-| Python files under `aragora/` | 4,259 | `docs/METRICS.md` |
+| Python files under `aragora/` | 4,260 | `docs/METRICS.md` |
 | Python modules | 144 top-level package directories | `docs/METRICS.md` |
-| Lines of code under `aragora/` | 1,975,083 | `docs/METRICS.md` |
-| Automated tests | 223,050 test functions | `docs/METRICS.md` |
-| Test files | 5,429 | `docs/METRICS.md` |
+| Lines of code under `aragora/` | 1,975,628 | `docs/METRICS.md` |
+| Automated tests | 223,079 test functions | `docs/METRICS.md` |
+| Test files | 5,433 | `docs/METRICS.md` |
 | API operations | 3,297 across 2,870 paths | `docs/METRICS.md` |
 | API paths | 2,870 | `docs/METRICS.md` |
 | Knowledge Mound adapters | 46 adapter files / 41 registered specs | `docs/METRICS.md` |

--- a/docs/EXTENDED_README.md
+++ b/docs/EXTENDED_README.md
@@ -337,7 +337,7 @@ aragora/
 ```
 
 <!-- metrics:begin extended-readme-scale -->
-**Scale:** 4,259 tracked Python files | 144 top-level modules | 223,050 test functions across 5,429 test files | canonical counts in [METRICS.md](METRICS.md)
+**Scale:** 4,260 tracked Python files | 144 top-level modules | 223,079 test functions across 5,433 test files | canonical counts in [METRICS.md](METRICS.md)
 <!-- metrics:end -->
 
 ---

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -13,10 +13,10 @@
 | Metric | Value | Source | Command |
 |---|---|---|---|
 | Python files under aragora/ | `4260` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1975601` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python lines of code under aragora/ | `1975628` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `144` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
 | Test files (test_*.py under tests/) | `5433` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `223076` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| Test functions (class + module level) | `223079` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
 | @pytest.mark.parametrize decorators | `833` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `84` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2870` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -12,13 +12,13 @@
 
 | Metric | Value | Source | Command |
 |---|---|---|---|
-| Python files under aragora/ | `4259` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1975083` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python files under aragora/ | `4260` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
+| Python lines of code under aragora/ | `1975597` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `144` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5429` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `223050` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
-| @pytest.mark.parametrize decorators | `832` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
-| CLI top-level command modules | `83` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
+| Test files (test_*.py under tests/) | `5433` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `223073` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| @pytest.mark.parametrize decorators | `833` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
+| CLI top-level command modules | `84` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2870` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
 | OpenAPI operations (HTTP verbs) | `3297` | `docs/api/openapi.json` | `python -c "import json; spec=json.load(open('docs/api/openapi.json')); print(sum(1 for p in spec['paths'].values() for m in p if m.lower() in {'get','post','put','delete','patch','head','options'}))"` |
 | @require_permission decorator calls | `1362` | `aragora/` | `git grep -E '@require_permission\(' -- aragora \| wc -l` |

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -13,10 +13,10 @@
 | Metric | Value | Source | Command |
 |---|---|---|---|
 | Python files under aragora/ | `4260` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1975600` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python lines of code under aragora/ | `1975601` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `144` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
 | Test files (test_*.py under tests/) | `5433` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `223074` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| Test functions (class + module level) | `223076` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
 | @pytest.mark.parametrize decorators | `833` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `84` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2870` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -13,10 +13,10 @@
 | Metric | Value | Source | Command |
 |---|---|---|---|
 | Python files under aragora/ | `4260` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1975597` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python lines of code under aragora/ | `1975600` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `144` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
 | Test files (test_*.py under tests/) | `5433` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `223073` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| Test functions (class + module level) | `223074` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
 | @pytest.mark.parametrize decorators | `833` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `84` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2870` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -153,8 +153,8 @@ For the full current-status narrative, use the canonical doc:
 
 ### Codebase Metrics (generated from `docs/METRICS.md`)
 <!-- metrics:begin status-codebase-metrics -->
-- **Python files (`aragora/`)**: 4,259
-- **Tests**: 223,050 across 5,429 test files
+- **Python files (`aragora/`)**: 4,260
+- **Tests**: 223,079 across 5,433 test files
 - **KM adapters**: 41 registered adapter specs
 - **API operations**: 3,297 across 2,870 paths
 <!-- metrics:end -->

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -754,8 +754,8 @@ Critical operations use explicit transactions:
 - **Storage tests**: 4,300+ tests across all backends including KM (Phase A2)
 - **SDK breadth**: Python and TypeScript SDKs (module counts in `docs/METRICS.md`)
 <!-- metrics:begin architecture-scale -->
-- **Test coverage**: 223,050 tests across 5,429 test files
-- **Source files**: 4,259 Python files under `aragora/`
+- **Test coverage**: 223,079 tests across 5,433 test files
+- **Source files**: 4,260 Python files under `aragora/`
 - **API surface**: 3,297 API operations across 2,870 paths
 - **KM adapters**: 41 registered adapters (see `aragora/knowledge/mound/adapters/`)
 <!-- metrics:end -->

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -129,7 +129,7 @@ For full runtime configuration, see [ENVIRONMENT](ENVIRONMENT.md).
 | `spec` | - | Transform a vague idea into a structured specification | - |
 | `starter` | - | SME Starter Pack -- install to decision receipt in 15 minutes | - |
 | `stats` | - | Show memory statistics | - |
-| `status` | - | Show environment health and agent availability | - |
+| `status` | - | Show environment health, agent availability, or founder ops status | - |
 | `swarm` | - | Launch a swarm of AI agents to accomplish a goal | - |
 | `tasks` | - | Inspect and operate the developer task queue | `claim`, `complete`, `heartbeat`, `leases`, `list`, `release`, `salvage`, `show`, `stats`, `sync` |
 | `template` | - | Manage workflow templates | `list`, `package`, `run`, `show`, `validate` |

--- a/docs/status/FEATURE_DISCOVERY.md
+++ b/docs/status/FEATURE_DISCOVERY.md
@@ -23,7 +23,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | [Self-Improvement](#9-self-improvement--nomic-loop) | 18+ | Stable |
 
 <!-- metrics:begin feature-discovery-total -->
-**Total**: 230+ features | 4,259 Python files | 223,050 tests | 3,297 API operations across 2,870 paths
+**Total**: 230+ features | 4,260 Python files | 223,079 tests | 3,297 API operations across 2,870 paths
 <!-- metrics:end -->
 
 ---

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -3513,6 +3513,20 @@ class TestGhTimeouts:
 
 
 class TestBuildQueueAndPacket:
+    def test_command_parser_accepts_build_repo_override(self) -> None:
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers(dest="command")
+        add_review_queue_parser(subparsers)
+
+        args = parser.parse_args(
+            ["review-queue", "build", "--repo", "synaptent/aragora", "--limit", "7"]
+        )
+
+        assert args.command == "review-queue"
+        assert args.review_queue_command == "build"
+        assert args.repo == "synaptent/aragora"
+        assert args.limit == 7
+
     def test_merge_packet_explicit_pr_refs_do_not_hydrate_open_queue(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -2252,7 +2252,7 @@ class TestModelReviewQuorum:
         )
         monkeypatch.setattr(
             "aragora.cli.commands.review_queue._build_queue",
-            lambda limit: [_classify_pr(_make_pr(number=7736))],
+            lambda limit, repo_override=None: [_classify_pr(_make_pr(number=7736))],
         )
 
         def _gh_json_dispatch(args: list[str]) -> Any:
@@ -3611,6 +3611,39 @@ class TestBuildQueueAndPacket:
             "repairable",
             "parked",
         ]
+
+    def test_build_queue_passes_repo_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        seen_args: list[list[str]] = []
+
+        def fake_gh_json(args: list[str]) -> list[dict[str, Any]]:
+            seen_args.append(args)
+            return []
+
+        monkeypatch.setattr("aragora.cli.commands.review_queue._gh_json", fake_gh_json)
+
+        assert _build_queue(limit=7, repo_override="synaptent/aragora") == []
+        assert seen_args
+        assert seen_args[0][-2:] == ["--repo", "synaptent/aragora"]
+
+    def test_merge_packet_open_queue_uses_repo_override(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen_repo_overrides: list[str | None] = []
+
+        def fake_build_queue(*, limit: int, repo_override: str | None = None) -> list[QueueItem]:
+            seen_repo_overrides.append(repo_override)
+            return []
+
+        monkeypatch.setattr("aragora.cli.commands.review_queue._build_queue", fake_build_queue)
+
+        packet = _build_merge_authorization_packet(
+            pr_refs=[],
+            limit=7,
+            repo_override="synaptent/aragora",
+        )
+
+        assert seen_repo_overrides == ["synaptent/aragora"]
+        assert packet["queue_pressure"]["current_open_prs"] == 0
 
     def test_build_packet_sets_recommendation(self, monkeypatch: pytest.MonkeyPatch) -> None:
         pr_payload = _make_pr(
@@ -5354,7 +5387,7 @@ class TestBuildQueueAndPacket:
         ]
         monkeypatch.setattr(
             "aragora.cli.commands.review_queue._build_queue",
-            lambda limit: [_classify_pr(_make_pr(number=7470))],
+            lambda limit, repo_override=None: [_classify_pr(_make_pr(number=7470))],
         )
         monkeypatch.setattr(
             "aragora.cli.commands.review_queue._gh_json",
@@ -5468,7 +5501,7 @@ class TestBuildQueueAndPacket:
         )
         monkeypatch.setattr(
             "aragora.cli.commands.review_queue._build_queue",
-            lambda limit: [_classify_pr(_make_pr(number=7447))],
+            lambda limit, repo_override=None: [_classify_pr(_make_pr(number=7447))],
         )
         monkeypatch.setattr(
             "aragora.cli.commands.review_queue._gh_json",
@@ -5518,7 +5551,7 @@ class TestBuildQueueAndPacket:
         )
         monkeypatch.setattr(
             "aragora.cli.commands.review_queue._build_queue",
-            lambda limit: [_classify_pr(_make_pr(number=7466))],
+            lambda limit, repo_override=None: [_classify_pr(_make_pr(number=7466))],
         )
         monkeypatch.setattr(
             "aragora.cli.commands.review_queue._gh_json",
@@ -5585,7 +5618,7 @@ class TestBuildQueueAndPacket:
         )
         monkeypatch.setattr(
             "aragora.cli.commands.review_queue._build_queue",
-            lambda limit: [_classify_pr(_make_pr(number=7466))],
+            lambda limit, repo_override=None: [_classify_pr(_make_pr(number=7466))],
         )
         monkeypatch.setattr(
             "aragora.cli.commands.review_queue._gh_json",
@@ -7234,7 +7267,10 @@ class TestSettlementHelpers:
                 },
             )
 
-        monkeypatch.setattr("aragora.cli.commands.review_queue._build_queue", lambda limit: queue)
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._build_queue",
+            lambda limit, repo_override=None: queue,
+        )
         monkeypatch.setattr(
             "aragora.cli.commands.review_queue._build_packet",
             _fake_build_packet,

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -537,6 +537,17 @@ class TestDemoTasks:
 class TestMain:
     """Tests for main entry point."""
 
+    def test_review_queue_build_accepts_repo_override(self):
+        parser = cli_parser.build_parser()
+        args = parser.parse_args(
+            ["review-queue", "build", "--repo", "synaptent/aragora", "--limit", "7"]
+        )
+
+        assert args.command == "review-queue"
+        assert args.review_queue_command == "build"
+        assert args.repo == "synaptent/aragora"
+        assert args.limit == 7
+
     def test_record_settlement_skips_startup_secret_hydration(self):
         """Receipt-only settlement recording should not need provider secrets."""
         parser = cli_parser.build_parser()

--- a/tests/cli/test_founder_status.py
+++ b/tests/cli/test_founder_status.py
@@ -149,3 +149,12 @@ def test_cmd_status_delegates_founder(monkeypatch, capsys) -> None:
     assert result == 0
     assert seen["called"] is True
     assert "Aragora Founder Status" in capsys.readouterr().out
+
+
+def test_status_json_requires_founder(capsys) -> None:
+    result = cmd_status(argparse.Namespace(founder=False, json=True))
+
+    assert result == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "status --json requires --founder" in captured.err

--- a/tests/cli/test_founder_status.py
+++ b/tests/cli/test_founder_status.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+from pathlib import Path
+
+from aragora.cli.commands.founder_status import (
+    gather_founder_status,
+    render_founder_status,
+)
+from aragora.cli.commands.status import cmd_status
+from aragora.cli.parser import build_parser
+from aragora.review.health import HealthReport, SurfaceCheck
+
+
+def _health(status: str = "fresh") -> HealthReport:
+    return HealthReport(
+        generated_at=datetime(2026, 7, 4, tzinfo=timezone.utc),
+        overall_status=status,
+        surfaces=[
+            SurfaceCheck(
+                name="boss_metrics",
+                status=status,
+                count=3,
+                detail="ok",
+            )
+        ],
+    )
+
+
+def test_founder_status_reports_queue_and_next_blocker(tmp_path: Path) -> None:
+    state = tmp_path / ".aragora"
+    brief_root = state / "overnight-brief"
+    brief_root.mkdir(parents=True)
+    (brief_root / "latest.md").write_text("# Morning brief\n\nTop 3.\n", encoding="utf-8")
+
+    def merge_packet_builder(**_: object) -> dict[str, object]:
+        return {
+            "queue_pressure": {"current_open_prs": 2, "cap": 6, "active": False},
+            "admin_squash_order": [],
+            "human_risk_settlement_required": [],
+            "not_ready": [8827],
+            "entries": [
+                {
+                    "pr_number": 8827,
+                    "title": "refactor(events): split security debate runner",
+                    "url": "https://github.com/synaptent/aragora/pull/8827",
+                    "head_sha": "abc123",
+                    "tier": 2,
+                    "status": "needs_model_review_quorum",
+                    "verdict": "collect_model_quorum_before_merge",
+                    "admin_squash_allowed": False,
+                    "requires_human_risk_settlement": False,
+                    "requires_human_preapproval": False,
+                    "unresolved_dissent": False,
+                    "checks_summary": "1 failing / 6 required",
+                    "counted_model_families": [],
+                    "reasons": ["model quorum incomplete: 0/2 signal(s)"],
+                }
+            ],
+        }
+
+    report = gather_founder_status(
+        repo_root=str(tmp_path),
+        limit=5,
+        health_gatherer=lambda **_: _health(),
+        merge_packet_builder=merge_packet_builder,
+    )
+
+    assert report["queue"]["transport_status"] == "ok"
+    assert report["queue"]["not_ready"] == [8827]
+    assert report["latest_brief"]["preview"].startswith("# Morning brief")
+    assert report["next_action"]["kind"] == "queue_blocker"
+    assert "PR #8827" in report["next_action"]["summary"]
+
+    rendered = render_founder_status(report)
+    assert "Aragora Founder Status" in rendered
+    assert "Next action: Work one bounded blocker on PR #8827" in rendered
+
+
+def test_founder_status_degrades_on_merge_packet_transport_error(tmp_path: Path) -> None:
+    def broken_builder(**_: object) -> dict[str, object]:
+        raise RuntimeError("organization access is disabled")
+
+    report = gather_founder_status(
+        repo_root=str(tmp_path),
+        health_gatherer=lambda **_: _health(),
+        merge_packet_builder=broken_builder,
+    )
+
+    assert report["queue"]["transport_status"] == "blocked"
+    assert "organization access is disabled" in report["queue"]["transport_error"]
+    assert report["next_action"]["kind"] == "repair_transport"
+
+
+def test_status_parser_accepts_founder_flags() -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "status",
+            "--founder",
+            "--json",
+            "--repo",
+            "synaptent/aragora",
+            "--limit",
+            "3",
+            "--repo-root",
+            "/tmp/repo",
+        ]
+    )
+
+    assert args.command == "status"
+    assert args.founder is True
+    assert args.json is True
+    assert args.repo == "synaptent/aragora"
+    assert args.limit == 3
+    assert args.repo_root == "/tmp/repo"
+
+
+def test_cmd_status_delegates_founder(monkeypatch, capsys) -> None:
+    seen: dict[str, bool] = {}
+
+    def fake_gather(**_: object) -> dict[str, object]:
+        seen["called"] = True
+        return {
+            "generated_at": "2026-07-04T00:00:00+00:00",
+            "repo_root": "/tmp/repo",
+            "queue": {
+                "transport_status": "ok",
+                "queue_pressure": {"current_open_prs": 0, "cap": 6, "active": False},
+                "status_counts": {},
+                "admin_squash_order": [],
+                "human_risk_settlement_required": [],
+                "not_ready": [],
+                "top_entries": [],
+            },
+            "proof_loop": {"overall_status": "fresh", "surfaces": []},
+            "latest_brief": {"path": None, "age_hours": None, "preview": ""},
+            "next_action": {"summary": "No queue action.", "detail": ""},
+        }
+
+    monkeypatch.setattr(
+        "aragora.cli.commands.founder_status.gather_founder_status",
+        fake_gather,
+    )
+
+    result = cmd_status(argparse.Namespace(founder=True, json=False, limit=1))
+
+    assert result == 0
+    assert seen["called"] is True
+    assert "Aragora Founder Status" in capsys.readouterr().out

--- a/tests/cli/test_founder_status.py
+++ b/tests/cli/test_founder_status.py
@@ -78,6 +78,67 @@ def test_founder_status_reports_queue_and_next_blocker(tmp_path: Path) -> None:
     assert "Next action: Work one bounded blocker on PR #8827" in rendered
 
 
+def test_founder_status_next_action_uses_not_ready_entry_beyond_top_entries(
+    tmp_path: Path,
+) -> None:
+    def ready_entry(pr_number: int) -> dict[str, object]:
+        return {
+            "pr_number": pr_number,
+            "title": f"ready {pr_number}",
+            "url": f"https://github.com/synaptent/aragora/pull/{pr_number}",
+            "head_sha": "abc123",
+            "tier": 2,
+            "status": "admin_squash_allowed",
+            "verdict": "admin_squash_allowed",
+            "admin_squash_allowed": True,
+            "requires_human_risk_settlement": False,
+            "requires_human_preapproval": False,
+            "unresolved_dissent": False,
+            "checks_summary": "6 / 6 required",
+            "counted_model_families": ["claude", "openai"],
+            "reasons": [],
+        }
+
+    blocked = {
+        "pr_number": 8899,
+        "title": "blocked outside top display rows",
+        "url": "https://github.com/synaptent/aragora/pull/8899",
+        "head_sha": "def456",
+        "tier": 2,
+        "status": "needs_model_review_quorum",
+        "verdict": "collect_model_quorum_before_merge",
+        "admin_squash_allowed": False,
+        "requires_human_risk_settlement": False,
+        "requires_human_preapproval": False,
+        "unresolved_dissent": False,
+        "checks_summary": "1 failing / 6 required",
+        "counted_model_families": [],
+        "reasons": ["model quorum incomplete: 0/2 signal(s)"],
+    }
+
+    def merge_packet_builder(**_: object) -> dict[str, object]:
+        return {
+            "queue_pressure": {"current_open_prs": 11, "cap": 6, "active": True},
+            "admin_squash_order": [],
+            "human_risk_settlement_required": [],
+            "not_ready": [8899],
+            "entries": [*(ready_entry(8800 + index) for index in range(10)), blocked],
+        }
+
+    report = gather_founder_status(
+        repo_root=str(tmp_path),
+        limit=12,
+        health_gatherer=lambda **_: _health(),
+        merge_packet_builder=merge_packet_builder,
+    )
+
+    assert all(entry["pr_number"] != 8899 for entry in report["queue"]["top_entries"])
+    assert report["queue"]["not_ready_entries"][0]["pr_number"] == 8899
+    assert report["next_action"]["kind"] == "queue_blocker"
+    assert "PR #8899" in report["next_action"]["summary"]
+    assert "model quorum incomplete" in report["next_action"]["detail"]
+
+
 def test_founder_status_degrades_on_merge_packet_transport_error(tmp_path: Path) -> None:
     def broken_builder(**_: object) -> dict[str, object]:
         raise RuntimeError("organization access is disabled")


### PR DESCRIPTION
## Summary
- add `aragora status --founder` as a read-only founder ops report
- compose merge-packet queue blockers, proof-loop health, latest overnight brief, and one suggested next action
- degrade cleanly when GitHub transport is blocked instead of crashing

## Validation
- `python3 -m pytest tests/cli/test_status_validate_env.py tests/cli/commands/test_review_queue.py::TestCommandDispatch::test_parser_registers_build_packet_run_and_act tests/cli/test_founder_status.py -q`
- `python3 -m ruff check aragora/cli/commands/founder_status.py aragora/cli/commands/status.py aragora/cli/parser.py tests/cli/test_founder_status.py`
- `python3 -m ruff format --check aragora/cli/commands/founder_status.py aragora/cli/commands/status.py aragora/cli/parser.py tests/cli/test_founder_status.py`
- `pre-commit run --hook-stage pre-push --files aragora/cli/commands/founder_status.py aragora/cli/commands/status.py aragora/cli/parser.py tests/cli/test_founder_status.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- live smoke: `python3 -m aragora.cli.main status --founder --repo synaptent/aragora --limit 2`

Note: the generated git hook in this checkout points at a root `.venv` without `pre_commit`, so commit/push used `--no-verify` only after the equivalent pre-commit/pre-push stages passed manually.