### PR TITLE
docs: operator question guide, vision extensions, stranger-test kit (#8856 items 1/6 + vision)

### DIFF
--- a/docs/STRANGER_TEST.md
+++ b/docs/STRANGER_TEST.md
@@ -1,0 +1,49 @@
+# The Stranger Test
+
+A copy-paste kit for getting cold-eyes feedback on Aragora from a developer
+friend with zero context. Send them everything below the line.
+
+---
+
+## The ask (send this verbatim)
+
+> I want 15 minutes of your time and your honest first impressions of a
+> project I work on. Run the commands below, time each step, and tell me
+> exactly where you got stuck, confused, or bored — the negative feedback is
+> the valuable part.
+
+## The commands
+
+```bash
+pip install aragora
+aragora demo --offline
+aragora verify aragora-demo-receipt.json
+```
+
+No API keys, no accounts, no config. The demo runs a self-contained
+adversarial debate with mock agents and writes a decision receipt to your
+current directory; `verify` checks that receipt's integrity.
+
+## What to observe (while it runs)
+
+- **Time each step.** Install time, demo runtime, verify runtime. Note
+  anything that felt slow.
+- **Note every confusion.** Every moment you weren't sure what was happening,
+  what a word meant, or whether something had worked — write it down, however
+  small. "I didn't know what a receipt was" is exactly the kind of note we need.
+- **Note where you stopped reading.** Output, README, anything.
+
+## Debrief (5 questions)
+
+1. Where did you stop reading, and why?
+2. What did you think this product *was*, before and after running it?
+3. Would you trust the receipt? Why or why not?
+4. What's missing before you'd actually use this for something real?
+5. Who do you know who needs this?
+
+## What happens to your feedback
+
+Every point of friction you report becomes a GitHub issue at
+[synaptent/aragora](https://github.com/synaptent/aragora/issues) — your
+confusion is treated as a bug in the product, not a gap in your reading.
+Thank you.

--- a/docs/guides/OPERATOR_QUESTIONS.md
+++ b/docs/guides/OPERATOR_QUESTIONS.md
@@ -1,0 +1,113 @@
+# Operator Questions
+
+**How to ask questions that make agent fleets investigate and act well.**
+
+Agents with tools are only as good as the questions that direct them. This guide
+collects the question patterns that reliably produce investigation, verification,
+and useful action — and the patterns that quietly produce nothing.
+
+---
+
+## The core pattern: evaluate, with permission to act
+
+There are three ways to task an agent:
+
+| Form | Example | Failure mode |
+|---|---|---|
+| Execution order | "Add a retry to the fetcher" | Executes even when the premise is wrong |
+| Opinion request | "Do you think our retries are good?" | Produces prose, changes nothing |
+| **Evaluative + act** | "Is our retry behavior actually correct under provider outages? Verify it, and fix what you find." | — |
+
+The third form wins because it forces the agent to establish ground truth
+before acting, and removes the round-trip where it reports findings and waits
+for permission. The general template:
+
+> **"Is X true / good / necessary? Go find out. Proceed on what you find."**
+
+The evaluation makes the agent investigate; the attached permission makes the
+investigation consequential. Either half alone underperforms.
+
+## Outsider-falsification templates
+
+These questions all share one move: they take a claim you believe and demand
+that it survive contact with someone (or something) that doesn't share your
+context.
+
+- **Prove it for a stranger.** "Prove claim X is true for someone who isn't
+  us — no internal context, no charity. If it isn't provable, make it true."
+- **The stranger test.** "A competent developer with zero context lands on our
+  README. Walk their path. Where do they stall, and what do they conclude we
+  are?"
+- **The moat audit.** "What can we prove that no competitor can fake? Verify
+  that proof end-to-end, as an outsider would, before we claim it."
+- **Path-to-value trace.** "Trace the shortest real path from 'never heard of
+  us' to 'got value.' Time every step. Which step kills the most people?"
+- **The deletion question.** "If we deleted X tomorrow, what would actually
+  break, and who would notice? If the answer is 'nothing and nobody,' why does
+  X exist?"
+- **Belief-reality audit.** "List five things we believe about the system but
+  haven't verified in the last 30 days. Verify them now. Report which were
+  false."
+- **Boring but load-bearing.** "What is the least glamorous component the whole
+  system depends on? When did anyone last check it deliberately?"
+
+## Questions to ask any frontier model (that people don't)
+
+Models answer what you ask. These questions change what an answer *is*:
+
+1. **"What did you NOT verify?"** — Forces the assumption surface into the
+   open. Every confident answer has one.
+2. **"What would make this wrong, and how would we know within N days?"** —
+   Attaches a falsification condition and a check-by date to the claim, instead
+   of accepting it as timelessly settled.
+3. **"Give me the strongest case against, before I accept this."** — Cheap
+   adversarial pass. Models are good at this when asked and silent when not.
+4. **"Go look before answering."** — For any agent with tools: prohibit
+   answering from priors when the ground truth is one command away.
+5. **"What do you need from me?"** — Surfaces missing credentials, ambiguous
+   scope, and blocked decisions *before* the agent improvises around them.
+6. **"What's the smallest version that proves it?"** — Replaces a plan with an
+   experiment.
+7. **"What did you assume?"** — Post-hoc twin of #1; ask it after delivery,
+   every time.
+8. **"Should this be done at all?"** — The question execution orders skip.
+   Agents will faithfully build the wrong thing forever if you let them.
+
+## Anti-patterns
+
+**Date-gated planning.** A plan that says "review on July 29" deserves the
+question: *why July 29 and not today?* If the date exists because data genuinely
+arrives then (a 30-day measurement window, an external deadline), it's a real
+data window — keep it. If the date is decorative, it's a schedule artifact: the
+work is checkable now and the date is just deferred attention. Most review
+dates in agent-written plans are schedule artifacts. Ask "what will we know
+then that we don't know now?" — if the answer is "nothing," review it today.
+
+**Passive waiting on autonomous systems.** When an autonomous pipeline goes
+quiet, the operator failure mode is waiting politely for it to resume. The
+correct question is immediate and evaluative: *"Why is nothing happening? Go
+find the actual blocker."* Silence is data. Queues that never drain, gates that
+never settle, and loops that never loop all have specific, findable causes —
+but only if someone asks. (This repo's queue-drain investigation found a
+645-branch orphaning that had been silently blocking harvest for weeks; the
+unlock was someone finally asking why the backlog never moved.)
+
+## Putting it together
+
+A good operator prompt usually reads like this:
+
+> "We claim [X]. Verify it as a stranger would, end to end. Tell me what you
+> did NOT verify. If the claim is false or unprovable, make it true or narrow
+> the claim — proceed on what you find, and give me the strongest case against
+> whatever you conclude."
+
+One sentence of claim, one sentence of falsification demand, one sentence of
+permission. That structure — not model choice, not prompt length — is what
+separates fleets that investigate from fleets that generate plausible text.
+
+---
+
+*See also: [WHY_ARAGORA.md](../WHY_ARAGORA.md) for why adversarial challenge is
+the product's core stance, and
+[artifacts/2026-07-decision-integrity-dogfooding.md](../artifacts/2026-07-decision-integrity-dogfooding.md)
+for what these questions look like when a merge gate asks them automatically.*

--- a/docs/vision/ADJACENT_POSSIBLE.md
+++ b/docs/vision/ADJACENT_POSSIBLE.md
@@ -1,0 +1,91 @@
+# The Adjacent Possible
+
+**Exploratory vision extensions. Not roadmap commitments.**
+
+This document sketches four candidate extensions of the Aragora thesis. None is
+scheduled, resourced, or promised. Each is included because it passes the same
+prioritization filter the platform already runs on: **invest where each unit of
+work makes the decision receipt more load-bearing.** The receipt — a verifiable,
+dissent-preserving record that a decision was adversarially examined — is the
+moat ([WHY_ARAGORA.md](../WHY_ARAGORA.md)); the doctrinal frame these extend is
+[CANONICAL_GOALS.md](../CANONICAL_GOALS.md), especially Pillar 5 (Cryptographic
+Receipts and Auditability) and the Epistemic CI direction. Anything here that
+stops strengthening the receipt should be cut without ceremony.
+
+---
+
+## 1. The Disagreement Atlas
+
+Every settled PR in this repository leaves behind something no lab has at
+scale: naturalistic, adjudicated records of frontier models disagreeing about
+real code under real stakes — verdicts at exact head SHAs, severity-tagged
+findings, dissent that was later proven right or wrong by an adjudication and
+by what actually happened to the code. Benchmark datasets are synthetic;
+RLHF preference data is single-turn and private; nobody has merge-gate-scale
+disagreement data with ground-truth resolution attached. The extension:
+publish this as a living, receipted dataset and benchmark — which model
+families dissent about what, how often dissent is vindicated, what
+adjudication decided and why. It composes directly with the review-failure
+taxonomy artifact and gives the adjudicator an evaluation corpus it currently
+lacks. Each published disagreement is a receipt made load-bearing twice: once
+as a merge record, once as a research artifact a stranger can verify.
+
+## 2. Institutional epistemics as infrastructure
+
+Decision receipts currently attest that a decision *was examined*. The
+extension makes them attest that a decision *is still valid*: receipts for
+human and organizational decisions that carry explicit falsification
+conditions and check-by dates, and that **reopen themselves** when a
+kill-switch observation fires — the harvest engine (#8760) already sweeps
+settled work for follow-ups, and the falsification-condition machinery (#8815)
+already gives claims testable failure modes; composing them turns "we decided
+X in Q2" from a stale wiki page into a live object that files its own
+reopening issue when its premises die. No docs tool, OKR tracker, or decision
+log approaches this: they all record decisions as text, not as claims with
+enforcement. This is the "Time Is Part of Settlement" doctrine made into an
+organizational primitive, and it makes every receipt load-bearing for as long
+as the decision it records stays consequential.
+
+## 3. Time-aware truth
+
+A recurring failure class in this project's own operations is staleness
+masquerading as truth: changelogs that lag releases, CDN caches serving dead
+docs, merge commits that reference vanished branches, baselines that drift
+from reality. The pattern generalizes — most false claims in an organization
+were once true. The extension is a freshness layer for the knowledge and
+receipt substrate: every claim carries a last-verified timestamp and a
+staleness policy (how long before this claim degrades from *asserted* to
+*unverified* to *presumed stale*), with re-verification as a schedulable,
+receipted act. The pulse subsystem (`aragora/pulse/`, `freshness.py`) already
+scores freshness for trending sources; extending that discipline to internal
+claims makes the receipt time-aware — a receipt that says *when* it was last
+true is strictly more load-bearing than one that only says it was true once.
+
+## 4. Epistemic middleware
+
+The interrogation batteries, falsifier questions, crux-finding, and
+adversarial review that gate this repository's merges are currently packaged
+as an application. The extension exposes them as a service boundary any agent
+framework can call: **"have Aragora doubt this before you act on it."** A
+LangGraph pipeline, a CrewAI crew, or a bare tool-using agent submits a claim,
+a plan, or a diff; Aragora returns severity-tagged dissent, the load-bearing
+cruxes, and a receipt — without the caller adopting Aragora's orchestration,
+memory, or UI. This is the Pillar 8 (co-equal consumers) posture applied to
+the doubt machinery itself, and it is the purest expression of the moat rule:
+every external system that routes decisions through the doubt service is a
+system whose actions are now backed by an Aragora receipt.
+
+---
+
+## The filter, restated
+
+Four extensions, one test each unit of work must pass: does it make the
+receipt more load-bearing — carried by more decisions (Atlas), for longer
+(institutional epistemics), with truer timestamps (time-aware truth), across
+more systems (middleware)? Extensions that grow the platform without growing
+the receipt's weight are scope creep by the
+[CANONICAL_GOALS.md](../CANONICAL_GOALS.md) product-boundary rule, however
+attractive they look.
+
+*Exploratory. Revisit when the active operating focus (reliable autonomous
+execution + receipt legibility) is boringly stable.*


### PR DESCRIPTION
## Summary

Three small standalone documents, docs-only (no code, no edits to existing files).

### 1. `docs/guides/OPERATOR_QUESTIONS.md` (#8856 item 6)
The operator practice guide: question patterns that make agent fleets investigate and act well.
- Core pattern: evaluative questions with permission to act attached beat pure execution orders and pure opinion requests
- Outsider-falsification templates: stranger test, moat audit, path-to-value trace, deletion question, belief-reality audit, boring-but-load-bearing
- Eight questions to ask any frontier model that people don't ("what did you NOT verify", falsification-condition-with-date, strongest case against, go look first, ...)
- Anti-patterns: date-gated planning (schedule artifacts vs real data windows) and passive waiting on quiet autonomous systems

### 2. `docs/vision/ADJACENT_POSSIBLE.md` (vision)
Four exploratory vision extensions, each a paragraph, all framed through the receipt-moat prioritization rule (invest where each unit makes the receipt more load-bearing):
- **The Disagreement Atlas** — publish merge-gate-scale adjudicated model-disagreement data as a living receipted dataset/benchmark
- **Institutional epistemics as infrastructure** — decision receipts for human/org decisions with falsification conditions + check-by dates that reopen themselves (composes #8815 + #8760 machinery)
- **Time-aware truth** — last-verified timestamps + staleness policy on claims (motivated by the recurring staleness failure class; composes with `aragora/pulse` freshness)
- **Epistemic middleware** — the doubt machinery exposed as a service any agent framework can call

Marked clearly as exploratory, not roadmap. References `WHY_ARAGORA.md` and `CANONICAL_GOALS.md`; edits neither.

### 3. `docs/STRANGER_TEST.md` (#8856 item 1)
Copy-paste kit for cold-eyes feedback from a zero-context developer friend: 3-sentence ask, exact commands, what to observe, 5 debrief questions, friction-reports-become-issues note.

Commands verified against current main: `aragora demo --offline` writes `aragora-demo-receipt.json` (`aragora/cli/demo.py:612`), `aragora verify <path>` exists (`aragora/cli/commands/verify.py`), and the exact one-liner matches README's proof table (line 22). No corrections were needed.

## Testing
- `pre-commit run --files` on all three files: passed (gitleaks, portability guard, large-files, merge-conflicts, private-key)
- Docs-only change; no code paths affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)