### PR TITLE
fix(cli): describe native DecisionReceipt integrity in receipt verify --help

### DIFF
--- a/aragora/cli/commands/receipt.py
+++ b/aragora/cli/commands/receipt.py
@@ -100,6 +100,17 @@ Examples:
     verify_parser = receipt_sub.add_parser(
         "verify",
         help="Verify receipt artifact hash and signature integrity",
+        description=(
+            "Validate a native DecisionReceipt JSON file's integrity (this repo's "
+            "internal receipt record -- for the portable Open Decision Receipt/ODR "
+            "format, use the standalone 'aragora-verify' tool instead). Recomputes "
+            "the SHA-256 decision-integrity hash (artifact_hash) over the "
+            "decision-integrity fields (receipt_id, gauntlet_id, input_hash, "
+            "risk_summary, verdict, confidence) and compares it to the stored value "
+            "to detect tampering of those fields; also confirms the required fields "
+            "(receipt_id, verdict, timestamp, confidence) are present. When the "
+            "receipt carries a cryptographic signature, verifies it too."
+        ),
     )
     verify_parser.add_argument("receipt", help="Path to receipt JSON file")
     verify_parser.add_argument(

--- a/tests/cli/test_verify.py
+++ b/tests/cli/test_verify.py
@@ -10,6 +10,7 @@ Validates that the verify command correctly:
 
 from __future__ import annotations
 
+import argparse
 import hashlib
 import json
 import textwrap
@@ -25,6 +26,7 @@ from aragora.cli.commands.verify import (
     _recompute_checksum,
     _verify_receipt,
     cmd_verify,
+    create_verify_parser,
 )
 
 
@@ -368,3 +370,95 @@ class TestCmdVerify:
         args = _FakeArgs(receipt_path=str(path))
         rc = cmd_verify(args)
         assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# Help-text tests: `aragora receipt verify --help` (VAL-VERIFY-013)
+#
+# The `receipt verify` subcommand (aragora/cli/commands/receipt.py) is a
+# separate implementation from the top-level `verify` command tested above:
+# it checks artifact_hash presence, recomputes the SHA-256 decision-integrity
+# hash, checks required-field presence, and (if present) verifies a
+# cryptographic signature -- but unlike `cmd_verify` it does NOT fall back to
+# a legacy `checksum` field. Its --help text must describe that real behavior
+# instead of being blank, and must stay disambiguated from the standalone
+# `aragora-verify` ODR verifier per docs/specs/INDEPENDENT_VERIFIER_GUIDE.md.
+# ---------------------------------------------------------------------------
+
+
+def _build_receipt_verify_subparser() -> argparse.ArgumentParser:
+    """Construct just the 'receipt verify' subparser for help-text inspection."""
+    from aragora.cli.commands.receipt import add_receipt_parser
+
+    root = argparse.ArgumentParser(prog="aragora")
+    subparsers = root.add_subparsers(dest="command")
+    add_receipt_parser(subparsers)
+    receipt_parser = subparsers.choices["receipt"]
+
+    receipt_subparsers_action = next(
+        action
+        for action in receipt_parser._actions  # noqa: SLF001
+        if isinstance(getattr(action, "choices", None), dict)
+    )
+    return receipt_subparsers_action.choices["verify"]
+
+
+def _build_top_level_verify_parser() -> argparse.ArgumentParser:
+    """Construct just the top-level 'verify' parser for help-text inspection."""
+    root = argparse.ArgumentParser(prog="aragora")
+    subparsers = root.add_subparsers(dest="command")
+    create_verify_parser(subparsers)
+    return subparsers.choices["verify"]
+
+
+# Terms that must appear (case-insensitively) in help text describing native
+# DecisionReceipt integrity verification, per the disambiguation table in
+# docs/specs/INDEPENDENT_VERIFIER_GUIDE.md: native = in-repo DecisionReceipt
+# checks (SHA-256 hash recompute + tamper detection + signature check), as
+# opposed to the standalone `aragora-verify` ODR document verifier.
+_NATIVE_INTEGRITY_TERMS = ("sha-256", "artifact_hash", "tamper", "signature")
+
+
+class TestReceiptVerifyHelpText:
+    """`aragora receipt verify --help` must describe what it actually verifies."""
+
+    def test_receipt_verify_has_nonempty_description(self):
+        """The subparser must declare a description, not rely on `help=` alone."""
+        verify_subparser = _build_receipt_verify_subparser()
+        assert verify_subparser.description, "receipt verify must have a description"
+
+    def test_receipt_verify_description_mentions_native_integrity_terms(self):
+        """Description must name the real checks: SHA-256 hash, tamper, signature."""
+        verify_subparser = _build_receipt_verify_subparser()
+        description = verify_subparser.description.lower()
+        for term in _NATIVE_INTEGRITY_TERMS:
+            assert term in description, f"expected {term!r} in receipt verify description"
+        assert "decisionreceipt" in description
+
+    def test_receipt_verify_description_disambiguates_from_odr_verifier(self):
+        """Description should point ODR holders at the standalone verifier instead."""
+        verify_subparser = _build_receipt_verify_subparser()
+        description = verify_subparser.description.lower()
+        assert "aragora-verify" in description or "odr" in description
+
+    def test_receipt_verify_help_exits_zero_and_prints_native_terms(self, capsys):
+        """`aragora receipt verify --help` must exit 0 and print the description."""
+        verify_subparser = _build_receipt_verify_subparser()
+        with pytest.raises(SystemExit) as exc_info:
+            verify_subparser.parse_args(["--help"])
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        output = captured.out.lower()
+        for term in _NATIVE_INTEGRITY_TERMS:
+            assert term in output
+
+    def test_top_level_verify_help_still_exits_zero_and_prints_native_terms(self, capsys):
+        """`aragora verify --help` keeps describing native verification (no regression)."""
+        verify_parser = _build_top_level_verify_parser()
+        with pytest.raises(SystemExit) as exc_info:
+            verify_parser.parse_args(["--help"])
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        output = captured.out.lower()
+        for term in _NATIVE_INTEGRITY_TERMS:
+            assert term in output


### PR DESCRIPTION
## Summary

Milestone: `m3-verifier`. Feature: `m3-receipt-verify-help-text` (VAL-VERIFY-013).

**parked: operator-review (Tier 1)** — additive `aragora/cli/**` help-text change; per
mission policy any `aragora/**` code change is a parked ready PR, not auto-merged.

`aragora receipt verify --help` exited 0 but its `description` was **blank** (only a
one-line `help=` summary existed), unlike `aragora verify --help`, which fully
describes the SHA-256 decision-integrity hash recompute, legacy-checksum fallback,
`schema_version`/verdict/timestamp checks. This left the native-vs-ODR verifier
disambiguation table in `docs/specs/INDEPENDENT_VERIFIER_GUIDE.md` (merged #8832)
ungrounded in observable CLI reality for the `receipt verify` subcommand.

## What changed

Added a `description=` to the `verify` subparser registered in
`aragora/cli/commands/receipt.py` (`add_receipt_parser`). The text was written
**after reading `cmd_receipt_verify`'s actual checks** (not copied from `aragora
verify`'s description, which covers different behavior):

- `receipt verify` checks `artifact_hash` presence, recomputes the SHA-256
  decision-integrity hash over `receipt_id, gauntlet_id, input_hash, risk_summary,
  verdict, confidence` and compares it to the stored value (tamper detection),
  confirms `receipt_id, verdict, timestamp, confidence` are present, and — when the
  receipt carries a `signature` — verifies it via `DecisionReceipt.verify_signature()`.
- Unlike the top-level `aragora verify`, `receipt verify` does **not** implement a
  legacy-`checksum`-field fallback (that logic lives only in
  `aragora/cli/commands/verify.py::cmd_verify` / `_recompute_checksum`). The new
  description does not claim it does, per "read the handler first; do not overclaim."
- The description also disambiguates from the standalone `aragora-verify` ODR
  verifier, consistent with `docs/specs/INDEPENDENT_VERIFIER_GUIDE.md`'s table
  (native `DecisionReceipt` checks vs. portable ODR document checks).

**Help-text only. No behavior change** — `cmd_receipt_verify`'s logic, exit codes,
and arguments are untouched; only the `description=` kwarg passed to
`argparse`'s `add_parser` was added.

## Verification

```console
$ aragora receipt verify --help
usage: main.py receipt verify [-h] [--verbose] receipt

Validate a native DecisionReceipt JSON file's integrity (this repo's internal
receipt record -- for the portable Open Decision Receipt/ODR format, use the
standalone 'aragora-verify' tool instead). Recomputes the SHA-256 decision-
integrity hash (artifact_hash) over the decision-integrity fields (receipt_id,
gauntlet_id, input_hash, risk_summary, verdict, confidence) and compares it to
the stored value to detect tampering of those fields; also confirms the
required fields (receipt_id, verdict, timestamp, confidence) are present. When
the receipt carries a cryptographic signature, verifies it too.
...
$ echo $?
0
```

`aragora verify --help` is unchanged (still exits 0; still describes SHA-256 hash +
legacy-checksum fallback + schema_version/verdict/timestamp checks). Both commands
now mention `SHA-256`, `artifact_hash`, `tamper`, and `signature`.

- Curated in-tree gate (`tests/cli/test_verify.py tests/export/test_decision_receipt.py
  tests/gauntlet/test_receipt.py tests/gauntlet/test_odr_verify.py
  tests/gauntlet/test_odr_verify_schema.py`): **247 passed** (was 242; +5 new tests),
  zero failures.
- `tests/cli/test_debate_receipt.py tests/cli/test_receipt_roundtrip.py` (exercise
  `cmd_receipt_verify` end-to-end): **8 passed**, confirming no behavior regression.
- Scoped lint: `ruff check aragora/gauntlet aragora/cli aragora/cli/commands/receipt.py
  tests/cli/test_verify.py` → clean.
- Scoped typecheck: `mypy --ignore-missing-imports --follow-imports=skip
  aragora/gauntlet/odr_export.py aragora/gauntlet/odr_signing.py aragora/cli/review.py
  aragora/cli/commands/receipt.py` → `Success: no issues found in 4 source files`.
- `python scripts/generate_cli_reference.py --check` → up to date (this generator
  only reads top-level command `help=` summaries and nested subcommand *names*, not
  nested descriptions, so `docs/reference/CLI_REFERENCE.md` / `docs-site/docs/api/cli.md`
  are unaffected by this change).
- No test in the repo pinned the old (blank) description, so no other test needed
  updating.

## Tests added

`tests/cli/test_verify.py::TestReceiptVerifyHelpText` (5 new tests):
- `test_receipt_verify_has_nonempty_description`
- `test_receipt_verify_description_mentions_native_integrity_terms`
- `test_receipt_verify_description_disambiguates_from_odr_verifier`
- `test_receipt_verify_help_exits_zero_and_prints_native_terms`
- `test_top_level_verify_help_still_exits_zero_and_prints_native_terms` (locks in the
  no-regression requirement for `aragora verify --help`)

## Risk

Tier 1 (additive, internal, non-breaking): a CLI `--help`/`description` string only.
No argument, exit-code, or output-format change to `cmd_receipt_verify`.
