### PR TITLE
feat(tooling): receipted cancelled-run retrigger (CI-nanny wiring)

### DIFF
--- a/docs/governance/PR_RUN_CANCELLATION_DIAGNOSIS.md
+++ b/docs/governance/PR_RUN_CANCELLATION_DIAGNOSIS.md
@@ -122,6 +122,31 @@ Document them as "advisory; cancellation ≠ failure" and rely on the weekly `sc
 runs (Module Tier Drift / Metrics Drift already run Monday) plus `push`-to-main runs
 (Portability Lint) for real coverage. Zero engineering cost; leaves PR UI noisy.
 
+## How to run in the transport loop
+
+Use the Python guardian manually from a conductor or executor lane before treating
+cancelled advisory checks as a human transport task. Start with a dry run scoped to
+the target PR and a 24-hour TTL:
+
+```bash
+GITHUB_REPOSITORY=synaptent/aragora GITHUB_TOKEN="$GITHUB_TOKEN" \
+  python scripts/retrigger_cancelled_pr_runs.py \
+    --repo synaptent/aragora \
+    --pr <PR_NUMBER> \
+    --ttl-minutes 1440 \
+    --marker-file .aragora/retrigger_cancelled/marker.json
+```
+
+If every eligible run is a current-head cancelled PR run and the conductor lane is
+allowed to spend one rerun per run id, repeat with `--apply`. The tool writes a
+per-invocation JSON receipt under
+`.aragora/retrigger_cancelled/receipts/` recording the scope, dry-run/apply mode,
+eligible run ids, rerun ids, and head SHAs. The marker file remains the loop guard:
+a run id recorded there is not retriggered again.
+
+Do not use this tool to bypass real failures. A rerun that comes back failed, such
+as a docs-sync/build failure, is a repair packet for the PR branch.
+
 ## Decision points
 
 1. Pursue **M2 first** (identify the canceller) before building **M1**? Re-running

--- a/docs/governance/PR_RUN_CANCELLATION_DIAGNOSIS.md
+++ b/docs/governance/PR_RUN_CANCELLATION_DIAGNOSIS.md
@@ -126,7 +126,9 @@ runs (Module Tier Drift / Metrics Drift already run Monday) plus `push`-to-main 
 
 Use the Python guardian manually from a conductor or executor lane before treating
 cancelled advisory checks as a human transport task. Start with a dry run scoped to
-the target PR and a 24-hour TTL:
+the target PR and a 24-hour TTL. In `--pr` mode the tool queries workflow runs for
+that PR branch/event and verifies the run's PR association before considering it
+eligible:
 
 ```bash
 GITHUB_REPOSITORY=synaptent/aragora GITHUB_TOKEN="$GITHUB_TOKEN" \
@@ -141,8 +143,11 @@ If every eligible run is a current-head cancelled PR run and the conductor lane 
 allowed to spend one rerun per run id, repeat with `--apply`. The tool writes a
 per-invocation JSON receipt under
 `.aragora/retrigger_cancelled/receipts/` recording the scope, dry-run/apply mode,
-eligible run ids, rerun ids, and head SHAs. The marker file remains the loop guard:
-a run id recorded there is not retriggered again.
+eligible run ids, rerun ids, and head SHAs. Receipts older than seven days are
+pruned by default (`--receipt-retention-hours 168`). The marker file remains the
+loop guard: a run id recorded there is not retriggered again. If receipt writing
+fails after an otherwise successful rerun attempt, the tool reports `receipt_error`
+in its JSON output instead of treating the rerun as failed.
 
 Do not use this tool to bypass real failures. A rerun that comes back failed, such
 as a docs-sync/build failure, is a repair packet for the PR branch.

--- a/scripts/retrigger_cancelled_pr_runs.py
+++ b/scripts/retrigger_cancelled_pr_runs.py
@@ -146,10 +146,21 @@ class GitHubClient:
             raise GitHubApiError(f"Expected PR object for #{pr_number}, got {type(pull)}")
         return pull
 
-    def list_recent_workflow_runs(self, max_runs: int) -> list[dict[str, Any]]:
+    def list_recent_workflow_runs(
+        self,
+        max_runs: int,
+        *,
+        branch: str | None = None,
+        event: str | None = None,
+    ) -> list[dict[str, Any]]:
+        query: dict[str, Any] = {"per_page": 100}
+        if branch:
+            query["branch"] = branch
+        if event:
+            query["event"] = event
         runs = self.paginate(
             f"/repos/{self.repo}/actions/runs",
-            query={"per_page": 100},
+            query=query,
             max_pages=max(1, (max_runs + 99) // 100),
         )
         normalized = [r for r in runs if isinstance(r, dict)]
@@ -204,6 +215,22 @@ def _run_branch(run: dict[str, Any]) -> str:
 
 def _run_workflow_key(run: dict[str, Any]) -> Any:
     return _field(run, "workflow_id", "workflowId") or _field(run, "name", default="")
+
+
+def _run_matches_pr(run: dict[str, Any], pr_number: int) -> bool:
+    pulls = run.get("pull_requests") or run.get("pullRequests") or []
+    if not isinstance(pulls, list):
+        return False
+    for pull in pulls:
+        if not isinstance(pull, dict):
+            continue
+        try:
+            number = int(pull.get("number", 0) or 0)
+        except (TypeError, ValueError):
+            continue
+        if number == pr_number:
+            return True
+    return False
 
 
 def _has_newer_sibling(
@@ -365,6 +392,18 @@ def _safe_filename_fragment(value: str) -> str:
     return fragment.strip("-") or "all"
 
 
+def _prune_receipts(path: Path, *, now: datetime, retention_hours: int) -> None:
+    if retention_hours <= 0 or not path.exists():
+        return
+    cutoff = now.timestamp() - (retention_hours * 3600)
+    for child in path.glob("RETRIGGER_CANCELLED_RECEIPT_*.json"):
+        try:
+            if child.stat().st_mtime < cutoff:
+                child.unlink()
+        except OSError:
+            continue
+
+
 def _write_receipt(
     *,
     receipt_dir: str,
@@ -372,11 +411,16 @@ def _write_receipt(
     repo: str,
     scope: str,
     summary: dict[str, Any],
+    retention_hours: int,
 ) -> str:
     path = Path(receipt_dir)
     path.mkdir(parents=True, exist_ok=True)
-    timestamp = now.strftime("%Y%m%dT%H%M%SZ")
-    filename = f"RETRIGGER_CANCELLED_RECEIPT_{timestamp}_{_safe_filename_fragment(scope)}.json"
+    _prune_receipts(path, now=now, retention_hours=retention_hours)
+    timestamp = now.strftime("%Y%m%dT%H%M%S%fZ")
+    filename = (
+        f"RETRIGGER_CANCELLED_RECEIPT_{timestamp}_pid{os.getpid()}_"
+        f"{_safe_filename_fragment(scope)}.json"
+    )
     receipt_path = path / filename
     receipt = {
         "schema": "retrigger-cancelled-pr-runs-receipt/v1",
@@ -484,6 +528,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Directory for per-invocation JSON receipts",
     )
     parser.add_argument(
+        "--receipt-retention-hours",
+        type=int,
+        default=168,
+        help="Prune retrigger receipts older than this many hours (<=0 disables pruning)",
+    )
+    parser.add_argument(
         "--apply",
         action="store_true",
         help="Actually re-run eligible runs (default: dry run)",
@@ -528,14 +578,26 @@ def main(argv: list[str] | None = None) -> int:
         active_heads = compute_active_head_map(
             open_pulls, keep_draft_runs=bool(args.keep_draft_runs)
         )
-        runs = client.list_recent_workflow_runs(max_runs=args.max_runs)
+        runs: list[dict[str, Any]]
         scoped_branch = ""
         scoped_sha = ""
         if scoped_pr is not None:
             head = scoped_pr.get("head", {})
             scoped_branch = str(head.get("ref", "")).strip()
             scoped_sha = str(head.get("sha", "")).strip()
-            runs = [r for r in runs if _run_branch(r) == scoped_branch]
+            runs_by_id: dict[int, dict[str, Any]] = {}
+            for event_name in sorted(cancel_events):
+                for run in client.list_recent_workflow_runs(
+                    max_runs=args.max_runs,
+                    branch=scoped_branch,
+                    event=event_name,
+                ):
+                    run_id = int(_field(run, "id", "databaseId", default=0) or 0)
+                    if run_id > 0 and _run_matches_pr(run, int(args.pr)):
+                        runs_by_id[run_id] = run
+            runs = sorted(runs_by_id.values(), key=_run_sort_key, reverse=True)
+        else:
+            runs = client.list_recent_workflow_runs(max_runs=args.max_runs)
         eligible, reasons, candidates = compute_retriggerable_runs(
             runs,
             active_heads=active_heads,
@@ -581,14 +643,20 @@ def main(argv: list[str] | None = None) -> int:
             "scoped_branch": scoped_branch,
             "scoped_sha": scoped_sha,
         }
-        receipt_path = _write_receipt(
-            receipt_dir=args.receipt_dir,
-            now=now,
-            repo=args.repo,
-            scope=str(summary["scope"]),
-            summary=summary,
-        )
-        summary["receipt"] = receipt_path
+        try:
+            receipt_path = _write_receipt(
+                receipt_dir=args.receipt_dir,
+                now=now,
+                repo=args.repo,
+                scope=str(summary["scope"]),
+                summary=summary,
+                retention_hours=int(args.receipt_retention_hours),
+            )
+            summary["receipt"] = receipt_path
+            summary["receipt_error"] = ""
+        except OSError as exc:
+            summary["receipt"] = ""
+            summary["receipt_error"] = str(exc)
         print(json.dumps(summary))
         return 0
     except (GitHubApiError, ValueError) as exc:

--- a/scripts/retrigger_cancelled_pr_runs.py
+++ b/scripts/retrigger_cancelled_pr_runs.py
@@ -30,8 +30,10 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 from urllib import error, parse, request
 
@@ -137,6 +139,12 @@ class GitHubClient:
             max_pages=5,
         )
         return [p for p in pulls if isinstance(p, dict)]
+
+    def get_pull(self, pr_number: int) -> dict[str, Any]:
+        pull = self.get(f"/repos/{self.repo}/pulls/{pr_number}")
+        if not isinstance(pull, dict):
+            raise GitHubApiError(f"Expected PR object for #{pr_number}, got {type(pull)}")
+        return pull
 
     def list_recent_workflow_runs(self, max_runs: int) -> list[dict[str, Any]]:
         runs = self.paginate(
@@ -352,6 +360,54 @@ def save_marker(path: str, data: dict[str, str]) -> None:
         json.dump(data, handle, indent=2, sort_keys=True)
 
 
+def _safe_filename_fragment(value: str) -> str:
+    fragment = re.sub(r"[^A-Za-z0-9_.-]+", "-", value.strip())
+    return fragment.strip("-") or "all"
+
+
+def _write_receipt(
+    *,
+    receipt_dir: str,
+    now: datetime,
+    repo: str,
+    scope: str,
+    summary: dict[str, Any],
+) -> str:
+    path = Path(receipt_dir)
+    path.mkdir(parents=True, exist_ok=True)
+    timestamp = now.strftime("%Y%m%dT%H%M%SZ")
+    filename = f"RETRIGGER_CANCELLED_RECEIPT_{timestamp}_{_safe_filename_fragment(scope)}.json"
+    receipt_path = path / filename
+    receipt = {
+        "schema": "retrigger-cancelled-pr-runs-receipt/v1",
+        "generated_at": now.isoformat(),
+        "repo": repo,
+        "scope": scope,
+        "dry_run": bool(summary.get("dry_run", True)),
+        "scanned": int(summary.get("scanned", 0) or 0),
+        "candidates": int(summary.get("candidates", 0) or 0),
+        "eligible": int(summary.get("eligible", 0) or 0),
+        "eligible_run_ids": [int(item["run_id"]) for item in summary.get("eligible_runs", [])],
+        "applied": int(summary.get("applied", 0) or 0),
+        "apply_failed": int(summary.get("apply_failed", 0) or 0),
+        "rerun_run_ids": [
+            int(item["run_id"]) for item in summary.get("rerun_results", []) if item.get("ok")
+        ],
+        "head_shas": sorted(
+            {
+                str(item.get("sha", "")).strip()
+                for item in summary.get("eligible_runs", [])
+                if str(item.get("sha", "")).strip()
+            }
+        ),
+        "summary": summary,
+    }
+    with receipt_path.open("w", encoding="utf-8") as handle:
+        json.dump(receipt, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+    return str(receipt_path)
+
+
 def compute_active_head_map(
     open_pulls: list[dict[str, Any]],
     *,
@@ -376,6 +432,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--repo",
         default=os.environ.get("GITHUB_REPOSITORY", ""),
         help="GitHub repository in OWNER/REPO format",
+    )
+    parser.add_argument(
+        "--pr",
+        type=int,
+        default=None,
+        help="Scope scanning to one pull request's branch/head",
     )
     parser.add_argument(
         "--max-runs",
@@ -417,6 +479,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Prune marker entries older than this many hours",
     )
     parser.add_argument(
+        "--receipt-dir",
+        default=os.environ.get("RETRIGGER_RECEIPT_DIR", ".aragora/retrigger_cancelled/receipts"),
+        help="Directory for per-invocation JSON receipts",
+    )
+    parser.add_argument(
         "--apply",
         action="store_true",
         help="Actually re-run eligible runs (default: dry run)",
@@ -449,11 +516,26 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         client = GitHubClient(repo=args.repo, token=token)
-        open_pulls = client.list_open_pulls()
+        scoped_pr: dict[str, Any] | None = None
+        if args.pr is not None:
+            if args.pr <= 0:
+                print("--pr must be a positive integer", file=sys.stderr)
+                return 1
+            scoped_pr = client.get_pull(int(args.pr))
+            open_pulls = [scoped_pr] if str(scoped_pr.get("state")) == "open" else []
+        else:
+            open_pulls = client.list_open_pulls()
         active_heads = compute_active_head_map(
             open_pulls, keep_draft_runs=bool(args.keep_draft_runs)
         )
         runs = client.list_recent_workflow_runs(max_runs=args.max_runs)
+        scoped_branch = ""
+        scoped_sha = ""
+        if scoped_pr is not None:
+            head = scoped_pr.get("head", {})
+            scoped_branch = str(head.get("ref", "")).strip()
+            scoped_sha = str(head.get("sha", "")).strip()
+            runs = [r for r in runs if _run_branch(r) == scoped_branch]
         eligible, reasons, candidates = compute_retriggerable_runs(
             runs,
             active_heads=active_heads,
@@ -466,9 +548,12 @@ def main(argv: list[str] | None = None) -> int:
 
         applied = 0
         apply_failed = 0
+        rerun_results: list[dict[str, Any]] = []
         if args.apply:
             for item in eligible:
-                ok, _msg = client.rerun_workflow_run(int(item["run_id"]))
+                run_id = int(item["run_id"])
+                ok, msg = client.rerun_workflow_run(run_id)
+                rerun_results.append({"run_id": run_id, "ok": ok, "message": msg})
                 if ok:
                     applied += 1
                     marker_data[str(item["run_id"])] = now.isoformat()
@@ -488,9 +573,22 @@ def main(argv: list[str] | None = None) -> int:
             "dry_run": not args.apply,
             "applied": applied,
             "apply_failed": apply_failed,
+            "rerun_results": rerun_results,
             "ttl_minutes": args.ttl_minutes,
             "max_attempts": args.max_attempts,
+            "pr": int(args.pr) if args.pr is not None else None,
+            "scope": f"pr-{args.pr}" if args.pr is not None else "all-open-prs",
+            "scoped_branch": scoped_branch,
+            "scoped_sha": scoped_sha,
         }
+        receipt_path = _write_receipt(
+            receipt_dir=args.receipt_dir,
+            now=now,
+            repo=args.repo,
+            scope=str(summary["scope"]),
+            summary=summary,
+        )
+        summary["receipt"] = receipt_path
         print(json.dumps(summary))
         return 0
     except (GitHubApiError, ValueError) as exc:

--- a/tests/scripts/test_retrigger_cancelled_pr_runs.py
+++ b/tests/scripts/test_retrigger_cancelled_pr_runs.py
@@ -30,6 +30,7 @@ def make_run(**over: Any) -> dict[str, Any]:
         "workflow_id": 100,
         "name": "Portability Lint",
         "created_at": RECENT,
+        "pull_requests": [{"number": 123}],
     }
     run.update(over)
     return run
@@ -201,11 +202,25 @@ def test_main_scopes_to_pr_and_writes_receipt(tmp_path, monkeypatch, capsys) -> 
                 "head": {"ref": "feat/a", "sha": "sha-a"},
             }
 
-        def list_recent_workflow_runs(self, max_runs: int) -> list[dict[str, Any]]:
+        def list_recent_workflow_runs(
+            self,
+            max_runs: int,
+            *,
+            branch: str | None = None,
+            event: str | None = None,
+        ) -> list[dict[str, Any]]:
             assert max_runs == 300
+            assert branch == "feat/a"
+            if event != "pull_request":
+                return []
             return [
                 make_run(id=31, head_branch="feat/a", head_sha="sha-a"),
-                make_run(id=32, head_branch="feat/b", head_sha="sha-b"),
+                make_run(
+                    id=32,
+                    head_branch="feat/a",
+                    head_sha="sha-a",
+                    pull_requests=[{"number": 456}],
+                ),
             ]
 
     monkeypatch.setenv("GITHUB_TOKEN", "token")
@@ -291,3 +306,36 @@ def test_main_apply_records_rerun_results_in_receipt(tmp_path, monkeypatch, caps
     receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
     assert receipt["dry_run"] is False
     assert receipt["rerun_run_ids"] == [41]
+
+
+def test_receipt_write_failure_is_reported_without_failing(monkeypatch, capsys) -> None:
+    class FakeClient:
+        def __init__(self, repo: str, token: str) -> None:
+            self.repo = repo
+
+        def list_open_pulls(self) -> list[dict[str, Any]]:
+            return [
+                {
+                    "state": "open",
+                    "draft": False,
+                    "head": {"ref": "feat/a", "sha": "sha-a"},
+                }
+            ]
+
+        def list_recent_workflow_runs(self, max_runs: int) -> list[dict[str, Any]]:
+            return [make_run(id=51, head_branch="feat/a", head_sha="sha-a")]
+
+    def fail_receipt(**_: Any) -> str:
+        raise OSError("receipt path unavailable")
+
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setattr(retrigger, "GitHubClient", FakeClient)
+    monkeypatch.setattr(retrigger, "_write_receipt", fail_receipt)
+
+    rc = main(["--repo", "synaptent/aragora", "--ttl-minutes", "100000"])
+
+    assert rc == 0
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["eligible"] == 1
+    assert summary["receipt"] == ""
+    assert summary["receipt_error"] == "receipt path unavailable"

--- a/tests/scripts/test_retrigger_cancelled_pr_runs.py
+++ b/tests/scripts/test_retrigger_cancelled_pr_runs.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
 from typing import Any
 
+import scripts.retrigger_cancelled_pr_runs as retrigger
 from scripts.retrigger_cancelled_pr_runs import (
     compute_retriggerable_runs,
+    main,
     prune_marker,
 )
 
@@ -182,3 +185,109 @@ def test_prune_marker_drops_old_entries() -> None:
     data = {"1": RECENT, "2": "2026-06-05T10:00:00Z"}
     pruned = prune_marker(data, now=NOW, retention_hours=24)
     assert pruned == {"1": RECENT}
+
+
+def test_main_scopes_to_pr_and_writes_receipt(tmp_path, monkeypatch, capsys) -> None:
+    class FakeClient:
+        def __init__(self, repo: str, token: str) -> None:
+            assert repo == "synaptent/aragora"
+            assert token == "token"
+
+        def get_pull(self, pr_number: int) -> dict[str, Any]:
+            assert pr_number == 123
+            return {
+                "state": "open",
+                "draft": False,
+                "head": {"ref": "feat/a", "sha": "sha-a"},
+            }
+
+        def list_recent_workflow_runs(self, max_runs: int) -> list[dict[str, Any]]:
+            assert max_runs == 300
+            return [
+                make_run(id=31, head_branch="feat/a", head_sha="sha-a"),
+                make_run(id=32, head_branch="feat/b", head_sha="sha-b"),
+            ]
+
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setattr(retrigger, "GitHubClient", FakeClient)
+
+    rc = main(
+        [
+            "--repo",
+            "synaptent/aragora",
+            "--pr",
+            "123",
+            "--ttl-minutes",
+            "100000",
+            "--receipt-dir",
+            str(tmp_path),
+        ]
+    )
+
+    assert rc == 0
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["pr"] == 123
+    assert summary["scope"] == "pr-123"
+    assert summary["scoped_branch"] == "feat/a"
+    assert summary["scoped_sha"] == "sha-a"
+    assert summary["scanned"] == 1
+    assert summary["eligible"] == 1
+    assert [run["run_id"] for run in summary["eligible_runs"]] == [31]
+    assert summary["dry_run"] is True
+
+    receipt_path = tmp_path / summary["receipt"].split("/")[-1]
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert receipt["schema"] == "retrigger-cancelled-pr-runs-receipt/v1"
+    assert receipt["repo"] == "synaptent/aragora"
+    assert receipt["scope"] == "pr-123"
+    assert receipt["dry_run"] is True
+    assert receipt["eligible_run_ids"] == [31]
+    assert receipt["head_shas"] == ["sha-a"]
+
+
+def test_main_apply_records_rerun_results_in_receipt(tmp_path, monkeypatch, capsys) -> None:
+    class FakeClient:
+        def __init__(self, repo: str, token: str) -> None:
+            self.repo = repo
+
+        def list_open_pulls(self) -> list[dict[str, Any]]:
+            return [
+                {
+                    "state": "open",
+                    "draft": False,
+                    "head": {"ref": "feat/a", "sha": "sha-a"},
+                }
+            ]
+
+        def list_recent_workflow_runs(self, max_runs: int) -> list[dict[str, Any]]:
+            return [make_run(id=41, head_branch="feat/a", head_sha="sha-a")]
+
+        def rerun_workflow_run(self, run_id: int) -> tuple[bool, str]:
+            assert run_id == 41
+            return True, "rerun_requested"
+
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setattr(retrigger, "GitHubClient", FakeClient)
+
+    rc = main(
+        [
+            "--repo",
+            "synaptent/aragora",
+            "--ttl-minutes",
+            "100000",
+            "--apply",
+            "--receipt-dir",
+            str(tmp_path),
+        ]
+    )
+
+    assert rc == 0
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["dry_run"] is False
+    assert summary["applied"] == 1
+    assert summary["rerun_results"] == [{"run_id": 41, "ok": True, "message": "rerun_requested"}]
+
+    receipt_path = tmp_path / summary["receipt"].split("/")[-1]
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert receipt["dry_run"] is False
+    assert receipt["rerun_run_ids"] == [41]


### PR DESCRIPTION
## Summary
- Extends `scripts/retrigger_cancelled_pr_runs.py` with `--pr` scoping to one pull request branch/head.
- Writes a per-invocation JSON receipt under `.aragora/retrigger_cancelled/receipts/` for dry-run and apply modes.
- Documents the manual transport-loop invocation in `docs/governance/PR_RUN_CANCELLATION_DIAGNOSIS.md`.

No workflow files, branch protection, evidence posting, or merge authority are changed.

## Live dry-run evidence
Initial live dry-run artifact: `/tmp/retrigger_dryrun_20260704T220154Z.json`

```json
{
  "open_prs_total": 11,
  "active_heads_total": 7,
  "scanned": 300,
  "candidates": 67,
  "eligible": 5,
  "eligible_runs": [
    {
      "run_id": 28719713640,
      "workflow": "Tests",
      "branch": "codex/founder-status-automation-20260704T1846Z",
      "sha": "5527b749fdce33d11c10d93eb5f86652ee78d8e2",
      "run_attempt": 1,
      "rerun_command": "gh run rerun 28719713640"
    },
    {
      "run_id": 28718440748,
      "workflow": "Portability Lint",
      "branch": "codex/settlement-inbox-source-v2-20260704T1928Z",
      "sha": "3e433141648050bdad6aa115521f43f9da4a213d",
      "run_attempt": 1,
      "rerun_command": "gh run rerun 28718440748"
    },
    {
      "run_id": 28718440729,
      "workflow": "Contract Drift Governance",
      "branch": "codex/settlement-inbox-source-v2-20260704T1928Z",
      "sha": "3e433141648050bdad6aa115521f43f9da4a213d",
      "run_attempt": 1,
      "rerun_command": "gh run rerun 28718440729"
    },
    {
      "run_id": 28718440728,
      "workflow": "Module Tier Drift",
      "branch": "codex/settlement-inbox-source-v2-20260704T1928Z",
      "sha": "3e433141648050bdad6aa115521f43f9da4a213d",
      "run_attempt": 1,
      "rerun_command": "gh run rerun 28718440728"
    },
    {
      "run_id": 28718440723,
      "workflow": "Metrics Drift",
      "branch": "codex/settlement-inbox-source-v2-20260704T1928Z",
      "sha": "3e433141648050bdad6aa115521f43f9da4a213d",
      "run_attempt": 1,
      "rerun_command": "gh run rerun 28718440723"
    }
  ],
  "reasons": {"superseded-sha": 62},
  "dry_run": true,
  "applied": 0,
  "apply_failed": 0,
  "ttl_minutes": 1440,
  "max_attempts": 2
}
```

Patched scoped dry-run artifact: `/tmp/retrigger_dryrun_patched_8846_20260704T220430Z.json`

Receipt produced by patched dry-run: `.aragora/retrigger_cancelled/receipts/RETRIGGER_CANCELLED_RECEIPT_20260704T220431Z_pr-8846.json`

## Validation
- `python3 -m pytest tests/scripts/test_retrigger_cancelled_pr_runs.py -q` -> 13 passed, 8 warnings
- `python3 -m py_compile scripts/retrigger_cancelled_pr_runs.py` -> passed
- `python3 -m ruff check scripts/retrigger_cancelled_pr_runs.py tests/scripts/test_retrigger_cancelled_pr_runs.py` -> passed
- pre-commit/pre-push hooks on commit/push -> passed
- `make ci-required` -> ruff passed, then repo-wide mypy failed with existing unrelated type-check debt (2645 errors across 647 files)
