### PR TITLE
docs(strategy): preserve July strategy durability

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Contributions welcome — see [CONTRIBUTING.md](CONTRIBUTING.md). MIT licensed
 | What's real vs aspirational | [`docs/HONEST_ASSESSMENT.md`](docs/HONEST_ASSESSMENT.md) |
 | Receipt format (the external contract) | [Open Decision Receipt spec](docs/specs/OPEN_DECISION_RECEIPT.md) |
 | Decision-semantics roadmap | ODR spine epic [#8223](https://github.com/synaptent/aragora/issues/8223); ODR-1..7 → [#8224](https://github.com/synaptent/aragora/issues/8224)/[#8225](https://github.com/synaptent/aragora/issues/8225)/[#8226](https://github.com/synaptent/aragora/issues/8226)/[#8227](https://github.com/synaptent/aragora/issues/8227)/[#8229](https://github.com/synaptent/aragora/issues/8229)/[#8230](https://github.com/synaptent/aragora/issues/8230)/[#8231](https://github.com/synaptent/aragora/issues/8231) |
+| Jul 2026 durability capture / outsider-verifiable claims | [Durable strategy capture](docs/strategy/2026-07-05-durable-strategy-capture.md); executable claims manifest [`outsider_verifiable_claims.yaml`](docs/status/claims/outsider_verifiable_claims.yaml); parent capture issue [#8856](https://github.com/synaptent/aragora/issues/8856) |
 | Autonomy truth | B0 benchmark [`docs/status/B0_BENCHMARK_TRUTH_STATUS.md`](docs/status/B0_BENCHMARK_TRUTH_STATUS.md) |
 | Enterprise / compliance | [GA checklist](docs/GA_CHECKLIST.md) (SOC 2 / pentest gate) · [Enterprise features](docs/enterprise/ENTERPRISE_FEATURES.md) |
 | Frontier work is bounded | the proof-first Foreman gate + capability checkpoints CP-1..5 (below) |

--- a/docs/status/claims/README.md
+++ b/docs/status/claims/README.md
@@ -27,3 +27,11 @@ only; DIC-14 owns evaluation.
 Queue policy: failed or stale claims must not directly create `boss-ready` work
 from this manifest. DIC-17 may later propose bounded follow-up issues, still
 subject to proof-first queue governance.
+
+## Current Manifests
+
+- `proof_first_claims.yaml` - initial proof-first runtime and queue-policy
+  claims for the Epistemic CI tranche.
+- `outsider_verifiable_claims.yaml` - Jul 2026 preservation claims for the
+  outsider-verifiable ODR path, public dogfood artifact reproducibility,
+  strategy durability, and question-battery tracking.

--- a/docs/status/claims/outsider_verifiable_claims.yaml
+++ b/docs/status/claims/outsider_verifiable_claims.yaml
@@ -1,0 +1,93 @@
+schema_version: 1
+manifest_id: outsider_verifiable_claims
+description: >
+  Jul 2026 preservation claims for outsider-verifiable public proof, dogfood
+  artifact reproducibility, strategy durability, and question-battery tracking.
+  These claims are report/propose-only and do not mutate the queue directly.
+claims:
+  - claim_id: outsider.odr.offline_verifier_path
+    statement: "A stranger can verify a checked-in Open Decision Receipt offline using the standalone aragora-verify path."
+    owner: decision-integrity
+    scope: public-proof
+    confidence: high
+    evidence:
+      - path: README.md
+      - path: docs/specs/examples/example-decision-receipt.odr.json
+      - issue: 8223
+      - pull_request: 8816
+    freshness_sla_hours: 168
+    verification:
+      kind: manual
+      command: "In a fresh environment, install aragora-verify and run it against docs/specs/examples/example-decision-receipt.odr.json."
+      expected_result: "The receipt verifies offline without requiring Aragora service credentials."
+    failure:
+      severity: blocking
+      allowed_action: propose_bounded_issue
+      repair_note: "Fix the install, verifier, or README path before repeating the public claim."
+    receipts:
+      - type: outsider_verifier_path
+        note: "Captured by the README repair PR #8816; future runs should bind this to a signed receipt."
+
+  - claim_id: outsider.dogfood_artifact.reproducible_public_proof
+    statement: "The July 2026 dogfood artifact gives reproducible public evidence for Aragora gating its own merges with its decision-integrity product."
+    owner: decision-integrity
+    scope: public-proof
+    confidence: medium
+    evidence:
+      - path: docs/artifacts/2026-07-decision-integrity-dogfooding.md
+      - issue: 8856
+    freshness_sla_hours: 168
+    verification:
+      kind: manual
+      command: "Re-run the GitHub queries and receipt verification commands embedded in docs/artifacts/2026-07-decision-integrity-dogfooding.md."
+      expected_result: "The artifact's quoted counts and receipt examples are still reproducible or are marked stale with a replacement artifact."
+    failure:
+      severity: warning
+      allowed_action: propose_bounded_issue
+      repair_note: "Refresh the dogfood artifact or build the live dashboard tracked under #8856."
+    receipts:
+      - type: dogfood_public_proof_artifact
+        path: docs/artifacts/2026-07-decision-integrity-dogfooding.md
+
+  - claim_id: strategy.durability_capture.current
+    statement: "The Jul 1-5 strategy value is preserved in a repo-visible strategy document and parent GitHub issue instead of only chat or session memory."
+    owner: founder-review
+    scope: strategy
+    confidence: high
+    evidence:
+      - path: docs/strategy/2026-07-05-durable-strategy-capture.md
+      - issue: 8856
+    freshness_sla_hours: 720
+    verification:
+      kind: command
+      command: "test -s docs/strategy/2026-07-05-durable-strategy-capture.md"
+      expected_result: "The strategy capture document exists and is non-empty."
+    failure:
+      severity: warning
+      allowed_action: propose_bounded_issue
+      repair_note: "Restore or recreate the durability capture before relying on #8856 as the parent epic."
+    receipts:
+      - type: strategy_durability_capture
+        path: docs/strategy/2026-07-05-durable-strategy-capture.md
+
+  - claim_id: strategy.question_batteries.tracked
+    statement: "Operator-side and product-side question batteries are tracked in durable repo artifacts rather than only chat transcripts."
+    owner: founder-review
+    scope: strategy
+    confidence: medium
+    evidence:
+      - path: docs/strategy/2026-07-05-durable-strategy-capture.md
+      - issue: 8815
+      - issue: 8856
+    freshness_sla_hours: 720
+    verification:
+      kind: manual
+      command: "Confirm #8815, #8856, and docs/strategy/2026-07-05-durable-strategy-capture.md still link the product-side and operator-side question batteries."
+      expected_result: "Question batteries remain discoverable from both the product issue and the operator strategy doc."
+    failure:
+      severity: warning
+      allowed_action: propose_bounded_issue
+      repair_note: "Re-link or refresh the question-battery tracking before using the prompts as product/roadmap guidance."
+    receipts:
+      - type: question_battery_tracking
+        note: "Operator prompts are captured in the Jul 2026 strategy doc; product implementation remains tracked by #8815."

--- a/docs/strategy/2026-07-05-durable-strategy-capture.md
+++ b/docs/strategy/2026-07-05-durable-strategy-capture.md
@@ -1,0 +1,162 @@
+# Durable Strategy Capture: Jul 1-5, 2026
+
+**Status:** preservation pass for issue #8856
+**Scope:** capture strategy value from the Jul 1-5 operator run into repo-visible
+docs, claim manifests, issues, and roadmap links without changing product code.
+
+## Summary
+
+The strongest value from the week was not a single implementation. It was a
+repeatable operating pattern: ask evaluative questions that name an outsider,
+force live evidence, and authorize one bounded action when the answer is clear.
+
+Most implementation value was preserved in pull requests, tests, receipts, and
+issues. The weaker preservation layer was strategy: prompt patterns, question
+batteries, roadmap thesis, and adjacent ideas still lived too much in chat or
+session memory. Issue #8856 is the parent capture issue for closing that gap.
+
+This document records the durable thesis and points each follow-up at an issue,
+artifact, or manifest so the work can be executed by future agents without
+reconstructing the chat.
+
+## Best Prompt Patterns And What They Produced
+
+| Prompt pattern | What it forced | Durable result |
+|---|---|---|
+| "Is what is happening making the project better and more useful to others?" | Split internal improvement from external usefulness; pushed the project toward public proof rather than substrate churn. | Dogfooding artifact `docs/artifacts/2026-07-decision-integrity-dogfooding.md`, ODR/public-verifier work, #8856 capture issue. |
+| "Why do we need Jul 29 rather than Jul 4?" | Converted a calendar superstition into data-window triggers. | #8856 item 2: adjudicator stalls, lease-rule quiet days, executor history, issue-close discipline, cancelled-run concurrency. |
+| "Nothing is happening" / "why doesn't it work" / "why does 8800 take 30 minutes?" | Treated impatience as instrumentation against silent autonomy failure. | Findings around stale policy, settle/quorum ordering, invoker identity, cancelled-run poisoning, stale rerun traps; captured for taxonomy work under #8856. |
+| "What steps do I take over and over, and are any automatable into Aragora?" | Turned operator behavior into product surface. | #8845 Operator Settlement Inbox; #8846 founder status report; follow-on automation issues #8848 and #8849. |
+| "Are beads useful, or is meta-beads poor design thinking?" | Forced a live primitive inventory instead of adding another abstraction. | #8851 Convergence Audit; follow-on #8852/#8853; no live bead records until #8851 decides work-primitive authority. |
+| "Check whether recent Codex/Factory activity is good, using Aragora tooling and transcripts." | Audited the fleet with the product's own lenses. | Collision/freeze findings, division-of-labor evidence, lease-rule pressure, and #8851 as the coordination authority agenda. |
+| "Start from live repo truth; pick the best next bounded unit; proceed." | Made strategy operational: choose one safe unit, execute, stop at a real gate. | Fable goal-cycle artifacts under `.aragora/goal_cycles/`; #8811 exact-head Tier 4 park; #8841 repair after dry-run evidence found a real P2. |
+| "Can Aragora adjudicate review nitpicks and escape unproductive cycles?" | Reused debate primitives against Aragora's own review queue. | #8747 primitive-composition plan; review adjudicator work; #8754 merged follow-up; advisory-followup preservation. |
+| "Verify this ODR parity issue from live truth, then make the smallest fail-closed fix." | Prevented stale issue text from causing unnecessary production changes. | #8837 parity coverage PR; #8838 unsigned-authenticity follow-up. |
+| "How can Zenith-style mission control integrate into Aragora?" | Mapped an external approach onto existing mission primitives. | #8743 native mission-boundary/control PR; future harness enforcement remains proposal work. |
+| "Test a public Aragora claim as an outsider and fix the first thing that makes it untrue." | Made outsider reality the proof source. | #8816 README fix; #8815 question batteries; this document and `docs/status/claims/outsider_verifiable_claims.yaml`. |
+
+The meta-pattern: the best prompts were not "do X." They were "is X true, good,
+necessary, or useful to someone outside the room; proceed on what the evidence
+says."
+
+## Durable Artifact Map
+
+| Artifact | Role |
+|---|---|
+| #8223 Open Decision Receipt epic | Main decision-semantics product spine: portable receipt, signing, offline verification, crux, calibration, oversight, anchoring. |
+| #8815 Epistemic question batteries | Product-side question batteries: falsification, unverified, assumptions, intake interrogation, question personas, scheduled receipt audit. |
+| #8845 Operator Settlement Inbox | Productizes repeated operator settlement behavior into packets, scoped action tokens, and exact-head settlement execution. |
+| #8851 Convergence Audit | Decides one authority per orchestration concern and whether beads are live work records or deferred/dormant primitives. |
+| #8856 Durability capture | Parent issue for Jul 1-5 uncaptured strategy value and wave-4 seeds. |
+| #8760 Harvest engine | Mechanism for folding merged, parked, orphaned, and stale outcomes back into backlog decisions. |
+| #8846 founder status report | Read-only operator status surface that composes queue blockers, proof-loop health, and latest brief. |
+| `docs/artifacts/2026-07-decision-integrity-dogfooding.md` | Frozen public proof that Aragora gates its own merges with its own decision-integrity product. |
+| `docs/status/claims/outsider_verifiable_claims.yaml` | Executable-claim manifest for outsider-verifiable public claims and strategy durability. |
+| #8837 / #8838 | ODR verifier parity coverage and adjacent unsigned-authenticity gap. |
+| #8743 | Native mission-boundary/control implementation. |
+| #8754 | Review-adjudicator follow-up merge. |
+
+## Missing Durability Gaps From #8856
+
+These are the remaining wave-4 seeds that need durable execution tracking:
+
+1. **One real outsider (#8858).** A human with no repo context must run the install/demo/
+   verify path and every friction must be filed. A simulated agent run does not
+   count.
+2. **Data-window arming scoreboard (#8859).** Replace the stale Jul 29 agenda with live
+   arming data: adjudicator stalls, lease-rule warnings, executor history,
+   issue-close discipline, and cancelled-run concurrency.
+3. **Reviewer-failure taxonomy (#8860).** Turn naturalistic merge-gate review failures
+   into a receipted artifact and adjudicator eval fixtures.
+4. **Live dogfood dashboard (#8861).** Regenerate the July dogfooding proof on a schedule
+   so receipt, merge, and dissent stats do not go stale.
+5. **Skip-audit redesign (#8862).** Count unjustified skips, not all skips; require
+   inline skip category and rationale.
+6. **Operator question-guide doc (#8863).** Preserve the action-producing prompt forms
+   as operator practice, linked to #8815's product-side batteries.
+7. **Time-aware truth (#8864).** Claims and roadmap assertions should carry last-verified
+   timestamps, freshness SLAs, and stale behavior.
+
+## Updated Thesis
+
+Aragora is not primarily a generic agent runner. It is a decision-integrity
+system: an institution for making consequential AI-assisted decisions inspectable,
+challengeable, time-aware, and externally verifiable.
+
+The most differentiated pillars are:
+
+1. **Portable ODRs.** The receipt is the unit of truth: a vendor-neutral artifact
+   binding decision rationale, adversarial quorum, dissent, confidence, and human
+   oversight to a subject that outsiders can verify offline.
+2. **Disagreement as evidence.** Model disagreement is not noise to average away.
+   It is preserved, classified, adjudicated, and later used to improve gates.
+3. **Self-application with public receipts.** The repo's own merges and operator
+   loops must keep proving the product under real pressure.
+4. **Outsider-verifiable claims.** Public claims should be tested from outside
+   the repo first. If the claim fails, make the smallest truthful fix or record
+   the blocker.
+
+This keeps external positioning narrower than the maximalist roadmap: say what
+is verified, link the proof, and label the rest as roadmap.
+
+## Roadmap And Maximalist Vision
+
+The roadmap should prioritize work that makes the receipt and its surrounding
+decision process more load-bearing:
+
+- **Disagreement Atlas.** Publish a living taxonomy of model-review failures with
+  receipt links and fixture candidates: diff-blindness, stale-world grounding,
+  timezone mistakes, repeated dissent, out-of-scope carousels, and cross-family
+  contradictions on settled designs.
+- **Institutional epistemics.** Generalize receipts beyond code: vendor choices,
+  RFCs, hiring bars, strategy pivots, and policy decisions should carry
+  falsification conditions, check-by dates, and reopen rules.
+- **Time-aware truth.** Claims need last-verified timestamps, freshness SLAs,
+  stale states, and repair/report policies. This applies to public claims,
+  roadmap assertions, generated dogfood proof, and issue health.
+- **Epistemic middleware.** Export the outsider/falsifier/assumption/deletion
+  batteries as a service other agent frameworks can call before acting.
+- **Fleet-coordination playbook.** Leases, exact-head evidence, settlement
+  ceremonies, and shared-repo coordination are themselves product knowledge.
+
+Deprioritize generic orchestration, connector breadth, chat delivery, and broad
+marketplace motion unless they directly strengthen receipts, outsider proof, or
+decision afterlife.
+
+## Operator Question Guide
+
+Use these prompts when the goal is investigation plus action:
+
+- **Outsider falsification:** "Take our strongest public claim, test it from a
+  stranger/customer/auditor point of view against live reality, and fix the first
+  thing that makes it untrue."
+- **Belief-reality audit:** "What do we believe is working, what evidence would
+  prove that wrong, and where is the latest live proof?"
+- **Deletion question:** "What should we stop doing, delete, defer, or stop
+  routing through agents because it no longer creates proof or user value?"
+- **Unverified-assumption audit:** "What did this answer, receipt, plan, or merge
+  not verify, and which unverified assumption is most likely to matter?"
+- **Should-this-exist prompt:** "Is this work making Aragora more useful to
+  outsiders, or only making the system more elaborate?"
+
+These are operator-side practice prompts. The product-side implementation remains
+#8815 and should be composed into receipts, intake, modes, and harvest rather
+than rebuilt here.
+
+## Follow-Up Tracking
+
+#8856 is the parent epic for this preservation pass. The concrete child issues
+are:
+
+- #8858 - one real outsider verification run
+- #8859 - data-window arming scoreboard
+- #8860 - Disagreement Atlas artifact and eval fixtures
+- #8861 - live dogfood dashboard
+- #8862 - skip-audit redesign
+- #8863 - operator question-guide doc
+- #8864 - time-aware truth layer
+
+These issues should be bead-ready, but this pass deliberately does not create
+live bead records. #8851 owns the decision about whether workspace beads become
+the live work primitive, an adapter over `nomic.dev_coordination`, or a dormant
+surface to archive.


### PR DESCRIPTION
## Summary
- capture the Jul 1-5 strategy value in `docs/strategy/2026-07-05-durable-strategy-capture.md`
- add `docs/status/claims/outsider_verifiable_claims.yaml` for outsider-verifiable public proof, dogfood reproducibility, strategy durability, and question-battery tracking
- link the new preservation artifacts from the README proof ladder and claim-manifest index

## Issue pass
- Parent epic updated and labeled: #8856
- Child issues created: #8858, #8859, #8860, #8861, #8862, #8863, #8864
- Bead creation intentionally deferred to #8851

## Validation
- `git diff --check HEAD~1..HEAD`
- `rg -n "TBD|TODO|fill in later" docs/strategy/2026-07-05-durable-strategy-capture.md docs/status/claims/outsider_verifiable_claims.yaml README.md || true`
- `python3 - <<'PY' ... ClaimManifest.from_yaml_file(Path('docs/status/claims/outsider_verifiable_claims.yaml')) ... PY`
- `python3 -m pytest tests/scripts/test_executable_claim_manifests.py tests/epistemic/test_executable_claim.py -q` -> 18 passed
- `gh issue view 8856 --repo synaptent/aragora --json labels,body`
- `gh issue list --repo synaptent/aragora --search "#8856" --state open --json number,title,state,labels,url --limit 50`
