### PR TITLE
test(aragora-verify): harden verifier coverage — schema parity + key-type CLI exit codes

### DIFF
--- a/aragora-verify/tests/test_cli.py
+++ b/aragora-verify/tests/test_cli.py
@@ -72,10 +72,36 @@ def test_cli_json_output_is_machine_readable(tmp_path: Path, capsys) -> None:
     rc = main([_write(tmp_path, "r.json", valid_odr()), "--json"])
     assert rc == 0
     payload = json.loads(capsys.readouterr().out)
+
+    # Exact key set + type for every documented top-level field (the
+    # machine-readable contract other tools parse against).
+    assert payload.keys() == {
+        "ok",
+        "authenticity_unverified",
+        "receipt_id",
+        "odr_digest",
+        "checks",
+        "warnings",
+    }
     assert payload["ok"] is True
+    assert isinstance(payload["authenticity_unverified"], bool)
+    assert payload["authenticity_unverified"] is False
+    assert isinstance(payload["receipt_id"], str) and payload["receipt_id"]
+    assert isinstance(payload["odr_digest"], str)
     assert len(payload["odr_digest"]) == 64
+    assert all(ch in "0123456789abcdef" for ch in payload["odr_digest"])
+
+    assert isinstance(payload["checks"], list) and payload["checks"]
+    for check in payload["checks"]:
+        assert check.keys() == {"name", "status", "detail"}
+        assert isinstance(check["name"], str) and check["name"]
+        assert check["status"] in {"pass", "fail", "warn", "skip"}
+        assert isinstance(check["detail"], str)
     assert {c["name"] for c in payload["checks"]} >= {
         "schema_conformance",
         "canonical_digest",
         "signature",
     }
+
+    assert isinstance(payload["warnings"], list)
+    assert all(isinstance(w, str) for w in payload["warnings"])

--- a/aragora-verify/tests/test_example_signed_and_chain_fixtures.py
+++ b/aragora-verify/tests/test_example_signed_and_chain_fixtures.py
@@ -32,6 +32,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from cryptography.hazmat.primitives import serialization
 
 from aragora_verify import odr_content_digest, verify
 from aragora_verify.cli import main
@@ -157,6 +158,41 @@ def test_cli_signed_golden_content_tamper_caught_by_signature_not_schema() -> No
     assert result.ok is False
     assert _check(result, "schema_conformance").status == PASS
     assert _check(result, "signature").status == FAIL
+
+
+def test_cli_signed_golden_with_wrong_ed25519_pubkey_exits_one(tmp_path: Path) -> None:
+    # A structurally valid Ed25519 key that did NOT sign this receipt is a
+    # signature failure, not a usage error: exit 1, distinct from the
+    # "key rejected before any verification" exit 2 below (VAL-VERIFY-012a).
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    wrong_public_key = Ed25519PrivateKey.generate().public_key()
+    wrong_pem_path = tmp_path / "wrong-ed25519.pem"
+    wrong_pem_path.write_bytes(
+        wrong_public_key.public_bytes(
+            serialization.Encoding.PEM, serialization.PublicFormat.SubjectPublicKeyInfo
+        )
+    )
+    rc = main([str(SIGNED), "--pubkey", str(wrong_pem_path)])
+    assert rc == 1
+
+
+def test_cli_signed_golden_with_non_ed25519_pubkey_exits_two(tmp_path: Path) -> None:
+    # An RSA key is well-formed PEM but the wrong algorithm; load_public_key()
+    # rejects it BEFORE any signature check runs -- a usage/input error
+    # (exit 2), distinct from the signature mismatch (exit 1) above
+    # (VAL-VERIFY-012b).
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    rsa_public_key = rsa.generate_private_key(public_exponent=65537, key_size=2048).public_key()
+    rsa_pem_path = tmp_path / "wrong-rsa.pem"
+    rsa_pem_path.write_bytes(
+        rsa_public_key.public_bytes(
+            serialization.Encoding.PEM, serialization.PublicFormat.SubjectPublicKeyInfo
+        )
+    )
+    rc = main([str(SIGNED), "--pubkey", str(rsa_pem_path)])
+    assert rc == 2
 
 
 def _load_public_key(path: Path):  # noqa: ANN202 - thin test helper

--- a/aragora-verify/tests/test_schema_parity.py
+++ b/aragora-verify/tests/test_schema_parity.py
@@ -1,0 +1,55 @@
+"""Byte-parity between the two ``odr_schema.json`` copies (VAL-VERIFY-009).
+
+The ODR v0.1 JSON Schema is intentionally duplicated: the canonical in-tree
+copy lives at ``aragora/gauntlet/odr_schema.json`` and a bundled copy ships
+inside the standalone ``aragora-verify`` package so the verifier stays
+installable and runnable with zero dependency on the monorepo (see
+``aragora_verify.schema.load_bundled_schema``). Nothing enforces the two
+copies stay identical except this test: if they drift, the offline verifier
+could silently accept or reject receipts the emitter does not.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+_BUNDLED_SCHEMA = Path(__file__).resolve().parents[1] / "src" / "aragora_verify" / "odr_schema.json"
+_IN_TREE_SCHEMA = Path(__file__).resolve().parents[2] / "aragora" / "gauntlet" / "odr_schema.json"
+
+
+def test_bundled_schema_file_exists() -> None:
+    assert _BUNDLED_SCHEMA.is_file(), _BUNDLED_SCHEMA
+
+
+def test_bundled_schema_is_valid_json() -> None:
+    doc = json.loads(_BUNDLED_SCHEMA.read_text(encoding="utf-8"))
+    assert isinstance(doc, dict)
+    assert doc  # non-empty
+
+
+def test_bundled_schema_is_byte_identical_to_in_tree_copy() -> None:
+    # A monorepo checkout is required for this comparison; a standalone
+    # aragora-verify checkout (e.g. an extracted sdist) has no ``aragora/``
+    # sibling to diff against.
+    if not _IN_TREE_SCHEMA.is_file():
+        pytest.skip(f"in-tree schema not present at {_IN_TREE_SCHEMA} (standalone checkout)")
+    bundled = _BUNDLED_SCHEMA.read_bytes()
+    in_tree = _IN_TREE_SCHEMA.read_bytes()
+    assert bundled == in_tree, (
+        f"{_BUNDLED_SCHEMA} and {_IN_TREE_SCHEMA} have drifted; the two ODR "
+        "schema copies must be kept byte-identical (mirror `diff` the two "
+        "paths and sync whichever is stale)"
+    )
+
+
+def test_bundled_schema_matches_package_loader_output() -> None:
+    # Guards against the package loader (importlib.resources) resolving a
+    # different file than the one this test reads directly off disk -- e.g.
+    # a stale installed copy shadowing the source tree.
+    from aragora_verify.schema import load_bundled_schema
+
+    on_disk = json.loads(_BUNDLED_SCHEMA.read_text(encoding="utf-8"))
+    assert load_bundled_schema() == on_disk


### PR DESCRIPTION
## What

Tests-only hardening for `aragora-verify` (m3-verifier milestone, feature `m3-verifier-hardening-tests`). Per the feature's drift note, `aragora-verify/tests/test_cli.py` already covered exit-2 missing-file/bad-JSON, `--json` payload, and tampered exit-1, and the in-tree `aragora/gauntlet/odr_verify.py` engine (#8389) has its own parity suite (`tests/gauntlet/test_odr_verify_cross_verifier_parity.py`, #8837). This PR first audited that existing coverage, then added only the confirmed-missing pieces:

1. **Schema byte-parity test** (`test_schema_parity.py`, new file) - `aragora/gauntlet/odr_schema.json` and `aragora-verify/src/aragora_verify/odr_schema.json` are two independently-wired copies of the ODR v0.1 schema with **no existing test anywhere** guarding them against drift. Confirmed via `diff` they're identical today; the test now fails loudly if that ever changes.
2. **CLI-level wrong-key vs non-Ed25519-key exit codes** (extends `test_example_signed_and_chain_fixtures.py`) - on the signed golden fixture: a different *valid* Ed25519 public key gives exit 1 (signature FAIL); an RSA/EC public key gives exit 2 (rejected before verification even runs). This distinction previously only existed at the `verify()`/`load_public_key()` unit level (`test_verifier.py::test_wrong_key_does_not_verify`, `test_review_fixes.py::test_non_ed25519_pubkey_raises_clean_error`) - never through the packaged CLI's actual process exit code.
3. **Extended the shallow `--json` shape test** (`test_cli.py::test_cli_json_output_is_machine_readable`) - now asserts the exact key set and type of every documented field (ok / authenticity_unverified / receipt_id / odr_digest / checks[] / warnings[]), plus per-check name/status/detail shape and a valid status enum, instead of only checking `ok` plus digest length plus a check-name subset.

Item (d) from the feature description ("optionally a cross-engine consistency test") was audited and found **already covered** by the existing #8837 `test_odr_verify_cross_verifier_parity.py` suite plus `test_jcs_parity_with_canonical_emitter` / `test_signed_golden_digest_matches_in_tree_emitter` - not duplicated here.

## Test counts

- `aragora-verify` (`PYTHONPATH=src pytest tests -q`): **86 to 92 passed** (+6 new tests; 0 duplicated).
- In-tree receipt/verify gate (`tests/cli/test_verify.py tests/export/test_decision_receipt.py tests/gauntlet/test_receipt.py tests/gauntlet/test_odr_verify.py tests/gauntlet/test_odr_verify_schema.py`): unaffected, **242 passed** (no files in this suite touched).

## Verification

- `cd aragora-verify && PYTHONPATH=src pytest tests -q` result: 92 passed.
- Manual CLI spot-check (openssl-generated keys, independent of the test harness):
  - correct pubkey: exit 0 (VERIFIED)
  - wrong Ed25519 pubkey: exit 1 (FAILED, signature check reports INVALID)
  - RSA pubkey: exit 2 (error: public key is not Ed25519, got RSAPublicKey)
  - EC pubkey: exit 2 (error: public key is not Ed25519, got ECPublicKey)
- Manual byte diff of the two schema copies: no output (identical).
- ruff self-check on the new/changed files with S101 ignored: clean (per AGENTS.md, `aragora-verify/tests/**` has no `[tool.ruff]` config of its own and isn't covered by root per-file-ignores yet; this is the documented interim diligence until the packaging-deps PR adds the ignore).
- mypy (ignore-missing-imports, follow-imports=skip) on the changed files: no issues.
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`: ok.

## Scope

Tests only, no aragora runtime code or scripts code, no schema changes, no workflow changes. Auto-merge eligible per the mission's tiering rules.

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>
