### PR TITLE
Adopt lease identity across lane tooling

### DIFF
--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -598,15 +598,21 @@ def _sidecar_compatible_with_lane(record: LaneRecord, sidecar: dict[str, Any]) -
 
 
 def _fill_from_sidecar(record: LaneRecord, sidecar: dict[str, Any]) -> None:
+    filled_lease_from_sidecar = False
     if not record.work_id:
         record.work_id = str(sidecar.get("work_id") or "")
     if not record.lease_id:
         record.lease_id = str(sidecar.get("lease_id") or "")
+        filled_lease_from_sidecar = bool(record.lease_id)
+    if filled_lease_from_sidecar:
+        record.lease_health = "sidecar"
     if not record.lease_status:
         record.lease_status = str(sidecar.get("lease_status") or "")
     if not record.lease_health:
         record.lease_health = str(sidecar.get("lease_health") or "")
-    if record.lease_id and not record.lease_health:
+    if filled_lease_from_sidecar:
+        record.lease_health = "sidecar"
+    elif record.lease_id and not record.lease_health:
         record.lease_health = "sidecar"
 
 
@@ -619,6 +625,21 @@ def _enrich_lane_records_with_leases(records: list[LaneRecord]) -> list[LaneReco
         if sidecar and _sidecar_compatible_with_lane(record, sidecar):
             _fill_from_sidecar(record, sidecar)
     return records
+
+
+def _lane_has_countable_dev_lease(record: LaneRecord) -> bool:
+    if not record.lease_id:
+        return False
+    invalid_statuses = {"expired", "invalid", "missing", "released", "stale"}
+    invalid_health = {
+        "bridge_only_no_dev_lease",
+        "expired",
+        "invalid",
+        "missing",
+        "sidecar",
+        "stale",
+    }
+    return record.lease_status not in invalid_statuses and record.lease_health not in invalid_health
 
 
 def _write_lane_registry(records: list[LaneRecord]) -> None:
@@ -3038,10 +3059,14 @@ def cmd_operator_snapshot(args: argparse.Namespace) -> int:
         ),
         "active_lanes": sum(1 for r in records if r.status in ACTIVE_LANE_STATUSES),
         "active_lanes_missing_dev_lease": sum(
-            1 for r in records if r.status in ACTIVE_LANE_STATUSES and not r.lease_id
+            1
+            for r in records
+            if r.status in ACTIVE_LANE_STATUSES and not _lane_has_countable_dev_lease(r)
         ),
         "active_lanes_with_dev_lease": sum(
-            1 for r in records if r.status in ACTIVE_LANE_STATUSES and bool(r.lease_id)
+            1
+            for r in records
+            if r.status in ACTIVE_LANE_STATUSES and _lane_has_countable_dev_lease(r)
         ),
         "conflict_lanes": sum(1 for r in records if r.status == "conflict")
         + len(computed_conflict_lane_ids),

--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -677,7 +677,16 @@ def _lane_has_countable_dev_lease(record: LaneRecord) -> bool:
     }
     if record.lease_status in invalid_statuses or record.lease_health in invalid_health:
         return False
-    return record.lease_health == "ok"
+    if record.lease_health != "ok":
+        return False
+    return _sidecar_points_to_active_dev_lease(
+        record,
+        {
+            "branch": record.branch,
+            "lease_id": record.lease_id,
+            "work_id": record.work_id,
+        },
+    )
 
 
 def _write_lane_registry(records: list[LaneRecord]) -> None:

--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -603,7 +603,10 @@ def _sidecar_work_id_matches_lease(lease: Any, work_id: str) -> bool:
     if work_id.startswith("branch:"):
         _prefix, _sep, branch_name = work_id.partition(":")
         return getattr(lease, "branch", "") == branch_name
-    return getattr(lease, "work_id", None) == work_id or getattr(lease, "task_id", "") == work_id
+    lease_work_id = getattr(lease, "work_id", None)
+    if lease_work_id is None or str(lease_work_id).startswith("branch:"):
+        return True
+    return lease_work_id == work_id or getattr(lease, "task_id", "") == work_id
 
 
 def _sidecar_points_to_active_dev_lease(record: LaneRecord, sidecar: dict[str, Any]) -> bool:
@@ -672,7 +675,9 @@ def _lane_has_countable_dev_lease(record: LaneRecord) -> bool:
         "sidecar",
         "stale",
     }
-    return record.lease_status not in invalid_statuses and record.lease_health not in invalid_health
+    if record.lease_status in invalid_statuses or record.lease_health in invalid_health:
+        return False
+    return record.lease_health == "ok"
 
 
 def _write_lane_registry(records: list[LaneRecord]) -> None:

--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -63,6 +63,7 @@ except ModuleNotFoundError:
 AGENT_BRIDGE_DIR = Path.home() / ".aragora" / "agent-bridge"
 SESSION_SNAPSHOT_FILE = AGENT_BRIDGE_DIR / "sessions.json"
 LANE_REGISTRY_FILE = AGENT_BRIDGE_DIR / "lanes.json"
+LANE_LEASES_FILENAME = "lane-leases.json"
 USER_HEARTBEATS_FILE = AGENT_BRIDGE_DIR / "heartbeats.json"
 TMUX_SESSIONS_DIR = Path.home() / ".aragora" / "tmux-sessions"
 TMUX_SESSION = "aragora"
@@ -174,6 +175,27 @@ def _bridge_files_for_lane_read() -> list[Path]:
     return paths or [LANE_REGISTRY_FILE]
 
 
+def _bridge_files_for_lane_lease_read() -> list[Path]:
+    """Return sidecar lease mappings written by check_work_lease.py v0."""
+    candidates = [
+        AGENT_BRIDGE_DIR / LANE_LEASES_FILENAME,
+        _state_root_bridge_dir() / LANE_LEASES_FILENAME,
+    ]
+    paths: list[Path] = []
+    seen: set[Path] = set()
+    for path in candidates:
+        try:
+            resolved = path.resolve()
+        except OSError:
+            resolved = path
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        if path.exists():
+            paths.append(path)
+    return paths
+
+
 def _bridge_file_for_write(default_path: Path) -> Path:
     try:
         _assert_writable_dir(default_path.parent)
@@ -249,6 +271,10 @@ class LaneRecord:
     last_ack_at: str = ""
     last_heartbeat_at: str = ""
     last_steering_outcome: str = ""
+    work_id: str = ""
+    lease_id: str = ""
+    lease_status: str = ""
+    lease_health: str = ""
 
     def to_dict(self) -> dict[str, Any]:
         return {k: v for k, v in asdict(self).items() if v not in ("", None)}
@@ -281,6 +307,10 @@ class LaneRecord:
             last_ack_at=str(payload.get("last_ack_at", "")),
             last_heartbeat_at=str(payload.get("last_heartbeat_at", "")),
             last_steering_outcome=str(payload.get("last_steering_outcome", "")),
+            work_id=str(payload.get("work_id", "")),
+            lease_id=str(payload.get("lease_id", "")),
+            lease_status=str(payload.get("lease_status", "")),
+            lease_health=str(payload.get("lease_health", "")),
         )
 
 
@@ -516,7 +546,9 @@ def _load_lane_registry() -> list[LaneRecord]:
                     current[1],
                 )
 
-    return anonymous + [record for record, _source_index in merged.values()]
+    return _enrich_lane_records_with_leases(
+        anonymous + [record for record, _source_index in merged.values()]
+    )
 
 
 def _prefer_lane_record(
@@ -543,6 +575,50 @@ def _fill_sparse_lane_identity(preferred: LaneRecord, fallback: LaneRecord) -> L
     if preferred.pr_number is None:
         preferred.pr_number = fallback.pr_number
     return preferred
+
+
+def _load_lane_lease_sidecars() -> dict[str, dict[str, Any]]:
+    merged: dict[str, dict[str, Any]] = {}
+    for sidecar in _bridge_files_for_lane_lease_read():
+        try:
+            payload = json.loads(sidecar.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        for lane_id, record in payload.items():
+            if isinstance(lane_id, str) and isinstance(record, dict):
+                merged[lane_id] = record
+    return merged
+
+
+def _sidecar_compatible_with_lane(record: LaneRecord, sidecar: dict[str, Any]) -> bool:
+    sidecar_branch = str(sidecar.get("branch") or "").strip()
+    return not (record.branch and sidecar_branch and record.branch != sidecar_branch)
+
+
+def _fill_from_sidecar(record: LaneRecord, sidecar: dict[str, Any]) -> None:
+    if not record.work_id:
+        record.work_id = str(sidecar.get("work_id") or "")
+    if not record.lease_id:
+        record.lease_id = str(sidecar.get("lease_id") or "")
+    if not record.lease_status:
+        record.lease_status = str(sidecar.get("lease_status") or "")
+    if not record.lease_health:
+        record.lease_health = str(sidecar.get("lease_health") or "")
+    if record.lease_id and not record.lease_health:
+        record.lease_health = "sidecar"
+
+
+def _enrich_lane_records_with_leases(records: list[LaneRecord]) -> list[LaneRecord]:
+    sidecars = _load_lane_lease_sidecars()
+    if not sidecars:
+        return records
+    for record in records:
+        sidecar = sidecars.get(record.lane_id)
+        if sidecar and _sidecar_compatible_with_lane(record, sidecar):
+            _fill_from_sidecar(record, sidecar)
+    return records
 
 
 def _write_lane_registry(records: list[LaneRecord]) -> None:
@@ -2961,6 +3037,12 @@ def cmd_operator_snapshot(args: argparse.Namespace) -> int:
             1 for run in broker_runs if run.get("status") in {"running", "awaiting_human"}
         ),
         "active_lanes": sum(1 for r in records if r.status in ACTIVE_LANE_STATUSES),
+        "active_lanes_missing_dev_lease": sum(
+            1 for r in records if r.status in ACTIVE_LANE_STATUSES and not r.lease_id
+        ),
+        "active_lanes_with_dev_lease": sum(
+            1 for r in records if r.status in ACTIVE_LANE_STATUSES and bool(r.lease_id)
+        ),
         "conflict_lanes": sum(1 for r in records if r.status == "conflict")
         + len(computed_conflict_lane_ids),
         "health_issues": len(issues),

--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -648,6 +648,9 @@ def _fill_from_sidecar(record: LaneRecord, sidecar: dict[str, Any]) -> None:
         record.lease_health = str(sidecar.get("lease_health") or "")
     if filled_lease_from_sidecar:
         record.lease_health = "ok" if sidecar_is_active else "sidecar"
+    elif sidecar_is_active and record.lease_id == str(sidecar.get("lease_id") or "").strip():
+        record.lease_status = "active"
+        record.lease_health = "ok"
     elif record.lease_id and not record.lease_health:
         record.lease_health = "sidecar"
 

--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -684,6 +684,7 @@ def _lane_has_countable_dev_lease(record: LaneRecord) -> bool:
         {
             "branch": record.branch,
             "lease_id": record.lease_id,
+            "owner_session_id": record.owner_session,
             "work_id": record.work_id,
         },
     )

--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -179,6 +179,7 @@ def _bridge_files_for_lane_lease_read() -> list[Path]:
     """Return sidecar lease mappings written by check_work_lease.py v0."""
     candidates = [
         AGENT_BRIDGE_DIR / LANE_LEASES_FILENAME,
+        CANONICAL_REPO_ROOT / ".aragora" / "agent-bridge" / LANE_LEASES_FILENAME,
         _state_root_bridge_dir() / LANE_LEASES_FILENAME,
     ]
     paths: list[Path] = []

--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -597,21 +597,54 @@ def _sidecar_compatible_with_lane(record: LaneRecord, sidecar: dict[str, Any]) -
     return not (record.branch and sidecar_branch and record.branch != sidecar_branch)
 
 
+def _sidecar_work_id_matches_lease(lease: Any, work_id: str) -> bool:
+    if not work_id:
+        return True
+    if work_id.startswith("branch:"):
+        _prefix, _sep, branch_name = work_id.partition(":")
+        return getattr(lease, "branch", "") == branch_name
+    return getattr(lease, "work_id", None) == work_id or getattr(lease, "task_id", "") == work_id
+
+
+def _sidecar_points_to_active_dev_lease(record: LaneRecord, sidecar: dict[str, Any]) -> bool:
+    lease_id = str(sidecar.get("lease_id") or "").strip()
+    branch = str(sidecar.get("branch") or record.branch or "").strip()
+    owner_session_id = str(sidecar.get("owner_session_id") or "").strip()
+    work_id = str(sidecar.get("work_id") or record.work_id or "").strip()
+    if not lease_id or not branch:
+        return False
+    try:
+        import check_work_lease
+
+        db_path = check_work_lease.resolve_db_path(CANONICAL_REPO_ROOT)
+        leases = check_work_lease.active_leases_for_branch(db_path, branch)
+    except Exception:
+        return False
+    for lease in leases:
+        if lease.lease_id != lease_id:
+            continue
+        if owner_session_id and lease.owner_session_id != owner_session_id:
+            return False
+        return _sidecar_work_id_matches_lease(lease, work_id)
+    return False
+
+
 def _fill_from_sidecar(record: LaneRecord, sidecar: dict[str, Any]) -> None:
     filled_lease_from_sidecar = False
+    sidecar_is_active = _sidecar_points_to_active_dev_lease(record, sidecar)
     if not record.work_id:
         record.work_id = str(sidecar.get("work_id") or "")
     if not record.lease_id:
         record.lease_id = str(sidecar.get("lease_id") or "")
         filled_lease_from_sidecar = bool(record.lease_id)
-    if filled_lease_from_sidecar:
-        record.lease_health = "sidecar"
     if not record.lease_status:
-        record.lease_status = str(sidecar.get("lease_status") or "")
+        record.lease_status = (
+            "active" if sidecar_is_active else str(sidecar.get("lease_status") or "")
+        )
     if not record.lease_health:
         record.lease_health = str(sidecar.get("lease_health") or "")
     if filled_lease_from_sidecar:
-        record.lease_health = "sidecar"
+        record.lease_health = "ok" if sidecar_is_active else "sidecar"
     elif record.lease_id and not record.lease_health:
         record.lease_health = "sidecar"
 

--- a/scripts/build_next_prompt.py
+++ b/scripts/build_next_prompt.py
@@ -1594,13 +1594,15 @@ def _branch_write_lease_preflight_lines(
     if not lane or str(lane.get("status") or "") not in ACTIVE_STATUSES:
         return []
     lease_branch = str(lane.get("branch") or branch or "").strip()
+    owner_session = str(lane.get("owner_session") or "").strip()
     work_id = _prompt_work_id(lane, pr=pr, branch=lease_branch or branch)
     if not lease_branch or not work_id:
         return []
+    session_arg = f" --session-id {shlex.quote(owner_session)}" if owner_session else ""
     command = (
         "python3 scripts/check_work_lease.py "
         f"{shlex.quote(lease_branch)} --verify-only --work-id {shlex.quote(work_id)} "
-        "--strict --json"
+        f"--strict{session_arg} --json"
     )
     return [
         "",

--- a/scripts/build_next_prompt.py
+++ b/scripts/build_next_prompt.py
@@ -1568,6 +1568,47 @@ def _mailbox_command(lane: dict[str, Any] | None, *, pr: int | None, branch: str
     return "python3 scripts/agent_bridge.py operator-snapshot --json --summary-only || true"
 
 
+def _prompt_work_id(
+    lane: dict[str, Any] | None, *, pr: int | None, branch: str | None
+) -> str | None:
+    if lane:
+        raw = str(lane.get("work_id") or "").strip()
+        if raw:
+            return raw
+        raw_pr = lane.get("pr_number")
+        if raw_pr is not None:
+            try:
+                return f"pr:{int(raw_pr)}"
+            except (TypeError, ValueError):
+                pass
+    if pr is not None:
+        return f"pr:{pr}"
+    if branch:
+        return f"branch:{branch}"
+    return None
+
+
+def _branch_write_lease_preflight_lines(
+    lane: dict[str, Any] | None, *, pr: int | None, branch: str | None
+) -> list[str]:
+    if not lane or str(lane.get("status") or "") not in ACTIVE_STATUSES:
+        return []
+    lease_branch = str(lane.get("branch") or branch or "").strip()
+    work_id = _prompt_work_id(lane, pr=pr, branch=lease_branch or branch)
+    if not lease_branch or not work_id:
+        return []
+    command = (
+        "python3 scripts/check_work_lease.py "
+        f"{shlex.quote(lease_branch)} --verify-only --work-id {shlex.quote(work_id)} "
+        "--strict --json"
+    )
+    return [
+        "",
+        "Before any branch push when ARAGORA_REQUIRE_BRANCH_WRITE_LEASE=1, verify the dev_coordination branch-write lease:",
+        command,
+    ]
+
+
 def build_prompt(
     *,
     registry_path: Path,
@@ -1642,6 +1683,7 @@ def build_prompt(
                 f"python3 -m aragora.cli.main review-queue merge-packet --pr {pr} --json || true",
             ]
         )
+    lines.extend(_branch_write_lease_preflight_lines(lane, pr=pr, branch=branch))
 
     lines.append("")
     if lane:

--- a/scripts/check_work_lease.py
+++ b/scripts/check_work_lease.py
@@ -660,6 +660,8 @@ def main(argv: list[str] | None = None) -> int:
     ]
     mine = [lease for lease in matching_leases if lease.owner_session_id == session_id]
     theirs = [lease for lease in matching_leases if lease.owner_session_id != session_id]
+    branch_mine = [lease for lease in leases if lease.owner_session_id == session_id]
+    branch_theirs = [lease for lease in leases if lease.owner_session_id != session_id]
 
     if args.verify_only:
         sidecar = read_lane_lease(repo_root, args.record_lane) if args.record_lane else None
@@ -679,7 +681,7 @@ def main(argv: list[str] | None = None) -> int:
                 owners=sorted(distinct_owners),
             )
             return _advisory_exit_code(args, False)
-        if theirs:
+        if branch_theirs:
             _emit(
                 args,
                 ok=False,
@@ -687,10 +689,10 @@ def main(argv: list[str] | None = None) -> int:
                 reason=REASON_WRONG_OWNER,
                 work_id=work_id,
                 branch=branch,
-                lease_id=theirs[0].lease_id,
-                owner_session_id=theirs[0].owner_session_id,
-                detail=f"LEASE CONFLICT: {theirs[0].owner_report()}",
-                owner=dataclasses.asdict(theirs[0]),
+                lease_id=branch_theirs[0].lease_id,
+                owner_session_id=branch_theirs[0].owner_session_id,
+                detail=f"LEASE CONFLICT: {branch_theirs[0].owner_report()}",
+                owner=dataclasses.asdict(branch_theirs[0]),
             )
             return _advisory_exit_code(args, False)
         if mine:
@@ -755,7 +757,7 @@ def main(argv: list[str] | None = None) -> int:
     # path (when we hold nothing) must NOT short-circuit here: it goes to
     # store.claim_lease first so the store can reap expired and dead-worker
     # leases instead of letting them squat the branch until TTL.
-    if theirs and not (args.claim and not mine):
+    if branch_theirs and not (args.claim and not branch_mine):
         _emit(
             args,
             ok=False,
@@ -763,10 +765,10 @@ def main(argv: list[str] | None = None) -> int:
             reason=REASON_WRONG_OWNER,
             work_id=work_id,
             branch=branch,
-            lease_id=theirs[0].lease_id,
-            owner_session_id=theirs[0].owner_session_id,
-            detail=f"LEASE CONFLICT: {theirs[0].owner_report()}",
-            owner=dataclasses.asdict(theirs[0]),
+            lease_id=branch_theirs[0].lease_id,
+            owner_session_id=branch_theirs[0].owner_session_id,
+            detail=f"LEASE CONFLICT: {branch_theirs[0].owner_report()}",
+            owner=dataclasses.asdict(branch_theirs[0]),
         )
         return _advisory_exit_code(args, False)
 

--- a/scripts/check_work_lease.py
+++ b/scripts/check_work_lease.py
@@ -49,6 +49,7 @@ from __future__ import annotations
 
 import argparse
 import dataclasses
+import fcntl
 import getpass
 import json
 import os
@@ -368,37 +369,40 @@ def record_lane_lease(
     """
     sidecar = repo_root / LANE_LEASES_RELPATH
     sidecar.parent.mkdir(parents=True, exist_ok=True)
-    payload: dict[str, Any] = {}
-    if sidecar.exists():
+    lock_path = sidecar.with_name(f"{sidecar.name}.lock")
+    with lock_path.open("a+", encoding="utf-8") as lock_handle:
+        fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
+        payload: dict[str, Any] = {}
+        if sidecar.exists():
+            try:
+                loaded = json.loads(sidecar.read_text(encoding="utf-8"))
+                if isinstance(loaded, dict):
+                    payload = loaded
+            except (OSError, json.JSONDecodeError):
+                payload = {}
+        if lease_id is None:
+            payload.pop(lane_id, None)
+        else:
+            payload[lane_id] = {
+                "branch": branch,
+                "lease_id": lease_id,
+                "owner_session_id": session_id,
+                "updated_at": _utcnow().isoformat(),
+            }
+            if work_id:
+                payload[lane_id]["work_id"] = work_id
+        fd, tmp_name = tempfile.mkstemp(dir=str(sidecar.parent), prefix=".lane-leases-")
         try:
-            loaded = json.loads(sidecar.read_text(encoding="utf-8"))
-            if isinstance(loaded, dict):
-                payload = loaded
-        except (OSError, json.JSONDecodeError):
-            payload = {}
-    if lease_id is None:
-        payload.pop(lane_id, None)
-    else:
-        payload[lane_id] = {
-            "branch": branch,
-            "lease_id": lease_id,
-            "owner_session_id": session_id,
-            "updated_at": _utcnow().isoformat(),
-        }
-        if work_id:
-            payload[lane_id]["work_id"] = work_id
-    fd, tmp_name = tempfile.mkstemp(dir=str(sidecar.parent), prefix=".lane-leases-")
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as handle:
-            json.dump(payload, handle, indent=2, sort_keys=True)
-            handle.write("\n")
-        os.replace(tmp_name, sidecar)
-    except OSError:
-        try:
-            os.unlink(tmp_name)
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(payload, handle, indent=2, sort_keys=True)
+                handle.write("\n")
+            os.replace(tmp_name, sidecar)
         except OSError:
-            pass
-        raise
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass
+            raise
     return sidecar
 
 

--- a/scripts/check_work_lease.py
+++ b/scripts/check_work_lease.py
@@ -175,6 +175,9 @@ def _resolve_work_id(args: argparse.Namespace, branch: str) -> str | None:
 def _lease_matches_work_id(lease: LeaseRow, work_id: str | None) -> bool:
     if work_id is None:
         return True
+    if work_id.startswith("branch:"):
+        _prefix, _sep, branch_name = work_id.partition(":")
+        return lease.branch == branch_name
     return lease.work_id == work_id or lease.task_id == work_id
 
 

--- a/scripts/check_work_lease.py
+++ b/scripts/check_work_lease.py
@@ -670,7 +670,6 @@ def main(argv: list[str] | None = None) -> int:
         lease for lease in all_leases if lease.is_expired and _lease_matches_work_id(lease, work_id)
     ]
     mine = [lease for lease in matching_leases if lease.owner_session_id == session_id]
-    theirs = [lease for lease in matching_leases if lease.owner_session_id != session_id]
     branch_mine = [lease for lease in leases if lease.owner_session_id == session_id]
     branch_theirs = [lease for lease in leases if lease.owner_session_id != session_id]
     if work_id and not mine:

--- a/scripts/check_work_lease.py
+++ b/scripts/check_work_lease.py
@@ -674,7 +674,7 @@ def main(argv: list[str] | None = None) -> int:
     mine = [lease for lease in matching_leases if lease.owner_session_id == session_id]
     branch_mine = [lease for lease in leases if lease.owner_session_id == session_id]
     branch_theirs = [lease for lease in leases if lease.owner_session_id != session_id]
-    if work_id and not mine:
+    if work_id and not mine and not matching_leases:
         mine = [lease for lease in branch_mine if _lease_allows_branch_owner_fallback(lease)]
 
     if args.verify_only:

--- a/scripts/check_work_lease.py
+++ b/scripts/check_work_lease.py
@@ -79,6 +79,13 @@ DEFAULT_TTL_HOURS = 8.0
 # claims for the same branch conflict transactionally at the store.
 BRANCH_LOCK_GLOB_TEMPLATE = ".aragora/branch-locks/{branch}"
 
+REASON_MISSING_LEASE = "missing_lease"
+REASON_EXPIRED_LEASE = "expired_lease"
+REASON_WRONG_OWNER = "wrong_owner"
+REASON_BRIDGE_ONLY_NO_DEV_LEASE = "bridge_only_no_dev_lease"
+REASON_AMBIGUOUS_OWNER = "ambiguous_owner"
+REASON_STORE_UNREACHABLE = "store_unreachable"
+
 
 class StoreUnreachableError(RuntimeError):
     """The dev_coordination store cannot be read or resolved."""
@@ -98,10 +105,20 @@ class LeaseRow:
     status: str
     created_at: str
     expires_at: str
+    metadata: dict[str, Any]
 
     @property
     def is_expired(self) -> bool:
         return _parse_dt(self.expires_at) <= _utcnow()
+
+    @property
+    def work_id(self) -> str | None:
+        value = self.metadata.get("work_id")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        if _looks_like_work_id(self.task_id):
+            return self.task_id
+        return None
 
     def owner_report(self) -> str:
         return (
@@ -123,6 +140,56 @@ def _parse_dt(value: str) -> datetime:
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=timezone.utc)
     return parsed
+
+
+def _json_obj(raw: Any) -> dict[str, Any]:
+    if isinstance(raw, dict):
+        return raw
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(str(raw))
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _looks_like_work_id(value: str | None) -> bool:
+    if not value:
+        return False
+    prefix, sep, suffix = value.partition(":")
+    return bool(sep and suffix and prefix in {"pr", "issue", "factory", "branch"})
+
+
+def _resolve_work_id(args: argparse.Namespace, branch: str) -> str | None:
+    explicit = getattr(args, "work_id", None)
+    if explicit and explicit.strip():
+        return explicit.strip()
+    if getattr(args, "pr", None) is not None:
+        return f"pr:{args.pr}"
+    if getattr(args, "task_id", None) and _looks_like_work_id(args.task_id):
+        return args.task_id
+    return None
+
+
+def _lease_matches_work_id(lease: LeaseRow, work_id: str | None) -> bool:
+    if work_id is None:
+        return True
+    return lease.work_id == work_id or lease.task_id == work_id
+
+
+def _advisory_exit_code(args: argparse.Namespace, ok: bool) -> int:
+    return 0 if ok or getattr(args, "advisory", False) else 1
+
+
+def _sidecar_matches(record: dict[str, Any] | None, *, branch: str, work_id: str | None) -> bool:
+    if not record:
+        return False
+    sidecar_branch = str(record.get("branch") or "").strip()
+    if sidecar_branch and sidecar_branch != branch:
+        return False
+    sidecar_work_id = str(record.get("work_id") or "").strip()
+    return not (work_id and sidecar_work_id and sidecar_work_id != work_id)
 
 
 def resolve_db_path(repo_root: Path, explicit: str | None = None) -> Path:
@@ -196,7 +263,7 @@ def _query_lease_rows(db_path: Path, branch: str, *, immutable: bool) -> list[sq
         conn.row_factory = sqlite3.Row
         return conn.execute(
             "SELECT lease_id, task_id, title, owner_agent, owner_session_id, branch,"
-            " worktree_path, status, created_at, expires_at"
+            " worktree_path, status, created_at, expires_at, metadata_json"
             " FROM leases WHERE branch = ? AND status = 'active'"
             " ORDER BY created_at ASC, lease_id ASC",
             (branch,),
@@ -205,8 +272,8 @@ def _query_lease_rows(db_path: Path, branch: str, *, immutable: bool) -> list[sq
         conn.close()
 
 
-def active_leases_for_branch(db_path: Path, branch: str) -> list[LeaseRow]:
-    """Read-only query of active, unexpired leases for ``branch``.
+def leases_for_branch(db_path: Path, branch: str) -> list[LeaseRow]:
+    """Read-only query of active leases for ``branch``.
 
     A missing DB file means the store has never been initialised, which we
     treat as "no leases" rather than unreachable (deterministic for fresh
@@ -243,9 +310,16 @@ def active_leases_for_branch(db_path: Path, branch: str) -> list[LeaseRow]:
             status=row["status"],
             created_at=row["created_at"],
             expires_at=row["expires_at"],
+            metadata=_json_obj(row["metadata_json"]),
         )
         for row in rows
     ]
+    return leases
+
+
+def active_leases_for_branch(db_path: Path, branch: str) -> list[LeaseRow]:
+    """Read-only query of active, unexpired leases for ``branch``."""
+    leases = leases_for_branch(db_path, branch)
     return [lease for lease in leases if not lease.is_expired]
 
 
@@ -271,6 +345,7 @@ def record_lane_lease(
     branch: str,
     lease_id: str | None,
     session_id: str,
+    work_id: str | None = None,
 ) -> Path:
     """Record (or clear, when ``lease_id`` is None) a lane→lease mapping.
 
@@ -296,6 +371,8 @@ def record_lane_lease(
             "owner_session_id": session_id,
             "updated_at": _utcnow().isoformat(),
         }
+        if work_id:
+            payload[lane_id]["work_id"] = work_id
     fd, tmp_name = tempfile.mkstemp(dir=str(sidecar.parent), prefix=".lane-leases-")
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
@@ -311,9 +388,45 @@ def record_lane_lease(
     return sidecar
 
 
-def _emit(args: argparse.Namespace, *, ok: bool, action: str, detail: str, **extra: Any) -> None:
+def read_lane_lease(repo_root: Path, lane_id: str) -> dict[str, Any] | None:
+    sidecar = repo_root / LANE_LEASES_RELPATH
+    if not sidecar.exists():
+        return None
+    try:
+        payload = json.loads(sidecar.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    record = payload.get(lane_id)
+    return record if isinstance(record, dict) else None
+
+
+def _emit(
+    args: argparse.Namespace,
+    *,
+    ok: bool,
+    action: str,
+    detail: str,
+    reason: str | None = None,
+    work_id: str | None = None,
+    branch: str | None = None,
+    lease_id: str | None = None,
+    owner_session_id: str | None = None,
+    **extra: Any,
+) -> None:
     if getattr(args, "json", False):
-        payload = {"ok": ok, "action": action, "detail": detail, **extra}
+        payload = {
+            "ok": ok,
+            "action": action,
+            "reason": reason,
+            "work_id": work_id,
+            "branch": branch,
+            "lease_id": lease_id,
+            "owner_session_id": owner_session_id,
+            "detail": detail,
+            **extra,
+        }
         print(json.dumps(payload, indent=2, sort_keys=True, default=str))  # noqa: T201
     else:
         prefix = "OK" if ok else "BLOCKED"
@@ -326,13 +439,20 @@ def _warn_fail_open(args: argparse.Namespace, reason: str) -> int:
             args,
             ok=False,
             action="store-unreachable",
+            reason=REASON_STORE_UNREACHABLE,
             detail=f"{reason} (--strict: failing closed)",
         )
-        return 1
+        return _advisory_exit_code(args, False)
     message = f"WARNING: lease store unreachable ({reason}) — proceeding fail-open (v0; use --strict to fail closed)"
     print(message, file=sys.stderr)  # noqa: T201
     if args.json:
-        _emit(args, ok=True, action="store-unreachable", detail=message)
+        _emit(
+            args,
+            ok=True,
+            action="store-unreachable",
+            reason=REASON_STORE_UNREACHABLE,
+            detail=message,
+        )
     return 0
 
 
@@ -369,12 +489,15 @@ def _claim(
     metadata: dict[str, Any] = {"claimed_via": "check_work_lease"}
     if args.pr is not None:
         metadata["pr_number"] = args.pr
+    work_id = _resolve_work_id(args, branch)
+    if work_id:
+        metadata["work_id"] = work_id
     from aragora.nomic.dev_coordination import LeaseConflictError
 
     branch_lock = BRANCH_LOCK_GLOB_TEMPLATE.format(branch=branch)
     try:
         lease = store.claim_lease(
-            task_id=args.task_id or f"branch:{branch}",
+            task_id=args.task_id or work_id or f"branch:{branch}",
             title=args.title or f"Push lease for {branch}",
             owner_agent=args.agent,
             owner_session_id=session_id,
@@ -390,10 +513,13 @@ def _claim(
             args,
             ok=False,
             action="claim",
+            reason=REASON_WRONG_OWNER,
+            work_id=work_id,
+            branch=branch,
             detail=f"LEASE CONFLICT: {_conflict_line(exc.conflicts[0], branch)}",
             conflicts=exc.conflicts,
         )
-        return 1, None
+        return _advisory_exit_code(args, False), None
     # Post-claim double-check: helper-vs-helper conflicts are caught
     # transactionally by the branch-lock glob above, but a store-direct
     # claimant (e.g. swarm) holding this branch with a non-overlapping file
@@ -406,15 +532,26 @@ def _claim(
         if contender.owner_session_id != session_id:
             store.release_lease(lease.lease_id)
             _emit(
-                args, ok=False, action="claim", detail=f"LEASE CONFLICT: {contender.owner_report()}"
+                args,
+                ok=False,
+                action="claim",
+                reason=REASON_WRONG_OWNER,
+                work_id=work_id,
+                branch=branch,
+                lease_id=contender.lease_id,
+                owner_session_id=contender.owner_session_id,
+                detail=f"LEASE CONFLICT: {contender.owner_report()}",
             )
-            return 1, None
+            return _advisory_exit_code(args, False), None
     _emit(
         args,
         ok=True,
         action="claim",
+        work_id=work_id,
+        branch=branch,
         detail=f"claimed lease {lease.lease_id} for branch '{branch}' (session {session_id})",
         lease_id=lease.lease_id,
+        owner_session_id=session_id,
     )
     return 0, lease.lease_id
 
@@ -439,6 +576,21 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--claim", action="store_true", help="Claim the lease if nobody holds it")
     parser.add_argument("--renew", action="store_true", help="Renew (heartbeat) the held lease")
     parser.add_argument("--release", action="store_true", help="Release the held lease")
+    parser.add_argument(
+        "--verify-only",
+        action="store_true",
+        help="Only verify an existing matching lease; never write lease or lane state",
+    )
+    parser.add_argument(
+        "--advisory",
+        action="store_true",
+        help="Report the same check result but exit 0 on failures",
+    )
+    parser.add_argument(
+        "--work-id",
+        default=None,
+        help="Stable work identity: pr:<n>, issue:<n>, factory:<id>, or branch:<name>",
+    )
     parser.add_argument(
         "--strict", action="store_true", help="Fail closed when the store is unreachable"
     )
@@ -469,6 +621,8 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.release and (args.claim or args.renew):
         parser.error("--release cannot be combined with --claim/--renew")
+    if args.verify_only and (args.claim or args.renew or args.release):
+        parser.error("--verify-only cannot be combined with --claim/--renew/--release")
 
     repo_root = Path(args.repo).expanduser().resolve()
     session_id, stable = resolve_session_id(args.session_id)
@@ -491,12 +645,108 @@ def main(argv: list[str] | None = None) -> int:
     try:
         branch = resolve_branch(repo_root, args.branch)
         db_path = resolve_db_path(repo_root, args.db)
-        leases = active_leases_for_branch(db_path, branch)
+        all_leases = leases_for_branch(db_path, branch)
     except (StoreUnreachableError, subprocess.TimeoutExpired, OSError) as exc:
         return _warn_fail_open(args, str(exc))
 
-    mine = [lease for lease in leases if lease.owner_session_id == session_id]
-    theirs = [lease for lease in leases if lease.owner_session_id != session_id]
+    work_id = _resolve_work_id(args, branch)
+    leases = [lease for lease in all_leases if not lease.is_expired]
+    matching_leases = [lease for lease in leases if _lease_matches_work_id(lease, work_id)]
+    expired_matching_leases = [
+        lease for lease in all_leases if lease.is_expired and _lease_matches_work_id(lease, work_id)
+    ]
+    mine = [lease for lease in matching_leases if lease.owner_session_id == session_id]
+    theirs = [lease for lease in matching_leases if lease.owner_session_id != session_id]
+
+    if args.verify_only:
+        sidecar = read_lane_lease(repo_root, args.record_lane) if args.record_lane else None
+        distinct_owners = {lease.owner_session_id for lease in matching_leases}
+        if len(distinct_owners) > 1:
+            first = matching_leases[0]
+            _emit(
+                args,
+                ok=False,
+                action="check",
+                reason=REASON_AMBIGUOUS_OWNER,
+                work_id=work_id,
+                branch=branch,
+                lease_id=first.lease_id,
+                owner_session_id=first.owner_session_id,
+                detail=f"ambiguous active leases for branch '{branch}' and work_id '{work_id}'",
+                owners=sorted(distinct_owners),
+            )
+            return _advisory_exit_code(args, False)
+        if theirs:
+            _emit(
+                args,
+                ok=False,
+                action="check",
+                reason=REASON_WRONG_OWNER,
+                work_id=work_id,
+                branch=branch,
+                lease_id=theirs[0].lease_id,
+                owner_session_id=theirs[0].owner_session_id,
+                detail=f"LEASE CONFLICT: {theirs[0].owner_report()}",
+                owner=dataclasses.asdict(theirs[0]),
+            )
+            return _advisory_exit_code(args, False)
+        if mine:
+            _emit(
+                args,
+                ok=True,
+                action="check",
+                work_id=work_id,
+                branch=branch,
+                lease_id=mine[0].lease_id,
+                owner_session_id=session_id,
+                detail=f"holding lease {mine[0].lease_id} for branch '{branch}' (session {session_id})",
+            )
+            return 0
+        if expired_matching_leases:
+            first = expired_matching_leases[0]
+            _emit(
+                args,
+                ok=False,
+                action="check",
+                reason=REASON_EXPIRED_LEASE,
+                work_id=work_id,
+                branch=branch,
+                lease_id=first.lease_id,
+                owner_session_id=first.owner_session_id,
+                detail=(
+                    f"lease {first.lease_id} for branch '{branch}' expired at {first.expires_at}"
+                ),
+            )
+            return _advisory_exit_code(args, False)
+        if _sidecar_matches(sidecar, branch=branch, work_id=work_id):
+            _emit(
+                args,
+                ok=False,
+                action="check",
+                reason=REASON_BRIDGE_ONLY_NO_DEV_LEASE,
+                work_id=work_id,
+                branch=branch,
+                lease_id=str(sidecar.get("lease_id") or "") or None,
+                owner_session_id=str(sidecar.get("owner_session_id") or "") or None,
+                detail=(
+                    f"lane '{args.record_lane}' has bridge lease metadata but no matching "
+                    "dev_coordination lease"
+                ),
+            )
+            return _advisory_exit_code(args, False)
+        _emit(
+            args,
+            ok=False,
+            action="check",
+            reason=REASON_MISSING_LEASE,
+            work_id=work_id,
+            branch=branch,
+            detail=(
+                f"no active lease held for branch '{branch}'"
+                + (f" and work_id '{work_id}'" if work_id else "")
+            ),
+        )
+        return _advisory_exit_code(args, False)
 
     # Foreign leases block immediately on the read-only paths. The --claim
     # path (when we hold nothing) must NOT short-circuit here: it goes to
@@ -507,10 +757,15 @@ def main(argv: list[str] | None = None) -> int:
             args,
             ok=False,
             action="check",
+            reason=REASON_WRONG_OWNER,
+            work_id=work_id,
+            branch=branch,
+            lease_id=theirs[0].lease_id,
+            owner_session_id=theirs[0].owner_session_id,
             detail=f"LEASE CONFLICT: {theirs[0].owner_report()}",
             owner=dataclasses.asdict(theirs[0]),
         )
-        return 1
+        return _advisory_exit_code(args, False)
 
     try:
         if args.release:
@@ -519,6 +774,8 @@ def main(argv: list[str] | None = None) -> int:
                     args,
                     ok=True,
                     action="release",
+                    work_id=work_id,
+                    branch=branch,
                     detail=f"no active lease held for branch '{branch}' (no-op)",
                 )
             else:
@@ -529,7 +786,11 @@ def main(argv: list[str] | None = None) -> int:
                     args,
                     ok=True,
                     action="release",
+                    work_id=work_id,
+                    branch=branch,
                     detail=f"released lease {mine[0].lease_id} for branch '{branch}'",
+                    lease_id=mine[0].lease_id,
+                    owner_session_id=session_id,
                 )
             if args.record_lane:
                 record_lane_lease(
@@ -545,16 +806,22 @@ def main(argv: list[str] | None = None) -> int:
                 args,
                 ok=True,
                 action="renew",
+                work_id=work_id,
+                branch=branch,
                 detail=f"renewed lease {renewed.lease_id} for branch '{branch}' until {renewed.expires_at}",
                 lease_id=renewed.lease_id,
+                owner_session_id=session_id,
             )
         elif mine:
             _emit(
                 args,
                 ok=True,
                 action="check",
+                work_id=work_id,
+                branch=branch,
                 detail=f"holding lease {mine[0].lease_id} for branch '{branch}' (session {session_id})",
                 lease_id=mine[0].lease_id,
+                owner_session_id=session_id,
             )
         elif args.claim:
             code, lease_id = _claim(
@@ -567,21 +834,32 @@ def main(argv: list[str] | None = None) -> int:
                 args,
                 ok=False,
                 action="renew",
+                reason=REASON_MISSING_LEASE,
+                work_id=work_id,
+                branch=branch,
                 detail=f"no active lease held for branch '{branch}' — claim one with --claim",
             )
-            return 1
+            return _advisory_exit_code(args, False)
         else:
             _emit(
                 args,
                 ok=False,
                 action="check",
+                reason=REASON_MISSING_LEASE,
+                work_id=work_id,
+                branch=branch,
                 detail=f"no active lease held for branch '{branch}' (session {session_id}) — run with --claim before pushing",
             )
-            return 1
+            return _advisory_exit_code(args, False)
 
         if args.record_lane and lease_id:
             record_lane_lease(
-                repo_root, args.record_lane, branch=branch, lease_id=lease_id, session_id=session_id
+                repo_root,
+                args.record_lane,
+                branch=branch,
+                lease_id=lease_id,
+                session_id=session_id,
+                work_id=work_id,
             )
         return 0
     except (StoreUnreachableError, subprocess.TimeoutExpired, OSError) as exc:

--- a/scripts/check_work_lease.py
+++ b/scripts/check_work_lease.py
@@ -181,6 +181,11 @@ def _lease_matches_work_id(lease: LeaseRow, work_id: str | None) -> bool:
     return lease.work_id == work_id or lease.task_id == work_id
 
 
+def _lease_allows_branch_owner_fallback(lease: LeaseRow) -> bool:
+    work_id = lease.work_id
+    return work_id is None or work_id.startswith("branch:")
+
+
 def _advisory_exit_code(args: argparse.Namespace, ok: bool) -> int:
     return 0 if ok or getattr(args, "advisory", False) else 1
 
@@ -662,6 +667,8 @@ def main(argv: list[str] | None = None) -> int:
     theirs = [lease for lease in matching_leases if lease.owner_session_id != session_id]
     branch_mine = [lease for lease in leases if lease.owner_session_id == session_id]
     branch_theirs = [lease for lease in leases if lease.owner_session_id != session_id]
+    if work_id and not mine:
+        mine = [lease for lease in branch_mine if _lease_allows_branch_owner_fallback(lease)]
 
     if args.verify_only:
         sidecar = read_lane_lease(repo_root, args.record_lane) if args.record_lane else None

--- a/scripts/check_work_lease.py
+++ b/scripts/check_work_lease.py
@@ -637,6 +637,8 @@ def main(argv: list[str] | None = None) -> int:
         parser.error("--release cannot be combined with --claim/--renew")
     if args.verify_only and (args.claim or args.renew or args.release):
         parser.error("--verify-only cannot be combined with --claim/--renew/--release")
+    if args.advisory and (args.claim or args.renew or args.release):
+        parser.error("--advisory cannot be combined with --claim/--renew/--release")
 
     repo_root = Path(args.repo).expanduser().resolve()
     session_id, stable = resolve_session_id(args.session_id)

--- a/scripts/check_work_lease.py
+++ b/scripts/check_work_lease.py
@@ -116,6 +116,12 @@ class LeaseRow:
         value = self.metadata.get("work_id")
         if isinstance(value, str) and value.strip():
             return value.strip()
+        pr_number = self.metadata.get("pr_number")
+        if pr_number is not None:
+            try:
+                return f"pr:{int(pr_number)}"
+            except (TypeError, ValueError):
+                pass
         if _looks_like_work_id(self.task_id):
             return self.task_id
         return None

--- a/scripts/identify_lane_owner.py
+++ b/scripts/identify_lane_owner.py
@@ -167,6 +167,7 @@ COMPLETED_STATUSES = {"completed", "released", "superseded", "expired"}
 SNAPSHOT_TIMEOUT_SECONDS = 30
 
 SnapshotProvider = Callable[[], dict[str, Any] | None]
+WORK_ID_PREFIXES = ("pr:", "issue:", "factory:", "branch:")
 
 
 # ---------------------------------------------------------------------------
@@ -329,6 +330,96 @@ def find_lane(
                 matches.append(r)
         return _best_lane_match(matches)
     return None
+
+
+def _lane_work_id(lane: dict[str, Any]) -> str | None:
+    raw = str(lane.get("work_id") or "").strip()
+    if raw.startswith(WORK_ID_PREFIXES):
+        return raw
+    raw_pr = lane.get("pr_number")
+    if raw_pr is not None:
+        try:
+            return f"pr:{int(raw_pr)}"
+        except (TypeError, ValueError):
+            pass
+    branch = str(lane.get("branch") or "").strip()
+    return f"branch:{branch}" if branch else None
+
+
+def _check_dev_coordination_lease(
+    lane: dict[str, Any],
+    *,
+    repo_root: Path = REPO_ROOT,
+    timeout_seconds: float = 10.0,
+) -> dict[str, Any]:
+    """Advisory read of the dev_coordination branch-write lease for a lane."""
+
+    branch = str(lane.get("branch") or "").strip()
+    work_id = _lane_work_id(lane)
+    if not branch:
+        return {
+            "status": "unavailable",
+            "reason": "missing_branch",
+            "work_id": work_id,
+            "lease_id": None,
+            "owner_session_id": None,
+        }
+
+    cmd = [
+        sys.executable,
+        str(REPO_ROOT / "scripts" / "check_work_lease.py"),
+        branch,
+        "--repo",
+        str(repo_root),
+        "--verify-only",
+        "--advisory",
+        "--strict",
+        "--json",
+    ]
+    if work_id:
+        cmd.extend(["--work-id", work_id])
+    owner_session = str(lane.get("owner_session") or "").strip()
+    if owner_session:
+        cmd.extend(["--session-id", owner_session])
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=repo_root,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {
+            "status": "unavailable",
+            "reason": "store_unreachable",
+            "work_id": work_id,
+            "lease_id": None,
+            "owner_session_id": owner_session or None,
+            "detail": str(exc),
+        }
+    try:
+        payload = json.loads(proc.stdout or "{}")
+    except json.JSONDecodeError:
+        return {
+            "status": "unavailable",
+            "reason": "store_unreachable",
+            "work_id": work_id,
+            "lease_id": None,
+            "owner_session_id": owner_session or None,
+            "detail": (proc.stderr or proc.stdout or "").strip(),
+        }
+    if not isinstance(payload, dict):
+        payload = {}
+    return {
+        "status": "valid" if payload.get("ok") is True else "invalid",
+        "reason": payload.get("reason"),
+        "work_id": payload.get("work_id") or work_id,
+        "lease_id": payload.get("lease_id"),
+        "owner_session_id": payload.get("owner_session_id") or owner_session or None,
+        "detail": payload.get("detail"),
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -2354,11 +2445,17 @@ def main(argv: Sequence[str] | None = None) -> int:
                 )
 
     output_info, payload = _info_with_aligned_owner_state(info, liveness_payload)
+    dev_coordination_lease: dict[str, Any] | None = None
+    if args.liveness:
+        dev_coordination_lease = _check_dev_coordination_lease(lane)
+        payload["dev_coordination_lease"] = dev_coordination_lease
 
     if args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     else:
         _print_human(output_info)
+        if dev_coordination_lease is not None:
+            print(f"dev_coordination_lease: {dev_coordination_lease}")
         if liveness_payload is not None:
             _print_liveness_summary(payload)
 

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -1200,6 +1200,8 @@ def test_operator_snapshot_summary_reports_active_lanes_missing_dev_lease(
                     "branch": "codex/held",
                     "lease_id": "lease-1",
                     "work_id": "pr:8852",
+                    "lease_status": "active",
+                    "lease_health": "ok",
                 },
                 {
                     "lane_id": "lane-sidecar-only",

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -166,6 +166,49 @@ def test_lane_registry_sidecar_enriches_missing_lease_fields(
     assert record.lease_health == "sidecar"
 
 
+def test_lane_registry_reads_repo_local_sidecar_when_state_root_configured(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import agent_bridge as mod
+
+    _patch_bridge_paths(mod, tmp_path, monkeypatch)
+    monkeypatch.setenv("ARAGORA_AUTOMATION_STATE_ROOT", str(tmp_path / "state-root"))
+    mod.LANE_REGISTRY_FILE.parent.mkdir(parents=True)
+    mod.LANE_REGISTRY_FILE.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "lane-1",
+                    "owner_session": "codex-A",
+                    "status": "active",
+                    "branch": "codex/lease",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    sidecar = mod.CANONICAL_REPO_ROOT / ".aragora" / "agent-bridge" / "lane-leases.json"
+    sidecar.parent.mkdir(parents=True)
+    sidecar.write_text(
+        json.dumps(
+            {
+                "lane-1": {
+                    "branch": "codex/lease",
+                    "work_id": "pr:8852",
+                    "lease_id": "lease-1",
+                    "owner_session_id": "sess-1",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    [record] = mod._load_lane_registry()
+
+    assert record.work_id == "pr:8852"
+    assert record.lease_id == "lease-1"
+
+
 def test_lane_registry_native_lease_fields_override_sidecar(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -88,6 +88,133 @@ def test_lane_record_preserves_desktop_identity_metadata() -> None:
     assert payload["session_title"] == "Review #7286"
 
 
+def test_lane_record_lease_fields_are_backward_compatible() -> None:
+    import agent_bridge as mod
+
+    old_record = mod.LaneRecord.from_dict(
+        {
+            "lane_id": "codex-old",
+            "owner_session": "codex-A",
+            "status": "active",
+        }
+    )
+    old_payload = old_record.to_dict()
+    assert "lease_id" not in old_payload
+    assert "work_id" not in old_payload
+
+    new_record = mod.LaneRecord.from_dict(
+        {
+            "lane_id": "codex-new",
+            "owner_session": "codex-B",
+            "status": "active",
+            "work_id": "pr:8852",
+            "lease_id": "lease-1",
+            "lease_status": "active",
+            "lease_health": "ok",
+        }
+    )
+    new_payload = new_record.to_dict()
+    assert new_payload["work_id"] == "pr:8852"
+    assert new_payload["lease_id"] == "lease-1"
+    assert new_payload["lease_status"] == "active"
+    assert new_payload["lease_health"] == "ok"
+
+
+def test_lane_registry_sidecar_enriches_missing_lease_fields(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import agent_bridge as mod
+
+    _patch_bridge_paths(mod, tmp_path, monkeypatch)
+    mod.LANE_REGISTRY_FILE.parent.mkdir(parents=True)
+    mod.LANE_REGISTRY_FILE.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "lane-1",
+                    "owner_session": "codex-A",
+                    "status": "active",
+                    "branch": "codex/lease",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    sidecar = mod.CANONICAL_REPO_ROOT / ".aragora" / "agent-bridge" / "lane-leases.json"
+    sidecar.parent.mkdir(parents=True)
+    sidecar.write_text(
+        json.dumps(
+            {
+                "lane-1": {
+                    "branch": "codex/lease",
+                    "work_id": "pr:8852",
+                    "lease_id": "lease-1",
+                    "owner_session_id": "sess-1",
+                    "lease_status": "active",
+                    "lease_health": "ok",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    [record] = mod._load_lane_registry()
+
+    assert record.work_id == "pr:8852"
+    assert record.lease_id == "lease-1"
+    assert record.lease_status == "active"
+    assert record.lease_health == "ok"
+
+
+def test_lane_registry_native_lease_fields_override_sidecar(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import agent_bridge as mod
+
+    _patch_bridge_paths(mod, tmp_path, monkeypatch)
+    mod.LANE_REGISTRY_FILE.parent.mkdir(parents=True)
+    mod.LANE_REGISTRY_FILE.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "lane-1",
+                    "owner_session": "codex-A",
+                    "status": "active",
+                    "branch": "codex/lease",
+                    "work_id": "pr:8852",
+                    "lease_id": "native-lease",
+                    "lease_status": "active",
+                    "lease_health": "ok",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    sidecar = mod.CANONICAL_REPO_ROOT / ".aragora" / "agent-bridge" / "lane-leases.json"
+    sidecar.parent.mkdir(parents=True)
+    sidecar.write_text(
+        json.dumps(
+            {
+                "lane-1": {
+                    "branch": "codex/lease",
+                    "work_id": "pr:9999",
+                    "lease_id": "sidecar-lease",
+                    "lease_status": "stale",
+                    "lease_health": "sidecar",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    [record] = mod._load_lane_registry()
+
+    assert record.work_id == "pr:8852"
+    assert record.lease_id == "native-lease"
+    assert record.lease_status == "active"
+    assert record.lease_health == "ok"
+
+
 def test_cmd_approve_droid_uses_enter_menu_selection(monkeypatch: pytest.MonkeyPatch) -> None:
     import agent_bridge as mod
 
@@ -1046,6 +1173,61 @@ def test_operator_snapshot_summary_counts_repo_local_lane_when_user_registry_exi
     payload = json.loads(capsys.readouterr().out)
     assert "lanes" not in payload
     assert payload["summary"]["active_lanes"] == 1
+
+
+def test_operator_snapshot_summary_reports_active_lanes_missing_dev_lease(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import agent_bridge as mod
+
+    _patch_bridge_paths(mod, tmp_path, monkeypatch)
+    mod.AGENT_BRIDGE_DIR.mkdir(parents=True, exist_ok=True)
+    mod.LANE_REGISTRY_FILE.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "lane-missing",
+                    "owner_session": "codex-A",
+                    "status": "active",
+                    "branch": "codex/missing",
+                },
+                {
+                    "lane_id": "lane-held",
+                    "owner_session": "codex-B",
+                    "status": "active",
+                    "branch": "codex/held",
+                    "lease_id": "lease-1",
+                    "work_id": "pr:8852",
+                },
+                {
+                    "lane_id": "lane-complete",
+                    "owner_session": "codex-C",
+                    "status": "completed",
+                    "branch": "codex/done",
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mod, "discover", lambda **_kwargs: [])
+    monkeypatch.setattr(
+        mod,
+        "_collect_agent_process_census",
+        lambda *, include_records=True, record_limit=None, ps_lines=None: {
+            "ok": True,
+            "total": 0,
+            "by_role": {},
+        },
+    )
+
+    rc = mod.cmd_operator_snapshot(argparse.Namespace(json=True, summary_only=True))
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["summary"]["active_lanes"] == 2
+    assert payload["summary"]["active_lanes_missing_dev_lease"] == 1
 
 
 def test_operator_snapshot_counts_active_duplicate_pr_lanes_as_conflicts(

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -1254,6 +1254,68 @@ def test_operator_snapshot_summary_reports_active_lanes_missing_dev_lease(
     assert payload["summary"]["active_lanes_with_dev_lease"] == 1
 
 
+def test_operator_snapshot_counts_validated_sidecar_dev_lease(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import agent_bridge as mod
+
+    _patch_bridge_paths(mod, tmp_path, monkeypatch)
+    mod.LANE_REGISTRY_FILE.parent.mkdir(parents=True)
+    mod.LANE_REGISTRY_FILE.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "lane-sidecar",
+                    "owner_session": "codex-sidecar",
+                    "status": "active",
+                    "branch": "codex/sidecar",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    sidecar = mod.CANONICAL_REPO_ROOT / ".aragora" / "agent-bridge" / "lane-leases.json"
+    sidecar.parent.mkdir(parents=True)
+    sidecar.write_text(
+        json.dumps(
+            {
+                "lane-sidecar": {
+                    "branch": "codex/sidecar",
+                    "work_id": "pr:8853",
+                    "lease_id": "live-sidecar-lease",
+                    "owner_session_id": "codex-sidecar",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        mod,
+        "_sidecar_points_to_active_dev_lease",
+        lambda record, sidecar: sidecar.get("lease_id") == "live-sidecar-lease",
+    )
+    monkeypatch.setattr(mod, "discover", lambda **_kwargs: [])
+    monkeypatch.setattr(
+        mod,
+        "_collect_agent_process_census",
+        lambda *, include_records=True, record_limit=None, ps_lines=None: {
+            "ok": True,
+            "total": 0,
+            "by_role": {},
+        },
+    )
+
+    rc = mod.cmd_operator_snapshot(argparse.Namespace(json=True, summary_only=True))
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["summary"]["active_lanes"] == 1
+    assert payload["summary"]["active_lanes_missing_dev_lease"] == 0
+    assert payload["summary"]["active_lanes_with_dev_lease"] == 1
+
+
 def test_operator_snapshot_counts_active_duplicate_pr_lanes_as_conflicts(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -1236,6 +1236,11 @@ def test_operator_snapshot_summary_reports_active_lanes_missing_dev_lease(
         ),
         encoding="utf-8",
     )
+    monkeypatch.setattr(
+        mod,
+        "_sidecar_points_to_active_dev_lease",
+        lambda record, sidecar: sidecar.get("lease_id") == "lease-1",
+    )
     monkeypatch.setattr(mod, "discover", lambda **_kwargs: [])
     monkeypatch.setattr(
         mod,
@@ -1316,6 +1321,52 @@ def test_operator_snapshot_counts_validated_sidecar_dev_lease(
     assert payload["summary"]["active_lanes"] == 1
     assert payload["summary"]["active_lanes_missing_dev_lease"] == 0
     assert payload["summary"]["active_lanes_with_dev_lease"] == 1
+
+
+def test_operator_snapshot_does_not_count_unvalidated_native_dev_lease(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import agent_bridge as mod
+
+    _patch_bridge_paths(mod, tmp_path, monkeypatch)
+    mod.LANE_REGISTRY_FILE.parent.mkdir(parents=True)
+    mod.LANE_REGISTRY_FILE.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "lane-stale-native",
+                    "owner_session": "codex-stale",
+                    "status": "active",
+                    "branch": "codex/stale",
+                    "work_id": "pr:8853",
+                    "lease_id": "stale-native-lease",
+                    "lease_status": "active",
+                    "lease_health": "ok",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mod, "discover", lambda **_kwargs: [])
+    monkeypatch.setattr(
+        mod,
+        "_collect_agent_process_census",
+        lambda *, include_records=True, record_limit=None, ps_lines=None: {
+            "ok": True,
+            "total": 0,
+            "by_role": {},
+        },
+    )
+
+    rc = mod.cmd_operator_snapshot(argparse.Namespace(json=True, summary_only=True))
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["summary"]["active_lanes"] == 1
+    assert payload["summary"]["active_lanes_missing_dev_lease"] == 1
+    assert payload["summary"]["active_lanes_with_dev_lease"] == 0
 
 
 def test_operator_snapshot_counts_active_duplicate_pr_lanes_as_conflicts(

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -163,7 +163,7 @@ def test_lane_registry_sidecar_enriches_missing_lease_fields(
     assert record.work_id == "pr:8852"
     assert record.lease_id == "lease-1"
     assert record.lease_status == "active"
-    assert record.lease_health == "ok"
+    assert record.lease_health == "sidecar"
 
 
 def test_lane_registry_native_lease_fields_override_sidecar(
@@ -1202,12 +1202,35 @@ def test_operator_snapshot_summary_reports_active_lanes_missing_dev_lease(
                     "work_id": "pr:8852",
                 },
                 {
+                    "lane_id": "lane-sidecar-only",
+                    "owner_session": "codex-sidecar",
+                    "status": "active",
+                    "branch": "codex/sidecar",
+                },
+                {
                     "lane_id": "lane-complete",
                     "owner_session": "codex-C",
                     "status": "completed",
                     "branch": "codex/done",
                 },
             ]
+        ),
+        encoding="utf-8",
+    )
+    sidecar = mod.CANONICAL_REPO_ROOT / ".aragora" / "agent-bridge" / "lane-leases.json"
+    sidecar.parent.mkdir(parents=True)
+    sidecar.write_text(
+        json.dumps(
+            {
+                "lane-sidecar-only": {
+                    "branch": "codex/sidecar",
+                    "work_id": "pr:8853",
+                    "lease_id": "stale-sidecar-lease",
+                    "owner_session_id": "codex-sidecar",
+                    "lease_status": "active",
+                    "lease_health": "ok",
+                }
+            }
         ),
         encoding="utf-8",
     )
@@ -1226,8 +1249,9 @@ def test_operator_snapshot_summary_reports_active_lanes_missing_dev_lease(
 
     assert rc == 0
     payload = json.loads(capsys.readouterr().out)
-    assert payload["summary"]["active_lanes"] == 2
-    assert payload["summary"]["active_lanes_missing_dev_lease"] == 1
+    assert payload["summary"]["active_lanes"] == 3
+    assert payload["summary"]["active_lanes_missing_dev_lease"] == 2
+    assert payload["summary"]["active_lanes_with_dev_lease"] == 1
 
 
 def test_operator_snapshot_counts_active_duplicate_pr_lanes_as_conflicts(

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -1369,6 +1369,59 @@ def test_operator_snapshot_does_not_count_unvalidated_native_dev_lease(
     assert payload["summary"]["active_lanes_with_dev_lease"] == 0
 
 
+def test_operator_snapshot_validates_native_dev_lease_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import agent_bridge as mod
+
+    _patch_bridge_paths(mod, tmp_path, monkeypatch)
+    mod.LANE_REGISTRY_FILE.parent.mkdir(parents=True)
+    mod.LANE_REGISTRY_FILE.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "lane-native",
+                    "owner_session": "codex-native",
+                    "status": "active",
+                    "branch": "codex/native",
+                    "work_id": "pr:8853",
+                    "lease_id": "native-lease",
+                    "lease_status": "active",
+                    "lease_health": "ok",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    seen: list[dict[str, str]] = []
+
+    def fake_validate(record, sidecar):
+        seen.append(dict(sidecar))
+        return sidecar.get("owner_session_id") == "codex-native"
+
+    monkeypatch.setattr(mod, "_sidecar_points_to_active_dev_lease", fake_validate)
+    monkeypatch.setattr(mod, "discover", lambda **_kwargs: [])
+    monkeypatch.setattr(
+        mod,
+        "_collect_agent_process_census",
+        lambda *, include_records=True, record_limit=None, ps_lines=None: {
+            "ok": True,
+            "total": 0,
+            "by_role": {},
+        },
+    )
+
+    rc = mod.cmd_operator_snapshot(argparse.Namespace(json=True, summary_only=True))
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert seen[0]["owner_session_id"] == "codex-native"
+    assert payload["summary"]["active_lanes_missing_dev_lease"] == 0
+    assert payload["summary"]["active_lanes_with_dev_lease"] == 1
+
+
 def test_operator_snapshot_counts_active_duplicate_pr_lanes_as_conflicts(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -215,6 +215,54 @@ def test_lane_registry_native_lease_fields_override_sidecar(
     assert record.lease_health == "ok"
 
 
+def test_lane_registry_sidecar_health_self_heals_after_live_validation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import agent_bridge as mod
+
+    _patch_bridge_paths(mod, tmp_path, monkeypatch)
+    mod.LANE_REGISTRY_FILE.parent.mkdir(parents=True)
+    mod.LANE_REGISTRY_FILE.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "lane-1",
+                    "owner_session": "codex-A",
+                    "status": "active",
+                    "branch": "codex/lease",
+                    "work_id": "pr:8852",
+                    "lease_id": "lease-1",
+                    "lease_status": "active",
+                    "lease_health": "sidecar",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    sidecar = mod.CANONICAL_REPO_ROOT / ".aragora" / "agent-bridge" / "lane-leases.json"
+    sidecar.parent.mkdir(parents=True)
+    sidecar.write_text(
+        json.dumps(
+            {
+                "lane-1": {
+                    "branch": "codex/lease",
+                    "work_id": "pr:8852",
+                    "lease_id": "lease-1",
+                    "owner_session_id": "codex-A",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mod, "_sidecar_points_to_active_dev_lease", lambda *_args: True)
+
+    [record] = mod._load_lane_registry()
+
+    assert record.lease_id == "lease-1"
+    assert record.lease_status == "active"
+    assert record.lease_health == "ok"
+
+
 def test_cmd_approve_droid_uses_enter_menu_selection(monkeypatch: pytest.MonkeyPatch) -> None:
     import agent_bridge as mod
 

--- a/tests/scripts/test_build_next_prompt.py
+++ b/tests/scripts/test_build_next_prompt.py
@@ -123,6 +123,11 @@ def test_prompt_starts_with_mailbox_and_owner_verification(tmp_path: Path) -> No
         "Continue only if you are owner_session droid-P106-merge-gate-settlement-20260521T2118Z"
         in prompt
     )
+    assert "ARAGORA_REQUIRE_BRANCH_WRITE_LEASE=1" in prompt
+    assert (
+        "python3 scripts/check_work_lease.py claude/recover-merge-gate-reconciliation "
+        "--verify-only --work-id pr:7423 --strict --json"
+    ) in prompt
     assert (
         "If the prompt above accomplishes no incremental progress make the next prompt one that does"
         in prompt
@@ -144,6 +149,7 @@ def test_prompt_for_non_owner_read_only_when_no_lane_match(tmp_path: Path) -> No
 
     assert "If you cannot map yourself to a lane, run read-only only" in prompt
     assert "Do not paste raw transcripts" in prompt
+    assert "ARAGORA_REQUIRE_BRANCH_WRITE_LEASE=1" not in prompt
 
 
 def test_prompt_shell_quotes_live_lane_values(tmp_path: Path) -> None:

--- a/tests/scripts/test_build_next_prompt.py
+++ b/tests/scripts/test_build_next_prompt.py
@@ -126,7 +126,8 @@ def test_prompt_starts_with_mailbox_and_owner_verification(tmp_path: Path) -> No
     assert "ARAGORA_REQUIRE_BRANCH_WRITE_LEASE=1" in prompt
     assert (
         "python3 scripts/check_work_lease.py claude/recover-merge-gate-reconciliation "
-        "--verify-only --work-id pr:7423 --strict --json"
+        "--verify-only --work-id pr:7423 --strict "
+        "--session-id droid-P106-merge-gate-settlement-20260521T2118Z --json"
     ) in prompt
     assert (
         "If the prompt above accomplishes no incremental progress make the next prompt one that does"

--- a/tests/scripts/test_check_work_lease.py
+++ b/tests/scripts/test_check_work_lease.py
@@ -571,6 +571,13 @@ def test_advisory_preserves_missing_lease_reason_but_exits_zero(
     assert payload["branch"] == "feat-x"
 
 
+def test_advisory_rejected_for_mutating_modes(repo: Path) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        _main(repo, "feat-x", "--claim", "--advisory", "--session-id", "sess-a")
+
+    assert excinfo.value.code == 2
+
+
 def test_verify_only_wrong_owner_reason(repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
     assert _main(repo, "feat-x", "--claim", "--session-id", "sess-a", "--work-id", "pr:8852") == 0
     capsys.readouterr()

--- a/tests/scripts/test_check_work_lease.py
+++ b/tests/scripts/test_check_work_lease.py
@@ -477,6 +477,31 @@ def test_verify_only_pr_work_id_reports_nonmatching_foreign_branch_lease(
     assert payload["owner_session_id"] == "sess-swarm"
 
 
+def test_verify_only_pr_work_id_accepts_owned_branch_level_lease(
+    repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert _main(repo, "feat-x", "--claim", "--session-id", "sess-a") == 0
+    capsys.readouterr()
+
+    assert (
+        _main(
+            repo,
+            "feat-x",
+            "--verify-only",
+            "--session-id",
+            "sess-a",
+            "--work-id",
+            "pr:8852",
+            "--json",
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["reason"] is None
+    assert payload["owner_session_id"] == "sess-a"
+
+
 def test_verify_only_rejects_mismatched_work_id_with_stable_reason(
     repo: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/scripts/test_check_work_lease.py
+++ b/tests/scripts/test_check_work_lease.py
@@ -439,6 +439,44 @@ def test_verify_only_branch_work_id_reports_foreign_store_direct_lease(
     assert payload["owner_session_id"] == "sess-swarm"
 
 
+def test_verify_only_pr_work_id_reports_nonmatching_foreign_branch_lease(
+    repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert _main(repo, "feat-x", "--claim", "--session-id", "sess-a", "--work-id", "pr:8852") == 0
+    from aragora.nomic.dev_coordination import DevCoordinationStore
+
+    store = DevCoordinationStore(repo_root=repo)
+    lease = store.claim_lease(
+        task_id="WO-nonmatching",
+        title="swarm work order",
+        owner_agent="swarm",
+        owner_session_id="sess-swarm",
+        branch="feat-x",
+        worktree_path=str(repo),
+        allowed_globs=["aragora/swarm/*.py"],
+    )
+    capsys.readouterr()
+
+    assert (
+        _main(
+            repo,
+            "feat-x",
+            "--verify-only",
+            "--session-id",
+            "sess-a",
+            "--work-id",
+            "pr:8852",
+            "--json",
+        )
+        == 1
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["reason"] == "wrong_owner"
+    assert payload["lease_id"] == lease.lease_id
+    assert payload["owner_session_id"] == "sess-swarm"
+
+
 def test_verify_only_rejects_mismatched_work_id_with_stable_reason(
     repo: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/scripts/test_check_work_lease.py
+++ b/tests/scripts/test_check_work_lease.py
@@ -520,6 +520,48 @@ def test_verify_only_pr_work_id_accepts_owned_branch_level_lease(
     assert payload["owner_session_id"] == "sess-a"
 
 
+def test_verify_only_pr_work_id_rejects_foreign_exact_pr_lease_despite_branch_fallback(
+    repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert _main(repo, "feat-x", "--claim", "--session-id", "sess-a") == 0
+    with sqlite3.connect(_db_path(repo)) as conn:
+        conn.execute(
+            """
+            INSERT INTO leases (
+                lease_id, task_id, title, owner_agent, owner_session_id, branch, worktree_path,
+                allowed_globs_json, claimed_paths_json, expected_tests_json, status, created_at,
+                updated_at, expires_at, metadata_json
+            )
+            SELECT
+                'lease-foreign-pr', 'pr:8852', title, 'codex', 'sess-b', branch, worktree_path,
+                allowed_globs_json, claimed_paths_json, expected_tests_json, status, created_at,
+                updated_at, expires_at, '{"work_id": "pr:8852"}'
+            FROM leases
+            WHERE branch = ?
+            """,
+            ("feat-x",),
+        )
+    capsys.readouterr()
+
+    assert (
+        _main(
+            repo,
+            "feat-x",
+            "--verify-only",
+            "--session-id",
+            "sess-a",
+            "--work-id",
+            "pr:8852",
+            "--json",
+        )
+        == 1
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["reason"] in {"ambiguous_owner", "wrong_owner"}
+    assert payload["owner_session_id"] == "sess-b"
+
+
 def test_verify_only_rejects_mismatched_work_id_with_stable_reason(
     repo: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/scripts/test_check_work_lease.py
+++ b/tests/scripts/test_check_work_lease.py
@@ -67,6 +67,24 @@ def _db_path(repo: Path) -> Path:
     return cwl.resolve_db_path(repo)
 
 
+def test_lease_row_work_id_accepts_legacy_pr_number_metadata() -> None:
+    lease = cwl.LeaseRow(
+        lease_id="lease-1",
+        task_id="branch:feat-x",
+        title="legacy PR lease",
+        owner_agent="codex",
+        owner_session_id="sess-a",
+        branch="feat-x",
+        worktree_path="/tmp/repo",
+        status="active",
+        created_at=datetime.now(timezone.utc).isoformat(),
+        expires_at=(datetime.now(timezone.utc) + timedelta(hours=1)).isoformat(),
+        metadata={"pr_number": "8852"},
+    )
+
+    assert lease.work_id == "pr:8852"
+
+
 def test_no_lease_without_claim_fails(repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
     code = _main(repo, "feat-x", "--session-id", "sess-a")
     assert code == 1

--- a/tests/scripts/test_check_work_lease.py
+++ b/tests/scripts/test_check_work_lease.py
@@ -365,6 +365,80 @@ def test_verify_only_matching_work_id_succeeds_without_sidecar_write(
     assert not (repo / ".aragora" / "agent-bridge" / "lane-leases.json").exists()
 
 
+def test_verify_only_branch_work_id_matches_store_direct_branch_lease(
+    repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from aragora.nomic.dev_coordination import DevCoordinationStore
+
+    store = DevCoordinationStore(repo_root=repo)
+    lease = store.claim_lease(
+        task_id="WO-branch-owner",
+        title="swarm work order",
+        owner_agent="swarm",
+        owner_session_id="sess-swarm",
+        branch="feat-x",
+        worktree_path=str(repo),
+        allowed_globs=["aragora/swarm/*.py"],
+    )
+    capsys.readouterr()
+
+    assert (
+        _main(
+            repo,
+            "feat-x",
+            "--verify-only",
+            "--session-id",
+            "sess-swarm",
+            "--work-id",
+            "branch:feat-x",
+            "--json",
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["reason"] is None
+    assert payload["lease_id"] == lease.lease_id
+    assert payload["owner_session_id"] == "sess-swarm"
+
+
+def test_verify_only_branch_work_id_reports_foreign_store_direct_lease(
+    repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from aragora.nomic.dev_coordination import DevCoordinationStore
+
+    store = DevCoordinationStore(repo_root=repo)
+    lease = store.claim_lease(
+        task_id="WO-branch-owner",
+        title="swarm work order",
+        owner_agent="swarm",
+        owner_session_id="sess-swarm",
+        branch="feat-x",
+        worktree_path=str(repo),
+        allowed_globs=["aragora/swarm/*.py"],
+    )
+    capsys.readouterr()
+
+    assert (
+        _main(
+            repo,
+            "feat-x",
+            "--verify-only",
+            "--session-id",
+            "sess-other",
+            "--work-id",
+            "branch:feat-x",
+            "--json",
+        )
+        == 1
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["reason"] == "wrong_owner"
+    assert payload["lease_id"] == lease.lease_id
+    assert payload["owner_session_id"] == "sess-swarm"
+
+
 def test_verify_only_rejects_mismatched_work_id_with_stable_reason(
     repo: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/scripts/test_check_work_lease.py
+++ b/tests/scripts/test_check_work_lease.py
@@ -320,6 +320,257 @@ def test_json_output(repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
     assert payload["lease_id"]
 
 
+def test_verify_only_matching_work_id_succeeds_without_sidecar_write(
+    repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert (
+        _main(
+            repo,
+            "feat-x",
+            "--claim",
+            "--session-id",
+            "sess-a",
+            "--agent",
+            "claude",
+            "--work-id",
+            "pr:8852",
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    assert (
+        _main(
+            repo,
+            "feat-x",
+            "--verify-only",
+            "--record-lane",
+            "lane-1",
+            "--session-id",
+            "sess-a",
+            "--work-id",
+            "pr:8852",
+            "--json",
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["action"] == "check"
+    assert payload["reason"] is None
+    assert payload["work_id"] == "pr:8852"
+    assert payload["branch"] == "feat-x"
+    assert payload["owner_session_id"] == "sess-a"
+    assert payload["lease_id"]
+    assert not (repo / ".aragora" / "agent-bridge" / "lane-leases.json").exists()
+
+
+def test_verify_only_rejects_mismatched_work_id_with_stable_reason(
+    repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert _main(repo, "feat-x", "--claim", "--session-id", "sess-a", "--work-id", "pr:8852") == 0
+    capsys.readouterr()
+
+    assert (
+        _main(
+            repo,
+            "feat-x",
+            "--verify-only",
+            "--session-id",
+            "sess-a",
+            "--work-id",
+            "pr:9999",
+            "--json",
+        )
+        == 1
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["reason"] == "missing_lease"
+    assert payload["work_id"] == "pr:9999"
+    assert payload["branch"] == "feat-x"
+    assert payload["lease_id"] is None
+
+
+def test_advisory_preserves_missing_lease_reason_but_exits_zero(
+    repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert (
+        _main(
+            repo,
+            "feat-x",
+            "--verify-only",
+            "--advisory",
+            "--session-id",
+            "sess-a",
+            "--work-id",
+            "branch:feat-x",
+            "--json",
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["reason"] == "missing_lease"
+    assert payload["work_id"] == "branch:feat-x"
+    assert payload["branch"] == "feat-x"
+
+
+def test_verify_only_wrong_owner_reason(repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    assert _main(repo, "feat-x", "--claim", "--session-id", "sess-a", "--work-id", "pr:8852") == 0
+    capsys.readouterr()
+
+    assert (
+        _main(
+            repo,
+            "feat-x",
+            "--verify-only",
+            "--session-id",
+            "sess-b",
+            "--work-id",
+            "pr:8852",
+            "--json",
+        )
+        == 1
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["reason"] == "wrong_owner"
+    assert payload["owner_session_id"] == "sess-a"
+    assert payload["lease_id"]
+
+
+def test_verify_only_expired_lease_reason(repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    assert _main(repo, "feat-x", "--claim", "--session-id", "sess-a", "--work-id", "pr:8852") == 0
+    past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    with sqlite3.connect(_db_path(repo)) as conn:
+        conn.execute("UPDATE leases SET expires_at = ?", (past,))
+    capsys.readouterr()
+
+    assert (
+        _main(
+            repo,
+            "feat-x",
+            "--verify-only",
+            "--session-id",
+            "sess-a",
+            "--work-id",
+            "pr:8852",
+            "--json",
+        )
+        == 1
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["reason"] == "expired_lease"
+    assert payload["owner_session_id"] == "sess-a"
+
+
+def test_verify_only_bridge_sidecar_without_dev_lease_reason(
+    repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    sidecar = repo / ".aragora" / "agent-bridge" / "lane-leases.json"
+    sidecar.parent.mkdir(parents=True)
+    sidecar.write_text(
+        json.dumps(
+            {
+                "lane-1": {
+                    "branch": "feat-x",
+                    "lease_id": "missing-lease",
+                    "owner_session_id": "sess-a",
+                    "work_id": "pr:8852",
+                }
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert (
+        _main(
+            repo,
+            "feat-x",
+            "--verify-only",
+            "--record-lane",
+            "lane-1",
+            "--session-id",
+            "sess-a",
+            "--work-id",
+            "pr:8852",
+            "--json",
+        )
+        == 1
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["reason"] == "bridge_only_no_dev_lease"
+    assert payload["lease_id"] == "missing-lease"
+
+
+def test_verify_only_ambiguous_owner_reason(repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    assert _main(repo, "feat-x", "--claim", "--session-id", "sess-a", "--work-id", "pr:8852") == 0
+    with sqlite3.connect(_db_path(repo)) as conn:
+        conn.execute(
+            """
+            INSERT INTO leases (
+                lease_id, task_id, title, owner_agent, owner_session_id, branch, worktree_path,
+                allowed_globs_json, claimed_paths_json, expected_tests_json, status, created_at,
+                updated_at, expires_at, metadata_json
+            )
+            SELECT
+                'lease-ambiguous', task_id, title, 'codex', 'sess-b', branch, worktree_path,
+                allowed_globs_json, claimed_paths_json, expected_tests_json, status, created_at,
+                updated_at, expires_at, metadata_json
+            FROM leases
+            WHERE branch = ?
+            """,
+            ("feat-x",),
+        )
+    capsys.readouterr()
+
+    assert (
+        _main(
+            repo,
+            "feat-x",
+            "--verify-only",
+            "--session-id",
+            "sess-a",
+            "--work-id",
+            "pr:8852",
+            "--json",
+        )
+        == 1
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["reason"] == "ambiguous_owner"
+    assert payload["owners"] == ["sess-a", "sess-b"]
+
+
+def test_verify_only_store_unreachable_json_reason(
+    repo: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    corrupt = tmp_path / "corrupt.db"
+    corrupt.write_bytes(b"this is not a sqlite database at all........")
+
+    assert (
+        _main(
+            repo,
+            "feat-x",
+            "--verify-only",
+            "--strict",
+            "--advisory",
+            "--db",
+            str(corrupt),
+            "--json",
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["reason"] == "store_unreachable"
+
+
 def test_session_id_from_environment(
     repo: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/scripts/test_identify_lane_owner.py
+++ b/tests/scripts/test_identify_lane_owner.py
@@ -138,6 +138,55 @@ def test_default_state_root_honors_automation_state_root(
     assert ilo._default_state_root(tmp_path / "worktree") == state_root / ".aragora"
 
 
+def test_json_output_includes_dev_coordination_lease_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    registry = write_lane_registry(tmp_path)
+    monkeypatch.setattr(ilo, "_default_snapshot_provider", lambda: None)
+    monkeypatch.setattr(
+        ilo,
+        "_check_dev_coordination_lease",
+        lambda lane, **_kwargs: {
+            "status": "valid",
+            "reason": None,
+            "work_id": "pr:7292",
+            "lease_id": "lease-7292",
+            "owner_session_id": lane["owner_session"],
+        },
+        raising=False,
+    )
+
+    rc = ilo.main(
+        [
+            "--pr",
+            "7292",
+            "--json",
+            "--registry-path",
+            str(registry),
+            "--codex-sessions-root",
+            str(tmp_path / "no_codex"),
+            "--claude-projects-root",
+            str(tmp_path / "no_claude"),
+            "--factory-bg-path",
+            str(tmp_path / "no_factory.json"),
+            "--steering-inbox-root",
+            str(tmp_path / "no_steering"),
+            "--heartbeat-path",
+            str(tmp_path / "no_heartbeats.json"),
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["dev_coordination_lease"] == {
+        "status": "valid",
+        "reason": None,
+        "work_id": "pr:7292",
+        "lease_id": "lease-7292",
+        "owner_session_id": "codex-p19-repair-7292",
+    }
+
+
 # ---------------------------------------------------------------------------
 # load_lane_records / find_lane
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Stacked on #8852 (`claude/lease-rule-preflight`). Do not merge before #8852 lands.

- extends `scripts/check_work_lease.py` with verify-only/advisory/work-id semantics and stable JSON failure reasons
- adds optional lane lease fields plus sidecar enrichment and missing-lease summary counts in agent-bridge
- reports dev_coordination lease state from `identify_lane_owner.py` and adds env-gated strict lease preflight text in `build_next_prompt.py`

## Validation

- `pytest -q tests/scripts/test_check_work_lease.py`
- `pytest -q tests/scripts/test_agent_bridge.py`
- `pytest -q tests/scripts/test_identify_lane_owner.py`
- `pytest -q tests/scripts/test_build_next_prompt.py`
- `ruff check scripts/check_work_lease.py scripts/agent_bridge.py scripts/identify_lane_owner.py scripts/build_next_prompt.py tests/scripts/test_check_work_lease.py tests/scripts/test_agent_bridge.py tests/scripts/test_identify_lane_owner.py tests/scripts/test_build_next_prompt.py`
- pre-push hooks, including changed-file mypy
